### PR TITLE
Fix SDK + Rust + top-level doc inaccuracies (Unit 7)

### DIFF
--- a/docs/rust/advanced.mdx
+++ b/docs/rust/advanced.mdx
@@ -59,9 +59,9 @@ Built-in clients for major LLM providers:
     ```rust
     use meerkat::AnthropicClient;
 
-    let client = AnthropicClient::new("sk-ant-...".to_string());
+    let client = AnthropicClient::new("sk-ant-...".to_string())?;
     let client = AnthropicClient::from_env()?;
-    let client = AnthropicClient::new("key".to_string())
+    let client = AnthropicClient::new("key".to_string())?
         .with_base_url("https://my-proxy.example.com".to_string());
     ```
   </Tab>
@@ -115,7 +115,9 @@ Pass provider-specific options via `AgentBuildConfig`:
 ```rust
 use async_trait::async_trait;
 use meerkat::{AgentLlmClient, AgentError, LlmStreamResult, Message, ToolDef, StopReason, Usage};
+use meerkat::AssistantBlock;
 use serde_json::Value;
+use std::sync::Arc;
 
 struct MyCustomClient { api_key: String }
 
@@ -124,18 +126,17 @@ impl AgentLlmClient for MyCustomClient {
     async fn stream_response(
         &self,
         messages: &[Message],
-        tools: &[ToolDef],
+        tools: &[Arc<ToolDef>],
         max_tokens: u32,
         temperature: Option<f32>,
         provider_params: Option<&Value>,
     ) -> Result<LlmStreamResult, AgentError> {
         // Call your LLM API here
-        Ok(LlmStreamResult {
-            content: "Response text".to_string(),
-            tool_calls: vec![],
-            stop_reason: StopReason::EndTurn,
-            usage: Usage { input_tokens: 10, output_tokens: 20, ..Default::default() },
-        })
+        Ok(LlmStreamResult::new(
+            vec![AssistantBlock::Text { text: "Response text".to_string(), meta: None }],
+            StopReason::EndTurn,
+            Usage { input_tokens: 10, output_tokens: 20, ..Default::default() },
+        ))
     }
 
     fn provider(&self) -> &'static str { "my-provider" }
@@ -325,7 +326,8 @@ async fn handle_chat(session_id: SessionId, user_msg: String) -> impl IntoRespon
 
 ```rust
 use meerkat::{AgentFactory, Config, build_ephemeral_service};
-use meerkat::service::{CreateSessionRequest, InitialTurnPolicy, StartTurnRequest, SessionService};
+use meerkat::{CreateSessionRequest, StartTurnRequest, SessionService};
+use meerkat_core::service::InitialTurnPolicy;
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
@@ -342,6 +344,8 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         host_mode: false,
         skill_references: None,
         initial_turn: InitialTurnPolicy::RunImmediately,
+        build: None,
+        labels: None,
     }).await?;
 
     println!("Response: {}", result.text);
@@ -350,6 +354,9 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         prompt: "Now divide that result by 5.".into(),
         event_tx: None,
         host_mode: false,
+        skill_references: None,
+        flow_tool_overlay: None,
+        additional_instructions: None,
     }).await?;
 
     println!("Follow-up: {}", result.text);

--- a/docs/rust/overview.mdx
+++ b/docs/rust/overview.mdx
@@ -87,7 +87,8 @@ The recommended entry point is `SessionService` via `build_ephemeral_service`:
 
 ```rust
 use meerkat::{AgentFactory, Config, build_ephemeral_service};
-use meerkat::service::{CreateSessionRequest, InitialTurnPolicy, SessionService};
+use meerkat::{CreateSessionRequest, SessionService};
+use meerkat_core::service::InitialTurnPolicy;
 use meerkat_store;
 
 #[tokio::main]
@@ -106,6 +107,8 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         host_mode: false,
         skill_references: None,
         initial_turn: InitialTurnPolicy::RunImmediately,
+        build: None,
+        labels: None,
     }).await?;
 
     println!("Response: {}", result.text);
@@ -123,7 +126,8 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 ### Multi-turn conversations
 
 ```rust
