### PR TITLE
fix(mob-pack): explicit signer identity instead of filename derivation (dogma round 4)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3609,7 +3609,6 @@ dependencies = [
  "tempfile",
  "thiserror 2.0.18",
  "toml 0.8.23",
- "tracing",
 ]
 
 [[package]]

--- a/meerkat-cli/src/main.rs
+++ b/meerkat-cli/src/main.rs
@@ -1775,8 +1775,14 @@ enum MobCommands {
         dir: PathBuf,
         #[arg(short = 'o', long)]
         output: PathBuf,
-        #[arg(long)]
+        /// Path to an Ed25519 signing key (hex-encoded).
+        /// Requires --signer-id.
+        #[arg(long, requires = "signer_id")]
         sign: Option<PathBuf>,
+        /// Semantic signer identity recorded in the pack signature
+        /// (e.g. "team@example.com"). Required when --sign is set.
+        #[arg(long, requires = "sign")]
+        signer_id: Option<String>,
     },
     /// Inspect a .mobpack archive.
     Inspect { pack: PathBuf },
@@ -7962,8 +7968,23 @@ async fn wait_for_terminal_flow_run(
 
 #[cfg(feature = "mob")]
 async fn handle_mob_command(command: MobCommands, scope: &RuntimeScope) -> anyhow::Result<()> {
-    if let MobCommands::Pack { dir, output, sign } = &command {
-        println!("{}", execute_mob_pack(dir, output, sign.as_deref()).await?);
+    if let MobCommands::Pack {
+        dir,
+        output,
+        sign,
+        signer_id,
+    } = &command
+    {
+        let signing = match (sign.as_deref(), signer_id.as_deref()) {
+            (Some(key_path), Some(id)) => Some(meerkat_mob_pack::pack::SigningRequest {
+                signer_id: id,
+                key_path,
+            }),
+            (None, None) => None,
+            // clap `requires` already enforces both-or-neither at parse time.
+            _ => unreachable!("clap enforces --sign and --signer-id together"),
+        };
+        println!("{}", execute_mob_pack(dir, output, signing).await?);
         return Ok(());
     }
 
@@ -8363,9 +8384,9 @@ fn format_inspect_output(info: &meerkat_mob_pack::pack::InspectResult) -> String
 async fn execute_mob_pack(
     dir: &std::path::Path,
     output: &std::path::Path,
-    sign: Option<&std::path::Path>,
+    signing: Option<meerkat_mob_pack::pack::SigningRequest<'_>>,
 ) -> anyhow::Result<String> {
-    let result = pack_directory_with_excludes(dir, sign, &[output])
+    let result = pack_directory_with_excludes(dir, signing, &[output])
         .map_err(|err| anyhow::anyhow!("mob pack failed: {err}"))?;
     tokio::fs::write(output, &result.archive_bytes)
         .await
@@ -9415,7 +9436,7 @@ fn resolve_cli_provider(config: &Config, model: &str, explicit: Option<Provider>
 }
 
 #[cfg(test)]
-#[allow(clippy::unwrap_used, clippy::expect_used)]
+#[allow(clippy::unwrap_used, clippy::expect_used, clippy::panic)]
 mod tests {
     use super::*;
     use async_trait::async_trait;
@@ -10701,19 +10722,72 @@ mod tests {
             "./out.mobpack",
             "--sign",
             "./signing.key",
+            "--signer-id",
+            "team@example.com",
         ])
         .expect("mob pack command should parse");
 
         match cli.command {
             Commands::Mob {
-                command: MobCommands::Pack { dir, output, sign },
+                command:
+                    MobCommands::Pack {
+                        dir,
+                        output,
+                        sign,
+                        signer_id,
+                    },
             } => {
                 assert_eq!(dir, PathBuf::from("./example-mob"));
                 assert_eq!(output, PathBuf::from("./out.mobpack"));
                 assert_eq!(sign, Some(PathBuf::from("./signing.key")));
+                assert_eq!(signer_id.as_deref(), Some("team@example.com"));
             }
             _ => unreachable!("expected mob pack command"),
         }
+    }
+
+    #[cfg(feature = "mob")]
+    #[test]
+    fn test_cli_mob_pack_requires_signer_id_with_sign() {
+        let Err(err) = Cli::try_parse_from([
+            "rkat",
+            "mob",
+            "pack",
+            "./example-mob",
+            "-o",
+            "./out.mobpack",
+            "--sign",
+            "./signing.key",
+        ]) else {
+            panic!("--sign without --signer-id should be rejected");
+        };
+        let rendered = err.to_string();
+        assert!(
+            rendered.contains("signer-id") || rendered.contains("signer_id"),
+            "expected signer-id requirement error, got: {rendered}"
+        );
+    }
+
+    #[cfg(feature = "mob")]
+    #[test]
+    fn test_cli_mob_pack_requires_sign_with_signer_id() {
+        let Err(err) = Cli::try_parse_from([
+            "rkat",
+            "mob",
+            "pack",
+            "./example-mob",
+            "-o",
+            "./out.mobpack",
+            "--signer-id",
+            "team@example.com",
+        ]) else {
+            panic!("--signer-id without --sign should be rejected");
+        };
+        let rendered = err.to_string();
+        assert!(
+            rendered.contains("sign"),
+            "expected sign requirement error, got: {rendered}"
+        );
     }
 
     #[cfg(feature = "mob")]
@@ -11875,9 +11949,16 @@ capabilities = ["definitely_missing_capability"]
             "0707070707070707070707070707070707070707070707070707070707070707",
         )
         .expect("write signing key");
-        execute_mob_pack(&mob_dir, &pack_out, Some(&signing_key))
-            .await
-            .expect("signed pack succeeds");
+        execute_mob_pack(
+            &mob_dir,
+            &pack_out,
+            Some(meerkat_mob_pack::pack::SigningRequest {
+                signer_id: "ci-test",
+                key_path: &signing_key,
+            }),
+        )
+        .await
+        .expect("signed pack succeeds");
 
         let archive_bytes = tokio::fs::read(&pack_out).await.expect("read archive");
         let files = extract_targz_safe(&archive_bytes).expect("extract archive");
@@ -11967,9 +12048,16 @@ capabilities = ["definitely_missing_capability"]
         )
         .expect("write signing key");
 
-        execute_mob_pack(&mob_dir, &pack_out, Some(&signing_key))
-            .await
-            .expect("signed pack should succeed");
+        execute_mob_pack(
+            &mob_dir,
+            &pack_out,
+            Some(meerkat_mob_pack::pack::SigningRequest {
+                signer_id: "ci-test",
+                key_path: &signing_key,
+            }),
+        )
+        .await
+        .expect("signed pack should succeed");
 
         let archive_bytes = tokio::fs::read(&pack_out)
             .await
@@ -12064,9 +12152,16 @@ capabilities = ["definitely_missing_capability"]
             "0505050505050505050505050505050505050505050505050505050505050505",
         )
         .expect("write signing key");
