### PR TITLE
fix(machine): typed effect classifiers in MeerkatMachine (dogma round 3, wave 2a)

### DIFF
--- a/meerkat-machine-schema/src/catalog/dsl/meerkat_machine.rs
+++ b/meerkat-machine-schema/src/catalog/dsl/meerkat_machine.rs
@@ -327,7 +327,10 @@ machine! {
             RequestCancellationAtBoundary,
             WakeInterrupt,
             CommittedVisibleSetPublished { revision: u64 },
-            RuntimeNotice { kind: String, detail: String },
+            // `kind` is a closed classifier of runtime lifecycle markers;
+            // `detail` stays `String` because it's a free-form diagnostic
+            // message paired with the kind.
+            RuntimeNotice { kind: Enum<RuntimeNoticeKind>, detail: String },
             // Absorbed effects
             ResolveAdmission,
             SubmitAdmittedIngressEffect,
@@ -726,7 +729,7 @@ machine! {
             guard "session_registered" { self.session_id != None }
             update {}
             to Idle
-            emit RuntimeNotice { kind: "drain", detail: "drain exited" }
+            emit RuntimeNotice { kind: RuntimeNoticeKind::Drain, detail: "drain exited" }
         }
 
         // 10. InterruptCurrentRun: Attached + Running self-loops
@@ -908,7 +911,7 @@ machine! {
                 self.silent_intent_overrides = EmptySet;
             }
             to Idle
-            emit RuntimeNotice { kind: "reset", detail: "runtime reset" }
+            emit RuntimeNotice { kind: RuntimeNoticeKind::Reset, detail: "runtime reset" }
         }
 
         // 16. StopRuntimeExecutor: different behavior per phase
@@ -926,7 +929,7 @@ machine! {
                 self.silent_intent_overrides = EmptySet;
             }
             to Stopped
-            emit RuntimeNotice { kind: "stop", detail: "runtime executor stopped" }
+            emit RuntimeNotice { kind: RuntimeNoticeKind::Stop, detail: "runtime executor stopped" }
         }
         // Attached → Attached (self-loop)
         transition StopRuntimeExecutorAttached {
@@ -936,7 +939,7 @@ machine! {
                 self.silent_intent_overrides = EmptySet;
             }
             to Attached
-            emit RuntimeNotice { kind: "stop", detail: "runtime executor stopped" }
+            emit RuntimeNotice { kind: RuntimeNoticeKind::Stop, detail: "runtime executor stopped" }
         }
         // Running → Running (self-loop)
         transition StopRuntimeExecutorRunning {
@@ -946,7 +949,7 @@ machine! {
                 self.silent_intent_overrides = EmptySet;
             }
             to Running
-            emit RuntimeNotice { kind: "stop", detail: "runtime executor stopped" }
+            emit RuntimeNotice { kind: RuntimeNoticeKind::Stop, detail: "runtime executor stopped" }
         }
 
         // 17. Destroy: from all non-Destroyed → Destroyed
@@ -2587,6 +2590,21 @@ pub enum WorkOrigin {
     /// Canonical admission entrypoint fired by the runtime control plane
     /// with no surface-level transport or work-lane label.
     Ingest,
+}
+
+/// Typed runtime notice classifier for the `RuntimeNotice` effect (catalog
+/// DSL twin). Closed set of per-transition runtime lifecycle markers
+/// emitted by the runtime-control plane so the shell dispatcher matches
+/// exhaustively on a typed discriminant instead of comparing string
+/// literals.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
+pub enum RuntimeNoticeKind {
+    #[default]
+    Drain,
+    Reset,
+    Stop,
+    Exit,
+    Recover,
 }
 
 // =====================================================================

--- a/meerkat-runtime/src/meerkat_machine/dsl.rs
+++ b/meerkat-runtime/src/meerkat_machine/dsl.rs
@@ -1022,6 +1022,36 @@ pub enum PreRunPhase {
     Retired,
 }
 
