### PR TITLE
docs: pre-release audit fixes (45 issues across 20 files)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -66,6 +66,8 @@ meerkat-comms     → Inter-agent communication (Ed25519-signed messaging, trans
 meerkat-contracts → Wire types, capability registry, error codes (canonical over all surfaces)
 meerkat-skills    → Skill loading, resolution, rendering (filesystem, git, HTTP, embedded sources)
 meerkat-hooks     → Hook infrastructure (in-process, command, HTTP runtimes)
+meerkat-mob       → Multi-agent mob orchestration (spawn, provision, finalize)
+meerkat-mob-mcp   → Expose mob tools as MCP interface (MobMcpState, MobMcpDispatcher)
 meerkat-cli       → CLI binary (produces `rkat`)
 meerkat           → Facade crate, re-exports, AgentFactory, SDK helpers
 ```
@@ -225,7 +227,7 @@ Installed via `make install-hooks`. Two stages:
 - Secret detection (gitleaks)
 - Trailing whitespace, YAML/TOML validation, merge conflict check, large file check
 - `make test` (fast tests: unit + integration-fast)
-- `cargo clippy` (workspace, all features, warnings as errors)
+- `cargo clippy` (workspace, warnings as errors)
 - `cargo doc` (workspace docs build)
 - `make audit` (cargo-deny security audit)
 
@@ -241,7 +243,7 @@ Five files must agree on the same version:
 | `sdks/typescript/package.json` | `version` |
 | `artifacts/schemas/version.json` | `contract_version` |
 
-Additionally, all 15 internal crate dependencies in `Cargo.toml` must match the workspace version.
+Additionally, all 17 internal crate dependencies in `Cargo.toml` must match the workspace version.
 
 **`make verify-version-parity`** runs in CI and fails on any drift. After changing versions or wire types:
 
@@ -339,7 +341,7 @@ See `docs/reference/design-philosophy.mdx` for the full treatment with code exam
 ### Architectural Principles
 
 - **Infrastructure, not application** — the agent loop is a composable primitive with no opinions about prompts, tools, or output
-- **Trait contracts own the architecture** — `meerkat-core` defines six trait contracts with zero I/O dependencies; implementations live in satellite crates
+- **Trait contracts own the architecture** — `meerkat-core` defines the core trait contracts (`AgentLlmClient`, `AgentToolDispatcher`, `AgentSessionStore`, `SessionService`, `Compactor`, `MemoryStore`, `HookEngine`, `SkillEngine`/`SkillSource`) with zero I/O dependencies; implementations live in satellite crates
 - **Surfaces are interchangeable skins** — CLI, REST, RPC, MCP Server all route through `SessionService` → `AgentFactory::build_agent()`; no surface constructs agents directly
 - **Composition over configuration** — optional components (`CommsRuntime`, `HookEngine`, `Compactor`, `MemoryStore`) are `Option<Arc<dyn Trait>>`, not feature-flagged defaults
 - **Sessions are first-class, persistence is optional** — `EphemeralSessionService` (always available) and `PersistentSessionService` (event-sourced) share the same `SessionService` trait

--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ rkat run --enable-builtins --enable-shell \
 **Extract structured data** with schema validation and budget controls:
 
 ```bash
-rkat run --model claude-sonnet-4-6 --enable-builtins --enable-shell \
+rkat run --model claude-sonnet-4-5 --enable-builtins --enable-shell \
   --output-schema '{"type":"object","properties":{"issues":{"type":"array","items":{"type":"object","properties":{"file":{"type":"string"},"severity":{"type":"string","enum":["critical","high","medium","low"]},"description":{"type":"string"}},"required":["file","severity","description"]}}},"required":["issues"]}' \
   --max-tokens 4000 \
   "Audit the last 20 commits for security issues. Check each changed file."
@@ -169,7 +169,7 @@ let mut agent = AgentBuilder::new()
     .model("claude-sonnet-4-5")
     .system_prompt("You are an incident triage system.")
     .output_schema(OutputSchema::new(triage_schema)?)
-    .budget(BudgetLimits::new().max_tokens(2000).max_turns(1))
+    .budget(BudgetLimits::default().with_max_tokens(2000))
     .build(llm, tools, store)
     .await;
 

--- a/docs/api/rest.mdx
+++ b/docs/api/rest.mdx
@@ -136,7 +136,12 @@ Create and run a new session.
   "verbose": false,
   "host_mode": false,
   "comms_name": null,
-  "hooks_override": null
+  "peer_meta": null,
+  "hooks_override": null,
+  "enable_builtins": null,
+  "enable_shell": null,
+  "enable_subagents": null,
+  "enable_memory": null
 }
 ```
 
@@ -199,8 +204,28 @@ Create and run a new session.
   Agent name for inter-agent communication.
 </ParamField>
 
+<ParamField body="peer_meta" type="object | null" default="null">
+  Friendly metadata for peer discovery (name, description, labels).
+</ParamField>
+
 <ParamField body="hooks_override" type="HookRunOverrides | null" default="null">
   Run-scoped hook overrides (see [Hooks](/guides/hooks)).
+</ParamField>
+
+<ParamField body="enable_builtins" type="bool | null" default="null (factory default)">
+  Enable built-in tools (task management, etc.). Omit to use factory defaults.
+</ParamField>
+
+<ParamField body="enable_shell" type="bool | null" default="null (factory default)">
+  Enable shell tool (requires `enable_builtins`). Omit to use factory defaults.
+</ParamField>
+
+<ParamField body="enable_subagents" type="bool | null" default="null (factory default)">
+  Enable sub-agent tools. Omit to use factory defaults.
+</ParamField>
+
+<ParamField body="enable_memory" type="bool | null" default="null (factory default)">
+  Enable semantic memory. Omit to use factory defaults.
 </ParamField>
 
 #### Response fields
@@ -543,13 +568,15 @@ If `expected_generation` is stale, the server returns `400` with a generation-co
 
 ### POST /comms/send
 
-Push a comms message into a running session. Requires the `comms` feature.
+Push a canonical comms command into a running session. Requires the `comms` feature.
 
 <CodeGroup>
 ```json Request
 {
   "session_id": "01936f8a-7b2c-7000-8000-000000000001",
-  "payload": {"alert": "build failed", "repo": "main"},
+  "kind": "peer_message",
+  "to": "reviewer",
+  "body": "Please review the latest diff",
   "source": "ci-pipeline"
 }
 ```
@@ -560,15 +587,51 @@ Push a comms message into a running session. Requires the `comms` feature.
 </CodeGroup>
 
 <ParamField body="session_id" type="string" required>
-  Session ID to push the event to.
+  Session ID to dispatch the comms command to.
 </ParamField>
 
-<ParamField body="payload" type="any JSON" required>
-  Any JSON value. Serialized and injected as event body.
+<ParamField body="kind" type="string" required>
+  Command kind: `"peer_message"`, `"peer_request"`, or `"peer_response"`.
 </ParamField>
 
-<ParamField body="source" type="string">
+<ParamField body="to" type="string | null">
+  Peer name to send to (required for `peer_message` and `peer_request`).
+</ParamField>
+
+<ParamField body="body" type="string | null">
+  Message body (required for `peer_message`).
+</ParamField>
+
+<ParamField body="intent" type="string | null">
+  Request intent (required for `peer_request`, e.g. `"review"`, `"delegate"`).
+</ParamField>
+
+<ParamField body="params" type="object | null">
+  Request parameters (optional for `peer_request`).
+</ParamField>
+
+<ParamField body="in_reply_to" type="string | null">
+  ID of the request being responded to (required for `peer_response`).
+</ParamField>
+
+<ParamField body="status" type="string | null">
+  Response status: `"accepted"`, `"completed"`, or `"failed"` (for `peer_response`).
+</ParamField>
+
+<ParamField body="result" type="object | null">
+  Response result data (optional for `peer_response`).
+</ParamField>
+
+<ParamField body="source" type="string | null">
   Optional source label.
+</ParamField>
+
+<ParamField body="stream" type="string | null">
+  Optional stream identifier.
+</ParamField>
+
+<ParamField body="allow_self_session" type="bool | null">
+  Allow the session to send a message to itself (default: false).
 </ParamField>
 
 <Note>
@@ -579,7 +642,11 @@ that already know the session ID.
 
 ### GET /comms/peers
 
-List discoverable peers. Requires the `comms` feature.
+List discoverable peers for a session. Requires the `comms` feature.
+
+<ParamField query="session_id" type="string" required>
+  Session ID to query peers for.
+</ParamField>
 
 ```json Response
 {
@@ -603,7 +670,7 @@ All errors are returned as JSON with an HTTP status code:
 
 | HTTP Status | Code | When |
 |-------------|------|------|
-| 400 | `INVALID_PARAMS` | Invalid parameters, session ID mismatch, host_mode without comms |
+| 400 | `BAD_REQUEST` | Invalid parameters, session ID mismatch, host_mode without comms |
 | 403 | `HOOK_DENIED` | Hook blocked the operation |
 | 404 | `SESSION_NOT_FOUND` | Session does not exist |
 | 404 | `SKILL_NOT_FOUND` | Requested skill does not exist |
@@ -627,7 +694,7 @@ All errors are returned as JSON with an HTTP status code:
 ```json Bad request
 {
   "error": "Session ID mismatch: path=abc body=def",
-  "code": "INVALID_PARAMS"
+  "code": "BAD_REQUEST"
 }
 ```
 </CodeGroup>

--- a/docs/api/rpc.mdx
+++ b/docs/api/rpc.mdx
@@ -372,7 +372,7 @@ Remove a session from the runtime.
 ```
 
 ```json Response
-{"jsonrpc":"2.0","id":5,"result":{}}
+{"jsonrpc":"2.0","id":5,"result":{"archived":true}}
 ```
 </CodeGroup>
 
@@ -441,7 +441,7 @@ Cancel an in-flight turn. No-op if the session is idle.
 ```
 
 ```json Response
-{"jsonrpc":"2.0","id":7,"result":{}}
+{"jsonrpc":"2.0","id":7,"result":{"interrupted":true}}
 ```
 </CodeGroup>
 
@@ -537,18 +537,28 @@ Open a scoped event stream for a session. Events from this session will be emitt
   "id": 10,
   "method": "comms/stream_open",
   "params": {
-    "session_id": "01936f8a-..."
+    "session_id": "01936f8a-...",
+    "scope": "session",
+    "interaction_id": null
   }
 }
 ```
 
 ```json Response
-{"jsonrpc":"2.0","id":10,"result":{}}
+{"jsonrpc":"2.0","id":10,"result":{"stream_id":"550e8400-e29b-41d4-a716-446655440000","opened":true}}
 ```
 </CodeGroup>
 
 <ParamField body="session_id" type="string" required>
   Session ID to stream events for.
+</ParamField>
+
+<ParamField body="scope" type="string" required>
+  Stream scope: `"session"` (all events for the session) or `"interaction"` (events for a specific interaction).
+</ParamField>
+
+<ParamField body="interaction_id" type="string | null" default="null">
+  Interaction UUID (required when `scope` is `"interaction"`).
 </ParamField>
 
 ### comms/stream_close
@@ -562,18 +572,18 @@ Close a previously opened scoped event stream. Requires the `comms` feature.
   "id": 11,
   "method": "comms/stream_close",
   "params": {
-    "session_id": "01936f8a-..."
+    "stream_id": "550e8400-e29b-41d4-a716-446655440000"
   }
 }
 ```
 
 ```json Response
-{"jsonrpc":"2.0","id":11,"result":{}}
+{"jsonrpc":"2.0","id":11,"result":{"stream_id":"550e8400-e29b-41d4-a716-446655440000","closed":true}}
 ```
 </CodeGroup>
 
-<ParamField body="session_id" type="string" required>
-  Session ID to stop streaming events for.
+<ParamField body="stream_id" type="string" required>
+  Stream ID returned by `comms/stream_open`.
 </ParamField>
 
 ## Capabilities
@@ -822,16 +832,19 @@ When a scoped event stream is open (via `comms/stream_open`), the server emits `
   "jsonrpc": "2.0",
   "method": "comms/stream_event",
   "params": {
-    "session_id": "01936f8a-...",
+    "stream_id": "550e8400-e29b-41d4-a716-446655440000",
+    "scope": {"type": "session", "session_id": "01936f8a-..."},
+    "sequence": 1,
     "event": {
       "type": "text_delta",
       "delta": "Hello"
-    }
+    },
+    "contract_version": "0.3.4"
   }
 }
 ```
 
-These events are scoped to the session and only emitted while the stream is open.
+These events are scoped to the stream and only emitted while the stream is open.
 
 ## Error codes
 

--- a/docs/cli/configuration.mdx
+++ b/docs/cli/configuration.mdx
@@ -86,7 +86,7 @@ Project servers override user servers with the same name.
 |------|---------|
 | 0 | Success |
 | 1 | Internal error |
-| 2 | Invalid parameters |
+| 2 | Budget exhausted |
 | 10 | Session not found |
 | 11 | Session busy |
 | 12 | Session not running |

--- a/docs/examples/advanced.mdx
+++ b/docs/examples/advanced.mdx
@@ -352,8 +352,7 @@ curl -X POST http://localhost:8080/sessions/sid_abc/event \
 
 ```python
 # Or via Python SDK
-await client.send(
-    session_id=session_id,
+await session.send(
     payload={"alert": "deployment failed", "env": "prod"},
     source="github-actions",
 )

--- a/docs/examples/basics.mdx
+++ b/docs/examples/basics.mdx
@@ -164,7 +164,7 @@ The agent emits `AgentEvent` values during execution. When using the SDK directl
 Events are delivered as `session/event` notifications:
 
 ```json
-{"jsonrpc":"2.0","method":"session/event","params":{"session_id":"...","event":{"type":"text_delta","content":"Hello"}}}
+{"jsonrpc":"2.0","method":"session/event","params":{"session_id":"...","event":{"type":"text_delta","delta":"Hello"}}}
 {"jsonrpc":"2.0","method":"session/event","params":{"session_id":"...","event":{"type":"tool_use","name":"add","input":{"a":2,"b":3}}}}
 {"jsonrpc":"2.0","method":"session/event","params":{"session_id":"...","event":{"type":"turn_end","usage":{"input_tokens":50,"output_tokens":20}}}}
 ```

--- a/docs/guides/cd-and-distribution.md
+++ b/docs/guides/cd-and-distribution.md
@@ -1,7 +1,7 @@
 # CD and Distribution Rulebook
 
 This document captures the publication model for Meerkat binaries and SDKs
-(`rkat`, `meerkat-rpc`, `meerkat-rest`, `meerkat-mcp-server`, Python SDK,
+(`rkat`, `rkat-rpc`, `rkat-rest`, `rkat-mcp`, Python SDK,
 and TypeScript SDK).
 
 ## Goals
@@ -39,9 +39,9 @@ Version and contract compatibility must already be in sync via:
 Release artifacts are built for each surface binary:
 
 - `rkat` (CLI)
-- `meerkat-rpc`
-- `meerkat-rest`
-- `meerkat-mcp-server`
+- `rkat-rpc`
+- `rkat-rest`
+- `rkat-mcp`
 
 Build targets:
 
@@ -52,8 +52,8 @@ Build targets:
 
 Publish as release assets, for example:
 
-- `meerkat-rpc-vX.Y.Z-x86_64-apple-darwin.tar.gz`
-- `meerkat-rest-vX.Y.Z-x86_64-unknown-linux-gnu.zip`
+- `rkat-rpc-vX.Y.Z-x86_64-apple-darwin.tar.gz`
+- `rkat-rest-vX.Y.Z-x86_64-unknown-linux-gnu.zip`
 
 Include a checksum manifest with all artifacts:
 
@@ -68,7 +68,7 @@ Package behavior should be pure-Python with optional runtime auto-download:
 - Package should not require Rust/toolchain locally
 - First connect:
   - If `MEERKAT_BIN_PATH` is set, use it
-  - Otherwise, download correct `meerkat-rpc` binary for platform/version from GitHub Releases
+  - Otherwise, download correct `rkat-rpc` binary for platform/version from GitHub Releases
   - Cache in user-local location (`~/.cache/meerkat/bin/...`)
 
 This gives users a true one-command install path for Python.
@@ -84,7 +84,7 @@ This gives users a true one-command install path for Python.
 For MCP-style tooling (`claude mcp add`, `npx`), provide a CLI entrypoint package:
 
 - `npx @meerkat/mcp` (or equivalent) launches the JS shim
-- shim resolves local override or downloaded `meerkat-mcp-server`
+- shim resolves local override or downloaded `rkat-mcp`
 
 ## GitHub Actions Design (single-release flow)
 

--- a/docs/guides/comms.mdx
+++ b/docs/guides/comms.mdx
@@ -243,7 +243,7 @@ Standard strings are parsed into their enum variants; unknown strings become `Cu
 
 ## LLM-facing tools
 
