### PR TITLE
chore: prepare 0.4.1 release

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -199,6 +199,29 @@ jobs:
         if: matrix.test
         run: cargo nextest run -p ${{ matrix.pkg }} --no-default-features --features session-store,mcp --no-capture
 
+  wasm-check:
+    name: WASM compilation check
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Add wasm32 target
+        run: rustup target add wasm32-unknown-unknown
+
+      - name: Cache cargo registry
+        uses: Swatinem/rust-cache@v2
+        with:
+          prefix-key: wasm32
+
+      - name: Check meerkat-web-runtime for wasm32
+        env:
+          RUSTFLAGS: '--cfg getrandom_backend="wasm_js"'
+        run: cargo check -p meerkat-web-runtime --target wasm32-unknown-unknown
+
   audit:
     name: Security audit
     runs-on: ubuntu-latest
@@ -212,7 +235,7 @@ jobs:
   gate:
     name: CI gate
     if: always()
-    needs: [fmt-lint, test, test-minimal, test-feature-matrix-lib, test-feature-matrix-surface-checks, test-surface-smoke, audit]
+    needs: [fmt-lint, test, test-minimal, test-feature-matrix-lib, test-feature-matrix-surface-checks, test-surface-smoke, wasm-check, audit]
     runs-on: ubuntu-latest
     steps:
       - name: Check results
@@ -225,6 +248,7 @@ jobs:
             test-feature-matrix-lib \
             test-feature-matrix-surface-checks \
             test-surface-smoke \
+            wasm-check \
             audit
           do
             case "$job" in
@@ -234,6 +258,7 @@ jobs:
               test-feature-matrix-lib) result="${{ needs.test-feature-matrix-lib.result }}" ;;
               test-feature-matrix-surface-checks) result="${{ needs.test-feature-matrix-surface-checks.result }}" ;;
               test-surface-smoke) result="${{ needs.test-surface-smoke.result }}" ;;
+              wasm-check) result="${{ needs.wasm-check.result }}" ;;
               audit) result="${{ needs.audit.result }}" ;;
             esac
             if [[ "$result" != "success" ]]; then

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -5,6 +5,16 @@
 default_stages: [pre-commit]
 
 repos:
+  # On commit: auto-format Rust code
+  - repo: local
+    hooks:
+      - id: cargo-fmt-fix
+        name: cargo fmt (auto-fix)
+        entry: cargo fmt --all
+        language: system
+        types: [rust]
+        pass_filenames: false
+
   # On commit: clippy + unit tests on changed crates only (~5-10s)
   - repo: local
     hooks:
@@ -57,6 +67,17 @@ repos:
       - id: cargo-clippy
         name: cargo clippy (workspace)
         entry: cargo clippy --workspace --all-targets --all-features -- -D warnings
