### PR TITLE
W1-B: Typed drop-reasons + canonical terminal classification

### DIFF
--- a/meerkat-comms/src/agent/manager.rs
+++ b/meerkat-comms/src/agent/manager.rs
@@ -250,6 +250,7 @@ mod tests {
         manager
             .inbox_sender()
             .send(InboxItem::External { envelope })
+            .into_result()
             .unwrap();
 
         // Give tokio a moment to process

--- a/meerkat-comms/src/event_injector.rs
+++ b/meerkat-comms/src/event_injector.rs
@@ -1,6 +1,6 @@
 //! Concrete `EventInjector` implementation wrapping `InboxSender`.
 
-use crate::inbox::{InboxError, InboxSender};
+use crate::inbox::{AdmissionOutcome, DropReason, InboxSender};
 #[cfg(target_arch = "wasm32")]
 use crate::tokio;
 use crate::types::InboxItem;
@@ -57,19 +57,31 @@ impl EventInjector for CommsEventInjector {
             ContentInput::Text(_) => None,
             ContentInput::Blocks(blocks) => Some(blocks),
         };
-        self.sender
-            .send_classified(InboxItem::PlainEvent {
-                body,
-                source,
-                handling_mode,
-                interaction_id: None,
-                blocks,
-                render_metadata,
-            })
-            .map_err(|e| match e {
-                InboxError::Full => EventInjectorError::Full,
-                InboxError::Closed => EventInjectorError::Closed,
-            })
+        match self.sender.send_classified(InboxItem::PlainEvent {
+            body,
+            source,
+            handling_mode,
+            interaction_id: None,
+            blocks,
+            render_metadata,
+        }) {
+            AdmissionOutcome::Admitted => Ok(()),
+            AdmissionOutcome::Dropped { reason } => Err(drop_reason_to_injector_error(reason)),
+        }
+    }
+}
+
+fn drop_reason_to_injector_error(reason: DropReason) -> EventInjectorError {
+    match reason {
+        DropReason::InboxFull => EventInjectorError::Full,
+        DropReason::SessionClosed => EventInjectorError::Closed,
+        // Plain events never hit the peer-auth gate (auth classification is
+        // external-envelope-only), but an ingress-stage rejection still maps
+        // to Closed from the caller's perspective — the event did not reach
+        // the agent.
+        DropReason::UntrustedSender | DropReason::ClassificationRejected => {
+            EventInjectorError::Closed
+        }
     }
 }
 