+/// Typed runtime notice classifier for the `RuntimeNotice` effect. Closed set
+/// of per-transition runtime lifecycle markers (drain exited, runtime reset,
+/// executor stopped/exited, runtime recovered) emitted by the runtime-control
+/// plane. Replaces the former literal-string `kind` field on `RuntimeNotice`
+/// so the shell dispatcher matches exhaustively on a typed discriminant
+/// instead of comparing string literals. `detail` stays `String` — it's a
+/// free-form diagnostic message that accompanies the kind.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
+pub enum RuntimeNoticeKind {
+    #[default]
+    Drain,
+    Reset,
+    Stop,
+    Exit,
+    Recover,
+}
+
+/// Typed reason classifier for the `TurnRunCancelled` effect. Closed set of
+/// cancellation-observation origins emitted when a turn's cancellation
+/// request lands at an observable boundary. Replaces the former literal-
+/// string `reason` field on `TurnRunCancelled`. Only one origin is emitted
+/// today (`Observed`, fired by the `CancellationObserved` transition), but
+/// this remains a closed classifier not a free-form message — future
+/// cancellation origins extend the enum rather than reintroducing strings.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
+pub enum TurnCancellationReason {
+    #[default]
+    Observed,
+}
+
 /// Typed base lifecycle state for an external tool surface. Closed mirror of
 /// [`meerkat_core::tool_scope::ExternalToolSurfaceBaseState`] — replaces the
 /// former literal-string values in `surface_base_state`.