-        execute_mob_pack(&mob_dir, &pack_out, Some(&signing_key))
-            .await
-            .expect("signed pack should succeed");
+        execute_mob_pack(
+            &mob_dir,
+            &pack_out,
+            Some(meerkat_mob_pack::pack::SigningRequest {
+                signer_id: "ci-test",
+                key_path: &signing_key,
+            }),
+        )
+        .await
+        .expect("signed pack should succeed");
 
         let err = execute_mob_deploy(
             &scope,
@@ -12099,9 +12194,16 @@ capabilities = ["definitely_missing_capability"]
             "0404040404040404040404040404040404040404040404040404040404040404",
         )
         .expect("write signing key");
-        execute_mob_pack(&mob_dir, &signed_pack, Some(&signing_key))
-            .await
-            .expect("signed pack should succeed");
+        execute_mob_pack(
+            &mob_dir,
+            &signed_pack,
+            Some(meerkat_mob_pack::pack::SigningRequest {
+                signer_id: "ci-test",
+                key_path: &signing_key,
+            }),
+        )
+        .await
+        .expect("signed pack should succeed");
 
         let signed_bytes = tokio::fs::read(&signed_pack)
             .await
@@ -12171,9 +12273,16 @@ capabilities = ["definitely_missing_capability"]
             "0606060606060606060606060606060606060606060606060606060606060606",
         )
         .expect("write signing key");