-Four tools are exposed to the LLM when comms is enabled.
+Two tools are exposed to the LLM when comms is enabled.
 
 <Accordion title="send (kind=peer_message)">
 Send a fire-and-forget text message to a peer.
@@ -338,8 +338,9 @@ the current agent.
 ### Tool availability
 
 Comms tools are conditionally available based on peer/trust configuration in the
-surface. `CommsToolSurface::peer_availability()` checks whether either
-`TrustedPeers` has entries or `InprocRegistry` contains a peer other than self.
+surface. `CommsToolSurface::peer_availability()` checks whether `TrustedPeers`
+has any configured peers (`TrustedPeers::has_peers()`). Tools are hidden when no
+peers are configured.
 
 ## Inbox
 

--- a/docs/guides/skills.mdx
+++ b/docs/guides/skills.mdx
@@ -101,13 +101,29 @@ The renderer produces two output formats:
 
 <Tabs>
   <Tab title="Inventory section">
-    Generates a `## Available Skills` section listing all available skills for the system prompt:
+    Generates an `<available_skills>` XML block listing all available skills for the system prompt:
 
-    ```text
-    ## Available Skills
+    ```xml
+    <available_skills>
+      <skill id="task-workflow">
+        <description>How to use task_create/task_update/task_list for structured work tracking</description>
+      </skill>
+      <skill id="shell-patterns">
+        <description>Background job patterns with shell and job management tools</description>
+      </skill>
+    </available_skills>
+    ```
 
-    - `/task-workflow` -- How to use task_create/task_update/task_list for structured work tracking
-    - `/shell-patterns` -- Background job patterns with shell and job management tools
+    When there are more than 12 skills, collection mode is used instead:
+
+    ```xml
+    <available_skills mode="collections">
+      <collection path="extraction" count="8">Entity extraction skills</collection>
+      <collection path="formatting" count="3">Output formatting skills</collection>
+
+      Use the browse_skills tool to list skills in a collection or search.
+      Use the load_skill tool or /collection/skill-name to activate a skill.
+    </available_skills>
     ```
 
     This section is injected into the system prompt via the `extra_sections` parameter of `assemble_system_prompt()` in `meerkat/src/prompt_assembly.rs`.
@@ -116,7 +132,7 @@ The renderer produces two output formats:
     Wraps the skill body in XML-style tags for per-turn injection:
 
     ```xml
-    <skill name="Shell Patterns">
+    <skill id="shell-patterns">
     # Shell Patterns
 
     When running background jobs...

--- a/docs/introduction.mdx
+++ b/docs/introduction.mdx
@@ -11,7 +11,7 @@ It's a set of modular Rust crates that handle the hard parts of agentic systems:
 
 - **Fast.** Rust from the ground up. Single 5MB binary, &lt;10ms cold start, ~20MB memory. No runtime, no garbage collector, no dependency tree to manage.
 - **Provider-agnostic.** Same code, same tools, same sessions across Anthropic, OpenAI, and Gemini. Switch models with a config change. Run a Claude parent that spawns GPT sub-agents.
-- **Modular.** Twelve crates, all opt-in. Need just the agent loop? Pull in `meerkat-core`. Need session persistence? Add `meerkat-store`. Need inter-agent comms? Add `meerkat-comms`. Your binary includes only what you use. Disabled features return typed errors, not panics.
+- **Modular.** Eighteen crates, all opt-in. Need just the agent loop? Pull in `meerkat-core`. Need session persistence? Add `meerkat-store`. Need inter-agent comms? Add `meerkat-comms`. Your binary includes only what you use. Disabled features return typed errors, not panics.
 - **Stable.** Deterministic state machine with defined transitions. Typed errors with compile-time guarantees. Every error code maps to a stable string across JSON-RPC, REST, and CLI exit codes.
 - **Controlled.** Hard budget limits on tokens, wall-clock time, and tool calls. Eight hook points for guardrails, audit, and content rewriting. Shell security with allow/deny lists.
 - **Multi-agent native.** Sub-agents spawn on different providers with isolated budgets. Independent agents communicate over Ed25519-signed channels. Compaction + semantic memory handles conversations that exceed any context window.

--- a/docs/quickstart.mdx
+++ b/docs/quickstart.mdx
@@ -9,7 +9,7 @@ description: "Install Meerkat and run your first agent. Single binary, any provi
   <Tab title="Rust crate">
     ```toml Cargo.toml
     [dependencies]
-    meerkat = "0.2"
+    meerkat = "0.3"
     tokio = { version = "1", features = ["full"] }
     ```
   </Tab>
@@ -17,13 +17,13 @@ description: "Install Meerkat and run your first agent. Single binary, any provi
     ```bash
     pip install meerkat-sdk
     ```
-    <Note>Requires the `rkat` binary on your PATH.</Note>
+    <Note>Requires the `rkat-rpc` binary on your PATH.</Note>
   </Tab>
   <Tab title="TypeScript">
     ```bash
-    npm install @meerkat/sdk
+    npm install @rkat/sdk
     ```
-    <Note>Requires the `rkat` binary on your PATH.</Note>
+    <Note>Requires the `rkat-rpc` binary on your PATH.</Note>
   </Tab>
   <Tab title="CLI">
     ```bash
@@ -37,10 +37,28 @@ description: "Install Meerkat and run your first agent. Single binary, any provi
 <Tabs>
   <Tab title="Rust">
     ```rust
-    let result = meerkat::with_anthropic(std::env::var("ANTHROPIC_API_KEY")?)
+    use std::sync::Arc;
+    use meerkat::{AgentBuilder, AgentFactory, AnthropicClient, JsonlStore};
+    use meerkat_store::StoreAdapter;
+
+    let api_key = std::env::var("ANTHROPIC_API_KEY")?;
+    let store_dir = std::env::current_dir()?.join(".rkat").join("sessions");
+    std::fs::create_dir_all(&store_dir)?;
+
+    let factory = AgentFactory::new(store_dir.clone());
+    let client = Arc::new(AnthropicClient::new(api_key)?);
+    let llm = factory.build_llm_adapter(client, "claude-sonnet-4-5").await;
+    let store = Arc::new(StoreAdapter::new(Arc::new(JsonlStore::new(store_dir))));
+    let tools = Arc::new(meerkat_tools::EmptyToolDispatcher);
+
+    let mut agent = AgentBuilder::new()
         .model("claude-sonnet-4-5")
-        .run("What is the capital of France?")
-        .await?;
+        .system_prompt("You are a helpful assistant.")
+        .max_tokens_per_turn(1024)
+        .build(Arc::new(llm), tools, store)
+        .await;
+
+    let result = agent.run("What is the capital of France?".to_string()).await?;
     println!("{}", result.text);
     ```
   </Tab>
@@ -57,11 +75,11 @@ description: "Install Meerkat and run your first agent. Single binary, any provi
   </Tab>
   <Tab title="TypeScript">
     ```typescript
-    import { MeerkatClient } from "@meerkat/sdk";
+    import { MeerkatClient } from "@rkat/sdk";
 
     const client = new MeerkatClient();
     await client.connect();
-    const result = await client.createSession({ prompt: "What is the capital of France?" });
+    const result = await client.createSession("What is the capital of France?");
     console.log(result.text);
     await client.close();
     ```

--- a/docs/reference/api-reference.mdx
+++ b/docs/reference/api-reference.mdx
@@ -14,7 +14,7 @@ This page is a quick-lookup index. For detailed usage with examples, see the [Ru
 | `AgentBuilder` | `meerkat_core` | Builder pattern for agent construction |
 | `Session` | `meerkat_core` | Conversation state container |
 | `SessionId` | `meerkat_core` | Unique session identifier (UUIDv7) |
-| `Message` | `meerkat_core` | Conversation message enum (`System`, `User`, `Assistant`, `ToolResults`) |
+| `Message` | `meerkat_core` | Conversation message enum (`System`, `User`, `Assistant`, `BlockAssistant`, `ToolResults`) |
 | `ToolDef` | `meerkat_core` | Tool definition (name, description, JSON Schema) |
 | `ToolCall` | `meerkat_core` | Tool invocation request from the model |
 | `ToolCallView` | `meerkat_core` | Zero-allocation borrowed view of a tool call |
@@ -177,7 +177,6 @@ For cross-surface behavior and examples (CLI/RPC/REST/MCP/Python/TypeScript), se
 | `AgentFactory::new(store_root)` | Create a factory for building agents | [Rust SDK](/rust/overview#quick-start) |
 | `AgentFactory::session_store(store)` | Override session store (e.g. BigQuery, DynamoDB) | [Rust SDK: custom stores](/rust/tools-and-stores#session-stores) |
 | `build_ephemeral_service(factory, config, cap)` | Build an in-memory session service | [Rust SDK](/rust/overview#sessions) |
-| `meerkat::with_anthropic(key)` | Quick-start builder for Anthropic | [Rust SDK](/rust/overview#quick-start) |
 | `Config::load()` | Load layered config (legacy/global-project flow) | [Configuration](/concepts/configuration) |
 
 ## Structured output types
@@ -217,7 +216,7 @@ See the [hooks guide](/guides/hooks) for usage details.
 | `SkillScope` | `Builtin`, `Project`, `User` |
 | `SkillDescriptor` | Skill metadata (id, name, description, required capabilities) |
 | `SkillDocument` | Loaded skill with body content |
-| `SkillError` | `NotFound`, `CapabilityUnavailable`, `Ambiguous`, `Load`, `Parse` |
+| `SkillError` | `NotFound`, `CapabilityUnavailable`, `Ambiguous`, `Load`, `Parse`, `SourceUuidCollision`, `SourceUuidMutationWithoutLineage`, `MissingSkillRemaps`, `RemapWithoutLineage`, `InvalidLegacySkillRefFormat`, `UnknownSkillAlias`, `RemapCycle` |
 
 See the [skills guide](/guides/skills) for usage details.
 
@@ -234,7 +233,7 @@ See the [skills guide](/guides/skills) for usage details.
 | `WireSessionSummary` | Lightweight session summary |
 | `WireEvent` | Event wire format |
 | `WireUsage` | Token/cost usage breakdown |
-| `ContractVersion` | Semver version (`0.2.0` currently) |
+| `ContractVersion` | Semver version (`0.3.4` currently) |
 | `CoreCreateParams` | Session creation parameters |
 | `StructuredOutputParams` | Schema + retry count |
 | `CommsParams` | Host mode + agent name |
@@ -276,7 +275,7 @@ All implement `LlmClient` and normalize responses to `LlmEvent` (text deltas, to
 
 | Store | Feature flag | Purpose | Detailed docs |
 |-------|-------------|---------|---------------|
-| `JsonlStore` | `jsonl-store` (default) | File-based JSONL persistence | [Rust SDK: session stores](/rust/tools-and-stores#session-stores) |
+| `JsonlStore` | `jsonl-store` | File-based JSONL persistence | [Rust SDK: session stores](/rust/tools-and-stores#session-stores) |
 | `RedbSessionStore` | `session-store` | Embedded database (redb) | [Rust SDK: session stores](/rust/tools-and-stores#session-stores) |
 | `MemoryStore` | `memory-store` | In-memory (testing) | [Rust SDK: session stores](/rust/tools-and-stores#session-stores) |
 | Custom (`dyn SessionStore`) | — | User-provided via `AgentFactory::session_store()` | [Rust SDK: custom stores](/rust/tools-and-stores#session-stores) |

--- a/docs/reference/architecture.mdx
+++ b/docs/reference/architecture.mdx
@@ -9,7 +9,7 @@ Meerkat is a library-first, modular agent engine built in Rust. It provides the 
 ## Design philosophy
 
 1. **Library-first** -- the Rust crate is the primary interface; surfaces (CLI, REST, RPC, MCP) are thin wrappers
-2. **Modular** -- twelve crates, all opt-in. Clean trait boundaries let you swap providers, stores, and dispatchers
+2. **Modular** -- eighteen crates, all opt-in. Clean trait boundaries let you swap providers, stores, and dispatchers
 3. **No I/O in core** -- `meerkat-core` has no network or filesystem dependencies; all I/O is in satellite crates
 4. **Streaming-first** -- all LLM interactions use streaming for responsive user experiences
 5. **Budget-aware** -- built-in resource tracking for tokens, time, and tool calls
@@ -32,6 +32,8 @@ graph TD
     COMMS["meerkat-comms<br/>Ed25519 / Transports / Trust"]
     CONTRACTS["meerkat-contracts<br/>Wire types / Capabilities / Error codes"]
     SKILLS["meerkat-skills<br/>Filesystem / Git / HTTP / Embedded"]
+    MOB["meerkat-mob<br/>Mob runtime / Flows / Tasks"]
+    MOBMCP["meerkat-mob-mcp<br/>MobMcpDispatcher / MobMcpState"]
 
     CORE["meerkat-core<br/>Traits, agent loop, types<br/>SessionService trait, SessionError"]
 
@@ -42,10 +44,14 @@ graph TD
     FACADE --> TOOLS
     FACADE --> MEMORY
     FACADE --> HOOKS
-    FACADE --> MCPSERVER
     FACADE --> COMMS
     FACADE --> CONTRACTS
     FACADE --> SKILLS
+
+    MCPSERVER --> FACADE
+    MOBMCP --> MOB
+    MOBMCP --> CORE
+    MOB --> CORE
 
     CLIENT --> CORE
     SESSION --> CORE
@@ -54,7 +60,6 @@ graph TD
     TOOLS --> CORE
     MEMORY --> CORE
     HOOKS --> CORE
-    MCPSERVER --> CORE
     COMMS --> CORE
     CONTRACTS --> CORE
     SKILLS --> CORE
@@ -104,6 +109,8 @@ graph TD
     SESSION["meerkat-session<br/>Ephemeral / Persistent / Compactor"]
     MEMORY["meerkat-memory<br/>HNSW / Simple"]
     MCP["meerkat-mcp<br/>McpRouter / Stdio / HTTP"]
+    MOB["meerkat-mob<br/>Mob runtime / Flows / Tasks"]
+    MOBMCP["meerkat-mob-mcp<br/>MobMcpDispatcher"]
 
     AGENT --> CLIENT
     AGENT --> TOOLS
@@ -111,6 +118,8 @@ graph TD
     AGENT --> SESSION
     AGENT --> MEMORY
     TOOLS --> MCP
+    MOBMCP --> MOB
+    TOOLS -.->|external_tools composition| MOBMCP
 ```
 
 ## Crate structure
@@ -160,14 +169,18 @@ All providers implement the `LlmClient` trait and normalize responses to `LlmEve
 pub trait LlmClient: Send + Sync {
     fn stream(&self, request: &LlmRequest) -> Pin<Box<dyn Stream<Item = Result<LlmEvent, LlmError>> + Send>>;
     fn provider(&self) -> &'static str;
+    async fn health_check(&self) -> Result<(), LlmError>;
+    fn compile_schema(&self, output_schema: &OutputSchema) -> Result<CompiledSchema, SchemaError>;
 }
 
 pub enum LlmEvent {
-    TextDelta { delta: String },
+    TextDelta { delta: String, meta: Option<Box<ProviderMeta>> },
+    ReasoningDelta { delta: String },
+    ReasoningComplete { text: String, meta: Option<Box<ProviderMeta>> },
     ToolCallDelta { id: String, name: Option<String>, args_delta: String },
-    ToolCallComplete { id: String, name: String, args: Value },
+    ToolCallComplete { id: String, name: String, args: Value, meta: Option<Box<ProviderMeta>> },
     UsageUpdate { usage: Usage },
-    Done { stop_reason: StopReason },
+    Done { outcome: LlmDoneOutcome },
 }
 ```
 </Accordion>
