### PR TITLE
fix(runtime): canonical session-identity claim owner (dogma #2)

### DIFF
--- a/meerkat-comms/src/lib.rs
+++ b/meerkat-comms/src/lib.rs
@@ -55,8 +55,6 @@ pub use runtime::comms_config::CoreCommsConfig;
 #[cfg(not(target_arch = "wasm32"))]
 pub use runtime::comms_config::ResolvedCommsConfig;
 pub use runtime::comms_runtime::{CommsRuntime, CommsRuntimeError, CommsToolMaterial};
-#[cfg(not(target_arch = "wasm32"))]
-pub use runtime::comms_runtime::{clear_all_session_claims, release_session_claim};
 
 pub use agent::CommsAgent;
 pub use agent::dispatcher::{

--- a/meerkat-comms/src/runtime/comms_runtime.rs
+++ b/meerkat-comms/src/runtime/comms_runtime.rs
@@ -23,6 +23,8 @@ use meerkat_core::comms::{
     TrustedPeerSpec,
 };
 use meerkat_core::config::PlainEventSource;
+#[cfg(not(target_arch = "wasm32"))]
+use meerkat_core::handles::{SessionClaim, SessionClaimError, SessionClaimHandle};
 use meerkat_core::hydrate_content_blocks;
 use meerkat_core::time_compat::Instant;
 use meerkat_core::{BlobStore, MissingBlobBehavior};
@@ -33,8 +35,6 @@ use std::collections::{HashMap, HashSet};
 use std::path::Path;
 use std::pin::Pin;
 use std::sync::Arc;
-#[cfg(not(target_arch = "wasm32"))]
-use std::sync::LazyLock;
 use std::sync::atomic::{AtomicBool, Ordering};
 use thiserror::Error;
 #[cfg(not(target_arch = "wasm32"))]
@@ -106,58 +106,6 @@ impl StreamRegistryEntry {
 }
 
 type InteractionStreamRegistry = Arc<Mutex<HashMap<Uuid, StreamRegistryEntry>>>;
-
-#[cfg(not(target_arch = "wasm32"))]
-static SESSION_IDENTITY_CLAIMS: LazyLock<Mutex<HashSet<String>>> =
-    LazyLock::new(|| Mutex::new(HashSet::new()));
-
-#[cfg(not(target_arch = "wasm32"))]
-struct SessionIdentityClaim {
-    session_id: String,
-}
-
-#[cfg(not(target_arch = "wasm32"))]
-impl SessionIdentityClaim {
-    fn acquire(session_id: &meerkat_core::SessionId) -> Result<Self, CommsRuntimeError> {
-        let session_id = session_id.to_string();
-        let mut claims = SESSION_IDENTITY_CLAIMS.lock();
-        if !claims.insert(session_id.clone()) {
-            return Err(CommsRuntimeError::SessionIdentityInUse(session_id));
-        }
-        Ok(Self { session_id })
-    }
-}
-
-#[cfg(not(target_arch = "wasm32"))]
-impl Drop for SessionIdentityClaim {
-    fn drop(&mut self) {
-        SESSION_IDENTITY_CLAIMS.lock().remove(&self.session_id);
-    }
-}
-
-/// Forcibly release a session identity claim that was not cleaned up by Drop.
-///
-/// This is needed when the task holding a [`SessionIdentityClaim`] is not
-/// joined on shutdown — the Drop never fires and the claim persists in the
-/// process-global set, preventing the same session_id from being reused
-/// after an in-process restart.
-///
-/// Returns `true` if the claim was present and removed.
-#[cfg(not(target_arch = "wasm32"))]
-pub fn release_session_claim(session_id: &meerkat_core::SessionId) -> bool {
-    SESSION_IDENTITY_CLAIMS
-        .lock()
-        .remove(&session_id.to_string())
-}
-
-/// Remove all session identity claims.
-///
-/// Intended for in-process restart / test teardown where the previous
-/// runtime's tasks may not have been joined and their claims linger.
-#[cfg(not(target_arch = "wasm32"))]
-pub fn clear_all_session_claims() {
-    SESSION_IDENTITY_CLAIMS.lock().clear();
-}
 
 struct InteractionStream {
     id: Uuid,
@@ -998,6 +946,17 @@ pub enum CommsRuntimeError {
     UnsafeBinding(String),
 }
 
+#[cfg(not(target_arch = "wasm32"))]
+impl From<SessionClaimError> for CommsRuntimeError {
+    fn from(err: SessionClaimError) -> Self {
+        match err {
+            SessionClaimError::SessionIdentityInUse(sid) => {
+                Self::SessionIdentityInUse(sid.to_string())
+            }
+        }
+    }
+}
+
 /// Material needed by the facade's comms tool composition helper.
 ///
 /// Bundles the concrete router/trust/key access so the facade doesn't
@@ -1053,7 +1012,7 @@ pub struct CommsRuntime {
     #[cfg(not(target_arch = "wasm32"))]
     listeners_started: bool,
     #[cfg(not(target_arch = "wasm32"))]
-    _session_identity_claim: Option<SessionIdentityClaim>,
+    _session_identity_claim: Option<SessionClaim>,
     keypair: Arc<Keypair>,
     bridge_bootstrap_token: String,
     require_peer_auth: bool,
@@ -1320,8 +1279,11 @@ impl CommsRuntime {
         identity_root: std::path::PathBuf,
         session_id: &meerkat_core::SessionId,
         silent_intents: Arc<HashSet<String>>,
+        session_claim_handle: Arc<dyn SessionClaimHandle>,
     ) -> Result<Self, CommsRuntimeError> {
-        let claim = SessionIdentityClaim::acquire(session_id)?;
+        let claim = session_claim_handle
+            .try_acquire(session_id)
+            .map_err(CommsRuntimeError::from)?;
         let identity_dir = identity_root.join(session_id.to_string());
         let keypair = Keypair::load_or_generate(&identity_dir)
             .await
@@ -3900,16 +3862,25 @@ mod tests {
         );
     }
 
+    /// Build a fresh per-test session-claim handle. Each test gets its own
+    /// registry instance so suite-scoped identity claims do not leak across
+    /// tests run in parallel.
+    fn test_claim_handle() -> Arc<dyn SessionClaimHandle> {
+        Arc::new(meerkat_core::handles::DefaultSessionClaimRegistry::new())
+    }
+
     #[tokio::test]
     async fn test_session_scoped_inproc_identity_preserves_peer_id_for_same_session() {
         let tmp = tempfile::tempdir().expect("tempdir");
         let session_id = SessionId::new();
+        let claim_handle = test_claim_handle();
         let runtime = CommsRuntime::inproc_only_session_scoped_with_silent_intents(
             "session-scoped-peer",
             None,
             tmp.path().join("session-identities"),
             &session_id,
             Arc::new(HashSet::new()),
+            Arc::clone(&claim_handle),
         )
         .await
         .expect("create first session-scoped runtime");
@@ -3922,6 +3893,7 @@ mod tests {
             tmp.path().join("session-identities"),
             &session_id,
             Arc::new(HashSet::new()),
+            claim_handle,
         )
         .await
         .expect("recreate session-scoped runtime");
@@ -3937,12 +3909,14 @@ mod tests {
     async fn test_session_scoped_inproc_identity_rejects_second_live_activation() {
         let tmp = tempfile::tempdir().expect("tempdir");
         let session_id = SessionId::new();
+        let claim_handle = test_claim_handle();
         let _runtime = CommsRuntime::inproc_only_session_scoped_with_silent_intents(
             "session-scoped-lock",
             None,
             tmp.path().join("session-identities"),
             &session_id,
             Arc::new(HashSet::new()),
+            Arc::clone(&claim_handle),
         )
         .await
         .expect("create first session-scoped runtime");
@@ -3953,6 +3927,7 @@ mod tests {
             tmp.path().join("session-identities"),
             &session_id,
             Arc::new(HashSet::new()),
+            claim_handle,
         )
         .await
         {
@@ -3970,12 +3945,14 @@ mod tests {
     async fn test_session_scoped_inproc_identity_does_not_restore_trust_from_disk() {
         let tmp = tempfile::tempdir().expect("tempdir");
         let session_id = SessionId::new();
+        let claim_handle = test_claim_handle();
         let sender = CommsRuntime::inproc_only_session_scoped_with_silent_intents(
             "session-scoped-trust",
             None,
             tmp.path().join("session-identities"),
             &session_id,
             Arc::new(HashSet::new()),
+            Arc::clone(&claim_handle),
         )
         .await
         .expect("create session-scoped runtime");
@@ -4004,6 +3981,7 @@ mod tests {
             tmp.path().join("session-identities"),
             &session_id,
             Arc::new(HashSet::new()),
+            claim_handle,
         )
         .await
         .expect("recreate session-scoped runtime");
@@ -4693,45 +4671,5 @@ mod tests {
             !removed,
             "remove should return false for peer that was never trusted"
         );
-    }
-
-    /// Regression: SESSION_IDENTITY_CLAIMS is process-global. If a task
-    /// holding a SessionIdentityClaim is not joined on shutdown, the claim
-    /// lingers and prevents re-acquiring the same session_id after an
-    /// in-process restart.
-    #[test]
-    fn test_release_session_claim_allows_reacquire() {
-        let sid = meerkat_core::SessionId::new();
-        // Acquire the claim
-        let claim = SessionIdentityClaim::acquire(&sid).unwrap();
-        // Simulate leaked claim (forget Drop)
-        std::mem::forget(claim);
-
-        // Without release, re-acquiring fails
-        assert!(
-            SessionIdentityClaim::acquire(&sid).is_err(),
-            "second acquire should fail while claim is leaked"
-        );
-
-        // Force-release the leaked claim
-        assert!(release_session_claim(&sid));
-
-        // Now re-acquiring succeeds
-        let claim2 = SessionIdentityClaim::acquire(&sid)
-            .expect("acquire should succeed after force-release");
-        drop(claim2);
-    }
-
-    #[test]
-    fn test_clear_all_session_claims_allows_reacquire() {
-        let sid = meerkat_core::SessionId::new();
-        let claim = SessionIdentityClaim::acquire(&sid).unwrap();
-        std::mem::forget(claim);
-
-        clear_all_session_claims();
-
-        let claim2 =
-            SessionIdentityClaim::acquire(&sid).expect("acquire should succeed after clear_all");
-        drop(claim2);
     }
 }

--- a/meerkat-comms/src/runtime/mod.rs
+++ b/meerkat-comms/src/runtime/mod.rs
@@ -12,5 +12,3 @@ pub use comms_config::CoreCommsConfig;
 #[cfg(not(target_arch = "wasm32"))]
 pub use comms_config::ResolvedCommsConfig;
 pub use comms_runtime::{CommsRuntime, CommsRuntimeError};
-#[cfg(not(target_arch = "wasm32"))]
-pub use comms_runtime::{clear_all_session_claims, release_session_claim};

--- a/meerkat-core/src/handles.rs
+++ b/meerkat-core/src/handles.rs
@@ -26,6 +26,7 @@ use crate::lifecycle::{InputId, RunId};
 use crate::peer_correlation::{
     InboundPeerRequestState, OutboundPeerRequestState, PeerCorrelationId,
 };
+use crate::types::SessionId;
 
 /// Error surfaced when a DSL transition is rejected.
 ///
@@ -675,4 +676,142 @@ pub trait SessionContextAdvancedObserver: Send + Sync {
     /// effect. `updated_at_ms` is the monotonic millisecond watermark of
     /// the canonical session-context mutation that produced this tick.
     fn on_session_context_advanced(&self, updated_at_ms: u64);
+}
+
+// ---------------------------------------------------------------------------
+// SessionClaimHandle (dogma #2 — canonical session-identity owner)
+// ---------------------------------------------------------------------------
+
+/// Error surfaced by [`SessionClaimHandle::try_acquire`].
+#[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
+pub enum SessionClaimError {
+    /// Another live claim already exists for this session id.
+    #[error("session identity already claimed: {0}")]
+    SessionIdentityInUse(SessionId),
+}
+
+/// RAII token returned by [`SessionClaimHandle::try_acquire`].
+///
+/// While alive, the underlying registry guarantees no other caller can
+/// acquire a claim for the same `session_id`. Drop releases the claim back
+/// through the owning handle.
+pub struct SessionClaim {
+    session_id: SessionId,
+    handle: Arc<dyn SessionClaimHandle>,
+}
+
+impl SessionClaim {
+    /// Construct a new claim — only [`SessionClaimHandle`] impls should call
+    /// this, immediately after they have inserted `session_id` into their
+    /// canonical registry under a single critical section.
+    pub fn new(session_id: SessionId, handle: Arc<dyn SessionClaimHandle>) -> Self {
+        Self { session_id, handle }
+    }
+
+    /// The session id this claim covers.
+    pub fn session_id(&self) -> &SessionId {
+        &self.session_id
+    }
+}
+
+impl Drop for SessionClaim {
+    fn drop(&mut self) {
+        self.handle.release(&self.session_id);
+    }
+}
+
+impl std::fmt::Debug for SessionClaim {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("SessionClaim")
+            .field("session_id", &self.session_id)
+            .finish_non_exhaustive()
+    }
+}
+
+/// Process-scope canonical owner of "this session id is currently active."
+///
+/// One canonical owner per process: `MeerkatMachine` exposes its registry
+/// when a runtime is wired (so every live runtime-registered session also
+/// owns its identity claim), and a default in-process registry covers bare
+/// `AgentFactory` callers without a runtime. Either way, "this session id
+/// is in use" lives in a typed owner — never in process-global shell
+/// bookkeeping.
+pub trait SessionClaimHandle: Send + Sync {
+    /// Atomically reserve `session_id`. Returns a [`SessionClaim`] whose
+    /// `Drop` releases the slot. Returns
+    /// [`SessionClaimError::SessionIdentityInUse`] if another live claim
+    /// already covers this session.
+    ///
+    /// Implementations MUST insert under a single critical section so two
+    /// concurrent callers cannot both succeed.
+    fn try_acquire(
+        self: Arc<Self>,
+        session_id: &SessionId,
+    ) -> Result<SessionClaim, SessionClaimError>;
+
+    /// Release a claim previously created by [`Self::try_acquire`].
+    ///
+    /// Called from [`SessionClaim`]'s `Drop`. Idempotent: releasing an
+    /// unknown id is a no-op (the registry was already cleared, e.g. via
+    /// runtime teardown).
+    fn release(&self, session_id: &SessionId);
+}
+
+/// In-process default [`SessionClaimHandle`] for bare-usage paths that have
+/// no `MeerkatMachine` available (standalone `AgentFactory` callers, doc
+/// examples, simple SDK consumers). One process-global instance keeps the
+/// "one active claim per session id" invariant intact even when no runtime
+/// is wired.
+pub struct DefaultSessionClaimRegistry {
+    claims: std::sync::Mutex<std::collections::HashSet<SessionId>>,
+}
+
+impl DefaultSessionClaimRegistry {
+    /// Construct an empty registry.
+    pub fn new() -> Self {
+        Self {
+            claims: std::sync::Mutex::new(std::collections::HashSet::new()),
+        }
+    }
+
+    /// Process-global instance — used by bare-usage facade builders.
+    pub fn global() -> Arc<Self> {
+        use std::sync::OnceLock;
+        static GLOBAL: OnceLock<Arc<DefaultSessionClaimRegistry>> = OnceLock::new();
+        Arc::clone(GLOBAL.get_or_init(|| Arc::new(DefaultSessionClaimRegistry::new())))
+    }
+}
+
+impl Default for DefaultSessionClaimRegistry {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl SessionClaimHandle for DefaultSessionClaimRegistry {
+    fn try_acquire(
+        self: Arc<Self>,
+        session_id: &SessionId,
+    ) -> Result<SessionClaim, SessionClaimError> {
+        let mut claims = self
+            .claims
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        if !claims.insert(session_id.clone()) {
+            return Err(SessionClaimError::SessionIdentityInUse(session_id.clone()));
+        }
+        drop(claims);
+        Ok(SessionClaim::new(
+            session_id.clone(),
+            self as Arc<dyn SessionClaimHandle>,
+        ))
+    }
+
+    fn release(&self, session_id: &SessionId) {
+        let mut claims = self
+            .claims
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        claims.remove(session_id);
+    }
 }

--- a/meerkat-core/src/runtime_epoch.rs
+++ b/meerkat-core/src/runtime_epoch.rs
@@ -15,8 +15,8 @@ use uuid::Uuid;
 use crate::completion_feed::CompletionSeq;
 use crate::handles::{
     AuthLeaseHandle, CommsDrainHandle, ExternalToolSurfaceHandle, McpServerLifecycleHandle,
-    PeerCommsHandle, PeerInteractionHandle, SessionAdmissionHandle, SessionContextHandle,
-    TurnStateHandle,
+    PeerCommsHandle, PeerInteractionHandle, SessionAdmissionHandle, SessionClaimHandle,
+    SessionContextHandle, TurnStateHandle,
 };
 use crate::ops_lifecycle::OpsLifecycleRegistry;
 use crate::tool_scope::ToolVisibilityOwner;
@@ -192,6 +192,15 @@ pub struct SessionRuntimeBindings {
     /// a typed `SessionContextAdvanced` effect instead of polling a watch
     /// channel. Shares the same `HandleDslAuthority` as the other handles.
     pub session_context: Arc<dyn SessionContextHandle>,
+    /// Session-identity claim handle owned by the runtime (dogma #2).
+    ///
+    /// Comms runtimes built for this session acquire their typed
+    /// [`SessionClaim`] through this handle. The canonical owner lives on
+    /// `MeerkatMachine` so per-process uniqueness is enforced by the
+    /// runtime, not by process-global shell statics.
+    ///
+    /// [`SessionClaim`]: crate::handles::SessionClaim
+    pub session_claim_handle: Arc<dyn SessionClaimHandle>,
 }
 
 impl Clone for SessionRuntimeBindings {
@@ -211,6 +220,7 @@ impl Clone for SessionRuntimeBindings {
             mcp_server_lifecycle: Arc::clone(&self.mcp_server_lifecycle),
             peer_interaction: self.peer_interaction.as_ref().map(Arc::clone),
             session_context: Arc::clone(&self.session_context),
+            session_claim_handle: Arc::clone(&self.session_claim_handle),
         }
     }
 }
@@ -238,6 +248,7 @@ impl std::fmt::Debug for SessionRuntimeBindings {
                     .map(|_| "<dyn PeerInteractionHandle>"),
             )
             .field("session_context", &"<dyn SessionContextHandle>")
+            .field("session_claim_handle", &"<dyn SessionClaimHandle>")
             .finish()
     }
 }
@@ -250,10 +261,10 @@ impl std::fmt::Debug for SessionRuntimeBindings {
 ///   epoch owner. Never creates a competing registry.
 ///
 /// The `SessionOwned` variant is intentionally large — it carries the full
-/// bundle of Arc-wrapped DSL handles and registries. Since `SessionOwned`
-/// is the common case on every runtime-backed surface (RPC, REST, MCP),
-/// boxing it to shrink the enum would regress the hot path. The
-/// `StandaloneEphemeral` path only appears in WASM, tests, and
+/// bundle of Arc-wrapped DSL handles and registries. Every value passes
+/// through the factory exactly once, never lands in a collection, so paying
+/// for an extra heap indirection on every construction would regress the hot
+/// path. The `StandaloneEphemeral` path only appears in WASM, tests, and
 /// standalone embedded runs.
 #[allow(clippy::large_enum_variant)]
 pub enum RuntimeBuildMode {

--- a/meerkat-runtime/src/handles/mod.rs
+++ b/meerkat-runtime/src/handles/mod.rs
@@ -31,6 +31,7 @@ mod mcp_server_lifecycle;
 mod peer_comms;
 mod peer_interaction;
 mod session_admission;
+mod session_claim;
 mod session_context;
 mod turn_state;
 
@@ -41,6 +42,7 @@ pub use mcp_server_lifecycle::RuntimeMcpServerLifecycleHandle;
 pub use peer_comms::RuntimePeerCommsHandle;
 pub use peer_interaction::RuntimePeerInteractionHandle;
 pub use session_admission::RuntimeSessionAdmissionHandle;
+pub use session_claim::RuntimeSessionClaimRegistry;
 pub use session_context::RuntimeSessionContextHandle;
 pub use turn_state::RuntimeTurnStateHandle;
 

--- a/meerkat-runtime/src/handles/session_claim.rs
+++ b/meerkat-runtime/src/handles/session_claim.rs
@@ -1,0 +1,48 @@
+//! Runtime-side session-id claim registry.
+//!
+//! Owned by [`crate::meerkat_machine::MeerkatMachine`] (one registry per
+//! `MeerkatMachine` instance). Every live runtime-registered session that
+//! also wires comms goes through this handle to reserve its session-id
+//! identity, so the machine instance is the canonical owner of "this
+//! session id is currently active" — no process-global statics in the
+//! comms shell (dogma #2).
+//!
+//! The impl lives in [`meerkat_core::handles::DefaultSessionClaimRegistry`];
+//! the runtime just re-exports it under a runtime-flavored name so
+//! downstream surfaces do not need to know the trait's default concrete
+//! type. `DefaultSessionClaimRegistry::global()` remains the process-scope
+//! fallback for bare `AgentFactory` callers without a runtime.
+
+pub use meerkat_core::handles::DefaultSessionClaimRegistry as RuntimeSessionClaimRegistry;
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used)]
+mod tests {
+    use std::sync::Arc;
+
+    use meerkat_core::SessionId;
+    use meerkat_core::handles::{SessionClaimError, SessionClaimHandle};
+
+    use super::RuntimeSessionClaimRegistry;
+
+    #[test]
+    fn second_live_acquire_for_same_session_fails() {
+        let registry: Arc<dyn SessionClaimHandle> = Arc::new(RuntimeSessionClaimRegistry::new());
+        let sid = SessionId::new();
+        let _claim = registry.clone().try_acquire(&sid).expect("first acquire");
+        let err = registry.try_acquire(&sid).expect_err("second must fail");
+        assert!(matches!(err, SessionClaimError::SessionIdentityInUse(_)));
+    }
+
+    #[test]
+    fn drop_releases_claim() {
+        let registry: Arc<dyn SessionClaimHandle> = Arc::new(RuntimeSessionClaimRegistry::new());
+        let sid = SessionId::new();
+        {
+            let _claim = registry.clone().try_acquire(&sid).expect("first acquire");
+        }
+        let _claim2 = registry
+            .try_acquire(&sid)
+            .expect("acquire after drop should succeed");
+    }
+}

--- a/meerkat-runtime/src/meerkat_machine/dispatch_session.rs
+++ b/meerkat-runtime/src/meerkat_machine/dispatch_session.rs
@@ -322,6 +322,7 @@ impl MeerkatMachine {
                                 &shared_handle_authority,
                             )),
                         ),
+                        session_claim_handle: self.session_claim_handle(),
                     },
                 ))
             }

