### PR TITLE
Fix stale CI assertions on main

### DIFF
--- a/meerkat-cli/src/main.rs
+++ b/meerkat-cli/src/main.rs
@@ -8560,7 +8560,7 @@ mod tests {
         let top = render_help(Cli::command());
         assert!(top.contains("Usage: rkat [OPTIONS] <PROMPT>"));
         assert!(top.contains("cat story.txt | rkat \"summarize the story\""));
-        assert!(top.contains("tail -f app.log | rkat --stdin lines"));
+        assert!(top.contains("tail -f app.log | rkat run --stdin lines"));
 
         let run = render_help(Cli::command().find_subcommand("run").unwrap().clone());
         assert!(run.contains("--tools <TOOLS>"));

--- a/meerkat-rpc/tests/regression_rpc.rs
+++ b/meerkat-rpc/tests/regression_rpc.rs
@@ -12,6 +12,7 @@ use async_trait::async_trait;
 use futures::stream;
 use meerkat::AgentFactory;
 use meerkat_client::{LlmClient, LlmError};
+use meerkat_contracts::ContractVersion;
 use meerkat_core::{BlobStore, Config, ConfigRuntime, MemoryConfigStore, StopReason};
 use meerkat_rpc::server::RpcServer;
 use meerkat_rpc::session_runtime::SessionRuntime;
@@ -790,10 +791,11 @@ async fn initialize_methods_list_complete() {
     send_request(&mut writer, &req).await;
     let resp = read_response(&mut reader).await;
     assert!(resp["error"].is_null(), "initialize failed: {resp}");
+    let expected_contract_version = ContractVersion::CURRENT.to_string();
 
     assert_eq!(
         resp["result"]["contract_version"].as_str(),
-        Some("0.5.1"),
+        Some(expected_contract_version.as_str()),
         "initialize must report the current contract version"
     );
 


### PR DESCRIPTION
## Summary
- update the RPC initialize regression to follow `ContractVersion::CURRENT` instead of a stale hard-coded version
- update the rkat help snapshot to match the current `run --stdin lines` example shown by the CLI

## Testing
- ./scripts/repo-cargo test -p meerkat-rpc --test regression_rpc initialize_methods_list_complete -- --nocapture
- ./scripts/repo-cargo test -p rkat test_help_snapshots_cover_current_public_surface -- --nocapture