@@ -1946,14 +1976,24 @@ machine! {
             RuntimeDestroyed { agent_runtime_id: AgentRuntimeId, fence_token: FenceToken },
             TurnRunStarted { run_id: RunId },
             TurnBoundaryApplied { run_id: RunId, boundary_sequence: u64 },
-            TurnRunCompleted { run_id: RunId, outcome: String },
+            TurnRunCompleted { run_id: RunId, outcome: Enum<TurnTerminalOutcome> },
+            // `error` is a free-form error message paired with a terminal
+            // outcome; it is not a closed classifier (its values include
+            // variable error strings bubbled up from extraction / LLM
+            // failures via `TurnFailed { error }`). Kept as `String`.
             TurnRunFailed { run_id: RunId, error: String },
-            TurnRunCancelled { run_id: RunId, reason: String },
+            TurnRunCancelled { run_id: RunId, reason: Enum<TurnCancellationReason> },
             TurnCheckCompaction,
             RequestCancellationAtBoundary,
             WakeInterrupt,
             CommittedVisibleSetPublished { revision: u64 },
-            RuntimeNotice { kind: String, detail: String },
+            // `kind` is a closed classifier of runtime lifecycle markers;
+            // `detail` stays `String` because it's a free-form diagnostic
+            // message paired with the kind (e.g. "runtime executor stopped",
+            // "runtime recovered"). Detail strings are not matched on by
+            // consumers — they surface through structured logging / traces
+            // as human-readable context.
+            RuntimeNotice { kind: Enum<RuntimeNoticeKind>, detail: String },
             // Absorbed effects
             ResolveAdmission,
             SubmitAdmittedIngressEffect,
@@ -1982,15 +2022,26 @@ machine! {
             CollectCompletedResult,
             EnqueueClassifiedEntry,
             SpawnDrainTask,
+            // `surface_id` stays `String`: it's an opaque surface identity,
+            // not a closed classifier. `operation` is the same typed
+            // discriminant used on `EmitExternalToolDelta` and on the
+            // `surface_last_delta_operation` state map.
             ScheduleSurfaceCompletion {
                 surface_id: String,
-                operation: String,
+                operation: Enum<ExternalToolSurfaceDeltaOperation>,
                 pending_task_sequence: u64,
                 staged_intent_sequence: u64,
                 applied_at_turn: u64,
             },
             RefreshVisibleSurfaceSet,
-            EmitExternalToolDelta { surface_id: String, operation: String, phase: String },
+            // `surface_id` stays `String` (opaque surface identity). Both
+            // `operation` and `phase` are closed classifiers mirrored from
+            // `meerkat-core::tool_scope`.
+            EmitExternalToolDelta {
+                surface_id: String,
+                operation: Enum<ExternalToolSurfaceDeltaOperation>,
+                phase: Enum<ExternalToolSurfaceDeltaPhase>,
+            },
             CloseSurfaceConnection { surface_id: String },
             RejectSurfaceCall { surface_id: String, reason: String },
             // Realtime-attachment effects.
@@ -2381,7 +2432,7 @@ machine! {
             guard "session_registered" { self.session_id != None }
             update {}
             to Idle
-            emit RuntimeNotice { kind: "drain", detail: "drain exited" }
+            emit RuntimeNotice { kind: RuntimeNoticeKind::Drain, detail: "drain exited" }
         }
 
         // 10. InterruptCurrentRun: Attached + Running self-loops
@@ -2563,7 +2614,7 @@ machine! {
                 self.silent_intent_overrides = EmptySet;
             }
             to Idle
-            emit RuntimeNotice { kind: "reset", detail: "runtime reset" }
+            emit RuntimeNotice { kind: RuntimeNoticeKind::Reset, detail: "runtime reset" }
         }
 
         // 16. StopRuntimeExecutor: different behavior per phase
@@ -2581,7 +2632,7 @@ machine! {
                 self.silent_intent_overrides = EmptySet;
             }
             to Stopped
-            emit RuntimeNotice { kind: "stop", detail: "runtime executor stopped" }
+            emit RuntimeNotice { kind: RuntimeNoticeKind::Stop, detail: "runtime executor stopped" }
         }
         // Attached → Attached (self-loop)
         transition StopRuntimeExecutorAttached {
@@ -2591,7 +2642,7 @@ machine! {
                 self.silent_intent_overrides = EmptySet;
             }
             to Attached
-            emit RuntimeNotice { kind: "stop", detail: "runtime executor stopped" }
+            emit RuntimeNotice { kind: RuntimeNoticeKind::Stop, detail: "runtime executor stopped" }
         }
         // Running → Running (self-loop)
         transition StopRuntimeExecutorRunning {
@@ -2601,7 +2652,7 @@ machine! {
                 self.silent_intent_overrides = EmptySet;
             }
             to Running
-            emit RuntimeNotice { kind: "stop", detail: "runtime executor stopped" }
+            emit RuntimeNotice { kind: RuntimeNoticeKind::Stop, detail: "runtime executor stopped" }
         }
 
         // RuntimeExecutorExited: async finalization of the stop-runtime path.
@@ -2618,7 +2669,7 @@ machine! {
                 self.silent_intent_overrides = EmptySet;
             }
             to Stopped
