### PR TITLE
revert: undo admin-merged MCP connect timeout (#107)

### DIFF
--- a/meerkat-core/src/agent.rs
+++ b/meerkat-core/src/agent.rs
@@ -118,32 +118,6 @@ impl LlmStreamResult {
     }
 }
 
-/// A notice about an externally-completed tool configuration change.
-///
-/// Produced by background MCP connection tasks and consumed by the agent loop.
-#[derive(Debug, Clone)]
-pub struct ExternalToolNotice {
-    /// Server or source name.
-    pub server: String,
-    /// What kind of operation completed.
-    pub operation: crate::event::ToolConfigChangeOperation,
-    /// Human-readable status (e.g. "activated", "failed").
-    pub status: String,
-    /// Number of tools provided (on success).
-    pub tool_count: Option<usize>,
-}
-
-/// Result of polling for external tool updates.
-///
-/// Returned by [`AgentToolDispatcher::poll_external_updates`].
-#[derive(Debug, Clone, Default)]
-pub struct ExternalToolUpdate {
-    /// Notices about completed background operations since last poll.
-    pub notices: Vec<ExternalToolNotice>,
-    /// Names of servers still connecting in the background.
-    pub pending: Vec<String>,
-}
-
 /// Trait for tool dispatchers
 #[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
 #[cfg_attr(not(target_arch = "wasm32"), async_trait)]
@@ -153,15 +127,6 @@ pub trait AgentToolDispatcher: Send + Sync {
     /// Execute a tool call
     async fn dispatch(&self, call: ToolCallView<'_>)
     -> Result<ToolResult, crate::error::ToolError>;
-
-    /// Poll for external tool updates from background operations (e.g. async MCP loading).
-    ///
-    /// The default implementation returns an empty update. Implementations that
-    /// support background tool loading (like `McpRouterAdapter`) override this
-    /// to drain completed results and report pending servers.
-    async fn poll_external_updates(&self) -> ExternalToolUpdate {
-        ExternalToolUpdate::default()
-    }
 }
 
 /// A tool dispatcher that filters tools based on a policy
@@ -211,10 +176,6 @@ impl<T: AgentToolDispatcher + ?Sized + 'static> AgentToolDispatcher for Filtered
             return Err(crate::error::ToolError::access_denied(call.name));
         }
         self.inner.dispatch(call).await
-    }
-
-    async fn poll_external_updates(&self) -> ExternalToolUpdate {
-        self.inner.poll_external_updates().await
     }
 }
 

--- a/meerkat-core/src/agent/state.rs
+++ b/meerkat-core/src/agent/state.rs
@@ -187,41 +187,7 @@ where
 
             match self.state {
                 LoopState::CallingLlm => {
-                    // 1. Poll external updates BEFORE tool capture so newly
-                    //    connected tools are visible in the same LLM call.
-                    let ext = self.tools.poll_external_updates().await;
-
-                    // 2. Emit ToolConfigChanged for completed background connections.
-                    for notice in &ext.notices {
-                        emit_event!(AgentEvent::ToolConfigChanged {
-                            payload: ToolConfigChangedPayload {
-                                operation: notice.operation.clone(),
-                                target: notice.server.clone(),
-                                status: notice.status.clone(),
-                                persisted: false,
-                                applied_at_turn: Some(turn_count),
-                            },
-                        });
-                    }
-
-                    // 3. Manage [MCP_PENDING] notice lifecycle.
-                    //    Always strip prior synthetic notices to avoid stale state.
-                    //    Uses starts_with on a strict prefix to avoid matching user text.
-                    const MCP_PENDING_PREFIX: &str = "[SYSTEM NOTICE][MCP_PENDING] ";
-                    self.session.messages_mut().retain(
-                        |m| !matches!(m, Message::User(u) if u.content.starts_with(MCP_PENDING_PREFIX)),
-                    );
-                    if !ext.pending.is_empty() {
-                        self.session.push(Message::User(UserMessage {
-                            content: format!(
-                                "{MCP_PENDING_PREFIX}Servers connecting: {}. \
-                                 Tools will appear when ready.",
-                                ext.pending.join(", ")
-                            ),
-                        }));
-                    }
-
-                    // 4. Apply tool scope staged updates atomically at the CallingLlm boundary.
+                    // Apply tool scope staged updates atomically at the CallingLlm boundary.
                     let tool_defs = {
                         let dispatcher_tools = self.tools.tools();
                         match self.tool_scope.apply_staged(dispatcher_tools.clone()) {

--- a/meerkat-core/src/gateway.rs
+++ b/meerkat-core/src/gateway.rs
@@ -29,7 +29,6 @@
 //! ```
 
 use crate::AgentToolDispatcher;
-use crate::agent::{ExternalToolNotice, ExternalToolUpdate};
 use crate::error::ToolError;
 #[cfg(target_arch = "wasm32")]
 use crate::tokio;
@@ -365,42 +364,6 @@ impl AgentToolDispatcher for ToolGateway {
         }
 
         entry.dispatcher.dispatch(call).await
-    }
-
-    /// Aggregate external updates across all dispatcher entries.
-    ///
-    /// Deduplicates by server name for pending, by `(server, operation, status)`
-    /// for notices. First-seen wins, stable order.
-    async fn poll_external_updates(&self) -> ExternalToolUpdate {
-        let mut all_notices: Vec<ExternalToolNotice> = Vec::new();
-        let mut all_pending: Vec<String> = Vec::new();
-        let mut seen_pending: std::collections::HashSet<String> = std::collections::HashSet::new();
-        let mut seen_notices: std::collections::HashSet<(String, String, String)> =
-            std::collections::HashSet::new();
-
-        for entry in &self.entries {
-            let update = entry.dispatcher.poll_external_updates().await;
-            for notice in update.notices {
-                let key = (
-                    notice.server.clone(),
-                    format!("{:?}", notice.operation),
-                    notice.status.clone(),
-                );
-                if seen_notices.insert(key) {
-                    all_notices.push(notice);
-                }
-            }
-            for pending in update.pending {
-                if seen_pending.insert(pending.clone()) {
-                    all_pending.push(pending);
-                }
-            }
-        }
-
-        ExternalToolUpdate {
-            notices: all_notices,
-            pending: all_pending,
-        }
     }
 }
 

--- a/meerkat-core/src/lib.rs
+++ b/meerkat-core/src/lib.rs
@@ -55,7 +55,7 @@ pub mod types;
 // Re-export main types at crate root
 pub use agent::{
     Agent, AgentBuilder, AgentLlmClient, AgentRunner, AgentSessionStore, AgentToolDispatcher,
-    CommsRuntime, ExternalToolNotice, ExternalToolUpdate, FilteredToolDispatcher, LlmStreamResult,
+    CommsRuntime, FilteredToolDispatcher, LlmStreamResult,
 };
 pub use budget::{Budget, BudgetLimits, BudgetPool};
 pub use checkpoint::SessionCheckpointer;

--- a/meerkat-core/src/mcp_config.rs
+++ b/meerkat-core/src/mcp_config.rs
@@ -88,10 +88,6 @@ pub struct McpServerConfig {
     /// Transport configuration (stdio or HTTP)
     #[serde(flatten)]
     pub transport: McpTransportConfig,
-    /// Connection timeout in seconds (connect + handshake + list_tools).
-    /// Defaults to 10 seconds when not specified.
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub connect_timeout_secs: Option<u32>,
 }
 
 impl McpServerConfig {
@@ -108,7 +104,6 @@ impl McpServerConfig {
                 args,
                 env,
             }),
-            connect_timeout_secs: None,
         }
     }
 
