### PR TITLE
[codex] fix(runtime): collapse shared ingress authority

### DIFF
--- a/meerkat-cli/src/main.rs
+++ b/meerkat-cli/src/main.rs
@@ -9538,13 +9538,13 @@ mod tests {
             .register_session_with_executor(session_id.clone(), executor)
             .await;
 
-        tokio::time::timeout(
+        Box::pin(tokio::time::timeout(
             Duration::from_secs(2),
             pipeline.shutdown_after(async {
                 runtime_adapter.unregister_session(&session_id).await;
                 Ok(())
             }),
-        )
+        ))
         .await
         .expect("shutdown should finish once runtime executor is unregistered")
         .expect("shutdown should succeed");

--- a/meerkat-mcp-server/src/lib.rs
+++ b/meerkat-mcp-server/src/lib.rs
@@ -1335,7 +1335,10 @@ pub async fn handle_tools_call(
     tool_name: &str,
     arguments: &Value,
 ) -> Result<Value, ToolCallError> {
-    handle_tools_call_with_notifier(state, tool_name, arguments, None, None).await
+    Box::pin(handle_tools_call_with_notifier(
+        state, tool_name, arguments, None, None,
+    ))
+    .await
 }
 
 /// Handle a tools/call request with optional event notifications.
@@ -1363,12 +1366,18 @@ pub async fn handle_tools_call_with_notifier(
         "meerkat_run" => {
             let input: MeerkatRunInput = serde_json::from_value(arguments.clone())
                 .map_err(|e| ToolCallError::invalid_params(format!("Invalid arguments: {e}")))?;
-            handle_meerkat_run(state, input, notifier, request_context).await
+            Box::pin(handle_meerkat_run(state, input, notifier, request_context)).await
         }
         "meerkat_resume" => {
             let input: MeerkatResumeInput = serde_json::from_value(arguments.clone())
                 .map_err(|e| ToolCallError::invalid_params(format!("Invalid arguments: {e}")))?;
-            handle_meerkat_resume(state, input, notifier, request_context).await
+            Box::pin(handle_meerkat_resume(
+                state,
+                input,
+                notifier,
+                request_context,
+            ))
+            .await
         }
         "meerkat_config" => {
             let input: MeerkatConfigInput = serde_json::from_value(arguments.clone())
@@ -3812,7 +3821,7 @@ mod tests {
     async fn test_handle_meerkat_run_keep_alive_requires_comms_name() {
         let store: Arc<dyn SessionStore> = Arc::new(meerkat::MemoryStore::new());
         let state = MeerkatMcpState::new_with_store(store).await;
-        let result = handle_meerkat_run(
+        let result = Box::pin(handle_meerkat_run(
             &state,
             MeerkatRunInput {
                 prompt: "test".to_string(),
@@ -3846,7 +3855,7 @@ mod tests {
             },
             None,
             None,
-        )
+        ))
         .await;
 
         assert!(result.is_err());
@@ -3861,7 +3870,7 @@ mod tests {
         let state = MeerkatMcpState::new_with_store(store).await;
         let context = cancelled_request_context("req-run-cancelled").await;
 
-        let result = handle_meerkat_run(
+        let result = Box::pin(handle_meerkat_run(
             &state,
             MeerkatRunInput {
                 prompt: "test".to_string(),
@@ -3895,7 +3904,7 @@ mod tests {
             },
             None,
             Some(context),
-        )
+        ))
         .await;
 
         let err = result.expect_err("pre-cancelled run should be rejected");
@@ -3910,7 +3919,7 @@ mod tests {
         let (state, session_id) = state_with_persisted_session().await;
         let context = cancelled_request_context("req-resume-cancelled").await;
 
-        let result = handle_meerkat_resume(
+        let result = Box::pin(handle_meerkat_resume(
             &state,
             MeerkatResumeInput {
                 session_id,
@@ -3943,7 +3952,7 @@ mod tests {
             },
             None,
             Some(context),
-        )
+        ))
         .await;
 
         let err = result.expect_err("pre-cancelled resume should be rejected");
@@ -3964,11 +3973,11 @@ mod tests {
             .await
             .expect("blob stored");
 
-        let result = handle_tools_call(
+        let result = Box::pin(handle_tools_call(
             &state,
             "meerkat_blob_get",
             &json!({ "blob_id": blob_ref.blob_id.as_str() }),
-        )
+        ))
         .await
         .expect("blob get succeeds");
 
@@ -4057,9 +4066,13 @@ mod tests {
     async fn test_handle_tools_call_unknown_tool_still_errors() {
         let store: Arc<dyn SessionStore> = Arc::new(meerkat::MemoryStore::new());
         let state = MeerkatMcpState::new_with_store(store).await;
-        let err = handle_tools_call(&state, "meerkat_mob_prefabz_typo", &json!({}))
-            .await
-            .expect_err("unknown tool must error");
+        let err = Box::pin(handle_tools_call(
+            &state,
+            "meerkat_mob_prefabz_typo",
+            &json!({}),
+        ))
+        .await
+        .expect_err("unknown tool must error");
         assert_eq!(err.code, -32601);
         assert!(err.message.contains("Unknown tool"));
     }
@@ -4069,7 +4082,7 @@ mod tests {
     async fn test_public_mcp_server_rejects_raw_mob_dispatcher_tool_names() {
         let store: Arc<dyn SessionStore> = Arc::new(meerkat::MemoryStore::new());
         let state = MeerkatMcpState::new_with_store(store).await;
-        let err = handle_tools_call(&state, "mob_create", &json!({}))
+        let err = Box::pin(handle_tools_call(&state, "mob_create", &json!({})))
             .await
             .expect_err("raw internal mob tool name must not be exposed");
         assert_eq!(err.code, -32601);
@@ -4082,7 +4095,7 @@ mod tests {
         let store: Arc<dyn SessionStore> = Arc::new(meerkat::MemoryStore::new());
         let state = MeerkatMcpState::new_with_store(store).await;
 
-        let created = handle_tools_call(
+        let created = Box::pin(handle_tools_call(
             &state,
             "meerkat_mob_create",
             &json!({
@@ -4093,19 +4106,19 @@ mod tests {
                     }
                 }
             }),
-        )
+        ))
         .await
         .expect("typed mob create should succeed");
         let created = unwrap_tool_payload_json(created);
         assert_eq!(created["mob_id"], "mob-1");
 
-        let listed = handle_tools_call(&state, "meerkat_mob_list", &json!({}))
+        let listed = Box::pin(handle_tools_call(&state, "meerkat_mob_list", &json!({})))
             .await
             .expect("typed mob list should succeed");
         let listed = unwrap_tool_payload_json(listed);
         assert_eq!(listed["mobs"][0]["mob_id"], "mob-1");
 
-        let err = handle_tools_call(
+        let err = Box::pin(handle_tools_call(
             &state,
             "meerkat_mob_create",
             &json!({
@@ -4121,7 +4134,7 @@ mod tests {
                     }
                 }
             }),
-        )
+        ))
         .await
         .expect_err("nested internal tool bundle fields must be rejected");
         assert_eq!(err.code, -32602);
@@ -4135,7 +4148,7 @@ mod tests {
     async fn test_mcp_handlers_sessions_read_list_interrupt_archive() {
         let (state, session_id) = state_with_persisted_session().await;
 
-        let listed = handle_tools_call(&state, "meerkat_sessions", &json!({}))
+        let listed = Box::pin(handle_tools_call(&state, "meerkat_sessions", &json!({})))
             .await
             .expect("sessions list call should succeed");
         let listed_payload = unwrap_payload(listed);
@@ -4149,20 +4162,24 @@ mod tests {
             "persisted session should appear in list"
         );
 
-        let read = handle_tools_call(&state, "meerkat_read", &json!({ "session_id": session_id }))
-            .await
-            .expect("read call should succeed");
+        let read = Box::pin(handle_tools_call(
+            &state,
+            "meerkat_read",
+            &json!({ "session_id": session_id }),
+        ))
+        .await
+        .expect("read call should succeed");
         let read_payload = unwrap_payload(read);
         assert_eq!(
             read_payload["session_id"],
             read_payload["state"]["session_id"]
         );
 
-        let interrupt_err = handle_tools_call(
+        let interrupt_err = Box::pin(handle_tools_call(
             &state,
             "meerkat_interrupt",
             &json!({ "session_id": read_payload["session_id"] }),
-        )
+        ))
         .await
         .expect_err("interrupt should fail for non-running persisted session");
         assert!(
@@ -4171,11 +4188,11 @@ mod tests {
                 .contains("Failed to interrupt session")
         );
 
-        let archived = handle_tools_call(
+        let archived = Box::pin(handle_tools_call(
             &state,
             "meerkat_archive",
             &json!({ "session_id": read_payload["session_id"] }),
-        )
+        ))
         .await
         .expect("archive call should succeed");
         let archived_payload = unwrap_payload(archived);
@@ -4221,11 +4238,11 @@ mod tests {
             .await
             .expect("persisted history session");
 
-        let history = handle_tools_call(
+        let history = Box::pin(handle_tools_call(
             &state,
             "meerkat_history",
             &json!({ "session_id": session_id, "offset": 1, "limit": 2 }),
-        )
+        ))
         .await
         .expect("history should succeed");
         let history_payload = unwrap_payload(history);
@@ -4244,11 +4261,11 @@ mod tests {
             .await
             .expect("archive should succeed");
 
-        let archived_history = handle_tools_call(
+        let archived_history = Box::pin(handle_tools_call(
             &state,
             "meerkat_history",
             &json!({ "session_id": session_id }),
-        )
+        ))
         .await
         .expect("archived history should succeed");
         let archived_payload = unwrap_payload(archived_history);
@@ -4312,11 +4329,11 @@ mod tests {
         });
         store.save(&session).await.expect("persisted mixed session");
 
-        let history = handle_tools_call(
+        let history = Box::pin(handle_tools_call(
             &state,
             "meerkat_history",
             &json!({ "session_id": session_id }),
-        )
+        ))
         .await
         .expect("mixed history should succeed");
         let payload = unwrap_payload(history);
@@ -4343,7 +4360,7 @@ mod tests {
     async fn test_mcp_handlers_add_remove_reload_require_registered_adapter() {
         let (state, session_id) = state_with_persisted_session().await;
 
-        let err = handle_tools_call(
+        let err = Box::pin(handle_tools_call(
             &state,
             "meerkat_mcp_add",
             &json!({
@@ -4351,7 +4368,7 @@ mod tests {
                 "server_name": "demo",
                 "server_config": {"command": "cat", "args": [], "env": {}}
             }),
-        )
+        ))
         .await
         .expect_err("mcp add should fail without adapter registration");
         assert!(err.message.contains("Live MCP unavailable"));
@@ -4368,7 +4385,7 @@ mod tests {
             )
             .await;
 
-        let add = handle_tools_call(
+        let add = Box::pin(handle_tools_call(
             &state,
             "meerkat_mcp_add",
             &json!({
@@ -4376,35 +4393,35 @@ mod tests {
                 "server_name": "demo",
                 "server_config": {"command": "cat", "args": [], "env": {}}
             }),
-        )
+        ))
         .await
         .expect("mcp add should succeed");
         let add_payload = unwrap_payload(add);
         assert_eq!(add_payload["operation"], "add");
         assert_eq!(add_payload["status"], "staged");
 
-        let remove = handle_tools_call(
+        let remove = Box::pin(handle_tools_call(
             &state,
             "meerkat_mcp_remove",
             &json!({
                 "session_id": add_payload["session_id"],
                 "server_name": "demo"
             }),
-        )
+        ))
         .await
         .expect("mcp remove should succeed");
         let remove_payload = unwrap_payload(remove);
         assert_eq!(remove_payload["operation"], "remove");
         assert_eq!(remove_payload["status"], "staged");
 
-        let reload = handle_tools_call(
+        let reload = Box::pin(handle_tools_call(
             &state,
             "meerkat_mcp_reload",
             &json!({
                 "session_id": remove_payload["session_id"],
                 "server_name": "demo"
             }),
-        )
+        ))
         .await
         .expect("mcp reload should succeed");
         let reload_payload = unwrap_payload(reload);
@@ -4417,11 +4434,11 @@ mod tests {
         let store: Arc<dyn SessionStore> = Arc::new(meerkat::MemoryStore::new());
         let state = MeerkatMcpState::new_with_store(store).await;
         let missing_id = meerkat::SessionId::new().to_string();
-        let err = handle_tools_call(
+        let err = Box::pin(handle_tools_call(
             &state,
             "meerkat_event_stream_open",
             &json!({ "session_id": missing_id }),
-        )
+        ))
         .await
         .expect_err("open should fail for missing session");
         assert!(err.message.contains("Failed to open session event stream"));
@@ -4440,21 +4457,21 @@ mod tests {
             }),
         );
 
-        let read = handle_tools_call(
+        let read = Box::pin(handle_tools_call(
             &state,
             "meerkat_event_stream_read",
             &json!({ "stream_id": stream_id }),
-        )
+        ))
         .await
         .expect("read should complete with timeout");
         let read_payload = unwrap_payload(read);
         assert_eq!(read_payload["status"], "timeout");
 
-        let closed = handle_tools_call(
+        let closed = Box::pin(handle_tools_call(
             &state,
             "meerkat_event_stream_close",
             &json!({ "stream_id": "stream-timeout-default" }),
-        )
+        ))
         .await
         .expect("close should succeed");
         let close_payload = unwrap_payload(closed);
@@ -4499,21 +4516,21 @@ mod tests {
             }),
         );
 
-        let read = handle_tools_call(
+        let read = Box::pin(handle_tools_call(
             &state,
             "meerkat_event_stream_read",
             &json!({ "stream_id": stream_id }),
-        )
+        ))
         .await
         .expect("read should succeed");
         let read_payload = unwrap_payload(read);
         assert_eq!(read_payload["status"], "closed");
 
-        let close = handle_tools_call(
+        let close = Box::pin(handle_tools_call(
             &state,
             "meerkat_event_stream_close",
             &json!({ "stream_id": "stream-closed" }),
-        )
+        ))
         .await
         .expect("close should succeed");
         let close_payload = unwrap_payload(close);

--- a/meerkat-mcp-server/src/runtime_ingress.rs
+++ b/meerkat-mcp-server/src/runtime_ingress.rs
@@ -230,7 +230,7 @@ impl McpRuntimeIngressContext {
             .await
             .insert(session_id.clone(), state.clone());
         let context = self.clone();
-        let result = materialize_session(
+        let result = Box::pin(materialize_session(
             &self.service,
             &self.runtime_adapter,
             session,
@@ -242,7 +242,7 @@ impl McpRuntimeIngressContext {
                     state,
                 ))
             },
-        )
+        ))
         .await;
 
         match result {

--- a/meerkat-mcp-server/src/schedule_host.rs
+++ b/meerkat-mcp-server/src/schedule_host.rs
@@ -413,7 +413,13 @@ impl SurfaceScheduleSessionHost for McpScheduleTargetAdapter {
         occurrence: &Occurrence,
         dispatch: ScheduledPromptDispatch,
     ) -> Result<DeliveryDispatch, ScheduleDomainError> {
-        deliver_scheduled_prompt(&self.context, session_id, occurrence, dispatch).await
+        Box::pin(deliver_scheduled_prompt(
+            &self.context,
+            session_id,
+            occurrence,
+            dispatch,
+        ))
+        .await
     }
 
     async fn deliver_event(
@@ -659,7 +665,7 @@ async fn deliver_scheduled_prompt(
     occurrence: &Occurrence,
     dispatch: ScheduledPromptDispatch,
 ) -> Result<DeliveryDispatch, ScheduleDomainError> {
-    match accept_scheduled_prompt_with_completion(
+    match Box::pin(accept_scheduled_prompt_with_completion(
         context,
         session_id,
         occurrence,
@@ -667,7 +673,7 @@ async fn deliver_scheduled_prompt(
         dispatch.render_metadata,
         dispatch.skill_references,
         dispatch.additional_instructions,
-    )
+    ))
     .await
     {
         Ok(accepted) => Ok(build_dispatch_from_accepted(

--- a/meerkat-mob/src/runtime/actor.rs
+++ b/meerkat-mob/src/runtime/actor.rs
@@ -3868,7 +3868,7 @@ impl MobActor {
             return Err(error);
         }
 
-        let spawn_result = async {
+        let spawn_result = Box::pin(async {
             let spawn_receipt = self.provisioner.provision_member(provision_request).await?;
             if runtime_mode == crate::MobRuntimeMode::AutonomousHost
                 && let Err(capability_error) =
@@ -3921,7 +3921,7 @@ impl MobActor {
             )
             .await
             .map(|outcome| outcome.receipt)
-        }
+        })
         .await;
 
         let (_pending, task_handle) =
@@ -4808,7 +4808,7 @@ impl MobActor {
 
         // 4. Provision and finalize the replacement member inline so the receipt reflects
         //    the committed canonical member/session state before we return.
-        let replacement_result: Result<super::handle::MemberSpawnReceipt, MobRespawnError> = async {
+        let replacement_result: Result<super::handle::MemberSpawnReceipt, MobRespawnError> = Box::pin(async {
             let spawn_receipt = self
                 .provisioner
                 .provision_member(provision_request)
@@ -4916,7 +4916,7 @@ impl MobActor {
                     failed_peer_ids: finalized.failed_restore_peer_ids.into_iter().map(|mid| AgentIdentity::from(mid.as_str())).collect(),
                 })
             }
-        }
+        })
         .await;
 
         let (_respawn_pending, respawn_task) =

--- a/meerkat-rest/src/lib.rs
+++ b/meerkat-rest/src/lib.rs
@@ -2844,7 +2844,7 @@ async fn create_session(
 ) -> Result<Json<SessionResponse>, ApiError> {
     let req_ctx = extract_request_context(&headers, &state.request_executor)?;
     let executor = state.request_executor.clone();
-    let outcome = create_session_inner(&state, req, req_ctx.clone()).await;
+    let outcome = Box::pin(create_session_inner(&state, req, req_ctx.clone())).await;
     with_request_lifecycle(&executor, req_ctx, outcome).await
 }
 
@@ -3573,7 +3573,7 @@ async fn continue_session(
 ) -> Result<Json<SessionResponse>, ApiError> {
     let req_ctx = extract_request_context(&headers, &state.request_executor)?;
     let executor = state.request_executor.clone();
-    let outcome = continue_session_inner(&state, &id, req, req_ctx.clone()).await;
+    let outcome = Box::pin(continue_session_inner(&state, &id, req, req_ctx.clone())).await;
     with_request_lifecycle(&executor, req_ctx, outcome).await
 }
 

--- a/meerkat-rpc/src/router.rs
+++ b/meerkat-rpc/src/router.rs
@@ -838,7 +838,7 @@ impl MethodRouter {
     /// require a response.
     #[allow(clippy::if_not_else)]
     pub async fn dispatch(&self, request: RpcRequest) -> Option<RpcResponse> {
-        self.dispatch_with_request_context(request, None).await
+        Box::pin(self.dispatch_with_request_context(request, None)).await
     }
 
     /// Dispatch a request with optional host-level request context for
@@ -870,14 +870,14 @@ impl MethodRouter {
                 self.runtime_adapter.runtime_mode() == meerkat_runtime::RuntimeMode::V9Compliant,
             ),
             "session/create" => {
-                handlers::session::handle_create(
+                Box::pin(handlers::session::handle_create(
                     id,
                     params,
                     self.runtime.clone(),
                     &self.notification_sink,
                     &self.runtime_adapter,
                     request_context.clone(),
-                )
+                ))
                 .await
             }
             "session/list" => handlers::session::handle_list(id, params, &self.runtime).await,

--- a/meerkat-rpc/src/server.rs
+++ b/meerkat-rpc/src/server.rs
@@ -253,7 +253,7 @@ impl<R: AsyncBufRead + Unpin, W: TransportWriter> RpcServer<R, W> {
                             let router = self.router.clone();
                             let resp_tx = self.response_tx.clone();
                             tokio::spawn(async move {
-                                if let Some(response) = router.dispatch(request).await {
+                                if let Some(response) = Box::pin(router.dispatch(request)).await {
                                     let _ = resp_tx.send(response).await;
                                 }
                             });
@@ -380,9 +380,8 @@ impl<R: AsyncBufRead + Unpin, W: TransportWriter> RpcServer<R, W> {
         let request = request.clone();
         let request_key_for_task = request_key.clone();
         let handle = tokio::spawn(async move {
-            if let Some(response) = router
-                .dispatch_with_request_context(request, Some(context))
-                .await
+            if let Some(response) =
+                Box::pin(router.dispatch_with_request_context(request, Some(context))).await
             {
                 let terminal = classify_long_running_response(&response, publish_on_success);
                 let _ = long_running_tx

--- a/meerkat-rpc/src/session_executor.rs
+++ b/meerkat-rpc/src/session_executor.rs
@@ -153,9 +153,8 @@ impl CoreExecutor for SessionRuntimeExecutor {
             }
         });
 
-        let result = self
-            .runtime
-            .apply_runtime_turn(
+        let result = Box::pin(
+            self.runtime.apply_runtime_turn(
                 &self.session_id,
                 run_id,
                 &primitive,
@@ -189,8 +188,9 @@ impl CoreExecutor for SessionRuntimeExecutor {
                         .turn_metadata()
                         .and_then(|meta| meta.connection_ref.clone()),
                 }),
-            )
-            .await;
+            ),
+        )
+        .await;
 
         // Wait for the event forwarder to finish
         let _ = forwarder.await;

--- a/meerkat-rpc/src/session_runtime.rs
+++ b/meerkat-rpc/src/session_runtime.rs
@@ -2873,17 +2873,16 @@ impl SessionRuntime {
         };
 
         if self.live_session_is_stale(session_id).await? {
-            return self
-                .try_recover_persisted_session(
-                    session_id,
-                    turn_prompt,
-                    event_tx,
-                    keep_alive,
-                    skill_references,
-                    flow_tool_overlay,
-                    additional_instructions,
-                )
-                .await;
+            return Box::pin(self.try_recover_persisted_session(
+                session_id,
+                turn_prompt,
+                event_tx,
+                keep_alive,
+                skill_references,
+                flow_tool_overlay,
+                additional_instructions,
+            ))
+            .await;
         }
 
         // Persist explicit keep_alive override so subsequent inheriting calls
@@ -2930,7 +2929,7 @@ impl SessionRuntime {
             Err(SessionError::NotFound { .. }) => {
                 // Attempt persisted session recovery: the session may exist in the
                 // store from a previous runtime lifetime.
-                self.try_recover_persisted_session(
+                Box::pin(self.try_recover_persisted_session(
                     session_id,
                     turn_prompt,
                     event_tx,
@@ -2938,7 +2937,7 @@ impl SessionRuntime {
                     skill_references,
                     flow_tool_overlay,
                     additional_instructions,
-                )
+                ))
                 .await
             }
             Err(err) => Err(session_error_to_rpc(err)),

--- a/meerkat-rpc/src/session_runtime/schedule_host.rs
+++ b/meerkat-rpc/src/session_runtime/schedule_host.rs
@@ -109,9 +109,7 @@ impl SurfaceScheduleSessionHost for RpcScheduleTargetAdapter {
         prompt_system_prompt: Option<&str>,
     ) -> Result<SessionId, ScheduleDomainError> {
         let runtime = self.upgrade_runtime()?;
-        runtime
-            .materialize_scheduled_session(create, prompt_system_prompt)
-            .await
+        Box::pin(runtime.materialize_scheduled_session(create, prompt_system_prompt)).await
     }
 
     async fn deliver_prompt(

--- a/meerkat-runtime/src/accept.rs
+++ b/meerkat-runtime/src/accept.rs
@@ -44,12 +44,22 @@ pub enum AdmissionPlan {
     },
 }
 
+/// Coarse accept flags used by the MeerkatMachine DSL's
+/// `AcceptWithCompletion` branches.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct CoarseAdmissionFlags {
+    pub request_immediate_processing: bool,
+    pub interrupt_yielding: bool,
+    pub wake_if_idle: bool,
+}
+
 /// Machine-owned resolution of an accepted input's semantic admission path.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ResolvedAdmission {
     pub policy: PolicyDecision,
     pub handling_mode: HandlingMode,
     pub admission_plan: AdmissionPlan,
+    pub coarse_flags: CoarseAdmissionFlags,
 }
 
 /// Typed reason why an input was rejected at the accept boundary.
@@ -250,11 +260,21 @@ pub fn resolve_admission(
     crate::silent_intent::apply_silent_intent_override(input, silent_intents, &mut policy);
     let handling_mode = handling_mode_from_policy(&policy);
     let admission_plan = admission_plan_from_policy(&policy, handling_mode, existing_superseded_id);
+    let request_immediate_processing = requests_immediate_processing(input);
+    let interrupt_yielding = !request_immediate_processing
+        && matches!(policy.wake_mode, crate::WakeMode::InterruptYielding);
+    let wake_if_idle =
+        !request_immediate_processing && matches!(policy.wake_mode, crate::WakeMode::WakeIfIdle);
 
     ResolvedAdmission {
         policy,
         handling_mode,
         admission_plan,
+        coarse_flags: CoarseAdmissionFlags {
+            request_immediate_processing,
+            interrupt_yielding,
+            wake_if_idle,
+        },
     }
 }
 

--- a/meerkat-runtime/src/driver/ephemeral.rs
+++ b/meerkat-runtime/src/driver/ephemeral.rs
@@ -11,7 +11,7 @@
 //! - S25 retire/reset/destroy lifecycle operations
 
 use std::collections::HashMap;
-use std::sync::{Arc, RwLock as StdRwLock};
+use std::sync::{Arc, Mutex, RwLock as StdRwLock};
 
 use chrono::Utc;
 use meerkat_core::lifecycle::{InputId, RunBoundaryReceipt, RunId};
@@ -105,6 +105,25 @@ pub struct ReplayQueuedContributorsPlan {
     pub notice_kind: &'static str,
 }
 
+#[derive(Clone)]
+pub(crate) struct EphemeralDriverRollbackSnapshot {
+    control_projection: RuntimeControlProjection,
+    dsl_state: mm_dsl::MeerkatMachineState,
+    ledger: InputLedger,
+    queue: InputQueue,
+    steer_queue: InputQueue,
+    events: Vec<RuntimeEventEnvelope>,
+    post_admission_signal: PostAdmissionSignal,
+    silent_comms_intents: Vec<String>,
+    handling_mode: HashMap<InputId, HandlingMode>,
+    is_prompt_set: std::collections::HashSet<InputId>,
+    content_shape: HashMap<InputId, ContentShape>,
+    request_id: HashMap<InputId, Option<RequestId>>,
+    reservation_key: HashMap<InputId, Option<ReservationKey>>,
+    policy_snapshot: HashMap<InputId, PolicyDecision>,
+    admission_order: Vec<InputId>,
+}
+
 /// Ephemeral runtime driver -- all state in-memory.
 #[derive(Clone)]
 pub struct EphemeralRuntimeDriver {
@@ -124,12 +143,8 @@ pub struct EphemeralRuntimeDriver {
     /// drain. `RequestImmediateProcessing` is strictly stronger than `WakeLoop`.
     post_admission_signal: PostAdmissionSignal,
     silent_comms_intents: Vec<String>,
-    /// DSL authority owning ingress semantics (queue/steer lanes, input
-    /// phases, admission ordering). The per-session DSL used by the dispatch
-    /// layer is a separate instance — this driver-local DSL carries the
-    /// mechanical state needed by the queue projections and readers. Both
-    /// are driven by the same DSL transitions and stay in step because the
-    /// shell is now just a reader, not a shadow authority.
+    /// Shared session-owned DSL authority for ingress semantics (queue/steer
+    /// lanes, input phases, admission ordering).
     dsl: DslAuthority,
     /// Per-input admission metadata with no DSL home (content shape,
     /// correlation IDs, policy snapshot, handling mode). These are pure
@@ -152,22 +167,32 @@ pub struct EphemeralRuntimeDriver {
 /// The generated `MeerkatMachineAuthority` does not derive `Debug`, but
 /// `EphemeralRuntimeDriver` requires `Clone` which is satisfied via the
 /// custom impl below.
-struct DslAuthority(mm_dsl::MeerkatMachineAuthority);
+pub(crate) type SharedIngressDslAuthority = Arc<Mutex<mm_dsl::MeerkatMachineAuthority>>;
+
+struct DslAuthority(SharedIngressDslAuthority);
 
 impl Clone for DslAuthority {
     fn clone(&self) -> Self {
-        Self(mm_dsl::MeerkatMachineAuthority::from_state(
-            self.0.state.clone(),
-        ))
+        Self(Arc::clone(&self.0))
     }
 }
 
-fn new_ingress_dsl_authority() -> DslAuthority {
+impl DslAuthority {
+    fn lock(&self) -> std::sync::MutexGuard<'_, mm_dsl::MeerkatMachineAuthority> {
+        self.0
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+    }
+}
+
+pub(crate) fn new_ingress_dsl_authority() -> SharedIngressDslAuthority {
     let state = mm_dsl::MeerkatMachineState {
         lifecycle_phase: mm_dsl::MeerkatPhase::Idle,
         ..mm_dsl::MeerkatMachineState::default()
     };
-    DslAuthority(mm_dsl::MeerkatMachineAuthority::from_state(state))
+    Arc::new(Mutex::new(mm_dsl::MeerkatMachineAuthority::from_state(
+        state,
+    )))
 }
 
 impl EphemeralRuntimeDriver {
@@ -194,15 +219,24 @@ impl EphemeralRuntimeDriver {
     }
 
     pub fn new(runtime_id: LogicalRuntimeId) -> Self {
-        Self::new_with_control(
+        Self::new_with_control_and_dsl(
             runtime_id,
             Arc::new(StdRwLock::new(RuntimeControlProjection::default())),
+            new_ingress_dsl_authority(),
         )
     }
 
     pub(crate) fn new_with_control(
         runtime_id: LogicalRuntimeId,
         control: Arc<StdRwLock<RuntimeControlProjection>>,
+    ) -> Self {
+        Self::new_with_control_and_dsl(runtime_id, control, new_ingress_dsl_authority())
+    }
+
+    pub(crate) fn new_with_control_and_dsl(
+        runtime_id: LogicalRuntimeId,
+        control: Arc<StdRwLock<RuntimeControlProjection>>,
+        dsl: SharedIngressDslAuthority,
     ) -> Self {
         Self {
             runtime_id,
@@ -213,7 +247,7 @@ impl EphemeralRuntimeDriver {
             events: Vec::new(),
             post_admission_signal: PostAdmissionSignal::None,
             silent_comms_intents: Vec::new(),
-            dsl: new_ingress_dsl_authority(),
+            dsl: DslAuthority(dsl),
             handling_mode: HashMap::new(),
             is_prompt_set: std::collections::HashSet::new(),
             content_shape: HashMap::new(),
@@ -222,6 +256,55 @@ impl EphemeralRuntimeDriver {
             policy_snapshot: HashMap::new(),
             admission_order: Vec::new(),
         }
+    }
+
+    pub(crate) fn rollback_snapshot(&self) -> EphemeralDriverRollbackSnapshot {
+        EphemeralDriverRollbackSnapshot {
+            control_projection: self.read_control_projection().clone(),
+            dsl_state: self.with_dsl_state(Clone::clone),
+            ledger: self.ledger.clone(),
+            queue: self.queue.clone(),
+            steer_queue: self.steer_queue.clone(),
+            events: self.events.clone(),
+            post_admission_signal: self.post_admission_signal,
+            silent_comms_intents: self.silent_comms_intents.clone(),
+            handling_mode: self.handling_mode.clone(),
+            is_prompt_set: self.is_prompt_set.clone(),
+            content_shape: self.content_shape.clone(),
+            request_id: self.request_id.clone(),
+            reservation_key: self.reservation_key.clone(),
+            policy_snapshot: self.policy_snapshot.clone(),
+            admission_order: self.admission_order.clone(),
+        }
+    }
+
+    pub(crate) fn restore_rollback_snapshot(&mut self, snapshot: EphemeralDriverRollbackSnapshot) {
+        {
+            let mut control = self.write_control_projection();
+            *control = snapshot.control_projection;
+        }
+        {
+            let mut authority = self.dsl.lock();
+            authority.state = snapshot.dsl_state;
+        }
+        self.ledger = snapshot.ledger;
+        self.queue = snapshot.queue;
+        self.steer_queue = snapshot.steer_queue;
+        self.events = snapshot.events;
+        self.post_admission_signal = snapshot.post_admission_signal;
+        self.silent_comms_intents = snapshot.silent_comms_intents;
+        self.handling_mode = snapshot.handling_mode;
+        self.is_prompt_set = snapshot.is_prompt_set;
+        self.content_shape = snapshot.content_shape;
+        self.request_id = snapshot.request_id;
+        self.reservation_key = snapshot.reservation_key;
+        self.policy_snapshot = snapshot.policy_snapshot;
+        self.admission_order = snapshot.admission_order;
+    }
+
+    #[cfg(test)]
+    pub(crate) fn shared_dsl_authority(&self) -> SharedIngressDslAuthority {
+        Arc::clone(&self.dsl.0)
     }
 
     /// Apply a DSL input locally, mapping any rejection into a driver error.
@@ -238,10 +321,12 @@ impl EphemeralRuntimeDriver {
         input: mm_dsl::MeerkatMachineInput,
         context: &str,
     ) -> Result<(), RuntimeDriverError> {
-        let transition =
-            mm_dsl::MeerkatMachineMutator::apply(&mut self.dsl.0, input).map_err(|err| {
+        let transition = {
+            let mut authority = self.dsl.lock();
+            mm_dsl::MeerkatMachineMutator::apply(&mut *authority, input).map_err(|err| {
                 RuntimeDriverError::Internal(format!("DSL rejected {context}: {err:?}"))
-            })?;
+            })?
+        };
         self.absorb_dsl_effects(&transition.effects);
         Ok(())
     }
@@ -268,8 +353,28 @@ impl EphemeralRuntimeDriver {
         }
     }
 
+    pub(crate) fn absorb_post_admission_effects(
+        &mut self,
+        effects: &[mm_dsl::MeerkatMachineEffect],
+    ) {
+        self.absorb_dsl_effects(effects);
+    }
+
     fn dsl_key(input_id: &InputId) -> String {
         input_id.to_string()
+    }
+
+    fn with_dsl_state<R>(&self, body: impl FnOnce(&mm_dsl::MeerkatMachineState) -> R) -> R {
+        let authority = self.dsl.lock();
+        body(&authority.state)
+    }
+
+    fn with_dsl_state_mut<R>(
+        &mut self,
+        body: impl FnOnce(&mut mm_dsl::MeerkatMachineState) -> R,
+    ) -> R {
+        let mut authority = self.dsl.lock();
+        body(&mut authority.state)
     }
 
     /// Read the current queue lane (FIFO) in admission order, as tracked by
@@ -283,23 +388,21 @@ impl EphemeralRuntimeDriver {
     }
 
     fn lane_in_admission_order(&self, lane: mm_dsl::InputLane) -> Vec<InputId> {
-        let mut candidates: Vec<(u64, InputId)> = self
-            .admission_order
-            .iter()
-            .filter(|id| self.dsl.0.state.input_lane.get(&Self::dsl_key(id)).copied() == Some(lane))
-            .cloned()
-            .map(|id| {
-                let seq = self
-                    .dsl
-                    .0
-                    .state
-                    .input_admission_seq
-                    .get(&Self::dsl_key(&id))
-                    .copied()
-                    .unwrap_or(u64::MAX);
-                (seq, id)
-            })
-            .collect();
+        let mut candidates: Vec<(u64, InputId)> = self.with_dsl_state(|state| {
+            self.admission_order
+                .iter()
+                .filter(|id| state.input_lane.get(&Self::dsl_key(id)).copied() == Some(lane))
+                .cloned()
+                .map(|id| {
+                    let seq = state
+                        .input_admission_seq
+                        .get(&Self::dsl_key(&id))
+                        .copied()
+                        .unwrap_or(u64::MAX);
+                    (seq, id)
+                })
+                .collect()
+        });
         candidates.sort_by_key(|(seq, _)| *seq);
         candidates.into_iter().map(|(_, id)| id).collect()
     }
@@ -311,7 +414,7 @@ impl EphemeralRuntimeDriver {
     /// post-GC).
     pub fn input_phase(&self, input_id: &InputId) -> Option<InputLifecycleState> {
         let key = Self::dsl_key(input_id);
-        let phase = self.dsl.0.state.input_phases.get(&key).copied()?;
+        let phase = self.with_dsl_state(|state| state.input_phases.get(&key).copied())?;
         Some(Self::input_phase_to_lifecycle(phase))
     }
 
@@ -337,49 +440,52 @@ impl EphemeralRuntimeDriver {
     /// Read the run association an input was last staged for, from the DSL.
     pub fn input_last_run_id(&self, input_id: &InputId) -> Option<RunId> {
         let key = Self::dsl_key(input_id);
-        let raw = self.dsl.0.state.input_run_associations.get(&key)?;
+        let raw = self.with_dsl_state(|state| state.input_run_associations.get(&key).cloned())?;
         raw.parse::<uuid::Uuid>().ok().map(RunId::from_uuid)
     }
 
     /// Read the committed boundary sequence for an input, from the DSL.
     pub fn input_last_boundary_sequence(&self, input_id: &InputId) -> Option<u64> {
         let key = Self::dsl_key(input_id);
-        self.dsl.0.state.input_boundary_sequences.get(&key).copied()
+        self.with_dsl_state(|state| state.input_boundary_sequences.get(&key).copied())
     }
 
     /// Read the typed terminal outcome for an input, reconstructed from the
     /// DSL's typed terminal metadata maps.
     pub fn input_terminal_outcome(&self, input_id: &InputId) -> Option<InputTerminalOutcome> {
         let key = Self::dsl_key(input_id);
-        let kind = self.dsl.0.state.input_terminal_kind.get(&key).copied()?;
+        let kind = self.with_dsl_state(|state| state.input_terminal_kind.get(&key).copied())?;
         match kind {
             mm_dsl::InputTerminalKind::Consumed => Some(InputTerminalOutcome::Consumed),
             mm_dsl::InputTerminalKind::Superseded => {
-                let raw = self.dsl.0.state.input_superseded_by.get(&key)?;
+                let raw =
+                    self.with_dsl_state(|state| state.input_superseded_by.get(&key).cloned())?;
                 let id = raw.parse::<uuid::Uuid>().ok().map(InputId::from_uuid)?;
                 Some(InputTerminalOutcome::Superseded { superseded_by: id })
             }
             mm_dsl::InputTerminalKind::Coalesced => {
-                let raw = self.dsl.0.state.input_aggregate_id.get(&key)?;
+                let raw =
+                    self.with_dsl_state(|state| state.input_aggregate_id.get(&key).cloned())?;
                 let id = raw.parse::<uuid::Uuid>().ok().map(InputId::from_uuid)?;
                 Some(InputTerminalOutcome::Coalesced { aggregate_id: id })
             }
             mm_dsl::InputTerminalKind::Abandoned => {
-                let reason = match self.dsl.0.state.input_abandon_reason.get(&key).copied()? {
+                let reason = match self
+                    .with_dsl_state(|state| state.input_abandon_reason.get(&key).copied())?
+                {
                     mm_dsl::InputAbandonReason::Retired => InputAbandonReason::Retired,
                     mm_dsl::InputAbandonReason::Reset => InputAbandonReason::Reset,
                     mm_dsl::InputAbandonReason::Stopped => InputAbandonReason::Stopped,
                     mm_dsl::InputAbandonReason::Destroyed => InputAbandonReason::Destroyed,
                     mm_dsl::InputAbandonReason::Cancelled => InputAbandonReason::Cancelled,
                     mm_dsl::InputAbandonReason::MaxAttemptsExhausted => {
-                        let attempts = self
-                            .dsl
-                            .0
-                            .state
-                            .input_abandon_attempt_count
-                            .get(&key)
-                            .copied()
-                            .unwrap_or(0) as u32;
+                        let attempts = self.with_dsl_state(|state| {
+                            state
+                                .input_abandon_attempt_count
+                                .get(&key)
+                                .copied()
+                                .unwrap_or(0)
+                        }) as u32;
                         InputAbandonReason::MaxAttemptsExhausted { attempts }
                     }
                 };
@@ -391,13 +497,8 @@ impl EphemeralRuntimeDriver {
     /// Read the attempt count for an input from the DSL.
     pub fn input_attempt_count(&self, input_id: &InputId) -> u32 {
         let key = Self::dsl_key(input_id);
-        self.dsl
-            .0
-            .state
-            .input_attempt_counts
-            .get(&key)
-            .copied()
-            .unwrap_or(0) as u32
+        self.with_dsl_state(|state| state.input_attempt_counts.get(&key).copied().unwrap_or(0))
+            as u32
     }
 
     // ---- Admission metadata accessors (read-only) ----
@@ -609,130 +710,124 @@ impl EphemeralRuntimeDriver {
             request_id,
             reservation_key,
         );
-        self.dsl
-            .0
-            .state
-            .input_phases
-            .insert(key.clone(), Self::lifecycle_to_input_phase(lifecycle_state));
+        self.with_dsl_state_mut(|state| {
+            state
+                .input_phases
+                .insert(key.clone(), Self::lifecycle_to_input_phase(lifecycle_state));
+        });
         match recovered_seed.terminal_outcome.clone() {
             Some(InputTerminalOutcome::Consumed) => {
-                self.dsl
-                    .0
-                    .state
-                    .input_terminal_kind
-                    .insert(key.clone(), mm_dsl::InputTerminalKind::Consumed);
-                self.dsl.0.state.input_superseded_by.remove(&key);
-                self.dsl.0.state.input_aggregate_id.remove(&key);
-                self.dsl.0.state.input_abandon_reason.remove(&key);
-                self.dsl.0.state.input_abandon_attempt_count.remove(&key);
+                self.with_dsl_state_mut(|state| {
+                    state
+                        .input_terminal_kind
+                        .insert(key.clone(), mm_dsl::InputTerminalKind::Consumed);
+                    state.input_superseded_by.remove(&key);
+                    state.input_aggregate_id.remove(&key);
+                    state.input_abandon_reason.remove(&key);
+                    state.input_abandon_attempt_count.remove(&key);
+                });
             }
             Some(InputTerminalOutcome::Superseded { superseded_by }) => {
-                self.dsl
-                    .0
-                    .state
-                    .input_terminal_kind
-                    .insert(key.clone(), mm_dsl::InputTerminalKind::Superseded);
-                self.dsl
-                    .0
-                    .state
-                    .input_superseded_by
-                    .insert(key.clone(), superseded_by.to_string());
-                self.dsl.0.state.input_aggregate_id.remove(&key);
-                self.dsl.0.state.input_abandon_reason.remove(&key);
-                self.dsl.0.state.input_abandon_attempt_count.remove(&key);
+                self.with_dsl_state_mut(|state| {
+                    state
+                        .input_terminal_kind
+                        .insert(key.clone(), mm_dsl::InputTerminalKind::Superseded);
+                    state
+                        .input_superseded_by
+                        .insert(key.clone(), superseded_by.to_string());
+                    state.input_aggregate_id.remove(&key);
+                    state.input_abandon_reason.remove(&key);
+                    state.input_abandon_attempt_count.remove(&key);
+                });
             }
             Some(InputTerminalOutcome::Coalesced { aggregate_id }) => {
-                self.dsl
-                    .0
-                    .state
-                    .input_terminal_kind
-                    .insert(key.clone(), mm_dsl::InputTerminalKind::Coalesced);
-                self.dsl
-                    .0
-                    .state
-                    .input_aggregate_id
-                    .insert(key.clone(), aggregate_id.to_string());
-                self.dsl.0.state.input_superseded_by.remove(&key);
-                self.dsl.0.state.input_abandon_reason.remove(&key);
-                self.dsl.0.state.input_abandon_attempt_count.remove(&key);
+                self.with_dsl_state_mut(|state| {
+                    state
+                        .input_terminal_kind
+                        .insert(key.clone(), mm_dsl::InputTerminalKind::Coalesced);
+                    state
+                        .input_aggregate_id
+                        .insert(key.clone(), aggregate_id.to_string());
+                    state.input_superseded_by.remove(&key);
+                    state.input_abandon_reason.remove(&key);
+                    state.input_abandon_attempt_count.remove(&key);
+                });
             }
             Some(InputTerminalOutcome::Abandoned { reason }) => {
-                self.dsl
-                    .0
-                    .state
-                    .input_terminal_kind
-                    .insert(key.clone(), mm_dsl::InputTerminalKind::Abandoned);
-                self.dsl
-                    .0
-                    .state
-                    .input_abandon_reason
-                    .insert(key.clone(), mm_dsl::InputAbandonReason::from(&reason));
-                self.dsl
-                    .0
-                    .state
-                    .input_abandon_attempt_count
-                    .insert(key.clone(), u64::from(recovered_seed.attempt_count));
-                self.dsl.0.state.input_superseded_by.remove(&key);
-                self.dsl.0.state.input_aggregate_id.remove(&key);
+                self.with_dsl_state_mut(|state| {
+                    state
+                        .input_terminal_kind
+                        .insert(key.clone(), mm_dsl::InputTerminalKind::Abandoned);
+                    state
+                        .input_abandon_reason
+                        .insert(key.clone(), mm_dsl::InputAbandonReason::from(&reason));
+                    state
+                        .input_abandon_attempt_count
+                        .insert(key.clone(), u64::from(recovered_seed.attempt_count));
+                    state.input_superseded_by.remove(&key);
+                    state.input_aggregate_id.remove(&key);
+                });
             }
             None => {
-                self.dsl.0.state.input_terminal_kind.remove(&key);
-                self.dsl.0.state.input_superseded_by.remove(&key);
-                self.dsl.0.state.input_aggregate_id.remove(&key);
-                self.dsl.0.state.input_abandon_reason.remove(&key);
-                self.dsl.0.state.input_abandon_attempt_count.remove(&key);
+                self.with_dsl_state_mut(|state| {
+                    state.input_terminal_kind.remove(&key);
+                    state.input_superseded_by.remove(&key);
+                    state.input_aggregate_id.remove(&key);
+                    state.input_abandon_reason.remove(&key);
+                    state.input_abandon_attempt_count.remove(&key);
+                });
             }
         }
-        self.dsl
-            .0
-            .state
-            .input_attempt_counts
-            .insert(key.clone(), u64::from(recovered_seed.attempt_count));
+        self.with_dsl_state_mut(|state| {
+            state
+                .input_attempt_counts
+                .insert(key.clone(), u64::from(recovered_seed.attempt_count));
+        });
         match recovered_seed.last_run_id.clone() {
             Some(run_id) => {
-                self.dsl
-                    .0
-                    .state
-                    .input_run_associations
-                    .insert(key.clone(), run_id.to_string());
+                self.with_dsl_state_mut(|state| {
+                    state
+                        .input_run_associations
+                        .insert(key.clone(), run_id.to_string());
+                });
             }
             None => {
-                self.dsl.0.state.input_run_associations.remove(&key);
+                self.with_dsl_state_mut(|state| {
+                    state.input_run_associations.remove(&key);
+                });
             }
         }
         match recovered_seed.last_boundary_sequence {
             Some(seq) => {
-                self.dsl
-                    .0
-                    .state
-                    .input_boundary_sequences
-                    .insert(key.clone(), seq);
+                self.with_dsl_state_mut(|state| {
+                    state.input_boundary_sequences.insert(key.clone(), seq);
+                });
             }
             None => {
-                self.dsl.0.state.input_boundary_sequences.remove(&key);
+                self.with_dsl_state_mut(|state| {
+                    state.input_boundary_sequences.remove(&key);
+                });
             }
         }
-        if !self.dsl.0.state.input_admission_seq.contains_key(&key) {
-            let seq = self.dsl.0.state.next_admission_seq;
-            self.dsl
-                .0
-                .state
-                .input_admission_seq
-                .insert(key.clone(), seq);
-            self.dsl.0.state.next_admission_seq = seq.saturating_add(1);
-        }
+        self.with_dsl_state_mut(|state| {
+            if !state.input_admission_seq.contains_key(&key) {
+                let seq = state.next_admission_seq;
+                state.input_admission_seq.insert(key.clone(), seq);
+                state.next_admission_seq = seq.saturating_add(1);
+            }
+        });
         // Recovery seeding is a direct DSL-state write from the persisted
         // snapshot by design — there are no transitions to replay. Only
         // Queued inputs carry lane membership; staged/terminal inputs are
         // not in any work lane.
-        self.dsl.0.state.input_lane.remove(&key);
-        if matches!(lifecycle_state, InputLifecycleState::Queued) {
-            self.dsl
-                .0
-                .state
-                .input_lane
-                .insert(key, mm_dsl::InputLane::from(handling_mode));
-        }
+        self.with_dsl_state_mut(|state| {
+            state.input_lane.remove(&key);
+            if matches!(lifecycle_state, InputLifecycleState::Queued) {
+                state
+                    .input_lane
+                    .insert(key, mm_dsl::InputLane::from(handling_mode));
+            }
+        });
     }
 
     #[allow(clippy::too_many_arguments)]
@@ -920,20 +1015,17 @@ impl EphemeralRuntimeDriver {
                 let key = Self::dsl_key(input_id);
                 // Priority routing: reassign the admission sequence so this
                 // input sorts ahead of existing entries in the lane.
-                let min_seq = self
-                    .dsl
-                    .0
-                    .state
-                    .input_admission_seq
-                    .values()
-                    .min()
-                    .copied()
-                    .unwrap_or(0);
-                self.dsl
-                    .0
-                    .state
-                    .input_admission_seq
-                    .insert(key.clone(), min_seq.saturating_sub(1));
+                self.with_dsl_state_mut(|state| {
+                    let min_seq = state
+                        .input_admission_seq
+                        .values()
+                        .min()
+                        .copied()
+                        .unwrap_or(0);
+                    state
+                        .input_admission_seq
+                        .insert(key.clone(), min_seq.saturating_sub(1));
+                });
                 let target_lane = mm_dsl::InputLane::from(target);
                 if target_lane != admission_lane {
                     self.dsl_apply(
@@ -1073,17 +1165,17 @@ impl EphemeralRuntimeDriver {
 
     pub fn has_queued_input(&self, input_id: &InputId) -> bool {
         let key = Self::dsl_key(input_id);
-        self.dsl.0.state.input_lane.contains_key(&key)
+        self.with_dsl_state(|state| state.input_lane.contains_key(&key))
     }
     pub fn has_queued_input_outside(&self, excluded: &[InputId]) -> bool {
         let excluded_keys: std::collections::HashSet<String> =
             excluded.iter().map(Self::dsl_key).collect();
-        self.dsl
-            .0
-            .state
-            .input_lane
-            .keys()
-            .any(|queued_key| !excluded_keys.contains(queued_key))
+        self.with_dsl_state(|state| {
+            state
+                .input_lane
+                .keys()
+                .any(|queued_key| !excluded_keys.contains(queued_key))
+        })
     }
     fn existing_superseded_input(
         &self,
@@ -1472,6 +1564,9 @@ impl EphemeralRuntimeDriver {
 
     pub(crate) fn destroy_cleanup(&mut self) -> usize {
         let abandoned = self.abandon_all_non_terminal(InputAbandonReason::Destroyed);
+        self.queue.drain();
+        self.steer_queue.drain();
+        self.post_admission_signal = PostAdmissionSignal::None;
         self.silent_comms_intents.clear();
         self.rebuild_queue_projections();
         self.debug_assert_queue_projection_alignment();
@@ -1563,6 +1658,173 @@ impl EphemeralRuntimeDriver {
             causation_id: None,
             correlation_id: None,
         }
+    }
+
+    pub(crate) fn resolve_admission(&self, input: &Input) -> crate::accept::ResolvedAdmission {
+        let runtime_idle = self.read_control_projection().phase.is_idle_or_attached();
+        let existing_superseded_id = self.existing_superseded_input(input).map(|(id, _)| id);
+        crate::accept::resolve_admission(
+            input,
+            runtime_idle,
+            &self.silent_comms_intents,
+            existing_superseded_id,
+        )
+    }
+
+    pub(crate) async fn accept_resolved_input(
+        &mut self,
+        input: Input,
+        resolved: crate::accept::ResolvedAdmission,
+    ) -> Result<AcceptOutcome, RuntimeDriverError> {
+        match self.read_control_projection().phase {
+            RuntimeState::Retired | RuntimeState::Stopped => {
+                return Err(RuntimeDriverError::NotReady {
+                    state: self.read_control_projection().phase,
+                });
+            }
+            RuntimeState::Destroyed => return Err(RuntimeDriverError::Destroyed),
+            RuntimeState::Initializing
+            | RuntimeState::Idle
+            | RuntimeState::Attached
+            | RuntimeState::Running => {}
+        }
+
+        if let Err(e) = validate_durability(&input) {
+            match e {
+                DurabilityError::DerivedForbidden { .. }
+                | DurabilityError::ExternalDerivedForbidden => {
+                    return Ok(AcceptOutcome::Rejected {
+                        reason: crate::accept::RejectReason::DurabilityViolation {
+                            detail: e.to_string(),
+                        },
+                    });
+                }
+            }
+        }
+        if let Err(e) = crate::peer_handling_mode::validate_peer_handling_mode(&input) {
+            return Ok(AcceptOutcome::Rejected {
+                reason: crate::accept::RejectReason::PeerHandlingModeInvalid {
+                    detail: e.to_string(),
+                },
+            });
+        }
+
+        let input_id = input.id().clone();
+        let mut state = InputState::new_accepted(input_id.clone());
+        state.durability = Some(input.header().durability);
+        state.idempotency_key = input.header().idempotency_key.clone();
+        if let Some(ref key) = input.header().idempotency_key {
+            if let Some(existing_id) = self
+                .ledger
+                .accept_with_idempotency(state.clone(), key.clone())
+            {
+                tracing::debug!(
+                    work_id = ?input_id,
+                    existing_id = ?existing_id,
+                    "input deduplicated"
+                );
+                self.emit_event(RuntimeEvent::InputLifecycle(
+                    InputLifecycleEvent::Deduplicated {
+                        input_id: input_id.clone(),
+                        existing_id: existing_id.clone(),
+                    },
+                ));
+                return Ok(AcceptOutcome::Deduplicated {
+                    input_id,
+                    existing_id,
+                });
+            }
+        } else {
+            self.ledger.accept(state.clone());
+        }
+
+        if let Some(s) = self.ledger.get_mut(&input_id) {
+            s.policy = Some(PolicySnapshot {
+                version: resolved.policy.policy_version,
+                decision: resolved.policy.clone(),
+            });
+        }
+        self.emit_event(RuntimeEvent::InputLifecycle(
+            InputLifecycleEvent::Accepted {
+                input_id: input_id.clone(),
+            },
+        ));
+
+        let runtime_idle = self.read_control_projection().phase.is_idle_or_attached();
+        let handling_mode = resolved.handling_mode;
+        let content_shape = ContentShape(input.kind_id().to_string());
+        let is_prompt = matches!(input, Input::Prompt(_));
+        match resolved.admission_plan {
+            AdmissionPlan::ConsumedOnAccept => {
+                self.record_admission_metadata(
+                    &input_id,
+                    &content_shape,
+                    handling_mode,
+                    is_prompt,
+                    &resolved.policy,
+                    None,
+                    None,
+                );
+                self.dsl_apply(
+                    mm_dsl::MeerkatMachineInput::QueueAccepted {
+                        input_id: Self::dsl_key(&input_id),
+                    },
+                    "QueueAccepted(consumed_on_accept)",
+                )?;
+                self.dsl_apply(
+                    mm_dsl::MeerkatMachineInput::ConsumeOnAccept {
+                        input_id: Self::dsl_key(&input_id),
+                    },
+                    "ConsumeOnAccept",
+                )?;
+                let now = Utc::now();
+                if let Some(s) = self.ledger.get_mut(&input_id) {
+                    s.history.push(InputStateHistoryEntry {
+                        timestamp: now,
+                        from: InputLifecycleState::Accepted,
+                        to: InputLifecycleState::Consumed,
+                        reason: Some("ConsumeOnAccept (Ignore+OnAccept)".into()),
+                    });
+                    s.terminal_outcome = Some(InputTerminalOutcome::Consumed);
+                    s.updated_at = now;
+                }
+                tracing::debug!(work_id = ?input_id, "input consumed on accept");
+            }
+            AdmissionPlan::Queued {
+                persist_and_queue,
+                queue_action,
+                existing_action,
+            } => {
+                if persist_and_queue {
+                    self.apply_persist_and_queue(
+                        &input_id,
+                        &input,
+                        &content_shape,
+                        handling_mode,
+                        is_prompt,
+                        &resolved.policy,
+                        queue_action,
+                        existing_action.as_ref(),
+                    )?;
+                }
+            }
+        }
+        self.rebuild_queue_projections();
+        self.debug_assert_queue_projection_alignment();
+
+        if !runtime_idle
+            && matches!(resolved.policy.wake_mode, crate::WakeMode::WakeIfIdle)
+            && PostAdmissionSignal::WakeLoop > self.post_admission_signal
+        {
+            self.post_admission_signal = PostAdmissionSignal::WakeLoop;
+        }
+
+        let final_state = self.ledger.get(&input_id).cloned().unwrap_or(state);
+        Ok(AcceptOutcome::Accepted {
+            input_id,
+            policy: resolved.policy,
+            state: final_state,
+        })
     }
 
     pub fn abandon_all_non_terminal(&mut self, reason: InputAbandonReason) -> usize {
@@ -1718,7 +1980,7 @@ impl EphemeralRuntimeDriver {
 
         for input_id in &receipt.contributing_input_ids {
             let key = Self::dsl_key(input_id);
-            if !self.dsl.0.state.input_phases.contains_key(&key) {
+            if !self.with_dsl_state(|state| state.input_phases.contains_key(&key)) {
                 continue;
             }
             // The matches_last_run guard on the DSL / shell is enforced by
@@ -1783,195 +2045,8 @@ impl EphemeralRuntimeDriver {
 #[cfg_attr(target_arch = "wasm32", async_trait::async_trait(?Send))]
 impl crate::traits::RuntimeDriver for EphemeralRuntimeDriver {
     async fn accept_input(&mut self, input: Input) -> Result<AcceptOutcome, RuntimeDriverError> {
-        match self.runtime_state() {
-            RuntimeState::Retired | RuntimeState::Stopped => {
-                return Err(RuntimeDriverError::NotReady {
-                    state: self.runtime_state(),
-                });
-            }
-            RuntimeState::Destroyed => return Err(RuntimeDriverError::Destroyed),
-            RuntimeState::Initializing
-            | RuntimeState::Idle
-            | RuntimeState::Attached
-            | RuntimeState::Running => {}
-        }
-
-        if let Err(e) = validate_durability(&input) {
-            match e {
-                DurabilityError::DerivedForbidden { .. }
-                | DurabilityError::ExternalDerivedForbidden => {
-                    return Ok(AcceptOutcome::Rejected {
-                        reason: crate::accept::RejectReason::DurabilityViolation {
-                            detail: e.to_string(),
-                        },
-                    });
-                }
-            }
-        }
-        if let Err(e) = crate::peer_handling_mode::validate_peer_handling_mode(&input) {
-            return Ok(AcceptOutcome::Rejected {
-                reason: crate::accept::RejectReason::PeerHandlingModeInvalid {
-                    detail: e.to_string(),
-                },
-            });
-        }
-        let input_id = input.id().clone();
-        let mut state = InputState::new_accepted(input_id.clone());
-        state.durability = Some(input.header().durability);
-        state.idempotency_key = input.header().idempotency_key.clone();
-        if let Some(ref key) = input.header().idempotency_key {
-            if let Some(existing_id) = self
-                .ledger
-                .accept_with_idempotency(state.clone(), key.clone())
-            {
-                // Dedup is a pure observational outcome — emit the lifecycle
-                // event and return. No DSL mutation fires because the new
-                // input never enters the admission pipeline.
-                tracing::debug!(
-                    work_id = ?input_id,
-                    existing_id = ?existing_id,
-                    "input deduplicated"
-                );
-                self.emit_event(RuntimeEvent::InputLifecycle(
-                    InputLifecycleEvent::Deduplicated {
-                        input_id: input_id.clone(),
-                        existing_id: existing_id.clone(),
-                    },
-                ));
-                return Ok(AcceptOutcome::Deduplicated {
-                    input_id,
-                    existing_id,
-                });
-            }
-        } else {
-            self.ledger.accept(state.clone());
-        }
-        let runtime_idle = self.runtime_state().is_idle_or_attached();
-        let existing_superseded_id = self.existing_superseded_input(&input).map(|(id, _)| id);
-        let resolved = crate::accept::resolve_admission(
-            &input,
-            runtime_idle,
-            &self.silent_comms_intents,
-            existing_superseded_id,
-        );
-        if let Some(s) = self.ledger.get_mut(&input_id) {
-            s.policy = Some(PolicySnapshot {
-                version: resolved.policy.policy_version,
-                decision: resolved.policy.clone(),
-            });
-        }
-        self.emit_event(RuntimeEvent::InputLifecycle(
-            InputLifecycleEvent::Accepted {
-                input_id: input_id.clone(),
-            },
-        ));
-
-        // Machine-owned admission plan. The checked-in admission plan
-        // decides the semantic path (consume-on-accept, queue, priority,
-        // coalesce, supersede); the driver applies the plan directly via
-        // DSL transitions and shell mechanics.
-        let handling_mode = resolved.handling_mode;
-        let content_shape = ContentShape(input.kind_id().to_string());
-        let is_prompt = matches!(input, Input::Prompt(_));
-        match resolved.admission_plan {
-            AdmissionPlan::ConsumedOnAccept => {
-                self.record_admission_metadata(
-                    &input_id,
-                    &content_shape,
-                    handling_mode,
-                    is_prompt,
-                    &resolved.policy,
-                    None,
-                    None,
-                );
-                self.dsl_apply(
-                    mm_dsl::MeerkatMachineInput::QueueAccepted {
-                        input_id: Self::dsl_key(&input_id),
-                    },
-                    "QueueAccepted(consumed_on_accept)",
-                )?;
-                self.dsl_apply(
-                    mm_dsl::MeerkatMachineInput::ConsumeOnAccept {
-                        input_id: Self::dsl_key(&input_id),
-                    },
-                    "ConsumeOnAccept",
-                )?;
-                let now = Utc::now();
-                if let Some(s) = self.ledger.get_mut(&input_id) {
-                    s.history.push(InputStateHistoryEntry {
-                        timestamp: now,
-                        from: InputLifecycleState::Accepted,
-                        to: InputLifecycleState::Consumed,
-                        reason: Some("ConsumeOnAccept (Ignore+OnAccept)".into()),
-                    });
-                    s.terminal_outcome = Some(InputTerminalOutcome::Consumed);
-                    s.updated_at = now;
-                }
-                tracing::debug!(work_id = ?input_id, "input consumed on accept");
-            }
-            AdmissionPlan::Queued {
-                persist_and_queue,
-                queue_action,
-                existing_action,
-            } => {
-                if persist_and_queue {
-                    self.apply_persist_and_queue(
-                        &input_id,
-                        &input,
-                        &content_shape,
-                        handling_mode,
-                        is_prompt,
-                        &resolved.policy,
-                        queue_action,
-                        existing_action.as_ref(),
-                    )?;
-                }
-            }
-        }
-        self.rebuild_queue_projections();
-        self.debug_assert_queue_projection_alignment();
-
-        // Driver-side projection of the machine-owned admission signal.
-        //
-        // Long-form intent: the MeerkatMachine DSL's `AcceptWithCompletion`
-        // transitions are the canonical authority for the typed admission
-        // signal (WakeLoop / InterruptYielding / RequestImmediateProcessing).
-        // In production that transition runs on the machine's per-session
-        // DSL authority in `dispatch_ingress::stage_session_dsl_input`,
-        // where `session_id` / `lifecycle_phase` are kept in sync with the
-        // control projection. The driver's *local* DSL authority is a
-        // parallel copy whose `session_id` / `lifecycle_phase` are not
-        // synchronized from `contract_set_control_projection`, so firing
-        // `AcceptWithCompletion` on the driver-local DSL in this path
-        // silently rejects on the `session_registered` / phase guards.
-        //
-        // Until the two DSL authorities collapse into one (the right
-        // architectural endpoint, but a separate PR), mirror the policy
-        // decision directly into the driver-owned accumulator so
-        // `take_post_admission_signal` / `take_wake_requested` observe the
-        // same signal the DSL would have emitted:
-        //   - Idle runtime: the outcome-side signal is the authority and
-        //     the caller wakes the loop themselves; the driver stores
-        //     nothing.
-        //   - Running + `WakeIfIdle`: accumulate `WakeLoop` so the loop's
-        //     next idle re-check fires.
-        //   - `InterruptYielding` is a right-now cooperative interrupt,
-        //     not persisted for later — dropping it if missed is correct.
-        //
-        // Monotonic; never demote a stronger signal already set elsewhere.
-        if !runtime_idle
-            && matches!(resolved.policy.wake_mode, crate::WakeMode::WakeIfIdle)
-            && PostAdmissionSignal::WakeLoop > self.post_admission_signal
-        {
-            self.post_admission_signal = PostAdmissionSignal::WakeLoop;
-        }
-
-        let final_state = self.ledger.get(&input_id).cloned().unwrap_or_else(|| state);
-        Ok(AcceptOutcome::Accepted {
-            input_id,
-            policy: resolved.policy,
-            state: final_state,
-        })
+        let resolved = self.resolve_admission(&input);
+        self.accept_resolved_input(input, resolved).await
     }
 
     async fn on_runtime_event(

--- a/meerkat-runtime/src/driver/persistent.rs
+++ b/meerkat-runtime/src/driver/persistent.rs
@@ -19,7 +19,7 @@ use crate::runtime_state::RuntimeState;
 use crate::store::RuntimeStore;
 use crate::traits::{DestroyReport, RecoveryReport, RuntimeDriver, RuntimeDriverError};
 
-use super::ephemeral::EphemeralRuntimeDriver;
+use super::ephemeral::{EphemeralRuntimeDriver, SharedIngressDslAuthority};
 
 /// Persistent runtime driver — durable InputState via RuntimeStore.
 pub struct PersistentRuntimeDriver {
@@ -47,6 +47,7 @@ impl PersistentRuntimeDriver {
             Arc::new(StdRwLock::new(
                 crate::driver::ephemeral::RuntimeControlProjection::default(),
             )),
+            crate::driver::ephemeral::new_ingress_dsl_authority(),
         )
     }
 
@@ -55,9 +56,14 @@ impl PersistentRuntimeDriver {
         store: Arc<dyn RuntimeStore>,
         blob_store: Arc<dyn BlobStore>,
         control: Arc<StdRwLock<crate::driver::ephemeral::RuntimeControlProjection>>,
+        dsl: SharedIngressDslAuthority,
     ) -> Self {
         Self {
-            inner: EphemeralRuntimeDriver::new_with_control(runtime_id.clone(), control),
+            inner: EphemeralRuntimeDriver::new_with_control_and_dsl(
+                runtime_id.clone(),
+                control,
+                dsl,
+            ),
             store,
             blob_store,
             runtime_id,
@@ -172,6 +178,55 @@ impl PersistentRuntimeDriver {
         self.inner.has_queued_input_outside(excluded)
     }
 
+    pub(crate) fn absorb_post_admission_effects(
+        &mut self,
+        effects: &[crate::meerkat_machine::dsl::MeerkatMachineEffect],
+    ) {
+        self.inner.absorb_post_admission_effects(effects);
+    }
+
+    pub(crate) fn resolve_admission(&self, input: &Input) -> crate::accept::ResolvedAdmission {
+        self.inner.resolve_admission(input)
+    }
+
+    pub(crate) async fn accept_resolved_input(
+        &mut self,
+        input: Input,
+        resolved: crate::accept::ResolvedAdmission,
+    ) -> Result<AcceptOutcome, RuntimeDriverError> {
+        let checkpoint = self.inner.rollback_snapshot();
+        let input_for_recovery = input.clone();
+
+        let mut outcome = self.inner.accept_resolved_input(input, resolved).await?;
+
+        if let AcceptOutcome::Accepted {
+            ref input_id,
+            ref mut state,
+            ..
+        } = outcome
+            && let Some(mut bundle) = self.inner.stored_input_state(input_id)
+        {
+            let mut input_for_recovery = input_for_recovery.clone();
+            if let Err(err) =
+                externalize_input_images(self.blob_store.as_ref(), &mut input_for_recovery).await
+            {
+                self.inner.restore_rollback_snapshot(checkpoint);
+                return Err(RuntimeDriverError::Internal(format!(
+                    "failed to externalize runtime input images: {err}"
+                )));
+            }
+            bundle.state.persisted_input = Some(input_for_recovery);
+            self.inner.ledger_mut().accept(bundle.state.clone());
+            if let Err(err) = self.persist_state(&bundle).await {
+                self.inner.restore_rollback_snapshot(checkpoint);
+                return Err(err);
+            }
+            *state = bundle.state;
+        }
+
+        Ok(outcome)
+    }
+
     /// Stage input (delegates to inner).
     pub fn stage_input(
         &mut self,
@@ -235,7 +290,7 @@ impl PersistentRuntimeDriver {
         &mut self,
         reason: InputAbandonReason,
     ) -> Result<usize, RuntimeDriverError> {
-        let checkpoint = self.inner.clone();
+        let checkpoint = self.inner.rollback_snapshot();
         let abandoned = self.inner.abandon_pending_inputs(reason);
         let input_states = self.inner.stored_input_states_snapshot();
         if let Err(err) = self
@@ -247,7 +302,7 @@ impl PersistentRuntimeDriver {
             )
             .await
         {
-            self.inner = checkpoint;
+            self.inner.restore_rollback_snapshot(checkpoint);
             return Err(RuntimeDriverError::Internal(format!(
                 "pending input abandon persist failed: {err}"
             )));
@@ -263,9 +318,7 @@ impl PersistentRuntimeDriver {
         &mut self,
         target_phase: RuntimeState,
     ) -> Result<usize, RuntimeDriverError> {
-        let checkpoint = self.inner.clone();
-        let silent_intents = self.inner.silent_comms_intents();
-        let control = self.inner.control_handle();
+        let checkpoint = self.inner.rollback_snapshot();
         let input_states = self.inner.stored_input_states_snapshot();
         if let Err(err) = self
             .store
@@ -276,15 +329,13 @@ impl PersistentRuntimeDriver {
             )
             .await
         {
-            self.inner = checkpoint;
+            self.inner.restore_rollback_snapshot(checkpoint);
             return Err(RuntimeDriverError::Internal(format!(
                 "recycle persist failed: {err}"
             )));
         }
 
-        self.inner = EphemeralRuntimeDriver::new_with_control(self.runtime_id.clone(), control);
-        self.inner.set_silent_comms_intents(silent_intents);
-        let _ = RuntimeDriver::recover(self).await?;
+        let _ = self.inner.recycle_preserving_work()?;
         self.inner.set_control_projection(target_phase, None, None);
         Ok(self.inner.active_input_ids().len())
     }
@@ -292,7 +343,7 @@ impl PersistentRuntimeDriver {
     pub async fn finalize_retire(
         &mut self,
     ) -> Result<crate::traits::RetireReport, RuntimeDriverError> {
-        let checkpoint = self.inner.clone();
+        let checkpoint = self.inner.rollback_snapshot();
         let report = self.inner.finalize_retire();
         let input_states = self.inner.stored_input_states_snapshot();
         if let Err(err) = self
@@ -304,7 +355,7 @@ impl PersistentRuntimeDriver {
             )
             .await
         {
-            self.inner = checkpoint;
+            self.inner.restore_rollback_snapshot(checkpoint);
             return Err(RuntimeDriverError::Internal(format!(
                 "retire persist failed: {err}"
             )));
@@ -325,7 +376,7 @@ impl PersistentRuntimeDriver {
     pub async fn finalize_reset(
         &mut self,
     ) -> Result<crate::traits::ResetReport, RuntimeDriverError> {
-        let checkpoint = self.inner.clone();
+        let checkpoint = self.inner.rollback_snapshot();
         let report = self.inner.reset_cleanup();
         let input_states = self.inner.stored_input_states_snapshot();
         if let Err(err) = self
@@ -337,7 +388,7 @@ impl PersistentRuntimeDriver {
             )
             .await
         {
-            self.inner = checkpoint;
+            self.inner.restore_rollback_snapshot(checkpoint);
             return Err(RuntimeDriverError::Internal(format!(
                 "reset persist failed: {err}"
             )));
@@ -385,7 +436,7 @@ impl PersistentRuntimeDriver {
     }
 
     pub async fn finalize_stop_runtime(&mut self) -> Result<(), RuntimeDriverError> {
-        let checkpoint = self.inner.clone();
+        let checkpoint = self.inner.rollback_snapshot();
         self.inner.stop_runtime_cleanup();
         let input_states = self.inner.stored_input_states_snapshot();
         if let Err(err) = self
@@ -397,7 +448,7 @@ impl PersistentRuntimeDriver {
             )
             .await
         {
-            self.inner = checkpoint;
+            self.inner.restore_rollback_snapshot(checkpoint);
             return Err(RuntimeDriverError::Internal(format!(
                 "stop persist failed: {err}"
             )));
@@ -429,7 +480,7 @@ impl PersistentRuntimeDriver {
         receipt: &RunBoundaryReceipt,
         session_snapshot: Option<&Vec<u8>>,
     ) -> Result<(), RuntimeDriverError> {
-        let checkpoint = self.inner.clone();
+        let checkpoint = self.inner.rollback_snapshot();
         self.inner
             .machine_realize_boundary_applied(run_id, receipt)?;
         if self
@@ -459,7 +510,7 @@ impl PersistentRuntimeDriver {
             )
             .await
             .map_err(|e| {
-                self.inner = checkpoint;
+                self.inner.restore_rollback_snapshot(checkpoint);
                 RuntimeDriverError::Internal(format!("runtime boundary commit failed: {e}"))
             })?;
         Ok(())
@@ -479,7 +530,7 @@ impl PersistentRuntimeDriver {
         run_id: &RunId,
         consumed_input_ids: &[InputId],
     ) -> Result<(), RuntimeDriverError> {
-        let checkpoint = self.inner.clone();
+        let checkpoint = self.inner.rollback_snapshot();
         self.inner
             .machine_realize_run_completed(run_id, consumed_input_ids)?;
         let input_states = self.inner.stored_input_states_snapshot();
@@ -492,7 +543,7 @@ impl PersistentRuntimeDriver {
             )
             .await
         {
-            self.inner = checkpoint;
+            self.inner.restore_rollback_snapshot(checkpoint);
             return Err(RuntimeDriverError::Internal(format!(
                 "terminal event persist failed: {err}"
             )));
@@ -526,7 +577,7 @@ impl PersistentRuntimeDriver {
         error: &str,
         recoverable: bool,
     ) -> Result<(), RuntimeDriverError> {
-        let checkpoint = self.inner.clone();
+        let checkpoint = self.inner.rollback_snapshot();
         self.inner
             .machine_realize_run_failed(run_id, contributing_input_ids, replay_plan)?;
         tracing::debug!(
@@ -545,7 +596,7 @@ impl PersistentRuntimeDriver {
             )
             .await
         {
-            self.inner = checkpoint;
+            self.inner.restore_rollback_snapshot(checkpoint);
             return Err(RuntimeDriverError::Internal(format!(
                 "terminal event persist failed: {err}"
             )));
@@ -558,39 +609,8 @@ impl PersistentRuntimeDriver {
 #[cfg_attr(target_arch = "wasm32", async_trait::async_trait(?Send))]
 impl RuntimeDriver for PersistentRuntimeDriver {
     async fn accept_input(&mut self, input: Input) -> Result<AcceptOutcome, RuntimeDriverError> {
-        let checkpoint = self.inner.clone();
-        let input_for_recovery = input.clone();
-
-        // Delegate to ephemeral for state machine logic
-        let mut outcome = self.inner.accept_input(input).await?;
-
-        // Durable-before-ack: persist InputState before returning
-        if let AcceptOutcome::Accepted {
-            ref input_id,
-            ref mut state,
-            ..
-        } = outcome
-            && let Some(mut bundle) = self.inner.stored_input_state(input_id)
-        {
-            let mut input_for_recovery = input_for_recovery.clone();
-            if let Err(err) =
-                externalize_input_images(self.blob_store.as_ref(), &mut input_for_recovery).await
-            {
-                self.inner = checkpoint;
-                return Err(RuntimeDriverError::Internal(format!(
-                    "failed to externalize runtime input images: {err}"
-                )));
-            }
-            bundle.state.persisted_input = Some(input_for_recovery);
-            self.inner.ledger_mut().accept(bundle.state.clone());
-            if let Err(err) = self.persist_state(&bundle).await {
-                self.inner = checkpoint;
-                return Err(err);
-            }
-            *state = bundle.state;
-        }
-
-        Ok(outcome)
+        let resolved = self.resolve_admission(&input);
+        self.accept_resolved_input(input, resolved).await
     }
 
     async fn on_runtime_event(

--- a/meerkat-runtime/src/meerkat_machine/dispatch_control.rs
+++ b/meerkat-runtime/src/meerkat_machine/dispatch_control.rs
@@ -46,11 +46,30 @@ impl MeerkatMachine {
                     }
                 };
 
-                let request_immediate_processing =
-                    crate::accept::requests_immediate_processing(&input);
                 let (outcome, signal) = {
                     let mut drv = driver.lock().await;
-                    let result = match drv.as_driver_mut().accept_input(input).await {
+                    let resolved = drv.resolve_admission(&input);
+                    let preview_run_id = RunId::new();
+                    self.preview_session_dsl_input(
+                        &session_id,
+                        crate::meerkat_machine::dsl::MeerkatMachineInput::AcceptWithCompletion {
+                            input_id: crate::meerkat_machine::dsl::InputId::from_domain(
+                                &InputId::new(),
+                            ),
+                            request_immediate_processing: resolved
+                                .coarse_flags
+                                .request_immediate_processing,
+                            interrupt_yielding: resolved.coarse_flags.interrupt_yielding,
+                            wake_if_idle: resolved.coarse_flags.wake_if_idle,
+                            run_id: crate::meerkat_machine::dsl::RunId::from_domain(
+                                &preview_run_id,
+                            ),
+                        },
+                        "AcceptWithCompletion(Ingest)",
+                    )
+                    .await
+                    .map_err(RuntimeControlPlaneError::Internal)?;
+                    let result = match drv.accept_resolved_input(input, resolved.clone()).await {
                         Ok(result) => result,
                         Err(err) => {
                             drop(drv);
@@ -59,8 +78,35 @@ impl MeerkatMachine {
                             return Err(RuntimeControlPlaneError::Internal(err.to_string()));
                         }
                     };
-                    let signal =
-                        Self::machine_owned_admission_signal(&result, request_immediate_processing);
+                    let signal = match &result {
+                        AcceptOutcome::Accepted { input_id, .. } => {
+                            let (_, effects) = self
+                                .apply_session_dsl_input(
+                                    &session_id,
+                                    crate::meerkat_machine::dsl::MeerkatMachineInput::AcceptWithCompletion {
+                                        input_id: crate::meerkat_machine::dsl::InputId::from_domain(
+                                            input_id,
+                                        ),
+                                        request_immediate_processing: resolved
+                                            .coarse_flags
+                                            .request_immediate_processing,
+                                        interrupt_yielding: resolved.coarse_flags.interrupt_yielding,
+                                        wake_if_idle: resolved.coarse_flags.wake_if_idle,
+                                        run_id: crate::meerkat_machine::dsl::RunId::from_domain(
+                                            &preview_run_id,
+                                        ),
+                                    },
+                                    "AcceptWithCompletion(Ingest)",
+                                )
+                                .await
+                                .map_err(RuntimeControlPlaneError::Internal)?;
+                            drv.absorb_post_admission_effects(&effects);
+                            Self::post_admission_signal_from_effects(&effects)
+                        }
+                        AcceptOutcome::Deduplicated { .. } | AcceptOutcome::Rejected { .. } => {
+                            crate::driver::ephemeral::PostAdmissionSignal::None
+                        }
+                    };
                     (result, signal)
                 };
 
@@ -360,26 +406,28 @@ impl MeerkatMachine {
                 if matches!(state, RuntimeState::Initializing) {
                     return Err(RuntimeControlPlaneError::InvalidState { state });
                 }
-                let previous_dsl_state = self
-                    .stage_session_dsl_input(
-                        &session_id,
-                        crate::meerkat_machine::dsl::MeerkatMachineInput::Destroy,
-                        "Destroy",
-                    )
-                    .await
-                    .map_err(RuntimeControlPlaneError::Internal)?;
+                self.preview_session_dsl_input(
+                    &session_id,
+                    crate::meerkat_machine::dsl::MeerkatMachineInput::Destroy,
+                    "Destroy",
+                )
+                .await
+                .map_err(RuntimeControlPlaneError::Internal)?;
 
                 let mut drv = driver.lock().await;
                 let report = match machine_destroy(&mut drv).await {
                     Ok(report) => report,
-                    Err(err) => {
-                        drop(drv);
-                        self.restore_session_dsl_state(&session_id, previous_dsl_state)
-                            .await;
-                        return Err(RuntimeControlPlaneError::Internal(err.to_string()));
-                    }
+                    Err(err) => return Err(RuntimeControlPlaneError::Internal(err.to_string())),
                 };
                 drop(drv);
+
+                self.apply_session_dsl_input(
+                    &session_id,
+                    crate::meerkat_machine::dsl::MeerkatMachineInput::Destroy,
+                    "Destroy",
+                )
+                .await
+                .map_err(RuntimeControlPlaneError::Internal)?;
 
                 let mut comp = completions.lock().await;
                 comp.resolve_all_terminated("runtime destroyed");

--- a/meerkat-runtime/src/meerkat_machine/dispatch_ingress.rs
+++ b/meerkat-runtime/src/meerkat_machine/dispatch_ingress.rs
@@ -45,32 +45,21 @@ impl MeerkatMachine {
                     });
                 }
 
-                let request_immediate_processing =
-                    crate::accept::requests_immediate_processing(&input);
-                // Machine-owned wake-if-idle intent: derived from the
-                // kind-level policy so the DSL's Running+Queued split
-                // picks the `AcceptWithCompletionRunningQueuedWakeIfIdle`
-                // arm (emit WakeLoop) vs the passive arm (no emit).
-                let wake_if_idle = crate::accept::requests_wake_if_idle(&input);
-
-                // DSL-first: validate the coarse AcceptWithCompletion transition
-                // before the driver realizes the effect.
                 let run_id_for_dsl = RunId::new();
-                // We don't have the input_id yet (driver hasn't accepted), so use a
-                // placeholder InputId. The DSL transition for AcceptWithCompletion
-                // doesn't gate on input_id value — it gates on phase/state.
-                let dsl_input_id =
-                    crate::meerkat_machine::dsl::InputId::from_domain(&InputId::new());
-                let previous_dsl_state = self
-                    .stage_session_dsl_input(
+                let (resolved, outcome, handle, accepted_input_id, signal) = {
+                    let mut driver = driver.lock().await;
+                    let resolved = driver.resolve_admission(&input);
+                    self.preview_session_dsl_input(
                         &session_id,
                         crate::meerkat_machine::dsl::MeerkatMachineInput::AcceptWithCompletion {
-                            input_id: dsl_input_id,
-                            request_immediate_processing,
-                            // We don't know interrupt_yielding yet (depends on outcome),
-                            // but the DSL transition doesn't gate on this field.
-                            interrupt_yielding: false,
-                            wake_if_idle,
+                            input_id: crate::meerkat_machine::dsl::InputId::from_domain(
+                                &InputId::new(),
+                            ),
+                            request_immediate_processing: resolved
+                                .coarse_flags
+                                .request_immediate_processing,
+                            interrupt_yielding: resolved.coarse_flags.interrupt_yielding,
+                            wake_if_idle: resolved.coarse_flags.wake_if_idle,
                             run_id: crate::meerkat_machine::dsl::RunId::from_domain(
                                 &run_id_for_dsl,
                             ),
@@ -79,30 +68,21 @@ impl MeerkatMachine {
                     )
                     .await
                     .map_err(|reason| RuntimeDriverError::ValidationFailed { reason })?;
-
-                let (outcome, signal, handle) = {
-                    let mut driver = driver.lock().await;
                     let result = match driver
-                        .as_driver_mut()
-                        .accept_input(input)
+                        .accept_resolved_input(input, resolved.clone())
                         .await
                         .map_err(Self::normalize_destroyed_error)
                     {
                         Ok(r) => r,
-                        Err(err) => {
-                            self.restore_session_dsl_state(&session_id, previous_dsl_state)
-                                .await;
-                            return Err(err);
-                        }
+                        Err(err) => return Err(err),
                     };
-                    let signal =
-                        Self::machine_owned_admission_signal(&result, request_immediate_processing);
 
                     match &result {
                         AcceptOutcome::Accepted { input_id, .. } => {
+                            let accepted_input_id = input_id.clone();
                             let is_terminal = driver
                                 .as_driver()
-                                .input_phase(input_id)
+                                .input_phase(&accepted_input_id)
                                 .map(|phase| phase.is_terminal())
                                 .unwrap_or(true);
                             let handle = if is_terminal {
@@ -110,10 +90,16 @@ impl MeerkatMachine {
                             } else {
                                 Some({
                                     let mut completions = completions.lock().await;
-                                    completions.register(input_id.clone())
+                                    completions.register(accepted_input_id.clone())
                                 })
                             };
-                            (result, signal, handle)
+                            (
+                                resolved,
+                                result,
+                                handle,
+                                Some(accepted_input_id),
+                                crate::driver::ephemeral::PostAdmissionSignal::None,
+                            )
                         }
                         AcceptOutcome::Deduplicated { existing_id, .. } => {
                             let is_terminal = driver
@@ -123,71 +109,67 @@ impl MeerkatMachine {
                                 .unwrap_or(true);
 
                             if is_terminal {
-                                (result, signal, None)
+                                (
+                                    resolved,
+                                    result,
+                                    None,
+                                    None,
+                                    crate::driver::ephemeral::PostAdmissionSignal::None,
+                                )
                             } else {
                                 let handle = {
                                     let mut completions = completions.lock().await;
                                     completions.register(existing_id.clone())
                                 };
-                                (result, signal, Some(handle))
+                                (
+                                    resolved,
+                                    result,
+                                    Some(handle),
+                                    None,
+                                    crate::driver::ephemeral::PostAdmissionSignal::None,
+                                )
                             }
                         }
                         AcceptOutcome::Rejected { reason } => {
-                            self.restore_session_dsl_state(&session_id, previous_dsl_state)
-                                .await;
                             return Err(RuntimeDriverError::ValidationFailed {
                                 reason: reason.to_string(),
                             });
                         }
                     }
                 };
-
-                // Input lifecycle shadow: infer from outcome which transition fired
-                let shadow_input_id = match &outcome {
-                    AcceptOutcome::Accepted { input_id, .. } => input_id.clone(),
-                    AcceptOutcome::Deduplicated { existing_id, .. } => existing_id.clone(),
-                    AcceptOutcome::Rejected { .. } => {
-                        unreachable!("rejected case is returned above")
-                    }
-                };
-                {
-                    let is_terminal = match &outcome {
-                        AcceptOutcome::Accepted { input_id, .. } => {
-                            let drv = driver.lock().await;
-                            drv.as_driver()
-                                .input_phase(input_id)
-                                .map(|phase| phase.is_terminal())
-                                .unwrap_or(true)
-                        }
-                        _ => false,
-                    };
-                    let shadow_input = if is_terminal {
-                        Some(
-                            crate::meerkat_machine::dsl::MeerkatMachineInput::ConsumeOnAccept {
-                                input_id: shadow_input_id.to_string(),
+                let signal = if let Some(input_id) = accepted_input_id {
+                    let (_, effects) = self
+                        .apply_session_dsl_input(
+                            &session_id,
+                            crate::meerkat_machine::dsl::MeerkatMachineInput::AcceptWithCompletion {
+                                input_id: crate::meerkat_machine::dsl::InputId::from_domain(
+                                    &input_id,
+                                ),
+                                request_immediate_processing: resolved
+                                    .coarse_flags
+                                    .request_immediate_processing,
+                                interrupt_yielding: resolved.coarse_flags.interrupt_yielding,
+                                wake_if_idle: resolved.coarse_flags.wake_if_idle,
+                                run_id: crate::meerkat_machine::dsl::RunId::from_domain(
+                                    &run_id_for_dsl,
+                                ),
                             },
+                            "AcceptWithCompletion",
                         )
-                    } else if matches!(&outcome, AcceptOutcome::Accepted { .. }) {
-                        Some(
-                            crate::meerkat_machine::dsl::MeerkatMachineInput::QueueAccepted {
-                                input_id: shadow_input_id.to_string(),
-                            },
-                        )
-                    } else {
-                        None // Deduplicated — no new input lifecycle transition
-                    };
-                    if let Some(input) = shadow_input
-                        && let Err(err) = self
-                            .stage_session_dsl_input(&session_id, input, "InputLifecycle(accept)")
-                            .await
+                        .await
+                        .map_err(|reason| {
+                            RuntimeDriverError::Internal(format!(
+                                "canonical AcceptWithCompletion apply failed after admission: {reason}"
+                            ))
+                        })?;
                     {
-                        tracing::warn!(
-                            session_id = %session_id,
-                            error = %err,
-                            "DSL/runtime DISAGREEMENT on input lifecycle after accept"
-                        );
+                        let mut driver = driver.lock().await;
+                        driver.absorb_post_admission_effects(&effects);
                     }
-                }
+                    Self::post_admission_signal_from_effects(&effects)
+                } else {
+                    signal
+                };
 
                 if signal.should_wake()
                     && let Some(ref wake_tx) = wake_tx
@@ -242,103 +224,68 @@ impl MeerkatMachine {
                     });
                 }
 
-                let request_immediate_processing =
-                    crate::accept::requests_immediate_processing(&input);
-
-                // DSL-first: validate AcceptWithoutWake before driver realizes the effect.
-                let dsl_input_id =
-                    crate::meerkat_machine::dsl::InputId::from_domain(&InputId::new());
-                let previous_dsl_state = self
-                    .stage_session_dsl_input(
+                let (outcome, accepted_input_id) = {
+                    let mut driver = driver.lock().await;
+                    let resolved = driver.resolve_admission(&input);
+                    self.preview_session_dsl_input(
                         &session_id,
                         crate::meerkat_machine::dsl::MeerkatMachineInput::AcceptWithoutWake {
-                            input_id: dsl_input_id,
+                            input_id: crate::meerkat_machine::dsl::InputId::from_domain(
+                                &InputId::new(),
+                            ),
                         },
                         "AcceptWithoutWake",
                     )
                     .await
                     .map_err(|reason| RuntimeDriverError::ValidationFailed { reason })?;
-
-                let outcome = {
-                    let mut driver = driver.lock().await;
                     let result = match driver
-                        .as_driver_mut()
-                        .accept_input(input)
+                        .accept_resolved_input(input, resolved)
                         .await
                         .map_err(Self::normalize_destroyed_error)
                     {
                         Ok(r) => r,
-                        Err(err) => {
-                            self.restore_session_dsl_state(&session_id, previous_dsl_state)
-                                .await;
-                            return Err(err);
-                        }
+                        Err(err) => return Err(err),
                     };
-                    let signal =
-                        Self::machine_owned_admission_signal(&result, request_immediate_processing);
-                    debug_assert!(
-                        !signal.should_process_immediately(),
-                        "queue-only admission unexpectedly requested immediate processing"
-                    );
                     if let AcceptOutcome::Rejected { reason } = &result {
-                        self.restore_session_dsl_state(&session_id, previous_dsl_state)
-                            .await;
                         return Err(RuntimeDriverError::ValidationFailed {
                             reason: reason.to_string(),
                         });
                     }
-                    result
-                };
-                let shadow_input_id = match &outcome {
-                    AcceptOutcome::Accepted { input_id, .. } => input_id.clone(),
-                    AcceptOutcome::Deduplicated { existing_id, .. } => existing_id.clone(),
-                    AcceptOutcome::Rejected { .. } => {
-                        unreachable!("rejected case handled above")
-                    }
-                };
-
-                // Input lifecycle shadow: infer from outcome which transition fired
-                {
-                    let is_terminal = match &outcome {
-                        AcceptOutcome::Accepted { input_id, .. } => {
-                            let drv = driver.lock().await;
-                            drv.as_driver()
-                                .input_phase(input_id)
-                                .map(|phase| phase.is_terminal())
-                                .unwrap_or(true)
-                        }
-                        _ => false,
+                    let accepted_input_id = match &result {
+                        AcceptOutcome::Accepted { input_id, .. } => Some(input_id.clone()),
+                        AcceptOutcome::Deduplicated { .. } => None,
+                        AcceptOutcome::Rejected { .. } => unreachable!("handled above"),
                     };
-                    let shadow_input = if is_terminal {
-                        Some(
-                            crate::meerkat_machine::dsl::MeerkatMachineInput::ConsumeOnAccept {
-                                input_id: shadow_input_id.to_string(),
+                    (result, accepted_input_id)
+                };
+                if let Some(input_id) = accepted_input_id {
+                    let (_, effects) = self
+                        .apply_session_dsl_input(
+                            &session_id,
+                            crate::meerkat_machine::dsl::MeerkatMachineInput::AcceptWithoutWake {
+                                input_id: crate::meerkat_machine::dsl::InputId::from_domain(
+                                    &input_id,
+                                ),
                             },
+                            "AcceptWithoutWake",
                         )
-                    } else if matches!(&outcome, AcceptOutcome::Accepted { .. }) {
-                        Some(
-                            crate::meerkat_machine::dsl::MeerkatMachineInput::QueueAccepted {
-                                input_id: shadow_input_id.to_string(),
-                            },
-                        )
-                    } else {
-                        None // Deduplicated — no new input lifecycle transition
-                    };
-                    if let Some(input) = shadow_input
-                        && let Err(err) = self
-                            .stage_session_dsl_input(
-                                &session_id,
-                                input,
-                                "InputLifecycle(accept_without_wake)",
-                            )
-                            .await
+                        .await
+                        .map_err(|reason| {
+                            RuntimeDriverError::Internal(format!(
+                                "canonical AcceptWithoutWake apply failed after admission: {reason}"
+                            ))
+                        })?;
                     {
-                        tracing::warn!(
-                            session_id = %session_id,
-                            error = %err,
-                            "DSL/runtime DISAGREEMENT on input lifecycle after accept_without_wake"
-                        );
+                        let mut driver = driver.lock().await;
+                        driver.absorb_post_admission_effects(&effects);
                     }
+                    let signal = Self::post_admission_signal_from_effects(&effects);
+                    debug_assert!(
+                        !signal.should_wake()
+                            && !signal.should_interrupt_yielding()
+                            && !signal.should_process_immediately(),
+                        "AcceptWithoutWake unexpectedly emitted a post-admission signal"
+                    );
                 }
 
                 Ok(MeerkatMachineCommandResult::AcceptOutcome(outcome))
@@ -548,31 +495,6 @@ impl MeerkatMachine {
                     }
                 };
 
-                // Input lifecycle shadows: accept queued + stage for run
-                for shadow in [
-                    crate::meerkat_machine::dsl::MeerkatMachineInput::QueueAccepted {
-                        input_id: prepared.input_id.to_string(),
-                    },
-                    crate::meerkat_machine::dsl::MeerkatMachineInput::StageForRun {
-                        input_id: prepared.input_id.to_string(),
-                        run_id: prepared.run_id.to_string(),
-                    },
-                    crate::meerkat_machine::dsl::MeerkatMachineInput::IncrementAttemptCount {
-                        input_id: prepared.input_id.to_string(),
-                    },
-                ] {
-                    if let Err(err) = self
-                        .stage_session_dsl_input(&session_id, shadow, "InputLifecycle(prepare)")
-                        .await
-                    {
-                        tracing::warn!(
-                            session_id = %session_id,
-                            error = %err,
-                            "DSL/runtime DISAGREEMENT on input lifecycle during prepare"
-                        );
-                    }
-                }
-
                 Ok(MeerkatMachineCommandResult::Prepared(prepared))
             }
             MeerkatMachineCommand::Commit {
@@ -614,24 +536,6 @@ impl MeerkatMachine {
                     .await
                     .map_err(|reason| RuntimeDriverError::ValidationFailed { reason })?;
 
-                // DSL-first: stage ConsumeInput before the driver commit realizes it.
-                if let Err(err) = self
-                    .stage_session_dsl_input(
-                        &session_id,
-                        crate::meerkat_machine::dsl::MeerkatMachineInput::ConsumeInput {
-                            input_id: shadow_input_id.to_string(),
-                        },
-                        "InputLifecycle(commit)",
-                    )
-                    .await
-                {
-                    tracing::warn!(
-                        session_id = %session_id,
-                        error = %err,
-                        "DSL/runtime DISAGREEMENT on input lifecycle during commit"
-                    );
-                }
-
                 let commit_run_id = run_id.clone();
                 if let Err(err) = commit_runtime_loop_run(
                     &driver,
@@ -642,10 +546,10 @@ impl MeerkatMachine {
                 )
                 .await
                 {
-                    self.restore_session_dsl_state(&session_id, previous_dsl_state)
-                        .await;
-                    // Driver unwinds Running → pre-run phase on commit failure.
-                    // Apply DSL Fail to keep the machine phase in sync.
+                    let _ = previous_dsl_state;
+                    // Driver already unwinds the shared canonical ingress state
+                    // on commit failure. Only the coarse Fail transition remains
+                    // to keep the top-level machine phase in sync.
                     if let Err(dsl_err) = self
                         .stage_session_dsl_input(
                             &session_id,

--- a/meerkat-runtime/src/meerkat_machine/driver.rs
+++ b/meerkat-runtime/src/meerkat_machine/driver.rs
@@ -4,10 +4,12 @@ use std::sync::Arc;
 
 use meerkat_core::lifecycle::{InputId, RunId};
 
+use crate::accept::{AcceptOutcome, ResolvedAdmission};
 use crate::driver::ephemeral::EphemeralRuntimeDriver;
 use crate::driver::persistent::PersistentRuntimeDriver;
 use crate::identifiers::LogicalRuntimeId;
 use crate::ingress_types::ContentShape;
+use crate::input::Input;
 use crate::input_state::{
     InputLifecycleState, InputState, InputStateHistoryEntry, InputStateSeed, InputTerminalOutcome,
     StoredInputState,
@@ -102,6 +104,24 @@ impl DriverEntry {
         }
     }
 
+    pub(crate) fn resolve_admission(&self, input: &Input) -> ResolvedAdmission {
+        match self {
+            DriverEntry::Ephemeral(d) => d.resolve_admission(input),
+            DriverEntry::Persistent(d) => d.resolve_admission(input),
+        }
+    }
+
+    pub(crate) async fn accept_resolved_input(
+        &mut self,
+        input: Input,
+        resolved: ResolvedAdmission,
+    ) -> Result<AcceptOutcome, RuntimeDriverError> {
+        match self {
+            DriverEntry::Ephemeral(d) => d.accept_resolved_input(input, resolved).await,
+            DriverEntry::Persistent(d) => d.accept_resolved_input(input, resolved).await,
+        }
+    }
+
     pub(crate) fn input_phase(&self, input_id: &InputId) -> Option<InputLifecycleState> {
         self.as_driver().input_phase(input_id)
     }
@@ -170,6 +190,26 @@ impl DriverEntry {
         match self {
             DriverEntry::Ephemeral(d) => d.post_admission_signal(),
             DriverEntry::Persistent(d) => d.post_admission_signal(),
+        }
+    }
+
+    #[cfg(test)]
+    pub(crate) fn shared_dsl_authority(
+        &self,
+    ) -> crate::driver::ephemeral::SharedIngressDslAuthority {
+        match self {
+            DriverEntry::Ephemeral(d) => d.shared_dsl_authority(),
+            DriverEntry::Persistent(d) => d.inner_ref().shared_dsl_authority(),
+        }
+    }
+
+    pub(crate) fn absorb_post_admission_effects(
+        &mut self,
+        effects: &[crate::meerkat_machine::dsl::MeerkatMachineEffect],
+    ) {
+        match self {
+            DriverEntry::Ephemeral(d) => d.absorb_post_admission_effects(effects),
+            DriverEntry::Persistent(d) => d.absorb_post_admission_effects(effects),
         }
     }
 

--- a/meerkat-runtime/src/meerkat_machine/mod.rs
+++ b/meerkat-runtime/src/meerkat_machine/mod.rs
@@ -280,27 +280,81 @@ impl MeerkatMachine {
             .map(|entry| Arc::clone(&entry.mutation_gate))
     }
 
+    async fn session_dsl_authority(
+        &self,
+        session_id: &SessionId,
+    ) -> Result<Arc<std::sync::Mutex<dsl::MeerkatMachineAuthority>>, String> {
+        let sessions = self.sessions.read().await;
+        sessions
+            .get(session_id)
+            .map(|entry| Arc::clone(&entry.dsl_authority))
+            .ok_or_else(|| {
+                RuntimeDriverError::NotReady {
+                    state: RuntimeState::Destroyed,
+                }
+                .to_string()
+            })
+    }
+
+    fn preview_dsl_input_on_state(
+        state: &dsl::MeerkatMachineState,
+        input: dsl::MeerkatMachineInput,
+        context: &str,
+    ) -> Result<Vec<dsl::MeerkatMachineEffect>, String> {
+        let mut preview = dsl::MeerkatMachineAuthority::from_state(state.clone());
+        dsl::MeerkatMachineMutator::apply(&mut preview, input)
+            .map(|transition| transition.effects)
+            .map_err(|err| dsl_authority::map_error(err, context))
+    }
+
+    async fn preview_session_dsl_input(
+        &self,
+        session_id: &SessionId,
+        input: dsl::MeerkatMachineInput,
+        context: &str,
+    ) -> Result<Vec<dsl::MeerkatMachineEffect>, String> {
+        let authority = self.session_dsl_authority(session_id).await?;
+        let state = {
+            let authority = authority
+                .lock()
+                .unwrap_or_else(std::sync::PoisonError::into_inner);
+            authority.state.clone()
+        };
+        Self::preview_dsl_input_on_state(&state, input, context)
+    }
+
     async fn stage_session_dsl_input(
         &self,
         session_id: &SessionId,
         input: dsl::MeerkatMachineInput,
         context: &str,
     ) -> Result<Box<dsl::MeerkatMachineState>, String> {
-        let mut sessions = self.sessions.write().await;
-        let entry = sessions.get_mut(session_id).ok_or_else(|| {
-            RuntimeDriverError::NotReady {
-                state: RuntimeState::Destroyed,
-            }
-            .to_string()
-        })?;
-        let mut authority = entry
-            .dsl_authority
+        self.apply_session_dsl_input(session_id, input, context)
+            .await
+            .map(|(previous_state, _)| previous_state)
+    }
+
+    async fn apply_session_dsl_input(
+        &self,
+        session_id: &SessionId,
+        input: dsl::MeerkatMachineInput,
+        context: &str,
+    ) -> Result<
+        (
+            Box<dsl::MeerkatMachineState>,
+            Vec<dsl::MeerkatMachineEffect>,
+        ),
+        String,
+    > {
+        let authority = self.session_dsl_authority(session_id).await?;
+        let mut authority = authority
             .lock()
             .unwrap_or_else(std::sync::PoisonError::into_inner);
         let previous_state = Box::new(authority.state.clone());
-        dsl::MeerkatMachineMutator::apply(&mut *authority, input)
+        let effects = dsl::MeerkatMachineMutator::apply(&mut *authority, input)
+            .map(|transition| transition.effects)
             .map_err(|err| dsl_authority::map_error(err, context))?;
-        Ok(previous_state)
+        Ok((previous_state, effects))
     }
 
     async fn restore_session_dsl_state(
@@ -308,10 +362,8 @@ impl MeerkatMachine {
         session_id: &SessionId,
         state: Box<dsl::MeerkatMachineState>,
     ) {
-        let mut sessions = self.sessions.write().await;
-        if let Some(entry) = sessions.get_mut(session_id) {
-            let mut authority = entry
-                .dsl_authority
+        if let Ok(authority) = self.session_dsl_authority(session_id).await {
+            let mut authority = authority
                 .lock()
                 .unwrap_or_else(std::sync::PoisonError::into_inner);
             *authority = dsl::MeerkatMachineAuthority::from_state(*state);
@@ -433,8 +485,27 @@ impl MeerkatMachine {
         Arc::clone(&self.session_claims) as Arc<dyn meerkat_core::handles::SessionClaimHandle>
     }
 
+    #[cfg(test)]
+    pub(crate) async fn debug_shared_ingress_authorities(
+        &self,
+        session_id: &SessionId,
+    ) -> Option<(
+        Arc<std::sync::Mutex<dsl::MeerkatMachineAuthority>>,
+        crate::driver::ephemeral::SharedIngressDslAuthority,
+    )> {
+        let sessions = self.sessions.read().await;
+        let entry = sessions.get(session_id)?;
+        let session_authority = Arc::clone(&entry.dsl_authority);
+        let driver = entry.driver.lock().await;
+        Some((session_authority, driver.shared_dsl_authority()))
+    }
+
     /// Create a driver entry for a session.
-    fn make_driver(&self, session_id: &SessionId) -> DriverEntry {
+    fn make_driver(
+        &self,
+        session_id: &SessionId,
+        dsl_authority: crate::driver::ephemeral::SharedIngressDslAuthority,
+    ) -> DriverEntry {
         let runtime_id = LogicalRuntimeId::new(session_id.to_string());
         let control_projection = Arc::new(StdRwLock::new(
             crate::driver::ephemeral::RuntimeControlProjection::default(),
@@ -446,6 +517,7 @@ impl MeerkatMachine {
                     store.clone(),
                     blob_store.clone(),
                     control_projection,
+                    dsl_authority,
                 ))
             }
             (Some(_store), None) => {
@@ -454,14 +526,16 @@ impl MeerkatMachine {
                     "persistent runtime store present but blob store missing; \
                      falling back to ephemeral driver"
                 );
-                DriverEntry::Ephemeral(EphemeralRuntimeDriver::new_with_control(
+                DriverEntry::Ephemeral(EphemeralRuntimeDriver::new_with_control_and_dsl(
                     runtime_id,
                     control_projection,
+                    dsl_authority,
                 ))
             }
-            _ => DriverEntry::Ephemeral(EphemeralRuntimeDriver::new_with_control(
+            _ => DriverEntry::Ephemeral(EphemeralRuntimeDriver::new_with_control_and_dsl(
                 runtime_id,
                 control_projection,
+                dsl_authority,
             )),
         }
     }

--- a/meerkat-runtime/src/meerkat_machine/session_management.rs
+++ b/meerkat-runtime/src/meerkat_machine/session_management.rs
@@ -1,6 +1,34 @@
 use super::*;
 
 impl MeerkatMachine {
+    fn sync_session_dsl_authority_from_driver(
+        dsl_authority: &Arc<std::sync::Mutex<super::dsl::MeerkatMachineAuthority>>,
+        session_id: &SessionId,
+        control_projection: &Arc<StdRwLock<crate::driver::ephemeral::RuntimeControlProjection>>,
+        driver_runtime_id: &LogicalRuntimeId,
+        driver_silent_intents: std::collections::BTreeSet<String>,
+    ) {
+        let control = control_projection
+            .read()
+            .map(|guard| guard.clone())
+            .unwrap_or_else(|poisoned| poisoned.into_inner().clone());
+        let mut authority = dsl_authority
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        authority.state.lifecycle_phase = super::dsl_authority::project_phase(control.phase);
+        authority.state.session_id = Some(super::dsl::SessionId::from_domain(session_id));
+        authority.state.active_runtime_id =
+            Some(super::dsl::AgentRuntimeId::from_domain(driver_runtime_id));
+        authority.state.current_run_id = control
+            .current_run_id
+            .as_ref()
+            .map(super::dsl::RunId::from_domain);
+        authority.state.pre_run_phase = control
+            .pre_run_phase
+            .and_then(super::dsl_authority::pre_run_phase_from_runtime_state);
+        authority.state.silent_intent_overrides = driver_silent_intents;
+    }
+
     pub(super) async fn register_session_inner(&self, session_id: SessionId) {
         {
             let mut sessions = self.sessions.write().await;
@@ -10,34 +38,39 @@ impl MeerkatMachine {
             }
         }
 
-        let mut entry = self.make_driver(&session_id);
+        let runtime_id = LogicalRuntimeId::new(session_id.to_string());
+        let dsl_authority = Arc::new(std::sync::Mutex::new(
+            super::dsl::MeerkatMachineAuthority::from_state(super::dsl_authority::project_state(
+                &session_id,
+                RuntimeState::Idle,
+                Some(&runtime_id),
+                None,
+                None,
+                std::collections::BTreeSet::new(),
+                None,
+            )),
+        ));
+        let mut entry = self.make_driver(&session_id, Arc::clone(&dsl_authority));
         if let Err(err) = entry.as_driver_mut().recover().await {
             tracing::error!(%session_id, error = %err, "failed to recover runtime driver during registration");
             return;
         }
-
-        let (ops_lifecycle, epoch_id, cursor_state) =
-            self.recover_or_create_ops_state(&session_id).await;
         let control_projection = entry.control_projection_handle();
         let driver_runtime_id = entry.runtime_id().clone();
         let driver_silent_intents = entry
             .silent_comms_intents()
             .into_iter()
             .collect::<std::collections::BTreeSet<_>>();
-        let dsl_authority = Arc::new(std::sync::Mutex::new(
-            super::dsl::MeerkatMachineAuthority::from_state(super::dsl_authority::project_state(
-                &session_id,
-                control_projection
-                    .read()
-                    .map(|guard| guard.phase)
-                    .unwrap_or_else(|poisoned| poisoned.into_inner().phase),
-                Some(&driver_runtime_id),
-                None,
-                None,
-                driver_silent_intents,
-                None,
-            )),
-        ));
+        Self::sync_session_dsl_authority_from_driver(
+            &dsl_authority,
+            &session_id,
+            &control_projection,
+            &driver_runtime_id,
+            driver_silent_intents,
+        );
+
+        let (ops_lifecycle, epoch_id, cursor_state) =
+            self.recover_or_create_ops_state(&session_id).await;
         let session_entry = RuntimeSessionEntry {
             mutation_gate: Arc::new(Mutex::new(())),
             control_projection,
@@ -164,7 +197,21 @@ impl MeerkatMachine {
                 }
                 (driver, completions, ops_lifecycle)
             } else {
-                let mut recovered_entry = self.make_driver(&session_id);
+                let runtime_id = LogicalRuntimeId::new(session_id.to_string());
+                let dsl_authority = Arc::new(std::sync::Mutex::new(
+                    super::dsl::MeerkatMachineAuthority::from_state(
+                        super::dsl_authority::project_state(
+                            &session_id,
+                            RuntimeState::Idle,
+                            Some(&runtime_id),
+                            None,
+                            None,
+                            std::collections::BTreeSet::new(),
+                            None,
+                        ),
+                    ),
+                ));
+                let mut recovered_entry = self.make_driver(&session_id, Arc::clone(&dsl_authority));
                 if let Err(err) = recovered_entry.as_driver_mut().recover().await {
                     tracing::error!(
                         %session_id,
@@ -173,6 +220,19 @@ impl MeerkatMachine {
                     );
                     return;
                 }
+                let control_projection = recovered_entry.control_projection_handle();
+                let driver_runtime_id = recovered_entry.runtime_id().clone();
+                let driver_silent_intents = recovered_entry
+                    .silent_comms_intents()
+                    .into_iter()
+                    .collect::<std::collections::BTreeSet<_>>();
+                Self::sync_session_dsl_authority_from_driver(
+                    &dsl_authority,
+                    &session_id,
+                    &control_projection,
+                    &driver_runtime_id,
+                    driver_silent_intents,
+                );
 
                 // Recover ops state OUTSIDE the sessions lock to avoid blocking
                 // other adapter operations behind potentially slow disk I/O.
@@ -195,30 +255,9 @@ impl MeerkatMachine {
                     )
                 } else {
                     let control_projection = recovered_entry.control_projection_handle();
-                    let driver_runtime_id = recovered_entry.runtime_id().clone();
-                    let driver_silent_intents = recovered_entry
-                        .silent_comms_intents()
-                        .into_iter()
-                        .collect::<std::collections::BTreeSet<_>>();
                     let driver = Arc::new(Mutex::new(recovered_entry));
                     let completions =
                         Arc::new(Mutex::new(crate::completion::CompletionRegistry::new()));
-                    let dsl_authority = Arc::new(std::sync::Mutex::new(
-                        super::dsl::MeerkatMachineAuthority::from_state(
-                            super::dsl_authority::project_state(
-                                &session_id,
-                                control_projection
-                                    .read()
-                                    .map(|guard| guard.phase)
-                                    .unwrap_or_else(|poisoned| poisoned.into_inner().phase),
-                                Some(&driver_runtime_id),
-                                None,
-                                None,
-                                driver_silent_intents,
-                                None,
-                            ),
-                        ),
-                    ));
                     sessions.insert(
                         session_id.clone(),
                         RuntimeSessionEntry {

--- a/meerkat-runtime/src/meerkat_machine/traits.rs
+++ b/meerkat-runtime/src/meerkat_machine/traits.rs
@@ -187,14 +187,27 @@ impl MeerkatMachine {
         LogicalRuntimeId::new(session_id.to_string())
     }
 
-    pub(super) fn machine_owned_admission_signal(
-        outcome: &AcceptOutcome,
-        request_immediate_processing: bool,
+    pub(super) fn post_admission_signal_from_effects(
+        effects: &[crate::meerkat_machine::dsl::MeerkatMachineEffect],
     ) -> crate::driver::ephemeral::PostAdmissionSignal {
-        crate::accept::post_admission_signal_from_accept_outcome(
-            outcome,
-            request_immediate_processing,
-        )
+        effects
+            .iter()
+            .find_map(|effect| match effect {
+                crate::meerkat_machine::dsl::MeerkatMachineEffect::PostAdmissionSignal {
+                    signal,
+                } => Some(match signal.as_str() {
+                    "WakeLoop" => crate::driver::ephemeral::PostAdmissionSignal::WakeLoop,
+                    "InterruptYielding" => {
+                        crate::driver::ephemeral::PostAdmissionSignal::InterruptYielding
+                    }
+                    "RequestImmediateProcessing" => {
+                        crate::driver::ephemeral::PostAdmissionSignal::RequestImmediateProcessing
+                    }
+                    _ => crate::driver::ephemeral::PostAdmissionSignal::None,
+                }),
+                _ => None,
+            })
+            .unwrap_or(crate::driver::ephemeral::PostAdmissionSignal::None)
     }
 
     pub(super) fn driver_error_from_command_error(

--- a/meerkat-runtime/src/meerkat_machine_tests.rs
+++ b/meerkat-runtime/src/meerkat_machine_tests.rs
@@ -1032,6 +1032,47 @@ async fn meerkat_machine_spine_snapshot_recycle_reconciles_stale_completion_wait
 }
 
 #[tokio::test]
+async fn shared_ingress_authority_is_identical_after_register_recover_and_recycle() {
+    let adapter = Arc::new(MeerkatMachine::ephemeral());
+    let session_id = SessionId::new();
+
+    adapter.register_session(session_id.clone()).await;
+    let (session_authority, driver_authority) = adapter
+        .debug_shared_ingress_authorities(&session_id)
+        .await
+        .expect("registered session should expose shared ingress authorities");
+    assert!(
+        Arc::ptr_eq(&session_authority, &driver_authority),
+        "fresh registration should share one ingress authority between session and driver",
+    );
+
+    let runtime_id = LogicalRuntimeId::new(session_id.to_string());
+    crate::traits::RuntimeControlPlane::recover(&*adapter, &runtime_id)
+        .await
+        .expect("recover should succeed");
+    let (session_authority, driver_authority) = adapter
+        .debug_shared_ingress_authorities(&session_id)
+        .await
+        .expect("recovered session should expose shared ingress authorities");
+    assert!(
+        Arc::ptr_eq(&session_authority, &driver_authority),
+        "recover should preserve one shared ingress authority",
+    );
+
+    crate::traits::RuntimeControlPlane::recycle(&*adapter, &runtime_id)
+        .await
+        .expect("recycle should succeed");
+    let (session_authority, driver_authority) = adapter
+        .debug_shared_ingress_authorities(&session_id)
+        .await
+        .expect("recycled session should expose shared ingress authorities");
+    assert!(
+        Arc::ptr_eq(&session_authority, &driver_authority),
+        "recycle should preserve one shared ingress authority",
+    );
+}
+
+#[tokio::test]
 async fn meerkat_machine_spine_snapshot_preserves_completion_waiters_after_recover() {
     let adapter = Arc::new(MeerkatMachine::ephemeral());
     let session_id = SessionId::new();
@@ -1092,6 +1133,81 @@ async fn meerkat_machine_spine_snapshot_preserves_completion_waiters_after_recov
         }
         other => panic!("expected runtime reset termination, got {other:?}"),
     }
+}
+
+#[tokio::test]
+async fn deduplicated_accept_with_completion_emits_no_new_signal() {
+    let adapter = Arc::new(MeerkatMachine::ephemeral());
+    let session_id = SessionId::new();
+
+    adapter.register_session(session_id.clone()).await;
+
+    let mut first = make_prompt("dedup me");
+    let key = IdempotencyKey::new("runtime-dedup");
+    if let Input::Prompt(ref mut prompt) = first {
+        prompt.header.idempotency_key = Some(key.clone());
+    }
+    let accepted = adapter
+        .execute_meerkat_machine_command(
+            None,
+            MeerkatMachineCommand::AcceptWithCompletion {
+                session_id: session_id.clone(),
+                input: first,
+            },
+        )
+        .await
+        .expect("first input should be accepted");
+    let MeerkatMachineCommandResult::AcceptWithCompletion {
+        outcome: first_outcome,
+        admission_signal: first_signal,
+        ..
+    } = accepted
+    else {
+        panic!("expected AcceptWithCompletion result");
+    };
+    assert!(first_outcome.is_accepted());
+    assert_eq!(
+        first_signal,
+        crate::driver::ephemeral::PostAdmissionSignal::WakeLoop
+    );
+
+    let mut duplicate = make_prompt("dedup me too");
+    if let Input::Prompt(ref mut prompt) = duplicate {
+        prompt.header.idempotency_key = Some(key);
+    }
+    let duplicate_result = adapter
+        .execute_meerkat_machine_command(
+            None,
+            MeerkatMachineCommand::AcceptWithCompletion {
+                session_id: session_id.clone(),
+                input: duplicate,
+            },
+        )
+        .await
+        .expect("duplicate input should return a deduplicated outcome");
+    let MeerkatMachineCommandResult::AcceptWithCompletion {
+        outcome,
+        admission_signal,
+        ..
+    } = duplicate_result
+    else {
+        panic!("expected AcceptWithCompletion result");
+    };
+    assert!(outcome.is_deduplicated());
+    assert_eq!(
+        admission_signal,
+        crate::driver::ephemeral::PostAdmissionSignal::None,
+        "dedup should not emit a fresh admission signal",
+    );
+
+    let snapshot = adapter
+        .meerkat_machine_spine_snapshot(&session_id)
+        .await
+        .expect("snapshot should exist after dedup");
+    assert_eq!(
+        snapshot.inputs.post_admission_signal, "WakeLoop",
+        "dedup should not overwrite the previously accumulated canonical signal",
+    );
 }
 
 #[tokio::test]

--- a/meerkat-runtime/tests/driver_persistent.rs
+++ b/meerkat-runtime/tests/driver_persistent.rs
@@ -33,6 +33,8 @@ fn stored_accepted(state: InputState) -> StoredInputState {
 struct FailPersistInputStore {
     inner: Arc<InMemoryRuntimeStore>,
     fail_persist_input_state: AtomicBool,
+    fail_atomic_apply: AtomicBool,
+    fail_atomic_lifecycle_commit: AtomicBool,
 }
 
 impl FailPersistInputStore {
@@ -40,6 +42,26 @@ impl FailPersistInputStore {
         Self {
             inner,
             fail_persist_input_state: AtomicBool::new(true),
+            fail_atomic_apply: AtomicBool::new(false),
+            fail_atomic_lifecycle_commit: AtomicBool::new(false),
+        }
+    }
+
+    fn fail_atomic_apply_once(inner: Arc<InMemoryRuntimeStore>) -> Self {
+        Self {
+            inner,
+            fail_persist_input_state: AtomicBool::new(false),
+            fail_atomic_apply: AtomicBool::new(true),
+            fail_atomic_lifecycle_commit: AtomicBool::new(false),
+        }
+    }
+
+    fn fail_atomic_lifecycle_commit_once(inner: Arc<InMemoryRuntimeStore>) -> Self {
+        Self {
+            inner,
+            fail_persist_input_state: AtomicBool::new(false),
+            fail_atomic_apply: AtomicBool::new(false),
+            fail_atomic_lifecycle_commit: AtomicBool::new(true),
         }
     }
 }
@@ -75,6 +97,11 @@ impl RuntimeStore for FailPersistInputStore {
         input_updates: Vec<StoredInputState>,
         session_store_key: Option<meerkat_core::types::SessionId>,
     ) -> Result<(), RuntimeStoreError> {
+        if self.fail_atomic_apply.swap(false, Ordering::SeqCst) {
+            return Err(RuntimeStoreError::WriteFailed(
+                "synthetic atomic_apply failure".into(),
+            ));
+        }
         self.inner
             .atomic_apply(
                 runtime_id,
@@ -153,6 +180,14 @@ impl RuntimeStore for FailPersistInputStore {
         runtime_state: RuntimeState,
         input_states: &[StoredInputState],
     ) -> Result<(), RuntimeStoreError> {
+        if self
+            .fail_atomic_lifecycle_commit
+            .swap(false, Ordering::SeqCst)
+        {
+            return Err(RuntimeStoreError::WriteFailed(
+                "synthetic atomic_lifecycle_commit failure".into(),
+            ));
+        }
         self.inner
             .atomic_lifecycle_commit(runtime_id, runtime_state, input_states)
             .await
@@ -408,6 +443,45 @@ async fn boundary_applied_persists_atomically() {
 }
 
 #[tokio::test]
+async fn boundary_apply_failure_restores_staged_state() {
+    let inner = Arc::new(InMemoryRuntimeStore::new());
+    let store: Arc<dyn RuntimeStore> =
+        Arc::new(FailPersistInputStore::fail_atomic_apply_once(inner.clone()));
+    let rid = LogicalRuntimeId::new("test");
+    let mut driver = PersistentRuntimeDriver::new(rid, store, memory_blob_store());
+
+    let input = make_prompt("hello");
+    let input_id = input.id().clone();
+    driver.accept_input(input).await.unwrap();
+
+    let run_id = RunId::new();
+    bind_running(&mut driver, run_id.clone(), RuntimeState::Idle);
+    driver.stage_input(&input_id, &run_id).unwrap();
+
+    let receipt = RunBoundaryReceipt {
+        run_id: run_id.clone(),
+        boundary: RunApplyBoundary::RunStart,
+        contributing_input_ids: vec![input_id.clone()],
+        conversation_digest: None,
+        message_count: 1,
+        sequence: 0,
+    };
+    let err = driver
+        .boundary_applied(run_id, receipt, Some(b"session-data".to_vec()))
+        .await
+        .expect_err("atomic apply should fail");
+    assert!(
+        err.to_string().contains("synthetic atomic_apply failure"),
+        "unexpected error: {err}",
+    );
+    assert_eq!(
+        driver.inner_ref().input_phase(&input_id),
+        Some(meerkat_runtime::input_state::InputLifecycleState::Staged),
+        "failed boundary apply must restore the staged lifecycle",
+    );
+}
+
+#[tokio::test]
 async fn durable_runtime_input_externalizes_inline_images_before_ack() {
     let store = Arc::new(InMemoryRuntimeStore::new());
     let rid = LogicalRuntimeId::new("test");
@@ -496,6 +570,40 @@ async fn durable_accept_failure_restores_canonical_ingress_state() {
     assert!(
         outcome.is_accepted(),
         "retry after failed durable admission should succeed cleanly"
+    );
+}
+
+#[tokio::test]
+async fn recycle_failure_restores_canonical_ingress_state() {
+    let inner = Arc::new(InMemoryRuntimeStore::new());
+    let store: Arc<dyn RuntimeStore> = Arc::new(
+        FailPersistInputStore::fail_atomic_lifecycle_commit_once(inner.clone()),
+    );
+    let rid = LogicalRuntimeId::new("test");
+    let mut driver = PersistentRuntimeDriver::new(rid, store, memory_blob_store());
+
+    let input = make_prompt("hello");
+    let input_id = input.id().clone();
+    driver.accept_input(input).await.unwrap();
+
+    let err = driver
+        .recycle_preserving_work(RuntimeState::Idle)
+        .await
+        .expect_err("recycle persist should fail");
+    assert!(
+        err.to_string()
+            .contains("synthetic atomic_lifecycle_commit failure"),
+        "unexpected error: {err}",
+    );
+    assert_eq!(
+        driver.inner_ref().input_phase(&input_id),
+        Some(meerkat_runtime::input_state::InputLifecycleState::Queued),
+        "failed recycle must restore the queued lifecycle",
+    );
+    assert_eq!(
+        driver.dequeue_next().map(|(id, _)| id),
+        Some(input_id),
+        "failed recycle must restore the queue projection",
     );
 }
 

--- a/meerkat-runtime/tests/meerkat_machine.rs
+++ b/meerkat-runtime/tests/meerkat_machine.rs
@@ -287,6 +287,34 @@ async fn persistent_adapter_accept() {
 }
 
 #[tokio::test]
+async fn cold_reregister_preserves_destroyed_runtime_state() {
+    let store = Arc::new(meerkat_runtime::store::InMemoryRuntimeStore::new());
+    let sid = SessionId::new();
+
+    let adapter = Arc::new(MeerkatMachine::persistent(
+        Arc::clone(&store) as Arc<dyn RuntimeStore>,
+        memory_blob_store(),
+    ));
+    adapter.register_session(sid.clone()).await;
+    let runtime_id = LogicalRuntimeId::new(sid.to_string());
+    meerkat_runtime::traits::RuntimeControlPlane::destroy(&*adapter, &runtime_id)
+        .await
+        .expect("destroy should succeed before adapter restart");
+    drop(adapter);
+
+    let restarted = Arc::new(MeerkatMachine::persistent(
+        Arc::clone(&store) as Arc<dyn RuntimeStore>,
+        memory_blob_store(),
+    ));
+    restarted.register_session(sid.clone()).await;
+    assert_eq!(
+        restarted.runtime_state(&sid).await.unwrap(),
+        RuntimeState::Destroyed,
+        "cold re-registration must preserve the stored destroyed phase",
+    );
+}
+
+#[tokio::test]
 async fn unregistered_session_errors() {
     let adapter = Arc::new(MeerkatMachine::ephemeral());
     let sid = SessionId::new();

--- a/meerkat/src/surface/runtime_backed.rs
+++ b/meerkat/src/surface/runtime_backed.rs
@@ -416,7 +416,7 @@ mod tests {
         let session = Session::new();
         let session_id = session.id().clone();
 
-        let error = materialize_session(
+        let error = Box::pin(materialize_session(
             &service,
             &adapter,
             session,
@@ -429,7 +429,7 @@ mod tests {
                 let adapter = Arc::clone(&adapter);
                 move |session_id| default_persistent_executor(service, adapter, session_id)
             },
-        )
+        ))
         .await
         .expect_err("invalid build settings must fail");
 
@@ -460,7 +460,7 @@ mod tests {
         let temp = tempfile::tempdir().expect("tempdir");
         let (service, adapter) = build_test_service(&temp).await;
 
-        let result = materialize_session(
+        let result = Box::pin(materialize_session(
             &service,
             &adapter,
             Session::new(),
@@ -470,7 +470,7 @@ mod tests {
                 let adapter = Arc::clone(&adapter);
                 move |session_id| default_persistent_executor(service, adapter, session_id)
             },
-        )
+        ))
         .await
         .expect("create session with shared default executor");
 
@@ -548,7 +548,7 @@ mod tests {
     async fn persistent_runtime_executor_stop_discards_and_unregisters() {
         let temp = tempfile::tempdir().expect("tempdir");
         let (service, adapter) = build_test_service(&temp).await;
-        let result = materialize_session(
+        let result = Box::pin(materialize_session(
             &service,
             &adapter,
             Session::new(),
@@ -558,7 +558,7 @@ mod tests {
                 let adapter = Arc::clone(&adapter);
                 move |session_id| default_persistent_executor(service, adapter, session_id)
             },
-        )
+        ))
         .await
         .expect("materialize session");
 
@@ -592,7 +592,7 @@ mod tests {
     async fn persistent_runtime_executor_cancel_surfaces_no_active_run() {
         let temp = tempfile::tempdir().expect("tempdir");
         let (service, adapter) = build_test_service(&temp).await;
-        let result = materialize_session(
+        let result = Box::pin(materialize_session(
             &service,
             &adapter,
             Session::new(),
@@ -602,7 +602,7 @@ mod tests {
                 let adapter = Arc::clone(&adapter);
                 move |session_id| default_persistent_executor(service, adapter, session_id)
             },
-        )
+        ))
         .await
         .expect("materialize session");
 
@@ -629,7 +629,7 @@ mod tests {
     async fn persistent_runtime_executor_cancel_after_boundary_surfaces_no_active_run() {
         let temp = tempfile::tempdir().expect("tempdir");
         let (service, adapter) = build_test_service(&temp).await;
-        let result = materialize_session(
+        let result = Box::pin(materialize_session(
             &service,
             &adapter,
             Session::new(),
@@ -639,7 +639,7 @@ mod tests {
                 let adapter = Arc::clone(&adapter);
                 move |session_id| default_persistent_executor(service, adapter, session_id)
             },
-        )
+        ))
         .await
         .expect("materialize session");
 
@@ -672,7 +672,7 @@ mod tests {
             CommsRuntime::inproc_only("surface-peer-ingress").expect("create inproc comms runtime"),
         );
         let (service, adapter) = build_test_service_with_runtime(&temp, Some(shared_runtime)).await;
-        let result = materialize_session(
+        let result = Box::pin(materialize_session(
             &service,
             &adapter,
             Session::new(),
@@ -686,7 +686,7 @@ mod tests {
                 let adapter = Arc::clone(&adapter);
                 move |session_id| default_persistent_executor(service, adapter, session_id)
             },
-        )
+        ))
         .await
         .expect("materialize session");
 
@@ -707,7 +707,7 @@ mod tests {
             CommsRuntime::inproc_only("surface-keep-alive").expect("create inproc comms runtime"),
         );
         let (service, adapter) = build_test_service_with_runtime(&temp, Some(shared_runtime)).await;
-        let result = materialize_session(
+        let result = Box::pin(materialize_session(
             &service,
             &adapter,
             Session::new(),
@@ -721,7 +721,7 @@ mod tests {
                 let adapter = Arc::clone(&adapter);
                 move |session_id| default_persistent_executor(service, adapter, session_id)
             },
-        )
+        ))
         .await
         .expect("materialize session");
 
@@ -758,7 +758,7 @@ mod tests {
 
         let temp = tempfile::tempdir().expect("tempdir");
         let (service, adapter) = build_test_service(&temp).await;
-        let result = materialize_session(
+        let result = Box::pin(materialize_session(
             &service,
             &adapter,
             Session::new(),
@@ -768,7 +768,7 @@ mod tests {
                 let adapter = Arc::clone(&adapter);
                 move |session_id| default_persistent_executor(service, adapter, session_id)
             },
-        )
+        ))
         .await
         .expect("materialize session");
 
@@ -924,7 +924,7 @@ mod tests {
     async fn runtime_backed_openai_live_orchestrator_routes_tool_calls_through_service_host() {
         let temp = tempfile::tempdir().expect("tempdir");
         let (service, adapter) = build_test_service(&temp).await;
-        let result = materialize_session(
+        let result = Box::pin(materialize_session(
             &service,
             &adapter,
             Session::new(),
@@ -934,7 +934,7 @@ mod tests {
                 let adapter = Arc::clone(&adapter);
                 move |session_id| default_persistent_executor(service, adapter, session_id)
             },
-        )
+        ))
         .await
         .expect("materialize session");
         let session_id = result.session_id.clone();

--- a/meerkat/src/surface/runtime_schedule_host.rs
+++ b/meerkat/src/surface/runtime_schedule_host.rs
@@ -339,7 +339,7 @@ impl SurfaceScheduleSessionHost for RuntimeBackedScheduleSessionHost {
     ) -> Result<SessionId, ScheduleDomainError> {
         let request = self.build_materialized_request(create, prompt_system_prompt);
         let keep_alive = request.build.as_ref().is_some_and(|build| build.keep_alive);
-        let result = materialize_session(
+        let result = Box::pin(materialize_session(
             &self.service,
             &self.runtime_adapter,
             Session::new(),
@@ -349,7 +349,7 @@ impl SurfaceScheduleSessionHost for RuntimeBackedScheduleSessionHost {
                 let runtime_adapter = Arc::clone(&self.runtime_adapter);
                 move |session_id| default_persistent_executor(service, runtime_adapter, session_id)
             },
-        )
+        ))
         .await
         .map_err(schedule_internal)?;
         #[cfg(feature = "comms")]

--- a/test-fixtures/surface-build-fixtures/src/bin/runtime_backed_min.rs
+++ b/test-fixtures/surface-build-fixtures/src/bin/runtime_backed_min.rs
@@ -34,7 +34,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let builder = FactoryAgentBuilder::new(factory, config.clone());
     let (service, runtime_adapter) = build_runtime_backed_service(builder, 4, persistence);
     let service = Arc::new(service);
-    let result = materialize_session(
+    let result = Box::pin(materialize_session(
         &service,
         &runtime_adapter,
         meerkat::Session::new(),
@@ -56,7 +56,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             let adapter = Arc::clone(&runtime_adapter);
             move |session_id| default_persistent_executor(service, adapter, session_id)
         },
-    )
+    ))
     .await?;
 
     let (_outcome, handle) = runtime_adapter


### PR DESCRIPTION
## Summary
Collapses ingress authority to one shared per-session `MeerkatMachineAuthority` instead of a session-owned DSL plus a private driver DSL kept in sync by replay and disagreement warnings.

## Root Cause
The runtime kept two writable copies of ingress truth:
- the session-owned `RuntimeSessionEntry.dsl_authority`
- a private driver-owned ingress DSL inside `EphemeralRuntimeDriver`

Fresh admission and lifecycle transitions were realized in the driver, then shadow-replayed back onto the session DSL in `dispatch_ingress`, with `DSL/runtime DISAGREEMENT` warnings when they drifted. That duplicated semantic ownership and also forced helper recomputation / manual mirroring for post-admission signals.

## What Changed
- shares one ingress DSL authority between the session entry and the runtime driver
- removes fresh-ingress shadow replay from `dispatch_ingress`
- uses one resolved-admission classification for preview, driver realization, and final coarse accept apply
- suppresses deduped `AcceptWithCompletion` signals correctly by only committing coarse accept on real accepted outcomes
- feeds fresh-admission `post_admission_signal` from canonical committed DSL effects
- keeps the existing failed-run replay wake path as the temporary explicit exception
- replaces persistent-driver rollback-by-`inner.clone()` with explicit shell + authority snapshots
- preserves the canonical shared authority across recover / recycle paths
- fixes destroy / boundary-commit unwind behavior exposed by the shared-authority cutover

## Validation
- `./scripts/repo-cargo check -p meerkat-runtime`
- `./scripts/repo-cargo clippy -p meerkat-runtime --tests -- -D warnings`
- `./scripts/repo-cargo test -p meerkat-runtime -- --nocapture`

## Added Defensive Coverage
- shared authority identity across register / recover / recycle
- deduplicated `AcceptWithCompletion` emits no new signal
- persistent `atomic_apply` rollback restores staged state
- persistent recycle failure restores canonical ingress state
