### PR TITLE
Fix abandoned runtime retry spin loop

### DIFF
--- a/meerkat-runtime/src/driver/ephemeral.rs
+++ b/meerkat-runtime/src/driver/ephemeral.rs
@@ -714,28 +714,35 @@ impl EphemeralRuntimeDriver {
     }
 
     pub fn rollback_staged(&mut self, input_ids: &[InputId]) -> Result<(), InputLifecycleError> {
+        let mut terminal_inputs = Vec::new();
+
         for input_id in input_ids {
-            let mut requeue_input = None;
-            let mut is_steer = false;
             if let Some(state) = self.ledger.get_mut(input_id) {
                 match state.apply(InputLifecycleInput::RollbackStaged) {
                     Ok(transition) => {
-                        // Only re-enqueue if the transition went to Queued.
-                        // If max attempts exhausted, the machine transitions
-                        // to Abandoned — do not re-enqueue.
-                        if transition.next_phase == crate::input_state::InputLifecycleState::Queued
+                        if transition.next_phase != crate::input_state::InputLifecycleState::Queued
                         {
-                            requeue_input = state.persisted_input.clone();
-                            is_steer = requeue_input
-                                .as_ref()
-                                .and_then(super::super::input::Input::handling_mode)
-                                == Some(HandlingMode::Steer);
-                        } else {
                             tracing::warn!(
                                 input_id = %input_id,
                                 next_phase = ?transition.next_phase,
                                 "input abandoned after max stage attempts"
                             );
+                            if let Some(outcome) = state.terminal_outcome().cloned() {
+                                terminal_inputs.push((input_id.clone(), outcome.clone()));
+                                if let crate::input_state::InputTerminalOutcome::Abandoned {
+                                    reason,
+                                } = outcome
+                                {
+                                    self.events.push(self.make_envelope(
+                                        RuntimeEvent::InputLifecycle(
+                                            InputLifecycleEvent::Abandoned {
+                                                input_id: input_id.clone(),
+                                                reason: format!("{reason:?}"),
+                                            },
+                                        ),
+                                    ));
+                                }
+                            }
                         }
                     }
                     Err(
@@ -745,16 +752,25 @@ impl EphemeralRuntimeDriver {
                     Err(err) => return Err(err),
                 }
             }
-            if !self.has_queued_input(input_id)
-                && let Some(input) = requeue_input
+        }
+
+        if !terminal_inputs.is_empty() {
+            match self
+                .ingress
+                .apply(RuntimeIngressInput::ReconcileTerminalInputs { terminal_inputs })
             {
-                if is_steer {
-                    self.steer_queue.enqueue(input_id.clone(), input);
-                } else {
-                    self.queue.enqueue(input_id.clone(), input);
+                Ok(transition) => {
+                    self.process_ingress_effects(&transition.effects);
+                }
+                Err(err) => {
+                    tracing::warn!(
+                        error = %err,
+                        "ingress authority rejected ReconcileTerminalInputs"
+                    );
                 }
             }
         }
+
         self.rebuild_queue_projections();
         self.debug_assert_queue_projection_alignment();
         Ok(())

--- a/meerkat-runtime/src/runtime_ingress_authority.rs
+++ b/meerkat-runtime/src/runtime_ingress_authority.rs
@@ -9,10 +9,10 @@
 //! the machine schema in `meerkat-machine-schema/src/catalog/runtime_ingress.rs`:
 //!
 //! - 3 phases: Active, Retired, Destroyed
-//! - 15 inputs: AdmitQueued, AdmitConsumedOnAccept, AdmitDeduplicated, StageDrainSnapshot,
+//! - 16 inputs: AdmitQueued, AdmitConsumedOnAccept, AdmitDeduplicated, StageDrainSnapshot,
 //!   BoundaryApplied, RunCompleted, RunFailed, RunCancelled,
 //!   SupersedeQueuedInput, CoalesceQueuedInputs, Retire, Reset, Destroy,
-//!   Recover, SetSilentIntentOverrides
+//!   Recover, ReconcileTerminalInputs, SetSilentIntentOverrides
 //! - 18 fields: admitted_inputs, admission_order, content_shape, request_id,
 //!   reservation_key, policy_snapshot, handling_mode, lifecycle,
 //!   terminal_outcome, queue, steer_queue, current_run, current_run_contributors,
@@ -156,6 +156,11 @@ pub enum RuntimeIngressInput {
     },
     /// Recover: re-derive transient state from canonical state.
     Recover,
+    /// Reconcile inputs that became terminal outside the ingress authority's
+    /// local retry bookkeeping.
+    ReconcileTerminalInputs {
+        terminal_inputs: Vec<(InputId, InputTerminalOutcome)>,
+    },
     /// Configure silent intent overrides.
     SetSilentIntentOverrides { intents: BTreeSet<String> },
 }
@@ -718,6 +723,9 @@ impl RuntimeIngressAuthority {
             RuntimeIngressInput::Reset => self.eval_reset(phase),
             RuntimeIngressInput::Destroy => self.eval_destroy(phase),
             RuntimeIngressInput::Recover => self.eval_recover(phase),
+            RuntimeIngressInput::ReconcileTerminalInputs { terminal_inputs } => {
+                self.eval_reconcile_terminal_inputs(phase, terminal_inputs)
+            }
 
             RuntimeIngressInput::SetSilentIntentOverrides { intents } => {
                 self.eval_set_silent_intent_overrides(phase, intents)
@@ -1910,6 +1918,66 @@ impl RuntimeIngressAuthority {
         Ok((phase, fields, effects))
     }
 
+    fn eval_reconcile_terminal_inputs(
+        &self,
+        phase: IngressPhase,
+        terminal_inputs: &[(InputId, InputTerminalOutcome)],
+    ) -> Result<
+        (
+            IngressPhase,
+            RuntimeIngressFields,
+            Vec<RuntimeIngressEffect>,
+        ),
+        RuntimeIngressError,
+    > {
+        if !matches!(phase, IngressPhase::Active | IngressPhase::Retired) {
+            return Err(RuntimeIngressError::InvalidTransition {
+                from: phase,
+                input: "ReconcileTerminalInputs".into(),
+            });
+        }
+
+        let mut fields = self.fields.clone();
+        let mut effects = Vec::new();
+
+        for (work_id, outcome) in terminal_inputs {
+            if !fields.admitted_inputs.contains(work_id) {
+                continue;
+            }
+
+            fields.queue.retain(|id| id != work_id);
+            fields.steer_queue.retain(|id| id != work_id);
+
+            let terminal_state = match outcome {
+                InputTerminalOutcome::Consumed => InputLifecycleState::Consumed,
+                InputTerminalOutcome::Superseded { .. } => InputLifecycleState::Superseded,
+                InputTerminalOutcome::Coalesced { .. } => InputLifecycleState::Coalesced,
+                InputTerminalOutcome::Abandoned { .. } => InputLifecycleState::Abandoned,
+            };
+
+            fields.lifecycle.insert(work_id.clone(), terminal_state);
+            fields
+                .terminal_outcome
+                .insert(work_id.clone(), Some(outcome.clone()));
+
+            effects.push(RuntimeIngressEffect::InputLifecycleNotice {
+                work_id: work_id.clone(),
+                new_state: terminal_state,
+            });
+            effects.push(RuntimeIngressEffect::CompletionResolved {
+                work_id: work_id.clone(),
+                outcome: outcome.clone(),
+            });
+        }
+
+        if fields.queue.is_empty() && fields.steer_queue.is_empty() {
+            fields.wake_requested = false;
+            fields.process_requested = false;
+        }
+
+        Ok((phase, fields, effects))
+    }
+
     fn eval_set_silent_intent_overrides(
         &self,
         phase: IngressPhase,
@@ -2470,6 +2538,49 @@ mod tests {
         assert!(auth.queue().contains(&w1));
         assert!(auth.current_run().is_none());
         assert!(auth.wake_requested());
+    }
+
+    #[test]
+    fn reconcile_terminal_inputs_prunes_requeued_terminal_work() {
+        let mut auth = RuntimeIngressAuthority::new();
+        let w1 = InputId::new();
+        admit_queued(&mut auth, w1.clone(), HandlingMode::Queue);
+
+        let run_id = RunId::new();
+        auth.apply(RuntimeIngressInput::StageDrainSnapshot {
+            run_id: run_id.clone(),
+            contributing_work_ids: vec![w1.clone()],
+        })
+        .unwrap();
+        auth.apply(RuntimeIngressInput::RunFailed { run_id })
+            .unwrap();
+
+        let transition = auth
+            .apply(RuntimeIngressInput::ReconcileTerminalInputs {
+                terminal_inputs: vec![(
+                    w1.clone(),
+                    InputTerminalOutcome::Abandoned {
+                        reason: crate::input_state::InputAbandonReason::MaxAttemptsExhausted {
+                            attempts: 3,
+                        },
+                    },
+                )],
+            })
+            .expect("reconcile terminal inputs should succeed");
+
+        assert_eq!(
+            auth.lifecycle_state(&w1),
+            Some(InputLifecycleState::Abandoned)
+        );
+        assert!(!auth.queue().contains(&w1));
+        assert!(!auth.wake_requested());
+        assert!(transition.effects.iter().any(|effect| matches!(
+            effect,
+            RuntimeIngressEffect::CompletionResolved {
+                work_id,
+                outcome: InputTerminalOutcome::Abandoned { .. },
+            } if work_id == &w1
+        )));
     }
 
     // ---- RunCancelled ----

--- a/meerkat-runtime/tests/session_adapter.rs
+++ b/meerkat-runtime/tests/session_adapter.rs
@@ -677,9 +677,9 @@ async fn accept_with_executor_triggers_loop() {
     assert!(active.is_empty(), "All inputs should be consumed");
 }
 
-/// Test that a failed executor re-queues the input (not stranded in APC).
+/// Test that a failed executor never strands the input in APC.
 #[tokio::test]
-async fn failed_executor_requeues_input() {
+async fn failed_executor_does_not_strand_input_in_apc() {
     use meerkat_core::lifecycle::core_executor::{
         CoreApplyOutput, CoreExecutor, CoreExecutorError,
     };
@@ -722,12 +722,88 @@ async fn failed_executor_requeues_input() {
     let state = adapter.runtime_state(&sid).await.unwrap();
     assert_eq!(state, RuntimeState::Attached);
 
-    // Input should be rolled back to Queued (not stranded in APC)
+    // Input should roll back or abandon after retry exhaustion, but never
+    // remain stuck in an in-flight lifecycle state.
     let is = adapter.input_state(&sid, &input_id).await.unwrap().unwrap();
+    assert!(
+        matches!(
+            is.current_state(),
+            InputLifecycleState::Queued | InputLifecycleState::Abandoned
+        ),
+        "Failed execution should roll input back or abandon it after retry budget exhaustion, not strand it in AppliedPendingConsumption"
+    );
+}
+
+#[tokio::test]
+async fn failed_executor_stops_retrying_after_stage_budget_exhausted() {
+    use meerkat_core::lifecycle::core_executor::{
+        CoreApplyOutput, CoreExecutor, CoreExecutorError,
+    };
+    use meerkat_core::lifecycle::run_control::RunControlCommand;
+    use meerkat_core::lifecycle::run_primitive::RunPrimitive;
+    use meerkat_runtime::input_state::InputLifecycleState;
+
+    struct CountingFailExecutor {
+        calls: Arc<AtomicUsize>,
+    }
+
+    #[async_trait::async_trait]
+    impl CoreExecutor for CountingFailExecutor {
+        async fn apply(
+            &mut self,
+            _run_id: RunId,
+            _primitive: RunPrimitive,
+        ) -> Result<CoreApplyOutput, CoreExecutorError> {
+            self.calls.fetch_add(1, Ordering::SeqCst);
+            Err(CoreExecutorError::ApplyFailed {
+                reason: "always fails".into(),
+            })
+        }
+
+        async fn control(&mut self, _cmd: RunControlCommand) -> Result<(), CoreExecutorError> {
+            Ok(())
+        }
+    }
+
+    let calls = Arc::new(AtomicUsize::new(0));
+    let adapter = RuntimeSessionAdapter::ephemeral();
+    let sid = SessionId::new();
+    adapter
+        .register_session_with_executor(
+            sid.clone(),
+            Box::new(CountingFailExecutor {
+                calls: Arc::clone(&calls),
+            }),
+        )
+        .await;
+
+    let input = make_prompt("hello failing forever");
+    let input_id = input.id().clone();
+    adapter.accept_input(&sid, input).await.unwrap();
+
+    tokio::time::sleep(Duration::from_millis(500)).await;
+
+    let call_count = calls.load(Ordering::SeqCst);
+    assert!(
+        (1..=3).contains(&call_count),
+        "retry budget should remain bounded; expected 1-3 attempts, saw {call_count}"
+    );
+
+    let state = adapter.input_state(&sid, &input_id).await.unwrap().unwrap();
+    assert!(
+        !matches!(
+            state.current_state(),
+            InputLifecycleState::Staged | InputLifecycleState::AppliedPendingConsumption
+        ),
+        "failed inputs must not remain stuck in an in-flight lifecycle state"
+    );
+
+    tokio::time::sleep(Duration::from_millis(150)).await;
+
     assert_eq!(
-        is.current_state(),
-        InputLifecycleState::Queued,
-        "Failed execution should roll input back to Queued, not strand in AppliedPendingConsumption"
+        calls.load(Ordering::SeqCst),
+        call_count,
+        "failed inputs must not keep spinning through fresh run ids"
     );
 }
 


### PR DESCRIPTION
## Summary
- reconcile retry-exhausted inputs back into runtime ingress so abandoned work is pruned from canonical queues before the next wake
- keep failed runtime inputs out of in-flight lifecycle states while bounding retry attempts
- add regressions for ingress reconciliation and bounded retry behavior

## Testing
- cargo test -p meerkat-runtime --test session_adapter failed_executor_does_not_strand_input_in_apc -- --nocapture
- cargo test -p meerkat-runtime --test session_adapter failed_executor_stops_retrying_after_stage_budget_exhausted -- --nocapture
- cargo test -p meerkat-runtime reconcile_terminal_inputs_prunes_requeued_terminal_work -- --nocapture