--- a/meerkat-runtime/src/meerkat_machine/mod.rs
+++ b/meerkat-runtime/src/meerkat_machine/mod.rs
@@ -362,6 +362,13 @@ pub struct MeerkatMachine {
     comms_drain_slots: RwLock<HashMap<SessionId, CommsDrainSlot>>,
     /// Runtime-owned shell seam for live session LLM reconfiguration I/O.
     llm_reconfigure_host: StdRwLock<Option<Arc<dyn SessionLlmReconfigureHost>>>,
+    /// Canonical owner of "this session id is currently active" — replaces
+    /// the deleted process-global `SESSION_IDENTITY_CLAIMS` static in the
+    /// comms shell (dogma #2). Comms runtimes acquire a typed
+    /// [`meerkat_core::handles::SessionClaim`] through this handle and hold
+    /// it for their lifetime; the registry is scoped to this `MeerkatMachine`
+    /// instance, so tests / multi-runtime processes get clean isolation.
+    session_claims: Arc<crate::handles::RuntimeSessionClaimRegistry>,
 }
 
 impl MeerkatMachine {
@@ -383,6 +390,7 @@ impl MeerkatMachine {
             blob_store: None,
             comms_drain_slots: RwLock::new(HashMap::new()),
             llm_reconfigure_host: StdRwLock::new(None),
+            session_claims: Arc::new(crate::handles::RuntimeSessionClaimRegistry::new()),
         }
     }
 
