### PR TITLE
Add custom SessionStore support on AgentFactory

### DIFF
--- a/meerkat-store/src/adapter.rs
+++ b/meerkat-store/src/adapter.rs
@@ -10,18 +10,18 @@ use std::sync::Arc;
 use crate::SessionStore;
 
 /// Adapter that wraps a SessionStore to implement AgentSessionStore.
-pub struct StoreAdapter<S: SessionStore> {
+pub struct StoreAdapter<S: SessionStore + ?Sized> {
     store: Arc<S>,
 }
 
-impl<S: SessionStore> StoreAdapter<S> {
+impl<S: SessionStore + ?Sized> StoreAdapter<S> {
     pub fn new(store: Arc<S>) -> Self {
         Self { store }
     }
 }
 
 #[async_trait]
-impl<S: SessionStore + 'static> AgentSessionStore for StoreAdapter<S> {
+impl<S: SessionStore + ?Sized + 'static> AgentSessionStore for StoreAdapter<S> {
     async fn save(&self, session: &Session) -> Result<(), AgentError> {
         self.store.save(session).await.map_err(store_error)
     }


### PR DESCRIPTION
## Summary

- Applications embedding Meerkat can now inject a custom `SessionStore` (e.g. BigQuery, DynamoDB) via `AgentFactory::session_store()` without bypassing the factory
- `StoreAdapter<S>` relaxed to `S: ?Sized` so it accepts `dyn SessionStore`
- Zero breaking changes — existing behavior unchanged when `session_store()` is not called

## Changes

- `meerkat/src/factory.rs`: New `custom_store` field, `session_store()` builder method, `if let` check in `build_agent()` before feature-flag fallback
- `meerkat-store/src/adapter.rs`: `?Sized` bound on `StoreAdapter<S>` generics
- `meerkat/tests/factory_build_agent.rs`: Integration test with `TrackingSessionStore` mock verifying saves route through custom store

## Test plan

- [x] `cargo build --workspace` compiles clean
- [x] `cargo test --workspace --lib --bins --tests` — 47/47 pass
- [x] New test `build_agent_with_custom_session_store` verifies the custom store receives save calls

🤖 Generated with [Claude Code](https://claude.com/claude-code)