### PR TITLE
fix(hooks): typed HookRuntimeKind dispatch (dogma round 4)

### DIFF
--- a/docs/guides/hooks.mdx
+++ b/docs/guides/hooks.mdx
@@ -332,7 +332,7 @@ The hook engine emits `AgentEvent` variants during execution:
 ```rust
 use meerkat_hooks::{DefaultHookEngine, InProcessHookHandler, RuntimeHookResponse};
 use meerkat_core::{HooksConfig, HookEntryConfig, HookId, HookPoint,
-                   HookCapability, HookRuntimeConfig};
+                   HookCapability, HookRuntimeConfig, HookRuntimeKind};
 use std::sync::Arc;
 
 let mut config = HooksConfig::default();
@@ -342,7 +342,7 @@ config.entries.push(HookEntryConfig {
     capability: HookCapability::Guardrail,
     priority: 10,
     runtime: HookRuntimeConfig::new(
-        "in_process",
+        HookRuntimeKind::InProcess,
         Some(serde_json::json!({"name": "my-handler"})),
     )?,
     ..Default::default()

--- a/examples/011-hooks-guardrails-rs/main.rs
+++ b/examples/011-hooks-guardrails-rs/main.rs
@@ -20,8 +20,8 @@ use std::sync::Arc;
 use async_trait::async_trait;
 use meerkat::{
     AgentBuilder, AgentEvent, AgentFactory, AgentToolDispatcher, AnthropicClient, HookCapability,
-    HookEntryConfig, HookExecutionMode, HookId, HookPoint, HookRuntimeConfig, HooksConfig, ToolDef,
-    ToolError, ToolResult,
+    HookEntryConfig, HookExecutionMode, HookId, HookPoint, HookRuntimeConfig, HookRuntimeKind,
+    HooksConfig, ToolDef, ToolError, ToolResult,
 };
 use meerkat_core::{ToolCallView, ToolDispatchOutcome};
 use meerkat_hooks::{DefaultHookEngine, RuntimeHookResponse};
@@ -110,7 +110,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                 mode: HookExecutionMode::Foreground,
                 capability: HookCapability::Observe,
                 runtime: HookRuntimeConfig::new(
-                    "in_process",
+                    HookRuntimeKind::InProcess,
                     Some(serde_json::json!({ "name": "audit-log" })),
                 )
                 .unwrap_or_default(),
@@ -123,7 +123,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                 mode: HookExecutionMode::Foreground,
                 capability: HookCapability::Observe,
                 runtime: HookRuntimeConfig::new(
-                    "in_process",
+                    HookRuntimeKind::InProcess,
                     Some(serde_json::json!({ "name": "tool-filter" })),
                 )
                 .unwrap_or_default(),
@@ -136,7 +136,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                 mode: HookExecutionMode::Foreground,
                 capability: HookCapability::Observe,
                 runtime: HookRuntimeConfig::new(
-                    "in_process",
+                    HookRuntimeKind::InProcess,
                     Some(serde_json::json!({ "name": "turn-monitor" })),
                 )
                 .unwrap_or_default(),

--- a/meerkat-core/src/config.rs
+++ b/meerkat-core/src/config.rs
@@ -1556,21 +1556,63 @@ impl Default for HookEntryConfig {
             priority: 100,
             failure_policy: None,
             timeout_ms: None,
-            runtime: HookRuntimeConfig::new("in_process", Some(serde_json::json!({"name":"noop"})))
-                .unwrap_or_else(|_| HookRuntimeConfig {
-                    kind: "in_process".to_string(),
-                    config: None,
-                }),
+            runtime: HookRuntimeConfig::new(
+                HookRuntimeKind::InProcess,
+                Some(serde_json::json!({"name":"noop"})),
+            )
+            .unwrap_or(HookRuntimeConfig {
+                kind: HookRuntimeKind::InProcess,
+                config: None,
+            }),
         }
+    }
+}
+
+/// Closed set of hook runtime adapters the engine can dispatch to.
+///
+/// Wire format uses snake_case (`in_process`, `command`, `http`) under the
+/// `type` field on [`HookRuntimeConfig`] for backwards compatibility.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum HookRuntimeKind {
+    InProcess,
+    Command,
+    Http,
+}
+
+impl HookRuntimeKind {
+    /// Canonical wire/logging string for this runtime kind.
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            Self::InProcess => "in_process",
+            Self::Command => "command",
+            Self::Http => "http",
+        }
+    }
+
+    /// Parse the canonical wire form. Returns `None` for unrecognized strings.
+    pub fn parse(s: &str) -> Option<Self> {
+        match s {
+            "in_process" => Some(Self::InProcess),
+            "command" => Some(Self::Command),
+            "http" => Some(Self::Http),
+            _ => None,
+        }
+    }
+}
+
+impl std::fmt::Display for HookRuntimeKind {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(self.as_str())
     }
 }
 
 /// Runtime configuration used by hook adapters.
 ///
-/// Core treats this as an opaque payload to avoid adapter-specific coupling.
+/// The dispatch kind is typed; `config` remains an opaque per-kind payload
+/// parsed by the adapter.
 #[derive(Debug, Clone)]
 pub struct HookRuntimeConfig {
-    pub kind: String,
+    pub kind: HookRuntimeKind,
     #[allow(clippy::box_collection)]
     pub config: Option<Box<RawValue>>,
 }
@@ -1584,15 +1626,12 @@ impl PartialEq for HookRuntimeConfig {
 }
 
 impl HookRuntimeConfig {
-    pub fn new(kind: impl Into<String>, config: Option<Value>) -> Result<Self, serde_json::Error> {
+    pub fn new(kind: HookRuntimeKind, config: Option<Value>) -> Result<Self, serde_json::Error> {
         let config = match config {
             Some(value) => Some(raw_json_from_value(value)?),
             None => None,
         };
-        Ok(Self {
-            kind: kind.into(),
-            config,
-        })
+        Ok(Self { kind, config })
     }
 
     pub fn config_value(&self) -> Result<Value, serde_json::Error> {
@@ -1605,8 +1644,12 @@ impl HookRuntimeConfig {
 
 impl Default for HookRuntimeConfig {
     fn default() -> Self {
-        Self::new("in_process", Some(serde_json::json!({"name":"noop"}))).unwrap_or_else(|_| Self {
-            kind: "in_process".to_string(),
+        Self::new(
+            HookRuntimeKind::InProcess,
+            Some(serde_json::json!({"name":"noop"})),
+        )
+        .unwrap_or(Self {
+            kind: HookRuntimeKind::InProcess,
             config: None,
         })
     }
@@ -1618,7 +1661,10 @@ impl Serialize for HookRuntimeConfig {
         S: serde::Serializer,
     {
         let mut map = Map::new();
-        map.insert("type".to_string(), Value::String(self.kind.clone()));
+        map.insert(
+            "type".to_string(),
+            Value::String(self.kind.as_str().to_string()),
+        );
 
         if let Some(raw) = &self.config {
             let parsed: Value =
@@ -1650,12 +1696,15 @@ impl<'de> Deserialize<'de> for HookRuntimeConfig {
             .cloned()
             .ok_or_else(|| serde::de::Error::custom("hook runtime must be an object"))?;
 
-        let kind = obj
+        let kind_str = obj
             .remove("type")
             .and_then(|value| value.as_str().map(ToOwned::to_owned))
             .ok_or_else(|| {
                 serde::de::Error::custom("hook runtime missing required field 'type'")
             })?;
+        let kind = HookRuntimeKind::parse(&kind_str).ok_or_else(|| {
+            serde::de::Error::custom(format!("unsupported hook runtime '{kind_str}'"))
+        })?;
 
         let config_value = if let Some(explicit) = obj.remove("config") {
             if obj.is_empty() {

--- a/meerkat-core/src/lib.rs
+++ b/meerkat-core/src/lib.rs
@@ -103,7 +103,7 @@ pub use completion_feed::{
 pub use config::{
     AgentConfig, BudgetConfig, CallTimeoutOverride, CommsAuthMode, CommsRuntimeConfig,
     CommsRuntimeMode, Config, ConfigDelta, ConfigError, ConfigScope, HookEntryConfig,
-    HookRunOverrides, HookRuntimeConfig, HooksConfig, LimitsConfig, ModelDefaults,
+    HookRunOverrides, HookRuntimeConfig, HookRuntimeKind, HooksConfig, LimitsConfig, ModelDefaults,
     PlainEventSource, ProviderToolsConfig, RetryConfig, SelfHostedApiStyle, SelfHostedConfig,
     SelfHostedModelConfig, SelfHostedServerConfig, SelfHostedTransport, ShellDefaults,
     StorageConfig, StoreConfig, ToolsConfig,

--- a/meerkat-core/tests/hooks_contracts.rs
+++ b/meerkat-core/tests/hooks_contracts.rs
@@ -3,7 +3,7 @@
 use meerkat_core::{
     AgentEvent, Config, HookCapability, HookDecision, HookEntryConfig, HookExecutionMode, HookId,
     HookInvocation, HookLlmRequest, HookOutcome, HookPatch, HookPoint, HookReasonCode,
-    HookRunOverrides, HookRuntimeConfig, HooksConfig, SessionId,
+    HookRunOverrides, HookRuntimeConfig, HookRuntimeKind, HooksConfig, SessionId,
 };
 use serde_json::json;
 
@@ -21,7 +21,7 @@ fn hooks_config_roundtrip_contract() -> Result<(), Box<dyn std::error::Error>> {
             capability: HookCapability::Guardrail,
             priority: 5,
             runtime: HookRuntimeConfig::new(
-                "in_process",
+                HookRuntimeKind::InProcess,
                 Some(json!({"name": "guard_pre_tool", "config": {"mode": "strict"}})),
             )?,
             ..Default::default()
@@ -164,7 +164,10 @@ fn run_override_schema_roundtrip_contract() -> Result<(), Box<dyn std::error::Er
             mode: HookExecutionMode::Foreground,
             capability: HookCapability::Rewrite,
             priority: 1,
-            runtime: HookRuntimeConfig::new("in_process", Some(json!({"name": "run_patch"})))?,
+            runtime: HookRuntimeConfig::new(
+                HookRuntimeKind::InProcess,
+                Some(json!({"name": "run_patch"})),
+            )?,
             ..Default::default()
         }],
         disable: vec![HookId::new("global-hook")],

--- a/meerkat-hooks/src/lib.rs
+++ b/meerkat-hooks/src/lib.rs
@@ -37,7 +37,8 @@ use meerkat_core::time_compat::Duration;
 use meerkat_core::{
     HookCapability, HookDecision, HookEngine, HookEngineError, HookEntryConfig, HookExecutionMode,
     HookExecutionReport, HookFailurePolicy, HookId, HookInvocation, HookOutcome, HookPatch,
-    HookPatchEnvelope, HookReasonCode, HookRevision, HookRunOverrides, HooksConfig,
+    HookPatchEnvelope, HookReasonCode, HookRevision, HookRunOverrides, HookRuntimeKind,
+    HooksConfig,
 };
 use serde::{Deserialize, Serialize};
 use std::collections::{HashMap, HashSet};
@@ -369,7 +370,6 @@ impl DefaultHookEngine {
         entry: &HookEntryConfig,
         invocation: HookInvocation,
     ) -> Result<RuntimeHookResponse, HookEngineError> {
-        let runtime_kind = entry.runtime.kind.as_str();
         let runtime_config =
             entry
                 .runtime
@@ -379,8 +379,8 @@ impl DefaultHookEngine {
                     reason: format!("invalid runtime config payload: {err}"),
                 })?;
 
-        match runtime_kind {
-            "in_process" => {
+        match entry.runtime.kind {
+            HookRuntimeKind::InProcess => {
                 let cfg: InProcessRuntimeConfig =
                     serde_json::from_value(runtime_config).map_err(|err| {
                         HookEngineError::ExecutionFailed {
@@ -409,7 +409,7 @@ impl DefaultHookEngine {
                         reason,
                     })
             }
-            "command" => {
+            HookRuntimeKind::Command => {
                 let cfg: CommandRuntimeConfig =
                     serde_json::from_value(runtime_config).map_err(|err| {
                         HookEngineError::ExecutionFailed {
@@ -420,7 +420,7 @@ impl DefaultHookEngine {
                 self.invoke_command_runtime(entry, &cfg.command, &cfg.args, &cfg.env, invocation)
                     .await
             }
-            "http" => {
+            HookRuntimeKind::Http => {
                 let cfg: HttpRuntimeConfig =
                     serde_json::from_value(runtime_config).map_err(|err| {
                         HookEngineError::ExecutionFailed {
@@ -431,10 +431,6 @@ impl DefaultHookEngine {
                 self.invoke_http_runtime(entry, &cfg.url, &cfg.method, &cfg.headers, invocation)
                     .await
             }
-            other => Err(HookEngineError::ExecutionFailed {
-                hook_id: entry.id.clone(),
-                reason: format!("unsupported hook runtime '{other}'"),
-            }),
         }
     }
 
@@ -784,7 +780,8 @@ impl HookEngine for DefaultHookEngine {
 mod tests {
     use super::*;
     use meerkat_core::{
-        HookFailurePolicy, HookLlmRequest, HookPoint, HookReasonCode, HookRuntimeConfig, SessionId,
+        HookFailurePolicy, HookLlmRequest, HookPoint, HookReasonCode, HookRuntimeConfig,
+        HookRuntimeKind, SessionId,
     };
     use std::sync::atomic::{AtomicUsize, Ordering as AtomicOrdering};
 
@@ -806,8 +803,11 @@ mod tests {
     }
 
     fn runtime_in_process(name: &str) -> HookRuntimeConfig {
-        HookRuntimeConfig::new("in_process", Some(serde_json::json!({"name": name})))
-            .unwrap_or_default()
+        HookRuntimeConfig::new(
+            HookRuntimeKind::InProcess,
+            Some(serde_json::json!({"name": name})),
+        )
+        .unwrap_or_default()
     }
 
     #[tokio::test]
@@ -1367,7 +1367,7 @@ mod tests {
             id: HookId::new("command-hook"),
             point: HookPoint::PreToolExecution,
             runtime: HookRuntimeConfig::new(
-                "command",
+                HookRuntimeKind::Command,
                 Some(serde_json::json!({
                     "command": "sh",
                     "args": ["-c", "cat >/dev/null; printf '{\"patches\":[]}'"],
@@ -1441,7 +1441,7 @@ mod tests {
             id: HookId::new("http-hook"),
             point: HookPoint::PreToolExecution,
             runtime: HookRuntimeConfig::new(
-                "http",
+                HookRuntimeKind::Http,
                 Some(serde_json::json!({
                     "url": format!("http://{}/hook", addr),
                     "method": "POST",

--- a/meerkat/src/lib.rs
+++ b/meerkat/src/lib.rs
@@ -74,6 +74,7 @@ pub use meerkat_core::{
     HookRevision,
     HookRunOverrides,
     HookRuntimeConfig,
+    HookRuntimeKind,
     HooksConfig,
     // Interaction types
     InteractionContent,

--- a/meerkat/src/sdk.rs
+++ b/meerkat/src/sdk.rs
@@ -659,6 +659,7 @@ mod tests {
     use meerkat_core::ops_lifecycle::OpsLifecycleRegistry;
     use meerkat_core::{
         HookCapability, HookEntryConfig, HookExecutionMode, HookId, HookPoint, HookRuntimeConfig,
+        HookRuntimeKind,
     };
     use std::path::Path;
 
@@ -882,7 +883,7 @@ mod tests {
                 mode: HookExecutionMode::Foreground,
                 capability: HookCapability::Observe,
                 runtime: HookRuntimeConfig::new(
-                    "in_process",
+                    HookRuntimeKind::InProcess,
                     Some(serde_json::json!({"name":"sdk_hook"})),
                 )
                 .unwrap_or_default(),
@@ -900,7 +901,7 @@ mod tests {
             mode: HookExecutionMode::Foreground,
             capability: HookCapability::Observe,
             runtime: HookRuntimeConfig::new(
-                "command",
+                HookRuntimeKind::Command,
                 Some(serde_json::json!({ "command": command })),
             )
             .unwrap_or_default(),

--- a/meerkat/tests/smoke_meerkat_sdk.rs
+++ b/meerkat/tests/smoke_meerkat_sdk.rs
@@ -706,7 +706,7 @@ mod scenario_06_hooks {
                     failure_policy: None,
                     timeout_ms: None,
                     runtime: HookRuntimeConfig::new(
-                        "in_process",
+                        HookRuntimeKind::InProcess,
                         Some(serde_json::json!({"name": "observer"})),
                     )
                     .unwrap(),
@@ -721,7 +721,7 @@ mod scenario_06_hooks {
                     failure_policy: None,
                     timeout_ms: None,
                     runtime: HookRuntimeConfig::new(
-                        "in_process",
+                        HookRuntimeKind::InProcess,
                         Some(serde_json::json!({"name": "guardrail"})),
                     )
                     .unwrap(),
@@ -736,7 +736,7 @@ mod scenario_06_hooks {
                     failure_policy: None,
                     timeout_ms: None,
                     runtime: HookRuntimeConfig::new(
-                        "in_process",
+                        HookRuntimeKind::InProcess,
                         Some(serde_json::json!({"name": "rewriter"})),
                     )
                     .unwrap(),


### PR DESCRIPTION
## Summary

Hook runtime dispatch in `DefaultHookEngine::invoke_runtime` was driven by string matching on `HookRuntimeConfig.kind: String` with a wildcard fallback arm (`other => Err("unsupported hook runtime '{other}'")`). The set of runtime kinds is closed (`in_process`, `command`, `http`), so dispatch should be an exhaustive `match` on a typed enum with no fallback branch — same pattern established in R1 U3 / R3 wave 1 (`Provider`).

- Introduce `HookRuntimeKind { InProcess, Command, Http }` in `meerkat-core::config` with `as_str()` / `parse()` / `Display` following the `Provider` pattern.
- Retype `HookRuntimeConfig::kind` from `String` to `HookRuntimeKind`; parse once at the serde deserialization boundary (unknown strings fail there with a clear error).
- Retype `HookRuntimeConfig::new` to accept `HookRuntimeKind` directly — all ~15 callsites updated.
- Replace the string-match dispatch with an exhaustive enum match; the compiler enforces completeness and the stringly fallback arm is deleted.
- Wire format preserved: `{"type":"in_process"|"command"|"http", ...}` round-trips identically — `hooks_config_roundtrip_contract` still passes.

## Test plan

- [x] `./scripts/repo-cargo fmt --all -- --check`
- [x] `./scripts/repo-cargo clippy --workspace --all-targets -- -D warnings`
- [x] `./scripts/repo-cargo check -p meerkat-hooks`
- [x] `./scripts/repo-cargo nextest run -p meerkat-hooks` (11 passed)
- [x] `./scripts/repo-cargo nextest run -p meerkat-core --test hooks_contracts` (6 passed, wire round-trip preserved)

🤖 Generated with [Claude Code](https://claude.com/claude-code)