+        language: system
+        types: [rust]
+        pass_filenames: false
+        stages: [pre-push]
+
+  # On push: workspace build check
+  - repo: local
+    hooks:
+      - id: cargo-build
+        name: cargo build (workspace)
+        entry: cargo build --workspace
         language: system
         types: [rust]
         pass_filenames: false

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,84 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+## [0.4.1] - 2026-02-28
+
+### Added
+
+#### WASM Browser Runtime
+- `meerkat-web-runtime` crate with 25+ `wasm_bindgen` exports for browser deployment.
+- 9 crates compile for `wasm32-unknown-unknown`: meerkat-store, meerkat-skills, meerkat-hooks, meerkat-comms, meerkat-tools, meerkat-session, meerkat (facade), meerkat-mob, meerkat-mob-mcp.
+- Override-first resource injection: `AgentBuildConfig` accepts `tool_dispatcher_override`, `session_store_override`, `hook_engine_override`, `skill_engine_override` — bypasses filesystem resolution on wasm32.
+- `AgentFactory::minimal()` filesystem-free factory constructor for browser environments.
+- `CompositeDispatcher::new_wasm()` tool dispatcher without shell tools.
+- `MobStorage::in_memory()` ephemeral mob storage for browser-hosted mobs.
+- `FactoryAgentBuilder` default injection propagates wasm32-compatible resources to mob-spawned sessions automatically.
+- Time compatibility layer (`meerkat_core::time_compat`) using `web-time` for `SystemTime`/`Instant` on wasm32.
+- Anthropic client auto-adds `anthropic-dangerous-direct-browser-access` header on wasm32.
+
+#### Tool Scoping and Runtime Tool Control
+- `ToolScope` contract with `ToolFilter` enum (whitelist/blacklist) for per-turn tool visibility.
+- Live MCP mutation: `mcp/add`, `mcp/remove`, `mcp/reload` RPC methods for runtime server provisioning.
+- `tool_scope` field on `SessionBuildOptions` for session-wide tool visibility defaults.
+
+#### Mob API Enhancements (Architecture Review)
+- `Roster::session_id()` convenience accessor for direct session ID retrieval.
+- `MobHandle::subscribe_agent_events()` per-member event subscription with point-in-time snapshots.
+- `AttributedEvent` type for mob-level event sourcing with member attribution.
+- Non-blocking `respawn` command (atomic retire + spawn).
+- `SpawnPolicy` trait as extension point for auto-provisioning strategy on external turns.
+- `MobEventRouter` independent async task merging per-member event streams.
+- `inject_and_subscribe()` request-reply pattern for sync-like interactions over autonomous agents.
+
+#### EventEnvelope Standardization
+- Hard-cut canonical `EventEnvelope` contract: `{timestamp_ms, source_id, seq, event_id, payload}` across all surfaces.
+- Strict `seq` ordering for replay and idempotency.
+- Client-side malformed event guards with structured logging.
+
+#### Schema Hardening
+- Recursive `additionalProperties: false` injection at all nesting levels for Anthropic schema compliance.
+- Handles arrays of objects, union types (`anyOf`), and deeply nested properties.
+- Preserves user-provided `additionalProperties` settings.
+
+#### Mobpack Archive Format
+- `meerkat-mob-pack` crate: portable multi-agent deployment bundles.
+- Pack/deploy/sign pipeline with Ed25519 signing, digest verification, and allowlist trust.
+- WASM web build target support for browser deployment of mobpacks.
+
+#### Documentation
+- 10 new feature pages: sessions, tools, structured output, hooks, skills, memory, comms, mobs, mobpack, WASM.
+- Examples gallery with 11 curated showcase applications.
+- Universal surface tabs showing CLI, RPC, REST, MCP, Python, TypeScript, and Rust implementations.
+- 20+ stale references fixed (version numbers, crate counts, CI descriptions, build matrix).
+
+#### Examples
+- Expanded to 31 polished examples (up from 27) covering all features and surfaces.
+- All examples compile and exercise real features (validated in CI).
+- WASM mini-diplomacy demo: 3-faction browser app with real mob orchestration.
+
+#### CI/CD
+- WASM compilation check job in CI workflow.
+- `cargo fmt --all` auto-fix on pre-commit hook stage.
+- `cargo build --workspace` added to pre-push hook stage.
+
+### Changed
+- CI parallelized to 8 jobs (~3.5 min): fmt-lint, test, test-minimal, test-feature-matrix-lib, test-feature-matrix-surface-checks, test-surface-smoke, audit, gate.
+- Adopted `nextest` for faster parallel test execution across all CI jobs.
+- Pedantic clippy with `-D warnings` enforced across full feature matrix.
+- Toolchain updated to 1.93.1 with provenance tracking.
+- Cross-surface parity: all 7 surfaces (CLI, RPC, REST, MCP, Python SDK, TypeScript SDK, Rust SDK) support EventEnvelope, tool scoping, live MCP controls, and mob feature-gating.
+- Facade re-exports expanded: `ConfigStore`, `ConfigError`, `SessionServiceCommsExt`.
+- CODEOWNERS file added for maintenance coverage.
+
+### Fixed
+- WASM32 runtime panics: `SystemTime`/`Instant` replaced with `web-time` shims, CORS headers for Anthropic, JSON schema validation restored.
+- Mob spawn pipeline on WASM: `FactoryAgentBuilder` default injection ensures mob-spawned sessions inherit wasm32-compatible resources.
+- Inproc comms enabled on wasm32 with override-first pattern.
+- All 31 examples compile without warnings (non-exhaustive match, unused_mut, vec![] → array literals).
+- Import ordering fixed for `cargo fmt` compliance across workspace.
+
+## [0.4.0] - 2026-02-23
+
 ### Added
 
 #### Mobs (Multi-Agent Orchestration)
