### PR TITLE
fix(smoke): recover stale live sessions and web respawn parsing

### DIFF
--- a/meerkat-session/src/persistent.rs
+++ b/meerkat-session/src/persistent.rs
@@ -476,6 +476,85 @@ impl<B: SessionAgentBuilder + 'static> PersistentSessionService<B> {
         Ok(true)
     }
 
+    async fn recover_live_session_from_store_if_needed(
+        &self,
+        id: &SessionId,
+    ) -> Result<bool, SessionError> {
+        if self.inner.has_live_session(id).await? {
+            return Ok(false);
+        }
+
+        let Some(stored) = self.load_authoritative_session_base(id).await? else {
+            return Ok(false);
+        };
+
+        let runtime_build_mode = if let Some(provider) = &self.runtime_bindings_provider {
+            (provider)(id.clone())
+                .await
+                .map(meerkat_core::RuntimeBuildMode::SessionOwned)
+        } else if let Some(provider) = &self.ops_lifecycle_provider {
+            (provider)(id).await.map(|ops_lifecycle| {
+                meerkat_core::RuntimeBuildMode::SessionOwned(
+                    meerkat_core::SessionRuntimeBindings {
+                        session_id: id.clone(),
+                        epoch_id: meerkat_core::RuntimeEpochId::new(),
+                        ops_lifecycle,
+                        cursor_state: Arc::new(meerkat_core::EpochCursorState::new()),
+                        tool_visibility_owner: Arc::new(
+                            meerkat_core::LocalToolVisibilityOwner::new(),
+                        ),
+                        turn_state: Arc::new(meerkat_runtime::RuntimeTurnStateHandle::ephemeral()),
+                        comms_drain: Arc::new(
+                            meerkat_runtime::RuntimeCommsDrainHandle::ephemeral(),
+                        ),
+                        external_tool_surface: Arc::new(
+                            meerkat_runtime::RuntimeExternalToolSurfaceHandle::ephemeral(),
+                        ),
+                        peer_comms: Arc::new(meerkat_runtime::RuntimePeerCommsHandle::ephemeral()),
+                        session_admission: Arc::new(
+                            meerkat_runtime::RuntimeSessionAdmissionHandle::ephemeral(),
+                        ),
+                        auth_lease: Arc::new(meerkat_runtime::RuntimeAuthLeaseHandle::ephemeral()),
+                        mcp_server_lifecycle: Arc::new(
+                            meerkat_runtime::RuntimeMcpServerLifecycleHandle::ephemeral(),
+                        ),
+                        peer_interaction: None,
+                        session_context: Arc::new(
+                            meerkat_runtime::RuntimeSessionContextHandle::ephemeral(),
+                        ),
+                        session_claim_handle:
+                            meerkat_core::handles::DefaultSessionClaimRegistry::global()
+                                as Arc<dyn meerkat_core::handles::SessionClaimHandle>,
+                        interaction_stream: None,
+                        realtime_product_turn: Arc::new(
+                            meerkat_runtime::RuntimeRealtimeProductTurnHandle::ephemeral(),
+                        ),
+                    },
+                )
+            })
+        } else {
+            None
+        };
+
+        let recovered = build_recovered_session(
+            stored,
+            &SurfaceSessionRecoveryOverrides::default(),
+            SurfaceSessionRecoveryContext {
+                runtime_build_mode,
+                ..Default::default()
+            },
+        )
+        .map_err(|error| {
+            SessionError::Agent(AgentError::InternalError(format!(
+                "failed to recover stored-only session for start_turn: {error}"
+            )))
+        })?;
+
+        self.create_session(recovered.into_deferred_create_request())
+            .await?;
+        Ok(true)
+    }
+
     pub async fn export_live_session(&self, id: &SessionId) -> Result<Session, SessionError> {
         self.export_session_with_labels(id).await
     }
