### PR TITLE
Fix API surface docs: stale versions, missing tools and endpoints

### DIFF
--- a/docs/api/mcp.mdx
+++ b/docs/api/mcp.mdx
@@ -32,14 +32,35 @@ The `meerkat-mcp-server` crate exposes Meerkat as MCP tools that other clients c
 |------|-------------|
 | `meerkat_run` | Start a new agent session |
 | `meerkat_resume` | Continue a session or provide tool results |
+| `meerkat_read` | Read a session's state |
+| `meerkat_sessions` | List sessions in the active realm |
+| `meerkat_interrupt` | Interrupt an in-flight turn |
+| `meerkat_archive` | Archive (remove) a session |
 | `meerkat_config` | Get or update server config |
 | `meerkat_capabilities` | Query runtime capabilities |
 | `meerkat_skills` | List or inspect available skills |
+| `meerkat_mcp_add` | Stage a live MCP server addition on an active session |
+| `meerkat_mcp_remove` | Stage a live MCP server removal on an active session |
+| `meerkat_mcp_reload` | Stage a live MCP server reload on an active session |
+| `meerkat_event_stream_open` | Open a session-level agent event stream |
+| `meerkat_event_stream_read` | Read the next item from an open event stream |
+| `meerkat_event_stream_close` | Close a previously opened event stream |
+| `meerkat_mob_prefabs` | List built-in mob prefab templates (mob feature) |
+| `meerkat_mob_event_stream_open` | Open a mob-level event stream (mob feature) |
+| `meerkat_mob_event_stream_read` | Read the next event from an open mob stream (mob feature) |
+| `meerkat_mob_event_stream_close` | Close a previously opened mob event stream (mob feature) |
+| `meerkat_comms_send` | Send a canonical comms command to a session (comms feature) |
+| `meerkat_comms_peers` | List peers visible to a session (comms feature) |
+| `meerkat_comms_stream_open` | Open a comms event stream (comms feature) |
+| `meerkat_comms_stream_read` | Read the next event from a comms stream (comms feature) |
+| `meerkat_comms_stream_close` | Close a previously opened comms stream (comms feature) |
 
 <Note>
-Mob capability for MCP session tools is provided by composing
-`meerkat-mob-mcp` (`MobMcpState` + `MobMcpDispatcher`) into the session build
-path (`SessionBuildOptions.external_tools`) used by `meerkat_run`/`meerkat_resume`.
+When the `mob` feature is enabled, `meerkat-mob-mcp` mob lifecycle tools (e.g.
+`mob_create`, `mob_list`, `mob_lifecycle`) are also exposed alongside the
+`meerkat_*` tools listed above. Additionally, mob capability within sessions is
+provided by composing `MobMcpDispatcher` into `SessionBuildOptions.external_tools`
+used by `meerkat_run`/`meerkat_resume`.
 </Note>
 
 ## Use MCP servers as tools (client)
@@ -526,7 +547,7 @@ Returns the runtime capability set with status resolved against config.
 
 ```json Response
 {
-  "contract_version": {"major": 0, "minor": 2, "patch": 0},
+  "contract_version": {"major": 0, "minor": 4, "patch": 1},
   "capabilities": [
     {
       "id": "sessions",

--- a/docs/api/rest.mdx
+++ b/docs/api/rest.mdx
@@ -53,12 +53,23 @@ If `--realm` is omitted, the server creates a new isolated opaque realm (`realm-
 | Method | Path | Description |
 |--------|------|-------------|
 | `POST` | `/sessions` | Create and run a new session |
-| `POST` | `/sessions/{id}/messages` | Continue an existing session |
-| `POST` | `/sessions/{id}/event` | Push an external event into a session |
+| `GET` | `/sessions` | List sessions |
 | `GET` | `/sessions/{id}` | Fetch session metadata and usage |
+| `POST` | `/sessions/{id}/messages` | Continue an existing session |
+| `POST` | `/sessions/{id}/interrupt` | Interrupt an in-flight turn |
+| `DELETE` | `/sessions/{id}` | Archive (remove) a session |
 | `GET` | `/sessions/{id}/events` | SSE stream for real-time updates |
+| `POST` | `/sessions/{id}/event` | Push an external event into a session (legacy) |
+| `POST` | `/sessions/{id}/mcp/add` | Stage live MCP server addition (mcp feature) |
+| `POST` | `/sessions/{id}/mcp/remove` | Stage live MCP server removal (mcp feature) |
+| `POST` | `/sessions/{id}/mcp/reload` | Reload MCP server(s) (mcp feature) |
 | `POST` | `/comms/send` | Push comms message into a session (comms feature) |
 | `GET` | `/comms/peers` | List discoverable peers (comms feature) |
