### PR TITLE
fix(surface): machine-owned request lifecycle (dogma round 4, wave 3, G)

### DIFF
--- a/examples/034-codemob-mcp/src/main.rs
+++ b/examples/034-codemob-mcp/src/main.rs
@@ -192,28 +192,24 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                 }
             }
             Some(completion) = completion_rx.recv() => {
-                let terminal = if executor.cancel_requested(&completion.request_key) {
-                    RequestTerminal::RespondWithoutPublish(
-                        request_cancelled_response(request_id_from_terminal(&completion.terminal))
-                    )
-                } else {
-                    completion.terminal
-                };
-
-                match terminal {
+                match completion.terminal {
                     RequestTerminal::Publish(response) => {
-                        if writer.send(response).await.is_ok() {
-                            executor.mark_published(&completion.request_key);
-                            executor.remove_published(&completion.request_key);
-                        } else {
-                            executor.finish_unpublished(&completion.request_key).await;
+                        if writer.send(response).await.is_err() {
+                            let _ = executor.finish_unpublished(&completion.request_key).await;
                             break Ok(());
                         }
+                        let _ = executor.publish_and_complete(&completion.request_key);
                     }
                     RequestTerminal::RespondWithoutPublish(response) => {
-                        let send_result = writer.send(response).await;
-                        executor.finish_unpublished(&completion.request_key).await;
-                        if send_result.is_err() {
+                        let cancel_id = response.get("id").cloned();
+                        let outcome = executor.finish_unpublished(&completion.request_key).await;
+                        let to_write = match outcome {
+                            meerkat::surface::CompleteOutcome::Completed => response,
+                            meerkat::surface::CompleteOutcome::SupersededByCancel => {
+                                request_cancelled_response(cancel_id)
+                            }
+                        };
+                        if writer.send(to_write).await.is_err() {
                             break Ok(());
                         }
                     }
@@ -249,15 +245,6 @@ fn request_key(id: &Value) -> String {
 fn request_cancel_target(params: Option<&Value>) -> Option<String> {
     let request_id = params?.get("requestId")?;
     Some(request_key(request_id))
-}
-
-fn request_id_from_terminal(terminal: &RequestTerminal<Value>) -> Option<Value> {
-    let response = match terminal {
-        RequestTerminal::Publish(response) | RequestTerminal::RespondWithoutPublish(response) => {
-            response
-        }
-    };
-    response.get("id").cloned()
 }
 
 fn request_cancelled_response(id: Option<Value>) -> Value {

--- a/examples/034-codemob-mcp/src/tools/consult.rs
+++ b/examples/034-codemob-mcp/src/tools/consult.rs
@@ -60,14 +60,15 @@ pub async fn handle(
         if let Some(context) = request_context.as_ref() {
             let service = state.session_service.clone();
             let session_id_for_cancel = session_id.clone();
-            context.replace_cancel_action(request_action(move || {
-                let service = service.clone();
-                let session_id = session_id_for_cancel.clone();
-                async move {
-                    let _ = service.interrupt(&session_id).await;
-                }
-            }));
-            let _ = context.run_cancel_if_requested().await;
+            let _ = context
+                .install_cancel_action(request_action(move || {
+                    let service = service.clone();
+                    let session_id = session_id_for_cancel.clone();
+                    async move {
+                        let _ = service.interrupt(&session_id).await;
+                    }
+                }))
+                .await;
         }
 
         let req = StartTurnRequest {
@@ -103,15 +104,16 @@ pub async fn handle(
     if let Some(context) = request_context.as_ref() {
         let service = state.session_service.clone();
         let session_id_for_cancel = session_id.clone();
-        context.replace_cancel_action(request_action(move || {
-            let service = service.clone();
-            let session_id = session_id_for_cancel.clone();
-            async move {
-                let _ = service.interrupt(&session_id).await;
-            }
-        }));
         // No archive cleanup — session stays alive for continuation via session_id.
-        let _ = context.run_cancel_if_requested().await;
+        let _ = context
+            .install_cancel_action(request_action(move || {
+                let service = service.clone();
+                let session_id = session_id_for_cancel.clone();
+                async move {
+                    let _ = service.interrupt(&session_id).await;
+                }
+            }))
+            .await;
     }
 
     let system_prompt = input

--- a/examples/034-codemob-mcp/src/tools/deliberate.rs
+++ b/examples/034-codemob-mcp/src/tools/deliberate.rs
@@ -79,36 +79,39 @@ pub async fn handle(
 
     if let Some(context) = request_context.as_ref() {
         if !resuming {
-            let mob_state = state.mob_state.clone();
-            let mob_id_for_cancel = mob_id.clone();
-            context.replace_cancel_action(request_action(move || {
-                let mob_state = mob_state.clone();
-                let mob_id = mob_id_for_cancel.clone();
-                async move {
-                    let _ = mob_state.mob_destroy(&mob_id).await;
-                }
-            }));
-            let mob_state = state.mob_state.clone();
+            let mob_state_cleanup = state.mob_state.clone();
             let mob_id_for_cleanup = mob_id.clone();
             context.set_unpublished_cleanup(request_action(move || {
-                let mob_state = mob_state.clone();
+                let mob_state = mob_state_cleanup.clone();
                 let mob_id = mob_id_for_cleanup.clone();
                 async move {
                     let _ = mob_state.mob_destroy(&mob_id).await;
                 }
             }));
+            let mob_state = state.mob_state.clone();
+            let mob_id_for_cancel = mob_id.clone();
+            let _ = context
+                .install_cancel_action(request_action(move || {
+                    let mob_state = mob_state.clone();
+                    let mob_id = mob_id_for_cancel.clone();
+                    async move {
+                        let _ = mob_state.mob_destroy(&mob_id).await;
+                    }
+                }))
+                .await;
         } else {
             let mob_state = state.mob_state.clone();
             let mob_id_for_cancel = mob_id.clone();
-            context.replace_cancel_action(request_action(move || {
-                let mob_state = mob_state.clone();
-                let mob_id = mob_id_for_cancel.clone();
-                async move {
-                    let _ = mob_state.mob_stop(&mob_id).await;
-                }
-            }));
+            let _ = context
+                .install_cancel_action(request_action(move || {
+                    let mob_state = mob_state.clone();
+                    let mob_id = mob_id_for_cancel.clone();
+                    async move {
+                        let _ = mob_state.mob_stop(&mob_id).await;
+                    }
+                }))
+                .await;
         }
-        let _ = context.run_cancel_if_requested().await;
     }
 
     // Collect profile names and orchestrator before moving definition
@@ -290,16 +293,17 @@ async fn run_flow(
         let mob_state = state.mob_state.clone();
         let mob_id_for_cancel = mob_id.clone();
         let run_id_for_cancel = run_id.clone();
-        context.replace_cancel_action(request_action(move || {
-            let mob_state = mob_state.clone();
-            let mob_id = mob_id_for_cancel.clone();
-            let run_id = run_id_for_cancel.clone();
-            async move {
-                let _ = mob_state.mob_cancel_flow(&mob_id, run_id.clone()).await;
-                let _ = mob_state.mob_destroy(&mob_id).await;
-            }
-        }));
-        let _ = context.run_cancel_if_requested().await;
+        let _ = context
+            .install_cancel_action(request_action(move || {
+                let mob_state = mob_state.clone();
+                let mob_id = mob_id_for_cancel.clone();
+                let run_id = run_id_for_cancel.clone();
+                async move {
+                    let _ = mob_state.mob_cancel_flow(&mob_id, run_id.clone()).await;
+                    let _ = mob_state.mob_destroy(&mob_id).await;
+                }
+            }))
+            .await;
     }
 
     let last_completed = Arc::new(AtomicUsize::new(0));

--- a/meerkat-mcp-server/src/lib.rs
+++ b/meerkat-mcp-server/src/lib.rs
@@ -2498,13 +2498,15 @@ async fn handle_meerkat_run(
     if let Some(context) = request_context.as_ref() {
         let service = state.service.clone();
         let session_id_for_cancel = session_id.clone();
-        context.replace_cancel_action(request_action(move || {
-            let service = service.clone();
-            let session_id = session_id_for_cancel.clone();
-            async move {
-                let _ = service.interrupt(&session_id).await;
-            }
-        }));
+        let phase = context
+            .install_cancel_action(request_action(move || {
+                let service = service.clone();
+                let session_id = session_id_for_cancel.clone();
+                async move {
+                    let _ = service.interrupt(&session_id).await;
+                }
+            }))
+            .await;
         let service = state.service.clone();
         let session_id_for_cleanup = session_id.clone();
         let ingress_for_cleanup = ingress.clone();
@@ -2517,7 +2519,7 @@ async fn handle_meerkat_run(
                 ingress.clear_session(&session_id).await;
             }
         }));
-        if context.run_cancel_if_requested().await {
+        if phase == meerkat::surface::SurfaceRequestPhase::Cancelled {
             let _ = state.service.archive(&session_id).await;
             ingress.clear_session(&session_id).await;
             return Err(request_cancelled_tool_error());
@@ -2684,14 +2686,16 @@ async fn handle_meerkat_resume(
     if let Some(context) = request_context.as_ref() {
         let service = state.service.clone();
         let session_id_for_cancel = session_id.clone();
-        context.replace_cancel_action(request_action(move || {
-            let service = service.clone();
-            let session_id = session_id_for_cancel.clone();
-            async move {
-                let _ = service.interrupt(&session_id).await;
-            }
-        }));
-        if context.run_cancel_if_requested().await {
+        let phase = context
+            .install_cancel_action(request_action(move || {
+                let service = service.clone();
+                let session_id = session_id_for_cancel.clone();
+                async move {
+                    let _ = service.interrupt(&session_id).await;
+                }
+            }))
+            .await;
+        if phase == meerkat::surface::SurfaceRequestPhase::Cancelled {
             return Err(request_cancelled_tool_error());
         }
     }
@@ -3155,10 +3159,15 @@ mod tests {
     }
 
     async fn cancelled_request_context(key: &str) -> RequestContext {
+        use meerkat::surface::CancelOutcome;
         let executor = SurfaceRequestExecutor::new(Duration::from_millis(1));
         let context = executor.begin_request(key.to_string(), noop_request_action());
-        let cancelled = executor.cancel_request(key).await;
-        assert!(cancelled, "pre-cancel should mark request cancelled");
+        let outcome = executor.cancel_request(key).await;
+        assert_eq!(
+            outcome,
+            CancelOutcome::Cancelled,
+            "pre-cancel should transition Pending → Cancelled"
+        );
         context
     }
 

--- a/meerkat-mcp-server/src/main.rs
+++ b/meerkat-mcp-server/src/main.rs
@@ -289,36 +289,32 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                 }
             }
             Some(completion) = completion_rx.recv() => {
-                // Late cancel must not override committed work: if the task
-                // produced a Publish terminal, the work already ran and the
-                // client must learn the result. Only suppress uncommitted
-                // (RespondWithoutPublish) terminals when cancel was requested.
-                let terminal = match completion.terminal {
-                    RequestTerminal::Publish(_) => completion.terminal,
-                    RequestTerminal::RespondWithoutPublish(ref _resp)
-                        if request_executor.cancel_requested(&completion.request_key) =>
-                    {
-                        RequestTerminal::RespondWithoutPublish(
-                            request_cancelled_response(request_id_from_terminal(&completion.terminal)),
-                        )
-                    }
-                    other => other,
-                };
-
-                match terminal {
+                // Lifecycle truth lives in the executor's typed state machine:
+                // Publish always commits; RespondWithoutPublish yields to a
+                // prior cancel via CompleteOutcome. No shell-side rewriting.
+                match completion.terminal {
                     RequestTerminal::Publish(response) => {
-                        if writer.send(response).await.is_ok() {
-                            request_executor.mark_published(&completion.request_key);
-                            request_executor.remove_published(&completion.request_key);
-                        } else {
-                            request_executor.finish_unpublished(&completion.request_key).await;
+                        if writer.send(response).await.is_err() {
+                            let _ = request_executor
+                                .finish_unpublished(&completion.request_key)
+                                .await;
                             break Ok(());
                         }
+                        let _ = request_executor
+                            .publish_and_complete(&completion.request_key);
                     }
                     RequestTerminal::RespondWithoutPublish(response) => {
-                        let send_result = writer.send(response).await;
-                        request_executor.finish_unpublished(&completion.request_key).await;
-                        if send_result.is_err() {
+                        let cancel_id = response.get("id").cloned();
+                        let outcome = request_executor
+                            .finish_unpublished(&completion.request_key)
+                            .await;
+                        let to_write = match outcome {
+                            meerkat::surface::CompleteOutcome::Completed => response,
+                            meerkat::surface::CompleteOutcome::SupersededByCancel => {
+                                request_cancelled_response(cancel_id)
+                            }
+                        };
+                        if writer.send(to_write).await.is_err() {
                             break Ok(());
                         }
                     }
@@ -350,15 +346,6 @@ fn request_key(id: &Value) -> String {
 fn request_cancel_target(params: Option<&Value>) -> Option<String> {
     let request_id = params?.get("requestId")?;
     Some(request_key(request_id))
-}
-
-fn request_id_from_terminal(terminal: &RequestTerminal<Value>) -> Option<Value> {
-    let response = match terminal {
-        RequestTerminal::Publish(response) | RequestTerminal::RespondWithoutPublish(response) => {
-            response
-        }
-    };
-    response.get("id").cloned()
 }
 
 fn request_cancelled_response(id: Option<Value>) -> Value {

--- a/meerkat-rest/src/lib.rs
+++ b/meerkat-rest/src/lib.rs
@@ -1032,12 +1032,20 @@ async fn with_request_lifecycle<T>(
     match ctx {
         Some(ctx) => match outcome {
             RequestOutcome::Published(val) => {
-                executor.mark_published(ctx.key());
-                executor.remove_published(ctx.key());
+                // publish_and_complete rejects terminal phases (e.g. late
+                // cancel landed first). REST handlers don't spawn long-running
+                // tasks after announcing Published, so the only way this can
+                // fail in practice is shutdown racing, where we still want
+                // to return the caller's value.
+                let _ = executor.publish_and_complete(ctx.key());
                 val
             }
             RequestOutcome::Unpublished(val) => {
-                executor.finish_unpublished(ctx.key()).await;
+                // CompleteOutcome is observed by RPC/MCP surfaces for the
+                // late-cancel branch; REST decides Unpublished inline so the
+                // outcome is always Completed (cleanup runs) or the entry was
+                // already removed by a parallel shutdown path.
+                let _ = executor.finish_unpublished(ctx.key()).await;
                 val
             }
         },
@@ -2879,7 +2887,7 @@ async fn create_session_inner(
 
     // Early cancel check — before any stateful work.
     if let Some(ctx) = req_ctx.as_ref()
-        && ctx.run_cancel_if_requested().await
+        && ctx.phase() == meerkat::surface::SurfaceRequestPhase::Cancelled
     {
         return RequestOutcome::Unpublished(Err(ApiError::RequestCancelled { details: None }));
     }
@@ -2951,19 +2959,22 @@ async fn create_session_inner(
             }
         }));
 
-        // Install cancel action: interrupt the session.
+        // Install cancel action: interrupt the session. If a cancel already
+        // landed before this install, install_cancel_action fires the newly
+        // installed action immediately and reports the observed phase.
         let cancel_svc = state.session_service.clone();
         let cancel_sid = session_id.clone();
-        ctx.replace_cancel_action(request_action(move || {
-            let svc = cancel_svc.clone();
-            let sid = cancel_sid.clone();
-            async move {
-                let _ = svc.interrupt(&sid).await;
-            }
-        }));
+        let phase = ctx
+            .install_cancel_action(request_action(move || {
+                let svc = cancel_svc.clone();
+                let sid = cancel_sid.clone();
+                async move {
+                    let _ = svc.interrupt(&sid).await;
+                }
+            }))
+            .await;
 
-        // Re-check cancel after installing the action.
-        if ctx.run_cancel_if_requested().await {
+        if phase == meerkat::surface::SurfaceRequestPhase::Cancelled {
             drop(caller_event_tx);
             drain_event_forwarder(&session_id, forward_task).await;
             return RequestOutcome::Unpublished(Err(ApiError::RequestCancelled { details: None }));
@@ -3129,7 +3140,7 @@ async fn create_session_inner(
     // when no turn is running, so cancel between the last recheck and here
     // would be lost without this gate.
     if let Some(ctx) = req_ctx.as_ref()
-        && ctx.cancel_requested()
+        && ctx.phase() == meerkat::surface::SurfaceRequestPhase::Cancelled
     {
         drop(caller_event_tx);
         drain_event_forwarder(&session_id, forward_task).await;
@@ -3516,15 +3527,24 @@ async fn cancel_request(
     State(state): State<AppState>,
     Path(request_id): Path<String>,
 ) -> Result<Json<Value>, ApiError> {
-    if state.request_executor.cancel_request(&request_id).await {
-        Ok(Json(json!({
+    use meerkat::surface::CancelOutcome;
+    match state.request_executor.cancel_request(&request_id).await {
+        CancelOutcome::Cancelled | CancelOutcome::AlreadyCancelled => Ok(Json(json!({
             "request_id": request_id,
             "cancelled": true
-        })))
-    } else {
-        Err(ApiError::NotFound(format!(
+        }))),
+        CancelOutcome::AlreadyPublished | CancelOutcome::AlreadyCompleted => {
+            // Committed work cannot be revoked; caller already observed (or
+            // will observe) the terminal response on the original request.
+            Ok(Json(json!({
+                "request_id": request_id,
+                "cancelled": false,
+                "reason": "already_terminal"
+            })))
+        }
+        CancelOutcome::NotFound => Err(ApiError::NotFound(format!(
             "request not found: {request_id}"
-        )))
+        ))),
     }
 }
 
@@ -3620,7 +3640,7 @@ async fn continue_session_inner(
 
     // Early cancel check — before any stateful work.
     if let Some(ctx) = req_ctx.as_ref()
-        && ctx.run_cancel_if_requested().await
+        && ctx.phase() == meerkat::surface::SurfaceRequestPhase::Cancelled
     {
         return RequestOutcome::Unpublished(Err(ApiError::RequestCancelled { details: None }));
     }
@@ -3849,16 +3869,19 @@ async fn continue_session_inner(
 
             let cancel_svc = state.session_service.clone();
             let cancel_sid = session_id.clone();
-            ctx.replace_cancel_action(request_action(move || {
-                let svc = cancel_svc.clone();
-                let sid = cancel_sid.clone();
-                async move {
-                    let _ = svc.interrupt(&sid).await;
-                }
-            }));
+            let phase = ctx
+                .install_cancel_action(request_action(move || {
+                    let svc = cancel_svc.clone();
+                    let sid = cancel_sid.clone();
+                    async move {
+                        let _ = svc.interrupt(&sid).await;
+                    }
+                }))
+                .await;
 
-            // Post-install recheck.
-            if ctx.run_cancel_if_requested().await {
+            // If cancel raced with install, install_cancel_action already ran
+            // the newly installed action; bail out with a cancelled terminal.
+            if phase == meerkat::surface::SurfaceRequestPhase::Cancelled {
                 drop(caller_event_tx);
                 drain_event_forwarder(&session_id, forward_task).await;
                 return RequestOutcome::Unpublished(Err(ApiError::RequestCancelled {
@@ -3889,7 +3912,7 @@ async fn continue_session_inner(
             ));
         // Final cancel recheck before submitting input.
         if let Some(ctx) = req_ctx.as_ref()
-            && ctx.cancel_requested()
+            && ctx.phase() == meerkat::surface::SurfaceRequestPhase::Cancelled
         {
             drop(caller_event_tx);
             drain_event_forwarder(&session_id, forward_task).await;
@@ -3972,16 +3995,19 @@ async fn continue_session_inner(
         if let Some(ctx) = req_ctx.as_ref() {
             let cancel_svc = state.session_service.clone();
             let cancel_sid = session_id.clone();
-            ctx.replace_cancel_action(request_action(move || {
-                let svc = cancel_svc.clone();
-                let sid = cancel_sid.clone();
-                async move {
-                    let _ = svc.interrupt(&sid).await;
-                }
-            }));
+            let phase = ctx
+                .install_cancel_action(request_action(move || {
+                    let svc = cancel_svc.clone();
+                    let sid = cancel_sid.clone();
+                    async move {
+                        let _ = svc.interrupt(&sid).await;
+                    }
+                }))
+                .await;
 
-            // Post-install recheck.
-            if ctx.run_cancel_if_requested().await {
+            // If cancel raced with install, install_cancel_action already ran
+            // the newly installed action; bail out with a cancelled terminal.
+            if phase == meerkat::surface::SurfaceRequestPhase::Cancelled {
                 drop(caller_event_tx);
                 drain_event_forwarder(&session_id, forward_task).await;
                 return RequestOutcome::Unpublished(Err(ApiError::RequestCancelled {
@@ -4005,7 +4031,7 @@ async fn continue_session_inner(
             ));
         // Final cancel recheck before submitting input.
         if let Some(ctx) = req_ctx.as_ref()
-            && ctx.cancel_requested()
+            && ctx.phase() == meerkat::surface::SurfaceRequestPhase::Cancelled
         {
             drop(caller_event_tx);
             drain_event_forwarder(&session_id, forward_task).await;
@@ -6664,10 +6690,12 @@ mod tests {
             assert!(val.is_ok());
             assert_eq!(val.unwrap(), 200);
 
-            // Cancel arrives after completion — should return false (already gone).
-            assert!(
-                !executor.cancel_request(&key).await,
-                "cancel after Published removal should return false"
+            // Cancel arrives after completion — entry is gone, so the typed
+            // NotFound outcome is returned (no rewriting, no side effects).
+            assert_eq!(
+                executor.cancel_request(&key).await,
+                meerkat::surface::CancelOutcome::NotFound,
+                "cancel after Published removal must report NotFound"
             );
         }
     }

--- a/meerkat-rpc/src/handlers/session.rs
+++ b/meerkat-rpc/src/handlers/session.rs
@@ -381,13 +381,15 @@ pub async fn handle_create(
     if let Some(context) = request_context.as_ref() {
         let runtime_for_cancel = Arc::clone(&runtime);
         let session_id_for_cancel = session_id.clone();
-        context.replace_cancel_action(request_action(move || {
-            let runtime = Arc::clone(&runtime_for_cancel);
-            let session_id = session_id_for_cancel.clone();
-            async move {
-                let _ = runtime.interrupt(&session_id).await;
-            }
-        }));
+        let phase = context
+            .install_cancel_action(request_action(move || {
+                let runtime = Arc::clone(&runtime_for_cancel);
+                let session_id = session_id_for_cancel.clone();
+                async move {
+                    let _ = runtime.interrupt(&session_id).await;
+                }
+            }))
+            .await;
 
         let runtime_for_cleanup = Arc::clone(&runtime);
         let session_id_for_cleanup = session_id.clone();
@@ -398,7 +400,7 @@ pub async fn handle_create(
                 let _ = runtime.archive_session(&session_id).await;
             }
         }));
-        if context.run_cancel_if_requested().await {
+        if phase == meerkat::surface::SurfaceRequestPhase::Cancelled {
             let _ = runtime.archive_session(&session_id).await;
             runtime_adapter.unregister_session(&session_id).await;
             return RpcResponse::error(

--- a/meerkat-rpc/src/handlers/turn.rs
+++ b/meerkat-rpc/src/handlers/turn.rs
@@ -160,14 +160,16 @@ pub async fn handle_start(
     if let Some(context) = request_context.as_ref() {
         let runtime = Arc::clone(&runtime);
         let session_id = session_id.clone();
-        context.replace_cancel_action(request_action(move || {
-            let runtime = Arc::clone(&runtime);
-            let session_id = session_id.clone();
-            async move {
-                let _ = runtime.interrupt(&session_id).await;
-            }
-        }));
-        if context.run_cancel_if_requested().await {
+        let phase = context
+            .install_cancel_action(request_action(move || {
+                let runtime = Arc::clone(&runtime);
+                let session_id = session_id.clone();
+                async move {
+                    let _ = runtime.interrupt(&session_id).await;
+                }
+            }))
+            .await;
+        if phase == meerkat::surface::SurfaceRequestPhase::Cancelled {
             return RpcResponse::error(
                 id,
                 error::REQUEST_CANCELLED,

--- a/meerkat-rpc/src/router.rs
+++ b/meerkat-rpc/src/router.rs
@@ -2930,11 +2930,16 @@ mod tests {
     }
 
     async fn cancelled_request_context(id: &RpcId) -> RequestContext {
+        use meerkat::surface::CancelOutcome;
         let executor = SurfaceRequestExecutor::new(Duration::from_millis(1));
         let key = serde_json::to_string(id).expect("request id should serialize");
         let context = executor.begin_request(key.clone(), noop_request_action());
-        let cancelled = executor.cancel_request(&key).await;
-        assert!(cancelled, "pre-cancel should mark request cancelled");
+        let outcome = executor.cancel_request(&key).await;
+        assert_eq!(
+            outcome,
+            CancelOutcome::Cancelled,
+            "pre-cancel should transition Pending → Cancelled"
+        );
         context
     }
 

--- a/meerkat-rpc/src/server.rs
+++ b/meerkat-rpc/src/server.rs
@@ -292,41 +292,44 @@ impl<R: AsyncBufRead + Unpin, W: TransportWriter> RpcServer<R, W> {
                 }
 
                 Some(response) = self.long_running_rx.recv() => {
-                    // Late cancel must not override committed work: if the task
-                    // produced a Publish terminal, the work already ran and the
-                    // client must learn the result. Only suppress uncommitted
-                    // (RespondWithoutPublish) terminals when cancel was requested.
-                    let terminal = match response.terminal {
-                        RequestTerminal::Publish(_) => response.terminal,
-                        RequestTerminal::RespondWithoutPublish(ref _resp)
-                            if self.request_executor.cancel_requested(&response.request_key) =>
-                        {
-                            RequestTerminal::RespondWithoutPublish(
-                                request_cancelled_response(request_id_from_response(&response.terminal)),
-                            )
-                        }
-                        other => other,
-                    };
-
-                    match terminal {
+                    // Lifecycle truth lives in the executor's typed state
+                    // machine: Publish always commits; RespondWithoutPublish
+                    // yields to a prior cancel via CompleteOutcome.
+                    match response.terminal {
                         RequestTerminal::Publish(rpc_response) => {
-                            // Defer ownership publication until the response is
-                            // actually written to the transport (not just enqueued).
-                            match self.transport.write_response(&rpc_response).await {
-                                Ok(()) => {
-                                    self.request_executor.mark_published(&response.request_key);
-                                    self.request_executor.remove_published(&response.request_key);
-                                }
-                                Err(_) => {
-                                    self.request_executor.finish_unpublished(&response.request_key).await;
-                                    break;
-                                }
+                            // Committed work is observable; write first, then
+                            // record publish. publish_and_complete rejects
+                            // post-terminal transitions with a typed error,
+                            // which here can only mean shutdown raced ahead.
+                            if self.transport.write_response(&rpc_response).await.is_err() {
+                                let _ = self
+                                    .request_executor
+                                    .finish_unpublished(&response.request_key)
+                                    .await;
+                                break;
                             }
+                            let _ = self
+                                .request_executor
+                                .publish_and_complete(&response.request_key);
                         }
                         RequestTerminal::RespondWithoutPublish(rpc_response) => {
-                            let write_result = self.transport.write_response(&rpc_response).await;
-                            self.request_executor.finish_unpublished(&response.request_key).await;
-                            if write_result.is_err() {
+                            // Uncommitted terminal: the executor tells us
+                            // whether cancel landed first. No shell-side
+                            // rewriting — a SupersededByCancel outcome means
+                            // we emit the cancel response the caller
+                            // requested, not the task's stale payload.
+                            let cancel_id = rpc_response.id.clone();
+                            let outcome = self
+                                .request_executor
+                                .finish_unpublished(&response.request_key)
+                                .await;
+                            let to_write = match outcome {
+                                meerkat::surface::CompleteOutcome::Completed => rpc_response,
+                                meerkat::surface::CompleteOutcome::SupersededByCancel => {
+                                    request_cancelled_response(cancel_id)
+                                }
+                            };
+                            if self.transport.write_response(&to_write).await.is_err() {
                                 break;
                             }
                         }
@@ -500,14 +503,6 @@ fn session_create_runs_immediately(params: Option<&serde_json::value::RawValue>)
             .and_then(serde_json::Value::as_str),
         Some("deferred")
     )
-}
-
-fn request_id_from_response(terminal: &RequestTerminal<RpcResponse>) -> Option<RpcId> {
-    match terminal {
-        RequestTerminal::Publish(response) | RequestTerminal::RespondWithoutPublish(response) => {
-            response.id.clone()
-        }
-    }
 }
 
 /// Start the RPC server on stdin/stdout.

--- a/meerkat/src/surface.rs
+++ b/meerkat/src/surface.rs
@@ -22,8 +22,9 @@ pub use meerkat_core::{
     session_allows_first_turn_build_overrides,
 };
 pub use request_execution::{
-    PreparedSurfaceSession, RequestAlreadyExists, RequestAsyncAction, RequestContext,
-    RequestTerminal, SurfaceRequestExecutor, noop_request_action, prepare_surface_session,
+    CancelOutcome, CompleteOutcome, PreparedSurfaceSession, RequestAlreadyExists,
+    RequestAsyncAction, RequestContext, RequestTerminal, RequestTransitionError,
+    SurfaceRequestExecutor, SurfaceRequestPhase, noop_request_action, prepare_surface_session,
     request_action,
 };
 #[cfg(all(feature = "session-store", feature = "comms"))]

--- a/meerkat/src/surface/request_execution.rs
+++ b/meerkat/src/surface/request_execution.rs
@@ -1,6 +1,6 @@
 use std::collections::HashMap;
+use std::fmt;
 use std::future::Future;
-use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, Mutex, MutexGuard};
 use std::time::Duration;
 
@@ -46,15 +46,104 @@ pub fn noop_request_action() -> RequestAsyncAction {
 #[derive(Debug)]
 pub struct RequestAlreadyExists;
 
+/// Terminal outcome produced by a long-running task (RPC/MCP async dispatch).
 #[derive(Debug)]
 pub enum RequestTerminal<T> {
+    /// Committed terminal. The request's side effects have been persisted and
+    /// the client must observe the result; late cancel does not override this.
     Publish(T),
+    /// Uncommitted terminal. Side effects did not land; a late cancel can
+    /// supersede this via [`CompleteOutcome::SupersededByCancel`].
     RespondWithoutPublish(T),
 }
 
+/// Canonical lifecycle phase of a tracked request.
+///
+/// Every tracked request advances through this state machine exactly once.
+/// Transitions are guarded: publish and cancel are mutually exclusive terminals,
+/// and re-entering a terminal phase yields a typed [`RequestTransitionError`]
+/// rather than silently rewriting state.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SurfaceRequestPhase {
+    /// Registered and in-flight. Cancel will run the installed action.
+    Pending,
+    /// Terminal: committed work was observed by the client.
+    Published,
+    /// Terminal: cancel won; any completion that arrives is superseded.
+    Cancelled,
+    /// Terminal: uncommitted work finished without publishing.
+    Completed,
+}
+
+impl fmt::Display for SurfaceRequestPhase {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            SurfaceRequestPhase::Pending => f.write_str("Pending"),
+            SurfaceRequestPhase::Published => f.write_str("Published"),
+            SurfaceRequestPhase::Cancelled => f.write_str("Cancelled"),
+            SurfaceRequestPhase::Completed => f.write_str("Completed"),
+        }
+    }
+}
+
+/// Typed rejection when a transition is inapplicable to the current phase.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum RequestTransitionError {
+    /// No tracked request with this key.
+    NotFound,
+    /// The request is already in a terminal phase; the requested transition
+    /// is rejected rather than silently overwriting prior state.
+    AlreadyTerminal { current: SurfaceRequestPhase },
+}
+
+impl fmt::Display for RequestTransitionError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::NotFound => f.write_str("request not tracked"),
+            Self::AlreadyTerminal { current } => {
+                write!(f, "request already terminal (phase = {current})")
+            }
+        }
+    }
+}
+
+impl std::error::Error for RequestTransitionError {}
+
+/// Outcome of a cancel attempt.
+///
+/// Callers branch on this rather than reading a `cancel_requested` bool
+/// and making their own publish/cancel decision.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CancelOutcome {
+    /// Pending → Cancelled; the installed cancel action was run.
+    Cancelled,
+    /// The request was already committed (Published); cancel is suppressed.
+    /// Committed work is observable by the client and cannot be revoked.
+    AlreadyPublished,
+    /// The request had already transitioned to Cancelled (idempotent replay).
+    AlreadyCancelled,
+    /// The request had already completed without publishing; cancel arrived
+    /// too late and has no effect.
+    AlreadyCompleted,
+    /// No tracked request with this key.
+    NotFound,
+}
+
+/// Outcome of completing a request via the uncommitted path.
+///
+/// RPC and MCP surfaces use this to decide whether to write the task's own
+/// response or a cancel response — without peeking at internal booleans.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CompleteOutcome {
+    /// Pending → Completed; the surface should write the task's own response.
+    Completed,
+    /// Cancel landed first; the surface should write a cancel response instead
+    /// of the task's uncommitted terminal.
+    SupersededByCancel,
+}
+
 struct RequestEntry {
-    cancel_requested: AtomicBool,
-    ownership_published: AtomicBool,
+    phase: Mutex<SurfaceRequestPhase>,
     cancel_action: Mutex<RequestAsyncAction>,
     unpublished_cleanup: Mutex<Option<RequestAsyncAction>>,
     task_handle: Mutex<Option<JoinHandle<()>>>,
@@ -63,12 +152,15 @@ struct RequestEntry {
 impl RequestEntry {
     fn new(initial_cancel: RequestAsyncAction) -> Self {
         Self {
-            cancel_requested: AtomicBool::new(false),
-            ownership_published: AtomicBool::new(false),
+            phase: Mutex::new(SurfaceRequestPhase::Pending),
             cancel_action: Mutex::new(initial_cancel),
             unpublished_cleanup: Mutex::new(None),
             task_handle: Mutex::new(None),
         }
+    }
+
+    fn phase(&self) -> SurfaceRequestPhase {
+        *lock_or_recover(&self.phase)
     }
 }
 
@@ -83,44 +175,38 @@ impl RequestContext {
         &self.key
     }
 
-    pub fn replace_cancel_action(&self, action: RequestAsyncAction) {
-        let mut slot = self.cancel_action_guard();
-        *slot = action;
+    /// Current lifecycle phase (observation seam; not for decision-making
+    /// that should go through typed transitions).
+    pub fn phase(&self) -> SurfaceRequestPhase {
+        self.entry.phase()
     }
 
-    pub fn set_unpublished_cleanup(&self, cleanup: RequestAsyncAction) {
-        let mut slot = self.cleanup_guard();
-        *slot = Some(cleanup);
-    }
-
-    pub fn clear_unpublished_cleanup(&self) {
-        let mut slot = self.cleanup_guard();
-        *slot = None;
-    }
-
-    pub fn cancel_requested(&self) -> bool {
-        self.entry.cancel_requested.load(Ordering::Acquire)
-    }
-
-    pub async fn run_cancel_if_requested(&self) -> bool {
-        if !self.cancel_requested() {
-            return false;
-        }
-
-        let action = {
-            let slot = self.cancel_action_guard();
-            Arc::clone(&slot)
+    /// Install (or replace) the cancel action. If the request is already
+    /// [`SurfaceRequestPhase::Cancelled`], the newly-installed action is run
+    /// immediately so initialization-time races can't leave the caller with a
+    /// stale noop action on a cancelled request.
+    ///
+    /// Returns the phase observed at install time.
+    pub async fn install_cancel_action(&self, action: RequestAsyncAction) -> SurfaceRequestPhase {
+        let (phase, maybe_run) = {
+            let phase = *lock_or_recover(&self.entry.phase);
+            let mut slot = lock_or_recover(&self.entry.cancel_action);
+            *slot = Arc::clone(&action);
+            // If cancel already landed, honour the upgrade by re-firing now.
+            let run = matches!(phase, SurfaceRequestPhase::Cancelled).then(|| Arc::clone(&slot));
+            (phase, run)
         };
-        action().await;
-        true
+        if let Some(action) = maybe_run {
+            action().await;
+        }
+        phase
     }
 
-    fn cancel_action_guard(&self) -> MutexGuard<'_, RequestAsyncAction> {
-        lock_or_recover(&self.entry.cancel_action)
-    }
-
-    fn cleanup_guard(&self) -> MutexGuard<'_, Option<RequestAsyncAction>> {
-        lock_or_recover(&self.entry.unpublished_cleanup)
+    /// Install the cleanup action that runs if the request finishes without
+    /// publishing.
+    pub fn set_unpublished_cleanup(&self, cleanup: RequestAsyncAction) {
+        let mut slot = lock_or_recover(&self.entry.unpublished_cleanup);
+        *slot = Some(cleanup);
     }
 }
 
@@ -138,6 +224,8 @@ impl SurfaceRequestExecutor {
         }
     }
 
+    /// Register a new in-flight request. Panics on duplicate keys are avoided;
+    /// use [`Self::try_begin_request`] when the caller must detect duplicates.
     pub fn begin_request(
         &self,
         key: impl Into<String>,
@@ -170,127 +258,147 @@ impl SurfaceRequestExecutor {
         Ok(RequestContext { key, entry })
     }
 
+    /// Attach the task handle for later forced abort during shutdown.
     pub fn attach_task(&self, key: &str, handle: JoinHandle<()>) {
-        if let Some(entry) = self
-            .entries
-            .lock()
-            .unwrap_or_else(std::sync::PoisonError::into_inner)
-            .get(key)
-            .cloned()
-        {
-            let mut slot = entry
-                .task_handle
-                .lock()
-                .unwrap_or_else(std::sync::PoisonError::into_inner);
+        if let Some(entry) = lock_or_recover(&self.entries).get(key).cloned() {
+            let mut slot = lock_or_recover(&entry.task_handle);
             *slot = Some(handle);
         }
     }
 
-    pub fn cancel_requested(&self, key: &str) -> bool {
-        self.entries
-            .lock()
-            .unwrap_or_else(std::sync::PoisonError::into_inner)
+    /// Read-only observation of the current phase for a key.
+    pub fn phase(&self, key: &str) -> Option<SurfaceRequestPhase> {
+        lock_or_recover(&self.entries)
             .get(key)
-            .is_some_and(|entry| entry.cancel_requested.load(Ordering::Acquire))
+            .map(|entry| entry.phase())
     }
 
-    pub async fn cancel_request(&self, key: &str) -> bool {
-        let Some(entry) = self
-            .entries
-            .lock()
-            .unwrap_or_else(std::sync::PoisonError::into_inner)
-            .get(key)
-            .cloned()
-        else {
-            return false;
+    /// Typed cancel transition.
+    ///
+    /// * `Pending → Cancelled` fires the installed cancel action.
+    /// * `Published` is suppressed ([`CancelOutcome::AlreadyPublished`]);
+    ///   committed work cannot be revoked at the surface.
+    /// * Terminal phases return the matching `Already*` outcome; no state
+    ///   is mutated and no action fires twice.
+    pub async fn cancel_request(&self, key: &str) -> CancelOutcome {
+        // Acquire entry + decide transition atomically. Actions run outside
+        // the lock so they can await.
+        let (outcome, maybe_action) = {
+            let entries = lock_or_recover(&self.entries);
+            let Some(entry) = entries.get(key).cloned() else {
+                return CancelOutcome::NotFound;
+            };
+            drop(entries);
+
+            let mut phase = lock_or_recover(&entry.phase);
+            match *phase {
+                SurfaceRequestPhase::Pending => {
+                    *phase = SurfaceRequestPhase::Cancelled;
+                    drop(phase);
+                    let action = Arc::clone(&lock_or_recover(&entry.cancel_action));
+                    (CancelOutcome::Cancelled, Some(action))
+                }
+                SurfaceRequestPhase::Published => (CancelOutcome::AlreadyPublished, None),
+                SurfaceRequestPhase::Cancelled => (CancelOutcome::AlreadyCancelled, None),
+                SurfaceRequestPhase::Completed => (CancelOutcome::AlreadyCompleted, None),
+            }
         };
 
-        entry.cancel_requested.store(true, Ordering::Release);
-        if entry.ownership_published.load(Ordering::Acquire) {
-            return true;
+        if let Some(action) = maybe_action {
+            action().await;
         }
-
-        let action = {
-            let slot = entry
-                .cancel_action
-                .lock()
-                .unwrap_or_else(std::sync::PoisonError::into_inner);
-            Arc::clone(&slot)
-        };
-        action().await;
-        true
+        outcome
     }
 
-    pub fn mark_published(&self, key: &str) {
-        if let Some(entry) = self
-            .entries
-            .lock()
-            .unwrap_or_else(std::sync::PoisonError::into_inner)
-            .get(key)
-            .cloned()
-        {
-            entry.ownership_published.store(true, Ordering::Release);
-        }
-    }
-
-    pub fn remove_published(&self, key: &str) {
+    /// Committed-terminal transition.
+    ///
+    /// `Pending → Published → (entry removed)` in one atomic step. Rejects
+    /// terminal phases via [`RequestTransitionError::AlreadyTerminal`] so a
+    /// late publish after cancel surfaces as a typed error rather than a
+    /// silent overwrite.
+    pub fn publish_and_complete(&self, key: &str) -> Result<(), RequestTransitionError> {
         let mut entries = lock_or_recover(&self.entries);
-        entries.remove(key);
+        let Some(entry) = entries.get(key).cloned() else {
+            return Err(RequestTransitionError::NotFound);
+        };
+        let mut phase = lock_or_recover(&entry.phase);
+        match *phase {
+            SurfaceRequestPhase::Pending => {
+                *phase = SurfaceRequestPhase::Published;
+                drop(phase);
+                entries.remove(key);
+                Ok(())
+            }
+            current => Err(RequestTransitionError::AlreadyTerminal { current }),
+        }
     }
 
-    pub async fn finish_unpublished(&self, key: &str) {
-        let entry = {
+    /// Uncommitted-terminal transition.
+    ///
+    /// * `Pending → Completed`: runs the installed cleanup (if any) and
+    ///   removes the entry; returns [`CompleteOutcome::Completed`].
+    /// * `Cancelled`: cancel already won the race. Cleanup is still run
+    ///   (the surface still needs the invariants restored), and the caller
+    ///   is told to write a cancel response instead of the task's terminal.
+    /// * `Published`/`Completed`: terminal reached via another path;
+    ///   returns `Completed` idempotently with no side effect.
+    pub async fn finish_unpublished(&self, key: &str) -> CompleteOutcome {
+        let (outcome, cleanup) = {
             let mut entries = lock_or_recover(&self.entries);
-            entries.remove(key)
+            let Some(entry) = entries.get(key).cloned() else {
+                return CompleteOutcome::Completed;
+            };
+            let mut phase = lock_or_recover(&entry.phase);
+            match *phase {
+                SurfaceRequestPhase::Pending => {
+                    *phase = SurfaceRequestPhase::Completed;
+                    drop(phase);
+                    entries.remove(key);
+                    let cleanup = lock_or_recover(&entry.unpublished_cleanup).take();
+                    (CompleteOutcome::Completed, cleanup)
+                }
+                SurfaceRequestPhase::Cancelled => {
+                    drop(phase);
+                    entries.remove(key);
+                    let cleanup = lock_or_recover(&entry.unpublished_cleanup).take();
+                    (CompleteOutcome::SupersededByCancel, cleanup)
+                }
+                SurfaceRequestPhase::Published | SurfaceRequestPhase::Completed => {
+                    // Entry may linger only if publish_and_complete wasn't
+                    // called; belt-and-braces remove.
+                    drop(phase);
+                    entries.remove(key);
+                    (CompleteOutcome::Completed, None)
+                }
+            }
         };
 
-        let Some(entry) = entry else {
-            return;
-        };
-
-        if entry.ownership_published.load(Ordering::Acquire) {
-            return;
-        }
-
-        let cleanup = entry
-            .unpublished_cleanup
-            .lock()
-            .unwrap_or_else(std::sync::PoisonError::into_inner)
-            .take();
         if let Some(cleanup) = cleanup {
             cleanup().await;
         }
+        outcome
     }
 
+    /// Cancel every tracked request. Honours the same typed transitions as
+    /// [`Self::cancel_request`]; already-terminal entries are left alone.
     pub async fn cancel_all(&self) {
-        let keys: Vec<String> = self
-            .entries
-            .lock()
-            .unwrap_or_else(std::sync::PoisonError::into_inner)
-            .keys()
-            .cloned()
-            .collect();
+        let keys: Vec<String> = lock_or_recover(&self.entries).keys().cloned().collect();
 
         for key in keys {
             let _ = self.cancel_request(&key).await;
         }
     }
 
+    /// Graceful shutdown: cancel all, wait `shutdown_grace`, then force-abort
+    /// remaining tasks and run any pending unpublished cleanups.
     pub async fn shutdown_and_abort_stragglers(&self) {
-        let has_entries = !self
-            .entries
-            .lock()
-            .unwrap_or_else(std::sync::PoisonError::into_inner)
-            .is_empty();
+        let has_entries = !lock_or_recover(&self.entries).is_empty();
         if has_entries {
             self.cancel_all().await;
             tokio::time::sleep(self.shutdown_grace).await;
         }
 
-        let remaining: Vec<(String, Arc<RequestEntry>)> = self
-            .entries
-            .lock()
-            .unwrap_or_else(std::sync::PoisonError::into_inner)
+        let remaining: Vec<(String, Arc<RequestEntry>)> = lock_or_recover(&self.entries)
             .iter()
             .map(|(key, entry)| (key.clone(), Arc::clone(entry)))
             .collect();
@@ -299,18 +407,17 @@ impl SurfaceRequestExecutor {
             if let Some(handle) = lock_or_recover(&entry.task_handle).take() {
                 handle.abort();
             }
-            if !entry.ownership_published.load(Ordering::Acquire) {
-                let cleanup = entry
-                    .unpublished_cleanup
-                    .lock()
-                    .unwrap_or_else(std::sync::PoisonError::into_inner)
-                    .take();
+            let phase = entry.phase();
+            if matches!(
+                phase,
+                SurfaceRequestPhase::Pending | SurfaceRequestPhase::Cancelled
+            ) {
+                let cleanup = lock_or_recover(&entry.unpublished_cleanup).take();
                 if let Some(cleanup) = cleanup {
                     cleanup().await;
                 }
             }
-            let mut entries = lock_or_recover(&self.entries);
-            entries.remove(&key);
+            lock_or_recover(&self.entries).remove(&key);
         }
     }
 }
@@ -358,9 +465,11 @@ mod tests {
             }
         }));
 
-        executor.finish_unpublished("req-1").await;
-        executor.finish_unpublished("req-1").await;
+        let first = executor.finish_unpublished("req-1").await;
+        let second = executor.finish_unpublished("req-1").await;
 
+        assert_eq!(first, CompleteOutcome::Completed);
+        assert_eq!(second, CompleteOutcome::Completed);
         assert_eq!(cleanup_count.load(Ordering::SeqCst), 1);
     }
 
@@ -379,9 +488,12 @@ mod tests {
             }
         }));
 
-        executor.mark_published("req-2");
-        executor.finish_unpublished("req-2").await;
+        executor
+            .publish_and_complete("req-2")
+            .expect("publish must succeed on Pending");
+        let outcome = executor.finish_unpublished("req-2").await;
 
+        assert_eq!(outcome, CompleteOutcome::Completed);
         assert_eq!(cleanup_count.load(Ordering::SeqCst), 0);
     }
 
@@ -403,17 +515,22 @@ mod tests {
             }),
         );
 
-        context.replace_cancel_action(request_action({
-            let upgraded_count = Arc::clone(&upgraded_count);
-            move || {
+        context
+            .install_cancel_action(request_action({
                 let upgraded_count = Arc::clone(&upgraded_count);
-                async move {
-                    upgraded_count.fetch_add(1, Ordering::SeqCst);
+                move || {
+                    let upgraded_count = Arc::clone(&upgraded_count);
+                    async move {
+                        upgraded_count.fetch_add(1, Ordering::SeqCst);
+                    }
                 }
-            }
-        }));
+            }))
+            .await;
 
-        assert!(executor.cancel_request("req-3").await);
+        assert_eq!(
+            executor.cancel_request("req-3").await,
+            CancelOutcome::Cancelled
+        );
         assert_eq!(initial_count.load(Ordering::SeqCst), 0);
         assert_eq!(upgraded_count.load(Ordering::SeqCst), 1);
     }
@@ -434,11 +551,170 @@ mod tests {
         let _ctx = executor
             .try_begin_request("reuse-key", noop_request_action())
             .expect("first registration should succeed");
-        executor.finish_unpublished("reuse-key").await;
+        let _ = executor.finish_unpublished("reuse-key").await;
         let result = executor.try_begin_request("reuse-key", noop_request_action());
         assert!(
             result.is_ok(),
             "key should be available after previous request is removed"
         );
+    }
+
+    // ---- Wave 3 G defensive tests: typed terminal-phase rejection. ----
+
+    #[tokio::test]
+    async fn late_cancel_on_published_returns_already_published() {
+        let executor = SurfaceRequestExecutor::new(Duration::from_millis(1));
+        let cancel_count = Arc::new(AtomicUsize::new(0));
+        let _ctx = executor.begin_request(
+            "pub-then-cancel",
+            request_action({
+                let cancel_count = Arc::clone(&cancel_count);
+                move || {
+                    let cancel_count = Arc::clone(&cancel_count);
+                    async move {
+                        cancel_count.fetch_add(1, Ordering::SeqCst);
+                    }
+                }
+            }),
+        );
+
+        executor
+            .publish_and_complete("pub-then-cancel")
+            .expect("publish must succeed on Pending");
+
+        // Entry was removed by publish_and_complete — NotFound is the typed
+        // signal for "no tracked request with this key" (consistent with the
+        // post-terminal semantics).
+        let outcome = executor.cancel_request("pub-then-cancel").await;
+        assert_eq!(outcome, CancelOutcome::NotFound);
+        assert_eq!(
+            cancel_count.load(Ordering::SeqCst),
+            0,
+            "cancel action must not run after publish committed"
+        );
+    }
+
+    #[tokio::test]
+    async fn publish_after_cancel_rejects_with_already_terminal() {
+        let executor = SurfaceRequestExecutor::new(Duration::from_millis(1));
+        let _ctx = executor.begin_request("cancel-then-pub", noop_request_action());
+
+        assert_eq!(
+            executor.cancel_request("cancel-then-pub").await,
+            CancelOutcome::Cancelled
+        );
+
+        let err = executor
+            .publish_and_complete("cancel-then-pub")
+            .expect_err("publish on Cancelled must be rejected");
+        assert!(matches!(
+            err,
+            RequestTransitionError::AlreadyTerminal {
+                current: SurfaceRequestPhase::Cancelled
+            }
+        ));
+    }
+
+    #[tokio::test]
+    async fn finish_unpublished_after_cancel_reports_superseded() {
+        let executor = SurfaceRequestExecutor::new(Duration::from_millis(1));
+        let cleanup_count = Arc::new(AtomicUsize::new(0));
+        let context = executor.begin_request("cancel-then-finish", noop_request_action());
+        context.set_unpublished_cleanup(request_action({
+            let cleanup_count = Arc::clone(&cleanup_count);
+            move || {
+                let cleanup_count = Arc::clone(&cleanup_count);
+                async move {
+                    cleanup_count.fetch_add(1, Ordering::SeqCst);
+                }
+            }
+        }));
+
+        assert_eq!(
+            executor.cancel_request("cancel-then-finish").await,
+            CancelOutcome::Cancelled
+        );
+
+        // Task completion arriving after cancel yields the typed "superseded"
+        // outcome — no shell-side late-cancel rewriting.
+        let outcome = executor.finish_unpublished("cancel-then-finish").await;
+        assert_eq!(outcome, CompleteOutcome::SupersededByCancel);
+        assert_eq!(
+            cleanup_count.load(Ordering::SeqCst),
+            1,
+            "cleanup must still run on cancel-superseded completion"
+        );
+    }
+
+    #[tokio::test]
+    async fn double_cancel_is_idempotent() {
+        let executor = SurfaceRequestExecutor::new(Duration::from_millis(1));
+        let cancel_count = Arc::new(AtomicUsize::new(0));
+        let _ctx = executor.begin_request(
+            "double-cancel",
+            request_action({
+                let cancel_count = Arc::clone(&cancel_count);
+                move || {
+                    let cancel_count = Arc::clone(&cancel_count);
+                    async move {
+                        cancel_count.fetch_add(1, Ordering::SeqCst);
+                    }
+                }
+            }),
+        );
+
+        let first = executor.cancel_request("double-cancel").await;
+        let second = executor.cancel_request("double-cancel").await;
+        assert_eq!(first, CancelOutcome::Cancelled);
+        assert_eq!(second, CancelOutcome::AlreadyCancelled);
+        assert_eq!(
+            cancel_count.load(Ordering::SeqCst),
+            1,
+            "cancel action must run exactly once"
+        );
+    }
+
+    #[tokio::test]
+    async fn install_cancel_action_fires_when_already_cancelled() {
+        let executor = SurfaceRequestExecutor::new(Duration::from_millis(1));
+        let noop_count = Arc::new(AtomicUsize::new(0));
+        let upgraded_count = Arc::new(AtomicUsize::new(0));
+        let context = executor.begin_request(
+            "install-after-cancel",
+            request_action({
+                let noop_count = Arc::clone(&noop_count);
+                move || {
+                    let noop_count = Arc::clone(&noop_count);
+                    async move {
+                        noop_count.fetch_add(1, Ordering::SeqCst);
+                    }
+                }
+            }),
+        );
+
+        // Cancel before the "real" action was installed; initial noop runs.
+        assert_eq!(
+            executor.cancel_request("install-after-cancel").await,
+            CancelOutcome::Cancelled
+        );
+
+        // Install the session-aware action; it fires immediately because the
+        // request is already Cancelled (the init race the old code covered
+        // via replace_cancel_action + run_cancel_if_requested).
+        let phase = context
+            .install_cancel_action(request_action({
+                let upgraded_count = Arc::clone(&upgraded_count);
+                move || {
+                    let upgraded_count = Arc::clone(&upgraded_count);
+                    async move {
+                        upgraded_count.fetch_add(1, Ordering::SeqCst);
+                    }
+                }
+            }))
+            .await;
+
+        assert_eq!(phase, SurfaceRequestPhase::Cancelled);
+        assert_eq!(noop_count.load(Ordering::SeqCst), 1);
+        assert_eq!(upgraded_count.load(Ordering::SeqCst), 1);
     }
 }


### PR DESCRIPTION
## Summary

Dogma round 4, wave 3, cluster G: catalog row 13 (High) — surface-local request lifecycle authority outside machine-owned semantics.

Four surfaces (`meerkat::surface::SurfaceRequestExecutor`, REST, RPC, MCP server) each decided publish/unpublish/cancel behaviour by poking local `AtomicBool`s (`cancel_requested`, `ownership_published`) inside `RequestEntry`, plus rewriting task completions into cancel responses at the transport layer when a bool read said cancel had arrived. One semantic fact — what phase is this request in — owned four times.

This PR collapses the decision into a single typed state machine inside `SurfaceRequestExecutor` and deletes the shell-side late-cancel rewrite.

## Design

Per team lead guidance (option C, not a new DSL machine): transport-request correlation is mechanics, not semantics in the DSL sense. The canonical machine seam for this row is a typed, guarded state machine inside the executor — not a TLC-verified DSL machine.

Canonical model (`meerkat/src/surface/request_execution.rs`):

- `SurfaceRequestPhase { Pending, Published, Cancelled, Completed }` is the sole state per tracked request. Every transition is atomic under the entry lock.
- `RequestTransitionError::AlreadyTerminal { current }` plus `CancelOutcome::{Cancelled, AlreadyPublished, AlreadyCancelled, AlreadyCompleted, NotFound}` and `CompleteOutcome::{Completed, SupersededByCancel}` replace bool returns. Late publish after cancel is a typed rejection, not a silent overwrite; late cancel against a committed request yields `AlreadyPublished`/`NotFound`.
- `install_cancel_action` folds the old `replace_cancel_action` + `run_cancel_if_requested` pair into one atomic "install or run if already cancelled" operation, closing the init-race window.
- `finish_unpublished` returns `CompleteOutcome::SupersededByCancel` when cancel landed first, so RPC/MCP transport-write code decides which response to emit by matching a typed outcome — no peeking at a `cancel_requested` bool, no shell-side rewriting.

## Delete late-cancel rewriting

- `meerkat-rpc/src/server.rs:294` — long_running_rx branch no longer inspects `cancel_requested` or rewrites `RespondWithoutPublish` into a cancel response. It matches on `CompleteOutcome` from `finish_unpublished` and writes the cancel response iff the executor says cancel won. Committed `Publish` terminals always write unconditionally.
- `meerkat-mcp-server/src/main.rs:292` — same transformation.
- `examples/034-codemob-mcp/src/main.rs` mirrors the pattern.

## Rewire four surfaces

All four surfaces (facade/REST/RPC/MCP) install cancel actions via `install_cancel_action` and check the returned phase for the early-cancel bail-out, rather than the legacy replace+recheck pair. `ctx.cancel_requested()` / `ctx.run_cancel_if_requested()` / `ctx.replace_cancel_action()` / `executor.mark_published()` / `executor.remove_published()` are deleted — the retype makes the old "decide lifecycle locally" path unrepresentable at compile time.

REST `/requests/{id}/cancel` endpoint now returns `cancelled: false` + `reason: already_terminal` for published/completed requests rather than faking success.

## Defensive tests

In `request_execution.rs`:

- `publish_after_cancel_rejects_with_already_terminal` — the exact invariant the row called out: publish fired after cancel yields `RequestTransitionError::AlreadyTerminal { current: Cancelled }`.
- `finish_unpublished_after_cancel_reports_superseded` — cancel-racing-completion yields `SupersededByCancel`, not silent rewriting. Cleanup still runs.
- `late_cancel_on_published_returns_already_published` — the mirror-image rejection; committed work cannot be revoked.
- `double_cancel_is_idempotent` — cancel action fires exactly once across duplicate cancels.
- `install_cancel_action_fires_when_already_cancelled` — init-race closure: installing a session-aware action on an already-cancelled request fires the new action atomically.

## No wire / schema impact

No `meerkat-contracts` changes; no DSL changes; no SDK codegen drift. Surface protocols are unchanged.

## Test plan

- [x] `./scripts/repo-cargo fmt --all -- --check`
- [x] `./scripts/repo-cargo clippy --workspace --all-targets -- -D warnings`
- [x] `./scripts/repo-cargo unit` — 3811/3811 pass
- [x] integration-fast (explicit nextest w/ lane filters) — 4795/4795 pass
- [x] `./scripts/repo-cargo e2e-fast` — 5/5 pass
- [x] Pre-push hooks (fmt, clippy on changed crates, machine codegen+verify, W2-F bridge gate, deterministic gate) all green
- [ ] Full CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)