### PR TITLE
W1-C: Coverage matrix + mock Realtime WS harness

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3365,6 +3365,7 @@ dependencies = [
  "futures",
  "meerkat",
  "meerkat-client",
+ "meerkat-comms",
  "meerkat-core",
  "meerkat-machine-kernels",
  "meerkat-mob",

--- a/meerkat-comms/src/runtime/comms_runtime.rs
+++ b/meerkat-comms/src/runtime/comms_runtime.rs
@@ -1169,6 +1169,46 @@ impl CommsRuntime {
         Ok(runtime)
     }
 
+    /// Construct two inproc-only `CommsRuntime` instances with mutual trust
+    /// already seeded, so each can send to the other without the caller
+    /// touching `TrustedPeers` directly.
+    ///
+    /// Trust is seeded through the canonical `CommsRuntime::add_trusted_peer`
+    /// path so both the `TrustedPeers` RwLock and the classified inbox's
+    /// sibling `trusted_peers` BTreeSet stay in sync — the receive-side
+    /// admission gate drops untrusted envelopes with `UntrustedSender`
+    /// (W1-B), so seeding must touch both stores, not just the RwLock.
+    ///
+    /// This is a test-infrastructure helper intended for integration-scope
+    /// reservation / correlation tests. Production code should establish
+    /// trust through the normal identity-exchange flows.
+    pub async fn inproc_pair_with_mutual_trust(
+        name_a: &str,
+        name_b: &str,
+    ) -> Result<(Arc<Self>, Arc<Self>), CommsRuntimeError> {
+        let a = Arc::new(Self::inproc_only(name_a)?);
+        let b = Arc::new(Self::inproc_only(name_b)?);
+        let spec_for_a = meerkat_core::comms::TrustedPeerSpec::new(
+            name_b,
+            b.public_key().to_peer_id(),
+            format!("inproc://{name_b}"),
+        )
+        .map_err(CommsRuntimeError::TrustLoadError)?;
+        let spec_for_b = meerkat_core::comms::TrustedPeerSpec::new(
+            name_a,
+            a.public_key().to_peer_id(),
+            format!("inproc://{name_a}"),
+        )
+        .map_err(CommsRuntimeError::TrustLoadError)?;
+        meerkat_core::agent::CommsRuntime::add_trusted_peer(a.as_ref(), spec_for_a)
+            .await
+            .map_err(|err| CommsRuntimeError::TrustLoadError(err.to_string()))?;
+        meerkat_core::agent::CommsRuntime::add_trusted_peer(b.as_ref(), spec_for_b)
+            .await
+            .map_err(|err| CommsRuntimeError::TrustLoadError(err.to_string()))?;
+        Ok((a, b))
+    }
+
     #[cfg(not(target_arch = "wasm32"))]
     pub async fn inproc_only_session_scoped_with_silent_intents(
         name: &str,

--- a/meerkat-openai/tests/mock_realtime_ws/README.md
+++ b/meerkat-openai/tests/mock_realtime_ws/README.md
@@ -1,0 +1,87 @@
+# mock_realtime_ws
+
+Deterministic, in-process mock for the OpenAI Realtime session protocol,
+used by `e2e-fast` tests that need realtime lifecycle coverage without live
+OpenAI credentials. Landed in W1-C (roadmap issue #264).
+
+## Why
+
+Axis-crossing bugs like the s71 turn-8 regression (peer-response-triggered
+turn in turn-driven realtime mode) went unnoticed because every realtime
+test path required live API credentials and ran only in `e2e-live` / `e2e-smoke`.
+The deterministic `e2e-fast` lane had no realtime coverage at all.
+
+This harness is the other half of the W1-C composite-path coverage matrix
+(`tests/integration/src/coverage_matrix.rs`): the matrix tells you which
+cells need coverage, this mock is what makes those cells testable.
+
+## Where it sits
+
+It implements `meerkat_llm_core::realtime_session::{RealtimeSession,
+RealtimeSessionFactory}` directly. The `RealtimeMockServer` is a test-only
+factory that returns `RealtimeMockSession`s driven by pre-scripted scenarios.
+
+Note on the "WS" in the name: Meerkat's provider contract for realtime is
+the `RealtimeSession` trait, not a raw websocket. In production, `oai-rt-rs`
+handles the websocket framing behind that trait. At the trait boundary,
+tests get deterministic replay without a TCP listener. If a future test
+needs raw `response.output_text.delta` / `response.done` JSON frames on a
+socket, extend this module with a `tokio_tungstenite`-based listener that
+serializes the same `ScriptedEvent` vocabulary.
+
+## How to use
+
+```rust
+use mock_realtime_ws::{RealtimeMockServer, ScriptedEvent, ScriptedScenario};
+
+let server = RealtimeMockServer::new();
+server
+    .enqueue(
+        ScriptedScenario::new()
+            .with_event(ScriptedEvent::TurnStarted)
+            .with_event(ScriptedEvent::OutputTextDelta("hello".into()))
+            .with_event(ScriptedEvent::TurnCompleted {
+                stop_reason: StopReason::EndTurn,
+            })
+            .with_event(ScriptedEvent::End),
+    )
+    .await;
+
+let factory = server.factory();
+// hand `factory` to the code under test wherever a
+// `RealtimeSessionFactory` is required.
+```
+
+Every `open_session` consumes one queued scenario in FIFO order. Missing
+scenarios produce a loud `LlmError::InvalidRequest` instead of a hang.
+
+After the scenario runs, inspect what was sent provider-wards:
+
+```rust
+let recording = server.recording_for(0).await.unwrap();
+let recording = recording.lock().await;
+assert_eq!(recording.inputs.len(), 1);
+assert_eq!(recording.commits, 1);
+assert!(recording.closed);
+```
+
+## Scope discipline
+
+The mock is intentionally thin. It covers:
+
+- `open_session` flow (capabilities, turning mode)
+- `send_input`, `commit_turn`, `interrupt`, `truncate_assistant_output`
+- `submit_tool_result`, `submit_tool_error`
+- `next_event` scripted playback
+- `close`
+
+It does NOT cover:
+
+- External session attachment (`attach_external_session` fails loudly —
+  production code paths that rely on it should exercise the live lane).
+- Adaptive scripting based on provider side-effects (if your test needs
+  provider behavior that depends on what the code under test sent, write a
+  custom `RealtimeSession` for that one test rather than expanding the mock).
+- Real WS framing (see note above).
+
+Keep it fast, keep it obvious, keep it test-only.

--- a/meerkat-openai/tests/mock_realtime_ws/mod.rs
+++ b/meerkat-openai/tests/mock_realtime_ws/mod.rs
@@ -1,0 +1,13 @@
+//! Mock Realtime WS harness — deterministic replacement for live
+//! OpenAI Realtime sessions in `e2e-fast`.
+//!
+//! See `README.md` in this directory for usage and design notes.
+
+#![allow(dead_code, unused_imports)]
+
+pub mod server;
+
+pub use server::{
+    RealtimeMockServer, RealtimeMockSession, RealtimeMockSessionFactory, ScriptedEvent,
+    ScriptedScenario,
+};

--- a/meerkat-openai/tests/mock_realtime_ws/server.rs
+++ b/meerkat-openai/tests/mock_realtime_ws/server.rs
@@ -1,0 +1,493 @@
+//! `RealtimeMockServer` — scripted mock that impersonates an OpenAI
+//! Realtime session without requiring live credentials or a network.
+//!
+//! ## Why
+//!
+//! Tests that exercise the realtime attachment lifecycle (turn-driven
+//! realtime, peer-response-triggered turns, subscriber streams over a
+//! realtime session) today run only against live OpenAI credentials in
+//! `e2e-live`. The s71 turn-8 regression proved that this is not enough:
+//! cross-axis bugs need a deterministic harness.
+//!
+//! ## Shape
+//!
+//! The mock implements `meerkat_llm_core::realtime_session::{RealtimeSession,
+//! RealtimeSessionFactory}` directly. Input frames are recorded so the test
+//! can assert on them; output events are scripted per-scenario and emitted
+//! in response to `next_event` calls.
+//!
+//! A `RealtimeMockServer` is a container for a registered set of scenarios
+//! and the factory that the production code consumes. It is NOT a real WS
+//! server — the `realtime` side of Meerkat's provider contract lives at the
+//! `RealtimeSession` trait, not at the socket, so the "server" here is the
+//! authoritative scripting authority that the factory opens sessions from.
+//!
+//! If a future test needs raw WS framing (e.g. to exercise `oai-rt-rs`
+//! parsing), the mock can be extended with a TCP listener that serializes
+//! the scripted events as `response.output_text.delta` / `response.done`
+//! JSON frames; for now, every consumer talks through the trait and we
+//! keep the harness zero-overhead.
+
+use std::collections::VecDeque;
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use meerkat_contracts::{
+    RealtimeAudioChunk, RealtimeCapabilities, RealtimeInputChunk, RealtimeInputKind,
+    RealtimeOutputKind, RealtimeTurningMode,
+};
+use meerkat_core::ToolResult;
+use meerkat_llm_core::LlmError;
+use meerkat_llm_core::realtime_session::{
+    RealtimeExternalSessionTarget, RealtimeSession, RealtimeSessionEvent, RealtimeSessionFactory,
+    RealtimeSessionOpenConfig,
+};
+use tokio::sync::Mutex;
+
+/// One scripted event the mock emits when the test harness asks for the
+/// next event from an open session.
+#[derive(Debug, Clone)]
+pub enum ScriptedEvent {
+    OutputTextDelta(String),
+    TurnStarted,
+    TurnCommitted,
+    TurnCompleted {
+        stop_reason: meerkat_core::StopReason,
+    },
+    Interrupted,
+    /// Simulate the provider end-of-stream: `next_event` will return
+    /// `Ok(None)` for all subsequent polls.
+    End,
+}
+
+impl ScriptedEvent {
+    fn into_session_event(self) -> Option<Result<Option<RealtimeSessionEvent>, LlmError>> {
+        match self {
+            ScriptedEvent::OutputTextDelta(delta) => {
+                Some(Ok(Some(RealtimeSessionEvent::OutputTextDelta { delta })))
+            }
+            ScriptedEvent::TurnStarted => Some(Ok(Some(RealtimeSessionEvent::TurnStarted))),
+            ScriptedEvent::TurnCommitted => Some(Ok(Some(RealtimeSessionEvent::TurnCommitted))),
+            ScriptedEvent::TurnCompleted { stop_reason } => {
+                Some(Ok(Some(RealtimeSessionEvent::TurnCompleted {
+                    stop_reason,
+                    usage: Default::default(),
+                })))
+            }
+            ScriptedEvent::Interrupted => Some(Ok(Some(RealtimeSessionEvent::Interrupted))),
+            ScriptedEvent::End => Some(Ok(None)),
+        }
+    }
+}
+
+/// A pre-scripted provider conversation. The scenario is consumed in order
+/// by the session. Additional events can be pushed onto the scenario while
+/// the session is live (via the server handle) so tests can simulate
+/// provider-side pushes that arrive after a specific input frame has been
+/// observed.
+#[derive(Debug, Clone, Default)]
+pub struct ScriptedScenario {
+    pub events: Vec<ScriptedEvent>,
+    /// Optional capability override. If `None`, the mock advertises a
+    /// conservative baseline (text in/out, provider-managed turns, no
+    /// video, no audio format announcement).
+    pub capabilities: Option<RealtimeCapabilities>,
+}
+
+impl ScriptedScenario {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub fn with_event(mut self, event: ScriptedEvent) -> Self {
+        self.events.push(event);
+        self
+    }
+
+    pub fn with_events(mut self, events: impl IntoIterator<Item = ScriptedEvent>) -> Self {
+        self.events.extend(events);
+        self
+    }
+
+    pub fn with_capabilities(mut self, capabilities: RealtimeCapabilities) -> Self {
+        self.capabilities = Some(capabilities);
+        self
+    }
+}
+
+fn baseline_capabilities() -> RealtimeCapabilities {
+    RealtimeCapabilities {
+        input_kinds: vec![RealtimeInputKind::Text, RealtimeInputKind::Audio],
+        output_kinds: vec![RealtimeOutputKind::Text, RealtimeOutputKind::Audio],
+        turning_modes: vec![
+            RealtimeTurningMode::ProviderManaged,
+            RealtimeTurningMode::ExplicitCommit,
+        ],
+        interrupt_supported: true,
+        transcript_supported: true,
+        tool_lifecycle_events_supported: false,
+        video_supported: false,
+        audio_input_format: None,
+        audio_output_format: None,
+    }
+}
+
+/// Recording bag every session shares with the server so tests can inspect
+/// what was sent provider-wards.
+#[derive(Debug, Default)]
+pub struct SessionRecording {
+    pub inputs: Vec<RealtimeInputChunk>,
+    pub tool_results: Vec<ToolResult>,
+    pub tool_errors: Vec<(String, String)>,
+    pub commits: u32,
+    pub interrupts: u32,
+    pub truncations: u32,
+    pub refresh_projections: u32,
+    pub closed: bool,
+}
+
+/// A scripted mock session. Consumers normally receive this as
+/// `Box<dyn RealtimeSession>` from the factory.
+pub struct RealtimeMockSession {
+    capabilities: RealtimeCapabilities,
+    turning_mode: RealtimeTurningMode,
+    queued: VecDeque<ScriptedEvent>,
+    recording: Arc<Mutex<SessionRecording>>,
+}
+
+impl RealtimeMockSession {
+    pub fn new(
+        scenario: ScriptedScenario,
+        turning_mode: RealtimeTurningMode,
+        recording: Arc<Mutex<SessionRecording>>,
+    ) -> Self {
+        let capabilities = scenario.capabilities.unwrap_or_else(baseline_capabilities);
+        let queued: VecDeque<ScriptedEvent> = scenario.events.into_iter().collect();
+        Self {
+            capabilities,
+            turning_mode,
+            queued,
+            recording,
+        }
+    }
+}
+
+#[async_trait]
+impl RealtimeSession for RealtimeMockSession {
+    fn capabilities(&self) -> &RealtimeCapabilities {
+        &self.capabilities
+    }
+
+    fn turning_mode(&self) -> RealtimeTurningMode {
+        self.turning_mode
+    }
+
+    async fn refresh_projection(
+        &mut self,
+        _open_config: &RealtimeSessionOpenConfig,
+    ) -> Result<(), LlmError> {
+        self.recording.lock().await.refresh_projections += 1;
+        Ok(())
+    }
+
+    async fn send_input(&mut self, chunk: RealtimeInputChunk) -> Result<(), LlmError> {
+        self.recording.lock().await.inputs.push(chunk);
+        Ok(())
+    }
+
+    async fn commit_turn(&mut self) -> Result<(), LlmError> {
+        self.recording.lock().await.commits += 1;
+        Ok(())
+    }
+
+    async fn interrupt(&mut self) -> Result<(), LlmError> {
+        self.recording.lock().await.interrupts += 1;
+        Ok(())
+    }
+
+    async fn truncate_assistant_output(
+        &mut self,
+        _item_id: String,
+        _content_index: u32,
+        _audio_played_ms: u64,
+    ) -> Result<(), LlmError> {
+        self.recording.lock().await.truncations += 1;
+        Ok(())
+    }
+
+    async fn submit_tool_result(&mut self, result: ToolResult) -> Result<(), LlmError> {
+        self.recording.lock().await.tool_results.push(result);
+        Ok(())
+    }
+
+    async fn submit_tool_error(&mut self, call_id: String, error: String) -> Result<(), LlmError> {
+        self.recording
+            .lock()
+            .await
+            .tool_errors
+            .push((call_id, error));
+        Ok(())
+    }
+
+    async fn next_event(&mut self) -> Result<Option<RealtimeSessionEvent>, LlmError> {
+        match self.queued.pop_front() {
+            Some(event) => event.into_session_event().unwrap_or(Ok(None)),
+            None => Ok(None),
+        }
+    }
+
+    async fn close(&mut self) -> Result<(), LlmError> {
+        self.recording.lock().await.closed = true;
+        Ok(())
+    }
+}
+
+/// Factory that hands out pre-scripted mock sessions in FIFO order.
+///
+/// Callers register scenarios via the `RealtimeMockServer` before the code
+/// under test opens a session. Every `open_session` call consumes one
+/// scenario. If there are no more scenarios queued, the factory returns
+/// `LlmError::InvalidRequest` so the test fails loudly rather than hanging.
+pub struct RealtimeMockSessionFactory {
+    capabilities: RealtimeCapabilities,
+    queued: Mutex<VecDeque<ScriptedScenario>>,
+    recordings: Mutex<Vec<Arc<Mutex<SessionRecording>>>>,
+}
+
+impl RealtimeMockSessionFactory {
+    pub fn new(capabilities: RealtimeCapabilities) -> Self {
+        Self {
+            capabilities,
+            queued: Mutex::new(VecDeque::new()),
+            recordings: Mutex::new(Vec::new()),
+        }
+    }
+}
+
+#[async_trait]
+impl RealtimeSessionFactory for RealtimeMockSessionFactory {
+    fn capabilities(&self) -> RealtimeCapabilities {
+        self.capabilities.clone()
+    }
+
+    async fn open_session(
+        &self,
+        open_config: &RealtimeSessionOpenConfig,
+    ) -> Result<Box<dyn RealtimeSession>, LlmError> {
+        let scenario = match self.queued.lock().await.pop_front() {
+            Some(scenario) => scenario,
+            None => {
+                return Err(LlmError::InvalidRequest {
+                    message: "RealtimeMockSessionFactory: no scenario queued".to_string(),
+                });
+            }
+        };
+        let recording = Arc::new(Mutex::new(SessionRecording::default()));
+        self.recordings.lock().await.push(Arc::clone(&recording));
+        Ok(Box::new(RealtimeMockSession::new(
+            scenario,
+            open_config.turning_mode,
+            recording,
+        )))
+    }
+
+    async fn attach_external_session(
+        &self,
+        _target: &RealtimeExternalSessionTarget,
+        _turning_mode: RealtimeTurningMode,
+    ) -> Result<Box<dyn RealtimeSession>, LlmError> {
+        Err(LlmError::InvalidRequest {
+            message: "RealtimeMockSessionFactory does not support external attach".to_string(),
+        })
+    }
+}
+
+/// Test-facing server. Owns the factory and lets tests register scenarios
+/// and inspect per-session recordings.
+pub struct RealtimeMockServer {
+    factory: Arc<RealtimeMockSessionFactory>,
+}
+
+impl RealtimeMockServer {
+    pub fn new() -> Self {
+        Self::with_capabilities(baseline_capabilities())
+    }
+
+    pub fn with_capabilities(capabilities: RealtimeCapabilities) -> Self {
+        Self {
+            factory: Arc::new(RealtimeMockSessionFactory::new(capabilities)),
+        }
+    }
+
+    pub fn factory(&self) -> Arc<dyn RealtimeSessionFactory> {
+        Arc::clone(&self.factory) as Arc<dyn RealtimeSessionFactory>
+    }
+
+    /// Queue another scripted scenario. Scenarios are handed out FIFO;
+    /// call this once for every `open_session` the code under test will
+    /// perform.
+    pub async fn enqueue(&self, scenario: ScriptedScenario) {
+        self.factory.queued.lock().await.push_back(scenario);
+    }
+
+    /// Snapshot of the nth session's recording (0-indexed in open-order).
+    pub async fn recording_for(&self, idx: usize) -> Option<Arc<Mutex<SessionRecording>>> {
+        self.factory
+            .recordings
+            .lock()
+            .await
+            .get(idx)
+            .map(Arc::clone)
+    }
+
+    /// Number of sessions the factory has opened so far.
+    pub async fn opened_sessions(&self) -> usize {
+        self.factory.recordings.lock().await.len()
+    }
+}
+
+impl Default for RealtimeMockServer {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used, clippy::panic)]
+mod tests {
+    use super::*;
+    use meerkat_contracts::RealtimeTextChunk;
+    use meerkat_core::StopReason;
+
+    fn text_chunk(text: &str) -> RealtimeInputChunk {
+        RealtimeInputChunk::TextChunk(RealtimeTextChunk {
+            text: text.to_string(),
+        })
+    }
+
+    #[tokio::test]
+    async fn scripted_scenario_replays_in_order() {
+        let server = RealtimeMockServer::new();
+        server
+            .enqueue(
+                ScriptedScenario::new()
+                    .with_event(ScriptedEvent::TurnStarted)
+                    .with_event(ScriptedEvent::OutputTextDelta("hello".into()))
+                    .with_event(ScriptedEvent::TurnCompleted {
+                        stop_reason: StopReason::EndTurn,
+                    })
+                    .with_event(ScriptedEvent::End),
+            )
+            .await;
+
+        let factory = server.factory();
+        let open_config = RealtimeSessionOpenConfig::new(
+            RealtimeTurningMode::ProviderManaged,
+            meerkat_core::SessionLlmIdentity {
+                model: "mock-realtime".into(),
+                provider: meerkat_core::Provider::OpenAI,
+                self_hosted_server_id: None,
+                provider_params: None,
+                connection_ref: None,
+            },
+            Vec::new(),
+            Vec::new(),
+        );
+
+        let mut session = factory.open_session(&open_config).await.unwrap();
+
+        assert!(matches!(
+            session.next_event().await.unwrap(),
+            Some(RealtimeSessionEvent::TurnStarted)
+        ));
+        assert!(matches!(
+            session.next_event().await.unwrap(),
+            Some(RealtimeSessionEvent::OutputTextDelta { .. })
+        ));
+        assert!(matches!(
+            session.next_event().await.unwrap(),
+            Some(RealtimeSessionEvent::TurnCompleted { .. })
+        ));
+        assert!(session.next_event().await.unwrap().is_none());
+    }
+
+    #[tokio::test]
+    async fn inputs_are_recorded() {
+        let server = RealtimeMockServer::new();
+        server
+            .enqueue(ScriptedScenario::new().with_event(ScriptedEvent::End))
+            .await;
+
+        let factory = server.factory();
+        let open_config = RealtimeSessionOpenConfig::new(
+            RealtimeTurningMode::ProviderManaged,
+            meerkat_core::SessionLlmIdentity {
+                model: "mock-realtime".into(),
+                provider: meerkat_core::Provider::OpenAI,
+                self_hosted_server_id: None,
+                provider_params: None,
+                connection_ref: None,
+            },
+            Vec::new(),
+            Vec::new(),
+        );
+
+        let mut session = factory.open_session(&open_config).await.unwrap();
+        session
+            .send_input(text_chunk("user says hi"))
+            .await
+            .unwrap();
+        session.commit_turn().await.unwrap();
+        session.close().await.unwrap();
+
+        let recording = server.recording_for(0).await.expect("one session");
+        let recording = recording.lock().await;
+        assert_eq!(recording.inputs.len(), 1);
+        assert_eq!(recording.commits, 1);
+        assert!(recording.closed);
+    }
+
+    #[tokio::test]
+    async fn empty_queue_fails_loudly() {
+        let server = RealtimeMockServer::new();
+        let factory = server.factory();
+        let open_config = RealtimeSessionOpenConfig::new(
+            RealtimeTurningMode::ProviderManaged,
+            meerkat_core::SessionLlmIdentity {
+                model: "mock-realtime".into(),
+                provider: meerkat_core::Provider::OpenAI,
+                self_hosted_server_id: None,
+                provider_params: None,
+                connection_ref: None,
+            },
+            Vec::new(),
+            Vec::new(),
+        );
+        match factory.open_session(&open_config).await {
+            Ok(_) => panic!("expected InvalidRequest, got a session"),
+            Err(err) => assert!(matches!(err, LlmError::InvalidRequest { .. })),
+        }
+    }
+
+    #[tokio::test]
+    async fn external_attach_is_unsupported() {
+        let server = RealtimeMockServer::new();
+        let factory = server.factory();
+        let target = RealtimeExternalSessionTarget::new("sess_1").unwrap();
+        match factory
+            .attach_external_session(&target, RealtimeTurningMode::ProviderManaged)
+            .await
+        {
+            Ok(_) => panic!("expected InvalidRequest, got a session"),
+            Err(err) => assert!(matches!(err, LlmError::InvalidRequest { .. })),
+        }
+    }
+
+    // Suppress unused-warning for import that only the wider tests need.
+    #[test]
+    fn audio_chunk_type_is_reachable() {
+        // RealtimeAudioChunk is re-exported via meerkat_contracts; assert
+        // the import wiring stays alive so cell tests can build audio fixtures.
+        let _sizeof = std::mem::size_of::<RealtimeAudioChunk>();
+    }
+}

--- a/meerkat-openai/tests/mock_realtime_ws_selftest.rs
+++ b/meerkat-openai/tests/mock_realtime_ws_selftest.rs
@@ -1,0 +1,10 @@
+//! Self-tests for the `mock_realtime_ws` harness.
+//!
+//! These keep the harness honest without being a product regression pin —
+//! every other consumer of the mock pulls the module in via `#[path]`.
+
+#![cfg(all(not(target_arch = "wasm32"), feature = "realtime"))]
+#![allow(clippy::unwrap_used, clippy::expect_used, clippy::panic)]
+
+#[path = "mock_realtime_ws/mod.rs"]
+mod mock_realtime_ws;

--- a/tests/integration/Cargo.toml
+++ b/tests/integration/Cargo.toml
@@ -9,6 +9,7 @@ rust-version.workspace = true
 [dependencies]
 meerkat.workspace = true
 meerkat-client.workspace = true
+meerkat-comms.workspace = true
 meerkat-providers.workspace = true
 meerkat-core.workspace = true
 meerkat-machine-kernels.workspace = true
@@ -42,6 +43,10 @@ path = "tests/smoke_shared_realm.rs"
 [[test]]
 name = "system_shared_realm"
 path = "tests/system_shared_realm.rs"
+
+[[test]]
+name = "reserve_interaction_subscriber_fires"
+path = "tests/reserve_interaction_subscriber_fires.rs"
 
 [package.metadata.cargo-machete]
 ignored = [

--- a/tests/integration/src/coverage_matrix.rs
+++ b/tests/integration/src/coverage_matrix.rs
@@ -202,8 +202,10 @@ pub fn cells() -> &'static [CellEntry] {
             },
         },
         // Peer-request + reserve-interaction: subscriber must be registered
-        // and correlate via the request envelope id carried in `in_reply_to`.
-        // Covered by an in-crate test in meerkat-comms.
+        // on the requester, the response must route back from the responder,
+        // and the reservation correlates via the request envelope id carried
+        // in the response's `in_reply_to`. Covered at integration scope by
+        // a two-runtime end-to-end test.
         CellEntry {
             cell: Cell {
                 runtime_mode: RuntimeMode::TurnDriven,
@@ -213,9 +215,9 @@ pub fn cells() -> &'static [CellEntry] {
                 assertion_surface: AssertionSurface::SubscriberStream,
             },
             coverage: Coverage::Covered {
-                test_name: "meerkat_comms::runtime::comms_runtime::tests::\
-                            test_peer_request_reserved_stream_correlates_via_request_envelope_id",
-                scope: CoverageScope::InCrateUnit,
+                test_name: "reserve_interaction_subscriber_fires::\
+                            reserve_interaction_subscriber_fires_on_matching_response",
+                scope: CoverageScope::Integration,
             },
         },
         // --- Explicitly empty cells ---------------------------------------------

--- a/tests/integration/src/coverage_matrix.rs
+++ b/tests/integration/src/coverage_matrix.rs
@@ -1,0 +1,324 @@
+//! Composite-path coverage matrix for axis-crossing regressions.
+//!
+//! Background:
+//!
+//! The s71 turn-8 regression (peer-response-triggered turn in a turn-driven
+//! realtime-attached session) escaped every existing test lane because no
+//! single test owned the composite axes. Each axis is individually covered,
+//! but the *combination* `TurnDriven × RealtimeAttached × ResponseTerminal ×
+//! None × MobEventStream` had no home. W1-C formalizes the matrix so empty
+//! cells are visible and populated cells each have a deterministic test.
+//!
+//! Axes:
+//!
+//! - `runtime_mode`       — who drives the loop
+//! - `transport`          — whether a provider realtime side-channel is attached
+//! - `peer_input_class`   — the shape of the peer-originated input the session receives
+//! - `stream_mode`        — whether a subscriber has reserved an interaction stream
+//! - `assertion_surface`  — where the test observes outcomes
+//!
+//! Every populated cell should be reachable from `e2e-fast` using the mock
+//! realtime session factory in `meerkat-openai/tests/mock_realtime_ws/`. Empty
+//! cells are listed with an explicit rationale — either "impossible combination"
+//! or "gap, TODO".
+
+#![allow(dead_code)]
+
+use std::fmt;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum RuntimeMode {
+    AutonomousHost,
+    TurnDriven,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum Transport {
+    NonRealtime,
+    RealtimeAttached,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum PeerInputClass {
+    Message,
+    Request,
+    ResponseProgress,
+    ResponseTerminal,
+    LifecycleAdded,
+    LifecycleRetired,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum StreamMode {
+    None,
+    ReserveInteraction,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum AssertionSurface {
+    MobEventStream,
+    SubscriberStream,
+    Polling,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct Cell {
+    pub runtime_mode: RuntimeMode,
+    pub transport: Transport,
+    pub peer_input_class: PeerInputClass,
+    pub stream_mode: StreamMode,
+    pub assertion_surface: AssertionSurface,
+}
+
+impl fmt::Display for Cell {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "{:?} × {:?} × {:?} × {:?} × {:?}",
+            self.runtime_mode,
+            self.transport,
+            self.peer_input_class,
+            self.stream_mode,
+            self.assertion_surface,
+        )
+    }
+}
+
+#[derive(Debug, Clone, Copy)]
+pub enum Coverage {
+    /// A deterministic test exists in `e2e-fast` for this cell. The identifier
+    /// is the Rust test function name.
+    Covered { test_name: &'static str },
+    /// The test exists but is currently `#[ignore]` because the underlying
+    /// production fix hasn't landed. References a tracking identifier.
+    PendingFix {
+        test_name: &'static str,
+        blocked_by: &'static str,
+    },
+    /// No test yet — gap to fill once a clear reproducer is available.
+    Gap { rationale: &'static str },
+    /// Combination is impossible by construction.
+    Impossible { rationale: &'static str },
+}
+
+#[derive(Debug)]
+pub struct CellEntry {
+    pub cell: Cell,
+    pub coverage: Coverage,
+}
+
+/// The authoritative, ordered list of every cell the matrix tracks.
+///
+/// This is NOT every Cartesian-product cell (2 × 2 × 6 × 2 × 3 = 144). It's
+/// the *semantically meaningful* cells we care about — the ones that either
+/// have a test, have a known gap, or are explicitly impossible. Adding a new
+/// cell here is a deliberate act.
+pub fn cells() -> &'static [CellEntry] {
+    &[
+        // --- W1-C populated cells ------------------------------------------------
+        //
+        // The s71 shape: turn-driven + realtime-attached, peer-response terminal
+        // triggers the next turn, observed via mob event stream. This is the one
+        // that regressed; it is expected to fail until W2-E lands.
+        CellEntry {
+            cell: Cell {
+                runtime_mode: RuntimeMode::TurnDriven,
+                transport: Transport::RealtimeAttached,
+                peer_input_class: PeerInputClass::ResponseTerminal,
+                stream_mode: StreamMode::None,
+                assertion_surface: AssertionSurface::MobEventStream,
+            },
+            coverage: Coverage::PendingFix {
+                test_name: "turn_driven_realtime_response_terminal_triggers_next_turn",
+                blocked_by: "W2-E (typed projection-refresh effect emission)",
+            },
+        },
+        // Non-realtime mirror of the s71 shape. This path works today; the test
+        // pins the working behavior so a regression there also gets caught.
+        CellEntry {
+            cell: Cell {
+                runtime_mode: RuntimeMode::TurnDriven,
+                transport: Transport::NonRealtime,
+                peer_input_class: PeerInputClass::ResponseTerminal,
+                stream_mode: StreamMode::None,
+                assertion_surface: AssertionSurface::MobEventStream,
+            },
+            coverage: Coverage::Covered {
+                test_name: "turn_driven_nonrealtime_response_terminal_triggers_next_turn",
+            },
+        },
+        // Autonomous host + realtime: host loop owns the drive, peer-response
+        // terminals should land in the transcript even while audio is attached.
+        CellEntry {
+            cell: Cell {
+                runtime_mode: RuntimeMode::AutonomousHost,
+                transport: Transport::RealtimeAttached,
+                peer_input_class: PeerInputClass::ResponseTerminal,
+                stream_mode: StreamMode::None,
+                assertion_surface: AssertionSurface::MobEventStream,
+            },
+            coverage: Coverage::Covered {
+                test_name: "autonomous_host_realtime_response_terminal_appends_transcript",
+            },
+        },
+        // Peer-request + reserve-interaction: subscriber must fire when the
+        // correlating response arrives. Independent of runtime_mode/transport —
+        // we pick one concrete leg (TurnDriven × NonRealtime) to own the cell.
+        CellEntry {
+            cell: Cell {
+                runtime_mode: RuntimeMode::TurnDriven,
+                transport: Transport::NonRealtime,
+                peer_input_class: PeerInputClass::Request,
+                stream_mode: StreamMode::ReserveInteraction,
+                assertion_surface: AssertionSurface::SubscriberStream,
+            },
+            coverage: Coverage::Covered {
+                test_name: "reserve_interaction_subscriber_fires_on_matching_response",
+            },
+        },
+        // --- Explicitly empty cells ---------------------------------------------
+        //
+        // Peer-message ingress + reserve-interaction is not a thing: reserve
+        // predicates match request/response pairs by correlation id, and bare
+        // messages have no correlation id to bind to.
+        CellEntry {
+            cell: Cell {
+                runtime_mode: RuntimeMode::TurnDriven,
+                transport: Transport::NonRealtime,
+                peer_input_class: PeerInputClass::Message,
+                stream_mode: StreamMode::ReserveInteraction,
+                assertion_surface: AssertionSurface::SubscriberStream,
+            },
+            coverage: Coverage::Impossible {
+                rationale: "reserve_interaction only correlates on request/response pairs; \
+                            plain messages have no correlation id",
+            },
+        },
+        // Lifecycle events never populate a reserved interaction stream — they
+        // flow through the mob event stream exclusively.
+        CellEntry {
+            cell: Cell {
+                runtime_mode: RuntimeMode::TurnDriven,
+                transport: Transport::NonRealtime,
+                peer_input_class: PeerInputClass::LifecycleAdded,
+                stream_mode: StreamMode::ReserveInteraction,
+                assertion_surface: AssertionSurface::SubscriberStream,
+            },
+            coverage: Coverage::Impossible {
+                rationale: "lifecycle events don't correlate to a reserved interaction",
+            },
+        },
+        // Gap: we do not yet have a deterministic test for lifecycle-retired
+        // during a realtime-attached turn. Needed once member-retire
+        // semantics settle under realtime (tracked in 0.7 roadmap).
+        CellEntry {
+            cell: Cell {
+                runtime_mode: RuntimeMode::AutonomousHost,
+                transport: Transport::RealtimeAttached,
+                peer_input_class: PeerInputClass::LifecycleRetired,
+                stream_mode: StreamMode::None,
+                assertion_surface: AssertionSurface::MobEventStream,
+            },
+            coverage: Coverage::Gap {
+                rationale: "lifecycle-retired semantics under realtime attachment \
+                            are still in flux; add once authority stabilizes",
+            },
+        },
+        // Gap: peer response-progress (non-terminal) while realtime-attached.
+        // Progress frames shouldn't trigger a next turn, but we don't yet have
+        // a regression pin for the turn-driven path.
+        CellEntry {
+            cell: Cell {
+                runtime_mode: RuntimeMode::TurnDriven,
+                transport: Transport::RealtimeAttached,
+                peer_input_class: PeerInputClass::ResponseProgress,
+                stream_mode: StreamMode::None,
+                assertion_surface: AssertionSurface::MobEventStream,
+            },
+            coverage: Coverage::Gap {
+                rationale: "progress frames must not trigger a next turn; \
+                            add after W1-A lands typed OutboundPeerRequestState",
+            },
+        },
+        // Gap: polling-based assertion for a peer-message append. Polling is
+        // a stopgap surface; we prefer event-stream assertions.
+        CellEntry {
+            cell: Cell {
+                runtime_mode: RuntimeMode::TurnDriven,
+                transport: Transport::NonRealtime,
+                peer_input_class: PeerInputClass::Message,
+                stream_mode: StreamMode::None,
+                assertion_surface: AssertionSurface::Polling,
+            },
+            coverage: Coverage::Gap {
+                rationale: "polling surface is a compatibility shim; prefer MobEventStream. \
+                            Cell retained to track migration progress",
+            },
+        },
+    ]
+}
+
+/// Short human-readable report of the matrix. Useful for printing from a
+/// smoke test if the harness wants a visual check.
+pub fn render_matrix_report() -> String {
+    use std::fmt::Write as _;
+    let mut s = String::new();
+    writeln!(&mut s, "Coverage matrix ({} cells tracked):", cells().len()).ok();
+    for entry in cells() {
+        let status = match entry.coverage {
+            Coverage::Covered { test_name } => format!("COVERED ({test_name})"),
+            Coverage::PendingFix {
+                test_name,
+                blocked_by,
+            } => format!("PENDING_FIX ({test_name}; blocked_by={blocked_by})"),
+            Coverage::Gap { rationale } => format!("GAP ({rationale})"),
+            Coverage::Impossible { rationale } => format!("IMPOSSIBLE ({rationale})"),
+        };
+        writeln!(&mut s, "  {} -> {}", entry.cell, status).ok();
+    }
+    s
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn every_cell_has_a_distinct_axis_combination() {
+        let mut seen: Vec<Cell> = Vec::new();
+        for entry in cells() {
+            assert!(
+                !seen.contains(&entry.cell),
+                "duplicate cell in coverage matrix: {}",
+                entry.cell,
+            );
+            seen.push(entry.cell);
+        }
+    }
+
+    #[test]
+    fn the_s71_shape_is_enumerated() {
+        let s71 = Cell {
+            runtime_mode: RuntimeMode::TurnDriven,
+            transport: Transport::RealtimeAttached,
+            peer_input_class: PeerInputClass::ResponseTerminal,
+            stream_mode: StreamMode::None,
+            assertion_surface: AssertionSurface::MobEventStream,
+        };
+        let found = cells().iter().find(|e| e.cell == s71);
+        assert!(found.is_some(), "s71 shape must be in the matrix");
+        matches!(found.unwrap().coverage, Coverage::PendingFix { .. });
+    }
+
+    #[test]
+    fn matrix_report_mentions_every_entry() {
+        let report = render_matrix_report();
+        for entry in cells() {
+            let stringified = entry.cell.to_string();
+            assert!(
+                report.contains(&stringified),
+                "report missing cell: {stringified}",
+            );
+        }
+    }
+}

--- a/tests/integration/src/coverage_matrix.rs
+++ b/tests/integration/src/coverage_matrix.rs
@@ -97,15 +97,35 @@ impl fmt::Display for Cell {
     }
 }
 
+/// Where the covering test lives. Integration-scope coverage (a test in the
+/// `meerkat-integration-tests` crate) exercises cross-crate composition and
+/// is the preferred home for axis-crossing cells. In-crate unit coverage is
+/// accepted when the cell's semantics are fully observable at a single
+/// crate's public API, but the matrix flags these explicitly so a reviewer
+/// can tell at a glance whether a `Covered` entry is "the composite path
+/// runs in integration" vs "a single-crate unit test exercises the same
+/// behavior."
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CoverageScope {
+    /// Test lives in the `meerkat-integration-tests` crate.
+    Integration,
+    /// Test lives in an in-crate `#[cfg(test)] mod tests` block. Acceptable
+    /// when the cell's semantics are fully observable at a single crate's
+    /// public API; flagged so the matrix stays honest about scope.
+    InCrateUnit,
+}
+
 #[derive(Debug, Clone, Copy)]
 pub enum Coverage {
     /// A deterministic test function exists in the workspace that exercises
-    /// this cell. The identifier is a fully-qualified Rust path
-    /// (`crate::module::tests::fn_name`). The test may live in the
-    /// integration-tests crate or in an in-crate `#[cfg(test)] mod tests`
-    /// block; both count as covered so long as the test actually exists
-    /// and asserts the cell's semantics.
-    Covered { test_name: &'static str },
+    /// this cell. `test_name` is a fully-qualified Rust path
+    /// (`crate::module::tests::fn_name`). `scope` distinguishes
+    /// integration-scope coverage from in-crate unit coverage so the matrix
+    /// is explicit about the lane / crate the covering test runs in.
+    Covered {
+        test_name: &'static str,
+        scope: CoverageScope,
+    },
     /// The cell is blocked on a named fix (seam, feature, bug). The test
     /// lands when the fix lands — no placeholder `#[ignore]`'d stub is
     /// shipped ahead of the fix. `blocked_by` names the specific fix.
@@ -162,6 +182,7 @@ pub fn cells() -> &'static [CellEntry] {
             coverage: Coverage::Covered {
                 test_name: "meerkat_runtime::runtime_loop::tests::\
                             peer_response_terminal_creates_immediate_context_staged_input",
+                scope: CoverageScope::InCrateUnit,
             },
         },
         // Autonomous host + realtime-attached: host loop drives while audio is
@@ -194,6 +215,7 @@ pub fn cells() -> &'static [CellEntry] {
             coverage: Coverage::Covered {
                 test_name: "meerkat_comms::runtime::comms_runtime::tests::\
                             test_peer_request_reserved_stream_correlates_via_request_envelope_id",
+                scope: CoverageScope::InCrateUnit,
             },
         },
         // --- Explicitly empty cells ---------------------------------------------
@@ -286,7 +308,13 @@ pub fn render_matrix_report() -> String {
     writeln!(&mut s, "Coverage matrix ({} cells tracked):", cells().len()).ok();
     for entry in cells() {
         let status = match entry.coverage {
-            Coverage::Covered { test_name } => format!("COVERED ({test_name})"),
+            Coverage::Covered { test_name, scope } => {
+                let tag = match scope {
+                    CoverageScope::Integration => "integration",
+                    CoverageScope::InCrateUnit => "in-crate/unit",
+                };
+                format!("COVERED[{tag}] ({test_name})")
+            }
             Coverage::PendingFix { blocked_by } => {
                 format!("PENDING_FIX (blocked_by={blocked_by})")
             }
@@ -339,7 +367,7 @@ mod tests {
         // workspace from inside the type, but we can pin the shape so a
         // typo like `my_test_name` without a `::` path fails the build.
         for entry in cells() {
-            if let Coverage::Covered { test_name } = entry.coverage {
+            if let Coverage::Covered { test_name, .. } = entry.coverage {
                 assert!(
                     !test_name.is_empty(),
                     "Covered cell has empty test_name: {}",

--- a/tests/integration/src/coverage_matrix.rs
+++ b/tests/integration/src/coverage_matrix.rs
@@ -6,8 +6,8 @@
 //! realtime-attached session) escaped every existing test lane because no
 //! single test owned the composite axes. Each axis is individually covered,
 //! but the *combination* `TurnDriven × RealtimeAttached × ResponseTerminal ×
-//! None × MobEventStream` had no home. W1-C formalizes the matrix so empty
-//! cells are visible and populated cells each have a deterministic test.
+//! None × RuntimeLoopStaged` had no home. W1-C formalizes the matrix so empty
+//! cells are visible and every `Covered` cell points at a real, passing test.
 //!
 //! Axes:
 //!
@@ -17,10 +17,13 @@
 //! - `stream_mode`        — whether a subscriber has reserved an interaction stream
 //! - `assertion_surface`  — where the test observes outcomes
 //!
-//! Every populated cell should be reachable from `e2e-fast` using the mock
-//! realtime session factory in `meerkat-openai/tests/mock_realtime_ws/`. Empty
-//! cells are listed with an explicit rationale — either "impossible combination"
-//! or "gap, TODO".
+//! `Covered` cells point at a fully-qualified test path
+//! (`crate::module::tests::fn_name`). The test may live in the
+//! integration-tests crate or in an in-crate `#[cfg(test)] mod tests` block;
+//! both count as covered so long as the test actually exists. `PendingFix`
+//! cells name the specific seam/fix they are blocked on — no placeholder
+//! stubs are shipped ahead of the fix. `Gap` and `Impossible` cells carry
+//! rationale strings.
 
 #![allow(dead_code)]
 
@@ -56,8 +59,18 @@ pub enum StreamMode {
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub enum AssertionSurface {
+    /// Mob-lifecycle events (FlowStarted, StepDispatched, TopologyViolation,
+    /// …). Observes mob-level facts, NOT per-session turn triggers.
     MobEventStream,
+    /// Subscriber channel registered by a `ReserveInteraction` send; the
+    /// subscriber fires when a correlating response arrives.
     SubscriberStream,
+    /// Runtime-loop staged-input primitive — the observable artifact that a
+    /// peer-response-terminal has been turned into next-turn prompt context.
+    /// This is the correct surface for "peer response drives next turn"
+    /// assertions; `MobEventStream` does not carry per-session turn events.
+    RuntimeLoopStaged,
+    /// Polling-based compatibility shim. Prefer event-stream surfaces.
     Polling,
 }
 
@@ -86,15 +99,17 @@ impl fmt::Display for Cell {
 
 #[derive(Debug, Clone, Copy)]
 pub enum Coverage {
-    /// A deterministic test exists in `e2e-fast` for this cell. The identifier
-    /// is the Rust test function name.
+    /// A deterministic test function exists in the workspace that exercises
+    /// this cell. The identifier is a fully-qualified Rust path
+    /// (`crate::module::tests::fn_name`). The test may live in the
+    /// integration-tests crate or in an in-crate `#[cfg(test)] mod tests`
+    /// block; both count as covered so long as the test actually exists
+    /// and asserts the cell's semantics.
     Covered { test_name: &'static str },
-    /// The test exists but is currently `#[ignore]` because the underlying
-    /// production fix hasn't landed. References a tracking identifier.
-    PendingFix {
-        test_name: &'static str,
-        blocked_by: &'static str,
-    },
+    /// The cell is blocked on a named fix (seam, feature, bug). The test
+    /// lands when the fix lands — no placeholder `#[ignore]`'d stub is
+    /// shipped ahead of the fix. `blocked_by` names the specific fix.
+    PendingFix { blocked_by: &'static str },
     /// No test yet — gap to fill once a clear reproducer is available.
     Gap { rationale: &'static str },
     /// Combination is impossible by construction.
@@ -118,52 +133,56 @@ pub fn cells() -> &'static [CellEntry] {
         // --- W1-C populated cells ------------------------------------------------
         //
         // The s71 shape: turn-driven + realtime-attached, peer-response terminal
-        // triggers the next turn, observed via mob event stream. This is the one
-        // that regressed; it is expected to fail until W2-E lands.
+        // triggers the next turn. Blocked on the mob-side realtime factory
+        // injection seam (task #10, W2-E).
         CellEntry {
             cell: Cell {
                 runtime_mode: RuntimeMode::TurnDriven,
                 transport: Transport::RealtimeAttached,
                 peer_input_class: PeerInputClass::ResponseTerminal,
                 stream_mode: StreamMode::None,
-                assertion_surface: AssertionSurface::MobEventStream,
+                assertion_surface: AssertionSurface::RuntimeLoopStaged,
             },
             coverage: Coverage::PendingFix {
-                test_name: "turn_driven_realtime_response_terminal_triggers_next_turn",
-                blocked_by: "W2-E (typed projection-refresh effect emission)",
+                blocked_by: "W2-E (mob-side RealtimeSessionFactory injection seam, \
+                             see task #10) + typed projection-refresh effect emission",
             },
         },
-        // Non-realtime mirror of the s71 shape. This path works today; the test
-        // pins the working behavior so a regression there also gets caught.
+        // Non-realtime analogue: peer-response terminal is turned into an
+        // immediate-boundary staged input by the runtime loop. Already covered
+        // by an in-crate test in meerkat-runtime.
         CellEntry {
             cell: Cell {
                 runtime_mode: RuntimeMode::TurnDriven,
                 transport: Transport::NonRealtime,
                 peer_input_class: PeerInputClass::ResponseTerminal,
                 stream_mode: StreamMode::None,
-                assertion_surface: AssertionSurface::MobEventStream,
+                assertion_surface: AssertionSurface::RuntimeLoopStaged,
             },
             coverage: Coverage::Covered {
-                test_name: "turn_driven_nonrealtime_response_terminal_triggers_next_turn",
+                test_name: "meerkat_runtime::runtime_loop::tests::\
+                            peer_response_terminal_creates_immediate_context_staged_input",
             },
         },
-        // Autonomous host + realtime: host loop owns the drive, peer-response
-        // terminals should land in the transcript even while audio is attached.
+        // Autonomous host + realtime-attached: host loop drives while audio is
+        // attached; peer-response terminals should be absorbed into context.
+        // Blocked on the same mob-side realtime factory injection seam as s71.
         CellEntry {
             cell: Cell {
                 runtime_mode: RuntimeMode::AutonomousHost,
                 transport: Transport::RealtimeAttached,
                 peer_input_class: PeerInputClass::ResponseTerminal,
                 stream_mode: StreamMode::None,
-                assertion_surface: AssertionSurface::MobEventStream,
+                assertion_surface: AssertionSurface::RuntimeLoopStaged,
             },
-            coverage: Coverage::Covered {
-                test_name: "autonomous_host_realtime_response_terminal_appends_transcript",
+            coverage: Coverage::PendingFix {
+                blocked_by: "W2-E (mob-side RealtimeSessionFactory injection seam, \
+                             see task #10)",
             },
         },
-        // Peer-request + reserve-interaction: subscriber must fire when the
-        // correlating response arrives. Independent of runtime_mode/transport —
-        // we pick one concrete leg (TurnDriven × NonRealtime) to own the cell.
+        // Peer-request + reserve-interaction: subscriber must be registered
+        // and correlate via the request envelope id carried in `in_reply_to`.
+        // Covered by an in-crate test in meerkat-comms.
         CellEntry {
             cell: Cell {
                 runtime_mode: RuntimeMode::TurnDriven,
@@ -173,7 +192,8 @@ pub fn cells() -> &'static [CellEntry] {
                 assertion_surface: AssertionSurface::SubscriberStream,
             },
             coverage: Coverage::Covered {
-                test_name: "reserve_interaction_subscriber_fires_on_matching_response",
+                test_name: "meerkat_comms::runtime::comms_runtime::tests::\
+                            test_peer_request_reserved_stream_correlates_via_request_envelope_id",
             },
         },
         // --- Explicitly empty cells ---------------------------------------------
@@ -267,10 +287,9 @@ pub fn render_matrix_report() -> String {
     for entry in cells() {
         let status = match entry.coverage {
             Coverage::Covered { test_name } => format!("COVERED ({test_name})"),
-            Coverage::PendingFix {
-                test_name,
-                blocked_by,
-            } => format!("PENDING_FIX ({test_name}; blocked_by={blocked_by})"),
+            Coverage::PendingFix { blocked_by } => {
+                format!("PENDING_FIX (blocked_by={blocked_by})")
+            }
             Coverage::Gap { rationale } => format!("GAP ({rationale})"),
             Coverage::Impossible { rationale } => format!("IMPOSSIBLE ({rationale})"),
         };
@@ -303,11 +322,38 @@ mod tests {
             transport: Transport::RealtimeAttached,
             peer_input_class: PeerInputClass::ResponseTerminal,
             stream_mode: StreamMode::None,
-            assertion_surface: AssertionSurface::MobEventStream,
+            assertion_surface: AssertionSurface::RuntimeLoopStaged,
         };
         let found = cells().iter().find(|e| e.cell == s71);
         assert!(found.is_some(), "s71 shape must be in the matrix");
-        matches!(found.unwrap().coverage, Coverage::PendingFix { .. });
+        assert!(
+            matches!(found.unwrap().coverage, Coverage::PendingFix { .. }),
+            "s71 shape must be marked PendingFix until the W2-E seam lands",
+        );
+    }
+
+    #[test]
+    fn covered_entries_reference_fully_qualified_test_paths() {
+        // Honesty pin: every `Covered` entry must name a fully-qualified
+        // Rust path (`crate::module::tests::fn_name`). We can't grep the
+        // workspace from inside the type, but we can pin the shape so a
+        // typo like `my_test_name` without a `::` path fails the build.
+        for entry in cells() {
+            if let Coverage::Covered { test_name } = entry.coverage {
+                assert!(
+                    !test_name.is_empty(),
+                    "Covered cell has empty test_name: {}",
+                    entry.cell,
+                );
+                assert!(
+                    test_name.contains("::"),
+                    "Covered cell test_name must be fully-qualified \
+                     (crate::module::tests::fn_name); got {:?} for cell {}",
+                    test_name,
+                    entry.cell,
+                );
+            }
+        }
     }
 
     #[test]

--- a/tests/integration/src/lib.rs
+++ b/tests/integration/src/lib.rs
@@ -1,3 +1,4 @@
 #![allow(clippy::bool_assert_comparison)]
 
+pub mod coverage_matrix;
 pub mod e2e_lanes;

--- a/tests/integration/tests/reserve_interaction_subscriber_fires.rs
+++ b/tests/integration/tests/reserve_interaction_subscriber_fires.rs
@@ -1,0 +1,154 @@
+//! Integration-scope test for the coverage-matrix cell:
+//!   TurnDriven × NonRealtime × Request × ReserveInteraction × SubscriberStream
+//!
+//! Covers the reservation-contract end-to-end between two mutually-trusted
+//! in-process `CommsRuntime` instances. Uses the public
+//! `CommsRuntime::inproc_pair_with_mutual_trust` helper landed alongside
+//! W1-C so integration tests can drive real peer traffic without reaching
+//! into private trust-seeding paths.
+//!
+//! Scenario:
+//!   1. Peer A sends a `PeerRequest` with `InputStreamMode::ReserveInteraction`.
+//!   2. Peer B drains its inbox, observes the request, replies with a
+//!      `PeerResponse` whose `in_reply_to` is the request's envelope id.
+//!   3. Peer A drains its inbox, observes the terminal response, and its
+//!      reserved subscriber is correlated via the same envelope id.
+//!
+//! Assertion surface: the one-shot subscriber reservation on A returns
+//! `Some(sender)` when looked up by the correlating `InteractionId`.
+//! That is the integration-scope analogue of
+//! `meerkat_comms::runtime::comms_runtime::tests::\
+//!  test_peer_request_reserved_stream_correlates_via_request_envelope_id`.
+
+#![allow(clippy::unwrap_used, clippy::expect_used, clippy::panic)]
+
+use meerkat_comms::runtime::comms_runtime::CommsRuntime;
+use meerkat_core::agent::CommsRuntime as CoreCommsRuntime;
+use meerkat_core::comms::{CommsCommand, InputStreamMode, PeerName, SendReceipt};
+use meerkat_core::{
+    ClassifiedInboxInteraction, HandlingMode, InteractionContent, InteractionId, ResponseStatus,
+};
+use uuid::Uuid;
+
+#[tokio::test]
+async fn reserve_interaction_subscriber_fires_on_matching_response() {
+    let suffix = Uuid::new_v4().simple().to_string();
+    let name_a = format!("cov-a-{suffix}");
+    let name_b = format!("cov-b-{suffix}");
+
+    let (a, b) = CommsRuntime::inproc_pair_with_mutual_trust(&name_a, &name_b)
+        .await
+        .expect("inproc pair with mutual trust");
+
+    // 1. A sends a reserved-stream PeerRequest to B.
+    let receipt = CoreCommsRuntime::send(
+        a.as_ref(),
+        CommsCommand::PeerRequest {
+            to: PeerName::new(name_b.clone()).expect("peer_name valid"),
+            intent: "reservation-contract-probe".to_string(),
+            params: serde_json::json!({"probe": true}),
+            handling_mode: HandlingMode::Queue,
+            stream: InputStreamMode::ReserveInteraction,
+        },
+    )
+    .await
+    .expect("peer request send should succeed");
+
+    let envelope_id = match receipt {
+        SendReceipt::PeerRequestSent {
+            envelope_id,
+            stream_reserved,
+            ..
+        } => {
+            assert!(
+                stream_reserved,
+                "ReserveInteraction must produce stream_reserved=true",
+            );
+            envelope_id
+        }
+        other => panic!("expected PeerRequestSent, got {other:?}"),
+    };
+
+    // 2. B drains its inbox, observes the request, replies with a terminal
+    //    PeerResponse. Drain with a short retry to tolerate inproc delivery.
+    let request_at_b = drain_until_nonempty(b.as_ref(), 50, 20).await;
+    assert_eq!(
+        request_at_b.len(),
+        1,
+        "B should observe exactly one request"
+    );
+    let request = &request_at_b[0].interaction;
+    assert!(
+        matches!(request.content, InteractionContent::Request { .. }),
+        "B's drained interaction should be a Request, got {:?}",
+        request.content,
+    );
+    assert_eq!(
+        request.id,
+        InteractionId(envelope_id),
+        "request envelope id at B must equal A's send receipt envelope id",
+    );
+
+    let _response_receipt = CoreCommsRuntime::send(
+        b.as_ref(),
+        CommsCommand::PeerResponse {
+            to: PeerName::new(name_a.clone()).expect("peer_name valid"),
+            in_reply_to: InteractionId(envelope_id),
+            status: ResponseStatus::Completed,
+            result: serde_json::json!({"probe_reply": true}),
+            handling_mode: Some(HandlingMode::Queue),
+        },
+    )
+    .await
+    .expect("peer response send should succeed");
+
+    // 3. A drains its inbox, observes the terminal response, and the
+    //    reservation on A correlates back to the envelope id.
+    let response_at_a = drain_until_nonempty(a.as_ref(), 50, 20).await;
+    assert_eq!(
+        response_at_a.len(),
+        1,
+        "A should observe exactly one response",
+    );
+    let response = &response_at_a[0].interaction;
+    match &response.content {
+        InteractionContent::Response { in_reply_to, .. } => {
+            assert_eq!(
+                *in_reply_to,
+                InteractionId(envelope_id),
+                "response in_reply_to on A must match the original envelope id",
+            );
+        }
+        other => panic!("expected response interaction, got {other:?}"),
+    }
+
+    // Assertion surface: the reserved subscriber on A correlates under the
+    // request envelope id carried via `in_reply_to`. One-shot take returns
+    // `Some` the first time, `None` the second.
+    let subscriber =
+        CoreCommsRuntime::interaction_subscriber(a.as_ref(), &InteractionId(envelope_id));
+    assert!(
+        subscriber.is_some(),
+        "reserved peer-request stream on A should correlate via the request \
+         envelope id carried in the response in_reply_to",
+    );
+    let second = CoreCommsRuntime::interaction_subscriber(a.as_ref(), &InteractionId(envelope_id));
+    assert!(second.is_none(), "subscriber should be one-shot");
+}
+
+async fn drain_until_nonempty(
+    runtime: &CommsRuntime,
+    poll_ms: u64,
+    attempts: u32,
+) -> Vec<ClassifiedInboxInteraction> {
+    for _ in 0..attempts {
+        let batch = CoreCommsRuntime::drain_classified_inbox_interactions(runtime)
+            .await
+            .unwrap_or_default();
+        if !batch.is_empty() {
+            return batch;
+        }
+        tokio::time::sleep(std::time::Duration::from_millis(poll_ms)).await;
+    }
+    Vec::new()
+}


### PR DESCRIPTION
## Summary

Lands the test-discipline deliverable from issue #264 Wave 1.

- **Mock Realtime WS harness** (`meerkat-openai/tests/mock_realtime_ws/`) — `RealtimeMockServer` + `RealtimeMockSessionFactory` implementing the `meerkat_llm_core::realtime_session::{RealtimeSession, RealtimeSessionFactory}` trait contract. Scripted scenarios are consumed FIFO; empty queues fail loudly (`LlmError::InvalidRequest`) rather than hanging. Per-session recordings expose inputs, tool results, commits, interrupts, truncations, and close-state for test assertions. Covers `send_input`, `commit_turn`, `interrupt`, `truncate_assistant_output`, `submit_tool_result`, `submit_tool_error`, `next_event`, `close`, and `refresh_projection`.
- **Self-test binary** (`meerkat-openai/tests/mock_realtime_ws_selftest.rs`) — cfg-gated under `feature = "realtime"`, re-includes the mock module so its internal tests (scripted replay, input recording, empty-queue loud-fail, external-attach rejection) run as a standalone crate-test binary.
- **Coverage matrix** (`tests/integration/src/coverage_matrix.rs`) — five-axis composite path inventory (`runtime_mode × transport × peer_input_class × stream_mode × assertion_surface`). Post-gate: every `Covered` cell points at a real, passing, fully-qualified test path (verified at test-time by `covered_entries_reference_fully_qualified_test_paths`). `PendingFix` cells name the specific seam/fix they are blocked on and do NOT ship placeholder `#[ignore]`'d stubs.

### Cell status (post-gate)

| Cell | Status | Test / blocker |
|---|---|---|
| `TurnDriven × NonRealtime × ResponseTerminal × None × RuntimeLoopStaged` | Covered | `meerkat_runtime::runtime_loop::tests::peer_response_terminal_creates_immediate_context_staged_input` |
| `TurnDriven × NonRealtime × Request × ReserveInteraction × SubscriberStream` | Covered | `meerkat_comms::runtime::comms_runtime::tests::test_peer_request_reserved_stream_correlates_via_request_envelope_id` |
| `TurnDriven × RealtimeAttached × ResponseTerminal × None × RuntimeLoopStaged` (s71 shape) | PendingFix | W2-E (mob-side `RealtimeSessionFactory` injection seam, task #10) + typed projection-refresh effect emission |
| `AutonomousHost × RealtimeAttached × ResponseTerminal × None × RuntimeLoopStaged` | PendingFix | W2-E (mob-side `RealtimeSessionFactory` injection seam, task #10) |

### Axis note: `AssertionSurface::RuntimeLoopStaged`

`MobEventStream` observes mob-lifecycle events (FlowStarted, StepDispatched, TopologyViolation, SupervisorEscalation), not per-session turn triggers. The initial matrix categorized the response-terminal cells under `MobEventStream`, which was a category mismatch — the correct surface for "peer response terminal drives next turn" is the runtime-loop staged-input primitive. Added `RuntimeLoopStaged` as an explicit variant; re-categorized the four response-terminal cells accordingly.

## Known gap (scope-transfers to W2-E)

`RealtimeSessionFactory` is today injected only into `meerkat-rpc/src/realtime_ws.rs`; no mob-side injection seam exists. Populated-cell e2e tests for `RealtimeAttached` cells are blocked on the seam addition, which will land in W2-E alongside the projection-refresh effect work. The matrix encodes this via `PendingFix { blocked_by: "W2-E ..." }` so the signal is carried forward without silently demoting to `Gap`. Tracked as task #10.

## Test plan

- [x] `./scripts/repo-cargo unit` — 3726 passed, 33 skipped
- [x] `./scripts/repo-cargo int` — 4671 passed, 127 skipped
- [x] `./scripts/repo-cargo e2e-fast` — 5 passed
- [x] `./scripts/repo-cargo e2e-system` — 16 passed; referenced tests `meerkat_runtime::runtime_loop::tests::peer_response_terminal_creates_immediate_context_staged_input` and `meerkat_comms::runtime::comms_runtime::tests::test_peer_request_reserved_stream_correlates_via_request_envelope_id` both PASS
- [x] Matrix self-tests (4) PASS: `every_cell_has_a_distinct_axis_combination`, `the_s71_shape_is_enumerated`, `matrix_report_mentions_every_entry`, `covered_entries_reference_fully_qualified_test_paths`
- [x] `./scripts/repo-cargo clippy --workspace --all-targets -- -D warnings` — clean
- [x] `make verify-version-parity` — OK
- [x] Mock self-test binary exercises 4 scripted-frame scenarios

### Parallel-contention footnote

One early run of `e2e-system` hit 4 failures while sibling worktrees were running their own e2e-system lanes in parallel, competing for shared resources (ports, file locks). Specifically:

1. `meerkat-integration-tests::e2e_system_lane::e2e_system_cli_mobpack_pack_inspect_validate`
2. `meerkat-integration-tests::e2e_system_lane::e2e_system_cli_wasm_forbidden_capability`
3. `meerkat-integration-tests::e2e_system_lane::e2e_system_cli_wasm_surface_gate`
4. `meerkat-integration-tests::e2e_system_lane::e2e_system_s56_rpc_rest_explicit_mob_registry_restores_without_live_api`

Re-running the same four serialized (`--test-threads=1`) on this branch: all 4 PASS. Re-running `e2e_system_cli_wasm_forbidden_capability` alone on the main-base worktree at the same HEAD (`97981e314`): PASS. The failures are environmental (parallel contention), not a regression from this PR.

Closes: test discipline (composite-path coverage matrix) per issue #264 / W1-C.