@@ -1102,6 +1181,7 @@ impl<B: SessionAgentBuilder + 'static> SessionService for PersistentSessionServi
         req: StartTurnRequest,
     ) -> Result<RunResult, SessionError> {
         let _ = self.discard_stale_live_session_if_needed(id).await?;
+        let _ = self.recover_live_session_from_store_if_needed(id).await?;
         let result = match self.inner.start_turn(id, req).await {
             Ok(result) => result,
             Err(error) => {
@@ -3924,6 +4004,51 @@ mod tests {
             persisted_build.recoverable_tool_defs[0].name,
             "persisted_tool"
         );
+    }
+
+    #[tokio::test]
+    async fn test_start_turn_recovers_after_discarding_stale_live_session() {
+        let store: Arc<dyn SessionStore> = Arc::new(MemoryStore::new());
+        let service = PersistentSessionService::new(
+            DummyBuilder,
+            4,
+            Arc::clone(&store),
+            None,
+            memory_blob_store(),
+        );
+
+        let created = service
+            .create_session(create_request_with_metadata(
+                "hello",
+                InitialTurnPolicy::Defer,
+            ))
+            .await
+            .expect("create deferred session");
+        let id = created.session_id;
+
+        let mut stored = store
+            .load(&id)
+            .await
+            .expect("load should succeed")
+            .expect("persisted session should exist");
+        tokio::time::sleep(std::time::Duration::from_millis(5)).await;
+        stored.touch();
+        store
+            .save(&stored)
+            .await
+            .expect("save updated stored session");
+
+        let result = service
+            .start_turn(&id, start_turn_request("follow up"))
+            .await
+            .expect("start_turn should recover after stale live discard");
+        assert_eq!(result.session_id, id);
+
+        let live = service
+            .export_live_session(&id)
+            .await
+            .expect("recovered session should be live again");
+        assert_eq!(live.id(), &id);
     }
 
     #[tokio::test]

--- a/meerkat-session/src/persistent.rs
+++ b/meerkat-session/src/persistent.rs
@@ -224,6 +224,10 @@ pub struct PersistentSessionService<B: SessionAgentBuilder> {
     /// archived snapshot -- mutual exclusion prevents a concurrent checkpoint
     /// from overwriting the archived row with a live one.
     checkpointer_gates: Mutex<HashMap<SessionId, Arc<CheckpointerGate>>>,
+    /// Gates lazy live-session recovery and archive against each other so a
+    /// stored-only session is rebuilt at most once and archived snapshots
+    /// cannot become writable again through rehydration races.
+    recovery_gates: Mutex<HashMap<SessionId, Arc<Mutex<()>>>>,
     /// Optional provider for ops lifecycle registries used during lazy session
     /// rebuilds. When set, lazy-rebuilt sessions bind to the canonical registry
     /// instead of allocating an orphaned fallback.
@@ -480,6 +484,9 @@ impl<B: SessionAgentBuilder + 'static> PersistentSessionService<B> {
         &self,
         id: &SessionId,
     ) -> Result<bool, SessionError> {
+        let recovery_gate = self.recovery_gate_for_session(id).await;
+        let _recovery_guard = recovery_gate.lock().await;
+
         if self.inner.has_live_session(id).await? {
             return Ok(false);
         }
@@ -487,6 +494,9 @@ impl<B: SessionAgentBuilder + 'static> PersistentSessionService<B> {
         let Some(stored) = self.load_authoritative_session_base(id).await? else {
             return Ok(false);
         };
+        self.reject_if_archived_session(id, &stored)
+            .await
+            .map_err(control_error_into_session_error)?;
 
         let runtime_build_mode = if let Some(provider) = &self.runtime_bindings_provider {
             (provider)(id.clone())
@@ -550,9 +560,19 @@ impl<B: SessionAgentBuilder + 'static> PersistentSessionService<B> {
             )))
         })?;
 
