### PR TITLE
Fix inaccuracies in guide documentation

### DIFF
--- a/docs/guides/comms.mdx
+++ b/docs/guides/comms.mdx
@@ -118,6 +118,7 @@ pub struct TrustedPeer {
     pub name: String,     // Human-readable name (used by tools)
     pub pubkey: PubKey,   // Ed25519 public key
     pub addr: String,     // Address: "uds://...", "tcp://...", or "inproc://..."
+    pub meta: PeerMeta,   // Friendly metadata for peer discovery (description, labels)
 }
 ```
 

--- a/docs/guides/mobs.mdx
+++ b/docs/guides/mobs.mdx
@@ -149,9 +149,9 @@ A mob definition is a JSON or TOML document that declares everything: profiles, 
 | Prefab | Pattern | Profiles |
 |--------|---------|----------|
 | `coding_swarm` | Lead + workers for coding tasks | lead, worker |
-| `research_team` | Diverge/converge research | lead, researcher |
-| `pipeline` | Sequential stage handoffs | stages |
-| `review_board` | Multi-reviewer consensus | author, reviewer |
+| `code_review` | Multi-reviewer code audits | lead, worker |
+| `research_team` | Diverge/converge research | lead, worker |
+| `pipeline` | Sequential stage handoffs | lead, worker |
 
 Prefabs are starting points — create from a prefab, then customize.
 
@@ -201,7 +201,7 @@ When mob capability is enabled on a session, the agent gets these tools:
 | `mob_cancel_flow` | `mob_id`, `run_id` | Cancel a running flow |
 | `meerkat_spawn` | `mob_id`, `specs[]` | Spawn members (batch) |
 | `meerkat_retire` | `mob_id`, `meerkat_id` | Remove a member |
-| `meerkat_wire` | `mob_id`, `a`, `b` | Establish comms channel |
+| `meerkat_wire` | `mob_id`, `a`, `b`, `action` | Wire or unwire comms channel (`action`: `"wire"` or `"unwire"`) |
 | `meerkat_list` | `mob_id` | List members and state |
 | `meerkat_message` | `mob_id`, `meerkat_id`, `message` | Send a turn to a member |
 

--- a/docs/guides/skills.mdx
+++ b/docs/guides/skills.mdx
@@ -292,18 +292,18 @@ When multiple sources provide a skill with the same ID, the first source wins (p
 [
   {
     "id": "task-workflow",
-    "name": "Task Workflow",
-    "scope": "builtin",
-    "source": "embedded",
+    "name": "Custom Task Workflow",
+    "scope": "project",
+    "source": "company",
     "is_active": true
   },
   {
     "id": "task-workflow",
-    "name": "Custom Task Workflow",
-    "scope": "project",
-    "source": "company",
+    "name": "Task Workflow",
+    "scope": "builtin",
+    "source": "embedded",
     "is_active": false,
-    "shadowed_by": "embedded"
+    "shadowed_by": "company"
   }
 ]
 ```


### PR DESCRIPTION
## Summary
- **mobs.mdx**: Fix prefab table — rename `review_board` to `code_review` (matching `Prefab::CodeReview` in source), correct profile names to `lead, worker` for all four prefabs (all use the same pair), and add missing `action` parameter to `meerkat_wire` tool description (the tool handles both wire and unwire via the `action` field)
- **skills.mdx**: Fix shadowing example — project-scoped skills take precedence over embedded per the documented resolution order (project > user > git > http > embedded), so the project skill should be `is_active: true` and the embedded one should show `shadowed_by: "company"`
- **comms.mdx**: Add missing `meta: PeerMeta` field to `TrustedPeer` struct example (the field has existed since peer metadata support was added)

## Test plan
- [x] All changes are documentation-only (no code changes)
- [x] Verified each fix against source code (`meerkat-mob/src/prefab.rs`, `meerkat-mob-mcp/src/lib.rs`, `meerkat-core/src/skills/mod.rs`, `meerkat-comms/src/trust.rs`)
- [x] `cargo test --workspace --lib --bins --tests` passes with 0 failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)