### PR TITLE
fix(ts-smoke): port e2e_smoke test to dogma #10 memberRef shape

### DIFF
--- a/sdks/typescript/tests/e2e_smoke.test.mjs
+++ b/sdks/typescript/tests/e2e_smoke.test.mjs
@@ -357,11 +357,9 @@ describe("Live Smoke: TypeScript SDK", { skip: !binaryPath }, () => {
         runtimeMode: "turn_driven",
       }));
       assert.equal(lead.agentIdentity, "lead-1");
-      assert.ok(lead.agentRuntimeId);
-      assert.ok(Number.isInteger(lead.fenceToken));
+      assert.ok(lead.memberRef);
       assert.equal(reviewer.agentIdentity, "reviewer-1");
-      assert.ok(reviewer.agentRuntimeId);
-      assert.ok(Number.isInteger(reviewer.fenceToken));
+      assert.ok(reviewer.memberRef);
 
       await withStepTimeout(scenario, "wire lead -> reviewer", mob.wire("lead-1", "reviewer-1"));
       const append = await withStepTimeout(scenario, "append reviewer system context", mob.appendSystemContext(
@@ -388,8 +386,7 @@ describe("Live Smoke: TypeScript SDK", { skip: !binaryPath }, () => {
           ),
         );
         assert.equal(reviewerReceipt.agentIdentity, "reviewer-1");
-        assert.equal(reviewerReceipt.agentRuntimeId, reviewer.agentRuntimeId);
-        assert.equal(reviewerReceipt.fenceToken, reviewer.fenceToken);
+        assert.equal(reviewerReceipt.memberRef, reviewer.memberRef);
         const iterator = subscription[Symbol.asyncIterator]();
         let firstEventTimer = null;
         const firstEvent = await withStepTimeout(scenario, "receive first reviewer event", Promise.race([
@@ -441,14 +438,13 @@ describe("Live Smoke: TypeScript SDK", { skip: !binaryPath }, () => {
         "Come back online and say REVIEWER_RESPAWN_44.",
       ));
       assert.equal(respawn.receipt.agentIdentity, "reviewer-1");
-      assert.ok(respawn.receipt.agentRuntimeId);
+      assert.ok(respawn.receipt.memberRef);
       const membersAfterRespawn = await waitFor(
         async () => withStepTimeout(scenario, "poll members after respawn", mob.listMembers()),
         (items) => items.some(
           (member) =>
             member.agentIdentity === "reviewer-1"
-            && member.agentRuntimeId === respawn.receipt.agentRuntimeId
-            && member.fenceToken === respawn.receipt.fenceToken
+            && member.memberRef === respawn.receipt.memberRef
             && member.state === "Active",
         ),
         { timeoutMs: 60000, intervalMs: 200 },
@@ -457,7 +453,7 @@ describe("Live Smoke: TypeScript SDK", { skip: !binaryPath }, () => {
       const respawnedReviewer = membersAfterRespawn.find(
         (member) => member.agentIdentity === "reviewer-1",
       );
-      assert.ok(respawnedReviewer?.agentRuntimeId);
+      assert.ok(respawnedReviewer?.memberRef);
       const respawnReceipt = await withStepTimeout(
         scenario,
         "send respawn reviewer turn",
@@ -466,8 +462,7 @@ describe("Live Smoke: TypeScript SDK", { skip: !binaryPath }, () => {
         ),
       );
       assert.equal(respawnReceipt.agentIdentity, "reviewer-1");
-      assert.equal(respawnReceipt.agentRuntimeId, respawn.receipt.agentRuntimeId);
-      assert.equal(respawnReceipt.fenceToken, respawn.receipt.fenceToken);
+      assert.equal(respawnReceipt.memberRef, respawn.receipt.memberRef);
       const respawnedState = await waitFor(
         async () => withStepTimeout(scenario, "poll reviewer status after respawn send", mob.memberStatus("reviewer-1")),
         (state) => (state.outputPreview || "").toLowerCase().includes("reviewer_respawn_44"),
@@ -489,7 +484,7 @@ describe("Live Smoke: TypeScript SDK", { skip: !binaryPath }, () => {
           agentIdentity: "broken-1",
           runtimeMode: "turn_driven",
         }));
-        assert.ok(broken.agentRuntimeId);
+        assert.ok(broken.memberRef);
         await assert.rejects(
           () => withStepTimeout(
             scenario,


### PR DESCRIPTION
## Summary

Replaces retired `agentRuntimeId` + `fenceToken` assertions with `memberRef` equivalents in `sdks/typescript/tests/e2e_smoke.test.mjs`.

PR #295 (dogma #10, `5f3938186`) retired those fields from `MobSpawnResult`, `MemberDeliveryReceipt`, `MemberRespawnReceipt`, and `MobMember` in favour of the server-resolved `MobMemberRef`. The TS smoke test was never updated, so every dogma-round-1+ live smoke run fails at the first post-spawn assertion:

```
assert.ok(lead.agentRuntimeId)   // line 360 → always false; field removed
```

The W3-H finisher caught the parallel bug in the Python SDK smoke (`receipt["agent_runtime_id"]` → `current_session_id`); this PR does the same for TypeScript.

## What changed

- Every `X.agentRuntimeId` → `X.memberRef`
- Every `X.fenceToken` assertion dropped (no replacement — `memberRef` is the opaque identity the server resolves)
- Before/after comparisons (respawn flow) now compare on `memberRef` which remains unique per runtime binding

Test-only change. No SDK code changes.

## Verification

Ran against main HEAD (`e093fcc19`) with live API keys:

- Before: s44 fails at line 360 in 0.3s with `expected: true, operator: '=='`
- After: s44 gets past spawn/respawn/retire assertions; fails separately at line 429 on an LLM-output assertion (`assert.ok(reviewerText.includes("swarm_marker_7f3x2a"))`) where the reviewer says "swarm marker: reviewer ready" but drops the `7F3X2A` token. That's model-output flakiness, orthogonal scope.

## Scope note

This PR clears the test-code blocker. The orthogonal LLM-output flakiness in s44 (and similar scenarios) deserves its own triage — likely stronger prompt or retry logic — but is separate from this dogma-10 test-shape port.

## Related

- PR #295 (dogma #10): server-resolved MemberRef + typed lifecycle
- PR #300 (W3-H): fixed the parallel Python smoke pred (`receipt["agent_runtime_id"]` → `current_session_id`)