### PR TITLE
Wire targets as mesh peers via kennel PeerWire relay

### DIFF
--- a/examples/035-mdm-tux-rs/src/bin/kennel.rs
+++ b/examples/035-mdm-tux-rs/src/bin/kennel.rs
@@ -253,6 +253,10 @@ async fn main() -> anyhow::Result<()> {
                  Use the 'peers' tool to discover which targets are connected.\n\
                  Use 'send_request' to dispatch tasks to targets and collect responses.\n\
                  Use 'send_message' for fire-and-forget notifications.\n\
+                 Use 'mob_wire' to create direct comms links between targets so they \
+                 can communicate peer-to-peer without routing through you.\n\
+                 Use 'mob_unwire' to remove peer-to-peer links between targets.\n\
+                 Use 'mob_list_members' to see which targets are in the fleet.\n\
                  Always check peers first to see who is available before dispatching work."
                     .to_string(),
             );
@@ -545,6 +549,43 @@ async fn handle_connection(
                                     eprintln!(
                                         "[kennel] mob spawn {name}: {e} (peer still updated)"
                                     );
+                                }
+                            }
+                        }
+
+                        // Mesh-wire: tell the new target about all existing targets
+                        // and tell each existing target about the new one.
+                        {
+                            let guard = state.lock();
+                            for (tid, rec) in &guard.targets {
+                                if tid == target_id {
+                                    continue;
+                                }
+                                // Tell new target about existing peer
+                                let wire_new = build_signed_envelope(
+                                    &keypair,
+                                    &kennel_id,
+                                    KennelPayload::PeerWire {
+                                        peer_name: rec.name.clone(),
+                                        peer_id: rec.pubkey.clone(),
+                                        peer_addr: rec.direct_addr.clone(),
+                                    },
+                                );
+                                if let Ok(env) = wire_new {
+                                    let _ = tx.send(env);
+                                }
+                                // Tell existing peer about new target
+                                let wire_existing = build_signed_envelope(
+                                    &keypair,
+                                    &kennel_id,
+                                    KennelPayload::PeerWire {
+                                        peer_name: name.clone(),
+                                        peer_id: pubkey.clone(),
+                                        peer_addr: direct_addr.clone(),
+                                    },
+                                );
+                                if let Ok(env) = wire_existing {
+                                    let _ = rec.tx.send(env);
                                 }
                             }
                         }

--- a/examples/035-mdm-tux-rs/src/bin/target.rs
+++ b/examples/035-mdm-tux-rs/src/bin/target.rs
@@ -1637,6 +1637,23 @@ async fn run_kennel_mode(args: &[String]) -> anyhow::Result<()> {
                             ))?;
                             bail!("kennel rejected target re-registration ({reason:?}): {message}");
                         }
+                        KennelPayload::PeerWire { peer_name, peer_id, peer_addr } => {
+                            if let Ok(pk) = meerkat_comms::identity::PubKey::from_peer_id(&peer_id) {
+                                comms_runtime.upsert_trusted_peer(meerkat_comms::TrustedPeer {
+                                    name: peer_name.clone(),
+                                    pubkey: pk,
+                                    addr: peer_addr.clone(),
+                                    meta: meerkat_comms::PeerMeta::default(),
+                                });
+                                eprintln!("[target] peer wired: {peer_name} at {peer_addr}");
+                            }
+                        }
+                        KennelPayload::PeerUnwire { peer_id } => {
+                            if let Ok(pk) = meerkat_comms::identity::PubKey::from_peer_id(&peer_id) {
+                                comms_runtime.router_arc().remove_trusted_peer(&pk);
+                                eprintln!("[target] peer unwired: {peer_id}");
+                            }
+                        }
                         _ => {}
                     }
                 }

--- a/examples/035-mdm-tux-rs/src/kennel.rs
+++ b/examples/035-mdm-tux-rs/src/kennel.rs
@@ -195,6 +195,21 @@ pub enum KennelPayload {
     HiveError {
         message: String,
     },
+    /// Kennel tells a target to add another target as a trusted comms peer.
+    /// Sent to both sides when the kennel wires two targets together.
+    PeerWire {
+        /// Human-readable name for the peer (the other target's name).
+        peer_name: String,
+        /// Comms public key of the peer (ed25519 peer ID).
+        peer_id: String,
+        /// Comms transport address of the peer (tcp://host:port).
+        peer_addr: String,
+    },
+    /// Kennel tells a target to remove another target from its trusted peers.
+    PeerUnwire {
+        /// Comms public key of the peer to remove.
+        peer_id: String,
+    },
     Error {
         message: String,
     },


### PR DESCRIPTION
## Summary

- **PeerWire/PeerUnwire kennel payloads** — kennel tells targets to add/remove each other as trusted comms peers
- **Mesh wiring at registration** — when a target registers, the kennel sends PeerWire to all existing targets and vice versa, creating an all-to-all comms mesh
- **Target handles PeerWire** — calls `upsert_trusted_peer` so targets can communicate directly without routing through the hive
- **Hive system prompt updated** — mentions `mob_wire`, `mob_unwire`, `mob_list_members` tools

Builds on #238 (RuntimeBinding). Targets now have direct peer-to-peer comms links established at registration time.

## Test plan

- [x] 8 kennel protocol tests pass
- [x] 4098 workspace tests pass
- [x] Clippy clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)