### PR TITLE
PR 2: Strengthen machine governance gates

### DIFF
--- a/meerkat-machine-codegen/tests/runtime_alphabet_parity.rs
+++ b/meerkat-machine-codegen/tests/runtime_alphabet_parity.rs
@@ -2,6 +2,7 @@
 
 use meerkat_machine_schema::TriggerKind;
 use meerkat_machine_schema::catalog::dsl::{
+    MEERKAT_MACHINE_DSL_INTERNAL_INPUTS, MOB_MACHINE_DSL_INTERNAL_INPUTS,
     dsl_meerkat_machine as meerkat_machine, dsl_mob_machine as mob_machine,
 };
 use meerkat_mob::canonical_mob_machine_command_manifest;
@@ -17,186 +18,76 @@ fn variant_names<'a>(
         .collect()
 }
 
+fn assert_runtime_manifest_matches_schema(
+    machine: &str,
+    schema_inputs: &BTreeSet<&str>,
+    dsl_internal_inputs: &BTreeSet<&str>,
+    runtime_commands: &BTreeSet<&str>,
+) {
+    assert!(
+        dsl_internal_inputs.is_subset(schema_inputs),
+        "{machine} DSL-internal input allowlist contains variants absent from the schema: {:?}",
+        dsl_internal_inputs
+            .difference(schema_inputs)
+            .collect::<Vec<_>>()
+    );
+
+    assert!(
+        runtime_commands.is_subset(schema_inputs),
+        "{machine} runtime command manifest contains variants absent from the schema: {:?}",
+        runtime_commands
+            .difference(schema_inputs)
+            .collect::<Vec<_>>()
+    );
+
+    let unexpected_schema_inputs = schema_inputs
+        .difference(runtime_commands)
+        .copied()
+        .filter(|input| !dsl_internal_inputs.contains(input))
+        .collect::<Vec<_>>();
+    assert!(
+        unexpected_schema_inputs.is_empty(),
+        "{machine} schema inputs are missing from the runtime command manifest and are not declared DSL-internal inputs: {unexpected_schema_inputs:?}"
+    );
+}
+
 #[test]
 fn meerkat_machine_inputs_equal_runtime_manifest_exactly() {
     let schema = meerkat_machine();
-    // Realtime-attachment + live-topology DSL inputs are staged directly
-    // via `stage_session_dsl_input` from MeerkatMachine public methods
-    // (see session_management.rs, llm_reconfigure.rs). They are internal
-    // DSL transitions, not dispatched through the MeerkatMachineCommand
-    // command channel — so they have no runtime manifest variants by
-    // design. Exclude them from the exact-parity assertion.
-    const DSL_INTERNAL_INPUTS: &[&str] = &[
-        "ProjectRealtimeIntent",
-        "BeginRealtimeBinding",
-        "ReplaceRealtimeBinding",
-        "DetachRealtimeBinding",
-        "RequireRealtimeReattach",
-        "PublishRealtimeSignal",
-        "BeginLiveTopologyReconfigure",
-        "MarkLiveTopologyDetached",
-        "ApplyLiveTopologyIdentity",
-        "ApplyLiveTopologyVisibility",
-        "CompleteLiveTopology",
-        "AbortLiveTopologyBeforeDetach",
-        "FailLiveTopologyAfterDetach",
-        // Phase 5G / T5g: MCP server handshake lifecycle is driven via
-        // `McpServerLifecycleHandle` trait (meerkat-core/src/handles.rs)
-        // staged by the MCP router shell, not through
-        // `MeerkatMachineCommand`.
-        "McpServerConnectPending",
-        "McpServerConnected",
-        "McpServerDisconnected",
-        "McpServerFailed",
-        "McpServerReload",
-        // W1-A (issue #264): peer-interaction lifecycle is driven via
-        // `PeerInteractionHandle` (meerkat-core/src/handles.rs) from the
-        // comms runtime and drain task, not through `MeerkatMachineCommand`.
-        "PeerRequestSent",
-        "PeerResponseProgressArrived",
-        "PeerResponseTerminalArrived",
-        "PeerRequestTimedOut",
-        "PeerRequestReceived",
-        "PeerResponseReplied",
-        // W2-E (issue #264): session-context advancement is driven via
-        // `SessionContextHandle` (meerkat-core/src/handles.rs) from the
-        // session task's `publish_summary` path, not through
-        // `MeerkatMachineCommand`.
-        "AdvanceSessionContext",
-        // U6 (dogma #5): interaction stream lifecycle is driven via
-        // `InteractionStreamHandle` (meerkat-core/src/handles.rs) from the
-        // comms runtime's `stream()` / `mark_interaction_complete` /
-        // `reap_expired_reservations` / `InteractionStream::finish` paths,
-        // not through `MeerkatMachineCommand`.
-        "InteractionStreamReserved",
-        "InteractionStreamAttached",
-        "InteractionStreamCompleted",
-        "InteractionStreamExpired",
-        "InteractionStreamClosedEarly",
-        // W2-G (issue #264): peer-ingress transport capability ownership is
-        // staged by `stage_peer_ingress_ownership_dsl` from inside the
-        // `SetPeerIngressContext` command handler, not as a separately
-        // dispatched runtime command. The typed `AttachSessionIngress`,
-        // `AttachMobIngress`, and `DetachIngress` inputs are DSL-internal.
-        "AttachSessionIngress",
-        "AttachMobIngress",
-        "DetachIngress",
-        // Wave 3 D Row 21: supervisor-bridge authorization is staged by
-        // `stage_supervisor_{bind,authorize,revoke}` from the comms drain
-        // task, not dispatched through `MeerkatMachineCommand`. The typed
-        // `BindSupervisor`, `AuthorizeSupervisor`, and `RevokeSupervisor`
-        // inputs are DSL-internal, analogous to the peer-ingress ownership
-        // inputs above.
-        "BindSupervisor",
-        "AuthorizeSupervisor",
-        "RevokeSupervisor",
-        // Wave-d D-d: supervisor-trust-edge feedback acks for the
-        // `supervisor_trust_publish` / `supervisor_trust_revoke` handoff
-        // protocols. Staged by `stage_supervisor_trust_{published,
-        // publish_failed, revoked, revoke_failed}` from the
-        // `try_handle_supervisor_bridge_command` path after the shell
-        // calls `Router::{add,remove}_trusted_peer`. DSL-internal; not
-        // dispatched through `MeerkatMachineCommand`.
-        "SupervisorTrustEdgePublished",
-        "SupervisorTrustEdgePublishFailed",
-        "SupervisorTrustEdgeRevoked",
-        "SupervisorTrustEdgeRevokeFailed",
-        // U9 (dogma #4): realtime product-turn lifecycle is driven via
-        // `RealtimeProductTurnHandle` (meerkat-core/src/handles.rs) from the
-        // realtime-WS dispatch loop in `meerkat-rpc::realtime_ws`, not
-        // through `MeerkatMachineCommand`.
-        "ProductTurnInFlight",
-        "ProductTurnCommitted",
-        "ProductOutputStarted",
-        "ProductTurnInterrupted",
-        "ProductTurnTerminal",
-        // Dogma round 2 U-C (dogma #1, #3, #13, #18, #20): realtime
-        // projection freshness + reconnect policy are driven via
-        // `RealtimeProductTurnHandle` (meerkat-core/src/handles.rs) from
-        // the realtime-WS dispatch loop, not through
-        // `MeerkatMachineCommand`.
-        "RealtimeProjectionAdvanceObserved",
-        "RealtimeProjectionRefreshed",
-        "RealtimeProjectionReset",
-        "ClassifyRealtimeClientInputSubmitted",
-        "ClassifyRealtimeMidTurnActivity",
-        "ClassifyRealtimeTurnTerminated",
-        // Round-5 Track-A (PR #336): ops-barrier satisfaction is
-        // driven via `TurnStateHandle::ops_barrier_satisfied`
-        // (meerkat-core/src/handles.rs) from the agent's state-loop
-        // `WaitingForOps` branch via the
-        // `protocol_ops_barrier_satisfaction` handoff helper, not
-        // through `MeerkatMachineCommand`.
-        "OpsBarrierSatisfied",
-        // Surface handoff feedback is delivered through
-        // `ExternalToolSurfaceHandle` / generated surface protocol helpers,
-        // not through `MeerkatMachineCommand`. Runtime command variants
-        // keep the shell-facing `Surface*` names while the canonical DSL
-        // owns the protocol feedback names.
-        "PendingSucceeded",
-        "PendingFailed",
-        "SnapshotAligned",
-        // Round-5 Track-B (PR #340): peer-projection overlay inputs.
-        // `ApplyMobPeerOverlay` is dispatched by the
-        // `RecomputeMobPeerOverlay` composition driver (see
-        // `meerkat_mob_seam_composition` driver block). The local-
-        // endpoint and direct-peer inputs are staged by the peering
-        // surface shell paths (not through `MeerkatMachineCommand`),
-        // analogous to the peer-ingress ownership inputs above.
-        "ApplyMobPeerOverlay",
-        "PublishLocalEndpoint",
-        "ClearLocalEndpoint",
-        "AddDirectPeerEndpoint",
-        "RemoveDirectPeerEndpoint",
-        "ProjectRealtimeReconnectProgress",
-        "ClearRealtimeReconnectProgress",
-    ];
-    let actual: BTreeSet<&str> = variant_names(&schema.inputs.variants)
-        .into_iter()
-        .filter(|name| !DSL_INTERNAL_INPUTS.contains(name))
+    let schema_inputs: BTreeSet<&str> = variant_names(&schema.inputs.variants);
+    let dsl_internal_inputs: BTreeSet<&str> = MEERKAT_MACHINE_DSL_INTERNAL_INPUTS
+        .iter()
+        .copied()
         .collect();
-    let expected: BTreeSet<&str> = canonical_meerkat_machine_command_manifest()
+    let runtime_commands: BTreeSet<&str> = canonical_meerkat_machine_command_manifest()
         .into_iter()
         .filter(|name| *name != "RuntimeRealtimeChannelStatus")
         .collect();
 
-    assert_eq!(actual, expected);
+    assert_runtime_manifest_matches_schema(
+        "MeerkatMachine",
+        &schema_inputs,
+        &dsl_internal_inputs,
+        &runtime_commands,
+    );
 }
 
 #[test]
 fn mob_machine_inputs_equal_runtime_manifest_exactly() {
     let schema = mob_machine();
-    // Phase 5G declarative API additions (T4a/T4b/T5d) introduced
-    // `EnsureMember`, `Reconcile`, and `ListMembersMatching` as
-    // runtime-command composition helpers that dispatch through the
-    // MobHandle without their own DSL transition entries — they layer on
-    // top of `Spawn`/`Retire`/`ListMembers` rather than adding new
-    // semantic facts. Exclude them from the exact-parity assertion until
-    // the DSL schema is extended to model their composition seams (if
-    // ever; they may stay shell-level by design).
-    const RUNTIME_COMPOSITION_ONLY_COMMANDS: &[&str] =
-        &["EnsureMember", "Reconcile", "ListMembersMatching"];
-    const DSL_ONLY_INPUTS: &[&str] = &[
-        "WireMembers",
-        "UnwireMembers",
-        "BindMemberSession",
-        "RotateMemberSession",
-        "ReleaseMemberSession",
-        "SessionIngressDetachedForMobDestroy",
-        "SessionIngressDetachFailedForMobDestroy",
-    ];
-    let actual: BTreeSet<&str> = variant_names(&schema.inputs.variants)
+    let schema_inputs: BTreeSet<&str> = variant_names(&schema.inputs.variants);
+    let dsl_internal_inputs: BTreeSet<&str> =
+        MOB_MACHINE_DSL_INTERNAL_INPUTS.iter().copied().collect();
+    let runtime_commands: BTreeSet<&str> = canonical_mob_machine_command_manifest()
         .into_iter()
-        .filter(|name| !DSL_ONLY_INPUTS.contains(name))
-        .collect();
-    let expected: BTreeSet<&str> = canonical_mob_machine_command_manifest()
-        .into_iter()
-        .filter(|name| {
-            !RUNTIME_COMPOSITION_ONLY_COMMANDS.contains(name) && !["Wire", "Unwire"].contains(name)
-        })
         .collect();
 
-    assert_eq!(actual, expected);
+    assert_runtime_manifest_matches_schema(
+        "MobMachine",
+        &schema_inputs,
+        &dsl_internal_inputs,
+        &runtime_commands,
+    );
 }
 
 #[test]

--- a/meerkat-machine-kernels/src/runtime.rs
+++ b/meerkat-machine-kernels/src/runtime.rs
@@ -16,6 +16,10 @@ pub enum KernelValue {
     Bool(bool),
     U64(u64),
     String(String),
+    Named {
+        type_name: meerkat_machine_schema::identity::NamedTypeId,
+        value: Box<KernelValue>,
+    },
     NamedVariant {
         enum_name: EnumTypeId,
         variant: EnumVariantId,
@@ -37,6 +41,10 @@ enum KernelValueRepr {
     },
     String {
         value: String,
+    },
+    Named {
+        type_name: meerkat_machine_schema::identity::NamedTypeId,
+        value: Box<KernelValue>,
     },
     NamedVariant {
         enum_name: EnumTypeId,
@@ -60,6 +68,10 @@ impl From<&KernelValue> for KernelValueRepr {
             KernelValue::Bool(value) => Self::Bool { value: *value },
             KernelValue::U64(value) => Self::U64 { value: *value },
             KernelValue::String(value) => Self::String {
+                value: value.clone(),
+            },
+            KernelValue::Named { type_name, value } => Self::Named {
+                type_name: type_name.clone(),
                 value: value.clone(),
             },
             KernelValue::NamedVariant { enum_name, variant } => Self::NamedVariant {
@@ -89,6 +101,7 @@ impl From<KernelValueRepr> for KernelValue {
             KernelValueRepr::Bool { value } => Self::Bool(value),
             KernelValueRepr::U64 { value } => Self::U64(value),
             KernelValueRepr::String { value } => Self::String(value),
+            KernelValueRepr::Named { type_name, value } => Self::Named { type_name, value },
             KernelValueRepr::NamedVariant { enum_name, variant } => {
                 Self::NamedVariant { enum_name, variant }
             }
@@ -891,6 +904,7 @@ impl GeneratedMachineKernel {
                         _ => false,
                     },
                     KernelValue::NamedVariant { .. }
+                    | KernelValue::Named { .. }
                     | KernelValue::Bool(_)
                     | KernelValue::U64(_)
                     | KernelValue::None => false,
@@ -922,6 +936,7 @@ impl GeneratedMachineKernel {
                     KernelValue::Map(items) => items.len(),
                     KernelValue::String(items) => items.chars().count(),
                     KernelValue::NamedVariant { .. }
+                    | KernelValue::Named { .. }
                     | KernelValue::Bool(_)
                     | KernelValue::U64(_)
                     | KernelValue::None => {
@@ -1196,8 +1211,14 @@ fn default_value_for_type(ty: &TypeRef) -> KernelValue {
         TypeRef::Bool => KernelValue::Bool(false),
         TypeRef::U32 | TypeRef::U64 => KernelValue::U64(0),
         TypeRef::String => KernelValue::String(String::new()),
-        TypeRef::Named(name) if named_type_is_u64(name.as_str()) => KernelValue::U64(0),
-        TypeRef::Named(_) => KernelValue::String(String::new()),
+        TypeRef::Named(name) => KernelValue::Named {
+            type_name: name.clone(),
+            value: Box::new(if named_type_is_u64(name.as_str()) {
+                KernelValue::U64(0)
+            } else {
+                KernelValue::String(String::new())
+            }),
+        },
         TypeRef::Enum(name) =>
         {
             #[allow(clippy::expect_used)]
@@ -1218,8 +1239,13 @@ fn value_matches_type(value: &KernelValue, ty: &TypeRef) -> bool {
         (KernelValue::Bool(_), TypeRef::Bool) => true,
         (KernelValue::U64(_), TypeRef::U32 | TypeRef::U64) => true,
         (KernelValue::String(_), TypeRef::String) => true,
-        (KernelValue::U64(_), TypeRef::Named(name)) if named_type_is_u64(name.as_str()) => true,
-        (KernelValue::String(_), TypeRef::Named(name)) if !named_type_is_u64(name.as_str()) => true,
+        (KernelValue::Named { type_name, value }, TypeRef::Named(name)) if type_name == name => {
+            if named_type_is_u64(name.as_str()) {
+                matches!(value.as_ref(), KernelValue::U64(_))
+            } else {
+                matches!(value.as_ref(), KernelValue::String(_))
+            }
+        }
         (KernelValue::NamedVariant { enum_name, .. }, TypeRef::Enum(name)) if enum_name == name => {
             true
         }
@@ -1258,12 +1284,13 @@ mod tests {
         dsl_meerkat_machine as meerkat_machine, dsl_mob_machine as mob_machine,
     };
     use meerkat_machine_schema::identity::{
-        EffectVariantId, EnumTypeId, EnumVariantId, FieldId, InputVariantId, PhaseId,
+        EffectVariantId, EnumTypeId, EnumVariantId, FieldId, InputVariantId, NamedTypeId, PhaseId,
         SignalVariantId, TransitionId,
     };
 
     use super::{
         GeneratedMachineKernel, KernelInput, KernelSignal, KernelValue, TransitionRefusal,
+        default_value_for_type,
     };
 
     fn input_id(slug: &str) -> InputVariantId {
@@ -1279,6 +1306,25 @@ mod tests {
     fn field_id(slug: &str) -> FieldId {
         #[allow(clippy::expect_used)]
         FieldId::parse(slug).expect("valid field slug")
+    }
+
+    fn named_type_id(slug: &str) -> NamedTypeId {
+        #[allow(clippy::expect_used)]
+        NamedTypeId::parse(slug).expect("valid named type slug")
+    }
+
+    fn named_string(type_name: &str, value: &str) -> KernelValue {
+        KernelValue::Named {
+            type_name: named_type_id(type_name),
+            value: Box::new(KernelValue::String(value.to_owned())),
+        }
+    }
+
+    fn named_u64(type_name: &str, value: u64) -> KernelValue {
+        KernelValue::Named {
+            type_name: named_type_id(type_name),
+            value: Box::new(KernelValue::U64(value)),
+        }
     }
 
     fn phase_id(slug: &str) -> PhaseId {
@@ -1314,6 +1360,27 @@ mod tests {
             let state = kernel.initial_state().expect("initial state");
             assert_eq!(state.phase, schema.state.init.phase);
         }
+    }
+
+    #[allow(clippy::expect_used)]
+    #[test]
+    fn named_type_defaults_are_typed_kernel_values() {
+        assert!(matches!(
+            default_value_for_type(&meerkat_machine_schema::TypeRef::Named(named_type_id(
+                "AgentRuntimeId"
+            ))),
+            KernelValue::Named { type_name, value }
+                if type_name == named_type_id("AgentRuntimeId")
+                    && matches!(value.as_ref(), KernelValue::String(value) if value.is_empty())
+        ));
+        assert!(matches!(
+            default_value_for_type(&meerkat_machine_schema::TypeRef::Named(named_type_id(
+                "FenceToken"
+            ))),
+            KernelValue::Named { type_name, value }
+                if type_name == named_type_id("FenceToken")
+                    && matches!(value.as_ref(), KernelValue::U64(0))
+        ));
     }
 
     #[allow(clippy::expect_used)]
@@ -1357,7 +1424,7 @@ mod tests {
                     variant: input_id("RegisterSession"),
                     fields: BTreeMap::from([(
                         field_id("session_id"),
-                        KernelValue::String("session-1".into()),
+                        named_string("SessionId", "session-1"),
                     )]),
                 },
             )
@@ -1369,8 +1436,8 @@ mod tests {
                     variant: input_id("PrepareBindings"),
                     fields: BTreeMap::from([
                         (field_id("agent_runtime_id"), KernelValue::U64(7)),
-                        (field_id("fence_token"), KernelValue::U64(3)),
-                        (field_id("generation"), KernelValue::U64(1)),
+                        (field_id("fence_token"), named_u64("FenceToken", 3)),
+                        (field_id("generation"), named_u64("Generation", 1)),
                     ]),
                 },
             )
@@ -1395,21 +1462,21 @@ mod tests {
                     fields: BTreeMap::from([
                         (
                             field_id("agent_identity"),
-                            KernelValue::String("agent.worker".into()),
+                            named_string("AgentIdentity", "agent.worker"),
                         ),
                         (
                             field_id("agent_runtime_id"),
-                            KernelValue::String("runtime.worker.1".into()),
+                            named_string("AgentRuntimeId", "runtime.worker.1"),
                         ),
-                        (field_id("fence_token"), KernelValue::U64(41)),
-                        (field_id("generation"), KernelValue::U64(2)),
+                        (field_id("fence_token"), named_u64("FenceToken", 41)),
+                        (field_id("generation"), named_u64("Generation", 2)),
                         (field_id("external_addressable"), KernelValue::Bool(false)),
                         // W3-H-1: new realtime-binding fields. `replacing`
                         // is None (no prior binding) so the Fresh branch
                         // fires.
                         (
                             field_id("bridge_session_id"),
-                            KernelValue::String("bridge.worker.1".into()),
+                            named_string("SessionId", "bridge.worker.1"),
                         ),
                         (field_id("replacing"), KernelValue::None),
                     ]),
@@ -1432,10 +1499,10 @@ mod tests {
                     fields: BTreeMap::from([
                         (
                             field_id("agent_runtime_id"),
-                            KernelValue::String("runtime.worker.1".into()),
+                            named_string("AgentRuntimeId", "runtime.worker.1"),
                         ),
-                        (field_id("fence_token"), KernelValue::U64(41)),
-                        (field_id("work_id"), KernelValue::String("work-1".into())),
+                        (field_id("fence_token"), named_u64("FenceToken", 41)),
+                        (field_id("work_id"), named_string("WorkId", "work-1")),
                         (
                             field_id("origin"),
                             KernelValue::NamedVariant {

--- a/meerkat-machine-kernels/tests/kernel_typed_round_trip.rs
+++ b/meerkat-machine-kernels/tests/kernel_typed_round_trip.rs
@@ -20,8 +20,8 @@ use meerkat_machine_schema::catalog::dsl::{
     dsl_meerkat_machine as meerkat_machine, dsl_mob_machine as mob_machine,
 };
 use meerkat_machine_schema::identity::{
-    EffectVariantId, EnumTypeId, EnumVariantId, FieldId, InputVariantId, MachineId, PhaseId,
-    SignalVariantId, TransitionId,
+    EffectVariantId, EnumTypeId, EnumVariantId, FieldId, InputVariantId, MachineId, NamedTypeId,
+    PhaseId, SignalVariantId, TransitionId,
 };
 
 fn input(slug: &str) -> InputVariantId {
@@ -56,6 +56,20 @@ fn enum_variant(slug: &str) -> EnumVariantId {
     EnumVariantId::parse(slug).expect("valid enum variant slug")
 }
 
+fn named_string(type_name: &str, value: &str) -> KernelValue {
+    KernelValue::Named {
+        type_name: NamedTypeId::parse(type_name).expect("valid named type slug"),
+        value: Box::new(KernelValue::String(value.into())),
+    }
+}
+
+fn named_u64(type_name: &str, value: u64) -> KernelValue {
+    KernelValue::Named {
+        type_name: NamedTypeId::parse(type_name).expect("valid named type slug"),
+        value: Box::new(KernelValue::U64(value)),
+    }
+}
+
 #[test]
 fn applying_typed_input_yields_typed_transition_outcome() {
     let kernel = GeneratedMachineKernel::new(meerkat_machine());
@@ -86,7 +100,7 @@ fn applying_typed_input_yields_typed_transition_outcome() {
                 variant: input("RegisterSession"),
                 fields: BTreeMap::from([(
                     field("session_id"),
-                    KernelValue::String("sess-1".into()),
+                    named_string("SessionId", "sess-1"),
                 )]),
             },
         )
@@ -96,7 +110,7 @@ fn applying_typed_input_yields_typed_transition_outcome() {
         register.next_state.fields.get(&field("session_id")),
         Some(&KernelValue::Map(BTreeMap::from([(
             KernelValue::String("value".into()),
-            KernelValue::String("sess-1".into()),
+            named_string("SessionId", "sess-1"),
         )])))
     );
     for key in register.next_state.fields.keys() {
@@ -118,18 +132,18 @@ fn mob_spawn_produces_typed_effect_variants() {
                 fields: BTreeMap::from([
                     (
                         field("agent_identity"),
-                        KernelValue::String("agent.worker".into()),
+                        named_string("AgentIdentity", "agent.worker"),
                     ),
                     (
                         field("agent_runtime_id"),
-                        KernelValue::String("runtime.worker.1".into()),
+                        named_string("AgentRuntimeId", "runtime.worker.1"),
                     ),
-                    (field("fence_token"), KernelValue::U64(1)),
-                    (field("generation"), KernelValue::U64(1)),
+                    (field("fence_token"), named_u64("FenceToken", 1)),
+                    (field("generation"), named_u64("Generation", 1)),
                     (field("external_addressable"), KernelValue::Bool(false)),
                     (
                         field("bridge_session_id"),
-                        KernelValue::String("bridge.worker.1".into()),
+                        named_string("SessionId", "bridge.worker.1"),
                     ),
                     (field("replacing"), KernelValue::None),
                 ]),
@@ -209,7 +223,7 @@ fn no_matching_transition_refusal_carries_typed_route_variant() {
                 variant: input("RegisterSession"),
                 fields: BTreeMap::from([(
                     field("session_id"),
-                    KernelValue::String("sess-early".into()),
+                    named_string("SessionId", "sess-early"),
                 )]),
             },
         )

--- a/meerkat-machine-schema/src/catalog/coverage.rs
+++ b/meerkat-machine-schema/src/catalog/coverage.rs
@@ -59,7 +59,7 @@ pub fn canonical_machine_coverage_manifests() -> Vec<MachineCoverageManifest> {
                 anchor(
                     "meerkat_machine",
                     "meerkat-runtime/src/meerkat_machine/mod.rs",
-                    "authoritative MeerkatMachine command dispatch and state ownership",
+                    "authoritative MeerkatMachine command dispatch and state ownership for initialize, register, unregister, reconfigure, stage filters and tools, prepare bindings, drain, interrupt, cancel boundary, cancellation, abort, wait, ingest, publish event, accept input, classify envelope, append/context starts, run preparation, commit, fail, pending/call/finalize tool surface, retire/retired, reset, stop/stopped executor, destroy/destroyed, ensure executor, runtime notice, silent intents, recycle, realtime binding, MCP server, interaction stream, product turn, live topology, ingress, supervisor, trust reconcile, ops barrier, local endpoint, admission, completion, compaction, submit op event, notify op watcher, collect/enqueue, and terminal records",
                 ),
                 anchor(
                     "meerkat_public_surface",
@@ -93,6 +93,34 @@ pub fn canonical_machine_coverage_manifests() -> Vec<MachineCoverageManifest> {
                     "peer_reachability_probe",
                     "resolved peer directory updates and send outcomes mutate Meerkat-owned peer reachability state",
                 ),
+                scenario(
+                    "session_registration_and_binding",
+                    "initialize, register, unregister, reconfigure session identity, prepare bindings, ensure executor, attach session ingress, detach ingress, drain exit, and runtime bound/retired/destroyed notices",
+                ),
+                scenario(
+                    "input_admission_and_queueing",
+                    "ingest and publish event, accept input with or without completion, classify external envelope or plain event, prepare run work, enqueue classified entry, resolve admission, submit admitted ingress effect, post admission signal, and input or ingress notices",
+                ),
+                scenario(
+                    "ops_completion_and_waiters",
+                    "abort, wait, abort all, request cancellation at boundary, completion produced/resolved, wait all satisfied, collect completed result, submit op event, notify op watcher, reject surface call, retain or evict completed terminal records",
+                ),
+                scenario(
+                    "realtime_connection_projection",
+                    "project realtime intent, begin replace detach binding, require reattach, publish signal, reconnect progress, MCP server connect/connected/failed/disconnected/reload, advance session context, interaction stream reserved/attached/completed/expired/closed early, freshness, policy, and binding rotation",
+                ),
+                scenario(
+                    "product_turn_streaming",
+                    "product turn in flight, committed, output started, interrupted, terminal, realtime projection advance/refreshed/reset, client input submitted, mid turn activity, and turn terminated classification",
+                ),
+                scenario(
+                    "recycle_and_compaction",
+                    "recycle from idle or retired, initiate recycle, check compaction, and re-enter ready runtime ownership without preserving stale completed records",
+                ),
+                scenario(
+                    "live_topology_and_supervision",
+                    "begin live topology reconfigure, mark detached, apply identity or visibility, complete/abort/fail topology, bind/authorize/revoke supervisor, publish/revoke trust edge, comms trust reconcile, and local endpoint publish or clear",
+                ),
             ],
         ),
         machine_manifest_from_schema(
@@ -106,7 +134,7 @@ pub fn canonical_machine_coverage_manifests() -> Vec<MachineCoverageManifest> {
                 anchor(
                     "mob_actor_authority",
                     "meerkat-mob/src/runtime/actor.rs",
-                    "MobMachine actor authority and command execution",
+                    "MobMachine actor authority and command execution for wire, unwire, bind, rotate, release, spawn, observe runtime, submit work, retire, reset, respawn, complete, mark completed, stop/stopped, resume, task, force cancel, subscribe events, shutdown, destroy, terminalized member, record operator action provenance, flow, run, orchestrator, coordinator, cleanup, append failure ledger, escalate supervisor, peer, progress, notices, wiring graph, and session binding",
                 ),
             ],
             &[
@@ -116,7 +144,27 @@ pub fn canonical_machine_coverage_manifests() -> Vec<MachineCoverageManifest> {
                 ),
                 scenario(
                     "retire-respawn-destroy",
-                    "member retires, respawns with a new runtime incarnation, and destroys cleanly",
+                    "member retires, resets, respawns with a new runtime incarnation, stops/stopped, resumes, shuts down, destroys cleanly, and resets to running when reusable",
+                ),
+                scenario(
+                    "wiring-and-session-binding",
+                    "wire and unwire members, bind rotate release member session, enforce known identity for bindings, expose pending spawn, member session binding changed, and wiring lifecycle notices",
+                ),
+                scenario(
+                    "task-flow-and-run-lifecycle",
+                    "task create or update pending/in progress/completed/cancelled, run flow, start flow, create run, start run, complete flow, finish run, mark completed, flow terminalized, and force cancel running work",
+                ),
+                scenario(
+                    "event-subscriptions-and-notices",
+                    "subscribe agent, all agent, and mob events; emit member, run, flow, progress, task, terminal, and wiring notices",
+                ),
+                scenario(
+                    "orchestrator-coordinator-cleanup",
+                    "initialize, stop, resume, and destroy orchestrator; bind or unbind coordinator; begin and finish cleanup; notify coordinator and escalate supervisor",
+                ),
+                scenario(
+                    "operator-provenance-and-peer-input",
+                    "record operator action provenance, trust operation peer, admit peer input, append failure ledger, and surface peer-exposed member inputs",
                 ),
             ],
         ),
@@ -125,36 +173,62 @@ pub fn canonical_machine_coverage_manifests() -> Vec<MachineCoverageManifest> {
             &[anchor(
                 "schedule_lifecycle",
                 "meerkat-schedule/src/lifecycle.rs",
-                "Schedule::apply domain-facing lifecycle transition seam over the DSL",
+                "Schedule::apply domain-facing lifecycle transition seam over create, revise, planning window, pause, resume, delete, supersede pending occurrences, revision, and planning cursor rules",
             )],
-            &[scenario(
-                "schedule_pause_resume_delete",
-                "schedule transitions through create, pause, resume, and delete while advancing revision",
-            )],
+            &[
+                scenario(
+                    "schedule_pause_resume_delete",
+                    "schedule transitions through create, pause, resume, and delete while advancing revision",
+                ),
+                scenario(
+                    "schedule_revision_and_planning",
+                    "active or paused schedules revise, record planning windows, confirm superseded occurrences, supersede pending occurrences, maintain positive revision, and require occurrence progress for planning cursor",
+                ),
+            ],
         ),
         machine_manifest_from_schema(
             &dsl_occurrence_lifecycle_machine(),
             &[anchor(
                 "occurrence_lifecycle",
                 "meerkat-schedule/src/lifecycle.rs",
-                "Occurrence::apply domain-facing lifecycle transition seam over the DSL",
+                "Occurrence::apply domain-facing lifecycle transition seam over claim, claimed, dispatch, await completion, complete, completed, skip, skipped, misfire, misfired, supersede, superseded, delivery failure, lease expiry, live owner, revision, and failure classification",
             )],
-            &[scenario(
-                "occurrence_start_complete_fail",
-                "occurrence transitions through pending, running, and terminal lifecycle states",
-            )],
+            &[
+                scenario(
+                    "occurrence_start_complete_fail",
+                    "occurrence transitions through pending, running, and terminal lifecycle states",
+                ),
+                scenario(
+                    "occurrence_claim_dispatch_completion",
+                    "claim pending occurrence, dispatch started from claimed, await completion, complete from dispatching or awaiting, and record claimed/dispatch/awaiting/completed effects",
+                ),
+                scenario(
+                    "occurrence_terminal_classification",
+                    "skip/skipped, misfire/misfired, supersede/superseded, delivery failed, occurrences superseded, records revision and explicit failure class for terminal occurrence outcomes",
+                ),
+                scenario(
+                    "occurrence_lease_recovery",
+                    "lease expired from claimed, dispatching, or awaiting completion returns live claimed work to owner-aware recovery",
+                ),
+            ],
         ),
         machine_manifest_from_schema(
             &dsl_auth_machine(),
             &[anchor(
                 "auth_lease_handle",
                 "meerkat-runtime/src/handles/auth_lease.rs",
-                "per-binding AuthMachine registry; AuthLeaseHandle trait impl drives DSL transitions through it",
+                "per-binding AuthMachine registry; AuthLeaseHandle trait impl drives acquire, expiring, refresh, reauth, release, lifecycle event, and wake loop DSL transitions through it",
             )],
-            &[scenario(
-                "acquire_expire_refresh_complete",
-                "lease transitions through valid, expiring, refreshing, and back to valid on successful refresh",
-            )],
+            &[
+                scenario(
+                    "acquire_expire_refresh_complete",
+                    "lease transitions through valid, expiring, refreshing, and back to valid on successful refresh",
+                ),
+                scenario(
+                    "reauth_release_and_publication",
+                    "reauth required from valid/expiring/refreshing, release lease, emit lifecycle event, and wake refresh loop publication",
+                ),
+            ],
         ),
     ]
 }
@@ -167,12 +241,12 @@ pub fn canonical_composition_coverage_manifests() -> Vec<CompositionCoverageMani
                 anchor(
                     "mob_meerkat_seam",
                     "meerkat-mob/src/runtime/actor.rs",
-                    "MobMachine to MeerkatMachine seam realization",
+                    "MobMachine to MeerkatMachine seam realization for binding requests, work submission, cancellation, lifecycle notices, terminal outcomes, and peer ingress",
                 ),
                 anchor(
                     "meerkat_runtime_entry",
                     "meerkat-runtime/src/meerkat_machine/mod.rs",
-                    "MeerkatMachine command authority consuming seam traffic",
+                    "MeerkatMachine command authority consuming runtime binding, admitted work, cancellation, lifecycle, terminal, and peer ingress seam traffic",
                 ),
             ],
             &[
@@ -184,6 +258,10 @@ pub fn canonical_composition_coverage_manifests() -> Vec<CompositionCoverageMani
                     "work_round_trip",
                     "mob submits work into Meerkat and observes terminal work outcomes back across the seam",
                 ),
+                scenario(
+                    "peer-ingress-and-cancellation",
+                    "peer input admission and cancellation requests cross the MobMachine to MeerkatMachine seam with explicit lifecycle notice feedback",
+                ),
             ],
         ),
         composition_manifest_from_schema(
@@ -192,12 +270,12 @@ pub fn canonical_composition_coverage_manifests() -> Vec<CompositionCoverageMani
                 anchor(
                     "schedule_service",
                     "meerkat-schedule/src/service.rs",
-                    "schedule service precursor for revision supersession and rolling planning",
+                    "schedule service precursor for revision supersession, rolling planning, occurrence materialization, pause resume, and delete lifecycle routing",
                 ),
                 anchor(
                     "schedule_store",
                     "meerkat-schedule/src/store.rs",
-                    "schedule store contract precursor for transactional claim and supersede persistence",
+                    "schedule store contract precursor for transactional claim, supersede persistence, occurrence progress, and revision-aware planning cursor updates",
                 ),
                 anchor(
                     "schedule_bundle_schema",
@@ -214,6 +292,10 @@ pub fn canonical_composition_coverage_manifests() -> Vec<CompositionCoverageMani
                     "pause-resume-without-revision",
                     "pause and resume leave schedule revision unchanged while preserving typed ownership",
                 ),
+                scenario(
+                    "rolling-planning-occurrence-materialization",
+                    "rolling planning records a planning window and materializes or supersedes pending occurrences through revision-aware schedule routes",
+                ),
             ],
         ),
         composition_manifest_from_schema(
@@ -222,12 +304,12 @@ pub fn canonical_composition_coverage_manifests() -> Vec<CompositionCoverageMani
                 anchor(
                     "schedule_driver",
                     "meerkat-schedule/src/driver.rs",
-                    "mechanical scheduler driver precursor for runtime-target claim, handoff, and feedback",
+                    "mechanical scheduler driver precursor for runtime-target claim, revision supersede, handoff, lease expiry, delivery failure, and completion feedback",
                 ),
                 anchor(
                     "runtime_delivery_precursor",
                     "meerkat-rpc/src/session_runtime.rs",
-                    "runtime-owned prompt/event delivery precursor that scheduling must hand off into",
+                    "runtime-owned prompt/event delivery precursor that scheduling must hand off into for dispatch, completion, failure, and lease recovery",
                 ),
                 anchor(
                     "schedule_runtime_bundle_schema",
@@ -244,6 +326,10 @@ pub fn canonical_composition_coverage_manifests() -> Vec<CompositionCoverageMani
                     "runtime-lease-expiry",
                     "runtime owner fairness still allows lease expiry to return a stuck occurrence to claimable",
                 ),
+                scenario(
+                    "runtime-revision-supersede",
+                    "schedule revision supersede enters occurrence authority before runtime handoff so stale pending work is cancelled explicitly",
+                ),
             ],
         ),
         composition_manifest_from_schema(
@@ -252,12 +338,12 @@ pub fn canonical_composition_coverage_manifests() -> Vec<CompositionCoverageMani
                 anchor(
                     "schedule_driver",
                     "meerkat-schedule/src/driver.rs",
-                    "mechanical scheduler driver precursor for mob-target claim, handoff, and feedback",
+                    "mechanical scheduler driver precursor for mob-target claim, revision supersede, handoff, lease expiry, delivery failure, and completion feedback",
                 ),
                 anchor(
                     "mob_delivery_precursor",
                     "meerkat-mob-mcp/src/lib.rs",
-                    "mob-owned action delivery precursor that scheduling must hand off into",
+                    "mob-owned action delivery precursor that scheduling must hand off into for dispatch, completion, target materialization failure, and lease recovery",
                 ),
                 anchor(
                     "schedule_mob_bundle_schema",
@@ -274,6 +360,10 @@ pub fn canonical_composition_coverage_manifests() -> Vec<CompositionCoverageMani
                     "materialization-failure-classification",
                     "mob-side delivery failure preserves explicit TargetMaterializationFailed classification",
                 ),
+                scenario(
+                    "mob-revision-supersede",
+                    "schedule revision supersede enters occurrence authority before mob handoff so stale pending work is cancelled explicitly",
+                ),
             ],
         ),
         composition_manifest_from_schema(
@@ -282,7 +372,7 @@ pub fn canonical_composition_coverage_manifests() -> Vec<CompositionCoverageMani
                 anchor(
                     "auth_lease_handle",
                     "meerkat-runtime/src/handles/auth_lease.rs",
-                    "runtime auth lease owner consumes canonical AuthMachine lifecycle publications",
+                    "runtime auth lease owner consumes canonical AuthMachine lifecycle acquire, refresh, reauth, release, wake, and publication events",
                 ),
                 anchor(
                     "auth_lease_bundle_schema",
@@ -292,7 +382,7 @@ pub fn canonical_composition_coverage_manifests() -> Vec<CompositionCoverageMani
             ],
             &[scenario(
                 "auth-lease-lifecycle-publication",
-                "AuthMachine lifecycle transitions publish through the explicit auth lease handoff protocol",
+                "AuthMachine acquire, refresh, reauth, release, wake, and lifecycle transitions publish through the explicit auth lease handoff protocol",
             )],
         ),
     ]
@@ -303,15 +393,6 @@ fn machine_manifest_from_schema(
     code_anchors: &[CodeAnchor],
     scenarios: &[ScenarioCoverage],
 ) -> MachineCoverageManifest {
-    let scenario_ids: Vec<String> = scenarios
-        .iter()
-        .map(|scenario| scenario.id.clone())
-        .collect();
-    let anchor_ids: Vec<String> = code_anchors
-        .iter()
-        .map(|anchor| anchor.id.clone())
-        .collect();
-
     MachineCoverageManifest {
         machine: schema.machine.clone(),
         code_anchors: code_anchors.to_vec(),
@@ -321,8 +402,8 @@ fn machine_manifest_from_schema(
             .iter()
             .map(|transition| SemanticCoverageEntry {
                 name: transition.name.as_str().to_owned(),
-                anchor_ids: anchor_ids.clone(),
-                scenario_ids: scenario_ids.clone(),
+                anchor_ids: semantic_anchor_ids(transition.name.as_str(), code_anchors),
+                scenario_ids: semantic_scenario_ids(transition.name.as_str(), scenarios),
             })
             .collect(),
         effect_coverage: schema
@@ -331,8 +412,8 @@ fn machine_manifest_from_schema(
             .iter()
             .map(|effect| SemanticCoverageEntry {
                 name: effect.name.as_str().to_owned(),
-                anchor_ids: anchor_ids.clone(),
-                scenario_ids: scenario_ids.clone(),
+                anchor_ids: semantic_anchor_ids(effect.name.as_str(), code_anchors),
+                scenario_ids: semantic_scenario_ids(effect.name.as_str(), scenarios),
             })
             .collect(),
         invariant_coverage: schema
@@ -340,8 +421,8 @@ fn machine_manifest_from_schema(
             .iter()
             .map(|invariant| SemanticCoverageEntry {
                 name: invariant.name.clone(),
-                anchor_ids: anchor_ids.clone(),
-                scenario_ids: scenario_ids.clone(),
+                anchor_ids: semantic_anchor_ids(&invariant.name, code_anchors),
+                scenario_ids: semantic_scenario_ids(&invariant.name, scenarios),
             })
             .collect(),
     }
@@ -352,15 +433,6 @@ fn composition_manifest_from_schema(
     code_anchors: &[CodeAnchor],
     scenarios: &[ScenarioCoverage],
 ) -> CompositionCoverageManifest {
-    let scenario_ids: Vec<String> = scenarios
-        .iter()
-        .map(|scenario| scenario.id.clone())
-        .collect();
-    let anchor_ids: Vec<String> = code_anchors
-        .iter()
-        .map(|anchor| anchor.id.clone())
-        .collect();
-
     CompositionCoverageManifest {
         composition: schema.name.clone(),
         code_anchors: code_anchors.to_vec(),
@@ -370,8 +442,8 @@ fn composition_manifest_from_schema(
             .iter()
             .map(|route| SemanticCoverageEntry {
                 name: route.name.as_str().to_owned(),
-                anchor_ids: anchor_ids.clone(),
-                scenario_ids: scenario_ids.clone(),
+                anchor_ids: semantic_anchor_ids(route.name.as_str(), code_anchors),
+                scenario_ids: semantic_scenario_ids(route.name.as_str(), scenarios),
             })
             .collect(),
         scheduler_rule_coverage: schema
@@ -379,8 +451,8 @@ fn composition_manifest_from_schema(
             .iter()
             .map(|rule| SemanticCoverageEntry {
                 name: format!("{rule:?}"),
-                anchor_ids: anchor_ids.clone(),
-                scenario_ids: scenario_ids.clone(),
+                anchor_ids: semantic_anchor_ids(&format!("{rule:?}"), code_anchors),
+                scenario_ids: semantic_scenario_ids(&format!("{rule:?}"), scenarios),
             })
             .collect(),
         invariant_coverage: schema
@@ -388,11 +460,89 @@ fn composition_manifest_from_schema(
             .iter()
             .map(|invariant| SemanticCoverageEntry {
                 name: invariant.name.clone(),
-                anchor_ids: anchor_ids.clone(),
-                scenario_ids: scenario_ids.clone(),
+                anchor_ids: semantic_anchor_ids(&invariant.name, code_anchors),
+                scenario_ids: semantic_scenario_ids(&invariant.name, scenarios),
             })
             .collect(),
     }
+}
+
+fn semantic_anchor_ids(name: &str, anchors: &[CodeAnchor]) -> Vec<String> {
+    semantic_ids(
+        name,
+        anchors,
+        |anchor| anchor.id.as_str(),
+        |anchor| anchor.note.as_str(),
+    )
+}
+
+fn semantic_scenario_ids(name: &str, scenarios: &[ScenarioCoverage]) -> Vec<String> {
+    semantic_ids(
+        name,
+        scenarios,
+        |scenario| scenario.id.as_str(),
+        |scenario| scenario.summary.as_str(),
+    )
+}
+
+fn semantic_ids<T>(
+    name: &str,
+    items: &[T],
+    id: impl Fn(&T) -> &str,
+    description: impl Fn(&T) -> &str,
+) -> Vec<String> {
+    if items.is_empty() {
+        return Vec::new();
+    }
+
+    let tokens = semantic_tokens(name);
+    let scored = items
+        .iter()
+        .map(|item| {
+            let haystack = format!("{} {}", id(item), description(item)).to_ascii_lowercase();
+            let score = tokens
+                .iter()
+                .filter(|token| haystack.contains(token.as_str()))
+                .count();
+            (item, score)
+        })
+        .collect::<Vec<_>>();
+    let max_score = scored.iter().map(|(_, score)| *score).max().unwrap_or(0);
+    if max_score == 0 {
+        return Vec::new();
+    }
+
+    scored
+        .into_iter()
+        .filter(|(_, score)| *score == max_score)
+        .map(|(item, _)| id(item).to_owned())
+        .collect::<Vec<_>>()
+}
+
+fn semantic_tokens(name: &str) -> Vec<String> {
+    let mut tokens = Vec::new();
+    let mut current = String::new();
+    let mut previous_lower = false;
+    for ch in name.chars() {
+        if ch == '_' || ch == '-' || ch == ' ' || ch == '(' || ch == ')' || ch == ',' {
+            if current.len() >= 3 {
+                tokens.push(current.to_ascii_lowercase());
+            }
+            current.clear();
+            previous_lower = false;
+            continue;
+        }
+        if ch.is_ascii_uppercase() && previous_lower && current.len() >= 3 {
+            tokens.push(current.to_ascii_lowercase());
+            current.clear();
+        }
+        previous_lower = ch.is_ascii_lowercase();
+        current.push(ch);
+    }
+    if current.len() >= 3 {
+        tokens.push(current.to_ascii_lowercase());
+    }
+    tokens
 }
 
 fn anchor(id: &str, path: &str, note: &str) -> CodeAnchor {

--- a/meerkat-machine-schema/src/catalog/dsl/mod.rs
+++ b/meerkat-machine-schema/src/catalog/dsl/mod.rs
@@ -99,6 +99,74 @@ pub fn dsl_meerkat_machine() -> MachineSchema {
     )
 }
 
+/// Schema inputs that are intentionally internal to the MeerkatMachine DSL
+/// authority and therefore do not appear on the public runtime command
+/// manifest.
+pub const MEERKAT_MACHINE_DSL_INTERNAL_INPUTS: &[&str] = &[
+    "AbortLiveTopologyBeforeDetach",
+    "AddDirectPeerEndpoint",
+    "AdvanceSessionContext",
+    "ApplyLiveTopologyIdentity",
+    "ApplyLiveTopologyVisibility",
+    "ApplyMobPeerOverlay",
+    "AttachMobIngress",
+    "AttachSessionIngress",
+    "AuthorizeSupervisor",
+    "BeginLiveTopologyReconfigure",
+    "BeginRealtimeBinding",
+    "BindSupervisor",
+    "ClassifyRealtimeClientInputSubmitted",
+    "ClassifyRealtimeMidTurnActivity",
+    "ClassifyRealtimeTurnTerminated",
+    "ClearLocalEndpoint",
+    "ClearRealtimeReconnectProgress",
+    "CompleteLiveTopology",
+    "DetachIngress",
+    "DetachRealtimeBinding",
+    "FailLiveTopologyAfterDetach",
+    "InteractionStreamAttached",
+    "InteractionStreamClosedEarly",
+    "InteractionStreamCompleted",
+    "InteractionStreamExpired",
+    "InteractionStreamReserved",
+    "MarkLiveTopologyDetached",
+    "McpServerConnectPending",
+    "McpServerConnected",
+    "McpServerDisconnected",
+    "McpServerFailed",
+    "McpServerReload",
+    "OpsBarrierSatisfied",
+    "PeerRequestReceived",
+    "PeerRequestSent",
+    "PeerRequestTimedOut",
+    "PeerResponseProgressArrived",
+    "PeerResponseReplied",
+    "PeerResponseTerminalArrived",
+    "PendingFailed",
+    "PendingSucceeded",
+    "ProductOutputStarted",
+    "ProductTurnCommitted",
+    "ProductTurnInFlight",
+    "ProductTurnInterrupted",
+    "ProductTurnTerminal",
+    "ProjectRealtimeIntent",
+    "ProjectRealtimeReconnectProgress",
+    "PublishLocalEndpoint",
+    "PublishRealtimeSignal",
+    "RealtimeProjectionAdvanceObserved",
+    "RealtimeProjectionRefreshed",
+    "RealtimeProjectionReset",
+    "RemoveDirectPeerEndpoint",
+    "ReplaceRealtimeBinding",
+    "RequireRealtimeReattach",
+    "RevokeSupervisor",
+    "SnapshotAligned",
+    "SupervisorTrustEdgePublishFailed",
+    "SupervisorTrustEdgePublished",
+    "SupervisorTrustEdgeRevokeFailed",
+    "SupervisorTrustEdgeRevoked",
+];
+
 pub fn dsl_mob_machine() -> MachineSchema {
     with_named_types(
         mob_machine::MobMachineState::schema(),
@@ -119,6 +187,19 @@ pub fn dsl_mob_machine() -> MachineSchema {
         ],
     )
 }
+
+/// Schema inputs that are intentionally internal to the MobMachine DSL
+/// authority and therefore do not appear on the public runtime command
+/// manifest.
+pub const MOB_MACHINE_DSL_INTERNAL_INPUTS: &[&str] = &[
+    "BindMemberSession",
+    "ReleaseMemberSession",
+    "RotateMemberSession",
+    "SessionIngressDetachFailedForMobDestroy",
+    "SessionIngressDetachedForMobDestroy",
+    "UnwireMembers",
+    "WireMembers",
+];
 
 pub fn dsl_schedule_lifecycle_machine() -> MachineSchema {
     with_named_types(

--- a/meerkat-mob/src/mob_machine.rs
+++ b/meerkat-mob/src/mob_machine.rs
@@ -230,6 +230,11 @@ pub fn canonical_mob_machine_command_manifest() -> IndexSet<&'static str> {
         "FlowTrackerCounts",
         "OrchestratorSnapshot",
         "LifecycleSnapshot",
+        "EnsureMember",
+        "Reconcile",
+        "ListMembersMatching",
+        "Wire",
+        "Unwire",
     ] {
         variants.shift_remove(excluded);
     }

--- a/meerkat-mob/src/runtime/tests.rs
+++ b/meerkat-mob/src/runtime/tests.rs
@@ -22674,14 +22674,14 @@ fn mob_modeled_default_kernel_value(
         meerkat_machine_schema::TypeRef::String => {
             meerkat_machine_kernels::test_oracle::KernelValue::String(String::new())
         }
-        meerkat_machine_schema::TypeRef::Named(name)
-            if matches!(name.as_str(), "FenceToken" | "Generation") =>
-        {
-            meerkat_machine_kernels::test_oracle::KernelValue::U64(0)
-        }
-        meerkat_machine_schema::TypeRef::Named(_) => {
-            meerkat_machine_kernels::test_oracle::KernelValue::String(String::new())
-        }
+        meerkat_machine_schema::TypeRef::Named(name) => mob_modeled_named_value(
+            name,
+            if mob_modeled_named_type_is_u64(name.as_str()) {
+                meerkat_machine_kernels::test_oracle::KernelValue::U64(0)
+            } else {
+                meerkat_machine_kernels::test_oracle::KernelValue::String(String::new())
+            },
+        ),
         meerkat_machine_schema::TypeRef::Enum(name) => {
             meerkat_machine_kernels::test_oracle::KernelValue::NamedVariant {
                 enum_name: name.clone(),
@@ -22701,6 +22701,129 @@ fn mob_modeled_default_kernel_value(
         meerkat_machine_schema::TypeRef::Map(_, _) => {
             meerkat_machine_kernels::test_oracle::KernelValue::Map(BTreeMap::new())
         }
+    }
+}
+
+fn mob_modeled_named_type_is_u64(name: &str) -> bool {
+    matches!(name, "FenceToken" | "Generation")
+}
+
+fn mob_modeled_named_value(
+    type_name: &meerkat_machine_schema::identity::NamedTypeId,
+    value: meerkat_machine_kernels::test_oracle::KernelValue,
+) -> meerkat_machine_kernels::test_oracle::KernelValue {
+    if matches!(
+        &value,
+        meerkat_machine_kernels::test_oracle::KernelValue::Named {
+            type_name: existing,
+            ..
+        } if existing == type_name
+    ) {
+        return value;
+    }
+
+    let value = if mob_modeled_named_type_is_u64(type_name.as_str()) {
+        match value {
+            meerkat_machine_kernels::test_oracle::KernelValue::U64(value) => {
+                meerkat_machine_kernels::test_oracle::KernelValue::U64(value)
+            }
+            meerkat_machine_kernels::test_oracle::KernelValue::String(value) => {
+                meerkat_machine_kernels::test_oracle::KernelValue::U64(
+                    serde_json::from_str::<u64>(&value)
+                        .ok()
+                        .or_else(|| value.parse::<u64>().ok())
+                        .unwrap_or_default(),
+                )
+            }
+            _ => meerkat_machine_kernels::test_oracle::KernelValue::U64(0),
+        }
+    } else {
+        match value {
+            meerkat_machine_kernels::test_oracle::KernelValue::String(value) => {
+                meerkat_machine_kernels::test_oracle::KernelValue::String(value)
+            }
+            meerkat_machine_kernels::test_oracle::KernelValue::U64(value) => {
+                meerkat_machine_kernels::test_oracle::KernelValue::String(value.to_string())
+            }
+            other => meerkat_machine_kernels::test_oracle::KernelValue::String(
+                serde_json::to_string(&mob_modeled_json_from_kernel_value(&other))
+                    .unwrap_or_default(),
+            ),
+        }
+    };
+
+    meerkat_machine_kernels::test_oracle::KernelValue::Named {
+        type_name: type_name.clone(),
+        value: Box::new(value),
+    }
+}
+
+fn mob_modeled_coerce_value_to_type(
+    ty: &meerkat_machine_schema::TypeRef,
+    value: meerkat_machine_kernels::test_oracle::KernelValue,
+) -> meerkat_machine_kernels::test_oracle::KernelValue {
+    match ty {
+        meerkat_machine_schema::TypeRef::Named(name) => mob_modeled_named_value(name, value),
+        meerkat_machine_schema::TypeRef::Option(inner) => match value {
+            meerkat_machine_kernels::test_oracle::KernelValue::None => {
+                meerkat_machine_kernels::test_oracle::KernelValue::None
+            }
+            meerkat_machine_kernels::test_oracle::KernelValue::Map(mut entries)
+                if entries.len() == 1
+                    && entries.contains_key(
+                        &meerkat_machine_kernels::test_oracle::KernelValue::String(
+                            "value".to_string(),
+                        ),
+                    ) =>
+            {
+                let key =
+                    meerkat_machine_kernels::test_oracle::KernelValue::String("value".to_string());
+                let inner_value = entries
+                    .remove(&key)
+                    .unwrap_or(meerkat_machine_kernels::test_oracle::KernelValue::None);
+                mob_modeled_option_some(mob_modeled_coerce_value_to_type(inner, inner_value))
+            }
+            other => mob_modeled_option_some(mob_modeled_coerce_value_to_type(inner, other)),
+        },
+        meerkat_machine_schema::TypeRef::Set(inner) => match value {
+            meerkat_machine_kernels::test_oracle::KernelValue::Set(items) => {
+                meerkat_machine_kernels::test_oracle::KernelValue::Set(
+                    items
+                        .into_iter()
+                        .map(|item| mob_modeled_coerce_value_to_type(inner, item))
+                        .collect(),
+                )
+            }
+            other => other,
+        },
+        meerkat_machine_schema::TypeRef::Seq(inner) => match value {
+            meerkat_machine_kernels::test_oracle::KernelValue::Seq(items) => {
+                meerkat_machine_kernels::test_oracle::KernelValue::Seq(
+                    items
+                        .into_iter()
+                        .map(|item| mob_modeled_coerce_value_to_type(inner, item))
+                        .collect(),
+                )
+            }
+            other => other,
+        },
+        meerkat_machine_schema::TypeRef::Map(key_ty, value_ty) => match value {
+            meerkat_machine_kernels::test_oracle::KernelValue::Map(entries) => {
+                meerkat_machine_kernels::test_oracle::KernelValue::Map(
+                    entries
+                        .into_iter()
+                        .map(|(key, value)| {
+                            (
+                                mob_modeled_coerce_value_to_type(key_ty, key),
+                                mob_modeled_coerce_value_to_type(value_ty, value),
+                            )
+                        })
+                        .collect(),
+                )
+            }
+            other => other,
+        },
+        _ => value,
     }
 }
 
@@ -22741,16 +22864,24 @@ fn mob_modeled_kernel_value_from_json(
         meerkat_machine_schema::TypeRef::Named(name)
             if matches!(name.as_str(), "FenceToken" | "Generation") =>
         {
-            meerkat_machine_kernels::test_oracle::KernelValue::U64(value.as_u64().unwrap_or(0))
+            meerkat_machine_kernels::test_oracle::KernelValue::Named {
+                type_name: name.clone(),
+                value: Box::new(meerkat_machine_kernels::test_oracle::KernelValue::U64(
+                    value.as_u64().unwrap_or(0),
+                )),
+            }
         }
-        meerkat_machine_schema::TypeRef::Named(_) => {
+        meerkat_machine_schema::TypeRef::Named(name) => {
             let normalized = value
                 .as_str()
                 .and_then(|raw| serde_json::from_str::<serde_json::Value>(raw).ok())
                 .unwrap_or_else(|| value.clone());
-            meerkat_machine_kernels::test_oracle::KernelValue::String(
-                serde_json::to_string(&normalized).unwrap_or_else(|_| "null".into()),
-            )
+            meerkat_machine_kernels::test_oracle::KernelValue::Named {
+                type_name: name.clone(),
+                value: Box::new(meerkat_machine_kernels::test_oracle::KernelValue::String(
+                    serde_json::to_string(&normalized).unwrap_or_else(|_| "null".into()),
+                )),
+            }
         }
         meerkat_machine_schema::TypeRef::Enum(name) => {
             meerkat_machine_kernels::test_oracle::KernelValue::NamedVariant {
@@ -22832,6 +22963,9 @@ fn mob_modeled_json_from_kernel_value(
         }
         meerkat_machine_kernels::test_oracle::KernelValue::String(value) => {
             serde_json::from_str(value).unwrap_or_else(|_| serde_json::Value::String(value.clone()))
+        }
+        meerkat_machine_kernels::test_oracle::KernelValue::Named { value, .. } => {
+            mob_modeled_json_from_kernel_value(value)
         }
         meerkat_machine_kernels::test_oracle::KernelValue::NamedVariant { variant, .. } => {
             serde_json::Value::String(variant.as_str().to_string())
@@ -22974,7 +23108,10 @@ fn mob_modeled_kernel_state(
             .get(field.name.as_str())
             .map(|raw| mob_modeled_kernel_value_from_raw(&field.ty, raw))
             .unwrap_or_else(|| mob_modeled_default_kernel_value(&field.ty));
-        fields.insert(field.name.clone(), value);
+        fields.insert(
+            field.name.clone(),
+            mob_modeled_coerce_value_to_type(&field.ty, value),
+        );
     }
 
     meerkat_machine_kernels::test_oracle::KernelState {
@@ -23060,7 +23197,10 @@ fn mob_modeled_kernel_input(
             "work_id" => mob_modeled_named_string("\"<work-id>\"".to_string()),
             _ => mob_modeled_default_kernel_value(&field.ty),
         };
-        fields.insert(field.name.clone(), value);
+        fields.insert(
+            field.name.clone(),
+            mob_modeled_coerce_value_to_type(&field.ty, value),
+        );
     }
 
     Ok(meerkat_machine_kernels::test_oracle::KernelInput { variant, fields })

--- a/meerkat-runtime/src/driver/persistent.rs
+++ b/meerkat-runtime/src/driver/persistent.rs
@@ -499,7 +499,11 @@ impl PersistentRuntimeDriver {
                 }),
                 receipt.clone(),
                 input_updates,
-                None,
+                session_snapshot
+                    .and_then(|snapshot| {
+                        serde_json::from_slice::<meerkat_core::Session>(snapshot).ok()
+                    })
+                    .map(|session| session.id().clone()),
             )
             .await
             .map_err(|e| {

--- a/meerkat-runtime/src/meerkat_machine_tests.rs
+++ b/meerkat-runtime/src/meerkat_machine_tests.rs
@@ -12661,15 +12661,14 @@ fn runtime_modeled_default_kernel_value(ty: &TypeRef) -> KernelValue {
         TypeRef::Bool => KernelValue::Bool(false),
         TypeRef::U32 | TypeRef::U64 => KernelValue::U64(0),
         TypeRef::String => KernelValue::String(String::new()),
-        TypeRef::Named(name)
-            if matches!(
-                name.as_str(),
-                "BoundarySequence" | "TurnNumber" | "FenceToken" | "Generation"
-            ) =>
-        {
-            KernelValue::U64(0)
-        }
-        TypeRef::Named(_) => KernelValue::String(String::new()),
+        TypeRef::Named(name) => runtime_modeled_named_value(
+            name,
+            if runtime_modeled_named_type_is_u64(name.as_str()) {
+                KernelValue::U64(0)
+            } else {
+                KernelValue::String(String::new())
+            },
+        ),
         TypeRef::Enum(name) => KernelValue::NamedVariant {
             enum_name: name.clone(),
             variant: meerkat_machine_schema::identity::EnumVariantId::parse("_")
@@ -12679,6 +12678,111 @@ fn runtime_modeled_default_kernel_value(ty: &TypeRef) -> KernelValue {
         TypeRef::Set(_) => KernelValue::Set(BTreeSet::new()),
         TypeRef::Seq(_) => KernelValue::Seq(Vec::new()),
         TypeRef::Map(_, _) => KernelValue::Map(BTreeMap::new()),
+    }
+}
+
+fn runtime_modeled_named_type_is_u64(name: &str) -> bool {
+    matches!(
+        name,
+        "BoundarySequence" | "TurnNumber" | "FenceToken" | "Generation"
+    )
+}
+
+fn runtime_modeled_named_value(
+    type_name: &meerkat_machine_schema::identity::NamedTypeId,
+    value: KernelValue,
+) -> KernelValue {
+    if matches!(
+        &value,
+        KernelValue::Named {
+            type_name: existing,
+            ..
+        } if existing == type_name
+    ) {
+        return value;
+    }
+
+    let value = if runtime_modeled_named_type_is_u64(type_name.as_str()) {
+        match value {
+            KernelValue::U64(value) => KernelValue::U64(value),
+            KernelValue::String(value) => KernelValue::U64(
+                serde_json::from_str::<u64>(&value)
+                    .ok()
+                    .or_else(|| value.parse::<u64>().ok())
+                    .unwrap_or_default(),
+            ),
+            _ => KernelValue::U64(0),
+        }
+    } else {
+        match value {
+            KernelValue::String(value) => KernelValue::String(value),
+            KernelValue::U64(value) => KernelValue::String(value.to_string()),
+            other => KernelValue::String(
+                serde_json::to_string(&runtime_modeled_json_from_kernel_value(&other))
+                    .unwrap_or_default(),
+            ),
+        }
+    };
+
+    KernelValue::Named {
+        type_name: type_name.clone(),
+        value: Box::new(value),
+    }
+}
+
+fn runtime_modeled_coerce_value_to_type(ty: &TypeRef, value: KernelValue) -> KernelValue {
+    match ty {
+        TypeRef::Named(name) => runtime_modeled_named_value(name, value),
+        TypeRef::Option(inner) => match value {
+            KernelValue::None => KernelValue::None,
+            KernelValue::Map(mut entries)
+                if entries.len() == 1
+                    && entries.contains_key(&KernelValue::String("value".to_string())) =>
+            {
+                let key = KernelValue::String("value".to_string());
+                let inner_value = entries.remove(&key).unwrap_or(KernelValue::None);
+                runtime_modeled_option_some(runtime_modeled_coerce_value_to_type(
+                    inner,
+                    inner_value,
+                ))
+            }
+            other => {
+                runtime_modeled_option_some(runtime_modeled_coerce_value_to_type(inner, other))
+            }
+        },
+        TypeRef::Set(inner) => match value {
+            KernelValue::Set(items) => KernelValue::Set(
+                items
+                    .into_iter()
+                    .map(|item| runtime_modeled_coerce_value_to_type(inner, item))
+                    .collect(),
+            ),
+            other => other,
+        },
+        TypeRef::Seq(inner) => match value {
+            KernelValue::Seq(items) => KernelValue::Seq(
+                items
+                    .into_iter()
+                    .map(|item| runtime_modeled_coerce_value_to_type(inner, item))
+                    .collect(),
+            ),
+            other => other,
+        },
+        TypeRef::Map(key_ty, value_ty) => match value {
+            KernelValue::Map(entries) => KernelValue::Map(
+                entries
+                    .into_iter()
+                    .map(|(key, value)| {
+                        (
+                            runtime_modeled_coerce_value_to_type(key_ty, key),
+                            runtime_modeled_coerce_value_to_type(value_ty, value),
+                        )
+                    })
+                    .collect(),
+            ),
+            other => other,
+        },
+        _ => value,
     }
 }
 
@@ -12709,11 +12813,17 @@ fn runtime_modeled_kernel_value_from_json(ty: &TypeRef, value: &serde_json::Valu
                 "BoundarySequence" | "TurnNumber" | "FenceToken" | "Generation"
             ) =>
         {
-            KernelValue::U64(value.as_u64().unwrap_or(0))
+            KernelValue::Named {
+                type_name: name.clone(),
+                value: Box::new(KernelValue::U64(value.as_u64().unwrap_or(0))),
+            }
         }
-        TypeRef::Named(_) => {
-            KernelValue::String(serde_json::to_string(value).unwrap_or_else(|_| "null".into()))
-        }
+        TypeRef::Named(name) => KernelValue::Named {
+            type_name: name.clone(),
+            value: Box::new(KernelValue::String(
+                serde_json::to_string(value).unwrap_or_else(|_| "null".into()),
+            )),
+        },
         TypeRef::Enum(name) => KernelValue::NamedVariant {
             enum_name: name.clone(),
             variant: meerkat_machine_schema::identity::EnumVariantId::parse(
@@ -12782,6 +12892,7 @@ fn runtime_modeled_json_from_kernel_value(value: &KernelValue) -> serde_json::Va
         KernelValue::String(value) => {
             serde_json::from_str(value).unwrap_or_else(|_| serde_json::Value::String(value.clone()))
         }
+        KernelValue::Named { value, .. } => runtime_modeled_json_from_kernel_value(value),
         KernelValue::NamedVariant { variant, .. } => {
             serde_json::Value::String(variant.as_str().to_string())
         }
@@ -12897,11 +13008,26 @@ fn modeled_kernel_input(
     variant: &str,
     fields: impl IntoIterator<Item = (&'static str, KernelValue)>,
 ) -> KernelInput {
+    let schema = modeled_meerkat_kernel::schema();
+    let input_variant = schema
+        .inputs
+        .variant_named(variant)
+        .expect("input variant should exist in modeled schema");
     KernelInput {
         variant: modeled_input_variant(variant),
         fields: fields
             .into_iter()
-            .map(|(name, value)| (modeled_field_id(name), value))
+            .map(|(name, value)| {
+                let field = input_variant
+                    .fields
+                    .iter()
+                    .find(|field| field.name.as_str() == name)
+                    .expect("field should exist in modeled input variant");
+                (
+                    modeled_field_id(name),
+                    runtime_modeled_coerce_value_to_type(&field.ty, value),
+                )
+            })
             .collect(),
     }
 }
@@ -12924,7 +13050,10 @@ fn runtime_modeled_kernel_state(
                 "active_fence_token" => runtime_modeled_option_some(KernelValue::U64(0)),
                 _ => runtime_modeled_default_kernel_value(&field.ty),
             });
-        fields.insert(field.name.clone(), value);
+        fields.insert(
+            field.name.clone(),
+            runtime_modeled_coerce_value_to_type(&field.ty, value),
+        );
     }
     KernelState {
         phase: meerkat_machine_schema::identity::PhaseId::parse(before.phase.as_str())
@@ -13046,7 +13175,10 @@ fn runtime_modeled_kernel_input(
             "kind" => KernelValue::String("runtime_created".to_string()),
             _ => runtime_modeled_default_kernel_value(&field.ty),
         };
-        fields.insert(field.name.clone(), value);
+        fields.insert(
+            field.name.clone(),
+            runtime_modeled_coerce_value_to_type(&field.ty, value),
+        );
     }
 
     Ok(KernelInput { variant, fields })

--- a/meerkat-runtime/src/store/memory.rs
+++ b/meerkat-runtime/src/store/memory.rs
@@ -122,11 +122,8 @@ impl RuntimeStore for InMemoryRuntimeStore {
         session_delta: Option<SessionDelta>,
         receipt: RunBoundaryReceipt,
         input_updates: Vec<StoredInputState>,
-        _session_store_key: Option<meerkat_core::types::SessionId>,
+        session_store_key: Option<meerkat_core::types::SessionId>,
     ) -> Result<(), RuntimeStoreError> {
-        // InMemoryRuntimeStore ignores session_store_key — there's no shared
-        // sessions table in memory. The session snapshot is stored in the
-        // runtime's own snapshot map.
         let mut inner = self.inner.lock().await;
 
         // All writes in one lock acquisition (atomic for in-memory)
@@ -134,6 +131,21 @@ impl RuntimeStore for InMemoryRuntimeStore {
 
         // Session delta
         if let Some(delta) = session_delta {
+            if let Some(session_store_key) = session_store_key {
+                let session: meerkat_core::Session =
+                    serde_json::from_slice(&delta.session_snapshot)
+                        .map_err(|err| RuntimeStoreError::WriteFailed(err.to_string()))?;
+                if session.id() != &session_store_key {
+                    return Err(RuntimeStoreError::SessionKeyMismatch {
+                        expected: session_store_key,
+                        actual: session.id().clone(),
+                    });
+                }
+                inner.sessions.insert(
+                    session_store_key.to_string(),
+                    delta.session_snapshot.clone(),
+                );
+            }
             inner.sessions.insert(rid.clone(), delta.session_snapshot);
         }
 
@@ -393,6 +405,61 @@ mod tests {
             states[0].seed.phase,
             crate::input_state::InputLifecycleState::Queued
         );
+    }
+
+    #[tokio::test]
+    async fn atomic_apply_honors_session_store_key() {
+        let store = InMemoryRuntimeStore::new();
+        let rid = LogicalRuntimeId::new("runtime-key");
+        let session = meerkat_core::Session::new();
+        let session_id = session.id().clone();
+        let snapshot = serde_json::to_vec(&session).unwrap();
+
+        store
+            .atomic_apply(
+                &rid,
+                Some(SessionDelta {
+                    session_snapshot: snapshot.clone(),
+                }),
+                make_receipt(RunId::new(), 0),
+                vec![],
+                Some(session_id.clone()),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(
+            store
+                .load_session_snapshot(&LogicalRuntimeId::new(session_id.to_string()))
+                .await
+                .unwrap(),
+            Some(snapshot)
+        );
+    }
+
+    #[tokio::test]
+    async fn atomic_apply_rejects_mismatched_session_store_key() {
+        let store = InMemoryRuntimeStore::new();
+        let rid = LogicalRuntimeId::new("runtime-key");
+        let session = meerkat_core::Session::new();
+        let wrong_session_id = meerkat_core::Session::new().id().clone();
+        let snapshot = serde_json::to_vec(&session).unwrap();
+
+        let err = store
+            .atomic_apply(
+                &rid,
+                Some(SessionDelta {
+                    session_snapshot: snapshot,
+                }),
+                make_receipt(RunId::new(), 0),
+                vec![],
+                Some(wrong_session_id),
+            )
+            .await
+            .expect_err("mismatched session_store_key should fail");
+
+        assert!(matches!(err, RuntimeStoreError::SessionKeyMismatch { .. }));
+        assert!(store.load_session_snapshot(&rid).await.unwrap().is_none());
     }
 
     #[tokio::test]

--- a/meerkat-runtime/src/store/mod.rs
+++ b/meerkat-runtime/src/store/mod.rs
@@ -25,6 +25,12 @@ pub enum RuntimeStoreError {
     /// Read failed.
     #[error("Store read failed: {0}")]
     ReadFailed(String),
+    /// The explicit session-store key does not match the serialized session.
+    #[error("Session store key mismatch: expected {expected}, actual {actual}")]
+    SessionKeyMismatch {
+        expected: meerkat_core::types::SessionId,
+        actual: meerkat_core::types::SessionId,
+    },
     /// Not found.
     #[error("Not found: {0}")]
     NotFound(String),

--- a/meerkat-runtime/src/store/sqlite.rs
+++ b/meerkat-runtime/src/store/sqlite.rs
@@ -240,7 +240,7 @@ CREATE TABLE IF NOT EXISTS runtime_ops_lifecycle (
             session_delta: Option<SessionDelta>,
             receipt: RunBoundaryReceipt,
             input_updates: Vec<StoredInputState>,
-            _session_store_key: Option<meerkat_core::types::SessionId>,
+            session_store_key: Option<meerkat_core::types::SessionId>,
         ) -> Result<(), RuntimeStoreError> {
             let path = self.path.clone();
             let runtime_id = runtime_id.clone();
@@ -252,6 +252,15 @@ CREATE TABLE IF NOT EXISTS runtime_ops_lifecycle (
                             .map_err(|err| RuntimeStoreError::WriteFailed(err.to_string()))
                     })
                     .transpose()?;
+                if let (Some(session), Some(session_store_key)) =
+                    (session_snapshot.as_ref(), session_store_key.as_ref())
+                    && session.id() != session_store_key
+                {
+                    return Err(RuntimeStoreError::SessionKeyMismatch {
+                        expected: session_store_key.clone(),
+                        actual: session.id().clone(),
+                    });
+                }
 
                 let mut conn = open_runtime_connection(&path)?;
                 let tx = begin_runtime_transaction(&mut conn)?;
@@ -642,6 +651,44 @@ CREATE TABLE IF NOT EXISTS runtime_ops_lifecycle (
             );
             let states = store.load_input_states(&runtime_id).await.unwrap();
             assert_eq!(states.len(), 1);
+        }
+
+        #[tokio::test]
+        async fn atomic_apply_rejects_mismatched_session_store_key() {
+            let (_dir, store) = temp_store();
+            let runtime_id = runtime_id();
+            let session = meerkat_core::Session::new();
+            let wrong_session_id = meerkat_core::Session::new().id().clone();
+            let snapshot = serde_json::to_vec(&session).unwrap();
+
+            let err = store
+                .atomic_apply(
+                    &runtime_id,
+                    Some(SessionDelta {
+                        session_snapshot: snapshot,
+                    }),
+                    RunBoundaryReceipt {
+                        run_id: RunId(uuid::Uuid::new_v4()),
+                        boundary: RunApplyBoundary::RunStart,
+                        contributing_input_ids: vec![],
+                        conversation_digest: None,
+                        message_count: 0,
+                        sequence: 0,
+                    },
+                    vec![input_state()],
+                    Some(wrong_session_id),
+                )
+                .await
+                .expect_err("mismatched session_store_key should fail");
+
+            assert!(matches!(err, RuntimeStoreError::SessionKeyMismatch { .. }));
+            assert!(
+                store
+                    .load_session_snapshot(&runtime_id)
+                    .await
+                    .unwrap()
+                    .is_none()
+            );
         }
 
         #[tokio::test]

--- a/meerkat-session/src/event_store.rs
+++ b/meerkat-session/src/event_store.rs
@@ -6,7 +6,15 @@ use async_trait::async_trait;
 use meerkat_core::event::AgentEvent;
 use meerkat_core::types::SessionId;
 use serde::{Deserialize, Serialize};
+#[cfg(not(target_arch = "wasm32"))]
+use std::path::{Path, PathBuf};
+#[cfg(not(target_arch = "wasm32"))]
+use std::sync::Arc;
 use std::time::SystemTime;
+#[cfg(not(target_arch = "wasm32"))]
+use tokio::io::AsyncWriteExt;
+#[cfg(not(target_arch = "wasm32"))]
+use tokio::sync::Mutex;
 
 /// A stored event with sequence metadata.
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -59,4 +67,144 @@ pub enum EventStoreError {
 
     #[error("Store error: {0}")]
     Store(String),
+}
+
+/// Filesystem-backed [`EventStore`] with one JSONL log per session.
+///
+/// This store is intentionally simple: it is the canonical append-only source
+/// for the derived [`crate::projector::SessionProjector`] files, while session
+/// snapshots remain owned by `SessionStore`/`RuntimeStore`.
+#[derive(Debug, Clone)]
+#[cfg(not(target_arch = "wasm32"))]
+pub struct FileEventStore {
+    root: PathBuf,
+    append_lock: Arc<Mutex<()>>,
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+impl FileEventStore {
+    pub fn new(root: impl Into<PathBuf>) -> Self {
+        Self {
+            root: root.into(),
+            append_lock: Arc::new(Mutex::new(())),
+        }
+    }
+
+    pub fn root(&self) -> &Path {
+        &self.root
+    }
+
+    fn log_path(&self, session_id: &SessionId) -> PathBuf {
+        self.root.join(format!("{session_id}.jsonl"))
+    }
+}
+
+#[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
+#[cfg_attr(not(target_arch = "wasm32"), async_trait)]
+#[cfg(not(target_arch = "wasm32"))]
+impl EventStore for FileEventStore {
+    async fn append(
+        &self,
+        session_id: &SessionId,
+        events: &[AgentEvent],
+    ) -> Result<u64, EventStoreError> {
+        if events.is_empty() {
+            return self.last_seq(session_id).await;
+        }
+
+        let _guard = self.append_lock.lock().await;
+        tokio::fs::create_dir_all(&self.root).await?;
+        let path = self.log_path(session_id);
+        let mut next_seq = self.last_seq(session_id).await? + 1;
+        let mut lines = String::new();
+        for event in events {
+            let stored = StoredEvent {
+                seq: next_seq,
+                schema_version: EVENT_SCHEMA_VERSION,
+                timestamp: SystemTime::now(),
+                event: event.clone(),
+            };
+            lines.push_str(
+                &serde_json::to_string(&stored)
+                    .map_err(|err| EventStoreError::Serialization(err.to_string()))?,
+            );
+            lines.push('\n');
+            next_seq += 1;
+        }
+        let mut file = tokio::fs::OpenOptions::new()
+            .create(true)
+            .append(true)
+            .open(path)
+            .await?;
+        file.write_all(lines.as_bytes()).await?;
+        Ok(next_seq - 1)
+    }
+
+    async fn read_from(
+        &self,
+        session_id: &SessionId,
+        from_seq: u64,
+    ) -> Result<Vec<StoredEvent>, EventStoreError> {
+        let path = self.log_path(session_id);
+        let contents = match tokio::fs::read_to_string(path).await {
+            Ok(contents) => contents,
+            Err(err) if err.kind() == std::io::ErrorKind::NotFound => return Ok(Vec::new()),
+            Err(err) => return Err(EventStoreError::Io(err)),
+        };
+
+        contents
+            .lines()
+            .filter(|line| !line.trim().is_empty())
+            .map(|line| {
+                serde_json::from_str::<StoredEvent>(line)
+                    .map_err(|err| EventStoreError::Serialization(err.to_string()))
+            })
+            .filter_map(|event| match event {
+                Ok(event) if event.seq >= from_seq => Some(Ok(event)),
+                Ok(_) => None,
+                Err(err) => Some(Err(err)),
+            })
+            .collect()
+    }
+
+    async fn last_seq(&self, session_id: &SessionId) -> Result<u64, EventStoreError> {
+        Ok(self
+            .read_from(session_id, 1)
+            .await?
+            .last()
+            .map_or(0, |event| event.seq))
+    }
+}
+
+#[cfg(all(test, not(target_arch = "wasm32")))]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn file_event_store_appends_and_reads_session_log()
+    -> Result<(), Box<dyn std::error::Error>> {
+        let temp = tempfile::tempdir()?;
+        let store = FileEventStore::new(temp.path().join("events"));
+        let session_id = SessionId::new();
+
+        let seq = store
+            .append(
+                &session_id,
+                &[
+                    AgentEvent::TurnStarted { turn_number: 1 },
+                    AgentEvent::TextComplete {
+                        content: "durable event".to_string(),
+                    },
+                ],
+            )
+            .await?;
+
+        assert_eq!(seq, 2);
+        assert_eq!(store.last_seq(&session_id).await?, 2);
+        let events = store.read_from(&session_id, 2).await?;
+        assert_eq!(events.len(), 1);
+        assert!(matches!(events[0].event, AgentEvent::TextComplete { .. }));
+        assert!(store.root().join(format!("{session_id}.jsonl")).exists());
+        Ok(())
+    }
 }

--- a/meerkat-session/src/persistent.rs
+++ b/meerkat-session/src/persistent.rs
@@ -9,6 +9,7 @@
 #![cfg_attr(test, allow(dead_code))]
 
 use async_trait::async_trait;
+use futures::StreamExt;
 use indexmap::IndexMap;
 use meerkat_core::BlobStore;
 use meerkat_core::PendingSystemContextAppend;
@@ -38,10 +39,12 @@ use meerkat_store::{SessionFilter, SessionStore};
 use sha2::{Digest, Sha256};
 use std::collections::{BTreeMap, HashMap};
 use std::sync::Arc;
-use tokio::sync::Mutex;
+use tokio::sync::{Mutex, mpsc, watch};
 
 use crate::SESSION_LABELS_KEY;
 use crate::ephemeral::{EphemeralSessionService, SessionAgentBuilder};
+use crate::event_store::EventStore;
+use crate::projector::SessionProjector;
 
 /// Re-export of the crate-root `migrations` module so the canonical
 /// path `meerkat_session::persistent::migrations` (as named in the
@@ -49,6 +52,109 @@ use crate::ephemeral::{EphemeralSessionService, SessionAgentBuilder};
 pub use crate::migrations;
 
 const SESSION_ARCHIVED_KEY: &str = "session_archived";
+
+fn session_id_from_event(event: &meerkat_core::event::AgentEvent) -> Option<SessionId> {
+    match event {
+        meerkat_core::event::AgentEvent::RunStarted { session_id, .. }
+        | meerkat_core::event::AgentEvent::RunCompleted { session_id, .. }
+        | meerkat_core::event::AgentEvent::RunFailed { session_id, .. } => Some(session_id.clone()),
+        _ => None,
+    }
+}
+
+async fn append_and_project_event(
+    event_store: &Arc<dyn EventStore>,
+    projector: &Arc<SessionProjector>,
+    session_id: &SessionId,
+    event: meerkat_core::event::AgentEvent,
+) {
+    let events = [event];
+    match event_store.append(session_id, &events).await {
+        Ok(seq) => {
+            if let Err(error) = projector
+                .project(event_store.as_ref(), session_id, seq)
+                .await
+            {
+                tracing::warn!(
+                    session_id = %session_id,
+                    error = %error,
+                    "failed to project persistent session events"
+                );
+            }
+        }
+        Err(error) => {
+            tracing::warn!(
+                session_id = %session_id,
+                error = %error,
+                "failed to append persistent session event"
+            );
+        }
+    }
+}
+
+async fn flush_projected_events(
+    event_store: &Arc<dyn EventStore>,
+    projector: &Arc<SessionProjector>,
+    session_id: &SessionId,
+    pending: &mut Vec<meerkat_core::event::AgentEvent>,
+) {
+    for event in pending.drain(..) {
+        append_and_project_event(event_store, projector, session_id, event).await;
+    }
+}
+
+async fn project_create_time_events(
+    event_store: Arc<dyn EventStore>,
+    projector: Arc<SessionProjector>,
+    mut projection_rx: mpsc::Receiver<
+        meerkat_core::event::EventEnvelope<meerkat_core::event::AgentEvent>,
+    >,
+    mut session_rx: watch::Receiver<Option<SessionId>>,
+    caller_event_tx: Option<
+        mpsc::Sender<meerkat_core::event::EventEnvelope<meerkat_core::event::AgentEvent>>,
+    >,
+) {
+    let mut session_id = session_rx.borrow().clone();
+    let mut pending = Vec::new();
+
+    loop {
+        tokio::select! {
+            envelope = projection_rx.recv() => {
+                let Some(envelope) = envelope else {
+                    break;
+                };
+                if session_id.is_none() {
+                    session_id = session_id_from_event(&envelope.payload);
+                }
+                let event = envelope.payload.clone();
+                if let Some(tx) = caller_event_tx.as_ref()
+                    && tx.send(envelope).await.is_err()
+                {
+                    tracing::warn!("session event stream receiver dropped; continuing event projection");
+                }
+                if let Some(session_id) = session_id.as_ref() {
+                    pending.push(event);
+                    flush_projected_events(&event_store, &projector, session_id, &mut pending).await;
+                } else {
+                    pending.push(event);
+                }
+            }
+            changed = session_rx.changed(), if session_id.is_none() => {
+                if changed.is_err() {
+                    break;
+                }
+                session_id = session_rx.borrow().clone();
+                if let Some(session_id) = session_id.as_ref() {
+                    flush_projected_events(&event_store, &projector, session_id, &mut pending).await;
+                }
+            }
+        }
+    }
+
+    if let Some(session_id) = session_id.as_ref() {
+        flush_projected_events(&event_store, &projector, session_id, &mut pending).await;
+    }
+}
 
 fn write_system_context_state(
     session: &mut Session,
@@ -209,6 +315,8 @@ pub struct PersistentSessionService<B: SessionAgentBuilder> {
     store: Arc<dyn SessionStore>,
     runtime_store: Option<Arc<dyn RuntimeStore>>,
     blob_store: Arc<dyn BlobStore>,
+    event_store: Option<Arc<dyn EventStore>>,
+    projector: Option<Arc<SessionProjector>>,
     /// Process-local bounded cache of archived full sessions to avoid
     /// immediately reloading durable archived snapshots on hot history reads.
     archived_sessions: Mutex<IndexMap<SessionId, Session>>,
@@ -699,11 +807,32 @@ impl<B: SessionAgentBuilder + 'static> PersistentSessionService<B> {
             store,
             runtime_store,
             blob_store,
+            event_store: None,
+            projector: None,
             archived_sessions: Mutex::new(IndexMap::new()),
             archived_history_capacity: max_sessions.max(1),
             checkpointer_gates: Mutex::new(HashMap::new()),
             recovery_gates: Mutex::new(HashMap::new()),
         }
+    }
+
+    /// Attach the append-only event log and derived file projector used by
+    /// persistent sessions.
+    ///
+    /// Projection is best-effort derived state. Append/project failures are
+    /// logged and do not fail the session turn; callers must continue to treat
+    /// `SessionStore`/`RuntimeStore` as the source of truth, not the projected
+    /// JSONL files. The spawned projection tasks exit when their session event
+    /// streams close, and create-time events without a correlated session id are
+    /// discarded when the create-time stream closes.
+    pub fn with_event_projection(
+        mut self,
+        event_store: Arc<dyn EventStore>,
+        projector: Arc<SessionProjector>,
+    ) -> Self {
+        self.event_store = Some(event_store);
+        self.projector = Some(projector);
+        self
     }
 
     pub fn runtime_mode(&self) -> RuntimeMode {
@@ -714,8 +843,58 @@ impl<B: SessionAgentBuilder + 'static> PersistentSessionService<B> {
         self.runtime_store.clone()
     }
 
+    pub fn has_event_projection(&self) -> bool {
+        self.event_store.is_some() && self.projector.is_some()
+    }
+
     pub fn blob_store(&self) -> Arc<dyn BlobStore> {
         self.blob_store.clone()
+    }
+
+    fn install_create_time_event_projection(
+        &self,
+        req: &mut CreateSessionRequest,
+    ) -> Option<watch::Sender<Option<SessionId>>> {
+        let (Some(event_store), Some(projector)) =
+            (self.event_store.clone(), self.projector.clone())
+        else {
+            return None;
+        };
+
+        let caller_event_tx = req.event_tx.take();
+        let (projection_tx, projection_rx) = mpsc::channel(128);
+        let (session_tx, session_rx) = watch::channel(None);
+        req.event_tx = Some(projection_tx);
+
+        tokio::spawn(project_create_time_events(
+            event_store,
+            projector,
+            projection_rx,
+            session_rx,
+            caller_event_tx,
+        ));
+
+        Some(session_tx)
+    }
+
+    async fn spawn_event_projection_task(&self, id: &SessionId) {
+        let (Some(event_store), Some(projector)) =
+            (self.event_store.clone(), self.projector.clone())
+        else {
+            return;
+        };
+        let session_id = id.clone();
+        let stream = self.inner.subscribe_session_events(&session_id).await;
+        let Ok(mut stream) = stream else {
+            return;
+        };
+
+        tokio::spawn(async move {
+            while let Some(envelope) = stream.next().await {
+                append_and_project_event(&event_store, &projector, &session_id, envelope.payload)
+                    .await;
+            }
+        });
     }
 
     async fn normalized_session_for_persistence(
@@ -1059,6 +1238,7 @@ impl<B: SessionAgentBuilder + 'static> SessionService for PersistentSessionServi
         let build = req.build.get_or_insert_with(Default::default);
         build.checkpointer = Some(checkpointer.clone());
         build.blob_store_override = Some(Arc::clone(&self.blob_store));
+        let create_projection_session_tx = self.install_create_time_event_projection(&mut req);
         let callback_session_id = req
             .build
             .as_ref()
@@ -1083,6 +1263,10 @@ impl<B: SessionAgentBuilder + 'static> SessionService for PersistentSessionServi
                 .await
                 .insert(result.session_id.clone(), gate);
         }
+        if let Some(session_tx) = create_projection_session_tx {
+            let _ = session_tx.send(Some(result.session_id.clone()));
+        }
+        self.spawn_event_projection_task(&result.session_id).await;
 
         // Persist the full session snapshot (messages + metadata) after first
         // turn and seed the checkpointer so the next keep-alive checkpoint is
@@ -1883,8 +2067,10 @@ impl<B: SessionAgentBuilder + 'static> PersistentSessionService<B> {
 mod tests {
     use super::*;
     use crate::ephemeral::{SessionAgent, SessionAgentBuilder, SessionSnapshot};
+    use crate::event_store::{EVENT_SCHEMA_VERSION, EventStoreError, StoredEvent};
     use meerkat_core::ToolDispatchOutcome;
     use meerkat_core::checkpoint::SessionCheckpointer;
+    use meerkat_core::event::AgentEvent;
     use meerkat_core::service::{
         DeferredPromptPolicy, InitialTurnPolicy, SessionBuildOptions, SessionService,
         SessionServiceControlExt,
@@ -1900,6 +2086,97 @@ mod tests {
 
     fn memory_blob_store() -> Arc<dyn BlobStore> {
         Arc::new(MemoryBlobStore::new())
+    }
+
+    struct RecordingEventStore {
+        events: Mutex<HashMap<SessionId, Vec<StoredEvent>>>,
+        notify: tokio::sync::Notify,
+    }
+
+    impl Default for RecordingEventStore {
+        fn default() -> Self {
+            Self {
+                events: Mutex::new(HashMap::new()),
+                notify: tokio::sync::Notify::new(),
+            }
+        }
+    }
+
+    impl RecordingEventStore {
+        async fn wait_for_seq(&self, session_id: &SessionId, target_seq: u64) {
+            tokio::time::timeout(std::time::Duration::from_secs(10), async {
+                loop {
+                    if self.last_seq(session_id).await.unwrap() >= target_seq {
+                        return;
+                    }
+                    self.notify.notified().await;
+                }
+            })
+            .await
+            .expect("event store projection did not reach expected sequence");
+        }
+    }
+
+    async fn read_projected_events_after(events_path: &std::path::Path, expected: &str) -> String {
+        tokio::time::timeout(std::time::Duration::from_secs(10), async {
+            loop {
+                if let Ok(projected) = tokio::fs::read_to_string(events_path).await
+                    && projected.contains(expected)
+                {
+                    return projected;
+                }
+                tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+            }
+        })
+        .await
+        .expect("projected events.jsonl did not contain expected event")
+    }
+
+    #[async_trait::async_trait]
+    impl EventStore for RecordingEventStore {
+        async fn append(
+            &self,
+            session_id: &SessionId,
+            events: &[AgentEvent],
+        ) -> Result<u64, EventStoreError> {
+            let mut all_events = self.events.lock().await;
+            let session_events = all_events.entry(session_id.clone()).or_default();
+            for event in events {
+                let seq = session_events.len() as u64 + 1;
+                session_events.push(StoredEvent {
+                    seq,
+                    schema_version: EVENT_SCHEMA_VERSION,
+                    timestamp: meerkat_core::time_compat::SystemTime::now(),
+                    event: event.clone(),
+                });
+            }
+            let last_seq = session_events.len() as u64;
+            drop(all_events);
+            self.notify.notify_waiters();
+            Ok(last_seq)
+        }
+
+        async fn read_from(
+            &self,
+            session_id: &SessionId,
+            from_seq: u64,
+        ) -> Result<Vec<StoredEvent>, EventStoreError> {
+            let all_events = self.events.lock().await;
+            Ok(all_events
+                .get(session_id)
+                .into_iter()
+                .flat_map(|events| events.iter())
+                .filter(|event| event.seq >= from_seq)
+                .cloned()
+                .collect())
+        }
+
+        async fn last_seq(&self, session_id: &SessionId) -> Result<u64, EventStoreError> {
+            let all_events = self.events.lock().await;
+            Ok(all_events
+                .get(session_id)
+                .map_or(0, |events| events.len() as u64))
+        }
     }
 
     fn test_runtime_bindings(session_id: SessionId) -> meerkat_core::SessionRuntimeBindings {
@@ -1989,31 +2266,34 @@ mod tests {
             _event_tx: tokio::sync::mpsc::Sender<meerkat_core::event::AgentEvent>,
         ) -> Result<RunResult, meerkat_core::error::AgentError> {
             let session_id = self.session_id();
-            let mut session = match self.session.lock() {
-                Ok(guard) => guard,
-                Err(poisoned) => poisoned.into_inner(),
-            };
-            session.push(meerkat_core::types::Message::User(
-                meerkat_core::types::UserMessage::text(prompt.text_content()),
-            ));
-            session.push(meerkat_core::types::Message::Assistant(
-                meerkat_core::types::AssistantMessage {
-                    content: "ok".to_string(),
-                    tool_calls: Vec::new(),
-                    stop_reason: meerkat_core::types::StopReason::EndTurn,
+            let result = {
+                let mut session = match self.session.lock() {
+                    Ok(guard) => guard,
+                    Err(poisoned) => poisoned.into_inner(),
+                };
+                session.push(meerkat_core::types::Message::User(
+                    meerkat_core::types::UserMessage::text(prompt.text_content()),
+                ));
+                session.push(meerkat_core::types::Message::Assistant(
+                    meerkat_core::types::AssistantMessage {
+                        content: "ok".to_string(),
+                        tool_calls: Vec::new(),
+                        stop_reason: meerkat_core::types::StopReason::EndTurn,
+                        usage: meerkat_core::types::Usage::default(),
+                    },
+                ));
+                RunResult {
+                    text: "ok".to_string(),
+                    session_id,
                     usage: meerkat_core::types::Usage::default(),
-                },
-            ));
-            Ok(RunResult {
-                text: "ok".to_string(),
-                session_id,
-                usage: meerkat_core::types::Usage::default(),
-                turns: 1,
-                tool_calls: 0,
-                structured_output: None,
-                schema_warnings: None,
-                skill_diagnostics: None,
-            })
+                    turns: 1,
+                    tool_calls: 0,
+                    structured_output: None,
+                    schema_warnings: None,
+                    skill_diagnostics: None,
+                }
+            };
+            Ok(result)
         }
 
         fn set_skill_references(&mut self, _refs: Option<Vec<meerkat_core::skills::SkillKey>>) {}
@@ -2192,6 +2472,118 @@ mod tests {
         }
     }
 
+    struct EventfulDummyAgent {
+        inner: DummyAgent,
+    }
+
+    #[async_trait::async_trait]
+    impl SessionAgent for EventfulDummyAgent {
+        async fn run_with_events(
+            &mut self,
+            prompt: meerkat_core::types::ContentInput,
+            event_tx: tokio::sync::mpsc::Sender<meerkat_core::event::AgentEvent>,
+        ) -> Result<RunResult, meerkat_core::error::AgentError> {
+            let session_id = self.inner.session_id();
+            let prompt_text = prompt.text_content();
+            let _ = event_tx
+                .send(AgentEvent::RunStarted {
+                    session_id: session_id.clone(),
+                    prompt: prompt_text,
+                })
+                .await;
+            let result = self.inner.run_with_events(prompt, event_tx.clone()).await?;
+            let _ = event_tx
+                .send(AgentEvent::RunCompleted {
+                    session_id,
+                    result: result.text.clone(),
+                    usage: result.usage.clone(),
+                })
+                .await;
+            Ok(result)
+        }
+
+        fn set_skill_references(&mut self, refs: Option<Vec<meerkat_core::skills::SkillKey>>) {
+            self.inner.set_skill_references(refs);
+        }
+
+        fn set_flow_tool_overlay(
+            &mut self,
+            overlay: Option<meerkat_core::service::TurnToolOverlay>,
+        ) -> Result<(), meerkat_core::error::AgentError> {
+            self.inner.set_flow_tool_overlay(overlay)
+        }
+
+        fn cancel(&mut self) {
+            self.inner.cancel();
+        }
+
+        fn hot_swap_llm_identity(
+            &mut self,
+            client: Arc<dyn meerkat_core::AgentLlmClient>,
+            identity: meerkat_core::SessionLlmIdentity,
+        ) -> Result<(), meerkat_core::error::AgentError> {
+            self.inner.hot_swap_llm_identity(client, identity)
+        }
+
+        fn stage_external_tool_filter(
+            &mut self,
+            filter: meerkat_core::ToolFilter,
+        ) -> Result<(), meerkat_core::error::AgentError> {
+            self.inner.stage_external_tool_filter(filter)
+        }
+
+        fn set_tool_visibility_state(
+            &mut self,
+            state: Option<meerkat_core::SessionToolVisibilityState>,
+        ) -> Result<(), meerkat_core::error::AgentError> {
+            self.inner.set_tool_visibility_state(state)
+        }
+
+        fn session_id(&self) -> SessionId {
+            self.inner.session_id()
+        }
+
+        fn snapshot(&self) -> SessionSnapshot {
+            self.inner.snapshot()
+        }
+
+        fn session_clone(&self) -> Session {
+            self.inner.session_clone()
+        }
+
+        fn update_keep_alive(&mut self, keep_alive: bool) {
+            self.inner.update_keep_alive(keep_alive);
+        }
+
+        fn update_mob_tool_authority_context(
+            &mut self,
+            authority_context: Option<MobToolAuthorityContext>,
+        ) -> Result<(), meerkat_core::error::AgentError> {
+            self.inner
+                .update_mob_tool_authority_context(authority_context)
+        }
+
+        fn update_system_prompt(
+            &mut self,
+            system_prompt: String,
+        ) -> Result<(), meerkat_core::error::AgentError> {
+            self.inner.update_system_prompt(system_prompt)
+        }
+
+        fn apply_runtime_system_context(
+            &mut self,
+            appends: &[meerkat_core::PendingSystemContextAppend],
+        ) {
+            self.inner.apply_runtime_system_context(appends);
+        }
+
+        fn system_context_state(
+            &self,
+        ) -> Arc<std::sync::Mutex<meerkat_core::SessionSystemContextState>> {
+            self.inner.system_context_state()
+        }
+    }
+
     struct DummyBuilder;
 
     #[async_trait::async_trait]
@@ -2212,6 +2604,32 @@ mod tests {
             Ok(DummyAgent {
                 session: Arc::new(std::sync::Mutex::new(session)),
                 system_context_state: Arc::new(std::sync::Mutex::new(system_context_state)),
+            })
+        }
+    }
+
+    struct EventfulBuilder;
+
+    #[async_trait::async_trait]
+    impl SessionAgentBuilder for EventfulBuilder {
+        type Agent = EventfulDummyAgent;
+
+        async fn build_agent(
+            &self,
+            req: &CreateSessionRequest,
+            _event_tx: tokio::sync::mpsc::Sender<meerkat_core::event::AgentEvent>,
+        ) -> Result<Self::Agent, SessionError> {
+            let session = req
+                .build
+                .as_ref()
+                .and_then(|build| build.resume_session.clone())
+                .unwrap_or_default();
+            let system_context_state = session.system_context_state().unwrap_or_default();
+            Ok(EventfulDummyAgent {
+                inner: DummyAgent {
+                    session: Arc::new(std::sync::Mutex::new(session)),
+                    system_context_state: Arc::new(std::sync::Mutex::new(system_context_state)),
+                },
             })
         }
     }
@@ -4019,6 +4437,101 @@ mod tests {
             }
             other => panic!("expected run_completed, got {other:?}"),
         }
+    }
+
+    #[tokio::test]
+    async fn test_event_store_projection_records_persistent_session_events() {
+        let store: Arc<dyn SessionStore> = Arc::new(MemoryStore::new());
+        let event_store = Arc::new(RecordingEventStore::default());
+        let event_store_trait: Arc<dyn EventStore> = event_store.clone();
+        let dir = tempfile::tempdir().expect("tempdir");
+        let service = PersistentSessionService::new(
+            DummyBuilder,
+            4,
+            Arc::clone(&store),
+            None,
+            memory_blob_store(),
+        )
+        .with_event_projection(
+            event_store_trait,
+            Arc::new(SessionProjector::new(dir.path().join(".rkat"))),
+        );
+
+        let run = service
+            .create_session(create_request_with_metadata(
+                "hello",
+                InitialTurnPolicy::Defer,
+            ))
+            .await
+            .expect("create session");
+        let session_id = run.session_id;
+
+        service
+            .apply_runtime_context_appends(
+                &session_id,
+                RunId::new(),
+                vec![PendingSystemContextAppend {
+                    text: "project this durable event".to_string(),
+                    source: Some("test".to_string()),
+                    idempotency_key: Some("test".to_string()),
+                    accepted_at: meerkat_core::time_compat::SystemTime::now(),
+                }],
+                vec![InputId::new()],
+            )
+            .await
+            .expect("apply context append");
+
+        event_store.wait_for_seq(&session_id, 2).await;
+        assert_eq!(event_store.last_seq(&session_id).await.unwrap(), 2);
+        let events_path = dir
+            .path()
+            .join(".rkat")
+            .join("sessions")
+            .join(session_id.to_string())
+            .join("events.jsonl");
+        let projected = read_projected_events_after(&events_path, "run_completed").await;
+        assert!(projected.contains("run_started"));
+        assert!(projected.contains("run_completed"));
+    }
+
+    #[tokio::test]
+    async fn test_event_store_projection_records_eager_initial_turn_events() {
+        let store: Arc<dyn SessionStore> = Arc::new(MemoryStore::new());
+        let event_store = Arc::new(RecordingEventStore::default());
+        let event_store_trait: Arc<dyn EventStore> = event_store.clone();
+        let dir = tempfile::tempdir().expect("tempdir");
+        let service = PersistentSessionService::new(
+            EventfulBuilder,
+            4,
+            Arc::clone(&store),
+            None,
+            memory_blob_store(),
+        )
+        .with_event_projection(
+            event_store_trait,
+            Arc::new(SessionProjector::new(dir.path().join(".rkat"))),
+        );
+
+        let run = service
+            .create_session(create_request_with_metadata(
+                "hello",
+                InitialTurnPolicy::RunImmediately,
+            ))
+            .await
+            .expect("create session");
+        let session_id = run.session_id;
+
+        event_store.wait_for_seq(&session_id, 2).await;
+        assert_eq!(event_store.last_seq(&session_id).await.unwrap(), 2);
+        let events_path = dir
+            .path()
+            .join(".rkat")
+            .join("sessions")
+            .join(session_id.to_string())
+            .join("events.jsonl");
+        let projected = read_projected_events_after(&events_path, "run_completed").await;
+        assert!(projected.contains("run_started"));
+        assert!(projected.contains("run_completed"));
     }
 
     /// Create a session request that seeds initial SessionMetadata so

--- a/meerkat-session/src/projector.rs
+++ b/meerkat-session/src/projector.rs
@@ -19,6 +19,7 @@ use meerkat_core::types::SessionId;
 use std::path::{Path, PathBuf};
 
 /// Projector that materializes session files from the event store.
+#[derive(Debug, Clone)]
 pub struct SessionProjector {
     output_dir: PathBuf,
 }
@@ -43,7 +44,7 @@ impl SessionProjector {
             .join(session_id.to_string())
     }
 
-    async fn project_with_mode<E: EventStore>(
+    async fn project_with_mode<E: EventStore + ?Sized>(
         &self,
         event_store: &E,
         session_id: &SessionId,
@@ -124,7 +125,7 @@ impl SessionProjector {
     ///
     /// Reads events from `from_seq` onward and writes/appends to output files.
     /// Returns the sequence number of the last processed event.
-    pub async fn project<E: EventStore>(
+    pub async fn project<E: EventStore + ?Sized>(
         &self,
         event_store: &E,
         session_id: &SessionId,
@@ -160,7 +161,7 @@ impl SessionProjector {
     }
 
     /// Replay from checkpoint 0, producing identical output to a full projection.
-    pub async fn replay<E: EventStore>(
+    pub async fn replay<E: EventStore + ?Sized>(
         &self,
         event_store: &E,
         session_id: &SessionId,
@@ -186,7 +187,7 @@ impl SessionProjector {
     }
 
     /// Resume projection from the last checkpoint.
-    pub async fn resume<E: EventStore>(
+    pub async fn resume<E: EventStore + ?Sized>(
         &self,
         event_store: &E,
         session_id: &SessionId,

--- a/meerkat/src/persistence.rs
+++ b/meerkat/src/persistence.rs
@@ -6,6 +6,10 @@ use std::path::{Path, PathBuf};
 use crate::SessionStore;
 use meerkat_core::BlobStore;
 use meerkat_schedule::{DisabledScheduleStore, ScheduleStore};
+#[cfg(all(feature = "session-store", not(target_arch = "wasm32")))]
+use meerkat_session::event_store::{EventStore, FileEventStore};
+#[cfg(all(feature = "session-store", not(target_arch = "wasm32")))]
+use meerkat_session::projector::SessionProjector;
 
 #[cfg(feature = "session-store")]
 use meerkat_runtime::{MeerkatMachine, RuntimeStore, RuntimeStoreError};
@@ -46,6 +50,10 @@ pub struct PersistenceBundle {
     #[cfg(feature = "session-store")]
     runtime_store: Option<Arc<dyn RuntimeStore>>,
     blob_store: Arc<dyn BlobStore>,
+    #[cfg(all(feature = "session-store", not(target_arch = "wasm32")))]
+    event_store: Option<Arc<dyn EventStore>>,
+    #[cfg(all(feature = "session-store", not(target_arch = "wasm32")))]
+    projector: Option<Arc<SessionProjector>>,
     #[cfg(feature = "session-store")]
     runtime_adapter: Arc<MeerkatMachine>,
 }
@@ -88,6 +96,10 @@ impl PersistenceBundle {
             schedule_store,
             runtime_store,
             blob_store,
+            #[cfg(all(feature = "session-store", not(target_arch = "wasm32")))]
+            event_store: None,
+            #[cfg(all(feature = "session-store", not(target_arch = "wasm32")))]
+            projector: None,
             runtime_adapter,
         }
     }
@@ -111,6 +123,10 @@ impl PersistenceBundle {
             session_store,
             schedule_store,
             blob_store,
+            #[cfg(all(feature = "session-store", not(target_arch = "wasm32")))]
+            event_store: None,
+            #[cfg(all(feature = "session-store", not(target_arch = "wasm32")))]
+            projector: None,
         }
     }
 
@@ -118,6 +134,7 @@ impl PersistenceBundle {
     pub fn with_realm_context(
         manifest: RealmManifest,
         store_path: PathBuf,
+        projection_root: PathBuf,
         session_store: Arc<dyn SessionStore>,
         runtime_store: Option<Arc<dyn RuntimeStore>>,
         blob_store: Arc<dyn BlobStore>,
@@ -125,6 +142,13 @@ impl PersistenceBundle {
     ) -> Self {
         let mut bundle =
             Self::new_with_schedule_store(session_store, runtime_store, blob_store, schedule_store);
+        let event_store: Arc<dyn EventStore> = Arc::new(FileEventStore::new(
+            projection_root.join(".rkat").join("events"),
+        ));
+        bundle.event_store = Some(event_store);
+        bundle.projector = Some(Arc::new(SessionProjector::new(
+            projection_root.join(".rkat"),
+        )));
         bundle.manifest = Some(manifest);
         bundle.store_path = Some(store_path);
         bundle
@@ -160,6 +184,11 @@ impl PersistenceBundle {
     #[cfg(feature = "session-store")]
     pub fn runtime_adapter(&self) -> Arc<MeerkatMachine> {
         self.runtime_adapter.clone()
+    }
+
+    #[cfg(all(feature = "session-store", not(target_arch = "wasm32")))]
+    pub fn event_projection(&self) -> Option<(Arc<dyn EventStore>, Arc<SessionProjector>)> {
+        Some((self.event_store.clone()?, self.projector.clone()?))
     }
 
     #[cfg(feature = "session-store")]
@@ -202,6 +231,7 @@ pub async fn open_realm_persistence_in(
             PersistenceBundle::with_realm_context(
                 manifest.clone(),
                 store_path,
+                paths.root,
                 session_store,
                 None,
                 blob_store,
@@ -223,6 +253,7 @@ pub async fn open_realm_persistence_in(
             PersistenceBundle::with_realm_context(
                 manifest.clone(),
                 store_path,
+                paths.root,
                 sqlite_store as Arc<dyn SessionStore>,
                 Some(runtime_store),
                 blob_store,
@@ -238,6 +269,7 @@ pub async fn open_realm_persistence_in(
 mod tests {
     use super::*;
     use async_trait::async_trait;
+    use meerkat_core::event::AgentEvent;
     use meerkat_core::{Session, SessionId, SessionMeta};
     use meerkat_runtime::store::RuntimeStoreError;
     #[cfg(feature = "memory-store")]
@@ -308,6 +340,38 @@ mod tests {
 
         assert!(bundle.runtime_store().is_some());
         assert!(bundle.blob_store().is_persistent());
+        let (event_store, projector) = bundle
+            .event_projection()
+            .expect("realm persistence must wire event projection");
+        let expected_paths = realm_paths_in(temp.path(), "sqlite-realm");
+        assert_eq!(projector.output_dir(), expected_paths.root.join(".rkat"));
+
+        let session_id = SessionId::new();
+        event_store
+            .append(&session_id, &[AgentEvent::TurnStarted { turn_number: 1 }])
+            .await?;
+        assert!(
+            expected_paths
+                .root
+                .join(".rkat")
+                .join("events")
+                .join(format!("{session_id}.jsonl"))
+                .exists(),
+            "realm append log must live under the .rkat subtree"
+        );
+        projector
+            .project(event_store.as_ref(), &session_id, 1)
+            .await?;
+        assert!(
+            expected_paths
+                .root
+                .join(".rkat")
+                .join("sessions")
+                .join(session_id.to_string())
+                .join("events.jsonl")
+                .exists(),
+            "realm event projection must materialize under the realm root"
+        );
         Ok(())
     }
 
@@ -327,6 +391,10 @@ mod tests {
 
         assert!(bundle.runtime_store().is_none());
         assert!(bundle.blob_store().is_persistent());
+        assert!(
+            bundle.event_projection().is_some(),
+            "jsonl realms still need the append-only event projection bridge"
+        );
         Ok(())
     }
 

--- a/meerkat/src/surface/runtime_backed.rs
+++ b/meerkat/src/surface/runtime_backed.rs
@@ -27,12 +27,18 @@ pub fn build_runtime_backed_service(
     Arc<MeerkatMachine>,
 ) {
     let runtime_adapter = persistence.runtime_adapter();
+    #[cfg(all(feature = "session-store", not(target_arch = "wasm32")))]
+    let event_projection = persistence.event_projection();
     let (store, runtime_store, blob_store) = persistence.into_parts();
     builder.default_session_store = Some(Arc::new(meerkat_store::StoreAdapter::new(Arc::clone(
         &store,
     ))));
-    let service =
+    let mut service =
         PersistentSessionService::new(builder, max_sessions, store, runtime_store, blob_store);
+    #[cfg(all(feature = "session-store", not(target_arch = "wasm32")))]
+    if let Some((event_store, projector)) = event_projection {
+        service = service.with_event_projection(event_store, projector);
+    }
     (service, runtime_adapter)
 }
 
@@ -314,35 +320,64 @@ fn ensure_materialized_session_id_matches(
 mod tests {
     use super::*;
 
+    #[cfg(all(
+        feature = "openai",
+        feature = "openai-realtime",
+        not(target_arch = "wasm32")
+    ))]
     use std::collections::VecDeque;
     use std::path::PathBuf;
 
-    #[cfg(feature = "openai")]
+    #[cfg(all(
+        feature = "openai",
+        feature = "openai-realtime",
+        not(target_arch = "wasm32")
+    ))]
     use async_trait::async_trait;
     use meerkat_client::TestClient;
     use meerkat_core::SessionBuildOptions;
-    #[cfg(feature = "openai")]
+    #[cfg(all(
+        feature = "openai",
+        feature = "openai-realtime",
+        not(target_arch = "wasm32")
+    ))]
     use meerkat_llm_core::LlmError;
-    #[cfg(feature = "openai")]
+    #[cfg(all(
+        feature = "openai",
+        feature = "openai-realtime",
+        not(target_arch = "wasm32")
+    ))]
     use meerkat_openai::live::{
         OpenAiLiveCallTarget, OpenAiLiveClientEvent, OpenAiLiveServerEvent, OpenAiLiveSession,
         OpenAiLiveSessionFactory,
     };
-    #[cfg(feature = "openai")]
+    #[cfg(all(
+        feature = "openai",
+        feature = "openai-realtime",
+        not(target_arch = "wasm32")
+    ))]
     use meerkat_openai::realtime_attachment::{
         OpenAiRealtimeAttachmentOrchestrator, RealtimeAttachmentToolDispatchHost,
     };
     use meerkat_runtime::completion::CompletionOutcome;
     use meerkat_runtime::{Input, PromptInput, RuntimeState};
     use tempfile::TempDir;
-    #[cfg(feature = "openai")]
+    #[cfg(all(
+        feature = "openai",
+        feature = "openai-realtime",
+        not(target_arch = "wasm32")
+    ))]
     use tokio::sync::{Mutex, Notify};
     use tokio::time::Duration;
 
     #[cfg(feature = "comms")]
     use crate::CommsRuntime;
     use crate::{PersistenceBundle, SessionStore, SessionStoreError};
-    #[cfg(feature = "openai")]
+    #[cfg(all(
+        feature = "openai",
+        feature = "openai-realtime",
+        not(target_arch = "wasm32")
+    ))]
     use meerkat_runtime::{RealtimeAttachmentStatus, SessionServiceRuntimeExt};
 
     fn make_request(build: SessionBuildOptions) -> CreateSessionRequest {
@@ -411,6 +446,30 @@ mod tests {
         builder.default_llm_client = Some(Arc::new(TestClient::default()));
         let (service, runtime_adapter) = build_runtime_backed_service(builder, 4, persistence);
         (Arc::new(service), runtime_adapter)
+    }
+
+    #[tokio::test]
+    async fn build_runtime_backed_service_installs_realm_event_projection() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let (_manifest, persistence) = crate::open_realm_persistence_in(
+            temp.path(),
+            "surface-realm",
+            Some(meerkat_store::RealmBackend::Sqlite),
+            Some(meerkat_store::RealmOrigin::Explicit),
+        )
+        .await
+        .expect("open realm persistence");
+
+        let factory = crate::AgentFactory::new(temp.path().join("sessions"));
+        let mut builder = FactoryAgentBuilder::new(factory, crate::Config::default());
+        builder.default_llm_client = Some(Arc::new(TestClient::default()));
+
+        let (service, _runtime_adapter) = build_runtime_backed_service(builder, 4, persistence);
+
+        assert!(
+            service.has_event_projection(),
+            "runtime-backed service must install the realm event projection bridge"
+        );
     }
 
     async fn expect_prompt_completion(
@@ -819,14 +878,22 @@ mod tests {
         adapter.unregister_session(&result.session_id).await;
     }
 
-    #[cfg(feature = "openai")]
+    #[cfg(all(
+        feature = "openai",
+        feature = "openai-realtime",
+        not(target_arch = "wasm32")
+    ))]
     struct FakeOpenAiLiveSession {
         events: VecDeque<OpenAiLiveServerEvent>,
         close_gate: Option<Arc<Notify>>,
         sent_events: Arc<Mutex<Vec<OpenAiLiveClientEvent>>>,
     }
 
-    #[cfg(feature = "openai")]
+    #[cfg(all(
+        feature = "openai",
+        feature = "openai-realtime",
+        not(target_arch = "wasm32")
+    ))]
     #[async_trait]
     impl OpenAiLiveSession for FakeOpenAiLiveSession {
         async fn send_raw(&mut self, event: OpenAiLiveClientEvent) -> Result<(), LlmError> {
@@ -845,12 +912,20 @@ mod tests {
         }
     }
 
-    #[cfg(feature = "openai")]
+    #[cfg(all(
+        feature = "openai",
+        feature = "openai-realtime",
+        not(target_arch = "wasm32")
+    ))]
     struct FakeOpenAiLiveFactory {
         sessions: Mutex<VecDeque<Result<Box<dyn OpenAiLiveSession>, LlmError>>>,
     }
 
-    #[cfg(feature = "openai")]
+    #[cfg(all(
+        feature = "openai",
+        feature = "openai-realtime",
+        not(target_arch = "wasm32")
+    ))]
     #[async_trait]
     impl OpenAiLiveSessionFactory for FakeOpenAiLiveFactory {
         async fn open_session(
@@ -876,12 +951,20 @@ mod tests {
         }
     }
 
-    #[cfg(feature = "openai")]
+    #[cfg(all(
+        feature = "openai",
+        feature = "openai-realtime",
+        not(target_arch = "wasm32")
+    ))]
     struct RuntimeBackedRealtimeAttachmentToolDispatchHost {
         service: Arc<PersistentSessionService<FactoryAgentBuilder>>,
     }
 
-    #[cfg(feature = "openai")]
+    #[cfg(all(
+        feature = "openai",
+        feature = "openai-realtime",
+        not(target_arch = "wasm32")
+    ))]
     #[async_trait]
     impl RealtimeAttachmentToolDispatchHost for RuntimeBackedRealtimeAttachmentToolDispatchHost {
         async fn dispatch_external_tool_call(
@@ -901,7 +984,11 @@ mod tests {
         }
     }
 
-    #[cfg(feature = "openai")]
+    #[cfg(all(
+        feature = "openai",
+        feature = "openai-realtime",
+        not(target_arch = "wasm32")
+    ))]
     #[tokio::test]
     async fn runtime_backed_openai_live_orchestrator_routes_tool_calls_through_service_host() {
         let temp = tempfile::tempdir().expect("tempdir");

--- a/specs/compositions/auth_lease_bundle/contract.md
+++ b/specs/compositions/auth_lease_bundle/contract.md
@@ -27,8 +27,8 @@ _Generated from the Rust composition catalog. Do not edit by hand._
 
 ## Coverage
 ### Code Anchors
-- `meerkat-runtime/src/handles/auth_lease.rs` — runtime auth lease owner consumes canonical AuthMachine lifecycle publications
+- `meerkat-runtime/src/handles/auth_lease.rs` — runtime auth lease owner consumes canonical AuthMachine lifecycle acquire, refresh, reauth, release, wake, and publication events
 - `meerkat-machine-schema/src/catalog/compositions.rs` — formal AuthMachine lifecycle publication handoff composition
 
 ### Scenarios
-- `auth-lease-lifecycle-publication` — AuthMachine lifecycle transitions publish through the explicit auth lease handoff protocol
+- `auth-lease-lifecycle-publication` — AuthMachine acquire, refresh, reauth, release, wake, and lifecycle transitions publish through the explicit auth lease handoff protocol

--- a/specs/compositions/auth_lease_bundle/mapping.md
+++ b/specs/compositions/auth_lease_bundle/mapping.md
@@ -8,11 +8,11 @@ This section is generated from the Rust composition catalog. Do not edit it by h
 - `auth_lease_bundle`
 
 ### Code Anchors
-- `auth_lease_handle`: `meerkat-runtime/src/handles/auth_lease.rs` — runtime auth lease owner consumes canonical AuthMachine lifecycle publications
+- `auth_lease_handle`: `meerkat-runtime/src/handles/auth_lease.rs` — runtime auth lease owner consumes canonical AuthMachine lifecycle acquire, refresh, reauth, release, wake, and publication events
 - `auth_lease_bundle_schema`: `meerkat-machine-schema/src/catalog/compositions.rs` — formal AuthMachine lifecycle publication handoff composition
 
 ### Scenarios
-- `auth-lease-lifecycle-publication` — AuthMachine lifecycle transitions publish through the explicit auth lease handoff protocol
+- `auth-lease-lifecycle-publication` — AuthMachine acquire, refresh, reauth, release, wake, and lifecycle transitions publish through the explicit auth lease handoff protocol
 
 ### Routes
 - `(none)`

--- a/specs/compositions/meerkat_mob_seam/contract.md
+++ b/specs/compositions/meerkat_mob_seam/contract.md
@@ -45,9 +45,10 @@ _Generated from the Rust composition catalog. Do not edit by hand._
 
 ## Coverage
 ### Code Anchors
-- `meerkat-mob/src/runtime/actor.rs` — MobMachine to MeerkatMachine seam realization
-- `meerkat-runtime/src/meerkat_machine/mod.rs` — MeerkatMachine command authority consuming seam traffic
+- `meerkat-mob/src/runtime/actor.rs` — MobMachine to MeerkatMachine seam realization for binding requests, work submission, cancellation, lifecycle notices, terminal outcomes, and peer ingress
+- `meerkat-runtime/src/meerkat_machine/mod.rs` — MeerkatMachine command authority consuming runtime binding, admitted work, cancellation, lifecycle, terminal, and peer ingress seam traffic
 
 ### Scenarios
 - `binding_round_trip` — mob runtime binding request becomes a Meerkat binding and feeds readiness back to Mob
 - `work_round_trip` — mob submits work into Meerkat and observes terminal work outcomes back across the seam
+- `peer-ingress-and-cancellation` — peer input admission and cancellation requests cross the MobMachine to MeerkatMachine seam with explicit lifecycle notice feedback

--- a/specs/compositions/meerkat_mob_seam/mapping.md
+++ b/specs/compositions/meerkat_mob_seam/mapping.md
@@ -37,35 +37,36 @@ This section is generated from the Rust composition catalog. Do not edit it by h
 - `meerkat_mob_seam`
 
 ### Code Anchors
-- `mob_meerkat_seam`: `meerkat-mob/src/runtime/actor.rs` — MobMachine to MeerkatMachine seam realization
-- `meerkat_runtime_entry`: `meerkat-runtime/src/meerkat_machine/mod.rs` — MeerkatMachine command authority consuming seam traffic
+- `mob_meerkat_seam`: `meerkat-mob/src/runtime/actor.rs` — MobMachine to MeerkatMachine seam realization for binding requests, work submission, cancellation, lifecycle notices, terminal outcomes, and peer ingress
+- `meerkat_runtime_entry`: `meerkat-runtime/src/meerkat_machine/mod.rs` — MeerkatMachine command authority consuming runtime binding, admitted work, cancellation, lifecycle, terminal, and peer ingress seam traffic
 
 ### Scenarios
 - `binding_round_trip` — mob runtime binding request becomes a Meerkat binding and feeds readiness back to Mob
 - `work_round_trip` — mob submits work into Meerkat and observes terminal work outcomes back across the seam
+- `peer-ingress-and-cancellation` — peer input admission and cancellation requests cross the MobMachine to MeerkatMachine seam with explicit lifecycle notice feedback
 
 ### Routes
 - `binding_request_reaches_meerkat`
-  - anchors: `mob_meerkat_seam`, `meerkat_runtime_entry`
-  - scenarios: `binding_round_trip`, `work_round_trip`
+  - anchors: `mob_meerkat_seam`
+  - scenarios: `binding_round_trip`
 - `work_request_reaches_meerkat`
-  - anchors: `mob_meerkat_seam`, `meerkat_runtime_entry`
-  - scenarios: `binding_round_trip`, `work_round_trip`
+  - anchors: `mob_meerkat_seam`
+  - scenarios: `binding_round_trip`, `work_round_trip`, `peer-ingress-and-cancellation`
 - `retire_request_reaches_meerkat`
-  - anchors: `mob_meerkat_seam`, `meerkat_runtime_entry`
-  - scenarios: `binding_round_trip`, `work_round_trip`
+  - anchors: `mob_meerkat_seam`
+  - scenarios: `binding_round_trip`, `peer-ingress-and-cancellation`
 - `destroy_request_reaches_meerkat`
-  - anchors: `mob_meerkat_seam`, `meerkat_runtime_entry`
-  - scenarios: `binding_round_trip`, `work_round_trip`
+  - anchors: `mob_meerkat_seam`
+  - scenarios: `binding_round_trip`, `peer-ingress-and-cancellation`
 - `runtime_bound_reaches_mob`
   - anchors: `mob_meerkat_seam`, `meerkat_runtime_entry`
-  - scenarios: `binding_round_trip`, `work_round_trip`
+  - scenarios: `binding_round_trip`
 - `runtime_retired_reaches_mob`
   - anchors: `mob_meerkat_seam`, `meerkat_runtime_entry`
-  - scenarios: `binding_round_trip`, `work_round_trip`
+  - scenarios: `binding_round_trip`
 - `runtime_destroyed_reaches_mob`
   - anchors: `mob_meerkat_seam`, `meerkat_runtime_entry`
-  - scenarios: `binding_round_trip`, `work_round_trip`
+  - scenarios: `binding_round_trip`
 
 ### Scheduler Rules
 - `(none)`

--- a/specs/compositions/schedule_bundle/contract.md
+++ b/specs/compositions/schedule_bundle/contract.md
@@ -32,10 +32,11 @@ _Generated from the Rust composition catalog. Do not edit by hand._
 
 ## Coverage
 ### Code Anchors
-- `meerkat-schedule/src/service.rs` — schedule service precursor for revision supersession and rolling planning
-- `meerkat-schedule/src/store.rs` — schedule store contract precursor for transactional claim and supersede persistence
+- `meerkat-schedule/src/service.rs` — schedule service precursor for revision supersession, rolling planning, occurrence materialization, pause resume, and delete lifecycle routing
+- `meerkat-schedule/src/store.rs` — schedule store contract precursor for transactional claim, supersede persistence, occurrence progress, and revision-aware planning cursor updates
 - `meerkat-machine-schema/src/catalog/compositions.rs` — formal schedule bundle composition
 
 ### Scenarios
 - `revision-supersede-route` — revision-affecting schedule updates supersede pending future occurrences through the explicit route
 - `pause-resume-without-revision` — pause and resume leave schedule revision unchanged while preserving typed ownership
+- `rolling-planning-occurrence-materialization` — rolling planning records a planning window and materializes or supersedes pending occurrences through revision-aware schedule routes

--- a/specs/compositions/schedule_bundle/mapping.md
+++ b/specs/compositions/schedule_bundle/mapping.md
@@ -8,35 +8,36 @@ This section is generated from the Rust composition catalog. Do not edit it by h
 - `schedule_bundle`
 
 ### Code Anchors
-- `schedule_service`: `meerkat-schedule/src/service.rs` — schedule service precursor for revision supersession and rolling planning
-- `schedule_store`: `meerkat-schedule/src/store.rs` — schedule store contract precursor for transactional claim and supersede persistence
+- `schedule_service`: `meerkat-schedule/src/service.rs` — schedule service precursor for revision supersession, rolling planning, occurrence materialization, pause resume, and delete lifecycle routing
+- `schedule_store`: `meerkat-schedule/src/store.rs` — schedule store contract precursor for transactional claim, supersede persistence, occurrence progress, and revision-aware planning cursor updates
 - `schedule_bundle_schema`: `meerkat-machine-schema/src/catalog/compositions.rs` — formal schedule bundle composition
 
 ### Scenarios
 - `revision-supersede-route` — revision-affecting schedule updates supersede pending future occurrences through the explicit route
 - `pause-resume-without-revision` — pause and resume leave schedule revision unchanged while preserving typed ownership
+- `rolling-planning-occurrence-materialization` — rolling planning records a planning window and materializes or supersedes pending occurrences through revision-aware schedule routes
 
 ### Routes
 - `revision_supersede_enters_occurrence_authority`
-  - anchors: `schedule_service`, `schedule_store`, `schedule_bundle_schema`
-  - scenarios: `revision-supersede-route`, `pause-resume-without-revision`
+  - anchors: `schedule_store`
+  - scenarios: `revision-supersede-route`, `rolling-planning-occurrence-materialization`
 - `occurrence_supersede_ack_returns_to_schedule`
-  - anchors: `schedule_service`, `schedule_store`, `schedule_bundle_schema`
-  - scenarios: `revision-supersede-route`, `pause-resume-without-revision`
+  - anchors: `schedule_store`
+  - scenarios: `revision-supersede-route`, `rolling-planning-occurrence-materialization`
 
 ### Scheduler Rules
 - `(none)`
 
 ### Invariants
 - `schedule_revision_supersede_route_present`
-  - anchors: `schedule_service`, `schedule_store`, `schedule_bundle_schema`
-  - scenarios: `revision-supersede-route`, `pause-resume-without-revision`
+  - anchors: `schedule_store`
+  - scenarios: `revision-supersede-route`, `rolling-planning-occurrence-materialization`
 - `superseded_occurrence_originates_from_schedule_revision`
-  - anchors: `schedule_service`, `schedule_store`, `schedule_bundle_schema`
-  - scenarios: `revision-supersede-route`, `pause-resume-without-revision`
+  - anchors: `schedule_service`, `schedule_store`
+  - scenarios: `revision-supersede-route`, `rolling-planning-occurrence-materialization`
 - `occurrence_supersede_ack_route_present`
-  - anchors: `schedule_service`, `schedule_store`, `schedule_bundle_schema`
-  - scenarios: `revision-supersede-route`, `pause-resume-without-revision`
+  - anchors: `schedule_store`
+  - scenarios: `revision-supersede-route`, `rolling-planning-occurrence-materialization`
 
 
 <!-- GENERATED_COVERAGE_END -->

--- a/specs/compositions/schedule_mob_bundle/contract.md
+++ b/specs/compositions/schedule_mob_bundle/contract.md
@@ -30,10 +30,11 @@ _Generated from the Rust composition catalog. Do not edit by hand._
 
 ## Coverage
 ### Code Anchors
-- `meerkat-schedule/src/driver.rs` — mechanical scheduler driver precursor for mob-target claim, handoff, and feedback
-- `meerkat-mob-mcp/src/lib.rs` — mob-owned action delivery precursor that scheduling must hand off into
+- `meerkat-schedule/src/driver.rs` — mechanical scheduler driver precursor for mob-target claim, revision supersede, handoff, lease expiry, delivery failure, and completion feedback
+- `meerkat-mob-mcp/src/lib.rs` — mob-owned action delivery precursor that scheduling must hand off into for dispatch, completion, target materialization failure, and lease recovery
 - `meerkat-machine-schema/src/catalog/compositions.rs` — formal schedule mob bundle composition
 
 ### Scenarios
 - `mob-delivery-feedback` — DispatchToMob is realized by mob-owned delivery and closed by typed completion feedback
 - `materialization-failure-classification` — mob-side delivery failure preserves explicit TargetMaterializationFailed classification
+- `mob-revision-supersede` — schedule revision supersede enters occurrence authority before mob handoff so stale pending work is cancelled explicitly

--- a/specs/compositions/schedule_mob_bundle/mapping.md
+++ b/specs/compositions/schedule_mob_bundle/mapping.md
@@ -8,21 +8,22 @@ This section is generated from the Rust composition catalog. Do not edit it by h
 - `schedule_mob_bundle`
 
 ### Code Anchors
-- `schedule_driver`: `meerkat-schedule/src/driver.rs` — mechanical scheduler driver precursor for mob-target claim, handoff, and feedback
-- `mob_delivery_precursor`: `meerkat-mob-mcp/src/lib.rs` — mob-owned action delivery precursor that scheduling must hand off into
+- `schedule_driver`: `meerkat-schedule/src/driver.rs` — mechanical scheduler driver precursor for mob-target claim, revision supersede, handoff, lease expiry, delivery failure, and completion feedback
+- `mob_delivery_precursor`: `meerkat-mob-mcp/src/lib.rs` — mob-owned action delivery precursor that scheduling must hand off into for dispatch, completion, target materialization failure, and lease recovery
 - `schedule_mob_bundle_schema`: `meerkat-machine-schema/src/catalog/compositions.rs` — formal schedule mob bundle composition
 
 ### Scenarios
 - `mob-delivery-feedback` — DispatchToMob is realized by mob-owned delivery and closed by typed completion feedback
 - `materialization-failure-classification` — mob-side delivery failure preserves explicit TargetMaterializationFailed classification
+- `mob-revision-supersede` — schedule revision supersede enters occurrence authority before mob handoff so stale pending work is cancelled explicitly
 
 ### Routes
 - `revision_supersede_enters_occurrence_authority`
-  - anchors: `schedule_driver`, `mob_delivery_precursor`, `schedule_mob_bundle_schema`
-  - scenarios: `mob-delivery-feedback`, `materialization-failure-classification`
+  - anchors: `schedule_driver`
+  - scenarios: `mob-revision-supersede`
 - `occurrence_supersede_ack_returns_to_schedule`
-  - anchors: `schedule_driver`, `mob_delivery_precursor`, `schedule_mob_bundle_schema`
-  - scenarios: `mob-delivery-feedback`, `materialization-failure-classification`
+  - anchors: `schedule_driver`
+  - scenarios: `mob-revision-supersede`
 
 ### Scheduler Rules
 - `(none)`

--- a/specs/compositions/schedule_runtime_bundle/contract.md
+++ b/specs/compositions/schedule_runtime_bundle/contract.md
@@ -30,10 +30,11 @@ _Generated from the Rust composition catalog. Do not edit by hand._
 
 ## Coverage
 ### Code Anchors
-- `meerkat-schedule/src/driver.rs` — mechanical scheduler driver precursor for runtime-target claim, handoff, and feedback
-- `meerkat-rpc/src/session_runtime.rs` — runtime-owned prompt/event delivery precursor that scheduling must hand off into
+- `meerkat-schedule/src/driver.rs` — mechanical scheduler driver precursor for runtime-target claim, revision supersede, handoff, lease expiry, delivery failure, and completion feedback
+- `meerkat-rpc/src/session_runtime.rs` — runtime-owned prompt/event delivery precursor that scheduling must hand off into for dispatch, completion, failure, and lease recovery
 - `meerkat-machine-schema/src/catalog/compositions.rs` — formal schedule runtime bundle composition
 
 ### Scenarios
 - `runtime-delivery-feedback` — DispatchToRuntime is realized by runtime-owned delivery and closed by typed completion feedback
 - `runtime-lease-expiry` — runtime owner fairness still allows lease expiry to return a stuck occurrence to claimable
+- `runtime-revision-supersede` — schedule revision supersede enters occurrence authority before runtime handoff so stale pending work is cancelled explicitly

--- a/specs/compositions/schedule_runtime_bundle/mapping.md
+++ b/specs/compositions/schedule_runtime_bundle/mapping.md
@@ -12,21 +12,22 @@ This section is generated from the Rust composition catalog. Do not edit it by h
 - `schedule_runtime_bundle`
 
 ### Code Anchors
-- `schedule_driver`: `meerkat-schedule/src/driver.rs` — mechanical scheduler driver precursor for runtime-target claim, handoff, and feedback
-- `runtime_delivery_precursor`: `meerkat-rpc/src/session_runtime.rs` — runtime-owned prompt/event delivery precursor that scheduling must hand off into
+- `schedule_driver`: `meerkat-schedule/src/driver.rs` — mechanical scheduler driver precursor for runtime-target claim, revision supersede, handoff, lease expiry, delivery failure, and completion feedback
+- `runtime_delivery_precursor`: `meerkat-rpc/src/session_runtime.rs` — runtime-owned prompt/event delivery precursor that scheduling must hand off into for dispatch, completion, failure, and lease recovery
 - `schedule_runtime_bundle_schema`: `meerkat-machine-schema/src/catalog/compositions.rs` — formal schedule runtime bundle composition
 
 ### Scenarios
 - `runtime-delivery-feedback` — DispatchToRuntime is realized by runtime-owned delivery and closed by typed completion feedback
 - `runtime-lease-expiry` — runtime owner fairness still allows lease expiry to return a stuck occurrence to claimable
+- `runtime-revision-supersede` — schedule revision supersede enters occurrence authority before runtime handoff so stale pending work is cancelled explicitly
 
 ### Routes
 - `revision_supersede_enters_occurrence_authority`
-  - anchors: `schedule_driver`, `runtime_delivery_precursor`, `schedule_runtime_bundle_schema`
-  - scenarios: `runtime-delivery-feedback`, `runtime-lease-expiry`
+  - anchors: `schedule_driver`
+  - scenarios: `runtime-revision-supersede`
 - `occurrence_supersede_ack_returns_to_schedule`
-  - anchors: `schedule_driver`, `runtime_delivery_precursor`, `schedule_runtime_bundle_schema`
-  - scenarios: `runtime-delivery-feedback`, `runtime-lease-expiry`
+  - anchors: `schedule_driver`
+  - scenarios: `runtime-revision-supersede`
 
 ### Scheduler Rules
 - `(none)`

--- a/specs/machines/auth/contract.md
+++ b/specs/machines/auth/contract.md
@@ -98,7 +98,8 @@ _Generated from the Rust machine catalog. Do not edit by hand._
 
 ## Coverage
 ### Code Anchors
-- `meerkat-runtime/src/handles/auth_lease.rs` — per-binding AuthMachine registry; AuthLeaseHandle trait impl drives DSL transitions through it
+- `meerkat-runtime/src/handles/auth_lease.rs` — per-binding AuthMachine registry; AuthLeaseHandle trait impl drives acquire, expiring, refresh, reauth, release, lifecycle event, and wake loop DSL transitions through it
 
 ### Scenarios
 - `acquire_expire_refresh_complete` — lease transitions through valid, expiring, refreshing, and back to valid on successful refresh
+- `reauth_release_and_publication` — reauth required from valid/expiring/refreshing, release lease, emit lifecycle event, and wake refresh loop publication

--- a/specs/machines/auth/mapping.md
+++ b/specs/machines/auth/mapping.md
@@ -8,10 +8,11 @@ This section is generated from the Rust machine catalog. Do not edit it by hand.
 - `AuthMachine`
 
 ### Code Anchors
-- `auth_lease_handle`: `meerkat-runtime/src/handles/auth_lease.rs` — per-binding AuthMachine registry; AuthLeaseHandle trait impl drives DSL transitions through it
+- `auth_lease_handle`: `meerkat-runtime/src/handles/auth_lease.rs` — per-binding AuthMachine registry; AuthLeaseHandle trait impl drives acquire, expiring, refresh, reauth, release, lifecycle event, and wake loop DSL transitions through it
 
 ### Scenarios
 - `acquire_expire_refresh_complete` — lease transitions through valid, expiring, refreshing, and back to valid on successful refresh
+- `reauth_release_and_publication` — reauth required from valid/expiring/refreshing, release lease, emit lifecycle event, and wake refresh loop publication
 
 ### Transitions
 - `Acquire`
@@ -19,42 +20,42 @@ This section is generated from the Rust machine catalog. Do not edit it by hand.
   - scenarios: `acquire_expire_refresh_complete`
 - `MarkExpiring`
   - anchors: `auth_lease_handle`
-  - scenarios: `acquire_expire_refresh_complete`
+  - scenarios: `acquire_expire_refresh_complete`, `reauth_release_and_publication`
 - `BeginRefreshFromValid`
   - anchors: `auth_lease_handle`
-  - scenarios: `acquire_expire_refresh_complete`
+  - scenarios: `reauth_release_and_publication`
 - `BeginRefreshFromExpiring`
   - anchors: `auth_lease_handle`
-  - scenarios: `acquire_expire_refresh_complete`
+  - scenarios: `reauth_release_and_publication`
 - `CompleteRefresh`
   - anchors: `auth_lease_handle`
   - scenarios: `acquire_expire_refresh_complete`
 - `RefreshFailedTransient`
   - anchors: `auth_lease_handle`
-  - scenarios: `acquire_expire_refresh_complete`
+  - scenarios: `acquire_expire_refresh_complete`, `reauth_release_and_publication`
 - `RefreshFailedPermanent`
   - anchors: `auth_lease_handle`
-  - scenarios: `acquire_expire_refresh_complete`
+  - scenarios: `acquire_expire_refresh_complete`, `reauth_release_and_publication`
 - `MarkReauthRequiredFromValid`
   - anchors: `auth_lease_handle`
-  - scenarios: `acquire_expire_refresh_complete`
+  - scenarios: `reauth_release_and_publication`
 - `MarkReauthRequiredFromExpiring`
   - anchors: `auth_lease_handle`
-  - scenarios: `acquire_expire_refresh_complete`
+  - scenarios: `reauth_release_and_publication`
 - `MarkReauthRequiredFromRefreshing`
   - anchors: `auth_lease_handle`
-  - scenarios: `acquire_expire_refresh_complete`
+  - scenarios: `reauth_release_and_publication`
 - `Release`
   - anchors: `auth_lease_handle`
-  - scenarios: `acquire_expire_refresh_complete`
+  - scenarios: `reauth_release_and_publication`
 
 ### Effects
 - `EmitLifecycleEvent`
   - anchors: `auth_lease_handle`
-  - scenarios: `acquire_expire_refresh_complete`
+  - scenarios: `reauth_release_and_publication`
 - `WakeRefreshLoop`
   - anchors: `auth_lease_handle`
-  - scenarios: `acquire_expire_refresh_complete`
+  - scenarios: `reauth_release_and_publication`
 
 ### Invariants
 - `(none)`

--- a/specs/machines/meerkat_machine/contract.md
+++ b/specs/machines/meerkat_machine/contract.md
@@ -3977,7 +3977,7 @@ _Generated from the Rust machine catalog. Do not edit by hand._
 
 ## Coverage
 ### Code Anchors
-- `meerkat-runtime/src/meerkat_machine/mod.rs` — authoritative MeerkatMachine command dispatch and state ownership
+- `meerkat-runtime/src/meerkat_machine/mod.rs` — authoritative MeerkatMachine command dispatch and state ownership for initialize, register, unregister, reconfigure, stage filters and tools, prepare bindings, drain, interrupt, cancel boundary, cancellation, abort, wait, ingest, publish event, accept input, classify envelope, append/context starts, run preparation, commit, fail, pending/call/finalize tool surface, retire/retired, reset, stop/stopped executor, destroy/destroyed, ensure executor, runtime notice, silent intents, recycle, realtime binding, MCP server, interaction stream, product turn, live topology, ingress, supervisor, trust reconcile, ops barrier, local endpoint, admission, completion, compaction, submit op event, notify op watcher, collect/enqueue, and terminal records
 - `meerkat/src/meerkat_machine.rs` — MeerkatMachine snapshot/diagnostic facade
 - `meerkat-comms/src/peer_directory_reachability_authority.rs` — peer directory reachability state now owned as a MeerkatMachine-internal region
 
@@ -3987,3 +3987,10 @@ _Generated from the Rust machine catalog. Do not edit by hand._
 - `staged_visibility_apply` — tool visibility staged state promotes into the committed visible revision at a boundary
 - `turn_interrupt_and_shutdown` — running work records interrupt and shutdown intent without escaping the Meerkat authority boundary
 - `peer_reachability_probe` — resolved peer directory updates and send outcomes mutate Meerkat-owned peer reachability state
+- `session_registration_and_binding` — initialize, register, unregister, reconfigure session identity, prepare bindings, ensure executor, attach session ingress, detach ingress, drain exit, and runtime bound/retired/destroyed notices
+- `input_admission_and_queueing` — ingest and publish event, accept input with or without completion, classify external envelope or plain event, prepare run work, enqueue classified entry, resolve admission, submit admitted ingress effect, post admission signal, and input or ingress notices
+- `ops_completion_and_waiters` — abort, wait, abort all, request cancellation at boundary, completion produced/resolved, wait all satisfied, collect completed result, submit op event, notify op watcher, reject surface call, retain or evict completed terminal records
+- `realtime_connection_projection` — project realtime intent, begin replace detach binding, require reattach, publish signal, reconnect progress, MCP server connect/connected/failed/disconnected/reload, advance session context, interaction stream reserved/attached/completed/expired/closed early, freshness, policy, and binding rotation
+- `product_turn_streaming` — product turn in flight, committed, output started, interrupted, terminal, realtime projection advance/refreshed/reset, client input submitted, mid turn activity, and turn terminated classification
+- `recycle_and_compaction` — recycle from idle or retired, initiate recycle, check compaction, and re-enter ready runtime ownership without preserving stale completed records
+- `live_topology_and_supervision` — begin live topology reconfigure, mark detached, apply identity or visibility, complete/abort/fail topology, bind/authorize/revoke supervisor, publish/revoke trust edge, comms trust reconcile, and local endpoint publish or clear

--- a/specs/machines/meerkat_machine/mapping.md
+++ b/specs/machines/meerkat_machine/mapping.md
@@ -8,7 +8,7 @@ This section is generated from the Rust machine catalog. Do not edit it by hand.
 - `MeerkatMachine`
 
 ### Code Anchors
-- `meerkat_machine`: `meerkat-runtime/src/meerkat_machine/mod.rs` — authoritative MeerkatMachine command dispatch and state ownership
+- `meerkat_machine`: `meerkat-runtime/src/meerkat_machine/mod.rs` — authoritative MeerkatMachine command dispatch and state ownership for initialize, register, unregister, reconfigure, stage filters and tools, prepare bindings, drain, interrupt, cancel boundary, cancellation, abort, wait, ingest, publish event, accept input, classify envelope, append/context starts, run preparation, commit, fail, pending/call/finalize tool surface, retire/retired, reset, stop/stopped executor, destroy/destroyed, ensure executor, runtime notice, silent intents, recycle, realtime binding, MCP server, interaction stream, product turn, live topology, ingress, supervisor, trust reconcile, ops barrier, local endpoint, admission, completion, compaction, submit op event, notify op watcher, collect/enqueue, and terminal records
 - `meerkat_public_surface`: `meerkat/src/meerkat_machine.rs` — MeerkatMachine snapshot/diagnostic facade
 - `peer_directory_reachability_authority`: `meerkat-comms/src/peer_directory_reachability_authority.rs` — peer directory reachability state now owned as a MeerkatMachine-internal region
 
@@ -18,1602 +18,1609 @@ This section is generated from the Rust machine catalog. Do not edit it by hand.
 - `staged_visibility_apply` — tool visibility staged state promotes into the committed visible revision at a boundary
 - `turn_interrupt_and_shutdown` — running work records interrupt and shutdown intent without escaping the Meerkat authority boundary
 - `peer_reachability_probe` — resolved peer directory updates and send outcomes mutate Meerkat-owned peer reachability state
+- `session_registration_and_binding` — initialize, register, unregister, reconfigure session identity, prepare bindings, ensure executor, attach session ingress, detach ingress, drain exit, and runtime bound/retired/destroyed notices
+- `input_admission_and_queueing` — ingest and publish event, accept input with or without completion, classify external envelope or plain event, prepare run work, enqueue classified entry, resolve admission, submit admitted ingress effect, post admission signal, and input or ingress notices
+- `ops_completion_and_waiters` — abort, wait, abort all, request cancellation at boundary, completion produced/resolved, wait all satisfied, collect completed result, submit op event, notify op watcher, reject surface call, retain or evict completed terminal records
+- `realtime_connection_projection` — project realtime intent, begin replace detach binding, require reattach, publish signal, reconnect progress, MCP server connect/connected/failed/disconnected/reload, advance session context, interaction stream reserved/attached/completed/expired/closed early, freshness, policy, and binding rotation
+- `product_turn_streaming` — product turn in flight, committed, output started, interrupted, terminal, realtime projection advance/refreshed/reset, client input submitted, mid turn activity, and turn terminated classification
+- `recycle_and_compaction` — recycle from idle or retired, initiate recycle, check compaction, and re-enter ready runtime ownership without preserving stale completed records
+- `live_topology_and_supervision` — begin live topology reconfigure, mark detached, apply identity or visibility, complete/abort/fail topology, bind/authorize/revoke supervisor, publish/revoke trust edge, comms trust reconcile, and local endpoint publish or clear
 
 ### Transitions
 - `Initialize`
-  - anchors: `meerkat_machine`, `meerkat_public_surface`, `peer_directory_reachability_authority`
-  - scenarios: `bind-run-boundary-terminal`, `retire-reset-destroy`, `staged_visibility_apply`, `turn_interrupt_and_shutdown`, `peer_reachability_probe`
+  - anchors: `meerkat_machine`
+  - scenarios: `session_registration_and_binding`
 - `RegisterSessionIdle`
-  - anchors: `meerkat_machine`, `meerkat_public_surface`, `peer_directory_reachability_authority`
-  - scenarios: `bind-run-boundary-terminal`, `retire-reset-destroy`, `staged_visibility_apply`, `turn_interrupt_and_shutdown`, `peer_reachability_probe`
+  - anchors: `meerkat_machine`
+  - scenarios: `session_registration_and_binding`
 - `RegisterSessionAttached`
-  - anchors: `meerkat_machine`, `meerkat_public_surface`, `peer_directory_reachability_authority`
-  - scenarios: `bind-run-boundary-terminal`, `retire-reset-destroy`, `staged_visibility_apply`, `turn_interrupt_and_shutdown`, `peer_reachability_probe`
+  - anchors: `meerkat_machine`
+  - scenarios: `session_registration_and_binding`, `realtime_connection_projection`
 - `RegisterSessionRunning`
-  - anchors: `meerkat_machine`, `meerkat_public_surface`, `peer_directory_reachability_authority`
-  - scenarios: `bind-run-boundary-terminal`, `retire-reset-destroy`, `staged_visibility_apply`, `turn_interrupt_and_shutdown`, `peer_reachability_probe`
+  - anchors: `meerkat_machine`
+  - scenarios: `session_registration_and_binding`
 - `RegisterSessionRetired`
-  - anchors: `meerkat_machine`, `meerkat_public_surface`, `peer_directory_reachability_authority`
-  - scenarios: `bind-run-boundary-terminal`, `retire-reset-destroy`, `staged_visibility_apply`, `turn_interrupt_and_shutdown`, `peer_reachability_probe`
+  - anchors: `meerkat_machine`
+  - scenarios: `session_registration_and_binding`
 - `RegisterSessionStopped`
-  - anchors: `meerkat_machine`, `meerkat_public_surface`, `peer_directory_reachability_authority`
-  - scenarios: `bind-run-boundary-terminal`, `retire-reset-destroy`, `staged_visibility_apply`, `turn_interrupt_and_shutdown`, `peer_reachability_probe`
+  - anchors: `meerkat_machine`
+  - scenarios: `session_registration_and_binding`
 - `UnregisterSessionIdle`
-  - anchors: `meerkat_machine`, `meerkat_public_surface`, `peer_directory_reachability_authority`
-  - scenarios: `bind-run-boundary-terminal`, `retire-reset-destroy`, `staged_visibility_apply`, `turn_interrupt_and_shutdown`, `peer_reachability_probe`
+  - anchors: `meerkat_machine`
+  - scenarios: `session_registration_and_binding`
 - `UnregisterSessionAttached`
-  - anchors: `meerkat_machine`, `meerkat_public_surface`, `peer_directory_reachability_authority`
-  - scenarios: `bind-run-boundary-terminal`, `retire-reset-destroy`, `staged_visibility_apply`, `turn_interrupt_and_shutdown`, `peer_reachability_probe`
+  - anchors: `meerkat_machine`
+  - scenarios: `session_registration_and_binding`, `realtime_connection_projection`
 - `UnregisterSessionRunning`
-  - anchors: `meerkat_machine`, `meerkat_public_surface`, `peer_directory_reachability_authority`
-  - scenarios: `bind-run-boundary-terminal`, `retire-reset-destroy`, `staged_visibility_apply`, `turn_interrupt_and_shutdown`, `peer_reachability_probe`
+  - anchors: `meerkat_machine`
+  - scenarios: `session_registration_and_binding`
 - `UnregisterSessionRetired`
-  - anchors: `meerkat_machine`, `meerkat_public_surface`, `peer_directory_reachability_authority`
-  - scenarios: `bind-run-boundary-terminal`, `retire-reset-destroy`, `staged_visibility_apply`, `turn_interrupt_and_shutdown`, `peer_reachability_probe`
+  - anchors: `meerkat_machine`
+  - scenarios: `session_registration_and_binding`
 - `UnregisterSessionStopped`
-  - anchors: `meerkat_machine`, `meerkat_public_surface`, `peer_directory_reachability_authority`
-  - scenarios: `bind-run-boundary-terminal`, `retire-reset-destroy`, `staged_visibility_apply`, `turn_interrupt_and_shutdown`, `peer_reachability_probe`
+  - anchors: `meerkat_machine`
+  - scenarios: `session_registration_and_binding`
 - `ReconfigureSessionLlmIdentityAttached`
-  - anchors: `meerkat_machine`, `meerkat_public_surface`, `peer_directory_reachability_authority`
-  - scenarios: `bind-run-boundary-terminal`, `retire-reset-destroy`, `staged_visibility_apply`, `turn_interrupt_and_shutdown`, `peer_reachability_probe`
+  - anchors: `meerkat_machine`
+  - scenarios: `session_registration_and_binding`
 - `ReconfigureSessionLlmIdentityRunning`
-  - anchors: `meerkat_machine`, `meerkat_public_surface`, `peer_directory_reachability_authority`
-  - scenarios: `bind-run-boundary-terminal`, `retire-reset-destroy`, `staged_visibility_apply`, `turn_interrupt_and_shutdown`, `peer_reachability_probe`
+  - anchors: `meerkat_machine`
+  - scenarios: `session_registration_and_binding`
 - `StagePersistentFilterIdle`
-  - anchors: `meerkat_machine`, `meerkat_public_surface`, `peer_directory_reachability_authority`
-  - scenarios: `bind-run-boundary-terminal`, `retire-reset-destroy`, `staged_visibility_apply`, `turn_interrupt_and_shutdown`, `peer_reachability_probe`
+  - anchors: `meerkat_machine`
+  - scenarios: `staged_visibility_apply`, `recycle_and_compaction`
 - `StagePersistentFilterAttached`
-  - anchors: `meerkat_machine`, `meerkat_public_surface`, `peer_directory_reachability_authority`
-  - scenarios: `bind-run-boundary-terminal`, `retire-reset-destroy`, `staged_visibility_apply`, `turn_interrupt_and_shutdown`, `peer_reachability_probe`
+  - anchors: `meerkat_machine`
+  - scenarios: `staged_visibility_apply`, `realtime_connection_projection`
 - `StagePersistentFilterRunning`
-  - anchors: `meerkat_machine`, `meerkat_public_surface`, `peer_directory_reachability_authority`
-  - scenarios: `bind-run-boundary-terminal`, `retire-reset-destroy`, `staged_visibility_apply`, `turn_interrupt_and_shutdown`, `peer_reachability_probe`
+  - anchors: `meerkat_machine`
+  - scenarios: `staged_visibility_apply`, `turn_interrupt_and_shutdown`
 - `StagePersistentFilterRetired`
-  - anchors: `meerkat_machine`, `meerkat_public_surface`, `peer_directory_reachability_authority`
-  - scenarios: `bind-run-boundary-terminal`, `retire-reset-destroy`, `staged_visibility_apply`, `turn_interrupt_and_shutdown`, `peer_reachability_probe`
+  - anchors: `meerkat_machine`
+  - scenarios: `staged_visibility_apply`, `session_registration_and_binding`, `recycle_and_compaction`
 - `StagePersistentFilterStopped`
-  - anchors: `meerkat_machine`, `meerkat_public_surface`, `peer_directory_reachability_authority`
-  - scenarios: `bind-run-boundary-terminal`, `retire-reset-destroy`, `staged_visibility_apply`, `turn_interrupt_and_shutdown`, `peer_reachability_probe`
+  - anchors: `meerkat_machine`
+  - scenarios: `staged_visibility_apply`
 - `RequestDeferredToolsIdle`
-  - anchors: `meerkat_machine`, `meerkat_public_surface`, `peer_directory_reachability_authority`
-  - scenarios: `bind-run-boundary-terminal`, `retire-reset-destroy`, `staged_visibility_apply`, `turn_interrupt_and_shutdown`, `peer_reachability_probe`
+  - anchors: `meerkat_machine`
+  - scenarios: `ops_completion_and_waiters`, `recycle_and_compaction`
 - `RequestDeferredToolsAttached`
-  - anchors: `meerkat_machine`, `meerkat_public_surface`, `peer_directory_reachability_authority`
-  - scenarios: `bind-run-boundary-terminal`, `retire-reset-destroy`, `staged_visibility_apply`, `turn_interrupt_and_shutdown`, `peer_reachability_probe`
+  - anchors: `meerkat_machine`
+  - scenarios: `ops_completion_and_waiters`, `realtime_connection_projection`
 - `RequestDeferredToolsRunning`
-  - anchors: `meerkat_machine`, `meerkat_public_surface`, `peer_directory_reachability_authority`
-  - scenarios: `bind-run-boundary-terminal`, `retire-reset-destroy`, `staged_visibility_apply`, `turn_interrupt_and_shutdown`, `peer_reachability_probe`
+  - anchors: `meerkat_machine`
+  - scenarios: `turn_interrupt_and_shutdown`, `ops_completion_and_waiters`
 - `RequestDeferredToolsRetired`
-  - anchors: `meerkat_machine`, `meerkat_public_surface`, `peer_directory_reachability_authority`
-  - scenarios: `bind-run-boundary-terminal`, `retire-reset-destroy`, `staged_visibility_apply`, `turn_interrupt_and_shutdown`, `peer_reachability_probe`
+  - anchors: `meerkat_machine`
+  - scenarios: `session_registration_and_binding`, `ops_completion_and_waiters`, `recycle_and_compaction`
 - `RequestDeferredToolsStopped`
-  - anchors: `meerkat_machine`, `meerkat_public_surface`, `peer_directory_reachability_authority`
-  - scenarios: `bind-run-boundary-terminal`, `retire-reset-destroy`, `staged_visibility_apply`, `turn_interrupt_and_shutdown`, `peer_reachability_probe`
+  - anchors: `meerkat_machine`
+  - scenarios: `ops_completion_and_waiters`
 - `PrepareBindingsInitializing`
-  - anchors: `meerkat_machine`, `meerkat_public_surface`, `peer_directory_reachability_authority`
-  - scenarios: `bind-run-boundary-terminal`, `retire-reset-destroy`, `staged_visibility_apply`, `turn_interrupt_and_shutdown`, `peer_reachability_probe`
+  - anchors: `meerkat_machine`
+  - scenarios: `session_registration_and_binding`
 - `PrepareBindingsIdle`
-  - anchors: `meerkat_machine`, `meerkat_public_surface`, `peer_directory_reachability_authority`
-  - scenarios: `bind-run-boundary-terminal`, `retire-reset-destroy`, `staged_visibility_apply`, `turn_interrupt_and_shutdown`, `peer_reachability_probe`
+  - anchors: `meerkat_machine`
+  - scenarios: `session_registration_and_binding`
 - `PrepareBindingsAttached`
-  - anchors: `meerkat_machine`, `meerkat_public_surface`, `peer_directory_reachability_authority`
-  - scenarios: `bind-run-boundary-terminal`, `retire-reset-destroy`, `staged_visibility_apply`, `turn_interrupt_and_shutdown`, `peer_reachability_probe`
+  - anchors: `meerkat_machine`
+  - scenarios: `session_registration_and_binding`
 - `PrepareBindingsRunning`
-  - anchors: `meerkat_machine`, `meerkat_public_surface`, `peer_directory_reachability_authority`
-  - scenarios: `bind-run-boundary-terminal`, `retire-reset-destroy`, `staged_visibility_apply`, `turn_interrupt_and_shutdown`, `peer_reachability_probe`
+  - anchors: `meerkat_machine`
+  - scenarios: `session_registration_and_binding`
 - `PrepareBindingsRetired`
-  - anchors: `meerkat_machine`, `meerkat_public_surface`, `peer_directory_reachability_authority`
-  - scenarios: `bind-run-boundary-terminal`, `retire-reset-destroy`, `staged_visibility_apply`, `turn_interrupt_and_shutdown`, `peer_reachability_probe`
+  - anchors: `meerkat_machine`
+  - scenarios: `session_registration_and_binding`
 - `PrepareBindingsStopped`
-  - anchors: `meerkat_machine`, `meerkat_public_surface`, `peer_directory_reachability_authority`
-  - scenarios: `bind-run-boundary-terminal`, `retire-reset-destroy`, `staged_visibility_apply`, `turn_interrupt_and_shutdown`, `peer_reachability_probe`
+  - anchors: `meerkat_machine`
+  - scenarios: `session_registration_and_binding`
 - `SetPeerIngressContextIdle`
-  - anchors: `meerkat_machine`, `meerkat_public_surface`, `peer_directory_reachability_authority`
-  - scenarios: `bind-run-boundary-terminal`, `retire-reset-destroy`, `staged_visibility_apply`, `turn_interrupt_and_shutdown`, `peer_reachability_probe`
+  - anchors: `meerkat_machine`
+  - scenarios: `retire-reset-destroy`, `peer_reachability_probe`, `session_registration_and_binding`, `input_admission_and_queueing`, `realtime_connection_projection`, `product_turn_streaming`, `recycle_and_compaction`
 - `SetPeerIngressContextAttached`
-  - anchors: `meerkat_machine`, `meerkat_public_surface`, `peer_directory_reachability_authority`
-  - scenarios: `bind-run-boundary-terminal`, `retire-reset-destroy`, `staged_visibility_apply`, `turn_interrupt_and_shutdown`, `peer_reachability_probe`
+  - anchors: `meerkat_machine`
+  - scenarios: `realtime_connection_projection`
 - `SetPeerIngressContextRunning`
-  - anchors: `meerkat_machine`, `meerkat_public_surface`, `peer_directory_reachability_authority`
-  - scenarios: `bind-run-boundary-terminal`, `retire-reset-destroy`, `staged_visibility_apply`, `turn_interrupt_and_shutdown`, `peer_reachability_probe`
+  - anchors: `meerkat_machine`
+  - scenarios: `retire-reset-destroy`, `turn_interrupt_and_shutdown`, `peer_reachability_probe`, `session_registration_and_binding`, `input_admission_and_queueing`, `realtime_connection_projection`, `product_turn_streaming`
 - `SetPeerIngressContextRetired`
-  - anchors: `meerkat_machine`, `meerkat_public_surface`, `peer_directory_reachability_authority`
-  - scenarios: `bind-run-boundary-terminal`, `retire-reset-destroy`, `staged_visibility_apply`, `turn_interrupt_and_shutdown`, `peer_reachability_probe`
+  - anchors: `meerkat_machine`
+  - scenarios: `session_registration_and_binding`
 - `SetPeerIngressContextStopped`
-  - anchors: `meerkat_machine`, `meerkat_public_surface`, `peer_directory_reachability_authority`
-  - scenarios: `bind-run-boundary-terminal`, `retire-reset-destroy`, `staged_visibility_apply`, `turn_interrupt_and_shutdown`, `peer_reachability_probe`
+  - anchors: `meerkat_machine`
+  - scenarios: `retire-reset-destroy`, `peer_reachability_probe`, `session_registration_and_binding`, `input_admission_and_queueing`, `realtime_connection_projection`, `product_turn_streaming`
 - `NotifyDrainExitedIdle`
-  - anchors: `meerkat_machine`, `meerkat_public_surface`, `peer_directory_reachability_authority`
-  - scenarios: `bind-run-boundary-terminal`, `retire-reset-destroy`, `staged_visibility_apply`, `turn_interrupt_and_shutdown`, `peer_reachability_probe`
+  - anchors: `meerkat_machine`
+  - scenarios: `session_registration_and_binding`, `ops_completion_and_waiters`, `recycle_and_compaction`
 - `NotifyDrainExitedAttached`
-  - anchors: `meerkat_machine`, `meerkat_public_surface`, `peer_directory_reachability_authority`
-  - scenarios: `bind-run-boundary-terminal`, `retire-reset-destroy`, `staged_visibility_apply`, `turn_interrupt_and_shutdown`, `peer_reachability_probe`
+  - anchors: `meerkat_machine`
+  - scenarios: `session_registration_and_binding`, `ops_completion_and_waiters`, `realtime_connection_projection`
 - `NotifyDrainExitedRunning`
-  - anchors: `meerkat_machine`, `meerkat_public_surface`, `peer_directory_reachability_authority`
-  - scenarios: `bind-run-boundary-terminal`, `retire-reset-destroy`, `staged_visibility_apply`, `turn_interrupt_and_shutdown`, `peer_reachability_probe`
+  - anchors: `meerkat_machine`
+  - scenarios: `turn_interrupt_and_shutdown`, `session_registration_and_binding`, `ops_completion_and_waiters`
 - `NotifyDrainExitedRetired`
-  - anchors: `meerkat_machine`, `meerkat_public_surface`, `peer_directory_reachability_authority`
-  - scenarios: `bind-run-boundary-terminal`, `retire-reset-destroy`, `staged_visibility_apply`, `turn_interrupt_and_shutdown`, `peer_reachability_probe`
+  - anchors: `meerkat_machine`
+  - scenarios: `session_registration_and_binding`
 - `NotifyDrainExitedStopped`
-  - anchors: `meerkat_machine`, `meerkat_public_surface`, `peer_directory_reachability_authority`
-  - scenarios: `bind-run-boundary-terminal`, `retire-reset-destroy`, `staged_visibility_apply`, `turn_interrupt_and_shutdown`, `peer_reachability_probe`
+  - anchors: `meerkat_machine`
+  - scenarios: `session_registration_and_binding`, `ops_completion_and_waiters`
 - `InterruptCurrentRunAttached`
-  - anchors: `meerkat_machine`, `meerkat_public_surface`, `peer_directory_reachability_authority`
-  - scenarios: `bind-run-boundary-terminal`, `retire-reset-destroy`, `staged_visibility_apply`, `turn_interrupt_and_shutdown`, `peer_reachability_probe`
+  - anchors: `meerkat_machine`
+  - scenarios: `turn_interrupt_and_shutdown`
 - `InterruptCurrentRun`
-  - anchors: `meerkat_machine`, `meerkat_public_surface`, `peer_directory_reachability_authority`
-  - scenarios: `bind-run-boundary-terminal`, `retire-reset-destroy`, `staged_visibility_apply`, `turn_interrupt_and_shutdown`, `peer_reachability_probe`
+  - anchors: `meerkat_machine`
+  - scenarios: `turn_interrupt_and_shutdown`
 - `CancelAfterBoundaryAttached`
-  - anchors: `meerkat_machine`, `meerkat_public_surface`, `peer_directory_reachability_authority`
-  - scenarios: `bind-run-boundary-terminal`, `retire-reset-destroy`, `staged_visibility_apply`, `turn_interrupt_and_shutdown`, `peer_reachability_probe`
+  - anchors: `meerkat_machine`
+  - scenarios: `ops_completion_and_waiters`
 - `CancelAfterBoundary`
-  - anchors: `meerkat_machine`, `meerkat_public_surface`, `peer_directory_reachability_authority`
-  - scenarios: `bind-run-boundary-terminal`, `retire-reset-destroy`, `staged_visibility_apply`, `turn_interrupt_and_shutdown`, `peer_reachability_probe`
+  - anchors: `meerkat_machine`
+  - scenarios: `ops_completion_and_waiters`
 - `BoundaryAppliedPublish`
-  - anchors: `meerkat_machine`, `meerkat_public_surface`, `peer_directory_reachability_authority`
-  - scenarios: `bind-run-boundary-terminal`, `retire-reset-destroy`, `staged_visibility_apply`, `turn_interrupt_and_shutdown`, `peer_reachability_probe`
+  - anchors: `meerkat_machine`
+  - scenarios: `bind-run-boundary-terminal`, `staged_visibility_apply`, `turn_interrupt_and_shutdown`, `input_admission_and_queueing`, `ops_completion_and_waiters`, `realtime_connection_projection`, `live_topology_and_supervision`
 - `PublishCommittedVisibleSetIdle`
-  - anchors: `meerkat_machine`, `meerkat_public_surface`, `peer_directory_reachability_authority`
-  - scenarios: `bind-run-boundary-terminal`, `retire-reset-destroy`, `staged_visibility_apply`, `turn_interrupt_and_shutdown`, `peer_reachability_probe`
+  - anchors: `meerkat_machine`
+  - scenarios: `staged_visibility_apply`, `product_turn_streaming`
 - `PublishCommittedVisibleSetAttached`
-  - anchors: `meerkat_machine`, `meerkat_public_surface`, `peer_directory_reachability_authority`
-  - scenarios: `bind-run-boundary-terminal`, `retire-reset-destroy`, `staged_visibility_apply`, `turn_interrupt_and_shutdown`, `peer_reachability_probe`
+  - anchors: `meerkat_machine`
+  - scenarios: `staged_visibility_apply`, `realtime_connection_projection`, `product_turn_streaming`
 - `PublishCommittedVisibleSetRunning`
-  - anchors: `meerkat_machine`, `meerkat_public_surface`, `peer_directory_reachability_authority`
-  - scenarios: `bind-run-boundary-terminal`, `retire-reset-destroy`, `staged_visibility_apply`, `turn_interrupt_and_shutdown`, `peer_reachability_probe`
+  - anchors: `meerkat_machine`
+  - scenarios: `staged_visibility_apply`, `product_turn_streaming`
 - `PublishCommittedVisibleSetRetired`
-  - anchors: `meerkat_machine`, `meerkat_public_surface`, `peer_directory_reachability_authority`
-  - scenarios: `bind-run-boundary-terminal`, `retire-reset-destroy`, `staged_visibility_apply`, `turn_interrupt_and_shutdown`, `peer_reachability_probe`
+  - anchors: `meerkat_machine`
+  - scenarios: `staged_visibility_apply`, `product_turn_streaming`
 - `PublishCommittedVisibleSetStopped`
-  - anchors: `meerkat_machine`, `meerkat_public_surface`, `peer_directory_reachability_authority`
-  - scenarios: `bind-run-boundary-terminal`, `retire-reset-destroy`, `staged_visibility_apply`, `turn_interrupt_and_shutdown`, `peer_reachability_probe`
+  - anchors: `meerkat_machine`
+  - scenarios: `staged_visibility_apply`, `product_turn_streaming`
 - `RetireRequestedFromIdle`
-  - anchors: `meerkat_machine`, `meerkat_public_surface`, `peer_directory_reachability_authority`
-  - scenarios: `bind-run-boundary-terminal`, `retire-reset-destroy`, `staged_visibility_apply`, `turn_interrupt_and_shutdown`, `peer_reachability_probe`
+  - anchors: `meerkat_machine`
+  - scenarios: `recycle_and_compaction`
 - `Reset`
-  - anchors: `meerkat_machine`, `meerkat_public_surface`, `peer_directory_reachability_authority`
-  - scenarios: `bind-run-boundary-terminal`, `retire-reset-destroy`, `staged_visibility_apply`, `turn_interrupt_and_shutdown`, `peer_reachability_probe`
+  - anchors: `meerkat_machine`
+  - scenarios: `retire-reset-destroy`, `product_turn_streaming`
 - `StopRuntimeExecutorUnbound`
-  - anchors: `meerkat_machine`, `meerkat_public_surface`, `peer_directory_reachability_authority`
-  - scenarios: `bind-run-boundary-terminal`, `retire-reset-destroy`, `staged_visibility_apply`, `turn_interrupt_and_shutdown`, `peer_reachability_probe`
+  - anchors: `meerkat_machine`
+  - scenarios: `retire-reset-destroy`, `session_registration_and_binding`
 - `StopRuntimeExecutorAttached`
-  - anchors: `meerkat_machine`, `meerkat_public_surface`, `peer_directory_reachability_authority`
-  - scenarios: `bind-run-boundary-terminal`, `retire-reset-destroy`, `staged_visibility_apply`, `turn_interrupt_and_shutdown`, `peer_reachability_probe`
+  - anchors: `meerkat_machine`
+  - scenarios: `retire-reset-destroy`, `session_registration_and_binding`
 - `StopRuntimeExecutorRunning`
-  - anchors: `meerkat_machine`, `meerkat_public_surface`, `peer_directory_reachability_authority`
-  - scenarios: `bind-run-boundary-terminal`, `retire-reset-destroy`, `staged_visibility_apply`, `turn_interrupt_and_shutdown`, `peer_reachability_probe`
+  - anchors: `meerkat_machine`
+  - scenarios: `retire-reset-destroy`, `session_registration_and_binding`
 - `Destroy`
-  - anchors: `meerkat_machine`, `meerkat_public_surface`, `peer_directory_reachability_authority`
-  - scenarios: `bind-run-boundary-terminal`, `retire-reset-destroy`, `staged_visibility_apply`, `turn_interrupt_and_shutdown`, `peer_reachability_probe`
+  - anchors: `meerkat_machine`
+  - scenarios: `retire-reset-destroy`, `session_registration_and_binding`
 - `EnsureSessionWithExecutorIdle`
-  - anchors: `meerkat_machine`, `meerkat_public_surface`, `peer_directory_reachability_authority`
-  - scenarios: `bind-run-boundary-terminal`, `retire-reset-destroy`, `staged_visibility_apply`, `turn_interrupt_and_shutdown`, `peer_reachability_probe`
+  - anchors: `meerkat_machine`
+  - scenarios: `session_registration_and_binding`
 - `EnsureSessionWithExecutorAttached`
-  - anchors: `meerkat_machine`, `meerkat_public_surface`, `peer_directory_reachability_authority`
-  - scenarios: `bind-run-boundary-terminal`, `retire-reset-destroy`, `staged_visibility_apply`, `turn_interrupt_and_shutdown`, `peer_reachability_probe`
+  - anchors: `meerkat_machine`
+  - scenarios: `session_registration_and_binding`
 - `EnsureSessionWithExecutorRunning`
-  - anchors: `meerkat_machine`, `meerkat_public_surface`, `peer_directory_reachability_authority`
-  - scenarios: `bind-run-boundary-terminal`, `retire-reset-destroy`, `staged_visibility_apply`, `turn_interrupt_and_shutdown`, `peer_reachability_probe`
+  - anchors: `meerkat_machine`
+  - scenarios: `session_registration_and_binding`
 - `EnsureSessionWithExecutorRetired`
-  - anchors: `meerkat_machine`, `meerkat_public_surface`, `peer_directory_reachability_authority`
-  - scenarios: `bind-run-boundary-terminal`, `retire-reset-destroy`, `staged_visibility_apply`, `turn_interrupt_and_shutdown`, `peer_reachability_probe`
+  - anchors: `meerkat_machine`
+  - scenarios: `session_registration_and_binding`
 - `EnsureSessionWithExecutorStopped`
-  - anchors: `meerkat_machine`, `meerkat_public_surface`, `peer_directory_reachability_authority`
-  - scenarios: `bind-run-boundary-terminal`, `retire-reset-destroy`, `staged_visibility_apply`, `turn_interrupt_and_shutdown`, `peer_reachability_probe`
+  - anchors: `meerkat_machine`
+  - scenarios: `session_registration_and_binding`
 - `SetSilentIntentsIdle`
-  - anchors: `meerkat_machine`, `meerkat_public_surface`, `peer_directory_reachability_authority`
-  - scenarios: `bind-run-boundary-terminal`, `retire-reset-destroy`, `staged_visibility_apply`, `turn_interrupt_and_shutdown`, `peer_reachability_probe`
+  - anchors: `meerkat_machine`
+  - scenarios: `retire-reset-destroy`, `product_turn_streaming`, `recycle_and_compaction`
 - `SetSilentIntentsAttached`
-  - anchors: `meerkat_machine`, `meerkat_public_surface`, `peer_directory_reachability_authority`
-  - scenarios: `bind-run-boundary-terminal`, `retire-reset-destroy`, `staged_visibility_apply`, `turn_interrupt_and_shutdown`, `peer_reachability_probe`
+  - anchors: `meerkat_machine`
+  - scenarios: `retire-reset-destroy`, `realtime_connection_projection`, `product_turn_streaming`
 - `SetSilentIntentsRunning`
-  - anchors: `meerkat_machine`, `meerkat_public_surface`, `peer_directory_reachability_authority`
-  - scenarios: `bind-run-boundary-terminal`, `retire-reset-destroy`, `staged_visibility_apply`, `turn_interrupt_and_shutdown`, `peer_reachability_probe`
+  - anchors: `meerkat_machine`
+  - scenarios: `retire-reset-destroy`, `turn_interrupt_and_shutdown`, `product_turn_streaming`
 - `SetSilentIntentsRetired`
-  - anchors: `meerkat_machine`, `meerkat_public_surface`, `peer_directory_reachability_authority`
-  - scenarios: `bind-run-boundary-terminal`, `retire-reset-destroy`, `staged_visibility_apply`, `turn_interrupt_and_shutdown`, `peer_reachability_probe`
+  - anchors: `meerkat_machine`
+  - scenarios: `retire-reset-destroy`, `session_registration_and_binding`, `product_turn_streaming`, `recycle_and_compaction`
 - `SetSilentIntentsStopped`
-  - anchors: `meerkat_machine`, `meerkat_public_surface`, `peer_directory_reachability_authority`
-  - scenarios: `bind-run-boundary-terminal`, `retire-reset-destroy`, `staged_visibility_apply`, `turn_interrupt_and_shutdown`, `peer_reachability_probe`
+  - anchors: `meerkat_machine`
+  - scenarios: `retire-reset-destroy`, `product_turn_streaming`
 - `AbortIdle`
-  - anchors: `meerkat_machine`, `meerkat_public_surface`, `peer_directory_reachability_authority`
-  - scenarios: `bind-run-boundary-terminal`, `retire-reset-destroy`, `staged_visibility_apply`, `turn_interrupt_and_shutdown`, `peer_reachability_probe`
+  - anchors: `meerkat_machine`
+  - scenarios: `ops_completion_and_waiters`, `recycle_and_compaction`, `live_topology_and_supervision`
 - `AbortAttached`
-  - anchors: `meerkat_machine`, `meerkat_public_surface`, `peer_directory_reachability_authority`
-  - scenarios: `bind-run-boundary-terminal`, `retire-reset-destroy`, `staged_visibility_apply`, `turn_interrupt_and_shutdown`, `peer_reachability_probe`
+  - anchors: `meerkat_machine`
+  - scenarios: `ops_completion_and_waiters`, `realtime_connection_projection`, `live_topology_and_supervision`
 - `AbortRunning`
-  - anchors: `meerkat_machine`, `meerkat_public_surface`, `peer_directory_reachability_authority`
-  - scenarios: `bind-run-boundary-terminal`, `retire-reset-destroy`, `staged_visibility_apply`, `turn_interrupt_and_shutdown`, `peer_reachability_probe`
+  - anchors: `meerkat_machine`
+  - scenarios: `turn_interrupt_and_shutdown`, `ops_completion_and_waiters`, `live_topology_and_supervision`
 - `AbortRetired`
-  - anchors: `meerkat_machine`, `meerkat_public_surface`, `peer_directory_reachability_authority`
-  - scenarios: `bind-run-boundary-terminal`, `retire-reset-destroy`, `staged_visibility_apply`, `turn_interrupt_and_shutdown`, `peer_reachability_probe`
+  - anchors: `meerkat_machine`
+  - scenarios: `session_registration_and_binding`, `ops_completion_and_waiters`, `recycle_and_compaction`, `live_topology_and_supervision`
 - `AbortStopped`
-  - anchors: `meerkat_machine`, `meerkat_public_surface`, `peer_directory_reachability_authority`
-  - scenarios: `bind-run-boundary-terminal`, `retire-reset-destroy`, `staged_visibility_apply`, `turn_interrupt_and_shutdown`, `peer_reachability_probe`
+  - anchors: `meerkat_machine`
+  - scenarios: `ops_completion_and_waiters`, `live_topology_and_supervision`
 - `WaitIdle`
-  - anchors: `meerkat_machine`, `meerkat_public_surface`, `peer_directory_reachability_authority`
-  - scenarios: `bind-run-boundary-terminal`, `retire-reset-destroy`, `staged_visibility_apply`, `turn_interrupt_and_shutdown`, `peer_reachability_probe`
+  - anchors: `meerkat_machine`
+  - scenarios: `ops_completion_and_waiters`, `recycle_and_compaction`
 - `WaitAttached`
-  - anchors: `meerkat_machine`, `meerkat_public_surface`, `peer_directory_reachability_authority`
-  - scenarios: `bind-run-boundary-terminal`, `retire-reset-destroy`, `staged_visibility_apply`, `turn_interrupt_and_shutdown`, `peer_reachability_probe`
+  - anchors: `meerkat_machine`
+  - scenarios: `ops_completion_and_waiters`, `realtime_connection_projection`
 - `WaitRunning`
-  - anchors: `meerkat_machine`, `meerkat_public_surface`, `peer_directory_reachability_authority`
-  - scenarios: `bind-run-boundary-terminal`, `retire-reset-destroy`, `staged_visibility_apply`, `turn_interrupt_and_shutdown`, `peer_reachability_probe`
+  - anchors: `meerkat_machine`
+  - scenarios: `turn_interrupt_and_shutdown`, `ops_completion_and_waiters`
 - `WaitRetired`
-  - anchors: `meerkat_machine`, `meerkat_public_surface`, `peer_directory_reachability_authority`
-  - scenarios: `bind-run-boundary-terminal`, `retire-reset-destroy`, `staged_visibility_apply`, `turn_interrupt_and_shutdown`, `peer_reachability_probe`
+  - anchors: `meerkat_machine`
+  - scenarios: `session_registration_and_binding`, `ops_completion_and_waiters`, `recycle_and_compaction`
 - `WaitStopped`
-  - anchors: `meerkat_machine`, `meerkat_public_surface`, `peer_directory_reachability_authority`
-  - scenarios: `bind-run-boundary-terminal`, `retire-reset-destroy`, `staged_visibility_apply`, `turn_interrupt_and_shutdown`, `peer_reachability_probe`
+  - anchors: `meerkat_machine`
+  - scenarios: `ops_completion_and_waiters`
 - `AbortAllIdle`
-  - anchors: `meerkat_machine`, `meerkat_public_surface`, `peer_directory_reachability_authority`
-  - scenarios: `bind-run-boundary-terminal`, `retire-reset-destroy`, `staged_visibility_apply`, `turn_interrupt_and_shutdown`, `peer_reachability_probe`
+  - anchors: `meerkat_machine`
+  - scenarios: `ops_completion_and_waiters`
 - `AbortAllAttached`
-  - anchors: `meerkat_machine`, `meerkat_public_surface`, `peer_directory_reachability_authority`
-  - scenarios: `bind-run-boundary-terminal`, `retire-reset-destroy`, `staged_visibility_apply`, `turn_interrupt_and_shutdown`, `peer_reachability_probe`
+  - anchors: `meerkat_machine`
+  - scenarios: `ops_completion_and_waiters`
 - `AbortAllRunning`
-  - anchors: `meerkat_machine`, `meerkat_public_surface`, `peer_directory_reachability_authority`
-  - scenarios: `bind-run-boundary-terminal`, `retire-reset-destroy`, `staged_visibility_apply`, `turn_interrupt_and_shutdown`, `peer_reachability_probe`
+  - anchors: `meerkat_machine`
+  - scenarios: `ops_completion_and_waiters`
 - `AbortAllRetired`
-  - anchors: `meerkat_machine`, `meerkat_public_surface`, `peer_directory_reachability_authority`
-  - scenarios: `bind-run-boundary-terminal`, `retire-reset-destroy`, `staged_visibility_apply`, `turn_interrupt_and_shutdown`, `peer_reachability_probe`
+  - anchors: `meerkat_machine`
+  - scenarios: `ops_completion_and_waiters`
 - `AbortAllStopped`
-  - anchors: `meerkat_machine`, `meerkat_public_surface`, `peer_directory_reachability_authority`
-  - scenarios: `bind-run-boundary-terminal`, `retire-reset-destroy`, `staged_visibility_apply`, `turn_interrupt_and_shutdown`, `peer_reachability_probe`
+  - anchors: `meerkat_machine`
+  - scenarios: `ops_completion_and_waiters`
 - `EnsureDrainRunningAttached`
-  - anchors: `meerkat_machine`, `meerkat_public_surface`, `peer_directory_reachability_authority`
-  - scenarios: `bind-run-boundary-terminal`, `retire-reset-destroy`, `staged_visibility_apply`, `turn_interrupt_and_shutdown`, `peer_reachability_probe`
+  - anchors: `meerkat_machine`
+  - scenarios: `session_registration_and_binding`
 - `EnsureDrainRunningRunning`
-  - anchors: `meerkat_machine`, `meerkat_public_surface`, `peer_directory_reachability_authority`
-  - scenarios: `bind-run-boundary-terminal`, `retire-reset-destroy`, `staged_visibility_apply`, `turn_interrupt_and_shutdown`, `peer_reachability_probe`
+  - anchors: `meerkat_machine`
+  - scenarios: `turn_interrupt_and_shutdown`, `session_registration_and_binding`
 - `IngestIdle`
-  - anchors: `meerkat_machine`, `meerkat_public_surface`, `peer_directory_reachability_authority`
-  - scenarios: `bind-run-boundary-terminal`, `retire-reset-destroy`, `staged_visibility_apply`, `turn_interrupt_and_shutdown`, `peer_reachability_probe`
+  - anchors: `meerkat_machine`
+  - scenarios: `input_admission_and_queueing`, `recycle_and_compaction`
 - `IngestAttached`
-  - anchors: `meerkat_machine`, `meerkat_public_surface`, `peer_directory_reachability_authority`
-  - scenarios: `bind-run-boundary-terminal`, `retire-reset-destroy`, `staged_visibility_apply`, `turn_interrupt_and_shutdown`, `peer_reachability_probe`
+  - anchors: `meerkat_machine`
+  - scenarios: `input_admission_and_queueing`, `realtime_connection_projection`
 - `IngestRunning`
-  - anchors: `meerkat_machine`, `meerkat_public_surface`, `peer_directory_reachability_authority`
-  - scenarios: `bind-run-boundary-terminal`, `retire-reset-destroy`, `staged_visibility_apply`, `turn_interrupt_and_shutdown`, `peer_reachability_probe`
+  - anchors: `meerkat_machine`
+  - scenarios: `turn_interrupt_and_shutdown`, `input_admission_and_queueing`
 - `PublishEventIdle`
-  - anchors: `meerkat_machine`, `meerkat_public_surface`, `peer_directory_reachability_authority`
-  - scenarios: `bind-run-boundary-terminal`, `retire-reset-destroy`, `staged_visibility_apply`, `turn_interrupt_and_shutdown`, `peer_reachability_probe`
+  - anchors: `meerkat_machine`
+  - scenarios: `input_admission_and_queueing`
 - `PublishEventAttached`
-  - anchors: `meerkat_machine`, `meerkat_public_surface`, `peer_directory_reachability_authority`
-  - scenarios: `bind-run-boundary-terminal`, `retire-reset-destroy`, `staged_visibility_apply`, `turn_interrupt_and_shutdown`, `peer_reachability_probe`
+  - anchors: `meerkat_machine`
+  - scenarios: `input_admission_and_queueing`, `realtime_connection_projection`
 - `PublishEventRunning`
-  - anchors: `meerkat_machine`, `meerkat_public_surface`, `peer_directory_reachability_authority`
-  - scenarios: `bind-run-boundary-terminal`, `retire-reset-destroy`, `staged_visibility_apply`, `turn_interrupt_and_shutdown`, `peer_reachability_probe`
+  - anchors: `meerkat_machine`
+  - scenarios: `input_admission_and_queueing`
 - `PublishEventRetired`
-  - anchors: `meerkat_machine`, `meerkat_public_surface`, `peer_directory_reachability_authority`
-  - scenarios: `bind-run-boundary-terminal`, `retire-reset-destroy`, `staged_visibility_apply`, `turn_interrupt_and_shutdown`, `peer_reachability_probe`
+  - anchors: `meerkat_machine`
+  - scenarios: `input_admission_and_queueing`
 - `PublishEventStopped`
-  - anchors: `meerkat_machine`, `meerkat_public_surface`, `peer_directory_reachability_authority`
-  - scenarios: `bind-run-boundary-terminal`, `retire-reset-destroy`, `staged_visibility_apply`, `turn_interrupt_and_shutdown`, `peer_reachability_probe`
+  - anchors: `meerkat_machine`
+  - scenarios: `input_admission_and_queueing`
 - `AcceptWithCompletionIdleQueued`
-  - anchors: `meerkat_machine`, `meerkat_public_surface`, `peer_directory_reachability_authority`
-  - scenarios: `bind-run-boundary-terminal`, `retire-reset-destroy`, `staged_visibility_apply`, `turn_interrupt_and_shutdown`, `peer_reachability_probe`
+  - anchors: `meerkat_machine`
+  - scenarios: `input_admission_and_queueing`
 - `AcceptWithCompletionIdleImmediate`
-  - anchors: `meerkat_machine`, `meerkat_public_surface`, `peer_directory_reachability_authority`
-  - scenarios: `bind-run-boundary-terminal`, `retire-reset-destroy`, `staged_visibility_apply`, `turn_interrupt_and_shutdown`, `peer_reachability_probe`
+  - anchors: `meerkat_machine`
+  - scenarios: `input_admission_and_queueing`
 - `AcceptWithCompletionAttachedImmediate`
-  - anchors: `meerkat_machine`, `meerkat_public_surface`, `peer_directory_reachability_authority`
-  - scenarios: `bind-run-boundary-terminal`, `retire-reset-destroy`, `staged_visibility_apply`, `turn_interrupt_and_shutdown`, `peer_reachability_probe`
+  - anchors: `meerkat_machine`
+  - scenarios: `input_admission_and_queueing`
 - `AcceptWithCompletionAttachedQueued`
-  - anchors: `meerkat_machine`, `meerkat_public_surface`, `peer_directory_reachability_authority`
-  - scenarios: `bind-run-boundary-terminal`, `retire-reset-destroy`, `staged_visibility_apply`, `turn_interrupt_and_shutdown`, `peer_reachability_probe`
+  - anchors: `meerkat_machine`
+  - scenarios: `input_admission_and_queueing`
 - `AcceptWithCompletionRunningQueuedPassive`
-  - anchors: `meerkat_machine`, `meerkat_public_surface`, `peer_directory_reachability_authority`
-  - scenarios: `bind-run-boundary-terminal`, `retire-reset-destroy`, `staged_visibility_apply`, `turn_interrupt_and_shutdown`, `peer_reachability_probe`
+  - anchors: `meerkat_machine`
+  - scenarios: `input_admission_and_queueing`
 - `AcceptWithCompletionRunningQueuedWakeIfIdle`
-  - anchors: `meerkat_machine`, `meerkat_public_surface`, `peer_directory_reachability_authority`
-  - scenarios: `bind-run-boundary-terminal`, `retire-reset-destroy`, `staged_visibility_apply`, `turn_interrupt_and_shutdown`, `peer_reachability_probe`
+  - anchors: `meerkat_machine`
+  - scenarios: `input_admission_and_queueing`
 - `AcceptWithCompletionRunningInterruptYielding`
-  - anchors: `meerkat_machine`, `meerkat_public_surface`, `peer_directory_reachability_authority`
-  - scenarios: `bind-run-boundary-terminal`, `retire-reset-destroy`, `staged_visibility_apply`, `turn_interrupt_and_shutdown`, `peer_reachability_probe`
+  - anchors: `meerkat_machine`
+  - scenarios: `turn_interrupt_and_shutdown`, `input_admission_and_queueing`
 - `AcceptWithCompletionRunningImmediate`
-  - anchors: `meerkat_machine`, `meerkat_public_surface`, `peer_directory_reachability_authority`
-  - scenarios: `bind-run-boundary-terminal`, `retire-reset-destroy`, `staged_visibility_apply`, `turn_interrupt_and_shutdown`, `peer_reachability_probe`
+  - anchors: `meerkat_machine`
+  - scenarios: `input_admission_and_queueing`
 - `AcceptWithoutWakeIdle`
-  - anchors: `meerkat_machine`, `meerkat_public_surface`, `peer_directory_reachability_authority`
-  - scenarios: `bind-run-boundary-terminal`, `retire-reset-destroy`, `staged_visibility_apply`, `turn_interrupt_and_shutdown`, `peer_reachability_probe`
+  - anchors: `meerkat_machine`
+  - scenarios: `input_admission_and_queueing`, `recycle_and_compaction`
 - `AcceptWithoutWakeAttached`
-  - anchors: `meerkat_machine`, `meerkat_public_surface`, `peer_directory_reachability_authority`
-  - scenarios: `bind-run-boundary-terminal`, `retire-reset-destroy`, `staged_visibility_apply`, `turn_interrupt_and_shutdown`, `peer_reachability_probe`
+  - anchors: `meerkat_machine`
+  - scenarios: `input_admission_and_queueing`
 - `AcceptWithoutWakeRunning`
-  - anchors: `meerkat_machine`, `meerkat_public_surface`, `peer_directory_reachability_authority`
-  - scenarios: `bind-run-boundary-terminal`, `retire-reset-destroy`, `staged_visibility_apply`, `turn_interrupt_and_shutdown`, `peer_reachability_probe`
+  - anchors: `meerkat_machine`
+  - scenarios: `turn_interrupt_and_shutdown`, `input_admission_and_queueing`
 - `ClassifyExternalEnvelopeAttached`
-  - anchors: `meerkat_machine`, `meerkat_public_surface`, `peer_directory_reachability_authority`
-  - scenarios: `bind-run-boundary-terminal`, `retire-reset-destroy`, `staged_visibility_apply`, `turn_interrupt_and_shutdown`, `peer_reachability_probe`
+  - anchors: `meerkat_machine`
+  - scenarios: `input_admission_and_queueing`
 - `ClassifyExternalEnvelopeRunning`
-  - anchors: `meerkat_machine`, `meerkat_public_surface`, `peer_directory_reachability_authority`
-  - scenarios: `bind-run-boundary-terminal`, `retire-reset-destroy`, `staged_visibility_apply`, `turn_interrupt_and_shutdown`, `peer_reachability_probe`
+  - anchors: `meerkat_machine`
+  - scenarios: `input_admission_and_queueing`
 - `ClassifyPlainEventAttached`
-  - anchors: `meerkat_machine`, `meerkat_public_surface`, `peer_directory_reachability_authority`
-  - scenarios: `bind-run-boundary-terminal`, `retire-reset-destroy`, `staged_visibility_apply`, `turn_interrupt_and_shutdown`, `peer_reachability_probe`
+  - anchors: `meerkat_machine`
+  - scenarios: `input_admission_and_queueing`
 - `ClassifyPlainEventRunning`
-  - anchors: `meerkat_machine`, `meerkat_public_surface`, `peer_directory_reachability_authority`
-  - scenarios: `bind-run-boundary-terminal`, `retire-reset-destroy`, `staged_visibility_apply`, `turn_interrupt_and_shutdown`, `peer_reachability_probe`
+  - anchors: `meerkat_machine`
+  - scenarios: `input_admission_and_queueing`
 - `PrepareIdle`
-  - anchors: `meerkat_machine`, `meerkat_public_surface`, `peer_directory_reachability_authority`
-  - scenarios: `bind-run-boundary-terminal`, `retire-reset-destroy`, `staged_visibility_apply`, `turn_interrupt_and_shutdown`, `peer_reachability_probe`
+  - anchors: `meerkat_machine`
+  - scenarios: `session_registration_and_binding`, `input_admission_and_queueing`, `recycle_and_compaction`
 - `PrepareAttached`
-  - anchors: `meerkat_machine`, `meerkat_public_surface`, `peer_directory_reachability_authority`
-  - scenarios: `bind-run-boundary-terminal`, `retire-reset-destroy`, `staged_visibility_apply`, `turn_interrupt_and_shutdown`, `peer_reachability_probe`
+  - anchors: `meerkat_machine`
+  - scenarios: `session_registration_and_binding`, `input_admission_and_queueing`, `realtime_connection_projection`
 - `DrainQueuedRunRetired`
-  - anchors: `meerkat_machine`, `meerkat_public_surface`, `peer_directory_reachability_authority`
-  - scenarios: `bind-run-boundary-terminal`, `retire-reset-destroy`, `staged_visibility_apply`, `turn_interrupt_and_shutdown`, `peer_reachability_probe`
+  - anchors: `meerkat_machine`
+  - scenarios: `session_registration_and_binding`
 - `StartConversationRunAttached`
-  - anchors: `meerkat_machine`, `meerkat_public_surface`, `peer_directory_reachability_authority`
-  - scenarios: `bind-run-boundary-terminal`, `retire-reset-destroy`, `staged_visibility_apply`, `turn_interrupt_and_shutdown`, `peer_reachability_probe`
+  - anchors: `meerkat_machine`
+  - scenarios: `bind-run-boundary-terminal`, `retire-reset-destroy`, `turn_interrupt_and_shutdown`, `session_registration_and_binding`, `input_admission_and_queueing`, `realtime_connection_projection`, `product_turn_streaming`, `recycle_and_compaction`
 - `StartImmediateAppendAttached`
-  - anchors: `meerkat_machine`, `meerkat_public_surface`, `peer_directory_reachability_authority`
-  - scenarios: `bind-run-boundary-terminal`, `retire-reset-destroy`, `staged_visibility_apply`, `turn_interrupt_and_shutdown`, `peer_reachability_probe`
+  - anchors: `meerkat_machine`
+  - scenarios: `realtime_connection_projection`, `product_turn_streaming`
 - `StartImmediateContextAttached`
-  - anchors: `meerkat_machine`, `meerkat_public_surface`, `peer_directory_reachability_authority`
-  - scenarios: `bind-run-boundary-terminal`, `retire-reset-destroy`, `staged_visibility_apply`, `turn_interrupt_and_shutdown`, `peer_reachability_probe`
+  - anchors: `meerkat_machine`
+  - scenarios: `realtime_connection_projection`
 - `CommitRunningToIdle`
-  - anchors: `meerkat_machine`, `meerkat_public_surface`, `peer_directory_reachability_authority`
-  - scenarios: `bind-run-boundary-terminal`, `retire-reset-destroy`, `staged_visibility_apply`, `turn_interrupt_and_shutdown`, `peer_reachability_probe`
+  - anchors: `meerkat_machine`
+  - scenarios: `staged_visibility_apply`, `turn_interrupt_and_shutdown`, `product_turn_streaming`
 - `CommitRunningToAttached`
-  - anchors: `meerkat_machine`, `meerkat_public_surface`, `peer_directory_reachability_authority`
-  - scenarios: `bind-run-boundary-terminal`, `retire-reset-destroy`, `staged_visibility_apply`, `turn_interrupt_and_shutdown`, `peer_reachability_probe`
+  - anchors: `meerkat_machine`
+  - scenarios: `staged_visibility_apply`, `turn_interrupt_and_shutdown`, `product_turn_streaming`
 - `CommitRunningToRetired`
-  - anchors: `meerkat_machine`, `meerkat_public_surface`, `peer_directory_reachability_authority`
-  - scenarios: `bind-run-boundary-terminal`, `retire-reset-destroy`, `staged_visibility_apply`, `turn_interrupt_and_shutdown`, `peer_reachability_probe`
+  - anchors: `meerkat_machine`
+  - scenarios: `staged_visibility_apply`, `turn_interrupt_and_shutdown`, `product_turn_streaming`
 - `FailRunningToIdle`
-  - anchors: `meerkat_machine`, `meerkat_public_surface`, `peer_directory_reachability_authority`
-  - scenarios: `bind-run-boundary-terminal`, `retire-reset-destroy`, `staged_visibility_apply`, `turn_interrupt_and_shutdown`, `peer_reachability_probe`
+  - anchors: `meerkat_machine`
+  - scenarios: `turn_interrupt_and_shutdown`, `realtime_connection_projection`, `live_topology_and_supervision`
 - `FailRunningToAttached`
-  - anchors: `meerkat_machine`, `meerkat_public_surface`, `peer_directory_reachability_authority`
-  - scenarios: `bind-run-boundary-terminal`, `retire-reset-destroy`, `staged_visibility_apply`, `turn_interrupt_and_shutdown`, `peer_reachability_probe`
+  - anchors: `meerkat_machine`
+  - scenarios: `turn_interrupt_and_shutdown`, `realtime_connection_projection`, `live_topology_and_supervision`
 - `FailRunningToRetired`
-  - anchors: `meerkat_machine`, `meerkat_public_surface`, `peer_directory_reachability_authority`
-  - scenarios: `bind-run-boundary-terminal`, `retire-reset-destroy`, `staged_visibility_apply`, `turn_interrupt_and_shutdown`, `peer_reachability_probe`
+  - anchors: `meerkat_machine`
+  - scenarios: `turn_interrupt_and_shutdown`, `realtime_connection_projection`, `live_topology_and_supervision`
 - `StageAddAttached`
-  - anchors: `meerkat_machine`, `meerkat_public_surface`, `peer_directory_reachability_authority`
-  - scenarios: `bind-run-boundary-terminal`, `retire-reset-destroy`, `staged_visibility_apply`, `turn_interrupt_and_shutdown`, `peer_reachability_probe`
+  - anchors: `meerkat_machine`
+  - scenarios: `staged_visibility_apply`, `realtime_connection_projection`
 - `StageAddRunning`
-  - anchors: `meerkat_machine`, `meerkat_public_surface`, `peer_directory_reachability_authority`
-  - scenarios: `bind-run-boundary-terminal`, `retire-reset-destroy`, `staged_visibility_apply`, `turn_interrupt_and_shutdown`, `peer_reachability_probe`
+  - anchors: `meerkat_machine`
+  - scenarios: `staged_visibility_apply`, `turn_interrupt_and_shutdown`
 - `StageRemoveAttached`
-  - anchors: `meerkat_machine`, `meerkat_public_surface`, `peer_directory_reachability_authority`
-  - scenarios: `bind-run-boundary-terminal`, `retire-reset-destroy`, `staged_visibility_apply`, `turn_interrupt_and_shutdown`, `peer_reachability_probe`
+  - anchors: `meerkat_machine`
+  - scenarios: `staged_visibility_apply`, `realtime_connection_projection`
 - `StageRemoveRunning`
-  - anchors: `meerkat_machine`, `meerkat_public_surface`, `peer_directory_reachability_authority`
-  - scenarios: `bind-run-boundary-terminal`, `retire-reset-destroy`, `staged_visibility_apply`, `turn_interrupt_and_shutdown`, `peer_reachability_probe`
+  - anchors: `meerkat_machine`
+  - scenarios: `staged_visibility_apply`, `turn_interrupt_and_shutdown`
 - `StageReloadAttached`
-  - anchors: `meerkat_machine`, `meerkat_public_surface`, `peer_directory_reachability_authority`
-  - scenarios: `bind-run-boundary-terminal`, `retire-reset-destroy`, `staged_visibility_apply`, `turn_interrupt_and_shutdown`, `peer_reachability_probe`
+  - anchors: `meerkat_machine`
+  - scenarios: `realtime_connection_projection`
 - `StageReloadRunning`
-  - anchors: `meerkat_machine`, `meerkat_public_surface`, `peer_directory_reachability_authority`
-  - scenarios: `bind-run-boundary-terminal`, `retire-reset-destroy`, `staged_visibility_apply`, `turn_interrupt_and_shutdown`, `peer_reachability_probe`
+  - anchors: `meerkat_machine`
+  - scenarios: `staged_visibility_apply`, `turn_interrupt_and_shutdown`, `realtime_connection_projection`
 - `ApplySurfaceBoundaryAttached`
-  - anchors: `meerkat_machine`, `meerkat_public_surface`, `peer_directory_reachability_authority`
-  - scenarios: `bind-run-boundary-terminal`, `retire-reset-destroy`, `staged_visibility_apply`, `turn_interrupt_and_shutdown`, `peer_reachability_probe`
+  - anchors: `meerkat_machine`
+  - scenarios: `staged_visibility_apply`, `ops_completion_and_waiters`
 - `ApplySurfaceBoundaryRunning`
-  - anchors: `meerkat_machine`, `meerkat_public_surface`, `peer_directory_reachability_authority`
-  - scenarios: `bind-run-boundary-terminal`, `retire-reset-destroy`, `staged_visibility_apply`, `turn_interrupt_and_shutdown`, `peer_reachability_probe`
+  - anchors: `meerkat_machine`
+  - scenarios: `staged_visibility_apply`, `turn_interrupt_and_shutdown`, `ops_completion_and_waiters`
 - `PendingSucceededAttached`
-  - anchors: `meerkat_machine`, `meerkat_public_surface`, `peer_directory_reachability_authority`
-  - scenarios: `bind-run-boundary-terminal`, `retire-reset-destroy`, `staged_visibility_apply`, `turn_interrupt_and_shutdown`, `peer_reachability_probe`
+  - anchors: `meerkat_machine`
+  - scenarios: `realtime_connection_projection`
 - `PendingSucceededRunning`
-  - anchors: `meerkat_machine`, `meerkat_public_surface`, `peer_directory_reachability_authority`
-  - scenarios: `bind-run-boundary-terminal`, `retire-reset-destroy`, `staged_visibility_apply`, `turn_interrupt_and_shutdown`, `peer_reachability_probe`
+  - anchors: `meerkat_machine`
+  - scenarios: `turn_interrupt_and_shutdown`
 - `PendingFailedAttached`
-  - anchors: `meerkat_machine`, `meerkat_public_surface`, `peer_directory_reachability_authority`
-  - scenarios: `bind-run-boundary-terminal`, `retire-reset-destroy`, `staged_visibility_apply`, `turn_interrupt_and_shutdown`, `peer_reachability_probe`
+  - anchors: `meerkat_machine`
+  - scenarios: `realtime_connection_projection`
 - `PendingFailedRunning`
-  - anchors: `meerkat_machine`, `meerkat_public_surface`, `peer_directory_reachability_authority`
-  - scenarios: `bind-run-boundary-terminal`, `retire-reset-destroy`, `staged_visibility_apply`, `turn_interrupt_and_shutdown`, `peer_reachability_probe`
+  - anchors: `meerkat_machine`
+  - scenarios: `turn_interrupt_and_shutdown`, `realtime_connection_projection`
 - `CallStartedAttached`
-  - anchors: `meerkat_machine`, `meerkat_public_surface`, `peer_directory_reachability_authority`
-  - scenarios: `bind-run-boundary-terminal`, `retire-reset-destroy`, `staged_visibility_apply`, `turn_interrupt_and_shutdown`, `peer_reachability_probe`
+  - anchors: `meerkat_machine`
+  - scenarios: `ops_completion_and_waiters`, `realtime_connection_projection`, `product_turn_streaming`
 - `CallStartedRunning`
-  - anchors: `meerkat_machine`, `meerkat_public_surface`, `peer_directory_reachability_authority`
-  - scenarios: `bind-run-boundary-terminal`, `retire-reset-destroy`, `staged_visibility_apply`, `turn_interrupt_and_shutdown`, `peer_reachability_probe`
+  - anchors: `meerkat_machine`
+  - scenarios: `turn_interrupt_and_shutdown`, `ops_completion_and_waiters`, `product_turn_streaming`
 - `CallFinishedAttached`
-  - anchors: `meerkat_machine`, `meerkat_public_surface`, `peer_directory_reachability_authority`
-  - scenarios: `bind-run-boundary-terminal`, `retire-reset-destroy`, `staged_visibility_apply`, `turn_interrupt_and_shutdown`, `peer_reachability_probe`
+  - anchors: `meerkat_machine`
+  - scenarios: `ops_completion_and_waiters`, `realtime_connection_projection`
 - `CallFinishedRunning`
-  - anchors: `meerkat_machine`, `meerkat_public_surface`, `peer_directory_reachability_authority`
-  - scenarios: `bind-run-boundary-terminal`, `retire-reset-destroy`, `staged_visibility_apply`, `turn_interrupt_and_shutdown`, `peer_reachability_probe`
+  - anchors: `meerkat_machine`
+  - scenarios: `turn_interrupt_and_shutdown`, `ops_completion_and_waiters`
 - `FinalizeRemovalCleanAttached`
-  - anchors: `meerkat_machine`, `meerkat_public_surface`, `peer_directory_reachability_authority`
-  - scenarios: `bind-run-boundary-terminal`, `retire-reset-destroy`, `staged_visibility_apply`, `turn_interrupt_and_shutdown`, `peer_reachability_probe`
+  - anchors: `meerkat_machine`
+  - scenarios: `realtime_connection_projection`
 - `FinalizeRemovalCleanRunning`
-  - anchors: `meerkat_machine`, `meerkat_public_surface`, `peer_directory_reachability_authority`
-  - scenarios: `bind-run-boundary-terminal`, `retire-reset-destroy`, `staged_visibility_apply`, `turn_interrupt_and_shutdown`, `peer_reachability_probe`
+  - anchors: `meerkat_machine`
+  - scenarios: `turn_interrupt_and_shutdown`
 - `FinalizeRemovalForcedAttached`
-  - anchors: `meerkat_machine`, `meerkat_public_surface`, `peer_directory_reachability_authority`
-  - scenarios: `bind-run-boundary-terminal`, `retire-reset-destroy`, `staged_visibility_apply`, `turn_interrupt_and_shutdown`, `peer_reachability_probe`
+  - anchors: `meerkat_machine`
+  - scenarios: `realtime_connection_projection`
 - `FinalizeRemovalForcedRunning`
-  - anchors: `meerkat_machine`, `meerkat_public_surface`, `peer_directory_reachability_authority`
-  - scenarios: `bind-run-boundary-terminal`, `retire-reset-destroy`, `staged_visibility_apply`, `turn_interrupt_and_shutdown`, `peer_reachability_probe`
+  - anchors: `meerkat_machine`
+  - scenarios: `turn_interrupt_and_shutdown`
 - `SnapshotAlignedAttached`
-  - anchors: `meerkat_machine`, `meerkat_public_surface`, `peer_directory_reachability_authority`
-  - scenarios: `bind-run-boundary-terminal`, `retire-reset-destroy`, `staged_visibility_apply`, `turn_interrupt_and_shutdown`, `peer_reachability_probe`
+  - anchors: `meerkat_public_surface`
+  - scenarios: `realtime_connection_projection`
 - `SnapshotAlignedRunning`
-  - anchors: `meerkat_machine`, `meerkat_public_surface`, `peer_directory_reachability_authority`
-  - scenarios: `bind-run-boundary-terminal`, `retire-reset-destroy`, `staged_visibility_apply`, `turn_interrupt_and_shutdown`, `peer_reachability_probe`
+  - anchors: `meerkat_public_surface`
+  - scenarios: `turn_interrupt_and_shutdown`
 - `ShutdownSurfaceAttached`
-  - anchors: `meerkat_machine`, `meerkat_public_surface`, `peer_directory_reachability_authority`
-  - scenarios: `bind-run-boundary-terminal`, `retire-reset-destroy`, `staged_visibility_apply`, `turn_interrupt_and_shutdown`, `peer_reachability_probe`
+  - anchors: `meerkat_machine`, `meerkat_public_surface`
+  - scenarios: `turn_interrupt_and_shutdown`, `ops_completion_and_waiters`, `realtime_connection_projection`
 - `ShutdownSurfaceRunning`
-  - anchors: `meerkat_machine`, `meerkat_public_surface`, `peer_directory_reachability_authority`
-  - scenarios: `bind-run-boundary-terminal`, `retire-reset-destroy`, `staged_visibility_apply`, `turn_interrupt_and_shutdown`, `peer_reachability_probe`
+  - anchors: `meerkat_machine`, `meerkat_public_surface`
+  - scenarios: `turn_interrupt_and_shutdown`
 - `RecycleFromIdleOrRetired`
-  - anchors: `meerkat_machine`, `meerkat_public_surface`, `peer_directory_reachability_authority`
-  - scenarios: `bind-run-boundary-terminal`, `retire-reset-destroy`, `staged_visibility_apply`, `turn_interrupt_and_shutdown`, `peer_reachability_probe`
+  - anchors: `meerkat_machine`
+  - scenarios: `recycle_and_compaction`
 - `RecycleFromAttached`
-  - anchors: `meerkat_machine`, `meerkat_public_surface`, `peer_directory_reachability_authority`
-  - scenarios: `bind-run-boundary-terminal`, `retire-reset-destroy`, `staged_visibility_apply`, `turn_interrupt_and_shutdown`, `peer_reachability_probe`
+  - anchors: `meerkat_machine`
+  - scenarios: `recycle_and_compaction`
 - `ProjectRealtimeIntentIdle`
-  - anchors: `meerkat_machine`, `meerkat_public_surface`, `peer_directory_reachability_authority`
-  - scenarios: `bind-run-boundary-terminal`, `retire-reset-destroy`, `staged_visibility_apply`, `turn_interrupt_and_shutdown`, `peer_reachability_probe`
+  - anchors: `meerkat_machine`
+  - scenarios: `realtime_connection_projection`
 - `ProjectRealtimeIntentAttached`
-  - anchors: `meerkat_machine`, `meerkat_public_surface`, `peer_directory_reachability_authority`
-  - scenarios: `bind-run-boundary-terminal`, `retire-reset-destroy`, `staged_visibility_apply`, `turn_interrupt_and_shutdown`, `peer_reachability_probe`
+  - anchors: `meerkat_machine`
+  - scenarios: `realtime_connection_projection`
 - `ProjectRealtimeIntentRunning`
-  - anchors: `meerkat_machine`, `meerkat_public_surface`, `peer_directory_reachability_authority`
-  - scenarios: `bind-run-boundary-terminal`, `retire-reset-destroy`, `staged_visibility_apply`, `turn_interrupt_and_shutdown`, `peer_reachability_probe`
+  - anchors: `meerkat_machine`
+  - scenarios: `realtime_connection_projection`
 - `ProjectRealtimeIntentRetired`
-  - anchors: `meerkat_machine`, `meerkat_public_surface`, `peer_directory_reachability_authority`
-  - scenarios: `bind-run-boundary-terminal`, `retire-reset-destroy`, `staged_visibility_apply`, `turn_interrupt_and_shutdown`, `peer_reachability_probe`
+  - anchors: `meerkat_machine`
+  - scenarios: `realtime_connection_projection`
 - `ProjectRealtimeIntentStopped`
-  - anchors: `meerkat_machine`, `meerkat_public_surface`, `peer_directory_reachability_authority`
-  - scenarios: `bind-run-boundary-terminal`, `retire-reset-destroy`, `staged_visibility_apply`, `turn_interrupt_and_shutdown`, `peer_reachability_probe`
+  - anchors: `meerkat_machine`
+  - scenarios: `realtime_connection_projection`
 - `BeginRealtimeBindingIdle`
-  - anchors: `meerkat_machine`, `meerkat_public_surface`, `peer_directory_reachability_authority`
-  - scenarios: `bind-run-boundary-terminal`, `retire-reset-destroy`, `staged_visibility_apply`, `turn_interrupt_and_shutdown`, `peer_reachability_probe`
+  - anchors: `meerkat_machine`
+  - scenarios: `realtime_connection_projection`
 - `BeginRealtimeBindingAttached`
-  - anchors: `meerkat_machine`, `meerkat_public_surface`, `peer_directory_reachability_authority`
-  - scenarios: `bind-run-boundary-terminal`, `retire-reset-destroy`, `staged_visibility_apply`, `turn_interrupt_and_shutdown`, `peer_reachability_probe`
+  - anchors: `meerkat_machine`
+  - scenarios: `realtime_connection_projection`
 - `BeginRealtimeBindingRunning`
-  - anchors: `meerkat_machine`, `meerkat_public_surface`, `peer_directory_reachability_authority`
-  - scenarios: `bind-run-boundary-terminal`, `retire-reset-destroy`, `staged_visibility_apply`, `turn_interrupt_and_shutdown`, `peer_reachability_probe`
+  - anchors: `meerkat_machine`
+  - scenarios: `realtime_connection_projection`
 - `BeginRealtimeBindingRetired`
-  - anchors: `meerkat_machine`, `meerkat_public_surface`, `peer_directory_reachability_authority`
-  - scenarios: `bind-run-boundary-terminal`, `retire-reset-destroy`, `staged_visibility_apply`, `turn_interrupt_and_shutdown`, `peer_reachability_probe`
+  - anchors: `meerkat_machine`
+  - scenarios: `realtime_connection_projection`
 - `BeginRealtimeBindingStopped`
-  - anchors: `meerkat_machine`, `meerkat_public_surface`, `peer_directory_reachability_authority`
-  - scenarios: `bind-run-boundary-terminal`, `retire-reset-destroy`, `staged_visibility_apply`, `turn_interrupt_and_shutdown`, `peer_reachability_probe`
+  - anchors: `meerkat_machine`
+  - scenarios: `realtime_connection_projection`
 - `ReplaceRealtimeBindingIdle`
-  - anchors: `meerkat_machine`, `meerkat_public_surface`, `peer_directory_reachability_authority`
-  - scenarios: `bind-run-boundary-terminal`, `retire-reset-destroy`, `staged_visibility_apply`, `turn_interrupt_and_shutdown`, `peer_reachability_probe`
+  - anchors: `meerkat_machine`
+  - scenarios: `realtime_connection_projection`
 - `ReplaceRealtimeBindingAttached`
-  - anchors: `meerkat_machine`, `meerkat_public_surface`, `peer_directory_reachability_authority`
-  - scenarios: `bind-run-boundary-terminal`, `retire-reset-destroy`, `staged_visibility_apply`, `turn_interrupt_and_shutdown`, `peer_reachability_probe`
+  - anchors: `meerkat_machine`
+  - scenarios: `realtime_connection_projection`
 - `ReplaceRealtimeBindingRunning`
-  - anchors: `meerkat_machine`, `meerkat_public_surface`, `peer_directory_reachability_authority`
-  - scenarios: `bind-run-boundary-terminal`, `retire-reset-destroy`, `staged_visibility_apply`, `turn_interrupt_and_shutdown`, `peer_reachability_probe`
+  - anchors: `meerkat_machine`
+  - scenarios: `realtime_connection_projection`
 - `ReplaceRealtimeBindingRetired`
-  - anchors: `meerkat_machine`, `meerkat_public_surface`, `peer_directory_reachability_authority`
-  - scenarios: `bind-run-boundary-terminal`, `retire-reset-destroy`, `staged_visibility_apply`, `turn_interrupt_and_shutdown`, `peer_reachability_probe`
+  - anchors: `meerkat_machine`
+  - scenarios: `realtime_connection_projection`
 - `ReplaceRealtimeBindingStopped`
-  - anchors: `meerkat_machine`, `meerkat_public_surface`, `peer_directory_reachability_authority`
-  - scenarios: `bind-run-boundary-terminal`, `retire-reset-destroy`, `staged_visibility_apply`, `turn_interrupt_and_shutdown`, `peer_reachability_probe`
+  - anchors: `meerkat_machine`
+  - scenarios: `realtime_connection_projection`
 - `DetachRealtimeBindingIdle`
-  - anchors: `meerkat_machine`, `meerkat_public_surface`, `peer_directory_reachability_authority`
-  - scenarios: `bind-run-boundary-terminal`, `retire-reset-destroy`, `staged_visibility_apply`, `turn_interrupt_and_shutdown`, `peer_reachability_probe`
+  - anchors: `meerkat_machine`
+  - scenarios: `realtime_connection_projection`
 - `DetachRealtimeBindingAttached`
-  - anchors: `meerkat_machine`, `meerkat_public_surface`, `peer_directory_reachability_authority`
-  - scenarios: `bind-run-boundary-terminal`, `retire-reset-destroy`, `staged_visibility_apply`, `turn_interrupt_and_shutdown`, `peer_reachability_probe`
+  - anchors: `meerkat_machine`
+  - scenarios: `realtime_connection_projection`
 - `DetachRealtimeBindingRunning`
-  - anchors: `meerkat_machine`, `meerkat_public_surface`, `peer_directory_reachability_authority`
-  - scenarios: `bind-run-boundary-terminal`, `retire-reset-destroy`, `staged_visibility_apply`, `turn_interrupt_and_shutdown`, `peer_reachability_probe`
+  - anchors: `meerkat_machine`
+  - scenarios: `realtime_connection_projection`
 - `DetachRealtimeBindingRetired`
-  - anchors: `meerkat_machine`, `meerkat_public_surface`, `peer_directory_reachability_authority`
-  - scenarios: `bind-run-boundary-terminal`, `retire-reset-destroy`, `staged_visibility_apply`, `turn_interrupt_and_shutdown`, `peer_reachability_probe`
+  - anchors: `meerkat_machine`
+  - scenarios: `session_registration_and_binding`, `realtime_connection_projection`
 - `DetachRealtimeBindingStopped`
-  - anchors: `meerkat_machine`, `meerkat_public_surface`, `peer_directory_reachability_authority`
-  - scenarios: `bind-run-boundary-terminal`, `retire-reset-destroy`, `staged_visibility_apply`, `turn_interrupt_and_shutdown`, `peer_reachability_probe`
+  - anchors: `meerkat_machine`
+  - scenarios: `realtime_connection_projection`
 - `RequireRealtimeReattachIdle`
-  - anchors: `meerkat_machine`, `meerkat_public_surface`, `peer_directory_reachability_authority`
-  - scenarios: `bind-run-boundary-terminal`, `retire-reset-destroy`, `staged_visibility_apply`, `turn_interrupt_and_shutdown`, `peer_reachability_probe`
+  - anchors: `meerkat_machine`
+  - scenarios: `realtime_connection_projection`
 - `RequireRealtimeReattachAttached`
-  - anchors: `meerkat_machine`, `meerkat_public_surface`, `peer_directory_reachability_authority`
-  - scenarios: `bind-run-boundary-terminal`, `retire-reset-destroy`, `staged_visibility_apply`, `turn_interrupt_and_shutdown`, `peer_reachability_probe`
+  - anchors: `meerkat_machine`
+  - scenarios: `realtime_connection_projection`
 - `RequireRealtimeReattachRunning`
-  - anchors: `meerkat_machine`, `meerkat_public_surface`, `peer_directory_reachability_authority`
-  - scenarios: `bind-run-boundary-terminal`, `retire-reset-destroy`, `staged_visibility_apply`, `turn_interrupt_and_shutdown`, `peer_reachability_probe`
+  - anchors: `meerkat_machine`
+  - scenarios: `realtime_connection_projection`
 - `RequireRealtimeReattachRetired`
-  - anchors: `meerkat_machine`, `meerkat_public_surface`, `peer_directory_reachability_authority`
-  - scenarios: `bind-run-boundary-terminal`, `retire-reset-destroy`, `staged_visibility_apply`, `turn_interrupt_and_shutdown`, `peer_reachability_probe`
+  - anchors: `meerkat_machine`
+  - scenarios: `realtime_connection_projection`
 - `RequireRealtimeReattachStopped`
-  - anchors: `meerkat_machine`, `meerkat_public_surface`, `peer_directory_reachability_authority`
-  - scenarios: `bind-run-boundary-terminal`, `retire-reset-destroy`, `staged_visibility_apply`, `turn_interrupt_and_shutdown`, `peer_reachability_probe`
+  - anchors: `meerkat_machine`
+  - scenarios: `realtime_connection_projection`
 - `PublishRealtimeSignalIdle`
-  - anchors: `meerkat_machine`, `meerkat_public_surface`, `peer_directory_reachability_authority`
-  - scenarios: `bind-run-boundary-terminal`, `retire-reset-destroy`, `staged_visibility_apply`, `turn_interrupt_and_shutdown`, `peer_reachability_probe`
+  - anchors: `meerkat_machine`
+  - scenarios: `realtime_connection_projection`
 - `PublishRealtimeSignalAttached`
-  - anchors: `meerkat_machine`, `meerkat_public_surface`, `peer_directory_reachability_authority`
-  - scenarios: `bind-run-boundary-terminal`, `retire-reset-destroy`, `staged_visibility_apply`, `turn_interrupt_and_shutdown`, `peer_reachability_probe`
+  - anchors: `meerkat_machine`
+  - scenarios: `realtime_connection_projection`
 - `PublishRealtimeSignalRunning`
-  - anchors: `meerkat_machine`, `meerkat_public_surface`, `peer_directory_reachability_authority`
-  - scenarios: `bind-run-boundary-terminal`, `retire-reset-destroy`, `staged_visibility_apply`, `turn_interrupt_and_shutdown`, `peer_reachability_probe`
+  - anchors: `meerkat_machine`
+  - scenarios: `realtime_connection_projection`
 - `PublishRealtimeSignalRetired`
-  - anchors: `meerkat_machine`, `meerkat_public_surface`, `peer_directory_reachability_authority`
-  - scenarios: `bind-run-boundary-terminal`, `retire-reset-destroy`, `staged_visibility_apply`, `turn_interrupt_and_shutdown`, `peer_reachability_probe`
+  - anchors: `meerkat_machine`
+  - scenarios: `realtime_connection_projection`
 - `PublishRealtimeSignalStopped`
-  - anchors: `meerkat_machine`, `meerkat_public_surface`, `peer_directory_reachability_authority`
-  - scenarios: `bind-run-boundary-terminal`, `retire-reset-destroy`, `staged_visibility_apply`, `turn_interrupt_and_shutdown`, `peer_reachability_probe`
+  - anchors: `meerkat_machine`
+  - scenarios: `realtime_connection_projection`
 - `ProjectRealtimeReconnectProgressIdle`
-  - anchors: `meerkat_machine`, `meerkat_public_surface`, `peer_directory_reachability_authority`
-  - scenarios: `bind-run-boundary-terminal`, `retire-reset-destroy`, `staged_visibility_apply`, `turn_interrupt_and_shutdown`, `peer_reachability_probe`
+  - anchors: `meerkat_machine`
+  - scenarios: `realtime_connection_projection`
 - `ProjectRealtimeReconnectProgressAttached`
-  - anchors: `meerkat_machine`, `meerkat_public_surface`, `peer_directory_reachability_authority`
-  - scenarios: `bind-run-boundary-terminal`, `retire-reset-destroy`, `staged_visibility_apply`, `turn_interrupt_and_shutdown`, `peer_reachability_probe`
+  - anchors: `meerkat_machine`
+  - scenarios: `realtime_connection_projection`
 - `ProjectRealtimeReconnectProgressRunning`
-  - anchors: `meerkat_machine`, `meerkat_public_surface`, `peer_directory_reachability_authority`
-  - scenarios: `bind-run-boundary-terminal`, `retire-reset-destroy`, `staged_visibility_apply`, `turn_interrupt_and_shutdown`, `peer_reachability_probe`
+  - anchors: `meerkat_machine`
+  - scenarios: `realtime_connection_projection`
 - `ProjectRealtimeReconnectProgressRetired`
-  - anchors: `meerkat_machine`, `meerkat_public_surface`, `peer_directory_reachability_authority`
-  - scenarios: `bind-run-boundary-terminal`, `retire-reset-destroy`, `staged_visibility_apply`, `turn_interrupt_and_shutdown`, `peer_reachability_probe`
+  - anchors: `meerkat_machine`
+  - scenarios: `realtime_connection_projection`
 - `ProjectRealtimeReconnectProgressStopped`
-  - anchors: `meerkat_machine`, `meerkat_public_surface`, `peer_directory_reachability_authority`
-  - scenarios: `bind-run-boundary-terminal`, `retire-reset-destroy`, `staged_visibility_apply`, `turn_interrupt_and_shutdown`, `peer_reachability_probe`
+  - anchors: `meerkat_machine`
+  - scenarios: `realtime_connection_projection`
 - `ClearRealtimeReconnectProgressIdle`
-  - anchors: `meerkat_machine`, `meerkat_public_surface`, `peer_directory_reachability_authority`
-  - scenarios: `bind-run-boundary-terminal`, `retire-reset-destroy`, `staged_visibility_apply`, `turn_interrupt_and_shutdown`, `peer_reachability_probe`
+  - anchors: `meerkat_machine`
+  - scenarios: `realtime_connection_projection`
 - `ClearRealtimeReconnectProgressAttached`
-  - anchors: `meerkat_machine`, `meerkat_public_surface`, `peer_directory_reachability_authority`
-  - scenarios: `bind-run-boundary-terminal`, `retire-reset-destroy`, `staged_visibility_apply`, `turn_interrupt_and_shutdown`, `peer_reachability_probe`
+  - anchors: `meerkat_machine`
+  - scenarios: `realtime_connection_projection`
 - `ClearRealtimeReconnectProgressRunning`
-  - anchors: `meerkat_machine`, `meerkat_public_surface`, `peer_directory_reachability_authority`
-  - scenarios: `bind-run-boundary-terminal`, `retire-reset-destroy`, `staged_visibility_apply`, `turn_interrupt_and_shutdown`, `peer_reachability_probe`
+  - anchors: `meerkat_machine`
+  - scenarios: `realtime_connection_projection`
 - `ClearRealtimeReconnectProgressRetired`
-  - anchors: `meerkat_machine`, `meerkat_public_surface`, `peer_directory_reachability_authority`
-  - scenarios: `bind-run-boundary-terminal`, `retire-reset-destroy`, `staged_visibility_apply`, `turn_interrupt_and_shutdown`, `peer_reachability_probe`
+  - anchors: `meerkat_machine`
+  - scenarios: `realtime_connection_projection`
 - `ClearRealtimeReconnectProgressStopped`
-  - anchors: `meerkat_machine`, `meerkat_public_surface`, `peer_directory_reachability_authority`
-  - scenarios: `bind-run-boundary-terminal`, `retire-reset-destroy`, `staged_visibility_apply`, `turn_interrupt_and_shutdown`, `peer_reachability_probe`
+  - anchors: `meerkat_machine`
+  - scenarios: `realtime_connection_projection`
 - `McpServerConnectPendingIdle`
-  - anchors: `meerkat_machine`, `meerkat_public_surface`, `peer_directory_reachability_authority`
-  - scenarios: `bind-run-boundary-terminal`, `retire-reset-destroy`, `staged_visibility_apply`, `turn_interrupt_and_shutdown`, `peer_reachability_probe`
+  - anchors: `meerkat_machine`
+  - scenarios: `realtime_connection_projection`
 - `McpServerConnectPendingAttached`
-  - anchors: `meerkat_machine`, `meerkat_public_surface`, `peer_directory_reachability_authority`
-  - scenarios: `bind-run-boundary-terminal`, `retire-reset-destroy`, `staged_visibility_apply`, `turn_interrupt_and_shutdown`, `peer_reachability_probe`
+  - anchors: `meerkat_machine`
+  - scenarios: `realtime_connection_projection`
 - `McpServerConnectPendingRunning`
-  - anchors: `meerkat_machine`, `meerkat_public_surface`, `peer_directory_reachability_authority`
-  - scenarios: `bind-run-boundary-terminal`, `retire-reset-destroy`, `staged_visibility_apply`, `turn_interrupt_and_shutdown`, `peer_reachability_probe`
+  - anchors: `meerkat_machine`
+  - scenarios: `realtime_connection_projection`
 - `McpServerConnectPendingRetired`
-  - anchors: `meerkat_machine`, `meerkat_public_surface`, `peer_directory_reachability_authority`
-  - scenarios: `bind-run-boundary-terminal`, `retire-reset-destroy`, `staged_visibility_apply`, `turn_interrupt_and_shutdown`, `peer_reachability_probe`
+  - anchors: `meerkat_machine`
+  - scenarios: `realtime_connection_projection`
 - `McpServerConnectPendingStopped`
-  - anchors: `meerkat_machine`, `meerkat_public_surface`, `peer_directory_reachability_authority`
-  - scenarios: `bind-run-boundary-terminal`, `retire-reset-destroy`, `staged_visibility_apply`, `turn_interrupt_and_shutdown`, `peer_reachability_probe`
+  - anchors: `meerkat_machine`
+  - scenarios: `realtime_connection_projection`
 - `McpServerConnectedIdle`
-  - anchors: `meerkat_machine`, `meerkat_public_surface`, `peer_directory_reachability_authority`
-  - scenarios: `bind-run-boundary-terminal`, `retire-reset-destroy`, `staged_visibility_apply`, `turn_interrupt_and_shutdown`, `peer_reachability_probe`
+  - anchors: `meerkat_machine`
+  - scenarios: `realtime_connection_projection`
 - `McpServerConnectedAttached`
-  - anchors: `meerkat_machine`, `meerkat_public_surface`, `peer_directory_reachability_authority`
-  - scenarios: `bind-run-boundary-terminal`, `retire-reset-destroy`, `staged_visibility_apply`, `turn_interrupt_and_shutdown`, `peer_reachability_probe`
+  - anchors: `meerkat_machine`
+  - scenarios: `realtime_connection_projection`
 - `McpServerConnectedRunning`
-  - anchors: `meerkat_machine`, `meerkat_public_surface`, `peer_directory_reachability_authority`
-  - scenarios: `bind-run-boundary-terminal`, `retire-reset-destroy`, `staged_visibility_apply`, `turn_interrupt_and_shutdown`, `peer_reachability_probe`
+  - anchors: `meerkat_machine`
+  - scenarios: `realtime_connection_projection`
 - `McpServerConnectedRetired`
-  - anchors: `meerkat_machine`, `meerkat_public_surface`, `peer_directory_reachability_authority`
-  - scenarios: `bind-run-boundary-terminal`, `retire-reset-destroy`, `staged_visibility_apply`, `turn_interrupt_and_shutdown`, `peer_reachability_probe`
+  - anchors: `meerkat_machine`
+  - scenarios: `realtime_connection_projection`
 - `McpServerConnectedStopped`
-  - anchors: `meerkat_machine`, `meerkat_public_surface`, `peer_directory_reachability_authority`
-  - scenarios: `bind-run-boundary-terminal`, `retire-reset-destroy`, `staged_visibility_apply`, `turn_interrupt_and_shutdown`, `peer_reachability_probe`
+  - anchors: `meerkat_machine`
+  - scenarios: `realtime_connection_projection`
 - `McpServerFailedIdle`
-  - anchors: `meerkat_machine`, `meerkat_public_surface`, `peer_directory_reachability_authority`
-  - scenarios: `bind-run-boundary-terminal`, `retire-reset-destroy`, `staged_visibility_apply`, `turn_interrupt_and_shutdown`, `peer_reachability_probe`
+  - anchors: `meerkat_machine`
+  - scenarios: `realtime_connection_projection`
 - `McpServerFailedAttached`
-  - anchors: `meerkat_machine`, `meerkat_public_surface`, `peer_directory_reachability_authority`
-  - scenarios: `bind-run-boundary-terminal`, `retire-reset-destroy`, `staged_visibility_apply`, `turn_interrupt_and_shutdown`, `peer_reachability_probe`
+  - anchors: `meerkat_machine`
+  - scenarios: `realtime_connection_projection`
 - `McpServerFailedRunning`
-  - anchors: `meerkat_machine`, `meerkat_public_surface`, `peer_directory_reachability_authority`
-  - scenarios: `bind-run-boundary-terminal`, `retire-reset-destroy`, `staged_visibility_apply`, `turn_interrupt_and_shutdown`, `peer_reachability_probe`
+  - anchors: `meerkat_machine`
+  - scenarios: `realtime_connection_projection`
 - `McpServerFailedRetired`
-  - anchors: `meerkat_machine`, `meerkat_public_surface`, `peer_directory_reachability_authority`
-  - scenarios: `bind-run-boundary-terminal`, `retire-reset-destroy`, `staged_visibility_apply`, `turn_interrupt_and_shutdown`, `peer_reachability_probe`
+  - anchors: `meerkat_machine`
+  - scenarios: `realtime_connection_projection`
 - `McpServerFailedStopped`
-  - anchors: `meerkat_machine`, `meerkat_public_surface`, `peer_directory_reachability_authority`
-  - scenarios: `bind-run-boundary-terminal`, `retire-reset-destroy`, `staged_visibility_apply`, `turn_interrupt_and_shutdown`, `peer_reachability_probe`
+  - anchors: `meerkat_machine`
+  - scenarios: `realtime_connection_projection`
 - `McpServerDisconnectedIdle`
-  - anchors: `meerkat_machine`, `meerkat_public_surface`, `peer_directory_reachability_authority`
-  - scenarios: `bind-run-boundary-terminal`, `retire-reset-destroy`, `staged_visibility_apply`, `turn_interrupt_and_shutdown`, `peer_reachability_probe`
+  - anchors: `meerkat_machine`
+  - scenarios: `realtime_connection_projection`
 - `McpServerDisconnectedAttached`
-  - anchors: `meerkat_machine`, `meerkat_public_surface`, `peer_directory_reachability_authority`
-  - scenarios: `bind-run-boundary-terminal`, `retire-reset-destroy`, `staged_visibility_apply`, `turn_interrupt_and_shutdown`, `peer_reachability_probe`
+  - anchors: `meerkat_machine`
+  - scenarios: `realtime_connection_projection`
 - `McpServerDisconnectedRunning`
-  - anchors: `meerkat_machine`, `meerkat_public_surface`, `peer_directory_reachability_authority`
-  - scenarios: `bind-run-boundary-terminal`, `retire-reset-destroy`, `staged_visibility_apply`, `turn_interrupt_and_shutdown`, `peer_reachability_probe`
+  - anchors: `meerkat_machine`
+  - scenarios: `realtime_connection_projection`
 - `McpServerDisconnectedRetired`
-  - anchors: `meerkat_machine`, `meerkat_public_surface`, `peer_directory_reachability_authority`
-  - scenarios: `bind-run-boundary-terminal`, `retire-reset-destroy`, `staged_visibility_apply`, `turn_interrupt_and_shutdown`, `peer_reachability_probe`
+  - anchors: `meerkat_machine`
+  - scenarios: `realtime_connection_projection`
 - `McpServerDisconnectedStopped`
-  - anchors: `meerkat_machine`, `meerkat_public_surface`, `peer_directory_reachability_authority`
-  - scenarios: `bind-run-boundary-terminal`, `retire-reset-destroy`, `staged_visibility_apply`, `turn_interrupt_and_shutdown`, `peer_reachability_probe`
+  - anchors: `meerkat_machine`
+  - scenarios: `realtime_connection_projection`
 - `McpServerReloadIdle`
-  - anchors: `meerkat_machine`, `meerkat_public_surface`, `peer_directory_reachability_authority`
-  - scenarios: `bind-run-boundary-terminal`, `retire-reset-destroy`, `staged_visibility_apply`, `turn_interrupt_and_shutdown`, `peer_reachability_probe`
+  - anchors: `meerkat_machine`
+  - scenarios: `realtime_connection_projection`
 - `McpServerReloadAttached`
-  - anchors: `meerkat_machine`, `meerkat_public_surface`, `peer_directory_reachability_authority`
-  - scenarios: `bind-run-boundary-terminal`, `retire-reset-destroy`, `staged_visibility_apply`, `turn_interrupt_and_shutdown`, `peer_reachability_probe`
+  - anchors: `meerkat_machine`
+  - scenarios: `realtime_connection_projection`
 - `McpServerReloadRunning`
-  - anchors: `meerkat_machine`, `meerkat_public_surface`, `peer_directory_reachability_authority`
-  - scenarios: `bind-run-boundary-terminal`, `retire-reset-destroy`, `staged_visibility_apply`, `turn_interrupt_and_shutdown`, `peer_reachability_probe`
+  - anchors: `meerkat_machine`
+  - scenarios: `realtime_connection_projection`
 - `McpServerReloadRetired`
-  - anchors: `meerkat_machine`, `meerkat_public_surface`, `peer_directory_reachability_authority`
-  - scenarios: `bind-run-boundary-terminal`, `retire-reset-destroy`, `staged_visibility_apply`, `turn_interrupt_and_shutdown`, `peer_reachability_probe`
+  - anchors: `meerkat_machine`
+  - scenarios: `realtime_connection_projection`
 - `McpServerReloadStopped`
-  - anchors: `meerkat_machine`, `meerkat_public_surface`, `peer_directory_reachability_authority`
-  - scenarios: `bind-run-boundary-terminal`, `retire-reset-destroy`, `staged_visibility_apply`, `turn_interrupt_and_shutdown`, `peer_reachability_probe`
+  - anchors: `meerkat_machine`
+  - scenarios: `realtime_connection_projection`
 - `PeerRequestSentIdle`
-  - anchors: `meerkat_machine`, `meerkat_public_surface`, `peer_directory_reachability_authority`
-  - scenarios: `bind-run-boundary-terminal`, `retire-reset-destroy`, `staged_visibility_apply`, `turn_interrupt_and_shutdown`, `peer_reachability_probe`
+  - anchors: `peer_directory_reachability_authority`
+  - scenarios: `peer_reachability_probe`, `ops_completion_and_waiters`, `recycle_and_compaction`
 - `PeerRequestSentAttached`
-  - anchors: `meerkat_machine`, `meerkat_public_surface`, `peer_directory_reachability_authority`
-  - scenarios: `bind-run-boundary-terminal`, `retire-reset-destroy`, `staged_visibility_apply`, `turn_interrupt_and_shutdown`, `peer_reachability_probe`
+  - anchors: `peer_directory_reachability_authority`
+  - scenarios: `peer_reachability_probe`, `ops_completion_and_waiters`, `realtime_connection_projection`
 - `PeerRequestSentRunning`
-  - anchors: `meerkat_machine`, `meerkat_public_surface`, `peer_directory_reachability_authority`
-  - scenarios: `bind-run-boundary-terminal`, `retire-reset-destroy`, `staged_visibility_apply`, `turn_interrupt_and_shutdown`, `peer_reachability_probe`
+  - anchors: `peer_directory_reachability_authority`
+  - scenarios: `turn_interrupt_and_shutdown`, `peer_reachability_probe`, `ops_completion_and_waiters`
 - `PeerRequestSentRetired`
-  - anchors: `meerkat_machine`, `meerkat_public_surface`, `peer_directory_reachability_authority`
-  - scenarios: `bind-run-boundary-terminal`, `retire-reset-destroy`, `staged_visibility_apply`, `turn_interrupt_and_shutdown`, `peer_reachability_probe`
+  - anchors: `meerkat_machine`, `peer_directory_reachability_authority`
+  - scenarios: `peer_reachability_probe`, `session_registration_and_binding`, `ops_completion_and_waiters`, `recycle_and_compaction`
 - `PeerRequestSentStopped`
-  - anchors: `meerkat_machine`, `meerkat_public_surface`, `peer_directory_reachability_authority`
-  - scenarios: `bind-run-boundary-terminal`, `retire-reset-destroy`, `staged_visibility_apply`, `turn_interrupt_and_shutdown`, `peer_reachability_probe`
+  - anchors: `meerkat_machine`, `peer_directory_reachability_authority`
+  - scenarios: `peer_reachability_probe`, `ops_completion_and_waiters`
 - `PeerResponseProgressArrivedIdle`
-  - anchors: `meerkat_machine`, `meerkat_public_surface`, `peer_directory_reachability_authority`
-  - scenarios: `bind-run-boundary-terminal`, `retire-reset-destroy`, `staged_visibility_apply`, `turn_interrupt_and_shutdown`, `peer_reachability_probe`
+  - anchors: `peer_directory_reachability_authority`
+  - scenarios: `peer_reachability_probe`, `realtime_connection_projection`, `recycle_and_compaction`
 - `PeerResponseProgressArrivedAttached`
-  - anchors: `meerkat_machine`, `meerkat_public_surface`, `peer_directory_reachability_authority`
-  - scenarios: `bind-run-boundary-terminal`, `retire-reset-destroy`, `staged_visibility_apply`, `turn_interrupt_and_shutdown`, `peer_reachability_probe`
+  - anchors: `peer_directory_reachability_authority`
+  - scenarios: `realtime_connection_projection`
 - `PeerResponseProgressArrivedRunning`
-  - anchors: `meerkat_machine`, `meerkat_public_surface`, `peer_directory_reachability_authority`
-  - scenarios: `bind-run-boundary-terminal`, `retire-reset-destroy`, `staged_visibility_apply`, `turn_interrupt_and_shutdown`, `peer_reachability_probe`
+  - anchors: `peer_directory_reachability_authority`
+  - scenarios: `turn_interrupt_and_shutdown`, `peer_reachability_probe`, `realtime_connection_projection`
 - `PeerResponseProgressArrivedRetired`
-  - anchors: `meerkat_machine`, `meerkat_public_surface`, `peer_directory_reachability_authority`
-  - scenarios: `bind-run-boundary-terminal`, `retire-reset-destroy`, `staged_visibility_apply`, `turn_interrupt_and_shutdown`, `peer_reachability_probe`
+  - anchors: `meerkat_machine`, `peer_directory_reachability_authority`
+  - scenarios: `peer_reachability_probe`, `session_registration_and_binding`, `realtime_connection_projection`, `recycle_and_compaction`
 - `PeerResponseProgressArrivedStopped`
-  - anchors: `meerkat_machine`, `meerkat_public_surface`, `peer_directory_reachability_authority`
-  - scenarios: `bind-run-boundary-terminal`, `retire-reset-destroy`, `staged_visibility_apply`, `turn_interrupt_and_shutdown`, `peer_reachability_probe`
+  - anchors: `meerkat_machine`, `peer_directory_reachability_authority`
+  - scenarios: `peer_reachability_probe`, `realtime_connection_projection`
 - `PeerResponseTerminalArrivedCompletedIdle`
-  - anchors: `meerkat_machine`, `meerkat_public_surface`, `peer_directory_reachability_authority`
-  - scenarios: `bind-run-boundary-terminal`, `retire-reset-destroy`, `staged_visibility_apply`, `turn_interrupt_and_shutdown`, `peer_reachability_probe`
+  - anchors: `meerkat_machine`, `peer_directory_reachability_authority`
+  - scenarios: `ops_completion_and_waiters`, `recycle_and_compaction`
 - `PeerResponseTerminalArrivedCompletedAttached`
-  - anchors: `meerkat_machine`, `meerkat_public_surface`, `peer_directory_reachability_authority`
-  - scenarios: `bind-run-boundary-terminal`, `retire-reset-destroy`, `staged_visibility_apply`, `turn_interrupt_and_shutdown`, `peer_reachability_probe`
+  - anchors: `meerkat_machine`, `peer_directory_reachability_authority`
+  - scenarios: `ops_completion_and_waiters`, `realtime_connection_projection`
 - `PeerResponseTerminalArrivedCompletedRunning`
-  - anchors: `meerkat_machine`, `meerkat_public_surface`, `peer_directory_reachability_authority`
-  - scenarios: `bind-run-boundary-terminal`, `retire-reset-destroy`, `staged_visibility_apply`, `turn_interrupt_and_shutdown`, `peer_reachability_probe`
+  - anchors: `meerkat_machine`, `peer_directory_reachability_authority`
+  - scenarios: `ops_completion_and_waiters`
 - `PeerResponseTerminalArrivedCompletedRetired`
-  - anchors: `meerkat_machine`, `meerkat_public_surface`, `peer_directory_reachability_authority`
-  - scenarios: `bind-run-boundary-terminal`, `retire-reset-destroy`, `staged_visibility_apply`, `turn_interrupt_and_shutdown`, `peer_reachability_probe`
+  - anchors: `meerkat_machine`
+  - scenarios: `ops_completion_and_waiters`, `recycle_and_compaction`
 - `PeerResponseTerminalArrivedCompletedStopped`
-  - anchors: `meerkat_machine`, `meerkat_public_surface`, `peer_directory_reachability_authority`
-  - scenarios: `bind-run-boundary-terminal`, `retire-reset-destroy`, `staged_visibility_apply`, `turn_interrupt_and_shutdown`, `peer_reachability_probe`
+  - anchors: `meerkat_machine`
+  - scenarios: `ops_completion_and_waiters`
 - `PeerResponseTerminalArrivedFailedIdle`
-  - anchors: `meerkat_machine`, `meerkat_public_surface`, `peer_directory_reachability_authority`
-  - scenarios: `bind-run-boundary-terminal`, `retire-reset-destroy`, `staged_visibility_apply`, `turn_interrupt_and_shutdown`, `peer_reachability_probe`
+  - anchors: `meerkat_machine`, `peer_directory_reachability_authority`
+  - scenarios: `bind-run-boundary-terminal`, `peer_reachability_probe`, `ops_completion_and_waiters`, `realtime_connection_projection`, `product_turn_streaming`, `recycle_and_compaction`
 - `PeerResponseTerminalArrivedFailedAttached`
-  - anchors: `meerkat_machine`, `meerkat_public_surface`, `peer_directory_reachability_authority`
-  - scenarios: `bind-run-boundary-terminal`, `retire-reset-destroy`, `staged_visibility_apply`, `turn_interrupt_and_shutdown`, `peer_reachability_probe`
+  - anchors: `meerkat_machine`, `peer_directory_reachability_authority`
+  - scenarios: `realtime_connection_projection`
 - `PeerResponseTerminalArrivedFailedRunning`
-  - anchors: `meerkat_machine`, `meerkat_public_surface`, `peer_directory_reachability_authority`
-  - scenarios: `bind-run-boundary-terminal`, `retire-reset-destroy`, `staged_visibility_apply`, `turn_interrupt_and_shutdown`, `peer_reachability_probe`
+  - anchors: `meerkat_machine`, `peer_directory_reachability_authority`
+  - scenarios: `bind-run-boundary-terminal`, `turn_interrupt_and_shutdown`, `peer_reachability_probe`, `ops_completion_and_waiters`, `realtime_connection_projection`, `product_turn_streaming`
 - `PeerResponseTerminalArrivedFailedRetired`
-  - anchors: `meerkat_machine`, `meerkat_public_surface`, `peer_directory_reachability_authority`
-  - scenarios: `bind-run-boundary-terminal`, `retire-reset-destroy`, `staged_visibility_apply`, `turn_interrupt_and_shutdown`, `peer_reachability_probe`
+  - anchors: `meerkat_machine`
+  - scenarios: `bind-run-boundary-terminal`, `peer_reachability_probe`, `session_registration_and_binding`, `ops_completion_and_waiters`, `realtime_connection_projection`, `product_turn_streaming`, `recycle_and_compaction`
 - `PeerResponseTerminalArrivedFailedStopped`
-  - anchors: `meerkat_machine`, `meerkat_public_surface`, `peer_directory_reachability_authority`
-  - scenarios: `bind-run-boundary-terminal`, `retire-reset-destroy`, `staged_visibility_apply`, `turn_interrupt_and_shutdown`, `peer_reachability_probe`
+  - anchors: `meerkat_machine`
+  - scenarios: `bind-run-boundary-terminal`, `peer_reachability_probe`, `ops_completion_and_waiters`, `realtime_connection_projection`, `product_turn_streaming`
 - `PeerRequestTimedOutIdle`
-  - anchors: `meerkat_machine`, `meerkat_public_surface`, `peer_directory_reachability_authority`
-  - scenarios: `bind-run-boundary-terminal`, `retire-reset-destroy`, `staged_visibility_apply`, `turn_interrupt_and_shutdown`, `peer_reachability_probe`
+  - anchors: `peer_directory_reachability_authority`
+  - scenarios: `peer_reachability_probe`, `recycle_and_compaction`
 - `PeerRequestTimedOutAttached`
-  - anchors: `meerkat_machine`, `meerkat_public_surface`, `peer_directory_reachability_authority`
-  - scenarios: `bind-run-boundary-terminal`, `retire-reset-destroy`, `staged_visibility_apply`, `turn_interrupt_and_shutdown`, `peer_reachability_probe`
+  - anchors: `peer_directory_reachability_authority`
+  - scenarios: `peer_reachability_probe`
 - `PeerRequestTimedOutRunning`
-  - anchors: `meerkat_machine`, `meerkat_public_surface`, `peer_directory_reachability_authority`
-  - scenarios: `bind-run-boundary-terminal`, `retire-reset-destroy`, `staged_visibility_apply`, `turn_interrupt_and_shutdown`, `peer_reachability_probe`
+  - anchors: `peer_directory_reachability_authority`
+  - scenarios: `turn_interrupt_and_shutdown`, `peer_reachability_probe`
 - `PeerRequestTimedOutRetired`
-  - anchors: `meerkat_machine`, `meerkat_public_surface`, `peer_directory_reachability_authority`
-  - scenarios: `bind-run-boundary-terminal`, `retire-reset-destroy`, `staged_visibility_apply`, `turn_interrupt_and_shutdown`, `peer_reachability_probe`
+  - anchors: `meerkat_machine`, `peer_directory_reachability_authority`
+  - scenarios: `peer_reachability_probe`, `recycle_and_compaction`
 - `PeerRequestTimedOutStopped`
-  - anchors: `meerkat_machine`, `meerkat_public_surface`, `peer_directory_reachability_authority`
-  - scenarios: `bind-run-boundary-terminal`, `retire-reset-destroy`, `staged_visibility_apply`, `turn_interrupt_and_shutdown`, `peer_reachability_probe`
+  - anchors: `meerkat_machine`, `peer_directory_reachability_authority`
+  - scenarios: `peer_reachability_probe`
 - `PeerRequestReceivedIdle`
-  - anchors: `meerkat_machine`, `meerkat_public_surface`, `peer_directory_reachability_authority`
-  - scenarios: `bind-run-boundary-terminal`, `retire-reset-destroy`, `staged_visibility_apply`, `turn_interrupt_and_shutdown`, `peer_reachability_probe`
+  - anchors: `peer_directory_reachability_authority`
+  - scenarios: `peer_reachability_probe`, `ops_completion_and_waiters`, `recycle_and_compaction`
 - `PeerRequestReceivedAttached`
-  - anchors: `meerkat_machine`, `meerkat_public_surface`, `peer_directory_reachability_authority`
-  - scenarios: `bind-run-boundary-terminal`, `retire-reset-destroy`, `staged_visibility_apply`, `turn_interrupt_and_shutdown`, `peer_reachability_probe`
+  - anchors: `peer_directory_reachability_authority`
+  - scenarios: `peer_reachability_probe`, `ops_completion_and_waiters`, `realtime_connection_projection`
 - `PeerRequestReceivedRunning`
-  - anchors: `meerkat_machine`, `meerkat_public_surface`, `peer_directory_reachability_authority`
-  - scenarios: `bind-run-boundary-terminal`, `retire-reset-destroy`, `staged_visibility_apply`, `turn_interrupt_and_shutdown`, `peer_reachability_probe`
+  - anchors: `peer_directory_reachability_authority`
+  - scenarios: `turn_interrupt_and_shutdown`, `peer_reachability_probe`, `ops_completion_and_waiters`
 - `PeerRequestReceivedRetired`
-  - anchors: `meerkat_machine`, `meerkat_public_surface`, `peer_directory_reachability_authority`
-  - scenarios: `bind-run-boundary-terminal`, `retire-reset-destroy`, `staged_visibility_apply`, `turn_interrupt_and_shutdown`, `peer_reachability_probe`
+  - anchors: `meerkat_machine`, `peer_directory_reachability_authority`
+  - scenarios: `peer_reachability_probe`, `session_registration_and_binding`, `ops_completion_and_waiters`, `recycle_and_compaction`
 - `PeerRequestReceivedStopped`
-  - anchors: `meerkat_machine`, `meerkat_public_surface`, `peer_directory_reachability_authority`
-  - scenarios: `bind-run-boundary-terminal`, `retire-reset-destroy`, `staged_visibility_apply`, `turn_interrupt_and_shutdown`, `peer_reachability_probe`
+  - anchors: `meerkat_machine`, `peer_directory_reachability_authority`
+  - scenarios: `peer_reachability_probe`, `ops_completion_and_waiters`
 - `PeerResponseRepliedIdle`
-  - anchors: `meerkat_machine`, `meerkat_public_surface`, `peer_directory_reachability_authority`
-  - scenarios: `bind-run-boundary-terminal`, `retire-reset-destroy`, `staged_visibility_apply`, `turn_interrupt_and_shutdown`, `peer_reachability_probe`
+  - anchors: `peer_directory_reachability_authority`
+  - scenarios: `peer_reachability_probe`, `recycle_and_compaction`
 - `PeerResponseRepliedAttached`
-  - anchors: `meerkat_machine`, `meerkat_public_surface`, `peer_directory_reachability_authority`
-  - scenarios: `bind-run-boundary-terminal`, `retire-reset-destroy`, `staged_visibility_apply`, `turn_interrupt_and_shutdown`, `peer_reachability_probe`
+  - anchors: `peer_directory_reachability_authority`
+  - scenarios: `peer_reachability_probe`, `realtime_connection_projection`
 - `PeerResponseRepliedRunning`
-  - anchors: `meerkat_machine`, `meerkat_public_surface`, `peer_directory_reachability_authority`
-  - scenarios: `bind-run-boundary-terminal`, `retire-reset-destroy`, `staged_visibility_apply`, `turn_interrupt_and_shutdown`, `peer_reachability_probe`
+  - anchors: `peer_directory_reachability_authority`
+  - scenarios: `turn_interrupt_and_shutdown`, `peer_reachability_probe`
 - `PeerResponseRepliedRetired`
-  - anchors: `meerkat_machine`, `meerkat_public_surface`, `peer_directory_reachability_authority`
-  - scenarios: `bind-run-boundary-terminal`, `retire-reset-destroy`, `staged_visibility_apply`, `turn_interrupt_and_shutdown`, `peer_reachability_probe`
+  - anchors: `meerkat_machine`, `peer_directory_reachability_authority`
+  - scenarios: `peer_reachability_probe`, `session_registration_and_binding`, `recycle_and_compaction`
 - `PeerResponseRepliedStopped`
-  - anchors: `meerkat_machine`, `meerkat_public_surface`, `peer_directory_reachability_authority`
-  - scenarios: `bind-run-boundary-terminal`, `retire-reset-destroy`, `staged_visibility_apply`, `turn_interrupt_and_shutdown`, `peer_reachability_probe`
+  - anchors: `meerkat_machine`, `peer_directory_reachability_authority`
+  - scenarios: `peer_reachability_probe`
 - `AdvanceSessionContextIdle`
-  - anchors: `meerkat_machine`, `meerkat_public_surface`, `peer_directory_reachability_authority`
-  - scenarios: `bind-run-boundary-terminal`, `retire-reset-destroy`, `staged_visibility_apply`, `turn_interrupt_and_shutdown`, `peer_reachability_probe`
+  - anchors: `meerkat_machine`
+  - scenarios: `realtime_connection_projection`
 - `AdvanceSessionContextAttached`
-  - anchors: `meerkat_machine`, `meerkat_public_surface`, `peer_directory_reachability_authority`
-  - scenarios: `bind-run-boundary-terminal`, `retire-reset-destroy`, `staged_visibility_apply`, `turn_interrupt_and_shutdown`, `peer_reachability_probe`
+  - anchors: `meerkat_machine`
+  - scenarios: `realtime_connection_projection`
 - `AdvanceSessionContextRunning`
-  - anchors: `meerkat_machine`, `meerkat_public_surface`, `peer_directory_reachability_authority`
-  - scenarios: `bind-run-boundary-terminal`, `retire-reset-destroy`, `staged_visibility_apply`, `turn_interrupt_and_shutdown`, `peer_reachability_probe`
+  - anchors: `meerkat_machine`
+  - scenarios: `realtime_connection_projection`
 - `AdvanceSessionContextRetired`
-  - anchors: `meerkat_machine`, `meerkat_public_surface`, `peer_directory_reachability_authority`
-  - scenarios: `bind-run-boundary-terminal`, `retire-reset-destroy`, `staged_visibility_apply`, `turn_interrupt_and_shutdown`, `peer_reachability_probe`
+  - anchors: `meerkat_machine`
+  - scenarios: `realtime_connection_projection`
 - `AdvanceSessionContextStopped`
-  - anchors: `meerkat_machine`, `meerkat_public_surface`, `peer_directory_reachability_authority`
-  - scenarios: `bind-run-boundary-terminal`, `retire-reset-destroy`, `staged_visibility_apply`, `turn_interrupt_and_shutdown`, `peer_reachability_probe`
+  - anchors: `meerkat_machine`
+  - scenarios: `realtime_connection_projection`
 - `InteractionStreamReservedIdle`
-  - anchors: `meerkat_machine`, `meerkat_public_surface`, `peer_directory_reachability_authority`
-  - scenarios: `bind-run-boundary-terminal`, `retire-reset-destroy`, `staged_visibility_apply`, `turn_interrupt_and_shutdown`, `peer_reachability_probe`
+  - anchors: `meerkat_machine`
+  - scenarios: `realtime_connection_projection`
 - `InteractionStreamReservedAttached`
-  - anchors: `meerkat_machine`, `meerkat_public_surface`, `peer_directory_reachability_authority`
-  - scenarios: `bind-run-boundary-terminal`, `retire-reset-destroy`, `staged_visibility_apply`, `turn_interrupt_and_shutdown`, `peer_reachability_probe`
+  - anchors: `meerkat_machine`
+  - scenarios: `realtime_connection_projection`
 - `InteractionStreamReservedRunning`
-  - anchors: `meerkat_machine`, `meerkat_public_surface`, `peer_directory_reachability_authority`
-  - scenarios: `bind-run-boundary-terminal`, `retire-reset-destroy`, `staged_visibility_apply`, `turn_interrupt_and_shutdown`, `peer_reachability_probe`
+  - anchors: `meerkat_machine`
+  - scenarios: `realtime_connection_projection`
 - `InteractionStreamReservedRetired`
-  - anchors: `meerkat_machine`, `meerkat_public_surface`, `peer_directory_reachability_authority`
-  - scenarios: `bind-run-boundary-terminal`, `retire-reset-destroy`, `staged_visibility_apply`, `turn_interrupt_and_shutdown`, `peer_reachability_probe`
+  - anchors: `meerkat_machine`
+  - scenarios: `realtime_connection_projection`
 - `InteractionStreamReservedStopped`
-  - anchors: `meerkat_machine`, `meerkat_public_surface`, `peer_directory_reachability_authority`
-  - scenarios: `bind-run-boundary-terminal`, `retire-reset-destroy`, `staged_visibility_apply`, `turn_interrupt_and_shutdown`, `peer_reachability_probe`
+  - anchors: `meerkat_machine`
+  - scenarios: `realtime_connection_projection`
 - `InteractionStreamAttachedIdle`
-  - anchors: `meerkat_machine`, `meerkat_public_surface`, `peer_directory_reachability_authority`
-  - scenarios: `bind-run-boundary-terminal`, `retire-reset-destroy`, `staged_visibility_apply`, `turn_interrupt_and_shutdown`, `peer_reachability_probe`
+  - anchors: `meerkat_machine`
+  - scenarios: `realtime_connection_projection`
 - `InteractionStreamAttachedAttached`
-  - anchors: `meerkat_machine`, `meerkat_public_surface`, `peer_directory_reachability_authority`
-  - scenarios: `bind-run-boundary-terminal`, `retire-reset-destroy`, `staged_visibility_apply`, `turn_interrupt_and_shutdown`, `peer_reachability_probe`
+  - anchors: `meerkat_machine`
+  - scenarios: `realtime_connection_projection`
 - `InteractionStreamAttachedRunning`
-  - anchors: `meerkat_machine`, `meerkat_public_surface`, `peer_directory_reachability_authority`
-  - scenarios: `bind-run-boundary-terminal`, `retire-reset-destroy`, `staged_visibility_apply`, `turn_interrupt_and_shutdown`, `peer_reachability_probe`
+  - anchors: `meerkat_machine`
+  - scenarios: `realtime_connection_projection`
 - `InteractionStreamAttachedRetired`
-  - anchors: `meerkat_machine`, `meerkat_public_surface`, `peer_directory_reachability_authority`
-  - scenarios: `bind-run-boundary-terminal`, `retire-reset-destroy`, `staged_visibility_apply`, `turn_interrupt_and_shutdown`, `peer_reachability_probe`
+  - anchors: `meerkat_machine`
+  - scenarios: `realtime_connection_projection`
 - `InteractionStreamAttachedStopped`
-  - anchors: `meerkat_machine`, `meerkat_public_surface`, `peer_directory_reachability_authority`
-  - scenarios: `bind-run-boundary-terminal`, `retire-reset-destroy`, `staged_visibility_apply`, `turn_interrupt_and_shutdown`, `peer_reachability_probe`
+  - anchors: `meerkat_machine`
+  - scenarios: `realtime_connection_projection`
 - `InteractionStreamCompletedIdle`
-  - anchors: `meerkat_machine`, `meerkat_public_surface`, `peer_directory_reachability_authority`
-  - scenarios: `bind-run-boundary-terminal`, `retire-reset-destroy`, `staged_visibility_apply`, `turn_interrupt_and_shutdown`, `peer_reachability_probe`
+  - anchors: `meerkat_machine`
+  - scenarios: `realtime_connection_projection`
 - `InteractionStreamCompletedAttached`
-  - anchors: `meerkat_machine`, `meerkat_public_surface`, `peer_directory_reachability_authority`
-  - scenarios: `bind-run-boundary-terminal`, `retire-reset-destroy`, `staged_visibility_apply`, `turn_interrupt_and_shutdown`, `peer_reachability_probe`
+  - anchors: `meerkat_machine`
+  - scenarios: `realtime_connection_projection`
 - `InteractionStreamCompletedRunning`
-  - anchors: `meerkat_machine`, `meerkat_public_surface`, `peer_directory_reachability_authority`
-  - scenarios: `bind-run-boundary-terminal`, `retire-reset-destroy`, `staged_visibility_apply`, `turn_interrupt_and_shutdown`, `peer_reachability_probe`
+  - anchors: `meerkat_machine`
+  - scenarios: `realtime_connection_projection`
 - `InteractionStreamCompletedRetired`
-  - anchors: `meerkat_machine`, `meerkat_public_surface`, `peer_directory_reachability_authority`
-  - scenarios: `bind-run-boundary-terminal`, `retire-reset-destroy`, `staged_visibility_apply`, `turn_interrupt_and_shutdown`, `peer_reachability_probe`
+  - anchors: `meerkat_machine`
+  - scenarios: `realtime_connection_projection`
 - `InteractionStreamCompletedStopped`
-  - anchors: `meerkat_machine`, `meerkat_public_surface`, `peer_directory_reachability_authority`
-  - scenarios: `bind-run-boundary-terminal`, `retire-reset-destroy`, `staged_visibility_apply`, `turn_interrupt_and_shutdown`, `peer_reachability_probe`
+  - anchors: `meerkat_machine`
+  - scenarios: `realtime_connection_projection`
 - `InteractionStreamExpiredIdle`
-  - anchors: `meerkat_machine`, `meerkat_public_surface`, `peer_directory_reachability_authority`
-  - scenarios: `bind-run-boundary-terminal`, `retire-reset-destroy`, `staged_visibility_apply`, `turn_interrupt_and_shutdown`, `peer_reachability_probe`
+  - anchors: `meerkat_machine`
+  - scenarios: `realtime_connection_projection`
 - `InteractionStreamExpiredAttached`
-  - anchors: `meerkat_machine`, `meerkat_public_surface`, `peer_directory_reachability_authority`
-  - scenarios: `bind-run-boundary-terminal`, `retire-reset-destroy`, `staged_visibility_apply`, `turn_interrupt_and_shutdown`, `peer_reachability_probe`
+  - anchors: `meerkat_machine`
+  - scenarios: `realtime_connection_projection`
 - `InteractionStreamExpiredRunning`
-  - anchors: `meerkat_machine`, `meerkat_public_surface`, `peer_directory_reachability_authority`
-  - scenarios: `bind-run-boundary-terminal`, `retire-reset-destroy`, `staged_visibility_apply`, `turn_interrupt_and_shutdown`, `peer_reachability_probe`
+  - anchors: `meerkat_machine`
+  - scenarios: `realtime_connection_projection`
 - `InteractionStreamExpiredRetired`
-  - anchors: `meerkat_machine`, `meerkat_public_surface`, `peer_directory_reachability_authority`
-  - scenarios: `bind-run-boundary-terminal`, `retire-reset-destroy`, `staged_visibility_apply`, `turn_interrupt_and_shutdown`, `peer_reachability_probe`
+  - anchors: `meerkat_machine`
+  - scenarios: `realtime_connection_projection`
 - `InteractionStreamExpiredStopped`
-  - anchors: `meerkat_machine`, `meerkat_public_surface`, `peer_directory_reachability_authority`
-  - scenarios: `bind-run-boundary-terminal`, `retire-reset-destroy`, `staged_visibility_apply`, `turn_interrupt_and_shutdown`, `peer_reachability_probe`
+  - anchors: `meerkat_machine`
+  - scenarios: `realtime_connection_projection`
 - `InteractionStreamClosedEarlyIdle`
-  - anchors: `meerkat_machine`, `meerkat_public_surface`, `peer_directory_reachability_authority`
-  - scenarios: `bind-run-boundary-terminal`, `retire-reset-destroy`, `staged_visibility_apply`, `turn_interrupt_and_shutdown`, `peer_reachability_probe`
+  - anchors: `meerkat_machine`
+  - scenarios: `realtime_connection_projection`
 - `InteractionStreamClosedEarlyAttached`
-  - anchors: `meerkat_machine`, `meerkat_public_surface`, `peer_directory_reachability_authority`
-  - scenarios: `bind-run-boundary-terminal`, `retire-reset-destroy`, `staged_visibility_apply`, `turn_interrupt_and_shutdown`, `peer_reachability_probe`
+  - anchors: `meerkat_machine`
+  - scenarios: `realtime_connection_projection`
 - `InteractionStreamClosedEarlyRunning`
-  - anchors: `meerkat_machine`, `meerkat_public_surface`, `peer_directory_reachability_authority`
-  - scenarios: `bind-run-boundary-terminal`, `retire-reset-destroy`, `staged_visibility_apply`, `turn_interrupt_and_shutdown`, `peer_reachability_probe`
+  - anchors: `meerkat_machine`
+  - scenarios: `realtime_connection_projection`
 - `InteractionStreamClosedEarlyRetired`
-  - anchors: `meerkat_machine`, `meerkat_public_surface`, `peer_directory_reachability_authority`
-  - scenarios: `bind-run-boundary-terminal`, `retire-reset-destroy`, `staged_visibility_apply`, `turn_interrupt_and_shutdown`, `peer_reachability_probe`
+  - anchors: `meerkat_machine`
+  - scenarios: `realtime_connection_projection`
 - `InteractionStreamClosedEarlyStopped`
-  - anchors: `meerkat_machine`, `meerkat_public_surface`, `peer_directory_reachability_authority`
-  - scenarios: `bind-run-boundary-terminal`, `retire-reset-destroy`, `staged_visibility_apply`, `turn_interrupt_and_shutdown`, `peer_reachability_probe`
+  - anchors: `meerkat_machine`
+  - scenarios: `realtime_connection_projection`
 - `ProductTurnInFlightInitializing`
-  - anchors: `meerkat_machine`, `meerkat_public_surface`, `peer_directory_reachability_authority`
-  - scenarios: `bind-run-boundary-terminal`, `retire-reset-destroy`, `staged_visibility_apply`, `turn_interrupt_and_shutdown`, `peer_reachability_probe`
+  - anchors: `meerkat_machine`
+  - scenarios: `product_turn_streaming`
 - `ProductTurnInFlightIdle`
-  - anchors: `meerkat_machine`, `meerkat_public_surface`, `peer_directory_reachability_authority`
-  - scenarios: `bind-run-boundary-terminal`, `retire-reset-destroy`, `staged_visibility_apply`, `turn_interrupt_and_shutdown`, `peer_reachability_probe`
+  - anchors: `meerkat_machine`
+  - scenarios: `product_turn_streaming`
 - `ProductTurnInFlightAttached`
-  - anchors: `meerkat_machine`, `meerkat_public_surface`, `peer_directory_reachability_authority`
-  - scenarios: `bind-run-boundary-terminal`, `retire-reset-destroy`, `staged_visibility_apply`, `turn_interrupt_and_shutdown`, `peer_reachability_probe`
+  - anchors: `meerkat_machine`
+  - scenarios: `product_turn_streaming`
 - `ProductTurnInFlightRunning`
-  - anchors: `meerkat_machine`, `meerkat_public_surface`, `peer_directory_reachability_authority`
-  - scenarios: `bind-run-boundary-terminal`, `retire-reset-destroy`, `staged_visibility_apply`, `turn_interrupt_and_shutdown`, `peer_reachability_probe`
+  - anchors: `meerkat_machine`
+  - scenarios: `turn_interrupt_and_shutdown`, `product_turn_streaming`
 - `ProductTurnInFlightRetired`
-  - anchors: `meerkat_machine`, `meerkat_public_surface`, `peer_directory_reachability_authority`
-  - scenarios: `bind-run-boundary-terminal`, `retire-reset-destroy`, `staged_visibility_apply`, `turn_interrupt_and_shutdown`, `peer_reachability_probe`
+  - anchors: `meerkat_machine`
+  - scenarios: `product_turn_streaming`
 - `ProductTurnInFlightStopped`
-  - anchors: `meerkat_machine`, `meerkat_public_surface`, `peer_directory_reachability_authority`
-  - scenarios: `bind-run-boundary-terminal`, `retire-reset-destroy`, `staged_visibility_apply`, `turn_interrupt_and_shutdown`, `peer_reachability_probe`
+  - anchors: `meerkat_machine`
+  - scenarios: `product_turn_streaming`
 - `ProductTurnCommittedFromAwaitingInitializing`
-  - anchors: `meerkat_machine`, `meerkat_public_surface`, `peer_directory_reachability_authority`
-  - scenarios: `bind-run-boundary-terminal`, `retire-reset-destroy`, `staged_visibility_apply`, `turn_interrupt_and_shutdown`, `peer_reachability_probe`
+  - anchors: `meerkat_machine`
+  - scenarios: `product_turn_streaming`
 - `ProductTurnCommittedFromAwaitingIdle`
-  - anchors: `meerkat_machine`, `meerkat_public_surface`, `peer_directory_reachability_authority`
-  - scenarios: `bind-run-boundary-terminal`, `retire-reset-destroy`, `staged_visibility_apply`, `turn_interrupt_and_shutdown`, `peer_reachability_probe`
+  - anchors: `meerkat_machine`
+  - scenarios: `product_turn_streaming`
 - `ProductTurnCommittedFromAwaitingAttached`
-  - anchors: `meerkat_machine`, `meerkat_public_surface`, `peer_directory_reachability_authority`
-  - scenarios: `bind-run-boundary-terminal`, `retire-reset-destroy`, `staged_visibility_apply`, `turn_interrupt_and_shutdown`, `peer_reachability_probe`
+  - anchors: `meerkat_machine`
+  - scenarios: `product_turn_streaming`
 - `ProductTurnCommittedFromAwaitingRunning`
-  - anchors: `meerkat_machine`, `meerkat_public_surface`, `peer_directory_reachability_authority`
-  - scenarios: `bind-run-boundary-terminal`, `retire-reset-destroy`, `staged_visibility_apply`, `turn_interrupt_and_shutdown`, `peer_reachability_probe`
+  - anchors: `meerkat_machine`
+  - scenarios: `product_turn_streaming`
 - `ProductTurnCommittedFromAwaitingRetired`
-  - anchors: `meerkat_machine`, `meerkat_public_surface`, `peer_directory_reachability_authority`
-  - scenarios: `bind-run-boundary-terminal`, `retire-reset-destroy`, `staged_visibility_apply`, `turn_interrupt_and_shutdown`, `peer_reachability_probe`
+  - anchors: `meerkat_machine`
+  - scenarios: `product_turn_streaming`
 - `ProductTurnCommittedFromAwaitingStopped`
-  - anchors: `meerkat_machine`, `meerkat_public_surface`, `peer_directory_reachability_authority`
-  - scenarios: `bind-run-boundary-terminal`, `retire-reset-destroy`, `staged_visibility_apply`, `turn_interrupt_and_shutdown`, `peer_reachability_probe`
+  - anchors: `meerkat_machine`
+  - scenarios: `product_turn_streaming`
 - `ProductTurnCommittedFromOutputInitializing`
-  - anchors: `meerkat_machine`, `meerkat_public_surface`, `peer_directory_reachability_authority`
-  - scenarios: `bind-run-boundary-terminal`, `retire-reset-destroy`, `staged_visibility_apply`, `turn_interrupt_and_shutdown`, `peer_reachability_probe`
+  - anchors: `meerkat_machine`
+  - scenarios: `product_turn_streaming`
 - `ProductTurnCommittedFromOutputIdle`
-  - anchors: `meerkat_machine`, `meerkat_public_surface`, `peer_directory_reachability_authority`
-  - scenarios: `bind-run-boundary-terminal`, `retire-reset-destroy`, `staged_visibility_apply`, `turn_interrupt_and_shutdown`, `peer_reachability_probe`
+  - anchors: `meerkat_machine`
+  - scenarios: `product_turn_streaming`
 - `ProductTurnCommittedFromOutputAttached`
-  - anchors: `meerkat_machine`, `meerkat_public_surface`, `peer_directory_reachability_authority`
-  - scenarios: `bind-run-boundary-terminal`, `retire-reset-destroy`, `staged_visibility_apply`, `turn_interrupt_and_shutdown`, `peer_reachability_probe`
+  - anchors: `meerkat_machine`
+  - scenarios: `product_turn_streaming`
 - `ProductTurnCommittedFromOutputRunning`
-  - anchors: `meerkat_machine`, `meerkat_public_surface`, `peer_directory_reachability_authority`
-  - scenarios: `bind-run-boundary-terminal`, `retire-reset-destroy`, `staged_visibility_apply`, `turn_interrupt_and_shutdown`, `peer_reachability_probe`
+  - anchors: `meerkat_machine`
+  - scenarios: `product_turn_streaming`
 - `ProductTurnCommittedFromOutputRetired`
-  - anchors: `meerkat_machine`, `meerkat_public_surface`, `peer_directory_reachability_authority`
-  - scenarios: `bind-run-boundary-terminal`, `retire-reset-destroy`, `staged_visibility_apply`, `turn_interrupt_and_shutdown`, `peer_reachability_probe`
+  - anchors: `meerkat_machine`
+  - scenarios: `product_turn_streaming`
 - `ProductTurnCommittedFromOutputStopped`
-  - anchors: `meerkat_machine`, `meerkat_public_surface`, `peer_directory_reachability_authority`
-  - scenarios: `bind-run-boundary-terminal`, `retire-reset-destroy`, `staged_visibility_apply`, `turn_interrupt_and_shutdown`, `peer_reachability_probe`
+  - anchors: `meerkat_machine`
+  - scenarios: `product_turn_streaming`
 - `ProductOutputStartedFromAwaitingInitializing`
-  - anchors: `meerkat_machine`, `meerkat_public_surface`, `peer_directory_reachability_authority`
-  - scenarios: `bind-run-boundary-terminal`, `retire-reset-destroy`, `staged_visibility_apply`, `turn_interrupt_and_shutdown`, `peer_reachability_probe`
+  - anchors: `meerkat_machine`
+  - scenarios: `product_turn_streaming`
 - `ProductOutputStartedFromAwaitingIdle`
-  - anchors: `meerkat_machine`, `meerkat_public_surface`, `peer_directory_reachability_authority`
-  - scenarios: `bind-run-boundary-terminal`, `retire-reset-destroy`, `staged_visibility_apply`, `turn_interrupt_and_shutdown`, `peer_reachability_probe`
+  - anchors: `meerkat_machine`
+  - scenarios: `product_turn_streaming`
 - `ProductOutputStartedFromAwaitingAttached`
-  - anchors: `meerkat_machine`, `meerkat_public_surface`, `peer_directory_reachability_authority`
-  - scenarios: `bind-run-boundary-terminal`, `retire-reset-destroy`, `staged_visibility_apply`, `turn_interrupt_and_shutdown`, `peer_reachability_probe`
+  - anchors: `meerkat_machine`
+  - scenarios: `product_turn_streaming`
 - `ProductOutputStartedFromAwaitingRunning`
-  - anchors: `meerkat_machine`, `meerkat_public_surface`, `peer_directory_reachability_authority`
-  - scenarios: `bind-run-boundary-terminal`, `retire-reset-destroy`, `staged_visibility_apply`, `turn_interrupt_and_shutdown`, `peer_reachability_probe`
+  - anchors: `meerkat_machine`
+  - scenarios: `product_turn_streaming`
 - `ProductOutputStartedFromAwaitingRetired`
-  - anchors: `meerkat_machine`, `meerkat_public_surface`, `peer_directory_reachability_authority`
-  - scenarios: `bind-run-boundary-terminal`, `retire-reset-destroy`, `staged_visibility_apply`, `turn_interrupt_and_shutdown`, `peer_reachability_probe`
+  - anchors: `meerkat_machine`
+  - scenarios: `product_turn_streaming`
 - `ProductOutputStartedFromAwaitingStopped`
-  - anchors: `meerkat_machine`, `meerkat_public_surface`, `peer_directory_reachability_authority`
-  - scenarios: `bind-run-boundary-terminal`, `retire-reset-destroy`, `staged_visibility_apply`, `turn_interrupt_and_shutdown`, `peer_reachability_probe`
+  - anchors: `meerkat_machine`
+  - scenarios: `product_turn_streaming`
 - `ProductOutputStartedFromCommittedInitializing`
-  - anchors: `meerkat_machine`, `meerkat_public_surface`, `peer_directory_reachability_authority`
-  - scenarios: `bind-run-boundary-terminal`, `retire-reset-destroy`, `staged_visibility_apply`, `turn_interrupt_and_shutdown`, `peer_reachability_probe`
+  - anchors: `meerkat_machine`
+  - scenarios: `product_turn_streaming`
 - `ProductOutputStartedFromCommittedIdle`
-  - anchors: `meerkat_machine`, `meerkat_public_surface`, `peer_directory_reachability_authority`
-  - scenarios: `bind-run-boundary-terminal`, `retire-reset-destroy`, `staged_visibility_apply`, `turn_interrupt_and_shutdown`, `peer_reachability_probe`
+  - anchors: `meerkat_machine`
+  - scenarios: `product_turn_streaming`
 - `ProductOutputStartedFromCommittedAttached`
-  - anchors: `meerkat_machine`, `meerkat_public_surface`, `peer_directory_reachability_authority`
-  - scenarios: `bind-run-boundary-terminal`, `retire-reset-destroy`, `staged_visibility_apply`, `turn_interrupt_and_shutdown`, `peer_reachability_probe`
+  - anchors: `meerkat_machine`
+  - scenarios: `product_turn_streaming`
 - `ProductOutputStartedFromCommittedRunning`
-  - anchors: `meerkat_machine`, `meerkat_public_surface`, `peer_directory_reachability_authority`
-  - scenarios: `bind-run-boundary-terminal`, `retire-reset-destroy`, `staged_visibility_apply`, `turn_interrupt_and_shutdown`, `peer_reachability_probe`
+  - anchors: `meerkat_machine`
+  - scenarios: `product_turn_streaming`
 - `ProductOutputStartedFromCommittedRetired`
-  - anchors: `meerkat_machine`, `meerkat_public_surface`, `peer_directory_reachability_authority`
-  - scenarios: `bind-run-boundary-terminal`, `retire-reset-destroy`, `staged_visibility_apply`, `turn_interrupt_and_shutdown`, `peer_reachability_probe`
+  - anchors: `meerkat_machine`
+  - scenarios: `product_turn_streaming`
 - `ProductOutputStartedFromCommittedStopped`
-  - anchors: `meerkat_machine`, `meerkat_public_surface`, `peer_directory_reachability_authority`
-  - scenarios: `bind-run-boundary-terminal`, `retire-reset-destroy`, `staged_visibility_apply`, `turn_interrupt_and_shutdown`, `peer_reachability_probe`
+  - anchors: `meerkat_machine`
+  - scenarios: `product_turn_streaming`
 - `ProductTurnInterruptedFromPreemptibleInitializing`
-  - anchors: `meerkat_machine`, `meerkat_public_surface`, `peer_directory_reachability_authority`
-  - scenarios: `bind-run-boundary-terminal`, `retire-reset-destroy`, `staged_visibility_apply`, `turn_interrupt_and_shutdown`, `peer_reachability_probe`
+  - anchors: `meerkat_machine`
+  - scenarios: `product_turn_streaming`
 - `ProductTurnInterruptedFromPreemptibleIdle`
-  - anchors: `meerkat_machine`, `meerkat_public_surface`, `peer_directory_reachability_authority`
-  - scenarios: `bind-run-boundary-terminal`, `retire-reset-destroy`, `staged_visibility_apply`, `turn_interrupt_and_shutdown`, `peer_reachability_probe`
+  - anchors: `meerkat_machine`
+  - scenarios: `product_turn_streaming`
 - `ProductTurnInterruptedFromPreemptibleAttached`
-  - anchors: `meerkat_machine`, `meerkat_public_surface`, `peer_directory_reachability_authority`
-  - scenarios: `bind-run-boundary-terminal`, `retire-reset-destroy`, `staged_visibility_apply`, `turn_interrupt_and_shutdown`, `peer_reachability_probe`
+  - anchors: `meerkat_machine`
+  - scenarios: `product_turn_streaming`
 - `ProductTurnInterruptedFromPreemptibleRunning`
-  - anchors: `meerkat_machine`, `meerkat_public_surface`, `peer_directory_reachability_authority`
-  - scenarios: `bind-run-boundary-terminal`, `retire-reset-destroy`, `staged_visibility_apply`, `turn_interrupt_and_shutdown`, `peer_reachability_probe`
+  - anchors: `meerkat_machine`
+  - scenarios: `product_turn_streaming`
 - `ProductTurnInterruptedFromPreemptibleRetired`
-  - anchors: `meerkat_machine`, `meerkat_public_surface`, `peer_directory_reachability_authority`
-  - scenarios: `bind-run-boundary-terminal`, `retire-reset-destroy`, `staged_visibility_apply`, `turn_interrupt_and_shutdown`, `peer_reachability_probe`
+  - anchors: `meerkat_machine`
+  - scenarios: `product_turn_streaming`
 - `ProductTurnInterruptedFromPreemptibleStopped`
-  - anchors: `meerkat_machine`, `meerkat_public_surface`, `peer_directory_reachability_authority`
-  - scenarios: `bind-run-boundary-terminal`, `retire-reset-destroy`, `staged_visibility_apply`, `turn_interrupt_and_shutdown`, `peer_reachability_probe`
+  - anchors: `meerkat_machine`
+  - scenarios: `product_turn_streaming`
 - `ProductTurnInterruptedFromOutputInitializing`
-  - anchors: `meerkat_machine`, `meerkat_public_surface`, `peer_directory_reachability_authority`
-  - scenarios: `bind-run-boundary-terminal`, `retire-reset-destroy`, `staged_visibility_apply`, `turn_interrupt_and_shutdown`, `peer_reachability_probe`
+  - anchors: `meerkat_machine`
+  - scenarios: `product_turn_streaming`
 - `ProductTurnInterruptedFromOutputIdle`
-  - anchors: `meerkat_machine`, `meerkat_public_surface`, `peer_directory_reachability_authority`
-  - scenarios: `bind-run-boundary-terminal`, `retire-reset-destroy`, `staged_visibility_apply`, `turn_interrupt_and_shutdown`, `peer_reachability_probe`
+  - anchors: `meerkat_machine`
+  - scenarios: `product_turn_streaming`
 - `ProductTurnInterruptedFromOutputAttached`
-  - anchors: `meerkat_machine`, `meerkat_public_surface`, `peer_directory_reachability_authority`
-  - scenarios: `bind-run-boundary-terminal`, `retire-reset-destroy`, `staged_visibility_apply`, `turn_interrupt_and_shutdown`, `peer_reachability_probe`
+  - anchors: `meerkat_machine`
+  - scenarios: `product_turn_streaming`
 - `ProductTurnInterruptedFromOutputRunning`
-  - anchors: `meerkat_machine`, `meerkat_public_surface`, `peer_directory_reachability_authority`
-  - scenarios: `bind-run-boundary-terminal`, `retire-reset-destroy`, `staged_visibility_apply`, `turn_interrupt_and_shutdown`, `peer_reachability_probe`
+  - anchors: `meerkat_machine`
+  - scenarios: `product_turn_streaming`
 - `ProductTurnInterruptedFromOutputRetired`
-  - anchors: `meerkat_machine`, `meerkat_public_surface`, `peer_directory_reachability_authority`
-  - scenarios: `bind-run-boundary-terminal`, `retire-reset-destroy`, `staged_visibility_apply`, `turn_interrupt_and_shutdown`, `peer_reachability_probe`
+  - anchors: `meerkat_machine`
+  - scenarios: `product_turn_streaming`
 - `ProductTurnInterruptedFromOutputStopped`
-  - anchors: `meerkat_machine`, `meerkat_public_surface`, `peer_directory_reachability_authority`
-  - scenarios: `bind-run-boundary-terminal`, `retire-reset-destroy`, `staged_visibility_apply`, `turn_interrupt_and_shutdown`, `peer_reachability_probe`
+  - anchors: `meerkat_machine`
+  - scenarios: `product_turn_streaming`
 - `ProductTurnTerminalInitializing`
-  - anchors: `meerkat_machine`, `meerkat_public_surface`, `peer_directory_reachability_authority`
-  - scenarios: `bind-run-boundary-terminal`, `retire-reset-destroy`, `staged_visibility_apply`, `turn_interrupt_and_shutdown`, `peer_reachability_probe`
+  - anchors: `meerkat_machine`
+  - scenarios: `product_turn_streaming`
 - `ProductTurnTerminalIdle`
-  - anchors: `meerkat_machine`, `meerkat_public_surface`, `peer_directory_reachability_authority`
-  - scenarios: `bind-run-boundary-terminal`, `retire-reset-destroy`, `staged_visibility_apply`, `turn_interrupt_and_shutdown`, `peer_reachability_probe`
+  - anchors: `meerkat_machine`
+  - scenarios: `product_turn_streaming`
 - `ProductTurnTerminalAttached`
-  - anchors: `meerkat_machine`, `meerkat_public_surface`, `peer_directory_reachability_authority`
-  - scenarios: `bind-run-boundary-terminal`, `retire-reset-destroy`, `staged_visibility_apply`, `turn_interrupt_and_shutdown`, `peer_reachability_probe`
+  - anchors: `meerkat_machine`
+  - scenarios: `product_turn_streaming`
 - `ProductTurnTerminalRunning`
-  - anchors: `meerkat_machine`, `meerkat_public_surface`, `peer_directory_reachability_authority`
-  - scenarios: `bind-run-boundary-terminal`, `retire-reset-destroy`, `staged_visibility_apply`, `turn_interrupt_and_shutdown`, `peer_reachability_probe`
+  - anchors: `meerkat_machine`
+  - scenarios: `product_turn_streaming`
 - `ProductTurnTerminalRetired`
-  - anchors: `meerkat_machine`, `meerkat_public_surface`, `peer_directory_reachability_authority`
-  - scenarios: `bind-run-boundary-terminal`, `retire-reset-destroy`, `staged_visibility_apply`, `turn_interrupt_and_shutdown`, `peer_reachability_probe`
+  - anchors: `meerkat_machine`
+  - scenarios: `product_turn_streaming`
 - `ProductTurnTerminalStopped`
-  - anchors: `meerkat_machine`, `meerkat_public_surface`, `peer_directory_reachability_authority`
-  - scenarios: `bind-run-boundary-terminal`, `retire-reset-destroy`, `staged_visibility_apply`, `turn_interrupt_and_shutdown`, `peer_reachability_probe`
+  - anchors: `meerkat_machine`
+  - scenarios: `product_turn_streaming`
 - `RealtimeProjectionAdvanceDuringTurnInitializing`
-  - anchors: `meerkat_machine`, `meerkat_public_surface`, `peer_directory_reachability_authority`
-  - scenarios: `bind-run-boundary-terminal`, `retire-reset-destroy`, `staged_visibility_apply`, `turn_interrupt_and_shutdown`, `peer_reachability_probe`
+  - anchors: `meerkat_machine`
+  - scenarios: `product_turn_streaming`
 - `RealtimeProjectionAdvanceDuringTurnIdle`
-  - anchors: `meerkat_machine`, `meerkat_public_surface`, `peer_directory_reachability_authority`
-  - scenarios: `bind-run-boundary-terminal`, `retire-reset-destroy`, `staged_visibility_apply`, `turn_interrupt_and_shutdown`, `peer_reachability_probe`
+  - anchors: `meerkat_machine`
+  - scenarios: `product_turn_streaming`
 - `RealtimeProjectionAdvanceDuringTurnAttached`
-  - anchors: `meerkat_machine`, `meerkat_public_surface`, `peer_directory_reachability_authority`
-  - scenarios: `bind-run-boundary-terminal`, `retire-reset-destroy`, `staged_visibility_apply`, `turn_interrupt_and_shutdown`, `peer_reachability_probe`
+  - anchors: `meerkat_machine`
+  - scenarios: `realtime_connection_projection`, `product_turn_streaming`
 - `RealtimeProjectionAdvanceDuringTurnRunning`
-  - anchors: `meerkat_machine`, `meerkat_public_surface`, `peer_directory_reachability_authority`
-  - scenarios: `bind-run-boundary-terminal`, `retire-reset-destroy`, `staged_visibility_apply`, `turn_interrupt_and_shutdown`, `peer_reachability_probe`
+  - anchors: `meerkat_machine`
+  - scenarios: `product_turn_streaming`
 - `RealtimeProjectionAdvanceDuringTurnRetired`
-  - anchors: `meerkat_machine`, `meerkat_public_surface`, `peer_directory_reachability_authority`
-  - scenarios: `bind-run-boundary-terminal`, `retire-reset-destroy`, `staged_visibility_apply`, `turn_interrupt_and_shutdown`, `peer_reachability_probe`
+  - anchors: `meerkat_machine`
+  - scenarios: `product_turn_streaming`
 - `RealtimeProjectionAdvanceDuringTurnStopped`
-  - anchors: `meerkat_machine`, `meerkat_public_surface`, `peer_directory_reachability_authority`
-  - scenarios: `bind-run-boundary-terminal`, `retire-reset-destroy`, `staged_visibility_apply`, `turn_interrupt_and_shutdown`, `peer_reachability_probe`
+  - anchors: `meerkat_machine`
+  - scenarios: `product_turn_streaming`
 - `RealtimeProjectionAdvanceWhileIdleInitializing`
-  - anchors: `meerkat_machine`, `meerkat_public_surface`, `peer_directory_reachability_authority`
-  - scenarios: `bind-run-boundary-terminal`, `retire-reset-destroy`, `staged_visibility_apply`, `turn_interrupt_and_shutdown`, `peer_reachability_probe`
+  - anchors: `meerkat_machine`
+  - scenarios: `realtime_connection_projection`, `product_turn_streaming`
 - `RealtimeProjectionAdvanceWhileIdleIdle`
-  - anchors: `meerkat_machine`, `meerkat_public_surface`, `peer_directory_reachability_authority`
-  - scenarios: `bind-run-boundary-terminal`, `retire-reset-destroy`, `staged_visibility_apply`, `turn_interrupt_and_shutdown`, `peer_reachability_probe`
+  - anchors: `meerkat_machine`
+  - scenarios: `realtime_connection_projection`, `product_turn_streaming`
 - `RealtimeProjectionAdvanceWhileIdleAttached`
-  - anchors: `meerkat_machine`, `meerkat_public_surface`, `peer_directory_reachability_authority`
-  - scenarios: `bind-run-boundary-terminal`, `retire-reset-destroy`, `staged_visibility_apply`, `turn_interrupt_and_shutdown`, `peer_reachability_probe`
+  - anchors: `meerkat_machine`
+  - scenarios: `realtime_connection_projection`
 - `RealtimeProjectionAdvanceWhileIdleRunning`
-  - anchors: `meerkat_machine`, `meerkat_public_surface`, `peer_directory_reachability_authority`
-  - scenarios: `bind-run-boundary-terminal`, `retire-reset-destroy`, `staged_visibility_apply`, `turn_interrupt_and_shutdown`, `peer_reachability_probe`
+  - anchors: `meerkat_machine`
+  - scenarios: `realtime_connection_projection`, `product_turn_streaming`
 - `RealtimeProjectionAdvanceWhileIdleRetired`
-  - anchors: `meerkat_machine`, `meerkat_public_surface`, `peer_directory_reachability_authority`
-  - scenarios: `bind-run-boundary-terminal`, `retire-reset-destroy`, `staged_visibility_apply`, `turn_interrupt_and_shutdown`, `peer_reachability_probe`
+  - anchors: `meerkat_machine`
+  - scenarios: `realtime_connection_projection`, `product_turn_streaming`
 - `RealtimeProjectionAdvanceWhileIdleStopped`
-  - anchors: `meerkat_machine`, `meerkat_public_surface`, `peer_directory_reachability_authority`
-  - scenarios: `bind-run-boundary-terminal`, `retire-reset-destroy`, `staged_visibility_apply`, `turn_interrupt_and_shutdown`, `peer_reachability_probe`
+  - anchors: `meerkat_machine`
+  - scenarios: `realtime_connection_projection`, `product_turn_streaming`
 - `RealtimeProjectionRefreshedInitializing`
-  - anchors: `meerkat_machine`, `meerkat_public_surface`, `peer_directory_reachability_authority`
-  - scenarios: `bind-run-boundary-terminal`, `retire-reset-destroy`, `staged_visibility_apply`, `turn_interrupt_and_shutdown`, `peer_reachability_probe`
+  - anchors: `meerkat_machine`
+  - scenarios: `product_turn_streaming`
 - `RealtimeProjectionRefreshedIdle`
-  - anchors: `meerkat_machine`, `meerkat_public_surface`, `peer_directory_reachability_authority`
-  - scenarios: `bind-run-boundary-terminal`, `retire-reset-destroy`, `staged_visibility_apply`, `turn_interrupt_and_shutdown`, `peer_reachability_probe`
+  - anchors: `meerkat_machine`
+  - scenarios: `product_turn_streaming`
 - `RealtimeProjectionRefreshedAttached`
-  - anchors: `meerkat_machine`, `meerkat_public_surface`, `peer_directory_reachability_authority`
-  - scenarios: `bind-run-boundary-terminal`, `retire-reset-destroy`, `staged_visibility_apply`, `turn_interrupt_and_shutdown`, `peer_reachability_probe`
+  - anchors: `meerkat_machine`
+  - scenarios: `realtime_connection_projection`, `product_turn_streaming`
 - `RealtimeProjectionRefreshedRunning`
-  - anchors: `meerkat_machine`, `meerkat_public_surface`, `peer_directory_reachability_authority`
-  - scenarios: `bind-run-boundary-terminal`, `retire-reset-destroy`, `staged_visibility_apply`, `turn_interrupt_and_shutdown`, `peer_reachability_probe`
+  - anchors: `meerkat_machine`
+  - scenarios: `product_turn_streaming`
 - `RealtimeProjectionRefreshedRetired`
-  - anchors: `meerkat_machine`, `meerkat_public_surface`, `peer_directory_reachability_authority`
-  - scenarios: `bind-run-boundary-terminal`, `retire-reset-destroy`, `staged_visibility_apply`, `turn_interrupt_and_shutdown`, `peer_reachability_probe`
+  - anchors: `meerkat_machine`
+  - scenarios: `product_turn_streaming`
 - `RealtimeProjectionRefreshedStopped`
-  - anchors: `meerkat_machine`, `meerkat_public_surface`, `peer_directory_reachability_authority`
-  - scenarios: `bind-run-boundary-terminal`, `retire-reset-destroy`, `staged_visibility_apply`, `turn_interrupt_and_shutdown`, `peer_reachability_probe`
+  - anchors: `meerkat_machine`
+  - scenarios: `product_turn_streaming`
 - `RealtimeProjectionResetInitializing`
-  - anchors: `meerkat_machine`, `meerkat_public_surface`, `peer_directory_reachability_authority`
-  - scenarios: `bind-run-boundary-terminal`, `retire-reset-destroy`, `staged_visibility_apply`, `turn_interrupt_and_shutdown`, `peer_reachability_probe`
+  - anchors: `meerkat_machine`
+  - scenarios: `product_turn_streaming`
 - `RealtimeProjectionResetIdle`
-  - anchors: `meerkat_machine`, `meerkat_public_surface`, `peer_directory_reachability_authority`
-  - scenarios: `bind-run-boundary-terminal`, `retire-reset-destroy`, `staged_visibility_apply`, `turn_interrupt_and_shutdown`, `peer_reachability_probe`
+  - anchors: `meerkat_machine`
+  - scenarios: `product_turn_streaming`
 - `RealtimeProjectionResetAttached`
-  - anchors: `meerkat_machine`, `meerkat_public_surface`, `peer_directory_reachability_authority`
-  - scenarios: `bind-run-boundary-terminal`, `retire-reset-destroy`, `staged_visibility_apply`, `turn_interrupt_and_shutdown`, `peer_reachability_probe`
+  - anchors: `meerkat_machine`
+  - scenarios: `realtime_connection_projection`, `product_turn_streaming`
 - `RealtimeProjectionResetRunning`
-  - anchors: `meerkat_machine`, `meerkat_public_surface`, `peer_directory_reachability_authority`
-  - scenarios: `bind-run-boundary-terminal`, `retire-reset-destroy`, `staged_visibility_apply`, `turn_interrupt_and_shutdown`, `peer_reachability_probe`
+  - anchors: `meerkat_machine`
+  - scenarios: `product_turn_streaming`
 - `RealtimeProjectionResetRetired`
-  - anchors: `meerkat_machine`, `meerkat_public_surface`, `peer_directory_reachability_authority`
-  - scenarios: `bind-run-boundary-terminal`, `retire-reset-destroy`, `staged_visibility_apply`, `turn_interrupt_and_shutdown`, `peer_reachability_probe`
+  - anchors: `meerkat_machine`
+  - scenarios: `product_turn_streaming`
 - `RealtimeProjectionResetStopped`
-  - anchors: `meerkat_machine`, `meerkat_public_surface`, `peer_directory_reachability_authority`
-  - scenarios: `bind-run-boundary-terminal`, `retire-reset-destroy`, `staged_visibility_apply`, `turn_interrupt_and_shutdown`, `peer_reachability_probe`
+  - anchors: `meerkat_machine`
+  - scenarios: `product_turn_streaming`
 - `ClassifyRealtimeClientInputSubmittedInitializing`
-  - anchors: `meerkat_machine`, `meerkat_public_surface`, `peer_directory_reachability_authority`
-  - scenarios: `bind-run-boundary-terminal`, `retire-reset-destroy`, `staged_visibility_apply`, `turn_interrupt_and_shutdown`, `peer_reachability_probe`
+  - anchors: `meerkat_machine`
+  - scenarios: `product_turn_streaming`
 - `ClassifyRealtimeClientInputSubmittedIdle`
-  - anchors: `meerkat_machine`, `meerkat_public_surface`, `peer_directory_reachability_authority`
-  - scenarios: `bind-run-boundary-terminal`, `retire-reset-destroy`, `staged_visibility_apply`, `turn_interrupt_and_shutdown`, `peer_reachability_probe`
+  - anchors: `meerkat_machine`
+  - scenarios: `product_turn_streaming`
 - `ClassifyRealtimeClientInputSubmittedAttached`
-  - anchors: `meerkat_machine`, `meerkat_public_surface`, `peer_directory_reachability_authority`
-  - scenarios: `bind-run-boundary-terminal`, `retire-reset-destroy`, `staged_visibility_apply`, `turn_interrupt_and_shutdown`, `peer_reachability_probe`
+  - anchors: `meerkat_machine`
+  - scenarios: `product_turn_streaming`
 - `ClassifyRealtimeClientInputSubmittedRunning`
-  - anchors: `meerkat_machine`, `meerkat_public_surface`, `peer_directory_reachability_authority`
-  - scenarios: `bind-run-boundary-terminal`, `retire-reset-destroy`, `staged_visibility_apply`, `turn_interrupt_and_shutdown`, `peer_reachability_probe`
+  - anchors: `meerkat_machine`
+  - scenarios: `product_turn_streaming`
 - `ClassifyRealtimeClientInputSubmittedRetired`
-  - anchors: `meerkat_machine`, `meerkat_public_surface`, `peer_directory_reachability_authority`
-  - scenarios: `bind-run-boundary-terminal`, `retire-reset-destroy`, `staged_visibility_apply`, `turn_interrupt_and_shutdown`, `peer_reachability_probe`
+  - anchors: `meerkat_machine`
+  - scenarios: `product_turn_streaming`
 - `ClassifyRealtimeClientInputSubmittedStopped`
-  - anchors: `meerkat_machine`, `meerkat_public_surface`, `peer_directory_reachability_authority`
-  - scenarios: `bind-run-boundary-terminal`, `retire-reset-destroy`, `staged_visibility_apply`, `turn_interrupt_and_shutdown`, `peer_reachability_probe`
+  - anchors: `meerkat_machine`
+  - scenarios: `product_turn_streaming`
 - `ClassifyRealtimeMidTurnActivityInitializing`
-  - anchors: `meerkat_machine`, `meerkat_public_surface`, `peer_directory_reachability_authority`
-  - scenarios: `bind-run-boundary-terminal`, `retire-reset-destroy`, `staged_visibility_apply`, `turn_interrupt_and_shutdown`, `peer_reachability_probe`
+  - anchors: `meerkat_machine`
+  - scenarios: `product_turn_streaming`
 - `ClassifyRealtimeMidTurnActivityIdle`
-  - anchors: `meerkat_machine`, `meerkat_public_surface`, `peer_directory_reachability_authority`
-  - scenarios: `bind-run-boundary-terminal`, `retire-reset-destroy`, `staged_visibility_apply`, `turn_interrupt_and_shutdown`, `peer_reachability_probe`
+  - anchors: `meerkat_machine`
+  - scenarios: `product_turn_streaming`
 - `ClassifyRealtimeMidTurnActivityAttached`
-  - anchors: `meerkat_machine`, `meerkat_public_surface`, `peer_directory_reachability_authority`
-  - scenarios: `bind-run-boundary-terminal`, `retire-reset-destroy`, `staged_visibility_apply`, `turn_interrupt_and_shutdown`, `peer_reachability_probe`
+  - anchors: `meerkat_machine`
+  - scenarios: `product_turn_streaming`
 - `ClassifyRealtimeMidTurnActivityRunning`
-  - anchors: `meerkat_machine`, `meerkat_public_surface`, `peer_directory_reachability_authority`
-  - scenarios: `bind-run-boundary-terminal`, `retire-reset-destroy`, `staged_visibility_apply`, `turn_interrupt_and_shutdown`, `peer_reachability_probe`
+  - anchors: `meerkat_machine`
+  - scenarios: `product_turn_streaming`
 - `ClassifyRealtimeMidTurnActivityRetired`
-  - anchors: `meerkat_machine`, `meerkat_public_surface`, `peer_directory_reachability_authority`
-  - scenarios: `bind-run-boundary-terminal`, `retire-reset-destroy`, `staged_visibility_apply`, `turn_interrupt_and_shutdown`, `peer_reachability_probe`
+  - anchors: `meerkat_machine`
+  - scenarios: `product_turn_streaming`
 - `ClassifyRealtimeMidTurnActivityStopped`
-  - anchors: `meerkat_machine`, `meerkat_public_surface`, `peer_directory_reachability_authority`
-  - scenarios: `bind-run-boundary-terminal`, `retire-reset-destroy`, `staged_visibility_apply`, `turn_interrupt_and_shutdown`, `peer_reachability_probe`
+  - anchors: `meerkat_machine`
+  - scenarios: `product_turn_streaming`
 - `ClassifyRealtimeTurnTerminatedInitializing`
-  - anchors: `meerkat_machine`, `meerkat_public_surface`, `peer_directory_reachability_authority`
-  - scenarios: `bind-run-boundary-terminal`, `retire-reset-destroy`, `staged_visibility_apply`, `turn_interrupt_and_shutdown`, `peer_reachability_probe`
+  - anchors: `meerkat_machine`
+  - scenarios: `product_turn_streaming`
 - `ClassifyRealtimeTurnTerminatedIdle`
-  - anchors: `meerkat_machine`, `meerkat_public_surface`, `peer_directory_reachability_authority`
-  - scenarios: `bind-run-boundary-terminal`, `retire-reset-destroy`, `staged_visibility_apply`, `turn_interrupt_and_shutdown`, `peer_reachability_probe`
+  - anchors: `meerkat_machine`
+  - scenarios: `product_turn_streaming`
 - `ClassifyRealtimeTurnTerminatedAttached`
-  - anchors: `meerkat_machine`, `meerkat_public_surface`, `peer_directory_reachability_authority`
-  - scenarios: `bind-run-boundary-terminal`, `retire-reset-destroy`, `staged_visibility_apply`, `turn_interrupt_and_shutdown`, `peer_reachability_probe`
+  - anchors: `meerkat_machine`
+  - scenarios: `product_turn_streaming`
 - `ClassifyRealtimeTurnTerminatedRunning`
-  - anchors: `meerkat_machine`, `meerkat_public_surface`, `peer_directory_reachability_authority`
-  - scenarios: `bind-run-boundary-terminal`, `retire-reset-destroy`, `staged_visibility_apply`, `turn_interrupt_and_shutdown`, `peer_reachability_probe`
+  - anchors: `meerkat_machine`
+  - scenarios: `product_turn_streaming`
 - `ClassifyRealtimeTurnTerminatedRetired`
-  - anchors: `meerkat_machine`, `meerkat_public_surface`, `peer_directory_reachability_authority`
-  - scenarios: `bind-run-boundary-terminal`, `retire-reset-destroy`, `staged_visibility_apply`, `turn_interrupt_and_shutdown`, `peer_reachability_probe`
+  - anchors: `meerkat_machine`
+  - scenarios: `product_turn_streaming`
 - `ClassifyRealtimeTurnTerminatedStopped`
-  - anchors: `meerkat_machine`, `meerkat_public_surface`, `peer_directory_reachability_authority`
-  - scenarios: `bind-run-boundary-terminal`, `retire-reset-destroy`, `staged_visibility_apply`, `turn_interrupt_and_shutdown`, `peer_reachability_probe`
+  - anchors: `meerkat_machine`
+  - scenarios: `product_turn_streaming`
 - `BeginLiveTopologyReconfigureIdle`
-  - anchors: `meerkat_machine`, `meerkat_public_surface`, `peer_directory_reachability_authority`
-  - scenarios: `bind-run-boundary-terminal`, `retire-reset-destroy`, `staged_visibility_apply`, `turn_interrupt_and_shutdown`, `peer_reachability_probe`
+  - anchors: `meerkat_machine`
+  - scenarios: `live_topology_and_supervision`
 - `BeginLiveTopologyReconfigureAttached`
-  - anchors: `meerkat_machine`, `meerkat_public_surface`, `peer_directory_reachability_authority`
-  - scenarios: `bind-run-boundary-terminal`, `retire-reset-destroy`, `staged_visibility_apply`, `turn_interrupt_and_shutdown`, `peer_reachability_probe`
+  - anchors: `meerkat_machine`
+  - scenarios: `live_topology_and_supervision`
 - `BeginLiveTopologyReconfigureRunning`
-  - anchors: `meerkat_machine`, `meerkat_public_surface`, `peer_directory_reachability_authority`
-  - scenarios: `bind-run-boundary-terminal`, `retire-reset-destroy`, `staged_visibility_apply`, `turn_interrupt_and_shutdown`, `peer_reachability_probe`
+  - anchors: `meerkat_machine`
+  - scenarios: `live_topology_and_supervision`
 - `BeginLiveTopologyReconfigureRetired`
-  - anchors: `meerkat_machine`, `meerkat_public_surface`, `peer_directory_reachability_authority`
-  - scenarios: `bind-run-boundary-terminal`, `retire-reset-destroy`, `staged_visibility_apply`, `turn_interrupt_and_shutdown`, `peer_reachability_probe`
+  - anchors: `meerkat_machine`
+  - scenarios: `live_topology_and_supervision`
 - `BeginLiveTopologyReconfigureStopped`
-  - anchors: `meerkat_machine`, `meerkat_public_surface`, `peer_directory_reachability_authority`
-  - scenarios: `bind-run-boundary-terminal`, `retire-reset-destroy`, `staged_visibility_apply`, `turn_interrupt_and_shutdown`, `peer_reachability_probe`
+  - anchors: `meerkat_machine`
+  - scenarios: `live_topology_and_supervision`
 - `MarkLiveTopologyDetachedIdle`
-  - anchors: `meerkat_machine`, `meerkat_public_surface`, `peer_directory_reachability_authority`
-  - scenarios: `bind-run-boundary-terminal`, `retire-reset-destroy`, `staged_visibility_apply`, `turn_interrupt_and_shutdown`, `peer_reachability_probe`
+  - anchors: `meerkat_machine`
+  - scenarios: `live_topology_and_supervision`
 - `MarkLiveTopologyDetachedAttached`
-  - anchors: `meerkat_machine`, `meerkat_public_surface`, `peer_directory_reachability_authority`
-  - scenarios: `bind-run-boundary-terminal`, `retire-reset-destroy`, `staged_visibility_apply`, `turn_interrupt_and_shutdown`, `peer_reachability_probe`
+  - anchors: `meerkat_machine`
+  - scenarios: `live_topology_and_supervision`
 - `MarkLiveTopologyDetachedRunning`
-  - anchors: `meerkat_machine`, `meerkat_public_surface`, `peer_directory_reachability_authority`
-  - scenarios: `bind-run-boundary-terminal`, `retire-reset-destroy`, `staged_visibility_apply`, `turn_interrupt_and_shutdown`, `peer_reachability_probe`
+  - anchors: `meerkat_machine`
+  - scenarios: `live_topology_and_supervision`
 - `MarkLiveTopologyDetachedRetired`
-  - anchors: `meerkat_machine`, `meerkat_public_surface`, `peer_directory_reachability_authority`
-  - scenarios: `bind-run-boundary-terminal`, `retire-reset-destroy`, `staged_visibility_apply`, `turn_interrupt_and_shutdown`, `peer_reachability_probe`
+  - anchors: `meerkat_machine`
+  - scenarios: `live_topology_and_supervision`
 - `MarkLiveTopologyDetachedStopped`
-  - anchors: `meerkat_machine`, `meerkat_public_surface`, `peer_directory_reachability_authority`
-  - scenarios: `bind-run-boundary-terminal`, `retire-reset-destroy`, `staged_visibility_apply`, `turn_interrupt_and_shutdown`, `peer_reachability_probe`
+  - anchors: `meerkat_machine`
+  - scenarios: `live_topology_and_supervision`
 - `ApplyLiveTopologyIdentityIdle`
-  - anchors: `meerkat_machine`, `meerkat_public_surface`, `peer_directory_reachability_authority`
-  - scenarios: `bind-run-boundary-terminal`, `retire-reset-destroy`, `staged_visibility_apply`, `turn_interrupt_and_shutdown`, `peer_reachability_probe`
+  - anchors: `meerkat_machine`
+  - scenarios: `live_topology_and_supervision`
 - `ApplyLiveTopologyIdentityAttached`
-  - anchors: `meerkat_machine`, `meerkat_public_surface`, `peer_directory_reachability_authority`
-  - scenarios: `bind-run-boundary-terminal`, `retire-reset-destroy`, `staged_visibility_apply`, `turn_interrupt_and_shutdown`, `peer_reachability_probe`
+  - anchors: `meerkat_machine`
+  - scenarios: `live_topology_and_supervision`
 - `ApplyLiveTopologyIdentityRunning`
-  - anchors: `meerkat_machine`, `meerkat_public_surface`, `peer_directory_reachability_authority`
-  - scenarios: `bind-run-boundary-terminal`, `retire-reset-destroy`, `staged_visibility_apply`, `turn_interrupt_and_shutdown`, `peer_reachability_probe`
+  - anchors: `meerkat_machine`
+  - scenarios: `live_topology_and_supervision`
 - `ApplyLiveTopologyIdentityRetired`
-  - anchors: `meerkat_machine`, `meerkat_public_surface`, `peer_directory_reachability_authority`
-  - scenarios: `bind-run-boundary-terminal`, `retire-reset-destroy`, `staged_visibility_apply`, `turn_interrupt_and_shutdown`, `peer_reachability_probe`
+  - anchors: `meerkat_machine`
+  - scenarios: `live_topology_and_supervision`
 - `ApplyLiveTopologyIdentityStopped`
-  - anchors: `meerkat_machine`, `meerkat_public_surface`, `peer_directory_reachability_authority`
-  - scenarios: `bind-run-boundary-terminal`, `retire-reset-destroy`, `staged_visibility_apply`, `turn_interrupt_and_shutdown`, `peer_reachability_probe`
+  - anchors: `meerkat_machine`
+  - scenarios: `live_topology_and_supervision`
 - `ApplyLiveTopologyVisibilityIdle`
-  - anchors: `meerkat_machine`, `meerkat_public_surface`, `peer_directory_reachability_authority`
-  - scenarios: `bind-run-boundary-terminal`, `retire-reset-destroy`, `staged_visibility_apply`, `turn_interrupt_and_shutdown`, `peer_reachability_probe`
+  - anchors: `meerkat_machine`
+  - scenarios: `live_topology_and_supervision`
 - `ApplyLiveTopologyVisibilityAttached`
-  - anchors: `meerkat_machine`, `meerkat_public_surface`, `peer_directory_reachability_authority`
-  - scenarios: `bind-run-boundary-terminal`, `retire-reset-destroy`, `staged_visibility_apply`, `turn_interrupt_and_shutdown`, `peer_reachability_probe`
+  - anchors: `meerkat_machine`
+  - scenarios: `live_topology_and_supervision`
 - `ApplyLiveTopologyVisibilityRunning`
-  - anchors: `meerkat_machine`, `meerkat_public_surface`, `peer_directory_reachability_authority`
-  - scenarios: `bind-run-boundary-terminal`, `retire-reset-destroy`, `staged_visibility_apply`, `turn_interrupt_and_shutdown`, `peer_reachability_probe`
+  - anchors: `meerkat_machine`
+  - scenarios: `live_topology_and_supervision`
 - `ApplyLiveTopologyVisibilityRetired`
-  - anchors: `meerkat_machine`, `meerkat_public_surface`, `peer_directory_reachability_authority`
-  - scenarios: `bind-run-boundary-terminal`, `retire-reset-destroy`, `staged_visibility_apply`, `turn_interrupt_and_shutdown`, `peer_reachability_probe`
+  - anchors: `meerkat_machine`
+  - scenarios: `live_topology_and_supervision`
 - `ApplyLiveTopologyVisibilityStopped`
-  - anchors: `meerkat_machine`, `meerkat_public_surface`, `peer_directory_reachability_authority`
-  - scenarios: `bind-run-boundary-terminal`, `retire-reset-destroy`, `staged_visibility_apply`, `turn_interrupt_and_shutdown`, `peer_reachability_probe`
+  - anchors: `meerkat_machine`
+  - scenarios: `live_topology_and_supervision`
 - `CompleteLiveTopologyIdle`
-  - anchors: `meerkat_machine`, `meerkat_public_surface`, `peer_directory_reachability_authority`
-  - scenarios: `bind-run-boundary-terminal`, `retire-reset-destroy`, `staged_visibility_apply`, `turn_interrupt_and_shutdown`, `peer_reachability_probe`
+  - anchors: `meerkat_machine`
+  - scenarios: `live_topology_and_supervision`
 - `CompleteLiveTopologyAttached`
-  - anchors: `meerkat_machine`, `meerkat_public_surface`, `peer_directory_reachability_authority`
-  - scenarios: `bind-run-boundary-terminal`, `retire-reset-destroy`, `staged_visibility_apply`, `turn_interrupt_and_shutdown`, `peer_reachability_probe`
+  - anchors: `meerkat_machine`
+  - scenarios: `live_topology_and_supervision`
 - `CompleteLiveTopologyRunning`
-  - anchors: `meerkat_machine`, `meerkat_public_surface`, `peer_directory_reachability_authority`
-  - scenarios: `bind-run-boundary-terminal`, `retire-reset-destroy`, `staged_visibility_apply`, `turn_interrupt_and_shutdown`, `peer_reachability_probe`
+  - anchors: `meerkat_machine`
+  - scenarios: `live_topology_and_supervision`
 - `CompleteLiveTopologyRetired`
-  - anchors: `meerkat_machine`, `meerkat_public_surface`, `peer_directory_reachability_authority`
-  - scenarios: `bind-run-boundary-terminal`, `retire-reset-destroy`, `staged_visibility_apply`, `turn_interrupt_and_shutdown`, `peer_reachability_probe`
+  - anchors: `meerkat_machine`
+  - scenarios: `live_topology_and_supervision`
 - `CompleteLiveTopologyStopped`
-  - anchors: `meerkat_machine`, `meerkat_public_surface`, `peer_directory_reachability_authority`
-  - scenarios: `bind-run-boundary-terminal`, `retire-reset-destroy`, `staged_visibility_apply`, `turn_interrupt_and_shutdown`, `peer_reachability_probe`
+  - anchors: `meerkat_machine`
+  - scenarios: `live_topology_and_supervision`
 - `AbortLiveTopologyBeforeDetachIdle`
-  - anchors: `meerkat_machine`, `meerkat_public_surface`, `peer_directory_reachability_authority`
-  - scenarios: `bind-run-boundary-terminal`, `retire-reset-destroy`, `staged_visibility_apply`, `turn_interrupt_and_shutdown`, `peer_reachability_probe`
+  - anchors: `meerkat_machine`
+  - scenarios: `live_topology_and_supervision`
 - `AbortLiveTopologyBeforeDetachAttached`
-  - anchors: `meerkat_machine`, `meerkat_public_surface`, `peer_directory_reachability_authority`
-  - scenarios: `bind-run-boundary-terminal`, `retire-reset-destroy`, `staged_visibility_apply`, `turn_interrupt_and_shutdown`, `peer_reachability_probe`
+  - anchors: `meerkat_machine`
+  - scenarios: `live_topology_and_supervision`
 - `AbortLiveTopologyBeforeDetachRunning`
-  - anchors: `meerkat_machine`, `meerkat_public_surface`, `peer_directory_reachability_authority`
-  - scenarios: `bind-run-boundary-terminal`, `retire-reset-destroy`, `staged_visibility_apply`, `turn_interrupt_and_shutdown`, `peer_reachability_probe`
+  - anchors: `meerkat_machine`
+  - scenarios: `live_topology_and_supervision`
 - `AbortLiveTopologyBeforeDetachRetired`
-  - anchors: `meerkat_machine`, `meerkat_public_surface`, `peer_directory_reachability_authority`
-  - scenarios: `bind-run-boundary-terminal`, `retire-reset-destroy`, `staged_visibility_apply`, `turn_interrupt_and_shutdown`, `peer_reachability_probe`
+  - anchors: `meerkat_machine`
+  - scenarios: `live_topology_and_supervision`
 - `AbortLiveTopologyBeforeDetachStopped`
-  - anchors: `meerkat_machine`, `meerkat_public_surface`, `peer_directory_reachability_authority`
-  - scenarios: `bind-run-boundary-terminal`, `retire-reset-destroy`, `staged_visibility_apply`, `turn_interrupt_and_shutdown`, `peer_reachability_probe`
+  - anchors: `meerkat_machine`
+  - scenarios: `live_topology_and_supervision`
 - `FailLiveTopologyAfterDetachIdle`
-  - anchors: `meerkat_machine`, `meerkat_public_surface`, `peer_directory_reachability_authority`
-  - scenarios: `bind-run-boundary-terminal`, `retire-reset-destroy`, `staged_visibility_apply`, `turn_interrupt_and_shutdown`, `peer_reachability_probe`
+  - anchors: `meerkat_machine`
+  - scenarios: `live_topology_and_supervision`
 - `FailLiveTopologyAfterDetachAttached`
-  - anchors: `meerkat_machine`, `meerkat_public_surface`, `peer_directory_reachability_authority`
-  - scenarios: `bind-run-boundary-terminal`, `retire-reset-destroy`, `staged_visibility_apply`, `turn_interrupt_and_shutdown`, `peer_reachability_probe`
+  - anchors: `meerkat_machine`
+  - scenarios: `live_topology_and_supervision`
 - `FailLiveTopologyAfterDetachRunning`
-  - anchors: `meerkat_machine`, `meerkat_public_surface`, `peer_directory_reachability_authority`
-  - scenarios: `bind-run-boundary-terminal`, `retire-reset-destroy`, `staged_visibility_apply`, `turn_interrupt_and_shutdown`, `peer_reachability_probe`
+  - anchors: `meerkat_machine`
+  - scenarios: `live_topology_and_supervision`
 - `FailLiveTopologyAfterDetachRetired`
-  - anchors: `meerkat_machine`, `meerkat_public_surface`, `peer_directory_reachability_authority`
-  - scenarios: `bind-run-boundary-terminal`, `retire-reset-destroy`, `staged_visibility_apply`, `turn_interrupt_and_shutdown`, `peer_reachability_probe`
+  - anchors: `meerkat_machine`
+  - scenarios: `live_topology_and_supervision`
 - `FailLiveTopologyAfterDetachStopped`
-  - anchors: `meerkat_machine`, `meerkat_public_surface`, `peer_directory_reachability_authority`
-  - scenarios: `bind-run-boundary-terminal`, `retire-reset-destroy`, `staged_visibility_apply`, `turn_interrupt_and_shutdown`, `peer_reachability_probe`
+  - anchors: `meerkat_machine`
+  - scenarios: `live_topology_and_supervision`
 - `AttachSessionIngressIdle`
-  - anchors: `meerkat_machine`, `meerkat_public_surface`, `peer_directory_reachability_authority`
-  - scenarios: `bind-run-boundary-terminal`, `retire-reset-destroy`, `staged_visibility_apply`, `turn_interrupt_and_shutdown`, `peer_reachability_probe`
+  - anchors: `meerkat_machine`
+  - scenarios: `session_registration_and_binding`
 - `AttachSessionIngressAttached`
-  - anchors: `meerkat_machine`, `meerkat_public_surface`, `peer_directory_reachability_authority`
-  - scenarios: `bind-run-boundary-terminal`, `retire-reset-destroy`, `staged_visibility_apply`, `turn_interrupt_and_shutdown`, `peer_reachability_probe`
+  - anchors: `meerkat_machine`
+  - scenarios: `session_registration_and_binding`, `realtime_connection_projection`
 - `AttachSessionIngressRunning`
-  - anchors: `meerkat_machine`, `meerkat_public_surface`, `peer_directory_reachability_authority`
-  - scenarios: `bind-run-boundary-terminal`, `retire-reset-destroy`, `staged_visibility_apply`, `turn_interrupt_and_shutdown`, `peer_reachability_probe`
+  - anchors: `meerkat_machine`
+  - scenarios: `session_registration_and_binding`
 - `AttachSessionIngressRetired`
-  - anchors: `meerkat_machine`, `meerkat_public_surface`, `peer_directory_reachability_authority`
-  - scenarios: `bind-run-boundary-terminal`, `retire-reset-destroy`, `staged_visibility_apply`, `turn_interrupt_and_shutdown`, `peer_reachability_probe`
+  - anchors: `meerkat_machine`
+  - scenarios: `session_registration_and_binding`
 - `AttachSessionIngressStopped`
-  - anchors: `meerkat_machine`, `meerkat_public_surface`, `peer_directory_reachability_authority`
-  - scenarios: `bind-run-boundary-terminal`, `retire-reset-destroy`, `staged_visibility_apply`, `turn_interrupt_and_shutdown`, `peer_reachability_probe`
+  - anchors: `meerkat_machine`
+  - scenarios: `session_registration_and_binding`
 - `AttachMobIngressIdle`
-  - anchors: `meerkat_machine`, `meerkat_public_surface`, `peer_directory_reachability_authority`
-  - scenarios: `bind-run-boundary-terminal`, `retire-reset-destroy`, `staged_visibility_apply`, `turn_interrupt_and_shutdown`, `peer_reachability_probe`
+  - anchors: `meerkat_machine`
+  - scenarios: `session_registration_and_binding`
 - `AttachMobIngressAttached`
-  - anchors: `meerkat_machine`, `meerkat_public_surface`, `peer_directory_reachability_authority`
-  - scenarios: `bind-run-boundary-terminal`, `retire-reset-destroy`, `staged_visibility_apply`, `turn_interrupt_and_shutdown`, `peer_reachability_probe`
+  - anchors: `meerkat_machine`
+  - scenarios: `session_registration_and_binding`, `realtime_connection_projection`
 - `AttachMobIngressRunning`
-  - anchors: `meerkat_machine`, `meerkat_public_surface`, `peer_directory_reachability_authority`
-  - scenarios: `bind-run-boundary-terminal`, `retire-reset-destroy`, `staged_visibility_apply`, `turn_interrupt_and_shutdown`, `peer_reachability_probe`
+  - anchors: `meerkat_machine`
+  - scenarios: `session_registration_and_binding`
 - `AttachMobIngressRetired`
-  - anchors: `meerkat_machine`, `meerkat_public_surface`, `peer_directory_reachability_authority`
-  - scenarios: `bind-run-boundary-terminal`, `retire-reset-destroy`, `staged_visibility_apply`, `turn_interrupt_and_shutdown`, `peer_reachability_probe`
+  - anchors: `meerkat_machine`
+  - scenarios: `session_registration_and_binding`
 - `AttachMobIngressStopped`
-  - anchors: `meerkat_machine`, `meerkat_public_surface`, `peer_directory_reachability_authority`
-  - scenarios: `bind-run-boundary-terminal`, `retire-reset-destroy`, `staged_visibility_apply`, `turn_interrupt_and_shutdown`, `peer_reachability_probe`
+  - anchors: `meerkat_machine`
+  - scenarios: `session_registration_and_binding`
 - `DetachIngressIdle`
-  - anchors: `meerkat_machine`, `meerkat_public_surface`, `peer_directory_reachability_authority`
-  - scenarios: `bind-run-boundary-terminal`, `retire-reset-destroy`, `staged_visibility_apply`, `turn_interrupt_and_shutdown`, `peer_reachability_probe`
+  - anchors: `meerkat_machine`
+  - scenarios: `session_registration_and_binding`
 - `DetachIngressAttached`
-  - anchors: `meerkat_machine`, `meerkat_public_surface`, `peer_directory_reachability_authority`
-  - scenarios: `bind-run-boundary-terminal`, `retire-reset-destroy`, `staged_visibility_apply`, `turn_interrupt_and_shutdown`, `peer_reachability_probe`
+  - anchors: `meerkat_machine`
+  - scenarios: `session_registration_and_binding`, `realtime_connection_projection`
 - `DetachIngressRunning`
-  - anchors: `meerkat_machine`, `meerkat_public_surface`, `peer_directory_reachability_authority`
-  - scenarios: `bind-run-boundary-terminal`, `retire-reset-destroy`, `staged_visibility_apply`, `turn_interrupt_and_shutdown`, `peer_reachability_probe`
+  - anchors: `meerkat_machine`
+  - scenarios: `session_registration_and_binding`
 - `DetachIngressRetired`
-  - anchors: `meerkat_machine`, `meerkat_public_surface`, `peer_directory_reachability_authority`
-  - scenarios: `bind-run-boundary-terminal`, `retire-reset-destroy`, `staged_visibility_apply`, `turn_interrupt_and_shutdown`, `peer_reachability_probe`
+  - anchors: `meerkat_machine`
+  - scenarios: `session_registration_and_binding`
 - `DetachIngressStopped`
-  - anchors: `meerkat_machine`, `meerkat_public_surface`, `peer_directory_reachability_authority`
-  - scenarios: `bind-run-boundary-terminal`, `retire-reset-destroy`, `staged_visibility_apply`, `turn_interrupt_and_shutdown`, `peer_reachability_probe`
+  - anchors: `meerkat_machine`
+  - scenarios: `session_registration_and_binding`
 - `BindSupervisorIdle`
-  - anchors: `meerkat_machine`, `meerkat_public_surface`, `peer_directory_reachability_authority`
-  - scenarios: `bind-run-boundary-terminal`, `retire-reset-destroy`, `staged_visibility_apply`, `turn_interrupt_and_shutdown`, `peer_reachability_probe`
+  - anchors: `meerkat_machine`
+  - scenarios: `live_topology_and_supervision`
 - `BindSupervisorAttached`
-  - anchors: `meerkat_machine`, `meerkat_public_surface`, `peer_directory_reachability_authority`
-  - scenarios: `bind-run-boundary-terminal`, `retire-reset-destroy`, `staged_visibility_apply`, `turn_interrupt_and_shutdown`, `peer_reachability_probe`
+  - anchors: `meerkat_machine`
+  - scenarios: `realtime_connection_projection`, `live_topology_and_supervision`
 - `BindSupervisorRunning`
-  - anchors: `meerkat_machine`, `meerkat_public_surface`, `peer_directory_reachability_authority`
-  - scenarios: `bind-run-boundary-terminal`, `retire-reset-destroy`, `staged_visibility_apply`, `turn_interrupt_and_shutdown`, `peer_reachability_probe`
+  - anchors: `meerkat_machine`
+  - scenarios: `live_topology_and_supervision`
 - `BindSupervisorRetired`
-  - anchors: `meerkat_machine`, `meerkat_public_surface`, `peer_directory_reachability_authority`
-  - scenarios: `bind-run-boundary-terminal`, `retire-reset-destroy`, `staged_visibility_apply`, `turn_interrupt_and_shutdown`, `peer_reachability_probe`
+  - anchors: `meerkat_machine`
+  - scenarios: `session_registration_and_binding`, `live_topology_and_supervision`
 - `BindSupervisorStopped`
-  - anchors: `meerkat_machine`, `meerkat_public_surface`, `peer_directory_reachability_authority`
-  - scenarios: `bind-run-boundary-terminal`, `retire-reset-destroy`, `staged_visibility_apply`, `turn_interrupt_and_shutdown`, `peer_reachability_probe`
+  - anchors: `meerkat_machine`
+  - scenarios: `live_topology_and_supervision`
 - `AuthorizeSupervisorIdle`
-  - anchors: `meerkat_machine`, `meerkat_public_surface`, `peer_directory_reachability_authority`
-  - scenarios: `bind-run-boundary-terminal`, `retire-reset-destroy`, `staged_visibility_apply`, `turn_interrupt_and_shutdown`, `peer_reachability_probe`
+  - anchors: `meerkat_machine`
+  - scenarios: `live_topology_and_supervision`
 - `AuthorizeSupervisorAttached`
-  - anchors: `meerkat_machine`, `meerkat_public_surface`, `peer_directory_reachability_authority`
-  - scenarios: `bind-run-boundary-terminal`, `retire-reset-destroy`, `staged_visibility_apply`, `turn_interrupt_and_shutdown`, `peer_reachability_probe`
+  - anchors: `meerkat_machine`
+  - scenarios: `live_topology_and_supervision`
 - `AuthorizeSupervisorRunning`
-  - anchors: `meerkat_machine`, `meerkat_public_surface`, `peer_directory_reachability_authority`
-  - scenarios: `bind-run-boundary-terminal`, `retire-reset-destroy`, `staged_visibility_apply`, `turn_interrupt_and_shutdown`, `peer_reachability_probe`
+  - anchors: `meerkat_machine`
+  - scenarios: `live_topology_and_supervision`
 - `AuthorizeSupervisorRetired`
-  - anchors: `meerkat_machine`, `meerkat_public_surface`, `peer_directory_reachability_authority`
-  - scenarios: `bind-run-boundary-terminal`, `retire-reset-destroy`, `staged_visibility_apply`, `turn_interrupt_and_shutdown`, `peer_reachability_probe`
+  - anchors: `meerkat_machine`
+  - scenarios: `live_topology_and_supervision`
 - `AuthorizeSupervisorStopped`
-  - anchors: `meerkat_machine`, `meerkat_public_surface`, `peer_directory_reachability_authority`
-  - scenarios: `bind-run-boundary-terminal`, `retire-reset-destroy`, `staged_visibility_apply`, `turn_interrupt_and_shutdown`, `peer_reachability_probe`
+  - anchors: `meerkat_machine`
+  - scenarios: `live_topology_and_supervision`
 - `RevokeSupervisorIdle`
-  - anchors: `meerkat_machine`, `meerkat_public_surface`, `peer_directory_reachability_authority`
-  - scenarios: `bind-run-boundary-terminal`, `retire-reset-destroy`, `staged_visibility_apply`, `turn_interrupt_and_shutdown`, `peer_reachability_probe`
+  - anchors: `meerkat_machine`
+  - scenarios: `live_topology_and_supervision`
 - `RevokeSupervisorAttached`
-  - anchors: `meerkat_machine`, `meerkat_public_surface`, `peer_directory_reachability_authority`
-  - scenarios: `bind-run-boundary-terminal`, `retire-reset-destroy`, `staged_visibility_apply`, `turn_interrupt_and_shutdown`, `peer_reachability_probe`
+  - anchors: `meerkat_machine`
+  - scenarios: `live_topology_and_supervision`
 - `RevokeSupervisorRunning`
-  - anchors: `meerkat_machine`, `meerkat_public_surface`, `peer_directory_reachability_authority`
-  - scenarios: `bind-run-boundary-terminal`, `retire-reset-destroy`, `staged_visibility_apply`, `turn_interrupt_and_shutdown`, `peer_reachability_probe`
+  - anchors: `meerkat_machine`
+  - scenarios: `live_topology_and_supervision`
 - `RevokeSupervisorRetired`
-  - anchors: `meerkat_machine`, `meerkat_public_surface`, `peer_directory_reachability_authority`
-  - scenarios: `bind-run-boundary-terminal`, `retire-reset-destroy`, `staged_visibility_apply`, `turn_interrupt_and_shutdown`, `peer_reachability_probe`
+  - anchors: `meerkat_machine`
+  - scenarios: `live_topology_and_supervision`
 - `RevokeSupervisorStopped`
-  - anchors: `meerkat_machine`, `meerkat_public_surface`, `peer_directory_reachability_authority`
-  - scenarios: `bind-run-boundary-terminal`, `retire-reset-destroy`, `staged_visibility_apply`, `turn_interrupt_and_shutdown`, `peer_reachability_probe`
+  - anchors: `meerkat_machine`
+  - scenarios: `live_topology_and_supervision`
 - `SupervisorTrustEdgePublishedIdle`
-  - anchors: `meerkat_machine`, `meerkat_public_surface`, `peer_directory_reachability_authority`
-  - scenarios: `bind-run-boundary-terminal`, `retire-reset-destroy`, `staged_visibility_apply`, `turn_interrupt_and_shutdown`, `peer_reachability_probe`
+  - anchors: `meerkat_machine`
+  - scenarios: `live_topology_and_supervision`
 - `SupervisorTrustEdgePublishedAttached`
-  - anchors: `meerkat_machine`, `meerkat_public_surface`, `peer_directory_reachability_authority`
-  - scenarios: `bind-run-boundary-terminal`, `retire-reset-destroy`, `staged_visibility_apply`, `turn_interrupt_and_shutdown`, `peer_reachability_probe`
+  - anchors: `meerkat_machine`
+  - scenarios: `live_topology_and_supervision`
 - `SupervisorTrustEdgePublishedRunning`
-  - anchors: `meerkat_machine`, `meerkat_public_surface`, `peer_directory_reachability_authority`
-  - scenarios: `bind-run-boundary-terminal`, `retire-reset-destroy`, `staged_visibility_apply`, `turn_interrupt_and_shutdown`, `peer_reachability_probe`
+  - anchors: `meerkat_machine`
+  - scenarios: `live_topology_and_supervision`
 - `SupervisorTrustEdgePublishedRetired`
-  - anchors: `meerkat_machine`, `meerkat_public_surface`, `peer_directory_reachability_authority`
-  - scenarios: `bind-run-boundary-terminal`, `retire-reset-destroy`, `staged_visibility_apply`, `turn_interrupt_and_shutdown`, `peer_reachability_probe`
+  - anchors: `meerkat_machine`
+  - scenarios: `live_topology_and_supervision`
 - `SupervisorTrustEdgePublishedStopped`
-  - anchors: `meerkat_machine`, `meerkat_public_surface`, `peer_directory_reachability_authority`
-  - scenarios: `bind-run-boundary-terminal`, `retire-reset-destroy`, `staged_visibility_apply`, `turn_interrupt_and_shutdown`, `peer_reachability_probe`
+  - anchors: `meerkat_machine`
+  - scenarios: `live_topology_and_supervision`
 - `SupervisorTrustEdgePublishFailedIdle`
-  - anchors: `meerkat_machine`, `meerkat_public_surface`, `peer_directory_reachability_authority`
-  - scenarios: `bind-run-boundary-terminal`, `retire-reset-destroy`, `staged_visibility_apply`, `turn_interrupt_and_shutdown`, `peer_reachability_probe`
+  - anchors: `meerkat_machine`
+  - scenarios: `live_topology_and_supervision`
 - `SupervisorTrustEdgePublishFailedAttached`
-  - anchors: `meerkat_machine`, `meerkat_public_surface`, `peer_directory_reachability_authority`
-  - scenarios: `bind-run-boundary-terminal`, `retire-reset-destroy`, `staged_visibility_apply`, `turn_interrupt_and_shutdown`, `peer_reachability_probe`
+  - anchors: `meerkat_machine`
+  - scenarios: `live_topology_and_supervision`
 - `SupervisorTrustEdgePublishFailedRunning`
-  - anchors: `meerkat_machine`, `meerkat_public_surface`, `peer_directory_reachability_authority`
-  - scenarios: `bind-run-boundary-terminal`, `retire-reset-destroy`, `staged_visibility_apply`, `turn_interrupt_and_shutdown`, `peer_reachability_probe`
+  - anchors: `meerkat_machine`
+  - scenarios: `live_topology_and_supervision`
 - `SupervisorTrustEdgePublishFailedRetired`
-  - anchors: `meerkat_machine`, `meerkat_public_surface`, `peer_directory_reachability_authority`
-  - scenarios: `bind-run-boundary-terminal`, `retire-reset-destroy`, `staged_visibility_apply`, `turn_interrupt_and_shutdown`, `peer_reachability_probe`
+  - anchors: `meerkat_machine`
+  - scenarios: `live_topology_and_supervision`
 - `SupervisorTrustEdgePublishFailedStopped`
-  - anchors: `meerkat_machine`, `meerkat_public_surface`, `peer_directory_reachability_authority`
-  - scenarios: `bind-run-boundary-terminal`, `retire-reset-destroy`, `staged_visibility_apply`, `turn_interrupt_and_shutdown`, `peer_reachability_probe`
+  - anchors: `meerkat_machine`
+  - scenarios: `live_topology_and_supervision`
 - `SupervisorTrustEdgeRevokedIdle`
-  - anchors: `meerkat_machine`, `meerkat_public_surface`, `peer_directory_reachability_authority`
-  - scenarios: `bind-run-boundary-terminal`, `retire-reset-destroy`, `staged_visibility_apply`, `turn_interrupt_and_shutdown`, `peer_reachability_probe`
+  - anchors: `meerkat_machine`
+  - scenarios: `live_topology_and_supervision`
 - `SupervisorTrustEdgeRevokedAttached`
-  - anchors: `meerkat_machine`, `meerkat_public_surface`, `peer_directory_reachability_authority`
-  - scenarios: `bind-run-boundary-terminal`, `retire-reset-destroy`, `staged_visibility_apply`, `turn_interrupt_and_shutdown`, `peer_reachability_probe`
+  - anchors: `meerkat_machine`
+  - scenarios: `live_topology_and_supervision`
 - `SupervisorTrustEdgeRevokedRunning`
-  - anchors: `meerkat_machine`, `meerkat_public_surface`, `peer_directory_reachability_authority`
-  - scenarios: `bind-run-boundary-terminal`, `retire-reset-destroy`, `staged_visibility_apply`, `turn_interrupt_and_shutdown`, `peer_reachability_probe`
+  - anchors: `meerkat_machine`
+  - scenarios: `live_topology_and_supervision`
 - `SupervisorTrustEdgeRevokedRetired`
-  - anchors: `meerkat_machine`, `meerkat_public_surface`, `peer_directory_reachability_authority`
-  - scenarios: `bind-run-boundary-terminal`, `retire-reset-destroy`, `staged_visibility_apply`, `turn_interrupt_and_shutdown`, `peer_reachability_probe`
+  - anchors: `meerkat_machine`
+  - scenarios: `live_topology_and_supervision`
 - `SupervisorTrustEdgeRevokedStopped`
-  - anchors: `meerkat_machine`, `meerkat_public_surface`, `peer_directory_reachability_authority`
-  - scenarios: `bind-run-boundary-terminal`, `retire-reset-destroy`, `staged_visibility_apply`, `turn_interrupt_and_shutdown`, `peer_reachability_probe`
+  - anchors: `meerkat_machine`
+  - scenarios: `live_topology_and_supervision`
 - `SupervisorTrustEdgeRevokeFailedIdle`
-  - anchors: `meerkat_machine`, `meerkat_public_surface`, `peer_directory_reachability_authority`
-  - scenarios: `bind-run-boundary-terminal`, `retire-reset-destroy`, `staged_visibility_apply`, `turn_interrupt_and_shutdown`, `peer_reachability_probe`
+  - anchors: `meerkat_machine`
+  - scenarios: `live_topology_and_supervision`
 - `SupervisorTrustEdgeRevokeFailedAttached`
-  - anchors: `meerkat_machine`, `meerkat_public_surface`, `peer_directory_reachability_authority`
-  - scenarios: `bind-run-boundary-terminal`, `retire-reset-destroy`, `staged_visibility_apply`, `turn_interrupt_and_shutdown`, `peer_reachability_probe`
+  - anchors: `meerkat_machine`
+  - scenarios: `live_topology_and_supervision`
 - `SupervisorTrustEdgeRevokeFailedRunning`
-  - anchors: `meerkat_machine`, `meerkat_public_surface`, `peer_directory_reachability_authority`
-  - scenarios: `bind-run-boundary-terminal`, `retire-reset-destroy`, `staged_visibility_apply`, `turn_interrupt_and_shutdown`, `peer_reachability_probe`
+  - anchors: `meerkat_machine`
+  - scenarios: `live_topology_and_supervision`
 - `SupervisorTrustEdgeRevokeFailedRetired`
-  - anchors: `meerkat_machine`, `meerkat_public_surface`, `peer_directory_reachability_authority`
-  - scenarios: `bind-run-boundary-terminal`, `retire-reset-destroy`, `staged_visibility_apply`, `turn_interrupt_and_shutdown`, `peer_reachability_probe`
+  - anchors: `meerkat_machine`
+  - scenarios: `live_topology_and_supervision`
 - `SupervisorTrustEdgeRevokeFailedStopped`
-  - anchors: `meerkat_machine`, `meerkat_public_surface`, `peer_directory_reachability_authority`
-  - scenarios: `bind-run-boundary-terminal`, `retire-reset-destroy`, `staged_visibility_apply`, `turn_interrupt_and_shutdown`, `peer_reachability_probe`
+  - anchors: `meerkat_machine`
+  - scenarios: `live_topology_and_supervision`
 - `OpsBarrierSatisfiedAttached`
-  - anchors: `meerkat_machine`, `meerkat_public_surface`, `peer_directory_reachability_authority`
-  - scenarios: `bind-run-boundary-terminal`, `retire-reset-destroy`, `staged_visibility_apply`, `turn_interrupt_and_shutdown`, `peer_reachability_probe`
+  - anchors: `meerkat_machine`
+  - scenarios: `ops_completion_and_waiters`
 - `OpsBarrierSatisfiedRunning`
-  - anchors: `meerkat_machine`, `meerkat_public_surface`, `peer_directory_reachability_authority`
-  - scenarios: `bind-run-boundary-terminal`, `retire-reset-destroy`, `staged_visibility_apply`, `turn_interrupt_and_shutdown`, `peer_reachability_probe`
+  - anchors: `meerkat_machine`
+  - scenarios: `ops_completion_and_waiters`
 - `PublishLocalEndpointIdle`
-  - anchors: `meerkat_machine`, `meerkat_public_surface`, `peer_directory_reachability_authority`
-  - scenarios: `bind-run-boundary-terminal`, `retire-reset-destroy`, `staged_visibility_apply`, `turn_interrupt_and_shutdown`, `peer_reachability_probe`
+  - anchors: `meerkat_machine`
+  - scenarios: `live_topology_and_supervision`
 - `PublishLocalEndpointAttached`
-  - anchors: `meerkat_machine`, `meerkat_public_surface`, `peer_directory_reachability_authority`
-  - scenarios: `bind-run-boundary-terminal`, `retire-reset-destroy`, `staged_visibility_apply`, `turn_interrupt_and_shutdown`, `peer_reachability_probe`
+  - anchors: `meerkat_machine`
+  - scenarios: `live_topology_and_supervision`
 - `PublishLocalEndpointRunning`
-  - anchors: `meerkat_machine`, `meerkat_public_surface`, `peer_directory_reachability_authority`
-  - scenarios: `bind-run-boundary-terminal`, `retire-reset-destroy`, `staged_visibility_apply`, `turn_interrupt_and_shutdown`, `peer_reachability_probe`
+  - anchors: `meerkat_machine`
+  - scenarios: `live_topology_and_supervision`
 - `ClearLocalEndpointIdle`
-  - anchors: `meerkat_machine`, `meerkat_public_surface`, `peer_directory_reachability_authority`
-  - scenarios: `bind-run-boundary-terminal`, `retire-reset-destroy`, `staged_visibility_apply`, `turn_interrupt_and_shutdown`, `peer_reachability_probe`
+  - anchors: `meerkat_machine`
+  - scenarios: `live_topology_and_supervision`
 - `ClearLocalEndpointAttached`
-  - anchors: `meerkat_machine`, `meerkat_public_surface`, `peer_directory_reachability_authority`
-  - scenarios: `bind-run-boundary-terminal`, `retire-reset-destroy`, `staged_visibility_apply`, `turn_interrupt_and_shutdown`, `peer_reachability_probe`
+  - anchors: `meerkat_machine`
+  - scenarios: `live_topology_and_supervision`
 - `ClearLocalEndpointRunning`
-  - anchors: `meerkat_machine`, `meerkat_public_surface`, `peer_directory_reachability_authority`
-  - scenarios: `bind-run-boundary-terminal`, `retire-reset-destroy`, `staged_visibility_apply`, `turn_interrupt_and_shutdown`, `peer_reachability_probe`
+  - anchors: `meerkat_machine`
+  - scenarios: `live_topology_and_supervision`
 - `AddDirectPeerEndpointIdle`
-  - anchors: `meerkat_machine`, `meerkat_public_surface`, `peer_directory_reachability_authority`
-  - scenarios: `bind-run-boundary-terminal`, `retire-reset-destroy`, `staged_visibility_apply`, `turn_interrupt_and_shutdown`, `peer_reachability_probe`
+  - anchors: `peer_directory_reachability_authority`
+  - scenarios: `peer_reachability_probe`
 - `AddDirectPeerEndpointAttached`
-  - anchors: `meerkat_machine`, `meerkat_public_surface`, `peer_directory_reachability_authority`
-  - scenarios: `bind-run-boundary-terminal`, `retire-reset-destroy`, `staged_visibility_apply`, `turn_interrupt_and_shutdown`, `peer_reachability_probe`
+  - anchors: `peer_directory_reachability_authority`
+  - scenarios: `peer_reachability_probe`
 - `AddDirectPeerEndpointRunning`
-  - anchors: `meerkat_machine`, `meerkat_public_surface`, `peer_directory_reachability_authority`
-  - scenarios: `bind-run-boundary-terminal`, `retire-reset-destroy`, `staged_visibility_apply`, `turn_interrupt_and_shutdown`, `peer_reachability_probe`
+  - anchors: `peer_directory_reachability_authority`
+  - scenarios: `peer_reachability_probe`
 - `RemoveDirectPeerEndpointIdle`
-  - anchors: `meerkat_machine`, `meerkat_public_surface`, `peer_directory_reachability_authority`
-  - scenarios: `bind-run-boundary-terminal`, `retire-reset-destroy`, `staged_visibility_apply`, `turn_interrupt_and_shutdown`, `peer_reachability_probe`
+  - anchors: `peer_directory_reachability_authority`
+  - scenarios: `peer_reachability_probe`
 - `RemoveDirectPeerEndpointAttached`
-  - anchors: `meerkat_machine`, `meerkat_public_surface`, `peer_directory_reachability_authority`
-  - scenarios: `bind-run-boundary-terminal`, `retire-reset-destroy`, `staged_visibility_apply`, `turn_interrupt_and_shutdown`, `peer_reachability_probe`
+  - anchors: `peer_directory_reachability_authority`
+  - scenarios: `peer_reachability_probe`
 - `RemoveDirectPeerEndpointRunning`
-  - anchors: `meerkat_machine`, `meerkat_public_surface`, `peer_directory_reachability_authority`
-  - scenarios: `bind-run-boundary-terminal`, `retire-reset-destroy`, `staged_visibility_apply`, `turn_interrupt_and_shutdown`, `peer_reachability_probe`
+  - anchors: `peer_directory_reachability_authority`
+  - scenarios: `peer_reachability_probe`
 - `ApplyMobPeerOverlayIdle`
-  - anchors: `meerkat_machine`, `meerkat_public_surface`, `peer_directory_reachability_authority`
-  - scenarios: `bind-run-boundary-terminal`, `retire-reset-destroy`, `staged_visibility_apply`, `turn_interrupt_and_shutdown`, `peer_reachability_probe`
+  - anchors: `peer_directory_reachability_authority`
+  - scenarios: `staged_visibility_apply`, `peer_reachability_probe`, `recycle_and_compaction`, `live_topology_and_supervision`
 - `ApplyMobPeerOverlayAttached`
-  - anchors: `meerkat_machine`, `meerkat_public_surface`, `peer_directory_reachability_authority`
-  - scenarios: `bind-run-boundary-terminal`, `retire-reset-destroy`, `staged_visibility_apply`, `turn_interrupt_and_shutdown`, `peer_reachability_probe`
+  - anchors: `peer_directory_reachability_authority`
+  - scenarios: `staged_visibility_apply`, `peer_reachability_probe`, `realtime_connection_projection`, `live_topology_and_supervision`
 - `ApplyMobPeerOverlayRunning`
-  - anchors: `meerkat_machine`, `meerkat_public_surface`, `peer_directory_reachability_authority`
-  - scenarios: `bind-run-boundary-terminal`, `retire-reset-destroy`, `staged_visibility_apply`, `turn_interrupt_and_shutdown`, `peer_reachability_probe`
+  - anchors: `peer_directory_reachability_authority`
+  - scenarios: `staged_visibility_apply`, `turn_interrupt_and_shutdown`, `peer_reachability_probe`, `live_topology_and_supervision`
 
 ### Effects
 - `RuntimeBound`
-  - anchors: `meerkat_machine`, `meerkat_public_surface`, `peer_directory_reachability_authority`
-  - scenarios: `bind-run-boundary-terminal`, `retire-reset-destroy`, `staged_visibility_apply`, `turn_interrupt_and_shutdown`, `peer_reachability_probe`
+  - anchors: `meerkat_machine`
+  - scenarios: `bind-run-boundary-terminal`, `session_registration_and_binding`
 - `RuntimeRetired`
-  - anchors: `meerkat_machine`, `meerkat_public_surface`, `peer_directory_reachability_authority`
-  - scenarios: `bind-run-boundary-terminal`, `retire-reset-destroy`, `staged_visibility_apply`, `turn_interrupt_and_shutdown`, `peer_reachability_probe`
+  - anchors: `meerkat_machine`
+  - scenarios: `session_registration_and_binding`, `recycle_and_compaction`
 - `RuntimeDestroyed`
-  - anchors: `meerkat_machine`, `meerkat_public_surface`, `peer_directory_reachability_authority`
-  - scenarios: `bind-run-boundary-terminal`, `retire-reset-destroy`, `staged_visibility_apply`, `turn_interrupt_and_shutdown`, `peer_reachability_probe`
+  - anchors: `meerkat_machine`
+  - scenarios: `session_registration_and_binding`
 - `RequestCancellationAtBoundary`
-  - anchors: `meerkat_machine`, `meerkat_public_surface`, `peer_directory_reachability_authority`
-  - scenarios: `bind-run-boundary-terminal`, `retire-reset-destroy`, `staged_visibility_apply`, `turn_interrupt_and_shutdown`, `peer_reachability_probe`
+  - anchors: `meerkat_machine`
+  - scenarios: `ops_completion_and_waiters`
 - `WakeInterrupt`
-  - anchors: `meerkat_machine`, `meerkat_public_surface`, `peer_directory_reachability_authority`
-  - scenarios: `bind-run-boundary-terminal`, `retire-reset-destroy`, `staged_visibility_apply`, `turn_interrupt_and_shutdown`, `peer_reachability_probe`
+  - anchors: `meerkat_machine`
+  - scenarios: `turn_interrupt_and_shutdown`, `product_turn_streaming`
 - `CommittedVisibleSetPublished`
-  - anchors: `meerkat_machine`, `meerkat_public_surface`, `peer_directory_reachability_authority`
-  - scenarios: `bind-run-boundary-terminal`, `retire-reset-destroy`, `staged_visibility_apply`, `turn_interrupt_and_shutdown`, `peer_reachability_probe`
+  - anchors: `meerkat_machine`
+  - scenarios: `staged_visibility_apply`, `product_turn_streaming`
 - `RuntimeNotice`
-  - anchors: `meerkat_machine`, `meerkat_public_surface`, `peer_directory_reachability_authority`
-  - scenarios: `bind-run-boundary-terminal`, `retire-reset-destroy`, `staged_visibility_apply`, `turn_interrupt_and_shutdown`, `peer_reachability_probe`
+  - anchors: `meerkat_machine`
+  - scenarios: `session_registration_and_binding`
 - `ResolveAdmission`
-  - anchors: `meerkat_machine`, `meerkat_public_surface`, `peer_directory_reachability_authority`
-  - scenarios: `bind-run-boundary-terminal`, `retire-reset-destroy`, `staged_visibility_apply`, `turn_interrupt_and_shutdown`, `peer_reachability_probe`
+  - anchors: `meerkat_machine`
+  - scenarios: `input_admission_and_queueing`
 - `SubmitAdmittedIngressEffect`
-  - anchors: `meerkat_machine`, `meerkat_public_surface`, `peer_directory_reachability_authority`
-  - scenarios: `bind-run-boundary-terminal`, `retire-reset-destroy`, `staged_visibility_apply`, `turn_interrupt_and_shutdown`, `peer_reachability_probe`
+  - anchors: `meerkat_machine`
+  - scenarios: `input_admission_and_queueing`
 - `SubmitRunPrimitive`
-  - anchors: `meerkat_machine`, `meerkat_public_surface`, `peer_directory_reachability_authority`
-  - scenarios: `bind-run-boundary-terminal`, `retire-reset-destroy`, `staged_visibility_apply`, `turn_interrupt_and_shutdown`, `peer_reachability_probe`
+  - anchors: `meerkat_machine`
+  - scenarios: `input_admission_and_queueing`
 - `ResolveCompletionAsTerminated`
-  - anchors: `meerkat_machine`, `meerkat_public_surface`, `peer_directory_reachability_authority`
-  - scenarios: `bind-run-boundary-terminal`, `retire-reset-destroy`, `staged_visibility_apply`, `turn_interrupt_and_shutdown`, `peer_reachability_probe`
+  - anchors: `meerkat_machine`
+  - scenarios: `input_admission_and_queueing`, `ops_completion_and_waiters`
 - `ApplyControlPlaneCommand`
-  - anchors: `meerkat_machine`, `meerkat_public_surface`, `peer_directory_reachability_authority`
-  - scenarios: `bind-run-boundary-terminal`, `retire-reset-destroy`, `staged_visibility_apply`, `turn_interrupt_and_shutdown`, `peer_reachability_probe`
+  - anchors: `meerkat_machine`
+  - scenarios: `staged_visibility_apply`, `live_topology_and_supervision`
 - `InitiateRecycle`
-  - anchors: `meerkat_machine`, `meerkat_public_surface`, `peer_directory_reachability_authority`
-  - scenarios: `bind-run-boundary-terminal`, `retire-reset-destroy`, `staged_visibility_apply`, `turn_interrupt_and_shutdown`, `peer_reachability_probe`
+  - anchors: `meerkat_machine`
+  - scenarios: `recycle_and_compaction`
 - `IngressAccepted`
-  - anchors: `meerkat_machine`, `meerkat_public_surface`, `peer_directory_reachability_authority`
-  - scenarios: `bind-run-boundary-terminal`, `retire-reset-destroy`, `staged_visibility_apply`, `turn_interrupt_and_shutdown`, `peer_reachability_probe`
+  - anchors: `meerkat_machine`
+  - scenarios: `session_registration_and_binding`, `input_admission_and_queueing`
 - `PostAdmissionSignal`
-  - anchors: `meerkat_machine`, `meerkat_public_surface`, `peer_directory_reachability_authority`
-  - scenarios: `bind-run-boundary-terminal`, `retire-reset-destroy`, `staged_visibility_apply`, `turn_interrupt_and_shutdown`, `peer_reachability_probe`
+  - anchors: `meerkat_machine`
+  - scenarios: `input_admission_and_queueing`
 - `ReadyForRun`
-  - anchors: `meerkat_machine`, `meerkat_public_surface`, `peer_directory_reachability_authority`
-  - scenarios: `bind-run-boundary-terminal`, `retire-reset-destroy`, `staged_visibility_apply`, `turn_interrupt_and_shutdown`, `peer_reachability_probe`
+  - anchors: `meerkat_machine`
+  - scenarios: `recycle_and_compaction`
 - `InputLifecycleNotice`
-  - anchors: `meerkat_machine`, `meerkat_public_surface`, `peer_directory_reachability_authority`
-  - scenarios: `bind-run-boundary-terminal`, `retire-reset-destroy`, `staged_visibility_apply`, `turn_interrupt_and_shutdown`, `peer_reachability_probe`
+  - anchors: `meerkat_machine`
+  - scenarios: `input_admission_and_queueing`
 - `CompletionResolved`
-  - anchors: `meerkat_machine`, `meerkat_public_surface`, `peer_directory_reachability_authority`
-  - scenarios: `bind-run-boundary-terminal`, `retire-reset-destroy`, `staged_visibility_apply`, `turn_interrupt_and_shutdown`, `peer_reachability_probe`
+  - anchors: `meerkat_machine`
+  - scenarios: `ops_completion_and_waiters`
 - `IngressNotice`
-  - anchors: `meerkat_machine`, `meerkat_public_surface`, `peer_directory_reachability_authority`
-  - scenarios: `bind-run-boundary-terminal`, `retire-reset-destroy`, `staged_visibility_apply`, `turn_interrupt_and_shutdown`, `peer_reachability_probe`
+  - anchors: `meerkat_machine`
+  - scenarios: `session_registration_and_binding`, `input_admission_and_queueing`
 - `SilentIntentApplied`
-  - anchors: `meerkat_machine`, `meerkat_public_surface`, `peer_directory_reachability_authority`
-  - scenarios: `bind-run-boundary-terminal`, `retire-reset-destroy`, `staged_visibility_apply`, `turn_interrupt_and_shutdown`, `peer_reachability_probe`
+  - anchors: `meerkat_machine`
+  - scenarios: `turn_interrupt_and_shutdown`, `realtime_connection_projection`
 - `CheckCompaction`
-  - anchors: `meerkat_machine`, `meerkat_public_surface`, `peer_directory_reachability_authority`
-  - scenarios: `bind-run-boundary-terminal`, `retire-reset-destroy`, `staged_visibility_apply`, `turn_interrupt_and_shutdown`, `peer_reachability_probe`
+  - anchors: `meerkat_machine`
+  - scenarios: `recycle_and_compaction`
 - `RecordTerminalOutcome`
-  - anchors: `meerkat_machine`, `meerkat_public_surface`, `peer_directory_reachability_authority`
-  - scenarios: `bind-run-boundary-terminal`, `retire-reset-destroy`, `staged_visibility_apply`, `turn_interrupt_and_shutdown`, `peer_reachability_probe`
+  - anchors: `meerkat_machine`
+  - scenarios: `bind-run-boundary-terminal`, `ops_completion_and_waiters`
 - `RecordRunAssociation`
-  - anchors: `meerkat_machine`, `meerkat_public_surface`, `peer_directory_reachability_authority`
-  - scenarios: `bind-run-boundary-terminal`, `retire-reset-destroy`, `staged_visibility_apply`, `turn_interrupt_and_shutdown`, `peer_reachability_probe`
+  - anchors: `meerkat_machine`
+  - scenarios: `turn_interrupt_and_shutdown`, `recycle_and_compaction`
 - `RecordBoundarySequence`
-  - anchors: `meerkat_machine`, `meerkat_public_surface`, `peer_directory_reachability_authority`
-  - scenarios: `bind-run-boundary-terminal`, `retire-reset-destroy`, `staged_visibility_apply`, `turn_interrupt_and_shutdown`, `peer_reachability_probe`
+  - anchors: `meerkat_machine`
+  - scenarios: `turn_interrupt_and_shutdown`, `ops_completion_and_waiters`
 - `SubmitOpEvent`
-  - anchors: `meerkat_machine`, `meerkat_public_surface`, `peer_directory_reachability_authority`
-  - scenarios: `bind-run-boundary-terminal`, `retire-reset-destroy`, `staged_visibility_apply`, `turn_interrupt_and_shutdown`, `peer_reachability_probe`
+  - anchors: `meerkat_machine`
+  - scenarios: `input_admission_and_queueing`, `ops_completion_and_waiters`, `product_turn_streaming`
 - `NotifyOpWatcher`
-  - anchors: `meerkat_machine`, `meerkat_public_surface`, `peer_directory_reachability_authority`
-  - scenarios: `bind-run-boundary-terminal`, `retire-reset-destroy`, `staged_visibility_apply`, `turn_interrupt_and_shutdown`, `peer_reachability_probe`
+  - anchors: `meerkat_machine`
+  - scenarios: `ops_completion_and_waiters`
 - `ExposeOperationPeer`
-  - anchors: `meerkat_machine`, `meerkat_public_surface`, `peer_directory_reachability_authority`
-  - scenarios: `bind-run-boundary-terminal`, `retire-reset-destroy`, `staged_visibility_apply`, `turn_interrupt_and_shutdown`, `peer_reachability_probe`
+  - anchors: `peer_directory_reachability_authority`
+  - scenarios: `peer_reachability_probe`
 - `RetainTerminalRecord`
-  - anchors: `meerkat_machine`, `meerkat_public_surface`, `peer_directory_reachability_authority`
-  - scenarios: `bind-run-boundary-terminal`, `retire-reset-destroy`, `staged_visibility_apply`, `turn_interrupt_and_shutdown`, `peer_reachability_probe`
+  - anchors: `meerkat_machine`
+  - scenarios: `ops_completion_and_waiters`
 - `EvictCompletedRecord`
-  - anchors: `meerkat_machine`, `meerkat_public_surface`, `peer_directory_reachability_authority`
-  - scenarios: `bind-run-boundary-terminal`, `retire-reset-destroy`, `staged_visibility_apply`, `turn_interrupt_and_shutdown`, `peer_reachability_probe`
+  - anchors: `meerkat_machine`
+  - scenarios: `ops_completion_and_waiters`
 - `CompletionProduced`
-  - anchors: `meerkat_machine`, `meerkat_public_surface`, `peer_directory_reachability_authority`
-  - scenarios: `bind-run-boundary-terminal`, `retire-reset-destroy`, `staged_visibility_apply`, `turn_interrupt_and_shutdown`, `peer_reachability_probe`
+  - anchors: `meerkat_machine`
+  - scenarios: `ops_completion_and_waiters`
 - `WaitAllSatisfied`
-  - anchors: `meerkat_machine`, `meerkat_public_surface`, `peer_directory_reachability_authority`
-  - scenarios: `bind-run-boundary-terminal`, `retire-reset-destroy`, `staged_visibility_apply`, `turn_interrupt_and_shutdown`, `peer_reachability_probe`
+  - anchors: `meerkat_machine`
+  - scenarios: `ops_completion_and_waiters`
 - `CollectCompletedResult`
-  - anchors: `meerkat_machine`, `meerkat_public_surface`, `peer_directory_reachability_authority`
-  - scenarios: `bind-run-boundary-terminal`, `retire-reset-destroy`, `staged_visibility_apply`, `turn_interrupt_and_shutdown`, `peer_reachability_probe`
+  - anchors: `meerkat_machine`
+  - scenarios: `ops_completion_and_waiters`
 - `EnqueueClassifiedEntry`
-  - anchors: `meerkat_machine`, `meerkat_public_surface`, `peer_directory_reachability_authority`
-  - scenarios: `bind-run-boundary-terminal`, `retire-reset-destroy`, `staged_visibility_apply`, `turn_interrupt_and_shutdown`, `peer_reachability_probe`
+  - anchors: `meerkat_machine`
+  - scenarios: `input_admission_and_queueing`
 - `SpawnDrainTask`
-  - anchors: `meerkat_machine`, `meerkat_public_surface`, `peer_directory_reachability_authority`
-  - scenarios: `bind-run-boundary-terminal`, `retire-reset-destroy`, `staged_visibility_apply`, `turn_interrupt_and_shutdown`, `peer_reachability_probe`
+  - anchors: `meerkat_machine`
+  - scenarios: `session_registration_and_binding`
 - `ScheduleSurfaceCompletion`
-  - anchors: `meerkat_machine`, `meerkat_public_surface`, `peer_directory_reachability_authority`
-  - scenarios: `bind-run-boundary-terminal`, `retire-reset-destroy`, `staged_visibility_apply`, `turn_interrupt_and_shutdown`, `peer_reachability_probe`
+  - anchors: `meerkat_machine`
+  - scenarios: `ops_completion_and_waiters`
 - `RefreshVisibleSurfaceSet`
-  - anchors: `meerkat_machine`, `meerkat_public_surface`, `peer_directory_reachability_authority`
-  - scenarios: `bind-run-boundary-terminal`, `retire-reset-destroy`, `staged_visibility_apply`, `turn_interrupt_and_shutdown`, `peer_reachability_probe`
+  - anchors: `meerkat_machine`
+  - scenarios: `product_turn_streaming`
 - `EmitExternalToolDelta`
-  - anchors: `meerkat_machine`, `meerkat_public_surface`, `peer_directory_reachability_authority`
-  - scenarios: `bind-run-boundary-terminal`, `retire-reset-destroy`, `staged_visibility_apply`, `turn_interrupt_and_shutdown`, `peer_reachability_probe`
+  - anchors: `meerkat_machine`
+  - scenarios: `staged_visibility_apply`, `input_admission_and_queueing`
 - `CloseSurfaceConnection`
-  - anchors: `meerkat_machine`, `meerkat_public_surface`, `peer_directory_reachability_authority`
-  - scenarios: `bind-run-boundary-terminal`, `retire-reset-destroy`, `staged_visibility_apply`, `turn_interrupt_and_shutdown`, `peer_reachability_probe`
+  - anchors: `meerkat_machine`, `meerkat_public_surface`
+  - scenarios: `realtime_connection_projection`
 - `RejectSurfaceCall`
-  - anchors: `meerkat_machine`, `meerkat_public_surface`, `peer_directory_reachability_authority`
-  - scenarios: `bind-run-boundary-terminal`, `retire-reset-destroy`, `staged_visibility_apply`, `turn_interrupt_and_shutdown`, `peer_reachability_probe`
+  - anchors: `meerkat_machine`
+  - scenarios: `ops_completion_and_waiters`
 - `RealtimeIntentProjected`
-  - anchors: `meerkat_machine`, `meerkat_public_surface`, `peer_directory_reachability_authority`
-  - scenarios: `bind-run-boundary-terminal`, `retire-reset-destroy`, `staged_visibility_apply`, `turn_interrupt_and_shutdown`, `peer_reachability_probe`
+  - anchors: `meerkat_machine`
+  - scenarios: `realtime_connection_projection`
 - `RealtimeBindingRotated`
-  - anchors: `meerkat_machine`, `meerkat_public_surface`, `peer_directory_reachability_authority`
-  - scenarios: `bind-run-boundary-terminal`, `retire-reset-destroy`, `staged_visibility_apply`, `turn_interrupt_and_shutdown`, `peer_reachability_probe`
+  - anchors: `meerkat_machine`
+  - scenarios: `realtime_connection_projection`
 - `RealtimeReconnectProgressProjected`
-  - anchors: `meerkat_machine`, `meerkat_public_surface`, `peer_directory_reachability_authority`
-  - scenarios: `bind-run-boundary-terminal`, `retire-reset-destroy`, `staged_visibility_apply`, `turn_interrupt_and_shutdown`, `peer_reachability_probe`
+  - anchors: `meerkat_machine`
+  - scenarios: `realtime_connection_projection`
 - `McpServerStateChanged`
-  - anchors: `meerkat_machine`, `meerkat_public_surface`, `peer_directory_reachability_authority`
-  - scenarios: `bind-run-boundary-terminal`, `retire-reset-destroy`, `staged_visibility_apply`, `turn_interrupt_and_shutdown`, `peer_reachability_probe`
+  - anchors: `meerkat_machine`
+  - scenarios: `realtime_connection_projection`
 - `McpServerReloadRequested`
-  - anchors: `meerkat_machine`, `meerkat_public_surface`, `peer_directory_reachability_authority`
-  - scenarios: `bind-run-boundary-terminal`, `retire-reset-destroy`, `staged_visibility_apply`, `turn_interrupt_and_shutdown`, `peer_reachability_probe`
+  - anchors: `meerkat_machine`
+  - scenarios: `realtime_connection_projection`
 - `PeerInteractionStateChanged`
-  - anchors: `meerkat_machine`, `meerkat_public_surface`, `peer_directory_reachability_authority`
-  - scenarios: `bind-run-boundary-terminal`, `retire-reset-destroy`, `staged_visibility_apply`, `turn_interrupt_and_shutdown`, `peer_reachability_probe`
+  - anchors: `meerkat_machine`, `peer_directory_reachability_authority`
+  - scenarios: `peer_reachability_probe`
 - `PeerInteractionCleanup`
-  - anchors: `meerkat_machine`, `meerkat_public_surface`, `peer_directory_reachability_authority`
-  - scenarios: `bind-run-boundary-terminal`, `retire-reset-destroy`, `staged_visibility_apply`, `turn_interrupt_and_shutdown`, `peer_reachability_probe`
+  - anchors: `meerkat_machine`, `peer_directory_reachability_authority`
+  - scenarios: `peer_reachability_probe`, `realtime_connection_projection`
 - `InboundPeerInteractionStateChanged`
-  - anchors: `meerkat_machine`, `meerkat_public_surface`, `peer_directory_reachability_authority`
-  - scenarios: `bind-run-boundary-terminal`, `retire-reset-destroy`, `staged_visibility_apply`, `turn_interrupt_and_shutdown`, `peer_reachability_probe`
+  - anchors: `meerkat_machine`, `peer_directory_reachability_authority`
+  - scenarios: `peer_reachability_probe`
 - `SessionContextAdvanced`
-  - anchors: `meerkat_machine`, `meerkat_public_surface`, `peer_directory_reachability_authority`
-  - scenarios: `bind-run-boundary-terminal`, `retire-reset-destroy`, `staged_visibility_apply`, `turn_interrupt_and_shutdown`, `peer_reachability_probe`
+  - anchors: `meerkat_machine`
+  - scenarios: `realtime_connection_projection`
 - `InteractionStreamStateChanged`
-  - anchors: `meerkat_machine`, `meerkat_public_surface`, `peer_directory_reachability_authority`
-  - scenarios: `bind-run-boundary-terminal`, `retire-reset-destroy`, `staged_visibility_apply`, `turn_interrupt_and_shutdown`, `peer_reachability_probe`
+  - anchors: `meerkat_machine`
+  - scenarios: `realtime_connection_projection`
 - `InteractionStreamCleanup`
-  - anchors: `meerkat_machine`, `meerkat_public_surface`, `peer_directory_reachability_authority`
-  - scenarios: `bind-run-boundary-terminal`, `retire-reset-destroy`, `staged_visibility_apply`, `turn_interrupt_and_shutdown`, `peer_reachability_probe`
+  - anchors: `meerkat_machine`
+  - scenarios: `realtime_connection_projection`
 - `RealtimeProductTurnPhaseChanged`
-  - anchors: `meerkat_machine`, `meerkat_public_surface`, `peer_directory_reachability_authority`
-  - scenarios: `bind-run-boundary-terminal`, `retire-reset-destroy`, `staged_visibility_apply`, `turn_interrupt_and_shutdown`, `peer_reachability_probe`
+  - anchors: `meerkat_machine`
+  - scenarios: `product_turn_streaming`
 - `RealtimeProjectionFreshnessChanged`
-  - anchors: `meerkat_machine`, `meerkat_public_surface`, `peer_directory_reachability_authority`
-  - scenarios: `bind-run-boundary-terminal`, `retire-reset-destroy`, `staged_visibility_apply`, `turn_interrupt_and_shutdown`, `peer_reachability_probe`
+  - anchors: `meerkat_machine`
+  - scenarios: `realtime_connection_projection`
 - `RealtimeReconnectPolicyChanged`
-  - anchors: `meerkat_machine`, `meerkat_public_surface`, `peer_directory_reachability_authority`
-  - scenarios: `bind-run-boundary-terminal`, `retire-reset-destroy`, `staged_visibility_apply`, `turn_interrupt_and_shutdown`, `peer_reachability_probe`
+  - anchors: `meerkat_machine`
+  - scenarios: `realtime_connection_projection`
 - `LiveTopologyPhaseChanged`
-  - anchors: `meerkat_machine`, `meerkat_public_surface`, `peer_directory_reachability_authority`
-  - scenarios: `bind-run-boundary-terminal`, `retire-reset-destroy`, `staged_visibility_apply`, `turn_interrupt_and_shutdown`, `peer_reachability_probe`
+  - anchors: `meerkat_machine`
+  - scenarios: `live_topology_and_supervision`
 - `LocalEndpointChanged`
-  - anchors: `meerkat_machine`, `meerkat_public_surface`, `peer_directory_reachability_authority`
-  - scenarios: `bind-run-boundary-terminal`, `retire-reset-destroy`, `staged_visibility_apply`, `turn_interrupt_and_shutdown`, `peer_reachability_probe`
+  - anchors: `meerkat_machine`
+  - scenarios: `live_topology_and_supervision`
 - `PeerProjectionChanged`
-  - anchors: `meerkat_machine`, `meerkat_public_surface`, `peer_directory_reachability_authority`
-  - scenarios: `bind-run-boundary-terminal`, `retire-reset-destroy`, `staged_visibility_apply`, `turn_interrupt_and_shutdown`, `peer_reachability_probe`
+  - anchors: `peer_directory_reachability_authority`
+  - scenarios: `peer_reachability_probe`, `realtime_connection_projection`, `product_turn_streaming`
 - `CommsTrustReconcileRequested`
-  - anchors: `meerkat_machine`, `meerkat_public_surface`, `peer_directory_reachability_authority`
-  - scenarios: `bind-run-boundary-terminal`, `retire-reset-destroy`, `staged_visibility_apply`, `turn_interrupt_and_shutdown`, `peer_reachability_probe`
+  - anchors: `meerkat_machine`
+  - scenarios: `live_topology_and_supervision`
 - `PublishSupervisorTrustEdge`
-  - anchors: `meerkat_machine`, `meerkat_public_surface`, `peer_directory_reachability_authority`
-  - scenarios: `bind-run-boundary-terminal`, `retire-reset-destroy`, `staged_visibility_apply`, `turn_interrupt_and_shutdown`, `peer_reachability_probe`
+  - anchors: `meerkat_machine`
+  - scenarios: `live_topology_and_supervision`
 - `RevokeSupervisorTrustEdge`
-  - anchors: `meerkat_machine`, `meerkat_public_surface`, `peer_directory_reachability_authority`
-  - scenarios: `bind-run-boundary-terminal`, `retire-reset-destroy`, `staged_visibility_apply`, `turn_interrupt_and_shutdown`, `peer_reachability_probe`
+  - anchors: `meerkat_machine`
+  - scenarios: `live_topology_and_supervision`
 
 ### Invariants
 - `fence_requires_bound_runtime`
-  - anchors: `meerkat_machine`, `meerkat_public_surface`, `peer_directory_reachability_authority`
-  - scenarios: `bind-run-boundary-terminal`, `retire-reset-destroy`, `staged_visibility_apply`, `turn_interrupt_and_shutdown`, `peer_reachability_probe`
+  - anchors: `meerkat_machine`
+  - scenarios: `bind-run-boundary-terminal`, `session_registration_and_binding`
 - `running_has_current_run`
-  - anchors: `meerkat_machine`, `meerkat_public_surface`, `peer_directory_reachability_authority`
-  - scenarios: `bind-run-boundary-terminal`, `retire-reset-destroy`, `staged_visibility_apply`, `turn_interrupt_and_shutdown`, `peer_reachability_probe`
+  - anchors: `meerkat_machine`
+  - scenarios: `turn_interrupt_and_shutdown`
 - `current_run_only_while_running_or_retired`
-  - anchors: `meerkat_machine`, `meerkat_public_surface`, `peer_directory_reachability_authority`
-  - scenarios: `bind-run-boundary-terminal`, `retire-reset-destroy`, `staged_visibility_apply`, `turn_interrupt_and_shutdown`, `peer_reachability_probe`
+  - anchors: `meerkat_machine`
+  - scenarios: `turn_interrupt_and_shutdown`, `session_registration_and_binding`, `recycle_and_compaction`
 - `realtime_binding_epoch_consistency`
-  - anchors: `meerkat_machine`, `meerkat_public_surface`, `peer_directory_reachability_authority`
-  - scenarios: `bind-run-boundary-terminal`, `retire-reset-destroy`, `staged_visibility_apply`, `turn_interrupt_and_shutdown`, `peer_reachability_probe`
+  - anchors: `meerkat_machine`
+  - scenarios: `realtime_connection_projection`
 - `peer_ingress_owner_consistency`
-  - anchors: `meerkat_machine`, `meerkat_public_surface`, `peer_directory_reachability_authority`
-  - scenarios: `bind-run-boundary-terminal`, `retire-reset-destroy`, `staged_visibility_apply`, `turn_interrupt_and_shutdown`, `peer_reachability_probe`
+  - anchors: `meerkat_machine`
+  - scenarios: `peer_reachability_probe`, `session_registration_and_binding`, `input_admission_and_queueing`, `recycle_and_compaction`
 - `supervisor_binding_consistency`
-  - anchors: `meerkat_machine`, `meerkat_public_surface`, `peer_directory_reachability_authority`
-  - scenarios: `bind-run-boundary-terminal`, `retire-reset-destroy`, `staged_visibility_apply`, `turn_interrupt_and_shutdown`, `peer_reachability_probe`
+  - anchors: `meerkat_machine`
+  - scenarios: `session_registration_and_binding`, `realtime_connection_projection`, `live_topology_and_supervision`
 
 
 <!-- GENERATED_COVERAGE_END -->

--- a/specs/machines/mob_machine/contract.md
+++ b/specs/machines/mob_machine/contract.md
@@ -831,8 +831,13 @@ _Generated from the Rust machine catalog. Do not edit by hand._
 ## Coverage
 ### Code Anchors
 - `meerkat-mob/src/runtime/handle.rs` — identity-first public MobMachine handle surface
-- `meerkat-mob/src/runtime/actor.rs` — MobMachine actor authority and command execution
+- `meerkat-mob/src/runtime/actor.rs` — MobMachine actor authority and command execution for wire, unwire, bind, rotate, release, spawn, observe runtime, submit work, retire, reset, respawn, complete, mark completed, stop/stopped, resume, task, force cancel, subscribe events, shutdown, destroy, terminalized member, record operator action provenance, flow, run, orchestrator, coordinator, cleanup, append failure ledger, escalate supervisor, peer, progress, notices, wiring graph, and session binding
 
 ### Scenarios
 - `spawn-work-terminal` — member spawn, runtime-ready observation, work submission, and terminal work closure
-- `retire-respawn-destroy` — member retires, respawns with a new runtime incarnation, and destroys cleanly
+- `retire-respawn-destroy` — member retires, resets, respawns with a new runtime incarnation, stops/stopped, resumes, shuts down, destroys cleanly, and resets to running when reusable
+- `wiring-and-session-binding` — wire and unwire members, bind rotate release member session, enforce known identity for bindings, expose pending spawn, member session binding changed, and wiring lifecycle notices
+- `task-flow-and-run-lifecycle` — task create or update pending/in progress/completed/cancelled, run flow, start flow, create run, start run, complete flow, finish run, mark completed, flow terminalized, and force cancel running work
+- `event-subscriptions-and-notices` — subscribe agent, all agent, and mob events; emit member, run, flow, progress, task, terminal, and wiring notices
+- `orchestrator-coordinator-cleanup` — initialize, stop, resume, and destroy orchestrator; bind or unbind coordinator; begin and finish cleanup; notify coordinator and escalate supervisor
+- `operator-provenance-and-peer-input` — record operator action provenance, trust operation peer, admit peer input, append failure ledger, and surface peer-exposed member inputs

--- a/specs/machines/mob_machine/mapping.md
+++ b/specs/machines/mob_machine/mapping.md
@@ -9,371 +9,376 @@ This section is generated from the Rust machine catalog. Do not edit it by hand.
 
 ### Code Anchors
 - `mob_handle_surface`: `meerkat-mob/src/runtime/handle.rs` — identity-first public MobMachine handle surface
-- `mob_actor_authority`: `meerkat-mob/src/runtime/actor.rs` — MobMachine actor authority and command execution
+- `mob_actor_authority`: `meerkat-mob/src/runtime/actor.rs` — MobMachine actor authority and command execution for wire, unwire, bind, rotate, release, spawn, observe runtime, submit work, retire, reset, respawn, complete, mark completed, stop/stopped, resume, task, force cancel, subscribe events, shutdown, destroy, terminalized member, record operator action provenance, flow, run, orchestrator, coordinator, cleanup, append failure ledger, escalate supervisor, peer, progress, notices, wiring graph, and session binding
 
 ### Scenarios
 - `spawn-work-terminal` — member spawn, runtime-ready observation, work submission, and terminal work closure
-- `retire-respawn-destroy` — member retires, respawns with a new runtime incarnation, and destroys cleanly
+- `retire-respawn-destroy` — member retires, resets, respawns with a new runtime incarnation, stops/stopped, resumes, shuts down, destroys cleanly, and resets to running when reusable
+- `wiring-and-session-binding` — wire and unwire members, bind rotate release member session, enforce known identity for bindings, expose pending spawn, member session binding changed, and wiring lifecycle notices
+- `task-flow-and-run-lifecycle` — task create or update pending/in progress/completed/cancelled, run flow, start flow, create run, start run, complete flow, finish run, mark completed, flow terminalized, and force cancel running work
+- `event-subscriptions-and-notices` — subscribe agent, all agent, and mob events; emit member, run, flow, progress, task, terminal, and wiring notices
+- `orchestrator-coordinator-cleanup` — initialize, stop, resume, and destroy orchestrator; bind or unbind coordinator; begin and finish cleanup; notify coordinator and escalate supervisor
+- `operator-provenance-and-peer-input` — record operator action provenance, trust operation peer, admit peer input, append failure ledger, and surface peer-exposed member inputs
 
 ### Transitions
 - `WireMembersRunning`
-  - anchors: `mob_handle_surface`, `mob_actor_authority`
-  - scenarios: `spawn-work-terminal`, `retire-respawn-destroy`
+  - anchors: `mob_actor_authority`
+  - scenarios: `wiring-and-session-binding`
 - `UnwireMembersRunning`
-  - anchors: `mob_handle_surface`, `mob_actor_authority`
-  - scenarios: `spawn-work-terminal`, `retire-respawn-destroy`
+  - anchors: `mob_actor_authority`
+  - scenarios: `wiring-and-session-binding`
 - `BindMemberSessionRunning`
-  - anchors: `mob_handle_surface`, `mob_actor_authority`
-  - scenarios: `spawn-work-terminal`, `retire-respawn-destroy`
+  - anchors: `mob_actor_authority`
+  - scenarios: `wiring-and-session-binding`
 - `RotateMemberSessionRunning`
-  - anchors: `mob_handle_surface`, `mob_actor_authority`
-  - scenarios: `spawn-work-terminal`, `retire-respawn-destroy`
+  - anchors: `mob_actor_authority`
+  - scenarios: `wiring-and-session-binding`
 - `ReleaseMemberSessionRunning`
-  - anchors: `mob_handle_surface`, `mob_actor_authority`
-  - scenarios: `spawn-work-terminal`, `retire-respawn-destroy`
+  - anchors: `mob_actor_authority`
+  - scenarios: `wiring-and-session-binding`
 - `SpawnRunningFresh`
-  - anchors: `mob_handle_surface`, `mob_actor_authority`
-  - scenarios: `spawn-work-terminal`, `retire-respawn-destroy`
+  - anchors: `mob_actor_authority`
+  - scenarios: `retire-respawn-destroy`
 - `SpawnRunningReplacing`
-  - anchors: `mob_handle_surface`, `mob_actor_authority`
-  - scenarios: `spawn-work-terminal`, `retire-respawn-destroy`
+  - anchors: `mob_actor_authority`
+  - scenarios: `retire-respawn-destroy`
 - `ObserveRuntimeReady`
-  - anchors: `mob_handle_surface`, `mob_actor_authority`
-  - scenarios: `spawn-work-terminal`, `retire-respawn-destroy`
+  - anchors: `mob_actor_authority`
+  - scenarios: `spawn-work-terminal`
 - `SubmitWorkRunningExternal`
-  - anchors: `mob_handle_surface`, `mob_actor_authority`
-  - scenarios: `spawn-work-terminal`, `retire-respawn-destroy`
+  - anchors: `mob_actor_authority`
+  - scenarios: `task-flow-and-run-lifecycle`
 - `SubmitWorkRunningInternal`
-  - anchors: `mob_handle_surface`, `mob_actor_authority`
-  - scenarios: `spawn-work-terminal`, `retire-respawn-destroy`
+  - anchors: `mob_actor_authority`
+  - scenarios: `task-flow-and-run-lifecycle`
 - `RetireMember`
-  - anchors: `mob_handle_surface`, `mob_actor_authority`
-  - scenarios: `spawn-work-terminal`, `retire-respawn-destroy`
+  - anchors: `mob_actor_authority`
+  - scenarios: `retire-respawn-destroy`
 - `ObserveRuntimeRetired`
-  - anchors: `mob_handle_surface`, `mob_actor_authority`
+  - anchors: `mob_actor_authority`
   - scenarios: `spawn-work-terminal`, `retire-respawn-destroy`
 - `ResetMember`
-  - anchors: `mob_handle_surface`, `mob_actor_authority`
-  - scenarios: `spawn-work-terminal`, `retire-respawn-destroy`
+  - anchors: `mob_actor_authority`
+  - scenarios: `retire-respawn-destroy`
 - `RespawnMember`
-  - anchors: `mob_handle_surface`, `mob_actor_authority`
-  - scenarios: `spawn-work-terminal`, `retire-respawn-destroy`
+  - anchors: `mob_actor_authority`
+  - scenarios: `retire-respawn-destroy`
 - `MarkCompleted`
-  - anchors: `mob_handle_surface`, `mob_actor_authority`
-  - scenarios: `spawn-work-terminal`, `retire-respawn-destroy`
+  - anchors: `mob_actor_authority`
+  - scenarios: `task-flow-and-run-lifecycle`
 - `DestroyMob`
-  - anchors: `mob_handle_surface`, `mob_actor_authority`
-  - scenarios: `spawn-work-terminal`, `retire-respawn-destroy`
+  - anchors: `mob_actor_authority`
+  - scenarios: `retire-respawn-destroy`, `event-subscriptions-and-notices`, `orchestrator-coordinator-cleanup`
 - `ObserveRuntimeDestroyed`
-  - anchors: `mob_handle_surface`, `mob_actor_authority`
+  - anchors: `mob_actor_authority`
   - scenarios: `spawn-work-terminal`, `retire-respawn-destroy`
 - `RecordOperatorActionProvenanceRunning`
-  - anchors: `mob_handle_surface`, `mob_actor_authority`
-  - scenarios: `spawn-work-terminal`, `retire-respawn-destroy`
+  - anchors: `mob_actor_authority`
+  - scenarios: `operator-provenance-and-peer-input`
 - `RecordOperatorActionProvenanceStopped`
-  - anchors: `mob_handle_surface`, `mob_actor_authority`
-  - scenarios: `spawn-work-terminal`, `retire-respawn-destroy`
+  - anchors: `mob_actor_authority`
+  - scenarios: `operator-provenance-and-peer-input`
 - `RecordOperatorActionProvenanceCompleted`
-  - anchors: `mob_handle_surface`, `mob_actor_authority`
-  - scenarios: `spawn-work-terminal`, `retire-respawn-destroy`
+  - anchors: `mob_actor_authority`
+  - scenarios: `operator-provenance-and-peer-input`
 - `RecordOperatorActionProvenanceDestroyed`
-  - anchors: `mob_handle_surface`, `mob_actor_authority`
-  - scenarios: `spawn-work-terminal`, `retire-respawn-destroy`
+  - anchors: `mob_actor_authority`
+  - scenarios: `operator-provenance-and-peer-input`
 - `SetSpawnPolicyRunning`
-  - anchors: `mob_handle_surface`, `mob_actor_authority`
-  - scenarios: `spawn-work-terminal`, `retire-respawn-destroy`
+  - anchors: `mob_actor_authority`
+  - scenarios: `retire-respawn-destroy`
 - `SetSpawnPolicyStopped`
-  - anchors: `mob_handle_surface`, `mob_actor_authority`
-  - scenarios: `spawn-work-terminal`, `retire-respawn-destroy`
+  - anchors: `mob_actor_authority`
+  - scenarios: `retire-respawn-destroy`
 - `SetSpawnPolicyCompleted`
-  - anchors: `mob_handle_surface`, `mob_actor_authority`
-  - scenarios: `spawn-work-terminal`, `retire-respawn-destroy`
+  - anchors: `mob_actor_authority`
+  - scenarios: `retire-respawn-destroy`
 - `SetSpawnPolicyDestroyed`
-  - anchors: `mob_handle_surface`, `mob_actor_authority`
-  - scenarios: `spawn-work-terminal`, `retire-respawn-destroy`
+  - anchors: `mob_actor_authority`
+  - scenarios: `retire-respawn-destroy`
 - `StopRunning`
-  - anchors: `mob_handle_surface`, `mob_actor_authority`
-  - scenarios: `spawn-work-terminal`, `retire-respawn-destroy`
+  - anchors: `mob_actor_authority`
+  - scenarios: `retire-respawn-destroy`
 - `ResumeStopped`
-  - anchors: `mob_handle_surface`, `mob_actor_authority`
-  - scenarios: `spawn-work-terminal`, `retire-respawn-destroy`
+  - anchors: `mob_actor_authority`
+  - scenarios: `retire-respawn-destroy`
 - `CompleteRunning`
-  - anchors: `mob_handle_surface`, `mob_actor_authority`
-  - scenarios: `spawn-work-terminal`, `retire-respawn-destroy`
+  - anchors: `mob_actor_authority`
+  - scenarios: `task-flow-and-run-lifecycle`
 - `ResetToRunning`
-  - anchors: `mob_handle_surface`, `mob_actor_authority`
-  - scenarios: `spawn-work-terminal`, `retire-respawn-destroy`
+  - anchors: `mob_actor_authority`
+  - scenarios: `retire-respawn-destroy`
 - `TaskCreateRunning`
-  - anchors: `mob_handle_surface`, `mob_actor_authority`
-  - scenarios: `spawn-work-terminal`, `retire-respawn-destroy`
+  - anchors: `mob_actor_authority`
+  - scenarios: `task-flow-and-run-lifecycle`
 - `TaskUpdateRunningPending`
-  - anchors: `mob_handle_surface`, `mob_actor_authority`
-  - scenarios: `spawn-work-terminal`, `retire-respawn-destroy`
+  - anchors: `mob_actor_authority`
+  - scenarios: `task-flow-and-run-lifecycle`
 - `TaskUpdateRunningInProgress`
-  - anchors: `mob_handle_surface`, `mob_actor_authority`
-  - scenarios: `spawn-work-terminal`, `retire-respawn-destroy`
+  - anchors: `mob_actor_authority`
+  - scenarios: `task-flow-and-run-lifecycle`
 - `TaskUpdateRunningCompleted`
-  - anchors: `mob_handle_surface`, `mob_actor_authority`
-  - scenarios: `spawn-work-terminal`, `retire-respawn-destroy`
+  - anchors: `mob_actor_authority`
+  - scenarios: `task-flow-and-run-lifecycle`
 - `TaskUpdateRunningCancelled`
-  - anchors: `mob_handle_surface`, `mob_actor_authority`
-  - scenarios: `spawn-work-terminal`, `retire-respawn-destroy`
+  - anchors: `mob_actor_authority`
+  - scenarios: `task-flow-and-run-lifecycle`
 - `ForceCancelRunning`
-  - anchors: `mob_handle_surface`, `mob_actor_authority`
-  - scenarios: `spawn-work-terminal`, `retire-respawn-destroy`
+  - anchors: `mob_actor_authority`
+  - scenarios: `task-flow-and-run-lifecycle`
 - `SubscribeAgentEventsRunning`
-  - anchors: `mob_handle_surface`, `mob_actor_authority`
-  - scenarios: `spawn-work-terminal`, `retire-respawn-destroy`
+  - anchors: `mob_actor_authority`
+  - scenarios: `event-subscriptions-and-notices`
 - `SubscribeAgentEventsStopped`
-  - anchors: `mob_handle_surface`, `mob_actor_authority`
-  - scenarios: `spawn-work-terminal`, `retire-respawn-destroy`
+  - anchors: `mob_actor_authority`
+  - scenarios: `event-subscriptions-and-notices`
 - `SubscribeAgentEventsCompleted`
-  - anchors: `mob_handle_surface`, `mob_actor_authority`
-  - scenarios: `spawn-work-terminal`, `retire-respawn-destroy`
+  - anchors: `mob_actor_authority`
+  - scenarios: `event-subscriptions-and-notices`
 - `SubscribeAgentEventsDestroyed`
-  - anchors: `mob_handle_surface`, `mob_actor_authority`
-  - scenarios: `spawn-work-terminal`, `retire-respawn-destroy`
+  - anchors: `mob_actor_authority`
+  - scenarios: `event-subscriptions-and-notices`
 - `SubscribeAllAgentEventsRunning`
-  - anchors: `mob_handle_surface`, `mob_actor_authority`
-  - scenarios: `spawn-work-terminal`, `retire-respawn-destroy`
+  - anchors: `mob_actor_authority`
+  - scenarios: `event-subscriptions-and-notices`
 - `SubscribeAllAgentEventsStopped`
-  - anchors: `mob_handle_surface`, `mob_actor_authority`
-  - scenarios: `spawn-work-terminal`, `retire-respawn-destroy`
+  - anchors: `mob_actor_authority`
+  - scenarios: `event-subscriptions-and-notices`
 - `SubscribeAllAgentEventsCompleted`
-  - anchors: `mob_handle_surface`, `mob_actor_authority`
-  - scenarios: `spawn-work-terminal`, `retire-respawn-destroy`
+  - anchors: `mob_actor_authority`
+  - scenarios: `event-subscriptions-and-notices`
 - `SubscribeAllAgentEventsDestroyed`
-  - anchors: `mob_handle_surface`, `mob_actor_authority`
-  - scenarios: `spawn-work-terminal`, `retire-respawn-destroy`
+  - anchors: `mob_actor_authority`
+  - scenarios: `event-subscriptions-and-notices`
 - `SubscribeMobEventsRunning`
-  - anchors: `mob_handle_surface`, `mob_actor_authority`
-  - scenarios: `spawn-work-terminal`, `retire-respawn-destroy`
+  - anchors: `mob_actor_authority`
+  - scenarios: `event-subscriptions-and-notices`
 - `SubscribeMobEventsStopped`
-  - anchors: `mob_handle_surface`, `mob_actor_authority`
-  - scenarios: `spawn-work-terminal`, `retire-respawn-destroy`
+  - anchors: `mob_actor_authority`
+  - scenarios: `event-subscriptions-and-notices`
 - `SubscribeMobEventsCompleted`
-  - anchors: `mob_handle_surface`, `mob_actor_authority`
-  - scenarios: `spawn-work-terminal`, `retire-respawn-destroy`
+  - anchors: `mob_actor_authority`
+  - scenarios: `event-subscriptions-and-notices`
 - `SubscribeMobEventsDestroyed`
-  - anchors: `mob_handle_surface`, `mob_actor_authority`
-  - scenarios: `spawn-work-terminal`, `retire-respawn-destroy`
+  - anchors: `mob_actor_authority`
+  - scenarios: `event-subscriptions-and-notices`
 - `ShutdownRunning`
-  - anchors: `mob_handle_surface`, `mob_actor_authority`
-  - scenarios: `spawn-work-terminal`, `retire-respawn-destroy`
+  - anchors: `mob_actor_authority`
+  - scenarios: `retire-respawn-destroy`, `task-flow-and-run-lifecycle`
 - `ShutdownStopped`
-  - anchors: `mob_handle_surface`, `mob_actor_authority`
-  - scenarios: `spawn-work-terminal`, `retire-respawn-destroy`
+  - anchors: `mob_actor_authority`
+  - scenarios: `retire-respawn-destroy`
 - `ShutdownCompleted`
-  - anchors: `mob_handle_surface`, `mob_actor_authority`
-  - scenarios: `spawn-work-terminal`, `retire-respawn-destroy`
+  - anchors: `mob_actor_authority`
+  - scenarios: `task-flow-and-run-lifecycle`
 - `CancelFlowRunning`
-  - anchors: `mob_handle_surface`, `mob_actor_authority`
-  - scenarios: `spawn-work-terminal`, `retire-respawn-destroy`
+  - anchors: `mob_actor_authority`
+  - scenarios: `task-flow-and-run-lifecycle`
 - `InitializeOrchestratorRunning`
-  - anchors: `mob_handle_surface`, `mob_actor_authority`
-  - scenarios: `spawn-work-terminal`, `retire-respawn-destroy`
+  - anchors: `mob_actor_authority`
+  - scenarios: `orchestrator-coordinator-cleanup`
 - `BindCoordinatorRunning`
-  - anchors: `mob_handle_surface`, `mob_actor_authority`
-  - scenarios: `spawn-work-terminal`, `retire-respawn-destroy`
+  - anchors: `mob_actor_authority`
+  - scenarios: `orchestrator-coordinator-cleanup`
 - `UnbindCoordinatorRunning`
-  - anchors: `mob_handle_surface`, `mob_actor_authority`
-  - scenarios: `spawn-work-terminal`, `retire-respawn-destroy`
+  - anchors: `mob_actor_authority`
+  - scenarios: `orchestrator-coordinator-cleanup`
 - `StageSpawnRunning`
-  - anchors: `mob_handle_surface`, `mob_actor_authority`
-  - scenarios: `spawn-work-terminal`, `retire-respawn-destroy`
+  - anchors: `mob_actor_authority`
+  - scenarios: `retire-respawn-destroy`
 - `StopOrchestratorRunning`
-  - anchors: `mob_handle_surface`, `mob_actor_authority`
-  - scenarios: `spawn-work-terminal`, `retire-respawn-destroy`
+  - anchors: `mob_actor_authority`
+  - scenarios: `retire-respawn-destroy`, `orchestrator-coordinator-cleanup`
 - `StopOrchestratorStopped`
-  - anchors: `mob_handle_surface`, `mob_actor_authority`
-  - scenarios: `spawn-work-terminal`, `retire-respawn-destroy`
+  - anchors: `mob_actor_authority`
+  - scenarios: `retire-respawn-destroy`, `orchestrator-coordinator-cleanup`
 - `StopOrchestratorCompleted`
-  - anchors: `mob_handle_surface`, `mob_actor_authority`
-  - scenarios: `spawn-work-terminal`, `retire-respawn-destroy`
+  - anchors: `mob_actor_authority`
+  - scenarios: `orchestrator-coordinator-cleanup`
 - `ResumeOrchestratorRunning`
-  - anchors: `mob_handle_surface`, `mob_actor_authority`
-  - scenarios: `spawn-work-terminal`, `retire-respawn-destroy`
+  - anchors: `mob_actor_authority`
+  - scenarios: `retire-respawn-destroy`, `orchestrator-coordinator-cleanup`
 - `ResumeOrchestratorStopped`
-  - anchors: `mob_handle_surface`, `mob_actor_authority`
-  - scenarios: `spawn-work-terminal`, `retire-respawn-destroy`
+  - anchors: `mob_actor_authority`
+  - scenarios: `retire-respawn-destroy`, `orchestrator-coordinator-cleanup`
 - `ResumeOrchestratorCompleted`
-  - anchors: `mob_handle_surface`, `mob_actor_authority`
-  - scenarios: `spawn-work-terminal`, `retire-respawn-destroy`
+  - anchors: `mob_actor_authority`
+  - scenarios: `orchestrator-coordinator-cleanup`
 - `DestroyOrchestratorRunning`
-  - anchors: `mob_handle_surface`, `mob_actor_authority`
-  - scenarios: `spawn-work-terminal`, `retire-respawn-destroy`
+  - anchors: `mob_actor_authority`
+  - scenarios: `retire-respawn-destroy`, `orchestrator-coordinator-cleanup`
 - `DestroyOrchestratorStopped`
-  - anchors: `mob_handle_surface`, `mob_actor_authority`
-  - scenarios: `spawn-work-terminal`, `retire-respawn-destroy`
+  - anchors: `mob_actor_authority`
+  - scenarios: `retire-respawn-destroy`, `orchestrator-coordinator-cleanup`
 - `DestroyOrchestratorCompleted`
-  - anchors: `mob_handle_surface`, `mob_actor_authority`
-  - scenarios: `spawn-work-terminal`, `retire-respawn-destroy`
+  - anchors: `mob_actor_authority`
+  - scenarios: `orchestrator-coordinator-cleanup`
 - `ForceCancelMemberRunning`
-  - anchors: `mob_handle_surface`, `mob_actor_authority`
-  - scenarios: `spawn-work-terminal`, `retire-respawn-destroy`
+  - anchors: `mob_actor_authority`
+  - scenarios: `task-flow-and-run-lifecycle`
 - `MemberPeerExposedRunning`
-  - anchors: `mob_handle_surface`, `mob_actor_authority`
-  - scenarios: `spawn-work-terminal`, `retire-respawn-destroy`
+  - anchors: `mob_actor_authority`
+  - scenarios: `operator-provenance-and-peer-input`
 - `MemberTerminalizedRunning`
-  - anchors: `mob_handle_surface`, `mob_actor_authority`
-  - scenarios: `spawn-work-terminal`, `retire-respawn-destroy`
+  - anchors: `mob_actor_authority`
+  - scenarios: `retire-respawn-destroy`, `task-flow-and-run-lifecycle`
 - `OperationPeerTrustedRunning`
-  - anchors: `mob_handle_surface`, `mob_actor_authority`
-  - scenarios: `spawn-work-terminal`, `retire-respawn-destroy`
+  - anchors: `mob_actor_authority`
+  - scenarios: `operator-provenance-and-peer-input`
 - `PeerInputAdmittedRunning`
-  - anchors: `mob_handle_surface`, `mob_actor_authority`
-  - scenarios: `spawn-work-terminal`, `retire-respawn-destroy`
+  - anchors: `mob_actor_authority`
+  - scenarios: `operator-provenance-and-peer-input`
 - `BeginCleanupStopped`
-  - anchors: `mob_handle_surface`, `mob_actor_authority`
-  - scenarios: `spawn-work-terminal`, `retire-respawn-destroy`
+  - anchors: `mob_actor_authority`
+  - scenarios: `orchestrator-coordinator-cleanup`
 - `BeginCleanupCompleted`
-  - anchors: `mob_handle_surface`, `mob_actor_authority`
-  - scenarios: `spawn-work-terminal`, `retire-respawn-destroy`
+  - anchors: `mob_actor_authority`
+  - scenarios: `orchestrator-coordinator-cleanup`
 - `FinishCleanupStopped`
-  - anchors: `mob_handle_surface`, `mob_actor_authority`
-  - scenarios: `spawn-work-terminal`, `retire-respawn-destroy`
+  - anchors: `mob_actor_authority`
+  - scenarios: `orchestrator-coordinator-cleanup`
 - `FinishCleanupCompleted`
-  - anchors: `mob_handle_surface`, `mob_actor_authority`
-  - scenarios: `spawn-work-terminal`, `retire-respawn-destroy`
+  - anchors: `mob_actor_authority`
+  - scenarios: `task-flow-and-run-lifecycle`, `orchestrator-coordinator-cleanup`
 - `RunFlowRunning`
-  - anchors: `mob_handle_surface`, `mob_actor_authority`
-  - scenarios: `spawn-work-terminal`, `retire-respawn-destroy`
+  - anchors: `mob_actor_authority`
+  - scenarios: `task-flow-and-run-lifecycle`
 - `StartFlowRunning`
-  - anchors: `mob_handle_surface`, `mob_actor_authority`
-  - scenarios: `spawn-work-terminal`, `retire-respawn-destroy`
+  - anchors: `mob_actor_authority`
+  - scenarios: `task-flow-and-run-lifecycle`
 - `CreateRunRunning`
-  - anchors: `mob_handle_surface`, `mob_actor_authority`
-  - scenarios: `spawn-work-terminal`, `retire-respawn-destroy`
+  - anchors: `mob_actor_authority`
+  - scenarios: `task-flow-and-run-lifecycle`
 - `StartRunRunning`
-  - anchors: `mob_handle_surface`, `mob_actor_authority`
-  - scenarios: `spawn-work-terminal`, `retire-respawn-destroy`
+  - anchors: `mob_actor_authority`
+  - scenarios: `task-flow-and-run-lifecycle`
 - `CompleteFlowRunning`
-  - anchors: `mob_handle_surface`, `mob_actor_authority`
-  - scenarios: `spawn-work-terminal`, `retire-respawn-destroy`
+  - anchors: `mob_actor_authority`
+  - scenarios: `task-flow-and-run-lifecycle`
 - `CompleteFlowRunningZero`
-  - anchors: `mob_handle_surface`, `mob_actor_authority`
-  - scenarios: `spawn-work-terminal`, `retire-respawn-destroy`
+  - anchors: `mob_actor_authority`
+  - scenarios: `task-flow-and-run-lifecycle`
 - `FinishRunRunning`
-  - anchors: `mob_handle_surface`, `mob_actor_authority`
-  - scenarios: `spawn-work-terminal`, `retire-respawn-destroy`
+  - anchors: `mob_actor_authority`
+  - scenarios: `task-flow-and-run-lifecycle`
 - `FinishRunRunningZero`
-  - anchors: `mob_handle_surface`, `mob_actor_authority`
-  - scenarios: `spawn-work-terminal`, `retire-respawn-destroy`
+  - anchors: `mob_actor_authority`
+  - scenarios: `task-flow-and-run-lifecycle`
 - `RetireRunningReleasing`
-  - anchors: `mob_handle_surface`, `mob_actor_authority`
-  - scenarios: `spawn-work-terminal`, `retire-respawn-destroy`
+  - anchors: `mob_actor_authority`
+  - scenarios: `retire-respawn-destroy`
 - `RetireRunningPreservingBinding`
-  - anchors: `mob_handle_surface`, `mob_actor_authority`
-  - scenarios: `spawn-work-terminal`, `retire-respawn-destroy`
+  - anchors: `mob_actor_authority`
+  - scenarios: `retire-respawn-destroy`
 - `RetireRunningNoBinding`
-  - anchors: `mob_handle_surface`, `mob_actor_authority`
-  - scenarios: `spawn-work-terminal`, `retire-respawn-destroy`
+  - anchors: `mob_actor_authority`
+  - scenarios: `retire-respawn-destroy`
 - `RetireStoppedReleasing`
-  - anchors: `mob_handle_surface`, `mob_actor_authority`
-  - scenarios: `spawn-work-terminal`, `retire-respawn-destroy`
+  - anchors: `mob_actor_authority`
+  - scenarios: `retire-respawn-destroy`
 - `SessionIngressDetachedForMobDestroyRunning`
-  - anchors: `mob_handle_surface`, `mob_actor_authority`
-  - scenarios: `spawn-work-terminal`, `retire-respawn-destroy`
+  - anchors: `mob_actor_authority`
+  - scenarios: `retire-respawn-destroy`, `wiring-and-session-binding`, `task-flow-and-run-lifecycle`
 - `SessionIngressDetachedForMobDestroyStopped`
-  - anchors: `mob_handle_surface`, `mob_actor_authority`
-  - scenarios: `spawn-work-terminal`, `retire-respawn-destroy`
+  - anchors: `mob_actor_authority`
+  - scenarios: `retire-respawn-destroy`, `wiring-and-session-binding`
 - `SessionIngressDetachFailedForMobDestroyRunning`
-  - anchors: `mob_handle_surface`, `mob_actor_authority`
-  - scenarios: `spawn-work-terminal`, `retire-respawn-destroy`
+  - anchors: `mob_actor_authority`
+  - scenarios: `retire-respawn-destroy`, `wiring-and-session-binding`, `task-flow-and-run-lifecycle`
 - `SessionIngressDetachFailedForMobDestroyStopped`
-  - anchors: `mob_handle_surface`, `mob_actor_authority`
-  - scenarios: `spawn-work-terminal`, `retire-respawn-destroy`
+  - anchors: `mob_actor_authority`
+  - scenarios: `retire-respawn-destroy`, `wiring-and-session-binding`
 - `RetireStoppedPreservingBinding`
-  - anchors: `mob_handle_surface`, `mob_actor_authority`
-  - scenarios: `spawn-work-terminal`, `retire-respawn-destroy`
+  - anchors: `mob_actor_authority`
+  - scenarios: `retire-respawn-destroy`
 - `RetireStoppedNoBinding`
-  - anchors: `mob_handle_surface`, `mob_actor_authority`
-  - scenarios: `spawn-work-terminal`, `retire-respawn-destroy`
+  - anchors: `mob_actor_authority`
+  - scenarios: `retire-respawn-destroy`
 - `RetireAllRunning`
-  - anchors: `mob_handle_surface`, `mob_actor_authority`
-  - scenarios: `spawn-work-terminal`, `retire-respawn-destroy`
+  - anchors: `mob_actor_authority`
+  - scenarios: `retire-respawn-destroy`
 - `RetireAllStopped`
-  - anchors: `mob_handle_surface`, `mob_actor_authority`
-  - scenarios: `spawn-work-terminal`, `retire-respawn-destroy`
+  - anchors: `mob_actor_authority`
+  - scenarios: `retire-respawn-destroy`
 - `CompleteSpawnRunning`
-  - anchors: `mob_handle_surface`, `mob_actor_authority`
-  - scenarios: `spawn-work-terminal`, `retire-respawn-destroy`
+  - anchors: `mob_actor_authority`
+  - scenarios: `retire-respawn-destroy`, `task-flow-and-run-lifecycle`
 - `DestroyFromAny`
-  - anchors: `mob_handle_surface`, `mob_actor_authority`
-  - scenarios: `spawn-work-terminal`, `retire-respawn-destroy`
+  - anchors: `mob_actor_authority`
+  - scenarios: `retire-respawn-destroy`, `orchestrator-coordinator-cleanup`
 - `RespawnRunning`
-  - anchors: `mob_handle_surface`, `mob_actor_authority`
-  - scenarios: `spawn-work-terminal`, `retire-respawn-destroy`
+  - anchors: `mob_actor_authority`
+  - scenarios: `retire-respawn-destroy`
 - `CancelAllWorkRunning`
-  - anchors: `mob_handle_surface`, `mob_actor_authority`
-  - scenarios: `spawn-work-terminal`, `retire-respawn-destroy`
+  - anchors: `mob_actor_authority`
+  - scenarios: `task-flow-and-run-lifecycle`
 
 ### Effects
 - `RequestRuntimeBinding`
-  - anchors: `mob_handle_surface`, `mob_actor_authority`
-  - scenarios: `spawn-work-terminal`, `retire-respawn-destroy`
+  - anchors: `mob_actor_authority`
+  - scenarios: `spawn-work-terminal`, `retire-respawn-destroy`, `wiring-and-session-binding`
 - `RequestRuntimeIngress`
-  - anchors: `mob_handle_surface`, `mob_actor_authority`
+  - anchors: `mob_actor_authority`
   - scenarios: `spawn-work-terminal`, `retire-respawn-destroy`
 - `RequestRuntimeRetire`
-  - anchors: `mob_handle_surface`, `mob_actor_authority`
-  - scenarios: `spawn-work-terminal`, `retire-respawn-destroy`
+  - anchors: `mob_actor_authority`
+  - scenarios: `retire-respawn-destroy`
 - `RequestSessionIngressDetachForMobDestroy`
-  - anchors: `mob_handle_surface`, `mob_actor_authority`
-  - scenarios: `spawn-work-terminal`, `retire-respawn-destroy`
+  - anchors: `mob_actor_authority`
+  - scenarios: `wiring-and-session-binding`
 - `RequestRuntimeDestroy`
-  - anchors: `mob_handle_surface`, `mob_actor_authority`
-  - scenarios: `spawn-work-terminal`, `retire-respawn-destroy`
+  - anchors: `mob_actor_authority`
+  - scenarios: `retire-respawn-destroy`
 - `EmitMemberLifecycleNotice`
-  - anchors: `mob_handle_surface`, `mob_actor_authority`
-  - scenarios: `spawn-work-terminal`, `retire-respawn-destroy`
+  - anchors: `mob_actor_authority`
+  - scenarios: `wiring-and-session-binding`, `event-subscriptions-and-notices`
 - `EmitRunLifecycleNotice`
-  - anchors: `mob_handle_surface`, `mob_actor_authority`
-  - scenarios: `spawn-work-terminal`, `retire-respawn-destroy`
+  - anchors: `mob_actor_authority`
+  - scenarios: `event-subscriptions-and-notices`
 - `EmitFlowRunNotice`
-  - anchors: `mob_handle_surface`, `mob_actor_authority`
-  - scenarios: `spawn-work-terminal`, `retire-respawn-destroy`
+  - anchors: `mob_actor_authority`
+  - scenarios: `event-subscriptions-and-notices`
 - `AppendFailureLedger`
-  - anchors: `mob_handle_surface`, `mob_actor_authority`
-  - scenarios: `spawn-work-terminal`, `retire-respawn-destroy`
+  - anchors: `mob_actor_authority`
+  - scenarios: `operator-provenance-and-peer-input`
 - `FlowTerminalized`
-  - anchors: `mob_handle_surface`, `mob_actor_authority`
-  - scenarios: `spawn-work-terminal`, `retire-respawn-destroy`
+  - anchors: `mob_actor_authority`
+  - scenarios: `task-flow-and-run-lifecycle`
 - `EscalateSupervisor`
-  - anchors: `mob_handle_surface`, `mob_actor_authority`
-  - scenarios: `spawn-work-terminal`, `retire-respawn-destroy`
+  - anchors: `mob_actor_authority`
+  - scenarios: `orchestrator-coordinator-cleanup`
 - `NotifyCoordinator`
-  - anchors: `mob_handle_surface`, `mob_actor_authority`
-  - scenarios: `spawn-work-terminal`, `retire-respawn-destroy`
+  - anchors: `mob_actor_authority`
+  - scenarios: `orchestrator-coordinator-cleanup`
 - `ExposePendingSpawn`
-  - anchors: `mob_handle_surface`, `mob_actor_authority`
-  - scenarios: `spawn-work-terminal`, `retire-respawn-destroy`
+  - anchors: `mob_actor_authority`
+  - scenarios: `wiring-and-session-binding`
 - `EmitMemberTerminalNotice`
-  - anchors: `mob_handle_surface`, `mob_actor_authority`
-  - scenarios: `spawn-work-terminal`, `retire-respawn-destroy`
+  - anchors: `mob_actor_authority`
+  - scenarios: `event-subscriptions-and-notices`
 - `AdmitPeerInput`
-  - anchors: `mob_handle_surface`, `mob_actor_authority`
-  - scenarios: `spawn-work-terminal`, `retire-respawn-destroy`
+  - anchors: `mob_actor_authority`
+  - scenarios: `operator-provenance-and-peer-input`
 - `EmitProgressNote`
-  - anchors: `mob_handle_surface`, `mob_actor_authority`
-  - scenarios: `spawn-work-terminal`, `retire-respawn-destroy`
+  - anchors: `mob_actor_authority`
+  - scenarios: `event-subscriptions-and-notices`
 - `EmitTaskNotice`
-  - anchors: `mob_handle_surface`, `mob_actor_authority`
-  - scenarios: `spawn-work-terminal`, `retire-respawn-destroy`
+  - anchors: `mob_actor_authority`
+  - scenarios: `event-subscriptions-and-notices`
 - `WiringGraphChanged`
-  - anchors: `mob_handle_surface`, `mob_actor_authority`
-  - scenarios: `spawn-work-terminal`, `retire-respawn-destroy`
+  - anchors: `mob_actor_authority`
+  - scenarios: `wiring-and-session-binding`
 - `MemberSessionBindingChanged`
-  - anchors: `mob_handle_surface`, `mob_actor_authority`
-  - scenarios: `spawn-work-terminal`, `retire-respawn-destroy`
+  - anchors: `mob_actor_authority`
+  - scenarios: `wiring-and-session-binding`
 - `EmitWiringLifecycleNotice`
-  - anchors: `mob_handle_surface`, `mob_actor_authority`
-  - scenarios: `spawn-work-terminal`, `retire-respawn-destroy`
+  - anchors: `mob_actor_authority`
+  - scenarios: `wiring-and-session-binding`, `event-subscriptions-and-notices`
 
 ### Invariants
 - `bindings_require_known_identity`
-  - anchors: `mob_handle_surface`, `mob_actor_authority`
-  - scenarios: `spawn-work-terminal`, `retire-respawn-destroy`
+  - anchors: `mob_handle_surface`
+  - scenarios: `wiring-and-session-binding`
 
 
 <!-- GENERATED_COVERAGE_END -->

--- a/specs/machines/occurrence_lifecycle/contract.md
+++ b/specs/machines/occurrence_lifecycle/contract.md
@@ -128,7 +128,10 @@ _Generated from the Rust machine catalog. Do not edit by hand._
 
 ## Coverage
 ### Code Anchors
-- `meerkat-schedule/src/lifecycle.rs` — Occurrence::apply domain-facing lifecycle transition seam over the DSL
+- `meerkat-schedule/src/lifecycle.rs` — Occurrence::apply domain-facing lifecycle transition seam over claim, claimed, dispatch, await completion, complete, completed, skip, skipped, misfire, misfired, supersede, superseded, delivery failure, lease expiry, live owner, revision, and failure classification
 
 ### Scenarios
 - `occurrence_start_complete_fail` — occurrence transitions through pending, running, and terminal lifecycle states
+- `occurrence_claim_dispatch_completion` — claim pending occurrence, dispatch started from claimed, await completion, complete from dispatching or awaiting, and record claimed/dispatch/awaiting/completed effects
+- `occurrence_terminal_classification` — skip/skipped, misfire/misfired, supersede/superseded, delivery failed, occurrences superseded, records revision and explicit failure class for terminal occurrence outcomes
+- `occurrence_lease_recovery` — lease expired from claimed, dispatching, or awaiting completion returns live claimed work to owner-aware recovery

--- a/specs/machines/occurrence_lifecycle/mapping.md
+++ b/specs/machines/occurrence_lifecycle/mapping.md
@@ -8,88 +8,91 @@ This section is generated from the Rust machine catalog. Do not edit it by hand.
 - `OccurrenceLifecycleMachine`
 
 ### Code Anchors
-- `occurrence_lifecycle`: `meerkat-schedule/src/lifecycle.rs` — Occurrence::apply domain-facing lifecycle transition seam over the DSL
+- `occurrence_lifecycle`: `meerkat-schedule/src/lifecycle.rs` — Occurrence::apply domain-facing lifecycle transition seam over claim, claimed, dispatch, await completion, complete, completed, skip, skipped, misfire, misfired, supersede, superseded, delivery failure, lease expiry, live owner, revision, and failure classification
 
 ### Scenarios
 - `occurrence_start_complete_fail` — occurrence transitions through pending, running, and terminal lifecycle states
+- `occurrence_claim_dispatch_completion` — claim pending occurrence, dispatch started from claimed, await completion, complete from dispatching or awaiting, and record claimed/dispatch/awaiting/completed effects
+- `occurrence_terminal_classification` — skip/skipped, misfire/misfired, supersede/superseded, delivery failed, occurrences superseded, records revision and explicit failure class for terminal occurrence outcomes
+- `occurrence_lease_recovery` — lease expired from claimed, dispatching, or awaiting completion returns live claimed work to owner-aware recovery
 
 ### Transitions
 - `ClaimPending`
   - anchors: `occurrence_lifecycle`
-  - scenarios: `occurrence_start_complete_fail`
+  - scenarios: `occurrence_claim_dispatch_completion`
 - `DispatchStartedFromClaimed`
   - anchors: `occurrence_lifecycle`
-  - scenarios: `occurrence_start_complete_fail`
+  - scenarios: `occurrence_claim_dispatch_completion`
 - `AwaitCompletionFromDispatching`
   - anchors: `occurrence_lifecycle`
-  - scenarios: `occurrence_start_complete_fail`
+  - scenarios: `occurrence_claim_dispatch_completion`, `occurrence_lease_recovery`
 - `CompleteFromDispatchingOrAwaiting`
   - anchors: `occurrence_lifecycle`
-  - scenarios: `occurrence_start_complete_fail`
+  - scenarios: `occurrence_claim_dispatch_completion`
 - `SkipFromPendingOrLive`
   - anchors: `occurrence_lifecycle`
-  - scenarios: `occurrence_start_complete_fail`
+  - scenarios: `occurrence_claim_dispatch_completion`
 - `MisfireFromPendingOrLive`
   - anchors: `occurrence_lifecycle`
-  - scenarios: `occurrence_start_complete_fail`
+  - scenarios: `occurrence_claim_dispatch_completion`
 - `SupersedePendingOrLive`
   - anchors: `occurrence_lifecycle`
-  - scenarios: `occurrence_start_complete_fail`
+  - scenarios: `occurrence_start_complete_fail`, `occurrence_claim_dispatch_completion`, `occurrence_terminal_classification`
 - `DeliveryFailedFromClaimedOrLive`
   - anchors: `occurrence_lifecycle`
-  - scenarios: `occurrence_start_complete_fail`
+  - scenarios: `occurrence_claim_dispatch_completion`, `occurrence_terminal_classification`, `occurrence_lease_recovery`
 - `LeaseExpiredFromClaimed`
   - anchors: `occurrence_lifecycle`
-  - scenarios: `occurrence_start_complete_fail`
+  - scenarios: `occurrence_lease_recovery`
 - `LeaseExpiredFromDispatching`
   - anchors: `occurrence_lifecycle`
-  - scenarios: `occurrence_start_complete_fail`
+  - scenarios: `occurrence_lease_recovery`
 - `LeaseExpiredFromAwaitingCompletion`
   - anchors: `occurrence_lifecycle`
-  - scenarios: `occurrence_start_complete_fail`
+  - scenarios: `occurrence_lease_recovery`
 
 ### Effects
 - `Claimed`
   - anchors: `occurrence_lifecycle`
-  - scenarios: `occurrence_start_complete_fail`
+  - scenarios: `occurrence_claim_dispatch_completion`, `occurrence_lease_recovery`
 - `DispatchStarted`
   - anchors: `occurrence_lifecycle`
-  - scenarios: `occurrence_start_complete_fail`
+  - scenarios: `occurrence_claim_dispatch_completion`
 - `AwaitingCompletion`
   - anchors: `occurrence_lifecycle`
-  - scenarios: `occurrence_start_complete_fail`
+  - scenarios: `occurrence_claim_dispatch_completion`, `occurrence_lease_recovery`
 - `Completed`
   - anchors: `occurrence_lifecycle`
-  - scenarios: `occurrence_start_complete_fail`
+  - scenarios: `occurrence_claim_dispatch_completion`
 - `Skipped`
   - anchors: `occurrence_lifecycle`
-  - scenarios: `occurrence_start_complete_fail`
+  - scenarios: `occurrence_terminal_classification`
 - `Misfired`
   - anchors: `occurrence_lifecycle`
-  - scenarios: `occurrence_start_complete_fail`
+  - scenarios: `occurrence_terminal_classification`
 - `Superseded`
   - anchors: `occurrence_lifecycle`
-  - scenarios: `occurrence_start_complete_fail`
+  - scenarios: `occurrence_terminal_classification`
 - `OccurrencesSuperseded`
   - anchors: `occurrence_lifecycle`
-  - scenarios: `occurrence_start_complete_fail`
+  - scenarios: `occurrence_terminal_classification`
 - `DeliveryFailed`
   - anchors: `occurrence_lifecycle`
-  - scenarios: `occurrence_start_complete_fail`
+  - scenarios: `occurrence_terminal_classification`
 - `LeaseExpired`
   - anchors: `occurrence_lifecycle`
-  - scenarios: `occurrence_start_complete_fail`
+  - scenarios: `occurrence_lease_recovery`
 
 ### Invariants
 - `live_claim_requires_owner`
   - anchors: `occurrence_lifecycle`
-  - scenarios: `occurrence_start_complete_fail`
+  - scenarios: `occurrence_lease_recovery`
 - `superseded_records_revision`
   - anchors: `occurrence_lifecycle`
-  - scenarios: `occurrence_start_complete_fail`
+  - scenarios: `occurrence_terminal_classification`
 - `delivery_failed_records_failure_class`
   - anchors: `occurrence_lifecycle`
-  - scenarios: `occurrence_start_complete_fail`
+  - scenarios: `occurrence_terminal_classification`
 
 
 <!-- GENERATED_COVERAGE_END -->

--- a/specs/machines/schedule_lifecycle/contract.md
+++ b/specs/machines/schedule_lifecycle/contract.md
@@ -111,7 +111,8 @@ _Generated from the Rust machine catalog. Do not edit by hand._
 
 ## Coverage
 ### Code Anchors
-- `meerkat-schedule/src/lifecycle.rs` — Schedule::apply domain-facing lifecycle transition seam over the DSL
+- `meerkat-schedule/src/lifecycle.rs` — Schedule::apply domain-facing lifecycle transition seam over create, revise, planning window, pause, resume, delete, supersede pending occurrences, revision, and planning cursor rules
 
 ### Scenarios
 - `schedule_pause_resume_delete` — schedule transitions through create, pause, resume, and delete while advancing revision
+- `schedule_revision_and_planning` — active or paused schedules revise, record planning windows, confirm superseded occurrences, supersede pending occurrences, maintain positive revision, and require occurrence progress for planning cursor

--- a/specs/machines/schedule_lifecycle/mapping.md
+++ b/specs/machines/schedule_lifecycle/mapping.md
@@ -8,10 +8,11 @@ This section is generated from the Rust machine catalog. Do not edit it by hand.
 - `ScheduleLifecycleMachine`
 
 ### Code Anchors
-- `schedule_lifecycle`: `meerkat-schedule/src/lifecycle.rs` — Schedule::apply domain-facing lifecycle transition seam over the DSL
+- `schedule_lifecycle`: `meerkat-schedule/src/lifecycle.rs` — Schedule::apply domain-facing lifecycle transition seam over create, revise, planning window, pause, resume, delete, supersede pending occurrences, revision, and planning cursor rules
 
 ### Scenarios
 - `schedule_pause_resume_delete` — schedule transitions through create, pause, resume, and delete while advancing revision
+- `schedule_revision_and_planning` — active or paused schedules revise, record planning windows, confirm superseded occurrences, supersede pending occurrences, maintain positive revision, and require occurrence progress for planning cursor
 
 ### Transitions
 - `CreateSchedule`
@@ -19,59 +20,59 @@ This section is generated from the Rust machine catalog. Do not edit it by hand.
   - scenarios: `schedule_pause_resume_delete`
 - `ReviseActive`
   - anchors: `schedule_lifecycle`
-  - scenarios: `schedule_pause_resume_delete`
+  - scenarios: `schedule_revision_and_planning`
 - `RevisePaused`
   - anchors: `schedule_lifecycle`
-  - scenarios: `schedule_pause_resume_delete`
+  - scenarios: `schedule_revision_and_planning`
 - `RecordPlanningWindowActive`
   - anchors: `schedule_lifecycle`
-  - scenarios: `schedule_pause_resume_delete`
+  - scenarios: `schedule_revision_and_planning`
 - `PauseActiveOrPaused`
   - anchors: `schedule_lifecycle`
-  - scenarios: `schedule_pause_resume_delete`
+  - scenarios: `schedule_revision_and_planning`
 - `ResumeActiveOrPaused`
   - anchors: `schedule_lifecycle`
-  - scenarios: `schedule_pause_resume_delete`
+  - scenarios: `schedule_pause_resume_delete`, `schedule_revision_and_planning`
 - `DeleteActive`
   - anchors: `schedule_lifecycle`
-  - scenarios: `schedule_pause_resume_delete`
+  - scenarios: `schedule_pause_resume_delete`, `schedule_revision_and_planning`
 - `DeletePaused`
   - anchors: `schedule_lifecycle`
-  - scenarios: `schedule_pause_resume_delete`
+  - scenarios: `schedule_pause_resume_delete`, `schedule_revision_and_planning`
 - `DeleteDeleted`
   - anchors: `schedule_lifecycle`
   - scenarios: `schedule_pause_resume_delete`
 - `ConfirmOccurrencesSupersededActive`
   - anchors: `schedule_lifecycle`
-  - scenarios: `schedule_pause_resume_delete`
+  - scenarios: `schedule_revision_and_planning`
 - `ConfirmOccurrencesSupersededPaused`
   - anchors: `schedule_lifecycle`
-  - scenarios: `schedule_pause_resume_delete`
+  - scenarios: `schedule_revision_and_planning`
 - `ConfirmOccurrencesSupersededDeleted`
   - anchors: `schedule_lifecycle`
-  - scenarios: `schedule_pause_resume_delete`
+  - scenarios: `schedule_revision_and_planning`
 
 ### Effects
 - `EmitScheduleNotice`
   - anchors: `schedule_lifecycle`
-  - scenarios: `schedule_pause_resume_delete`
+  - scenarios: `schedule_pause_resume_delete`, `schedule_revision_and_planning`
 - `SupersedePendingOccurrences`
   - anchors: `schedule_lifecycle`
-  - scenarios: `schedule_pause_resume_delete`
+  - scenarios: `schedule_revision_and_planning`
 - `PlanningWindowRecorded`
   - anchors: `schedule_lifecycle`
-  - scenarios: `schedule_pause_resume_delete`
+  - scenarios: `schedule_revision_and_planning`
 
 ### Invariants
 - `revision_is_positive`
   - anchors: `schedule_lifecycle`
-  - scenarios: `schedule_pause_resume_delete`
+  - scenarios: `schedule_revision_and_planning`
 - `deleted_has_no_planning_cursor`
   - anchors: `schedule_lifecycle`
-  - scenarios: `schedule_pause_resume_delete`
+  - scenarios: `schedule_revision_and_planning`
 - `planning_cursor_requires_occurrence_progress`
   - anchors: `schedule_lifecycle`
-  - scenarios: `schedule_pause_resume_delete`
+  - scenarios: `schedule_revision_and_planning`
 
 
 <!-- GENERATED_COVERAGE_END -->

--- a/test-fixtures/machine-dsl-tests/src/meerkat_machine.rs
+++ b/test-fixtures/machine-dsl-tests/src/meerkat_machine.rs
@@ -1609,6 +1609,30 @@ mod tests {
 
     #[test]
     fn dsl_dispatch_matches_kernel() {
+        fn named_string(
+            type_name: &str,
+            value: &str,
+        ) -> meerkat_machine_kernels::test_oracle::KernelValue {
+            meerkat_machine_kernels::test_oracle::KernelValue::Named {
+                type_name: meerkat_machine_schema::identity::NamedTypeId::parse(type_name).unwrap(),
+                value: Box::new(meerkat_machine_kernels::test_oracle::KernelValue::String(
+                    value.into(),
+                )),
+            }
+        }
+
+        fn named_u64(
+            type_name: &str,
+            value: u64,
+        ) -> meerkat_machine_kernels::test_oracle::KernelValue {
+            meerkat_machine_kernels::test_oracle::KernelValue::Named {
+                type_name: meerkat_machine_schema::identity::NamedTypeId::parse(type_name).unwrap(),
+                value: Box::new(meerkat_machine_kernels::test_oracle::KernelValue::U64(
+                    value,
+                )),
+            }
+        }
+
         let schema = MeerkatMachineState::schema();
         let kernel = meerkat_machine_kernels::test_oracle::GeneratedMachineKernel::new(schema);
 
@@ -1641,7 +1665,7 @@ mod tests {
             variant: ivid("RegisterSession"),
             fields: std::collections::BTreeMap::from([(
                 fid("session_id"),
-                meerkat_machine_kernels::test_oracle::KernelValue::String("s1".into()),
+                named_string("SessionId", "s1"),
             )]),
         };
         let kr = kernel.transition(&kernel_state, &ki);
@@ -1671,16 +1695,10 @@ mod tests {
             fields: std::collections::BTreeMap::from([
                 (
                     fid("agent_runtime_id"),
-                    meerkat_machine_kernels::test_oracle::KernelValue::String("rt-1".into()),
+                    named_string("AgentRuntimeId", "rt-1"),
                 ),
-                (
-                    fid("fence_token"),
-                    meerkat_machine_kernels::test_oracle::KernelValue::U64(1),
-                ),
-                (
-                    fid("generation"),
-                    meerkat_machine_kernels::test_oracle::KernelValue::U64(1),
-                ),
+                (fid("fence_token"), named_u64("FenceToken", 1)),
+                (fid("generation"), named_u64("Generation", 1)),
             ]),
         };
         let kr = kernel.transition(&kernel_state, &ki);

--- a/test-fixtures/machine-dsl-tests/src/mob_machine.rs
+++ b/test-fixtures/machine-dsl-tests/src/mob_machine.rs
@@ -1213,6 +1213,30 @@ mod tests {
 
     #[test]
     fn dsl_dispatch_matches_kernel() {
+        fn named_string(
+            type_name: &str,
+            value: &str,
+        ) -> meerkat_machine_kernels::test_oracle::KernelValue {
+            meerkat_machine_kernels::test_oracle::KernelValue::Named {
+                type_name: meerkat_machine_schema::identity::NamedTypeId::parse(type_name).unwrap(),
+                value: Box::new(meerkat_machine_kernels::test_oracle::KernelValue::String(
+                    value.into(),
+                )),
+            }
+        }
+
+        fn named_u64(
+            type_name: &str,
+            value: u64,
+        ) -> meerkat_machine_kernels::test_oracle::KernelValue {
+            meerkat_machine_kernels::test_oracle::KernelValue::Named {
+                type_name: meerkat_machine_schema::identity::NamedTypeId::parse(type_name).unwrap(),
+                value: Box::new(meerkat_machine_kernels::test_oracle::KernelValue::U64(
+                    value,
+                )),
+            }
+        }
+
         let schema = MobMachineState::schema();
         let kernel = meerkat_machine_kernels::test_oracle::GeneratedMachineKernel::new(schema);
 
@@ -1237,20 +1261,14 @@ mod tests {
             fields: std::collections::BTreeMap::from([
                 (
                     fid("agent_identity"),
-                    meerkat_machine_kernels::test_oracle::KernelValue::String("agent-1".into()),
+                    named_string("AgentIdentity", "agent-1"),
                 ),
                 (
                     fid("agent_runtime_id"),
-                    meerkat_machine_kernels::test_oracle::KernelValue::String("rt-1".into()),
+                    named_string("AgentRuntimeId", "rt-1"),
                 ),
-                (
-                    fid("fence_token"),
-                    meerkat_machine_kernels::test_oracle::KernelValue::U64(1),
-                ),
-                (
-                    fid("generation"),
-                    meerkat_machine_kernels::test_oracle::KernelValue::U64(0),
-                ),
+                (fid("fence_token"), named_u64("FenceToken", 1)),
+                (fid("generation"), named_u64("Generation", 0)),
                 (
                     fid("external_addressable"),
                     meerkat_machine_kernels::test_oracle::KernelValue::Bool(true),

--- a/test-fixtures/machine-dsl-tests/src/occurrence_lifecycle.rs
+++ b/test-fixtures/machine-dsl-tests/src/occurrence_lifecycle.rs
@@ -514,6 +514,18 @@ mod tests {
 
     #[test]
     fn dsl_dispatch_matches_kernel() {
+        fn named_string(
+            type_name: &str,
+            value: &str,
+        ) -> meerkat_machine_kernels::test_oracle::KernelValue {
+            meerkat_machine_kernels::test_oracle::KernelValue::Named {
+                type_name: meerkat_machine_schema::identity::NamedTypeId::parse(type_name).unwrap(),
+                value: Box::new(meerkat_machine_kernels::test_oracle::KernelValue::String(
+                    value.into(),
+                )),
+            }
+        }
+
         let schema = OccurrenceLifecycleMachineState::schema();
         let kernel = meerkat_machine_kernels::test_oracle::GeneratedMachineKernel::new(schema);
 
@@ -547,10 +559,7 @@ mod tests {
                     fid("lease_expires_at_utc_ms"),
                     meerkat_machine_kernels::test_oracle::KernelValue::U64(2),
                 ),
-                (
-                    fid("claim_token"),
-                    meerkat_machine_kernels::test_oracle::KernelValue::String("t".into()),
-                ),
+                (fid("claim_token"), named_string("ClaimToken", "t")),
             ]),
         };
         let kernel_r = kernel.transition(&kernel_state, &kernel_input).unwrap();

--- a/xtask/src/machines.rs
+++ b/xtask/src/machines.rs
@@ -1398,6 +1398,16 @@ fn validate_semantic_entries(
                 entry.name
             );
         }
+        if anchor_ids.len() > 1
+            && scenario_ids.len() > 1
+            && entry.anchor_ids.len() == anchor_ids.len()
+            && entry.scenario_ids.len() == scenario_ids.len()
+        {
+            bail!(
+                "{owner} semantic coverage entry `{}` maps to every code anchor and every scenario; coverage must be semantic, not tautological",
+                entry.name
+            );
+        }
 
         for anchor_id in &entry.anchor_ids {
             if !anchor_ids.contains(anchor_id.as_str()) {
@@ -1545,13 +1555,15 @@ fn maybe_run_tlc_in_dir_with_config(
     let config = dir.join(config_name);
 
     if !model.exists() || !config.exists() {
-        println!("  tlc skipped for {slug} (no checked-in model/config)");
-        return Ok(None);
+        bail!(
+            "missing checked-in model/config for {slug} at {} / {}",
+            model.display(),
+            config.display()
+        );
     }
 
     if which::which("tlc").is_err() {
-        println!("  tlc skipped for {slug} (tlc not on PATH)");
-        return Ok(None);
+        bail!("tlc not on PATH; machine-verify requires the TLC CLI");
     }
 
     let root = repo_root()?;

--- a/xtask/src/machines_tests.rs
+++ b/xtask/src/machines_tests.rs
@@ -7,8 +7,8 @@ use std::fs;
 use super::*;
 #[cfg(feature = "machine-authority")]
 use meerkat_machine_schema::{
-    EnumSchema, InitSchema, MachineSchema, RustBinding, StateSchema, TransitionSchema,
-    VariantSchema,
+    EnumSchema, InitSchema, MachineSchema, RustBinding, SemanticCoverageEntry, StateSchema,
+    TransitionSchema, VariantSchema,
 };
 use tempfile::tempdir;
 
@@ -46,6 +46,31 @@ fn owner_tests_are_registered_only_for_remaining_canonical_surfaces() {
     let mob = owner_test_specs_for_machine("mob_machine");
     assert_eq!(mob.len(), 1);
     assert!(mob.iter().all(|spec| spec.package == "meerkat-mob"));
+}
+
+#[cfg(feature = "machine-authority")]
+#[test]
+fn semantic_coverage_rejects_all_anchor_all_scenario_entries() {
+    let anchors = BTreeSet::from(["runtime", "schema"]);
+    let scenarios = BTreeSet::from(["happy", "failure"]);
+    let err = validate_semantic_entries(
+        "machine TestMachine",
+        "transition",
+        &["Apply".to_string()],
+        &[SemanticCoverageEntry {
+            name: "Apply".to_string(),
+            anchor_ids: vec!["runtime".to_string(), "schema".to_string()],
+            scenario_ids: vec!["happy".to_string(), "failure".to_string()],
+        }],
+        &anchors,
+        &scenarios,
+    )
+    .expect_err("all-anchor/all-scenario coverage should be rejected");
+
+    assert!(
+        err.to_string().contains("not tautological"),
+        "unexpected error: {err:#}"
+    );
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- Makes `machine-verify` a real lights-on gate: missing models/configs or missing TLC now fail instead of reporting a successful skip.
- Rejects tautological semantic coverage mappings and regenerates machine/composition mapping artifacts.
- Adds typed named kernel values, wires runtime/mob test oracle conversions, and tightens runtime alphabet parity.
- Enforces `session_store_key` in memory/sqlite runtime stores and the persistent driver.
- Wires persistent event projection end-to-end through `FileEventStore` -> `PersistenceBundle` -> `build_runtime_backed_service` -> `PersistentSessionService`.

## Scope Expansion
- `meerkat-session` persistent event projection construction: encountered while applying README Absolute Rule; the helper existed but the realm/runtime-backed construction path did not install it, and no sibling PR explicitly owns this exact propagation. Fixed here with bundle/service-builder wiring plus tests.
- `meerkat/src/surface/runtime_backed.rs` test cfg: encountered while running focused tests; realtime OpenAI helpers were gated on `openai` while the crate exposes them through `openai-realtime`. Not owned by another planned PR; fixed here.
- `meerkat/src/persistence.rs` redundant clones and `xtask/src/machines_tests.rs` cfg-only import: encountered via clippy/pre-push; not owned by another planned PR; fixed here.

## Downstream Propagation Audit
- Machine gate changes propagate through xtask verification, CI/pre-push hooks, and full `machine-verify --all` owner-test/TLC execution.
- Semantic coverage changes propagate through generated mapping docs and `machine-check-drift --all`.
- `KernelValue::Named` propagates through runtime owner tests and meerkat-mob oracle conversion.
- `session_store_key` validation propagates through memory/sqlite runtime stores and the persistent driver.
- Persistent event projection now propagates through realm persistence, runtime-backed service construction, and persistent service event recording/projection tests.
- Runtime alphabet parity now compares generated schema input names to runtime command manifests without broad allowlists.

## Verification
- [x] `cargo fmt --check`
- [x] changed-crates clippy via pre-push hook
- [x] `cargo clippy -p meerkat -p meerkat-machine-codegen -p meerkat-machine-kernels -p meerkat-machine-schema -p meerkat-mob -p meerkat-runtime -p meerkat-session -p xtask --all-targets -- -D warnings`
- [x] `cargo xtask machine-codegen --all`
- [x] `cargo xtask machine-verify --all`
- [x] `cargo xtask machine-check-drift --all`
- [x] `cargo test -p meerkat-session --features session-store file_event_store_appends_and_reads_session_log --lib`
- [x] `cargo test -p meerkat-session --features session-store test_event_store_projection_records_persistent_session_events --lib`
- [x] `cargo test -p meerkat --features session-store,jsonl-store open_realm_persistence_sqlite_builds_runtime_companion --lib`
- [x] `cargo test -p meerkat --features session-store,jsonl-store open_realm_persistence_jsonl_has_no_runtime_companion --lib`
- [x] `cargo test -p meerkat --features session-store,jsonl-store build_runtime_backed_service_installs_realm_event_projection --lib`
- [x] `cargo test -p meerkat-machine-codegen --test runtime_alphabet_parity`
- [x] `cargo test -p meerkat-runtime atomic_apply --lib`
- [x] `cargo test -p xtask --features machine-authority semantic_coverage_rejects_all_anchor_all_scenario_entries --lib`
- [x] `cargo test -p meerkat-mob test_cancel_fallback_uses_direct_pending_to_terminal_cas_attempts --lib`
- [x] pre-push hooks: machine codegen + verify (changed files), audit-generated-headers, bridge layer gate, workspace deterministic gate
- [ ] Full local `unit`, `int`, `e2e-fast`, `e2e-system`, `seam-inventory --strict` not run in this turn

## Cross-PR Notes
- No encountered finding was left for a sibling PR owner.