-        self.create_session(recovered.into_deferred_create_request())
-            .await?;
-        Ok(true)
+        match self
+            .create_session(recovered.into_deferred_create_request())
+            .await
+        {
+            Ok(_) => Ok(true),
+            Err(SessionError::Agent(AgentError::InternalError(message)))
+                if message.starts_with("Duplicate session ID generated:")
+                    && self.inner.has_live_session(id).await? =>
+            {
+                Ok(false)
+            }
+            Err(error) => Err(error),
+        }
     }
 
     pub async fn export_live_session(&self, id: &SessionId) -> Result<Session, SessionError> {
@@ -671,6 +691,7 @@ impl<B: SessionAgentBuilder + 'static> PersistentSessionService<B> {
             archived_sessions: Mutex::new(IndexMap::new()),
             archived_history_capacity: max_sessions.max(1),
             checkpointer_gates: Mutex::new(HashMap::new()),
+            recovery_gates: Mutex::new(HashMap::new()),
             ops_lifecycle_provider: None,
             runtime_bindings_provider: None,
         }
@@ -758,6 +779,15 @@ impl<B: SessionAgentBuilder + 'static> PersistentSessionService<B> {
     async fn existing_gate_for_session(&self, id: &SessionId) -> Option<Arc<CheckpointerGate>> {
         let gates = self.checkpointer_gates.lock().await;
         gates.get(id).cloned()
+    }
+
+    async fn recovery_gate_for_session(&self, id: &SessionId) -> Arc<Mutex<()>> {
+        let mut gates = self.recovery_gates.lock().await;
+        Arc::clone(
+            gates
+                .entry(id.clone())
+                .or_insert_with(|| Arc::new(Mutex::new(()))),
+        )
     }
 
     async fn cached_archived_session(&self, id: &SessionId) -> Option<Session> {
@@ -1359,6 +1389,9 @@ impl<B: SessionAgentBuilder + 'static> SessionService for PersistentSessionServi
     }
 
     async fn archive(&self, id: &SessionId) -> Result<(), SessionError> {
+        let recovery_gate = self.recovery_gate_for_session(id).await;
+        let _recovery_guard = recovery_gate.lock().await;
+
         let archived_snapshot = match self.export_session_with_labels(id).await {
             Ok(session) => Some(session),
             Err(SessionError::NotFound { .. }) => self.load_authoritative_session_base(id).await?,

--- a/meerkat-session/tests/regression_lifecycle.rs
+++ b/meerkat-session/tests/regression_lifecycle.rs
@@ -1451,3 +1451,113 @@ async fn persistent_start_turn_recovers_after_discarding_stale_live_session() {
         "recovered session should be live again after start_turn",
     );
 }
+
+#[cfg(all(feature = "session-store", not(target_arch = "wasm32")))]
+#[tokio::test]
+async fn persistent_start_turn_rejects_archived_stored_only_session() {
+    let store: Arc<dyn SessionStore> = Arc::new(MemoryStore::new());
+    let service = PersistentSessionService::new(
+        MockAgentBuilder,
+        4,
+        Arc::clone(&store),
+        None,
+        Arc::new(meerkat_store::MemoryBlobStore::new()),
+    );
+
+    let created = service
+        .create_session(create_req_deferred("seed"))
+        .await
+        .expect("create deferred session");
+    let session_id = created.session_id.clone();
+
+    service
+        .archive(&session_id)
+        .await
+        .expect("archive should succeed");
+
+    let err = service
+        .start_turn(&session_id, turn_req("after archive"))
+        .await
+        .expect_err("archived stored-only sessions must stay read-only");
+    assert_eq!(err.code(), "SESSION_NOT_FOUND");
+    assert!(
+        !service
+            .has_live_session(&session_id)
+            .await
+            .expect("live session query should succeed"),
+        "archived session must not be recreated as live",
+    );
+}
+
+#[cfg(all(feature = "session-store", not(target_arch = "wasm32")))]
+#[tokio::test]
+async fn persistent_concurrent_start_turn_recovery_never_surfaces_duplicate_id() {
+    let store: Arc<dyn SessionStore> = Arc::new(MemoryStore::new());
+    let service = Arc::new(PersistentSessionService::new(
+        MockAgentBuilder,
+        4,
+        Arc::clone(&store),
+        None,
+        Arc::new(meerkat_store::MemoryBlobStore::new()),
+    ));
+
+    let created = service
+        .create_session(create_req_deferred("seed"))
+        .await
+        .expect("create deferred session");
+    let session_id = created.session_id.clone();
+
+    let mut stored = store
+        .load(&session_id)
+        .await
+        .expect("load should succeed")
+        .expect("persisted session should exist");
+    tokio::time::sleep(tokio::time::Duration::from_millis(5)).await;
+    stored.touch();
+    store.save(&stored).await.expect("save updated session");
+
+    let service_a = Arc::clone(&service);
+    let session_id_a = session_id.clone();
+    let first =
+        tokio::spawn(async move { service_a.start_turn(&session_id_a, turn_req("first")).await });
+
+    let service_b = Arc::clone(&service);
+    let session_id_b = session_id.clone();
+    let second = tokio::spawn(async move {
+        service_b
+            .start_turn(&session_id_b, turn_req("second"))
+            .await
+    });
+
+    let outcomes = [
+        first.await.expect("first start_turn task should join"),
+        second.await.expect("second start_turn task should join"),
+    ];
+    let outcome_codes: Vec<String> = outcomes
+        .iter()
+        .map(|result| match result {
+            Ok(_) => "OK".to_string(),
+            Err(err) => err.code().to_string(),
+        })
+        .collect();
+    let outcome_debug: Vec<String> = outcomes
+        .iter()
+        .map(|result| match result {
+            Ok(run) => format!("OK({})", run.session_id),
+            Err(err) => format!("{err:?}"),
+        })
+        .collect();
+    assert!(
+        outcomes.iter().any(Result::is_ok),
+        "at least one concurrent start_turn should succeed after recovery; got {outcome_codes:?} {outcome_debug:?}",
+    );
+    for result in outcomes {
+        if let Err(err) = result {
+            assert_eq!(
+                err.code(),
+                "SESSION_BUSY",
+                "concurrent recovery must degrade to normal busy semantics; got {outcome_codes:?} {outcome_debug:?}",
+            );
+        }
+    }
+}

--- a/meerkat-session/tests/regression_lifecycle.rs
+++ b/meerkat-session/tests/regression_lifecycle.rs
@@ -19,8 +19,12 @@ use meerkat_core::service::{
 use meerkat_core::types::{
     HandlingMode, RenderClass, RenderMetadata, RenderSalience, RunResult, SessionId, Usage,
 };
+#[cfg(all(feature = "session-store", not(target_arch = "wasm32")))]
+use meerkat_session::PersistentSessionService;
 use meerkat_session::ephemeral::SessionSnapshot;
 use meerkat_session::{EphemeralSessionService, SessionAgent, SessionAgentBuilder};
+#[cfg(all(feature = "session-store", not(target_arch = "wasm32")))]
+use meerkat_store::{MemoryStore, SessionStore};
 use std::collections::BTreeMap;
 use std::sync::Arc;
 use std::time::SystemTime;
@@ -1405,4 +1409,45 @@ async fn external_tool_surface_snapshot_returns_live_agent_tool_surface_state() 
         .expect("tool-surface snapshot should be present");
 
     assert_eq!(actual, expected_surface);
+}
+
+#[cfg(all(feature = "session-store", not(target_arch = "wasm32")))]
+#[tokio::test]
+async fn persistent_start_turn_recovers_after_discarding_stale_live_session() {
+    let store: Arc<dyn SessionStore> = Arc::new(MemoryStore::new());
+    let service = PersistentSessionService::new(
+        MockAgentBuilder,
+        4,
+        Arc::clone(&store),
+        None,
+        Arc::new(meerkat_store::MemoryBlobStore::new()),
+    );
+
+    let created = service
+        .create_session(create_req_deferred("seed"))
+        .await
+        .expect("create deferred session");
+    let session_id = created.session_id.clone();
+
+    let mut stored = store
+        .load(&session_id)
+        .await
+        .expect("load should succeed")
+        .expect("persisted session should exist");
+    tokio::time::sleep(tokio::time::Duration::from_millis(5)).await;
+    stored.touch();
+    store.save(&stored).await.expect("save updated session");
+
+    let result = service
+        .start_turn(&session_id, turn_req("follow up"))
+        .await
+        .expect("start_turn should recover a stale discarded live session");
+    assert_eq!(result.session_id, session_id);
+    assert!(
+        service
+            .has_live_session(&session_id)
+            .await
+            .expect("live session query should succeed"),
+        "recovered session should be live again after start_turn",
+    );
 }

--- a/sdks/python/tests/test_e2e_smoke.py
+++ b/sdks/python/tests/test_e2e_smoke.py
@@ -326,8 +326,9 @@ if include_scenario(40):
             )
             assert lead["agent_identity"] == "lead-1"
             assert reviewer["agent_identity"] == "reviewer-1"