@@ -124,7 +119,6 @@ impl McpServerConfig {
                 headers,
                 transport: None,
             }),
-            connect_timeout_secs: None,
         }
     }
 
@@ -140,7 +134,6 @@ impl McpServerConfig {
                 headers,
                 transport: Some(McpHttpTransport::Sse),
             }),
-            connect_timeout_secs: None,
         }
     }
 
@@ -412,7 +405,6 @@ where
     Ok(McpServerConfig {
         name: server.name,
         transport,
-        connect_timeout_secs: server.connect_timeout_secs,
     })
 }
 

--- a/meerkat-mcp/src/adapter.rs
+++ b/meerkat-mcp/src/adapter.rs
@@ -2,16 +2,13 @@
 
 use async_trait::async_trait;
 use meerkat_core::error::ToolError;
-use meerkat_core::{
-    ExternalToolUpdate, ToolCallView, ToolDef, ToolResult, agent::AgentToolDispatcher,
-};
+use meerkat_core::{ToolCallView, ToolDef, ToolResult, agent::AgentToolDispatcher};
 use serde_json::Value;
 use std::sync::Arc;
-use std::sync::atomic::{AtomicBool, Ordering};
 use std::time::Duration;
 use tokio::sync::RwLock;
 
-use crate::{McpApplyResult, McpReloadTarget, McpRouter, McpServerConfig};
+use crate::{McpApplyDelta, McpReloadTarget, McpRouter, McpServerConfig};
 
 /// Adapter that wraps an [`McpRouter`] to implement [`AgentToolDispatcher`].
 ///
