### PR TITLE
Add stdin pipe support for CLI context injection

### DIFF
--- a/.claude/skills/meerkat-platform/SKILL.md
+++ b/.claude/skills/meerkat-platform/SKILL.md
@@ -119,6 +119,13 @@ Do not conflate the two: mob tool availability is a surface behavior, backend is
 rkat run "What is Rust?"
 rkat --realm team-alpha run "Create a todo app" --enable-builtins --enable-shell --stream -v
 rkat --realm team-alpha resume sid_abc123 "Now add error handling"
+# Batch context: pipe finite content as context
+cat document.txt | rkat run "Summarize this document"
+git diff | rkat run "Review these changes" --enable-builtins
+# Chained pipes: each rkat reads stdin, writes response to stdout
+cat data.csv | rkat run "Extract entities" | rkat run "Write a story about them"
+# Live streaming: --host --stdin reads stdin line-by-line as events
+tail -f app.log | rkat run --host --stdin "Monitor and alert on anomalies"
 rkat mob prefabs
 rkat mob create --prefab coding_swarm
 rkat mob list

--- a/.claude/skills/meerkat-platform/references/api_reference.md
+++ b/.claude/skills/meerkat-platform/references/api_reference.md
@@ -40,6 +40,7 @@ Core commands:
 
 ```bash
 rkat run <PROMPT> [OPTIONS]
+cat file.txt | rkat run "Analyze this"   # stdin piped as context
 rkat resume <SESSION-ID> <PROMPT>
 rkat sessions list [--limit N]
 rkat sessions show <ID>

--- a/docs/cli/commands.mdx
+++ b/docs/cli/commands.mdx
@@ -89,6 +89,30 @@ Tooling convenience:
 
 - `--enable-shell` now implies `--enable-builtins`; you can use `-x` alone for common shell-enabled runs.
 
+Stdin has two modes depending on whether you want batch context or live streaming:
+
+**Batch context** — when stdin is not a terminal (and `--stdin` is not set), `rkat run` reads all of stdin and prepends it to the prompt as context wrapped in `<stdin>` tags. The pipe must be finite (EOF-terminated):
+
+```bash
+cat document.txt | rkat run "Summarize this"
+git diff | rkat run "Review these changes"
+curl -s https://example.com/api | rkat run "Parse the response"
+```
+
+Batch pipes can be chained — each `rkat run` reads stdin context and writes its response to stdout:
+
+```bash
+cat data.csv | rkat run "Extract all entities" | rkat run "Write a short story involving these entities"
+```
+
+**Live event streaming** — `--host --stdin` keeps the agent alive and reads stdin line-by-line as external events (newline-delimited JSON or plain text). The pipe can be infinite:
+
+```bash
+tail -f app.log | rkat run --host --stdin "Monitor incidents and alert on anomalies"
+```
+
+When `--stdin` is set, batch context injection is skipped so stdin remains available for the event reader.
+
 When `--enable-mob` (`-M`) is passed, `run` composes the consolidated mob tool surface (backed by `meerkat-mob-mcp`) into the agent tool list (`mob_create`, `mob_list`, `mob_lifecycle`, `meerkat_spawn`, `meerkat_retire`, `meerkat_wire`, `meerkat_message`, `meerkat_list`, `mob_events`, `mob_run_flow`, `mob_flow_status`, `mob_cancel_flow`).
 Mob tools are opt-in and disabled by default. When enabled, they are available even when built-ins are disabled.
 


### PR DESCRIPTION
## Summary

- When stdin is not a terminal, `rkat run` reads all of stdin and prepends it to the prompt wrapped in `<stdin>` tags
- Enables piping file content or command output as context to the agent

```bash
cat document.txt | rkat run "Summarize this"
git diff | rkat run "Review these changes"
curl -s https://api.example.com/data | rkat run "Parse this JSON"
```

## Test plan

- [x] `cargo test -p rkat` — all 87 tests pass
- [x] Pre-push hooks pass (clippy, doc, audit)
- [ ] Manual: `echo "hello" | rkat run "what did I say?"` responds about "hello"
- [ ] Manual: `rkat run "hi"` (interactive, no pipe) works unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)