-        execute_mob_pack(&mob_dir, &signed_pack, Some(&signing_key))
-            .await
-            .expect("signed pack should succeed");
+        execute_mob_pack(
+            &mob_dir,
+            &signed_pack,
+            Some(meerkat_mob_pack::pack::SigningRequest {
+                signer_id: "ci-test",
+                key_path: &signing_key,
+            }),
+        )
+        .await
+        .expect("signed pack should succeed");
 
         let signed_bytes = tokio::fs::read(&signed_pack)
             .await

--- a/meerkat-cli/tests/cli_mobpack_live_smoke.rs
+++ b/meerkat-cli/tests/cli_mobpack_live_smoke.rs
@@ -642,6 +642,8 @@ async fn e2e_scenario_28_cli_mobpack_deploy_signed_strict_live()
         pack.display().to_string(),
         "--sign".to_string(),
         key_path.display().to_string(),
+        "--signer-id".to_string(),
+        "smoke-ci".to_string(),
     ];
     let pack_refs: Vec<&str> = pack_args.iter().map(String::as_str).collect();
     let pack_out = run_rkat(&rkat, &project_dir, &pack_refs, Some(&api_key)).await?;

--- a/meerkat-mob-pack/Cargo.toml
+++ b/meerkat-mob-pack/Cargo.toml
@@ -24,7 +24,6 @@ tar = "0.4"
 ed25519-dalek = { version = "2.0", features = ["rand_core"] }
 hex = "0.4"
 chrono = { workspace = true }
-tracing = { workspace = true }
 
 [dev-dependencies]
 tempfile = { workspace = true }

--- a/meerkat-mob-pack/src/pack.rs
+++ b/meerkat-mob-pack/src/pack.rs
@@ -7,7 +7,7 @@ use chrono::{SecondsFormat, Utc};
 use ed25519_dalek::SigningKey;
 use meerkat_mob::MobDefinition;
 use std::collections::BTreeMap;