+| `GET` | `/comms/stream` | Comms SSE stream (comms feature) |
+| `GET` | `/mob/prefabs` | List mob prefab templates (mob feature) |
+| `GET` | `/mob/tools` | List mob tools (mob feature) |
+| `POST` | `/mob/call` | Call a mob tool (mob feature) |
+| `GET` | `/mob/{id}/events` | Mob event SSE stream (mob feature) |
 | `GET` | `/skills` | List skills with provenance |
 | `GET` | `/skills/{id}` | Inspect a skill's full content |
 | `GET` | `/health` | Liveness check |
@@ -338,6 +349,22 @@ Create and run a new session.
   JSON Schema object. The wrapper enables explicit `compat`/`format` settings.
 </Accordion>
 
+### GET /sessions
+
+List sessions. Supports optional label filters via query parameters.
+
+```json Response
+{
+  "sessions": [
+    {
+      "session_id": "01936f8a-7b2c-7000-8000-000000000001",
+      "state": "idle",
+      "created_at": "2025-01-15T10:30:00Z"
+    }
+  ]
+}
+```
+
 ### POST /sessions/\{id\}/messages
 
 Continue an existing session.
@@ -420,6 +447,26 @@ Continue an existing session.
 #### Response fields
 
 Same shape as `POST /sessions`.
+
+### POST /sessions/\{id\}/interrupt
+
+Interrupt an in-flight turn. No-op if the session is idle.
+
+```json Response
+{"interrupted": true}
+```
+
+Returns `404` if the session is not found, `409` if the session is not running.
+
+### DELETE /sessions/\{id\}
+
+Archive (remove) a session.
+
+```json Response
+{"archived": true}
+```
+
+Returns `404` if the session is not found.
 
 ### POST /sessions/\{id\}/event
 
@@ -564,7 +611,7 @@ Returns runtime capabilities with status resolved against config.
 
 ```json Response (abbreviated)
 {
-  "contract_version": {"major": 0, "minor": 2, "patch": 0},
+  "contract_version": {"major": 0, "minor": 4, "patch": 1},
   "capabilities": [
     {
       "id": "sessions",
@@ -580,7 +627,7 @@ Returns runtime capabilities with status resolved against config.
 }
 ```
 
