### PR TITLE
fix(smoke-lane): npm install (not npm ci) for fresh-worktree bootstrap

### DIFF
--- a/tests/integration/src/e2e_lanes.rs
+++ b/tests/integration/src/e2e_lanes.rs
@@ -1258,7 +1258,7 @@ fn scenario_spec(id: u16) -> Option<&'static Spec> {
             env: &[("MEERKAT_BIN_PATH", "{cargo_target_dir}/debug/rkat-rpc")],
             cargo_bin_env: &[],
             pre_commands: &[
-                &["npm", "ci"],
+                &["npm", "install", "--no-audit", "--no-fund"],
                 &[
                     "cargo",
                     "build",
@@ -1287,7 +1287,7 @@ fn scenario_spec(id: u16) -> Option<&'static Spec> {
             env: &[("MEERKAT_BIN_PATH", "{cargo_target_dir}/debug/rkat-rpc")],
             cargo_bin_env: &[],
             pre_commands: &[
-                &["npm", "ci"],
+                &["npm", "install", "--no-audit", "--no-fund"],
                 &[
                     "cargo",
                     "build",
@@ -1316,7 +1316,7 @@ fn scenario_spec(id: u16) -> Option<&'static Spec> {
             env: &[("MEERKAT_BIN_PATH", "{cargo_target_dir}/debug/rkat-rpc")],
             cargo_bin_env: &[],
             pre_commands: &[
-                &["npm", "ci"],
+                &["npm", "install", "--no-audit", "--no-fund"],
                 &[
                     "cargo",
                     "build",
@@ -1348,7 +1348,7 @@ fn scenario_spec(id: u16) -> Option<&'static Spec> {
             env: &[("MEERKAT_BIN_PATH", "{cargo_target_dir}/debug/rkat-rpc")],
             cargo_bin_env: &[],
             pre_commands: &[
-                &["npm", "ci"],
+                &["npm", "install", "--no-audit", "--no-fund"],
                 &[
                     "cargo",
                     "build",
@@ -1848,7 +1848,7 @@ fn scenario_spec(id: u16) -> Option<&'static Spec> {
             env: &[("MEERKAT_BIN_PATH", "{cargo_target_dir}/debug/rkat-rpc")],
             cargo_bin_env: &[],
             pre_commands: &[
-                &["npm", "ci"],
+                &["npm", "install", "--no-audit", "--no-fund"],
                 &[
                     "cargo",
                     "build",


### PR DESCRIPTION
## Summary

Replaces `npm ci` with `npm install --no-audit --no-fund` across the five SDK-building smoke scenario specs in `tests/integration/src/e2e_lanes.rs` (s41, s42, s43, s44, and the TypeScript full-lifecycle suite at line 1851).

## Problem

`sdks/typescript/package-lock.json` and `sdks/web/package-lock.json` are gitignored (`.gitignore` lines 50 and 55). A fresh worktree produced by `git worktree add /tmp/smoke-verify origin/main` — the natural shape for ad-hoc smoke runs against main HEAD — has no lock files. `npm ci` refuses to install without one:

```
npm error code EUSAGE
npm error The `npm ci` command can only install with an existing
npm error package-lock.json or npm-shrinkwrap.json
```

This was surfaced during the overnight post-W3-H full-lane smoke run against main `e093fcc19`: s44 and s59 both failed in 0.3s with the above error before any test code ran.

## Fix

`npm install --no-audit --no-fund` handles both cases cleanly:
- If a lock file exists → respects it, installs to match.
- If missing → generates one, installs deps.
- Flags suppress noise that `npm ci` also suppresses by default.

No semantic change for existing warm worktrees (main, w2f, etc.) that already have lock files — install-with-existing-lock is equivalent to `npm ci` modulo strictness on lock drift, which we don't care about in the smoke lane.

## Why `npm install` and not "commit the lock files"

Committing the lock files is the alternative but has tradeoffs:
- Breaks renovate dep-bump PR flow (every bump rewrites the lock).
- Forces reviewers to audit generated files.
- The gitignore is longstanding and intentional.

Keeping the lock ignored and making the test harness tolerant of its absence is the smaller-change fix.

## Verification

Ran `./scripts/repo-cargo check -p meerkat-integration-tests --tests` — compiles clean.
Manually verified s59 passes end-to-end after `npm install` bootstrap during overnight smoke.