### PR TITLE
docs(guides): rewrite mobs guide — concepts-first

### DIFF
--- a/docs/guides/mobs.mdx
+++ b/docs/guides/mobs.mdx
@@ -142,9 +142,9 @@ A mob definition is a JSON or TOML document that declares everything: profiles, 
 }
 ```
 
-### Prefabs
+### Prefabs and mobpacks
 
-Meerkat ships with built-in prefab definitions for common patterns:
+**Prefabs** are built-in definition templates for common patterns:
 
 | Prefab | Pattern | Profiles |
 |--------|---------|----------|
@@ -153,7 +153,9 @@ Meerkat ships with built-in prefab definitions for common patterns:
 | `pipeline` | Sequential stage handoffs | stages |
 | `review_board` | Multi-reviewer consensus | author, reviewer |
 
-Prefabs are starting points — create from a prefab, then customize the definition.
+Prefabs are starting points — create from a prefab, then customize.
+
+**Mobpacks** are portable archives (`.mobpack`) that bundle a mob definition with its skills, config, and optional Ed25519 signatures into a single deployable artifact. Mobpacks can be deployed to any surface or compiled into a browser-runnable WASM bundle. See the [Mobpack guide](/guides/mobpack) for packaging, signing, trust policies, and web deployment.
 
 ---
 


### PR DESCRIPTION
## Summary

Rewrite the mobs guide from scratch. The previous version was implementation-oriented, CLI-heavy, and buried concepts halfway down.

New structure:
1. Core concepts (profiles, wiring, runtime modes, flows) with field reference tables
2. Full mob definition format with realistic example
3. Prefabs + mobpacks (related distribution concepts, with link to dedicated guide)
4. Lifecycle phases and spawn semantics
5. Mob tools reference (all 12 tools)
6. Direct control plane (RPC, REST, Python, TypeScript, Rust — no CLI-first examples)
7. Topology rules
8. When to use mobs vs plain sessions

Key changes:
- No CLI-first examples — guide focuses on concepts and programmatic APIs
- Flows presented as optional, not the only coordination pattern
- Autonomous self-organization via wiring + skills highlighted as often preferable
- Mobpacks mentioned alongside prefabs with link to dedicated guide

🤖 Generated with [Claude Code](https://claude.com/claude-code)