-use meerkat::service::{CreateSessionRequest, InitialTurnPolicy, StartTurnRequest, SessionService};
+use meerkat::{CreateSessionRequest, StartTurnRequest, SessionService};
+use meerkat_core::service::InitialTurnPolicy;
 
 // Turn 1: create session
 let result = service.create_session(CreateSessionRequest {
@@ -144,6 +148,9 @@ let result = service.start_turn(&session_id, StartTurnRequest {
     prompt: "What's my name?".into(),
     event_tx: None,
     host_mode: false,
+    skill_references: None,
+    flow_tool_overlay: None,
+    additional_instructions: None,
 }).await?;
 
 // Read session state
@@ -157,7 +164,7 @@ service.archive(&session_id).await?;
 ### Error handling
 
 ```rust
-use meerkat::service::SessionError;
+use meerkat::SessionError;
 
 match service.start_turn(&id, req).await {
     Ok(result) => println!("Response: {}", result.text),
@@ -244,8 +251,18 @@ match event {
     AgentEvent::RunCompleted { session_id, result, usage } => {}
     AgentEvent::RunFailed { session_id, error } => {}
 
+    // Hook lifecycle
+    AgentEvent::HookStarted { hook_id, point } => {}
+    AgentEvent::HookCompleted { hook_id, point, duration_ms } => {}
+    AgentEvent::HookFailed { hook_id, point, error } => {}
+    AgentEvent::HookDenied { hook_id, point, reason_code, message, .. } => {}
+    AgentEvent::HookRewriteApplied { hook_id, point, patch } => {}
+    AgentEvent::HookPatchPublished { hook_id, point, envelope } => {}
+
     // LLM interaction
     AgentEvent::TurnStarted { turn_number } => {}
+    AgentEvent::ReasoningDelta { delta } => {}
+    AgentEvent::ReasoningComplete { content } => {}
     AgentEvent::TextDelta { delta } => {}
     AgentEvent::TextComplete { content } => {}
     AgentEvent::ToolCallRequested { id, name, args } => {}
@@ -255,12 +272,32 @@ match event {
     // Tool execution
     AgentEvent::ToolExecutionStarted { id, name } => {}
     AgentEvent::ToolExecutionCompleted { id, name, result, is_error, duration_ms } => {}
+    AgentEvent::ToolExecutionTimedOut { id, name, timeout_ms } => {}
+
+    // Compaction
+    AgentEvent::CompactionStarted { input_tokens, estimated_history_tokens, message_count } => {}
+    AgentEvent::CompactionCompleted { summary_tokens, messages_before, messages_after } => {}
+    AgentEvent::CompactionFailed { error } => {}
 
     // Budget
     AgentEvent::BudgetWarning { budget_type, used, limit, percent } => {}
 
     // Retry
     AgentEvent::Retrying { attempt, max_attempts, error, delay_ms } => {}
+
+    // Skills
+    AgentEvent::SkillsResolved { skills, injection_bytes } => {}
+    AgentEvent::SkillResolutionFailed { reference, error } => {}
+
+    // Interaction-scoped streaming
+    AgentEvent::InteractionComplete { interaction_id, result } => {}
+    AgentEvent::InteractionFailed { interaction_id, error } => {}
+    AgentEvent::StreamTruncated { reason } => {}
+
+    // Tool config changes
+    AgentEvent::ToolConfigChanged { payload } => {}
+
+    _ => {} // non_exhaustive: forward compatibility
 }
 ```
 </Accordion>

--- a/docs/sdks/python/overview.mdx
+++ b/docs/sdks/python/overview.mdx
@@ -164,9 +164,11 @@ async def create_session(
     enable_shell: bool = False,
     enable_subagents: bool = False,
     enable_memory: bool = False,
+    enable_mob: bool = False,
     host_mode: bool = False,
     comms_name: str | None = None,
     peer_meta: dict | None = None,
+    budget_limits: dict | None = None,
     provider_params: dict | None = None,
     preload_skills: list[str] | None = None,
     skill_refs: list[SkillRef] | None = None,
@@ -369,7 +371,7 @@ All events are frozen dataclasses importable from `meerkat`. Unknown event types
 | `ToolExecutionTimedOut` | `id`, `name`, `timeout_ms` | Tool exceeded its timeout |
 | `RunCompleted` | `session_id`, `result`, `usage` | Agent run completed |
 | `RunFailed` | `session_id`, `error` | Agent run failed |
-| `CompactionStarted` | `input_tokens`, `message_count` | Context compaction began |
+| `CompactionStarted` | `input_tokens`, `estimated_history_tokens`, `message_count` | Context compaction began |
 | `CompactionCompleted` | `summary_tokens`, `messages_before`, `messages_after` | Compaction finished |
 | `CompactionFailed` | `error` | Compaction failed |
 | `BudgetWarning` | `budget_type`, `used`, `limit`, `percent` | A budget threshold crossed |
@@ -384,6 +386,7 @@ All events are frozen dataclasses importable from `meerkat`. Unknown event types
 | `InteractionComplete` | `interaction_id`, `result` | Comms interaction completed |
 | `InteractionFailed` | `interaction_id`, `error` | Comms interaction failed |
 | `StreamTruncated` | `reason` | Event stream was truncated |
+| `ToolConfigChanged` | `payload` | Live tool configuration changed for this session |
 | `UnknownEvent` | `type`, `data` | Unrecognised event type (forward compat) |
 
 ---

--- a/docs/sdks/python/reference.mdx
+++ b/docs/sdks/python/reference.mdx
@@ -207,6 +207,7 @@ from meerkat import (
     SkillsResolved, SkillResolutionFailed,
     InteractionComplete, InteractionFailed,
     StreamTruncated,
+    ToolConfigChanged, ToolConfigChangedPayload,
     UnknownEvent,
 )
 ```
@@ -477,7 +478,7 @@ The SDK negotiates version compatibility during `connect()`:
 
 ```python
 from meerkat import CONTRACT_VERSION
-print(CONTRACT_VERSION)  # e.g. "0.2.0"
+print(CONTRACT_VERSION)  # e.g. "0.4.1"
 ```
 
 ---

--- a/docs/sdks/typescript/overview.mdx
+++ b/docs/sdks/typescript/overview.mdx
@@ -190,9 +190,11 @@ interface SessionOptions {
   enableShell?: boolean;
   enableSubagents?: boolean;
   enableMemory?: boolean;
+  enableMob?: boolean;
   hostMode?: boolean;
   commsName?: string;
   peerMeta?: Record<string, unknown>;
+  budgetLimits?: Record<string, unknown>;
   providerParams?: Record<string, unknown>;
   preloadSkills?: string[];
   skillRefs?: SkillRef[];

--- a/docs/sdks/typescript/reference.mdx
+++ b/docs/sdks/typescript/reference.mdx
@@ -272,6 +272,7 @@ type AgentEvent =
   | InteractionCompleteEvent
   | InteractionFailedEvent
   | StreamTruncatedEvent
+  | ToolConfigChangedEvent
   | UnknownEvent;
 ```
 
@@ -365,6 +366,20 @@ interface SkillResolutionFailedEvent { type: "skill_resolution_failed"; referenc
 ```typescript
 interface InteractionCompleteEvent { type: "interaction_complete"; interactionId: string; result: string }
 interface InteractionFailedEvent   { type: "interaction_failed";   interactionId: string; error: string }
+```
+
+### Tool config events
+
+```typescript
+interface ToolConfigChangedEvent { type: "tool_config_changed"; payload: ToolConfigChangedPayload }
+
+interface ToolConfigChangedPayload {
+  operation: "add" | "remove" | "reload";
+  target: string;
+  status: string;
+  persisted: boolean;
+  appliedAtTurn?: number;
+}
 ```
 
 ### Stream management
@@ -483,7 +498,7 @@ const result2 = await session.invokeSkill(
 
 ```typescript
 import { CONTRACT_VERSION } from "@rkat/sdk";
-console.log(CONTRACT_VERSION);  // e.g. "0.4.0"
+console.log(CONTRACT_VERSION);  // e.g. "0.4.1"
 ```
 
 - While the major version is `0`, minor versions must match exactly between SDK and server.


### PR DESCRIPTION
## Summary

- **Python SDK docs**: Add missing `enable_mob` and `budget_limits` params to `create_session()` signature, fix `CONTRACT_VERSION` example from `"0.2.0"` to `"0.4.1"`, add `estimated_history_tokens` to `CompactionStarted` event fields, add `ToolConfigChanged`/`ToolConfigChangedPayload` to event table and imports
- **TypeScript SDK docs**: Add missing `enableMob` and `budgetLimits` to `SessionOptions` interface, fix `CONTRACT_VERSION` example from `"0.4.0"` to `"0.4.1"`, add `ToolConfigChangedEvent` to `AgentEvent` union and document its interface/payload
- **Rust overview docs**: Fix import paths from `meerkat::service::` to `meerkat::` (facade re-exports) and `meerkat_core::service::InitialTurnPolicy`, add missing `build`/`labels` fields to `CreateSessionRequest` struct literals, add missing `skill_references`/`flow_tool_overlay`/`additional_instructions` to `StartTurnRequest`, expand `AgentEvent` match to include all 26 current variants plus `_ =>` wildcard for `#[non_exhaustive]`
- **Rust advanced docs**: Fix `AnthropicClient::new()` to show `Result` return type with `?`, fix `AgentLlmClient` custom implementation example to use `Arc<ToolDef>`, `LlmStreamResult::new()`, and `AssistantBlock::Text` (matching actual API), fix import paths and add missing struct fields

## Test plan

- [x] `cargo test --workspace --lib --bins --tests` passes (140 tests, 0 failures)
- [x] Changes are documentation-only (`.mdx` files) -- no code changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)