### PR TITLE
fix(schedule): propagate typed runtime outcomes through schedule host (dogma round 4, salvage)

### DIFF
--- a/examples/035-mdm-tux-rs/src/bin/target.rs
+++ b/examples/035-mdm-tux-rs/src/bin/target.rs
@@ -34,9 +34,8 @@ use meerkat::{
 };
 use meerkat::surface::{
     NoopScheduleMobHost, ScheduledPromptDispatch, SharedScheduleTargetAdapter,
-    SurfaceScheduleSessionHost, accepted_scheduled_input_from_runtime_outcome,
-    build_dispatch_from_accepted, schedule_attempt_idempotency_key, schedule_host_supported,
-    spawn_schedule_host,
+    SurfaceScheduleSessionHost, dispatch_from_admission, project_runtime_admission,
+    schedule_attempt_idempotency_key, schedule_host_supported, spawn_schedule_host,
 };
 use meerkat_comms::{CommsRuntime, PeerMeta, ResolvedCommsConfig, TrustedPeer};
 use meerkat_core::lifecycle::RunId;
@@ -350,9 +349,9 @@ impl SurfaceScheduleSessionHost for TargetScheduleSessionHost {
             .await
             .map_err(|error| meerkat::ScheduleDomainError::Internal(error.to_string()))?;
 
-        Ok(build_dispatch_from_accepted(
+        Ok(dispatch_from_admission(
             occurrence,
-            accepted_scheduled_input_from_runtime_outcome(outcome, handle),
+            project_runtime_admission(outcome, handle),
             dispatch.materialized_session_id,
         ))
     }
@@ -397,9 +396,9 @@ impl SurfaceScheduleSessionHost for TargetScheduleSessionHost {
             .await
             .map_err(|error| meerkat::ScheduleDomainError::Internal(error.to_string()))?;
 
-        Ok(build_dispatch_from_accepted(
+        Ok(dispatch_from_admission(
             occurrence,
-            accepted_scheduled_input_from_runtime_outcome(outcome, handle),
+            project_runtime_admission(outcome, handle),
             materialized_session_id,
         ))
     }

--- a/meerkat-cli/src/main.rs
+++ b/meerkat-cli/src/main.rs
@@ -11,9 +11,8 @@ use base64::engine::general_purpose::STANDARD as BASE64_STANDARD;
 use chrono::Utc;
 use meerkat::surface::{
     NoopScheduleMobHost, ScheduledPromptDispatch, SharedScheduleTargetAdapter,
-    SurfaceScheduleSessionHost, accepted_scheduled_input_from_runtime_outcome,
-    build_dispatch_from_accepted, schedule_attempt_idempotency_key, schedule_host_supported,
-    spawn_schedule_host,
+    SurfaceScheduleSessionHost, dispatch_from_admission, project_runtime_admission,
+    schedule_attempt_idempotency_key, schedule_host_supported, spawn_schedule_host,
 };
 use meerkat::{
     AgentFactory, EphemeralSessionService, FactoryAgentBuilder, PersistenceBundle, ScheduleService,
@@ -6457,9 +6456,9 @@ impl SurfaceScheduleSessionHost for CliScheduleSessionHost {
             .accept_input_with_completion(session_id, Input::Prompt(prompt_input))
             .await
             .map_err(|error| meerkat::ScheduleDomainError::Internal(error.to_string()))?;
-        Ok(build_dispatch_from_accepted(
+        Ok(dispatch_from_admission(
             occurrence,
-            accepted_scheduled_input_from_runtime_outcome(outcome, handle),
+            project_runtime_admission(outcome, handle),
             dispatch.materialized_session_id,
         ))
     }
@@ -6501,9 +6500,9 @@ impl SurfaceScheduleSessionHost for CliScheduleSessionHost {
             .accept_input_with_completion(session_id, input)
             .await
             .map_err(|error| meerkat::ScheduleDomainError::Internal(error.to_string()))?;
-        Ok(build_dispatch_from_accepted(
+        Ok(dispatch_from_admission(
             occurrence,
-            accepted_scheduled_input_from_runtime_outcome(outcome, handle),
+            project_runtime_admission(outcome, handle),
             materialized_session_id,
         ))
     }

--- a/meerkat-mcp-server/src/schedule_host.rs
+++ b/meerkat-mcp-server/src/schedule_host.rs
@@ -7,9 +7,9 @@ use async_trait::async_trait;
 use meerkat::DeliveryTerminal;
 use meerkat::surface::prepare_surface_session;
 use meerkat::surface::{
-    ScheduledPromptDispatch, SharedScheduleTargetAdapter, SurfaceScheduleMobHost,
-    SurfaceScheduleSessionHost, accepted_scheduled_input_from_runtime_outcome,
-    build_dispatch_from_accepted, immediate_delivery_failure, schedule_attempt_idempotency_key,
+    RuntimeAdmissionProjection, ScheduledPromptDispatch, SharedScheduleTargetAdapter,
+    SurfaceScheduleMobHost, SurfaceScheduleSessionHost, dispatch_from_admission,
+    immediate_delivery_failure, project_runtime_admission, schedule_attempt_idempotency_key,
     schedule_host_supported, spawn_schedule_host,
 };
 #[cfg(feature = "mob")]
@@ -670,9 +670,9 @@ async fn deliver_scheduled_prompt(
     )
     .await
     {
-        Ok(accepted) => Ok(build_dispatch_from_accepted(
+        Ok(projection) => Ok(dispatch_from_admission(
             occurrence,
-            accepted,
+            projection,
             dispatch.materialized_session_id,
         )),
         Err(error) => Ok(immediate_delivery_failure(
@@ -704,9 +704,9 @@ async fn deliver_scheduled_event(
     )
     .await
     {
-        Ok(accepted) => Ok(build_dispatch_from_accepted(
+        Ok(projection) => Ok(dispatch_from_admission(
             occurrence,
-            accepted,
+            projection,
             materialized_session_id,
         )),
         Err(error) => Ok(immediate_delivery_failure(
@@ -727,7 +727,7 @@ async fn accept_scheduled_prompt_with_completion(
     render_metadata: Option<meerkat_core::types::RenderMetadata>,
     skill_references: Vec<String>,
     additional_instructions: Vec<String>,
-) -> Result<meerkat::surface::AcceptedScheduledInput, ScheduleDomainError> {
+) -> Result<RuntimeAdmissionProjection, ScheduleDomainError> {
     let config = context
         .config_runtime
         .get()
@@ -770,9 +770,7 @@ async fn accept_scheduled_prompt_with_completion(
         .accept_input_with_completion(session_id, Input::Prompt(prompt_input), None)
         .await
         .map_err(|error| ScheduleDomainError::Internal(error.to_string()))?;
-    Ok(accepted_scheduled_input_from_runtime_outcome(
-        outcome, handle,
-    ))
+    Ok(project_runtime_admission(outcome, handle))
 }
 
 async fn accept_scheduled_event_with_completion(
@@ -782,7 +780,7 @@ async fn accept_scheduled_event_with_completion(
     event_type: String,
     payload: serde_json::Value,
     render_metadata: Option<meerkat_core::types::RenderMetadata>,
-) -> Result<meerkat::surface::AcceptedScheduledInput, ScheduleDomainError> {
+) -> Result<RuntimeAdmissionProjection, ScheduleDomainError> {
     context
         .ensure_runtime_session_registered(session_id)
         .await?;
@@ -815,9 +813,7 @@ async fn accept_scheduled_event_with_completion(
         .accept_input_with_completion(session_id, input, None)
         .await
         .map_err(|error| ScheduleDomainError::Internal(error.to_string()))?;
-    Ok(accepted_scheduled_input_from_runtime_outcome(
-        outcome, handle,
-    ))
+    Ok(project_runtime_admission(outcome, handle))
 }
 
 async fn update_peer_ingress_context(_context: &McpScheduleContext, _session_id: &SessionId) {

--- a/meerkat-rest/src/schedule_host.rs
+++ b/meerkat-rest/src/schedule_host.rs
@@ -6,9 +6,9 @@ use async_trait::async_trait;
 #[cfg(feature = "mob")]
 use meerkat::DeliveryTerminal;
 use meerkat::surface::{
-    ScheduledPromptDispatch, SharedScheduleTargetAdapter, SurfaceScheduleMobHost,
-    SurfaceScheduleSessionHost, accepted_scheduled_input_from_runtime_outcome,
-    build_dispatch_from_accepted, immediate_delivery_failure, schedule_attempt_idempotency_key,
+    RuntimeAdmissionProjection, ScheduledPromptDispatch, SharedScheduleTargetAdapter,
+    SurfaceScheduleMobHost, SurfaceScheduleSessionHost, dispatch_from_admission,
+    immediate_delivery_failure, project_runtime_admission, schedule_attempt_idempotency_key,
     schedule_host_supported, spawn_schedule_host,
 };
 #[cfg(feature = "mob")]
@@ -583,9 +583,9 @@ async fn deliver_scheduled_prompt(
     )
     .await
     {
-        Ok(accepted) => Ok(build_dispatch_from_accepted(
+        Ok(projection) => Ok(dispatch_from_admission(
             occurrence,
-            accepted,
+            projection,
             dispatch.materialized_session_id,
         )),
         Err(error) => Ok(immediate_delivery_failure(
@@ -617,9 +617,9 @@ async fn deliver_scheduled_event(
     )
     .await
     {
-        Ok(accepted) => Ok(build_dispatch_from_accepted(
+        Ok(projection) => Ok(dispatch_from_admission(
             occurrence,
-            accepted,
+            projection,
             materialized_session_id,
         )),
         Err(error) => Ok(immediate_delivery_failure(
@@ -640,7 +640,7 @@ async fn accept_scheduled_prompt_with_completion(
     render_metadata: Option<meerkat_core::types::RenderMetadata>,
     skill_references: Vec<String>,
     additional_instructions: Vec<String>,
-) -> Result<meerkat::surface::AcceptedScheduledInput, ScheduleDomainError> {
+) -> Result<RuntimeAdmissionProjection, ScheduleDomainError> {
     context
         .ensure_runtime_session_registered(session_id)
         .await?;
@@ -676,9 +676,7 @@ async fn accept_scheduled_prompt_with_completion(
         .accept_input_with_completion(session_id, Input::Prompt(prompt_input))
         .await
         .map_err(|error| ScheduleDomainError::Internal(error.to_string()))?;
-    Ok(accepted_scheduled_input_from_runtime_outcome(
-        outcome, handle,
-    ))
+    Ok(project_runtime_admission(outcome, handle))
 }
 
 async fn accept_scheduled_event_with_completion(
@@ -688,7 +686,7 @@ async fn accept_scheduled_event_with_completion(
     event_type: String,
     payload: serde_json::Value,
     render_metadata: Option<meerkat_core::types::RenderMetadata>,
-) -> Result<meerkat::surface::AcceptedScheduledInput, ScheduleDomainError> {
+) -> Result<RuntimeAdmissionProjection, ScheduleDomainError> {
     context
         .ensure_runtime_session_registered(session_id)
         .await?;
@@ -722,9 +720,7 @@ async fn accept_scheduled_event_with_completion(
         .accept_input_with_completion(session_id, input)
         .await
         .map_err(|error| ScheduleDomainError::Internal(error.to_string()))?;
-    Ok(accepted_scheduled_input_from_runtime_outcome(
-        outcome, handle,
-    ))
+    Ok(project_runtime_admission(outcome, handle))
 }
 
 #[cfg(feature = "comms")]

--- a/meerkat-rpc/src/session_runtime/schedule_host.rs
+++ b/meerkat-rpc/src/session_runtime/schedule_host.rs
@@ -6,9 +6,9 @@ use async_trait::async_trait;
 #[cfg(feature = "mob")]
 use meerkat::DeliveryTerminal;
 use meerkat::surface::{
-    ScheduledPromptDispatch, SharedScheduleTargetAdapter, SurfaceScheduleMobHost,
-    SurfaceScheduleSessionHost, accepted_scheduled_input_from_runtime_outcome,
-    build_dispatch_from_accepted, immediate_delivery_failure, schedule_attempt_idempotency_key,
+    RuntimeAdmissionProjection, ScheduledPromptDispatch, SharedScheduleTargetAdapter,
+    SurfaceScheduleMobHost, SurfaceScheduleSessionHost, dispatch_from_admission,
+    immediate_delivery_failure, project_runtime_admission, schedule_attempt_idempotency_key,
     schedule_host_supported, spawn_schedule_host,
 };
 #[cfg(feature = "mob")]
@@ -486,9 +486,9 @@ impl SessionRuntime {
             )
             .await
         {
-            Ok(accepted) => Ok(build_dispatch_from_accepted(
+            Ok(projection) => Ok(dispatch_from_admission(
                 occurrence,
-                accepted,
+                projection,
                 dispatch.materialized_session_id,
             )),
             Err(error) => Ok(immediate_delivery_failure(
@@ -520,9 +520,9 @@ impl SessionRuntime {
             )
             .await
         {
-            Ok(accepted) => Ok(build_dispatch_from_accepted(
+            Ok(projection) => Ok(dispatch_from_admission(
                 occurrence,
-                accepted,
+                projection,
                 materialized_session_id,
             )),
             Err(error) => Ok(immediate_delivery_failure(
@@ -543,7 +543,7 @@ impl SessionRuntime {
         render_metadata: Option<meerkat_core::types::RenderMetadata>,
         skill_references: Vec<String>,
         additional_instructions: Vec<String>,
-    ) -> Result<meerkat::surface::AcceptedScheduledInput, ScheduleDomainError> {
+    ) -> Result<RuntimeAdmissionProjection, ScheduleDomainError> {
         if self
             .live_session_is_stale(session_id)
             .await
@@ -618,9 +618,7 @@ impl SessionRuntime {
             .accept_input_with_completion(session_id, Input::Prompt(prompt_input))
             .await
             .map_err(|error| ScheduleDomainError::Internal(error.to_string()))?;
-        Ok(accepted_scheduled_input_from_runtime_outcome(
-            outcome, handle,
-        ))
+        Ok(project_runtime_admission(outcome, handle))
     }
 
     async fn accept_scheduled_event_with_completion(
@@ -630,7 +628,7 @@ impl SessionRuntime {
         event_type: String,
         payload: serde_json::Value,
         render_metadata: Option<meerkat_core::types::RenderMetadata>,
-    ) -> Result<meerkat::surface::AcceptedScheduledInput, ScheduleDomainError> {
+    ) -> Result<RuntimeAdmissionProjection, ScheduleDomainError> {
         if self
             .live_session_is_stale(session_id)
             .await
@@ -672,9 +670,7 @@ impl SessionRuntime {
             .accept_input_with_completion(session_id, input)
             .await
             .map_err(|error| ScheduleDomainError::Internal(error.to_string()))?;
-        Ok(accepted_scheduled_input_from_runtime_outcome(
-            outcome, handle,
-        ))
+        Ok(project_runtime_admission(outcome, handle))
     }
 
     fn schedule_owner_id(&self) -> String {

--- a/meerkat/src/surface.rs
+++ b/meerkat/src/surface.rs
@@ -36,11 +36,12 @@ pub use runtime_backed::{
 #[cfg(feature = "session-store")]
 pub use runtime_schedule_host::spawn_runtime_backed_schedule_host;
 pub use schedule_host::{
-    AcceptedScheduledInput, NoopScheduleMobHost, ScheduleHostHandle, ScheduledPromptDispatch,
-    SharedScheduleTargetAdapter, SurfaceScheduleMobHost, SurfaceScheduleSessionHost,
-    accepted_scheduled_input_from_runtime_outcome, async_completion_dispatch,
-    build_dispatch_from_accepted, immediate_completed_dispatch, immediate_delivery_failure,
-    schedule_attempt_idempotency_key, schedule_host_supported, spawn_schedule_host,
+    AcceptedScheduledInput, NoopScheduleMobHost, RuntimeAdmissionProjection, ScheduleHostHandle,
+    ScheduledPromptDispatch, SharedScheduleTargetAdapter, SurfaceScheduleMobHost,
+    SurfaceScheduleSessionHost, async_completion_dispatch, build_dispatch_from_accepted,
+    dispatch_from_admission, immediate_completed_dispatch, immediate_delivery_failure,
+    project_runtime_admission, schedule_attempt_idempotency_key, schedule_host_supported,
+    spawn_schedule_host,
 };
 #[cfg(not(target_arch = "wasm32"))]
 pub use stdio_json::{StdioJsonWriter, spawn_stdio_json_writer};

--- a/meerkat/src/surface/runtime_schedule_host.rs
+++ b/meerkat/src/surface/runtime_schedule_host.rs
@@ -6,10 +6,10 @@ use chrono::Utc;
 #[cfg(feature = "comms")]
 use super::configure_peer_ingress;
 use super::{
-    NoopScheduleMobHost, ScheduledPromptDispatch, SharedScheduleTargetAdapter,
-    SurfaceScheduleSessionHost, accepted_scheduled_input_from_runtime_outcome,
-    build_dispatch_from_accepted, default_persistent_executor, immediate_delivery_failure,
-    materialize_session, schedule_attempt_idempotency_key, schedule_host_supported,
+    NoopScheduleMobHost, RuntimeAdmissionProjection, ScheduledPromptDispatch,
+    SharedScheduleTargetAdapter, SurfaceScheduleSessionHost, default_persistent_executor,
+    dispatch_from_admission, immediate_delivery_failure, materialize_session,
+    project_runtime_admission, schedule_attempt_idempotency_key, schedule_host_supported,
     spawn_schedule_host,
 };
 use crate::{
@@ -216,7 +216,7 @@ impl RuntimeBackedScheduleSessionHost {
         render_metadata: Option<meerkat_core::types::RenderMetadata>,
         skill_references: Vec<String>,
         additional_instructions: Vec<String>,
-    ) -> Result<super::AcceptedScheduledInput, ScheduleDomainError> {
+    ) -> Result<RuntimeAdmissionProjection, ScheduleDomainError> {
         self.ensure_runtime_session_registered(session_id).await?;
         let skill_keys = self.canonical_skill_keys(skill_references)?;
 
@@ -249,9 +249,7 @@ impl RuntimeBackedScheduleSessionHost {
             .accept_input_with_completion(session_id, Input::Prompt(prompt_input))
             .await
             .map_err(|error| ScheduleDomainError::Internal(error.to_string()))?;
-        Ok(accepted_scheduled_input_from_runtime_outcome(
-            outcome, handle,
-        ))
+        Ok(project_runtime_admission(outcome, handle))
     }
 
     async fn accept_scheduled_event_with_completion(
@@ -261,7 +259,7 @@ impl RuntimeBackedScheduleSessionHost {
         event_type: String,
         payload: serde_json::Value,
         render_metadata: Option<meerkat_core::types::RenderMetadata>,
-    ) -> Result<super::AcceptedScheduledInput, ScheduleDomainError> {
+    ) -> Result<RuntimeAdmissionProjection, ScheduleDomainError> {
         self.ensure_runtime_session_registered(session_id).await?;
 
         let input = Input::ExternalEvent(meerkat_runtime::ExternalEventInput {
@@ -291,9 +289,7 @@ impl RuntimeBackedScheduleSessionHost {
             .accept_input_with_completion(session_id, input)
             .await
             .map_err(|error| ScheduleDomainError::Internal(error.to_string()))?;
-        Ok(accepted_scheduled_input_from_runtime_outcome(
-            outcome, handle,
-        ))
+        Ok(project_runtime_admission(outcome, handle))
     }
 }
 
@@ -382,9 +378,9 @@ impl SurfaceScheduleSessionHost for RuntimeBackedScheduleSessionHost {
             )
             .await
         {
-            Ok(accepted) => Ok(build_dispatch_from_accepted(
+            Ok(projection) => Ok(dispatch_from_admission(
                 occurrence,
-                accepted,
+                projection,
                 dispatch.materialized_session_id,
             )),
             Err(error) => Ok(immediate_delivery_failure(
@@ -416,9 +412,9 @@ impl SurfaceScheduleSessionHost for RuntimeBackedScheduleSessionHost {
             )
             .await
         {
-            Ok(accepted) => Ok(build_dispatch_from_accepted(
+            Ok(projection) => Ok(dispatch_from_admission(
                 occurrence,
-                accepted,
+                projection,
                 materialized_session_id,
             )),
             Err(error) => Ok(immediate_delivery_failure(

--- a/meerkat/src/surface/schedule_host.rs
+++ b/meerkat/src/surface/schedule_host.rs
@@ -44,8 +44,21 @@ struct ResolvedScheduledSession {
 }
 
 pub struct AcceptedScheduledInput {
-    pub correlation_id: String,
+    pub correlation_id: Option<String>,
     pub handle: Option<CompletionHandle>,
+}
+
+/// Typed projection of a runtime admission outcome into the schedule surface.
+///
+/// The schedule taxonomy (`OccurrenceFailureClass`) has domain-specific variants
+/// (target/lease/mob) that the runtime does not know about, so we keep it distinct
+/// from the runtime's `AcceptOutcome`. Callers exhaustively match this projection
+/// and route the rejected arm through `immediate_delivery_failure` with the
+/// correct failure class, rather than laundering it back through the accepted
+/// path with a sentinel correlation id.
+pub enum RuntimeAdmissionProjection {
+    Admitted(AcceptedScheduledInput),
+    Rejected { detail: String },
 }
 
 #[derive(Debug, Clone)]
@@ -373,31 +386,54 @@ pub fn spawn_schedule_host(
     }
 }
 
-pub fn accepted_scheduled_input_from_runtime_outcome(
+pub fn project_runtime_admission(
     outcome: AcceptOutcome,
     handle: Option<CompletionHandle>,
-) -> AcceptedScheduledInput {
+) -> RuntimeAdmissionProjection {
     match outcome {
-        AcceptOutcome::Accepted { input_id, .. } => AcceptedScheduledInput {
-            correlation_id: input_id.to_string(),
-            handle,
+        AcceptOutcome::Accepted { input_id, .. } => {
+            RuntimeAdmissionProjection::Admitted(AcceptedScheduledInput {
+                correlation_id: Some(input_id.to_string()),
+                handle,
+            })
+        }
+        AcceptOutcome::Deduplicated { existing_id, .. } => {
+            RuntimeAdmissionProjection::Admitted(AcceptedScheduledInput {
+                correlation_id: Some(existing_id.to_string()),
+                handle,
+            })
+        }
+        AcceptOutcome::Rejected { reason } => RuntimeAdmissionProjection::Rejected {
+            detail: reason.to_string(),
         },
-        AcceptOutcome::Deduplicated { existing_id, .. } => AcceptedScheduledInput {
-            correlation_id: existing_id.to_string(),
-            handle,
+        // `AcceptOutcome` is `#[non_exhaustive]`; treat additions as rejections
+        // until the surface is taught to project them.
+        other => RuntimeAdmissionProjection::Rejected {
+            detail: format!("unsupported runtime accept outcome: {other:?}"),
         },
-        AcceptOutcome::Rejected { reason } => AcceptedScheduledInput {
-            correlation_id: "rejected".to_string(),
-            handle: Some(CompletionHandle::already_resolved(
-                CompletionOutcome::Abandoned(reason.to_string()),
-            )),
-        },
-        _ => AcceptedScheduledInput {
-            correlation_id: "rejected".to_string(),
-            handle: Some(CompletionHandle::already_resolved(
-                CompletionOutcome::Abandoned("unsupported runtime accept outcome".to_string()),
-            )),
-        },
+    }
+}
+
+/// Build a `DeliveryDispatch` from a runtime admission projection.
+///
+/// Admitted inputs flow through `build_dispatch_from_accepted`; rejected inputs
+/// flow through `immediate_delivery_failure` with `OccurrenceFailureClass::RuntimeRejected`.
+pub fn dispatch_from_admission(
+    occurrence: &Occurrence,
+    projection: RuntimeAdmissionProjection,
+    materialized_session_id: Option<SessionId>,
+) -> DeliveryDispatch {
+    match projection {
+        RuntimeAdmissionProjection::Admitted(accepted) => {
+            build_dispatch_from_accepted(occurrence, accepted, materialized_session_id)
+        }
+        RuntimeAdmissionProjection::Rejected { detail } => immediate_delivery_failure(
+            occurrence,
+            detail,
+            OccurrenceFailureClass::RuntimeRejected,
+            None,
+            materialized_session_id,
+        ),
     }
 }
 
@@ -411,7 +447,7 @@ pub fn build_dispatch_from_accepted(
         occurrence.attempt_count,
         DeliveryReceiptStage::DispatchAccepted,
     );
-    receipt.correlation_id = Some(accepted.correlation_id.clone());
+    receipt.correlation_id = accepted.correlation_id.clone();
     receipt.materialized_session_id = materialized_session_id.clone();
 
     let occurrence_id = occurrence.occurrence_id.clone();
@@ -426,7 +462,7 @@ pub fn build_dispatch_from_accepted(
                 attempt_count,
                 DeliveryReceiptStage::Completed,
             );
-            receipt.correlation_id = Some(correlation_id);
+            receipt.correlation_id = correlation_id;
             receipt.materialized_session_id = completed_materialized_session_id;
             Ok(DeliveryTerminal::completed(Some(receipt)))
         }),
@@ -434,7 +470,7 @@ pub fn build_dispatch_from_accepted(
 
     DeliveryDispatch {
         receipt,
-        correlation_id: Some(accepted.correlation_id),
+        correlation_id: accepted.correlation_id,
         materialized_session_id,
         completion,
     }
@@ -514,6 +550,12 @@ pub fn schedule_attempt_idempotency_key(occurrence: &Occurrence) -> String {
     )
 }
 
+/// Project a runtime `CompletionOutcome` into a schedule `DeliveryTerminal`.
+///
+/// This is an exhaustive typed mapping from the runtime's completion taxonomy
+/// into the schedule's failure-class taxonomy (see `OccurrenceFailureClass`).
+/// The taxonomies are distinct: the runtime surfaces callback/terminated
+/// semantics that the schedule domain models as delivery failure categories.
 fn scheduled_completion_future(
     handle: CompletionHandle,
     materialized_session_id: Option<SessionId>,


### PR DESCRIPTION
## Summary

Dogma violation #24 — schedule surface reinterprets runtime terminal classes at `meerkat/src/surface/schedule_host.rs:390,396,523,536,550`.

Before, each schedule host called a helper (`accepted_scheduled_input_from_runtime_outcome`) that funneled runtime rejections back through the accepted path with a synthetic `"rejected"` correlation-id sentinel. Downstream code then string-matched on that sentinel to remap into `OccurrenceFailureClass::RuntimeRejected`. That is exactly the laundering pattern the dogma rejects.

After this change, runtime admission is projected into a typed enum:

```rust
pub enum RuntimeAdmissionProjection {
    Admitted(AcceptedScheduledInput),
    Rejected { detail: String },
}
```

- `project_runtime_admission(outcome, handle)` does the typed projection from `AcceptOutcome` at the boundary.
- `dispatch_from_admission(occurrence, projection, materialized_session_id)` fans the projection to `build_dispatch_from_accepted` for `Admitted` or to `immediate_delivery_failure(..., OccurrenceFailureClass::RuntimeRejected, ...)` for `Rejected`.
- No sentinel strings; no wildcard fallback arms. `AcceptOutcome`'s `#[non_exhaustive]` guard now lands in an explicit wildcard arm in `project_runtime_admission` that maps to `Rejected { detail: ... }` until a future revision teaches the surface about new outcomes — that is a typed path, not a silent default.

### Product answer: is the schedule failure taxonomy a subset of runtime outcomes or distinct?

**Distinct.** The schedule taxonomy (`OccurrenceFailureClass`) models target/lease/mob-specific variants (`TargetMaterializationFailed`, `MobRejected`, `InternalError`, etc.) that the runtime does not know about. The runtime's `AcceptOutcome` models admission outcomes (`Accepted`/`Deduplicated`/`Rejected`). `RuntimeAdmissionProjection` is the typed seam between the two — the previous `AcceptedScheduledInput` type is preserved as the payload of `Admitted` so existing downstream helpers (`build_dispatch_from_accepted`) reuse without duplication. The old enum is not deleted because domain-specific failure variants still live there.

### What was already done vs what I completed

**Previous agent's work (5 files, kept as-is):**
- `meerkat/src/surface/schedule_host.rs` — introduced `RuntimeAdmissionProjection`, `project_runtime_admission`, `dispatch_from_admission` helpers and deleted the string-based `accepted_scheduled_input_from_runtime_outcome` helper.
- `meerkat-rpc/src/session_runtime/schedule_host.rs`, `meerkat-rest/src/schedule_host.rs` — refactored their `accept_scheduled_*_with_completion` helpers to return `RuntimeAdmissionProjection` and their `deliver_scheduled_*` helpers to use `dispatch_from_admission`.
- `meerkat/src/surface.rs` — updated re-exports.

**My completion work (3 additional call sites the previous agent missed, fixed in the same style):**
- `meerkat/src/surface/runtime_schedule_host.rs` — previous agent had introduced the helper call site but never updated the function. Compile blocker.
- `meerkat-mcp-server/src/schedule_host.rs` — imported the new helpers but still called the deleted one and still used the old `build_dispatch_from_accepted` match arms.
- `meerkat-cli/src/main.rs` and `examples/035-mdm-tux-rs/src/bin/target.rs` — two more scheduled-target adapters the previous agent hadn't touched at all; switched them to `dispatch_from_admission(occurrence, project_runtime_admission(outcome, handle), ...)` at the inline call sites.

Single commit because the intent is one cohesive refactor and splitting would require fabricating staged/unstaged boundaries the working tree didn't have.

## Test plan

- [x] `./scripts/repo-cargo check --workspace --all-targets` — clean
- [x] `./scripts/repo-cargo fmt --all -- --check` — clean
- [x] `./scripts/repo-cargo clippy --workspace --all-targets -- -D warnings` — clean
- [x] `./scripts/repo-cargo nextest run -p meerkat -p meerkat-schedule` — 189 tests passing
- [x] `./scripts/repo-cargo e2e-fast` — 5/5 passing
- [ ] CI green