### PR TITLE
fix(skills): unblock clippy and add CLI v2.1 skill-ref parity

### DIFF
--- a/meerkat-skills/src/resolve.rs
+++ b/meerkat-skills/src/resolve.rs
@@ -111,12 +111,14 @@ pub async fn resolve_repositories_with_roots(
 
                         sources.push(NamedSource {
                             name: repo.name.clone(),
-                            source: SourceNode::Http(HttpSkillSource::new_with_source_uuid(
-                                repo.source_uuid.to_string(),
-                                url.clone(),
-                                auth,
-                                std::time::Duration::from_secs(*refresh_seconds),
-                                std::time::Duration::from_secs(*timeout_seconds),
+                            source: SourceNode::Http(Box::new(
+                                HttpSkillSource::new_with_source_uuid(
+                                    repo.source_uuid.to_string(),
+                                    url.clone(),
+                                    auth,
+                                    std::time::Duration::from_secs(*refresh_seconds),
+                                    std::time::Duration::from_secs(*timeout_seconds),
+                                ),
                             )),
                         });
                     }
@@ -227,7 +229,7 @@ pub async fn resolve_repositories_with_roots(
 
                     sources.push(NamedSource {
                         name: repo.name.clone(),
-                        source: SourceNode::Git(GitSkillSource::new(config)),
+                        source: SourceNode::Git(Box::new(GitSkillSource::new(config))),
                     });
                 }
             }

--- a/meerkat-skills/src/source/mod.rs
+++ b/meerkat-skills/src/source/mod.rs
@@ -26,10 +26,10 @@ pub use protocol::{ExternalSkillSource, StdioExternalClient};
 pub enum SourceNode {
     Embedded(EmbeddedSkillSource),
     Filesystem(FilesystemSkillSource),
-    Git(git::GitSkillSource),
+    Git(Box<git::GitSkillSource>),
     Memory(InMemorySkillSource),
     #[cfg(any(feature = "skills-http", test))]
-    Http(HttpSkillSource),
+    Http(Box<HttpSkillSource>),
     External(ExternalSkillSource<StdioExternalClient>),
 }
 


### PR DESCRIPTION
## Summary
- box oversized  variants in  to satisfy strict clippy ()
- add CLI surface parity for skills v2.1 refs on  and 
  -  (structured JSON or legacy string)
  -  (legacy compatibility)
- canonicalize refs via  + source identity registry before session requests

## Files
- 
- 
- 

## Validation
- 
running 84 tests
test parser::tests::test_missing_frontmatter ... ok
test parser::tests::test_rejects_name_directory_mismatch ... ok
test parser::tests::test_parse_no_capabilities ... ok
test engine::tests::test_resolve_and_render_unknown_id ... ok
test parser::tests::test_parse_description_with_colon ... ok
test parser::tests::test_parse_simple_skill ... ok
test engine::tests::test_list_skills_collection_filter ... ok
test engine::tests::test_list_skills_no_filter ... ok
test engine::tests::test_inventory_section_uses_xml ... ok
test engine::tests::test_inventory_filters_by_capabilities ... ok
test renderer::tests::test_inventory_threshold_boundary ... ok
test parser::tests::test_rejects_unnamespaced_unknown_field ... ok
test parser::tests::test_rejects_nontrivial_extension_without_version ... ok
test renderer::tests::test_render_inventory_empty ... ok
test renderer::tests::test_render_inventory_collections_xml ... ok
test renderer::tests::test_render_inventory_flat_xml ... ok
test resolve::tests::test_resolve_disabled_returns_none ... ok
test resolve::tests::test_resolve_git_repo ... ignored
test parser::tests::test_accepts_namespaced_extension_with_version ... ok
test resolve::tests::test_resolve_embedded_always_appended ... ok
test resolve::tests::test_resolve_empty_config_uses_defaults ... ok
test resolver::tests::test_resolve_deep_nested ... ok
test resolver::tests::test_resolve_empty_after_slash_fails ... ok
test resolver::tests::test_resolve_no_prefix_fails ... ok
test resolver::tests::test_resolve_slash_namespaced_id ... ok
test resolver::tests::test_resolve_slash_root_level ... ok
test source::composite::tests::test_collections_merged_across_sources ... ok
test source::composite::tests::test_list_merges_across_sources ... ok
test source::composite::tests::test_named_sources_populate_source_name ... ok
test source::composite::tests::test_shadowing_by_name ... ok
test source::embedded::tests::registration_descriptor_uses_canonical_slug_and_preserves_display_name ... ok
test source::embedded::tests::registration_document_preserves_canonical_descriptor_and_metadata ... ok
test resolve::tests::test_resolve_with_no_roots_skips_filesystem_defaults ... ok
test resolve::tests::test_resolve_filesystem_repo ... ok
test engine::tests::test_preload_missing_skill_errors ... ok
test engine::tests::test_resolve_and_render_returns_vec ... ok
test renderer::tests::test_render_injection_xml ... ok
test renderer::tests::test_injection_escapes_closing_tag ... ok
test renderer::tests::test_injection_escapes_whitespace_tag ... ok
test resolve::tests::test_resolve_mixed_repos ... ok
test renderer::tests::test_injection_escapes_case_insensitive ... ok
test renderer::tests::test_injection_truncation ... ok
test renderer::tests::test_escape_before_truncate ... ok
test source::git::tests::test_integration_real_clone_on_first_access ... ignored
test source::git::tests::test_integration_real_collection_md ... ignored
test source::git::tests::test_integration_real_namespaced_ids ... ignored
test source::git::tests::test_integration_real_skills_root_subdirectory ... ignored
test source::git::tests::test_integration_real_tag_ref_no_refresh ... ignored
test resolve::tests::test_resolve_wires_non_default_health_thresholds_into_filesystem_source ... ok
test source::git::tests::test_lazy_no_clone_on_construction ... ok
test source::filesystem::tests::test_root_level_skill ... ok
test resolve::tests::test_resolve_precedence_matches_config ... ok
test source::http::tests::test_endpoint_for_protocol_requests ... ok
test source::http::tests::test_capability_mismatch_returns_typed_error_for_http ... ok
test source::http::tests::test_auth_headers_still_applied_for_protocol_calls ... ok
test source::memory::tests::test_list_collection_filter_no_sibling ... ok
test source::memory::tests::test_list_with_collection_filter ... ok
test source::memory::tests::test_list_with_empty_filter ... ok
test source::protocol::tests::test_adversarial_mock_fail_then_succeed ... ignored, external-boundary-adversarial
test source::protocol::tests::test_adversarial_mock_never_responds ... ignored, external-boundary-adversarial
test source::protocol::tests::test_adversarial_mock_schema_invalid ... ignored, external-boundary-adversarial
test source::protocol::tests::test_adversarial_mock_unexpected_type ... ignored, external-boundary-adversarial
test source::protocol::tests::test_capability_mismatch_returns_typed_error ... ok
test source::protocol::tests::test_handshake_precedes_ops_and_is_cached_per_source_instance ... ok
test source::protocol::tests::test_protocol_payload_roundtrip_stdio_http_envelopes ... ok
test source::http::tests::test_handshake_cached_for_http_source_instance ... ok
test source::filesystem::tests::test_collection_md_loading ... ok
test source::tests::source_node_embedded_dispatches_concretely ... ok
test source::http::tests::test_http_transport_lifecycle_summaries_package_resources_functions ... ok
test source::filesystem::tests::test_collection_md_missing_fallback ... ok
test resolve::tests::test_resolve_with_explicit_roots_context_over_user ... ok
test source::filesystem::tests::test_recursive_scan_deep_nesting ... ok
test source::filesystem::tests::test_health_snapshot_transitions_with_invalid_ratio ... ok
test source::filesystem::tests::test_recursive_scan_nested_dirs ... ok
test source::git::tests::test_health_thresholds_and_diagnostics_wired_for_git_source ... ok
test source::filesystem::tests::test_list_with_collection_filter ... ok
test source::filesystem::tests::test_invalid_skill_is_quarantined_but_valid_skills_are_listed ... ok
test resolve::tests::test_resolve_stdio_repo_wires_external_source_node ... ok
test source::git::tests::test_clone_failure_returns_error ... ok
test source::tests::source_node_external_dispatches_through_bounded_external_client ... ok
test source::protocol::tests::test_stdio_transport_timeout_returns_typed_error ... ok
test source::http::tests::test_http_transport_timeout_returns_typed_error ... ok
test source::protocol::tests::test_stdio_transport_lifecycle_summaries_package_resources_functions ... ok
test source::filesystem::tests::test_quarantine_diagnostics_retain_first_seen_and_update_last_seen ... ok

test result: ok. 74 passed; 0 failed; 10 ignored; 0 measured; 0 filtered out; finished in 1.12s


running 78 tests
test mcp::tests::test_mask_secret_short ... ok
test mcp::tests::test_format_server_target_http ... ok
test mcp::tests::test_format_server_target_sse ... ok
test mcp::tests::test_format_server_target_stdio ... ok
test mcp::tests::test_mask_secret_unicode ... ok
test mcp::tests::test_mask_secret_long ... ok
test mcp::tests::test_parse_env_vars_invalid ... ok
test mcp::tests::test_parse_headers_invalid ... ok
test mcp::tests::test_remove_from_missing_file_fails ... ok
test mcp::tests::test_transport_label ... ok
test mcp::tests::test_truncate_str_ascii ... ok
test mcp::tests::test_truncate_str_unicode ... ok
test stdin_events::tests::test_parse_stdin_line_empty ... ok
test mcp::tests::test_parse_headers_valid ... ok
test mcp::tests::test_parse_env_vars_valid ... ok
test stdin_events::tests::test_parse_stdin_line_plain_text ... ok
test stdin_events::tests::test_parse_stdin_line_json_with_body ... ok
test mcp::tests::test_add_server_to_new_file ... ok
test mcp::tests::test_add_http_server_with_headers ... ok
test mcp::tests::test_add_server_with_env ... ok
test mcp::tests::test_add_http_server_to_file ... ok
test mcp::tests::test_add_duplicate_server_fails ... ok
test mcp::tests::test_add_sse_server_to_file ... ok
test mcp::tests::test_remove_nonexistent_server_fails ... ok
test mcp::tests::test_add_server_to_existing_file ... ok
test mcp::tests::test_remove_server_from_file ... ok
test stdin_events::tests::test_parse_stdin_line_json_without_body ... ok
test tests::test_enable_builtins_with_no_subagents ... ok
test tests::test_infer_provider_anthropic ... ok
test tests::test_infer_provider_gemini ... ok
test tests::test_infer_provider_openai ... ok
test tests::test_infer_provider_unknown ... ok
test tests::test_enabled_tools_subagents_only ... ok
test tests::test_enabled_tools_builtins_and_subagents ... ok
test tests::test_cached_run_snapshot_returns_only_terminal_runs ... ok
test tests::test_comms_tool_dispatcher_provides_comms_tools ... ok
test tests::test_compose_external_tool_dispatchers_prefers_primary_on_name_collision ... ok
test tests::test_json_output_payload_includes_skill_diagnostics_field ... ok
test tests::test_no_subagents_flag_disables_subagents ... ok
test tests::test_compose_external_tool_dispatchers_merges_two_sources ... ok
test tests::test_parse_hook_overrides_from_file_matches_fixture ... ok
test tests::test_parse_hook_overrides_from_inline_json_matches_file ... ok
test tests::test_canonical_skill_keys_accepts_structured_and_legacy_forms ... ok
test tests::test_parse_provider_params_empty ... ok
test tests::test_mob_tools_available_for_composition ... ok
test tests::test_parse_provider_params_empty_value ... ok
test tests::test_parse_provider_params_invalid_no_equals ... ok
test tests::test_parse_provider_params_single ... ok
test tests::test_parse_provider_params_multiple ... ok
test tests::test_parse_provider_params_value_with_equals ... ok
test tests::test_parse_run_flow_params_accepts_object_and_rejects_non_object ... ok
test tests::test_parse_skill_ref_arg_accepts_legacy_string ... ok
test tests::test_parse_skill_ref_arg_accepts_structured_json ... ok
test tests::test_resolve_host_mode_allows_when_comms_enabled ... ok
test tests::test_render_flow_status_json_outputs_json_or_null ... ok
test tests::test_resolve_scoped_session_id_accepts_session_ref_in_active_realm ... ok
test tests::test_resolve_scoped_session_id_rejects_realm_mismatch ... ok
test tests::test_prune_inner_skips_legacy_unknown_without_force ... ok
test tests::test_prepare_run_mob_tools_does_not_hold_registry_lock_for_context_lifetime ... ok
test tests::test_run_mob_tools_runtime_mode_turn_driven_surface_wiring ... ok
test tests::test_delete_realm_blocks_when_active_without_force ... ok
test tests::test_subagent_enabled_by_default ... ok
test tests::test_subagents_independent_of_builtins ... ok
test tests::test_run_mob_tools_persist_destroy_removes_registry_entry ... ok
test tests::test_run_mob_tools_persist_across_context_rebuild ... ok
test tests::test_mob_create_rejects_prefab_and_definition_together ... ok
test tests::test_mob_flow_status_rejects_invalid_run_id ... ok
test tests::test_mob_create_prefab_and_list_registry ... ok
test tests::test_mob_run_flow_failure_persists_terminal_snapshot_and_rehydrates ... ok
test tests::test_mob_registry_serializes_concurrent_writers ... ok
test tests::test_flow_status_discards_non_terminal_cached_snapshot_when_run_missing ... ok
test tests::test_mob_run_flow_rejects_unknown_flow_id ... ok
test tests::test_run_session_build_wires_mob_tools_into_llm_request ... ok
test tests::test_mob_prefabs_and_lifecycle_commands_parse_and_dispatch ... ok
test tests::test_mob_flow_commands_parse_and_dispatch ... ok
test tests::test_resume_session_wires_mob_tools_into_llm_request ... ok
test tests::test_find_session_matches_returns_all_matching_realms_in_scope_root ... ok
test tests::test_prune_inner_reports_leftovers_on_partial_failure ... ok

test result: ok. 78 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 6.81s


running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s
- 
