### PR TITLE
fix(skills): remove silent identity fallback in external skill protocol (dogma round 4, salvage)

### DIFF
--- a/meerkat-skills/src/resolve.rs
+++ b/meerkat-skills/src/resolve.rs
@@ -165,10 +165,7 @@ pub async fn resolve_repositories_with_roots(
                     );
                     sources.push(NamedSource {
                         name: repo.name.clone(),
-                        source: SourceNode::External(ExternalSkillSource::new(
-                            repo.source_uuid.to_string(),
-                            client,
-                        )),
+                        source: SourceNode::External(ExternalSkillSource::new(client)),
                     });
                 }
                 SkillRepoTransport::Git {

--- a/meerkat-skills/src/source/http.rs
+++ b/meerkat-skills/src/source/http.rs
@@ -387,10 +387,12 @@ impl HttpSkillSource {
         );
 
         Self {
-            external: ExternalSkillSource::new(
-                source_uuid.clone(),
-                HttpExternalClient::new_with_timeout(source_uuid, base_url, auth, request_timeout),
-            ),
+            external: ExternalSkillSource::new(HttpExternalClient::new_with_timeout(
+                source_uuid,
+                base_url,
+                auth,
+                request_timeout,
+            )),
             client,
             cache_ttl,
             cache: RwLock::new(HttpSkillCache::new()),

--- a/meerkat-skills/src/source/mod.rs
+++ b/meerkat-skills/src/source/mod.rs
@@ -250,7 +250,7 @@ fi
             BTreeMap::new(),
             None,
         );
-        let external = ExternalSkillSource::new("ext-src", client);
+        let external = ExternalSkillSource::new(client);
         let node = SourceNode::External(external);
         let listed = node.list(&SkillFilter::default()).await.unwrap();
         assert_eq!(listed.len(), 1);

--- a/meerkat-skills/src/source/protocol.rs
+++ b/meerkat-skills/src/source/protocol.rs
@@ -181,8 +181,13 @@ pub trait ExternalClient: Send + Sync {
 }
 
 /// External source adapter that performs and caches capability handshake per instance.
+///
+/// The adapter owns no local source identity: every `source_uuid` used on the
+/// wire is discovered from the remote `skills/list_summaries` enumeration and
+/// cached in `skill_source_index` as a read-through projection of that
+/// canonical answer. There is intentionally no local-UUID fallback — a skill
+/// the remote has not announced resolves to `SkillError::NotFound`.
 pub struct ExternalSkillSource<C: ExternalClient> {
-    source_uuid: String,
     client: C,
     handshake: Arc<RwLock<Option<SourceCapabilityHandshake>>>,
     skill_source_index: Arc<RwLock<HashMap<SkillId, String>>>,
@@ -190,9 +195,8 @@ pub struct ExternalSkillSource<C: ExternalClient> {
 }
 
 impl<C: ExternalClient> ExternalSkillSource<C> {
-    pub fn new(source_uuid: impl Into<String>, client: C) -> Self {
+    pub fn new(client: C) -> Self {
         Self {
-            source_uuid: source_uuid.into(),
             client,
             handshake: Arc::new(RwLock::new(None)),
             skill_source_index: Arc::new(RwLock::new(HashMap::new())),
@@ -255,6 +259,11 @@ impl<C: ExternalClient> ExternalSkillSource<C> {
         Ok(())
     }
 
+    /// Resolve the canonical `source_uuid` for a skill by consulting the remote
+    /// source's `skills/list_summaries` enumeration. The in-memory index is a
+    /// read-through projection of that canonical enumeration — never treated as
+    /// authority on its own. A miss after refresh is a typed `NotFound`, not a
+    /// silent substitution of the local source UUID.
     async fn source_for_skill(&self, skill_id: &SkillId) -> Result<String, SkillError> {
         if let Some(found) = self.skill_source_index.read().await.get(skill_id).cloned() {
             return Ok(found);
@@ -273,7 +282,9 @@ impl<C: ExternalClient> ExternalSkillSource<C> {
             index.insert(id, summary.source_uuid);
         }
 
-        Ok(discovered.unwrap_or_else(|| self.source_uuid.clone()))
+        discovered.ok_or_else(|| SkillError::NotFound {
+            id: skill_id.clone(),
+        })
     }
 
     pub async fn list_artifacts(
@@ -285,7 +296,8 @@ impl<C: ExternalClient> ExternalSkillSource<C> {
         let artifacts = self
             .client
             .skills_list_artifacts(&source_uuid, &skill_id.0)
-            .await?;
+            .await
+            .map_err(|error| normalize_not_found(error, skill_id))?;
         Ok(artifacts
             .into_iter()
             .map(|artifact| SkillArtifact {
@@ -306,7 +318,8 @@ impl<C: ExternalClient> ExternalSkillSource<C> {
         let artifact = self
             .client
             .skills_read_artifact(&source_uuid, &skill_id.0, artifact_path)
-            .await?;
+            .await
+            .map_err(|error| normalize_not_found(error, skill_id))?;
         Ok(SkillArtifactContent {
             path: artifact.path,
             mime_type: artifact.mime_type,
@@ -325,6 +338,20 @@ impl<C: ExternalClient> ExternalSkillSource<C> {
         self.client
             .skills_invoke_function(&source_uuid, &skill_id.0, function_name, arguments)
             .await
+            .map_err(|error| normalize_not_found(error, skill_id))
+    }
+}
+
+/// Re-anchor remote `NotFound` errors to the caller-supplied `skill_id`.
+/// Remote sources may emit `NotFound` with the skill name they were asked about
+/// or a sentinel id; callers of these methods always expect the id they passed
+/// to come back on a miss. All other variants pass through unchanged.
+fn normalize_not_found(error: SkillError, skill_id: &SkillId) -> SkillError {
+    match error {
+        SkillError::NotFound { .. } => SkillError::NotFound {
+            id: skill_id.clone(),
+        },
+        other => other,
     }
 }
 
@@ -397,10 +424,7 @@ impl<C: ExternalClient + Send + Sync> SkillSource for ExternalSkillSource<C> {
                 .client
                 .skills_load_package(&source_uuid, &id.0)
                 .await
-                .map_err(|error| match error {
-                    SkillError::NotFound { .. } => SkillError::NotFound { id: id.clone() },
-                    other => other,
-                })?;
+                .map_err(|error| normalize_not_found(error, id))?;
 
             Ok(SkillDocument {
                 descriptor: SkillDescriptor {
@@ -1087,7 +1111,7 @@ mod tests {
     async fn test_handshake_precedes_ops_and_is_cached_per_source_instance() {
         let client = MockExternalClient::full();
         let handshake_counter = client.handshake_calls.clone();
-        let source = ExternalSkillSource::new("source-a", client);
+        let source = ExternalSkillSource::new(client);
 
         let listed = source.list(&SkillFilter::default()).await.unwrap();
         assert_eq!(listed.len(), 1);
@@ -1119,10 +1143,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_capability_mismatch_returns_typed_error() {
-        let source = ExternalSkillSource::new(
-            "source-a",
-            MockExternalClient::missing("skills/read_artifact"),
-        );
+        let source = ExternalSkillSource::new(MockExternalClient::missing("skills/read_artifact"));
 
         let error = source
             .read_artifact(
@@ -1150,6 +1171,49 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn test_unknown_skill_returns_not_found_without_identity_fallback() {
+        // Remote announces `extraction/email` but caller asks for
+        // `extraction/phone`. The adapter must surface a typed NotFound — it
+        // must NOT silently substitute its own identity and proceed.
+        let source = ExternalSkillSource::new(MockExternalClient::full());
+
+        let error = source
+            .load(&SkillId("extraction/phone".to_string()))
+            .await
+            .expect_err("unknown skill should fail");
+
+        assert!(matches!(
+            error,
+            SkillError::NotFound { id: SkillId(ref id) } if id == "extraction/phone"
+        ));
+
+        let error = source
+            .list_artifacts(&SkillId("extraction/phone".to_string()))
+            .await
+            .expect_err("unknown skill should fail on list_artifacts");
+        assert!(matches!(error, SkillError::NotFound { .. }));
+
+        let error = source
+            .read_artifact(
+                &SkillId("extraction/phone".to_string()),
+                "resources/schema.json",
+            )
+            .await
+            .expect_err("unknown skill should fail on read_artifact");
+        assert!(matches!(error, SkillError::NotFound { .. }));
+
+        let error = source
+            .invoke_function(
+                &SkillId("extraction/phone".to_string()),
+                "validate",
+                serde_json::json!({}),
+            )
+            .await
+            .expect_err("unknown skill should fail on invoke_function");
+        assert!(matches!(error, SkillError::NotFound { .. }));
+    }
+
+    #[tokio::test]
     async fn test_stdio_transport_lifecycle_summaries_package_resources_functions() {
         let response_script = r##"
 read line
@@ -1174,7 +1238,7 @@ fi
             BTreeMap::new(),
             None,
         );
-        let source = ExternalSkillSource::new("source-a", client);
+        let source = ExternalSkillSource::new(client);
 
         let summaries = source.list(&SkillFilter::default()).await.unwrap();
         assert_eq!(summaries.len(), 1);

--- a/meerkat/tests/integration.rs
+++ b/meerkat/tests/integration.rs
@@ -1140,15 +1140,12 @@ elif echo "$line" | grep -q '"method":"skills/invoke_function"'; then
   echo '{"jsonrpc":"2.0","id":"1","payload":{"method":"skills/invoke_function","result":{"output":{"transport":"stdio","ok":true}}}}'
 fi
 "#;
-        let stdio = ExternalSkillSource::new(
-            "stdio-src",
-            StdioExternalClient::new(
-                "sh",
-                vec!["-c".to_string(), stdio_script.to_string()],
-                BTreeMap::new(),
-                None,
-            ),
-        );
+        let stdio = ExternalSkillSource::new(StdioExternalClient::new(
+            "sh",
+            vec!["-c".to_string(), stdio_script.to_string()],
+            BTreeMap::new(),
+            None,
+        ));
 
         let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
         let addr = listener.local_addr().unwrap();
@@ -1201,10 +1198,11 @@ fi
                 });
             }
         });
-        let http = ExternalSkillSource::new(
+        let http = ExternalSkillSource::new(HttpExternalClient::new(
             "http-src",
-            HttpExternalClient::new("http-src", format!("http://{addr}"), None),
-        );
+            format!("http://{addr}"),
+            None,
+        ));
 
         let stdio_skills = stdio.list(&SkillFilter::default()).await.unwrap();
         let http_skills = http.list(&SkillFilter::default()).await.unwrap();


### PR DESCRIPTION
## Summary

Dogma round 4, violation #11 — `meerkat-skills/src/source/protocol.rs:188,258,276,283,304,391`: the `ExternalSkillSource` adapter carried a local `source_uuid` that acted as an authoritative fallback whenever the remote source had not announced a requested skill. A miss became a silent identity substitution — callers got `Ok(...)` bound to the adapter's own UUID and subsequent calls executed against the wrong source. This PR removes the fallback and propagates typed `NotFound` instead.

This is a **salvage** of a prior run that stalled mid-task. The core protocol change was already on disk and compiled clean; this commit adds the regression coverage the previous run was about to write and runs the full pre-push gate.

## Refactor direction

- Drop the local `source_uuid` field from `ExternalSkillSource`. There is no local identity. Every `source_uuid` used on the wire is discovered from `skills/list_summaries` and cached in `skill_source_index` strictly as a read-through projection of the canonical remote answer.
- `source_for_skill` now returns `SkillError::NotFound { id }` on a cache miss + no discovery instead of substituting the local UUID.
- `normalize_not_found` helper re-anchors remote `NotFound` errors to the caller's requested `SkillId` across `list_artifacts`, `read_artifact`, `invoke_function`, and `load`, so callers always see the id they asked for.
- `ExternalSkillSource::new(client)` is now single-arg. All construction sites (`resolve.rs`, `http.rs`, module tests, integration tests) updated.

## Previous agent's work vs. what I added

Previous agent (5 files, +98/-37) — already on disk, compiles clean:
- Removed `source_uuid` field and constructor arg.
- Switched `source_for_skill` to return typed `NotFound`.
- Added `normalize_not_found` + wired it through `list_artifacts`, `read_artifact`, `invoke_function`, and tightened the `load` path.
- Updated all `ExternalSkillSource::new(...)` callers.

What I added on top:
- The regression test the previous run was about to write: `test_unknown_skill_returns_not_found_without_identity_fallback`, exercising all four read paths (`load`, `list_artifacts`, `read_artifact`, `invoke_function`) for a skill (`extraction/phone`) that the mock remote never announces. Asserts typed `NotFound` rather than `Ok(...)` with a substituted identity.
- Full pre-push gate: workspace fmt, `clippy -D warnings` (workspace), `nextest -p meerkat-skills` (81/81), and workspace `int-fast` (4759/4759).

## Offline-mode finding

The previous agent collapsed the fallback **entirely**. There is no `OfflineCached` wrapper, no typed offline-authoritative variant. Once the remote hasn't announced a skill, the answer is `NotFound` — period. The `skill_source_index` cache is still present, but only as a read-through projection of prior canonical enumerations, never as standalone authority.

This is the right call for this refactor: a silent fall-through inside `ExternalSkillSource` was the exact dogma violation. If cached-offline behaviour is ever wanted, it should be a separate typed source that explicitly declares its staleness semantics, not a fall-through here. I recorded that product question in the commit body.

## Test plan

- [x] `./scripts/repo-cargo fmt --all -- --check`
- [x] `./scripts/repo-cargo clippy --workspace --all-targets -- -D warnings`
- [x] `./scripts/repo-cargo nextest run -p meerkat-skills` — 81 passed (incl. new regression test)
- [x] `./scripts/repo-cargo int` — 4759 tests run, 4759 passed, 0 failed
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)