### PR TITLE
[codex] refresh documentation and skills references

### DIFF
--- a/.claude/skills/meerkat-architecture/SKILL.md
+++ b/.claude/skills/meerkat-architecture/SKILL.md
@@ -61,18 +61,19 @@ Load `references/realtime-attachment.md` when touching realtime
 attachment state, the live-topology reconfigure flow, or the DSL
 authority epoch model.
 
-## The 4-machine target
+## The 5-machine target
 
-Exactly four canonical machines, each with a DSL source in `meerkat-machine-schema/src/catalog/dsl/`:
+Exactly five canonical machines, each with a DSL source in `meerkat-machine-schema/src/catalog/dsl/`:
 
 - **MeerkatMachine** — session-scoped execution kernel. Owns session lifecycle, input admission, ops lifecycle, turn execution, tool surface state, drain lifecycle, peer comms classification, **realtime attachment authority, live-topology reconfigure phase**.
-- **MobMachine** — mob-scoped orchestration. Owns mob lifecycle, member lifecycle, kickoff, wiring, roster, flow/frame/loop execution. (Per-member voice intent was removed — realtime is driven by each member's session-level `ModelCapabilities.realtime`.)
+- **MobMachine** — mob-scoped orchestration. Owns mob lifecycle, member lifecycle, kickoff, wiring, roster, flow/frame/loop execution. (Per-member realtime intent was removed — realtime is driven by each member's session-level `ModelCapabilities.realtime`.)
 - **ScheduleLifecycleMachine** — scheduler triggers and schedule lifecycle.
 - **OccurrenceLifecycleMachine** — occurrence dispatch and delivery.
+- **AuthMachine** — auth/session authorization state that must remain machine-owned.
 
 Plus four composition protocols at the seams: `meerkat_mob_seam`, `schedule_bundle`, `schedule_runtime_bundle`, `schedule_mob_bundle`.
 
-**Zero handwritten `*_authority.rs` state machines exist outside the catalog.** Shell helpers that retain `_authority.rs` naming are pure data projections (`roster`), planning helpers (`mob_wiring`), or DSL adapter plumbing (`dsl_authority`) — none contain `fn apply(input) -> Result<Transition, Error>` match tables.
+**Primary semantic authority should live in the catalog-generated machines.** Handwritten `*_authority.rs` helpers that still exist should be treated as transitional or adapter-level mechanics, not competing semantic owners.
 
 Detailed architecture, DSL ↔ schema ↔ kernel ↔ TLA+ flow, the field-driven design principle, signals vs inputs, and the cross-crate handle trait pattern: **load `references/machine-system.md`**.
 
@@ -86,7 +87,7 @@ Stable per-member identity is separate from per-runtime binding:
 - **`Generation`** — mob-member generation counter; increments on respawn.
 
 When adding state or effects keyed on member identity, choose
-`AgentIdentity` if the fact survives respawn (voice intent,
+`AgentIdentity` if the fact survives respawn (realtime attachment preferences,
 wiring preferences), `AgentRuntimeId` if it's per-binding (ops
 registry membership, live bridge).
 
@@ -94,10 +95,13 @@ registry membership, live bridge).
 
 | Crate | Owns | Key Trait |
 |-------|------|-----------|
-| `meerkat-models` | Model catalog, provider profiles, parameter schemas (leaf; no meerkat deps) | — |
+| `meerkat-models` | Compatibility shim that re-exports `meerkat_core::model_profile` | — |
 | `meerkat-core` | Agent loop, core types, session-store contract, ALL trait contracts, DSL handle traits | `AgentLlmClient`, `AgentToolDispatcher`, `AgentSessionStore`, `SessionStore`, `SessionService`, `CommsRuntime`, `HookEngine`, `OpsLifecycleRegistry`, `TurnStateHandle`, `CommsDrainHandle`, `ExternalToolSurfaceHandle`, `PeerCommsHandle`, `SessionAdmissionHandle` |
 | `meerkat-contracts` | Wire types, catalogs, stable error codes, generated surface schemas, **supervisor bridge protocol (`BridgeCommand`, `BridgeReply`, `BridgePeerSpec`, `BridgeSupervisorPayload`)** | — |
-| `meerkat-client` | LLM providers (Anthropic, OpenAI, Gemini), **realtime (OpenAI) transport** | Implements `AgentLlmClient` |
+| `meerkat-client` | Compatibility client shim that re-exports provider surfaces | Compatibility exports only |
+| `meerkat-auth-core` | Shared auth primitives, token stores, OAuth helpers, cloud authorizers | — |
+| `meerkat-providers` | Compatibility provider-runtime/auth shim surface | — |
+| `meerkat-anthropic` / `meerkat-openai` / `meerkat-gemini` | Provider-specific client/runtime implementations | Implements `AgentLlmClient` via provider-specific crates |
 | `meerkat-store` | Session-store implementations and adapters (SQLite, Jsonl, Memory) | Implements `SessionStore` |
 | `meerkat-tools` | Tool registry, builtins, shell, session-scoped task store | Implements `AgentToolDispatcher` |
 | `meerkat-mcp` | MCP client, protocol transport, router (routes to `ExternalToolSurfaceHandle`) | — |
@@ -138,7 +142,7 @@ Load these as needed. SKILL.md alone is intentionally minimal — everything els
 
 For comprehensive file lists, see the matching reference. This is a minimal pointer index for the most common landmarks.
 
-- `meerkat-machine-schema/src/catalog/dsl/` — DSL sources (truth for all 4 machines)
+- `meerkat-machine-schema/src/catalog/dsl/` — DSL sources (truth for all 5 canonical machines)
 - `meerkat-machine-schema/src/catalog/mod.rs` — `canonical_machine_schemas()` registry
 - `meerkat-machine-kernels/src/runtime.rs` — `GeneratedMachineKernel` interpreter
 - `meerkat-runtime/src/meerkat_machine/` — `MeerkatMachine`, session management, dispatch paths, DSL adapter

--- a/.claude/skills/meerkat-architecture/references/agent-construction.md
+++ b/.claude/skills/meerkat-architecture/references/agent-construction.md
@@ -26,7 +26,7 @@ The factory validates `bindings.session_id == session.id()` for `SessionOwned` b
 
 ## Multimodal Content
 
-- `ContentBlock` (meerkat-core): `Text { text }` or `Image { media_type, data, source_path }`
+- `ContentBlock` (meerkat-core): `Text { text }`, `Image { media_type, ... }`, or `Video { media_type, duration_ms, ... }`
 - `ContentInput` (meerkat-core): `Text(String)` or `Blocks(Vec<ContentBlock>)`
 - `ToolOutput` (meerkat-tools): `Json(Value)` or `Blocks(Vec<ContentBlock>)`
 

--- a/.claude/skills/meerkat-architecture/references/machine-system.md
+++ b/.claude/skills/meerkat-architecture/references/machine-system.md
@@ -2,18 +2,19 @@
 
 Load this reference when working on DSL definitions, schema catalog, generated kernels, TLC verification, or authority cutover.
 
-## The 4-machine target
+## The 5-machine target
 
-The final system has exactly four canonical machines:
+The final system has exactly five canonical machines:
 
 - **MeerkatMachine** — session-scoped execution kernel (absorbs input lifecycle, runtime ingress, ops lifecycle, turn execution, comms drain, peer comms, external tool surface, session turn admission)
 - **MobMachine** — mob-scoped orchestration (absorbs mob lifecycle, member bootstrap, member lifecycle, wiring, roster, orchestrator, flow, loop iteration)
 - **ScheduleLifecycleMachine** — perimeter scheduler
 - **OccurrenceLifecycleMachine** — perimeter occurrence lifecycle
+- **AuthMachine** — auth/session authorization lifecycle
 
 Plus four composition protocols at the seams: `meerkat_mob_seam`, `schedule_bundle`, `schedule_runtime_bundle`, `schedule_mob_bundle`.
 
-Catalog authoritative file: `meerkat-machine-schema/src/catalog/dsl/` — contains exactly these four machine DSLs.
+Catalog authoritative file: `meerkat-machine-schema/src/catalog/dsl/` — contains exactly these five machine DSLs.
 
 Previously-standalone machines absorbed into MeerkatMachine/MobMachine state become fields, inputs, and transitions inside the host machine. Post-absorption, no `*_authority.rs` files should remain for absorbed domains — shell code routes through the host machine's DSL via handle traits (see "Cross-crate DSL access" below).
 
@@ -23,11 +24,12 @@ The DSL is a single source that produces two artifacts:
 
 ```
 ┌────────────────────────────────────────────────────────────────────┐
-│  DSL SOURCE (single source of truth, 4 files)                      │
+│  DSL SOURCE (single source of truth, 5 files)                      │
 │  meerkat-machine-schema/src/catalog/dsl/meerkat_machine.rs         │
 │  meerkat-machine-schema/src/catalog/dsl/mob_machine.rs             │
 │  meerkat-machine-schema/src/catalog/dsl/schedule_lifecycle.rs      │
 │  meerkat-machine-schema/src/catalog/dsl/occurrence_lifecycle.rs    │
+│  meerkat-machine-schema/src/catalog/dsl/auth_machine.rs            │
 │                                                                    │
 │  machine_dsl! {                                                    │
 │    state { <fields> }                                              │

--- a/.claude/skills/meerkat-architecture/references/realtime-attachment.md
+++ b/.claude/skills/meerkat-architecture/references/realtime-attachment.md
@@ -211,7 +211,7 @@ validation happens inside the DSL guard, not in shell pre-checks.
   `turn_phase ∈ {Ready, DrainingBoundary, ...}`. Catalog doesn't model
   `turn_phase` and is a strict over-approximation; TLC-proven
   invariants still hold in production.
-- **OpenAI Realtime only**: `gpt-realtime` is the only production
+- **OpenAI Realtime only**: `gpt-realtime-1.5` is the canonical production
   realtime-capable model today. Gemini `*-live*` models are reserved
   in the capability derivation but have no production entries.
 

--- a/.claude/skills/meerkat-platform/SKILL.md
+++ b/.claude/skills/meerkat-platform/SKILL.md
@@ -5,7 +5,7 @@ description: "Comprehensive guide for building applications with the Meerkat age
 
 # Meerkat Platform Guide
 
-Meerkat (`rkat`) is a library-first agent runtime exposed through multiple surfaces. The execution pipeline is shared, state is realm-scoped, and 0.5 semantics are runtime-backed by default.
+Meerkat (`rkat`) is a library-first agent runtime exposed through multiple surfaces. The execution pipeline is shared, state is realm-scoped, and the current runtime-backed semantics are the default product path.
 
 If the request is about upgrading older integrations or mental models, load:
 
@@ -101,7 +101,7 @@ For detailed mob behavior across all surfaces, load: `references/mobs.md`.
 - Prefabs are gone. All mob creation uses `MobDefinition` only (CLI, REST, RPC, MCP, SDKs).
 - Agent-facing delegation tools (`delegate`, `mob_create`, `mob_destroy`, `mob_spawn_member`, `mob_retire_member`, `mob_check_member`, `mob_list_members`, `mob_list`, `mob_wire`, `mob_unwire`) are provided by `AgentMobToolSurface` in `meerkat-mob-mcp`. These tools let agents spawn and manage mob members through implicit session-owned mobs, and create/remove peer-to-peer comms links between members.
 - Portable mob artifacts are available through mobpack (`rkat mob pack/deploy/inspect/validate`) and browser deployment (`rkat mob web build`).
-- Public realtime attachment capability is named `realtime`, not `voice`: surfaces should describe `ModelCapabilities.realtime`, `runtime/realtime_attachment_status`, `runtime/realtime_attachment_statuses`, and `mob/member_status.realtime_attachment_status`. Realtime transport is capability-driven — there is no caller-initiated attach/detach RPC; set the session's model to a realtime-capable one (e.g. `gpt-realtime`) and the runtime manages attach/detach automatically.
+- Public realtime attachment capability is named `realtime`, not `voice`: surfaces should describe `ModelCapabilities.realtime`, `runtime/realtime_attachment_status`, `runtime/realtime_attachment_statuses`, and `mob/member_status.realtime_attachment_status`. Realtime transport is capability-driven — there is no caller-initiated attach/detach RPC; set the session's model to a realtime-capable one (e.g. `gpt-realtime-1.5`) and the runtime manages attach/detach automatically.
 - OpenAI realtime integration is an internal runtime-backed companion, not a
   public protocol authority: host/facade composition wires it, and RPC/REST
   surfaces expose only the `runtime/realtime_attachment_status(es)` status
@@ -111,7 +111,7 @@ For detailed mob behavior across all surfaces, load: `references/mobs.md`.
 
 Realtime is a delivery mode of the session's LLM, not a separate
 subsystem. Enable it by pointing the session at a realtime-capable
-model (currently only `gpt-realtime`); the runtime reads
+model (currently `gpt-realtime-1.5`, with `gpt-realtime` as a compatibility alias); the runtime reads
 `ModelCapabilities.realtime` and attaches an OpenAI Realtime transport
 automatically. The session retains a single canonical history; audio
 commits into it at turn boundaries.
@@ -123,19 +123,19 @@ Internal architecture reference: `.claude/skills/meerkat-architecture/references
 
 | Surface | Enable realtime | Observe status | Open audio channel |
 |---------|-----------------|----------------|---------------------|
-| JSON-RPC | `session/create` (or profile default) with `model: "gpt-realtime"` | `runtime/realtime_attachment_status`, `runtime/realtime_attachment_statuses`, `mob/member_status.realtime_attachment_status` | `realtime/open_info` |
-| REST | `POST /sessions` with `{"model":"gpt-realtime"}` | `GET /runtime/{id}/realtime_attachment_status` | `realtime/open_info` via RPC |
+| JSON-RPC | `session/create` (or profile default) with `model: "gpt-realtime-1.5"` | `runtime/realtime_attachment_status`, `runtime/realtime_attachment_statuses`, `mob/member_status.realtime_attachment_status` | `realtime/open_info` |
+| REST | `POST /sessions` with `{"model":"gpt-realtime-1.5"}` | `GET /runtime/{id}/realtime_attachment_status` | `realtime/open_info` via RPC |
 | MCP (public) | (set model via host composition) | `meerkat_realtime_status`, `meerkat_realtime_capabilities` | `meerkat_realtime_open_info` |
-| Python SDK | `client.create_session(model="gpt-realtime", ...)` | `client.runtime_realtime_attachment_status(...)` | `client.realtime_open_info(...)` |
-| TypeScript SDK | `client.createSession({ model: "gpt-realtime", ... })` | `client.runtimeRealtimeAttachmentStatus(...)` | `client.realtimeOpenInfo(...)` |
-| Rust | `SessionBuildOptions { model: Some("gpt-realtime".into()), ... }` | `MeerkatMachine::realtime_attachment_status` | provider integration in `meerkat-client` |
+| Python SDK | `client.create_session(model="gpt-realtime-1.5", ...)` | `client.runtime_realtime_attachment_status(...)` | `client.realtime_open_info(...)` |
+| TypeScript SDK | `client.createSession({ model: "gpt-realtime-1.5", ... })` | `client.runtimeRealtimeAttachmentStatus(...)` | `client.realtimeOpenInfo(...)` |
+| Rust | `SessionBuildOptions { model: Some("gpt-realtime-1.5".into()), ... }` | `MeerkatMachine::realtime_attachment_status` | provider integration in `meerkat-client` |
 
 There is **no** caller-initiated attach/detach RPC. Transport lifecycle
 is a function of the session's resolved model capability.
 
 **Capability source.** `ModelCapabilities.realtime: bool` is set per
 model in `meerkat-models`. OpenAI capability derivation matches any
-model name containing `realtime` (production: only `gpt-realtime`).
+model name containing `realtime` (production: canonical `gpt-realtime-1.5`; `gpt-realtime` remains a compatibility alias).
 Gemini derivation matches `*-live*` (no production entries today).
 Anthropic and self-hosted default to `false`.
 
@@ -165,7 +165,7 @@ and `FailLiveTopologyAfterDetach` (post-detach failure, binding gone,
 reattach required).
 
 **Known limitations:**
-- `gpt-realtime` is the only production realtime-capable model today.
+- `gpt-realtime-1.5` is the canonical production realtime-capable model today (`gpt-realtime` remains a compatibility alias).
 - Single realtime binding per session; per-member realtime in mobs is
   achieved by spawning members on realtime-capable profiles.
 - Idle sessions cannot host a binding — the transport is brought up as
@@ -182,19 +182,15 @@ rkat run "create a mob with a lead and workers, then wire and report status"
 rkat run --resume <session_id> "retire worker-2 and add worker-4"
 ```
 
-Where needed, direct lifecycle commands are available as operational compatibility surface:
+Where needed, the current helper-oriented CLI mob surface is:
 
 ```bash
-rkat mob create --definition <path>
-rkat mob list
-rkat mob status <mob_id>
 rkat mob spawn-helper <mob_id> <prompt> [--agent-identity <id>] [--profile <profile>]
+rkat mob fork-helper <mob_id> <source_member> <prompt> [--agent-identity <id>] [--profile <profile>]
 rkat mob member-status <mob_id> <agent_identity>
 rkat mob respawn <mob_id> <agent_identity> [--message <msg>]
-rkat mob wire <mob_id> <a> <b>
-rkat mob unwire <mob_id> <a> <b>
-rkat mob force-cancel <mob_id> <agent_identity>
 rkat mob run-flow <mob_id> --flow <flow_id> [--params <json>]
+rkat mob flow-status <mob_id> <run_id>
 rkat mob wait-kickoff <mob_id> [--member <agent_identity>...]
 ```
 
@@ -261,7 +257,7 @@ await mob.spawn([{ profile: 'worker', agent_identity: 'w1' }]);
 - Session lifecycle (EphemeralSessionService)
 - Mob orchestration (MobBuilder, MobActor, FlowEngine, FlowFrameEngine, in-memory storage)
 - Comms (inproc — InprocRegistry, Ed25519 signing, peer discovery)
-- Tool dispatch (task tools, utility builtins like `wait`/`datetime`/`apply_patch`, comms tools, skill tools — no shell)
+- Tool dispatch (task tools, `datetime`, comms tools, skill tools — no shell and no filesystem-mutating builtins)
 - Skills (embedded + memory sources from mobpack)
 - Hooks (in-process + HTTP — no command hooks)
 - Config (in-memory, programmatic)
@@ -273,7 +269,7 @@ await mob.spawn([{ profile: 'worker', agent_identity: 'w1' }]);
 - MCP protocol client (rmcp blocked by tokio/mio)
 - Network comms (TCP/UDS sockets — inproc only)
 
-**WASM API surface:** See the meerkat-wasm skill (`references/api_surface.md`) for the complete export table. Key additions in 0.5: `runtime_version()`, `register_tool_callback()`, `clear_tool_callbacks()`, `create_session_simple()`, per-provider base URLs on all config types.
+**WASM API surface:** See the meerkat-wasm skill (`references/api_surface.md`) for the complete export table. The 0.5 notes in `references/migration_0_5.md` are legacy migration context, not the current release contract.
 
 **Build:**
 ```bash
@@ -334,12 +330,13 @@ Each schedule produces `Occurrence` instances (individual fires) projected withi
 
 | Tool | Description |
 |------|-------------|
-| `schedule_create` | Create a schedule with trigger + target |
-| `schedule_list` | List schedules with optional filters |
-| `schedule_read` | Read a schedule and its occurrences |
-| `schedule_update` | Update trigger, target, or policies |
-| `schedule_pause` / `schedule_resume` | Pause/resume a schedule |
-| `schedule_delete` | Delete a schedule |
+| `meerkat_schedule_create` | Create a schedule with trigger + target |
+| `meerkat_schedule_get` | Read one schedule |
+| `meerkat_schedule_list` | List schedules |
+| `meerkat_schedule_update` | Update trigger, target, or policies |
+| `meerkat_schedule_pause` / `meerkat_schedule_resume` | Pause/resume a schedule |
+| `meerkat_schedule_delete` | Delete a schedule |
+| `meerkat_schedule_occurrences` | Read schedule occurrences |
 
 Tools are available across all surfaces (CLI, REST, RPC, MCP) via `ScheduleToolDispatcher` (implements `AgentToolDispatcher`), wired as a first-class surface capability. WASM uses `DisabledScheduleStore`.
 
@@ -401,8 +398,8 @@ git diff | rkat run "Review these changes" --tools safe
 cat data.csv | rkat run "Extract entities" | rkat run "Write a story about them"
 # Live streaming: --keep-alive --stdin reads stdin line-by-line as events
 tail -f app.log | rkat run --keep-alive --stdin lines "Monitor and alert on anomalies"
-rkat mob create --definition ./mobs/coding-swarm.toml
-rkat mob list
+rkat mob spawn-helper coding-swarm "Join as lead-1 and summarize the current plan." --profile lead --agent-identity lead-1
+rkat mob run-flow coding-swarm --flow triage --params '{"severity":"high"}'
 ```
 
 ### Python SDK
@@ -515,10 +512,10 @@ Key facts:
   tracing event (deferral §5). REST/RPC login/logout emit matching
   events for user-initiated actions.
 
-The provider-runtime + OAuth + auth-store + authorizer modules live
-in the separately-published `meerkat-providers` crate. The `meerkat`
-facade and `meerkat-client` crate re-export the necessary types;
-surfaces import `meerkat_providers::*` directly.
+Provider-runtime/auth compatibility shims live in `meerkat-providers` and
+`meerkat-client`, but the concrete provider implementations now live in the
+provider-specific crates such as `meerkat-openai`, `meerkat-anthropic`, and
+`meerkat-gemini`.
 
 See `docs/guides/auth.mdx` for the full walkthrough and
 `docs/architecture/meerkat-runtime-dogma.md` for the §1/§10/§12
@@ -530,13 +527,13 @@ The `meerkat` facade crate defaults to providers only (Anthropic, OpenAI, Gemini
 
 ```toml
 # Default: three providers, no storage/comms/tools
-meerkat = "0.5"
+meerkat = "0.6.0"
 
 # Single provider, minimal
-meerkat = { version = "0.5", default-features = false, features = ["anthropic"] }
+meerkat = { version = "0.6.0", default-features = false, features = ["anthropic"] }
 
 # Add persistence + memory + comms
-meerkat = { version = "0.5", features = [
+meerkat = { version = "0.6.0", features = [
     "jsonl-store", "session-store", "session-compaction",
     "memory-store-session", "comms", "mcp", "skills"
 ] }
@@ -554,7 +551,7 @@ Disabled features return typed errors (e.g. `SessionError::PersistenceDisabled`)
 
 ### Model catalog
 
-The `meerkat-models` crate provides a curated model catalog queryable from all surfaces:
+The compatibility `meerkat-models` crate re-exports the curated model catalog queryable from all surfaces:
 
 - CLI: `rkat models`
 - RPC: `models/catalog`
@@ -689,8 +686,8 @@ Surface availability:
 | Surface | Live MCP | Tool filter | Status |
 |---------|----------|-------------|--------|
 | JSON-RPC | `mcp/add`, `mcp/remove`, `mcp/reload` | Via session runtime | Fully wired |
-| REST | `POST /sessions/{id}/mcp/*` | — | Routes registered (placeholder) |
-| CLI | `rkat mcp add/remove --session --live-server-url` | — | Delegates to REST |
+| REST | `POST /sessions/{id}/mcp/*` | — | Fully wired |
+| CLI | `rkat mcp reload --session --live-server-url` | — | Host-managed live reload flow |
 
 ### Memory
 

--- a/.claude/skills/meerkat-platform/references/mobs.md
+++ b/.claude/skills/meerkat-platform/references/mobs.md
@@ -265,12 +265,11 @@ rkat run --resume <session_id> "Retire worker-2 and add worker-4, then summarize
 ### CLI direct commands (explicit operational)
 
 ```bash
-rkat mob create --definition mob.toml
-rkat mob spawn team-mob lead lead-1
-rkat mob wire team-mob lead-1 worker-1
-rkat mob status team-mob
+rkat mob spawn-helper team-mob "Join as lead-1" --profile lead --agent-identity lead-1
+rkat mob fork-helper team-mob lead-1 "Investigate the failing test cluster." --profile worker
+rkat mob member-status team-mob lead-1
 rkat mob respawn team-mob worker-1 --message "restart"
-rkat mob events team-mob --member worker-1
+rkat mob run-flow team-mob --flow triage
 ```
 
 ### CLI artifact + web deployment

--- a/.claude/skills/meerkat-wasm/SKILL.md
+++ b/.claude/skills/meerkat-wasm/SKILL.md
@@ -123,7 +123,7 @@ Clippy: `cargo clippy -p meerkat-web-runtime --target wasm32-unknown-unknown -- 
 
 ## Subsystem Availability on wasm32
 
-Full: agent loop, LLM providers (browser fetch), sessions (ephemeral), comms (inproc), mob orchestration (in-memory), tools (non-shell utility/task/comms/skill surfaces, including `view_image` for vision-capable models), tool scoping (`ToolScope` + per-turn overlays), skills (embedded), hooks (in-process), config (in-memory), compaction, multimodal content (`ContentInput`/`ContentBlock` parsing at WASM bridge).
+Full: agent loop, LLM providers (browser fetch), sessions (ephemeral), comms (inproc), mob orchestration (in-memory), tools (task tools + `datetime` + comms/skill surfaces; no shell and no filesystem-mutating builtins), tool scoping (`ToolScope` + per-turn overlays), skills (embedded), hooks (in-process), config (in-memory), compaction, multimodal content (`ContentInput`/`ContentBlock` parsing at WASM bridge).
 
 Excluded: shell tools, filesystem-mutating builtins such as `apply_patch`, filesystem persistence, MCP client (rmcp), network comms (TCP/UDS).
 

--- a/audit/docs-review-2026-04-21/README.md
+++ b/audit/docs-review-2026-04-21/README.md
@@ -1,0 +1,79 @@
+# Docs and Skills Review Audit
+
+This folder contains independent documentation review findings gathered on
+2026-04-21.
+
+Each agent owns exactly one findings file and reviews only its assigned scope.
+The goal is to identify:
+
+- factual inaccuracies
+- stale or misleading guidance
+- missing coverage
+- broken cross-links or navigation mismatches
+- inconsistencies between docs, skills, and current code/layout
+
+Assigned scopes:
+
+1. `agent-01-getting-started-and-nav.md`
+   - `docs/introduction.mdx`
+   - `docs/quickstart.mdx`
+   - `docs/docs.json`
+   - global navigation / discoverability issues
+
+2. `agent-02-concepts-and-configuration.md`
+   - `docs/concepts/*.mdx`
+   - configuration-related conceptual framing
+
+3. `agent-03-guides-auth-providers-models.md`
+   - `docs/guides/auth.mdx`
+   - `docs/guides/self-hosted-gemma4.mdx`
+   - provider/model/auth guidance referenced from guides
+
+4. `agent-04-guides-tools-hooks-skills-memory.md`
+   - `docs/guides/hooks.mdx`
+   - `docs/guides/skills.mdx`
+   - `docs/guides/memory.mdx`
+   - `docs/guides/structured-output.mdx`
+   - `docs/examples/hooks.mdx`
+   - `docs/examples/skills.mdx`
+   - `docs/examples/memory.mdx`
+   - `docs/examples/tools.mdx`
+   - `docs/examples/structured-output.mdx`
+
+5. `agent-05-guides-mobs-comms-realtime-scheduling.md`
+   - `docs/guides/comms.mdx`
+   - `docs/guides/mobs.mdx`
+   - `docs/guides/mobpack.mdx`
+   - `docs/guides/realtime.mdx`
+   - `docs/guides/scheduling.mdx`
+   - `docs/examples/comms.mdx`
+   - `docs/examples/mobs.mdx`
+   - `docs/examples/mobpack.mdx`
+   - `docs/examples/wasm.mdx`
+
+6. `agent-06-surfaces-cli-api-sdk-rust.md`
+   - `docs/cli/*.mdx`
+   - `docs/api/*.mdx`
+   - `docs/rust/*.mdx`
+   - `docs/sdks/**/*.mdx`
+
+7. `agent-07-reference-architecture-and-contracts.md`
+   - `docs/reference/*`
+   - `docs/architecture/*`
+   - `docs/design/*`
+   - architecture/reference parity with current crate layout
+
+8. `agent-08-meerkat-skill-files.md`
+   - `.claude/skills/meerkat-platform/SKILL.md`
+   - `.claude/skills/meerkat-architecture/SKILL.md`
+   - `.claude/skills/meerkat-wasm/SKILL.md`
+   - skill/doc parity against `docs/` and current repo layout
+
+Expected file shape:
+
+- Scope reviewed
+- Files reviewed
+- Findings
+- Suggested follow-ups
+
+Prefer concrete citations using file paths and, when useful, line numbers.

--- a/audit/docs-review-2026-04-21/agent-01-getting-started-and-nav.md
+++ b/audit/docs-review-2026-04-21/agent-01-getting-started-and-nav.md
@@ -1,0 +1,128 @@
+# Agent 01 Findings
+
+## Scope reviewed
+
+- `docs/introduction.mdx`
+- `docs/quickstart.mdx`
+- `docs/docs.json`
+- Global navigation and first-run discoverability related to getting-started content
+
+## Files reviewed
+
+- `docs/introduction.mdx`
+- `docs/quickstart.mdx`
+- `docs/docs.json`
+- `docs/examples/gallery.mdx`
+- `docs/guides/auth.mdx`
+- `docs/cli/commands.mdx`
+- `docs/concepts/providers.mdx`
+- `docs/concepts/realms.mdx`
+- `README.md`
+- `Cargo.toml`
+- `meerkat/Cargo.toml`
+- `meerkat/examples/simple.rs`
+- `sdks/python/pyproject.toml`
+- `sdks/python/meerkat/client.py`
+- `sdks/python/README.md`
+- `sdks/typescript/package.json`
+- `sdks/typescript/src/client.ts`
+- `examples/002-hello-meerkat-py/README.md`
+- `examples/003-hello-meerkat-ts/README.md`
+
+## Findings
+
+### 1. Quickstart CLI install path is repo-local, not a real public install path
+
+- `docs/quickstart.mdx:28-32` tells users to run `cargo install --path meerkat-cli`.
+- That command only works from a checked-out Meerkat repo, but the page is framed as the primary public quickstart.
+- The workspace metadata shows the CLI crate is published as `rkat`, not just as a local path crate: `Cargo.toml` lists `meerkat-cli` with the note `publishes as "rkat" on crates.io` under the workspace members.
+- The repo README also points new users to `cargo install rkat` instead of a repo-local `--path` install (`README.md:46-49`).
+
+Why this matters:
+- A first-time user following the docs site verbatim can fail immediately unless they already cloned the repo.
+- The other install tabs use public package-manager commands, so the CLI tab currently breaks that pattern.
+
+Suggested correction:
+- Make `cargo install rkat` the default quickstart instruction.
+- If source builds are still worth mentioning, label them explicitly as an alternative for contributors or local development.
+
+### 2. Python and TypeScript quickstart notes incorrectly say `rkat-rpc` must already be on `PATH`
+
+- `docs/quickstart.mdx:16-26` says both the Python and TypeScript SDKs require the `rkat-rpc` binary on `PATH`.
+- That no longer matches the current SDK implementations:
+  - Python resolves `rkat-rpc`, but if it is missing it attempts to download the binary and can also fall back to `rkat` (`sdks/python/meerkat/client.py:256-268`, `sdks/python/meerkat/client.py:2285-2305`).
+  - TypeScript does the same: it first checks `PATH`, then downloads `rkat-rpc`, and only falls back to `rkat` if needed (`sdks/typescript/src/client.ts:274-287`, `sdks/typescript/src/client.ts:2948-2958`).
+- The surrounding repo docs/examples already reflect the newer behavior:
+  - `examples/003-hello-meerkat-ts/README.md:3-9` says the TypeScript SDK auto-downloads and spawns `rkat-rpc`.
+  - The Python SDK README does not list a manual binary install as a prerequisite (`sdks/python/README.md:10-18`).
+
+Why this matters:
+- The quickstart currently adds friction that the product has already removed.
+- It also creates conflicting guidance between the main quickstart and the SDK-specific docs/examples.
+
+Suggested correction:
+- Update the notes to say the SDKs will auto-resolve/download `rkat-rpc` by default.
+- Keep the standalone-binary caveat only for advanced realm/context options, which both SDKs still gate behind a real `rkat-rpc` binary.
+
+### 3. The Rust quickstart sample is drifting away from the maintained in-repo starter example
+
+- `docs/quickstart.mdx:40-64` contains a Rust starter snippet.
+- The closest maintained canonical example in the repo is `meerkat/examples/simple.rs:22-48`.
+- The two versions have already diverged in several observable ways:
+  - docs use `claude-sonnet-4-6`; the repo example uses `claude-sonnet-4-5`
+  - docs omit the explicit `store.init().await?` call that the checked-in example includes (`meerkat/examples/simple.rs:27-29`)
+  - docs print only `result.text`; the example prints response plus session stats (`meerkat/examples/simple.rs:40-48`)
+
+Why this matters:
+- Even if the docs snippet still works, there are now two competing "starter" versions to maintain.
+- New users who compare the docs against the repo example have to guess which one is authoritative.
+
+Suggested correction:
+- Either generate/sync the quickstart Rust snippet from `meerkat/examples/simple.rs`, or clearly point readers to that example as the maintained source of truth.
+
+### 4. Authentication/setup guidance exists but is effectively hidden from the getting-started path
+
+- There is a dedicated auth guide at `docs/guides/auth.mdx`.
+- It is not present anywhere in `docs/docs.json`, so it is not discoverable from the main navigation.
+- Within the scoped pages, there is also no direct link from `docs/introduction.mdx` or `docs/quickstart.mdx` to the auth guide or even to provider-setup guidance before asking users to run commands.
+- This is especially noticeable because the quickstart assumes provider credentials immediately (`docs/quickstart.mdx:45`, `docs/quickstart.mdx:90`) but does not provide a first-run route to the auth/setup material.
+
+Why this matters:
+- Credential setup is a first-run task, not an advanced edge case.
+- Hiding it in a non-nav page increases the chance that users bounce from the quickstart to guesswork instead of finding the supported setup path.
+
+Suggested correction:
+- Add `guides/auth` to `docs/docs.json`, likely in either "Getting started" or "Guides".
+- Link to it directly from quickstart install/run sections and/or the introduction page.
+
+### 5. The introduction sends users to an examples gallery that skips the actual hello-world starters
+
+- `docs/introduction.mdx:58-64` sends users from "Get started" to `/examples/gallery`.
+- The repo does contain explicit beginner examples:
+  - `examples/001-hello-meerkat-rs`
+  - `examples/002-hello-meerkat-py`
+  - `examples/003-hello-meerkat-ts`
+- But `docs/examples/gallery.mdx:9-67` starts at example 017 and focuses on advanced multi-agent, deployment, and demo apps.
+- The gallery footer then says "All 35 examples (including single-feature demos and hello-world starters) are in `examples/` in the repository" (`docs/examples/gallery.mdx:71`), but the page itself does not surface those starter examples.
+
+Why this matters:
+- The introduction's CTA implies "show me runnable next steps," but the target page is optimized for advanced showcase material, not onboarding.
+- This is a discoverability mismatch rather than a broken link, but it affects first-run usability.
+
+Suggested correction:
+- Add a "Hello world / starter examples" section to `/examples/gallery`, or change the introduction CTA to point to a more beginner-focused examples page.
+
+### 6. No broken internal destinations found in the scoped intro/quickstart navigation paths
+
+- I did not find any missing internal docs pages referenced directly by:
+  - `docs/introduction.mdx`
+  - `docs/quickstart.mdx`
+  - the relevant `docs/docs.json` navigation entries in scope
+- The main issue in this area is discoverability/placement, not broken page targets.
+
+## Suggested follow-ups
+
+- Update `docs/quickstart.mdx` to use a public CLI install command and to remove the outdated "`rkat-rpc` must be on `PATH`" requirement for basic Python/TypeScript usage.
+- Add `docs/guides/auth.mdx` to `docs/docs.json` and link it from the quickstart and/or introduction.
+- Decide on a single maintained Rust starter source, preferably the checked-in example in `meerkat/examples/simple.rs`, and keep the quickstart aligned with it.
+- Rework `/examples/gallery` or the introduction CTA so first-time users can find `001`/`002`/`003` without leaving the docs flow.

--- a/audit/docs-review-2026-04-21/agent-02-concepts-and-configuration.md
+++ b/audit/docs-review-2026-04-21/agent-02-concepts-and-configuration.md
@@ -1,0 +1,64 @@
+# Agent 02 Findings
+
+## Scope reviewed
+
+- Concepts docs audit for configuration/provider/realm/session/tool behavior.
+- Validation against current implementation and adjacent reference docs.
+
+## Files reviewed
+
+- `docs/concepts/configuration.mdx`
+- `docs/concepts/providers.mdx`
+- `docs/concepts/realms.mdx`
+- `docs/concepts/sessions.mdx`
+- `docs/concepts/tools.mdx`
+- `meerkat-core/src/config.rs`
+- `meerkat-core/src/config_runtime.rs`
+- `meerkat-core/src/config_store.rs`
+- `meerkat-core/src/session_locator.rs`
+- `meerkat-core/src/agent.rs`
+- `meerkat-core/src/types.rs`
+- `meerkat-core/src/model_profile/capabilities/anthropic.rs`
+- `meerkat-core/src/model_profile/capabilities/openai.rs`
+- `meerkat-core/src/model_profile/capabilities/gemini.rs`
+- `meerkat-core/src/model_profile/schema_builder.rs`
+- `meerkat/src/factory.rs`
+- `meerkat-rpc/src/handlers/config.rs`
+- `meerkat-rpc/src/handlers/mcp.rs`
+- `meerkat-rpc/src/router.rs`
+- `meerkat-rpc/src/session_runtime.rs`
+- `meerkat-rest/src/lib.rs`
+- `meerkat-mcp-server/src/lib.rs`
+- `docs/reference/builtin-tools.mdx`
+- `docs/reference/session-contracts.mdx`
+- `docs/api/mcp.mdx`
+
+## Findings
+
+1. `docs/concepts/configuration.mdx:25-33` still describes environment variables as a normal config-precedence layer, but the current config loader no longer mutates `Config` from env at all. `Config::load()` still mentions `defaults -> file -> env`, yet `apply_env_overrides_from()` is now an intentional no-op with a comment explaining that provider credentials are resolved later through binding resolution rather than written into config state (`meerkat-core/src/config.rs:106-143`, `meerkat-core/src/config.rs:576-598`). The concept page should stop implying that env vars override realm `config.toml` fields and instead distinguish runtime credential lookup from persisted realm config.
+
+2. `docs/concepts/providers.mdx:17-23` has a stale/misleading Anthropic model table. It lists `claude-opus-4-6` twice, including one row that reads like the top-tier/current recommendation, while the actual curated catalog marks `claude-opus-4-7` as the recommended Opus row and `claude-opus-4-6` as the supported fallback (`meerkat-core/src/model_profile/capabilities/anthropic.rs:86-114`, `meerkat-core/src/model_profile/capabilities/anthropic.rs:127-155`). As written, the table can make readers think 4.6 is both the highest-quality choice and a fallback at the same time.
+
+3. `docs/concepts/providers.mdx:145-152` has stale OpenAI parameter guidance. It says `reasoning_effort` is for “o-series models” and only documents `low`, `medium`, and `high`, but the current GPT-5.4 path is what actually uses this field, and the catalog/client support `none`, `low`, `medium`, `high`, and `xhigh` (`meerkat-core/src/model_profile/capabilities/openai.rs:10-18`, `meerkat-core/src/model_profile/capabilities/openai.rs:31-70`, `meerkat-openai/src/client.rs:189-197`). This should be rewritten around GPT-5-era behavior, not older o-series wording.
+
+4. `docs/concepts/realms.mdx:11-15` overstates realm ID freedom by calling realms “opaque strings.” Explicit realm IDs are validated across surfaces: they must be 1-64 chars, start with ASCII alphanumeric, use only ASCII alnum / `_` / `-`, cannot contain whitespace or `:`, and UUID-like values are rejected (`meerkat-contracts/src/session_locator.rs:42-63`). The docs should describe realm IDs as user-chosen stable identifiers with syntax constraints, not arbitrary opaque strings.
+
+5. `docs/concepts/sessions.mdx:11-20` and `docs/concepts/sessions.mdx:43-54` miss an important archived-session behavior: archive removes the live/runtime handle and hides the session from normal listing, but committed history remains readable after archive on the primary runtime-backed path. That behavior is explicitly covered in tests (`meerkat-rpc/src/router.rs:5646-5670`) and aligns with the reference contract (`docs/reference/session-contracts.mdx:113-126`). The concepts page currently makes archive sound like full removal only, which is too lossy for users reasoning about audit/history retention.
+
+6. `docs/concepts/tools.mdx:11-43` shows an outdated custom-dispatcher API. The example still returns `Result<ToolResult, ToolError>`, but `AgentToolDispatcher::dispatch()` now returns `Result<ToolDispatchOutcome, ToolError>` and synchronous results are wrapped into that outcome (`meerkat-core/src/agent.rs:275-283`; see current example style in `examples/006-custom-tools-rs/main.rs:81-140`). Readers copying the concept example will implement the wrong signature.
+
+7. `docs/concepts/tools.mdx:63-70` has an incomplete built-in category list. Current agent factories also expose schedule tools behind `enable_schedule`, but the page only lists builtins, shell, memory, comms, and mob (`meerkat/src/factory.rs:797-803`, `meerkat/src/factory.rs:1045-1048`). Schedule tooling is live enough that the repo has RPC handlers and tool-name coverage for it (`meerkat-rpc/src/handlers/schedule.rs:423-427`). The concepts page should either include schedule explicitly or explain why it is intentionally omitted.
+
+8. `docs/concepts/tools.mdx:77-83` conflates live MCP mutation with external tool filtering. The page says callers can stage allow/deny filters via session APIs such as `mcp/add` and `mcp/remove`, but those handlers only stage MCP server lifecycle changes (`meerkat-rpc/src/handlers/mcp.rs:13-169`, `meerkat-rest/src/lib.rs:4304-4376`). The actual allow/deny filter mechanism is `ToolScopeHandle::stage_external_filter(...)` in-process (`meerkat-core/src/tool_scope.rs:942-947`), and I did not find a parallel public RPC/REST control plane for it in the current repo. This is conceptually misleading because it suggests a public feature surface that does not exist.
+
+9. `docs/concepts/tools.mdx:107-112` says REST live MCP support is only “Route stubs registered,” but the REST server wires real handlers for `POST /sessions/{id}/mcp/add|remove|reload` and those handlers stage the requested mutations (`meerkat-rest/src/lib.rs:1203-1207`, `meerkat-rest/src/lib.rs:4304-4376`). This should be updated from placeholder language to active support.
+
+10. `docs/concepts/tools.mdx:115-129` contains stale multimodal result details. The page says `ContentBlock` has only text and image variants and documents an image `source_path` field, but the current core type includes `Text`, `Image`, and `Video`, and `ContentBlock::Image` itself no longer carries `source_path` on the wire shape (`meerkat-core/src/types.rs:70-95`). The general custom-tool return path is also centered on `ToolResult.content` / `ToolResult::with_blocks(...)` rather than only the built-in-tool `ToolOutput` abstraction (`meerkat-core/src/types.rs:1121-1164`). The section should be updated so readers do not internalize an obsolete content model.
+
+## Suggested follow-ups
+
+- Update `docs/concepts/configuration.mdx` to separate “persisted realm config precedence” from “runtime credential resolution,” and remove the claim that env vars currently override config fields.
+- Refresh `docs/concepts/providers.mdx` from the curated capability rows instead of hand-maintained summaries, especially for Anthropic recommendations and OpenAI reasoning-effort values.
+- Tighten `docs/concepts/realms.mdx` and `docs/concepts/sessions.mdx` around operational contracts: realm ID syntax, archive semantics, and what remains readable after archive.
+- Rework `docs/concepts/tools.mdx` against current source-of-truth docs and types. The highest-priority fixes are the stale dispatcher signature, missing schedule tools, incorrect external-filter description, incorrect REST live-MCP status, and obsolete multimodal block shape.
+- After the concepts pages are fixed, sweep adjacent docs that likely copied the same outdated tool examples/status text, especially `docs/examples/tools.mdx` and `docs/reference/builtin-tools.mdx`.

--- a/audit/docs-review-2026-04-21/agent-03-guides-auth-providers-models.md
+++ b/audit/docs-review-2026-04-21/agent-03-guides-auth-providers-models.md
@@ -1,0 +1,64 @@
+# Agent 03 Findings
+
+## Scope reviewed
+
+- `docs/guides/auth.mdx`
+- `docs/guides/self-hosted-gemma4.mdx`
+- Adjacent provider/auth/model docs that these pages depend on, especially `docs/concepts/providers.mdx` and `docs/cli/configuration.mdx`
+- Current provider/auth/model code paths in `meerkat-cli`, `meerkat-core`, `meerkat-auth-core`, `meerkat-anthropic`, `meerkat-openai`, `meerkat-gemini`, and `meerkat-runtime`
+
+No findings for the env-var fast path itself: the docs' `RKAT_*` precedence and Gemini fallback to `GOOGLE_API_KEY` match the current resolver and synthesized `env_default` realm behavior in `meerkat-auth-core/src/resolver.rs:30-47` and `meerkat-core/src/connection.rs:271-356`.
+
+## Files reviewed
+
+- `docs/guides/auth.mdx`
+- `docs/guides/self-hosted-gemma4.mdx`
+- `docs/concepts/providers.mdx`
+- `docs/cli/configuration.mdx`
+- `meerkat-cli/src/main.rs`
+- `meerkat-core/src/connection.rs`
+- `meerkat-core/src/config.rs`
+- `meerkat-core/src/model_profile/mod.rs`
+- `meerkat-core/src/model_registry.rs`
+- `meerkat-core/src/provider_matrix/anthropic_auth.rs`
+- `meerkat-core/src/provider_matrix/google_backend.rs`
+- `meerkat-core/src/provider_matrix/google_auth.rs`
+- `meerkat-auth-core/src/resolver.rs`
+- `meerkat-anthropic/src/runtime/mod.rs`
+- `meerkat-openai/src/runtime/mod.rs`
+- `meerkat-openai/src/client_compatible.rs`
+- `meerkat-gemini/src/runtime/mod.rs`
+- `meerkat-rest/src/auth_endpoints.rs`
+- `meerkat-rpc/src/handlers/auth.rs`
+- `meerkat-runtime/src/meerkat_machine_types.rs`
+
+## Findings
+
+1. `docs/guides/auth.mdx` currently overstates `rkat auth login` as a realm-scoped flow.
+
+The guide says users can "declare a realm in your config, register credentials via `rkat auth login`" and then use bindings like `prod:default` / `prod:openai` (`docs/guides/auth.mdx:9-12`, `docs/guides/auth.mdx:39-98`). The current CLI does not support `--realm` or `--profile-id` on `rkat auth login`; interactive login always persists to hard-coded `dev` keys like `dev:anthropic_oauth`, `dev:openai_oauth`, and `dev:google_oauth`, and non-interactive login always writes `dev:default_<provider>` (`meerkat-cli/src/main.rs:1380-1411`, `meerkat-cli/src/main.rs:3526-3550`, `meerkat-cli/src/main.rs:3622-3640`). Provider runtimes also resolve persisted credentials using `<realm>:<auth_profile.id>`, so a guide example built around `realm.prod` is not populated by `rkat auth login` as written (`meerkat-anthropic/src/runtime/mod.rs:184-203`, `meerkat-openai/src/runtime/mod.rs:141-160`, `meerkat-gemini/src/runtime/mod.rs:148-165`). This is the largest user-facing mismatch in the page.
+
+2. The auth-method matrix in `docs/guides/auth.mdx` contains stale backend/auth identifiers.
+
+Two entries do not match the strings accepted by the current provider matrix:
+- Bedrock SigV4 is documented as `bedrock_aws` in `docs/guides/auth.mdx:141`, but the actual auth method name is `bedrock_aws_sigv4` in `meerkat-core/src/provider_matrix/anthropic_auth.rs:30-49`.
+- Gemini Code Assist is documented under backend `code_assist` in `docs/guides/auth.mdx:150`, but the actual backend kind is `google_code_assist` in `meerkat-core/src/provider_matrix/google_backend.rs:11-24`, and the runtime error/help text also uses that name in `meerkat-gemini/src/runtime/mod.rs:331-370`.
+
+Because this table is presented as "what's wired today," these stale identifiers are likely to cause copy/paste config failures.
+
+3. The credential-source section is incomplete and partially misleading relative to the current enum surface.
+
+`docs/guides/auth.mdx:156-167` says "Five shapes are supported" and lists `InlineSecret`, `Env`, `ManagedStore`, `ExternalResolver`, and `Command`. The current `CredentialSourceSpec` also includes `PlatformDefault` and `FileDescriptor` (`meerkat-core/src/connection.rs:81-131`), and the CLI already renders both names (`meerkat-cli/src/main.rs:3865-3871`). In addition, the page frames `ManagedStore { profile }` as the source-level lookup shape, but current provider runtimes load persisted credentials by `binding.auth_profile.id` rather than by `source.profile`, and `source.profile` does not appear to be consumed in the runtime lookup path (`meerkat-anthropic/src/runtime/mod.rs:188-198`, `meerkat-openai/src/runtime/mod.rs:145-155`, `meerkat-gemini/src/runtime/mod.rs:150-160`). That means the docs currently describe a more flexible `ManagedStore` lookup contract than the code actually implements.
+
+4. `docs/guides/self-hosted-gemma4.mdx` needs a stronger caveat around audio support.
+
+The guide says `E2B` and `E4B` "expose native audio support" (`docs/guides/self-hosted-gemma4.mdx:16`, `docs/guides/self-hosted-gemma4.mdx:249`), but Meerkat's self-hosted model/profile surface has no audio capability field at all. The self-hosted config schema only carries temperature/thinking/reasoning/vision/image-tool-results/web-search/realtime/timeouts (`meerkat-core/src/config.rs:1006-1029`), the exported model profile surface also has no audio field (`meerkat-core/src/model_profile/mod.rs:52-68`, `meerkat-runtime/src/meerkat_machine_types.rs:87-101`), and self-hosted aliases are currently registered with `realtime: false` (`meerkat-core/src/model_registry.rs:170-183`). As written, the page can be read as if Meerkat exposes self-hosted Gemma audio capability today, when the current runtime only documents text/image/tooling on this path.
+
+## Suggested follow-ups
+
+- Update `docs/guides/auth.mdx` to distinguish three separate stories clearly:
+  `env_default` fast path, CLI login's current fixed `dev:*` behavior, and truly realm/profile-targeted persistence via REST/RPC surfaces.
+- Correct the auth matrix identifiers to `bedrock_aws_sigv4` and `google_code_assist`, and consider adding the exact accepted backend/auth strings from the provider matrix enums.
+- Either document `PlatformDefault` and `FileDescriptor` explicitly or narrow the "supported shapes" language so it does not claim the list is exhaustive.
+- Decide whether `ManagedStore.profile` is intended to matter. If yes, the runtime behavior likely needs a code fix; if no, the docs should stop implying that field drives lookup.
+- Add a caveat to `docs/guides/self-hosted-gemma4.mdx` that upstream Gemma audio capability is not currently surfaced as a Meerkat self-hosted capability/realtime transport on this path.

--- a/audit/docs-review-2026-04-21/agent-04-guides-tools-hooks-skills-memory.md
+++ b/audit/docs-review-2026-04-21/agent-04-guides-tools-hooks-skills-memory.md
@@ -1,0 +1,111 @@
+# Agent 04 Findings
+
+## Scope reviewed
+
+- Guides:
+  - `docs/guides/hooks.mdx`
+  - `docs/guides/skills.mdx`
+  - `docs/guides/memory.mdx`
+  - `docs/guides/structured-output.mdx`
+- Examples:
+  - `docs/examples/hooks.mdx`
+  - `docs/examples/skills.mdx`
+  - `docs/examples/memory.mdx`
+  - `docs/examples/tools.mdx`
+  - `docs/examples/structured-output.mdx`
+- Current implementation checked for parity in:
+  - `meerkat-core`
+  - `meerkat-hooks`
+  - `meerkat-memory`
+  - `meerkat-cli`
+  - `meerkat-rest`
+  - `meerkat-rpc`
+  - `meerkat-mcp-server`
+  - `sdks/python`
+  - `sdks/typescript`
+
+## Files reviewed
+
+- `docs/guides/hooks.mdx`
+- `docs/guides/skills.mdx`
+- `docs/guides/memory.mdx`
+- `docs/guides/structured-output.mdx`
+- `docs/examples/hooks.mdx`
+- `docs/examples/skills.mdx`
+- `docs/examples/memory.mdx`
+- `docs/examples/tools.mdx`
+- `docs/examples/structured-output.mdx`
+- `meerkat-core/src/hooks.rs`
+- `meerkat-core/src/config.rs`
+- `meerkat-core/src/agent.rs`
+- `meerkat-core/src/agent/runner.rs`
+- `meerkat-core/src/agent/state.rs`
+- `meerkat-core/src/service/mod.rs`
+- `meerkat-core/src/types.rs`
+- `meerkat-core/src/budget.rs`
+- `meerkat-core/src/event.rs`
+- `meerkat-hooks/src/lib.rs`
+- `meerkat-memory/src/tool.rs`
+- `meerkat/src/factory.rs`
+- `meerkat-cli/src/main.rs`
+- `meerkat-rest/src/lib.rs`
+- `meerkat-rpc/src/handlers/session.rs`
+- `meerkat-mcp-server/src/lib.rs`
+- `sdks/python/meerkat/client.py`
+- `sdks/python/meerkat/session.py`
+- `sdks/typescript/src/client.ts`
+
+## Findings
+
+1. `docs/examples/hooks.mdx` shows a hook-override wire shape that no longer deserializes.
+   - The examples at `docs/examples/hooks.mdx:16-24`, `docs/examples/hooks.mdx:125-133`, and `docs/examples/hooks.mdx:261-268` put `command` or `url` directly on each entry and use `mode: "blocking"`.
+   - The live wire type is `HookEntryConfig { id, enabled, point, mode, capability, priority, failure_policy, timeout_ms, runtime }`, where `mode` is `foreground` or `background`, and runtime config must be nested under `runtime`/`type` rather than flattened onto the entry itself. See `meerkat-core/src/config.rs:1525-1539`, `meerkat-core/src/hooks.rs:69-84`, and `meerkat-core/src/config.rs:1642-1679`.
+   - As written, these examples omit required fields like `capability` and `runtime`, and use an invalid enum value for `mode`, so copy-pasting them into CLI/REST/RPC/MCP calls should fail before hook execution starts.
+
+2. `docs/guides/hooks.mdx` is missing the current image-content caveat for tool-result hooks.
+   - The guide’s supporting-type summary at `docs/guides/hooks.mdx:199-204` documents `HookToolResult` as `tool_use_id`, `name`, `content`, `is_error`, but the current type also includes `has_images`. See `meerkat-core/src/hooks.rs:222-234`.
+   - This matters because hook authors only receive the text projection of tool output; non-text content is signaled separately via `has_images`, and `HookPatch::ToolResult` preserves image blocks instead of replacing the entire result. See `meerkat-core/src/hooks.rs:305-329`.
+   - Without that caveat, users can incorrectly assume a rewrite hook has full fidelity over multimodal tool results.
+
+3. The skills guide/examples still document legacy string refs and CLI behavior that do not match the current preferred API.
+   - `docs/guides/skills.mdx:220-250` still promotes slash-prefixed user-message activation and frames legacy strings as routine compatibility input. In core, per-turn activation now comes from canonical `SkillKey` values staged by the surface; the runner explicitly notes that slash refs are no longer parsed directly in the core runtime. See `meerkat-core/src/agent/runner.rs:1011-1016`.
+   - `docs/examples/skills.mdx:145-165`, `docs/examples/skills.mdx:188-200`, and `docs/examples/skills.mdx:307-367` use string arrays like `["/formatting/markdown"]` for `skill_refs`/`skill_references`, and the Python per-turn example at `docs/examples/skills.mdx:343-346` is also missing `await`.
+   - The Python and TypeScript SDKs now normalize `skill_refs` to structured `{ source_uuid, skill_name }` payloads, and their legacy string fallback expects `"<source_uuid>/<skill_name>"`, not a bare skill ID. See `sdks/python/meerkat/session.py:37-60`, `sdks/python/meerkat/client.py:2485-2489`, `sdks/typescript/src/client.ts:185-205`, and `sdks/typescript/src/client.ts:2799-2802`.
+   - The CLI `--skill` flag only resolves runtime-local skill sources and preloads skill IDs into `preload_skills`; it is not a per-turn `skill_refs` surface. See `meerkat-cli/src/main.rs:2471-2491` and `meerkat-cli/src/main.rs:2192-2255`.
+
+4. `docs/guides/memory.mdx` conflates semantic memory enablement with compaction enablement.
+   - The guide says at `docs/guides/memory.mdx:16-42` that both systems require “per-request enablement” and that `AgentFactory.memory(true)` enables “semantic memory + compaction”.
+   - In the factory, `override_memory` only gates the memory store and `memory_search` tool. The compactor is wired independently whenever the binary is built with `session-compaction`, regardless of the memory toggle. See `meerkat/src/factory.rs:2726-2759` and `meerkat/src/factory.rs:2761-2768`.
+   - This is an important library-user distinction: compaction can be on without semantic memory, and `enable_memory` is not the runtime switch for compaction.
+
+5. The memory guide/examples contain stale CLI and budget parameter guidance.
+   - `docs/guides/memory.mdx:29` says `cargo build -p meerkat-cli`, but the CLI package name is `rkat`. See `meerkat-cli/Cargo.toml:1-17`.
+   - `docs/guides/memory.mdx:223-225` suggests `rkat run --memory`, but there is no `--memory` CLI flag. The CLI only toggles memory through tool presets, with `--tools full` setting the memory override. See `meerkat-cli/src/main.rs:1171-1183` and `meerkat-cli/src/main.rs:400-427`.
+   - `docs/examples/memory.mdx:185-189` and `docs/examples/memory.mdx:228-232` use `max_total_tokens` and `max_duration_ms` for RPC/REST/Python budget payloads, and `docs/examples/memory.mdx:268-272` uses `"budget_type": "max_tokens"`. The live structs/events use `BudgetLimits { max_tokens, max_duration, max_tool_calls }` and `BudgetType::{tokens,time,tool_calls}`. See `meerkat-core/src/budget.rs:10-19`, `meerkat-rpc/src/handlers/session.rs:101-103`, `meerkat-rest/src/lib.rs:832-834`, `meerkat-mcp-server/src/lib.rs:981-999`, and `meerkat-core/src/event.rs:392-406` plus `meerkat-core/src/event.rs:540-548`.
+
+6. `docs/examples/tools.mdx` still uses pre-refactor Rust SDK interfaces for custom tools and session creation.
+   - The custom tool snippet at `docs/examples/tools.mdx:33-41` returns `Result<ToolResult, ToolError>`, but `AgentToolDispatcher::dispatch` now returns `Result<ToolDispatchOutcome, ToolError>`. See `meerkat-core/src/agent.rs:275-283`.
+   - The Rust session-creation snippet at `docs/examples/tools.mdx:137-141` relies on `CreateSessionRequest { ..Default::default() }`, but `CreateSessionRequest` is not `Default` and now requires fields such as `model`, `prompt`, `render_metadata`, `initial_turn`, and `deferred_prompt_policy`. See `meerkat-core/src/service/mod.rs:148-171`.
+   - That makes the example misleading for library users trying to build a minimal custom-tool integration from the docs.
+
+7. The structured-output guide/examples still carry removed surface names and outdated Rust API shapes.
+   - `docs/guides/structured-output.mdx:264-279` still documents a REST `POST /v1/run` endpoint, but the REST server exposes `POST /sessions`. See `meerkat-rest/src/lib.rs:1084-1090` and `docs/api/rest.mdx:55-60`.
+   - `docs/guides/structured-output.mdx:285-294` introduces a `StructuredOutputParams` type that does not exist in the current codebase; current surfaces carry `output_schema` and `structured_output_retries` directly on session/turn request structs. See `meerkat-rpc/src/handlers/session.rs:107-115` and `meerkat-rest/src/lib.rs:838-846`.
+   - The Rust snippets in `docs/examples/structured-output.mdx:127-140` and `docs/examples/structured-output.mdx:227-241` are also stale for the same `CreateSessionRequest` reason noted above (`meerkat-core/src/service/mod.rs:148-171`).
+
+## Suggested follow-ups
+
+- Rewrite `docs/examples/hooks.mdx` so every override entry uses the actual `HookEntryConfig` wire shape:
+  - include `mode: "foreground" | "background"`
+  - include `capability`
+  - nest command/http config under `runtime`
+- Update `docs/guides/hooks.mdx` to document `HookToolResult.has_images` and explicitly state that tool-result patches preserve image blocks.
+- Refresh `docs/guides/skills.mdx` and `docs/examples/skills.mdx` around current activation paths:
+  - CLI `--skill` = preload only
+  - API/SDK `skill_refs` = structured `SkillKey`
+  - legacy string refs require `<source_uuid>/<skill_name>` and should be labeled deprecated everywhere
+- Split memory docs into two clearly separate stories:
+  - compaction availability (`session-compaction`)
+  - semantic memory availability (`memory-store-session` plus runtime memory enablement)
+- Fix all budget examples to use the live field names for each surface, and align event examples with `BudgetType` serialization (`tokens`, `time`, `tool_calls`).
+- Refresh Rust snippets in `docs/examples/tools.mdx` and `docs/examples/structured-output.mdx` against the current `CreateSessionRequest` and `AgentToolDispatcher` signatures before the next docs publish.

--- a/audit/docs-review-2026-04-21/agent-05-guides-mobs-comms-realtime-scheduling.md
+++ b/audit/docs-review-2026-04-21/agent-05-guides-mobs-comms-realtime-scheduling.md
@@ -1,0 +1,71 @@
+# Agent 05 Findings
+
+## Scope reviewed
+
+- Guides: comms, mobs, mobpack, realtime, scheduling
+- Examples: comms, mobs, mobpack, wasm
+- Validation sources: current RPC handlers, schedule types/tool schemas, web runtime exports, and Python/TypeScript SDK surfaces
+- No factual drift found in the mobpack packaging/trust-policy docs. `docs/guides/mobpack.mdx` and `docs/examples/mobpack.mdx` matched the current CLI nouns and flow closely enough during this pass.
+
+## Files reviewed
+
+- `docs/guides/comms.mdx`
+- `docs/guides/mobs.mdx`
+- `docs/guides/mobpack.mdx`
+- `docs/guides/realtime.mdx`
+- `docs/guides/scheduling.mdx`
+- `docs/examples/comms.mdx`
+- `docs/examples/mobs.mdx`
+- `docs/examples/mobpack.mdx`
+- `docs/examples/wasm.mdx`
+- `docs/api/rpc.mdx`
+- `docs/api/mcp.mdx`
+- `meerkat-rpc/src/handlers/comms.rs`
+- `meerkat-rpc/src/handlers/mob.rs`
+- `meerkat-rpc/src/handlers/realtime.rs`
+- `meerkat-rpc/src/router.rs`
+- `meerkat-core/src/comms.rs`
+- `meerkat-core/src/model_profile/capabilities/openai.rs`
+- `meerkat-schedule/src/types.rs`
+- `meerkat-schedule/src/tools.rs`
+- `meerkat-web-runtime/src/lib.rs`
+- `sdks/python/meerkat/client.py`
+- `sdks/python/meerkat/session.py`
+- `sdks/python/meerkat/mob.py`
+- `sdks/typescript/src/client.ts`
+- `sdks/typescript/src/session.ts`
+
+## Findings
+
+1. `docs/guides/mobs.mdx` still documents stale mob tool names and blurs the agent-side vs host-side split. The table at `docs/guides/mobs.mdx:178-200` lists tools like `spawn_member`, `spawn_many_members`, `wire_members`, and `unwire_members`, then says those tools are available on every surface. Current host surfaces expose typed `mob/*` methods such as `mob/spawn`, `mob/spawn_many`, `mob/wire`, `mob/unwire`, `mob/flow_run`, and `mob/flow_status` instead (`docs/api/rpc.mdx:82-122`, `meerkat-rpc/src/handlers/mob.rs:203-420`, `meerkat-rpc/src/handlers/mob.rs:534-904`). The public MCP surface likewise exposes `meerkat_mob_*` control-plane tools, not raw agent-side `mob_*` tools (`docs/api/mcp.mdx:71-76`). As written, the guide teaches a surface contract that no longer matches the canonical RPC/MCP/SDK API.
+
+2. `docs/examples/mobs.mdx` keeps using agent-tool workflows in tabs that are labeled like direct surface examples, and it has a visible duplicated block. In the “Agent-side mob tools reference” section the agent tool names are at least current, but the later JSON-RPC/REST/MCP/Python/TypeScript tabs for “Spawn members” and “Wire and unwire peers” tell readers to call `mob_spawn_member` / `mob_wire` tool payloads instead of the current host APIs (`docs/examples/mobs.mdx:228-289`). The current direct surfaces are `mob/spawn` / `mob/wire` on RPC (`docs/api/rpc.mdx:86-101`, `meerkat-rpc/src/handlers/mob.rs:268-326`, `meerkat-rpc/src/handlers/mob.rs:542-590`) and first-class `Mob.spawn()` / `Mob.wire()` on the SDKs (`sdks/python/meerkat/mob.py:220-242`, `sdks/python/meerkat/mob.py:338-342`). There is also an accidental duplicated “Spawn members” block in `docs/examples/mobs.mdx:218-260`, which makes the stale examples harder to trust.
+
+3. `docs/examples/comms.mdx` mixes the old external-event shape with the new typed comms API, and the SDK snippets are no longer valid. The RPC/REST examples in “Send a message” and “External event injection” use `payload` plus `source` without a `kind` discriminator (`docs/examples/comms.mdx:92-147`, `docs/examples/comms.mdx:198-259`), but the current `comms/send` handler expects the flat `CommsCommandRequest` wire shape with `kind: "input" | "peer_message" | "peer_request" | "peer_response"` (`meerkat-rpc/src/handlers/comms.rs:97-180`, `meerkat-core/src/comms.rs:71-123`). The Python and TypeScript SDK snippets are also stale: `session.send(payload=..., source=...)` / `session.send({ payload, source })` no longer match the SDK signatures, which now require a typed comms command (`sdks/python/meerkat/session.py:314-322`, `sdks/python/meerkat/client.py:2065-2108`, `sdks/typescript/src/session.ts:154-160`, `sdks/typescript/src/client.ts:1803-1809`). This should be split into two clearly different flows: `session/external_event` or `sendExternalEvent(...)` for durable external events, and `comms/send` or `session.send({ kind: ... })` for typed comms.
+
+4. `docs/guides/scheduling.mdx` is describing an older scheduler contract and will mislead anyone trying to use the current API. Specific drift:
+- It uses `schedule_create` via `tool/call` in the RPC example (`docs/guides/scheduling.mdx:59-80`), but the canonical host methods are `schedule/create`, `schedule/list`, `schedule/update`, `schedule/occurrences`, etc. (`docs/api/rpc.mdx:123-132`).
+- It describes `type: "cron"` plus `values` / `range` field objects (`docs/guides/scheduling.mdx:85-103`), but the current trigger model is `once`, `interval`, or `calendar`, with calendar fields encoded as `{ "kind": "any" | "values" }` (`meerkat-schedule/src/types.rs:147-205`, `meerkat-schedule/src/tools.rs:73-90`).
+- It shows an interval trigger with only `every_seconds` (`docs/guides/scheduling.mdx:108-113`), but `IntervalTriggerSpec` now requires `start_at_utc` and optionally `end_at_utc` (`meerkat-schedule/src/types.rs:156-163`).
+- It shows simplified target shapes like `{ "type": "session", "model": ..., "prompt": ... }` and `{ "type": "mob", "action": "create_and_run", ... }` (`docs/guides/scheduling.mdx:117-141`), but the real wire model is `target_kind: "session" | "mob"` with typed variants such as `exact_session`, `resumable_session`, `materialize_on_demand_session`, `member`, `flow`, `spawn_helper`, and `fork_helper` (`meerkat-schedule/src/types.rs:280-326`, `meerkat-schedule/src/types.rs:496-527`).
+- The policy names and lifecycle states are also outdated. Current defaults are `misfire_policy = {"type":"skip"}`, `overlap_policy = "skip_if_running"`, `missing_target_policy = "mark_misfired"` (`meerkat-schedule/src/tools.rs:109-125`, `meerkat-schedule/src/types.rs:263-278`), while schedule phase is now only `active | paused | deleted` and occurrence phase includes `awaiting_completion`, `misfired`, and `delivery_failed` (`meerkat-schedule/src/types.rs:97-145`).
+
+5. `docs/guides/realtime.mdx` is missing an important lifecycle caveat: reaching `binding_ready` is not sufficient by itself to guarantee `realtime/open_info` works on a given host. The guide currently tells readers to poll `runtime/realtime_attachment_status` and then call `realtime/open_info` (`docs/guides/realtime.mdx:167-180`), but the handler explicitly returns capability-unavailable when the realtime WebSocket host is not wired in (`meerkat-rpc/src/handlers/realtime.rs:219-224`, routed from `meerkat-rpc/src/router.rs:1179-1211`). The guide should mention that bootstrap methods depend on a host that actually exposes `RealtimeWsHost`, otherwise readers will treat attachment readiness as equivalent to transport availability. Separately, the model guidance is slightly stale: the catalog now treats `gpt-realtime-1.5` as the canonical realtime model and `gpt-realtime` as a supported legacy alias (`meerkat-core/src/model_profile/capabilities/openai.rs:109-163`), so the guide should either prefer `gpt-realtime-1.5` in examples or call out the aliasing explicitly.
+
+6. `docs/examples/wasm.mdx` has a wrong `wire_cross_mob` call signature. The example passes three arguments at `docs/examples/wasm.mdx:113-115`, but the export takes four: `wire_cross_mob(mob_a, agent_a, mob_b, agent_b)` (`meerkat-web-runtime/src/lib.rs:1932-1937`). Anyone copying the snippet will fail before they even get to the comms behavior the example is trying to demonstrate.
+
+## Suggested follow-ups
+
+1. Rewrite the mob docs so each page explicitly separates:
+- agent-side `mob_*` tools inside a running session
+- typed host APIs: `mob/*` over RPC/SDKs and `meerkat_mob_*` over public MCP
+
+2. Rebuild the scheduling guide from the current schedule schema instead of prose memory. `meerkat-schedule/src/tools.rs` plus `meerkat-schedule/src/types.rs` is the best source of truth for trigger, target, and policy shapes.
+
+3. Split comms examples into two sections with different contracts:
+- typed comms commands via `comms/send` / `session.send({ kind: ... })`
+- durable external events via `session/external_event` or `sendExternalEvent(...)`
+
+4. Add a realtime caveat note near the bootstrap flow stating that `realtime/open_info` requires a host with the realtime WebSocket service enabled, and refresh examples to prefer `gpt-realtime-1.5` while mentioning `gpt-realtime` as the compatibility alias.
+
+5. Fix the WASM cross-mob snippet and remove the duplicated “Spawn members” block in `docs/examples/mobs.mdx` during the same cleanup pass.

--- a/audit/docs-review-2026-04-21/agent-06-surfaces-cli-api-sdk-rust.md
+++ b/audit/docs-review-2026-04-21/agent-06-surfaces-cli-api-sdk-rust.md
@@ -1,0 +1,102 @@
+# Agent 06 Findings
+
+## Scope reviewed
+
+- CLI surface docs
+- REST, RPC, and MCP API docs
+- Rust library docs
+- Python SDK docs
+- TypeScript SDK docs
+
+## Files reviewed
+
+- `docs/cli/commands.mdx`
+- `docs/cli/configuration.mdx`
+- `docs/api/mcp.mdx`
+- `docs/api/rest.mdx`
+- `docs/api/rpc.mdx`
+- `docs/rust/overview.mdx`
+- `docs/rust/tools-and-stores.mdx`
+- `docs/rust/advanced.mdx`
+- `docs/sdks/python/overview.mdx`
+- `docs/sdks/python/reference.mdx`
+- `docs/sdks/typescript/overview.mdx`
+- `docs/sdks/typescript/reference.mdx`
+
+## Findings
+
+1. `docs/cli/commands.mdx` is missing current top-level CLI commands.
+
+The “Common commands” table in `docs/cli/commands.mdx:44-59` does not mention `rkat realtime`, `rkat blob`, or `rkat auth`, even though the current CLI exposes them as first-class commands in `meerkat-cli/src/main.rs:1228-1309`. The root help text also advertises `run, realtime` and `session, blob, models, capabilities, doctor` in `meerkat-cli/src/main.rs:84`. This makes the command reference incomplete for the shipped binary.
+
+2. `docs/cli/configuration.mdx` documents stale CLI exit codes.
+
+The exit-code table in `docs/cli/configuration.mdx:126-143` lists codes `10`, `11`, `12`, `20`, `21`, `22`, `30`, `40`, `41`, and `42`. The current CLI only defines and returns `0`, `1`, and `2` in `meerkat-cli/src/main.rs:77-80,2104-2115`. The additional per-error codes are no longer emitted by this binary, so the page currently overstates the contract.
+
+3. `docs/api/rest.mdx` understates the current public REST surface.
+
+The endpoint overview in `docs/api/rest.mdx:51-79` is missing several live routes from the current router in `meerkat-rest/src/lib.rs:1083-1207`, including:
+
+- `/sessions/{id}/system_context`
+- `/sessions/{id}/peer-response-terminal`
+- `/schedule/tools` and `/schedule/call`
+- the full `/schedules/*` family
+- `/realtime/open_info`, `/realtime/status`, `/realtime/capabilities`
+- `/runtime/*` and `/input/*`
+- `/auth/*` and `/realms/*`
+- mob helper/member endpoints such as `/mob/{id}/spawn-helper`, `/fork-helper`, `/wait-kickoff`, member status, member cancel, and member respawn
+
+As written, the page reads like the REST host only exposes session CRUD plus a few helper endpoints, which is no longer true.
+
+4. `docs/api/rest.mdx` points readers at the wrong realm config path.
+
+`docs/api/rest.mdx:105-113` says REST realm config lives under `.../meerkat/rest/realms/<realm>/config.toml`. In the implementation, REST resolves the shared realm locator, opens persistence under the normal realm root, and then reads `realm_paths.config_path` from that shared realm directory in `meerkat-rest/src/lib.rs:221-247`. The default shared state root is `.../meerkat/realms` per `meerkat-core/src/runtime_bootstrap.rs:74-80`. `rest_instance_root()` is `.../meerkat/rest` (`meerkat-rest/src/lib.rs:747-752`), but that is not the realm config location the docs describe.
+
+5. The Python SDK docs are stale on both installation/runtime requirements and the external-event API shape.
+
+`docs/sdks/python/overview.mdx:9-12` says the SDK has “Runtime dependencies: none”, but the published package declares `websockets>=12,<16` in `sdks/python/pyproject.toml:5-11`.
+
+Separately, both Python docs describe `send_external_event` without the required event type:
+
+- `docs/sdks/python/overview.mdx:64-67`
+- `docs/sdks/python/reference.mdx:133-140`
+
+The actual API is `send_external_event(session_id, event_type, payload, *, blocks=None)` in `sdks/python/meerkat/client.py:730-747`, with the session convenience wrapper matching that shape in `sdks/python/meerkat/session.py:245-257`. The docs currently imply a two-argument payload-only call that will not match the shipped client.
+
+6. The TypeScript SDK docs misdescribe default realm behavior and the external-event signature, and they under-document the current exported surface.
+
+`docs/sdks/typescript/overview.mdx:163` says that if `realmId` is omitted and `isolated` is not set, sessions are stored in “the default realm”. The actual server default is isolated mode: `rkat-rpc` builds `RealmSelection::Isolated` when no realm flags are supplied in `meerkat-rpc/src/main.rs:124-129`. The SDK also only forwards realm args when options are explicitly set in `sdks/typescript/src/client.ts:274-283`, so the documented “default realm” behavior is incorrect for the current client/server pair.
+
+The same overview page also documents `sendExternalEvent(sessionId, payload, options?)` at `docs/sdks/typescript/overview.mdx:74`, but the actual method is `sendExternalEvent(sessionId, eventType, payload, options?)` in `sdks/typescript/src/client.ts:496-511`.
+
+In addition, the TS docs still present a narrower surface than the package exports today. The package root exports realtime handles in `sdks/typescript/src/index.ts:35-42`, and the client exposes auth/realm wrappers in `sdks/typescript/src/client.ts:1992-2067`, but those surfaces are not covered in either TS doc page.
+
+7. `docs/rust/tools-and-stores.mdx` contains multiple stale or non-compiling public-API examples.
+
+There are several concrete mismatches on this page:
+
+- `docs/rust/tools-and-stores.mdx:85-100` shows `ToolRegistry::register(tool_def, closure)`, but the actual API only registers schema definitions via `register(def)` / `register_many(defs)` in `meerkat-tools/src/registry.rs:15-30`.
+- `docs/rust/tools-and-stores.mdx:103-123` imports `meerkat::ToolOutput`, but `ToolOutput` is not re-exported from the `meerkat` facade (`meerkat/src/lib.rs:242-245`). The enum currently lives in `meerkat-tools::builtin` at `meerkat-tools/src/builtin/mod.rs:61-68`.
+- `docs/rust/tools-and-stores.mdx:177-195` implements `SessionStore` with `StoreError`, but the trait requires `SessionStoreError` in `meerkat-core/src/session_store.rs:60-74`.
+- `docs/rust/tools-and-stores.mdx:198-215` claims that `AgentFactory::session_store()` makes `build_persistent_service(...)` persist through the custom store. In reality, the runtime-backed service persists through the `PersistenceBundle` store passed into `build_runtime_backed_service`, which becomes the `PersistentSessionService` store in `meerkat/src/surface/runtime_backed.rs:28-35` and `meerkat-session/src/persistent.rs:580-598`.
+- `docs/rust/tools-and-stores.mdx:247-252` uses `McpServerConfig::http(...)`, but the current constructors are `streamable_http(...)` and `sse(...)` in `meerkat-core/src/mcp_config.rs:97-145`.
+
+These examples are likely to fail for readers who copy them verbatim.
+
+8. No material drift found in the remaining scoped pages.
+
+I did not find contract-level inaccuracies in these files during this pass:
+
+- `docs/api/mcp.mdx`
+- `docs/api/rpc.mdx`
+- `docs/rust/overview.mdx`
+- `docs/rust/advanced.mdx`
+
+Those pages looked aligned with the current binaries/contracts, aside from the broader SDK/REST gaps already called out above.
+
+## Suggested follow-ups
+
+- Update the CLI docs together: command inventory in `docs/cli/commands.mdx` and exit-code guidance in `docs/cli/configuration.mdx` should be regenerated from the current binary behavior to avoid further drift.
+- Rework `docs/api/rest.mdx` from the router table in `meerkat-rest/src/lib.rs`, not a hand-maintained subset. The current page is missing too many routes to be safely partial without saying so.
+- Refresh both SDK doc sets from the current exported clients. At minimum, cover realtime, auth/realm, blob, MCP live ops, and the correct external-event signatures in both Python and TypeScript.
+- Replace the Rust `tools-and-stores` examples with compile-checked snippets or snippets derived from examples/tests. This page currently has the highest copy-paste failure risk in the audited set.

--- a/audit/docs-review-2026-04-21/agent-07-reference-architecture-and-contracts.md
+++ b/audit/docs-review-2026-04-21/agent-07-reference-architecture-and-contracts.md
@@ -1,0 +1,105 @@
+# Agent 07 Findings
+
+## Scope reviewed
+
+- Reference docs for architecture, API/contracts, built-in tools, capability/error behavior, skills governance, and historical comms design context.
+- Architecture/design docs under `docs/architecture/*` and `docs/design/mobpack.md` for drift against the current crate graph, runtime/machine seams, and CLI/runtime contracts.
+- Current code for the machine catalog, session/runtime seams, tool registration, mobpack CLI support, skill identity governance, and transport error mapping.
+
+## Files reviewed
+
+Docs in scope:
+
+- `docs/reference/api-reference.mdx`
+- `docs/reference/architecture.mdx`
+- `docs/reference/builtin-tools.mdx`
+- `docs/reference/capability-matrix.mdx`
+- `docs/reference/comms-redesign-v6-hard-cut.md`
+- `docs/reference/design-philosophy.mdx`
+- `docs/reference/session-contracts.mdx`
+- `docs/reference/skills-governance-runbook.mdx`
+- `docs/architecture/RMAT.md`
+- `docs/architecture/deferred-tool-catalog-proposal.md`
+- `docs/architecture/finite-ownership-ledger.md`
+- `docs/architecture/formal-seam-closure.md`
+- `docs/architecture/identity-first-live-voice-proposal.md`
+- `docs/architecture/identity-generation-and-runtime-epoch.md`
+- `docs/architecture/machine-simplification-proposal.md`
+- `docs/architecture/meerkat-runtime-dogma.md`
+- `docs/architecture/meerkat-runtime-schema-parity-ledger.md`
+- `docs/architecture/mob-runtime-schema-parity-ledger.md`
+- `docs/architecture/realtime-259-port-plan.md`
+- `docs/architecture/realtime-transcript-fidelity.md`
+- `docs/architecture/rebuild-trigger-audit.md`
+- `docs/architecture/surface-composability-and-cli-layering-proposal.md`
+- `docs/design/mobpack.md`
+
+Primary code checked for verification:
+
+- `Cargo.toml`
+- `meerkat-machine-schema/src/catalog/mod.rs`
+- `meerkat-cli/src/main.rs`
+- `meerkat-core/src/service/mod.rs`
+- `meerkat-core/src/service/transport.rs`
+- `meerkat-core/src/session.rs`
+- `meerkat-core/src/skills/mod.rs`
+- `meerkat-core/src/agent/state.rs`
+- `meerkat-contracts/src/error/mod.rs`
+- `meerkat-contracts/src/version.rs`
+- `meerkat-session/Cargo.toml`
+- `meerkat/src/factory.rs`
+- `meerkat-schedule/src/tools.rs`
+- `meerkat-mob-pack/src/validate.rs`
+- `meerkat-models/src/lib.rs`
+- `meerkat-auth-core/src/lib.rs`
+- `meerkat-client/src/lib.rs`
+- `meerkat-providers/src/lib.rs`
+- `meerkat-mcp-server/src/lib.rs`
+- `meerkat-web-runtime/src/lib.rs`
+
+## Findings
+
+1. `docs/reference/architecture.mdx` currently conflicts with the settled runtime-backed construction path and understates the live crate ownership split.
+
+- The architecture diagram routes `SURFACES -> SessionService -> MeerkatMachine -> AgentFactory` at `docs/reference/architecture.mdx:17-20`, but the canonical runtime-backed seam elsewhere in the reference set is `MeerkatMachine::prepare_bindings(...)` first, then `SessionBuildOptions.runtime_build_mode = SessionOwned(...)`, then `SessionService::create_session(...)` (`docs/reference/session-contracts.mdx:17-27`, `docs/reference/api-reference.mdx:58-63`, `docs/reference/design-philosophy.mdx:35-39`). The code follows the latter ordering; for example the CLI prepares bindings before building the create request in `meerkat-cli/src/main.rs:5277-5329`.
+- The crate ownership table at `docs/reference/architecture.mdx:75-89` omits several now-important crates from the live workspace graph in `Cargo.toml:3-44`, including the April 18 split shims and new ownership boundaries: `meerkat-auth-core` (`meerkat-auth-core/src/lib.rs:1-12`), `meerkat-client` (`meerkat-client/src/lib.rs:1-12`), `meerkat-providers` (`meerkat-providers/src/lib.rs:1-12`), `meerkat-mob-pack` (`meerkat-mob-pack/src/lib.rs:1-7`), `meerkat-mcp-server` (`meerkat-mcp-server/src/lib.rs:1-6`), `meerkat-web-runtime` (`meerkat-web-runtime/src/lib.rs:1-20`), `meerkat-store` (`meerkat-store/src/lib.rs:1-19`), and `meerkat-memory` (`meerkat-memory/src/lib.rs:1-14`). That makes the page a partial map rather than the “current architecture” source of truth it claims to be.
+
+2. `docs/reference/builtin-tools.mdx` is stale for the scheduler tool surface and for per-build tool override semantics.
+
+- The overview table documents scheduler tools as `schedule_create`, `schedule_list`, `schedule_read`, `schedule_update`, `schedule_pause`, `schedule_resume`, and `schedule_delete` at `docs/reference/builtin-tools.mdx:27-33`. The actual exported tool names are `meerkat_schedule_create`, `meerkat_schedule_get`, `meerkat_schedule_list`, `meerkat_schedule_update`, `meerkat_schedule_pause`, `meerkat_schedule_resume`, `meerkat_schedule_delete`, and `meerkat_schedule_occurrences` in `meerkat-schedule/src/tools.rs:60-181`. `schedule_read` is especially misleading because the real API split is `get` plus `occurrences`.
+- The factory flag table omits the scheduler category entirely at `docs/reference/builtin-tools.mdx:40-46`, even though `AgentFactory` has `enable_schedule` and `.schedule(bool)` in `meerkat/src/factory.rs:797-803` and `meerkat/src/factory.rs:1045-1048`.
+- The per-build override section says the override fields are `Option<bool>` and lists only builtins/shell/memory/mob at `docs/reference/builtin-tools.mdx:53-64`. The current build seam uses tri-state `ToolCategoryOverride` values (`inherit` / `enable` / `disable`) in `meerkat-core/src/session.rs:956-1025`, and the factory/build config now includes `override_schedule` and `schedule_tools` as well as the other categories in `meerkat-core/src/service/mod.rs:199-209` and `meerkat/src/factory.rs:223-242`.
+- There is also an internal-reference gap: the page advertises schedule tools in the overview but never gives them a dedicated reference section, while it does so for task/shell/memory/utility/comms. That makes the only schedule details live in source rather than in the docs page that claims to be comprehensive.
+
+3. The reference error-code tables in `docs/reference/capability-matrix.mdx` and `docs/reference/api-reference.mdx` no longer match the current `SessionError` transport projections.
+
+- `docs/reference/capability-matrix.mdx:37-45` maps `PersistenceDisabled` and `CompactionDisabled` to `CAPABILITY_UNAVAILABLE`, JSON-RPC `-32020`, and CLI `exit 40`. The current session-layer codes are `SESSION_PERSISTENCE_DISABLED` and `SESSION_COMPACTION_DISABLED` in `meerkat-core/src/service/mod.rs:88-100`; their session transport projections are JSON-RPC `-32003` and `-32004`, HTTP `501`, and CLI exit code `0` in `meerkat-core/src/service/transport.rs:8-42`.
+- `docs/reference/api-reference.mdx:281-296` similarly presents a single “Capability unavailable” row as the reference contract, but the session layer now distinguishes capability-disabled session operations from the higher-level wire `ErrorCode::CapabilityUnavailable`. The wire conversion still collapses some `SessionError`s to capability-unavailable at the contracts boundary in `meerkat-contracts/src/error/mod.rs:202-216`, so the docs need to clearly separate “session-layer transport mapping” from “canonical wire envelope mapping” instead of mixing them.
+- The prose at `docs/reference/capability-matrix.mdx:49-53` is also stale for CLI behavior, because the actual session transport helper returns `0` for persistence/compaction-disabled cases, not a non-zero hard failure (`meerkat-core/src/service/transport.rs:34-42`).
+
+4. `docs/design/mobpack.md` is materially ahead of the shipped CLI and mixes implemented behavior with commands that do not exist.
+
+- The page still presents `rkat mob embed`, `rkat mob compile`, `rkat mob publish`, `rkat mob web serve`, and `rkat mob web publish` as available commands (`docs/design/mobpack.md:19-23`, `docs/design/mobpack.md:214-218`, `docs/design/mobpack.md:249-310`, `docs/design/mobpack.md:354-362`). The actual mob CLI only exposes `pack`, `inspect`, `validate`, `deploy`, and `web build` in `meerkat-cli/src/main.rs:1773-1918`.
+- `docs/design/mobpack.md:244-246` documents `--budget-max-tokens`, but the current deploy command uses `--max-total-tokens`, `--max-duration`, and `--max-tool-calls` (`meerkat-cli/src/main.rs:1786-1805`).
+- `docs/design/mobpack.md:354-355` documents `rkat mob validate ... --target web`, but the current validator only accepts a pack path and does not parse any target selector (`meerkat-cli/src/main.rs:1781-1784`, `meerkat-cli/src/main.rs:8387-8394`, `meerkat-mob-pack/src/validate.rs:1-37`).
+- The page is clearly labeled a proposal at the top (`docs/design/mobpack.md:3`), so this is not a correctness failure in isolation; the problem is that it lives in a design/reference path without a stronger “not implemented” fence or a link back to the real CLI surface. Right now it is easy to read it as current product documentation.
+
+5. `docs/reference/skills-governance-runbook.mdx` is behind the current skill identity model.
+
+- The “Required Source Record Fields” section only allows `status` values `active` or `retired` at `docs/reference/skills-governance-runbook.mdx:17-23`, but the actual enum also includes `Disabled` in `meerkat-core/src/skills/mod.rs:196-215`.
+- The migration procedures only cover `rotate`, `split`, and `merge` at `docs/reference/skills-governance-runbook.mdx:35-51`, but the live lineage enum also supports `RenameOrRelocate` in `meerkat-core/src/skills/mod.rs:217-249`, and the identity logic handles it explicitly in `meerkat-core/src/skills/identity.rs:158-241`.
+- The runbook otherwise aligns with the canonical `SkillKey { source_uuid, skill_name }` model and with the existence of remap validation errors such as `MissingSkillRemaps` / `RemapWithoutLineage` / `RemapCycle` (`meerkat-core/src/skills/mod.rs:251-259`, `meerkat-core/src/skills/mod.rs:627-649`), so this looks like partial doc drift rather than a wholesale rewrite need.
+
+6. No material architectural drift was found in the doctrine/ADR set under `docs/architecture/*`, but a couple of historical pages would benefit from clearer linkage to current references.
+
+- The canonical machine/composition counts in `docs/reference/architecture.mdx:46-73` still match `meerkat-machine-schema/src/catalog/mod.rs:18-35`.
+- The machine/spec directories referenced by the reference pages exist under `specs/machines/*` and `specs/compositions/*`.
+- `docs/reference/comms-redesign-v6-hard-cut.md` already has a historical warning banner at `docs/reference/comms-redesign-v6-hard-cut.md:3-9`, which is good. I did not find a code-contract mismatch that requires changing that page for correctness, but it still reads like a reference page while describing removed APIs in the body; that is a documentation-positioning issue more than a factual bug.
+
+## Suggested follow-ups
+
+- Update `docs/reference/architecture.mdx` so the execution-path diagram matches the settled runtime-binding contract, and either expand the crate ownership table to the current workspace split or relabel it as a curated subset.
+- Refresh `docs/reference/builtin-tools.mdx` to use the real scheduler tool names, add the missing scheduler category/override docs, and document the tri-state `ToolCategoryOverride` model instead of `Option<bool>`.
+- Split “session-layer transport mapping” from “wire `ErrorCode` mapping” in `docs/reference/capability-matrix.mdx` and `docs/reference/api-reference.mdx`, so readers can see why `SessionError` codes and `WireError` codes differ.
+- Either move `docs/design/mobpack.md` out of the “current docs” path, or add a strong implementation-status note near every non-shipped command family and link readers to the live CLI command docs.
+- Extend `docs/reference/skills-governance-runbook.mdx` to cover `disabled` source records and `rename_or_relocate` lineage events.

--- a/audit/docs-review-2026-04-21/agent-08-meerkat-skill-files.md
+++ b/audit/docs-review-2026-04-21/agent-08-meerkat-skill-files.md
@@ -1,0 +1,100 @@
+# Agent 08 Findings
+
+## Scope reviewed
+
+- `.claude/skills/meerkat-platform/SKILL.md`
+- `.claude/skills/meerkat-architecture/SKILL.md`
+- `.claude/skills/meerkat-wasm/SKILL.md`
+- Parity against current repo layout, selected runtime/tooling code paths, and current `docs/` pages that cover architecture, capability matrix, CLI, realtime, and WASM behavior
+
+## Files reviewed
+
+- `.claude/skills/meerkat-platform/SKILL.md`
+- `.claude/skills/meerkat-platform/references/api_reference.md`
+- `.claude/skills/meerkat-platform/references/migration_0_5.md`
+- `.claude/skills/meerkat-architecture/SKILL.md`
+- `.claude/skills/meerkat-architecture/references/machine-system.md`
+- `.claude/skills/meerkat-wasm/SKILL.md`
+- `.claude/skills/meerkat-wasm/references/api_surface.md`
+- `docs/reference/architecture.mdx`
+- `docs/reference/capability-matrix.mdx`
+- `docs/guides/realtime.mdx`
+- `docs/cli/commands.mdx`
+- `docs/examples/mobs.mdx`
+- `docs/examples/wasm.mdx`
+- `Cargo.toml`
+- `meerkat-machine-schema/src/catalog/dsl/mod.rs`
+- `meerkat-models/src/lib.rs`
+- `meerkat-tools/src/builtin/composite.rs`
+- `meerkat-web-runtime/src/lib.rs`
+- `meerkat-cli/src/main.rs`
+
+## Findings
+
+### 1. `meerkat-architecture/SKILL.md` still documents a four-machine world, but the current catalog and public architecture docs now expose five canonical machines
+
+- The skill says "Exactly four canonical machines" and claims `meerkat-machine-schema/src/catalog/dsl/` contains exactly those four DSLs: `.claude/skills/meerkat-architecture/SKILL.md:64-77`.
+- The same stale framing is repeated in `.claude/skills/meerkat-architecture/references/machine-system.md:5-18` and `:153-167`.
+- Current repo state disagrees:
+  - `meerkat-machine-schema/src/catalog/dsl/mod.rs:29-54` exports `auth_machine` alongside `meerkat_machine`, `mob_machine`, `schedule_lifecycle`, and `occurrence_lifecycle`.
+  - `docs/reference/architecture.mdx:44-59` explicitly says the current catalog exposes **five** canonical machines, including `AuthMachine`.
+- Impact: the architecture skill will steer readers toward an outdated machine model and can cause bad assumptions when touching auth or schema/catalog parity work.
+
+### 2. `meerkat-architecture/SKILL.md` has stale crate ownership for `meerkat-models`
+
+- The skill says `meerkat-models` owns "Model catalog, provider profiles, parameter schemas": `.claude/skills/meerkat-architecture/SKILL.md:95-118`, especially line 97.
+- Current repo state shows `meerkat-models` is now a shim:
+  - `meerkat-models/src/lib.rs:1-19` says all model catalog/profile data moved to `meerkat_core::model_profile` on 2026-04-18 and that the crate is retained as a thin re-export layer.
+  - `docs/reference/architecture.mdx:75-89` matches that newer ownership model and describes `meerkat-models` as a compatibility shim.
+- Impact: the skill points maintainers at the wrong ownership boundary for model-catalog work.
+
+### 3. `meerkat-architecture/SKILL.md` is internally inconsistent on `voice intent` after the repo’s vocabulary convergence to `realtime`
+
+- The skill correctly says public surfaces describe `realtime`, not `voice`: `.claude/skills/meerkat-architecture/SKILL.md:42-62`.
+- It also says per-member voice intent was removed: `.claude/skills/meerkat-architecture/SKILL.md:69`.
+- But later it still uses `voice intent` as the example of a fact that survives respawn and should be keyed by `AgentIdentity`: `.claude/skills/meerkat-architecture/SKILL.md:88-91`.
+- Current guide text uses the converged `realtime` vocabulary instead: `docs/guides/realtime.mdx:12-18`.
+- Impact: this is a confusing, self-contradictory instruction inside the same skill file.
+
+### 4. `meerkat-platform/SKILL.md` still frames current platform guidance around `0.5`, even though the workspace and docs are on `0.6.0`
+
+- The skill intro says "0.5 semantics are runtime-backed by default": `.claude/skills/meerkat-platform/SKILL.md:8`.
+- It immediately directs users to `references/migration_0_5.md`: `.claude/skills/meerkat-platform/SKILL.md:10-21`.
+- It later describes WASM additions as "Key additions in 0.5": `.claude/skills/meerkat-platform/SKILL.md:276`.
+- Its dependency examples still pin `meerkat = "0.5"` and `version = "0.5"`: `.claude/skills/meerkat-platform/SKILL.md:527-542`.
+- Current repo/docs disagree:
+  - `Cargo.toml:48` sets the workspace version to `0.6.0`.
+  - `docs/reference/capability-matrix.mdx:57-72` uses `0.6.0` dependency examples.
+  - `sdks/web/package.json:3` is also `0.6.0`.
+- Impact: readers using the skill as current guidance are likely to copy stale dependency snippets and infer that 0.5 is still the current contract rather than legacy migration context.
+
+### 5. Both the platform and WASM skills overstate which built-in tools are available on wasm32
+
+- `meerkat-platform/SKILL.md` says wasm32 tool dispatch includes utility builtins like `wait`, `datetime`, and `apply_patch`: `.claude/skills/meerkat-platform/SKILL.md:258-266`, especially line 264.
+- `meerkat-wasm/SKILL.md` says wasm32 includes non-shell utility/task/comms/skill surfaces, "including `view_image` for vision-capable models": `.claude/skills/meerkat-wasm/SKILL.md:124-128`.
+- Current code disagrees:
+  - `meerkat-tools/src/builtin/composite.rs:195-235` shows `CompositeDispatcher::new_wasm()` only registers task tools plus `DateTimeTool`.
+  - There is no wasm registration of `apply_patch` or `view_image` in that constructor.
+  - `meerkat-web-runtime/src/lib.rs:441-449` wires the wasm runtime through that dispatcher.
+- Impact: both skills currently advertise wasm capabilities that the runtime does not actually ship.
+
+### 6. No stale path/layout issues found in the three skill directories themselves
+
+- All three scoped skill files exist.
+- Their local `references/` files also exist:
+  - `.claude/skills/meerkat-platform/references/*`
+  - `.claude/skills/meerkat-architecture/references/*`
+  - `.claude/skills/meerkat-wasm/references/*`
+- The top-level repo paths they mention most often also exist (`sdks/web/`, `meerkat-web-runtime/`, `meerkat-machine-schema/`, `meerkat-runtime/`, `meerkat-mob-mcp/`, `tests/integration/`, `scripts/`).
+- So the main problems are guidance drift and architectural drift, not broken relative paths.
+
+## Suggested follow-ups
+
+- Update `.claude/skills/meerkat-architecture/SKILL.md` and `.claude/skills/meerkat-architecture/references/machine-system.md` to reflect the current five-machine catalog and the current `AuthMachine` role.
+- Update the crate ownership table in `.claude/skills/meerkat-architecture/SKILL.md` so `meerkat-models` is described as a compatibility shim, not the primary owner of catalog/profile truth.
+- Remove or rename the lingering `voice intent` wording in `.claude/skills/meerkat-architecture/SKILL.md` so the file consistently uses the post-convergence `realtime` model.
+- Reframe `.claude/skills/meerkat-platform/SKILL.md` so `0.5` appears only as legacy migration context, and refresh example dependency snippets to `0.6.0`.
+- Narrow the wasm capability claims in `.claude/skills/meerkat-platform/SKILL.md` and `.claude/skills/meerkat-wasm/SKILL.md` to match `CompositeDispatcher::new_wasm()`.
+- Outside the scoped skill files, reconcile related public docs that are already drifting in the same area:
+  - `docs/cli/commands.mdx` still shows a different `spawn-helper` syntax than the current CLI implementation and `docs/examples/mobs.mdx`.
+  - `docs/examples/wasm.mdx` still documents an older low-level API/capability picture that does not match the current `@rkat/web` wrapper focus or current runtime behavior.

--- a/audit/docs-review-2026-04-21/unified-remediation-checklist.md
+++ b/audit/docs-review-2026-04-21/unified-remediation-checklist.md
@@ -1,0 +1,285 @@
+# Unified Documentation Remediation Checklist
+
+This checklist consolidates the eight independent audit reports in this folder
+into one working remediation plan.
+
+Use this file as the primary cleanup tracker. The per-agent reports remain the
+detailed evidence/source material.
+
+## Source reports
+
+- [README.md](/Users/luka/.codex/worktrees/fc6a/meerkat/audit/docs-review-2026-04-21/README.md)
+- [agent-01-getting-started-and-nav.md](/Users/luka/.codex/worktrees/fc6a/meerkat/audit/docs-review-2026-04-21/agent-01-getting-started-and-nav.md)
+- [agent-02-concepts-and-configuration.md](/Users/luka/.codex/worktrees/fc6a/meerkat/audit/docs-review-2026-04-21/agent-02-concepts-and-configuration.md)
+- [agent-03-guides-auth-providers-models.md](/Users/luka/.codex/worktrees/fc6a/meerkat/audit/docs-review-2026-04-21/agent-03-guides-auth-providers-models.md)
+- [agent-04-guides-tools-hooks-skills-memory.md](/Users/luka/.codex/worktrees/fc6a/meerkat/audit/docs-review-2026-04-21/agent-04-guides-tools-hooks-skills-memory.md)
+- [agent-05-guides-mobs-comms-realtime-scheduling.md](/Users/luka/.codex/worktrees/fc6a/meerkat/audit/docs-review-2026-04-21/agent-05-guides-mobs-comms-realtime-scheduling.md)
+- [agent-06-surfaces-cli-api-sdk-rust.md](/Users/luka/.codex/worktrees/fc6a/meerkat/audit/docs-review-2026-04-21/agent-06-surfaces-cli-api-sdk-rust.md)
+- [agent-07-reference-architecture-and-contracts.md](/Users/luka/.codex/worktrees/fc6a/meerkat/audit/docs-review-2026-04-21/agent-07-reference-architecture-and-contracts.md)
+- [agent-08-meerkat-skill-files.md](/Users/luka/.codex/worktrees/fc6a/meerkat/audit/docs-review-2026-04-21/agent-08-meerkat-skill-files.md)
+
+## How To Use This Checklist
+
+- Mark items done only after the docs change lands and the affected examples are re-checked against current code.
+- Treat `P0` items as copy-paste-breakage or major contract drift.
+- Treat `P1` items as important user-facing accuracy fixes.
+- Treat `P2` items as discoverability, consistency, and maintenance hardening.
+
+## P0: Broken Or Highly Misleading Examples And API Contracts
+
+- [x] Fix the quickstart CLI install command so the main path uses the public install flow instead of repo-local `cargo install --path meerkat-cli`.
+  Affected: `docs/quickstart.mdx`
+  Source: agent 01
+
+- [x] Update quickstart Python and TypeScript setup notes to say the SDKs auto-resolve/download `rkat-rpc` by default instead of requiring it on `PATH`.
+  Affected: `docs/quickstart.mdx`
+  Source: agent 01
+
+- [x] Replace the stale custom dispatcher signature in the concepts/tools docs so it returns `ToolDispatchOutcome`, not `ToolResult`.
+  Affected: `docs/concepts/tools.mdx`
+  Source: agent 02
+
+- [x] Rewrite the hook examples to match the current `HookEntryConfig` wire shape.
+  Required fixes: use `foreground`/`background`, include `capability`, and nest runtime config under `runtime`.
+  Affected: `docs/examples/hooks.mdx`
+  Source: agent 04
+
+- [x] Refresh the Rust custom-tools examples to match the current `AgentToolDispatcher` and `CreateSessionRequest` APIs.
+  Affected: `docs/examples/tools.mdx`
+  Source: agent 04
+
+- [x] Refresh the structured-output guide and examples to use the current REST and Rust surfaces.
+  Required fixes: `POST /sessions` instead of `/v1/run`, remove `StructuredOutputParams`, and update the Rust session creation snippets.
+  Affected: `docs/guides/structured-output.mdx`, `docs/examples/structured-output.mdx`
+  Source: agent 04
+
+- [x] Fix memory examples to use the live budget field names and live `BudgetType` values.
+  Required fixes: stop using `max_total_tokens`, `max_duration_ms`, and `budget_type = "max_tokens"` in places where the current schema expects `max_tokens`, `max_duration`, and `tokens`/`time`/`tool_calls`.
+  Affected: `docs/examples/memory.mdx`
+  Source: agent 04
+
+- [x] Replace stale mob host-surface examples that still teach agent-tool payloads instead of the current `mob/*` host APIs and SDK methods.
+  Affected: `docs/guides/mobs.mdx`, `docs/examples/mobs.mdx`
+  Source: agent 05
+
+- [x] Rebuild the scheduling guide against the current schedule schema and host APIs.
+  Required fixes: stop using `schedule_create` via `tool/call`, old `cron` field objects, simplified interval triggers, and obsolete target/policy/lifecycle shapes.
+  Affected: `docs/guides/scheduling.mdx`
+  Source: agent 05
+
+- [x] Fix the comms examples so typed comms and durable external events use the current distinct APIs.
+  Required fixes: current `kind`-based `comms/send` shape, correct Python/TypeScript SDK signatures, and a clear split from `session/external_event`.
+  Affected: `docs/examples/comms.mdx`
+  Source: agent 05
+
+- [x] Fix the WASM cross-mob example to use the actual `wire_cross_mob(mob_a, agent_a, mob_b, agent_b)` signature.
+  Affected: `docs/examples/wasm.mdx`
+  Source: agent 05
+
+- [x] Expand the REST API docs from the live router instead of the current subset so they match the actual shipped surface.
+  Required fixes: include the missing session helper, schedule, realtime, runtime, input, auth, realm, and extended mob endpoints.
+  Affected: `docs/api/rest.mdx`
+  Source: agent 06
+
+- [x] Correct the Python SDK docs for runtime requirements and `send_external_event(...)`.
+  Required fixes: document the `websockets` dependency and the required `event_type` argument.
+  Affected: `docs/sdks/python/overview.mdx`, `docs/sdks/python/reference.mdx`
+  Source: agent 06
+
+- [x] Correct the TypeScript SDK docs for `sendExternalEvent(...)` and default realm behavior.
+  Required fixes: include the `eventType` argument and stop claiming omitted realm options use a shared default realm when the current default is isolated mode.
+  Affected: `docs/sdks/typescript/overview.mdx`, `docs/sdks/typescript/reference.mdx`
+  Source: agent 06
+
+- [x] Rework the Rust tools-and-stores page so all public API snippets compile against current code.
+  Required fixes: `ToolRegistry` usage, `ToolOutput` import/source, `SessionStoreError`, persistent-store wiring, and MCP config constructors.
+  Affected: `docs/rust/tools-and-stores.mdx`
+  Source: agent 06
+
+- [x] Replace stale scheduler tool names and override semantics in the built-in tools reference.
+  Required fixes: current `meerkat_schedule_*` names, `occurrences`, scheduler category docs, and tri-state `ToolCategoryOverride`.
+  Affected: `docs/reference/builtin-tools.mdx`
+  Source: agents 02 and 07
+
+## P1: User-Facing Accuracy And Behavioral Drift
+
+- [x] Add the auth guide to docs navigation and link it directly from the introduction/quickstart flow.
+  Affected: `docs/docs.json`, `docs/introduction.mdx`, `docs/quickstart.mdx`
+  Source: agent 01
+
+- [x] Rework the introduction/examples path so first-time users can actually discover the hello-world starters.
+  Options: add a starter section to the gallery or change the CTA target.
+  Affected: `docs/introduction.mdx`, `docs/examples/gallery.mdx`
+  Source: agent 01
+
+- [x] Clarify configuration docs so env vars are described as runtime credential lookup, not as a normal config-precedence layer that mutates `Config`.
+  Affected: `docs/concepts/configuration.mdx`
+  Source: agent 02
+
+- [x] Fix the Anthropic provider table so it no longer presents `claude-opus-4-6` as both the top recommendation and the fallback.
+  Affected: `docs/concepts/providers.mdx`
+  Source: agent 02
+
+- [x] Update OpenAI provider parameter guidance to current GPT-5-era `reasoning_effort` semantics and supported values.
+  Affected: `docs/concepts/providers.mdx`
+  Source: agent 02
+
+- [x] Document realm ID syntax constraints instead of calling realm IDs opaque/free-form strings.
+  Affected: `docs/concepts/realms.mdx`
+  Source: agent 02
+
+- [x] Clarify archive semantics in the sessions concept docs.
+  Required fix: explain that archive removes the live/runtime handle and hides the session from normal listing, but committed history remains readable.
+  Affected: `docs/concepts/sessions.mdx`
+  Source: agent 02
+
+- [x] Update concepts/tools to include current schedule-tool availability and correct the description of live MCP mutation vs external filter control.
+  Affected: `docs/concepts/tools.mdx`
+  Source: agent 02
+
+- [x] Update concepts/tools multimodal output guidance to the current content model.
+  Required fixes: include `Video`, remove obsolete `source_path` expectations, and describe the current `ToolResult.content` model.
+  Affected: `docs/concepts/tools.mdx`
+  Source: agent 02
+
+- [x] Correct the auth guide so it does not imply `rkat auth login` is currently realm-scoped.
+  Required fix: distinguish `env_default`, current CLI `dev:*` behavior, and realm/profile-targeted REST/RPC flows.
+  Affected: `docs/guides/auth.mdx`
+  Source: agent 03
+
+- [x] Fix stale backend/auth identifiers in the auth matrix.
+  Required fixes: `bedrock_aws_sigv4`, `google_code_assist`, and related exact names from the provider matrix.
+  Affected: `docs/guides/auth.mdx`
+  Source: agent 03
+
+- [x] Expand or narrow the credential-source section so it matches the current surface.
+  Required fixes: account for `PlatformDefault` and `FileDescriptor`, and stop overstating `ManagedStore.profile` if runtime lookup is binding-driven.
+  Affected: `docs/guides/auth.mdx`
+  Source: agent 03
+
+- [x] Add a clear caveat that self-hosted Gemma audio capability is not currently surfaced as a Meerkat self-hosted capability/realtime path.
+  Affected: `docs/guides/self-hosted-gemma4.mdx`
+  Source: agent 03
+
+- [x] Add the current `HookToolResult.has_images` caveat and explain that tool-result hook patches preserve image blocks rather than replacing the entire multimodal result.
+  Affected: `docs/guides/hooks.mdx`
+  Source: agent 04
+
+- [x] Rewrite skills docs around the current activation model.
+  Required fixes: CLI `--skill` as preload-only, structured `SkillKey`/`skill_refs` on APIs, and legacy string refs clearly labeled as deprecated compatibility input.
+  Affected: `docs/guides/skills.mdx`, `docs/examples/skills.mdx`
+  Source: agent 04
+
+- [x] Separate semantic memory enablement from compaction enablement in the memory guide.
+  Affected: `docs/guides/memory.mdx`
+  Source: agent 04
+
+- [x] Fix stale memory CLI guidance.
+  Required fixes: `cargo build -p rkat` or equivalent current guidance, and stop documenting a non-existent `rkat run --memory` flag.
+  Affected: `docs/guides/memory.mdx`
+  Source: agent 04
+
+- [x] Rewrite mob docs so agent-side `mob_*` tools and host-side `mob/*` / `meerkat_mob_*` surfaces are clearly separated.
+  Affected: `docs/guides/mobs.mdx`, `docs/examples/mobs.mdx`
+  Source: agent 05
+
+- [x] Add a realtime caveat that `binding_ready` does not by itself guarantee `realtime/open_info` works; the host must expose the realtime websocket service.
+  Affected: `docs/guides/realtime.mdx`
+  Source: agent 05
+
+- [x] Refresh realtime examples to prefer the current canonical realtime model while documenting any legacy aliasing explicitly.
+  Affected: `docs/guides/realtime.mdx`
+  Source: agent 05
+
+- [x] Expand the CLI command docs to include the currently shipped top-level commands.
+  Required fixes: include `auth`, `blob`, `realtime`, and anything else missing from the current binary.
+  Affected: `docs/cli/commands.mdx`
+  Source: agent 06
+
+- [x] Correct stale CLI exit-code documentation.
+  Affected: `docs/cli/configuration.mdx`
+  Source: agent 06
+
+- [x] Fix the REST docs’ stated realm config path so it points to the shared realm root rather than a REST-specific directory.
+  Affected: `docs/api/rest.mdx`
+  Source: agent 06
+
+- [x] Expand the TypeScript docs to cover the currently exported realtime and auth/realm surfaces.
+  Affected: `docs/sdks/typescript/overview.mdx`, `docs/sdks/typescript/reference.mdx`
+  Source: agent 06
+
+- [x] Split session-layer transport error mapping from canonical wire-envelope error mapping in the reference docs.
+  Affected: `docs/reference/capability-matrix.mdx`, `docs/reference/api-reference.mdx`
+  Source: agent 07
+
+- [x] Update the skills governance runbook for current source statuses and lineage events.
+  Required fixes: `disabled` status and `rename_or_relocate`.
+  Affected: `docs/reference/skills-governance-runbook.mdx`
+  Source: agent 07
+
+- [x] Update `meerkat-architecture` skill docs for the current five-machine catalog, current `meerkat-models` ownership, and the repo-wide `realtime` vocabulary.
+  Affected: `.claude/skills/meerkat-architecture/SKILL.md`, `.claude/skills/meerkat-architecture/references/machine-system.md`
+  Source: agent 08
+
+- [x] Reframe `meerkat-platform` skill guidance so `0.5` is treated as legacy migration context, not as the current platform contract.
+  Affected: `.claude/skills/meerkat-platform/SKILL.md`
+  Source: agent 08
+
+- [x] Narrow both platform/WASM skill files to the actual wasm32 built-in tool surface.
+  Affected: `.claude/skills/meerkat-platform/SKILL.md`, `.claude/skills/meerkat-wasm/SKILL.md`
+  Source: agent 08
+
+## P2: Discoverability, Cleanup, And Maintenance Hardening
+
+- [x] Align the quickstart Rust snippet with one maintained in-repo starter example or explicitly point readers to the maintained example as the source of truth.
+  Affected: `docs/quickstart.mdx`, `meerkat/examples/simple.rs`
+  Source: agent 01
+
+- [x] Sweep adjacent docs for copied stale tool examples/status text after fixing the concepts/tools page.
+  High-value follow-up targets: `docs/examples/tools.mdx`, `docs/reference/builtin-tools.mdx`
+  Source: agent 02
+
+- [x] Remove the duplicated “Spawn members” block in the mobs examples page.
+  Affected: `docs/examples/mobs.mdx`
+  Source: agent 05
+
+- [x] Add or improve schedule-tool reference coverage so the docs do not mention the category only in passing.
+  Affected: `docs/reference/builtin-tools.mdx` and any schedule docs that should link back to it
+  Source: agents 02 and 07
+
+- [x] Update the reference architecture page so its execution-path diagram matches the settled runtime-binding contract.
+  Affected: `docs/reference/architecture.mdx`
+  Source: agent 07
+
+- [x] Expand or relabel the architecture crate ownership table so it reflects the current workspace split instead of reading like a complete map while omitting important crates.
+  Affected: `docs/reference/architecture.mdx`
+  Source: agent 07
+
+- [x] Decide how to position historical/proposal docs so they are not mistaken for shipped product behavior.
+  Priority targets: `docs/design/mobpack.md`, `docs/reference/comms-redesign-v6-hard-cut.md`
+  Source: agent 07
+
+- [x] Add stronger implementation-status notes to `docs/design/mobpack.md` wherever it documents commands or flags the CLI does not currently ship.
+  Affected: `docs/design/mobpack.md`
+  Source: agent 07
+
+- [x] Reconcile public docs and skill docs anywhere the same architectural drift appears in both.
+  Current overlap hot spots: machine count, `meerkat-models` ownership, realtime/voice vocabulary, wasm tool availability.
+  Affected: `docs/reference/architecture.mdx`, `docs/guides/realtime.mdx`, `.claude/skills/meerkat-*`
+  Source: agents 07 and 08
+
+## Recommended Execution Order
+
+- [x] Batch 1: Fix quickstart, auth discoverability, and obviously broken example snippets.
+- [x] Batch 2: Fix current host/API surface docs for tools, schedules, mobs, comms, REST, Python, TypeScript, and Rust examples.
+- [x] Batch 3: Fix concept/reference drift and error-code/ownership tables.
+- [x] Batch 4: Fix `.claude/skills/meerkat-*` parity and historical/proposal doc positioning.
+- [x] Batch 5: Do a final cross-doc consistency pass for vocabulary, tool names, and surface names.
+
+## Completion Criteria
+
+- [x] Every changed example has been compared against current code or a current test/example.
+- [x] Quickstart paths work for CLI, Rust, Python, and TypeScript without hidden prerequisites.
+- [x] Host-surface docs consistently distinguish CLI/REST/RPC/MCP/SDK calls from in-agent tool calls.
+- [x] Architecture/reference pages no longer contradict current runtime/machine ownership.
+- [x] `.claude/skills/meerkat-*` no longer teach stale platform assumptions.

--- a/audit/docs-review-pass2-2026-04-21/README.md
+++ b/audit/docs-review-pass2-2026-04-21/README.md
@@ -1,0 +1,79 @@
+# Docs and Skills Review Audit — Pass 2
+
+This folder contains an independent second-pass documentation review gathered on
+2026-04-21 after remediation work landed.
+
+Each agent owns exactly one findings file and reviews only its assigned scope.
+The goal is to identify any remaining:
+
+- factual inaccuracies
+- stale or misleading guidance
+- missing coverage
+- broken cross-links or navigation mismatches
+- inconsistencies between docs, skills, and current code/layout
+
+Assigned scopes:
+
+1. `agent-01-getting-started-and-nav.md`
+   - `docs/introduction.mdx`
+   - `docs/quickstart.mdx`
+   - `docs/docs.json`
+   - global navigation / discoverability issues
+
+2. `agent-02-concepts-and-configuration.md`
+   - `docs/concepts/*.mdx`
+   - configuration-related conceptual framing
+
+3. `agent-03-guides-auth-providers-models.md`
+   - `docs/guides/auth.mdx`
+   - `docs/guides/self-hosted-gemma4.mdx`
+   - provider/model/auth guidance referenced from guides
+
+4. `agent-04-guides-tools-hooks-skills-memory.md`
+   - `docs/guides/hooks.mdx`
+   - `docs/guides/skills.mdx`
+   - `docs/guides/memory.mdx`
+   - `docs/guides/structured-output.mdx`
+   - `docs/examples/hooks.mdx`
+   - `docs/examples/skills.mdx`
+   - `docs/examples/memory.mdx`
+   - `docs/examples/tools.mdx`
+   - `docs/examples/structured-output.mdx`
+
+5. `agent-05-guides-mobs-comms-realtime-scheduling.md`
+   - `docs/guides/comms.mdx`
+   - `docs/guides/mobs.mdx`
+   - `docs/guides/mobpack.mdx`
+   - `docs/guides/realtime.mdx`
+   - `docs/guides/scheduling.mdx`
+   - `docs/examples/comms.mdx`
+   - `docs/examples/mobs.mdx`
+   - `docs/examples/mobpack.mdx`
+   - `docs/examples/wasm.mdx`
+
+6. `agent-06-surfaces-cli-api-sdk-rust.md`
+   - `docs/cli/*.mdx`
+   - `docs/api/*.mdx`
+   - `docs/rust/*.mdx`
+   - `docs/sdks/**/*.mdx`
+
+7. `agent-07-reference-architecture-and-contracts.md`
+   - `docs/reference/*`
+   - `docs/architecture/*`
+   - `docs/design/*`
+   - architecture/reference parity with current crate layout
+
+8. `agent-08-meerkat-skill-files.md`
+   - `.claude/skills/meerkat-platform/SKILL.md`
+   - `.claude/skills/meerkat-architecture/SKILL.md`
+   - `.claude/skills/meerkat-wasm/SKILL.md`
+   - skill/doc parity against `docs/` and current repo layout
+
+Expected file shape:
+
+- Scope reviewed
+- Files reviewed
+- Findings
+- Suggested follow-ups
+
+Prefer concrete citations using file paths and, when useful, line numbers.

--- a/audit/docs-review-pass2-2026-04-21/agent-01-getting-started-and-nav.md
+++ b/audit/docs-review-pass2-2026-04-21/agent-01-getting-started-and-nav.md
@@ -1,0 +1,69 @@
+# Agent 01 Findings
+
+## Scope reviewed
+
+- `docs/introduction.mdx`
+- `docs/quickstart.mdx`
+- `docs/docs.json`
+- Global navigation and discoverability around the getting-started path
+
+## Files reviewed
+
+- `docs/introduction.mdx`
+- `docs/quickstart.mdx`
+- `docs/docs.json`
+- `meerkat/examples/simple.rs`
+- `meerkat-cli/Cargo.toml`
+- `meerkat-rpc/Cargo.toml`
+- `meerkat-rest/Cargo.toml`
+- `meerkat-mcp-server/Cargo.toml`
+- `examples/README.md`
+- `examples/001-hello-meerkat-rs/README.md`
+- `examples/002-hello-meerkat-py/README.md`
+- `examples/003-hello-meerkat-ts/README.md`
+- `docs/examples/gallery.mdx`
+- `docs/guides/hooks.mdx`
+- `docs/examples/hooks.mdx`
+- `examples/011-hooks-guardrails-rs/README.md`
+- `meerkat-hooks/src/lib.rs`
+
+## Findings
+
+1. `docs/quickstart.mdx` ends with a docs-site-broken local filesystem link, and the note attached to it is no longer accurate.
+
+   - `docs/quickstart.mdx:150-151` links to `/Users/luka/.codex/worktrees/fc6a/meerkat/meerkat/examples/simple.rs`. That is a machine-local path, not a portable docs URL, so it will not work for published docs readers.
+   - The same note says the quickstart Rust snippet is "kept aligned" with the maintained starter example, but the current example uses `claude-sonnet-4-5` in both `factory.build_llm_adapter(...)` and `.model(...)` at `meerkat/examples/simple.rs:25` and `meerkat/examples/simple.rs:34`, while `docs/quickstart.mdx:59` and `docs/quickstart.mdx:66` use `claude-sonnet-4-6`.
+   - Impact: the final trust-building note on the page currently does the opposite: it sends readers to a dead link and overstates snippet parity.
+
+2. The introduction's "single 5MB binary" positioning does not match the current shipped surface layout.
+
+   - `docs/introduction.mdx:12` and `docs/introduction.mdx:25` describe Meerkat as a "Single 5MB binary" with "<10ms startup".
+   - The current repo ships multiple binaries across separate surface crates, not a single user-facing binary: `rkat` and `rkat-mini` in `meerkat-cli/Cargo.toml:15-21`, `rkat-rpc` and `rkat-rpc-mini` in `meerkat-rpc/Cargo.toml:15-21`, `rkat-rest` in `meerkat-rest/Cargo.toml:15-17`, and `rkat-mcp` in `meerkat-mcp-server/Cargo.toml:15-17`.
+   - `docs/quickstart.mdx:21` and `docs/quickstart.mdx:29` also explicitly tell Python and TypeScript users that the SDK auto-resolves `rkat-rpc`, which further reinforces that the current product story is "multiple surfaces and helper binaries", not "one binary".
+   - Impact: this is likely to confuse readers evaluating installation/distribution options from the landing page.
+
+3. The introduction makes an exact "eight hook points" claim while the current repo still contains conflicting "7 hook points" language.
+
+   - `docs/introduction.mdx:16` says there are "Eight hook points".
+   - Some current docs and code agree with that: `docs/guides/hooks.mdx:11-22` and `docs/examples/hooks.mdx:453-464`.
+   - But current repo content still says 7 in multiple places: `examples/011-hooks-guardrails-rs/README.md:3-8` and `meerkat-hooks/src/lib.rs:14` and `meerkat-hooks/src/lib.rs:26`.
+   - Impact: even if eight is the intended current contract, the introduction is presenting a precise count that the rest of the repo has not fully converged on. For a landing page, this reads as unstable guidance.
+
+4. The getting-started navigation underexposes the beginner examples even though the repo has a strong examples-first on-ramp.
+
+   - In `docs/docs.json:29-30`, the "Getting started" group includes only `introduction`, `quickstart`, and `guides/auth`.
+   - The repo has an explicit beginner examples entrypoint in `examples/README.md:6-27` and a dedicated "Beginner -- Getting Started" section at `examples/README.md:54-64`, plus language-specific hello examples in `examples/001-hello-meerkat-rs/README.md:1-13`, `examples/002-hello-meerkat-py/README.md:1-20`, and `examples/003-hello-meerkat-ts/README.md:1-20`.
+   - `docs/examples/gallery.mdx:12-18` also already exposes those three hello examples, but that page is tucked under the later "Examples" nav group rather than the initial getting-started path.
+   - Impact: a new reader can finish the landing page and quickstart without ever being steered to the most obvious language-specific runnable examples.
+
+5. `docs/docs.json` does not appear to have broken scoped page references, but the scoped nav still misses a stronger onboarding path.
+
+   - I did not find any missing page targets among the scoped nav entries in `docs/docs.json`; all referenced pages for the reviewed groups exist under `docs/`.
+   - The issue here is discoverability rather than broken navigation: the current structure is valid, but it is not optimized for the first-run journey described by `introduction.mdx` and `quickstart.mdx`.
+
+## Suggested follow-ups
+
+- Replace the local absolute path in `docs/quickstart.mdx` with a portable docs or GitHub link, and either sync the snippet to `meerkat/examples/simple.rs` or remove the claim that it is kept aligned.
+- Reword the landing-page binary/performance copy in `docs/introduction.mdx` so it reflects the current multi-surface distribution story without relying on a single-binary simplification.
+- Reconcile the hook-point count across the repo before keeping an exact number in the introduction; if that broader cleanup is out of scope, soften the landing-page wording for now.
+- Promote examples earlier in the onboarding flow by adding `examples/gallery` to the getting-started nav group in `docs/docs.json`, or by adding a more prominent "Choose your language example" step near the top or bottom of `docs/quickstart.mdx`.

--- a/audit/docs-review-pass2-2026-04-21/agent-02-concepts-and-configuration.md
+++ b/audit/docs-review-pass2-2026-04-21/agent-02-concepts-and-configuration.md
@@ -1,0 +1,64 @@
+# Agent 02 Findings
+
+## Scope reviewed
+
+- `docs/concepts/configuration.mdx`
+- `docs/concepts/providers.mdx`
+- `docs/concepts/realms.mdx`
+- `docs/concepts/sessions.mdx`
+- `docs/concepts/tools.mdx`
+
+This pass compared the concept docs against the current runtime/config/session/tooling code and adjacent reference docs for config envelopes, model capability gating, provider inference, and archived-session behavior.
+
+## Files reviewed
+
+- Concept docs:
+  - `docs/concepts/configuration.mdx`
+  - `docs/concepts/providers.mdx`
+  - `docs/concepts/realms.mdx`
+  - `docs/concepts/sessions.mdx`
+  - `docs/concepts/tools.mdx`
+- Key implementation and reference checks:
+  - `meerkat-core/src/config_runtime.rs`
+  - `meerkat-rest/src/lib.rs`
+  - `meerkat-rpc/src/handlers/config.rs`
+  - `meerkat-mcp-server/src/lib.rs`
+  - `meerkat-core/src/provider.rs`
+  - `meerkat-core/src/model_profile/capabilities/openai.rs`
+  - `docs/reference/capability-matrix.mdx`
+  - `meerkat-rpc/src/router.rs`
+  - `meerkat-rest/tests/live_rest_regression.rs`
+
+## Findings
+
+1. `docs/concepts/configuration.mdx:41-48` and `docs/concepts/realms.mdx:75-79` overstate `resolved_paths` as part of one universal config envelope across surfaces.
+
+   The runtime now has explicit public vs diagnostic config-envelope policies. `ConfigEnvelope.resolved_paths` is optional, and `ConfigEnvelopePolicy::Public` strips it entirely (`meerkat-core/src/config_runtime.rs:31-68`). RPC currently returns the diagnostic shape (`meerkat-rpc/src/handlers/config.rs:38-42`), but REST and MCP only include `resolved_paths` when `expose_paths` is enabled; otherwise they return the public shape without it (`meerkat-rest/src/lib.rs:2589-2596`, `meerkat-rest/src/lib.rs:2617-2624`, `meerkat-rest/src/lib.rs:2651-2658`, `meerkat-mcp-server/src/lib.rs:1670-1679`). As written, both concept pages imply `resolved_paths` is always present everywhere, which no longer matches product behavior.
+
+2. `docs/concepts/providers.mdx:7` is too strong when it says tools work identically across Anthropic, OpenAI, Gemini, and self-hosted models.
+
+   Session/config surfaces are largely provider-agnostic, but tool visibility and result handling are capability-gated per model. The capability matrix explicitly calls out that `view_image` is hidden when either `vision` or `image_tool_results` is false (`docs/reference/capability-matrix.mdx:88-93`). The curated OpenAI row for `gpt-5.4` sets `image_tool_results: false` (`meerkat-core/src/model_profile/capabilities/openai.rs:39-66`), so OpenAI sessions do not actually get the same effective tool surface as Anthropic/Gemini for image-returning tools. The opening copy should be softened to reflect “shared session/config model with capability-gated differences,” otherwise it promises stronger cross-provider equivalence than the runtime provides.
+
+3. `docs/concepts/providers.mdx:182-186` has stale provider auto-detection guidance.
+
+   The page says OpenAI inference covers `gpt-*`, `o1-*`, `o3-*`, and `chatgpt-*`, but the current provider inference implementation only recognizes `gpt-*` and `chatgpt-*` for OpenAI (`meerkat-core/src/provider.rs:41-61`). That means the docs currently promise automatic provider inference for `o1-*` and `o3-*` names that the runtime will not infer.
+
+4. `docs/concepts/sessions.mdx:19` and `docs/concepts/sessions.mdx:55` under-describe archived-session readability and make archive sound closer to “hide + history only” than the real lifecycle contract.
+
+   The current RPC behavior explicitly keeps archived sessions readable via `session/read` while rejecting mutating operations afterward (`meerkat-rpc/src/router.rs:4297-4345`). REST also treats archived reads as potentially still available on persistent services, not as a hard-delete guarantee (`meerkat-rest/tests/live_rest_regression.rs:297-314`). The concept page does explain that history remains available, but it omits the more important mental model: archiving retires the live runtime handle and blocks further mutation, while read availability can still persist depending on the surface/service. That omission can mislead readers into treating `archive` like deletion.
+
+5. No additional factual mismatches found in `docs/concepts/tools.mdx`.
+
+   The dispatcher example, built-in category split, staged tool-scope behavior, live MCP mutation notes, multimodal `ToolResult` description, and mob-tool composition all matched the current code/reference docs closely enough for this pass.
+
+6. No additional factual mismatches found in `docs/concepts/realms.mdx` beyond the shared `resolved_paths` wording called out in finding 1.
+
+   Realm ID validation, workspace-vs-opaque defaulting, backend pinning, and SQLite-as-default-persistent-backend messaging all matched the current runtime bootstrap/store behavior.
+
+## Suggested follow-ups
+
+- Update `configuration.mdx` and `realms.mdx` to describe config envelopes as `config`, `generation`, `realm_id`, `instance_id`, and `backend` everywhere, with `resolved_paths` called out as diagnostic/opt-in rather than universal.
+- Rephrase the `providers.mdx` intro so it distinguishes portable session/config concepts from provider-specific capability gating, and cross-link to the capability matrix or tools docs for examples like `view_image`.
+- Fix the auto-detection list in `providers.mdx` to match `Provider::infer_from_model(...)`, or expand the implementation if those legacy prefixes are still meant to resolve.
+- Expand `sessions.mdx` archive language so it says archived sessions keep committed state, reject new mutation/streaming work, and may remain readable depending on the surface/service implementation.
+- Optional docs improvement: `providers.mdx` could use a short “modern parameter caveats” note for Anthropic/Gemini, since the current page only shows legacy `thinking_budget` examples and does not explain newer capability-specific knobs such as Anthropic `effort` or Gemini’s still-unwired `thinking_level`.

--- a/audit/docs-review-pass2-2026-04-21/agent-03-guides-auth-providers-models.md
+++ b/audit/docs-review-pass2-2026-04-21/agent-03-guides-auth-providers-models.md
@@ -1,0 +1,91 @@
+# Agent 03 Findings
+
+## Scope reviewed
+
+- `docs/guides/auth.mdx`
+- `docs/guides/self-hosted-gemma4.mdx`
+- Adjacent provider/auth/model guidance these pages rely on, especially:
+  - `docs/cli/configuration.mdx`
+  - `docs/concepts/providers.mdx`
+  - `README.md`
+- Current auth/provider/self-hosted implementation in:
+  - `meerkat-cli`
+  - `meerkat-core`
+  - `meerkat-auth-core`
+  - `meerkat-anthropic`
+  - `meerkat-openai`
+  - `meerkat-gemini`
+  - `meerkat`
+  - `meerkat-rpc`
+
+## Files reviewed
+
+- `docs/guides/auth.mdx`
+- `docs/guides/self-hosted-gemma4.mdx`
+- `docs/cli/configuration.mdx`
+- `docs/concepts/providers.mdx`
+- `README.md`
+- `meerkat-cli/src/main.rs`
+- `meerkat-core/src/connection.rs`
+- `meerkat-core/src/config.rs`
+- `meerkat-core/src/model_registry.rs`
+- `meerkat-core/src/provider_matrix/anthropic_auth.rs`
+- `meerkat-core/src/provider_matrix/google_auth.rs`
+- `meerkat-core/src/provider_matrix/google_backend.rs`
+- `meerkat-core/src/provider_matrix/openai_auth.rs`
+- `meerkat-auth-core/src/resolver.rs`
+- `meerkat-anthropic/src/runtime/mod.rs`
+- `meerkat-openai/src/runtime/mod.rs`
+- `meerkat-openai/src/client_compatible.rs`
+- `meerkat-gemini/src/runtime/mod.rs`
+- `meerkat/src/factory.rs`
+- `meerkat-rpc/src/handlers/auth.rs`
+- `meerkat-rpc/src/handlers/turn.rs`
+- `meerkat-mob-mcp/src/agent_tools.rs`
+
+## Findings
+
+### 1. `docs/guides/auth.mdx` still implies `rkat auth login` is part of a general realm-targeted setup flow, but the CLI persists only to fixed `dev:*` identities.
+
+- The page intro and main setup flow still read as "declare a realm in config, register credentials via `rkat auth login`, then use `--connection-ref prod:...`" in one continuous story: `docs/guides/auth.mdx:7-17`, `docs/guides/auth.mdx:54-104`.
+- The CLI does not let users choose a target realm or profile during login. Interactive login always persists to fixed `dev` keys such as `dev:anthropic_oauth`, `dev:openai_oauth`, and `dev:google_oauth`; non-interactive login always writes `dev:default_<provider>`: `meerkat-cli/src/main.rs:3522-3550`, `meerkat-cli/src/main.rs:3597-3640`.
+- Provider runtimes then read persisted OAuth material by `<realm>:<auth_profile.id>`, not by an arbitrary binding name. If a user follows the guide's `realm.prod` example, `rkat auth login anthropic` does not populate `prod:anthropic_oauth` for them: `meerkat-anthropic/src/runtime/mod.rs:184-203`, `meerkat-openai/src/runtime/mod.rs:141-160`, `meerkat-gemini/src/runtime/mod.rs:146-165`.
+- The note at `docs/guides/auth.mdx:15-17` helps, but the surrounding walkthrough still overstates what the CLI login flow can do today.
+
+### 2. The auth guide's reference tables are incomplete/inexact versus the shipped auth/config schema.
+
+- The auth-method matrix claims to summarize what is wired today, but it omits the `external_authorizer` method that is present in all three provider auth enums: `docs/guides/auth.mdx:137-160`; `meerkat-core/src/provider_matrix/anthropic_auth.rs:22-50`; `meerkat-core/src/provider_matrix/openai_auth.rs:23-42`; `meerkat-core/src/provider_matrix/google_auth.rs:14-37`.
+- The credential-source table lists `FileDescriptor { fd, format }`, but the current schema is `FileDescriptor { fd, scope_override }`: `docs/guides/auth.mdx:167-175`; `meerkat-core/src/connection.rs:108-129`.
+- The guide also says command/file-descriptor sources "let host applications inject tokens" without noting that `FileDescriptor` is not handled by the simple-secret resolver unless a host-scoped reader is provided. Current resolver behavior is an explicit error on that path: `docs/guides/auth.mdx:158-160`; `meerkat-auth-core/src/resolver.rs:95-104`.
+
+### 3. Self-hosted Gemma guidance is internally consistent with current code, but adjacent config docs still carry stale transport recommendations.
+
+- `docs/guides/self-hosted-gemma4.mdx` aligns with the current implementation on the important mechanics:
+  - self-hosted config is `self_hosted.servers.*` plus `self_hosted.models.*`: `docs/guides/self-hosted-gemma4.mdx:26-65`; `meerkat-core/src/config.rs:972-1058`
+  - only `openai_compatible` transport is currently supported: `meerkat/src/factory.rs:1456-1459`
+  - `chat_completions` is the default API style in config: `meerkat-core/src/config.rs:964-993`
+  - `rkat doctor` checks the normalized `/v1/models` endpoint and validates alias-to-remote-model mapping there: `meerkat-cli/src/main.rs:3905-3978`; `meerkat-core/src/model_registry.rs:215-221`
+- However, `docs/cli/configuration.mdx` still says:
+  - "`responses` for Ollama and LM Studio style servers"
+  - "`chat_completions` for vLLM style deployments"
+  at `docs/cli/configuration.mdx:82-87`.
+- That is now stale relative to the Gemma guide's recommendation to prefer `chat_completions` for Ollama, LM Studio, and vLLM (`docs/guides/self-hosted-gemma4.mdx:16-24`, `docs/guides/self-hosted-gemma4.mdx:91-99`, `docs/guides/self-hosted-gemma4.mdx:147-155`, `docs/guides/self-hosted-gemma4.mdx:187-195`) and relative to the code default of `ChatCompletions` (`meerkat-core/src/config.rs:966-993`).
+
+### 4. No code/documentation mismatch found for the env-var fast path, `connection_ref` carry-through, or self-hosted alias registration mechanics.
+
+- The auth guide's env-var precedence and Gemini fallback are consistent with the resolver and synthesized `env_default` realm: `docs/guides/auth.mdx:24-41`; `meerkat-auth-core/src/resolver.rs:28-48`; `meerkat-core/src/connection.rs:268-340`.
+- The hot-swap/resume `connection_ref` story is supported by current session/turn plumbing: `docs/guides/auth.mdx:183-229`; `meerkat-rpc/src/handlers/turn.rs:29-80`; `meerkat/src/factory.rs:1210-1215`.
+- The self-hosted alias path itself is wired as documented: aliases are merged into the model registry and can be resolved without an explicit provider flag: `meerkat-core/src/model_registry.rs:133-200`; `meerkat-cli/tests/cli_auth_flow.rs:90-120`.
+
+## Suggested follow-ups
+
+1. Rewrite the auth guide's main flow so it clearly separates:
+   - env-var fallback (`env_default`)
+   - current CLI login persistence into fixed `dev:*` TokenStore entries
+   - truly realm/profile-targeted persistence via REST/RPC auth APIs
+2. Update `docs/guides/auth.mdx` tables to match the actual schema:
+   - add `external_authorizer` where supported
+   - fix `FileDescriptor` field names
+   - add a caveat that `FileDescriptor` requires host support beyond the plain resolver path
+3. Bring `docs/cli/configuration.mdx` into line with the self-hosted Gemma guide and current defaults by removing the older "responses for Ollama/LM Studio, chat_completions for vLLM" recommendation.
+4. Optional cleanup: add one explicit note in the auth guide that interactive Google login is the Gemini Code Assist OAuth path, while `google_genai` remains the API-key path.

--- a/audit/docs-review-pass2-2026-04-21/agent-04-guides-tools-hooks-skills-memory.md
+++ b/audit/docs-review-pass2-2026-04-21/agent-04-guides-tools-hooks-skills-memory.md
@@ -1,0 +1,76 @@
+# Agent 04 Findings
+
+## Scope reviewed
+
+- Guides and examples for hooks, skills, memory/compaction, structured output, and tools/MCP.
+- Current runtime/code behavior for hook registration, skill parsing/resolution, memory wiring, and structured-output validation.
+
+## Files reviewed
+
+- `docs/guides/hooks.mdx`
+- `docs/guides/skills.mdx`
+- `docs/guides/memory.mdx`
+- `docs/guides/structured-output.mdx`
+- `docs/examples/hooks.mdx`
+- `docs/examples/skills.mdx`
+- `docs/examples/memory.mdx`
+- `docs/examples/tools.mdx`
+- `docs/examples/structured-output.mdx`
+- `meerkat-cli/src/main.rs`
+- `meerkat-core/src/config.rs`
+- `meerkat-core/src/hooks.rs`
+- `meerkat-core/src/schema.rs`
+- `meerkat-core/src/types.rs`
+- `meerkat-core/src/agent/extraction.rs`
+- `meerkat-core/src/agent/state.rs`
+- `meerkat-core/src/agent/skills.rs`
+- `meerkat-core/src/skills/mod.rs`
+- `meerkat-core/src/skills_config.rs`
+- `meerkat-hooks/src/lib.rs`
+- `meerkat-skills/src/parser.rs`
+- `meerkat-skills/src/renderer.rs`
+- `meerkat-skills/src/resolver.rs`
+- `meerkat-skills/src/resolve.rs`
+- `meerkat-memory/src/lib.rs`
+- `meerkat-memory/src/tool.rs`
+- `meerkat-memory/src/hnsw.rs`
+- `meerkat-memory/src/simple.rs`
+- `meerkat-tools/src/builtin/skills/mod.rs`
+- `meerkat-tools/src/lib.rs`
+- `meerkat-openai/src/client.rs`
+- `meerkat-anthropic/src/client.rs`
+- `meerkat-gemini/src/client.rs`
+- `meerkat/src/factory.rs`
+- `meerkat/src/sdk.rs`
+- `meerkat/Cargo.toml`
+- `meerkat-cli/Cargo.toml`
+
+## Findings
+
+- Hooks: the CLI examples are currently documenting flags that do not exist on `rkat run`. `docs/guides/hooks.mdx:289-311` and `docs/examples/hooks.mdx:14-30`, `docs/examples/hooks.mdx:153-169`, `docs/examples/hooks.mdx:320-336`, `docs/examples/hooks.mdx:476-482` all use `--hooks-override-json` / `--hooks-override-file`, but the `Run` clap args do not define those options in `meerkat-cli/src/main.rs:1013-1226`. The only parser for those flags is test-only (`#[cfg(test)]`) at `meerkat-cli/src/main.rs:2509-2537`. Library-user impact: the documented CLI path for trying hooks in isolation is not available in normal builds.
+
+- Skills: the documented `SKILL.md` examples use invalid frontmatter for the current parser. `docs/guides/skills.mdx:54-74` and `docs/guides/skills.mdx:184-195` show human-readable `name` values like `Shell Patterns` / `Deployment Guide`, but `meerkat-skills/src/parser.rs:83-137` validates `name` via `SkillName::parse`, which only accepts lowercase slug names (`[a-z0-9-]`) and, when loaded from a directory, requires the slug to match the directory name (`meerkat-core/src/skills/mod.rs:108-145`). As written, those examples would be quarantined as parse errors instead of loading successfully.
+
+- Skills: the repository configuration examples are stale relative to the current config schema. `docs/guides/skills.mdx:23-48` uses `transport = "git"` / `transport = "http"` and omits `source_uuid`, but the actual schema is `type = "git" | "http" | "filesystem" | "stdio"` plus a required `source_uuid` on every repository entry (`meerkat-core/src/skills_config.rs:75-133`). The HTTP example also documents `auth_bearer` and `cache_ttl_seconds`, while the runtime expects `auth_token`, optional `auth_header`, `refresh_seconds`, and `timeout_seconds` (`meerkat-skills/src/resolve.rs:92-173`). This is likely to produce copy-paste config failures for library users.
+
+- Skills: the discovery/resolution narrative no longer matches the current implementation. `docs/guides/skills.mdx:83-97` claims exact case-insensitive name matching, but the dedicated resolver is slash-prefix only and explicitly says “No name matching” (`meerkat-skills/src/resolver.rs:1-18`); slash activation in the agent path is also start-of-message `/skill-id` parsing only (`meerkat-core/src/agent/skills.rs:1-31`). Separately, the source-precedence tables in `docs/guides/skills.mdx:9-18` and `docs/examples/skills.mdx:453-463` omit configured filesystem and stdio sources even though both are supported (`meerkat-skills/src/resolve.rs:69-173`), and the built-in skill table in `docs/guides/skills.mdx:148-160` omits `mob-communication`, which is registered in `meerkat/src/lib.rs:253-264`.
+
+- Memory: the SDK override example is using an outdated type. `docs/guides/memory.mdx:34-42` sets `build_config.override_memory = Some(true)`, but `override_memory` is now a `ToolCategoryOverride`, not `Option<bool>` (`meerkat/src/factory.rs:223-231`, `meerkat/src/factory.rs:429-433`). This is a concrete compile-break for Rust users following the guide.
+
+- Memory: the examples understate the build-feature caveat for semantic memory. `docs/examples/memory.mdx:9-83` and the “enable built-in tools” section in `docs/examples/tools.mdx:46-152` present `--tools full` / `enable_memory: true` as sufficient, but memory wiring is still feature-gated at build time (`meerkat/src/factory.rs:2726-2759`) and the default CLI feature set does not include `memory-store` (`meerkat-cli/Cargo.toml:82-99`). The guide already mentions this prerequisite in `docs/guides/memory.mdx:14-33`; the examples should echo or link that caveat so users do not assume the toggle works in a default source build.
+
+- Structured output: the guide currently describes validation as unconditional and `strict` as a generic validation toggle, but the implementation is narrower. `docs/guides/structured-output.mdx:20-28` says the response is validated against the schema using `jsonschema::Validator`, yet validation is feature-gated and silently falls back to “accept parsed JSON without schema validation” when `jsonschema` is disabled (`meerkat-core/src/agent/state.rs:1761-1788`). Also, `docs/guides/structured-output.mdx:47-53` describes `strict` as “Whether to enforce strict schema validation,” but the runtime treats it as provider-lowering/constrained-decoding behavior instead (`meerkat-core/src/types.rs:576-584`, `meerkat-openai/src/client.rs:864-876`). This is an important capability caveat for library users embedding Meerkat with custom feature sets.
+
+- Tools/MCP: no standalone request-shape mismatches found in `docs/examples/tools.mdx` beyond the memory-feature caveat above. The MCP add/remove/reload examples align with the current surfaced parameters.
+
+## Suggested follow-ups
+
+- Update the hooks docs to remove the nonexistent CLI override flags or add a note that hook overrides are currently available only via RPC/REST/MCP/SDK surfaces. If CLI support is intended, it should be wired into `Run` args before the docs keep advertising it.
+
+- Rewrite the skills frontmatter examples so `name` is a lowercase slug matching the directory name, and refresh the repo config snippets to use the current `type = ...` + `source_uuid = ...` format, including stdio/filesystem transport coverage.
+
+- Refresh the skills guide/examples to document the actual current resolution model: slash-ID activation, canonical `SkillKey`/`skill_refs`, supported source transports, and the full built-in skill inventory including `mob-communication`.
+
+- Fix the Rust memory override example to use `ToolCategoryOverride`, and add a short “requires a memory-enabled build” note anywhere examples suggest `enable_memory` or `--tools full` is enough by itself.
+
+- Add a structured-output caveat that schema validation depends on the `jsonschema` feature, and clarify that `strict` is provider-lowering behavior rather than a universal extra validation pass.

--- a/audit/docs-review-pass2-2026-04-21/agent-05-guides-mobs-comms-realtime-scheduling.md
+++ b/audit/docs-review-pass2-2026-04-21/agent-05-guides-mobs-comms-realtime-scheduling.md
@@ -1,0 +1,88 @@
+# Agent 05 Findings
+
+## Scope reviewed
+
+- Guides:
+  - `docs/guides/comms.mdx`
+  - `docs/guides/mobs.mdx`
+  - `docs/guides/mobpack.mdx`
+  - `docs/guides/realtime.mdx`
+  - `docs/guides/scheduling.mdx`
+- Examples:
+  - `docs/examples/comms.mdx`
+  - `docs/examples/mobs.mdx`
+  - `docs/examples/mobpack.mdx`
+  - `docs/examples/wasm.mdx`
+- Implementation cross-checks:
+  - mob RPC catalog and handlers
+  - comms RPC handlers and MCP tool surface
+  - wasm runtime exports
+  - SDK call sites where they clarify current public lifecycle
+
+## Files reviewed
+
+- `docs/guides/comms.mdx`
+- `docs/guides/mobs.mdx`
+- `docs/guides/mobpack.mdx`
+- `docs/guides/realtime.mdx`
+- `docs/guides/scheduling.mdx`
+- `docs/examples/comms.mdx`
+- `docs/examples/mobs.mdx`
+- `docs/examples/mobpack.mdx`
+- `docs/examples/wasm.mdx`
+- `meerkat-contracts/src/rpc_catalog.rs`
+- `meerkat-rpc/src/handlers/comms.rs`
+- `meerkat-rpc/src/handlers/mob.rs`
+- `meerkat-mob-mcp/src/lib.rs`
+- `meerkat-comms/src/mcp/tools.rs`
+- `meerkat-web-runtime/src/lib.rs`
+- `sdks/python/meerkat/client.py`
+- `sdks/typescript/src/client.ts`
+
+## Findings
+
+### Mobs
+
+1. `docs/guides/mobs.mdx` has a stale mob-tool inventory and no longer matches the current agent-side or host-side control plane. The table at `docs/guides/mobs.mdx:180-205` still presents a smaller older surface and leaves out current tools that users now need to understand lifecycle and readiness, including `mob_events`, `mob_respawn`, `mob_force_cancel`, `mob_wait_kickoff`, `mob_wait_ready`, and profile CRUD. On the host side it also never points readers at newer typed RPCs such as `mob/ensure_member`, `mob/reconcile`, `mob/list_members_matching`, `mob/destroy`, `mob/submit_work`, `mob/cancel_work`, `mob/cancel_all_work`, `mob/wait_kickoff`, and `mob/wait_ready`, all of which are now in the public RPC catalog. Current surfaces are defined in `meerkat-mob-mcp/src/lib.rs:1946-2108` and `meerkat-contracts/src/rpc_catalog.rs:340-429`.
+
+2. `docs/examples/mobs.mdx` teaches `mob/member_send` as the host-side way to “send work” (`docs/examples/mobs.mdx:231-269`), but current behavior distinguishes ordinary member-directed content delivery from the newer work lane. `mob/member_send` just delivers content plus `handling_mode` (`meerkat-rpc/src/handlers/mob.rs:667-711`), while tracked work submission/cancellation now lives under `mob/submit_work`, `mob/cancel_work`, and `mob/cancel_all_work` (`meerkat-rpc/src/handlers/mob.rs:1206-1295`, `sdks/typescript/src/client.ts:1181-1212`, `sdks/python/meerkat/client.py:1761-1789`). Without a note about when to use `member_send` versus the work lane, host integrators can easily build on the wrong primitive and miss `work_ref`-based cancellation/idempotency.
+
+### Comms
+
+3. `docs/guides/comms.mdx` underspecifies the current tool contracts in ways that are user-visible. The guide says `send_message`, `send_request`, and `send_response` return only `{"status":"sent"}` (`docs/guides/comms.mdx:254-317`), but the current MCP tool surface returns `{"status":"sent","kind":"..."}` (`meerkat-comms/src/mcp/tools.rs:193-227`). The guide also omits the optional `handling_mode` override on `send_response`, which is part of the current tool contract (`meerkat-comms/src/mcp/tools.rs:165-178`) and matters because it controls whether the requester is interrupted immediately or sees the response at a later turn boundary. Separately, host-side `comms/send` already returns typed receipts such as `peer_message_sent`, `peer_request_sent`, and `peer_response_sent` with IDs and ACK state (`meerkat-rpc/src/handlers/comms.rs:56-94`), so the docs should distinguish the agent-tool receipt from the richer host receipt instead of collapsing both to “sent”.
+
+4. No actionable drift found in `docs/examples/comms.mdx` beyond the guide-level contract gaps above. The examples still match the current `session/create`, `comms/send`, `comms/peers`, and `session/external_event` host surfaces.
+
+### WASM
+
+5. `docs/examples/wasm.mdx` uses the wrong credential/config shape for the current browser runtime. The example passes a singular `api_key` into both `init_runtime()` and `create_session()` (`docs/examples/wasm.mdx:31-54`), but the current wasm bootstrap expects provider-specific keys such as `anthropic_api_key`, `openai_api_key`, and `gemini_api_key` (`meerkat-web-runtime/src/lib.rs:1088-1098`, `meerkat-web-runtime/src/lib.rs:1145-1159`). More importantly, `create_session()` no longer accepts per-session API keys at all: credentials are loaded during runtime bootstrap, and session creation only accepts session config (`meerkat-web-runtime/src/lib.rs:1217-1221`, `meerkat-web-runtime/src/lib.rs:1312-1316`). As written, the sample is copy-paste broken for current code.
+
+### Realtime
+
+6. No actionable drift found in `docs/guides/realtime.mdx` during this pass. The guide’s capability-driven attachment model, `runtime/realtime_attachment_status*` coverage, and no-public-reconfigure-RPC caveat matched the current runtime and RPC surface closely enough that I did not flag remediation here.
+
+### Scheduling
+
+7. No actionable drift found in `docs/guides/scheduling.mdx`. The trigger types, target bindings, policy names, lifecycle phases, and agent-side tool names matched the current schedule types/tool surface on this branch.
+
+### Mobpack
+
+8. No actionable drift found in `docs/guides/mobpack.mdx` or `docs/examples/mobpack.mdx`. The documented `pack`, `inspect`, `validate`, `deploy`, `web build`, and trust-policy resolution flow still line up with the current CLI.
+
+## Suggested follow-ups
+
+1. Update `docs/guides/mobs.mdx` to separate:
+   - current agent-side mob tools
+   - current public host RPC/SDK methods
+   - readiness/work-lane lifecycle guidance (`wait_*` and `submit_work`)
+
+2. Update `docs/examples/mobs.mdx` so the “send work” section distinguishes:
+   - `mob/member_send` for ordinary content delivery
+   - `mob/submit_work` for tracked/cancellable work
+
+3. Refresh `docs/guides/comms.mdx` to document:
+   - actual agent-tool return payloads
+   - optional `send_response.handling_mode`
+   - the difference between MCP tool receipts and host `comms/send` receipts
+
+4. Fix `docs/examples/wasm.mdx` snippets to use bootstrap-time provider keys and session-time config only, with no per-session `api_key` field.

--- a/audit/docs-review-pass2-2026-04-21/agent-06-surfaces-cli-api-sdk-rust.md
+++ b/audit/docs-review-pass2-2026-04-21/agent-06-surfaces-cli-api-sdk-rust.md
@@ -1,0 +1,55 @@
+# Agent 06 Findings
+
+## Scope reviewed
+
+- CLI surface docs for command/config behavior
+- Public API docs for MCP, REST, and JSON-RPC
+- Rust library docs for overview, tools/stores, and advanced embedding
+- Python and TypeScript SDK overview/reference docs, with parity checks against current SDK code
+
+## Files reviewed
+
+- `docs/cli/commands.mdx`
+- `docs/cli/configuration.mdx`
+- `docs/api/mcp.mdx`
+- `docs/api/rest.mdx`
+- `docs/api/rpc.mdx`
+- `docs/rust/overview.mdx`
+- `docs/rust/tools-and-stores.mdx`
+- `docs/rust/advanced.mdx`
+- `docs/sdks/python/overview.mdx`
+- `docs/sdks/python/reference.mdx`
+- `docs/sdks/typescript/overview.mdx`
+- `docs/sdks/typescript/reference.mdx`
+
+## Findings
+
+1. `docs/cli/configuration.mdx:126-134` has a stale exit-code contract. The page says exit code `2` means “Invalid params or CLI contract error,” but the current CLI reserves `2` for graceful budget exhaustion and returns `1` for ordinary command/runtime failures. The active constants and exit mapping are in `meerkat-cli/src/main.rs:77-80` and `meerkat-cli/src/main.rs:2102-2115`. This is user-visible drift for scripts/CI that branch on exit codes.
+
+2. `docs/api/mcp.mdx:37-69` presents the MCP host tool list as if it were the always-available `rkat-mcp` surface, but the actual tool inventory is both incomplete and incorrectly gated.
+   The docs omit default/base tools that are currently shipped, including `meerkat_skills` and `meerkat_blob_get` from `meerkat-mcp-server/src/lib.rs:1205-1228`, plus the schedule tools added unconditionally by `tools_list()` in `meerkat-mcp-server/src/lib.rs:1316-1318`.
+   The docs also list mob/realtime tools as general surface tools, but those are only added when the `mob` feature is compiled in (`meerkat-mcp-server/src/lib.rs:1320-1327`), while the crate’s default features are only `comms` and `schedule` (`meerkat-mcp-server/Cargo.toml:47-51`). The realtime MCP tools specifically come from `meerkat_mob_mcp::public_tools_list()` (`meerkat-mob-mcp/src/public_mcp.rs:504-520`), so the current page can make default `rkat-mcp` builds look richer than they are.
+
+3. `docs/api/rest.mdx:104-112` documents `POST /mob/{id}/members/{agent_identity}/realtime/attach` and `/realtime/detach` as active mob endpoints, but the handlers are explicitly marked unavailable and always return a bad-request error because realtime is now session-scoped. See `meerkat-rest/src/lib.rs:1996-2018`. This is a concrete REST contract mismatch.
+
+4. `docs/api/rpc.mdx:1-24` documents `rkat-rpc` as a stdio-only surface, but the current binary also supports `--tcp <addr>` and `--realtime-ws <addr>` listener modes. Those flags are part of the public CLI in `meerkat-rpc/src/main.rs:37-46`. Even if stdio remains the primary mode, the page title, description, and getting-started section currently hide a supported transport mode from app/IDE integrators.
+
+5. `docs/rust/advanced.mdx:45-53` contains an `AgentBuilder` example that does not compile as written. `AgentBuilder::build(...)` is async (`meerkat-core/src/agent/builder.rs:214-220`), so the snippet needs `.await`, and the resulting agent must be mutable for direct run APIs because `run`/`run_with_events` take `&mut self` (`meerkat-core/src/agent/runner.rs:823-834`). This is a sharp edge on the “expert-level” page where readers are most likely to copy-paste.
+
+6. The Python SDK docs materially understate the public client surface, which creates parity drift against the actual SDK.
+   `docs/sdks/python/overview.mdx:53-119` and `docs/sdks/python/reference.mdx:14-128` cover the session/config/schedule/mob core, but the current client also exposes realm and auth wrappers (`list_realms`, `get_realm`, `list_auth_profiles`, `get_auth_profile`, `create_auth_profile`, `delete_auth_profile`, `test_auth_profile`, `auth_login_*`, `auth_provision_api_key`, `auth_status`, `auth_logout`) in `sdks/python/meerkat/client.py:340-492`.
+   The docs also miss public session/control helpers such as `send_peer_response_terminal` (`sdks/python/meerkat/client.py:749-765`), blob/skill/MCP surfaces (`sdks/python/meerkat/client.py:801-807`, `sdks/python/meerkat/client.py:925-1010`), and realtime/runtime helpers (`sdks/python/meerkat/client.py:2117-2189`).
+
+7. The TypeScript SDK docs have the same parity problem, although with a different omission pattern.
+   `docs/sdks/typescript/overview.mdx:65-98` and `docs/sdks/typescript/reference.mdx:58-64` mention the core surface plus realtime/auth wrappers, but they still omit several public `MeerkatClient` methods: `sendPeerResponseTerminal` (`sdks/typescript/src/client.ts:514-528`), `mcpAdd`/`mcpRemove`/`mcpReload` and their snake_case aliases (`sdks/typescript/src/client.ts:619-648`), `listSkills`/`inspectSkill`/`getBlob` (`sdks/typescript/src/client.ts:652-675`), runtime/input helpers (`sdks/typescript/src/client.ts:1845-1983`), and realm wrappers (`sdks/typescript/src/client.ts:1992-2065`). As written, the docs make TS and Python look narrower and less aligned with the current RPC catalog than they actually are.
+
+8. No material contract drift found in `docs/cli/commands.mdx`, `docs/rust/overview.mdx`, or `docs/rust/tools-and-stores.mdx` during this pass. I checked command names/examples against the current CLI and Rust facade exports and did not find another concrete mismatch worth flagging beyond the items above.
+
+## Suggested follow-ups
+
+- Update `docs/cli/configuration.mdx` to reflect the actual CLI exit-code semantics, especially that exit code `2` is now budget exhaustion rather than generic invalid params.
+- Split `docs/api/mcp.mdx` into “always present”, “feature-gated”, and “default build vs `mob` build” tool sections, and add the currently omitted blob/skills/schedule tools.
+- Mark the REST mob realtime attach/detach routes as unavailable/deprecated, or remove them from the endpoint overview entirely.
+- Expand `docs/api/rpc.mdx` so it documents the supported TCP and optional realtime-WebSocket listener flags in addition to stdio.
+- Fix the `AgentBuilder` Rust snippet so it compiles (`let mut agent = ...build(...).await;`) and re-scan direct-agent examples for mutability/async correctness.
+- Add SDK “additional wrappers” sections for both Python and TypeScript that enumerate auth, realm, MCP live ops, blob/skills, runtime/realtime, and peer-response helpers so the docs match the exported public surface.

--- a/audit/docs-review-pass2-2026-04-21/agent-07-reference-architecture-and-contracts.md
+++ b/audit/docs-review-pass2-2026-04-21/agent-07-reference-architecture-and-contracts.md
@@ -1,0 +1,101 @@
+# Agent 07 Findings
+
+## Scope reviewed
+
+- Reference docs for architecture, contracts, API surface, builtin tools, capability behavior, and skills governance.
+- Design docs under `docs/architecture/` that still describe current machine/runtime ownership or are linked as canonical references.
+- Mobpack design notes in `docs/design/mobpack.md`.
+- Current crate layout and source-of-truth code for runtime bindings, tool registration, model capability gating, error-code mapping, and machine/runtime module layout.
+
+Sub-areas with no material drift found in this pass:
+
+- `docs/reference/architecture.mdx` core machine/composition counts and crate ownership summary matched the current workspace layout.
+- `docs/reference/session-contracts.mdx` matched the current runtime-backed binding seam and session ownership model.
+- `docs/reference/design-philosophy.mdx` broadly matched the current architectural direction.
+- `docs/reference/skills-governance-runbook.mdx` matched the current skill-identity and lineage validation logic.
+- `docs/reference/comms-redesign-v6-hard-cut.md` is clearly marked historical and did not present itself as current API reference.
+- `docs/design/mobpack.md` is clearly labeled as a design proposal, and its implementation-status note matches the currently shipped CLI commands.
+
+## Files reviewed
+
+- `docs/reference/api-reference.mdx`
+- `docs/reference/architecture.mdx`
+- `docs/reference/builtin-tools.mdx`
+- `docs/reference/capability-matrix.mdx`
+- `docs/reference/comms-redesign-v6-hard-cut.md`
+- `docs/reference/design-philosophy.mdx`
+- `docs/reference/session-contracts.mdx`
+- `docs/reference/skills-governance-runbook.mdx`
+- `docs/architecture/finite-ownership-ledger.md`
+- `docs/architecture/realtime-259-port-plan.md`
+- `docs/architecture/rebuild-trigger-audit.md`
+- `docs/architecture/machine-simplification-proposal.md`
+- `docs/architecture/meerkat-runtime-dogma.md`
+- `docs/architecture/meerkat-runtime-schema-parity-ledger.md`
+- `docs/architecture/mob-runtime-schema-parity-ledger.md`
+- `docs/design/mobpack.md`
+- `meerkat/src/factory.rs`
+- `meerkat/src/service_factory.rs`
+- `meerkat-tools/src/lib.rs`
+- `meerkat-tools/src/builtin/composite.rs`
+- `meerkat-tools/src/builtin/skills/browse.rs`
+- `meerkat-tools/src/builtin/skills/load.rs`
+- `meerkat-tools/src/builtin/skills/resources.rs`
+- `meerkat-tools/src/builtin/skills/functions.rs`
+- `meerkat-tools/src/control_plane.rs`
+- `meerkat-core/src/types.rs`
+- `meerkat-core/src/session.rs`
+- `meerkat-core/src/service/mod.rs`
+- `meerkat-core/src/model_profile/capabilities.rs`
+- `meerkat-contracts/src/error/mod.rs`
+- `meerkat-models/src/lib.rs`
+- `meerkat-runtime/src/meerkat_machine/runtime_control.rs`
+- `meerkat-runtime/src/meerkat_machine/llm_reconfigure.rs`
+- `meerkat-rpc/src/error.rs`
+- `meerkat-rpc/src/session_runtime.rs`
+- `Cargo.toml`
+- `meerkat/Cargo.toml`
+
+## Findings
+
+### 1. `docs/reference/builtin-tools.mdx` is no longer comprehensive and omits shipped built-in tool surfaces
+
+- The page title/description and overview table present the page as a comprehensive inventory, but the current docs stop at task/shell/memory/utility/comms/schedule tools and do not mention the skill builtins or deferred tool-catalog control plane. See `docs/reference/builtin-tools.mdx:2-4` and `docs/reference/builtin-tools.mdx:9-34`.
+- The current runtime ships five skill builtins: `browse_skills`, `load_skill`, `skill_list_resources`, `skill_read_resource`, and `skill_invoke_function`. See `meerkat-tools/src/builtin/skills/mod.rs:22-49`, `meerkat-tools/src/builtin/skills/browse.rs:102-120`, `meerkat-tools/src/builtin/skills/load.rs:35-53`, `meerkat-tools/src/builtin/skills/resources.rs:58-76`, `meerkat-tools/src/builtin/skills/resources.rs:101-119`, and `meerkat-tools/src/builtin/skills/functions.rs:44-62`.
+- The current runtime also exposes deferred catalog control-plane tools `tool_catalog_search` and `tool_catalog_load`, which are absent from the reference page. See `meerkat-tools/src/control_plane.rs:17-18` and `meerkat-tools/src/control_plane.rs:451-470`.
+- This is more than a completeness nit: readers using the reference page today will miss current first-party tooling that is discoverable in code and reachable through the dispatcher surface.
+
+### 2. `docs/reference/capability-matrix.mdx` overstates `view_image` gating and no longer matches the actual capability filter
+
+- The doc says `view_image` is hidden when either `vision` or `image_tool_results` is false. See `docs/reference/capability-matrix.mdx:88-93`.
+- The current machine-owned capability filter only gates `view_image` on `image_tool_results`; there is no corresponding `vision` check in the tool-visibility filter path. See `meerkat-core/src/session.rs:192-199`.
+- The live reconfigure path also applies only `capability_base_filter_for_image_tool_results(target_capability_surface.image_tool_results)`, again without a `vision`-based tool denial. See `meerkat-rpc/src/session_runtime.rs:1294-1319` and `meerkat-runtime/src/meerkat_machine/llm_reconfigure.rs:51-79`.
+- The page should either narrow the claim to `image_tool_results` or explicitly document any separate `vision` enforcement path if one is intended later.
+
+### 3. `docs/reference/api-reference.mdx` has drift in core type descriptions for `Message`
+
+- The API reference still describes `Message` as `System`, `User`, `Assistant`, `BlockAssistant`, `ToolResults`. See `docs/reference/api-reference.mdx:13-18`.
+- The current enum also includes `SystemNotice`, which matters for runtime/system notices and tool-visibility updates. See `meerkat-core/src/types.rs:767-782`.
+- Because this page is supposed to be the quick-lookup public type index, omitting `SystemNotice` now understates the actual persisted/runtime-visible message model.
+
+### 4. `docs/reference/api-reference.mdx` error-code reference is incomplete and partially out of sync with current source of truth
+
+- The “canonical `ErrorCode`” table omits `REQUEST_CANCELLED` and `DUPLICATE_INPUT`, even though both are part of the current public enum. Compare `docs/reference/api-reference.mdx:287-300` with `meerkat-contracts/src/error/mod.rs:25-40`.
+- The current canonical projections are defined in `meerkat-contracts/src/error/mod.rs:43-100`; that file assigns `RequestCancelled -> -32005 / 499 / 14` and `DuplicateInput -> -32004 / 409 / 13`, neither of which is documented in the table.
+- There is also a broader mismatch across docs and code for “session not running”: the API reference says the canonical wire code is `-32003` (`docs/reference/api-reference.mdx:289-292`), the capability-matrix page documents a lower-level session transport mapping of `-32005` (`docs/reference/capability-matrix.mdx:40-49`), and the current RPC adapter maps `SessionError::NotRunning` to `INTERNAL_ERROR` in `meerkat-rpc/src/session_runtime.rs:3876-3894`.
+- Even if the intent is to distinguish canonical-wire vs transport-specific mappings, the current reference set does not explain the divergence cleanly enough, and the API page is definitely missing current error codes.
+
+### 5. Several `docs/architecture/*` pages still point at pre-split runtime module paths, creating stale internal references
+
+- `docs/architecture/finite-ownership-ledger.md` repeatedly points at `meerkat-runtime/src/meerkat_machine.rs` as the ownership boundary location. See `docs/architecture/finite-ownership-ledger.md:21-27` and `docs/architecture/finite-ownership-ledger.md:39-71`.
+- That monolithic file no longer exists; the runtime machine is now split across `meerkat-runtime/src/meerkat_machine/mod.rs` plus submodules such as `runtime_control.rs`, `dispatch_session.rs`, `session_management.rs`, and others. The current `prepare_bindings` entry point, for example, lives in `meerkat-runtime/src/meerkat_machine/runtime_control.rs:322-342`.
+- `docs/architecture/realtime-259-port-plan.md` still calls out a shell module path `meerkat-runtime/src/meerkat_machine/realtime_attachment.rs` as “my current implementation.” See `docs/architecture/realtime-259-port-plan.md:39-43`. That file no longer exists.
+- These stale paths matter because the reference architecture pages are supposed to help readers locate current owners and current seams. Right now they send readers to files that are gone after the runtime module split.
+
+## Suggested follow-ups
+
+- Update `docs/reference/builtin-tools.mdx` so it either becomes truly comprehensive or explicitly scopes itself to a subset. At minimum, add the skill builtins and `tool_catalog_search` / `tool_catalog_load`.
+- Correct `docs/reference/capability-matrix.mdx` to document the current `view_image` rule as implemented, or add a note distinguishing model-input `vision` capability from tool-visibility gating.
+- Refresh `docs/reference/api-reference.mdx` against current enums and contracts: add `SystemNotice`, fill out the full canonical `ErrorCode` table, and clarify canonical-wire vs transport-specific mappings.
+- Regenerate or manually refresh the affected `docs/architecture/*` pages so file-path references point to the split runtime module layout instead of the removed monolithic files.
+- Sanity-check the RPC `SessionError::NotRunning` mapping in `meerkat-rpc/src/session_runtime.rs:3876-3894`; if the implementation is intentional, document that exception explicitly, and if not, fix code and then align the docs.

--- a/audit/docs-review-pass2-2026-04-21/agent-08-meerkat-skill-files.md
+++ b/audit/docs-review-pass2-2026-04-21/agent-08-meerkat-skill-files.md
@@ -1,0 +1,49 @@
+# Agent 08 Findings
+
+## Scope reviewed
+
+- `.claude/skills/meerkat-platform/SKILL.md`
+- `.claude/skills/meerkat-architecture/SKILL.md`
+- `.claude/skills/meerkat-wasm/SKILL.md`
+- Parity checks against current repo layout, current CLI/runtime code, and current docs under `docs/`
+
+## Files reviewed
+
+- `.claude/skills/meerkat-platform/SKILL.md`
+- `.claude/skills/meerkat-architecture/SKILL.md`
+- `.claude/skills/meerkat-wasm/SKILL.md`
+- `docs/cli/commands.mdx`
+- `docs/guides/mobs.mdx`
+- `docs/api/rest.mdx`
+- `docs/reference/architecture.mdx`
+- `meerkat-cli/src/main.rs`
+- `meerkat-rest/src/lib.rs`
+- `meerkat-machine-schema/src/catalog/mod.rs`
+- `meerkat-client/src/lib.rs`
+- `meerkat-providers/src/lib.rs`
+- `meerkat-openai/src/lib.rs`
+- `meerkat-mob/src/runtime/loop_iteration_authority.rs`
+- `meerkat-mcp/src/external_tool_surface_authority.rs`
+- `sdks/web/package.json`
+- `meerkat-web-runtime/src/lib.rs`
+
+## Findings
+
+1. `.claude/skills/meerkat-platform/SKILL.md` still documents removed direct CLI mob lifecycle commands. The block at lines 185-199 advertises `rkat mob create`, `list`, `status`, `wire`, `unwire`, and `force-cancel` as the current operational CLI surface, but the actual `MobCommands` enum only exposes artifact commands plus helper/flow commands such as `run-flow`, `flow-status`, `spawn-helper`, `fork-helper`, `member-status`, `respawn`, `wait-kickoff`, and `web build` in `meerkat-cli/src/main.rs:1772-1904`. Current docs also describe the CLI as helper-oriented rather than lifecycle-oriented in `docs/guides/mobs.mdx:200-204`, while `docs/cli/commands.mdx:55` now summarizes `rkat mob ...` as an artifact surface. This is a real surface mismatch, not just wording drift.
+
+2. `.claude/skills/meerkat-platform/SKILL.md` has stale realtime surface guidance for REST and Rust. The realtime table at lines 124-131 says REST opens the channel via RPC and says Rust uses provider integration in `meerkat-client`, but the current REST API exposes `POST /realtime/open_info` directly in both docs and code (`docs/api/rest.mdx:81-85`, `meerkat-rest/src/lib.rs:1123-1130`). On the Rust side, `meerkat-client` is now a compatibility shim, while the OpenAI realtime attachment implementation lives under `meerkat-openai` (`meerkat-client/src/lib.rs:1-12,20-57`, `meerkat-openai/src/lib.rs:1-28`). Agents following the skill literally will reach for the wrong crate and understate the REST surface.
+
+3. `.claude/skills/meerkat-platform/SKILL.md` and `.claude/skills/meerkat-architecture/SKILL.md` both still teach pre-split crate ownership. Platform lines 519-522 still say provider-runtime, OAuth, auth-store, and authorizers live in `meerkat-providers` and are re-exported by `meerkat-client`, while the architecture table at lines 98-119 says `meerkat-client` owns the LLM providers/realtime transport. Current crate headers say the opposite: `meerkat-client` is a thin compatibility shim (`meerkat-client/src/lib.rs:1-12`), `meerkat-providers` is also a compatibility shim for generic provider-runtime/auth primitives and explicitly does not re-export per-provider verticals (`meerkat-providers/src/lib.rs:1-13`), and provider implementations now live in provider-specific crates such as `meerkat-openai` and `meerkat-anthropic` (`meerkat-openai/src/lib.rs:1-28`). `docs/reference/architecture.mdx:76-98` already reflects the new split, so the skill files are behind current docs and current code.
+
+4. `.claude/skills/meerkat-architecture/SKILL.md` contains an internal contradiction about canonical machines. It correctly says “Exactly five canonical machines” at lines 64-72, but the quick index later says `meerkat-machine-schema/src/catalog/dsl/` is the truth for “all 4 machines” at line 142. The code confirms there are five canonical machine schemas in `meerkat-machine-schema/src/catalog/mod.rs:18-25`, and `docs/reference/architecture.mdx:45-60` also documents five. This is small, but it is exactly the kind of inconsistency that makes an architecture navigator less trustworthy.
+
+5. `.claude/skills/meerkat-architecture/SKILL.md` overstates the “no handwritten authority” story. Lines 76-78 say no handwritten `*_authority.rs` state machines remain outside the catalog and imply remaining `_authority.rs` files are only projections/helpers, but the repo still contains handwritten authority-style mutators with `apply(...)` methods, including `LoopIterationAuthority` in `meerkat-mob/src/runtime/loop_iteration_authority.rs:1-80` and `ExternalToolSurfaceAuthority` in `meerkat-mcp/src/external_tool_surface_authority.rs:1-16,416-438,1800-1815`. Even if these are transitional or standalone-only paths, the current skill wording is too absolute.
+
+6. No stale paths or obvious surface drift were found in `.claude/skills/meerkat-wasm/SKILL.md` during this pass. The referenced paths exist (`sdks/web/`, `sdks/web/proxy/index.mjs`, `meerkat-web-runtime/src/lib.rs`, `tests/integration/src/e2e_lanes.rs`), the build guidance matches `docs/examples/wasm.mdx:23-24` and `sdks/web/scripts/build-wasm.mjs`, and the package/runtime surface described there still matches the current `@rkat/web` package and wasm exports (`sdks/web/package.json`, `meerkat-web-runtime/src/lib.rs:931-936`).
+
+## Suggested follow-ups
+
+- Refresh `.claude/skills/meerkat-platform/SKILL.md` so its CLI mob section matches the current `MobCommands` surface, and update the realtime table to point REST users at `/realtime/open_info` and Rust users at the current provider-vertical crates instead of `meerkat-client`.
+- Refresh `.claude/skills/meerkat-architecture/SKILL.md` against `docs/reference/architecture.mdx` and the 2026-04-18 crate split, especially the crate-ownership table and the “zero handwritten authority” claim.
+- Decide which mob CLI doc is canonical, because `docs/guides/mobs.mdx` and `docs/cli/commands.mdx` currently frame the `rkat mob` surface differently; once that is settled, align the skills and the docs together.
+- Consider adding a lightweight docs audit check that flags removed CLI subcommands and crate-role mismatches by comparing skill snippets against `meerkat-cli/src/main.rs` and `docs/reference/architecture.mdx`.

--- a/docs/api/mcp.mdx
+++ b/docs/api/mcp.mdx
@@ -39,14 +39,16 @@ second surface-local execution loop.
 | `meerkat_run` | Start a new agent session |
 | `meerkat_resume` | Continue a session or provide tool results |
 | `meerkat_read` | Read a session's state |
-| `meerkat_history` | Read a session's committed transcript history |
+| `meerkat_history` | Read a session's committed history |
 | `meerkat_sessions` | List sessions in the active realm |
+| `meerkat_blob_get` | Fetch a blob payload by id |
 | `meerkat_interrupt` | Interrupt an in-flight turn |
 | `meerkat_archive` | Archive (remove) a session |
 | `meerkat_config` | Get or update server config |
 | `meerkat_capabilities` | Query runtime capabilities |
 | `meerkat_models_catalog` | List available models with provider profiles and capabilities |
 | `meerkat_skills` | List or inspect available skills |
+| `meerkat_schedule_*` tools | Agent-facing schedule create/get/list/update/pause/resume/delete/occurrences tools |
 | `meerkat_mcp_add` | Stage a live MCP server addition on an active session |
 | `meerkat_mcp_remove` | Stage a live MCP server removal on an active session |
 | `meerkat_mcp_reload` | Stage a live MCP server reload on an active session |
@@ -69,6 +71,10 @@ second surface-local execution loop.
 | `meerkat_realtime_capabilities` | Read product-layer realtime capabilities for a target (realtime feature) |
 
 <Note>
+Default `rkat-mcp` builds are driven by the crate feature set. The base/default tool surface includes the core session/config/history/blob/skills surface plus schedule tools. Mob and realtime MCP tools are feature-gated and appear only when the `mob` feature is compiled in.
+</Note>
+
+<Note>
 When the `mob` feature is enabled, the public MCP host surface uses typed
 `meerkat_mob_*` control-plane tools. Inside running sessions, mob capability is
 still agent-side and comes from composing a mob tools factory into
@@ -80,10 +86,10 @@ model. Public host MCP surfaces should not re-export that raw dispatcher.
 **Realtime attachment over MCP.** Realtime transport is driven by
 `ModelCapabilities.realtime` on the session's model; it attaches
 automatically when the session runs a realtime-capable model (e.g.
-`gpt-realtime`). The public MCP tool set exposes only the product-layer
+`gpt-realtime-1.5`). The public MCP tool set exposes only the product-layer
 bootstrap and status surfaces (`meerkat_realtime_open_info`,
 `meerkat_realtime_status`, `meerkat_realtime_capabilities`) — there is
-no MCP attach/detach tool. See the [Realtime voice
+no MCP attach/detach tool. See the [Realtime
 guide](/guides/realtime) for the capability-driven model and the full
 attachment state machine.
 </Note>

--- a/docs/api/rest.mdx
+++ b/docs/api/rest.mdx
@@ -56,18 +56,60 @@ If `--realm` is omitted, the server creates a new isolated opaque realm (`realm-
 | `GET` | `/sessions` | List sessions |
 | `GET` | `/sessions/{id}` | Fetch session metadata and usage |
 | `GET` | `/sessions/{id}/history` | Fetch committed session transcript messages |
+| `POST` | `/sessions/{id}/system_context` | Append staged runtime system context |
 | `POST` | `/sessions/{id}/messages` | Continue an existing session |
 | `POST` | `/sessions/{id}/external-events` | Queue a runtime-backed external event |
+| `POST` | `/sessions/{id}/peer-response-terminal` | Queue a typed peer terminal response event |
 | `POST` | `/sessions/{id}/interrupt` | Interrupt an in-flight turn |
 | `DELETE` | `/sessions/{id}` | Archive (remove) a session |
 | `GET` | `/sessions/{id}/events` | SSE stream for real-time updates |
+| `GET` | `/schedule/tools` | List schedule tool definitions |
+| `POST` | `/schedule/call` | Call a schedule tool directly |
+| `POST` | `/schedules` | Create a schedule |
+| `GET` | `/schedules` | List schedules |
+| `GET` | `/schedules/{id}` | Fetch one schedule |
+| `PATCH` | `/schedules/{id}` | Update a schedule |
+| `DELETE` | `/schedules/{id}` | Delete a schedule |
+| `POST` | `/schedules/{id}/pause` | Pause a schedule |
+| `POST` | `/schedules/{id}/resume` | Resume a schedule |
+| `GET` | `/schedules/{id}/occurrences` | List schedule occurrences |
 | `POST` | `/sessions/{id}/mcp/add` | Stage live MCP server addition (mcp feature) |
 | `POST` | `/sessions/{id}/mcp/remove` | Stage live MCP server removal (mcp feature) |
 | `POST` | `/sessions/{id}/mcp/reload` | Reload MCP server(s) (mcp feature) |
 | `POST` | `/comms/send` | Push comms message into a session (comms feature) |
 | `GET` | `/comms/peers` | List discoverable peers (comms feature) |
-| `GET` | `/mob/{id}/events` | Mob event SSE stream (mob feature) |
+| `POST` | `/realtime/open_info` | Issue a realtime websocket bootstrap token |
+| `POST` | `/realtime/status` | Read product-layer realtime status |
+| `POST` | `/realtime/capabilities` | Read product-layer realtime capabilities |
+| `GET` | `/runtime/{id}/state` | Read runtime state |
 | `GET` | `/runtime/{id}/realtime_attachment_status` | Read the runtime-owned realtime attachment status for a session |
+| `POST` | `/runtime/{id}/accept` | Admit runtime input explicitly |
+| `POST` | `/runtime/{id}/retire` | Retire a runtime |
+| `POST` | `/runtime/{id}/reset` | Reset a runtime |
+| `GET` | `/input/{id}/list` | List runtime input state entries |
+| `GET` | `/input/{session_id}/{input_id}` | Read one runtime input state |
+| `GET` | `/auth/profiles` | List auth profiles |
+| `POST` | `/auth/profiles` | Create an auth profile |
+| `GET` | `/auth/profiles/{id}` | Read an auth profile |
+| `DELETE` | `/auth/profiles/{id}` | Delete an auth profile |
+| `POST` | `/auth/profiles/{id}/test` | Test an auth profile binding |
+| `POST` | `/auth/login/start` | Start interactive auth login |
+| `POST` | `/auth/login/complete` | Complete interactive auth login |
+| `POST` | `/auth/login/device/start` | Start device-code login |
+| `POST` | `/auth/login/device/complete` | Complete device-code login |
+| `GET` | `/auth/status/{id}` | Read auth status |
+| `POST` | `/auth/logout/{id}` | Log out an auth profile |
+| `GET` | `/realms` | List configured realms |
+| `GET` | `/realms/{id}` | Read one realm |
+| `GET` | `/mob/{id}/events` | Mob event SSE stream (mob feature) |
+| `POST` | `/mob/{id}/spawn-helper` | Spawn a helper into a mob (mob feature) |
+| `POST` | `/mob/{id}/fork-helper` | Fork a helper from an existing member (mob feature) |
+| `POST` | `/mob/{id}/wait-kickoff` | Wait for kickoff completion (mob feature) |
+| `GET` | `/mob/{id}/members/{agent_identity}/status` | Read member status (mob feature) |
+| `POST` | `/mob/{id}/members/{agent_identity}/realtime/attach` | Compatibility route present but unavailable; realtime is session-scoped (mob feature) |
+| `POST` | `/mob/{id}/members/{agent_identity}/realtime/detach` | Compatibility route present but unavailable; realtime is session-scoped (mob feature) |
+| `POST` | `/mob/{id}/members/{agent_identity}/cancel` | Force-cancel a member (mob feature) |
+| `POST` | `/mob/{id}/members/{agent_identity}/respawn` | Respawn a member (mob feature) |
 | `GET` | `/skills` | List skills with provenance |
 | `GET` | `/skills/{id}` | Inspect a skill's full content |
 | `GET` | `/health` | Liveness check |
@@ -105,9 +147,9 @@ Cancellation only affects uncommitted work:
 <Accordion title="Server configuration details">
   REST configuration is realm-scoped:
 
-  - macOS: `~/Library/Application Support/meerkat/rest/realms/<realm>/config.toml`
-  - Linux: `~/.local/share/meerkat/rest/realms/<realm>/config.toml`
-  - Windows: `%APPDATA%\\meerkat\\rest\\realms\\<realm>\\config.toml`
+  - macOS: `~/Library/Application Support/meerkat/realms/<realm>/config.toml`
+  - Linux: `~/.local/share/meerkat/realms/<realm>/config.toml`
+  - Windows: `%APPDATA%\\meerkat\\realms\\<realm>\\config.toml`
 
   Each realm also has `realm_manifest.json` (backend pinning) and `config_state.json` (generation CAS state).
 
@@ -851,19 +893,19 @@ List discoverable peers for a session. Requires the `comms` feature.
 
 Realtime is a delivery mode of the session's LLM, driven by
 `ModelCapabilities.realtime`. To enable realtime audio on a session,
-create it with a realtime-capable model (for example `gpt-realtime`):
+create it with a realtime-capable model (for example `gpt-realtime-1.5`):
 
 ```bash
 curl -X POST http://127.0.0.1:8080/sessions \
   -H 'content-type: application/json' \
-  -d '{"prompt":"Ready for voice.","model":"gpt-realtime","provider":"openai"}'
+  -d '{"prompt":"Ready for voice.","model":"gpt-realtime-1.5","provider":"openai"}'
 ```
 
 The runtime attaches the OpenAI Realtime transport automatically and
 the status endpoint below reports `binding_ready` once the provider
 confirms. There is no caller-initiated attach/detach endpoint — swap
 the session's model (or choose a realtime-capable default) to control
-whether the session runs in realtime mode. See the [Realtime voice
+whether the session runs in realtime mode. See the [Realtime
 guide](/guides/realtime) for the full capability-driven model, state
 machine, and reconfigure flow.
 
@@ -882,7 +924,7 @@ Read the runtime-owned realtime attachment status projection for a session.
 }
 ```
 
-Status values: `unattached`, `intent_present_unbound`, `binding_not_ready`, `binding_ready`, `replacement_pending`, `reattach_required`. See the [Realtime voice guide](/guides/realtime#attachment-states) for the full state table and transition diagram.
+Status values: `unattached`, `intent_present_unbound`, `binding_not_ready`, `binding_ready`, `replacement_pending`, `reattach_required`. See the [Realtime guide](/guides/realtime#attachment-states) for the full state table and transition diagram.
 
 ## Error responses
 

--- a/docs/api/rpc.mdx
+++ b/docs/api/rpc.mdx
@@ -1,10 +1,10 @@
 ---
 title: "JSON-RPC stdio server"
-description: "Stateful JSON-RPC 2.0 stdio interface for IDE integration, desktop apps, and automation tools."
+description: "Stateful JSON-RPC 2.0 interface for stdio, TCP, and optional realtime websocket hosting."
 icon: "terminal"
 ---
 
-Meerkat exposes a JSON-RPC 2.0 stdio interface for IDE integration, desktop apps, and automation tools. Unlike REST and MCP, the RPC server keeps agents alive between turns for fast multi-turn conversations.
+Meerkat exposes a JSON-RPC 2.0 surface for IDE integration, desktop apps, and automation tools. Stdio is the default, and the binary also supports TCP plus an optional realtime-websocket listener. Unlike REST and MCP, the RPC server keeps agents alive between turns for fast multi-turn conversations.
 
 The RPC surface is fully runtime-backed:
 
@@ -21,6 +21,13 @@ The RPC surface is fully runtime-backed:
     ```
 
     The server reads newline-delimited JSON (JSONL) from stdin and writes JSONL to stdout. Each line is a complete JSON-RPC 2.0 message.
+
+    Optional listener modes:
+
+    ```bash
+    rkat-rpc --tcp 127.0.0.1:9001
+    rkat-rpc --tcp 127.0.0.1:9001 --realtime-ws 127.0.0.1:9002
+    ```
   </Step>
   <Step title="Send the handshake">
     ```json
@@ -165,7 +172,7 @@ rkat-rpc [--realm <id>] [--isolated] [--instance <id>] [--realm-backend <sqlite|
 Realtime is a delivery mode of the session's LLM, driven by
 `ModelCapabilities.realtime`. To enable realtime audio on a session,
 create the session with a realtime-capable model (for example
-`gpt-realtime`); transport attach/detach is managed automatically by
+`gpt-realtime-1.5`); transport attach/detach is managed automatically by
 the runtime. Observe status via `runtime/realtime_attachment_status`
 (single) or `runtime/realtime_attachment_statuses` (batch). There is no
 caller-initiated attach/detach RPC.
@@ -818,12 +825,12 @@ Inspect a skill's full content (body).
 
 ## Realtime attachment methods
 
-Enable realtime on a session by pointing it at a realtime-capable model, then observe the runtime-owned attachment status for that session. The runtime attaches and detaches the OpenAI Realtime transport automatically based on `ModelCapabilities.realtime` — there is no caller-initiated attach/detach RPC. See the [Realtime voice guide](/guides/realtime) for the full capability-driven model, the attachment state machine, and the `RealtimeAttachmentSignalAuthority` authority-epoch token.
+Enable realtime on a session by pointing it at a realtime-capable model, then observe the runtime-owned attachment status for that session. The runtime attaches and detaches the OpenAI Realtime transport automatically based on `ModelCapabilities.realtime` — there is no caller-initiated attach/detach RPC. See the [Realtime guide](/guides/realtime) for the full capability-driven model, the attachment state machine, and the `RealtimeAttachmentSignalAuthority` authority-epoch token.
 
 ### Enabling realtime on a session
 
 Realtime is enabled by pointing the session at a realtime-capable model.
-To make a session realtime, set its model to `gpt-realtime` at
+To make a session realtime, set its model to `gpt-realtime-1.5` at
 `session/create`:
 
 ```json
@@ -833,7 +840,7 @@ To make a session realtime, set its model to `gpt-realtime` at
   "method": "session/create",
   "params": {
     "prompt": "Let's talk.",
-    "model": "gpt-realtime",
+    "model": "gpt-realtime-1.5",
     "provider": "openai"
   }
 }
@@ -843,7 +850,7 @@ The runtime inspects `ModelCapabilities.realtime` for the resolved
 model and brings up the OpenAI Realtime transport automatically. Poll
 `runtime/realtime_attachment_status` to confirm the binding reaches
 `binding_ready`, then call `realtime/open_info` to obtain a bootstrap
-token for the audio WebSocket. See the [Realtime voice
+token for the audio WebSocket on hosts that expose the realtime websocket service. See the [Realtime
 guide](/guides/realtime) for the full flow.
 
 ### runtime/realtime_attachment_status
@@ -874,7 +881,7 @@ Read the runtime-owned realtime attachment status projection for a session.
 ```
 </CodeGroup>
 
-Status values: `unattached`, `intent_present_unbound`, `binding_not_ready`, `binding_ready`, `replacement_pending`, `reattach_required`. See the [Realtime voice guide](/guides/realtime#attachment-states) for the full state table and mermaid transition diagram.
+Status values: `unattached`, `intent_present_unbound`, `binding_not_ready`, `binding_ready`, `replacement_pending`, `reattach_required`. See the [Realtime guide](/guides/realtime#attachment-states) for the full state table and mermaid transition diagram.
 
 `mob/member_status` responses include the same value under the `realtime_attachment_status` field for sessions bound to mob members.
 

--- a/docs/architecture/finite-ownership-ledger.md
+++ b/docs/architecture/finite-ownership-ledger.md
@@ -6,6 +6,9 @@
 This document is generated from the typed ownership registry in `xtask`.
 It is the authoritative inventory of semantic state, semantic-operation boundaries, and keyed-store invariants for the current closure program.
 
+> Note: historical path references below that point at `meerkat-runtime/src/meerkat_machine/`
+> should now be read as the split module tree under `meerkat-runtime/src/meerkat_machine/`.
+
 ## Summary
 
 | Subsystem | State Cells | Semantic Operations | Coupling Invariants | Open State Cells | Open Operations | Open Invariants |
@@ -18,13 +21,13 @@ It is the authoritative inventory of semantic state, semantic-operation boundari
 
 | Family | Kind | Path | Type / Trait | Methods |
 | --- | --- | --- | --- | --- |
-| runtime-control-plane | trait-impl | `meerkat-runtime/src/meerkat_machine.rs` | `MeerkatMachine` / `RuntimeControlPlane` | `ingest`, `publish_event`, `retire`, `recycle`, `reset`, `recover`, `destroy` |
-| runtime-session-adapter | public-inherent | `meerkat-runtime/src/meerkat_machine.rs` | `MeerkatMachine` | `register_session`, `set_session_silent_intents`, `register_session_with_executor`, `ensure_session_with_executor`, `unregister_session`, `interrupt_current_run`, `stop_runtime_executor`, `accept_input_and_run`, `accept_input_with_completion`, `update_peer_ingress_context`, `abort_comms_drains`, `abort_comms_drain`, `wait_comms_drain` |
+| runtime-control-plane | trait-impl | `meerkat-runtime/src/meerkat_machine/` | `MeerkatMachine` / `RuntimeControlPlane` | `ingest`, `publish_event`, `retire`, `recycle`, `reset`, `recover`, `destroy` |
+| runtime-session-adapter | public-inherent | `meerkat-runtime/src/meerkat_machine/` | `MeerkatMachine` | `register_session`, `set_session_silent_intents`, `register_session_with_executor`, `ensure_session_with_executor`, `unregister_session`, `interrupt_current_run`, `stop_runtime_executor`, `accept_input_and_run`, `accept_input_with_completion`, `update_peer_ingress_context`, `abort_comms_drains`, `abort_comms_drain`, `wait_comms_drain` |
 | mcp-router | public-inherent | `meerkat-mcp/src/router.rs` | `McpRouter` | `set_removal_timeout`, `add_server`, `stage_add`, `stage_remove`, `stage_reload`, `apply_staged`, `take_lifecycle_actions`, `take_external_updates`, `progress_removals`, `call_tool`, `shutdown` |
 | mcp-router-adapter | public-inherent | `meerkat-mcp/src/adapter.rs` | `McpRouterAdapter` | `refresh_tools`, `stage_add`, `stage_remove`, `stage_reload`, `apply_staged`, `poll_lifecycle_actions`, `progress_removals`, `wait_until_ready`, `shutdown` |
 | mob-handle | public-inherent | `meerkat-mob/src/runtime/handle.rs` | `MobHandle` | `spawn_spec`, `spawn_many`, `retire`, `respawn`, `retire_all`, `wire`, `unwire`, `internal_turn`, `run_flow`, `run_flow_with_stream`, `cancel_flow`, `stop`, `resume`, `complete`, `reset`, `destroy`, `task_create`, `task_update`, `set_spawn_policy`, `shutdown`, `force_cancel_member`, `wait_one`, `wait_all`, `spawn_helper`, `fork_helper` |
 | mob-command-dispatch | enum-dispatch | `meerkat-mob/src/runtime/actor.rs` | `MobActor` / `MobCommand` | `enqueue_spawn`, `handle_force_cancel`, `handle_retire`, `handle_respawn`, `handle_wire`, `handle_unwire`, `handle_external_turn`, `handle_internal_turn`, `retire_all_members`, `handle_task_create`, `handle_task_update`, `handle_run_flow`, `handle_cancel_flow`, `handle_flow_cleanup`, `handle_complete`, `handle_destroy`, `handle_reset` |
-| manual-callback | manual-callback | `meerkat-runtime/src/meerkat_machine.rs` | `MeerkatMachine` | `notify_comms_drain_exited` |
+| manual-callback | manual-callback | `meerkat-runtime/src/meerkat_machine/` | `MeerkatMachine` | `notify_comms_drain_exited` |
 | manual-callback | manual-callback | `meerkat-mcp/src/router.rs` | `McpRouter` | `process_pending_result` |
 | manual-callback | manual-callback | `meerkat-mob/src/runtime/actor.rs` | `MobActor` | `handle_spawn_provisioned_batch` |
 | shell-background-job-view | export-contract (app-facing) | `meerkat-tools/src/builtin/shell/types.rs` | `BackgroundJob` | `exports_raw_operation_id=false` |
@@ -36,11 +39,11 @@ It is the authoritative inventory of semantic state, semantic-operation boundari
 
 | Path | Symbol | Class | Status | Anchor | Contract |
 | --- | --- | --- | --- | --- | --- |
-| `meerkat-runtime/src/meerkat_machine.rs` | `MeerkatMachine.sessions` | `capability-index` | `closed` | `MeerkatMachine registered-session + attachment publication contract` | src: `registered session entries with recovered driver/completion capabilities`; trigger: `register/ensure/attach/detach/unregister/destroy transitions + dead-attachment normalization`; stale: `forbidden` |
-| `meerkat-runtime/src/meerkat_machine.rs` | `MeerkatMachine.comms_drain_slots` | `capability-index` | `closed` | `MeerkatMachine registered-session contract + drain-control region` | src: `registered session keys + comms drain lifecycle slot allocation`; trigger: `register/unregister/destroy + drain lifecycle transitions + control installation`; stale: `forbidden` |
-| `meerkat-runtime/src/meerkat_machine.rs` | `RuntimeSessionEntry.driver` | `capability-handle` | `closed` | `MeerkatMachine control + admission + input-lifecycle regions` | - |
-| `meerkat-runtime/src/meerkat_machine.rs` | `RuntimeSessionEntry.phase` | `capability-handle` | `closed` | `MeerkatMachine attachment publication contract` | - |
-| `meerkat-runtime/src/meerkat_machine.rs` | `RuntimeSessionEntry.completions` | `capability-handle` | `closed` | `InputLifecycle terminal wait plumbing` | - |
+| `meerkat-runtime/src/meerkat_machine/` | `MeerkatMachine.sessions` | `capability-index` | `closed` | `MeerkatMachine registered-session + attachment publication contract` | src: `registered session entries with recovered driver/completion capabilities`; trigger: `register/ensure/attach/detach/unregister/destroy transitions + dead-attachment normalization`; stale: `forbidden` |
+| `meerkat-runtime/src/meerkat_machine/` | `MeerkatMachine.comms_drain_slots` | `capability-index` | `closed` | `MeerkatMachine registered-session contract + drain-control region` | src: `registered session keys + comms drain lifecycle slot allocation`; trigger: `register/unregister/destroy + drain lifecycle transitions + control installation`; stale: `forbidden` |
+| `meerkat-runtime/src/meerkat_machine/` | `RuntimeSessionEntry.driver` | `capability-handle` | `closed` | `MeerkatMachine control + admission + input-lifecycle regions` | - |
+| `meerkat-runtime/src/meerkat_machine/` | `RuntimeSessionEntry.phase` | `capability-handle` | `closed` | `MeerkatMachine attachment publication contract` | - |
+| `meerkat-runtime/src/meerkat_machine/` | `RuntimeSessionEntry.completions` | `capability-handle` | `closed` | `InputLifecycle terminal wait plumbing` | - |
 | `meerkat-runtime/src/driver/ephemeral.rs` | `EphemeralRuntimeDriver.queue` | `derived-projection` | `closed` | `MeerkatMachine admission queue lane` | src: `MeerkatMachine admission queue entries`; trigger: `any ingress queue mutation or rollback/recovery rebuild`; stale: `forbidden` |
 | `meerkat-runtime/src/driver/ephemeral.rs` | `EphemeralRuntimeDriver.steer_queue` | `derived-projection` | `closed` | `MeerkatMachine admission steer lane` | src: `MeerkatMachine admission steer entries`; trigger: `any ingress steer mutation or rollback/recovery rebuild`; stale: `forbidden` |
 
@@ -48,27 +51,27 @@ It is the authoritative inventory of semantic state, semantic-operation boundari
 
 | Path | Symbol | Boundary | Status | Anchor |
 | --- | --- | --- | --- | --- |
-| `meerkat-runtime/src/meerkat_machine.rs` | `register_session` | `public-inherent` | `closed` | `MeerkatMachine registration + recovery publication contract` |
-| `meerkat-runtime/src/meerkat_machine.rs` | `set_session_silent_intents` | `public-inherent` | `closed` | `MeerkatMachine admission/control policy truth` |
-| `meerkat-runtime/src/meerkat_machine.rs` | `register_session_with_executor` | `public-inherent` | `closed` | `MeerkatMachine registration + attachment publication contract` |
-| `meerkat-runtime/src/meerkat_machine.rs` | `ensure_session_with_executor` | `public-inherent` | `closed` | `MeerkatMachine attachment publication contract + RuntimeControl transitions` |
-| `meerkat-runtime/src/meerkat_machine.rs` | `unregister_session` | `public-inherent` | `closed` | `registered-session contract + MeerkatMachine drain-control region` |
-| `meerkat-runtime/src/meerkat_machine.rs` | `interrupt_current_run` | `public-inherent` | `closed` | `MeerkatMachine control region + runtime attachment publication contract` |
-| `meerkat-runtime/src/meerkat_machine.rs` | `stop_runtime_executor` | `public-inherent` | `closed` | `MeerkatMachine control region + runtime attachment publication contract` |
-| `meerkat-runtime/src/meerkat_machine.rs` | `accept_input_and_run` | `public-inherent` | `closed` | `MeerkatMachine admission + input lifecycle + control regions` |
-| `meerkat-runtime/src/meerkat_machine.rs` | `accept_input_with_completion` | `public-inherent` | `closed` | `MeerkatMachine admission + input-lifecycle regions` |
-| `meerkat-runtime/src/meerkat_machine.rs` | `update_peer_ingress_context` | `public-inherent` | `closed` | `MeerkatMachine drain-control region` |
-| `meerkat-runtime/src/meerkat_machine.rs` | `notify_comms_drain_exited` | `manual-callback` | `closed` | `MeerkatMachine drain-control region` |
-| `meerkat-runtime/src/meerkat_machine.rs` | `abort_comms_drains` | `public-inherent` | `closed` | `MeerkatMachine drain-control region` |
-| `meerkat-runtime/src/meerkat_machine.rs` | `abort_comms_drain` | `public-inherent` | `closed` | `MeerkatMachine drain-control region` |
-| `meerkat-runtime/src/meerkat_machine.rs` | `wait_comms_drain` | `public-inherent` | `closed` | `MeerkatMachine drain-control region` |
-| `meerkat-runtime/src/meerkat_machine.rs` | `publish_event` | `trait-impl` | `closed` | `MeerkatMachine control + input-lifecycle regions` |
-| `meerkat-runtime/src/meerkat_machine.rs` | `retire` | `trait-impl` | `closed` | `MeerkatMachine control region` |
-| `meerkat-runtime/src/meerkat_machine.rs` | `recycle` | `trait-impl` | `closed` | `MeerkatMachine control region` |
-| `meerkat-runtime/src/meerkat_machine.rs` | `reset` | `trait-impl` | `closed` | `MeerkatMachine control region` |
-| `meerkat-runtime/src/meerkat_machine.rs` | `recover` | `trait-impl` | `closed` | `MeerkatMachine control region` |
-| `meerkat-runtime/src/meerkat_machine.rs` | `destroy` | `trait-impl` | `closed` | `MeerkatMachine control region` |
-| `meerkat-runtime/src/meerkat_machine.rs` | `ingest` | `trait-impl` | `closed` | `MeerkatMachine admission + input-lifecycle regions` |
+| `meerkat-runtime/src/meerkat_machine/` | `register_session` | `public-inherent` | `closed` | `MeerkatMachine registration + recovery publication contract` |
+| `meerkat-runtime/src/meerkat_machine/` | `set_session_silent_intents` | `public-inherent` | `closed` | `MeerkatMachine admission/control policy truth` |
+| `meerkat-runtime/src/meerkat_machine/` | `register_session_with_executor` | `public-inherent` | `closed` | `MeerkatMachine registration + attachment publication contract` |
+| `meerkat-runtime/src/meerkat_machine/` | `ensure_session_with_executor` | `public-inherent` | `closed` | `MeerkatMachine attachment publication contract + RuntimeControl transitions` |
+| `meerkat-runtime/src/meerkat_machine/` | `unregister_session` | `public-inherent` | `closed` | `registered-session contract + MeerkatMachine drain-control region` |
+| `meerkat-runtime/src/meerkat_machine/` | `interrupt_current_run` | `public-inherent` | `closed` | `MeerkatMachine control region + runtime attachment publication contract` |
+| `meerkat-runtime/src/meerkat_machine/` | `stop_runtime_executor` | `public-inherent` | `closed` | `MeerkatMachine control region + runtime attachment publication contract` |
+| `meerkat-runtime/src/meerkat_machine/` | `accept_input_and_run` | `public-inherent` | `closed` | `MeerkatMachine admission + input lifecycle + control regions` |
+| `meerkat-runtime/src/meerkat_machine/` | `accept_input_with_completion` | `public-inherent` | `closed` | `MeerkatMachine admission + input-lifecycle regions` |
+| `meerkat-runtime/src/meerkat_machine/` | `update_peer_ingress_context` | `public-inherent` | `closed` | `MeerkatMachine drain-control region` |
+| `meerkat-runtime/src/meerkat_machine/` | `notify_comms_drain_exited` | `manual-callback` | `closed` | `MeerkatMachine drain-control region` |
+| `meerkat-runtime/src/meerkat_machine/` | `abort_comms_drains` | `public-inherent` | `closed` | `MeerkatMachine drain-control region` |
+| `meerkat-runtime/src/meerkat_machine/` | `abort_comms_drain` | `public-inherent` | `closed` | `MeerkatMachine drain-control region` |
+| `meerkat-runtime/src/meerkat_machine/` | `wait_comms_drain` | `public-inherent` | `closed` | `MeerkatMachine drain-control region` |
+| `meerkat-runtime/src/meerkat_machine/` | `publish_event` | `trait-impl` | `closed` | `MeerkatMachine control + input-lifecycle regions` |
+| `meerkat-runtime/src/meerkat_machine/` | `retire` | `trait-impl` | `closed` | `MeerkatMachine control region` |
+| `meerkat-runtime/src/meerkat_machine/` | `recycle` | `trait-impl` | `closed` | `MeerkatMachine control region` |
+| `meerkat-runtime/src/meerkat_machine/` | `reset` | `trait-impl` | `closed` | `MeerkatMachine control region` |
+| `meerkat-runtime/src/meerkat_machine/` | `recover` | `trait-impl` | `closed` | `MeerkatMachine control region` |
+| `meerkat-runtime/src/meerkat_machine/` | `destroy` | `trait-impl` | `closed` | `MeerkatMachine control region` |
+| `meerkat-runtime/src/meerkat_machine/` | `ingest` | `trait-impl` | `closed` | `MeerkatMachine admission + input-lifecycle regions` |
 
 ## Runtime Coupling Invariants
 

--- a/docs/architecture/realtime-259-port-plan.md
+++ b/docs/architecture/realtime-259-port-plan.md
@@ -9,8 +9,8 @@ decides DSL-extend vs. shell-mechanic per the meerkat-architecture skill
 
 ## Inventory of realtime-voice runtime additions that touch machines
 
-Source: `diff cfe85b55a..backup/realtime-voice-pre-259-rebase --
-meerkat-runtime/src/meerkat_machine.rs`.
+Source: historical diff against the pre-split runtime machine implementation
+that now lives under `meerkat-runtime/src/meerkat_machine/`.
 
 ### A. Semantic state (MUST become DSL state)
 
@@ -38,9 +38,9 @@ Status projection: `status() → RealtimeAttachmentStatus` derived from `{bindin
 
 **Dogma verdict:** one semantic fact, one owner. Machines own semantics. This
 is not a projection — it's a state machine with explicit guards and authority
-epochs. It must live in MeerkatMachine DSL. My current implementation
-(`meerkat-runtime/src/meerkat_machine/realtime_attachment.rs` shell module)
-violates the dogma.
+epochs. It must live in MeerkatMachine DSL. The historical note below refers to
+the pre-split runtime shell layout; the current runtime now uses the split
+`meerkat-runtime/src/meerkat_machine/` module tree.
 
 ### B. Commands already in `meerkat_machine_types.rs` (from the squash)
 
@@ -159,12 +159,12 @@ that the model's guards hold. Any guard bug surfaces here.
 
 ### Phase 2 — Rewire shell through DSL
 
-1. **Delete** `meerkat-runtime/src/meerkat_machine/realtime_attachment.rs`
-   (the shell authority struct).
+1. **Delete** the old dedicated realtime-attachment shell authority struct
+   from the runtime machine implementation.
 2. **Remove** `realtime_attachment: RuntimeRealtimeAttachmentAuthority` from
    `RuntimeSessionEntry` in `meerkat-runtime/src/meerkat_machine/mod.rs`.
-3. **Rewrite** the 7 public methods in `session_management.rs` (or a new
-   `realtime_attachment.rs` that is now pure shell-routing) so every mutation
+3. **Rewrite** the 7 public methods in `session_management.rs` (or a pure
+   shell-routing helper under the split runtime machine modules) so every mutation
    routes through `apply_dsl_input`/`stage_session_dsl_input`:
    - `project_realtime_attachment_intent(session_id, present)` → ProjectRealtimeIntent
    - `attach_live(session_id)` → BeginRealtimeBinding, then read DSL state to construct `RealtimeAttachmentSignalAuthority { session_id, authority_epoch: dsl.realtime_binding_authority_epoch.expect("set by transition") }`

--- a/docs/cli/commands.mdx
+++ b/docs/cli/commands.mdx
@@ -49,8 +49,11 @@ rkat [--realm <id>] [--isolated] [--instance <id>] \
 | `rkat session ...` | Inspect, delete, or interrupt sessions |
 | `rkat realm ...` | Inspect or manage realms |
 | `rkat config ...` | Read or update CLI/runtime config |
+| `rkat auth ...` | Log in, inspect auth profiles, test bindings, and refresh/logout credentials |
+| `rkat blob ...` | Inspect and retrieve stored blob content |
 | `rkat mcp ...` | Manage local/project MCP server config |
 | `rkat mob ...` | Pack, inspect, validate, deploy, and build mob artifacts |
+| `rkat realtime ...` | Product-layer realtime websocket utilities |
 | `rkat skill ...` | Manage configured skill sources and inspect available skills |
 | `rkat models` | List built-in models plus configured self-hosted aliases |
 | `rkat capabilities` | Show runtime capabilities |

--- a/docs/cli/configuration.mdx
+++ b/docs/cli/configuration.mdx
@@ -81,8 +81,8 @@ call_timeout_secs = 600
 
 `api_style` chooses the upstream API shape:
 
-- `responses` for Ollama and LM Studio style servers
-- `chat_completions` for vLLM style deployments
+- `chat_completions` is the safest default for Ollama, LM Studio, and vLLM in current Meerkat docs and examples
+- `responses` should be treated as an advanced/server-specific path you validate explicitly before depending on it
 
 For Gemma 4, prefer `chat_completions` unless you have verified a server-specific `responses` workflow you want to use.
 
@@ -129,17 +129,9 @@ Project servers override user servers with the same name.
 |------|---------|
 | 0 | Success |
 | 1 | Internal error |
-| 2 | Budget exhausted (CLI) or invalid params (contracts) |
-| 10 | Session not found |
-| 11 | Session busy |
-| 12 | Session not running |
-| 20 | Provider error |
-| 21 | Budget exhausted |
-| 22 | Hook denied |
-| 30 | Agent error |
-| 40 | Capability unavailable |
-| 41 | Skill not found |
-| 42 | Skill resolution failed |
+| 2 | Budget exhausted |
+
+Most richer session/provider/runtime failures are reported through structured error payloads and stderr text rather than a large exit-code taxonomy. In particular, session persistence/compaction disabled conditions are informational at the CLI transport layer and do not map to dedicated non-zero exit codes.
 
 ## See also
 

--- a/docs/concepts/configuration.mdx
+++ b/docs/concepts/configuration.mdx
@@ -24,12 +24,17 @@ Use [realms](/concepts/realms) to choose whether state is shared or isolated.
 
 ## Effective precedence
 
-For a given realm, effective settings are:
+For a given realm, effective persisted configuration is:
 
 1. Built-in defaults
 2. Realm `config.toml`
-3. Environment overrides (secrets and supported runtime env overrides)
-4. Per-request runtime parameters (for example model/system prompt/tool toggles on create/resume calls)
+3. Per-request runtime parameters (for example model/system prompt/tool toggles on create/resume calls)
+
+Environment variables still matter, but they are primarily part of **runtime credential resolution**, not a general config layer that mutates the loaded realm config. In practice:
+
+- realm config remains the canonical persisted settings surface
+- provider credentials can still come from `RKAT_*` or provider-native env vars at resolve time
+- bindings and auth profiles decide how those credentials are used at runtime
 
 ## Config APIs and CAS
 
@@ -40,7 +45,8 @@ RPC, REST, and MCP all expose the same config envelope:
 - `realm_id`
 - `instance_id`
 - `backend`
-- `resolved_paths`
+
+Some surfaces also expose `resolved_paths` in diagnostic/admin contexts. Treat that field as optional rather than universal across all public config envelopes.
 
 Writes support optimistic concurrency:
 
@@ -53,7 +59,7 @@ This gives deterministic behavior when multiple clients or processes update conf
 
 Meerkat uses two distinct update models:
 
-1. Layered config loading (`defaults -> file -> env -> runtime`) uses **field-wise merge**:
+1. Layered config loading (`defaults -> file -> runtime`) uses **field-wise merge**:
   - scalar/option values: last non-default wins
   - section values (for example `providers`, `store`, `comms`, `compaction`): replace whole section
   - hook entries: append/extend

--- a/docs/concepts/providers.mdx
+++ b/docs/concepts/providers.mdx
@@ -4,7 +4,7 @@ description: "Provider-agnostic: same tools, same sessions across Anthropic, Ope
 icon: "server"
 ---
 
-Meerkat is provider-agnostic. Your tools, sessions, hooks, and configuration work identically across Anthropic, OpenAI, Gemini, and configured self-hosted models. Switch providers by changing the model name. If you register a self-hosted alias such as `gemma-4-31b`, it behaves like any other model ID in the runtime.
+Meerkat is provider-agnostic at the session/config/runtime model level. You can switch providers by changing the model name, and a configured self-hosted alias such as `gemma-4-31b` behaves like any other model ID in the runtime. Tool visibility and multimodal behavior still depend on model capabilities, so provider/model differences can affect the effective tool surface.
 
 ## Provider setup
 
@@ -16,7 +16,6 @@ Meerkat is provider-agnostic. Your tools, sessions, hooks, and configuration wor
 
     | Model | Context | Max output | Best for |
     |-------|---------|------------|----------|
-    | `claude-opus-4-6` | 200K / 1M (beta) | 128K | Complex reasoning, highest quality |
     | `claude-opus-4-7` | 1M | 128K | Default Anthropic recommendation |
     | `claude-opus-4-6` | 1M | 128K | Supported Opus fallback |
     | `claude-sonnet-4-6` | 1M | 64K | Balanced performance and cost |
@@ -144,7 +143,7 @@ Provider-specific options can be passed via the `--param` CLI flag or `provider_
   <Tab title="OpenAI">
     | Parameter | Values | Description |
     |-----------|--------|-------------|
-    | `reasoning_effort` | `low`, `medium`, `high` | Reasoning effort for o-series models |
+    | `reasoning_effort` | `none`, `low`, `medium`, `high`, `xhigh` | Reasoning effort for GPT-5-era OpenAI models and other compatible OpenAI reasoning surfaces |
     | `seed` | Integer | Seed for deterministic outputs |
 
     ```bash
@@ -165,7 +164,7 @@ Provider-specific options can be passed via the `--param` CLI flag or `provider_
 
 ## Model catalog
 
-The `meerkat-models` crate maintains the curated built-in catalog. At runtime, Meerkat merges that catalog with any configured self-hosted aliases into one effective model registry used for capability detection, provider resolution, and catalog responses.
+Meerkat ships a curated built-in model catalog and merges it with any configured self-hosted aliases into one effective runtime registry used for capability detection, provider resolution, and catalog responses. The compatibility `meerkat-models` crate re-exports that catalog surface for consumers that still depend on the older crate boundary.
 
 Query the catalog programmatically from any surface:
 
@@ -183,7 +182,7 @@ For Gemma 4 specifically, prefer `chat_completions` as the default OpenAI-compat
 The provider is automatically inferred from the model name:
 
 - `claude-*` models use Anthropic
-- `gpt-*`, `o1-*`, `o3-*`, `chatgpt-*` models use OpenAI
+- `gpt-*`, `chatgpt-*` models use OpenAI
 - `gemini-*` models use Gemini
 
 Configured self-hosted aliases are resolved by exact model ID match before prefix inference. That means an alias such as `gemma-4-31b` works without `--provider`.

--- a/docs/concepts/realms.mdx
+++ b/docs/concepts/realms.mdx
@@ -11,7 +11,9 @@ Meerkat is realm-first. A `realm_id` is the only identity key for sharing or iso
 1. Same `realm_id` means shared sessions, config, and runtime metadata.
 2. Different `realm_id` means strict isolation, even from the same folder.
 3. Backend (`sqlite` or `jsonl`) is pinned once per realm via `realm_manifest.json`.
-4. Realms are opaque strings. Reuse the same value to collaborate across surfaces.
+4. Realm IDs are user-chosen stable identifiers with syntax constraints. Reuse the same value to collaborate across surfaces.
+
+Realm IDs must be 1-64 characters, start with an ASCII alphanumeric character, and may contain only ASCII alphanumerics, `_`, and `-`. They cannot contain whitespace or `:`, and UUID-like opaque values are rejected for explicit user-facing realm IDs.
 
 ## Surface defaults
 
@@ -72,9 +74,12 @@ Existing realms stay pinned to the backend recorded in their manifest. Changing 
 
 Config is realm-scoped and generation-based.
 
-- `config/get` returns: `config`, `generation`, `realm_id`, `instance_id`, `backend`, `resolved_paths`.
+- `config/get` returns the core envelope fields `config`, `generation`, `realm_id`, `instance_id`, and `backend`.
+- Some surfaces may also include diagnostic fields such as `resolved_paths`, but those should be treated as optional.
 - `config/set` and `config/patch` accept optional `expected_generation`.
 - Stale writes fail deterministically with generation conflict.
+
+`resolved_paths` should be treated as a diagnostic/admin field rather than a guaranteed universal field on every public config envelope.
 
 ## Why this solves multi-surface concurrency
 

--- a/docs/concepts/sessions.mdx
+++ b/docs/concepts/sessions.mdx
@@ -16,7 +16,7 @@ Sessions are realm-scoped. A session is visible across surfaces only when they u
 | `read` | Return session state + usage |
 | `read_history` | Return committed transcript messages with optional pagination |
 | `list` | List sessions in the active realm |
-| `archive` | Remove from runtime (and persistent store when supported) |
+| `archive` | Remove the live runtime handle and hide the session from normal listing while preserving committed history for later reads |
 
 ## Realm visibility rules
 
@@ -51,6 +51,8 @@ Public surfaces now expose full transcript history separately from lightweight m
 - TypeScript SDK: `readSessionHistory()`, `Session.history()`, `DeferredSession.history()`
 
 History responses return committed messages oldest-to-newest and support `offset` / `limit` pagination. They do not expose in-flight partial output.
+
+Archived sessions still keep their committed transcript history on the normal runtime-backed path. Archiving retires the live runtime handle, blocks further mutation, and can still leave committed state readable depending on the surface/service implementation. It is a lifecycle visibility change, not a history wipe.
 
 ## Persistence and backend pinning
 

--- a/docs/concepts/tools.mdx
+++ b/docs/concepts/tools.mdx
@@ -30,12 +30,12 @@ impl AgentToolDispatcher for MathTools {
         })].into()
     }
 
-    async fn dispatch(&self, call: ToolCallView<'_>) -> Result<ToolResult, ToolError> {
+    async fn dispatch(&self, call: ToolCallView<'_>) -> Result<ToolDispatchOutcome, ToolError> {
         match call.name {
             "add" => {
                 let args: AddArgs = call.parse_args()
                     .map_err(|e| ToolError::invalid_arguments(call.name, e.to_string()))?;
-                Ok(ToolResult::new(call.id.to_string(), format!("{}", args.a + args.b), false))
+                Ok(ToolResult::new(call.id.to_string(), format!("{}", args.a + args.b), false).into())
             }
             _ => Err(ToolError::not_found(call.name)),
         }
@@ -65,6 +65,7 @@ Meerkat ships with tool categories you enable per-agent. Nothing is on by defaul
 | Builtins | `task_create`, `task_list`, `task_get`, `task_update`, `datetime`, `apply_patch`, `view_image` | `enable_builtins` |
 | Shell | `shell`, `shell_jobs`, `shell_job_status`, `shell_job_cancel` | `enable_shell` |
 | Memory | `memory_search` | `enable_memory` |
+| Scheduler | `meerkat_schedule_*` | `enable_schedule` |
 | Comms | `send_message`, `send_request`, `send_response`, `peers` | `enable_comms` |
 | Mob orchestration | `mob_*`, `meerkat_*` | `enable_mob` |
 
@@ -74,7 +75,7 @@ Shell tools support allow/deny list security policies. Runtime tool visibility c
 
 Tool visibility can change during a session without restarting the agent. Changes are **staged** then **atomically applied** at the turn boundary — the LLM never sees a tool list change mid-stream.
 
-**External filters.** Callers can stage an allow-list or deny-list filter via the session API (RPC `mcp/add`, `mcp/remove`, REST endpoints, or programmatically through `ToolScopeHandle`). The filter is persisted in session metadata and survives resume.
+**External filters.** Callers can stage an allow-list or deny-list filter programmatically through `ToolScopeHandle`. This is distinct from MCP server lifecycle management.
 
 **Per-turn overlays.** Mob flow steps can restrict tools for a single turn via `TurnToolOverlay` (allow + deny). The overlay is ephemeral — it's cleared after the turn completes.
 
@@ -106,27 +107,29 @@ All mutations are staged and applied at the next turn boundary. Set `persisted: 
 
 | Surface | Live MCP | External tool filter |
 |---------|----------|---------------------|
-| JSON-RPC | `mcp/add`, `mcp/remove`, `mcp/reload` | Via `ToolScopeHandle` on session runtime |
-| CLI | `rkat mcp add --session --live-server-url` | Delegates to REST |
-| REST | Route stubs registered | -- |
+| JSON-RPC | `mcp/add`, `mcp/remove`, `mcp/reload` | Via in-process `ToolScopeHandle` on the session runtime |
+| CLI | `rkat mcp reload --session --live-server-url ...` and related host-managed flows | No standalone public CLI surface today |
+| REST | `POST /sessions/{id}/mcp/add`, `remove`, `reload` | No standalone public REST filter surface today |
 
 See the [built-in tools reference](/reference/builtin-tools) for the mechanical details of factory flags and per-build overrides.
 
 ## Multimodal tool results
 
-Tools can return rich content beyond plain text. The `ToolOutput` enum controls what gets injected into the conversation as a tool result:
+Tools can return rich content beyond plain text. The injected runtime shape is `ToolResult.content: Vec<ContentBlock>`, with helper constructors for text-only or multimodal output.
 
-- **`ToolOutput::Json(Value)`** -- the standard path. The JSON value is serialized to a text `ContentBlock` in the tool result.
-- **`ToolOutput::Blocks(Vec<ContentBlock>)`** -- returns one or more content blocks directly, including images. Used by tools like `view_image` to pass image data to vision-capable models.
+- **`ToolResult::new(...)`** -- the standard text-only path. The string becomes a single text content block.
+- **`ToolResult::with_blocks(...)`** -- returns one or more content blocks directly, including images and video.
+- Built-in tools that expose richer output may internally use `ToolOutput::Blocks(...)`, but the persisted/runtime-facing result shape is still `ToolResult.content`.
 
-`ContentBlock` has two variants:
+`ContentBlock` currently has three variants:
 
 - `ContentBlock::Text { text }` -- plain text content.
-- `ContentBlock::Image { media_type, data, source_path }` -- base64-encoded image with MIME type. The `source_path` field is domain-only metadata (stripped from wire types).
+- `ContentBlock::Image { media_type, ... }` -- inline or blob-backed image content.
+- `ContentBlock::Video { media_type, duration_ms, ... }` -- inline video content.
 
-The built-in `view_image` tool reads an image file from disk and returns a `ToolOutput::Blocks` containing a single `ContentBlock::Image`. It supports PNG, JPEG, GIF, WebP, and SVG formats up to 5 MB. The tool is automatically hidden from models that lack vision support via `ToolScope` capability gating based on `ModelProfile.vision` and `ModelProfile.image_tool_results`.
+The built-in `view_image` tool reads an image file from disk and returns a result containing image content blocks. It supports PNG, JPEG, GIF, WebP, and SVG formats up to 5 MB. The tool is automatically hidden from models that lack vision support via capability-aware tool visibility.
 
-Custom tools can return multimodal content by implementing `BuiltinTool::call()` and returning `ToolOutput::Blocks(...)` with the appropriate content blocks.
+Custom tools can return multimodal content by returning `ToolResult::with_blocks(...)` with the appropriate content blocks.
 
 ## Composition
 

--- a/docs/design/mobpack.md
+++ b/docs/design/mobpack.md
@@ -1,6 +1,8 @@
 # Mobpack: Portable Multi-Agent Deployment
 
 > Status: **Design proposal** | Author: Luka + Claude | Date: 2026-02-24
+>
+> **Implementation status note:** today the shipped CLI supports `rkat mob pack`, `inspect`, `validate`, `deploy`, and `web build`. Command families such as `embed`, `compile`, `publish`, `web serve`, and `web publish` described below are proposal-only and should not be treated as current product surface.
 
 ## Overview
 
@@ -67,7 +69,7 @@ description = "Automated release triage with code review and changelog generatio
 authors = ["team@example.com"]
 
 [requires]
-meerkat = ">=0.5.0"
+meerkat = ">=0.6.0"
 credentials = ["anthropic_api_key"]       # declared, never stored
 capabilities = ["comms", "shell"]         # what the mob needs from the runtime
 
@@ -397,7 +399,7 @@ description = "Browser-deployed release triage mob"
 authors = ["team@example.com"]
 
 [requires]
-meerkat = ">=0.5.0"
+meerkat = ">=0.6.0"
 browser_features = ["web_workers", "indexeddb", "fetch"]
 credentials = ["oauth:jira", "oauth:salesforce"]
 

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -27,7 +27,7 @@
         "groups": [
           {
             "group": "Getting started",
-            "pages": ["introduction", "quickstart"]
+            "pages": ["introduction", "quickstart", "guides/auth", "examples/gallery"]
           },
           {
             "group": "Core concepts",

--- a/docs/examples/comms.mdx
+++ b/docs/examples/comms.mdx
@@ -1,14 +1,14 @@
 ---
-title: "Comms & mobs"
-description: "Inter-agent messaging, keep-alive sessions, external event injection, and mob orchestration."
+title: "Comms & external events"
+description: "Keep-alive sessions, typed comms commands, peer discovery, and durable external event ingress."
 icon: "tower-broadcast"
 ---
 
-For the full guide, see [Comms](/guides/comms) and the `0.5` mob orchestration architecture notes.
+For the full guide, see [Comms](/guides/comms).
 
-## Keep-alive mode
+## Keep a session alive for inbound work
 
-Enable the comms listener so the agent stays alive after its initial prompt, waiting for incoming messages and external events as future runtime-backed turn work.
+Keep-alive sessions stay resident so later comms or external events can wake them up as future runtime-backed work.
 
 <Tabs>
   <Tab title="CLI">
@@ -19,7 +19,8 @@ Enable the comms listener so the agent stays alive after its initial prompt, wai
   <Tab title="JSON-RPC">
     ```json
     {
-      "jsonrpc": "2.0", "id": 1,
+      "jsonrpc": "2.0",
+      "id": 1,
       "method": "session/create",
       "params": {
         "prompt": "You are a coordinator.",
@@ -40,16 +41,6 @@ Enable the comms listener so the agent stays alive after its initial prompt, wai
       }'
     ```
   </Tab>
-  <Tab title="MCP">
-    ```json
-    {
-      "prompt": "You are a coordinator.",
-      "keep_alive": true,
-      "comms_name": "agent-a"
-    }
-    ```
-    Called via the `meerkat_run` tool.
-  </Tab>
   <Tab title="Python">
     ```python
     session = await client.create_session(
@@ -67,42 +58,25 @@ Enable the comms listener so the agent stays alive after its initial prompt, wai
     });
     ```
   </Tab>
-  <Tab title="Rust">
-    ```rust
-    let result = service.create_session(CreateSessionRequest {
-        model: "claude-sonnet-4-6".into(),
-        prompt: "You are a coordinator.".into(),
-        system_prompt: None,
-        max_tokens: None,
-        render_metadata: None,
-        event_tx: None,
-        skill_references: None,
-        initial_turn: InitialTurnPolicy::RunImmediately,
-        build: Some(SessionBuildOptions {
-            keep_alive: true,
-            comms_name: Some("agent-a".into()),
-            ..Default::default()
-        }),
-        labels: None,
-    }).await?;
-    ```
-  </Tab>
 </Tabs>
 
-## Send a message
+## Send a typed comms command
 
-Push an event into a running session's comms inbox.
+`comms/send` is the typed host-side comms surface. Use it for local input, peer messages, peer requests, and peer responses.
 
 <Tabs>
   <Tab title="JSON-RPC">
     ```json
     {
-      "jsonrpc": "2.0", "id": 2,
+      "jsonrpc": "2.0",
+      "id": 2,
       "method": "comms/send",
       "params": {
         "session_id": "01936f8a-...",
-        "payload": {"alert": "build failed", "severity": "high"},
-        "source": "ci-pipeline"
+        "kind": "peer_message",
+        "to": "agent-b",
+        "body": "Build failed in CI. Please investigate.",
+        "handling_mode": "queue"
       }
     }
     ```
@@ -111,155 +85,158 @@ Push an event into a running session's comms inbox.
     ```bash
     curl -X POST http://localhost:8080/comms/send \
       -H "Content-Type: application/json" \
-      -d '{"session_id":"01936f8a-...","payload":{"alert":"build failed"},"source":"ci-pipeline"}'
+      -d '{
+        "session_id": "01936f8a-...",
+        "kind": "peer_message",
+        "to": "agent-b",
+        "body": "Build failed in CI. Please investigate.",
+        "handling_mode": "queue"
+      }'
     ```
   </Tab>
   <Tab title="MCP">
     ```json
-    {"name": "meerkat_comms_send", "arguments": {
-      "session_id": "01936f8a-...",
-      "kind": "peer_message",
-      "to": "agent-b",
-      "body": "Hello from agent-a",
-      "handling_mode": "queue"
-    }}
+    {
+      "name": "meerkat_comms_send",
+      "arguments": {
+        "session_id": "01936f8a-...",
+        "kind": "peer_message",
+        "to": "agent-b",
+        "body": "Build failed in CI. Please investigate.",
+        "handling_mode": "queue"
+      }
+    }
     ```
   </Tab>
   <Tab title="Python">
     ```python
-    session = await client.create_session("...", keep_alive=True, comms_name="agent-a")
-    await session.send(payload={"alert": "build failed"}, source="ci-pipeline")
+    receipt = await session.send({
+        "kind": "peer_message",
+        "to": "agent-b",
+        "body": "Build failed in CI. Please investigate.",
+        "handling_mode": "queue",
+    })
+    print(receipt)
     ```
   </Tab>
   <Tab title="TypeScript">
     ```typescript
-    const session = await client.createSession("...", { keepAlive: true, commsName: "agent-a" });
-    await session.send({ payload: { alert: "build failed" }, source: "ci-pipeline" });
-    ```
-  </Tab>
-  <Tab title="Rust">
-    ```rust
-    let injector = service.event_injector(&session_id).await
-        .expect("comms must be enabled");
-    injector.inject(r#"{"alert": "build failed"}"#.into(), PlainEventSource::Rpc)?;
+    const receipt = await session.send({
+      kind: "peer_message",
+      to: "agent-b",
+      body: "Build failed in CI. Please investigate.",
+      handling_mode: "queue",
+    });
+    console.log(receipt);
     ```
   </Tab>
 </Tabs>
 
-## List peers
+## List discoverable peers
 
-Discover trusted peers visible to a running session.
+Use `comms/peers` to see which trusted peers are currently visible to the session runtime.
 
 <Tabs>
   <Tab title="JSON-RPC">
     ```json
     {
-      "jsonrpc": "2.0", "id": 3,
+      "jsonrpc": "2.0",
+      "id": 3,
       "method": "comms/peers",
-      "params": { "session_id": "01936f8a-..." }
+      "params": {
+        "session_id": "01936f8a-..."
+      }
     }
     ```
   </Tab>
   <Tab title="REST">
     ```bash
-    curl http://localhost:8080/comms/peers?session_id=01936f8a-...
+    curl "http://localhost:8080/comms/peers?session_id=01936f8a-..."
     ```
   </Tab>
   <Tab title="MCP">
     ```json
-    {"name": "meerkat_comms_peers", "arguments": {
-      "session_id": "01936f8a-..."
-    }}
+    {
+      "name": "meerkat_comms_peers",
+      "arguments": {
+        "session_id": "01936f8a-..."
+      }
+    }
     ```
   </Tab>
   <Tab title="Python">
     ```python
     peers = await session.peers()
-    for p in peers:
-        print(f"{p['name']} @ {p['address']}")
+    for peer in peers:
+        print(peer["name"])
     ```
   </Tab>
   <Tab title="TypeScript">
     ```typescript
     const peers = await session.peers();
-    peers.forEach(p => console.log(`${p.name} @ ${p.address}`));
-    ```
-  </Tab>
-  <Tab title="Rust">
-    ```rust
-    let runtime = service.comms_runtime(&session_id).await
-        .expect("comms must be enabled");
-    let peers = runtime.peers().await;
-    for p in &peers { println!("{} @ {}", p.name, p.address); }
+    peers.forEach((peer) => console.log(peer.name));
     ```
   </Tab>
 </Tabs>
 
-## External event injection
+## Inject a durable external event
 
-Push external events from outside systems into a running agent. Events are queued as runtime-backed external inputs and admitted as future turn work.
+Use `session/external_event` when the event should enter the runtime's external-ingress lane rather than the comms command lane.
 
 <Tabs>
-  <Tab title="CLI">
-    ```bash
-    # Keep-alive with stdin events (pipe or type interactively)
-    rkat run --comms-name monitor --keep-alive --stdin \
-      "You are a monitoring agent."
-    ```
-  </Tab>
   <Tab title="JSON-RPC">
     ```json
     {
-      "jsonrpc": "2.0", "id": 4,
-      "method": "comms/send",
+      "jsonrpc": "2.0",
+      "id": 4,
+      "method": "session/external_event",
       "params": {
         "session_id": "01936f8a-...",
-        "payload": {"event": "deploy_complete", "env": "prod"},
-        "source": "deploy-bot"
+        "kind": "generic_json",
+        "event_type": "deploy_complete",
+        "payload": {
+          "environment": "prod",
+          "release": "2026.04.21"
+        }
       }
     }
     ```
   </Tab>
   <Tab title="REST">
     ```bash
-    curl -X POST http://localhost:8080/comms/send \
+    curl -X POST http://localhost:8080/sessions/01936f8a-.../external-events \
       -H "Content-Type: application/json" \
-      -d '{"session_id":"01936f8a-...","payload":{"event":"deploy_complete","env":"prod"},"source":"deploy-bot"}'
-    ```
-  </Tab>
-  <Tab title="MCP">
-    ```json
-    {"name": "meerkat_comms_send", "arguments": {
-      "session_id": "01936f8a-...",
-      "kind": "event",
-      "body": "{\"event\":\"deploy_complete\",\"env\":\"prod\"}"
-    }}
+      -d '{
+        "kind": "generic_json",
+        "event_type": "deploy_complete",
+        "payload": {
+          "environment": "prod",
+          "release": "2026.04.21"
+        }
+      }'
     ```
   </Tab>
   <Tab title="Python">
     ```python
-    await session.send(payload={"event": "deploy_complete", "env": "prod"}, source="deploy-bot")
+    await session.send_external_event(
+        "deploy_complete",
+        {
+            "environment": "prod",
+            "release": "2026.04.21",
+        },
+    )
     ```
   </Tab>
   <Tab title="TypeScript">
     ```typescript
-    await session.send({ payload: { event: "deploy_complete", env: "prod" }, source: "deploy-bot" });
-    ```
-  </Tab>
-  <Tab title="Rust">
-    ```rust
-    let injector = service.event_injector(&session_id).await
-        .expect("comms must be enabled");
-
-    injector.inject(
-        r#"{"event": "deploy_complete"}"#.into(),
-        PlainEventSource::Rpc,
-    )?;
-
+    await session.sendExternalEvent("deploy_complete", {
+      environment: "prod",
+      release: "2026.04.21",
+    });
     ```
   </Tab>
 </Tabs>
 
-## Delegate through mobs
-
-In `0.5`, delegated and multi-agent work routes through mobs rather than a standalone helper-agent tool family. Use mob member refs, flow runs, and peer messaging to coordinate temporary discussion groups or longer-lived orchestration topologies.
+<Note>
+Use `comms/send` for typed inbox and peer communication. Use `session/external_event` when an outside system is appending durable runtime-backed work.
+</Note>

--- a/docs/examples/gallery.mdx
+++ b/docs/examples/gallery.mdx
@@ -6,6 +6,22 @@ icon: "rocket"
 
 Production-ready applications in the [repository](https://github.com/lukacf/meerkat/tree/main/examples). For feature-by-feature code snippets, start with [Sessions & streaming](/examples/sessions).
 
+## Starter examples
+
+<CardGroup cols={3}>
+  <Card title="001 Hello Meerkat (Rust)" icon="code" href="https://github.com/lukacf/meerkat/tree/main/examples/001-hello-meerkat-rs">
+    **Rust** -- Minimal in-process agent setup for a first successful run.
+  </Card>
+  <Card title="002 Hello Meerkat (Python)" icon="python" href="https://github.com/lukacf/meerkat/tree/main/examples/002-hello-meerkat-py">
+    **Python** -- Smallest SDK flow for connecting, creating a session, and reading the result.
+  </Card>
+  <Card title="003 Hello Meerkat (TypeScript)" icon="js" href="https://github.com/lukacf/meerkat/tree/main/examples/003-hello-meerkat-ts">
+    **TypeScript** -- Minimal Node.js SDK example with automatic `rkat-rpc` resolution.
+  </Card>
+</CardGroup>
+
+If you are new to Meerkat, start with the three hello-world examples above before jumping into the larger multi-agent and deployment demos below.
+
 ## Multi-agent systems
 
 <CardGroup cols={2}>

--- a/docs/examples/hooks.mdx
+++ b/docs/examples/hooks.mdx
@@ -12,17 +12,7 @@ A `post_tool_execution` background hook that logs every tool call to a file. Bac
 
 <Tabs>
   <Tab title="CLI">
-    ```bash
-    rkat run "Summarize this repo" --hooks-override-json '{
-      "entries": [{
-        "id": "audit-log",
-        "point": "post_tool_execution",
-        "mode": "background",
-        "command": ["python3", "hooks/log_tool.py"],
-        "timeout_ms": 3000
-      }]
-    }'
-    ```
+    Run-scoped hook override flags are not currently exposed on the normal `rkat run` surface. Use the JSON-RPC, REST, MCP, or SDK examples below for per-run hook override testing.
   </Tab>
   <Tab title="JSON-RPC">
     ```json
@@ -36,7 +26,12 @@ A `post_tool_execution` background hook that logs every tool call to a file. Bac
             "id": "audit-log",
             "point": "post_tool_execution",
             "mode": "background",
-            "command": ["python3", "hooks/log_tool.py"],
+            "capability": "observe",
+            "runtime": {
+              "type": "command",
+              "command": "python3",
+              "args": ["hooks/log_tool.py"]
+            },
             "timeout_ms": 3000
           }]
         }
@@ -55,7 +50,12 @@ A `post_tool_execution` background hook that logs every tool call to a file. Bac
             "id": "audit-log",
             "point": "post_tool_execution",
             "mode": "background",
-            "command": ["python3", "hooks/log_tool.py"],
+            "capability": "observe",
+            "runtime": {
+              "type": "command",
+              "command": "python3",
+              "args": ["hooks/log_tool.py"]
+            },
             "timeout_ms": 3000
           }]
         }
@@ -74,7 +74,12 @@ A `post_tool_execution` background hook that logs every tool call to a file. Bac
             "id": "audit-log",
             "point": "post_tool_execution",
             "mode": "background",
-            "command": ["python3", "hooks/log_tool.py"],
+            "capability": "observe",
+            "runtime": {
+              "type": "command",
+              "command": "python3",
+              "args": ["hooks/log_tool.py"]
+            },
             "timeout_ms": 3000
           }]
         }
@@ -91,7 +96,12 @@ A `post_tool_execution` background hook that logs every tool call to a file. Bac
                 "id": "audit-log",
                 "point": "post_tool_execution",
                 "mode": "background",
-                "command": ["python3", "hooks/log_tool.py"],
+                "capability": "observe",
+                "runtime": {
+                    "type": "command",
+                    "command": "python3",
+                    "args": ["hooks/log_tool.py"],
+                },
                 "timeout_ms": 3000,
             }]
         },
@@ -106,7 +116,12 @@ A `post_tool_execution` background hook that logs every tool call to a file. Bac
           id: "audit-log",
           point: "post_tool_execution",
           mode: "background",
-          command: ["python3", "hooks/log_tool.py"],
+          capability: "observe",
+          runtime: {
+            type: "command",
+            command: "python3",
+            args: ["hooks/log_tool.py"],
+          },
           timeoutMs: 3000,
         }],
       },
@@ -115,23 +130,13 @@ A `post_tool_execution` background hook that logs every tool call to a file. Bac
   </Tab>
 </Tabs>
 
-## Guardrail hook (blocking)
+## Guardrail hook (foreground)
 
-A `pre_tool_execution` blocking hook that must approve each tool call before it runs. If the hook returns `deny`, the tool call is skipped.
+A `pre_tool_execution` foreground hook that must approve each tool call before it runs. If the hook returns `deny`, the tool call is skipped.
 
 <Tabs>
   <Tab title="CLI">
-    ```bash
-    rkat run "Delete old logs" --hooks-override-json '{
-      "entries": [{
-        "id": "safety-gate",
-        "point": "pre_tool_execution",
-        "mode": "blocking",
-        "command": ["python3", "hooks/approve_tool.py"],
-        "timeout_ms": 5000
-      }]
-    }'
-    ```
+    Run-scoped hook override flags are not currently exposed on the normal `rkat run` surface. Use the JSON-RPC, REST, MCP, or SDK examples below for per-run hook override testing.
   </Tab>
   <Tab title="JSON-RPC">
     ```json
@@ -144,8 +149,13 @@ A `pre_tool_execution` blocking hook that must approve each tool call before it 
           "entries": [{
             "id": "safety-gate",
             "point": "pre_tool_execution",
-            "mode": "blocking",
-            "command": ["python3", "hooks/approve_tool.py"],
+            "mode": "foreground",
+            "capability": "guardrail",
+            "runtime": {
+              "type": "command",
+              "command": "python3",
+              "args": ["hooks/approve_tool.py"]
+            },
             "timeout_ms": 5000
           }]
         }
@@ -163,8 +173,13 @@ A `pre_tool_execution` blocking hook that must approve each tool call before it 
           "entries": [{
             "id": "safety-gate",
             "point": "pre_tool_execution",
-            "mode": "blocking",
-            "command": ["python3", "hooks/approve_tool.py"],
+            "mode": "foreground",
+            "capability": "guardrail",
+            "runtime": {
+              "type": "command",
+              "command": "python3",
+              "args": ["hooks/approve_tool.py"]
+            },
             "timeout_ms": 5000
           }]
         }
@@ -182,8 +197,13 @@ A `pre_tool_execution` blocking hook that must approve each tool call before it 
           "entries": [{
             "id": "safety-gate",
             "point": "pre_tool_execution",
-            "mode": "blocking",
-            "command": ["python3", "hooks/approve_tool.py"],
+            "mode": "foreground",
+            "capability": "guardrail",
+            "runtime": {
+              "type": "command",
+              "command": "python3",
+              "args": ["hooks/approve_tool.py"]
+            },
             "timeout_ms": 5000
           }]
         }
@@ -199,8 +219,13 @@ A `pre_tool_execution` blocking hook that must approve each tool call before it 
             "entries": [{
                 "id": "safety-gate",
                 "point": "pre_tool_execution",
-                "mode": "blocking",
-                "command": ["python3", "hooks/approve_tool.py"],
+                "mode": "foreground",
+                "capability": "guardrail",
+                "runtime": {
+                    "type": "command",
+                    "command": "python3",
+                    "args": ["hooks/approve_tool.py"],
+                },
                 "timeout_ms": 5000,
             }]
         },
@@ -214,8 +239,13 @@ A `pre_tool_execution` blocking hook that must approve each tool call before it 
         entries: [{
           id: "safety-gate",
           point: "pre_tool_execution",
-          mode: "blocking",
-          command: ["python3", "hooks/approve_tool.py"],
+          mode: "foreground",
+          capability: "guardrail",
+          runtime: {
+            type: "command",
+            command: "python3",
+            args: ["hooks/approve_tool.py"],
+          },
           timeoutMs: 5000,
         }],
       },
@@ -257,17 +287,7 @@ A hook that POSTs the invocation payload to a remote URL. Useful for centralized
 
 <Tabs>
   <Tab title="CLI">
-    ```bash
-    rkat run "Analyze quarterly data" --hooks-override-json '{
-      "entries": [{
-        "id": "policy-server",
-        "point": "pre_llm_request",
-        "mode": "blocking",
-        "url": "https://hooks.example.com/policy",
-        "timeout_ms": 10000
-      }]
-    }'
-    ```
+    Run-scoped hook override flags are not currently exposed on the normal `rkat run` surface. Use the JSON-RPC, REST, MCP, or SDK examples below for per-run hook override testing.
   </Tab>
   <Tab title="JSON-RPC">
     ```json
@@ -280,8 +300,13 @@ A hook that POSTs the invocation payload to a remote URL. Useful for centralized
           "entries": [{
             "id": "policy-server",
             "point": "pre_llm_request",
-            "mode": "blocking",
-            "url": "https://hooks.example.com/policy",
+            "mode": "foreground",
+            "capability": "guardrail",
+            "runtime": {
+              "type": "http",
+              "url": "https://hooks.example.com/policy",
+              "method": "POST"
+            },
             "timeout_ms": 10000
           }]
         }
@@ -299,8 +324,13 @@ A hook that POSTs the invocation payload to a remote URL. Useful for centralized
           "entries": [{
             "id": "policy-server",
             "point": "pre_llm_request",
-            "mode": "blocking",
-            "url": "https://hooks.example.com/policy",
+            "mode": "foreground",
+            "capability": "guardrail",
+            "runtime": {
+              "type": "http",
+              "url": "https://hooks.example.com/policy",
+              "method": "POST"
+            },
             "timeout_ms": 10000
           }]
         }
@@ -318,8 +348,13 @@ A hook that POSTs the invocation payload to a remote URL. Useful for centralized
           "entries": [{
             "id": "policy-server",
             "point": "pre_llm_request",
-            "mode": "blocking",
-            "url": "https://hooks.example.com/policy",
+            "mode": "foreground",
+            "capability": "guardrail",
+            "runtime": {
+              "type": "http",
+              "url": "https://hooks.example.com/policy",
+              "method": "POST"
+            },
             "timeout_ms": 10000
           }]
         }
@@ -335,8 +370,13 @@ A hook that POSTs the invocation payload to a remote URL. Useful for centralized
             "entries": [{
                 "id": "policy-server",
                 "point": "pre_llm_request",
-                "mode": "blocking",
-                "url": "https://hooks.example.com/policy",
+                "mode": "foreground",
+                "capability": "guardrail",
+                "runtime": {
+                    "type": "http",
+                    "url": "https://hooks.example.com/policy",
+                    "method": "POST",
+                },
                 "timeout_ms": 10000,
             }]
         },
@@ -350,8 +390,13 @@ A hook that POSTs the invocation payload to a remote URL. Useful for centralized
         entries: [{
           id: "policy-server",
           point: "pre_llm_request",
-          mode: "blocking",
-          url: "https://hooks.example.com/policy",
+          mode: "foreground",
+          capability: "guardrail",
+          runtime: {
+            type: "http",
+            url: "https://hooks.example.com/policy",
+            method: "POST",
+          },
           timeoutMs: 10000,
         }],
       },
@@ -374,7 +419,7 @@ A hook that POSTs the invocation payload to a remote URL. Useful for centralized
 | `run_failed` | post | After a run fails with an error |
 
 <Note>
-Pre-point hooks in `blocking` mode halt the agent loop until they return. Pre-point hooks in `background` mode are limited to observe-only capability.
+Pre-point hooks in `foreground` mode halt the agent loop until they return. Pre-point hooks in `background` mode are limited to observe-only capability.
 </Note>
 
 ## Disable a hook

--- a/docs/examples/memory.mdx
+++ b/docs/examples/memory.mdx
@@ -6,6 +6,10 @@ icon: "brain"
 
 For the full guide, see [Memory](/guides/memory).
 
+<Note>
+The runtime toggles shown below still depend on a memory-enabled build. If the binary was compiled without the relevant memory features, `enable_memory` and `--tools full` do not magically add semantic memory on their own.
+</Note>
+
 ## Enable semantic memory
 
 When memory is enabled, discarded conversation turns are indexed into a semantic store. The agent gains a `memory_search` tool to recall past context on demand.
@@ -170,7 +174,7 @@ Cap resource usage per session with token, time, and tool-call limits. When a bu
   <Tab title="CLI">
     ```bash
     rkat run "Research this topic" \
-      --max-total-tokens 10000 \
+      --max-tokens 10000 \
       --max-duration 30s \
       --max-tool-calls 5
     ```
@@ -183,8 +187,7 @@ Cap resource usage per session with token, time, and tool-call limits. When a bu
       "params": {
         "prompt": "Research this topic",
         "budget_limits": {
-          "max_total_tokens": 10000,
-          "max_duration_ms": 30000,
+          "max_tokens": 10000,
           "max_tool_calls": 5
         }
       }
@@ -198,8 +201,7 @@ Cap resource usage per session with token, time, and tool-call limits. When a bu
       -d '{
         "prompt": "Research this topic",
         "budget_limits": {
-          "max_total_tokens": 10000,
-          "max_duration_ms": 30000,
+          "max_tokens": 10000,
           "max_tool_calls": 5
         }
       }'
@@ -214,7 +216,6 @@ Cap resource usage per session with token, time, and tool-call limits. When a bu
         "enable_builtins": true,
         "budget_limits": {
           "max_tokens": 10000,
-          "max_duration_secs": 30,
           "max_tool_calls": 5
         }
       }
@@ -226,8 +227,7 @@ Cap resource usage per session with token, time, and tool-call limits. When a bu
     result = await client.create_session(
         "Research this topic",
         budget_limits={
-            "max_total_tokens": 10000,
-            "max_duration_ms": 30000,
+            "max_tokens": 10000,
             "max_tool_calls": 5,
         },
     )
@@ -237,9 +237,8 @@ Cap resource usage per session with token, time, and tool-call limits. When a bu
     ```typescript
     const result = await client.createSession("Research this topic", {
       budgetLimits: {
-        maxTotalTokens: 10000,
-        maxDurationMs: 30000,
-        maxToolCalls: 5,
+        max_tokens: 10000,
+        max_tool_calls: 5,
       },
     });
     ```
@@ -265,7 +264,7 @@ When consumption nears a limit, a warning event is emitted before the budget is 
 ```json
 {
   "type": "budget_warning",
-  "budget_type": "max_tokens",
+  "budget_type": "tokens",
   "used": 8500,
   "limit": 10000,
   "percent": 85.0

--- a/docs/examples/mobs.mdx
+++ b/docs/examples/mobs.mdx
@@ -1,211 +1,104 @@
 ---
 title: "Mobs"
-description: "Multi-agent orchestration with roles, wiring, flows, and lifecycle management."
+description: "Create mobs, spawn members, wire peers, send work, and run flows through the current host control plane."
 icon: "users"
 ---
 
 For the full guide, see [Mobs](/guides/mobs).
 
-## Mob definition
-
-A mob definition declares profiles (agent templates), wiring rules, and flows. Definitions can be JSON or TOML.
-
-```json
-{
-  "id": "release-triage",
-  "profiles": {
-    "lead": {
-      "model": "claude-opus-4-6",
-      "peer_description": "Coordinates triage, assigns issues",
-      "tools": { "builtins": true, "comms": true, "mob": true, "mob_tasks": true },
-      "skills": ["triage-workflow"],
-      "runtime_mode": "autonomous_host"
-    },
-    "analyst": {
-      "model": "claude-sonnet-4-6",
-      "peer_description": "Investigates assigned issues",
-      "tools": { "builtins": true, "shell": true, "comms": true },
-      "runtime_mode": "autonomous_host"
-    }
-  },
-  "wiring": {
-    "auto_wire_orchestrator": false,
-    "role_wiring": [
-      { "a": "lead", "b": "analyst" }
-    ]
-  },
-  "flows": {
-    "triage": {
-      "description": "Triage incoming issues",
-      "steps": {
-        "scan": {
-          "role": "lead",
-          "message": "Scan the issue tracker and prioritize"
-        },
-        "investigate": {
-          "role": "analyst",
-          "message": "Investigate the top priority issue",
-          "depends_on": ["scan"],
-          "dispatch_mode": "fan_out"
-        },
-        "summarize": {
-          "role": "lead",
-          "message": "Summarize findings and recommend actions",
-          "depends_on": ["investigate"],
-          "depends_on_mode": "all"
-        }
-      }
-    }
-  },
-  "limits": {
-    "max_flow_duration_ms": 300000,
-    "max_step_retries": 2,
-    "max_orphaned_turns": 10
-  }
-}
-```
-
-### Profile fields
-
-| Field | Type | Description |
-|-------|------|-------------|
-| `model` | string | LLM model name |
-| `skills` | string[] | Skill references to load |
-| `tools` | object | Tool categories: `builtins`, `shell`, `comms`, `memory`, `mob`, `mob_tasks`, `mcp` (server names) |
-| `peer_description` | string | Visible to peers in comms discovery |
-| `runtime_mode` | string | `"autonomous_host"` (default) or `"turn_driven"` |
-| `external_addressable` | bool | Visible for cross-mob comms |
-| `output_schema` | object | JSON Schema for structured output extraction |
-
-### Flow step fields
-
-| Field | Type | Description |
-|-------|------|-------------|
-| `role` | string | Profile name to execute this step |
-| `message` | string | Prompt sent to the member |
-| `depends_on` | string[] | Step IDs that must complete first |
-| `depends_on_mode` | string | `"all"` (default) or `"any"` |
-| `dispatch_mode` | string | `"fan_out"` (default), `"one_to_one"`, `"fan_in"` |
-| `condition` | object | Guard expression (`eq`, `in`, `gt`, `lt`, `and`, `or`, `not`) |
-| `branch` | string | Branch label for conditional routing |
-| `timeout_ms` | number | Step-level timeout |
-| `allowed_tools` / `blocked_tools` | string[] | Per-step tool overlay |
-
----
-
-## Agent-side mob tools reference
-
-When `enable_mob` is set, the running agent gets these in-session tools:
-
-| Tool | Parameters | Description |
-|------|-----------|-------------|
-| `mob_create` | `definition` (JSON) | Create a mob from definition |
-| `mob_list` | `mob_id?` | List mobs, or get status of one |
-| `mob_lifecycle` | `mob_id`, `action` (stop/resume/complete/destroy) | Control mob state |
-| `mob_events` | `mob_id`, `after_cursor?`, `limit?` | Read mob event log |
-| `mob_run_flow` | `mob_id`, `flow_id`, `params?` | Execute a DAG flow |
-| `mob_flow_status` | `mob_id`, `run_id` | Check flow run status |
-| `mob_cancel_flow` | `mob_id`, `run_id` | Cancel a running flow |
-| `mob_spawn_member` | `mob_id`, `specs` (array of `{profile, agent_identity, runtime_mode?, initial_message?}`) | Spawn members (batch) |
-| `mob_retire_member` | `mob_id`, `agent_identity` | Remove a member |
-| `mob_wire` | `mob_id`, `agent_identity`, `peer`, `action` | Establish or remove a trusted comms channel |
-| `mob_list_members` | `mob_id` | List mob members and their state |
-
 <Note>
-These are the agent-side `mob_*` tools. Public host surfaces use typed control
-planes instead:
+There are two different mob surfaces:
 
-- JSON-RPC / SDKs: explicit `mob/*` methods
-- Public MCP hosts: typed `meerkat_mob_*` tools
-- REST: typed mob endpoints where available, rather than agent-side `mob_*`
+- **Host APIs**: typed `mob/*` methods over JSON-RPC and the SDK-backed `Mob` classes
+- **Agent-side tools**: `mob_*` tools exposed inside a running agent session
+
+This page focuses on the host control plane. It does **not** treat agent-side `mob_*` tools as if they were the public RPC/SDK API.
 </Note>
-
----
 
 ## Create a mob
 
 <Tabs>
-  <Tab title="CLI">
-    ```bash
-    # From a definition file
-    rkat mob create --definition ./mobs/triage/definition.json
-    ```
-  </Tab>
   <Tab title="JSON-RPC">
     ```json
     {
-      "jsonrpc": "2.0", "id": 1,
-      "method": "session/create",
+      "jsonrpc": "2.0",
+      "id": 1,
+      "method": "mob/create",
       "params": {
-        "prompt": "Create a coding swarm mob, spawn all members, wire them, and report status.",
-        "enable_builtins": true,
-        "enable_mob": true
+        "definition": {
+          "id": "release-triage",
+          "profiles": {
+            "lead": {
+              "model": "claude-opus-4-6",
+              "peer_description": "Coordinates triage"
+            },
+            "analyst": {
+              "model": "claude-sonnet-4-6",
+              "peer_description": "Investigates issues"
+            }
+          },
+          "flows": {
+            "triage": {
+              "steps": {
+                "scan": { "role": "lead", "message": "Prioritize incoming issues." }
+              }
+            }
+          }
+        }
       }
     }
     ```
   </Tab>
-  <Tab title="REST">
-    ```bash
-    curl -X POST http://localhost:8080/sessions \
-      -H "Content-Type: application/json" \
-      -d '{"prompt":"Create a coding swarm mob, spawn and wire all members.","enable_builtins":true,"enable_mob":true}'
-    ```
-  </Tab>
-  <Tab title="MCP">
-    ```json
-    {"name": "meerkat_run", "arguments": {
-      "prompt": "Create a coding swarm mob, spawn all members, wire them.",
-      "enable_builtins": true,
-      "enable_mob": true
-    }}
-    ```
-  </Tab>
   <Tab title="Python">
     ```python
-    session = await client.create_session(
-        prompt="Create a coding swarm, spawn all members, wire them.",
-        enable_builtins=True,
-        enable_mob=True,
+    mob = await client.create_mob(
+        definition={
+            "id": "release-triage",
+            "profiles": {
+                "lead": {
+                    "model": "claude-opus-4-6",
+                    "peer_description": "Coordinates triage",
+                },
+                "analyst": {
+                    "model": "claude-sonnet-4-6",
+                    "peer_description": "Investigates issues",
+                },
+            },
+        }
     )
+    print(mob.id)
     ```
   </Tab>
   <Tab title="TypeScript">
     ```typescript
-    const session = await client.createSession("Create a coding swarm, spawn all members, wire them.", {
-      enableBuiltins: true,
-      enableMob: true,
+    const mob = await client.createMob({
+      definition: {
+        id: "release-triage",
+        profiles: {
+          lead: {
+            model: "claude-opus-4-6",
+            peer_description: "Coordinates triage",
+          },
+          analyst: {
+            model: "claude-sonnet-4-6",
+            peer_description: "Investigates issues",
+          },
+        },
+      },
     });
+    console.log(mob.mobId);
     ```
   </Tab>
   <Tab title="Rust">
     ```rust
-    let definition = MobDefinition::from_toml(r#"
-    [mob]
-    id = "coding_swarm"
-    orchestrator = "lead"
+    let definition = MobDefinition::from_json(json!({
+        "id": "release-triage",
+        "profiles": {
+            "lead": { "model": "claude-opus-4-6" },
+            "analyst": { "model": "claude-sonnet-4-6" }
+        }
+    }))?;
 
-    [profiles.lead]
-    model = "claude-opus-4-6"
-    external_addressable = true
-
-    [profiles.lead.tools]
-    builtins = true
-    comms = true
-    mob = true
-    mob_tasks = true
-
-    [profiles.worker]
-    model = "claude-sonnet-4-6"
-
-    [profiles.worker.tools]
-    builtins = true
-    shell = true
-    comms = true
-    mob_tasks = true
-
-    [wiring]
-    auto_wire_orchestrator = true
-    "#)?;
     let handle = MobBuilder::new(definition, MobStorage::in_memory())
         .with_session_service(service)
         .allow_ephemeral_sessions(true)
@@ -219,43 +112,64 @@ planes instead:
 
 <Tabs>
   <Tab title="CLI">
-    ```bash
-    rkat mob spawn-helper my-mob "join as lead-1" --profile lead --agent-identity lead-1
-    rkat mob spawn-helper my-mob "join as worker-1" --profile worker --agent-identity worker-1
-    rkat mob spawn-helper my-mob "join as worker-2" --profile worker --agent-identity worker-2
-    ```
+    The CLI currently exposes helper-oriented mob commands such as `spawn-helper`, `fork-helper`, `run-flow`, `member-status`, `respawn`, and `wait-kickoff`. It does not expose the raw host-side `mob/spawn` lifecycle directly.
   </Tab>
   <Tab title="JSON-RPC">
-    Agent calls `mob_spawn_member` tool:
     ```json
-    {"mob_id": "my-mob", "specs": [
-      {"profile": "lead", "agent_identity": "lead-1"},
-      {"profile": "worker", "agent_identity": "worker-1"},
-      {"profile": "worker", "agent_identity": "worker-2", "runtime_mode": "turn_driven"}
-    ]}
+    {
+      "jsonrpc": "2.0",
+      "id": 2,
+      "method": "mob/spawn",
+      "params": {
+        "mob_id": "release-triage",
+        "profile": "lead",
+        "agent_identity": "lead-1"
+      }
+    }
+    ```
+
+    ```json
+    {
+      "jsonrpc": "2.0",
+      "id": 3,
+      "method": "mob/spawn_many",
+      "params": {
+        "mob_id": "release-triage",
+        "specs": [
+          { "profile": "analyst", "agent_identity": "analyst-1" },
+          { "profile": "analyst", "agent_identity": "analyst-2", "runtime_mode": "turn_driven" }
+        ]
+      }
+    }
     ```
   </Tab>
-  <Tab title="REST">
-    Agent calls `mob_spawn_member` tool (same JSON as RPC — mob ops are tool-driven on all session surfaces).
-  </Tab>
-  <Tab title="MCP">
-    Agent calls `mob_spawn_member` tool (same JSON as RPC).
-  </Tab>
   <Tab title="Python">
-    Agent calls `mob_spawn_member` tool (same JSON as RPC).
+    ```python
+    await mob.spawn(profile="lead", agent_identity="lead-1")
+    await mob.spawn_many([
+        {"profile": "analyst", "agent_identity": "analyst-1"},
+        {"profile": "analyst", "agent_identity": "analyst-2", "runtime_mode": "turn_driven"},
+    ])
+    ```
   </Tab>
   <Tab title="TypeScript">
-    Agent calls `mob_spawn_member` tool (same JSON as RPC).
+    ```typescript
+    await mob.spawn({ profile: "lead", agentIdentity: "lead-1" });
+    await mob.spawnMany([
+      { profile: "analyst", agentIdentity: "analyst-1" },
+      { profile: "analyst", agentIdentity: "analyst-2", runtimeMode: "turn_driven" },
+    ]);
+    ```
   </Tab>
   <Tab title="Rust">
     ```rust
-    use meerkat_mob::{AgentIdentity, SpawnMemberSpec};
+    handle
+        .spawn_spec(SpawnMemberSpec::new("lead", AgentIdentity::from("lead-1")))
+        .await?;
 
-    handle.spawn_spec(SpawnMemberSpec::new("lead", AgentIdentity::from("lead-1"))).await?;
-    let mut spec = SpawnMemberSpec::new("worker", AgentIdentity::from("worker-1"));
-    spec.runtime_mode = Some(MobRuntimeMode::TurnDriven);
-    handle.spawn_spec(spec).await?;
-    handle.spawn_spec(SpawnMemberSpec::new("worker", AgentIdentity::from("worker-2"))).await?;
+    let mut analyst = SpawnMemberSpec::new("analyst", AgentIdentity::from("analyst-2"));
+    analyst.runtime_mode = Some(MobRuntimeMode::TurnDriven);
+    handle.spawn_spec(analyst).await?;
     ```
   </Tab>
 </Tabs>
@@ -263,360 +177,208 @@ planes instead:
 ## Wire and unwire peers
 
 <Tabs>
-  <Tab title="CLI">
-    ```bash
-    rkat mob wire my-mob lead-1 worker-1
-    rkat mob unwire my-mob lead-1 worker-2
-    ```
-  </Tab>
   <Tab title="JSON-RPC">
-    Agent calls `mob_wire` tool:
     ```json
-    {"mob_id": "my-mob", "agent_identity": "lead-1", "peer": {"local": "worker-1"}, "action": "wire"}
+    {
+      "jsonrpc": "2.0",
+      "id": 4,
+      "method": "mob/wire",
+      "params": {
+        "mob_id": "release-triage",
+        "agent_identity": "lead-1",
+        "peer": "analyst-1"
+      }
+    }
     ```
-  </Tab>
-  <Tab title="REST">
-    Agent calls `mob_wire` tool (same JSON as RPC).
-  </Tab>
-  <Tab title="MCP">
-    Agent calls `mob_wire` tool (same JSON as RPC).
+
+    ```json
+    {
+      "jsonrpc": "2.0",
+      "id": 5,
+      "method": "mob/unwire",
+      "params": {
+        "mob_id": "release-triage",
+        "agent_identity": "lead-1",
+        "peer": "analyst-1"
+      }
+    }
+    ```
   </Tab>
   <Tab title="Python">
-    Agent calls `mob_wire` tool (same JSON as RPC).
+    ```python
+    await mob.wire("lead-1", "analyst-1")
+    await mob.unwire("lead-1", "analyst-1")
+    ```
   </Tab>
   <Tab title="TypeScript">
-    Agent calls `mob_wire` tool (same JSON as RPC).
+    ```typescript
+    await mob.wire("lead-1", "analyst-1");
+    await mob.unwire("lead-1", "analyst-1");
+    ```
   </Tab>
   <Tab title="Rust">
     ```rust
-    handle.wire("lead-1", "worker-1").await?;
-    handle.unwire("lead-1", "worker-2").await?;
+    handle
+        .wire(AgentIdentity::from("lead-1"), AgentIdentity::from("analyst-1"))
+        .await?;
+    handle
+        .unwire(AgentIdentity::from("lead-1"), AgentIdentity::from("analyst-1"))
+        .await?;
     ```
   </Tab>
 </Tabs>
 
-## Retire a member
+## Send work to a member
+
+Use the host control plane when an application needs to deliver content directly to a member session.
 
 <Tabs>
-  <Tab title="CLI">
-    ```bash
-    rkat mob respawn my-mob worker-2 --initial-message "resume with fresh runtime"
-    ```
-  </Tab>
   <Tab title="JSON-RPC">
-    Agent calls `mob_retire_member` tool:
     ```json
-    {"mob_id": "my-mob", "agent_identity": "worker-2"}
+    {
+      "jsonrpc": "2.0",
+      "id": 6,
+      "method": "mob/member_send",
+      "params": {
+        "mob_id": "release-triage",
+        "agent_identity": "lead-1",
+        "content": "Decompose the task and assign work to the analysts.",
+        "handling_mode": "queue"
+      }
+    }
     ```
-  </Tab>
-  <Tab title="REST">
-    Agent calls `mob_retire_member` tool (same JSON as RPC).
-  </Tab>
-  <Tab title="MCP">
-    Agent calls `mob_retire_member` tool (same JSON as RPC).
   </Tab>
   <Tab title="Python">
-    Agent calls `mob_retire_member` tool (same JSON as RPC).
+    ```python
+    lead = mob.member("lead-1")
+    await lead.send(
+        "Decompose the task and assign work to the analysts.",
+        handling_mode="queue",
+    )
+    ```
   </Tab>
   <Tab title="TypeScript">
-    Agent calls `mob_retire_member` tool (same JSON as RPC).
-  </Tab>
-  <Tab title="Rust">
-    ```rust
-    handle.retire("worker-2").await?;
+    ```typescript
+    const lead = mob.member("lead-1");
+    await lead.send(
+      "Decompose the task and assign work to the analysts.",
+      { handlingMode: "queue" },
+    );
     ```
   </Tab>
 </Tabs>
 
-## Send a turn
+## Submit tracked work
 
-Send a message directly to a specific mob member, triggering an LLM turn.
+Use the work lane when you need a cancellable work reference rather than plain content delivery.
 
 <Tabs>
-  <Tab title="CLI">
-    ```bash
-    rkat run "send a message to mob member lead-1 in my-mob: Decompose the task and assign to workers."
+  <Tab title="JSON-RPC">
+    ```json
+    {
+      "jsonrpc": "2.0",
+      "id": 8,
+      "method": "mob/submit_work",
+      "params": {
+        "mob_id": "release-triage",
+        "agent_identity": "lead-1",
+        "content": "Review the flaky test history and summarize the top failure modes."
+      }
+    }
     ```
   </Tab>
-  <Tab title="JSON-RPC">
-    Agent-to-agent interaction stays on comms tools. Direct member delivery is reserved for host/runtime control-plane APIs.
-  </Tab>
-  <Tab title="REST">
-    Agent-to-agent interaction stays on comms tools. Direct member delivery is reserved for host/runtime control-plane APIs.
-  </Tab>
-  <Tab title="MCP">
-    Agent-to-agent interaction stays on comms tools. Direct member delivery is reserved for host/runtime control-plane APIs.
-  </Tab>
   <Tab title="Python">
-    Agent-to-agent interaction stays on comms tools. Direct member delivery is reserved for host/runtime control-plane APIs.
+    ```python
+    work = await client.submit_mob_work(
+        "release-triage",
+        "lead-1",
+        "Review the flaky test history and summarize the top failure modes.",
+    )
+    ```
   </Tab>
   <Tab title="TypeScript">
-    Agent-to-agent interaction stays on comms tools. Direct member delivery is reserved for host/runtime control-plane APIs.
-  </Tab>
-  <Tab title="Rust">
-    ```rust
-    use meerkat_core::types::HandlingMode;
-
-    let lead = handle.member(&"lead-1".into()).await?;
-    lead.send("Decompose the task and assign to workers.", HandlingMode::Queue, None).await?;
+    ```typescript
+    const work = await client.submitMobWork(
+      "release-triage",
+      "lead-1",
+      "Review the flaky test history and summarize the top failure modes.",
+    );
     ```
   </Tab>
 </Tabs>
 
 ## Run a flow
 
-Execute a named DAG flow. Steps execute in dependency order with configured dispatch modes.
-
 <Tabs>
   <Tab title="CLI">
     ```bash
-    rkat mob run-flow my-mob --flow triage --params '{"pr": 42}'
-    rkat mob run-flow my-mob --flow triage --stream --stream-view mux
-    ```
-  </Tab>
-  <Tab title="JSON-RPC">
-    Agent calls `mob_run_flow` tool:
-    ```json
-    {"mob_id": "my-mob", "flow_id": "triage", "params": {"pr": 42}}
-    ```
-  </Tab>
-  <Tab title="REST">
-    Agent calls `mob_run_flow` tool (same JSON as RPC).
-  </Tab>
-  <Tab title="MCP">
-    Agent calls `mob_run_flow` tool (same JSON as RPC).
-  </Tab>
-  <Tab title="Python">
-    Agent calls `mob_run_flow` tool (same JSON as RPC).
-  </Tab>
-  <Tab title="TypeScript">
-    Agent calls `mob_run_flow` tool (same JSON as RPC).
-  </Tab>
-  <Tab title="Rust">
-    ```rust
-    let run_id = handle.run_flow("triage".into(), json!({"pr": 42})).await?;
-    ```
-  </Tab>
-</Tabs>
-
-## Check status
-
-<Tabs>
-  <Tab title="CLI">
-    ```bash
-    rkat mob status my-mob
-    rkat mob list
-    rkat mob flows my-mob
-    rkat mob flow-status my-mob <run_id>
-    ```
-  </Tab>
-  <Tab title="JSON-RPC">
-    Host calls typed methods such as `mob/list`, `mob/status`, and
-    `mob/flow_status`:
-    ```json
-    {"mob_id": "my-mob"}
-    {"mob_id": "my-mob", "run_id": "01936f8a-..."}
-    ```
-  </Tab>
-  <Tab title="REST">
-    Use the typed mob/member status routes documented in the REST API. REST does
-    not re-export the agent-side `mob_*` dispatcher.
-  </Tab>
-  <Tab title="MCP">
-    Host calls `meerkat_mob_list`, `meerkat_mob_status`, and
-    `meerkat_mob_flow_status`.
-  </Tab>
-  <Tab title="Python">
-    Use the typed client methods: `await client.list_mobs()`,
-    `await client.mob_status("my-mob")`, and
-    `await client.get_mob_flow_status("my-mob", run_id)`.
-  </Tab>
-  <Tab title="TypeScript">
-    Use the typed client methods: `await client.listMobs()`,
-    `await client.mobStatus("my-mob")`, and
-    `await client.getMobFlowStatus("my-mob", runId)`.
-  </Tab>
-  <Tab title="Rust">
-    ```rust
-    let status = handle.status().await?;
-    let flow_run = handle.flow_status(run_id).await?;
-    ```
-  </Tab>
-</Tabs>
-
-## Mob events
-
-Read the structural event log (spawns, retires, wires, flow transitions).
-
-<Tabs>
-  <Tab title="CLI">
-    ```bash
-    rkat mob events my-mob
-    ```
-  </Tab>
-  <Tab title="JSON-RPC">
-    Host calls typed `mob/events`:
-    ```json
-    {"mob_id": "my-mob", "after_cursor": 0, "limit": 50}
-    ```
-  </Tab>
-  <Tab title="REST">
-    Use the typed `/mob/{id}/events` stream route.
-  </Tab>
-  <Tab title="MCP">
-    Use `meerkat_mob_events` for history and `meerkat_mob_event_stream_*` for
-    streaming.
-  </Tab>
-  <Tab title="Python">
-    Use `await client.subscribe_mob_events("my-mob")`.
-  </Tab>
-  <Tab title="TypeScript">
-    Use `await client.subscribeMobEvents("my-mob")`.
-  </Tab>
-  <Tab title="Rust">
-    ```rust
-    let events_view = handle.events();
-    // Use events_view to read the structural event log
-    ```
-  </Tab>
-</Tabs>
-
-## Lifecycle
-
-Control mob state transitions.
-
-<Tabs>
-  <Tab title="CLI">
-    ```bash
-    rkat mob stop my-mob       # pause all members
-    rkat mob resume my-mob     # restart members
-    rkat mob complete my-mob   # mark as done
-    rkat mob destroy my-mob    # tear down all resources
-    ```
-  </Tab>
-  <Tab title="JSON-RPC">
-    Host calls typed `mob/lifecycle`:
-    ```json
-    {"mob_id": "my-mob", "action": "stop"}
-    {"mob_id": "my-mob", "action": "resume"}
-    {"mob_id": "my-mob", "action": "complete"}
-    {"mob_id": "my-mob", "action": "destroy"}
-    ```
-  </Tab>
-  <Tab title="REST">
-    Use JSON-RPC, MCP, or the SDKs for general mob lifecycle control; REST does
-    not expose the full lifecycle surface.
-  </Tab>
-  <Tab title="MCP">
-    Host calls `meerkat_mob_lifecycle`.
-  </Tab>
-  <Tab title="Python">
-    Use `await client.mob_lifecycle("my-mob", "stop")` and related actions.
-  </Tab>
-  <Tab title="TypeScript">
-    Use `await client.mobLifecycle("my-mob", "stop")` and related actions.
-  </Tab>
-  <Tab title="Rust">
-    ```rust
-    handle.stop().await?;
-    handle.resume().await?;
-    handle.complete().await?;
-    handle.destroy().await?;
-    ```
-  </Tab>
-</Tabs>
-
-## Tool-driven mob usage
-
-The primary pattern across all surfaces: enable mob tools and let the agent orchestrate everything from a natural language request.
-
-<Tabs>
-  <Tab title="CLI">
-    ```bash
-    rkat run --tools full "Create a research team with a lead and 3 analysts. \
-      Wire them, then run the synthesis flow."
+    rkat mob run-flow release-triage --flow triage --params '{"severity":"high"}'
+    rkat mob run-flow release-triage --flow triage --stream
     ```
   </Tab>
   <Tab title="JSON-RPC">
     ```json
     {
-      "jsonrpc": "2.0", "id": 1,
-      "method": "session/create",
+      "jsonrpc": "2.0",
+      "id": 7,
+      "method": "mob/flow_run",
       "params": {
-        "prompt": "Create a research team with a lead and 3 analysts, then run the synthesis flow.",
-        "enable_builtins": true,
-        "enable_mob": true
+        "mob_id": "release-triage",
+        "flow_id": "triage",
+        "params": { "severity": "high" }
       }
     }
     ```
   </Tab>
-  <Tab title="REST">
-    ```bash
-    curl -X POST http://localhost:8080/sessions \
-      -H "Content-Type: application/json" \
-      -d '{"prompt":"Create a research team and run the synthesis flow","enable_builtins":true,"enable_mob":true}'
-    ```
-  </Tab>
-  <Tab title="MCP">
-    ```json
-    {"name": "meerkat_run", "arguments": {
-      "prompt": "Create a research team and run the synthesis flow",
-      "enable_builtins": true,
-      "enable_mob": true
-    }}
-    ```
-  </Tab>
   <Tab title="Python">
     ```python
-    session = await client.create_session(
-        prompt="Create a research team and run the synthesis flow",
-        enable_builtins=True,
-        enable_mob=True,
-    )
+    run_id = await mob.run_flow("triage", {"severity": "high"})
+    status = await mob.flow_status(run_id)
     ```
   </Tab>
   <Tab title="TypeScript">
     ```typescript
-    const session = await client.createSession("Create a research team and run the synthesis flow", {
-      enableBuiltins: true,
-      enableMob: true,
-    });
+    const runId = await mob.runFlow("triage", { severity: "high" });
+    const status = await mob.flowStatus(runId);
     ```
   </Tab>
   <Tab title="Rust">
     ```rust
-    let factory = AgentFactory::new(root)
-        .builtins(true)
-        .mob(true);
-    let service = build_ephemeral_service(factory, config, 64); // Queue-only embedded/testing substrate
-    let result = service.create_session(CreateSessionRequest {
-        model: "claude-sonnet-4-6".into(),
-        prompt: "Create a research team and run the synthesis flow".into(),
-        system_prompt: None,
-        max_tokens: None,
-        event_tx: None,
-        skill_references: None,
-        initial_turn: InitialTurnPolicy::RunImmediately,
-        build: None,
-        labels: None,
-    }).await?;
+    let run_id = handle.run_flow("triage".into(), json!({"severity": "high"})).await?;
+    let status = handle.flow_status(&run_id).await?;
     ```
   </Tab>
 </Tabs>
 
-## Runtime modes
+## Helper-oriented CLI flows
 
-| Mode | Behavior | Use case |
-|------|----------|----------|
-| `autonomous_host` (default) | Member runs a long-lived runtime-backed loop: admit inbox work → process → respond → sleep | Long-lived agents that react to messages |
-| `turn_driven` | Member only executes when driven by host/runtime control-plane delivery or flow dispatch | Controlled execution, deterministic ordering |
+The current CLI is strongest for helper-style workflows on an existing mob:
 
-Set per-profile in the definition:
-```json
-{"model": "claude-sonnet-4-6", "runtime_mode": "turn_driven", "tools": {"comms": true}}
-```
-
-Or per-spawn:
 ```bash
-rkat mob spawn-helper my-mob "join as worker-1" --profile worker --agent-identity worker-1
+rkat mob spawn-helper release-triage "Join as lead-1 and summarize the release status." --profile lead --agent-identity lead-1
+rkat mob fork-helper release-triage lead-1 "Investigate the flaky test history." --profile analyst
+rkat mob member-status release-triage lead-1 --json
+rkat mob respawn release-triage analyst-2 --initial-message "Resume with a fresh runtime."
+rkat mob wait-kickoff release-triage --json
 ```
+
+## Events and subscriptions
+
+```python
+events = await mob.subscribe_member_events("lead-1")
+async for event in events:
+    print(event)
+```
+
+```typescript
+const events = await mob.subscribeMemberEvents("lead-1");
+for await (const event of events) {
+  console.log(event);
+}
+```
+
+## See also
+
+- [Mobs guide](/guides/mobs)
+- [Realtime guide](/guides/realtime)
+- [Mobpack examples](/examples/mobpack)

--- a/docs/examples/skills.mdx
+++ b/docs/examples/skills.mdx
@@ -8,7 +8,7 @@ For the full guide, see [Skills](/guides/skills).
 
 ## List available skills
 
-Discover all skills from every source (project, user, git, HTTP, embedded) with provenance and shadowing info.
+Discover all skills from every source (project, user, filesystem, git, HTTP, stdio, embedded) with provenance and shadowing info.
 
 <Tabs>
   <Tab title="CLI">
@@ -142,14 +142,14 @@ View the full body and metadata of a specific skill. Use `--source` to inspect a
 
 ## Inject skills on session create
 
-Use the CLI `--skill` flag, or pass `skill_references` through the API surfaces, to resolve and inject skill content into the system prompt when a session starts.
+Use the CLI `--skill` flag for preload-oriented local skill loading, or pass typed `skill_refs` through API surfaces to resolve and inject skill content when a session starts.
 
 <Tabs>
   <Tab title="CLI">
     ```bash
     rkat run "Extract emails" \
-      --skill /email-extractor \
-      --skill /formatting/markdown
+      --skill email-extractor \
+      --skill markdown-formatter
     ```
   </Tab>
   <Tab title="JSON-RPC">
@@ -159,7 +159,16 @@ Use the CLI `--skill` flag, or pass `skill_references` through the API surfaces,
       "method": "session/create",
       "params": {
         "prompt": "Extract emails",
-        "skill_references": ["/email-extractor", "/formatting/markdown"]
+        "skill_refs": [
+          {
+            "source_uuid": "dc256086-0d2f-4f61-a307-320d4148107f",
+            "skill_name": "email-extractor"
+          },
+          {
+            "source_uuid": "dc256086-0d2f-4f61-a307-320d4148107f",
+            "skill_name": "markdown-formatter"
+          }
+        ]
       }
     }
     ```
@@ -170,7 +179,16 @@ Use the CLI `--skill` flag, or pass `skill_references` through the API surfaces,
       -H "Content-Type: application/json" \
       -d '{
         "prompt": "Extract emails",
-        "skill_references": ["/email-extractor", "/formatting/markdown"]
+        "skill_refs": [
+          {
+            "source_uuid": "dc256086-0d2f-4f61-a307-320d4148107f",
+            "skill_name": "email-extractor"
+          },
+          {
+            "source_uuid": "dc256086-0d2f-4f61-a307-320d4148107f",
+            "skill_name": "markdown-formatter"
+          }
+        ]
       }'
     ```
   </Tab>
@@ -180,7 +198,16 @@ Use the CLI `--skill` flag, or pass `skill_references` through the API surfaces,
       "name": "meerkat_run",
       "arguments": {
         "prompt": "Extract emails",
-        "skill_references": ["/email-extractor", "/formatting/markdown"]
+        "skill_refs": [
+          {
+            "source_uuid": "dc256086-0d2f-4f61-a307-320d4148107f",
+            "skill_name": "email-extractor"
+          },
+          {
+            "source_uuid": "dc256086-0d2f-4f61-a307-320d4148107f",
+            "skill_name": "markdown-formatter"
+          }
+        ]
       }
     }
     ```
@@ -189,14 +216,32 @@ Use the CLI `--skill` flag, or pass `skill_references` through the API surfaces,
     ```python
     result = await client.create_session(
         "Extract emails",
-        skill_refs=["/email-extractor", "/formatting/markdown"],
+        skill_refs=[
+            SkillKey(
+                source_uuid="dc256086-0d2f-4f61-a307-320d4148107f",
+                skill_name="email-extractor",
+            ),
+            SkillKey(
+                source_uuid="dc256086-0d2f-4f61-a307-320d4148107f",
+                skill_name="markdown-formatter",
+            ),
+        ],
     )
     ```
   </Tab>
   <Tab title="TypeScript">
     ```typescript
     const result = await client.createSession("Extract emails", {
-      skillRefs: ["/email-extractor", "/formatting/markdown"],
+      skillRefs: [
+        {
+          sourceUuid: "dc256086-0d2f-4f61-a307-320d4148107f",
+          skillName: "email-extractor",
+        },
+        {
+          sourceUuid: "dc256086-0d2f-4f61-a307-320d4148107f",
+          skillName: "markdown-formatter",
+        },
+      ],
     });
     ```
   </Tab>
@@ -208,11 +253,19 @@ Use the CLI `--skill` flag, or pass `skill_references` through the API surfaces,
         system_prompt: None,
         max_tokens: None,
         event_tx: None,
+        render_metadata: None,
         skill_references: Some(vec![
-            "/email-extractor".parse()?,
-            "/formatting/markdown".parse()?,
+            SkillKey {
+                source_uuid: SourceUuid::parse("dc256086-0d2f-4f61-a307-320d4148107f")?,
+                skill_name: SkillName::parse("email-extractor")?,
+            },
+            SkillKey {
+                source_uuid: SourceUuid::parse("dc256086-0d2f-4f61-a307-320d4148107f")?,
+                skill_name: SkillName::parse("markdown-formatter")?,
+            },
         ]),
         initial_turn: InitialTurnPolicy::RunImmediately,
+        deferred_prompt_policy: DeferredPromptPolicy::Discard,
         build: None,
         labels: None,
     };
@@ -294,13 +347,13 @@ Preloaded skills are resolved and injected into the system prompt before the fir
 
 ## Per-turn skill injection
 
-Inject skills into a specific turn on an existing session. The skill content is added to the context for that turn only.
+Inject skills into a specific turn on an existing session. The skill content is added to the context for that turn only. On the CLI, `--skill` remains the preload-style runtime-local path; the typed per-turn surface is `skill_refs`.
 
 <Tabs>
   <Tab title="CLI">
     ```bash
     rkat run --resume <session-id> "Now format the output" \
-      --skill formatting/markdown
+      --skill markdown-formatter
     ```
   </Tab>
   <Tab title="JSON-RPC">
@@ -311,7 +364,12 @@ Inject skills into a specific turn on an existing session. The skill content is 
       "params": {
         "session_id": "019467d9-7e3a-7000-8000-000000000000",
         "prompt": "Now format the output",
-        "skill_references": ["/formatting/markdown"]
+        "skill_refs": [
+          {
+            "source_uuid": "dc256086-0d2f-4f61-a307-320d4148107f",
+            "skill_name": "markdown-formatter"
+          }
+        ]
       }
     }
     ```
@@ -322,7 +380,12 @@ Inject skills into a specific turn on an existing session. The skill content is 
       -H "Content-Type: application/json" \
       -d '{
         "prompt": "Now format the output",
-        "skill_references": ["/formatting/markdown"]
+        "skill_refs": [
+          {
+            "source_uuid": "dc256086-0d2f-4f61-a307-320d4148107f",
+            "skill_name": "markdown-formatter"
+          }
+        ]
       }'
     ```
   </Tab>
@@ -333,23 +396,38 @@ Inject skills into a specific turn on an existing session. The skill content is 
       "arguments": {
         "session_id": "019467d9-7e3a-7000-8000-000000000000",
         "prompt": "Now format the output",
-        "skill_references": ["/formatting/markdown"]
+        "skill_refs": [
+          {
+            "source_uuid": "dc256086-0d2f-4f61-a307-320d4148107f",
+            "skill_name": "markdown-formatter"
+          }
+        ]
       }
     }
     ```
   </Tab>
   <Tab title="Python">
     ```python
-    result = session.turn(
+    result = await session.turn(
         "Now format the output",
-        skill_refs=["/formatting/markdown"],
+        skill_refs=[
+            SkillKey(
+                source_uuid="dc256086-0d2f-4f61-a307-320d4148107f",
+                skill_name="markdown-formatter",
+            )
+        ],
     )
     ```
   </Tab>
   <Tab title="TypeScript">
     ```typescript
     const result = await session.turn("Now format the output", {
-      skillRefs: ["/formatting/markdown"],
+      skillRefs: [
+        {
+          sourceUuid: "dc256086-0d2f-4f61-a307-320d4148107f",
+          skillName: "markdown-formatter",
+        },
+      ],
     });
     ```
   </Tab>
@@ -361,7 +439,10 @@ Inject skills into a specific turn on an existing session. The skill content is 
         render_metadata: None,
         handling_mode: HandlingMode::Queue,
         event_tx: None,
-        skill_references: Some(vec!["/formatting/markdown".parse()?]),
+        skill_references: Some(vec![SkillKey {
+            source_uuid: SourceUuid::parse("dc256086-0d2f-4f61-a307-320d4148107f")?,
+            skill_name: SkillName::parse("markdown-formatter")?,
+        }]),
         flow_tool_overlay: None,
         additional_instructions: None,
     }).await?;

--- a/docs/examples/structured-output.mdx
+++ b/docs/examples/structured-output.mdx
@@ -127,11 +127,13 @@ Provide an `output_schema` and the agent will extract validated JSON after the a
     let result = service.create_session(CreateSessionRequest {
         model: "claude-sonnet-4-6".into(),
         prompt: "Tell me about Tokyo".into(),
+        render_metadata: None,
         system_prompt: None,
         max_tokens: None,
         event_tx: None,
         skill_references: None,
         initial_turn: InitialTurnPolicy::RunImmediately,
+        deferred_prompt_policy: DeferredPromptPolicy::Discard,
         build: Some(SessionBuildOptions {
             output_schema: Some(schema),
             ..Default::default()
@@ -227,11 +229,13 @@ When validation fails, the agent retries the extraction turn with error feedback
     let result = service.create_session(CreateSessionRequest {
         model: "claude-sonnet-4-6".into(),
         prompt: "Extract entities".into(),
+        render_metadata: None,
         system_prompt: None,
         max_tokens: None,
         event_tx: None,
         skill_references: None,
         initial_turn: InitialTurnPolicy::RunImmediately,
+        deferred_prompt_policy: DeferredPromptPolicy::Discard,
         build: Some(SessionBuildOptions {
             output_schema: Some(schema),
             structured_output_retries: 5,

--- a/docs/examples/tools.mdx
+++ b/docs/examples/tools.mdx
@@ -30,12 +30,12 @@ impl AgentToolDispatcher for MathTools {
         })].into()
     }
 
-    async fn dispatch(&self, call: ToolCallView<'_>) -> Result<ToolResult, ToolError> {
+    async fn dispatch(&self, call: ToolCallView<'_>) -> Result<ToolDispatchOutcome, ToolError> {
         match call.name {
             "add" => {
                 let args: AddArgs = call.parse_args()
                     .map_err(|e| ToolError::invalid_arguments("add", e.to_string()))?;
-                Ok(ToolResult::new(call.id.to_string(), format!("{}", args.a + args.b), false))
+                Ok(ToolResult::new(call.id.to_string(), format!("{}", args.a + args.b), false).into())
             }
             _ => Err(ToolError::not_found(call.name)),
         }
@@ -136,8 +136,17 @@ Built-in tool categories: builtins, shell, semantic memory, and mob orchestratio
 
     let service = build_ephemeral_service(factory, config, 64); // Queue-only embedded/testing substrate
     let result = service.create_session(CreateSessionRequest {
+        model: "claude-sonnet-4-6".into(),
         prompt: "List files in /tmp".into(),
-        ..Default::default()
+        render_metadata: None,
+        system_prompt: None,
+        max_tokens: None,
+        event_tx: None,
+        skill_references: None,
+        initial_turn: InitialTurnPolicy::RunImmediately,
+        deferred_prompt_policy: DeferredPromptPolicy::Discard,
+        build: None,
+        labels: None,
     }).await?;
     ```
   </Tab>

--- a/docs/examples/wasm.mdx
+++ b/docs/examples/wasm.mdx
@@ -36,7 +36,7 @@ await init();
 init_runtime(
   mobpackBytes,
   JSON.stringify({
-    api_key: "sk-ant-...",
+    anthropic_api_key: "sk-ant-...",
     model: "claude-sonnet-4-6",
   })
 );
@@ -46,7 +46,6 @@ init_runtime(
 
 ```javascript
 const handle = create_session(mobpackBytes, JSON.stringify({
-  api_key: "sk-ant-...",
   model: "claude-sonnet-4-6",
 }));
 
@@ -111,7 +110,12 @@ Wire ambassadors across mobs for inter-faction communication. The `wire_cross_mo
 
 ```javascript
 // Wire ambassadors between two mobs
-await wire_cross_mob(mobIdNorth, "ambassador-north", "ambassador-south");
+await wire_cross_mob(
+  mobIdNorth,
+  "ambassador-north",
+  mobIdSouth,
+  "ambassador-south",
+);
 
 // Send work to a member through the canonical member path
 await mob_member_send(

--- a/docs/guides/auth.mdx
+++ b/docs/guides/auth.mdx
@@ -12,6 +12,10 @@ login` or the REST/RPC surfaces, and pass `--connection-ref
 <realm>:<binding>` to scope a session or mob member to that specific
 binding.
 
+<Note>
+Today, CLI `rkat auth login` is primarily a convenience bootstrap flow for the default `dev:*` credential namespace. If you need explicit realm/profile-targeted auth persistence such as `prod:openai`, use the REST/RPC auth surfaces or manage the realm config entries directly.
+</Note>
+
 Both paths route through the same `ProviderRuntimeRegistry`. There's no
 hidden magic path: the env fallback is a synthesized realm with
 `CredentialSourceSpec::Env`, resolved by the same code that handles
@@ -90,6 +94,8 @@ rkat auth login anthropic
 rkat auth login openai --non-interactive --secret "$OPENAI_KEY"
 ```
 
+The current CLI login flow is convenient for local setup, but it does not yet let you choose an arbitrary target realm/profile name at login time. It seeds the runtime-managed default `dev:*` identities and is best thought of as the easiest way to get persisted credentials into Meerkat quickly.
+
 ### Use the binding
 
 ```bash
@@ -138,16 +144,17 @@ auth_method)` pairs. The table below summarizes what's wired today.
 | Anthropic | `anthropic_api`     | `api_key`, `static_bearer` | Direct to api.anthropic.com |
 | Anthropic | `anthropic_api`     | `claude_ai_oauth`       | Claude Pro/Max OAuth (PKCE, S256) |
 | Anthropic | `anthropic_api`     | `oauth_to_api_key`      | Console OAuth → provisions api_key |
-| Anthropic | `bedrock`           | `bedrock_bearer`, `bedrock_aws` | AWS SigV4 / env-bearer |
+| Anthropic | `anthropic_api`     | `external_authorizer`   | Host-resolved auth injection |
+| Anthropic | `bedrock`           | `bedrock_bearer`, `bedrock_aws_sigv4` | AWS SigV4 / env-bearer |
 | Anthropic | `vertex`            | `vertex_google_auth`    | GoogleAuth / Vertex AI |
 | Anthropic | `foundry`           | `foundry_api_key`, `foundry_azure_ad` | Azure AI Foundry |
-| OpenAI    | `openai_api`        | `api_key`, `static_bearer` | Direct to api.openai.com |
+| OpenAI    | `openai_api`        | `api_key`, `static_bearer`, `external_authorizer` | Direct to api.openai.com or host-resolved auth |
 | OpenAI    | `chatgpt_backend`   | `managed_chatgpt_oauth` | ChatGPT Plus/Pro OAuth |
 | OpenAI    | `chatgpt_backend`   | `external_chatgpt_tokens` | Host-supplied tokens |
-| Google    | `google_genai`      | `api_key`, `bearer_api_key` | Direct to Google GenAI |
+| Google    | `google_genai`      | `api_key`, `bearer_api_key`, `external_authorizer` | Direct to Google GenAI or host-resolved auth |
 | Google    | `vertex_ai`         | `api_key_express`       | Vertex API Express key |
 | Google    | `vertex_ai`         | `adc`, `compute_adc`    | ADC / compute metadata |
-| Google    | `code_assist`       | `google_oauth`          | Gemini Code Assist OAuth |
+| Google    | `google_code_assist` | `google_oauth`         | Gemini Code Assist OAuth |
 
 External commands (`CredentialSourceSpec::Command`) and file
 descriptors (`CredentialSourceSpec::FileDescriptor`) let host
@@ -156,21 +163,27 @@ applications inject tokens without going through OAuth.
 ## Credential sources
 
 The `source` field on an auth profile declares *where* credentials
-come from. Five shapes are supported:
+come from.
 
 | Kind | Description |
 |------|-------------|
 | `InlineSecret { secret }` | Secret stored inline in the TOML (use only for dev/local) |
 | `Env { env, fallback }` | Read env var at resolve time via `ResolverEnvironment::env_lookup` |
-| `ManagedStore { profile }` | Resolve via the `TokenStore` (set by `rkat auth login`) |
+| `ManagedStore { profile }` | Resolve via the `TokenStore`; in current provider runtimes, persisted lookup is tied to the active auth-profile identity/binding path |
+| `PlatformDefault` | Use the host platform's default credential chain where supported |
 | `ExternalResolver { handle }` | Host-registered JS callback (WASM) or Rust resolver (embedded) |
 | `Command { program, args, ... }` | Run an external binary; cache stdout for `refresh_interval_ms` |
+| `FileDescriptor { fd, scope_override }` | Read credentials from a host-supplied file descriptor |
 
 <Warning>
 Storing api keys inline in config files works but shouldn't be
 checked into git. Prefer `ManagedStore` (which writes to the OS
 keychain or a 0o600 file) or `Env`.
 </Warning>
+
+<Note>
+`FileDescriptor` is a host-integration seam rather than a plain standalone resolver path. It requires a host-scoped reader/injection path, so treat it as an advanced embedding surface rather than a generic CLI config trick.
+</Note>
 
 ## Hot-swap mid-session
 
@@ -200,16 +213,16 @@ binding — no env-default fallback, no cross-realm credential bleed.
 ## Per-mob-member override
 
 Mob members default to env-default / config-realm fallback credentials.
-Pass `connection_ref` on `mob_spawn_member` to scope a member to a
+Pass `connection_ref` on the host-side mob spawn surface to scope a member to a
 specific binding:
 
 ```json
 {
-  "tool": "mob_spawn_member",
-  "args": {
+  "method": "mob/spawn",
+  "params": {
     "mob_id": "research",
     "profile": "analyst",
-    "member_id": "a1",
+    "agent_identity": "a1",
     "connection_ref": "prod:openai"
   }
 }

--- a/docs/guides/comms.mdx
+++ b/docs/guides/comms.mdx
@@ -266,7 +266,7 @@ Send a collaboration message to a peer.
   Delivery mode. Use `"queue"` for ordinary delivery or `"steer"` for immediate steer processing on runtime-backed sessions.
 </ParamField>
 
-**Response**: `{"status": "sent"}`
+**Response**: `{"status": "sent", "kind": "peer_message"}`
 </Accordion>
 
 <Accordion title="send_request">
@@ -288,7 +288,7 @@ Send a structured ask to a peer when you want explicit `intent + params` and a c
   Delivery mode. Use `"queue"` for ordinary delivery or `"steer"` for immediate steer processing on runtime-backed sessions.
 </ParamField>
 
-**Response**: `{"status": "sent"}`
+**Response**: `{"status": "sent", "kind": "peer_request"}`
 
 <Note>
 Use `send_message` by default for ordinary collaboration. `send_request` is for structured ask/reply semantics only. It is not task tracking, a stronger delivery mode, or a reserved response channel.
@@ -314,7 +314,15 @@ Send a response to a previously received request.
   Response result data. Defaults to `null`.
 </ParamField>
 
-**Response**: `{"status": "sent"}`
+<ParamField path="handling_mode" type="string">
+  Optional delivery mode override. Use `"queue"` for normal delivery or `"steer"` when you need immediate steer processing on runtime-backed sessions.
+</ParamField>
+
+**Response**: `{"status": "sent", "kind": "peer_response"}`
+
+<Note>
+The LLM-facing comms tools return lightweight tool receipts. Host-side `comms/send` returns richer typed receipts such as `peer_message_sent`, `peer_request_sent`, and `peer_response_sent`, with identifiers and ACK-related data for application code.
+</Note>
 </Accordion>
 
 <Accordion title="peers">

--- a/docs/guides/hooks.mdx
+++ b/docs/guides/hooks.mdx
@@ -66,9 +66,13 @@ Background hooks on post-points publish patches via `HookPatchEnvelope` (contain
     Write the handler that receives a `HookInvocation` and returns a `RuntimeHookResponse` with an optional decision and patches.
   </Step>
   <Step title="Test with overrides">
-    Use `HookRunOverrides` to test your hook in isolation before committing the config.
+    Use `HookRunOverrides` to test your hook in isolation through RPC, REST, MCP, or embedded builders before committing the config.
   </Step>
 </Steps>
+
+<Note>
+The docs below show run-scoped hook overrides conceptually, but the current CLI does not expose `--hooks-override-json` / `--hooks-override-file` in normal builds. For now, use RPC, REST, MCP, or the SDK/embedded surfaces when you want per-run hook overrides.
+</Note>
 
 ## Runtimes
 
@@ -200,8 +204,10 @@ Hooks receive a `HookInvocation` struct containing contextual data. Fields are p
 - **`HookLlmRequest`**: `max_tokens`, `temperature`, `provider_params`, `message_count`
 - **`HookLlmResponse`**: `assistant_text`, `tool_call_names`, `stop_reason`, `usage`
 - **`HookToolCall`**: `tool_use_id`, `name`, `args`
-- **`HookToolResult`**: `tool_use_id`, `name`, `content`, `is_error`
+- **`HookToolResult`**: `tool_use_id`, `name`, `content`, `is_error`, `has_images`
 </Accordion>
+
+`HookToolResult.content` is always the text projection of the tool result. If the original result also contains image blocks, `has_images` is set so hook authors know multimodal content exists. A `HookPatch::ToolResult` rewrite preserves those image blocks and replaces only the text projection plus optional `is_error`.
 
 ## Priority ordering and deny short-circuiting
 

--- a/docs/guides/memory.mdx
+++ b/docs/guides/memory.mdx
@@ -13,33 +13,39 @@ Together they allow agents to maintain coherent multi-turn sessions that exceed 
 
 ## Feature flags
 
-Both systems require compile-time features and per-request enablement.
+Compaction and semantic memory have separate build-time and runtime switches.
 
 | Feature flag | Cargo feature | What it enables |
 |---|---|---|
 | Compaction strategy | `session-compaction` | `DefaultCompactor` in `meerkat-session` |
-| Memory store backend | `memory-store` | `meerkat-store/memory` backend |
-| Memory + compaction wiring | `memory-store-session` | `HnswMemoryStore`, `MemorySearchDispatcher`, agent loop integration |
+| Memory store backend | `memory-store` | CLI convenience feature enabling the memory store backend and session wiring |
+| Memory session wiring | `memory-store-session` | `HnswMemoryStore`, `memory_search`, and memory integration with the agent/session path |
 
 <Note>
-The CLI's default features include `skills` but **not** `session-compaction` or `memory-store`. You must enable them explicitly.
+The CLI's default features include `skills` but **not** `session-compaction` or memory features. You must enable them explicitly for source builds.
 </Note>
 
 ```bash
-cargo build -p meerkat-cli --features session-compaction,memory-store
+cargo build -p rkat --features session-compaction,memory-store
 ```
 
-At runtime, the `AgentFactory` has an `enable_memory` flag (default: `false`). Per-request builds can override it via `AgentBuildConfig::override_memory`.
+At runtime, `AgentFactory::memory(true)` enables the semantic memory path (`HnswMemoryStore` + `memory_search`). Compaction is controlled independently by whether the binary is built with `session-compaction` and whether a compactor is wired into the session path.
 
 ```rust
 let factory = AgentFactory::new(store_path)
     .builtins(true)
-    .memory(true);  // enable semantic memory + compaction
+    .memory(true);  // enable semantic memory
 
 // Per-request override:
 let mut build_config = AgentBuildConfig::new("claude-sonnet-4-6");
-build_config.override_memory = Some(true);
+build_config.override_memory = ToolCategoryOverride::Enable;
 ```
+
+That means these cases are all valid:
+
+- compaction enabled, semantic memory disabled
+- semantic memory enabled, compaction unavailable
+- both enabled together
 
 ## CompactionConfig
 
@@ -209,7 +215,7 @@ When the `memory-store-session` feature is compiled in and memory is enabled:
 
 1. An `HnswMemoryStore` is opened at `{store_path}/memory/`.
 2. The `memory_search` tool is added to the agent's tool set.
-3. A `DefaultCompactor` is attached (if `session-compaction` is also enabled).
+3. A `DefaultCompactor` is attached only if `session-compaction` is also enabled.
 4. A built-in `memory-retrieval` skill is injected into the system prompt, teaching the agent how to use memory search.
 
 ## Examples
@@ -218,10 +224,10 @@ When the `memory-store-session` feature is compiled in and memory is enabled:
   <Tab title="CLI">
     ```bash
     # Build with memory + compaction features
-    cargo build -p meerkat-cli --features session-compaction,memory-store
+    cargo build -p rkat --features session-compaction,memory-store
 
-    # Run with memory enabled (if the CLI surfaces this flag)
-    rkat run --memory "Analyze this large codebase..."
+    # Enable the richer tool preset so memory_search is available
+    rkat run --tools full "Analyze this large codebase..."
     ```
   </Tab>
   <Tab title="SDK">

--- a/docs/guides/mobs.mdx
+++ b/docs/guides/mobs.mdx
@@ -177,27 +177,37 @@ Spawning is deferred — `create_session()` registers the member without running
 
 ## Mob tools
 
-When mob capability is enabled on a session, the agent gets these tools:
+When mob capability is enabled on a session, the agent gets agent-side `mob_*` tools inside that session:
 
 | Tool | Parameters | Description |
 |------|-----------|-------------|
-| `spawn_member` | `profile`, `member_id`, `initial_message?`, `backend?`, `runtime_mode?` | Spawn one member |
-| `spawn_many_members` | `specs[]` | Spawn multiple members concurrently |
-| `retire_member` | `member_id` | Remove a member |
-| `force_cancel_member` | `member_id` | Force-cancel a member |
-| `member_status` | `member_id` | Get member status |
-| `list_members` | none | List members and state |
-| `wire_members` | `member_id`, `peer_member_id` | Wire a comms channel between two members |
-| `unwire_members` | `member_id`, `peer_member_id` | Unwire a comms channel |
+| `mob_create` | `definition` | Create a mob from a definition |
+| `mob_list` | optional filters | List mobs or inspect one |
+| `mob_lifecycle` | `mob_id`, `action` | Stop, resume, complete, destroy, or reset a mob |
+| `mob_events` | `mob_id`, `after_cursor?`, `limit?` | Read mob event history |
+| `mob_spawn_member` | `mob_id`, `specs[]` | Spawn one or more members |
+| `mob_retire_member` | `mob_id`, `agent_identity` | Remove a member |
+| `mob_respawn_member` | `mob_id`, `agent_identity`, `initial_message?` | Respawn a member with a fresh runtime |
+| `mob_force_cancel_member` | `mob_id`, `agent_identity` | Force-cancel a member's active work |
+| `mob_member_status` | `mob_id`, `agent_identity` | Get canonical member status |
+| `mob_list_members` | `mob_id` | List members and state |
+| `mob_wire` | `mob_id`, `agent_identity`, `peer`, `action` | Wire or unwire a comms edge |
 | `mob_run_flow` | `flow_id`, `params?` | Execute a DAG flow |
 | `mob_flow_status` | `run_id` | Check flow run status |
 | `mob_cancel_flow` | `run_id` | Cancel a running flow |
+| `mob_wait_kickoff` | `mob_id`, `member_ids?`, `timeout_ms?` | Wait for kickoff completion |
+| `mob_wait_ready` | `mob_id`, `member_ids?`, `timeout_ms?` | Wait until members are bound/ready |
 | `mob_task_create` | `subject`, `description`, `blocked_by?` | Create a shared task |
 | `mob_task_list` | none | List shared tasks |
 | `mob_task_update` | `task_id`, `status`, `owner?` | Update a task's status |
 | `mob_task_get` | `task_id` | Get task details |
 
-These tools are available on **every surface** — CLI, RPC, REST, MCP, Python SDK, TypeScript SDK. The agent orchestrates the mob by calling these tools in response to natural language instructions.
+These are the **in-agent** tools. Public host surfaces use typed control planes instead:
+
+- JSON-RPC and SDKs: explicit `mob/*` methods such as `mob/create`, `mob/spawn`, `mob/wire`, and `mob/flow_run`
+- JSON-RPC and SDKs also expose richer host-side lifecycle and work-lane methods such as `mob/ensure_member`, `mob/reconcile`, `mob/list_members_matching`, `mob/destroy`, `mob/submit_work`, `mob/cancel_work`, `mob/cancel_all_work`, `mob/wait_kickoff`, and `mob/wait_ready`
+- Public MCP hosts: typed `meerkat_mob_*` tools
+- CLI: helper-oriented commands such as `spawn-helper`, `fork-helper`, `run-flow`, `member-status`, `respawn`, and `wait-kickoff`
 
 ---
 
@@ -263,6 +273,15 @@ In addition to tool-driven orchestration (where an agent calls mob tools), there
   </Tab>
 </Tabs>
 
+### Work lane vs member send
+
+There are two different host-side delivery models:
+
+- `mob/member_send` for ordinary content delivery to a member session
+- `mob/submit_work` / `mob/cancel_work` / `mob/cancel_all_work` for tracked, cancellable work-lane operations
+
+Use the work lane when your application needs server-issued work references, cancellation by handle, or explicit tracked work state. Use `member_send` for plain direct content delivery.
+
 ---
 
 ## Topology
@@ -302,11 +321,11 @@ Wildcard `"*"` matches any role.
 
 ## Realtime attachment
 
-Each mob member runs in its own session, so realtime is enabled per-member by pointing a profile at a realtime-capable model (for example `gpt-realtime`). The runtime attaches and detaches the OpenAI Realtime transport automatically based on `ModelCapabilities.realtime` — there is no per-member attach/detach RPC. Use `runtime/realtime_attachment_statuses` to observe all members' attachment state in one round trip. See the [Realtime voice guide](/guides/realtime) for the capability-driven model, state machine, and live-topology reconfigure flow.
+Each mob member runs in its own session, so realtime is enabled per-member by pointing a profile at a realtime-capable model (for example `gpt-realtime-1.5`). The runtime attaches and detaches the OpenAI Realtime transport automatically based on `ModelCapabilities.realtime` — there is no per-member attach/detach RPC. Use `runtime/realtime_attachment_statuses` to observe all members' attachment state in one round trip. See the [Realtime guide](/guides/realtime) for the capability-driven model, state machine, and live-topology reconfigure flow.
 
 ## See also
 
-- [Realtime voice guide](/guides/realtime) — per-member realtime audio attachment
+- [Realtime guide](/guides/realtime) — per-member realtime audio attachment
 - [Examples: Mobs](/examples/mobs) — code examples across all surfaces
 - [Examples: Mobpack](/examples/mobpack) — portable deployment
 - [Examples: WASM](/examples/wasm) — browser deployment

--- a/docs/guides/realtime.mdx
+++ b/docs/guides/realtime.mdx
@@ -4,7 +4,7 @@ description: "Enable low-latency audio on a session by choosing a realtime-capab
 icon: "microphone"
 ---
 
-Realtime in Meerkat is **a delivery mode of the session's LLM, not a separate subsystem**. To use realtime audio on a session, pick a realtime-capable model (for example `gpt-realtime`). The runtime attaches an OpenAI Realtime transport automatically when the resolved model advertises `ModelCapabilities.realtime == true`, and detaches automatically when a reconfigure swaps the session onto a non-realtime model. There is no caller-initiated attach RPC.
+Realtime in Meerkat is **a delivery mode of the session's LLM, not a separate subsystem**. To use realtime audio on a session, pick a realtime-capable model (for example `gpt-realtime-1.5`). The runtime attaches an OpenAI Realtime transport automatically when the resolved model advertises `ModelCapabilities.realtime == true`, and detaches automatically when a reconfigure swaps the session onto a non-realtime model. There is no caller-initiated attach RPC.
 
 This guide covers the capability-driven model, how to enable realtime on a session, how to observe the attachment status, and the live-topology reconfigure flow for swapping the session's model while a realtime binding is active.
 
@@ -14,7 +14,7 @@ Public API surfaces describe `realtime`, not `voice`. The converged vocabulary i
 
 ## Mental model
 
-A session has exactly one conversation history. The session's LLM client is the active delivery mechanism for that history; most models deliver via request/response (e.g. Anthropic `claude-opus-4-7`, OpenAI `gpt-5.2`), a small class delivers via a persistent bidirectional socket (e.g. OpenAI `gpt-realtime`). The only thing a realtime-capable model changes is *how* the model is reached — the session still owns history, tools, context, and turn boundaries.
+A session has exactly one conversation history. The session's LLM client is the active delivery mechanism for that history; most models deliver via request/response (e.g. Anthropic `claude-opus-4-7`, OpenAI `gpt-5.2`), a small class delivers via a persistent bidirectional socket (e.g. OpenAI `gpt-realtime-1.5`). The only thing a realtime-capable model changes is *how* the model is reached — the session still owns history, tools, context, and turn boundaries.
 
 ```text
         +--------------------------+
@@ -22,7 +22,7 @@ A session has exactly one conversation history. The session's LLM client is the 
         |   tools, context)        |
         +--------------------------+
                      |
-                     | session.model = "gpt-realtime"
+                     | session.model = "gpt-realtime-1.5"
                      v
         +--------------------------+
         | OpenAI Realtime binding  |  audio ingress/egress,
@@ -41,7 +41,7 @@ Key invariants:
 
 `ModelCapabilities.realtime: bool` is set per model in the curated catalog (`meerkat-models`). Capability is derived from the model family:
 
-- **OpenAI**: any model whose name contains `realtime` (currently **only `gpt-realtime`**; the legacy `gpt-4o-realtime-preview` was the predecessor and is now superseded).
+- **OpenAI**: any model whose name contains `realtime` (currently **`gpt-realtime-1.5`** as the canonical realtime model; `gpt-realtime` remains a legacy compatibility alias, and `gpt-4o-realtime-preview` is superseded).
 - **Gemini**: reserved for future `*-live*` endpoints — no production models today.
 - **Anthropic**: no realtime-capable models today.
 - **Self-hosted**: `realtime = false` by default.
@@ -64,7 +64,7 @@ Set the model on `session/create` (RPC) or the equivalent REST / SDK call:
   "method": "session/create",
   "params": {
     "prompt": "Let's talk.",
-    "model": "gpt-realtime",
+    "model": "gpt-realtime-1.5",
     "provider": "openai"
   }
 }
@@ -73,7 +73,7 @@ Set the model on `session/create` (RPC) or the equivalent REST / SDK call:
 ```bash REST
 curl -X POST http://127.0.0.1:8080/sessions \
   -H 'content-type: application/json' \
-  -d '{"prompt":"Let'"'"'s talk.","model":"gpt-realtime","provider":"openai"}'
+  -d '{"prompt":"Let'"'"'s talk.","model":"gpt-realtime-1.5","provider":"openai"}'
 ```
 
 ```python Python SDK
@@ -83,7 +83,7 @@ async with MeerkatClient() as client:
     await client.connect(realm_id="team-alpha")
     session = await client.create_session(
         prompt="Let's talk.",
-        model="gpt-realtime",
+        model="gpt-realtime-1.5",
         provider="openai",
     )
 ```
@@ -93,7 +93,7 @@ The runtime resolves the model, sees `ModelCapabilities.realtime == true`, and b
 
 ### Configuration defaults
 
-The session's default model can be set in config (`~/.rkat/config.toml` or project-local) via `default_model`. Any session created without an explicit `model` parameter inherits the configured default — so setting `default_model = "gpt-realtime"` makes realtime the default for the whole install. See the [Configuration guide](/concepts/configuration).
+The session's default model can be set in config (`~/.rkat/config.toml` or project-local) via `default_model`. Any session created without an explicit `model` parameter inherits the configured default — so setting `default_model = "gpt-realtime-1.5"` makes realtime the default for the whole install. See the [Configuration guide](/concepts/configuration).
 
 ### Mid-session: swap to a realtime-capable model
 
@@ -176,8 +176,13 @@ These are emitted by `rkat-rpc`'s realtime WebSocket listener. Callers typically
 
 1. Create or resume a session on a realtime-capable model.
 2. Poll `runtime/realtime_attachment_status` until it reports `binding_ready`.
-3. Call `realtime/open_info` to obtain a bootstrap token.
-4. Open a WebSocket to the bootstrap URL to exchange audio chunks.
+3. Ensure the host actually exposes the realtime websocket bootstrap service.
+4. Call `realtime/open_info` to obtain a bootstrap token.
+5. Open a WebSocket to the bootstrap URL to exchange audio chunks.
+
+<Warning>
+`binding_ready` means the runtime's realtime attachment is live. It does **not** by itself guarantee that `realtime/open_info` is available on the current host. The bootstrap methods require a host that wires in the realtime websocket service (`RealtimeWsHost` in the RPC host path).
+</Warning>
 
 ## Authority token
 
@@ -270,7 +275,7 @@ async with MeerkatClient() as client:
     # 1. Create a session on a realtime-capable model — transport attaches automatically.
     session = await client.create_session(
         prompt="Ready for voice.",
-        model="gpt-realtime",
+        model="gpt-realtime-1.5",
         provider="openai",
     )
 
@@ -298,16 +303,16 @@ Each mob member has its own session, so realtime attachment is per-member by con
 id = "voice-demo"
 
 [profiles.host]
-model = "gpt-realtime"
+model = "gpt-realtime-1.5"
 provider = "openai"
 peer_description = "Realtime host"
 ```
 
-Every member spawned under that profile is initialized on `gpt-realtime` and its session gets a realtime binding automatically. Use `runtime/realtime_attachment_statuses` with the member session IDs to observe attachment state across the whole mob in one round trip.
+Every member spawned under that profile is initialized on `gpt-realtime-1.5` and its session gets a realtime binding automatically. Use `runtime/realtime_attachment_statuses` with the member session IDs to observe attachment state across the whole mob in one round trip.
 
 ## Limitations and known gaps
 
-- **OpenAI Realtime only.** The shipped provider integration is OpenAI Realtime (`gpt-realtime`). Other providers are not yet wired into the realtime transport layer.
+- **OpenAI Realtime only.** The shipped provider integration is OpenAI Realtime (`gpt-realtime-1.5`, with `gpt-realtime` kept as a compatibility alias). Other providers are not yet wired into the realtime transport layer.
 - **Single realtime binding per session.** A session has at most one realtime attachment at a time. To attach multiple members, spawn them as separate mob members — each has its own session.
 - **Idle sessions cannot host a new binding.** The realtime transport is brought up as part of the executor binding; sessions that have never run a turn have no binding to attach to. Start a turn first (even a trivial prompt) or spawn via a mob to bring the executor online.
 - **No remote-callable reconfigure RPC.** Host code can call `reconfigure_live_topology` via `SessionLlmReconfigureHost`; there is no JSON-RPC or REST method that triggers a model swap from a remote caller today. Applications that need mid-session swaps should integrate at the host trait level.

--- a/docs/guides/scheduling.mdx
+++ b/docs/guides/scheduling.mdx
@@ -1,142 +1,250 @@
 ---
 title: Scheduling
-description: Automate agent tasks with cron and interval triggers
+description: Automate durable session and mob work with once, interval, and calendar schedules.
 icon: "clock"
 ---
 
 # Scheduling
 
-Meerkat's scheduler lets you define recurring agent tasks that run automatically. Schedules are durable, authority-backed, and integrated across all surfaces.
+Meerkat's scheduler persists **schedules** and projects concrete **occurrences** from them.
 
-## How it works
+- A **schedule** is the durable rule: trigger + target + policies.
+- An **occurrence** is one planned delivery produced from that rule.
+- The **driver** claims due occurrences and delivers them to the target at runtime.
 
-A **schedule** defines a trigger (when to fire) and a target (what to run). The scheduler projects **occurrences** from the trigger spec, and a **driver** claims and delivers them at the right time.
-
-```
+```text
 Schedule (trigger + target + policies)
-  → Occurrence projection (planning horizon)
-  → Driver tick loop claims due occurrences
-  → Delivery: creates session, runs prompt
-  → Occurrence marked completed/skipped/failed
+  -> projected occurrences
+  -> driver claims due work
+  -> runtime delivery
+  -> completed / skipped / misfired / delivery_failed
 ```
 
-## Creating a schedule
+## Host APIs vs agent tools
+
+Use the typed host APIs when your application is managing schedules directly:
+
+- JSON-RPC: `schedule/create`, `schedule/list`, `schedule/get`, `schedule/update`, `schedule/pause`, `schedule/resume`, `schedule/delete`, `schedule/occurrences`
+- REST: `POST /schedules`, `GET /schedules`, `GET /schedules/{id}`, `PATCH /schedules/{id}`, `POST /schedules/{id}/pause`, `POST /schedules/{id}/resume`, `DELETE /schedules/{id}`, `GET /schedules/{id}/occurrences`
+
+Inside an agent session, the scheduler is exposed through typed schedule tools such as `meerkat_schedule_create`, `meerkat_schedule_get`, and `meerkat_schedule_occurrences`.
+
+## Create a schedule
 
 <Tabs>
-  <Tab title="CLI">
-    Schedules are managed through agent tools. The agent can create, update, and manage schedules using the built-in `schedule_*` tools:
-
-    ```bash
-    rkat run "Create a schedule that runs every hour to check system health"
-    ```
-  </Tab>
-  <Tab title="Rust SDK">
-    ```rust
-    use meerkat_schedule::{
-        ScheduleService, MemoryScheduleStore, CreateScheduleRequest,
-        TriggerSpec, IntervalTriggerSpec, TargetBinding, SessionTargetBinding,
-    };
-    use std::sync::Arc;
-    use chrono::Duration;
-
-    let store = Arc::new(MemoryScheduleStore::new());
-    let service = ScheduleService::new(store);
-
-    let schedule = service.create(CreateScheduleRequest {
-        display_name: "hourly-health-check".into(),
-        trigger: TriggerSpec::Interval(IntervalTriggerSpec {
-            every: Duration::hours(1).to_std().unwrap(),
-        }),
-        target: TargetBinding::Session(SessionTargetBinding {
-            model: "claude-sonnet-4-6".into(),
-            prompt: "Check system health and report anomalies".into(),
-            ..Default::default()
-        }),
-        ..Default::default()
-    }).await?;
-    ```
-  </Tab>
-  <Tab title="RPC">
+  <Tab title="JSON-RPC">
     ```json
     {
-      "method": "tool/call",
+      "jsonrpc": "2.0",
+      "id": 1,
+      "method": "schedule/create",
       "params": {
-        "name": "schedule_create",
-        "arguments": {
-          "display_name": "hourly-health-check",
-          "trigger": {
-            "type": "interval",
-            "every_seconds": 3600
-          },
-          "target": {
-            "type": "session",
+        "name": "hourly-health-check",
+        "trigger": {
+          "type": "interval",
+          "start_at_utc": "2026-04-21T09:00:00Z",
+          "every_seconds": 3600
+        },
+        "target": {
+          "target_kind": "session",
+          "type": "materialize_on_demand_session",
+          "create": {
             "model": "claude-sonnet-4-6",
-            "prompt": "Check system health and report anomalies"
+            "system_prompt": "You are a health-check assistant."
+          },
+          "action": {
+            "type": "prompt",
+            "prompt": "Check system health and report anomalies."
           }
-        }
+        },
+        "misfire_policy": { "type": "skip" },
+        "overlap_policy": "skip_if_running",
+        "missing_target_policy": "mark_misfired"
       }
     }
     ```
   </Tab>
+  <Tab title="REST">
+    ```bash
+    curl -X POST http://localhost:8080/schedules \
+      -H "Content-Type: application/json" \
+      -d '{
+        "name": "hourly-health-check",
+        "trigger": {
+          "type": "interval",
+          "start_at_utc": "2026-04-21T09:00:00Z",
+          "every_seconds": 3600
+        },
+        "target": {
+          "target_kind": "session",
+          "type": "materialize_on_demand_session",
+          "create": {
+            "model": "claude-sonnet-4-6",
+            "system_prompt": "You are a health-check assistant."
+          },
+          "action": {
+            "type": "prompt",
+            "prompt": "Check system health and report anomalies."
+          }
+        },
+        "misfire_policy": { "type": "skip" },
+        "overlap_policy": "skip_if_running",
+        "missing_target_policy": "mark_misfired"
+      }'
+    ```
+  </Tab>
+  <Tab title="Rust SDK">
+    ```rust
+    use chrono::Utc;
+    use meerkat_schedule::{
+        CreateScheduleRequest, IntervalTriggerSpec, MissingTargetPolicy,
+        MisfirePolicy, OverlapPolicy, ScheduleService, SessionMaterializationSpec,
+        SessionTargetBinding, TriggerSpec, TargetBinding, ScheduledSessionAction,
+    };
+    use std::collections::BTreeMap;
+
+    let schedule = service.create(CreateScheduleRequest {
+        name: Some("hourly-health-check".into()),
+        description: None,
+        trigger: TriggerSpec::Interval(IntervalTriggerSpec {
+            start_at_utc: Utc::now(),
+            every_seconds: 3600,
+            end_at_utc: None,
+        }),
+        target: TargetBinding::session(SessionTargetBinding::materialize_on_demand(
+            SessionMaterializationSpec {
+                model: "claude-sonnet-4-6".into(),
+                system_prompt: Some("You are a health-check assistant.".into()),
+                ..Default::default()
+            },
+            ScheduledSessionAction::Prompt {
+                prompt: "Check system health and report anomalies.".into(),
+                system_prompt: None,
+                render_metadata: None,
+                skill_references: Vec::new(),
+                additional_instructions: Vec::new(),
+            },
+        )),
+        misfire_policy: MisfirePolicy::Skip,
+        overlap_policy: OverlapPolicy::SkipIfRunning,
+        missing_target_policy: MissingTargetPolicy::MarkMisfired,
+        labels: BTreeMap::new(),
+        planning_horizon_days: None,
+        planning_horizon_occurrences: None,
+    }).await?;
+    ```
+  </Tab>
 </Tabs>
 
-## Triggers
+## Trigger types
 
-### Cron triggers
+### Once
 
-Fire at specific calendar times using cron-style field specs:
+Fire one time at an exact UTC timestamp.
 
 ```json
 {
-  "type": "cron",
-  "minute": { "values": [0] },
-  "hour": { "values": [9, 17] },
-  "day_of_week": { "range": { "from": 1, "to": 5 } },
-  "timezone": "America/New_York"
+  "type": "once",
+  "due_at_utc": "2026-04-21T15:00:00Z"
 }
 ```
 
-Each field supports:
-- `"all"` — every value (default)
-- `{ "values": [1, 15, 30] }` — specific values
-- `{ "range": { "from": 0, "to": 59, "step": 5 } }` — range with optional step
+### Interval
 
-### Interval triggers
-
-Fire at fixed intervals:
+Fire repeatedly at a fixed cadence.
 
 ```json
 {
   "type": "interval",
+  "start_at_utc": "2026-04-21T09:00:00Z",
   "every_seconds": 3600
 }
 ```
 
-## Targets
-
-### Session target
-
-Creates a new agent session for each occurrence:
+Add `end_at_utc` to stop the schedule automatically:
 
 ```json
 {
-  "type": "session",
-  "model": "claude-sonnet-4-6",
-  "prompt": "Generate the daily report",
-  "system_prompt": "You are a reporting agent.",
-  "provider": "anthropic"
+  "type": "interval",
+  "start_at_utc": "2026-04-21T09:00:00Z",
+  "every_seconds": 3600,
+  "end_at_utc": "2026-04-22T09:00:00Z"
 }
 ```
 
-### Mob target
+### Calendar
 
-Runs a mob for each occurrence:
+Fire at named wall-clock times in a timezone. Omitted fields default to `{"kind":"any"}`.
 
 ```json
 {
-  "type": "mob",
-  "action": "create_and_run",
-  "definition": { ... }
+  "type": "calendar",
+  "timezone": "Europe/Stockholm",
+  "minute": { "kind": "values", "values": [0] },
+  "hour": { "kind": "values", "values": [9] },
+  "day_of_week": { "kind": "values", "values": [1, 2, 3, 4, 5] }
+}
+```
+
+That means “09:00 every weekday in Stockholm”.
+
+## Target types
+
+### Session targets
+
+`target_kind` must be `"session"` with one of these `type` variants:
+
+- `exact_session`: deliver to one specific existing session
+- `resumable_session`: deliver to a specific session that may be idle/suspended
+- `materialize_on_demand_session`: create a session on first fire, then reuse it
+
+Example exact-session prompt delivery:
+
+```json
+{
+  "target_kind": "session",
+  "type": "exact_session",
+  "session_id": "01936f8a-7b2c-7000-8000-000000000001",
+  "action": {
+    "type": "prompt",
+    "prompt": "Run the daily follow-up."
+  }
+}
+```
+
+Example event delivery:
+
+```json
+{
+  "target_kind": "session",
+  "type": "resumable_session",
+  "session_id": "01936f8a-7b2c-7000-8000-000000000001",
+  "action": {
+    "type": "event",
+    "event_type": "deploy_complete",
+    "payload": { "environment": "prod" }
+  }
+}
+```
+
+### Mob targets
+
+`target_kind` must be `"mob"` with one of these `type` variants:
+
+- `member`: deliver content to a specific mob member
+- `flow`: run a named mob flow
+- `spawn_helper`: create a helper in a mob and wait for it
+- `fork_helper`: fork from an existing member and wait for it
+
+Example flow target:
+
+```json
+{
+  "target_kind": "mob",
+  "type": "flow",
+  "mob_id": "release-triage",
+  "flow_id": "triage",
+  "params": { "severity": "high" }
 }
 ```
 
@@ -144,75 +252,76 @@ Runs a mob for each occurrence:
 
 ### Misfire policy
 
-What to do when an occurrence fires late (e.g., after a restart):
+What happens when an occurrence is materially late:
 
-| Policy | Behavior |
-|--------|----------|
-| `execute` | Run anyway (default) |
-| `skip` | Skip the missed occurrence |
-| `skip_if_older_than` | Skip if overdue by more than the specified duration |
+- `{"type":"skip"}`: skip overdue work after the grace window
+- `{"type":"catch_up_within","window_seconds":300}`: catch up if still within the lateness window
 
 ### Overlap policy
 
-What to do when a previous occurrence is still running:
+What happens when the next occurrence fires while previous work is still active:
 
-| Policy | Behavior |
-|--------|----------|
-| `allow` | Run concurrently (default) |
-| `skip` | Skip until previous completes |
+- `skip_if_running` (recommended)
+- `allow_concurrent`
 
 ### Missing target policy
 
-What to do when the target doesn't exist:
+What happens when the target is missing at fire time:
 
-| Policy | Behavior |
-|--------|----------|
-| `skip` | Skip the occurrence |
-| `fail` | Mark as failed |
-| `create` | Create the target automatically (default) |
+- `mark_misfired` (recommended)
+- `skip`
 
-## Schedule tools
+## Recommended defaults
 
-Agents can manage schedules through built-in tools:
+For most recurring jobs, start with:
 
-| Tool | Description |
-|------|-------------|
-| `schedule_create` | Create a new schedule |
-| `schedule_list` | List schedules with optional filters |
-| `schedule_read` | Read schedule details and occurrences |
-| `schedule_update` | Update trigger, target, or policies |
-| `schedule_pause` | Pause a schedule |
-| `schedule_resume` | Resume a paused schedule |
-| `schedule_delete` | Delete a schedule |
-
-These tools are available across CLI, REST, RPC, and MCP surfaces. WASM environments use a disabled store and return capability-unavailable errors.
+```json
+{
+  "misfire_policy": { "type": "skip" },
+  "overlap_policy": "skip_if_running",
+  "missing_target_policy": "mark_misfired"
+}
+```
 
 ## Schedule lifecycle
 
-```
-Active ──pause──→ Paused ──resume──→ Active
-  │                                    │
-  ├──cancel──→ Cancelled               │
-  │                                    ├──cancel──→ Cancelled
-  └──(max_occurrences reached)──→ Completed
-```
+Schedule phase is intentionally small:
 
-## Occurrence lifecycle
+- `active`
+- `paused`
+- `deleted`
 
-```
-Pending ──claim──→ Claimed ──deliver──→ Delivering
-                                          │
-                                ┌─────────┼─────────┐
-                                ↓         ↓         ↓
-                           Completed   Skipped    Failed
-```
+Occurrence phase is more detailed:
 
-Occurrences can also be **superseded** when a schedule is updated and new occurrences replace planned ones.
+- `pending`
+- `claimed`
+- `dispatching`
+- `awaiting_completion`
+- `completed`
+- `skipped`
+- `misfired`
+- `superseded`
+- `delivery_failed`
 
-## Persistence
+Use `schedule/occurrences` or `GET /schedules/{id}/occurrences` to inspect what actually fired and why.
 
-Schedule stores are per-realm. Multiple processes can share a store safely through `atomic_plan_mutation()`, which provides store-level atomicity for multi-step planning changes.
+## Agent-side schedule tools
 
-Available backends:
-- **SQLite** — durable, multi-process safe (default for persistent realms)
-- **Memory** — testing and WASM
+When scheduling is exposed inside a running agent, the canonical tool names are:
+
+- `meerkat_schedule_create`
+- `meerkat_schedule_get`
+- `meerkat_schedule_list`
+- `meerkat_schedule_update`
+- `meerkat_schedule_pause`
+- `meerkat_schedule_resume`
+- `meerkat_schedule_delete`
+- `meerkat_schedule_occurrences`
+
+These are distinct from the host APIs (`schedule/*` over RPC and `/schedules/*` over REST).
+
+## See also
+
+- [JSON-RPC API](/api/rpc)
+- [REST API](/api/rest)
+- [Builtin tools reference](/reference/builtin-tools)

--- a/docs/guides/self-hosted-gemma4.mdx
+++ b/docs/guides/self-hosted-gemma4.mdx
@@ -13,7 +13,11 @@ This guide uses the four Gemma 4 aliases we recommend for Meerkat:
 - `gemma-4-26b-a4b`
 - `gemma-4-31b`
 
-Gemma 4 is a reasoning-capable family with native `system` role support and native function calling. All four variants support text and image input, while `E2B` and `E4B` also expose native audio support in the model capability tables. For Meerkat, the safest OpenAI-compatible serving default today is `chat_completions`, because that is the path most clearly documented for Gemma 4 tool calling across the serving stacks below.
+Gemma 4 is a reasoning-capable family with native `system` role support and native function calling. All four variants fit well into Meerkat's current self-hosted text, image, and tool-calling path. For Meerkat, the safest OpenAI-compatible serving default today is `chat_completions`, because that is the path most clearly documented for Gemma 4 tool calling across the serving stacks below.
+
+<Warning>
+Upstream Gemma capability tables may advertise audio on some variants, but Meerkat's current self-hosted path does not surface self-hosted Gemma audio as a realtime/audio capability. Treat the current integration as text + image + tools unless and until a dedicated self-hosted realtime/audio path is documented.
+</Warning>
 
 <Warning>
 Treat `supports_thinking` and `supports_reasoning` as transport-facing settings, not raw model facts. Gemma 4 itself is reasoning-capable, but normalized reasoning controls and trace streaming still vary by serving stack.
@@ -246,7 +250,7 @@ Use vLLM when you want a self-managed server and the most control over deploymen
 | `gemma-4-26b-a4b` | Stronger quality on a serious local or remote GPU setup |
 | `gemma-4-31b` | Best quality of the four, usually best on a dedicated server |
 
-`E2B` and `E4B` are also the sizes with native audio support in the upstream capability tables; `26B A4B` and `31B` are text+image models.
+Upstream capability tables may differentiate the smaller variants on audio, but Meerkat's current self-hosted integration treats all four aliases as text/image/tool-capable models rather than a separate self-hosted audio transport surface.
 
 ## Validation checklist
 

--- a/docs/guides/skills.mdx
+++ b/docs/guides/skills.mdx
@@ -12,9 +12,11 @@ Skills are discovered from multiple sources, in precedence order:
 
 1. **Project/runtime root** (`<runtime-root>/.rkat/skills/`) — highest precedence
 2. **User** (`~/.rkat/skills/`)
-3. **Git repositories** — cloned to local cache, refreshed on TTL
-4. **HTTP endpoints** — fetched from remote skill servers
-5. **Embedded** (builtin skills from component crates)
+3. **Configured filesystem sources**
+4. **Git repositories** — cloned to local cache, refreshed on TTL
+5. **HTTP endpoints** — fetched from remote skill servers
+6. **Stdio sources**
+7. **Embedded** (builtin skills from component crates)
 
 <Note>
 A project skill with the same ID as a builtin skill overrides the builtin (first-source-wins).
@@ -27,7 +29,8 @@ Configured in skills settings (typically in realm `config.toml`). Uses gitoxide 
 ```toml
 [[repositories]]
 name = "company"
-transport = "git"
+source_uuid = "11111111-1111-1111-1111-111111111111"
+type = "git"
 url = "https://github.com/company/meerkat-skills.git"
 git_ref = "main"
 ref_type = "branch"    # "branch", "tag", or "commit"
@@ -41,10 +44,29 @@ depth = 1              # shallow clone depth
 ```toml
 [[repositories]]
 name = "remote"
-transport = "http"
+source_uuid = "22222222-2222-2222-2222-222222222222"
+type = "http"
 url = "https://skills.example.com/api"
-# auth_bearer = "${SKILLS_API_KEY}"
-cache_ttl_seconds = 300
+auth_token = "${SKILLS_API_KEY}"
+refresh_seconds = 300
+timeout_seconds = 15
+```
+
+### Filesystem and stdio sources
+
+```toml
+[[repositories]]
+name = "local-shared"
+source_uuid = "33333333-3333-3333-3333-333333333333"
+type = "filesystem"
+path = "/opt/meerkat-skills"
+
+[[repositories]]
+name = "generated"
+source_uuid = "44444444-4444-4444-4444-444444444444"
+type = "stdio"
+command = "my-skill-server"
+args = ["--json"]
 ```
 
 ## SKILL.md format
@@ -53,12 +75,12 @@ Each skill is a markdown file with YAML frontmatter:
 
 ```markdown
 ---
-name: Shell Patterns
+name: shell-patterns
 description: "Background job workflows: patterns and tips"
 requires_capabilities: [builtins, shell]
 ---
 
-# Shell Patterns
+# shell-patterns
 
 When running background jobs...
 ```
@@ -67,7 +89,7 @@ When running background jobs...
 
 | Field | Type | Required | Description |
 |-------|------|----------|-------------|
-| `name` | `String` | Yes | Display name for the skill |
+| `name` | `String` | Yes | Canonical lowercase slug name for the skill |
 | `description` | `String` | Yes | One-line description |
 | `requires_capabilities` | `Vec<String>` | No (default `[]`) | Capability IDs that must be available |
 
@@ -84,16 +106,13 @@ Skills are filtered by their `requires_capabilities` field before being shown or
 
 The resolver supports two reference formats:
 
-1. **Slash-prefix ID**: `/skill-id` -- matches against `SkillDescriptor.id`.
-2. **Exact name match** (case-insensitive): `"Shell Patterns"` or `"shell patterns"` -- matches against `SkillDescriptor.name`.
-
-Resolution returns `SkillError::NotFound` if no match, or `SkillError::Ambiguous` if multiple skills match.
+1. **Slash-prefix ID**: `/skill-id` -- current slash activation path.
 
 Resolution mode:
 
 | Mode | Behavior |
 |------|----------|
-| `Explicit` | Only explicit `/skill-id` or exact name matches |
+| `Explicit` | Only explicit `/skill-id` matches |
 
 ## Rendering
 
@@ -158,6 +177,7 @@ The following skills are embedded in component crates:
 | `memory-retrieval` | Memory Retrieval | `meerkat-memory` | `memory_store` |
 | `session-management` | Session Management | `meerkat-session` | `session_store` |
 | `multi-agent-comms` | Multi-Agent Comms | `meerkat-comms` | `comms` |
+| `mob-communication` | Mob Communication | `meerkat` | `comms` |
 
 ## Configuration reference
 
@@ -183,12 +203,12 @@ The following skills are embedded in component crates:
 
     ```markdown
     ---
-    name: Deployment Guide
+    name: my-deployment
     description: Project-specific deployment procedures
     requires_capabilities: []
     ---
 
-    # Deployment Guide
+    # my-deployment
 
     1. Run `make build` to create the release binary.
     2. Deploy via `./deploy.sh production`.
@@ -217,15 +237,15 @@ In collection mode (when there are more than 12 skills), the system prompt shows
 
 Skills can be activated in three ways:
 
-### 1. Slash reference in user message
+### 1. Legacy slash reference compatibility
 
-Include `/skill-id` at the start of a message:
+Some host surfaces still accept legacy slash references as boundary compatibility input:
 
 ```
 /extraction/email Extract the sender from this email
 ```
 
-The agent detects the reference, resolves the skill, and injects its body before running the LLM.
+Treat this as compatibility behavior rather than the primary model. The recommended current path is explicit `skill_refs`, because the canonical runtime identity for a skill is `SkillKey { source_uuid, skill_name }`.
 
 ### 2. Programmatic typed `skill_refs` (per-turn, recommended)
 
@@ -263,7 +283,7 @@ Pass `preload_skills` to inject skills into the system prompt at session creatio
 }
 ```
 
-See the [Python SDK](/sdks/python/reference#skills-parameters) and [TypeScript SDK](/sdks/typescript/reference#skills-parameters) for SDK wrappers.
+See the [Python SDK](/sdks/python/reference#skills-parameters) and [TypeScript SDK](/sdks/typescript/reference#skills-parameters) for SDK wrappers. CLI `--skill` is the preload-oriented path for runtime-local skill loading; it is not the same surface as typed per-turn `skill_refs`.
 
 ## Skill introspection
 
@@ -344,7 +364,8 @@ inventory_threshold = 12       # flat listing below, collection mode above
 
 [[repositories]]
 name = "company"
-transport = "git"
+source_uuid = "55555555-5555-5555-5555-555555555555"
+type = "git"
 url = "https://github.com/company/skills.git"
 ```
 

--- a/docs/guides/structured-output.mdx
+++ b/docs/guides/structured-output.mdx
@@ -18,7 +18,7 @@ When `output_schema` is configured on an agent, the execution flow is:
     An additional LLM call is made with no tools, temperature `0.0` for deterministic output, and a prompt asking for valid JSON matching the schema.
   </Step>
   <Step title="Validation">
-    The response is parsed as JSON and validated against the schema using the `jsonschema` crate's `Validator`.
+    The response is parsed as JSON and, when the `jsonschema` feature is enabled, validated against the schema using the `jsonschema` crate's `Validator`.
   </Step>
   <Step title="On success">
     `RunResult.structured_output` contains the parsed `serde_json::Value`.
@@ -48,7 +48,7 @@ pub struct OutputSchema {
 |-------|------|---------|-------------|
 | `schema` | `MeerkatSchema` | (required) | The JSON schema definition |
 | `name` | `Option<String>` | `None` | Optional schema name (used by some providers) |
-| `strict` | `bool` | `false` | Whether to enforce strict schema validation |
+| `strict` | `bool` | `false` | Whether to request stricter provider-side lowering / constrained decoding behavior where supported |
 | `compat` | `SchemaCompat` | `Lossy` | Compatibility mode for provider lowering |
 | `format` | `SchemaFormat` | `MeerkatV1` | Schema format version |
 
@@ -179,7 +179,11 @@ The extraction turn logic:
 4. LLM is called with **no tools** and **temperature 0.0**.
 5. Response text is trimmed, then markdown code fences are stripped (handles `` ```json `` and `` ``` `` wrappers).
 6. Parsed as JSON via `serde_json::from_str`.
-7. Validated against the compiled schema via `jsonschema::Validator`.
+7. Validated against the compiled schema via `jsonschema::Validator` when the `jsonschema` feature is enabled.
+
+<Note>
+If Meerkat is built without the `jsonschema` feature, structured output still parses JSON and returns it, but schema validation is skipped.
+</Note>
 
 ### On success
 
@@ -263,7 +267,7 @@ Schema warnings are collected during compilation and included in `RunResult.sche
   </Tab>
   <Tab title="REST API">
     ```bash
-    curl -X POST http://localhost:8080/v1/run \
+    curl -X POST http://localhost:8080/sessions \
       -H "Content-Type: application/json" \
       -d '{
         "prompt": "Analyze this code",
@@ -284,12 +288,19 @@ Schema warnings are collected during compilation and included in `RunResult.sche
 
 ## Wire parameters
 
-Structured output is passed per-request via `StructuredOutputParams`:
+Structured output is passed directly on the normal per-request session surfaces:
 
 ```rust
-pub struct StructuredOutputParams {
+pub struct CreateSessionRequest {
+    pub prompt: ContentInput,
+    // ...
+    pub build: Option<SessionBuildOptions>,
+}
+
+pub struct SessionBuildOptions {
     pub output_schema: Option<OutputSchema>,
-    pub structured_output_retries: Option<u32>,
+    pub structured_output_retries: u32,
+    // ...
 }
 ```
 
@@ -329,7 +340,7 @@ let schema = OutputSchema::new(json!({
 }))?;
 
 // Configure via AgentBuildConfig
-let mut build_config = AgentBuildConfig::default();
+let mut build_config = AgentBuildConfig::new("claude-sonnet-4-6");
 build_config.output_schema = Some(schema);
 build_config.structured_output_retries = 3;
 ```

--- a/docs/introduction.mdx
+++ b/docs/introduction.mdx
@@ -9,8 +9,8 @@ It's a set of modular Rust crates that handle the hard parts of agentic systems:
 
 ## Why Meerkat
 
-- **Fast.** Rust from the ground up. Single 5MB binary, &lt;10ms cold start, ~20MB memory. No runtime, no garbage collector, no dependency tree to manage.
-- **Provider-agnostic.** Same code, same tools, same sessions across Anthropic, OpenAI, and Gemini. Switch models with a config change.
+- **Fast.** Rust from the ground up. Lean native binaries and embeddable libraries, &lt;10ms cold start in the core path, and no VM/runtime dependency stack.
+- **Provider-agnostic.** Same session/config model across Anthropic, OpenAI, and Gemini, with capability-gated differences where model support diverges.
 - **Modular.** A workspace of focused crates, all opt-in. Need just the agent loop? Pull in `meerkat-core`. Need session persistence? Add `meerkat-store`. Need inter-agent comms? Add `meerkat-comms`. Your binary includes only what you use. Disabled features return typed errors, not panics.
 - **Stable.** Deterministic state machine with defined transitions. Typed errors with compile-time guarantees. Every error code maps to a stable string across JSON-RPC, REST, and CLI exit codes.
 - **Controlled.** Hard budget limits on tokens, wall-clock time, and tool calls. Eight hook points for guardrails, audit, and content rewriting. Shell security with allow/deny lists.
@@ -55,11 +55,17 @@ Those tools excel at interactive development with rich terminal UIs. Meerkat has
 
 ## Get started
 
-<CardGroup cols={2}>
+<CardGroup cols={4}>
   <Card title="Quickstart" icon="rocket" href="/quickstart">
     Install and run your first agent in under a minute.
   </Card>
+  <Card title="Auth setup" icon="key" href="/guides/auth">
+    Configure provider credentials, realms, bindings, and OAuth flows.
+  </Card>
+  <Card title="Hello examples" icon="play" href="/examples/gallery">
+    Start with the Rust, Python, or TypeScript hello-world examples.
+  </Card>
   <Card title="Examples" icon="code" href="/examples/gallery">
-    Functional apps and feature walkthroughs you can copy and run.
+    Start with hello-world examples, then move into larger production patterns.
   </Card>
 </CardGroup>

--- a/docs/quickstart.mdx
+++ b/docs/quickstart.mdx
@@ -17,21 +17,29 @@ meerkat = "0.6.0"
     ```bash
     pip install meerkat-sdk
     ```
-    <Note>Requires the `rkat-rpc` binary on your PATH.</Note>
+    <Note>
+    The SDK resolves `rkat-rpc` automatically by default and downloads it when needed. Install the standalone binary only if you want to manage it yourself.
+    </Note>
   </Tab>
   <Tab title="TypeScript">
     ```bash
     npm install @rkat/sdk
     ```
-    <Note>Requires the `rkat-rpc` binary on your PATH.</Note>
+    <Note>
+    The SDK resolves `rkat-rpc` automatically by default and downloads it when needed. Install the standalone binary only if you want to manage it yourself.
+    </Note>
   </Tab>
   <Tab title="CLI">
     ```bash
-    cargo install --path meerkat-cli
+    cargo install rkat
     ```
-    <Note>`rkat-mini` ships as an official slim binary in release artifacts. For source builds, see [Mini surfaces](/guides/mini-surfaces).</Note>
+    <Note>`rkat-mini` ships as an official slim binary in release artifacts. For source builds or slim custom builds, see [Mini surfaces](/guides/mini-surfaces).</Note>
   </Tab>
 </Tabs>
+
+<Note>
+Before your first run, set up provider credentials. The fastest path is environment variables; for realm-scoped bindings and OAuth flows, see [Auth](/guides/auth) and [Providers](/concepts/providers).
+</Note>
 
 ## Run an agent
 
@@ -49,18 +57,22 @@ meerkat = "0.6.0"
     let factory = AgentFactory::new(store_dir.clone());
     let client = Arc::new(AnthropicClient::new(api_key)?);
     let llm = factory.build_llm_adapter(client, "claude-sonnet-4-6").await;
-    let store = Arc::new(StoreAdapter::new(Arc::new(JsonlStore::new(store_dir))));
+    let store = Arc::new(JsonlStore::new(store_dir));
+    store.init().await?;
+    let store = Arc::new(StoreAdapter::new(store));
     let tools = Arc::new(meerkat_tools::EmptyToolDispatcher);
 
     let mut agent = AgentBuilder::new()
         .model("claude-sonnet-4-6")
-        .system_prompt("You are a helpful assistant.")
+        .system_prompt("You are a helpful assistant. Be concise in your responses.")
         .max_tokens_per_turn(1024)
         .build(Arc::new(llm), tools, store)
         .await;
 
-    let result = agent.run("What is the capital of France?".to_string()).await?;
-    println!("{}", result.text);
+    let result = agent
+        .run("What is the capital of France? Answer in one sentence.".into())
+        .await?;
+    println!("Response: {}", result.text);
     ```
   </Tab>
   <Tab title="Python">
@@ -130,6 +142,11 @@ The agent completes its current turn when a limit is hit, then stops.
 ## What's next
 
 - [Examples](/examples/sessions) -- every feature shown across surfaces
+- [Auth](/guides/auth) -- environment vars, realms, bindings, and OAuth flows
 - [Mini surfaces](/guides/mini-surfaces) -- shipped slim binaries and custom-build guidance
 - [Providers](/concepts/providers) -- model tables and provider parameters
 - [Rust SDK](/rust/overview) / [Python SDK](/sdks/python/overview) / [TypeScript SDK](/sdks/typescript/overview) -- full API reference
+
+<Note>
+For a maintained repository starter, see the Rust example in the Meerkat repository under `meerkat/examples/simple.rs`.
+</Note>

--- a/docs/reference/api-reference.mdx
+++ b/docs/reference/api-reference.mdx
@@ -14,7 +14,7 @@ This page is a quick-lookup index. For current session/runtime semantics, see [S
 | `AgentBuilder` | `meerkat_core` | Builder pattern for agent construction |
 | `Session` | `meerkat_core` | Conversation state container |
 | `SessionId` | `meerkat_core` | Unique session identifier (UUIDv7) |
-| `Message` | `meerkat_core` | Conversation message enum (`System`, `User`, `Assistant`, `BlockAssistant`, `ToolResults`) |
+| `Message` | `meerkat_core` | Conversation message enum (`System`, `SystemNotice`, `User`, `Assistant`, `BlockAssistant`, `ToolResults`, with runtime notices carried through `SystemNotice`) |
 | `ToolDef` | `meerkat_core` | Tool definition (name, description, JSON Schema) |
 | `ToolCall` | `meerkat_core` | Tool invocation request from the model |
 | `ToolCallView` | `meerkat_core` | Zero-allocation borrowed view of a tool call |
@@ -271,12 +271,16 @@ See the [skills guide](/guides/skills) for usage details.
 | `WireUsage` | Token/cost usage breakdown |
 | `ContractVersion` | Semver version (`0.6.0` currently) |
 | `CoreCreateParams` | Session creation parameters |
-| `StructuredOutputParams` | Schema + retry count |
+| `OutputSchema` + `structured_output_retries` | Structured-output schema and retry settings carried directly on session/turn request surfaces |
 | `CommsParams` | Keep-alive + comms identity parameters |
 | `HookParams` | Hook override entries |
 | `SkillsParams` | Skill enablement + references |
 
 ## Error code reference
+
+This table describes the higher-level canonical `ErrorCode`/wire envelope view.
+It is not identical to the lower-level `SessionError` transport mapping used by
+the session service adapters.
 
 Every `ErrorCode` maps to a stable string, JSON-RPC code, HTTP status, and CLI exit code:
 
@@ -290,10 +294,14 @@ Every `ErrorCode` maps to a stable string, JSON-RPC code, HTTP status, and CLI e
 | Hook denied | `HOOK_DENIED` | -32012 | 403 | 22 |
 | Agent error | `AGENT_ERROR` | -32013 | 500 | 30 |
 | Capability unavailable | `CAPABILITY_UNAVAILABLE` | -32020 | 501 | 40 |
+| Duplicate input | `DUPLICATE_INPUT` | -32004 | 409 | 13 |
+| Request cancelled | `REQUEST_CANCELLED` | -32005 | 499 | 14 |
 | Skill not found | `SKILL_NOT_FOUND` | -32021 | 404 | 41 |
 | Skill resolution failed | `SKILL_RESOLUTION_FAILED` | -32022 | 422 | 42 |
 | Invalid params | `INVALID_PARAMS` | -32602 | 400 | 2 |
 | Internal error | `INTERNAL_ERROR` | -32603 | 500 | 1 |
+
+For session-service transport behavior specifically, see the [Capability matrix](/reference/capability-matrix#error-codes).
 
 ## Provider clients
 

--- a/docs/reference/architecture.mdx
+++ b/docs/reference/architecture.mdx
@@ -14,9 +14,10 @@ The architecture working dump under `docs/architecture/two-kernel-research/` was
 
 ```mermaid
 graph TD
-    SURFACES["CLI / REST / RPC / MCP / Rust / SDKs"] --> SERVICE["SessionService"]
-    SERVICE --> MACHINE["MeerkatMachine"]
-    MACHINE --> FACTORY["AgentFactory::build_agent()"]
+    SURFACES["CLI / REST / RPC / MCP / Rust / SDKs"] --> MACHINE["MeerkatMachine"]
+    MACHINE --> BINDINGS["prepare_bindings(session_id)"]
+    BINDINGS --> SERVICE["SessionService::create_session / start_turn"]
+    SERVICE --> FACTORY["AgentFactory::build_agent()"]
     FACTORY --> AGENT["Agent loop"]
 
     AGENT --> PROVIDERS["LLM adapters"]
@@ -27,11 +28,11 @@ graph TD
     MACHINE --> SCHEDULE["Schedule runtime"]
 ```
 
-Runtime-backed surfaces route through `SessionService`, then bind into
-`MeerkatMachine`, which owns runtime semantics such as keep-alive, admission,
-realtime attachment state, and recovery-safe turn execution. `AgentFactory`
-hydrates the session-scoped agent with the resolved provider, tool surface,
-memory/hooks/skills, and optional mob tooling.
+Runtime-backed surfaces prepare session-owned runtime bindings through
+`MeerkatMachine`, then hand those bindings into `SessionService` via
+`RuntimeBuildMode::SessionOwned(...)`. `AgentFactory` hydrates the
+session-scoped agent with the resolved provider, tool surface, memory/hooks/skills,
+and optional mob tooling.
 
 ## Architectural rules
 
@@ -80,12 +81,20 @@ Generated specs for the machine and composition surfaces live under
 | `meerkat-contracts` | Wire types, error codes, public protocol schemas, contract version |
 | `meerkat-runtime` | `MeerkatMachine`, runtime control plane, session binding/recovery, realtime transport orchestration |
 | `meerkat-session` | Persistent and ephemeral `SessionService` implementations |
+| `meerkat-store` | Session and realm persistence backends (`sqlite`, `jsonl`, schedule store helpers) |
 | `meerkat-tools` | Builtin tools, tool scoping, MCP live-surface integration points |
 | `meerkat-mcp` | MCP client/router used to consume external tool servers |
+| `meerkat-mcp-server` | Meerkat-as-MCP host surface |
 | `meerkat-mob` | Mob runtime, storage, flow engine, member lifecycle |
+| `meerkat-mob-pack` | Mobpack archive/signing/trust primitives |
 | `meerkat-mob-mcp` | Public mob control-plane tools plus agent-side mob tool surfaces |
 | `meerkat-schedule` | Schedule and occurrence services |
+| `meerkat-auth-core` | Shared auth primitives, token stores, OAuth helpers, cloud authorizers |
+| `meerkat-client` | Compatibility client crate that re-exports provider client surfaces |
+| `meerkat-providers` | Compatibility provider-runtime crate for auth/LLM provider resolution seams |
+| `meerkat-memory` | Semantic memory store and retrieval tooling |
 | `meerkat-models` | Compatibility shim that re-exports `meerkat_core::model_profile` |
+| `meerkat-web-runtime` | Browser/WASM runtime surface |
 | `meerkat` | Facade crate that wires the runtime-backed build path together |
 
 ## Canonical references

--- a/docs/reference/builtin-tools.mdx
+++ b/docs/reference/builtin-tools.mdx
@@ -19,18 +19,26 @@ icon: "wrench"
 | `memory_search` | Memory | N/A | `memory-store-session` | Search semantic memory |
 | `datetime` | Utility | Yes | -- | Get current date/time |
 | `apply_patch` | Utility | Yes | -- | Apply structured file patches inside the project root |
-| `view_image` | Utility | Yes | vision | Read an image file and return base64 content |
+| `view_image` | Utility | Yes | `image_tool_results` | Read an image file and return base64 content |
 | `send_message` | Comms | Yes | `comms` | Send a collaboration message to a peer |
 | `send_request` | Comms | Yes | `comms` | Send a structured request to a peer |
 | `send_response` | Comms | Yes | `comms` | Send a response to a peer request |
 | `peers` | Comms | Yes | `comms` | List discoverable peers (trusted + inproc) |
-| `schedule_create` | Schedule | Yes | `schedule` | Create a new schedule |
-| `schedule_list` | Schedule | Yes | `schedule` | List schedules with optional filters |
-| `schedule_read` | Schedule | Yes | `schedule` | Read a schedule and its occurrences |
-| `schedule_update` | Schedule | Yes | `schedule` | Update trigger, target, or policies |
-| `schedule_pause` | Schedule | Yes | `schedule` | Pause a schedule |
-| `schedule_resume` | Schedule | Yes | `schedule` | Resume a paused schedule |
-| `schedule_delete` | Schedule | Yes | `schedule` | Delete a schedule |
+| `browse_skills` | Skills | Yes | `skills` | Browse skill collections and search skills |
+| `load_skill` | Skills | Yes | `skills` | Load a skill's full instructions into the conversation |
+| `skill_list_resources` | Skills | Yes | `skills` | List skill-owned resources |
+| `skill_read_resource` | Skills | Yes | `skills` | Read a specific skill-owned resource |
+| `skill_invoke_function` | Skills | Yes | `skills` | Invoke a skill-defined function |
+| `tool_catalog_search` | Control plane | Yes | `builtins` | Search deferred tool-catalog entries |
+| `tool_catalog_load` | Control plane | Yes | `builtins` | Load deferred tool-catalog entries into visibility |
+| `meerkat_schedule_create` | Schedule | Yes | `schedule` | Create a new schedule |
+| `meerkat_schedule_get` | Schedule | Yes | `schedule` | Read one schedule |
+| `meerkat_schedule_list` | Schedule | Yes | `schedule` | List schedules |
+| `meerkat_schedule_update` | Schedule | Yes | `schedule` | Update trigger, target, or policies |
+| `meerkat_schedule_pause` | Schedule | Yes | `schedule` | Pause a schedule |
+| `meerkat_schedule_resume` | Schedule | Yes | `schedule` | Resume a paused schedule |
+| `meerkat_schedule_delete` | Schedule | Yes | `schedule` | Delete a schedule |
+| `meerkat_schedule_occurrences` | Schedule | Yes | `schedule` | List occurrences for a schedule |
 
 ## Enabling and disabling tools
 
@@ -42,6 +50,7 @@ icon: "wrench"
 | `enable_builtins` | `.builtins(bool)` | `false` | Task tools, utility tools (`datetime`, `apply_patch`, `view_image`) |
 | `enable_shell` | `.shell(bool)` | `false` | All shell tools (`shell`, `shell_jobs`, `shell_job_status`, `shell_job_cancel`) |
 | `enable_memory` | `.memory(bool)` | `false` | `memory_search` (requires `memory-store-session` feature) |
+| `enable_schedule` | `.schedule(bool)` | `false` | Scheduler tools (`meerkat_schedule_*`) |
 | `enable_comms` | `.comms(bool)` | `false` | All comms tools (requires `comms` feature) |
 | `enable_mob` | `.mob(bool)` | `false` | Mob orchestration tools (`mob_*`, `meerkat_*`) |
 
@@ -55,12 +64,13 @@ Each `AgentBuildConfig` can override factory-level flags for a single agent buil
 
 | Override Field | Type | Effect |
 |---------------|------|--------|
-| `override_builtins` | `Option<bool>` | Takes precedence over `enable_builtins` when `Some` |
-| `override_shell` | `Option<bool>` | Takes precedence over `enable_shell` when `Some` |
-| `override_memory` | `Option<bool>` | Takes precedence over `enable_memory` when `Some` |
-| `override_mob` | `Option<bool>` | Takes precedence over `enable_mob` when `Some` |
+| `override_builtins` | `ToolCategoryOverride` | Explicit `enable`, `disable`, or `inherit` |
+| `override_shell` | `ToolCategoryOverride` | Explicit `enable`, `disable`, or `inherit` |
+| `override_memory` | `ToolCategoryOverride` | Explicit `enable`, `disable`, or `inherit` |
+| `override_schedule` | `ToolCategoryOverride` | Explicit `enable`, `disable`, or `inherit` |
+| `override_mob` | `ToolCategoryOverride` | Explicit `enable`, `disable`, or `inherit` |
 
-All default to `None` (use factory-level setting).
+All default to `inherit` (use the factory-level setting).
 
 **Source:** `meerkat/src/factory.rs` -- `AgentBuildConfig` struct.
 </Accordion>
@@ -105,8 +115,8 @@ MCP servers can be added or removed from a running session. Operations are stage
 | Surface | Method | Status |
 |---------|--------|--------|
 | JSON-RPC | `mcp/add`, `mcp/remove`, `mcp/reload` | Fully wired (staged) |
-| REST | `POST /sessions/{id}/mcp/add\|remove\|reload` | Routes registered (placeholder) |
-| CLI | `rkat mcp add/remove --session <id> --live-server-url <url>` | Delegates to REST |
+| REST | `POST /sessions/{id}/mcp/add\|remove\|reload` | Fully wired |
+| CLI | `rkat mcp reload --session <id> --live-server-url <url>` | Host-managed live reload flow |
 
 Servers being removed transition through `Active → Removing (draining) → Removed` to allow in-flight tool calls to complete before finalization.
 
@@ -126,6 +136,25 @@ TurnToolOverlay {
 Set on `StartTurnRequest.flow_tool_overlay` by the flow engine. Ephemeral — cleared after the turn completes. Composes with the external filter using most-restrictive semantics.
 
 **Source:** `meerkat-core/src/service/mod.rs`, `meerkat-mob/src/runtime/flow.rs`
+</Accordion>
+
+## Schedule tools
+
+Schedule tools are the agent-facing scheduler surface. They are distinct from the host APIs (`schedule/*` over RPC and `/schedules/*` over REST).
+
+<Accordion title="Schedule tool inventory">
+| Tool | Purpose |
+|------|---------|
+| `meerkat_schedule_create` | Create a durable schedule with trigger, target, and policies |
+| `meerkat_schedule_get` | Read one schedule by `schedule_id` |
+| `meerkat_schedule_list` | List schedules in the active realm |
+| `meerkat_schedule_update` | Update trigger, target, policies, or labels |
+| `meerkat_schedule_pause` | Pause a schedule |
+| `meerkat_schedule_resume` | Resume a paused schedule |
+| `meerkat_schedule_delete` | Delete a schedule |
+| `meerkat_schedule_occurrences` | List occurrences for a schedule |
+
+These tools are provided by `ScheduleToolDispatcher` in `meerkat-schedule` and are gated by the scheduler capability.
 </Accordion>
 
 ## Task tools
@@ -518,7 +547,7 @@ Get the current date and time. Returns ISO 8601 formatted datetime and Unix time
 <Accordion title="view_image">
 Read an image file from the project directory and return its contents as a base64-encoded `ContentBlock::Image`. This enables vision-capable models to analyze images from disk during tool use.
 
-**Default enabled:** Yes (when builtins are on and model supports vision)
+**Default enabled:** Yes (when builtins are on and the model supports image tool results)
 
 <ParamField body="path" type="String" required>
   Path to the image file, relative to the project root.
@@ -528,9 +557,9 @@ Read an image file from the project directory and return its contents as a base6
 
 **Size limit:** 5 MB. Files exceeding this limit return an error.
 
-**Capability gating:** `view_image` is automatically hidden via `ToolScope` when the active model does not support vision (i.e., `ModelProfile.vision == false`). It is also hidden when the model does not support image content in tool results (`ModelProfile.image_tool_results == false`). This means the tool never appears in the tool list sent to models that cannot process image content.
+**Capability gating:** `view_image` is currently hidden via `ToolScope` when the active model does not support image content in tool results (`ModelProfile.image_tool_results == false`).
 
-**Returns:** A `ToolOutput::Blocks` containing a single `ContentBlock::Image` with the base64-encoded image data and detected media type. The `source_path` field is set on the domain type but stripped from the wire representation (`WireContentBlock`).
+**Returns:** A content-block result containing a single `ContentBlock::Image` with the base64-encoded image data and detected media type.
 
 **Source:** `meerkat-tools/src/builtin/utility/view_image.rs`
 </Accordion>

--- a/docs/reference/capability-matrix.mdx
+++ b/docs/reference/capability-matrix.mdx
@@ -30,27 +30,30 @@ Meerkat is modular. Every feature is opt-in. This matrix shows what works in eac
 
 ## Error codes
 
-Deterministic error codes across all surfaces. The canonical mapping is defined in
-`meerkat-contracts` (`ErrorCode`). Every `SessionError` variant maps to a stable
-string code and a transport-specific representation:
+Two layers matter here:
+
+- **Session transport mapping**: how `SessionError` is projected by session-facing transports
+- **Canonical wire `ErrorCode` mapping**: the higher-level `meerkat-contracts` envelope model used across public protocol surfaces
+
+The table below is the current **session transport** mapping:
 
 | `SessionError` | Code | JSON-RPC | REST | MCP | CLI |
 |----------------|------|----------|------|-----|-----|
-| `NotFound` | `SESSION_NOT_FOUND` | -32001 | 404 | tool error | exit 10 |
-| `Busy` | `SESSION_BUSY` | -32002 | 409 | tool error | exit 11 |
-| `NotRunning` | `SESSION_NOT_RUNNING` | -32003 | 409 | tool error | exit 12 |
-| `PersistenceDisabled` | `CAPABILITY_UNAVAILABLE` | -32020 | 501 | tool error | exit 40 |
-| `CompactionDisabled` | `CAPABILITY_UNAVAILABLE` | -32020 | 501 | tool error | exit 40 |
-| `Store` | `INTERNAL_ERROR` | -32603 | 500 | tool error | exit 1 |
-| `Agent` | `AGENT_ERROR` | -32013 | 500 | tool error | exit 30 |
+| `NotFound` | `SESSION_NOT_FOUND` | -32001 | 404 | tool error | exit 1 |
+| `Busy` | `SESSION_BUSY` | -32002 | 409 | tool error | exit 1 |
+| `PersistenceDisabled` | `SESSION_PERSISTENCE_DISABLED` | -32003 | 501 | tool error | exit 0 |
+| `CompactionDisabled` | `SESSION_COMPACTION_DISABLED` | -32004 | 501 | tool error | exit 0 |
+| `NotRunning` | `SESSION_NOT_RUNNING` | -32005 | 409 | tool error | exit 1 |
+| `Store` | `SESSION_STORE_ERROR` | -32006 | 500 | tool error | exit 1 |
+| `Unsupported` | `SESSION_UNSUPPORTED` | -32007 | 501 | tool error | exit 1 |
+| `Agent` | `AGENT_ERROR` | -32000 | 500 | tool error | exit 1 |
 
 ### Transport error mapping summary
 
-- **JSON-RPC**: Custom error codes in the -32000..-32099 range. The `code` field of the
-  JSON-RPC error object carries the string code (e.g. `SESSION_NOT_FOUND`).
+- **JSON-RPC**: Custom numeric transport codes in the -32000..-32099 range.
 - **REST**: HTTP status codes (404, 409, 500, 501). Error body includes `{ "code": "...", "message": "..." }`.
 - **MCP Server**: Tool calls return `is_error: true` with the error message and code in the content.
-- **CLI**: Non-zero exit codes. Each `ErrorCode` maps to a stable exit code (see [CLI exit codes](/cli/configuration#exit-codes)). Error details printed to stderr.
+- **CLI**: `SessionError` transport projection is intentionally coarse: most failures collapse to exit 1, while persistence/compaction-disabled remain informational (exit 0). Error details are printed to stderr.
 
 ## Pick only what you need
 
@@ -84,7 +87,7 @@ meerkat = { version = "0.6.0", features = ["all-providers", "session-store", "se
 
 These fields are set in the model catalog (`meerkat-models`) and exposed via `ModelProfile`. They control:
 
-- **`view_image` tool visibility** -- hidden via `ToolScope` when either `vision` or `image_tool_results` is `false`.
+- **`view_image` tool visibility** -- currently hidden via `ToolScope` when `image_tool_results` is `false`.
 - **`ContentBlock::Image` in tool results** -- providers that do not support `image_tool_results` will receive image content blocks converted to text descriptions.
 - **`ContentBlock::Image` in user messages** -- providers that do not support `vision` will not receive image content blocks in user messages.
 - **Provider-native web search** -- injected by default when `supports_web_search` is `true` and the corresponding `provider_tools.*` config is enabled.

--- a/docs/reference/comms-redesign-v6-hard-cut.md
+++ b/docs/reference/comms-redesign-v6-hard-cut.md
@@ -6,7 +6,8 @@
 > time of implementation was `0.4.x`. Public `comms/stream_*`, MCP comms-stream
 > tools, and SDK `send_and_stream` / `open_comms_stream` helpers were removed
 > before merge; remaining mentions below are historical only. See the current
-> session, agent, and mob observation APIs for the supported public model.
+> session, agent, and mob observation APIs for the supported public model. Do
+> not use the command/type names in this file as current API reference.
 
 ## Unified TDD Master Plan V6: Hard-Cut Comms Redesign (Final)
 

--- a/docs/reference/skills-governance-runbook.mdx
+++ b/docs/reference/skills-governance-runbook.mdx
@@ -20,7 +20,7 @@ Every source identity record must include:
 - `display_name`
 - `transport_kind`
 - locator `fingerprint`
-- `status` (`active` or `retired`)
+- `status` (`active`, `disabled`, or `retired`)
 
 ## Governance Checks
 
@@ -37,6 +37,12 @@ Startup rejects:
 1. Add lineage event `rotate` from old UUID to new UUID.
 2. Add remap rows for all affected skills (`old_uuid/skill` -> `new_uuid/skill`).
 3. Deploy config and verify canonicalization tests pass.
+
+### Rename or relocate (same logical source, new UUID/path binding)
+
+1. Add lineage event `rename_or_relocate` from old UUID to new UUID.
+2. Add remap rows for all affected skills.
+3. Verify canonicalization still resolves the same semantic skills under the new source identity.
 
 ### Split (one source to many)
 

--- a/docs/rust/advanced.mdx
+++ b/docs/rust/advanced.mdx
@@ -45,12 +45,13 @@ If you are embedding Meerkat into an application, start with `SessionService`. R
 ```rust
 use meerkat::AgentBuilder;
 
-let agent = AgentBuilder::new()
+let mut agent = AgentBuilder::new()
     .model("claude-sonnet-4-6")
     .system_prompt("You are a helpful assistant.")
     .max_tokens_per_turn(4096)
     .temperature(0.7)
-    .build(llm_client, tool_dispatcher, session_store);
+    .build(llm_client, tool_dispatcher, session_store)
+    .await;
 ```
 
 <Accordion title="All builder methods">

--- a/docs/rust/overview.mdx
+++ b/docs/rust/overview.mdx
@@ -382,8 +382,7 @@ let user = Message::User(UserMessage {
         ContentBlock::Text { text: "What is in this image?".to_string() },
         ContentBlock::Image {
             media_type: "image/png".to_string(),
-            data: base64_data,
-            source_path: None,
+            data: ImageData::Inline { data: base64_data },
         },
     ],
 });
@@ -404,8 +403,7 @@ let prompt = ContentInput::Blocks(vec![
     ContentBlock::Text { text: "Describe this image.".to_string() },
     ContentBlock::Image {
         media_type: "image/jpeg".to_string(),
-        data: base64_data,
-        source_path: None,
+        data: ImageData::Inline { data: base64_data },
     },
 ]);
 ```

--- a/docs/rust/tools-and-stores.mdx
+++ b/docs/rust/tools-and-stores.mdx
@@ -43,6 +43,7 @@ The `AgentToolDispatcher` trait connects your tools to the agent:
 use async_trait::async_trait;
 use meerkat::{AgentToolDispatcher, ToolCallView, ToolDef, ToolResult};
 use meerkat::error::ToolError;
+use meerkat_core::ops::ToolDispatchOutcome;
 use serde_json::json;
 use std::sync::Arc;
 
@@ -66,15 +67,15 @@ impl AgentToolDispatcher for MyToolDispatcher {
         ].into()
     }
 
-    async fn dispatch(&self, call: ToolCallView<'_>) -> Result<ToolResult, ToolError> {
+    async fn dispatch(&self, call: ToolCallView<'_>) -> Result<ToolDispatchOutcome, ToolError> {
         match call.name {
             "search" => {
                 #[derive(serde::Deserialize)]
                 struct Args { query: String }
 
                 let args: Args = call.parse_args()
-                    .map_err(|e| ToolError::InvalidArguments(e.to_string()))?;
-                Ok(ToolResult::success(call.id, format!("Results for: {}", args.query)))
+                    .map_err(|e| ToolError::invalid_arguments("search", e.to_string()))?;
+                Ok(ToolResult::new(call.id.to_string(), format!("Results for: {}", args.query), false).into())
             }
             _ => Err(ToolError::not_found(call.name)),
         }
@@ -90,41 +91,37 @@ use meerkat::ToolRegistry;
 
 let mut registry = ToolRegistry::new();
 
-registry.register(tool_def, Box::new(|args| {
-    Box::pin(async move {
-        Ok("result".to_string())
-    })
-}));
+registry.register(tool_def);
 
-let tools = registry.tools();
+let weather = registry.get("get_weather");
+let tools = registry.list();
 ```
 </Accordion>
 
 ### Multimodal tool results
 
-Built-in tools return `ToolOutput`, which supports both JSON and multimodal content:
+Tool results can carry either plain text or multimodal content blocks:
 
 ```rust
-use meerkat::ToolOutput;
-use meerkat::ContentBlock;
+use meerkat::ToolResult;
+use meerkat_core::{ContentBlock, ImageData};
 
-// Standard JSON result
-let output = ToolOutput::Json(json!({"status": "ok", "count": 42}));
+// Standard text result
+let output = ToolResult::new("tool-1".into(), "{\"status\":\"ok\",\"count\":42}".into(), false);
 
 // Multimodal result with image content
-let output = ToolOutput::Blocks(vec![
+let output = ToolResult::with_blocks("tool-2".into(), vec![
     ContentBlock::Text { text: "Screenshot captured:".to_string() },
     ContentBlock::Image {
         media_type: "image/png".to_string(),
-        data: base64_encoded_png,
-        source_path: Some("/path/to/screenshot.png".into()),
+        data: ImageData::Inline { data: base64_encoded_png },
     },
-]);
+], false);
 ```
 
-`ToolOutput::Json` is serialized into a text content block in the tool result. `ToolOutput::Blocks` passes content blocks directly into `ToolResult.content`, enabling tools to return images and other rich content to vision-capable models.
+`ToolResult::new(...)` creates a text-only result. `ToolResult::with_blocks(...)` passes content blocks directly into `ToolResult.content`, enabling tools to return images and other rich content to vision-capable models.
 
-The built-in `view_image` tool uses this mechanism to read image files from disk and return them as `ContentBlock::Image` blocks. It is automatically hidden from models that lack vision or image tool result support.
+The built-in `view_image` tool uses the same content-block mechanism to read image files from disk and return them as `ContentBlock::Image` blocks. It is automatically hidden from models that lack vision or image tool result support.
 
 ---
 
@@ -164,55 +161,36 @@ Implement the `SessionStore` trait and pass it to `AgentFactory::session_store()
 
 ```rust
 use async_trait::async_trait;
-use meerkat::{
-    AgentFactory, Config, SessionStore, SessionFilter, StoreError, Session, SessionId,
-    build_persistent_service, open_realm_persistence_in,
-};
+use meerkat::{SessionFilter, SessionId, SessionStore, SessionStoreError};
+use meerkat_core::{Session, SessionMeta};
 use meerkat_core::SessionMeta;
-use meerkat_store::RealmBackend;
 use std::sync::Arc;
 
 struct BigQueryStore { /* your storage backend */ }
 
 #[async_trait]
 impl SessionStore for BigQueryStore {
-    async fn save(&self, session: &Session) -> Result<(), StoreError> {
+    async fn save(&self, session: &Session) -> Result<(), SessionStoreError> {
         // Persist session to BigQuery
         Ok(())
     }
 
-    async fn load(&self, id: &SessionId) -> Result<Option<Session>, StoreError> {
+    async fn load(&self, id: &SessionId) -> Result<Option<Session>, SessionStoreError> {
         // Load session by ID
         Ok(None)
     }
 
-    async fn list(&self, filter: SessionFilter) -> Result<Vec<SessionMeta>, StoreError> {
+    async fn list(&self, filter: SessionFilter) -> Result<Vec<SessionMeta>, SessionStoreError> {
         Ok(vec![])
     }
 
-    async fn delete(&self, id: &SessionId) -> Result<(), StoreError> {
+    async fn delete(&self, id: &SessionId) -> Result<(), SessionStoreError> {
         Ok(())
     }
 }
 
-// Wire into AgentFactory — all factory features (comms, hooks, skills, etc.) work unchanged
+// Use as a custom store implementation boundary
 let store: Arc<dyn SessionStore> = Arc::new(BigQueryStore { /* ... */ });
-let realms_root = std::env::current_dir()?.join(".rkat").join("realms");
-let (_manifest, persistence) = open_realm_persistence_in(
-    &realms_root,
-    "team-alpha",
-    Some(RealmBackend::Sqlite),
-    None,
-).await?;
-let factory = AgentFactory::new(realms_root.clone())
-    .runtime_root(realms_root)
-    .session_store(store)
-    .builtins(true)
-    .shell(true);
-
-let config = Config::load().await?;
-let service = build_persistent_service(factory, config, 64, persistence);
-// Sessions created through `service` now persist through BigQuery
 ```
 
 <Note>
@@ -220,6 +198,12 @@ Prefer `SessionStore` + `session_store()` over implementing `AgentSessionStore` 
 `SessionStore` is the richer trait (with `list`, `delete`, `exists`) and `AgentFactory`
 automatically wraps it via `StoreAdapter`. Implementing `AgentSessionStore` directly
 bypasses the factory and loses runtime-backed session orchestration.
+
+For runtime-backed persistent services, realm persistence still flows through the
+`PersistenceBundle` opened for that realm. Treat custom `SessionStore`
+implementations as a storage seam for custom builders or direct agent/store
+integration, not as a drop-in replacement for the entire runtime persistence
+bundle.
 </Note>
 </Accordion>
 
@@ -245,9 +229,10 @@ let config = McpServerConfig::stdio(
 router.add_server(config).await?;
 
 // Add HTTP/SSE-based MCP server
-let config = McpServerConfig::http(
+let config = McpServerConfig::streamable_http(
     "remote-server",
     "https://mcp.example.com/sse".to_string(),
+    HashMap::new(),
 );
 router.add_server(config).await?;
 

--- a/docs/sdks/python/overview.mdx
+++ b/docs/sdks/python/overview.mdx
@@ -8,7 +8,7 @@ The Python SDK (`meerkat-sdk`) is a runtime-backed client over `rkat-rpc`.
 
 - **Contract version:** `0.6.0`
 - **Python:** `>=3.10`
-- **Runtime dependencies:** none
+- **Runtime dependencies:** `websockets>=12,<16`
 
 ## Install
 
@@ -63,8 +63,8 @@ asyncio.run(main())
 
 - `await client.inject_context(session_id, text, source=None, idempotency_key=None)`
 - `await session.inject_context(...)`
-- `await client.send_external_event(session_id, payload, source=None)`
-- `await session.send_external_event(...)`
+- `await client.send_external_event(session_id, event_type, payload, blocks=None)`
+- `await session.send_external_event(event_type, payload, blocks=None)`
 
 ### Turn APIs
 
@@ -117,6 +117,16 @@ All config APIs return a **config envelope** (`config`, `generation`, realm meta
 - `await client.list_mob_profiles()`
 - `await client.update_mob_profile(name, profile, expected_revision=...)`
 - `await client.delete_mob_profile(name, expected_revision=...)`
+
+### Additional wrappers
+
+The Python client also exposes:
+
+- realm helpers: `list_realms()`, `get_realm(...)`
+- auth helpers: `list_auth_profiles(...)`, `get_auth_profile(...)`, `create_auth_profile(...)`, `delete_auth_profile(...)`, `test_auth_profile(...)`, `auth_login_*`, `auth_provision_api_key(...)`, `auth_status(...)`, `auth_logout(...)`
+- realtime/runtime helpers: `runtime_realtime_attachment_status(...)`, `runtime_realtime_attachment_statuses(...)`, `realtime_open_info(...)`, `realtime_status(...)`, `realtime_capabilities(...)`
+- blob/skill/MCP helpers: `get_blob(...)`, `list_skills()`, `inspect_skill(...)`, `mcp_add(...)`, `mcp_remove(...)`, `mcp_reload(...)`
+- typed ingress helpers: `send_peer_response_terminal(...)`
 
 ## Typed session metadata
 

--- a/docs/sdks/python/reference.mdx
+++ b/docs/sdks/python/reference.mdx
@@ -133,11 +133,21 @@ await session.inject_context(text, source=None, idempotency_key=None)
 ### `send_external_event`
 
 ```python
-await client.send_external_event(session_id, payload, source=None)
-await session.send_external_event(payload, source=None)
+await client.send_external_event(session_id, event_type, payload, blocks=None)
+await session.send_external_event(event_type, payload, blocks=None)
 ```
 
 Returns `ExternalEventOutcome` (runtime admission outcome payload).
+
+## Additional client wrappers
+
+The Python SDK also exposes:
+
+- realm helpers: `list_realms()`, `get_realm(...)`
+- auth helpers: `list_auth_profiles(...)`, `get_auth_profile(...)`, `create_auth_profile(...)`, `delete_auth_profile(...)`, `test_auth_profile(...)`, `auth_login_*`, `auth_provision_api_key(...)`, `auth_status(...)`, `auth_logout(...)`
+- realtime/runtime helpers: `runtime_realtime_attachment_status(...)`, `runtime_realtime_attachment_statuses(...)`, `realtime_open_info(...)`, `realtime_status(...)`, `realtime_capabilities(...)`
+- blob/skill/MCP helpers: `get_blob(...)`, `list_skills()`, `inspect_skill(...)`, `mcp_add(...)`, `mcp_remove(...)`, `mcp_reload(...)`
+- typed ingress helper: `send_peer_response_terminal(...)`
 
 ## Mob profile and events surfaces
 

--- a/docs/sdks/typescript/overview.mdx
+++ b/docs/sdks/typescript/overview.mdx
@@ -20,6 +20,8 @@ The TypeScript SDK (`@rkat/sdk`) is a thin wrapper over Meerkat's settled runtim
     # Ensure target/release/rkat-rpc is on your $PATH
     ```
 
+    By default the SDK can also auto-resolve and download `rkat-rpc` for the current platform, so a manual binary install is optional unless you want to control the binary path yourself.
+
     You also need an API key for at least one LLM provider (e.g. `ANTHROPIC_API_KEY`).
   </Step>
   <Step title="Configure tsconfig">
@@ -71,7 +73,7 @@ The TypeScript SDK (`@rkat/sdk`) is a thin wrapper over Meerkat's settled runtim
 | `listSessions()` | List active sessions |
 | `readSession(sessionId)` | Read typed session metadata (`SessionInfo`) |
 | `readSessionHistory(sessionId, options?)` | Read committed session transcript history |
-| `sendExternalEvent(sessionId, payload, options?)` | Inject a canonical external event into a session |
+| `sendExternalEvent(sessionId, eventType, payload, options?)` | Inject a canonical external event into a session |
 | `injectContext(sessionId, text, options?)` | Append runtime system context |
 | `getModelsCatalog()` | Read config-backed model catalog |
 | `createSchedule/getSchedule/listSchedules/updateSchedule/pauseSchedule/resumeSchedule/deleteSchedule/listScheduleOccurrences/listScheduleTools/callScheduleTool` | Schedule API wrappers |
@@ -81,6 +83,24 @@ The TypeScript SDK (`@rkat/sdk`) is a thin wrapper over Meerkat's settled runtim
 | `getConfig()` | Read runtime configuration |
 | `setConfig(config)` | Replace runtime configuration |
 | `patchConfig(patch)` | Merge-patch runtime configuration |
+
+### Realtime and auth wrappers
+
+The SDK also exposes the runtime/product realtime helpers and auth-profile wrappers from the RPC surface:
+
+- `runtimeRealtimeAttachmentStatus(...)`
+- `runtimeRealtimeAttachmentStatuses(...)`
+- `realtimeOpenInfo(...)`
+- `realtimeStatus(...)`
+- `realtimeCapabilities(...)`
+- `authProfileList(...)`, `authProfileGet(...)`, `authProfileCreate(...)`, `authProfileDelete(...)`, `authProfileTest(...)`
+- `authLoginStart(...)`, `authLoginComplete(...)`, `authLoginDeviceStart(...)`, `authLoginDeviceComplete(...)`, `authLoginProvisionApiKey(...)`
+- `authStatusGet(...)`, `authLogout(...)`
+- `realmList(...)`, `realmGet(...)`
+- `sendPeerResponseTerminal(...)`
+- `mcpAdd(...)`, `mcpRemove(...)`, `mcpReload(...)`
+- `getBlob(...)`, `listSkills()`, `inspectSkill(...)`
+- `runtimeState(...)`, `runtimeAccept(...)`, `runtimeRetire(...)`, `runtimeReset(...)`, `inputState(...)`, `inputList(...)`
 
 ### Capability methods
 
@@ -160,7 +180,7 @@ export interface ConnectOptions {
 }
 ```
 
-`realmId` and `isolated` are mutually exclusive. If `realmId` is omitted and `isolated` is not set, sessions are stored in the default realm. Reuse `realmId` to share sessions and config across processes or surfaces.
+`realmId` and `isolated` are mutually exclusive. If `realmId` is omitted and `isolated` is not set, the spawned `rkat-rpc` process uses its normal isolated-mode default rather than a shared default realm. Reuse `realmId` explicitly to share sessions and config across processes or surfaces.
 
 ### createSession()
 

--- a/docs/sdks/typescript/reference.mdx
+++ b/docs/sdks/typescript/reference.mdx
@@ -55,6 +55,19 @@ import type {
 } from "@rkat/sdk";
 ```
 
+## Additional client wrappers
+
+The package exports more than the core session lifecycle. The `MeerkatClient` also exposes:
+
+- realtime helpers: `runtimeRealtimeAttachmentStatus`, `runtimeRealtimeAttachmentStatuses`, `realtimeOpenInfo`, `realtimeStatus`, `realtimeCapabilities`
+- auth-profile helpers: `authProfileList`, `authProfileGet`, `authProfileCreate`, `authProfileDelete`, `authProfileTest`
+- auth-login helpers: `authLoginStart`, `authLoginComplete`, `authLoginDeviceStart`, `authLoginDeviceComplete`, `authLoginProvisionApiKey`, `authStatusGet`, `authLogout`
+- realm helpers: `realmList`, `realmGet`
+- typed ingress helper: `sendPeerResponseTerminal`
+- MCP live-op helpers: `mcpAdd`, `mcpRemove`, `mcpReload`
+- blob/skill helpers: `getBlob`, `listSkills`, `inspectSkill`
+- runtime/input helpers: `runtimeState`, `runtimeAccept`, `runtimeRetire`, `runtimeReset`, `inputState`, `inputList`
+
 ---
 
 ## Core types

--- a/examples/011-hooks-guardrails-rs/README.md
+++ b/examples/011-hooks-guardrails-rs/README.md
@@ -1,10 +1,10 @@
 # 011 — Hooks & Guardrails (Rust)
 
-Intercept and control agent behavior at 7 defined hook points. Use hooks for
+Intercept and control agent behavior at 8 defined hook points. Use hooks for
 audit logging, content filtering, approval gates, cost tracking, and more.
 
 ## Concepts
-- `HookPoint` — 7 interception points in the agent loop
+- `HookPoint` — 8 interception points in the agent loop
 - `HookCapability` — observe (read-only) or gate (Allow/Deny/Rewrite)
 - `HookExecutionMode` — foreground (blocking) or background (async)
 - `HookRuntimeConfig` — command, HTTP, or in-process execution

--- a/meerkat-hooks/src/lib.rs
+++ b/meerkat-hooks/src/lib.rs
@@ -11,7 +11,7 @@ inventory::submit! {
     meerkat_skills::SkillRegistration {
         id: "hook-authoring",
         name: "Hook Authoring",
-        description: "Writing hooks for the 7 hook points, execution modes, and decision semantics",
+        description: "Writing hooks for the 8 hook points, execution modes, and decision semantics",
         scope: meerkat_core::skills::SkillScope::Builtin,
         requires_capabilities: &["hooks"],
         body: include_str!("../skills/hook-authoring/SKILL.md"),
@@ -23,7 +23,7 @@ inventory::submit! {
 inventory::submit! {
     meerkat_contracts::CapabilityRegistration {
         id: meerkat_contracts::CapabilityId::Hooks,
-        description: "7 hook points, 3 runtimes (in-process/command/HTTP), deny/allow/rewrite semantics",
+        description: "8 hook points, 3 runtimes (in-process/command/HTTP), deny/allow/rewrite semantics",
         scope: meerkat_contracts::CapabilityScope::Universal,
         requires_feature: None,
         prerequisites: &[],


### PR DESCRIPTION
## What changed

This PR refreshes the Meerkat documentation and local `meerkat-*` skill files after two independent audit passes.

It updates:

- onboarding docs (`introduction`, `quickstart`, docs nav, examples gallery)
- concepts/guides/examples across tools, hooks, skills, memory, mobs, comms, realtime, scheduling, and structured output
- CLI / REST / RPC / MCP / Rust / Python / TypeScript reference docs
- `.claude/skills/meerkat-*` parity with the current 0.6 runtime, provider split, realtime vocabulary, and WASM surface
- audit artifacts under `audit/` documenting both review passes and the remediation checklist

## Why it changed

The repo had accumulated documentation drift in a few categories:

- stale API shapes and example payloads
- host-surface docs that no longer matched current CLI / RPC / REST / SDK behavior
- architecture/reference docs lagging behind the runtime/module split and provider crate split
- local Meerkat skill files teaching older platform assumptions

Two separate 8-agent doc audits were run to surface these issues independently, and the fixes in this PR are the result of working through those findings systematically.

## User and developer impact

- first-run docs are clearer and less misleading
- examples are much closer to current copy-paste correctness
- host-vs-agent surface boundaries are documented more explicitly
- SDK and API pages better reflect the exported public surface
- local `.claude` Meerkat skills should steer future agents toward the current architecture rather than pre-split assumptions

## Root cause

Most of the drift came from product evolution outpacing hand-maintained docs:

- runtime-backed semantics and machine ownership changed
- provider/auth crate ownership changed
- mob/comms/scheduling/realtime surfaces evolved
- some examples and skill references were left on older wire shapes and command inventories

## Validation

- `python -m json.tool docs/docs.json`
- `./scripts/repo-cargo check -p meerkat-hooks`
- local commit/push hooks passed, including formatting, clippy on changed crates, machine codegen/verify, and deterministic workspace gates

## Notes

This PR intentionally includes the audit artifacts in `audit/` so the review trail and remediation checklist stay with the docs refresh.