@@ -395,6 +403,7 @@ impl MeerkatMachine {
             blob_store: Some(blob_store),
             comms_drain_slots: RwLock::new(HashMap::new()),
             llm_reconfigure_host: StdRwLock::new(None),
+            session_claims: Arc::new(crate::handles::RuntimeSessionClaimRegistry::new()),
         }
     }
 
@@ -412,7 +421,16 @@ impl MeerkatMachine {
             blob_store: None,
             comms_drain_slots: RwLock::new(HashMap::new()),
             llm_reconfigure_host: StdRwLock::new(None),
+            session_claims: Arc::new(crate::handles::RuntimeSessionClaimRegistry::new()),
         }
+    }
+
+    /// The canonical session-identity claim handle owned by this
+    /// `MeerkatMachine`. Comms runtimes wired through this machine acquire
+    /// their session-id claim through it; the registry is scoped to this
+    /// machine instance so tests / parallel runtimes do not collide.
+    pub fn session_claim_handle(&self) -> Arc<dyn meerkat_core::handles::SessionClaimHandle> {
+        Arc::clone(&self.session_claims) as Arc<dyn meerkat_core::handles::SessionClaimHandle>
     }
 
     /// Create a driver entry for a session.

--- a/meerkat-session/src/persistent.rs
+++ b/meerkat-session/src/persistent.rs
@@ -969,6 +969,14 @@ impl<B: SessionAgentBuilder + 'static> PersistentSessionService<B> {
                             session_context: Arc::new(
                                 meerkat_runtime::RuntimeSessionContextHandle::ephemeral(),
                             ),