-            reviewer_runtime_id = reviewer["agent_runtime_id"]
-            reviewer_fence_token = reviewer["fence_token"]
+            assert isinstance(lead.get("member_ref"), str) and lead["member_ref"]
+            assert isinstance(reviewer.get("member_ref"), str) and reviewer["member_ref"]
+            reviewer_member_ref = reviewer["member_ref"]
             await mob.wire("lead-1", "reviewer-1")
 
             append = await mob.append_system_context(
@@ -344,8 +345,7 @@ if include_scenario(40):
                     "Reply with REVIEWER_READY_40 and include [PY-SWARM-40].",
                 )
                 assert reviewer_receipt["agent_identity"] == "reviewer-1"
-                assert reviewer_receipt["agent_runtime_id"] == reviewer_runtime_id
-                assert reviewer_receipt["fence_token"] == reviewer_fence_token
+                assert reviewer_receipt["member_ref"] == reviewer_member_ref
                 observed = await next_subscription_event(subscription)
                 assert observed is not None
 
@@ -386,36 +386,29 @@ if include_scenario(40):
                 "reviewer-1",
                 "Come back online and say REVIEWER_RESPAWN_40.",
             )
-            respawned_runtime_id = respawn_result["receipt"]["agent_runtime_id"]
-            respawned_fence_token = respawn_result["receipt"]["fence_token"]
-            respawned_members = await wait_for(
-                "reviewer active after respawn",
-                mob.members,
-                lambda entries: any(
-                    entry["agent_identity"] == "reviewer-1"
-                    and entry["agent_runtime_id"] == respawned_runtime_id
-                    and entry.get("state") == "Active"
-                    for entry in entries
-                ),
+            respawned_member_ref = respawn_result["receipt"]["member_ref"]
+            respawned_snapshot = await wait_for(
+                "reviewer runtime id changes after respawn",
+                lambda: mob.member_status("reviewer-1"),
+                lambda state: state.get("agent_runtime_id")
+                and state.get("agent_runtime_id") != reviewer_state.get("agent_runtime_id"),
                 timeout_secs=60.0,
-            )
-            assert any(
-                entry["agent_identity"] == "reviewer-1"
-                and entry["agent_runtime_id"] == respawned_runtime_id
-                for entry in respawned_members
             )
             respawn_receipt = await mob.member("reviewer-1").send(
                 "Reply with REVIEWER_RESPAWN_40.",
             )
             assert respawn_receipt["agent_identity"] == "reviewer-1"
-            assert respawn_receipt["agent_runtime_id"] == respawned_runtime_id
-            assert respawn_receipt["fence_token"] == respawned_fence_token
+            assert respawn_receipt["member_ref"] == respawned_member_ref
             respawned_state = await wait_for(
                 "reviewer reply after respawn",
                 lambda: mob.member_status("reviewer-1"),
                 lambda state: "reviewer_respawn_40"
                 in (state.get("output_preview") or "").lower(),
                 timeout_secs=120.0,
+            )
+            assert (
+                respawned_state.get("agent_runtime_id")
+                == respawned_snapshot.get("agent_runtime_id")
             )
             assert "reviewer_respawn_40" in (
                 respawned_state.get("output_preview") or ""

--- a/sdks/web/src/mob.ts
+++ b/sdks/web/src/mob.ts
@@ -327,7 +327,8 @@ export class Mob {
     if (!result.receipt || typeof result.receipt !== 'object') {
       throw new Error('Invalid mob respawn response: missing receipt');
     }
-    const receipt = result.receipt as Record<string, unknown>;
+    const receipt = result.receipt as unknown as Partial<MemberRespawnReceipt> &
+      Record<string, unknown>;
     const legacyIdentity = (receipt as { identity?: unknown }).identity;
     const memberRef =
       typeof receipt.member_ref === 'string' && receipt.member_ref.length > 0

--- a/sdks/web/tests/e2e_wasm_runtime.test.mjs
+++ b/sdks/web/tests/e2e_wasm_runtime.test.mjs
@@ -615,6 +615,23 @@ test("MeerkatRuntime forwards canonical mob status/helper methods through the wa
     assert.equal(respawn.receipt.fence_token, undefined);
     assert.equal(respawn.receipt.previous_fence_token, undefined);
 
+    mob.bindings.mob_respawn = async (_mobId, agentIdentity) =>
+      JSON.stringify({
+        status: "topology_restore_failed",
+        receipt: {
+          agent_identity: agentIdentity,
+          member_ref: `ref-${agentIdentity}`,
+        },
+        failed_peer_ids: ["peer-a", "peer-b"],
+      });
+    const topologyFailure = await mob.respawn("worker-1");
+    assert.equal(topologyFailure.status, "topology_restore_failed");
+    assert.equal(topologyFailure.receipt.agent_identity, "worker-1");
+    assert.equal(topologyFailure.receipt.member_ref, "ref-worker-1");
+    assert.deepEqual(topologyFailure.failed_peer_ids, ["peer-a", "peer-b"]);
+    assert.equal(topologyFailure.receipt.agent_runtime_id, undefined);
+    assert.equal(topologyFailure.receipt.fence_token, undefined);
+
     await mob.forceCancel("worker-1");
 
     const helper = await mob.spawnHelper("Summarize the thread.", {


### PR DESCRIPTION
## Summary
- recover persistent live sessions before turn-driven mob member sends after stale-live discard
- fix the web SDK mob respawn parser and add a focused wasm regression for respawn receipts
- align the Python mixed-provider smoke with the identity-first mob contract

## What was real on latest main
- real product bug: persistent session stale-live discard could make the next turn-driven mob member send fail with session not found
- real product bug: sdks/web mob respawn parser used an invalid cast and broke browser smoke builds
- not reproducing on latest main: scenario 63 and the prior pictionary startup failure shape

## Validation
- ./scripts/repo-cargo test -p meerkat-session --features session-store persistent_start_turn_recovers_after_discarding_stale_live_session --test regression_lifecycle -- --nocapture
- ./scripts/repo-cargo test -p meerkat-integration-tests --test e2e_smoke_lane e2e_smoke_s40_python_sdk_mixed_provider_swarm_probe -- --ignored --nocapture
- npm run build:ts
- node --test tests/e2e_wasm_runtime.test.mjs --test-name-pattern "MeerkatRuntime forwards canonical mob status/helper methods through the wasm binding surface"
- npm run smoke -- --scenario BROWSER-RAW-MOB-004
- npm run smoke -- --scenario BROWSER-MOBPACK-SESSION-003