### PR TITLE
Fix example docs to match current API signatures

### DIFF
--- a/docs/examples/comms.mdx
+++ b/docs/examples/comms.mdx
@@ -70,13 +70,19 @@ Enable the comms listener so the agent stays alive after its initial prompt, wai
   <Tab title="Rust">
     ```rust
     let result = service.create_session(CreateSessionRequest {
+        model: "claude-sonnet-4-5".into(),
         prompt: "You are a coordinator.".into(),
+        system_prompt: None,
+        max_tokens: None,
+        event_tx: None,
         host_mode: true,
+        skill_references: None,
+        initial_turn: InitialTurnPolicy::RunImmediately,
         build: Some(SessionBuildOptions {
             comms_name: Some("agent-a".into()),
             ..Default::default()
         }),
-        ..Default::default()
+        labels: None,
     }).await?;
     ```
   </Tab>

--- a/docs/examples/hooks.mdx
+++ b/docs/examples/hooks.mdx
@@ -263,7 +263,7 @@ A hook that POSTs the invocation payload to a remote URL. Useful for centralized
     rkat run "Analyze quarterly data" --hooks-override-json '{
       "entries": [{
         "id": "policy-server",
-        "point": "pre_llm_call",
+        "point": "pre_llm_request",
         "mode": "blocking",
         "url": "https://hooks.example.com/policy",
         "timeout_ms": 10000
@@ -281,7 +281,7 @@ A hook that POSTs the invocation payload to a remote URL. Useful for centralized
         "hooks_override": {
           "entries": [{
             "id": "policy-server",
-            "point": "pre_llm_call",
+            "point": "pre_llm_request",
             "mode": "blocking",
             "url": "https://hooks.example.com/policy",
             "timeout_ms": 10000
@@ -300,7 +300,7 @@ A hook that POSTs the invocation payload to a remote URL. Useful for centralized
         "hooks_override": {
           "entries": [{
             "id": "policy-server",
-            "point": "pre_llm_call",
+            "point": "pre_llm_request",
             "mode": "blocking",
             "url": "https://hooks.example.com/policy",
             "timeout_ms": 10000
@@ -319,7 +319,7 @@ A hook that POSTs the invocation payload to a remote URL. Useful for centralized
         "hooks_override": {
           "entries": [{
             "id": "policy-server",
-            "point": "pre_llm_call",
+            "point": "pre_llm_request",
             "mode": "blocking",
             "url": "https://hooks.example.com/policy",
             "timeout_ms": 10000
@@ -336,7 +336,7 @@ A hook that POSTs the invocation payload to a remote URL. Useful for centralized
         hooks_override={
             "entries": [{
                 "id": "policy-server",
-                "point": "pre_llm_call",
+                "point": "pre_llm_request",
                 "mode": "blocking",
                 "url": "https://hooks.example.com/policy",
                 "timeout_ms": 10000,
@@ -367,14 +367,14 @@ A hook that POSTs the invocation payload to a remote URL. Useful for centralized
 
 | Hook point | Classification | When it fires |
 |---|---|---|
-| `pre_run` | pre | Start of `Agent::run()`, before any LLM call |
-| `pre_llm_call` | pre | Before each LLM streaming call |
+| `run_started` | pre | Start of `Agent::run()`, before any LLM call |
+| `pre_llm_request` | pre | Before each LLM streaming call |
 | `pre_tool_execution` | pre | Before each individual tool call is dispatched |
-| `pre_turn` | pre | Between turns, after all tool results are collected |
-| `post_llm_call` | post | After the LLM response is received |
+| `turn_boundary` | pre | Between turns, after all tool results are collected |
+| `post_llm_response` | post | After the LLM response is received |
 | `post_tool_execution` | post | After each tool execution completes |
-| `post_turn` | post | After a turn completes |
-| `post_run` | post | After a successful run completes |
+| `run_completed` | post | After a successful run completes |
+| `run_failed` | post | After a run fails with an error |
 
 <Note>
 Pre-point hooks in `blocking` mode halt the agent loop until they return. Pre-point hooks in `background` mode are limited to observe-only capability.
@@ -463,14 +463,14 @@ Hooks emit events into the session event stream. Subscribe to these to build das
 {"type": "hook_started", "hook_id": "safety-gate", "point": "pre_tool_execution"}
 
 // HookCompleted -- emitted when a hook finishes successfully
-{"type": "hook_completed", "hook_id": "safety-gate", "decision": "allow"}
+{"type": "hook_completed", "hook_id": "safety-gate", "point": "pre_tool_execution", "duration_ms": 42}
 
 // HookDenied -- emitted when a hook blocks execution
-{"type": "hook_denied", "hook_id": "safety-gate", "reason_code": "policy_violation", "message": "rm -rf not allowed"}
+{"type": "hook_denied", "hook_id": "safety-gate", "point": "pre_tool_execution", "reason_code": "policy_violation", "message": "rm -rf not allowed"}
 
 // HookFailed -- emitted when a hook errors or times out
-{"type": "hook_failed", "hook_id": "audit-log", "error": "process exited with code 1"}
+{"type": "hook_failed", "hook_id": "audit-log", "point": "post_tool_execution", "error": "process exited with code 1"}
 
-// HookRewriteApplied -- emitted when a background hook publishes a patch
-{"type": "hook_rewrite_applied", "hook_id": "pii-scrub", "patch_type": "tool_result"}
+// HookRewriteApplied -- emitted when a hook applies a patch
+{"type": "hook_rewrite_applied", "hook_id": "pii-scrub", "point": "post_tool_execution", "patch": {"ToolResult": {"content": "***", "is_error": null}}}
 ```

--- a/docs/examples/memory.mdx
+++ b/docs/examples/memory.mdx
@@ -251,8 +251,8 @@ Cap resource usage per session with token, time, and tool-call limits. When a bu
     ```rust
     let build_opts = SessionBuildOptions {
         budget_limits: Some(BudgetLimits {
-            max_total_tokens: Some(10_000),
-            max_duration_ms: Some(30_000),
+            max_tokens: Some(10_000),
+            max_duration: Some(Duration::from_secs(30)),
             max_tool_calls: Some(5),
         }),
         ..Default::default()
@@ -268,10 +268,10 @@ When consumption nears a limit, a warning event is emitted before the budget is 
 ```json
 {
   "type": "budget_warning",
-  "limit_type": "max_total_tokens",
-  "current": 8500,
+  "budget_type": "max_tokens",
+  "used": 8500,
   "limit": 10000,
-  "message": "Token budget 85% consumed"
+  "percent": 85.0
 }
 ```
 
@@ -285,7 +285,7 @@ Transient LLM errors (rate limits, network timeouts) trigger automatic retries w
   "attempt": 2,
   "max_attempts": 5,
   "error": "rate_limit_exceeded",
-  "backoff_ms": 4000
+  "delay_ms": 4000
 }
 ```
 

--- a/docs/examples/mobs.mdx
+++ b/docs/examples/mobs.mdx
@@ -220,7 +220,7 @@ When `enable_mob` is set, the agent gets these tools:
   </Tab>
   <Tab title="Rust">
     ```rust
-    let definition = Prefab::CodingSwarm.definition("my-swarm");
+    let definition = Prefab::CodingSwarm.definition();
     let handle = MobBuilder::new(definition, MobStorage::in_memory())
         .with_session_service(service)
         .allow_ephemeral_sessions(true)
@@ -264,11 +264,12 @@ When `enable_mob` is set, the agent gets these tools:
   </Tab>
   <Tab title="Rust">
     ```rust
-    handle.spawn_batch(vec![
-        SpawnSpec::new("lead", "lead-1"),
-        SpawnSpec::new("worker", "worker-1").runtime_mode(MobRuntimeMode::TurnDriven),
-        SpawnSpec::new("worker", "worker-2"),
-    ]).await?;
+    handle.spawn("lead".into(), "lead-1".into(), None).await?;
+    handle.spawn_with_options(
+        "worker".into(), "worker-1".into(), None,
+        Some(MobRuntimeMode::TurnDriven), None,
+    ).await?;
+    handle.spawn("worker".into(), "worker-2".into(), None).await?;
     ```
   </Tab>
 </Tabs>
@@ -371,7 +372,7 @@ Send a message directly to a specific mob member, triggering an LLM turn.
   </Tab>
   <Tab title="Rust">
     ```rust
-    handle.turn("lead-1", "Decompose the task and assign to workers.").await?;
+    handle.send_message("lead-1".into(), "Decompose the task and assign to workers.".into()).await?;
     ```
   </Tab>
 </Tabs>
@@ -407,7 +408,7 @@ Execute a named DAG flow. Steps execute in dependency order with configured disp
   </Tab>
   <Tab title="Rust">
     ```rust
-    let run_id = handle.run_flow("triage", json!({"pr": 42})).await?;
+    let run_id = handle.run_flow("triage".into(), json!({"pr": 42})).await?;
     ```
   </Tab>
 </Tabs>
@@ -444,8 +445,8 @@ Execute a named DAG flow. Steps execute in dependency order with configured disp
   </Tab>
   <Tab title="Rust">
     ```rust
-    let status = handle.status().await?;
-    let flow_run = handle.flow_status(&run_id).await?;
+    let status = handle.status();
+    let flow_run = handle.flow_status(run_id).await?;
     ```
   </Tab>
 </Tabs>
@@ -480,8 +481,8 @@ Read the structural event log (spawns, retires, wires, flow transitions).
   </Tab>
   <Tab title="Rust">
     ```rust
-    let events = handle.events(0, 100).await?;
-    for e in &events { println!("{:?}", e); }
+    let events_view = handle.events();
+    // Use events_view to read the structural event log
     ```
   </Tab>
 </Tabs>
@@ -595,8 +596,16 @@ The primary pattern across all surfaces: enable mob tools and let the agent orch
         .mob(true);
     let service = build_ephemeral_service(factory, config, 64);
     let result = service.create_session(CreateSessionRequest {
+        model: "claude-sonnet-4-5".into(),
         prompt: "Create a research team and run the synthesis flow".into(),
-        ..Default::default()
+        system_prompt: None,
+        max_tokens: None,
+        event_tx: None,
+        host_mode: false,
+        skill_references: None,
+        initial_turn: InitialTurnPolicy::RunImmediately,
+        build: None,
+        labels: None,
     }).await?;
     ```
   </Tab>

--- a/docs/examples/sessions.mdx
+++ b/docs/examples/sessions.mdx
@@ -74,6 +74,8 @@ For concepts, see [Sessions](/concepts/sessions) and [Realms](/concepts/realms).
         host_mode: false,
         skill_references: None,
         initial_turn: InitialTurnPolicy::RunImmediately,
+        build: None,
+        labels: None,
     }).await?;
     println!("{}", result.text);
     ```
@@ -145,6 +147,7 @@ For concepts, see [Sessions](/concepts/sessions) and [Realms](/concepts/realms).
         host_mode: false,
         skill_references: None,
         flow_tool_overlay: None,
+        additional_instructions: None,
     }).await?;
     println!("{}", result.text);
     ```
@@ -549,12 +552,18 @@ Cancel an in-flight turn. No-op if the session is idle.
     let result = service.create_session(CreateSessionRequest {
         model: "gpt-5.2".into(),
         prompt: "Explain monads".into(),
+        system_prompt: None,
+        max_tokens: None,
+        event_tx: None,
+        host_mode: false,
+        skill_references: None,
+        initial_turn: InitialTurnPolicy::RunImmediately,
         build: Some(SessionBuildOptions {
             provider: Some(Provider::OpenAi),
             provider_params: Some(json!({"temperature": 0.7})),
             ..Default::default()
         }),
-        ..Default::default()
+        labels: None,
     }).await?;
     ```
   </Tab>

--- a/docs/examples/skills.mdx
+++ b/docs/examples/skills.mdx
@@ -202,12 +202,19 @@ Pass `skill_references` to resolve and inject skill content into the system prom
   <Tab title="Rust">
     ```rust
     let request = CreateSessionRequest {
+        model: "claude-sonnet-4-5".into(),
         prompt: "Extract emails".into(),
-        skill_references: vec![
-            "/email-extractor".into(),
-            "/formatting/markdown".into(),
-        ],
-        ..Default::default()
+        system_prompt: None,
+        max_tokens: None,
+        event_tx: None,
+        host_mode: false,
+        skill_references: Some(vec![
+            "/email-extractor".parse()?,
+            "/formatting/markdown".parse()?,
+        ]),
+        initial_turn: InitialTurnPolicy::RunImmediately,
+        build: None,
+        labels: None,
     };
     let result = service.create_session(request).await?;
     ```
@@ -276,10 +283,10 @@ Preloaded skills are resolved and injected into the system prompt before the fir
   <Tab title="Rust">
     ```rust
     let build_opts = SessionBuildOptions {
-        preload_skills: vec![
+        preload_skills: Some(vec![
             "deployment-guide".into(),
             "shell-patterns".into(),
-        ],
+        ]),
         ..Default::default()
     };
     ```
@@ -351,8 +358,11 @@ Inject skills into a specific turn on an existing session. The skill content is 
     ```rust
     let result = service.start_turn(&session_id, StartTurnRequest {
         prompt: "Now format the output".into(),
+        event_tx: None,
+        host_mode: false,
         skill_references: Some(vec!["/formatting/markdown".parse()?]),
-        ..Default::default()
+        flow_tool_overlay: None,
+        additional_instructions: None,
     }).await?;
     ```
   </Tab>

--- a/docs/examples/structured-output.mdx
+++ b/docs/examples/structured-output.mdx
@@ -125,12 +125,19 @@ Provide an `output_schema` and the agent will extract validated JSON after the a
     }))?;
 
     let result = service.create_session(CreateSessionRequest {
+        model: "claude-sonnet-4-5".into(),
         prompt: "Tell me about Tokyo".into(),
+        system_prompt: None,
+        max_tokens: None,
+        event_tx: None,
+        host_mode: false,
+        skill_references: None,
+        initial_turn: InitialTurnPolicy::RunImmediately,
         build: Some(SessionBuildOptions {
             output_schema: Some(schema),
             ..Default::default()
         }),
-        ..Default::default()
+        labels: None,
     }).await?;
     println!("{:?}", result.structured_output);
     ```
@@ -219,13 +226,20 @@ When validation fails, the agent retries the extraction turn with error feedback
   <Tab title="Rust">
     ```rust
     let result = service.create_session(CreateSessionRequest {
+        model: "claude-sonnet-4-5".into(),
         prompt: "Extract entities".into(),
+        system_prompt: None,
+        max_tokens: None,
+        event_tx: None,
+        host_mode: false,
+        skill_references: None,
+        initial_turn: InitialTurnPolicy::RunImmediately,
         build: Some(SessionBuildOptions {
             output_schema: Some(schema),
-            structured_output_retries: Some(5),
+            structured_output_retries: 5,
             ..Default::default()
         }),
-        ..Default::default()
+        labels: None,
     }).await?;
     ```
   </Tab>

--- a/docs/examples/tools.mdx
+++ b/docs/examples/tools.mdx
@@ -34,8 +34,8 @@ impl AgentToolDispatcher for MathTools {
         match call.name {
             "add" => {
                 let args: AddArgs = call.parse_args()
-                    .map_err(|e| ToolError::InvalidArguments(e.to_string()))?;
-                Ok(ToolResult::success(call.id, format!("{}", args.a + args.b)))
+                    .map_err(|e| ToolError::invalid_arguments("add", e.to_string()))?;
+                Ok(ToolResult::new(call.id.to_string(), format!("{}", args.a + args.b), false))
             }
             _ => Err(ToolError::not_found(call.name)),
         }

--- a/docs/examples/wasm.mdx
+++ b/docs/examples/wasm.mdx
@@ -107,25 +107,21 @@ close_subscription(sub);
 
 ## Cross-mob comms
 
-Wire ambassadors across mobs for inter-faction communication, then send messages through the comms system.
+Wire ambassadors across mobs for inter-faction communication. The `wire_cross_mob` function establishes trust between members in different mobs so they can exchange messages via the comms system.
 
 ```javascript
 // Wire ambassadors between two mobs
 await wire_cross_mob(mobIdNorth, "ambassador-north", "ambassador-south");
 
-// Send a message through the ambassador's session
-await comms_send(
-  ambassadorSessionId,
-  JSON.stringify({
-    kind: "peer_message",
-    to: "south-faction/operator/ambassador-south",
-    body: "Proposing alliance on the eastern front.",
-  })
+// Send a message to a member (triggers a turn with the message)
+await mob_send_message(mobIdNorth, "ambassador-north",
+  "Send a message to the south faction proposing an alliance on the eastern front."
 );
-
-// Check peers visible to the ambassador
-const peers = JSON.parse(await comms_peers(ambassadorSessionId));
 ```
+
+<Note>
+Direct `comms_send` and `comms_peers` functions are not yet exported as WASM bindings. Inter-agent messaging happens through the comms tools available to agents during their turns (the `send` and `peers` tools).
+</Note>
 
 ## What is available on wasm32
 


### PR DESCRIPTION
## Summary
- Audited all 11 `docs/examples/*.mdx` files against actual codebase source code
- Fixed Rust code examples with incorrect type names, function signatures, struct field names, and non-compiling patterns
- Fixed event JSON schemas with wrong field names (`backoff_ms` -> `delay_ms`, `limit_type` -> `budget_type`, etc.)
- Fixed hook point names to match actual `HookPoint` enum serde names (`pre_llm_call` -> `pre_llm_request`, etc.)
- Replaced `..Default::default()` on `CreateSessionRequest` (which does not implement Default) with explicit field initialization
- Corrected WASM docs to note that `comms_send`/`comms_peers` are not yet exported as bindings

## Test plan
- [x] `cargo test --workspace --lib --bins --tests` passes (2 pre-existing flaky realm lock tests excluded)
- [x] Documentation-only changes -- no code modified
- [x] Each fix verified against actual source code (struct definitions, enum variants, function signatures)

🤖 Generated with [Claude Code](https://claude.com/claude-code)