@@ -21,16 +18,13 @@ use crate::{McpApplyResult, McpReloadTarget, McpRouter, McpServerConfig};
 pub struct McpRouterAdapter {
     router: RwLock<Option<McpRouter>>,
     cached_tools: RwLock<Arc<[Arc<ToolDef>]>>,
-    has_pending: AtomicBool,
 }
 
 impl McpRouterAdapter {
     pub fn new(router: McpRouter) -> Self {
-        let has_pending = router.has_pending_or_notices();
         Self {
             router: RwLock::new(Some(router)),
             cached_tools: RwLock::new(Arc::from([])),
-            has_pending: AtomicBool::new(has_pending),
         }
     }
 
@@ -54,7 +48,6 @@ impl McpRouterAdapter {
         if let Some(router) = router.take() {
             router.shutdown().await;
         }
-        self.has_pending.store(false, Ordering::Release);
     }
 
     /// Stage an MCP server add operation.
@@ -97,27 +90,23 @@ impl McpRouterAdapter {
     }
 
     /// Apply staged MCP operations and refresh the visible tool cache.
-    pub async fn apply_staged(&self) -> Result<McpApplyResult, String> {
+    pub async fn apply_staged(&self) -> Result<McpApplyDelta, String> {
         let mut router = self.router.write().await;
         let router = router
             .as_mut()
             .ok_or_else(|| "MCP router has been shut down".to_string())?;
-        let result = router
+        let delta = router
             .apply_staged()
             .await
             .map_err(|error| error.to_string())?;
         let tools: Arc<[Arc<ToolDef>]> = router.list_tools().to_vec().into();
         let mut cached = self.cached_tools.write().await;
         *cached = tools;
-        self.has_pending.store(
-            result.pending_count > 0 || router.has_pending_or_notices(),
-            Ordering::Release,
-        );
-        Ok(result)
+        Ok(delta)
     }
 
     /// Progress only Removing server finalization (drain/timeout) without applying staged ops.
-    pub async fn progress_removals(&self) -> Result<crate::McpApplyDelta, String> {
+    pub async fn progress_removals(&self) -> Result<McpApplyDelta, String> {
         let mut router = self.router.write().await;
         let router = router
             .as_mut()
@@ -169,6 +158,9 @@ impl McpRouterAdapter {
 #[async_trait]
 impl AgentToolDispatcher for McpRouterAdapter {
     fn tools(&self) -> Arc<[Arc<ToolDef>]> {
+        // Return the cached tools (blocking read in sync context).
+        // Requires refresh_tools() to be called before first use.
+        // Uses try_read to avoid deadlocks, falling back to empty vec.
         match self.cached_tools.try_read() {
             Ok(tools) => Arc::clone(&tools),
             Err(_) => Arc::from([]),
@@ -193,32 +185,5 @@ impl AgentToolDispatcher for McpRouterAdapter {
             }
             None => Err(ToolError::execution_failed("MCP router has been shut down")),
         }
-    }
-
-    async fn poll_external_updates(&self) -> ExternalToolUpdate {
-        // Fast path: skip write lock if nothing is pending.
-        if !self.has_pending.load(Ordering::Acquire) {
-            return ExternalToolUpdate::default();
-        }
-
-        let mut router = self.router.write().await;
-        let Some(router) = router.as_mut() else {
-            return ExternalToolUpdate::default();
-        };
-
-        let update = router.take_external_updates();
-
-        // Refresh tool cache since new tools may have become visible.
-        if !update.notices.is_empty() {
-            let tools: Arc<[Arc<ToolDef>]> = router.list_tools().to_vec().into();
-            let mut cached = self.cached_tools.write().await;
-            *cached = tools;
-        }
-
-        self.has_pending.store(
-            !update.pending.is_empty() || router.has_pending_or_notices(),
-            Ordering::Release,
-        );
-        update
     }
 }

--- a/meerkat-mcp/src/connection.rs
+++ b/meerkat-mcp/src/connection.rs
@@ -15,12 +15,11 @@ use rmcp::{
     transport::TokioChildProcess,
 };
 use serde_json::Value;
-use std::sync::Arc;
-use std::time::Duration;
 use tokio::process::Command;
 
 /// Connection to an MCP server
 pub struct McpConnection {
+    #[allow(dead_code)]
     config: McpServerConfig,
     service: RunningService<RoleClient, ()>,
 }
@@ -90,46 +89,6 @@ impl McpConnection {
             config: config.clone(),
             service,
         })
-    }
-
-    /// Default connection timeout in seconds.
-    pub const DEFAULT_CONNECT_TIMEOUT_SECS: u32 = 10;
-
-    /// Connect to an MCP server, perform handshake, and enumerate tools in a
-    /// single timeout-bounded operation.
-    ///
-    /// This is the preferred entry point for all add/reload paths. The timeout
-    /// covers connect + initialize handshake + list_tools as a single budget.
-    pub async fn connect_and_enumerate(
-        config: &McpServerConfig,
-    ) -> Result<(Self, Vec<Arc<ToolDef>>), McpError> {
-        let timeout_secs = config
-            .connect_timeout_secs
-            .unwrap_or(Self::DEFAULT_CONNECT_TIMEOUT_SECS);
-        let timeout = Duration::from_secs(timeout_secs as u64);
-
-        tokio::time::timeout(timeout, async {
-            let conn = Self::connect(config).await?;
-            let tools = conn
-                .list_tools()
-                .await?
-                .into_iter()
-                .map(Arc::new)
-                .collect::<Vec<_>>();
-            Ok((conn, tools))
-        })
-        .await
-        .map_err(|_| McpError::ConnectionFailed {
-            reason: format!(
-                "Timed out connecting to '{}' ({timeout_secs}s)",
-                config.name
-            ),
-        })?
-    }
-
-    /// Get the config used to create this connection.
-    pub fn config(&self) -> &McpServerConfig {
-        &self.config
     }
 
     /// Get server info

--- a/meerkat-mcp/src/lib.rs
+++ b/meerkat-mcp/src/lib.rs
@@ -14,8 +14,7 @@ pub use connection::McpConnection;
 pub use error::McpError;
 pub use protocol::McpProtocol;
 pub use router::{
-    McpApplyDelta, McpApplyResult, McpLifecycleAction, McpReloadTarget, McpRouter,
-    McpServerLifecycleState,
+    McpApplyDelta, McpLifecycleAction, McpReloadTarget, McpRouter, McpServerLifecycleState,
 };
 
 // Re-export McpServerConfig from meerkat-core for backwards compatibility

--- a/meerkat-mcp/src/router.rs
+++ b/meerkat-mcp/src/router.rs
@@ -4,19 +4,15 @@ use crate::{McpConnection, McpError, McpServerConfig};
 use async_trait::async_trait;
 use meerkat_core::AgentToolDispatcher;
 use meerkat_core::error::ToolError;
-use meerkat_core::event::ToolConfigChangeOperation;
 use meerkat_core::types::ToolDef;
 use meerkat_core::types::{ToolCallView, ToolResult};
-use meerkat_core::{ExternalToolNotice, ExternalToolUpdate};
 use serde_json::Value;
-use std::collections::{HashMap, VecDeque};
+use std::collections::HashMap;
+use std::sync::Arc;
 use std::sync::atomic::{AtomicUsize, Ordering};
-use std::sync::{Arc, Mutex};
 use std::time::{Duration, Instant};
-use tokio::sync::mpsc;
 
 const DEFAULT_REMOVAL_TIMEOUT: Duration = Duration::from_secs(30);
-const PENDING_CHANNEL_CAPACITY: usize = 32;
 
 /// MCP server lifecycle state used by staged router apply.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -65,20 +61,11 @@ impl From<McpServerConfig> for McpReloadTarget {
 }
 
 /// Lifecycle actions emitted by [`McpRouter::apply_staged`].
-///
-/// Only **synchronous** actions appear here. Async completions (activated,
-/// activation failed) go through [`McpRouter::take_external_updates`].
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum McpLifecycleAction {
-    /// Server connection is being attempted in the background (add or reload).
-    PendingConnect { server: String },
-    /// Server has been activated (synchronous backward-compat path only).
     Activated { server: String },
-    /// Server removal drain started.
     RemovingStarted { server: String },
-    /// Server fully removed.
     Removed { server: String, degraded: bool },
-    /// Server reload completed (synchronous backward-compat path only).
     Reloaded { server: String },
 }
 
@@ -90,30 +77,6 @@ pub struct McpApplyDelta {
     pub reloaded_servers: Vec<String>,
     pub lifecycle_actions: Vec<McpLifecycleAction>,
     pub degraded_removals: Vec<String>,
-}
-
-/// Return value of [`McpRouter::apply_staged`].
-#[derive(Debug)]
-pub struct McpApplyResult {
-    pub delta: McpApplyDelta,
-    pub pending_count: usize,
-}
-
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-enum PendingOp {
-    Add,
-    Reload,
-}
-
-struct PendingState {
-    generation: u64,
-}
-
-struct PendingResult {
-    server_name: String,
-    generation: u64,
-    op: PendingOp,
-    result: Result<(McpConnection, Vec<Arc<ToolDef>>), McpError>,
 }
 
 #[derive(Debug, Clone)]
@@ -154,11 +117,7 @@ impl Drop for InflightCallGuard<'_> {
     }
 }
 
