### PR TITLE
fix(web): strip Origin/Referer headers in proxy

### DIFF
--- a/sdks/web/proxy/index.mjs
+++ b/sdks/web/proxy/index.mjs
@@ -107,8 +107,8 @@ export function createProxyHandler(provider, opts = {}) {
     // Copy headers, inject auth
     const headers = new Headers();
     for (const [key, value] of req.headers) {
-      // Skip hop-by-hop, host, and encoding headers
-      if (['host', 'connection', 'keep-alive', 'transfer-encoding', 'accept-encoding'].includes(key.toLowerCase())) continue;
+      // Skip hop-by-hop, host, encoding, and browser-origin headers
+      if (['host', 'connection', 'keep-alive', 'transfer-encoding', 'accept-encoding', 'origin', 'referer'].includes(key.toLowerCase())) continue;
       headers.set(key, value);
     }
     config.injectAuth(headers, apiKey);


### PR DESCRIPTION
## Summary

- Strip `Origin` and `Referer` headers from forwarded proxy requests
- Prevents Anthropic from treating proxied requests as CORS browser requests and rejecting them with "CORS requests must set anthropic-dangerous-direct-browser-access"

The proxy is server-side — browser-origin headers should not leak to the upstream provider.

## Test plan

- [x] Verified: `curl` with `-H "Origin: http://localhost:3001"` through proxy → Anthropic responds successfully (previously rejected)

🤖 Generated with [Claude Code](https://claude.com/claude-code)