### PR TITLE
W2-F: Bridge = protocol only (issue #264)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,6 +36,9 @@ jobs:
       - name: Legacy surface gate
         run: make legacy-surface-gate
 
+      - name: Bridge-classifier gate (W2-F)
+        run: make bridge-no-responsestatus-gate
+
       - name: Verify version parity
         run: make verify-version-parity
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -83,6 +83,16 @@ repos:
         pass_filenames: false
         stages: [pre-push]
 
+  # On push: W2-F bridge-classifier gate (no ResponseStatus matches in bridge files)
+  - repo: local
+    hooks:
+      - id: bridge-no-responsestatus
+        name: bridge layer must not re-interpret ResponseStatus (W2-F)
+        entry: scripts/pre-push-bridge-no-responsestatus.sh
+        language: script
+        pass_filenames: false
+        stages: [pre-push]
+
   # On push: deterministic repo gate
   - repo: local
     hooks:

--- a/Makefile
+++ b/Makefile
@@ -202,12 +202,12 @@ audit-alt:
 	$(CARGO) audit
 
 # Full CI pipeline - runs the required deterministic lanes plus build policy checks
-ci: fmt-check legacy-surface-gate deprecated-backend-gate rmat-read-seam-lint verify-version-parity verify-rpc-surface-alignment verify-sdk-wrapper-freshness check-rust-release-packaging lint lint-feature-matrix test-unit test-int e2e-fast e2e-system test-minimal test-feature-matrix test-surface-modularity rmat-audit audit
+ci: fmt-check legacy-surface-gate deprecated-backend-gate rmat-read-seam-lint bridge-no-responsestatus-gate verify-version-parity verify-rpc-surface-alignment verify-sdk-wrapper-freshness check-rust-release-packaging lint lint-feature-matrix test-unit test-int e2e-fast e2e-system test-minimal test-feature-matrix test-surface-modularity rmat-audit audit
 	@echo "$(GREEN)CI pipeline complete!$(NC)"
 
 # Developer smoke CI pipeline for faster pre-release iteration.
 # Keeps core validation, skips full feature matrix clippy/test expansion.
-ci-smoke: fmt-check legacy-surface-gate deprecated-backend-gate rmat-read-seam-lint verify-version-parity verify-rpc-surface-alignment verify-sdk-wrapper-freshness check-rust-release-packaging lint test-unit test-int e2e-fast e2e-system test-minimal rmat-audit audit
+ci-smoke: fmt-check legacy-surface-gate deprecated-backend-gate rmat-read-seam-lint bridge-no-responsestatus-gate verify-version-parity verify-rpc-surface-alignment verify-sdk-wrapper-freshness check-rust-release-packaging lint test-unit test-int e2e-fast e2e-system test-minimal rmat-audit audit
 	@echo "$(GREEN)CI smoke pipeline complete!$(NC)"
 
 # RMAT read-seam lint: detect shell code that reads authority state to gate
@@ -231,6 +231,14 @@ legacy-surface-inventory:
 deprecated-backend-gate:
 	@echo "$(GREEN)Checking for deprecated backend references...$(NC)"
 	@scripts/deprecated_backend_scan.sh
+
+# W2-F bridge-classifier gate: supervisor_bridge / local_bridge / bridge
+# wire types must not re-interpret `ResponseStatus`. All terminal-vs-progress
+# decisions go through `meerkat_core::interaction::classify_response_terminality`
+# so the canonical classifier stays the single source of truth.
+bridge-no-responsestatus-gate:
+	@echo "$(GREEN)Running W2-F bridge-classifier gate...$(NC)"
+	@scripts/pre-push-bridge-no-responsestatus.sh
 
 deprecated-backend-inventory:
 	@echo "$(GREEN)Generating deprecated backend inventory...$(NC)"

--- a/meerkat-mob/src/runtime/actor.rs
+++ b/meerkat-mob/src/runtime/actor.rs
@@ -6123,6 +6123,8 @@ impl MobActor {
                             .put_supervisor_authority(&self.definition.id, &next)
                             .await?;
                         self.supervisor_bridge.rotate(next.clone()).await?;
+                        self.reinstall_session_backed_supervisor_trust(&current, &next)
+                            .await;
                         message.push_str(
                             "; local supervisor authority advanced to the partially applied next authority to preserve deterministic recovery",
                         );
@@ -6137,11 +6139,97 @@ impl MobActor {
             .put_supervisor_authority(&self.definition.id, &next)
             .await?;
         self.supervisor_bridge.rotate(next.clone()).await?;
+        self.reinstall_session_backed_supervisor_trust(&current, &next)
+            .await;
         Ok(super::handle::SupervisorRotationReport {
             previous_epoch: current.epoch,
             current_epoch: next.epoch,
             public_peer_id,
         })
+    }
+
+    /// Re-install supervisor private trust on every session-backed member
+    /// after a supervisor rotation.
+    ///
+    /// External (peer-only) members receive the new authority through the
+    /// `AuthorizeSupervisor` bridge command that runs earlier in
+    /// `handle_rotate_supervisor`. Session-backed members have no bridge
+    /// channel — they trust the supervisor via the private-trust seam
+    /// installed during `finalize_spawn_from_pending`. Without this step,
+    /// after a rotation the old supervisor peer id is still in the member's
+    /// private-trust set and the new supervisor's lifecycle notifications
+    /// (`mob.peer_added`, `mob.peer_retired`, …) get dropped at the
+    /// classified inbox's admission gate.
+    ///
+    /// Best-effort: a failure on one member is logged but does not abort
+    /// the rotation — the local authority is already advanced at this
+    /// point, so recovery is a per-member reconciliation problem, not a
+    /// "reject rotation" problem.
+    async fn reinstall_session_backed_supervisor_trust(
+        &self,
+        previous: &crate::store::SupervisorAuthorityRecord,
+        next: &crate::store::SupervisorAuthorityRecord,
+    ) {
+        let next_spec = match self.supervisor_bridge.supervisor_spec().await {
+            Ok(spec) => spec,
+            Err(error) => {
+                tracing::warn!(
+                    mob_id = %self.definition.id,
+                    %error,
+                    "supervisor_spec unavailable after rotation; \
+                     session-backed members will not receive rotated lifecycle notifications"
+                );
+                return;
+            }
+        };
+
+        let session_backed: Vec<RosterEntry> = {
+            let roster = self.roster.read().await;
+            roster
+                .list_all()
+                .filter(|entry| entry.member_ref.bridge_session_id().is_some())
+                .cloned()
+                .collect()
+        };
+
+        for entry in session_backed {
+            let Some(member_comms) = self.provisioner_comms(&entry.member_ref).await else {
+                tracing::debug!(
+                    mob_id = %self.definition.id,
+                    agent_identity = %entry.agent_identity,
+                    "no provisioner comms for session-backed member during rotation trust re-install"
+                );
+                continue;
+            };
+
+            if let Err(error) = member_comms
+                .remove_private_trusted_peer(&previous.public_peer_id)
+                .await
+            {
+                tracing::warn!(
+                    mob_id = %self.definition.id,
+                    agent_identity = %entry.agent_identity,
+                    previous_peer_id = %previous.public_peer_id,
+                    %error,
+                    "failed to revoke previous supervisor private-trust during rotation; \
+                     old supervisor may still be accepted by the member's inbox"
+                );
+            }
+
+            if let Err(error) = member_comms
+                .add_private_trusted_peer(next_spec.clone())
+                .await
+            {
+                tracing::warn!(
+                    mob_id = %self.definition.id,
+                    agent_identity = %entry.agent_identity,
+                    next_peer_id = %next.public_peer_id,
+                    %error,
+                    "failed to install rotated supervisor private-trust on session-backed member; \
+                     lifecycle notifications from the new supervisor will be dropped at admission"
+                );
+            }
+        }
     }
 
     /// Cancel checkpointers and transition to Stopped. Used by `handle_reset`

--- a/meerkat-mob/src/runtime/supervisor_bridge.rs
+++ b/meerkat-mob/src/runtime/supervisor_bridge.rs
@@ -4,7 +4,9 @@ use crate::store::SupervisorAuthorityRecord;
 use crate::tokio;
 use meerkat_core::agent::CommsRuntime as CoreCommsRuntime;
 use meerkat_core::comms::{CommsCommand, InputStreamMode, PeerName, SendReceipt, TrustedPeerSpec};
-use meerkat_core::interaction::{InteractionContent, PeerInputCandidate};
+use meerkat_core::interaction::{
+    InteractionContent, PeerInputCandidate, TerminalityClass, classify_response_terminality,
+};
 use meerkat_core::types::HandlingMode;
 use std::collections::{HashSet, VecDeque};
 use std::sync::Arc;
@@ -221,6 +223,12 @@ impl MobSupervisorBridge {
         Ok(matched)
     }
 
+    /// Extract a terminal response value for the awaited request, if any.
+    ///
+    /// Bridge code does not interpret `ResponseStatus` directly — it routes
+    /// through `classify_response_terminality` and matches the typed
+    /// `TerminalityClass` exhaustively. W1-B made that classifier canonical
+    /// across the system; W2-F closes the bridge layer against drift.
     fn response_value(
         candidate: &PeerInputCandidate,
         request_envelope_id: uuid::Uuid,
@@ -238,10 +246,15 @@ impl MobSupervisorBridge {
             return Ok(None);
         }
 
-        match status {
-            meerkat_core::interaction::ResponseStatus::Completed
-            | meerkat_core::interaction::ResponseStatus::Failed => Ok(Some(result.clone())),
-            meerkat_core::interaction::ResponseStatus::Accepted => Ok(None),
+        // Forward-compat wildcard: `TerminalityClass` is `#[non_exhaustive]`.
+        // Any future variant is treated as non-terminal here so the bridge
+        // keeps waiting rather than invented-terminal-ing on a class it does
+        // not yet understand — matching the conservative pattern in
+        // `meerkat-runtime/src/comms_drain.rs`.
+        match classify_response_terminality(*status) {
+            TerminalityClass::Terminal { .. } => Ok(Some(result.clone())),
+            TerminalityClass::Progress => Ok(None),
+            _ => Ok(None),
         }
     }
 }
@@ -307,6 +320,80 @@ mod tests {
         assert!(
             value.is_none(),
             "Accepted is progress and must not satisfy wait_for_response"
+        );
+    }
+
+    #[test]
+    fn response_value_failed_returns_payload() {
+        let request_envelope_id = uuid::Uuid::new_v4();
+        let expected = serde_json::json!({"error": "boom"});
+        let candidate = response_candidate(
+            request_envelope_id,
+            ResponseStatus::Failed,
+            expected.clone(),
+        );
+
+        let value = MobSupervisorBridge::response_value(&candidate, request_envelope_id)
+            .expect("failed response should parse");
+
+        assert_eq!(
+            value,
+            Some(expected),
+            "Failed is terminal and must surface the result payload"
+        );
+    }
+
+    #[test]
+    fn response_value_routes_all_statuses_through_canonical_classifier() {
+        use meerkat_core::interaction::{TerminalityClass, classify_response_terminality};
+
+        for status in [
+            ResponseStatus::Accepted,
+            ResponseStatus::Completed,
+            ResponseStatus::Failed,
+        ] {
+            let request_envelope_id = uuid::Uuid::new_v4();
+            let payload = serde_json::json!({"status": format!("{status:?}")});
+            let candidate = response_candidate(request_envelope_id, status, payload.clone());
+
+            let value = MobSupervisorBridge::response_value(&candidate, request_envelope_id)
+                .expect("status-response should parse");
+
+            match classify_response_terminality(status) {
+                TerminalityClass::Terminal { .. } => assert_eq!(
+                    value,
+                    Some(payload),
+                    "terminal classification must surface payload (status={status:?})"
+                ),
+                TerminalityClass::Progress => assert!(
+                    value.is_none(),
+                    "progress classification must not surface payload (status={status:?})"
+                ),
+                _ => panic!(
+                    "TerminalityClass variant grew; update supervisor_bridge::response_value \
+                     and this test before landing the new class"
+                ),
+            }
+        }
+    }
+
+    #[test]
+    fn response_value_for_unrelated_envelope_returns_none() {
+        let awaited = uuid::Uuid::new_v4();
+        let other = uuid::Uuid::new_v4();
+        assert_ne!(awaited, other);
+        let candidate = response_candidate(
+            other,
+            ResponseStatus::Completed,
+            serde_json::json!({"ok": true}),
+        );
+
+        let value = MobSupervisorBridge::response_value(&candidate, awaited)
+            .expect("mismatched envelope should still parse");
+
+        assert!(
+            value.is_none(),
+            "response for a different envelope must not satisfy the current wait"
         );
     }
 }

--- a/meerkat-mob/src/runtime/tests.rs
+++ b/meerkat-mob/src/runtime/tests.rs
@@ -18103,6 +18103,136 @@ async fn test_supervisor_private_trust_preserves_send_resolution() {
 }
 
 #[tokio::test]
+async fn test_rotate_supervisor_reinstalls_private_trust_on_session_backed_member() {
+    // W2-F integration test: after a supervisor rotation, session-backed
+    // members must privately trust the NEW supervisor peer id and must no
+    // longer trust the previous one. Without the re-install step, the old
+    // peer id sticks in the member's private-trust set and new-supervisor
+    // lifecycle notifications (`mob.peer_added`, `mob.peer_retired`, …) are
+    // dropped at the classified inbox's admission gate.
+    let _serial = REAL_COMMS_TEST_LOCK.lock().expect("real-comms test lock");
+    let definition = with_unique_mob_id(sample_definition(), "rotate-private-trust");
+    let mob_id = definition.id.clone();
+    let (handle, service) = create_test_mob_with_real_comms(definition).await;
+    let receipt = handle
+        .spawn(
+            ProfileName::from("worker"),
+            MeerkatId::from("w-rotate"),
+            None,
+        )
+        .await
+        .expect("spawn session-backed member");
+    let session_id = receipt
+        .bridge_session_id()
+        .cloned()
+        .expect("session-backed member has bridge session id");
+    let member_comms = service
+        .real_comms(&session_id)
+        .await
+        .expect("member comms runtime");
+
+    // Capture the pre-rotation supervisor pubkey. This is what the member's
+    // private trust set must no longer trust after the rotation.
+    let previous_supervisor_pubkey = {
+        let trusted = member_comms.trusted_peers_shared();
+        let guard = trusted.read();
+        let entry = guard
+            .peers
+            .iter()
+            .find(|p| p.name.contains("__mob_supervisor__"))
+            .expect("spawn bootstraps supervisor private trust");
+        entry.pubkey
+    };
+    assert!(
+        member_comms
+            .router()
+            .is_private(&previous_supervisor_pubkey),
+        "pre-rotation supervisor must start as a private-trust entry"
+    );
+
+    let previous_name = {
+        let trusted = member_comms.trusted_peers_shared();
+        let guard = trusted.read();
+        guard
+            .peers
+            .iter()
+            .find(|p| p.name.contains("__mob_supervisor__"))
+            .expect("supervisor trust entry")
+            .name
+            .clone()
+    };
+
+    let report = handle.rotate_supervisor().await.expect("rotate supervisor");
+    assert_eq!(
+        report.previous_epoch + 1,
+        report.current_epoch,
+        "rotation must bump epoch by exactly one"
+    );
+    assert_ne!(
+        report.public_peer_id,
+        previous_supervisor_pubkey.to_peer_id(),
+        "rotation must replace the supervisor keypair"
+    );
+
+    // Post-rotation: the old supervisor pubkey must no longer be trusted,
+    // and the rotated supervisor pubkey must be present and marked private
+    // so the directory still hides it while the admission gate still
+    // accepts lifecycle notifications.
+    let (new_supervisor_pubkey_opt, old_still_present) = {
+        let trusted = member_comms.trusted_peers_shared();
+        let guard = trusted.read();
+        let new_entry = guard
+            .peers
+            .iter()
+            .find(|p| p.name.contains("__mob_supervisor__"));
+        let old_still_present = guard
+            .peers
+            .iter()
+            .any(|p| p.pubkey == previous_supervisor_pubkey);
+        (new_entry.map(|entry| entry.pubkey), old_still_present)
+    };
+    assert!(
+        !old_still_present,
+        "previous supervisor private trust must be revoked by the rotation \
+         trust re-install; leaving it in would accept lifecycle notifications \
+         from the superseded authority"
+    );
+    let new_supervisor_pubkey = new_supervisor_pubkey_opt
+        .expect("rotated supervisor private trust must be installed on the session-backed member");
+    assert_ne!(
+        new_supervisor_pubkey, previous_supervisor_pubkey,
+        "rotation must change the trusted supervisor pubkey"
+    );
+    assert!(
+        member_comms.router().is_private(&new_supervisor_pubkey),
+        "rotated supervisor must stay on the private-trust edge — it is a \
+         control-plane peer and must not leak into `comms.peers`"
+    );
+    assert_eq!(
+        new_supervisor_pubkey.to_peer_id(),
+        report.public_peer_id,
+        "member-side private trust must agree with the rotation report"
+    );
+
+    // And the directory must still hide the (rotated) supervisor, matching
+    // the invariant from `test_supervisor_trust_does_not_leak_into_member_peer_directory`.
+    let directory = member_comms.peers().await;
+    assert!(
+        directory
+            .iter()
+            .all(|entry| !entry.name.as_str().contains("__mob_supervisor__")),
+        "rotated supervisor must remain absent from the public peer directory; got: {directory:?}"
+    );
+
+    // Sanity check: we really did spawn a session-backed member of the
+    // expected mob (the trust-entry name embeds the mob id).
+    assert!(
+        previous_name.starts_with(mob_id.as_str()),
+        "private-trust entry name must be scoped to this mob; got: {previous_name}"
+    );
+}
+
+#[tokio::test]
 async fn test_external_tools_provider_called_per_spawn() {
     let counter = Arc::new(std::sync::atomic::AtomicU32::new(0));
     let counter_clone = counter.clone();

--- a/scripts/pre-push-bridge-no-responsestatus.sh
+++ b/scripts/pre-push-bridge-no-responsestatus.sh
@@ -1,0 +1,73 @@
+#!/usr/bin/env bash
+# pre-push-bridge-no-responsestatus.sh — grep gate for W2-F.
+#
+# The supervisor bridge transports typed commands/replies. It must not
+# re-interpret `ResponseStatus` — all "is this terminal?" questions go
+# through `classify_response_terminality` / `TerminalityClass`, so the
+# canonical classifier in `meerkat-core::interaction` stays the single
+# source of truth. See issue #264 (W2-F).
+#
+# Exit 0 = clean, exit 1 = violations found.
+
+set -euo pipefail
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+NC='\033[0m'
+
+VIOLATIONS=0
+
+# Files that must not match `ResponseStatus` on their non-test, non-import
+# lines. The production path is limited to the bridge sender, the bridge
+# wire types, and the bridge receiver used by local members. The bridge
+# receiver in `supervisor_bridge.rs` is allowed to name
+# `ResponseStatus` in test-only code (see `#[cfg(test)]` block) because
+# the test module exercises the canonical classifier directly.
+BRIDGE_FILES=(
+    "meerkat-mob/src/runtime/supervisor_bridge.rs"
+    "meerkat-mob/src/runtime/local_bridge.rs"
+    "meerkat-contracts/src/wire/supervisor_bridge.rs"
+)
+
+for file in "${BRIDGE_FILES[@]}"; do
+    if [[ ! -f "$file" ]]; then
+        continue
+    fi
+
+    # Strip everything after `#[cfg(test)]` / `mod tests` so test code can
+    # still name `ResponseStatus`. The production bridge must not `match`
+    # on `ResponseStatus`.
+    production=$(awk '
+        /^#\[cfg\(test\)\]/ { in_test = 1 }
+        /^mod tests/        { in_test = 1 }
+        !in_test            { print NR ": " $0 }
+    ' "$file")
+
+    # The W2-F contract: no `match` on `ResponseStatus` in bridge code.
+    # Doc comments and imports naming the type are fine — the point is to
+    # ban re-deriving "is this terminal?" locally.
+    hits=$(printf '%s\n' "$production" \
+        | grep -v '^\s*[0-9]*:\s*//' \
+        | grep -v '^\s*[0-9]*:\s*///' \
+        | grep -E 'match[^;]*ResponseStatus|ResponseStatus::(Completed|Failed|Accepted)' \
+        || true)
+
+    if [[ -n "$hits" ]]; then
+        echo -e "${RED}W2-F violation:${NC} bridge file interprets \`ResponseStatus\` directly — route through \`classify_response_terminality\` + \`TerminalityClass\`:"
+        echo -e "  file: ${file}"
+        echo "$hits" | sed 's/^/    /'
+        VIOLATIONS=$((VIOLATIONS + 1))
+    fi
+done
+
+if [[ $VIOLATIONS -eq 0 ]]; then
+    echo -e "${GREEN}W2-F bridge-classifier gate clean.${NC}"
+    exit 0
+fi
+
+echo ""
+echo -e "${RED}${VIOLATIONS} file(s) violate the W2-F contract.${NC}"
+echo "All terminal-vs-progress decisions in the bridge layer must go"
+echo "through \`meerkat_core::interaction::classify_response_terminality\`"
+echo "and match \`TerminalityClass\` exhaustively."
+exit 1


### PR DESCRIPTION
## Summary

- supervisor_bridge stops interpreting `ResponseStatus`; `response_value()` now routes through `meerkat_core::interaction::classify_response_terminality` and exhaustively matches `TerminalityClass`, matching the canonical W1-B classifier
- `handle_rotate_supervisor` now re-installs supervisor private-trust on every session-backed member via `remove_private_trusted_peer` + `add_private_trusted_peer`, closing the gap where rotations silently orphaned lifecycle notifications
- New CI-integrated grep gate (`scripts/pre-push-bridge-no-responsestatus.sh`) enforces no `match` on `ResponseStatus` in `supervisor_bridge.rs`, `local_bridge.rs`, or `meerkat-contracts/src/wire/supervisor_bridge.rs`

Refs: issue #264 (W2-F). Closes dogma #1, #3, #4, #17.

## Details

### Bridge classification

`supervisor_bridge.rs:241-245` had the exact `match status { Completed | Failed => Some, Accepted => None }` pattern W1-B's canonical classifier was introduced to replace. Migrated to `classify_response_terminality(*status)` + `TerminalityClass::Terminal { .. } | Progress` with a forward-compat `_ => Ok(None)` wildcard that mirrors the conservative pattern in `meerkat-runtime/src/comms_drain.rs`.

`local_bridge.rs` was already clean — no `ResponseStatus` interpretation. `meerkat-contracts/src/wire/supervisor_bridge.rs` uses typed `BridgeReply` variants (`Ack` / `Observation` / `Delivery` / `Retire` / `Destroy` / `Rejected { cause, reason }`) which never carry `ResponseStatus`, so no change needed.

### Supervisor rotation trust re-install (was task #7)

W1-B's `finalize_spawn_from_pending` bootstraps supervisor private-trust on every session-backed member so lifecycle notifications reach the classified inbox. `handle_rotate_supervisor` had no corresponding re-install path: after a rotation, the member's private-trust set still contained the *previous* supervisor pubkey, so lifecycle notifications from the *new* supervisor were dropped at admission.

New `reinstall_session_backed_supervisor_trust` helper walks the roster, filters to `MemberRef` with a `bridge_session_id`, and for each:
1. `remove_private_trusted_peer(previous.public_peer_id)` — revoke the superseded authority
2. `add_private_trusted_peer(next_supervisor_spec)` — install the rotated authority

Runs on the happy path and on the partial-failure branch that advances local authority after rollback failures (the CLAUDE.md-documented "supervisor_bridge rollback best-effort" scenario). Best-effort per member: missing comms or either API failing is logged at `warn!` and the rotation still completes — the local authority is already advanced, recovery is per-member reconciliation not "reject rotation".

### Tests

- `response_value_completed_returns_payload` (existing, passing post-migration)
- `response_value_accepted_is_not_terminal` (existing, passing post-migration)
- `response_value_failed_returns_payload` (new) — Failed is terminal and must surface the payload
- `response_value_routes_all_statuses_through_canonical_classifier` (new) — every `ResponseStatus` is classified through `classify_response_terminality` with matching behavior
- `response_value_for_unrelated_envelope_returns_none` (new) — envelope correlation precedes classification
- `test_rotate_supervisor_reinstalls_private_trust_on_session_backed_member` (new integration test, real-comms harness) — spawns a session-backed worker, captures the pre-rotation supervisor pubkey, rotates via `handle.rotate_supervisor()`, asserts: old pubkey is removed from the member's `trusted_peers_shared`, the new pubkey is present and marked private via `router().is_private()`, the new pubkey matches the rotation report, and the public peer directory still hides the rotated supervisor. Test fails without the `actor.rs` change (verified by `git stash push meerkat-mob/src/runtime/actor.rs` + re-run).

### Grep gate

`scripts/pre-push-bridge-no-responsestatus.sh` fails if any of the three bridge files match `match[^;]*ResponseStatus` or `ResponseStatus::(Completed|Failed|Accepted)` outside the `#[cfg(test)] mod tests` block. Wired into:

- `.pre-commit-config.yaml` (pre-push stage)
- `Makefile` target `bridge-no-responsestatus-gate` + appended to `make ci` / `make ci-smoke`
- `.github/workflows/ci.yml` fmt-lint job

Verified by drift-testing: injecting `match status { meerkat_core::interaction::ResponseStatus::Completed => Ok(...), ...}` into the production path triggers a gate violation with file + line output.

## Dogma closed

- **#1** (shell owns mechanics not meaning): bridge stops reinventing "terminal"; the domain word lives exactly once in `meerkat-core::interaction`.
- **#3** (typed vocabularies at canonical seams): `TerminalityClass` is now the sole terminal-vs-progress vocabulary across the mob bridge layer.
- **#4**: one-way door against local `ResponseStatus` matching in bridge code, enforced by CI-integrated grep gate.
- **#17** (surfaces are skins): the supervisor bridge is now a pure protocol-only transport of typed commands + typed classified replies, regardless of who sits on the other end.

## Test plan

- [x] `make fmt-check`
- [x] `cargo clippy --workspace --all-targets -D warnings`
- [x] `cargo unit` (3744/3744 passed)
- [x] `cargo nextest workspace integration` (4703/4703 passed)
- [x] `cargo e2e-fast` (5/5 passed)
- [x] `cargo e2e-system` (16/16 passed)
- [x] `cargo e2e-smoke` baseline — failures match main-baseline (s30, s44, s47, s48, s55 macOS-26.3 timeout; see task #14); zero W2-F-attributable regressions
- [x] `make verify-version-parity` clean
- [x] Bridge grep gate clean; drift-tested with a synthetic regression
- [x] Rotation test fails without fix, verified by stash/restore

🤖 Generated with [Claude Code](https://claude.com/claude-code)