### PR TITLE
fix(mob): enable skills feature and remove duplicated comms text

### DIFF
--- a/meerkat-mob/Cargo.toml
+++ b/meerkat-mob/Cargo.toml
@@ -17,7 +17,7 @@ categories.workspace = true
 meerkat-core = { workspace = true }
 meerkat-comms = { workspace = true }
 meerkat-skills = { workspace = true }
-meerkat = { workspace = true, features = ["comms", "session-compaction", "memory-store", "anthropic", "openai", "gemini"] }
+meerkat = { workspace = true, features = ["comms", "skills", "session-compaction", "memory-store", "anthropic", "openai", "gemini"] }
 meerkat-session = { workspace = true, features = ["session-compaction", "session-store"] }
 meerkat-client = { workspace = true }
 


### PR DESCRIPTION
## Summary

Follow-up to PR #51. The previous commit relied on `preload_skills` for mob comms instructions but `meerkat-mob` did not enable the `skills` feature on its `meerkat` dependency, so the skill engine was never wired and agents silently lost comms instructions.

### Changes
- Enable `skills` feature on `meerkat` dep in `meerkat-mob/Cargo.toml`
- Remove `MOB_COMMS_INSTRUCTIONS` constant — single source of truth is `skills/mob-communication/SKILL.md`
- Remove system_prompt fallback path — `skills` feature is now guaranteed available

### Design
- **Single source of truth**: `SKILL.md` is the only place comms instructions are defined
- **Feature guarantee**: `Cargo.toml` enforces `skills` is always enabled for mob builds
- **Override resilience**: Skills are appended via `extra_sections` in prompt assembly, surviving any per-request `system_prompt` override

## Test plan
- [x] All 22 mob build tests pass
- [x] `test_build_agent_config_preloads_mob_communication_skill` verifies preload
- [x] Full pre-push hooks pass (tests, clippy, docs, audit)

🤖 Generated with [Claude Code](https://claude.com/claude-code)