### PR TITLE
feat(session): explicit initial-turn policy and deferred mob spawn startup

### DIFF
--- a/.claude/skills/meerkat-platform/SKILL.md
+++ b/.claude/skills/meerkat-platform/SKILL.md
@@ -50,6 +50,7 @@ For detailed mob behavior across all surfaces, load: `references/mobs.md`.
 - CLI `mob ...` is the explicit lifecycle surface for persisted mob registry operations.
 - RPC/REST/MCP server/Python SDK/TypeScript SDK expose mob capability via the same dispatcher composition model (`SessionBuildOptions.external_tools`) in host integrations.
 - Member runtime default is `autonomous_host` when `runtime_mode` is omitted; `turn_driven` is explicit opt-in for controlled dispatch paths.
+- Spawned mob members use deferred initial turn semantics; mob actor lifecycle starts autonomous loops explicitly after spawn registration.
 
 ### Mob lifecycle (standard/default usage)
 

--- a/.claude/skills/meerkat-platform/references/mobs.md
+++ b/.claude/skills/meerkat-platform/references/mobs.md
@@ -212,6 +212,13 @@ Runtime-mode behavior is shared across these surfaces because dispatch comes fro
 - autonomous members: event injection/subscription dispatch
 - turn-driven members: direct `start_turn` dispatch
 
+### Spawn startup policy
+
+- Mob member spawn uses deferred initial turn semantics.
+- Session creation for spawn registers the session without immediately running a model turn.
+- Autonomous members then start host loops explicitly from mob actor lifecycle control.
+- First model work is triggered by real dispatch (`external_turn`, peer message, or flow step).
+
 ## Multi-surface examples
 
 ### CLI tool-driven (primary)

--- a/docs/guides/mobs.mdx
+++ b/docs/guides/mobs.mdx
@@ -199,6 +199,16 @@ Selection rules:
 - Override at profile level (`[profiles.<name>].runtime_mode`)
 - Override at spawn/tool-call level (`runtime_mode` argument)
 
+## Spawn Semantics (Deferred Initial Turn)
+
+Mob spawns now use deferred session startup:
+
+- `create_session()` registers the member session without running an LLM turn.
+- The mob actor starts autonomous host loops explicitly after spawn bookkeeping.
+- First model work happens on real input (`external_turn`, peer injection, or flow dispatch).
+
+This keeps spawn latency bounded by session provisioning (not first-turn model latency), which is important for larger mobs.
+
 ## Backends and identity
 
 Mob members can run with different backend kinds:

--- a/docs/rust/advanced.mdx
+++ b/docs/rust/advanced.mdx
@@ -317,7 +317,7 @@ async fn handle_chat(session_id: SessionId, user_msg: String) -> impl IntoRespon
 
 ```rust
 use meerkat::{AgentFactory, Config, build_ephemeral_service};
-use meerkat::service::{CreateSessionRequest, StartTurnRequest, SessionService};
+use meerkat::service::{CreateSessionRequest, InitialTurnPolicy, StartTurnRequest, SessionService};
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
@@ -332,6 +332,8 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         max_tokens: Some(2048),
         event_tx: None,
         host_mode: false,
+        skill_references: None,
+        initial_turn: InitialTurnPolicy::RunImmediately,
     }).await?;
 
     println!("Response: {}", result.text);

--- a/docs/rust/overview.mdx
+++ b/docs/rust/overview.mdx
@@ -87,7 +87,7 @@ The recommended entry point is `SessionService` via `build_ephemeral_service`:
 
 ```rust
 use meerkat::{AgentFactory, Config, build_ephemeral_service};
-use meerkat::service::{CreateSessionRequest, SessionService};
+use meerkat::service::{CreateSessionRequest, InitialTurnPolicy, SessionService};
 use meerkat_store;
 
 #[tokio::main]
@@ -104,6 +104,8 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         max_tokens: Some(1024),
         event_tx: None,
         host_mode: false,
+        skill_references: None,
+        initial_turn: InitialTurnPolicy::RunImmediately,
     }).await?;
 
     println!("Response: {}", result.text);
