### PR TITLE
fix: mob authority via typed tool effects (no re-entrant deadlock)

### DIFF
--- a/meerkat-core/src/agent.rs
+++ b/meerkat-core/src/agent.rs
@@ -762,6 +762,12 @@ where
     /// Optional enrichment provider for completion display details.
     pub(crate) completion_enrichment:
         Option<Arc<dyn crate::completion_feed::CompletionEnrichmentProvider>>,
+    /// Shared effective mob authority handle. Owned by the agent, passed to
+    /// mob tools at construction for authorization reads. Updated by
+    /// `apply_session_effects` after each tool batch as a derived projection
+    /// of the canonical `session.build_state().mob_tool_authority_context`.
+    pub(crate) mob_authority_handle:
+        Option<Arc<std::sync::RwLock<crate::service::MobToolAuthorityContext>>>,
     /// Machine authority for turn-execution state transitions (RMAT).
     pub(crate) turn_authority: crate::turn_execution_authority::TurnExecutionAuthority,
     /// Optional resolver for model-specific operational defaults (e.g., call timeout).

--- a/meerkat-core/src/agent/builder.rs
+++ b/meerkat-core/src/agent/builder.rs
@@ -273,6 +273,7 @@ impl AgentBuilder {
             epoch_cursor_state: self.epoch_cursor_state,
             interrupt_baseline: self.interrupt_baseline,
             completion_enrichment: self.completion_enrichment,
+            mob_authority_handle: None,
             turn_authority: crate::turn_execution_authority::TurnExecutionAuthority::new(),
             model_defaults_resolver: self.model_defaults_resolver,
             call_timeout_override: self.call_timeout_override,

--- a/meerkat-core/src/agent/runner.rs
+++ b/meerkat-core/src/agent/runner.rs
@@ -77,6 +77,76 @@ where
         Ok(())
     }
 
+    /// Apply accumulated session effects from tool dispatch.
+    ///
+    /// Called by the agent loop after each parallel tool batch completes,
+    /// BEFORE `Message::ToolResults` is appended to the session. This is
+    /// the canonical commit point for tool-produced session mutations
+    /// (e.g., mob authority grants).
+    ///
+    /// The session's `build_state` is the source of truth. The shared
+    /// `mob_authority_handle` (if present) is updated as a derived projection
+    /// after the canonical write succeeds.
+    pub(crate) fn apply_session_effects(
+        &mut self,
+        effects: &[crate::ops::SessionEffect],
+    ) -> Result<(), crate::error::AgentError> {
+        use crate::error::AgentError;
+
+        let mut build_state = self.session.build_state().unwrap_or_default();
+        let authority = build_state
+            .mob_tool_authority_context
+            .as_mut()
+            .ok_or_else(|| {
+                AgentError::InternalError(
+                    "mob authority effect applied without canonical authority context".into(),
+                )
+            })?;
+
+        for effect in effects {
+            match effect {
+                crate::ops::SessionEffect::GrantManageMob { mob_id } => {
+                    authority.grant_manage_mob_in_place(mob_id.clone());
+                }
+            }
+        }
+
+        self.session.set_build_state(build_state).map_err(|e| {
+            AgentError::InternalError(format!(
+                "failed to persist session effects into build state: {e}"
+            ))
+        })?;
+
+        // Update the shared effective-authority handle so mob tools in
+        // subsequent batches see the widened scope. The handle is a derived
+        // projection of the canonical session build_state — it is never
+        // treated as an independent truth source.
+        if let Some(ref handle) = self.mob_authority_handle {
+            let updated = self
+                .session
+                .build_state()
+                .and_then(|bs| bs.mob_tool_authority_context);
+            if let Some(authority) = updated {
+                *handle
+                    .write()
+                    .unwrap_or_else(std::sync::PoisonError::into_inner) = authority;
+            }
+        }
+
+        Ok(())
+    }
+
+    /// Set the shared mob authority handle for session-effect application.
+    ///
+    /// The agent updates this handle after merging `SessionEffect`s from tool
+    /// dispatch. Mob tools read from it for authorization checks.
+    pub fn set_mob_authority_handle(
+        &mut self,
+        handle: Arc<std::sync::RwLock<crate::service::MobToolAuthorityContext>>,
+    ) {
+        self.mob_authority_handle = Some(handle);
+    }
+
     /// Replace the LLM client for subsequent turns.
     ///
     /// Enables hot-swapping the model/provider on a live session without

