### PR TITLE
Fix inaccuracies in meerkat-architecture skill docs

### DIFF
--- a/.claude/skills/meerkat-architecture/SKILL.md
+++ b/.claude/skills/meerkat-architecture/SKILL.md
@@ -20,12 +20,12 @@ Meerkat is a library-first agent runtime. The execution pipeline is shared acros
 | Crate | Owns | Key Trait |
 |-------|------|-----------|
 | `meerkat-core` | Agent loop, types, budget, retry, state machine, ALL trait contracts | `AgentLlmClient`, `AgentToolDispatcher`, `AgentSessionStore`, `SessionService`, `CommsRuntime`, `HookEngine` |
-| `meerkat-client` | LLM providers (Anthropic, OpenAI, Gemini) | Implements `LlmClient` |
+| `meerkat-client` | LLM providers (Anthropic, OpenAI, Gemini) | Implements `AgentLlmClient` (via `LlmClientAdapter`) |
 | `meerkat-store` | Session persistence (Jsonl, Memory, Redb) | Implements `SessionStore` |
 | `meerkat-tools` | Tool registry, dispatch, builtins | Implements `AgentToolDispatcher` |
 | `meerkat-session` | Session orchestration (Ephemeral, Persistent) | Implements `SessionService` |
-| `meerkat-comms` | Inter-agent messaging (inproc, TCP, UDS) | Implements `CoreCommsRuntime` |
-| `meerkat-mob` | Multi-agent orchestration (MobBuilder, FlowEngine) | `MobSessionService`, `MobProvisioner` |
+| `meerkat-comms` | Inter-agent messaging (inproc, TCP, UDS) | Implements `CommsRuntime` |
+| `meerkat-mob` | Multi-agent orchestration (MobBuilder, FlowEngine) | `MobSessionService`, `MobProvisioner` (mob-local traits) |
 | `meerkat-mob-pack` | Mobpack archive format, signing, trust policies, validation | — |
 | `meerkat-mob-mcp` | Expose mob tools as MCP interface | `MobMcpState`, `MobMcpDispatcher` |
 | `meerkat-web-runtime` | WASM browser deployment (wasm_bindgen exports) | — |
@@ -37,22 +37,22 @@ Meerkat is a library-first agent runtime. The execution pipeline is shared acros
 
 ## Agent Construction Pipeline
 
-`AgentFactory::build_agent()` is the single entry point for ALL surfaces. 12 steps:
+`AgentFactory::build_agent()` is the single entry point for ALL surfaces. Key steps:
 
 1. Validate host_mode
 2. Resolve provider (infer from model or explicit)
 3. Create LLM client (override > factory credentials > config)
-4. Create LLM adapter (with event channel)
+4. Create LLM adapter (with event channel and event tap)
 5. Resolve max_tokens
 6a. Build skill engine (override > factory > config > filesystem)
-6b. Create comms runtime (if comms_name set; inproc on wasm32)
-6b. Build tool dispatcher (override > factory builtin builder)
+6b. Build tool dispatcher (override > factory builtin builder); create comms runtime (if comms_name set; inproc on wasm32); wire sub-agent comms inheritance (if enabled)
 7. Create session store (override > factory custom_store > feature-flag default)
-8. Sub-agent comms inheritance (if enabled)
 9. Compose tools with comms (add send/list_peers tools)
 10. Resolve hooks (override > filesystem layered config)
 11. Generate skill inventory
-12. Build system prompt + AgentBuilder + SessionMetadata
+12. Build system prompt + AgentBuilder + wire memory/compactor/skill-engine/event-tap/checkpointer
+13. Build agent
+14. Set SessionMetadata
 
 **Precedence at every step:** `build_config override > factory field > config resolution > default`
 

