### PR TITLE
fix(ops): typed op kind/outcome + decision moves to MeerkatMachine (dogma round 4, wave 2a)

### DIFF
--- a/meerkat-runtime/src/meerkat_machine/dsl.rs
+++ b/meerkat-runtime/src/meerkat_machine/dsl.rs
@@ -1906,6 +1906,7 @@ machine! {
             TerminateOp { operation_id: String, outcome: Enum<OperationTerminalOutcomeKind>, payload: String },
             RequestWaitAll { operation_ids: Set<String> },
             SatisfyWaitAll,
+            CancelWaitAll,
             // Comms drain inputs
             SpawnDrain { mode: DrainMode },
             StopDrain,
@@ -4562,11 +4563,25 @@ machine! {
             emit NotifyOpWatcher { operation_id: operation_id }
         }
 
-        // PeerReadyOp: mark operation's peer as ready (Running|Retiring only).
+        // PeerReadyOp: mark operation's peer as ready.
+        //
+        // The "only MobMemberChild ops expose a peer handoff" and
+        // "only once per op" decisions live in the DSL as guards, not in
+        // the shell. The shell classifies a guard rejection on
+        // `kind_is_mob_member_child` back into
+        // `OpsLifecycleError::PeerNotExpected`, and a rejection on
+        // `not_already_peer_ready` into `OpsLifecycleError::AlreadyPeerReady`
+        // via `classify_peer_ready_rejection`.
         transition PeerReadyOp {
             per_phase [Idle, Attached, Running, Retired, Stopped]
             on input PeerReadyOp { operation_id }
             guard "op_registered" { self.op_statuses.contains_key(operation_id) }
+            guard "kind_is_mob_member_child" {
+                self.op_kinds.get_copied(operation_id) == Some(OperationKind::MobMemberChild)
+            }
+            guard "not_already_peer_ready" {
+                self.op_peer_ready.get_copied(operation_id) != Some(true)
+            }
             guard "from_status_valid" {
                 self.op_statuses.get_copied(operation_id) == Some(OperationStatus::Running)
                 || self.op_statuses.get_copied(operation_id) == Some(OperationStatus::Retiring)
@@ -4667,17 +4682,48 @@ machine! {
             to Idle
         }
 
-        // SatisfyWaitAll: deactivate wait-all barrier
+        // SatisfyWaitAll: deactivate wait-all barrier once every member of
+        // `wait_operation_ids` has reached a terminal status. The
+        // "all members terminal" decision lives in the DSL guard — the
+        // shell no longer pre-computes the verdict before firing this input.
+        // A guard rejection under `wait_is_active` means the barrier wasn't
+        // active; a rejection under `all_members_terminal` means the shell
+        // fired early. Callers drive satisfaction by firing this input on
+        // each op terminalization; the guard serves as the fixed point.
         transition SatisfyWaitAll {
             per_phase [Idle, Attached, Running, Retired, Stopped]
             on input SatisfyWaitAll
             guard "wait_is_active" { self.wait_active == true }
+            guard "all_members_terminal" {
+                for_all(member_id in self.wait_operation_ids,
+                    self.op_statuses.get_copied(member_id) == Some(OperationStatus::Completed)
+                    || self.op_statuses.get_copied(member_id) == Some(OperationStatus::Failed)
+                    || self.op_statuses.get_copied(member_id) == Some(OperationStatus::Aborted)
+                    || self.op_statuses.get_copied(member_id) == Some(OperationStatus::Cancelled)
+                    || self.op_statuses.get_copied(member_id) == Some(OperationStatus::Retired)
+                    || self.op_statuses.get_copied(member_id) == Some(OperationStatus::Terminated))
+            }
             update {
                 self.wait_active = false;
                 self.wait_operation_ids = EmptySet;
             }
             to Idle
             emit WaitAllSatisfied
+        }
+
+        // CancelWaitAll: clear the wait-all barrier without the terminality
+        // check. Fired by the shell on `wait_all` future drop; the
+        // satisfaction obligation is NOT emitted because no authority
+        // resolved the request. Idempotent on an already-cleared barrier.
+        transition CancelWaitAll {
+            per_phase [Idle, Attached, Running, Retired, Stopped]
+            on input CancelWaitAll
+            guard "wait_is_active" { self.wait_active == true }
+            update {
+                self.wait_active = false;
+                self.wait_operation_ids = EmptySet;
+            }
+            to Idle
         }
 
         // =====================================================================

--- a/meerkat-runtime/src/meerkat_machine/dsl.rs
+++ b/meerkat-runtime/src/meerkat_machine/dsl.rs
@@ -135,18 +135,40 @@ impl OperationId {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
-pub struct OperationKind(pub String);
+/// Typed async-operation kind. Closed mirror of
+/// [`meerkat_core::ops_lifecycle::OperationKind`] — replaces the former
+/// newtype wrapper around an opaque JSON-encoded string. The DSL writes this
+/// variant directly on `RegisterOp` so guards on `PeerReadyOp`
+/// (`kind_is_mob_member_child`) can reason about the closed set without
+/// string parsing.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
+pub enum OperationKind {
+    #[default]
+    MobMemberChild,
+    BackgroundToolOp,
+}
 
-impl<T: Into<String>> From<T> for OperationKind {
-    fn from(s: T) -> Self {
-        Self(s.into())
+impl From<meerkat_core::ops_lifecycle::OperationKind> for OperationKind {
+    fn from(kind: meerkat_core::ops_lifecycle::OperationKind) -> Self {
+        match kind {
+            meerkat_core::ops_lifecycle::OperationKind::MobMemberChild => Self::MobMemberChild,
+            meerkat_core::ops_lifecycle::OperationKind::BackgroundToolOp => Self::BackgroundToolOp,
+        }
+    }
+}
+
+impl From<OperationKind> for meerkat_core::ops_lifecycle::OperationKind {
+    fn from(kind: OperationKind) -> Self {
+        match kind {
+            OperationKind::MobMemberChild => Self::MobMemberChild,
+            OperationKind::BackgroundToolOp => Self::BackgroundToolOp,
+        }
     }
 }
 
 impl OperationKind {
-    pub fn from_domain(id: &meerkat_core::ops_lifecycle::OperationKind) -> Self {
-        Self::from(serde_json::to_string(id).unwrap_or_else(|_| "\"unknown\"".to_string()))
+    pub fn from_domain(kind: &meerkat_core::ops_lifecycle::OperationKind) -> Self {
+        Self::from(*kind)
     }
 }
 
@@ -1301,6 +1323,30 @@ impl From<OperationStatus> for meerkat_core::ops_lifecycle::OperationStatus {
     }
 }
 
+/// Typed discriminant mirror of
+/// [`meerkat_core::ops_lifecycle::OperationTerminalOutcome`] — replaces the
+/// former opaque JSON string carried in the DSL's `op_terminal_outcomes`
+/// map. Unit variants only; payload data (completion result, failure error,
+/// cancellation reason, terminated reason) rides on the companion
+/// `op_terminal_payload: Map<String, String>` field of the DSL state as
+/// JSON keyed to the same operation id, and is reconstructed in the shell
+/// by pairing the typed discriminant with the companion entry.
+///
+/// The DSL writes these variants directly on each terminal transition
+/// (`CompleteOp`, `FailOp`, `CancelOp`, `AbortOp`, `RetireCompletedOp`,
+/// `TerminateOp`); the shell reads them through the typed map and rebuilds
+/// the domain enum in `ShellState::terminal_outcome`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
+pub enum OperationTerminalOutcomeKind {
+    #[default]
+    Completed,
+    Failed,
+    Aborted,
+    Cancelled,
+    Retired,
+    Terminated,
+}
+
 /// Typed input-abandonment reason. Closed mirror of the discriminant set of
 /// [`crate::input_state::InputAbandonReason`] — replaces the former
 /// `format!("{reason:?}")` Debug round-trip in the DSL's
@@ -1443,8 +1489,11 @@ machine! {
             // --- Ops lifecycle substate ---
             op_statuses: Map<String, Enum<OperationStatus>>,
             op_completion_seq: Map<String, u64>,
-            op_terminal_outcomes: Map<String, String>,
-            op_kinds: Map<String, String>,
+            // Terminal-outcome discriminant. Payload (result/error/reason)
+            // rides on the companion `op_terminal_payload` map as JSON.
+            op_terminal_outcomes: Map<String, Enum<OperationTerminalOutcomeKind>>,
+            op_terminal_payload: Map<String, String>,
+            op_kinds: Map<String, Enum<OperationKind>>,
             op_peer_ready: Map<String, bool>,
             op_progress_counts: Map<String, u64>,
             active_op_count: u64,
@@ -1662,6 +1711,7 @@ machine! {
             op_statuses = EmptyMap,
             op_completion_seq = EmptyMap,
             op_terminal_outcomes = EmptyMap,
+            op_terminal_payload = EmptyMap,
             op_kinds = EmptyMap,
             op_peer_ready = EmptyMap,
             op_progress_counts = EmptyMap,
@@ -1837,18 +1887,23 @@ machine! {
                 attempt_count: u64,
             },
             RecordBoundarySeq { input_id: String, seq: u64 },
-            // Ops lifecycle inputs
-            RegisterOp { operation_id: String, kind: String },
+            // Ops lifecycle inputs.
+            // Terminal transitions carry a typed outcome discriminant plus
+            // an opaque `payload` string — the inner payload of the domain
+            // `OperationTerminalOutcome` encoded as JSON by the shell. The
+            // DSL does not parse the payload; it only tracks the closed-set
+            // discriminant so guards can reason about it.
+            RegisterOp { operation_id: String, kind: Enum<OperationKind> },
             StartOp { operation_id: String },
-            CompleteOp { operation_id: String, outcome: String },
-            FailOp { operation_id: String, outcome: String },
-            CancelOp { operation_id: String, outcome: String },
-            AbortOp { operation_id: String, outcome: String },
+            CompleteOp { operation_id: String, outcome: Enum<OperationTerminalOutcomeKind>, payload: String },
+            FailOp { operation_id: String, outcome: Enum<OperationTerminalOutcomeKind>, payload: String },
+            CancelOp { operation_id: String, outcome: Enum<OperationTerminalOutcomeKind>, payload: String },
+            AbortOp { operation_id: String, outcome: Enum<OperationTerminalOutcomeKind>, payload: String },
             PeerReadyOp { operation_id: String },
             ProgressReportedOp { operation_id: String },
             RetireRequestedOp { operation_id: String },
-            RetireCompletedOp { operation_id: String, outcome: String },
-            TerminateOp { operation_id: String, outcome: String },
+            RetireCompletedOp { operation_id: String, outcome: Enum<OperationTerminalOutcomeKind>, payload: String },
+            TerminateOp { operation_id: String, outcome: Enum<OperationTerminalOutcomeKind>, payload: String },
             RequestWaitAll { operation_ids: Set<String> },
             SatisfyWaitAll,
             // Comms drain inputs
@@ -4420,7 +4475,7 @@ machine! {
         // CompleteOp: terminal success from Running|Retiring.
         transition CompleteOp {
             per_phase [Idle, Attached, Running, Retired, Stopped]
-            on input CompleteOp { operation_id, outcome }
+            on input CompleteOp { operation_id, outcome, payload }
             guard "op_registered" { self.op_statuses.contains_key(operation_id) }
             guard "from_status_valid" {
                 self.op_statuses.get_copied(operation_id) == Some(OperationStatus::Running)
@@ -4429,6 +4484,7 @@ machine! {
             update {
                 self.op_statuses.insert(operation_id, OperationStatus::Completed);
                 self.op_terminal_outcomes.insert(operation_id, outcome);
+                self.op_terminal_payload.insert(operation_id, payload);
                 self.active_op_count -= 1;
                 self.op_completion_seq.insert(operation_id, self.next_completion_seq);
                 self.next_completion_seq += 1;
@@ -4445,7 +4501,7 @@ machine! {
         // callers that only care about one sub-state.
         transition FailOp {
             per_phase [Idle, Attached, Running, Retired, Stopped]
-            on input FailOp { operation_id, outcome }
+            on input FailOp { operation_id, outcome, payload }
             guard "op_registered" { self.op_statuses.contains_key(operation_id) }
             guard "from_status_valid" {
                 self.op_statuses.get_copied(operation_id) == Some(OperationStatus::Provisioning)
@@ -4455,6 +4511,7 @@ machine! {
             update {
                 self.op_statuses.insert(operation_id, OperationStatus::Failed);
                 self.op_terminal_outcomes.insert(operation_id, outcome);
+                self.op_terminal_payload.insert(operation_id, payload);
                 self.active_op_count -= 1;
             }
             to Idle
@@ -4465,7 +4522,7 @@ machine! {
         // CancelOp: terminal cancellation from any non-terminal state.
         transition CancelOp {
             per_phase [Idle, Attached, Running, Retired, Stopped]
-            on input CancelOp { operation_id, outcome }
+            on input CancelOp { operation_id, outcome, payload }
             guard "op_registered" { self.op_statuses.contains_key(operation_id) }
             guard "from_status_valid" {
                 self.op_statuses.get_copied(operation_id) == Some(OperationStatus::Provisioning)
@@ -4475,6 +4532,7 @@ machine! {
             update {
                 self.op_statuses.insert(operation_id, OperationStatus::Cancelled);
                 self.op_terminal_outcomes.insert(operation_id, outcome);
+                self.op_terminal_payload.insert(operation_id, payload);
                 self.active_op_count -= 1;
             }
             to Idle
@@ -4488,7 +4546,7 @@ machine! {
         // semantic boundary crisp.
         transition AbortOp {
             per_phase [Idle, Attached, Running, Retired, Stopped]
-            on input AbortOp { operation_id, outcome }
+            on input AbortOp { operation_id, outcome, payload }
             guard "op_registered" { self.op_statuses.contains_key(operation_id) }
             guard "from_status_valid" {
                 self.op_statuses.get_copied(operation_id) == Some(OperationStatus::Provisioning)
@@ -4496,6 +4554,7 @@ machine! {
             update {
                 self.op_statuses.insert(operation_id, OperationStatus::Aborted);
                 self.op_terminal_outcomes.insert(operation_id, outcome);
+                self.op_terminal_payload.insert(operation_id, payload);
                 self.active_op_count -= 1;
             }
             to Idle
@@ -4553,7 +4612,7 @@ machine! {
         // RetireCompletedOp: terminal retirement (Running|Retiring -> Retired).
         transition RetireCompletedOp {
             per_phase [Idle, Attached, Running, Retired, Stopped]
-            on input RetireCompletedOp { operation_id, outcome }
+            on input RetireCompletedOp { operation_id, outcome, payload }
             guard "op_registered" { self.op_statuses.contains_key(operation_id) }
             guard "from_status_valid" {
                 self.op_statuses.get_copied(operation_id) == Some(OperationStatus::Running)
@@ -4562,6 +4621,7 @@ machine! {
             update {
                 self.op_statuses.insert(operation_id, OperationStatus::Retired);
                 self.op_terminal_outcomes.insert(operation_id, outcome);
+                self.op_terminal_payload.insert(operation_id, payload);
                 self.active_op_count -= 1;
             }
             to Idle
@@ -4570,12 +4630,14 @@ machine! {
         }
 
         // TerminateOp: bulk-terminate variant used by owner-terminated cascade.
-        // Shell loops across non-terminal ops and issues one TerminateOp each;
-        // the session lock provides cascade atomicity. Legal only from any
-        // non-terminal state — terminal-state TerminateOp is a guard rejection.
+        // Shell loops across non-terminal ops (mechanical cursor) and issues
+        // one TerminateOp per op; the session lock provides cascade atomicity.
+        // The "is this op terminal-able?" decision lives in the DSL guard —
+        // terminal-state TerminateOp is a guard rejection, surfaced to the
+        // caller via `classify_op_rejection` as `InvalidTransition`.
         transition TerminateOp {
             per_phase [Idle, Attached, Running, Retired, Stopped]
-            on input TerminateOp { operation_id, outcome }
+            on input TerminateOp { operation_id, outcome, payload }
             guard "op_registered" { self.op_statuses.contains_key(operation_id) }
             guard "from_status_valid" {
                 self.op_statuses.get_copied(operation_id) == Some(OperationStatus::Provisioning)
@@ -4585,6 +4647,7 @@ machine! {
             update {
                 self.op_statuses.insert(operation_id, OperationStatus::Terminated);
                 self.op_terminal_outcomes.insert(operation_id, outcome);
+                self.op_terminal_payload.insert(operation_id, payload);
                 self.active_op_count -= 1;
             }
             to Idle

--- a/meerkat-runtime/src/meerkat_machine/dsl_authority.rs
+++ b/meerkat-runtime/src/meerkat_machine/dsl_authority.rs
@@ -122,6 +122,7 @@ pub(crate) fn project_state(
         op_statuses: std::collections::BTreeMap::new(),
         op_completion_seq: std::collections::BTreeMap::new(),
         op_terminal_outcomes: std::collections::BTreeMap::new(),
+        op_terminal_payload: std::collections::BTreeMap::new(),
         op_kinds: std::collections::BTreeMap::new(),
         op_peer_ready: std::collections::BTreeMap::new(),
         op_progress_counts: std::collections::BTreeMap::new(),

--- a/meerkat-runtime/src/ops_lifecycle.rs
+++ b/meerkat-runtime/src/ops_lifecycle.rs
@@ -412,14 +412,47 @@ impl ShellState {
         mm_dsl::MeerkatMachineMutator::apply(&mut self.dsl.0, input).map(|_transition| ())
     }
 
-    /// Serialize the provided terminal outcome for DSL storage.
+    /// Split a domain terminal outcome into a `(discriminant, payload)` pair
+    /// suitable for the DSL's typed `op_terminal_outcomes` +
+    /// `op_terminal_payload` fields.
     ///
-    /// Terminal outcomes carry caller-provided payloads (error strings,
-    /// cancellation reasons, operation results) that the DSL tracks as
-    /// opaque strings. Serialisation is lossless JSON; the shell rehydrates
-    /// typed outcomes via [`Self::terminal_outcome`].
-    fn encode_outcome(outcome: &OperationTerminalOutcome) -> String {
-        serde_json::to_string(outcome).unwrap_or_default()
+    /// The discriminant is a typed DSL enum mirror; the payload is the JSON
+    /// encoding of the outcome's *inner* payload (e.g., the `OperationResult`
+    /// for `Completed`, the error string for `Failed`, the optional reason
+    /// for `Aborted` / `Cancelled`, the reason string for `Terminated`). For
+    /// `Retired` the payload is empty — it carries no data.
+    ///
+    /// The shell rehydrates the typed domain outcome via
+    /// [`Self::terminal_outcome`], pairing the DSL discriminant with the
+    /// companion payload entry.
+    fn split_outcome(
+        outcome: &OperationTerminalOutcome,
+    ) -> (mm_dsl::OperationTerminalOutcomeKind, String) {
+        match outcome {
+            OperationTerminalOutcome::Completed(result) => (
+                mm_dsl::OperationTerminalOutcomeKind::Completed,
+                serde_json::to_string(result).unwrap_or_default(),
+            ),
+            OperationTerminalOutcome::Failed { error } => (
+                mm_dsl::OperationTerminalOutcomeKind::Failed,
+                serde_json::to_string(error).unwrap_or_default(),
+            ),
+            OperationTerminalOutcome::Aborted { reason } => (
+                mm_dsl::OperationTerminalOutcomeKind::Aborted,
+                serde_json::to_string(reason).unwrap_or_default(),
+            ),
+            OperationTerminalOutcome::Cancelled { reason } => (
+                mm_dsl::OperationTerminalOutcomeKind::Cancelled,
+                serde_json::to_string(reason).unwrap_or_default(),
+            ),
+            OperationTerminalOutcome::Retired => {
+                (mm_dsl::OperationTerminalOutcomeKind::Retired, String::new())
+            }
+            OperationTerminalOutcome::Terminated { reason } => (
+                mm_dsl::OperationTerminalOutcomeKind::Terminated,
+                serde_json::to_string(reason).unwrap_or_default(),
+            ),
+        }
     }
 
     /// Read the DSL operation status for `id`, or `None` if not registered.
@@ -437,11 +470,13 @@ impl ShellState {
     /// Read the DSL operation kind for `id`, or `None` if not registered.
     fn kind(&self, id: &OperationId) -> Option<OperationKind> {
         let id_key = mm_dsl::OperationId::from_domain(id).0;
-        let serialized = self.dsl.0.state.op_kinds.get(&id_key)?;
-        if serialized.is_empty() {
-            return None;
-        }
-        serde_json::from_str::<OperationKind>(serialized).ok()
+        self.dsl
+            .0
+            .state
+            .op_kinds
+            .get(&id_key)
+            .copied()
+            .map(OperationKind::from)
     }
 
     /// Read the peer-ready flag for `id`.
@@ -461,14 +496,55 @@ impl ShellState {
             .map(|v| (*v).min(u32::MAX as u64) as u32)
     }
 
-    /// Read the terminal outcome for `id`, deserialising the stored JSON.
+    /// Read the terminal outcome for `id` by pairing the DSL's typed
+    /// discriminant with the companion payload JSON. Returns `None` when the
+    /// op has no recorded terminal discriminant.
     fn terminal_outcome(&self, id: &OperationId) -> Option<OperationTerminalOutcome> {
         let id_key = mm_dsl::OperationId::from_domain(id).0;
-        let serialized = self.dsl.0.state.op_terminal_outcomes.get(&id_key)?;
-        if serialized.is_empty() {
-            return None;
+        let kind = self
+            .dsl
+            .0
+            .state
+            .op_terminal_outcomes
+            .get(&id_key)
+            .copied()?;
+        let payload = self
+            .dsl
+            .0
+            .state
+            .op_terminal_payload
+            .get(&id_key)
+            .map(String::as_str)
+            .unwrap_or("");
+        match kind {
+            mm_dsl::OperationTerminalOutcomeKind::Completed => {
+                let result = serde_json::from_str::<OperationResult>(payload).ok()?;
+                Some(OperationTerminalOutcome::Completed(result))
+            }
+            mm_dsl::OperationTerminalOutcomeKind::Failed => {
+                let error = serde_json::from_str::<String>(payload).unwrap_or_default();
+                Some(OperationTerminalOutcome::Failed { error })
+            }
+            mm_dsl::OperationTerminalOutcomeKind::Aborted => {
+                let reason = serde_json::from_str::<Option<String>>(payload)
+                    .ok()
+                    .flatten();
+                Some(OperationTerminalOutcome::Aborted { reason })
+            }
+            mm_dsl::OperationTerminalOutcomeKind::Cancelled => {
+                let reason = serde_json::from_str::<Option<String>>(payload)
+                    .ok()
+                    .flatten();
+                Some(OperationTerminalOutcome::Cancelled { reason })
+            }
+            mm_dsl::OperationTerminalOutcomeKind::Retired => {
+                Some(OperationTerminalOutcome::Retired)
+            }
+            mm_dsl::OperationTerminalOutcomeKind::Terminated => {
+                let reason = serde_json::from_str::<String>(payload).unwrap_or_default();
+                Some(OperationTerminalOutcome::Terminated { reason })
+            }
         }
-        serde_json::from_str::<OperationTerminalOutcome>(serialized).ok()
     }
 
     /// Whether the operation is currently tracked in DSL state.
@@ -598,6 +674,7 @@ impl ShellState {
                 self.dsl.0.state.op_peer_ready.remove(&evicted_key);
                 self.dsl.0.state.op_progress_counts.remove(&evicted_key);
                 self.dsl.0.state.op_terminal_outcomes.remove(&evicted_key);
+                self.dsl.0.state.op_terminal_payload.remove(&evicted_key);
                 self.dsl.0.state.op_completion_seq.remove(&evicted_key);
                 self.records.remove(&evicted);
             }
@@ -902,8 +979,12 @@ impl RuntimeOpsLifecycleRegistry {
                 id_key.clone(),
                 mm_dsl::OperationStatus::from(op_state.status),
             );
-            let kind_str = serde_json::to_string(&op_state.kind).unwrap_or_default();
-            shell.dsl.0.state.op_kinds.insert(id_key.clone(), kind_str);
+            shell
+                .dsl
+                .0
+                .state
+                .op_kinds
+                .insert(id_key.clone(), mm_dsl::OperationKind::from(op_state.kind));
             shell
                 .dsl
                 .0
@@ -917,13 +998,19 @@ impl RuntimeOpsLifecycleRegistry {
                 .op_progress_counts
                 .insert(id_key.clone(), op_state.progress_count as u64);
             if let Some(outcome) = op_state.terminal_outcome.as_ref() {
-                let outcome_str = ShellState::encode_outcome(outcome);
+                let (kind, payload) = ShellState::split_outcome(outcome);
                 shell
                     .dsl
                     .0
                     .state
                     .op_terminal_outcomes
-                    .insert(id_key.clone(), outcome_str);
+                    .insert(id_key.clone(), kind);
+                shell
+                    .dsl
+                    .0
+                    .state
+                    .op_terminal_payload
+                    .insert(id_key.clone(), payload);
             }
             retained_ids.insert(op_id);
         }
@@ -1199,7 +1286,7 @@ impl OpsLifecycleRegistry for RuntimeOpsLifecycleRegistry {
         state.dsl_apply(
             mm_dsl::MeerkatMachineInput::RegisterOp {
                 operation_id: mm_dsl::OperationId::from_domain(&operation_id).0,
-                kind: mm_dsl::OperationKind::from_domain(&kind).0,
+                kind: mm_dsl::OperationKind::from_domain(&kind),
             },
             "RegisterOp",
         )?;
@@ -1246,11 +1333,12 @@ impl OpsLifecycleRegistry for RuntimeOpsLifecycleRegistry {
             .ok_or_else(|| OpsLifecycleError::NotFound(id.clone()))?;
 
         let terminal_outcome = OperationTerminalOutcome::Failed { error };
-        let outcome_serialized = ShellState::encode_outcome(&terminal_outcome);
+        let (outcome_kind, outcome_payload) = ShellState::split_outcome(&terminal_outcome);
 
         if let Err(err) = state.dsl_apply_raw(mm_dsl::MeerkatMachineInput::FailOp {
             operation_id: mm_dsl::OperationId::from_domain(id).0,
-            outcome: outcome_serialized,
+            outcome: outcome_kind,
+            payload: outcome_payload,
         }) {
             return Err(classify_op_rejection(err, id, status, "fail_operation"));
         }
@@ -1349,11 +1437,12 @@ impl OpsLifecycleRegistry for RuntimeOpsLifecycleRegistry {
             .ok_or_else(|| OpsLifecycleError::NotFound(id.clone()))?;
 
         let terminal_outcome = OperationTerminalOutcome::Completed(result);
-        let outcome_serialized = ShellState::encode_outcome(&terminal_outcome);
+        let (outcome_kind, outcome_payload) = ShellState::split_outcome(&terminal_outcome);
 
         if let Err(err) = state.dsl_apply_raw(mm_dsl::MeerkatMachineInput::CompleteOp {
             operation_id: mm_dsl::OperationId::from_domain(id).0,
-            outcome: outcome_serialized,
+            outcome: outcome_kind,
+            payload: outcome_payload,
         }) {
             return Err(classify_op_rejection(err, id, status, "complete_operation"));
         }
@@ -1371,11 +1460,12 @@ impl OpsLifecycleRegistry for RuntimeOpsLifecycleRegistry {
             .ok_or_else(|| OpsLifecycleError::NotFound(id.clone()))?;
 
         let terminal_outcome = OperationTerminalOutcome::Failed { error };
-        let outcome_serialized = ShellState::encode_outcome(&terminal_outcome);
+        let (outcome_kind, outcome_payload) = ShellState::split_outcome(&terminal_outcome);
 
         if let Err(err) = state.dsl_apply_raw(mm_dsl::MeerkatMachineInput::FailOp {
             operation_id: mm_dsl::OperationId::from_domain(id).0,
-            outcome: outcome_serialized,
+            outcome: outcome_kind,
+            payload: outcome_payload,
         }) {
             return Err(classify_op_rejection(err, id, status, "fail_operation"));
         }
@@ -1397,11 +1487,12 @@ impl OpsLifecycleRegistry for RuntimeOpsLifecycleRegistry {
             .ok_or_else(|| OpsLifecycleError::NotFound(id.clone()))?;
 
         let terminal_outcome = OperationTerminalOutcome::Aborted { reason };
-        let outcome_serialized = ShellState::encode_outcome(&terminal_outcome);
+        let (outcome_kind, outcome_payload) = ShellState::split_outcome(&terminal_outcome);
 
         if let Err(err) = state.dsl_apply_raw(mm_dsl::MeerkatMachineInput::AbortOp {
             operation_id: mm_dsl::OperationId::from_domain(id).0,
-            outcome: outcome_serialized,
+            outcome: outcome_kind,
+            payload: outcome_payload,
         }) {
             return Err(classify_op_rejection(err, id, status, "abort_provisioning"));
         }
@@ -1423,11 +1514,12 @@ impl OpsLifecycleRegistry for RuntimeOpsLifecycleRegistry {
             .ok_or_else(|| OpsLifecycleError::NotFound(id.clone()))?;
 
         let terminal_outcome = OperationTerminalOutcome::Cancelled { reason };
-        let outcome_serialized = ShellState::encode_outcome(&terminal_outcome);
+        let (outcome_kind, outcome_payload) = ShellState::split_outcome(&terminal_outcome);
 
         if let Err(err) = state.dsl_apply_raw(mm_dsl::MeerkatMachineInput::CancelOp {
             operation_id: mm_dsl::OperationId::from_domain(id).0,
-            outcome: outcome_serialized,
+            outcome: outcome_kind,
+            payload: outcome_payload,
         }) {
             return Err(classify_op_rejection(err, id, status, "cancel_operation"));
         }
@@ -1460,11 +1552,12 @@ impl OpsLifecycleRegistry for RuntimeOpsLifecycleRegistry {
             .ok_or_else(|| OpsLifecycleError::NotFound(id.clone()))?;
 
         let terminal_outcome = OperationTerminalOutcome::Retired;
-        let outcome_serialized = ShellState::encode_outcome(&terminal_outcome);
+        let (outcome_kind, outcome_payload) = ShellState::split_outcome(&terminal_outcome);
 
         if let Err(err) = state.dsl_apply_raw(mm_dsl::MeerkatMachineInput::RetireCompletedOp {
             operation_id: mm_dsl::OperationId::from_domain(id).0,
-            outcome: outcome_serialized,
+            outcome: outcome_kind,
+            payload: outcome_payload,
         }) {
             return Err(classify_op_rejection(err, id, status, "mark_retired"));
         }
@@ -1512,11 +1605,12 @@ impl OpsLifecycleRegistry for RuntimeOpsLifecycleRegistry {
             let terminal_outcome = OperationTerminalOutcome::Terminated {
                 reason: reason.clone(),
             };
-            let outcome_serialized = ShellState::encode_outcome(&terminal_outcome);
+            let (outcome_kind, outcome_payload) = ShellState::split_outcome(&terminal_outcome);
 
             if let Err(err) = state.dsl_apply_raw(mm_dsl::MeerkatMachineInput::TerminateOp {
                 operation_id: mm_dsl::OperationId::from_domain(op_id).0,
-                outcome: outcome_serialized,
+                outcome: outcome_kind,
+                payload: outcome_payload,
             }) {
                 return Err(classify_op_rejection(
                     err,
@@ -1551,6 +1645,7 @@ impl OpsLifecycleRegistry for RuntimeOpsLifecycleRegistry {
             state.dsl.0.state.op_peer_ready.remove(&id_key);
             state.dsl.0.state.op_progress_counts.remove(&id_key);
             state.dsl.0.state.op_terminal_outcomes.remove(&id_key);
+            state.dsl.0.state.op_terminal_payload.remove(&id_key);
             state.dsl.0.state.op_completion_seq.remove(&id_key);
             state.records.remove(&id);
             if let Some(outcome) = outcome {

--- a/meerkat-runtime/src/ops_lifecycle.rs
+++ b/meerkat-runtime/src/ops_lifecycle.rs
@@ -702,28 +702,33 @@ impl ShellState {
 
     /// Check whether a pending barrier wait is now satisfied and resolve it.
     ///
-    /// Barrier membership lives in DSL `wait_operation_ids`; `wait_active`
-    /// signals whether a barrier is pending. `wait_request_id` is the
-    /// shell-owned oneshot correlation id that selects which sender to
-    /// notify; when the DSL barrier satisfies without a live correlation
-    /// (post-recovery, or duplicate resolution), the oneshot simply remains
-    /// pending.
+    /// Barrier membership and the "all members terminal" decision both live
+    /// in the DSL: `wait_operation_ids` carries the set, `wait_active`
+    /// signals a pending barrier, and `SatisfyWaitAll`'s
+    /// `all_members_terminal` guard owns the fixed-point test. The shell
+    /// fires `SatisfyWaitAll` idempotently on every terminal transition and
+    /// lets the DSL guard reject early firings as a no-op. On acceptance
+    /// (transition returns `Ok`), the shell selects the correlated oneshot
+    /// and delivers the `WaitAllSatisfied` obligation token.
+    ///
+    /// `wait_request_id` is the shell-owned oneshot correlation id that
+    /// selects which sender to notify; when the DSL barrier satisfies
+    /// without a live correlation (post-recovery, or duplicate resolution),
+    /// the oneshot simply remains pending.
     fn maybe_satisfy_wait(&mut self) {
-        if !self.wait_active() {
-            return;
-        }
+        // Capture membership *before* applying — `SatisfyWaitAll`'s update
+        // clause resets `wait_operation_ids` to empty, so a post-apply read
+        // would lose the member list carried on the obligation token.
         let ids = self.wait_operation_ids();
-        let all_terminal = ids
-            .iter()
-            .all(|id| self.status(id).is_some_and(OperationStatus::is_terminal));
-        if !all_terminal {
+        if self
+            .dsl_apply_raw(mm_dsl::MeerkatMachineInput::SatisfyWaitAll)
+            .is_err()
+        {
+            // Guard rejection (barrier inactive, or members not all terminal
+            // yet) is an expected idempotent no-op on the satisfaction fixed
+            // point, not a shell/DSL desync. Swallow.
             return;
         }
-        // Reflect barrier resolution in DSL state — clears wait_active + members.
-        let _ = self.dsl_apply(
-            mm_dsl::MeerkatMachineInput::SatisfyWaitAll,
-            "SatisfyWaitAll",
-        );
         let wait_id = match self.wait_request_id.take() {
             Some(id) => id,
             None => return,
@@ -1137,12 +1142,15 @@ impl RuntimeOpsLifecycleRegistry {
             Some(active) if active == wait_request_id => {
                 state.wait_request_id = None;
                 state.pending_wait = None;
-                // Clear the DSL barrier — SatisfyWaitAll resets wait_active +
-                // wait_operation_ids. The `wait_is_active` guard ensures this
-                // is a no-op if the barrier was already cleared.
+                // Clear the DSL barrier via the dedicated `CancelWaitAll`
+                // transition. Unlike `SatisfyWaitAll`, it does not require
+                // every member to be terminal (the request was dropped, not
+                // resolved) and does not emit the `WaitAllSatisfied`
+                // obligation. The `wait_is_active` guard keeps it an
+                // idempotent no-op if the barrier was already cleared.
                 let _ = state.dsl_apply(
-                    mm_dsl::MeerkatMachineInput::SatisfyWaitAll,
-                    "SatisfyWaitAll(cancel)",
+                    mm_dsl::MeerkatMachineInput::CancelWaitAll,
+                    "CancelWaitAll(cancel)",
                 );
                 Ok(())
             }
@@ -1262,6 +1270,44 @@ fn classify_op_rejection(
     }
 }
 
+/// Classify a `PeerReadyOp` DSL rejection back into the public error surface.
+///
+/// `PeerReadyOp`'s DSL guards layer three distinct rejections onto a single
+/// `GuardRejected` variant. The shell distinguishes them by re-reading the
+/// canonical DSL state under the same write lock that observed the guard
+/// failure — so the classification cannot race with a concurrent mutation.
+///
+/// Priority mirrors the declared guard order in the DSL transition:
+/// 1. `kind_is_mob_member_child` → `PeerNotExpected`
+/// 2. `not_already_peer_ready`   → `AlreadyPeerReady`
+/// 3. `from_status_valid`        → `InvalidTransition`
+fn classify_peer_ready_rejection(
+    state: &ShellState,
+    err: mm_dsl::MeerkatMachineTransitionError,
+    id: &OperationId,
+    status: OperationStatus,
+) -> OpsLifecycleError {
+    match err {
+        mm_dsl::MeerkatMachineTransitionError::GuardRejected { .. } => {
+            let kind = state.kind(id);
+            if kind != Some(OperationKind::MobMemberChild) {
+                return OpsLifecycleError::PeerNotExpected(id.clone());
+            }
+            if state.peer_ready(id).unwrap_or(false) {
+                return OpsLifecycleError::AlreadyPeerReady(id.clone());
+            }
+            OpsLifecycleError::InvalidTransition {
+                id: id.clone(),
+                status,
+                action: "peer_ready",
+            }
+        }
+        other => OpsLifecycleError::Internal(format!(
+            "DSL rejected ops transition (peer_ready): {other:?}"
+        )),
+    }
+}
+
 impl OpsLifecycleRegistry for RuntimeOpsLifecycleRegistry {
     fn register_operation(&self, spec: OperationSpec) -> Result<(), OpsLifecycleError> {
         let mut state = self.write_state()?;
@@ -1358,23 +1404,15 @@ impl OpsLifecycleRegistry for RuntimeOpsLifecycleRegistry {
         let status = state
             .status(id)
             .ok_or_else(|| OpsLifecycleError::NotFound(id.clone()))?;
-        let kind = state
-            .kind(id)
-            .ok_or_else(|| OpsLifecycleError::NotFound(id.clone()))?;
 
-        // Shell-owned guards (domain-shape concerns, not transition legality):
-        // peer-ready is only meaningful for MobMemberChild ops, and only once.
-        if kind != OperationKind::MobMemberChild {
-            return Err(OpsLifecycleError::PeerNotExpected(id.clone()));
-        }
-        if state.peer_ready(id).unwrap_or(false) {
-            return Err(OpsLifecycleError::AlreadyPeerReady(id.clone()));
-        }
-
+        // The kind / not-already-peer-ready / status decisions all live in
+        // the DSL's `PeerReadyOp` guards. The shell fires unconditionally
+        // and classifies a guard rejection by re-reading the state under
+        // the same write lock (so no race with the DSL's guard evaluation).
         if let Err(err) = state.dsl_apply_raw(mm_dsl::MeerkatMachineInput::PeerReadyOp {
             operation_id: mm_dsl::OperationId::from_domain(id).0,
         }) {
-            return Err(classify_op_rejection(err, id, status, "peer_ready"));
+            return Err(classify_peer_ready_rejection(&state, err, id, status));
         }
 
         // Shell concern: store the peer handle.
@@ -1589,11 +1627,13 @@ impl OpsLifecycleRegistry for RuntimeOpsLifecycleRegistry {
     fn terminate_owner(&self, reason: String) -> Result<(), OpsLifecycleError> {
         let mut state = self.write_state()?;
 
-        // Collect non-terminal op IDs — the shell loop mirrors the old
-        // OwnerTerminated cascade; session lock serialises the batch. The
-        // DSL's `TerminateOp` transition guards on the same non-terminal set,
-        // so guard rejection here indicates a genuine state desync rather
-        // than the common already-terminal no-op.
+        // The shell loop is a mechanical cursor over DSL-owned state; the
+        // "is this op non-terminal?" decision is expressed as a typed read
+        // of the DSL's `op_statuses` map via `OperationStatus::is_terminal`,
+        // not a handwritten branch over stringly-typed state. The DSL's
+        // `TerminateOp` transition guards on the same non-terminal set, so
+        // guard rejection here indicates a genuine state desync rather than
+        // the common already-terminal no-op.
         let to_terminate: Vec<(OperationId, OperationStatus)> = state
             .operation_ids()
             .into_iter()
@@ -1754,11 +1794,13 @@ impl OpsLifecycleRegistry for RuntimeOpsLifecycleRegistry {
                     if state.pending_wait.is_some() {
                         // Roll back the DSL barrier we just activated so the
                         // registry is not stuck in a wait-active state with
-                        // no correlation oneshot to resolve.
+                        // no correlation oneshot to resolve. `CancelWaitAll`
+                        // is the no-obligation clearer (members need not be
+                        // terminal).
                         state.wait_request_id = None;
                         let _ = state.dsl_apply(
-                            mm_dsl::MeerkatMachineInput::SatisfyWaitAll,
-                            "SatisfyWaitAll(rollback)",
+                            mm_dsl::MeerkatMachineInput::CancelWaitAll,
+                            "CancelWaitAll(rollback)",
                         );
                         return Box::pin(WaitAllFuture {
                             registry: self,


### PR DESCRIPTION
## Summary

Dogma cleanup Round 4, Wave 2-A: two sibling violations in the ops-lifecycle
tail, landed as two commits.

**Part 1 — typed DSL state (`417aac921`)**
Replace the opaque-JSON `op_kinds` and `op_terminal_outcomes` maps with
typed DSL enums mirroring `meerkat-core::ops_lifecycle`:
- `OperationKind` (newtype `String` → closed `enum`): MobMemberChild / BackgroundToolOp
- `OperationTerminalOutcomeKind` (new discriminant enum): Completed / Failed / Aborted / Cancelled / Retired / Terminated
- New companion `op_terminal_payload: Map<String, String>` carries the inner payload JSON (result struct / error / reason)
- Every terminal transition input now carries `outcome: Enum<OperationTerminalOutcomeKind>` + `payload: String` instead of `outcome: String`
- Shell `split_outcome` / `terminal_outcome` pair the discriminant with the payload; the former string-match rehydration at read sites is gone

**Part 2 — legality moves to DSL guards (`b6200f097`)**
- `PeerReadyOp`: new DSL guards `kind_is_mob_member_child` + `not_already_peer_ready`; shell `peer_ready` fires unconditionally and uses `classify_peer_ready_rejection` to re-read DSL state under the write lock and produce `PeerNotExpected` / `AlreadyPeerReady` / `InvalidTransition`
- `SatisfyWaitAll`: new `all_members_terminal` guard using `for_all(member_id in self.wait_operation_ids, ...)` over the typed `op_statuses` map; shell `maybe_satisfy_wait` fires idempotently on every terminal and swallows guard rejection
- New `CancelWaitAll` transition: clears the barrier without the terminality requirement and without emitting `WaitAllSatisfied`; used at wait-future drop + rollback sites (previously these abused `SatisfyWaitAll`, which would now be blocked)
- `terminate_owner`: shell loop unchanged (mechanical cursor), comment clarifies the shell loops / DSL decides boundary

## Test plan
- [x] `./scripts/repo-cargo fmt --all -- --check`
- [x] `./scripts/repo-cargo clippy --workspace --all-targets -- -D warnings`
- [x] `./scripts/repo-cargo nextest run -p meerkat-runtime --lib ops_lifecycle` — 13/13 pass
- [x] `./scripts/repo-cargo int` (workspace-wide fast tests) — 4770/4770 pass
- [x] `./scripts/repo-cargo e2e-fast` — 5/5 pass
- [x] `make machine-codegen && make machine-verify && make machine-check-drift` — up to date

🤖 Generated with [Claude Code](https://claude.com/claude-code)