@@ -187,7 +200,6 @@ Session service orchestration:
 - **EphemeralSessionService**: in-memory session lifecycle (always available)
 - **PersistentSessionService**: durable session lifecycle over `SessionStore` backends
 - **DefaultCompactor**: context compaction implementation (feature: `session-compaction`)
-- **SessionRuntime**: per-session task ownership + turn concurrency coordination
 
 Feature gates: `session-store`, `session-compaction`.
 </Accordion>
@@ -247,7 +259,7 @@ Canonical wire types and capability model shared across all surfaces:
 - **Wire types**: `WireRunResult`, `WireSessionInfo`, `WireEvent`, `WireUsage`, `WireError`
 - **Capabilities**: `CapabilityId`, `CapabilityStatus`, `CapabilityRegistration`, `CapabilitiesResponse`
 - **Error codes**: `ErrorCode` with stable projections to JSON-RPC codes, HTTP status, and CLI exit codes
-- **Contract version**: semver versioning for API compatibility (`0.2.0`)
+- **Contract version**: semver versioning for API compatibility (`0.3.4`)
 - **Parameter types**: `CoreCreateParams`, `StructuredOutputParams`, `HookParams`, `CommsParams`, `SkillsParams`
 </Accordion>
 
@@ -261,6 +273,29 @@ Skill loading, resolution, and rendering:
 - **Discovery tools**: `browse_skills` and `load_skill` (when builtins enabled)
 
 Feature-gated behind `skills`.
+</Accordion>
+
+<Accordion title="meerkat-mob">
+Mob runtime for multi-agent coordination:
+
+- **MobBuilder**: construct or resume a mob runtime from a `MobDefinition` and `MobStorage`
+- **MobHandle**: runtime handle for lifecycle, membership, wiring, turns, flows, and tasks
+- **MobDefinition**: declarative mob structure (profiles, wiring, topology, limits, flows)
+- **MobStorage**: event/run/spec storage bundle (in-memory or redb)
+- **Flow engine**: `run_flow` / `flow_status` / `cancel_flow` for multi-step orchestration
+- **Task board**: shared `task_create` / `task_update` / `task_list` for structured work assignment
+- **Parallel spawn**: `spawn_many_member_refs` batches provisioning and wiring concurrently
+
+Feature-gated; depends on `meerkat-core` directly.
+</Accordion>
+
+<Accordion title="meerkat-mob-mcp">
+Tool-dispatch bridge that exposes mob capabilities to non-Rust-SDK surfaces:
+
+- **MobMcpState**: shared state handle wrapping the `MobSessionService`
+- **MobMcpDispatcher**: implements `AgentToolDispatcher`, routing `mob_*` tool calls into the mob runtime
+
+Composed via `SessionBuildOptions.external_tools` so CLI, REST, RPC, and MCP server surfaces all get mob tool capability through the same path.
 </Accordion>
 
 <Accordion title="meerkat-rpc">
@@ -382,7 +417,6 @@ Events emitted at turn boundaries:
 
 - `TurnCompleted`
 - `ToolResultReceived`
-- `CheckpointSaved`
 - `HookStarted` / `HookCompleted` / `HookFailed`
 - `HookDenied`
 - `HookRewriteApplied`

--- a/docs/reference/capability-matrix.mdx
+++ b/docs/reference/capability-matrix.mdx
@@ -57,16 +57,16 @@ string code and a transport-specific representation:
 ```toml
 # Minimal: just the agent loop
 [dependencies]
-meerkat = { version = "0.2", default-features = false, features = ["anthropic"] }
+meerkat = { version = "0.3", default-features = false, features = ["anthropic"] }
 
 # Add persistence
-meerkat = { version = "0.2", default-features = false, features = ["anthropic", "session-store"] }
+meerkat = { version = "0.3", default-features = false, features = ["anthropic", "session-store"] }
 
 # Add compaction
-meerkat = { version = "0.2", default-features = false, features = ["anthropic", "session-store", "session-compaction"] }
+meerkat = { version = "0.3", default-features = false, features = ["anthropic", "session-store", "session-compaction"] }
 
 # Kitchen sink
-meerkat = { version = "0.2", features = ["all-providers", "session-store", "session-compaction", "comms", "mcp"] }
+meerkat = { version = "0.3", features = ["all-providers", "session-store", "session-compaction", "comms", "mcp"] }
 ```
 
 ## Compaction behavior

--- a/docs/reference/design-philosophy.mdx
+++ b/docs/reference/design-philosophy.mdx
@@ -12,7 +12,7 @@ Meerkat treats the LLM execution loop the way a database engine treats storage �
 
 ### Trait contracts own the architecture
 
-`meerkat-core` defines six trait contracts (`AgentLlmClient`, `AgentToolDispatcher`, `AgentSessionStore`, `SessionService`, `Compactor`, `MemoryStore`) and contains zero I/O dependencies. Everything else — providers, storage backends, tool registries — lives in separate crates that implement these traits.
+`meerkat-core` defines nine trait contracts (`AgentLlmClient`, `AgentToolDispatcher`, `AgentSessionStore`, `SessionService`, `Compactor`, `MemoryStore`, `HookEngine`, `SkillEngine`, `SkillSource`) and contains zero I/O dependencies. Everything else — providers, storage backends, tool registries — lives in separate crates that implement these traits.
 
 This is a hard constraint, not an aspiration. The core agent loop is testable in-memory without mocks, embeddable in any Rust binary, and provably independent of any specific LLM provider or storage backend.
 

--- a/docs/sdks/python/overview.mdx
+++ b/docs/sdks/python/overview.mdx
@@ -1,10 +1,10 @@
 ---
 title: "Python SDK"
-description: "Getting started with the Meerkat Python SDK: sessions, turns, events, and capabilities."
+description: "Getting started with the Meerkat Python SDK: sessions, turns, streaming events, and capabilities."
 icon: "python"
 ---
 
-The Python SDK (`meerkat-sdk`) lets you manage sessions, run agent turns, stream events, and query capabilities from Python. It communicates with a local `rkat-rpc` subprocess over JSON-RPC 2.0 and can scope that process to an explicit realm.
+The Python SDK (`meerkat-sdk`) lets you create sessions, run agent turns, stream typed events, and query capabilities from Python. It spawns `rkat-rpc` as a subprocess and communicates with it over JSON-RPC 2.0.
 
 - **Python:** `>=3.10`
 - **Dependencies:** zero runtime dependencies
@@ -30,26 +30,24 @@ The Python SDK (`meerkat-sdk`) lets you manage sessions, run agent turns, stream
     cargo build -p meerkat-rpc --release
     # Binary is at target/release/rkat-rpc
     ```
+
+    Alternatively, `MeerkatClient` will attempt to download a matching release binary automatically if `rkat-rpc` is not found on `PATH`.
   </Step>
   <Step title="Connect and run">
     ```python
     import asyncio
-    from meerkat import MeerkatClient
+    from meerkat import MeerkatClient, TextDelta
 
     async def main():
-        client = MeerkatClient()
-        await client.connect(realm_id="team-alpha")
+        async with MeerkatClient() as client:
+            session = await client.create_session("What is the capital of France?")
+            print(session.text)
 
-        result = await client.create_session("What is the capital of France?")
-        print(result.text)
-        print(result.session_id)
+            # Multi-turn
+            result = await session.turn("And of Germany?")
+            print(result.text)
 
-        # Multi-turn
-        result2 = await client.start_turn(result.session_id, "And of Germany?")
-        print(result2.text)
-
-        await client.archive_session(result.session_id)
-        await client.close()
+            await session.archive()
 
     asyncio.run(main())
     ```
@@ -57,7 +55,7 @@ The Python SDK (`meerkat-sdk`) lets you manage sessions, run agent turns, stream
 </Steps>
 
 <Tip>
-If `rkat-rpc` is not on `PATH`, pass its location explicitly:
+If `rkat-rpc` is not on `PATH`, pass its location explicitly or set the `MEERKAT_BIN_PATH` environment variable:
 
 ```python
 client = MeerkatClient(rkat_path="/path/to/rkat-rpc")
@@ -68,23 +66,45 @@ client = MeerkatClient(rkat_path="/path/to/rkat-rpc")
 
 ## Method overview
 
-| Method | Description |
-|--------|-------------|
-| `connect(realm_id?, instance_id?, realm_backend?)` | Spawn `rkat-rpc`, handshake, fetch capabilities |
-| `close()` | Terminate the subprocess |
-| `create_session(prompt, ...)` | Create a session and run the first turn |
-| `start_turn(session_id, prompt)` | Continue an existing session |
-| `interrupt(session_id)` | Cancel an in-flight turn |
-| `list_sessions()` | List active sessions |
-| `read_session(session_id)` | Read session state |
-| `archive_session(session_id)` | Remove a session |
-| `get_capabilities()` | Get runtime capabilities |
-| `has_capability(id)` | Check if a capability is available |
-| `require_capability(id)` | Guard a code path by capability |
-| `get_config()` | Read runtime configuration |
-| `set_config(config)` | Replace runtime configuration |
-| `patch_config(patch)` | Merge-patch runtime configuration |
-| `send(session_id, payload, source)` | Push an external event into a session |
+### MeerkatClient methods
+
+| Method / Property | Description |
+|-------------------|-------------|
+| `async with MeerkatClient() as client` | Preferred usage — starts `rkat-rpc` and cleans up on exit |
+| `await client.connect(...)` | Explicit connect: spawn `rkat-rpc`, handshake, fetch capabilities |
+| `await client.close()` | Terminate the subprocess |
+| `await client.create_session(prompt, ...)` | Create a session and run the first turn; returns `Session` |
+| `client.create_session_streaming(prompt, ...)` | Create a session and stream typed events; returns `EventStream` |
+| `await client.list_sessions()` | List active sessions; returns `list[SessionInfo]` |
+| `await client.read_session(session_id)` | Read raw session state |
+| `client.capabilities` | `list[Capability]` — capabilities fetched during handshake |
+| `client.has_capability(id)` | `True` if a capability is available |
+| `client.require_capability(id)` | Raises `CapabilityUnavailableError` if not available |
+| `await client.get_config()` | Read runtime configuration |
+| `await client.set_config(config)` | Replace runtime configuration |
+| `await client.patch_config(patch)` | Merge-patch runtime configuration |
+
+### Session methods
+
+`create_session()` returns a `Session` object. All subsequent operations on a session go through it.
+
+| Method / Property | Description |
+|-------------------|-------------|
+| `session.id` | Stable session UUID |
+| `session.ref` | Optional human-readable session reference |
+| `session.text` | Assistant text from the last turn |
+| `session.usage` | `Usage` from the last turn |
+| `session.turns` | Number of LLM turns in the last run |
+| `session.tool_calls` | Number of tool calls in the last run |
+| `session.structured_output` | Structured output from the last run, if requested |
+| `session.last_result` | Full `RunResult` from the last turn |
+| `await session.turn(prompt, ...)` | Run another turn; returns `RunResult` |
+| `session.stream(prompt, ...)` | Run another turn with streaming; returns `EventStream` |
+| `await session.archive()` | Archive (remove) the session |
+| `await session.interrupt()` | Cancel the currently running turn |
+| `await session.invoke_skill(skill_ref, prompt)` | Invoke a skill in this session |
+| `await session.send(**kwargs)` | Push a comms event into this session |
+| `await session.peers()` | List peers visible to this session's comms runtime |
 
 ---
 
@@ -96,25 +116,27 @@ client = MeerkatClient(rkat_path="/path/to/rkat-rpc")
 MeerkatClient(rkat_path: str = "rkat-rpc")
 ```
 
-Raises `MeerkatError` (code `"BINARY_NOT_FOUND"`) if the binary is not found.
+Creates the client object. The subprocess is not started until `connect()` is called (or the async context manager is entered).
 
 ### connect()
 
 ```python
 async def connect(
     self,
-    realm_id: Optional[str] = None,
-    instance_id: Optional[str] = None,
-    realm_backend: Optional[str] = None,
+    *,
+    realm_id: str | None = None,
+    instance_id: str | None = None,
+    realm_backend: str | None = None,
+    isolated: bool = False,
+    state_root: str | None = None,
+    context_root: str | None = None,
+    user_config_root: str | None = None,
 ) -> MeerkatClient
 ```
 
 Starts the `rkat-rpc` subprocess, performs the `initialize` handshake, checks contract version compatibility, and fetches capabilities. Returns `self` for chaining.
 
-If `realm_id` is omitted, each SDK process gets an isolated default RPC realm. Reuse `realm_id` to share config and sessions across SDK/CLI/REST/MCP surfaces.
-`realm_backend` is a creation hint only; backend selection is pinned per realm in `realm_manifest.json`.
-
-The Python SDK is RPC-backed. Mob capability is provided by the RPC host composing `meerkat-mob-mcp` (`MobMcpState` + `MobMcpDispatcher`) into `SessionBuildOptions.external_tools`, which exposes `mob_*` tools to session turns.
+If `realm_id` is omitted, each SDK process gets a default realm. Reuse `realm_id` to share config and sessions across SDK/CLI/REST/MCP surfaces. `realm_id` and `isolated` are mutually exclusive.
 
 ### close()
 
@@ -130,47 +152,73 @@ Sends `SIGTERM` and waits up to 5 seconds; falls back to `SIGKILL` on timeout.
 async def create_session(
     self,
     prompt: str,
-    model: Optional[str] = None,
-    provider: Optional[str] = None,
-    system_prompt: Optional[str] = None,
-    max_tokens: Optional[int] = None,
-    output_schema: Optional[dict] = None,
+    *,
+    model: str | None = None,
+    provider: str | None = None,
+    system_prompt: str | None = None,
+    max_tokens: int | None = None,
+    output_schema: dict | None = None,
     structured_output_retries: int = 2,
-    hooks_override: Optional[dict] = None,
+    hooks_override: dict | None = None,
     enable_builtins: bool = False,
     enable_shell: bool = False,
     enable_subagents: bool = False,
     enable_memory: bool = False,
     host_mode: bool = False,
-    comms_name: Optional[str] = None,
-    provider_params: Optional[dict] = None,
-) -> WireRunResult
+    comms_name: str | None = None,
+    peer_meta: dict | None = None,
+    provider_params: dict | None = None,
+    preload_skills: list[str] | None = None,
+    skill_refs: list[SkillRef] | None = None,
+    skill_references: list[str] | None = None,
+) -> Session
 ```
 
-Creates a new session and runs the first turn. Returns a `WireRunResult`.
+Creates a new session and runs the first turn. Returns a `Session` whose convenience properties (`text`, `usage`, `turns`, `tool_calls`, `structured_output`) reflect the result of that first turn.
 
-### start_turn()
+### create_session_streaming()
 
 ```python
-async def start_turn(self, session_id: str, prompt: str) -> WireRunResult
+def create_session_streaming(
+    self,
+    prompt: str,
+    *,
+    # same keyword arguments as create_session()
+) -> EventStream
 ```
 
-Starts a new turn on an existing session.
-
-### interrupt()
+Creates a new session and streams typed events from the first turn. Returns an `EventStream` async context manager — the request is sent when entering the `async with` block. After iteration, `stream.session_id` and `stream.result` are available.
 
 ```python
-async def interrupt(self, session_id: str) -> None
+async with client.create_session_streaming("Hello!") as stream:
+    async for event in stream:
+        match event:
+            case TextDelta(delta=chunk):
+                print(chunk, end="", flush=True)
+    print()
+    session_id = stream.session_id
+    result = stream.result
 ```
 
-Cancels a running turn.
-
-### Session management
+### Capabilities
 
 ```python
-sessions = await client.list_sessions()
-info = await client.read_session(session_id)
-await client.archive_session(session_id)
+# Property: list[Capability] populated during connect()
+client.capabilities
+
+# Check availability
+if client.has_capability("shell"):
+    print("Shell tool is available")
+
+# Guard a code path
+client.require_capability("comms")  # raises CapabilityUnavailableError if unavailable
+```
+
+### Session queries
+
+```python
+sessions: list[SessionInfo] = await client.list_sessions()
+raw: dict = await client.read_session(session_id)
 ```
 
 ### Config management
@@ -181,42 +229,170 @@ await client.set_config(config)
 updated = await client.patch_config({"max_tokens": 2048})
 ```
 
-### send()
+---
+
+## Session
+
+`Session` is returned by `create_session()` and is the primary handle for multi-turn conversations.
+
+### Properties
 
 ```python
