### PR TITLE
fix(connection): propagate binding policy through hot-swap + resolution (dogma round 4, wave 3, H)

### DIFF
--- a/meerkat-anthropic/src/runtime/mod.rs
+++ b/meerkat-anthropic/src/runtime/mod.rs
@@ -7,7 +7,7 @@ use std::sync::Arc;
 
 use async_trait::async_trait;
 
-use meerkat_core::{AuthError, AuthMetadata, AuthProfile, BackendProfile, Provider};
+use meerkat_core::{AuthError, AuthMetadata, AuthProfile, BackendProfile, BindingPolicy, Provider};
 
 use meerkat_auth_core::resolver::{resolve_external_authorizer, resolve_simple_secret};
 use meerkat_llm_core::LlmClient;
@@ -95,6 +95,7 @@ impl ProviderRuntime for AnthropicProviderRuntime {
         &self,
         backend: &BackendProfile,
         auth: &AuthProfile,
+        policy: &BindingPolicy,
     ) -> Result<ValidatedBinding, ProviderBindingError> {
         if backend.provider != Provider::Anthropic || auth.provider != Provider::Anthropic {
             return Err(ProviderBindingError::ProviderMismatch);
@@ -116,7 +117,7 @@ impl ProviderRuntime for AnthropicProviderRuntime {
             auth: NormalizedAuthMethod::Anthropic(auth_method),
             backend_profile: Arc::new(backend.clone()),
             auth_profile: Arc::new(auth.clone()),
-            policy: Default::default(),
+            policy: policy.clone(),
         })
     }
 

--- a/meerkat-gemini/src/runtime/mod.rs
+++ b/meerkat-gemini/src/runtime/mod.rs
@@ -7,7 +7,7 @@ use std::sync::Arc;
 
 use async_trait::async_trait;
 
-use meerkat_core::{AuthError, AuthMetadata, AuthProfile, BackendProfile, Provider};
+use meerkat_core::{AuthError, AuthMetadata, AuthProfile, BackendProfile, BindingPolicy, Provider};
 
 use meerkat_auth_core::resolver::{resolve_external_authorizer, resolve_simple_secret};
 use meerkat_llm_core::LlmClient;
@@ -66,6 +66,7 @@ impl ProviderRuntime for GoogleProviderRuntime {
         &self,
         backend: &BackendProfile,
         auth: &AuthProfile,
+        policy: &BindingPolicy,
     ) -> Result<ValidatedBinding, ProviderBindingError> {
         if backend.provider != Provider::Gemini || auth.provider != Provider::Gemini {
             return Err(ProviderBindingError::ProviderMismatch);
@@ -87,7 +88,7 @@ impl ProviderRuntime for GoogleProviderRuntime {
             auth: NormalizedAuthMethod::Google(auth_method),
             backend_profile: Arc::new(backend.clone()),
             auth_profile: Arc::new(auth.clone()),
-            policy: Default::default(),
+            policy: policy.clone(),
         })
     }
 

