### PR TITLE
feat: per-agent shell env, send_message returns SessionId, SpawnMemberSpec builder

### DIFF
--- a/examples/034-codemob-mcp/src/tools/deliberate.rs
+++ b/examples/034-codemob-mcp/src/tools/deliberate.rs
@@ -65,17 +65,7 @@ pub async fn handle(
     // Spawn one agent per profile (meerkat_id = profile name for simplicity)
     let specs: Vec<SpawnMemberSpec> = profile_names
         .iter()
-        .map(|name| SpawnMemberSpec {
-            profile_name: ProfileName::from(name.as_str()),
-            meerkat_id: MeerkatId::from(name.as_str()),
-            initial_message: None,
-            runtime_mode: None,
-            backend: None,
-            context: None,
-            labels: None,
-            resume_session_id: None,
-            additional_instructions: None,
-        })
+        .map(|name| SpawnMemberSpec::new(name.as_str(), name.as_str()))
         .collect();
 
     let spawn_results = state

--- a/meerkat-cli/src/main.rs
+++ b/meerkat-cli/src/main.rs
@@ -3125,6 +3125,7 @@ async fn run_agent(
         } else {
             Some(instructions)
         },
+        shell_env: None,
     };
 
     let parsed_labels = if labels.is_empty() {
@@ -3598,6 +3599,7 @@ async fn resume_session_with_llm_override(
         max_inline_peer_notifications: None,
         app_context: None,
         additional_instructions: None,
+        shell_env: None,
     };
 
     // Route through SessionService::create_session() with the resumed session

--- a/meerkat-contracts/src/wire/params.rs
+++ b/meerkat-contracts/src/wire/params.rs
@@ -30,6 +30,9 @@ pub struct CoreCreateParams {
     pub additional_instructions: Option<Vec<String>>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub app_context: Option<serde_json::Value>,
+    /// Per-agent environment variables injected into shell tool subprocesses.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub shell_env: Option<std::collections::HashMap<String, String>>,
 }
 
 /// Structured output parameters.
@@ -355,6 +358,7 @@ mod tests {
                 "Use JSON output.".to_string(),
             ]),
             app_context: Some(serde_json::json!({"org_id": "acme", "tier": "premium"})),
+            shell_env: None,
         };
         let json = serde_json::to_string(&params)?;
         let parsed: CoreCreateParams = serde_json::from_str(&json)?;
@@ -394,11 +398,13 @@ mod tests {
             labels: None,
             additional_instructions: None,
             app_context: None,
+            shell_env: None,
         };
         let json = serde_json::to_string(&params)?;
         assert!(!json.contains("\"labels\""));
         assert!(!json.contains("\"additional_instructions\""));
         assert!(!json.contains("\"app_context\""));
+        assert!(!json.contains("\"shell_env\""));
         Ok(())
     }
 }

--- a/meerkat-core/src/service/mod.rs
+++ b/meerkat-core/src/service/mod.rs
@@ -200,6 +200,10 @@ pub struct SessionBuildOptions {
     /// Additional instruction sections appended to the system prompt after skill
     /// assembly, before tool instructions. Order preserved.
     pub additional_instructions: Option<Vec<String>>,
+    /// Environment variables injected into shell tool subprocesses for this agent.
+    /// Set by the application's `SessionAgentBuilder` — never by the LLM.
+    /// Values are not included in the agent's context window.
+    pub shell_env: Option<std::collections::HashMap<String, String>>,
 }
 
 impl Default for SessionBuildOptions {
@@ -233,6 +237,7 @@ impl Default for SessionBuildOptions {
             max_inline_peer_notifications: None,
             app_context: None,
             additional_instructions: None,
+            shell_env: None,
         }
     }
 }

--- a/meerkat-mcp-server/src/lib.rs
+++ b/meerkat-mcp-server/src/lib.rs
@@ -153,6 +153,9 @@ pub struct MeerkatRunInput {
     /// Opaque application context forwarded to the agent build pipeline.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub app_context: Option<serde_json::Value>,
+    /// Per-agent environment variables injected into shell tool subprocesses.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub shell_env: Option<std::collections::HashMap<String, String>>,
 }
 
 fn default_structured_output_retries() -> u32 {
@@ -2159,6 +2162,7 @@ async fn handle_meerkat_run(
         max_inline_peer_notifications: None,
         app_context: input.app_context.clone(),
         additional_instructions: input.additional_instructions.clone(),
+        shell_env: input.shell_env.clone(),
     };
 
     let req = CreateSessionRequest {
@@ -2359,6 +2363,7 @@ async fn handle_meerkat_resume(
         max_inline_peer_notifications: None,
         app_context: None,
         additional_instructions: input.additional_instructions.clone(),
+        shell_env: None,
     };
 
     let needs_rebuild = existing_adapter.is_none()
@@ -3110,6 +3115,7 @@ mod tests {
                 labels: None,
                 additional_instructions: None,
                 app_context: None,
+                shell_env: None,
             },
             None,
         )

--- a/meerkat-mob-mcp/src/lib.rs
+++ b/meerkat-mob-mcp/src/lib.rs
@@ -153,21 +153,10 @@ impl MobMcpState {
         runtime_mode: Option<MobRuntimeMode>,
         backend: Option<MobBackendKind>,
     ) -> Result<meerkat_mob::MemberRef, MobError> {
-        self.mob_spawn_spec(
-            mob_id,
-            SpawnMemberSpec {
-                profile_name: profile,
-                meerkat_id,
-                initial_message: None,
-                runtime_mode,
-                backend,
-                context: None,
-                labels: None,
-                resume_session_id: None,
-                additional_instructions: None,
-            },
-        )
-        .await
+        let mut spec = SpawnMemberSpec::new(profile, meerkat_id);
+        spec.runtime_mode = runtime_mode;
+        spec.backend = backend;
+        self.mob_spawn_spec(mob_id, spec).await
     }
 
     pub async fn mob_spawn_spec(
@@ -276,7 +265,7 @@ impl MobMcpState {
         mob_id: &MobId,
         meerkat_id: MeerkatId,
         message: String,
-    ) -> Result<(), MobError> {
+    ) -> Result<SessionId, MobError> {
         self.handle_for(mob_id)
             .await?
             .send_message(meerkat_id, message)
@@ -1141,17 +1130,15 @@ impl AgentToolDispatcher for MobMcpDispatcher {
                                 })
                             })
                             .transpose()?;