-use std::path::{Path, PathBuf};
+use std::path::Path;
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct PackResult {
@@ -24,32 +24,44 @@ pub struct InspectResult {
     pub digest: MobpackDigest,
 }
 
+/// Inputs required to sign a mobpack.
+///
+/// `signer_id` is the semantic identity recorded in `signature.toml` and looked
+/// up against the trust store. `key_path` is key material used to authenticate
+/// that identity; it is deliberately separate because the filesystem layout of
+/// the key file is not a source of identity.
+#[derive(Debug, Clone, Copy)]
+pub struct SigningRequest<'a> {
+    pub signer_id: &'a str,
+    pub key_path: &'a Path,
+}
+
 pub fn pack_directory(
     directory: &Path,
-    signing_key_file: Option<&Path>,
+    signing: Option<SigningRequest<'_>>,
 ) -> Result<PackResult, PackValidationError> {
-    pack_directory_with_excludes(directory, signing_key_file, &[])
+    pack_directory_with_excludes(directory, signing, &[])
 }
 
 pub fn pack_directory_with_excludes(
     directory: &Path,
-    signing_key_file: Option<&Path>,
+    signing: Option<SigningRequest<'_>>,
     excluded_paths: &[&Path],
 ) -> Result<PackResult, PackValidationError> {
     let mut files = scan_directory(directory)?;
     exclude_paths_from_pack(directory, excluded_paths, &mut files);
-    if let Some(key_path) = signing_key_file {
-        exclude_paths_from_pack(directory, &[key_path], &mut files);
+    if let Some(request) = signing {
+        exclude_paths_from_pack(directory, &[request.key_path], &mut files);
     }
     validate_required_files(&files)?;
 
-    if let Some(key_path) = signing_key_file {
+    if let Some(request) = signing {
         let unsigned_archive = create_targz(&files)?;
         let digest = compute_archive_digest(&unsigned_archive)?;
-        let signing_key = load_signing_key(key_path)?;
+        let signing_key = load_signing_key(request.key_path)?;
         let signature = sign_digest(&signing_key, digest);
         let signature_toml = toml::to_string(&PackSignature {
-            signer_id: signer_id_from_path(key_path),
+            signer_id: request.signer_id.to_string(),
             public_key: hex::encode(signing_key.verifying_key().to_bytes()),
             digest,
             signature: hex::encode(signature.to_bytes()),
@@ -210,31 +222,6 @@ fn load_signing_key(path: &Path) -> Result<SigningKey, PackValidationError> {
     Ok(SigningKey::from_bytes(&secret))
 }
 
-fn signer_id_from_path(path: &Path) -> String {
-    let file_name = path
-        .file_name()
-        .and_then(|v| v.to_str())
-        .map(ToOwned::to_owned)
-        .unwrap_or_else(|| {
-            tracing::debug!(
-                signing_key = %path.display(),
-                "unable to derive signer_id from key filename; falling back to default"
-            );
-            "signer".to_string()
-        });
-    if let Some(stem) = PathBuf::from(file_name)
-        .file_stem()
-        .and_then(|v| v.to_str())
-    {
-        return stem.to_string();
-    }
-    tracing::debug!(
-        signing_key = %path.display(),
-        "unable to derive signer_id from key filename stem; falling back to default"
-    );
-    "signer".to_string()
-}
-
 #[cfg(test)]
 #[allow(clippy::expect_used, clippy::panic, clippy::unwrap_used)]
 mod tests {
@@ -305,7 +292,14 @@ mod tests {
         )
         .unwrap();
 
-        let packed = pack_directory(temp.path(), Some(&key_path)).unwrap();
+        let packed = pack_directory(
+            temp.path(),
+            Some(SigningRequest {
+                signer_id: "test-signer",
+                key_path: &key_path,
+            }),
+        )
+        .unwrap();
         let extracted = extract_targz_safe(&packed.archive_bytes).unwrap();
         let signature_toml = extracted.get("signature.toml").expect("signature.toml");
         let signature: PackSignature =
@@ -313,6 +307,7 @@ mod tests {
         let recomputed = compute_archive_digest(&packed.archive_bytes).unwrap();
         assert_eq!(recomputed, packed.digest);
         assert_eq!(signature.digest, packed.digest);
+        assert_eq!(signature.signer_id, "test-signer");
 
         let vk_bytes: [u8; 32] = hex::decode(signature.public_key)
             .unwrap()


### PR DESCRIPTION
## Summary

- `meerkat-mob-pack` previously derived `signer_id` from the signing-key filename stem and silently fell back to the literal string `"signer"` when it couldn't. Signer identity is a semantic fact (who signed the pack) — it shouldn't be inferred from filesystem layout, and there's no sensible default for a missing one.
- `pack_directory` / `pack_directory_with_excludes` now take `Option<SigningRequest<'_> { signer_id, key_path }>`. Signing requires **both** an identity and key material; the API enforces that by construction.
- `signer_id_from_path` and the `"signer"` literal are deleted.
- `rkat mob pack` gains `--signer-id <id>`, required together with `--sign <key>` (enforced by clap `requires`). Live-smoke and deploy tests updated to pass an explicit id.
- Wire format (`signature.toml.signer_id`) is unchanged — only construction changes.

## Test plan

- [x] `./scripts/repo-cargo fmt --all -- --check`
- [x] `./scripts/repo-cargo clippy --workspace --all-targets -- -D warnings`
- [x] `./scripts/repo-cargo check -p meerkat-mob-pack`
- [x] `./scripts/repo-cargo nextest run -p meerkat-mob-pack` (41/41 pass)
- [x] `./scripts/repo-cargo nextest run -p rkat -E 'test(mob)'` (56/56 pass, includes signed-deploy, trust-store, and CLI parsing lanes)
- [x] Two new clap-validation tests assert `--sign` and `--signer-id` are required together.

Co-authored-by: Claude Opus 4.7 (1M context) <noreply@anthropic.com>