@@ -293,7 +371,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 Initial development release.
 
-[Unreleased]: https://github.com/lukacf/meerkat/compare/v0.3.3...HEAD
+[Unreleased]: https://github.com/lukacf/meerkat/compare/v0.4.1...HEAD
+[0.4.1]: https://github.com/lukacf/meerkat/compare/v0.4.0...v0.4.1
+[0.4.0]: https://github.com/lukacf/meerkat/compare/v0.3.0...v0.4.0
 [0.3.0]: https://github.com/lukacf/meerkat/compare/v0.2.0...v0.3.0
 [0.2.0]: https://github.com/lukacf/meerkat/compare/v0.1.0...v0.2.0
 [0.1.0]: https://github.com/lukacf/meerkat/releases/tag/v0.1.0

--- a/meerkat-mob/src/runtime/event_router.rs
+++ b/meerkat-mob/src/runtime/event_router.rs
@@ -129,6 +129,7 @@ async fn run_event_router(
     }
 
     let mut poll_interval = tokio::time::interval(config.poll_interval);
+    #[cfg(not(target_arch = "wasm32"))]
     poll_interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
 
     loop {

--- a/meerkat/src/factory.rs
+++ b/meerkat/src/factory.rs
@@ -1214,11 +1214,11 @@ impl AgentFactory {
         // 5. Resolve max_tokens
         let max_tokens = build_config.max_tokens.unwrap_or(config.max_tokens);
         let _realm_scope_root = self.realm_scope_root(&build_config);
-        let conventions_context_root = self
+        let _conventions_context_root = self
             .context_root
             .as_deref()
             .or(self.project_root.as_deref());
-        let conventions_user_root = self.user_config_root.as_deref();
+        let _conventions_user_root = self.user_config_root.as_deref();
 
         // 6a. Build skill engine (override > factory > config > filesystem).
         #[cfg(feature = "skills")]
@@ -1236,8 +1236,8 @@ impl AgentFactory {
                         {
                             match meerkat_skills::resolve_repositories_with_roots(
                                 &config.skills,
-                                conventions_context_root,
-                                conventions_user_root,
+                                _conventions_context_root,
+                                _conventions_user_root,
                                 Some(_realm_scope_root.as_path()),
                             )
                             .await
@@ -1421,8 +1421,8 @@ impl AgentFactory {
             #[cfg(not(target_arch = "wasm32"))]
             {
                 let layered_hooks = resolve_layered_hooks_config(
-                    conventions_context_root,
-                    conventions_user_root,
+                    _conventions_context_root,
+                    _conventions_user_root,
                     config,
                 )
                 .await;
@@ -1518,7 +1518,7 @@ impl AgentFactory {
         let system_prompt = crate::assemble_system_prompt(
             config,
             per_request_prompt.as_deref(),
-            conventions_context_root,
+            _conventions_context_root,
             &extra_sections,
             &tool_usage_instructions,
         )


### PR DESCRIPTION
## Summary
- Comprehensive CHANGELOG for 0.4.1 (55 commits: WASM runtime, tool scoping, mob API, EventEnvelope, schema hardening, CI parallelization, cross-surface parity, docs overhaul)
- Retroactive [0.4.0] section added to CHANGELOG
- WASM compilation check (`cargo check --target wasm32-unknown-unknown`) added to CI workflow as new `wasm-check` job
- Pre-commit hook: `cargo fmt --all` auto-fix on commit stage
- Pre-push hook: `cargo build --workspace` added
- Fix: cfg-gate `MissedTickBehavior` in mob event router for wasm32 compatibility
- Fix: suppress wasm32 unused-variable warnings in facade factory

## Test plan
- [x] `cargo nextest run --workspace --lib` — 1942 tests pass
- [x] `cargo check -p meerkat-web-runtime --target wasm32-unknown-unknown` — compiles clean
- [x] `cargo fmt --all -- --check` — clean
- [x] Pre-commit hooks pass (cargo fmt auto-fix + changed-crate tests)
- [x] Pre-push hooks pass (gitleaks, clippy, build, unit tests)
- [ ] CI gate passes (new WASM check job included)

After merge: `cargo release patch` from main to cut v0.4.1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)