+                            // Recovery path: same rationale as `peer_interaction`
+                            // above — until the runtime epoch rebinds via
+                            // `prepare_bindings`, fall back to the process-global
+                            // default registry so bare comms paths still hit a
+                            // canonical owner (dogma #2).
+                            session_claim_handle:
+                                meerkat_core::handles::DefaultSessionClaimRegistry::global()
+                                    as Arc<dyn meerkat_core::handles::SessionClaimHandle>,
                         },
                     )
                 })

--- a/meerkat/src/factory.rs
+++ b/meerkat/src/factory.rs
@@ -2064,6 +2064,21 @@ impl AgentFactory {
                     .cloned()
                     .collect::<std::collections::HashSet<String>>(),
             );
+            // Source the canonical session-claim handle from the build's
+            // runtime bindings when present; otherwise fall back to the
+            // process-global default registry so bare facade callers still
+            // hit a typed canonical owner (dogma #2 — "this session id is
+            // in use" never lives in process-global shell statics).
+            let session_claim_handle: Arc<dyn meerkat_core::handles::SessionClaimHandle> =
+                match &build_config.runtime_build_mode {
+                    meerkat_core::RuntimeBuildMode::SessionOwned(bindings) => {
+                        Arc::clone(&bindings.session_claim_handle)
+                    }
+                    meerkat_core::RuntimeBuildMode::StandaloneEphemeral => {
+                        meerkat_core::handles::DefaultSessionClaimRegistry::global()
+                            as Arc<dyn meerkat_core::handles::SessionClaimHandle>
+                    }
+                };
             let mut runtime =
                 crate::build_session_scoped_comms_runtime_from_config_scoped_with_silent_intents(
                     config,
@@ -2075,6 +2090,7 @@ impl AgentFactory {
                     build_config.realm_id.clone(),
                     session.id(),
                     silent_intents,
+                    session_claim_handle,
                 )
                 .await
                 .map_err(BuildAgentError::Comms)?;

--- a/meerkat/src/sdk.rs
+++ b/meerkat/src/sdk.rs
@@ -531,6 +531,7 @@ pub async fn build_session_scoped_comms_runtime_from_config_scoped_with_silent_i
     inproc_namespace: Option<String>,
     session_id: &meerkat_core::SessionId,
     silent_intents: std::sync::Arc<std::collections::HashSet<String>>,
+    session_claim_handle: std::sync::Arc<dyn meerkat_core::handles::SessionClaimHandle>,
 ) -> Result<CommsRuntime, String> {
     let event_listen_tcp = config
         .comms
@@ -549,6 +550,7 @@ pub async fn build_session_scoped_comms_runtime_from_config_scoped_with_silent_i
             canonical_session_comms_identity_root(user_config_root)?,
             session_id,
             silent_intents.clone(),
+            session_claim_handle,
         )
         .await
         .map_err(|e| format!("Failed to create inproc comms runtime: {e}"))?,