-            emit RuntimeNotice { kind: "exit", detail: "runtime executor exited" }
+            emit RuntimeNotice { kind: RuntimeNoticeKind::Exit, detail: "runtime executor exited" }
         }
         transition RuntimeExecutorExitedFromRunning {
             on input RuntimeExecutorExited
@@ -2629,7 +2680,7 @@ machine! {
                 self.silent_intent_overrides = EmptySet;
             }
             to Stopped
-            emit RuntimeNotice { kind: "exit", detail: "runtime executor exited" }
+            emit RuntimeNotice { kind: RuntimeNoticeKind::Exit, detail: "runtime executor exited" }
         }
         transition RuntimeExecutorExitedFromIdle {
             on input RuntimeExecutorExited
@@ -2638,7 +2689,7 @@ machine! {
                 self.silent_intent_overrides = EmptySet;
             }
             to Stopped
-            emit RuntimeNotice { kind: "exit", detail: "runtime executor exited" }
+            emit RuntimeNotice { kind: RuntimeNoticeKind::Exit, detail: "runtime executor exited" }
         }
         transition RuntimeExecutorExitedFromRetired {
             on input RuntimeExecutorExited
@@ -2649,7 +2700,7 @@ machine! {
                 self.silent_intent_overrides = EmptySet;
             }
             to Stopped
-            emit RuntimeNotice { kind: "exit", detail: "runtime executor exited" }
+            emit RuntimeNotice { kind: RuntimeNoticeKind::Exit, detail: "runtime executor exited" }
         }
         transition RuntimeExecutorExitedFromStopped {
             on input RuntimeExecutorExited
@@ -2685,35 +2736,35 @@ machine! {
             guard { self.lifecycle_phase == Phase::Initializing }
             update {}
             to Initializing
-            emit RuntimeNotice { kind: "recover", detail: "runtime recovered" }
+            emit RuntimeNotice { kind: RuntimeNoticeKind::Recover, detail: "runtime recovered" }
         }
         transition RecoverIdle {
             on input Recover
             guard { self.lifecycle_phase == Phase::Idle }
             update {}
             to Idle
-            emit RuntimeNotice { kind: "recover", detail: "runtime recovered" }
+            emit RuntimeNotice { kind: RuntimeNoticeKind::Recover, detail: "runtime recovered" }
         }
         transition RecoverAttached {
             on input Recover
             guard { self.lifecycle_phase == Phase::Attached }
             update {}
             to Attached
-            emit RuntimeNotice { kind: "recover", detail: "runtime recovered" }
+            emit RuntimeNotice { kind: RuntimeNoticeKind::Recover, detail: "runtime recovered" }
         }
         transition RecoverRetired {
             on input Recover
             guard { self.lifecycle_phase == Phase::Retired }
             update {}
             to Retired
-            emit RuntimeNotice { kind: "recover", detail: "runtime recovered" }
+            emit RuntimeNotice { kind: RuntimeNoticeKind::Recover, detail: "runtime recovered" }
         }
         transition RecoverStopped {
             on input Recover
             guard { self.lifecycle_phase == Phase::Stopped }
             update {}
             to Stopped
-            emit RuntimeNotice { kind: "recover", detail: "runtime recovered" }
+            emit RuntimeNotice { kind: RuntimeNoticeKind::Recover, detail: "runtime recovered" }
         }
 
         // =====================================================================
@@ -3366,7 +3417,7 @@ machine! {
             }
             to Running
             emit TurnBoundaryApplied { run_id: self.current_run_id.get("value"), boundary_sequence: self.boundary_count }
-            emit TurnRunCompleted { run_id: self.current_run_id.get("value"), outcome: "Completed" }
+            emit TurnRunCompleted { run_id: self.current_run_id.get("value"), outcome: TurnTerminalOutcome::Completed }
             emit TurnCheckCompaction
         }
 
@@ -3479,7 +3530,7 @@ machine! {
             }
             to Running
             emit TurnBoundaryApplied { run_id: self.current_run_id.get("value"), boundary_sequence: self.boundary_count }
-            emit TurnRunCompleted { run_id: self.current_run_id.get("value"), outcome: "Completed" }
+            emit TurnRunCompleted { run_id: self.current_run_id.get("value"), outcome: TurnTerminalOutcome::Completed }
             emit TurnCheckCompaction
         }
 
@@ -3511,7 +3562,7 @@ machine! {
                 self.terminal_outcome = Some(TurnTerminalOutcome::Completed);
             }
             to Running
-            emit TurnRunCompleted { run_id: self.current_run_id.get("value"), outcome: "Completed" }
+            emit TurnRunCompleted { run_id: self.current_run_id.get("value"), outcome: TurnTerminalOutcome::Completed }
             emit TurnCheckCompaction
         }
 
@@ -3617,7 +3668,7 @@ machine! {
                 self.terminal_outcome = Some(TurnTerminalOutcome::Cancelled);
             }
             to Running