--- a/.claude/skills/meerkat-architecture/references/crate_map.md
+++ b/.claude/skills/meerkat-architecture/references/crate_map.md
@@ -28,23 +28,35 @@ Surface binaries:
   └── meerkat-mcp-server (rkat-mcp)
 ```
 
-## Key Traits (all in meerkat-core)
+## Key Traits
+
+### Core traits (defined in meerkat-core)
 
 | Trait | Purpose | Implementors |
 |-------|---------|-------------|
-| `AgentLlmClient` | LLM provider abstraction | `LlmClientAdapter` |
-| `AgentToolDispatcher` | Tool routing | `CompositeDispatcher`, `ToolGateway`, `EmptyToolDispatcher` |
-| `AgentSessionStore` | Session persistence | `StoreAdapter<S>`, no-op stores |
-| `SessionService` | Full session lifecycle | `EphemeralSessionService<B>`, `PersistentSessionService<B>` |
-| `SessionAgentBuilder` | Agent construction from request | `FactoryAgentBuilder` |
-| `SessionAgent` | Running agent with session access | `FactoryAgent` |
+| `AgentLlmClient` | LLM provider abstraction | `LlmClientAdapter` (meerkat-client) |
+| `AgentToolDispatcher` | Tool routing | `CompositeDispatcher` (meerkat-tools), `ToolGateway` (meerkat-core), `EmptyToolDispatcher` (meerkat-tools) |
+| `AgentSessionStore` | Session persistence | `StoreAdapter<S>` (meerkat-store), no-op stores |
+| `SessionService` | Full session lifecycle | `EphemeralSessionService<B>` (meerkat-session), `PersistentSessionService<B>` (meerkat-session) |
 | `CommsRuntime` | Inter-agent communication | `meerkat_comms::CommsRuntime` |
-| `HookEngine` | Hook execution | `DefaultHookEngine` |
-| `SkillEngine` | Skill resolution + rendering | `DefaultSkillEngine` |
-| `Compactor` | Context compaction | `DefaultCompactor` |
-| `MemoryStore` | Semantic memory | `HnswMemoryStore`, `SimpleMemoryStore` |
+| `HookEngine` | Hook execution | `DefaultHookEngine` (meerkat-hooks) |
+| `SkillEngine` | Skill resolution + rendering | `DefaultSkillEngine` (meerkat-skills) |
+| `Compactor` | Context compaction | `DefaultCompactor` (meerkat-session) |
+| `MemoryStore` | Semantic memory | `HnswMemoryStore` (meerkat-memory), `SimpleMemoryStore` (meerkat-memory) |
+
+### Session traits (defined in meerkat-session)
+
+| Trait | Purpose | Implementors |
+|-------|---------|-------------|
+| `SessionAgentBuilder` | Agent construction from request | `FactoryAgentBuilder` (meerkat facade) |
+| `SessionAgent` | Running agent with session access | `FactoryAgent` (meerkat facade) |
+
+### Mob traits (defined in meerkat-mob)
+
+| Trait | Purpose | Implementors |
+|-------|---------|-------------|
 | `MobSessionService` | Session service + comms access for mobs | `EphemeralSessionService<B>`, `PersistentSessionService<B>` |
-| `MobProvisioner` | Member spawn/retire/turn | `SubagentBackend`, `MultiBackendProvisioner` |
+| `MobProvisioner` | Member spawn/retire/turn | `MultiBackendProvisioner`, `SubagentBackend` |
 | `MobEventStore` | Mob structural events | `InMemoryMobEventStore`, `RedbMobEventStore` |
 
 ## Agent Loop State Machine
@@ -80,7 +92,7 @@ archive(id)
 MobBuilder::create() → MobHandle
   ├── validate definition
   ├── emit MobCreated event
-  ├── create provisioner (SubagentBackend wrapping session_service)
+  ├── create provisioner (MultiBackendProvisioner wrapping session_service)
   └── spawn MobActor task
 
 MobHandle::spawn(profile, meerkat_id)


### PR DESCRIPTION
## Summary
- Fix incorrect trait names and ownership in SKILL.md and crate_map.md (meerkat-architecture skill)
- Correct trait location claims: `SessionAgentBuilder`/`SessionAgent` are in meerkat-session, `MobSessionService`/`MobProvisioner`/`MobEventStore` are in meerkat-mob (not all in meerkat-core as previously stated)
- Fix build_agent pipeline step descriptions to match actual factory.rs implementation

## Test plan
- [x] Verified all trait names and locations against actual source code
- [x] `cargo test --workspace --lib --bins --tests` passes (140 tests, documentation-only change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)