@@ -121,7 +123,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 ### Multi-turn conversations
 
 ```rust
-use meerkat::service::{CreateSessionRequest, StartTurnRequest, SessionService};
+use meerkat::service::{CreateSessionRequest, InitialTurnPolicy, StartTurnRequest, SessionService};
 
 // Turn 1: create session
 let result = service.create_session(CreateSessionRequest {
@@ -131,6 +133,8 @@ let result = service.create_session(CreateSessionRequest {
     max_tokens: None,
     event_tx: None,
     host_mode: false,
+    skill_references: None,
+    initial_turn: InitialTurnPolicy::RunImmediately,
 }).await?;
 
 let session_id = result.session_id;

--- a/meerkat-cli/src/main.rs
+++ b/meerkat-cli/src/main.rs
@@ -1716,12 +1716,12 @@ impl meerkat_mob::MobSessionService for RunMobSessionService {
         &self,
         session_id: &SessionId,
     ) -> Result<meerkat_core::comms::EventStream, meerkat_core::comms::StreamError> {
-        let runtime = self
-            .inner
-            .comms_runtime(session_id)
-            .await
-            .ok_or_else(|| meerkat_core::comms::StreamError::NotFound(format!("session {session_id}")))?;
-        runtime.stream(meerkat_core::comms::StreamScope::Session(session_id.clone()))
+        let runtime = self.inner.comms_runtime(session_id).await.ok_or_else(|| {
+            meerkat_core::comms::StreamError::NotFound(format!("session {session_id}"))
+        })?;
+        runtime.stream(meerkat_core::comms::StreamScope::Session(
+            session_id.clone(),
+        ))
     }
 
     fn supports_persistent_sessions(&self) -> bool {
@@ -2008,6 +2008,7 @@ async fn run_agent(
         event_tx: event_tx.clone(),
         host_mode,
         skill_references: None,
+        initial_turn: meerkat_core::service::InitialTurnPolicy::RunImmediately,
         build: Some(build),
     };
 
@@ -2331,6 +2332,7 @@ async fn resume_session_with_llm_override(
             event_tx,
             host_mode,
             skill_references: None,
+            initial_turn: meerkat_core::service::InitialTurnPolicy::RunImmediately,
             build: Some(build),
         })
         .await
@@ -2537,7 +2539,9 @@ impl meerkat_mob::MobSessionService for MobCliSessionService {
         )
         .await
         .ok_or_else(|| meerkat_core::comms::StreamError::NotFound(format!("session {session_id}")))?;
-        runtime.stream(meerkat_core::comms::StreamScope::Session(session_id.clone()))
+        runtime.stream(meerkat_core::comms::StreamScope::Session(
+            session_id.clone(),
+        ))
     }
 
     fn supports_persistent_sessions(&self) -> bool {
@@ -4087,6 +4091,7 @@ mod tests {
             event_tx: None,
             host_mode: false,
             skill_references: None,
+            initial_turn: meerkat_core::service::InitialTurnPolicy::RunImmediately,
             build: Some(build),
         };
 

--- a/meerkat-core/src/service/mod.rs
+++ b/meerkat-core/src/service/mod.rs
@@ -16,6 +16,15 @@ use std::sync::Arc;
 use std::time::SystemTime;
 use tokio::sync::mpsc;
 
+/// Controls whether `create_session()` should execute an initial turn.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum InitialTurnPolicy {
+    /// Run the initial turn immediately as part of session creation.
+    RunImmediately,
+    /// Register the session and return without running an initial turn.
+    Defer,
+}
+
 /// Errors returned by `SessionService` methods.
 #[derive(Debug, thiserror::Error)]
 pub enum SessionError {
@@ -81,6 +90,8 @@ pub struct CreateSessionRequest {
     pub host_mode: bool,
     /// Skill IDs to resolve and inject for the first turn.
     pub skill_references: Option<Vec<crate::skills::SkillId>>,
+    /// Initial turn behavior for this session creation call.
+    pub initial_turn: InitialTurnPolicy,
     /// Optional extended build options for factory-backed builders.
     pub build: Option<SessionBuildOptions>,
 }

--- a/meerkat-mcp-server/src/lib.rs
+++ b/meerkat-mcp-server/src/lib.rs
@@ -11,7 +11,8 @@ use meerkat::{
 };
 use meerkat_core::error::invalid_session_id_message;
 use meerkat_core::service::{
-    CreateSessionRequest, SessionBuildOptions, SessionError, SessionService, StartTurnRequest,
+    CreateSessionRequest, InitialTurnPolicy, SessionBuildOptions, SessionError, SessionService,
+    StartTurnRequest,
 };
 use meerkat_core::{
     AgentEvent, Config, ConfigDelta, ConfigEnvelope, ConfigEnvelopePolicy, ConfigRuntimeError,
@@ -850,6 +851,7 @@ async fn handle_meerkat_run(
         event_tx: event_tx.clone(),
         host_mode,
         skill_references: None,
+        initial_turn: InitialTurnPolicy::RunImmediately,
         build: Some(build),
     };
 
@@ -1014,6 +1016,7 @@ async fn handle_meerkat_resume(
                 event_tx: event_tx.clone(),
                 host_mode,
                 skill_references: None,
+                initial_turn: InitialTurnPolicy::RunImmediately,
                 build: Some(build),
             };
 

--- a/meerkat-mob/src/build.rs
+++ b/meerkat-mob/src/build.rs
@@ -90,6 +90,10 @@ pub fn to_create_session_request(
         event_tx: None,
         host_mode: config.host_mode,
         skill_references: None,
+        // Mob runtime owns lifecycle startup and starts autonomous host loops
+        // explicitly after provisioning. Avoid synchronous first-turn execution
+        // during create_session so spawn does not block on LLM latency.
+        initial_turn: meerkat_core::service::InitialTurnPolicy::Defer,
         build: Some(build_options),
     }
 }

--- a/meerkat-mob/src/tests/contracts.rs
+++ b/meerkat-mob/src/tests/contracts.rs
@@ -585,6 +585,7 @@ fn host_mode_req(comms_name: &str) -> CreateSessionRequest {
         event_tx: None,
         host_mode: true,
         skill_references: None,
+        initial_turn: meerkat_core::service::InitialTurnPolicy::RunImmediately,
         build: Some(SessionBuildOptions {
             comms_name: Some(comms_name.to_string()),
             ..Default::default()

--- a/meerkat-rest/src/lib.rs
+++ b/meerkat-rest/src/lib.rs
@@ -35,8 +35,8 @@ use meerkat::{
 };
 use meerkat_contracts::{SessionLocator, format_session_ref};
 use meerkat_core::service::{
-    CreateSessionRequest as SvcCreateSessionRequest, SessionBuildOptions, SessionError,
-    StartTurnRequest as SvcStartTurnRequest,
+    CreateSessionRequest as SvcCreateSessionRequest, InitialTurnPolicy, SessionBuildOptions,
+    SessionError, StartTurnRequest as SvcStartTurnRequest,
 };
 use meerkat_core::{
     Config, ConfigDelta, ConfigEnvelope, ConfigEnvelopePolicy, ConfigStore, FileConfigStore,
@@ -889,6 +889,7 @@ async fn create_session(
         event_tx: Some(caller_event_tx),
         host_mode,
         skill_references: None,
+        initial_turn: InitialTurnPolicy::RunImmediately,
         build: Some(build),
     };
 
@@ -1073,6 +1074,7 @@ async fn continue_session(
                 event_tx: Some(caller_event_tx.clone()),
                 host_mode: continue_host_mode,
                 skill_references: None,
+                initial_turn: InitialTurnPolicy::RunImmediately,
                 build: Some(build),
             };
 

--- a/meerkat-rpc/src/session_runtime.rs
+++ b/meerkat-rpc/src/session_runtime.rs
@@ -250,6 +250,7 @@ impl SessionRuntime {
                 event_tx: Some(event_tx),
                 host_mode: build_config.host_mode,
                 skill_references: skill_references.clone(),
+                initial_turn: meerkat_core::service::InitialTurnPolicy::RunImmediately,
                 build: Some(build),
             };
 

--- a/meerkat/src/service_factory.rs
+++ b/meerkat/src/service_factory.rs
@@ -427,6 +427,7 @@ mod tests {
             event_tx: None,
             host_mode: false,
             skill_references: None,
+            initial_turn: meerkat_core::service::InitialTurnPolicy::RunImmediately,
             build: Some(build),
         };
 

--- a/meerkat/tests/e2e_smoke.rs
+++ b/meerkat/tests/e2e_smoke.rs
@@ -1228,6 +1228,7 @@ mod scenario_09_session_service {
             event_tx: None,
             host_mode: false,
             skill_references: None,
+            initial_turn: meerkat_core::service::InitialTurnPolicy::RunImmediately,
             build: None,
         };
 


### PR DESCRIPTION
## Summary
- add first-class `InitialTurnPolicy` to `CreateSessionRequest` (`RunImmediately` / `Defer`)
- make mob spawns use `InitialTurnPolicy::Defer` so spawn registration is not blocked by first-turn LLM latency
- keep all other surfaces explicit with `RunImmediately`
- update `EphemeralSessionService::create_session` to register deferred sessions without starting a turn
- add regression coverage for deferred create-session behavior and mob spawn request semantics
- update docs and meerkat-platform skill references for deferred mob spawn startup semantics

## Why
Mob autonomous spawn latency should be dominated by provisioning, not by serialized first-turn model calls.

## Validation
- `cargo check -p meerkat-core -p meerkat-session -p meerkat-mob -p meerkat -p rkat -p meerkat-rest -p meerkat-mcp-server -p meerkat-rpc`
- `cargo test -p meerkat-session test_create_session_can_defer_initial_turn -- --nocapture`
- `cargo test -p meerkat-mob test_spawn_create_session_request_sets_non_host_mode_and_peer_meta_labels -- --nocapture`
- `cargo clippy -p meerkat-core -p meerkat-session -p meerkat-mob -p meerkat -p rkat -p meerkat-rest -p meerkat-mcp-server -p meerkat-rpc --lib -- -D warnings`