-                        Ok(SpawnMemberSpec {
-                            profile_name: ProfileName::from(spec.profile),
-                            meerkat_id: MeerkatId::from(spec.meerkat_id),
-                            initial_message: spec.initial_message,
-                            runtime_mode: spec.runtime_mode,
-                            backend: spec.backend,
-                            context: spec.context,
-                            labels: spec.labels,
-                            resume_session_id,
-                            additional_instructions: spec.additional_instructions,
-                        })
+                        let mut s = SpawnMemberSpec::new(spec.profile, spec.meerkat_id);
+                        s.initial_message = spec.initial_message;
+                        s.runtime_mode = spec.runtime_mode;
+                        s.backend = spec.backend;
+                        s.context = spec.context;
+                        s.labels = spec.labels;
+                        s.resume_session_id = resume_session_id;
+                        s.additional_instructions = spec.additional_instructions;
+                        Ok(s)
                     })
                     .collect::<Result<Vec<_>, ToolError>>()?;
                 // Single-spec fast path returns flat member_ref; multi-spec returns results array.
@@ -1244,7 +1231,8 @@ impl AgentToolDispatcher for MobMcpDispatcher {
                 let args: MessageArgs = call
                     .parse_args()
                     .map_err(|e| ToolError::invalid_arguments(call.name, e.to_string()))?;
-                self.state
+                let session_id = self
+                    .state
                     .mob_send_message(
                         &MobId::from(args.mob_id),
                         MeerkatId::from(args.meerkat_id),
@@ -1252,7 +1240,7 @@ impl AgentToolDispatcher for MobMcpDispatcher {
                     )
                     .await
                     .map_err(|e| map_mob_err(call, e))?;
-                encode(call, json!({"ok": true}))
+                encode(call, json!({"ok": true, "session_id": session_id}))
             }
             "mob_respawn" => {
                 let args: RespawnArgs = call

--- a/meerkat-mob/src/build.rs
+++ b/meerkat-mob/src/build.rs
@@ -24,6 +24,7 @@ pub struct BuildAgentConfigParams<'a> {
     pub context: Option<serde_json::Value>,
     pub labels: Option<std::collections::BTreeMap<String, String>>,
     pub additional_instructions: Option<Vec<String>>,
+    pub shell_env: Option<std::collections::HashMap<String, String>>,
 }
 
 /// Build an [`AgentBuildConfig`] from a mob profile.
@@ -47,6 +48,7 @@ pub async fn build_agent_config(
         context,
         labels,
         additional_instructions,
+        shell_env,
     } = params;
 
     if !profile.tools.comms {
@@ -117,6 +119,7 @@ pub async fn build_agent_config(
     // Opaque application context passed through to the agent build pipeline
     config.app_context = context;
     config.additional_instructions = additional_instructions;
+    config.shell_env = shell_env;
     config.provider_params = profile.provider_params.clone();
 
     // Structured output: convert JSON schema value to OutputSchema
@@ -305,6 +308,7 @@ mod tests {
             context: None,
             labels: None,
             additional_instructions: None,
+            shell_env: None,
         })
         .await
         .expect("build_agent_config");
@@ -326,6 +330,7 @@ mod tests {
             context: None,
             labels: None,
             additional_instructions: None,
+            shell_env: None,
         })
         .await
         .expect("build_agent_config");
@@ -351,6 +356,7 @@ mod tests {
             context: None,
             labels: None,
             additional_instructions: None,
+            shell_env: None,
         })
         .await
         .expect("build_agent_config");
@@ -382,6 +388,7 @@ mod tests {
             context: None,
             labels: None,
             additional_instructions: None,
+            shell_env: None,
         })
         .await
         .expect("build_agent_config");
@@ -409,6 +416,7 @@ mod tests {
             context: None,
             labels: None,
             additional_instructions: None,
+            shell_env: None,
         })
         .await
         .expect("build_agent_config");
@@ -429,6 +437,7 @@ mod tests {
             context: None,
             labels: None,
             additional_instructions: None,
+            shell_env: None,
         })
         .await
         .expect("build_agent_config");
@@ -460,6 +469,7 @@ mod tests {
             context: None,
             labels: None,
             additional_instructions: None,
+            shell_env: None,
         })
         .await;
         assert!(
@@ -482,6 +492,7 @@ mod tests {
             context: None,
             labels: None,
             additional_instructions: None,
+            shell_env: None,
         })
         .await
         .expect("build_agent_config");
@@ -510,6 +521,7 @@ mod tests {
             context: None,
             labels: None,
             additional_instructions: None,
+            shell_env: None,
         })
         .await
         .expect("build_agent_config");
@@ -538,6 +550,7 @@ mod tests {
             context: None,
             labels: None,
             additional_instructions: None,
+            shell_env: None,
         })
         .await
         .expect("build_agent_config");
@@ -576,6 +589,7 @@ mod tests {
             context: None,
             labels: None,
             additional_instructions: None,
+            shell_env: None,
         })
         .await
         .expect("build_agent_config");