--- a/meerkat-core/src/agent/state.rs
+++ b/meerkat-core/src/agent/state.rs
@@ -1038,10 +1038,13 @@ where
 
                         // Process results and emit events
                         let mut all_async_ops = Vec::<crate::ops::AsyncOpRef>::new();
+                        let mut accumulated_session_effects =
+                            Vec::<crate::ops::SessionEffect>::new();
                         for (tc, dispatch_result, duration_ms) in dispatch_results {
                             let mut tool_result = match dispatch_result {
                                 Ok(outcome) => {
                                     all_async_ops.extend(outcome.async_ops);
+                                    accumulated_session_effects.extend(outcome.session_effects);
                                     outcome.result
                                 }
                                 Err(crate::error::ToolError::CallbackPending {
@@ -1181,6 +1184,15 @@ where
                         let has_barrier_ops = pending_op_refs
                             .iter()
                             .any(|r| r.wait_policy == crate::ops::WaitPolicy::Barrier);
+
+                        // Apply session effects from tool dispatch before
+                        // appending ToolResults. This ensures the canonical
+                        // session state is updated before the next boundary,
+                        // so an invariant failure doesn't occur after
+                        // ToolResults is already in the transcript.
+                        if !accumulated_session_effects.is_empty() {
+                            self.apply_session_effects(&accumulated_session_effects)?;
+                        }
 
                         // Add tool results to session
                         self.session.push(Message::ToolResults {

--- a/meerkat-core/src/lib.rs
+++ b/meerkat-core/src/lib.rs
@@ -148,8 +148,8 @@ pub use mcp_config::{McpConfig, McpConfigError, McpScope, McpServerConfig, McpSe
 pub use model_defaults::ModelOperationalDefaultsResolver;
 pub use ops::{
     AsyncOpRef, ConcurrencyLimits, ContextStrategy, ForkBranch, ForkBudgetPolicy, OpEvent,
-    OperationId, OperationPolicy, OperationResult, OperationSpec, ResultShape, SpawnSpec,
-    ToolAccessPolicy, ToolDispatchOutcome, WaitPolicy, WorkKind,
+    OperationId, OperationPolicy, OperationResult, OperationSpec, ResultShape, SessionEffect,
+    SpawnSpec, ToolAccessPolicy, ToolDispatchOutcome, WaitPolicy, WorkKind,
 };
 pub use ops_lifecycle::{
     OperationCompletionWatch, OperationKind, OperationLifecycleSnapshot, OperationPeerHandle,

--- a/meerkat-core/src/ops.rs
+++ b/meerkat-core/src/ops.rs
@@ -71,6 +71,19 @@ impl AsyncOpRef {
 /// what the runtime scheduler sees (barrier/detached classification). This
 /// prevents hooks, persistence, and message serialization from accidentally
 /// owning barrier semantics.
+/// Typed session-level effect produced by tool dispatch.
+///
+/// Tools that need to mutate session-owned durable state (e.g., mob authority)
+/// must NOT call `SessionService` methods from inside dispatch. Instead they
+/// return typed effects here, and the turn owner (agent loop) merges and commits
+/// them after the parallel tool batch completes.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "effect_type", rename_all = "snake_case")]
+pub enum SessionEffect {
+    /// Grant management scope for a specific mob.
+    GrantManageMob { mob_id: String },
+}
+
 #[derive(Debug, Clone)]
 pub struct ToolDispatchOutcome {
     /// The tool result for the conversation transcript.
@@ -80,14 +93,21 @@ pub struct ToolDispatchOutcome {
     /// Empty for synchronous tools. Barrier ops block the turn boundary;
     /// detached ops run independently.
     pub async_ops: Vec<AsyncOpRef>,
+    /// Session-level effects to be merged by the turn owner after the batch.
+    ///
+    /// Most tools return an empty vec. Tools that need durable session state
+    /// changes (e.g., mob authority grants) emit typed effects here instead
+    /// of calling `SessionService` from inside dispatch.
+    pub session_effects: Vec<SessionEffect>,
 }
 
 impl ToolDispatchOutcome {
-    /// Create an outcome with no async operations (synchronous tool).
+    /// Create an outcome with no async operations or session effects (synchronous tool).
     pub fn sync_result(result: crate::types::ToolResult) -> Self {
         Self {
             result,
             async_ops: Vec::new(),
+            session_effects: Vec::new(),
         }
     }
 }
@@ -466,5 +486,35 @@ mod tests {
         assert_eq!(limits.max_concurrent_ops, 32);
         assert_eq!(limits.max_concurrent_agents, 8);
         assert_eq!(limits.max_children_per_agent, 5);
+    }
+
+    #[test]
+    fn session_effect_grant_manage_mob_serde_round_trip() {
+        let effect = SessionEffect::GrantManageMob {
+            mob_id: "test-mob".into(),
+        };
+        let json = serde_json::to_value(&effect).unwrap();
+        let parsed: SessionEffect = serde_json::from_value(json).unwrap();
+        assert_eq!(effect, parsed);
+    }
+
+    #[test]
+    fn tool_dispatch_outcome_with_session_effects() {
+        let result = crate::types::ToolResult::new("t1".into(), "ok".into(), false);
+        let outcome = ToolDispatchOutcome {
+            result,
+            async_ops: vec![],
+            session_effects: vec![SessionEffect::GrantManageMob {
+                mob_id: "mob-1".into(),
+            }],
+        };
+        assert_eq!(outcome.session_effects.len(), 1);
+    }
+
+    #[test]
+    fn tool_dispatch_outcome_sync_result_has_empty_effects() {
+        let result = crate::types::ToolResult::new("t1".into(), "ok".into(), false);
+        let outcome = ToolDispatchOutcome::sync_result(result);
+        assert!(outcome.session_effects.is_empty());
     }
 }

--- a/meerkat-core/src/service/mod.rs
+++ b/meerkat-core/src/service/mod.rs
@@ -407,6 +407,14 @@ impl MobToolAuthorityContext {
         self
     }
 
+    /// Grant management scope for a mob in-place (mutable borrow).
+    ///
+    /// Used by the turn executor when applying `SessionEffect::GrantManageMob`
+    /// effects from tool dispatch.
+    pub fn grant_manage_mob_in_place(&mut self, mob_id: String) {
+        self.managed_mob_scope.insert(mob_id);
+    }
+
     pub fn with_managed_mob_scope<I, S>(mut self, mob_ids: I) -> Self
     where
         I: IntoIterator<Item = S>,
@@ -475,6 +483,13 @@ pub struct MobToolsBuildArgs {
     /// dispatch must still re-check the typed create/scope fields on every
     /// call.
     pub authority_context: Option<MobToolAuthorityContext>,
+    /// Shared effective mob authority handle owned by the agent.
+    ///
+    /// Mob tools read from this handle for authorization checks. The agent
+    /// (turn owner) is the sole writer — it updates this handle via
+    /// `apply_session_effects` after merging tool-produced `SessionEffect`s.
+    /// If `None`, mob tools fall back to `authority_context` as a static snapshot.
+    pub effective_authority: Option<Arc<std::sync::RwLock<MobToolAuthorityContext>>>,
     /// Comms name of the owning agent (for building TrustedPeerSpec).
     pub comms_name: Option<String>,
     /// Optional comms runtime for auto-wiring spawned members.
@@ -1119,5 +1134,30 @@ mod tests {
             .await
             .expect_err("default implementation should fail loudly");
         assert!(matches!(err, SessionError::Unsupported(name) if name == "has_live_session"));
+    }
+
+    #[test]
+    fn grant_manage_mob_in_place_adds_mob_id() {
+        let mut ctx = MobToolAuthorityContext::create_only_generated();
+        ctx.grant_manage_mob_in_place("mob-1".into());
+        assert!(ctx.managed_mob_scope.contains("mob-1"));
+    }
+
+    #[test]
+    fn grant_manage_mob_in_place_is_idempotent() {
+        let mut ctx = MobToolAuthorityContext::create_only_generated();
+        ctx.grant_manage_mob_in_place("mob-1".into());
+        ctx.grant_manage_mob_in_place("mob-1".into());
+        assert_eq!(ctx.managed_mob_scope.len(), 1);
+    }
+
+    #[test]
+    fn grant_manage_mob_in_place_accumulates() {
+        let mut ctx = MobToolAuthorityContext::create_only_generated();
+        ctx.grant_manage_mob_in_place("mob-1".into());
+        ctx.grant_manage_mob_in_place("mob-2".into());
+        assert!(ctx.managed_mob_scope.contains("mob-1"));
+        assert!(ctx.managed_mob_scope.contains("mob-2"));
+        assert_eq!(ctx.managed_mob_scope.len(), 2);
     }
 }

--- a/meerkat-mob-mcp/src/agent_tools.rs
+++ b/meerkat-mob-mcp/src/agent_tools.rs
@@ -50,9 +50,11 @@ pub struct AgentMobToolSurface {
     /// Pre-seeded on resume; otherwise set by first delegate via get_or_create_implicit_mob.
     /// Read-only cache — MobMcpState is the canonical owner.
     cached_implicit_mob_id: RwLock<Option<MobId>>,
-    /// Typed runtime-injected operator authority. This is the only source of
-    /// authorization for agent-facing mob tools.
-    authority_context: RwLock<MobToolAuthorityContext>,
+    /// Effective mob authority — shared handle owned by the agent/turn executor.
+    /// Mob tools read from this for authorization. The agent is the sole writer
+    /// (via apply_session_effects). Falls back to a local RwLock when no shared
+    /// handle is provided (non-runtime test paths).
+    effective_authority: Arc<std::sync::RwLock<MobToolAuthorityContext>>,
     tools: Arc<[Arc<ToolDef>]>,
     owner_session_id: SessionId,
     /// Model name inherited by implicit mob helpers.
@@ -84,10 +86,10 @@ impl AgentMobToolSurface {
         comms_peer_id: Option<String>,
         comms_runtime: Option<Arc<dyn meerkat_core::agent::CommsRuntime>>,
     ) -> Self {
-        Self::new_with_authority(
+        Self::new_with_effective_authority(
             state,
             implicit_mob_id,
-            authority_context,
+            Arc::new(std::sync::RwLock::new(authority_context)),
             model,
             owner_session_id,
             comms_name,
@@ -96,12 +98,15 @@ impl AgentMobToolSurface {
         )
     }
 
-    /// Create with a pre-populated set of owned mob IDs (for resume).
+    /// Create with a shared effective authority handle.
+    ///
+    /// The handle is owned by the agent and updated via `apply_session_effects`.
+    /// Mob tools read from it for authorization checks.
     #[allow(clippy::too_many_arguments)]
-    pub fn new_with_authority(
+    pub fn new_with_effective_authority(
         state: Arc<MobMcpState>,
         implicit_mob_id: Option<MobId>,
-        authority_context: MobToolAuthorityContext,
+        effective_authority: Arc<std::sync::RwLock<MobToolAuthorityContext>>,
         model: String,
         owner_session_id: SessionId,
         comms_name: Option<String>,
@@ -112,7 +117,7 @@ impl AgentMobToolSurface {
         Self {
             state,
             cached_implicit_mob_id: RwLock::new(implicit_mob_id),
-            authority_context: RwLock::new(authority_context),
+            effective_authority,
             tools,
             owner_session_id,
             model,
@@ -141,23 +146,36 @@ impl AgentMobToolSurface {
         call: ToolCallView<'_>,
         value: serde_json::Value,
     ) -> Result<meerkat_core::ToolDispatchOutcome, ToolError> {
+        Self::encode_result_with_effects(call, value, vec![])
+    }
+
+    fn encode_result_with_effects(
+        call: ToolCallView<'_>,
+        value: serde_json::Value,
+        session_effects: Vec<meerkat_core::SessionEffect>,
+    ) -> Result<meerkat_core::ToolDispatchOutcome, ToolError> {
         let content = serde_json::to_string(&value)
             .map_err(|e| ToolError::execution_failed(format!("encode tool result: {e}")))?;
-        Ok(meerkat_core::ToolDispatchOutcome::sync_result(
-            ToolResult::new(call.id.to_string(), content, false),
-        ))
+        Ok(meerkat_core::ToolDispatchOutcome {
+            result: ToolResult::new(call.id.to_string(), content, false),
+            async_ops: vec![],
+            session_effects,
+        })
     }
 
     fn map_mob_error(call: ToolCallView<'_>, error: MobError) -> ToolError {
         ToolError::execution_failed(format!("tool '{}' failed: {error}", call.name))
     }
 
-    async fn authority_context_snapshot(&self) -> MobToolAuthorityContext {
-        self.authority_context.read().await.clone()
+    fn authority_context_snapshot(&self) -> MobToolAuthorityContext {
+        self.effective_authority
+            .read()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .clone()
     }
 
     async fn ensure_create_authority(&self, tool_name: &str) -> Result<(), ToolError> {
-        if self.authority_context.read().await.can_create_mobs() {
+        if self.authority_context_snapshot().can_create_mobs() {
             return Ok(());
         }
         Err(ToolError::access_denied(tool_name))
@@ -169,9 +187,7 @@ impl AgentMobToolSurface {
         mob_id: &MobId,
     ) -> Result<(), ToolError> {
         if self
-            .authority_context
-            .read()
-            .await
+            .authority_context_snapshot()
             .can_manage_mob(mob_id.as_str())
         {
             return Ok(());
@@ -184,7 +200,7 @@ impl AgentMobToolSurface {
         handle: &meerkat_mob::MobHandle,
         tool_name: &str,
     ) {
-        let authority_context = self.authority_context_snapshot().await;
+        let authority_context = self.authority_context_snapshot();
         if let Err(error) = handle
             .record_operator_action_provenance(tool_name, &authority_context)
             .await
@@ -198,43 +214,10 @@ impl AgentMobToolSurface {
         }
     }
 
-    async fn grant_exact_mob_scope_after_create(
-        &self,
-        tool_name: &str,
-        mob_id: &MobId,
-    ) -> Result<(), ToolError> {
-        let authority_context = self
-            .authority_context_snapshot()
-            .await
-            .grant_manage_mob(mob_id.to_string());
-
-        match self
-            .state
-            .session_service()
-            .update_session_mob_authority_context(
-                &self.owner_session_id,
-                Some(authority_context.clone()),
-            )
-            .await
-        {
-            Ok(()) => {}
-            Err(SessionError::Unsupported(_)) => {
-                tracing::debug!(
-                    session_id = %self.owner_session_id,
-                    mob_id = %mob_id,
-                    "session service does not persist mob authority updates; keeping in-memory scope only"
-                );
-            }
-            Err(error) => {
-                return Err(ToolError::execution_failed(format!(
-                    "tool '{tool_name}' failed: unable to persist exact mob scope for {mob_id}: {error}"
-                )));
-            }
-        }
-
-        *self.authority_context.write().await = authority_context;
-        Ok(())
-    }
+    // grant_exact_mob_scope_after_create removed — mob authority grants are
+    // now returned as typed SessionEffect::GrantManageMob effects. The turn
+    // owner (agent loop) merges and commits them to session build_state.
+    // No re-entrant session service call from inside tool dispatch.
 
     /// Get or create the implicit mob for this agent's session.
     ///
@@ -270,19 +253,20 @@ impl AgentMobToolSurface {
             .ensure_implicit_mob()
             .await
             .map_err(|e| Self::map_mob_error(call, e))?;
-        if first_delegate
-            && let Err(error) = self
-                .grant_exact_mob_scope_after_create(call.name, &mob_id)
-                .await
+
+        // Authority grant is returned as a typed effect for the turn owner
+        // to merge and commit — no re-entrant session service call.
+        // Emit the grant whenever the mob isn't already in scope, not just
+        // on first_delegate — a prior failed delegate may have created the
+        // implicit mob without the grant effect being applied.
+        let mut session_effects = Vec::new();
+        if !self
+            .authority_context_snapshot()
+            .can_manage_mob(mob_id.as_str())
         {
-            if let Err(cleanup_error) = self.state.mob_destroy(&mob_id).await {
-                tracing::warn!(
-                    mob_id = %mob_id,
-                    error = %cleanup_error,
-                    "failed to roll back implicit mob after authority persistence error"
-                );
-            }
-            return Err(error);
+            session_effects.push(meerkat_core::SessionEffect::GrantManageMob {
+                mob_id: mob_id.to_string(),
+            });
         }
 
         // Build spawn spec
@@ -389,7 +373,7 @@ impl AgentMobToolSurface {
                 .await;
         }
 
-        Self::encode_result(call, result)
+        Self::encode_result_with_effects(call, result, session_effects)
     }
 
     async fn dispatch_mob_create(
@@ -415,26 +399,17 @@ impl AgentMobToolSurface {
             .await
             .map_err(|e| Self::map_mob_error(call, e))?;
 
-        if let Err(error) = self
-            .grant_exact_mob_scope_after_create(call.name, &mob_id)
-            .await
-        {
-            if let Err(cleanup_error) = self.state.mob_destroy(&mob_id).await {
-                tracing::warn!(
-                    mob_id = %mob_id,
-                    error = %cleanup_error,
-                    "failed to roll back explicit mob after authority persistence error"
-                );
-            }
-            return Err(error);
-        }
+        // Authority grant as typed effect — no re-entrant session service call.
+        let session_effects = vec![meerkat_core::SessionEffect::GrantManageMob {
+            mob_id: mob_id.to_string(),
+        }];
 
         if let Ok(handle) = self.state.handle_for(&mob_id).await {
             self.record_successful_operator_action(&handle, call.name)
                 .await;
         }
 
-        Self::encode_result(call, json!({"mob_id": mob_id}))
+        Self::encode_result_with_effects(call, json!({"mob_id": mob_id}), session_effects)
     }
 
     async fn dispatch_mob_destroy(
@@ -578,7 +553,7 @@ impl AgentMobToolSurface {
         &self,
         call: ToolCallView<'_>,
     ) -> Result<meerkat_core::ToolDispatchOutcome, ToolError> {
-        let authority_context = self.authority_context_snapshot().await;
+        let authority_context = self.authority_context_snapshot();
         let mobs = self.state.mob_list().await;
         let mob_list: Vec<serde_json::Value> = mobs
             .into_iter()
@@ -629,10 +604,17 @@ impl meerkat_core::service::MobToolsFactory for AgentMobToolSurfaceFactory {
 
         // Extract parent comms identity for wiring helpers.
         let comms_peer_id = args.comms_runtime.as_ref().and_then(|r| r.public_key());
-        let surface = AgentMobToolSurface::new_with_authority(
+        // Use the shared effective-authority handle if provided (runtime-backed
+        // sessions). The agent/turn owner updates this handle via
+        // apply_session_effects; mob tools read from it for authorization.
+        // Falls back to a local handle for non-runtime paths.
+        let effective_authority_handle = args
+            .effective_authority
+            .unwrap_or_else(|| Arc::new(std::sync::RwLock::new(authority_context)));
+        let surface = AgentMobToolSurface::new_with_effective_authority(
             Arc::clone(&self.state),
             implicit_mob_id,
-            authority_context,
+            effective_authority_handle,
             args.model,
             args.session_id,
             args.comms_name,
@@ -1048,6 +1030,7 @@ mod tests {
                 session_id: SessionId::new(),
                 model: "claude-sonnet-4-5".to_string(),
                 authority_context: None,
+                effective_authority: None,
                 comms_name: None,
                 comms_runtime: None,
             })
@@ -1077,6 +1060,7 @@ mod tests {
                 session_id,
                 model: "claude-sonnet-4-5".to_string(),
                 authority_context: Some(create_only_authority()),
+                effective_authority: None,
                 comms_name: None,
                 comms_runtime: None,
             })
@@ -1130,6 +1114,7 @@ mod tests {
                 session_id,
                 model: "gpt-5.4".to_string(),
                 authority_context: Some(create_only_authority()),
+                effective_authority: None,
                 comms_name: None,
                 comms_runtime: None,
             })
@@ -1294,38 +1279,20 @@ mod tests {
             "mob_create must not allow callers to mint faux implicit mobs"
         );
 
-        let list_args = serde_json::value::RawValue::from_string("{}".to_string()).unwrap();
-        let list_result = surface
-            .dispatch(ToolCallView {
-                id: "list-1",
-                name: "mob_list",
-                args: &list_args,
-            })
-            .await
-            .expect("mob_list should still be callable");
-        let listed: serde_json::Value =
-            serde_json::from_str(&list_result.result.text_content()).unwrap();
+        // mob_create should return a GrantManageMob effect for the turn owner
+        // to merge into canonical session authority.
         assert_eq!(
-            listed["mobs"].as_array().map(Vec::len),
-            Some(1),
-            "mob_create should grant exact scope for the new explicit mob"
+            create_result.session_effects.len(),
+            1,
+            "mob_create should emit exactly one session effect"
         );
-        assert_eq!(listed["mobs"][0]["mob_id"], json!(mob_id));
-
-        let destroy_args =
-            serde_json::value::RawValue::from_string(json!({ "mob_id": mob_id }).to_string())
-                .unwrap();
-        let destroy_result = surface
-            .dispatch(ToolCallView {
-                id: "destroy-1",
-                name: "mob_destroy",
-                args: &destroy_args,
-            })
-            .await
-            .expect("newly-created explicit mob should be immediately manageable");
-        let destroyed: serde_json::Value =
-            serde_json::from_str(&destroy_result.result.text_content()).unwrap();
-        assert_eq!(destroyed, json!({ "ok": true }));
+        assert_eq!(
+            create_result.session_effects[0],
+            meerkat_core::SessionEffect::GrantManageMob {
+                mob_id: mob_id.clone()
+            },
+            "mob_create effect should carry the created mob_id"
+        );
     }
 
     #[tokio::test]
@@ -1359,44 +1326,16 @@ mod tests {
             matches!(delegate_error, ToolError::ExecutionFailed { .. }),
             "unexpected delegate error: {delegate_error:?}"
         );
-        let mob_id = state
+        // The implicit mob should still be created even though spawn failed.
+        let _mob_id = state
             .find_implicit_mob(&session_key)
             .await
-            .expect("delegate should still create an implicit mob")
-            .to_string();
+            .expect("delegate should still create an implicit mob");
 
-        let list_args = serde_json::value::RawValue::from_string("{}".to_string()).unwrap();
-        let list_result = surface
-            .dispatch(ToolCallView {
-                id: "list-1",
-                name: "mob_list",
-                args: &list_args,
-            })
-            .await
-            .expect("delegate-created implicit mob should become manageable");
-        let listed: serde_json::Value =
-            serde_json::from_str(&list_result.result.text_content()).unwrap();
-        assert_eq!(
-            listed["mobs"].as_array().map(Vec::len),
-            Some(1),
-            "delegate should grant exact scope for the new implicit mob"
-        );
-        assert_eq!(listed["mobs"][0]["mob_id"], json!(mob_id));
-
-        let list_members_args =
-            serde_json::value::RawValue::from_string(json!({ "mob_id": mob_id }).to_string())
-                .unwrap();
-        let list_members_result = surface
-            .dispatch(ToolCallView {
-                id: "members-1",
-                name: "mob_list_members",
-                args: &list_members_args,
-            })
-            .await
-            .expect("delegate-created implicit mob should allow follow-up scoped tools");
-        let members: serde_json::Value =
-            serde_json::from_str(&list_members_result.result.text_content()).unwrap();
-        assert_eq!(members["members"].as_array().map(Vec::len), Some(0));
+        // No session effect is returned when delegate errors — the effect
+        // is part of the ToolDispatchOutcome which is only produced on success.
+        // This is correct: the turn owner should not widen authority for a
+        // failed tool call.
     }
 
     #[tokio::test]

--- a/meerkat-mob/src/runtime/tools.rs
+++ b/meerkat-mob/src/runtime/tools.rs
@@ -433,6 +433,7 @@ impl MobOperatorToolDispatcher {
         Ok(meerkat_core::ToolDispatchOutcome {
             result: ToolResult::new(call.id.to_string(), content, false),
             async_ops,
+            session_effects: vec![],
         })
     }
 

--- a/meerkat-tools/src/builtin/composite.rs
+++ b/meerkat-tools/src/builtin/composite.rs
@@ -391,7 +391,11 @@ impl AgentToolDispatcher for CompositeDispatcher {
                         ToolResult::with_blocks(call.id.to_string(), blocks, false)
                     }
                 };
-                return Ok(ToolDispatchOutcome { result, async_ops });
+                return Ok(ToolDispatchOutcome {
+                    result,
+                    async_ops,
+                    session_effects: vec![],
+                });
             }
         }
 
@@ -425,7 +429,11 @@ impl AgentToolDispatcher for CompositeDispatcher {
                             ToolResult::with_blocks(call.id.to_string(), blocks, false)
                         }
                     };
-                    return Ok(ToolDispatchOutcome { result, async_ops });
+                    return Ok(ToolDispatchOutcome {
+                        result,
+                        async_ops,
+                        session_effects: vec![],
+                    });
                 }
             }
         }

--- a/meerkat/src/factory.rs
+++ b/meerkat/src/factory.rs
@@ -1600,6 +1600,11 @@ impl AgentFactory {
             .mob_tools
             .take()
             .or_else(|| self.mob_tools.clone());
+        // Shared mob authority handle — created inside the mob block, hoisted
+        // out so the agent builder can reference it after the block.
+        let mut hoisted_mob_authority_handle: Option<
+            Arc<std::sync::RwLock<meerkat_core::service::MobToolAuthorityContext>>,
+        > = None;
         if effective_mob && let Some(mob_factory) = mob_factory {
             // Build comms runtime arg: clone from the comms phase if available.
             #[cfg(feature = "comms")]
@@ -1609,10 +1614,19 @@ impl AgentFactory {
             #[cfg(not(feature = "comms"))]
             let mob_comms: Option<Arc<dyn meerkat_core::agent::CommsRuntime>> = None;
 
+            // Create the shared effective-authority handle. The agent owns the
+            // write side (via apply_session_effects); mob tools get a read view.
+            let mob_authority_handle = build_config
+                .mob_tool_authority_context
+                .as_ref()
+                .map(|ctx| Arc::new(std::sync::RwLock::new(ctx.clone())));
+            hoisted_mob_authority_handle = mob_authority_handle.clone();
+
             let mob_args = meerkat_core::service::MobToolsBuildArgs {
                 session_id: session.id().clone(),
                 model: model.clone(),
                 authority_context: build_config.mob_tool_authority_context.clone(),
+                effective_authority: mob_authority_handle.clone(),
                 comms_name: build_config.comms_name.clone(),
                 comms_runtime: mob_comms,
             };
@@ -2110,6 +2124,11 @@ impl AgentFactory {
 
         // 13. Build agent
         let mut agent = builder.build(llm_adapter, tools, store_adapter).await;
+
+        // Wire mob authority handle into agent for session-effect application.
+        if let Some(handle) = hoisted_mob_authority_handle {
+            agent.set_mob_authority_handle(handle);
+        }
 
         // 13b. Stage initial external filter to hide view_image when the model
         // cannot process image blocks in tool results. For resumed sessions,

--- a/tests/integration/tests/e2e_agent_mob_tools.rs
+++ b/tests/integration/tests/e2e_agent_mob_tools.rs
@@ -822,6 +822,7 @@ async fn e2e_resume_model_override_recreates_implicit_mob() {
                 meerkat_core::service::OpaquePrincipalToken::new("e2e-resume-override"),
                 true,
             )),
+            effective_authority: None,
             comms_name: None,
             comms_runtime: None,
         })


### PR DESCRIPTION
## Summary

Replace the re-entrant session service call in `grant_exact_mob_scope_after_create` with typed `SessionEffect::GrantManageMob` effects on `ToolDispatchOutcome`.

**Root cause**: `delegate` and `mob_create` deadlocked on runtime-backed sessions because the tool handler called `session_service.update_session_mob_authority_context()` from inside tool dispatch, re-entering the session command channel while the session task was busy running the turn.

**Fix**: Make mob tools ordinary tools that emit typed effects. The turn owner (agent loop) collects effects from all parallel tool calls, merges them into canonical session `build_state`, and updates the shared effective-authority handle — all before `ToolResults` is appended to the transcript.

**Discipline**: No tool may synchronously mutate session-owned durable semantics through `SessionService` during dispatch.

## Key changes

- `SessionEffect` enum on `ToolDispatchOutcome` — typed effect channel for tool-produced session mutations
- `Agent::apply_session_effects` — merges effects into canonical session `build_state` BEFORE `ToolResults` is appended
- Shared `mob_authority_handle: Arc<RwLock<MobToolAuthorityContext>>` — owned by agent, read by mob tools for authorization
- `grant_exact_mob_scope_after_create` removed entirely — no session service roundtrip from tool dispatch
- `MobToolAuthorityContext::grant_manage_mob_in_place` — in-place mutation for effect merge
- `MobToolsBuildArgs.effective_authority` — factory wires shared handle to mob tools

## Dogma compliance

- **#1 One fact, one owner**: Session/turn executor owns authority truth
- **#2 Machines own semantics**: Tools emit typed effects; turn executor merges
- **#3 Shell owns mechanics**: Tool surface reads a projection, doesn't own truth
- **#5 Typed truth**: `GrantManageMob` is explicit, not "maybe mutate this lock"

## Test plan

- [x] 3835 tests pass, 0 failures
- [x] Clippy clean with `-D warnings`
- [x] Pre-push hooks pass
- [x] New tests: `SessionEffect` serde, `ToolDispatchOutcome.session_effects`, `grant_manage_mob_in_place` (3 tests)
- [x] Updated tests: mob_create and delegate effect verification

## Manual verification needed

- Rebuild example 035, run target + TUX, `/claim`, "use delegate to write a joke" — should complete without freezing

Closes #222

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>