### PR TITLE
Compact session references and continue command

### DIFF
--- a/.claude/skills/meerkat-platform/SKILL.md
+++ b/.claude/skills/meerkat-platform/SKILL.md
@@ -119,6 +119,9 @@ Do not conflate the two: mob tool availability is a surface behavior, backend is
 rkat "What is Rust?"                     # "run" is the default subcommand
 rkat run "What is Rust?"                 # equivalent explicit form
 rkat --realm team-alpha run "Create a todo app" --enable-builtins --enable-shell --stream -v
+rkat resume last "keep going"             # resume most recent session
+rkat resume 019c8b99 "continue"          # resume by short prefix
+rkat continue "next step"                # shortcut for resume last
 rkat --realm team-alpha resume sid_abc123 "Now add error handling"
 # Batch context: pipe finite content as context
 cat document.txt | rkat run "Summarize this document"

--- a/.claude/skills/meerkat-platform/references/api_reference.md
+++ b/.claude/skills/meerkat-platform/references/api_reference.md
@@ -42,7 +42,8 @@ Core commands:
 rkat run <PROMPT> [OPTIONS]
 rkat <PROMPT>                            # shorthand — "run" is implied
 cat file.txt | rkat run "Analyze this"   # stdin piped as context
-rkat resume <SESSION-ID> <PROMPT>
+rkat resume <SESSION-ID> <PROMPT>         # full UUID, short prefix, last, ~N
+rkat continue <PROMPT>                   # shortcut for resume last
 rkat sessions list [--limit N]
 rkat sessions show <ID>
 rkat sessions delete <ID>

--- a/docs/cli/commands.mdx
+++ b/docs/cli/commands.mdx
@@ -139,11 +139,23 @@ Comms options:
 
 ```bash
 rkat resume <SESSION_ID> <PROMPT>
+rkat resume last "continue where we left off"   # most recent session
+rkat resume ~2 "go back to this one"             # 2nd most recent
+rkat resume 019c8b99 "keep going"                # short prefix match
 ```
 
-Resumes a session from the active realm.
+Session identifiers accept full UUIDs, short prefixes (git-style, fails on ambiguity), or relative aliases (`last`/`~`/`~N`). All scoped to the active realm.
 
 Like `run`, `resume` composes the mob tool surface when `--enable-mob` (`-M`) is passed.
+
+## continue
+
+```bash
+rkat continue <PROMPT>
+rkat c "keep going"                              # alias
+```
+
+Shortcut for `rkat resume last <PROMPT>`. Resumes the most recent session in the active realm.
 
 ## mob
 


### PR DESCRIPTION
## Summary

- **Short prefix matching**: `rkat resume 019c8b99 "continue"` — git-style prefix resolution, fails on ambiguity
- **Relative aliases**: `rkat resume last "keep going"`, `rkat resume ~2 "back to this"` — scoped to active realm
- **`continue` command**: `rkat continue "next step"` (alias: `rkat c "next"`) — shortcut for `resume last`
- **Compact output**: session line now shows 8-char ID instead of full UUID + ref

```
[Session: 019c8b99 | Turns: 1 | Tokens: 4251 in / 324 out]
```

All resolution is scoped to the active realm (CWD or `--realm`).

## Test plan

- [x] `cargo test -p rkat` — 88 tests pass
- [x] Pre-push hooks pass (clippy, doc, audit)
- [ ] Manual: `rkat resume last "continue"` resumes most recent
- [ ] Manual: `rkat resume 019c "continue"` prefix-matches
- [ ] Manual: `rkat c "keep going"` works as shortcut

🤖 Generated with [Claude Code](https://claude.com/claude-code)