### PR TITLE
fix(wire): typed comms-send surface (dogma #6)

### DIFF
--- a/artifacts/schemas/wire-types.json
+++ b/artifacts/schemas/wire-types.json
@@ -1,4 +1,375 @@
 {
+  "CommsCommandRequest": {
+    "$defs": {
+      "BlobId": {
+        "description": "Canonical realm-local blob identifier.\n\nThe identifier is content-addressed, but storage and GC semantics remain\nrealm-scoped.",
+        "type": "string"
+      },
+      "ContentBlock": {
+        "oneOf": [
+          {
+            "description": "Plain text content.",
+            "properties": {
+              "text": {
+                "type": "string"
+              },
+              "type": {
+                "const": "text",
+                "type": "string"
+              }
+            },
+            "required": [
+              "type",
+              "text"
+            ],
+            "type": "object"
+          },
+          {
+            "description": "Base64-encoded image content.",
+            "oneOf": [
+              {
+                "description": "Base64-encoded inline bytes used for ingress and live execution.",
+                "properties": {
+                  "data": {
+                    "type": "string"
+                  },
+                  "source": {
+                    "const": "inline",
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "source",
+                  "data"
+                ],
+                "type": "object"
+              },
+              {
+                "description": "Durable blob reference used by persisted history/runtime state.",
+                "properties": {
+                  "blob_id": {
+                    "$ref": "#/$defs/BlobId"
+                  },
+                  "source": {
+                    "const": "blob",
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "source",
+                  "blob_id"
+                ],
+                "type": "object"
+              }
+            ],
+            "properties": {
+              "media_type": {
+                "description": "MIME type (e.g. \"image/png\", \"image/jpeg\").",
+                "type": "string"
+              },
+              "type": {
+                "const": "image",
+                "type": "string"
+              }
+            },
+            "required": [
+              "type",
+              "media_type"
+            ],
+            "type": "object"
+          },
+          {
+            "description": "Base64-encoded video content.",
+            "oneOf": [
+              {
+                "description": "Base64-encoded inline bytes used for ingress and live execution.",
+                "properties": {
+                  "data": {
+                    "type": "string"
+                  },
+                  "source": {
+                    "const": "inline",
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "source",
+                  "data"
+                ],
+                "type": "object"
+              }
+            ],
+            "properties": {
+              "duration_ms": {
+                "description": "Caller-provided clip duration in milliseconds.",
+                "format": "uint64",
+                "minimum": 0,
+                "type": "integer"
+              },
+              "media_type": {
+                "description": "MIME type (e.g. \"video/mp4\", \"video/webm\").",
+                "type": "string"
+              },
+              "type": {
+                "const": "video",
+                "type": "string"
+              }
+            },
+            "required": [
+              "type",
+              "media_type",
+              "duration_ms"
+            ],
+            "type": "object"
+          }
+        ]
+      },
+      "HandlingMode": {
+        "description": "Handling mode for ordinary content-bearing work.\n\n`Queue` means outer-loop / next-turn handling and leaves the current run\nuntouched.\n`Steer` means inner-loop handling and requests injection at the earliest\nadmissible cooperative boundary, while remaining ordinary work rather than\nan out-of-band control-plane command.",
+        "enum": [
+          "queue",
+          "steer"
+        ],
+        "type": "string"
+      },
+      "InputSource": {
+        "description": "Source for an input event posted to an agent.",
+        "enum": [
+          "tcp",
+          "uds",
+          "stdin",
+          "webhook",
+          "rpc"
+        ],
+        "type": "string"
+      },
+      "InputStreamMode": {
+        "description": "Whether this input/peer command should reserve a local interaction stream.",
+        "oneOf": [
+          {
+            "const": "none",
+            "description": "Do not reserve any stream.",
+            "type": "string"
+          },
+          {
+            "const": "reserve_interaction",
+            "description": "Reserve an interaction stream for the command.",
+            "type": "string"
+          }
+        ]
+      },
+      "InteractionId": {
+        "description": "Unique identifier for an interaction.",
+        "type": "string"
+      },
+      "PeerName": {
+        "type": "string"
+      },
+      "ResponseStatus": {
+        "description": "Typed status for response interactions.\n\nMirrors `CommsStatus` from `meerkat-comms` — the comms runtime converts at the boundary.",
+        "enum": [
+          "accepted",
+          "completed",
+          "failed"
+        ],
+        "type": "string"
+      }
+    },
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "description": "Typed wire request for `comms/send`.\n\nVariants are serde-tagged on `kind` and validated structurally at the\ndeserialization boundary. Required fields per kind are enforced by the\ntype system; invalid discriminators (`source`, `stream`, `handling_mode`,\n`status`) become serde deserialization errors rather than runtime\nstring-match failures.\n\nCross-field invariants that cannot be expressed structurally (e.g.\n`handling_mode` is forbidden on `Accepted` peer responses) are checked\nin [`CommsCommandRequest::into_command`].",
+    "oneOf": [
+      {
+        "description": "Inject input into the local session.",
+        "properties": {
+          "allow_self_session": {
+            "type": [
+              "boolean",
+              "null"
+            ]
+          },
+          "blocks": {
+            "items": {
+              "$ref": "#/$defs/ContentBlock"
+            },
+            "type": [
+              "array",
+              "null"
+            ]
+          },
+          "body": {
+            "type": "string"
+          },
+          "handling_mode": {
+            "anyOf": [
+              {
+                "$ref": "#/$defs/HandlingMode"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "kind": {
+            "const": "input",
+            "type": "string"
+          },
+          "source": {
+            "anyOf": [
+              {
+                "$ref": "#/$defs/InputSource"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "stream": {
+            "anyOf": [
+              {
+                "$ref": "#/$defs/InputStreamMode"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          }
+        },
+        "required": [
+          "kind",
+          "body"
+        ],
+        "type": "object"
+      },
+      {
+        "description": "Send a one-way peer message.",
+        "properties": {
+          "blocks": {
+            "items": {
+              "$ref": "#/$defs/ContentBlock"
+            },
+            "type": [
+              "array",
+              "null"
+            ]
+          },
+          "body": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "handling_mode": {
+            "anyOf": [
+              {
+                "$ref": "#/$defs/HandlingMode"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "kind": {
+            "const": "peer_message",
+            "type": "string"
+          },
+          "to": {
+            "$ref": "#/$defs/PeerName"
+          }
+        },
+        "required": [
+          "kind",
+          "to"
+        ],
+        "type": "object"
+      },
+      {
+        "description": "Send a request to a peer.",
+        "properties": {
+          "body": {
+            "description": "Legacy promotion: if `params` is absent, `body` is wrapped as\n`{\"body\": <body>}` for backwards-compatibility with single-string\nrequesters. Prefer `params`.",
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "handling_mode": {
+            "anyOf": [
+              {
+                "$ref": "#/$defs/HandlingMode"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "intent": {
+            "type": "string"
+          },
+          "kind": {
+            "const": "peer_request",
+            "type": "string"
+          },
+          "params": true,
+          "stream": {
+            "anyOf": [
+              {
+                "$ref": "#/$defs/InputStreamMode"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "to": {
+            "$ref": "#/$defs/PeerName"
+          }
+        },
+        "required": [
+          "kind",
+          "to",
+          "intent"
+        ],
+        "type": "object"
+      },
+      {
+        "description": "Send a response to a prior peer request.",
+        "properties": {
+          "handling_mode": {
+            "anyOf": [
+              {
+                "$ref": "#/$defs/HandlingMode"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "in_reply_to": {
+            "$ref": "#/$defs/InteractionId"
+          },
+          "kind": {
+            "const": "peer_response",
+            "type": "string"
+          },
+          "result": true,
+          "status": {
+            "$ref": "#/$defs/ResponseStatus"
+          },
+          "to": {
+            "$ref": "#/$defs/PeerName"
+          }
+        },
+        "required": [
+          "kind",
+          "to",
+          "in_reply_to",
+          "status"
+        ],
+        "type": "object"
+      }
+    ],
+    "title": "CommsCommandRequest"
+  },
   "ContractVersion": {
     "$schema": "https://json-schema.org/draft/2020-12/schema",
     "description": "Semantic version for the Meerkat wire contract.\n\nStart at 0.1.0 — allow breaking changes during Phase 1-3 development.\nBump to 1.0.0 when the SDK Builder ships (Phase 5) and external\nconsumers exist. Before 1.0.0, minor bumps can be breaking.",

--- a/meerkat-cli/src/main.rs
+++ b/meerkat-cli/src/main.rs
@@ -7083,64 +7083,15 @@ async fn interrupt_session(id: &str, scope: &RuntimeScope) -> anyhow::Result<()>
 }
 
 #[cfg(all(feature = "comms", test))]
-#[derive(Debug, serde::Deserialize)]
-struct CliCommsSendRequest {
-    kind: String,
-    #[serde(default)]
-    to: Option<String>,
-    #[serde(default)]
-    body: Option<String>,
-    #[serde(default)]
-    intent: Option<String>,
-    #[serde(default)]
-    params: Option<serde_json::Value>,
-    #[serde(default)]
-    in_reply_to: Option<String>,
-    #[serde(default)]
-    status: Option<String>,
-    #[serde(default)]
-    result: Option<serde_json::Value>,
-    #[serde(default)]
-    source: Option<String>,
-    #[serde(default)]
-    stream: Option<String>,
-    #[serde(default)]
-    allow_self_session: Option<bool>,
-    #[serde(default)]
-    handling_mode: Option<String>,
-}
-
-#[cfg(all(feature = "comms", test))]
 fn parse_comms_send_payload(
     payload_json: &str,
     session_id: &SessionId,
 ) -> anyhow::Result<meerkat_core::comms::CommsCommand> {
-    let req: CliCommsSendRequest = serde_json::from_str(payload_json)
+    let request: meerkat_core::comms::CommsCommandRequest = serde_json::from_str(payload_json)
         .map_err(|e| anyhow::anyhow!("Invalid comms JSON payload: {e}"))?;
-    let request = meerkat_core::comms::CommsCommandRequest {
-        kind: req.kind,
-        to: req.to,
-        body: req.body,
-        blocks: None,
-        intent: req.intent,
-        params: req.params,
-        in_reply_to: req.in_reply_to,
-        status: req.status,
-        result: req.result,
-        source: req.source,
-        stream: req.stream,
-        allow_self_session: req.allow_self_session,
-        handling_mode: req.handling_mode,
-    };
-
-    request.parse(session_id).map_err(|errors| {
-        let json_errors =
-            meerkat_core::comms::CommsCommandRequest::validation_errors_to_json(&errors);
-        anyhow::anyhow!(
-            "Invalid comms command: {}",
-            serde_json::to_string(&json_errors).unwrap_or_else(|_| "[]".to_string())
-        )
-    })
+    request
+        .into_command(session_id)
+        .map_err(|err| anyhow::anyhow!("Invalid comms command: {err}"))
 }
 
 #[cfg(test)]
@@ -10708,7 +10659,9 @@ mod tests {
         let err =
             parse_comms_send_payload(r#"{"kind":"peer_request","to":"agent-b"}"#, &session_id)
                 .expect_err("missing intent should be rejected");
-        assert!(err.to_string().contains("Invalid comms command"));
+        // Missing required `intent` field is rejected at the typed-serde
+        // boundary, not a runtime string match.
+        assert!(err.to_string().contains("Invalid comms JSON payload"));
         assert!(err.to_string().contains("intent"));
     }
 

--- a/meerkat-comms/src/mcp/mod.rs
+++ b/meerkat-comms/src/mcp/mod.rs
@@ -2,4 +2,4 @@
 
 pub mod tools;
 
-pub use tools::{PeersInput, SendInput, ToolContext, handle_tools_call, tools_list};
+pub use tools::{PeersInput, ToolContext, handle_tools_call, tools_list};

--- a/meerkat-comms/src/mcp/tools.rs
+++ b/meerkat-comms/src/mcp/tools.rs
@@ -2,6 +2,11 @@
 //!
 //! Exposes agent-facing comms tools: `send_message`, `send_request`,
 //! `send_response`, and `peers`.
+//!
+//! All comms-send tools serialize into the typed
+//! [`meerkat_core::comms::CommsCommandRequest`] enum at the deserialization
+//! boundary. Invalid discriminators (`source`, `stream`, `handling_mode`,
+//! `status`) become serde errors rather than runtime string-match failures.
 
 use parking_lot::RwLock;
 use schemars::JsonSchema;
@@ -14,6 +19,9 @@ use std::sync::Arc;
 use crate::{CommsConfig, Keypair};
 use crate::{Router, Status, TrustedPeers};
 use meerkat_core::agent::CommsRuntime as CoreCommsRuntime;
+use meerkat_core::comms::{CommsCommand, CommsCommandRequest, PeerName};
+use meerkat_core::interaction::{InteractionId, ResponseStatus};
+use meerkat_core::types::HandlingMode;
 
 fn schema_for<T: JsonSchema>() -> Value {
     let schema = schemars::schema_for!(T);
@@ -45,7 +53,7 @@ pub struct SendMessageInput {
     /// Message body
     pub body: String,
     /// "steer" for immediate processing (normal), "queue" for next turn boundary
-    pub handling_mode: String,
+    pub handling_mode: HandlingMode,
 }
 
 /// Send a structured request to a peer and expect a correlated response.
@@ -58,7 +66,7 @@ pub struct SendRequestInput {
     /// Request intent (e.g. "review", "analyze")
     pub intent: String,
     /// "steer" for immediate processing (normal), "queue" for next turn boundary
-    pub handling_mode: String,
+    pub handling_mode: HandlingMode,
     /// Request parameters (optional, defaults to {})
     #[serde(default)]
     pub params: Option<Value>,
@@ -74,41 +82,18 @@ pub struct SendResponseInput {
     /// ID of the request being responded to (from the original request)
     pub in_reply_to: String,
     /// Response status: "accepted", "completed", or "failed"
-    pub status: String,
+    pub status: ResponseStatus,
     /// Response result data (optional)
     #[serde(default)]
     pub result: Option<Value>,
     /// Handling mode override for terminal responses: "steer" or "queue" (optional)
     #[serde(default)]
-    pub handling_mode: Option<String>,
+    pub handling_mode: Option<HandlingMode>,
 }
 
 /// Input schema for `peers` tool
 #[derive(Debug, Deserialize, JsonSchema)]
 pub struct PeersInput {}
-
-/// Backward-compatible unified send input (used by `normalize_comms_call`).
-#[derive(Debug, Deserialize)]
-pub struct SendInput {
-    pub kind: String,
-    pub to: String,
-    #[serde(default)]
-    pub body: Option<String>,
-    #[serde(default)]
-    pub blocks: Option<Vec<meerkat_core::types::ContentBlock>>,
-    #[serde(default)]
-    pub intent: Option<String>,
-    #[serde(default)]
-    pub params: Option<Value>,
-    #[serde(default)]
-    pub in_reply_to: Option<String>,
-    #[serde(default)]
-    pub status: Option<String>,
-    #[serde(default)]
-    pub result: Option<Value>,
-    #[serde(default)]
-    pub handling_mode: Option<String>,
-}
 
 /// Context for comms tool execution
 #[derive(Clone)]
@@ -154,76 +139,43 @@ pub async fn handle_tools_call(
         "send_message" => {
             let input: SendMessageInput = serde_json::from_value(args.clone())
                 .map_err(|e| format!("Invalid arguments: {e}"))?;
-            handle_send_unified(
-                ctx,
-                "peer_message",
-                input.to,
-                Some(input.body),
-                None,
-                None,
-                None,
-                None,
-                None,
-                Some(input.handling_mode),
-                None,
-            )
-            .await
+            let to = peer_name(&input.to)?;
+            let request = CommsCommandRequest::PeerMessage {
+                to,
+                body: Some(input.body),
+                blocks: None,
+                handling_mode: Some(input.handling_mode),
+            };
+            dispatch(ctx, request).await
         }
         "send_request" => {
             let input: SendRequestInput = serde_json::from_value(args.clone())
                 .map_err(|e| format!("Invalid arguments: {e}"))?;
-            handle_send_unified(
-                ctx,
-                "peer_request",
-                input.to,
-                None,
-                None,
-                Some(input.intent),
-                input.params,
-                None,
-                None,
-                Some(input.handling_mode),
-                None,
-            )
-            .await
+            let to = peer_name(&input.to)?;
+            let request = CommsCommandRequest::PeerRequest {
+                to,
+                intent: input.intent,
+                params: input.params,
+                body: None,
+                handling_mode: Some(input.handling_mode),
+                stream: None,
+            };
+            dispatch(ctx, request).await
         }
         "send_response" => {
             let input: SendResponseInput = serde_json::from_value(args.clone())
                 .map_err(|e| format!("Invalid arguments: {e}"))?;
-            handle_send_unified(
-                ctx,
-                "peer_response",
-                input.to,
-                None,
-                None,
-                None,
-                None,
-                Some(input.in_reply_to),
-                Some(input.status),
-                input.handling_mode,
-                input.result,
-            )
-            .await
-        }
-        // Backward compatibility: the old unified "send" tool still works
-        // for programmatic callers that use the kind discriminator.
-        "send" => {
-            let input: SendInput = serde_json::from_value(args.clone())
-                .map_err(|e| format!("Invalid arguments: {e}"))?;
-            handle_send_unified(
-                ctx,
-                &input.kind,
-                input.to,
-                input.body,
-                input.blocks,
-                input.intent,
-                input.params,
-                input.in_reply_to,
-                input.status,
-                input.handling_mode,
-                input.result,
-            )
-            .await
+            let to = peer_name(&input.to)?;
+            let in_reply_to_uuid = uuid::Uuid::parse_str(&input.in_reply_to)
+                .map_err(|_| format!("invalid UUID for in_reply_to: {}", input.in_reply_to))?;
+            let request = CommsCommandRequest::PeerResponse {
+                to,
+                in_reply_to: InteractionId(in_reply_to_uuid),
+                status: input.status,
+                result: input.result,
+                handling_mode: input.handling_mode,
+            };
+            dispatch(ctx, request).await
         }
         "peers" => {
             let _input: PeersInput = serde_json::from_value(args.clone())
@@ -234,55 +186,39 @@ pub async fn handle_tools_call(
     }
 }
 
-#[allow(clippy::too_many_arguments)]
-async fn handle_send_unified(
-    ctx: &ToolContext,
-    kind: &str,
-    to: String,
-    body: Option<String>,
-    blocks: Option<Vec<meerkat_core::types::ContentBlock>>,
-    intent: Option<String>,
-    params: Option<Value>,
-    in_reply_to: Option<String>,
-    status: Option<String>,
-    handling_mode: Option<String>,
-    result: Option<Value>,
-) -> Result<Value, String> {
-    let request = meerkat_core::comms::CommsCommandRequest {
-        kind: kind.to_string(),
-        to: Some(to),
-        body,
-        blocks,
-        intent,
-        params,
-        in_reply_to,
-        status,
-        result,
-        source: None,
-        stream: None,
-        allow_self_session: None,
-        handling_mode,
-    };
-    let command = request
-        .parse(&meerkat_core::SessionId::new())
-        .map_err(format_comms_command_error)?;
+fn peer_name(value: &str) -> Result<PeerName, String> {
+    PeerName::new(value).map_err(|err| format!("invalid to: {err}"))
+}
 
+async fn dispatch(ctx: &ToolContext, request: CommsCommandRequest) -> Result<Value, String> {
+    // Capture peer name for error normalization before consuming the request.
+    let peer_for_errors = match &request {
+        CommsCommandRequest::PeerMessage { to, .. }
+        | CommsCommandRequest::PeerRequest { to, .. }
+        | CommsCommandRequest::PeerResponse { to, .. } => Some(to.as_string()),
+        CommsCommandRequest::Input { .. } => None,
+    };
+
+    let command = request
+        // Per-session id is irrelevant here — the agent-facing tools only
+        // reach peer_* commands, never the local `Input` variant.
+        .into_command(&meerkat_core::SessionId::new())
+        .map_err(|e| e.to_string())?;
     let cmd_kind = command.command_kind().to_string();
+
     if let Some(runtime) = &ctx.runtime {
         runtime.send(command).await.map_err(|error| match error {
-            meerkat_core::comms::SendError::PeerNotFound(peer_name) => {
-                format!(
-                    "peer_not_found_or_not_trusted: peer '{peer_name}' is not found or not trusted"
-                )
+            meerkat_core::comms::SendError::PeerNotFound(p) => {
+                format!("peer_not_found_or_not_trusted: peer '{p}' is not found or not trusted")
             }
             meerkat_core::comms::SendError::PeerOffline => format!(
                 "peer_unreachable: peer '{}' is unreachable: offline_or_no_ack",
-                request.to.as_deref().unwrap_or("<unknown>")
+                peer_for_errors.as_deref().unwrap_or("<unknown>")
             ),
             meerkat_core::comms::SendError::Internal(inner) if is_transport_internal(&inner) => {
                 format!(
                     "peer_unreachable: peer '{}' is unreachable: transport_error ({inner})",
-                    request.to.as_deref().unwrap_or("<unknown>")
+                    peer_for_errors.as_deref().unwrap_or("<unknown>")
                 )
             }
             other => other.to_string(),
@@ -291,10 +227,8 @@ async fn handle_send_unified(
     }
 
     match command {
-        meerkat_core::comms::CommsCommand::Input { .. } => {
-            Err("input command is not supported by MCP send".to_string())
-        }
-        meerkat_core::comms::CommsCommand::PeerMessage {
+        CommsCommand::Input { .. } => Err("input command is not supported by MCP send".to_string()),
+        CommsCommand::PeerMessage {
             to,
             body,
             blocks,
@@ -313,7 +247,7 @@ async fn handle_send_unified(
                 .map_err(|e| format_router_send_error(to.as_str(), e))?;
             Ok(json!({ "status": "sent", "kind": cmd_kind }))
         }
-        meerkat_core::comms::CommsCommand::PeerRequest {
+        CommsCommand::PeerRequest {
             to,
             intent,
             params,
@@ -333,7 +267,7 @@ async fn handle_send_unified(
                 .map_err(|e| format_router_send_error(to.as_str(), e))?;
             Ok(json!({ "status": "sent", "kind": cmd_kind }))
         }
-        meerkat_core::comms::CommsCommand::PeerResponse {
+        CommsCommand::PeerResponse {
             to,
             in_reply_to,
             status,
@@ -341,9 +275,9 @@ async fn handle_send_unified(
             handling_mode,
         } => {
             let status = match status {
-                meerkat_core::ResponseStatus::Accepted => Status::Accepted,
-                meerkat_core::ResponseStatus::Completed => Status::Completed,
-                meerkat_core::ResponseStatus::Failed => Status::Failed,
+                ResponseStatus::Accepted => Status::Accepted,
+                ResponseStatus::Completed => Status::Completed,
+                ResponseStatus::Failed => Status::Failed,
             };
             ctx.router
                 .send(
@@ -396,53 +330,6 @@ fn format_router_send_error(peer_name: &str, error: crate::router::SendError) ->
 
 fn is_transport_internal(message: &str) -> bool {
     message.starts_with("Transport error:") || message.starts_with("IO error:")
-}
-
-fn format_comms_command_error(
-    errors: Vec<meerkat_core::comms::CommsCommandValidationError>,
-) -> String {
-    let errors = meerkat_core::comms::CommsCommandRequest::validation_errors_to_json(&errors);
-    if let Some(first) = errors.first() {
-        let field = first["field"].as_str().unwrap_or("command");
-        let issue = first["issue"].as_str().unwrap_or("invalid");
-        let got = first["got"].as_str();
-        match (field, issue) {
-            ("body", "required_field") => "peer_message requires body".to_string(),
-            ("to", "required_field") => "to is required".to_string(),
-            ("intent", "required_field") => "peer_request requires intent".to_string(),
-            ("in_reply_to", "required_field") => "peer_response requires in_reply_to".to_string(),
-            ("in_reply_to", "invalid_uuid") => got.map_or_else(
-                || "invalid in_reply_to".to_string(),
-                |value| format!("invalid UUID for in_reply_to: {value}"),
-            ),
-            ("status", "invalid_value") => got.map_or_else(
-                || "invalid status".to_string(),
-                |value| format!("invalid status: {value}"),
-            ),
-            ("to", "invalid_value") => got.map_or_else(
-                || "invalid peer name".to_string(),
-                |value| format!("invalid to: {value}"),
-            ),
-            ("source", "invalid_value") => got.map_or_else(
-                || "invalid source".to_string(),
-                |value| format!("invalid source: {value}"),
-            ),
-            ("stream", "removed_unsupported_field") => got.map_or_else(
-                || "stream field has been removed".to_string(),
-                |value| format!("stream field has been removed (got: {value})"),
-            ),
-            ("kind", "unknown_kind") => got.map_or_else(
-                || "unknown kind".to_string(),
-                |value| format!("unknown kind: {value}"),
-            ),
-            ("handling_mode", "required_field") => {
-                "handling_mode is required: use \"steer\" for normal collaboration or \"queue\" for next-turn processing".to_string()
-            }
-            _ => issue.to_string(),
-        }
-    } else {
-        "invalid command".to_string()
-    }
 }
 
 async fn handle_peers(ctx: &ToolContext) -> Result<Value, String> {
@@ -627,17 +514,15 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_legacy_send_still_works() {
-        let suffix = uuid::Uuid::new_v4().simple().to_string();
-        let receiver_name = format!("receiver-{suffix}");
-        let sender_keypair = Keypair::generate();
+    async fn test_send_message_invalid_handling_mode_fails_at_serde_boundary() {
+        let keypair = Keypair::generate();
         let trusted_peers = Arc::new(RwLock::new(TrustedPeers::new()));
-        let (_, router_inbox_sender) = crate::Inbox::new();
+        let (_, inbox_sender) = crate::Inbox::new();
         let router = Arc::new(Router::with_shared_peers(
-            sender_keypair,
+            keypair,
             trusted_peers.clone(),
             CommsConfig::default(),
-            router_inbox_sender,
+            inbox_sender,
             true,
         ));
         let ctx = ToolContext {
@@ -646,21 +531,25 @@ mod tests {
             runtime: None,
         };
 
-        // The old "send" tool with kind discriminator still works
+        // "almost" is not a valid HandlingMode — typed enum rejects it at
+        // deserialization, never reaches the runtime.
         let result = handle_tools_call(
             &ctx,
-            "send",
+            "send_message",
             &json!({
-                "kind": "peer_message",
-                "to": receiver_name,
+                "to": "alice",
                 "body": "hello",
-                "handling_mode": "steer"
+                "handling_mode": "almost"
             }),
         )
         .await;
-        // Will fail because peer is not trusted, but the parsing should succeed
-        let error = result.expect_err("send should fail for an unreachable peer");
-        assert!(error.contains("not found or not trusted"));
+
+        let error = result.expect_err("invalid handling_mode must be rejected");
+        assert!(
+            error.contains("Invalid arguments")
+                && (error.contains("handling_mode") || error.contains("almost")),
+            "expected serde error mentioning handling_mode, got: {error}"
+        );
     }
 
     #[tokio::test]

--- a/meerkat-contracts/src/emit.rs
+++ b/meerkat-contracts/src/emit.rs
@@ -103,6 +103,7 @@ pub fn emit_all_schemas(output_dir: &std::path::Path) -> Result<(), Box<dyn std:
         "WireRealmConnectionSet": schema_for!(crate::wire::WireRealmConnectionSet),
         "WireAuthStatus": schema_for!(crate::wire::WireAuthStatus),
         "WireAuthError": schema_for!(crate::wire::WireAuthError),
+        "CommsCommandRequest": schema_for!(crate::wire::CommsCommandRequest),
     });
     fs::write(
         output_dir.join("wire-types.json"),

--- a/meerkat-contracts/src/wire/comms.rs
+++ b/meerkat-contracts/src/wire/comms.rs
@@ -1,0 +1,14 @@
+//! Wire types for `comms/send`.
+//!
+//! These re-export the typed [`meerkat_core::comms::CommsCommandRequest`]
+//! enum and its supporting discriminator enums so the schema-emit pipeline
+//! can produce JSON schemas and SDK codegen can derive typed client bindings.
+//!
+//! The wire shape is `{ "kind": "<variant>", ... }` — serde-tagged on
+//! `kind` with structurally enforced per-variant fields.
+
+pub use meerkat_core::comms::{
+    CommsCommandError, CommsCommandRequest, InputSource, InputStreamMode, PeerName,
+};
+pub use meerkat_core::interaction::ResponseStatus;
+pub use meerkat_core::types::HandlingMode;

--- a/meerkat-contracts/src/wire/mod.rs
+++ b/meerkat-contracts/src/wire/mod.rs
@@ -1,5 +1,6 @@
 //! Canonical wire response types.
 
+mod comms;
 mod connection;
 mod event;
 mod mcp_live;
@@ -15,6 +16,11 @@ pub mod skills;
 pub mod supervisor_bridge;
 mod usage;
 
+pub use comms::{
+    CommsCommandError, CommsCommandRequest, HandlingMode as WireCommsHandlingMode,
+    InputSource as WireCommsInputSource, InputStreamMode as WireCommsInputStreamMode,
+    PeerName as WireCommsPeerName, ResponseStatus as WireCommsResponseStatus,
+};
 pub use connection::{
     WireAuthError, WireAuthProfile, WireAuthStatus, WireBackendProfile, WireConnectionRef,
     WireProviderBinding, WireRealmConnectionSet,

--- a/meerkat-core/src/comms.rs
+++ b/meerkat-core/src/comms.rs
@@ -9,9 +9,9 @@ use crate::interaction::{InteractionId, ResponseStatus};
 use crate::types::{ContentBlock, HandlingMode};
 use futures::Stream;
 use serde::{Deserialize, Serialize};
-use serde_json::json;
 use std::pin::Pin;
 
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub struct PeerName(String);
 
@@ -55,327 +55,174 @@ impl From<PeerName> for String {
     }
 }
 
-/// Build inputs for canonical comms command parsing.
-#[derive(Debug, Clone, Default)]
-pub struct CommsCommandRequest {
-    pub kind: String,
-    pub to: Option<String>,
-    pub body: Option<String>,
-    pub blocks: Option<Vec<ContentBlock>>,
-    pub intent: Option<String>,
-    pub params: Option<serde_json::Value>,
-    pub in_reply_to: Option<String>,
-    pub status: Option<String>,
-    pub result: Option<serde_json::Value>,
-    pub source: Option<String>,
-    pub stream: Option<String>,
-    pub allow_self_session: Option<bool>,
-    pub handling_mode: Option<String>,
+/// Typed wire request for `comms/send`.
+///
+/// Variants are serde-tagged on `kind` and validated structurally at the
+/// deserialization boundary. Required fields per kind are enforced by the
+/// type system; invalid discriminators (`source`, `stream`, `handling_mode`,
+/// `status`) become serde deserialization errors rather than runtime
+/// string-match failures.
+///
+/// Cross-field invariants that cannot be expressed structurally (e.g.
+/// `handling_mode` is forbidden on `Accepted` peer responses) are checked
+/// in [`CommsCommandRequest::into_command`].
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(tag = "kind", rename_all = "snake_case")]
+pub enum CommsCommandRequest {
+    /// Inject input into the local session.
+    Input {
+        body: String,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        blocks: Option<Vec<ContentBlock>>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        source: Option<InputSource>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        stream: Option<InputStreamMode>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        handling_mode: Option<HandlingMode>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        allow_self_session: Option<bool>,
+    },
+    /// Send a one-way peer message.
+    PeerMessage {
+        to: PeerName,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        body: Option<String>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        blocks: Option<Vec<ContentBlock>>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        handling_mode: Option<HandlingMode>,
+    },
+    /// Send a request to a peer.
+    PeerRequest {
+        to: PeerName,
+        intent: String,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        params: Option<serde_json::Value>,
+        /// Legacy promotion: if `params` is absent, `body` is wrapped as
+        /// `{"body": <body>}` for backwards-compatibility with single-string
+        /// requesters. Prefer `params`.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        body: Option<String>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        handling_mode: Option<HandlingMode>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        stream: Option<InputStreamMode>,
+    },
+    /// Send a response to a prior peer request.
+    PeerResponse {
+        to: PeerName,
+        in_reply_to: InteractionId,
+        status: ResponseStatus,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        result: Option<serde_json::Value>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        handling_mode: Option<HandlingMode>,
+    },
 }
 
-/// Validation failure for one command field.
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub struct CommsCommandValidationError {
-    pub field: String,
-    pub issue: String,
-    pub got: Option<String>,
-}
-
-impl CommsCommandValidationError {
-    fn new(field: impl Into<String>, issue: impl Into<String>, got: Option<String>) -> Self {
-        Self {
-            field: field.into(),
-            issue: issue.into(),
-            got,
-        }
-    }
-
-    pub fn to_json_value(&self) -> serde_json::Value {
-        match &self.got {
-            Some(got) => json!({
-                "field": self.field,
-                "issue": self.issue,
-                "got": got,
-            }),
-            None => json!({
-                "field": self.field,
-                "issue": self.issue,
-            }),
-        }
-    }
+/// Cross-field validation failure for [`CommsCommandRequest::into_command`].
+///
+/// Per-field discriminator validation is enforced by serde at deserialization
+/// — only invariants that span multiple fields surface here.
+#[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
+pub enum CommsCommandError {
+    /// `handling_mode` is set on a `peer_response` whose `status` is
+    /// `Accepted`. Progress responses cannot carry a handling mode — the
+    /// receiver's admission gate would drop them, so reject at parse time.
+    #[error("handling_mode is forbidden on accepted peer responses")]
+    HandlingModeForbiddenForAcceptedResponse,
 }
 
 impl CommsCommandRequest {
-    pub fn parse(
-        &self,
+    /// Convert the typed wire request into a [`CommsCommand`] domain envelope.
+    ///
+    /// `session_id` is supplied separately because it is owned by the
+    /// surface that received the request, not the wire payload.
+    pub fn into_command(
+        self,
         session_id: &crate::types::SessionId,
-    ) -> Result<CommsCommand, Vec<CommsCommandValidationError>> {
-        let mut errors = Vec::new();
-
-        let kind = self.kind.as_str();
-        match kind {
-            "input" => {
-                let Some(body) = self.body.clone() else {
-                    errors.push(CommsCommandValidationError::new(
-                        "body",
-                        "required_field",
-                        None,
-                    ));
-                    return Err(errors);
-                };
-
-                let source = match self.source.as_deref() {
-                    Some("tcp") => InputSource::Tcp,
-                    Some("uds") => InputSource::Uds,
-                    Some("stdin") => InputSource::Stdin,
-                    Some("webhook") => InputSource::Webhook,
-                    Some("rpc") | None => InputSource::Rpc,
-                    Some(other) => {
-                        errors.push(CommsCommandValidationError::new(
-                            "source",
-                            "invalid_value",
-                            Some(other.to_string()),
-                        ));
-                        return Err(errors);
-                    }
-                };
-
-                let stream = match self.stream.as_deref() {
-                    Some("reserve_interaction") => InputStreamMode::ReserveInteraction,
-                    Some("none") | None => InputStreamMode::None,
-                    Some(other) => {
-                        errors.push(CommsCommandValidationError::new(
-                            "stream",
-                            "invalid_value",
-                            Some(other.to_string()),
-                        ));
-                        return Err(errors);
-                    }
-                };
-
-                Ok(CommsCommand::Input {
-                    session_id: session_id.clone(),
-                    body,
-                    blocks: self.blocks.clone(),
-                    handling_mode: match self.handling_mode.as_deref() {
-                        Some("steer") => HandlingMode::Steer,
-                        Some("queue") | None => HandlingMode::Queue,
-                        Some(other) => {
-                            errors.push(CommsCommandValidationError::new(
-                                "handling_mode",
-                                "invalid_value",
-                                Some(other.to_string()),
-                            ));
-                            return Err(errors);
-                        }
-                    },
-                    source,
-                    stream,
-                    allow_self_session: self.allow_self_session.unwrap_or(false),
-                })
-            }
-            "peer_message" => {
-                let to = to_peer_name(self.to.as_ref(), &mut errors);
-                let handling_mode = match self.handling_mode.as_deref() {
-                    Some("steer") => HandlingMode::Steer,
-                    Some("queue") | None => HandlingMode::Queue,
-                    Some(other) => {
-                        errors.push(CommsCommandValidationError::new(
-                            "handling_mode",
-                            "invalid_value",
-                            Some(other.to_string()),
-                        ));
-                        return Err(errors);
-                    }
-                };
-                if let Some(to) = to {
-                    Ok(CommsCommand::PeerMessage {
-                        to,
-                        body: self.body.clone().unwrap_or_default(),
-                        blocks: self.blocks.clone(),
-                        handling_mode,
-                    })
-                } else {
-                    Err(errors)
+    ) -> Result<CommsCommand, CommsCommandError> {
+        Ok(match self {
+            CommsCommandRequest::Input {
+                body,
+                blocks,
+                source,
+                stream,
+                handling_mode,
+                allow_self_session,
+            } => CommsCommand::Input {
+                session_id: session_id.clone(),
+                body,
+                blocks,
+                handling_mode: handling_mode.unwrap_or_default(),
+                source: source.unwrap_or(InputSource::Rpc),
+                stream: stream.unwrap_or(InputStreamMode::None),
+                allow_self_session: allow_self_session.unwrap_or(false),
+            },
+            CommsCommandRequest::PeerMessage {
+                to,
+                body,
+                blocks,
+                handling_mode,
+            } => CommsCommand::PeerMessage {
+                to,
+                body: body.unwrap_or_default(),
+                blocks,
+                handling_mode: handling_mode.unwrap_or_default(),
+            },
+            CommsCommandRequest::PeerRequest {
+                to,
+                intent,
+                params,
+                body,
+                handling_mode,
+                stream,
+            } => CommsCommand::PeerRequest {
+                to,
+                intent,
+                params: match (params, body) {
+                    (Some(p), _) => p,
+                    (None, Some(body)) => serde_json::json!({ "body": body }),
+                    (None, None) => serde_json::Value::Object(Default::default()),
+                },
+                handling_mode: handling_mode.unwrap_or_default(),
+                stream: stream.unwrap_or(InputStreamMode::None),
+            },
+            CommsCommandRequest::PeerResponse {
+                to,
+                in_reply_to,
+                status,
+                result,
+                handling_mode,
+            } => {
+                if status == ResponseStatus::Accepted && handling_mode.is_some() {
+                    return Err(CommsCommandError::HandlingModeForbiddenForAcceptedResponse);
+                }
+                CommsCommand::PeerResponse {
+                    to,
+                    in_reply_to,
+                    status,
+                    result: result.unwrap_or(serde_json::Value::Null),
+                    handling_mode,
                 }
             }
-            "peer_request" => {
-                let to = to_peer_name(self.to.as_ref(), &mut errors);
-                let Some(intent) = self.intent.clone() else {
-                    errors.push(CommsCommandValidationError::new(
-                        "intent",
-                        "required_field",
-                        None,
-                    ));
-                    return Err(errors);
-                };
-                let stream = match self.stream.as_deref() {
-                    Some("reserve_interaction") => InputStreamMode::ReserveInteraction,
-                    Some("none") | None => InputStreamMode::None,
-                    Some(other) => {
-                        errors.push(CommsCommandValidationError::new(
-                            "stream",
-                            "invalid_value",
-                            Some(other.to_string()),
-                        ));
-                        return Err(errors);
-                    }
-                };
-                let handling_mode = match self.handling_mode.as_deref() {
-                    Some("steer") => HandlingMode::Steer,
-                    Some("queue") | None => HandlingMode::Queue,
-                    Some(other) => {
-                        errors.push(CommsCommandValidationError::new(
-                            "handling_mode",
-                            "invalid_value",
-                            Some(other.to_string()),
-                        ));
-                        return Err(errors);
-                    }
-                };
-                if errors.is_empty() {
-                    let Some(to) = to else {
-                        return Err(errors);
-                    };
-                    Ok(CommsCommand::PeerRequest {
-                        to,
-                        intent,
-                        params: match (&self.params, &self.body) {
-                            (Some(p), _) => p.clone(),
-                            (None, Some(body)) => serde_json::json!({ "body": body }),
-                            (None, None) => serde_json::Value::Object(Default::default()),
-                        },
-                        handling_mode,
-                        stream,
-                    })
-                } else {
-                    Err(errors)
-                }
-            }
-            "peer_response" => {
-                let to = to_peer_name(self.to.as_ref(), &mut errors);
-                let in_reply_to = match &self.in_reply_to {
-                    Some(in_reply_to) => match uuid::Uuid::parse_str(in_reply_to) {
-                        Ok(id) => crate::interaction::InteractionId(id),
-                        Err(_) => {
-                            errors.push(CommsCommandValidationError::new(
-                                "in_reply_to",
-                                "invalid_uuid",
-                                Some(in_reply_to.clone()),
-                            ));
-                            return Err(errors);
-                        }
-                    },
-                    None => {
-                        errors.push(CommsCommandValidationError::new(
-                            "in_reply_to",
-                            "required_field",
-                            None,
-                        ));
-                        return Err(errors);
-                    }
-                };
-                let status = match self.status.as_deref() {
-                    Some("accepted") => crate::ResponseStatus::Accepted,
-                    Some("completed") | None => crate::ResponseStatus::Completed,
-                    Some("failed") => crate::ResponseStatus::Failed,
-                    Some(other) => {
-                        errors.push(CommsCommandValidationError::new(
-                            "status",
-                            "invalid_value",
-                            Some(other.to_string()),
-                        ));
-                        return Err(errors);
-                    }
-                };
-                let handling_mode = match self.handling_mode.as_deref() {
-                    Some("steer") => Some(HandlingMode::Steer),
-                    Some("queue") => Some(HandlingMode::Queue),
-                    None => None,
-                    Some(other) => {
-                        errors.push(CommsCommandValidationError::new(
-                            "handling_mode",
-                            "invalid_value",
-                            Some(other.to_string()),
-                        ));
-                        return Err(errors);
-                    }
-                };
-                // handling_mode is forbidden on "accepted" (progress) responses.
-                // Runtime admission rejects PeerInput(ResponseProgress) with
-                // handling_mode, so reject at parse time to avoid a sender-side
-                // success path for a combination the receiver will drop.
-                if status == crate::ResponseStatus::Accepted && handling_mode.is_some() {
-                    errors.push(CommsCommandValidationError::new(
-                        "handling_mode",
-                        "forbidden_for_accepted_response",
-                        self.handling_mode.clone(),
-                    ));
-                    return Err(errors);
-                }
-                if errors.is_empty() {
-                    let Some(to) = to else {
-                        return Err(errors);
-                    };
-                    Ok(CommsCommand::PeerResponse {
-                        to,
-                        in_reply_to,
-                        status,
-                        result: self.result.clone().unwrap_or(serde_json::Value::Null),
-                        handling_mode,
-                    })
-                } else {
-                    Err(errors)
-                }
-            }
-            other => {
-                errors.push(CommsCommandValidationError::new(
-                    "kind",
-                    "unknown_kind",
-                    Some(other.to_string()),
-                ));
-                Err(errors)
-            }
-        }
+        })
     }
 
-    pub fn validation_errors_to_json(
-        errors: &[CommsCommandValidationError],
-    ) -> Vec<serde_json::Value> {
-        errors
-            .iter()
-            .map(CommsCommandValidationError::to_json_value)
-            .collect()
-    }
-}
-
-fn to_peer_name(
-    value: Option<&String>,
-    errors: &mut Vec<CommsCommandValidationError>,
-) -> Option<PeerName> {
-    match value {
-        Some(name) => match PeerName::new(name) {
-            Ok(peer) => Some(peer),
-            Err(_) => {
-                errors.push(CommsCommandValidationError::new(
-                    "to",
-                    "invalid_value",
-                    Some(name.clone()),
-                ));
-                None
-            }
-        },
-        None => {
-            errors.push(CommsCommandValidationError::new(
-                "to",
-                "required_field",
-                None,
-            ));
-            None
+    /// Stable wire discriminant for telemetry / logging.
+    pub fn kind(&self) -> &'static str {
+        match self {
+            Self::Input { .. } => "input",
+            Self::PeerMessage { .. } => "peer_message",
+            Self::PeerRequest { .. } => "peer_request",
+            Self::PeerResponse { .. } => "peer_response",
         }
     }
 }
 /// Source for an input event posted to an agent.
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "lowercase")]
 pub enum InputSource {
@@ -411,6 +258,7 @@ impl From<InputSource> for crate::config::PlainEventSource {
 }
 
 /// Whether this input/peer command should reserve a local interaction stream.
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum InputStreamMode {
@@ -708,23 +556,16 @@ mod tests {
     fn peer_request_cmd(
         params: Option<Value>,
         body: Option<String>,
-    ) -> Result<CommsCommand, Vec<CommsCommandValidationError>> {
-        let req = CommsCommandRequest {
-            kind: "peer_request".to_string(),
-            to: Some("bob".to_string()),
-            body,
-            blocks: None,
-            intent: Some("greet".to_string()),
+    ) -> Result<CommsCommand, CommsCommandError> {
+        let req = CommsCommandRequest::PeerRequest {
+            to: PeerName::new("bob").expect("peer name"),
+            intent: "greet".to_string(),
             params,
-            in_reply_to: None,
-            status: None,
-            result: None,
-            source: None,
-            stream: None,
-            allow_self_session: None,
+            body,
             handling_mode: None,
+            stream: None,
         };
-        req.parse(&crate::types::SessionId::new())
+        req.into_command(&crate::types::SessionId::new())
     }
 
     #[test]
@@ -797,42 +638,79 @@ mod tests {
 
     #[test]
     fn peer_response_accepted_with_handling_mode_rejected() {
-        let req = CommsCommandRequest {
-            kind: "peer_response".to_string(),
-            to: Some("peer-1".to_string()),
-            in_reply_to: Some(uuid::Uuid::now_v7().to_string()),
-            status: Some("accepted".to_string()),
-            handling_mode: Some("steer".to_string()),
-            ..Default::default()
+        let req = CommsCommandRequest::PeerResponse {
+            to: PeerName::new("peer-1").expect("peer"),
+            in_reply_to: InteractionId(uuid::Uuid::now_v7()),
+            status: ResponseStatus::Accepted,
+            result: None,
+            handling_mode: Some(HandlingMode::Steer),
         };
-        let result = req.parse(&crate::SessionId::new());
-        assert!(
-            result.is_err(),
-            "accepted response with handling_mode must be rejected"
-        );
-        let errors = result.unwrap_err();
-        assert!(
-            errors
-                .iter()
-                .any(|e| e.issue == "forbidden_for_accepted_response"),
-            "should have forbidden_for_accepted_response error, got: {errors:?}"
+        let err = req
+            .into_command(&crate::SessionId::new())
+            .expect_err("accepted response with handling_mode must be rejected");
+        assert_eq!(
+            err,
+            CommsCommandError::HandlingModeForbiddenForAcceptedResponse
         );
     }
 
     #[test]
     fn peer_response_completed_with_handling_mode_accepted() {
-        let req = CommsCommandRequest {
-            kind: "peer_response".to_string(),
-            to: Some("peer-1".to_string()),
-            in_reply_to: Some(uuid::Uuid::now_v7().to_string()),
-            status: Some("completed".to_string()),
-            handling_mode: Some("steer".to_string()),
-            ..Default::default()
+        let req = CommsCommandRequest::PeerResponse {
+            to: PeerName::new("peer-1").expect("peer"),
+            in_reply_to: InteractionId(uuid::Uuid::now_v7()),
+            status: ResponseStatus::Completed,
+            result: None,
+            handling_mode: Some(HandlingMode::Steer),
         };
-        let result = req.parse(&crate::SessionId::new());
         assert!(
-            result.is_ok(),
+            req.into_command(&crate::SessionId::new()).is_ok(),
             "completed response with handling_mode=steer should be accepted"
+        );
+    }
+
+    #[test]
+    fn deserialize_input_with_typed_source() -> Result<(), serde_json::Error> {
+        let json = r#"{"kind":"input","body":"hello","source":"webhook","handling_mode":"steer"}"#;
+        let req: CommsCommandRequest = serde_json::from_str(json)?;
+        match req {
+            CommsCommandRequest::Input {
+                body,
+                source,
+                handling_mode,
+                ..
+            } => {
+                assert_eq!(body, "hello");
+                assert_eq!(source, Some(InputSource::Webhook));
+                assert_eq!(handling_mode, Some(HandlingMode::Steer));
+            }
+            other => panic!("expected Input, got {other:?}"),
+        }
+        Ok(())
+    }
+
+    #[test]
+    fn deserialize_input_invalid_source_rejects_at_serde_boundary() {
+        let json = r#"{"kind":"input","body":"hello","source":"webhookd"}"#;
+        let err = serde_json::from_str::<CommsCommandRequest>(json)
+            .expect_err("invalid source must fail deserialization");
+        let msg = err.to_string();
+        // serde reports "unknown variant `webhookd`, expected one of ...".
+        assert!(
+            msg.contains("webhookd"),
+            "error should name the rejected value, got: {msg}"
+        );
+    }
+
+    #[test]
+    fn deserialize_unknown_kind_rejects_at_serde_boundary() {
+        let json = r#"{"kind":"foobar","body":"hello"}"#;
+        let err = serde_json::from_str::<CommsCommandRequest>(json)
+            .expect_err("unknown kind must fail deserialization");
+        let msg = err.to_string();
+        assert!(
+            msg.contains("foobar") || msg.contains("variant"),
+            "error should mention unknown variant, got: {msg}"
         );
     }
 }

--- a/meerkat-core/src/interaction.rs
+++ b/meerkat-core/src/interaction.rs
@@ -25,6 +25,7 @@ impl std::fmt::Display for InteractionId {
 /// Typed status for response interactions.
 ///
 /// Mirrors `CommsStatus` from `meerkat-comms` — the comms runtime converts at the boundary.
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum ResponseStatus {

--- a/meerkat-core/src/types.rs
+++ b/meerkat-core/src/types.rs
@@ -338,6 +338,7 @@ impl From<&str> for ContentInput {
 /// `Steer` means inner-loop handling and requests injection at the earliest
 /// admissible cooperative boundary, while remaining ordinary work rather than
 /// an out-of-band control-plane command.
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Default)]
 #[serde(rename_all = "snake_case")]
 pub enum HandlingMode {

--- a/meerkat-mcp-server/src/lib.rs
+++ b/meerkat-mcp-server/src/lib.rs
@@ -971,29 +971,11 @@ pub struct MeerkatCommsPeersInput {
 #[derive(Debug, Deserialize, JsonSchema)]
 pub struct MeerkatCommsSendInput {
     pub session_id: String,
-    pub kind: String,
-    #[serde(default)]
-    pub to: Option<String>,
-    #[serde(default)]
-    pub body: Option<String>,
-    #[serde(default)]
-    pub intent: Option<String>,
-    #[serde(default)]
-    pub params: Option<serde_json::Value>,
-    #[serde(default)]
-    pub in_reply_to: Option<String>,
-    #[serde(default)]
-    pub status: Option<String>,
-    #[serde(default)]
-    pub result: Option<serde_json::Value>,
-    #[serde(default)]
-    pub source: Option<String>,
-    #[serde(default)]
-    pub stream: Option<String>,
-    #[serde(default)]
-    pub allow_self_session: Option<bool>,
-    #[serde(default)]
-    pub handling_mode: Option<String>,
+    /// Typed comms command — serde-tagged on `kind`. Invalid discriminators
+    /// (`source`, `stream`, `handling_mode`, `status`) become deserialization
+    /// errors here, never reach runtime.
+    #[serde(flatten)]
+    pub command: meerkat_core::comms::CommsCommandRequest,
 }
 
 #[derive(Debug, Clone, Deserialize, Serialize, JsonSchema)]
@@ -2321,36 +2303,26 @@ async fn handle_meerkat_comms_send(
                 })),
             )
         })?;
-    let request = meerkat_core::comms::CommsCommandRequest {
-        kind: input.kind,
-        to: input.to,
-        body: input.body,
-        blocks: None,
-        intent: input.intent,
-        params: input.params,
-        in_reply_to: input.in_reply_to,
-        status: input.status,
-        result: input.result,
-        source: input.source,
-        stream: input.stream,
-        allow_self_session: input.allow_self_session,
-        handling_mode: input.handling_mode,
+    let peer_name = match &input.command {
+        meerkat_core::comms::CommsCommandRequest::PeerMessage { to, .. }
+        | meerkat_core::comms::CommsCommandRequest::PeerRequest { to, .. }
+        | meerkat_core::comms::CommsCommandRequest::PeerResponse { to, .. } => Some(to.as_string()),
+        meerkat_core::comms::CommsCommandRequest::Input { .. } => None,
     };
-    let cmd = request.parse(&session_id).map_err(|errors| {
-        let details = meerkat_core::comms::CommsCommandRequest::validation_errors_to_json(&errors);
+    let cmd = input.command.into_command(&session_id).map_err(|err| {
         ToolCallError::new(
             -32602,
             "Invalid comms command",
             Some(json!({
                 "code": "invalid_comms_command",
-                "validation_errors": details,
+                "message": err.to_string(),
             })),
         )
     })?;
     let receipt = comms
         .send(cmd)
         .await
-        .map_err(|e| normalize_mcp_comms_send_error(request.to.as_deref(), &e))?;
+        .map_err(|e| normalize_mcp_comms_send_error(peer_name.as_deref(), &e))?;
     Ok(wrap_tool_payload(
         json!({ "receipt": build_comms_receipt_json(receipt) }),
     ))
@@ -3145,7 +3117,7 @@ impl AgentToolDispatcher for MpcToolDispatcher {
 }
 
 #[cfg(test)]
-#[allow(clippy::unwrap_used, clippy::expect_used)]
+#[allow(clippy::unwrap_used, clippy::expect_used, clippy::panic)]
 mod tests {
     use super::*;
     use futures::stream;
@@ -4550,18 +4522,10 @@ mod tests {
 
     #[cfg(feature = "comms")]
     #[test]
-    fn test_comms_send_schema_includes_handling_mode() {
-        let schema = meerkat_tools::schema_for::<MeerkatCommsSendInput>();
-        let props = schema["properties"].as_object().expect("properties map");
-        assert!(
-            props.contains_key("handling_mode"),
-            "MeerkatCommsSendInput schema must expose handling_mode"
-        );
-    }
+    fn test_comms_send_input_threads_typed_handling_mode() {
+        use meerkat_core::comms::CommsCommandRequest;
+        use meerkat_core::types::HandlingMode;
 
-    #[cfg(feature = "comms")]
-    #[test]
-    fn test_comms_send_input_threads_handling_mode() {
         let input: MeerkatCommsSendInput = serde_json::from_value(json!({
             "session_id": "01234567-89ab-cdef-0123-456789abcdef",
             "kind": "peer_message",
@@ -4570,23 +4534,33 @@ mod tests {
             "handling_mode": "steer"
         }))
         .unwrap();
-        assert_eq!(input.handling_mode.as_deref(), Some("steer"));
+        match input.command {
+            CommsCommandRequest::PeerMessage {
+                ref to,
+                handling_mode,
+                ..
+            } => {
+                assert_eq!(to.as_str(), "alice");
+                assert_eq!(handling_mode, Some(HandlingMode::Steer));
+            }
+            other => panic!("expected peer_message, got {other:?}"),
+        }
+    }
 
-        let request = meerkat_core::comms::CommsCommandRequest {
-            kind: input.kind,
-            to: input.to,
-            body: input.body,
-            blocks: None,
-            intent: input.intent,
-            params: input.params,
-            in_reply_to: input.in_reply_to,
-            status: input.status,
-            result: input.result,
-            source: input.source,
-            stream: input.stream,
-            allow_self_session: input.allow_self_session,
-            handling_mode: input.handling_mode,
-        };
-        assert_eq!(request.handling_mode.as_deref(), Some("steer"));
+    #[cfg(feature = "comms")]
+    #[test]
+    fn test_comms_send_input_invalid_handling_mode_rejected_at_serde_boundary() {
+        let err = serde_json::from_value::<MeerkatCommsSendInput>(json!({
+            "session_id": "01234567-89ab-cdef-0123-456789abcdef",
+            "kind": "peer_message",
+            "to": "alice",
+            "body": "hi",
+            "handling_mode": "invalid"
+        }))
+        .expect_err("invalid handling_mode must fail deserialization");
+        assert!(
+            err.to_string().contains("handling_mode") || err.to_string().contains("invalid"),
+            "expected serde error mentioning handling_mode, got: {err}"
+        );
     }
 }

--- a/meerkat-rest/src/lib.rs
+++ b/meerkat-rest/src/lib.rs
@@ -2043,32 +2043,28 @@ async fn mob_member_respawn(
 }
 
 /// Canonical comms send request body.
+///
+/// `command` carries the typed [`meerkat_core::comms::CommsCommandRequest`]
+/// enum (serde-tagged on `kind`). Wire shape is flat:
+/// `{"session_id": "...", "kind": "...", ...}`.
 #[derive(Debug, Deserialize)]
 pub struct CommsSendRequest {
     pub session_id: String,
-    pub kind: String,
-    #[serde(default)]
-    pub to: Option<String>,
-    #[serde(default)]
-    pub body: Option<String>,
-    #[serde(default)]
-    pub intent: Option<String>,
-    #[serde(default)]
-    pub params: Option<Value>,
-    #[serde(default)]
-    pub in_reply_to: Option<String>,
-    #[serde(default)]
-    pub status: Option<String>,
-    #[serde(default)]
-    pub result: Option<Value>,
-    #[serde(default)]
-    pub source: Option<String>,
-    #[serde(default)]
-    pub stream: Option<String>,
-    #[serde(default)]
-    pub allow_self_session: Option<bool>,
-    #[serde(default)]
-    pub handling_mode: Option<String>,
+    #[serde(flatten)]
+    pub command: meerkat_core::comms::CommsCommandRequest,
+}
+
+impl CommsSendRequest {
+    /// Recipient peer name for error normalization, if the command targets one.
+    fn peer_name(&self) -> Option<&str> {
+        use meerkat_core::comms::CommsCommandRequest;
+        match &self.command {
+            CommsCommandRequest::PeerMessage { to, .. }
+            | CommsCommandRequest::PeerRequest { to, .. }
+            | CommsCommandRequest::PeerResponse { to, .. } => Some(to.as_str()),
+            CommsCommandRequest::Input { .. } => None,
+        }
+    }
 }
 
 /// Canonical comms peers request body.
@@ -2104,11 +2100,15 @@ async fn comms_send(
             ))
         })?;
 
-    let cmd = build_comms_command(&req, &session_id)?;
+    let peer_name = req.peer_name().map(str::to_string);
+    let cmd = req
+        .command
+        .into_command(&session_id)
+        .map_err(|err| ApiError::BadRequest(err.to_string()))?;
 
     match comms.send(cmd).await {
         Ok(receipt) => Ok(Json(comms_send_receipt_json(receipt))),
-        Err(e) => Err(normalize_rest_comms_send_error(req.to.as_deref(), &e)),
+        Err(e) => Err(normalize_rest_comms_send_error(peer_name.as_deref(), &e)),
     }
 }
 
@@ -2207,73 +2207,6 @@ fn normalize_rest_comms_send_error(
             }),
         },
     }
-}
-
-fn build_comms_command(
-    req: &CommsSendRequest,
-    session_id: &SessionId,
-) -> Result<meerkat_core::comms::CommsCommand, ApiError> {
-    let request = meerkat_core::comms::CommsCommandRequest {
-        kind: req.kind.clone(),
-        to: req.to.clone(),
-        body: req.body.clone(),
-        blocks: None,
-        intent: req.intent.clone(),
-        params: req.params.clone(),
-        in_reply_to: req.in_reply_to.clone(),
-        status: req.status.clone(),
-        result: req.result.clone(),
-        source: req.source.clone(),
-        stream: req.stream.clone(),
-        allow_self_session: req.allow_self_session,
-        handling_mode: req.handling_mode.clone(),
-    };
-
-    request.parse(session_id).map_err(|errors| {
-        let json_errors =
-            meerkat_core::comms::CommsCommandRequest::validation_errors_to_json(&errors);
-        let msg = if let Some(first) = json_errors.first() {
-            let field = first["field"].as_str().unwrap_or("command");
-            let issue = first["issue"].as_str().unwrap_or("invalid");
-            let got = first["got"].as_str();
-            match (field, issue) {
-                ("source", "invalid_value") => got.map_or_else(
-                    || "invalid source".to_string(),
-                    |got| format!("invalid source: {got}"),
-                ),
-                ("stream", "invalid_value") => got.map_or_else(
-                    || "invalid stream".to_string(),
-                    |got| format!("invalid stream: {got}"),
-                ),
-                ("status", "invalid_value") => got.map_or_else(
-                    || "invalid status".to_string(),
-                    |got| format!("invalid status: {got}"),
-                ),
-                ("kind", "unknown_kind") => got.map_or_else(
-                    || "unknown kind".to_string(),
-                    |got| format!("unknown kind: {got}"),
-                ),
-                ("body", "required_field") => "input requires 'body'".to_string(),
-                ("to", "required_field") => "to is required".to_string(),
-                ("intent", "required_field") => "peer_request requires 'intent'".to_string(),
-                ("in_reply_to", "required_field") => {
-                    "peer_response requires 'in_reply_to'".to_string()
-                }
-                ("in_reply_to", "invalid_uuid") => got.map_or_else(
-                    || "invalid UUID".to_string(),
-                    |got| format!("invalid UUID: {got}"),
-                ),
-                ("to", "invalid_value") => got.map_or_else(
-                    || "invalid peer name".to_string(),
-                    |got| format!("invalid to: {got}"),
-                ),
-                _ => issue.to_string(),
-            }
-        } else {
-            "invalid command".to_string()
-        };
-        ApiError::BadRequest(msg)
-    })
 }
 
 /// GET /comms/peers — list peers visible to a session's comms runtime.
@@ -5717,78 +5650,39 @@ mod tests {
     }
 
     #[test]
-    fn test_build_comms_command_peer_request_invalid_stream() {
-        let req = CommsSendRequest {
-            session_id: "sid_123".to_string(),
-            kind: "peer_request".to_string(),
-            to: Some("alice".to_string()),
-            body: None,
-            intent: Some("ask".to_string()),
-            params: None,
-            in_reply_to: None,
-            status: None,
-            result: None,
-            source: None,
-            stream: Some("invalid".to_string()),
-            allow_self_session: None,
-            handling_mode: None,
-        };
-        let session_id = meerkat_core::SessionId::new();
-        let err = build_comms_command(&req, &session_id).expect_err("invalid stream should fail");
-        let ApiError::BadRequest(msg) = err else {
-            unreachable!("expected bad request");
-        };
-        assert_eq!(msg, "invalid stream: invalid");
+    fn test_comms_send_request_peer_request_invalid_stream_rejected_at_serde() {
+        let json = r#"{"session_id":"sid_123","kind":"peer_request","to":"alice","intent":"ask","stream":"invalid"}"#;
+        let err = serde_json::from_str::<CommsSendRequest>(json)
+            .expect_err("invalid stream must fail deserialization");
+        assert!(
+            err.to_string().contains("stream") || err.to_string().contains("invalid"),
+            "expected serde error mentioning stream, got: {err}"
+        );
     }
 
     #[test]
-    fn test_build_comms_command_peer_response_invalid_status() {
-        let req = CommsSendRequest {
-            session_id: "sid_123".to_string(),
-            kind: "peer_response".to_string(),
-            to: Some("alice".to_string()),
-            body: None,
-            intent: None,
-            params: None,
-            in_reply_to: Some(uuid::Uuid::new_v4().to_string()),
-            status: Some("almost-done".to_string()),
-            result: None,
-            source: None,
-            stream: None,
-            allow_self_session: None,
-            handling_mode: None,
-        };
-        let session_id = meerkat_core::SessionId::new();
-        let err = build_comms_command(&req, &session_id).expect_err("invalid status should fail");
-        let ApiError::BadRequest(msg) = err else {
-            unreachable!("expected bad request");
-        };
-        assert_eq!(msg, "invalid status: almost-done");
+    fn test_comms_send_request_peer_response_invalid_status_rejected_at_serde() {
+        let json = format!(
+            r#"{{"session_id":"sid_123","kind":"peer_response","to":"alice","in_reply_to":"{}","status":"almost-done"}}"#,
+            uuid::Uuid::new_v4()
+        );
+        let err = serde_json::from_str::<CommsSendRequest>(&json)
+            .expect_err("invalid status must fail deserialization");
+        assert!(
+            err.to_string().contains("status") || err.to_string().contains("almost-done"),
+            "expected serde error mentioning status, got: {err}"
+        );
     }
 
     #[test]
-    fn test_build_comms_command_invalid_source() {
-        let req = CommsSendRequest {
-            session_id: "sid_123".to_string(),
-            kind: "input".to_string(),
-            to: None,
-            body: Some("hi".to_string()),
-            intent: None,
-            params: None,
-            in_reply_to: None,
-            status: None,
-            result: None,
-            source: Some("webhookd".to_string()),
-            stream: None,
-            allow_self_session: None,
-            handling_mode: None,
-        };
-        let session_id = meerkat_core::SessionId::new();
-        let err = build_comms_command(&req, &session_id).expect_err("invalid source should fail");
-        let ApiError::BadRequest(msg) = err else {
-            unreachable!("expected bad request");
-        };
-        assert_eq!(msg, "invalid source: webhookd");
+    fn test_comms_send_request_invalid_source_rejected_at_serde() {
+        let json = r#"{"session_id":"sid_123","kind":"input","body":"hi","source":"webhookd"}"#;
+        let err = serde_json::from_str::<CommsSendRequest>(json)
+            .expect_err("invalid source must fail deserialization");
+        assert!(
+            err.to_string().contains("source") || err.to_string().contains("webhookd"),
+            "expected serde error mentioning source, got: {err}"
+        );
     }
 
     #[cfg(not(feature = "comms"))]

--- a/meerkat-rpc/src/handlers/comms.rs
+++ b/meerkat-rpc/src/handlers/comms.rs
@@ -53,7 +53,7 @@ fn normalize_send_error(
     }
 }
 
-fn send_receipt_json(receipt: meerkat_core::comms::SendReceipt) -> serde_json::Value {
+pub(crate) fn send_receipt_json(receipt: meerkat_core::comms::SendReceipt) -> serde_json::Value {
     match receipt {
         meerkat_core::comms::SendReceipt::InputAccepted {
             interaction_id,
@@ -95,32 +95,27 @@ fn send_receipt_json(receipt: meerkat_core::comms::SendReceipt) -> serde_json::V
 }
 
 /// Parameters for `comms/send`.
-#[derive(Deserialize)]
+///
+/// `command` carries the typed [`CommsCommandRequest`] enum (serde-tagged on
+/// `kind`). The wire shape is flat: `{"session_id": "...", "kind": "...", ...}`.
+#[derive(Debug, Deserialize)]
 pub struct CommsSendParams {
     pub session_id: String,
-    pub kind: String,
-    #[serde(default)]
-    pub to: Option<String>,
-    #[serde(default)]
-    pub body: Option<String>,
-    #[serde(default)]
-    pub intent: Option<String>,
-    #[serde(default)]
-    pub params: Option<serde_json::Value>,
-    #[serde(default)]
-    pub in_reply_to: Option<String>,
-    #[serde(default)]
-    pub status: Option<String>,
-    #[serde(default)]
-    pub result: Option<serde_json::Value>,
-    #[serde(default)]
-    pub source: Option<String>,
-    #[serde(default)]
-    pub stream: Option<String>,
-    #[serde(default)]
-    pub allow_self_session: Option<bool>,
-    #[serde(default)]
-    pub handling_mode: Option<String>,
+    #[serde(flatten)]
+    pub command: meerkat_core::comms::CommsCommandRequest,
+}
+
+impl CommsSendParams {
+    /// Recipient peer name for error normalization, if the command targets one.
+    pub fn peer_name(&self) -> Option<&str> {
+        use meerkat_core::comms::CommsCommandRequest;
+        match &self.command {
+            CommsCommandRequest::PeerMessage { to, .. }
+            | CommsCommandRequest::PeerRequest { to, .. }
+            | CommsCommandRequest::PeerResponse { to, .. } => Some(to.as_str()),
+            CommsCommandRequest::Input { .. } => None,
+        }
+    }
 }
 
 /// Parameters for `comms/peers`.
@@ -156,21 +151,18 @@ pub async fn handle_send(
         }
     };
 
-    let cmd = match build_comms_command(&params, &session_id) {
+    let peer_name = params.peer_name().map(str::to_string);
+    let cmd = match params.command.into_command(&session_id) {
         Ok(cmd) => cmd,
-        Err(details) => {
-            let normalized = serde_json::json!({
-                "code": "invalid_command",
-                "message": "Command validation failed",
-                "details": meerkat_core::comms::CommsCommandRequest::validation_errors_to_json(
-                    &details
-                ),
-            });
+        Err(err) => {
             return RpcResponse::error_with_data(
                 id,
                 error::INVALID_PARAMS,
                 "Command validation failed",
-                normalized,
+                serde_json::json!({
+                    "code": "invalid_command",
+                    "message": err.to_string(),
+                }),
             );
         }
     };
@@ -178,7 +170,7 @@ pub async fn handle_send(
     match comms.send(cmd).await {
         Ok(receipt) => RpcResponse::success(id, send_receipt_json(receipt)),
         Err(e) => {
-            let normalized = normalize_send_error(params.to.as_deref(), &e);
+            let normalized = normalize_send_error(peer_name.as_deref(), &e);
             let message = normalized
                 .get("message")
                 .and_then(serde_json::Value::as_str)
@@ -237,185 +229,73 @@ pub async fn handle_peers(
     RpcResponse::success(id, serde_json::json!({ "peers": entries }))
 }
 
-pub(crate) fn build_comms_command(
-    params: &CommsSendParams,
-    session_id: &meerkat_core::SessionId,
-) -> Result<meerkat_core::comms::CommsCommand, Vec<meerkat_core::comms::CommsCommandValidationError>>
-{
-    let request = meerkat_core::comms::CommsCommandRequest {
-        kind: params.kind.clone(),
-        to: params.to.clone(),
-        body: params.body.clone(),
-        blocks: None,
-        intent: params.intent.clone(),
-        params: params.params.clone(),
-        in_reply_to: params.in_reply_to.clone(),
-        status: params.status.clone(),
-        result: params.result.clone(),
-        source: params.source.clone(),
-        stream: params.stream.clone(),
-        allow_self_session: params.allow_self_session,
-        handling_mode: params.handling_mode.clone(),
-    };
-    request.parse(session_id)
-}
-
 #[cfg(test)]
 #[allow(clippy::unwrap_used, clippy::expect_used)]
 mod tests {
     use super::*;
+    use meerkat_core::comms::CommsCommandRequest;
 
     #[test]
-    fn test_comms_send_params_deserialization() {
+    fn deserialize_input_command() {
         let json = r#"{"session_id":"sid_1","kind":"input","body":"hello"}"#;
         let params: CommsSendParams = serde_json::from_str(json).unwrap();
-        assert_eq!(params.kind, "input");
-        assert_eq!(params.body.as_deref(), Some("hello"));
+        assert_eq!(params.session_id, "sid_1");
+        assert!(matches!(params.command, CommsCommandRequest::Input { .. }));
     }
 
     #[test]
-    fn test_comms_send_params_peer_message() {
+    fn deserialize_peer_message_command() {
         let json = r#"{"session_id":"sid_1","kind":"peer_message","to":"alice","body":"hi"}"#;
         let params: CommsSendParams = serde_json::from_str(json).unwrap();
-        assert_eq!(params.kind, "peer_message");
-        assert_eq!(params.to.as_deref(), Some("alice"));
+        assert_eq!(params.peer_name(), Some("alice"));
+        assert!(matches!(
+            params.command,
+            CommsCommandRequest::PeerMessage { .. }
+        ));
     }
 
     #[test]
-    fn test_build_comms_command_unknown_kind() {
-        let params = CommsSendParams {
-            session_id: "sid_1".to_string(),
-            kind: "foobar".to_string(),
-            to: None,
-            body: None,
-            intent: None,
-            params: None,
-            in_reply_to: None,
-            status: None,
-            result: None,
-            source: None,
-            stream: None,
-            allow_self_session: None,
-            handling_mode: None,
-        };
-        let session_id = meerkat_core::SessionId::new();
-        let result = build_comms_command(&params, &session_id);
-        assert!(result.is_err());
-        let errors = meerkat_core::comms::CommsCommandRequest::validation_errors_to_json(
-            &result.unwrap_err(),
+    fn deserialize_unknown_kind_fails_at_serde_boundary() {
+        let json = r#"{"session_id":"sid_1","kind":"foobar"}"#;
+        let err = serde_json::from_str::<CommsSendParams>(json).unwrap_err();
+        assert!(
+            err.to_string().contains("foobar") || err.to_string().contains("variant"),
+            "expected unknown-variant serde error, got: {err}"
         );
-        assert_eq!(errors[0]["issue"], "unknown_kind");
     }
 
     #[test]
-    fn test_build_comms_command_input_missing_body() {
-        let params = CommsSendParams {
-            session_id: "sid_1".to_string(),
-            kind: "input".to_string(),
-            to: None,
-            body: None,
-            intent: None,
-            params: None,
-            in_reply_to: None,
-            status: None,
-            result: None,
-            source: None,
-            stream: None,
-            allow_self_session: None,
-            handling_mode: None,
-        };
-        let session_id = meerkat_core::SessionId::new();
-        let result = build_comms_command(&params, &session_id);
-        assert!(result.is_err());
-        let errors = meerkat_core::comms::CommsCommandRequest::validation_errors_to_json(
-            &result.unwrap_err(),
+    fn deserialize_input_missing_body_fails_at_serde_boundary() {
+        let json = r#"{"session_id":"sid_1","kind":"input"}"#;
+        let err = serde_json::from_str::<CommsSendParams>(json).unwrap_err();
+        assert!(
+            err.to_string().contains("body"),
+            "expected missing-body serde error, got: {err}"
         );
-        assert_eq!(errors[0]["field"], "body");
     }
 
     #[test]
-    fn test_build_comms_command_peer_request_invalid_stream() {
-        let params = CommsSendParams {
-            session_id: "sid_1".to_string(),
-            kind: "peer_request".to_string(),
-            to: Some("alice".to_string()),
-            body: None,
-            intent: Some("ask".to_string()),
-            params: None,
-            in_reply_to: None,
-            status: None,
-            result: None,
-            source: None,
-            stream: Some("invalid".to_string()),
-            allow_self_session: None,
-            handling_mode: None,
-        };
-        let session_id = meerkat_core::SessionId::new();
-        let result = build_comms_command(&params, &session_id);
-        assert!(result.is_err());
-        let errors = meerkat_core::comms::CommsCommandRequest::validation_errors_to_json(
-            &result.unwrap_err(),
+    fn deserialize_input_invalid_source_fails_at_serde_boundary() {
+        let json = r#"{"session_id":"sid_1","kind":"input","body":"hi","source":"webhookd"}"#;
+        let err = serde_json::from_str::<CommsSendParams>(json).unwrap_err();
+        assert!(
+            err.to_string().contains("source") || err.to_string().contains("webhookd"),
+            "expected invalid-source serde error, got: {err}"
         );
-        assert_eq!(errors[0]["field"], "stream");
-        assert_eq!(errors[0]["issue"], "invalid_value");
     }
 
     #[test]
-    fn test_build_comms_command_peer_response_invalid_status() {
-        let params = CommsSendParams {
-            session_id: "sid_1".to_string(),
-            kind: "peer_response".to_string(),
-            to: Some("alice".to_string()),
-            body: None,
-            intent: None,
-            params: None,
-            in_reply_to: Some(uuid::Uuid::new_v4().to_string()),
-            status: Some("almost-done".to_string()),
-            result: None,
-            source: None,
-            stream: None,
-            allow_self_session: None,
-            handling_mode: None,
-        };
-        let session_id = meerkat_core::SessionId::new();
-        let result = build_comms_command(&params, &session_id);
-        assert!(result.is_err());
-        let errors = meerkat_core::comms::CommsCommandRequest::validation_errors_to_json(
-            &result.unwrap_err(),
+    fn deserialize_peer_response_invalid_status_fails_at_serde_boundary() {
+        let json = r#"{"session_id":"sid_1","kind":"peer_response","to":"alice","in_reply_to":"00000000-0000-0000-0000-000000000000","status":"almost-done"}"#;
+        let err = serde_json::from_str::<CommsSendParams>(json).unwrap_err();
+        assert!(
+            err.to_string().contains("status") || err.to_string().contains("almost-done"),
+            "expected invalid-status serde error, got: {err}"
         );
-        assert_eq!(errors[0]["field"], "status");
-        assert_eq!(errors[0]["issue"], "invalid_value");
     }
 
     #[test]
-    fn test_build_comms_command_input_invalid_source() {
-        let params = CommsSendParams {
-            session_id: "sid_1".to_string(),
-            kind: "input".to_string(),
-            to: None,
-            body: Some("hi".to_string()),
-            intent: None,
-            params: None,
-            in_reply_to: None,
-            status: None,
-            result: None,
-            source: Some("webhookd".to_string()),
-            stream: None,
-            allow_self_session: None,
-            handling_mode: None,
-        };
-        let session_id = meerkat_core::SessionId::new();
-        let result = build_comms_command(&params, &session_id);
-        assert!(result.is_err());
-        let errors = meerkat_core::comms::CommsCommandRequest::validation_errors_to_json(
-            &result.unwrap_err(),
-        );
-        assert_eq!(errors[0]["field"], "source");
-        assert_eq!(errors[0]["issue"], "invalid_value");
-    }
-
-    #[test]
-    fn test_handler_send_receipt_json_peer_request_uses_envelope_id_as_request_id() {
+    fn handler_send_receipt_json_peer_request_uses_envelope_id_as_request_id() {
         let envelope_id = uuid::Uuid::new_v4();
         let interaction_id = meerkat_core::interaction::InteractionId(uuid::Uuid::new_v4());
 

--- a/meerkat-rpc/src/router.rs
+++ b/meerkat-rpc/src/router.rs
@@ -1640,19 +1640,18 @@ impl MethodRouter {
                 format!("Session not found or comms not enabled: {session_id}"),
             );
         };
-        let cmd = match handlers::comms::build_comms_command(&params, &session_id) {
+        let peer_name = params.peer_name().map(str::to_string);
+        let cmd = match params.command.into_command(&session_id) {
             Ok(cmd) => cmd,
-            Err(details) => {
-                let normalized = serde_json::json!({
-                    "code": "invalid_command",
-                    "message": "Command validation failed",
-                    "details": meerkat_core::comms::CommsCommandRequest::validation_errors_to_json(&details),
-                });
+            Err(err) => {
                 return RpcResponse::error_with_data(
                     id,
                     error::INVALID_PARAMS,
                     "Command validation failed",
-                    normalized,
+                    json!({
+                        "code": "invalid_command",
+                        "message": err.to_string(),
+                    }),
                 );
             }
         };
@@ -1666,7 +1665,7 @@ impl MethodRouter {
                         "message": format!("peer '{peer}' is not found or not trusted"),
                     }),
                     meerkat_core::comms::SendError::PeerOffline => {
-                        let peer = params.to.as_deref().unwrap_or("<unknown>");
+                        let peer = peer_name.as_deref().unwrap_or("<unknown>");
                         json!({
                             "code": "peer_unreachable",
                             "peer": peer,
@@ -1675,9 +1674,9 @@ impl MethodRouter {
                         })
                     }
                     meerkat_core::comms::SendError::Internal(details)
-                        if params.to.is_some() && is_transport_internal(details) =>
+                        if peer_name.is_some() && is_transport_internal(details) =>
                     {
-                        let peer = params.to.as_deref().unwrap_or("<unknown>");
+                        let peer = peer_name.as_deref().unwrap_or("<unknown>");
                         json!({
                             "code": "peer_unreachable",
                             "peer": peer,

--- a/sdks/python/meerkat/client.py
+++ b/sdks/python/meerkat/client.py
@@ -2068,9 +2068,60 @@ class MeerkatClient:
     async def _peers(self, session_id: str) -> dict[str, Any]:
         return await self.peers(session_id)
 
-    async def send(self, session_id: str, **kwargs: Any) -> dict[str, Any]:
-        params: dict[str, Any] = {"session_id": session_id, **kwargs}
-        return await self._request("comms/send", params)
+    # Typed literal aliases mirror the Rust `CommsCommandRequest` enum
+    # (`meerkat-core/src/comms.rs`). Invalid discriminator values are rejected
+    # at the server's typed-serde boundary — these aliases document the
+    # closed-world shape for callers.
+    _CommsKind = Literal["input", "peer_message", "peer_request", "peer_response"]
+    _HandlingMode = Literal["queue", "steer"]
+    _InputSource = Literal["tcp", "uds", "stdin", "webhook", "rpc"]
+    _InputStreamMode = Literal["none", "reserve_interaction"]
+    _ResponseStatus = Literal["accepted", "completed", "failed"]
+
+    async def send(
+        self,
+        session_id: str,
+        *,
+        kind: "MeerkatClient._CommsKind",
+        to: str | None = None,
+        body: str | None = None,
+        intent: str | None = None,
+        params: dict[str, Any] | None = None,
+        in_reply_to: str | None = None,
+        status: "MeerkatClient._ResponseStatus | None" = None,
+        result: Any = None,
+        source: "MeerkatClient._InputSource | None" = None,
+        stream: "MeerkatClient._InputStreamMode | None" = None,
+        allow_self_session: bool | None = None,
+        handling_mode: "MeerkatClient._HandlingMode | None" = None,
+    ) -> dict[str, Any]:
+        """Send a typed comms command.
+
+        Mirrors the Rust `CommsCommandRequest` variants:
+        - ``kind="input"`` — inject input into the local session.
+        - ``kind="peer_message"`` — fire-and-forget peer message.
+        - ``kind="peer_request"`` — request/response with correlated reply.
+        - ``kind="peer_response"`` — reply to a prior peer request.
+
+        Invalid discriminator values (``source``, ``stream``, ``handling_mode``,
+        ``status``) are rejected at the server's typed-serde boundary.
+        """
+        fields: dict[str, Any] = {
+            "to": to,
+            "body": body,
+            "intent": intent,
+            "params": params,
+            "in_reply_to": in_reply_to,
+            "status": status,
+            "result": result,
+            "source": source,
+            "stream": stream,
+            "allow_self_session": allow_self_session,
+            "handling_mode": handling_mode,
+        }
+        payload: dict[str, Any] = {"session_id": session_id, "kind": kind}
+        payload.update({k: v for k, v in fields.items() if v is not None})
+        return await self._request("comms/send", payload)
 
     async def peers(self, session_id: str) -> dict[str, Any]:
         return await self._request("comms/peers", {"session_id": session_id})

--- a/sdks/python/meerkat/generated/types.py
+++ b/sdks/python/meerkat/generated/types.py
@@ -761,5 +761,18 @@ WireToolResultContent = str | list[dict[str, Any]]
 # Model recommendation tier.
 WireModelTier = str
 
+# Typed wire request for `comms/send`.
+#
+# Variants are serde-tagged on `kind` and validated structurally at the
+# deserialization boundary. Required fields per kind are enforced by the
+# type system; invalid discriminators (`source`, `stream`, `handling_mode`,
+# `status`) become serde deserialization errors rather than runtime
+# string-match failures.
+#
+# Cross-field invariants that cannot be expressed structurally (e.g.
+# `handling_mode` is forbidden on `Accepted` peer responses) are checked
+# in [`CommsCommandRequest::into_command`].
+CommsCommandRequest = dict[str, Any]
+
 # Response payload for `input/state`.
 InputStateResult = Optional[WireInputState]

--- a/sdks/typescript/src/client.ts
+++ b/sdks/typescript/src/client.ts
@@ -78,6 +78,7 @@ import type {
   AttributedMobEvent,
   BlobPayload,
   Capability,
+  CommsCommand,
   CommsSendReceipt,
   ConfigEnvelope,
   ContentInput,
@@ -1794,10 +1795,7 @@ export class MeerkatClient {
   }
 
   /** @internal */
-  async _send(
-    sessionId: string,
-    command: Record<string, unknown>,
-  ): Promise<CommsSendReceipt> {
+  async _send(sessionId: string, command: CommsCommand): Promise<CommsSendReceipt> {
     return this.send(sessionId, command);
   }
 
@@ -1808,10 +1806,12 @@ export class MeerkatClient {
     return this.peers(sessionId);
   }
 
-  async send(
-    sessionId: string,
-    command: Record<string, unknown>,
-  ): Promise<CommsSendReceipt> {
+  /**
+   * Send a typed comms command. Invalid discriminators (`source`, `stream`,
+   * `handling_mode`, `status`) are rejected at the server's typed-serde
+   * boundary.
+   */
+  async send(sessionId: string, command: CommsCommand): Promise<CommsSendReceipt> {
     const result = await this.request("comms/send", { session_id: sessionId, ...command });
     return MeerkatClient.parseCommsSendReceipt(result);
   }

--- a/sdks/typescript/src/generated/types.ts
+++ b/sdks/typescript/src/generated/types.ts
@@ -262,6 +262,8 @@ export type WireToolResultContent = string | Record<string, unknown>[];
 
 export type WireModelTier = string;
 
+export type CommsCommandRequest = Record<string, unknown>;
+
 export interface WireRenderMetadata {
   class: "user_prompt" | "peer_message" | "peer_request" | "peer_response" | "external_event" | "flow_step" | "continuation" | "system_notice" | "tool_scope_notice" | "ops_progress";
   salience?: "background" | "normal" | "important" | "urgent";

--- a/sdks/typescript/src/session.ts
+++ b/sdks/typescript/src/session.ts
@@ -21,6 +21,7 @@
 
 import type {
   AgentEventEnvelope,
+  CommsCommand,
   CommsSendReceipt,
   ContentBlock,
   RunResult,
@@ -127,9 +128,8 @@ export class Session {
     return this.turn(prompt, { skillRefs: [skillRef] });
   }
 
-  async send(command: Record<string, unknown>): Promise<CommsSendReceipt> {
-    const { session_id: _ignored, ...rest } = command;
-    return this._client._send(this._id, rest);
+  async send(command: CommsCommand): Promise<CommsSendReceipt> {
+    return this._client._send(this._id, command);
   }
 
   async peers(): Promise<Array<Record<string, unknown>>> {

--- a/sdks/typescript/src/types.ts
+++ b/sdks/typescript/src/types.ts
@@ -372,6 +372,61 @@ export interface CommsSendReceipt extends Record<string, unknown> {
   readonly inputId?: string;
 }
 
+// ---------------------------------------------------------------------------
+// comms/send typed command surface.
+//
+// Mirrors the Rust `CommsCommandRequest` enum (`meerkat-core/src/comms.rs`).
+// Invalid discriminator values are rejected at the server's typed-serde
+// boundary — these aliases document the closed-world shape for callers.
+// ---------------------------------------------------------------------------
+
+export type CommsHandlingMode = "queue" | "steer";
+export type CommsInputSource = "tcp" | "uds" | "stdin" | "webhook" | "rpc";
+export type CommsInputStreamMode = "none" | "reserve_interaction";
+export type CommsResponseStatus = "accepted" | "completed" | "failed";
+
+export interface CommsInputCommand {
+  kind: "input";
+  body: string;
+  source?: CommsInputSource;
+  stream?: CommsInputStreamMode;
+  handling_mode?: CommsHandlingMode;
+  allow_self_session?: boolean;
+}
+
+export interface CommsPeerMessageCommand {
+  kind: "peer_message";
+  to: string;
+  body?: string;
+  handling_mode?: CommsHandlingMode;
+}
+
+export interface CommsPeerRequestCommand {
+  kind: "peer_request";
+  to: string;
+  intent: string;
+  params?: Record<string, unknown>;
+  body?: string;
+  handling_mode?: CommsHandlingMode;
+  stream?: CommsInputStreamMode;
+}
+
+export interface CommsPeerResponseCommand {
+  kind: "peer_response";
+  to: string;
+  in_reply_to: string;
+  status: CommsResponseStatus;
+  result?: unknown;
+  handling_mode?: CommsHandlingMode;
+}
+
+/** Typed comms/send command — serde-tagged on `kind`. */
+export type CommsCommand =
+  | CommsInputCommand
+  | CommsPeerMessageCommand
+  | CommsPeerRequestCommand
+  | CommsPeerResponseCommand;
+
 export type ModelTier = "recommended" | "supported";
 
 export interface ModelProfile {

--- a/tools/sdk-codegen/generate.py
+++ b/tools/sdk-codegen/generate.py
@@ -488,6 +488,11 @@ def generate_python_types(schemas: dict, output_dir: Path, *, has_comms: bool = 
     append_python_alias("WireStopReason", wire_schema, "Canonical stop reason for transcript messages.")
     append_python_alias("WireToolResultContent", wire_schema, "Wire-safe tool result content.")
     append_python_alias("WireModelTier", schemas.get("models", {}), "Wire-level model recommendation tier.")
+    append_python_alias(
+        "CommsCommandRequest",
+        wire_schema,
+        "Typed comms/send command (serde-tagged on `kind`).",
+    )
     types_content += "\n# Response payload for `input/state`.\nInputStateResult = Optional[WireInputState]\n"
 
     (output_dir / "types.py").write_text(types_content)
@@ -705,6 +710,7 @@ def generate_typescript_types(schemas: dict, output_dir: Path, *, has_comms: boo
     append_typescript_alias("WireStopReason", wire_schema)
     append_typescript_alias("WireToolResultContent", wire_schema)
     append_typescript_alias("WireModelTier", schemas.get("models", {}))
+    append_typescript_alias("CommsCommandRequest", wire_schema)
     append_typescript_interface("WireRenderMetadata", wire_schema)
     append_typescript_interface("WireTrustedPeerSpec", wire_schema)
     append_typescript_interface("MobWireResult", wire_schema)


### PR DESCRIPTION
## Summary

Replaces the stringly-typed `comms/send` wire contract with a serde-tagged enum. Invalid discriminators (`kind`, `source`, `stream`, `handling_mode`, `status`) become serde deserialization errors at the wire boundary instead of runtime string-match failures.

- `meerkat-core/src/comms.rs`: `CommsCommandRequest` is now an enum tagged on `kind` with per-variant required fields. `parse()` + `CommsCommandValidationError` + `validation_errors_to_json` deleted; replaced with `into_command()` returning a narrow `CommsCommandError` for the sole cross-field invariant (`handling_mode` forbidden on `accepted` peer responses).
- `meerkat-core/{types,interaction}.rs`: `JsonSchema` derives added to `HandlingMode`, `ResponseStatus`, `InputSource`, `InputStreamMode`, `PeerName` so the wire shape emits through schemars.
- `meerkat-contracts/src/wire/comms.rs`: new module re-exporting the typed enum; registered in the schema emit for SDK codegen.
- `meerkat-rpc` + `meerkat-rest` + `meerkat-mcp-server` + `meerkat-cli`: surface params flatten the typed enum; string-translation helpers + `build_comms_command` fn deleted.
- `meerkat-comms/src/mcp/tools.rs`: the legacy `send` unified tool is dropped (no backwards-compat per dogma); `SendMessageInput` / `SendRequestInput` / `SendResponseInput` use `HandlingMode` + `ResponseStatus` directly.
- SDKs: TS adds typed `CommsCommand` union in `types.ts` used by `client.ts` / `session.ts`. Python adds typed `Literal` keyword signature on `MeerkatClient.send()`.
- `make regen-schemas` run; schema artifacts + generated SDK types committed. `make verify-version-parity` passes.

Resolves violation #6 (**Stringly typed comms send surfaces**) from `/Users/luka/.codex/dogma-violations.md`.

## Test plan

- [x] `./scripts/repo-cargo fmt --all -- --check`
- [x] `./scripts/repo-cargo clippy --workspace --all-targets -- -D warnings`
- [x] `./scripts/repo-cargo unit` (3765 passed)
- [x] `./scripts/repo-cargo nextest run --workspace --tests -E "not binary(e2e_fast_lane) and not binary(e2e_system_lane) and not binary(e2e_live_lane) and not binary(e2e_smoke_lane) and not binary(e2e_models_lane)"` (4724 passed)
- [x] `./scripts/repo-cargo e2e-fast` (5 passed)
- [x] `make regen-schemas`
- [x] `make verify-version-parity`

🤖 Generated with [Claude Code](https://claude.com/claude-code)