-async def send(
+session.id               # str  — stable session UUID
+session.ref              # str | None  — optional human-readable reference
+session.text             # str  — assistant text from the last turn
+session.usage            # Usage — token usage from the last turn
+session.turns            # int  — LLM turns in the last run
+session.tool_calls       # int  — tool calls in the last run
+session.structured_output  # Any | None — structured output if requested
+session.last_result      # RunResult — full result object from the last turn
+```
+
+### turn()
+
+```python
+async def turn(
     self,
-    session_id: str,
-    payload: Any,
-    source: Optional[str] = None,
-) -> dict
+    prompt: str,
+    *,
+    skill_refs: list[SkillRef] | None = None,
+    skill_references: list[str] | None = None,
+) -> RunResult
 ```
 
-Push an external event into a running session's inbox. The event is queued and processed at the next turn boundary. Returns `{"queued": True}` on success.
+Runs another turn on this session (non-streaming). Updates `last_result` and returns the new `RunResult`.
+
+### stream()
 
 ```python
-await client.send(
-    session_id=session_id,
-    payload={"alert": "deployment failed", "env": "prod"},
-    source="monitoring",
-)
+def stream(
+    self,
+    prompt: str,
+    *,
+    skill_refs: list[SkillRef] | None = None,
+    skill_references: list[str] | None = None,
+) -> EventStream
 ```
 
-### Session convenience methods
+Runs another turn with streaming events. Returns an `EventStream`. Updates `last_result` when the stream completes.
 
-`create_session()` returns a `Session` object with convenience wrappers over the client APIs:
+```python
+async with session.stream("Explain the CI pipeline") as events:
+    async for event in events:
+        match event:
+            case TextDelta(delta=chunk):
+                print(chunk, end="", flush=True)
+    print()
+    print(f"Tokens used: {events.result.usage.input_tokens}")
+```
 
-- `await session.invoke_skill(skill_ref, prompt)` uses structured `skill_refs`.
-- `await session.send(**command)` scopes `comms/send` to the active session.
-- `await session.peers()` returns the session-visible peer list.
+### archive() and interrupt()
+
+```python
+await session.archive()     # Remove session from the server
+await session.interrupt()   # Cancel the currently running turn
+```
+
+### invoke_skill()
+
+```python
+async def invoke_skill(self, skill_ref: SkillRef, prompt: str) -> RunResult
+```
+
+Invokes a skill in this session. Requires the `"skills"` capability — raises `CapabilityUnavailableError` if it is not available. Accepts a `SkillKey` or a legacy string of the form `"<source_uuid>/<skill_name>"`.
+
+```python
+from meerkat import SkillKey
+
+key = SkillKey(source_uuid="abc123", skill_name="code-review")
+result = await session.invoke_skill(key, "Review this function")
+```
+
+### send() and peers()
+
+```python
+# Push a comms event into this session
+await session.send(payload={"alert": "deployment failed"}, source="monitoring")
+
+# List peers visible to this session
+peers: list[dict] = await session.peers()
+```
+
+---
+
+## Streaming
+
+### EventStream
+
+`EventStream` is an async context manager returned by `session.stream()` and `client.create_session_streaming()`. Iterate it to receive typed `Event` subclass instances.
+
+```python
+async with session.stream("Summarise the logs") as events:
+    async for event in events:
+        match event:
+            case TextDelta(delta=chunk):
+                print(chunk, end="", flush=True)
+            case ToolCallRequested(name=name, args=args):
+                print(f"\nCalling tool: {name}")
+            case TurnCompleted(usage=u):
+                print(f"\nTokens: {u.input_tokens} in / {u.output_tokens} out")
+            case _:
+                pass
+    result = events.result   # RunResult, available after iteration
+```
+
+### Convenience methods
+
+```python
+# Consume all events silently, return RunResult
+result = await session.stream("prompt").collect()
+
+# Accumulate text deltas, return (full_text, RunResult)
+text, result = await session.stream("prompt").collect_text()
+```
+
+### Typed event classes
+
+All events are frozen dataclasses importable from `meerkat`. Unknown event types (from newer server versions) are surfaced as `UnknownEvent` for forward compatibility.
+
+| Class | Key fields | Description |
+|-------|------------|-------------|
+| `RunStarted` | `session_id`, `prompt` | Agent run has started |
+| `TurnStarted` | `turn_number` | A new LLM turn has begun |
+| `TextDelta` | `delta` | Incremental text chunk from the LLM |
+| `TextComplete` | `content` | Full assistant text for the current turn |
+| `ToolCallRequested` | `id`, `name`, `args` | LLM wants to invoke a tool |
+| `ToolResultReceived` | `id`, `name`, `is_error` | Tool result fed back to LLM |
+| `TurnCompleted` | `stop_reason`, `usage` | LLM turn finished |
+| `ToolExecutionStarted` | `id`, `name` | Tool began executing |
+| `ToolExecutionCompleted` | `id`, `name`, `result`, `is_error`, `duration_ms` | Tool finished |
+| `ToolExecutionTimedOut` | `id`, `name`, `timeout_ms` | Tool exceeded its timeout |
+| `RunCompleted` | `session_id`, `result`, `usage` | Agent run completed |
+| `RunFailed` | `session_id`, `error` | Agent run failed |
+| `CompactionStarted` | `input_tokens`, `message_count` | Context compaction began |
+| `CompactionCompleted` | `summary_tokens`, `messages_before`, `messages_after` | Compaction finished |
+| `CompactionFailed` | `error` | Compaction failed |
+| `BudgetWarning` | `budget_type`, `used`, `limit`, `percent` | A budget threshold crossed |
+| `Retrying` | `attempt`, `max_attempts`, `error`, `delay_ms` | LLM request being retried |
+| `HookStarted` | `hook_id`, `point` | Hook invocation started |
+| `HookCompleted` | `hook_id`, `point`, `duration_ms` | Hook invocation completed |
+| `HookFailed` | `hook_id`, `point`, `error` | Hook invocation failed |
+| `HookDenied` | `hook_id`, `point`, `reason_code`, `message` | Hook denied the operation |
+| `HookRewriteApplied` | `hook_id`, `point`, `patch` | Hook rewrote part of request/response |
+| `SkillsResolved` | `skills`, `injection_bytes` | Skills resolved for this turn |
+| `SkillResolutionFailed` | `reference`, `error` | Skill reference could not be resolved |
+| `InteractionComplete` | `interaction_id`, `result` | Comms interaction completed |
+| `InteractionFailed` | `interaction_id`, `error` | Comms interaction failed |
+| `StreamTruncated` | `reason` | Event stream was truncated |
+| `UnknownEvent` | `type`, `data` | Unrecognised event type (forward compat) |
 
 ---
 
 ## Parsing and typing notes
 
-- Capability statuses may be encoded as externally-tagged enum objects by Rust (for example `{"DisabledByPolicy": {...}}`). The SDK normalizes these to the string key.
-- Event parsing intentionally defaults missing fields to empty/zero values so partial streaming payloads can still be surfaced as typed events.
-- `RunResult.skill_diagnostics` is typed as `SkillRuntimeDiagnostics` (with `source_health` and `quarantined`) when diagnostics are present.
+- Capability statuses may be encoded as externally-tagged enum objects by Rust (for example `{"DisabledByPolicy": {...}}`). The SDK normalises these to the string key.
+- Event parsing intentionally defaults missing fields to empty/zero values so partially delivered streaming payloads can still be surfaced as typed events.
+- `RunResult.skill_diagnostics` is `SkillRuntimeDiagnostics | None` — present when the skills subsystem emits runtime diagnostics.
 
 ---
 
@@ -224,30 +400,59 @@ await client.send(
 
 <Accordion title="Multi-turn conversation">
 ```python
-async def multi_turn():
-    client = MeerkatClient()
-    await client.connect()
+import asyncio
+from meerkat import MeerkatClient
 
-    result = await client.create_session(
-        "You are a helpful math tutor. What is 12 * 15?",
-        model="claude-sonnet-4-5",
-    )
-    print(f"Turn 1: {result.text}")
+async def main():
+    async with MeerkatClient() as client:
+        session = await client.create_session(
+            "You are a helpful math tutor. What is 12 * 15?",
+            model="claude-sonnet-4-5",
+        )
+        print(f"Turn 1: {session.text}")
 
-    result2 = await client.start_turn(result.session_id, "Now divide that result by 3.")
-    print(f"Turn 2: {result2.text}")
+        result = await session.turn("Now divide that result by 3.")
+        print(f"Turn 2: {result.text}")
 
-    await client.archive_session(result.session_id)
-    await client.close()
+        await session.archive()
+
+asyncio.run(main())
+```
+</Accordion>
+
+<Accordion title="Streaming with typed events">
+```python
+import asyncio
+from meerkat import MeerkatClient, TextDelta, ToolCallRequested, TurnCompleted
+
+async def main():
+    async with MeerkatClient() as client:
+        session = await client.create_session(
+            "List three interesting facts about penguins.",
+            model="claude-sonnet-4-5",
+        )
+        print(f"First turn: {session.text}\n")
+
+        async with session.stream("Now give me three more facts.") as events:
+            async for event in events:
+                match event:
+                    case TextDelta(delta=chunk):
+                        print(chunk, end="", flush=True)
+                    case TurnCompleted(usage=u):
+                        print(f"\nTokens: {u.input_tokens} in / {u.output_tokens} out")
+                    case _:
+                        pass
+
+asyncio.run(main())
 ```
 </Accordion>
 
 <Accordion title="Structured output">
 ```python
-async def structured():
-    client = MeerkatClient()
-    await client.connect()
+import asyncio
+from meerkat import MeerkatClient
 
