### PR TITLE
Implement lifecycle correctness RCT run

### DIFF
--- a/meerkat-core/src/agent/runner.rs
+++ b/meerkat-core/src/agent/runner.rs
@@ -9,7 +9,7 @@ use crate::ops::{
 };
 use crate::retry::RetryPolicy;
 use crate::service::TurnToolOverlay;
-use crate::session::Session;
+use crate::session::{PendingSystemContextAppend, Session};
 use crate::state::LoopState;
 #[cfg(target_arch = "wasm32")]
 use crate::tokio;
@@ -201,8 +201,13 @@ where
         }
     }
 
-    /// Apply all pending system-context appends at the current LLM boundary.
-    pub(crate) fn apply_pending_system_context_boundary(&mut self) -> usize {
+    /// Consume all pending system-context appends for the next LLM boundary.
+    ///
+    /// The returned appends are intended for transient request composition only;
+    /// they must not be written back into the canonical session prompt.
+    pub(crate) fn take_pending_system_context_boundary(
+        &mut self,
+    ) -> Vec<PendingSystemContextAppend> {
         let pending = {
             let mut state = match self.system_context_state.lock() {
                 Ok(guard) => guard,
@@ -212,16 +217,28 @@ where
                 }
             };
             if state.pending.is_empty() {
-                return 0;
+                return Vec::new();
             }
             let pending = state.pending.clone();
             state.mark_pending_applied();
             pending
         };
 
-        self.session.append_system_context_blocks(&pending);
         self.sync_system_context_state_to_session();
-        pending.len()
+        pending
+    }
+
+    pub(crate) fn llm_messages_with_runtime_system_context(
+        &self,
+        appends: &[PendingSystemContextAppend],
+    ) -> Vec<Message> {
+        if appends.is_empty() {
+            return self.session.messages().to_vec();
+        }
+
+        let mut session = self.session.clone();
+        session.append_system_context_blocks(appends);
+        session.messages().to_vec()
     }
 
     /// Persist the current session through the configured checkpointer after syncing control state.

--- a/meerkat-core/src/agent/state.rs
+++ b/meerkat-core/src/agent/state.rs
@@ -125,10 +125,6 @@ where
                 return Ok(self.build_result(turn_count, tool_call_count).await);
             }
 
-            if self.state == LoopState::CallingLlm {
-                let _applied_system_contexts = self.apply_pending_system_context_boundary();
-            }
-
             // Check compaction trigger (before CallingLlm)
             if self.state == LoopState::CallingLlm
                 && let Some(ref compactor) = self.compactor
@@ -360,9 +356,12 @@ where
                     }
 
                     // Call LLM with retry