-The full response includes all capabilities: `sessions`, `streaming`, `structured_output`, `hooks`, `builtins`, `shell`, `comms`, `sub_agents`, `memory_store`, `skills`. See the [RPC capabilities endpoint](/api/rpc#capabilitiesget) for the complete example.
+The full response includes all capabilities: `sessions`, `streaming`, `structured_output`, `hooks`, `builtins`, `shell`, `comms`, `sub_agents`, `memory_store`, `session_store`, `session_compaction`, `skills`, `mcp_live`. See the [RPC capabilities endpoint](/api/rpc#capabilitiesget) for the complete example.
 
 ### GET /config
 

--- a/docs/api/rpc.mdx
+++ b/docs/api/rpc.mdx
@@ -55,22 +55,27 @@ rkat-rpc [--realm <id>] [--isolated] [--instance <id>] [--realm-backend <redb|js
 | `session/archive` | Session | Remove session from runtime |
 | `turn/start` | Turn | Start a new turn on existing session |
 | `turn/interrupt` | Turn | Cancel in-flight turn |
+| `mob/prefabs` | Mob | List mob prefab templates (mob feature) |
+| `mob/tools` | Mob | List mob tools (mob feature) |
+| `mob/call` | Mob | Call a mob tool (mob feature) |
+| `mob/stream_open` | Mob | Open mob event stream (mob feature) |
+| `mob/stream_close` | Mob | Close mob event stream (mob feature) |
 | `comms/send` | Comms | Push an external event into a session |
 | `comms/peers` | Comms | List discoverable peers (comms feature) |
 | `comms/stream_open` | Comms | Open scoped event stream (comms feature) |
 | `comms/stream_close` | Comms | Close scoped event stream (comms feature) |
 | `skills/list` | Skills | List skills with provenance |
 | `skills/inspect` | Skills | Inspect a skill's full content |
-| `mcp/add` | MCP | Stage live MCP server addition |
-| `mcp/remove` | MCP | Stage live MCP server removal |
-| `mcp/reload` | MCP | Reload one or all MCP servers |
+| `mcp/add` | MCP | Stage live MCP server addition (mcp feature) |
+| `mcp/remove` | MCP | Stage live MCP server removal (mcp feature) |
+| `mcp/reload` | MCP | Reload one or all MCP servers (mcp feature) |
 | `capabilities/get` | Capabilities | Runtime capability report |
 | `config/get` | Config | Read current config |
 | `config/set` | Config | Replace config |
 | `config/patch` | Config | Merge-patch config (RFC 7396) |
 
 <Note>
-RPC uses generic session/turn methods as the control plane. Mob capability is added by composing `meerkat-mob-mcp` (`MobMcpState` + `MobMcpDispatcher`) into `SessionBuildOptions.external_tools`, which exposes `mob_*` tools to the running agent session.
+The `mob/*` methods (feature-gated on `mob`) provide direct protocol-level mob orchestration. Additionally, mob capability within sessions is added by composing `meerkat-mob-mcp` (`MobMcpState` + `MobMcpDispatcher`) into `SessionBuildOptions.external_tools`, which exposes `mob_*` tools to the running agent.
 </Note>
 
 ## Protocol
@@ -124,18 +129,21 @@ Handshake. Returns server capabilities.
   "result": {
     "server_info": {
       "name": "meerkat-rpc",
-      "version": "0.4.0"
+      "version": "0.4.1"
     },
-    "contract_version": "0.4.0",
+    "contract_version": "0.4.1",
     "methods": [
       "initialize", "initialized",
       "session/create", "session/list", "session/read",
       "session/archive", "turn/start", "turn/interrupt",
-      "comms/send", "comms/peers", "comms/stream_open", "comms/stream_close",
-      "skills/list", "skills/inspect",
-      "mcp/add", "mcp/remove", "mcp/reload",
+      "config/get", "config/set", "config/patch",
       "capabilities/get",
-      "config/get", "config/set", "config/patch"
+      "skills/list", "skills/inspect",
+      "mob/prefabs", "mob/tools", "mob/call",
+      "mob/stream_open", "mob/stream_close",
+      "mcp/add", "mcp/remove", "mcp/reload",
+      "comms/send", "comms/peers",
+      "comms/stream_open", "comms/stream_close"
     ]
   }
 }
@@ -848,7 +856,7 @@ Return runtime capabilities with status resolved against config. This lists ever
   "jsonrpc": "2.0",
   "id": 8,
   "result": {
-    "contract_version": {"major": 0, "minor": 2, "patch": 0},
+    "contract_version": {"major": 0, "minor": 4, "patch": 1},
     "capabilities": [
       {
         "id": "sessions",
@@ -1086,12 +1094,30 @@ When a scoped event stream is open (via `comms/stream_open`), the server emits `
       "type": "text_delta",
       "delta": "Hello"
     },
-    "contract_version": "0.4.0"
+    "contract_version": "0.3.0"
   }
 }
 ```
 
 These events are scoped to the stream and only emitted while the stream is open.
+
+### mob/stream_event notifications
+
+When a mob event stream is open (via `mob/stream_open`), the server emits `mob/stream_event` notifications. Requires the `mob` feature.
+
+```json
+{
+  "jsonrpc": "2.0",
+  "method": "mob/stream_event",
+  "params": {
+    "stream_id": "550e8400-e29b-41d4-a716-446655440000",
+    "sequence": 1,
+    "event": { "...": "..." }
+  }
+}
+```
+
+For mob-wide streams the event is an `AttributedEvent` (source + profile + envelope). For per-member streams the event is the raw `EventEnvelope<AgentEvent>`.
 
 ## Error codes
 


### PR DESCRIPTION
## Summary

- Update contract version from 0.2.0/0.4.0 to 0.4.1 in all example JSON responses across `rest.mdx`, `rpc.mdx`, and `mcp.mdx` (verified against `ContractVersion::CURRENT` in `meerkat-contracts/src/version.rs`)
- Fix comms stream `contract_version` to 0.3.0 (matches `COMMS_STREAM_CONTRACT_VERSION` constant)
- Add 19 missing tools to the MCP server tool overview table (verified against `base_tools_list()` + feature-gated extensions in `meerkat-mcp-server/src/lib.rs`)
- Add 5 missing `mob/*` methods and feature-gate annotations to the RPC method overview table and initialize response example (verified against `handle_initialize` in `meerkat-rpc/src/handlers/initialize.rs`)
- Add 11 missing REST endpoints to the overview table including `GET /sessions`, `POST /sessions/{id}/interrupt`, `DELETE /sessions/{id}`, MCP live ops, mob ops, and comms stream (verified against router in `meerkat-rest/src/lib.rs`)
- Add brief endpoint sections for `GET /sessions`, `POST interrupt`, `DELETE archive`
- Add `mob/stream_event` notification section to RPC docs
- Update capabilities list to include `session_store`, `session_compaction`, and `mcp_live` (verified against `CapabilityId` enum in `meerkat-contracts`)

## Test plan

- [x] All changes are documentation-only (`.mdx` files)
- [x] Verified all version numbers, tool names, endpoint paths, and method names against source code
- [x] `cargo test --workspace --lib --bins --tests` passes (140 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)