### PR TITLE
Make scheduler a first-class surface capability

### DIFF
--- a/examples/035-mdm-tux-rs/Cargo.toml
+++ b/examples/035-mdm-tux-rs/Cargo.toml
@@ -19,7 +19,7 @@ name = "mdm-kennel"
 path = "src/bin/kennel.rs"
 
 [dependencies]
-meerkat       = { path = "../../meerkat", features = ["comms", "jsonl-store", "session-store"] }
+meerkat       = { path = "../../meerkat", features = ["comms", "jsonl-store", "session-store", "schedule"] }
 meerkat-core  = { path = "../../meerkat-core" }
 meerkat-comms = { path = "../../meerkat-comms" }
 meerkat-mob-mcp = { path = "../../meerkat-mob-mcp" }

--- a/examples/035-mdm-tux-rs/src/bin/kennel.rs
+++ b/examples/035-mdm-tux-rs/src/bin/kennel.rs
@@ -890,7 +890,7 @@ fn dispatch_effects(
                         kennel_id,
                         KennelPayload::Released {
                             lease_ref: lease_ref.clone(),
-                            reason: reason.clone(),
+                            reason: *reason,
                         },
                     )
                 {
@@ -910,7 +910,7 @@ fn dispatch_effects(
                         KennelPayload::ClaimReleased {
                             lease_ref: lease_ref.clone(),
                             target_id: target_id.to_string(),
-                            reason: reason.clone(),
+                            reason: *reason,
                         },
                     )
                 {

--- a/examples/035-mdm-tux-rs/src/bin/target.rs
+++ b/examples/035-mdm-tux-rs/src/bin/target.rs
@@ -6,7 +6,7 @@
 //! This target is a **runtime-backed surface** (same tier as CLI/RPC/REST):
 //! - Agent construction via `AgentFactory::build_agent()`
 //! - Session lifecycle via `PersistentSessionService`
-//! - Input routing via canonical classified peer ingress
+//! - Input routing via `RuntimeSessionAdapter` with `HandlingMode::Steer`
 //! - Typed `MessageKind` classification (no string prefixes)
 //!
 //! Sessions are persisted to disk. On restart the most recent session
@@ -19,40 +19,50 @@
 //!
 //! Set one of: `ANTHROPIC_API_KEY`, `OPENAI_API_KEY`, or `GEMINI_API_KEY`.
 
-use std::collections::{BTreeMap, VecDeque};
+use std::collections::BTreeMap;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use std::time::Duration;
 
 use anyhow::{Context as _, bail};
 use futures::StreamExt;
-use meerkat::{AgentFactory, FactoryAgentBuilder, PersistentSessionService};
+use meerkat::PersistentSessionService;
+use meerkat::{
+    AgentFactory, FactoryAgentBuilder, PersistenceBundle, ScheduleService,
+    ScheduleToolDispatcher, SqliteScheduleStore,
+};
+use meerkat::surface::{
+    NoopScheduleMobHost, ScheduledPromptDispatch, SharedScheduleTargetAdapter,
+    SurfaceScheduleSessionHost, accepted_scheduled_input_from_runtime_outcome,
+    build_dispatch_from_accepted, schedule_attempt_idempotency_key, schedule_host_supported,
+    spawn_schedule_host,
+};
 use meerkat_comms::MessageKind;
 use meerkat_comms::{CommsRuntime, PeerMeta, ResolvedCommsConfig, TrustedPeer};
-use meerkat_core::agent::CommsRuntime as _;
-use meerkat_core::interaction::{InteractionContent, PeerInputCandidate};
+use meerkat_core::lifecycle::RunId;
+use meerkat_core::lifecycle::core_executor::{CoreApplyOutput, CoreExecutor, CoreExecutorError};
+use meerkat_core::lifecycle::run_control::RunControlCommand;
+use meerkat_core::lifecycle::run_primitive::{CoreRenderable, RunApplyBoundary, RunPrimitive};
 use meerkat_core::service::{
-    CreateSessionRequest, InitialTurnPolicy, SessionBuildOptions, SessionError,
+    CreateSessionRequest, InitialTurnPolicy, SessionBuildOptions, SessionError, SessionService,
+    StartTurnRequest,
 };
-use meerkat_core::types::{ContentInput, SessionId};
-use meerkat_core::{AgentEvent, AgentToolDispatcher, Config};
-use meerkat_mob_mcp::wire_mob_tools;
-use meerkat_mob_mcp::MobMcpState;
-use meerkat_runtime::comms_bridge::peer_input_candidate_to_runtime_input;
-use meerkat_runtime::identifiers::LogicalRuntimeId;
-use meerkat_runtime::SessionServiceRuntimeExt;
-use meerkat_runtime::RuntimeSessionAdapter;
-use meerkat_schedule::{ScheduleService, ScheduleToolSurface};
-use meerkat_store::{MemoryBlobStore, SessionFilter, StoreAdapter};
-use meerkat::surface::{
-    default_persistent_executor, materialize_session, spawn_runtime_backed_schedule_host,
-    wire_runtime_bindings,
+use meerkat_core::types::{ContentInput, HandlingMode, SessionId};
+use meerkat_core::{AgentEvent, Config, Session};
+use meerkat_mob_mcp::{AgentMobToolSurfaceFactory, MobMcpState};
+use meerkat_runtime::{
+    CorrelationId, IdempotencyKey, Input, InputOrigin, PromptInput, RuntimeSessionAdapter,
 };
+use meerkat_runtime::input::{
+    InputDurability, InputHeader, InputVisibility, PeerConvention, PeerInput,
+};
+use meerkat_runtime::service_ext::SessionServiceRuntimeExt;
+use meerkat_store::{JsonlStore, MemoryBlobStore, SessionFilter, SessionStore};
 
 use mdm_tux::{
     DirectControlPayload, KennelPayload, ProviderKind, RegResponse, auto_detect,
-    build_signed_envelope, direct_control_request, read_envelope, register_with_backoff,
-    open_example_runtime_persistence, verify_envelope, write_envelope, DIRECT_CONTROL_INTENT,
+    build_signed_envelope, direct_control_request, parse_direct_control_message, read_envelope,
+    register_with_backoff, verify_envelope, write_envelope,
 };
 use tokio::io::BufReader;
 use tokio::net::TcpStream;
@@ -65,29 +75,333 @@ use mdm_tux::machines::target_session_binding::{
 const SYSTEM_PROMPT: &str = "\
 You are a managed system agent named '{name}' controlled by a human operator via TUX.
 Execute user requests using your available tools. Respond conversationally.
+Your current session_id is '{session_id}'. If you schedule follow-up work for this same running agent session, use that exact session_id.
 Your responses stream directly to the controller — do not use the 'send' comms tool to reply.";
 
 struct TargetRuntimeSurface {
     service: Arc<PersistentSessionService<FactoryAgentBuilder>>,
     runtime_adapter: Arc<RuntimeSessionAdapter>,
-    comms_runtime: Arc<CommsRuntime>,
-    #[allow(dead_code)]
-    schedule_service: ScheduleService,
-    schedule_tools: Arc<dyn AgentToolDispatcher>,
-    session_store: Arc<dyn meerkat::SessionStore>,
+    jsonl_store: Arc<JsonlStore>,
     mob_state: Arc<MobMcpState>,
     _schedule_host: Option<meerkat::surface::ScheduleHostHandle>,
 }
 
-fn target_session_build_template(
-    schedule_tools: Arc<dyn AgentToolDispatcher>,
-) -> SessionBuildOptions {
-    SessionBuildOptions {
-        external_tools: Some(schedule_tools),
-        override_builtins: meerkat_core::ToolCategoryOverride::Enable,
-        override_shell: meerkat_core::ToolCategoryOverride::Enable,
-        override_mob: meerkat_core::ToolCategoryOverride::Enable,
-        ..Default::default()
+#[derive(Clone)]
+struct TargetScheduleSessionHost {
+    service: Arc<PersistentSessionService<FactoryAgentBuilder>>,
+    runtime_adapter: Arc<RuntimeSessionAdapter>,
+    mob_state: Arc<MobMcpState>,
+}
+
+impl TargetScheduleSessionHost {
+    fn new(
+        service: Arc<PersistentSessionService<FactoryAgentBuilder>>,
+        runtime_adapter: Arc<RuntimeSessionAdapter>,
+        mob_state: Arc<MobMcpState>,
+    ) -> Self {
+        Self {
+            service,
+            runtime_adapter,
+            mob_state,
+        }
+    }
+
+    fn executor(&self, session_id: SessionId) -> TargetCoreExecutor {
+        TargetCoreExecutor::new(
+            Arc::clone(&self.service),
+            Arc::clone(&self.mob_state),
+            session_id,
+        )
+    }
+
+    async fn ensure_runtime_session_registered(
+        &self,
+        session_id: &SessionId,
+    ) -> Result<(), meerkat::ScheduleDomainError> {
+        let session_exists = self.service.read(session_id).await.is_ok()
+            || self
+                .service
+                .load_persisted(session_id)
+                .await
+                .map_err(|error| meerkat::ScheduleDomainError::Internal(error.to_string()))?
+                .is_some();
+        if !session_exists {
+            return Err(meerkat::ScheduleDomainError::InvalidSchedule(format!(
+                "session not found: {session_id}"
+            )));
+        }
+
+        let executor = Box::new(self.executor(session_id.clone()));
+        self.runtime_adapter
+            .ensure_session_with_executor(session_id.clone(), executor)
+            .await;
+        Ok(())
+    }
+
+    async fn update_peer_ingress_context(&self, session_id: &SessionId) {
+        let keep_alive = self
+            .service
+            .load_persisted(session_id)
+            .await
+            .ok()
+            .flatten()
+            .and_then(|session| session.session_metadata().map(|metadata| metadata.keep_alive))
+            .unwrap_or(false);
+        let comms_rt = self.service.comms_runtime(session_id).await;
+        self.runtime_adapter
+            .update_peer_ingress_context(session_id, keep_alive, comms_rt)
+            .await;
+    }
+}
+
+fn session_metadata_marks_archived(session: &Session) -> bool {
+    session
+        .metadata()
+        .get("session_archived")
+        .and_then(serde_json::Value::as_bool)
+        .unwrap_or(false)
+}
+
+fn scheduled_skill_keys(
+    skill_references: &[String],
+) -> Result<Option<Vec<meerkat_core::skills::SkillKey>>, meerkat::ScheduleDomainError> {
+    if skill_references.is_empty() {
+        return Ok(None);
+    }
+
+    skill_references
+        .iter()
+        .map(|reference| {
+            let mut parts = reference.split('/');
+            let Some(source_uuid_raw) = parts.next() else {
+                return Err(meerkat::ScheduleDomainError::InvalidSchedule(format!(
+                    "invalid scheduled skill reference: {reference}"
+                )));
+            };
+            let Some(skill_name_raw) = parts.next() else {
+                return Err(meerkat::ScheduleDomainError::InvalidSchedule(format!(
+                    "invalid scheduled skill reference: {reference}"
+                )));
+            };
+            if parts.next().is_some() {
+                return Err(meerkat::ScheduleDomainError::InvalidSchedule(format!(
+                    "invalid scheduled skill reference: {reference}"
+                )));
+            }
+            Ok(meerkat_core::skills::SkillKey {
+                source_uuid: meerkat_core::skills::SourceUuid::parse(source_uuid_raw).map_err(
+                    |_| {
+                        meerkat::ScheduleDomainError::InvalidSchedule(format!(
+                            "invalid scheduled skill reference: {reference}"
+                        ))
+                    },
+                )?,
+                skill_name: meerkat_core::skills::SkillName::parse(skill_name_raw).map_err(
+                    |_| {
+                        meerkat::ScheduleDomainError::InvalidSchedule(format!(
+                            "invalid scheduled skill reference: {reference}"
+                        ))
+                    },
+                )?,
+            })
+        })
+        .collect::<Result<Vec<_>, _>>()
+        .map(Some)
+}
+
+#[async_trait::async_trait]
+impl SurfaceScheduleSessionHost for TargetScheduleSessionHost {
+    async fn probe_session_target(
+        &self,
+        binding: &meerkat::SessionTargetBinding,
+    ) -> Result<meerkat::TargetProbeOutcome, meerkat::ScheduleDomainError> {
+        let Some(session_id) = binding.resolved_session_id() else {
+            return Ok(meerkat::TargetProbeOutcome::Ready);
+        };
+
+        if let Ok(view) = self.service.read(session_id).await {
+            return Ok(if view.state.is_active {
+                meerkat::TargetProbeOutcome::Busy {
+                    detail: Some(format!("session still running: {session_id}")),
+                }
+            } else {
+                meerkat::TargetProbeOutcome::Ready
+            });
+        }
+
+        let persisted = self
+            .service
+            .load_persisted(session_id)
+            .await
+            .map_err(|error| meerkat::ScheduleDomainError::Internal(error.to_string()))?;
+        match persisted {
+            Some(session) if !session_metadata_marks_archived(&session) => {
+                Ok(meerkat::TargetProbeOutcome::Ready)
+            }
+            _ => Ok(meerkat::TargetProbeOutcome::Missing {
+                detail: Some(format!("session not found: {session_id}")),
+            }),
+        }
+    }
+
+    async fn materialize_session(
+        &self,
+        create: &meerkat::SessionMaterializationSpec,
+        prompt_system_prompt: Option<&str>,
+    ) -> Result<SessionId, meerkat::ScheduleDomainError> {
+        let session = Session::new();
+        let session_id = session.id().clone();
+        let bindings = self
+            .runtime_adapter
+            .prepare_bindings(session_id.clone())
+            .await
+            .map_err(|error| meerkat::ScheduleDomainError::Internal(error.to_string()))?;
+
+        let build = SessionBuildOptions {
+            provider: create.provider,
+            output_schema: create.output_schema.clone(),
+            structured_output_retries: create.structured_output_retries,
+            comms_name: create.comms_name.clone(),
+            peer_meta: create.peer_meta.clone(),
+            resume_session: Some(session),
+            provider_params: create.provider_params.clone(),
+            preload_skills: (!create.preload_skills.is_empty()).then(|| {
+                create
+                    .preload_skills
+                    .iter()
+                    .cloned()
+                    .map(Into::into)
+                    .collect()
+            }),
+            additional_instructions: (!create.additional_instructions.is_empty())
+                .then(|| create.additional_instructions.clone()),
+            realm_id: create.realm_id.clone(),
+            instance_id: create.instance_id.clone(),
+            backend: create.backend.clone(),
+            keep_alive: create.keep_alive,
+            app_context: create.app_context.clone(),
+            runtime_build_mode: meerkat_core::RuntimeBuildMode::SessionOwned(bindings),
+            ..SessionBuildOptions::default()
+        };
+
+        let result = self
+            .service
+            .create_session(CreateSessionRequest {
+                model: create.model.clone(),
+                prompt: ContentInput::Text(String::new()),
+                render_metadata: None,
+                system_prompt: prompt_system_prompt
+                    .map(str::to_owned)
+                    .or_else(|| create.system_prompt.clone()),
+                max_tokens: create.max_tokens,
+                event_tx: None,
+                skill_references: None,
+                initial_turn: InitialTurnPolicy::Defer,
+                deferred_prompt_policy: meerkat_core::service::DeferredPromptPolicy::Discard,
+                build: Some(build),
+                labels: Some(create.labels.clone()),
+            })
+            .await
+            .map_err(|error| meerkat::ScheduleDomainError::Internal(error.to_string()))?;
+
+        self.runtime_adapter
+            .ensure_session_with_executor(
+                result.session_id.clone(),
+                Box::new(self.executor(result.session_id.clone())),
+            )
+            .await;
+
+        Ok(result.session_id)
+    }
+
+    async fn deliver_prompt(
+        &self,
+        session_id: &SessionId,
+        occurrence: &meerkat::Occurrence,
+        dispatch: ScheduledPromptDispatch,
+    ) -> Result<meerkat::DeliveryDispatch, meerkat::ScheduleDomainError> {
+        self.ensure_runtime_session_registered(session_id).await?;
+        self.update_peer_ingress_context(session_id).await;
+
+        let turn_metadata = Some(meerkat_core::lifecycle::run_primitive::RuntimeTurnMetadata {
+            handling_mode: None,
+            keep_alive: None,
+            skill_references: scheduled_skill_keys(&dispatch.skill_references)?,
+            flow_tool_overlay: None,
+            additional_instructions: (!dispatch.additional_instructions.is_empty())
+                .then_some(dispatch.additional_instructions.clone()),
+            model: None,
+            provider: None,
+            provider_params: None,
+            render_metadata: dispatch.render_metadata.clone(),
+            execution_kind: None,
+        });
+        let mut prompt_input = PromptInput::from_content_input(dispatch.prompt, turn_metadata);
+        prompt_input.header.source = InputOrigin::System;
+        prompt_input.header.idempotency_key = Some(IdempotencyKey::new(
+            schedule_attempt_idempotency_key(occurrence),
+        ));
+        prompt_input.header.correlation_id =
+            Some(CorrelationId::from_uuid(occurrence.occurrence_id.0));
+
+        let (outcome, handle) = self
+            .runtime_adapter
+            .accept_input_with_completion(session_id, Input::Prompt(prompt_input))
+            .await
+            .map_err(|error| meerkat::ScheduleDomainError::Internal(error.to_string()))?;
+
+        Ok(build_dispatch_from_accepted(
+            occurrence,
+            accepted_scheduled_input_from_runtime_outcome(outcome, handle),
+            dispatch.materialized_session_id,
+        ))
+    }
+
+    async fn deliver_event(
+        &self,
+        session_id: &SessionId,
+        occurrence: &meerkat::Occurrence,
+        event_type: String,
+        payload: serde_json::Value,
+        render_metadata: Option<meerkat_core::types::RenderMetadata>,
+        materialized_session_id: Option<SessionId>,
+    ) -> Result<meerkat::DeliveryDispatch, meerkat::ScheduleDomainError> {
+        self.ensure_runtime_session_registered(session_id).await?;
+        self.update_peer_ingress_context(session_id).await;
+
+        let input = Input::ExternalEvent(meerkat_runtime::ExternalEventInput {
+            header: InputHeader {
+                id: meerkat_core::lifecycle::InputId::new(),
+                timestamp: chrono::Utc::now(),
+                source: InputOrigin::External {
+                    source_name: format!("schedule:{}", occurrence.schedule_id),
+                },
+                durability: InputDurability::Durable,
+                visibility: InputVisibility::default(),
+                idempotency_key: Some(IdempotencyKey::new(schedule_attempt_idempotency_key(
+                    occurrence,
+                ))),
+                supersession_key: None,
+                correlation_id: Some(CorrelationId::from_uuid(occurrence.occurrence_id.0)),
+            },
+            event_type,
+            payload,
+            blocks: None,
+            handling_mode: HandlingMode::Queue,
+            render_metadata,
+        });
+
+        let (outcome, handle) = self
+            .runtime_adapter
+            .accept_input_with_completion(session_id, input)
+            .await
+            .map_err(|error| meerkat::ScheduleDomainError::Internal(error.to_string()))?;
+
+        Ok(build_dispatch_from_accepted(
+            occurrence,
+            accepted_scheduled_input_from_runtime_outcome(outcome, handle),
+            materialized_session_id,
+        ))
     }
 }
 
@@ -95,50 +409,84 @@ async fn build_target_runtime_surface(
     session_dir: &Path,
     comms_runtime: Arc<CommsRuntime>,
 ) -> anyhow::Result<TargetRuntimeSurface> {
-    let persistence = open_example_runtime_persistence(session_dir).await?;
-    let config = Config::default();
-    let session_store = persistence.session_store();
-    let schedule_service = ScheduleService::new(persistence.schedule_store());
+    let factory = AgentFactory::new(session_dir)
+        .shell(true)
+        .builtins(true)
+        .comms(true)
+        .schedule(true)
+        .mob(true)
+        .with_comms_runtime(comms_runtime);
+    let schedule_store = Arc::new(SqliteScheduleStore::open(
+        session_dir.join("schedule.sqlite"),
+    )?) as Arc<dyn meerkat::ScheduleStore>;
+    let schedule_service = ScheduleService::new(Arc::clone(&schedule_store));
+    let builder = FactoryAgentBuilder::new(factory, Config::default());
+    let mob_tools_slot = Arc::clone(&builder.default_mob_tools);
+    *builder
+        .default_schedule_tools
+        .write()
+        .unwrap_or_else(std::sync::PoisonError::into_inner) = Some(Arc::new(
+        ScheduleToolDispatcher::new(schedule_service.clone()),
+    ));
+
+    let jsonl_store = Arc::new(JsonlStore::new(session_dir.to_path_buf()));
+    jsonl_store.init().await?;
+
+    let persistence = PersistenceBundle::new_with_schedule_store(
+        Arc::clone(&jsonl_store) as Arc<dyn SessionStore>,
+        None,
+        Arc::new(MemoryBlobStore::new()),
+        schedule_store,
+    );
     let runtime_adapter = persistence.runtime_adapter();
-    let mut builder = FactoryAgentBuilder::new(
-        AgentFactory::new(session_dir.to_path_buf())
-            .session_store(Arc::clone(&session_store))
-            .with_comms_runtime(Arc::clone(&comms_runtime))
-            .shell(true)
-            .builtins(true)
-            .mob(true),
-        config.clone(),
-    );
-    builder.default_session_store = Some(Arc::new(StoreAdapter::new(Arc::clone(&session_store))));
-    let builder_mob_tools_slot = Arc::clone(&builder.default_mob_tools);
-    let (store, runtime_store, blob_store) = persistence.into_parts();
-    let mut service = PersistentSessionService::new(builder, 10, store, runtime_store, blob_store);
-    wire_runtime_bindings(&mut service, &runtime_adapter);
-    let service = Arc::new(service);
-    let schedule_tools: Arc<dyn AgentToolDispatcher> =
-        Arc::new(ScheduleToolSurface::new(schedule_service.clone()));
-    let schedule_host = spawn_runtime_backed_schedule_host(
-        Arc::clone(&service),
-        Arc::clone(&runtime_adapter),
-        config,
-        schedule_service.clone(),
-        target_session_build_template(Arc::clone(&schedule_tools)),
-        format!("mdm-target:{}", session_dir.display()),
-    );
-    let mob_state = wire_mob_tools(
-        &builder_mob_tools_slot,
+    let (session_store, runtime_store, blob_store) = persistence.into_parts();
+
+    let mut session_service =
+        PersistentSessionService::new(builder, 10, session_store, runtime_store, blob_store);
+    {
+        let adapter = runtime_adapter.clone();
+        session_service.set_runtime_bindings_provider(Arc::new(move |session_id| {
+            let adapter = adapter.clone();
+            Box::pin(async move { adapter.prepare_bindings(session_id).await.ok() })
+        }));
+    }
+    let service = Arc::new(session_service);
+    let mob_state = Arc::new(MobMcpState::new_with_runtime_adapter(
         service.clone(),
         Some(runtime_adapter.clone()),
-        None,
-    );
+    ));
+    *mob_tools_slot
+        .write()
+        .unwrap_or_else(std::sync::PoisonError::into_inner) = Some(Arc::new(
+        AgentMobToolSurfaceFactory::new(Arc::clone(&mob_state)),
+    ));
+    let schedule_host = if schedule_host_supported(schedule_service.store().kind()) {
+        let session_host: Arc<dyn SurfaceScheduleSessionHost> =
+            Arc::new(TargetScheduleSessionHost::new(
+                service.clone(),
+                runtime_adapter.clone(),
+                mob_state.clone(),
+            ));
+        let shared_adapter = Arc::new(SharedScheduleTargetAdapter::new(
+            schedule_service.clone(),
+            session_host,
+            Arc::new(NoopScheduleMobHost::new(
+                "scheduled mob targets are not enabled in mdm-target",
+            )),
+        ));
+        Some(spawn_schedule_host(
+            schedule_service,
+            shared_adapter,
+            "mdm-target",
+        ))
+    } else {
+        None
+    };
 
     Ok(TargetRuntimeSurface {
         service,
         runtime_adapter,
-        comms_runtime,
-        schedule_service,
-        schedule_tools,
-        session_store,
+        jsonl_store,
         mob_state,
         _schedule_host: schedule_host,
     })
@@ -157,78 +505,6 @@ async fn discard_live_session_with_mob_cleanup(
         eprintln!("[target] warning: cleanup mobs for session {session_id}: {error}");
     }
     discard_result
-}
-
-async fn sync_session_trusted_peers_from_surface(
-    surface: &TargetRuntimeSurface,
-    session_id: &SessionId,
-    source_runtime: &Arc<CommsRuntime>,
-) -> anyhow::Result<()> {
-    let Some(session_runtime) = surface.service.comms_runtime(session_id).await else {
-        return Ok(());
-    };
-
-    let desired_peers = source_runtime.peers().await;
-    let existing_peers = session_runtime.peers().await;
-
-    for peer in &existing_peers {
-        if desired_peers
-            .iter()
-            .all(|desired| desired.peer_id != peer.peer_id)
-        {
-            session_runtime
-                .remove_trusted_peer(&peer.peer_id)
-                .await
-                .with_context(|| {
-                    format!(
-                        "remove stale session peer {} ({})",
-                        peer.name.as_str(),
-                        peer.peer_id
-                    )
-                })?;
-        }
-    }
-
-    for peer in desired_peers {
-        if existing_peers
-            .iter()
-            .all(|existing| existing.peer_id != peer.peer_id)
-        {
-            let spec = meerkat_core::comms::TrustedPeerSpec::new(
-                peer.name.as_str(),
-                peer.peer_id.clone(),
-                peer.address.clone(),
-            )
-            .map_err(anyhow::Error::msg)
-            .context("build session trusted peer spec")?;
-            session_runtime
-                .add_trusted_peer(spec)
-                .await
-                .with_context(|| {
-                    format!(
-                        "add session peer {} ({})",
-                        peer.name.as_str(),
-                        peer.peer_id
-                    )
-                })?;
-        }
-    }
-
-    Ok(())
-}
-
-async fn inject_peer_input_candidate(
-    surface: &TargetRuntimeSurface,
-    session_id: &SessionId,
-    candidate: &PeerInputCandidate,
-) -> anyhow::Result<meerkat_runtime::AcceptOutcome> {
-    let runtime_id = LogicalRuntimeId::new(session_id.to_string());
-    let input = peer_input_candidate_to_runtime_input(candidate, &runtime_id);
-    surface
-        .runtime_adapter
-        .accept_input(session_id, input)
-        .await
-        .map_err(|error| anyhow::anyhow!(error.to_string()))
 }
 
 /// Build a `ResolvedCommsConfig` for the target's stable identity.
@@ -347,13 +623,25 @@ async fn main() -> anyhow::Result<()> {
     let session_dir = data_dir.join("sessions");
     tokio::fs::create_dir_all(&session_dir).await?;
     let surface = build_target_runtime_surface(&session_dir, Arc::clone(&comms_runtime)).await?;
+    let _schedule_host_guard = surface._schedule_host.as_ref();
     let service = Arc::clone(&surface.service);
+    let runtime_adapter = Arc::clone(&surface.runtime_adapter);
+    let jsonl_store = Arc::clone(&surface.jsonl_store);
+    let mob_state = Arc::clone(&surface.mob_state);
 
-    let system_prompt = SYSTEM_PROMPT.replace("{name}", &name);
+    let system_prompt_template = SYSTEM_PROMPT.replace("{name}", &name);
 
     // ── 4. Create or auto-resume session ──────────────────────────────────────
-    let mut current_session_id =
-        create_or_resume_session(&surface, &model, &system_prompt, &provider).await?;
+    let mut current_session_id = create_or_resume_session(
+        &service,
+        &runtime_adapter,
+        &jsonl_store,
+        &model,
+        &system_prompt_template,
+        &mob_state,
+        &provider,
+    )
+    .await?;
 
     let mut event_forwarder: Option<tokio::task::JoinHandle<()>> = None;
 
@@ -451,14 +739,6 @@ async fn main() -> anyhow::Result<()> {
             addr: format!("tcp://{host_addr}"),
             meta: PeerMeta::default(),
         });
-        if let Err(error) =
-            sync_session_trusted_peers_from_surface(&surface, &current_session_id, &comms_runtime)
-                .await
-        {
-            eprintln!(
-                "[target] warning: sync trusted peers into session {current_session_id}: {error}"
-            );
-        }
 
         // Disconnect signal: heartbeat + event forwarder can trigger reconnect
         let (disconnect_tx, disconnect_rx) = tokio::sync::watch::channel(false);
@@ -487,9 +767,12 @@ async fn main() -> anyhow::Result<()> {
             &comms_runtime,
             disconnect_rx,
             disconnect_tx,
-            &surface,
+            &service,
+            &runtime_adapter,
+            &jsonl_store,
             &model,
-            &system_prompt,
+            &system_prompt_template,
+            &mob_state,
             &provider,
             &mut session_binding_state,
             &mut current_session_id,
@@ -542,65 +825,39 @@ async fn run_inbox_loop(
     comms_runtime: &Arc<CommsRuntime>,
     mut disconnect_rx: tokio::sync::watch::Receiver<bool>,
     disconnect_tx: tokio::sync::watch::Sender<bool>,
-    surface: &TargetRuntimeSurface,
+    service: &Arc<PersistentSessionService<FactoryAgentBuilder>>,
+    runtime_adapter: &Arc<RuntimeSessionAdapter>,
+    jsonl_store: &JsonlStore,
     model: &str,
     system_prompt: &str,
+    mob_state: &Arc<MobMcpState>,
     provider: &str,
     session_binding_state: &mut SessionBindingState,
     current_session_id: &mut SessionId,
     event_forwarder: &mut Option<tokio::task::JoinHandle<()>>,
 ) {
-    let mut pending_candidates = VecDeque::new();
     loop {
-        if let Some(candidate) = pending_candidates.pop_front() {
-            match parse_direct_control_candidate(&candidate) {
-                Ok(Some(payload)) => {
-                    tracing::debug!(?payload, "ignoring direct control payload at target surface");
-                    continue;
-                }
-                Ok(None) => {}
-                Err(error) => {
-                    eprintln!("[target] invalid direct control payload: {error}");
-                    continue;
-                }
-            }
-            match handle_target_message(
-                &candidate,
-                comms_runtime,
-                &disconnect_tx,
-                surface,
-                model,
-                system_prompt,
-                provider,
-                session_binding_state,
-                current_session_id,
-                event_forwarder,
-            )
-            .await
-            {
-                TargetLoopAction::Continue => {}
-                TargetLoopAction::ExitProcess => std::process::exit(0),
-            }
-            continue;
-        }
-
-        let inbox_notify = comms_runtime.inbox_notify();
-        let notified = inbox_notify.notified();
-        pending_candidates.extend(comms_runtime.drain_peer_input_candidates().await);
-        if !pending_candidates.is_empty() {
-            continue;
-        }
-        if comms_runtime.dismiss_received() {
-            eprintln!("[target] received DISMISS — shutting down");
-            std::process::exit(0);
-        }
-
         tokio::select! {
-            _ = notified => {
-                pending_candidates.extend(comms_runtime.drain_peer_input_candidates().await);
-                if pending_candidates.is_empty() && comms_runtime.dismiss_received() {
-                    eprintln!("[target] received DISMISS — shutting down");
-                    std::process::exit(0);
+            msg = comms_runtime.recv_message() => {
+                let Some(msg) = msg else { break };
+                match handle_target_message(
+                    &msg,
+                    comms_runtime,
+                    &disconnect_tx,
+                    service,
+                    runtime_adapter,
+                    jsonl_store,
+                    model,
+                    system_prompt,
+                    mob_state,
+                    provider,
+                    session_binding_state,
+                    current_session_id,
+                    event_forwarder,
+                )
+                .await {
+                    TargetLoopAction::Continue => {}
+                    TargetLoopAction::ExitProcess => std::process::exit(0),
                 }
             }
 
@@ -780,32 +1037,42 @@ async fn apply_target_control_effects(
 
 #[allow(clippy::too_many_arguments)]
 async fn handle_target_message(
-    candidate: &PeerInputCandidate,
+    msg: &meerkat_comms::agent::types::CommsMessage,
     comms_runtime: &Arc<CommsRuntime>,
     disconnect_tx: &tokio::sync::watch::Sender<bool>,
-    surface: &TargetRuntimeSurface,
+    service: &Arc<PersistentSessionService<FactoryAgentBuilder>>,
+    runtime_adapter: &Arc<RuntimeSessionAdapter>,
+    jsonl_store: &JsonlStore,
     model: &str,
     system_prompt: &str,
+    mob_state: &Arc<MobMcpState>,
     provider: &str,
     session_binding_state: &mut SessionBindingState,
     current_session_id: &mut SessionId,
     event_forwarder: &mut Option<tokio::task::JoinHandle<()>>,
 ) -> TargetLoopAction {
-    let sender = candidate.interaction.from.clone();
-    match &candidate.interaction.content {
-        InteractionContent::Request { intent, .. } if intent == "dismiss" => {
+    let sender = msg.from_peer.clone();
+    match &msg.content {
+        meerkat_comms::agent::types::CommsContent::Request { intent, .. }
+            if intent.as_str() == "dismiss" =>
+        {
             eprintln!("[target] received DISMISS — shutting down");
             return TargetLoopAction::ExitProcess;
         }
-        InteractionContent::Request { intent, params } if intent == "command" => {
+        meerkat_comms::agent::types::CommsContent::Request { intent, params, .. }
+            if intent.as_str() == "command" =>
+        {
             let cmd = params.get("cmd").and_then(|v| v.as_str()).unwrap_or("");
             eprintln!("[target] command: {cmd}");
 
             let response = handle_command(
                 cmd,
-                surface,
+                service,
+                runtime_adapter,
+                jsonl_store,
                 model,
                 system_prompt,
+                mob_state,
                 provider,
                 session_binding_state,
                 current_session_id,
@@ -828,41 +1095,63 @@ async fn handle_target_message(
             );
             let _ = tokio::time::timeout(std::time::Duration::from_secs(5), reply_fut).await;
         }
-        InteractionContent::Request { intent, .. } if intent == "heartbeat" => {}
-        InteractionContent::Request { intent, .. } if intent == DIRECT_CONTROL_INTENT => {
-            tracing::debug!("ignoring direct control payload after surface handling");
+        meerkat_comms::agent::types::CommsContent::Request { intent, .. }
+            if intent.as_str() == "heartbeat" => {}
+        meerkat_comms::agent::types::CommsContent::Message { body, .. } => {
+            eprintln!("[target] received message from '{sender}'");
+
+            let peer_input = Input::Peer(PeerInput {
+                header: InputHeader {
+                    id: meerkat_core::lifecycle::InputId::new(),
+                    timestamp: chrono::Utc::now(),
+                    source: InputOrigin::Peer {
+                        peer_id: sender.clone(),
+                        runtime_id: None,
+                    },
+                    durability: InputDurability::Ephemeral,
+                    visibility: InputVisibility::default(),
+                    idempotency_key: None,
+                    supersession_key: None,
+                    correlation_id: None,
+                },
+                convention: Some(PeerConvention::Message),
+                body: body.clone(),
+                blocks: None,
+                handling_mode: Some(HandlingMode::Steer),
+            });
+
+            match runtime_adapter
+                .accept_input(active_session_id(session_binding_state), peer_input)
+                .await
+            {
+                Ok(outcome) => {
+                    tracing::debug!(?outcome, "input accepted");
+                }
+                Err(e) => {
+                    eprintln!("[target] accept_input error: {e}");
+                    let req = StartTurnRequest {
+                        prompt: ContentInput::Text(body.clone()),
+                        system_prompt: None,
+                        render_metadata: None,
+                        handling_mode: HandlingMode::Queue,
+                        event_tx: None,
+                        skill_references: None,
+                        flow_tool_overlay: None,
+                        additional_instructions: None,
+                        execution_kind: None,
+                    };
+                    if let Err(e) = service
+                        .start_turn(active_session_id(session_binding_state), req)
+                        .await
+                    {
+                        eprintln!("[target] fallback start_turn error: {e}");
+                    }
+                }
+            }
         }
-        InteractionContent::Message { .. }
-        | InteractionContent::Request { .. }
-        | InteractionContent::Response { .. } => match inject_peer_input_candidate(
-            surface,
-            active_session_id(session_binding_state),
-            candidate,
-        )
-        .await
-        {
-            Ok(outcome) => {
-                tracing::debug!(?outcome, "classified input accepted");
-            }
-            Err(error) => {
-                eprintln!("[target] inject_peer_input_candidate error: {error}");
-            }
-        },
+        _ => {}
     }
     TargetLoopAction::Continue
-}
-
-fn parse_direct_control_candidate(
-    candidate: &PeerInputCandidate,
-) -> anyhow::Result<Option<DirectControlPayload>> {
-    match &candidate.interaction.content {
-        InteractionContent::Request { intent, params } if intent == DIRECT_CONTROL_INTENT => {
-            let payload =
-                serde_json::from_value(params.clone()).context("decode direct control payload")?;
-            Ok(Some(payload))
-        }
-        _ => Ok(None),
-    }
 }
 
 async fn forward_stream_event(
@@ -933,9 +1222,12 @@ fn spawn_heartbeat(
 #[allow(clippy::too_many_arguments)]
 async fn handle_command(
     cmd: &str,
-    surface: &TargetRuntimeSurface,
+    service: &Arc<PersistentSessionService<FactoryAgentBuilder>>,
+    runtime_adapter: &Arc<RuntimeSessionAdapter>,
+    jsonl_store: &JsonlStore,
     model: &str,
     system_prompt: &str,
+    mob_state: &Arc<MobMcpState>,
     provider: &str,
     session_binding_state: &mut SessionBindingState,
     current_session_id: &mut SessionId,
@@ -945,10 +1237,12 @@ async fn handle_command(
 ) -> String {
     if cmd == "NEW_SESSION" {
         match switch_session(
-            surface,
+            service,
+            runtime_adapter,
             None,
             model,
             system_prompt,
+            mob_state,
             provider,
             session_binding_state,
             current_session_id,
@@ -962,7 +1256,7 @@ async fn handle_command(
             Err(e) => format!("Failed to create session: {e}"),
         }
     } else if cmd == "LIST_SESSIONS" {
-        match surface.session_store.list(SessionFilter::default()).await {
+        match jsonl_store.list(SessionFilter::default()).await {
             Ok(mut sessions) => {
                 sessions.sort_by(|a, b| b.updated_at.cmp(&a.updated_at));
                 if sessions.is_empty() {
@@ -1001,7 +1295,7 @@ async fn handle_command(
             Ok(n) if n >= 1 => n - 1,
             _ => return format!("Invalid session number: {arg}"),
         };
-        match surface.session_store.list(SessionFilter::default()).await {
+        match jsonl_store.list(SessionFilter::default()).await {
             Ok(mut sessions) => {
                 sessions.sort_by(|a, b| b.updated_at.cmp(&a.updated_at));
                 if idx >= sessions.len() {
@@ -1009,10 +1303,12 @@ async fn handle_command(
                 }
                 let resume_id = sessions[idx].id.clone();
                 match switch_session(
-                    surface,
+                    service,
+                    runtime_adapter,
                     Some(resume_id),
                     model,
                     system_prompt,
+                    mob_state,
                     provider,
                     session_binding_state,
                     current_session_id,
@@ -1051,21 +1347,32 @@ fn format_duration(d: std::time::Duration) -> String {
 /// Create a new session or resume an existing one. Registers the session
 /// with the RuntimeSessionAdapter and subscribes to its events.
 async fn create_or_resume_session(
-    surface: &TargetRuntimeSurface,
+    service: &Arc<PersistentSessionService<FactoryAgentBuilder>>,
+    runtime_adapter: &Arc<RuntimeSessionAdapter>,
+    jsonl_store: &JsonlStore,
     model: &str,
     system_prompt: &str,
+    mob_state: &Arc<MobMcpState>,
     provider: &str,
 ) -> anyhow::Result<SessionId> {
     // Try to auto-resume the most recent session. On failure, warn and start fresh.
-    if let Ok(mut sessions) = surface.session_store.list(SessionFilter::default()).await {
+    if let Ok(mut sessions) = jsonl_store.list(SessionFilter::default()).await {
         sessions.sort_by(|a, b| b.updated_at.cmp(&a.updated_at));
         if let Some(latest) = sessions.first() {
             eprintln!(
                 "[target] auto-resuming session {} ({} messages)",
                 latest.id, latest.message_count
             );
-            match setup_session(surface, Some(latest.id.clone()), model, system_prompt, provider)
-                .await
+            match setup_session(
+                service,
+                runtime_adapter,
+                Some(latest.id.clone()),
+                model,
+                system_prompt,
+                mob_state,
+                provider,
+            )
+            .await
             {
                 Ok(sid) => return Ok(sid),
                 Err(e) => {
@@ -1076,7 +1383,16 @@ async fn create_or_resume_session(
     }
 
     eprintln!("[target] starting fresh session");
-    setup_session(surface, None, model, system_prompt, provider).await
+    setup_session(
+        service,
+        runtime_adapter,
+        None,
+        model,
+        system_prompt,
+        mob_state,
+        provider,
+    )
+    .await
 }
 
 /// Switch to a new or resumed session. Drops the old event forwarder,
@@ -1084,10 +1400,12 @@ async fn create_or_resume_session(
 /// and spawns a new event forwarder.
 #[allow(clippy::too_many_arguments)]
 async fn switch_session(
-    surface: &TargetRuntimeSurface,
+    service: &Arc<PersistentSessionService<FactoryAgentBuilder>>,
+    runtime_adapter: &Arc<RuntimeSessionAdapter>,
     resume_id: Option<SessionId>,
     model: &str,
     system_prompt: &str,
+    mob_state: &Arc<MobMcpState>,
     provider: &str,
     session_binding_state: &mut SessionBindingState,
     current_session_id: &mut SessionId,
@@ -1107,8 +1425,16 @@ async fn switch_session(
     let mut new_id: Option<SessionId> = None;
     for effect in effects {
         if let SessionBindingEffect::SetupSession { resume_id } = effect {
-            let setup_result =
-                setup_session(surface, resume_id, model, system_prompt, provider).await;
+            let setup_result = setup_session(
+                service,
+                runtime_adapter,
+                resume_id,
+                model,
+                system_prompt,
+                mob_state,
+                provider,
+            )
+            .await;
             match setup_result {
                 Ok(session_id) => new_id = Some(session_id),
                 Err(err) => {
@@ -1150,7 +1476,7 @@ async fn switch_session(
                     old.abort();
                 }
                 match spawn_event_forwarder(
-                    &surface.service,
+                    service,
                     &session_id,
                     Arc::clone(comms_runtime),
                     disconnect_tx.clone(),
@@ -1172,12 +1498,12 @@ async fn switch_session(
                         for cleanup in cleanup_effects {
                             match cleanup {
                                 SessionBindingEffect::UnregisterRuntimeSession { session_id } => {
-                                    surface.runtime_adapter.unregister_session(&session_id).await;
+                                    runtime_adapter.unregister_session(&session_id).await;
                                 }
                                 SessionBindingEffect::DiscardLiveSession { session_id } => {
                                     if let Err(discard_err) = discard_live_session_with_mob_cleanup(
-                                        &surface.service,
-                                        &surface.mob_state,
+                                        service,
+                                        mob_state,
                                         &session_id,
                                     )
                                     .await
@@ -1197,16 +1523,11 @@ async fn switch_session(
                 }
             }
             SessionBindingEffect::UnregisterRuntimeSession { session_id } => {
-                surface.runtime_adapter.unregister_session(&session_id).await;
+                runtime_adapter.unregister_session(&session_id).await;
             }
             SessionBindingEffect::DiscardLiveSession { session_id } => {
                 if let Err(e) =
-                    discard_live_session_with_mob_cleanup(
-                        &surface.service,
-                        &surface.mob_state,
-                        &session_id,
-                    )
-                    .await
+                    discard_live_session_with_mob_cleanup(service, mob_state, &session_id).await
                     && !matches!(e, SessionError::NotFound { .. })
                 {
                     eprintln!("[target] warning: discard old session {session_id}: {e}");
@@ -1225,15 +1546,11 @@ async fn switch_session(
     for effect in effects {
         match effect {
             SessionBindingEffect::UnregisterRuntimeSession { session_id } => {
-                surface.runtime_adapter.unregister_session(&session_id).await;
+                runtime_adapter.unregister_session(&session_id).await;
             }
             SessionBindingEffect::DiscardLiveSession { session_id } => {
-                if let Err(e) = discard_live_session_with_mob_cleanup(
-                    &surface.service,
-                    &surface.mob_state,
-                    &session_id,
-                )
-                .await
+                if let Err(e) =
+                    discard_live_session_with_mob_cleanup(service, mob_state, &session_id).await
                     && !matches!(e, SessionError::NotFound { .. })
                 {
                     eprintln!("[target] warning: discard old session {session_id}: {e}");
@@ -1264,18 +1581,47 @@ async fn switch_session(
 
 /// Create or resume a session and register it with the runtime adapter.
 async fn setup_session(
-    surface: &TargetRuntimeSurface,
+    service: &Arc<PersistentSessionService<FactoryAgentBuilder>>,
+    runtime_adapter: &Arc<RuntimeSessionAdapter>,
     resume_id: Option<SessionId>,
     model: &str,
     system_prompt: &str,
+    mob_state: &Arc<MobMcpState>,
     provider: &str,
 ) -> anyhow::Result<SessionId> {
+    let resume_session = match &resume_id {
+        Some(id) => {
+            let loaded = service
+                .load_persisted(id)
+                .await
+                .map_err(|e| anyhow::anyhow!("load session {id}: {e}"))?;
+            Some(loaded.ok_or_else(|| anyhow::anyhow!("session {id} not found on disk"))?)
+        }
+        None => Some(Session::new()),
+    };
+    let prepared_session = resume_session
+        .clone()
+        .ok_or_else(|| anyhow::anyhow!("target setup requires a prepared session"))?;
+    let prepared_session_id = prepared_session.id().clone();
+    let system_prompt = system_prompt.replace("{session_id}", &prepared_session_id.to_string());
+
+    // Prepare canonical runtime bindings (registers + allocates epoch in one shot).
+    let bindings = runtime_adapter
+        .prepare_bindings(prepared_session_id.clone())
+        .await
+        .map_err(|e| anyhow::anyhow!("runtime bindings: {e}"))?;
+
     // No external_tools needed — the factory composes comms tools automatically
     // from the CommsRuntime set via AgentFactory::with_comms_runtime().
-    let mut build_opts = target_session_build_template(Arc::clone(&surface.schedule_tools));
-    build_opts.provider = Some(meerkat_core::Provider::from_name(provider));
-    build_opts.comms_name = resume_id.is_none().then(|| format!("target/{}", SessionId::new()));
-    build_opts.keep_alive = true;
+    let build_opts = SessionBuildOptions {
+        provider: Some(meerkat_core::Provider::from_name(provider)),
+        override_builtins: meerkat_core::ToolCategoryOverride::Enable,
+        override_shell: meerkat_core::ToolCategoryOverride::Enable,
+        override_mob: meerkat_core::ToolCategoryOverride::Enable,
+        resume_session: Some(prepared_session),
+        runtime_build_mode: meerkat_core::RuntimeBuildMode::SessionOwned(bindings),
+        ..Default::default()
+    };
 
     let req = CreateSessionRequest {
         model: model.to_string(),
@@ -1291,42 +1637,181 @@ async fn setup_session(
         labels: None,
     };
 
-    let session = match resume_id {
-        Some(session_id) => surface
-            .service
-            .load_persisted(&session_id)
-            .await
-            .map_err(|error| anyhow::anyhow!("load session {session_id}: {error}"))?
-            .ok_or_else(|| anyhow::anyhow!("persisted session not found: {session_id}"))?,
-        None => meerkat::Session::new(),
+    let result = match service.create_session(req).await {
+        Ok(result) => result,
+        Err(error) => {
+            runtime_adapter
+                .unregister_session(&prepared_session_id)
+                .await;
+            return Err(anyhow::anyhow!("create session: {error}"));
+        }
     };
-    let keep_alive = req.build.as_ref().is_some_and(|build| build.keep_alive);
-    let result = materialize_session(
-        &surface.service,
-        &surface.runtime_adapter,
-        session,
-        req,
-        {
-            let service = Arc::clone(&surface.service);
-            let runtime_adapter = Arc::clone(&surface.runtime_adapter);
-            move |session_id| default_persistent_executor(service, runtime_adapter, session_id)
-        },
-    )
-    .await
-    .map_err(|error| anyhow::anyhow!("create session: {error}"))?;
-    meerkat::surface::configure_peer_ingress(
-        &surface.runtime_adapter,
-        &surface.service,
-        &result.session_id,
-        keep_alive,
-    )
-    .await;
+
     let session_id = result.session_id;
-    sync_session_trusted_peers_from_surface(surface, &session_id, &surface.comms_runtime).await?;
     eprintln!("[target] session ready: {session_id}");
+
+    // Create executor and register with runtime adapter for Steer support
+    let executor = Box::new(TargetCoreExecutor::new(
+        service.clone(),
+        mob_state.clone(),
+        session_id.clone(),
+    ));
+    runtime_adapter
+        .ensure_session_with_executor(session_id.clone(), executor)
+        .await;
+
+    // Configure peer ingress so the comms drain runs for this session.
+    // Without this, peer messages from delegate helpers sit in the inbox
+    // and the parent never processes them.
+    let comms_rt = service.comms_runtime(&session_id).await;
+    runtime_adapter
+        .update_peer_ingress_context(&session_id, true, comms_rt)
+        .await;
 
     Ok(session_id)
 }
+
+// ── CoreExecutor for runtime loop ────────────────────────────────────────────
+
+/// Bridges the RuntimeSessionAdapter's runtime loop to the PersistentSessionService.
+/// When the runtime loop dequeues an input (via DefaultPolicyTable routing),
+/// it calls `apply()` which translates the RunPrimitive into a `start_turn()`.
+struct TargetCoreExecutor {
+    service: Arc<PersistentSessionService<FactoryAgentBuilder>>,
+    mob_state: Arc<MobMcpState>,
+    session_id: SessionId,
+}
+
+impl TargetCoreExecutor {
+    fn new(
+        service: Arc<PersistentSessionService<FactoryAgentBuilder>>,
+        mob_state: Arc<MobMcpState>,
+        session_id: SessionId,
+    ) -> Self {
+        Self {
+            service,
+            mob_state,
+            session_id,
+        }
+    }
+}
+
+/// Extract prompt content from a `RunPrimitive`, preserving multimodal blocks.
+fn extract_prompt(primitive: &RunPrimitive) -> ContentInput {
+    match primitive {
+        RunPrimitive::StagedInput(staged) => {
+            let mut all_blocks = Vec::new();
+            for append in &staged.appends {
+                match &append.content {
+                    CoreRenderable::Text { text } => {
+                        all_blocks
+                            .push(meerkat_core::types::ContentBlock::Text { text: text.clone() });
+                    }
+                    CoreRenderable::Blocks { blocks } => {
+                        all_blocks.extend(blocks.iter().cloned());
+                    }
+                    _ => {}
+                }
+            }
+            if all_blocks.is_empty() {
+                ContentInput::Text(String::new())
+            } else if all_blocks.len() == 1 {
+                if let meerkat_core::types::ContentBlock::Text { text } = &all_blocks[0] {
+                    ContentInput::Text(text.clone())
+                } else {
+                    ContentInput::Blocks(all_blocks)
+                }
+            } else {
+                ContentInput::Blocks(all_blocks)
+            }
+        }
+        RunPrimitive::ImmediateAppend(append) => match &append.content {
+            CoreRenderable::Text { text } => ContentInput::Text(text.clone()),
+            CoreRenderable::Blocks { blocks } => ContentInput::Blocks(blocks.clone()),
+            _ => ContentInput::Text(String::new()),
+        },
+        RunPrimitive::ImmediateContextAppend(ctx) => match &ctx.content {
+            CoreRenderable::Text { text } => ContentInput::Text(text.clone()),
+            CoreRenderable::Blocks { blocks } => ContentInput::Blocks(blocks.clone()),
+            _ => ContentInput::Text(String::new()),
+        },
+        _ => ContentInput::Text(String::new()),
+    }
+}
+
+#[async_trait::async_trait]
+impl CoreExecutor for TargetCoreExecutor {
+    async fn apply(
+        &mut self,
+        run_id: RunId,
+        primitive: RunPrimitive,
+    ) -> Result<CoreApplyOutput, CoreExecutorError> {
+        let prompt = extract_prompt(&primitive);
+
+        let req = StartTurnRequest {
+            prompt,
+            system_prompt: None,
+            render_metadata: None,
+            handling_mode: HandlingMode::Queue,
+            event_tx: None,
+            skill_references: primitive
+                .turn_metadata()
+                .and_then(|meta| meta.skill_references.clone()),
+            flow_tool_overlay: primitive
+                .turn_metadata()
+                .and_then(|meta| meta.flow_tool_overlay.clone()),
+            additional_instructions: primitive
+                .turn_metadata()
+                .and_then(|meta| meta.additional_instructions.clone()),
+            execution_kind: primitive.turn_metadata().and_then(|m| m.execution_kind),
+        };
+
+        let boundary = match &primitive {
+            RunPrimitive::StagedInput(staged) => staged.boundary,
+            _ => RunApplyBoundary::Immediate,
+        };
+        let input_ids = primitive.contributing_input_ids().to_vec();
+
+        self.service
+            .apply_runtime_turn(&self.session_id, run_id, req, boundary, input_ids)
+            .await
+            .map_err(|e| CoreExecutorError::ApplyFailed {
+                reason: e.to_string(),
+            })
+    }
+
+    async fn control(&mut self, command: RunControlCommand) -> Result<(), CoreExecutorError> {
+        match command {
+            RunControlCommand::CancelCurrentRun { .. } => {
+                self.service.interrupt(&self.session_id).await.map_err(|e| {
+                    CoreExecutorError::ControlFailed {
+                        reason: e.to_string(),
+                    }
+                })
+            }
+            RunControlCommand::StopRuntimeExecutor { .. } => {
+                let discard_result = discard_live_session_with_mob_cleanup(
+                    &self.service,
+                    &self.mob_state,
+                    &self.session_id,
+                )
+                .await;
+                runtime_adapter_unregister_noop();
+                match discard_result {
+                    Ok(()) | Err(SessionError::NotFound { .. }) => Ok(()),
+                    Err(err) => Err(CoreExecutorError::ControlFailed {
+                        reason: err.to_string(),
+                    }),
+                }
+            }
+            _ => Ok(()),
+        }
+    }
+}
+
+/// Placeholder for StopRuntimeExecutor — the target owns the adapter lifetime
+/// so explicit unregistration isn't needed during shutdown.
+fn runtime_adapter_unregister_noop() {}
 
 // ── Helpers ───────────────────────────────────────────────────────────────────
 
@@ -1370,9 +1855,22 @@ async fn run_kennel_mode(args: &[String]) -> anyhow::Result<()> {
     let session_dir = data_dir.join("sessions");
     tokio::fs::create_dir_all(&session_dir).await?;
     let surface = build_target_runtime_surface(&session_dir, Arc::clone(&comms_runtime)).await?;
+    let _schedule_host_guard = surface._schedule_host.as_ref();
+    let service = Arc::clone(&surface.service);
+    let runtime_adapter = Arc::clone(&surface.runtime_adapter);
+    let jsonl_store = Arc::clone(&surface.jsonl_store);
+    let mob_state = Arc::clone(&surface.mob_state);
     let system_prompt = SYSTEM_PROMPT.replace("{name}", &name);
-    let mut current_session_id =
-        create_or_resume_session(&surface, &model, &system_prompt, &provider).await?;
+    let mut current_session_id = create_or_resume_session(
+        &service,
+        &runtime_adapter,
+        &jsonl_store,
+        &model,
+        &system_prompt,
+        &mob_state,
+        &provider,
+    )
+    .await?;
     let mut event_forwarder: Option<tokio::task::JoinHandle<()>> = None;
     let (mut session_binding_state, _) = target_session_binding::transition(
         SessionBindingState::Unbound,
@@ -1531,9 +2029,12 @@ async fn run_kennel_mode(args: &[String]) -> anyhow::Result<()> {
                                 &mut write_half,
                                 adoption,
                                 true,
-                                &surface,
+                                &service,
+                                &runtime_adapter,
+                                &jsonl_store,
                                 &model,
                                 &system_prompt,
+                                &mob_state,
                                 &provider,
                                 &mut session_binding_state,
                                 &mut current_session_id,
@@ -1596,9 +2097,12 @@ async fn run_kennel_mode(args: &[String]) -> anyhow::Result<()> {
                                 &mut write_half,
                                 adoption,
                                 false,
-                                &surface,
+                                &service,
+                                &runtime_adapter,
+                                &jsonl_store,
                                 &model,
                                 &system_prompt,
+                                &mob_state,
                                 &provider,
                                 &mut session_binding_state,
                                 &mut current_session_id,
@@ -1669,9 +2173,12 @@ async fn run_adopted_loop(
     write_half: &mut tokio::net::tcp::OwnedWriteHalf,
     adoption: ActiveAdoption,
     attach_required: bool,
-    surface: &TargetRuntimeSurface,
+    service: &Arc<PersistentSessionService<FactoryAgentBuilder>>,
+    runtime_adapter: &Arc<RuntimeSessionAdapter>,
+    jsonl_store: &JsonlStore,
     model: &str,
     system_prompt: &str,
+    mob_state: &Arc<MobMcpState>,
     provider: &str,
     session_binding_state: &mut SessionBindingState,
     current_session_id: &mut SessionId,
@@ -1685,7 +2192,7 @@ async fn run_adopted_loop(
         old.abort();
     }
     if let Ok(handle) = spawn_event_forwarder(
-        &surface.service,
+        service,
         active_session_id(session_binding_state),
         Arc::clone(comms_runtime),
         disconnect_tx.clone(),
@@ -1705,9 +2212,12 @@ async fn run_adopted_loop(
         write_half,
         adoption,
         attach_required,
-        surface,
+        service,
+        runtime_adapter,
+        jsonl_store,
         model,
         system_prompt,
+        mob_state,
         provider,
         session_binding_state,
         current_session_id,
@@ -1734,9 +2244,12 @@ async fn run_adopted_loop_inner(
     write_half: &mut tokio::net::tcp::OwnedWriteHalf,
     adoption: ActiveAdoption,
     attach_required: bool,
-    surface: &TargetRuntimeSurface,
+    service: &Arc<PersistentSessionService<FactoryAgentBuilder>>,
+    runtime_adapter: &Arc<RuntimeSessionAdapter>,
+    jsonl_store: &JsonlStore,
     model: &str,
     system_prompt: &str,
+    mob_state: &Arc<MobMcpState>,
     provider: &str,
     session_binding_state: &mut SessionBindingState,
     current_session_id: &mut SessionId,
@@ -1771,7 +2284,7 @@ async fn run_adopted_loop_inner(
         comms_runtime,
         &effects,
         &mut heartbeat,
-        &disconnect_tx,
+        disconnect_tx,
         attachment_hint,
         attachment_hint_path,
     )
@@ -1784,7 +2297,7 @@ async fn run_adopted_loop_inner(
             comms_runtime,
             &effects,
             &mut heartbeat,
-            &disconnect_tx,
+            disconnect_tx,
             attachment_hint,
             attachment_hint_path,
         )
@@ -1796,80 +2309,64 @@ async fn run_adopted_loop_inner(
     }
 
     let mut kennel_heartbeat = tokio::time::interval(Duration::from_secs(10));
-    let mut pending_candidates = VecDeque::new();
 
     loop {
-        if let Some(candidate) = pending_candidates.pop_front() {
-            if let Some(payload) = parse_direct_control_candidate(&candidate)? {
-                match payload {
-                    DirectControlPayload::AttachAck { lease_id }
-                        if matches!(machine_state.attachment, TaState::Attaching { .. }) =>
-                    {
-                        let (s, effects) = target_kennel_control::transition(
-                            machine_state.clone(),
-                            TkcEvent::DirectAttachAck { lease_id },
-                        )
-                        .map_err(|e| anyhow::anyhow!("direct-attach-ack transition: {e}"))?;
-                        machine_state = s;
-                        let _ = apply_target_control_effects(
-                            comms_runtime,
-                            &effects,
-                            &mut heartbeat,
-                            &disconnect_tx,
-                            attachment_hint,
-                            attachment_hint_path,
-                        )
-                        .await?;
-                        continue;
-                    }
-                    other => {
-                        tracing::debug!(?other, "ignoring direct control payload at target surface");
-                        continue;
-                    }
-                }
-            }
-            match handle_target_message(
-                &candidate,
-                comms_runtime,
-                &disconnect_tx,
-                surface,
-                model,
-                system_prompt,
-                provider,
-                session_binding_state,
-                current_session_id,
-                event_forwarder,
-            )
-            .await
-            {
-                TargetLoopAction::Continue => {}
-                TargetLoopAction::ExitProcess => std::process::exit(0),
-            }
-            continue;
-        }
-
-        let inbox_notify = comms_runtime.inbox_notify();
-        let notified = inbox_notify.notified();
-        pending_candidates.extend(comms_runtime.drain_peer_input_candidates().await);
-        if !pending_candidates.is_empty() {
-            continue;
-        }
-        if comms_runtime.dismiss_received() {
-            eprintln!("[target] received DISMISS — shutting down");
-            std::process::exit(0);
-        }
-
         let poll_kennel = matches!(
             &machine_state.attachment,
             TaState::Attaching { .. } | TaState::Attached { .. }
         );
 
         tokio::select! {
-            _ = notified => {
-                pending_candidates.extend(comms_runtime.drain_peer_input_candidates().await);
-                if pending_candidates.is_empty() && comms_runtime.dismiss_received() {
-                    eprintln!("[target] received DISMISS — shutting down");
-                    std::process::exit(0);
+            msg = comms_runtime.recv_message() => {
+                let Some(msg) = msg else {
+                    if let Some(h) = heartbeat.take() { h.abort(); }
+                    let (s, effects) = target_kennel_control::transition(
+                        machine_state,
+                        TkcEvent::DirectLinkLost,
+                    )
+                    .map_err(|e| anyhow::anyhow!("direct-link-lost transition: {e}"))?;
+                    let _ = apply_target_control_effects(
+                        comms_runtime,
+                        &effects,
+                        &mut heartbeat,
+                        disconnect_tx,
+                        attachment_hint,
+                        attachment_hint_path,
+                    )
+                    .await?;
+                    if let Some(fwd) = event_forwarder.take() {
+                        fwd.abort();
+                    }
+                    return Ok(s);
+                };
+                if let Some(payload) = parse_direct_control_message(&msg)?
+                    && let DirectControlPayload::AttachAck { lease_id } = payload
+                    && matches!(machine_state.attachment, TaState::Attaching { .. })
+                {
+                    let (s, effects) = target_kennel_control::transition(
+                        machine_state.clone(),
+                        TkcEvent::DirectAttachAck { lease_id },
+                    )
+                    .map_err(|e| anyhow::anyhow!("direct-attach-ack transition: {e}"))?;
+                    machine_state = s;
+                    let _ = apply_target_control_effects(
+                        comms_runtime,
+                        &effects,
+                        &mut heartbeat,
+                        disconnect_tx,
+                        attachment_hint,
+                        attachment_hint_path,
+                    )
+                    .await?;
+                    continue;
+                }
+                match handle_target_message(
+                    &msg, comms_runtime, disconnect_tx, service, runtime_adapter,
+                    jsonl_store, model, system_prompt, mob_state, provider,
+                    session_binding_state, current_session_id, event_forwarder,
+                ).await {
+                    TargetLoopAction::Continue => {}
+                    TargetLoopAction::ExitProcess => std::process::exit(0),
                 }
             }
             // Event forwarding is handled by the dedicated event_forwarder task.
@@ -1891,7 +2388,7 @@ async fn run_adopted_loop_inner(
                         comms_runtime,
                         &effects,
                         &mut heartbeat,
-                        &disconnect_tx,
+                        disconnect_tx,
                         attachment_hint,
                         attachment_hint_path,
                     )
@@ -1921,7 +2418,7 @@ async fn run_adopted_loop_inner(
                                 comms_runtime,
                                 &effects,
                                 &mut heartbeat,
-                                &disconnect_tx,
+                                disconnect_tx,
                                 attachment_hint,
                                 attachment_hint_path,
                             )
@@ -1948,7 +2445,7 @@ async fn run_adopted_loop_inner(
                                     comms_runtime,
                                     &effects,
                                     &mut heartbeat,
-                                    &disconnect_tx,
+                                    disconnect_tx,
                                     attachment_hint,
                                     attachment_hint_path,
                                 )
@@ -1982,7 +2479,7 @@ async fn run_adopted_loop_inner(
                                     comms_runtime,
                                     &effects,
                                     &mut heartbeat,
-                                    &disconnect_tx,
+                                    disconnect_tx,
                                     attachment_hint,
                                     attachment_hint_path,
                                 )
@@ -2003,7 +2500,7 @@ async fn run_adopted_loop_inner(
                             comms_runtime,
                             &effects,
                             &mut heartbeat,
-                            &disconnect_tx,
+                            disconnect_tx,
                             attachment_hint,
                             attachment_hint_path,
                         )
@@ -2031,7 +2528,7 @@ async fn run_adopted_loop_inner(
                         comms_runtime,
                         &effects,
                         &mut heartbeat,
-                        &disconnect_tx,
+                        disconnect_tx,
                         attachment_hint,
                         attachment_hint_path,
                     )
@@ -2091,19 +2588,26 @@ mod tests {
     }
 
     use super::{
-        TargetRuntimeSurface, build_target_runtime_surface, create_target_comms_runtime,
-        discard_live_session_with_mob_cleanup, parse_provider_override, setup_session,
-        target_session_build_template,
+        TargetRuntimeSurface, TargetScheduleSessionHost, build_target_runtime_surface,
+        create_target_comms_runtime, discard_live_session_with_mob_cleanup,
+        parse_provider_override, setup_session,
     };
     use anyhow::Context as _;
-    use mdm_tux::{ProviderKind, open_example_runtime_persistence};
+    use chrono::{Duration as ChronoDuration, Utc};
+    use mdm_tux::ProviderKind;
+    use meerkat::surface::{
+        NoopScheduleMobHost, SharedScheduleTargetAdapter, SurfaceScheduleSessionHost,
+        schedule_host_supported, spawn_schedule_host,
+    };
     use meerkat::{
-        AgentFactory, FactoryAgentBuilder, LlmClient, SessionAgentBuilder, SessionService,
+        AgentFactory, CreateScheduleRequest, FactoryAgentBuilder, LlmClient, MisfirePolicy,
+        MissingTargetPolicy, OverlapPolicy, PersistenceBundle, PersistentSessionService,
+        ScheduleService, ScheduleToolDispatcher, ScheduledSessionAction, SessionAgentBuilder,
+        SessionService, SessionTargetBinding, SqliteScheduleStore, TargetBinding, TriggerSpec,
         encode_llm_client_override_for_service,
     };
     use meerkat_client::types::LlmStream;
     use meerkat_client::{LlmDoneOutcome, LlmError, LlmEvent, LlmRequest, TestClient};
-    use meerkat::{PersistentSessionService};
     use meerkat_comms::{CommsRuntime, ResolvedCommsConfig};
     use meerkat_core::Config;
     use meerkat_core::ops_lifecycle::OperationKind;
@@ -2111,14 +2615,8 @@ mod tests {
         CreateSessionRequest, InitialTurnPolicy, SessionBuildOptions, StartTurnRequest,
     };
     use meerkat_core::types::{ContentInput, HandlingMode};
-    use meerkat_mob_mcp::{AgentMobToolSurfaceFactory, MobMcpState, wire_mob_tools};
-    use meerkat_schedule::{
-        CreateScheduleRequest, MisfirePolicy, MissingTargetPolicy, OverlapPolicy,
-        ScheduleService, ScheduleToolSurface, ScheduledSessionAction, SessionTargetBinding,
-        TargetBinding, TriggerSpec,
-    };
-    use meerkat::surface::{spawn_runtime_backed_schedule_host, wire_runtime_bindings};
-    use meerkat_store::StoreAdapter;
+    use meerkat_mob_mcp::{AgentMobToolSurfaceFactory, MobMcpState};
+    use meerkat_store::{JsonlStore, MemoryBlobStore, SessionStore};
     use std::collections::{HashSet, VecDeque};
     use std::path::Path;
     use std::sync::{Arc, Mutex};
@@ -2136,6 +2634,27 @@ mod tests {
                 responses: Mutex::new(responses.into()),
             }
         }
+    }
+
+    async fn wait_for_captured_user_message(
+        capture: &CaptureClient,
+        expected: &str,
+    ) -> anyhow::Result<()> {
+        timeout(Duration::from_secs(5), async {
+            loop {
+                let matches = capture
+                    .user_messages()
+                    .into_iter()
+                    .filter(|message| message == expected)
+                    .count();
+                if matches == 1 {
+                    return Ok(());
+                }
+                tokio::time::sleep(Duration::from_millis(50)).await;
+            }
+        })
+        .await
+        .map_err(|_| anyhow::anyhow!("timed out waiting for scheduled prompt '{expected}'"))?
     }
 
     #[async_trait::async_trait]
@@ -2171,54 +2690,88 @@ mod tests {
         comms_runtime: Arc<CommsRuntime>,
         llm_client: Arc<dyn LlmClient>,
     ) -> anyhow::Result<TargetRuntimeSurface> {
-        let persistence = open_example_runtime_persistence(session_dir).await?;
-        let config = Config::default();
-        let session_store = persistence.session_store();
-        let schedule_service = ScheduleService::new(persistence.schedule_store());
-        let runtime_adapter = persistence.runtime_adapter();
-        let mut builder = FactoryAgentBuilder::new(
-            AgentFactory::new(session_dir.to_path_buf())
-                .session_store(Arc::clone(&session_store))
-                .with_comms_runtime(Arc::clone(&comms_runtime))
-                .shell(true)
-                .builtins(true)
-                .mob(true),
-            config.clone(),
-        );
+        let factory = AgentFactory::new(session_dir)
+            .shell(true)
+            .builtins(true)
+            .comms(true)
+            .schedule(true)
+            .mob(true)
+            .with_comms_runtime(comms_runtime);
+        let schedule_store = Arc::new(SqliteScheduleStore::open(
+            session_dir.join("schedule.sqlite"),
+        )?) as Arc<dyn meerkat::ScheduleStore>;
+        let schedule_service = ScheduleService::new(Arc::clone(&schedule_store));
+        let mut builder = FactoryAgentBuilder::new(factory, Config::default());
         builder.default_llm_client = Some(llm_client);
-        builder.default_session_store = Some(Arc::new(StoreAdapter::new(Arc::clone(
-            &session_store,
-        ))));
-        let builder_mob_tools_slot = Arc::clone(&builder.default_mob_tools);
-        let (store, runtime_store, blob_store) = persistence.into_parts();
-        let mut service =
-            PersistentSessionService::new(builder, 10, store, runtime_store, blob_store);
-        wire_runtime_bindings(&mut service, &runtime_adapter);
-        let service = Arc::new(service);
-        let schedule_tools: Arc<dyn meerkat_core::AgentToolDispatcher> =
-            Arc::new(ScheduleToolSurface::new(schedule_service.clone()));
-        let schedule_host = spawn_runtime_backed_schedule_host(
-            Arc::clone(&service),
-            Arc::clone(&runtime_adapter),
-            config,
-            schedule_service.clone(),
-            target_session_build_template(Arc::clone(&schedule_tools)),
-            format!("mdm-target:test:{}", session_dir.display()),
+        let mob_tools_slot = Arc::clone(&builder.default_mob_tools);
+        *builder
+            .default_schedule_tools
+            .write()
+            .unwrap_or_else(std::sync::PoisonError::into_inner) = Some(Arc::new(
+            ScheduleToolDispatcher::new(schedule_service.clone()),
+        ));
+
+        let jsonl_store = Arc::new(JsonlStore::new(session_dir.to_path_buf()));
+        jsonl_store.init().await?;
+
+        let bundle_store = JsonlStore::new(session_dir.to_path_buf());
+        bundle_store.init().await?;
+
+        let persistence = PersistenceBundle::new_with_schedule_store(
+            Arc::new(bundle_store) as Arc<dyn SessionStore>,
+            None,
+            Arc::new(MemoryBlobStore::new()),
+            schedule_store,
         );
-        let mob_state = wire_mob_tools(
-            &builder_mob_tools_slot,
+        let runtime_adapter = persistence.runtime_adapter();
+        let (session_store, runtime_store, blob_store) = persistence.into_parts();
+
+        let mut session_service =
+            PersistentSessionService::new(builder, 10, session_store, runtime_store, blob_store);
+        {
+            let adapter = runtime_adapter.clone();
+            session_service.set_runtime_bindings_provider(Arc::new(move |session_id| {
+                let adapter = adapter.clone();
+                Box::pin(async move { adapter.prepare_bindings(session_id).await.ok() })
+            }));
+        }
+        let service = Arc::new(session_service);
+        let mob_state = Arc::new(MobMcpState::new_with_runtime_adapter(
             service.clone(),
             Some(runtime_adapter.clone()),
-            None,
-        );
+        ));
+        *mob_tools_slot
+            .write()
+            .unwrap_or_else(std::sync::PoisonError::into_inner) = Some(Arc::new(
+            AgentMobToolSurfaceFactory::new(Arc::clone(&mob_state)),
+        ));
+        let schedule_host = if schedule_host_supported(schedule_service.store().kind()) {
+            let session_host: Arc<dyn SurfaceScheduleSessionHost> =
+                Arc::new(TargetScheduleSessionHost::new(
+                    service.clone(),
+                    runtime_adapter.clone(),
+                    mob_state.clone(),
+                ));
+            let shared_adapter = Arc::new(SharedScheduleTargetAdapter::new(
+                schedule_service.clone(),
+                session_host,
+                Arc::new(NoopScheduleMobHost::new(
+                    "scheduled mob targets are not enabled in mdm-target",
+                )),
+            ));
+            Some(spawn_schedule_host(
+                schedule_service,
+                shared_adapter,
+                "mdm-target-test",
+            ))
+        } else {
+            None
+        };
 
         Ok(TargetRuntimeSurface {
             service,
             runtime_adapter,
-            comms_runtime,
-            schedule_service,
-            schedule_tools,
-            session_store,
+            jsonl_store,
             mob_state,
             _schedule_host: schedule_host,
         })
@@ -2283,6 +2836,8 @@ mod tests {
         let factory = AgentFactory::new(temp.path().join("sessions"))
             .shell(true)
             .builtins(true)
+            .comms(true)
+            .schedule(true)
             .mob(true)
             .with_comms_runtime(comms_runtime);
         let builder = FactoryAgentBuilder::new(factory, Config::default());
@@ -2293,15 +2848,16 @@ mod tests {
             .unwrap_or_else(std::sync::PoisonError::into_inner) = Some(Arc::new(
             AgentMobToolSurfaceFactory::new(Arc::clone(&mob_state)),
         ));
+        *builder
+            .default_schedule_tools
+            .write()
+            .unwrap_or_else(std::sync::PoisonError::into_inner) = Some(Arc::new(
+            ScheduleToolDispatcher::new(ScheduleService::new(Arc::new(
+                SqliteScheduleStore::open(temp.path().join("schedule.sqlite")).unwrap(),
+            ))),
+        ));
 
         let capture: Arc<CaptureClient> = Arc::new(CaptureClient::default());
-        let schedule_tools: Arc<dyn meerkat_core::AgentToolDispatcher> =
-            Arc::new(ScheduleToolSurface::new(ScheduleService::new(
-                open_example_runtime_persistence(temp.path())
-                    .await
-                    .unwrap()
-                    .schedule_store(),
-            )));
 
         let req = CreateSessionRequest {
             model: "gpt-5.2".to_string(),
@@ -2317,7 +2873,6 @@ mod tests {
                 llm_client_override: Some(encode_llm_client_override_for_service(
                     capture.clone() as Arc<dyn LlmClient>
                 )),
-                external_tools: Some(schedule_tools),
                 override_builtins: meerkat_core::ToolCategoryOverride::Enable,
                 override_shell: meerkat_core::ToolCategoryOverride::Enable,
                 override_mob: meerkat_core::ToolCategoryOverride::Enable,
@@ -2339,54 +2894,55 @@ mod tests {
         assert!(!tool_names.iter().any(|name| name == "wait"));
         assert!(tool_names.iter().any(|name| name == "shell"));
         assert!(tool_names.iter().any(|name| name == "send_message"));
-        assert!(tool_names.iter().any(|name| name == "send_request"));
-        assert!(tool_names.iter().any(|name| name == "send_response"));
         assert!(tool_names.iter().any(|name| name == "peers"));
+        assert!(tool_names.iter().any(|name| name == "meerkat_schedule_create"));
+        assert!(tool_names.iter().any(|name| name == "meerkat_schedule_list"));
         assert!(tool_names.iter().any(|name| name == "delegate"));
         assert!(tool_names.iter().any(|name| name == "mob_list"));
         assert!(tool_names.iter().any(|name| name == "mob_check_member"));
-        assert!(tool_names.iter().any(|name| name == "meerkat_schedule_create"));
-        assert!(tool_names.iter().any(|name| name == "meerkat_schedule_list"));
     }
 
     #[tokio::test]
-    async fn target_schedule_host_delivers_due_prompt_to_runtime_session() {
+    async fn target_schedule_host_delivers_future_prompt_once() {
         let temp = tempfile::tempdir().unwrap();
-        let comms_runtime = create_target_comms_runtime("test-schedule", temp.path())
+        let comms_runtime = create_target_comms_runtime("test-scheduled-target", temp.path())
             .await
             .unwrap();
-        comms_runtime.upsert_trusted_peer(meerkat_comms::TrustedPeer {
-            name: "tux".into(),
-            pubkey: meerkat_comms::identity::Keypair::generate().public_key(),
-            addr: "tcp://127.0.0.1:9999".into(),
-            meta: meerkat_comms::PeerMeta::default(),
-        });
-
         let capture: Arc<CaptureClient> = Arc::new(CaptureClient::default());
-        let session_dir = temp.path().join("sessions");
+
         let surface = build_target_runtime_surface_with_client(
-            &session_dir,
+            temp.path(),
             Arc::clone(&comms_runtime),
             capture.clone() as Arc<dyn LlmClient>,
         )
         .await
         .unwrap();
-        let session_id = setup_session(&surface, None, "gpt-5.2", "test", "openai")
-            .await
-            .unwrap();
+        let session_id = setup_session(
+            &surface.service,
+            &surface.runtime_adapter,
+            None,
+            "gpt-5.2",
+            "test",
+            &surface.mob_state,
+            "openai",
+        )
+        .await
+        .unwrap();
 
-        let schedule = surface
-            .schedule_service
+        let schedule_service = ScheduleService::new(Arc::new(
+            SqliteScheduleStore::open(temp.path().join("schedule.sqlite")).unwrap(),
+        ));
+        schedule_service
             .create(CreateScheduleRequest {
-                name: Some("scheduled-target-prompt".into()),
-                description: None,
+                name: Some("scheduled-ping".into()),
+                description: Some("deliver one scheduled prompt".into()),
                 trigger: TriggerSpec::Once {
-                    due_at_utc: chrono::Utc::now() - chrono::Duration::seconds(1),
+                    due_at_utc: Utc::now() + ChronoDuration::seconds(1),
                 },
                 target: TargetBinding::session(SessionTargetBinding::ExactSession {
-                    session_id: session_id.clone(),
+                    session_id,
                     action: ScheduledSessionAction::Prompt {
-                        prompt: ContentInput::Text("scheduled hello".into()),
+                        prompt: "scheduled ping".into(),
                         system_prompt: None,
                         render_metadata: None,
                         skill_references: Vec::new(),
@@ -2396,50 +2952,16 @@ mod tests {
                 misfire_policy: MisfirePolicy::Skip,
                 overlap_policy: OverlapPolicy::SkipIfRunning,
                 missing_target_policy: MissingTargetPolicy::MarkMisfired,
-                labels: std::collections::BTreeMap::new(),
+                labels: Default::default(),
                 planning_horizon_days: Some(1),
                 planning_horizon_occurrences: Some(1),
             })
             .await
             .unwrap();
 
-        timeout(Duration::from_secs(5), async {
-            loop {
-                if capture
-                    .user_messages()
-                    .iter()
-                    .any(|message| message.contains("scheduled hello"))
-                {
-                    break;
-                }
-                tokio::time::sleep(Duration::from_millis(50)).await;
-            }
-        })
-        .await
-        .expect("scheduled prompt should reach the target session");
-
-        let occurrences = surface
-            .schedule_service
-            .list_occurrences(&schedule.schedule_id)
+        wait_for_captured_user_message(capture.as_ref(), "scheduled ping")
             .await
             .unwrap();
-        assert!(
-            occurrences.iter().any(|occurrence| {
-                matches!(
-                    &occurrence.target_snapshot,
-                    TargetBinding::Session(binding)
-                        if binding.resolved_session_id() == Some(&session_id)
-                )
-            }),
-            "scheduled occurrence should stay bound to the target session target"
-        );
-
-        surface.runtime_adapter.abort_comms_drain(&session_id).await;
-        surface.runtime_adapter.wait_comms_drain(&session_id).await;
-        discard_live_session_with_mob_cleanup(&surface.service, &surface.mob_state, &session_id)
-            .await
-            .unwrap();
-        surface.runtime_adapter.unregister_session(&session_id).await;
     }
 
     #[tokio::test]
@@ -2585,9 +3107,17 @@ mod tests {
                 .await
                 .unwrap();
 
-        let session_id = setup_session(&surface, None, "gpt-5.2", "test background shell", "openai")
-            .await
-            .unwrap();
+        let session_id = setup_session(
+            &surface.service,
+            &surface.runtime_adapter,
+            None,
+            "gpt-5.2",
+            "test background shell",
+            &surface.mob_state,
+            "openai",
+        )
+        .await
+        .unwrap();
 
         let runtime_registry = surface
             .runtime_adapter
@@ -2662,6 +3192,8 @@ mod tests {
         let factory = AgentFactory::new(temp.path().join("sessions2"))
             .shell(true)
             .builtins(true)
+            .comms(true)
+            .schedule(true)
             .mob(true)
             .with_comms_runtime(Arc::clone(&comms_runtime));
         let builder = FactoryAgentBuilder::new(factory, Config::default());
@@ -2671,15 +3203,16 @@ mod tests {
             .unwrap_or_else(std::sync::PoisonError::into_inner) = Some(Arc::new(
             AgentMobToolSurfaceFactory::new(MobMcpState::new_in_memory()),
         ));
+        *builder
+            .default_schedule_tools
+            .write()
+            .unwrap_or_else(std::sync::PoisonError::into_inner) = Some(Arc::new(
+            ScheduleToolDispatcher::new(ScheduleService::new(Arc::new(
+                SqliteScheduleStore::open(temp.path().join("sessions2-schedule.sqlite")).unwrap(),
+            ))),
+        ));
 
         let capture2: Arc<CaptureClient> = Arc::new(CaptureClient::default());
-        let schedule_tools: Arc<dyn meerkat_core::AgentToolDispatcher> =
-            Arc::new(ScheduleToolSurface::new(ScheduleService::new(
-                open_example_runtime_persistence(temp.path())
-                    .await
-                    .unwrap()
-                    .schedule_store(),
-            )));
         let req2 = CreateSessionRequest {
             model: "gpt-5.2".to_string(),
             prompt: ContentInput::Text("list tools".into()),
@@ -2694,7 +3227,6 @@ mod tests {
                 llm_client_override: Some(encode_llm_client_override_for_service(
                     capture2.clone() as Arc<dyn LlmClient>
                 )),
-                external_tools: Some(schedule_tools),
                 override_builtins: meerkat_core::ToolCategoryOverride::Enable,
                 override_shell: meerkat_core::ToolCategoryOverride::Enable,
                 override_mob: meerkat_core::ToolCategoryOverride::Enable,
@@ -2732,16 +3264,16 @@ mod tests {
             "missing comms 'send_message', got: {tool_names:?}"
         );
         assert!(
-            tool_names.iter().any(|n| n == "send_request"),
-            "missing comms 'send_request', got: {tool_names:?}"
-        );
-        assert!(
-            tool_names.iter().any(|n| n == "send_response"),
-            "missing comms 'send_response', got: {tool_names:?}"
-        );
-        assert!(
             tool_names.iter().any(|n| n == "peers"),
             "missing comms 'peers', got: {tool_names:?}"
+        );
+        assert!(
+            tool_names.iter().any(|n| n == "meerkat_schedule_create"),
+            "missing scheduler 'meerkat_schedule_create', got: {tool_names:?}"
+        );
+        assert!(
+            tool_names.iter().any(|n| n == "meerkat_schedule_list"),
+            "missing scheduler 'meerkat_schedule_list', got: {tool_names:?}"
         );
         // Mob
         assert!(
@@ -2751,14 +3283,6 @@ mod tests {
         assert!(
             tool_names.iter().any(|n| n == "mob_list"),
             "missing 'mob_list', got: {tool_names:?}"
-        );
-        assert!(
-            tool_names.iter().any(|n| n == "meerkat_schedule_create"),
-            "missing schedule 'meerkat_schedule_create', got: {tool_names:?}"
-        );
-        assert!(
-            tool_names.iter().any(|n| n == "meerkat_schedule_list"),
-            "missing schedule 'meerkat_schedule_list', got: {tool_names:?}"
         );
     }
 
@@ -2783,59 +3307,78 @@ mod tests {
         let surface = build_target_runtime_surface(&session_dir, Arc::clone(&comms_runtime))
             .await
             .unwrap();
-        let fresh_id = setup_session(&surface, None, "gpt-5.2", "test", "openai")
-            .await
-            .unwrap();
-
-        // 2. Simulate a process restart before resuming.
-        discard_live_session_with_mob_cleanup(&surface.service, &surface.mob_state, &fresh_id)
-            .await
-            .unwrap();
-        surface.runtime_adapter.unregister_session(&fresh_id).await;
-        drop(surface);
-        drop(comms_runtime);
-
-        let restart_dir = temp.path().join("resume-restart");
-        let restart_comms_runtime =
-            create_target_comms_runtime("test-resume-restart", restart_dir.as_path())
-                .await
-                .unwrap();
-        restart_comms_runtime.upsert_trusted_peer(meerkat_comms::TrustedPeer {
-            name: "tux".into(),
-            pubkey: meerkat_comms::identity::Keypair::generate().public_key(),
-            addr: "tcp://127.0.0.1:9999".into(),
-            meta: meerkat_comms::PeerMeta::default(),
-        });
-
-        let capture: Arc<CaptureClient> = Arc::new(CaptureClient::default());
-        let restart_surface = build_target_runtime_surface_with_client(
-            &session_dir,
-            Arc::clone(&restart_comms_runtime),
-            capture.clone() as Arc<dyn LlmClient>,
+        let fresh_id = setup_session(
+            &surface.service,
+            &surface.runtime_adapter,
+            None,
+            "gpt-5.2",
+            "test",
+            &surface.mob_state,
+            "openai",
         )
         .await
         .unwrap();
-        let resumed_id = setup_session(&restart_surface, Some(fresh_id.clone()), "gpt-5.2", "test", "openai")
-            .await
-            .unwrap();
-        assert_eq!(resumed_id, fresh_id);
 
-        restart_surface
+        // 2. Resume that session through the builder with a capture client.
+        let capture: Arc<CaptureClient> = Arc::new(CaptureClient::default());
+        let loaded = surface
             .service
-            .start_turn(
-                &resumed_id,
-                StartTurnRequest {
-                    prompt: ContentInput::Text("list tools".into()),
-                    system_prompt: None,
-                    render_metadata: None,
-                    handling_mode: HandlingMode::Queue,
-                    event_tx: None,
-                    skill_references: None,
-                    flow_tool_overlay: None,
-                    additional_instructions: None,
-                    execution_kind: None,
-                },
-            )
+            .load_persisted(&fresh_id)
+            .await
+            .unwrap()
+            .unwrap();
+
+        let factory = AgentFactory::new(temp.path().join("sessions2"))
+            .shell(true)
+            .builtins(true)
+            .comms(true)
+            .schedule(true)
+            .mob(true)
+            .with_comms_runtime(Arc::clone(&comms_runtime));
+        let builder = FactoryAgentBuilder::new(factory, Config::default());
+        *builder
+            .default_mob_tools
+            .write()
+            .unwrap_or_else(std::sync::PoisonError::into_inner) = Some(Arc::new(
+            AgentMobToolSurfaceFactory::new(MobMcpState::new_in_memory()),
+        ));
+        *builder
+            .default_schedule_tools
+            .write()
+            .unwrap_or_else(std::sync::PoisonError::into_inner) = Some(Arc::new(
+            ScheduleToolDispatcher::new(ScheduleService::new(Arc::new(
+                SqliteScheduleStore::open(temp.path().join("sessions2-schedule.sqlite")).unwrap(),
+            ))),
+        ));
+
+        let req = CreateSessionRequest {
+            model: "gpt-5.2".to_string(),
+            prompt: ContentInput::Text("list tools".into()),
+            render_metadata: None,
+            system_prompt: Some("test".into()),
+            max_tokens: None,
+            event_tx: None,
+            skill_references: None,
+            initial_turn: InitialTurnPolicy::Defer,
+            deferred_prompt_policy: meerkat_core::service::DeferredPromptPolicy::Discard,
+            build: Some(SessionBuildOptions {
+                llm_client_override: Some(encode_llm_client_override_for_service(
+                    capture.clone() as Arc<dyn LlmClient>
+                )),
+                override_builtins: meerkat_core::ToolCategoryOverride::Enable,
+                override_shell: meerkat_core::ToolCategoryOverride::Enable,
+                override_mob: meerkat_core::ToolCategoryOverride::Enable,
+                resume_session: Some(loaded),
+                ..Default::default()
+            }),
+            labels: None,
+        };
+
+        let (event_tx, _) = mpsc::channel(8);
+        let mut agent = builder.build_agent(&req, event_tx).await.unwrap();
+        agent
+            .agent_mut()
+            .run(ContentInput::Text("list tools".into()))
             .await
             .unwrap();
 
@@ -2857,28 +3400,12 @@ mod tests {
             "resumed session missing comms 'send_message', got: {tool_names:?}"
         );
         assert!(
-            tool_names.iter().any(|n| n == "send_request"),
-            "resumed session missing comms 'send_request', got: {tool_names:?}"
-        );
-        assert!(
-            tool_names.iter().any(|n| n == "send_response"),
-            "resumed session missing comms 'send_response', got: {tool_names:?}"
-        );
-        assert!(
-            tool_names.iter().any(|n| n == "peers"),
-            "resumed session missing comms 'peers', got: {tool_names:?}"
+            tool_names.iter().any(|n| n == "meerkat_schedule_create"),
+            "resumed session missing scheduler 'meerkat_schedule_create', got: {tool_names:?}"
         );
         assert!(
             tool_names.iter().any(|n| n == "delegate"),
             "resumed session missing mob 'delegate', got: {tool_names:?}"
-        );
-        assert!(
-            tool_names.iter().any(|n| n == "meerkat_schedule_create"),
-            "resumed session missing schedule 'meerkat_schedule_create', got: {tool_names:?}"
-        );
-        assert!(
-            tool_names.iter().any(|n| n == "meerkat_schedule_list"),
-            "resumed session missing schedule 'meerkat_schedule_list', got: {tool_names:?}"
         );
     }
 }

--- a/examples/035-mdm-tux-rs/src/bin/tux.rs
+++ b/examples/035-mdm-tux-rs/src/bin/tux.rs
@@ -27,24 +27,34 @@ use crossterm::event::{
     DisableBracketedPaste, EnableBracketedPaste, Event, KeyCode, KeyEventKind, KeyModifiers,
 };
 use meerkat::{
-    AgentEvent, AgentFactory, FactoryAgentBuilder, LlmClient, PersistentSessionService,
-    SessionError, SessionService, ToolGatewayBuilder,
+    AgentEvent, AgentFactory, FactoryAgentBuilder, LlmClient, PersistenceBundle,
+    PersistentSessionService, ScheduleService, ScheduleToolDispatcher, SqliteScheduleStore,
+};
+use meerkat::surface::{
+    NoopScheduleMobHost, ScheduledPromptDispatch, SharedScheduleTargetAdapter,
+    SurfaceScheduleSessionHost, accepted_scheduled_input_from_runtime_outcome,
+    build_dispatch_from_accepted, schedule_attempt_idempotency_key, schedule_host_supported,
+    spawn_schedule_host,
 };
 use meerkat_comms::MessageKind;
 use meerkat_comms::agent::CommsToolDispatcher;
 use meerkat_comms::agent::types::CommsContent;
-use meerkat_core::AgentToolDispatcher;
+use meerkat_core::lifecycle::RunId;
+use meerkat_core::lifecycle::core_executor::{CoreApplyOutput, CoreExecutor, CoreExecutorError};
+use meerkat_core::lifecycle::run_control::RunControlCommand;
+use meerkat_core::lifecycle::run_primitive::{RunApplyBoundary, RunPrimitive};
 use meerkat_core::service::{
-    CreateSessionRequest, DeferredPromptPolicy, InitialTurnPolicy, SessionBuildOptions,
+    CreateSessionRequest, InitialTurnPolicy, SessionBuildOptions, SessionError, SessionService,
     StartTurnRequest,
 };
 use meerkat_core::types::{ContentInput, HandlingMode, SessionId};
-use meerkat_schedule::{ScheduleService, ScheduleToolSurface};
-use meerkat::surface::{
-    default_persistent_executor, materialize_session, spawn_runtime_backed_schedule_host,
-    wire_runtime_bindings,
+use meerkat_core::{AgentToolDispatcher, Config, Session, ToolCategoryOverride};
+use meerkat_mob_mcp::{AgentMobToolSurfaceFactory, MobMcpState};
+use meerkat_runtime::{
+    CorrelationId, IdempotencyKey, Input, InputOrigin, PromptInput, RuntimeSessionAdapter,
 };
-use meerkat_store::StoreAdapter;
+use meerkat_runtime::input::{InputDurability, InputHeader, InputVisibility};
+use meerkat_store::{JsonlStore, MemoryBlobStore, SessionStore};
 use ratatui::layout::{Constraint, Direction, Layout};
 use ratatui::style::{Color, Modifier, Style};
 use ratatui::text::{Line, Span};
@@ -61,9 +71,8 @@ use mdm_tux::machines::tux_runtime_registry as runtime_registry;
 use mdm_tux::{
     ClaimGrant, CommsNode, DirectControlPayload, KennelPayload, LeaseRef, LeaseTerminationReason,
     ListScope, ProviderKind, TargetListEntry, auto_detect, build_signed_envelope,
-    direct_control_request, load_or_generate_keypair, parse_direct_control_message,
-    read_envelope, run_registration_server, open_example_runtime_persistence, verify_envelope,
-    write_envelope,
+    direct_control_request, load_or_generate_keypair, parse_direct_control_message, read_envelope,
+    run_registration_server, verify_envelope, write_envelope,
 };
 use tokio::io::BufReader;
 use tokio::net::TcpStream;
@@ -73,35 +82,391 @@ use tokio::net::TcpStream;
 const SEND_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(10);
 
 struct HiveAgentState {
-    service: Arc<PersistentSessionService<FactoryAgentBuilder>>,
+    _service: Arc<PersistentSessionService<FactoryAgentBuilder>>,
+    runtime_adapter: Arc<RuntimeSessionAdapter>,
     session_id: SessionId,
+    _mob_state: Arc<MobMcpState>,
     _schedule_host: Option<meerkat::surface::ScheduleHostHandle>,
 }
 
 impl HiveAgentState {
-    async fn run(&self, prompt: String) -> Result<meerkat::RunResult, SessionError> {
+    async fn run(&mut self, prompt: String) -> anyhow::Result<meerkat_core::RunResult> {
+        let (_outcome, handle) = self
+            .runtime_adapter
+            .accept_input_with_completion(&self.session_id, Input::Prompt(PromptInput::new(prompt, None)))
+            .await
+            .map_err(|error| anyhow::anyhow!("runtime accept failed: {error}"))?;
+        match handle {
+            Some(handle) => match handle.wait().await {
+                meerkat_runtime::completion::CompletionOutcome::Completed(result) => Ok(result),
+                meerkat_runtime::completion::CompletionOutcome::CompletedWithoutResult => {
+                    Err(anyhow::anyhow!("turn completed without result"))
+                }
+                meerkat_runtime::completion::CompletionOutcome::CallbackPending { tool_name, .. } => {
+                    Err(anyhow::anyhow!("callback pending for tool {tool_name}"))
+                }
+                meerkat_runtime::completion::CompletionOutcome::Abandoned(reason) => {
+                    Err(anyhow::anyhow!("turn abandoned: {reason}"))
+                }
+                meerkat_runtime::completion::CompletionOutcome::RuntimeTerminated(reason) => {
+                    Err(anyhow::anyhow!("runtime terminated: {reason}"))
+                }
+            },
+            None => Err(anyhow::anyhow!("duplicate input")),
+        }
+    }
+}
+
+struct HiveCoreExecutor {
+    service: Arc<PersistentSessionService<FactoryAgentBuilder>>,
+    session_id: SessionId,
+}
+
+#[async_trait::async_trait]
+impl CoreExecutor for HiveCoreExecutor {
+    async fn apply(
+        &mut self,
+        run_id: RunId,
+        primitive: RunPrimitive,
+    ) -> Result<CoreApplyOutput, CoreExecutorError> {
+        let req = StartTurnRequest {
+            prompt: primitive.extract_content_input(),
+            system_prompt: None,
+            render_metadata: None,
+            handling_mode: HandlingMode::Queue,
+            event_tx: None,
+            skill_references: primitive
+                .turn_metadata()
+                .and_then(|meta| meta.skill_references.clone()),
+            flow_tool_overlay: primitive
+                .turn_metadata()
+                .and_then(|meta| meta.flow_tool_overlay.clone()),
+            additional_instructions: primitive
+                .turn_metadata()
+                .and_then(|meta| meta.additional_instructions.clone()),
+            execution_kind: primitive.turn_metadata().and_then(|m| m.execution_kind),
+        };
+        let boundary = match &primitive {
+            RunPrimitive::StagedInput(staged) => staged.boundary,
+            _ => RunApplyBoundary::Immediate,
+        };
+
         self.service
-            .start_turn(
+            .apply_runtime_turn(
                 &self.session_id,
-                StartTurnRequest {
-                    prompt: ContentInput::Text(prompt),
-                    system_prompt: None,
-                    render_metadata: None,
-                    handling_mode: HandlingMode::Queue,
-                    event_tx: None,
-                    skill_references: None,
-                    flow_tool_overlay: None,
-                    additional_instructions: None,
-                    execution_kind: None,
-                },
+                run_id,
+                req,
+                boundary,
+                primitive.contributing_input_ids().to_vec(),
             )
             .await
+            .map_err(|error| CoreExecutorError::ApplyFailed {
+                reason: error.to_string(),
+            })
     }
 
-    async fn shutdown(self) {
-        if let Some(schedule_host) = self._schedule_host {
-            schedule_host.shutdown().await;
+    async fn control(&mut self, command: RunControlCommand) -> Result<(), CoreExecutorError> {
+        match command {
+            RunControlCommand::CancelCurrentRun { .. } => {
+                self.service
+                    .interrupt(&self.session_id)
+                    .await
+                    .map_err(|error| CoreExecutorError::ControlFailed {
+                        reason: error.to_string(),
+                    })
+            }
+            RunControlCommand::StopRuntimeExecutor { .. } => match self
+                .service
+                .discard_live_session(&self.session_id)
+                .await
+            {
+                Ok(()) | Err(SessionError::NotFound { .. }) => Ok(()),
+                Err(error) => Err(CoreExecutorError::ControlFailed {
+                    reason: error.to_string(),
+                }),
+            },
+            _ => Ok(()),
         }
+    }
+}
+
+#[derive(Clone)]
+struct HiveScheduleSessionHost {
+    service: Arc<PersistentSessionService<FactoryAgentBuilder>>,
+    runtime_adapter: Arc<RuntimeSessionAdapter>,
+}
+
+impl HiveScheduleSessionHost {
+    async fn ensure_runtime_session_registered(
+        &self,
+        session_id: &SessionId,
+    ) -> Result<(), meerkat::ScheduleDomainError> {
+        let session_exists = self.service.read(session_id).await.is_ok()
+            || self
+                .service
+                .load_persisted(session_id)
+                .await
+                .map_err(|error| meerkat::ScheduleDomainError::Internal(error.to_string()))?
+                .is_some();
+        if !session_exists {
+            return Err(meerkat::ScheduleDomainError::InvalidSchedule(format!(
+                "session not found: {session_id}"
+            )));
+        }
+        self.runtime_adapter
+            .ensure_session_with_executor(
+                session_id.clone(),
+                Box::new(HiveCoreExecutor {
+                    service: Arc::clone(&self.service),
+                    session_id: session_id.clone(),
+                }),
+            )
+            .await;
+        Ok(())
+    }
+}
+
+fn hive_session_metadata_marks_archived(session: &Session) -> bool {
+    session
+        .metadata()
+        .get("session_archived")
+        .and_then(serde_json::Value::as_bool)
+        .unwrap_or(false)
+}
+
+fn scheduled_skill_keys(
+    skill_references: &[String],
+) -> Result<Option<Vec<meerkat_core::skills::SkillKey>>, meerkat::ScheduleDomainError> {
+    if skill_references.is_empty() {
+        return Ok(None);
+    }
+
+    skill_references
+        .iter()
+        .map(|reference| {
+            let mut parts = reference.split('/');
+            let Some(source_uuid_raw) = parts.next() else {
+                return Err(meerkat::ScheduleDomainError::InvalidSchedule(format!(
+                    "invalid scheduled skill reference: {reference}"
+                )));
+            };
+            let Some(skill_name_raw) = parts.next() else {
+                return Err(meerkat::ScheduleDomainError::InvalidSchedule(format!(
+                    "invalid scheduled skill reference: {reference}"
+                )));
+            };
+            if parts.next().is_some() {
+                return Err(meerkat::ScheduleDomainError::InvalidSchedule(format!(
+                    "invalid scheduled skill reference: {reference}"
+                )));
+            }
+            Ok(meerkat_core::skills::SkillKey {
+                source_uuid: meerkat_core::skills::SourceUuid::parse(source_uuid_raw).map_err(
+                    |_| {
+                        meerkat::ScheduleDomainError::InvalidSchedule(format!(
+                            "invalid scheduled skill reference: {reference}"
+                        ))
+                    },
+                )?,
+                skill_name: meerkat_core::skills::SkillName::parse(skill_name_raw).map_err(
+                    |_| {
+                        meerkat::ScheduleDomainError::InvalidSchedule(format!(
+                            "invalid scheduled skill reference: {reference}"
+                        ))
+                    },
+                )?,
+            })
+        })
+        .collect::<Result<Vec<_>, _>>()
+        .map(Some)
+}
+
+#[async_trait::async_trait]
+impl SurfaceScheduleSessionHost for HiveScheduleSessionHost {
+    async fn probe_session_target(
+        &self,
+        binding: &meerkat::SessionTargetBinding,
+    ) -> Result<meerkat::TargetProbeOutcome, meerkat::ScheduleDomainError> {
+        let Some(session_id) = binding.resolved_session_id() else {
+            return Ok(meerkat::TargetProbeOutcome::Ready);
+        };
+
+        if let Ok(view) = self.service.read(session_id).await {
+            return Ok(if view.state.is_active {
+                meerkat::TargetProbeOutcome::Busy {
+                    detail: Some(format!("session still running: {session_id}")),
+                }
+            } else {
+                meerkat::TargetProbeOutcome::Ready
+            });
+        }
+
+        let persisted = self
+            .service
+            .load_persisted(session_id)
+            .await
+            .map_err(|error| meerkat::ScheduleDomainError::Internal(error.to_string()))?;
+        match persisted {
+            Some(session) if !hive_session_metadata_marks_archived(&session) => {
+                Ok(meerkat::TargetProbeOutcome::Ready)
+            }
+            _ => Ok(meerkat::TargetProbeOutcome::Missing {
+                detail: Some(format!("session not found: {session_id}")),
+            }),
+        }
+    }
+
+    async fn materialize_session(
+        &self,
+        create: &meerkat::SessionMaterializationSpec,
+        prompt_system_prompt: Option<&str>,
+    ) -> Result<SessionId, meerkat::ScheduleDomainError> {
+        let session = Session::new();
+        let session_id = session.id().clone();
+        let bindings = self
+            .runtime_adapter
+            .prepare_bindings(session_id.clone())
+            .await
+            .map_err(|error| meerkat::ScheduleDomainError::Internal(error.to_string()))?;
+        let build = SessionBuildOptions {
+            provider: create.provider,
+            output_schema: create.output_schema.clone(),
+            structured_output_retries: create.structured_output_retries,
+            comms_name: create.comms_name.clone(),
+            peer_meta: create.peer_meta.clone(),
+            resume_session: Some(session),
+            provider_params: create.provider_params.clone(),
+            preload_skills: (!create.preload_skills.is_empty()).then(|| {
+                create
+                    .preload_skills
+                    .iter()
+                    .cloned()
+                    .map(Into::into)
+                    .collect()
+            }),
+            additional_instructions: (!create.additional_instructions.is_empty())
+                .then(|| create.additional_instructions.clone()),
+            realm_id: create.realm_id.clone(),
+            instance_id: create.instance_id.clone(),
+            backend: create.backend.clone(),
+            keep_alive: create.keep_alive,
+            app_context: create.app_context.clone(),
+            runtime_build_mode: meerkat_core::RuntimeBuildMode::SessionOwned(bindings),
+            ..SessionBuildOptions::default()
+        };
+        let result = self
+            .service
+            .create_session(CreateSessionRequest {
+                model: create.model.clone(),
+                prompt: ContentInput::Text(String::new()),
+                render_metadata: None,
+                system_prompt: prompt_system_prompt
+                    .map(str::to_owned)
+                    .or_else(|| create.system_prompt.clone()),
+                max_tokens: create.max_tokens,
+                event_tx: None,
+                skill_references: None,
+                initial_turn: InitialTurnPolicy::Defer,
+                deferred_prompt_policy: meerkat_core::service::DeferredPromptPolicy::Discard,
+                build: Some(build),
+                labels: Some(create.labels.clone()),
+            })
+            .await
+            .map_err(|error| meerkat::ScheduleDomainError::Internal(error.to_string()))?;
+        self.runtime_adapter
+            .ensure_session_with_executor(
+                result.session_id.clone(),
+                Box::new(HiveCoreExecutor {
+                    service: Arc::clone(&self.service),
+                    session_id: result.session_id.clone(),
+                }),
+            )
+            .await;
+        Ok(result.session_id)
+    }
+
+    async fn deliver_prompt(
+        &self,
+        session_id: &SessionId,
+        occurrence: &meerkat::Occurrence,
+        dispatch: ScheduledPromptDispatch,
+    ) -> Result<meerkat::DeliveryDispatch, meerkat::ScheduleDomainError> {
+        self.ensure_runtime_session_registered(session_id).await?;
+        let mut prompt_input = PromptInput::from_content_input(
+            dispatch.prompt,
+            Some(meerkat_core::lifecycle::run_primitive::RuntimeTurnMetadata {
+                handling_mode: None,
+                keep_alive: None,
+                skill_references: scheduled_skill_keys(&dispatch.skill_references)?,
+                flow_tool_overlay: None,
+                additional_instructions: (!dispatch.additional_instructions.is_empty())
+                    .then_some(dispatch.additional_instructions.clone()),
+                model: None,
+                provider: None,
+                provider_params: None,
+                render_metadata: dispatch.render_metadata.clone(),
+                execution_kind: None,
+            }),
+        );
+        prompt_input.header.source = InputOrigin::System;
+        prompt_input.header.idempotency_key = Some(IdempotencyKey::new(
+            schedule_attempt_idempotency_key(occurrence),
+        ));
+        prompt_input.header.correlation_id =
+            Some(CorrelationId::from_uuid(occurrence.occurrence_id.0));
+        let (outcome, handle) = self
+            .runtime_adapter
+            .accept_input_with_completion(session_id, Input::Prompt(prompt_input))
+            .await
+            .map_err(|error| meerkat::ScheduleDomainError::Internal(error.to_string()))?;
+        Ok(build_dispatch_from_accepted(
+            occurrence,
+            accepted_scheduled_input_from_runtime_outcome(outcome, handle),
+            dispatch.materialized_session_id,
+        ))
+    }
+
+    async fn deliver_event(
+        &self,
+        session_id: &SessionId,
+        occurrence: &meerkat::Occurrence,
+        event_type: String,
+        payload: serde_json::Value,
+        render_metadata: Option<meerkat_core::types::RenderMetadata>,
+        materialized_session_id: Option<SessionId>,
+    ) -> Result<meerkat::DeliveryDispatch, meerkat::ScheduleDomainError> {
+        self.ensure_runtime_session_registered(session_id).await?;
+        let input = Input::ExternalEvent(meerkat_runtime::ExternalEventInput {
+            header: InputHeader {
+                id: meerkat_core::lifecycle::InputId::new(),
+                timestamp: chrono::Utc::now(),
+                source: InputOrigin::External {
+                    source_name: format!("schedule:{}", occurrence.schedule_id),
+                },
+                durability: InputDurability::Durable,
+                visibility: InputVisibility::default(),
+                idempotency_key: Some(IdempotencyKey::new(schedule_attempt_idempotency_key(
+                    occurrence,
+                ))),
+                supersession_key: None,
+                correlation_id: Some(CorrelationId::from_uuid(occurrence.occurrence_id.0)),
+            },
+            event_type,
+            payload,
+            blocks: None,
+            handling_mode: HandlingMode::Queue,
+            render_metadata,
+        });
+        let (outcome, handle) = self
+            .runtime_adapter
+            .accept_input_with_completion(session_id, input)
+            .await
+            .map_err(|error| meerkat::ScheduleDomainError::Internal(error.to_string()))?;
+        Ok(build_dispatch_from_accepted(
+            occurrence,
+            accepted_scheduled_input_from_runtime_outcome(outcome, handle),
+            materialized_session_id,
+        ))
     }
 }
 
@@ -372,9 +737,7 @@ fn short_id(id: &str) -> String {
 }
 
 fn format_age_ms(age_ms: i64) -> String {
-    if age_ms < 0 {
-        "just now".into()
-    } else if age_ms < 1_000 {
+    if age_ms < 1_000 {
         "just now".into()
     } else if age_ms < 60_000 {
         format!("{}s ago", age_ms / 1_000)
@@ -710,9 +1073,7 @@ async fn main() -> anyhow::Result<()> {
                             .await;
                     }
                     AppCommand::ResetHive => {
-                        if let Some(hive) = hive_agent.take() {
-                            hive.shutdown().await;
-                        }
+                        hive_agent = None;
                     }
                     AppCommand::ClaimTarget { .. } | AppCommand::ReleaseTarget { .. } => {}
                     AppCommand::RunHive { prompt } => {
@@ -749,7 +1110,7 @@ async fn main() -> anyhow::Result<()> {
                                 }
                             }
                         }
-                        let agent = hive_agent.as_ref().expect("just built");
+                        let agent = hive_agent.as_mut().expect("just built");
                         let ev = match agent.run(prompt).await {
                             Ok(r) => TuiEvent::HivePlanDone(r.text),
                             Err(e) => TuiEvent::HiveError(e.to_string()),
@@ -858,95 +1219,135 @@ async fn build_hive_with_llm_override(
     trusted: Arc<parking_lot::RwLock<meerkat_comms::TrustedPeers>>,
     llm_client_override: Option<Arc<dyn LlmClient>>,
 ) -> anyhow::Result<HiveAgentState> {
-    let persistence = open_example_runtime_persistence(session_dir).await?;
-    let config = meerkat_core::Config::default();
-    let session_store = persistence.session_store();
-    let schedule_service = ScheduleService::new(persistence.schedule_store());
+    let factory = AgentFactory::new(session_dir)
+        .builtins(false)
+        .shell(false)
+        .schedule(true)
+        .mob(true);
+    let tools: Arc<dyn AgentToolDispatcher> = Arc::new(CommsToolDispatcher::new(router, trusted));
+    let schedule_store = Arc::new(SqliteScheduleStore::open(
+        session_dir.join("schedule.sqlite"),
+    )?) as Arc<dyn meerkat::ScheduleStore>;
+    let schedule_service = ScheduleService::new(Arc::clone(&schedule_store));
+
+    let jsonl_store = Arc::new(JsonlStore::new(session_dir.to_path_buf()));
+    jsonl_store.init().await?;
+    let persistence = PersistenceBundle::new_with_schedule_store(
+        Arc::clone(&jsonl_store) as Arc<dyn SessionStore>,
+        None,
+        Arc::new(MemoryBlobStore::new()),
+        schedule_store,
+    );
     let runtime_adapter = persistence.runtime_adapter();
-    let mut builder = FactoryAgentBuilder::new(
-        AgentFactory::new(session_dir.to_path_buf())
-            .session_store(Arc::clone(&session_store))
-            .mob(true),
-        config.clone(),
-    );
+    let (session_store, runtime_store, blob_store) = persistence.into_parts();
+
+    let mut builder = FactoryAgentBuilder::new(factory, Config::default());
     builder.default_llm_client = llm_client_override;
-    builder.default_session_store = Some(Arc::new(StoreAdapter::new(Arc::clone(
-        &session_store,
-    ))));
-    let (store, runtime_store, blob_store) = persistence.into_parts();
-    let mut service =
-        PersistentSessionService::new(builder, 4, store, runtime_store, blob_store);
-    wire_runtime_bindings(&mut service, &runtime_adapter);
-    let service = Arc::new(service);
-    let schedule_tools: Arc<dyn AgentToolDispatcher> =
-        Arc::new(ScheduleToolSurface::new(schedule_service.clone()));
-    let tools: Arc<dyn AgentToolDispatcher> = Arc::new(
-        ToolGatewayBuilder::new()
-            .add_dispatcher(Arc::new(CommsToolDispatcher::new(router, trusted)))
-            .add_dispatcher(Arc::clone(&schedule_tools))
-            .build()?,
+    let mob_tools_slot = Arc::clone(&builder.default_mob_tools);
+    *builder
+        .default_schedule_tools
+        .write()
+        .unwrap_or_else(std::sync::PoisonError::into_inner) = Some(Arc::new(
+        ScheduleToolDispatcher::new(schedule_service.clone()),
+    ));
+
+    let mut session_service =
+        PersistentSessionService::new(builder, 10, session_store, runtime_store, blob_store);
+    {
+        let adapter = runtime_adapter.clone();
+        session_service.set_runtime_bindings_provider(Arc::new(move |session_id| {
+            let adapter = adapter.clone();
+            Box::pin(async move { adapter.prepare_bindings(session_id).await.ok() })
+        }));
+    }
+    let service = Arc::new(session_service);
+    let mob_state = Arc::new(MobMcpState::new_with_runtime_adapter(
+        service.clone(),
+        Some(runtime_adapter.clone()),
+    ));
+    *mob_tools_slot
+        .write()
+        .unwrap_or_else(std::sync::PoisonError::into_inner) = Some(Arc::new(
+        AgentMobToolSurfaceFactory::new(Arc::clone(&mob_state)),
+    ));
+
+    let schedule_host = if schedule_host_supported(schedule_service.store().kind()) {
+        let session_host: Arc<dyn SurfaceScheduleSessionHost> =
+            Arc::new(HiveScheduleSessionHost {
+                service: service.clone(),
+                runtime_adapter: runtime_adapter.clone(),
+            });
+        let shared_adapter = Arc::new(SharedScheduleTargetAdapter::new(
+            schedule_service.clone(),
+            session_host,
+            Arc::new(NoopScheduleMobHost::new(
+                "scheduled mob targets are not enabled in mdm-tux hive",
+            )),
+        ));
+        Some(spawn_schedule_host(
+            schedule_service,
+            shared_adapter,
+            "mdm-tux-hive",
+        ))
+    } else {
+        None
+    };
+
+    let session = Session::new();
+    let session_id = session.id().clone();
+    let system_prompt = format!(
+        "You are a hive orchestrator for a fleet of remote machines. \
+         Your current session_id is '{session_id}'. If you schedule follow-up work for this same running hive session, use that exact session_id. \
+         Use the 'peers' tool to discover targets, then 'send_message' to dispatch \
+         commands. Target replies appear in the TUX output panel; the user \
+         will relay results if needed. Keep dispatches concise."
     );
-    let build_template = hive_session_build_template(Arc::clone(&tools));
-    let schedule_host = spawn_runtime_backed_schedule_host(
-        Arc::clone(&service),
-        Arc::clone(&runtime_adapter),
-        config,
-        schedule_service,
-        build_template.clone(),
-        format!("mdm-tux:hive:{}", session_dir.display()),
-    );
-    let session_id = materialize_session(
-        &service,
-        &runtime_adapter,
-        meerkat::Session::new(),
-        CreateSessionRequest {
+    let bindings = runtime_adapter
+        .prepare_bindings(session_id.clone())
+        .await
+        .map_err(|error| anyhow::anyhow!("runtime bindings: {error}"))?;
+    let create_result = service
+        .create_session(CreateSessionRequest {
             model: model.to_string(),
             prompt: ContentInput::Text(String::new()),
             render_metadata: None,
-            system_prompt: Some(
-                "You are a hive orchestrator for a fleet of remote machines. \
-                 Use the 'peers' tool to discover targets, then 'send' to dispatch \
-                 commands. Target replies appear in the TUX output panel; the user \
-                 will relay results if needed. Keep dispatches concise."
-                    .to_string(),
-            ),
+            system_prompt: Some(system_prompt),
             max_tokens: None,
             event_tx: None,
             skill_references: None,
             initial_turn: InitialTurnPolicy::Defer,
-            deferred_prompt_policy: DeferredPromptPolicy::Discard,
+            deferred_prompt_policy: meerkat_core::service::DeferredPromptPolicy::Discard,
             build: Some(SessionBuildOptions {
                 provider: Some(meerkat_core::Provider::from_name(&provider.to_string())),
-                llm_client_override: None,
-                ..build_template
+                resume_session: Some(session),
+                external_tools: Some(tools),
+                override_builtins: ToolCategoryOverride::Disable,
+                override_shell: ToolCategoryOverride::Disable,
+                override_schedule: ToolCategoryOverride::Enable,
+                override_mob: ToolCategoryOverride::Enable,
+                runtime_build_mode: meerkat_core::RuntimeBuildMode::SessionOwned(bindings),
+                ..SessionBuildOptions::default()
             }),
             labels: None,
-        },
-        {
-            let service = Arc::clone(&service);
-            let runtime_adapter = Arc::clone(&runtime_adapter);
-            move |session_id| default_persistent_executor(service, runtime_adapter, session_id)
-        },
-    )
-    .await?
-    .session_id;
+        })
+        .await?;
+    runtime_adapter
+        .ensure_session_with_executor(
+            create_result.session_id.clone(),
+            Box::new(HiveCoreExecutor {
+                service: Arc::clone(&service),
+                session_id: create_result.session_id.clone(),
+            }),
+        )
+        .await;
+
     Ok(HiveAgentState {
-        service,
-        session_id,
+        _service: service,
+        runtime_adapter,
+        session_id: create_result.session_id,
+        _mob_state: mob_state,
         _schedule_host: schedule_host,
     })
-}
-
-fn hive_session_build_template(
-    tools: Arc<dyn AgentToolDispatcher>,
-) -> SessionBuildOptions {
-    SessionBuildOptions {
-        external_tools: Some(tools),
-        override_builtins: meerkat_core::ToolCategoryOverride::Disable,
-        override_shell: meerkat_core::ToolCategoryOverride::Disable,
-        override_mob: meerkat_core::ToolCategoryOverride::Enable,
-        ..Default::default()
-    }
 }
 
 fn current_attached_target_ids(claims: &ClaimRegistry) -> Vec<String> {
@@ -1278,9 +1679,7 @@ async fn spawn_command_processor(
                 );
             }
             AppCommand::ResetHive => {
-                if let Some(hive) = hive_agent.take() {
-                    hive.shutdown().await;
-                }
+                hive_agent = None;
             }
             AppCommand::RunHive { prompt } => {
                 if hive_agent.is_none() {
@@ -1312,7 +1711,7 @@ async fn spawn_command_processor(
                         }
                     }
                 }
-                let agent = hive_agent.as_ref().expect("just built");
+                let agent = hive_agent.as_mut().expect("just built");
                 let ev = match agent.run(prompt).await {
                     Ok(r) => TuiEvent::HivePlanDone(r.text),
                     Err(e) => TuiEvent::HiveError(e.to_string()),
@@ -3309,12 +3708,39 @@ mod tests {
         is_known_slash_command, normalize_tool_text, parse_provider_override, scroll_timeline_down,
         scroll_timeline_up, timeline_max_scroll,
     };
+    use chrono::{Duration as ChronoDuration, Utc};
     use mdm_tux::ProviderKind;
-    use meerkat::LlmClient;
+    use meerkat::{
+        CreateScheduleRequest, LlmClient, MisfirePolicy, MissingTargetPolicy, OverlapPolicy,
+        ScheduleService, ScheduledSessionAction, SessionTargetBinding, SqliteScheduleStore,
+        TargetBinding, TriggerSpec,
+    };
     use meerkat_comms::identity::Keypair;
     use std::collections::{BTreeMap, HashMap, VecDeque};
     use std::sync::Arc;
     use test_support::CaptureClient;
+    use tokio::time::{Duration, timeout};
+
+    async fn wait_for_captured_user_message(
+        capture: &CaptureClient,
+        expected: &str,
+    ) -> anyhow::Result<()> {
+        timeout(Duration::from_secs(5), async {
+            loop {
+                let matches = capture
+                    .user_messages()
+                    .into_iter()
+                    .filter(|message| message == expected)
+                    .count();
+                if matches == 1 {
+                    return Ok(());
+                }
+                tokio::time::sleep(Duration::from_millis(50)).await;
+            }
+        })
+        .await
+        .map_err(|_| anyhow::anyhow!("timed out waiting for scheduled prompt '{expected}'"))?
+    }
 
     #[test]
     fn provider_override_requires_model_and_provider_together() {
@@ -3433,6 +3859,36 @@ mod tests {
         let node = mdm_tux::CommsNode::new(Keypair::generate());
         let capture: Arc<CaptureClient> = Arc::new(CaptureClient::default());
 
+        let mut hive = build_hive_with_llm_override(
+            temp.path(),
+            "gpt-5.2",
+            ProviderKind::Openai,
+            node.router.clone(),
+            node.trusted.clone(),
+            Some(capture.clone() as Arc<dyn LlmClient>),
+        )
+        .await
+        .unwrap();
+
+        hive.run("inspect hive tools".to_string().into()).await.unwrap();
+
+        let tool_names = capture.tool_names();
+        assert!(tool_names.iter().any(|name| name == "send_message"));
+        assert!(tool_names.iter().any(|name| name == "peers"));
+        assert!(tool_names.iter().any(|name| name == "meerkat_schedule_create"));
+        assert!(tool_names.iter().any(|name| name == "meerkat_schedule_list"));
+        assert!(tool_names.iter().any(|name| name == "delegate"));
+        assert!(tool_names.iter().any(|name| name == "mob_list"));
+        assert!(tool_names.iter().any(|name| name == "mob_check_member"));
+        assert!(!tool_names.iter().any(|name| name == "shell"));
+    }
+
+    #[tokio::test]
+    async fn hive_schedule_host_delivers_future_prompt_once() {
+        let temp = tempfile::tempdir().unwrap();
+        let node = mdm_tux::CommsNode::new(Keypair::generate());
+        let capture: Arc<CaptureClient> = Arc::new(CaptureClient::default());
+
         let hive = build_hive_with_llm_override(
             temp.path(),
             "gpt-5.2",
@@ -3444,20 +3900,38 @@ mod tests {
         .await
         .unwrap();
 
-        hive.run("inspect hive tools".to_string()).await.unwrap();
+        let schedule_service = ScheduleService::new(Arc::new(
+            SqliteScheduleStore::open(temp.path().join("schedule.sqlite")).unwrap(),
+        ));
+        schedule_service
+            .create(CreateScheduleRequest {
+                name: Some("scheduled-ping".into()),
+                description: Some("deliver one scheduled prompt".into()),
+                trigger: TriggerSpec::Once {
+                    due_at_utc: Utc::now() + ChronoDuration::seconds(1),
+                },
+                target: TargetBinding::session(SessionTargetBinding::ExactSession {
+                    session_id: hive.session_id.clone(),
+                    action: ScheduledSessionAction::Prompt {
+                        prompt: "scheduled ping".into(),
+                        system_prompt: None,
+                        render_metadata: None,
+                        skill_references: Vec::new(),
+                        additional_instructions: Vec::new(),
+                    },
+                }),
+                misfire_policy: MisfirePolicy::Skip,
+                overlap_policy: OverlapPolicy::SkipIfRunning,
+                missing_target_policy: MissingTargetPolicy::MarkMisfired,
+                labels: Default::default(),
+                planning_horizon_days: Some(1),
+                planning_horizon_occurrences: Some(1),
+            })
+            .await
+            .unwrap();
 
-        let tool_names = capture.tool_names();
-        assert!(tool_names.iter().any(|name| name == "send_message"));
-        assert!(tool_names.iter().any(|name| name == "send_request"));
-        assert!(tool_names.iter().any(|name| name == "send_response"));
-        assert!(tool_names.iter().any(|name| name == "peers"));
-        assert!(tool_names.iter().any(|name| name == "delegate"));
-        assert!(tool_names.iter().any(|name| name == "mob_list"));
-        assert!(tool_names.iter().any(|name| name == "mob_check_member"));
-        assert!(tool_names.iter().any(|name| name == "meerkat_schedule_create"));
-        assert!(tool_names.iter().any(|name| name == "meerkat_schedule_list"));
-        assert!(!tool_names.iter().any(|name| name == "shell"));
-
-        hive.shutdown().await;
+        wait_for_captured_user_message(capture.as_ref(), "scheduled ping")
+            .await
+            .unwrap();
     }
 }

--- a/examples/035-mdm-tux-rs/src/machines/kennel_lease.rs
+++ b/examples/035-mdm-tux-rs/src/machines/kennel_lease.rs
@@ -342,7 +342,7 @@ pub fn transition(state: State, event: Event) -> Result<(State, Vec<Effect>), Tr
                     lease_ref: LeaseRef::Known {
                         lease_id: lease_id.clone(),
                     },
-                    reason: reason.clone(),
+                    reason,
                 },
                 Effect::SendClaimReleasedToTux {
                     target_id,
@@ -511,7 +511,7 @@ pub fn transition(state: State, event: Event) -> Result<(State, Vec<Effect>), Tr
                     lease_ref: LeaseRef::Known {
                         lease_id: lease_id.clone(),
                     },
-                    reason: reason.clone(),
+                    reason,
                 },
                 Effect::SendClaimReleasedToTux {
                     target_id,
@@ -684,7 +684,7 @@ pub fn transition(state: State, event: Event) -> Result<(State, Vec<Effect>), Tr
                     lease_ref: LeaseRef::Known {
                         lease_id: lease_id.clone(),
                     },
-                    reason: reason.clone(),
+                    reason,
                 },
                 Effect::SendClaimReleasedToTux {
                     target_id,

--- a/examples/035-mdm-tux-rs/src/test_support.rs
+++ b/examples/035-mdm-tux-rs/src/test_support.rs
@@ -17,9 +17,11 @@ impl CaptureClient {
         self.seen_tools.lock().expect("capture lock").clone()
     }
 
-    #[allow(dead_code)]
     pub fn user_messages(&self) -> Vec<String> {
-        self.seen_user_messages.lock().expect("capture lock").clone()
+        self.seen_user_messages
+            .lock()
+            .expect("capture lock")
+            .clone()
     }
 }
 
@@ -29,14 +31,15 @@ impl LlmClient for CaptureClient {
     fn stream<'a>(&'a self, request: &'a LlmRequest) -> LlmStream<'a> {
         *self.seen_tools.lock().expect("capture lock") =
             request.tools.iter().map(|tool| tool.name.clone()).collect();
-        *self.seen_user_messages.lock().expect("capture lock") = request
+        let seen_user_messages = request
             .messages
             .iter()
             .filter_map(|message| match message {
-                Message::User(message) => Some(message.text_content()),
+                Message::User(user) => Some(user.text_content()),
                 _ => None,
             })
             .collect();
+        *self.seen_user_messages.lock().expect("capture lock") = seen_user_messages;
         self.inner.stream(request)
     }
 

--- a/meerkat-cli/Cargo.toml
+++ b/meerkat-cli/Cargo.toml
@@ -69,7 +69,7 @@ async-trait = { workspace = true }
 nix = { workspace = true }
 
 [features]
-default = ["anthropic", "openai", "gemini", "jsonl-store", "session-store", "skills", "comms", "mcp"]
+default = ["anthropic", "openai", "gemini", "jsonl-store", "session-store", "skills", "comms", "mcp", "schedule"]
 
 # LLM providers (forwarded to facade)
 anthropic = ["meerkat/anthropic"]
@@ -89,6 +89,7 @@ memory-store-session = ["meerkat/memory-store-session"]
 # Subsystems
 comms = ["dep:meerkat-comms", "meerkat/comms"]
 mcp = ["dep:meerkat-mcp", "meerkat/mcp"]
+schedule = ["meerkat/schedule"]
 skills = ["meerkat/skills"]
 
 integration-real-tests = []

--- a/meerkat-cli/src/main.rs
+++ b/meerkat-cli/src/main.rs
@@ -7,10 +7,17 @@ mod stream_renderer;
 
 use base64::Engine as _;
 use base64::engine::general_purpose::STANDARD as BASE64_STANDARD;
-#[cfg(feature = "comms")]
-use meerkat::surface::configure_peer_ingress;
-use meerkat::surface::{materialize_session, wire_runtime_bindings};
-use meerkat::{AgentFactory, EphemeralSessionService, FactoryAgentBuilder, PersistenceBundle};
+use chrono::Utc;
+use meerkat::surface::{
+    NoopScheduleMobHost, ScheduledPromptDispatch, SharedScheduleTargetAdapter,
+    SurfaceScheduleSessionHost, accepted_scheduled_input_from_runtime_outcome,
+    build_dispatch_from_accepted, schedule_attempt_idempotency_key, schedule_host_supported,
+    spawn_schedule_host,
+};
+use meerkat::{
+    AgentFactory, EphemeralSessionService, FactoryAgentBuilder, PersistenceBundle, ScheduleService,
+    ScheduleToolDispatcher,
+};
 use meerkat_contracts::{SessionLocator, SessionLocatorError, SkillsParams, format_session_ref};
 use meerkat_core::AgentToolDispatcher;
 #[cfg(feature = "comms")]
@@ -39,6 +46,8 @@ use meerkat_mob_pack::pack::{
 };
 use meerkat_mob_pack::targz::extract_targz_safe;
 use meerkat_mob_pack::trust::{TrustPolicy, load_trusted_signers, verify_pack_trust};
+use meerkat_runtime::input::{InputDurability, InputHeader, InputVisibility};
+use meerkat_runtime::{CorrelationId, IdempotencyKey, Input, InputOrigin, PromptInput};
 use meerkat_tools::find_project_root;
 use tokio::io::{AsyncBufRead, AsyncWrite, AsyncWriteExt, BufReader};
 use tokio::sync::mpsc;
@@ -62,8 +71,6 @@ use tokio::process::Command as TokioCommand;
 const EXIT_SUCCESS: u8 = 0;
 const EXIT_ERROR: u8 = 1;
 const EXIT_BUDGET_EXHAUSTED: u8 = 2;
-
-type BoxFuture<'a, T> = std::pin::Pin<Box<dyn std::future::Future<Output = T> + Send + 'a>>;
 
 /// Safely truncate a string to approximately `max_bytes`, respecting UTF-8 char boundaries.
 fn truncate_str(s: &str, max_bytes: usize) -> &str {
@@ -346,11 +353,14 @@ fn print_cli_callback_pending(
     Ok(())
 }
 
-async fn finalize_cli_runtime_backed_turn<T>(
+async fn finalize_cli_runtime_backed_turn<T, F>(
     output_pipeline: CliOutputPipeline,
     turn_result: anyhow::Result<T>,
-    after_sender_drop: BoxFuture<'_, anyhow::Result<()>>,
-) -> anyhow::Result<T> {
+    after_sender_drop: F,
+) -> anyhow::Result<T>
+where
+    F: std::future::Future<Output = anyhow::Result<()>>,
+{
     let shutdown_result = output_pipeline.shutdown_after(after_sender_drop).await;
     match (turn_result, shutdown_result) {
         (Ok(result), Ok(())) => Ok(result),
@@ -605,6 +615,7 @@ enum RealmBackendArg {
     #[cfg(feature = "jsonl-store")]
     Jsonl,
     Sqlite,
+    Redb,
 }
 
 impl From<RealmBackendArg> for RealmBackend {
@@ -613,6 +624,7 @@ impl From<RealmBackendArg> for RealmBackend {
             #[cfg(feature = "jsonl-store")]
             RealmBackendArg::Jsonl => RealmBackend::Jsonl,
             RealmBackendArg::Sqlite => RealmBackend::Sqlite,
+            RealmBackendArg::Redb => RealmBackend::Redb,
         }
     }
 }
@@ -2421,8 +2433,11 @@ async fn create_persistence_bundle(
 fn realm_store_path(manifest: &meerkat_store::RealmManifest, scope: &RuntimeScope) -> PathBuf {
     let paths = meerkat_store::realm_paths_in(&scope.locator.state_root, &scope.locator.realm_id);
     match manifest.backend {
+        #[cfg(feature = "jsonl-store")]
         RealmBackend::Jsonl => paths.sessions_jsonl_dir,
-        RealmBackend::Sqlite => paths.root,
+        RealmBackend::Sqlite | RealmBackend::Redb => paths.root,
+        #[cfg(not(feature = "jsonl-store"))]
+        _ => paths.root,
     }
 }
 
@@ -3001,12 +3016,16 @@ fn compose_external_tool_dispatchers(
 }
 
 /// Build an `EphemeralSessionService` backed by the factory.
-#[cfg(test)]
 fn build_cli_service(
     factory: AgentFactory,
     config: Config,
+    default_schedule_tools: Option<Arc<dyn AgentToolDispatcher>>,
 ) -> EphemeralSessionService<FactoryAgentBuilder> {
     let builder = FactoryAgentBuilder::new(factory, config);
+    *builder
+        .default_schedule_tools
+        .write()
+        .unwrap_or_else(std::sync::PoisonError::into_inner) = default_schedule_tools;
     EphemeralSessionService::new(builder, 64)
 }
 
@@ -3015,10 +3034,18 @@ async fn build_deploy_mob_session_service(
     config: Config,
 ) -> anyhow::Result<Arc<dyn meerkat_mob::MobSessionService>> {
     let (manifest, persistence) = create_persistence_bundle(scope).await?;
-    let (service, _runtime_adapter) =
-        build_cli_persistent_service_from_bundle(scope, config, manifest, persistence)?;
-    let service = Arc::new(service);
-    Ok(Arc::new(MobCliSessionService::new(service)))
+    let surface =
+        get_or_create_cli_persistent_surface_from_bundle(scope, config, manifest, persistence)?;
+    Ok(Arc::new(MobCliSessionService::new(Arc::clone(
+        &surface.service,
+    ))))
+}
+
+fn session_err_to_anyhow(e: meerkat_core::service::SessionError) -> anyhow::Error {
+    match e {
+        meerkat_core::service::SessionError::Agent(agent_err) => anyhow::Error::from(agent_err),
+        other => anyhow::anyhow!("Session service error: {other}"),
+    }
 }
 
 fn resolve_scoped_session_id(input: &str, scope: &RuntimeScope) -> anyhow::Result<SessionId> {
@@ -3209,8 +3236,6 @@ async fn run_agent(
 ) -> anyhow::Result<()> {
     let keep_alive = resolve_keep_alive(keep_alive)?;
     let effective_mob = enable_mob || config.tools.mob_enabled;
-    #[cfg(not(feature = "comms"))]
-    let _ = line_format;
     let canonical_skill_refs = canonical_skill_keys(config, skill_refs, skill_references)?;
     let flow_tool_overlay = build_flow_tool_overlay(allow_tools, block_tools);
     let run_initial_turn_during_create = flow_tool_overlay.is_none();
@@ -3257,7 +3282,8 @@ async fn run_agent(
         )
         .project_root(project_root)
         .builtins(enable_builtins)
-        .shell(enable_shell);
+        .shell(enable_shell)
+        .schedule(true);
     if let Some(context_root) = scope.context_root.clone() {
         factory = factory.context_root(context_root);
     }
@@ -3279,8 +3305,13 @@ async fn run_agent(
         config.comms.address = Some(addr.clone());
     }
 
-    let (service, runtime_adapter) =
-        compose_runtime_service_from_factory(factory, config.clone(), persistence.clone());
+    // Build the parent session service with the same explicit scheduler tools the
+    // persistent CLI surface injects on resumed/runtime-backed paths.
+    let schedule_service = ScheduleService::new(persistence.schedule_store());
+    let default_schedule_tools = Some(
+        Arc::new(ScheduleToolDispatcher::new(schedule_service)) as Arc<dyn AgentToolDispatcher>
+    );
+    let service = build_cli_service(factory, config.clone(), default_schedule_tools);
 
     if keep_alive {
         eprintln!(
@@ -3288,6 +3319,9 @@ async fn run_agent(
             if verbose { " with verbose output" } else { "" }
         );
     }
+
+    // Wrap in Arc so we can share with the stdin reader task
+    let service = Arc::new(service);
 
     let mut run_mob_tools = if effective_mob {
         let mob_persistent = get_or_create_mob_persistent_service_from_bundle(
@@ -3324,6 +3358,13 @@ async fn run_agent(
     let output_pipeline =
         CliOutputPipeline::new(stream, verbose, stream_policy.clone(), primary_scope_path)?;
 
+    // Create ephemeral runtime adapter and prepare epoch-local bindings.
+    let runtime_adapter = std::sync::Arc::new(meerkat_runtime::RuntimeSessionAdapter::ephemeral());
+    let bindings = runtime_adapter
+        .prepare_bindings(session_id.clone())
+        .await
+        .map_err(|e| anyhow::anyhow!("runtime bindings: {e}"))?;
+
     let mut build = SessionBuildOptions {
         provider: Some(provider.as_core()),
         output_schema,
@@ -3331,7 +3372,7 @@ async fn run_agent(
         hooks_override,
         comms_name: comms_name.clone(),
         peer_meta: comms_overrides.peer_meta.clone(),
-        resume_session: None,
+        resume_session: Some(session),
         budget_limits: Some(limits),
         provider_params,
         external_tools,
@@ -3340,7 +3381,9 @@ async fn run_agent(
         override_builtins: meerkat_core::ToolCategoryOverride::from_effective(enable_builtins),
         override_shell: meerkat_core::ToolCategoryOverride::from_effective(enable_shell),
         override_memory: meerkat_core::ToolCategoryOverride::from_effective(enable_memory),
+        override_schedule: meerkat_core::ToolCategoryOverride::Inherit,
         override_mob: meerkat_core::ToolCategoryOverride::Inherit,
+        schedule_tools: None,
         mob_tool_authority_context: None,
         preload_skills,
         realm_id: Some(scope.locator.realm_id.clone()),
@@ -3358,7 +3401,7 @@ async fn run_agent(
             Some(instructions)
         },
         shell_env: None,
-        runtime_build_mode: meerkat_core::RuntimeBuildMode::StandaloneEphemeral,
+        runtime_build_mode: meerkat_core::RuntimeBuildMode::SessionOwned(bindings),
         resume_override_mask: Default::default(),
         call_timeout_override: Default::default(),
         blob_store_override: None,
@@ -3412,58 +3455,38 @@ async fn run_agent(
     let mut stdin_reader_handle: Option<tokio::task::JoinHandle<()>> = None;
 
     let turn_result = async {
-        let executor_event_tx = output_pipeline.event_sender();
         #[cfg(feature = "comms")]
-        let create_result = materialize_session(&service, &runtime_adapter, session, create_req, {
-            let service = Arc::clone(&service);
-            let runtime_adapter = Arc::clone(&runtime_adapter);
-            move |runtime_session_id| {
-                Box::new(CliRuntimeExecutor {
-                    service: Arc::clone(&service) as Arc<dyn meerkat_core::service::SessionService>,
-                    persistent_service: Some(Arc::clone(&service)),
-                    session_id: runtime_session_id,
-                    runtime_adapter: Arc::clone(&runtime_adapter),
-                    event_tx: executor_event_tx,
-                })
-            }
-        })
-        .await
-        .map_err(|error| anyhow::anyhow!("failed to materialize session: {error}"))?;
-        #[cfg(feature = "comms")]
-        configure_peer_ingress(
-            &runtime_adapter,
-            &service,
-            &create_result.session_id,
-            keep_alive,
-        )
-        .await;
+        let create_result = service
+            .create_session(create_req)
+            .await
+            .map_err(session_err_to_anyhow)?;
 
         #[cfg(not(feature = "comms"))]
         let create_result = {
             let _ = stdin_events;
-            materialize_session(&service, &runtime_adapter, session, create_req, {
-                let service = Arc::clone(&service);
-                let runtime_adapter = Arc::clone(&runtime_adapter);
-                move |runtime_session_id| {
-                    Box::new(CliRuntimeExecutor {
-                        service: Arc::clone(&service)
-                            as Arc<dyn meerkat_core::service::SessionService>,
-                        persistent_service: Some(Arc::clone(&service)),
-                        session_id: runtime_session_id,
-                        runtime_adapter: Arc::clone(&runtime_adapter),
-                        event_tx: executor_event_tx,
-                    })
-                }
-            })
-            .await
-            .map_err(|error| anyhow::anyhow!("failed to materialize session: {error}"))?
+            service
+                .create_session(create_req)
+                .await
+                .map_err(session_err_to_anyhow)?
         };
+
+        // Register executor and route turn through runtime adapter.
         let session_id = create_result.session_id.clone();
+        let executor = Box::new(CliRuntimeExecutor {
+            service: service.clone() as Arc<dyn meerkat_core::service::SessionService>,
+            persistent_service: None,
+            session_id: session_id.clone(),
+            runtime_adapter: runtime_adapter.clone(),
+            event_tx: output_pipeline.event_sender(),
+        });
+        runtime_adapter
+            .register_session_with_executor(session_id.clone(), executor)
+            .await;
 
         #[cfg(feature = "comms")]
         if stdin_events && keep_alive {
             stdin_reader_handle = Some(stdin_events::spawn_stdin_reader(
-                Arc::clone(&runtime_adapter),
+                runtime_adapter.clone(),
                 session_id.clone(),
                 match line_format {
                     LineFormat::Text => stdin_events::StdinLineFormat::Text,
@@ -3488,6 +3511,16 @@ async fn run_agent(
             .accept_input_with_completion(&session_id, input)
             .await
             .map_err(|err| anyhow::anyhow!("runtime accept failed: {err}"))?;
+
+        // Spawn the comms drain in keep-alive mode so inbound peer interactions are
+        // routed through the runtime adapter and automatically trigger new turns.
+        #[cfg(feature = "comms")]
+        {
+            let comms_rt = service.comms_runtime(&session_id).await;
+            runtime_adapter
+                .update_peer_ingress_context(&session_id, keep_alive, comms_rt)
+                .await;
+        }
 
         match handle {
             Some(handle) => completion_outcome_to_cli_runtime_turn_result(
@@ -3517,10 +3550,10 @@ async fn run_agent(
         eprintln!("\nShutting down...");
     }
 
-    let result = finalize_cli_runtime_backed_turn(
+    let result = Box::pin(finalize_cli_runtime_backed_turn(
         output_pipeline,
         turn_result,
-        Box::pin(async {
+        async {
             // Abort the comms drain so the CLI can exit cleanly.
             #[cfg(feature = "comms")]
             {
@@ -3544,8 +3577,8 @@ async fn run_agent(
                 mob_ctx.persist(scope).await?;
             }
             Ok(())
-        }),
-    )
+        },
+    ))
     .await?;
 
     // Output the result
@@ -3785,7 +3818,8 @@ async fn resume_session_with_llm_override(
         )
         .project_root(project_root)
         .builtins(tooling.builtins.resolve(config.tools.builtins_enabled))
-        .shell(tooling.shell.resolve(config.tools.shell_enabled));
+        .shell(tooling.shell.resolve(config.tools.shell_enabled))
+        .schedule(true);
     if let Some(context_root) = scope.context_root.clone() {
         factory = factory.context_root(context_root);
     }
@@ -3797,8 +3831,15 @@ async fn resume_session_with_llm_override(
     let factory = factory.comms(tooling.comms.resolve(config.tools.comms_enabled) || keep_alive);
 
     log_stage("build_cli_persistent_service");
-    let (service, resume_adapter) =
-        compose_runtime_service_from_factory(factory, config.clone(), persistence.clone());
+    // Build persistent session service for resume — durable runtime semantics.
+    let (persistent_service, resume_adapter) =
+        meerkat::build_persistent_service_with_runtime_adapter(
+            factory,
+            config.clone(),
+            64,
+            persistence.clone(),
+        );
+    let service = Arc::new(persistent_service);
 
     log_stage("compose_external_tool_dispatchers");
     let mut run_mob_tools = if tooling.mob.resolve(config.tools.mob_enabled) {
@@ -3836,13 +3877,19 @@ async fn resume_session_with_llm_override(
         }],
     )?;
 
+    // Prepare epoch-local bindings for the resumed session.
+    let resume_bindings = resume_adapter
+        .prepare_bindings(session_id.clone())
+        .await
+        .map_err(|e| anyhow::anyhow!("runtime bindings: {e}"))?;
+
     let mut build = SessionBuildOptions {
         provider: Some(provider_core),
         output_schema: None,
         structured_output_retries: 2,
         hooks_override,
         comms_name: comms_name.clone(),
-        resume_session: None,
+        resume_session: Some(session),
         budget_limits: budget_override,
         provider_params: merged_provider_params,
         external_tools,
@@ -3851,7 +3898,9 @@ async fn resume_session_with_llm_override(
         override_builtins: tooling.builtins,
         override_shell: tooling.shell,
         override_memory: tooling.memory,
+        override_schedule: meerkat_core::ToolCategoryOverride::Inherit,
         override_mob: meerkat_core::ToolCategoryOverride::Inherit,
+        schedule_tools: None,
         mob_tool_authority_context: None,
         preload_skills: None,
         peer_meta: stored_metadata.as_ref().and_then(|m| m.peer_meta.clone()),
@@ -3875,7 +3924,7 @@ async fn resume_session_with_llm_override(
         app_context: None,
         additional_instructions: None,
         shell_env: None,
-        runtime_build_mode: meerkat_core::RuntimeBuildMode::StandaloneEphemeral,
+        runtime_build_mode: meerkat_core::RuntimeBuildMode::SessionOwned(resume_bindings),
         resume_override_mask: ResumeOverrideMask {
             provider_params: provider_params_override,
             ..Default::default()
@@ -3893,16 +3942,12 @@ async fn resume_session_with_llm_override(
     );
 
     let turn_result = async {
-        let executor_event_tx = output_pipeline.event_sender();
         // Route through SessionService::create_session() with the resumed session
         // staged in the build config. The service builds the agent (which picks up
         // the resume_session), runs the first turn, and returns RunResult.
         log_stage("service.create_session(start)");
-        let create_result = materialize_session(
-            &service,
-            &resume_adapter,
-            session,
-            CreateSessionRequest {
+        let create_result = service
+            .create_session(CreateSessionRequest {
                 model,
                 prompt: prompt.to_string().into(),
                 render_metadata: None,
@@ -3920,32 +3965,9 @@ async fn resume_session_with_llm_override(
                 deferred_prompt_policy: DeferredPromptPolicy::Discard,
                 build: Some(build),
                 labels: None,
-            },
-            {
-                let service = Arc::clone(&service);
-                let resume_adapter = Arc::clone(&resume_adapter);
-                move |runtime_session_id| {
-                    Box::new(CliRuntimeExecutor {
-                        service: Arc::clone(&service)
-                            as Arc<dyn meerkat_core::service::SessionService>,
-                        persistent_service: Some(Arc::clone(&service)),
-                        session_id: runtime_session_id,
-                        runtime_adapter: Arc::clone(&resume_adapter),
-                        event_tx: executor_event_tx,
-                    })
-                }
-            },
-        )
-        .await
-        .map_err(|error| anyhow::anyhow!("failed to materialize session: {error}"))?;
-        #[cfg(feature = "comms")]
-        configure_peer_ingress(
-            &resume_adapter,
-            &service,
-            &create_result.session_id,
-            keep_alive,
-        )
-        .await;
+            })
+            .await
+            .map_err(session_err_to_anyhow)?;
 
         let additional_instructions = if instructions.is_empty() {
             None
@@ -3955,6 +3977,17 @@ async fn resume_session_with_llm_override(
 
         // Route through runtime adapter (same pattern as run command)
         let session_id = create_result.session_id.clone();
+        let executor = Box::new(CliRuntimeExecutor {
+            service: service.clone() as Arc<dyn meerkat_core::service::SessionService>,
+            persistent_service: Some(service.clone()),
+            session_id: session_id.clone(),
+            runtime_adapter: resume_adapter.clone(),
+            event_tx: output_pipeline.event_sender(),
+        });
+        resume_adapter
+            .register_session_with_executor(session_id.clone(), executor)
+            .await;
+
         let input = meerkat_runtime::Input::Prompt(meerkat_runtime::PromptInput::new(
             prompt.to_string(),
             Some(
@@ -3972,6 +4005,16 @@ async fn resume_session_with_llm_override(
             .await
             .map_err(|err| anyhow::anyhow!("runtime accept failed: {err}"))?;
 
+        // Spawn the comms drain in keep-alive mode so inbound peer interactions are
+        // routed through the runtime adapter and automatically trigger new turns.
+        #[cfg(feature = "comms")]
+        {
+            let comms_rt = service.comms_runtime(&session_id).await;
+            resume_adapter
+                .update_peer_ingress_context(&session_id, keep_alive, comms_rt)
+                .await;
+        }
+
         match handle {
             Some(handle) => completion_outcome_to_cli_runtime_turn_result(
                 handle.wait().await,
@@ -3987,10 +4030,10 @@ async fn resume_session_with_llm_override(
     }
     .await;
 
-    let result = finalize_cli_runtime_backed_turn(
+    let result = Box::pin(finalize_cli_runtime_backed_turn(
         output_pipeline,
         turn_result,
-        Box::pin(async {
+        async {
             // The resume turn is complete — abort the comms drain so the CLI can
             // return. Same rationale as run_agent: one-shot commands must not block.
             #[cfg(feature = "comms")]
@@ -4011,8 +4054,8 @@ async fn resume_session_with_llm_override(
                 mob_ctx.persist(scope).await?;
             }
             Ok(())
-        }),
-    )
+        },
+    ))
     .await?;
 
     // Output the result
@@ -4044,7 +4087,7 @@ async fn build_cli_persistent_service(
     scope: &RuntimeScope,
     config: Config,
 ) -> anyhow::Result<(
-    meerkat::PersistentSessionService<FactoryAgentBuilder>,
+    Arc<meerkat::PersistentSessionService<FactoryAgentBuilder>>,
     Arc<meerkat_runtime::RuntimeSessionAdapter>,
 )> {
     let (manifest, persistence) = create_persistence_bundle(scope).await?;
@@ -4057,9 +4100,27 @@ fn build_cli_persistent_service_from_bundle(
     manifest: meerkat_store::RealmManifest,
     persistence: PersistenceBundle,
 ) -> anyhow::Result<(
-    meerkat::PersistentSessionService<FactoryAgentBuilder>,
+    Arc<meerkat::PersistentSessionService<FactoryAgentBuilder>>,
     Arc<meerkat_runtime::RuntimeSessionAdapter>,
 )> {
+    let surface =
+        get_or_create_cli_persistent_surface_from_bundle(scope, config, manifest, persistence)?;
+    Ok((
+        Arc::clone(&surface.service),
+        Arc::clone(&surface.runtime_adapter),
+    ))
+}
+
+fn get_or_create_cli_persistent_surface_from_bundle(
+    scope: &RuntimeScope,
+    config: Config,
+    manifest: meerkat_store::RealmManifest,
+    persistence: PersistenceBundle,
+) -> anyhow::Result<Arc<CliPersistentSurfaceState>> {
+    if let Some(existing) = cached_cli_persistent_surface(scope)? {
+        return Ok(existing);
+    }
+
     let store = persistence.session_store();
     let store_path = persistence
         .store_path()
@@ -4077,7 +4138,8 @@ fn build_cli_persistent_service_from_bundle(
         )
         .project_root(project_root)
         .builtins(config.tools.builtins_enabled)
-        .shell(config.tools.shell_enabled);
+        .shell(config.tools.shell_enabled)
+        .schedule(true);
     if let Some(context_root) = scope.context_root.clone() {
         factory = factory.context_root(context_root);
     }
@@ -4085,24 +4147,57 @@ fn build_cli_persistent_service_from_bundle(
         factory = factory.user_config_root(user_root);
     }
 
-    let (mut service, runtime_adapter) =
-        meerkat::build_persistent_service_with_runtime_adapter(factory, config, 64, persistence);
-    wire_runtime_bindings(&mut service, &runtime_adapter);
-    Ok((service, runtime_adapter))
-}
+    let schedule_service = ScheduleService::new(persistence.schedule_store());
+    let runtime_adapter = persistence.runtime_adapter();
+    let (store, runtime_store, blob_store) = persistence.into_parts();
+    let builder = FactoryAgentBuilder::new(factory, config);
+    *builder
+        .default_schedule_tools
+        .write()
+        .unwrap_or_else(std::sync::PoisonError::into_inner) = Some(Arc::new(
+        ScheduleToolDispatcher::new(schedule_service.clone()),
+    ));
 
-fn compose_runtime_service_from_factory(
-    factory: AgentFactory,
-    config: Config,
-    persistence: PersistenceBundle,
-) -> (
-    Arc<meerkat::PersistentSessionService<FactoryAgentBuilder>>,
-    Arc<meerkat_runtime::RuntimeSessionAdapter>,
-) {
-    let (mut service, runtime_adapter) =
-        meerkat::build_persistent_service_with_runtime_adapter(factory, config, 64, persistence);
-    wire_runtime_bindings(&mut service, &runtime_adapter);
-    (Arc::new(service), runtime_adapter)
+    let mut service =
+        meerkat::PersistentSessionService::new(builder, 64, store, runtime_store, blob_store);
+    {
+        let adapter = runtime_adapter.clone();
+        service.set_runtime_bindings_provider(Arc::new(move |session_id| {
+            let adapter = adapter.clone();
+            Box::pin(async move { adapter.prepare_bindings(session_id).await.ok() })
+        }));
+    }
+
+    let service = Arc::new(service);
+    let schedule_host = if schedule_host_supported(schedule_service.store().kind()) {
+        let session_host: Arc<dyn SurfaceScheduleSessionHost> = Arc::new(CliScheduleSessionHost {
+            service: Arc::clone(&service),
+            runtime_adapter: Arc::clone(&runtime_adapter),
+        });
+        let shared_adapter = Arc::new(SharedScheduleTargetAdapter::new(
+            schedule_service.clone(),
+            session_host,
+            Arc::new(NoopScheduleMobHost::new(
+                "scheduled mob targets are not enabled in the CLI host",
+            )),
+        ));
+        Some(spawn_schedule_host(
+            schedule_service,
+            shared_adapter,
+            format!("rkat:{}", scope.locator.realm_id),
+        ))
+    } else {
+        None
+    };
+
+    remember_cli_persistent_surface(
+        scope,
+        Arc::new(CliPersistentSurfaceState {
+            service,
+            runtime_adapter,
+            _schedule_host: schedule_host,
+        }),
+    )
 }
 
 async fn handle_blob_command(command: BlobCommands, scope: &RuntimeScope) -> anyhow::Result<()> {
@@ -4136,6 +4231,356 @@ async fn handle_blob_command(command: BlobCommands, scope: &RuntimeScope) -> any
 }
 
 type CliPersistentService = meerkat::PersistentSessionService<FactoryAgentBuilder>;
+
+struct CliPersistentSurfaceState {
+    service: Arc<CliPersistentService>,
+    runtime_adapter: Arc<meerkat_runtime::RuntimeSessionAdapter>,
+    _schedule_host: Option<meerkat::surface::ScheduleHostHandle>,
+}
+
+#[derive(Clone)]
+struct CliScheduleSessionHost {
+    service: Arc<CliPersistentService>,
+    runtime_adapter: Arc<meerkat_runtime::RuntimeSessionAdapter>,
+}
+
+impl CliScheduleSessionHost {
+    fn executor(&self, session_id: SessionId) -> CliRuntimeExecutor {
+        CliRuntimeExecutor {
+            service: Arc::clone(&self.service) as Arc<dyn meerkat_core::service::SessionService>,
+            persistent_service: Some(Arc::clone(&self.service)),
+            session_id,
+            runtime_adapter: Arc::clone(&self.runtime_adapter),
+            event_tx: None,
+        }
+    }
+
+    async fn ensure_runtime_session_registered(
+        &self,
+        session_id: &SessionId,
+    ) -> Result<(), meerkat::ScheduleDomainError> {
+        let session_exists = self.service.read(session_id).await.is_ok()
+            || self
+                .service
+                .load_persisted(session_id)
+                .await
+                .map_err(|error| meerkat::ScheduleDomainError::Internal(error.to_string()))?
+                .is_some();
+        if !session_exists {
+            return Err(meerkat::ScheduleDomainError::InvalidSchedule(format!(
+                "session not found: {session_id}"
+            )));
+        }
+
+        self.runtime_adapter
+            .ensure_session_with_executor(
+                session_id.clone(),
+                Box::new(self.executor(session_id.clone())),
+            )
+            .await;
+        self.update_peer_ingress_context(session_id).await;
+        Ok(())
+    }
+
+    async fn update_peer_ingress_context(&self, session_id: &SessionId) {
+        let keep_alive = self
+            .service
+            .load_persisted(session_id)
+            .await
+            .ok()
+            .flatten()
+            .and_then(|session| {
+                session
+                    .session_metadata()
+                    .map(|metadata| metadata.keep_alive)
+            })
+            .unwrap_or(false);
+        let comms_rt = self.service.comms_runtime(session_id).await;
+        self.runtime_adapter
+            .update_peer_ingress_context(session_id, keep_alive, comms_rt)
+            .await;
+    }
+}
+
+fn cli_session_metadata_marks_archived(session: &Session) -> bool {
+    session
+        .metadata()
+        .get("session_archived")
+        .and_then(serde_json::Value::as_bool)
+        .unwrap_or(false)
+}
+
+fn scheduled_skill_keys(
+    skill_references: &[String],
+) -> Result<Option<Vec<meerkat_core::skills::SkillKey>>, meerkat::ScheduleDomainError> {
+    if skill_references.is_empty() {
+        return Ok(None);
+    }
+
+    skill_references
+        .iter()
+        .map(|reference| {
+            let mut parts = reference.split('/');
+            let Some(source_uuid_raw) = parts.next() else {
+                return Err(meerkat::ScheduleDomainError::InvalidSchedule(format!(
+                    "invalid scheduled skill reference: {reference}"
+                )));
+            };
+            let Some(skill_name_raw) = parts.next() else {
+                return Err(meerkat::ScheduleDomainError::InvalidSchedule(format!(
+                    "invalid scheduled skill reference: {reference}"
+                )));
+            };
+            if parts.next().is_some() {
+                return Err(meerkat::ScheduleDomainError::InvalidSchedule(format!(
+                    "invalid scheduled skill reference: {reference}"
+                )));
+            }
+            Ok(meerkat_core::skills::SkillKey {
+                source_uuid: meerkat_core::skills::SourceUuid::parse(source_uuid_raw).map_err(
+                    |_| {
+                        meerkat::ScheduleDomainError::InvalidSchedule(format!(
+                            "invalid scheduled skill reference: {reference}"
+                        ))
+                    },
+                )?,
+                skill_name: meerkat_core::skills::SkillName::parse(skill_name_raw).map_err(
+                    |_| {
+                        meerkat::ScheduleDomainError::InvalidSchedule(format!(
+                            "invalid scheduled skill reference: {reference}"
+                        ))
+                    },
+                )?,
+            })
+        })
+        .collect::<Result<Vec<_>, _>>()
+        .map(Some)
+}
+
+#[async_trait::async_trait]
+impl SurfaceScheduleSessionHost for CliScheduleSessionHost {
+    async fn probe_session_target(
+        &self,
+        binding: &meerkat::SessionTargetBinding,
+    ) -> Result<meerkat::TargetProbeOutcome, meerkat::ScheduleDomainError> {
+        let Some(session_id) = binding.resolved_session_id() else {
+            return Ok(meerkat::TargetProbeOutcome::Ready);
+        };
+
+        if let Ok(view) = self.service.read(session_id).await {
+            return Ok(if view.state.is_active {
+                meerkat::TargetProbeOutcome::Busy {
+                    detail: Some(format!("session still running: {session_id}")),
+                }
+            } else {
+                meerkat::TargetProbeOutcome::Ready
+            });
+        }
+
+        let persisted = self
+            .service
+            .load_persisted(session_id)
+            .await
+            .map_err(|error| meerkat::ScheduleDomainError::Internal(error.to_string()))?;
+        match persisted {
+            Some(session) if !cli_session_metadata_marks_archived(&session) => {
+                Ok(meerkat::TargetProbeOutcome::Ready)
+            }
+            _ => Ok(meerkat::TargetProbeOutcome::Missing {
+                detail: Some(format!("session not found: {session_id}")),
+            }),
+        }
+    }
+
+    async fn materialize_session(
+        &self,
+        create: &meerkat::SessionMaterializationSpec,
+        prompt_system_prompt: Option<&str>,
+    ) -> Result<SessionId, meerkat::ScheduleDomainError> {
+        let session = Session::new();
+        let session_id = session.id().clone();
+        let bindings = self
+            .runtime_adapter
+            .prepare_bindings(session_id.clone())
+            .await
+            .map_err(|error| meerkat::ScheduleDomainError::Internal(error.to_string()))?;
+
+        let build = SessionBuildOptions {
+            provider: create.provider,
+            output_schema: create.output_schema.clone(),
+            structured_output_retries: create.structured_output_retries,
+            comms_name: create.comms_name.clone(),
+            peer_meta: create.peer_meta.clone(),
+            resume_session: Some(session),
+            provider_params: create.provider_params.clone(),
+            preload_skills: (!create.preload_skills.is_empty()).then(|| {
+                create
+                    .preload_skills
+                    .iter()
+                    .cloned()
+                    .map(Into::into)
+                    .collect()
+            }),
+            additional_instructions: (!create.additional_instructions.is_empty())
+                .then(|| create.additional_instructions.clone()),
+            realm_id: create.realm_id.clone(),
+            instance_id: create.instance_id.clone(),
+            backend: create.backend.clone(),
+            keep_alive: create.keep_alive,
+            app_context: create.app_context.clone(),
+            runtime_build_mode: meerkat_core::RuntimeBuildMode::SessionOwned(bindings),
+            ..SessionBuildOptions::default()
+        };
+
+        let result = self
+            .service
+            .create_session(CreateSessionRequest {
+                model: create.model.clone(),
+                prompt: "".into(),
+                render_metadata: None,
+                system_prompt: prompt_system_prompt
+                    .map(str::to_owned)
+                    .or_else(|| create.system_prompt.clone()),
+                max_tokens: create.max_tokens,
+                event_tx: None,
+                skill_references: None,
+                initial_turn: meerkat_core::service::InitialTurnPolicy::Defer,
+                deferred_prompt_policy: DeferredPromptPolicy::Discard,
+                build: Some(build),
+                labels: Some(create.labels.clone()),
+            })
+            .await
+            .map_err(|error| meerkat::ScheduleDomainError::Internal(error.to_string()))?;
+
+        self.runtime_adapter
+            .ensure_session_with_executor(
+                result.session_id.clone(),
+                Box::new(self.executor(result.session_id.clone())),
+            )
+            .await;
+        self.update_peer_ingress_context(&result.session_id).await;
+        Ok(result.session_id)
+    }
+
+    async fn deliver_prompt(
+        &self,
+        session_id: &SessionId,
+        occurrence: &meerkat::Occurrence,
+        dispatch: ScheduledPromptDispatch,
+    ) -> Result<meerkat::DeliveryDispatch, meerkat::ScheduleDomainError> {
+        self.ensure_runtime_session_registered(session_id).await?;
+
+        let mut prompt_input = PromptInput::from_content_input(
+            dispatch.prompt,
+            Some(
+                meerkat_core::lifecycle::run_primitive::RuntimeTurnMetadata {
+                    handling_mode: None,
+                    keep_alive: None,
+                    skill_references: scheduled_skill_keys(&dispatch.skill_references)?,
+                    flow_tool_overlay: None,
+                    additional_instructions: (!dispatch.additional_instructions.is_empty())
+                        .then_some(dispatch.additional_instructions.clone()),
+                    model: None,
+                    provider: None,
+                    provider_params: None,
+                    render_metadata: dispatch.render_metadata.clone(),
+                    execution_kind: None,
+                },
+            ),
+        );
+        prompt_input.header.source = InputOrigin::System;
+        prompt_input.header.idempotency_key = Some(IdempotencyKey::new(
+            schedule_attempt_idempotency_key(occurrence),
+        ));
+        prompt_input.header.correlation_id =
+            Some(CorrelationId::from_uuid(occurrence.occurrence_id.0));
+
+        let (outcome, handle) = self
+            .runtime_adapter
+            .accept_input_with_completion(session_id, Input::Prompt(prompt_input))
+            .await
+            .map_err(|error| meerkat::ScheduleDomainError::Internal(error.to_string()))?;
+        Ok(build_dispatch_from_accepted(
+            occurrence,
+            accepted_scheduled_input_from_runtime_outcome(outcome, handle),
+            dispatch.materialized_session_id,
+        ))
+    }
+
+    async fn deliver_event(
+        &self,
+        session_id: &SessionId,
+        occurrence: &meerkat::Occurrence,
+        event_type: String,
+        payload: serde_json::Value,
+        render_metadata: Option<meerkat_core::types::RenderMetadata>,
+        materialized_session_id: Option<SessionId>,
+    ) -> Result<meerkat::DeliveryDispatch, meerkat::ScheduleDomainError> {
+        self.ensure_runtime_session_registered(session_id).await?;
+
+        let input = Input::ExternalEvent(meerkat_runtime::ExternalEventInput {
+            header: InputHeader {
+                id: meerkat_core::lifecycle::InputId::new(),
+                timestamp: Utc::now(),
+                source: InputOrigin::External {
+                    source_name: format!("schedule:{}", occurrence.schedule_id),
+                },
+                durability: InputDurability::Durable,
+                visibility: InputVisibility::default(),
+                idempotency_key: Some(IdempotencyKey::new(schedule_attempt_idempotency_key(
+                    occurrence,
+                ))),
+                supersession_key: None,
+                correlation_id: Some(CorrelationId::from_uuid(occurrence.occurrence_id.0)),
+            },
+            event_type,
+            payload,
+            blocks: None,
+            handling_mode: meerkat_core::types::HandlingMode::Queue,
+            render_metadata,
+        });
+        let (outcome, handle) = self
+            .runtime_adapter
+            .accept_input_with_completion(session_id, input)
+            .await
+            .map_err(|error| meerkat::ScheduleDomainError::Internal(error.to_string()))?;
+        Ok(build_dispatch_from_accepted(
+            occurrence,
+            accepted_scheduled_input_from_runtime_outcome(outcome, handle),
+            materialized_session_id,
+        ))
+    }
+}
+
+fn cli_persistent_surface_cache()
+-> &'static Mutex<std::collections::HashMap<String, Arc<CliPersistentSurfaceState>>> {
+    static CACHE: OnceLock<
+        Mutex<std::collections::HashMap<String, Arc<CliPersistentSurfaceState>>>,
+    > = OnceLock::new();
+    CACHE.get_or_init(|| Mutex::new(std::collections::HashMap::new()))
+}
+
+fn cached_cli_persistent_surface(
+    scope: &RuntimeScope,
+) -> anyhow::Result<Option<Arc<CliPersistentSurfaceState>>> {
+    let key = mob_persistent_service_key(scope);
+    Ok(cli_persistent_surface_cache()
+        .lock()
+        .map_err(|_| anyhow::anyhow!("cli persistent surface cache poisoned"))?
+        .get(&key)
+        .cloned())
+}
+
+fn remember_cli_persistent_surface(
+    scope: &RuntimeScope,
+    created: Arc<CliPersistentSurfaceState>,
+) -> anyhow::Result<Arc<CliPersistentSurfaceState>> {
+    let key = mob_persistent_service_key(scope);
+    let mut cache = cli_persistent_surface_cache()
+        .lock()
+        .map_err(|_| anyhow::anyhow!("cli persistent surface cache poisoned"))?;
+    Ok(cache.entry(key).or_insert(created).clone())
+}
 
 fn mob_persistent_service_cache()
 -> &'static Mutex<std::collections::HashMap<String, Weak<CliPersistentService>>> {
@@ -4187,7 +4632,7 @@ fn build_mob_persistent_service_from_bundle(
 ) -> anyhow::Result<Arc<CliPersistentService>> {
     let (persistent_service, _runtime_adapter) =
         build_cli_persistent_service_from_bundle(scope, config, manifest, persistence)?;
-    remember_mob_persistent_service(scope, Arc::new(persistent_service))
+    remember_mob_persistent_service(scope, persistent_service)
 }
 
 async fn get_or_create_mob_persistent_service(
@@ -4562,7 +5007,6 @@ async fn delete_session(id: &str, scope: &RuntimeScope) -> anyhow::Result<()> {
 
     let (config, _) = load_config(scope).await?;
     let (service, _runtime_adapter) = build_cli_persistent_service(scope, config.clone()).await?;
-    let service = Arc::new(service);
 
     // Archive and clean up any session-owned mobs.
     if config.tools.mob_enabled
@@ -6222,15 +6666,15 @@ const WEB_INDEX_HTML: &str = r#"<!doctype html>
 </html>
 "#;
 
-fn execute_mob_deploy<'a>(
-    scope: &'a RuntimeScope,
-    pack: &'a std::path::Path,
-    prompt: &'a str,
+async fn execute_mob_deploy(
+    scope: &RuntimeScope,
+    pack: &std::path::Path,
+    prompt: &str,
     cli_trust_policy: Option<TrustPolicyArg>,
     surface: DeploySurfaceArg,
     cli_overrides: CliOverrides,
-) -> BoxFuture<'a, anyhow::Result<String>> {
-    execute_mob_deploy_internal(
+) -> anyhow::Result<String> {
+    Box::pin(execute_mob_deploy_internal(
         scope,
         pack,
         prompt,
@@ -6241,7 +6685,8 @@ fn execute_mob_deploy<'a>(
             rpc_io: None,
             config_observer: None,
         },
-    )
+    ))
+    .await
 }
 
 type RpcDeployIo = (
@@ -6257,105 +6702,100 @@ struct DeployInvocation {
     config_observer: Option<DeployConfigObserver>,
 }
 
-fn execute_mob_deploy_internal<'a>(
-    scope: &'a RuntimeScope,
-    pack: &'a std::path::Path,
-    prompt: &'a str,
+async fn execute_mob_deploy_internal(
+    scope: &RuntimeScope,
+    pack: &std::path::Path,
+    prompt: &str,
     invocation: DeployInvocation,
-) -> BoxFuture<'a, anyhow::Result<String>> {
-    Box::pin(async move {
-        let bytes = tokio::fs::read(pack)
-            .await
-            .map_err(|err| anyhow::anyhow!("failed reading pack '{}': {err}", pack.display()))?;
-        let files = extract_targz_safe(&bytes)
-            .map_err(|err| anyhow::anyhow!("mob deploy failed: {err}"))?;
-        let archive = MobpackArchive::from_extracted_files(&files)
-            .map_err(|err| anyhow::anyhow!("mob deploy failed: {err}"))?;
-        let digest = compute_archive_digest(&bytes)
-            .map_err(|err| anyhow::anyhow!("mob deploy failed: {err}"))?;
-        let config_trust = read_config_trust_policy(scope)?;
-        let trust_policy = resolve_trust_policy(
-            invocation.cli_trust_policy,
-            |key| std::env::var(key).ok(),
-            config_trust,
-        )?;
-        let trusted_signers = load_trusted_signers(
-            &user_trust_store_path(scope),
-            &project_trust_store_path(scope),
-        )
+) -> anyhow::Result<String> {
+    let bytes = tokio::fs::read(pack)
+        .await
+        .map_err(|err| anyhow::anyhow!("failed reading pack '{}': {err}", pack.display()))?;
+    let files =
+        extract_targz_safe(&bytes).map_err(|err| anyhow::anyhow!("mob deploy failed: {err}"))?;
+    let archive = MobpackArchive::from_extracted_files(&files)
         .map_err(|err| anyhow::anyhow!("mob deploy failed: {err}"))?;
-        let warnings = verify_pack_trust(&files, digest, trust_policy, &trusted_signers)
-            .map_err(|err| anyhow::anyhow!("mob deploy failed: {err}"))?;
-        validate_required_capabilities(
-            &archive.manifest,
-            &runtime_capabilities(invocation.surface),
-        )
+    let digest = compute_archive_digest(&bytes)
         .map_err(|err| anyhow::anyhow!("mob deploy failed: {err}"))?;
-        let effective_config = load_deploy_config_with_pack_defaults(
-            scope,
-            archive.config.get("config/defaults.toml"),
-            invocation.cli_overrides,
-        )?;
-        if let Some(observer) = invocation.config_observer.as_ref() {
-            observer(&effective_config);
-        }
+    let config_trust = read_config_trust_policy(scope)?;
+    let trust_policy = resolve_trust_policy(
+        invocation.cli_trust_policy,
+        |key| std::env::var(key).ok(),
+        config_trust,
+    )?;
+    let trusted_signers = load_trusted_signers(
+        &user_trust_store_path(scope),
+        &project_trust_store_path(scope),
+    )
+    .map_err(|err| anyhow::anyhow!("mob deploy failed: {err}"))?;
+    let warnings = verify_pack_trust(&files, digest, trust_policy, &trusted_signers)
+        .map_err(|err| anyhow::anyhow!("mob deploy failed: {err}"))?;
+    validate_required_capabilities(&archive.manifest, &runtime_capabilities(invocation.surface))
+        .map_err(|err| anyhow::anyhow!("mob deploy failed: {err}"))?;
+    let effective_config = load_deploy_config_with_pack_defaults(
+        scope,
+        archive.config.get("config/defaults.toml"),
+        invocation.cli_overrides,
+    )?;
+    if let Some(observer) = invocation.config_observer.as_ref() {
+        observer(&effective_config);
+    }
 
-        let deployed_mob_id = if matches!(invocation.surface, DeploySurfaceArg::Rpc) {
-            let (reader, writer): RpcDeployIo = invocation.rpc_io.unwrap_or_else(|| {
-                (
-                    Box::new(BufReader::new(tokio::io::stdin())),
-                    Box::new(tokio::io::stdout()),
-                )
-            });
-            run_rpc_surface(scope, effective_config, &archive, prompt, reader, writer).await?
-        } else {
-            let session_service =
-                build_deploy_mob_session_service(scope, effective_config.clone()).await?;
-            let mut builder = meerkat_mob::MobBuilder::from_mobpack(
-                archive.definition.clone(),
-                archive.skills.clone(),
-                meerkat_mob::MobStorage::in_memory(),
+    let deployed_mob_id = if matches!(invocation.surface, DeploySurfaceArg::Rpc) {
+        let (reader, writer): RpcDeployIo = invocation.rpc_io.unwrap_or_else(|| {
+            (
+                Box::new(BufReader::new(tokio::io::stdin())),
+                Box::new(tokio::io::stdout()),
             )
-            .map_err(|err| anyhow::anyhow!("mob deploy failed: {err}"))?
-            .with_session_service(session_service.clone());
-            if let Some(adapter) = session_service.runtime_adapter() {
-                builder = builder.with_runtime_adapter(adapter);
-            }
-            let handle = builder
-                .create()
-                .await
-                .map_err(|err| anyhow::anyhow!("mob deploy failed: {err}"))?;
-
-            if let Some(orchestrator) = &archive.definition.orchestrator {
-                let roster = handle.roster().await;
-                if let Some(entry) = roster.by_profile(&orchestrator.profile).next() {
-                    handle
-                        .member(&entry.meerkat_id)
-                        .await
-                        .map_err(|err| anyhow::anyhow!("mob deploy failed: {err}"))?
-                        .send(prompt.to_string(), meerkat_core::types::HandlingMode::Queue)
-                        .await
-                        .map_err(|err| anyhow::anyhow!("mob deploy failed: {err}"))?;
-                }
-            }
-
-            handle.mob_id().to_string()
-        };
-
-        let mut rendered = format!(
-            "deployed\tmob={}\tsurface={}\tprompt_bytes={}",
-            deployed_mob_id,
-            match invocation.surface {
-                DeploySurfaceArg::Cli => "cli",
-                DeploySurfaceArg::Rpc => "rpc",
-            },
-            prompt.len()
-        );
-        for warning in warnings {
-            rendered.push_str(&format!("\nwarning\t{warning}"));
+        });
+        run_rpc_surface(scope, effective_config, &archive, prompt, reader, writer).await?
+    } else {
+        let session_service =
+            build_deploy_mob_session_service(scope, effective_config.clone()).await?;
+        let mut builder = meerkat_mob::MobBuilder::from_mobpack(
+            archive.definition.clone(),
+            archive.skills.clone(),
+            meerkat_mob::MobStorage::in_memory(),
+        )
+        .map_err(|err| anyhow::anyhow!("mob deploy failed: {err}"))?
+        .with_session_service(session_service.clone());
+        if let Some(adapter) = session_service.runtime_adapter() {
+            builder = builder.with_runtime_adapter(adapter);
         }
-        Ok(rendered)
-    })
+        let handle = builder
+            .create()
+            .await
+            .map_err(|err| anyhow::anyhow!("mob deploy failed: {err}"))?;
+
+        if let Some(orchestrator) = &archive.definition.orchestrator {
+            let roster = handle.roster().await;
+            if let Some(entry) = roster.by_profile(&orchestrator.profile).next() {
+                handle
+                    .member(&entry.meerkat_id)
+                    .await
+                    .map_err(|err| anyhow::anyhow!("mob deploy failed: {err}"))?
+                    .send(prompt.to_string(), meerkat_core::types::HandlingMode::Queue)
+                    .await
+                    .map_err(|err| anyhow::anyhow!("mob deploy failed: {err}"))?;
+            }
+        }
+
+        handle.mob_id().to_string()
+    };
+
+    let mut rendered = format!(
+        "deployed\tmob={}\tsurface={}\tprompt_bytes={}",
+        deployed_mob_id,
+        match invocation.surface {
+            DeploySurfaceArg::Cli => "cli",
+            DeploySurfaceArg::Rpc => "rpc",
+        },
+        prompt.len()
+    );
+    for warning in warnings {
+        rendered.push_str(&format!("\nwarning\t{warning}"));
+    }
+    Ok(rendered)
 }
 
 fn resolve_trust_policy<F>(
@@ -6528,6 +6968,7 @@ where
                 root: paths.root.display().to_string(),
                 manifest_path: paths.manifest_path.display().to_string(),
                 config_path: paths.config_path.display().to_string(),
+                sessions_redb_path: paths.sessions_redb_path.display().to_string(),
                 sessions_sqlite_path: Some(paths.sessions_sqlite_path.display().to_string()),
                 sessions_jsonl_dir: paths.sessions_jsonl_dir.display().to_string(),
             }),
@@ -6800,7 +7241,7 @@ mod tests {
                 realm_id: realm_id.to_string(),
             },
             instance_id: None,
-            backend_hint: Some(RealmBackend::Sqlite),
+            backend_hint: Some(RealmBackend::Redb),
             origin_hint: RealmOrigin::Explicit,
             context_root: None,
             user_config_root: None,
@@ -6937,10 +7378,10 @@ mod tests {
             finalize_cli_runtime_backed_turn(
                 pipeline,
                 Err::<(), _>(anyhow::anyhow!("turn abandoned: synthetic failure")),
-                Box::pin(async {
+                async {
                     runtime_adapter.unregister_session(&session_id).await;
                     Ok(())
-                }),
+                },
             ),
         )
         .await
@@ -8498,14 +8939,14 @@ capabilities = ["definitely_missing_capability"]
             .await
             .expect("pack succeeds");
 
-        let err = Box::pin(execute_mob_deploy(
+        let err = execute_mob_deploy(
             &scope,
             &pack_out,
             "hello",
             None,
             DeploySurfaceArg::Cli,
             CliOverrides::default(),
-        ))
+        )
         .await
         .expect_err("missing capability should reject deploy");
         assert!(
@@ -8525,14 +8966,14 @@ capabilities = ["definitely_missing_capability"]
             .await
             .expect("pack succeeds");
 
-        let output = Box::pin(execute_mob_deploy(
+        let output = execute_mob_deploy(
             &scope,
             &pack_out,
             "hello",
             None,
             DeploySurfaceArg::Cli,
             CliOverrides::default(),
-        ))
+        )
         .await
         .expect("deploy should succeed");
         assert!(
@@ -8566,14 +9007,14 @@ capabilities = ["definitely_missing_capability"]
             .await
             .expect("write archive");
 
-        let err = Box::pin(execute_mob_deploy(
+        let err = execute_mob_deploy(
             &scope,
             &pack_out,
             "hello",
             None,
             DeploySurfaceArg::Cli,
             CliOverrides::default(),
-        ))
+        )
         .await
         .expect_err("missing packed skill path should fail");
         assert!(
@@ -8605,14 +9046,14 @@ capabilities = ["definitely_missing_capability"]
             .await
             .expect("write archive");
 
-        let err = Box::pin(execute_mob_deploy(
+        let err = execute_mob_deploy(
             &scope,
             &pack_out,
             "hello",
             None,
             DeploySurfaceArg::Cli,
             CliOverrides::default(),
-        ))
+        )
         .await
         .expect_err("invalid UTF-8 skill bytes should fail");
         assert!(
@@ -8689,14 +9130,14 @@ capabilities = ["definitely_missing_capability"]
             .await
             .expect("pack succeeds");
 
-        let err = Box::pin(execute_mob_deploy(
+        let err = execute_mob_deploy(
             &scope,
             &pack_out,
             "hello",
             Some(TrustPolicyArg::Strict),
             DeploySurfaceArg::Cli,
             CliOverrides::default(),
-        ))
+        )
         .await
         .expect_err("strict mode must reject unsigned pack");
         assert!(
@@ -8717,14 +9158,14 @@ capabilities = ["definitely_missing_capability"]
             .await
             .expect("pack succeeds");
 
-        let output = Box::pin(execute_mob_deploy(
+        let output = execute_mob_deploy(
             &scope,
             &pack_out,
             "hello",
             Some(TrustPolicyArg::Permissive),
             DeploySurfaceArg::Cli,
             CliOverrides::default(),
-        ))
+        )
         .await
         .expect("permissive mode should allow unsigned pack");
         assert!(
@@ -8777,14 +9218,14 @@ capabilities = ["definitely_missing_capability"]
         )
         .expect("write trusted signers");
 
-        let output = Box::pin(execute_mob_deploy(
+        let output = execute_mob_deploy(
             &scope,
             &pack_out,
             "hello",
             Some(TrustPolicyArg::Strict),
             DeploySurfaceArg::Cli,
             CliOverrides::default(),
-        ))
+        )
         .await
         .expect("strict trusted signed deploy should succeed");
         assert!(
@@ -8809,14 +9250,14 @@ capabilities = ["definitely_missing_capability"]
             .await
             .expect("pack should succeed");
 
-        let output = Box::pin(execute_mob_deploy(
+        let output = execute_mob_deploy(
             &scope,
             &pack_out,
             "hello",
             None,
             DeploySurfaceArg::Cli,
             CliOverrides::default(),
-        ))
+        )
         .await
         .expect("deploy should succeed");
 
@@ -8873,14 +9314,14 @@ capabilities = ["definitely_missing_capability"]
         )
         .expect("write trust store");
 
-        let output = Box::pin(execute_mob_deploy(
+        let output = execute_mob_deploy(
             &scope,
             &pack_out,
             "hello",
             Some(TrustPolicyArg::Strict),
             DeploySurfaceArg::Cli,
             CliOverrides::default(),
-        ))
+        )
         .await
         .expect("strict signed deploy should succeed");
 
@@ -8905,14 +9346,14 @@ capabilities = ["definitely_missing_capability"]
             .await
             .expect("pack should succeed");
 
-        let err = Box::pin(execute_mob_deploy(
+        let err = execute_mob_deploy(
             &scope,
             &pack_out,
             "hello",
             Some(TrustPolicyArg::Strict),
             DeploySurfaceArg::Cli,
             CliOverrides::default(),
-        ))
+        )
         .await
         .expect_err("strict mode must reject unsigned pack");
         assert!(
@@ -8939,14 +9380,14 @@ capabilities = ["definitely_missing_capability"]
             .await
             .expect("signed pack should succeed");
 
-        let err = Box::pin(execute_mob_deploy(
+        let err = execute_mob_deploy(
             &scope,
             &pack_out,
             "hello",
             Some(TrustPolicyArg::Strict),
             DeploySurfaceArg::Cli,
             CliOverrides::default(),
-        ))
+        )
         .await
         .expect_err("strict mode must reject unknown signer");
         assert!(
@@ -9009,14 +9450,14 @@ capabilities = ["definitely_missing_capability"]
         )
         .expect("write trust store");
 
-        let err = Box::pin(execute_mob_deploy(
+        let err = execute_mob_deploy(
             &scope,
             &tampered_pack,
             "hello",
             Some(TrustPolicyArg::Strict),
             DeploySurfaceArg::Cli,
             CliOverrides::default(),
-        ))
+        )
         .await
         .expect_err("strict mode must reject tampered content");
         assert!(
@@ -9078,14 +9519,14 @@ capabilities = ["definitely_missing_capability"]
             .await
             .expect("write archive");
 
-        let err = Box::pin(execute_mob_deploy(
+        let err = execute_mob_deploy(
             &scope,
             &bad_signature_pack,
             "hello",
             Some(TrustPolicyArg::Permissive),
             DeploySurfaceArg::Cli,
             CliOverrides::default(),
-        ))
+        )
         .await
         .expect_err("permissive mode must reject invalid signatures when present");
         assert!(
@@ -9421,7 +9862,7 @@ printf '\0\141\163\155' > "$out_dir/runtime_bg.wasm"
         let factory = AgentFactory::new(temp.path().join("sessions"))
             .builtins(true)
             .mob(true);
-        let service = Arc::new(build_cli_service(factory, Config::default()));
+        let service = Arc::new(build_cli_service(factory, Config::default(), None));
 
         // Create mob tools factory (new pattern: factory instead of external_tools)
         let mob_service: Arc<dyn meerkat_mob::MobSessionService> =
@@ -9488,6 +9929,66 @@ printf '\0\141\163\155' > "$out_dir/runtime_bg.wasm"
         assert!(system_prompt.contains("mob_list"));
         assert!(system_prompt.contains("mob_create"));
         assert!(system_prompt.contains("delegate"));
+    }
+
+    #[tokio::test]
+    async fn test_run_session_build_wires_schedule_tools_into_initial_llm_request() {
+        let temp = tempfile::tempdir().expect("tempdir must be created");
+        let factory = AgentFactory::new(temp.path().join("sessions"))
+            .builtins(true)
+            .schedule(true);
+        let schedule_service =
+            ScheduleService::new(Arc::new(meerkat::MemoryScheduleStore::default()));
+        let default_schedule_tools =
+            Some(Arc::new(ScheduleToolDispatcher::new(schedule_service))
+                as Arc<dyn AgentToolDispatcher>);
+        let service = Arc::new(build_cli_service(
+            factory,
+            Config::default(),
+            default_schedule_tools,
+        ));
+
+        let captured_tool_names = Arc::new(Mutex::new(Vec::<String>::new()));
+        let captured_system_prompt = Arc::new(Mutex::new(None::<String>));
+        let llm_override: Arc<dyn LlmClient> = Arc::new(CapturingLlmClient::new(
+            captured_tool_names.clone(),
+            captured_system_prompt,
+        ));
+
+        let req = CreateSessionRequest {
+            model: "gpt-5.4".to_string(),
+            prompt: "list tools".to_string().into(),
+            render_metadata: None,
+            system_prompt: None,
+            max_tokens: Some(32),
+            event_tx: None,
+            skill_references: None,
+            initial_turn: meerkat_core::service::InitialTurnPolicy::RunImmediately,
+            deferred_prompt_policy: DeferredPromptPolicy::Discard,
+            build: Some(SessionBuildOptions {
+                llm_client_override: Some(meerkat::encode_llm_client_override_for_service(
+                    llm_override,
+                )),
+                ..SessionBuildOptions::default()
+            }),
+            labels: None,
+        };
+
+        service
+            .create_session(req)
+            .await
+            .expect("session should run with llm override");
+
+        let names: std::collections::BTreeSet<String> = captured_tool_names
+            .lock()
+            .expect("captured tool mutex should not be poisoned")
+            .iter()
+            .cloned()
+            .collect();
+
+        assert!(names.contains("meerkat_schedule_create"));
+        assert!(names.contains("meerkat_schedule_list"));
+        assert!(names.contains("meerkat_schedule_occurrences"));
     }
 
     async fn call_tool_json(
@@ -9921,9 +10422,7 @@ printf '\0\141\163\155' > "$out_dir/runtime_bg.wasm"
         let tools = dispatcher.tools();
         let tool_names: Vec<_> = tools.iter().map(|t| t.name.as_ref()).collect();
 
-        assert!(tool_names.contains(&"send_message"));
-        assert!(tool_names.contains(&"send_request"));
-        assert!(tool_names.contains(&"send_response"));
+        assert!(tool_names.contains(&"send"));
         assert!(tool_names.contains(&"peers"));
     }
 
@@ -9938,7 +10437,7 @@ printf '\0\141\163\155' > "$out_dir/runtime_bg.wasm"
             .expect("create root");
         let manifest = serde_json::json!({
             "realm_id": realm_id,
-            "backend": "sqlite",
+            "backend": "redb",
             "created_at": "1"
         });
         tokio::fs::write(
@@ -9964,7 +10463,7 @@ printf '\0\141\163\155' > "$out_dir/runtime_bg.wasm"
         let _manifest = meerkat_store::ensure_realm_manifest_in(
             &state_root,
             realm_id,
-            Some(meerkat_store::RealmBackend::Sqlite),
+            Some(meerkat_store::RealmBackend::Redb),
             Some(meerkat_store::RealmOrigin::Generated),
         )
         .await
@@ -10000,7 +10499,7 @@ printf '\0\141\163\155' > "$out_dir/runtime_bg.wasm"
         let _manifest = meerkat_store::ensure_realm_manifest_in(
             &state_root,
             realm_id,
-            Some(meerkat_store::RealmBackend::Sqlite),
+            Some(meerkat_store::RealmBackend::Redb),
             Some(meerkat_store::RealmOrigin::Generated),
         )
         .await
@@ -10047,7 +10546,7 @@ printf '\0\141\163\155' > "$out_dir/runtime_bg.wasm"
             let (_manifest, store) = meerkat_store::open_realm_session_store_in(
                 &state_root,
                 realm_id,
-                Some(RealmBackend::Sqlite),
+                Some(RealmBackend::Redb),
                 Some(RealmOrigin::Explicit),
             )
             .await
@@ -10076,7 +10575,7 @@ printf '\0\141\163\155' > "$out_dir/runtime_bg.wasm"
                 realm_id: "test-realm".to_string(),
             },
             instance_id: None,
-            backend_hint: Some(RealmBackend::Sqlite),
+            backend_hint: Some(RealmBackend::Redb),
             origin_hint: RealmOrigin::Explicit,
             context_root: Some(root),
             user_config_root: None,

--- a/meerkat-cli/src/main.rs
+++ b/meerkat-cli/src/main.rs
@@ -615,7 +615,6 @@ enum RealmBackendArg {
     #[cfg(feature = "jsonl-store")]
     Jsonl,
     Sqlite,
-    Redb,
 }
 
 impl From<RealmBackendArg> for RealmBackend {
@@ -624,7 +623,6 @@ impl From<RealmBackendArg> for RealmBackend {
             #[cfg(feature = "jsonl-store")]
             RealmBackendArg::Jsonl => RealmBackend::Jsonl,
             RealmBackendArg::Sqlite => RealmBackend::Sqlite,
-            RealmBackendArg::Redb => RealmBackend::Redb,
         }
     }
 }
@@ -2435,7 +2433,7 @@ fn realm_store_path(manifest: &meerkat_store::RealmManifest, scope: &RuntimeScop
     match manifest.backend {
         #[cfg(feature = "jsonl-store")]
         RealmBackend::Jsonl => paths.sessions_jsonl_dir,
-        RealmBackend::Sqlite | RealmBackend::Redb => paths.root,
+        RealmBackend::Sqlite => paths.root,
         #[cfg(not(feature = "jsonl-store"))]
         _ => paths.root,
     }
@@ -6968,7 +6966,6 @@ where
                 root: paths.root.display().to_string(),
                 manifest_path: paths.manifest_path.display().to_string(),
                 config_path: paths.config_path.display().to_string(),
-                sessions_redb_path: paths.sessions_redb_path.display().to_string(),
                 sessions_sqlite_path: Some(paths.sessions_sqlite_path.display().to_string()),
                 sessions_jsonl_dir: paths.sessions_jsonl_dir.display().to_string(),
             }),
@@ -7241,7 +7238,7 @@ mod tests {
                 realm_id: realm_id.to_string(),
             },
             instance_id: None,
-            backend_hint: Some(RealmBackend::Redb),
+            backend_hint: Some(RealmBackend::Sqlite),
             origin_hint: RealmOrigin::Explicit,
             context_root: None,
             user_config_root: None,
@@ -10463,7 +10460,7 @@ printf '\0\141\163\155' > "$out_dir/runtime_bg.wasm"
         let _manifest = meerkat_store::ensure_realm_manifest_in(
             &state_root,
             realm_id,
-            Some(meerkat_store::RealmBackend::Redb),
+            Some(meerkat_store::RealmBackend::Sqlite),
             Some(meerkat_store::RealmOrigin::Generated),
         )
         .await
@@ -10499,7 +10496,7 @@ printf '\0\141\163\155' > "$out_dir/runtime_bg.wasm"
         let _manifest = meerkat_store::ensure_realm_manifest_in(
             &state_root,
             realm_id,
-            Some(meerkat_store::RealmBackend::Redb),
+            Some(meerkat_store::RealmBackend::Sqlite),
             Some(meerkat_store::RealmOrigin::Generated),
         )
         .await
@@ -10546,7 +10543,7 @@ printf '\0\141\163\155' > "$out_dir/runtime_bg.wasm"
             let (_manifest, store) = meerkat_store::open_realm_session_store_in(
                 &state_root,
                 realm_id,
-                Some(RealmBackend::Redb),
+                Some(RealmBackend::Sqlite),
                 Some(RealmOrigin::Explicit),
             )
             .await
@@ -10575,7 +10572,7 @@ printf '\0\141\163\155' > "$out_dir/runtime_bg.wasm"
                 realm_id: "test-realm".to_string(),
             },
             instance_id: None,
-            backend_hint: Some(RealmBackend::Redb),
+            backend_hint: Some(RealmBackend::Sqlite),
             origin_hint: RealmOrigin::Explicit,
             context_root: Some(root),
             user_config_root: None,

--- a/meerkat-core/src/service/mod.rs
+++ b/meerkat-core/src/service/mod.rs
@@ -198,7 +198,14 @@ pub struct SessionBuildOptions {
     pub override_builtins: ToolCategoryOverride,
     pub override_shell: ToolCategoryOverride,
     pub override_memory: ToolCategoryOverride,
+    /// Per-build override for the factory-level scheduler capability.
+    pub override_schedule: ToolCategoryOverride,
     pub override_mob: ToolCategoryOverride,
+    /// Agent-facing scheduler tools supplied by the embedding surface.
+    ///
+    /// Scheduler remains surface-owned. This dispatcher only controls
+    /// tool visibility/composition for the built agent.
+    pub schedule_tools: Option<Arc<dyn AgentToolDispatcher>>,
     pub preload_skills: Option<Vec<crate::skills::SkillId>>,
     pub realm_id: Option<String>,
     pub instance_id: Option<String>,
@@ -581,7 +588,9 @@ impl Default for SessionBuildOptions {
             override_builtins: ToolCategoryOverride::Inherit,
             override_shell: ToolCategoryOverride::Inherit,
             override_memory: ToolCategoryOverride::Inherit,
+            override_schedule: ToolCategoryOverride::Inherit,
             override_mob: ToolCategoryOverride::Inherit,
+            schedule_tools: None,
             preload_skills: None,
             realm_id: None,
             instance_id: None,
@@ -622,7 +631,9 @@ impl std::fmt::Debug for SessionBuildOptions {
             .field("override_builtins", &self.override_builtins)
             .field("override_shell", &self.override_shell)
             .field("override_memory", &self.override_memory)
+            .field("override_schedule", &self.override_schedule)
             .field("override_mob", &self.override_mob)
+            .field("schedule_tools", &self.schedule_tools.is_some())
             .field("preload_skills", &self.preload_skills)
             .field("realm_id", &self.realm_id)
             .field("instance_id", &self.instance_id)

--- a/meerkat-core/src/session_recovery.rs
+++ b/meerkat-core/src/session_recovery.rs
@@ -221,10 +221,12 @@ pub fn build_recovered_session(
             .override_memory
             .map(ToolCategoryOverride::from_effective)
             .unwrap_or(metadata.tooling.memory),
+        override_schedule: ToolCategoryOverride::Inherit,
         override_mob: overrides
             .override_mob
             .map(ToolCategoryOverride::from_effective)
             .unwrap_or(metadata.tooling.mob),
+        schedule_tools: None,
         preload_skills: overrides
             .preload_skills
             .clone()

--- a/meerkat-mcp-server/Cargo.toml
+++ b/meerkat-mcp-server/Cargo.toml
@@ -21,7 +21,7 @@ name = "live_mcp_matrix"
 path = "tests/live_mcp_matrix.rs"
 
 [dependencies]
-meerkat = { workspace = true, features = ["anthropic", "openai", "gemini", "jsonl-store", "session-store", "memory-store", "skills"] }
+meerkat = { workspace = true, features = ["anthropic", "openai", "gemini", "jsonl-store", "session-store", "memory-store", "skills", "schedule"] }
 meerkat-mcp = { workspace = true }
 meerkat-core = { workspace = true }
 meerkat-contracts = { workspace = true, features = ["schema"] }
@@ -45,9 +45,10 @@ clap = { workspace = true, features = ["derive"] }
 chrono = { workspace = true }
 
 [features]
-default = ["comms"]
+default = ["comms", "schedule"]
 comms = ["meerkat/comms", "dep:meerkat-comms"]
 mob = ["dep:meerkat-mob", "dep:meerkat-mob-mcp"]
+schedule = ["meerkat/schedule"]
 
 [package.metadata.cargo-machete]
 ignored = ["dirs", "meerkat-client", "meerkat-comms", "meerkat-mcp", "meerkat-mob", "meerkat-mob-mcp", "meerkat-runtime", "rmcp"]  # feature-gated / optional

--- a/meerkat-mcp-server/src/lib.rs
+++ b/meerkat-mcp-server/src/lib.rs
@@ -337,7 +337,6 @@ fn tagged_realm_config_store(
                 root: paths.root.display().to_string(),
                 manifest_path: paths.manifest_path.display().to_string(),
                 config_path: paths.config_path.display().to_string(),
-                sessions_redb_path: paths.sessions_redb_path.display().to_string(),
                 sessions_sqlite_path: Some(paths.sessions_sqlite_path.display().to_string()),
                 sessions_jsonl_dir: paths.sessions_jsonl_dir.display().to_string(),
             }),
@@ -373,7 +372,7 @@ fn realm_store_path(
     let paths = meerkat_store::realm_paths_in(realms_root, realm_id);
     match backend {
         meerkat_store::RealmBackend::Jsonl => paths.sessions_jsonl_dir,
-        meerkat_store::RealmBackend::Sqlite | meerkat_store::RealmBackend::Redb => paths.root,
+        meerkat_store::RealmBackend::Sqlite => paths.root,
     }
 }
 
@@ -744,7 +743,6 @@ fn parse_backend_hint(raw: &str) -> Option<meerkat_store::RealmBackend> {
     match raw {
         "jsonl" => Some(meerkat_store::RealmBackend::Jsonl),
         "sqlite" => Some(meerkat_store::RealmBackend::Sqlite),
-        "redb" => Some(meerkat_store::RealmBackend::Redb),
         _ => None,
     }
 }
@@ -3127,12 +3125,11 @@ mod tests {
             metadata: Some(meerkat_core::ConfigStoreMetadata {
                 realm_id: Some("team".to_string()),
                 instance_id: Some("mcp-1".to_string()),
-                backend: Some("redb".to_string()),
+                backend: Some("sqlite".to_string()),
                 resolved_paths: Some(meerkat_core::ConfigResolvedPaths {
                     root: "/tmp/root".to_string(),
                     manifest_path: "/tmp/root/realm_manifest.json".to_string(),
                     config_path: "/tmp/root/config.toml".to_string(),
-                    sessions_redb_path: "/tmp/root/sessions.redb".to_string(),
                     sessions_sqlite_path: Some("/tmp/root/sessions.sqlite3".to_string()),
                     sessions_jsonl_dir: "/tmp/root/sessions_jsonl".to_string(),
                 }),
@@ -3151,12 +3148,11 @@ mod tests {
             metadata: Some(meerkat_core::ConfigStoreMetadata {
                 realm_id: Some("team".to_string()),
                 instance_id: Some("mcp-1".to_string()),
-                backend: Some("redb".to_string()),
+                backend: Some("sqlite".to_string()),
                 resolved_paths: Some(meerkat_core::ConfigResolvedPaths {
                     root: "/tmp/root".to_string(),
                     manifest_path: "/tmp/root/realm_manifest.json".to_string(),
                     config_path: "/tmp/root/config.toml".to_string(),
-                    sessions_redb_path: "/tmp/root/sessions.redb".to_string(),
                     sessions_sqlite_path: Some("/tmp/root/sessions.sqlite3".to_string()),
                     sessions_jsonl_dir: "/tmp/root/sessions_jsonl".to_string(),
                 }),

--- a/meerkat-mcp-server/src/lib.rs
+++ b/meerkat-mcp-server/src/lib.rs
@@ -8,12 +8,10 @@ mod schedule_host;
 
 #[cfg(test)]
 use meerkat::SessionStore;
-use meerkat::surface::{
-    RequestContext, prepare_surface_session, request_action, wire_runtime_bindings,
-};
+use meerkat::surface::{RequestContext, prepare_surface_session, request_action};
 use meerkat::{
     AgentFactory, FactoryAgentBuilder, OutputSchema, PersistentSessionService, ScheduleService,
-    ToolError, ToolResult,
+    ScheduleToolDispatcher, ToolError, ToolResult,
 };
 use meerkat_contracts::SkillsParams;
 use meerkat_core::error::invalid_session_id_message;
@@ -27,9 +25,6 @@ use meerkat_core::{
     RealmSelection, RuntimeBootstrap, ToolCallView, ToolCategoryOverride, format_verbose_event,
 };
 use meerkat_mcp::{McpReloadTarget, McpRouter};
-#[cfg(feature = "mob")]
-use meerkat_mob_mcp::wire_mob_tools;
-use meerkat_store::StoreAdapter;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use serde_json::{Value, json};
@@ -342,6 +337,7 @@ fn tagged_realm_config_store(
                 root: paths.root.display().to_string(),
                 manifest_path: paths.manifest_path.display().to_string(),
                 config_path: paths.config_path.display().to_string(),
+                sessions_redb_path: paths.sessions_redb_path.display().to_string(),
                 sessions_sqlite_path: Some(paths.sessions_sqlite_path.display().to_string()),
                 sessions_jsonl_dir: paths.sessions_jsonl_dir.display().to_string(),
             }),
@@ -377,7 +373,7 @@ fn realm_store_path(
     let paths = meerkat_store::realm_paths_in(realms_root, realm_id);
     match backend {
         meerkat_store::RealmBackend::Jsonl => paths.sessions_jsonl_dir,
-        meerkat_store::RealmBackend::Sqlite => paths.root,
+        meerkat_store::RealmBackend::Sqlite | meerkat_store::RealmBackend::Redb => paths.root,
     }
 }
 
@@ -408,48 +404,6 @@ pub struct MeerkatMcpState {
     runtime_adapter: Arc<meerkat_runtime::RuntimeSessionAdapter>,
     #[cfg(feature = "comms")]
     _realm_lease: Option<meerkat_store::RealmLeaseGuard>,
-}
-
-struct McpRuntimeComponents {
-    service: Arc<PersistentSessionService<FactoryAgentBuilder>>,
-    runtime_adapter: Arc<meerkat_runtime::RuntimeSessionAdapter>,
-    #[cfg(feature = "mob")]
-    mob_state: Arc<meerkat_mob_mcp::MobMcpState>,
-}
-
-fn compose_runtime_components(
-    mut builder: FactoryAgentBuilder,
-    max_sessions: usize,
-    persistence: meerkat::PersistenceBundle,
-    #[cfg(feature = "mob")] persistent_storage_root: PathBuf,
-) -> McpRuntimeComponents {
-    let runtime_adapter = persistence.runtime_adapter();
-    if builder.default_session_store.is_none() {
-        builder.default_session_store =
-            Some(Arc::new(StoreAdapter::new(persistence.session_store())));
-    }
-    #[cfg(feature = "mob")]
-    let builder_mob_tools_slot = Arc::clone(&builder.default_mob_tools);
-    let (store, runtime_store, blob_store) = persistence.into_parts();
-    let mut service =
-        PersistentSessionService::new(builder, max_sessions, store, runtime_store, blob_store);
-    wire_runtime_bindings(&mut service, &runtime_adapter);
-    let service = Arc::new(service);
-
-    #[cfg(feature = "mob")]
-    let mob_state = wire_mob_tools(
-        &builder_mob_tools_slot,
-        service.clone(),
-        Some(runtime_adapter.clone()),
-        Some(persistent_storage_root),
-    );
-
-    McpRuntimeComponents {
-        service,
-        runtime_adapter,
-        #[cfg(feature = "mob")]
-        mob_state,
-    }
 }
 
 struct SessionEventStreamHandle {
@@ -546,7 +500,10 @@ impl MeerkatMcpState {
             .store_path()
             .map(std::path::Path::to_path_buf)
             .unwrap_or_else(|| realm_store_path(&realms_root, &realm_id, manifest.backend));
+        let runtime_adapter = persistence.runtime_adapter();
+        let runtime_store = persistence.runtime_store();
         let session_store = persistence.session_store();
+        let blob_store = persistence.blob_store();
         let schedule_service = ScheduleService::new(persistence.schedule_store());
         let realm_paths = meerkat_store::realm_paths_in(&realms_root, &realm_id);
         let conventions_context_root = bootstrap.context.context_root.clone();
@@ -578,7 +535,8 @@ impl MeerkatMcpState {
             .runtime_root(realm_paths.root.clone())
             .project_root(project_root)
             .builtins(true)
-            .shell(true);
+            .shell(true)
+            .schedule(true);
         if let Some(context_root) = conventions_context_root {
             factory = factory.context_root(context_root);
         }
@@ -590,18 +548,38 @@ impl MeerkatMcpState {
 
         let mut builder = FactoryAgentBuilder::new_with_config_store(factory, config, config_store);
         builder.default_llm_client = default_llm_client;
-        let McpRuntimeComponents {
-            service,
-            runtime_adapter,
-            #[cfg(feature = "mob")]
-            mob_state,
-        } = compose_runtime_components(
+        #[cfg(feature = "mob")]
+        let mob_tools_slot = Arc::clone(&builder.default_mob_tools);
+        *builder
+            .default_schedule_tools
+            .write()
+            .unwrap_or_else(std::sync::PoisonError::into_inner) = Some(Arc::new(
+            ScheduleToolDispatcher::new(schedule_service.clone()),
+        ));
+        let service = Arc::new(PersistentSessionService::new(
             builder,
             100,
-            persistence,
-            #[cfg(feature = "mob")]
-            realm_paths.root.clone(),
-        );
+            session_store,
+            runtime_store,
+            blob_store,
+        ));
+        #[cfg(feature = "mob")]
+        let mob_state = {
+            let persistent_mob_root = realm_paths.root.clone();
+            let state = Arc::new(
+                meerkat_mob_mcp::MobMcpState::new_with_runtime_adapter(
+                    service.clone(),
+                    Some(runtime_adapter.clone()),
+                )
+                .with_persistent_storage_root(Some(persistent_mob_root)),
+            );
+            *mob_tools_slot
+                .write()
+                .unwrap_or_else(std::sync::PoisonError::into_inner) = Some(Arc::new(
+                meerkat_mob_mcp::AgentMobToolSurfaceFactory::new(Arc::clone(&state)),
+            ));
+            state
+        };
 
         let state = Self {
             service,
@@ -630,7 +608,7 @@ impl MeerkatMcpState {
         Ok(state)
     }
 
-    /// Test constructor that accepts an injected store (avoids opening a durable store at platform data dir).
+    /// Test constructor that accepts an injected store (avoids opening redb at platform data dir).
     #[cfg(test)]
     pub(crate) async fn new_with_store(store: Arc<dyn SessionStore>) -> Self {
         let bootstrap = RuntimeBootstrap::default();
@@ -671,29 +649,26 @@ impl MeerkatMcpState {
             .runtime_root(runtime_root)
             .project_root(project_root)
             .builtins(true)
-            .shell(true);
+            .shell(true)
+            .schedule(true);
         if let Some(user_root) = bootstrap.context.user_config_root.clone() {
             factory = factory.user_config_root(user_root);
         }
 
-        let McpRuntimeComponents {
-            service,
-            runtime_adapter,
-            #[cfg(feature = "mob")]
-            mob_state,
-        } = compose_runtime_components(
-            FactoryAgentBuilder::new_with_config_store(factory, config, config_store),
-            100,
-            meerkat::PersistenceBundle::new(
-                store,
-                None,
-                Arc::new(meerkat_store::FsBlobStore::new(
-                    realm_paths.root.join("blobs"),
-                )),
-            ),
-            #[cfg(feature = "mob")]
-            realm_paths.root.clone(),
+        let builder = FactoryAgentBuilder::new_with_config_store(factory, config, config_store);
+        *builder
+            .default_schedule_tools
+            .write()
+            .unwrap_or_else(std::sync::PoisonError::into_inner) =
+            Some(Arc::new(ScheduleToolDispatcher::new(ScheduleService::new(
+                Arc::new(meerkat::MemoryScheduleStore::default()),
+            ))));
+        let blob_store: Arc<dyn meerkat_core::BlobStore> = Arc::new(
+            meerkat_store::FsBlobStore::new(realm_paths.root.join("blobs")),
         );
+        let service = Arc::new(PersistentSessionService::new(
+            builder, 100, store, None, blob_store,
+        ));
 
         let state = Self {
             service,
@@ -707,14 +682,14 @@ impl MeerkatMcpState {
             config_runtime,
             skill_runtime: None,
             #[cfg(feature = "mob")]
-            mob_state,
+            mob_state: meerkat_mob_mcp::MobMcpState::new_in_memory(),
             mcp_adapters: Arc::new(Mutex::new(HashMap::new())),
             runtime_sessions: Arc::new(tokio::sync::RwLock::new(HashMap::new())),
             session_event_streams: Arc::new(Mutex::new(HashMap::new())),
             #[cfg(feature = "mob")]
             mob_event_streams: Arc::new(Mutex::new(HashMap::new())),
             schedule_host: StdMutex::new(None),
-            runtime_adapter,
+            runtime_adapter: Arc::new(meerkat_runtime::RuntimeSessionAdapter::ephemeral()),
             #[cfg(feature = "comms")]
             _realm_lease: None,
         };
@@ -769,6 +744,7 @@ fn parse_backend_hint(raw: &str) -> Option<meerkat_store::RealmBackend> {
     match raw {
         "jsonl" => Some(meerkat_store::RealmBackend::Jsonl),
         "sqlite" => Some(meerkat_store::RealmBackend::Sqlite),
+        "redb" => Some(meerkat_store::RealmBackend::Redb),
         _ => None,
     }
 }
@@ -2563,7 +2539,9 @@ async fn handle_meerkat_run(
         override_builtins: ToolCategoryOverride::from_override(input.enable_builtins),
         override_shell: ToolCategoryOverride::from_override(enable_shell_override),
         override_memory: ToolCategoryOverride::from_override(input.enable_memory),
+        override_schedule: ToolCategoryOverride::Inherit,
         override_mob: ToolCategoryOverride::Inherit,
+        schedule_tools: None,
         mob_tool_authority_context: None,
         preload_skills,
         realm_id: Some(state.realm_id.clone()),
@@ -2799,6 +2777,15 @@ async fn handle_meerkat_resume(
             })?),
             None => None,
         };
+    let resume_bindings = state
+        .runtime_adapter
+        .prepare_bindings(session_id.clone())
+        .await
+        .map_err(|e| {
+            ToolCallError::internal(format!(
+                "failed to prepare bindings for session {session_id}: {e}"
+            ))
+        })?;
     let mut build = SessionBuildOptions {
         provider,
         output_schema,
@@ -2807,7 +2794,7 @@ async fn handle_meerkat_resume(
             .unwrap_or(default_structured_output_retries()),
         hooks_override: input.hooks_override.clone().unwrap_or_default(),
         comms_name: input.comms_name.clone(),
-        resume_session: None,
+        resume_session: Some(session),
         budget_limits: input.budget_limits.clone().map(Into::into),
         provider_params: input.provider_params.clone(),
         call_timeout_override: meerkat_core::CallTimeoutOverride::Inherit,
@@ -2815,11 +2802,13 @@ async fn handle_meerkat_resume(
         recoverable_tool_defs: (!input.tools.is_empty())
             .then(|| recoverable_callback_tool_defs(&input.tools)),
         llm_client_override: None,
-        runtime_build_mode: meerkat_core::RuntimeBuildMode::StandaloneEphemeral,
+        runtime_build_mode: meerkat_core::RuntimeBuildMode::SessionOwned(resume_bindings),
         override_builtins: ToolCategoryOverride::from_override(enable_builtins_override),
         override_shell: ToolCategoryOverride::from_override(enable_shell_override),
         override_memory: ToolCategoryOverride::from_override(input.enable_memory),
+        override_schedule: ToolCategoryOverride::Inherit,
         override_mob: ToolCategoryOverride::Inherit,
+        schedule_tools: None,
         mob_tool_authority_context: None,
         preload_skills,
         peer_meta: input.peer_meta.clone(),
@@ -2877,9 +2866,7 @@ async fn handle_meerkat_resume(
             build: Some(build),
             labels: None,
         };
-        ingress
-            .materialize_session_with_result(session, req, callback_tools.clone())
-            .await
+        state.service.create_session(req).await
     } else {
         if keep_alive_override.is_some() {
             let comms_rt = state.service.comms_runtime(&session_id).await;
@@ -2933,9 +2920,7 @@ async fn handle_meerkat_resume(
                     labels: None,
                 };
 
-                ingress
-                    .materialize_session_with_result(session, req, callback_tools.clone())
-                    .await
+                state.service.create_session(req).await
             }
             Err(other) => Err(other),
         }
@@ -3142,11 +3127,12 @@ mod tests {
             metadata: Some(meerkat_core::ConfigStoreMetadata {
                 realm_id: Some("team".to_string()),
                 instance_id: Some("mcp-1".to_string()),
-                backend: Some("sqlite".to_string()),
+                backend: Some("redb".to_string()),
                 resolved_paths: Some(meerkat_core::ConfigResolvedPaths {
                     root: "/tmp/root".to_string(),
                     manifest_path: "/tmp/root/realm_manifest.json".to_string(),
                     config_path: "/tmp/root/config.toml".to_string(),
+                    sessions_redb_path: "/tmp/root/sessions.redb".to_string(),
                     sessions_sqlite_path: Some("/tmp/root/sessions.sqlite3".to_string()),
                     sessions_jsonl_dir: "/tmp/root/sessions_jsonl".to_string(),
                 }),
@@ -3165,11 +3151,12 @@ mod tests {
             metadata: Some(meerkat_core::ConfigStoreMetadata {
                 realm_id: Some("team".to_string()),
                 instance_id: Some("mcp-1".to_string()),
-                backend: Some("sqlite".to_string()),
+                backend: Some("redb".to_string()),
                 resolved_paths: Some(meerkat_core::ConfigResolvedPaths {
                     root: "/tmp/root".to_string(),
                     manifest_path: "/tmp/root/realm_manifest.json".to_string(),
                     config_path: "/tmp/root/config.toml".to_string(),
+                    sessions_redb_path: "/tmp/root/sessions.redb".to_string(),
                     sessions_sqlite_path: Some("/tmp/root/sessions.sqlite3".to_string()),
                     sessions_jsonl_dir: "/tmp/root/sessions_jsonl".to_string(),
                 }),

--- a/meerkat-mcp-server/src/runtime_ingress.rs
+++ b/meerkat-mcp-server/src/runtime_ingress.rs
@@ -264,19 +264,6 @@ impl McpRuntimeIngressContext {
         }
     }
 
-    pub(crate) async fn materialize_session_with_result(
-        &self,
-        session: Session,
-        request: CreateSessionRequest,
-        callback_tools: Option<Arc<dyn AgentToolDispatcher>>,
-    ) -> Result<RunResult, SessionError> {
-        let keep_alive = request.build.as_ref().is_some_and(|build| build.keep_alive);
-        let state = Arc::new(McpRuntimeSessionState::default());
-        state.set_callback_tools(callback_tools).await;
-        self.materialize_with_state(session, request, keep_alive, state)
-            .await
-    }
-
     async fn rematerialize_persisted_session(
         &self,
         session_id: &SessionId,

--- a/meerkat-mcp-server/src/schedule_host.rs
+++ b/meerkat-mcp-server/src/schedule_host.rs
@@ -205,7 +205,9 @@ impl McpScheduleContext {
             override_builtins: meerkat_core::ToolCategoryOverride::Inherit,
             override_shell: meerkat_core::ToolCategoryOverride::Inherit,
             override_memory: meerkat_core::ToolCategoryOverride::Inherit,
+            override_schedule: meerkat_core::ToolCategoryOverride::Inherit,
             override_mob: meerkat_core::ToolCategoryOverride::Inherit,
+            schedule_tools: None,
             mob_tool_authority_context: None,
             preload_skills: preload_skill_ids(Some(create.preload_skills.clone())),
             realm_id: create

--- a/meerkat-rest/Cargo.toml
+++ b/meerkat-rest/Cargo.toml
@@ -37,7 +37,7 @@ path = "tests/live_rest_matrix.rs"
 required-features = ["integration-real-tests"]
 
 [dependencies]
-meerkat = { workspace = true, features = ["anthropic", "openai", "gemini", "jsonl-store", "session-store", "memory-store", "skills"] }
+meerkat = { workspace = true, features = ["anthropic", "openai", "gemini", "jsonl-store", "session-store", "memory-store", "skills", "schedule"] }
 meerkat-core = { workspace = true }
 meerkat-contracts = { workspace = true }
 meerkat-client = { workspace = true }
@@ -67,10 +67,11 @@ subtle = { workspace = true }
 clap = { workspace = true, features = ["derive"] }
 
 [features]
-default = ["comms", "mcp", "mob"]
+default = ["comms", "mcp", "mob", "schedule"]
 comms = ["meerkat/comms", "dep:meerkat-comms"]
 mcp = ["meerkat/mcp", "dep:meerkat-mcp"]
 mob = ["dep:meerkat-mob", "dep:meerkat-mob-mcp"]
+schedule = ["meerkat/schedule"]
 integration-real-tests = []
 
 [dev-dependencies]

--- a/meerkat-rest/src/lib.rs
+++ b/meerkat-rest/src/lib.rs
@@ -30,25 +30,23 @@ use axum::{
 };
 use chrono::{DateTime, Utc};
 use futures::stream::Stream;
-#[cfg(feature = "comms")]
-use meerkat::surface::configure_peer_ingress;
 use meerkat::surface::{
-    RequestAlreadyExists, RequestContext, SurfaceRequestExecutor, SurfaceRuntimeMaterializeError,
-    SurfaceSessionRecoveryContext, SurfaceSessionRecoveryOverrides, build_recovered_session,
-    materialize_session, noop_request_action, request_action, wire_runtime_bindings,
+    RequestAlreadyExists, RequestContext, SurfaceRequestExecutor, SurfaceSessionRecoveryContext,
+    SurfaceSessionRecoveryOverrides, build_recovered_session, noop_request_action, request_action,
 };
 use meerkat::{
     AgentEvent, AgentFactory, FactoryAgentBuilder, LlmClient, OutputSchema,
-    PersistentSessionService, ScheduleService, Session, SessionId, SessionService,
-    SessionServiceControlExt, SessionServiceHistoryExt, encode_llm_client_override_for_service,
-    handle_schedule_tools_call, open_realm_persistence_in, schedule_tools_list,
+    PersistentSessionService, ScheduleService, ScheduleToolDispatcher, Session, SessionId,
+    SessionService, SessionServiceControlExt, SessionServiceHistoryExt,
+    encode_llm_client_override_for_service, handle_schedule_tools_call, open_realm_persistence_in,
+    schedule_tools_list,
 };
 use meerkat_contracts::{SessionLocator, SkillsParams, format_session_ref};
 use meerkat_core::EventEnvelope;
 use meerkat_core::lifecycle::core_executor::{CoreApplyOutput, CoreExecutor, CoreExecutorError};
 use meerkat_core::lifecycle::run_control::RunControlCommand;
 use meerkat_core::lifecycle::run_primitive::{
-    ConversationContextAppend, CoreRenderable, RunPrimitive,
+    ConversationContextAppend, CoreRenderable, RunApplyBoundary, RunPrimitive,
 };
 use meerkat_core::service::{
     AppendSystemContextRequest as SvcAppendSystemContextRequest,
@@ -61,10 +59,8 @@ use meerkat_core::{
     FileConfigStore, HookRunOverrides, PendingSystemContextAppend, Provider, RealmSelection,
     RuntimeBootstrap, ToolCategoryOverride, agent_event_type, format_verbose_event,
 };
-#[cfg(feature = "mob")]
-use meerkat_mob_mcp::wire_mob_tools;
 use meerkat_runtime::SessionServiceRuntimeExt as _;
-use meerkat_store::{RealmBackend, RealmOrigin, StoreAdapter};
+use meerkat_store::{RealmBackend, RealmOrigin};
 use serde::{Deserialize, Serialize};
 use serde_json::{Value, json};
 use std::borrow::Cow;
@@ -168,48 +164,6 @@ struct RestSessionRuntimeExecutor {
     session_id: SessionId,
 }
 
-struct RestRuntimeComponents {
-    session_service: Arc<PersistentSessionService<FactoryAgentBuilder>>,
-    runtime_adapter: Arc<meerkat_runtime::RuntimeSessionAdapter>,
-    #[cfg(feature = "mob")]
-    mob_state: Arc<meerkat_mob_mcp::MobMcpState>,
-}
-
-fn compose_runtime_components(
-    mut builder: FactoryAgentBuilder,
-    max_sessions: usize,
-    persistence: meerkat::PersistenceBundle,
-    #[cfg(feature = "mob")] persistent_storage_root: PathBuf,
-) -> RestRuntimeComponents {
-    let runtime_adapter = persistence.runtime_adapter();
-    if builder.default_session_store.is_none() {
-        builder.default_session_store =
-            Some(Arc::new(StoreAdapter::new(persistence.session_store())));
-    }
-    #[cfg(feature = "mob")]
-    let builder_mob_tools_slot = Arc::clone(&builder.default_mob_tools);
-    let (store, runtime_store, blob_store) = persistence.into_parts();
-    let mut session_service =
-        PersistentSessionService::new(builder, max_sessions, store, runtime_store, blob_store);
-    wire_runtime_bindings(&mut session_service, &runtime_adapter);
-    let session_service = Arc::new(session_service);
-
-    #[cfg(feature = "mob")]
-    let mob_state = wire_mob_tools(
-        &builder_mob_tools_slot,
-        session_service.clone(),
-        Some(runtime_adapter.clone()),
-        Some(persistent_storage_root),
-    );
-
-    RestRuntimeComponents {
-        session_service,
-        runtime_adapter,
-        #[cfg(feature = "mob")]
-        mob_state,
-    }
-}
-
 impl AppState {
     pub async fn load() -> Result<Self, Box<dyn std::error::Error>> {
         Self::load_with_bootstrap_and_options(RuntimeBootstrap::default(), false).await
@@ -261,6 +215,7 @@ impl AppState {
             root: realm_paths.root.display().to_string(),
             manifest_path: realm_paths.manifest_path.display().to_string(),
             config_path: realm_paths.config_path.display().to_string(),
+            sessions_redb_path: realm_paths.sessions_redb_path.display().to_string(),
             sessions_sqlite_path: Some(realm_paths.sessions_sqlite_path.display().to_string()),
             sessions_jsonl_dir: realm_paths.sessions_jsonl_dir.display().to_string(),
         };
@@ -300,7 +255,9 @@ impl AppState {
             .map(std::path::Path::to_path_buf)
             .unwrap_or_else(|| match manifest.backend {
                 meerkat_store::RealmBackend::Jsonl => realm_paths.sessions_jsonl_dir.clone(),
-                meerkat_store::RealmBackend::Sqlite => realm_paths.root.clone(),
+                meerkat_store::RealmBackend::Sqlite | meerkat_store::RealmBackend::Redb => {
+                    realm_paths.root.clone()
+                }
             });
 
         let enable_builtins = config.tools.builtins_enabled;
@@ -315,7 +272,8 @@ impl AppState {
             .session_store(session_store.clone())
             .runtime_root(realm_paths.root.clone())
             .builtins(enable_builtins)
-            .shell(enable_shell);
+            .shell(enable_shell)
+            .schedule(true);
         let conventions_context_root = bootstrap.context.context_root.clone();
         let task_project_root = conventions_context_root
             .clone()
@@ -330,18 +288,32 @@ impl AppState {
 
         let skill_runtime = factory.build_skill_runtime(&config).await;
 
-        let RestRuntimeComponents {
-            session_service,
-            runtime_adapter,
-            #[cfg(feature = "mob")]
-            mob_state,
-        } = compose_runtime_components(
-            FactoryAgentBuilder::new_with_config_store(factory, config, Arc::clone(&config_store)),
-            100,
-            persistence,
-            #[cfg(feature = "mob")]
-            realm_paths.root.clone(),
-        );
+        let builder =
+            FactoryAgentBuilder::new_with_config_store(factory, config, Arc::clone(&config_store));
+        // Capture the mob tools slot before the builder is consumed into the session service.
+        // We set the actual factory after mob_state is constructed (circular dep break).
+        #[cfg(feature = "mob")]
+        let mob_tools_slot = Arc::clone(&builder.default_mob_tools);
+        let schedule_tools_slot = Arc::clone(&builder.default_schedule_tools);
+        *schedule_tools_slot
+            .write()
+            .unwrap_or_else(std::sync::PoisonError::into_inner) = Some(Arc::new(
+            ScheduleToolDispatcher::new(schedule_service.clone()),
+        ));
+        let runtime_adapter = persistence.runtime_adapter();
+        let (session_store, runtime_store, blob_store) = persistence.into_parts();
+        let mut session_service =
+            PersistentSessionService::new(builder, 100, session_store, runtime_store, blob_store);
+        {
+            let adapter = runtime_adapter.clone();
+            session_service.set_runtime_bindings_provider(Arc::new(move |session_id| {
+                let adapter = adapter.clone();
+                Box::pin(async move { adapter.prepare_bindings(session_id).await.ok() })
+            }));
+        }
+        let session_service = Arc::new(session_service);
+        #[cfg(feature = "mob")]
+        let mob_session_service = session_service.clone();
 
         Ok(Self {
             store_path,
@@ -369,7 +341,18 @@ impl AppState {
             runtime_adapter,
             schedule_host: Arc::new(schedule_host::ScheduleHostState::default()),
             #[cfg(feature = "mob")]
-            mob_state,
+            mob_state: {
+                let state = Arc::new(
+                    meerkat_mob_mcp::MobMcpState::new(mob_session_service)
+                        .with_persistent_storage_root(Some(realm_paths.root.clone())),
+                );
+                *mob_tools_slot
+                    .write()
+                    .unwrap_or_else(std::sync::PoisonError::into_inner) = Some(Arc::new(
+                    meerkat_mob_mcp::AgentMobToolSurfaceFactory::new(Arc::clone(&state)),
+                ));
+                state
+            },
             #[cfg(feature = "mcp")]
             mcp_sessions: Arc::new(RwLock::new(std::collections::HashMap::new())),
             request_executor: Arc::new(SurfaceRequestExecutor::new(
@@ -462,93 +445,6 @@ fn validate_prompt_video_input(
     Ok(())
 }
 
-fn surface_materialize_session_error(error: SurfaceRuntimeMaterializeError) -> SessionError {
-    match error {
-        SurfaceRuntimeMaterializeError::Session(error) => error,
-        SurfaceRuntimeMaterializeError::SessionIdMismatch { expected, actual } => {
-            SessionError::Agent(meerkat_core::error::AgentError::InternalError(format!(
-                "session service returned mismatched session id: expected {expected}, got {actual}"
-            )))
-        }
-        other => SessionError::Agent(meerkat_core::error::AgentError::InternalError(
-            other.to_string(),
-        )),
-    }
-}
-
-fn surface_recovery_session_error(
-    error: meerkat::surface::SurfaceSessionRecoveryError,
-) -> SessionError {
-    SessionError::Agent(meerkat_core::error::AgentError::InternalError(
-        error.to_string(),
-    ))
-}
-
-async fn rematerialize_rest_session(
-    context: &RestRuntimeExecutorContext,
-    session_id: &SessionId,
-    keep_alive: bool,
-) -> Result<SessionId, SessionError> {
-    let session = context
-        .session_service
-        .load_persisted(session_id)
-        .await?
-        .ok_or_else(|| SessionError::NotFound {
-            id: session_id.clone(),
-        })?;
-    let current_generation = context
-        .config_runtime
-        .get()
-        .await
-        .ok()
-        .map(|snapshot| snapshot.generation);
-    let recovery_request = build_recovered_session(
-        session.clone(),
-        &SurfaceSessionRecoveryOverrides {
-            keep_alive: Some(keep_alive),
-            ..Default::default()
-        },
-        SurfaceSessionRecoveryContext {
-            llm_client_override: context
-                .llm_client_override
-                .clone()
-                .map(encode_llm_client_override_for_service),
-            external_tools: None,
-            realm_id: Some(context.realm_id.clone()),
-            instance_id: context.instance_id.clone(),
-            backend: Some(context.backend.clone()),
-            config_generation: current_generation,
-            ..Default::default()
-        },
-    )
-    .map_err(surface_recovery_session_error)?
-    .into_deferred_create_request();
-    let runtime_context = context.clone();
-    let result = materialize_session(
-        &context.session_service,
-        &context.runtime_adapter,
-        session,
-        recovery_request,
-        move |runtime_session_id| {
-            Box::new(RestSessionRuntimeExecutor::new(
-                runtime_context,
-                runtime_session_id,
-            ))
-        },
-    )
-    .await
-    .map_err(surface_materialize_session_error)?;
-    #[cfg(feature = "comms")]
-    configure_peer_ingress(
-        &context.runtime_adapter,
-        &context.session_service,
-        &result.session_id,
-        keep_alive,
-    )
-    .await;
-    Ok(result.session_id)
-}
-
 async fn apply_runtime_turn(
     context: &RestRuntimeExecutorContext,
     session_id: &SessionId,
@@ -635,7 +531,10 @@ async fn apply_runtime_turn(
         )));
     }
 
-    let boundary = primitive.apply_boundary();
+    let boundary = match primitive {
+        RunPrimitive::StagedInput(staged) => staged.boundary,
+        _ => RunApplyBoundary::Immediate,
+    };
     let contributing_input_ids = primitive.contributing_input_ids().to_vec();
 
     let result = match context
@@ -651,12 +550,58 @@ async fn apply_runtime_turn(
     {
         Ok(output) => Ok(output),
         Err(SessionError::NotFound { .. }) => {
-            rematerialize_rest_session(context, session_id, keep_alive)
-                .await
-                .map_err(|error| match error {
-                    SessionError::NotFound { .. } => error,
-                    other => other,
+            let session = context
+                .session_service
+                .load_persisted(session_id)
+                .await?
+                .ok_or(SessionError::NotFound {
+                    id: session_id.clone(),
                 })?;
+            let current_generation = context
+                .config_runtime
+                .get()
+                .await
+                .ok()
+                .map(|s| s.generation);
+            let bindings = context
+                .runtime_adapter
+                .prepare_bindings(session_id.clone())
+                .await
+                .map_err(|e| {
+                    SessionError::Agent(meerkat_core::error::AgentError::InternalError(format!(
+                        "failed to prepare runtime bindings for session {session_id}: {e}"
+                    )))
+                })?;
+            let recovered = build_recovered_session(
+                session,
+                &SurfaceSessionRecoveryOverrides {
+                    keep_alive: Some(keep_alive),
+                    ..Default::default()
+                },
+                SurfaceSessionRecoveryContext {
+                    llm_client_override: context
+                        .llm_client_override
+                        .clone()
+                        .map(encode_llm_client_override_for_service),
+                    external_tools: None,
+                    runtime_build_mode: Some(meerkat_core::RuntimeBuildMode::SessionOwned(
+                        bindings,
+                    )),
+                    realm_id: Some(context.realm_id.clone()),
+                    instance_id: context.instance_id.clone(),
+                    backend: Some(context.backend.clone()),
+                    config_generation: current_generation,
+                },
+            )
+            .map_err(|error| {
+                SessionError::Agent(meerkat_core::error::AgentError::InternalError(
+                    error.to_string(),
+                ))
+            })?;
+            context
+                .session_service
+                .create_session(recovered.into_deferred_create_request())
+                .await?;
             let output = context
                 .session_service
                 .apply_runtime_turn_outcome(
@@ -755,6 +700,7 @@ fn parse_backend_hint(raw: &str) -> Option<RealmBackend> {
     match raw {
         "jsonl" => Some(RealmBackend::Jsonl),
         "sqlite" => Some(RealmBackend::Sqlite),
+        "redb" => Some(RealmBackend::Redb),
         _ => None,
     }
 }
@@ -2419,6 +2365,18 @@ async fn create_session_inner(
     // and event forwarding before the service call returns).
     let pre_session = Session::new();
     let session_id = pre_session.id().clone();
+    let bindings = match state
+        .runtime_adapter
+        .prepare_bindings(session_id.clone())
+        .await
+    {
+        Ok(v) => v,
+        Err(e) => {
+            let message = format!("failed to prepare runtime bindings: {e}");
+            return RequestOutcome::Unpublished(Err(ApiError::Internal(message)));
+        }
+    };
+
     // Set up event forwarding: caller channel -> broadcast
     let (caller_event_tx, caller_event_rx) = mpsc::channel::<EventEnvelope<AgentEvent>>(100);
     let forward_task = spawn_event_forwarder(
@@ -2497,7 +2455,7 @@ async fn create_session_inner(
         hooks_override: req.hooks_override.unwrap_or_default(),
         comms_name: req.comms_name.clone(),
         peer_meta: req.peer_meta.clone(),
-        resume_session: None,
+        resume_session: Some(pre_session),
         budget_limits: req.budget_limits,
         provider_params: req.provider_params.clone(),
         external_tools: mcp_external_tools,
@@ -2508,8 +2466,10 @@ async fn create_session_inner(
             .map(encode_llm_client_override_for_service),
         override_builtins: ToolCategoryOverride::from_override(req.enable_builtins),
         override_shell: ToolCategoryOverride::from_override(req.enable_shell),
+        override_schedule: ToolCategoryOverride::Inherit,
         override_memory: ToolCategoryOverride::from_override(req.enable_memory),
         override_mob: ToolCategoryOverride::Inherit,
+        schedule_tools: None,
         mob_tool_authority_context: None,
         preload_skills: req
             .preload_skills
@@ -2540,7 +2500,7 @@ async fn create_session_inner(
         call_timeout_override: Default::default(),
         blob_store_override: None,
         mob_tools: None,
-        runtime_build_mode: meerkat_core::RuntimeBuildMode::StandaloneEphemeral,
+        runtime_build_mode: meerkat_core::RuntimeBuildMode::SessionOwned(bindings),
     };
     build.apply_generated_create_only_mob_operator_access(ToolCategoryOverride::from_override(
         req.enable_mob,
@@ -2568,34 +2528,10 @@ async fn create_session_inner(
     }
 
     let adapter = state.runtime_adapter.clone();
-    let runtime_context = state.runtime_executor_context();
 
     // Create session with Defer, then route through runtime
-    let create_result = match materialize_session(
-        &state.session_service,
-        &state.runtime_adapter,
-        pre_session,
-        svc_req,
-        move |runtime_session_id| {
-            Box::new(RestSessionRuntimeExecutor::new(
-                runtime_context,
-                runtime_session_id,
-            ))
-        },
-    )
-    .await
-    {
-        Ok(result) => {
-            #[cfg(feature = "comms")]
-            configure_peer_ingress(
-                &state.runtime_adapter,
-                &state.session_service,
-                &result.session_id,
-                keep_alive_override.unwrap_or(false),
-            )
-            .await;
-            result
-        }
+    let create_result = match state.session_service.create_session(svc_req).await {
+        Ok(result) => result,
         Err(err) => {
             #[cfg(feature = "mcp")]
             cleanup_mcp_session(state, &session_id).await;
@@ -2603,20 +2539,44 @@ async fn create_session_inner(
             drop(caller_event_tx);
             drain_event_forwarder(&session_id, forward_task).await;
             let api_err = match err {
-                SurfaceRuntimeMaterializeError::Session(SessionError::NotFound { .. }) => {
-                    ApiError::NotFound(err.to_string())
-                }
-                SurfaceRuntimeMaterializeError::Session(SessionError::Busy { .. }) => {
+                SessionError::NotFound { .. } => ApiError::NotFound(err.to_string()),
+                SessionError::Busy { .. } => ApiError::BadRequest(err.to_string()),
+                SessionError::Agent(meerkat_core::error::AgentError::ConfigError(_)) => {
                     ApiError::BadRequest(err.to_string())
                 }
-                SurfaceRuntimeMaterializeError::Session(SessionError::Agent(
-                    meerkat_core::error::AgentError::ConfigError(_),
-                )) => ApiError::BadRequest(err.to_string()),
                 _ => ApiError::Agent(err.to_string()),
             };
             return RequestOutcome::Unpublished(Err(api_err));
         }
     };
+
+    // Register executor for the new session.
+    // Session is already committed — failure here must use Published(Err) to
+    // preserve the session for resumption.
+    if let Err(_resp) = ensure_runtime_session_registered(state, &create_result.session_id).await {
+        drop(caller_event_tx);
+        drain_event_forwarder(&session_id, forward_task).await;
+        return RequestOutcome::Published(Err(ApiError::InternalWithData {
+            message: "failed to register runtime executor".to_string(),
+            code: "SESSION_CREATED_WITH_TURN_FAILURE".to_string(),
+            details: json!({
+                "session_id": session_id.to_string(),
+                "session_ref": format_session_ref(&state.realm_id, &session_id),
+                "session_created": true,
+                "resumable": true,
+            }),
+        }));
+    }
+
+    // Update peer-ingress context so live sessions always get attached ingress
+    // and idle keep_alive sessions retain a persistent host drain.
+    #[cfg(feature = "comms")]
+    {
+        let comms_rt = state.session_service.comms_runtime(&session_id).await;
+        adapter
+            .update_peer_ingress_context(&session_id, keep_alive, comms_rt)
+            .await;
+    }
 
     // Create input and route through runtime
     let input = meerkat_runtime::Input::Prompt(meerkat_runtime::PromptInput::from_content_input(
@@ -3216,6 +3176,19 @@ async fn continue_session_inner(
                 ))));
             }
         };
+        let bindings = match state
+            .runtime_adapter
+            .prepare_bindings(session_id.clone())
+            .await
+        {
+            Ok(v) => v,
+            Err(e) => {
+                let message = format!("failed to prepare runtime bindings: {e}");
+                drop(caller_event_tx);
+                drain_event_forwarder(&session_id, forward_task).await;
+                return RequestOutcome::Unpublished(Err(ApiError::Internal(message)));
+            }
+        };
         let mut build = SessionBuildOptions {
             provider: req.provider,
             output_schema: req.output_schema,
@@ -3225,7 +3198,7 @@ async fn continue_session_inner(
             hooks_override: req.hooks_override.clone().unwrap_or_default(),
             comms_name: req.comms_name.clone(),
             peer_meta: req.peer_meta.clone(),
-            resume_session: None,
+            resume_session: Some(session),
             budget_limits: None,
             provider_params: None,
             external_tools: None,
@@ -3237,7 +3210,9 @@ async fn continue_session_inner(
             override_builtins: ToolCategoryOverride::Inherit,
             override_shell: ToolCategoryOverride::Inherit,
             override_memory: ToolCategoryOverride::Inherit,
+            override_schedule: ToolCategoryOverride::Inherit,
             override_mob: ToolCategoryOverride::Inherit,
+            schedule_tools: None,
             mob_tool_authority_context: None,
             preload_skills: None,
             realm_id: Some(state.realm_id.clone()),
@@ -3264,7 +3239,7 @@ async fn continue_session_inner(
             call_timeout_override: Default::default(),
             blob_store_override: None,
             mob_tools: None,
-            runtime_build_mode: meerkat_core::RuntimeBuildMode::StandaloneEphemeral,
+            runtime_build_mode: meerkat_core::RuntimeBuildMode::SessionOwned(bindings),
         };
         build.apply_generated_create_only_mob_operator_access(ToolCategoryOverride::Inherit);
         let create_req = SvcCreateSessionRequest {
@@ -3292,32 +3267,8 @@ async fn continue_session_inner(
             drain_event_forwarder(&session_id, forward_task).await;
             return RequestOutcome::Unpublished(Err(ApiError::BadRequest(err)));
         }
-        let runtime_context = state.runtime_executor_context();
-        let create_result = match materialize_session(
-            &state.session_service,
-            &state.runtime_adapter,
-            session,
-            create_req,
-            move |runtime_session_id| {
-                Box::new(RestSessionRuntimeExecutor::new(
-                    runtime_context,
-                    runtime_session_id,
-                ))
-            },
-        )
-        .await
-        {
-            Ok(v) => {
-                #[cfg(feature = "comms")]
-                configure_peer_ingress(
-                    &state.runtime_adapter,
-                    &state.session_service,
-                    &v.session_id,
-                    keep_alive_override.unwrap_or(false),
-                )
-                .await;
-                v
-            }
+        let create_result = match state.session_service.create_session(create_req).await {
+            Ok(v) => v,
             Err(e) => {
                 drop(caller_event_tx);
                 drain_event_forwarder(&session_id, forward_task).await;
@@ -3363,6 +3314,13 @@ async fn continue_session_inner(
             }
         }
 
+        #[cfg(feature = "comms")]
+        {
+            let comms_rt = state.session_service.comms_runtime(&session_id).await;
+            adapter
+                .update_peer_ingress_context(&session_id, keep_alive, comms_rt)
+                .await;
+        }
         let input =
             meerkat_runtime::Input::Prompt(meerkat_runtime::PromptInput::from_content_input(
                 turn_prompt.clone(),
@@ -3568,7 +3526,7 @@ async fn session_events(
 ) -> Result<Sse<impl Stream<Item = Result<Event, Infallible>>>, ApiError> {
     let session_id = resolve_session_id_for_state(&id, &state)?;
 
-    // load_persisted() only checks the durable session store. A session on its first
+    // load_persisted() only checks the redb store. A session on its first
     // in-progress turn (not yet persisted) will return 404. Future improvement:
     // try read() first for message_count (works for live sessions), fall back
     // to load_persisted() for inactive sessions.

--- a/meerkat-rest/src/lib.rs
+++ b/meerkat-rest/src/lib.rs
@@ -215,7 +215,6 @@ impl AppState {
             root: realm_paths.root.display().to_string(),
             manifest_path: realm_paths.manifest_path.display().to_string(),
             config_path: realm_paths.config_path.display().to_string(),
-            sessions_redb_path: realm_paths.sessions_redb_path.display().to_string(),
             sessions_sqlite_path: Some(realm_paths.sessions_sqlite_path.display().to_string()),
             sessions_jsonl_dir: realm_paths.sessions_jsonl_dir.display().to_string(),
         };
@@ -255,9 +254,7 @@ impl AppState {
             .map(std::path::Path::to_path_buf)
             .unwrap_or_else(|| match manifest.backend {
                 meerkat_store::RealmBackend::Jsonl => realm_paths.sessions_jsonl_dir.clone(),
-                meerkat_store::RealmBackend::Sqlite | meerkat_store::RealmBackend::Redb => {
-                    realm_paths.root.clone()
-                }
+                meerkat_store::RealmBackend::Sqlite => realm_paths.root.clone(),
             });
 
         let enable_builtins = config.tools.builtins_enabled;
@@ -700,7 +697,6 @@ fn parse_backend_hint(raw: &str) -> Option<RealmBackend> {
     match raw {
         "jsonl" => Some(RealmBackend::Jsonl),
         "sqlite" => Some(RealmBackend::Sqlite),
-        "redb" => Some(RealmBackend::Redb),
         _ => None,
     }
 }

--- a/meerkat-rpc/Cargo.toml
+++ b/meerkat-rpc/Cargo.toml
@@ -25,7 +25,7 @@ name = "live_rpc_regression"
 path = "tests/live_rpc_regression.rs"
 
 [dependencies]
-meerkat = { workspace = true, features = ["anthropic", "openai", "gemini", "jsonl-store", "session-store", "memory-store", "skills"] }
+meerkat = { workspace = true, features = ["anthropic", "openai", "gemini", "jsonl-store", "session-store", "memory-store", "skills", "schedule"] }
 meerkat-models = { workspace = true }
 meerkat-core = { workspace = true }
 meerkat-contracts = { workspace = true }
@@ -48,10 +48,11 @@ uuid = { workspace = true }
 clap = { workspace = true }
 
 [features]
-default = ["comms", "mcp", "mob"]
+default = ["comms", "mcp", "mob", "schedule"]
 comms = ["meerkat/comms"]
 mcp = ["meerkat/mcp"]
 mob = ["dep:meerkat-mob", "dep:meerkat-mob-mcp"]
+schedule = ["meerkat/schedule"]
 
 [dev-dependencies]
 tokio = { workspace = true, features = ["test-util", "macros"] }

--- a/meerkat-rpc/src/main.rs
+++ b/meerkat-rpc/src/main.rs
@@ -136,6 +136,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         .project_root(project_root)
         .builtins(true)
         .shell(true)
+        .schedule(true)
         .memory(true);
     if let Some(context_root) = cli.context_root.clone() {
         factory = factory.context_root(context_root);

--- a/meerkat-rpc/src/session_runtime.rs
+++ b/meerkat-rpc/src/session_runtime.rs
@@ -22,8 +22,8 @@ use std::time::Duration;
 use indexmap::IndexMap;
 use meerkat::{
     AgentBuildConfig, AgentFactory, FactoryAgentBuilder, PersistenceBundle,
-    PersistentSessionService, ScheduleService, encode_llm_client_override_for_service,
-    surface::wire_runtime_bindings,
+    PersistentSessionService, ScheduleService, ScheduleToolDispatcher,
+    encode_llm_client_override_for_service,
 };
 use meerkat_client::LlmClient;
 use meerkat_core::EventEnvelope;
@@ -61,9 +61,6 @@ use meerkat::{
 };
 #[cfg(feature = "mcp")]
 use meerkat_core::ToolConfigChangeOperation;
-#[cfg(feature = "mob")]
-use meerkat_mob_mcp::wire_mob_tools;
-use meerkat_store::StoreAdapter;
 
 fn render_context_append_text(content: &CoreRenderable) -> String {
     match content {
@@ -108,14 +105,6 @@ struct SessionMcpState {
     lifecycle_tx: mpsc::UnboundedSender<McpLifecycleAction>,
     lifecycle_rx: mpsc::UnboundedReceiver<McpLifecycleAction>,
     drain_task_running: Arc<AtomicBool>,
-}
-
-struct RuntimeBackedServiceComponents {
-    service: Arc<PersistentSessionService<FactoryAgentBuilder>>,
-    runtime_adapter: Arc<RuntimeSessionAdapter>,
-    builder_mob_tools_slot: Arc<StdRwLock<Option<Arc<dyn meerkat_core::service::MobToolsFactory>>>>,
-    #[cfg(feature = "mob")]
-    mob_state: Option<Arc<meerkat_mob_mcp::MobMcpState>>,
 }
 
 // ---------------------------------------------------------------------------
@@ -254,6 +243,10 @@ pub struct SessionRuntime {
     /// through to the actual builder that creates agents.
     pub builder_mob_tools_slot:
         Arc<StdRwLock<Option<Arc<dyn meerkat_core::service::MobToolsFactory>>>>,
+    /// Captured before the builder is consumed so runtime construction can
+    /// inject scheduler tools into resumed/runtime-backed agent builds.
+    pub builder_schedule_tools_slot:
+        Arc<StdRwLock<Option<Arc<dyn meerkat_core::AgentToolDispatcher>>>>,
 }
 
 fn session_metadata_marks_archived(session: &Session) -> bool {
@@ -265,40 +258,6 @@ fn session_metadata_marks_archived(session: &Session) -> bool {
 }
 
 impl SessionRuntime {
-    fn compose_runtime_backed_service(
-        mut builder: FactoryAgentBuilder,
-        max_sessions: usize,
-        persistence: PersistenceBundle,
-    ) -> RuntimeBackedServiceComponents {
-        let runtime_adapter = persistence.runtime_adapter();
-        if builder.default_session_store.is_none() {
-            builder.default_session_store =
-                Some(Arc::new(StoreAdapter::new(persistence.session_store())));
-        }
-        let builder_mob_tools_slot = Arc::clone(&builder.default_mob_tools);
-        let (store, runtime_store, blob_store) = persistence.into_parts();
-        let mut service =
-            PersistentSessionService::new(builder, max_sessions, store, runtime_store, blob_store);
-        wire_runtime_bindings(&mut service, &runtime_adapter);
-        let service = Arc::new(service);
-
-        #[cfg(feature = "mob")]
-        let mob_state = Some(wire_mob_tools(
-            &builder_mob_tools_slot,
-            service.clone(),
-            Some(runtime_adapter.clone()),
-            None,
-        ));
-
-        RuntimeBackedServiceComponents {
-            service,
-            runtime_adapter,
-            builder_mob_tools_slot,
-            #[cfg(feature = "mob")]
-            mob_state,
-        }
-    }
-
     async fn live_session_is_stale(&self, session_id: &SessionId) -> Result<bool, RpcError> {
         let live = match self.service.export_live_session(session_id).await {
             Ok(session) => session,
@@ -322,18 +281,25 @@ impl SessionRuntime {
         notification_sink: crate::router::NotificationSink,
     ) -> Self {
         let schedule_service = ScheduleService::new(persistence.schedule_store());
+        let runtime_adapter = persistence.runtime_adapter();
+        let (store, runtime_store, blob_store) = persistence.into_parts();
         let factory_clone = factory.clone();
-        let RuntimeBackedServiceComponents {
-            service,
-            runtime_adapter,
-            builder_mob_tools_slot,
-            #[cfg(feature = "mob")]
-            mob_state,
-        } = Self::compose_runtime_backed_service(
-            FactoryAgentBuilder::new(factory, config),
+        let builder = FactoryAgentBuilder::new(factory, config);
+        let builder_mob_tools_slot = Arc::clone(&builder.default_mob_tools);
+        let builder_schedule_tools_slot = Arc::clone(&builder.default_schedule_tools);
+        *builder_schedule_tools_slot
+            .write()
+            .unwrap_or_else(std::sync::PoisonError::into_inner) = Some(Arc::new(
+            ScheduleToolDispatcher::new(schedule_service.clone()),
+        ));
+        let service = Arc::new(Self::build_persistent_service(
+            builder,
             max_sessions,
-            persistence,
-        );
+            store,
+            runtime_store.clone(),
+            blob_store,
+            &runtime_adapter,
+        ));
 
         Self {
             service,
@@ -354,7 +320,7 @@ impl SessionRuntime {
                 registry: SourceIdentityRegistry::default(),
             })),
             #[cfg(feature = "mob")]
-            mob_state: StdRwLock::new(mob_state),
+            mob_state: StdRwLock::new(None),
             #[cfg(feature = "mcp")]
             mcp_sessions: RwLock::new(std::collections::HashMap::new()),
             callback_request_tx: StdRwLock::new(None),
@@ -363,6 +329,7 @@ impl SessionRuntime {
             ))),
             registered_tools_slot: StdRwLock::new(Arc::new(StdRwLock::new(Vec::new()))),
             builder_mob_tools_slot,
+            builder_schedule_tools_slot,
         }
     }
 
@@ -376,18 +343,26 @@ impl SessionRuntime {
         notification_sink: crate::router::NotificationSink,
     ) -> Self {
         let schedule_service = ScheduleService::new(persistence.schedule_store());
+        let runtime_adapter = persistence.runtime_adapter();
+        let (store, runtime_store, blob_store) = persistence.into_parts();
         let factory_clone = factory.clone();
-        let RuntimeBackedServiceComponents {
-            service,
-            runtime_adapter,
-            builder_mob_tools_slot,
-            #[cfg(feature = "mob")]
-            mob_state,
-        } = Self::compose_runtime_backed_service(
-            FactoryAgentBuilder::new_with_config_store(factory, initial_config, config_store),
+        let builder =
+            FactoryAgentBuilder::new_with_config_store(factory, initial_config, config_store);
+        let builder_mob_tools_slot = Arc::clone(&builder.default_mob_tools);
+        let builder_schedule_tools_slot = Arc::clone(&builder.default_schedule_tools);
+        *builder_schedule_tools_slot
+            .write()
+            .unwrap_or_else(std::sync::PoisonError::into_inner) = Some(Arc::new(
+            ScheduleToolDispatcher::new(schedule_service.clone()),
+        ));
+        let service = Arc::new(Self::build_persistent_service(
+            builder,
             max_sessions,
-            persistence,
-        );
+            store,
+            runtime_store.clone(),
+            blob_store,
+            &runtime_adapter,
+        ));
 
         Self {
             service,
@@ -408,7 +383,7 @@ impl SessionRuntime {
                 registry: SourceIdentityRegistry::default(),
             })),
             #[cfg(feature = "mob")]
-            mob_state: StdRwLock::new(mob_state),
+            mob_state: StdRwLock::new(None),
             #[cfg(feature = "mcp")]
             mcp_sessions: RwLock::new(std::collections::HashMap::new()),
             callback_request_tx: StdRwLock::new(None),
@@ -417,7 +392,29 @@ impl SessionRuntime {
             ))),
             registered_tools_slot: StdRwLock::new(Arc::new(StdRwLock::new(Vec::new()))),
             builder_mob_tools_slot,
+            builder_schedule_tools_slot,
         }
+    }
+
+    /// Build a `PersistentSessionService` with the runtime bindings provider
+    /// wired to the runtime adapter so lazy session rebuilds use the canonical
+    /// bindings instead of an orphaned fallback.
+    fn build_persistent_service(
+        builder: FactoryAgentBuilder,
+        max_sessions: usize,
+        store: Arc<dyn meerkat_store::SessionStore>,
+        runtime_store: Option<Arc<dyn meerkat_runtime::RuntimeStore>>,
+        blob_store: Arc<dyn meerkat_core::BlobStore>,
+        runtime_adapter: &Arc<meerkat_runtime::RuntimeSessionAdapter>,
+    ) -> PersistentSessionService<FactoryAgentBuilder> {
+        let mut service =
+            PersistentSessionService::new(builder, max_sessions, store, runtime_store, blob_store);
+        let adapter = runtime_adapter.clone();
+        service.set_runtime_bindings_provider(Arc::new(move |session_id| {
+            let adapter = adapter.clone();
+            Box::pin(async move { adapter.prepare_bindings(session_id).await.ok() })
+        }));
+        service
     }
 
     /// Attach realm context defaults used for session metadata.
@@ -850,17 +847,9 @@ impl SessionRuntime {
 
     #[cfg(feature = "mob")]
     pub fn set_mob_state(&self, mob_state: Arc<meerkat_mob_mcp::MobMcpState>) {
-        let mob_tools_factory = Arc::new(meerkat_mob_mcp::AgentMobToolSurfaceFactory::new(
-            Arc::clone(&mob_state),
-        ));
-        *self
-            .mob_state
-            .write()
-            .unwrap_or_else(std::sync::PoisonError::into_inner) = Some(mob_state);
-        *self
-            .builder_mob_tools_slot
-            .write()
-            .unwrap_or_else(std::sync::PoisonError::into_inner) = Some(mob_tools_factory);
+        if let Ok(mut slot) = self.mob_state.write() {
+            *slot = Some(mob_state);
+        }
     }
 
     #[cfg(feature = "mob")]
@@ -1202,6 +1191,24 @@ impl SessionRuntime {
             }
         };
 
+        let persisted_keep_alive = if pending_session.is_none() {
+            self.load_persisted_session(session_id)
+                .await?
+                .and_then(|session| session.session_metadata().map(|meta| meta.keep_alive))
+        } else {
+            None
+        };
+        let keep_alive = overrides
+            .as_ref()
+            .and_then(|ov| ov.keep_alive)
+            .or_else(|| {
+                pending_session
+                    .as_ref()
+                    .map(|(build_config, _, _, _, _)| build_config.keep_alive)
+            })
+            .or(persisted_keep_alive)
+            .unwrap_or(false);
+
         if pending_session.is_none() && !self.live_session_is_stale(session_id).await? {
             // Hot-swap LLM client if model/provider overrides are present.
             if let Some(ref ov) = overrides
@@ -1490,7 +1497,9 @@ impl SessionRuntime {
             override_builtins: tooling.builtins,
             override_shell: tooling.shell,
             override_memory: tooling.memory,
+            override_schedule: meerkat_core::ToolCategoryOverride::Inherit,
             override_mob: meerkat_core::ToolCategoryOverride::Inherit,
+            schedule_tools: None,
             mob_tool_authority_context: None,
             preload_skills: tooling.active_skills.clone(),
             realm_id: stored_metadata
@@ -1530,8 +1539,6 @@ impl SessionRuntime {
                 .as_ref()
                 .and_then(Session::mob_tool_authority_context),
         );
-        #[cfg(feature = "comms")]
-        let keep_alive = build.keep_alive;
         self.service
             .create_session(CreateSessionRequest {
                 model: stored_metadata
@@ -3606,46 +3613,6 @@ mod tests {
         assert!(
             slot.is_some(),
             "builder_mob_tools_slot should be set after set_mob_tools"
-        );
-    }
-
-    #[cfg(feature = "mob")]
-    #[tokio::test]
-    async fn set_mob_state_refreshes_builder_mob_tools_slot() {
-        let temp = tempfile::tempdir().unwrap();
-        let factory = AgentFactory::new(temp.path().join("sessions"))
-            .builtins(true)
-            .mob(true);
-        let runtime = make_runtime(factory, 10);
-
-        let original_factory = runtime
-            .builder_mob_tools_slot
-            .read()
-            .unwrap()
-            .clone()
-            .expect("host should preinstall a mob tools factory");
-
-        let mob_svc = runtime.session_service();
-        let replacement_state = Arc::new(meerkat_mob_mcp::MobMcpState::new(mob_svc));
-        runtime.set_mob_state(Arc::clone(&replacement_state));
-
-        let installed_state = runtime
-            .mob_state()
-            .expect("runtime mob state should be set");
-        assert!(
-            Arc::ptr_eq(&installed_state, &replacement_state),
-            "runtime should expose the replacement mob state"
-        );
-
-        let refreshed_factory = runtime
-            .builder_mob_tools_slot
-            .read()
-            .unwrap()
-            .clone()
-            .expect("replacement mob state should refresh the builder tools slot");
-        assert!(
-            !Arc::ptr_eq(&original_factory, &refreshed_factory),
-            "builder mob tools slot should refresh when the mob state changes"
         );
     }
 

--- a/meerkat-schedule/src/lib.rs
+++ b/meerkat-schedule/src/lib.rs
@@ -37,7 +37,7 @@ pub use tool_surface::ScheduleToolSurface;
 pub use tools::{
     CAPABILITY_UNAVAILABLE as SCHEDULE_TOOL_CAPABILITY_UNAVAILABLE,
     INVALID_ARGUMENTS as SCHEDULE_TOOL_INVALID_ARGUMENTS, NOT_FOUND as SCHEDULE_TOOL_NOT_FOUND,
-    ScheduleToolError, handle_schedule_tools_call, schedule_tools_list,
+    ScheduleToolDispatcher, ScheduleToolError, handle_schedule_tools_call, schedule_tools_list,
 };
 pub use trigger::{CronAuthoringSpec, next_due_after, occurrences_for_horizon};
 pub use types::{

--- a/meerkat-schedule/src/tools.rs
+++ b/meerkat-schedule/src/tools.rs
@@ -2,9 +2,14 @@ use crate::{
     CreateScheduleRequest, Occurrence, ScheduleDomainError, ScheduleId, ScheduleService,
     ScheduleStoreError, UpdateScheduleRequest,
 };
+use async_trait::async_trait;
+use meerkat_core::error::ToolError;
+use meerkat_core::types::{ToolCallView, ToolDef, ToolResult};
+use meerkat_core::{AgentToolDispatcher, ToolDispatchOutcome};
 use serde::de::DeserializeOwned;
 use serde::{Deserialize, Serialize};
 use serde_json::{Value, json};
+use std::sync::Arc;
 
 pub const INVALID_ARGUMENTS: i32 = -32602;
 const INTERNAL_ERROR: i32 = -32000;
@@ -95,6 +100,49 @@ pub fn schedule_tools_list() -> Vec<Value> {
             schedule_id_schema("The schedule_id whose occurrences should be listed."),
         ),
     ]
+}
+
+pub struct ScheduleToolDispatcher {
+    service: ScheduleService,
+    tool_defs: Arc<[Arc<ToolDef>]>,
+}
+
+impl ScheduleToolDispatcher {
+    pub fn new(service: ScheduleService) -> Self {
+        let tool_defs: Arc<[Arc<ToolDef>]> = schedule_tools_list()
+            .into_iter()
+            .map(|tool| {
+                Arc::new(ToolDef {
+                    name: tool["name"].as_str().unwrap_or_default().to_string(),
+                    description: tool["description"].as_str().unwrap_or_default().to_string(),
+                    input_schema: tool["inputSchema"].clone(),
+                })
+            })
+            .collect::<Vec<_>>()
+            .into();
+        Self { service, tool_defs }
+    }
+}
+
+#[async_trait]
+impl AgentToolDispatcher for ScheduleToolDispatcher {
+    fn tools(&self) -> Arc<[Arc<ToolDef>]> {
+        Arc::clone(&self.tool_defs)
+    }
+
+    async fn dispatch(&self, call: ToolCallView<'_>) -> Result<ToolDispatchOutcome, ToolError> {
+        if !self.tool_defs.iter().any(|tool| tool.name == call.name) {
+            return Err(ToolError::not_found(call.name));
+        }
+
+        let arguments: Value = serde_json::from_str(call.args.get())
+            .unwrap_or_else(|_| Value::String(call.args.get().to_string()));
+        let result = handle_schedule_tools_call(&self.service, call.name, &arguments)
+            .await
+            .map_err(|error| map_schedule_tool_dispatch_error(call.name, error))?;
+
+        Ok(ToolResult::new(call.id.to_string(), result.to_string(), false).into())
+    }
 }
 
 pub async fn handle_schedule_tools_call(
@@ -232,6 +280,15 @@ fn map_schedule_error(error: ScheduleDomainError) -> ScheduleToolError {
     }
 }
 
+fn map_schedule_tool_dispatch_error(name: &str, error: ScheduleToolError) -> ToolError {
+    if error.code == INVALID_ARGUMENTS {
+        return ToolError::invalid_arguments(name, error.message);
+    }
+    ToolError::ExecutionFailed {
+        message: format!("{name}: {}", error.message),
+    }
+}
+
 fn tool_descriptor(name: &'static str, description: &'static str, input_schema: Value) -> Value {
     json!({
         "name": name,
@@ -351,7 +408,9 @@ mod tests {
         OverlapPolicy, ScheduledSessionAction, SessionTargetBinding, TargetBinding, TriggerSpec,
     };
     use chrono::{Duration, Utc};
+    use meerkat_core::{AgentToolDispatcher, ToolError};
     use meerkat_core::{ContentInput, SessionId};
+    use serde_json::value::RawValue;
     use std::collections::BTreeMap;
     use std::sync::Arc;
 
@@ -418,5 +477,88 @@ mod tests {
             "planning should persist occurrences"
         );
         Ok(())
+    }
+
+    fn tool_call<'a>(
+        id: &'a str,
+        name: &'a str,
+        args: &'a RawValue,
+    ) -> meerkat_core::ToolCallView<'a> {
+        meerkat_core::ToolCallView { id, name, args }
+    }
+
+    #[tokio::test]
+    async fn schedule_tool_dispatcher_tools_match_tool_list() {
+        let service = ScheduleService::new(Arc::new(MemoryScheduleStore::default()));
+        let dispatcher = ScheduleToolDispatcher::new(service);
+
+        let actual: Vec<String> = dispatcher
+            .tools()
+            .iter()
+            .map(|tool| tool.name.clone())
+            .collect();
+        let expected: Vec<String> = schedule_tools_list()
+            .into_iter()
+            .map(|value| value["name"].as_str().expect("tool name").to_string())
+            .collect();
+
+        assert_eq!(actual, expected);
+    }
+
+    #[tokio::test]
+    async fn schedule_tool_dispatcher_delegates_to_schedule_handler() -> Result<(), String> {
+        let service = ScheduleService::new(Arc::new(MemoryScheduleStore::default()));
+        let dispatcher = ScheduleToolDispatcher::new(service.clone());
+        let args = serde_json::to_string(&schedule_request()).map_err(|error| error.to_string())?;
+        let raw = RawValue::from_string(args).map_err(|error| error.to_string())?;
+        let call = tool_call("sched-1", "meerkat_schedule_create", raw.as_ref());
+
+        let outcome = dispatcher
+            .dispatch(call)
+            .await
+            .map_err(|error| format!("{error:?}"))?;
+        let created_value: Value = serde_json::from_str(&outcome.result.text_content())
+            .map_err(|error| error.to_string())?;
+        assert_eq!(created_value["name"].as_str(), Some("heartbeat"));
+        assert!(created_value["schedule_id"].as_str().is_some());
+
+        let listed = handle_schedule_tools_call(&service, "meerkat_schedule_list", &json!({}))
+            .await
+            .map_err(|error| format!("{error:?}"))?;
+        assert_eq!(listed["schedules"].as_array().map(Vec::len), Some(1));
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn schedule_tool_dispatcher_unknown_tool_is_not_found() {
+        let service = ScheduleService::new(Arc::new(MemoryScheduleStore::default()));
+        let dispatcher = ScheduleToolDispatcher::new(service);
+        let raw = RawValue::from_string("{}".to_string()).expect("raw args");
+        let err = dispatcher
+            .dispatch(tool_call("sched-2", "unknown_schedule_tool", raw.as_ref()))
+            .await
+            .expect_err("unknown tool should fail");
+
+        assert!(matches!(err, ToolError::NotFound { .. }));
+    }
+
+    #[tokio::test]
+    async fn schedule_tool_dispatcher_maps_unsupported_backend_to_execution_failed() {
+        let service = ScheduleService::new(Arc::new(crate::DisabledScheduleStore));
+        let dispatcher = ScheduleToolDispatcher::new(service);
+        let raw = RawValue::from_string(
+            serde_json::to_string(&schedule_request()).expect("schedule request json"),
+        )
+        .expect("raw args");
+        let err = dispatcher
+            .dispatch(tool_call(
+                "sched-3",
+                "meerkat_schedule_create",
+                raw.as_ref(),
+            ))
+            .await
+            .expect_err("unsupported backend should fail");
+
+        assert!(matches!(err, ToolError::ExecutionFailed { .. }));
     }
 }

--- a/meerkat-schedule/src/tools.rs
+++ b/meerkat-schedule/src/tools.rs
@@ -392,66 +392,48 @@ fn date_time_schema(description: &'static str) -> Value {
 
 fn trigger_spec_schema() -> Value {
     json!({
-        "description": "TriggerSpec uses externally tagged JSON. Example once trigger: {\"Once\":{\"due_at_utc\":\"2026-04-09T12:00:00Z\"}}. Example interval trigger: {\"Interval\":{\"start_at_utc\":\"2026-04-09T12:00:00Z\",\"every_seconds\":60}}.",
+        "description": "TriggerSpec uses internally tagged JSON with a type field. Example once trigger: {\"type\":\"once\",\"due_at_utc\":\"2026-04-09T12:00:00Z\"}. Example interval trigger: {\"type\":\"interval\",\"start_at_utc\":\"2026-04-09T12:00:00Z\",\"every_seconds\":60}.",
         "oneOf": [
             {
                 "type": "object",
                 "properties": {
-                    "Once": {
-                        "type": "object",
-                        "properties": {
-                            "due_at_utc": date_time_schema("Deliver once at this UTC timestamp.")
-                        },
-                        "required": ["due_at_utc"],
-                        "additionalProperties": false
-                    }
+                    "type": { "const": "once" },
+                    "due_at_utc": date_time_schema("Deliver once at this UTC timestamp.")
                 },
-                "required": ["Once"],
+                "required": ["type", "due_at_utc"],
                 "additionalProperties": false
             },
             {
                 "type": "object",
                 "properties": {
-                    "Interval": {
-                        "type": "object",
-                        "properties": {
-                            "start_at_utc": date_time_schema("First due time in UTC."),
-                            "every_seconds": {
-                                "type": "integer",
-                                "minimum": 1,
-                                "description": "Repeat cadence in seconds."
-                            },
-                            "end_at_utc": date_time_schema("Optional final due time in UTC.")
-                        },
-                        "required": ["start_at_utc", "every_seconds"],
-                        "additionalProperties": false
-                    }
+                    "type": { "const": "interval" },
+                    "start_at_utc": date_time_schema("First due time in UTC."),
+                    "every_seconds": {
+                        "type": "integer",
+                        "minimum": 1,
+                        "description": "Repeat cadence in seconds."
+                    },
+                    "end_at_utc": date_time_schema("Optional final due time in UTC.")
                 },
-                "required": ["Interval"],
+                "required": ["type", "start_at_utc", "every_seconds"],
                 "additionalProperties": false
             },
             {
                 "type": "object",
                 "properties": {
-                    "Calendar": {
-                        "type": "object",
-                        "properties": {
-                            "timezone": {
-                                "type": "string",
-                                "description": "IANA timezone such as Europe/Stockholm or UTC."
-                            },
-                            "minute": calendar_field_schema("Minute values."),
-                            "hour": calendar_field_schema("Hour values, 0-23."),
-                            "day_of_month": calendar_field_schema("Day-of-month values, 1-31."),
-                            "month": calendar_field_schema("Month values, 1-12."),
-                            "day_of_week": calendar_field_schema("Weekday values, Monday=1 style domain used by the scheduler."),
-                            "year": calendar_field_schema("Optional year filter.")
-                        },
-                        "required": ["timezone"],
-                        "additionalProperties": false
-                    }
+                    "type": { "const": "calendar" },
+                    "timezone": {
+                        "type": "string",
+                        "description": "IANA timezone such as Europe/Stockholm or UTC."
+                    },
+                    "minute": calendar_field_schema("Minute values."),
+                    "hour": calendar_field_schema("Hour values, 0-23."),
+                    "day_of_month": calendar_field_schema("Day-of-month values, 1-31."),
+                    "month": calendar_field_schema("Month values, 1-12."),
+                    "day_of_week": calendar_field_schema("Weekday values using the scheduler's cron-style domain: 0-6 and weekday names such as MON or FRI."),
+                    "year": calendar_field_schema("Optional year filter.")
                 },
-                "required": ["Calendar"],
+                "required": ["type", "timezone"],
                 "additionalProperties": false
             }
         ]
@@ -865,6 +847,35 @@ mod tests {
             .collect();
 
         assert_eq!(actual, expected);
+    }
+
+    #[test]
+    fn schedule_trigger_schema_matches_internal_tagged_deserializer_shape() {
+        let tools = schedule_tools_list();
+        let create_schema = &tools
+            .iter()
+            .find(|tool| tool["name"] == "meerkat_schedule_create")
+            .expect("create tool schema must exist")["inputSchema"];
+        let trigger_schema = &create_schema["properties"]["trigger"];
+        let variants = trigger_schema["oneOf"]
+            .as_array()
+            .expect("trigger schema variants must be an array");
+
+        assert_eq!(
+            trigger_schema["description"].as_str(),
+            Some(
+                "TriggerSpec uses internally tagged JSON with a type field. Example once trigger: {\"type\":\"once\",\"due_at_utc\":\"2026-04-09T12:00:00Z\"}. Example interval trigger: {\"type\":\"interval\",\"start_at_utc\":\"2026-04-09T12:00:00Z\",\"every_seconds\":60}."
+            )
+        );
+        assert_eq!(variants[0]["properties"]["type"]["const"], json!("once"));
+        assert_eq!(
+            variants[1]["properties"]["type"]["const"],
+            json!("interval")
+        );
+        assert_eq!(
+            variants[2]["properties"]["type"]["const"],
+            json!("calendar")
+        );
     }
 
     #[tokio::test]

--- a/meerkat-schedule/src/tools.rs
+++ b/meerkat-schedule/src/tools.rs
@@ -124,7 +124,8 @@ impl ScheduleToolDispatcher {
     }
 }
 
-#[async_trait]
+#[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
+#[cfg_attr(not(target_arch = "wasm32"), async_trait)]
 impl AgentToolDispatcher for ScheduleToolDispatcher {
     fn tools(&self) -> Arc<[Arc<ToolDef>]> {
         Arc::clone(&self.tool_defs)

--- a/meerkat-schedule/src/tools.rs
+++ b/meerkat-schedule/src/tools.rs
@@ -61,7 +61,7 @@ pub fn schedule_tools_list() -> Vec<Value> {
     vec![
         tool_descriptor(
             "meerkat_schedule_create",
-            "Create a realm-scoped schedule from typed trigger and target data.",
+            "Create a realm-scoped schedule. Use an explicit TriggerSpec and TargetBinding; the input schema includes the exact JSON shapes for once, interval, calendar, session, and mob schedules. For follow-ups in an existing long-lived session such as TUX, use target_kind=session with type=exact_session or resumable_session and a real session_id. If you do not have a session_id, use materialize_on_demand_session instead.",
             create_schedule_schema(),
         ),
         tool_descriptor(
@@ -76,7 +76,7 @@ pub fn schedule_tools_list() -> Vec<Value> {
         ),
         tool_descriptor(
             "meerkat_schedule_update",
-            "Update a persisted schedule by schedule_id.",
+            "Update a persisted schedule by schedule_id. Any provided trigger or target must use the same typed shapes as meerkat_schedule_create.",
             update_schedule_schema(),
         ),
         tool_descriptor(
@@ -325,23 +325,11 @@ fn create_schedule_schema() -> Value {
         "properties": {
             "name": { "type": "string" },
             "description": { "type": "string" },
-            "trigger": {
-                "type": "object",
-                "description": "Typed trigger specification; canonical truth is TriggerSpec, not a cron string."
-            },
-            "target": {
-                "type": "object",
-                "description": "Typed session or mob target binding."
-            },
-            "misfire_policy": {
-                "description": "Misfire policy value; e.g. skip or catch_up_within."
-            },
-            "overlap_policy": {
-                "description": "Overlap policy value; e.g. allow_concurrent or skip_if_running."
-            },
-            "missing_target_policy": {
-                "description": "Missing target policy value; e.g. skip or mark_misfired."
-            },
+            "trigger": trigger_spec_schema(),
+            "target": target_binding_schema(),
+            "misfire_policy": misfire_policy_schema(),
+            "overlap_policy": overlap_policy_schema(),
+            "missing_target_policy": missing_target_policy_schema(),
             "labels": {
                 "type": "object",
                 "additionalProperties": { "type": "string" }
@@ -370,17 +358,11 @@ fn update_schedule_schema() -> Value {
             },
             "name": { "type": "string" },
             "description": { "type": "string" },
-            "trigger": {
-                "type": "object",
-                "description": "Updated typed trigger specification."
-            },
-            "target": {
-                "type": "object",
-                "description": "Updated typed session or mob target binding."
-            },
-            "misfire_policy": { "description": "Updated misfire policy." },
-            "overlap_policy": { "description": "Updated overlap policy." },
-            "missing_target_policy": { "description": "Updated missing-target policy." },
+            "trigger": trigger_spec_schema(),
+            "target": target_binding_schema(),
+            "misfire_policy": misfire_policy_schema(),
+            "overlap_policy": overlap_policy_schema(),
+            "missing_target_policy": missing_target_policy_schema(),
             "labels": {
                 "type": "object",
                 "additionalProperties": { "type": "string" }
@@ -396,6 +378,385 @@ fn update_schedule_schema() -> Value {
         },
         "required": ["schedule_id"],
         "additionalProperties": false,
+    })
+}
+
+fn date_time_schema(description: &'static str) -> Value {
+    json!({
+        "type": "string",
+        "format": "date-time",
+        "description": description,
+    })
+}
+
+fn trigger_spec_schema() -> Value {
+    json!({
+        "description": "TriggerSpec uses externally tagged JSON. Example once trigger: {\"Once\":{\"due_at_utc\":\"2026-04-09T12:00:00Z\"}}. Example interval trigger: {\"Interval\":{\"start_at_utc\":\"2026-04-09T12:00:00Z\",\"every_seconds\":60}}.",
+        "oneOf": [
+            {
+                "type": "object",
+                "properties": {
+                    "Once": {
+                        "type": "object",
+                        "properties": {
+                            "due_at_utc": date_time_schema("Deliver once at this UTC timestamp.")
+                        },
+                        "required": ["due_at_utc"],
+                        "additionalProperties": false
+                    }
+                },
+                "required": ["Once"],
+                "additionalProperties": false
+            },
+            {
+                "type": "object",
+                "properties": {
+                    "Interval": {
+                        "type": "object",
+                        "properties": {
+                            "start_at_utc": date_time_schema("First due time in UTC."),
+                            "every_seconds": {
+                                "type": "integer",
+                                "minimum": 1,
+                                "description": "Repeat cadence in seconds."
+                            },
+                            "end_at_utc": date_time_schema("Optional final due time in UTC.")
+                        },
+                        "required": ["start_at_utc", "every_seconds"],
+                        "additionalProperties": false
+                    }
+                },
+                "required": ["Interval"],
+                "additionalProperties": false
+            },
+            {
+                "type": "object",
+                "properties": {
+                    "Calendar": {
+                        "type": "object",
+                        "properties": {
+                            "timezone": {
+                                "type": "string",
+                                "description": "IANA timezone such as Europe/Stockholm or UTC."
+                            },
+                            "minute": calendar_field_schema("Minute values."),
+                            "hour": calendar_field_schema("Hour values, 0-23."),
+                            "day_of_month": calendar_field_schema("Day-of-month values, 1-31."),
+                            "month": calendar_field_schema("Month values, 1-12."),
+                            "day_of_week": calendar_field_schema("Weekday values, Monday=1 style domain used by the scheduler."),
+                            "year": calendar_field_schema("Optional year filter.")
+                        },
+                        "required": ["timezone"],
+                        "additionalProperties": false
+                    }
+                },
+                "required": ["Calendar"],
+                "additionalProperties": false
+            }
+        ]
+    })
+}
+
+fn calendar_field_schema(description: &'static str) -> Value {
+    json!({
+        "description": description,
+        "oneOf": [
+            {
+                "type": "object",
+                "properties": { "kind": { "const": "any" } },
+                "required": ["kind"],
+                "additionalProperties": false
+            },
+            {
+                "type": "object",
+                "properties": {
+                    "kind": { "const": "values" },
+                    "values": {
+                        "type": "array",
+                        "items": { "type": "integer", "minimum": 0 }
+                    }
+                },
+                "required": ["kind", "values"],
+                "additionalProperties": false
+            }
+        ]
+    })
+}
+
+fn target_binding_schema() -> Value {
+    json!({
+        "description": "TargetBinding selects a session or mob recipient. For a follow-up in the current TUX session, use target_kind=session with type=exact_session or resumable_session and a real session_id. If you need a fresh scheduled session, use materialize_on_demand_session.",
+        "oneOf": [
+            {
+                "type": "object",
+                "properties": {
+                    "target_kind": { "const": "session" },
+                    "type": {
+                        "enum": ["exact_session", "resumable_session", "materialize_on_demand_session"]
+                    },
+                    "session_id": {
+                        "type": "string",
+                        "description": "Required for exact_session and resumable_session."
+                    },
+                    "action": scheduled_session_action_schema(),
+                    "create": session_materialization_spec_schema(),
+                    "bound_session_id": {
+                        "type": "string",
+                        "description": "Only used by persisted materialize_on_demand_session schedules after the first materialization."
+                    }
+                },
+                "required": ["target_kind", "type", "action"],
+                "allOf": [
+                    {
+                        "if": { "properties": { "type": { "const": "materialize_on_demand_session" } } },
+                        "then": { "required": ["create"] }
+                    },
+                    {
+                        "if": {
+                            "properties": {
+                                "type": { "enum": ["exact_session", "resumable_session"] }
+                            }
+                        },
+                        "then": { "required": ["session_id"] }
+                    }
+                ],
+                "additionalProperties": false
+            },
+            {
+                "type": "object",
+                "properties": {
+                    "target_kind": { "const": "mob" },
+                    "type": { "enum": ["member", "flow", "spawn_helper", "fork_helper"] },
+                    "mob_id": { "type": "string" },
+                    "member_id": { "type": "string" },
+                    "source_member_id": { "type": "string" },
+                    "flow_id": { "type": "string" },
+                    "params": {
+                        "description": "Raw JSON value for mob flow parameters."
+                    },
+                    "prompt": { "type": "string" },
+                    "action": scheduled_mob_action_schema(),
+                    "fork_context": fork_context_schema(),
+                    "options": helper_options_schema()
+                },
+                "required": ["target_kind", "type", "mob_id"],
+                "additionalProperties": false
+            }
+        ]
+    })
+}
+
+fn scheduled_session_action_schema() -> Value {
+    json!({
+        "oneOf": [
+            {
+                "type": "object",
+                "properties": {
+                    "type": { "const": "prompt" },
+                    "prompt": content_input_schema(),
+                    "system_prompt": {
+                        "type": "string",
+                        "description": "Only supported when materializing a new session."
+                    },
+                    "render_metadata": { "type": "object" },
+                    "skill_references": {
+                        "type": "array",
+                        "items": { "type": "string" },
+                        "description": "Canonical skill references in source_uuid/skill-name form."
+                    },
+                    "additional_instructions": {
+                        "type": "array",
+                        "items": { "type": "string" }
+                    }
+                },
+                "required": ["type", "prompt"],
+                "additionalProperties": false
+            },
+            {
+                "type": "object",
+                "properties": {
+                    "type": { "const": "event" },
+                    "event_type": { "type": "string" },
+                    "payload": {},
+                    "render_metadata": { "type": "object" }
+                },
+                "required": ["type", "event_type", "payload"],
+                "additionalProperties": false
+            }
+        ]
+    })
+}
+
+fn session_materialization_spec_schema() -> Value {
+    json!({
+        "type": "object",
+        "properties": {
+            "model": { "type": "string" },
+            "system_prompt": { "type": "string" },
+            "max_tokens": { "type": "integer", "minimum": 1 },
+            "provider": { "enum": ["anthropic", "openai", "gemini", "other"] },
+            "output_schema": { "type": "object" },
+            "structured_output_retries": { "type": "integer", "minimum": 0 },
+            "provider_params": { "type": "object" },
+            "comms_name": { "type": "string" },
+            "peer_meta": { "type": "object" },
+            "labels": {
+                "type": "object",
+                "additionalProperties": { "type": "string" }
+            },
+            "preload_skills": {
+                "type": "array",
+                "items": { "type": "string" }
+            },
+            "additional_instructions": {
+                "type": "array",
+                "items": { "type": "string" }
+            },
+            "realm_id": { "type": "string" },
+            "instance_id": { "type": "string" },
+            "backend": { "type": "string" },
+            "config_generation": { "type": "integer", "minimum": 0 },
+            "keep_alive": { "type": "boolean" },
+            "app_context": { "type": "object" }
+        },
+        "required": ["model"],
+        "additionalProperties": false
+    })
+}
+
+fn scheduled_mob_action_schema() -> Value {
+    json!({
+        "type": "object",
+        "properties": {
+            "type": { "const": "send" },
+            "content": content_input_schema(),
+            "render_metadata": { "type": "object" }
+        },
+        "required": ["type", "content"],
+        "additionalProperties": false
+    })
+}
+
+fn helper_options_schema() -> Value {
+    json!({
+        "type": "object",
+        "properties": {
+            "profile_name": { "type": "string" },
+            "runtime_mode": { "enum": ["autonomous_host", "turn_driven"] },
+            "backend": { "enum": ["session", "external"] },
+            "tool_access_policy": { "type": "object" }
+        },
+        "additionalProperties": false
+    })
+}
+
+fn fork_context_schema() -> Value {
+    json!({
+        "oneOf": [
+            {
+                "type": "object",
+                "properties": { "type": { "const": "full_history" } },
+                "required": ["type"],
+                "additionalProperties": false
+            },
+            {
+                "type": "object",
+                "properties": {
+                    "type": { "const": "last_messages" },
+                    "count": { "type": "integer", "minimum": 1 }
+                },
+                "required": ["type", "count"],
+                "additionalProperties": false
+            }
+        ]
+    })
+}
+
+fn content_input_schema() -> Value {
+    json!({
+        "description": "Either a plain text string or a list of multimodal content blocks.",
+        "oneOf": [
+            { "type": "string" },
+            {
+                "type": "array",
+                "items": {
+                    "oneOf": [
+                        {
+                            "type": "object",
+                            "properties": {
+                                "type": { "const": "text" },
+                                "text": { "type": "string" }
+                            },
+                            "required": ["type", "text"],
+                            "additionalProperties": false
+                        },
+                        {
+                            "type": "object",
+                            "properties": {
+                                "type": { "const": "image" },
+                                "media_type": { "type": "string" },
+                                "source": { "enum": ["inline", "blob"] },
+                                "data": { "type": "string" },
+                                "blob_id": { "type": "string" }
+                            },
+                            "required": ["type", "media_type", "source"],
+                            "additionalProperties": true
+                        },
+                        {
+                            "type": "object",
+                            "properties": {
+                                "type": { "const": "video" },
+                                "media_type": { "type": "string" },
+                                "duration_ms": { "type": "integer", "minimum": 0 },
+                                "source": { "const": "inline" },
+                                "data": { "type": "string" }
+                            },
+                            "required": ["type", "media_type", "duration_ms", "source", "data"],
+                            "additionalProperties": false
+                        }
+                    ]
+                }
+            }
+        ]
+    })
+}
+
+fn misfire_policy_schema() -> Value {
+    json!({
+        "description": "Misfire policy object. Most schedules should use {\"type\":\"skip\"}.",
+        "oneOf": [
+            {
+                "type": "object",
+                "properties": { "type": { "const": "skip" } },
+                "required": ["type"],
+                "additionalProperties": false
+            },
+            {
+                "type": "object",
+                "properties": {
+                    "type": { "const": "catch_up_within" },
+                    "window_seconds": { "type": "integer", "minimum": 1 }
+                },
+                "required": ["type", "window_seconds"],
+                "additionalProperties": false
+            }
+        ]
+    })
+}
+
+fn overlap_policy_schema() -> Value {
+    json!({
+        "type": "string",
+        "enum": ["allow_concurrent", "skip_if_running"],
+        "description": "How to handle overlapping occurrences for the same schedule."
+    })
+}
+
+fn missing_target_policy_schema() -> Value {
+    json!({
+        "type": "string",
+        "enum": ["skip", "mark_misfired"],
+        "description": "What to do if the target session or mob is missing when the occurrence becomes due."
     })
 }
 

--- a/meerkat/Cargo.toml
+++ b/meerkat/Cargo.toml
@@ -87,6 +87,7 @@ memory-store-session = ["dep:meerkat-memory"]
 # Optional subsystems
 comms = ["dep:meerkat-comms", "dep:parking_lot", "meerkat-tools/comms"]
 mcp = ["dep:meerkat-mcp", "meerkat-tools/mcp"]
+schedule = []
 skills = ["dep:meerkat-skills", "meerkat-skills/skills-http", "meerkat-tools/skills"]
 
 [package.metadata.cargo-machete]

--- a/meerkat/src/factory.rs
+++ b/meerkat/src/factory.rs
@@ -227,8 +227,17 @@ pub struct AgentBuildConfig {
     /// Per-build override for factory-level `enable_memory`.
     /// `Inherit` defers to the factory default.
     pub override_memory: ToolCategoryOverride,
+    /// Per-build override for factory-level `enable_schedule`.
+    /// `Inherit` defers to the factory default.
+    pub override_schedule: ToolCategoryOverride,
     /// Per-build override for factory-level `enable_mob`.
     pub override_mob: ToolCategoryOverride,
+    /// Agent-facing scheduler tools supplied by the embedding surface.
+    ///
+    /// Scheduler is a surface capability. This dispatcher only controls
+    /// visibility/composition; schedule execution remains owned by the
+    /// schedule service/host chosen by the embedding surface.
+    pub schedule_tools: Option<Arc<dyn AgentToolDispatcher>>,
     /// Runtime-injected mob operator authority context.
     ///
     /// Tool visibility may depend on this context being present, but
@@ -340,7 +349,9 @@ impl std::fmt::Debug for AgentBuildConfig {
             .field("override_builtins", &self.override_builtins)
             .field("override_shell", &self.override_shell)
             .field("override_memory", &self.override_memory)
+            .field("override_schedule", &self.override_schedule)
             .field("override_mob", &self.override_mob)
+            .field("schedule_tools", &self.schedule_tools.is_some())
             .field(
                 "mob_tool_authority_context",
                 &self.mob_tool_authority_context.is_some(),
@@ -400,7 +411,9 @@ impl AgentBuildConfig {
             override_builtins: ToolCategoryOverride::Inherit,
             override_shell: ToolCategoryOverride::Inherit,
             override_memory: ToolCategoryOverride::Inherit,
+            override_schedule: ToolCategoryOverride::Inherit,
             override_mob: ToolCategoryOverride::Inherit,
+            schedule_tools: None,
             mob_tool_authority_context: None,
             mob_tools: None,
             preload_skills: None,
@@ -487,7 +500,9 @@ impl AgentBuildConfig {
         self.override_builtins = build.override_builtins;
         self.override_shell = build.override_shell;
         self.override_memory = build.override_memory;
+        self.override_schedule = build.override_schedule;
         self.override_mob = build.override_mob;
+        self.schedule_tools = build.schedule_tools.clone();
         self.mob_tool_authority_context = build.mob_tool_authority_context.clone();
         self.mob_tools = build.mob_tools.clone();
         self.preload_skills = build.preload_skills.clone();
@@ -530,7 +545,9 @@ impl AgentBuildConfig {
             override_builtins: self.override_builtins,
             override_shell: self.override_shell,
             override_memory: self.override_memory,
+            override_schedule: self.override_schedule,
             override_mob: self.override_mob,
+            schedule_tools: self.schedule_tools.clone(),
             mob_tool_authority_context: self.mob_tool_authority_context.clone(),
             mob_tools: self.mob_tools.clone(),
             preload_skills: self.preload_skills.clone(),
@@ -625,6 +642,7 @@ pub struct AgentFactory {
     #[cfg(feature = "comms")]
     pub enable_comms: bool,
     pub enable_memory: bool,
+    pub enable_schedule: bool,
     pub enable_mob: bool,
     /// Optional skill source override. When set, bypasses config-driven
     /// repository resolution. For SDK users who wire sources programmatically.
@@ -659,6 +677,7 @@ impl std::fmt::Debug for AgentFactory {
             .field("enable_builtins", &self.enable_builtins)
             .field("enable_shell", &self.enable_shell)
             .field("enable_memory", &self.enable_memory)
+            .field("enable_schedule", &self.enable_schedule)
             .field("enable_mob", &self.enable_mob);
         #[cfg(feature = "comms")]
         d.field("enable_comms", &self.enable_comms);
@@ -690,6 +709,7 @@ impl AgentFactory {
             #[cfg(feature = "comms")]
             enable_comms: false,
             enable_memory: false,
+            enable_schedule: false,
             enable_mob: false,
             #[cfg(feature = "skills")]
             skill_source: None,
@@ -713,6 +733,7 @@ impl AgentFactory {
             #[cfg(feature = "comms")]
             enable_comms: false,
             enable_memory: false,
+            enable_schedule: false,
             enable_mob: false,
             #[cfg(feature = "skills")]
             skill_source: None,
@@ -770,6 +791,12 @@ impl AgentFactory {
     /// Enable or disable semantic memory (memory_search tool + compaction indexing).
     pub fn memory(mut self, enabled: bool) -> Self {
         self.enable_memory = enabled;
+        self
+    }
+
+    /// Enable or disable scheduler tools.
+    pub fn schedule(mut self, enabled: bool) -> Self {
+        self.enable_schedule = enabled;
         self
     }
 
@@ -1584,8 +1611,32 @@ impl AgentFactory {
             "tool composition: after comms gateway"
         );
 
-        // 9b. Compose tools with mob surface (after comms, so mob gateway wraps the
-        // already-composed comms gateway).
+        // 9b. Compose tools with scheduler surface (after comms, before mob).
+        let effective_schedule = build_config.override_schedule.resolve(self.enable_schedule);
+        if effective_schedule && let Some(schedule_dispatcher) = build_config.schedule_tools.take()
+        {
+            let schedule_usage =
+                render_tool_usage_instructions(schedule_dispatcher.tools().as_ref());
+            tools = Arc::new(meerkat_core::DynamicToolComposite::new(vec![
+                tools,
+                schedule_dispatcher,
+            ]));
+            if !schedule_usage.is_empty() {
+                if !tool_usage_instructions.is_empty() {
+                    tool_usage_instructions.push_str("\n\n");
+                }
+                tool_usage_instructions.push_str(&schedule_usage);
+            }
+        }
+
+        tracing::debug!(
+            tool_count_after_schedule = tools.tools().len(),
+            effective_schedule,
+            "tool composition: after scheduler gateway"
+        );
+
+        // 9c. Compose tools with mob surface (after comms and scheduler, so mob
+        // gateway wraps the already-composed base capability stack).
         let effective_mob = build_config.override_mob.resolve(self.enable_mob)
             || build_config.mob_tool_authority_context.is_some();
         let mob_factory = build_config
@@ -1641,7 +1692,7 @@ impl AgentFactory {
             }
         }
 
-        // 9c. Bind capabilities on the FINAL composed dispatcher shape.
+        // 9d. Bind capabilities on the FINAL composed dispatcher shape.
         //
         // All composition (comms gateway, mob gateway) is complete.
         // Binding now happens once on the final shape. Gateway wrappers

--- a/meerkat/src/lib.rs
+++ b/meerkat/src/lib.rs
@@ -166,7 +166,7 @@ pub use meerkat_schedule::{
     SCHEDULE_TOOL_NOT_FOUND, Schedule, ScheduleDomainError, ScheduleDriver, ScheduleDriverConfig,
     ScheduleFilter, ScheduleId, SchedulePhase, ScheduleRevision, ScheduleService, ScheduleStore,
     ScheduleStoreError, ScheduleStoreKind, ScheduleTargetDelivery, ScheduleTargetProbe,
-    ScheduleToolError, ScheduleToolSurface, ScheduledMobAction, ScheduledMobBackendKind,
+    ScheduleToolDispatcher, ScheduleToolError, ScheduledMobAction, ScheduledMobBackendKind,
     ScheduledMobRuntimeMode, ScheduledSessionAction, SessionMaterializationSpec,
     SessionTargetBinding, TargetBinding, TargetProbeOutcome, TriggerSpec, UpdateScheduleRequest,
     handle_schedule_tools_call, schedule_tools_list,
@@ -230,6 +230,10 @@ pub use meerkat_store::JsonlStore;
 #[cfg(feature = "memory-store")]
 pub use meerkat_store::MemoryStore;
 
+#[cfg(all(feature = "session-store", not(target_arch = "wasm32")))]
+pub use meerkat_store::RedbScheduleStore;
+#[cfg(all(feature = "session-store", not(target_arch = "wasm32")))]
+pub use meerkat_store::RedbSessionStore;
 #[cfg(all(feature = "session-store", not(target_arch = "wasm32")))]
 pub use meerkat_store::SqliteScheduleStore;
 #[cfg(all(feature = "session-store", not(target_arch = "wasm32")))]

--- a/meerkat/src/lib.rs
+++ b/meerkat/src/lib.rs
@@ -231,10 +231,6 @@ pub use meerkat_store::JsonlStore;
 pub use meerkat_store::MemoryStore;
 
 #[cfg(all(feature = "session-store", not(target_arch = "wasm32")))]
-pub use meerkat_store::RedbScheduleStore;
-#[cfg(all(feature = "session-store", not(target_arch = "wasm32")))]
-pub use meerkat_store::RedbSessionStore;
-#[cfg(all(feature = "session-store", not(target_arch = "wasm32")))]
 pub use meerkat_store::SqliteScheduleStore;
 #[cfg(all(feature = "session-store", not(target_arch = "wasm32")))]
 pub use meerkat_store::SqliteSessionStore;

--- a/meerkat/src/service_factory.rs
+++ b/meerkat/src/service_factory.rs
@@ -281,6 +281,13 @@ pub struct FactoryAgentBuilder {
     /// session service construction and mob state creation).
     pub default_mob_tools:
         Arc<std::sync::RwLock<Option<Arc<dyn meerkat_core::service::MobToolsFactory>>>>,
+    /// Default scheduler tools injected into all builds.
+    ///
+    /// Wrapped in `Arc<StdRwLock<...>>` so surfaces can attach scheduler tool
+    /// visibility after the builder is consumed into a session service, while
+    /// keeping runtime/service ownership in the surface.
+    pub default_schedule_tools:
+        Arc<std::sync::RwLock<Option<Arc<dyn meerkat_core::AgentToolDispatcher>>>>,
 }
 
 impl FactoryAgentBuilder {
@@ -295,6 +302,7 @@ impl FactoryAgentBuilder {
             default_tool_dispatcher: None,
             default_session_store: None,
             default_mob_tools: Arc::new(std::sync::RwLock::new(None)),
+            default_schedule_tools: Arc::new(std::sync::RwLock::new(None)),
         }
     }
 
@@ -315,6 +323,7 @@ impl FactoryAgentBuilder {
             default_tool_dispatcher: None,
             default_session_store: None,
             default_mob_tools: Arc::new(std::sync::RwLock::new(None)),
+            default_schedule_tools: Arc::new(std::sync::RwLock::new(None)),
         }
     }
 
@@ -384,6 +393,17 @@ impl SessionAgentBuilder for FactoryAgentBuilder {
                 .clone()
         {
             build_config.mob_tools = Some(mob_factory);
+        }
+
+        // Inject default scheduler tools if none provided.
+        if build_config.schedule_tools.is_none()
+            && let Some(schedule_dispatcher) = self
+                .default_schedule_tools
+                .read()
+                .unwrap_or_else(std::sync::PoisonError::into_inner)
+                .clone()
+        {
+            build_config.schedule_tools = Some(schedule_dispatcher);
         }
 
         let config = self.resolve_config().await;
@@ -465,6 +485,7 @@ mod tests {
         Provider, ToolCallView, ToolDef, ToolDispatchOutcome, ToolError, ToolResult,
     };
     use meerkat_runtime::RuntimeSessionAdapter;
+    use meerkat_schedule::{MemoryScheduleStore, ScheduleService, ScheduleToolDispatcher};
     use meerkat_session::ephemeral::SessionAgent;
     use std::pin::Pin;
     use std::sync::Mutex;
@@ -478,6 +499,41 @@ mod tests {
     impl Default for MockLlmClient {
         fn default() -> Self {
             Self { delta: "ok" }
+        }
+    }
+
+    #[derive(Default)]
+    struct CaptureToolClient {
+        inner: meerkat_client::TestClient,
+        seen_tools: Mutex<Vec<String>>,
+    }
+
+    impl CaptureToolClient {
+        fn tool_names(&self) -> Vec<String> {
+            self.seen_tools.lock().expect("capture lock").clone()
+        }
+    }
+
+    #[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
+    #[cfg_attr(not(target_arch = "wasm32"), async_trait)]
+    impl LlmClient for CaptureToolClient {
+        fn stream<'a>(
+            &'a self,
+            request: &'a LlmRequest,
+        ) -> Pin<
+            Box<dyn futures::Stream<Item = Result<LlmEvent, meerkat_client::LlmError>> + Send + 'a>,
+        > {
+            *self.seen_tools.lock().expect("capture lock") =
+                request.tools.iter().map(|tool| tool.name.clone()).collect();
+            self.inner.stream(request)
+        }
+
+        fn provider(&self) -> &'static str {
+            self.inner.provider()
+        }
+
+        async fn health_check(&self) -> Result<(), meerkat_client::LlmError> {
+            self.inner.health_check().await
         }
     }
 
@@ -731,6 +787,78 @@ mod tests {
             .session_metadata()
             .ok_or_else(|| "missing session metadata".to_string())?;
         assert_eq!(metadata.provider, Provider::Other);
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn factory_builder_uses_default_schedule_tools_on_runtime_backed_resume()
+    -> Result<(), String> {
+        let temp = tempfile::tempdir().map_err(|err| format!("tempdir: {err}"))?;
+        let factory = AgentFactory::new(temp.path().join("sessions")).schedule(true);
+        let mut builder = FactoryAgentBuilder::new(factory, Config::default());
+        let capture: Arc<CaptureToolClient> = Arc::new(CaptureToolClient::default());
+        builder.default_llm_client = Some(capture.clone());
+        *builder
+            .default_schedule_tools
+            .write()
+            .unwrap_or_else(std::sync::PoisonError::into_inner) =
+            Some(Arc::new(ScheduleToolDispatcher::new(ScheduleService::new(
+                Arc::new(MemoryScheduleStore::default()),
+            ))));
+
+        let runtime_adapter = RuntimeSessionAdapter::ephemeral();
+        let session = Session::new();
+        let session_id = session.id().clone();
+        runtime_adapter.register_session(session_id.clone()).await;
+        let bindings = meerkat_core::SessionRuntimeBindings {
+            session_id,
+            epoch_id: meerkat_core::runtime_epoch::RuntimeEpochId::new(),
+            ops_lifecycle: runtime_adapter
+                .ops_lifecycle_registry(session.id())
+                .await
+                .ok_or_else(|| "missing runtime registry".to_string())?,
+            cursor_state: Arc::new(meerkat_core::EpochCursorState::new()),
+        };
+
+        let req = CreateSessionRequest {
+            model: "claude-sonnet-4-5".to_string(),
+            prompt: "hello".to_string().into(),
+            render_metadata: None,
+            system_prompt: None,
+            max_tokens: None,
+            event_tx: None,
+            skill_references: None,
+            initial_turn: meerkat_core::service::InitialTurnPolicy::RunImmediately,
+            deferred_prompt_policy: meerkat_core::service::DeferredPromptPolicy::Discard,
+            build: Some(SessionBuildOptions {
+                resume_session: Some(session),
+                runtime_build_mode: meerkat_core::RuntimeBuildMode::SessionOwned(bindings),
+                ..SessionBuildOptions::default()
+            }),
+            labels: None,
+        };
+
+        let (event_tx, _event_rx) = mpsc::channel(8);
+        let mut agent = builder
+            .build_agent(&req, event_tx)
+            .await
+            .map_err(|err| format!("{err}"))?;
+        let (run_tx, _run_rx) = mpsc::channel(8);
+        SessionAgent::run_with_events(&mut agent, "inspect".to_string().into(), run_tx)
+            .await
+            .map_err(|err| format!("{err}"))?;
+
+        let tool_names = capture.tool_names();
+        assert!(
+            tool_names
+                .iter()
+                .any(|name| name == "meerkat_schedule_create")
+        );
+        assert!(
+            tool_names
+                .iter()
+                .any(|name| name == "meerkat_schedule_list")
+        );
         Ok(())
     }
 

--- a/meerkat/tests/factory_build_agent.rs
+++ b/meerkat/tests/factory_build_agent.rs
@@ -13,15 +13,18 @@ use async_trait::async_trait;
 use futures::stream;
 use meerkat::BuildAgentError;
 use meerkat::{AgentBuildConfig, AgentFactory, LlmDoneOutcome, LlmEvent, LlmRequest};
-use meerkat_client::LlmClient;
+use meerkat_client::{LlmClient, TestClient};
+use meerkat_comms::{CommsRuntime, ResolvedCommsConfig, TrustedPeer, identity::Keypair};
 use meerkat_core::service::{MobToolAuthorityContext, OpaquePrincipalToken};
 use meerkat_core::{
     AgentToolDispatcher, Config, Provider, ProviderConfig, Session, SessionId, SessionMetadata,
     SessionTooling, ToolCallView, ToolCategoryOverride, ToolDef, ToolDispatchOutcome, ToolError,
     UserMessage,
 };
+use meerkat_schedule::{MemoryScheduleStore, ScheduleService, ScheduleToolDispatcher};
 use meerkat_store::{SessionFilter, SessionStore, SessionStoreError};
 use serde_json::json;
+use std::sync::Mutex;
 
 // ---------------------------------------------------------------------------
 // Mock LLM client (returns a simple text response)
@@ -58,6 +61,39 @@ impl LlmClient for MockLlmClient {
     }
 }
 
+#[derive(Default)]
+struct CaptureClient {
+    inner: TestClient,
+    seen_tools: Mutex<Vec<String>>,
+}
+
+impl CaptureClient {
+    fn tool_names(&self) -> Vec<String> {
+        self.seen_tools.lock().expect("capture lock").clone()
+    }
+}
+
+#[async_trait]
+impl LlmClient for CaptureClient {
+    fn stream<'a>(
+        &'a self,
+        request: &'a LlmRequest,
+    ) -> Pin<Box<dyn futures::Stream<Item = Result<LlmEvent, meerkat_client::LlmError>> + Send + 'a>>
+    {
+        *self.seen_tools.lock().expect("capture lock") =
+            request.tools.iter().map(|tool| tool.name.clone()).collect();
+        self.inner.stream(request)
+    }
+
+    fn provider(&self) -> &'static str {
+        self.inner.provider()
+    }
+
+    async fn health_check(&self) -> Result<(), meerkat_client::LlmError> {
+        self.inner.health_check().await
+    }
+}
+
 // ---------------------------------------------------------------------------
 // Helper: create a factory pointing at a temp directory
 // ---------------------------------------------------------------------------
@@ -72,6 +108,37 @@ struct EmptyDispatcher;
 impl AgentToolDispatcher for EmptyDispatcher {
     fn tools(&self) -> Arc<[Arc<ToolDef>]> {
         Vec::<Arc<ToolDef>>::new().into()
+    }
+
+    async fn dispatch(&self, call: ToolCallView<'_>) -> Result<ToolDispatchOutcome, ToolError> {
+        Err(ToolError::not_found(call.name))
+    }
+}
+
+struct NamedDispatcher {
+    tools: Arc<[Arc<ToolDef>]>,
+}
+
+impl NamedDispatcher {
+    fn new(name: &str) -> Self {
+        Self {
+            tools: Arc::from(vec![Arc::new(ToolDef {
+                name: name.to_string(),
+                description: format!("{name} test tool"),
+                input_schema: json!({
+                    "type": "object",
+                    "properties": {},
+                    "additionalProperties": false,
+                }),
+            })]),
+        }
+    }
+}
+
+#[async_trait]
+impl AgentToolDispatcher for NamedDispatcher {
+    fn tools(&self) -> Arc<[Arc<ToolDef>]> {
+        Arc::clone(&self.tools)
     }
 
     async fn dispatch(&self, call: ToolCallView<'_>) -> Result<ToolDispatchOutcome, ToolError> {
@@ -96,6 +163,34 @@ impl meerkat_core::service::MobToolsFactory for RecordingMobToolsFactory {
             .push(args.authority_context);
         Ok(Arc::new(EmptyDispatcher))
     }
+}
+
+struct StaticMobToolsFactory {
+    dispatcher: Arc<dyn AgentToolDispatcher>,
+}
+
+#[async_trait]
+impl meerkat_core::service::MobToolsFactory for StaticMobToolsFactory {
+    async fn build_mob_tools(
+        &self,
+        _args: meerkat_core::service::MobToolsBuildArgs,
+    ) -> Result<Arc<dyn AgentToolDispatcher>, Box<dyn std::error::Error + Send + Sync>> {
+        Ok(Arc::clone(&self.dispatcher))
+    }
+}
+
+async fn run_and_capture_tool_names(
+    factory: AgentFactory,
+    mut build_config: AgentBuildConfig,
+) -> Vec<String> {
+    let capture: Arc<CaptureClient> = Arc::new(CaptureClient::default());
+    build_config.llm_client_override = Some(capture.clone());
+    let mut agent = factory
+        .build_agent(build_config, &Config::default())
+        .await
+        .unwrap();
+    agent.run("inspect tools".to_string().into()).await.unwrap();
+    capture.tool_names()
 }
 
 fn create_test_authority() -> MobToolAuthorityContext {
@@ -277,6 +372,115 @@ async fn build_agent_with_builtins_has_tools() {
         ToolCategoryOverride::Inherit,
         "builtins should be Inherit when no explicit override was set"
     );
+}
+
+#[tokio::test]
+async fn build_agent_with_scheduler_has_tools_when_enabled_and_injected() {
+    let temp = tempfile::tempdir().unwrap();
+    let factory = temp_factory(&temp).schedule(true);
+    let tool_names = run_and_capture_tool_names(
+        factory,
+        AgentBuildConfig {
+            schedule_tools: Some(Arc::new(ScheduleToolDispatcher::new(ScheduleService::new(
+                Arc::new(MemoryScheduleStore::default()),
+            )))),
+            ..AgentBuildConfig::new("claude-sonnet-4-5")
+        },
+    )
+    .await;
+
+    assert!(
+        tool_names
+            .iter()
+            .any(|name| name == "meerkat_schedule_create")
+    );
+    assert!(
+        tool_names
+            .iter()
+            .any(|name| name == "meerkat_schedule_list")
+    );
+}
+
+#[tokio::test]
+async fn build_agent_without_scheduler_keeps_injected_scheduler_tools_hidden() {
+    let temp = tempfile::tempdir().unwrap();
+    let factory = temp_factory(&temp).schedule(false);
+    let tool_names = run_and_capture_tool_names(
+        factory,
+        AgentBuildConfig {
+            schedule_tools: Some(Arc::new(ScheduleToolDispatcher::new(ScheduleService::new(
+                Arc::new(MemoryScheduleStore::default()),
+            )))),
+            ..AgentBuildConfig::new("claude-sonnet-4-5")
+        },
+    )
+    .await;
+
+    assert!(
+        !tool_names
+            .iter()
+            .any(|name| name == "meerkat_schedule_create")
+    );
+}
+
+#[tokio::test]
+async fn build_agent_composes_scheduler_alongside_comms_and_mob() {
+    let temp = tempfile::tempdir().unwrap();
+    let comms_config = ResolvedCommsConfig {
+        enabled: true,
+        name: "test-scheduler-comms".to_string(),
+        inproc_namespace: None,
+        listen_tcp: None,
+        listen_uds: None,
+        event_listen_tcp: None,
+        #[cfg(unix)]
+        event_listen_uds: None,
+        identity_dir: temp.path().join("identity"),
+        trusted_peers_path: temp.path().join("trusted_peers.json"),
+        comms_config: Default::default(),
+        auth: Default::default(),
+        require_peer_auth: false,
+        allow_external_unauthenticated: false,
+    };
+    let comms_runtime = Arc::new(
+        CommsRuntime::new_with_silent_intents(comms_config, Arc::new(Default::default()))
+            .await
+            .unwrap(),
+    );
+    comms_runtime.upsert_trusted_peer(TrustedPeer {
+        name: "peer-a".into(),
+        pubkey: Keypair::generate().public_key(),
+        addr: "tcp://127.0.0.1:9999".into(),
+        meta: Default::default(),
+    });
+    let factory = temp_factory(&temp)
+        .comms(true)
+        .with_comms_runtime(comms_runtime)
+        .schedule(true)
+        .mob(true)
+        .mob_tools_factory(Arc::new(StaticMobToolsFactory {
+            dispatcher: Arc::new(NamedDispatcher::new("mob_probe")),
+        }));
+
+    let tool_names = run_and_capture_tool_names(
+        factory,
+        AgentBuildConfig {
+            schedule_tools: Some(Arc::new(ScheduleToolDispatcher::new(ScheduleService::new(
+                Arc::new(MemoryScheduleStore::default()),
+            )))),
+            ..AgentBuildConfig::new("claude-sonnet-4-5")
+        },
+    )
+    .await;
+
+    assert!(tool_names.iter().any(|name| name == "send_message"));
+    assert!(tool_names.iter().any(|name| name == "peers"));
+    assert!(
+        tool_names
+            .iter()
+            .any(|name| name == "meerkat_schedule_create")
+    );
+    assert!(tool_names.iter().any(|name| name == "mob_probe"));
 }
 
 /// 6. `build_agent` with `resume_session` preserves existing session messages.


### PR DESCRIPTION
## Summary
- add scheduler as a first-class optional agent capability, including default scheduler tool injection on runtime-backed and resumed builds
- wire explicit surface-owned scheduler runtime composition into CLI, REST, RPC, MCP, and example 035 instead of hiding host startup inside tool dispatch
- convert example 035 hive to a runtime-backed local surface with a real schedule host and SQLite-backed schedule store, and preserve scheduled prompt skill references through runtime delivery

## Testing
- `CARGO_TARGET_DIR=target/codex-schedule cargo check -p meerkat-core -p meerkat -p meerkat-rest -p meerkat-rpc -p meerkat-mcp-server -p rkat`
- `CARGO_TARGET_DIR=target/codex-schedule cargo check --manifest-path examples/035-mdm-tux-rs/Cargo.toml`
- `CARGO_TARGET_DIR=target/codex-schedule cargo test -p meerkat --lib factory_builder_uses_default_schedule_tools_on_runtime_backed_resume -- --nocapture`
- `CARGO_TARGET_DIR=target/codex-schedule cargo test --manifest-path examples/035-mdm-tux-rs/Cargo.toml target_builder_exposes_shell_comms_and_mob_tools -- --nocapture`
- `CARGO_TARGET_DIR=target/codex-schedule cargo test --manifest-path examples/035-mdm-tux-rs/Cargo.toml hive_build_exposes_comms_and_mob_tools_without_shell -- --nocapture`
- `CARGO_TARGET_DIR=target/codex-schedule cargo test --manifest-path examples/035-mdm-tux-rs/Cargo.toml resumed_session_retains_all_tool_categories -- --nocapture`
- `CARGO_TARGET_DIR=target/codex-schedule cargo clippy -p meerkat --lib -- -D warnings`
- `CARGO_TARGET_DIR=target/codex-schedule cargo clippy -p rkat -- -D warnings`
- `CARGO_TARGET_DIR=target/codex-schedule cargo clippy --manifest-path examples/035-mdm-tux-rs/Cargo.toml --bins -- -D warnings`