-            emit TurnRunCancelled { run_id: self.current_run_id.get("value"), reason: "observed" }
+            emit TurnRunCancelled { run_id: self.current_run_id.get("value"), reason: TurnCancellationReason::Observed }
         }
 
         transition AcknowledgeTerminal {

--- a/specs/compositions/meerkat_mob_seam/model.tla
+++ b/specs/compositions/meerkat_mob_seam/model.tla
@@ -943,7 +943,7 @@ meerkat_NotifyDrainExitedIdle(arg_reason) ==
        /\ observed_inputs' = observed_inputs
        /\ pending_routes' = pending_routes
        /\ delivered_routes' = delivered_routes
-       /\ emitted_effects' = emitted_effects \cup { [machine |-> "meerkat", variant |-> "RuntimeNotice", payload |-> [detail |-> "drain exited", kind |-> "drain"], effect_id |-> (model_step_count + 1), source_transition |-> "NotifyDrainExitedIdle"] }
+       /\ emitted_effects' = emitted_effects \cup { [machine |-> "meerkat", variant |-> "RuntimeNotice", payload |-> [detail |-> "drain exited", kind |-> "Drain"], effect_id |-> (model_step_count + 1), source_transition |-> "NotifyDrainExitedIdle"] }
        /\ observed_transitions' = observed_transitions \cup {[machine |-> "meerkat", transition |-> "NotifyDrainExitedIdle", actor |-> "meerkat_kernel", step |-> (model_step_count + 1), from_phase |-> meerkat_phase, to_phase |-> "Idle"]}
        /\ model_step_count' = model_step_count + 1
 
@@ -962,7 +962,7 @@ meerkat_NotifyDrainExitedAttached(arg_reason) ==
        /\ observed_inputs' = observed_inputs
        /\ pending_routes' = pending_routes
        /\ delivered_routes' = delivered_routes
-       /\ emitted_effects' = emitted_effects \cup { [machine |-> "meerkat", variant |-> "RuntimeNotice", payload |-> [detail |-> "drain exited", kind |-> "drain"], effect_id |-> (model_step_count + 1), source_transition |-> "NotifyDrainExitedAttached"] }
+       /\ emitted_effects' = emitted_effects \cup { [machine |-> "meerkat", variant |-> "RuntimeNotice", payload |-> [detail |-> "drain exited", kind |-> "Drain"], effect_id |-> (model_step_count + 1), source_transition |-> "NotifyDrainExitedAttached"] }
        /\ observed_transitions' = observed_transitions \cup {[machine |-> "meerkat", transition |-> "NotifyDrainExitedAttached", actor |-> "meerkat_kernel", step |-> (model_step_count + 1), from_phase |-> meerkat_phase, to_phase |-> "Attached"]}
        /\ model_step_count' = model_step_count + 1
 
@@ -981,7 +981,7 @@ meerkat_NotifyDrainExitedRunning(arg_reason) ==
        /\ observed_inputs' = observed_inputs
        /\ pending_routes' = pending_routes
        /\ delivered_routes' = delivered_routes
-       /\ emitted_effects' = emitted_effects \cup { [machine |-> "meerkat", variant |-> "RuntimeNotice", payload |-> [detail |-> "drain exited", kind |-> "drain"], effect_id |-> (model_step_count + 1), source_transition |-> "NotifyDrainExitedRunning"] }
+       /\ emitted_effects' = emitted_effects \cup { [machine |-> "meerkat", variant |-> "RuntimeNotice", payload |-> [detail |-> "drain exited", kind |-> "Drain"], effect_id |-> (model_step_count + 1), source_transition |-> "NotifyDrainExitedRunning"] }
        /\ observed_transitions' = observed_transitions \cup {[machine |-> "meerkat", transition |-> "NotifyDrainExitedRunning", actor |-> "meerkat_kernel", step |-> (model_step_count + 1), from_phase |-> meerkat_phase, to_phase |-> "Running"]}
        /\ model_step_count' = model_step_count + 1
 
@@ -1000,7 +1000,7 @@ meerkat_NotifyDrainExitedRetired(arg_reason) ==
        /\ observed_inputs' = observed_inputs
        /\ pending_routes' = pending_routes
        /\ delivered_routes' = delivered_routes
-       /\ emitted_effects' = emitted_effects \cup { [machine |-> "meerkat", variant |-> "RuntimeNotice", payload |-> [detail |-> "drain exited", kind |-> "drain"], effect_id |-> (model_step_count + 1), source_transition |-> "NotifyDrainExitedRetired"] }
+       /\ emitted_effects' = emitted_effects \cup { [machine |-> "meerkat", variant |-> "RuntimeNotice", payload |-> [detail |-> "drain exited", kind |-> "Drain"], effect_id |-> (model_step_count + 1), source_transition |-> "NotifyDrainExitedRetired"] }
        /\ observed_transitions' = observed_transitions \cup {[machine |-> "meerkat", transition |-> "NotifyDrainExitedRetired", actor |-> "meerkat_kernel", step |-> (model_step_count + 1), from_phase |-> meerkat_phase, to_phase |-> "Retired"]}
        /\ model_step_count' = model_step_count + 1
 
@@ -1019,7 +1019,7 @@ meerkat_NotifyDrainExitedStopped(arg_reason) ==
        /\ observed_inputs' = observed_inputs
        /\ pending_routes' = pending_routes
        /\ delivered_routes' = delivered_routes
-       /\ emitted_effects' = emitted_effects \cup { [machine |-> "meerkat", variant |-> "RuntimeNotice", payload |-> [detail |-> "drain exited", kind |-> "drain"], effect_id |-> (model_step_count + 1), source_transition |-> "NotifyDrainExitedStopped"] }
+       /\ emitted_effects' = emitted_effects \cup { [machine |-> "meerkat", variant |-> "RuntimeNotice", payload |-> [detail |-> "drain exited", kind |-> "Drain"], effect_id |-> (model_step_count + 1), source_transition |-> "NotifyDrainExitedStopped"] }
        /\ observed_transitions' = observed_transitions \cup {[machine |-> "meerkat", transition |-> "NotifyDrainExitedStopped", actor |-> "meerkat_kernel", step |-> (model_step_count + 1), from_phase |-> meerkat_phase, to_phase |-> "Stopped"]}
        /\ model_step_count' = model_step_count + 1
 
@@ -1278,7 +1278,7 @@ meerkat_Reset ==
        /\ observed_inputs' = observed_inputs
        /\ pending_routes' = pending_routes
        /\ delivered_routes' = delivered_routes
-       /\ emitted_effects' = emitted_effects \cup { [machine |-> "meerkat", variant |-> "RuntimeNotice", payload |-> [detail |-> "runtime reset", kind |-> "reset"], effect_id |-> (model_step_count + 1), source_transition |-> "Reset"] }
+       /\ emitted_effects' = emitted_effects \cup { [machine |-> "meerkat", variant |-> "RuntimeNotice", payload |-> [detail |-> "runtime reset", kind |-> "Reset"], effect_id |-> (model_step_count + 1), source_transition |-> "Reset"] }
        /\ observed_transitions' = observed_transitions \cup {[machine |-> "meerkat", transition |-> "Reset", actor |-> "meerkat_kernel", step |-> (model_step_count + 1), from_phase |-> meerkat_phase, to_phase |-> "Idle"]}
        /\ model_step_count' = model_step_count + 1
 
@@ -1298,7 +1298,7 @@ meerkat_StopRuntimeExecutorUnbound ==
        /\ observed_inputs' = observed_inputs
        /\ pending_routes' = pending_routes
        /\ delivered_routes' = delivered_routes
-       /\ emitted_effects' = emitted_effects \cup { [machine |-> "meerkat", variant |-> "RuntimeNotice", payload |-> [detail |-> "runtime executor stopped", kind |-> "stop"], effect_id |-> (model_step_count + 1), source_transition |-> "StopRuntimeExecutorUnbound"] }
+       /\ emitted_effects' = emitted_effects \cup { [machine |-> "meerkat", variant |-> "RuntimeNotice", payload |-> [detail |-> "runtime executor stopped", kind |-> "Stop"], effect_id |-> (model_step_count + 1), source_transition |-> "StopRuntimeExecutorUnbound"] }
        /\ observed_transitions' = observed_transitions \cup {[machine |-> "meerkat", transition |-> "StopRuntimeExecutorUnbound", actor |-> "meerkat_kernel", step |-> (model_step_count + 1), from_phase |-> meerkat_phase, to_phase |-> "Stopped"]}
        /\ model_step_count' = model_step_count + 1
 
@@ -1316,7 +1316,7 @@ meerkat_StopRuntimeExecutorAttached ==
        /\ observed_inputs' = observed_inputs
        /\ pending_routes' = pending_routes
        /\ delivered_routes' = delivered_routes
-       /\ emitted_effects' = emitted_effects \cup { [machine |-> "meerkat", variant |-> "RuntimeNotice", payload |-> [detail |-> "runtime executor stopped", kind |-> "stop"], effect_id |-> (model_step_count + 1), source_transition |-> "StopRuntimeExecutorAttached"] }
+       /\ emitted_effects' = emitted_effects \cup { [machine |-> "meerkat", variant |-> "RuntimeNotice", payload |-> [detail |-> "runtime executor stopped", kind |-> "Stop"], effect_id |-> (model_step_count + 1), source_transition |-> "StopRuntimeExecutorAttached"] }
        /\ observed_transitions' = observed_transitions \cup {[machine |-> "meerkat", transition |-> "StopRuntimeExecutorAttached", actor |-> "meerkat_kernel", step |-> (model_step_count + 1), from_phase |-> meerkat_phase, to_phase |-> "Attached"]}
        /\ model_step_count' = model_step_count + 1
 
@@ -1334,7 +1334,7 @@ meerkat_StopRuntimeExecutorRunning ==
        /\ observed_inputs' = observed_inputs
        /\ pending_routes' = pending_routes
        /\ delivered_routes' = delivered_routes
-       /\ emitted_effects' = emitted_effects \cup { [machine |-> "meerkat", variant |-> "RuntimeNotice", payload |-> [detail |-> "runtime executor stopped", kind |-> "stop"], effect_id |-> (model_step_count + 1), source_transition |-> "StopRuntimeExecutorRunning"] }
+       /\ emitted_effects' = emitted_effects \cup { [machine |-> "meerkat", variant |-> "RuntimeNotice", payload |-> [detail |-> "runtime executor stopped", kind |-> "Stop"], effect_id |-> (model_step_count + 1), source_transition |-> "StopRuntimeExecutorRunning"] }
        /\ observed_transitions' = observed_transitions \cup {[machine |-> "meerkat", transition |-> "StopRuntimeExecutorRunning", actor |-> "meerkat_kernel", step |-> (model_step_count + 1), from_phase |-> meerkat_phase, to_phase |-> "Running"]}
        /\ model_step_count' = model_step_count + 1
 

--- a/specs/machines/meerkat_machine/contract.md
+++ b/specs/machines/meerkat_machine/contract.md
@@ -159,7 +159,7 @@ _Generated from the Rust machine catalog. Do not edit by hand._
 - `RequestCancellationAtBoundary`
 - `WakeInterrupt`
 - `CommittedVisibleSetPublished`(revision: u64)
-- `RuntimeNotice`(kind: String, detail: String)
+- `RuntimeNotice`(kind: RuntimeNoticeKind, detail: String)
 - `ResolveAdmission`
 - `SubmitAdmittedIngressEffect`
 - `SubmitRunPrimitive`


### PR DESCRIPTION
## Summary

Round 3 wave 2a of the dogma cleanup: retypes closed-set discriminant fields on `MeerkatMachineEffect` from `String` to typed `Enum<T>`, so effect consumers match exhaustively on typed discriminants instead of comparing string literals.

### Retyped fields

| Effect | Field | New type | Source |
|---|---|---|---|
| `TurnRunCompleted` | `outcome` | `Enum<TurnTerminalOutcome>` | reuses U-B's DSL-local mirror of `meerkat-core::turn_execution_authority::TurnTerminalOutcome` |
| `TurnRunCancelled` | `reason` | `Enum<TurnCancellationReason>` | new DSL-local classifier (see below) |
| `RuntimeNotice` | `kind` | `Enum<RuntimeNoticeKind>` | new DSL-local enum: `Drain`/`Reset`/`Stop`/`Exit`/`Recover` |
| `EmitExternalToolDelta` | `operation` | `Enum<ExternalToolSurfaceDeltaOperation>` | reuses U-B's DSL-local mirror |
| `EmitExternalToolDelta` | `phase` | `Enum<ExternalToolSurfaceDeltaPhase>` | reuses U-B's DSL-local mirror |
| `ScheduleSurfaceCompletion` | `operation` | `Enum<ExternalToolSurfaceDeltaOperation>` | same typed discriminant |

### Finding on `TurnRunCancelled.reason`

**Retyped.** The only emit site today fires `"observed"` from the `CancellationObserved` transition — a closed-set discriminant with a single member. I introduced a dedicated `TurnCancellationReason` enum with one variant (`Observed`) and retyped the field. Rationale: closed classifiers must be typed regardless of cardinality. If cancellation origins grow (e.g. shutdown-driven, timeout-driven), future variants extend the enum rather than reintroducing strings.

### Kept as `String` (free-form, not a closed classifier)

- `TurnRunFailed.error` — emit sites carry both closed-set labels (`TurnLimitReached`, `BudgetExhausted`, `TimeBudgetExceeded`, `ExtractionExhausted`) *and* free-form `error: error` variable messages bubbled up from extraction / LLM failures via `TurnFailed { error }`. Documented inline.
- `RuntimeNotice.detail` — free-form diagnostic message paired with the kind (e.g. `"runtime executor stopped"`), never matched on by consumers. Documented inline.
- `EmitExternalToolDelta.surface_id`, `ScheduleSurfaceCompletion.surface_id`, `CloseSurfaceConnection.surface_id`, `RejectSurfaceCall.surface_id` — opaque surface identities, not discriminants.

### Deferred to a follow-up (out of scope)

`operation_id: String` fields on `SubmitOpEvent`, `NotifyOpWatcher`, `ExposeOperationPeer`, `RetainTerminalRecord`, `EvictCompletedRecord`: the DSL's `OperationId` is a newtype `String` wrapper at the DSL layer, and threading it through every effect consumer is a larger ripple than this wave should carry.

### Catalog twin

`meerkat-machine-schema/src/catalog/dsl/meerkat_machine.rs` retyped for `RuntimeNotice.kind` and gained a mirror `RuntimeNoticeKind` enum. `ScheduleSurfaceCompletion` and `EmitExternalToolDelta` remain unit variants in the catalog (catalog owns only what TLC cares about).

### Generated artifacts

`specs/compositions/meerkat_mob_seam/model.tla` and `specs/machines/meerkat_machine/contract.md` refreshed via `make machine-codegen` — the TLA+ model now serializes `kind |-> "Drain"` (etc.) instead of `"drain"`.

## Test plan

- [x] `./scripts/repo-cargo fmt --all -- --check`
- [x] `./scripts/repo-cargo clippy --workspace --all-targets -- -D warnings`
- [x] `./scripts/repo-cargo check -p meerkat-core -p meerkat-runtime -p meerkat-session -p meerkat-rpc`
- [x] `make machine-codegen && make machine-verify && make machine-check-drift`
- [x] `./scripts/repo-cargo nextest run -p meerkat-runtime` — 579 tests, all passed

No wire/SDK impact; no `make regen-schemas` needed.

Precedent: U-B (#296, `94e95f861`) is the pattern-match style this wave follows.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>