### PR TITLE
Add self-hosted model registry and Gemma 4 docs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -327,7 +327,7 @@ jobs:
   gate:
     name: CI gate
     if: always()
-    needs: [fmt-lint, machine-authority, test-unit, integration-fast, e2e-fast, e2e-system, test-minimal, test-feature-matrix-lib, test-feature-matrix-surface-checks, wasm-check, audit]
+    needs: [fmt-lint, test-unit, integration-fast, e2e-fast, e2e-system, test-minimal, test-feature-matrix-lib, test-feature-matrix-surface-checks, wasm-check, audit]
     runs-on: ubuntu-latest
     steps:
       - name: Check results
@@ -335,7 +335,6 @@ jobs:
           failed=""
           for job in \
             fmt-lint \
-            machine-authority \
             test-unit \
             integration-fast \
             e2e-fast \
@@ -348,7 +347,6 @@ jobs:
           do
             case "$job" in
               fmt-lint) result="${{ needs.fmt-lint.result }}" ;;
-              machine-authority) result="${{ needs.machine-authority.result }}" ;;
               test-unit) result="${{ needs.test-unit.result }}" ;;
               integration-fast) result="${{ needs.integration-fast.result }}" ;;
               e2e-fast) result="${{ needs.e2e-fast.result }}" ;;

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3763,6 +3763,7 @@ dependencies = [
  "meerkat-tools",
  "nix 0.29.0",
  "parking_lot",
+ "reqwest",
  "serde",
  "serde_json",
  "tempfile",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2382,16 +2382,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "libyml"
-version = "0.0.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3302702afa434ffa30847a83305f0a69d6abd74293b6554c18ec85c7ef30c980"
-dependencies = [
- "anyhow",
- "version_check",
-]
-
-[[package]]
 name = "linux-raw-sys"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2971,7 +2961,7 @@ dependencies = [
  "reqwest",
  "serde",
  "serde_json",
- "serde_yml",
+ "serde_yaml",
  "strum",
  "tempfile",
  "tokio",
@@ -4055,18 +4045,16 @@ dependencies = [
 ]
 
 [[package]]
-name = "serde_yml"
-version = "0.0.12"
+name = "serde_yaml"
+version = "0.9.34+deprecated"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59e2dd588bf1597a252c3b920e0143eb99b0f76e4e082f4c92ce34fbc9e71ddd"
+checksum = "6a8b1a1a2ebf674015cc02edccce75287f1a0130d394307b36743c2f5d504b47"
 dependencies = [
  "indexmap",
  "itoa",
- "libyml",
- "memchr",
  "ryu",
  "serde",
- "version_check",
+ "unsafe-libyaml",
 ]
 
 [[package]]
@@ -4665,6 +4653,12 @@ checksum = "5fd4f6878c9cb28d874b009da9e8d183b5abc80117c40bbd187a1fde336be6e8"
 dependencies = [
  "tinyvec",
 ]
+
+[[package]]
+name = "unsafe-libyaml"
+version = "0.2.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "673aac59facbab8a9007c7f6108d11f63b603f7cabff99fabf650fea5c32b861"
 
 [[package]]
 name = "untrusted"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -87,7 +87,7 @@ jsonschema = { version = "0.26", default-features = false }
 schemars = { version = "1", features = ["derive"] }
 
 # YAML
-serde_yml = "0.0.12"
+serde_yaml = "0.9"
 
 # Enum utilities
 strum = { version = "0.27", features = ["derive"] }

--- a/docs/cli/commands.mdx
+++ b/docs/cli/commands.mdx
@@ -50,9 +50,9 @@ rkat [--realm <id>] [--isolated] [--instance <id>] \
 | `rkat mcp ...` | Manage local/project MCP server config |
 | `rkat mob ...` | Pack, inspect, validate, deploy, and build mob artifacts |
 | `rkat skills ...` | Inspect available skills |
-| `rkat models catalog` | List available models with provider profiles |
+| `rkat models catalog` | List built-in models plus configured self-hosted aliases |
 | `rkat capabilities` | Show runtime capabilities |
-| `rkat doctor` | Check local setup and common prerequisites |
+| `rkat doctor` | Check local setup, provider keys, and self-hosted server reachability |
 | `rkat init` | Create project config from the global template |
 
 ## Prompt-first usage
@@ -76,7 +76,7 @@ rkat --yolo --param temperature=0.2 "take the gloves off"
 ### Common run flags
 
 - `-m, --model <MODEL>`
-- `-p, --provider <anthropic|openai|gemini>`
+- `-p, --provider <anthropic|openai|gemini|self_hosted>`
 - `-o, --output <text|json>`
 - `--json`
 - `-s, --stream`
@@ -181,6 +181,12 @@ tail -f app.log | rkat resume last --stdin lines "watch for new incidents"
 
 Resume supports the same stdin model as `run`, plus per-turn tool overlays and provider params.
 
+Self-hosted aliases work the same way:
+
+```bash
+rkat resume last -m gemma-4-31b "Continue with the local model"
+```
+
 ## continue
 
 ```bash
@@ -215,7 +221,28 @@ Examples:
 rkat config get --format toml
 rkat config set ./.rkat/config.toml
 rkat config patch '{"agent":{"model":"gpt-5.2"}}'
+rkat config patch '{"self_hosted":{"servers":{"ollama":{"transport":"openai_compatible","base_url":"http://127.0.0.1:11434","api_style":"chat_completions"}}}}'
 ```
+
+## models catalog
+
+```bash
+rkat models catalog
+```
+
+This prints the effective runtime model registry for the active realm, including configured `self_hosted` aliases and their `server_id`.
+
+## doctor
+
+```bash
+rkat doctor
+```
+
+For self-hosted setups, `doctor` checks the normalized `/v1/models` endpoint for each configured server and warns when configured aliases are missing from the returned model list.
+
+For Gemma 4, prefer `chat_completions` in your server config unless you have validated a specific `responses` path for your serving stack.
+
+Follow [Self-hosted Gemma 4](/guides/self-hosted-gemma4) for complete examples.
 
 ## mcp
 

--- a/docs/cli/configuration.mdx
+++ b/docs/cli/configuration.mdx
@@ -49,6 +49,47 @@ Compatibility files still exist:
 
 These are useful for templates (`rkat init`) and compatibility workflows, but realm config is the runtime source of truth for CLI/RPC/REST/MCP surfaces.
 
+## Self-hosted model config
+
+Self-hosted models are defined directly in realm config:
+
+```toml
+[self_hosted.servers.local]
+transport = "openai_compatible"
+base_url = "http://127.0.0.1:11434"
+api_style = "chat_completions"
+bearer_token_env = "LOCAL_LLM_TOKEN"
+
+[self_hosted.models.gemma-4-31b]
+server = "local"
+remote_model = "gemma4:31b"
+display_name = "Gemma 4 31B"
+family = "gemma-4"
+tier = "supported"
+context_window = 256000
+max_output_tokens = 8192
+vision = true
+image_tool_results = true
+inline_video = false
+supports_temperature = true
+supports_thinking = true
+supports_reasoning = true
+call_timeout_secs = 600
+```
+
+`transport` is currently `openai_compatible` only.
+
+`api_style` chooses the upstream API shape:
+
+- `responses` for Ollama and LM Studio style servers
+- `chat_completions` for vLLM style deployments
+
+For Gemma 4, prefer `chat_completions` unless you have verified a server-specific `responses` workflow you want to use.
+
+`supports_thinking` and `supports_reasoning` describe the behavior you intend Meerkat to expose through that configured transport. Gemma 4 models themselves are reasoning-capable, but some servers expose those capabilities with provider-specific conventions.
+
+Use `bearer_token_env` instead of `bearer_token` whenever possible.
+
 ## Session storage layout
 
 Realm storage lives under platform data dir:

--- a/docs/concepts/providers.mdx
+++ b/docs/concepts/providers.mdx
@@ -1,10 +1,10 @@
 ---
 title: "Providers"
-description: "Provider-agnostic: same tools, same sessions across Anthropic, OpenAI, and Gemini."
+description: "Provider-agnostic: same tools, same sessions across Anthropic, OpenAI, Gemini, and configured self-hosted models."
 icon: "server"
 ---
 
-Meerkat is provider-agnostic. Your tools, sessions, hooks, and configuration work identically across Anthropic, OpenAI, and Gemini. Switch providers by changing the model name -- no code changes. Set an API key for at least one.
+Meerkat is provider-agnostic. Your tools, sessions, hooks, and configuration work identically across Anthropic, OpenAI, Gemini, and configured self-hosted models. Switch providers by changing the model name. If you register a self-hosted alias such as `gemma-4-31b`, it behaves like any other model ID in the runtime.
 
 ## Provider setup
 
@@ -59,6 +59,31 @@ Meerkat is provider-agnostic. Your tools, sessions, hooks, and configuration wor
     max_tokens_per_turn = 8192
     ```
   </Tab>
+  <Tab title="Self-hosted">
+    Configure an OpenAI-compatible local or remote server, then register aliases under `self_hosted.models`.
+
+    ```toml config.toml (active realm)
+    [self_hosted.servers.ollama]
+    transport = "openai_compatible"
+    base_url = "http://127.0.0.1:11434"
+    api_style = "chat_completions"
+
+    [self_hosted.models.gemma-4-31b]
+    server = "ollama"
+    remote_model = "gemma4:31b"
+    display_name = "Gemma 4 31B"
+    family = "gemma-4"
+    tier = "supported"
+    context_window = 256000
+    max_output_tokens = 8192
+    vision = true
+    image_tool_results = true
+    inline_video = false
+    supports_temperature = true
+    supports_thinking = true
+    supports_reasoning = true
+    ```
+  </Tab>
 </Tabs>
 
 ## Environment variables
@@ -72,6 +97,8 @@ Meerkat is provider-agnostic. Your tools, sessions, hooks, and configuration wor
 <Note>
 The `RKAT_*` variants take precedence over provider-native names, so you can run Meerkat with dedicated keys separate from other tools.
 </Note>
+
+Self-hosted servers use the configured `bearer_token_env` or `bearer_token` on each server definition instead of the shared provider env vars above.
 
 ## SDK feature flags
 
@@ -135,7 +162,7 @@ Provider-specific options can be passed via the `--param` CLI flag or `provider_
 
 ## Model catalog
 
-The `meerkat-models` crate maintains a curated catalog of all supported models with their capabilities, context windows, output limits, and provider profile rules. This catalog is the single source of truth for model defaults, allowlists, and capability detection.
+The `meerkat-models` crate maintains the curated built-in catalog. At runtime, Meerkat merges that catalog with any configured self-hosted aliases into one effective model registry used for capability detection, provider resolution, and catalog responses.
 
 Query the catalog programmatically from any surface:
 
@@ -143,6 +170,10 @@ Query the catalog programmatically from any surface:
 - **RPC**: `models/catalog`
 - **REST**: `GET /models/catalog`
 - **MCP**: `meerkat_models_catalog`
+
+Configured self-hosted aliases appear under the `self_hosted` provider group and include their backing `server_id`.
+
+For Gemma 4 specifically, prefer `chat_completions` as the default OpenAI-compatible interface. It is the clearest common path for tool calling across Ollama, LM Studio, and vLLM, while reasoning-trace semantics still vary by server.
 
 ## Auto-detection
 
@@ -152,4 +183,10 @@ The provider is automatically inferred from the model name:
 - `gpt-*`, `o1-*`, `o3-*`, `chatgpt-*` models use OpenAI
 - `gemini-*` models use Gemini
 
-You can override this with `--provider` on the CLI or `provider` in API requests.
+Configured self-hosted aliases are resolved by exact model ID match before prefix inference. That means an alias such as `gemma-4-31b` works without `--provider`.
+
+You can still override this with `--provider` on the CLI or `provider` in API requests.
+
+## Recommended next step
+
+Follow [Self-hosted Gemma 4](/guides/self-hosted-gemma4) for complete Ollama, LM Studio, and vLLM setup recipes.

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -42,6 +42,7 @@
           {
             "group": "Guides",
             "pages": [
+              "guides/self-hosted-gemma4",
               "guides/structured-output",
               "guides/memory",
               "guides/hooks",

--- a/docs/guides/self-hosted-gemma4.mdx
+++ b/docs/guides/self-hosted-gemma4.mdx
@@ -1,0 +1,262 @@
+---
+title: "Self-hosted Gemma 4"
+description: "Configure Ollama, LM Studio, or vLLM so Gemma 4 aliases work in Meerkat like built-in models."
+icon: "microchip"
+---
+
+Meerkat can now treat configured self-hosted models as first-class model IDs. Once you register an alias such as `gemma-4-31b`, you can use it anywhere you would use `gpt-5.4` or `gemini-3.1-pro-preview`.
+
+This guide uses the four Gemma 4 aliases we recommend for Meerkat:
+
+- `gemma-4-e2b`
+- `gemma-4-e4b`
+- `gemma-4-26b-a4b`
+- `gemma-4-31b`
+
+Gemma 4 is a reasoning-capable family with native `system` role support and native function calling. All four variants support text and image input, while `E2B` and `E4B` also expose native audio support in the model capability tables. For Meerkat, the safest OpenAI-compatible serving default today is `chat_completions`, because that is the path most clearly documented for Gemma 4 tool calling across the serving stacks below.
+
+<Warning>
+Treat `supports_thinking` and `supports_reasoning` as transport-facing settings, not raw model facts. Gemma 4 itself is reasoning-capable, but normalized reasoning controls and trace streaming still vary by serving stack.
+</Warning>
+
+## What you configure
+
+Every self-hosted setup has two pieces:
+
+1. A server definition under `self_hosted.servers.<server_id>`
+2. One or more model aliases under `self_hosted.models.<alias>`
+
+The alias is the model name users type. The `remote_model` is whatever your serving stack exposes upstream.
+
+<Note>
+Prefer `bearer_token_env` over `bearer_token` so secrets stay out of checked-in config files.
+</Note>
+
+## Common Meerkat config
+
+This is the shared shape Meerkat expects regardless of serving stack:
+
+```toml config.toml
+[self_hosted.servers.local]
+transport = "openai_compatible"
+base_url = "http://127.0.0.1:11434"
+api_style = "chat_completions"
+bearer_token_env = "LOCAL_LLM_TOKEN"
+
+[self_hosted.models.gemma-4-31b]
+server = "local"
+remote_model = "gemma4:31b"
+display_name = "Gemma 4 31B"
+family = "gemma-4"
+tier = "supported"
+context_window = 256000
+max_output_tokens = 8192
+vision = true
+image_tool_results = true
+inline_video = false
+supports_temperature = true
+supports_thinking = true
+supports_reasoning = true
+call_timeout_secs = 600
+```
+
+## Quick use
+
+Once the alias is present in your active realm config:
+
+```bash
+rkat run -m gemma-4-31b "Summarize the architecture of this repository"
+rkat resume last -m gemma-4-e4b "Keep going, but faster"
+rkat models catalog
+rkat doctor
+```
+
+## Ollama
+
+Use Ollama when the model runs on the same machine as Meerkat and you want the lightest setup.
+
+<Steps>
+  <Step title="Serve Gemma 4">
+    Pull the model you want and make sure Ollama is running.
+
+    ```bash
+    ollama pull gemma4:31b
+    ollama list
+    ```
+  </Step>
+  <Step title="Register the server">
+    Prefer `chat_completions` mode for Gemma 4 agent flows.
+
+    ```toml config.toml
+    [self_hosted.servers.ollama]
+    transport = "openai_compatible"
+    base_url = "http://127.0.0.1:11434"
+    api_style = "chat_completions"
+    ```
+  </Step>
+  <Step title="Add aliases">
+    Map friendly Meerkat aliases to Ollama model IDs.
+
+    ```toml config.toml
+    [self_hosted.models.gemma-4-e2b]
+    server = "ollama"
+    remote_model = "gemma4:e2b"
+    display_name = "Gemma 4 E2B"
+    family = "gemma-4"
+    tier = "supported"
+    context_window = 128000
+    max_output_tokens = 8192
+    vision = true
+    image_tool_results = true
+    inline_video = false
+    supports_temperature = true
+    supports_thinking = true
+    supports_reasoning = true
+
+    [self_hosted.models.gemma-4-31b]
+    server = "ollama"
+    remote_model = "gemma4:31b"
+    display_name = "Gemma 4 31B"
+    family = "gemma-4"
+    tier = "supported"
+    context_window = 256000
+    max_output_tokens = 8192
+    vision = true
+    image_tool_results = true
+    inline_video = false
+    supports_temperature = true
+    supports_thinking = true
+    supports_reasoning = true
+    call_timeout_secs = 600
+    ```
+  </Step>
+</Steps>
+
+## LM Studio
+
+Use LM Studio when you want a desktop app with a local OpenAI-compatible server.
+
+<Steps>
+  <Step title="Start the local server">
+    Load your Gemma 4 model in LM Studio, then start the local server.
+  </Step>
+  <Step title="Register LM Studio">
+    Prefer `chat_completions` for Gemma 4 tool use and structured output.
+
+    ```toml config.toml
+    [self_hosted.servers.lmstudio]
+    transport = "openai_compatible"
+    base_url = "http://127.0.0.1:1234"
+    api_style = "chat_completions"
+    ```
+  </Step>
+  <Step title="Alias the served model">
+    Use the model name LM Studio exposes in its `/v1/models` output.
+
+    ```toml config.toml
+    [self_hosted.models.gemma-4-e4b]
+    server = "lmstudio"
+    remote_model = "google/gemma-4-e4b"
+    display_name = "Gemma 4 E4B"
+    family = "gemma-4"
+    tier = "supported"
+    context_window = 128000
+    max_output_tokens = 8192
+    vision = true
+    image_tool_results = true
+    inline_video = false
+    supports_temperature = true
+    supports_thinking = true
+    supports_reasoning = true
+    ```
+  </Step>
+</Steps>
+
+## vLLM
+
+Use vLLM when you want a self-managed server and the most control over deployment.
+
+<Steps>
+  <Step title="Launch vLLM">
+    Start vLLM with the Gemma 4 model you want to expose.
+  </Step>
+  <Step title="Register the server">
+    Use `chat_completions` mode for vLLM.
+
+    ```toml config.toml
+    [self_hosted.servers.vllm]
+    transport = "openai_compatible"
+    base_url = "http://my-gpu-box:8000"
+    api_style = "chat_completions"
+    bearer_token_env = "VLLM_API_TOKEN"
+    ```
+  </Step>
+  <Step title="Add remote aliases">
+    Point aliases at the exact model name your vLLM endpoint exposes.
+
+    ```toml config.toml
+    [self_hosted.models.gemma-4-26b-a4b]
+    server = "vllm"
+    remote_model = "google/gemma-4-26b-a4b"
+    display_name = "Gemma 4 26B A4B"
+    family = "gemma-4"
+    tier = "supported"
+    context_window = 256000
+    max_output_tokens = 8192
+    vision = true
+    image_tool_results = true
+    inline_video = false
+    supports_temperature = true
+    supports_thinking = true
+    supports_reasoning = true
+    call_timeout_secs = 600
+
+    [self_hosted.models.gemma-4-31b]
+    server = "vllm"
+    remote_model = "google/gemma-4-31b"
+    display_name = "Gemma 4 31B"
+    family = "gemma-4"
+    tier = "supported"
+    context_window = 256000
+    max_output_tokens = 8192
+    vision = true
+    image_tool_results = true
+    inline_video = false
+    supports_temperature = true
+    supports_thinking = true
+    supports_reasoning = true
+    call_timeout_secs = 600
+    ```
+  </Step>
+</Steps>
+
+## Reasoning and transport notes
+
+- `chat_completions` is the recommended Gemma 4 default for Ollama, LM Studio, and vLLM.
+- Text, image, and tool-calling requests fit well through OpenAI-compatible APIs today.
+- Reasoning traces and reasoning controls are less uniform. Some servers expose Gemma 4 thinking through Gemma-specific mechanisms rather than OpenAI-native reasoning events, so validate the exact behavior you need before depending on it in production.
+- If you only need chat, coding, tools, and image input, OpenAI-compatible serving is a good fit for Gemma 4.
+
+## Choosing a Gemma 4 size
+
+| Alias | Good default use |
+|-------|-------------------|
+| `gemma-4-e2b` | Lowest-footprint local experiments |
+| `gemma-4-e4b` | Fast local iteration with a bit more headroom |
+| `gemma-4-26b-a4b` | Stronger quality on a serious local or remote GPU setup |
+| `gemma-4-31b` | Best quality of the four, usually best on a dedicated server |
+
+`E2B` and `E4B` are also the sizes with native audio support in the upstream capability tables; `26B A4B` and `31B` are text+image models.
+
+## Validation checklist
+
+- `rkat models catalog` shows a `self_hosted` provider group and your aliases
+- `rkat doctor` reports the server as reachable
+- `rkat run -m gemma-4-31b "say hello"` works without `--provider`
+- The alias you configured matches the upstream `remote_model` shown by `/v1/models`
+
+## See also
+
+- [Providers](/concepts/providers)
+- [CLI configuration](/cli/configuration)
+- [CLI commands](/cli/commands)

--- a/meerkat-cli/Cargo.toml
+++ b/meerkat-cli/Cargo.toml
@@ -67,6 +67,7 @@ chrono = { workspace = true }
 futures = { workspace = true }
 async-trait = { workspace = true }
 nix = { workspace = true }
+reqwest = { workspace = true }
 
 [features]
 default = ["anthropic", "openai", "gemini", "jsonl-store", "session-store", "skills", "comms", "mcp", "schedule"]

--- a/meerkat-cli/src/main.rs
+++ b/meerkat-cli/src/main.rs
@@ -3446,6 +3446,7 @@ async fn run_agent(
 
     let mut build = SessionBuildOptions {
         provider: Some(provider.as_core()),
+        self_hosted_server_id: None,
         output_schema,
         structured_output_retries,
         hooks_override,
@@ -3960,6 +3961,9 @@ async fn resume_session_with_llm_override(
 
     let mut build = SessionBuildOptions {
         provider: Some(provider_core),
+        self_hosted_server_id: stored_metadata
+            .as_ref()
+            .and_then(|m| m.self_hosted_server_id.clone()),
         output_schema: None,
         structured_output_retries: 2,
         hooks_override,

--- a/meerkat-cli/src/main.rs
+++ b/meerkat-cli/src/main.rs
@@ -1612,7 +1612,7 @@ async fn main() -> anyhow::Result<ExitCode> {
         },
         Commands::Capabilities => handle_capabilities(&cli_scope).await,
         Commands::Models { command } => match command {
-            ModelsCommands::Catalog => handle_models_catalog().await,
+            ModelsCommands::Catalog => handle_models_catalog(&cli_scope).await,
         },
         Commands::Doctor => handle_doctor(&cli_scope).await,
     };
@@ -2075,8 +2075,9 @@ async fn handle_capabilities(scope: &RuntimeScope) -> anyhow::Result<()> {
     Ok(())
 }
 
-async fn handle_models_catalog() -> anyhow::Result<()> {
-    let response = meerkat::surface::build_models_catalog_response();
+async fn handle_models_catalog(scope: &RuntimeScope) -> anyhow::Result<()> {
+    let (config, _) = load_config(scope).await?;
+    let response = meerkat::surface::build_models_catalog_response(&config);
     println!(
         "{}",
         serde_json::to_string_pretty(&response).unwrap_or_else(|_| "{}".to_string())
@@ -2086,6 +2087,7 @@ async fn handle_models_catalog() -> anyhow::Result<()> {
 
 async fn handle_doctor(scope: &RuntimeScope) -> anyhow::Result<()> {
     let mut ok = true;
+    let (config, _) = load_config(scope).await?;
     let config_path =
         meerkat_store::realm_paths_in(&scope.locator.state_root, &scope.locator.realm_id)
             .config_path;
@@ -2110,6 +2112,87 @@ async fn handle_doctor(scope: &RuntimeScope) -> anyhow::Result<()> {
             println!("ok\tprovider\t{provider} via {env_key}");
         } else {
             println!("warn\tprovider\t{provider} missing {env_key}");
+        }
+    }
+
+    if config.self_hosted.servers.is_empty() {
+        println!("ok\tself_hosted\tno self-hosted servers configured");
+    } else {
+        let http = reqwest::Client::builder()
+            .timeout(std::time::Duration::from_secs(5))
+            .build()
+            .map_err(|e| anyhow::anyhow!("failed to build doctor HTTP client: {e}"))?;
+
+        for (server_id, server) in &config.self_hosted.servers {
+            let base_url = meerkat_core::model_registry::normalize_base_url(&server.base_url);
+            let models_url = format!("{base_url}/models");
+            let mut request = http.get(&models_url);
+
+            if let Some(token) = server.bearer_token.clone().or_else(|| {
+                server
+                    .bearer_token_env
+                    .as_deref()
+                    .and_then(|env_key| std::env::var(env_key).ok())
+            }) {
+                request = request.bearer_auth(token);
+            }
+
+            match request.send().await {
+                Ok(response) if response.status().is_success() => {
+                    println!("ok\tself_hosted\tserver {server_id} reachable at {models_url}");
+
+                    let configured_models: Vec<_> = config
+                        .self_hosted
+                        .models
+                        .iter()
+                        .filter(|(_, model)| model.server == *server_id)
+                        .map(|(alias, model)| (alias.as_str(), model.remote_model.as_str()))
+                        .collect();
+
+                    match response.json::<serde_json::Value>().await {
+                        Ok(json) => {
+                            let available: std::collections::HashSet<String> = json["data"]
+                                .as_array()
+                                .into_iter()
+                                .flatten()
+                                .filter_map(|entry| entry["id"].as_str().map(ToString::to_string))
+                                .collect();
+                            for (alias, remote_model) in configured_models {
+                                if available.is_empty() {
+                                    break;
+                                }
+                                if available.contains(remote_model) {
+                                    println!(
+                                        "ok\tself_hosted\talias {alias} -> {remote_model} listed by {server_id}"
+                                    );
+                                } else {
+                                    println!(
+                                        "warn\tself_hosted\talias {alias} -> {remote_model} not listed by {server_id}"
+                                    );
+                                }
+                            }
+                        }
+                        Err(_) => {
+                            println!(
+                                "warn\tself_hosted\tserver {server_id} did not return a parseable /models payload"
+                            );
+                        }
+                    }
+                }
+                Ok(response) => {
+                    ok = false;
+                    println!(
+                        "warn\tself_hosted\tserver {server_id} returned {} from {models_url}",
+                        response.status()
+                    );
+                }
+                Err(err) => {
+                    ok = false;
+                    println!(
+                        "warn\tself_hosted\tserver {server_id} unreachable at {models_url}: {err}"
+                    );
+                }
+            }
         }
     }
 
@@ -7135,6 +7218,8 @@ pub enum Provider {
     Openai,
     /// Google Gemini models
     Gemini,
+    /// Self-hosted models registered in config
+    SelfHosted,
 }
 
 impl Provider {
@@ -7171,6 +7256,7 @@ impl Provider {
             Provider::Anthropic => "anthropic",
             Provider::Openai => "openai",
             Provider::Gemini => "gemini",
+            Provider::SelfHosted => "self_hosted",
         }
     }
 
@@ -7180,6 +7266,7 @@ impl Provider {
             Provider::Anthropic => meerkat_core::Provider::Anthropic,
             Provider::Openai => meerkat_core::Provider::OpenAI,
             Provider::Gemini => meerkat_core::Provider::Gemini,
+            Provider::SelfHosted => meerkat_core::Provider::SelfHosted,
         }
     }
 
@@ -7189,6 +7276,7 @@ impl Provider {
             meerkat_core::Provider::Anthropic => Some(Provider::Anthropic),
             meerkat_core::Provider::OpenAI => Some(Provider::Openai),
             meerkat_core::Provider::Gemini => Some(Provider::Gemini),
+            meerkat_core::Provider::SelfHosted => Some(Provider::SelfHosted),
             meerkat_core::Provider::Other => None,
         }
     }

--- a/meerkat-cli/src/main.rs
+++ b/meerkat-cli/src/main.rs
@@ -2075,7 +2075,8 @@ async fn handle_capabilities(scope: &RuntimeScope) -> anyhow::Result<()> {
 
 async fn handle_models_catalog(scope: &RuntimeScope) -> anyhow::Result<()> {
     let (config, _) = load_config(scope).await?;
-    let response = meerkat::surface::build_models_catalog_response(&config);
+    let response = meerkat::surface::build_models_catalog_response(&config)
+        .map_err(|e| anyhow::anyhow!("failed to build model catalog: {e}"))?;
     println!(
         "{}",
         serde_json::to_string_pretty(&response).unwrap_or_else(|_| "{}".to_string())
@@ -2126,12 +2127,7 @@ async fn handle_doctor(scope: &RuntimeScope) -> anyhow::Result<()> {
             let models_url = format!("{base_url}/models");
             let mut request = http.get(&models_url);
 
-            if let Some(token) = server.bearer_token.clone().or_else(|| {
-                server
-                    .bearer_token_env
-                    .as_deref()
-                    .and_then(|env_key| std::env::var(env_key).ok())
-            }) {
+            if let Some(token) = server.bearer_token.clone() {
                 request = request.bearer_auth(token);
             }
 

--- a/meerkat-cli/src/main.rs
+++ b/meerkat-cli/src/main.rs
@@ -1673,9 +1673,7 @@ async fn handle_run_command(
 
     let model = model.unwrap_or_else(|| config.agent.model.clone());
     let max_tokens = max_tokens.unwrap_or(config.agent.max_tokens_per_turn);
-    let resolved_provider = provider
-        .or_else(|| Provider::infer_from_model(&model))
-        .unwrap_or_default();
+    let resolved_provider = resolve_cli_provider(&config, &model, provider);
 
     let duration = max_duration.map(|s| parse_duration(&s)).transpose();
     let provider_params = parse_provider_params(&params);
@@ -3867,11 +3865,7 @@ async fn resume_session_with_llm_override(
     let provider_core = stored_metadata
         .as_ref()
         .map(|meta| meta.provider)
-        .unwrap_or_else(|| {
-            Provider::infer_from_model(&model)
-                .unwrap_or_default()
-                .as_core()
-        });
+        .unwrap_or_else(|| resolve_cli_provider(&config, &model, None).as_core());
 
     tracing::info!(
         "Resuming session {} with {} messages (provider: {:?}, model: {})",
@@ -7292,6 +7286,19 @@ impl Provider {
     }
 }
 
+fn resolve_cli_provider(config: &Config, model: &str, explicit: Option<Provider>) -> Provider {
+    explicit
+        .or_else(|| {
+            config
+                .model_registry()
+                .ok()
+                .and_then(|registry| registry.entry(model).map(|entry| entry.provider))
+                .and_then(Provider::from_core)
+        })
+        .or_else(|| Provider::infer_from_model(model))
+        .unwrap_or_default()
+}
+
 #[cfg(test)]
 #[allow(clippy::unwrap_used, clippy::expect_used)]
 mod tests {
@@ -10478,6 +10485,41 @@ printf '\0\141\163\155' > "$out_dir/runtime_bg.wasm"
         assert_eq!(Provider::infer_from_model("mistral-7b"), None);
         assert_eq!(Provider::infer_from_model("custom-model"), None);
         assert_eq!(Provider::infer_from_model(""), None);
+    }
+
+    #[test]
+    fn test_resolve_cli_provider_prefers_self_hosted_registry_alias() {
+        let mut config = Config::default();
+        config
+            .merge_toml_str(
+                r#"
+[self_hosted.servers.ollama]
+transport = "openai_compatible"
+base_url = "http://127.0.0.1:11434"
+api_style = "chat_completions"
+
+[self_hosted.models.gemma-4-e2b]
+server = "ollama"
+remote_model = "gemma4:e2b"
+display_name = "Gemma 4 E2B"
+family = "gemma"
+tier = "supported"
+context_window = 128000
+max_output_tokens = 8192
+vision = true
+image_tool_results = true
+inline_video = false
+supports_temperature = true
+supports_thinking = true
+supports_reasoning = true
+"#,
+            )
+            .expect("valid self-hosted config");
+
+        assert_eq!(
+            resolve_cli_provider(&config, "gemma-4-e2b", None),
+            Provider::SelfHosted
+        );
     }
 
     #[cfg(feature = "comms")]

--- a/meerkat-cli/src/main.rs
+++ b/meerkat-cli/src/main.rs
@@ -2127,7 +2127,7 @@ async fn handle_doctor(scope: &RuntimeScope) -> anyhow::Result<()> {
             let models_url = format!("{base_url}/models");
             let mut request = http.get(&models_url);
 
-            if let Some(token) = server.bearer_token.clone() {
+            if let Some(token) = server.resolve_bearer_token() {
                 request = request.bearer_auth(token);
             }
 

--- a/meerkat-client/src/lib.rs
+++ b/meerkat-client/src/lib.rs
@@ -25,6 +25,8 @@ pub mod anthropic;
 
 #[cfg(feature = "openai")]
 pub mod openai;
+#[cfg(feature = "openai")]
+pub mod openai_compatible;
 
 #[cfg(feature = "gemini")]
 pub mod gemini;
@@ -44,6 +46,8 @@ pub use anthropic::AnthropicClient;
 
 #[cfg(feature = "openai")]
 pub use openai::OpenAiClient;
+#[cfg(feature = "openai")]
+pub use openai_compatible::{OpenAiCompatibleClient, OpenAiCompatibleMode};
 
 #[cfg(feature = "gemini")]
 pub use gemini::GeminiClient;

--- a/meerkat-client/src/openai.rs
+++ b/meerkat-client/src/openai.rs
@@ -19,7 +19,7 @@ use std::collections::HashSet;
 
 /// Client for OpenAI Responses API
 pub struct OpenAiClient {
-    api_key: String,
+    api_key: Option<String>,
     base_url: String,
     http: reqwest::Client,
 }
@@ -35,11 +35,22 @@ impl OpenAiClient {
 
     /// Create a new OpenAI client with the given API key
     pub fn new(api_key: String) -> Self {
-        Self::new_with_base_url(api_key, "https://api.openai.com".to_string())
+        Self::new_with_optional_api_key_and_base_url(
+            Some(api_key),
+            "https://api.openai.com".to_string(),
+        )
     }
 
     /// Create a new OpenAI client with an explicit base URL
     pub fn new_with_base_url(api_key: String, base_url: String) -> Self {
+        Self::new_with_optional_api_key_and_base_url(Some(api_key), base_url)
+    }
+
+    /// Create a new OpenAI client with an optional API key and explicit base URL.
+    pub fn new_with_optional_api_key_and_base_url(
+        api_key: Option<String>,
+        base_url: String,
+    ) -> Self {
         let http =
             crate::http::build_http_client_for_base_url(reqwest::Client::builder(), &base_url)
                 .unwrap_or_else(|_| reqwest::Client::new());
@@ -343,10 +354,16 @@ impl LlmClient for OpenAiClient {
         let inner: LlmStream<'a> = Box::pin(async_stream::try_stream! {
             let body = self.build_request_body(request)?;
 
-            let response = self.http
+            let request_builder = self
+                .http
                 .post(format!("{}/v1/responses", self.base_url))
-                .header("Authorization", format!("Bearer {}", self.api_key))
-                .header("Content-Type", "application/json")
+                .header("Content-Type", "application/json");
+            let request_builder = if let Some(api_key) = &self.api_key {
+                request_builder.header("Authorization", format!("Bearer {api_key}"))
+            } else {
+                request_builder
+            };
+            let response = request_builder
                 .json(&body)
                 .send()
                 .await

--- a/meerkat-client/src/openai.rs
+++ b/meerkat-client/src/openai.rs
@@ -25,12 +25,33 @@ pub struct OpenAiClient {
 }
 
 impl OpenAiClient {
+    pub(crate) const INTERNAL_SUPPORTS_TEMPERATURE: &str = "__meerkat_supports_temperature";
+    pub(crate) const INTERNAL_SUPPORTS_REASONING: &str = "__meerkat_supports_reasoning";
+
     fn model_supports_temperature(model: &str) -> bool {
         meerkat_models::profile::openai::supports_temperature(model)
     }
 
     fn model_supports_reasoning_payload(model: &str) -> bool {
         meerkat_models::profile::openai::supports_reasoning(model)
+    }
+
+    fn request_supports_temperature(request: &LlmRequest) -> bool {
+        request
+            .provider_params
+            .as_ref()
+            .and_then(|params| params.get(Self::INTERNAL_SUPPORTS_TEMPERATURE))
+            .and_then(Value::as_bool)
+            .unwrap_or_else(|| Self::model_supports_temperature(&request.model))
+    }
+
+    fn request_supports_reasoning_payload(request: &LlmRequest) -> bool {
+        request
+            .provider_params
+            .as_ref()
+            .and_then(|params| params.get(Self::INTERNAL_SUPPORTS_REASONING))
+            .and_then(Value::as_bool)
+            .unwrap_or_else(|| Self::model_supports_reasoning_payload(&request.model))
     }
 
     /// Create a new OpenAI client with the given API key
@@ -83,7 +104,7 @@ impl OpenAiClient {
     /// Build request body for OpenAI Responses API
     fn build_request_body(&self, request: &LlmRequest) -> Result<Value, LlmError> {
         let input = Self::convert_to_responses_input(&request.messages)?;
-        let reasoning_enabled = Self::model_supports_reasoning_payload(&request.model);
+        let reasoning_enabled = Self::request_supports_reasoning_payload(request);
 
         let mut body = serde_json::json!({
             "model": request.model,
@@ -102,7 +123,7 @@ impl OpenAiClient {
             });
         }
 
-        if Self::model_supports_temperature(&request.model)
+        if Self::request_supports_temperature(request)
             && let Some(temp) = request.temperature
             && let Some(num) = serde_json::Number::from_f64(temp as f64)
         {
@@ -307,7 +328,10 @@ impl OpenAiClient {
 
     /// Parse an SSE event from the Responses API stream
     fn parse_responses_sse_line(line: &str) -> Option<ResponsesStreamEvent> {
-        if let Some(data) = line.strip_prefix("data: ") {
+        if let Some(data) = line
+            .strip_prefix("data: ")
+            .or_else(|| line.strip_prefix("data:"))
+        {
             if data == "[DONE]" {
                 return None;
             }
@@ -1110,6 +1134,28 @@ mod tests {
         assert!(body.get("reasoning").is_none());
     }
 
+    #[test]
+    fn test_request_respects_internal_capability_overrides_for_self_hosted_aliases() {
+        let client = OpenAiClient::new("test-key".to_string());
+        let request = LlmRequest::new(
+            "gemma4:e2b",
+            vec![Message::User(UserMessage::text("test".to_string()))],
+        )
+        .with_temperature(0.3)
+        .with_provider_param(OpenAiClient::INTERNAL_SUPPORTS_TEMPERATURE, true)
+        .with_provider_param(OpenAiClient::INTERNAL_SUPPORTS_REASONING, true)
+        .with_provider_param("reasoning_effort", "high");
+
+        let body = client.build_request_body(&request).expect("build request");
+
+        let temperature = body["temperature"]
+            .as_f64()
+            .expect("temperature should be numeric");
+        assert!((temperature - 0.3).abs() < 1e-6);
+        assert_eq!(body["reasoning"]["effort"], "high");
+        assert_eq!(body["reasoning"]["summary"], "auto");
+    }
+
     // =========================================================================
     // BlockAssistant Message Tests
     // =========================================================================
@@ -1747,6 +1793,13 @@ mod tests {
         let line = "data: [DONE]";
         let event = OpenAiClient::parse_responses_sse_line(line);
         assert!(event.is_none());
+    }
+
+    #[test]
+    fn test_parse_responses_sse_line_without_trailing_space() {
+        let line = r#"data:{"type":"response.output_text.delta","delta":"hello"}"#;
+        let event = OpenAiClient::parse_responses_sse_line(line);
+        assert!(event.is_some());
     }
 
     #[test]

--- a/meerkat-client/src/openai_compatible.rs
+++ b/meerkat-client/src/openai_compatible.rs
@@ -27,6 +27,7 @@ pub struct OpenAiCompatibleClient {
     http: reqwest::Client,
     responses_delegate: Option<crate::OpenAiClient>,
     supports_temperature: bool,
+    supports_thinking: bool,
     supports_reasoning: bool,
 }
 
@@ -37,15 +38,16 @@ impl OpenAiCompatibleClient {
         base_url: String,
         bearer_token: Option<String>,
         supports_temperature: bool,
+        supports_thinking: bool,
         supports_reasoning: bool,
     ) -> Self {
         let http =
             crate::http::build_http_client_for_base_url(reqwest::Client::builder(), &base_url)
                 .unwrap_or_else(|_| reqwest::Client::new());
         let responses_delegate = matches!(mode, OpenAiCompatibleMode::Responses).then(|| {
-            crate::OpenAiClient::new_with_base_url(
-                bearer_token.clone().unwrap_or_else(|| "local".to_string()),
-                base_url.clone(),
+            crate::OpenAiClient::new_with_optional_api_key_and_base_url(
+                bearer_token.clone(),
+                trim_v1_suffix(&base_url),
             )
         });
         Self {
@@ -56,6 +58,7 @@ impl OpenAiCompatibleClient {
             http,
             responses_delegate,
             supports_temperature,
+            supports_thinking,
             supports_reasoning,
         }
     }
@@ -102,10 +105,29 @@ impl OpenAiCompatibleClient {
         }
 
         if let Some(params) = &request.provider_params {
-            if self.supports_reasoning
-                && let Some(reasoning) = params.get("reasoning_effort")
-            {
-                body["reasoning"] = serde_json::json!({ "effort": reasoning.clone() });
+            if self.supports_reasoning {
+                if let Some(reasoning) = params.get("reasoning")
+                    && reasoning.is_object()
+                {
+                    body["reasoning"] = reasoning.clone();
+                }
+                if let Some(reasoning_effort) = params.get("reasoning_effort") {
+                    if !body["reasoning"].is_object() {
+                        body["reasoning"] = serde_json::json!({});
+                    }
+                    body["reasoning"]["effort"] = reasoning_effort.clone();
+                    body["reasoning_effort"] = reasoning_effort.clone();
+                }
+                if self.supports_thinking
+                    && let Some(chat_template_kwargs) = params.get("chat_template_kwargs")
+                {
+                    body["chat_template_kwargs"] = chat_template_kwargs.clone();
+                }
+                if self.supports_thinking
+                    && let Some(thinking) = params.get("thinking")
+                {
+                    body["thinking"] = thinking.clone();
+                }
             }
             if let Some(structured) = params.get("structured_output") {
                 let output_schema: OutputSchema = serde_json::from_value(structured.clone())
@@ -271,16 +293,27 @@ impl OpenAiCompatibleClient {
         }
     }
 
-    fn parse_chat_completions_line(line: &str) -> Option<ChatCompletionsChunk> {
+    fn parse_chat_completions_line(line: &str) -> Result<Option<ChatCompletionsChunk>, LlmError> {
         if let Some(data) = line.strip_prefix("data: ") {
             if data == "[DONE]" {
-                return None;
+                return Ok(None);
             }
-            serde_json::from_str(data).ok()
+            serde_json::from_str(data)
+                .map(Some)
+                .map_err(|err| LlmError::StreamParseError {
+                    message: format!("failed to parse chat completions chunk: {err}; line={data}"),
+                })
         } else {
-            None
+            Ok(None)
         }
     }
+}
+
+fn trim_v1_suffix(base_url: &str) -> String {
+    base_url
+        .trim_end_matches('/')
+        .trim_end_matches("/v1")
+        .to_string()
 }
 
 fn ensure_additional_properties_false(value: &mut Value) {
@@ -365,6 +398,7 @@ impl LlmClient for OpenAiCompatibleClient {
                     let mut stream = stream_result?;
                     let mut buffer = String::with_capacity(512);
                     let mut tool_buffers: HashMap<usize, ToolCallBuffer> = HashMap::new();
+                    let mut reasoning_text = String::new();
                     let mut done_emitted = false;
 
                     while let Some(chunk) = stream.next().await {
@@ -377,11 +411,11 @@ impl LlmClient for OpenAiCompatibleClient {
                             let parsed = if should_process {
                                 Self::parse_chat_completions_line(line)
                             } else {
-                                None
+                                Ok(None)
                             };
                             buffer.drain(..=newline_pos);
 
-                            if let Some(event) = parsed {
+                            if let Some(event) = parsed? {
                                 if let Some(event_usage) = event.usage {
                                     let usage = Usage {
                                         input_tokens: event_usage.prompt_tokens.unwrap_or(0),
@@ -400,6 +434,19 @@ impl LlmClient for OpenAiCompatibleClient {
                                             yield LlmEvent::TextDelta {
                                                 delta: content,
                                                 meta: None,
+                                            };
+                                        }
+                                        let reasoning_delta = delta
+                                            .reasoning_content
+                                            .as_ref()
+                                            .or(delta.reasoning.as_ref())
+                                            .or(delta.thinking.as_ref());
+                                        if let Some(reasoning) = reasoning_delta
+                                            && !reasoning.is_empty()
+                                        {
+                                            reasoning_text.push_str(reasoning);
+                                            yield LlmEvent::ReasoningDelta {
+                                                delta: reasoning.clone(),
                                             };
                                         }
                                         if let Some(tool_calls) = delta.tool_calls {
@@ -456,6 +503,12 @@ impl LlmClient for OpenAiCompatibleClient {
                                                 }
                                             }
                                         }
+                                        if !reasoning_text.is_empty() {
+                                            yield LlmEvent::ReasoningComplete {
+                                                text: std::mem::take(&mut reasoning_text),
+                                                meta: None,
+                                            };
+                                        }
                                         if !done_emitted {
                                             done_emitted = true;
                                             yield LlmEvent::Done {
@@ -468,6 +521,20 @@ impl LlmClient for OpenAiCompatibleClient {
                         }
                     }
 
+                    if !buffer.trim().is_empty() {
+                        Err::<(), _>(LlmError::IncompleteResponse {
+                            message: format!(
+                                "chat completions stream ended with an incomplete SSE buffer: {}",
+                                buffer.trim()
+                            ),
+                        })?;
+                    }
+                    if !reasoning_text.is_empty() {
+                        yield LlmEvent::ReasoningComplete {
+                            text: reasoning_text,
+                            meta: None,
+                        };
+                    }
                     if !done_emitted {
                         yield LlmEvent::Done {
                             outcome: LlmDoneOutcome::Success {
@@ -539,6 +606,12 @@ struct ChatDelta {
     #[serde(default)]
     content: Option<String>,
     #[serde(default)]
+    reasoning: Option<String>,
+    #[serde(default)]
+    reasoning_content: Option<String>,
+    #[serde(default)]
+    thinking: Option<String>,
+    #[serde(default)]
     tool_calls: Option<Vec<ChatToolCallDelta>>,
 }
 
@@ -572,12 +645,41 @@ struct ChatUsage {
 #[allow(clippy::unwrap_used, clippy::expect_used)]
 mod tests {
     use super::*;
-    use axum::{Json, Router, extract::State, response::IntoResponse, routing::post};
+    use axum::{
+        Json, Router,
+        extract::{Request, State},
+        response::IntoResponse,
+        routing::post,
+    };
     use meerkat_core::UserMessage;
+    use std::sync::{Arc, Mutex};
     use tokio::net::TcpListener;
 
     async fn chat_sse(State(payload): State<String>) -> impl IntoResponse {
         ([("content-type", "text/event-stream")], payload)
+    }
+
+    #[derive(Clone)]
+    struct ResponsesStubState {
+        payload: String,
+        auth_headers: Arc<Mutex<Vec<Option<String>>>>,
+    }
+
+    async fn responses_sse(
+        State(state): State<ResponsesStubState>,
+        request: Request,
+    ) -> impl IntoResponse {
+        let auth = request
+            .headers()
+            .get("authorization")
+            .and_then(|value| value.to_str().ok())
+            .map(std::string::ToString::to_string);
+        state
+            .auth_headers
+            .lock()
+            .expect("auth header capture lock")
+            .push(auth);
+        ([("content-type", "text/event-stream")], state.payload)
     }
 
     async fn models() -> impl IntoResponse {
@@ -599,6 +701,31 @@ mod tests {
         (format!("http://{addr}/v1"), handle)
     }
 
+    async fn spawn_responses_stub_server(
+        payload: String,
+    ) -> (
+        String,
+        Arc<Mutex<Vec<Option<String>>>>,
+        tokio::task::JoinHandle<()>,
+    ) {
+        let auth_headers = Arc::new(Mutex::new(Vec::new()));
+        let app = Router::new()
+            .route("/v1/responses", post(responses_sse))
+            .route("/v1/models", axum::routing::get(models))
+            .with_state(ResponsesStubState {
+                payload,
+                auth_headers: Arc::clone(&auth_headers),
+            });
+        let listener = TcpListener::bind("127.0.0.1:0")
+            .await
+            .expect("bind test server");
+        let addr = listener.local_addr().expect("local addr");
+        let handle = tokio::spawn(async move {
+            axum::serve(listener, app).await.expect("serve test server");
+        });
+        (format!("http://{addr}/v1"), auth_headers, handle)
+    }
+
     #[tokio::test]
     async fn chat_completions_stream_accumulates_tool_calls() {
         let payload = concat!(
@@ -615,6 +742,7 @@ mod tests {
             base_url,
             None,
             true,
+            false,
             false,
         );
         let request = LlmRequest::new(
@@ -648,6 +776,120 @@ mod tests {
         }
         assert!(saw_complete);
         assert!(saw_done);
+        handle.abort();
+    }
+
+    #[tokio::test]
+    async fn chat_completions_stream_emits_reasoning_events() {
+        let payload = concat!(
+            "data: {\"choices\":[{\"delta\":{\"reasoning_content\":\"Let me think. \"}}]}\n\n",
+            "data: {\"choices\":[{\"delta\":{\"reasoning_content\":\"Need one more step.\"}}]}\n\n",
+            "data: {\"choices\":[{\"delta\":{\"content\":\"Final answer\"},\"finish_reason\":\"stop\"}]}\n\n",
+            "data: [DONE]\n\n"
+        )
+        .to_string();
+        let (base_url, handle) = spawn_chat_stub_server(payload).await;
+        let client = OpenAiCompatibleClient::new(
+            OpenAiCompatibleMode::ChatCompletions,
+            "remote-model".to_string(),
+            base_url,
+            None,
+            true,
+            true,
+            true,
+        );
+        let request = LlmRequest::new(
+            "gemma-4-31b",
+            vec![Message::User(UserMessage::text("hello".to_string()))],
+        );
+
+        let events: Vec<_> = client.stream(&request).collect().await;
+        let mut reasoning_deltas = Vec::new();
+        let mut reasoning_complete = None;
+        for event in events {
+            match event.expect("event") {
+                LlmEvent::ReasoningDelta { delta } => reasoning_deltas.push(delta),
+                LlmEvent::ReasoningComplete { text, .. } => reasoning_complete = Some(text),
+                _ => {}
+            }
+        }
+
+        assert_eq!(
+            reasoning_deltas,
+            vec![
+                "Let me think. ".to_string(),
+                "Need one more step.".to_string()
+            ]
+        );
+        assert_eq!(
+            reasoning_complete,
+            Some("Let me think. Need one more step.".to_string())
+        );
+        handle.abort();
+    }
+
+    #[test]
+    fn build_chat_completions_body_preserves_reasoning_overrides() {
+        let client = OpenAiCompatibleClient::new(
+            OpenAiCompatibleMode::ChatCompletions,
+            "remote-model".to_string(),
+            "http://localhost:11434/v1".to_string(),
+            None,
+            true,
+            true,
+            true,
+        );
+        let request = LlmRequest::new(
+            "gemma-4-31b",
+            vec![Message::User(UserMessage::text("hello".to_string()))],
+        )
+        .with_provider_param("reasoning_effort", "medium")
+        .with_provider_param(
+            "chat_template_kwargs",
+            serde_json::json!({ "enable_thinking": true }),
+        )
+        .with_provider_param("thinking", serde_json::json!({ "type": "enabled" }));
+
+        let body = client
+            .build_chat_completions_body(&request)
+            .expect("body should build");
+
+        assert_eq!(body["reasoning"]["effort"], "medium");
+        assert_eq!(body["reasoning_effort"], "medium");
+        assert_eq!(body["chat_template_kwargs"]["enable_thinking"], true);
+        assert_eq!(body["thinking"]["type"], "enabled");
+    }
+
+    #[tokio::test]
+    async fn responses_mode_uses_single_v1_prefix_and_omits_auth_when_unset() {
+        let payload = concat!(
+            "data: {\"type\":\"response.completed\",\"response\":{\"status\":\"completed\",\"output\":[{\"type\":\"message\",\"content\":[{\"type\":\"output_text\",\"text\":\"Hello\"}]}],\"usage\":{\"input_tokens\":10,\"output_tokens\":5}}}\n\n",
+            "data: {\"type\":\"response.done\",\"response\":{\"status\":\"completed\",\"output\":[],\"usage\":{\"input_tokens\":10,\"output_tokens\":5}}}\n\n"
+        )
+        .to_string();
+        let (base_url, auth_headers, handle) = spawn_responses_stub_server(payload).await;
+        let client = OpenAiCompatibleClient::new(
+            OpenAiCompatibleMode::Responses,
+            "gemma4:e2b".to_string(),
+            base_url,
+            None,
+            true,
+            true,
+            true,
+        );
+        let request = LlmRequest::new(
+            "gemma-4-e2b",
+            vec![Message::User(UserMessage::text("hello".to_string()))],
+        );
+
+        let events: Vec<_> = client.stream(&request).collect().await;
+        assert!(
+            events.iter().all(Result::is_ok),
+            "responses mode should succeed against a single /v1/responses endpoint"
+        );
+        let auth_headers = auth_headers.lock().expect("auth header capture lock");
+        assert_eq!(auth_headers.len(), 1);
+        assert_eq!(auth_headers[0], None);
         handle.abort();
     }
 

--- a/meerkat-client/src/openai_compatible.rs
+++ b/meerkat-client/src/openai_compatible.rs
@@ -313,10 +313,14 @@ impl LlmClient for OpenAiCompatibleClient {
     fn stream<'a>(&'a self, request: &'a LlmRequest) -> LlmStream<'a> {
         match self.mode {
             OpenAiCompatibleMode::Responses => {
-                let delegate = self
-                    .responses_delegate
-                    .as_ref()
-                    .expect("responses delegate should be configured");
+                let Some(delegate) = self.responses_delegate.as_ref() else {
+                    let inner: LlmStream<'a> = Box::pin(async_stream::try_stream! {
+                        Err(LlmError::Transport(
+                            "responses mode requires a configured delegate client".to_string(),
+                        ))?;
+                    });
+                    return inner;
+                };
                 let inner: LlmStream<'a> = Box::pin(async_stream::try_stream! {
                     let translated = self.request_with_remote_model(request);
                     let mut stream = delegate.stream(&translated);

--- a/meerkat-client/src/openai_compatible.rs
+++ b/meerkat-client/src/openai_compatible.rs
@@ -1,0 +1,678 @@
+//! OpenAI-compatible client for self-hosted endpoints.
+
+use crate::error::LlmError;
+use crate::types::{LlmClient, LlmDoneOutcome, LlmEvent, LlmRequest, LlmStream, ToolCallBuffer};
+use async_trait::async_trait;
+use futures::StreamExt;
+use meerkat_core::schema::{CompiledSchema, SchemaError};
+use meerkat_core::{
+    AssistantBlock, ContentBlock, ImageData, Message, OutputSchema, StopReason, Usage,
+};
+use serde::Deserialize;
+use serde_json::Value;
+use std::collections::HashMap;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum OpenAiCompatibleMode {
+    Responses,
+    ChatCompletions,
+}
+
+/// OpenAI-compatible client for self-hosted servers.
+pub struct OpenAiCompatibleClient {
+    mode: OpenAiCompatibleMode,
+    remote_model: String,
+    bearer_token: Option<String>,
+    base_url: String,
+    http: reqwest::Client,
+    responses_delegate: Option<crate::OpenAiClient>,
+    supports_temperature: bool,
+    supports_reasoning: bool,
+}
+
+impl OpenAiCompatibleClient {
+    pub fn new(
+        mode: OpenAiCompatibleMode,
+        remote_model: String,
+        base_url: String,
+        bearer_token: Option<String>,
+        supports_temperature: bool,
+        supports_reasoning: bool,
+    ) -> Self {
+        let http =
+            crate::http::build_http_client_for_base_url(reqwest::Client::builder(), &base_url)
+                .unwrap_or_else(|_| reqwest::Client::new());
+        let responses_delegate = matches!(mode, OpenAiCompatibleMode::Responses).then(|| {
+            crate::OpenAiClient::new_with_base_url(
+                bearer_token.clone().unwrap_or_else(|| "local".to_string()),
+                base_url.clone(),
+            )
+        });
+        Self {
+            mode,
+            remote_model,
+            bearer_token,
+            base_url,
+            http,
+            responses_delegate,
+            supports_temperature,
+            supports_reasoning,
+        }
+    }
+
+    fn request_with_remote_model(&self, request: &LlmRequest) -> LlmRequest {
+        let mut request = request.clone();
+        request.model = self.remote_model.clone();
+        request
+    }
+
+    fn build_chat_completions_body(&self, request: &LlmRequest) -> Result<Value, LlmError> {
+        let mut body = serde_json::json!({
+            "model": self.remote_model,
+            "messages": Self::convert_to_chat_messages(&request.messages)?,
+            "stream": true,
+            "stream_options": { "include_usage": true },
+            "max_completion_tokens": request.max_tokens,
+        });
+
+        if self.supports_temperature
+            && let Some(temp) = request.temperature
+            && let Some(num) = serde_json::Number::from_f64(temp as f64)
+        {
+            body["temperature"] = Value::Number(num);
+        }
+
+        if !request.tools.is_empty() {
+            body["tools"] = Value::Array(
+                request
+                    .tools
+                    .iter()
+                    .map(|tool| {
+                        serde_json::json!({
+                            "type": "function",
+                            "function": {
+                                "name": tool.name,
+                                "description": tool.description,
+                                "parameters": tool.input_schema
+                            }
+                        })
+                    })
+                    .collect(),
+            );
+        }
+
+        if let Some(params) = &request.provider_params {
+            if self.supports_reasoning
+                && let Some(reasoning) = params.get("reasoning_effort")
+            {
+                body["reasoning"] = serde_json::json!({ "effort": reasoning.clone() });
+            }
+            if let Some(structured) = params.get("structured_output") {
+                let output_schema: OutputSchema = serde_json::from_value(structured.clone())
+                    .map_err(|e| LlmError::InvalidRequest {
+                        message: format!("Invalid structured_output schema: {e}"),
+                    })?;
+                let compiled =
+                    self.compile_schema(&output_schema)
+                        .map_err(|e| LlmError::InvalidRequest {
+                            message: e.to_string(),
+                        })?;
+                body["response_format"] = serde_json::json!({
+                    "type": "json_schema",
+                    "json_schema": {
+                        "name": output_schema.name.as_deref().unwrap_or("output"),
+                        "schema": compiled.schema,
+                        "strict": output_schema.strict
+                    }
+                });
+            }
+        }
+
+        Ok(body)
+    }
+
+    fn convert_to_chat_messages(messages: &[Message]) -> Result<Vec<Value>, LlmError> {
+        let mut out = Vec::new();
+        for message in messages {
+            match message {
+                Message::System(system) => {
+                    out.push(serde_json::json!({
+                        "role": "system",
+                        "content": system.content
+                    }));
+                }
+                Message::SystemNotice(notice) => {
+                    out.push(serde_json::json!({
+                        "role": "user",
+                        "content": notice.rendered_text()
+                    }));
+                }
+                Message::User(user) => {
+                    if meerkat_core::has_non_text_content(&user.content) {
+                        let content: Vec<Value> = user
+                            .content
+                            .iter()
+                            .map(|block| match block {
+                                ContentBlock::Text { text } => serde_json::json!({
+                                    "type": "text",
+                                    "text": text
+                                }),
+                                ContentBlock::Image { media_type, data } => match data {
+                                    ImageData::Inline { data } => serde_json::json!({
+                                        "type": "image_url",
+                                        "image_url": {
+                                            "url": format!("data:{media_type};base64,{data}")
+                                        }
+                                    }),
+                                    ImageData::Blob { .. } => serde_json::json!({
+                                        "type": "text",
+                                        "text": block.text_projection()
+                                    }),
+                                },
+                                _ => serde_json::json!({
+                                    "type": "text",
+                                    "text": block.text_projection()
+                                }),
+                            })
+                            .collect();
+                        out.push(serde_json::json!({
+                            "role": "user",
+                            "content": content
+                        }));
+                    } else {
+                        out.push(serde_json::json!({
+                            "role": "user",
+                            "content": user.text_content()
+                        }));
+                    }
+                }
+                Message::Assistant(assistant) => {
+                    let tool_calls: Vec<Value> = assistant
+                        .tool_calls
+                        .iter()
+                        .map(|tool_call| {
+                            serde_json::json!({
+                                "id": tool_call.id,
+                                "type": "function",
+                                "function": {
+                                    "name": tool_call.name,
+                                    "arguments": tool_call.args.to_string(),
+                                }
+                            })
+                        })
+                        .collect();
+                    out.push(serde_json::json!({
+                        "role": "assistant",
+                        "content": if assistant.content.is_empty() {
+                            Value::Null
+                        } else {
+                            Value::String(assistant.content.clone())
+                        },
+                        "tool_calls": tool_calls
+                    }));
+                }
+                Message::BlockAssistant(assistant) => {
+                    let mut text_parts = Vec::new();
+                    let mut tool_calls = Vec::new();
+                    for block in &assistant.blocks {
+                        match block {
+                            AssistantBlock::Text { text, .. } => {
+                                if !text.is_empty() {
+                                    text_parts.push(text.clone());
+                                }
+                            }
+                            AssistantBlock::ToolUse { id, name, args, .. } => {
+                                tool_calls.push(serde_json::json!({
+                                    "id": id,
+                                    "type": "function",
+                                    "function": {
+                                        "name": name,
+                                        "arguments": args.get(),
+                                    }
+                                }));
+                            }
+                            _ => {}
+                        }
+                    }
+                    out.push(serde_json::json!({
+                        "role": "assistant",
+                        "content": if text_parts.is_empty() {
+                            Value::Null
+                        } else {
+                            Value::String(text_parts.join("\n"))
+                        },
+                        "tool_calls": tool_calls
+                    }));
+                }
+                Message::ToolResults { results } => {
+                    for result in results {
+                        out.push(serde_json::json!({
+                            "role": "tool",
+                            "tool_call_id": result.tool_use_id,
+                            "content": result.text_content()
+                        }));
+                    }
+                }
+            }
+        }
+        Ok(out)
+    }
+
+    fn apply_auth(
+        &self,
+        request: reqwest::RequestBuilder,
+        content_type: &'static str,
+    ) -> reqwest::RequestBuilder {
+        let request = request.header("Content-Type", content_type);
+        if let Some(token) = &self.bearer_token {
+            request.header("Authorization", format!("Bearer {token}"))
+        } else {
+            request
+        }
+    }
+
+    fn parse_chat_completions_line(line: &str) -> Option<ChatCompletionsChunk> {
+        if let Some(data) = line.strip_prefix("data: ") {
+            if data == "[DONE]" {
+                return None;
+            }
+            serde_json::from_str(data).ok()
+        } else {
+            None
+        }
+    }
+}
+
+fn ensure_additional_properties_false(value: &mut Value) {
+    match value {
+        Value::Object(obj) => {
+            let is_object_type = match obj.get("type") {
+                Some(Value::String(t)) => t == "object",
+                Some(Value::Array(types)) => types.iter().any(|t| t.as_str() == Some("object")),
+                _ => obj.contains_key("properties") || obj.contains_key("required"),
+            };
+            if is_object_type && !obj.contains_key("additionalProperties") {
+                obj.insert("additionalProperties".to_string(), Value::Bool(false));
+            }
+            for child in obj.values_mut() {
+                ensure_additional_properties_false(child);
+            }
+        }
+        Value::Array(items) => {
+            for item in items.iter_mut() {
+                ensure_additional_properties_false(item);
+            }
+        }
+        _ => {}
+    }
+}
+
+#[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
+#[cfg_attr(not(target_arch = "wasm32"), async_trait)]
+impl LlmClient for OpenAiCompatibleClient {
+    fn stream<'a>(&'a self, request: &'a LlmRequest) -> LlmStream<'a> {
+        match self.mode {
+            OpenAiCompatibleMode::Responses => {
+                let delegate = self
+                    .responses_delegate
+                    .as_ref()
+                    .expect("responses delegate should be configured");
+                let inner: LlmStream<'a> = Box::pin(async_stream::try_stream! {
+                    let translated = self.request_with_remote_model(request);
+                    let mut stream = delegate.stream(&translated);
+                    while let Some(event) = stream.next().await {
+                        yield event?;
+                    }
+                });
+                crate::streaming::ensure_terminal_done(inner)
+            }
+            OpenAiCompatibleMode::ChatCompletions => {
+                let inner: LlmStream<'a> = Box::pin(async_stream::try_stream! {
+                    let body = self.build_chat_completions_body(request)?;
+                    let response = self
+                        .apply_auth(
+                            self.http.post(format!("{}/chat/completions", self.base_url)),
+                            "application/json",
+                        )
+                        .json(&body)
+                        .send()
+                        .await
+                        .map_err(|e| {
+                            if e.is_timeout() {
+                                LlmError::NetworkTimeout { duration_ms: 30000 }
+                            } else if e.is_connect() {
+                                LlmError::ConnectionReset
+                            } else {
+                                LlmError::Unknown {
+                                    message: e.to_string(),
+                                }
+                            }
+                        })?;
+
+                    let status_code = response.status().as_u16();
+                    let stream_result = if (200..=299).contains(&status_code) {
+                        Ok(response.bytes_stream())
+                    } else {
+                        let headers = response.headers().clone();
+                        let text = response.text().await.unwrap_or_default();
+                        Err(LlmError::from_http_response(status_code, text, &headers))
+                    };
+                    let mut stream = stream_result?;
+                    let mut buffer = String::with_capacity(512);
+                    let mut tool_buffers: HashMap<usize, ToolCallBuffer> = HashMap::new();
+                    let mut done_emitted = false;
+
+                    while let Some(chunk) = stream.next().await {
+                        let chunk = chunk.map_err(|_| LlmError::ConnectionReset)?;
+                        buffer.push_str(&String::from_utf8_lossy(&chunk));
+
+                        while let Some(newline_pos) = buffer.find('\n') {
+                            let line = buffer[..newline_pos].trim();
+                            let should_process = !line.is_empty() && !line.starts_with(':');
+                            let parsed = if should_process {
+                                Self::parse_chat_completions_line(line)
+                            } else {
+                                None
+                            };
+                            buffer.drain(..=newline_pos);
+
+                            if let Some(event) = parsed {
+                                if let Some(event_usage) = event.usage {
+                                    let usage = Usage {
+                                        input_tokens: event_usage.prompt_tokens.unwrap_or(0),
+                                        output_tokens: event_usage.completion_tokens.unwrap_or(0),
+                                        cache_creation_tokens: None,
+                                        cache_read_tokens: None,
+                                    };
+                                    yield LlmEvent::UsageUpdate { usage };
+                                }
+
+                                for choice in event.choices {
+                                    if let Some(delta) = choice.delta {
+                                        if let Some(content) = delta.content
+                                            && !content.is_empty()
+                                        {
+                                            yield LlmEvent::TextDelta {
+                                                delta: content,
+                                                meta: None,
+                                            };
+                                        }
+                                        if let Some(tool_calls) = delta.tool_calls {
+                                            for tool_call in tool_calls {
+                                                let index = tool_call.index.unwrap_or(0);
+                                                let buffer = tool_buffers.entry(index).or_insert_with(|| {
+                                                    ToolCallBuffer::new(
+                                                        tool_call
+                                                            .id
+                                                            .clone()
+                                                            .unwrap_or_else(|| format!("tool_call_{index}")),
+                                                    )
+                                                });
+                                                if let Some(id) = tool_call.id
+                                                    && buffer.id.starts_with("tool_call_")
+                                                {
+                                                    buffer.id = id;
+                                                }
+                                                if let Some(function) = tool_call.function {
+                                                    if let Some(name) = function.name {
+                                                        buffer.name = Some(name);
+                                                    }
+                                                    if let Some(arguments) = function.arguments
+                                                        && !arguments.is_empty()
+                                                    {
+                                                        buffer.push_args(&arguments);
+                                                        yield LlmEvent::ToolCallDelta {
+                                                            id: buffer.id.clone(),
+                                                            name: buffer.name.clone(),
+                                                            args_delta: arguments,
+                                                        };
+                                                    }
+                                                }
+                                            }
+                                        }
+                                    }
+
+                                    if let Some(finish_reason) = choice.finish_reason {
+                                        let stop_reason = match finish_reason.as_str() {
+                                            "tool_calls" => StopReason::ToolUse,
+                                            "length" => StopReason::MaxTokens,
+                                            "content_filter" => StopReason::ContentFilter,
+                                            _ => StopReason::EndTurn,
+                                        };
+                                        if matches!(stop_reason, StopReason::ToolUse) {
+                                            for buffer in tool_buffers.values() {
+                                                if let Some(tool_call) = buffer.try_complete() {
+                                                    yield LlmEvent::ToolCallComplete {
+                                                        id: tool_call.id,
+                                                        name: tool_call.name,
+                                                        args: tool_call.args,
+                                                        meta: None,
+                                                    };
+                                                }
+                                            }
+                                        }
+                                        if !done_emitted {
+                                            done_emitted = true;
+                                            yield LlmEvent::Done {
+                                                outcome: LlmDoneOutcome::Success { stop_reason },
+                                            };
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+
+                    if !done_emitted {
+                        yield LlmEvent::Done {
+                            outcome: LlmDoneOutcome::Success {
+                                stop_reason: StopReason::EndTurn,
+                            },
+                        };
+                    }
+                });
+
+                crate::streaming::ensure_terminal_done(inner)
+            }
+        }
+    }
+
+    fn provider(&self) -> &'static str {
+        "self_hosted"
+    }
+
+    async fn health_check(&self) -> Result<(), LlmError> {
+        let response = self
+            .apply_auth(
+                self.http.get(format!("{}/models", self.base_url)),
+                "application/json",
+            )
+            .send()
+            .await
+            .map_err(|e| LlmError::Unknown {
+                message: e.to_string(),
+            })?;
+        let status = response.status().as_u16();
+        if (200..=299).contains(&status) {
+            Ok(())
+        } else {
+            let headers = response.headers().clone();
+            let text = response.text().await.unwrap_or_default();
+            Err(LlmError::from_http_response(status, text, &headers))
+        }
+    }
+
+    fn compile_schema(&self, output_schema: &OutputSchema) -> Result<CompiledSchema, SchemaError> {
+        let mut schema = output_schema.schema.as_value().clone();
+        if output_schema.strict {
+            ensure_additional_properties_false(&mut schema);
+        }
+        Ok(CompiledSchema {
+            schema,
+            warnings: Vec::new(),
+        })
+    }
+}
+
+#[derive(Debug, Deserialize)]
+struct ChatCompletionsChunk {
+    choices: Vec<ChatChoice>,
+    #[serde(default)]
+    usage: Option<ChatUsage>,
+}
+
+#[derive(Debug, Deserialize)]
+struct ChatChoice {
+    #[serde(default)]
+    delta: Option<ChatDelta>,
+    #[serde(default)]
+    finish_reason: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+struct ChatDelta {
+    #[serde(default)]
+    content: Option<String>,
+    #[serde(default)]
+    tool_calls: Option<Vec<ChatToolCallDelta>>,
+}
+
+#[derive(Debug, Deserialize)]
+struct ChatToolCallDelta {
+    #[serde(default)]
+    index: Option<usize>,
+    #[serde(default)]
+    id: Option<String>,
+    #[serde(default)]
+    function: Option<ChatFunctionDelta>,
+}
+
+#[derive(Debug, Deserialize)]
+struct ChatFunctionDelta {
+    #[serde(default)]
+    name: Option<String>,
+    #[serde(default)]
+    arguments: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+struct ChatUsage {
+    #[serde(default)]
+    prompt_tokens: Option<u64>,
+    #[serde(default)]
+    completion_tokens: Option<u64>,
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used)]
+mod tests {
+    use super::*;
+    use axum::{Json, Router, extract::State, response::IntoResponse, routing::post};
+    use meerkat_core::UserMessage;
+    use tokio::net::TcpListener;
+
+    async fn chat_sse(State(payload): State<String>) -> impl IntoResponse {
+        ([("content-type", "text/event-stream")], payload)
+    }
+
+    async fn models() -> impl IntoResponse {
+        Json(serde_json::json!({"data": []}))
+    }
+
+    async fn spawn_chat_stub_server(payload: String) -> (String, tokio::task::JoinHandle<()>) {
+        let app = Router::new()
+            .route("/v1/chat/completions", post(chat_sse))
+            .route("/v1/models", axum::routing::get(models))
+            .with_state(payload);
+        let listener = TcpListener::bind("127.0.0.1:0")
+            .await
+            .expect("bind test server");
+        let addr = listener.local_addr().expect("local addr");
+        let handle = tokio::spawn(async move {
+            axum::serve(listener, app).await.expect("serve test server");
+        });
+        (format!("http://{addr}/v1"), handle)
+    }
+
+    #[tokio::test]
+    async fn chat_completions_stream_accumulates_tool_calls() {
+        let payload = concat!(
+            "data: {\"choices\":[{\"delta\":{\"tool_calls\":[{\"index\":0,\"id\":\"call_1\",\"function\":{\"name\":\"read_file\",\"arguments\":\"{\\\"path\\\":\"}}]}}]}\n\n",
+            "data: {\"choices\":[{\"delta\":{\"tool_calls\":[{\"index\":0,\"function\":{\"arguments\":\"\\\"/tmp/a\\\"}\"}}]}}]}\n\n",
+            "data: {\"choices\":[{\"finish_reason\":\"tool_calls\"}],\"usage\":{\"prompt_tokens\":10,\"completion_tokens\":4}}\n\n",
+            "data: [DONE]\n\n"
+        )
+        .to_string();
+        let (base_url, handle) = spawn_chat_stub_server(payload).await;
+        let client = OpenAiCompatibleClient::new(
+            OpenAiCompatibleMode::ChatCompletions,
+            "remote-model".to_string(),
+            base_url,
+            None,
+            true,
+            false,
+        );
+        let request = LlmRequest::new(
+            "gemma-4-31b",
+            vec![Message::User(UserMessage::text("hello".to_string()))],
+        );
+
+        let events: Vec<_> = client.stream(&request).collect().await;
+        let mut saw_complete = false;
+        let mut saw_done = false;
+        for event in events {
+            let event = event.expect("event");
+            match event {
+                LlmEvent::ToolCallComplete { id, name, args, .. } => {
+                    saw_complete = true;
+                    assert_eq!(id, "call_1");
+                    assert_eq!(name, "read_file");
+                    assert_eq!(args["path"], "/tmp/a");
+                }
+                LlmEvent::Done { outcome } => {
+                    saw_done = true;
+                    assert!(matches!(
+                        outcome,
+                        LlmDoneOutcome::Success {
+                            stop_reason: StopReason::ToolUse
+                        }
+                    ));
+                }
+                _ => {}
+            }
+        }
+        assert!(saw_complete);
+        assert!(saw_done);
+        handle.abort();
+    }
+
+    #[test]
+    fn ensure_additional_properties_false_recurses_into_nested_objects() {
+        let mut value = serde_json::json!({
+            "type": "object",
+            "properties": {
+                "outer": {
+                    "type": "object",
+                    "properties": {
+                        "inner": {
+                            "type": "object",
+                            "properties": {}
+                        }
+                    }
+                }
+            }
+        });
+
+        ensure_additional_properties_false(&mut value);
+
+        assert_eq!(value["additionalProperties"], Value::Bool(false));
+        assert_eq!(
+            value["properties"]["outer"]["additionalProperties"],
+            Value::Bool(false)
+        );
+        assert_eq!(
+            value["properties"]["outer"]["properties"]["inner"]["additionalProperties"],
+            Value::Bool(false)
+        );
+    }
+}

--- a/meerkat-client/src/openai_compatible.rs
+++ b/meerkat-client/src/openai_compatible.rs
@@ -84,6 +84,28 @@ impl OpenAiCompatibleClient {
         request
     }
 
+    fn map_send_error(error: reqwest::Error) -> LlmError {
+        if error.is_timeout() {
+            LlmError::NetworkTimeout { duration_ms: 30000 }
+        } else if Self::is_connection_error(&error) {
+            LlmError::ConnectionReset
+        } else {
+            LlmError::Unknown {
+                message: error.to_string(),
+            }
+        }
+    }
+
+    #[cfg(not(target_arch = "wasm32"))]
+    fn is_connection_error(error: &reqwest::Error) -> bool {
+        error.is_connect()
+    }
+
+    #[cfg(target_arch = "wasm32")]
+    fn is_connection_error(_error: &reqwest::Error) -> bool {
+        false
+    }
+
     fn build_chat_completions_body(&self, request: &LlmRequest) -> Result<Value, LlmError> {
         let mut body = serde_json::json!({
             "model": self.remote_model,
@@ -393,17 +415,7 @@ impl LlmClient for OpenAiCompatibleClient {
                         .json(&body)
                         .send()
                         .await
-                        .map_err(|e| {
-                            if e.is_timeout() {
-                                LlmError::NetworkTimeout { duration_ms: 30000 }
-                            } else if e.is_connect() {
-                                LlmError::ConnectionReset
-                            } else {
-                                LlmError::Unknown {
-                                    message: e.to_string(),
-                                }
-                            }
-                        })?;
+                        .map_err(Self::map_send_error)?;
 
                     let status_code = response.status().as_u16();
                     let stream_result = if (200..=299).contains(&status_code) {

--- a/meerkat-client/src/openai_compatible.rs
+++ b/meerkat-client/src/openai_compatible.rs
@@ -314,11 +314,12 @@ impl LlmClient for OpenAiCompatibleClient {
         match self.mode {
             OpenAiCompatibleMode::Responses => {
                 let Some(delegate) = self.responses_delegate.as_ref() else {
-                    let inner: LlmStream<'a> = Box::pin(async_stream::try_stream! {
-                        Err(LlmError::Transport(
-                            "responses mode requires a configured delegate client".to_string(),
-                        ))?;
-                    });
+                    let inner: LlmStream<'a> = Box::pin(futures::stream::once(async {
+                        Err(LlmError::InvalidRequest {
+                            message: "responses mode requires a configured delegate client"
+                                .to_string(),
+                        })
+                    }));
                     return inner;
                 };
                 let inner: LlmStream<'a> = Box::pin(async_stream::try_stream! {

--- a/meerkat-client/src/openai_compatible.rs
+++ b/meerkat-client/src/openai_compatible.rs
@@ -66,6 +66,21 @@ impl OpenAiCompatibleClient {
     fn request_with_remote_model(&self, request: &LlmRequest) -> LlmRequest {
         let mut request = request.clone();
         request.model = self.remote_model.clone();
+        let mut provider_params = request
+            .provider_params
+            .take()
+            .unwrap_or_else(|| serde_json::json!({}));
+        if let Some(obj) = provider_params.as_object_mut() {
+            obj.insert(
+                crate::OpenAiClient::INTERNAL_SUPPORTS_TEMPERATURE.to_string(),
+                Value::Bool(self.supports_temperature),
+            );
+            obj.insert(
+                crate::OpenAiClient::INTERNAL_SUPPORTS_REASONING.to_string(),
+                Value::Bool(self.supports_reasoning),
+            );
+        }
+        request.provider_params = Some(provider_params);
         request
     }
 
@@ -294,7 +309,10 @@ impl OpenAiCompatibleClient {
     }
 
     fn parse_chat_completions_line(line: &str) -> Result<Option<ChatCompletionsChunk>, LlmError> {
-        if let Some(data) = line.strip_prefix("data: ") {
+        if let Some(data) = line
+            .strip_prefix("data: ")
+            .or_else(|| line.strip_prefix("data:"))
+        {
             if data == "[DONE]" {
                 return Ok(None);
             }
@@ -891,6 +909,49 @@ mod tests {
         assert_eq!(auth_headers.len(), 1);
         assert_eq!(auth_headers[0], None);
         handle.abort();
+    }
+
+    #[test]
+    fn request_with_remote_model_preserves_self_hosted_capabilities_for_delegate() {
+        let client = OpenAiCompatibleClient::new(
+            OpenAiCompatibleMode::Responses,
+            "gemma4:e2b".to_string(),
+            "http://localhost:11434/v1".to_string(),
+            None,
+            true,
+            true,
+            true,
+        );
+        let request = LlmRequest::new(
+            "gemma-4-e2b",
+            vec![Message::User(UserMessage::text("hello".to_string()))],
+        );
+
+        let translated = client.request_with_remote_model(&request);
+
+        assert_eq!(translated.model, "gemma4:e2b");
+        assert_eq!(
+            translated
+                .provider_params
+                .as_ref()
+                .and_then(|params| params.get(crate::OpenAiClient::INTERNAL_SUPPORTS_TEMPERATURE)),
+            Some(&Value::Bool(true))
+        );
+        assert_eq!(
+            translated
+                .provider_params
+                .as_ref()
+                .and_then(|params| params.get(crate::OpenAiClient::INTERNAL_SUPPORTS_REASONING)),
+            Some(&Value::Bool(true))
+        );
+    }
+
+    #[test]
+    fn parse_chat_completions_line_accepts_sse_data_without_space() {
+        let line = r#"data:{"choices":[{"delta":{"content":"Hello"}}]}"#;
+        let chunk =
+            OpenAiCompatibleClient::parse_chat_completions_line(line).expect("line should parse");
+        assert!(chunk.is_some());
     }
 
     #[test]

--- a/meerkat-client/src/provider.rs
+++ b/meerkat-client/src/provider.rs
@@ -45,6 +45,7 @@ impl ProviderResolver {
             Provider::Gemini => env("RKAT_GEMINI_API_KEY")
                 .or_else(|| env("GEMINI_API_KEY"))
                 .or_else(|| env("GOOGLE_API_KEY")),
+            Provider::SelfHosted => None,
             Provider::Other => None,
         }
     }
@@ -84,6 +85,7 @@ fn map_provider(provider: Provider) -> Option<LlmProvider> {
         Provider::Anthropic => Some(LlmProvider::Anthropic),
         Provider::OpenAI => Some(LlmProvider::OpenAi),
         Provider::Gemini => Some(LlmProvider::Gemini),
+        Provider::SelfHosted => None,
         Provider::Other => None,
     }
 }

--- a/meerkat-contracts/src/wire/models.rs
+++ b/meerkat-contracts/src/wire/models.rs
@@ -48,6 +48,9 @@ pub struct CatalogModelEntry {
     /// Maximum output tokens per response.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub max_output_tokens: Option<u32>,
+    /// Backing self-hosted server ID for configured aliases.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub server_id: Option<String>,
     /// Model profile with capability flags and parameter schema.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub profile: Option<WireModelProfile>,

--- a/meerkat-core/src/agent/runner.rs
+++ b/meerkat-core/src/agent/runner.rs
@@ -232,7 +232,8 @@ where
     }
 
     /// Synchronize the shared system-context state into the in-memory session metadata.
-    pub(crate) fn sync_system_context_state_to_session(&mut self) {
+    #[doc(hidden)]
+    pub fn sync_system_context_state_to_session(&mut self) {
         let state = match self.system_context_state.lock() {
             Ok(guard) => guard.clone(),
             Err(poisoned) => {

--- a/meerkat-core/src/config.rs
+++ b/meerkat-core/src/config.rs
@@ -441,6 +441,7 @@ impl Config {
         if let Some(servers) = self_hosted.get("servers").and_then(toml::Value::as_table) {
             if servers.is_empty() {
                 self.self_hosted.servers.clear();
+                self.self_hosted.models.clear();
             } else {
                 let mut merged_servers = self.self_hosted.servers.clone();
                 for (server_id, server_value) in servers {
@@ -992,7 +993,7 @@ pub struct SelfHostedServerConfig {
     pub transport: SelfHostedTransport,
     pub base_url: String,
     pub api_style: SelfHostedApiStyle,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[serde(default, skip_serializing)]
     pub bearer_token: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub bearer_token_env: Option<String>,
@@ -2055,6 +2056,25 @@ family = "gemma-4"
 
         assert!(config.self_hosted.servers.is_empty());
         assert!(config.self_hosted.models.is_empty());
+    }
+
+    #[test]
+    fn test_self_hosted_bearer_token_is_not_serialized() {
+        let config: Config = toml::from_str(
+            r#"
+[self_hosted.servers.local]
+base_url = "http://127.0.0.1:11434"
+bearer_token = "secret-token"
+"#,
+        )
+        .expect("config");
+
+        let value = serde_json::to_value(&config).expect("serialize config");
+        let server = &value["self_hosted"]["servers"]["local"];
+        assert!(
+            server.get("bearer_token").is_none(),
+            "literal bearer tokens must be redacted from serialized config"
+        );
     }
 
     #[test]

--- a/meerkat-core/src/config.rs
+++ b/meerkat-core/src/config.rs
@@ -439,100 +439,108 @@ impl Config {
         };
 
         if let Some(servers) = self_hosted.get("servers").and_then(toml::Value::as_table) {
-            let mut merged_servers = self.self_hosted.servers.clone();
-            for (server_id, server_value) in servers {
-                let Some(server_table) = server_value.as_table() else {
-                    continue;
-                };
-                let mut merged = self
-                    .self_hosted
-                    .servers
-                    .get(server_id)
-                    .cloned()
-                    .unwrap_or_default();
-                let Some(server_layer) = layer.servers.get(server_id) else {
-                    continue;
-                };
-                if server_table.contains_key("transport") {
-                    merged.transport = server_layer.transport;
+            if servers.is_empty() {
+                self.self_hosted.servers.clear();
+            } else {
+                let mut merged_servers = self.self_hosted.servers.clone();
+                for (server_id, server_value) in servers {
+                    let Some(server_table) = server_value.as_table() else {
+                        continue;
+                    };
+                    let mut merged = self
+                        .self_hosted
+                        .servers
+                        .get(server_id)
+                        .cloned()
+                        .unwrap_or_default();
+                    let Some(server_layer) = layer.servers.get(server_id) else {
+                        continue;
+                    };
+                    if server_table.contains_key("transport") {
+                        merged.transport = server_layer.transport;
+                    }
+                    if server_table.contains_key("base_url") {
+                        merged.base_url = server_layer.base_url.clone();
+                    }
+                    if server_table.contains_key("api_style") {
+                        merged.api_style = server_layer.api_style;
+                    }
+                    if server_table.contains_key("bearer_token") {
+                        merged.bearer_token = server_layer.bearer_token.clone();
+                    }
+                    if server_table.contains_key("bearer_token_env") {
+                        merged.bearer_token_env = server_layer.bearer_token_env.clone();
+                    }
+                    merged_servers.insert(server_id.clone(), merged);
                 }
-                if server_table.contains_key("base_url") {
-                    merged.base_url = server_layer.base_url.clone();
-                }
-                if server_table.contains_key("api_style") {
-                    merged.api_style = server_layer.api_style;
-                }
-                if server_table.contains_key("bearer_token") {
-                    merged.bearer_token = server_layer.bearer_token.clone();
-                }
-                if server_table.contains_key("bearer_token_env") {
-                    merged.bearer_token_env = server_layer.bearer_token_env.clone();
-                }
-                merged_servers.insert(server_id.clone(), merged);
+                self.self_hosted.servers = merged_servers;
             }
-            self.self_hosted.servers = merged_servers;
         }
 
         if let Some(models) = self_hosted.get("models").and_then(toml::Value::as_table) {
-            let mut merged_models = self.self_hosted.models.clone();
-            for (model_id, model_value) in models {
-                let Some(model_table) = model_value.as_table() else {
-                    continue;
-                };
-                let mut merged = self
-                    .self_hosted
-                    .models
-                    .get(model_id)
-                    .cloned()
-                    .unwrap_or_default();
-                let Some(model_layer) = layer.models.get(model_id) else {
-                    continue;
-                };
-                if model_table.contains_key("server") {
-                    merged.server = model_layer.server.clone();
+            if models.is_empty() {
+                self.self_hosted.models.clear();
+            } else {
+                let mut merged_models = self.self_hosted.models.clone();
+                for (model_id, model_value) in models {
+                    let Some(model_table) = model_value.as_table() else {
+                        continue;
+                    };
+                    let mut merged = self
+                        .self_hosted
+                        .models
+                        .get(model_id)
+                        .cloned()
+                        .unwrap_or_default();
+                    let Some(model_layer) = layer.models.get(model_id) else {
+                        continue;
+                    };
+                    if model_table.contains_key("server") {
+                        merged.server = model_layer.server.clone();
+                    }
+                    if model_table.contains_key("remote_model") {
+                        merged.remote_model = model_layer.remote_model.clone();
+                    }
+                    if model_table.contains_key("display_name") {
+                        merged.display_name = model_layer.display_name.clone();
+                    }
+                    if model_table.contains_key("family") {
+                        merged.family = model_layer.family.clone();
+                    }
+                    if model_table.contains_key("tier") {
+                        merged.tier = model_layer.tier;
+                    }
+                    if model_table.contains_key("context_window") {
+                        merged.context_window = model_layer.context_window;
+                    }
+                    if model_table.contains_key("max_output_tokens") {
+                        merged.max_output_tokens = model_layer.max_output_tokens;
+                    }
+                    if model_table.contains_key("vision") {
+                        merged.vision = model_layer.vision;
+                    }
+                    if model_table.contains_key("image_tool_results") {
+                        merged.image_tool_results = model_layer.image_tool_results;
+                    }
+                    if model_table.contains_key("inline_video") {
+                        merged.inline_video = model_layer.inline_video;
+                    }
+                    if model_table.contains_key("supports_temperature") {
+                        merged.supports_temperature = model_layer.supports_temperature;
+                    }
+                    if model_table.contains_key("supports_thinking") {
+                        merged.supports_thinking = model_layer.supports_thinking;
+                    }
+                    if model_table.contains_key("supports_reasoning") {
+                        merged.supports_reasoning = model_layer.supports_reasoning;
+                    }
+                    if model_table.contains_key("call_timeout_secs") {
+                        merged.call_timeout_secs = model_layer.call_timeout_secs;
+                    }
+                    merged_models.insert(model_id.clone(), merged);
                 }
-                if model_table.contains_key("remote_model") {
-                    merged.remote_model = model_layer.remote_model.clone();
-                }
-                if model_table.contains_key("display_name") {
-                    merged.display_name = model_layer.display_name.clone();
-                }
-                if model_table.contains_key("family") {
-                    merged.family = model_layer.family.clone();
-                }
-                if model_table.contains_key("tier") {
-                    merged.tier = model_layer.tier;
-                }
-                if model_table.contains_key("context_window") {
-                    merged.context_window = model_layer.context_window;
-                }
-                if model_table.contains_key("max_output_tokens") {
-                    merged.max_output_tokens = model_layer.max_output_tokens;
-                }
-                if model_table.contains_key("vision") {
-                    merged.vision = model_layer.vision;
-                }
-                if model_table.contains_key("image_tool_results") {
-                    merged.image_tool_results = model_layer.image_tool_results;
-                }
-                if model_table.contains_key("inline_video") {
-                    merged.inline_video = model_layer.inline_video;
-                }
-                if model_table.contains_key("supports_temperature") {
-                    merged.supports_temperature = model_layer.supports_temperature;
-                }
-                if model_table.contains_key("supports_thinking") {
-                    merged.supports_thinking = model_layer.supports_thinking;
-                }
-                if model_table.contains_key("supports_reasoning") {
-                    merged.supports_reasoning = model_layer.supports_reasoning;
-                }
-                if model_table.contains_key("call_timeout_secs") {
-                    merged.call_timeout_secs = model_layer.call_timeout_secs;
-                }
-                merged_models.insert(model_id.clone(), merged);
+                self.self_hosted.models = merged_models;
             }
-            self.self_hosted.models = merged_models;
         }
     }
 
@@ -2015,6 +2023,38 @@ bearer_token_env = "OLLAMA_TOKEN"
                 .map(|server| server.server_id.as_str()),
             Some("backup")
         );
+    }
+
+    #[test]
+    fn test_merge_self_hosted_empty_table_clears_inherited_entries() {
+        let mut config = Config::default();
+        config
+            .merge_toml_str(
+                r#"
+[self_hosted.servers.local]
+base_url = "http://127.0.0.1:11434"
+
+[self_hosted.models.gemma-4-e2b]
+server = "local"
+remote_model = "gemma4:e2b"
+display_name = "Gemma 4 E2B"
+family = "gemma-4"
+"#,
+            )
+            .expect("base self-hosted config");
+
+        config
+            .merge_toml_str(
+                r"
+[self_hosted.servers]
+
+[self_hosted.models]
+",
+            )
+            .expect("clear self-hosted config");
+
+        assert!(config.self_hosted.servers.is_empty());
+        assert!(config.self_hosted.models.is_empty());
     }
 
     #[test]

--- a/meerkat-core/src/config.rs
+++ b/meerkat-core/src/config.rs
@@ -230,11 +230,13 @@ impl Config {
         let file_config: Config = toml::from_str(content).map_err(ConfigError::Parse)?;
         let tools_layer = file_config.tools.clone();
         let retry_layer = file_config.retry.clone();
+        let self_hosted_layer = file_config.self_hosted.clone();
         // Merge (file values override defaults)
         self.merge(file_config);
         let parsed: toml::Value = toml::from_str(content).map_err(ConfigError::Parse)?;
         self.merge_tools_from_toml_presence(&parsed, &tools_layer);
         self.merge_retry_from_toml_presence(&parsed, &retry_layer);
+        self.merge_self_hosted_from_toml_presence(&parsed, &self_hosted_layer);
         Ok(())
     }
 
@@ -326,18 +328,6 @@ impl Config {
                 self.hooks.background_max_concurrency = other.hooks.background_max_concurrency;
             }
             self.hooks.entries.extend(other.hooks.entries);
-        }
-        if other.self_hosted != SelfHostedConfig::default() {
-            if !other.self_hosted.servers.is_empty() {
-                self.self_hosted
-                    .servers
-                    .extend(other.self_hosted.servers.clone());
-            }
-            if !other.self_hosted.models.is_empty() {
-                self.self_hosted
-                    .models
-                    .extend(other.self_hosted.models.clone());
-            }
         }
     }
 
@@ -436,6 +426,113 @@ impl Config {
         }
         if retry.contains_key("call_timeout") {
             self.retry.call_timeout_override = layer.call_timeout_override.clone();
+        }
+    }
+
+    fn merge_self_hosted_from_toml_presence(
+        &mut self,
+        parsed: &toml::Value,
+        layer: &SelfHostedConfig,
+    ) {
+        let Some(self_hosted) = parsed.get("self_hosted").and_then(toml::Value::as_table) else {
+            return;
+        };
+
+        if let Some(servers) = self_hosted.get("servers").and_then(toml::Value::as_table) {
+            let mut merged_servers = BTreeMap::new();
+            for (server_id, server_value) in servers {
+                let Some(server_table) = server_value.as_table() else {
+                    continue;
+                };
+                let mut merged = self
+                    .self_hosted
+                    .servers
+                    .get(server_id)
+                    .cloned()
+                    .unwrap_or_default();
+                let Some(server_layer) = layer.servers.get(server_id) else {
+                    continue;
+                };
+                if server_table.contains_key("transport") {
+                    merged.transport = server_layer.transport;
+                }
+                if server_table.contains_key("base_url") {
+                    merged.base_url = server_layer.base_url.clone();
+                }
+                if server_table.contains_key("api_style") {
+                    merged.api_style = server_layer.api_style;
+                }
+                if server_table.contains_key("bearer_token") {
+                    merged.bearer_token = server_layer.bearer_token.clone();
+                }
+                if server_table.contains_key("bearer_token_env") {
+                    merged.bearer_token_env = server_layer.bearer_token_env.clone();
+                }
+                merged_servers.insert(server_id.clone(), merged);
+            }
+            self.self_hosted.servers = merged_servers;
+        }
+
+        if let Some(models) = self_hosted.get("models").and_then(toml::Value::as_table) {
+            let mut merged_models = BTreeMap::new();
+            for (model_id, model_value) in models {
+                let Some(model_table) = model_value.as_table() else {
+                    continue;
+                };
+                let mut merged = self
+                    .self_hosted
+                    .models
+                    .get(model_id)
+                    .cloned()
+                    .unwrap_or_default();
+                let Some(model_layer) = layer.models.get(model_id) else {
+                    continue;
+                };
+                if model_table.contains_key("server") {
+                    merged.server = model_layer.server.clone();
+                }
+                if model_table.contains_key("remote_model") {
+                    merged.remote_model = model_layer.remote_model.clone();
+                }
+                if model_table.contains_key("display_name") {
+                    merged.display_name = model_layer.display_name.clone();
+                }
+                if model_table.contains_key("family") {
+                    merged.family = model_layer.family.clone();
+                }
+                if model_table.contains_key("tier") {
+                    merged.tier = model_layer.tier;
+                }
+                if model_table.contains_key("context_window") {
+                    merged.context_window = model_layer.context_window;
+                }
+                if model_table.contains_key("max_output_tokens") {
+                    merged.max_output_tokens = model_layer.max_output_tokens;
+                }
+                if model_table.contains_key("vision") {
+                    merged.vision = model_layer.vision;
+                }
+                if model_table.contains_key("image_tool_results") {
+                    merged.image_tool_results = model_layer.image_tool_results;
+                }
+                if model_table.contains_key("inline_video") {
+                    merged.inline_video = model_layer.inline_video;
+                }
+                if model_table.contains_key("supports_temperature") {
+                    merged.supports_temperature = model_layer.supports_temperature;
+                }
+                if model_table.contains_key("supports_thinking") {
+                    merged.supports_thinking = model_layer.supports_thinking;
+                }
+                if model_table.contains_key("supports_reasoning") {
+                    merged.supports_reasoning = model_layer.supports_reasoning;
+                }
+                if model_table.contains_key("call_timeout_secs") {
+                    merged.call_timeout_secs = model_layer.call_timeout_secs;
+                }
+                merged_models.insert(model_id.clone(), merged);
+            }
+            self.self_hosted.models = merged_models;
         }
     }
 
@@ -1817,21 +1914,16 @@ base_url = "http://127.0.0.1:11434"
 "#,
         )
         .expect("base self-hosted server");
-
-        let mut overlay = Config::default();
-        overlay
-            .merge_toml_str(
-                r#"
+        base.merge_toml_str(
+            r#"
 [self_hosted.models.gemma-4-e2b]
 server = "local"
 remote_model = "gemma4:e2b"
 display_name = "Gemma 4 E2B"
 family = "gemma-4"
 "#,
-            )
-            .expect("overlay self-hosted model");
-
-        base.merge(overlay);
+        )
+        .expect("overlay self-hosted model");
 
         assert!(base.self_hosted.servers.contains_key("local"));
         assert!(base.self_hosted.models.contains_key("gemma-4-e2b"));
@@ -1843,6 +1935,37 @@ family = "gemma-4"
                 .map(|server| server.server_id.as_str()),
             Some("local")
         );
+    }
+
+    #[test]
+    fn test_merge_self_hosted_partial_server_override_preserves_existing_fields() {
+        let mut config = Config::default();
+        config
+            .merge_toml_str(
+                r#"
+[self_hosted.servers.local]
+base_url = "http://127.0.0.1:11434"
+api_style = "responses"
+"#,
+            )
+            .expect("base server");
+        config
+            .merge_toml_str(
+                r#"
+[self_hosted.servers.local]
+bearer_token_env = "OLLAMA_TOKEN"
+"#,
+            )
+            .expect("overlay server");
+
+        let server = config
+            .self_hosted
+            .servers
+            .get("local")
+            .expect("merged server");
+        assert_eq!(server.base_url, "http://127.0.0.1:11434");
+        assert_eq!(server.api_style, SelfHostedApiStyle::Responses);
+        assert_eq!(server.bearer_token_env.as_deref(), Some("OLLAMA_TOKEN"));
     }
 
     #[test]

--- a/meerkat-core/src/config.rs
+++ b/meerkat-core/src/config.rs
@@ -860,6 +860,7 @@ pub struct ProviderSettings {
 #[serde(rename_all = "snake_case")]
 pub enum SelfHostedTransport {
     #[default]
+    #[serde(alias = "openai_compatible")]
     OpenAiCompatible,
 }
 
@@ -1937,6 +1938,31 @@ initial_delay = "750ms"
         assert_eq!(parsed.max_tokens, Some(100_000));
         assert_eq!(parsed.max_duration, Some(Duration::from_secs(300)));
         assert_eq!(parsed.max_tool_calls, Some(50));
+    }
+
+    #[test]
+    fn test_self_hosted_transport_accepts_openai_compatible_alias() {
+        let mut config = Config::default();
+        config
+            .merge_toml_str(
+                r#"
+[self_hosted.servers.ollama]
+transport = "openai_compatible"
+base_url = "http://127.0.0.1:11434"
+api_style = "chat_completions"
+"#,
+            )
+            .expect("alias should parse");
+
+        assert_eq!(
+            config
+                .self_hosted
+                .servers
+                .get("ollama")
+                .expect("server should exist")
+                .transport,
+            SelfHostedTransport::OpenAiCompatible
+        );
     }
 
     #[test]

--- a/meerkat-core/src/config.rs
+++ b/meerkat-core/src/config.rs
@@ -439,7 +439,7 @@ impl Config {
         };
 
         if let Some(servers) = self_hosted.get("servers").and_then(toml::Value::as_table) {
-            let mut merged_servers = BTreeMap::new();
+            let mut merged_servers = self.self_hosted.servers.clone();
             for (server_id, server_value) in servers {
                 let Some(server_table) = server_value.as_table() else {
                     continue;
@@ -474,7 +474,7 @@ impl Config {
         }
 
         if let Some(models) = self_hosted.get("models").and_then(toml::Value::as_table) {
-            let mut merged_models = BTreeMap::new();
+            let mut merged_models = self.self_hosted.models.clone();
             for (model_id, model_value) in models {
                 let Some(model_table) = model_value.as_table() else {
                     continue;
@@ -1966,6 +1966,55 @@ bearer_token_env = "OLLAMA_TOKEN"
         assert_eq!(server.base_url, "http://127.0.0.1:11434");
         assert_eq!(server.api_style, SelfHostedApiStyle::Responses);
         assert_eq!(server.bearer_token_env.as_deref(), Some("OLLAMA_TOKEN"));
+    }
+
+    #[test]
+    fn test_merge_self_hosted_partial_override_preserves_unrelated_inherited_entries() {
+        let mut config = Config::default();
+        config
+            .merge_toml_str(
+                r#"
+[self_hosted.servers.local]
+base_url = "http://127.0.0.1:11434"
+
+[self_hosted.servers.backup]
+base_url = "http://127.0.0.1:11435"
+
+[self_hosted.models.gemma-4-e2b]
+server = "local"
+remote_model = "gemma4:e2b"
+display_name = "Gemma 4 E2B"
+family = "gemma-4"
+
+[self_hosted.models.gemma-4-e4b]
+server = "backup"
+remote_model = "gemma4:e4b"
+display_name = "Gemma 4 E4B"
+family = "gemma-4"
+"#,
+            )
+            .expect("base self-hosted config");
+        config
+            .merge_toml_str(
+                r#"
+[self_hosted.servers.local]
+bearer_token_env = "OLLAMA_TOKEN"
+"#,
+            )
+            .expect("overlay self-hosted config");
+
+        assert!(config.self_hosted.servers.contains_key("backup"));
+        assert!(config.self_hosted.models.contains_key("gemma-4-e4b"));
+        let registry = config
+            .model_registry()
+            .expect("registry should remain valid");
+        assert_eq!(
+            registry
+                .entry("gemma-4-e4b")
+                .and_then(|entry| entry.self_hosted.as_ref())
+                .map(|server| server.server_id.as_str()),
+            Some("backup")
+        );
     }
 
     #[test]

--- a/meerkat-core/src/config.rs
+++ b/meerkat-core/src/config.rs
@@ -1011,6 +1011,16 @@ impl Default for SelfHostedServerConfig {
     }
 }
 
+impl SelfHostedServerConfig {
+    pub fn resolve_bearer_token(&self) -> Option<String> {
+        self.bearer_token.clone().or_else(|| {
+            self.bearer_token_env
+                .as_deref()
+                .and_then(|env_key| std::env::var(env_key).ok())
+        })
+    }
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, JsonSchema)]
 #[serde(default)]
 pub struct SelfHostedModelConfig {

--- a/meerkat-core/src/config.rs
+++ b/meerkat-core/src/config.rs
@@ -9,6 +9,7 @@ use crate::{
     retry::RetryPolicy,
     types::{OutputSchema, SecurityMode},
 };
+use meerkat_models::ModelTier;
 use schemars::JsonSchema;
 use serde::de::Deserializer;
 use serde::{Deserialize, Serialize};
@@ -41,6 +42,7 @@ pub struct Config {
     pub rest: RestServerConfig,
     pub hooks: HooksConfig,
     pub skills: crate::skills_config::SkillsConfig,
+    pub self_hosted: SelfHostedConfig,
 }
 
 impl Default for Config {
@@ -69,11 +71,17 @@ impl Default for Config {
             rest: RestServerConfig::default(),
             hooks: HooksConfig::default(),
             skills: crate::skills_config::SkillsConfig::default(),
+            self_hosted: SelfHostedConfig::default(),
         }
     }
 }
 
 impl Config {
+    /// Build the effective model registry for this config snapshot.
+    pub fn model_registry(&self) -> Result<crate::ModelRegistry, ConfigError> {
+        crate::ModelRegistry::from_config(self)
+    }
+
     /// Return the config template as TOML.
     pub fn template_toml() -> &'static str {
         CONFIG_TEMPLATE_TOML
@@ -318,6 +326,9 @@ impl Config {
                 self.hooks.background_max_concurrency = other.hooks.background_max_concurrency;
             }
             self.hooks.entries.extend(other.hooks.entries);
+        }
+        if other.self_hosted != SelfHostedConfig::default() {
+            self.self_hosted = other.self_hosted;
         }
     }
 
@@ -584,6 +595,8 @@ impl Config {
             }
         }
 
+        crate::model_registry::ModelRegistry::from_config(self)?;
+
         Ok(())
     }
 }
@@ -841,6 +854,95 @@ pub struct StoreConfig {
 pub struct ProviderSettings {
     pub base_urls: Option<HashMap<String, String>>,
     pub api_keys: Option<HashMap<String, String>>,
+}
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq, JsonSchema, Default)]
+#[serde(rename_all = "snake_case")]
+pub enum SelfHostedTransport {
+    #[default]
+    OpenAiCompatible,
+}
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq, JsonSchema, Default)]
+#[serde(rename_all = "snake_case")]
+pub enum SelfHostedApiStyle {
+    #[default]
+    Responses,
+    ChatCompletions,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, JsonSchema)]
+#[serde(default)]
+pub struct SelfHostedServerConfig {
+    pub transport: SelfHostedTransport,
+    pub base_url: String,
+    pub api_style: SelfHostedApiStyle,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub bearer_token: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub bearer_token_env: Option<String>,
+}
+
+impl Default for SelfHostedServerConfig {
+    fn default() -> Self {
+        Self {
+            transport: SelfHostedTransport::OpenAiCompatible,
+            base_url: String::new(),
+            api_style: SelfHostedApiStyle::Responses,
+            bearer_token: None,
+            bearer_token_env: None,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, JsonSchema)]
+#[serde(default)]
+pub struct SelfHostedModelConfig {
+    pub server: String,
+    pub remote_model: String,
+    pub display_name: String,
+    pub family: String,
+    pub tier: ModelTier,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub context_window: Option<u32>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub max_output_tokens: Option<u32>,
+    pub vision: bool,
+    pub image_tool_results: bool,
+    pub inline_video: bool,
+    pub supports_temperature: bool,
+    pub supports_thinking: bool,
+    pub supports_reasoning: bool,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub call_timeout_secs: Option<u64>,
+}
+
+impl Default for SelfHostedModelConfig {
+    fn default() -> Self {
+        Self {
+            server: String::new(),
+            remote_model: String::new(),
+            display_name: String::new(),
+            family: String::new(),
+            tier: ModelTier::Supported,
+            context_window: None,
+            max_output_tokens: None,
+            vision: false,
+            image_tool_results: false,
+            inline_video: false,
+            supports_temperature: true,
+            supports_thinking: false,
+            supports_reasoning: false,
+            call_timeout_secs: None,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Default, JsonSchema)]
+#[serde(default)]
+pub struct SelfHostedConfig {
+    pub servers: HashMap<String, SelfHostedServerConfig>,
+    pub models: HashMap<String, SelfHostedModelConfig>,
 }
 
 /// Runtime limits configured at the config layer.

--- a/meerkat-core/src/config.rs
+++ b/meerkat-core/src/config.rs
@@ -15,7 +15,7 @@ use serde::de::Deserializer;
 use serde::{Deserialize, Serialize};
 use serde_json::value::RawValue;
 use serde_json::{Map, Value};
-use std::collections::HashMap;
+use std::collections::{BTreeMap, HashMap};
 use std::path::PathBuf;
 use std::sync::OnceLock;
 use std::time::Duration;
@@ -328,7 +328,16 @@ impl Config {
             self.hooks.entries.extend(other.hooks.entries);
         }
         if other.self_hosted != SelfHostedConfig::default() {
-            self.self_hosted = other.self_hosted;
+            if !other.self_hosted.servers.is_empty() {
+                self.self_hosted
+                    .servers
+                    .extend(other.self_hosted.servers.clone());
+            }
+            if !other.self_hosted.models.is_empty() {
+                self.self_hosted
+                    .models
+                    .extend(other.self_hosted.models.clone());
+            }
         }
     }
 
@@ -867,8 +876,8 @@ pub enum SelfHostedTransport {
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq, JsonSchema, Default)]
 #[serde(rename_all = "snake_case")]
 pub enum SelfHostedApiStyle {
-    #[default]
     Responses,
+    #[default]
     ChatCompletions,
 }
 
@@ -889,7 +898,7 @@ impl Default for SelfHostedServerConfig {
         Self {
             transport: SelfHostedTransport::OpenAiCompatible,
             base_url: String::new(),
-            api_style: SelfHostedApiStyle::Responses,
+            api_style: SelfHostedApiStyle::ChatCompletions,
             bearer_token: None,
             bearer_token_env: None,
         }
@@ -942,8 +951,8 @@ impl Default for SelfHostedModelConfig {
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Default, JsonSchema)]
 #[serde(default)]
 pub struct SelfHostedConfig {
-    pub servers: HashMap<String, SelfHostedServerConfig>,
-    pub models: HashMap<String, SelfHostedModelConfig>,
+    pub servers: BTreeMap<String, SelfHostedServerConfig>,
+    pub models: BTreeMap<String, SelfHostedModelConfig>,
 }
 
 /// Runtime limits configured at the config layer.
@@ -1799,6 +1808,44 @@ model = "custom-model"
     }
 
     #[test]
+    fn test_merge_self_hosted_preserves_lower_layer_servers_and_models() {
+        let mut base = Config::default();
+        base.merge_toml_str(
+            r#"
+[self_hosted.servers.local]
+base_url = "http://127.0.0.1:11434"
+"#,
+        )
+        .expect("base self-hosted server");
+
+        let mut overlay = Config::default();
+        overlay
+            .merge_toml_str(
+                r#"
+[self_hosted.models.gemma-4-e2b]
+server = "local"
+remote_model = "gemma4:e2b"
+display_name = "Gemma 4 E2B"
+family = "gemma-4"
+"#,
+            )
+            .expect("overlay self-hosted model");
+
+        base.merge(overlay);
+
+        assert!(base.self_hosted.servers.contains_key("local"));
+        assert!(base.self_hosted.models.contains_key("gemma-4-e2b"));
+        let registry = base.model_registry().expect("merged self-hosted registry");
+        assert_eq!(
+            registry
+                .entry("gemma-4-e2b")
+                .and_then(|entry| entry.self_hosted.as_ref())
+                .map(|server| server.server_id.as_str()),
+            Some("local")
+        );
+    }
+
+    #[test]
     fn test_merge_providers_section_replaces_non_default() {
         let mut base = Config::default();
         base.providers.base_urls = Some(HashMap::from([
@@ -1962,6 +2009,14 @@ api_style = "chat_completions"
                 .expect("server should exist")
                 .transport,
             SelfHostedTransport::OpenAiCompatible
+        );
+    }
+
+    #[test]
+    fn test_self_hosted_server_config_defaults_to_chat_completions() {
+        assert_eq!(
+            SelfHostedServerConfig::default().api_style,
+            SelfHostedApiStyle::ChatCompletions
         );
     }
 

--- a/meerkat-core/src/lib.rs
+++ b/meerkat-core/src/lib.rs
@@ -40,6 +40,7 @@ pub mod lifecycle;
 pub mod mcp_config;
 pub mod memory;
 pub mod model_defaults;
+pub mod model_registry;
 pub mod ops;
 pub mod ops_lifecycle;
 pub mod peer_meta;
@@ -86,6 +87,7 @@ pub use compact::{
     SESSION_COMPACTION_CADENCE_KEY, SessionCompactionCadence,
 };
 pub use memory::{MemoryMetadata, MemoryResult, MemoryStore, MemoryStoreError};
+pub use model_registry::{ModelRegistry, ModelRegistryEntry, SelfHostedServerRef};
 pub use peer_meta::PeerMeta;
 
 pub use completion_feed::{
@@ -96,8 +98,9 @@ pub use config::{
     AgentConfig, BudgetConfig, CallTimeoutOverride, CommsAuthMode, CommsRuntimeConfig,
     CommsRuntimeMode, Config, ConfigDelta, ConfigError, ConfigScope, HookEntryConfig,
     HookRunOverrides, HookRuntimeConfig, HooksConfig, LimitsConfig, ModelDefaults,
-    PlainEventSource, ProviderConfig, ProviderSettings, RetryConfig, ShellDefaults, StorageConfig,
-    StoreConfig, ToolsConfig,
+    PlainEventSource, ProviderConfig, ProviderSettings, RetryConfig, SelfHostedApiStyle,
+    SelfHostedConfig, SelfHostedModelConfig, SelfHostedServerConfig, SelfHostedTransport,
+    ShellDefaults, StorageConfig, StoreConfig, ToolsConfig,
 };
 #[cfg(not(target_arch = "wasm32"))]
 pub use config_runtime::{

--- a/meerkat-core/src/model_registry.rs
+++ b/meerkat-core/src/model_registry.rs
@@ -214,6 +214,8 @@ pub fn normalize_base_url(base_url: &str) -> String {
 
 #[cfg(test)]
 mod tests {
+    #![allow(clippy::panic)]
+
     use super::*;
     use crate::config::{
         SelfHostedApiStyle, SelfHostedModelConfig, SelfHostedServerConfig, SelfHostedTransport,

--- a/meerkat-core/src/model_registry.rs
+++ b/meerkat-core/src/model_registry.rs
@@ -138,7 +138,7 @@ fn append_self_hosted(
         return Ok(());
     }
 
-    let default_model = config.models.keys().next().cloned().ok_or_else(|| {
+    let default_model = config.models.keys().min().cloned().ok_or_else(|| {
         ConfigError::InternalError("self-hosted models unexpectedly empty".to_string())
     })?;
     defaults.insert(Provider::SelfHosted, default_model);

--- a/meerkat-core/src/model_registry.rs
+++ b/meerkat-core/src/model_registry.rs
@@ -150,6 +150,12 @@ fn append_self_hosted(
                 model.server
             ))
         })?;
+        if server.bearer_token.is_some() {
+            tracing::warn!(
+                server_id = %model.server,
+                "self-hosted server uses a literal bearer_token; bearer_token_env is recommended to avoid storing secrets in config files"
+            );
+        }
 
         let self_hosted = SelfHostedServerRef {
             server_id: model.server.clone(),

--- a/meerkat-core/src/model_registry.rs
+++ b/meerkat-core/src/model_registry.rs
@@ -1,0 +1,362 @@
+//! Effective model registry merged from built-in catalog and configured self-hosted aliases.
+
+use crate::Provider;
+use crate::config::{
+    Config, ConfigError, SelfHostedApiStyle, SelfHostedConfig, SelfHostedTransport,
+};
+use meerkat_models::{ModelProfile, ModelTier};
+use std::collections::BTreeMap;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SelfHostedServerRef {
+    pub server_id: String,
+    pub remote_model: String,
+    pub transport: SelfHostedTransport,
+    pub api_style: SelfHostedApiStyle,
+    pub base_url: String,
+    pub bearer_token: Option<String>,
+    pub bearer_token_env: Option<String>,
+}
+
+impl SelfHostedServerRef {
+    pub fn resolve_bearer_token(&self) -> Option<String> {
+        self.bearer_token.clone().or_else(|| {
+            self.bearer_token_env
+                .as_deref()
+                .and_then(|env_key| std::env::var(env_key).ok())
+        })
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct ModelRegistryEntry {
+    pub id: String,
+    pub display_name: String,
+    pub provider: Provider,
+    pub tier: ModelTier,
+    pub context_window: Option<u32>,
+    pub max_output_tokens: Option<u32>,
+    pub profile: ModelProfile,
+    pub self_hosted: Option<SelfHostedServerRef>,
+}
+
+#[derive(Debug, Clone)]
+pub struct ModelRegistry {
+    entries: BTreeMap<String, ModelRegistryEntry>,
+    defaults: BTreeMap<Provider, String>,
+}
+
+impl ModelRegistry {
+    pub fn from_config(config: &Config) -> Result<Self, ConfigError> {
+        let mut entries = BTreeMap::new();
+        let mut defaults = BTreeMap::new();
+
+        for provider_name in meerkat_models::provider_names() {
+            let provider = Provider::parse_strict(provider_name).ok_or_else(|| {
+                ConfigError::InternalError(format!("unknown built-in provider '{provider_name}'"))
+            })?;
+            let default_model = meerkat_models::default_model(provider_name).ok_or_else(|| {
+                ConfigError::InternalError(format!(
+                    "missing built-in default for '{provider_name}'"
+                ))
+            })?;
+            defaults.insert(provider, default_model.to_string());
+
+            for entry in meerkat_models::catalog()
+                .iter()
+                .filter(|entry| entry.provider == *provider_name)
+            {
+                let profile =
+                    meerkat_models::profile_for(entry.provider, entry.id).ok_or_else(|| {
+                        ConfigError::InternalError(format!(
+                            "missing built-in profile for {}:{}",
+                            entry.provider, entry.id
+                        ))
+                    })?;
+                insert_unique(
+                    &mut entries,
+                    ModelRegistryEntry {
+                        id: entry.id.to_string(),
+                        display_name: entry.display_name.to_string(),
+                        provider,
+                        tier: entry.tier,
+                        context_window: entry.context_window,
+                        max_output_tokens: entry.max_output_tokens,
+                        profile,
+                        self_hosted: None,
+                    },
+                )?;
+            }
+        }
+
+        append_self_hosted(&mut entries, &mut defaults, &config.self_hosted)?;
+
+        Ok(Self { entries, defaults })
+    }
+
+    pub fn entry(&self, model_id: &str) -> Option<&ModelRegistryEntry> {
+        self.entries.get(model_id)
+    }
+
+    pub fn profile_for(&self, model_id: &str) -> Option<ModelProfile> {
+        self.entry(model_id)
+            .map(|entry| entry.profile.clone())
+            .or_else(|| inferred_builtin_profile(model_id))
+    }
+
+    pub fn default_model(&self, provider: Provider) -> Option<&str> {
+        self.defaults.get(&provider).map(String::as_str)
+    }
+
+    pub fn entries_for_provider(
+        &self,
+        provider: Provider,
+    ) -> impl Iterator<Item = &ModelRegistryEntry> {
+        self.entries
+            .values()
+            .filter(move |entry| entry.provider == provider)
+    }
+
+    pub fn provider_defaults(&self) -> impl Iterator<Item = (Provider, &str)> {
+        self.defaults
+            .iter()
+            .map(|(provider, default_model)| (*provider, default_model.as_str()))
+    }
+}
+
+fn inferred_builtin_profile(model_id: &str) -> Option<ModelProfile> {
+    let provider = Provider::infer_from_model(model_id)?;
+    meerkat_models::profile_for(provider.as_str(), model_id)
+}
+
+fn append_self_hosted(
+    entries: &mut BTreeMap<String, ModelRegistryEntry>,
+    defaults: &mut BTreeMap<Provider, String>,
+    config: &SelfHostedConfig,
+) -> Result<(), ConfigError> {
+    if config.models.is_empty() {
+        return Ok(());
+    }
+
+    let default_model = config.models.keys().next().cloned().ok_or_else(|| {
+        ConfigError::InternalError("self-hosted models unexpectedly empty".to_string())
+    })?;
+    defaults.insert(Provider::SelfHosted, default_model);
+
+    for (model_id, model) in &config.models {
+        let server = config.servers.get(&model.server).ok_or_else(|| {
+            ConfigError::Validation(format!(
+                "self_hosted.models.{model_id} references unknown server '{}'",
+                model.server
+            ))
+        })?;
+
+        let self_hosted = SelfHostedServerRef {
+            server_id: model.server.clone(),
+            remote_model: model.remote_model.clone(),
+            transport: server.transport,
+            api_style: server.api_style,
+            base_url: normalize_base_url(&server.base_url),
+            bearer_token: server.bearer_token.clone(),
+            bearer_token_env: server.bearer_token_env.clone(),
+        };
+        let profile = ModelProfile {
+            provider: Provider::SelfHosted.as_str().to_string(),
+            model_family: model.family.clone(),
+            supports_temperature: model.supports_temperature,
+            supports_thinking: model.supports_thinking,
+            supports_reasoning: model.supports_reasoning,
+            inline_video: model.inline_video,
+            vision: model.vision,
+            image_tool_results: model.image_tool_results,
+            params_schema: serde_json::json!({}),
+            call_timeout_secs: model.call_timeout_secs,
+        };
+
+        insert_unique(
+            entries,
+            ModelRegistryEntry {
+                id: model_id.clone(),
+                display_name: model.display_name.clone(),
+                provider: Provider::SelfHosted,
+                tier: model.tier,
+                context_window: model.context_window,
+                max_output_tokens: model.max_output_tokens,
+                profile,
+                self_hosted: Some(self_hosted),
+            },
+        )?;
+    }
+
+    Ok(())
+}
+
+fn insert_unique(
+    entries: &mut BTreeMap<String, ModelRegistryEntry>,
+    entry: ModelRegistryEntry,
+) -> Result<(), ConfigError> {
+    if entries.insert(entry.id.clone(), entry).is_some() {
+        return Err(ConfigError::Validation(
+            "model id must be unique across built-in and self-hosted entries".to_string(),
+        ));
+    }
+    Ok(())
+}
+
+pub fn normalize_base_url(base_url: &str) -> String {
+    let trimmed = base_url.trim_end_matches('/');
+    if trimmed.ends_with("/v1") {
+        trimmed.to_string()
+    } else {
+        format!("{trimmed}/v1")
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::config::{
+        SelfHostedApiStyle, SelfHostedModelConfig, SelfHostedServerConfig, SelfHostedTransport,
+    };
+
+    fn config_with_self_hosted() -> Config {
+        let mut config = Config::default();
+        config.self_hosted.servers.insert(
+            "local".to_string(),
+            SelfHostedServerConfig {
+                transport: SelfHostedTransport::OpenAiCompatible,
+                base_url: "http://127.0.0.1:11434".to_string(),
+                api_style: SelfHostedApiStyle::Responses,
+                bearer_token: None,
+                bearer_token_env: Some("LOCAL_TOKEN".to_string()),
+            },
+        );
+        config.self_hosted.models.insert(
+            "gemma-4-31b".to_string(),
+            SelfHostedModelConfig {
+                server: "local".to_string(),
+                remote_model: "gemma4:31b".to_string(),
+                display_name: "Gemma 4 31B".to_string(),
+                family: "gemma-4".to_string(),
+                tier: ModelTier::Supported,
+                context_window: Some(256_000),
+                max_output_tokens: Some(8_192),
+                vision: true,
+                image_tool_results: true,
+                inline_video: false,
+                supports_temperature: true,
+                supports_thinking: false,
+                supports_reasoning: false,
+                call_timeout_secs: Some(600),
+            },
+        );
+        config
+    }
+
+    #[test]
+    fn merges_self_hosted_models_into_registry() {
+        let config = config_with_self_hosted();
+        let registry = ModelRegistry::from_config(&config).expect("registry");
+        let entry = registry.entry("gemma-4-31b").expect("self-hosted entry");
+        assert_eq!(entry.provider, Provider::SelfHosted);
+        assert_eq!(entry.display_name, "Gemma 4 31B");
+        assert_eq!(
+            entry
+                .self_hosted
+                .as_ref()
+                .map(|server| server.server_id.as_str()),
+            Some("local")
+        );
+        assert_eq!(
+            entry
+                .self_hosted
+                .as_ref()
+                .map(|server| server.remote_model.as_str()),
+            Some("gemma4:31b")
+        );
+        assert_eq!(
+            entry
+                .self_hosted
+                .as_ref()
+                .map(|server| server.base_url.as_str()),
+            Some("http://127.0.0.1:11434/v1")
+        );
+        assert_eq!(
+            registry.default_model(Provider::SelfHosted),
+            Some("gemma-4-31b")
+        );
+    }
+
+    #[test]
+    fn rejects_unknown_server_reference() {
+        let mut config = Config::default();
+        config.self_hosted.models.insert(
+            "gemma-4-31b".to_string(),
+            SelfHostedModelConfig {
+                server: "missing".to_string(),
+                remote_model: "gemma4:31b".to_string(),
+                display_name: "Gemma 4 31B".to_string(),
+                family: "gemma-4".to_string(),
+                tier: ModelTier::Supported,
+                context_window: None,
+                max_output_tokens: None,
+                vision: true,
+                image_tool_results: true,
+                inline_video: false,
+                supports_temperature: true,
+                supports_thinking: false,
+                supports_reasoning: false,
+                call_timeout_secs: None,
+            },
+        );
+        let err = ModelRegistry::from_config(&config).expect_err("unknown server should fail");
+        assert!(err.to_string().contains("references unknown server"));
+    }
+
+    #[test]
+    fn rejects_duplicate_model_ids() {
+        let mut config = Config::default();
+        config.self_hosted.servers.insert(
+            "local".to_string(),
+            SelfHostedServerConfig {
+                transport: SelfHostedTransport::OpenAiCompatible,
+                base_url: "http://127.0.0.1:11434".to_string(),
+                api_style: SelfHostedApiStyle::Responses,
+                bearer_token: None,
+                bearer_token_env: None,
+            },
+        );
+        config.self_hosted.models.insert(
+            "gpt-5.4".to_string(),
+            SelfHostedModelConfig {
+                server: "local".to_string(),
+                remote_model: "override".to_string(),
+                display_name: "Override".to_string(),
+                family: "override".to_string(),
+                tier: ModelTier::Supported,
+                context_window: None,
+                max_output_tokens: None,
+                vision: false,
+                image_tool_results: false,
+                inline_video: false,
+                supports_temperature: true,
+                supports_thinking: false,
+                supports_reasoning: false,
+                call_timeout_secs: None,
+            },
+        );
+        let err = ModelRegistry::from_config(&config).expect_err("duplicate model id should fail");
+        assert!(err.to_string().contains("model id must be unique"));
+    }
+
+    #[test]
+    fn falls_back_to_inferred_builtin_profiles_for_non_catalog_models() {
+        let registry = ModelRegistry::from_config(&Config::default()).expect("registry");
+        let profile = registry
+            .profile_for("gpt-5.2")
+            .expect("gpt-5.2 should resolve via built-in provider inference");
+        assert_eq!(profile.provider, "openai");
+        assert!(profile.vision);
+        assert!(!profile.image_tool_results);
+    }
+}

--- a/meerkat-core/src/model_registry.rs
+++ b/meerkat-core/src/model_registry.rs
@@ -256,8 +256,14 @@ mod tests {
     #[test]
     fn merges_self_hosted_models_into_registry() {
         let config = config_with_self_hosted();
-        let registry = ModelRegistry::from_config(&config).expect("registry");
-        let entry = registry.entry("gemma-4-31b").expect("self-hosted entry");
+        let registry = match ModelRegistry::from_config(&config) {
+            Ok(registry) => registry,
+            Err(err) => panic!("registry construction failed: {err}"),
+        };
+        let entry = match registry.entry("gemma-4-31b") {
+            Some(entry) => entry,
+            None => panic!("missing self-hosted entry for gemma-4-31b"),
+        };
         assert_eq!(entry.provider, Provider::SelfHosted);
         assert_eq!(entry.display_name, "Gemma 4 31B");
         assert_eq!(
@@ -309,7 +315,10 @@ mod tests {
                 call_timeout_secs: None,
             },
         );
-        let err = ModelRegistry::from_config(&config).expect_err("unknown server should fail");
+        let err = match ModelRegistry::from_config(&config) {
+            Ok(_) => panic!("unknown server should fail"),
+            Err(err) => err,
+        };
         assert!(err.to_string().contains("references unknown server"));
     }
 
@@ -345,16 +354,23 @@ mod tests {
                 call_timeout_secs: None,
             },
         );
-        let err = ModelRegistry::from_config(&config).expect_err("duplicate model id should fail");
+        let err = match ModelRegistry::from_config(&config) {
+            Ok(_) => panic!("duplicate model id should fail"),
+            Err(err) => err,
+        };
         assert!(err.to_string().contains("model id must be unique"));
     }
 
     #[test]
     fn falls_back_to_inferred_builtin_profiles_for_non_catalog_models() {
-        let registry = ModelRegistry::from_config(&Config::default()).expect("registry");
-        let profile = registry
-            .profile_for("gpt-5.2")
-            .expect("gpt-5.2 should resolve via built-in provider inference");
+        let registry = match ModelRegistry::from_config(&Config::default()) {
+            Ok(registry) => registry,
+            Err(err) => panic!("registry construction failed: {err}"),
+        };
+        let profile = match registry.profile_for("gpt-5.2") {
+            Some(profile) => profile,
+            None => panic!("gpt-5.2 should resolve via built-in provider inference"),
+        };
         assert_eq!(profile.provider, "openai");
         assert!(profile.vision);
         assert!(!profile.image_tool_results);

--- a/meerkat-core/src/provider.rs
+++ b/meerkat-core/src/provider.rs
@@ -3,13 +3,14 @@
 use serde::{Deserialize, Serialize};
 
 /// Supported LLM providers.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
 #[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
 #[serde(rename_all = "snake_case")]
 pub enum Provider {
     Anthropic,
     OpenAI,
     Gemini,
+    SelfHosted,
     Other,
 }
 
@@ -20,6 +21,7 @@ impl Provider {
             "anthropic" => Self::Anthropic,
             "openai" => Self::OpenAI,
             "gemini" => Self::Gemini,
+            "self_hosted" => Self::SelfHosted,
             _ => Self::Other,
         }
     }
@@ -31,6 +33,7 @@ impl Provider {
             "anthropic" => Some(Self::Anthropic),
             "openai" => Some(Self::OpenAI),
             "gemini" => Some(Self::Gemini),
+            "self_hosted" => Some(Self::SelfHosted),
             _ => None,
         }
     }
@@ -64,11 +67,16 @@ impl Provider {
             Self::Anthropic => "anthropic",
             Self::OpenAI => "openai",
             Self::Gemini => "gemini",
+            Self::SelfHosted => "self_hosted",
             Self::Other => "other",
         }
     }
 
     /// All concrete (non-Other) providers.
-    pub const ALL_CONCRETE: &'static [Provider] =
-        &[Provider::Anthropic, Provider::OpenAI, Provider::Gemini];
+    pub const ALL_CONCRETE: &'static [Provider] = &[
+        Provider::Anthropic,
+        Provider::OpenAI,
+        Provider::Gemini,
+        Provider::SelfHosted,
+    ];
 }

--- a/meerkat-core/src/service/mod.rs
+++ b/meerkat-core/src/service/mod.rs
@@ -174,6 +174,7 @@ pub struct CreateSessionRequest {
 #[derive(Clone)]
 pub struct SessionBuildOptions {
     pub provider: Option<Provider>,
+    pub self_hosted_server_id: Option<String>,
     pub output_schema: Option<OutputSchema>,
     pub structured_output_retries: u32,
     pub hooks_override: HookRunOverrides,
@@ -596,6 +597,7 @@ impl Default for SessionBuildOptions {
     fn default() -> Self {
         Self {
             provider: None,
+            self_hosted_server_id: None,
             output_schema: None,
             structured_output_retries: 2,
             hooks_override: HookRunOverrides::default(),

--- a/meerkat-core/src/session.rs
+++ b/meerkat-core/src/session.rs
@@ -751,6 +751,8 @@ pub struct SessionMetadata {
     pub structured_output_retries: u32,
     pub provider: Provider,
     #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub self_hosted_server_id: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub provider_params: Option<serde_json::Value>,
     pub tooling: SessionTooling,
     #[serde(default)]
@@ -784,6 +786,8 @@ pub struct SessionLlmIdentity {
     pub model: String,
     pub provider: Provider,
     #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub self_hosted_server_id: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub provider_params: Option<serde_json::Value>,
 }
 
@@ -793,6 +797,7 @@ impl SessionMetadata {
         SessionLlmIdentity {
             model: self.model.clone(),
             provider: self.provider,
+            self_hosted_server_id: self.self_hosted_server_id.clone(),
             provider_params: self.provider_params.clone(),
         }
     }
@@ -801,6 +806,7 @@ impl SessionMetadata {
     pub fn apply_llm_identity(&mut self, identity: &SessionLlmIdentity) {
         self.model = identity.model.clone();
         self.provider = identity.provider;
+        self.self_hosted_server_id = identity.self_hosted_server_id.clone();
         self.provider_params = identity.provider_params.clone();
     }
 }

--- a/meerkat-core/src/session_recovery.rs
+++ b/meerkat-core/src/session_recovery.rs
@@ -177,6 +177,7 @@ pub fn build_recovered_session(
 
     let mut build = SessionBuildOptions {
         provider: Some(overrides.provider.unwrap_or(metadata.provider)),
+        self_hosted_server_id: metadata.self_hosted_server_id.clone(),
         output_schema: overrides
             .output_schema
             .clone()

--- a/meerkat-core/src/session_recovery.rs
+++ b/meerkat-core/src/session_recovery.rs
@@ -59,6 +59,13 @@ pub struct RecoveredSessionBuild {
     pub recoverable_tool_defs: Vec<ToolDef>,
 }
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ResumeLlmBinding {
+    pub provider: Option<Provider>,
+    pub self_hosted_server_id: Option<String>,
+    pub provider_overridden: bool,
+}
+
 impl RecoveredSessionBuild {
     pub fn into_deferred_create_request(self) -> CreateSessionRequest {
         CreateSessionRequest {
@@ -118,6 +125,32 @@ pub fn session_allows_first_turn_build_overrides(session: &Session) -> bool {
         .is_some_and(SessionDeferredTurnState::allows_initial_turn_overrides)
 }
 
+pub fn resolve_resume_llm_binding(
+    stored_provider: Provider,
+    stored_self_hosted_server_id: Option<String>,
+    model_override: Option<&str>,
+    provider_override: Option<Provider>,
+) -> ResumeLlmBinding {
+    let model_changed = model_override.is_some();
+    let provider_overridden = provider_override.is_some() || model_changed;
+    let provider = if model_changed && provider_override.is_none() {
+        None
+    } else {
+        Some(provider_override.unwrap_or(stored_provider))
+    };
+    let self_hosted_server_id = if model_changed {
+        None
+    } else {
+        stored_self_hosted_server_id
+    };
+
+    ResumeLlmBinding {
+        provider,
+        self_hosted_server_id,
+        provider_overridden,
+    }
+}
+
 pub fn build_recovered_session(
     session: Session,
     overrides: &SurfaceSessionRecoveryOverrides,
@@ -140,9 +173,15 @@ pub fn build_recovered_session(
     }
 
     let build_state = session.build_state().unwrap_or_default();
+    let llm_binding = resolve_resume_llm_binding(
+        metadata.provider,
+        metadata.self_hosted_server_id.clone(),
+        overrides.model.as_deref(),
+        overrides.provider,
+    );
     let resume_override_mask = ResumeOverrideMask {
         model: overrides.model.is_some(),
-        provider: overrides.provider.is_some(),
+        provider: llm_binding.provider_overridden,
         max_tokens: overrides.max_tokens.is_some(),
         structured_output_retries: overrides.structured_output_retries.is_some(),
         provider_params: overrides.provider_params.is_some(),
@@ -176,8 +215,8 @@ pub fn build_recovered_session(
         .unwrap_or_else(|| build_state.recoverable_tool_defs.clone());
 
     let mut build = SessionBuildOptions {
-        provider: Some(overrides.provider.unwrap_or(metadata.provider)),
-        self_hosted_server_id: metadata.self_hosted_server_id.clone(),
+        provider: llm_binding.provider,
+        self_hosted_server_id: llm_binding.self_hosted_server_id,
         output_schema: overrides
             .output_schema
             .clone()
@@ -603,6 +642,42 @@ mod tests {
         assert!(
             matches!(error, SurfaceSessionRecoveryError::InvalidOverride(_)),
             "provider-only override should be treated as InvalidOverride"
+        );
+    }
+
+    #[test]
+    fn build_recovered_session_model_override_clears_persisted_self_hosted_binding() {
+        let mut session = sample_session();
+        let mut metadata = session.session_metadata().expect("session metadata");
+        metadata.model = "gemma-4-e2b".to_string();
+        metadata.provider = Provider::SelfHosted;
+        metadata.self_hosted_server_id = Some("local".to_string());
+        session
+            .set_session_metadata(metadata)
+            .expect("updated session metadata");
+
+        let recovered = build_recovered_session(
+            session,
+            &SurfaceSessionRecoveryOverrides {
+                model: Some("gemma-4-31b".to_string()),
+                ..Default::default()
+            },
+            SurfaceSessionRecoveryContext::default(),
+        )
+        .expect("recovered session with model override");
+
+        assert_eq!(recovered.model, "gemma-4-31b");
+        assert_eq!(
+            recovered.build.provider, None,
+            "model-only overrides should recompute provider from the new model"
+        );
+        assert_eq!(
+            recovered.build.self_hosted_server_id, None,
+            "model-only overrides must clear the persisted self-hosted server binding"
+        );
+        assert!(
+            recovered.build.resume_override_mask.provider,
+            "model-only overrides must block stale provider restoration during resume"
         );
     }
 

--- a/meerkat-core/src/session_recovery.rs
+++ b/meerkat-core/src/session_recovery.rs
@@ -294,6 +294,7 @@ mod tests {
                 max_tokens: 4096,
                 structured_output_retries: 3,
                 provider: Provider::Anthropic,
+                self_hosted_server_id: None,
                 provider_params: Some(json!({ "temperature": 0.1 })),
                 tooling: SessionTooling {
                     builtins: ToolCategoryOverride::Disable,

--- a/meerkat-core/tests/rct_contracts.rs
+++ b/meerkat-core/tests/rct_contracts.rs
@@ -87,6 +87,7 @@ fn test_resume_metadata_contract() -> Result<(), Box<dyn std::error::Error>> {
         max_tokens: 1234,
         structured_output_retries: 2,
         provider: meerkat_core::Provider::Anthropic,
+        self_hosted_server_id: None,
         provider_params: None,
         tooling: meerkat_core::SessionTooling {
             builtins: meerkat_core::ToolCategoryOverride::Enable,
@@ -255,6 +256,7 @@ fn test_inv_003_resume_preserves_metadata() -> Result<(), Box<dyn std::error::Er
         max_tokens: 999,
         structured_output_retries: 2,
         provider: meerkat_core::Provider::OpenAI,
+        self_hosted_server_id: None,
         provider_params: None,
         tooling: meerkat_core::SessionTooling::default(),
         keep_alive: false,

--- a/meerkat-mcp-server/src/lib.rs
+++ b/meerkat-mcp-server/src/lib.rs
@@ -1619,7 +1619,8 @@ async fn handle_meerkat_models_catalog(state: &MeerkatMcpState) -> Result<Value,
         .await
         .map(|snapshot| snapshot.config)
         .unwrap_or_default();
-    let response = meerkat::surface::build_models_catalog_response(&config);
+    let response =
+        meerkat::surface::build_models_catalog_response(&config).map_err(|e| e.to_string())?;
     serde_json::to_value(&response).map_err(|e| format!("Serialization failed: {e}"))
 }
 

--- a/meerkat-mcp-server/src/lib.rs
+++ b/meerkat-mcp-server/src/lib.rs
@@ -1386,7 +1386,8 @@ pub async fn handle_tools_call_with_notifier(
             .await
             .map(wrap_tool_payload)
             .map_err(ToolCallError::internal),
-        "meerkat_models_catalog" => handle_meerkat_models_catalog()
+        "meerkat_models_catalog" => handle_meerkat_models_catalog(state)
+            .await
             .map(wrap_tool_payload)
             .map_err(ToolCallError::internal),
         "meerkat_skills" => {
@@ -1611,8 +1612,14 @@ async fn handle_meerkat_capabilities(state: &MeerkatMcpState) -> Result<Value, S
     serde_json::to_value(&response).map_err(|e| format!("Serialization failed: {e}"))
 }
 
-fn handle_meerkat_models_catalog() -> Result<Value, String> {
-    let response = meerkat::surface::build_models_catalog_response();
+async fn handle_meerkat_models_catalog(state: &MeerkatMcpState) -> Result<Value, String> {
+    let config = state
+        .config_runtime
+        .get()
+        .await
+        .map(|snapshot| snapshot.config)
+        .unwrap_or_default();
+    let response = meerkat::surface::build_models_catalog_response(&config);
     serde_json::to_value(&response).map_err(|e| format!("Serialization failed: {e}"))
 }
 

--- a/meerkat-mcp-server/src/lib.rs
+++ b/meerkat-mcp-server/src/lib.rs
@@ -2453,7 +2453,10 @@ async fn handle_meerkat_run(
         .await
         .map(|snapshot| snapshot.config)
         .unwrap_or_default();
-    let model = input.model.unwrap_or_else(|| config.agent.model.clone());
+    let model = input
+        .model
+        .clone()
+        .unwrap_or_else(|| config.agent.model.clone());
 
     // Build composed external tools:
     // - callback tools supplied by the MCP client
@@ -2527,9 +2530,20 @@ async fn handle_meerkat_run(
     });
 
     let current_generation = state.config_runtime.get().await.ok().map(|s| s.generation);
+    let llm_binding = meerkat_core::session_recovery::resolve_resume_llm_binding(
+        session
+            .session_metadata()
+            .map(|meta| meta.provider)
+            .unwrap_or(meerkat_core::Provider::Other),
+        session
+            .session_metadata()
+            .and_then(|meta| meta.self_hosted_server_id),
+        input.model.as_deref(),
+        input.provider.map(ProviderInput::to_provider),
+    );
     let mut build = SessionBuildOptions {
-        provider: input.provider.map(ProviderInput::to_provider),
-        self_hosted_server_id: None,
+        provider: llm_binding.provider,
+        self_hosted_server_id: llm_binding.self_hosted_server_id,
         output_schema,
         structured_output_retries: input
             .structured_output_retries
@@ -2566,7 +2580,7 @@ async fn handle_meerkat_run(
         additional_instructions: input.additional_instructions.clone(),
         shell_env: input.shell_env.clone(),
         resume_override_mask: ResumeOverrideMask {
-            provider: input.provider.is_some(),
+            provider: llm_binding.provider_overridden,
             max_tokens: input.max_tokens.is_some(),
             structured_output_retries: input.structured_output_retries.is_some(),
             provider_params: input.provider_params.is_some(),
@@ -2796,11 +2810,20 @@ async fn handle_meerkat_resume(
                 "failed to prepare bindings for session {session_id}: {e}"
             ))
         })?;
-    let mut build = SessionBuildOptions {
-        provider,
-        self_hosted_server_id: stored_metadata
+    let llm_binding = meerkat_core::session_recovery::resolve_resume_llm_binding(
+        stored_metadata
+            .as_ref()
+            .map(|m| m.provider)
+            .unwrap_or(meerkat_core::Provider::Other),
+        stored_metadata
             .as_ref()
             .and_then(|m| m.self_hosted_server_id.clone()),
+        input.model.as_deref(),
+        provider,
+    );
+    let mut build = SessionBuildOptions {
+        provider: llm_binding.provider,
+        self_hosted_server_id: llm_binding.self_hosted_server_id,
         output_schema,
         structured_output_retries: input
             .structured_output_retries
@@ -2847,7 +2870,7 @@ async fn handle_meerkat_resume(
         shell_env: None,
         resume_override_mask: ResumeOverrideMask {
             model: input.model.is_some(),
-            provider: input.provider.is_some(),
+            provider: llm_binding.provider_overridden,
             max_tokens: input.max_tokens.is_some(),
             structured_output_retries: input.structured_output_retries.is_some(),
             provider_params: input.provider_params.is_some(),

--- a/meerkat-mcp-server/src/lib.rs
+++ b/meerkat-mcp-server/src/lib.rs
@@ -2529,6 +2529,7 @@ async fn handle_meerkat_run(
     let current_generation = state.config_runtime.get().await.ok().map(|s| s.generation);
     let mut build = SessionBuildOptions {
         provider: input.provider.map(ProviderInput::to_provider),
+        self_hosted_server_id: None,
         output_schema,
         structured_output_retries: input
             .structured_output_retries
@@ -2797,6 +2798,9 @@ async fn handle_meerkat_resume(
         })?;
     let mut build = SessionBuildOptions {
         provider,
+        self_hosted_server_id: stored_metadata
+            .as_ref()
+            .and_then(|m| m.self_hosted_server_id.clone()),
         output_schema,
         structured_output_retries: input
             .structured_output_retries

--- a/meerkat-mcp-server/src/schedule_host.rs
+++ b/meerkat-mcp-server/src/schedule_host.rs
@@ -190,6 +190,7 @@ impl McpScheduleContext {
             .or(create.config_generation);
         let build = SessionBuildOptions {
             provider: create.provider,
+            self_hosted_server_id: None,
             output_schema,
             structured_output_retries: create.structured_output_retries,
             hooks_override: Default::default(),

--- a/meerkat-mob-mcp/src/lib.rs
+++ b/meerkat-mob-mcp/src/lib.rs
@@ -3238,6 +3238,7 @@ mod tests {
             max_tokens: 4096,
             structured_output_retries: 2,
             provider: Provider::Anthropic,
+            self_hosted_server_id: None,
             provider_params: None,
             tooling: SessionTooling {
                 comms: ToolCategoryOverride::Enable,
@@ -3272,6 +3273,7 @@ mod tests {
             max_tokens: 4096,
             structured_output_retries: 2,
             provider: Provider::Anthropic,
+            self_hosted_server_id: None,
             provider_params: None,
             tooling: SessionTooling {
                 comms: ToolCategoryOverride::Enable,
@@ -3311,6 +3313,7 @@ mod tests {
             max_tokens: 4096,
             structured_output_retries: 2,
             provider: Provider::Anthropic,
+            self_hosted_server_id: None,
             provider_params: None,
             tooling: SessionTooling {
                 comms: ToolCategoryOverride::Enable,

--- a/meerkat-mob/src/build.rs
+++ b/meerkat-mob/src/build.rs
@@ -685,6 +685,7 @@ mod tests {
                 max_tokens: 2048,
                 structured_output_retries: 2,
                 provider: meerkat_core::Provider::Anthropic,
+                self_hosted_server_id: None,
                 provider_params: None,
                 tooling: meerkat_core::session::SessionTooling {
                     builtins: meerkat_core::session::ToolCategoryOverride::Enable,

--- a/meerkat-mob/src/runtime/tests.rs
+++ b/meerkat-mob/src/runtime/tests.rs
@@ -864,6 +864,7 @@ impl SessionService for MockSessionService {
                 provider: build
                     .and_then(|b| b.provider)
                     .unwrap_or(Provider::Anthropic),
+                self_hosted_server_id: None,
                 provider_params: build.and_then(|b| b.provider_params.clone()),
                 tooling: SessionTooling {
                     builtins: build
@@ -6279,6 +6280,7 @@ async fn test_build_resumed_agent_config_rejects_mismatched_session_identity() {
             max_tokens: 4096,
             structured_output_retries: 2,
             provider: Provider::Anthropic,
+            self_hosted_server_id: None,
             provider_params: None,
             tooling: SessionTooling {
                 builtins: ToolCategoryOverride::Enable,

--- a/meerkat-rest/src/lib.rs
+++ b/meerkat-rest/src/lib.rs
@@ -2447,6 +2447,7 @@ async fn create_session_inner(
     let current_generation = state.config_runtime.get().await.ok().map(|s| s.generation);
     let mut build = SessionBuildOptions {
         provider: req.provider,
+        self_hosted_server_id: None,
         output_schema: req.output_schema,
         structured_output_retries: req
             .structured_output_retries
@@ -3190,6 +3191,9 @@ async fn continue_session_inner(
         };
         let mut build = SessionBuildOptions {
             provider: req.provider,
+            self_hosted_server_id: session
+                .session_metadata()
+                .and_then(|meta| meta.self_hosted_server_id),
             output_schema: req.output_schema,
             structured_output_retries: req
                 .structured_output_retries

--- a/meerkat-rest/src/lib.rs
+++ b/meerkat-rest/src/lib.rs
@@ -2061,9 +2061,11 @@ async fn get_capabilities(
 /// Get the effective model catalog for the current config.
 async fn get_models_catalog(
     State(state): State<AppState>,
-) -> Json<meerkat_contracts::ModelsCatalogResponse> {
+) -> Result<Json<meerkat_contracts::ModelsCatalogResponse>, ApiError> {
     let config = state.config_store.get().await.unwrap_or_default();
-    Json(meerkat::surface::build_models_catalog_response(&config))
+    let response = meerkat::surface::build_models_catalog_response(&config)
+        .map_err(|e| ApiError::Configuration(e.to_string()))?;
+    Ok(Json(response))
 }
 
 /// Get the current config

--- a/meerkat-rest/src/lib.rs
+++ b/meerkat-rest/src/lib.rs
@@ -2023,9 +2023,12 @@ async fn get_capabilities(
     Json(meerkat::surface::build_capabilities_response(&config))
 }
 
-/// Get the compiled-in model catalog.
-async fn get_models_catalog() -> Json<meerkat_contracts::ModelsCatalogResponse> {
-    Json(meerkat::surface::build_models_catalog_response())
+/// Get the effective model catalog for the current config.
+async fn get_models_catalog(
+    State(state): State<AppState>,
+) -> Json<meerkat_contracts::ModelsCatalogResponse> {
+    let config = state.config_store.get().await.unwrap_or_default();
+    Json(meerkat::surface::build_models_catalog_response(&config))
 }
 
 /// Get the current config
@@ -3404,6 +3407,7 @@ async fn continue_session_inner(
                     model: state.default_model.to_string(),
                     provider: meerkat_core::Provider::infer_from_model(&state.default_model)
                         .unwrap_or(meerkat_core::Provider::Other),
+                    self_hosted_server_id: None,
                     provider_params: None,
                 })
             });

--- a/meerkat-rest/src/lib.rs
+++ b/meerkat-rest/src/lib.rs
@@ -57,7 +57,8 @@ use meerkat_core::service::{
 use meerkat_core::{
     Config, ConfigDelta, ConfigEnvelope, ConfigEnvelopePolicy, ConfigStore, ContentInput,
     FileConfigStore, HookRunOverrides, PendingSystemContextAppend, Provider, RealmSelection,
-    RuntimeBootstrap, ToolCategoryOverride, agent_event_type, format_verbose_event,
+    RuntimeBootstrap, SessionLlmIdentity, ToolCategoryOverride, agent_event_type,
+    format_verbose_event,
 };
 use meerkat_runtime::SessionServiceRuntimeExt as _;
 use meerkat_store::{RealmBackend, RealmOrigin};
@@ -411,14 +412,40 @@ fn pending_system_context_appends(
         .collect()
 }
 
-fn provider_supports_inline_video(provider: meerkat_core::Provider) -> bool {
-    provider == meerkat_core::Provider::Gemini
-}
-
-fn validate_prompt_video_input(
-    prompt: &ContentInput,
+async fn resolve_validation_identity(
+    config_runtime: &meerkat_core::ConfigRuntime,
     model: &str,
     provider: Option<meerkat_core::Provider>,
+) -> SessionLlmIdentity {
+    let snapshot = config_runtime.get().await.ok().map(|state| state.config);
+    let registry = snapshot
+        .as_ref()
+        .and_then(|config| config.model_registry().ok());
+    let entry = registry.as_ref().and_then(|registry| registry.entry(model));
+    let provider = provider
+        .or_else(|| entry.map(|entry| entry.provider))
+        .or_else(|| meerkat_core::Provider::infer_from_model(model))
+        .unwrap_or(meerkat_core::Provider::Other);
+    let self_hosted_server_id = if provider == meerkat_core::Provider::SelfHosted {
+        entry
+            .and_then(|entry| entry.self_hosted.as_ref())
+            .map(|server| server.server_id.clone())
+    } else {
+        None
+    };
+
+    SessionLlmIdentity {
+        model: model.to_string(),
+        provider,
+        self_hosted_server_id,
+        provider_params: None,
+    }
+}
+
+async fn validate_prompt_video_input(
+    config_runtime: &meerkat_core::ConfigRuntime,
+    prompt: &ContentInput,
+    identity: &SessionLlmIdentity,
 ) -> Result<(), String> {
     let blocks = match prompt {
         ContentInput::Text(_) => return Ok(()),
@@ -427,16 +454,24 @@ fn validate_prompt_video_input(
 
     meerkat_core::validate_inline_video_blocks(blocks)?;
 
-    if meerkat_core::has_video(blocks) {
-        let effective_provider = provider
-            .or_else(|| meerkat_core::Provider::infer_from_model(model))
-            .unwrap_or(meerkat_core::Provider::Other);
-        if !provider_supports_inline_video(effective_provider) {
-            return Err(format!(
-                "inline video input requires a Gemini model; current provider is '{}'",
-                effective_provider.as_str()
-            ));
-        }
+    let supports_inline_video = config_runtime
+        .get()
+        .await
+        .ok()
+        .and_then(|state| state.config.model_registry().ok())
+        .and_then(|registry| {
+            registry
+                .profile_for(&identity.model)
+                .map(|profile| profile.inline_video)
+        })
+        .unwrap_or(false);
+
+    if meerkat_core::has_video(blocks) && !supports_inline_video {
+        return Err(format!(
+            "inline video input is not supported by model '{}' on provider '{}'",
+            identity.model,
+            identity.provider.as_str()
+        ));
     }
 
     Ok(())
@@ -521,7 +556,7 @@ async fn apply_runtime_turn(
         });
     if let Some(identity) = session_identity
         && let Err(message) =
-            validate_prompt_video_input(&prompt, &identity.model, Some(identity.provider))
+            validate_prompt_video_input(&context.config_runtime, &prompt, &identity).await
     {
         return Err(SessionError::Agent(meerkat_core::AgentError::ConfigError(
             message,
@@ -2522,7 +2557,11 @@ async fn create_session_inner(
         labels: req.labels,
     };
 
-    if let Err(err) = validate_prompt_video_input(&svc_req.prompt, &svc_req.model, create_provider)
+    let validation_identity =
+        resolve_validation_identity(&state.config_runtime, &svc_req.model, create_provider).await;
+    if let Err(err) =
+        validate_prompt_video_input(&state.config_runtime, &svc_req.prompt, &validation_identity)
+            .await
     {
         return RequestOutcome::Unpublished(Err(ApiError::BadRequest(err)));
     }
@@ -3189,11 +3228,20 @@ async fn continue_session_inner(
                 return RequestOutcome::Unpublished(Err(ApiError::Internal(message)));
             }
         };
-        let mut build = SessionBuildOptions {
-            provider: req.provider,
-            self_hosted_server_id: session
+        let llm_binding = meerkat_core::session_recovery::resolve_resume_llm_binding(
+            session
+                .session_metadata()
+                .map(|meta| meta.provider)
+                .unwrap_or(Provider::Other),
+            session
                 .session_metadata()
                 .and_then(|meta| meta.self_hosted_server_id),
+            req.model.as_deref(),
+            req.provider,
+        );
+        let mut build = SessionBuildOptions {
+            provider: llm_binding.provider,
+            self_hosted_server_id: llm_binding.self_hosted_server_id,
             output_schema: req.output_schema,
             structured_output_retries: req
                 .structured_output_retries
@@ -3231,7 +3279,7 @@ async fn continue_session_inner(
             shell_env: None,
             resume_override_mask: ResumeOverrideMask {
                 model: req.model.is_some(),
-                provider: req.provider.is_some(),
+                provider: llm_binding.provider_overridden,
                 max_tokens: req.max_tokens.is_some(),
                 structured_output_retries: req.structured_output_retries.is_some(),
                 keep_alive: keep_alive_override.is_some(),
@@ -3263,8 +3311,15 @@ async fn continue_session_inner(
             labels: None,
         };
         let create_provider = create_req.build.as_ref().and_then(|build| build.provider);
-        if let Err(err) =
-            validate_prompt_video_input(&create_req.prompt, &create_req.model, create_provider)
+        let validation_identity =
+            resolve_validation_identity(&state.config_runtime, &create_req.model, create_provider)
+                .await;
+        if let Err(err) = validate_prompt_video_input(
+            &state.config_runtime,
+            &create_req.prompt,
+            &validation_identity,
+        )
+        .await
         {
             drop(caller_event_tx);
             drain_event_forwarder(&session_id, forward_task).await;
@@ -3417,7 +3472,7 @@ async fn continue_session_inner(
             });
         if let Some(identity) = current_identity
             && let Err(err) =
-                validate_prompt_video_input(&turn_prompt, &identity.model, Some(identity.provider))
+                validate_prompt_video_input(&state.config_runtime, &turn_prompt, &identity).await
         {
             drop(caller_event_tx);
             drain_event_forwarder(&session_id, forward_task).await;
@@ -4013,10 +4068,14 @@ mod tests {
     use futures::stream;
     use meerkat::{OccurrenceFailureClass, OccurrencePhase, ScheduleId};
     use meerkat_client::{LlmDoneOutcome, LlmError, LlmEvent, LlmRequest};
-    use meerkat_core::SessionId;
+    use meerkat_core::{
+        MemoryConfigStore, SelfHostedApiStyle, SelfHostedServerConfig, SelfHostedTransport,
+        SessionId,
+    };
     use serde_json::json;
     use std::path::PathBuf;
     use std::pin::Pin;
+    use std::sync::Arc;
     use tempfile::TempDir;
 
     struct MockLlmClient;
@@ -4079,6 +4138,51 @@ mod tests {
             .expect("hook override fixture must deserialize")
     }
 
+    fn self_hosted_test_config(inline_video: bool) -> Config {
+        let mut config = Config::default();
+        config.self_hosted.servers.insert(
+            "local".to_string(),
+            SelfHostedServerConfig {
+                transport: SelfHostedTransport::OpenAiCompatible,
+                base_url: "http://127.0.0.1:11434".to_string(),
+                api_style: SelfHostedApiStyle::ChatCompletions,
+                bearer_token: None,
+                bearer_token_env: None,
+            },
+        );
+        config.self_hosted.models.insert(
+            "gemma-4-e2b".to_string(),
+            serde_json::from_value(json!({
+                "server": "local",
+                "remote_model": "gemma4:e2b",
+                "display_name": "Gemma 4 E2B",
+                "family": "gemma-4",
+                "tier": "supported",
+                "context_window": 128000,
+                "max_output_tokens": 8192,
+                "vision": true,
+                "image_tool_results": true,
+                "inline_video": inline_video,
+                "supports_temperature": true,
+                "supports_thinking": true,
+                "supports_reasoning": true,
+                "call_timeout_secs": 600
+            }))
+            .expect("self-hosted model config"),
+        );
+        config
+    }
+
+    fn inline_video_prompt() -> ContentInput {
+        ContentInput::Blocks(vec![meerkat_core::ContentBlock::Video {
+            media_type: "video/mp4".to_string(),
+            duration_ms: 1_000,
+            data: meerkat_core::VideoData::Inline {
+                data: "AAAA".to_string(),
+            },
+        }])
+    }
+
     #[tokio::test]
     async fn test_app_state_default() {
         let temp = TempDir::new().unwrap();
@@ -4088,6 +4192,22 @@ mod tests {
         assert!(!state.default_model.is_empty());
         assert!(state.max_tokens > 0);
         // runtime_adapter is always present (non-optional)
+    }
+
+    #[tokio::test]
+    async fn validate_prompt_video_input_accepts_self_hosted_alias_from_runtime_registry() {
+        let temp = TempDir::new().unwrap();
+        let store: Arc<dyn meerkat_core::ConfigStore> =
+            Arc::new(MemoryConfigStore::new(self_hosted_test_config(true)));
+        let config_runtime =
+            meerkat_core::ConfigRuntime::new(store, temp.path().join("config_state.json"));
+
+        let identity = resolve_validation_identity(&config_runtime, "gemma-4-e2b", None).await;
+        assert_eq!(identity.provider, Provider::SelfHosted);
+
+        validate_prompt_video_input(&config_runtime, &inline_video_prompt(), &identity)
+            .await
+            .expect("self-hosted aliases should validate inline video against the active registry");
     }
 
     #[test]

--- a/meerkat-rest/src/lib.rs
+++ b/meerkat-rest/src/lib.rs
@@ -2480,9 +2480,11 @@ async fn create_session_inner(
     }
 
     let current_generation = state.config_runtime.get().await.ok().map(|s| s.generation);
+    let initial_identity =
+        resolve_validation_identity(&state.config_runtime, &model, req.provider).await;
     let mut build = SessionBuildOptions {
         provider: req.provider,
-        self_hosted_server_id: None,
+        self_hosted_server_id: initial_identity.self_hosted_server_id.clone(),
         output_schema: req.output_schema,
         structured_output_retries: req
             .structured_output_retries
@@ -3458,21 +3460,15 @@ async fn continue_session_inner(
                 .await;
         }
 
+        let fallback_identity =
+            resolve_validation_identity(&state.config_runtime, &state.default_model, None).await;
         let current_identity = stored_metadata
             .as_ref()
             .map(meerkat::SessionMetadata::llm_identity)
-            .or_else(|| {
-                Some(meerkat_core::SessionLlmIdentity {
-                    model: state.default_model.to_string(),
-                    provider: meerkat_core::Provider::infer_from_model(&state.default_model)
-                        .unwrap_or(meerkat_core::Provider::Other),
-                    self_hosted_server_id: None,
-                    provider_params: None,
-                })
-            });
-        if let Some(identity) = current_identity
-            && let Err(err) =
-                validate_prompt_video_input(&state.config_runtime, &turn_prompt, &identity).await
+            .unwrap_or(fallback_identity);
+        if let Err(err) =
+            validate_prompt_video_input(&state.config_runtime, &turn_prompt, &current_identity)
+                .await
         {
             drop(caller_event_tx);
             drain_event_forwarder(&session_id, forward_task).await;

--- a/meerkat-rpc/src/handlers/models.rs
+++ b/meerkat-rpc/src/handlers/models.rs
@@ -2,10 +2,13 @@
 
 use meerkat_core::Config;
 
+use crate::error;
 use crate::protocol::{RpcId, RpcResponse};
 
 /// Handle `models/catalog` using the active config-backed model registry.
 pub fn handle_catalog(id: Option<RpcId>, config: &Config) -> RpcResponse {
-    let response = meerkat::surface::build_models_catalog_response(config);
-    RpcResponse::success(id, &response)
+    match meerkat::surface::build_models_catalog_response(config) {
+        Ok(response) => RpcResponse::success(id, &response),
+        Err(err) => RpcResponse::error(id, error::INVALID_PARAMS, err.to_string()),
+    }
 }

--- a/meerkat-rpc/src/handlers/models.rs
+++ b/meerkat-rpc/src/handlers/models.rs
@@ -1,9 +1,11 @@
 //! Handler for `models/catalog`.
 
+use meerkat_core::Config;
+
 use crate::protocol::{RpcId, RpcResponse};
 
-/// Handle `models/catalog` — returns the compiled-in model catalog.
-pub fn handle_catalog(id: Option<RpcId>) -> RpcResponse {
-    let response = meerkat::surface::build_models_catalog_response();
+/// Handle `models/catalog` using the active config-backed model registry.
+pub fn handle_catalog(id: Option<RpcId>, config: &Config) -> RpcResponse {
+    let response = meerkat::surface::build_models_catalog_response(config);
     RpcResponse::success(id, &response)
 }

--- a/meerkat-rpc/src/router.rs
+++ b/meerkat-rpc/src/router.rs
@@ -4532,11 +4532,10 @@ mod tests {
 
         tokio::time::timeout(std::time::Duration::from_secs(2), async {
             loop {
-                if recorded_requests
+                if !recorded_requests
                     .lock()
                     .expect("recorded requests lock poisoned")
-                    .len()
-                    >= 1
+                    .is_empty()
                 {
                     break;
                 }

--- a/meerkat-rpc/src/router.rs
+++ b/meerkat-rpc/src/router.rs
@@ -816,7 +816,10 @@ impl MethodRouter {
                 let config = self.config_store.get().await.unwrap_or_default();
                 handlers::capabilities::handle_get(id, &config)
             }
-            "models/catalog" => handlers::models::handle_catalog(id),
+            "models/catalog" => {
+                let config = self.config_store.get().await.unwrap_or_default();
+                handlers::models::handle_catalog(id, &config)
+            }
             "config/get" => {
                 handlers::config::handle_get(id, &self.config_store, self.runtime.config_runtime())
                     .await

--- a/meerkat-rpc/src/router.rs
+++ b/meerkat-rpc/src/router.rs
@@ -4508,6 +4508,10 @@ mod tests {
             .as_str()
             .unwrap()
             .to_string();
+        recorded_requests
+            .lock()
+            .expect("recorded requests lock poisoned")
+            .clear();
 
         let first_turn = {
             let router = router.clone();
@@ -4528,10 +4532,11 @@ mod tests {
 
         tokio::time::timeout(std::time::Duration::from_secs(2), async {
             loop {
-                if !recorded_requests
+                if recorded_requests
                     .lock()
                     .expect("recorded requests lock poisoned")
-                    .is_empty()
+                    .len()
+                    >= 1
                 {
                     break;
                 }

--- a/meerkat-rpc/src/session_runtime.rs
+++ b/meerkat-rpc/src/session_runtime.rs
@@ -269,7 +269,8 @@ impl SessionRuntime {
         };
         Ok(stored.updated_at() > live.updated_at()
             || (stored.updated_at() == live.updated_at()
-                && stored.messages().len() > live.messages().len()))
+                && stored.messages().len() > live.messages().len())
+            || stored_has_unapplied_system_context(&stored, &live))
     }
 
     /// Create a new session runtime.
@@ -481,12 +482,38 @@ impl SessionRuntime {
         SessionLlmIdentity {
             model: build_config.model.clone(),
             provider,
+            self_hosted_server_id: None,
             provider_params: build_config.provider_params.clone(),
         }
     }
 
+    async fn model_registry(&self) -> Result<meerkat_core::ModelRegistry, RpcError> {
+        let config = if let Some(runtime) = &self.config_runtime {
+            runtime
+                .get()
+                .await
+                .map(|snapshot| snapshot.config)
+                .map_err(|e| RpcError {
+                    code: error::INTERNAL_ERROR,
+                    message: format!("Failed to load config: {e}"),
+                    data: None,
+                })?
+        } else {
+            meerkat_core::Config::default()
+        };
+
+        config.model_registry().map_err(|e| RpcError {
+            code: error::INTERNAL_ERROR,
+            message: format!("Failed to resolve model registry: {e}"),
+            data: None,
+        })
+    }
+
     fn provider_supports_inline_video(identity: &SessionLlmIdentity) -> bool {
-        meerkat_models::profile::profile_for(identity.provider.as_str(), &identity.model)
+        meerkat_core::Config::default()
+            .model_registry()
+            .ok()
+            .and_then(|registry| registry.profile_for(&identity.model))
             .map(|profile| profile.inline_video)
             .unwrap_or(false)
     }
@@ -510,7 +537,8 @@ impl SessionRuntime {
             return Err(RpcError {
                 code: error::INVALID_PARAMS,
                 message: format!(
-                    "inline video input requires a Gemini model; current provider is '{}'",
+                    "inline video input is not supported by model '{}' on provider '{}'",
+                    identity.model,
                     identity.provider.as_str()
                 ),
                 data: None,
@@ -520,7 +548,8 @@ impl SessionRuntime {
         Ok(())
     }
 
-    fn resolve_target_llm_identity(
+    async fn resolve_target_llm_identity(
+        &self,
         current: &SessionLlmIdentity,
         ov: &crate::handlers::turn::TurnOverrides,
     ) -> Result<SessionLlmIdentity, RpcError> {
@@ -532,11 +561,16 @@ impl SessionRuntime {
             });
         }
 
+        let registry = self.model_registry().await?;
         let model = ov.model.clone().unwrap_or_else(|| current.model.clone());
         let provider = if let Some(provider_name) = ov.provider.as_ref() {
             meerkat_core::Provider::from_name(provider_name)
         } else if ov.model.is_some() {
-            meerkat_core::Provider::infer_from_model(&model).unwrap_or(current.provider)
+            registry
+                .entry(&model)
+                .map(|entry| entry.provider)
+                .or_else(|| meerkat_core::Provider::infer_from_model(&model))
+                .unwrap_or(current.provider)
         } else {
             current.provider
         };
@@ -544,10 +578,31 @@ impl SessionRuntime {
             .provider_params
             .clone()
             .or_else(|| current.provider_params.clone());
+        let self_hosted_server_id = if provider == meerkat_core::Provider::SelfHosted {
+            match registry.entry(&model) {
+                Some(entry) => entry
+                    .self_hosted
+                    .as_ref()
+                    .map(|server| server.server_id.clone()),
+                None if ov.model.is_none() => current.self_hosted_server_id.clone(),
+                None => {
+                    return Err(RpcError {
+                        code: error::INVALID_PARAMS,
+                        message: format!(
+                            "self-hosted provider requires a registered model alias; '{model}' is not configured"
+                        ),
+                        data: None,
+                    });
+                }
+            }
+        } else {
+            None
+        };
 
         Ok(SessionLlmIdentity {
             model,
             provider,
+            self_hosted_server_id,
             provider_params,
         })
     }
@@ -594,16 +649,25 @@ impl SessionRuntime {
         session_id: &SessionId,
         overrides: Option<&crate::handlers::turn::TurnOverrides>,
     ) -> Result<SessionLlmIdentity, RpcError> {
-        if let Some(pending) = self.pending.read().await.get(session_id) {
+        let pending_identity = {
+            let pending = self.pending.read().await;
+            pending
+                .get(session_id)
+                .map(|pending| pending.effective_llm_identity.clone())
+        };
+        if let Some(pending_identity) = pending_identity {
             return match overrides {
-                Some(ov) => Self::resolve_target_llm_identity(&pending.effective_llm_identity, ov),
-                None => Ok(pending.effective_llm_identity.clone()),
+                Some(ov) => {
+                    self.resolve_target_llm_identity(&pending_identity, ov)
+                        .await
+                }
+                None => Ok(pending_identity),
             };
         }
 
         let current = self.current_materialized_llm_identity(session_id).await?;
         match overrides {
-            Some(ov) => Self::resolve_target_llm_identity(&current, ov),
+            Some(ov) => self.resolve_target_llm_identity(&current, ov).await,
             None => Ok(current),
         }
     }
@@ -615,8 +679,21 @@ impl SessionRuntime {
         let raw_client = if let Some(ref default) = self.default_llm_client {
             Arc::clone(default)
         } else {
+            let config = if let Some(runtime) = &self.config_runtime {
+                runtime
+                    .get()
+                    .await
+                    .map(|snapshot| snapshot.config)
+                    .map_err(|e| RpcError {
+                        code: error::INTERNAL_ERROR,
+                        message: format!("Failed to load config for hot-swap: {e}"),
+                        data: None,
+                    })?
+            } else {
+                meerkat_core::Config::default()
+            };
             self.factory
-                .build_llm_client(identity.provider, None, None)
+                .build_llm_client_for_identity(&config, identity)
                 .await
                 .map_err(|e| RpcError {
                     code: error::INTERNAL_ERROR,
@@ -642,9 +719,11 @@ impl SessionRuntime {
         session_id: &SessionId,
         identity: &SessionLlmIdentity,
     ) {
-        let provider_str = identity.provider.as_str();
-        let Some(profile) = meerkat_models::profile::profile_for(provider_str, &identity.model)
-        else {
+        let registry = match self.model_registry().await {
+            Ok(registry) => registry,
+            Err(_) => return,
+        };
+        let Some(profile) = registry.profile_for(&identity.model) else {
             return;
         };
 
@@ -714,7 +793,9 @@ impl SessionRuntime {
         ov: &crate::handlers::turn::TurnOverrides,
     ) -> Result<(), RpcError> {
         let current_identity = self.current_materialized_llm_identity(session_id).await?;
-        let new_identity = Self::resolve_target_llm_identity(&current_identity, ov)?;
+        let new_identity = self
+            .resolve_target_llm_identity(&current_identity, ov)
+            .await?;
         let adapter = self.build_adapter_for_llm_identity(&new_identity).await?;
         self.service
             .hot_swap_session_llm_identity(session_id, adapter, new_identity.clone())
@@ -1276,10 +1357,12 @@ impl SessionRuntime {
                         data: None,
                     });
                 }
-                let resolved_identity = Self::resolve_target_llm_identity(
-                    &Self::llm_identity_from_pending_build(&build_config),
-                    ov,
-                )?;
+                let resolved_identity = self
+                    .resolve_target_llm_identity(
+                        &Self::llm_identity_from_pending_build(&build_config),
+                        ov,
+                    )
+                    .await?;
                 Self::apply_llm_identity_to_build_config(&mut build_config, &resolved_identity);
                 if let Some(max_tokens) = ov.max_tokens {
                     build_config.max_tokens = Some(max_tokens);
@@ -1808,10 +1891,12 @@ impl SessionRuntime {
                         data: None,
                     });
                 }
-                let resolved_identity = Self::resolve_target_llm_identity(
-                    &Self::llm_identity_from_pending_build(&build_config),
-                    ov,
-                )?;
+                let resolved_identity = self
+                    .resolve_target_llm_identity(
+                        &Self::llm_identity_from_pending_build(&build_config),
+                        ov,
+                    )
+                    .await?;
                 Self::apply_llm_identity_to_build_config(&mut build_config, &resolved_identity);
                 if let Some(max_tokens) = ov.max_tokens {
                     build_config.max_tokens = Some(max_tokens);
@@ -2975,6 +3060,15 @@ impl SessionRuntime {
         )
         .await;
     }
+}
+
+fn stored_has_unapplied_system_context(stored: &Session, live: &Session) -> bool {
+    let stored_state = stored.system_context_state().unwrap_or_default();
+    let live_state = live.system_context_state().unwrap_or_default();
+    stored_state
+        .pending
+        .iter()
+        .any(|pending| !live_state.pending.contains(pending))
 }
 
 // ---------------------------------------------------------------------------

--- a/meerkat-rpc/src/session_runtime.rs
+++ b/meerkat-rpc/src/session_runtime.rs
@@ -616,20 +616,28 @@ impl SessionRuntime {
             .clone()
             .or_else(|| current.provider_params.clone());
         let self_hosted_server_id = if provider == meerkat_core::Provider::SelfHosted {
-            match registry.entry(&model) {
-                Some(entry) => entry
-                    .self_hosted
-                    .as_ref()
-                    .map(|server| server.server_id.clone()),
-                None if ov.model.is_none() => current.self_hosted_server_id.clone(),
-                None => {
-                    return Err(RpcError {
-                        code: error::INVALID_PARAMS,
-                        message: format!(
-                            "self-hosted provider requires a registered model alias; '{model}' is not configured"
-                        ),
-                        data: None,
-                    });
+            if ov.model.is_none() {
+                current.self_hosted_server_id.clone().or_else(|| {
+                    registry
+                        .entry(&model)
+                        .and_then(|entry| entry.self_hosted.as_ref())
+                        .map(|server| server.server_id.clone())
+                })
+            } else {
+                match registry.entry(&model) {
+                    Some(entry) => entry
+                        .self_hosted
+                        .as_ref()
+                        .map(|server| server.server_id.clone()),
+                    None => {
+                        return Err(RpcError {
+                            code: error::INVALID_PARAMS,
+                            message: format!(
+                                "self-hosted provider requires a registered model alias; '{model}' is not configured"
+                            ),
+                            data: None,
+                        });
+                    }
                 }
             }
         } else {
@@ -3488,6 +3496,47 @@ mod tests {
                 .as_deref(),
             Some("local"),
             "pending sessions must remain pinned to the server selected at create time"
+        );
+    }
+
+    #[tokio::test]
+    async fn provider_param_override_keeps_pinned_self_hosted_server_binding() {
+        let temp = tempfile::tempdir().unwrap();
+        let mut runtime = make_runtime(temp_factory(&temp), 10);
+        let store: Arc<dyn meerkat_core::ConfigStore> = Arc::new(
+            meerkat_core::MemoryConfigStore::new(self_hosted_test_config("local", false)),
+        );
+        let config_runtime = Arc::new(meerkat_core::ConfigRuntime::new(
+            store,
+            temp.path().join("config_state.json"),
+        ));
+        runtime.set_config_runtime(config_runtime.clone());
+
+        config_runtime
+            .set(self_hosted_test_config("other", false), None)
+            .await
+            .expect("config patch");
+
+        let current = SessionLlmIdentity {
+            model: "gemma-4-e2b".to_string(),
+            provider: meerkat_core::Provider::SelfHosted,
+            self_hosted_server_id: Some("local".to_string()),
+            provider_params: None,
+        };
+        let overrides = crate::handlers::turn::TurnOverrides {
+            provider_params: Some(serde_json::json!({ "temperature": 0.2 })),
+            ..Default::default()
+        };
+
+        let resolved = runtime
+            .resolve_target_llm_identity(&current, &overrides)
+            .await
+            .expect("provider-param override should resolve");
+
+        assert_eq!(
+            resolved.self_hosted_server_id.as_deref(),
+            Some("local"),
+            "provider-param overrides must preserve the pinned self-hosted server binding"
         );
     }
 

--- a/meerkat-rpc/src/session_runtime.rs
+++ b/meerkat-rpc/src/session_runtime.rs
@@ -474,19 +474,6 @@ impl SessionRuntime {
         self.default_llm_client.clone()
     }
 
-    fn llm_identity_from_pending_build(build_config: &AgentBuildConfig) -> SessionLlmIdentity {
-        let provider = build_config
-            .provider
-            .or_else(|| meerkat_core::Provider::infer_from_model(&build_config.model))
-            .unwrap_or(meerkat_core::Provider::Other);
-        SessionLlmIdentity {
-            model: build_config.model.clone(),
-            provider,
-            self_hosted_server_id: None,
-            provider_params: build_config.provider_params.clone(),
-        }
-    }
-
     async fn model_registry(&self) -> Result<meerkat_core::ModelRegistry, RpcError> {
         let config = if let Some(runtime) = &self.config_runtime {
             runtime
@@ -509,16 +496,66 @@ impl SessionRuntime {
         })
     }
 
-    fn provider_supports_inline_video(identity: &SessionLlmIdentity) -> bool {
-        meerkat_core::Config::default()
-            .model_registry()
+    async fn llm_identity_from_pending_build(
+        &self,
+        build_config: &AgentBuildConfig,
+    ) -> Result<SessionLlmIdentity, RpcError> {
+        let registry = self.model_registry().await?;
+        let model = build_config.model.clone();
+        let provider = if let Some(provider) = build_config.provider {
+            provider
+        } else {
+            registry
+                .entry(&model)
+                .map(|entry| entry.provider)
+                .or_else(|| meerkat_core::Provider::infer_from_model(&model))
+                .unwrap_or(meerkat_core::Provider::Other)
+        };
+        let self_hosted_server_id = if provider == meerkat_core::Provider::SelfHosted {
+            if let Some(server_id) = build_config.self_hosted_server_id.clone() {
+                Some(server_id)
+            } else if let Some(metadata) = build_config
+                .resume_session
+                .as_ref()
+                .and_then(Session::session_metadata)
+            {
+                metadata.self_hosted_server_id
+            } else if let Some(entry) = registry.entry(&model) {
+                entry
+                    .self_hosted
+                    .as_ref()
+                    .map(|server| server.server_id.clone())
+            } else {
+                return Err(RpcError {
+                    code: error::INVALID_PARAMS,
+                    message: format!(
+                        "self-hosted provider requires a registered model alias; '{model}' is not configured"
+                    ),
+                    data: None,
+                });
+            }
+        } else {
+            None
+        };
+        Ok(SessionLlmIdentity {
+            model,
+            provider,
+            self_hosted_server_id,
+            provider_params: build_config.provider_params.clone(),
+        })
+    }
+
+    async fn provider_supports_inline_video(&self, identity: &SessionLlmIdentity) -> bool {
+        self.model_registry()
+            .await
             .ok()
             .and_then(|registry| registry.profile_for(&identity.model))
             .map(|profile| profile.inline_video)
             .unwrap_or(false)
     }
 
-    fn validate_prompt_video_input(
+    async fn validate_prompt_video_input(
+        &self,
         prompt: &ContentInput,
         identity: &SessionLlmIdentity,
     ) -> Result<(), RpcError> {
@@ -533,7 +570,7 @@ impl SessionRuntime {
             data: None,
         })?;
 
-        if meerkat_core::has_video(blocks) && !Self::provider_supports_inline_video(identity) {
+        if meerkat_core::has_video(blocks) && !self.provider_supports_inline_video(identity).await {
             return Err(RpcError {
                 code: error::INVALID_PARAMS,
                 message: format!(
@@ -613,6 +650,7 @@ impl SessionRuntime {
     ) {
         build_config.model = identity.model.clone();
         build_config.provider = Some(identity.provider);
+        build_config.self_hosted_server_id = identity.self_hosted_server_id.clone();
         build_config.provider_params = identity.provider_params.clone();
     }
 
@@ -1017,7 +1055,8 @@ impl SessionRuntime {
         let effective_identity = self
             .effective_llm_identity_for_turn(session_id, overrides.as_ref())
             .await?;
-        Self::validate_prompt_video_input(&prompt, &effective_identity)?;
+        self.validate_prompt_video_input(&prompt, &effective_identity)
+            .await?;
 
         if self.live_session_is_stale(session_id).await? {
             let _ = self.service.discard_live_session(session_id).await;
@@ -1228,7 +1267,8 @@ impl SessionRuntime {
         let effective_identity = self
             .effective_llm_identity_for_turn(session_id, overrides.as_ref())
             .await?;
-        Self::validate_prompt_video_input(&prompt, &effective_identity)?;
+        self.validate_prompt_video_input(&prompt, &effective_identity)
+            .await?;
 
         let pending_session = {
             let mut pending = self.pending.write().await;
@@ -1359,7 +1399,7 @@ impl SessionRuntime {
                 }
                 let resolved_identity = self
                     .resolve_target_llm_identity(
-                        &Self::llm_identity_from_pending_build(&build_config),
+                        &self.llm_identity_from_pending_build(&build_config).await?,
                         ov,
                     )
                     .await?;
@@ -1555,6 +1595,9 @@ impl SessionRuntime {
             })?;
         let mut build = SessionBuildOptions {
             provider: stored_metadata.as_ref().map(|meta| meta.provider),
+            self_hosted_server_id: stored_metadata
+                .as_ref()
+                .and_then(|meta| meta.self_hosted_server_id.clone()),
             output_schema: None,
             structured_output_retries: 2,
             hooks_override: HookRunOverrides::default(),
@@ -1706,13 +1749,15 @@ impl SessionRuntime {
     /// and will be materialized inside the service on the first `start_turn`.
     pub async fn create_session(
         &self,
-        build_config: AgentBuildConfig,
+        mut build_config: AgentBuildConfig,
         labels: Option<BTreeMap<String, String>>,
         deferred_prompt: Option<ContentInput>,
     ) -> Result<SessionId, RpcError> {
-        let effective_llm_identity = Self::llm_identity_from_pending_build(&build_config);
+        let effective_llm_identity = self.llm_identity_from_pending_build(&build_config).await?;
+        build_config.self_hosted_server_id = effective_llm_identity.self_hosted_server_id.clone();
         if let Some(prompt) = deferred_prompt.as_ref() {
-            Self::validate_prompt_video_input(prompt, &effective_llm_identity)?;
+            self.validate_prompt_video_input(prompt, &effective_llm_identity)
+                .await?;
         }
 
         // Check combined capacity (pending + active).
@@ -1893,7 +1938,7 @@ impl SessionRuntime {
                 }
                 let resolved_identity = self
                     .resolve_target_llm_identity(
-                        &Self::llm_identity_from_pending_build(&build_config),
+                        &self.llm_identity_from_pending_build(&build_config).await?,
                         ov,
                     )
                     .await?;
@@ -2007,7 +2052,7 @@ impl SessionRuntime {
                                 data: None,
                             })?;
                         let effective_llm_identity =
-                            Self::llm_identity_from_pending_build(&build_config);
+                            self.llm_identity_from_pending_build(&build_config).await?;
                         let mut pending = self.pending.write().await;
                         pending.insert(
                             session_id.clone(),
@@ -2144,13 +2189,17 @@ impl SessionRuntime {
     async fn restore_pending_from_promoting(
         &self,
         session_id: &SessionId,
-        build_config: AgentBuildConfig,
+        mut build_config: AgentBuildConfig,
         labels: Option<BTreeMap<String, String>>,
         deferred_prompt: Option<ContentInput>,
         created_at_secs: u64,
         updated_at_secs: u64,
     ) {
-        let effective_llm_identity = Self::llm_identity_from_pending_build(&build_config);
+        let Ok(effective_llm_identity) = self.llm_identity_from_pending_build(&build_config).await
+        else {
+            return;
+        };
+        build_config.self_hosted_server_id = effective_llm_identity.self_hosted_server_id.clone();
         let mut pending = self.pending.write().await;
         pending.insert(
             session_id.clone(),
@@ -2222,6 +2271,7 @@ impl SessionRuntime {
 
         if let Some(ref meta) = stored_metadata {
             build_config.provider = Some(meta.provider);
+            build_config.self_hosted_server_id = meta.self_hosted_server_id.clone();
             build_config.provider_params = meta.provider_params.clone();
             build_config.max_tokens = Some(meta.max_tokens);
             build_config.keep_alive = meta.keep_alive;
@@ -2270,7 +2320,8 @@ impl SessionRuntime {
         let labels: Option<BTreeMap<String, String>> = None;
 
         {
-            let effective_llm_identity = Self::llm_identity_from_pending_build(&build_config);
+            let effective_llm_identity =
+                self.llm_identity_from_pending_build(&build_config).await?;
             let mut pending = self.pending.write().await;
             pending.insert(
                 session_id.clone(),
@@ -3294,6 +3345,53 @@ mod tests {
         )
     }
 
+    fn self_hosted_test_config(server: &str, inline_video: bool) -> Config {
+        let mut config = Config::default();
+        config.self_hosted.servers.insert(
+            server.to_string(),
+            meerkat_core::SelfHostedServerConfig {
+                transport: meerkat_core::SelfHostedTransport::OpenAiCompatible,
+                base_url: format!(
+                    "http://127.0.0.1:{}",
+                    if server == "local" { 11434 } else { 22434 }
+                ),
+                api_style: meerkat_core::SelfHostedApiStyle::ChatCompletions,
+                bearer_token: None,
+                bearer_token_env: None,
+            },
+        );
+        config.self_hosted.models.insert(
+            "gemma-4-e2b".to_string(),
+            meerkat_core::SelfHostedModelConfig {
+                server: server.to_string(),
+                remote_model: "gemma4:e2b".to_string(),
+                display_name: "Gemma 4 E2B".to_string(),
+                family: "gemma-4".to_string(),
+                tier: meerkat_models::ModelTier::Supported,
+                context_window: Some(128_000),
+                max_output_tokens: Some(8_192),
+                vision: true,
+                image_tool_results: true,
+                inline_video,
+                supports_temperature: true,
+                supports_thinking: true,
+                supports_reasoning: true,
+                call_timeout_secs: Some(600),
+            },
+        );
+        config
+    }
+
+    fn inline_video_prompt() -> ContentInput {
+        ContentInput::Blocks(vec![meerkat_core::ContentBlock::Video {
+            media_type: "video/mp4".to_string(),
+            duration_ms: 1000,
+            data: meerkat_core::VideoData::Inline {
+                data: "AAAA".to_string(),
+            },
+        }])
+    }
+
     #[cfg(feature = "mcp")]
     fn mcp_test_server_path() -> PathBuf {
         let manifest_dir = std::env::var("CARGO_MANIFEST_DIR").expect("CARGO_MANIFEST_DIR");
@@ -3322,6 +3420,75 @@ mod tests {
             "env": {},
             "name": server_name,
         }))
+    }
+
+    #[tokio::test]
+    async fn create_session_accepts_video_for_self_hosted_alias_from_runtime_config() {
+        let temp = tempfile::tempdir().unwrap();
+        let mut runtime = make_runtime(temp_factory(&temp), 10);
+        let store: Arc<dyn meerkat_core::ConfigStore> = Arc::new(
+            meerkat_core::MemoryConfigStore::new(self_hosted_test_config("local", true)),
+        );
+        runtime.set_config_runtime(Arc::new(meerkat_core::ConfigRuntime::new(
+            store,
+            temp.path().join("config_state.json"),
+        )));
+
+        let session_id = runtime
+            .create_session(
+                AgentBuildConfig {
+                    llm_client_override: Some(Arc::new(MockLlmClient)),
+                    ..AgentBuildConfig::new("gemma-4-e2b")
+                },
+                None,
+                Some(inline_video_prompt()),
+            )
+            .await
+            .expect("self-hosted inline-video alias should validate against runtime registry");
+
+        assert!(runtime.pending_session_exists(&session_id).await);
+    }
+
+    #[tokio::test]
+    async fn create_session_pins_self_hosted_server_id_before_materialization() {
+        let temp = tempfile::tempdir().unwrap();
+        let mut runtime = make_runtime(temp_factory(&temp), 10);
+        let store: Arc<dyn meerkat_core::ConfigStore> = Arc::new(
+            meerkat_core::MemoryConfigStore::new(self_hosted_test_config("local", false)),
+        );
+        let config_runtime = Arc::new(meerkat_core::ConfigRuntime::new(
+            store,
+            temp.path().join("config_state.json"),
+        ));
+        runtime.set_config_runtime(config_runtime.clone());
+
+        let session_id = runtime
+            .create_session(
+                AgentBuildConfig {
+                    llm_client_override: Some(Arc::new(MockLlmClient)),
+                    ..AgentBuildConfig::new("gemma-4-e2b")
+                },
+                None,
+                None,
+            )
+            .await
+            .expect("pending self-hosted session should stage");
+
+        config_runtime
+            .set(self_hosted_test_config("other", false), None)
+            .await
+            .expect("config patch");
+
+        let pending = runtime.pending.read().await;
+        let staged = pending.get(&session_id).expect("pending session");
+        assert_eq!(
+            staged
+                .effective_llm_identity
+                .self_hosted_server_id
+                .as_deref(),
+            Some("local"),
+            "pending sessions must remain pinned to the server selected at create time"
+        );
     }
 
     #[cfg(feature = "mcp")]

--- a/meerkat-session/src/ephemeral.rs
+++ b/meerkat-session/src/ephemeral.rs
@@ -23,8 +23,9 @@ use meerkat_core::service::{
 use meerkat_core::time_compat::SystemTime;
 use meerkat_core::types::{ContentInput, RunResult, SessionId, ToolResult, Usage};
 use meerkat_core::{
-    InputId, PendingDeferredPrompt, PendingSystemContextAppend, PendingToolResultsMessage, RunId,
-    SessionDeferredTurnState, SessionLlmIdentity, SessionSystemContextState,
+    AppendSystemContextStatus, InputId, PendingDeferredPrompt, PendingSystemContextAppend,
+    PendingToolResultsMessage, RunId, SessionDeferredTurnState, SessionLlmIdentity,
+    SessionSystemContextState,
 };
 use sha2::{Digest, Sha256};
 use std::collections::BTreeMap;
@@ -102,6 +103,13 @@ enum SessionCommand {
     StageToolFilter {
         filter: meerkat_core::ToolFilter,
         reply_tx: oneshot::Sender<Result<(), meerkat_core::error::AgentError>>,
+    },
+    StageSystemContextAppend {
+        req: AppendSystemContextRequest,
+        accepted_at: SystemTime,
+    },
+    SyncSystemContextState {
+        reply_tx: oneshot::Sender<()>,
     },
     /// Export the full session (messages + metadata) for persistence.
     ExportSession {
@@ -351,6 +359,32 @@ pub trait SessionAgent: Send {
         &self,
     ) -> Arc<std::sync::Mutex<meerkat_core::SessionSystemContextState>>;
 
+    /// Synchronize the shared system-context control state into the canonical session metadata.
+    fn sync_system_context_state(&mut self) {}
+
+    /// Stage one system-context append against the shared control state.
+    fn stage_system_context_append(
+        &mut self,
+        req: &AppendSystemContextRequest,
+        accepted_at: SystemTime,
+    ) -> Result<AppendSystemContextStatus, meerkat_core::SystemContextStageError> {
+        let status = {
+            let state = self.system_context_state();
+            let mut guard = match state.lock() {
+                Ok(guard) => guard,
+                Err(poisoned) => {
+                    tracing::warn!(
+                        "system-context state lock poisoned while applying queued append"
+                    );
+                    poisoned.into_inner()
+                }
+            };
+            guard.stage_append(req, accepted_at)?
+        };
+        self.sync_system_context_state();
+        Ok(status)
+    }
+
     /// Get an event injector for pushing external events.
     ///
     /// Called once before the agent moves into its dedicated task. The returned
@@ -513,6 +547,7 @@ impl<B: SessionAgentBuilder + 'static> EphemeralSessionService<B> {
         SessionLlmIdentity {
             model: req.model.clone(),
             provider,
+            self_hosted_server_id: None,
             provider_params,
         }
     }
@@ -650,6 +685,52 @@ impl<B: SessionAgentBuilder + 'static> EphemeralSessionService<B> {
         reply_rx.await.map_err(|_| {
             SessionError::Agent(meerkat_core::error::AgentError::InternalError(
                 "Session task dropped the reply channel".to_string(),
+            ))
+        })
+    }
+
+    pub(crate) async fn enqueue_system_context_append(
+        &self,
+        id: &SessionId,
+        req: AppendSystemContextRequest,
+        accepted_at: SystemTime,
+    ) -> Result<(), SessionError> {
+        let sessions = self.sessions.read().await;
+        let handle = sessions
+            .get(id)
+            .ok_or_else(|| SessionError::NotFound { id: id.clone() })?;
+        handle
+            .command_tx
+            .send(SessionCommand::StageSystemContextAppend { req, accepted_at })
+            .await
+            .map_err(|_| {
+                SessionError::Agent(meerkat_core::error::AgentError::InternalError(
+                    "Session task has exited".to_string(),
+                ))
+            })
+    }
+
+    pub(crate) async fn sync_system_context_state(
+        &self,
+        id: &SessionId,
+    ) -> Result<(), SessionError> {
+        let sessions = self.sessions.read().await;
+        let handle = sessions
+            .get(id)
+            .ok_or_else(|| SessionError::NotFound { id: id.clone() })?;
+        let (reply_tx, reply_rx) = oneshot::channel();
+        handle
+            .command_tx
+            .send(SessionCommand::SyncSystemContextState { reply_tx })
+            .await
+            .map_err(|_| {
+                SessionError::Agent(meerkat_core::error::AgentError::InternalError(
+                    "Session task has exited".to_string(),
+                ))
+            })?;
+        reply_rx.await.map_err(|_| {
+            SessionError::Agent(meerkat_core::error::AgentError::InternalError(
+                "Session task dropped reply channel".to_string(),
             ))
         })
     }
@@ -1531,6 +1612,10 @@ impl<B: SessionAgentBuilder + 'static> SessionServiceControlExt for EphemeralSes
                 .map_err(|err| err.into_control_error(id))?
         };
 
+        self.sync_system_context_state(id)
+            .await
+            .map_err(SessionControlError::Session)?;
+
         Ok(AppendSystemContextResult { status })
     }
 
@@ -1804,6 +1889,15 @@ async fn session_task<A: SessionAgent>(
             }
             SessionCommand::StageToolFilter { filter, reply_tx } => {
                 let _ = reply_tx.send(agent.stage_external_tool_filter(filter));
+                continue;
+            }
+            SessionCommand::StageSystemContextAppend { req, accepted_at } => {
+                let _ = agent.stage_system_context_append(&req, accepted_at);
+                continue;
+            }
+            SessionCommand::SyncSystemContextState { reply_tx } => {
+                agent.sync_system_context_state();
+                let _ = reply_tx.send(());
                 continue;
             }
             SessionCommand::StartTurn {

--- a/meerkat-session/src/ephemeral.rs
+++ b/meerkat-session/src/ephemeral.rs
@@ -23,9 +23,8 @@ use meerkat_core::service::{
 use meerkat_core::time_compat::SystemTime;
 use meerkat_core::types::{ContentInput, RunResult, SessionId, ToolResult, Usage};
 use meerkat_core::{
-    AppendSystemContextStatus, InputId, PendingDeferredPrompt, PendingSystemContextAppend,
-    PendingToolResultsMessage, RunId, SessionDeferredTurnState, SessionLlmIdentity,
-    SessionSystemContextState,
+    InputId, PendingDeferredPrompt, PendingSystemContextAppend, PendingToolResultsMessage, RunId,
+    SessionDeferredTurnState, SessionLlmIdentity, SessionSystemContextState,
 };
 use sha2::{Digest, Sha256};
 use std::collections::BTreeMap;
@@ -103,10 +102,6 @@ enum SessionCommand {
     StageToolFilter {
         filter: meerkat_core::ToolFilter,
         reply_tx: oneshot::Sender<Result<(), meerkat_core::error::AgentError>>,
-    },
-    StageSystemContextAppend {
-        req: AppendSystemContextRequest,
-        accepted_at: SystemTime,
     },
     SyncSystemContextState {
         reply_tx: oneshot::Sender<()>,
@@ -362,29 +357,6 @@ pub trait SessionAgent: Send {
     /// Synchronize the shared system-context control state into the canonical session metadata.
     fn sync_system_context_state(&mut self) {}
 
-    /// Stage one system-context append against the shared control state.
-    fn stage_system_context_append(
-        &mut self,
-        req: &AppendSystemContextRequest,
-        accepted_at: SystemTime,
-    ) -> Result<AppendSystemContextStatus, meerkat_core::SystemContextStageError> {
-        let status = {
-            let state = self.system_context_state();
-            let mut guard = match state.lock() {
-                Ok(guard) => guard,
-                Err(poisoned) => {
-                    tracing::warn!(
-                        "system-context state lock poisoned while applying queued append"
-                    );
-                    poisoned.into_inner()
-                }
-            };
-            guard.stage_append(req, accepted_at)?
-        };
-        self.sync_system_context_state();
-        Ok(status)
-    }
-
     /// Get an event injector for pushing external events.
     ///
     /// Called once before the agent moves into its dedicated task. The returned
@@ -594,7 +566,7 @@ impl<B: SessionAgentBuilder + 'static> EphemeralSessionService<B> {
         &self,
         id: &SessionId,
     ) -> Result<meerkat_core::Session, SessionError> {
-        let (command_tx, deferred_turn_state) = {
+        let (command_tx, deferred_turn_state, system_context_state) = {
             let sessions = self.sessions.read().await;
             let handle = sessions
                 .get(id)
@@ -602,6 +574,7 @@ impl<B: SessionAgentBuilder + 'static> EphemeralSessionService<B> {
             (
                 handle.command_tx.clone(),
                 Arc::clone(&handle.deferred_turn_state),
+                Arc::clone(&handle.system_context_state),
             )
         };
 
@@ -627,6 +600,21 @@ impl<B: SessionAgentBuilder + 'static> EphemeralSessionService<B> {
                 "failed to serialize deferred-turn state: {err}"
             )))
         })?;
+
+        let system_context = match system_context_state.lock() {
+            Ok(guard) => guard.clone(),
+            Err(poisoned) => {
+                tracing::warn!("system-context state lock poisoned while exporting session");
+                poisoned.into_inner().clone()
+            }
+        };
+        session
+            .set_system_context_state(system_context)
+            .map_err(|err| {
+                SessionError::Agent(meerkat_core::error::AgentError::InternalError(format!(
+                    "failed to serialize system-context state: {err}"
+                )))
+            })?;
 
         Ok(session)
     }
@@ -687,27 +675,6 @@ impl<B: SessionAgentBuilder + 'static> EphemeralSessionService<B> {
                 "Session task dropped the reply channel".to_string(),
             ))
         })
-    }
-
-    pub(crate) async fn enqueue_system_context_append(
-        &self,
-        id: &SessionId,
-        req: AppendSystemContextRequest,
-        accepted_at: SystemTime,
-    ) -> Result<(), SessionError> {
-        let sessions = self.sessions.read().await;
-        let handle = sessions
-            .get(id)
-            .ok_or_else(|| SessionError::NotFound { id: id.clone() })?;
-        handle
-            .command_tx
-            .send(SessionCommand::StageSystemContextAppend { req, accepted_at })
-            .await
-            .map_err(|_| {
-                SessionError::Agent(meerkat_core::error::AgentError::InternalError(
-                    "Session task has exited".to_string(),
-                ))
-            })
     }
 
     pub(crate) async fn sync_system_context_state(
@@ -1889,10 +1856,6 @@ async fn session_task<A: SessionAgent>(
             }
             SessionCommand::StageToolFilter { filter, reply_tx } => {
                 let _ = reply_tx.send(agent.stage_external_tool_filter(filter));
-                continue;
-            }
-            SessionCommand::StageSystemContextAppend { req, accepted_at } => {
-                let _ = agent.stage_system_context_append(&req, accepted_at);
                 continue;
             }
             SessionCommand::SyncSystemContextState { reply_tx } => {

--- a/meerkat-session/src/persistent.rs
+++ b/meerkat-session/src/persistent.rs
@@ -1247,109 +1247,135 @@ impl<B: SessionAgentBuilder + 'static> SessionServiceControlExt for PersistentSe
             }
 
             let accepted_at = meerkat_core::time_compat::SystemTime::now();
-            let mut attempts = 0usize;
-            loop {
-                attempts += 1;
-                let (status, snapshot_state, persisted_state) = {
-                    let guard = match state_arc.lock() {
-                        Ok(guard) => guard,
-                        Err(poisoned) => {
-                            tracing::warn!(
-                                session_id = %id,
-                                "system-context state lock poisoned while snapshotting live append"
-                            );
-                            poisoned.into_inner()
-                        }
-                    };
-                    let snapshot_state = guard.clone();
-                    let mut candidate = snapshot_state.clone();
-                    let status = candidate
-                        .stage_append(&req, accepted_at)
-                        .map_err(|err| err.into_control_error(id))?;
-                    (status, snapshot_state, candidate)
-                };
-
-                // Persist the durable control state before mutating the live
-                // runtime state so an error never leaves the caller observing a
-                // failure while the next LLM boundary still applies the append.
-                let mut session = if self.runtime_store.is_some() {
-                    match self.load_authoritative_session_base(id).await? {
-                        Some(session) => session,
-                        None => {
-                            if created_gate {
-                                drop(gate_guard);
-                                self.checkpointer_gates.lock().await.remove(id);
-                            }
-                            return Err(SessionControlError::Session(SessionError::Agent(
-                                meerkat_core::error::AgentError::InternalError(
-                                    "runtime-backed live session is missing its last committed snapshot"
-                                        .to_string(),
-                                ),
-                            )));
-                        }
-                    }
-                } else {
-                    match self.export_session_with_labels(id).await {
-                        Ok(session) => session,
-                        Err(err) => {
-                            if created_gate && matches!(err, SessionError::NotFound { .. }) {
-                                drop(gate_guard);
-                                self.checkpointer_gates.lock().await.remove(id);
-                            }
-                            return Err(SessionControlError::Session(err));
-                        }
+            let (status, snapshot_state, persisted_state) = {
+                let mut guard = match state_arc.lock() {
+                    Ok(guard) => guard,
+                    Err(poisoned) => {
+                        tracing::warn!(
+                            session_id = %id,
+                            "system-context state lock poisoned while staging live append"
+                        );
+                        poisoned.into_inner()
                     }
                 };
+                let snapshot_state = guard.clone();
+                let mut candidate = snapshot_state.clone();
+                let status = candidate
+                    .stage_append(&req, accepted_at)
+                    .map_err(|err| err.into_control_error(id))?;
+                *guard = candidate.clone();
+                (status, snapshot_state, candidate)
+            };
 
+            let mut session = if self.runtime_store.is_some() {
+                match self.load_authoritative_session_base(id).await? {
+                    Some(session) => session,
+                    None => {
+                        if created_gate {
+                            drop(gate_guard);
+                            self.checkpointer_gates.lock().await.remove(id);
+                        }
+                        return Err(SessionControlError::Session(SessionError::Agent(
+                            meerkat_core::error::AgentError::InternalError(
+                                "runtime-backed live session is missing its last committed snapshot"
+                                    .to_string(),
+                            ),
+                        )));
+                    }
+                }
+            } else {
+                match self.export_session_with_labels(id).await {
+                    Ok(session) => session,
+                    Err(err) => {
+                        if created_gate && matches!(err, SessionError::NotFound { .. }) {
+                            drop(gate_guard);
+                            self.checkpointer_gates.lock().await.remove(id);
+                        }
+                        return Err(SessionControlError::Session(err));
+                    }
+                }
+            };
+
+            let persist_result = async {
                 self.reject_if_archived_session(id, &session).await?;
-                write_system_context_state(&mut session, persisted_state)?;
+                write_system_context_state(&mut session, persisted_state.clone())?;
                 self.save_normalized_session(session)
                     .await
                     .map_err(SessionControlError::Session)?;
+                Ok::<(), SessionControlError>(())
+            }
+            .await;
 
-                let _ = self
-                    .inner
-                    .enqueue_system_context_append(id, req.clone(), accepted_at)
-                    .await;
-
-                let commit_result = {
+            if let Err(err) = persist_result {
+                let rollback_result = {
                     let mut guard = match state_arc.lock() {
                         Ok(guard) => guard,
                         Err(poisoned) => {
                             tracing::warn!(
                                 session_id = %id,
-                                "system-context state lock poisoned while committing live append"
+                                "system-context state lock poisoned while rolling back failed live append"
                             );
                             poisoned.into_inner()
                         }
                     };
-                    if *guard == snapshot_state {
-                        let live_status = guard
-                            .stage_append(&req, accepted_at)
-                            .map_err(|err| err.into_control_error(id))?;
-                        Some(live_status)
+                    if *guard == persisted_state {
+                        *guard = snapshot_state;
+                        Ok(())
                     } else {
-                        None
+                        Err(())
                     }
                 };
-
-                if let Some(live_status) = commit_result {
-                    debug_assert_eq!(live_status, status);
+                if rollback_result.is_ok() {
                     let _ = self.inner.sync_system_context_state(id).await;
-                    drop(gate_guard);
-                    return Ok(AppendSystemContextResult { status });
-                }
-
-                if attempts >= 8 {
+                } else {
                     tracing::warn!(
                         session_id = %id,
-                        "system-context state kept changing after the durable append committed; discarding the live session so the next access reloads the authoritative stored state"
+                        "live system-context state diverged after a failed durable append; discarding the live session to restore authoritative state"
                     );
                     drop(gate_guard);
                     let _ = self.discard_live_session(id).await;
-                    return Ok(AppendSystemContextResult { status });
                 }
+                return Err(err);
             }
+
+            let reconciled_state = {
+                let guard = match state_arc.lock() {
+                    Ok(guard) => guard,
+                    Err(poisoned) => {
+                        tracing::warn!(
+                            session_id = %id,
+                            "system-context state lock poisoned while reconciling durable append state"
+                        );
+                        poisoned.into_inner()
+                    }
+                };
+                guard.clone()
+            };
+            if reconciled_state != persisted_state {
+                let mut session = if self.runtime_store.is_some() {
+                    match self.load_authoritative_session_base(id).await? {
+                        Some(session) => session,
+                        None => {
+                            drop(gate_guard);
+                            let _ = self.discard_live_session(id).await;
+                            return Ok(AppendSystemContextResult { status });
+                        }
+                    }
+                } else {
+                    self.export_session_with_labels(id)
+                        .await
+                        .map_err(SessionControlError::Session)?
+                };
+                self.reject_if_archived_session(id, &session).await?;
+                write_system_context_state(&mut session, reconciled_state)?;
+                self.save_normalized_session(session)
+                    .await
+                    .map_err(SessionControlError::Session)?;
+            }
+
+            let _ = self.inner.sync_system_context_state(id).await;
+            drop(gate_guard);
+            return Ok(AppendSystemContextResult { status });
         }
 
         if let Some(gate) = existing_gate {
@@ -2872,6 +2898,55 @@ mod tests {
         assert!(
             !guard.seen.contains_key("ctx-save-failure"),
             "failed append must not reserve the idempotency key in live state"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_export_live_session_merges_shared_system_context_state() {
+        let store: Arc<dyn SessionStore> = Arc::new(MemoryStore::new());
+        let service =
+            PersistentSessionService::new(DummyBuilder, 4, store, None, memory_blob_store());
+
+        let result = service
+            .create_session(create_request(
+                "hello",
+                meerkat_core::service::InitialTurnPolicy::RunImmediately,
+            ))
+            .await
+            .expect("create_session should succeed");
+        let id = result.session_id;
+
+        let state = service
+            .inner
+            .system_context_state(&id)
+            .await
+            .expect("live session should expose shared system-context state");
+        {
+            let mut guard = state.lock().expect("system-context state lock");
+            guard
+                .stage_append(
+                    &AppendSystemContextRequest {
+                        text: "queued live append".to_string(),
+                        source: Some("mob".to_string()),
+                        idempotency_key: Some("ctx-export-merge".to_string()),
+                    },
+                    meerkat_core::time_compat::SystemTime::now(),
+                )
+                .expect("staging into shared state should succeed");
+        }
+
+        let exported = service
+            .export_live_session(&id)
+            .await
+            .expect("export should succeed");
+        let exported_state = exported
+            .system_context_state()
+            .expect("exported session should include merged system-context state");
+        assert_eq!(exported_state.pending.len(), 1);
+        assert_eq!(exported_state.pending[0].text, "queued live append");
+        assert!(
+            exported_state.seen.contains_key("ctx-export-merge"),
+            "exported session should include the staged idempotency key"
         );
     }
 

--- a/meerkat-session/src/persistent.rs
+++ b/meerkat-session/src/persistent.rs
@@ -1775,6 +1775,7 @@ mod tests {
                         max_tokens: 0,
                         structured_output_retries: 2,
                         provider: identity.provider,
+                        self_hosted_server_id: None,
                         provider_params: identity.provider_params.clone(),
                         tooling: meerkat_core::SessionTooling::default(),
                         keep_alive: false,
@@ -2006,6 +2007,7 @@ mod tests {
                         max_tokens: 0,
                         structured_output_retries: 2,
                         provider: identity.provider,
+                        self_hosted_server_id: None,
                         provider_params: identity.provider_params.clone(),
                         tooling: meerkat_core::SessionTooling::default(),
                         keep_alive: false,
@@ -3249,6 +3251,7 @@ mod tests {
                 max_tokens: 1024,
                 structured_output_retries: 2,
                 provider: meerkat_core::Provider::Anthropic,
+                self_hosted_server_id: None,
                 provider_params: None,
                 tooling: meerkat_core::SessionTooling {
                     builtins: meerkat_core::ToolCategoryOverride::Enable,
@@ -3409,6 +3412,7 @@ mod tests {
                 max_tokens: 1024,
                 structured_output_retries: 2,
                 provider: meerkat_core::Provider::Anthropic,
+                self_hosted_server_id: None,
                 provider_params: None,
                 tooling: meerkat_core::SessionTooling {
                     builtins: meerkat_core::ToolCategoryOverride::Enable,
@@ -3490,6 +3494,7 @@ mod tests {
                 max_tokens: 1024,
                 structured_output_retries: 2,
                 provider: meerkat_core::Provider::Anthropic,
+                self_hosted_server_id: None,
                 provider_params: None,
                 tooling: meerkat_core::SessionTooling {
                     builtins: meerkat_core::ToolCategoryOverride::Enable,
@@ -3644,6 +3649,7 @@ mod tests {
             max_tokens: 1024,
             structured_output_retries: 2,
             provider: meerkat_core::Provider::Anthropic,
+            self_hosted_server_id: None,
             provider_params: None,
             tooling: meerkat_core::SessionTooling::default(),
             keep_alive: false,

--- a/meerkat-session/src/persistent.rs
+++ b/meerkat-session/src/persistent.rs
@@ -1307,6 +1307,11 @@ impl<B: SessionAgentBuilder + 'static> SessionServiceControlExt for PersistentSe
                     .await
                     .map_err(SessionControlError::Session)?;
 
+                let _ = self
+                    .inner
+                    .enqueue_system_context_append(id, req.clone(), accepted_at)
+                    .await;
+
                 let commit_result = {
                     let mut guard = match state_arc.lock() {
                         Ok(guard) => guard,
@@ -1330,6 +1335,7 @@ impl<B: SessionAgentBuilder + 'static> SessionServiceControlExt for PersistentSe
 
                 if let Some(live_status) = commit_result {
                     debug_assert_eq!(live_status, status);
+                    let _ = self.inner.sync_system_context_state(id).await;
                     drop(gate_guard);
                     return Ok(AppendSystemContextResult { status });
                 }

--- a/meerkat-skills/Cargo.toml
+++ b/meerkat-skills/Cargo.toml
@@ -26,7 +26,7 @@ serde_json = { workspace = true }
 async-trait = { workspace = true }
 tracing = { workspace = true }
 strum = { workspace = true }
-serde_yml = { workspace = true }
+serde_yaml = { workspace = true }
 indexmap = "2"
 regex = "1"
 reqwest = { workspace = true, optional = true }

--- a/meerkat-skills/src/parser.rs
+++ b/meerkat-skills/src/parser.rs
@@ -1,12 +1,12 @@
 //! SKILL.md frontmatter parser.
 //!
-//! Uses `serde_yml` for robust YAML parsing of the frontmatter block.
+//! Uses `serde_yaml` for robust YAML parsing of the frontmatter block.
 
 use indexmap::IndexMap;
 use meerkat_core::skills::{
     SkillDescriptor, SkillDocument, SkillError, SkillId, SkillName, SkillScope,
 };
-use serde_yml::Value;
+use serde_yaml::Value;
 
 /// Parsed frontmatter from a SKILL.md file.
 #[derive(Debug, serde::Deserialize)]
@@ -43,7 +43,7 @@ pub fn parse_skill_md(
     expected_skill_name: Option<&str>,
 ) -> Result<SkillDocument, SkillError> {
     let (frontmatter_str, body) = split_frontmatter(content)?;
-    let fm: Frontmatter = serde_yml::from_str(&frontmatter_str)
+    let fm: Frontmatter = serde_yaml::from_str(&frontmatter_str)
         .map_err(|e| SkillError::Parse(format!("frontmatter parse error: {e}").into()))?;
     validate_frontmatter(&fm, expected_skill_name)?;
 
@@ -57,7 +57,7 @@ pub fn parse_skill_md(
         let serialized = if let Some(s) = value.as_str() {
             s.to_string()
         } else {
-            serde_yml::to_string(&value)
+            serde_yaml::to_string(&value)
                 .map_err(|e| SkillError::Parse(format!("extension serialize error: {e}").into()))?
                 .trim()
                 .to_string()

--- a/meerkat/src/factory.rs
+++ b/meerkat/src/factory.rs
@@ -9,8 +9,10 @@ use std::sync::Arc;
 
 use meerkat_client::{
     DefaultClientFactory, DefaultFactoryConfig, FactoryError, LlmClient, LlmClientAdapter,
-    LlmClientFactory, LlmProvider, OpenAiCompatibleClient, OpenAiCompatibleMode, ProviderResolver,
+    LlmClientFactory, LlmProvider, ProviderResolver,
 };
+#[cfg(feature = "openai")]
+use meerkat_client::{OpenAiCompatibleClient, OpenAiCompatibleMode};
 use meerkat_core::ops_lifecycle::OpsLifecycleRegistry;
 use meerkat_core::service::{CreateSessionRequest, SessionBuildOptions};
 
@@ -1184,45 +1186,57 @@ impl AgentFactory {
         registry: &ModelRegistry,
         identity: &SessionLlmIdentity,
     ) -> Result<Arc<dyn LlmClient>, FactoryError> {
-        let entry = registry.entry(&identity.model).ok_or_else(|| {
-            FactoryError::ClientCreationFailed(format!("unknown model '{}'", identity.model))
-        })?;
-        let self_hosted = entry.self_hosted.as_ref().ok_or_else(|| {
-            FactoryError::ClientCreationFailed(format!(
-                "model '{}' is not self-hosted",
-                identity.model
-            ))
-        })?;
-        if let Some(expected_server_id) = identity.self_hosted_server_id.as_deref()
-            && self_hosted.server_id != expected_server_id
+        #[cfg(not(feature = "openai"))]
         {
-            return Err(FactoryError::ClientCreationFailed(format!(
-                "self-hosted model '{}' is bound to server '{}', but registry resolves to '{}'",
-                identity.model, expected_server_id, self_hosted.server_id
-            )));
-        }
-        if self_hosted.transport != meerkat_core::SelfHostedTransport::OpenAiCompatible {
+            let _ = registry;
+            let _ = identity;
             return Err(FactoryError::UnsupportedProvider(
-                "only openai_compatible transport is supported".to_string(),
+                "self_hosted requires the openai feature".to_string(),
             ));
         }
 
-        let mode = match self_hosted.api_style {
-            meerkat_core::SelfHostedApiStyle::Responses => OpenAiCompatibleMode::Responses,
-            meerkat_core::SelfHostedApiStyle::ChatCompletions => {
-                OpenAiCompatibleMode::ChatCompletions
+        #[cfg(feature = "openai")]
+        {
+            let entry = registry.entry(&identity.model).ok_or_else(|| {
+                FactoryError::ClientCreationFailed(format!("unknown model '{}'", identity.model))
+            })?;
+            let self_hosted = entry.self_hosted.as_ref().ok_or_else(|| {
+                FactoryError::ClientCreationFailed(format!(
+                    "model '{}' is not self-hosted",
+                    identity.model
+                ))
+            })?;
+            if let Some(expected_server_id) = identity.self_hosted_server_id.as_deref()
+                && self_hosted.server_id != expected_server_id
+            {
+                return Err(FactoryError::ClientCreationFailed(format!(
+                    "self-hosted model '{}' is bound to server '{}', but registry resolves to '{}'",
+                    identity.model, expected_server_id, self_hosted.server_id
+                )));
             }
-        };
+            if self_hosted.transport != meerkat_core::SelfHostedTransport::OpenAiCompatible {
+                return Err(FactoryError::UnsupportedProvider(
+                    "only openai_compatible transport is supported".to_string(),
+                ));
+            }
 
-        Ok(Arc::new(OpenAiCompatibleClient::new(
-            mode,
-            self_hosted.remote_model.clone(),
-            self_hosted.base_url.clone(),
-            self_hosted.resolve_bearer_token(),
-            entry.profile.supports_temperature,
-            entry.profile.supports_thinking,
-            entry.profile.supports_reasoning,
-        )))
+            let mode = match self_hosted.api_style {
+                meerkat_core::SelfHostedApiStyle::Responses => OpenAiCompatibleMode::Responses,
+                meerkat_core::SelfHostedApiStyle::ChatCompletions => {
+                    OpenAiCompatibleMode::ChatCompletions
+                }
+            };
+
+            Ok(Arc::new(OpenAiCompatibleClient::new(
+                mode,
+                self_hosted.remote_model.clone(),
+                self_hosted.base_url.clone(),
+                self_hosted.resolve_bearer_token(),
+                entry.profile.supports_temperature,
+                entry.profile.supports_thinking,
+                entry.profile.supports_reasoning,
+            )))
+        }
     }
 
     fn resolve_provider_credentials(

--- a/meerkat/src/factory.rs
+++ b/meerkat/src/factory.rs
@@ -185,6 +185,8 @@ pub struct AgentBuildConfig {
     pub model: String,
     /// Explicit provider. If `None`, inferred from the model name.
     pub provider: Option<Provider>,
+    /// Durable self-hosted server binding for configured aliases.
+    pub self_hosted_server_id: Option<String>,
     /// Max tokens per turn. If `None`, uses `Config::max_tokens`.
     pub max_tokens: Option<u32>,
     /// Override the system prompt. If `None`, uses the default composed prompt.
@@ -330,6 +332,7 @@ impl std::fmt::Debug for AgentBuildConfig {
         f.debug_struct("AgentBuildConfig")
             .field("model", &self.model)
             .field("provider", &self.provider)
+            .field("self_hosted_server_id", &self.self_hosted_server_id)
             .field("max_tokens", &self.max_tokens)
             .field(
                 "system_prompt",
@@ -398,6 +401,7 @@ impl AgentBuildConfig {
         Self {
             model: model.into(),
             provider: None,
+            self_hosted_server_id: None,
             max_tokens: None,
             system_prompt: None,
             output_schema: None,
@@ -489,6 +493,7 @@ impl AgentBuildConfig {
     /// Merge `SessionBuildOptions` into this build config.
     pub fn apply_session_build_options(&mut self, build: &SessionBuildOptions) {
         self.provider = build.provider;
+        self.self_hosted_server_id = build.self_hosted_server_id.clone();
         self.output_schema = build.output_schema.clone();
         self.structured_output_retries = build.structured_output_retries;
         self.hooks_override = build.hooks_override.clone();
@@ -534,6 +539,7 @@ impl AgentBuildConfig {
     pub fn to_session_build_options(&self) -> SessionBuildOptions {
         SessionBuildOptions {
             provider: self.provider,
+            self_hosted_server_id: self.self_hosted_server_id.clone(),
             output_schema: self.output_schema.clone(),
             structured_output_retries: self.structured_output_retries,
             hooks_override: self.hooks_override.clone(),
@@ -988,6 +994,9 @@ impl AgentFactory {
         if !mask.provider {
             build_config.provider = Some(metadata.provider);
         }
+        if !mask.model && !mask.provider {
+            build_config.self_hosted_server_id = metadata.self_hosted_server_id.clone();
+        }
         if !mask.provider_params {
             build_config.provider_params = metadata.provider_params.clone();
         }
@@ -1121,7 +1130,13 @@ impl AgentFactory {
                                 build_config.model
                             ))
                         })?;
-                    Ok((Provider::SelfHosted, Some(server_id)))
+                    Ok((
+                        Provider::SelfHosted,
+                        build_config
+                            .self_hosted_server_id
+                            .clone()
+                            .or(Some(server_id)),
+                    ))
                 }
                 Provider::Other => Ok((Provider::Other, None)),
                 other => Ok((other, None)),
@@ -1133,7 +1148,14 @@ impl AgentFactory {
                 .self_hosted
                 .as_ref()
                 .map(|server| server.server_id.clone());
-            return Ok((entry.provider, server_id));
+            return Ok((
+                entry.provider,
+                if matches!(entry.provider, Provider::SelfHosted) {
+                    build_config.self_hosted_server_id.clone().or(server_id)
+                } else {
+                    None
+                },
+            ));
         }
 
         let inferred = ProviderResolver::infer_from_model(&build_config.model);
@@ -1152,17 +1174,9 @@ impl AgentFactory {
     fn build_self_hosted_client_from_registry(
         &self,
         registry: &ModelRegistry,
-        model: &str,
+        identity: &SessionLlmIdentity,
     ) -> Result<Arc<dyn LlmClient>, FactoryError> {
-        self.build_self_hosted_client_for_identity(
-            registry,
-            &SessionLlmIdentity {
-                model: model.to_string(),
-                provider: Provider::SelfHosted,
-                self_hosted_server_id: None,
-                provider_params: None,
-            },
-        )
+        self.build_self_hosted_client_for_identity(registry, identity)
     }
 
     fn build_self_hosted_client_for_identity(
@@ -1483,16 +1497,36 @@ impl AgentFactory {
         let registry = self.model_registry(config)?;
 
         // 2. Resolve provider and any self-hosted server binding.
-        let (provider, self_hosted_server_id) =
+        let resumed_self_hosted_server_id = resumed_session_metadata
+            .as_ref()
+            .and_then(|metadata| metadata.self_hosted_server_id.clone());
+        let (provider, resolved_self_hosted_server_id) =
             self.resolve_provider_from_registry(&registry, &build_config)?;
+        let self_hosted_server_id = if matches!(provider, Provider::SelfHosted) {
+            build_config
+                .self_hosted_server_id
+                .clone()
+                .or(resumed_self_hosted_server_id)
+                .or(resolved_self_hosted_server_id)
+        } else {
+            None
+        };
 
         // 3. Create LLM client
         let llm_client: Arc<dyn LlmClient> = match build_config.llm_client_override.as_ref() {
             Some(client) => Arc::clone(client),
             None => {
                 if matches!(provider, Provider::SelfHosted) {
-                    self.build_self_hosted_client_from_registry(&registry, &build_config.model)
-                        .map_err(BuildAgentError::LlmClient)?
+                    self.build_self_hosted_client_from_registry(
+                        &registry,
+                        &SessionLlmIdentity {
+                            model: build_config.model.clone(),
+                            provider,
+                            self_hosted_server_id: self_hosted_server_id.clone(),
+                            provider_params: build_config.provider_params.clone(),
+                        },
+                    )
+                    .map_err(BuildAgentError::LlmClient)?
                 } else {
                     let (api_key, base_url) = self.resolve_provider_credentials(provider, config);
                     if api_key.is_none() {
@@ -2365,6 +2399,83 @@ impl AgentFactory {
         }
 
         Ok(agent)
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used)]
+mod tests {
+    use super::*;
+    use meerkat_core::{
+        SelfHostedApiStyle, SelfHostedModelConfig, SelfHostedServerConfig, SelfHostedTransport,
+    };
+
+    #[test]
+    fn resumed_self_hosted_binding_overrides_current_registry_server() {
+        let temp = tempfile::tempdir().unwrap();
+        let factory = AgentFactory::new(temp.path().join("sessions"));
+        let mut config = Config::default();
+        config.self_hosted.servers.insert(
+            "local".to_string(),
+            SelfHostedServerConfig {
+                transport: SelfHostedTransport::OpenAiCompatible,
+                base_url: "http://127.0.0.1:11434".to_string(),
+                api_style: SelfHostedApiStyle::ChatCompletions,
+                bearer_token: None,
+                bearer_token_env: None,
+            },
+        );
+        config.self_hosted.models.insert(
+            "gemma-4-e2b".to_string(),
+            SelfHostedModelConfig {
+                server: "local".to_string(),
+                remote_model: "gemma4:e2b".to_string(),
+                display_name: "Gemma 4 E2B".to_string(),
+                family: "gemma-4".to_string(),
+                tier: meerkat_models::ModelTier::Supported,
+                context_window: Some(128_000),
+                max_output_tokens: Some(8_192),
+                vision: true,
+                image_tool_results: true,
+                inline_video: false,
+                supports_temperature: true,
+                supports_thinking: true,
+                supports_reasoning: true,
+                call_timeout_secs: Some(600),
+            },
+        );
+
+        let mut resumed = Session::new();
+        resumed
+            .set_session_metadata(SessionMetadata {
+                model: "gemma-4-e2b".to_string(),
+                max_tokens: 8_192,
+                structured_output_retries: 2,
+                provider: Provider::SelfHosted,
+                self_hosted_server_id: Some("other".to_string()),
+                provider_params: None,
+                tooling: SessionTooling::default(),
+                keep_alive: false,
+                comms_name: None,
+                peer_meta: None,
+                realm_id: None,
+                instance_id: None,
+                backend: None,
+                config_generation: None,
+            })
+            .expect("resume metadata");
+
+        let mut build = AgentBuildConfig::new("gemma-4-e2b");
+        build.resume_session = Some(resumed);
+        let _ = AgentFactory::apply_resumed_session_metadata(&mut build);
+
+        let registry = factory.model_registry(&config).expect("registry");
+        let (provider, server_id) = factory
+            .resolve_provider_from_registry(&registry, &build)
+            .expect("resolved provider");
+
+        assert_eq!(provider, Provider::SelfHosted);
+        assert_eq!(server_id.as_deref(), Some("other"));
     }
 }
 

--- a/meerkat/src/factory.rs
+++ b/meerkat/src/factory.rs
@@ -2404,6 +2404,7 @@ impl AgentFactory {
 
 #[cfg(test)]
 #[allow(clippy::unwrap_used, clippy::expect_used)]
+#[allow(clippy::items_after_test_module)]
 mod tests {
     use super::*;
     use meerkat_core::{

--- a/meerkat/src/factory.rs
+++ b/meerkat/src/factory.rs
@@ -1084,7 +1084,7 @@ impl AgentFactory {
             .model_registry()
             .map_err(|err| FactoryError::ClientCreationFailed(err.to_string()))?;
         if matches!(identity.provider, Provider::SelfHosted) {
-            return self.build_self_hosted_client_from_registry(&registry, &identity.model);
+            return self.build_self_hosted_client_for_identity(&registry, identity);
         }
         let (api_key, base_url) = self.resolve_provider_credentials(identity.provider, config);
         self.build_llm_client(identity.provider, api_key, base_url)
@@ -1154,12 +1154,39 @@ impl AgentFactory {
         registry: &ModelRegistry,
         model: &str,
     ) -> Result<Arc<dyn LlmClient>, FactoryError> {
-        let entry = registry.entry(model).ok_or_else(|| {
-            FactoryError::ClientCreationFailed(format!("unknown model '{model}'"))
+        self.build_self_hosted_client_for_identity(
+            registry,
+            &SessionLlmIdentity {
+                model: model.to_string(),
+                provider: Provider::SelfHosted,
+                self_hosted_server_id: None,
+                provider_params: None,
+            },
+        )
+    }
+
+    fn build_self_hosted_client_for_identity(
+        &self,
+        registry: &ModelRegistry,
+        identity: &SessionLlmIdentity,
+    ) -> Result<Arc<dyn LlmClient>, FactoryError> {
+        let entry = registry.entry(&identity.model).ok_or_else(|| {
+            FactoryError::ClientCreationFailed(format!("unknown model '{}'", identity.model))
         })?;
         let self_hosted = entry.self_hosted.as_ref().ok_or_else(|| {
-            FactoryError::ClientCreationFailed(format!("model '{model}' is not self-hosted"))
+            FactoryError::ClientCreationFailed(format!(
+                "model '{}' is not self-hosted",
+                identity.model
+            ))
         })?;
+        if let Some(expected_server_id) = identity.self_hosted_server_id.as_deref()
+            && self_hosted.server_id != expected_server_id
+        {
+            return Err(FactoryError::ClientCreationFailed(format!(
+                "self-hosted model '{}' is bound to server '{}', but registry resolves to '{}'",
+                identity.model, expected_server_id, self_hosted.server_id
+            )));
+        }
         if self_hosted.transport != meerkat_core::SelfHostedTransport::OpenAiCompatible {
             return Err(FactoryError::UnsupportedProvider(
                 "only openai_compatible transport is supported".to_string(),
@@ -1179,6 +1206,7 @@ impl AgentFactory {
             self_hosted.base_url.clone(),
             self_hosted.resolve_bearer_token(),
             entry.profile.supports_temperature,
+            entry.profile.supports_thinking,
             entry.profile.supports_reasoning,
         )))
     }

--- a/meerkat/src/factory.rs
+++ b/meerkat/src/factory.rs
@@ -9,7 +9,7 @@ use std::sync::Arc;
 
 use meerkat_client::{
     DefaultClientFactory, DefaultFactoryConfig, FactoryError, LlmClient, LlmClientAdapter,
-    LlmClientFactory, LlmProvider, ProviderResolver,
+    LlmClientFactory, LlmProvider, OpenAiCompatibleClient, OpenAiCompatibleMode, ProviderResolver,
 };
 use meerkat_core::ops_lifecycle::OpsLifecycleRegistry;
 use meerkat_core::service::{CreateSessionRequest, SessionBuildOptions};
@@ -37,8 +37,8 @@ const DEFAULT_WASM_SYSTEM_PROMPT: &str = r"You are an autonomous agent. Your tas
 - If the task cannot be completed, explain what blocked progress and what was attempted.";
 use meerkat_core::{
     Agent, AgentBuilder, AgentEvent, AgentLlmClient, AgentSessionStore, AgentToolDispatcher,
-    BlobStore, BudgetLimits, Config, HookRunOverrides, OutputSchema, Provider, Session,
-    SessionMetadata, SessionTooling, ToolCategoryOverride,
+    BlobStore, BudgetLimits, Config, HookRunOverrides, ModelRegistry, OutputSchema, Provider,
+    Session, SessionLlmIdentity, SessionMetadata, SessionTooling, ToolCategoryOverride,
 };
 #[cfg(not(feature = "memory-store"))]
 use meerkat_core::{SessionId, SessionMeta};
@@ -616,11 +616,15 @@ pub enum BuildAgentError {
 /// This struct bridges the dependency gap: `meerkat-core` owns the
 /// `ModelOperationalDefaultsResolver` trait, and this facade-layer
 /// implementation provides the concrete `meerkat-models` lookup.
-struct ProfileBasedDefaultsResolver;
+struct RegistryBackedDefaultsResolver {
+    registry: Arc<ModelRegistry>,
+}
 
-impl meerkat_core::ModelOperationalDefaultsResolver for ProfileBasedDefaultsResolver {
+impl meerkat_core::ModelOperationalDefaultsResolver for RegistryBackedDefaultsResolver {
     fn call_timeout_for(&self, provider: &str, model: &str) -> Option<std::time::Duration> {
-        meerkat_models::profile::profile_for(provider, model)
+        let _ = provider;
+        self.registry
+            .profile_for(model)
             .and_then(|p| p.call_timeout_secs)
             .map(std::time::Duration::from_secs)
     }
@@ -1052,6 +1056,9 @@ impl AgentFactory {
             Provider::Anthropic => LlmProvider::Anthropic,
             Provider::OpenAI => LlmProvider::OpenAi,
             Provider::Gemini => LlmProvider::Gemini,
+            Provider::SelfHosted => {
+                return Err(FactoryError::UnsupportedProvider("self_hosted".to_string()));
+            }
             Provider::Other => return Err(FactoryError::UnsupportedProvider("other".to_string())),
         };
 
@@ -1066,6 +1073,114 @@ impl AgentFactory {
 
         let factory = DefaultClientFactory::with_config(config);
         factory.create_client(mapped, api_key)
+    }
+
+    pub async fn build_llm_client_for_identity(
+        &self,
+        config: &Config,
+        identity: &SessionLlmIdentity,
+    ) -> Result<Arc<dyn LlmClient>, FactoryError> {
+        let registry = config
+            .model_registry()
+            .map_err(|err| FactoryError::ClientCreationFailed(err.to_string()))?;
+        if matches!(identity.provider, Provider::SelfHosted) {
+            return self.build_self_hosted_client_from_registry(&registry, &identity.model);
+        }
+        let (api_key, base_url) = self.resolve_provider_credentials(identity.provider, config);
+        self.build_llm_client(identity.provider, api_key, base_url)
+            .await
+    }
+
+    fn model_registry(&self, config: &Config) -> Result<ModelRegistry, BuildAgentError> {
+        config
+            .model_registry()
+            .map_err(|err| BuildAgentError::Config(err.to_string()))
+    }
+
+    fn resolve_provider_from_registry(
+        &self,
+        registry: &ModelRegistry,
+        build_config: &AgentBuildConfig,
+    ) -> Result<(Provider, Option<String>), BuildAgentError> {
+        if let Some(provider) = build_config.provider {
+            return match provider {
+                Provider::SelfHosted => {
+                    let entry = registry.entry(&build_config.model).ok_or_else(|| {
+                        BuildAgentError::Config(format!(
+                            "self-hosted model '{}' is not registered in config",
+                            build_config.model
+                        ))
+                    })?;
+                    let server_id = entry
+                        .self_hosted
+                        .as_ref()
+                        .map(|server| server.server_id.clone())
+                        .ok_or_else(|| {
+                            BuildAgentError::Config(format!(
+                                "model '{}' is not backed by a self-hosted server",
+                                build_config.model
+                            ))
+                        })?;
+                    Ok((Provider::SelfHosted, Some(server_id)))
+                }
+                Provider::Other => Ok((Provider::Other, None)),
+                other => Ok((other, None)),
+            };
+        }
+
+        if let Some(entry) = registry.entry(&build_config.model) {
+            let server_id = entry
+                .self_hosted
+                .as_ref()
+                .map(|server| server.server_id.clone());
+            return Ok((entry.provider, server_id));
+        }
+
+        let inferred = ProviderResolver::infer_from_model(&build_config.model);
+        if inferred != Provider::Other {
+            return Ok((inferred, None));
+        }
+        if let Some(client) = build_config.llm_client_override.as_ref() {
+            return Ok((Provider::from_name(client.provider()), None));
+        }
+
+        Err(BuildAgentError::UnknownProvider {
+            model: build_config.model.clone(),
+        })
+    }
+
+    fn build_self_hosted_client_from_registry(
+        &self,
+        registry: &ModelRegistry,
+        model: &str,
+    ) -> Result<Arc<dyn LlmClient>, FactoryError> {
+        let entry = registry.entry(model).ok_or_else(|| {
+            FactoryError::ClientCreationFailed(format!("unknown model '{model}'"))
+        })?;
+        let self_hosted = entry.self_hosted.as_ref().ok_or_else(|| {
+            FactoryError::ClientCreationFailed(format!("model '{model}' is not self-hosted"))
+        })?;
+        if self_hosted.transport != meerkat_core::SelfHostedTransport::OpenAiCompatible {
+            return Err(FactoryError::UnsupportedProvider(
+                "only openai_compatible transport is supported".to_string(),
+            ));
+        }
+
+        let mode = match self_hosted.api_style {
+            meerkat_core::SelfHostedApiStyle::Responses => OpenAiCompatibleMode::Responses,
+            meerkat_core::SelfHostedApiStyle::ChatCompletions => {
+                OpenAiCompatibleMode::ChatCompletions
+            }
+        };
+
+        Ok(Arc::new(OpenAiCompatibleClient::new(
+            mode,
+            self_hosted.remote_model.clone(),
+            self_hosted.base_url.clone(),
+            self_hosted.resolve_bearer_token(),
+            entry.profile.supports_temperature,
+            entry.profile.supports_reasoning,
+        )))
     }
 
     fn resolve_provider_credentials(
@@ -1337,38 +1452,30 @@ impl AgentFactory {
             return Err(BuildAgentError::KeepAliveRequiresCommsName);
         }
 
-        // 2. Resolve provider
-        let provider = match build_config.provider {
-            Some(p) => p,
-            None => {
-                let inferred = ProviderResolver::infer_from_model(&build_config.model);
-                if inferred != Provider::Other {
-                    inferred
-                } else if let Some(client) = build_config.llm_client_override.as_ref() {
-                    // An explicit override is the authoritative execution transport
-                    // when the model name is not recognizable.
-                    Provider::from_name(client.provider())
-                } else {
-                    return Err(BuildAgentError::UnknownProvider {
-                        model: build_config.model.clone(),
-                    });
-                }
-            }
-        };
+        let registry = self.model_registry(config)?;
+
+        // 2. Resolve provider and any self-hosted server binding.
+        let (provider, self_hosted_server_id) =
+            self.resolve_provider_from_registry(&registry, &build_config)?;
 
         // 3. Create LLM client
         let llm_client: Arc<dyn LlmClient> = match build_config.llm_client_override.as_ref() {
             Some(client) => Arc::clone(client),
             None => {
-                let (api_key, base_url) = self.resolve_provider_credentials(provider, config);
-                if api_key.is_none() {
-                    return Err(BuildAgentError::MissingApiKey {
-                        provider: provider_key(provider).to_string(),
-                    });
+                if matches!(provider, Provider::SelfHosted) {
+                    self.build_self_hosted_client_from_registry(&registry, &build_config.model)
+                        .map_err(BuildAgentError::LlmClient)?
+                } else {
+                    let (api_key, base_url) = self.resolve_provider_credentials(provider, config);
+                    if api_key.is_none() {
+                        return Err(BuildAgentError::MissingApiKey {
+                            provider: provider_key(provider).to_string(),
+                        });
+                    }
+                    self.build_llm_client(provider, api_key, base_url)
+                        .await
+                        .map_err(BuildAgentError::LlmClient)?
                 }
-                self.build_llm_client(provider, api_key, base_url)
-                    .await
-                    .map_err(BuildAgentError::LlmClient)?
             }
         };
 
@@ -1540,7 +1647,8 @@ impl AgentFactory {
 
         // Resolve model profile for capability gating (e.g., hiding view_image
         // when the model cannot process image blocks in tool results).
-        let image_tool_results = meerkat_models::profile::profile_for(provider.as_str(), &model)
+        let image_tool_results = registry
+            .profile_for(&model)
             .is_none_or(|p| p.image_tool_results);
         // Resolve ops lifecycle registry via RuntimeBuildMode.
         use meerkat_core::runtime_epoch::RuntimeBuildMode;
@@ -2036,7 +2144,9 @@ impl AgentFactory {
             .budget(budget_limits)
             .structured_output_retries(build_config.structured_output_retries)
             .with_hook_run_overrides(build_config.hooks_override)
-            .with_model_defaults_resolver(Arc::new(ProfileBasedDefaultsResolver))
+            .with_model_defaults_resolver(Arc::new(RegistryBackedDefaultsResolver {
+                registry: Arc::new(registry.clone()),
+            }))
             .with_call_timeout_override(effective_call_timeout_override);
 
         if let Some(system_prompt) = system_prompt {
@@ -2174,6 +2284,7 @@ impl AgentFactory {
             metadata.max_tokens = max_tokens;
             metadata.structured_output_retries = build_config.structured_output_retries;
             metadata.provider = provider;
+            metadata.self_hosted_server_id = self_hosted_server_id.clone();
             metadata.provider_params = build_config.provider_params;
             metadata.tooling.builtins = build_config.override_builtins;
             metadata.tooling.shell = build_config.override_shell;
@@ -2199,6 +2310,7 @@ impl AgentFactory {
                 max_tokens,
                 structured_output_retries: build_config.structured_output_retries,
                 provider,
+                self_hosted_server_id,
                 provider_params: build_config.provider_params,
                 tooling: SessionTooling {
                     builtins: build_config.override_builtins,

--- a/meerkat/src/service_factory.rs
+++ b/meerkat/src/service_factory.rs
@@ -202,6 +202,10 @@ impl SessionAgent for FactoryAgent {
             .map_err(|error| meerkat_core::error::AgentError::ConfigError(error.to_string()))
     }
 
+    fn sync_system_context_state(&mut self) {
+        self.agent.sync_system_context_state_to_session();
+    }
+
     fn cancel(&mut self) {
         self.agent.cancel();
     }

--- a/meerkat/src/surface.rs
+++ b/meerkat/src/surface.rs
@@ -96,48 +96,54 @@ pub fn build_capabilities_response(config: &Config) -> CapabilitiesResponse {
 ///
 /// This is a pure function with no config dependency — the catalog is static data
 /// compiled into the binary from `meerkat-models`.
-pub fn build_models_catalog_response() -> meerkat_contracts::ModelsCatalogResponse {
-    let providers = meerkat_models::provider_defaults()
-        .iter()
-        .map(|pd| {
-            let models = pd
-                .models
-                .iter()
-                .map(|entry| {
-                    let profile = meerkat_models::profile_for(entry.provider, entry.id).map(|p| {
-                        meerkat_contracts::WireModelProfile {
-                            model_family: p.model_family,
-                            supports_temperature: p.supports_temperature,
-                            supports_thinking: p.supports_thinking,
-                            supports_reasoning: p.supports_reasoning,
-                            inline_video: p.inline_video,
-                            params_schema: p.params_schema,
+pub fn build_models_catalog_response(
+    config: &meerkat_core::Config,
+) -> meerkat_contracts::ModelsCatalogResponse {
+    let providers = match config.model_registry() {
+        Ok(registry) => registry
+            .provider_defaults()
+            .map(|(provider, default_model_id)| {
+                let models = registry
+                    .entries_for_provider(provider)
+                    .map(|entry| {
+                        let profile = Some(meerkat_contracts::WireModelProfile {
+                            model_family: entry.profile.model_family.clone(),
+                            supports_temperature: entry.profile.supports_temperature,
+                            supports_thinking: entry.profile.supports_thinking,
+                            supports_reasoning: entry.profile.supports_reasoning,
+                            inline_video: entry.profile.inline_video,
+                            params_schema: entry.profile.params_schema.clone(),
+                        });
+                        meerkat_contracts::CatalogModelEntry {
+                            id: entry.id.clone(),
+                            display_name: entry.display_name.clone(),
+                            tier: match entry.tier {
+                                meerkat_models::ModelTier::Recommended => {
+                                    meerkat_contracts::WireModelTier::Recommended
+                                }
+                                meerkat_models::ModelTier::Supported => {
+                                    meerkat_contracts::WireModelTier::Supported
+                                }
+                            },
+                            context_window: entry.context_window,
+                            max_output_tokens: entry.max_output_tokens,
+                            server_id: entry
+                                .self_hosted
+                                .as_ref()
+                                .map(|server| server.server_id.clone()),
+                            profile,
                         }
-                    });
-                    meerkat_contracts::CatalogModelEntry {
-                        id: entry.id.to_string(),
-                        display_name: entry.display_name.to_string(),
-                        tier: match entry.tier {
-                            meerkat_models::ModelTier::Recommended => {
-                                meerkat_contracts::WireModelTier::Recommended
-                            }
-                            meerkat_models::ModelTier::Supported => {
-                                meerkat_contracts::WireModelTier::Supported
-                            }
-                        },
-                        context_window: entry.context_window,
-                        max_output_tokens: entry.max_output_tokens,
-                        profile,
-                    }
-                })
-                .collect();
-            meerkat_contracts::ProviderCatalog {
-                provider: pd.provider.to_string(),
-                default_model_id: pd.default_model_id.to_string(),
-                models,
-            }
-        })
-        .collect();
+                    })
+                    .collect();
+                meerkat_contracts::ProviderCatalog {
+                    provider: provider.as_str().to_string(),
+                    default_model_id: default_model_id.to_string(),
+                    models,
+                }
+            })
+            .collect(),
+        Err(_) => Vec::new(),
+    };
 
     meerkat_contracts::ModelsCatalogResponse {
         contract_version: ContractVersion::CURRENT,

--- a/meerkat/src/surface.rs
+++ b/meerkat/src/surface.rs
@@ -98,57 +98,55 @@ pub fn build_capabilities_response(config: &Config) -> CapabilitiesResponse {
 /// compiled into the binary from `meerkat-models`.
 pub fn build_models_catalog_response(
     config: &meerkat_core::Config,
-) -> meerkat_contracts::ModelsCatalogResponse {
-    let providers = match config.model_registry() {
-        Ok(registry) => registry
-            .provider_defaults()
-            .map(|(provider, default_model_id)| {
-                let models = registry
-                    .entries_for_provider(provider)
-                    .map(|entry| {
-                        let profile = Some(meerkat_contracts::WireModelProfile {
-                            model_family: entry.profile.model_family.clone(),
-                            supports_temperature: entry.profile.supports_temperature,
-                            supports_thinking: entry.profile.supports_thinking,
-                            supports_reasoning: entry.profile.supports_reasoning,
-                            inline_video: entry.profile.inline_video,
-                            params_schema: entry.profile.params_schema.clone(),
-                        });
-                        meerkat_contracts::CatalogModelEntry {
-                            id: entry.id.clone(),
-                            display_name: entry.display_name.clone(),
-                            tier: match entry.tier {
-                                meerkat_models::ModelTier::Recommended => {
-                                    meerkat_contracts::WireModelTier::Recommended
-                                }
-                                meerkat_models::ModelTier::Supported => {
-                                    meerkat_contracts::WireModelTier::Supported
-                                }
-                            },
-                            context_window: entry.context_window,
-                            max_output_tokens: entry.max_output_tokens,
-                            server_id: entry
-                                .self_hosted
-                                .as_ref()
-                                .map(|server| server.server_id.clone()),
-                            profile,
-                        }
-                    })
-                    .collect();
-                meerkat_contracts::ProviderCatalog {
-                    provider: provider.as_str().to_string(),
-                    default_model_id: default_model_id.to_string(),
-                    models,
-                }
-            })
-            .collect(),
-        Err(_) => Vec::new(),
-    };
+) -> Result<meerkat_contracts::ModelsCatalogResponse, meerkat_core::ConfigError> {
+    let registry = config.model_registry()?;
+    let providers = registry
+        .provider_defaults()
+        .map(|(provider, default_model_id)| {
+            let models = registry
+                .entries_for_provider(provider)
+                .map(|entry| {
+                    let profile = Some(meerkat_contracts::WireModelProfile {
+                        model_family: entry.profile.model_family.clone(),
+                        supports_temperature: entry.profile.supports_temperature,
+                        supports_thinking: entry.profile.supports_thinking,
+                        supports_reasoning: entry.profile.supports_reasoning,
+                        inline_video: entry.profile.inline_video,
+                        params_schema: entry.profile.params_schema.clone(),
+                    });
+                    meerkat_contracts::CatalogModelEntry {
+                        id: entry.id.clone(),
+                        display_name: entry.display_name.clone(),
+                        tier: match entry.tier {
+                            meerkat_models::ModelTier::Recommended => {
+                                meerkat_contracts::WireModelTier::Recommended
+                            }
+                            meerkat_models::ModelTier::Supported => {
+                                meerkat_contracts::WireModelTier::Supported
+                            }
+                        },
+                        context_window: entry.context_window,
+                        max_output_tokens: entry.max_output_tokens,
+                        server_id: entry
+                            .self_hosted
+                            .as_ref()
+                            .map(|server| server.server_id.clone()),
+                        profile,
+                    }
+                })
+                .collect();
+            meerkat_contracts::ProviderCatalog {
+                provider: provider.as_str().to_string(),
+                default_model_id: default_model_id.to_string(),
+                models,
+            }
+        })
+        .collect();
 
-    meerkat_contracts::ModelsCatalogResponse {
+    Ok(meerkat_contracts::ModelsCatalogResponse {
         contract_version: ContractVersion::CURRENT,
         providers,
-    }
+    })
 }
 
 /// Validate whether keep-alive mode can be enabled in the current build.
@@ -401,6 +399,7 @@ pub async fn emit_mcp_lifecycle_events(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use meerkat_core::Config;
 
     #[test]
     fn validate_public_peer_meta_rejects_reserved_labels() {
@@ -425,5 +424,29 @@ mod tests {
             result.is_ok(),
             "ordinary peer metadata should stay available"
         );
+    }
+
+    #[test]
+    fn build_models_catalog_response_returns_error_for_invalid_self_hosted_config() {
+        let config: Result<Config, _> = toml::from_str(
+            r#"
+[self_hosted.models.gemma-4-e2b]
+server = "missing"
+remote_model = "gemma4:e2b"
+display_name = "Gemma 4 E2B"
+family = "gemma-4"
+"#,
+        );
+        assert!(config.is_ok(), "config parse failed");
+        let Ok(config) = config else {
+            unreachable!("asserted config parse succeeded above");
+        };
+
+        let result = build_models_catalog_response(&config);
+        assert!(result.is_err(), "invalid catalog config should fail");
+        let Err(err) = result else {
+            unreachable!("asserted invalid catalog config fails above");
+        };
+        assert!(err.to_string().contains("unknown server"));
     }
 }

--- a/meerkat/tests/factory_build_agent.rs
+++ b/meerkat/tests/factory_build_agent.rs
@@ -19,8 +19,8 @@ use meerkat_core::service::{MobToolAuthorityContext, OpaquePrincipalToken};
 use meerkat_core::{
     AgentToolDispatcher, Config, Provider, ProviderConfig, SelfHostedApiStyle,
     SelfHostedModelConfig, SelfHostedServerConfig, SelfHostedTransport, Session, SessionId,
-    SessionMetadata, SessionTooling, ToolCallView, ToolCategoryOverride, ToolDef,
-    ToolDispatchOutcome, ToolError, UserMessage,
+    SessionLlmIdentity, SessionMetadata, SessionTooling, ToolCallView, ToolCategoryOverride,
+    ToolDef, ToolDispatchOutcome, ToolError, UserMessage,
 };
 use meerkat_schedule::{MemoryScheduleStore, ScheduleService, ScheduleToolDispatcher};
 use meerkat_store::{SessionFilter, SessionStore, SessionStoreError};
@@ -398,6 +398,62 @@ async fn build_agent_resolves_self_hosted_alias_from_registry() {
     assert_eq!(metadata.model, "gemma-4-31b");
     assert_eq!(metadata.provider, Provider::SelfHosted);
     assert_eq!(metadata.self_hosted_server_id.as_deref(), Some("local"));
+}
+
+#[tokio::test]
+async fn build_llm_client_for_identity_rejects_self_hosted_server_mismatch() {
+    let temp = tempfile::tempdir().unwrap();
+    let factory = temp_factory(&temp);
+    let mut config = Config::default();
+    config.self_hosted.servers.insert(
+        "local".to_string(),
+        SelfHostedServerConfig {
+            transport: SelfHostedTransport::OpenAiCompatible,
+            base_url: "http://127.0.0.1:11434".to_string(),
+            api_style: SelfHostedApiStyle::ChatCompletions,
+            bearer_token: None,
+            bearer_token_env: None,
+        },
+    );
+    config.self_hosted.models.insert(
+        "gemma-4-e2b".to_string(),
+        SelfHostedModelConfig {
+            server: "local".to_string(),
+            remote_model: "gemma4:e2b".to_string(),
+            display_name: "Gemma 4 E2B".to_string(),
+            family: "gemma-4".to_string(),
+            tier: meerkat_models::ModelTier::Supported,
+            context_window: Some(128_000),
+            max_output_tokens: Some(8_192),
+            vision: true,
+            image_tool_results: true,
+            inline_video: false,
+            supports_temperature: true,
+            supports_thinking: true,
+            supports_reasoning: true,
+            call_timeout_secs: Some(600),
+        },
+    );
+
+    let err = match factory
+        .build_llm_client_for_identity(
+            &config,
+            &SessionLlmIdentity {
+                model: "gemma-4-e2b".to_string(),
+                provider: Provider::SelfHosted,
+                self_hosted_server_id: Some("other".to_string()),
+                provider_params: None,
+            },
+        )
+        .await
+    {
+        Ok(_) => panic!("mismatched server binding should be rejected"),
+        Err(err) => err,
+    };
+
+    let message = err.to_string();
+    assert!(message.contains("bound to server 'other'"));
+    assert!(message.contains("resolves to 'local'"));
 }
 
 /// 5. `build_agent` with `enable_builtins=true` produces agent with builtin tools.

--- a/meerkat/tests/factory_build_agent.rs
+++ b/meerkat/tests/factory_build_agent.rs
@@ -17,9 +17,10 @@ use meerkat_client::{LlmClient, TestClient};
 use meerkat_comms::{CommsRuntime, ResolvedCommsConfig, TrustedPeer, identity::Keypair};
 use meerkat_core::service::{MobToolAuthorityContext, OpaquePrincipalToken};
 use meerkat_core::{
-    AgentToolDispatcher, Config, Provider, ProviderConfig, Session, SessionId, SessionMetadata,
-    SessionTooling, ToolCallView, ToolCategoryOverride, ToolDef, ToolDispatchOutcome, ToolError,
-    UserMessage,
+    AgentToolDispatcher, Config, Provider, ProviderConfig, SelfHostedApiStyle,
+    SelfHostedModelConfig, SelfHostedServerConfig, SelfHostedTransport, Session, SessionId,
+    SessionMetadata, SessionTooling, ToolCallView, ToolCategoryOverride, ToolDef,
+    ToolDispatchOutcome, ToolError, UserMessage,
 };
 use meerkat_schedule::{MemoryScheduleStore, ScheduleService, ScheduleToolDispatcher};
 use meerkat_store::{SessionFilter, SessionStore, SessionStoreError};
@@ -347,6 +348,58 @@ async fn build_agent_sets_session_metadata() {
     assert!(metadata.comms_name.is_none());
 }
 
+/// 4b. Configured self-hosted aliases resolve as first-class model IDs.
+#[tokio::test]
+async fn build_agent_resolves_self_hosted_alias_from_registry() {
+    let temp = tempfile::tempdir().unwrap();
+    let factory = temp_factory(&temp);
+    let mut config = Config::default();
+    config.self_hosted.servers.insert(
+        "local".to_string(),
+        SelfHostedServerConfig {
+            transport: SelfHostedTransport::OpenAiCompatible,
+            base_url: "http://127.0.0.1:11434".to_string(),
+            api_style: SelfHostedApiStyle::Responses,
+            bearer_token: None,
+            bearer_token_env: None,
+        },
+    );
+    config.self_hosted.models.insert(
+        "gemma-4-31b".to_string(),
+        SelfHostedModelConfig {
+            server: "local".to_string(),
+            remote_model: "gemma4:31b".to_string(),
+            display_name: "Gemma 4 31B".to_string(),
+            family: "gemma-4".to_string(),
+            tier: meerkat_models::ModelTier::Supported,
+            context_window: Some(256_000),
+            max_output_tokens: Some(8_192),
+            vision: true,
+            image_tool_results: true,
+            inline_video: false,
+            supports_temperature: true,
+            supports_thinking: false,
+            supports_reasoning: false,
+            call_timeout_secs: Some(600),
+        },
+    );
+
+    let build_config = AgentBuildConfig {
+        llm_client_override: Some(Arc::new(MockLlmClient)),
+        ..AgentBuildConfig::new("gemma-4-31b")
+    };
+
+    let agent = factory.build_agent(build_config, &config).await.unwrap();
+    let metadata = agent
+        .session()
+        .session_metadata()
+        .expect("session should have metadata");
+
+    assert_eq!(metadata.model, "gemma-4-31b");
+    assert_eq!(metadata.provider, Provider::SelfHosted);
+    assert_eq!(metadata.self_hosted_server_id.as_deref(), Some("local"));
+}
+
 /// 5. `build_agent` with `enable_builtins=true` produces agent with builtin tools.
 #[tokio::test]
 async fn build_agent_with_builtins_has_tools() {
@@ -537,6 +590,7 @@ async fn build_agent_with_resume_uses_stored_metadata() {
         provider_params: Some(json!({
             "reasoning": { "budget_tokens": 2048 }
         })),
+        self_hosted_server_id: None,
         tooling: SessionTooling {
             builtins: ToolCategoryOverride::Enable,
             shell: ToolCategoryOverride::Disable,
@@ -616,6 +670,7 @@ async fn build_agent_with_resume_preserves_explicit_override_masked_fields() {
             provider_params: Some(json!({
                 "reasoning": { "budget_tokens": 2048 }
             })),
+            self_hosted_server_id: None,
             tooling: SessionTooling {
                 builtins: ToolCategoryOverride::Disable,
                 shell: ToolCategoryOverride::Disable,
@@ -692,6 +747,7 @@ async fn build_agent_with_resume_preserves_persisted_system_prompt() {
             structured_output_retries: 2,
             provider: Provider::Anthropic,
             provider_params: None,
+            self_hosted_server_id: None,
             tooling: SessionTooling {
                 builtins: ToolCategoryOverride::Enable,
                 shell: ToolCategoryOverride::Disable,
@@ -743,6 +799,7 @@ async fn build_agent_with_resume_preserves_explicit_inherit_tool_override() {
             structured_output_retries: 2,
             provider: Provider::Anthropic,
             provider_params: None,
+            self_hosted_server_id: None,
             tooling: SessionTooling {
                 builtins: ToolCategoryOverride::Enable,
                 shell: ToolCategoryOverride::Inherit,
@@ -794,6 +851,7 @@ async fn build_agent_with_resume_preserves_session_scoped_inproc_peer_id() {
             structured_output_retries: 2,
             provider: Provider::Anthropic,
             provider_params: None,
+            self_hosted_server_id: None,
             tooling: SessionTooling {
                 builtins: ToolCategoryOverride::Enable,
                 shell: ToolCategoryOverride::Disable,
@@ -870,6 +928,7 @@ async fn build_agent_with_resume_preserves_session_scoped_inproc_peer_id_across_
             structured_output_retries: 2,
             provider: Provider::Anthropic,
             provider_params: None,
+            self_hosted_server_id: None,
             tooling: SessionTooling {
                 builtins: ToolCategoryOverride::Enable,
                 shell: ToolCategoryOverride::Disable,
@@ -1191,6 +1250,7 @@ async fn test_resume_does_not_mutate_persisted_active_skills_when_current_surfac
             structured_output_retries: 2,
             provider: Provider::Anthropic,
             provider_params: None,
+            self_hosted_server_id: None,
             tooling: SessionTooling {
                 builtins: ToolCategoryOverride::Disable,
                 shell: ToolCategoryOverride::Disable,
@@ -1331,6 +1391,7 @@ async fn resume_with_inherit_mob_allows_factory_default() {
             structured_output_retries: 2,
             provider: Provider::Anthropic,
             provider_params: None,
+            self_hosted_server_id: None,
             tooling: SessionTooling {
                 builtins: ToolCategoryOverride::Enable,
                 shell: ToolCategoryOverride::Enable,
@@ -1381,6 +1442,7 @@ async fn resume_with_disable_mob_stays_disabled() {
             structured_output_retries: 2,
             provider: Provider::Anthropic,
             provider_params: None,
+            self_hosted_server_id: None,
             tooling: SessionTooling {
                 builtins: ToolCategoryOverride::Enable,
                 shell: ToolCategoryOverride::Enable,
@@ -1429,6 +1491,7 @@ async fn resume_with_enable_mob_stays_enabled() {
             structured_output_retries: 2,
             provider: Provider::Anthropic,
             provider_params: None,
+            self_hosted_server_id: None,
             tooling: SessionTooling {
                 builtins: ToolCategoryOverride::Enable,
                 shell: ToolCategoryOverride::Enable,
@@ -1499,6 +1562,7 @@ async fn resumed_enable_mob_metadata_does_not_imply_operator_capabilities() {
             structured_output_retries: 2,
             provider: Provider::Anthropic,
             provider_params: None,
+            self_hosted_server_id: None,
             tooling: SessionTooling {
                 builtins: ToolCategoryOverride::Enable,
                 shell: ToolCategoryOverride::Enable,
@@ -1572,6 +1636,7 @@ async fn resumed_explicit_mob_override_generates_create_only_operator_capabiliti
             structured_output_retries: 2,
             provider: Provider::Anthropic,
             provider_params: None,
+            self_hosted_server_id: None,
             tooling: SessionTooling {
                 builtins: ToolCategoryOverride::Enable,
                 shell: ToolCategoryOverride::Enable,
@@ -1663,6 +1728,7 @@ async fn resumed_persisted_mob_authority_is_forwarded_to_mob_tools_factory() {
             structured_output_retries: 2,
             provider: Provider::Anthropic,
             provider_params: None,
+            self_hosted_server_id: None,
             tooling: SessionTooling {
                 builtins: ToolCategoryOverride::Enable,
                 shell: ToolCategoryOverride::Enable,

--- a/tests/integration/src/e2e_lanes.rs
+++ b/tests/integration/src/e2e_lanes.rs
@@ -133,7 +133,17 @@ async fn run_pre_command(
     cwd: &Path,
     env_overrides: &[(String, String)],
 ) -> Result<(), String> {
-    let key = format!("{}::{}", cwd.display(), command_display(entry.command));
+    let env_signature = env_overrides
+        .iter()
+        .map(|(key, value)| format!("{key}={value}"))
+        .collect::<Vec<_>>()
+        .join("\n");
+    let key = format!(
+        "{}::{}::{}",
+        cwd.display(),
+        command_display(entry.command),
+        env_signature
+    );
     {
         let mut completed = completed_pre_commands().lock().unwrap();
         if !completed.insert(key) {


### PR DESCRIPTION
## Summary
- add a config-backed self-hosted model registry and self_hosted provider plumbing across CLI, REST, RPC, MCP, and session metadata
- add an OpenAI-compatible self-hosted client with `responses` and `chat_completions` modes plus dynamic `models/catalog` output and doctor checks
- add Gemma 4 self-hosted docs and correct the Gemma 4 capability/interface guidance to prefer `chat_completions`

## Verification
- `cargo check -q`
- `cargo test -q -p meerkat-core model_registry`
- `cargo test -q -p meerkat-client openai_compatible`
- `cargo test -q -p meerkat-rpc hot_swap_`
- branch push hooks passed (`cargo fmt --check`, `cargo clippy (changed crates)`, machine codegen verify, deterministic gate)

## Known issue
- full multi-crate test runs still have a remaining RPC regression in `session_inject_context_during_active_turn_waits_for_next_rpc_turn`; this branch is opened as draft because that race is not fully resolved yet.