@@ -597,6 +611,7 @@ mod tests {
             context: None,
             labels: None,
             additional_instructions: None,
+            shell_env: None,
         })
         .await
         .expect("build_agent_config");
@@ -618,6 +633,7 @@ mod tests {
             context: None,
             labels: None,
             additional_instructions: None,
+            shell_env: None,
         })
         .await
         .expect("build_agent_config");
@@ -651,6 +667,7 @@ mod tests {
             context: None,
             labels: None,
             additional_instructions: None,
+            shell_env: None,
         })
         .await
         .expect("build_agent_config");
@@ -695,6 +712,7 @@ mod tests {
             context: None,
             labels: None,
             additional_instructions: None,
+            shell_env: None,
         })
         .await
         .expect("build_agent_config should resolve path skill");
@@ -737,6 +755,7 @@ mod tests {
             context: None,
             labels: None,
             additional_instructions: None,
+            shell_env: None,
         })
         .await
         .expect_err("missing path skill should fail");
@@ -765,6 +784,7 @@ mod tests {
             context: Some(ctx.clone()),
             labels: None,
             additional_instructions: None,
+            shell_env: None,
         })
         .await
         .expect("build_agent_config");
@@ -790,6 +810,7 @@ mod tests {
             context: None,
             labels: None,
             additional_instructions: None,
+            shell_env: None,
         })
         .await
         .expect("build_agent_config");
@@ -823,6 +844,7 @@ mod tests {
             context: None,
             labels: None,
             additional_instructions: None,
+            shell_env: None,
         })
         .await
         .expect("build_agent_config");
@@ -867,6 +889,7 @@ mod tests {
             context: None,
             labels: Some(app_labels),
             additional_instructions: None,
+            shell_env: None,
         })
         .await
         .expect("build_agent_config");