--- a/meerkat-llm-core/src/provider_runtime/registry.rs
+++ b/meerkat-llm-core/src/provider_runtime/registry.rs
@@ -174,7 +174,7 @@ impl ProviderRuntimeRegistry {
         binding_id: &str,
         env: &ResolverEnvironment,
     ) -> Result<ResolvedConnection, ProviderAuthError> {
-        let (_binding, backend, auth) = realm
+        let (binding, backend, auth) = realm
             .lookup_binding(binding_id)
             .map_err(|e| ProviderAuthError::SourceResolutionFailed(e.to_string()))?;
         let runtime = self
@@ -182,7 +182,7 @@ impl ProviderRuntimeRegistry {
             .get(&backend.provider)
             .ok_or(ProviderAuthError::NoRuntimeRegistered(backend.provider))?;
         let validated = runtime
-            .validate_binding(backend, auth)
+            .validate_binding(backend, auth, &binding.policy)
             .map_err(ProviderAuthError::Binding)?;
         runtime.resolve_binding(&validated, env).await
     }

--- a/meerkat-llm-core/src/provider_runtime/runtime.rs
+++ b/meerkat-llm-core/src/provider_runtime/runtime.rs
@@ -5,7 +5,7 @@ use std::sync::Arc;
 
 use async_trait::async_trait;
 
-use meerkat_core::{AuthProfile, BackendProfile, Provider};
+use meerkat_core::{AuthProfile, BackendProfile, BindingPolicy, Provider};
 
 use crate::LlmClient;
 use crate::provider_runtime::binding::{ResolvedConnection, ValidatedBinding};
@@ -26,10 +26,19 @@ pub trait ProviderRuntime: Send + Sync {
 
     /// Normalize backend + auth strings into typed enums and verify the
     /// combination is listed in the runtime's `ALLOWED_BINDINGS` table.
+    ///
+    /// `policy` carries the binding's declared auth policy
+    /// (`allow_auth_override`, metadata requirements). Implementations
+    /// MUST populate `ValidatedBinding.policy` from this argument — the
+    /// policy is a contract fact about the binding, not an injectable
+    /// default. Dogma §16 (binding policy flows through resolution):
+    /// dropping it at validation silently substitutes the wrong policy
+    /// and bleeds defaults across bindings that declared otherwise.
     fn validate_binding(
         &self,
         backend: &BackendProfile,
         auth: &AuthProfile,
+        policy: &BindingPolicy,
     ) -> Result<ValidatedBinding, ProviderBindingError>;
 
     /// Resolve credential material per `CredentialSourceSpec` and wrap in a
@@ -71,6 +80,7 @@ mod tests {
             &self,
             _backend: &BackendProfile,
             _auth: &AuthProfile,
+            _policy: &BindingPolicy,
         ) -> Result<ValidatedBinding, ProviderBindingError> {
             Err(ProviderBindingError::ProviderMismatch)
         }

--- a/meerkat-openai/src/runtime/mod.rs
+++ b/meerkat-openai/src/runtime/mod.rs
@@ -7,7 +7,7 @@ use std::sync::Arc;
 
 use async_trait::async_trait;
 
-use meerkat_core::{AuthError, AuthMetadata, AuthProfile, BackendProfile, Provider};
+use meerkat_core::{AuthError, AuthMetadata, AuthProfile, BackendProfile, BindingPolicy, Provider};
 
 use meerkat_auth_core::resolver::{resolve_external_authorizer, resolve_simple_secret};
 use meerkat_llm_core::LlmClient;
@@ -56,6 +56,7 @@ impl ProviderRuntime for OpenAiProviderRuntime {
         &self,
         backend: &BackendProfile,
         auth: &AuthProfile,
+        policy: &BindingPolicy,
     ) -> Result<ValidatedBinding, ProviderBindingError> {
         if backend.provider != Provider::OpenAI || auth.provider != Provider::OpenAI {
             return Err(ProviderBindingError::ProviderMismatch);
@@ -77,7 +78,7 @@ impl ProviderRuntime for OpenAiProviderRuntime {
             auth: NormalizedAuthMethod::OpenAi(auth_method),
             backend_profile: Arc::new(backend.clone()),
             auth_profile: Arc::new(auth.clone()),
-            policy: Default::default(),
+            policy: policy.clone(),
         })
     }
 
@@ -408,7 +409,11 @@ mod tests {
     fn validate_accepts_allowed_combination() {
         let rt = OpenAiProviderRuntime;
         let vb = rt
-            .validate_binding(&backend("openai_api"), &auth("api_key"))
+            .validate_binding(
+                &backend("openai_api"),
+                &auth("api_key"),
+                &BindingPolicy::default(),
+            )
             .expect("allowed combination");
         assert_eq!(vb.provider, Provider::OpenAI);
     }
@@ -417,7 +422,11 @@ mod tests {
     fn validate_rejects_unknown_backend_kind() {
         let rt = OpenAiProviderRuntime;
         let err = rt
-            .validate_binding(&backend("bogus_backend"), &auth("api_key"))
+            .validate_binding(
+                &backend("bogus_backend"),
+                &auth("api_key"),
+                &BindingPolicy::default(),
+            )
             .unwrap_err();
         assert!(matches!(err, ProviderBindingError::UnknownBackendKind(_)));
     }
@@ -427,7 +436,11 @@ mod tests {
         // openai_api + managed_chatgpt_oauth is NOT in ALLOWED_BINDINGS.
         let rt = OpenAiProviderRuntime;
         let err = rt
-            .validate_binding(&backend("openai_api"), &auth("managed_chatgpt_oauth"))
+            .validate_binding(
+                &backend("openai_api"),
+                &auth("managed_chatgpt_oauth"),
+                &BindingPolicy::default(),
+            )
             .unwrap_err();
         assert!(matches!(
             err,
@@ -440,7 +453,25 @@ mod tests {
         let rt = OpenAiProviderRuntime;
         let mut wrong = backend("openai_api");
         wrong.provider = Provider::Anthropic;
-        let err = rt.validate_binding(&wrong, &auth("api_key")).unwrap_err();
+        let err = rt
+            .validate_binding(&wrong, &auth("api_key"), &BindingPolicy::default())
+            .unwrap_err();
         assert!(matches!(err, ProviderBindingError::ProviderMismatch));
+    }
+
+    #[test]
+    fn validate_propagates_binding_policy() {
+        // Dogma §16: policy declared on the binding must flow through
+        // validate_binding, not default-injected at the provider seam.
+        let rt = OpenAiProviderRuntime;
+        let policy = BindingPolicy {
+            allow_auth_override: true,
+            require_metadata_account: true,
+            require_metadata_workspace: false,
+        };
+        let vb = rt
+            .validate_binding(&backend("openai_api"), &auth("api_key"), &policy)
+            .expect("allowed combination");
+        assert_eq!(vb.policy, policy);
     }
 }

--- a/meerkat-rpc/src/handlers/turn.rs
+++ b/meerkat-rpc/src/handlers/turn.rs
@@ -134,6 +134,7 @@ impl TurnOverrides {
             && self.output_schema.is_none()
             && self.structured_output_retries.is_none()
             && self.provider_params.is_none()
+            && self.connection_ref.is_none()
     }
 }
 

--- a/meerkat-rpc/src/session_runtime.rs
+++ b/meerkat-rpc/src/session_runtime.rs
@@ -1087,7 +1087,7 @@ impl SessionRuntime {
             provider,
             self_hosted_server_id,
             provider_params: build_config.provider_params.clone(),
-            connection_ref: None,
+            connection_ref: build_config.connection_ref.clone(),
         })
     }
 
@@ -1190,12 +1190,21 @@ impl SessionRuntime {
             None
         };
 
+        // Dogma §10 inherit/set: `None` on the override preserves the
+        // session's existing binding, `Some(...)` sets a new one
+        // explicitly for this turn. Prevents cross-realm credential
+        // bleed when the override is the only changed field.
+        let connection_ref = ov
+            .connection_ref
+            .clone()
+            .or_else(|| current.connection_ref.clone());
+
         Ok(SessionLlmIdentity {
             model,
             provider,
             self_hosted_server_id,
             provider_params,
-            connection_ref: None,
+            connection_ref,
         })
     }
 
@@ -1207,6 +1216,7 @@ impl SessionRuntime {
         build_config.provider = Some(identity.provider);
         build_config.self_hosted_server_id = identity.self_hosted_server_id.clone();
         build_config.provider_params = identity.provider_params.clone();
+        build_config.connection_ref = identity.connection_ref.clone();
     }
 
     async fn current_materialized_llm_identity(
@@ -1409,7 +1419,7 @@ impl SessionRuntime {
             model: ov.model.clone(),
             provider: ov.provider.clone(),
             provider_params: ov.provider_params.clone(),
-            connection_ref: None,
+            connection_ref: ov.connection_ref.clone(),
         };
 
         if !self.runtime_adapter.contains_session(session_id).await
@@ -1837,7 +1847,7 @@ impl SessionRuntime {
                 provider_params: overrides.as_ref().and_then(|ov| ov.provider_params.clone()),
                 render_metadata: None,
                 execution_kind: None,
-                connection_ref: None,
+                connection_ref: overrides.as_ref().and_then(|ov| ov.connection_ref.clone()),
             },
         );
 
@@ -2184,7 +2194,10 @@ impl SessionRuntime {
         if pending_session.is_none() && !self.live_session_is_stale(session_id).await? {
             // Hot-swap LLM client if model/provider overrides are present.
             if let Some(ref ov) = overrides
-                && (ov.model.is_some() || ov.provider.is_some() || ov.provider_params.is_some())
+                && (ov.model.is_some()
+                    || ov.provider.is_some()
+                    || ov.provider_params.is_some()
+                    || ov.connection_ref.is_some())
             {
                 self.hot_swap_llm_client(session_id, ov).await?;
             }
@@ -5361,6 +5374,98 @@ mod tests {
             resolved.self_hosted_server_id.as_deref(),
             Some("local"),
             "provider-param overrides must preserve the pinned self-hosted server binding"
+        );
+    }
+
+    #[tokio::test]
+    async fn turn_override_connection_ref_propagates_to_resolved_identity() {
+        // Dogma §10 (inherit/set) + Wave 3 row 15: an explicit
+        // `connection_ref` override on a turn must flow through
+        // `resolve_target_llm_identity` onto the resolved identity —
+        // NOT be silently dropped to None. Guards against the earlier
+        // bug where hot-swap inherited stale binding even when the
+        // caller asked for a different realm.
+        let temp = tempfile::tempdir().unwrap();
+        let runtime = make_runtime(temp_factory(&temp), 10);
+
+        let current = SessionLlmIdentity {
+            model: "claude-sonnet-4-5".to_string(),
+            provider: meerkat_core::Provider::Anthropic,
+            self_hosted_server_id: None,
+            provider_params: None,
+            connection_ref: Some(meerkat_core::ConnectionRef {
+                realm_id: "tenant_a".into(),
+                binding_id: "anthropic_default".into(),
+            }),
+        };
+        let overrides = crate::handlers::turn::TurnOverrides {
+            connection_ref: Some(meerkat_core::ConnectionRef {
+                realm_id: "tenant_b".into(),
+                binding_id: "anthropic_vip".into(),
+            }),
+            ..Default::default()
+        };
+
+        let resolved = runtime
+            .resolve_target_llm_identity(&current, &overrides)
+            .await
+            .expect("connection_ref override should resolve");
+
+        assert_eq!(
+            resolved
+                .connection_ref
+                .as_ref()
+                .map(|c| c.realm_id.as_str()),
+            Some("tenant_b"),
+            "explicit connection_ref override must win over the session's current binding"
+        );
+        assert_eq!(
+            resolved
+                .connection_ref
+                .as_ref()
+                .map(|c| c.binding_id.as_str()),
+            Some("anthropic_vip"),
+        );
+    }
+
+    #[tokio::test]
+    async fn turn_without_connection_ref_override_preserves_current_binding() {
+        // Dogma §10 inherit semantics: `None` on the override does
+        // NOT mean "clear the binding" — it means "keep the current
+        // one". The earlier bug returned None either way, breaking
+        // multi-tenant sessions whose next turn happened to set
+        // another override (model/provider_params) alongside no
+        // explicit connection_ref.
+        let temp = tempfile::tempdir().unwrap();
+        let runtime = make_runtime(temp_factory(&temp), 10);
+
+        let current = SessionLlmIdentity {
+            model: "claude-sonnet-4-5".to_string(),
+            provider: meerkat_core::Provider::Anthropic,
+            self_hosted_server_id: None,
+            provider_params: None,
+            connection_ref: Some(meerkat_core::ConnectionRef {
+                realm_id: "tenant_a".into(),
+                binding_id: "anthropic_default".into(),
+            }),
+        };
+        let overrides = crate::handlers::turn::TurnOverrides {
+            provider_params: Some(serde_json::json!({ "temperature": 0.1 })),
+            ..Default::default()
+        };
+
+        let resolved = runtime
+            .resolve_target_llm_identity(&current, &overrides)
+            .await
+            .expect("resolve must succeed");
+
+        assert_eq!(
+            resolved
+                .connection_ref
+                .as_ref()
+                .map(|c| c.realm_id.as_str()),
+            Some("tenant_a"),
+            "absent connection_ref override must inherit the session's current binding, not drop it"
         );
     }
 


### PR DESCRIPTION
## Summary

Wave 3 Cluster H of the round-4 dogma cleanup — the connection binding policy was declared in the wire/domain types but dropped before reaching provider runtime resolution, and `connection_ref` turn overrides were silently ignored on hot-swap.

### Row 15 — `connection_ref` override dropped on hot-swap / reconfigure

`TurnOverrides.connection_ref` was accepted from RPC but silently set to `None` at five seams:

1. `TurnOverrides::is_empty()` ignored it — a turn with only a `connection_ref` override was treated as empty and passed `None` overrides through.
2. Both hot-swap trigger gates in `start_turn_via_runtime` / the legacy start-turn path checked only `model`/`provider`/`provider_params`, so a `connection_ref`-only override never triggered hot-swap.
3. The runtime-routed `RuntimeTurnMetadata.connection_ref` was hard-coded `None` on construction.
4. `hot_swap_llm_client` built `SessionLlmReconfigureRequest { connection_ref: None, .. }` regardless of the override.
5. `resolve_target_llm_identity` returned `SessionLlmIdentity { connection_ref: None, .. }`, and `apply_llm_identity_to_build_config` didn't copy the field, so even the session's current binding was lost.

End-to-end result: cross-realm credential bleed — hot-swaps would fall through to the env-default realm or keep a stale binding even when the caller explicitly asked for a different realm. Dogma §10 `inherit`/`set` semantics restored: `None` inherits the current binding, `Some(ref)` sets a new one explicitly.

### Row 16 — binding policy declared on the wire, discarded at provider resolution

`ProviderRuntimeRegistry::resolve` looked up the binding and handed `(backend, auth)` to `validate_binding` but dropped `binding.policy`. Each provider runtime's `validate_binding` filled `ValidatedBinding.policy = Default::default()` — overriding whatever the binding declared (`allow_auth_override`, metadata requirements). The trait now takes `&BindingPolicy` as a third argument and the three provider runtimes (OpenAI, Anthropic, Gemini) propagate it into `ValidatedBinding.policy`. Default-injection at the registry→provider seam is deleted.

### Defensive tests

- `turn_override_connection_ref_propagates_to_resolved_identity` in `meerkat-rpc`: explicit override wins over the session's current binding.
- `turn_without_connection_ref_override_preserves_current_binding`: absent override inherits the current binding (doesn't clear it).
- `validate_propagates_binding_policy` in `meerkat-openai`: non-default policy survives `validate_binding`, not default-injected.

## Test plan

- [x] `./scripts/repo-cargo fmt --all -- --check`
- [x] `./scripts/repo-cargo clippy --workspace --all-targets -- -D warnings`
- [x] `./scripts/repo-cargo unit` — 3803 tests passed
- [x] `./scripts/repo-cargo int` — 4779 tests passed (1 leaky, not a failure)
- [x] `./scripts/repo-cargo e2e-fast` — 5 tests passed
- [x] Pre-push hooks (fmt-check, clippy, machine codegen verify, workspace deterministic gate) all green.
- [ ] CI gate across all required jobs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)