### PR TITLE
Default to run subcommand when prompt is first arg

### DIFF
--- a/.claude/skills/meerkat-platform/SKILL.md
+++ b/.claude/skills/meerkat-platform/SKILL.md
@@ -116,7 +116,8 @@ Do not conflate the two: mob tool availability is a surface behavior, backend is
 ### CLI
 
 ```bash
-rkat run "What is Rust?"
+rkat "What is Rust?"                     # "run" is the default subcommand
+rkat run "What is Rust?"                 # equivalent explicit form
 rkat --realm team-alpha run "Create a todo app" --enable-builtins --enable-shell --stream -v
 rkat --realm team-alpha resume sid_abc123 "Now add error handling"
 # Batch context: pipe finite content as context

--- a/.claude/skills/meerkat-platform/references/api_reference.md
+++ b/.claude/skills/meerkat-platform/references/api_reference.md
@@ -40,6 +40,7 @@ Core commands:
 
 ```bash
 rkat run <PROMPT> [OPTIONS]
+rkat <PROMPT>                            # shorthand — "run" is implied
 cat file.txt | rkat run "Analyze this"   # stdin piped as context
 rkat resume <SESSION-ID> <PROMPT>
 rkat sessions list [--limit N]

--- a/docs/cli/commands.mdx
+++ b/docs/cli/commands.mdx
@@ -43,7 +43,10 @@ rkat-rpc --realm team-alpha
 
 ```bash
 rkat run [OPTIONS] <PROMPT>
+rkat <PROMPT>                    # shorthand — "run" is the default subcommand
 ```
+
+When the first positional argument is not a known subcommand, `run` is implied. `rkat "hello"` is equivalent to `rkat run "hello"`.
 
 Frequently used options:
 


### PR DESCRIPTION
## Summary

`rkat "hello"` is now equivalent to `rkat run "hello"`. When the first positional argument isn't a known subcommand, `run` is injected automatically.

```bash
rkat "What is Rust?"
rkat --realm team "Build a todo app" -x -s
cat file.txt | rkat "Summarize this"
```

Works with all global flags (`--realm`, `--isolated`, etc.) and stdin piping. The `--help` output includes a shorthand hint at the bottom.

## Test plan

- [x] `cargo test -p rkat` — 88 tests pass (including new `test_inject_default_run_subcommand`)
- [x] Pre-push hooks pass (clippy, doc, audit)
- [ ] Manual: `rkat "hello"` works
- [ ] Manual: `rkat run "hello"` still works
- [ ] Manual: `rkat init` / `rkat sessions list` / etc. still work

🤖 Generated with [Claude Code](https://claude.com/claude-code)