### PR TITLE
fix(runtime): typed InputKind for policy dispatch (dogma #9)

### DIFF
--- a/meerkat-runtime/src/coalescing.rs
+++ b/meerkat-runtime/src/coalescing.rs
@@ -7,7 +7,7 @@
 use chrono::Utc;
 use meerkat_core::lifecycle::InputId;
 
-use crate::identifiers::{LogicalRuntimeId, SupersessionKey};
+use crate::identifiers::{InputKind, LogicalRuntimeId, SupersessionKey};
 use crate::input::{Input, PeerConvention};
 use crate::input_state::{
     InputLifecycleState, InputState, InputStateHistoryEntry, InputTerminalOutcome,
@@ -29,7 +29,7 @@ pub fn is_coalescing_eligible(input: &Input) -> bool {
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct SupersessionScope {
     pub runtime_id: LogicalRuntimeId,
-    pub kind: String,
+    pub kind: InputKind,
     pub supersession_key: SupersessionKey,
 }
 
@@ -39,7 +39,7 @@ impl SupersessionScope {
         let key = input.header().supersession_key.as_ref()?;
         Some(Self {
             runtime_id: runtime_id.clone(),
-            kind: input.kind_id().0,
+            kind: input.kind(),
             supersession_key: key.clone(),
         })
     }

--- a/meerkat-runtime/src/durability.rs
+++ b/meerkat-runtime/src/durability.rs
@@ -52,7 +52,7 @@ pub fn validate_durability(input: &Input) -> Result<(), DurabilityError> {
                         | PeerConvention::ResponseTerminal { .. },
                     ) => {
                         return Err(DurabilityError::DerivedForbidden {
-                            kind: format!("peer_{}", input.kind_id().0),
+                            kind: format!("peer_{}", input.kind().as_str()),
                         });
                     }
                     // ResponseProgress CAN be Derived

--- a/meerkat-runtime/src/identifiers.rs
+++ b/meerkat-runtime/src/identifiers.rs
@@ -160,19 +160,83 @@ impl std::fmt::Display for PolicyVersion {
     }
 }
 
-/// Identifier for an input kind (e.g., "prompt", "peer_message").
-#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
-pub struct KindId(pub String);
+/// Typed input-kind taxonomy used by the runtime policy table.
+///
+/// Every variant the policy table dispatches on is enumerated here. New input
+/// kinds must be added to this enum AND wired into
+/// `DefaultPolicyTable::resolve_by_kind`; the compiler enforces exhaustive
+/// coverage.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+#[non_exhaustive]
+pub enum InputKind {
+    /// Operator/user prompt.
+    Prompt,
+    /// Peer message convention (or unconvented peer input).
+    PeerMessage,
+    /// Peer request convention.
+    PeerRequest,
+    /// Peer response progress convention.
+    PeerResponseProgress,
+    /// Peer response terminal convention.
+    PeerResponseTerminal,
+    /// Flow step input.
+    FlowStep,
+    /// External event input.
+    ExternalEvent,
+    /// Explicit continuation input.
+    Continuation,
+    /// Explicit operation/lifecycle input.
+    Operation,
+}
+
+impl InputKind {
+    /// Stable lowercase identifier. Wire formats and trace strings rely on
+    /// this exact spelling.
+    pub fn as_str(self) -> &'static str {
+        match self {
+            InputKind::Prompt => "prompt",
+            InputKind::PeerMessage => "peer_message",
+            InputKind::PeerRequest => "peer_request",
+            InputKind::PeerResponseProgress => "peer_response_progress",
+            InputKind::PeerResponseTerminal => "peer_response_terminal",
+            InputKind::FlowStep => "flow_step",
+            InputKind::ExternalEvent => "external_event",
+            InputKind::Continuation => "continuation",
+            InputKind::Operation => "operation",
+        }
+    }
+}
+
+impl std::fmt::Display for InputKind {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
+/// Identifier for an input kind, wrapping the typed [`InputKind`] taxonomy.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub struct KindId(pub InputKind);
 
 impl KindId {
-    pub fn new(id: impl Into<String>) -> Self {
-        Self(id.into())
+    pub const fn new(kind: InputKind) -> Self {
+        Self(kind)
+    }
+
+    pub const fn kind(self) -> InputKind {
+        self.0
+    }
+}
+
+impl From<InputKind> for KindId {
+    fn from(kind: InputKind) -> Self {
+        Self(kind)
     }
 }
 
 impl std::fmt::Display for KindId {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{}", self.0)
+        std::fmt::Display::fmt(&self.0, f)
     }
 }
 
@@ -286,7 +350,19 @@ mod tests {
 
     #[test]
     fn kind_id_display() {
-        let id = KindId::new("prompt");
+        let id = KindId::new(InputKind::Prompt);
         assert_eq!(id.to_string(), "prompt");
+        assert_eq!(
+            KindId::new(InputKind::PeerResponseProgress).to_string(),
+            "peer_response_progress"
+        );
+    }
+
+    #[test]
+    fn kind_id_serde_roundtrips_typed_variant() {
+        let id = KindId::new(InputKind::PeerResponseTerminal);
+        let json = serde_json::to_string(&id).unwrap();
+        let parsed: KindId = serde_json::from_str(&json).unwrap();
+        assert_eq!(id, parsed);
     }
 }

--- a/meerkat-runtime/src/input.rs
+++ b/meerkat-runtime/src/input.rs
@@ -16,7 +16,7 @@ use meerkat_core::{
 use serde::{Deserialize, Serialize};
 
 use crate::identifiers::{
-    CorrelationId, IdempotencyKey, KindId, LogicalRuntimeId, SupersessionKey,
+    CorrelationId, IdempotencyKey, InputKind, KindId, LogicalRuntimeId, SupersessionKey,
 };
 use meerkat_core::types::RenderMetadata;
 
@@ -135,26 +135,26 @@ impl Input {
         &self.header().id
     }
 
-    /// Get the kind ID for policy resolution.
-    pub fn kind_id(&self) -> KindId {
+    /// Typed kind for policy dispatch.
+    pub fn kind(&self) -> InputKind {
         match self {
-            Input::Prompt(_) => KindId::new("prompt"),
+            Input::Prompt(_) => InputKind::Prompt,
             Input::Peer(p) => match &p.convention {
-                Some(PeerConvention::Message) => KindId::new("peer_message"),
-                Some(PeerConvention::Request { .. }) => KindId::new("peer_request"),
-                Some(PeerConvention::ResponseProgress { .. }) => {
-                    KindId::new("peer_response_progress")
-                }
-                Some(PeerConvention::ResponseTerminal { .. }) => {
-                    KindId::new("peer_response_terminal")
-                }
-                None => KindId::new("peer_message"),
+                Some(PeerConvention::Message) | None => InputKind::PeerMessage,
+                Some(PeerConvention::Request { .. }) => InputKind::PeerRequest,
+                Some(PeerConvention::ResponseProgress { .. }) => InputKind::PeerResponseProgress,
+                Some(PeerConvention::ResponseTerminal { .. }) => InputKind::PeerResponseTerminal,
             },
-            Input::FlowStep(_) => KindId::new("flow_step"),
-            Input::ExternalEvent(_) => KindId::new("external_event"),
-            Input::Continuation(_) => KindId::new("continuation"),
-            Input::Operation(_) => KindId::new("operation"),
+            Input::FlowStep(_) => InputKind::FlowStep,
+            Input::ExternalEvent(_) => InputKind::ExternalEvent,
+            Input::Continuation(_) => InputKind::Continuation,
+            Input::Operation(_) => InputKind::Operation,
         }
+    }
+
+    /// Wrapped kind identifier (for newtype-discipline call sites).
+    pub fn kind_id(&self) -> KindId {
+        KindId::new(self.kind())
     }
 
     /// Handling-mode hint for ordinary work admitted through the runtime.
@@ -758,7 +758,7 @@ mod tests {
             blocks: None,
             turn_metadata: None,
         });
-        assert_eq!(prompt.kind_id().0, "prompt");
+        assert_eq!(prompt.kind(), InputKind::Prompt);
 
         let peer_msg = Input::Peer(PeerInput {
             header: make_header(),
@@ -768,7 +768,7 @@ mod tests {
             blocks: None,
             handling_mode: None,
         });
-        assert_eq!(peer_msg.kind_id().0, "peer_message");
+        assert_eq!(peer_msg.kind(), InputKind::PeerMessage);
 
         let peer_req = Input::Peer(PeerInput {
             header: make_header(),
@@ -781,7 +781,7 @@ mod tests {
             blocks: None,
             handling_mode: None,
         });
-        assert_eq!(peer_req.kind_id().0, "peer_request");
+        assert_eq!(peer_req.kind(), InputKind::PeerRequest);
 
         let continuation = Input::Continuation(ContinuationInput {
             header: make_header(),
@@ -789,7 +789,7 @@ mod tests {
             handling_mode: HandlingMode::Steer,
             request_id: None,
         });
-        assert_eq!(continuation.kind_id().0, "continuation");
+        assert_eq!(continuation.kind(), InputKind::Continuation);
 
         let operation = Input::Operation(OperationInput {
             header: make_header(),
@@ -798,7 +798,7 @@ mod tests {
                 id: OperationId::new(),
             },
         });
-        assert_eq!(operation.kind_id().0, "operation");
+        assert_eq!(operation.kind(), InputKind::Operation);
     }
 
     #[test]

--- a/meerkat-runtime/src/lib.rs
+++ b/meerkat-runtime/src/lib.rs
@@ -71,7 +71,7 @@ pub use handles::{
     RuntimeTurnStateHandle,
 };
 pub use identifiers::{
-    CausationId, ConversationId, CorrelationId, EventCodeId, IdempotencyKey, KindId,
+    CausationId, ConversationId, CorrelationId, EventCodeId, IdempotencyKey, InputKind, KindId,
     LogicalRuntimeId, PolicyVersion, ProjectionRuleId, RuntimeEventId, SchemaId, SupersessionKey,
 };
 pub use ingress_types::{ContentShape, RequestId, ReservationKey};

--- a/meerkat-runtime/src/policy_table.rs
+++ b/meerkat-runtime/src/policy_table.rs
@@ -2,7 +2,7 @@
 //!
 //! All input kinds × 2 idle states, exact per spec §17.
 
-use crate::identifiers::{KindId, PolicyVersion};
+use crate::identifiers::{InputKind, KindId, PolicyVersion};
 use crate::input::Input;
 use crate::policy::{
     ApplyMode, ConsumePoint, DrainPolicy, PolicyDecision, QueueMode, RoutingDisposition, WakeMode,
@@ -48,13 +48,13 @@ impl DefaultPolicyTable {
     /// for progress updates. Response terminal inputs honor handling_mode
     /// normally.
     pub fn resolve(input: &Input, runtime_idle: bool) -> PolicyDecision {
-        let kind = input.kind_id();
+        let kind = input.kind();
         // ResponseProgress must not have its policy overridden by
         // handling_mode. Admission validation rejects this combination,
         // but the policy table also refuses to honor it so the contract
         // holds for any caller of resolve(), not just the driver path.
-        let is_response_convention = matches!(kind.0.as_str(), "peer_response_progress");
-        if !is_response_convention && let Some(mode) = input.handling_mode() {
+        let is_response_progress = matches!(kind, InputKind::PeerResponseProgress);
+        if !is_response_progress && let Some(mode) = input.handling_mode() {
             return match mode {
                 meerkat_core::types::HandlingMode::Queue => pd(
                     ApplyMode::StageRunStart,
@@ -85,15 +85,14 @@ impl DefaultPolicyTable {
             };
         }
 
-        // kind already computed above for response-convention check.
-        Self::resolve_by_kind(&kind, runtime_idle)
+        Self::resolve_by_kind(KindId::new(kind), runtime_idle)
     }
 
-    /// Resolve by kind ID (for testing and extensibility).
-    pub fn resolve_by_kind(kind: &KindId, runtime_idle: bool) -> PolicyDecision {
-        match (kind.0.as_str(), runtime_idle) {
+    /// Resolve by typed kind (for testing and extensibility).
+    pub fn resolve_by_kind(kind: KindId, runtime_idle: bool) -> PolicyDecision {
+        match (kind.kind(), runtime_idle) {
             // PromptInput — StageRunStart, WakeIfIdle (idle) / None (running)
-            ("prompt", true) => pd(
+            (InputKind::Prompt, true) => pd(
                 ApplyMode::StageRunStart,
                 WakeMode::WakeIfIdle,
                 QueueMode::Fifo,
@@ -102,7 +101,7 @@ impl DefaultPolicyTable {
                 RoutingDisposition::Queue,
                 true,
             ),
-            ("prompt", false) => pd(
+            (InputKind::Prompt, false) => pd(
                 ApplyMode::StageRunStart,
                 WakeMode::None,
                 QueueMode::Fifo,
@@ -114,7 +113,7 @@ impl DefaultPolicyTable {
 
             // PeerInput(Message) — StageRunStart, WakeIfIdle (idle) /
             // InterruptYielding (running)
-            ("peer_message", true) => pd(
+            (InputKind::PeerMessage, true) => pd(
                 ApplyMode::StageRunStart,
                 WakeMode::WakeIfIdle,
                 QueueMode::Fifo,
@@ -123,7 +122,7 @@ impl DefaultPolicyTable {
                 RoutingDisposition::Queue,
                 true,
             ),
-            ("peer_message", false) => pd(
+            (InputKind::PeerMessage, false) => pd(
                 ApplyMode::StageRunStart,
                 WakeMode::InterruptYielding,
                 QueueMode::Fifo,
@@ -134,7 +133,7 @@ impl DefaultPolicyTable {
             ),
 
             // PeerInput(Request) — same as Message
-            ("peer_request", true) => pd(
+            (InputKind::PeerRequest, true) => pd(
                 ApplyMode::StageRunStart,
                 WakeMode::WakeIfIdle,
                 QueueMode::Fifo,
@@ -143,7 +142,7 @@ impl DefaultPolicyTable {
                 RoutingDisposition::Queue,
                 true,
             ),
-            ("peer_request", false) => pd(
+            (InputKind::PeerRequest, false) => pd(
                 ApplyMode::StageRunStart,
                 WakeMode::InterruptYielding,
                 QueueMode::Fifo,
@@ -154,16 +153,7 @@ impl DefaultPolicyTable {
             ),
 
             // PeerInput(ResponseProgress) — StageRunBoundary, None, Coalesce
-            ("peer_response_progress", true) => pd(
-                ApplyMode::StageRunBoundary,
-                WakeMode::None,
-                QueueMode::Coalesce,
-                ConsumePoint::OnRunComplete,
-                DrainPolicy::SteerBatch,
-                RoutingDisposition::Steer,
-                true,
-            ),
-            ("peer_response_progress", false) => pd(
+            (InputKind::PeerResponseProgress, _) => pd(
                 ApplyMode::StageRunBoundary,
                 WakeMode::None,
                 QueueMode::Coalesce,
@@ -194,16 +184,7 @@ impl DefaultPolicyTable {
             // dequeues and runs a turn regardless; turn-driven members (the
             // realtime audio case) now react to the response instead of
             // sitting on the appended context forever.
-            ("peer_response_terminal", true) => pd(
-                ApplyMode::StageRunStart,
-                WakeMode::WakeIfIdle,
-                QueueMode::Fifo,
-                ConsumePoint::OnRunComplete,
-                DrainPolicy::QueueNextTurn,
-                RoutingDisposition::Queue,
-                true,
-            ),
-            ("peer_response_terminal", false) => pd(
+            (InputKind::PeerResponseTerminal, _) => pd(
                 ApplyMode::StageRunStart,
                 WakeMode::WakeIfIdle,
                 QueueMode::Fifo,
@@ -214,7 +195,7 @@ impl DefaultPolicyTable {
             ),
 
             // FlowStepInput — StageRunStart, WakeIfIdle/None
-            ("flow_step", true) => pd(
+            (InputKind::FlowStep, true) => pd(
                 ApplyMode::StageRunStart,
                 WakeMode::WakeIfIdle,
                 QueueMode::Fifo,
@@ -223,7 +204,7 @@ impl DefaultPolicyTable {
                 RoutingDisposition::Queue,
                 true,
             ),
-            ("flow_step", false) => pd(
+            (InputKind::FlowStep, false) => pd(
                 ApplyMode::StageRunStart,
                 WakeMode::None,
                 QueueMode::Fifo,
@@ -234,7 +215,7 @@ impl DefaultPolicyTable {
             ),
 
             // ExternalEventInput — StageRunStart, WakeIfIdle/None
-            ("external_event", true) => pd(
+            (InputKind::ExternalEvent, true) => pd(
                 ApplyMode::StageRunStart,
                 WakeMode::WakeIfIdle,
                 QueueMode::Fifo,
@@ -243,7 +224,7 @@ impl DefaultPolicyTable {
                 RoutingDisposition::Queue,
                 true,
             ),
-            ("external_event", false) => pd(
+            (InputKind::ExternalEvent, false) => pd(
                 ApplyMode::StageRunStart,
                 WakeMode::None,
                 QueueMode::Fifo,
@@ -254,7 +235,7 @@ impl DefaultPolicyTable {
             ),
 
             // Continuation work remains explicit ordinary runtime work.
-            ("continuation", true) => pd(
+            (InputKind::Continuation, true) => pd(
                 ApplyMode::StageRunBoundary,
                 WakeMode::WakeIfIdle,
                 QueueMode::Fifo,
@@ -263,7 +244,7 @@ impl DefaultPolicyTable {
                 RoutingDisposition::Steer,
                 false,
             ),
-            ("continuation", false) => pd(
+            (InputKind::Continuation, false) => pd(
                 ApplyMode::StageRunBoundary,
                 WakeMode::InterruptYielding,
                 QueueMode::Fifo,
@@ -275,7 +256,7 @@ impl DefaultPolicyTable {
 
             // Typed operation/lifecycle inputs are admitted explicitly but do
             // not inject ordinary transcript-visible work in this phase.
-            ("operation", true | false) => pd(
+            (InputKind::Operation, _) => pd(
                 ApplyMode::Ignore,
                 WakeMode::None,
                 QueueMode::Priority,
@@ -283,17 +264,6 @@ impl DefaultPolicyTable {
                 DrainPolicy::Ignore,
                 RoutingDisposition::Drop,
                 false,
-            ),
-
-            // Unknown kind — default conservative: StageRunStart, no wake
-            (_, _) => pd(
-                ApplyMode::StageRunStart,
-                WakeMode::None,
-                QueueMode::Fifo,
-                ConsumePoint::OnRunComplete,
-                DrainPolicy::QueueNextTurn,
-                RoutingDisposition::Queue,
-                true,
             ),
         }
     }
@@ -305,7 +275,7 @@ mod tests {
     use super::*;
 
     fn assert_cell(
-        kind: &str,
+        kind: InputKind,
         idle: bool,
         expected_apply: ApplyMode,
         expected_wake: WakeMode,
@@ -313,33 +283,33 @@ mod tests {
         expected_consume: ConsumePoint,
         expected_transcript: bool,
     ) {
-        let decision = DefaultPolicyTable::resolve_by_kind(&KindId::new(kind), idle);
+        let decision = DefaultPolicyTable::resolve_by_kind(KindId::new(kind), idle);
         assert_eq!(
             decision.apply_mode, expected_apply,
-            "kind={kind}, idle={idle}: apply_mode"
+            "kind={kind:?}, idle={idle}: apply_mode"
         );
         assert_eq!(
             decision.wake_mode, expected_wake,
-            "kind={kind}, idle={idle}: wake_mode"
+            "kind={kind:?}, idle={idle}: wake_mode"
         );
         assert_eq!(
             decision.queue_mode, expected_queue,
-            "kind={kind}, idle={idle}: queue_mode"
+            "kind={kind:?}, idle={idle}: queue_mode"
         );
         assert_eq!(
             decision.consume_point, expected_consume,
-            "kind={kind}, idle={idle}: consume_point"
+            "kind={kind:?}, idle={idle}: consume_point"
         );
         assert_eq!(
             decision.record_transcript, expected_transcript,
-            "kind={kind}, idle={idle}: record_transcript"
+            "kind={kind:?}, idle={idle}: record_transcript"
         );
     }
 
     #[test]
     fn prompt_idle() {
         assert_cell(
-            "prompt",
+            InputKind::Prompt,
             true,
             ApplyMode::StageRunStart,
             WakeMode::WakeIfIdle,
@@ -351,7 +321,7 @@ mod tests {
     #[test]
     fn prompt_running() {
         assert_cell(
-            "prompt",
+            InputKind::Prompt,
             false,
             ApplyMode::StageRunStart,
             WakeMode::None,
@@ -363,7 +333,7 @@ mod tests {
     #[test]
     fn peer_message_idle() {
         assert_cell(
-            "peer_message",
+            InputKind::PeerMessage,
             true,
             ApplyMode::StageRunStart,
             WakeMode::WakeIfIdle,
@@ -375,7 +345,7 @@ mod tests {
     #[test]
     fn peer_message_running() {
         assert_cell(
-            "peer_message",
+            InputKind::PeerMessage,
             false,
             ApplyMode::StageRunStart,
             WakeMode::InterruptYielding,
@@ -387,7 +357,7 @@ mod tests {
     #[test]
     fn peer_request_idle() {
         assert_cell(
-            "peer_request",
+            InputKind::PeerRequest,
             true,
             ApplyMode::StageRunStart,
             WakeMode::WakeIfIdle,
@@ -399,7 +369,7 @@ mod tests {
     #[test]
     fn peer_request_running() {
         assert_cell(
-            "peer_request",
+            InputKind::PeerRequest,
             false,
             ApplyMode::StageRunStart,
             WakeMode::InterruptYielding,
@@ -411,7 +381,7 @@ mod tests {
     #[test]
     fn peer_response_progress_idle() {
         assert_cell(
-            "peer_response_progress",
+            InputKind::PeerResponseProgress,
             true,
             ApplyMode::StageRunBoundary,
             WakeMode::None,
@@ -423,7 +393,7 @@ mod tests {
     #[test]
     fn peer_response_progress_running() {
         assert_cell(
-            "peer_response_progress",
+            InputKind::PeerResponseProgress,
             false,
             ApplyMode::StageRunBoundary,
             WakeMode::None,
@@ -435,7 +405,7 @@ mod tests {
     #[test]
     fn peer_response_terminal_idle() {
         assert_cell(
-            "peer_response_terminal",
+            InputKind::PeerResponseTerminal,
             true,
             ApplyMode::StageRunStart,
             WakeMode::WakeIfIdle,
@@ -447,7 +417,7 @@ mod tests {
     #[test]
     fn peer_response_terminal_running() {
         assert_cell(
-            "peer_response_terminal",
+            InputKind::PeerResponseTerminal,
             false,
             ApplyMode::StageRunStart,
             WakeMode::WakeIfIdle,
@@ -459,7 +429,7 @@ mod tests {
     #[test]
     fn flow_step_idle() {
         assert_cell(
-            "flow_step",
+            InputKind::FlowStep,
             true,
             ApplyMode::StageRunStart,
             WakeMode::WakeIfIdle,
@@ -471,7 +441,7 @@ mod tests {
     #[test]
     fn flow_step_running() {
         assert_cell(
-            "flow_step",
+            InputKind::FlowStep,
             false,
             ApplyMode::StageRunStart,
             WakeMode::None,
@@ -483,7 +453,7 @@ mod tests {
     #[test]
     fn external_event_idle() {
         assert_cell(
-            "external_event",
+            InputKind::ExternalEvent,
             true,
             ApplyMode::StageRunStart,
             WakeMode::WakeIfIdle,
@@ -495,7 +465,7 @@ mod tests {
     #[test]
     fn external_event_running() {
         assert_cell(
-            "external_event",
+            InputKind::ExternalEvent,
             false,
             ApplyMode::StageRunStart,
             WakeMode::None,
@@ -507,7 +477,7 @@ mod tests {
     #[test]
     fn continuation_idle() {
         assert_cell(
-            "continuation",
+            InputKind::Continuation,
             true,
             ApplyMode::StageRunBoundary,
             WakeMode::WakeIfIdle,
@@ -519,7 +489,7 @@ mod tests {
     #[test]
     fn continuation_running() {
         assert_cell(
-            "continuation",
+            InputKind::Continuation,
             false,
             ApplyMode::StageRunBoundary,
             WakeMode::InterruptYielding,
@@ -531,7 +501,7 @@ mod tests {
     #[test]
     fn operation_idle() {
         assert_cell(
-            "operation",
+            InputKind::Operation,
             true,
             ApplyMode::Ignore,
             WakeMode::None,
@@ -543,7 +513,7 @@ mod tests {
     #[test]
     fn operation_running() {
         assert_cell(
-            "operation",
+            InputKind::Operation,
             false,
             ApplyMode::Ignore,
             WakeMode::None,
@@ -613,7 +583,8 @@ mod tests {
 
     #[test]
     fn peer_message_running_stays_queued_without_wake() {
-        let decision = DefaultPolicyTable::resolve_by_kind(&KindId::new("peer_message"), false);
+        let decision =
+            DefaultPolicyTable::resolve_by_kind(KindId::new(InputKind::PeerMessage), false);
         assert_eq!(
             decision.wake_mode,
             WakeMode::InterruptYielding,
@@ -623,7 +594,8 @@ mod tests {
 
     #[test]
     fn peer_request_running_interrupts_yielding() {
-        let decision = DefaultPolicyTable::resolve_by_kind(&KindId::new("peer_request"), false);
+        let decision =
+            DefaultPolicyTable::resolve_by_kind(KindId::new(InputKind::PeerRequest), false);
         assert_eq!(
             decision.wake_mode,
             WakeMode::InterruptYielding,
@@ -634,7 +606,8 @@ mod tests {
     #[test]
     fn peer_message_idle_still_wakes() {
         // Peer messages while idle should still wake normally.
-        let decision = DefaultPolicyTable::resolve_by_kind(&KindId::new("peer_message"), true);
+        let decision =
+            DefaultPolicyTable::resolve_by_kind(KindId::new(InputKind::PeerMessage), true);
         assert_eq!(
             decision.wake_mode,
             WakeMode::WakeIfIdle,
@@ -645,7 +618,8 @@ mod tests {
     #[test]
     fn peer_request_idle_still_wakes() {
         // Peer requests while idle should still wake normally.
-        let decision = DefaultPolicyTable::resolve_by_kind(&KindId::new("peer_request"), true);
+        let decision =
+            DefaultPolicyTable::resolve_by_kind(KindId::new(InputKind::PeerRequest), true);
         assert_eq!(
             decision.wake_mode,
             WakeMode::WakeIfIdle,

--- a/meerkat-runtime/tests/runtime_ingress_control.rs
+++ b/meerkat-runtime/tests/runtime_ingress_control.rs
@@ -209,7 +209,10 @@ async fn runtime_ingress_control_red_ok_reset_preempts_queued_input_once() {
 async fn runtime_ingress_control_closed_taxonomy_uses_explicit_continuation_and_operation_inputs() {
     let continuation = Input::Continuation(ContinuationInput::detached_background_op_completed());
     let continuation_policy = meerkat_runtime::DefaultPolicyTable::resolve(&continuation, true);
-    assert_eq!(continuation.kind_id().0, "continuation");
+    assert_eq!(
+        continuation.kind(),
+        meerkat_runtime::InputKind::Continuation
+    );
     assert_eq!(continuation_policy.apply_mode, ApplyMode::StageRunBoundary);
     assert_eq!(continuation_policy.wake_mode, WakeMode::WakeIfIdle);
     assert_eq!(continuation_policy.drain_policy, DrainPolicy::SteerBatch);
@@ -238,7 +241,7 @@ async fn runtime_ingress_control_closed_taxonomy_uses_explicit_continuation_and_
         },
     });
     let operation_policy = meerkat_runtime::DefaultPolicyTable::resolve(&operation, true);
-    assert_eq!(operation.kind_id().0, "operation");
+    assert_eq!(operation.kind(), meerkat_runtime::InputKind::Operation);
     assert_eq!(operation_policy.apply_mode, ApplyMode::Ignore);
     assert_eq!(operation_policy.queue_mode, QueueMode::Priority);
     assert_eq!(


### PR DESCRIPTION
## Summary

Eliminate the stringly-typed `KindId(String)` / string-match `DefaultPolicyTable` dispatch.

- Add `pub enum InputKind` (`#[non_exhaustive]`) in `meerkat-runtime::identifiers` enumerating every kind the policy table dispatches on.
- Migrate `KindId(String) -> KindId(InputKind)` (now `Copy`).
- Expose `Input::kind() -> InputKind` for call sites; keep `Input::kind_id()` as the newtype form where that discipline is wanted.
- Rewrite `DefaultPolicyTable::resolve_by_kind` as an **exhaustive `match` on `InputKind`** — no catch-all, no `unknown kind` fallback. The compiler now enforces completeness.
- Update every call site (coalescing `SupersessionScope.kind`, durability error formatter, driver `ContentShape`, tests) to the typed API. Stable wire strings preserved via `InputKind::as_str`.

Closes violation #9 from `/Users/luka/.codex/dogma-violations.md`. No shims.

## Test plan

- [x] `./scripts/repo-cargo fmt --all -- --check`
- [x] `./scripts/repo-cargo clippy --workspace --all-targets -- -D warnings`
- [x] `./scripts/repo-cargo unit` — 3764/3764 pass
- [x] `./scripts/repo-cargo int` — all pass (3 tcp_e2e flakes re-ran green in isolation; port-exhaustion environmental, not related to this change)
- [x] `./scripts/repo-cargo e2e-fast` — 5/5 pass

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>

Generated with [Claude Code](https://claude.com/claude-code)