### PR TITLE
Fix CLI and concept docs against actual codebase

### DIFF
--- a/docs/cli/commands.mdx
+++ b/docs/cli/commands.mdx
@@ -119,7 +119,7 @@ tail -f app.log | rkat run --host --stdin "Monitor incidents and alert on anomal
 
 When `--stdin` is set, batch context injection is skipped so stdin remains available for the event reader.
 
-When `--enable-mob` (`-M`) is passed, `run` composes the consolidated mob tool surface (backed by `meerkat-mob-mcp`) into the agent tool list (`mob_create`, `mob_list`, `mob_lifecycle`, `meerkat_spawn`, `meerkat_retire`, `meerkat_wire`, `send`, `meerkat_list`, `mob_events`, `mob_run_flow`, `mob_flow_status`, `mob_cancel_flow`).
+When `--enable-mob` (`-M`) is passed, `run` composes the consolidated mob tool surface (backed by `meerkat-mob-mcp`) into the agent tool list (`mob_create`, `mob_list`, `mob_lifecycle`, `mob_events`, `mob_run_flow`, `mob_flow_status`, `mob_cancel_flow`, `meerkat_spawn`, `meerkat_retire`, `meerkat_list`, `meerkat_wire`, `meerkat_message`, `mob_respawn`, `mob_inject_and_subscribe`).
 Mob tools are opt-in and disabled by default. When enabled, they are available even when built-ins are disabled.
 
 For mob workflows, this tool path is the primary CLI UX:
@@ -149,7 +149,7 @@ rkat resume 019c8b99 "keep going"                # short prefix match
 
 Session identifiers accept full UUIDs, short prefixes (git-style, fails on ambiguity), or relative aliases (`last`/`~`/`~N`). All scoped to the active realm.
 
-Like `run`, `resume` composes the mob tool surface when `--enable-mob` (`-M`) is passed.
+Mob tools are inherited from the original session configuration; `resume` does not accept `--enable-mob`.
 
 ## continue
 

--- a/docs/cli/configuration.mdx
+++ b/docs/cli/configuration.mdx
@@ -86,7 +86,7 @@ Project servers override user servers with the same name.
 |------|---------|
 | 0 | Success |
 | 1 | Internal error |
-| 2 | Budget exhausted |
+| 2 | Budget exhausted (CLI) or invalid params (contracts) |
 | 10 | Session not found |
 | 11 | Session busy |
 | 12 | Session not running |

--- a/docs/concepts/providers.mdx
+++ b/docs/concepts/providers.mdx
@@ -81,18 +81,18 @@ When using Meerkat as a Rust library, enable only the providers you need:
 | Feature | Description | Default |
 |---------|-------------|---------|
 | `anthropic` | Anthropic Claude support | Yes |
-| `openai` | OpenAI GPT support | No |
-| `gemini` | Google Gemini support | No |
-| `all-providers` | All LLM providers | No |
+| `openai` | OpenAI GPT support | Yes |
+| `gemini` | Google Gemini support | Yes |
+| `all-providers` | All LLM providers (convenience alias) | No |
 
 <CodeGroup>
 
 ```toml Anthropic only (smallest binary)
-meerkat = { version = "0.2", features = ["anthropic", "jsonl-store"] }
+meerkat = { version = "0.4", features = ["anthropic", "jsonl-store"] }
 ```
 
 ```toml All providers
-meerkat = { version = "0.2", features = ["all-providers", "jsonl-store"] }
+meerkat = { version = "0.4", features = ["all-providers", "jsonl-store"] }
 ```
 
 </CodeGroup>

--- a/docs/concepts/tools.mdx
+++ b/docs/concepts/tools.mdx
@@ -34,8 +34,8 @@ impl AgentToolDispatcher for MathTools {
         match call.name {
             "add" => {
                 let args: AddArgs = call.parse_args()
-                    .map_err(|e| ToolError::InvalidArguments(e.to_string()))?;
-                Ok(ToolResult::success(call.id, format!("{}", args.a + args.b)))
+                    .map_err(|e| ToolError::invalid_arguments(call.name, e.to_string()))?;
+                Ok(ToolResult::new(call.id.to_string(), format!("{}", args.a + args.b), false))
             }
             _ => Err(ToolError::not_found(call.name)),
         }
@@ -121,7 +121,7 @@ Tools from different sources (custom, MCP, built-in) are composed into a single 
 Mob tools (`mob_*`) are provided by the `meerkat-mob-mcp` dispatcher and composed
 through `SessionBuildOptions.external_tools`.
 
-- CLI `run`/`resume` pre-compose this dispatcher by default.
+- CLI `run` composes this dispatcher when `--enable-mob` (`-M`) is passed (opt-in, disabled by default).
 - `rkat mob ...` remains the explicit direct lifecycle surface.
 - Other session-driven surfaces (RPC/REST/MCP/SDK hosts) can expose the same `mob_*`
   capability by composing `MobMcpDispatcher` into their session build path.


### PR DESCRIPTION
## Summary
- **commands.mdx**: Correct mob tool names (`send` -> `meerkat_message`, add `mob_respawn` and `mob_inject_and_subscribe`). Fix incorrect claim that `resume` accepts `--enable-mob`.
- **configuration.mdx**: Disambiguate exit code 2 (CLI uses it for budget exhausted, contracts map it to InvalidParams).
- **providers.mdx**: Fix feature flag defaults (`openai` and `gemini` are both enabled by default, not opt-in). Update crate version from `0.2` to `0.4`.
- **tools.mdx**: Fix code example to use actual API (`ToolError::invalid_arguments` and `ToolResult::new` instead of non-existent `ToolError::InvalidArguments` tuple variant and `ToolResult::success`). Correct mob tools section from "pre-compose by default" to opt-in via `--enable-mob`.

## Test plan
- [x] All changes are documentation-only (.mdx files)
- [x] Verified each fix against source code (meerkat-cli/src/main.rs, meerkat-core/src/config.rs, meerkat-core/src/error.rs, meerkat-mob-mcp/src/lib.rs, meerkat/Cargo.toml)
- [x] `cargo test --workspace --lib --bins --tests` passes (0 failures)

🤖 Generated with [Claude Code](https://claude.com/claude-code)