### PR TITLE
Fix inaccuracies in reference docs (Unit 3)

### DIFF
--- a/docs/reference/api-reference.mdx
+++ b/docs/reference/api-reference.mdx
@@ -229,12 +229,12 @@ See the [skills guide](/guides/skills) for usage details.
 | `CapabilityStatus` | `Available`, `DisabledByPolicy`, `NotCompiled`, `NotSupportedByProtocol` |
 | `ErrorCode` | Stable error codes with projections to JSON-RPC, HTTP, and CLI exit codes |
 | `WireError` | Canonical error envelope (code, message, details, capability hint) |
-| `WireRunResult` | Canonical response (session_id, text, turns, tool_calls, usage, structured_output, schema_warnings) |
+| `WireRunResult` | Canonical response (session_id, session_ref, text, turns, tool_calls, usage, structured_output, schema_warnings, skill_diagnostics) |
 | `WireSessionInfo` | Session metadata |
 | `WireSessionSummary` | Lightweight session summary |
 | `WireEvent` | Event wire format |
 | `WireUsage` | Token/cost usage breakdown |
-| `ContractVersion` | Semver version (`0.4.0` currently) |
+| `ContractVersion` | Semver version (`0.4.1` currently) |
 | `CoreCreateParams` | Session creation parameters |
 | `StructuredOutputParams` | Schema + retry count |
 | `CommsParams` | Host mode + agent name |
