### PR TITLE
Type AcceptOutcome::Rejected reason as RejectReason enum

### DIFF
--- a/meerkat-rest/src/lib.rs
+++ b/meerkat-rest/src/lib.rs
@@ -1190,7 +1190,9 @@ async fn runtime_accept(
         Ok(outcome) => outcome,
         Err(meerkat_runtime::RuntimeDriverError::NotReady { state }) => {
             meerkat_runtime::AcceptOutcome::Rejected {
-                reason: format!("runtime not accepting input while in state: {state}"),
+                reason: meerkat_runtime::RejectReason::NotReady {
+                    state: format!("{state}"),
+                },
             }
         }
         Err(e) => {
@@ -1917,9 +1919,11 @@ async fn post_external_event(
             meerkat_runtime::AcceptOutcome::Accepted { .. }
             | meerkat_runtime::AcceptOutcome::Deduplicated { .. },
         ) => Ok((StatusCode::ACCEPTED, Json(json!({"queued": true})))),
-        Ok(meerkat_runtime::AcceptOutcome::Rejected { reason }) => {
-            Err((StatusCode::CONFLICT, Json(json!({"error": reason}))).into_response())
-        }
+        Ok(meerkat_runtime::AcceptOutcome::Rejected { reason }) => Err((
+            StatusCode::CONFLICT,
+            Json(json!({"error": reason.to_string()})),
+        )
+            .into_response()),
         Ok(outcome) => Err((
             StatusCode::INTERNAL_SERVER_ERROR,
             Json(json!({

--- a/meerkat-rpc/src/handlers/runtime.rs
+++ b/meerkat-rpc/src/handlers/runtime.rs
@@ -128,7 +128,7 @@ fn to_wire_accept_result(
             outcome_type: RuntimeAcceptOutcomeType::Rejected,
             input_id: None,
             existing_id: None,
-            reason: Some(reason),
+            reason: Some(reason.to_string()),
             policy: None,
             state: None,
         },
@@ -197,7 +197,9 @@ pub async fn handle_runtime_accept(
         },
         Err(meerkat_runtime::RuntimeDriverError::NotReady { state }) => {
             match to_wire_accept_result(meerkat_runtime::AcceptOutcome::Rejected {
-                reason: format!("runtime not accepting input while in state: {state}"),
+                reason: meerkat_runtime::RejectReason::NotReady {
+                    state: format!("{state}"),
+                },
             }) {
                 Ok(result) => RpcResponse::success(id, result),
                 Err(err) => RpcResponse::error(id, crate::error::INTERNAL_ERROR, err),

--- a/meerkat-runtime/src/accept.rs
+++ b/meerkat-runtime/src/accept.rs
@@ -2,9 +2,44 @@
 
 use meerkat_core::lifecycle::InputId;
 use serde::{Deserialize, Serialize};
+use std::fmt;
 
 use crate::input_state::InputState;
 use crate::policy::PolicyDecision;
+
+/// Typed reason why an input was rejected at the accept boundary.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(tag = "reject_type", rename_all = "snake_case")]
+#[non_exhaustive]
+pub enum RejectReason {
+    /// Runtime is not in a state that accepts input (e.g. stopped, destroyed).
+    NotReady {
+        /// The runtime state that caused the rejection.
+        state: String,
+    },
+    /// Input failed durability validation.
+    DurabilityViolation {
+        /// Description of the violation.
+        detail: String,
+    },
+    /// Peer input carried a forbidden handling_mode.
+    PeerHandlingModeInvalid {
+        /// Description of the violation.
+        detail: String,
+    },
+}
+
+impl fmt::Display for RejectReason {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::NotReady { state } => {
+                write!(f, "runtime not accepting input while in state: {state}")
+            }
+            Self::DurabilityViolation { detail } => write!(f, "{detail}"),
+            Self::PeerHandlingModeInvalid { detail } => write!(f, "{detail}"),
+        }
+    }
+}
 
 /// Outcome of `RuntimeDriver::accept_input()`.
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -31,7 +66,7 @@ pub enum AcceptOutcome {
     /// Input was rejected (validation failed, durability violation, etc.).
     Rejected {
         /// Why the input was rejected.
-        reason: String,
+        reason: RejectReason,
     },
 }
 
@@ -103,11 +138,61 @@ mod tests {
     #[test]
     fn rejected_serde() {
         let outcome = AcceptOutcome::Rejected {
-            reason: "durability violation".into(),
+            reason: RejectReason::DurabilityViolation {
+                detail: "durability violation".into(),
+            },
         };
         let json = serde_json::to_value(&outcome).unwrap();
         assert_eq!(json["outcome_type"], "rejected");
+        assert_eq!(json["reason"]["reject_type"], "durability_violation");
         let parsed: AcceptOutcome = serde_json::from_value(json).unwrap();
         assert!(parsed.is_rejected());
+    }
+
+    #[test]
+    fn reject_reason_display() {
+        let not_ready = RejectReason::NotReady {
+            state: "Stopped".into(),
+        };
+        assert_eq!(
+            not_ready.to_string(),
+            "runtime not accepting input while in state: Stopped"
+        );
+
+        let durability = RejectReason::DurabilityViolation {
+            detail: "Derived durability forbidden for prompt".into(),
+        };
+        assert_eq!(
+            durability.to_string(),
+            "Derived durability forbidden for prompt"
+        );
+
+        let peer = RejectReason::PeerHandlingModeInvalid {
+            detail: "handling_mode is forbidden on ResponseProgress peer inputs".into(),
+        };
+        assert_eq!(
+            peer.to_string(),
+            "handling_mode is forbidden on ResponseProgress peer inputs"
+        );
+    }
+
+    #[test]
+    fn reject_reason_serde_round_trip() {
+        let reasons = vec![
+            RejectReason::NotReady {
+                state: "Destroyed".into(),
+            },
+            RejectReason::DurabilityViolation {
+                detail: "external derived".into(),
+            },
+            RejectReason::PeerHandlingModeInvalid {
+                detail: "forbidden".into(),
+            },
+        ];
+        for reason in reasons {
+            let json = serde_json::to_value(&reason).unwrap();
+            let parsed: RejectReason = serde_json::from_value(json).unwrap();
+            assert_eq!(parsed, reason);
+        }
     }
 }

--- a/meerkat-runtime/src/driver/ephemeral.rs
+++ b/meerkat-runtime/src/driver/ephemeral.rs
@@ -972,14 +972,18 @@ impl crate::traits::RuntimeDriver for EphemeralRuntimeDriver {
                 DurabilityError::DerivedForbidden { .. }
                 | DurabilityError::ExternalDerivedForbidden => {
                     return Ok(AcceptOutcome::Rejected {
-                        reason: e.to_string(),
+                        reason: crate::accept::RejectReason::DurabilityViolation {
+                            detail: e.to_string(),
+                        },
                     });
                 }
             }
         }
         if let Err(e) = crate::peer_handling_mode::validate_peer_handling_mode(&input) {
             return Ok(AcceptOutcome::Rejected {
-                reason: e.to_string(),
+                reason: crate::accept::RejectReason::PeerHandlingModeInvalid {
+                    detail: e.to_string(),
+                },
             });
         }
         let input_id = input.id().clone();

--- a/meerkat-runtime/src/lib.rs
+++ b/meerkat-runtime/src/lib.rs
@@ -57,7 +57,7 @@ pub mod store;
 pub mod traits;
 
 // Re-exports for convenience
-pub use accept::AcceptOutcome;
+pub use accept::{AcceptOutcome, RejectReason};
 pub use coalescing::{
     AggregateDescriptor, CoalescingResult, SupersessionScope, apply_coalescing, apply_supersession,
     check_supersession, create_aggregate_input, is_coalescing_eligible,

--- a/meerkat-runtime/src/session_adapter.rs
+++ b/meerkat-runtime/src/session_adapter.rs
@@ -1001,7 +1001,9 @@ impl RuntimeSessionAdapter {
                     });
                 }
                 AcceptOutcome::Rejected { reason } => {
-                    return Err(RuntimeDriverError::ValidationFailed { reason });
+                    return Err(RuntimeDriverError::ValidationFailed {
+                        reason: reason.to_string(),
+                    });
                 }
             };
 
@@ -1170,7 +1172,7 @@ impl RuntimeSessionAdapter {
                 }
                 AcceptOutcome::Rejected { reason } => {
                     return Err(RuntimeDriverError::ValidationFailed {
-                        reason: reason.clone(),
+                        reason: reason.to_string(),
                     });
                 }
             }

--- a/meerkat/src/surface/schedule_host.rs
+++ b/meerkat/src/surface/schedule_host.rs
@@ -389,7 +389,7 @@ pub fn accepted_scheduled_input_from_runtime_outcome(
         AcceptOutcome::Rejected { reason } => AcceptedScheduledInput {
             correlation_id: "rejected".to_string(),
             handle: Some(CompletionHandle::already_resolved(
-                CompletionOutcome::Abandoned(reason),
+                CompletionOutcome::Abandoned(reason.to_string()),
             )),
         },
         _ => AcceptedScheduledInput {


### PR DESCRIPTION
## Summary

- Replace `AcceptOutcome::Rejected { reason: String }` with typed `RejectReason` enum (#181)
- Three variants: `NotReady`, `DurabilityViolation`, `PeerHandlingModeInvalid`
- Wire types (`RuntimeAcceptResult`) stay `String` via `Display` impl for backward compat
- 3 new tests (Display, serde round-trip, variant coverage)

## Test plan

- [x] `cargo check --workspace` clean
- [x] 345 matched tests pass (accept/reject/runtime_completion)
- [x] Pre-push hooks green (clippy, fmt, unit gate)

Closes #181

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>