-/// Router for MCP tool calls across multiple servers.
-///
-/// Add and reload operations are non-blocking: `apply_staged()` spawns
-/// background connection tasks and returns immediately. Completions are
-/// delivered via [`take_external_updates`](Self::take_external_updates).
+/// Router for MCP tool calls across multiple servers
 pub struct McpRouter {
     servers: HashMap<String, ServerEntry>,
     /// Maps tool name to owning server, including servers in Removing state.
@@ -167,32 +126,17 @@ pub struct McpRouter {
     cached_tools: Vec<Arc<ToolDef>>,
     staged_ops: Vec<StagedRouterOp>,
     removal_timeout: Duration,
-
-    // --- Async pending infrastructure ---
-    pending_tx: mpsc::Sender<PendingResult>,
-    /// Poison-safe mutex wrapping the receiver.
-    pending_rx: Mutex<mpsc::Receiver<PendingResult>>,
-    pending_servers: HashMap<String, PendingState>,
-    next_generation: u64,
-    /// Queued notices for the agent loop (from async completions).
-    completed_updates: VecDeque<ExternalToolNotice>,
 }
 
 impl McpRouter {
     /// Create a new empty router
     pub fn new() -> Self {
-        let (tx, rx) = mpsc::channel(PENDING_CHANNEL_CAPACITY);
         Self {
             servers: HashMap::new(),
             tool_to_server: HashMap::new(),
             cached_tools: Vec::new(),
             staged_ops: Vec::new(),
             removal_timeout: DEFAULT_REMOVAL_TIMEOUT,
-            pending_tx: tx,
-            pending_rx: Mutex::new(rx),
-            pending_servers: HashMap::new(),
-            next_generation: 0,
-            completed_updates: VecDeque::new(),
         }
     }
 
@@ -214,9 +158,8 @@ impl McpRouter {
     /// Prefer [`stage_add`](Self::stage_add) + [`apply_staged`](Self::apply_staged)
     /// for boundary semantics.
     pub async fn add_server(&mut self, config: McpServerConfig) -> Result<(), McpError> {
-        // Use the synchronous install path for backward compatibility.
-        self.install_active_server(config).await?;
-        self.rebuild_visible_cache();
+        self.stage_add(config);
+        self.apply_staged().await?;
         Ok(())
     }
 
@@ -238,39 +181,33 @@ impl McpRouter {
         self.staged_ops.push(StagedRouterOp::Reload(target.into()));
     }
 
-    /// Apply staged operations at a boundary (non-blocking for add/reload).
-    ///
-    /// Add and reload operations spawn background connection tasks and return
-    /// immediately with `PendingConnect` in the lifecycle actions. Completions
-    /// arrive via [`take_external_updates`](Self::take_external_updates).
-    ///
-    /// Remove operations are synchronous (start drain immediately).
-    pub async fn apply_staged(&mut self) -> Result<McpApplyResult, McpError> {
+    /// Apply staged operations at a boundary and return structural/lifecycle delta.
+    pub async fn apply_staged(&mut self) -> Result<McpApplyDelta, McpError> {
         let mut delta = McpApplyDelta::default();
         let staged_ops = std::mem::take(&mut self.staged_ops);
-
-        // 1. Drain pending results from background tasks.
-        self.drain_pending();
 
         for op in staged_ops {
             match op {
                 StagedRouterOp::Add(config) => {
                     let server_name = config.name.clone();
+                    let existed = self.servers.get(&server_name).is_some_and(|entry| {
+                        !matches!(entry.lifecycle, McpServerLifecycleState::Removed)
+                    });
+                    self.install_active_server(config).await?;
 
-                    // Cancel any existing pending op for this server.
-                    self.pending_servers.remove(&server_name);
-
-                    self.spawn_pending(config, PendingOp::Add);
-                    delta
-                        .lifecycle_actions
-                        .push(McpLifecycleAction::PendingConnect {
+                    if existed {
+                        delta.reloaded_servers.push(server_name.clone());
+                        delta.lifecycle_actions.push(McpLifecycleAction::Reloaded {
                             server: server_name,
                         });
+                    } else {
+                        delta.added_servers.push(server_name.clone());
+                        delta.lifecycle_actions.push(McpLifecycleAction::Activated {
+                            server: server_name,
+                        });
+                    }
                 }
                 StagedRouterOp::Remove(server_name) => {
-                    // Cancel pending for same server if any.
-                    self.pending_servers.remove(&server_name);
-
                     if let Some(entry) = self.servers.get_mut(&server_name)
                         && matches!(entry.lifecycle, McpServerLifecycleState::Active)
                     {
@@ -299,17 +236,11 @@ impl McpRouter {
                     };
 
                     let server_name = config.name.clone();
-
-                    // Cancel any existing pending op for this server.
-                    self.pending_servers.remove(&server_name);
-
-                    // Keep old connection active during reload.
-                    self.spawn_pending(config, PendingOp::Reload);
-                    delta
-                        .lifecycle_actions
-                        .push(McpLifecycleAction::PendingConnect {
-                            server: server_name,
-                        });
+                    self.install_active_server(config).await?;
+                    delta.reloaded_servers.push(server_name.clone());
+                    delta.lifecycle_actions.push(McpLifecycleAction::Reloaded {
+                        server: server_name,
+                    });
                 }
             }
         }
@@ -317,201 +248,17 @@ impl McpRouter {
         self.process_removals(&mut delta).await;
         self.rebuild_visible_cache();
 
-        let pending_count = self.pending_servers.len();
-        Ok(McpApplyResult {
-            delta,
-            pending_count,
-        })
-    }
-
-    /// Spawn a background task to connect and enumerate tools for a server.
-    fn spawn_pending(&mut self, config: McpServerConfig, op: PendingOp) {
-        let generation = self.next_generation;
-        self.next_generation += 1;
-
-        let server_name = config.name.clone();
-        self.pending_servers
-            .insert(server_name.clone(), PendingState { generation });
-
-        let tx = self.pending_tx.clone();
-        tokio::spawn(async move {
-            let result = McpConnection::connect_and_enumerate(&config).await;
-            // Channel may be closed if router was dropped — that's fine.
-            let _ = tx
-                .send(PendingResult {
-                    server_name,
-                    generation,
-                    op,
-                    result,
-                })
-                .await;
-        });
-    }
-
-    /// Drain completed pending results from the background channel.
-    fn drain_pending(&mut self) {
-        // Collect results under the lock, then process outside to avoid
-        // holding the MutexGuard across &mut self calls.
-        let results: Vec<PendingResult> = {
-            let mut rx = match self.pending_rx.lock() {
-                Ok(guard) => guard,
-                Err(poisoned) => {
-                    tracing::warn!(
-                        "MCP pending_rx mutex was poisoned; recovering. \
-                         Router state may be inconsistent."
-                    );
-                    poisoned.into_inner()
-                }
-            };
-            let mut buf = Vec::new();
-            while let Ok(result) = rx.try_recv() {
-                buf.push(result);
-            }
-            buf
-        };
-        for result in results {
-            self.process_pending_result(result);
-        }
-    }
-
-    fn process_pending_result(&mut self, result: PendingResult) {
-        // Check generation matches — discard stale results.
-        let current = self.pending_servers.get(&result.server_name);
-        let is_current = current
-            .map(|ps| ps.generation == result.generation)
-            .unwrap_or(false);
-
-        if !is_current {
-            tracing::debug!(
-                server = %result.server_name,
-                generation = result.generation,
-                "Discarding stale pending MCP result"
-            );
-            // Close the connection if it was successful.
-            if let Ok((conn, _)) = result.result {
-                let server_name = result.server_name;
-                tokio::spawn(async move {
-                    if let Err(e) = conn.close().await {
-                        tracing::debug!(
-                            "Error closing stale MCP connection '{}': {}",
-                            server_name,
-                            e
-                        );
-                    }
-                });
-            }
-            return;
-        }
-
-        // Remove from pending.
-        self.pending_servers.remove(&result.server_name);
-
-        match result.result {
-            Ok((conn, tools)) => {
-                let tool_count = tools.len();
-                let server_name = result.server_name.clone();
-
-                // Determine operation type for event.
-                let operation = match result.op {
-                    PendingOp::Add => ToolConfigChangeOperation::Add,
-                    PendingOp::Reload => ToolConfigChangeOperation::Reload,
-                };
-
-                // For reload: close old connection.
-                if result.op == PendingOp::Reload
-                    && let Some(old_entry) = self.servers.get_mut(&server_name)
-                {
-                    let old_conn = old_entry.connection.take();
-                    let name = server_name.clone();
-                    tokio::spawn(async move {
-                        Self::close_entry_connection(name, old_conn).await;
-                    });
-                }
-
-                // Install the new entry (or replace existing).
-                let config = conn.config().clone();
-                let new_entry = ServerEntry {
-                    config,
-                    connection: Some(conn),
-                    lifecycle: McpServerLifecycleState::Active,
-                    tools,
-                    active_calls: AtomicUsize::new(0),
-                };
-
-                if let Some(old_entry) = self.servers.insert(server_name.clone(), new_entry) {
-                    // For Add: close any leftover connection.
-                    if result.op == PendingOp::Add {
-                        let old_name = old_entry.config.name.clone();
-                        let old_conn = old_entry.connection;
-                        tokio::spawn(async move {
-                            Self::close_entry_connection(old_name, old_conn).await;
-                        });
-                    }
-                }
-
-                // Update tool mappings.
-                self.remove_tool_mappings_for_server(&server_name);
-                if let Some(entry) = self.servers.get(&server_name) {
-                    for tool in &entry.tools {
-                        self.tool_to_server
-                            .insert(tool.name.clone(), server_name.clone());
-                    }
-                }
-
-                self.completed_updates.push_back(ExternalToolNotice {
-                    server: server_name,
-                    operation,
-                    status: "activated".to_string(),
-                    tool_count: Some(tool_count),
-                });
-            }
-            Err(err) => {
-                let server_name = result.server_name.clone();
-                let operation = match result.op {
-                    PendingOp::Add => ToolConfigChangeOperation::Add,
-                    PendingOp::Reload => ToolConfigChangeOperation::Reload,
-                };
-
-                tracing::warn!(
-                    server = %server_name,
-                    error = %err,
-                    op = ?result.op,
-                    "MCP server background connection failed"
-                );
-
-                // For reload failure: keep old connection active.
-                // For add failure: nothing to keep.
-
-                self.completed_updates.push_back(ExternalToolNotice {
-                    server: server_name,
-                    operation,
-                    status: format!("failed: {err}"),
-                    tool_count: None,
-                });
-            }
-        }
-    }
-
-    /// Drain pending results and return queued external update notices.
-    ///
-    /// Called by the adapter's `poll_external_updates()` implementation.
-    pub fn take_external_updates(&mut self) -> ExternalToolUpdate {
-        self.drain_pending();
-        self.rebuild_visible_cache();
-
-        ExternalToolUpdate {
-            notices: self.completed_updates.drain(..).collect(),
-            pending: self.pending_servers.keys().cloned().collect(),
-        }
-    }
-
-    /// Returns true if there are pending background operations or undelivered notices.
-    pub fn has_pending_or_notices(&self) -> bool {
-        !self.pending_servers.is_empty() || !self.completed_updates.is_empty()
+        Ok(delta)
     }
 
     async fn install_active_server(&mut self, config: McpServerConfig) -> Result<(), McpError> {
-        let (conn, tools) = McpConnection::connect_and_enumerate(&config).await?;
+        let conn = McpConnection::connect(&config).await?;
+        let tools = conn
+            .list_tools()
+            .await?
+            .into_iter()
+            .map(Arc::new)
+            .collect::<Vec<_>>();
 
         let server_name = config.name.clone();
         let new_entry = ServerEntry {
@@ -661,12 +408,8 @@ impl McpRouter {
         conn.call_tool(name, args).await
     }
 
-    /// Gracefully shutdown all connections.
-    ///
-    /// Drops the pending sender to signal background tasks, then closes
-    /// all active connections.
+    /// Gracefully shutdown all connections
     pub async fn shutdown(self) {
-        drop(self.pending_tx);
         for (_, entry) in self.servers {
             Self::close_entry_connection(entry.config.name, entry.connection).await;
         }
@@ -759,35 +502,27 @@ mod tests {
         };
 
         let mut router = McpRouter::new();
+        router.stage_add(test_server_config("test-server", &server_path));
+        let delta = router.apply_staged().await.expect("apply staged add");
 
-        // Use add_server (synchronous path) for setup.
-        router
-            .add_server(test_server_config("test-server", &server_path))
-            .await
-            .expect("add_server");
-
+        assert_eq!(delta.added_servers, vec!["test-server"]);
+        assert!(delta.removed_servers.is_empty());
         assert!(matches!(
             router.server_lifecycle_state("test-server"),
             Some(McpServerLifecycleState::Active)
         ));
 
-        // Stage reload (async path) and wait for completion.
         router.stage_reload("test-server");
-        let result = router.apply_staged().await.expect("apply staged reload");
-        assert!(result.pending_count > 0 || !result.delta.reloaded_servers.is_empty());
-
-        // Wait for pending to resolve.
-        tokio::time::sleep(Duration::from_millis(500)).await;
-        let ext = router.take_external_updates();
-        assert!(
-            ext.notices.iter().any(|n| n.server == "test-server")
-                || router.server_lifecycle_state("test-server")
-                    == Some(McpServerLifecycleState::Active),
-        );
+        let delta = router.apply_staged().await.expect("apply staged reload");
+        assert_eq!(delta.reloaded_servers, vec!["test-server"]);
+        assert!(matches!(
+            router.server_lifecycle_state("test-server"),
+            Some(McpServerLifecycleState::Active)
+        ));
 
         router.stage_remove("test-server");
-        let result = router.apply_staged().await.expect("apply staged remove");
-        assert_eq!(result.delta.removed_servers, vec!["test-server"]);
+        let delta = router.apply_staged().await.expect("apply staged remove");
+        assert_eq!(delta.removed_servers, vec!["test-server"]);
         assert!(matches!(
             router.server_lifecycle_state("test-server"),
             Some(McpServerLifecycleState::Removed)
@@ -801,10 +536,8 @@ mod tests {
         };
 
         let mut router = McpRouter::new();
-        router
-            .add_server(test_server_config("test-server", &server_path))
-            .await
-            .expect("add_server");
+        router.stage_add(test_server_config("test-server", &server_path));
+        router.apply_staged().await.expect("apply add");
 
         let has_echo_before = router.list_tools().iter().any(|tool| tool.name == "echo");
         assert!(has_echo_before, "tool should be visible before remove");
@@ -823,19 +556,14 @@ mod tests {
         };
 
         let mut router = McpRouter::new_with_removal_timeout(Duration::from_secs(60));
-        router
-            .add_server(test_server_config("test-server", &server_path))
-            .await
-            .expect("add_server");
+        router.stage_add(test_server_config("test-server", &server_path));
+        router.apply_staged().await.expect("apply add");
 
         router.set_inflight_calls_for_testing("test-server", 1);
         router.stage_remove("test-server");
-        let result = router.apply_staged().await.expect("apply remove");
+        let delta = router.apply_staged().await.expect("apply remove");
 
-        assert!(
-            result.delta.removed_servers.is_empty(),
-            "should remain removing"
-        );
+        assert!(delta.removed_servers.is_empty(), "should remain removing");
         assert!(matches!(
             router.server_lifecycle_state("test-server"),
             Some(McpServerLifecycleState::Removing { .. })
@@ -848,13 +576,13 @@ mod tests {
         assert!(matches!(err, McpError::ServerUnavailable { .. }));
 
         router.set_inflight_calls_for_testing("test-server", 0);
-        let result = router
+        let delta = router
             .apply_staged()
             .await
             .expect("apply should finalize drained remove");
 
-        assert_eq!(result.delta.removed_servers, vec!["test-server"]);
-        assert!(result.delta.degraded_removals.is_empty());
+        assert_eq!(delta.removed_servers, vec!["test-server"]);
+        assert!(delta.degraded_removals.is_empty());
     }
 
     #[tokio::test]
@@ -864,22 +592,20 @@ mod tests {
         };
 
         let mut router = McpRouter::new_with_removal_timeout(Duration::from_millis(10));
-        router
-            .add_server(test_server_config("test-server", &server_path))
-            .await
-            .expect("add_server");
+        router.stage_add(test_server_config("test-server", &server_path));
+        router.apply_staged().await.expect("apply add");
 
         router.set_inflight_calls_for_testing("test-server", 1);
         router.stage_remove("test-server");
-        let result = router.apply_staged().await.expect("apply remove start");
-        assert!(result.delta.removed_servers.is_empty());
+        let delta = router.apply_staged().await.expect("apply remove start");
+        assert!(delta.removed_servers.is_empty());
 
         tokio::time::sleep(Duration::from_millis(30)).await;
-        let result = router.apply_staged().await.expect("apply timeout finalize");
+        let delta = router.apply_staged().await.expect("apply timeout finalize");
 
-        assert_eq!(result.delta.removed_servers, vec!["test-server"]);
-        assert_eq!(result.delta.degraded_removals, vec!["test-server"]);
-        assert!(result.delta.lifecycle_actions.iter().any(|action| {
+        assert_eq!(delta.removed_servers, vec!["test-server"]);
+        assert_eq!(delta.degraded_removals, vec!["test-server"]);
+        assert!(delta.lifecycle_actions.iter().any(|action| {
             matches!(
                 action,
                 McpLifecycleAction::Removed {
@@ -888,117 +614,5 @@ mod tests {
                 } if server == "test-server"
             )
         }));
-    }
-
-    #[tokio::test]
-    async fn apply_staged_add_is_non_blocking() {
-        let Some(server_path) = skip_if_no_test_server() else {
-            return;
-        };
-
-        let mut router = McpRouter::new();
-        router.stage_add(test_server_config("test-server", &server_path));
-        let result = router.apply_staged().await.expect("apply staged add");
-
-        // Should be pending, not immediately active.
-        assert!(
-            result.pending_count > 0,
-            "server should be pending after non-blocking add"
-        );
-        assert!(result.delta.lifecycle_actions.iter().any(|a| matches!(
-            a,
-            McpLifecycleAction::PendingConnect { server } if server == "test-server"
-        )));
-
-        // Poll until background task completes (max 3s).
-        let deadline = Instant::now() + Duration::from_secs(3);
-        loop {
-            let ext = router.take_external_updates();
-            if ext
-                .notices
-                .iter()
-                .any(|n| n.server == "test-server" && n.status == "activated")
-            {
-                break;
-            }
-            assert!(
-                Instant::now() < deadline,
-                "timed out waiting for background MCP connect"
-            );
-            tokio::time::sleep(Duration::from_millis(50)).await;
-        }
-
-        // Tools should now be visible.
-        assert!(
-            !router.list_tools().is_empty(),
-            "tools should be visible after activation"
-        );
-    }
-
-    #[tokio::test]
-    async fn connect_and_enumerate_times_out() {
-        // Use a config with a very short timeout pointing at a command that hangs.
-        let mut config = McpServerConfig::stdio(
-            "hang-server",
-            "sleep",
-            vec!["60".to_string()],
-            HashMap::new(),
-        );
-        config.connect_timeout_secs = Some(1);
-
-        let result = McpConnection::connect_and_enumerate(&config).await;
-        assert!(result.is_err(), "should time out");
-        let err_msg = result.err().expect("already checked").to_string();
-        assert!(
-            err_msg.contains("Timed out"),
-            "error should mention timeout: {err_msg}"
-        );
-    }
-
-    #[tokio::test]
-    async fn add_remove_add_discards_stale_generation() {
-        let Some(server_path) = skip_if_no_test_server() else {
-            return;
-        };
-
-        let mut router = McpRouter::new();
-
-        // Add server (non-blocking).
-        router.stage_add(test_server_config("test-server", &server_path));
-        let result = router.apply_staged().await.expect("first add");
-        assert_eq!(result.pending_count, 1);
-
-        // Immediately remove (cancels the pending add).
-        router.stage_remove("test-server");
-        router.apply_staged().await.expect("remove");
-
-        // Add again with a new generation.
-        router.stage_add(test_server_config("test-server", &server_path));
-        let result = router.apply_staged().await.expect("second add");
-        assert_eq!(result.pending_count, 1);
-
-        // Wait for the SECOND add to complete (first should be discarded).
-        let deadline = Instant::now() + Duration::from_secs(3);
-        loop {
-            let ext = router.take_external_updates();
-            if ext
-                .notices
-                .iter()
-                .any(|n| n.server == "test-server" && n.status == "activated")
-            {
-                break;
-            }
-            assert!(
-                Instant::now() < deadline,
-                "timed out waiting for second add to complete"
-            );
-            tokio::time::sleep(Duration::from_millis(50)).await;
-        }
-
-        // Should be active from the second add.
-        assert!(matches!(
-            router.server_lifecycle_state("test-server"),
-            Some(McpServerLifecycleState::Active)
-        ));
     }
 }

--- a/meerkat-rest/src/lib.rs
+++ b/meerkat-rest/src/lib.rs
@@ -1823,14 +1823,13 @@ async fn apply_mcp_boundary(
     }
 
     // Apply staged operations — fail the turn on error.
-    let result = adapter
+    let delta = adapter
         .apply_staged()
         .await
         .map_err(|e| ApiError::Internal(format!("failed to apply staged MCP operations: {e}")))?;
 
     // Spawn drain task if any removals started.
-    if result
-        .delta
+    if delta
         .lifecycle_actions
         .iter()
         .any(|a| matches!(a, McpLifecycleAction::RemovingStarted { .. }))
@@ -1838,7 +1837,7 @@ async fn apply_mcp_boundary(
         spawn_mcp_drain_task(adapter, drain_task_running, lifecycle_tx);
     }
 
-    queued_actions.extend(result.delta.lifecycle_actions);
+    queued_actions.extend(delta.lifecycle_actions);
     if !queued_actions.is_empty() {
         let source_id = format!("session:{session_id}");
         meerkat::surface::emit_mcp_lifecycle_events(

--- a/meerkat-rpc/src/session_runtime.rs
+++ b/meerkat-rpc/src/session_runtime.rs
@@ -779,14 +779,13 @@ impl SessionRuntime {
                 .await;
         }
 
-        let result = adapter.apply_staged().await.map_err(|e| RpcError {
+        let delta = adapter.apply_staged().await.map_err(|e| RpcError {
             code: error::INTERNAL_ERROR,
             message: format!("failed to apply staged MCP operations: {e}"),
             data: None,
         })?;
 
-        if result
-            .delta
+        if delta
             .lifecycle_actions
             .iter()
             .any(|action| matches!(action, McpLifecycleAction::RemovingStarted { .. }))
@@ -794,7 +793,7 @@ impl SessionRuntime {
             Self::spawn_mcp_drain_task_if_needed(adapter.clone(), drain_task_running, lifecycle_tx);
         }
 
-        queued_actions.extend(result.delta.lifecycle_actions);
+        queued_actions.extend(delta.lifecycle_actions);
         if queued_actions.is_empty() {
             return Ok(());
         }

--- a/meerkat-tools/src/builtin/composite.rs
+++ b/meerkat-tools/src/builtin/composite.rs
@@ -10,7 +10,6 @@ use crate::builtin::sub_agent::SubAgentToolSet;
 use crate::builtin::{BuiltinTool, BuiltinToolConfig, BuiltinToolError};
 use async_trait::async_trait;
 use meerkat_core::AgentToolDispatcher;
-use meerkat_core::ExternalToolUpdate;
 use meerkat_core::error::ToolError;
 use meerkat_core::types::{ToolCallView, ToolDef, ToolResult};
 use serde_json::Value;
@@ -399,14 +398,6 @@ impl AgentToolDispatcher for CompositeDispatcher {
         Err(ToolError::NotFound {
             name: call.name.to_string(),
         })
-    }
-
-    async fn poll_external_updates(&self) -> ExternalToolUpdate {
-        if let Some(ref ext) = self.external {
-            ext.poll_external_updates().await
-        } else {
-            ExternalToolUpdate::default()
-        }
     }
 }
 

--- a/meerkat/src/lib.rs
+++ b/meerkat/src/lib.rs
@@ -231,8 +231,8 @@ pub use meerkat_tools::{FileTaskStore, ensure_rkat_dir, find_project_root};
 // Re-export MCP client
 #[cfg(feature = "mcp")]
 pub use meerkat_mcp::{
-    McpApplyDelta, McpApplyResult, McpConnection, McpError, McpLifecycleAction, McpReloadTarget,
-    McpRouter, McpRouterAdapter, McpServerConfig, McpServerLifecycleState,
+    McpApplyDelta, McpConnection, McpError, McpLifecycleAction, McpReloadTarget, McpRouter,
+    McpRouterAdapter, McpServerConfig, McpServerLifecycleState,
 };
 
 // Skill types re-exports

--- a/meerkat/src/surface.rs
+++ b/meerkat/src/surface.rs
@@ -214,11 +214,6 @@ pub async fn emit_mcp_lifecycle_events(
 
     for action in actions {
         let (operation, target, status) = match action {
-            McpLifecycleAction::PendingConnect { server } => (
-                ToolConfigChangeOperation::Add,
-                server,
-                "pending".to_string(),
-            ),
             McpLifecycleAction::Activated { server } => (
                 ToolConfigChangeOperation::Add,
                 server,


### PR DESCRIPTION
## Summary

Reverts #107 which was incorrectly merged with `--admin`, bypassing branch protection and CI.

The feature will be re-submitted as a proper PR that goes through CI before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)