--- a/meerkat/src/service_factory.rs
+++ b/meerkat/src/service_factory.rs
@@ -770,6 +770,7 @@ mod tests {
                 meerkat_runtime::RuntimePeerInteractionHandle::ephemeral(),
             )),
             session_context: Arc::new(meerkat_runtime::RuntimeSessionContextHandle::ephemeral()),
+            session_claim_handle: runtime_adapter.session_claim_handle(),
         };
 
         let req = CreateSessionRequest {
@@ -961,6 +962,7 @@ mod tests {
                 meerkat_runtime::RuntimePeerInteractionHandle::ephemeral(),
             )),
             session_context: Arc::new(meerkat_runtime::RuntimeSessionContextHandle::ephemeral()),
+            session_claim_handle: runtime_adapter.session_claim_handle(),
         };
 
         let req = CreateSessionRequest {


### PR DESCRIPTION
## Summary

Replaces process-global `SESSION_IDENTITY_CLAIMS` / `SessionIdentityClaim` RAII + force-release helpers in the comms shell with a typed `SessionClaimHandle` trait whose canonical owner is `MeerkatMachine` (per-instance registry, not a process-global static). Bare facade paths with no runtime wired still enforce process-scope uniqueness through a `DefaultSessionClaimRegistry::global()` fallback, so no surface loses its uniqueness invariant.

- **`meerkat-core::handles`**: new `SessionClaimHandle` trait, `SessionClaim` RAII token, `SessionClaimError`, and `DefaultSessionClaimRegistry` default impl (reused by both facade fallback and runtime).
- **`meerkat-runtime`**: exposes `MeerkatMachine::session_claim_handle()` and plumbs it into `SessionRuntimeBindings.session_claim_handle`.
- **`meerkat-comms`**: `CommsRuntime::inproc_only_session_scoped_with_silent_intents` accepts an injected `Arc<dyn SessionClaimHandle>` and holds the typed `SessionClaim` for its lifetime. Deletes `SESSION_IDENTITY_CLAIMS`, `SessionIdentityClaim`, `release_session_claim`, and `clear_all_session_claims` (no shims).
- **`meerkat` facade**: threads the handle through `build_session_scoped_comms_runtime_from_config_scoped_with_silent_intents` and sources it from `RuntimeBuildMode::SessionOwned` when present, falling back to the process-global default registry otherwise.

Every existing regression ("second live activation for the same session_id rejects") is preserved; the test suite now uses per-test handle instances so suite-scoped state does not leak across parallel runs.

## Test plan

- [x] `./scripts/repo-cargo fmt --all -- --check`
- [x] `./scripts/repo-cargo clippy --workspace --all-targets -- -D warnings`
- [x] `./scripts/repo-cargo unit` — 3763 passed
- [x] `./scripts/repo-cargo nextest run --workspace --tests -E "not binary(e2e_*_lane)"` — 4722 passed
- [x] `./scripts/repo-cargo e2e-fast` — 5 passed
- [x] `./scripts/repo-cargo e2e-system` — 16 passed