### PR TITLE
fix(machine): typed OperationStatus + InputAbandonReason DSL state (dogma round 3, wave 1)

### DIFF
--- a/meerkat-runtime/src/driver/ephemeral.rs
+++ b/meerkat-runtime/src/driver/ephemeral.rs
@@ -365,14 +365,13 @@ impl EphemeralRuntimeDriver {
                 Some(InputTerminalOutcome::Coalesced { aggregate_id: id })
             }
             mm_dsl::InputTerminalKind::Abandoned => {
-                let reason_str = self.dsl.0.state.input_abandon_reason.get(&key)?;
-                let reason = match reason_str.as_str() {
-                    "Retired" => InputAbandonReason::Retired,
-                    "Reset" => InputAbandonReason::Reset,
-                    "Stopped" => InputAbandonReason::Stopped,
-                    "Destroyed" => InputAbandonReason::Destroyed,
-                    "Cancelled" => InputAbandonReason::Cancelled,
-                    "MaxAttemptsExhausted" => {
+                let reason = match self.dsl.0.state.input_abandon_reason.get(&key).copied()? {
+                    mm_dsl::InputAbandonReason::Retired => InputAbandonReason::Retired,
+                    mm_dsl::InputAbandonReason::Reset => InputAbandonReason::Reset,
+                    mm_dsl::InputAbandonReason::Stopped => InputAbandonReason::Stopped,
+                    mm_dsl::InputAbandonReason::Destroyed => InputAbandonReason::Destroyed,
+                    mm_dsl::InputAbandonReason::Cancelled => InputAbandonReason::Cancelled,
+                    mm_dsl::InputAbandonReason::MaxAttemptsExhausted => {
                         let attempts = self
                             .dsl
                             .0
@@ -383,7 +382,6 @@ impl EphemeralRuntimeDriver {
                             .unwrap_or(0) as u32;
                         InputAbandonReason::MaxAttemptsExhausted { attempts }
                     }
-                    _ => return None,
                 };
                 Some(InputTerminalOutcome::Abandoned { reason })
             }
@@ -668,7 +666,7 @@ impl EphemeralRuntimeDriver {
                     .0
                     .state
                     .input_abandon_reason
-                    .insert(key.clone(), format!("{reason:?}"));
+                    .insert(key.clone(), mm_dsl::InputAbandonReason::from(&reason));
                 self.dsl
                     .0
                     .state
@@ -1352,10 +1350,7 @@ impl EphemeralRuntimeDriver {
                 self.dsl_apply(
                     mm_dsl::MeerkatMachineInput::AbandonInput {
                         input_id: key.clone(),
-                        reason: format!(
-                            "{:?}",
-                            InputAbandonReason::MaxAttemptsExhausted { attempts }
-                        ),
+                        reason: mm_dsl::InputAbandonReason::MaxAttemptsExhausted,
                         attempt_count: attempts_count,
                     },
                     "AbandonInput(MaxAttemptsExhausted)",
@@ -1380,16 +1375,16 @@ impl EphemeralRuntimeDriver {
                     state.terminal_outcome = Some(outcome.clone());
                     state.updated_at = now;
                 }
-                self.events
-                    .push(self.make_envelope(RuntimeEvent::InputLifecycle(
+                self.events.push(
+                    self.make_envelope(RuntimeEvent::InputLifecycle(
                         InputLifecycleEvent::Abandoned {
                             input_id: input_id.clone(),
-                            reason: format!(
-                                "{:?}",
-                                InputAbandonReason::MaxAttemptsExhausted { attempts }
-                            ),
+                            reason: mm_dsl::InputAbandonReason::MaxAttemptsExhausted
+                                .as_str()
+                                .to_string(),
                         },
-                    )));
+                    )),
+                );
             } else {
                 // Still have attempts — rollback to Queued.
                 self.dsl_apply(
@@ -1583,6 +1578,8 @@ impl EphemeralRuntimeDriver {
                 }
             })
             .collect();
+        let dsl_reason = mm_dsl::InputAbandonReason::from(&reason);
+        let reason_label = dsl_reason.as_str();
         let mut count = 0;
         for id in &non_terminal_ids {
             let key = Self::dsl_key(id);
@@ -1598,7 +1595,7 @@ impl EphemeralRuntimeDriver {
                 .dsl_apply(
                     mm_dsl::MeerkatMachineInput::AbandonInput {
                         input_id: key.clone(),
-                        reason: format!("{reason:?}"),
+                        reason: dsl_reason,
                         attempt_count,
                     },
                     "AbandonInput",
@@ -1614,7 +1611,7 @@ impl EphemeralRuntimeDriver {
                     timestamp: now,
                     from: from_phase,
                     to: InputLifecycleState::Abandoned,
-                    reason: Some(format!("Abandon({reason:?})")),
+                    reason: Some(format!("Abandon({reason_label})")),
                 });
                 state.terminal_outcome = Some(InputTerminalOutcome::Abandoned {
                     reason: reason.clone(),
@@ -1626,7 +1623,7 @@ impl EphemeralRuntimeDriver {
                 .push(self.make_envelope(RuntimeEvent::InputLifecycle(
                     InputLifecycleEvent::Abandoned {
                         input_id: id.clone(),
-                        reason: format!("{reason:?}"),
+                        reason: reason_label.to_string(),
                     },
                 )));
         }

--- a/meerkat-runtime/src/meerkat_machine/dsl.rs
+++ b/meerkat-runtime/src/meerkat_machine/dsl.rs
@@ -1212,6 +1212,117 @@ impl From<meerkat_core::comms::InputSource> for WorkOrigin {
     }
 }
 
+/// Typed async-operation lifecycle status. Closed mirror of
+/// [`meerkat_core::ops_lifecycle::OperationStatus`] — replaces the former
+/// literal-string values in the DSL's `op_statuses` map.
+///
+/// The DSL writes these variants directly on each ops lifecycle transition
+/// (`RegisterOp`, `StartOp`, `CompleteOp`, `FailOp`, `CancelOp`, `AbortOp`,
+/// `RetireRequestedOp`, `RetireCompletedOp`, `TerminateOp`). The shell's
+/// `ShellState::status()` reads the typed value directly and maps to the
+/// domain enum via the `From` impl below — no string compares, no string
+/// parsing.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
+pub enum OperationStatus {
+    #[default]
+    Absent,
+    Provisioning,
+    Running,
+    Retiring,
+    Completed,
+    Failed,
+    Aborted,
+    Cancelled,
+    Retired,
+    Terminated,
+}
+
+impl From<meerkat_core::ops_lifecycle::OperationStatus> for OperationStatus {
+    fn from(status: meerkat_core::ops_lifecycle::OperationStatus) -> Self {
+        match status {
+            meerkat_core::ops_lifecycle::OperationStatus::Absent => Self::Absent,
+            meerkat_core::ops_lifecycle::OperationStatus::Provisioning => Self::Provisioning,
+            meerkat_core::ops_lifecycle::OperationStatus::Running => Self::Running,
+            meerkat_core::ops_lifecycle::OperationStatus::Retiring => Self::Retiring,
+            meerkat_core::ops_lifecycle::OperationStatus::Completed => Self::Completed,
+            meerkat_core::ops_lifecycle::OperationStatus::Failed => Self::Failed,
+            meerkat_core::ops_lifecycle::OperationStatus::Aborted => Self::Aborted,
+            meerkat_core::ops_lifecycle::OperationStatus::Cancelled => Self::Cancelled,
+            meerkat_core::ops_lifecycle::OperationStatus::Retired => Self::Retired,
+            meerkat_core::ops_lifecycle::OperationStatus::Terminated => Self::Terminated,
+        }
+    }
+}
+
+impl From<OperationStatus> for meerkat_core::ops_lifecycle::OperationStatus {
+    fn from(status: OperationStatus) -> Self {
+        match status {
+            OperationStatus::Absent => Self::Absent,
+            OperationStatus::Provisioning => Self::Provisioning,
+            OperationStatus::Running => Self::Running,
+            OperationStatus::Retiring => Self::Retiring,
+            OperationStatus::Completed => Self::Completed,
+            OperationStatus::Failed => Self::Failed,
+            OperationStatus::Aborted => Self::Aborted,
+            OperationStatus::Cancelled => Self::Cancelled,
+            OperationStatus::Retired => Self::Retired,
+            OperationStatus::Terminated => Self::Terminated,
+        }
+    }
+}
+
+/// Typed input-abandonment reason. Closed mirror of the discriminant set of
+/// [`crate::input_state::InputAbandonReason`] — replaces the former
+/// `format!("{reason:?}")` Debug round-trip in the DSL's
+/// `input_abandon_reason` map.
+///
+/// The `MaxAttemptsExhausted` variant's `attempts` payload rides on the
+/// companion `input_abandon_attempt_count: Map<String, u64>` field of the
+/// DSL state; this enum only carries the discriminant. The domain
+/// `InputAbandonReason::MaxAttemptsExhausted { attempts }` is reconstructed
+/// in the driver by pairing the typed discriminant with that companion map.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
+pub enum InputAbandonReason {
+    #[default]
+    Retired,
+    Reset,
+    Stopped,
+    Destroyed,
+    Cancelled,
+    MaxAttemptsExhausted,
+}
+
+impl From<&crate::input_state::InputAbandonReason> for InputAbandonReason {
+    fn from(reason: &crate::input_state::InputAbandonReason) -> Self {
+        match reason {
+            crate::input_state::InputAbandonReason::Retired => Self::Retired,
+            crate::input_state::InputAbandonReason::Reset => Self::Reset,
+            crate::input_state::InputAbandonReason::Stopped => Self::Stopped,
+            crate::input_state::InputAbandonReason::Destroyed => Self::Destroyed,
+            crate::input_state::InputAbandonReason::Cancelled => Self::Cancelled,
+            crate::input_state::InputAbandonReason::MaxAttemptsExhausted { .. } => {
+                Self::MaxAttemptsExhausted
+            }
+        }
+    }
+}
+
+impl InputAbandonReason {
+    /// Stable lowercase label for event wire formats. Mirrors the
+    /// snake-case serde representation of the domain enum for consistency
+    /// with existing consumers.
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::Retired => "retired",
+            Self::Reset => "reset",
+            Self::Stopped => "stopped",
+            Self::Destroyed => "destroyed",
+            Self::Cancelled => "cancelled",
+            Self::MaxAttemptsExhausted => "max_attempts_exhausted",
+        }
+    }
+}
+
 // Ensure we keep the exact generated schema DSL body from the catalog source.
 machine! {
     machine MeerkatMachine {
@@ -1262,7 +1373,7 @@ machine! {
             input_terminal_kind: Map<String, InputTerminalKind>,
             input_superseded_by: Map<String, String>,
             input_aggregate_id: Map<String, String>,
-            input_abandon_reason: Map<String, String>,
+            input_abandon_reason: Map<String, Enum<InputAbandonReason>>,
             input_abandon_attempt_count: Map<String, u64>,
             input_attempt_counts: Map<String, u64>,
             input_run_associations: Map<String, String>,
@@ -1273,7 +1384,7 @@ machine! {
             steer_lane: Set<String>,
 
             // --- Ops lifecycle substate ---
-            op_statuses: Map<String, String>,
+            op_statuses: Map<String, Enum<OperationStatus>>,
             op_completion_seq: Map<String, u64>,
             op_terminal_outcomes: Map<String, String>,
             op_kinds: Map<String, String>,
@@ -1664,7 +1775,7 @@ machine! {
             CoalesceInput { input_id: String, aggregate_id: String },
             AbandonInput {
                 input_id: String,
-                reason: String,
+                reason: Enum<InputAbandonReason>,
                 attempt_count: u64,
             },
             RecordBoundarySeq { input_id: String, seq: u64 },
@@ -4162,7 +4273,7 @@ machine! {
             on input RegisterOp { operation_id, kind }
             guard "not_already_registered" { !self.op_statuses.contains_key(operation_id) }
             update {
-                self.op_statuses.insert(operation_id, "Provisioning");
+                self.op_statuses.insert(operation_id, OperationStatus::Provisioning);
                 self.op_kinds.insert(operation_id, kind);
                 self.op_peer_ready.insert(operation_id, false);
                 self.op_progress_counts.insert(operation_id, 0);
@@ -4178,7 +4289,7 @@ machine! {
             on input StartOp { operation_id }
             guard "op_registered" { self.op_statuses.contains_key(operation_id) }
             update {
-                self.op_statuses.insert(operation_id, "Running");
+                self.op_statuses.insert(operation_id, OperationStatus::Running);
             }
             to Idle
             emit SubmitOpEvent { operation_id: operation_id }
@@ -4190,7 +4301,7 @@ machine! {
             on input CompleteOp { operation_id, outcome }
             guard "op_registered" { self.op_statuses.contains_key(operation_id) }
             update {
-                self.op_statuses.insert(operation_id, "Completed");
+                self.op_statuses.insert(operation_id, OperationStatus::Completed);
                 self.op_terminal_outcomes.insert(operation_id, outcome);
                 self.active_op_count -= 1;
                 self.op_completion_seq.insert(operation_id, self.next_completion_seq);
@@ -4207,7 +4318,7 @@ machine! {
             on input FailOp { operation_id, outcome }
             guard "op_registered" { self.op_statuses.contains_key(operation_id) }
             update {
-                self.op_statuses.insert(operation_id, "Failed");
+                self.op_statuses.insert(operation_id, OperationStatus::Failed);
                 self.op_terminal_outcomes.insert(operation_id, outcome);
                 self.active_op_count -= 1;
             }
@@ -4222,7 +4333,7 @@ machine! {
             on input CancelOp { operation_id, outcome }
             guard "op_registered" { self.op_statuses.contains_key(operation_id) }
             update {
-                self.op_statuses.insert(operation_id, "Cancelled");
+                self.op_statuses.insert(operation_id, OperationStatus::Cancelled);
                 self.op_terminal_outcomes.insert(operation_id, outcome);
                 self.active_op_count -= 1;
             }
@@ -4237,7 +4348,7 @@ machine! {
             on input AbortOp { operation_id, outcome }
             guard "op_registered" { self.op_statuses.contains_key(operation_id) }
             update {
-                self.op_statuses.insert(operation_id, "Aborted");
+                self.op_statuses.insert(operation_id, OperationStatus::Aborted);
                 self.op_terminal_outcomes.insert(operation_id, outcome);
                 self.active_op_count -= 1;
             }
@@ -4277,7 +4388,7 @@ machine! {
             on input RetireRequestedOp { operation_id }
             guard "op_registered" { self.op_statuses.contains_key(operation_id) }
             update {
-                self.op_statuses.insert(operation_id, "Retiring");
+                self.op_statuses.insert(operation_id, OperationStatus::Retiring);
             }
             to Idle
             emit SubmitOpEvent { operation_id: operation_id }
@@ -4289,7 +4400,7 @@ machine! {
             on input RetireCompletedOp { operation_id, outcome }
             guard "op_registered" { self.op_statuses.contains_key(operation_id) }
             update {
-                self.op_statuses.insert(operation_id, "Retired");
+                self.op_statuses.insert(operation_id, OperationStatus::Retired);
                 self.op_terminal_outcomes.insert(operation_id, outcome);
                 self.active_op_count -= 1;
             }
@@ -4306,7 +4417,7 @@ machine! {
             on input TerminateOp { operation_id, outcome }
             guard "op_registered" { self.op_statuses.contains_key(operation_id) }
             update {
-                self.op_statuses.insert(operation_id, "Terminated");
+                self.op_statuses.insert(operation_id, OperationStatus::Terminated);
                 self.op_terminal_outcomes.insert(operation_id, outcome);
                 self.active_op_count -= 1;
             }

--- a/meerkat-runtime/src/ops_lifecycle.rs
+++ b/meerkat-runtime/src/ops_lifecycle.rs
@@ -405,19 +405,13 @@ impl ShellState {
     /// Read the DSL operation status for `id`, or `None` if not registered.
     fn status(&self, id: &OperationId) -> Option<OperationStatus> {
         let id_key = mm_dsl::OperationId::from_domain(id).0;
-        let status_str = self.dsl.0.state.op_statuses.get(&id_key)?;
-        match status_str.as_str() {
-            "Provisioning" => Some(OperationStatus::Provisioning),
-            "Running" => Some(OperationStatus::Running),
-            "Retiring" => Some(OperationStatus::Retiring),
-            "Completed" => Some(OperationStatus::Completed),
-            "Failed" => Some(OperationStatus::Failed),
-            "Aborted" => Some(OperationStatus::Aborted),
-            "Cancelled" => Some(OperationStatus::Cancelled),
-            "Retired" => Some(OperationStatus::Retired),
-            "Terminated" => Some(OperationStatus::Terminated),
-            _ => None,
-        }
+        self.dsl
+            .0
+            .state
+            .op_statuses
+            .get(&id_key)
+            .copied()
+            .map(OperationStatus::from)
     }
 
     /// Read the DSL operation kind for `id`, or `None` if not registered.
@@ -884,25 +878,10 @@ impl RuntimeOpsLifecycleRegistry {
                 continue;
             }
             let id_key = mm_dsl::OperationId::from_domain(&op_id).0;
-            let status_str: &'static str = match op_state.status {
-                OperationStatus::Completed => "Completed",
-                OperationStatus::Failed => "Failed",
-                OperationStatus::Aborted => "Aborted",
-                OperationStatus::Cancelled => "Cancelled",
-                OperationStatus::Retired => "Retired",
-                OperationStatus::Terminated => "Terminated",
-                // Unreachable: filtered by is_terminal() above.
-                OperationStatus::Absent
-                | OperationStatus::Provisioning
-                | OperationStatus::Running
-                | OperationStatus::Retiring => continue,
-            };
-            shell
-                .dsl
-                .0
-                .state
-                .op_statuses
-                .insert(id_key.clone(), status_str.to_string());
+            shell.dsl.0.state.op_statuses.insert(
+                id_key.clone(),
+                mm_dsl::OperationStatus::from(op_state.status),
+            );
             let kind_str = serde_json::to_string(&op_state.kind).unwrap_or_default();
             shell.dsl.0.state.op_kinds.insert(id_key.clone(), kind_str);
             shell


### PR DESCRIPTION
## Summary

Closes two dogma round-3 violations in one cut, continuing the PR #296 retype pattern (typed DSL fields + single `From` boundary mapper, no string compares, no `fmt::Debug` round-trips):

- **Violation #2 — `op_statuses` stringly**: retype `MeerkatMachineState.op_statuses` from `Map<String, String>` to `Map<String, Enum<OperationStatus>>`. Every ops-lifecycle DSL transition (`RegisterOp`, `StartOp`, `CompleteOp`, `FailOp`, `CancelOp`, `AbortOp`, `RetireRequestedOp`, `RetireCompletedOp`, `TerminateOp`) writes the typed variant. `ShellState::status()` reads typed via `OperationStatus::from(..)`; the stringly match `"Provisioning" => .., ..` rehydration is gone. `RuntimeOpsLifecycleRegistry::from_recovered` writes through the same `From` boundary — no hand-maintained literal lookup.

- **Violation #5 — `input_abandon_reason` Debug round-trip**: retype `MeerkatMachineState.input_abandon_reason` from `Map<String, String>` to `Map<String, Enum<InputAbandonReason>>` and the `AbandonInput.reason` input field from `String` to `Enum<InputAbandonReason>`. The `MaxAttemptsExhausted { attempts }` payload keeps riding on the companion `input_abandon_attempt_count` map (DSL enum holds only the discriminant). Every `format!("{reason:?}")` Debug round-trip on the DSL path is deleted; the two `InputLifecycleEvent::Abandoned.reason: String` payloads use `InputAbandonReason::as_str()` (stable snake_case) instead of `Debug`.

Catalog DSL twin (`meerkat-machine-schema::catalog::dsl::meerkat_machine`) does not mirror `op_statuses` or `input_abandon_reason` — no catalog update needed.

No wire/SDK impact; both types are internal. No `make regen-schemas` needed.

## Test plan

- [x] `./scripts/repo-cargo fmt --all -- --check`
- [x] `./scripts/repo-cargo clippy --workspace --all-targets -- -D warnings`
- [x] `make machine-codegen && make machine-verify && make machine-check-drift`
- [x] `./scripts/repo-cargo unit` — 3788 passed
- [x] `./scripts/repo-cargo e2e-fast` — 5 passed
- [ ] CI: unit, int, e2e-fast, e2e-system, feature matrix

🤖 Generated with [Claude Code](https://claude.com/claude-code)