### PR TITLE
fix(runtime): unify peer-response projection + boundary (dogma round 4, wave 3, C)

### DIFF
--- a/meerkat-openai/src/live.rs
+++ b/meerkat-openai/src/live.rs
@@ -269,28 +269,22 @@ fn openai_realtime_history_context(seed_messages: &[Message]) -> Option<String> 
     (!sections.is_empty()).then(|| sections.join("\n\n"))
 }
 
-fn normalize_openai_authoritative_system_text(text: &str) -> String {
+fn runtime_system_context_body(text: &str) -> String {
     let trimmed = text.trim();
-    let body = if let Some((_, body)) = trimmed.split_once("\n\n")
-        && trimmed.starts_with("[Runtime System Context]")
-    {
-        body.trim()
-    } else {
-        trimmed
-    };
-
-    if let Some((_, authoritative_tail)) = body.split_once("Authoritative result fields:") {
-        return format!("Authoritative result fields:{}", authoritative_tail.trim());
+    if !trimmed.starts_with("[Runtime System Context]") {
+        return trimmed.to_string();
     }
-
-    body.to_string()
+    trimmed
+        .split_once("\n\n")
+        .map(|(_, body)| body.trim().to_string())
+        .unwrap_or_else(|| trimmed.to_string())
 }
 
 fn authoritative_runtime_system_blocks_from_text(text: &str) -> Vec<String> {
     text.split(meerkat_core::SYSTEM_CONTEXT_SEPARATOR)
         .map(str::trim)
         .filter(|segment| segment.starts_with("[Runtime System Context]"))
-        .map(normalize_openai_authoritative_system_text)
+        .map(runtime_system_context_body)
         .filter(|segment| !segment.is_empty())
         .collect()
 }
@@ -2309,7 +2303,7 @@ mod tests {
     fn instructions_extract_authoritative_runtime_blocks_embedded_in_root_system_prompt() {
         let seed_messages = vec![Message::System(meerkat_core::SystemMessage {
             content: format!(
-                "You are the realtime operator.{}\n[Runtime System Context]\nsource: peer_response_terminal:analyst:req-123\n\nAuthoritative result fields: request_intent=checksum_token, token=birch seventeen. For checksum_token requests, the exact token answer is `birch seventeen`.",
+                "You are the realtime operator.{}\n[Runtime System Context]\nsource: peer_response_terminal:analyst:req-123\n\n[SYSTEM NOTICE][PEER_RESPONSE_TERMINAL] Correlated peer response from analyst. Request ID: req-123. Status: completed. Result: {{\"request_intent\":\"checksum_token\",\"token\":\"birch seventeen\"}}.",
                 meerkat_core::SYSTEM_CONTEXT_SEPARATOR
             ),
         })];
@@ -2326,8 +2320,16 @@ mod tests {
             "expected authoritative runtime section to be synthesized: {instructions}"
         );
         assert!(
-            instructions.contains("request_intent=checksum_token, token=birch seventeen"),
-            "expected embedded runtime context to surface exact authoritative token facts: {instructions}"
+            instructions.contains("[SYSTEM NOTICE][PEER_RESPONSE_TERMINAL]"),
+            "expected canonical terminal-peer notice to surface in reconstruction instructions: {instructions}"
+        );
+        assert!(
+            instructions.contains("\"token\":\"birch seventeen\""),
+            "expected structured Result JSON to surface in reconstruction instructions: {instructions}"
+        );
+        assert!(
+            !instructions.contains("Authoritative result fields:"),
+            "runtime must no longer emit the per-fixture 'Authoritative result fields' scaffolding: {instructions}"
         );
     }
 
@@ -2393,7 +2395,7 @@ mod tests {
                 content: "You are the realtime operator.".to_string(),
             }),
             Message::System(meerkat_core::SystemMessage {
-                content: "[Runtime System Context]\nsource: peer_response_terminal:analyst-rt:req-123\n\n[SYSTEM NOTICE][PEER_RESPONSE_TERMINAL] Correlated peer response from analyst-rt. Request ID: req-123. Status: completed. Result: {\n  \"request_intent\": \"checksum_token\",\n  \"token\": \"birch seventeen\"\n}. Authoritative result fields: request_intent=checksum_token, token=birch seventeen.".to_string(),
+                content: "[Runtime System Context]\nsource: peer_response_terminal:analyst-rt:req-123\n\n[SYSTEM NOTICE][PEER_RESPONSE_TERMINAL] Correlated peer response from analyst-rt. Request ID: req-123. Status: completed. Result: {\n  \"request_intent\": \"checksum_token\",\n  \"token\": \"birch seventeen\"\n}.".to_string(),
             }),
             Message::User(meerkat_core::UserMessage::text("hello")),
             Message::Assistant(meerkat_core::AssistantMessage {

--- a/meerkat-runtime/src/runtime_loop.rs
+++ b/meerkat-runtime/src/runtime_loop.rs
@@ -38,20 +38,6 @@ fn input_boundary(input: &Input) -> RunApplyBoundary {
         Input::Peer(peer)
             if matches!(
                 peer.convention,
-                Some(crate::input::PeerConvention::ResponseTerminal { .. })
-            ) && peer.handling_mode.is_none() =>
-        {
-            // Runtime-owned default for terminal peer responses:
-            // when surfaces do not explicitly override handling_mode, the
-            // typed ResponseTerminal convention should apply immediately as a
-            // canonical context fact. Routing it through RunStart would strand
-            // the authoritative peer result until a later user turn, which is
-            // exactly the freshness gap the realtime audio smoke exposes.
-            RunApplyBoundary::Immediate
-        }
-        Input::Peer(peer)
-            if matches!(
-                peer.convention,
                 Some(crate::input::PeerConvention::ResponseProgress { .. })
             ) =>
         {
@@ -306,10 +292,9 @@ fn peer_prompt_text(peer: &crate::input::PeerInput) -> String {
             Some(crate::input::PeerConvention::ResponseTerminal { request_id, status }),
             crate::input::InputOrigin::Peer { peer_id, .. },
         ) => format!(
-            "[SYSTEM NOTICE][PEER_RESPONSE_TERMINAL] Correlated peer response from {peer_id}. Request ID: {request_id}. Status: {}. Result: {}.{}",
+            "[SYSTEM NOTICE][PEER_RESPONSE_TERMINAL] Correlated peer response from {peer_id}. Request ID: {request_id}. Status: {}. Result: {}.",
             response_terminal_status_label(status),
-            format_peer_payload(peer.payload.as_ref()),
-            format_authoritative_peer_result_hint(peer.payload.as_ref())
+            format_peer_payload(peer.payload.as_ref())
         ),
         _ => peer.body.clone(),
     }
@@ -318,48 +303,6 @@ fn peer_prompt_text(peer: &crate::input::PeerInput) -> String {
 fn format_peer_payload(payload: Option<&serde_json::Value>) -> String {
     serde_json::to_string_pretty(payload.unwrap_or(&serde_json::Value::Null))
         .unwrap_or_else(|_| "null".to_string())
-}
-
-fn format_authoritative_peer_result_hint(payload: Option<&serde_json::Value>) -> String {
-    let Some(serde_json::Value::Object(map)) = payload else {
-        return String::new();
-    };
-
-    let request_intent = map
-        .get("request_intent")
-        .and_then(serde_json::Value::as_str);
-    let token = map.get("token").and_then(serde_json::Value::as_str);
-
-    if request_intent.is_none() && token.is_none() {
-        return String::new();
-    }
-
-    // Transitional but machine-owned:
-    // until the machine/DSL branch exposes first-class structured peer-response
-    // fields directly to the model, the runtime-owned prompt projection must
-    // restate the authoritative scalar facts from terminal peer results here.
-    // This keeps the semantic hint on the runtime side rather than asking the
-    // smoke harness or comms helper text to carry the meaning.
-    let mut parts = Vec::new();
-    if let Some(request_intent) = request_intent {
-        parts.push(format!("request_intent={request_intent}"));
-    }
-    if let Some(token) = token {
-        parts.push(format!("token={token}"));
-    }
-
-    let exact_answer_hint = match (request_intent, token) {
-        (Some(request_intent), Some(token)) => format!(
-            " For {request_intent} requests, the exact token answer is `{token}`. If a later user asks what token came from the peer, answer with `{token}` exactly."
-        ),
-        _ => String::new(),
-    };
-
-    format!(
-        " Authoritative result fields: {}. This terminal peer result supersedes any earlier peer-request params for factual recall. Treat these exact values as durable facts for later turns until a newer authoritative terminal peer response supersedes them. Use these exact values, not placeholder words, request subjects, or unrelated remembered codewords.{}",
-        parts.join(", "),
-        exact_answer_hint
-    )
 }
 
 fn response_progress_phase_label(phase: &crate::input::ResponseProgressPhase) -> &'static str {
@@ -1107,7 +1050,56 @@ mod tests {
 
         assert_eq!(
             input_to_prompt(&input),
-            "[SYSTEM NOTICE][PEER_RESPONSE_TERMINAL] Correlated peer response from analyst-rt. Request ID: req-123. Status: completed. Result: {\n  \"request_intent\": \"checksum_token\",\n  \"token\": \"birch seventeen\"\n}. Authoritative result fields: request_intent=checksum_token, token=birch seventeen. This terminal peer result supersedes any earlier peer-request params for factual recall. Treat these exact values as durable facts for later turns until a newer authoritative terminal peer response supersedes them. Use these exact values, not placeholder words, request subjects, or unrelated remembered codewords. For checksum_token requests, the exact token answer is `birch seventeen`. If a later user asks what token came from the peer, answer with `birch seventeen` exactly."
+            "[SYSTEM NOTICE][PEER_RESPONSE_TERMINAL] Correlated peer response from analyst-rt. Request ID: req-123. Status: completed. Result: {\n  \"request_intent\": \"checksum_token\",\n  \"token\": \"birch seventeen\"\n}."
+        );
+    }
+
+    #[test]
+    fn input_to_prompt_peer_response_terminal_omits_payload_key_extraction() {
+        // Regression: runtime must not reach into the peer response payload
+        // to extract ad-hoc fields (request_intent, token, etc.) and bake
+        // them into prompt text. The canonical projection is the typed
+        // convention + the Result JSON verbatim; any per-fixture semantics
+        // belong to the peer application, not the runtime.
+        let input = Input::Peer(PeerInput {
+            header: InputHeader {
+                id: InputId::new(),
+                timestamp: Utc::now(),
+                source: InputOrigin::Peer {
+                    peer_id: "analyst-rt".into(),
+                    runtime_id: None,
+                },
+                durability: InputDurability::Durable,
+                visibility: InputVisibility::default(),
+                idempotency_key: None,
+                supersession_key: None,
+                correlation_id: None,
+            },
+            convention: Some(crate::input::PeerConvention::ResponseTerminal {
+                request_id: "req-123".into(),
+                status: crate::input::ResponseTerminalStatus::Completed,
+            }),
+            body: "stale helper-local comms prose".into(),
+            payload: Some(serde_json::json!({
+                "request_intent": "checksum_token",
+                "token": "birch seventeen"
+            })),
+            blocks: None,
+            handling_mode: None,
+        });
+
+        let rendered = input_to_prompt(&input);
+        assert!(
+            !rendered.contains("Authoritative result fields:"),
+            "runtime must not emit scenario-specific authoritative-field hints: {rendered}"
+        );
+        assert!(
+            !rendered.contains("the exact token answer is"),
+            "runtime must not coach the model about specific payload values: {rendered}"
+        );
+        assert!(
+            !rendered.contains("request_intent=checksum_token"),
+            "runtime must not re-flatten payload keys into prompt text: {rendered}"
         );
     }
 
@@ -1189,8 +1181,13 @@ mod tests {
     }
 
     #[test]
-    fn peer_response_terminal_without_handling_mode_defaults_to_immediate_boundary()
-    -> Result<(), String> {
+    fn peer_response_terminal_input_boundary_matches_machine_boundary() -> Result<(), String> {
+        // Row 12 unification: `input_boundary` (typed Input view) and
+        // `machine_input_boundary` (ingress handling_mode view) must agree
+        // on ResponseTerminal inputs. Canonical answer is RunStart, since
+        // ResponseTerminal is forbidden from carrying a handling_mode
+        // override and the runtime-loop batch path already stages it as
+        // RunStart.
         let input = Input::Peer(PeerInput {
             header: InputHeader {
                 id: InputId::new(),
@@ -1218,12 +1215,17 @@ mod tests {
             handling_mode: None,
         });
 
+        assert_eq!(input_boundary(&input), RunApplyBoundary::RunStart);
+
         let primitive = inputs_to_primitive(&[(input.id().clone(), input)]);
         let staged = match primitive {
             RunPrimitive::StagedInput(staged) => staged,
             other => return Err(format!("expected staged input, got {other:?}")),
         };
-        assert_eq!(staged.boundary, RunApplyBoundary::Immediate);
+        assert_eq!(staged.boundary, RunApplyBoundary::RunStart);
+        // Terminal peer payload still routes through the context-append
+        // path (not user-visible appends) since `input_to_append` returns
+        // None for the ResponseTerminal convention.
         assert!(staged.appends.is_empty());
         assert_eq!(staged.context_appends.len(), 1);
         Ok(())


### PR DESCRIPTION
## Summary
- Delete `format_authoritative_peer_result_hint` from `meerkat-runtime/src/runtime_loop.rs`. It reached into `peer.payload: Value` to extract ad-hoc scenario-71 smoke fixture keys (`request_intent`, `token`) and pasted them into prompt text with model coaching (`For checksum_token requests, the exact token answer is \`birch seventeen\``). That was the runtime scaffolding the model — `feedback_prompt_engineering_is_cheating.md` baked into the runtime itself. The canonical `[PEER_RESPONSE_TERMINAL]` notice already carries the structured `Result` JSON verbatim.
- Delete the downstream `normalize_openai_authoritative_system_text` split-on-string path in `meerkat-openai/src/live.rs`. The replacement `runtime_system_context_body` just strips the `[Runtime System Context]` header and returns the body.
- Unify `input_boundary` with `machine_input_boundary` on ResponseTerminal. Previously the typed-Input path returned `Immediate` for ResponseTerminal-without-handling_mode while the ingress-backed path returned `RunStart` for the same input — they disagreed across the `accept_input_and_run` synchronous shim vs. the queued-batch path. Canonical answer is `RunStart` (matches production); the one test fixture that asserted `Immediate` has been migrated.
- Defensive tests: runtime must not emit per-fixture "Authoritative result fields" hints or reflate payload keys into prompt text; `input_boundary` + staged-primitive agree on ResponseTerminal.

## Rows landed
- Row 11 (High): runtime-loop shell owns peer-response semantic projection — fixed by deleting the JSON-key extraction helper. The remaining projection at `runtime_loop.rs:287` renders the typed `PeerConvention` enum into notice text (legitimate typed-enum → prompt projection, same shape as `format_external_event_projection`).
- Row 12 (Medium): ResponseTerminal boundary split — fixed by removing the Immediate special-case from `input_boundary`. Both boundary classifiers now agree.

## Canonical classifier
`meerkat_core::interaction::classify_response_terminality` (PR #318) remains the canonical `ResponseStatus → TerminalityClass` classifier for comms-boundary code. No second classifier was introduced.

## Follow-up risk (not blocking this PR)
Scenario-71 live smoke (`tests/integration/tests/smoke_shared_realm.rs`) coaches the model to read `request_intent`/`token` keys from the peer-response `Result` JSON. It was passing partly because the runtime hint reinforced that coaching. If the live smoke regresses after this change lands, **that is the coaching the dogma round was supposed to rip out** — the fix is to measure scenario-71 against the canonical `[PEER_RESPONSE_TERMINAL]` structured output, not the hint, and file a new catalog row for the follow-up. Not gating this PR on live-smoke re-test, matching the separation used in W2-B.

## Test plan
- [x] `./scripts/repo-cargo fmt --all -- --check`
- [x] `./scripts/repo-cargo clippy --workspace --all-targets -- -D warnings`
- [x] `./scripts/repo-cargo unit` — 3807 passed
- [x] `./scripts/repo-cargo int` — 4791 passed
- [x] `./scripts/repo-cargo e2e-fast` — 5 passed
- [x] Pre-push hooks all green (fmt, clippy-changed, machine-codegen-verify, workspace gate)
- [ ] CI green (pushed; let the workflow confirm)

🤖 Generated with [Claude Code](https://claude.com/claude-code)