### PR TITLE
fix(smoke): s71/s72 — cap realtime audio max_output_tokens

### DIFF
--- a/meerkat-openai/src/text_adapter.rs
+++ b/meerkat-openai/src/text_adapter.rs
@@ -37,6 +37,22 @@ use oai_rt_rs::protocol::models::{
 };
 use oai_rt_rs::{ClientEvent, RealtimeClient, ServerEvent};
 
+/// OpenAI's Realtime API caps `response.max_output_tokens` at 4096 for
+/// integer values; larger values fail with `integer above maximum value`.
+/// Callers may request a higher per-turn cap because the same session-level
+/// `max_tokens_per_turn` flows through the Responses-API path (which allows
+/// 128K). Clamp at the realtime boundary so the API ceiling is honored
+/// regardless of caller intent.
+const REALTIME_MAX_OUTPUT_TOKENS: u32 = 4096;
+
+/// Translate an agent-level `max_tokens` budget into the optional
+/// `response.max_output_tokens` the Realtime API accepts, clamping to the
+/// protocol ceiling. Returns `None` when the caller did not request a
+/// finite budget so the provider default (`inf`) applies.
+fn realtime_max_output_tokens(max_tokens: u32) -> Option<MaxTokens> {
+    (max_tokens > 0).then(|| MaxTokens::Count(max_tokens.min(REALTIME_MAX_OUTPUT_TOKENS)))
+}
+
 /// LlmClient implementation that serves text turns via OpenAI Realtime WS.
 #[derive(Debug, Clone)]
 pub struct OpenAiRealtimeTextAdapter {
@@ -111,8 +127,7 @@ impl LlmClient for OpenAiRealtimeTextAdapter {
             // protocol's accepted [0.0, 2.0] range are dropped rather than
             // rejected — the upstream constructor returns a typed error we
             // do not want to elevate mid-stream.
-            let max_output_tokens =
-                (request.max_tokens > 0).then_some(MaxTokens::Count(request.max_tokens));
+            let max_output_tokens = realtime_max_output_tokens(request.max_tokens);
             let temperature = request
                 .temperature
                 .and_then(|t| Temperature::new(t).ok());
@@ -603,6 +618,39 @@ mod tests {
                 assert_eq!(description.as_deref(), Some("read a file"));
             }
             other => panic!("expected Tool::Function, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn realtime_max_output_tokens_drops_zero_budget() {
+        assert!(realtime_max_output_tokens(0).is_none());
+    }
+
+    #[test]
+    fn realtime_max_output_tokens_passes_values_at_or_below_ceiling() {
+        match realtime_max_output_tokens(1) {
+            Some(MaxTokens::Count(n)) => assert_eq!(n, 1),
+            other => panic!("expected Count(1), got {other:?}"),
+        }
+        match realtime_max_output_tokens(REALTIME_MAX_OUTPUT_TOKENS) {
+            Some(MaxTokens::Count(n)) => assert_eq!(n, REALTIME_MAX_OUTPUT_TOKENS),
+            other => panic!("expected Count(4096), got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn realtime_max_output_tokens_clamps_above_ceiling() {
+        // Default agent.max_tokens_per_turn is 16384 — above the realtime API's
+        // 4096 integer ceiling. Exercise the two specific values that triggered
+        // the s71/s72 smoke failures.
+        for requested in [4097_u32, 8_192, 16_384, u32::MAX] {
+            match realtime_max_output_tokens(requested) {
+                Some(MaxTokens::Count(n)) => assert_eq!(
+                    n, REALTIME_MAX_OUTPUT_TOKENS,
+                    "requested={requested} should clamp to {REALTIME_MAX_OUTPUT_TOKENS}"
+                ),
+                other => panic!("expected clamped Count, got {other:?}"),
+            }
         }
     }
 


### PR DESCRIPTION
## Summary

- OpenAI's Realtime API rejects `response.max_output_tokens` values above 4096 with `Invalid 'response.max_output_tokens': integer above maximum value` (docs: integer between 1–4096 or `inf`).
- `OpenAiRealtimeTextAdapter` was forwarding the session-level `max_tokens_per_turn` (default 16384) unclamped, so any realtime-capable model (e.g. `gpt-realtime`) blew up on the first text turn. This was surfacing as the `e2e_smoke_s71_rust_sdk_realtime_audio_mob_collaboration_roundtrip` and `e2e_smoke_s72_rust_sdk_realtime_audio_member_model_switch_continuity` failures.
- Added a small `realtime_max_output_tokens(u32) -> Option<MaxTokens>` helper that returns `None` for zero budgets (so the provider's `inf` default applies) and `Some(MaxTokens::Count(n.min(4096)))` otherwise, plus three unit tests covering drop-zero, pass-through at/below the ceiling, and clamp above (including the default 16384).

## Verification

- Local lanes all green:
  - unit (`cargo unit`): 3755/3755 passed
  - int (`cargo nextest run --workspace --tests -E '…'`): 4714/4714 passed
  - e2e-fast (`cargo e2e-fast`): 5/5 passed
  - e2e-system (`cargo e2e-system`): 16/16 passed
  - workspace clippy (`-D warnings`): clean
  - version parity and schema freshness: both green
- Smoke delta:
  - Before: both scenarios fail on the `mob/turn_start` seed text turn with OpenAI's `integer above maximum value` error.
  - After: the max_output_tokens error is gone from the full 200 s s71 run log and the 36 s s72 run log; both scenarios progress through their previously blocking initial turns. A separate downstream assertion trips on realtime audio language drift (CJK transcript vs English text deltas) — unrelated root cause, tracked under task #22.

## Test plan

- [ ] `cargo nextest run -p meerkat-openai --features realtime --lib -E 'test(realtime_max_output_tokens)'` — new unit tests pass.
- [ ] `cargo nextest run -p meerkat-integration-tests --test e2e_smoke_lane e2e_smoke_s71_rust_sdk_realtime_audio_mob_collaboration_roundtrip --run-ignored ignored-only --test-threads=1` — no `integer above maximum value` error in the log (failure, if any, is on downstream audio-language assertions).
- [ ] `cargo nextest run -p meerkat-integration-tests --test e2e_smoke_lane e2e_smoke_s72_rust_sdk_realtime_audio_member_model_switch_continuity --run-ignored ignored-only --test-threads=1` — same.

🤖 Generated with [Claude Code](https://claude.com/claude-code)