@@ -268,9 +268,9 @@ Every `ErrorCode` maps to a stable string, JSON-RPC code, HTTP status, and CLI e
 | `OpenAiClient` | OpenAI GPT | [Rust SDK: providers](/rust/advanced#providers) |
 | `GeminiClient` | Google Gemini | [Rust SDK: providers](/rust/advanced#providers) |
 
-All implement `LlmClient` and normalize responses to `LlmEvent` (text deltas, tool call deltas, usage updates, done).
+All implement `AgentLlmClient` and normalize streaming responses to `LlmEvent` (text deltas, tool call deltas, usage updates, done).
 
-`LlmError` variants: `RateLimited`, `ServerOverloaded`, `NetworkTimeout`, `ConnectionReset`, `ServerError`, `InvalidRequest`, `AuthenticationFailed`, `ContentFiltered`, `ContextLengthExceeded`, `ModelNotFound`, `InvalidApiKey`, `Unknown`. Use `error.is_retryable()` to check if an error should be retried.
+`LlmError` variants: `RateLimited`, `ServerOverloaded`, `NetworkTimeout`, `ConnectionReset`, `ServerError`, `InvalidRequest`, `AuthenticationFailed`, `ContentFiltered`, `ContextLengthExceeded`, `ModelNotFound`, `InvalidApiKey`, `Unknown`, `StreamParseError`, `IncompleteResponse`. Use `error.is_retryable()` to check if an error should be retried.
 
 ## Storage implementations
 

--- a/docs/reference/builtin-tools.mdx
+++ b/docs/reference/builtin-tools.mdx
@@ -686,10 +686,10 @@ Pause execution for the specified number of seconds. Supports fractional seconds
 **Default enabled:** Yes
 
 <ParamField body="seconds" type="f64" required>
-  Duration to wait (range: 0.1 to 300.0).
+  Duration to wait in seconds (clamped to 0.0 to 300.0).
 </ParamField>
 
-Maximum wait time is 300 seconds (5 minutes). Values below 0.1 or above 300.0 are rejected.
+Maximum wait time is 300 seconds (5 minutes). Values are clamped to the range 0.0 to 300.0.
 
 <CodeGroup>
 ```json Returns (completed)
@@ -704,7 +704,7 @@ Maximum wait time is 300 seconds (5 minutes). Values below 0.1 or above 300.0 ar
   "waited_seconds": 2.3,
   "requested_seconds": 5.0,
   "status": "interrupted",
-  "reason": "cancellation signal received"
+  "reason": "Wait interrupted after 2.3s: incoming message from peer"
 }
 ```
 </CodeGroup>
@@ -742,8 +742,7 @@ Comms tools enable inter-agent communication. They require the `comms` Cargo fea
 
 Comms tools are only shown to the agent when at least one peer is discoverable
 (controlled by `CommsToolSurface::peer_availability()`). The check passes when
-either `TrustedPeers` has entries or `InprocRegistry` has a peer other than
-self.
+`TrustedPeers` has entries.
 
 Tool definitions (name, description, input schema) are dynamically loaded from `meerkat_comms::tools_list()`.
 
@@ -786,7 +785,8 @@ Send a message, request, or response to a trusted peer. The `kind` parameter det
 
 ```json
 {
-  "status": "sent"
+  "status": "sent",
+  "kind": "peer_message"
 }
 ```
 
@@ -796,11 +796,7 @@ Send a message, request, or response to a trusted peer. The `kind` parameter det
 <Accordion title="peers">
 List all discoverable peers and their connection status.
 
-Returns the union of:
-- configured trusted peers (`TrustedPeers`)
-- in-process peers currently registered in `InprocRegistry`
-
-Peers are de-duplicated by name and the current agent ("self") is excluded.
+Returns configured trusted peers (`TrustedPeers`), excluding the current agent ("self") by public key.
 
 **Default enabled:** Yes (when comms is active)
 

--- a/docs/reference/comms-redesign-v6-hard-cut.md
+++ b/docs/reference/comms-redesign-v6-hard-cut.md
@@ -1,5 +1,11 @@
 # Comms Redesign V6 — Hard-Cut Plan
 
+> **Historical design document.** This plan was written before implementation.
+> The comms redesign has been implemented. The contract version references to
+> `0.3.0` below reflect the original plan; the actual contract version at
+> time of implementation was `0.4.x`. See the current `CommsRuntime` trait in
+> `meerkat-core/src/agent.rs` for the implemented API.
+
 ## Unified TDD Master Plan V6: Hard-Cut Comms Redesign (Final)
 
 ## Summary

--- a/docs/reference/session-contracts.mdx
+++ b/docs/reference/session-contracts.mdx
@@ -28,9 +28,11 @@ Agent construction is centralized in `AgentFactory::build_agent()`.
 
 ### create_session
 
-`create_session(req)` builds the agent and runs first turn.
+`create_session(req)` builds the agent and optionally runs the first turn.
 
 - Returns `RunResult` with `session_id`.
+- `InitialTurnPolicy::RunImmediately` executes the first turn inline (default).
+- `InitialTurnPolicy::Defer` registers the session without running a turn.
 - Supports host mode where enabled.
 
 ### start_turn


### PR DESCRIPTION
## Summary

- **api-reference.mdx**: Fix `ContractVersion` from `0.4.0` to `0.4.1`, trait name from `LlmClient` to `AgentLlmClient`, add missing `LlmError` variants (`StreamParseError`, `IncompleteResponse`), add missing `WireRunResult` fields (`session_ref`, `skill_diagnostics`)
- **builtin-tools.mdx**: Fix wait tool range description (values are clamped, not rejected; lower bound is 0.0, not 0.1), correct interrupt reason format to match source, fix `peers` tool to reflect trusted-peers-only behavior (not inproc union), fix `send` tool return value to include `kind` field, correct availability check description
- **session-contracts.mdx**: Document `InitialTurnPolicy` (`RunImmediately` vs `Defer`) on `create_session`
- **comms-redesign-v6-hard-cut.md**: Add historical design document banner noting `0.3.0` version references are from the original plan (current version is `0.4.x`)

## Test plan

- [x] Documentation-only changes, no code modified
- [x] `cargo test --workspace --lib --bins --tests` passes
- [x] All claims verified against source code

🤖 Generated with [Claude Code](https://claude.com/claude-code)