+                    let boundary_system_context = self.take_pending_system_context_boundary();
+                    let request_messages =
+                        self.llm_messages_with_runtime_system_context(&boundary_system_context);
                     let result = self
                         .call_llm_with_retry(
-                            self.session.messages(),
+                            &request_messages,
                             &tool_defs,
                             effective_max_tokens,
                             effective_temperature,

--- a/meerkat-mob-mcp/src/lib.rs
+++ b/meerkat-mob-mcp/src/lib.rs
@@ -164,7 +164,8 @@ impl MobMcpState {
         mob_id: &MobId,
         spec: SpawnMemberSpec,
     ) -> Result<meerkat_mob::MemberRef, MobError> {
-        self.handle_for(mob_id).await?.spawn_spec(spec).await
+        let member_ref = self.handle_for(mob_id).await?.spawn_spec(spec).await?;
+        Ok(member_ref)
     }
 
     pub async fn mob_spawn_many(
@@ -176,34 +177,39 @@ impl MobMcpState {
     }
 
     pub async fn mob_retire(&self, mob_id: &MobId, meerkat_id: MeerkatId) -> Result<(), MobError> {
-        self.handle_for(mob_id).await?.retire(meerkat_id).await
+        self.handle_for(mob_id)
+            .await?
+            .retire(meerkat_id.clone())
+            .await
     }
 
     pub async fn retire_member_by_session_id(
         &self,
         session_id: &SessionId,
     ) -> Result<(), MobError> {
-        let mobs: Vec<(MobId, MobHandle)> = self
-            .mobs
-            .read()
-            .await
-            .iter()
-            .map(|(mob_id, managed)| (mob_id.clone(), managed.handle.clone()))
-            .collect();
-
-        for (mob_id, handle) in mobs {
-            let members = handle.list_all_members().await;
-            if let Some(member) = members
-                .into_iter()
-                .find(|entry| entry.member_ref.session_id() == Some(session_id))
-            {
-                return self.mob_retire(&mob_id, member.meerkat_id).await;
+        // Derive membership from authoritative live mob roster state rather than
+        // maintaining a separate reverse index that can drift during retirement,
+        // respawn, or policy-driven auto-spawn flows.
+        let mob_ids = self.mobs.read().await.keys().cloned().collect::<Vec<_>>();
+        let mut resolved = None;
+        for mob_id in mob_ids {
+            let members = self.handle_for(&mob_id).await?.list_all_members().await;
+            if let Some(member) = members.into_iter().find(|member| {
+                member
+                    .member_ref
+                    .session_id()
+                    .is_some_and(|candidate| candidate == session_id)
+            }) {
+                resolved = Some((mob_id, member.meerkat_id));
+                break;
             }
         }
-
-        Err(MobError::Internal(format!(
-            "session not found in any mob: {session_id}"
-        )))
+        let Some((mob_id, meerkat_id)) = resolved else {
+            return Err(MobError::Internal(format!(
+                "session not found in any live mob authority: {session_id}"
+            )));
+        };
+        self.mob_retire(&mob_id, meerkat_id).await
     }
 
     pub async fn mob_wire(
@@ -428,21 +434,30 @@ impl CoreCommsRuntime for LocalCommsRuntime {
 
 struct LocalSessionService {
     sessions: RwLock<HashMap<SessionId, Arc<LocalCommsRuntime>>>,
+    archived_views: RwLock<HashMap<SessionId, SessionView>>,
     pending_context: RwLock<HashMap<SessionId, Vec<AppendSystemContextRequest>>>,
     /// Per-session broadcast channels for event streaming.
     event_txs:
         RwLock<HashMap<SessionId, tokio::sync::broadcast::Sender<EventEnvelope<AgentEvent>>>>,
     counter: std::sync::atomic::AtomicU64,
+    archive_delay_ms: std::sync::atomic::AtomicU64,
 }
 
 impl LocalSessionService {
     fn new() -> Self {
         Self {
             sessions: RwLock::new(HashMap::new()),
+            archived_views: RwLock::new(HashMap::new()),
             pending_context: RwLock::new(HashMap::new()),
             event_txs: RwLock::new(HashMap::new()),
             counter: std::sync::atomic::AtomicU64::new(0),
+            archive_delay_ms: std::sync::atomic::AtomicU64::new(0),
         }
+    }
+
+    fn set_archive_delay_ms(&self, delay_ms: u64) {
+        self.archive_delay_ms
+            .store(delay_ms, std::sync::atomic::Ordering::Relaxed);
     }
 }
 
@@ -567,13 +582,22 @@ impl SessionService for LocalSessionService {
         })
     }
 
-    async fn interrupt(&self, _id: &SessionId) -> Result<(), SessionError> {
+    async fn interrupt(&self, id: &SessionId) -> Result<(), SessionError> {
+        if !self.sessions.read().await.contains_key(id) {
+            return Err(SessionError::NotFound { id: id.clone() });
+        }
         Ok(())
     }
 
     async fn read(&self, id: &SessionId) -> Result<SessionView, SessionError> {
         if !self.sessions.read().await.contains_key(id) {
-            return Err(SessionError::NotFound { id: id.clone() });
+            return self
+                .archived_views
+                .read()
+                .await
+                .get(id)
+                .cloned()
+                .ok_or_else(|| SessionError::NotFound { id: id.clone() });
         }
         Ok(SessionView {
             state: SessionInfo {
@@ -611,10 +635,34 @@ impl SessionService for LocalSessionService {
     }
 
     async fn archive(&self, id: &SessionId) -> Result<(), SessionError> {
+        let archive_delay_ms = self
+            .archive_delay_ms
+            .load(std::sync::atomic::Ordering::Relaxed);
+        if archive_delay_ms > 0 {
+            tokio::time::sleep(std::time::Duration::from_millis(archive_delay_ms)).await;
+        }
         let removed = self.sessions.write().await.remove(id);
         self.pending_context.write().await.remove(id);
         self.event_txs.write().await.remove(id);
         if removed.is_some() {
+            self.archived_views.write().await.insert(
+                id.clone(),
+                SessionView {
+                    state: SessionInfo {
+                        session_id: id.clone(),
+                        created_at: SystemTime::now(),
+                        updated_at: SystemTime::now(),
+                        message_count: 0,
+                        is_active: false,
+                        last_assistant_text: None,
+                        labels: Default::default(),
+                    },
+                    billing: SessionUsage {
+                        total_tokens: 0,
+                        usage: Usage::default(),
+                    },
+                },
+            );
             Ok(())
         } else {
             Err(SessionError::NotFound { id: id.clone() })
@@ -710,6 +758,14 @@ impl MobSessionService for LocalSessionService {
 
     async fn session_belongs_to_mob(&self, _session_id: &SessionId, _mob_id: &MobId) -> bool {
         true
+    }
+}
+
+impl MobMcpState {
+    pub fn new_in_memory_with_archive_delay(delay_ms: u64) -> Arc<Self> {
+        let session_service = Arc::new(LocalSessionService::new());
+        session_service.set_archive_delay_ms(delay_ms);
+        Arc::new(Self::new(session_service))
     }
 }
 
@@ -1767,6 +1823,47 @@ mod tests {
 
         let pending = service.pending_context.read().await;
         assert_eq!(pending.get(&session_id).map(std::vec::Vec::len), Some(0));
+    }
+
+    #[tokio::test]
+    async fn local_session_service_archive_drops_staged_context() {
+        let service = LocalSessionService::new();
+        let run = service
+            .create_session(CreateSessionRequest {
+                model: "claude-sonnet-4-5".to_string(),
+                prompt: "hello".to_string(),
+                system_prompt: None,
+                max_tokens: None,
+                event_tx: None,
+                host_mode: false,
+                skill_references: None,
+                initial_turn: InitialTurnPolicy::Defer,
+                build: None,
+                labels: None,
+            })
+            .await
+            .expect("create session");
+        let session_id = run.session_id;
+
+        service
+            .append_system_context(
+                &session_id,
+                AppendSystemContextRequest {
+                    text: "Remember the customer preference.".to_string(),
+                    source: Some("mob".to_string()),
+                    idempotency_key: Some("ctx-archive".to_string()),
+                },
+            )
+            .await
+            .expect("append context");
+
+        service.archive(&session_id).await.expect("archive session");
+
+        let pending = service.pending_context.read().await;
+        assert!(
+            !pending.contains_key(&session_id),
+            "archive must drop unapplied staged context"
+        );
     }
 
     #[tokio::test]

--- a/meerkat-mob/src/runtime/actor.rs
+++ b/meerkat-mob/src/runtime/actor.rs
@@ -2201,7 +2201,12 @@ impl MobActor {
             roster.get(&meerkat_id).cloned()
         };
         let entry = match entry {
-            Some(e) => e,
+            Some(e) => {
+                if e.state != crate::roster::MemberState::Active {
+                    return Err(MobError::MeerkatNotFound(meerkat_id));
+                }
+                e
+            }
             None => {
                 // Consult spawn policy for auto-provisioning
                 if let Some(ref policy) = self.spawn_policy
@@ -2290,6 +2295,9 @@ impl MobActor {
                 .cloned()
                 .ok_or_else(|| MobError::MeerkatNotFound(meerkat_id.clone()))?
         };
+        if entry.state != crate::roster::MemberState::Active {
+            return Err(MobError::MeerkatNotFound(meerkat_id));
+        }
 
         self.dispatch_member_turn(&entry, message).await.map(|_| ())
     }

--- a/meerkat-mob/src/runtime/tests.rs
+++ b/meerkat-mob/src/runtime/tests.rs
@@ -301,6 +301,7 @@ struct MockSessionService {
     create_session_delay_ms: AtomicU64,
     create_session_in_flight: AtomicU64,
     create_session_max_in_flight: AtomicU64,
+    archive_delay_ms: AtomicU64,
     start_turn_delay_ms: AtomicU64,
     flow_turn_delay_ms: AtomicU64,
     flow_turn_never_terminal: std::sync::atomic::AtomicBool,
@@ -335,6 +336,7 @@ impl MockSessionService {
             create_session_delay_ms: AtomicU64::new(0),
             create_session_in_flight: AtomicU64::new(0),
             create_session_max_in_flight: AtomicU64::new(0),
+            archive_delay_ms: AtomicU64::new(0),
             start_turn_delay_ms: AtomicU64::new(0),
             flow_turn_delay_ms: AtomicU64::new(0),
             flow_turn_never_terminal: std::sync::atomic::AtomicBool::new(false),
@@ -468,6 +470,10 @@ impl MockSessionService {
 
     fn max_concurrent_create_session_calls(&self) -> u64 {
         self.create_session_max_in_flight.load(Ordering::Relaxed)
+    }
+
+    fn set_archive_delay_ms(&self, delay_ms: u64) {
+        self.archive_delay_ms.store(delay_ms, Ordering::Relaxed);
     }
 
     fn set_start_turn_delay_ms(&self, delay_ms: u64) {
@@ -841,6 +847,10 @@ impl SessionService for MockSessionService {
             return Err(SessionError::Store(Box::new(std::io::Error::other(
                 "mock archive failure",
             ))));
+        }
+        let archive_delay_ms = self.archive_delay_ms.load(Ordering::Relaxed);
+        if archive_delay_ms > 0 {
+            tokio::time::sleep(std::time::Duration::from_millis(archive_delay_ms)).await;
         }
         let mut sessions = self.sessions.write().await;
         if let Some(runtime) = sessions.remove(id) {
@@ -6691,6 +6701,79 @@ async fn test_concurrent_spawn_and_retire_same_meerkat_is_serialized() {
     assert!(
         roster.is_empty() || (roster.len() == 1 && roster[0].meerkat_id.as_str() == "w-1"),
         "serialized spawn/retire should never corrupt roster"
+    );
+}
+
+#[tokio::test]
+async fn test_retiring_member_is_not_routable_before_disposal_completes() {
+    let (handle, service) = create_test_mob(sample_definition()).await;
+    service.set_archive_delay_ms(250);
+
+    let session_id = handle
+        .spawn(ProfileName::from("worker"), MeerkatId::from("w-1"), None)
+        .await
+        .expect("spawn w-1")
+        .session_id()
+        .expect("session-backed")
+        .clone();
+
+    let retire_handle = {
+        let handle = handle.clone();
+        tokio::spawn(async move { handle.retire(MeerkatId::from("w-1")).await })
+    };
+
+    tokio::time::sleep(Duration::from_millis(25)).await;
+
+    let active_members = handle.list_members().await;
+    assert!(
+        active_members.is_empty(),
+        "retiring member must leave the active roster before disposal completes"
+    );
+
+    let all_members = handle.list_all_members().await;
+    assert_eq!(
+        all_members.len(),
+        1,
+        "retiring member should remain observable"
+    );
+    assert_eq!(all_members[0].meerkat_id.as_str(), "w-1");
+    assert_eq!(all_members[0].state, crate::roster::MemberState::Retiring);
+
+    let start_turn_calls_before = service.start_turn_call_count();
+    let external_turn = handle
+        .send_message(MeerkatId::from("w-1"), "still there?".to_string())
+        .await
+        .expect_err("retiring member must reject new external work");
+    assert!(matches!(external_turn, MobError::MeerkatNotFound(id) if id.as_str() == "w-1"));
+
+    let internal_turn = handle
+        .internal_turn(MeerkatId::from("w-1"), "still there?".to_string())
+        .await
+        .expect_err("retiring member must reject new internal work");
+    assert!(matches!(internal_turn, MobError::MeerkatNotFound(id) if id.as_str() == "w-1"));
+
+    assert_eq!(
+        service.start_turn_call_count(),
+        start_turn_calls_before,
+        "blocked turns must not reach the backing session"
+    );
+
+    retire_handle
+        .await
+        .expect("retire join")
+        .expect("retire completes");
+    assert!(
+        handle.get_member(&MeerkatId::from("w-1")).await.is_none(),
+        "member should be removed once retirement completes"
+    );
+    assert_eq!(
+        service.active_session_count().await,
+        0,
+        "completed retirement must archive the backing session"
+    );
+    assert!(
+        service.read(&session_id).await.is_err(),
+        "retired backing session should no longer resolve as active in the owner test harness"
     );
 }
 

--- a/meerkat-rpc/src/handlers/turn.rs
+++ b/meerkat-rpc/src/handlers/turn.rs
@@ -12,6 +12,8 @@ use meerkat_core::skills::{SkillKey, SkillRef};
 
 use super::{RpcResponseExt, parse_params, parse_session_id_for_runtime};
 use crate::NOTIFICATION_CHANNEL_CAPACITY;
+#[cfg(feature = "mob")]
+use crate::error;
 use crate::protocol::{RpcId, RpcResponse};
 use crate::router::NotificationSink;
 use crate::session_runtime::SessionRuntime;
@@ -138,6 +140,7 @@ pub async fn handle_interrupt(
     id: Option<RpcId>,
     params: Option<&RawValue>,
     runtime: &SessionRuntime,
+    #[cfg(feature = "mob")] mob_state: &meerkat_mob_mcp::MobMcpState,
 ) -> RpcResponse {
     let params: InterruptParams = match parse_params(params) {
         Ok(p) => p,
@@ -151,6 +154,15 @@ pub async fn handle_interrupt(
 
     match runtime.interrupt(&session_id).await {
         Ok(()) => RpcResponse::success(id, serde_json::json!({"interrupted": true})),
+        #[cfg(feature = "mob")]
+        Err(rpc_err) if rpc_err.code == error::SESSION_NOT_FOUND => {
+            match mob_state.session_service().interrupt(&session_id).await {
+                Ok(()) | Err(meerkat_core::service::SessionError::NotRunning { .. }) => {
+                    RpcResponse::success(id, serde_json::json!({"interrupted": true}))
+                }
+                Err(err) => RpcResponse::error(id, error::SESSION_NOT_FOUND, err.to_string()),
+            }
+        }
         Err(rpc_err) => RpcResponse::error(id, rpc_err.code, rpc_err.message),
     }
 }

--- a/meerkat-rpc/src/router.rs
+++ b/meerkat-rpc/src/router.rs
@@ -6,6 +6,7 @@ use std::sync::Arc;
 use futures::StreamExt;
 use tokio::sync::Mutex;
 use tokio::sync::mpsc;
+use tokio::sync::mpsc::error::TrySendError;
 use tokio::sync::oneshot;
 use tokio::task::JoinHandle;
 use uuid::Uuid;
@@ -22,6 +23,13 @@ use crate::handlers::RpcResponseExt;
 use crate::protocol::{RpcNotification, RpcRequest, RpcResponse};
 use crate::session_runtime::SessionRuntime;
 
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum SessionOwner {
+    Runtime,
+    #[cfg(feature = "mob")]
+    Mob,
+}
+
 // ---------------------------------------------------------------------------
 // NotificationSink
 // ---------------------------------------------------------------------------
@@ -31,6 +39,13 @@ use crate::session_runtime::SessionRuntime;
 #[derive(Clone)]
 pub struct NotificationSink {
     tx: mpsc::Sender<RpcNotification>,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum StreamEmitStatus {
+    Delivered,
+    Overflow,
+    ReceiverGone,
 }
 
 impl NotificationSink {
@@ -51,13 +66,13 @@ impl NotificationSink {
     }
 
     /// Emit a standalone session stream event notification.
-    pub async fn emit_session_stream_event(
+    async fn emit_session_stream_event(
         &self,
         stream_id: &Uuid,
         sequence: u64,
         session_id: &SessionId,
         event: &EventEnvelope<AgentEvent>,
-    ) {
+    ) -> StreamEmitStatus {
         let params = serde_json::json!({
             "stream_id": stream_id.to_string(),
             "sequence": sequence,
@@ -65,16 +80,33 @@ impl NotificationSink {
             "event": event,
         });
         let notification = RpcNotification::new("session/stream_event", params);
-        let _ = self.tx.send(notification).await;
+        match self.tx.try_send(notification) {
+            Ok(()) => StreamEmitStatus::Delivered,
+            Err(TrySendError::Full(_)) => StreamEmitStatus::Overflow,
+            Err(TrySendError::Closed(_)) => StreamEmitStatus::ReceiverGone,
+        }
     }
 
     /// Emit an explicit terminal notification for a standalone session stream.
-    pub async fn emit_session_stream_end(&self, stream_id: &Uuid, session_id: &SessionId) {
-        let params = serde_json::json!({
+    pub async fn emit_session_stream_end(
+        &self,
+        stream_id: &Uuid,
+        session_id: &SessionId,
+        outcome: &str,
+        detail: Option<&str>,
+    ) {
+        let mut params = serde_json::json!({
             "stream_id": stream_id.to_string(),
             "session_id": session_id.to_string(),
             "ended": true,
+            "outcome": outcome,
         });
+        if let Some(detail) = detail {
+            params["error"] = serde_json::json!({
+                "code": "stream_queue_overflow",
+                "message": detail,
+            });
+        }
         let notification = RpcNotification::new("session/stream_end", params);
         let _ = self.tx.send(notification).await;
     }
@@ -89,29 +121,48 @@ impl NotificationSink {
         stream_id: &Uuid,
         sequence: u64,
         event: &serde_json::Value,
-    ) {
+    ) -> StreamEmitStatus {
         let params = serde_json::json!({
             "stream_id": stream_id.to_string(),
             "sequence": sequence,
             "event": event,
         });
         let notification = RpcNotification::new("mob/stream_event", params);
-        let _ = self.tx.send(notification).await;
+        match self.tx.try_send(notification) {
+            Ok(()) => StreamEmitStatus::Delivered,
+            Err(TrySendError::Full(_)) => StreamEmitStatus::Overflow,
+            Err(TrySendError::Closed(_)) => StreamEmitStatus::ReceiverGone,
+        }
     }
 
     #[cfg(feature = "mob")]
-    async fn emit_mob_stream_end(&self, stream_id: &Uuid) {
-        let params = serde_json::json!({
+    async fn emit_mob_stream_end(&self, stream_id: &Uuid, outcome: &str, detail: Option<&str>) {
+        let mut params = serde_json::json!({
             "stream_id": stream_id.to_string(),
             "ended": true,
+            "outcome": outcome,
         });
+        if let Some(detail) = detail {
+            params["error"] = serde_json::json!({
+                "code": "stream_queue_overflow",
+                "message": detail,
+            });
+        }
         let notification = RpcNotification::new("mob/stream_end", params);
         let _ = self.tx.send(notification).await;
     }
 }
 
 struct StreamForwarder {
+    terminal: StreamTerminal,
     state: StreamForwarderState,
+}
+
+#[derive(Clone)]
+enum StreamTerminal {
+    Session(SessionId),
+    #[cfg(feature = "mob")]
+    Mob,
 }
 
 enum StreamForwarderState {
@@ -213,6 +264,29 @@ impl MethodRouter {
         }
     }
 
+    #[cfg(all(test, feature = "mob"))]
+    fn new_with_mob_state(
+        runtime: Arc<SessionRuntime>,
+        config_store: Arc<dyn ConfigStore>,
+        notification_sink: NotificationSink,
+        mob_state: Arc<meerkat_mob_mcp::MobMcpState>,
+    ) -> Self {
+        Self {
+            runtime,
+            config_store,
+            notification_sink,
+            skill_runtime: None,
+            active_session_streams: Arc::new(Mutex::new(HashMap::new())),
+            closed_session_streams: Arc::new(Mutex::new(ClosedStreamSet::new())),
+            #[cfg(feature = "mob")]
+            mob_state,
+            #[cfg(feature = "mob")]
+            active_mob_streams: Arc::new(Mutex::new(HashMap::new())),
+            #[cfg(feature = "mob")]
+            closed_mob_streams: Arc::new(Mutex::new(ClosedStreamSet::new())),
+        }
+    }
+
     /// Set the skill runtime for introspection methods.
     pub fn with_skill_runtime(
         mut self,
@@ -220,6 +294,30 @@ impl MethodRouter {
     ) -> Self {
         self.skill_runtime = runtime;
         self
+    }
+
+    // This intentionally does only the minimum owner probe. Handlers perform
+    // the authoritative operation-specific read again so they observe the
+    // freshest lifecycle state instead of routing off a cached snapshot.
+    async fn resolve_session_owner(&self, session_id: &SessionId) -> Option<SessionOwner> {
+        if self.runtime.session_state(session_id).await.is_some()
+            || self.runtime.read_session(session_id).await.is_ok()
+        {
+            return Some(SessionOwner::Runtime);
+        }
+
+        #[cfg(feature = "mob")]
+        if self
+            .mob_state
+            .session_service()
+            .read(session_id)
+            .await
+            .is_ok()
+        {
+            return Some(SessionOwner::Mob);
+        }
+
+        None
     }
 
     /// Dispatch a request to the appropriate handler.
@@ -263,7 +361,17 @@ impl MethodRouter {
                 handlers::turn::handle_start(id, params, &self.runtime, &self.notification_sink)
                     .await
             }
-            "turn/interrupt" => handlers::turn::handle_interrupt(id, params, &self.runtime).await,
+            "turn/interrupt" => {
+                #[cfg(feature = "mob")]
+                {
+                    handlers::turn::handle_interrupt(id, params, &self.runtime, &self.mob_state)
+                        .await
+                }
+                #[cfg(not(feature = "mob"))]
+                {
+                    handlers::turn::handle_interrupt(id, params, &self.runtime).await
+                }
+            }
             #[cfg(feature = "mob")]
             "mob/prefabs" => handlers::mob::handle_prefabs(id).await,
             #[cfg(feature = "mob")]
@@ -394,36 +502,53 @@ impl MethodRouter {
             Err(resp) => return resp,
         };
 
-        if let Some(info) = self.runtime.session_state(&session_id).await {
-            return RpcResponse::success(
+        match self.resolve_session_owner(&session_id).await {
+            Some(SessionOwner::Runtime) => {
+                if let Some(info) = self.runtime.session_state(&session_id).await {
+                    return RpcResponse::success(
+                        id,
+                        json!({
+                            "session_id": session_id.to_string(),
+                            "session_ref": self.runtime.realm_id().map(|realm| meerkat_contracts::format_session_ref(realm, &session_id)),
+                            "state": info.state.as_str(),
+                            "labels": info.labels,
+                        }),
+                    );
+                }
+                match self.runtime.read_session(&session_id).await {
+                    Ok(view) => RpcResponse::success(
+                        id,
+                        json!({
+                            "session_id": session_id.to_string(),
+                            "session_ref": self.runtime.realm_id().map(|realm| meerkat_contracts::format_session_ref(realm, &session_id)),
+                            "state": if view.state.is_active { "running" } else { "idle" },
+                            "labels": view.state.labels,
+                        }),
+                    ),
+                    Err(rpc_err) => RpcResponse::error(id, rpc_err.code, rpc_err.message),
+                }
+            }
+            #[cfg(feature = "mob")]
+            Some(SessionOwner::Mob) => {
+                match self.mob_state.session_service().read(&session_id).await {
+                    Ok(view) => RpcResponse::success(
+                        id,
+                        json!({
+                            "session_id": session_id.to_string(),
+                            "session_ref": self.runtime.realm_id().map(|realm| meerkat_contracts::format_session_ref(realm, &session_id)),
+                            "state": if view.state.is_active { "running" } else { "idle" },
+                            "labels": view.state.labels,
+                        }),
+                    ),
+                    Err(err) => RpcResponse::error(id, error::SESSION_NOT_FOUND, err.to_string()),
+                }
+            }
+            None => RpcResponse::error(
                 id,
-                json!({
-                    "session_id": session_id.to_string(),
-                    "session_ref": self.runtime.realm_id().map(|realm| meerkat_contracts::format_session_ref(realm, &session_id)),
-                    "state": info.state.as_str(),
-                    "labels": info.labels,
-                }),
-            );
+                error::SESSION_NOT_FOUND,
+                format!("Session not found: {session_id}"),
+            ),
         }
-
-        #[cfg(feature = "mob")]
-        if let Ok(view) = self.mob_state.session_service().read(&session_id).await {
-            return RpcResponse::success(
-                id,
-                json!({
-                    "session_id": session_id.to_string(),
-                    "session_ref": self.runtime.realm_id().map(|realm| meerkat_contracts::format_session_ref(realm, &session_id)),
-                    "state": if view.state.is_active { "running" } else { "idle" },
-                    "labels": view.state.labels,
-                }),
-            );
-        }
-
-        RpcResponse::error(
-            id,
-            error::SESSION_NOT_FOUND,
-            format!("Session not found: {session_id}"),
-        )
     }
 
     async fn handle_session_archive(
@@ -443,22 +568,25 @@ impl MethodRouter {
             Ok(sid) => sid,
             Err(resp) => return resp,
         };
-        match self.runtime.archive_session(&session_id).await {
-            Ok(()) => RpcResponse::success(id, json!({"archived": true})),
-            Err(rpc_err) if rpc_err.code == error::SESSION_NOT_FOUND => {
-                #[cfg(feature = "mob")]
-                {
-                    if let Ok(()) = self
-                        .mob_state
-                        .retire_member_by_session_id(&session_id)
-                        .await
-                    {
-                        return RpcResponse::success(id, json!({"archived": true}));
-                    }
-                }
-                RpcResponse::error(id, rpc_err.code, rpc_err.message)
-            }
-            Err(rpc_err) => RpcResponse::error(id, rpc_err.code, rpc_err.message),
+        match self.resolve_session_owner(&session_id).await {
+            Some(SessionOwner::Runtime) => match self.runtime.archive_session(&session_id).await {
+                Ok(()) => RpcResponse::success(id, json!({"archived": true})),
+                Err(rpc_err) => RpcResponse::error(id, rpc_err.code, rpc_err.message),
+            },
+            #[cfg(feature = "mob")]
+            Some(SessionOwner::Mob) => match self
+                .mob_state
+                .retire_member_by_session_id(&session_id)
+                .await
+            {
+                Ok(()) => RpcResponse::success(id, json!({"archived": true})),
+                Err(err) => RpcResponse::error(id, error::SESSION_NOT_FOUND, err.to_string()),
+            },
+            None => RpcResponse::error(
+                id,
+                error::SESSION_NOT_FOUND,
+                format!("Session not found: {session_id}"),
+            ),
         }
     }
 
@@ -485,27 +613,28 @@ impl MethodRouter {
             source: params.source,
             idempotency_key: params.idempotency_key,
         };
-        match self
-            .runtime
-            .append_system_context(&session_id, req.clone())
-            .await
-        {
-            Ok(result) => RpcResponse::success(id, json!({"status": result.status})),
-            Err(rpc_err) if rpc_err.code == error::SESSION_NOT_FOUND => {
-                #[cfg(feature = "mob")]
-                {
-                    if let Ok(result) = self
-                        .mob_state
-                        .session_service()
-                        .append_system_context(&session_id, req)
-                        .await
-                    {
-                        return RpcResponse::success(id, json!({"status": result.status}));
-                    }
+        match self.resolve_session_owner(&session_id).await {
+            Some(SessionOwner::Runtime) => {
+                match self.runtime.append_system_context(&session_id, req).await {
+                    Ok(result) => RpcResponse::success(id, json!({"status": result.status})),
+                    Err(rpc_err) => RpcResponse::error(id, rpc_err.code, rpc_err.message),
                 }
-                RpcResponse::error(id, rpc_err.code, rpc_err.message)
             }
-            Err(rpc_err) => RpcResponse::error(id, rpc_err.code, rpc_err.message),
+            #[cfg(feature = "mob")]
+            Some(SessionOwner::Mob) => match self
+                .mob_state
+                .session_service()
+                .append_system_context(&session_id, req)
+                .await
+            {
+                Ok(result) => RpcResponse::success(id, json!({"status": result.status})),
+                Err(err) => RpcResponse::error(id, error::SESSION_NOT_FOUND, err.to_string()),
+            },
+            None => RpcResponse::error(
+                id,
+                error::SESSION_NOT_FOUND,
+                format!("Session not found: {session_id}"),
+            ),
         }
     }
 
@@ -527,20 +656,25 @@ impl MethodRouter {
             Ok(sid) => sid,
             Err(resp) => return resp,
         };
-        let comms = if let Some(c) = self.runtime.comms_runtime(&session_id).await {
-            Some(c)
-        } else {
+        let comms = match self.resolve_session_owner(&session_id).await {
+            Some(SessionOwner::Runtime) => {
+                if self.runtime.session_state(&session_id).await.is_none() {
+                    return RpcResponse::error(
+                        id,
+                        error::INVALID_PARAMS,
+                        format!("Session is archived: {session_id}"),
+                    );
+                }
+                self.runtime.comms_runtime(&session_id).await
+            }
             #[cfg(feature = "mob")]
-            {
+            Some(SessionOwner::Mob) => {
                 self.mob_state
                     .session_service()
                     .comms_runtime(&session_id)
                     .await
             }
-            #[cfg(not(feature = "mob"))]
-            {
-                None
-            }
+            None => None,
         };
         let Some(comms) = comms else {
             return RpcResponse::error(
@@ -609,20 +743,25 @@ impl MethodRouter {
             Ok(sid) => sid,
             Err(resp) => return resp,
         };
-        let comms = if let Some(c) = self.runtime.comms_runtime(&session_id).await {
-            Some(c)
-        } else {
+        let comms = match self.resolve_session_owner(&session_id).await {
+            Some(SessionOwner::Runtime) => {
+                if self.runtime.session_state(&session_id).await.is_none() {
+                    return RpcResponse::error(
+                        id,
+                        error::INVALID_PARAMS,
+                        format!("Session is archived: {session_id}"),
+                    );
+                }
+                self.runtime.comms_runtime(&session_id).await
+            }
             #[cfg(feature = "mob")]
-            {
+            Some(SessionOwner::Mob) => {
                 self.mob_state
                     .session_service()
                     .comms_runtime(&session_id)
                     .await
             }
-            #[cfg(not(feature = "mob"))]
-            {
-                None
-            }
+            None => None,
         };
         let Some(comms) = comms else {
             return RpcResponse::error(
@@ -675,37 +814,43 @@ impl MethodRouter {
             Err(resp) => return resp,
         };
 
-        let stream = match self.runtime.subscribe_session_events(&session_id).await {
-            Ok(stream) => stream,
-            Err(runtime_err) => {
-                #[cfg(feature = "mob")]
-                {
-                    match meerkat_mob::MobSessionService::subscribe_session_events(
-                        self.mob_state.session_service(),
-                        &session_id,
-                    )
-                    .await
-                    {
-                        Ok(stream) => stream,
-                        Err(err) => {
-                            return RpcResponse::error(
-                                id,
-                                error::INVALID_PARAMS,
-                                format!(
-                                    "Failed to subscribe to session events: {runtime_err}; fallback: {err}"
-                                ),
-                            );
-                        }
+        let stream = match self.resolve_session_owner(&session_id).await {
+            Some(SessionOwner::Runtime) => {
+                match self.runtime.subscribe_session_events(&session_id).await {
+                    Ok(stream) => stream,
+                    Err(err) => {
+                        return RpcResponse::error(
+                            id,
+                            error::INVALID_PARAMS,
+                            format!("Failed to subscribe to session events: {err}"),
+                        );
                     }
                 }
-                #[cfg(not(feature = "mob"))]
+            }
+            #[cfg(feature = "mob")]
+            Some(SessionOwner::Mob) => {
+                match meerkat_mob::MobSessionService::subscribe_session_events(
+                    self.mob_state.session_service(),
+                    &session_id,
+                )
+                .await
                 {
-                    return RpcResponse::error(
-                        id,
-                        error::INVALID_PARAMS,
-                        format!("Failed to subscribe to session events: {runtime_err}"),
-                    );
+                    Ok(stream) => stream,
+                    Err(err) => {
+                        return RpcResponse::error(
+                            id,
+                            error::INVALID_PARAMS,
+                            format!("Failed to subscribe to session events: {err}"),
+                        );
+                    }
                 }
+            }
+            None => {
+                return RpcResponse::error(
+                    id,
+                    error::SESSION_NOT_FOUND,
+                    format!("Session not found: {session_id}"),
+                );
             }
         };
 
@@ -732,38 +877,78 @@ impl MethodRouter {
                         match event {
                             Some(envelope) => {
                                 sequence += 1;
-                                notification_sink
+                                let emit_status = notification_sink
                                     .emit_session_stream_event(&stream_id_for_task, sequence, &session_id_for_task, &envelope)
                                     .await;
+                                if emit_status == StreamEmitStatus::Overflow {
+                                    let should_emit = {
+                                        let mut streams = active_session_streams.lock().await;
+                                        if streams
+                                            .get(&stream_id_for_task)
+                                            .is_some_and(|s| matches!(s.state, StreamForwarderState::Active { .. }))
+                                        {
+                                            streams.remove(&stream_id_for_task);
+                                            closed_session_streams
+                                                .lock()
+                                                .await
+                                                .insert(stream_id_for_task);
+                                            true
+                                        } else {
+                                            false
+                                        }
+                                    };
+                                    if should_emit {
+                                        notification_sink
+                                            .emit_session_stream_end(
+                                                &stream_id_for_task,
+                                                &session_id_for_task,
+                                                "terminal_error",
+                                                Some("transport stream notification queue overflow"),
+                                            )
+                                            .await;
+                                    }
+                                    break;
+                                }
                             }
                             None => {
-                                notification_sink
-                                    .emit_session_stream_end(&stream_id_for_task, &session_id_for_task)
-                                    .await;
+                                let should_emit = {
+                                    let mut streams = active_session_streams.lock().await;
+                                    if streams
+                                        .get(&stream_id_for_task)
+                                        .is_some_and(|s| matches!(s.state, StreamForwarderState::Active { .. }))
+                                    {
+                                        streams.remove(&stream_id_for_task);
+                                        closed_session_streams
+                                            .lock()
+                                            .await
+                                            .insert(stream_id_for_task);
+                                        true
+                                    } else {
+                                        false
+                                    }
+                                };
+                                if should_emit {
+                                    notification_sink
+                                        .emit_session_stream_end(
+                                            &stream_id_for_task,
+                                            &session_id_for_task,
+                                            "remote_end",
+                                            None,
+                                        )
+                                        .await;
+                                }
                                 break;
                             }
                         }
                     }
                 }
             }
-
-            let mut streams = active_session_streams.lock().await;
-            if streams
-                .get(&stream_id_for_task)
-                .is_some_and(|s| matches!(s.state, StreamForwarderState::Active { .. }))
-            {
-                streams.remove(&stream_id_for_task);
-                // Track natural completion so subsequent close returns already_closed=true
-                closed_session_streams
-                    .lock()
-                    .await
-                    .insert(stream_id_for_task);
-            }
         });
 
         self.active_session_streams.lock().await.insert(
             stream_id,
             StreamForwarder {
+                terminal: StreamTerminal::Session(session_id.clone()),
                 state: StreamForwarderState::Active {
                     stop_tx: Some(stop_tx),
                     task,
@@ -810,18 +995,33 @@ impl MethodRouter {
             }
         };
 
-        let mut active_session_streams = self.active_session_streams.lock().await;
-        let already_closed = match active_session_streams.remove(&stream_id) {
-            Some(mut stream) => match &mut stream.state {
-                StreamForwarderState::Active { stop_tx, task } => {
-                    if let Some(stop_tx) = stop_tx.take() {
-                        let _ = stop_tx.send(());
+        let closed_terminal = {
+            let mut active_session_streams = self.active_session_streams.lock().await;
+            match active_session_streams.remove(&stream_id) {
+                Some(mut stream) => match &mut stream.state {
+                    StreamForwarderState::Active { stop_tx, task } => {
+                        if let Some(stop_tx) = stop_tx.take() {
+                            let _ = stop_tx.send(());
+                        }
+                        task.abort();
+                        self.closed_session_streams.lock().await.insert(stream_id);
+                        Some(stream.terminal)
                     }
-                    task.abort();
-                    self.closed_session_streams.lock().await.insert(stream_id);
-                    false
-                }
-            },
+                },
+                None => None,
+            }
+        };
+        let already_closed = match closed_terminal {
+            Some(StreamTerminal::Session(session_id)) => {
+                self.notification_sink
+                    .emit_session_stream_end(&stream_id, &session_id, "explicit_close", None)
+                    .await;
+                false
+            }
+            #[cfg(feature = "mob")]
+            Some(StreamTerminal::Mob) => {
+                unreachable!("session stream stored mob terminal metadata")
+            }
             None => self.closed_session_streams.lock().await.remove(&stream_id),
         };
 
@@ -907,39 +1107,70 @@ impl MethodRouter {
                                     sequence += 1;
                                     let event_json = serde_json::to_value(&envelope)
                                         .unwrap_or(serde_json::Value::Null);
-                                    notification_sink
+                                    let emit_status = notification_sink
                                         .emit_mob_stream_event(
                                             &stream_id_for_task,
                                             sequence,
                                             &event_json,
                                         )
                                         .await;
+                                    if emit_status == StreamEmitStatus::Overflow {
+                                        let should_emit = {
+                                            let mut streams = active_mob_streams.lock().await;
+                                            if streams
+                                                .get(&stream_id_for_task)
+                                                .is_some_and(|s| matches!(s.state, StreamForwarderState::Active { .. }))
+                                            {
+                                                streams.remove(&stream_id_for_task);
+                                                closed_mob_streams.lock().await.insert(stream_id_for_task);
+                                                true
+                                            } else {
+                                                false
+                                            }
+                                        };
+                                        if should_emit {
+                                            notification_sink
+                                                .emit_mob_stream_end(
+                                                    &stream_id_for_task,
+                                                    "terminal_error",
+                                                    Some("transport stream notification queue overflow"),
+                                                )
+                                                .await;
+                                        }
+                                        break;
+                                    }
                                 }
                                 None => {
-                                    notification_sink
-                                        .emit_mob_stream_end(&stream_id_for_task)
-                                        .await;
+                                    let should_emit = {
+                                        let mut streams = active_mob_streams.lock().await;
+                                        if streams
+                                            .get(&stream_id_for_task)
+                                            .is_some_and(|s| matches!(s.state, StreamForwarderState::Active { .. }))
+                                        {
+                                            streams.remove(&stream_id_for_task);
+                                            closed_mob_streams.lock().await.insert(stream_id_for_task);
+                                            true
+                                        } else {
+                                            false
+                                        }
+                                    };
+                                    if should_emit {
+                                        notification_sink
+                                            .emit_mob_stream_end(&stream_id_for_task, "remote_end", None)
+                                            .await;
+                                    }
                                     break;
                                 }
                             }
                         }
                     }
                 }
-
-                let closed_mob_streams = closed_mob_streams.clone();
-                let mut streams = active_mob_streams.lock().await;
-                if streams
-                    .get(&stream_id_for_task)
-                    .is_some_and(|s| matches!(s.state, StreamForwarderState::Active { .. }))
-                {
-                    streams.remove(&stream_id_for_task);
-                    closed_mob_streams.lock().await.insert(stream_id_for_task);
-                }
             });
 
             self.active_mob_streams.lock().await.insert(
                 stream_id,
                 StreamForwarder {
+                    terminal: StreamTerminal::Mob,
                     state: StreamForwarderState::Active {
                         stop_tx: Some(stop_tx),
                         task,
@@ -965,38 +1196,70 @@ impl MethodRouter {
                                     sequence += 1;
                                     let event_json = serde_json::to_value(&attributed)
                                         .unwrap_or(serde_json::Value::Null);
-                                    notification_sink
+                                    let emit_status = notification_sink
                                         .emit_mob_stream_event(
                                             &stream_id_for_task,
                                             sequence,
                                             &event_json,
                                         )
                                         .await;
+                                    if emit_status == StreamEmitStatus::Overflow {
+                                        let should_emit = {
+                                            let mut streams = active_mob_streams.lock().await;
+                                            if streams
+                                                .get(&stream_id_for_task)
+                                                .is_some_and(|s| matches!(s.state, StreamForwarderState::Active { .. }))
+                                            {
+                                                streams.remove(&stream_id_for_task);
+                                                closed_mob_streams.lock().await.insert(stream_id_for_task);
+                                                true
+                                            } else {
+                                                false
+                                            }
+                                        };
+                                        if should_emit {
+                                            notification_sink
+                                                .emit_mob_stream_end(
+                                                    &stream_id_for_task,
+                                                    "terminal_error",
+                                                    Some("transport stream notification queue overflow"),
+                                                )
+                                                .await;
+                                        }
+                                        break;
+                                    }
                                 }
                                 None => {
-                                    notification_sink
-                                        .emit_mob_stream_end(&stream_id_for_task)
-                                        .await;
+                                    let should_emit = {
+                                        let mut streams = active_mob_streams.lock().await;
+                                        if streams
+                                            .get(&stream_id_for_task)
+                                            .is_some_and(|s| matches!(s.state, StreamForwarderState::Active { .. }))
+                                        {
+                                            streams.remove(&stream_id_for_task);
+                                            closed_mob_streams.lock().await.insert(stream_id_for_task);
+                                            true
+                                        } else {
+                                            false
+                                        }
+                                    };
+                                    if should_emit {
+                                        notification_sink
+                                            .emit_mob_stream_end(&stream_id_for_task, "remote_end", None)
+                                            .await;
+                                    }
                                     break;
                                 }
                             }
                         }
                     }
                 }
-
-                let mut streams = active_mob_streams.lock().await;
-                if streams
-                    .get(&stream_id_for_task)
-                    .is_some_and(|s| matches!(s.state, StreamForwarderState::Active { .. }))
-                {
-                    streams.remove(&stream_id_for_task);
-                    closed_mob_streams.lock().await.insert(stream_id_for_task);
-                }
             });
 
             self.active_mob_streams.lock().await.insert(
                 stream_id,
                 StreamForwarder {
+                    terminal: StreamTerminal::Mob,
                     state: StreamForwarderState::Active {
                         stop_tx: Some(stop_tx),
                         task,
@@ -1044,18 +1307,32 @@ impl MethodRouter {
             }
         };
 
-        let mut active_mob_streams = self.active_mob_streams.lock().await;
-        let already_closed = match active_mob_streams.remove(&stream_id) {
-            Some(mut stream) => match &mut stream.state {
-                StreamForwarderState::Active { stop_tx, task } => {
-                    if let Some(stop_tx) = stop_tx.take() {
-                        let _ = stop_tx.send(());
+        let closed_terminal = {
+            let mut active_mob_streams = self.active_mob_streams.lock().await;
+            match active_mob_streams.remove(&stream_id) {
+                Some(mut stream) => match &mut stream.state {
+                    StreamForwarderState::Active { stop_tx, task } => {
+                        if let Some(stop_tx) = stop_tx.take() {
+                            let _ = stop_tx.send(());
+                        }
+                        task.abort();
+                        self.closed_mob_streams.lock().await.insert(stream_id);
+                        Some(stream.terminal)
                     }
-                    task.abort();
-                    self.closed_mob_streams.lock().await.insert(stream_id);
-                    false
-                }
-            },
+                },
+                None => None,
+            }
+        };
+        let already_closed = match closed_terminal {
+            Some(StreamTerminal::Mob) => {
+                self.notification_sink
+                    .emit_mob_stream_end(&stream_id, "explicit_close", None)
+                    .await;
+                false
+            }
+            Some(StreamTerminal::Session(_)) => {
+                unreachable!("mob stream stored session terminal metadata")
+            }
             None => self.closed_mob_streams.lock().await.remove(&stream_id),
         };
 
@@ -1091,7 +1368,7 @@ mod tests {
         SourceIdentityRecord, SourceIdentityRegistry, SourceIdentityStatus, SourceTransportKind,
         SourceUuid,
     };
-    use meerkat_core::{Config, ConfigRuntime, MemoryConfigStore, StopReason};
+    use meerkat_core::{Config, ConfigRuntime, MemoryConfigStore, Message, StopReason};
     use serde::Serialize;
 
     use crate::protocol::RpcId;
@@ -1132,6 +1409,76 @@ mod tests {
         }
     }
 
+    struct RecordingMockLlmClient {
+        requests: Arc<std::sync::Mutex<Vec<Vec<Message>>>>,
+        delay_ms: Option<u64>,
+    }
+
+    impl RecordingMockLlmClient {
+        fn new(requests: Arc<std::sync::Mutex<Vec<Vec<Message>>>>) -> Self {
+            Self {
+                requests,
+                delay_ms: None,
+            }
+        }
+
+        fn with_delay(requests: Arc<std::sync::Mutex<Vec<Vec<Message>>>>, delay_ms: u64) -> Self {
+            Self {
+                requests,
+                delay_ms: Some(delay_ms),
+            }
+        }
+    }
+
+    #[async_trait]
+    impl LlmClient for RecordingMockLlmClient {
+        fn stream<'a>(
+            &'a self,
+            request: &'a meerkat_client::LlmRequest,
+        ) -> Pin<
+            Box<dyn futures::Stream<Item = Result<meerkat_client::LlmEvent, LlmError>> + Send + 'a>,
+        > {
+            self.requests
+                .lock()
+                .expect("recorded requests lock poisoned")
+                .push(request.messages.clone());
+            let delay = self.delay_ms;
+            Box::pin(stream::unfold(0u8, move |state| async move {
+                match state {
+                    0 => {
+                        if let Some(delay_ms) = delay {
+                            tokio::time::sleep(std::time::Duration::from_millis(delay_ms)).await;
+                        }
+                        Some((
+                            Ok(meerkat_client::LlmEvent::TextDelta {
+                                delta: "Hello from mock".to_string(),
+                                meta: None,
+                            }),
+                            1,
+                        ))
+                    }
+                    1 => Some((
+                        Ok(meerkat_client::LlmEvent::Done {
+                            outcome: meerkat_client::LlmDoneOutcome::Success {
+                                stop_reason: StopReason::EndTurn,
+                            },
+                        }),
+                        2,
+                    )),
+                    _ => None,
+                }
+            }))
+        }
+
+        fn provider(&self) -> &'static str {
+            "mock"
+        }
+
+        async fn health_check(&self) -> Result<(), LlmError> {
+            Ok(())
+        }
+    }
+
     // -----------------------------------------------------------------------
     // Test helpers
     // -----------------------------------------------------------------------
@@ -1153,6 +1500,74 @@ mod tests {
         let (notif_tx, notif_rx) = mpsc::channel(100);
         let sink = NotificationSink::new(notif_tx);
         let router = MethodRouter::new(runtime, config_store, sink);
+        (router, notif_rx)
+    }
+
+    async fn test_router_with_llm(
+        llm_client: Arc<dyn LlmClient>,
+    ) -> (MethodRouter, mpsc::Receiver<RpcNotification>) {
+        let temp = tempfile::tempdir().unwrap();
+        let factory = AgentFactory::new(temp.path().join("sessions"));
+        let config = Config::default();
+        let store: Arc<dyn meerkat::SessionStore> = Arc::new(meerkat::MemoryStore::new());
+        let mut runtime = SessionRuntime::new(factory, config, 10, store);
+        let config_store: Arc<dyn ConfigStore> =
+            Arc::new(MemoryConfigStore::new(Config::default()));
+        runtime.default_llm_client = Some(llm_client);
+        runtime.set_config_runtime(Arc::new(ConfigRuntime::new(
+            Arc::clone(&config_store),
+            temp.path().join("config_state.json"),
+        )));
+        let runtime = Arc::new(runtime);
+        let (notif_tx, notif_rx) = mpsc::channel(100);
+        let sink = NotificationSink::new(notif_tx);
+        let router = MethodRouter::new(runtime, config_store, sink);
+        (router, notif_rx)
+    }
+
+    async fn test_router_with_llm_and_notification_capacity(
+        llm_client: Arc<dyn LlmClient>,
+        notification_capacity: usize,
+    ) -> (MethodRouter, mpsc::Receiver<RpcNotification>) {
+        let temp = tempfile::tempdir().unwrap();
+        let factory = AgentFactory::new(temp.path().join("sessions"));
+        let config = Config::default();
+        let store: Arc<dyn meerkat::SessionStore> = Arc::new(meerkat::MemoryStore::new());
+        let mut runtime = SessionRuntime::new(factory, config, 10, store);
+        let config_store: Arc<dyn ConfigStore> =
+            Arc::new(MemoryConfigStore::new(Config::default()));
+        runtime.default_llm_client = Some(llm_client);
+        runtime.set_config_runtime(Arc::new(ConfigRuntime::new(
+            Arc::clone(&config_store),
+            temp.path().join("config_state.json"),
+        )));
+        let runtime = Arc::new(runtime);
+        let (notif_tx, notif_rx) = mpsc::channel(notification_capacity);
+        let sink = NotificationSink::new(notif_tx);
+        let router = MethodRouter::new(runtime, config_store, sink);
+        (router, notif_rx)
+    }
+
+    #[cfg(feature = "mob")]
+    async fn test_router_with_mob_state(
+        mob_state: Arc<meerkat_mob_mcp::MobMcpState>,
+    ) -> (MethodRouter, mpsc::Receiver<RpcNotification>) {
+        let temp = tempfile::tempdir().unwrap();
+        let factory = AgentFactory::new(temp.path().join("sessions"));
+        let config = Config::default();
+        let store: Arc<dyn meerkat::SessionStore> = Arc::new(meerkat::MemoryStore::new());
+        let mut runtime = SessionRuntime::new(factory, config, 10, store);
+        let config_store: Arc<dyn ConfigStore> =
+            Arc::new(MemoryConfigStore::new(Config::default()));
+        runtime.default_llm_client = Some(Arc::new(MockLlmClient));
+        runtime.set_config_runtime(Arc::new(ConfigRuntime::new(
+            Arc::clone(&config_store),
+            temp.path().join("config_state.json"),
+        )));
+        let runtime = Arc::new(runtime);
+        let (notif_tx, notif_rx) = mpsc::channel(100);
+        let sink = NotificationSink::new(notif_tx);
+        let router = MethodRouter::new_with_mob_state(runtime, config_store, sink, mob_state);
         (router, notif_rx)
     }
 
@@ -1281,6 +1696,38 @@ mod tests {
         resp.error.as_ref().expect("Expected error response").code
     }
 
+    async fn drain_notifications(notif_rx: &mut mpsc::Receiver<RpcNotification>) {
+        tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+        while notif_rx.try_recv().is_ok() {}
+    }
+
+    async fn next_run_started_prompt(notif_rx: &mut mpsc::Receiver<RpcNotification>) -> String {
+        tokio::time::timeout(std::time::Duration::from_secs(2), async {
+            loop {
+                let notif = notif_rx.recv().await.expect("notification");
+                if notif.method != "session/event" {
+                    continue;
+                }
+                if notif.params["event"]["payload"]["type"] != "run_started" {
+                    continue;
+                }
+                break notif.params["event"]["payload"]["prompt"]
+                    .as_str()
+                    .expect("run_started prompt")
+                    .to_string();
+            }
+        })
+        .await
+        .expect("run_started notification")
+    }
+
+    fn system_prompt_from_request(messages: &[Message]) -> Option<&str> {
+        messages.iter().find_map(|message| match message {
+            Message::System(system) => Some(system.content.as_str()),
+            _ => None,
+        })
+    }
+
     // -----------------------------------------------------------------------
     // Tests
     // -----------------------------------------------------------------------
@@ -1305,6 +1752,10 @@ mod tests {
         assert!(method_names.contains(&"session/create"));
         assert!(method_names.contains(&"session/inject_context"));
         assert!(method_names.contains(&"turn/start"));
+        assert!(
+            !method_names.contains(&"session/destroy"),
+            "generic session/destroy must not appear until it has member-aware mob semantics"
+        );
         #[cfg(feature = "mob")]
         {
             assert!(method_names.contains(&"mob/prefabs"));
@@ -1393,7 +1844,7 @@ mod tests {
 
     #[tokio::test]
     async fn session_stream_close_removes_forwarder_from_active_map() {
-        let (router, _notif_rx) = test_router().await;
+        let (router, mut notif_rx) = test_router().await;
 
         let create_resp = router
             .dispatch(make_request(
@@ -1427,6 +1878,86 @@ mod tests {
         assert_eq!(closed["closed"], true);
         assert_eq!(closed["already_closed"], false);
         assert_eq!(router.active_session_streams.lock().await.len(), 0);
+
+        let notification = tokio::time::timeout(std::time::Duration::from_secs(2), async {
+            loop {
+                let notif = notif_rx.recv().await.expect("notification");
+                if notif.method == "session/stream_end" {
+                    break notif;
+                }
+            }
+        })
+        .await
+        .expect("session explicit-close notification");
+        assert_eq!(notification.params["stream_id"], stream_id);
+        assert_eq!(notification.params["session_id"], session_id);
+        assert_eq!(notification.params["outcome"], "explicit_close");
+    }
+
+    #[tokio::test]
+    async fn session_stream_close_is_idempotent_after_explicit_close() {
+        let (router, mut notif_rx) = test_router().await;
+
+        let create_resp = router
+            .dispatch(make_request(
+                "session/create",
+                serde_json::json!({ "prompt": "hello" }),
+            ))
+            .await
+            .unwrap();
+        let session_id = result_value(&create_resp)["session_id"]
+            .as_str()
+            .unwrap()
+            .to_string();
+
+        let open_resp = router
+            .dispatch(make_request(
+                "session/stream_open",
+                serde_json::json!({ "session_id": session_id }),
+            ))
+            .await
+            .unwrap();
+        let stream_id = result_value(&open_resp)["stream_id"]
+            .as_str()
+            .unwrap()
+            .to_string();
+
+        let close_resp = router
+            .dispatch(make_request(
+                "session/stream_close",
+                serde_json::json!({ "stream_id": stream_id }),
+            ))
+            .await
+            .unwrap();
+        assert_eq!(result_value(&close_resp)["already_closed"], false);
+
+        let notification = tokio::time::timeout(std::time::Duration::from_secs(2), async {
+            loop {
+                let notif = notif_rx.recv().await.expect("notification");
+                if notif.method == "session/stream_end" {
+                    break notif;
+                }
+            }
+        })
+        .await
+        .expect("explicit-close notification");
+        assert_eq!(notification.params["outcome"], "explicit_close");
+
+        let close_again_resp = router
+            .dispatch(make_request(
+                "session/stream_close",
+                serde_json::json!({ "stream_id": stream_id }),
+            ))
+            .await
+            .unwrap();
+        assert_eq!(result_value(&close_again_resp)["already_closed"], true);
+
+        let extra_notification =
+            tokio::time::timeout(std::time::Duration::from_millis(200), notif_rx.recv()).await;
+        assert!(
+            extra_notification.is_err(),
+            "idempotent close must not emit a second terminal notification"
+        );
     }
 
     #[cfg(feature = "mob")]
@@ -1605,6 +2136,64 @@ mod tests {
 
     #[cfg(feature = "mob")]
     #[tokio::test]
+    async fn mob_spawned_session_id_supports_turn_interrupt() {
+        let (router, _notif_rx) = test_router().await;
+
+        let create_resp = router
+            .dispatch(make_request(
+                "mob/create",
+                serde_json::json!({
+                    "definition": {
+                        "id": "mob-session-interrupt",
+                        "profiles": {
+                            "worker": {
+                                "model": "claude-sonnet-4-5",
+                                "tools": { "comms": true }
+                            }
+                        }
+                    }
+                }),
+            ))
+            .await
+            .unwrap();
+        let mob_id = result_value(&create_resp)["mob_id"]
+            .as_str()
+            .unwrap()
+            .to_string();
+
+        let spawn_resp = router
+            .dispatch(make_request(
+                "mob/spawn",
+                serde_json::json!({
+                    "mob_id": mob_id,
+                    "profile": "worker",
+                    "meerkat_id": "worker-1",
+                    "runtime_mode": "turn_driven"
+                }),
+            ))
+            .await
+            .unwrap();
+        let session_id = result_value(&spawn_resp)["session_id"]
+            .as_str()
+            .unwrap()
+            .to_string();
+
+        let interrupt_resp = router
+            .dispatch(make_request(
+                "turn/interrupt",
+                serde_json::json!({ "session_id": session_id }),
+            ))
+            .await
+            .unwrap();
+        assert!(
+            interrupt_resp.error.is_none(),
+            "mob-backed interrupt should route through the authoritative owner: {interrupt_resp:?}"
+        );
+        assert_eq!(result_value(&interrupt_resp)["interrupted"], true);
+    }
+
+    #[cfg(feature = "mob")]
+    #[tokio::test]
     async fn session_archive_for_mob_session_retires_member() {
         let (router, _notif_rx) = test_router().await;
 
@@ -1666,6 +2255,136 @@ mod tests {
         let members_value = result_value(&members_resp);
         let members = members_value["members"].as_array().unwrap();
         assert!(members.is_empty());
+
+        let interrupt_resp = router
+            .dispatch(make_request(
+                "turn/interrupt",
+                serde_json::json!({ "session_id": session_id }),
+            ))
+            .await
+            .unwrap();
+        assert!(
+            interrupt_resp.error.is_some(),
+            "retired mob-backed session must reject generic turn/interrupt"
+        );
+    }
+
+    #[cfg(feature = "mob")]
+    #[tokio::test]
+    async fn mob_spawned_session_id_supports_session_read() {
+        let (router, _notif_rx) = test_router().await;
+
+        let create_resp = router
+            .dispatch(make_request(
+                "mob/create",
+                serde_json::json!({
+                    "definition": {
+                        "id": "mob-session-read",
+                        "profiles": {
+                            "worker": {
+                                "model": "claude-sonnet-4-5",
+                                "tools": { "comms": true }
+                            }
+                        }
+                    }
+                }),
+            ))
+            .await
+            .unwrap();
+        let mob_id = result_value(&create_resp)["mob_id"]
+            .as_str()
+            .unwrap()
+            .to_string();
+
+        let spawn_resp = router
+            .dispatch(make_request(
+                "mob/spawn",
+                serde_json::json!({
+                    "mob_id": mob_id,
+                    "profile": "worker",
+                    "meerkat_id": "worker-1",
+                    "runtime_mode": "turn_driven"
+                }),
+            ))
+            .await
+            .unwrap();
+        let session_id = result_value(&spawn_resp)["session_id"]
+            .as_str()
+            .unwrap()
+            .to_string();
+
+        let read_resp = router
+            .dispatch(make_request(
+                "session/read",
+                serde_json::json!({ "session_id": session_id }),
+            ))
+            .await
+            .unwrap();
+        let read_value = result_value(&read_resp);
+
+        assert_eq!(read_value["session_id"].as_str().unwrap(), session_id);
+        assert!(read_value["state"].is_string());
+        assert!(read_value["labels"].is_object());
+    }
+
+    #[cfg(feature = "mob")]
+    #[tokio::test]
+    async fn session_inject_context_for_mob_session_targets_backing_service() {
+        let (router, _notif_rx) = test_router().await;
+
+        let create_resp = router
+            .dispatch(make_request(
+                "mob/create",
+                serde_json::json!({
+                    "definition": {
+                        "id": "mob-session-inject-context",
+                        "profiles": {
+                            "worker": {
+                                "model": "claude-sonnet-4-5",
+                                "tools": { "comms": true }
+                            }
+                        }
+                    }
+                }),
+            ))
+            .await
+            .unwrap();
+        let mob_id = result_value(&create_resp)["mob_id"]
+            .as_str()
+            .unwrap()
+            .to_string();
+
+        let spawn_resp = router
+            .dispatch(make_request(
+                "mob/spawn",
+                serde_json::json!({
+                    "mob_id": mob_id,
+                    "profile": "worker",
+                    "meerkat_id": "worker-1",
+                    "runtime_mode": "turn_driven"
+                }),
+            ))
+            .await
+            .unwrap();
+        let session_id = result_value(&spawn_resp)["session_id"]
+            .as_str()
+            .unwrap()
+            .to_string();
+
+        let inject_resp = router
+            .dispatch(make_request(
+                "session/inject_context",
+                serde_json::json!({
+                    "session_id": session_id,
+                    "text": "Coordinate with the lead before acting.",
+                    "source": "mob",
+                    "idempotency_key": "ctx-worker-1"
+                }),
+            ))
+            .await
+            .unwrap();
+
+        assert_eq!(result_value(&inject_resp)["status"], "staged");
     }
 
     #[tokio::test]
@@ -1682,6 +2401,486 @@ mod tests {
             response.error.as_ref().map(|e| e.code),
             Some(crate::error::SESSION_NOT_FOUND)
         );
+    }
+
+    #[tokio::test]
+    async fn notification_sink_reports_overflow_for_stream_events() {
+        let (tx, mut rx) = tokio::sync::mpsc::channel(1);
+        let sink = NotificationSink::new(tx);
+        let session_id = SessionId::new();
+        let envelope = EventEnvelope::new(
+            session_id.to_string(),
+            1,
+            None,
+            AgentEvent::TextDelta {
+                delta: "hello".to_string(),
+            },
+        );
+
+        assert!(
+            sink.emit_session_stream_event(&Uuid::new_v4(), 1, &session_id, &envelope)
+                .await
+                == StreamEmitStatus::Delivered
+        );
+        assert!(
+            sink.emit_session_stream_event(&Uuid::new_v4(), 2, &session_id, &envelope)
+                .await
+                == StreamEmitStatus::Overflow,
+            "second send should surface overflow to the caller"
+        );
+
+        let first = rx.recv().await.expect("first notification");
+        assert_eq!(first.method, "session/stream_event");
+    }
+
+    #[tokio::test]
+    async fn session_stream_overflow_emits_terminal_error_outcome() {
+        let (tx, mut rx) = tokio::sync::mpsc::channel(1);
+        let sink = NotificationSink::new(tx);
+        let session_id = SessionId::new();
+        let stream_id = Uuid::new_v4();
+        let envelope = EventEnvelope::new(
+            session_id.to_string(),
+            1,
+            None,
+            AgentEvent::TextDelta {
+                delta: "hello".to_string(),
+            },
+        );
+
+        assert_eq!(
+            sink.emit_session_stream_event(&stream_id, 1, &session_id, &envelope)
+                .await,
+            StreamEmitStatus::Delivered
+        );
+        assert_eq!(
+            sink.emit_session_stream_event(&stream_id, 2, &session_id, &envelope)
+                .await,
+            StreamEmitStatus::Overflow
+        );
+
+        let terminal = tokio::spawn({
+            let sink = sink.clone();
+            let session_id = session_id.clone();
+            async move {
+                sink.emit_session_stream_end(
+                    &stream_id,
+                    &session_id,
+                    "terminal_error",
+                    Some("transport stream notification queue overflow"),
+                )
+                .await;
+            }
+        });
+
+        let first = rx.recv().await.expect("first notification");
+        assert_eq!(first.method, "session/stream_event");
+
+        let terminal_notification =
+            tokio::time::timeout(std::time::Duration::from_secs(1), rx.recv())
+                .await
+                .expect("terminal notification should arrive after queue drains")
+                .expect("terminal notification");
+        terminal.await.expect("terminal send join");
+        assert_eq!(terminal_notification.method, "session/stream_end");
+        assert_eq!(terminal_notification.params["outcome"], "terminal_error");
+        assert_eq!(
+            terminal_notification.params["error"]["code"],
+            "stream_queue_overflow"
+        );
+    }
+
+    #[tokio::test]
+    async fn session_stream_router_overflow_emits_terminal_error_outcome() {
+        let requests = Arc::new(std::sync::Mutex::new(Vec::<Vec<Message>>::new()));
+        let llm_client = Arc::new(RecordingMockLlmClient::new(requests));
+        let (router, mut notif_rx) =
+            test_router_with_llm_and_notification_capacity(llm_client, 1).await;
+
+        let create_resp = router
+            .dispatch(make_request(
+                "session/create",
+                serde_json::json!({ "prompt": "create overflow session" }),
+            ))
+            .await
+            .unwrap();
+        let session_id = result_value(&create_resp)["session_id"]
+            .as_str()
+            .unwrap()
+            .to_string();
+
+        drain_notifications(&mut notif_rx).await;
+
+        let open_resp = router
+            .dispatch(make_request(
+                "session/stream_open",
+                serde_json::json!({ "session_id": session_id }),
+            ))
+            .await
+            .unwrap();
+        let stream_id = result_value(&open_resp)["stream_id"]
+            .as_str()
+            .unwrap()
+            .to_string();
+
+        let turn_resp = router
+            .dispatch(make_request(
+                "turn/start",
+                serde_json::json!({
+                    "session_id": session_id,
+                    "prompt": "overflow please"
+                }),
+            ))
+            .await
+            .unwrap();
+        assert!(turn_resp.error.is_none(), "turn should succeed");
+
+        let notification = tokio::time::timeout(std::time::Duration::from_secs(2), async {
+            loop {
+                let notif = notif_rx.recv().await.expect("notification");
+                if notif.method == "session/stream_end" {
+                    break notif;
+                }
+            }
+        })
+        .await
+        .expect("session stream end notification");
+        assert_eq!(notification.params["stream_id"], stream_id);
+        assert_eq!(notification.params["outcome"], "terminal_error");
+        assert_eq!(
+            notification.params["error"]["code"],
+            "stream_queue_overflow"
+        );
+    }
+
+    #[cfg(feature = "mob")]
+    #[tokio::test]
+    async fn mob_stream_overflow_emits_terminal_error_outcome() {
+        let (tx, mut rx) = tokio::sync::mpsc::channel(1);
+        let sink = NotificationSink::new(tx);
+        let stream_id = Uuid::new_v4();
+        let event = serde_json::json!({
+            "event_id": "e1",
+            "payload": {
+                "type": "text_delta",
+                "delta": "hello",
+            }
+        });
+
+        assert_eq!(
+            sink.emit_mob_stream_event(&stream_id, 1, &event).await,
+            StreamEmitStatus::Delivered
+        );
+        assert_eq!(
+            sink.emit_mob_stream_event(&stream_id, 2, &event).await,
+            StreamEmitStatus::Overflow
+        );
+
+        let terminal = tokio::spawn({
+            let sink = sink.clone();
+            async move {
+                sink.emit_mob_stream_end(
+                    &stream_id,
+                    "terminal_error",
+                    Some("transport stream notification queue overflow"),
+                )
+                .await;
+            }
+        });
+
+        let first = rx.recv().await.expect("first notification");
+        assert_eq!(first.method, "mob/stream_event");
+
+        let terminal_notification =
+            tokio::time::timeout(std::time::Duration::from_secs(1), rx.recv())
+                .await
+                .expect("terminal notification should arrive after queue drains")
+                .expect("terminal notification");
+        terminal.await.expect("terminal send join");
+        assert_eq!(terminal_notification.method, "mob/stream_end");
+        assert_eq!(terminal_notification.params["outcome"], "terminal_error");
+        assert_eq!(
+            terminal_notification.params["error"]["code"],
+            "stream_queue_overflow"
+        );
+    }
+
+    #[tokio::test]
+    async fn archived_session_read_remains_available_and_mutations_reject() {
+        let (router, _notif_rx) = test_router().await;
+
+        let create_resp = router
+            .dispatch(make_request(
+                "session/create",
+                serde_json::json!({
+                    "prompt": "Create a session that will be archived"
+                }),
+            ))
+            .await
+            .unwrap();
+        let session_id = result_value(&create_resp)["session_id"]
+            .as_str()
+            .unwrap()
+            .to_string();
+        tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+
+        let archive_resp = router
+            .dispatch(make_request(
+                "session/archive",
+                serde_json::json!({ "session_id": session_id }),
+            ))
+            .await
+            .unwrap();
+        assert_eq!(result_value(&archive_resp)["archived"], true);
+
+        let read_resp = router
+            .dispatch(make_request(
+                "session/read",
+                serde_json::json!({ "session_id": session_id }),
+            ))
+            .await
+            .unwrap();
+        assert!(
+            read_resp.error.is_none(),
+            "archived session should remain readable: {read_resp:?}"
+        );
+        let read = result_value(&read_resp);
+        assert_eq!(read["session_id"], session_id);
+
+        let stream_resp = router
+            .dispatch(make_request(
+                "session/stream_open",
+                serde_json::json!({ "session_id": session_id }),
+            ))
+            .await
+            .unwrap();
+        assert!(
+            stream_resp.error.is_some(),
+            "archived session must reject stream_open"
+        );
+
+        let inject_resp = router
+            .dispatch(make_request(
+                "session/inject_context",
+                serde_json::json!({
+                    "session_id": session_id,
+                    "text": "should be rejected"
+                }),
+            ))
+            .await
+            .unwrap();
+        assert!(
+            inject_resp.error.is_some(),
+            "archived session must reject staged context append"
+        );
+
+        let peers_resp = router
+            .dispatch(make_request(
+                "comms/peers",
+                serde_json::json!({ "session_id": session_id }),
+            ))
+            .await
+            .unwrap();
+        assert!(
+            peers_resp.error.is_some(),
+            "archived session must reject comms/peers"
+        );
+
+        let send_resp = router
+            .dispatch(make_request(
+                "comms/send",
+                serde_json::json!({
+                    "session_id": session_id,
+                    "kind": "peer_message",
+                    "target": "nobody",
+                    "content": "hello after archive"
+                }),
+            ))
+            .await
+            .unwrap();
+        assert!(
+            send_resp.error.is_some(),
+            "archived session must reject comms/send"
+        );
+    }
+
+    #[cfg(feature = "mob")]
+    #[tokio::test]
+    async fn archived_mob_backed_session_rejects_comms_after_retirement() {
+        let (router, _notif_rx) = test_router().await;
+
+        let create_resp = router
+            .dispatch(make_request(
+                "mob/create",
+                serde_json::json!({
+                    "definition": {
+                        "id": "mob-archive-comms-session",
+                        "profiles": {
+                            "worker": {
+                                "model": "claude-sonnet-4-5",
+                                "tools": { "comms": true }
+                            }
+                        }
+                    }
+                }),
+            ))
+            .await
+            .unwrap();
+        let mob_id = result_value(&create_resp)["mob_id"]
+            .as_str()
+            .unwrap()
+            .to_string();
+
+        let spawn_resp = router
+            .dispatch(make_request(
+                "mob/spawn",
+                serde_json::json!({
+                    "mob_id": mob_id,
+                    "profile": "worker",
+                    "meerkat_id": "worker-1",
+                    "runtime_mode": "turn_driven"
+                }),
+            ))
+            .await
+            .unwrap();
+        let session_id = result_value(&spawn_resp)["session_id"]
+            .as_str()
+            .unwrap()
+            .to_string();
+
+        let archive_resp = router
+            .dispatch(make_request(
+                "session/archive",
+                serde_json::json!({ "session_id": session_id }),
+            ))
+            .await
+            .unwrap();
+        assert_eq!(result_value(&archive_resp)["archived"], true);
+
+        let peers_resp = router
+            .dispatch(make_request(
+                "comms/peers",
+                serde_json::json!({ "session_id": session_id }),
+            ))
+            .await
+            .unwrap();
+        assert!(
+            peers_resp.error.is_some(),
+            "retired mob member must reject comms/peers"
+        );
+
+        let send_resp = router
+            .dispatch(make_request(
+                "comms/send",
+                serde_json::json!({
+                    "session_id": session_id,
+                    "kind": "peer_message",
+                    "target": "worker-2",
+                    "content": "hello after archive"
+                }),
+            ))
+            .await
+            .unwrap();
+        assert!(
+            send_resp.error.is_some(),
+            "retired mob member must reject comms/send"
+        );
+    }
+
+    #[cfg(feature = "mob")]
+    #[tokio::test]
+    async fn mob_send_rejects_while_archive_retirement_is_in_flight() {
+        let (router, _notif_rx) = test_router_with_mob_state(
+            meerkat_mob_mcp::MobMcpState::new_in_memory_with_archive_delay(250),
+        )
+        .await;
+
+        let create_resp = router
+            .dispatch(make_request(
+                "mob/create",
+                serde_json::json!({
+                    "definition": {
+                        "id": "mob-retiring-send",
+                        "profiles": {
+                            "lead": {
+                                "model": "claude-sonnet-4-5",
+                                "external_addressable": true,
+                                "tools": { "comms": true }
+                            }
+                        }
+                    }
+                }),
+            ))
+            .await
+            .unwrap();
+        let mob_id = result_value(&create_resp)["mob_id"]
+            .as_str()
+            .unwrap()
+            .to_string();
+
+        let spawn_resp = router
+            .dispatch(make_request(
+                "mob/spawn",
+                serde_json::json!({
+                    "mob_id": &mob_id,
+                    "profile": "lead",
+                    "meerkat_id": "lead-1",
+                    "runtime_mode": "turn_driven"
+                }),
+            ))
+            .await
+            .unwrap();
+        let session_id = result_value(&spawn_resp)["session_id"]
+            .as_str()
+            .unwrap()
+            .to_string();
+
+        let archive = {
+            let router = router.clone();
+            tokio::spawn(async move {
+                router
+                    .dispatch(make_request(
+                        "session/archive",
+                        serde_json::json!({ "session_id": &session_id }),
+                    ))
+                    .await
+                    .expect("archive response")
+            })
+        };
+
+        tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+
+        let members_resp = router
+            .dispatch(make_request(
+                "mob/members",
+                serde_json::json!({ "mob_id": &mob_id }),
+            ))
+            .await
+            .unwrap();
+        let members_value = result_value(&members_resp);
+        let members = members_value["members"].as_array().expect("members array");
+        assert_eq!(members.len(), 1, "retiring member should remain observable");
+        assert_eq!(members[0]["meerkat_id"], "lead-1");
+        assert_eq!(members[0]["state"], "Retiring");
+
+        let send_resp = router
+            .dispatch(make_request(
+                "mob/send",
+                serde_json::json!({
+                    "mob_id": &mob_id,
+                    "meerkat_id": "lead-1",
+                    "message": "do work while retiring"
+                }),
+            ))
+            .await
+            .unwrap();
+        assert!(
+            send_resp.error.is_some(),
+            "retiring member must reject new mob/send work before archive completes"
+        );
+
+        let archive_resp = archive.await.expect("archive join");
+        assert_eq!(result_value(&archive_resp)["archived"], true);
     }
 
     #[cfg(feature = "mob")]
@@ -1762,12 +2961,13 @@ mod tests {
         assert_eq!(notification.method, "session/stream_end");
         assert_eq!(notification.params["stream_id"], stream_id);
         assert_eq!(notification.params["ended"], true);
+        assert_eq!(notification.params["outcome"], "remote_end");
     }
 
     #[cfg(feature = "mob")]
     #[tokio::test]
     async fn mob_stream_close_removes_forwarder_from_active_map() {
-        let (router, _notif_rx) = test_router().await;
+        let (router, mut notif_rx) = test_router().await;
 
         let create_resp = router
             .dispatch(make_request(
@@ -1804,6 +3004,19 @@ mod tests {
         assert_eq!(closed["closed"], true);
         assert_eq!(closed["already_closed"], false);
         assert_eq!(router.active_mob_streams.lock().await.len(), 0);
+
+        let notification = tokio::time::timeout(std::time::Duration::from_secs(2), async {
+            loop {
+                let notif = notif_rx.recv().await.expect("notification");
+                if notif.method == "mob/stream_end" {
+                    break notif;
+                }
+            }
+        })
+        .await
+        .expect("mob explicit-close notification");
+        assert_eq!(notification.params["stream_id"], stream_id);
+        assert_eq!(notification.params["outcome"], "explicit_close");
     }
 
     #[cfg(feature = "mob")]
@@ -2033,6 +3246,308 @@ mod tests {
         assert_eq!(injected["status"], "staged");
     }
 
+    #[tokio::test]
+    async fn session_inject_context_is_consumed_by_next_turn_exactly_once() {
+        let recorded_requests = Arc::new(std::sync::Mutex::new(Vec::<Vec<Message>>::new()));
+        let (router, mut notif_rx) = test_router_with_llm(Arc::new(RecordingMockLlmClient::new(
+            Arc::clone(&recorded_requests),
+        )))
+        .await;
+
+        let create_resp = router
+            .dispatch(make_request(
+                "session/create",
+                serde_json::json!({ "prompt": "Hello" }),
+            ))
+            .await
+            .unwrap();
+        let session_id = result_value(&create_resp)["session_id"]
+            .as_str()
+            .unwrap()
+            .to_string();
+        drain_notifications(&mut notif_rx).await;
+        recorded_requests
+            .lock()
+            .expect("recorded requests lock poisoned")
+            .clear();
+
+        let injected_text = "Coordinate with the orchestrator exactly once.";
+        let inject_resp = router
+            .dispatch(make_request(
+                "session/inject_context",
+                serde_json::json!({
+                    "session_id": &session_id,
+                    "text": injected_text,
+                    "source": "mob",
+                    "idempotency_key": "ctx-next-turn-once"
+                }),
+            ))
+            .await
+            .unwrap();
+        assert_eq!(result_value(&inject_resp)["status"], "staged");
+
+        let first_turn_resp = router
+            .dispatch(make_request(
+                "turn/start",
+                serde_json::json!({
+                    "session_id": &session_id,
+                    "prompt": "first follow up"
+                }),
+            ))
+            .await
+            .unwrap();
+        assert!(first_turn_resp.error.is_none(), "first turn should succeed");
+        let first_prompt = next_run_started_prompt(&mut notif_rx).await;
+        assert!(
+            first_prompt.contains("first follow up"),
+            "turn notification must still reflect the user prompt: {first_prompt}"
+        );
+        let first_request = recorded_requests
+            .lock()
+            .expect("recorded requests lock poisoned")
+            .last()
+            .cloned()
+            .expect("first follow-up request");
+        let first_system_prompt =
+            system_prompt_from_request(&first_request).expect("system prompt on first turn");
+        assert!(
+            first_system_prompt.contains(injected_text),
+            "next eligible turn must include staged context in the LLM system prompt: {first_system_prompt}"
+        );
+        assert_eq!(first_system_prompt.matches(injected_text).count(), 1);
+        recorded_requests
+            .lock()
+            .expect("recorded requests lock poisoned")
+            .clear();
+
+        let second_turn_resp = router
+            .dispatch(make_request(
+                "turn/start",
+                serde_json::json!({
+                    "session_id": &session_id,
+                    "prompt": "second follow up"
+                }),
+            ))
+            .await
+            .unwrap();
+        assert!(
+            second_turn_resp.error.is_none(),
+            "second turn should succeed"
+        );
+        let second_prompt = next_run_started_prompt(&mut notif_rx).await;
+        assert!(
+            second_prompt.contains("second follow up"),
+            "turn notification must still reflect the user prompt: {second_prompt}"
+        );
+        let second_request = recorded_requests
+            .lock()
+            .expect("recorded requests lock poisoned")
+            .last()
+            .cloned()
+            .expect("second follow-up request");
+        let second_system_prompt =
+            system_prompt_from_request(&second_request).expect("system prompt on second turn");
+        assert!(
+            !second_system_prompt.contains(injected_text),
+            "staged context must be consumed exactly once, not replayed on later turns: {second_system_prompt}"
+        );
+    }
+
+    #[tokio::test]
+    async fn session_inject_context_during_active_turn_waits_for_next_rpc_turn() {
+        let recorded_requests = Arc::new(std::sync::Mutex::new(Vec::<Vec<Message>>::new()));
+        let (router, _notif_rx) = test_router_with_llm(Arc::new(
+            RecordingMockLlmClient::with_delay(Arc::clone(&recorded_requests), 200),
+        ))
+        .await;
+
+        let create_resp = router
+            .dispatch(make_request(
+                "session/create",
+                serde_json::json!({ "prompt": "Hello" }),
+            ))
+            .await
+            .unwrap();
+        let session_id = result_value(&create_resp)["session_id"]
+            .as_str()
+            .unwrap()
+            .to_string();
+
+        let first_turn = {
+            let router = router.clone();
+            let session_id = session_id.clone();
+            tokio::spawn(async move {
+                router
+                    .dispatch(make_request(
+                        "turn/start",
+                        serde_json::json!({
+                            "session_id": &session_id,
+                            "prompt": "first turn"
+                        }),
+                    ))
+                    .await
+                    .expect("first turn response")
+            })
+        };
+
+        tokio::time::timeout(std::time::Duration::from_secs(2), async {
+            loop {
+                if !recorded_requests
+                    .lock()
+                    .expect("recorded requests lock poisoned")
+                    .is_empty()
+                {
+                    break;
+                }
+                tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+            }
+        })
+        .await
+        .expect("first request should reach the LLM");
+
+        let injected_text = "Late staged context";
+        let inject_resp = router
+            .dispatch(make_request(
+                "session/inject_context",
+                serde_json::json!({
+                    "session_id": &session_id,
+                    "text": injected_text,
+                    "source": "mob",
+                    "idempotency_key": "ctx-rpc-during-active-turn"
+                }),
+            ))
+            .await
+            .unwrap();
+        assert_eq!(result_value(&inject_resp)["status"], "staged");
+
+        let first_turn_resp = first_turn.await.expect("first turn join");
+        assert!(
+            first_turn_resp.error.is_none(),
+            "first turn should still complete"
+        );
+        let first_request = recorded_requests
+            .lock()
+            .expect("recorded requests lock poisoned")
+            .first()
+            .cloned()
+            .expect("first request");
+        let first_system_prompt =
+            system_prompt_from_request(&first_request).expect("system prompt on first turn");
+        assert!(
+            !first_system_prompt.contains(injected_text),
+            "context appended during an active RPC turn must not affect the in-flight request"
+        );
+
+        let second_turn_resp = router
+            .dispatch(make_request(
+                "turn/start",
+                serde_json::json!({
+                    "session_id": &session_id,
+                    "prompt": "second turn"
+                }),
+            ))
+            .await
+            .unwrap();
+        assert!(
+            second_turn_resp.error.is_none(),
+            "second turn should succeed"
+        );
+        let second_request = recorded_requests
+            .lock()
+            .expect("recorded requests lock poisoned")
+            .last()
+            .cloned()
+            .expect("second request");
+        let second_system_prompt =
+            system_prompt_from_request(&second_request).expect("system prompt on second turn");
+        assert!(
+            second_system_prompt.contains(injected_text),
+            "context appended during an active RPC turn must apply on the next eligible turn"
+        );
+    }
+
+    #[tokio::test]
+    async fn session_inject_context_duplicate_idempotency_key_does_not_double_stage() {
+        let recorded_requests = Arc::new(std::sync::Mutex::new(Vec::<Vec<Message>>::new()));
+        let (router, mut notif_rx) = test_router_with_llm(Arc::new(RecordingMockLlmClient::new(
+            Arc::clone(&recorded_requests),
+        )))
+        .await;
+
+        let create_resp = router
+            .dispatch(make_request(
+                "session/create",
+                serde_json::json!({ "prompt": "Hello" }),
+            ))
+            .await
+            .unwrap();
+        let session_id = result_value(&create_resp)["session_id"]
+            .as_str()
+            .unwrap()
+            .to_string();
+        drain_notifications(&mut notif_rx).await;
+        recorded_requests
+            .lock()
+            .expect("recorded requests lock poisoned")
+            .clear();
+
+        let injected_text = "Only stage this once.";
+        let first_inject = router
+            .dispatch(make_request(
+                "session/inject_context",
+                serde_json::json!({
+                    "session_id": &session_id,
+                    "text": injected_text,
+                    "source": "mob",
+                    "idempotency_key": "ctx-dedup"
+                }),
+            ))
+            .await
+            .unwrap();
+        assert_eq!(result_value(&first_inject)["status"], "staged");
+
+        let second_inject = router
+            .dispatch(make_request(
+                "session/inject_context",
+                serde_json::json!({
+                    "session_id": &session_id,
+                    "text": injected_text,
+                    "source": "mob",
+                    "idempotency_key": "ctx-dedup"
+                }),
+            ))
+            .await
+            .unwrap();
+        assert_eq!(result_value(&second_inject)["status"], "duplicate");
+
+        let turn_resp = router
+            .dispatch(make_request(
+                "turn/start",
+                serde_json::json!({
+                    "session_id": &session_id,
+                    "prompt": "follow up"
+                }),
+            ))
+            .await
+            .unwrap();
+        assert!(turn_resp.error.is_none(), "turn should succeed");
+        let _prompt = next_run_started_prompt(&mut notif_rx).await;
+
+        let request = recorded_requests
+            .lock()
+            .expect("recorded requests lock poisoned")
+            .last()
+            .cloned()
+            .expect("follow-up request");
+        let system_prompt =
+            system_prompt_from_request(&request).expect("system prompt on follow-up turn");
+        assert_eq!(
+            system_prompt.matches(injected_text).count(),
+            1,
+            "duplicate idempotency keys must not enqueue multiple staged copies: {system_prompt}"
+        );
+    }
+
     /// 6. `session/archive` removes a session.
     #[tokio::test]
     async fn session_archive_removes_session() {
@@ -2062,6 +3577,99 @@ mod tests {
             .iter()
             .any(|s| s["session_id"].as_str() == Some(&session_id));
         assert!(!found, "Archived session should not appear in list");
+    }
+
+    #[tokio::test]
+    async fn archived_session_drops_unapplied_staged_context_before_any_later_turn() {
+        let recorded_requests = Arc::new(std::sync::Mutex::new(Vec::<Vec<Message>>::new()));
+        let (router, mut notif_rx) = test_router_with_llm(Arc::new(RecordingMockLlmClient::new(
+            Arc::clone(&recorded_requests),
+        )))
+        .await;
+
+        let create_resp = router
+            .dispatch(make_request(
+                "session/create",
+                serde_json::json!({ "prompt": "Hello" }),
+            ))
+            .await
+            .unwrap();
+        let session_id = result_value(&create_resp)["session_id"]
+            .as_str()
+            .unwrap()
+            .to_string();
+        drain_notifications(&mut notif_rx).await;
+        recorded_requests
+            .lock()
+            .expect("recorded requests lock poisoned")
+            .clear();
+
+        let injected_text = "This context must be dropped on archive.";
+        let inject_resp = router
+            .dispatch(make_request(
+                "session/inject_context",
+                serde_json::json!({
+                    "session_id": session_id,
+                    "text": injected_text,
+                    "source": "mob",
+                    "idempotency_key": "ctx-archive-drop"
+                }),
+            ))
+            .await
+            .unwrap();
+        assert_eq!(result_value(&inject_resp)["status"], "staged");
+
+        let archive_resp = router
+            .dispatch(make_request(
+                "session/archive",
+                serde_json::json!({ "session_id": session_id }),
+            ))
+            .await
+            .unwrap();
+        assert_eq!(result_value(&archive_resp)["archived"], true);
+
+        let rejected_turn = router
+            .dispatch(make_request(
+                "turn/start",
+                serde_json::json!({
+                    "session_id": session_id,
+                    "prompt": "should never run"
+                }),
+            ))
+            .await
+            .unwrap();
+        assert!(
+            rejected_turn.error.is_some(),
+            "archived session must reject later turns after staged context was accepted"
+        );
+        assert!(
+            recorded_requests
+                .lock()
+                .expect("recorded requests lock poisoned")
+                .is_empty(),
+            "archived session must not reach the LLM again after staged context is dropped"
+        );
+
+        let notification = tokio::time::timeout(std::time::Duration::from_millis(200), async {
+            notif_rx.recv().await
+        })
+        .await;
+        match notification {
+            Err(_) => {}
+            Ok(None) => {}
+            Ok(Some(notif)) => {
+                let event_type = notif.params["event"]["payload"]["type"].as_str();
+                assert!(
+                    !(notif.method == "session/event"
+                        && event_type == Some("run_started")
+                        && notif.params["session_id"].as_str() == Some(session_id.as_str())
+                        && notif.params["event"]["payload"]["prompt"]
+                            .as_str()
+                            .is_some_and(|prompt| prompt.contains(injected_text))),
+                    "archived session must not emit a later run_started that replays dropped staged context: {notif:?}"
+                );
+            }
+        }
     }
 
     /// 7. `turn/start` returns a result for an existing session.

--- a/meerkat-rpc/src/session_runtime.rs
+++ b/meerkat-rpc/src/session_runtime.rs
@@ -629,6 +629,17 @@ impl SessionRuntime {
         None
     }
 
+    /// Read the authoritative session view from the owning session service.
+    pub async fn read_session(
+        &self,
+        session_id: &SessionId,
+    ) -> Result<meerkat_core::service::SessionView, RpcError> {
+        self.service
+            .read(session_id)
+            .await
+            .map_err(session_error_to_rpc)
+    }
+
     /// Archive (remove) a session.
     pub async fn archive_session(&self, session_id: &SessionId) -> Result<(), RpcError> {
         // Check pending sessions first.

--- a/meerkat-session/src/ephemeral.rs
+++ b/meerkat-session/src/ephemeral.rs
@@ -233,6 +233,7 @@ pub trait SessionAgent: Send {
 /// Sessions are kept alive as tokio tasks. All state is lost on process exit.
 pub struct EphemeralSessionService<B: SessionAgentBuilder> {
     sessions: RwLock<IndexMap<SessionId, SessionHandle>>,
+    archived_views: RwLock<IndexMap<SessionId, SessionView>>,
     builder: B,
     max_sessions: usize,
     session_capacity: Arc<Semaphore>,
@@ -246,10 +247,30 @@ impl<B: SessionAgentBuilder + 'static> EphemeralSessionService<B> {
     pub fn new(builder: B, max_sessions: usize) -> Self {
         Self {
             sessions: RwLock::new(IndexMap::new()),
+            archived_views: RwLock::new(IndexMap::new()),
             builder,
             max_sessions,
             session_capacity: Arc::new(Semaphore::new(max_sessions)),
             session_registered: tokio::sync::Notify::new(),
+        }
+    }
+
+    fn archived_view_from_handle(id: &SessionId, handle: &SessionHandle) -> SessionView {
+        let cache = handle.summary_rx.borrow();
+        SessionView {
+            state: SessionInfo {
+                session_id: id.clone(),
+                created_at: handle.created_at,
+                updated_at: cache.updated_at,
+                message_count: cache.message_count,
+                is_active: false,
+                last_assistant_text: None,
+                labels: handle.labels.clone(),
+            },
+            billing: SessionUsage {
+                total_tokens: cache.total_tokens,
+                usage: Usage::default(),
+            },
         }
     }
 
@@ -657,9 +678,19 @@ impl<B: SessionAgentBuilder + 'static> SessionService for EphemeralSessionServic
 
     async fn read(&self, id: &SessionId) -> Result<SessionView, SessionError> {
         let sessions = self.sessions.read().await;
-        let handle = sessions
-            .get(id)
-            .ok_or_else(|| SessionError::NotFound { id: id.clone() })?;
+        let handle = match sessions.get(id) {
+            Some(handle) => handle,
+            None => {
+                drop(sessions);
+                return self
+                    .archived_views
+                    .read()
+                    .await
+                    .get(id)
+                    .cloned()
+                    .ok_or_else(|| SessionError::NotFound { id: id.clone() });
+            }
+        };
 
         let (reply_tx, reply_rx) = oneshot::channel();
         handle
@@ -743,6 +774,12 @@ impl<B: SessionAgentBuilder + 'static> SessionService for EphemeralSessionServic
         let handle = sessions
             .swap_remove(id)
             .ok_or_else(|| SessionError::NotFound { id: id.clone() })?;
+        let archived_view = Self::archived_view_from_handle(id, &handle);
+        drop(sessions);
+        self.archived_views
+            .write()
+            .await
+            .insert(id.clone(), archived_view);
 
         let _ = handle.command_tx.send(SessionCommand::Shutdown).await;
         Ok(())

--- a/meerkat-session/tests/ephemeral_contract.rs
+++ b/meerkat-session/tests/ephemeral_contract.rs
@@ -17,12 +17,15 @@ use meerkat_core::types::{
     AssistantBlock, RunResult, SessionId, StopReason, ToolCallView, ToolDef, ToolResult, Usage,
 };
 use meerkat_core::{
-    Agent, AgentBuilder, AgentLlmClient, AgentSessionStore, AgentToolDispatcher, LlmStreamResult,
+    Agent, AgentBuilder, AgentLlmClient, AgentSessionStore, AgentToolDispatcher, HookDecision,
+    HookEngine, HookExecutionReport, HookId, HookInvocation, HookOutcome, HookPoint,
+    HookReasonCode, LlmStreamResult,
 };
 use meerkat_session::ephemeral::SessionSnapshot;
 use meerkat_session::{EphemeralSessionService, SessionAgent, SessionAgentBuilder};
 use serde_json::{Value, json};
 use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::time::SystemTime;
 use tokio::sync::mpsc;
 
@@ -279,6 +282,58 @@ impl AgentToolDispatcher for StaticToolDispatcher {
 struct RecordingLlmClient {
     provider_visible_tools: Arc<std::sync::Mutex<Vec<Vec<String>>>>,
     provider_visible_system_prompts: Arc<std::sync::Mutex<Vec<Vec<String>>>>,
+    delay_ms: Option<u64>,
+}
+
+struct DenyNextPreLlmHookEngine {
+    deny_next: AtomicBool,
+}
+
+impl DenyNextPreLlmHookEngine {
+    fn new() -> Self {
+        Self {
+            deny_next: AtomicBool::new(true),
+        }
+    }
+}
+
+#[async_trait]
+impl HookEngine for DenyNextPreLlmHookEngine {
+    async fn execute(
+        &self,
+        invocation: HookInvocation,
+        _overrides: Option<&meerkat_core::config::HookRunOverrides>,
+    ) -> Result<HookExecutionReport, meerkat_core::HookEngineError> {
+        if invocation.point != HookPoint::PreLlmRequest
+            || !self.deny_next.swap(false, Ordering::AcqRel)
+        {
+            return Ok(HookExecutionReport::default());
+        }
+
+        let decision = HookDecision::deny(
+            HookId::new("deny-pre-llm"),
+            HookReasonCode::PolicyViolation,
+            "pre-llm turn denied",
+            None,
+        );
+
+        Ok(HookExecutionReport {
+            outcomes: vec![HookOutcome {
+                hook_id: HookId::new("deny-pre-llm"),
+                point: HookPoint::PreLlmRequest,
+                priority: 0,
+                registration_index: 0,
+                decision: Some(decision.clone()),
+                patches: Vec::new(),
+                published_patches: Vec::new(),
+                error: None,
+                duration_ms: None,
+            }],
+            decision: Some(decision),
+            patches: Vec::new(),
+            published_patches: Vec::new(),
+        })
+    }
 }
 
 #[async_trait]
@@ -296,6 +351,9 @@ impl AgentLlmClient for RecordingLlmClient {
             .lock()
             .expect("provider_visible_tools lock poisoned")
             .push(names);
+        if let Some(delay_ms) = self.delay_ms {
+            tokio::time::sleep(tokio::time::Duration::from_millis(delay_ms)).await;
+        }
         self.provider_visible_system_prompts
             .lock()
             .expect("provider_visible_system_prompts lock poisoned")
@@ -396,6 +454,8 @@ impl SessionAgent for RealSessionAgent {
 struct RealAgentBuilder {
     provider_visible_tools: Arc<std::sync::Mutex<Vec<Vec<String>>>>,
     provider_visible_system_prompts: Arc<std::sync::Mutex<Vec<Vec<String>>>>,
+    llm_delay_ms: Option<u64>,
+    hook_engine: Option<Arc<dyn HookEngine>>,
 }
 
 #[async_trait]
@@ -414,10 +474,14 @@ impl SessionAgentBuilder for RealAgentBuilder {
         if let Some(system_prompt) = &req.system_prompt {
             builder = builder.system_prompt(system_prompt.clone());
         }
+        if let Some(hook_engine) = &self.hook_engine {
+            builder = builder.with_hook_engine(Arc::clone(hook_engine));
+        }
 
         let client = Arc::new(RecordingLlmClient {
             provider_visible_tools: Arc::clone(&self.provider_visible_tools),
             provider_visible_system_prompts: Arc::clone(&self.provider_visible_system_prompts),
+            delay_ms: self.llm_delay_ms,
         });
         let tools = Arc::new(StaticToolDispatcher::new(&["alpha", "beta"]));
         let store = Arc::new(NoopSessionStore);
@@ -846,6 +910,8 @@ async fn test_flow_tool_overlay_enforced_by_runtime_and_resets_next_turn() {
         RealAgentBuilder {
             provider_visible_tools: Arc::clone(&provider_visible_tools),
             provider_visible_system_prompts: Arc::new(std::sync::Mutex::new(Vec::new())),
+            llm_delay_ms: None,
+            hook_engine: None,
         },
         10,
     ));
@@ -1033,6 +1099,8 @@ async fn test_staged_system_context_applies_at_next_llm_boundary() {
         RealAgentBuilder {
             provider_visible_tools: Arc::clone(&provider_visible_tools),
             provider_visible_system_prompts: Arc::clone(&provider_visible_system_prompts),
+            llm_delay_ms: None,
+            hook_engine: None,
         },
         10,
     ));
@@ -1126,6 +1194,278 @@ async fn test_staged_system_context_applies_at_next_llm_boundary() {
         .get("ctx-boundary")
         .expect("idempotency key should remain tracked");
     assert_eq!(seen.state, meerkat_core::SeenSystemContextState::Applied);
+}
+
+#[tokio::test]
+async fn test_staged_system_context_is_not_replayed_on_later_turns() {
+    let provider_visible_system_prompts =
+        Arc::new(std::sync::Mutex::new(Vec::<Vec<String>>::new()));
+    let service = Arc::new(EphemeralSessionService::new(
+        RealAgentBuilder {
+            provider_visible_tools: Arc::new(std::sync::Mutex::new(Vec::<Vec<String>>::new())),
+            provider_visible_system_prompts: Arc::clone(&provider_visible_system_prompts),
+            llm_delay_ms: None,
+            hook_engine: None,
+        },
+        10,
+    ));
+
+    let mut request = create_req_deferred("runtime tool scope");
+    request.system_prompt = Some("Base system prompt".to_string());
+    let _ = service
+        .create_session(request)
+        .await
+        .expect("create deferred session");
+    let session_id = service
+        .list(SessionQuery::default())
+        .await
+        .expect("list sessions")[0]
+        .session_id
+        .clone();
+
+    service
+        .append_system_context(
+            &session_id,
+            AppendSystemContextRequest {
+                text: "You are coordinating with an external orchestrator.".to_string(),
+                source: Some("mob".to_string()),
+                idempotency_key: Some("ctx-boundary-replay".to_string()),
+            },
+        )
+        .await
+        .expect("append system context");
+
+    service
+        .start_turn(
+            &session_id,
+            StartTurnRequest {
+                host_mode: false,
+                skill_references: None,
+                flow_tool_overlay: None,
+                prompt: "apply staged context".to_string(),
+                event_tx: None,
+                additional_instructions: None,
+            },
+        )
+        .await
+        .expect("first turn should run");
+
+    service
+        .start_turn(
+            &session_id,
+            StartTurnRequest {
+                host_mode: false,
+                skill_references: None,
+                flow_tool_overlay: None,
+                prompt: "follow-up turn".to_string(),
+                event_tx: None,
+                additional_instructions: None,
+            },
+        )
+        .await
+        .expect("second turn should run");
+
+    let prompts = provider_visible_system_prompts
+        .lock()
+        .expect("provider_visible_system_prompts lock poisoned")
+        .clone();
+    assert_eq!(prompts.len(), 2, "expected one provider call per turn");
+    assert!(
+        prompts[0][0].contains("You are coordinating with an external orchestrator."),
+        "first turn should include staged context"
+    );
+    assert!(
+        !prompts[1][0].contains("You are coordinating with an external orchestrator."),
+        "second turn must not replay single-use staged context"
+    );
+}
+
+#[tokio::test]
+async fn test_staged_system_context_appended_during_active_turn_waits_for_next_turn() {
+    let provider_visible_system_prompts =
+        Arc::new(std::sync::Mutex::new(Vec::<Vec<String>>::new()));
+    let service = Arc::new(EphemeralSessionService::new(
+        RealAgentBuilder {
+            provider_visible_tools: Arc::new(std::sync::Mutex::new(Vec::<Vec<String>>::new())),
+            provider_visible_system_prompts: Arc::clone(&provider_visible_system_prompts),
+            llm_delay_ms: Some(200),
+            hook_engine: None,
+        },
+        10,
+    ));
+
+    let mut request = create_req_deferred("runtime tool scope");
+    request.system_prompt = Some("Base system prompt".to_string());
+    let _ = service
+        .create_session(request)
+        .await
+        .expect("create deferred session");
+    let session_id = service
+        .list(SessionQuery::default())
+        .await
+        .expect("list sessions")[0]
+        .session_id
+        .clone();
+
+    let first_turn = {
+        let service = Arc::clone(&service);
+        let session_id = session_id.clone();
+        tokio::spawn(async move {
+            service
+                .start_turn(
+                    &session_id,
+                    StartTurnRequest {
+                        host_mode: false,
+                        skill_references: None,
+                        flow_tool_overlay: None,
+                        prompt: "first turn".to_string(),
+                        event_tx: None,
+                        additional_instructions: None,
+                    },
+                )
+                .await
+        })
+    };
+
+    tokio::time::sleep(tokio::time::Duration::from_millis(50)).await;
+    service
+        .append_system_context(
+            &session_id,
+            AppendSystemContextRequest {
+                text: "Late staged context".to_string(),
+                source: Some("mob".to_string()),
+                idempotency_key: Some("ctx-during-active-turn".to_string()),
+            },
+        )
+        .await
+        .expect("append during active turn");
+
+    first_turn
+        .await
+        .expect("first turn join")
+        .expect("first turn should finish");
+
+    service
+        .start_turn(
+            &session_id,
+            StartTurnRequest {
+                host_mode: false,
+                skill_references: None,
+                flow_tool_overlay: None,
+                prompt: "second turn".to_string(),
+                event_tx: None,
+                additional_instructions: None,
+            },
+        )
+        .await
+        .expect("second turn should run");
+
+    let prompts = provider_visible_system_prompts
+        .lock()
+        .expect("provider_visible_system_prompts lock poisoned")
+        .clone();
+    assert_eq!(prompts.len(), 2, "expected one provider call per turn");
+    assert!(
+        !prompts[0][0].contains("Late staged context"),
+        "context appended during an active turn must not enter the in-flight provider request"
+    );
+    assert!(
+        prompts[1][0].contains("Late staged context"),
+        "context appended during an active turn must stage for the subsequent eligible turn"
+    );
+}
+
+#[tokio::test]
+async fn test_pre_llm_denied_turn_does_not_consume_staged_system_context() {
+    let provider_visible_system_prompts =
+        Arc::new(std::sync::Mutex::new(Vec::<Vec<String>>::new()));
+    let service = Arc::new(EphemeralSessionService::new(
+        RealAgentBuilder {
+            provider_visible_tools: Arc::new(std::sync::Mutex::new(Vec::<Vec<String>>::new())),
+            provider_visible_system_prompts: Arc::clone(&provider_visible_system_prompts),
+            llm_delay_ms: None,
+            hook_engine: Some(Arc::new(DenyNextPreLlmHookEngine::new())),
+        },
+        10,
+    ));
+
+    let mut request = create_req_deferred("runtime tool scope");
+    request.system_prompt = Some("Base system prompt".to_string());
+    let _ = service
+        .create_session(request)
+        .await
+        .expect("create deferred session");
+    let session_id = service
+        .list(SessionQuery::default())
+        .await
+        .expect("list sessions")[0]
+        .session_id
+        .clone();
+
+    service
+        .append_system_context(
+            &session_id,
+            AppendSystemContextRequest {
+                text: "You are coordinating with an external orchestrator.".to_string(),
+                source: Some("mob".to_string()),
+                idempotency_key: Some("ctx-pre-llm-deny".to_string()),
+            },
+        )
+        .await
+        .expect("append system context");
+
+    let denied = service
+        .start_turn(
+            &session_id,
+            StartTurnRequest {
+                host_mode: false,
+                skill_references: None,
+                flow_tool_overlay: None,
+                prompt: "denied turn".to_string(),
+                event_tx: None,
+                additional_instructions: None,
+            },
+        )
+        .await;
+    assert!(denied.is_err(), "pre-llm hook should deny the first turn");
+
+    let prompts = provider_visible_system_prompts
+        .lock()
+        .expect("provider_visible_system_prompts lock poisoned")
+        .clone();
+    assert!(
+        prompts.is_empty(),
+        "a denied pre-llm turn must not reach the provider"
+    );
+
+    service
+        .start_turn(
+            &session_id,
+            StartTurnRequest {
+                host_mode: false,
+                skill_references: None,
+                flow_tool_overlay: None,
+                prompt: "eligible turn".to_string(),
+                event_tx: None,
+                additional_instructions: None,
+            },
+        )
+        .await
+        .expect("next eligible turn should run");
+
+    let prompts = provider_visible_system_prompts
+        .lock()
+        .expect("provider_visible_system_prompts lock poisoned")
+        .clone();
+    assert_eq!(
+        prompts.len(),
+        1,
+        "only the eligible turn should reach the provider"
+    );
+    assert!(
+        prompts[0][0].contains("You are coordinating with an external orchestrator."),
+        "staged context must survive a denied pre-llm turn and apply on the next eligible turn"
+    );
 }
 
 #[tokio::test]

--- a/meerkat-tools/src/builtin/composite.rs
+++ b/meerkat-tools/src/builtin/composite.rs
@@ -15,6 +15,7 @@ use meerkat_core::error::ToolError;
 use meerkat_core::types::{ToolCallView, ToolDef, ToolResult};
 use serde_json::Value;
 use std::collections::HashSet;
+#[cfg(not(target_arch = "wasm32"))]
 use std::path::PathBuf;
 use std::sync::Arc;
 

--- a/meerkat-web-runtime/src/lib.rs
+++ b/meerkat-web-runtime/src/lib.rs
@@ -2277,6 +2277,10 @@ pub fn poll_subscription(handle: u32) -> Result<String, JsValue> {
                         },
                         Err(TryRecvError::Lagged(n)) => {
                             tracing::warn!(skipped = n, "subscription lagged");
+                            events.push(serde_json::json!({
+                                "type": "lagged",
+                                "skipped": n,
+                            }));
                             continue;
                         }
                         Err(TryRecvError::Empty | TryRecvError::Closed) => break,
@@ -2316,7 +2320,12 @@ pub fn close_subscription(handle: u32) -> Result<(), JsValue> {
 
 #[cfg(test)]
 mod tests {
-    use super::{build_service_infrastructure, merge_runtime_system_context_state};
+    use super::{
+        EventSubscription, SUBSCRIPTIONS, SubscriptionInner, build_service_infrastructure,
+        close_subscription, merge_runtime_system_context_state, poll_subscription,
+    };
+    #[cfg(target_arch = "wasm32")]
+    use super::{append_system_context, create_session_simple, destroy_session, get_session_state};
     use meerkat::SessionServiceControlExt;
     use meerkat_core::Config;
     use meerkat_core::{
@@ -2485,5 +2494,118 @@ mod tests {
             system_context_state.pending[0].text,
             "Prioritize coordinating with the lead."
         );
+    }
+
+    #[cfg(target_arch = "wasm32")]
+    #[test]
+    fn append_system_context_export_stages_context_for_direct_session_handle() {
+        let handle = create_session_simple(
+            &json!({
+                "model": "claude-sonnet-4-5",
+                "api_key": "sk-test"
+            })
+            .to_string(),
+        )
+        .expect("create session");
+
+        let result = append_system_context(
+            handle,
+            &json!({
+                "text": "Remember the browser-side coordinator.",
+                "source": "web",
+                "idempotency_key": "ctx-web-1"
+            })
+            .to_string(),
+        )
+        .expect("append system context");
+        let result_json = result.as_string().expect("append result string");
+        let parsed: serde_json::Value =
+            serde_json::from_str(&result_json).expect("append result json");
+
+        assert_eq!(parsed["handle"], handle);
+        assert_eq!(parsed["status"], "staged");
+    }
+
+    #[cfg(target_arch = "wasm32")]
+    #[test]
+    fn destroy_session_export_removes_local_handle() {
+        let handle = create_session_simple(
+            &json!({
+                "model": "claude-sonnet-4-5",
+                "api_key": "sk-test"
+            })
+            .to_string(),
+        )
+        .expect("create session");
+
+        let before = get_session_state(handle).expect("session state before destroy");
+        let before: serde_json::Value = serde_json::from_str(&before).expect("state json");
+        assert_eq!(before["session_id"], handle);
+
+        destroy_session(handle).expect("destroy session");
+        assert!(get_session_state(handle).is_err());
+    }
+
+    #[test]
+    fn poll_subscription_surfaces_lagged_signal() {
+        let (tx, rx) = crate::tokio::sync::broadcast::channel(1);
+        let session_id = meerkat_core::SessionId::new();
+        tx.send(meerkat_core::EventEnvelope::new(
+            session_id.to_string(),
+            1,
+            None,
+            meerkat_core::AgentEvent::TextDelta {
+                delta: "first".to_string(),
+            },
+        ))
+        .unwrap_or(0);
+        tx.send(meerkat_core::EventEnvelope::new(
+            session_id.to_string(),
+            2,
+            None,
+            meerkat_core::AgentEvent::TextDelta {
+                delta: "second".to_string(),
+            },
+        ))
+        .unwrap_or(0);
+
+        let handle = SUBSCRIPTIONS.with(|cell| {
+            let mut registry = cell.borrow_mut();
+            let handle = registry.next_handle;
+            registry.next_handle = registry.next_handle.wrapping_add(1);
+            registry.subscriptions.insert(
+                handle,
+                EventSubscription {
+                    inner: SubscriptionInner::Member(std::cell::RefCell::new(rx)),
+                },
+            );
+            handle
+        });
+
+        let payload_result = poll_subscription(handle);
+        assert!(payload_result.is_ok());
+        let payload = match payload_result {
+            Ok(payload) => payload,
+            Err(_) => unreachable!(),
+        };
+        let parsed_result: Result<serde_json::Value, _> = serde_json::from_str(&payload);
+        assert!(parsed_result.is_ok());
+        let parsed = match parsed_result {
+            Ok(parsed) => parsed,
+            Err(_) => unreachable!(),
+        };
+        let items_opt = parsed.as_array();
+        assert!(items_opt.is_some());
+        let items = match items_opt {
+            Some(items) => items,
+            None => unreachable!(),
+        };
+        assert_eq!(items[0]["type"], "lagged");
+        assert_eq!(items[0]["skipped"], 1);
+        assert_eq!(items[1]["payload"]["type"], "text_delta");
+        assert_eq!(items[1]["payload"]["delta"], "second");
+
+        let close_result = close_subscription(handle);
+        assert!(close_result.is_ok());
     }
 }

--- a/sdks/python/meerkat/streaming.py
+++ b/sdks/python/meerkat/streaming.py
@@ -32,6 +32,7 @@ class _StdoutDispatcher:
         self._pending_stream_request_id: int | None = None
         self._unmatched_buffer: dict[str, list[dict[str, Any]]] = {}
         self._unmatched_stream_buffer: dict[str, list[dict[str, Any]]] = {}
+        self._stream_terminal: dict[str, dict[str, Any]] = {}
         self._unmatched_stream_end: set[str] = set()
         self._task: asyncio.Task[None] | None = None
         self._closed = False
@@ -74,6 +75,9 @@ class _StdoutDispatcher:
 
     def unsubscribe_stream(self, stream_id: str) -> None:
         self._stream_queues.pop(stream_id, None)
+
+    def stream_terminal(self, stream_id: str) -> dict[str, Any] | None:
+        return self._stream_terminal.get(stream_id)
 
     def subscribe_pending_stream(self, request_id: int) -> asyncio.Queue[dict[str, Any] | None]:
         if self._pending_stream_queue is not None:
@@ -139,6 +143,8 @@ class _StdoutDispatcher:
                     continue
                 if method in {"session/stream_end", "mob/stream_end"}:
                     stream_id = str(params.get("stream_id", ""))
+                    if stream_id:
+                        self._stream_terminal[stream_id] = dict(params)
                     queue = self._stream_queues.get(stream_id)
                     if queue is not None:
                         await queue.put(None)
@@ -166,6 +172,7 @@ class _StdoutDispatcher:
         self._stream_queues.clear()
         self._unmatched_stream_buffer.clear()
         self._unmatched_stream_end.clear()
+        self._stream_terminal.clear()
         if self._pending_stream_queue is not None:
             self._pending_stream_queue.put_nowait(None)
             self._pending_stream_queue = None
@@ -321,6 +328,10 @@ class EventSubscription:
     @property
     def stream_id(self) -> str:
         return self._stream_id
+
+    @property
+    def terminal_outcome(self) -> dict[str, Any] | None:
+        return self._dispatcher.stream_terminal(self._stream_id)
 
     async def __aenter__(self) -> EventSubscription:
         return self

--- a/sdks/python/tests/test_e2e.py
+++ b/sdks/python/tests/test_e2e.py
@@ -7,14 +7,21 @@ These tests require:
 Run with: pytest tests/test_e2e.py -v (skipped by default if rkat-rpc not found)
 """
 
+import asyncio
+from pathlib import Path
 import shutil
 import subprocess
 
 import pytest
 
-# Skip all tests in this file if rkat-rpc is not available
+WORKSPACE_BIN = Path(__file__).resolve().parents[3] / "target-codex" / "debug" / "rkat-rpc"
+
+
+# Skip all tests in this file if no usable rpc binary is available.
 pytestmark = pytest.mark.skipif(
-    shutil.which("rkat-rpc") is None and shutil.which("rkat") is None,
+    not WORKSPACE_BIN.exists()
+    and shutil.which("rkat-rpc") is None
+    and shutil.which("rkat") is None,
     reason="rkat-rpc binary not found on PATH",
 )
 
@@ -23,8 +30,12 @@ def test_rkat_rpc_starts_and_responds():
     """Verify rkat-rpc subprocess starts and responds to initialize."""
     import json
 
-    binary = "rkat-rpc" if shutil.which("rkat-rpc") else "rkat"
-    args = [binary] + (["rpc"] if binary == "rkat" else [])
+    if WORKSPACE_BIN.exists():
+        binary = str(WORKSPACE_BIN)
+        args = [binary]
+    else:
+        binary = "rkat-rpc" if shutil.which("rkat-rpc") else "rkat"
+        args = [binary] + (["rpc"] if binary == "rkat" else [])
     proc = subprocess.Popen(
         args,
         stdin=subprocess.PIPE,
@@ -75,3 +86,30 @@ def test_rkat_capabilities_command():
     # Verify at least Sessions is present
     cap_ids = [c["id"] for c in data["capabilities"]]
     assert "sessions" in cap_ids
+
+
+@pytest.mark.asyncio
+async def test_python_sdk_live_mob_stream_explicit_close():
+    """Verify the packaged Python SDK observes explicit_close on a live mob stream."""
+    from meerkat import MeerkatClient
+
+    rpc_path = str(WORKSPACE_BIN) if WORKSPACE_BIN.exists() else (
+        "rkat-rpc" if shutil.which("rkat-rpc") else "rkat"
+    )
+
+    async with MeerkatClient(rpc_path) as client:
+        created = await client.call_mob_tool("mob_create", {"prefab": "coding_swarm"})
+        mob_id = str(created.get("mob_id", ""))
+        assert mob_id
+
+        sub = await client.subscribe_mob_events(mob_id)
+        await sub.close()
+
+        for _ in range(10):
+            outcome = sub.terminal_outcome
+            if outcome and outcome.get("outcome") == "explicit_close":
+                break
+            await asyncio.sleep(0.02)
+
+        assert sub.terminal_outcome is not None
+        assert sub.terminal_outcome.get("outcome") == "explicit_close"

--- a/sdks/python/tests/test_stream_e2e_fake_rpc.py
+++ b/sdks/python/tests/test_stream_e2e_fake_rpc.py
@@ -1,0 +1,38 @@
+import asyncio
+from pathlib import Path
+
+import pytest
+
+
+FAKE_RPC = Path(__file__).resolve().parents[2] / "test-fixtures" / "fake_stream_rpc.mjs"
+
+
+@pytest.mark.asyncio
+async def test_python_sdk_buffered_stream_flushes_in_order_and_remote_end_is_visible():
+    from meerkat import MeerkatClient
+
+    async with MeerkatClient(str(FAKE_RPC)) as client:
+        sub = await client.subscribe_session_events("buffered-session")
+        deltas = []
+        async for event in sub:
+            deltas.append(getattr(event.payload, "delta", None))
+
+        assert deltas == ["hi", "there"]
+        assert sub.terminal_outcome is not None
+        assert sub.terminal_outcome.get("outcome") == "remote_end"
+
+
+@pytest.mark.asyncio
+async def test_python_sdk_terminal_error_stream_is_visible_without_manual_close():
+    from meerkat import MeerkatClient
+
+    async with MeerkatClient(str(FAKE_RPC)) as client:
+        sub = await client.subscribe_session_events("terminal-error-session")
+        events = []
+        async for event in sub:
+            events.append(event)
+
+        assert events == []
+        assert sub.terminal_outcome is not None
+        assert sub.terminal_outcome.get("outcome") == "terminal_error"
+        assert sub.terminal_outcome.get("error", {}).get("code") == "stream_queue_overflow"

--- a/sdks/python/tests/test_streaming.py
+++ b/sdks/python/tests/test_streaming.py
@@ -490,6 +490,24 @@ class TestStandaloneSubscriptions:
         await d.stop()
 
     @pytest.mark.asyncio
+    async def test_stream_notifications_buffered_until_stream_queue_registered_preserve_order(self):
+        ev1 = {"event_id": "e1", "payload": {"type": "text_delta", "delta": "hi"}}
+        ev2 = {"event_id": "e2", "payload": {"type": "text_delta", "delta": "there"}}
+        reader = asyncio.StreamReader()
+        d = _StdoutDispatcher(reader)
+        d.start()
+        reader.feed_data((stream_notification("stream-1", ev1) + "\n").encode())
+        reader.feed_data((stream_notification("stream-1", ev2) + "\n").encode())
+        await asyncio.sleep(0)
+        queue = d.subscribe_stream("stream-1")
+        first = await asyncio.wait_for(queue.get(), timeout=1.0)
+        second = await asyncio.wait_for(queue.get(), timeout=1.0)
+        assert first == ev1
+        assert second == ev2
+        reader.feed_eof()
+        await d.stop()
+
+    @pytest.mark.asyncio
     async def test_stream_end_buffered_until_stream_queue_registered(self):
         reader = asyncio.StreamReader()
         d = _StdoutDispatcher(reader)
@@ -497,12 +515,29 @@ class TestStandaloneSubscriptions:
         reader.feed_data((jline({
             "jsonrpc": "2.0",
             "method": "session/stream_end",
-            "params": {"stream_id": "stream-1", "ended": True},
+            "params": {"stream_id": "stream-1", "ended": True, "outcome": "remote_end"},
         }) + "\n").encode())
         await asyncio.sleep(0)
         queue = d.subscribe_stream("stream-1")
         event = await asyncio.wait_for(queue.get(), timeout=1.0)
         assert event is None
+        expected = {
+            "stream_id": "stream-1",
+            "ended": True,
+            "outcome": "remote_end",
+        }
+        assert d.stream_terminal("stream-1") == expected
+
+        from meerkat.streaming import EventSubscription
+
+        subscription = EventSubscription(
+            stream_id="stream-1",
+            event_queue=queue,
+            dispatcher=d,
+            close_remote=lambda _stream_id: asyncio.sleep(0),
+            parse_event_fn=lambda event: event,
+        )
+        assert subscription.terminal_outcome == expected
         reader.feed_eof()
         await d.stop()
 

--- a/sdks/test-fixtures/fake_stream_rpc.mjs
+++ b/sdks/test-fixtures/fake_stream_rpc.mjs
@@ -1,0 +1,155 @@
+#!/usr/bin/env node
+
+import readline from "node:readline";
+
+const CONTRACT_VERSION = "0.4.6";
+
+function write(message) {
+  process.stdout.write(`${JSON.stringify(message)}\n`);
+}
+
+function streamEvent(streamId, eventId, delta, seq) {
+  return {
+    jsonrpc: "2.0",
+    method: "session/stream_event",
+    params: {
+      stream_id: streamId,
+      event: {
+        event_id: eventId,
+        source_id: "fake-session",
+        seq,
+        timestamp_ms: seq,
+        payload: {
+          type: "text_delta",
+          delta,
+        },
+      },
+    },
+  };
+}
+
+function streamEnd(streamId, outcome, error = undefined) {
+  return {
+    jsonrpc: "2.0",
+    method: "session/stream_end",
+    params: {
+      stream_id: streamId,
+      ended: true,
+      outcome,
+      ...(error ? { error } : {}),
+    },
+  };
+}
+
+const rl = readline.createInterface({
+  input: process.stdin,
+  crlfDelay: Infinity,
+});
+
+rl.on("line", (line) => {
+  let request;
+  try {
+    request = JSON.parse(line);
+  } catch {
+    return;
+  }
+
+  const { id, method, params = {} } = request;
+  if (typeof id === "undefined" || !method) {
+    return;
+  }
+
+  if (method === "initialize") {
+    write({
+      jsonrpc: "2.0",
+      id,
+      result: {
+        contract_version: CONTRACT_VERSION,
+        capabilities: [],
+      },
+    });
+    return;
+  }
+
+  if (method === "capabilities/get") {
+    write({
+      jsonrpc: "2.0",
+      id,
+      result: {
+        capabilities: [
+          {
+            id: "sessions",
+            description: "Fake session capability",
+            status: "Available",
+          },
+        ],
+      },
+    });
+    return;
+  }
+
+  if (method === "session/stream_open") {
+    const sessionId = String(params.session_id ?? "");
+    if (sessionId === "buffered-session") {
+      write(streamEvent("stream-buffered", "e1", "hi", 1));
+      write(streamEvent("stream-buffered", "e2", "there", 2));
+      write(streamEnd("stream-buffered", "remote_end"));
+      write({
+        jsonrpc: "2.0",
+        id,
+        result: {
+          stream_id: "stream-buffered",
+        },
+      });
+      return;
+    }
+
+    if (sessionId === "terminal-error-session") {
+      write(
+        streamEnd("stream-terminal-error", "terminal_error", {
+          code: "stream_queue_overflow",
+          message: "transport stream notification queue overflow",
+        }),
+      );
+      write({
+        jsonrpc: "2.0",
+        id,
+        result: {
+          stream_id: "stream-terminal-error",
+        },
+      });
+      return;
+    }
+
+    write({
+      jsonrpc: "2.0",
+      id,
+      error: {
+        code: -32602,
+        message: `Unknown fake session: ${sessionId}`,
+      },
+    });
+    return;
+  }
+
+  if (method === "session/stream_close") {
+    write({
+      jsonrpc: "2.0",
+      id,
+      result: {
+        closed: true,
+        already_closed: false,
+      },
+    });
+    return;
+  }
+
+  write({
+    jsonrpc: "2.0",
+    id,
+    error: {
+      code: -32601,
+      message: `Method not found: ${method}`,
+    },
+  });
+});

--- a/sdks/typescript/package.json
+++ b/sdks/typescript/package.json
@@ -17,7 +17,8 @@
   ],
   "scripts": {
     "build": "tsc",
-    "test": "node --test tests/"
+    "test": "node --test tests/",
+    "test:e2e": "npm run build && node --test tests/e2e_sdk_smoke.test.mjs"
   },
   "license": "MIT OR Apache-2.0",
   "devDependencies": {

--- a/sdks/typescript/src/client.ts
+++ b/sdks/typescript/src/client.ts
@@ -144,7 +144,8 @@ export class MeerkatClient {
   private pendingStreamRequestId: number | null = null;
   private unmatchedStreamBuffer = new Map<string, Record<string, unknown>[]>();
   private unmatchedStandaloneStreamBuffer = new Map<string, Record<string, unknown>[]>();
-  private unmatchedStandaloneStreamEnd = new Set<string>();
+  private unmatchedStandaloneStreamEnd = new Map<string, Record<string, unknown>>();
+  private streamTerminalOutcomes = new Map<string, Record<string, unknown>>();
   private rl: ReadlineInterface | null = null;
 
   constructor(rkatPath = "rkat-rpc") {
@@ -221,6 +222,7 @@ export class MeerkatClient {
       queue.put(null);
     }
     this.streamQueues.clear();
+    this.streamTerminalOutcomes.clear();
     if (this.pendingStreamQueue) {
       this.pendingStreamQueue.put(null);
       this.pendingStreamQueue = null;
@@ -657,6 +659,7 @@ export class MeerkatClient {
         await this.request(closeMethod, { stream_id: id });
       },
       parseEvent: parse,
+      getTerminalOutcome: () => this.streamTerminalOutcomes.get(streamId),
     });
   }
 
@@ -839,11 +842,14 @@ export class MeerkatClient {
       }
       if (method === "session/stream_end" || method === "mob/stream_end") {
         const streamId = String(params.stream_id ?? "");
+        if (streamId) {
+          this.streamTerminalOutcomes.set(streamId, params);
+        }
         const queue = this.streamQueues.get(streamId);
         if (queue) {
           queue.put(null);
         } else if (streamId) {
-          this.unmatchedStandaloneStreamEnd.add(streamId);
+          this.unmatchedStandaloneStreamEnd.set(streamId, params);
         }
         return;
       }

--- a/sdks/typescript/src/subscription.ts
+++ b/sdks/typescript/src/subscription.ts
@@ -5,6 +5,7 @@ export class EventSubscription<T> implements AsyncIterable<T> {
   private readonly queue: AsyncQueue<Record<string, unknown> | null>;
   private readonly closeRemote: (streamId: string) => Promise<void>;
   private readonly parseEvent: (raw: Record<string, unknown>) => T;
+  private readonly getTerminalOutcome: () => Record<string, unknown> | undefined;
   private closed = false;
 
   /** @internal */
@@ -13,11 +14,13 @@ export class EventSubscription<T> implements AsyncIterable<T> {
     queue: AsyncQueue<Record<string, unknown> | null>;
     closeRemote: (streamId: string) => Promise<void>;
     parseEvent: (raw: Record<string, unknown>) => T;
+    getTerminalOutcome: () => Record<string, unknown> | undefined;
   }) {
     this.streamId = opts.streamId;
     this.queue = opts.queue;
     this.closeRemote = opts.closeRemote;
     this.parseEvent = opts.parseEvent;
+    this.getTerminalOutcome = opts.getTerminalOutcome;
   }
 
   get id(): string {
@@ -26,6 +29,10 @@ export class EventSubscription<T> implements AsyncIterable<T> {
 
   get isClosed(): boolean {
     return this.closed;
+  }
+
+  get terminalOutcome(): Record<string, unknown> | undefined {
+    return this.getTerminalOutcome();
   }
 
   async close(): Promise<void> {

--- a/sdks/typescript/tests/e2e_sdk_smoke.test.mjs
+++ b/sdks/typescript/tests/e2e_sdk_smoke.test.mjs
@@ -1,0 +1,118 @@
+import { after, before, describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { execSync } from "node:child_process";
+import { existsSync } from "node:fs";
+import { setTimeout as delay } from "node:timers/promises";
+import { fileURLToPath } from "node:url";
+
+const binaryPath = (() => {
+  const workspaceBinary = fileURLToPath(
+    new URL("../../../target-codex/debug/rkat-rpc", import.meta.url),
+  );
+  if (existsSync(workspaceBinary)) {
+    return workspaceBinary;
+  }
+  try {
+    return execSync("which rkat-rpc", { encoding: "utf8" }).trim();
+  } catch {
+    try {
+      return execSync("which rkat", { encoding: "utf8" }).trim();
+    } catch {
+      return "";
+    }
+  }
+})();
+
+const fakeStreamBinary = fileURLToPath(
+  new URL("../../test-fixtures/fake_stream_rpc.mjs", import.meta.url),
+);
+
+describe("E2E Smoke: TypeScript SDK package", { skip: !binaryPath }, () => {
+  let MeerkatClient;
+  let client;
+
+  before(async () => {
+    ({ MeerkatClient } = await import("../dist/index.js"));
+    client = new MeerkatClient(binaryPath);
+    await client.connect();
+  });
+
+  after(async () => {
+    if (client) {
+      await client.close();
+    }
+  });
+
+  it("connects through the packaged SDK and fetches capabilities", async () => {
+    const capabilities = client.capabilities;
+    assert.ok(Array.isArray(capabilities), "capabilities should be an array");
+    assert.ok(capabilities.length > 0, "capabilities should not be empty");
+    assert.ok(
+      capabilities.some((capability) => capability.id === "sessions"),
+      "sessions capability should be present",
+    );
+  });
+
+  it("surfaces a typed error for reading a missing session", async () => {
+    await assert.rejects(
+      () => client.readSession("00000000-0000-0000-0000-000000000000"),
+      /Session not found|RPC error/i,
+    );
+  });
+
+  it("opens and explicitly closes a live mob stream through the packaged SDK", async () => {
+    const created = await client.callMobTool("mob_create", { prefab: "coding_swarm" });
+    const mobId = String(created.mob_id ?? "");
+    assert.ok(mobId, "mob_create should return mob_id");
+
+    const sub = await client.subscribeMobEvents(mobId);
+    await sub.close();
+
+    for (let attempt = 0; attempt < 10; attempt += 1) {
+      if (sub.terminalOutcome?.outcome === "explicit_close") {
+        break;
+      }
+      await delay(20);
+    }
+
+    assert.equal(sub.terminalOutcome?.outcome, "explicit_close");
+  });
+});
+
+describe("E2E Smoke: TypeScript SDK package against scripted stream RPC", () => {
+  let MeerkatClient;
+  let client;
+
+  before(async () => {
+    ({ MeerkatClient } = await import("../dist/index.js"));
+    client = new MeerkatClient(fakeStreamBinary);
+    await client.connect();
+  });
+
+  after(async () => {
+    if (client) {
+      await client.close();
+    }
+  });
+
+  it("replays buffered standalone stream events in order and exposes remote_end", async () => {
+    const sub = await client.subscribeSessionEvents("buffered-session");
+    const deltas = [];
+    for await (const event of sub) {
+      deltas.push(event.payload.delta);
+    }
+
+    assert.deepEqual(deltas, ["hi", "there"]);
+    assert.equal(sub.terminalOutcome?.outcome, "remote_end");
+  });
+
+  it("surfaces terminal_error on the packaged standalone subscription API", async () => {
+    const sub = await client.subscribeSessionEvents("terminal-error-session");
+    const iterator = sub[Symbol.asyncIterator]();
+    const first = await iterator.next();
+
+    assert.equal(first.done, true);
+    assert.equal(sub.terminalOutcome?.outcome, "terminal_error");
+    assert.equal(sub.terminalOutcome?.error?.code, "stream_queue_overflow");
+  });
+});

--- a/sdks/typescript/tests/skills.test.js
+++ b/sdks/typescript/tests/skills.test.js
@@ -261,6 +261,7 @@ describe("Skills v2.1", () => {
           params: {
             stream_id: "stream-end-1",
             ended: true,
+            outcome: "remote_end",
           },
         }));
         return { stream_id: "stream-end-1" };
@@ -278,6 +279,11 @@ describe("Skills v2.1", () => {
       new Promise((_, reject) => setTimeout(() => reject(new Error("stream did not terminate")), 200)),
     ]);
     assert.equal(first.done, true);
+    assert.deepEqual(sub.terminalOutcome, {
+      stream_id: "stream-end-1",
+      ended: true,
+      outcome: "remote_end",
+    });
     await sub.close();
   });
 
@@ -307,6 +313,47 @@ describe("Skills v2.1", () => {
     assert.equal(first.done, false);
     assert.equal(first.value.payload.type, "text_delta");
     assert.equal(first.value.payload.delta, "hi");
+    await sub.close();
+  });
+
+  it("preserves buffered standalone stream notification order", async () => {
+    const client = new MeerkatClient();
+    client.request = async (method, params) => {
+      if (method === "session/stream_open") {
+        client.handleLine(JSON.stringify({
+          jsonrpc: "2.0",
+          method: "session/stream_event",
+          params: {
+            stream_id: "stream-ordered",
+            event: { event_id: "e1", payload: { type: "text_delta", delta: "hi" } },
+          },
+        }));
+        client.handleLine(JSON.stringify({
+          jsonrpc: "2.0",
+          method: "session/stream_event",
+          params: {
+            stream_id: "stream-ordered",
+            event: { event_id: "e2", payload: { type: "text_delta", delta: "there" } },
+          },
+        }));
+        return { stream_id: "stream-ordered" };
+      }
+      if (method === "session/stream_close") {
+        return { closed: true };
+      }
+      return {};
+    };
+
+    const sub = await client.subscribeSessionEvents("s1");
+    const iterator = sub[Symbol.asyncIterator]();
+    const first = await iterator.next();
+    const second = await iterator.next();
+    assert.equal(first.done, false);
+    assert.equal(second.done, false);
+    assert.equal(first.value.payload.type, "text_delta");
+    assert.equal(first.value.payload.delta, "hi");
+    assert.equal(second.value.payload.type, "text_delta");
+    assert.equal(second.value.payload.delta, "there");
     await sub.close();
   });
 

--- a/sdks/web/package.json
+++ b/sdks/web/package.json
@@ -13,6 +13,7 @@
       "import": "./dist/index.js",
       "types": "./dist/index.d.ts"
     },
+    "./wasm/*": "./wasm/*",
     "./proxy": {
       "import": "./proxy/index.mjs"
     }
@@ -27,7 +28,8 @@
     "build:ts": "tsc",
     "build": "npm run build:wasm && npm run build:ts",
     "prepublishOnly": "npm run build",
-    "test": "tsc --noEmit -p tests/tsconfig.json"
+    "test": "tsc --noEmit -p tests/tsconfig.json",
+    "test:e2e": "npm run build && node --test tests/e2e_wasm_runtime.test.mjs"
   },
   "license": "MIT OR Apache-2.0",
   "devDependencies": {

--- a/sdks/web/tests/e2e_wasm_runtime.test.mjs
+++ b/sdks/web/tests/e2e_wasm_runtime.test.mjs
@@ -1,0 +1,161 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import http from "node:http";
+import test from "node:test";
+import { setTimeout as delay } from "node:timers/promises";
+import { fileURLToPath } from "node:url";
+
+import { MeerkatRuntime } from "@rkat/web";
+import * as rawWasm from "@rkat/web/wasm/meerkat_web_runtime.js";
+
+async function makeNodeCompatibleWasmModule() {
+  const wasmUrl = import.meta.resolve("@rkat/web/wasm/meerkat_web_runtime_bg.wasm");
+  const wasmBytes = await readFile(fileURLToPath(wasmUrl));
+  return {
+    ...rawWasm,
+    default: async () => rawWasm.default({ module_or_path: wasmBytes }),
+  };
+}
+
+async function withAnthropicStreamServer(chunkCount, fn) {
+  const sseBody = Array.from(
+    { length: chunkCount },
+    (_, index) =>
+      `data: ${JSON.stringify({ type: "content_block_delta", delta: { type: "text_delta", text: String(index % 10) } })}\n\n`,
+  ).join("") + `data: ${JSON.stringify({ type: "message_stop" })}\n\n`;
+
+  const server = http.createServer((req, res) => {
+    if (req.method === "POST" && req.url === "/v1/messages") {
+      res.writeHead(200, { "content-type": "text/event-stream" });
+      res.end(sseBody);
+      return;
+    }
+    res.writeHead(404);
+    res.end("not found");
+  });
+
+  await new Promise((resolve) => server.listen(0, "127.0.0.1", resolve));
+  const { port } = server.address();
+  try {
+    return await fn(`http://127.0.0.1:${port}`);
+  } finally {
+    await new Promise((resolve, reject) =>
+      server.close((error) => (error ? reject(error) : resolve())),
+    );
+  }
+}
+
+test("MeerkatRuntime drives direct-session lifecycle through shipped wasm exports", async () => {
+  const wasm = await makeNodeCompatibleWasmModule();
+  const runtime = await MeerkatRuntime.init(wasm, {
+    anthropicApiKey: "sk-test",
+    model: "claude-sonnet-4-5",
+  });
+
+  const session = runtime.createSession({
+    model: "claude-sonnet-4-5",
+    apiKey: "sk-test",
+  });
+  const staged = session.appendSystemContext({
+    text: "Remember the browser-side coordinator.",
+    source: "web",
+    idempotencyKey: "ctx-web-1",
+  });
+
+  assert.equal(staged.status, "staged");
+  assert.equal(staged.handle, session.handle);
+
+  const state = session.getState();
+  assert.equal(state.session_id, session.handle);
+  assert.equal(state.model, "claude-sonnet-4-5");
+
+  session.destroy();
+  assert.equal(session.isDestroyed, true);
+  assert.throws(() => session.getState(), /destroyed/i);
+});
+
+test("MeerkatRuntime opens and closes a public mob subscription through the shipped package surface", async () => {
+  let subscribedHandle;
+  const wasm = {
+    ...(await makeNodeCompatibleWasmModule()),
+    async mob_subscribe_events(mobId) {
+      const handle = await rawWasm.mob_subscribe_events(mobId);
+      subscribedHandle = handle;
+      return handle;
+    },
+  };
+  const runtime = await MeerkatRuntime.init(wasm, {
+    anthropicApiKey: "sk-test",
+    model: "claude-sonnet-4-5",
+  });
+
+  const mob = await runtime.createMob({
+    id: "mob-web-phase-0",
+    profiles: {
+      worker: {
+        model: "claude-sonnet-4-5",
+        tools: { comms: true },
+      },
+    },
+  });
+
+  const subscription = await mob.subscribeAll();
+  assert.deepEqual(subscription.poll(), []);
+  subscription.close();
+  assert.equal(subscription.isClosed, true);
+  assert.notEqual(subscribedHandle, undefined);
+  assert.throws(
+    () => rawWasm.poll_subscription(subscribedHandle),
+    /unknown subscription handle/i,
+  );
+});
+
+test("MeerkatRuntime surfaces lagged subscription signals through the shipped package surface", async () => {
+  await withAnthropicStreamServer(305, async (anthropicBaseUrl) => {
+    const wasm = await makeNodeCompatibleWasmModule();
+    const runtime = await MeerkatRuntime.init(wasm, {
+      anthropicApiKey: "sk-test",
+      anthropicBaseUrl,
+      model: "claude-sonnet-4-5",
+    });
+
+    const mob = await runtime.createMob({
+      id: "mob-web-phase-4",
+      profiles: {
+        worker: {
+          model: "claude-sonnet-4-5",
+          external_addressable: true,
+          tools: { comms: true },
+        },
+      },
+    });
+
+    const spawned = await mob.spawn([
+      {
+        profile: "worker",
+        meerkat_id: "worker-1",
+        runtime_mode: "turn_driven",
+      },
+    ]);
+    assert.equal(spawned[0].status, "ok");
+
+    const subscription = await mob.subscribe("worker-1");
+    await mob.sendMessage("worker-1", "Trigger a long streamed response.");
+
+    let items = [];
+    for (let attempt = 0; attempt < 20; attempt += 1) {
+      await delay(25);
+      items = subscription.poll();
+      if (items.some((item) => item.type === "lagged")) {
+        break;
+      }
+    }
+
+    const lagged = items.find((item) => item.type === "lagged");
+    assert.ok(lagged, "expected a lagged signal from the shipped subscription path");
+    assert.ok(lagged.skipped >= 1);
+    const survivingEvent = items.find((item) => item.payload?.type === "text_delta");
+    assert.ok(survivingEvent, "expected a surviving text_delta event after lag");
+    subscription.close();
+  });
+});


### PR DESCRIPTION
## Summary
- implement the lifecycle correctness 0.4.7 RCT run across session authority routing, mob-backed retirement, staged context, archived-session semantics, and stream lifecycle behavior
- add proof-surface coverage for RPC, Python, TypeScript, and web/WASM, including packaged fake-RPC stream E2Es and real lag/terminal outcome checks
- commit the full `.rct` artifact set for phases, evidence, requirements, traceability, and final gate closure

## Verification
- cargo fmt --check --all
- cargo clippy --workspace --all-targets -- -D warnings
- cargo build --workspace
- CARGO_TARGET_DIR=target-codex cargo test -p meerkat-rpc --features mob,comms -- --nocapture
- CARGO_TARGET_DIR=target-codex cargo test -p meerkat-session --test ephemeral_contract -- --nocapture
- CARGO_TARGET_DIR=target-codex cargo test -p meerkat-mob test_retiring_member_is_not_routable_before_disposal_completes -- --nocapture
- CARGO_TARGET_DIR=target-codex cargo test -p meerkat-web-runtime -- --nocapture
- pytest -q sdks/python/tests/test_e2e.py::test_python_sdk_live_mob_stream_explicit_close sdks/python/tests/test_stream_e2e_fake_rpc.py
- pytest -q sdks/python/tests/test_streaming.py -k 'stream_notification_buffered_until_stream_queue_registered or stream_notifications_buffered_until_stream_queue_registered_preserve_order or stream_end_buffered_until_stream_queue_registered'
- npm --prefix sdks/typescript test
- npm --prefix sdks/typescript run test:e2e
- npm --prefix sdks/web run test:e2e