+async def main():
     schema = {
         "type": "object",
         "properties": {
@@ -258,34 +463,83 @@ async def structured():
         "required": ["city", "country", "population"],
     }
 
-    result = await client.create_session(
-        "Give me information about Tokyo.",
-        output_schema=schema,
-        structured_output_retries=3,
-    )
-    print(f"Structured: {result.structured_output}")
+    async with MeerkatClient() as client:
+        session = await client.create_session(
+            "Give me information about Tokyo.",
+            output_schema=schema,
+            structured_output_retries=3,
+        )
+        print(session.structured_output)
+        await session.archive()
 
-    await client.archive_session(result.session_id)
-    await client.close()
+asyncio.run(main())
 ```
 </Accordion>
 
 <Accordion title="Using with tools enabled">
 ```python
-async def with_tools():
-    client = MeerkatClient()
-    await client.connect()
+import asyncio
+from meerkat import MeerkatClient
 
-    result = await client.create_session(
-        "Create a file called hello.txt with 'Hello World' in it",
-        enable_builtins=True,
-        enable_shell=True,
-    )
-    print(f"Response: {result.text}")
-    print(f"Tool calls made: {result.tool_calls}")
+async def main():
+    async with MeerkatClient() as client:
+        session = await client.create_session(
+            "Create a file called hello.txt with 'Hello World' in it",
+            enable_builtins=True,
+            enable_shell=True,
+        )
+        print(f"Response: {session.text}")
+        print(f"Tool calls made: {session.tool_calls}")
+        await session.archive()
 
-    await client.archive_session(result.session_id)
-    await client.close()
+asyncio.run(main())
+```
+</Accordion>
+
+<Accordion title="Capability checking">
+```python
+import asyncio
+from meerkat import MeerkatClient, CapabilityUnavailableError
+
+async def main():
+    async with MeerkatClient() as client:
+        print("Available capabilities:")
+        for cap in client.capabilities:
+            if cap.available:
+                print(f"  {cap.id}: {cap.description}")
+
+        if client.has_capability("skills"):
+            print("Skills are available")
+
+        try:
+            client.require_capability("comms")
+            print("Comms capability confirmed")
+        except CapabilityUnavailableError as e:
+            print(f"Comms not available: {e.message}")
+
+asyncio.run(main())
+```
+</Accordion>
+
+<Accordion title="Skill invocation">
+```python
+import asyncio
+from meerkat import MeerkatClient, SkillKey
+
+async def main():
+    async with MeerkatClient() as client:
+        session = await client.create_session(
+            "I need help reviewing code.",
+            model="claude-sonnet-4-5",
+        )
+
+        key = SkillKey(source_uuid="abc123", skill_name="code-review")
+        result = await session.invoke_skill(key, "Review this Python function for bugs.")
+        print(result.text)
+
+        await session.archive()
+
+asyncio.run(main())
 ```
 </Accordion>
 
@@ -293,6 +547,6 @@ async def with_tools():
 
 ## See also
 
-- [Python SDK reference](/sdks/python/reference) - wire types, capabilities, skills, errors
-- [Rust SDK overview](/rust/overview) - Rust library API
-- [RPC reference](/api/rpc) - JSON-RPC protocol specification
+- [Python SDK reference](/sdks/python/reference) — types, streaming events, and error handling
+- [Rust SDK overview](/rust/overview) — Rust library API
+- [RPC reference](/api/rpc) — JSON-RPC protocol specification

--- a/docs/sdks/python/reference.mdx
+++ b/docs/sdks/python/reference.mdx
@@ -1,219 +1,413 @@
 ---
 title: "Python SDK reference"
-description: "Wire types, capability checking, skill helpers, event streaming, and error handling for the Python SDK."
+description: "Types, streaming events, capability checking, skill references, and error handling for the Python SDK."
 icon: "book"
 ---
 
-## Wire types
+## RunResult
 
-<Note>
-`get_config()` / `patch_config()` operate on the RPC config envelope (`config`, `generation`, `realm_id`, `instance_id`, `backend`, `resolved_paths`). `set_config()` currently forwards the payload you provide.
-</Note>
+`RunResult` is returned by `client.create_session()`, `session.turn()`, and `session.invoke_skill()`. It is also available as `events.result` after consuming an `EventStream`.
 
-<Accordion title="WireRunResult">
 ```python
-from meerkat import WireRunResult
+from meerkat import RunResult
 ```
 
-Returned by `create_session()` and `start_turn()`.
-
 <ResponseField name="session_id" type="str">Session UUID.</ResponseField>
-<ResponseField name="text" type="str">Agent response text.</ResponseField>
-<ResponseField name="turns" type="int">Number of turns completed.</ResponseField>
+<ResponseField name="text" type="str">Assistant response text.</ResponseField>
+<ResponseField name="turns" type="int">Number of LLM turns completed.</ResponseField>
 <ResponseField name="tool_calls" type="int">Number of tool calls made.</ResponseField>
-<ResponseField name="usage" type="Optional[WireUsage]">Token usage breakdown.</ResponseField>
-<ResponseField name="structured_output" type="Optional[Any]">Parsed structured output.</ResponseField>
-<ResponseField name="schema_warnings" type="Optional[list]">Schema validation warnings.</ResponseField>
-</Accordion>
+<ResponseField name="usage" type="Usage">Token usage breakdown.</ResponseField>
+<ResponseField name="session_ref" type="str | None">Optional human-readable session reference.</ResponseField>
+<ResponseField name="structured_output" type="Any | None">Parsed structured output, if an `output_schema` was provided.</ResponseField>
+<ResponseField name="schema_warnings" type="list[SchemaWarning] | None">Schema validation warnings emitted by the provider.</ResponseField>
+<ResponseField name="skill_diagnostics" type="SkillRuntimeDiagnostics | None">Runtime diagnostics from the skill subsystem, when present.</ResponseField>
 
-<Accordion title="WireUsage">
+---
+
+## Usage
+
+`Usage` is a frozen dataclass describing token consumption for a single LLM turn. It appears on `RunResult.usage` and on the `TurnCompleted` and `RunCompleted` events.
+
 ```python
-from meerkat import WireUsage
+from meerkat import Usage
 ```
 
 <ResponseField name="input_tokens" type="int">Input tokens consumed.</ResponseField>
 <ResponseField name="output_tokens" type="int">Output tokens generated.</ResponseField>
-<ResponseField name="total_tokens" type="int">Total tokens.</ResponseField>
-<ResponseField name="cache_creation_tokens" type="Optional[int]">Cache creation tokens.</ResponseField>
-<ResponseField name="cache_read_tokens" type="Optional[int]">Cache read tokens.</ResponseField>
-</Accordion>
-
-<Accordion title="WireEvent (deprecated)">
-```python
-from meerkat import WireEvent
-```
-
-<ResponseField name="session_id" type="str">Session this event belongs to.</ResponseField>
-<ResponseField name="event" type="Optional[dict]">The agent event payload.</ResponseField>
-
-<Warning>
-`WireEvent` is deprecated. The streaming API (`StreamingTurn`) yields raw event dicts directly. This type is retained for backward compatibility only.
-</Warning>
-</Accordion>
-
-<Accordion title="CapabilitiesResponse">
-```python
-from meerkat import CapabilitiesResponse, CapabilityEntry
-```
-
-<ResponseField name="contract_version" type="str">Server contract version.</ResponseField>
-<ResponseField name="capabilities" type="list[CapabilityEntry]">List of capability entries.</ResponseField>
-
-Each `CapabilityEntry` has `id`, `description`, and `status` fields.
-</Accordion>
+<ResponseField name="cache_creation_tokens" type="int | None">Tokens used to write to the prompt cache (provider-specific).</ResponseField>
+<ResponseField name="cache_read_tokens" type="int | None">Tokens read from the prompt cache (provider-specific).</ResponseField>
 
 ---
 
-## Domain run result types
+## SessionInfo
 
-The public SDK surface uses Python dataclasses (`RunResult`) instead of wire-prefixed types.
+Returned by `client.list_sessions()`.
 
-<Accordion title="SkillRuntimeDiagnostics">
 ```python
-@dataclass(frozen=True, slots=True)
-class SkillRuntimeDiagnostics:
-    source_health: SourceHealthSnapshot
-    quarantined: list[SkillQuarantineDiagnostic]
+from meerkat import SessionInfo
 ```
-</Accordion>
+
+<ResponseField name="session_id" type="str">Session UUID.</ResponseField>
+<ResponseField name="session_ref" type="str | None">Optional human-readable reference.</ResponseField>
+<ResponseField name="created_at" type="str">ISO 8601 creation timestamp.</ResponseField>
+<ResponseField name="updated_at" type="str">ISO 8601 last-updated timestamp.</ResponseField>
+<ResponseField name="message_count" type="int">Number of messages in the session.</ResponseField>
+<ResponseField name="total_tokens" type="int">Cumulative tokens consumed.</ResponseField>
+<ResponseField name="is_active" type="bool">Whether a turn is currently in progress.</ResponseField>
+
+---
+
+## Capability
+
+Returned as elements of `client.capabilities`.
+
+```python
+from meerkat import Capability
+```
+
+<ResponseField name="id" type="str">Capability identifier (e.g. `"shell"`, `"comms"`, `"skills"`).</ResponseField>
+<ResponseField name="description" type="str">Human-readable description.</ResponseField>
+<ResponseField name="status" type="str">Availability status string. Normalised from Rust-tagged enums to a plain string by the SDK.</ResponseField>
+<ResponseField name="available" type="bool">Convenience property — `True` when `status == "Available"`.</ResponseField>
+
+### Checking capabilities
+
+Capability inspection is done directly on the client — there is no separate checker class.
+
+```python
+# Property: list[Capability] populated during connect()
+for cap in client.capabilities:
+    if cap.available:
+        print(f"{cap.id}: {cap.description}")
+
+# Boolean check
+if client.has_capability("shell"):
+    ...
+
+# Guarded code path — raises CapabilityUnavailableError if not available
+client.require_capability("comms")
+```
+
+---
+
+## Skill types
+
+### SkillKey
+
+```python
+from meerkat import SkillKey
+
+key = SkillKey(source_uuid="abc123", skill_name="code-review")
+```
+
+<ResponseField name="source_uuid" type="str">UUID of the skill source.</ResponseField>
+<ResponseField name="skill_name" type="str">Name of the skill within the source.</ResponseField>
+
+### SkillRef
+
+```python
+SkillRef = Union[SkillKey, str]
+```
+
+Wherever a skill reference is accepted (e.g. `session.invoke_skill()`, `turn(skill_refs=...)`) you can pass either a `SkillKey` or a legacy string of the form `"<source_uuid>/<skill_name>"`. Legacy strings emit a `DeprecationWarning`.
+
+---
+
+## Diagnostic types
+
+### SchemaWarning
+
+```python
+from meerkat import SchemaWarning
+```
+
+<ResponseField name="provider" type="str">Provider that emitted the warning.</ResponseField>
+<ResponseField name="path" type="str">JSON path to the offending schema location.</ResponseField>
+<ResponseField name="message" type="str">Warning message.</ResponseField>
+
+### SkillRuntimeDiagnostics
+
+```python
+from meerkat import SkillRuntimeDiagnostics, SourceHealthSnapshot, SkillQuarantineDiagnostic
+```
+
+Present on `RunResult.skill_diagnostics` when the skill subsystem emits diagnostics.
+
+<ResponseField name="source_health" type="SourceHealthSnapshot">Health snapshot for skill source resolution.</ResponseField>
+<ResponseField name="quarantined" type="list[SkillQuarantineDiagnostic]">Skills that have been quarantined due to repeated failures.</ResponseField>
+
+`SourceHealthSnapshot` fields: `state`, `invalid_ratio`, `invalid_count`, `total_count`, `failure_streak`, `handshake_failed`.
+
+`SkillQuarantineDiagnostic` fields: `source_uuid`, `skill_id`, `location`, `error_code`, `error_class`, `message`, `first_seen_unix_secs`, `last_seen_unix_secs`.
+
+---
+
+## EventStream
+
+`EventStream` is an async context manager returned by `session.stream()` and `client.create_session_streaming()`. Iterating it yields typed `Event` subclass instances.
+
+```python
+from meerkat import EventStream
+```
 
 <Note>
-`RunResult.skill_diagnostics` is `SkillRuntimeDiagnostics | None` on the Python domain type.
+`session.stream()` and `client.create_session_streaming()` are synchronous — they return an `EventStream` directly. The JSON-RPC request is sent when entering the `async with` block.
 </Note>
 
----
+### Properties
 
-## CapabilityChecker
+<ResponseField name="session_id" type="str">Session UUID. For `create_session_streaming`, this is set after the response arrives (once `__aenter__` has flushed the request).</ResponseField>
+<ResponseField name="result" type="RunResult">The final result. Available only after the stream has been fully consumed. Raises `MeerkatError("STREAM_NOT_CONSUMED")` if accessed beforehand.</ResponseField>
 
-Standalone capability-checking helper:
-
-```python
-from meerkat import CapabilityChecker
-
-caps = await client.get_capabilities()
-checker = CapabilityChecker(caps)
-
-if checker.has("shell"):
-    print("Shell tool is available")
-
-checker.require("comms")  # raises CapabilityUnavailableError if unavailable
-
-print(checker.available)  # e.g. ["sessions", "streaming", "builtins"]
-```
-
-| Method | Description |
-|--------|-------------|
-| `has(capability_id)` | Returns `True` if status is `"Available"` |
-| `require(capability_id)` | Raises `CapabilityUnavailableError` if not available |
-| `available` | List of all available capability IDs |
-
----
-
-## SkillHelper
-
-Helpers for invoking Meerkat skills:
+### Usage patterns
 
 ```python
-from meerkat import SkillHelper
-
-helper = SkillHelper(client)
-
-if helper.is_available():
-    result = await helper.invoke(session_id, "/shell-patterns", "How do I run a background job?")
-    print(result.text)
-
-    result = await helper.invoke_new_session("/code-review", "Review this function", model="claude-sonnet-4-5")
+# Pattern matching on typed events
+async with session.stream("Explain monads") as events:
+    async for event in events:
+        match event:
+            case TextDelta(delta=chunk):
+                print(chunk, end="", flush=True)
+            case ToolCallRequested(name=name, args=args):
+                print(f"\nCalling tool: {name} with args: {args}")
+            case TurnCompleted(usage=u):
+                print(f"\nTokens: {u.input_tokens} in / {u.output_tokens} out")
+            case _:
+                pass
+    result = events.result
 ```
 
-| Method | Description |
-|--------|-------------|
-| `is_available()` | Returns `True` if `"skills"` capability is available |
-| `require_skills()` | Raises error if skills not available |
-| `invoke(session_id, skill_ref, prompt)` | Invoke skill in existing session |
-| `invoke_new_session(skill_ref, prompt, model?)` | Create session and invoke skill |
+```python
+# Consume silently, get RunResult
+result = await session.stream("prompt").collect()
+
+# Accumulate text, get (full_text, RunResult)
+text, result = await session.stream("prompt").collect_text()
+```
 
 ---
 
-## Streaming API
+## Typed events
 
-`StreamingTurn` provides real-time event streaming during agent execution. Events are yielded as raw dicts matching the Rust `AgentEvent` serde-tagged enum (e.g. `{"type": "text_delta", "delta": "..."}`).
-
-### create_session_streaming
+All events are frozen dataclasses. Import them from the top-level `meerkat` package.
 
 ```python
-async with client.create_session_streaming("Hello!") as stream:
-    async for event in stream:
-        if event["type"] == "text_delta":
-            print(event["delta"], end="", flush=True)
-    result = stream.result  # WireRunResult
-```
-
-Accepts all the same parameters as `create_session()` plus `preload_skills` and `skill_references`.
-
-### start_turn_streaming
-
-```python
-async with client.start_turn_streaming(session_id, "Follow up") as stream:
-    async for event in stream:
-        print(event)
-    result = stream.result
-```
-
-### Convenience methods
-
-```python
-# Consume all events, return result
-async with client.create_session_streaming("Hello!") as stream:
-    result = await stream.collect()
-
-# Accumulate text deltas
-async with client.create_session_streaming("Hello!") as stream:
-    full_text, result = await stream.collect_text()
-```
-
-### Event types
-
-Events have a `type` field discriminating the variant:
-
-| Type | Description |
-|------|-------------|
-| `run_started` | Agent run began |
-| `turn_started` | New LLM turn |
-| `text_delta` | Incremental text chunk (`delta` field) |
-| `text_complete` | Full text available |
-| `tool_call_requested` | Agent wants to call a tool |
-| `tool_result_received` | Tool returned a result |
-| `turn_completed` | LLM turn finished |
-| `run_completed` | Agent run finished |
-
-<Note>
-The streaming methods are synchronous (not `async def`) — they return a `StreamingTurn` directly. The request is sent when entering the `async with` block.
-</Note>
-
-### Skills parameters
-
-Both `create_session()` and `start_turn()` accept skill-related parameters:
-
-```python
-# Preload skills into the system prompt at session creation
-result = await client.create_session(
-    "Hello!",
-    preload_skills=["extraction/email", "formatting/markdown"],
-)
-
-# Inject skills for a specific turn
-result = await client.start_turn(
-    session_id,
-    "Extract emails from this text",
-    skill_references=["extraction/email"],
+from meerkat import (
+    Event,
+    RunStarted, RunCompleted, RunFailed,
+    TurnStarted, TurnCompleted,
+    TextDelta, TextComplete,
+    ToolCallRequested, ToolResultReceived,
+    ToolExecutionStarted, ToolExecutionCompleted, ToolExecutionTimedOut,
+    CompactionStarted, CompactionCompleted, CompactionFailed,
+    BudgetWarning,
+    Retrying,
+    HookStarted, HookCompleted, HookFailed, HookDenied,
+    HookRewriteApplied, HookPatchPublished,
+    SkillsResolved, SkillResolutionFailed,
+    InteractionComplete, InteractionFailed,
+    StreamTruncated,
+    UnknownEvent,
 )
 ```
+
+### Session lifecycle
+
+<Accordion title="RunStarted">
+Agent run has started.
+
+<ResponseField name="session_id" type="str">Session UUID.</ResponseField>
+<ResponseField name="prompt" type="str">The prompt that started this run.</ResponseField>
+</Accordion>
+
+<Accordion title="RunCompleted">
+Agent run completed successfully.
+
+<ResponseField name="session_id" type="str">Session UUID.</ResponseField>
+<ResponseField name="result" type="str">Final result text.</ResponseField>
+<ResponseField name="usage" type="Usage">Token usage for this run.</ResponseField>
+</Accordion>
+
+<Accordion title="RunFailed">
+Agent run failed.
+
+<ResponseField name="session_id" type="str">Session UUID.</ResponseField>
+<ResponseField name="error" type="str">Error description.</ResponseField>
+</Accordion>
+
+### LLM turn events
+
+<Accordion title="TurnStarted">
+A new LLM turn has begun.
+
+<ResponseField name="turn_number" type="int">1-based turn index within the current run.</ResponseField>
+</Accordion>
+
+<Accordion title="TextDelta">
+An incremental text chunk streamed from the LLM. Handle these to display output in real time.
+
+<ResponseField name="delta" type="str">The text chunk.</ResponseField>
+</Accordion>
+
+<Accordion title="TextComplete">
+Full assistant text for the current turn, emitted after streaming finishes.
+
+<ResponseField name="content" type="str">The complete text.</ResponseField>
+</Accordion>
+
+<Accordion title="ToolCallRequested">
+The LLM wants to invoke a tool.
+
+<ResponseField name="id" type="str">Tool call identifier.</ResponseField>
+<ResponseField name="name" type="str">Tool name.</ResponseField>
+<ResponseField name="args" type="Any">Parsed tool arguments.</ResponseField>
+</Accordion>
+
+<Accordion title="ToolResultReceived">
+A tool result was fed back to the LLM.
+
+<ResponseField name="id" type="str">Tool call identifier.</ResponseField>
+<ResponseField name="name" type="str">Tool name.</ResponseField>
+<ResponseField name="is_error" type="bool">`True` if the tool returned an error result.</ResponseField>
+</Accordion>
+
+<Accordion title="TurnCompleted">
+An LLM turn finished.
+
+<ResponseField name="stop_reason" type="str">The stop reason reported by the LLM provider (e.g. `"end_turn"`, `"tool_use"`).</ResponseField>
+<ResponseField name="usage" type="Usage">Token usage for this turn.</ResponseField>
+</Accordion>
+
+### Tool execution events
+
+<Accordion title="ToolExecutionStarted">
+<ResponseField name="id" type="str">Tool call identifier.</ResponseField>
+<ResponseField name="name" type="str">Tool name.</ResponseField>
+</Accordion>
+
+<Accordion title="ToolExecutionCompleted">
+<ResponseField name="id" type="str">Tool call identifier.</ResponseField>
+<ResponseField name="name" type="str">Tool name.</ResponseField>
+<ResponseField name="result" type="str">Tool output (truncated for large results).</ResponseField>
+<ResponseField name="is_error" type="bool">`True` if the tool execution resulted in an error.</ResponseField>
+<ResponseField name="duration_ms" type="int">Execution duration in milliseconds.</ResponseField>
+</Accordion>
+
+<Accordion title="ToolExecutionTimedOut">
+<ResponseField name="id" type="str">Tool call identifier.</ResponseField>
+<ResponseField name="name" type="str">Tool name.</ResponseField>
+<ResponseField name="timeout_ms" type="int">The configured timeout threshold in milliseconds.</ResponseField>
+</Accordion>
+
+### Compaction events
+
+<Accordion title="CompactionStarted">
+Context compaction has begun to free up context window space.
+
+<ResponseField name="input_tokens" type="int">Token count before compaction.</ResponseField>
+<ResponseField name="estimated_history_tokens" type="int">Estimated history tokens subject to compaction.</ResponseField>
+<ResponseField name="message_count" type="int">Number of messages before compaction.</ResponseField>
+</Accordion>
+
+<Accordion title="CompactionCompleted">
+<ResponseField name="summary_tokens" type="int">Tokens in the compacted summary.</ResponseField>
+<ResponseField name="messages_before" type="int">Message count before compaction.</ResponseField>
+<ResponseField name="messages_after" type="int">Message count after compaction.</ResponseField>
+</Accordion>
+
+<Accordion title="CompactionFailed">
+<ResponseField name="error" type="str">Failure description.</ResponseField>
+</Accordion>
+
+### Budget and retry events
+
+<Accordion title="BudgetWarning">
+A budget threshold has been crossed.
+
+<ResponseField name="budget_type" type="str">Budget category (e.g. `"tokens"`, `"turns"`).</ResponseField>
+<ResponseField name="used" type="int">Current usage.</ResponseField>
+<ResponseField name="limit" type="int">Configured limit.</ResponseField>
+<ResponseField name="percent" type="float">Usage as a percentage of the limit.</ResponseField>
+</Accordion>
+
+<Accordion title="Retrying">
+An LLM request is being retried after a transient failure.
+
+<ResponseField name="attempt" type="int">Current attempt number (1-based).</ResponseField>
+<ResponseField name="max_attempts" type="int">Maximum configured attempts.</ResponseField>
+<ResponseField name="error" type="str">The error that triggered the retry.</ResponseField>
+<ResponseField name="delay_ms" type="int">Backoff delay before this attempt in milliseconds.</ResponseField>
+</Accordion>
+
+### Hook events
+
+<Accordion title="HookStarted / HookCompleted / HookFailed">
+Lifecycle events for hook invocations.
+
+<ResponseField name="hook_id" type="str">Hook identifier.</ResponseField>
+<ResponseField name="point" type="str">Hook point (e.g. `"pre_turn"`, `"post_turn"`).</ResponseField>
+<ResponseField name="duration_ms" type="int">`HookCompleted` only — execution duration.</ResponseField>
+<ResponseField name="error" type="str">`HookFailed` only — failure description.</ResponseField>
+</Accordion>
+
+<Accordion title="HookDenied">
+A hook denied the current operation.
+
+<ResponseField name="hook_id" type="str">Hook identifier.</ResponseField>
+<ResponseField name="point" type="str">Hook point.</ResponseField>
+<ResponseField name="reason_code" type="str">Machine-readable denial reason.</ResponseField>
+<ResponseField name="message" type="str">Human-readable denial message.</ResponseField>
+<ResponseField name="payload" type="Any">Additional context from the hook.</ResponseField>
+</Accordion>
+
+<Accordion title="HookRewriteApplied / HookPatchPublished">
+Hook mutation events.
+
+<ResponseField name="hook_id" type="str">Hook identifier.</ResponseField>
+<ResponseField name="point" type="str">Hook point.</ResponseField>
+<ResponseField name="patch" type="dict">Applied patch (`HookRewriteApplied`) or published envelope (`HookPatchPublished`).</ResponseField>
+</Accordion>
+
+### Skill events
+
+<Accordion title="SkillsResolved">
+Skills were resolved and injected for this turn.
+
+<ResponseField name="skills" type="list[str]">List of resolved skill identifiers.</ResponseField>
+<ResponseField name="injection_bytes" type="int">Bytes of skill content injected into the context.</ResponseField>
+</Accordion>
+
+<Accordion title="SkillResolutionFailed">
+A skill reference could not be resolved.
+
+<ResponseField name="reference" type="str">The skill reference that failed.</ResponseField>
+<ResponseField name="error" type="str">Failure description.</ResponseField>
+</Accordion>
+
+### Comms events
+
+<Accordion title="InteractionComplete / InteractionFailed">
+Comms interaction lifecycle events.
+
+<ResponseField name="interaction_id" type="str">Interaction identifier.</ResponseField>
+<ResponseField name="result" type="str">`InteractionComplete` only — interaction result.</ResponseField>
+<ResponseField name="error" type="str">`InteractionFailed` only — failure description.</ResponseField>
+</Accordion>
+
+### Forward compatibility
+
+<Accordion title="UnknownEvent">
+Emitted when the server sends an event type not recognised by this SDK version. Inspect `type` and `data` to handle it manually.
+
+<ResponseField name="type" type="str">The wire discriminator string.</ResponseField>
+<ResponseField name="data" type="dict">The raw event payload.</ResponseField>
+</Accordion>
 
 ---
 
 ## Error handling
 
-All errors inherit from `MeerkatError`:
+All errors inherit from `MeerkatError`.
 
 ```python
 from meerkat import MeerkatError, CapabilityUnavailableError, SessionNotFoundError, SkillNotFoundError
@@ -230,11 +424,14 @@ from meerkat import MeerkatError, CapabilityUnavailableError, SessionNotFoundErr
 
 | Code | Description |
 |------|-------------|
-| `BINARY_NOT_FOUND` | `rkat-rpc` binary not found on PATH |
+| `BINARY_NOT_FOUND` | `rkat-rpc` binary not found on PATH and auto-download failed |
+| `BINARY_DOWNLOAD_FAILED` | Automatic binary download failed |
 | `NOT_CONNECTED` | Operation attempted before `connect()` |
 | `CONNECTION_CLOSED` | `rkat-rpc` process closed unexpectedly |
-| `VERSION_MISMATCH` | Server contract version incompatible |
-| `CAPABILITY_UNAVAILABLE` | Capability check failed |
+| `VERSION_MISMATCH` | Server contract version incompatible with SDK |
+| `CAPABILITY_UNAVAILABLE` | Capability check failed via `require_capability()` |
+| `STREAM_NOT_CONSUMED` | `EventStream.result` accessed before the stream was iterated |
+| `INVALID_ARGS` | Mutually exclusive options provided (e.g. `realm_id` + `isolated`) |
 
 ### Server-side error codes
 
@@ -251,11 +448,22 @@ from meerkat import MeerkatError, CapabilityUnavailableError, SessionNotFoundErr
 ### Example
 
 ```python
-try:
-    result = await client.start_turn("nonexistent-session-id", "hello")
-except MeerkatError as e:
-    print(f"Error code: {e.code}")
-    print(f"Message: {e.message}")
+from meerkat import MeerkatClient, MeerkatError, CapabilityUnavailableError
+
+async def main():
+    async with MeerkatClient() as client:
+        session = await client.create_session("Hello!")
+
+        try:
+            result = await session.turn("Follow up")
+        except MeerkatError as e:
+            print(f"Error code: {e.code}")
+            print(f"Message: {e.message}")
+
+        try:
+            client.require_capability("comms")
+        except CapabilityUnavailableError as e:
+            print(f"Comms not available: {e.message}")
 ```
 
 ---
@@ -269,7 +477,7 @@ The SDK negotiates version compatibility during `connect()`:
 
 ```python
 from meerkat import CONTRACT_VERSION
-print(CONTRACT_VERSION)  # "0.2.0"
+print(CONTRACT_VERSION)  # e.g. "0.2.0"
 ```
 
 ---
@@ -293,6 +501,6 @@ pytest sdks/python/tests/test_e2e_smoke.py -v
 
 ## See also
 
-- [Python SDK overview](/sdks/python/overview) - getting started and MeerkatClient API
-- [TypeScript SDK](/sdks/typescript/overview) - TypeScript SDK
-- [RPC reference](/api/rpc) - JSON-RPC protocol specification
+- [Python SDK overview](/sdks/python/overview) — getting started, MeerkatClient, and Session API
+- [TypeScript SDK](/sdks/typescript/overview) — TypeScript SDK
+- [RPC reference](/api/rpc) — JSON-RPC protocol specification

--- a/docs/sdks/typescript/overview.mdx
+++ b/docs/sdks/typescript/overview.mdx
@@ -1,17 +1,17 @@
 ---
 title: "TypeScript SDK"
-description: "Getting started with the Meerkat TypeScript SDK: sessions, turns, events, and capabilities."
+description: "Getting started with the Meerkat TypeScript SDK: sessions, turns, streaming events, and capabilities."
 icon: "js"
 ---
 
-The TypeScript SDK (`@meerkat/sdk`) lets you manage sessions, run agent turns, stream events, and query capabilities from TypeScript or JavaScript. It communicates with a local `rkat-rpc` subprocess over JSON-RPC 2.0 and supports explicit realm scoping.
+The TypeScript SDK (`@rkat/sdk`) lets you create sessions, run agent turns, stream typed events, and query capabilities from TypeScript or JavaScript. It spawns a local `rkat-rpc` subprocess and communicates with it over JSON-RPC 2.0.
 
 ## Getting started
 
 <Steps>
   <Step title="Install the SDK">
     ```bash
-    npm install @meerkat/sdk
+    npm install @rkat/sdk
     ```
   </Step>
   <Step title="Install the RPC binary">
@@ -38,22 +38,19 @@ The TypeScript SDK (`@meerkat/sdk`) lets you manage sessions, run agent turns, s
   </Step>
   <Step title="Connect and run">
     ```typescript
-    import { MeerkatClient } from "@meerkat/sdk";
+    import { MeerkatClient } from "@rkat/sdk";
 
     const client = new MeerkatClient();
-    await client.connect({ realmId: "team-alpha" });
+    await client.connect();
 
-    const result = await client.createSession({
-      prompt: "What is the capital of Sweden?",
-    });
+    const session = await client.createSession("What is the capital of Sweden?");
+    console.log(session.text);
+    console.log(session.id);
 
+    const result = await session.turn("And what is its population?");
     console.log(result.text);
-    console.log(result.session_id);
 
-    const followUp = await client.startTurn(result.session_id, "And what is its population?");
-    console.log(followUp.text);
-
-    await client.archiveSession(result.session_id);
+    await session.archive();
     await client.close();
     ```
   </Step>
@@ -63,24 +60,39 @@ The TypeScript SDK (`@meerkat/sdk`) lets you manage sessions, run agent turns, s
 
 ## Method overview
 
+### MeerkatClient methods
+
 | Method | Description |
 |--------|-------------|
 | `connect(options?)` | Spawn `rkat-rpc`, handshake, fetch capabilities |
 | `close()` | Kill the subprocess |
-| `createSession(params)` | Create a session and run the first turn |
-| `startTurn(sessionId, prompt)` | Continue an existing session |
-| `interrupt(sessionId)` | Cancel an in-flight turn |
+| `createSession(prompt, options?)` | Create a session, run the first turn, return a `Session` |
+| `createSessionStreaming(prompt, options?)` | Create a session and stream typed events from the first turn |
 | `listSessions()` | List active sessions |
-| `readSession(sessionId)` | Read session state |
-| `archiveSession(sessionId)` | Remove a session |
-| `getCapabilities()` | Get runtime capabilities |
-| `hasCapability(id)` | Check if a capability is available |
-| `requireCapability(id)` | Guard a code path by capability |
+| `readSession(sessionId)` | Read raw session state |
 | `getConfig()` | Read runtime configuration |
 | `setConfig(config)` | Replace runtime configuration |
 | `patchConfig(patch)` | Merge-patch runtime configuration |
-| `send(sessionId, command)` | Send a comms command to a session |
-| `peers(sessionId)` | List peers visible to a session |
+
+### Capability methods
+
+| Method | Description |
+|--------|-------------|
+| `client.capabilities` | Read-only array of all `Capability` objects |
+| `client.hasCapability(id)` | Returns `true` if capability is `"Available"` |
+| `client.requireCapability(id)` | Throws `CapabilityUnavailableError` if unavailable |
+
+### Session methods
+
+| Method | Description |
+|--------|-------------|
+| `session.turn(prompt, options?)` | Run another turn (non-streaming), returns `RunResult` |
+| `session.stream(prompt, options?)` | Run another turn with streaming, returns `EventStream` |
+| `session.interrupt()` | Cancel the currently running turn |
+| `session.archive()` | Remove the session from the server |
+| `session.invokeSkill(skillRef, prompt)` | Invoke a skill in this session |
+| `session.send(command)` | Send a comms command scoped to this session |
+| `session.peers()` | List peers visible to this session's comms runtime |
 
 ---
 
@@ -92,122 +104,259 @@ The TypeScript SDK (`@meerkat/sdk`) lets you manage sessions, run agent turns, s
 new MeerkatClient(rkatPath?: string)
 ```
 
+Defaults to searching `$PATH` for `rkat-rpc`. If not found, automatically downloads the correct binary for the current platform and caches it in `~/.cache/meerkat/bin/rkat-rpc`. Pass an explicit path or set `MEERKAT_BIN_PATH` to override.
+
 ### connect()
 
 ```typescript
-async connect(options?: {
-  realmId?: string;
-  instanceId?: string;
-  realmBackend?: "jsonl" | "redb";
-}): Promise<this>
+async connect(options?: ConnectOptions): Promise<this>
 ```
 
 Spawns `rkat-rpc`, performs `initialize` handshake, checks contract version compatibility, and fetches capabilities. Returns `this` for chaining.
 
-If `realmId` is omitted, each SDK process gets an isolated default RPC realm. Reuse `realmId` to share sessions/config across surfaces.
-`realmBackend` is a creation hint only; backend selection is pinned per realm in `realm_manifest.json`.
+```typescript
+export interface ConnectOptions {
+  realmId?: string;
+  instanceId?: string;
+  realmBackend?: "jsonl" | "redb";
+  isolated?: boolean;
+  stateRoot?: string;
+  contextRoot?: string;
+  userConfigRoot?: string;
+}
+```
 
-The TypeScript SDK is RPC-backed. Mob capability is provided by the RPC host composing `meerkat-mob-mcp` (`MobMcpState` + `MobMcpDispatcher`) into `SessionBuildOptions.external_tools`, which exposes `mob_*` tools to session turns.
+`realmId` and `isolated` are mutually exclusive. If `realmId` is omitted and `isolated` is not set, sessions are stored in the default realm. Reuse `realmId` to share sessions and config across processes or surfaces.
 
-### createSession(params)
+### createSession()
 
 ```typescript
-async createSession(params: {
-  prompt: string;
+async createSession(
+  prompt: string,
+  options?: SessionOptions,
+): Promise<Session>
+```
+
+Creates a new session, runs the first turn with `prompt`, and returns a `Session` object. The `Session` holds the last `RunResult` and exposes convenience accessors for the most recent text, usage, and tool call counts.
+
+```typescript
+const session = await client.createSession("Summarise this project", {
+  model: "claude-sonnet-4-5",
+  systemPrompt: "You are a senior engineer.",
+  maxTokens: 4096,
+});
+
+console.log(session.text);
+console.log(session.usage.inputTokens);
+```
+
+### createSessionStreaming()
+
+```typescript
+createSessionStreaming(
+  prompt: string,
+  options?: SessionOptions,
+): EventStream
+```
+
+Creates a new session and returns an `EventStream` for the first turn. Iterate the stream to receive typed events as they arrive. The final `RunResult` is available on `stream.result` after iteration completes.
+
+```typescript
+const stream = client.createSessionStreaming("Explain async/await in TypeScript");
+
+for await (const event of stream) {
+  if (event.type === "text_delta") {
+    process.stdout.write(event.delta);
+  }
+}
+
+console.log("\nTokens used:", stream.result.usage.outputTokens);
+```
+
+### SessionOptions
+
+All fields are camelCase:
+
+```typescript
+interface SessionOptions {
   model?: string;
   provider?: string;
-  system_prompt?: string;
-  max_tokens?: number;
-  output_schema?: Record<string, unknown>;
-  structured_output_retries?: number;
-  enable_builtins?: boolean;
-  enable_shell?: boolean;
-  enable_subagents?: boolean;
-  enable_memory?: boolean;
-  host_mode?: boolean;
-  comms_name?: string;
-  provider_params?: Record<string, unknown>;
-}): Promise<WireRunResult>
+  systemPrompt?: string;
+  maxTokens?: number;
+  outputSchema?: Record<string, unknown>;
+  structuredOutputRetries?: number;
+  hooksOverride?: Record<string, unknown>;
+  enableBuiltins?: boolean;
+  enableShell?: boolean;
+  enableSubagents?: boolean;
+  enableMemory?: boolean;
+  hostMode?: boolean;
+  commsName?: string;
+  peerMeta?: Record<string, unknown>;
+  providerParams?: Record<string, unknown>;
+  preloadSkills?: string[];
+  skillRefs?: SkillRef[];
+  skillReferences?: string[];
+}
 ```
 
-### startTurn(sessionId, prompt)
+---
+
+## Session
+
+`createSession()` and `createSessionStreaming()` both produce a `Session` object that acts as the handle for all subsequent turns on the same conversation.
+
+### Identity
 
 ```typescript
-async startTurn(sessionId: string, prompt: string): Promise<WireRunResult>
+session.id    // stable UUID string
+session.ref   // optional human-readable reference (string | undefined)
 ```
 
-### interrupt(sessionId)
+### Last-result shortcuts
+
+These accessors always reflect the most recent completed turn:
 
 ```typescript
-async interrupt(sessionId: string): Promise<void>
+session.text            // assistant text from the last turn
+session.usage           // Usage from the last turn
+session.turns           // number of LLM turns in the last run
+session.toolCalls       // number of tool calls in the last run
+session.structuredOutput // structured output from the last run (unknown | undefined)
+session.lastResult      // the full RunResult object
 ```
 
-### Session management
+### turn()
 
 ```typescript
-const sessions = await client.listSessions();
-const state = await client.readSession(sessionId);
-await client.archiveSession(sessionId);
+async turn(
+  prompt: string,
+  options?: { skillRefs?: SkillRef[]; skillReferences?: string[] },
+): Promise<RunResult>
 ```
 
-### Config management
+Sends another turn to the session and returns the `RunResult`. Also updates the session's last-result shortcuts.
+
+```typescript
+const result = await session.turn("Now explain the second point in more detail");
+console.log(result.text);
+```
+
+### stream()
+
+```typescript
+stream(
+  prompt: string,
+  options?: { skillRefs?: SkillRef[]; skillReferences?: string[] },
+): EventStream
+```
+
+Sends another turn and returns an `EventStream`. Iterating it yields typed `AgentEvent` objects. The session's last-result shortcuts are updated when iteration completes.
+
+```typescript
+for await (const event of session.stream("Elaborate on point three")) {
+  if (event.type === "text_delta") {
+    process.stdout.write(event.delta);
+  }
+}
+// session.text is now updated
+```
+
+### interrupt()
+
+```typescript
+async interrupt(): Promise<void>
+```
+
+Sends `turn/interrupt` for this session. Has no effect if no turn is running.
+
+### archive()
+
+```typescript
+async archive(): Promise<void>
+```
+
+Removes this session from the server. The `Session` object should not be used after calling `archive()`.
+
+### invokeSkill()
+
+```typescript
+async invokeSkill(skillRef: SkillRef, prompt: string): Promise<RunResult>
+```
+
+Calls `requireCapability("skills")`, then runs a turn with the provided skill reference injected. `SkillRef` is either a `SkillKey` object or a legacy string:
+
+```typescript
+// Structured (preferred)
+const result = await session.invokeSkill(
+  { sourceUuid: "abc123", skillName: "code-review" },
+  "Review this function for safety issues",
+);
+
+// Legacy string (deprecated)
+const result = await session.invokeSkill("/abc123/code-review", "Review this function");
+```
+
+### send() and peers()
+
+```typescript
+async send(command: Record<string, unknown>): Promise<Record<string, unknown>>
+async peers(): Promise<Array<Record<string, unknown>>>
+```
+
+Scope comms operations to this session. Requires the `comms` capability.
+
+```typescript
+await session.send({ kind: "peer_message", to: "agent-b", body: "Hello!" });
+const peers = await session.peers();
+```
+
+---
+
+## Capabilities
+
+Capabilities are fetched automatically during `connect()`. Use them to guard code paths that depend on optional features.
+
+```typescript
+// Read all capabilities
+console.log(client.capabilities);
+// [{ id: "sessions", description: "...", status: "Available" }, ...]
+
+// Check a single capability
+if (client.hasCapability("comms")) {
+  await session.send({ kind: "peer_message", to: "agent-b", body: "Hi" });
+}
+
+// Assert and throw if unavailable
+client.requireCapability("skills");  // throws CapabilityUnavailableError if not available
+```
+
+<Accordion title="Known capability IDs">
+| ID | Description |
+|---|-------------|
+| `sessions` | Session lifecycle |
+| `streaming` | Real-time event streaming |
+| `structured_output` | JSON schema structured output |
+| `hooks` | Lifecycle hooks |
+| `builtins` | Built-in tools |
+| `shell` | Shell tool |
+| `comms` | Inter-agent communication |
+| `sub_agents` | Sub-agent tools |
+| `memory_store` | Semantic memory |
+| `session_store` | Session persistence |
+| `session_compaction` | Context compaction |
+| `skills` | Skill loading |
+</Accordion>
+
+---
+
+## Config management
 
 ```typescript
 const config = await client.getConfig();
-await client.setConfig({ ...config, max_tokens: 4096 });
-const updated = await client.patchConfig({ max_tokens: 8192 });
+await client.setConfig({ ...config, model: "claude-opus-4-6" });
+const updated = await client.patchConfig({ maxTokens: 8192 });
 ```
-
-### send(sessionId, command)
-
-```typescript
-async send(
-  sessionId: string,
-  command: Record<string, unknown>,
-): Promise<Record<string, unknown>>
-```
-
-Send a canonical comms command to a session.
-
-```typescript
-await client.send(sessionId, {
-  kind: "peer_message",
-  to: "agent-b",
-  body: "Hello from Agent A!",
-});
-```
-
-### peers(sessionId)
-
-```typescript
-async peers(
-  sessionId: string,
-): Promise<{ peers: Array<Record<string, unknown>> }>
-```
-
-List peers visible to a session's comms runtime.
-
-```typescript
-const { peers } = await client.peers(sessionId);
-```
-
----
-
-## Session convenience methods
-
-`createSession()` returns a `Session` instance with convenience wrappers:
-
-- `await session.invokeSkill(skillRef, prompt)` sends structured `skillRefs`.
-- `await session.send(command)` scopes `comms/send` to the active session.
-- `await session.peers()` returns `peers` directly as an array.
-
----
-
-## Parsing and typing notes
-
-- Capability statuses may be encoded as externally-tagged enum objects by Rust (for example `{ DisabledByPolicy: {...} }`). The SDK normalizes these to the status key string.
-- Event parsing intentionally defaults missing fields to empty/zero values so partial streaming payloads can still be surfaced as typed events.
-- `RunResult.skillDiagnostics` is typed as `SkillRuntimeDiagnostics` (with `sourceHealth` and `quarantined`) when diagnostics are present.
 
 ---
 
@@ -215,34 +364,111 @@ const { peers } = await client.peers(sessionId);
 
 <Accordion title="Structured output">
 ```typescript
-const result = await client.createSession({
-  prompt: "List three European capitals",
-  output_schema: {
+import { MeerkatClient } from "@rkat/sdk";
+
+const client = new MeerkatClient();
+await client.connect();
+
+const session = await client.createSession("List three European capitals", {
+  outputSchema: {
     type: "object",
     properties: {
       capitals: { type: "array", items: { type: "string" } },
     },
     required: ["capitals"],
   },
-  structured_output_retries: 3,
+  structuredOutputRetries: 3,
 });
 
-console.log(result.structured_output);
+console.log(session.structuredOutput);
 // { capitals: ["Paris", "Berlin", "Madrid"] }
+
+await client.close();
 ```
 </Accordion>
 
 <Accordion title="Multi-turn conversation">
 ```typescript
-const session = await client.createSession({
-  prompt: "My name is Alice.",
+import { MeerkatClient } from "@rkat/sdk";
+
+const client = new MeerkatClient();
+await client.connect();
+
+const session = await client.createSession("My name is Alice.", {
   model: "claude-sonnet-4-5",
 });
 
-const turn2 = await client.startTurn(session.session_id, "What is my name?");
-console.log(turn2.text);  // Should mention "Alice"
+const result = await session.turn("What is my name?");
+console.log(result.text);  // Mentions "Alice"
 
-await client.archiveSession(session.session_id);
+await session.archive();
+await client.close();
+```
+</Accordion>
+
+<Accordion title="Streaming a turn">
+```typescript
+import { MeerkatClient } from "@rkat/sdk";
+
+const client = new MeerkatClient();
+await client.connect();
+
+const session = await client.createSession("You are a helpful assistant.", {
+  systemPrompt: "Be concise.",
+});
+
+for await (const event of session.stream("Explain Rust lifetimes in two sentences")) {
+  switch (event.type) {
+    case "text_delta":
+      process.stdout.write(event.delta);
+      break;
+    case "turn_completed":
+      console.log(`\nStop reason: ${event.stopReason}`);
+      console.log(`Tokens: ${event.usage.inputTokens} in / ${event.usage.outputTokens} out`);
+      break;
+  }
+}
+
+await client.close();
+```
+</Accordion>
+
+<Accordion title="Invoking a skill">
+```typescript
+import { MeerkatClient } from "@rkat/sdk";
+
+const client = new MeerkatClient();
+await client.connect();
+
+client.requireCapability("skills");
+
+const session = await client.createSession("Let's review some code.");
+
+const result = await session.invokeSkill(
+  { sourceUuid: "abc123", skillName: "code-review" },
+  "Review this function for correctness and safety",
+);
+
+console.log(result.text);
+
+await client.close();
+```
+</Accordion>
+
+<Accordion title="Using collectText() for simple streaming">
+```typescript
+import { MeerkatClient } from "@rkat/sdk";
+
+const client = new MeerkatClient();
+await client.connect();
+
+const stream = client.createSessionStreaming("Write a haiku about Rust");
+const [fullText, result] = await stream.collectText();
+
+console.log(fullText);
+console.log("Input tokens:", result.usage.inputTokens);
+
+await client.close();
 ```
 </Accordion>
 
@@ -250,6 +476,6 @@ await client.archiveSession(session.session_id);
 
 ## See also
 
-- [TypeScript SDK reference](/sdks/typescript/reference) - wire types, capabilities, skills, errors
+- [TypeScript SDK reference](/sdks/typescript/reference) - types, events, errors, and version compatibility
 - [Rust SDK overview](/rust/overview) - Rust library API
 - [RPC reference](/api/rpc) - JSON-RPC protocol specification

--- a/docs/sdks/typescript/reference.mdx
+++ b/docs/sdks/typescript/reference.mdx
@@ -1,243 +1,500 @@
 ---
 title: "TypeScript SDK reference"
-description: "Wire types, capability checking, skill helpers, event streaming, and error handling for the TypeScript SDK."
+description: "Types, events, error classes, and version compatibility for the @rkat/sdk TypeScript SDK."
 icon: "book"
 ---
 
-## Wire types
-
 <Note>
-`getConfig()` / `patchConfig()` return the RPC config envelope (`config`, `generation`, `realm_id`, `instance_id`, `backend`, `resolved_paths`). `setConfig()` forwards the payload you provide.
+All public types use camelCase field names. The SDK translates to and from the snake_case JSON-RPC wire format internally.
 </Note>
 
-<Accordion title="WireRunResult">
+## Imports
+
+Everything public is re-exported from the package root:
+
 ```typescript
-interface WireRunResult {
-  session_id: string;
-  text: string;
-  turns: number;
-  tool_calls: number;
-  usage: WireUsage;
-  structured_output?: unknown;
-  schema_warnings?: Array<{ provider: string; path: string; message: string }>;
-}
+import {
+  MeerkatClient,
+  Session,
+  EventStream,
+  MeerkatError,
+  CapabilityUnavailableError,
+  SessionNotFoundError,
+  SkillNotFoundError,
+  CONTRACT_VERSION,
+} from "@rkat/sdk";
+
+import type {
+  RunResult,
+  Usage,
+  SessionInfo,
+  SessionOptions,
+  Capability,
+  SkillKey,
+  SkillRef,
+  SkillRuntimeDiagnostics,
+  SchemaWarning,
+  AgentEvent,
+  TextDeltaEvent,
+  TurnCompletedEvent,
+  // ... all event types
+} from "@rkat/sdk";
 ```
-</Accordion>
-
-<Accordion title="WireUsage">
-```typescript
-interface WireUsage {
-  input_tokens: number;
-  output_tokens: number;
-  total_tokens: number;
-  cache_creation_tokens?: number;
-  cache_read_tokens?: number;
-}
-```
-</Accordion>
-
-<Accordion title="WireEvent">
-```typescript
-interface WireEvent {
-  session_id: string;
-  event: Record<string, unknown>;
-}
-```
-
-<Warning>
-The `sequence` and `contract_version` fields have been removed — they were never sent by the server. The streaming API uses raw event dicts directly.
-</Warning>
-</Accordion>
-
-<Accordion title="CapabilitiesResponse">
-```typescript
-interface CapabilitiesResponse {
-  contract_version: string;
-  capabilities: CapabilityEntry[];
-}
-
-interface CapabilityEntry {
-  id: string;
-  description: string;
-  status: string;  // "Available", "DisabledByPolicy", "NotCompiled", etc.
-}
-```
-</Accordion>
 
 ---
 
-## Domain run result types
+## Core types
 
-The public SDK surface uses camelCase domain types (`RunResult`) instead of wire types.
+### RunResult
 
-<Accordion title="SkillRuntimeDiagnostics">
+The result returned by `createSession()`, `session.turn()`, and `session.invokeSkill()`. Also available as `stream.result` after an `EventStream` is fully consumed.
+
+```typescript
+interface RunResult {
+  readonly sessionId: string;
+  readonly sessionRef?: string;
+  readonly text: string;
+  readonly turns: number;
+  readonly toolCalls: number;
+  readonly usage: Usage;
+  readonly structuredOutput?: unknown;
+  readonly schemaWarnings?: readonly SchemaWarning[];
+  readonly skillDiagnostics?: SkillRuntimeDiagnostics;
+}
+```
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `sessionId` | `string` | Stable UUID for this session |
+| `sessionRef` | `string \| undefined` | Optional human-readable reference |
+| `text` | `string` | Full assistant text from the last LLM turn |
+| `turns` | `number` | Number of LLM turns in this run |
+| `toolCalls` | `number` | Total tool calls executed in this run |
+| `usage` | `Usage` | Token usage for this run |
+| `structuredOutput` | `unknown \| undefined` | Parsed structured output when `outputSchema` was provided |
+| `schemaWarnings` | `SchemaWarning[] \| undefined` | Warnings emitted when structured output didn't fully match the schema |
+| `skillDiagnostics` | `SkillRuntimeDiagnostics \| undefined` | Runtime diagnostics from the skill subsystem |
+
+### Usage
+
+Token usage for a single run. All fields are camelCase — there is no `total_tokens` field.
+
+```typescript
+interface Usage {
+  readonly inputTokens: number;
+  readonly outputTokens: number;
+  readonly cacheCreationTokens?: number;
+  readonly cacheReadTokens?: number;
+}
+```
+
+### SessionInfo
+
+Summary returned by `client.listSessions()`.
+
+```typescript
+interface SessionInfo {
+  readonly sessionId: string;
+  readonly sessionRef?: string;
+  readonly createdAt: string;
+  readonly updatedAt: string;
+  readonly messageCount: number;
+  readonly totalTokens: number;
+  readonly isActive: boolean;
+}
+```
+
+### Capability
+
+A single runtime capability entry, as returned by `client.capabilities`.
+
+```typescript
+interface Capability {
+  readonly id: string;
+  readonly description: string;
+  readonly status: string;  // "Available", "DisabledByPolicy", "NotCompiled", etc.
+}
+```
+
+Status values may be emitted as externally-tagged Rust enum objects (e.g. `{ DisabledByPolicy: { ... } }`). The SDK normalizes these to the key string automatically.
+
+### SchemaWarning
+
+Emitted when a structured output response did not fully conform to the requested schema.
+
+```typescript
+interface SchemaWarning {
+  readonly provider: string;
+  readonly path: string;
+  readonly message: string;
+}
+```
+
+---
+
+## Skill types
+
+### SkillKey
+
+Structured skill identifier. Preferred over legacy string references.
+
+```typescript
+interface SkillKey {
+  readonly sourceUuid: string;
+  readonly skillName: string;
+}
+```
+
+### SkillRef
+
+A skill reference is either a `SkillKey` or a legacy string in the form `"<source_uuid>/<skill_name>"`. Legacy strings emit a deprecation warning.
+
+```typescript
+type SkillRef = SkillKey | string;
+```
+
+### SkillRuntimeDiagnostics
+
+Runtime diagnostics from the skill subsystem. Present on `RunResult.skillDiagnostics` when the server emits skill health data.
+
 ```typescript
 interface SkillRuntimeDiagnostics {
-  sourceHealth: {
-    state: string;
-    invalidRatio: number;
-    invalidCount: number;
-    totalCount: number;
-    failureStreak: number;
-    handshakeFailed: boolean;
-  };
-  quarantined: Array<{
-    sourceUuid: string;
-    skillId: string;
-    location: string;
-    errorCode: string;
-    errorClass: string;
-    message: string;
-    firstSeenUnixSecs: number;
-    lastSeenUnixSecs: number;
-  }>;
+  readonly sourceHealth: SourceHealthSnapshot;
+  readonly quarantined: readonly SkillQuarantineDiagnostic[];
+}
+
+interface SourceHealthSnapshot {
+  readonly state: string;
+  readonly invalidRatio: number;
+  readonly invalidCount: number;
+  readonly totalCount: number;
+  readonly failureStreak: number;
+  readonly handshakeFailed: boolean;
+}
+
+interface SkillQuarantineDiagnostic {
+  readonly sourceUuid: string;
+  readonly skillId: string;
+  readonly location: string;
+  readonly errorCode: string;
+  readonly errorClass: string;
+  readonly message: string;
+  readonly firstSeenUnixSecs: number;
+  readonly lastSeenUnixSecs: number;
 }
 ```
-</Accordion>
-
-<Note>
-`RunResult.skillDiagnostics` is `SkillRuntimeDiagnostics | undefined` on the TypeScript domain type.
-</Note>
 
 ---
 
-## CapabilityChecker
+## EventStream
 
-Standalone helper for checking runtime capabilities:
+`EventStream` is an `AsyncIterable<AgentEvent>` returned by `createSessionStreaming()` and `session.stream()`. It yields typed events as the agent runs, then makes the final `RunResult` available on `stream.result`.
 
 ```typescript
-import { MeerkatClient, CapabilityChecker } from "@meerkat/sdk";
+class EventStream implements AsyncIterable<AgentEvent> {
+  readonly sessionId: string;
+  readonly result: RunResult;  // throws if accessed before iteration completes
 
-const caps = await client.getCapabilities();
-const checker = new CapabilityChecker(caps);
+  [Symbol.asyncIterator](): AsyncGenerator<AgentEvent>;
 
-if (checker.has("comms")) {
-  console.log("Comms is available");
+  /** Consume all events and return the final RunResult. */
+  collect(): Promise<RunResult>;
+
+  /** Consume events, accumulate text deltas, return [fullText, result]. */
+  collectText(): Promise<[string, RunResult]>;
 }
-
-checker.require("skills");  // throws CapabilityUnavailableError if unavailable
-
-console.log(checker.available);  // ["sessions", "streaming", ...]
 ```
 
-| Method | Description |
-|--------|-------------|
-| `has(capabilityId)` | Returns `true` if status is `"Available"` |
-| `require(capabilityId)` | Throws if capability not available |
-| `available` | Getter returning all available capability IDs |
+### Iterating
 
-<Accordion title="Known capability IDs">
-| ID | Description |
-|---|-------------|
-| `sessions` | Session lifecycle |
-| `streaming` | Real-time event streaming |
-| `structured_output` | JSON schema structured output |
-| `hooks` | Lifecycle hooks |
-| `builtins` | Built-in tools |
-| `shell` | Shell tool |
-| `comms` | Inter-agent communication |
-| `sub_agents` | Sub-agent tools |
-| `memory_store` | Semantic memory |
-| `session_store` | Session persistence |
-| `session_compaction` | Context compaction |
-| `skills` | Skill loading |
-</Accordion>
+```typescript
+for await (const event of session.stream("Summarise this")) {
+  if (event.type === "text_delta") {
+    process.stdout.write(event.delta);
+  }
+}
+const result = stream.result;
+```
+
+### collect()
+
+Discards all events and returns the final result:
+
+```typescript
+const result = await stream.collect();
+```
+
+### collectText()
+
+Accumulates all `text_delta` events and returns the joined string alongside the result:
+
+```typescript
+const [fullText, result] = await stream.collectText();
+console.log(fullText);
+console.log("Output tokens:", result.usage.outputTokens);
+```
 
 ---
 
-## SkillHelper
+## Typed events
 
-Convenience wrapper for invoking Meerkat skills:
+All events are discriminated on the `type` field (snake_case, matching the wire protocol). All other fields are camelCase.
+
+### AgentEvent union
 
 ```typescript
-import { MeerkatClient, SkillHelper } from "@meerkat/sdk";
-
-const helper = new SkillHelper(client);
-
-if (helper.isAvailable()) {
-  const result = await helper.invoke(sessionId, "/shell-patterns", "How do I run a background job?");
-  console.log(result.text);
-}
-
-const result = await helper.invokeNewSession(
-  "/code-review",
-  "Review this function",
-  "claude-opus-4-6",
-);
+type AgentEvent =
+  | RunStartedEvent
+  | RunCompletedEvent
+  | RunFailedEvent
+  | TurnStartedEvent
+  | TextDeltaEvent
+  | TextCompleteEvent
+  | ToolCallRequestedEvent
+  | ToolResultReceivedEvent
+  | TurnCompletedEvent
+  | ToolExecutionStartedEvent
+  | ToolExecutionCompletedEvent
+  | ToolExecutionTimedOutEvent
+  | CompactionStartedEvent
+  | CompactionCompletedEvent
+  | CompactionFailedEvent
+  | BudgetWarningEvent
+  | RetryingEvent
+  | HookStartedEvent
+  | HookCompletedEvent
+  | HookFailedEvent
+  | HookDeniedEvent
+  | HookRewriteAppliedEvent
+  | HookPatchPublishedEvent
+  | SkillsResolvedEvent
+  | SkillResolutionFailedEvent
+  | InteractionCompleteEvent
+  | InteractionFailedEvent
+  | StreamTruncatedEvent
+  | UnknownEvent;
 ```
 
-| Method | Description |
-|--------|-------------|
-| `isAvailable()` | Returns `true` if `"skills"` capability is available |
-| `requireSkills()` | Throws if skills not available |
-| `invoke(sessionId, skillRef, prompt)` | Invoke skill in existing session |
-| `invokeNewSession(skillRef, prompt, model?)` | Create session and invoke skill |
+Unknown event types are surfaced as `UnknownEvent` for forward-compatibility.
 
----
-
-## Skills parameters
-
-Both `createSession()` and `startTurn()` accept skill-related parameters:
+### Session lifecycle events
 
 ```typescript
-// Preload skills into the system prompt at session creation
-const result = await client.createSession({
-  prompt: "Hello!",
-  preload_skills: ["extraction/email", "formatting/markdown"],
-});
+interface RunStartedEvent   { type: "run_started";   sessionId: string; prompt: string }
+interface RunCompletedEvent { type: "run_completed";  sessionId: string; result: string; usage: Usage }
+interface RunFailedEvent    { type: "run_failed";     sessionId: string; error: string }
+```
 
-// Inject skills for a specific turn
-const result = await client.startTurn(sessionId, "Extract emails", {
-  skill_references: ["extraction/email"],
-});
+### Turn and LLM events
+
+```typescript
+interface TurnStartedEvent        { type: "turn_started";         turnNumber: number }
+interface TextDeltaEvent          { type: "text_delta";            delta: string }
+interface TextCompleteEvent       { type: "text_complete";         content: string }
+interface ToolCallRequestedEvent  { type: "tool_call_requested";   id: string; name: string; args: unknown }
+interface ToolResultReceivedEvent { type: "tool_result_received";  id: string; name: string; isError: boolean }
+interface TurnCompletedEvent      { type: "turn_completed";        stopReason: StopReason; usage: Usage }
+```
+
+```typescript
+type StopReason =
+  | "end_turn"
+  | "tool_use"
+  | "max_tokens"
+  | "stop_sequence"
+  | "content_filter"
+  | "cancelled";
+```
+
+### Tool execution events
+
+```typescript
+interface ToolExecutionStartedEvent   { type: "tool_execution_started";    id: string; name: string }
+interface ToolExecutionCompletedEvent { type: "tool_execution_completed";   id: string; name: string; result: string; isError: boolean; durationMs: number }
+interface ToolExecutionTimedOutEvent  { type: "tool_execution_timed_out";   id: string; name: string; timeoutMs: number }
+```
+
+### Compaction events
+
+```typescript
+interface CompactionStartedEvent   { type: "compaction_started";   inputTokens: number; estimatedHistoryTokens: number; messageCount: number }
+interface CompactionCompletedEvent { type: "compaction_completed";  summaryTokens: number; messagesBefore: number; messagesAfter: number }
+interface CompactionFailedEvent    { type: "compaction_failed";     error: string }
+```
+
+### Budget events
+
+```typescript
+interface BudgetWarningEvent { type: "budget_warning"; budgetType: BudgetType; used: number; limit: number; percent: number }
+
+type BudgetType = "tokens" | "time" | "tool_calls";
+```
+
+### Retry events
+
+```typescript
+interface RetryingEvent { type: "retrying"; attempt: number; maxAttempts: number; error: string; delayMs: number }
+```
+
+### Hook events
+
+```typescript
+type HookPoint =
+  | "run_started" | "run_completed" | "run_failed"
+  | "pre_llm_request" | "post_llm_response"
+  | "pre_tool_execution" | "post_tool_execution"
+  | "turn_boundary";
+
+interface HookStartedEvent        { type: "hook_started";         hookId: string; point: HookPoint }
+interface HookCompletedEvent      { type: "hook_completed";        hookId: string; point: HookPoint; durationMs: number }
+interface HookFailedEvent         { type: "hook_failed";           hookId: string; point: HookPoint; error: string }
+interface HookDeniedEvent         { type: "hook_denied";           hookId: string; point: HookPoint; reasonCode: string; message: string; payload?: unknown }
+interface HookRewriteAppliedEvent { type: "hook_rewrite_applied";  hookId: string; point: HookPoint; patch: Record<string, unknown> }
+interface HookPatchPublishedEvent { type: "hook_patch_published";  hookId: string; point: HookPoint; envelope: Record<string, unknown> }
+```
+
+### Skill events
+
+```typescript
+interface SkillsResolvedEvent       { type: "skills_resolved";         skills: readonly string[]; injectionBytes: number }
+interface SkillResolutionFailedEvent { type: "skill_resolution_failed"; reference: string; error: string }
+```
+
+### Comms events
+
+```typescript
+interface InteractionCompleteEvent { type: "interaction_complete"; interactionId: string; result: string }
+interface InteractionFailedEvent   { type: "interaction_failed";   interactionId: string; error: string }
+```
+
+### Stream management
+
+```typescript
+interface StreamTruncatedEvent { type: "stream_truncated"; reason: string }
+```
+
+### Type guard utilities
+
+The SDK exports type guards for the most commonly used events:
+
+```typescript
+import {
+  isTextDelta,
+  isTextComplete,
+  isTurnCompleted,
+  isToolCallRequested,
+  isRunCompleted,
+  isRunFailed,
+} from "@rkat/sdk";
+
+for await (const event of session.stream("prompt")) {
+  if (isTextDelta(event)) {
+    process.stdout.write(event.delta);  // TypeScript knows event.delta exists
+  }
+  if (isTurnCompleted(event)) {
+    console.log(event.stopReason, event.usage.inputTokens);
+  }
+}
 ```
 
 ---
 
 ## Error handling
 
-All errors extend `MeerkatError`:
+All errors extend `MeerkatError`. Catch it as a base class or use the specific subclasses for targeted handling.
 
 ```typescript
-import { MeerkatError, CapabilityUnavailableError } from "@meerkat/sdk";
+import { MeerkatError, CapabilityUnavailableError } from "@rkat/sdk";
 
 try {
   await client.connect();
-  const result = await client.createSession({ prompt: "Hello" });
+  const session = await client.createSession("Hello");
+  await session.turn("Next");
 } catch (err) {
   if (err instanceof CapabilityUnavailableError) {
-    console.error("Missing capability:", err.message);
+    console.error("Missing capability:", err.message, err.capabilityHint);
   } else if (err instanceof MeerkatError) {
-    console.error(`[${err.code}]: ${err.message}`);
+    console.error(`[${err.code}] ${err.message}`);
   }
 } finally {
   await client.close();
 }
 ```
 
-| Class | Description |
+### Error classes
+
+```typescript
+class MeerkatError extends Error {
+  readonly code: string;
+  readonly details?: unknown;
+  readonly capabilityHint?: { capability_id: string; message: string };
+}
+
+class CapabilityUnavailableError extends MeerkatError {}
+class SessionNotFoundError extends MeerkatError {}
+class SkillNotFoundError extends MeerkatError {}
+```
+
+| Class | When thrown |
 |-------|-------------|
-| `MeerkatError` | Base error with `code`, `details`, `capabilityHint` |
-| `CapabilityUnavailableError` | Required capability not available |
-| `SessionNotFoundError` | Session ID does not exist |
-| `SkillNotFoundError` | Skill reference cannot be found |
+| `MeerkatError` | Base class for all SDK errors |
+| `CapabilityUnavailableError` | `client.requireCapability()` or `session.invokeSkill()` when the required capability is not available |
+| `SessionNotFoundError` | Server reports that the requested session does not exist |
+| `SkillNotFoundError` | Server reports that a skill reference cannot be resolved |
+
+### Common error codes
+
+| Code | Cause |
+|------|-------|
+| `NOT_CONNECTED` | Method called before `connect()` |
+| `VERSION_MISMATCH` | Server contract version incompatible with SDK |
+| `CAPABILITY_UNAVAILABLE` | Required capability not enabled in this build |
+| `CLIENT_CLOSED` | Method called after `close()` |
+| `STREAM_NOT_CONSUMED` | `stream.result` accessed before iteration completed |
+| `BINARY_NOT_FOUND` | `rkat-rpc` not found and auto-download failed |
+
+---
+
+## Skills
+
+Both `createSession()` and `session.turn()` accept skill parameters. Use `SkillKey` objects (preferred) or legacy strings.
+
+```typescript
+// Preload skills into the system prompt at session creation
+const session = await client.createSession("Hello!", {
+  preloadSkills: ["extraction/email", "formatting/markdown"],
+});
+
+// Inject a skill for a specific turn via session.turn()
+const result = await session.turn("Extract emails from this text", {
+  skillRefs: [{ sourceUuid: "abc123", skillName: "extraction-email" }],
+});
+
+// Convenience method on Session — wraps turn() with requireCapability check
+const result2 = await session.invokeSkill(
+  { sourceUuid: "abc123", skillName: "extraction-email" },
+  "Extract emails from this text",
+);
+```
 
 ---
 
 ## Version compatibility
 
 ```typescript
-import { CONTRACT_VERSION } from "@meerkat/sdk";
-console.log(CONTRACT_VERSION);  // "0.2.0"
+import { CONTRACT_VERSION } from "@rkat/sdk";
+console.log(CONTRACT_VERSION);  // e.g. "0.3.4"
 ```
 
-- While major version is `0`, minor versions must match exactly
-- Once `1.0.0` is reached, major versions must match (standard semver)
+- While the major version is `0`, minor versions must match exactly between SDK and server.
+- From `1.0.0` onwards, standard semver applies: major versions must match.
+
+Version checking happens automatically during `connect()`. A `MeerkatError` with code `VERSION_MISMATCH` is thrown if versions are incompatible.
 
 ---
 
 ## See also
 
-- [TypeScript SDK overview](/sdks/typescript/overview) - getting started and MeerkatClient API
+- [TypeScript SDK overview](/sdks/typescript/overview) - getting started, client and session API
 - [Python SDK](/sdks/python/overview) - Python SDK
 - [RPC reference](/api/rpc) - JSON-RPC protocol specification


### PR DESCRIPTION
## Summary

Comprehensive documentation accuracy audit before v0.4 release. 5 parallel audit agents identified 45 issues; 5 parallel fix agents resolved all of them across 20 files (+1672/-578 lines).

### SDK docs (complete rewrite)
- Python and TypeScript overview + reference docs rewritten for post-uplift Session-based API
- Removed non-existent types (WireRunResult, WireUsage, CapabilityChecker, SkillHelper)
- Fixed TS package name `@meerkat/sdk` -> `@rkat/sdk`
- Fixed `createSession` signature from object to positional string

### Entry points
- Replaced non-existent `meerkat::with_anthropic()` with actual `AgentBuilder` pattern
- Fixed `BudgetLimits` API in README
- Fixed model name, crate versions, SDK binary requirement

### API surfaces
- REST `comms/send` request body replaced with actual `CommsSendRequest` shape
- RPC `comms/stream_*` methods: fixed params, responses, notification format
- Fixed `session/archive` and `turn/interrupt` response bodies

### Reference docs
- Architecture: fixed crate count (18), reversed dep arrow, added mob crates, removed phantom event
- API reference: fixed `ContractVersion`, added `BlockAssistant`, removed `with_anthropic`

### Guides
- Comms: fixed tool count (2 not 4), fixed `peer_availability` description
- Skills: fixed injection/inventory format to match actual renderer output
- CD: fixed binary names `meerkat-*` -> `rkat-*`

## Test plan
- [ ] Verify all code examples compile/run against current SDK
- [ ] Spot-check mdx rendering in docs site

🤖 Generated with [Claude Code](https://claude.com/claude-code)