@@ -93,20 +105,19 @@ impl meerkat_core::event_injector::SubscribableInjector for CommsEventInjector {
         self.subscriber_registry.lock().insert(id, tx);
 
         // Send to inbox with interaction_id
-        if let Err(e) = self.sender.send_classified(InboxItem::PlainEvent {
-            body,
-            source,
-            handling_mode,
-            interaction_id: Some(id),
-            blocks,
-            render_metadata,
-        }) {
+        if let AdmissionOutcome::Dropped { reason } =
+            self.sender.send_classified(InboxItem::PlainEvent {
+                body,
+                source,
+                handling_mode,
+                interaction_id: Some(id),
+                blocks,
+                render_metadata,
+            })
+        {
             // Clean up subscriber on send failure
             self.subscriber_registry.lock().remove(&id);
-            return Err(match e {
-                InboxError::Full => EventInjectorError::Full,
-                InboxError::Closed => EventInjectorError::Closed,
-            });
+            return Err(drop_reason_to_injector_error(reason));
         }
 
         Ok(meerkat_core::event_injector::InteractionSubscription {

--- a/meerkat-comms/src/inbox.rs
+++ b/meerkat-comms/src/inbox.rs
@@ -10,6 +10,7 @@ use crate::tokio;
 use parking_lot::Mutex;
 use std::collections::VecDeque;
 use std::sync::Arc;
+use std::sync::atomic::{AtomicU64, Ordering};
 use tokio::sync::{Notify, mpsc};
 
 use crate::classify::IngressClassificationContext;
@@ -23,6 +24,52 @@ use meerkat_core::{
 use std::collections::BTreeSet;
 
 const DEFAULT_INBOX_CAPACITY: usize = 1024;
+
+/// Reason an ingress item was dropped before it reached the classified queue.
+///
+/// Every variant is a semantic failure mode — the envelope or event did not
+/// reach the agent. Silent `Ok(())` used to mask these; now they are typed,
+/// logged, and counted so tests can pin down "zero drops on the happy path".
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum DropReason {
+    /// `require_peer_auth` is on, the sender is not in the trusted set, and
+    /// the envelope is not auth-exempt (e.g. supervisor-bridge bootstrap).
+    UntrustedSender,
+    /// Classification rejected the item (e.g. pre-trust policy drop in the
+    /// classification context before it ever reached the admission gate).
+    ClassificationRejected,
+    /// The classified queue is closed (receiver dropped).
+    SessionClosed,
+    /// The classified queue is at capacity.
+    InboxFull,
+}
+
+/// Outcome of an admission attempt against the classified inbox.
+///
+/// Marked `#[must_use]` so that silently discarding a `Dropped` branch at a
+/// call site is a compile error — a drop is never "just success".
+#[must_use]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum AdmissionOutcome {
+    Admitted,
+    Dropped { reason: DropReason },
+}
+
+impl AdmissionOutcome {
+    /// True iff the item was admitted onto the queue.
+    pub fn is_admitted(&self) -> bool {
+        matches!(self, AdmissionOutcome::Admitted)
+    }
+
+    /// Convert this outcome into a `Result` with the drop reason as the error.
+    /// Useful at seams that already flow errors through `?`.
+    pub fn into_result(self) -> Result<(), DropReason> {
+        match self {
+            AdmissionOutcome::Admitted => Ok(()),
+            AdmissionOutcome::Dropped { reason } => Err(reason),
+        }
+    }
+}
 
 /// A classified inbox entry, pairing an item with its ingress classification.
 #[derive(Debug)]
@@ -39,6 +86,15 @@ pub(crate) struct ClassifiedInboxEntry {
     pub(crate) text_projection: String,
 }
 
+/// Internal admission decision paired with the peer-trust snapshot that the
+/// enqueue site still needs to stamp on the entry. `AdmissionOutcome` is the
+/// public face; `trusted_snapshot` stays crate-internal.
+#[derive(Debug, Clone, Copy)]
+pub(crate) struct AdmissionDecision {
+    pub(crate) outcome: AdmissionOutcome,
+    pub(crate) trusted_snapshot: Option<bool>,
+}
+
 #[derive(Debug)]
 struct ClassifiedInboxQueue {
     capacity: usize,
@@ -47,6 +103,7 @@ struct ClassifiedInboxQueue {
     auth_required: bool,
     trusted_peers: BTreeSet<PeerId>,
     phase: PeerIngressState,
+    dropped_count: Arc<AtomicU64>,
 }
 
 impl ClassifiedInboxQueue {
@@ -58,7 +115,12 @@ impl ClassifiedInboxQueue {
             auth_required,
             trusted_peers: BTreeSet::new(),
             phase: PeerIngressState::Absent,
+            dropped_count: Arc::new(AtomicU64::new(0)),
         }
+    }
+
+    fn dropped_counter(&self) -> Arc<AtomicU64> {
+        self.dropped_count.clone()
     }
 
     fn sync_trusted_peer_added(&mut self, peer_id: &str) {
@@ -71,19 +133,23 @@ impl ClassifiedInboxQueue {
 
     /// Admit a prepared item into the peer-ingress lifecycle.
     ///
-    /// Returns `(should_enqueue, trusted_snapshot)`:
-    /// - For plain events: always enqueue, no trust snapshot.
-    /// - For external envelopes: consult the trust set + auth-required policy.
-    ///   Untrusted senders with auth required are dropped (no enqueue); the
-    ///   trust snapshot still records the decision for queue visibility.
+    /// Returns a typed `AdmissionDecision`:
+    /// - Plain events are always admitted, with no trust snapshot.
+    /// - External envelopes consult the trust set + auth-required policy.
+    ///   Untrusted senders with auth required are `Dropped { reason:
+    ///   UntrustedSender }`; the trust snapshot still records the decision
+    ///   for queue visibility.
     ///
     /// Updates `phase` to track the observable lifecycle:
     /// `Absent → Received` (admitted), `Received → Received` (more work),
     /// `Absent → Dropped` (untrusted with empty queue), untrusted with queued
     /// work keeps `Received`.
-    fn admit_peer_receive(&mut self, prepared: &PreparedIngressItem) -> (bool, Option<bool>) {
+    fn admit_peer_receive(&mut self, prepared: &PreparedIngressItem) -> AdmissionDecision {
         let InboxItem::External { envelope } = &prepared.item else {
-            return (true, None);
+            return AdmissionDecision {
+                outcome: AdmissionOutcome::Admitted,
+                trusted_snapshot: None,
+            };
         };
         let peer_id = PeerId(envelope.from.to_peer_id());
         let trusted = self.trusted_peers.contains(&peer_id);
@@ -92,13 +158,22 @@ impl ClassifiedInboxQueue {
 
         if admitted {
             self.phase = PeerIngressState::Received;
-            (true, Some(trusted))
-        } else if had_queued_work {
-            self.phase = PeerIngressState::Received;
-            (false, Some(false))
+            AdmissionDecision {
+                outcome: AdmissionOutcome::Admitted,
+                trusted_snapshot: Some(trusted),
+            }
         } else {
-            self.phase = PeerIngressState::Dropped;
-            (false, Some(false))
+            if had_queued_work {
+                self.phase = PeerIngressState::Received;
+            } else {
+                self.phase = PeerIngressState::Dropped;
+            }
+            AdmissionDecision {
+                outcome: AdmissionOutcome::Dropped {
+                    reason: DropReason::UntrustedSender,
+                },
+                trusted_snapshot: Some(false),
+            }
         }
     }
 
@@ -212,6 +287,8 @@ pub struct Inbox {
     classified_queue: Option<Arc<Mutex<ClassifiedInboxQueue>>>,
     /// Notifier that fires only for actionable inputs.
     actionable_notify: Option<Arc<Notify>>,
+    /// Shared drop counter (cloned into `InboxSender`). Classified path only.
+    dropped_count: Option<Arc<AtomicU64>>,
 }
 
 /// The sending end of the inbox, cloned to IO tasks.
@@ -226,6 +303,8 @@ pub struct InboxSender {
     classified_queue: Option<Arc<Mutex<ClassifiedInboxQueue>>>,
     /// Notifier that fires only for actionable inputs.
     actionable_notify: Option<Arc<Notify>>,
+    /// Shared drop counter. Classified path only.
+    dropped_count: Option<Arc<AtomicU64>>,
 }
 
 impl Inbox {
@@ -244,6 +323,7 @@ impl Inbox {
                 notify: notify.clone(),
                 classified_queue: None,
                 actionable_notify: None,
+                dropped_count: None,
             },
             InboxSender {
                 tx,
@@ -251,6 +331,7 @@ impl Inbox {
                 classification_context: None,
                 classified_queue: None,
                 actionable_notify: None,
+                dropped_count: None,
             },
         )
     }
@@ -273,6 +354,7 @@ impl Inbox {
         for trusted_peer in &context.trusted_peers.read().peers {
             queue.sync_trusted_peer_added(&trusted_peer.pubkey.to_peer_id());
         }
+        let dropped_count = queue.dropped_counter();
         let classified_queue = Arc::new(Mutex::new(queue));
         (
             Inbox {
@@ -280,6 +362,7 @@ impl Inbox {
                 notify: notify.clone(),
                 classified_queue: Some(classified_queue.clone()),
                 actionable_notify: Some(actionable_notify.clone()),
+                dropped_count: Some(dropped_count.clone()),
             },
             InboxSender {
                 tx,
@@ -287,6 +370,7 @@ impl Inbox {
                 classification_context: Some(context),
                 classified_queue: Some(classified_queue),
                 actionable_notify: Some(actionable_notify),
+                dropped_count: Some(dropped_count),
             },
         )
     }
@@ -346,6 +430,20 @@ impl Inbox {
             .map(|queue| queue.lock().runtime_snapshot())
     }
 
+    /// Read the classified-inbox drop counter.
+    ///
+    /// Every `Dropped` outcome from `admit_peer_receive` (plus any failure
+    /// before enqueue — full queue, closed queue, classification rejection)
+    /// increments this counter. Tests assert this is zero on clean delivery
+    /// scenarios to pin down the "no silent drops" invariant.
+    ///
+    /// Returns `None` on non-classified inboxes (there is no admission step).
+    pub fn dropped_count(&self) -> Option<u64> {
+        self.dropped_count
+            .as_ref()
+            .map(|c| c.load(Ordering::Relaxed))
+    }
+
     pub(crate) fn note_trusted_peer_added(&mut self, peer_id: &str) {
         if let Some(queue) = &self.classified_queue {
             queue.lock().sync_trusted_peer_added(peer_id);
@@ -384,54 +482,107 @@ impl InboxSender {
     /// goes through the classified queue (the sole consumer). On non-classified
     /// runtimes, enqueues on the raw channel directly.
     ///
-    /// Returns an error if the inbox has been closed.
-    pub fn send(&self, item: InboxItem) -> Result<(), InboxError> {
-        // If classification context is available, route through classified path
+    /// Returns a typed `AdmissionOutcome`. Drops are never surfaced as `Ok(())`.
+    pub fn send(&self, item: InboxItem) -> AdmissionOutcome {
+        // If classification context is available, route through classified path.
         if self.classification_context.is_some() {
             return self.send_classified(item);
         }
-        self.tx.try_send(item).map_err(|err| match err {
-            mpsc::error::TrySendError::Closed(_) => InboxError::Closed,
-            mpsc::error::TrySendError::Full(_) => InboxError::Full,
-        })?;
-        // Notify any waiting tasks
-        self.notify.notify_waiters();
-        Ok(())
+        match self.tx.try_send(item) {
+            Ok(()) => {
+                self.notify.notify_waiters();
+                AdmissionOutcome::Admitted
+            }
+            Err(mpsc::error::TrySendError::Closed(_)) => {
+                tracing::warn!(
+                    reason = ?DropReason::SessionClosed,
+                    "raw inbox dropped item: queue closed"
+                );
+                self.record_drop(DropReason::SessionClosed)
+            }
+            Err(mpsc::error::TrySendError::Full(_)) => {
+                tracing::warn!(
+                    reason = ?DropReason::InboxFull,
+                    "raw inbox dropped item: queue full"
+                );
+                self.record_drop(DropReason::InboxFull)
+            }
+        }
     }
 
     /// Send an item with classification through the classified queue.
     ///
-    /// Classifies the item using the ingress context. Items that classify
-    /// as `None` (e.g., untrusted senders with `require_peer_auth`) are
-    /// silently dropped — snapshot semantics, no resurrection.
+    /// Returns a typed `AdmissionOutcome` so that silent discards become a
+    /// compile error. `Dropped` outcomes carry a `DropReason`, are emitted as
+    /// `tracing::warn!`, and increment the queue's drop counter. Tests assert
+    /// on the counter to prove the happy path doesn't leak drops.
+    ///
+    /// Transport/queue-level errors (closed queue, full queue) are surfaced as
+    /// `Dropped` outcomes rather than bubbled `Err`s — they're semantic drops
+    /// from the caller's perspective, not programmer errors.
     ///
     /// Classified items are enqueued only on the classified queue, then the
     /// appropriate notify is fired.
-    pub(crate) fn send_classified(&self, item: InboxItem) -> Result<(), InboxError> {
-        if let (Some(ctx), Some(classified_queue)) =
+    pub fn send_classified(&self, item: InboxItem) -> AdmissionOutcome {
+        let (Some(ctx), Some(classified_queue)) =
             (&self.classification_context, &self.classified_queue)
-        {
-            let result = match ctx.prepare(item) {
-                Some(r) => r,
-                None => {
-                    // Dropped at ingress — untrusted or otherwise rejected.
-                    // Do not enqueue, do not notify.
-                    return Ok(());
+        else {
+            // Non-classified fallback: enqueue on raw and report back as typed
+            // outcome. Use try_send directly to avoid infinite recursion with
+            // `send()` (which delegates to us when a classification context is
+            // present).
+            return match self.tx.try_send(item) {
+                Ok(()) => {
+                    self.notify.notify_waiters();
+                    AdmissionOutcome::Admitted
+                }
+                Err(mpsc::error::TrySendError::Closed(_)) => {
+                    tracing::warn!(
+                        reason = ?DropReason::SessionClosed,
+                        "classified inbox send_classified fell back to raw and found queue closed"
+                    );
+                    self.record_drop(DropReason::SessionClosed)
+                }
+                Err(mpsc::error::TrySendError::Full(_)) => {
+                    tracing::warn!(
+                        reason = ?DropReason::InboxFull,
+                        "classified inbox send_classified fell back to raw and found queue full"
+                    );
+                    self.record_drop(DropReason::InboxFull)
                 }
             };
-            let kind = result.ingress_kind();
-            let (should_enqueue, trusted_snapshot) = {
-                let mut queue = classified_queue.lock();
-                if result.auth_exempt && ctx.require_peer_auth && !result.trusted_sender {
-                    // Auth-exempt bridge traffic (bootstrap / idempotency-ack)
-                    // bypasses the peer-trust gate so bootstrapping can
-                    // complete before trust edges exist.
-                    (true, Some(false))
-                } else {
-                    queue.admit_peer_receive(&result)
+        };
+
+        let result = match ctx.prepare(item) {
+            Some(r) => r,
+            None => {
+                // Classification rejected the item before admission (e.g.
+                // pre-trust policy drop). No envelope context to log.
+                tracing::warn!(
+                    reason = ?DropReason::ClassificationRejected,
+                    "classified inbox dropped item at classification stage"
+                );
+                return self.record_drop(DropReason::ClassificationRejected);
+            }
+        };
+        let kind = result.ingress_kind();
+        let decision = {
+            let mut queue = classified_queue.lock();
+            if result.auth_exempt && ctx.require_peer_auth && !result.trusted_sender {
+                // Auth-exempt bridge traffic (bootstrap / idempotency-ack)
+                // bypasses the peer-trust gate so bootstrapping can
+                // complete before trust edges exist.
+                AdmissionDecision {
+                    outcome: AdmissionOutcome::Admitted,
+                    trusted_snapshot: Some(false),
                 }
-            };
-            if !should_enqueue {
+            } else {
+                queue.admit_peer_receive(&result)
+            }
+        };
+        match decision.outcome {
+            AdmissionOutcome::Admitted => {}
+            AdmissionOutcome::Dropped { reason } => {
                 if let InboxItem::External { envelope } = &result.item {
                     tracing::warn!(
                         peer_id = %envelope.from.to_peer_id(),
@@ -441,38 +592,63 @@ impl InboxSender {
                         request_id = result.request_id.as_deref().unwrap_or("<none>"),
                         auth_required = ctx.require_peer_auth,
                         trusted_sender = result.trusted_sender,
+                        reason = ?reason,
                         "classified inbox dropped external peer ingress at admission"
                     );
                 }
-                return Ok(());
+                return self.record_drop(reason);
             }
-            let entry = ClassifiedInboxEntry {
-                raw_item_id: result.raw_item_id,
-                item: result.item,
-                class: result.class,
-                auth_exempt: result.auth_exempt,
-                kind,
-                from_peer: result.from_peer,
-                lifecycle_peer: result.lifecycle_peer,
-                request_id: result.request_id,
-                trusted_snapshot,
-                text_projection: result.text_projection,
-            };
-            // Enqueue only on classified queue (no raw double-enqueue).
-            // drain_classified_inbox_interactions() is the sole consumer.
-            let is_actionable = entry.class.is_actionable();
-            classified_queue.lock().try_push(entry)?;
-            // Fire actionable notify only for actionable classes
-            if is_actionable && let Some(ref actionable) = self.actionable_notify {
-                actionable.notify_waiters();
-            }
-            // Always fire broad notify
-            self.notify.notify_waiters();
-            Ok(())
-        } else {
-            // Fallback: no classification context, just send raw
-            self.send(item)
         }
+        let entry = ClassifiedInboxEntry {
+            raw_item_id: result.raw_item_id,
+            item: result.item,
+            class: result.class,
+            auth_exempt: result.auth_exempt,
+            kind,
+            from_peer: result.from_peer,
+            lifecycle_peer: result.lifecycle_peer,
+            request_id: result.request_id,
+            trusted_snapshot: decision.trusted_snapshot,
+            text_projection: result.text_projection,
+        };
+        // Enqueue only on classified queue (no raw double-enqueue).
+        // drain_classified_inbox_interactions() is the sole consumer.
+        let is_actionable = entry.class.is_actionable();
+        let push_result = classified_queue.lock().try_push(entry);
+        match push_result {
+            Ok(()) => {
+                // Fire actionable notify only for actionable classes.
+                if is_actionable && let Some(ref actionable) = self.actionable_notify {
+                    actionable.notify_waiters();
+                }
+                // Always fire broad notify.
+                self.notify.notify_waiters();
+                AdmissionOutcome::Admitted
+            }
+            Err(InboxError::Closed) => {
+                tracing::warn!(
+                    kind = ?kind,
+                    reason = ?DropReason::SessionClosed,
+                    "classified inbox dropped item: queue closed"
+                );
+                self.record_drop(DropReason::SessionClosed)
+            }
+            Err(InboxError::Full) => {
+                tracing::warn!(
+                    kind = ?kind,
+                    reason = ?DropReason::InboxFull,
+                    "classified inbox dropped item: queue full"
+                );
+                self.record_drop(DropReason::InboxFull)
+            }
+        }
+    }
+
+    fn record_drop(&self, reason: DropReason) -> AdmissionOutcome {
+        if let Some(counter) = &self.dropped_count {
+            counter.fetch_add(1, Ordering::Relaxed);
+        }
+        AdmissionOutcome::Dropped { reason }
     }
 }
 
@@ -574,7 +750,7 @@ mod tests {
             envelope: make_test_envelope(),
         };
         let result = sender.send(item);
-        assert!(result.is_ok());
+        assert!(result.is_admitted());
     }
 
     #[tokio::test]
@@ -583,7 +759,10 @@ mod tests {
         let envelope = make_test_envelope();
         let envelope_id = envelope.id;
 
-        sender.send(InboxItem::External { envelope }).unwrap();
+        sender
+            .send(InboxItem::External { envelope })
+            .into_result()
+            .unwrap();
 
         let received = inbox.recv().await;
         assert!(received.is_some());
@@ -603,7 +782,10 @@ mod tests {
         for i in 0..3 {
             let mut envelope = make_test_envelope();
             envelope.id = Uuid::from_u128(i as u128);
-            sender.send(InboxItem::External { envelope }).unwrap();
+            sender
+                .send(InboxItem::External { envelope })
+                .into_result()
+                .unwrap();
         }
 
         // Give a moment for items to be queued
@@ -636,7 +818,12 @@ mod tests {
         let result = sender.send(InboxItem::External {
             envelope: make_test_envelope(),
         });
-        assert!(result.is_err());
+        assert!(matches!(
+            result,
+            AdmissionOutcome::Dropped {
+                reason: DropReason::SessionClosed
+            }
+        ));
     }
 
     #[test]
@@ -644,12 +831,21 @@ mod tests {
         let sender_pubkey = PubKey::new([1u8; 32]);
         let ctx = make_classification_context(make_trusted("peer", &sender_pubkey), false);
         let (inbox, sender) = Inbox::new_classified(ctx);
+        let counter = sender.dropped_count.clone();
         drop(inbox);
 
         let result = sender.send_classified(InboxItem::External {
             envelope: make_test_envelope(),
         });
-        assert!(matches!(result, Err(InboxError::Closed)));
+        assert!(matches!(
+            result,
+            AdmissionOutcome::Dropped {
+                reason: DropReason::SessionClosed
+            }
+        ));
+        // And the drop counter must have ticked — the silent `Ok(())` bug is gone.
+        let c = counter.expect("classified path must expose a counter");
+        assert_eq!(c.load(Ordering::Relaxed), 1);
     }
 
     // Phase 3: Wait interruption tests
@@ -676,6 +872,7 @@ mod tests {
             .send(InboxItem::External {
                 envelope: make_test_envelope(),
             })
+            .into_result()
             .unwrap();
 
         // The notification should complete immediately (message was sent before we awaited)
@@ -704,6 +901,7 @@ mod tests {
             .send(InboxItem::External {
                 envelope: make_test_envelope(),
             })
+            .into_result()
             .unwrap();
 
         // The task should complete
@@ -752,6 +950,7 @@ mod tests {
             .send_classified(InboxItem::External {
                 envelope: make_test_envelope(),
             })
+            .into_result()
             .unwrap();
 
         let result = tokio::time::timeout(std::time::Duration::from_millis(100), notified).await;
@@ -775,6 +974,7 @@ mod tests {
 
         sender
             .send_classified(InboxItem::External { envelope })
+            .into_result()
             .unwrap();
 
         let result = tokio::time::timeout(std::time::Duration::from_millis(100), notified).await;
@@ -798,6 +998,7 @@ mod tests {
 
         sender
             .send_classified(InboxItem::External { envelope })
+            .into_result()
             .unwrap();
 
         let notified = actionable.notified();
@@ -822,6 +1023,7 @@ mod tests {
 
         sender
             .send_classified(InboxItem::External { envelope })
+            .into_result()
             .unwrap();
 
         let notified = actionable.notified();
@@ -847,6 +1049,7 @@ mod tests {
                 blocks: None,
                 render_metadata: None,
             })
+            .into_result()
             .unwrap();
 
         let notified = actionable.notified();
@@ -873,6 +1076,7 @@ mod tests {
 
         sender
             .send_classified(InboxItem::External { envelope })
+            .into_result()
             .unwrap();
 
         let notified = actionable.notified();
@@ -893,6 +1097,7 @@ mod tests {
             .send_classified(InboxItem::External {
                 envelope: make_test_envelope(),
             })
+            .into_result()
             .unwrap();
 
         let entries = inbox.try_drain_classified();
@@ -916,6 +1121,7 @@ mod tests {
             .send_classified(InboxItem::External {
                 envelope: make_test_envelope(),
             })
+            .into_result()
             .unwrap();
 
         // Raw channel should be empty
@@ -940,6 +1146,7 @@ mod tests {
             .send_classified(InboxItem::External {
                 envelope: make_test_envelope(),
             })
+            .into_result()
             .unwrap();
         sender
             .send_classified(InboxItem::PlainEvent {
@@ -950,6 +1157,7 @@ mod tests {
                 blocks: None,
                 render_metadata: None,
             })
+            .into_result()
             .unwrap();
 
         let snapshot = inbox
@@ -994,6 +1202,7 @@ mod tests {
 
         sender
             .send_classified(InboxItem::External { envelope })
+            .into_result()
             .unwrap();
 
         let snapshot = inbox
@@ -1004,5 +1213,93 @@ mod tests {
         assert_eq!(snapshot.queued_entries[0].kind, PeerIngressKind::Request);
         assert_eq!(snapshot.queued_entries[0].request_id, Some(request_id));
         assert_eq!(snapshot.queued_entries[0].trusted_snapshot, Some(true));
+    }
+
+    #[tokio::test]
+    async fn test_classified_happy_path_reports_zero_drops() {
+        // Acceptance criterion: on a clean delivery scenario the drop counter
+        // stays at zero. This pins down the "no silent drops" invariant —
+        // regressions that reintroduce `Ok(())`-on-drop would bump it.
+        let sender_pubkey = PubKey::new([1u8; 32]);
+        let ctx = make_classification_context(make_trusted("peer", &sender_pubkey), true);
+        let (inbox, sender) = Inbox::new_classified(ctx);
+
+        let outcome = sender.send_classified(InboxItem::External {
+            envelope: make_test_envelope(),
+        });
+        assert_eq!(outcome, AdmissionOutcome::Admitted);
+        assert_eq!(
+            inbox.dropped_count(),
+            Some(0),
+            "happy-path delivery must not touch the drop counter"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_classified_untrusted_sender_returns_typed_drop_reason() {
+        // Untrusted sender + require_peer_auth: drop is typed, logged, and
+        // counted. No more `Ok(())` masquerading as delivery.
+        let untrusted_pubkey = PubKey::new([9u8; 32]);
+        let ctx = make_classification_context(TrustedPeers::new(), true);
+        let (inbox, sender) = Inbox::new_classified(ctx);
+
+        let mut envelope = make_test_envelope();
+        envelope.from = untrusted_pubkey;
+
+        let outcome = sender.send_classified(InboxItem::External { envelope });
+        assert_eq!(
+            outcome,
+            AdmissionOutcome::Dropped {
+                reason: DropReason::UntrustedSender
+            }
+        );
+        assert_eq!(inbox.dropped_count(), Some(1));
+    }
+
+    #[tokio::test]
+    async fn test_classified_full_queue_returns_typed_drop_reason() {
+        // InboxFull drops surface as typed `Dropped { InboxFull }` with the
+        // counter bumped. We build a classified queue at capacity 1 by using
+        // `new_with_capacity` plus then falling through to the classified
+        // path with trusted sender: admit the first, reject the second.
+        let sender_pubkey = PubKey::new([1u8; 32]);
+        let ctx = make_classification_context(make_trusted("peer", &sender_pubkey), false);
+        // `new_classified` uses DEFAULT_INBOX_CAPACITY; to exercise full we
+        // need a direct construction path. Fall back to building the queue
+        // directly and then driving it.
+        let actionable_notify = Arc::new(Notify::new());
+        let notify = Arc::new(Notify::new());
+        let mut queue = ClassifiedInboxQueue::new(1, ctx.require_peer_auth);
+        for trusted_peer in &ctx.trusted_peers.read().peers {
+            queue.sync_trusted_peer_added(&trusted_peer.pubkey.to_peer_id());
+        }
+        let counter = queue.dropped_counter();
+        let classified_queue = Arc::new(Mutex::new(queue));
+        let (tx, _rx) = mpsc::channel::<InboxItem>(1);
+        let sender = InboxSender {
+            tx,
+            notify,
+            classification_context: Some(ctx),
+            classified_queue: Some(classified_queue),
+            actionable_notify: Some(actionable_notify),
+            dropped_count: Some(counter.clone()),
+        };
+
+        let first = sender.send_classified(InboxItem::External {
+            envelope: make_test_envelope(),
+        });
+        assert_eq!(first, AdmissionOutcome::Admitted);
+        assert_eq!(counter.load(Ordering::Relaxed), 0);
+
+        let second = sender.send_classified(InboxItem::External {
+            envelope: make_test_envelope(),
+        });
+        assert_eq!(
+            second,
+            AdmissionOutcome::Dropped {
+                reason: DropReason::InboxFull
+            }
+        );
+        assert_eq!(counter.load(Ordering::Relaxed), 1);
     }
 }

--- a/meerkat-comms/src/inbox.rs
+++ b/meerkat-comms/src/inbox.rs
@@ -73,6 +73,21 @@ impl AdmissionOutcome {
     }
 }
 
+impl From<DropReason> for meerkat_core::comms::AdmissionDropReason {
+    fn from(reason: DropReason) -> Self {
+        match reason {
+            DropReason::UntrustedSender => {
+                meerkat_core::comms::AdmissionDropReason::UntrustedSender
+            }
+            DropReason::ClassificationRejected => {
+                meerkat_core::comms::AdmissionDropReason::ClassificationRejected
+            }
+            DropReason::SessionClosed => meerkat_core::comms::AdmissionDropReason::SessionClosed,
+            DropReason::InboxFull => meerkat_core::comms::AdmissionDropReason::InboxFull,
+        }
+    }
+}
+
 /// A classified inbox entry, pairing an item with its ingress classification.
 #[derive(Debug)]
 pub(crate) struct ClassifiedInboxEntry {

--- a/meerkat-comms/src/inbox.rs
+++ b/meerkat-comms/src/inbox.rs
@@ -118,7 +118,14 @@ struct ClassifiedInboxQueue {
     closed: bool,
     entries: VecDeque<ClassifiedInboxEntry>,
     auth_required: bool,
+    /// Public trust set — mirrors the router's user-facing `TrustedPeers`
+    /// and feeds `resolve_peer_directory()`.
     trusted_peers: BTreeSet<PeerId>,
+    /// Private trust set — admission-only, never feeds the peer directory.
+    /// Used for control-plane edges (e.g. supervisor→member lifecycle
+    /// notifications) that must bypass the user-facing `comms.peers` surface
+    /// so clients can't target internal channels as ordinary peers.
+    private_trusted_peers: BTreeSet<PeerId>,
     phase: PeerIngressState,
     dropped_count: Arc<AtomicU64>,
 }
@@ -131,6 +138,7 @@ impl ClassifiedInboxQueue {
             entries: VecDeque::new(),
             auth_required,
             trusted_peers: BTreeSet::new(),
+            private_trusted_peers: BTreeSet::new(),
             phase: PeerIngressState::Absent,
             dropped_count: Arc::new(AtomicU64::new(0)),
         }
@@ -146,6 +154,16 @@ impl ClassifiedInboxQueue {
 
     fn sync_trusted_peer_removed(&mut self, peer_id: &str) {
         self.trusted_peers.remove(&PeerId(peer_id.to_string()));
+    }
+
+    fn sync_private_trust_added(&mut self, peer_id: &str) -> bool {
+        self.private_trusted_peers
+            .insert(PeerId(peer_id.to_string()))
+    }
+
+    fn sync_private_trust_removed(&mut self, peer_id: &str) -> bool {
+        self.private_trusted_peers
+            .remove(&PeerId(peer_id.to_string()))
     }
 
     /// Admit a prepared item into the peer-ingress lifecycle.
@@ -169,7 +187,13 @@ impl ClassifiedInboxQueue {
             };
         };
         let peer_id = PeerId(envelope.from.to_peer_id());
-        let trusted = self.trusted_peers.contains(&peer_id);
+        // Either the public (directory-visible) trust set or the
+        // admission-only private trust set may admit. Private trust exists
+        // specifically for control-plane edges (e.g. supervisor→member
+        // lifecycle notifications) that must not leak into `comms.peers`.
+        let trusted_public = self.trusted_peers.contains(&peer_id);
+        let trusted_private = self.private_trusted_peers.contains(&peer_id);
+        let trusted = trusted_public || trusted_private;
         let admitted = trusted || !self.auth_required;
         let had_queued_work = !self.entries.is_empty();
 
@@ -471,6 +495,25 @@ impl Inbox {
         if let Some(queue) = &self.classified_queue {
             queue.lock().sync_trusted_peer_removed(peer_id);
         }
+    }
+
+    /// Sync a private-trust edge into the admission gate. Unlike
+    /// `note_trusted_peer_added`, this never touches the router's
+    /// directory-visible `TrustedPeers`. Returns `true` if the edge was
+    /// newly added (not already present).
+    pub(crate) fn note_private_trust_added(&mut self, peer_id: &str) -> bool {
+        self.classified_queue
+            .as_ref()
+            .map(|queue| queue.lock().sync_private_trust_added(peer_id))
+            .unwrap_or(false)
+    }
+
+    /// Returns `true` if the edge was present and removed.
+    pub(crate) fn note_private_trust_removed(&mut self, peer_id: &str) -> bool {
+        self.classified_queue
+            .as_ref()
+            .map(|queue| queue.lock().sync_private_trust_removed(peer_id))
+            .unwrap_or(false)
     }
 
     #[cfg(test)]

--- a/meerkat-comms/src/inbox.rs
+++ b/meerkat-comms/src/inbox.rs
@@ -31,6 +31,7 @@ const DEFAULT_INBOX_CAPACITY: usize = 1024;
 /// reach the agent. Silent `Ok(())` used to mask these; now they are typed,
 /// logged, and counted so tests can pin down "zero drops on the happy path".
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+#[non_exhaustive]
 pub enum DropReason {
     /// `require_peer_auth` is on, the sender is not in the trusted set, and
     /// the envelope is not auth-exempt (e.g. supervisor-bridge bootstrap).
@@ -50,6 +51,7 @@ pub enum DropReason {
 /// call site is a compile error — a drop is never "just success".
 #[must_use]
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[non_exhaustive]
 pub enum AdmissionOutcome {
     Admitted,
     Dropped { reason: DropReason },

--- a/meerkat-comms/src/inbox.rs
+++ b/meerkat-comms/src/inbox.rs
@@ -118,14 +118,7 @@ struct ClassifiedInboxQueue {
     closed: bool,
     entries: VecDeque<ClassifiedInboxEntry>,
     auth_required: bool,
-    /// Public trust set — mirrors the router's user-facing `TrustedPeers`
-    /// and feeds `resolve_peer_directory()`.
     trusted_peers: BTreeSet<PeerId>,
-    /// Private trust set — admission-only, never feeds the peer directory.
-    /// Used for control-plane edges (e.g. supervisor→member lifecycle
-    /// notifications) that must bypass the user-facing `comms.peers` surface
-    /// so clients can't target internal channels as ordinary peers.
-    private_trusted_peers: BTreeSet<PeerId>,
     phase: PeerIngressState,
     dropped_count: Arc<AtomicU64>,
 }
@@ -138,7 +131,6 @@ impl ClassifiedInboxQueue {
             entries: VecDeque::new(),
             auth_required,
             trusted_peers: BTreeSet::new(),
-            private_trusted_peers: BTreeSet::new(),
             phase: PeerIngressState::Absent,
             dropped_count: Arc::new(AtomicU64::new(0)),
         }
@@ -154,16 +146,6 @@ impl ClassifiedInboxQueue {
 
     fn sync_trusted_peer_removed(&mut self, peer_id: &str) {
         self.trusted_peers.remove(&PeerId(peer_id.to_string()));
-    }
-
-    fn sync_private_trust_added(&mut self, peer_id: &str) -> bool {
-        self.private_trusted_peers
-            .insert(PeerId(peer_id.to_string()))
-    }
-
-    fn sync_private_trust_removed(&mut self, peer_id: &str) -> bool {
-        self.private_trusted_peers
-            .remove(&PeerId(peer_id.to_string()))
     }
 
     /// Admit a prepared item into the peer-ingress lifecycle.
@@ -187,13 +169,7 @@ impl ClassifiedInboxQueue {
             };
         };
         let peer_id = PeerId(envelope.from.to_peer_id());
-        // Either the public (directory-visible) trust set or the
-        // admission-only private trust set may admit. Private trust exists
-        // specifically for control-plane edges (e.g. supervisor→member
-        // lifecycle notifications) that must not leak into `comms.peers`.
-        let trusted_public = self.trusted_peers.contains(&peer_id);
-        let trusted_private = self.private_trusted_peers.contains(&peer_id);
-        let trusted = trusted_public || trusted_private;
+        let trusted = self.trusted_peers.contains(&peer_id);
         let admitted = trusted || !self.auth_required;
         let had_queued_work = !self.entries.is_empty();
 
@@ -495,25 +471,6 @@ impl Inbox {
         if let Some(queue) = &self.classified_queue {
             queue.lock().sync_trusted_peer_removed(peer_id);
         }
-    }
-
-    /// Sync a private-trust edge into the admission gate. Unlike
-    /// `note_trusted_peer_added`, this never touches the router's
-    /// directory-visible `TrustedPeers`. Returns `true` if the edge was
-    /// newly added (not already present).
-    pub(crate) fn note_private_trust_added(&mut self, peer_id: &str) -> bool {
-        self.classified_queue
-            .as_ref()
-            .map(|queue| queue.lock().sync_private_trust_added(peer_id))
-            .unwrap_or(false)
-    }
-
-    /// Returns `true` if the edge was present and removed.
-    pub(crate) fn note_private_trust_removed(&mut self, peer_id: &str) -> bool {
-        self.classified_queue
-            .as_ref()
-            .map(|queue| queue.lock().sync_private_trust_removed(peer_id))
-            .unwrap_or(false)
     }
 
     #[cfg(test)]

--- a/meerkat-comms/src/inproc.rs
+++ b/meerkat-comms/src/inproc.rs
@@ -32,7 +32,7 @@ use parking_lot::RwLock;
 use uuid::Uuid;
 
 use crate::identity::{Keypair, PubKey, Signature};
-use crate::inbox::{InboxError, InboxSender};
+use crate::inbox::{AdmissionOutcome, DropReason, InboxSender};
 use crate::peer_meta::PeerMeta;
 use crate::types::{Envelope, InboxItem, MessageKind};
 
@@ -405,12 +405,18 @@ impl InprocRegistry {
         }
 
         let envelope_id = envelope.id;
-        sender
-            .send_classified(InboxItem::External { envelope })
-            .map_err(|err| match err {
-                InboxError::Closed => InprocSendError::InboxClosed,
-                InboxError::Full => InprocSendError::InboxFull,
-            })?;
+        match sender.send_classified(InboxItem::External { envelope }) {
+            AdmissionOutcome::Admitted => {}
+            AdmissionOutcome::Dropped {
+                reason: DropReason::SessionClosed,
+            } => return Err(InprocSendError::InboxClosed),
+            AdmissionOutcome::Dropped {
+                reason: DropReason::InboxFull,
+            } => return Err(InprocSendError::InboxFull),
+            AdmissionOutcome::Dropped { reason } => {
+                return Err(InprocSendError::IngressDropped(reason));
+            }
+        }
 
         Ok(envelope_id)
     }
@@ -463,12 +469,18 @@ impl InprocRegistry {
 
         // Deliver directly to inbox
         let envelope_id = envelope.id;
-        sender
-            .send_classified(InboxItem::External { envelope })
-            .map_err(|err| match err {
-                InboxError::Closed => InprocSendError::InboxClosed,
-                InboxError::Full => InprocSendError::InboxFull,
-            })?;
+        match sender.send_classified(InboxItem::External { envelope }) {
+            AdmissionOutcome::Admitted => {}
+            AdmissionOutcome::Dropped {
+                reason: DropReason::SessionClosed,
+            } => return Err(InprocSendError::InboxClosed),
+            AdmissionOutcome::Dropped {
+                reason: DropReason::InboxFull,
+            } => return Err(InprocSendError::InboxFull),
+            AdmissionOutcome::Dropped { reason } => {
+                return Err(InprocSendError::IngressDropped(reason));
+            }
+        }
 
         Ok(envelope_id)
     }
@@ -524,6 +536,8 @@ pub enum InprocSendError {
     InboxClosed,
     #[error("Peer inbox is full")]
     InboxFull,
+    #[error("Peer inbox dropped ingress: {0:?}")]
+    IngressDropped(crate::inbox::DropReason),
 }
 
 #[cfg(test)]

--- a/meerkat-comms/src/io_task.rs
+++ b/meerkat-comms/src/io_task.rs
@@ -16,7 +16,7 @@ use tokio::io::{AsyncRead, AsyncWrite};
 use tokio_util::codec::Framed;
 
 use crate::identity::{Keypair, Signature};
-use crate::inbox::{InboxError, InboxSender};
+use crate::inbox::{AdmissionOutcome, DropReason, InboxSender};
 use crate::transport::TransportError;
 use crate::transport::codec::{EnvelopeFrame, TransportCodec};
 use crate::trust::TrustedPeers;
@@ -99,15 +99,20 @@ where
         framed.send(frame).await?;
     }
 
-    // Enqueue to inbox (with classification if context is available)
-    inbox_sender
-        .send_classified(InboxItem::External { envelope })
-        .map_err(|err| match err {
-            InboxError::Closed => IoTaskError::InboxClosed,
-            InboxError::Full => IoTaskError::InboxFull,
-        })?;
-
-    Ok(())
+    // Enqueue to inbox (with classification if context is available).
+    // Typed admission outcome: explicit drops are surfaced as `IoTaskError`
+    // so the IO task can react (close connection, log, etc.) rather than
+    // silently returning `Ok(())`.
+    match inbox_sender.send_classified(InboxItem::External { envelope }) {
+        AdmissionOutcome::Admitted => Ok(()),
+        AdmissionOutcome::Dropped { reason } => Err(match reason {
+            DropReason::SessionClosed => IoTaskError::InboxClosed,
+            DropReason::InboxFull => IoTaskError::InboxFull,
+            DropReason::UntrustedSender | DropReason::ClassificationRejected => {
+                IoTaskError::IngressDropped(reason)
+            }
+        }),
+    }
 }
 
 /// Determine if we should send an ack for this message kind.
@@ -152,6 +157,8 @@ pub enum IoTaskError {
     InboxClosed,
     #[error("Inbox full")]
     InboxFull,
+    #[error("Ingress dropped: {0:?}")]
+    IngressDropped(DropReason),
 }
 
 #[cfg(test)]

--- a/meerkat-comms/src/lib.rs
+++ b/meerkat-comms/src/lib.rs
@@ -34,7 +34,7 @@ pub mod runtime;
 pub use agent::types::{DrainedMessage, PlainMessage, drain_inbox_item};
 pub use event_injector::CommsEventInjector;
 pub use identity::{IdentityError, Keypair, PubKey, Signature};
-pub use inbox::{Inbox, InboxError, InboxSender};
+pub use inbox::{AdmissionOutcome, DropReason, Inbox, InboxError, InboxSender};
 pub use inproc::{InprocPeerInfo, InprocRegistry, InprocSendError};
 #[cfg(not(target_arch = "wasm32"))]
 pub use io_task::{IoTaskError, handle_connection};

--- a/meerkat-comms/src/mcp/tools.rs
+++ b/meerkat-comms/src/mcp/tools.rs
@@ -370,6 +370,17 @@ fn format_router_send_error(peer_name: &str, error: crate::router::SendError) ->
         crate::router::SendError::PeerOffline => {
             format!("peer_unreachable: peer '{peer_name}' is unreachable: offline_or_no_ack")
         }
+        crate::router::SendError::AdmissionDropped { reason } => {
+            // Distinct from `peer_unreachable`: the peer's transport was
+            // live, ingress policy refused us. Surface the typed reason
+            // (untrusted_sender / inbox_full / …) so clients can tell
+            // policy failures from connectivity failures.
+            let code: meerkat_core::comms::AdmissionDropReason = reason.into();
+            format!(
+                "peer_admission_dropped: peer '{peer_name}' rejected envelope at ingress: {}",
+                code.as_code()
+            )
+        }
         crate::router::SendError::Transport(inner) => {
             format!(
                 "peer_unreachable: peer '{peer_name}' is unreachable: transport_error ({inner})"

--- a/meerkat-comms/src/plain_listener.rs
+++ b/meerkat-comms/src/plain_listener.rs
@@ -3,7 +3,7 @@
 //! Accepts newline-delimited JSON or plain text over TCP/UDS connections.
 //! Messages are pushed to the inbox as `InboxItem::PlainEvent`.
 
-use crate::inbox::{InboxError, InboxSender};
+use crate::inbox::{AdmissionOutcome, DropReason, InboxSender};
 use crate::transport::plain_codec::parse_plain_line;
 use crate::types::InboxItem;
 use futures::StreamExt;
@@ -47,13 +47,23 @@ pub async fn handle_plain_connection<S>(
                     blocks: None,
                     render_metadata: None,
                 }) {
-                    Ok(()) => {}
-                    Err(InboxError::Full) => {
+                    AdmissionOutcome::Admitted => {}
+                    AdmissionOutcome::Dropped {
+                        reason: DropReason::InboxFull,
+                    } => {
                         tracing::warn!("Plain listener: inbox full, dropping event");
                     }
-                    Err(InboxError::Closed) => {
+                    AdmissionOutcome::Dropped {
+                        reason: DropReason::SessionClosed,
+                    } => {
                         tracing::debug!("Plain listener: inbox closed, exiting");
                         return;
+                    }
+                    AdmissionOutcome::Dropped { reason } => {
+                        tracing::warn!(
+                            reason = ?reason,
+                            "Plain listener: inbox dropped plain event at ingress"
+                        );
                     }
                 }
             }

--- a/meerkat-comms/src/router.rs
+++ b/meerkat-comms/src/router.rs
@@ -86,6 +86,12 @@ pub struct Router {
     /// `trusted_peers_shared()`. Uses `parking_lot::RwLock` so ingress
     /// classification can read synchronously.
     trusted_peers: Arc<RwLock<TrustedPeers>>,
+    /// Directory-filter side-channel for private (control-plane) trust
+    /// edges. Membership here is additive to `trusted_peers`: the peer
+    /// is still admitted AND send-resolvable, but `resolve_peer_directory()`
+    /// filters it out of the `comms.peers` REST/RPC/MCP surface. Used e.g.
+    /// for the supervisor bridge in session-backed mob members.
+    private_pubkeys: Arc<RwLock<std::collections::HashSet<crate::identity::PubKey>>>,
     config: CommsConfig,
     require_peer_auth: bool,
     inbox_sender: InboxSender,
@@ -103,6 +109,7 @@ impl Router {
         Self {
             keypair: Arc::new(keypair),
             trusted_peers: Arc::new(RwLock::new(trusted_peers)),
+            private_pubkeys: Arc::new(RwLock::new(std::collections::HashSet::new())),
             config,
             require_peer_auth,
             inbox_sender,
@@ -120,11 +127,28 @@ impl Router {
         Self {
             keypair: Arc::new(keypair),
             trusted_peers,
+            private_pubkeys: Arc::new(RwLock::new(std::collections::HashSet::new())),
             config,
             require_peer_auth,
             inbox_sender,
             inproc_namespace: None,
         }
+    }
+
+    /// Mark a peer as private (hidden from `resolve_peer_directory`).
+    pub fn mark_private(&self, pubkey: crate::identity::PubKey) {
+        self.private_pubkeys.write().insert(pubkey);
+    }
+
+    /// Remove the private marker for a peer. Returns `true` if the marker
+    /// was present and removed.
+    pub fn unmark_private(&self, pubkey: &crate::identity::PubKey) -> bool {
+        self.private_pubkeys.write().remove(pubkey)
+    }
+
+    /// Returns `true` if the peer is currently marked private.
+    pub fn is_private(&self, pubkey: &crate::identity::PubKey) -> bool {
+        self.private_pubkeys.read().contains(pubkey)
     }
 
     /// Scope in-process routing to a namespace.

--- a/meerkat-comms/src/router.rs
+++ b/meerkat-comms/src/router.rs
@@ -63,6 +63,10 @@ fn map_inproc_send_error(err: InprocSendError) -> SendError {
     match err {
         InprocSendError::PeerNotFound(peer) => SendError::PeerNotFound(peer),
         InprocSendError::InboxClosed | InprocSendError::InboxFull => SendError::PeerOffline,
+        // A peer rejecting our envelope at its ingress gate looks externally
+        // identical to the peer being offline — the envelope did not land,
+        // and we have no typed cause to echo back on this crate's `SendError`.
+        InprocSendError::IngressDropped(_) => SendError::PeerOffline,
     }
 }
 

--- a/meerkat-comms/src/router.rs
+++ b/meerkat-comms/src/router.rs
@@ -47,6 +47,7 @@ impl Default for CommsConfig {
 }
 
 #[derive(Debug, Error)]
+#[non_exhaustive]
 pub enum SendError {
     #[error("Peer not found: {0}")]
     PeerNotFound(String),
@@ -56,6 +57,13 @@ pub enum SendError {
     Transport(#[from] TransportError),
     #[error("IO error: {0}")]
     Io(#[from] std::io::Error),
+    /// The peer admitted the transport layer but rejected our envelope at
+    /// its ingress admission gate. Semantically distinct from `PeerOffline`
+    /// — transport worked, policy refused. Carries the typed `DropReason`
+    /// so callers can render e.g. `untrusted_sender` rather than masquerade
+    /// as "peer unreachable".
+    #[error("Peer dropped envelope at admission: {reason:?}")]
+    AdmissionDropped { reason: crate::inbox::DropReason },
 }
 
 #[inline]
@@ -63,10 +71,10 @@ fn map_inproc_send_error(err: InprocSendError) -> SendError {
     match err {
         InprocSendError::PeerNotFound(peer) => SendError::PeerNotFound(peer),
         InprocSendError::InboxClosed | InprocSendError::InboxFull => SendError::PeerOffline,
-        // A peer rejecting our envelope at its ingress gate looks externally
-        // identical to the peer being offline — the envelope did not land,
-        // and we have no typed cause to echo back on this crate's `SendError`.
-        InprocSendError::IngressDropped(_) => SendError::PeerOffline,
+        // Preserve the typed ingress-drop reason all the way through to
+        // REST/RPC/MCP payloads. Do NOT collapse into `PeerOffline` — the
+        // transport worked, the receiver's admission policy rejected us.
+        InprocSendError::IngressDropped(reason) => SendError::AdmissionDropped { reason },
     }
 }
 

--- a/meerkat-comms/src/runtime/comms_runtime.rs
+++ b/meerkat-comms/src/runtime/comms_runtime.rs
@@ -301,6 +301,18 @@ impl CoreCommsRuntime for CommsRuntime {
         self.unregister_trusted_peer(peer_id).await
     }
 
+    async fn add_private_trusted_peer(&self, peer: TrustedPeerSpec) -> Result<(), SendError> {
+        let public_key = PubKey::from_peer_id(&peer.peer_id)
+            .map_err(|err| SendError::Validation(err.to_string()))?;
+        self.register_private_trust_edge(&public_key).await
+    }
+
+    async fn remove_private_trusted_peer(&self, peer_id: &str) -> Result<bool, SendError> {
+        let public_key =
+            PubKey::from_peer_id(peer_id).map_err(|err| SendError::Validation(err.to_string()))?;
+        self.unregister_private_trust_edge(&public_key).await
+    }
+
     fn dismiss_received(&self) -> bool {
         self.dismiss_flag.swap(false, Ordering::SeqCst)
     }
@@ -1421,6 +1433,31 @@ impl CommsRuntime {
             self.inbox.lock().await.note_trusted_peer_removed(peer_id);
         }
         Ok(removed)
+    }
+
+    /// Register a private (admission-only) trust edge for a peer key.
+    ///
+    /// Unlike [`register_trusted_peer`](Self::register_trusted_peer), this
+    /// seam never touches the router's public `TrustedPeers` list — the peer
+    /// will NOT appear in `resolve_peer_directory()` output or the
+    /// `comms.peers` REST/RPC/MCP surface. The sole effect is to admit
+    /// incoming envelopes from that peer through the classified inbox's
+    /// admission gate. Intended for control-plane edges such as the
+    /// supervisor→member lifecycle channel for session-backed mob members.
+    pub async fn register_private_trust_edge(&self, public_key: &PubKey) -> Result<(), SendError> {
+        let peer_id = public_key.to_peer_id();
+        self.inbox.lock().await.note_private_trust_added(&peer_id);
+        Ok(())
+    }
+
+    /// Remove a previously registered private-trust edge. Returns `true`
+    /// when the edge was present and removed, `false` otherwise.
+    pub async fn unregister_private_trust_edge(
+        &self,
+        public_key: &PubKey,
+    ) -> Result<bool, SendError> {
+        let peer_id = public_key.to_peer_id();
+        Ok(self.inbox.lock().await.note_private_trust_removed(&peer_id))
     }
 
     /// Canonical runtime trust-removal seam using a public key.

--- a/meerkat-comms/src/runtime/comms_runtime.rs
+++ b/meerkat-comms/src/runtime/comms_runtime.rs
@@ -304,13 +304,19 @@ impl CoreCommsRuntime for CommsRuntime {
     async fn add_private_trusted_peer(&self, peer: TrustedPeerSpec) -> Result<(), SendError> {
         let public_key = PubKey::from_peer_id(&peer.peer_id)
             .map_err(|err| SendError::Validation(err.to_string()))?;
-        self.register_private_trust_edge(&public_key).await
+        let trusted_peer = TrustedPeer {
+            name: peer.name,
+            pubkey: public_key,
+            addr: peer.address,
+            meta: crate::PeerMeta::default(),
+        };
+        self.register_private_trusted_peer(trusted_peer).await
     }
 
     async fn remove_private_trusted_peer(&self, peer_id: &str) -> Result<bool, SendError> {
         let public_key =
             PubKey::from_peer_id(peer_id).map_err(|err| SendError::Validation(err.to_string()))?;
-        self.unregister_private_trust_edge(&public_key).await
+        self.unregister_private_trusted_peer(&public_key).await
     }
 
     fn dismiss_received(&self) -> bool {
@@ -1435,29 +1441,39 @@ impl CommsRuntime {
         Ok(removed)
     }
 
-    /// Register a private (admission-only) trust edge for a peer key.
+    /// Register a trust edge whose peer entry is marked private.
     ///
-    /// Unlike [`register_trusted_peer`](Self::register_trusted_peer), this
-    /// seam never touches the router's public `TrustedPeers` list — the peer
-    /// will NOT appear in `resolve_peer_directory()` output or the
-    /// `comms.peers` REST/RPC/MCP surface. The sole effect is to admit
-    /// incoming envelopes from that peer through the classified inbox's
-    /// admission gate. Intended for control-plane edges such as the
-    /// supervisor→member lifecycle channel for session-backed mob members.
-    pub async fn register_private_trust_edge(&self, public_key: &PubKey) -> Result<(), SendError> {
-        let peer_id = public_key.to_peer_id();
-        self.inbox.lock().await.note_private_trust_added(&peer_id);
+    /// The peer goes through the same router + classified-inbox sync as
+    /// [`register_trusted_peer`](Self::register_trusted_peer) — admission
+    /// and send-resolution behave identically — but its pubkey is added
+    /// to the router's private-pubkey directory filter so
+    /// `resolve_peer_directory()` (and downstream `comms.peers`
+    /// REST/RPC/MCP handlers) filter it out. Intended for control-plane
+    /// edges such as the supervisor→member lifecycle channel for
+    /// session-backed mob members, where delivery AND reply-routing must
+    /// work but the recipient must not appear as an ordinary sendable
+    /// peer on user-facing surfaces.
+    pub async fn register_private_trusted_peer(&self, peer: TrustedPeer) -> Result<(), SendError> {
+        let peer_id = peer.pubkey.to_peer_id();
+        let pubkey = peer.pubkey;
+        self.router.add_trusted_peer(peer);
+        self.router.mark_private(pubkey);
+        self.inbox.lock().await.note_trusted_peer_added(&peer_id);
         Ok(())
     }
 
-    /// Remove a previously registered private-trust edge. Returns `true`
-    /// when the edge was present and removed, `false` otherwise.
-    pub async fn unregister_private_trust_edge(
+    /// Remove a previously registered private-trust edge.
+    pub async fn unregister_private_trusted_peer(
         &self,
         public_key: &PubKey,
     ) -> Result<bool, SendError> {
         let peer_id = public_key.to_peer_id();
-        Ok(self.inbox.lock().await.note_private_trust_removed(&peer_id))
+        let removed = self.router.remove_trusted_peer(public_key);
+        self.router.unmark_private(public_key);
+        if removed {
+            self.inbox.lock().await.note_trusted_peer_removed(&peer_id);
+        }
+        Ok(removed)
     }
 
     /// Canonical runtime trust-removal seam using a public key.
@@ -1553,6 +1569,18 @@ impl CommsRuntime {
             let trusted = self.trusted_peers.read();
             for peer in &trusted.peers {
                 if peer.name == participant_name || peer.pubkey == self.public_key {
+                    continue;
+                }
+                // Private peers are admission-visible and send-resolvable
+                // but never appear in the directory — that's the point of
+                // the private-trust seam (e.g. supervisor bridge for
+                // session-backed mob members). Still mark the name and
+                // pubkey as "known" so an unrelated inproc entry with the
+                // same identity doesn't fall through to the `Inproc`
+                // source below.
+                if self.router.is_private(&peer.pubkey) {
+                    trusted_names.insert(peer.name.clone());
+                    trusted_pubkeys.insert(peer.pubkey);
                     continue;
                 }
                 trusted_names.insert(peer.name.clone());

--- a/meerkat-comms/src/runtime/comms_runtime.rs
+++ b/meerkat-comms/src/runtime/comms_runtime.rs
@@ -1638,6 +1638,24 @@ impl CommsRuntime {
                 }
                 Err(SendError::PeerOffline)
             }
+            Err(crate::router::SendError::AdmissionDropped { reason }) => {
+                // Transport worked; the receiver's ingress admission policy
+                // rejected us. Surface the typed reason all the way to the
+                // public API error payload so clients see e.g.
+                // `untrusted_sender` rather than the old `PeerOffline` lie.
+                // Reachability stays distinct too: the peer is still live
+                // at the transport layer, so we record `AdmissionDropped`
+                // rather than `OfflineOrNoAck`.
+                if let Some(peer) = resolved_peer.as_ref() {
+                    self.peer_directory_reachability.lock().record_send_failed(
+                        &peer.reachability_key(),
+                        PeerReachabilityReason::AdmissionDropped,
+                    );
+                }
+                Err(SendError::AdmissionDropped {
+                    reason: reason.into(),
+                })
+            }
             Err(
                 error @ (crate::router::SendError::Transport(_) | crate::router::SendError::Io(_)),
             ) => {
@@ -3864,6 +3882,68 @@ mod tests {
         assert_eq!(
             entry.last_unreachable_reason,
             Some(PeerReachabilityReason::TransportError)
+        );
+    }
+
+    #[tokio::test]
+    async fn test_send_to_untrusted_peer_surfaces_admission_dropped_not_offline() {
+        // Regression: before typed `AdmissionOutcome`, the router collapsed a
+        // receiver-side ingress rejection into `PeerOffline`. That made a
+        // policy failure indistinguishable from a transport failure in
+        // REST/RPC/MCP payloads. Now it must come through as
+        // `SendError::AdmissionDropped { UntrustedSender }` with reachability
+        // recorded as `AdmissionDropped` (transport was live).
+        let suffix = Uuid::new_v4().simple().to_string();
+        let sender_name = format!("admit-sender-{suffix}");
+        let receiver_name = format!("admit-receiver-{suffix}");
+        let sender = CommsRuntime::inproc_only(&sender_name).unwrap();
+        let receiver = CommsRuntime::inproc_only(&receiver_name).unwrap();
+
+        // Sender trusts receiver; receiver does NOT trust sender. Receiver
+        // has `require_peer_auth: true` by default, so our envelope lands
+        // at its ingress gate and gets rejected with `UntrustedSender`.
+        CoreCommsRuntime::add_trusted_peer(
+            &sender,
+            TrustedPeerSpec::new(
+                &receiver_name,
+                receiver.public_key().to_peer_id(),
+                format!("inproc://{receiver_name}"),
+            )
+            .expect("valid trusted peer"),
+        )
+        .await
+        .expect("sender must trust receiver");
+
+        let result = CoreCommsRuntime::send(
+            &sender,
+            CommsCommand::PeerMessage {
+                blocks: None,
+                to: PeerName::new(receiver_name.clone()).expect("valid peer name"),
+                body: "policy-rejected".to_string(),
+                handling_mode: meerkat_core::types::HandlingMode::Queue,
+            },
+        )
+        .await;
+        assert!(
+            matches!(
+                result,
+                Err(SendError::AdmissionDropped {
+                    reason: meerkat_core::comms::AdmissionDropReason::UntrustedSender
+                })
+            ),
+            "untrusted-sender ingress drop must surface as typed AdmissionDropped, \
+             got: {result:?}"
+        );
+
+        let peers = CoreCommsRuntime::peers(&sender).await;
+        let entry = peers
+            .iter()
+            .find(|listed| listed.name.as_str() == receiver_name)
+            .expect("trusted peer should remain listed after admission drop");
+        assert_eq!(
+            entry.last_unreachable_reason,
+            Some(PeerReachabilityReason::AdmissionDropped),
+            "policy rejection must record AdmissionDropped, not OfflineOrNoAck"
         );
     }
 

--- a/meerkat-comms/src/runtime/comms_runtime.rs
+++ b/meerkat-comms/src/runtime/comms_runtime.rs
@@ -1748,25 +1748,31 @@ impl CommsRuntime {
             StreamRegistryEntry::reserved(sender, receiver),
         );
 
-        if let Err(error) =
-            self.router
-                .inbox_sender()
-                .send_classified(crate::types::InboxItem::PlainEvent {
-                    body,
-                    source: PlainEventSource::from(source),
-                    handling_mode,
-                    interaction_id: Some(interaction_id),
-                    blocks,
-                    render_metadata: None,
-                })
+        if let crate::inbox::AdmissionOutcome::Dropped { reason } = self
+            .router
+            .inbox_sender()
+            .send_classified(crate::types::InboxItem::PlainEvent {
+                body,
+                source: PlainEventSource::from(source),
+                handling_mode,
+                interaction_id: Some(interaction_id),
+                blocks,
+                render_metadata: None,
+            })
         {
             self.interaction_stream_registry
                 .lock()
                 .remove(&interaction_id);
             self.subscriber_registry.lock().remove(&interaction_id);
-            return Err(match error {
-                crate::inbox::InboxError::Full => SendError::Validation("input queue full".into()),
-                crate::inbox::InboxError::Closed => SendError::InputClosed,
+            return Err(match reason {
+                crate::inbox::DropReason::InboxFull => {
+                    SendError::Validation("input queue full".into())
+                }
+                crate::inbox::DropReason::SessionClosed => SendError::InputClosed,
+                crate::inbox::DropReason::UntrustedSender
+                | crate::inbox::DropReason::ClassificationRejected => {
+                    SendError::Validation(format!("input rejected at ingress: {reason:?}"))
+                }
             });
         }
 
@@ -2242,16 +2248,19 @@ mod tests {
             .router
             .inbox_sender()
             .send_classified(InboxItem::External { envelope: msg })
+            .into_result()
             .unwrap();
         runtime
             .router
             .inbox_sender()
             .send_classified(InboxItem::External { envelope: req })
+            .into_result()
             .unwrap();
         runtime
             .router
             .inbox_sender()
             .send_classified(InboxItem::External { envelope: resp })
+            .into_result()
             .unwrap();
 
         let interactions = CoreCommsRuntime::drain_inbox_interactions(&runtime).await;
@@ -2323,6 +2332,7 @@ mod tests {
             .router
             .inbox_sender()
             .send_classified(InboxItem::External { envelope: msg })
+            .into_result()
             .unwrap();
 
         let interactions = CoreCommsRuntime::drain_inbox_interactions(&runtime).await;
@@ -2391,6 +2401,22 @@ mod tests {
                 meta: crate::PeerMeta::default(),
             });
         }
+        // Peer must also trust the runtime: the receive-side admission gate
+        // now drops untrusted envelopes with `UntrustedSender` instead of
+        // silently reporting success, and reachability upstream reflects that.
+        // Use `add_trusted_peer` so the classified inbox's canonical
+        // `trusted_peers` BTreeSet is synced too, not just the RwLock.
+        CoreCommsRuntime::add_trusted_peer(
+            &peer,
+            TrustedPeerSpec::new(
+                &runtime_name,
+                runtime.public_key().to_peer_id(),
+                format!("inproc://{runtime_name}"),
+            )
+            .expect("valid trusted peer spec"),
+        )
+        .await
+        .expect("peer should accept trust entry for runtime");
 
         let receipt = CoreCommsRuntime::send(
             &runtime,
@@ -2564,6 +2590,7 @@ mod tests {
                 interaction_id: Some(interaction_id),
                 render_metadata: None,
             })
+            .into_result()
             .unwrap();
 
         let interactions = CoreCommsRuntime::drain_inbox_interactions(&runtime).await;
@@ -2592,6 +2619,7 @@ mod tests {
                 interaction_id: None,
                 render_metadata: Some(render_metadata.clone()),
             })
+            .into_result()
             .unwrap();
 
         let interactions = runtime.drain_classified_inbox_interactions().await.unwrap();
@@ -2621,6 +2649,7 @@ mod tests {
                 interaction_id: None,
                 render_metadata: None,
             })
+            .into_result()
             .unwrap();
 
         let snapshot = CoreCommsRuntime::peer_ingress_queue_snapshot(&runtime)
@@ -2665,6 +2694,7 @@ mod tests {
             .router
             .inbox_sender()
             .send_classified(InboxItem::External { envelope })
+            .into_result()
             .unwrap();
         runtime
             .router
@@ -2677,6 +2707,7 @@ mod tests {
                 interaction_id: None,
                 render_metadata: None,
             })
+            .into_result()
             .unwrap();
 
         let snapshot = CoreCommsRuntime::peer_ingress_queue_snapshot(&runtime)
@@ -2776,11 +2807,19 @@ mod tests {
             },
         );
 
-        runtime
+        // Untrusted sender, require_peer_auth on: the admission gate drops
+        // the envelope with `UntrustedSender`. We assert the typed outcome
+        // directly so the silent-Ok path can't creep back.
+        let outcome = runtime
             .router
             .inbox_sender()
-            .send_classified(InboxItem::External { envelope })
-            .unwrap();
+            .send_classified(InboxItem::External { envelope });
+        assert_eq!(
+            outcome,
+            crate::inbox::AdmissionOutcome::Dropped {
+                reason: crate::inbox::DropReason::UntrustedSender
+            }
+        );
 
         let snapshot = CoreCommsRuntime::peer_ingress_runtime_snapshot(&runtime)
             .await
@@ -2814,13 +2853,20 @@ mod tests {
             },
         );
 
-        runtime
+        // Untrusted sender under require_peer_auth: must be explicitly
+        // dropped at admission with a typed reason — no more silent Ok(()).
+        let outcome = runtime
             .router
             .inbox_sender()
             .send_classified(InboxItem::External {
                 envelope: envelope.clone(),
-            })
-            .unwrap();
+            });
+        assert_eq!(
+            outcome,
+            crate::inbox::AdmissionOutcome::Dropped {
+                reason: crate::inbox::DropReason::UntrustedSender
+            }
+        );
 
         {
             let inbox = runtime.inbox.lock().await;
@@ -2839,6 +2885,8 @@ mod tests {
                 inbox.peer_authority_trusts_peer_for_test(&peer_id),
                 Some(false)
             );
+            // Drop counter ticked exactly once — the bug repair is visible.
+            assert_eq!(inbox.dropped_count(), Some(1));
         }
 
         let trusted_peer = TrustedPeerSpec::new("sender", peer_id.clone(), "inproc://sender")
@@ -2863,6 +2911,7 @@ mod tests {
             .router
             .inbox_sender()
             .send_classified(InboxItem::External { envelope })
+            .into_result()
             .unwrap();
 
         let snapshot = CoreCommsRuntime::peer_ingress_runtime_snapshot(&runtime)
@@ -2947,6 +2996,7 @@ mod tests {
             .router
             .inbox_sender()
             .send_classified(InboxItem::External { envelope })
+            .into_result()
             .unwrap();
 
         {
@@ -3730,6 +3780,22 @@ mod tests {
         )
         .await
         .expect("add trusted peer");
+        // Receiver must trust the sender too: `require_peer_auth` is on by
+        // default, and with typed drop-reasons the receiver no longer silently
+        // accepts untrusted envelopes as `Ok(())` — the admission gate now
+        // reports `Dropped { UntrustedSender }`, which surfaces to this caller
+        // as `PeerOffline`. Mutual trust mirrors real deployments.
+        CoreCommsRuntime::add_trusted_peer(
+            &receiver,
+            TrustedPeerSpec::new(
+                &sender_name,
+                sender.public_key().to_peer_id(),
+                format!("inproc://{sender_name}"),
+            )
+            .expect("valid trusted peer"),
+        )
+        .await
+        .expect("add trusted peer");
 
         let peers_before = CoreCommsRuntime::peers(&sender).await;
         let before = peers_before
@@ -4059,6 +4125,19 @@ mod tests {
                 meta: crate::PeerMeta::default(),
             });
         }
+        // Receive side must also trust the sender after the silent-drop fix.
+        // Use `add_trusted_peer` so the classified queue's trust set syncs.
+        CoreCommsRuntime::add_trusted_peer(
+            &_peer,
+            TrustedPeerSpec::new(
+                &runtime_name,
+                runtime.public_key().to_peer_id(),
+                format!("inproc://{runtime_name}"),
+            )
+            .expect("valid trusted peer spec"),
+        )
+        .await
+        .expect("peer should accept trust entry for runtime");
 
         let cmd = CommsCommand::PeerMessage {
             blocks: None,

--- a/meerkat-core/src/agent.rs
+++ b/meerkat-core/src/agent.rs
@@ -586,6 +586,32 @@ pub trait CommsRuntime: Send + Sync {
         ))
     }
 
+    /// Register a peer for admission-only trust without listing it in the
+    /// directory.
+    ///
+    /// Used for control-plane edges — the canonical case is the supervisor
+    /// bridge for session-backed mob members: lifecycle notifications
+    /// (`mob.peer_added`, `mob.peer_retired`, …) must land at the member's
+    /// inbox, but the supervisor must not appear as an ordinary sendable
+    /// peer in `comms.peers` / REST / RPC / MCP. The admission gate consults
+    /// both the public and private trust sets; `resolve_peer_directory()`
+    /// consults only the public set.
+    async fn add_private_trusted_peer(&self, _peer: TrustedPeerSpec) -> Result<(), SendError> {
+        Err(SendError::Unsupported(
+            "add_private_trusted_peer not supported for this CommsRuntime".to_string(),
+        ))
+    }
+
+    /// Remove a previously registered private-trust edge by peer ID.
+    ///
+    /// Returns `true` if the edge was present and removed, `false` if it
+    /// was not.
+    async fn remove_private_trusted_peer(&self, _peer_id: &str) -> Result<bool, SendError> {
+        Err(SendError::Unsupported(
+            "remove_private_trusted_peer not supported for this CommsRuntime".to_string(),
+        ))
+    }
+
     /// Dispatch a canonical comms command.
     async fn send(&self, _cmd: CommsCommand) -> Result<SendReceipt, SendError> {
         Err(SendError::Unsupported(

--- a/meerkat-core/src/comms.rs
+++ b/meerkat-core/src/comms.rs
@@ -509,9 +509,14 @@ pub enum PeerReachability {
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
+#[non_exhaustive]
 pub enum PeerReachabilityReason {
     OfflineOrNoAck,
     TransportError,
+    /// The peer admitted the transport but rejected our envelope at its
+    /// ingress policy gate (untrusted sender, full inbox, etc.). The peer
+    /// is still reachable at the transport level; policy denied us.
+    AdmissionDropped,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -580,7 +585,44 @@ pub enum StreamError {
     Internal(String),
 }
 
+/// Typed reason a peer rejected our envelope at its ingress admission gate.
+///
+/// This mirrors `meerkat_comms::DropReason` across the core boundary so
+/// `SendError::AdmissionDropped` can carry the typed cause all the way to
+/// REST/RPC/MCP error payloads. Callers distinguish transport-level failure
+/// (`PeerOffline`) from policy-level rejection (`AdmissionDropped { reason }`)
+/// without collapsing both into "peer unreachable".
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, serde::Serialize, serde::Deserialize)]
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
+#[serde(rename_all = "snake_case")]
+#[non_exhaustive]
+pub enum AdmissionDropReason {
+    /// `require_peer_auth` is on, the sender is not in the trusted set, and
+    /// the envelope is not auth-exempt (e.g. supervisor-bridge bootstrap).
+    UntrustedSender,
+    /// Classification rejected the item before the admission gate ran.
+    ClassificationRejected,
+    /// The receiver's classified inbox is closed (receiver dropped).
+    SessionClosed,
+    /// The receiver's classified inbox is at capacity.
+    InboxFull,
+}
+
+impl AdmissionDropReason {
+    /// Stable wire code for this drop reason, suitable for REST/RPC/MCP
+    /// error payloads. Callers-facing discriminant — must stay stable.
+    pub fn as_code(&self) -> &'static str {
+        match self {
+            AdmissionDropReason::UntrustedSender => "untrusted_sender",
+            AdmissionDropReason::ClassificationRejected => "classification_rejected",
+            AdmissionDropReason::SessionClosed => "session_closed",
+            AdmissionDropReason::InboxFull => "inbox_full",
+        }
+    }
+}
+
 #[derive(Debug, Clone, thiserror::Error)]
+#[non_exhaustive]
 pub enum SendError {
     #[error("peer not found: {0}")]
     PeerNotFound(String),
@@ -596,6 +638,12 @@ pub enum SendError {
     Validation(String),
     #[error("internal: {0}")]
     Internal(String),
+    /// Receiver admitted the envelope-transport but rejected it at ingress
+    /// for a typed policy reason (untrusted sender, full inbox, etc.). This
+    /// is semantically distinct from `PeerOffline` — transport worked,
+    /// policy refused.
+    #[error("peer dropped at admission: {reason:?}")]
+    AdmissionDropped { reason: AdmissionDropReason },
 }
 
 #[derive(Debug, Clone, thiserror::Error)]

--- a/meerkat-core/src/interaction.rs
+++ b/meerkat-core/src/interaction.rs
@@ -33,6 +33,37 @@ pub enum ResponseStatus {
     Failed,
 }
 
+/// Canonical terminality classification of a `ResponseStatus`.
+///
+/// Consumers that care about progress-vs-terminal (and, within terminal,
+/// whether the response completed or failed) must read this typed class
+/// rather than re-`match` on `ResponseStatus` — that duplication is how
+/// "terminal" drifts from one call site to another.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum TerminalityClass {
+    Progress,
+    Terminal { disposition: TerminalDisposition },
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum TerminalDisposition {
+    Completed,
+    Failed,
+}
+
+/// Single source of truth for "is this response terminal?".
+pub fn classify_response_terminality(status: ResponseStatus) -> TerminalityClass {
+    match status {
+        ResponseStatus::Accepted => TerminalityClass::Progress,
+        ResponseStatus::Completed => TerminalityClass::Terminal {
+            disposition: TerminalDisposition::Completed,
+        },
+        ResponseStatus::Failed => TerminalityClass::Terminal {
+            disposition: TerminalDisposition::Failed,
+        },
+    }
+}
+
 /// Simplified interaction content for the core agent loop.
 ///
 /// This is an adapter type — `CommsContent` in meerkat-comms has richer types
@@ -301,6 +332,26 @@ mod tests {
             let parsed: ResponseStatus = serde_json::from_value(json).unwrap();
             assert_eq!(variant, parsed);
         }
+    }
+
+    #[test]
+    fn classify_response_terminality_covers_all_variants() {
+        assert_eq!(
+            classify_response_terminality(ResponseStatus::Accepted),
+            TerminalityClass::Progress
+        );
+        assert_eq!(
+            classify_response_terminality(ResponseStatus::Completed),
+            TerminalityClass::Terminal {
+                disposition: TerminalDisposition::Completed
+            }
+        );
+        assert_eq!(
+            classify_response_terminality(ResponseStatus::Failed),
+            TerminalityClass::Terminal {
+                disposition: TerminalDisposition::Failed
+            }
+        );
     }
 
     #[test]

--- a/meerkat-core/src/interaction.rs
+++ b/meerkat-core/src/interaction.rs
@@ -40,12 +40,14 @@ pub enum ResponseStatus {
 /// rather than re-`match` on `ResponseStatus` — that duplication is how
 /// "terminal" drifts from one call site to another.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+#[non_exhaustive]
 pub enum TerminalityClass {
     Progress,
     Terminal { disposition: TerminalDisposition },
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+#[non_exhaustive]
 pub enum TerminalDisposition {
     Completed,
     Failed,

--- a/meerkat-core/src/lib.rs
+++ b/meerkat-core/src/lib.rs
@@ -146,7 +146,8 @@ pub use image_content::{
 pub use interaction::{
     ClassifiedInboxInteraction, InboxInteraction, InteractionContent, InteractionId,
     PeerIngressAuthorityPhase, PeerIngressEntrySnapshot, PeerIngressKind, PeerIngressQueueSnapshot,
-    PeerIngressRuntimeSnapshot, PeerInputClass, ResponseStatus,
+    PeerIngressRuntimeSnapshot, PeerInputClass, ResponseStatus, TerminalDisposition,
+    TerminalityClass, classify_response_terminality,
 };
 pub use lifecycle::{
     ConversationAppend, ConversationAppendRole, ConversationContextAppend, CoreExecutor,

--- a/meerkat-mob/src/runtime/actor.rs
+++ b/meerkat-mob/src/runtime/actor.rs
@@ -3811,10 +3811,41 @@ impl MobActor {
         // From this point, rollback_failed_spawn handles cleanup via the
         // disposal pipeline.
         let member_ref = provision.commit()?;
-        let peer_id = self
-            .provisioner_comms(&member_ref)
-            .await
-            .and_then(|comms| comms.public_key());
+        let member_comms = self.provisioner_comms(&member_ref).await;
+        let peer_id = member_comms.as_ref().and_then(|comms| comms.public_key());
+
+        // Bootstrap supervisor trust on the member's comms runtime.
+        //
+        // The supervisor sends protocol-level lifecycle notifications
+        // (`mob.peer_added`, `mob.peer_retired`, …) to every member. These are
+        // not auth-exempt, so the receiving member must already trust the
+        // supervisor's peer id or the classified inbox will drop the
+        // envelope at admission. Before typed `AdmissionOutcome` landed, the
+        // drop was silent — now it surfaces as `PeerOffline`, which is what
+        // this bootstrap closes. External peers get the same edge via the
+        // supervisor-bridge BindMember bootstrap; session-backed members did
+        // not have an equivalent seam.
+        if let Some(member_comms) = member_comms.as_ref() {
+            match self.supervisor_bridge.supervisor_spec().await {
+                Ok(sup_spec) => {
+                    if let Err(err) = member_comms.add_trusted_peer(sup_spec).await {
+                        tracing::warn!(
+                            agent_identity = %agent_identity,
+                            error = %err,
+                            "could not register supervisor trust on session-backed member comms; \
+                             lifecycle notifications may be dropped at admission"
+                        );
+                    }
+                }
+                Err(err) => {
+                    tracing::warn!(
+                        agent_identity = %agent_identity,
+                        error = %err,
+                        "supervisor_spec unavailable; cannot bootstrap member→supervisor trust"
+                    );
+                }
+            }
+        }
 
         // Resolve `external_addressable` from the effective profile so we
         // can inform both the shell roster and the DSL (see the

--- a/meerkat-mob/src/runtime/actor.rs
+++ b/meerkat-mob/src/runtime/actor.rs
@@ -3817,23 +3817,27 @@ impl MobActor {
         // Bootstrap supervisor trust on the member's comms runtime.
         //
         // The supervisor sends protocol-level lifecycle notifications
-        // (`mob.peer_added`, `mob.peer_retired`, …) to every member. These are
-        // not auth-exempt, so the receiving member must already trust the
-        // supervisor's peer id or the classified inbox will drop the
-        // envelope at admission. Before typed `AdmissionOutcome` landed, the
-        // drop was silent — now it surfaces as `PeerOffline`, which is what
-        // this bootstrap closes. External peers get the same edge via the
-        // supervisor-bridge BindMember bootstrap; session-backed members did
-        // not have an equivalent seam.
+        // (`mob.peer_added`, `mob.peer_retired`, …) to every member. These
+        // are not auth-exempt, so the receiving member must already trust
+        // the supervisor's peer id or the classified inbox will drop the
+        // envelope at admission. External peers get this edge via the
+        // supervisor-bridge `BindMember` bootstrap; session-backed members
+        // had no equivalent seam before W1-B.
+        //
+        // Use the *private* trust seam: the supervisor is a control-plane
+        // peer and must NOT leak into the member's `comms.peers` directory,
+        // REST, RPC, or MCP surface — clients would otherwise be able to
+        // target the supervisor bridge as an ordinary sendable peer.
+        // `add_private_trusted_peer` wires only the admission gate.
         if let Some(member_comms) = member_comms.as_ref() {
             match self.supervisor_bridge.supervisor_spec().await {
                 Ok(sup_spec) => {
-                    if let Err(err) = member_comms.add_trusted_peer(sup_spec).await {
+                    if let Err(err) = member_comms.add_private_trusted_peer(sup_spec).await {
                         tracing::warn!(
                             agent_identity = %agent_identity,
                             error = %err,
-                            "could not register supervisor trust on session-backed member comms; \
-                             lifecycle notifications may be dropped at admission"
+                            "could not register supervisor private-trust on session-backed \
+                             member comms; lifecycle notifications may be dropped at admission"
                         );
                     }
                 }

--- a/meerkat-mob/src/runtime/tests.rs
+++ b/meerkat-mob/src/runtime/tests.rs
@@ -17993,14 +17993,18 @@ async fn test_trusted_peer_spec_uses_real_external_identity_for_peer_only_member
 
 #[tokio::test]
 async fn test_supervisor_trust_does_not_leak_into_member_peer_directory() {
-    // Fix 2 regression: `finalize_spawn_from_pending` bootstraps supervisor
-    // trust on every session-backed member so lifecycle notifications land
-    // at the classified inbox. That bootstrap must NOT register the
-    // supervisor as a public trusted peer — it's a control-plane edge and
-    // would otherwise surface as an ordinary sendable peer in the
-    // member's `comms.peers` output (and downstream REST/RPC/MCP). The
-    // admission-only private trust seam keeps the edge invisible to the
-    // directory.
+    // Fix 2 regression (negative invariant): `finalize_spawn_from_pending`
+    // bootstraps supervisor trust on every session-backed member so
+    // lifecycle notifications land at the classified inbox. That bootstrap
+    // must NOT register the supervisor as a publicly-listed trusted peer —
+    // it's a control-plane edge and would otherwise surface as an ordinary
+    // sendable peer in the member's `comms.peers` output (and downstream
+    // REST/RPC/MCP). The private-trust seam uses the router's
+    // `private_pubkeys` directory-filter to keep the entry invisible.
+    //
+    // The *positive* complement — "the supervisor is still trusted enough
+    // for the member to send back to it" — is enforced by
+    // `test_supervisor_private_trust_preserves_send_resolution` below.
     let _serial = REAL_COMMS_TEST_LOCK.lock().expect("real-comms test lock");
     let definition = with_unique_mob_id(sample_definition(), "no-supervisor-leak");
     let (handle, service) = create_test_mob_with_real_comms(definition).await;
@@ -18029,6 +18033,72 @@ async fn test_supervisor_trust_does_not_leak_into_member_peer_directory() {
         supervisor_entry.is_none(),
         "supervisor must NOT appear in the session-backed member's public \
          peer directory; the private-trust seam is the whole point. Got: {directory:?}"
+    );
+}
+
+#[tokio::test]
+async fn test_supervisor_private_trust_preserves_send_resolution() {
+    // Fix 2 positive invariant: the private-trust seam must still keep
+    // the supervisor fully send-resolvable from the member. When splitting
+    // `add_trusted_peer` into "admission + directory + send-resolution" vs
+    // "admission + send-resolution (no directory)", the positive side was
+    // the one that broke first — e2e-smoke caught pictionary kickoff
+    // timing out because the admission-only path left the member's
+    // router unable to resolve the supervisor's `PeerName` to a `PeerAddr`,
+    // so reply-sends silently failed. This test pins the required
+    // invariants: the supervisor entry is in the router's `TrustedPeers`
+    // (so `send_peer_command` can resolve), is marked private (so the
+    // directory hides it), and the member's classified inbox knows the
+    // supervisor pubkey (so admission accepts lifecycle notifications).
+    let _serial = REAL_COMMS_TEST_LOCK.lock().expect("real-comms test lock");
+    let definition = with_unique_mob_id(sample_definition(), "supervisor-send-resolution");
+    let (handle, service) = create_test_mob_with_real_comms(definition).await;
+    let receipt = handle
+        .spawn(ProfileName::from("worker"), MeerkatId::from("w-send"), None)
+        .await
+        .expect("spawn session-backed member");
+    let session_id = receipt
+        .bridge_session_id()
+        .cloned()
+        .expect("session-backed member has bridge session id");
+    let member_comms = service
+        .real_comms(&session_id)
+        .await
+        .expect("member comms runtime");
+
+    // Look up the supervisor pubkey via the member's trust list — this is
+    // the same list the router uses to resolve `PeerName → PeerAddr`.
+    let supervisor_pubkey = {
+        let trusted = member_comms.trusted_peers_shared();
+        let guard = trusted.read();
+        let entry = guard
+            .peers
+            .iter()
+            .find(|p| p.name.contains("__mob_supervisor__"))
+            .expect(
+                "send-resolution invariant: supervisor must still appear in the \
+                 member's internal TrustedPeers — that's what the router consults \
+                 to resolve the supervisor's PeerName to a PeerAddr on reply-sends",
+            );
+        entry.pubkey
+    };
+
+    // The directory-filter side-channel must mark this pubkey private.
+    assert!(
+        member_comms.router().is_private(&supervisor_pubkey),
+        "directory-filter invariant: supervisor pubkey must be marked \
+         private so `resolve_peer_directory()` hides it"
+    );
+
+    // And the directory must in fact hide it. This is the same fact the
+    // negative-invariant test asserts at the `peers()` API, pinned here
+    // as the end-to-end consequence of the two internal invariants above.
+    let directory = member_comms.peers().await;
+    assert!(
+        directory
+            .iter()
+            .all(|entry| !entry.name.as_str().contains("__mob_supervisor__")),
+        "directory output must not list the supervisor; got: {directory:?}"
     );
 }
 

--- a/meerkat-mob/src/runtime/tests.rs
+++ b/meerkat-mob/src/runtime/tests.rs
@@ -17992,6 +17992,47 @@ async fn test_trusted_peer_spec_uses_real_external_identity_for_peer_only_member
 }
 
 #[tokio::test]
+async fn test_supervisor_trust_does_not_leak_into_member_peer_directory() {
+    // Fix 2 regression: `finalize_spawn_from_pending` bootstraps supervisor
+    // trust on every session-backed member so lifecycle notifications land
+    // at the classified inbox. That bootstrap must NOT register the
+    // supervisor as a public trusted peer — it's a control-plane edge and
+    // would otherwise surface as an ordinary sendable peer in the
+    // member's `comms.peers` output (and downstream REST/RPC/MCP). The
+    // admission-only private trust seam keeps the edge invisible to the
+    // directory.
+    let _serial = REAL_COMMS_TEST_LOCK.lock().expect("real-comms test lock");
+    let definition = with_unique_mob_id(sample_definition(), "no-supervisor-leak");
+    let (handle, service) = create_test_mob_with_real_comms(definition).await;
+    let receipt = handle
+        .spawn(
+            ProfileName::from("worker"),
+            MeerkatId::from("w-private"),
+            None,
+        )
+        .await
+        .expect("spawn session-backed member");
+    let session_id = receipt
+        .bridge_session_id()
+        .cloned()
+        .expect("session-backed member has bridge session id");
+
+    let member_comms = service
+        .real_comms(&session_id)
+        .await
+        .expect("member comms runtime");
+    let directory = member_comms.peers().await;
+    let supervisor_entry = directory
+        .iter()
+        .find(|entry| entry.name.as_str().contains("__mob_supervisor__"));
+    assert!(
+        supervisor_entry.is_none(),
+        "supervisor must NOT appear in the session-backed member's public \
+         peer directory; the private-trust seam is the whole point. Got: {directory:?}"
+    );
+}
+
+#[tokio::test]
 async fn test_external_tools_provider_called_per_spawn() {
     let counter = Arc::new(std::sync::atomic::AtomicU32::new(0));
     let counter_clone = counter.clone();

--- a/meerkat-mob/src/tests/contracts.rs
+++ b/meerkat-mob/src/tests/contracts.rs
@@ -282,6 +282,20 @@ async fn contract_mob_005_remove_trusted_peer_revokes_send() {
     CoreCommsRuntime::add_trusted_peer(&sender, spec)
         .await
         .expect("add trusted peer");
+    // Receiver must trust the sender too: after typed `AdmissionOutcome`
+    // landed, the receiver's classified inbox rejects envelopes from
+    // untrusted senders with `Dropped { UntrustedSender }` (surfaced
+    // upstream as `PeerOffline`) instead of silently returning `Ok(())`.
+    // Mutual trust matches what real deployments set up.
+    let reverse_spec = TrustedPeerSpec::new(
+        &sender_name,
+        sender.public_key().to_peer_id(),
+        format!("inproc://{sender_name}"),
+    )
+    .expect("valid spec");
+    CoreCommsRuntime::add_trusted_peer(&receiver, reverse_spec)
+        .await
+        .expect("add reverse trusted peer");
 
     // Verify send works before removal
     let cmd = CommsCommand::PeerMessage {

--- a/meerkat-runtime/src/comms_drain.rs
+++ b/meerkat-runtime/src/comms_drain.rs
@@ -146,18 +146,21 @@ pub fn spawn_comms_drain(
                         }
                     }
                     PeerInputClass::Response => {
-                        // Distinguish progress responses from terminal responses.
-                        let is_terminal = matches!(
-                            &candidate.interaction.content,
+                        // Distinguish progress responses from terminal responses
+                        // via the canonical classifier in meerkat-core. Raw
+                        // `ResponseStatus` matching here is forbidden — all
+                        // consumers must read `TerminalityClass` so "terminal"
+                        // stays lock-stepped across the codebase.
+                        let is_terminal = match &candidate.interaction.content {
                             meerkat_core::interaction::InteractionContent::Response {
                                 status,
                                 ..
-                            } if matches!(
-                                status,
-                                meerkat_core::interaction::ResponseStatus::Completed
-                                    | meerkat_core::interaction::ResponseStatus::Failed
-                            )
-                        );
+                            } => matches!(
+                                meerkat_core::interaction::classify_response_terminality(*status),
+                                meerkat_core::interaction::TerminalityClass::Terminal { .. }
+                            ),
+                            _ => false,
+                        };
 
                         if is_terminal {
                             // Terminal response — single admission with


### PR DESCRIPTION
## Summary

- `InboxSender::send_classified` (and `send`) now return `AdmissionOutcome { Admitted, Dropped { reason } }` (marked `#[must_use]`), ending the silent `Ok(())`-on-drop behaviour that masked semantic failures. `DropReason` enumerates the four failure modes: `UntrustedSender`, `ClassificationRejected`, `SessionClosed`, `InboxFull`. Every drop emits a `tracing::warn!` and bumps a shared counter exposed as `Inbox::dropped_count()` so test harnesses can pin "zero drops on the happy path".
- New `TerminalityClass { Progress, Terminal { disposition: TerminalDisposition } }` and `classify_response_terminality()` in `meerkat-core::interaction` become the single source of truth for progress-vs-terminal. `meerkat-runtime::comms_drain` terminal-branch now reads the typed class instead of re-matching on `ResponseStatus`. Supervisor-bridge's direct `ResponseStatus` matching is intentionally left alone (W2-F scope).
- Typed `AdmissionOutcome` surfaced a latent production gap where supervisor lifecycle notifications to session-backed members (`mob.peer_added`, `mob.peer_retired`, …) were silently dropped at the auth-admission gate. Fix: `MobActor::finalize_spawn_from_pending` now registers the supervisor on the member's comms trust set at `meerkat-mob/src/runtime/actor.rs:3818`, right after the member's comms is resolved. Three mob tests that previously passed via silent-`Ok(())` masking now pass via real delivery.

Refs issue #264. Closes dogma items:
- **#4** — one canonical terminal path (`TerminalityClass` replaces duplicated `ResponseStatus` matching)
- **#5** — typed truth (`AdmissionOutcome` replaces silent `Ok(())`)
- **#14** — local fallback state must not leak (drop reasons surfaced as typed outcomes + counter)
- **#15** — success means truthful completion (no more `Ok(())` on a dropped envelope)

## Test plan

- [x] `./scripts/repo-cargo nextest run -p meerkat-comms` — 291 pass (3 new drop-reason tests pin happy-path, untrusted-sender, full-queue).
- [x] `./scripts/repo-cargo unit` — 3727 pass.
- [x] `./scripts/repo-cargo int` — 4667 pass.
- [x] `./scripts/repo-cargo e2e-fast` — 5 pass.
- [x] `./scripts/repo-cargo e2e-system` — 16 pass.
- [x] `./scripts/repo-cargo clippy --workspace --all-targets -- -D warnings` — clean.
- [x] `make regen-schemas && make verify-version-parity` — no semantic diff, parity green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)