### PR TITLE
feat(mob): per-member lifecycle state for best-effort retire

### DIFF
--- a/meerkat-core/src/service/mod.rs
+++ b/meerkat-core/src/service/mod.rs
@@ -98,6 +98,7 @@ pub struct CreateSessionRequest {
 }
 
 /// Optional build-time options used by factory-backed session builders.
+#[derive(Clone)]
 pub struct SessionBuildOptions {
     pub provider: Option<Provider>,
     pub output_schema: Option<OutputSchema>,

--- a/meerkat-mob-mcp/src/lib.rs
+++ b/meerkat-mob-mcp/src/lib.rs
@@ -199,7 +199,7 @@ impl MobMcpState {
     ) -> Result<Vec<meerkat_mob::RosterEntry>, MobError> {
         self.handle_for(mob_id)
             .await?
-            .list_meerkats()
+            .list_all_meerkats()
             .await
             .pipe(Ok)
     }

--- a/meerkat-mob/src/lib.rs
+++ b/meerkat-mob/src/lib.rs
@@ -58,7 +58,7 @@ pub use event::{
 pub use ids::{BranchId, FlowId, MeerkatId, MobId, ProfileName, RunId, StepId, TaskId};
 pub use prefab::Prefab;
 pub use profile::{Profile, ToolConfig};
-pub use roster::{Roster, RosterEntry};
+pub use roster::{MemberState, Roster, RosterEntry};
 pub use run::{
     FailureLedgerEntry, FlowContext, FlowRunConfig, MobRun, MobRunStatus, StepLedgerEntry,
     StepRunStatus,

--- a/meerkat-mob/src/runtime/state.rs
+++ b/meerkat-mob/src/runtime/state.rs
@@ -72,6 +72,9 @@ pub(super) enum MobCommand {
         meerkat_id: MeerkatId,
         reply_tx: oneshot::Sender<Result<(), MobError>>,
     },
+    RetireAll {
+        reply_tx: oneshot::Sender<Result<(), MobError>>,
+    },
     Wire {
         a: MeerkatId,
         b: MeerkatId,


### PR DESCRIPTION
## Summary

- **Problem**: `MobHandle::retire()` failed atomically when unwiring from already-retired peers or when session archive hit quota limits, leaving members stuck in the roster and blocking re-spawn. The mob-level state guard required `Running` for retire but `stop()` transitions to `Stopped`, creating a deadlock for "reset all" flows.

- **Solution**: Add `MemberState { Active, Retiring }` to `RosterEntry` and replace the transactional-with-rollback retire with mark-then-best-effort-cleanup. Roster removal is now unconditional — cleanup failures are logged as warnings but never block convergence.

- **Key changes**:
  - `Roster::list()`, `len()`, `is_empty()`, `by_profile()` filter Active only; `get()` returns any state
  - New `mark_retiring()`, `list_all()`, `list_retiring()` methods
  - `handle_retire()` rewritten: event-first → mark Retiring → best-effort cleanup → unconditional remove
  - Retire allowed in `Stopped` state (host loops already down)
  - `complete()`/`destroy()` use `list_all()` and log individual retire failures
  - `list_all_meerkats()` added to `MobHandle`; `MemberState` exported

## Test plan

- [x] `cargo test -p meerkat-mob --lib` — 334 tests pass (9 new roster tests + updated retire tests)
- [x] `cargo test -p meerkat-mob-mcp --lib` — 11 tests pass
- [x] `cargo test --workspace --lib --bins --tests` — full green
- [x] `cargo clippy -p meerkat-mob -p meerkat-mob-mcp --no-deps -- -D warnings` — no warnings
- [x] Pre-push hooks pass (gitleaks, tests, clippy, doc, audit)

🤖 Generated with [Claude Code](https://claude.com/claude-code)