### PR TITLE
Clarify AgentBuilder vs AgentFactory layering in docs

### DIFF
--- a/.claude/skills/meerkat-platform/references/api_reference.md
+++ b/.claude/skills/meerkat-platform/references/api_reference.md
@@ -278,6 +278,11 @@ Type/parsing notes:
 
 ## Rust SDK
 
+**AgentFactory vs AgentBuilder**: `AgentFactory` (facade crate) is the opinionated composition layer that
+wires all tool categories (builtins, shell, sub-agents, comms, memory, mob, skills) into the dispatcher.
+`AgentBuilder` (meerkat-core) is lower-level — it takes pre-built components and has no tool opinions.
+All surfaces go through `AgentFactory`; direct `AgentBuilder` usage means manual dispatcher composition.
+
 Recommended realm-aware factory bootstrap:
 
 ```rust
@@ -291,7 +296,8 @@ let factory = AgentFactory::new(realm.root.clone())
     .runtime_root(realm.root)
     .builtins(true)
     .shell(true)
-    .subagents(true);
+    .subagents(true)
+    .mob(true);  // opt-in mob orchestration tools
 
 let build = AgentBuildConfig::new("claude-sonnet-4-5");
 let mut agent = factory.build_agent(build, &config).await?;

--- a/docs/reference/builtin-tools.mdx
+++ b/docs/reference/builtin-tools.mdx
@@ -39,6 +39,9 @@ icon: "wrench"
 | `enable_subagents` | `.subagents(bool)` | `false` | All sub-agent tools (requires `sub-agents` feature) |
 | `enable_memory` | `.memory(bool)` | `false` | `memory_search` (requires `memory-store-session` feature) |
 | `enable_comms` | `.comms(bool)` | `false` | All comms tools (requires `comms` feature) |
+| `enable_mob` | `.mob(bool)` | `false` | Mob orchestration tools (`mob_*`, `meerkat_*`) |
+
+`AgentFactory` is the only place tool categories are composed. `AgentBuilder` (in `meerkat-core`) has no dependency on `meerkat-tools` and does not auto-register any tools — it takes a pre-built dispatcher. See [AgentBuilder vs AgentFactory](/rust/advanced#agentbuilder-vs-agentfactory).
 
 **Source:** `meerkat/src/factory.rs` -- `AgentFactory` struct and builder methods.
 </Accordion>
@@ -52,6 +55,7 @@ Each `AgentBuildConfig` can override factory-level flags for a single agent buil
 | `override_shell` | `Option<bool>` | Takes precedence over `enable_shell` when `Some` |
 | `override_subagents` | `Option<bool>` | Takes precedence over `enable_subagents` when `Some` |
 | `override_memory` | `Option<bool>` | Takes precedence over `enable_memory` when `Some` |
+| `override_mob` | `Option<bool>` | Takes precedence over `enable_mob` when `Some` |
 
 All default to `None` (use factory-level setting).
 

--- a/docs/rust/advanced.mdx
+++ b/docs/rust/advanced.mdx
@@ -6,6 +6,14 @@ icon: "gears"
 
 Advanced Rust SDK usage for fine-grained control over agent construction, provider configuration, and sub-agent management.
 
+## AgentBuilder vs AgentFactory
+
+`AgentBuilder` (in `meerkat-core`) wires the agent loop primitives — LLM client, tool dispatcher, session store. It has no dependency on `meerkat-tools` and no opinions about which tools exist. It creates a `SubAgentManager` internally for concurrency tracking, but does **not** auto-register sub-agent tools (or any other tool category).
+
+`AgentFactory` (in the `meerkat` facade) is the opinionated composition layer. It knows about all tool categories (builtins, shell, sub-agents, comms, memory, mob, skills) and wires them into the dispatcher before passing it to `AgentBuilder`. All four surfaces (CLI, REST, RPC, MCP Server) go through `AgentFactory` — none call `AgentBuilder` directly.
+
+**Use `AgentFactory`** (via `build_ephemeral_service()` or `build_agent()`) unless you need full manual control over every component. Direct `AgentBuilder` usage means you're responsible for composing the tool dispatcher yourself.
+
 ## AgentBuilder
 
 <Note>


### PR DESCRIPTION
## Summary

- Explain that `AgentBuilder` (meerkat-core) wires primitives with no tool opinions, while `AgentFactory` (facade) is the opinionated composition layer
- Clarify that `AgentBuilder` creates `SubAgentManager` internally for concurrency tracking but does NOT auto-register sub-agent tools — that's `AgentFactory`'s job
- Add `enable_mob` / `override_mob` to the factory flag and per-build override tables
- Update skill reference with the same clarification

Docs-only change, no code modifications.

🤖 Generated with [Claude Code](https://claude.com/claude-code)