### PR TITLE
Wire realm profile store and expose tooling in tool schemas

### DIFF
--- a/meerkat-mob-mcp/src/agent_tools.rs
+++ b/meerkat-mob-mcp/src/agent_tools.rs
@@ -1103,7 +1103,8 @@ fn build_tool_defs_with_profile_support(
         tool_def(
             TOOL_DELEGATE,
             "Delegate a task to a helper agent. Creates an implicit mob on first use, \
-             spawns a member with auto-wiring to you. Use for quick one-off delegation.",
+             spawns a member with auto-wiring to you. Use for quick one-off delegation. \
+             Use 'tooling' to control the helper's model/tools.",
             json!({
                 "type": "object",
                 "properties": {
@@ -1118,6 +1119,10 @@ fn build_tool_defs_with_profile_support(
                     "additional_instructions": {
                         "type": "string",
                         "description": "Extra instructions appended to the helper's system prompt"
+                    },
+                    "tooling": {
+                        "type": "object",
+                        "description": "Spawn tooling mode. Controls the helper's model and tool surface. Options: {\"mode\":\"inherit_parent\"} (default, inherits your tools), {\"mode\":\"minimal\"} (comms only), or {\"mode\":\"profile\",\"source\":{\"type\":\"realm_profile\",\"name\":\"...\"}} / {\"mode\":\"profile\",\"source\":{\"type\":\"inline\",\"model\":\"...\",\"tools\":{...}}}. Overlays: allow_overlay/deny_overlay arrays narrow the tool set."
                     }
                 },
                 "required": ["task"]
@@ -1150,12 +1155,12 @@ fn build_tool_defs_with_profile_support(
         ),
         tool_def(
             TOOL_MOB_SPAWN_MEMBER,
-            "Spawn a new member into a mob from a profile.",
+            "Spawn a new member into a mob from a profile. Use 'tooling' to override model/tools.",
             json!({
                 "type": "object",
                 "properties": {
                     "mob_id": {"type": "string"},
-                    "profile": {"type": "string", "description": "Profile name to spawn from"},
+                    "profile": {"type": "string", "description": "Role name (profile key) in the mob definition"},
                     "member_id": {"type": "string", "description": "Unique member identifier"},
                     "initial_message": {
                         "oneOf": [
@@ -1176,6 +1181,10 @@ fn build_tool_defs_with_profile_support(
                     "auto_wire_parent": {
                         "type": "boolean",
                         "description": "Auto-wire to spawner after spawn"
+                    },
+                    "tooling": {
+                        "type": "object",
+                        "description": "Spawn tooling override. Controls the member's model and tool surface instead of using the definition profile. Options: {\"mode\":\"inherit_parent\"} (inherit your tools), {\"mode\":\"minimal\"} (comms only), or {\"mode\":\"profile\",\"source\":{\"type\":\"realm_profile\",\"name\":\"...\"}} / {\"mode\":\"profile\",\"source\":{\"type\":\"inline\",\"model\":\"...\",\"tools\":{...}}}. Overlays: allow_overlay/deny_overlay arrays narrow the tool set."
                     }
                 },
                 "required": ["mob_id", "profile", "member_id"]

--- a/meerkat-mob-mcp/src/agent_tools.rs
+++ b/meerkat-mob-mcp/src/agent_tools.rs
@@ -850,6 +850,9 @@ impl AgentMobToolSurface {
         Self::encode_result(call, json!({"mobs": mob_list}))
     }
     // ─── Profile CRUD dispatch ────────────────────────────────────────
+    // TODO: Profile mutation authority. Currently gated on mob capability + store
+    // availability. Per-profile authority checks are a follow-up concern for
+    // multi-tenant realm scenarios.
 
     async fn dispatch_mob_profile_create(
         &self,

--- a/meerkat-mob-mcp/src/lib.rs
+++ b/meerkat-mob-mcp/src/lib.rs
@@ -147,7 +147,19 @@ impl MobMcpState {
     }
 
     pub fn with_persistent_storage_root(mut self, runtime_root: Option<PathBuf>) -> Self {
-        self.persistent_storage_root = runtime_root.map(|root| Self::persistent_mob_root(&root));
+        self.persistent_storage_root = runtime_root.map(|root| {
+            let mob_root = Self::persistent_mob_root(&root);
+            // Auto-create realm profile store when persistent storage is available.
+            #[cfg(not(target_arch = "wasm32"))]
+            if self.realm_profile_store.is_none() {
+                let db_path = mob_root.join("realm_profiles.db");
+                if let Ok(store) = meerkat_mob::SqliteRealmProfileStore::open(&db_path) {
+                    self.realm_profile_store =
+                        Some(Arc::new(store) as Arc<dyn meerkat_mob::RealmProfileStore>);
+                }
+            }
+            mob_root
+        });
         self
     }
 

--- a/meerkat-mob-mcp/src/lib.rs
+++ b/meerkat-mob-mcp/src/lib.rs
@@ -153,9 +153,17 @@ impl MobMcpState {
             #[cfg(not(target_arch = "wasm32"))]
             if self.realm_profile_store.is_none() {
                 let db_path = mob_root.join("realm_profiles.db");
-                if let Ok(store) = meerkat_mob::SqliteRealmProfileStore::open(&db_path) {
-                    self.realm_profile_store =
-                        Some(Arc::new(store) as Arc<dyn meerkat_mob::RealmProfileStore>);
+                match meerkat_mob::SqliteRealmProfileStore::open(&db_path) {
+                    Ok(store) => {
+                        self.realm_profile_store =
+                            Some(Arc::new(store) as Arc<dyn meerkat_mob::RealmProfileStore>);
+                    }
+                    Err(e) => {
+                        tracing::warn!(
+                            "failed to create realm profile store at {}: {e}",
+                            db_path.display()
+                        );
+                    }
                 }
             }
             mob_root

--- a/meerkat-mob/src/store/sqlite.rs
+++ b/meerkat-mob/src/store/sqlite.rs
@@ -1356,8 +1356,10 @@ impl SqliteRealmProfileStore {
         let conn = rusqlite::Connection::open(db_path).map_err(|e| {
             MobStoreError::Internal(format!("failed to open realm profile store: {e}"))
         })?;
-        conn.execute_batch("PRAGMA journal_mode=WAL; PRAGMA busy_timeout=5000;")
-            .map_err(se)?;
+        conn.execute_batch(
+            "PRAGMA journal_mode=WAL; PRAGMA busy_timeout=5000; PRAGMA synchronous=FULL;",
+        )
+        .map_err(se)?;
         conn.execute_batch(
             "CREATE TABLE IF NOT EXISTS realm_profiles (
                 name TEXT PRIMARY KEY,
@@ -2004,5 +2006,74 @@ mod tests {
     async fn realm_profile_list_empty() {
         let (_dir, store) = sqlite_realm_profile_store();
         contract_tests::test_list_empty(&store).await;
+    }
+
+    // -----------------------------------------------------------------------
+    // SqliteRealmProfileStore::open() standalone constructor tests
+    // -----------------------------------------------------------------------
+
+    #[tokio::test]
+    async fn sqlite_realm_profile_store_open_creates_directory() {
+        let dir = tempfile::tempdir().unwrap();
+        let nested = dir.path().join("a").join("b").join("realm_profiles.db");
+        assert!(!nested.parent().unwrap().exists());
+        let _store = SqliteRealmProfileStore::open(&nested).unwrap();
+        assert!(nested.parent().unwrap().exists());
+    }
+
+    #[tokio::test]
+    async fn sqlite_realm_profile_store_open_roundtrip() {
+        let dir = tempfile::tempdir().unwrap();
+        let db_path = dir.path().join("realm_profiles.db");
+
+        // First open: create a profile.
+        {
+            let store = SqliteRealmProfileStore::open(&db_path).unwrap();
+            let profile = Profile {
+                model: "claude-sonnet-4-5".into(),
+                skills: Vec::new(),
+                tools: ToolConfig::default(),
+                peer_description: String::new(),
+                external_addressable: false,
+                backend: None,
+                runtime_mode: crate::MobRuntimeMode::AutonomousHost,
+                max_inline_peer_notifications: None,
+                output_schema: None,
+                provider_params: None,
+            };
+            store.create("test-profile", &profile).await.unwrap();
+        }
+
+        // Second open: must see the profile from the first session.
+        {
+            let store = SqliteRealmProfileStore::open(&db_path).unwrap();
+            let got = store.get("test-profile").await.unwrap();
+            assert!(got.is_some(), "profile must survive reopen");
+            assert_eq!(got.unwrap().profile.model, "claude-sonnet-4-5");
+        }
+    }
+
+    #[tokio::test]
+    async fn sqlite_realm_profile_store_open_contract_create_and_get() {
+        let dir = tempfile::tempdir().unwrap();
+        let db_path = dir.path().join("realm_profiles.db");
+        let store = SqliteRealmProfileStore::open(&db_path).unwrap();
+        contract_tests::test_create_and_get(&store).await;
+    }
+
+    #[tokio::test]
+    async fn sqlite_realm_profile_store_open_contract_get_nonexistent() {
+        let dir = tempfile::tempdir().unwrap();
+        let db_path = dir.path().join("realm_profiles.db");
+        let store = SqliteRealmProfileStore::open(&db_path).unwrap();
+        contract_tests::test_get_nonexistent(&store).await;
+    }
+
+    #[tokio::test]
+    async fn sqlite_realm_profile_store_open_contract_list() {
+        let dir = tempfile::tempdir().unwrap();
+        let db_path = dir.path().join("realm_profiles.db");
+        let store = SqliteRealmProfileStore::open(&db_path).unwrap();
+        contract_tests::test_list(&store).await;
     }
 }

--- a/meerkat-mob/src/store/sqlite.rs
+++ b/meerkat-mob/src/store/sqlite.rs
@@ -1341,6 +1341,39 @@ pub struct SqliteRealmProfileStore {
     path: PathBuf,
 }
 
+impl SqliteRealmProfileStore {
+    /// Open a standalone realm profile store at the given database path.
+    ///
+    /// Creates the parent directory and initializes the schema if needed.
+    pub fn open(db_path: &std::path::Path) -> Result<Self, MobStoreError> {
+        if let Some(parent) = db_path.parent() {
+            std::fs::create_dir_all(parent).map_err(|e| {
+                MobStoreError::Internal(format!(
+                    "failed to create realm profile store directory: {e}"
+                ))
+            })?;
+        }
+        let conn = rusqlite::Connection::open(db_path).map_err(|e| {
+            MobStoreError::Internal(format!("failed to open realm profile store: {e}"))
+        })?;
+        conn.execute_batch("PRAGMA journal_mode=WAL; PRAGMA busy_timeout=5000;")
+            .map_err(se)?;
+        conn.execute_batch(
+            "CREATE TABLE IF NOT EXISTS realm_profiles (
+                name TEXT PRIMARY KEY,
+                profile_json BLOB NOT NULL,
+                revision INTEGER NOT NULL DEFAULT 1,
+                created_at TEXT NOT NULL,
+                updated_at TEXT NOT NULL
+            )",
+        )
+        .map_err(se)?;
+        Ok(Self {
+            path: db_path.to_path_buf(),
+        })
+    }
+}
+
 impl std::fmt::Debug for SqliteRealmProfileStore {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("SqliteRealmProfileStore")


### PR DESCRIPTION
## Summary

- Add `SqliteRealmProfileStore::open()` standalone constructor for creating realm-level profile stores
- Auto-wire realm profile store in `MobMcpState::with_persistent_storage_root()` so all runtime surfaces (RPC, CLI, REST, MCP) automatically get profile CRUD tools (`mob_profile_create/get/list/update/delete`)
- Add `tooling` parameter to `delegate` and `mob_spawn_member` JSON tool schemas so agents can see and use profile/model customization

Without this fix, agents had no way to discover or use the profile CRUD tools (store was never wired), and the tooling parameter was invisible in tool schemas.

## Test plan
- [x] 3976 tests pass
- [x] Clippy clean
- [x] Pre-push hooks pass
- [ ] Verify agent sees profile CRUD tools after fix
- [ ] Verify delegate tool shows tooling parameter

🤖 Generated with [Claude Code](https://claude.com/claude-code)