### PR TITLE
Fix CI by relocating mob examples to meerkat-mob

### DIFF
--- a/meerkat-mob/Cargo.toml
+++ b/meerkat-mob/Cargo.toml
@@ -66,5 +66,17 @@ meerkat-store = { workspace = true }
 [package.metadata.cargo-machete]
 ignored = ["async-stream"]  # proc macro (stream!)
 
+[[example]]
+name = "017-mob-coding-swarm"
+path = "../examples/017-mob-coding-swarm-rs/main.rs"
+
+[[example]]
+name = "018-mob-research-team"
+path = "../examples/018-mob-research-team-rs/main.rs"
+
+[[example]]
+name = "019-mob-pipeline"
+path = "../examples/019-mob-pipeline-rs/main.rs"
+
 [lints]
 workspace = true

--- a/meerkat/Cargo.toml
+++ b/meerkat/Cargo.toml
@@ -157,21 +157,6 @@ path = "../examples/016-sub-agent-orchestration-rs/main.rs"
 required-features = ["jsonl-store"]
 
 [[example]]
-name = "017-mob-coding-swarm"
-path = "../examples/017-mob-coding-swarm-rs/main.rs"
-required-features = ["comms"]
-
-[[example]]
-name = "018-mob-research-team"
-path = "../examples/018-mob-research-team-rs/main.rs"
-required-features = ["comms"]
-
-[[example]]
-name = "019-mob-pipeline"
-path = "../examples/019-mob-pipeline-rs/main.rs"
-required-features = ["comms"]
-
-[[example]]
 name = "020-comms-peer-messaging"
 path = "../examples/020-comms-peer-messaging-rs/main.rs"
 required-features = ["jsonl-store", "comms"]


### PR DESCRIPTION
## Summary
- remove mob example targets (017-019) from the `meerkat` facade crate
- register those same example binaries under `meerkat-mob` instead
- keep `meerkat` free of a `meerkat-mob` dependency edge

## Why
PR #93 was merged with bypass while CI was red. The red jobs (`Format, lint, and static checks`, `Feature matrix (library)`, `Test suite (all features)`) all failed because `meerkat` example targets 017/018/019 imported `meerkat_mob` after that dev-dependency was removed.

This change fixes that by placing mob examples on the crate that owns mob orchestration.

## Local verification
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- `make test-feature-matrix-lib`
- `cargo nextest run --workspace --all-features`

All passed locally.