--- a/meerkat-mob/src/runtime/actor.rs
+++ b/meerkat-mob/src/runtime/actor.rs
@@ -999,6 +999,7 @@ impl MobActor {
             labels,
             resume_session_id,
             additional_instructions,
+            shell_env,
         } = spec;
         let prepare_result = async {
             if meerkat_id
@@ -1108,6 +1109,7 @@ impl MobActor {
                 context,
                 labels: labels.clone(),
                 additional_instructions,
+                shell_env,
             })
             .await?;
             if let Some(ref client) = self.default_llm_client {
@@ -1583,21 +1585,10 @@ impl MobActor {
         // Enqueue async spawn with same profile and meerkat ID.
         // The spawn result is delivered via MeerkatSpawned event.
         let (spawn_reply_tx, spawn_reply_rx) = oneshot::channel();
-        self.enqueue_spawn(
-            super::handle::SpawnMemberSpec {
-                profile_name,
-                meerkat_id: meerkat_id.clone(),
-                initial_message,
-                runtime_mode: None,
-                backend: None,
-                context: None,
-                labels: None,
-                resume_session_id: None,
-                additional_instructions: None,
-            },
-            spawn_reply_tx,
-        )
-        .await;
+        let mut respawn_spec =
+            super::handle::SpawnMemberSpec::new(profile_name, meerkat_id.clone());
+        respawn_spec.initial_message = initial_message;
+        self.enqueue_spawn(respawn_spec, spawn_reply_tx).await;
 
         // Fire-and-forget: log spawn failures but don't block the caller.
         let mid = meerkat_id.clone();
@@ -2203,7 +2194,7 @@ impl MobActor {
         &mut self,
         meerkat_id: MeerkatId,
         message: String,
-    ) -> Result<(), MobError> {
+    ) -> Result<SessionId, MobError> {
         // Look up the entry
         let entry = {
             let roster = self.roster.read().await;
@@ -2217,54 +2208,56 @@ impl MobActor {
                     && let Some(spec) = policy.resolve(&meerkat_id).await
                 {
                     let (spawn_reply_tx, spawn_reply_rx) = oneshot::channel();
-                    self.enqueue_spawn(
-                        super::handle::SpawnMemberSpec {
-                            profile_name: spec.profile,
-                            meerkat_id: meerkat_id.clone(),
-                            initial_message: None,
-                            runtime_mode: spec.runtime_mode,
-                            backend: None,
-                            context: None,
-                            labels: None,
-                            resume_session_id: None,
-                            additional_instructions: None,
-                        },
-                        spawn_reply_tx,
-                    )
-                    .await;
+                    let mut spawn_spec =
+                        super::handle::SpawnMemberSpec::new(spec.profile, meerkat_id.clone());
+                    spawn_spec.runtime_mode = spec.runtime_mode;
+                    self.enqueue_spawn(spawn_spec, spawn_reply_tx).await;
 
-                    // Schedule deferred message delivery after spawn completes.
+                    // Wait for spawn to complete, then deliver the message
+                    // via a deferred ExternalTurn command.
                     let command_tx = self.command_tx.clone();
                     let target_id = meerkat_id.clone();
+                    let member_ref = spawn_reply_rx
+                        .await
+                        .map_err(|_| MobError::Internal("auto-spawn reply channel dropped".into()))?
+                        .map_err(|e| {
+                            MobError::Internal(format!("auto-spawn failed for '{target_id}': {e}"))
+                        })?;
+
+                    let session_id = member_ref.session_id().cloned().ok_or_else(|| {
+                        MobError::Internal(format!(
+                            "auto-spawned member '{target_id}' has no session"
+                        ))
+                    })?;
+
+                    // Deferred delivery — fire and forget after spawn completes.
                     self.lifecycle_tasks.spawn(async move {
-                        if let Ok(Ok(_)) = spawn_reply_rx.await {
-                            let (reply_tx, reply_rx) = oneshot::channel();
-                            let _ = command_tx
-                                .send(MobCommand::ExternalTurn {
-                                    meerkat_id: target_id.clone(),
-                                    message,
-                                    reply_tx,
-                                })
-                                .await;
-                            match reply_rx.await {
-                                Ok(Ok(())) => {}
-                                Ok(Err(e)) => {
-                                    tracing::error!(
-                                        meerkat_id = %target_id,
-                                        error = %e,
-                                        "deferred delivery after auto-spawn failed"
-                                    );
-                                }
-                                Err(_) => {
-                                    tracing::error!(
-                                        meerkat_id = %target_id,
-                                        "deferred delivery channel dropped before response"
-                                    );
-                                }
+                        let (reply_tx, reply_rx) = oneshot::channel();
+                        let _ = command_tx
+                            .send(MobCommand::ExternalTurn {
+                                meerkat_id: target_id.clone(),
+                                message,
+                                reply_tx,
+                            })
+                            .await;
+                        match reply_rx.await {
+                            Ok(Ok(_)) => {}
+                            Ok(Err(e)) => {
+                                tracing::error!(
+                                    meerkat_id = %target_id,
+                                    error = %e,
+                                    "deferred delivery after auto-spawn failed"
+                                );
+                            }
+                            Err(_) => {
+                                tracing::error!(
+                                    meerkat_id = %target_id,
+                                    "deferred delivery channel dropped before response"
+                                );
                             }
                         }
                     });
-                    return Ok(());
+                    return Ok(session_id);
                 }
                 return Err(MobError::MeerkatNotFound(meerkat_id));
             }
@@ -2281,9 +2274,7 @@ impl MobActor {
             return Err(MobError::NotExternallyAddressable(meerkat_id));
         }
 
-        self.dispatch_member_turn(&entry, message).await?;
-
-        Ok(())
+        self.dispatch_member_turn(&entry, message).await
     }
 
     /// Internal-turn path bypasses external_addressable checks.
@@ -2300,15 +2291,14 @@ impl MobActor {
                 .ok_or_else(|| MobError::MeerkatNotFound(meerkat_id.clone()))?
         };
 
-        self.dispatch_member_turn(&entry, message).await?;
-        Ok(())
+        self.dispatch_member_turn(&entry, message).await.map(|_| ())
     }
 
     async fn dispatch_member_turn(
         &self,
         entry: &RosterEntry,
         message: String,
-    ) -> Result<(), MobError> {
+    ) -> Result<SessionId, MobError> {
         match entry.runtime_mode {
             crate::MobRuntimeMode::AutonomousHost => {
                 let session_id = entry.member_ref.session_id().ok_or_else(|| {
@@ -2327,6 +2317,7 @@ impl MobActor {
                             entry.meerkat_id
                         ))
                     })?;
+                let session_id = session_id.clone();
                 injector
                     .inject(message, meerkat_core::PlainEventSource::Rpc)
                     .map_err(|error| {
@@ -2335,9 +2326,15 @@ impl MobActor {
                             entry.meerkat_id, error
                         ))
                     })?;
-                Ok(())
+                Ok(session_id)
             }
             crate::MobRuntimeMode::TurnDriven => {
+                let session_id = entry.member_ref.session_id().cloned().ok_or_else(|| {
+                    MobError::Internal(format!(
+                        "turn-driven dispatch requires session for '{}'",
+                        entry.meerkat_id
+                    ))
+                })?;
                 let req = meerkat_core::service::StartTurnRequest {
                     prompt: message,
                     event_tx: None,
@@ -2346,7 +2343,8 @@ impl MobActor {
                     flow_tool_overlay: None,
                     additional_instructions: None,
                 };
-                self.provisioner.start_turn(&entry.member_ref, req).await
+                self.provisioner.start_turn(&entry.member_ref, req).await?;
+                Ok(session_id)
             }
         }
     }

--- a/meerkat-mob/src/runtime/builder.rs
+++ b/meerkat-mob/src/runtime/builder.rs
@@ -445,6 +445,7 @@ impl MobBuilder {
                 context: None,
                 labels: None,
                 additional_instructions: None,
+                shell_env: None,
             })
             .await?;
             // Resume reconciliation needs live comms runtimes, but this path is

--- a/meerkat-mob/src/runtime/handle.rs
+++ b/meerkat-mob/src/runtime/handle.rs
@@ -32,6 +32,7 @@ pub struct MobEventsView {
 
 /// Spawn request for first-class batch member provisioning.
 #[derive(Clone, Debug)]
+#[non_exhaustive]
 pub struct SpawnMemberSpec {
     pub profile_name: ProfileName,
     pub meerkat_id: MeerkatId,
@@ -46,9 +47,66 @@ pub struct SpawnMemberSpec {
     pub resume_session_id: Option<meerkat_core::types::SessionId>,
     /// Additional instruction sections appended to the system prompt for this member.
     pub additional_instructions: Option<Vec<String>>,
+    /// Per-agent environment variables injected into shell tool subprocesses.
+    pub shell_env: Option<std::collections::HashMap<String, String>>,
 }
 
 impl SpawnMemberSpec {
+    pub fn new(profile: impl Into<ProfileName>, meerkat_id: impl Into<MeerkatId>) -> Self {
+        Self {
+            profile_name: profile.into(),
+            meerkat_id: meerkat_id.into(),
+            initial_message: None,
+            runtime_mode: None,
+            backend: None,
+            context: None,
+            labels: None,
+            resume_session_id: None,
+            additional_instructions: None,
+            shell_env: None,
+        }
+    }
+
+    pub fn with_shell_env(mut self, env: std::collections::HashMap<String, String>) -> Self {
+        self.shell_env = Some(env);
+        self
+    }
+
+    pub fn with_initial_message(mut self, message: String) -> Self {
+        self.initial_message = Some(message);
+        self
+    }
+
+    pub fn with_runtime_mode(mut self, mode: crate::MobRuntimeMode) -> Self {
+        self.runtime_mode = Some(mode);
+        self
+    }
+
+    pub fn with_backend(mut self, backend: MobBackendKind) -> Self {
+        self.backend = Some(backend);
+        self
+    }
+
+    pub fn with_context(mut self, context: serde_json::Value) -> Self {
+        self.context = Some(context);
+        self
+    }
+
+    pub fn with_labels(mut self, labels: std::collections::BTreeMap<String, String>) -> Self {
+        self.labels = Some(labels);
+        self
+    }
+
+    pub fn with_resume_session_id(mut self, id: meerkat_core::types::SessionId) -> Self {
+        self.resume_session_id = Some(id);
+        self
+    }
+
+    pub fn with_additional_instructions(mut self, instructions: Vec<String>) -> Self {
+        self.additional_instructions = Some(instructions);
+        self
+    }
+
     pub fn from_wire(
         profile: String,
         meerkat_id: String,
@@ -56,17 +114,11 @@ impl SpawnMemberSpec {
         runtime_mode: Option<crate::MobRuntimeMode>,
         backend: Option<MobBackendKind>,
     ) -> Self {
-        Self {
-            profile_name: ProfileName::from(profile),
-            meerkat_id: MeerkatId::from(meerkat_id),
-            initial_message,
-            runtime_mode,
-            backend,
-            context: None,
-            labels: None,
-            resume_session_id: None,
-            additional_instructions: None,
-        }
+        let mut spec = Self::new(profile, meerkat_id);
+        spec.initial_message = initial_message;
+        spec.runtime_mode = runtime_mode;
+        spec.backend = backend;
+        spec
     }
 }
 
@@ -326,18 +378,11 @@ impl MobHandle {
         runtime_mode: Option<crate::MobRuntimeMode>,
         backend: Option<MobBackendKind>,
     ) -> Result<MemberRef, MobError> {
-        self.spawn_spec(SpawnMemberSpec {
-            profile_name,
-            meerkat_id,
-            initial_message,
-            runtime_mode,
-            backend,
-            context: None,
-            labels: None,
-            resume_session_id: None,
-            additional_instructions: None,
-        })
-        .await
+        let mut spec = SpawnMemberSpec::new(profile_name, meerkat_id);
+        spec.initial_message = initial_message;
+        spec.runtime_mode = runtime_mode;
+        spec.backend = backend;
+        self.spawn_spec(spec).await
     }
 
     /// Spawn a member from a fully-specified [`SpawnMemberSpec`].
@@ -437,11 +482,14 @@ impl MobHandle {
     }
 
     /// Send a message to a member (enforces external_addressable).
+    ///
+    /// Returns the [`SessionId`] of the session that handled the turn,
+    /// enabling callers to correlate injection events with agent responses.
     pub async fn send_message(
         &self,
         meerkat_id: MeerkatId,
         message: String,
-    ) -> Result<(), MobError> {
+    ) -> Result<meerkat_core::types::SessionId, MobError> {
         let (reply_tx, reply_rx) = oneshot::channel();
         self.command_tx
             .send(MobCommand::ExternalTurn {

--- a/meerkat-mob/src/runtime/state.rs
+++ b/meerkat-mob/src/runtime/state.rs
@@ -91,7 +91,7 @@ pub(super) enum MobCommand {
     ExternalTurn {
         meerkat_id: MeerkatId,
         message: String,
-        reply_tx: oneshot::Sender<Result<(), MobError>>,
+        reply_tx: oneshot::Sender<Result<SessionId, MobError>>,
     },
     InternalTurn {
         meerkat_id: MeerkatId,

--- a/meerkat-mob/src/runtime/tests.rs
+++ b/meerkat-mob/src/runtime/tests.rs
@@ -6618,39 +6618,9 @@ async fn test_spawn_many_member_refs_returns_results_in_input_order() {
     service.set_create_session_delay_ms(100);
 
     let specs = vec![
-        SpawnMemberSpec {
-            profile_name: ProfileName::from("worker"),
-            meerkat_id: MeerkatId::from("w-a"),
-            initial_message: None,
-            runtime_mode: None,
-            backend: None,
-            context: None,
-            labels: None,
-            resume_session_id: None,
-            additional_instructions: None,
-        },
-        SpawnMemberSpec {
-            profile_name: ProfileName::from("worker"),
-            meerkat_id: MeerkatId::from("w-b"),
-            initial_message: None,
-            runtime_mode: None,
-            backend: None,
-            context: None,
-            labels: None,
-            resume_session_id: None,
-            additional_instructions: None,
-        },
-        SpawnMemberSpec {
-            profile_name: ProfileName::from("worker"),
-            meerkat_id: MeerkatId::from("w-c"),
-            initial_message: None,
-            runtime_mode: None,
-            backend: None,
-            context: None,
-            labels: None,
-            resume_session_id: None,
-            additional_instructions: None,
-        },
+        SpawnMemberSpec::new("worker", "w-a"),
+        SpawnMemberSpec::new("worker", "w-b"),
+        SpawnMemberSpec::new("worker", "w-c"),
     ];
 
     let results = handle.spawn_many(specs).await;
@@ -6675,28 +6645,8 @@ async fn test_spawn_many_parallel_finalize_emits_single_worker_pair_wire_event()
     service.set_create_session_delay_ms(120);
 
     let specs = vec![
-        SpawnMemberSpec {
-            profile_name: ProfileName::from("worker"),
-            meerkat_id: MeerkatId::from("w-a"),
-            initial_message: None,
-            runtime_mode: None,
-            backend: None,
-            context: None,
-            labels: None,
-            resume_session_id: None,
-            additional_instructions: None,
-        },
-        SpawnMemberSpec {
-            profile_name: ProfileName::from("worker"),
-            meerkat_id: MeerkatId::from("w-b"),
-            initial_message: None,
-            runtime_mode: None,
-            backend: None,
-            context: None,
-            labels: None,
-            resume_session_id: None,
-            additional_instructions: None,
-        },
+        SpawnMemberSpec::new("worker", "w-a"),
+        SpawnMemberSpec::new("worker", "w-b"),
     ];
 
     let results = handle.spawn_many(specs).await;

--- a/meerkat-rest/src/lib.rs
+++ b/meerkat-rest/src/lib.rs
@@ -379,6 +379,9 @@ pub struct CreateSessionRequest {
     /// Opaque application context passed through to custom builders.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub app_context: Option<Value>,
+    /// Per-agent environment variables injected into shell tool subprocesses.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub shell_env: Option<std::collections::HashMap<String, String>>,
 }
 
 fn default_structured_output_retries() -> u32 {
@@ -1297,6 +1300,7 @@ async fn create_session(
         max_inline_peer_notifications: None,
         app_context: req.app_context,
         additional_instructions: req.additional_instructions,
+        shell_env: req.shell_env,
     };
 
     let svc_req = SvcCreateSessionRequest {
@@ -1637,6 +1641,7 @@ async fn continue_session(
                 max_inline_peer_notifications: None,
                 app_context: None,
                 additional_instructions: None,
+                shell_env: None,
             };
 
             let svc_req = SvcCreateSessionRequest {

--- a/meerkat-rpc/src/handlers/mob.rs
+++ b/meerkat-rpc/src/handlers/mob.rs
@@ -12,8 +12,8 @@ use crate::session_runtime::SessionRuntime;
 use meerkat_core::service::AppendSystemContextRequest;
 use meerkat_core::types::SessionId;
 use meerkat_mob::{
-    FlowId, MeerkatId, MobBackendKind, MobDefinition, MobId, MobRuntimeMode, Prefab, ProfileName,
-    RunId, SpawnMemberSpec,
+    FlowId, MeerkatId, MobBackendKind, MobDefinition, MobId, MobRuntimeMode, Prefab, RunId,
+    SpawnMemberSpec,
 };
 use meerkat_mob_mcp::MobMcpState;
 use std::collections::BTreeMap;
@@ -238,17 +238,14 @@ pub async fn handle_spawn(
         },
         None => None,
     };
-    let spec = SpawnMemberSpec {
-        profile_name: ProfileName::from(params.profile.as_str()),
-        meerkat_id: MeerkatId::from(params.meerkat_id.as_str()),
-        initial_message: params.initial_message,
-        runtime_mode: params.runtime_mode,
-        backend: params.backend,
-        context: params.context,
-        labels: params.labels,
-        resume_session_id,
-        additional_instructions: params.additional_instructions,
-    };
+    let mut spec = SpawnMemberSpec::new(params.profile.as_str(), params.meerkat_id.as_str());
+    spec.initial_message = params.initial_message;
+    spec.runtime_mode = params.runtime_mode;
+    spec.backend = params.backend;
+    spec.context = params.context;
+    spec.labels = params.labels;
+    spec.resume_session_id = resume_session_id;
+    spec.additional_instructions = params.additional_instructions;
     match state.mob_spawn_spec(&mob_id, spec).await {
         Ok(member_ref) => RpcResponse::success(
             id,
@@ -448,7 +445,10 @@ pub async fn handle_send(
         )
         .await
     {
-        Ok(()) => RpcResponse::success(id, serde_json::json!({"sent": true})),
+        Ok(session_id) => RpcResponse::success(
+            id,
+            serde_json::json!({"sent": true, "session_id": session_id}),
+        ),
         Err(err) => invalid_params(id, err.to_string()),
     }
 }

--- a/meerkat-rpc/src/handlers/session.rs
+++ b/meerkat-rpc/src/handlers/session.rs
@@ -98,6 +98,10 @@ pub struct CreateSessionParams {
     /// Opaque application context passed to custom session builders.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub app_context: Option<serde_json::Value>,
+    /// Per-agent environment variables injected into shell tool subprocesses.
+    /// Set by the application — never visible to the LLM.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub shell_env: Option<std::collections::HashMap<String, String>>,
 }
 
 fn default_structured_output_retries() -> u32 {
@@ -255,6 +259,7 @@ pub async fn handle_create(
     build_config.provider_params = params.provider_params;
     build_config.additional_instructions = params.additional_instructions;
     build_config.app_context = params.app_context;
+    build_config.shell_env = params.shell_env;
     build_config.preload_skills = params
         .preload_skills
         .map(|ids| ids.into_iter().map(meerkat_core::skills::SkillId).collect());

--- a/meerkat-tools/src/builtin/shell/config.rs
+++ b/meerkat-tools/src/builtin/shell/config.rs
@@ -7,7 +7,9 @@ use super::security::SecurityEngine;
 use meerkat_core::ShellDefaults;
 use meerkat_core::types::SecurityMode;
 use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
 use std::ffi::OsStr;
+use std::fmt;
 use std::path::{Path, PathBuf};
 use thiserror::Error;
 
@@ -51,7 +53,7 @@ pub enum ShellError {
 ///
 /// Controls shell execution behavior including timeouts, working directory
 /// restrictions, and which shell to use.
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Clone, Serialize, Deserialize)]
 pub struct ShellConfig {
     /// Whether shell tool is enabled (default: false)
     pub enabled: bool,
@@ -103,6 +105,30 @@ pub struct ShellConfig {
     /// Patterns for allow/deny lists (glob format)
     #[serde(default)]
     pub security_patterns: Vec<String>,
+
+    /// Per-agent environment variables injected into shell subprocesses.
+    /// Redacted from Debug output to avoid leaking secrets.
+    #[serde(default, skip_serializing_if = "HashMap::is_empty")]
+    pub env_vars: HashMap<String, String>,
+}
+
+impl fmt::Debug for ShellConfig {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("ShellConfig")
+            .field("enabled", &self.enabled)
+            .field("default_timeout_secs", &self.default_timeout_secs)
+            .field("restrict_to_project", &self.restrict_to_project)
+            .field("shell", &self.shell)
+            .field("shell_path", &self.shell_path)
+            .field("project_root", &self.project_root)
+            .field("max_completed_jobs", &self.max_completed_jobs)
+            .field("completed_job_ttl_secs", &self.completed_job_ttl_secs)
+            .field("max_concurrent_processes", &self.max_concurrent_processes)
+            .field("security_mode", &self.security_mode)
+            .field("security_patterns", &self.security_patterns)
+            .field("env_vars", &format_args!("<{} vars>", self.env_vars.len()))
+            .finish()
+    }
 }
 
 fn default_max_completed_jobs() -> usize {
@@ -132,6 +158,7 @@ impl Default for ShellConfig {
             max_concurrent_processes: default_max_concurrent_processes(),
             security_mode: defaults.security_mode,
             security_patterns: defaults.security_patterns,
+            env_vars: HashMap::new(),
         }
     }
 }
@@ -398,6 +425,7 @@ mod tests {
             max_concurrent_processes: 5,
             security_mode: SecurityMode::AllowList,
             security_patterns: vec!["echo".to_string(), "cat".to_string()],
+            env_vars: HashMap::new(),
         };
 
         assert!(config.enabled);
@@ -472,6 +500,7 @@ mod tests {
             max_concurrent_processes: 15,
             security_mode: SecurityMode::AllowList,
             security_patterns: vec!["ls".to_string(), "cat".to_string()],
+            env_vars: HashMap::new(),
         };
 
         // Serialize to JSON

--- a/meerkat-tools/src/builtin/shell/job_manager.rs
+++ b/meerkat-tools/src/builtin/shell/job_manager.rs
@@ -283,6 +283,9 @@ impl JobManager {
         cmd.current_dir(work_dir);
         cmd.env("PWD", work_dir);
 
+        // Inject per-agent environment variables
+        cmd.envs(&self.config.env_vars);
+
         // Capture stdout/stderr
         cmd.stdout(Stdio::piped());
         cmd.stderr(Stdio::piped());
@@ -756,6 +759,7 @@ mod tests {
             max_concurrent_processes: 10,
             security_mode: SecurityMode::Unrestricted,
             security_patterns: vec![],
+            env_vars: std::collections::HashMap::new(),
         };
 
         let manager = JobManager::new(config);

--- a/meerkat-tools/src/builtin/shell/tool.rs
+++ b/meerkat-tools/src/builtin/shell/tool.rs
@@ -259,6 +259,9 @@ impl ShellTool {
             cmd.env("PWD", &self.config.project_root);
         }
 
+        // Inject per-agent environment variables
+        cmd.envs(&self.config.env_vars);
+
         // Capture stdout/stderr
         cmd.stdout(Stdio::piped());
         cmd.stderr(Stdio::piped());

--- a/meerkat-tools/tests/rct_contracts.rs
+++ b/meerkat-tools/tests/rct_contracts.rs
@@ -139,6 +139,7 @@ fn test_rct_contracts_shell_defaults_contract() -> Result<(), Box<dyn std::error
         max_concurrent_processes: 5,
         security_mode: meerkat_core::SecurityMode::Unrestricted,
         security_patterns: vec![],
+        env_vars: std::collections::HashMap::new(),
     };
     let json_str = serde_json::to_string(&tool)?;
     let json_val: serde_json::Value = serde_json::from_str(&json_str)?;

--- a/meerkat-web-runtime/src/lib.rs
+++ b/meerkat-web-runtime/src/lib.rs
@@ -1785,17 +1785,15 @@ pub async fn mob_spawn(mob_id: &str, specs_json: &str) -> Result<JsValue, JsValu
             })?),
             None => None,
         };
-        spawn_specs.push(meerkat_mob::SpawnMemberSpec {
-            profile_name: meerkat_mob::ProfileName::from(s.profile.as_str()),
-            meerkat_id: MeerkatId::from(s.meerkat_id.as_str()),
-            initial_message: s.initial_message,
-            runtime_mode: s.runtime_mode,
-            backend: s.backend,
-            context: s.context,
-            labels: s.labels,
-            resume_session_id,
-            additional_instructions: s.additional_instructions,
-        });
+        let mut spec = meerkat_mob::SpawnMemberSpec::new(s.profile.as_str(), s.meerkat_id.as_str());
+        spec.initial_message = s.initial_message;
+        spec.runtime_mode = s.runtime_mode;
+        spec.backend = s.backend;
+        spec.context = s.context;
+        spec.labels = s.labels;
+        spec.resume_session_id = resume_session_id;
+        spec.additional_instructions = s.additional_instructions;
+        spawn_specs.push(spec);
     }
 
     let results = mob_state
@@ -2027,19 +2025,22 @@ pub async fn wire_cross_mob(
 }
 
 /// Send an external message to a spawned meerkat.
+///
+/// Returns the session ID of the session that handled the turn.
 #[wasm_bindgen]
 pub async fn mob_send_message(
     mob_id: &str,
     meerkat_id: &str,
     message: &str,
-) -> Result<(), JsValue> {
+) -> Result<String, JsValue> {
     let mob_state = with_mob_state(Ok)?;
     let id = MobId::from(mob_id);
     let mid = MeerkatId::from(meerkat_id);
-    mob_state
+    let session_id = mob_state
         .mob_send_message(&id, mid, message.to_string())
         .await
-        .map_err(err_mob)
+        .map_err(err_mob)?;
+    Ok(session_id.to_string())
 }
 
 /// Retire and re-spawn a meerkat with the same profile.
@@ -2322,7 +2323,7 @@ mod tests {
         PendingSystemContextAppend, SeenSystemContextKey, SeenSystemContextState,
         SessionSystemContextState,
     };
-    use meerkat_mob::{MeerkatId, SpawnMemberSpec};
+    use meerkat_mob::SpawnMemberSpec;
     use serde_json::json;
     use std::collections::HashMap;
     use std::time::{Duration, SystemTime};
@@ -2436,17 +2437,10 @@ mod tests {
         let spawn_results = mob_state
             .mob_spawn_many(
                 &mob_id,
-                vec![SpawnMemberSpec {
-                    profile_name: meerkat_mob::ProfileName::from("worker"),
-                    meerkat_id: MeerkatId::from("worker-1"),
-                    initial_message: None,
-                    runtime_mode: Some(meerkat_mob::MobRuntimeMode::TurnDriven),
-                    backend: None,
-                    context: None,
-                    labels: None,
-                    resume_session_id: None,
-                    additional_instructions: None,
-                }],
+                vec![
+                    SpawnMemberSpec::new("worker", "worker-1")
+                        .with_runtime_mode(meerkat_mob::MobRuntimeMode::TurnDriven),
+                ],
             )
             .await
             .expect("spawn worker");

--- a/meerkat/src/factory.rs
+++ b/meerkat/src/factory.rs
@@ -300,6 +300,8 @@ pub struct AgentBuildConfig {
     /// servers finish connecting before starting the first agent turn.
     /// Default: false (servers connect in the background).
     pub wait_for_mcp: bool,
+    /// Per-agent environment variables injected into shell tool subprocesses.
+    pub shell_env: Option<std::collections::HashMap<String, String>>,
 }
 
 impl std::fmt::Debug for AgentBuildConfig {
@@ -403,6 +405,7 @@ impl AgentBuildConfig {
             app_context: None,
             additional_instructions: None,
             wait_for_mcp: false,
+            shell_env: None,
         }
     }
 
@@ -456,6 +459,7 @@ impl AgentBuildConfig {
         self.max_inline_peer_notifications = build.max_inline_peer_notifications;
         self.app_context = build.app_context.clone();
         self.additional_instructions = build.additional_instructions.clone();
+        self.shell_env = build.shell_env.clone();
     }
 
     /// Convert build options to the service transport representation.
@@ -492,6 +496,7 @@ impl AgentBuildConfig {
             max_inline_peer_notifications: self.max_inline_peer_notifications,
             app_context: self.app_context.clone(),
             additional_instructions: self.additional_instructions.clone(),
+            shell_env: self.shell_env.clone(),
         }
     }
 }
@@ -1366,6 +1371,7 @@ impl AgentFactory {
                         build_config.scoped_event_path.clone(),
                         #[cfg(all(feature = "sub-agents", feature = "comms"))]
                         sub_agent_comms,
+                        build_config.shell_env.take(),
                     )
                     .await?
                 }
@@ -1751,6 +1757,7 @@ impl AgentFactory {
         #[cfg(all(feature = "sub-agents", feature = "comms"))] sub_agent_comms: Option<
             SubAgentCommsWiring,
         >,
+        shell_env: Option<std::collections::HashMap<String, String>>,
     ) -> Result<(Arc<dyn AgentToolDispatcher>, String), BuildAgentError> {
         if !effective_builtins {
             // No builtins — return the external tools if provided, otherwise empty.
@@ -1776,7 +1783,11 @@ impl AgentFactory {
                 .project_root
                 .clone()
                 .unwrap_or_else(|| self.store_path.clone());
-            Some(ShellConfig::with_project_root(project_root))
+            let mut config = ShellConfig::with_project_root(project_root);
+            if let Some(env) = shell_env {
+                config.env_vars = env;
+            }
+            Some(config)
         } else {
             None
         };

--- a/meerkat/tests/e2e_shell.rs
+++ b/meerkat/tests/e2e_shell.rs
@@ -38,6 +38,7 @@ fn create_sh_config(temp_dir: &TempDir) -> ShellConfig {
         max_concurrent_processes: 0,       // Unlimited for e2e tests
         security_mode: Default::default(), // Unrestricted for e2e tests
         security_patterns: vec![],
+        env_vars: std::collections::HashMap::new(),
     }
 }
 


### PR DESCRIPTION
## Summary

- **Per-agent shell environment variables**: `SessionBuildOptions.shell_env` flows through `AgentBuildConfig` → `ShellConfig.env_vars` → `cmd.envs()` in subprocess execution (both foreground and background jobs). Custom `Debug` impl redacts env vars. Wired through all surfaces (RPC, REST, MCP Server, contracts wire type) and mob spawn pipeline.
- **`MobHandle::send_message` returns `SessionId`**: Enables callers to correlate injection events with agent responses. Both autonomous-host (inject) and turn-driven paths return the session that handled the turn. Auto-spawn path waits for provisioning to return the session ID.
- **`SpawnMemberSpec` builder with `#[non_exhaustive]`**: `new()` + `with_*` builder methods. All external construction sites converted. Prevents downstream breakage when adding fields.

## Test plan

- [ ] `cargo nextest run --workspace --all-features` passes
- [ ] Pre-push hooks pass (clippy, build, unit gate) ✅
- [ ] Verify `shell_env` round-trips through RPC `session/create` params
- [ ] Verify `send_message` response includes `session_id` in RPC/MCP surfaces
- [ ] Verify `SpawnMemberSpec::new("profile", "id").with_labels(...)` compiles from external crates

🤖 Generated with [Claude Code](https://claude.com/claude-code)