### PR TITLE
PR 4: Mob/Comms/Realtime Authority

### DIFF
--- a/meerkat-client/src/lib.rs
+++ b/meerkat-client/src/lib.rs
@@ -2,7 +2,7 @@
 //!
 //! The LLM wire-client trait + plumbing moved to `meerkat-llm-core`;
 //! per-provider clients (`AnthropicClient`, `OpenAiClient`, `GeminiClient`,
-//! `OpenAiLiveClient`, `OpenAiCompatibleClient`, `OpenAiRealtimeAttachmentOrchestrator`)
+//! `OpenAiLiveClient`, `OpenAiCompatibleClient`)
 //! moved to `meerkat-anthropic`, `meerkat-openai`, `meerkat-gemini`.
 //! Provider-runtime types moved to `meerkat-core::provider_runtime`.
 //! Auth primitives moved to `meerkat-auth-core`.
@@ -20,6 +20,12 @@ pub use meerkat_llm_core::{
 #[cfg(feature = "anthropic")]
 pub use meerkat_anthropic::AnthropicClient;
 
+#[cfg(all(
+    feature = "openai",
+    feature = "openai-realtime",
+    not(target_arch = "wasm32")
+))]
+pub use meerkat_openai::OpenAiLiveClient;
 #[cfg(feature = "openai")]
 pub use meerkat_openai::client_compatible::OpenAiCompatibleMode;
 #[cfg(all(
@@ -41,12 +47,6 @@ pub use meerkat_openai::live::{
 pub use meerkat_openai::realtime_attachment::RealtimeAttachmentToolDispatchHost;
 #[cfg(feature = "openai")]
 pub use meerkat_openai::{OpenAiClient, OpenAiCompatibleClient};
-#[cfg(all(
-    feature = "openai",
-    feature = "openai-realtime",
-    not(target_arch = "wasm32")
-))]
-pub use meerkat_openai::{OpenAiLiveClient, OpenAiRealtimeAttachmentOrchestrator};
 
 #[cfg(feature = "gemini")]
 pub use meerkat_gemini::GeminiClient;

--- a/meerkat-mob/src/runtime/actor.rs
+++ b/meerkat-mob/src/runtime/actor.rs
@@ -1100,35 +1100,34 @@ impl MobActor {
     }
 
     async fn clear_kickoff_state(&mut self, agent_identity: &MeerkatId) {
-        self.dsl_authority
-            .state
-            .member_kickoff_pending
-            .remove(&agent_identity.to_string());
-        self.dsl_authority
-            .state
-            .member_kickoff_starting
-            .remove(&agent_identity.to_string());
-        self.dsl_authority
-            .state
-            .member_kickoff_callback_pending
-            .remove(&agent_identity.to_string());
-        self.dsl_authority
-            .state
-            .member_kickoff_started
-            .remove(&agent_identity.to_string());
-        self.dsl_authority
-            .state
-            .member_kickoff_failed
-            .remove(&agent_identity.to_string());
-        self.dsl_authority
-            .state
-            .member_kickoff_cancelled
-            .remove(&agent_identity.to_string());
-        self.dsl_authority
-            .state
-            .member_kickoff_error
-            .remove(&agent_identity.to_string());
-        self.roster.write().await.set_kickoff(agent_identity, None);
+        match self
+            .apply_kickoff_input(
+                agent_identity,
+                mob_dsl::MobMachineInput::KickoffClear {
+                    member_id: agent_identity.to_string(),
+                },
+            )
+            .await
+        {
+            Ok(true) => {
+                self.roster.write().await.set_kickoff(agent_identity, None);
+            }
+            Ok(false) => {
+                tracing::warn!(
+                    mob_id = %self.definition.id,
+                    agent_identity = %agent_identity,
+                    "kickoff clear rejected by MobMachine; roster projection left unchanged"
+                );
+            }
+            Err(error) => {
+                tracing::warn!(
+                    mob_id = %self.definition.id,
+                    agent_identity = %agent_identity,
+                    %error,
+                    "kickoff clear failed"
+                );
+            }
+        }
     }
 
     async fn fail_startup_to_stopped(&mut self, failure_label: &'static str) {
@@ -2391,6 +2390,27 @@ impl MobActor {
                     let _ = reply_tx.send(super::state::MobStartupKickoffSnapshot {
                         pending_kickoff_member_ids: self.pending_kickoff_member_ids_from_dsl(),
                         ready_runtime_ids: self.ready_runtime_ids_from_dsl(),
+                    });
+                }
+                MobCommand::MemberMachineProjection {
+                    agent_identity,
+                    reply_tx,
+                } => {
+                    let dsl_identity = mob_dsl::AgentIdentity::from_domain(&agent_identity);
+                    let dsl = &self.dsl_authority.state;
+                    let runtime_id = dsl.identity_to_runtime.get(&dsl_identity).cloned();
+                    let state_marker = runtime_id
+                        .as_ref()
+                        .and_then(|runtime_id| dsl.member_state_markers.get(runtime_id).copied());
+                    let live_runtime = runtime_id
+                        .as_ref()
+                        .is_some_and(|runtime_id| dsl.live_runtime_ids.contains(runtime_id));
+                    let bound_session_id = dsl.member_session_bindings.get(&dsl_identity).cloned();
+                    let _ = reply_tx.send(super::state::MobMemberMachineProjection {
+                        runtime_id,
+                        state_marker,
+                        live_runtime,
+                        bound_session_id,
                     });
                 }
                 MobCommand::CurrentRealtimeBinding {
@@ -3972,10 +3992,85 @@ impl MobActor {
         let agent_runtime_id = crate::ids::AgentRuntimeId::new(identity.clone(), generation);
         let overlay_record =
             self.external_binding_overlay_record(&identity, generation, provision.member_ref());
+
+        // Resolve `external_addressable` from the effective profile so we
+        // can inform the DSL (see the `MobMachineInput::Spawn` dispatch
+        // below). Honours any override previously applied via
+        // `SpawnTooling::Profile` resolution.
+        let external_addressable = if let Some(profile) = effective_profile_override.as_ref() {
+            profile.external_addressable
+        } else {
+            self.definition
+                .resolve_profile(profile_name, self.realm_profile_store.as_ref())
+                .await
+                .map(|profile| profile.external_addressable)
+                .unwrap_or(false)
+        };
+
+        // Feed `Spawn` into the MobMachine DSL so it populates
+        // `live_runtime_ids` + `externally_addressable_runtime_ids` and
+        // downstream guards (Retire, SubmitWork, …) operate on authoritative
+        // membership state.
+        let dsl_identity = mob_dsl::AgentIdentity::from_domain(&identity);
+        let bridge_session_id = match provision.member_ref().bridge_session_id() {
+            Some(sid) => mob_dsl::SessionId::from_domain(sid),
+            None => mob_dsl::SessionId::default(),
+        };
+        let replacing = self
+            .dsl_authority
+            .state
+            .member_session_bindings
+            .get(&dsl_identity)
+            .cloned();
+        self.apply_dsl_input(
+            mob_dsl::MobMachineInput::Spawn {
+                agent_identity: dsl_identity.clone(),
+                agent_runtime_id: mob_dsl::AgentRuntimeId::from_domain(&agent_runtime_id),
+                fence_token: mob_dsl::FenceToken::from_domain(fence_token),
+                generation: mob_dsl::Generation::from_domain(generation),
+                external_addressable,
+                bridge_session_id,
+                replacing,
+            },
+            "finalize_spawn_from_pending_dsl_spawn",
+        )?;
+
         if let Some(overlay_record) = overlay_record.as_ref() {
-            self.runtime_metadata
+            if let Err(error) = self
+                .runtime_metadata
                 .upsert_external_binding_overlay(&self.definition.id, overlay_record)
-                .await?;
+                .await
+            {
+                let _ = self.apply_dsl_input(
+                    mob_dsl::MobMachineInput::Retire {
+                        agent_runtime_id: mob_dsl::AgentRuntimeId::from_domain(&agent_runtime_id),
+                        agent_identity: dsl_identity.clone(),
+                        releasing: self
+                            .dsl_authority
+                            .state
+                            .member_session_bindings
+                            .get(&dsl_identity)
+                            .cloned(),
+                        session_id: self
+                            .dsl_authority
+                            .state
+                            .member_session_bindings
+                            .get(&dsl_identity)
+                            .cloned()
+                            .unwrap_or_else(mob_dsl::SessionId::default),
+                    },
+                    "finalize_spawn_overlay_failed_retire_dsl",
+                );
+                if let Some(session_id) = provision.member_ref().bridge_session_id() {
+                    self.discard_pending_routed_effects_for_session(session_id);
+                }
+                if let Err(rollback_error) = provision.rollback().await {
+                    return Err(MobError::Internal(format!(
+                        "spawn overlay upsert failed for '{agent_identity}': {error}; archive compensation failed: {rollback_error}"
+                    )));
+                }
+                return Err(error.into());
+            }
         }
         if let Err(append_error) = self
             .events
@@ -4005,6 +4100,29 @@ impl MobActor {
                     .delete_external_binding_overlay_for_member(&identity, generation)
                     .await;
             }
+            let _ = self.apply_dsl_input(
+                mob_dsl::MobMachineInput::Retire {
+                    agent_runtime_id: mob_dsl::AgentRuntimeId::from_domain(&agent_runtime_id),
+                    agent_identity: dsl_identity.clone(),
+                    releasing: self
+                        .dsl_authority
+                        .state
+                        .member_session_bindings
+                        .get(&dsl_identity)
+                        .cloned(),
+                    session_id: self
+                        .dsl_authority
+                        .state
+                        .member_session_bindings
+                        .get(&dsl_identity)
+                        .cloned()
+                        .unwrap_or_else(mob_dsl::SessionId::default),
+                },
+                "finalize_spawn_append_failed_retire_dsl",
+            );
+            if let Some(session_id) = provision.member_ref().bridge_session_id() {
+                self.discard_pending_routed_effects_for_session(session_id);
+            }
             if let Err(rollback_error) = provision.rollback().await {
                 return Err(MobError::Internal(format!(
                     "spawn append failed for '{agent_identity}': {append_error}; archive compensation failed: {rollback_error}"
@@ -4019,56 +4137,6 @@ impl MobActor {
         let member_ref = provision.commit()?;
         if let Some(comms) = self.provisioner_comms(&member_ref).await {
             self.install_supervisor_private_trust(&comms).await?;
-        }
-
-        // Resolve `external_addressable` from the effective profile so we
-        // can inform the DSL (see the `MobMachineInput::Spawn` dispatch
-        // below). Honours any override previously applied via
-        // `SpawnTooling::Profile` resolution.
-        let external_addressable = if let Some(profile) = effective_profile_override.as_ref() {
-            profile.external_addressable
-        } else {
-            self.definition
-                .resolve_profile(profile_name, self.realm_profile_store.as_ref())
-                .await
-                .map(|profile| profile.external_addressable)
-                .unwrap_or(false)
-        };
-
-        // Feed `Spawn` into the MobMachine DSL so it populates
-        // `live_runtime_ids` + `externally_addressable_runtime_ids` and
-        // downstream guards (Retire, SubmitWork, …) operate on authoritative
-        // membership state.
-        let dsl_identity = mob_dsl::AgentIdentity::from_domain(&identity);
-        let bridge_session_id = match member_ref.bridge_session_id() {
-            Some(sid) => mob_dsl::SessionId::from_domain(sid),
-            None => mob_dsl::SessionId::default(),
-        };
-        let replacing = self
-            .dsl_authority
-            .state
-            .member_session_bindings
-            .get(&dsl_identity)
-            .cloned();
-        if let Err(error) = self.apply_dsl_input(
-            mob_dsl::MobMachineInput::Spawn {
-                agent_identity: dsl_identity.clone(),
-                agent_runtime_id: mob_dsl::AgentRuntimeId::from_domain(&agent_runtime_id),
-                fence_token: mob_dsl::FenceToken::from_domain(fence_token),
-                generation: mob_dsl::Generation::from_domain(generation),
-                external_addressable,
-                bridge_session_id,
-                replacing,
-            },
-            "finalize_spawn_from_pending_dsl_spawn",
-        ) {
-            tracing::warn!(
-                mob_id = %self.definition.id,
-                agent_identity = %agent_identity,
-                agent_runtime_id = %agent_runtime_id,
-                %error,
-                "Spawn DSL input rejected; downstream DSL membership guards may diverge from roster"
-            );
         }
         self.restore_diagnostics
             .write()
@@ -5641,18 +5709,11 @@ impl MobActor {
         }
     }
 
-    /// D-external-peer (#31): wire a local member to an external trusted peer.
+    /// Wire a local member to an external trusted peer.
     ///
-    /// Shell-mechanical trust install followed by an `ExternalPeerWired`
-    /// event append and roster projection. The event round-trips the full
-    /// [`TrustedPeerDescriptor`] so resume can reinstate trust
-    /// deterministically without a live comms runtime.
-    ///
-    /// Unlike local↔local wiring, external wiring is shell-authority over
-    /// the shape of trusted peers on the local session runtime only: the
-    /// MobMachine DSL has no opinion about external peer identities today.
-    /// Local↔local wiring still flows through [`Self::handle_wire`]'s
-    /// DSL-driven path.
+    /// `MobMachineInput::WireMembers` owns the identity-level topology edge;
+    /// the shell mechanically installs the trust descriptor and projects the
+    /// event only after the machine admits the edge.
     ///
     /// Idempotent: a second wire of the same (local, external_name) edge
     /// with the same descriptor is treated as a no-op success.
@@ -5668,6 +5729,10 @@ impl MobActor {
                 "wire requires distinct members (got '{local}')"
             )));
         }
+        let edge = mob_dsl::WiringEdge::new(
+            mob_dsl::AgentIdentity::from_domain(&local_identity),
+            mob_dsl::AgentIdentity::from_domain(&external_identity),
+        );
 
         // Look up the local member's roster entry and session binding.
         let (member_ref, already_wired_with_same_spec) = {
@@ -5684,6 +5749,7 @@ impl MobActor {
         };
 
         if already_wired_with_same_spec {
+            let _ = self.apply_wire_members_idempotent(&edge)?;
             return Ok(());
         }
 
@@ -5694,8 +5760,13 @@ impl MobActor {
             ))
         })?;
 
+        let dsl_added = self.apply_wire_members_idempotent(&edge)?;
+
         // Install trust on the local's session comms runtime.
-        comms.add_trusted_peer(spec.clone()).await?;
+        if let Err(error) = comms.add_trusted_peer(spec.clone()).await {
+            self.rollback_external_wire_dsl(&edge, dsl_added).await;
+            return Err(MobError::from(error));
+        }
 
         // Append ExternalPeerWired — if the append fails, compensate by
         // rolling back the trust install so failure leaves no side effect.
@@ -5721,6 +5792,7 @@ impl MobActor {
                         "failed to rollback external trust install after event append failure"
                     );
                 }
+                self.rollback_external_wire_dsl(&edge, dsl_added).await;
                 return Err(MobError::from(append_err));
             }
         };
@@ -5729,6 +5801,21 @@ impl MobActor {
         // as MembersWired in `handle_wire`.
         self.roster.write().await.apply_event(&stored);
         Ok(())
+    }
+
+    async fn rollback_external_wire_dsl(&mut self, edge: &mob_dsl::WiringEdge, dsl_added: bool) {
+        if dsl_added
+            && let Err(error) = self.apply_dsl_input(
+                mob_dsl::MobMachineInput::UnwireMembers { edge: edge.clone() },
+                "external_wire_rollback",
+            )
+        {
+            tracing::warn!(
+                mob_id = %self.definition.id,
+                %error,
+                "external wire rollback: failed to revert DSL wire"
+            );
+        }
     }
 
     /// D-external-peer (#31): unwire a local member from an external trusted peer.
@@ -5747,6 +5834,10 @@ impl MobActor {
     ) -> Result<(), MobError> {
         let local_identity = AgentIdentity::from(local.as_str());
         let external_identity = AgentIdentity::from(peer_name.as_str());
+        let edge = mob_dsl::WiringEdge::new(
+            mob_dsl::AgentIdentity::from_domain(&local_identity),
+            mob_dsl::AgentIdentity::from_domain(&external_identity),
+        );
 
         // Look up the prior descriptor so we can compensate on append
         // failure. Idempotent: absent projection stays success, but a
@@ -5762,12 +5853,29 @@ impl MobActor {
         };
 
         let Some(prior_spec) = prior_spec else {
+            let dsl_removed = self.apply_unwire_members_idempotent(&edge)?;
             if let Some(spec) = stale_cleanup_spec
                 && let Some(comms) = self.provisioner_comms(&member_ref).await
             {
-                let _ = comms
+                if let Err(error) = comms
                     .remove_trusted_peer(&Self::trusted_peer_removal_key(&spec))
-                    .await?;
+                    .await
+                {
+                    if dsl_removed
+                        && let Err(rollback_err) = self.apply_dsl_input(
+                            mob_dsl::MobMachineInput::WireMembers { edge: edge.clone() },
+                            "external_unwire_stale_cleanup_rollback",
+                        )
+                    {
+                        tracing::warn!(
+                            mob_id = %self.definition.id,
+                            local = %local,
+                            error = %rollback_err,
+                            "failed to rollback external DSL unwire after stale cleanup failure"
+                        );
+                    }
+                    return Err(MobError::from(error));
+                }
             }
             return Ok(());
         };
@@ -5778,10 +5886,28 @@ impl MobActor {
             ))
         })?;
 
+        let dsl_removed = self.apply_unwire_members_idempotent(&edge)?;
+
         // Remove trust on the local session runtime.
-        let _ = comms
+        if let Err(error) = comms
             .remove_trusted_peer(&Self::trusted_peer_removal_key(&prior_spec))
-            .await?;
+            .await
+        {
+            if dsl_removed
+                && let Err(rollback_err) = self.apply_dsl_input(
+                    mob_dsl::MobMachineInput::WireMembers { edge: edge.clone() },
+                    "external_unwire_trust_remove_rollback",
+                )
+            {
+                tracing::warn!(
+                    mob_id = %self.definition.id,
+                    local = %local,
+                    error = %rollback_err,
+                    "failed to rollback external DSL unwire after trust removal failure"
+                );
+            }
+            return Err(MobError::from(error));
+        }
 
         let event = NewMobEvent {
             mob_id: self.definition.id.clone(),
@@ -5802,6 +5928,19 @@ impl MobActor {
                         local = %local,
                         error = %rollback_err,
                         "failed to rollback external trust removal after event append failure"
+                    );
+                }
+                if dsl_removed
+                    && let Err(rollback_err) = self.apply_dsl_input(
+                        mob_dsl::MobMachineInput::WireMembers { edge: edge.clone() },
+                        "external_unwire_rollback",
+                    )
+                {
+                    tracing::warn!(
+                        mob_id = %self.definition.id,
+                        local = %local,
+                        error = %rollback_err,
+                        "failed to rollback external DSL unwire after event append failure"
                     );
                 }
                 return Err(MobError::from(append_err));

--- a/meerkat-mob/src/runtime/composition.rs
+++ b/meerkat-mob/src/runtime/composition.rs
@@ -51,6 +51,7 @@ use meerkat_runtime::composition::{
     DispatchRefusal, EffectPayload, FieldValue, OwnedFieldValue, ProducerEffect, ProducerInstance,
     RouteTable, SignalConsumerSurface,
 };
+use meerkat_runtime::meerkat_machine::dsl as meerkat_dsl;
 use std::sync::Arc;
 use tokio::sync::mpsc;
 
@@ -198,7 +199,7 @@ impl MobProducerEffect {
                 }
                 "fence_token" => Some(FieldValue::U64(fence_token.0)),
                 "work_id" => Some(FieldValue::Str(work_id.0.as_str())),
-                "origin" => Some(FieldValue::Str(work_origin_slug(origin))),
+                "origin" => Some(FieldValue::Opaque(Arc::new(meerkat_work_origin(origin)))),
                 _ => None,
             },
             Self::RequestRuntimeRetire { session_id } => match id.as_str() {
@@ -213,17 +214,11 @@ impl MobProducerEffect {
     }
 }
 
-/// Stable slug for a DSL [`mob_dsl::WorkOrigin`] used as the routed-effect
-/// field value. The DSL enum carries an `Ingest` variant the mob side
-/// never produces (it models the meerkat-side admission-kind), so emit a
-/// distinct slug for it — the consumer surface rejects it explicitly if
-/// it ever appears here, which would be a DSL bug rather than a silent
-/// drop.
-fn work_origin_slug(origin: &mob_dsl::WorkOrigin) -> &'static str {
+fn meerkat_work_origin(origin: &mob_dsl::WorkOrigin) -> meerkat_dsl::WorkOrigin {
     match origin {
-        mob_dsl::WorkOrigin::External => "External",
-        mob_dsl::WorkOrigin::Internal => "Internal",
-        mob_dsl::WorkOrigin::Ingest => "Ingest",
+        mob_dsl::WorkOrigin::External => meerkat_dsl::WorkOrigin::External,
+        mob_dsl::WorkOrigin::Internal => meerkat_dsl::WorkOrigin::Internal,
+        mob_dsl::WorkOrigin::Ingest => meerkat_dsl::WorkOrigin::Ingest,
     }
 }
 
@@ -609,10 +604,13 @@ mod tests {
                 .expect("agent_runtime_id alias"),
             FieldValue::Str("rt-x"),
         ));
-        assert!(matches!(
-            effect.field(&fid("origin")).expect("origin"),
-            FieldValue::Str("External"),
-        ));
+        match effect.field(&fid("origin")).expect("origin") {
+            FieldValue::Opaque(value) => assert!(matches!(
+                value.downcast_ref::<meerkat_dsl::WorkOrigin>(),
+                Some(meerkat_dsl::WorkOrigin::External)
+            )),
+            other => panic!("origin should stay typed, got {other:?}"),
+        }
     }
 
     #[test]

--- a/meerkat-mob/src/runtime/handle.rs
+++ b/meerkat-mob/src/runtime/handle.rs
@@ -6,7 +6,7 @@ use crate::roster::MobMemberKickoffSnapshot;
 use crate::runtime::MobLifecycleSnapshot;
 use crate::runtime::mob_member_lifecycle_authority::{
     CanonicalMemberSnapshotMaterial, CanonicalMemberStatus, CanonicalSessionObservation,
-    MobMemberLifecycleAuthority, MobMemberLifecycleInput,
+    MobMemberLifecycleInput, MobMemberLifecycleProjection,
 };
 use crate::runtime::reconcile::{
     EnsureMemberOutcome, MemberFilter, ReconcileFailure, ReconcileOptions, ReconcileReport,
@@ -663,6 +663,20 @@ impl MobHandle {
         reply_rx.await.map_err(|_| {
             crate::MobError::Internal("mob actor dropped CurrentRealtimeBinding reply".to_string())
         })
+    }
+
+    async fn member_machine_projection(
+        &self,
+        agent_identity: &MeerkatId,
+    ) -> super::state::MobMemberMachineProjection {
+        self.send_actor_command(
+            |reply_tx| super::state::MobCommand::MemberMachineProjection {
+                agent_identity: AgentIdentity::from(agent_identity.as_str()),
+                reply_tx,
+            },
+        )
+        .await
+        .unwrap_or_default()
     }
 }
 
@@ -1653,6 +1667,12 @@ impl MobHandle {
                 None => (roster.snapshot(), None, None, None),
             }
         };
+        let machine_projection = self.member_machine_projection(agent_identity).await;
+        let machine_bridge_session_id = machine_projection
+            .bound_session_id
+            .as_ref()
+            .and_then(|dsl_session_id| SessionId::parse(&dsl_session_id.0).ok());
+        let current_bridge_session_id = current_bridge_session_id.or(machine_bridge_session_id);
 
         let restore_failure = {
             self.restore_diagnostics
@@ -1662,7 +1682,7 @@ impl MobHandle {
                 .cloned()
         };
         if let Some(diag) = restore_failure {
-            return MobMemberLifecycleAuthority::materialize(MobMemberLifecycleInput {
+            return MobMemberLifecycleProjection::materialize(MobMemberLifecycleInput {
                 member_present: roster_state.is_some(),
                 roster_state,
                 session_observation: CanonicalSessionObservation::Missing,
@@ -1684,11 +1704,13 @@ impl MobHandle {
                 kickoff: roster_entry
                     .as_ref()
                     .and_then(|entry| entry.kickoff.clone()),
+                machine_state_marker: machine_projection.state_marker,
+                machine_runtime_live: machine_projection.live_runtime,
             });
         }
 
         match (roster_state, current_bridge_session_id) {
-            (None, _) => MobMemberLifecycleAuthority::materialize(MobMemberLifecycleInput {
+            (None, _) => MobMemberLifecycleProjection::materialize(MobMemberLifecycleInput {
                 member_present: false,
                 roster_state: None,
                 session_observation: CanonicalSessionObservation::Missing,
@@ -1702,6 +1724,8 @@ impl MobHandle {
                 current_bridge_session_id: None,
                 peer_connectivity: None,
                 kickoff: None,
+                machine_state_marker: machine_projection.state_marker,
+                machine_runtime_live: machine_projection.live_runtime,
             }),
             (Some(roster_state), None) => {
                 let session_observation = match roster_entry.as_ref().map(|entry| &entry.member_ref)
@@ -1711,7 +1735,7 @@ impl MobHandle {
                     }) => CanonicalSessionObservation::Unknown,
                     _ => CanonicalSessionObservation::Missing,
                 };
-                MobMemberLifecycleAuthority::materialize(MobMemberLifecycleInput {
+                MobMemberLifecycleProjection::materialize(MobMemberLifecycleInput {
                     member_present: true,
                     roster_state: Some(roster_state),
                     session_observation,
@@ -1733,6 +1757,8 @@ impl MobHandle {
                     kickoff: roster_entry
                         .as_ref()
                         .and_then(|entry| entry.kickoff.clone()),
+                    machine_state_marker: machine_projection.state_marker,
+                    machine_runtime_live: machine_projection.live_runtime,
                 })
             }
             (Some(roster_state), Some(bridge_session_id)) => {
@@ -1773,7 +1799,7 @@ impl MobHandle {
                 } else {
                     None
                 };
-                MobMemberLifecycleAuthority::materialize(MobMemberLifecycleInput {
+                MobMemberLifecycleProjection::materialize(MobMemberLifecycleInput {
                     member_present: true,
                     roster_state: Some(roster_state),
                     session_observation: observation,
@@ -1793,6 +1819,8 @@ impl MobHandle {
                     current_bridge_session_id: Some(bridge_session_id),
                     peer_connectivity,
                     kickoff: roster_entry.and_then(|entry| entry.kickoff),
+                    machine_state_marker: machine_projection.state_marker,
+                    machine_runtime_live: machine_projection.live_runtime,
                 })
             }
         }
@@ -3179,7 +3207,7 @@ impl MobHandle {
     ) -> Result<CanonicalMemberSnapshotMaterial, MobError> {
         loop {
             let material = self.canonical_member_list_material(agent_identity).await;
-            if MobMemberLifecycleAuthority::is_terminal(&material) {
+            if MobMemberLifecycleProjection::is_terminal(&material) {
                 return Ok(material);
             }
             tokio::time::sleep(std::time::Duration::from_millis(100)).await;

--- a/meerkat-mob/src/runtime/mob_member_lifecycle_authority.rs
+++ b/meerkat-mob/src/runtime/mob_member_lifecycle_authority.rs
@@ -54,7 +54,7 @@ impl CanonicalMemberSnapshotMaterial {
             CanonicalMemberStatus::Broken => MobMemberStatus::Broken,
             CanonicalMemberStatus::Completed => MobMemberStatus::Completed,
         };
-        let is_final = MobMemberLifecycleAuthority::is_terminal(self);
+        let is_final = MobMemberLifecycleProjection::is_terminal(self);
         MobMemberSnapshot {
             status,
             agent_runtime_id: self.agent_runtime_id.clone(),
@@ -96,11 +96,13 @@ pub(super) struct MobMemberLifecycleInput {
     pub(super) current_bridge_session_id: Option<SessionId>,
     pub(super) peer_connectivity: Option<MobPeerConnectivitySnapshot>,
     pub(super) kickoff: Option<MobMemberKickoffSnapshot>,
+    pub(super) machine_state_marker: Option<crate::machines::mob_machine::MobMemberState>,
+    pub(super) machine_runtime_live: bool,
 }
 
-pub(super) struct MobMemberLifecycleAuthority;
+pub(super) struct MobMemberLifecycleProjection;
 
-impl MobMemberLifecycleAuthority {
+impl MobMemberLifecycleProjection {
     pub(super) fn materialize(input: MobMemberLifecycleInput) -> CanonicalMemberSnapshotMaterial {
         if let Some(reason) = input.restore_failure {
             return CanonicalMemberSnapshotMaterial {
@@ -125,15 +127,20 @@ impl MobMemberLifecycleAuthority {
         let status = match (
             input.member_present,
             input.roster_state,
+            input.machine_state_marker,
+            input.machine_runtime_live,
             input.session_observation,
         ) {
-            (false, _, _) => CanonicalMemberStatus::Unknown,
-            (true, Some(MemberState::Retiring), _) => CanonicalMemberStatus::Retiring,
-            (true, Some(MemberState::Active), CanonicalSessionObservation::Missing) => {
+            (false, _, _, _, _) => CanonicalMemberStatus::Unknown,
+            (true, _, Some(crate::machines::mob_machine::MobMemberState::Retiring), _, _) => {
+                CanonicalMemberStatus::Retiring
+            }
+            (true, Some(MemberState::Retiring), _, _, _) => CanonicalMemberStatus::Retiring,
+            (true, Some(MemberState::Active), _, false, CanonicalSessionObservation::Missing) => {
                 CanonicalMemberStatus::Completed
             }
-            (true, Some(MemberState::Active), _) => CanonicalMemberStatus::Active,
-            (true, None, _) => CanonicalMemberStatus::Unknown,
+            (true, Some(MemberState::Active), _, _, _) => CanonicalMemberStatus::Active,
+            (true, None, _, _, _) => CanonicalMemberStatus::Unknown,
         };
 
         CanonicalMemberSnapshotMaterial {
@@ -186,7 +193,7 @@ mod tests {
 
     #[test]
     fn restore_failure_breaks_present_member() {
-        let material = MobMemberLifecycleAuthority::materialize(MobMemberLifecycleInput {
+        let material = MobMemberLifecycleProjection::materialize(MobMemberLifecycleInput {
             member_present: true,
             roster_state: Some(MemberState::Active),
             session_observation: CanonicalSessionObservation::Active,
@@ -198,6 +205,8 @@ mod tests {
             current_bridge_session_id: None,
             peer_connectivity: None,
             kickoff: None,
+            machine_state_marker: Some(crate::machines::mob_machine::MobMemberState::Active),
+            machine_runtime_live: true,
         });
         assert_eq!(material.status, CanonicalMemberStatus::Broken);
         assert_eq!(material.error.as_deref(), Some("restore mismatch"));
@@ -205,7 +214,7 @@ mod tests {
 
     #[test]
     fn missing_active_session_means_completed_not_broken() {
-        let material = MobMemberLifecycleAuthority::materialize(MobMemberLifecycleInput {
+        let material = MobMemberLifecycleProjection::materialize(MobMemberLifecycleInput {
             member_present: true,
             roster_state: Some(MemberState::Active),
             session_observation: CanonicalSessionObservation::Missing,
@@ -217,14 +226,16 @@ mod tests {
             current_bridge_session_id: None,
             peer_connectivity: None,
             kickoff: None,
+            machine_state_marker: Some(crate::machines::mob_machine::MobMemberState::Active),
+            machine_runtime_live: false,
         });
         assert_eq!(material.status, CanonicalMemberStatus::Completed);
-        assert!(MobMemberLifecycleAuthority::is_terminal(&material));
+        assert!(MobMemberLifecycleProjection::is_terminal(&material));
     }
 
     #[test]
     fn unknown_active_sessionless_member_stays_non_terminal() {
-        let material = MobMemberLifecycleAuthority::materialize(MobMemberLifecycleInput {
+        let material = MobMemberLifecycleProjection::materialize(MobMemberLifecycleInput {
             member_present: true,
             roster_state: Some(MemberState::Active),
             session_observation: CanonicalSessionObservation::Unknown,
@@ -236,14 +247,16 @@ mod tests {
             current_bridge_session_id: None,
             peer_connectivity: None,
             kickoff: None,
+            machine_state_marker: Some(crate::machines::mob_machine::MobMemberState::Active),
+            machine_runtime_live: true,
         });
         assert_eq!(material.status, CanonicalMemberStatus::Active);
-        assert!(!MobMemberLifecycleAuthority::is_terminal(&material));
+        assert!(!MobMemberLifecycleProjection::is_terminal(&material));
     }
 
     #[test]
     fn retiring_member_is_non_terminal_even_if_session_missing() {
-        let material = MobMemberLifecycleAuthority::materialize(MobMemberLifecycleInput {
+        let material = MobMemberLifecycleProjection::materialize(MobMemberLifecycleInput {
             member_present: true,
             roster_state: Some(MemberState::Retiring),
             session_observation: CanonicalSessionObservation::Missing,
@@ -255,8 +268,10 @@ mod tests {
             current_bridge_session_id: None,
             peer_connectivity: None,
             kickoff: None,
+            machine_state_marker: Some(crate::machines::mob_machine::MobMemberState::Retiring),
+            machine_runtime_live: false,
         });
         assert_eq!(material.status, CanonicalMemberStatus::Retiring);
-        assert!(!MobMemberLifecycleAuthority::is_terminal(&material));
+        assert!(!MobMemberLifecycleProjection::is_terminal(&material));
     }
 }

--- a/meerkat-mob/src/runtime/state.rs
+++ b/meerkat-mob/src/runtime/state.rs
@@ -131,6 +131,14 @@ pub(crate) struct MobStartupKickoffSnapshot {
     pub ready_runtime_ids: std::collections::BTreeSet<String>,
 }
 
+#[derive(Debug, Clone, Default)]
+pub(crate) struct MobMemberMachineProjection {
+    pub runtime_id: Option<crate::machines::mob_machine::AgentRuntimeId>,
+    pub state_marker: Option<crate::machines::mob_machine::MobMemberState>,
+    pub live_runtime: bool,
+    pub bound_session_id: Option<crate::machines::mob_machine::SessionId>,
+}
+
 /// Heap-allocated payload for `MobCommand::SubmitWork`. Boxing keeps the
 /// command-channel variant width bounded by the pointer, not by the full
 /// `ContentInput` + render metadata footprint.
@@ -252,6 +260,10 @@ pub(super) enum MobCommand {
     },
     StartupKickoffSnapshot {
         reply_tx: oneshot::Sender<MobStartupKickoffSnapshot>,
+    },
+    MemberMachineProjection {
+        agent_identity: crate::ids::AgentIdentity,
+        reply_tx: oneshot::Sender<MobMemberMachineProjection>,
     },
     /// W3-H: query the current realtime binding for an identity. Returns
     /// the bridge session id currently bound (projected from the canonical

--- a/meerkat-openai/src/realtime_attachment.rs
+++ b/meerkat-openai/src/realtime_attachment.rs
@@ -68,9 +68,9 @@ impl OpenAiRealtimeAttachmentOrchestrator {
         }
     }
 
-    /// Attach a runtime session to an OpenAI Realtime call and mark the live
-    /// attachment binding as ready once the provider transport is connected.
-    pub async fn attach(
+    /// Ensure the runtime-owned capability-driven realtime binding has an
+    /// OpenAI provider session and mark it ready once connected.
+    pub async fn ensure_attached_for_capable_session(
         &self,
         session_id: &SessionId,
         target: &OpenAiLiveCallTarget,
@@ -87,8 +87,23 @@ impl OpenAiRealtimeAttachmentOrchestrator {
             tasks.insert(session_id.clone(), OpenAiLiveTaskState::Connecting);
         }
 
-        let authority = match self.runtime.attach_live(session_id).await {
-            Ok(authority) => authority,
+        let authority = match self
+            .runtime
+            .apply_capability_driven_realtime_transport(session_id)
+            .await
+        {
+            Ok(Some(authority)) => authority,
+            Ok(None) => match self
+                .runtime
+                .current_realtime_attachment_authority(session_id)
+                .await
+            {
+                Ok(authority) => authority,
+                Err(error) => {
+                    self.tasks.lock().await.remove(session_id);
+                    return Err(error);
+                }
+            },
             Err(error) => {
                 self.tasks.lock().await.remove(session_id);
                 return Err(error);
@@ -99,7 +114,10 @@ impl OpenAiRealtimeAttachmentOrchestrator {
             Ok(session) => session,
             Err(error) => {
                 self.tasks.lock().await.remove(session_id);
-                self.runtime.detach_live(session_id).await?;
+                let _ = self
+                    .runtime
+                    .require_realtime_attachment_reattach_for_authority(authority)
+                    .await;
                 return Err(map_openai_live_error(error));
             }
         };
@@ -113,7 +131,10 @@ impl OpenAiRealtimeAttachmentOrchestrator {
             .await
         {
             self.tasks.lock().await.remove(session_id);
-            self.runtime.detach_live(session_id).await?;
+            let _ = self
+                .runtime
+                .require_realtime_attachment_reattach_for_authority(authority)
+                .await;
             return Err(error);
         }
 
@@ -139,23 +160,17 @@ impl OpenAiRealtimeAttachmentOrchestrator {
         Ok(())
     }
 
-    /// Detach the currently orchestrated provider session, abort its event pump,
-    /// and clear the runtime binding while preserving durable intent.
-    ///
-    /// Wave-c C-9b R9 invariant: this is the sole production `handle.abort()`
-    /// on a realtime attachment task across the workspace. `abort()` is
-    /// immediately paired with `runtime.detach_live(session_id)` so the DSL
-    /// authority never observes an orphaned binding when the event-pump task
-    /// is cancelled mid-`.await`. Any new realtime-task cancellation path must
-    /// follow the same ordering: abort-then-detach, never abort alone.
-    /// Verified by `rg "\.abort\(\)" meerkat-openai/ meerkat-rpc/` returning
-    /// only this site plus `#[cfg(test)]` harness aborts.
-    pub async fn detach(&self, session_id: &SessionId) -> Result<(), RuntimeDriverError> {
+    /// Stop the currently orchestrated provider session. Runtime attachment
+    /// lifecycle remains capability-driven by `MeerkatMachine`.
+    pub async fn stop_provider_session(
+        &self,
+        session_id: &SessionId,
+    ) -> Result<(), RuntimeDriverError> {
         let task = self.tasks.lock().await.remove(session_id);
         if let Some(OpenAiLiveTaskState::Attached(handle)) = task {
             handle.abort();
         }
-        self.runtime.detach_live(session_id).await
+        Ok(())
     }
 }
 
@@ -285,7 +300,6 @@ mod tests {
         OpenAiLiveSessionFactory,
     };
     use async_trait::async_trait;
-    use meerkat_core::ToolDispatchOutcome;
     use meerkat_core::lifecycle::RunId;
     use meerkat_core::lifecycle::core_executor::{
         CoreApplyOutput, CoreExecutor, CoreExecutorError,
@@ -294,13 +308,16 @@ mod tests {
     use meerkat_core::lifecycle::run_primitive::{RunApplyBoundary, RunPrimitive};
     use meerkat_core::lifecycle::run_receipt::RunBoundaryReceipt;
     use meerkat_core::types::{SessionId, ToolCall, ToolResult};
+    use meerkat_core::{Provider, SessionLlmIdentity, ToolDispatchOutcome};
     use serde_json::json;
     use tokio::sync::{Mutex, Notify};
 
     use super::{OpenAiRealtimeAttachmentOrchestrator, RealtimeAttachmentToolDispatchHost};
     use meerkat_llm_core::LlmError;
     use meerkat_runtime::{
-        Input, MeerkatMachine, PromptInput, RealtimeAttachmentStatus, RuntimeDriverError,
+        HydratedSessionLlmState, Input, MeerkatMachine, PromptInput, RealtimeAttachmentStatus,
+        ResolvedSessionLlmReconfigure, RuntimeDriverError, SessionLlmCapabilitySurface,
+        SessionLlmCapabilitySurfaceStatus, SessionLlmReconfigureHost, SessionLlmReconfigureRequest,
         SessionServiceRuntimeExt,
     };
 
@@ -440,8 +457,98 @@ mod tests {
         }
     }
 
+    struct RealtimeTestReconfigureHost {
+        identity: SessionLlmIdentity,
+        capability_surface: SessionLlmCapabilitySurface,
+    }
+
+    #[async_trait]
+    impl SessionLlmReconfigureHost for RealtimeTestReconfigureHost {
+        async fn hydrate_session_llm_state(
+            &self,
+            _session_id: &SessionId,
+        ) -> Result<HydratedSessionLlmState, RuntimeDriverError> {
+            Ok(HydratedSessionLlmState {
+                current_identity: self.identity.clone(),
+                current_visibility_state: Default::default(),
+                current_capability_surface: Some(self.capability_surface.clone()),
+                capability_surface_status: SessionLlmCapabilitySurfaceStatus::Resolved,
+                base_tool_names: Default::default(),
+            })
+        }
+
+        async fn resolve_target_session_llm_identity(
+            &self,
+            _request: &SessionLlmReconfigureRequest,
+            _current_identity: &SessionLlmIdentity,
+        ) -> Result<ResolvedSessionLlmReconfigure, RuntimeDriverError> {
+            Ok(ResolvedSessionLlmReconfigure {
+                target_identity: self.identity.clone(),
+                target_capability_surface: self.capability_surface.clone(),
+            })
+        }
+
+        async fn apply_live_session_llm_identity(
+            &self,
+            _session_id: &SessionId,
+            _identity: &SessionLlmIdentity,
+        ) -> Result<(), RuntimeDriverError> {
+            Ok(())
+        }
+
+        async fn apply_live_session_tool_visibility_state(
+            &self,
+            _session_id: &SessionId,
+            _visibility_state: Option<meerkat_core::SessionToolVisibilityState>,
+        ) -> Result<(), RuntimeDriverError> {
+            Ok(())
+        }
+
+        async fn persist_live_session(
+            &self,
+            _session_id: &SessionId,
+        ) -> Result<(), RuntimeDriverError> {
+            Ok(())
+        }
+
+        async fn discard_live_session(
+            &self,
+            _session_id: &SessionId,
+        ) -> Result<(), RuntimeDriverError> {
+            Ok(())
+        }
+    }
+
+    fn realtime_test_capability_surface() -> SessionLlmCapabilitySurface {
+        SessionLlmCapabilitySurface {
+            supports_temperature: true,
+            supports_thinking: false,
+            supports_reasoning: false,
+            inline_video: false,
+            vision: false,
+            image_tool_results: false,
+            supports_web_search: false,
+            realtime: true,
+            call_timeout_secs: None,
+        }
+    }
+
+    fn install_realtime_test_reconfigure_host(runtime: &Arc<MeerkatMachine>) {
+        runtime.set_session_llm_reconfigure_host(Arc::new(RealtimeTestReconfigureHost {
+            identity: SessionLlmIdentity {
+                model: "gpt-realtime".to_string(),
+                provider: Provider::OpenAI,
+                self_hosted_server_id: None,
+                provider_params: None,
+                connection_ref: None,
+            },
+            capability_surface: realtime_test_capability_surface(),
+        }));
+    }
+
     async fn runtime_with_live_executor() -> (Arc<MeerkatMachine>, SessionId) {
         let runtime = Arc::new(MeerkatMachine::ephemeral());
+        install_realtime_test_reconfigure_host(&runtime);
         let session_id = SessionId::new();
         runtime
             .register_session_with_executor(session_id.clone(), Box::new(NoopExecutor))
@@ -465,6 +572,7 @@ mod tests {
     async fn runtime_with_recording_executor()
     -> (Arc<MeerkatMachine>, SessionId, Arc<Mutex<Vec<String>>>) {
         let runtime = Arc::new(MeerkatMachine::ephemeral());
+        install_realtime_test_reconfigure_host(&runtime);
         let session_id = SessionId::new();
         let applied_prompts = Arc::new(Mutex::new(Vec::new()));
         runtime
@@ -535,6 +643,7 @@ mod tests {
         }
 
         let runtime = Arc::new(MeerkatMachine::ephemeral());
+        install_realtime_test_reconfigure_host(&runtime);
         let session_id = SessionId::new();
         let cancel_calls = Arc::new(AtomicUsize::new(0));
         let apply_started = Arc::new(Notify::new());
@@ -588,7 +697,7 @@ mod tests {
             .expect("non-empty call target should succeed");
 
         orchestrator
-            .attach(&session_id, &target)
+            .ensure_attached_for_capable_session(&session_id, &target)
             .await
             .expect("attach should succeed");
 
@@ -604,7 +713,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn openai_live_orchestrator_attach_failure_restores_unbound_status() {
+    async fn openai_live_orchestrator_attach_failure_marks_reattach_required() {
         let (runtime, session_id) = runtime_with_live_executor().await;
         let factory = Arc::new(FakeFactory {
             sessions: Mutex::new(VecDeque::from([Err(LlmError::InvalidRequest {
@@ -620,7 +729,7 @@ mod tests {
             OpenAiLiveCallTarget::new("call_attach_fail").expect("call target should succeed");
 
         let error = orchestrator
-            .attach(&session_id, &target)
+            .ensure_attached_for_capable_session(&session_id, &target)
             .await
             .expect_err("attach should surface provider rejection");
         assert!(matches!(error, RuntimeDriverError::ValidationFailed { .. }));
@@ -631,7 +740,7 @@ mod tests {
         )
         .await
         .expect("runtime status should resolve");
-        assert_eq!(status, RealtimeAttachmentStatus::IntentPresentUnbound);
+        assert_eq!(status, RealtimeAttachmentStatus::ReattachRequired);
     }
 
     #[tokio::test]
@@ -667,7 +776,7 @@ mod tests {
             OpenAiLiveCallTarget::new("call_disconnect").expect("call target should succeed");
 
         orchestrator
-            .attach(&session_id, &target)
+            .ensure_attached_for_capable_session(&session_id, &target)
             .await
             .expect("attach should succeed");
 
@@ -683,7 +792,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn openai_live_orchestrator_detach_clears_binding_and_stops_task() {
+    async fn openai_live_orchestrator_stop_provider_session_keeps_runtime_binding() {
         let (runtime, session_id) = runtime_with_live_executor().await;
         let hold_open = Arc::new(Notify::new());
         let sent_events = Arc::new(Mutex::new(Vec::new()));
@@ -704,11 +813,11 @@ mod tests {
         let target = OpenAiLiveCallTarget::new("call_detach").expect("call target should succeed");
 
         orchestrator
-            .attach(&session_id, &target)
+            .ensure_attached_for_capable_session(&session_id, &target)
             .await
             .expect("attach should succeed");
         orchestrator
-            .detach(&session_id)
+            .stop_provider_session(&session_id)
             .await
             .expect("detach should succeed");
 
@@ -718,7 +827,7 @@ mod tests {
         )
         .await
         .expect("runtime status should resolve");
-        assert_eq!(status, RealtimeAttachmentStatus::IntentPresentUnbound);
+        assert_eq!(status, RealtimeAttachmentStatus::BindingReady);
 
         hold_open.notify_waiters();
     }
@@ -746,7 +855,7 @@ mod tests {
             OpenAiLiveCallTarget::new("call_stale_disconnect").expect("call target should succeed");
 
         orchestrator
-            .attach(&session_id, &target)
+            .ensure_attached_for_capable_session(&session_id, &target)
             .await
             .expect("attach should succeed");
 
@@ -796,7 +905,7 @@ mod tests {
             OpenAiLiveCallTarget::new("call_transcript").expect("call target should succeed");
 
         orchestrator
-            .attach(&session_id, &target)
+            .ensure_attached_for_capable_session(&session_id, &target)
             .await
             .expect("attach should succeed");
 
@@ -851,7 +960,7 @@ mod tests {
             OpenAiLiveCallTarget::new("call_interrupt").expect("call target should succeed");
 
         orchestrator
-            .attach(&session_id, &target)
+            .ensure_attached_for_capable_session(&session_id, &target)
             .await
             .expect("attach should succeed");
 
@@ -949,7 +1058,7 @@ mod tests {
             OpenAiLiveCallTarget::new("call_tool_success").expect("call target should succeed");
 
         orchestrator
-            .attach(&session_id, &target)
+            .ensure_attached_for_capable_session(&session_id, &target)
             .await
             .expect("attach should succeed");
 
@@ -1034,7 +1143,7 @@ mod tests {
             OpenAiLiveCallTarget::new("call_tool_error").expect("call target should succeed");
 
         orchestrator
-            .attach(&session_id, &target)
+            .ensure_attached_for_capable_session(&session_id, &target)
             .await
             .expect("attach should succeed");
 

--- a/meerkat-rpc/src/realtime_ws.rs
+++ b/meerkat-rpc/src/realtime_ws.rs
@@ -1337,11 +1337,6 @@ async fn handle_realtime_socket(mut socket: WebSocket, state: RealtimeWsState) {
                                                 .await
                                                 {
                                                     Ok(Some(rotation)) => {
-                                                        let _ = state
-                                                            .runtime
-                                                            .runtime_adapter()
-                                                            .detach_live(&rotation.previous_session_id)
-                                                            .await;
                                                         if let Some(session_factory) =
                                                             state.host.session_factory()
                                                         {
@@ -1392,19 +1387,36 @@ async fn handle_realtime_socket(mut socket: WebSocket, state: RealtimeWsState) {
                                                                     continue;
                                                                 }
                                                             }
-                                                        } else if let Err(error) = state
-                                                            .runtime
-                                                            .runtime_adapter()
-                                                            .attach_live(&rotation.current_session_id)
-                                                            .await
-                                                            .map_err(|err| runtime_error_frame(err, "attach"))
-                                                        {
-                                                            let _ = send_server_frame(
-                                                                &mut socket,
-                                                                &RealtimeServerFrame::ChannelError(error),
-                                                            )
-                                                            .await;
-                                                            continue;
+                                                        } else {
+                                                            let status = state
+                                                                .runtime
+                                                                .runtime_adapter()
+                                                                .realtime_attachment_status(
+                                                                    &rotation.current_session_id,
+                                                                )
+                                                                .await
+                                                                .map(RealtimeChannelStatus::from)
+                                                                .map_err(|err| runtime_error_frame(err, "status"));
+                                                            match status {
+                                                                Ok(status) => {
+                                                                    let _ = emit_status_update(
+                                                                        &mut socket,
+                                                                        &mut last_visible_status,
+                                                                        status,
+                                                                        false,
+                                                                        Some((state.host.as_ref(), &registered)),
+                                                                    )
+                                                                    .await;
+                                                                }
+                                                                Err(error) => {
+                                                                    let _ = send_server_frame(
+                                                                        &mut socket,
+                                                                        &RealtimeServerFrame::ChannelError(error),
+                                                                    )
+                                                                    .await;
+                                                                    continue;
+                                                                }
+                                                            }
                                                         }
                                                     }
                                                     Ok(None) => {}
@@ -2558,11 +2570,6 @@ async fn bind_realtime_target(
                         bridge: Some(bridge),
                     })
                 } else {
-                    runtime
-                        .runtime_adapter()
-                        .attach_live(&session_id)
-                        .await
-                        .map_err(|err| runtime_error_frame(err, "attach"))?;
                     let status = runtime
                         .runtime_adapter()
                         .realtime_attachment_status(&session_id)
@@ -2663,11 +2670,6 @@ async fn bind_realtime_target(
                     bridge: Some(bridge),
                 })
             } else {
-                runtime
-                    .runtime_adapter()
-                    .attach_live(&current_session_id)
-                    .await
-                    .map_err(|err| runtime_error_frame(err, "attach"))?;
                 let status = runtime
                     .runtime_adapter()
                     .realtime_attachment_status(&current_session_id)
@@ -2713,15 +2715,26 @@ async fn open_product_session_bridge(
         .realtime_session_open_config(session_id, turning_mode)
         .await
         .map_err(session_error_frame)?;
-    let authority = runtime
+    let authority = match runtime
         .runtime_adapter()
-        .attach_live(session_id)
+        .apply_capability_driven_realtime_transport(session_id)
         .await
-        .map_err(|err| runtime_error_frame(err, "attach"))?;
+        .map_err(|err| runtime_error_frame(err, "attach"))?
+    {
+        Some(authority) => authority,
+        None => runtime
+            .runtime_adapter()
+            .current_realtime_attachment_authority(session_id)
+            .await
+            .map_err(|err| runtime_error_frame(err, "authority"))?,
+    };
     let session = match session_factory.open_session(&open_config).await {
         Ok(session) => session,
         Err(error) => {
-            let _ = runtime.runtime_adapter().detach_live(session_id).await;
+            let _ = runtime
+                .runtime_adapter()
+                .require_realtime_attachment_reattach_for_authority(authority)
+                .await;
             return Err(realtime_client_error_frame(error, "open"));
         }
     };
@@ -2733,7 +2746,10 @@ async fn open_product_session_bridge(
         )
         .await
     {
-        let _ = runtime.runtime_adapter().detach_live(session_id).await;
+        let _ = runtime
+            .runtime_adapter()
+            .require_realtime_attachment_reattach_for_authority(authority)
+            .await;
         return Err(runtime_error_frame(error, "bind_ready"));
     }
 
@@ -2757,25 +2773,13 @@ async fn open_product_session_bridge(
 }
 
 async fn cleanup_realtime_binding(
-    runtime: &SessionRuntime,
-    binding: Option<&RealtimeSocketBinding>,
+    _runtime: &SessionRuntime,
+    _binding: Option<&RealtimeSocketBinding>,
 ) -> Result<(), RealtimeChannelErrorFrame> {
-    let Some(binding) = binding else {
-        return Ok(());
-    };
-    // Observer channels do not own the runtime attachment; detach is a
-    // primary-only responsibility. MobMember primaries detach the current
-    // bridge session — whichever session the observer-driven
-    // `current_session_id` resolves to now (the one the WS was last
-    // actively pinned to before close).
-    if !binding.is_primary() {
-        return Ok(());
-    }
-    runtime
-        .runtime_adapter()
-        .detach_live(binding.current_session_id())
-        .await
-        .map_err(|err| runtime_error_frame(err, "detach"))
+    // Realtime attachment lifecycle is capability-driven by the runtime. A
+    // websocket close only releases the channel-local product bridge; it does
+    // not caller-drive `DetachRealtimeBinding`.
+    Ok(())
 }
 
 /// Wave-c C-9c R4: project the realtime-WS reconnect-overlay's current
@@ -2925,8 +2929,9 @@ async fn attempt_realtime_reconnect(
     } else {
         runtime
             .runtime_adapter()
-            .attach_live(session_id)
+            .apply_capability_driven_realtime_transport(session_id)
             .await
+            .map(|_| ())
             .map_err(|err| runtime_error_frame(err, "reattach"))?;
         Ok(None)
     }

--- a/meerkat-rpc/tests/realtime_ws_protocol.rs
+++ b/meerkat-rpc/tests/realtime_ws_protocol.rs
@@ -419,7 +419,7 @@ async fn create_materialized_session(runtime: &Arc<SessionRuntime>) -> meerkat_c
         .create_session(
             AgentBuildConfig {
                 override_builtins: ToolCategoryOverride::Enable,
-                ..AgentBuildConfig::new("claude-sonnet-4-5")
+                ..AgentBuildConfig::new("gpt-realtime")
             },
             None,
             None,
@@ -455,15 +455,20 @@ async fn create_materialized_session(runtime: &Arc<SessionRuntime>) -> meerkat_c
 #[tokio::test]
 async fn channel_open_attaches_runtime_and_reports_opening_status() {
     let (_temp, runtime, config_store) = build_test_runtime();
-    let session_id = "01234567-89ab-cdef-0123-456789abcdef";
-    register_live_session(&runtime, session_id).await;
+    let session_id = create_materialized_session(&runtime).await;
+    let session_id_text = session_id.to_string();
+    runtime
+        .runtime_adapter()
+        .apply_capability_driven_realtime_transport(&session_id)
+        .await
+        .expect("runtime should bind realtime-capable session");
     let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
     let addr = listener.local_addr().unwrap();
     let ws_url = format!("ws://{addr}{REALTIME_WS_PATH}");
     let host = Arc::new(RealtimeWsHost::new(ws_url.clone()));
     let open_info = issue_open_info(
         host.as_ref(),
-        session_id,
+        &session_id_text,
         RealtimeChannelRole::Primary,
         RealtimeTurningMode::ProviderManaged,
     )
@@ -503,7 +508,7 @@ async fn channel_open_attaches_runtime_and_reports_opening_status() {
     let runtime_status =
         <meerkat_runtime::MeerkatMachine as SessionServiceRuntimeExt>::realtime_attachment_status(
             runtime.runtime_adapter().as_ref(),
-            &meerkat_core::SessionId::parse(session_id).expect("session_id should parse"),
+            &session_id,
         )
         .await
         .expect("registered session should expose runtime live status");
@@ -2505,15 +2510,20 @@ async fn channel_interrupt_routes_to_runtime_control_for_active_session() {
 #[tokio::test]
 async fn reattach_required_primary_channel_retries_and_returns_to_opening_status() {
     let (_temp, runtime, config_store) = build_test_runtime();
-    let session_id = "01234567-89ab-cdef-0123-456789abcdef";
-    register_live_session(&runtime, session_id).await;
+    let session_id_value = create_materialized_session(&runtime).await;
+    let session_id = session_id_value.to_string();
+    runtime
+        .runtime_adapter()
+        .apply_capability_driven_realtime_transport(&session_id_value)
+        .await
+        .expect("runtime should bind realtime-capable session");
     let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
     let addr = listener.local_addr().unwrap();
     let ws_url = format!("ws://{addr}{REALTIME_WS_PATH}");
     let host = Arc::new(RealtimeWsHost::new(ws_url.clone()));
     let open_info = issue_open_info_with_policy(
         host.as_ref(),
-        session_id,
+        &session_id,
         RealtimeChannelRole::Primary,
         RealtimeTurningMode::ProviderManaged,
         Some(RealtimeReconnectPolicy {
@@ -2530,8 +2540,6 @@ async fn reattach_required_primary_channel_retries_and_returns_to_opening_status
         serve_realtime_ws_listener(listener, server_host, server_runtime, config_store).await
     });
 
-    let session_id_value =
-        meerkat_core::SessionId::parse(session_id).expect("session_id should parse");
     let mut ws_stream = connect_and_open(
         &ws_url,
         &open_info,

--- a/meerkat-runtime/src/comms_trust_reconcile.rs
+++ b/meerkat-runtime/src/comms_trust_reconcile.rs
@@ -15,9 +15,9 @@
 //!   post-transition `peer_projection_epoch` — the DSL emits the fact
 //!   "reconcile needed at epoch N", the shell does the mechanical
 //!   diff.
-//! * This handler owns the mechanical reconciliation: it maintains an
-//!   "applied trust store" view and, given a fresh effective peer
-//!   set, computes the add / remove delta and calls
+//! * This handler owns the mechanical reconciliation: it reads the
+//!   canonical trust store, computes the add / remove delta against a
+//!   fresh effective peer set, and calls
 //!   `CommsRuntime::add_trusted_peer` / `remove_trusted_peer`
 //!   mechanically. No semantic decisions live here; failures surface
 //!   through typed errors.
@@ -39,24 +39,11 @@
 use std::collections::BTreeSet;
 use std::sync::Arc;
 
-use meerkat_core::agent::CommsRuntime;
+use crate::meerkat_machine::dsl::PeerEndpoint;
+use meerkat_core::agent::{CommsCapabilityError, CommsRuntime};
 use meerkat_core::comms::{
     PeerAddress, PeerId, PeerName, PeerTransport, SendError, TrustedPeerDescriptor,
 };
-// `tokio::sync::Mutex` (async) rather than `std::sync::Mutex` (sync)
-// so the lock can be held across `.await` points. This lets the
-// reconcile path serialize end-to-end — trust-store mutations AND
-// the applied-view commit run inside the same critical section,
-// closing the TOCTOU class where a stale reconcile's mutations
-// could orphan peers in the trust store while its commit was
-// skipped (PR #340 re-review item).
-//
-// Use `crate::tokio::sync::Mutex` (the crate-level re-export) so the
-// WASM target picks up `tokio_with_wasm::alias::sync::Mutex` instead
-// of the plain `tokio` crate, which is not wasm32-compatible.
-use crate::tokio::sync::Mutex;
-
-use crate::meerkat_machine::dsl::PeerEndpoint;
 
 /// Typed error surfaced by the reconciliation handler.
 #[derive(Debug, thiserror::Error)]
@@ -82,6 +69,9 @@ pub enum CommsTrustReconcileError {
     /// the contract visible.
     #[error("invalid peer endpoint `{peer_id}`: {detail}")]
     InvalidEndpoint { peer_id: String, detail: String },
+    /// The bound runtime does not expose its canonical trust-store snapshot.
+    #[error("canonical trust-store snapshot unavailable: {0}")]
+    TrustSnapshotUnavailable(#[from] CommsCapabilityError),
 }
 
 /// Structured summary of a single reconciliation pass.
@@ -100,95 +90,40 @@ pub struct ReconcileReport {
 
 /// Mechanical trust reconciliation handler.
 ///
-/// Holds a reference to a `CommsRuntime` and an applied view the
-/// reconciler uses to compute deltas. Thread-safe; the applied
-/// view is guarded by a single `Mutex`.
+/// Holds a reference to a `CommsRuntime`. Deltas are computed from the
+/// runtime's canonical trust-store snapshot on every pass.
 pub struct CommsTrustReconciler {
     comms: Arc<dyn CommsRuntime>,
-    applied: Mutex<AppliedView>,
 }
 
 impl std::fmt::Debug for CommsTrustReconciler {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        // `dyn CommsRuntime` does not implement `Debug`; print a
-        // structural placeholder. Reading the applied view requires
-        // an async lock acquisition, which is not available from
-        // `Debug::fmt` — tests use `applied_snapshot()` for the
-        // view contents instead.
         f.debug_struct("CommsTrustReconciler")
             .finish_non_exhaustive()
     }
 }
 
-#[derive(Debug, Default)]
-struct AppliedView {
-    /// Peers currently registered in the trust store (per the
-    /// reconciler's view; failures are self-correcting on the next
-    /// pass).
-    peers: BTreeSet<PeerEndpoint>,
-    /// Highest epoch applied so far. Reconciles with strictly-lower
-    /// epoch are rejected to prevent out-of-order deliveries
-    /// regressing the trust view.
-    epoch: u64,
-}
-
 impl CommsTrustReconciler {
     /// Construct a reconciler bound to the given comms runtime.
-    /// Initial applied view is empty at epoch 0.
     pub fn new(comms: Arc<dyn CommsRuntime>) -> Self {
-        Self {
-            comms,
-            applied: Mutex::new(AppliedView::default()),
-        }
+        Self { comms }
     }
 
     /// Reconcile the trust store against `effective_peers`.
     ///
     /// Returns a [`ReconcileReport`] describing the add / remove
-    /// calls the reconciler made. Out-of-order epochs (epoch <
-    /// currently-applied) return `Ok` with an empty report — the
-    /// reconciler treats them as stale.
+    /// calls the reconciler made.
     ///
     /// Trust-store failures surface as
-    /// [`CommsTrustReconcileError`]; the applied view is only
-    /// advanced for peers the trust store acknowledged, so failed
-    /// adds/removes are retried on the next pass.
-    ///
-    /// Concurrency (PR #340 re-review fix): the entire reconcile
-    /// path — stale-epoch check, trust-store add/remove calls, and
-    /// applied-view commit — runs inside a single `tokio::sync::Mutex`
-    /// critical section. Stale reconciles fail the epoch check at
-    /// the TOP of the critical section and short-circuit WITHOUT
-    /// touching the trust store, preventing the earlier TOCTOU
-    /// class where a stale reconcile's mutations could orphan
-    /// peers in the trust store while its commit was skipped.
-    ///
-    /// The lock is tokio's async mutex (not `std::sync::Mutex`) so
-    /// it can be held across `.await` points for the trust-store
-    /// calls. The critical section is short relative to mob
-    /// topology changes — overlay reconciliation fires at the
-    /// rate of topology-change events, not per-message — so
-    /// holding the lock across awaits is well within the
-    /// reconciler's latency budget.
+    /// [`CommsTrustReconcileError`]. There is no helper-local applied
+    /// truth: if a prior mutation failed, the next pass re-reads the
+    /// canonical trust store and retries whatever delta remains.
     pub async fn reconcile(
         &self,
         epoch: u64,
         effective_peers: BTreeSet<PeerEndpoint>,
     ) -> Result<ReconcileReport, CommsTrustReconcileError> {
-        let mut guard = self.applied.lock().await;
-
-        if epoch < guard.epoch {
-            // Stale delivery — short-circuit INSIDE the lock.
-            // The trust store is not touched, so no orphaned
-            // mutations.
-            return Ok(ReconcileReport {
-                added: Vec::new(),
-                removed: Vec::new(),
-                applied_epoch: guard.epoch,
-            });
-        }
-
-        let previous_peers: BTreeSet<PeerEndpoint> = guard.peers.clone();
+        let previous_peers = self.canonical_trusted_peer_snapshot().await?;
 
         let to_add: Vec<PeerEndpoint> = effective_peers
             .iter()
@@ -206,9 +141,7 @@ impl CommsTrustReconciler {
 
         // Perform adds first so a concurrent peer-send from the same
         // session sees the new peer available even if a remove for
-        // an older session hasn't completed. Both adds and removes
-        // happen while the async mutex is held — concurrent
-        // reconciles wait their turn.
+        // an older session hasn't completed.
         for endpoint in to_add {
             let descriptor = endpoint_to_descriptor(&endpoint)?;
             self.comms
@@ -232,30 +165,22 @@ impl CommsTrustReconciler {
             removed.push(endpoint);
         }
 
-        // Commit the applied view under the same lock. No race
-        // possible — we've held the lock across the entire
-        // trust-store interaction.
-        guard.peers = effective_peers;
-        guard.epoch = epoch;
-        let applied_epoch = epoch;
-
         Ok(ReconcileReport {
             added,
             removed,
-            applied_epoch,
+            applied_epoch: epoch,
         })
     }
 
-    /// Snapshot of the reconciler's current applied view.
-    ///
-    /// Observability/test accessor. Production call sites should rely on
-    /// [`ReconcileReport`] returned from [`Self::reconcile`] instead —
-    /// the snapshot only reflects the reconciler's internal `AppliedView`
-    /// and is not authoritative for the trust store itself.
-    #[doc(hidden)]
-    pub async fn applied_snapshot(&self) -> (u64, BTreeSet<PeerEndpoint>) {
-        let guard = self.applied.lock().await;
-        (guard.epoch, guard.peers.clone())
+    async fn canonical_trusted_peer_snapshot(
+        &self,
+    ) -> Result<BTreeSet<PeerEndpoint>, CommsTrustReconcileError> {
+        let snapshot = self.comms.peer_ingress_runtime_snapshot().await?;
+        snapshot
+            .trusted_peers
+            .iter()
+            .map(descriptor_to_endpoint)
+            .collect()
     }
 }
 
@@ -307,11 +232,25 @@ fn parse_peer_address(raw: &str) -> Result<PeerAddress, String> {
     Ok(PeerAddress::new(transport, endpoint))
 }
 
+fn descriptor_to_endpoint(
+    descriptor: &TrustedPeerDescriptor,
+) -> Result<PeerEndpoint, CommsTrustReconcileError> {
+    Ok(PeerEndpoint {
+        name: crate::meerkat_machine::dsl::PeerName(descriptor.name.as_str().to_owned()),
+        peer_id: crate::meerkat_machine::dsl::PeerId(descriptor.peer_id.to_string()),
+        address: crate::meerkat_machine::dsl::PeerAddress(descriptor.address.to_string()),
+        signing_key: crate::meerkat_machine::dsl::PeerSigningKey(descriptor.pubkey),
+    })
+}
+
 #[cfg(test)]
 #[allow(clippy::unwrap_used, clippy::expect_used, clippy::panic)]
 mod tests {
     use super::*;
     use async_trait::async_trait;
+    use meerkat_core::{
+        PeerIngressAuthorityPhase, PeerIngressQueueSnapshot, PeerIngressRuntimeSnapshot,
+    };
     use std::sync::atomic::{AtomicBool, Ordering};
 
     /// Build a `PeerEndpoint` with a valid UUID `peer_id` and an
@@ -340,6 +279,7 @@ mod tests {
     struct RecordingCommsRuntime {
         adds: std::sync::Mutex<Vec<TrustedPeerDescriptor>>,
         removes: std::sync::Mutex<Vec<String>>,
+        trusted: std::sync::Mutex<BTreeSet<PeerEndpoint>>,
         fail_next_add: AtomicBool,
         fail_next_remove: AtomicBool,
     }
@@ -367,7 +307,11 @@ mod tests {
             self.adds
                 .lock()
                 .unwrap_or_else(std::sync::PoisonError::into_inner)
-                .push(peer);
+                .push(peer.clone());
+            self.trusted
+                .lock()
+                .unwrap_or_else(std::sync::PoisonError::into_inner)
+                .insert(descriptor_to_endpoint(&peer).expect("test descriptor should map"));
             Ok(())
         }
 
@@ -379,7 +323,33 @@ mod tests {
                 .lock()
                 .unwrap_or_else(std::sync::PoisonError::into_inner)
                 .push(peer_id.to_string());
+            self.trusted
+                .lock()
+                .unwrap_or_else(std::sync::PoisonError::into_inner)
+                .retain(|endpoint| endpoint.peer_id.0 != peer_id);
             Ok(true)
+        }
+
+        async fn peer_ingress_runtime_snapshot(
+            &self,
+        ) -> Result<PeerIngressRuntimeSnapshot, CommsCapabilityError> {
+            let trusted_peers = self
+                .trusted
+                .lock()
+                .unwrap_or_else(std::sync::PoisonError::into_inner)
+                .iter()
+                .map(endpoint_to_descriptor)
+                .collect::<Result<Vec<_>, _>>()
+                .map_err(|err| CommsCapabilityError::Unsupported(err.to_string()))?;
+            Ok(PeerIngressRuntimeSnapshot {
+                self_peer_id: PeerId::parse("00000000-0000-4000-8000-000000000000")
+                    .expect("valid test peer id"),
+                auth_required: true,
+                authority_phase: PeerIngressAuthorityPhase::Received,
+                trusted_peers,
+                submission_queue_len: 0,
+                queue: PeerIngressQueueSnapshot::default(),
+            })
         }
     }
 
@@ -466,7 +436,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn stale_epoch_reconcile_is_accepted_as_no_op() {
+    async fn reconcile_reads_canonical_store_not_local_applied_view() {
         let comms = Arc::new(RecordingCommsRuntime::default());
         let reconciler = CommsTrustReconciler::new(comms.clone());
 
@@ -475,20 +445,31 @@ mod tests {
             .await
             .expect("first reconcile");
 
-        let report = reconciler
-            .reconcile(4, BTreeSet::from([endpoint("B", UUID_B)]))
-            .await
-            .expect("stale reconcile accepted");
-        assert!(report.added.is_empty());
-        assert!(report.removed.is_empty());
-        assert_eq!(
-            report.applied_epoch, 5,
-            "applied_epoch must remain at the newer watermark",
-        );
+        // Mutate the canonical trust store outside the reconciler. A helper-
+        // local applied view would still believe A is present and B absent;
+        // the correct reconciler re-reads canonical truth and restores A while
+        // removing B.
+        comms
+            .trusted
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .clear();
+        comms
+            .trusted
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .insert(endpoint("B", UUID_B));
 
-        // Only the first reconcile's add made it to the trust store.
-        assert_eq!(comms.add_calls().len(), 1);
-        assert_eq!(comms.remove_calls().len(), 0);
+        let report = reconciler
+            .reconcile(4, BTreeSet::from([endpoint("A", UUID_A)]))
+            .await
+            .expect("reconcile should read canonical trust store");
+        assert_eq!(report.added, vec![endpoint("A", UUID_A)]);
+        assert_eq!(report.removed, vec![endpoint("B", UUID_B)]);
+        assert_eq!(report.applied_epoch, 4);
+
+        assert_eq!(comms.add_calls().len(), 2);
+        assert_eq!(comms.remove_calls(), vec![UUID_B.to_string()]);
     }
 
     #[tokio::test]

--- a/meerkat-runtime/src/meerkat_machine/comms_drain.rs
+++ b/meerkat-runtime/src/meerkat_machine/comms_drain.rs
@@ -392,25 +392,26 @@ impl MeerkatMachine {
             None => return false,
         };
 
-        // Wave-c C-H2: drain slot now lives on `RuntimeSessionEntry`, so
-        // one `sessions.write()` lock suffices for the "session exists +
-        // start the slot" gate. No separate drain-slots map to keep in
-        // sync with `sessions`.
+        // Inspect first, then stage the DSL transition, then mutate the
+        // mechanical slot. A rejected `SpawnDrain` must leave the shell slot
+        // untouched.
         let (needs_rebind, needs_spawn) = {
-            let mut sessions = self.sessions.write().await;
-            let Some(entry) = sessions.get_mut(session_id) else {
+            let sessions = self.sessions.read().await;
+            let Some(entry) = sessions.get(session_id) else {
                 tracing::warn!(
                     %session_id,
                     "refusing to spawn comms drain for unregistered session"
                 );
                 return false;
             };
-            let slot = &mut entry.drain_slot;
-            let needs_rebind = slot.begin_rebind(mode, comms.clone());
+            let slot = &entry.drain_slot;
+            let needs_rebind = slot.phase == CommsDrainPhase::Running
+                && slot.mode == Some(mode)
+                && !slot.bound_runtime_matches(&comms);
             let needs_spawn = if needs_rebind {
                 false
             } else {
-                slot.begin_running(mode, comms.clone())
+                slot.can_ensure_running()
             };
             (needs_rebind, needs_spawn)
         };
@@ -443,8 +444,6 @@ impl MeerkatMachine {
                         error = %crate::meerkat_machine::dsl_authority::map_error(err, "SpawnDrain"),
                         "DSL rejected SpawnDrain; skipping drain spawn"
                     );
-                    entry.drain_slot.phase = CommsDrainPhase::Stopped;
-                    entry.drain_slot.bound_runtime = None;
                     return false;
                 }
             } else {
@@ -473,6 +472,15 @@ impl MeerkatMachine {
         );
         let mut sessions = self.sessions.write().await;
         if let Some(entry) = sessions.get_mut(session_id) {
+            let slot_started = if needs_rebind {
+                entry.drain_slot.begin_rebind(mode, comms.clone())
+            } else {
+                entry.drain_slot.begin_running(mode, comms.clone())
+            };
+            if !slot_started {
+                handle.abort();
+                return false;
+            }
             entry.drain_slot.handle = Some(handle);
             entry.drain_slot.mark_task_spawned();
         }

--- a/meerkat-runtime/src/meerkat_machine/composition.rs
+++ b/meerkat-runtime/src/meerkat_machine/composition.rs
@@ -335,13 +335,23 @@ fn project_str<'a>(
         })
 }
 
-fn parse_work_origin(slug: &str) -> Result<mm_dsl::WorkOrigin, String> {
-    match slug {
-        "External" => Ok(mm_dsl::WorkOrigin::External),
-        "Internal" => Ok(mm_dsl::WorkOrigin::Internal),
-        "Ingest" => Ok(mm_dsl::WorkOrigin::Ingest),
-        other => Err(format!("unknown WorkOrigin slug `{other}`")),
-    }
+fn project_work_origin(
+    fields: &[(FieldId, OwnedFieldValue)],
+    name: &str,
+) -> Result<mm_dsl::WorkOrigin, String> {
+    fields
+        .iter()
+        .find(|(id, _)| id.as_str() == name)
+        .ok_or_else(|| format!("missing projected field `{name}`"))
+        .and_then(|(_, v)| match v {
+            OwnedFieldValue::Opaque(value) => value
+                .downcast_ref::<mm_dsl::WorkOrigin>()
+                .copied()
+                .ok_or_else(|| format!("projected field `{name}` is not WorkOrigin")),
+            other => Err(format!(
+                "projected field `{name}` is not WorkOrigin: {other:?}"
+            )),
+        })
 }
 
 #[async_trait]
@@ -377,8 +387,7 @@ impl ConsumerSurface for MeerkatConsumerSurface {
                 // `work_id`; producer `origin` → consumer `origin`.
                 let rt = project_str(&projected, "runtime_id")?;
                 let work_id = project_str(&projected, "work_id")?;
-                let origin_slug = project_str(&projected, "origin")?;
-                let origin = parse_work_origin(origin_slug)?;
+                let origin = project_work_origin(&projected, "origin")?;
                 mm_dsl::MeerkatMachineInput::Ingest {
                     runtime_id: mm_dsl::AgentRuntimeId::from(rt.to_string()),
                     work_id: mm_dsl::WorkId::from(work_id.to_string()),
@@ -549,7 +558,10 @@ mod tests {
                 vec![
                     (fld("runtime_id"), OwnedFieldValue::Str("rt-other".into())),
                     (fld("work_id"), OwnedFieldValue::Str("work-1".into())),
-                    (fld("origin"), OwnedFieldValue::Str("Ingest".into())),
+                    (
+                        fld("origin"),
+                        OwnedFieldValue::Opaque(Arc::new(mm_dsl::WorkOrigin::Ingest)),
+                    ),
                     (
                         fld("session_id"),
                         OwnedFieldValue::Str(session_id.to_string()),
@@ -574,7 +586,10 @@ mod tests {
                 vec![
                     (fld("runtime_id"), OwnedFieldValue::Str("rt-match".into())),
                     (fld("work_id"), OwnedFieldValue::Str("work-1".into())),
-                    (fld("origin"), OwnedFieldValue::Str("Ingest".into())),
+                    (
+                        fld("origin"),
+                        OwnedFieldValue::Opaque(Arc::new(mm_dsl::WorkOrigin::Ingest)),
+                    ),
                 ],
             )
             .await
@@ -595,7 +610,10 @@ mod tests {
                 vec![
                     (fld("runtime_id"), OwnedFieldValue::Str("rt-missing".into())),
                     (fld("work_id"), OwnedFieldValue::Str("work-1".into())),
-                    (fld("origin"), OwnedFieldValue::Str("Ingest".into())),
+                    (
+                        fld("origin"),
+                        OwnedFieldValue::Opaque(Arc::new(mm_dsl::WorkOrigin::Ingest)),
+                    ),
                 ],
             )
             .await
@@ -623,7 +641,10 @@ mod tests {
                 vec![
                     (fld("runtime_id"), OwnedFieldValue::Str("rt-shared".into())),
                     (fld("work_id"), OwnedFieldValue::Str("work-1".into())),
-                    (fld("origin"), OwnedFieldValue::Str("Ingest".into())),
+                    (
+                        fld("origin"),
+                        OwnedFieldValue::Opaque(Arc::new(mm_dsl::WorkOrigin::Ingest)),
+                    ),
                 ],
             )
             .await

--- a/meerkat-runtime/src/meerkat_machine/dispatch_drain.rs
+++ b/meerkat-runtime/src/meerkat_machine/dispatch_drain.rs
@@ -174,12 +174,17 @@ impl MeerkatMachine {
                         .map(|(sid, _)| sid.clone())
                         .collect()
                 };
+                let mut accepted_session_ids = Vec::new();
                 for sid in &session_ids {
-                    self.stage_drain_stop_dsl(sid).await;
+                    if self.stage_drain_stop_dsl(sid).await {
+                        accepted_session_ids.push(sid.clone());
+                    }
                 }
                 let mut sessions = self.sessions.write().await;
-                for (_, entry) in sessions.iter_mut() {
-                    abort_slot(&mut entry.drain_slot);
+                for sid in accepted_session_ids {
+                    if let Some(entry) = sessions.get_mut(&sid) {
+                        abort_slot(&mut entry.drain_slot);
+                    }
                 }
                 Ok(MeerkatMachineCommandResult::Unit)
             }
@@ -201,8 +206,8 @@ impl MeerkatMachine {
                         })
                         .unwrap_or(false)
                 };
-                if drain_is_running {
-                    self.stage_drain_stop_dsl(&session_id).await;
+                if drain_is_running && !self.stage_drain_stop_dsl(&session_id).await {
+                    return Ok(MeerkatMachineCommandResult::Unit);
                 }
                 let mut sessions = self.sessions.write().await;
                 if let Some(entry) = sessions.get_mut(&session_id) {
@@ -255,7 +260,7 @@ impl MeerkatMachine {
                     } else {
                         "DrainExitedClean(safety)"
                     };
-                    {
+                    let dsl_accepted = {
                         let mut sessions = self.sessions.write().await;
                         if let Some(entry) = sessions.get_mut(&session_id) {
                             let mut authority = entry
@@ -272,18 +277,25 @@ impl MeerkatMachine {
                                     error = %crate::meerkat_machine::dsl_authority::map_error(err, context),
                                     "DSL rejected drain exit safety net"
                                 );
+                                false
+                            } else {
+                                true
                             }
+                        } else {
+                            false
                         }
-                    }
+                    };
                     tracing::warn!(
                         "comms_drain: task exited without notifying authority (likely panicked), \
                          submitting Failed safety net"
                     );
-                    let mut sessions = self.sessions.write().await;
-                    if let Some(entry) = sessions.get_mut(&session_id) {
-                        entry.drain_slot.mark_task_exit_if_running_for_safety(
-                            crate::meerkat_machine::DrainExitReason::Failed,
-                        );
+                    if dsl_accepted {
+                        let mut sessions = self.sessions.write().await;
+                        if let Some(entry) = sessions.get_mut(&session_id) {
+                            entry.drain_slot.mark_task_exit_if_running_for_safety(
+                                crate::meerkat_machine::DrainExitReason::Failed,
+                            );
+                        }
                     }
                 }
                 Ok(MeerkatMachineCommandResult::Unit)
@@ -293,15 +305,13 @@ impl MeerkatMachine {
     }
 
     /// Fire the typed `StopDrain` DSL input for `session_id` if the session
-    /// still has a live DSL authority. A guard rejection (e.g. the drain
-    /// was never `Running` for this session) is downgraded to a warn so the
-    /// caller's abort-cleanup flow proceeds — `StopDrain` is idempotent by
-    /// DSL construction, so "already stopped" is the only legitimate
-    /// rejection shape at this seam.
-    async fn stage_drain_stop_dsl(&self, session_id: &meerkat_core::types::SessionId) {
+    /// still has a live DSL authority. Returns whether the machine accepted
+    /// the transition; callers use that gate before applying shell-side abort
+    /// projection.
+    async fn stage_drain_stop_dsl(&self, session_id: &meerkat_core::types::SessionId) -> bool {
         let mut sessions = self.sessions.write().await;
         let Some(entry) = sessions.get_mut(session_id) else {
-            return;
+            return false;
         };
         let mut authority = entry
             .dsl_authority
@@ -314,8 +324,11 @@ impl MeerkatMachine {
             tracing::warn!(
                 %session_id,
                 error = %crate::meerkat_machine::dsl_authority::map_error(err, "StopDrain"),
-                "DSL rejected StopDrain; proceeding with abort"
+                "DSL rejected StopDrain; skipping drain abort"
             );
+            false
+        } else {
+            true
         }
     }
 }

--- a/meerkat-runtime/src/meerkat_machine/session_management.rs
+++ b/meerkat-runtime/src/meerkat_machine/session_management.rs
@@ -773,7 +773,7 @@ impl MeerkatMachine {
     /// (runtime state == Attached or Running). Callers hitting Idle sessions
     /// get `RuntimeDriverError::NotReady`, matching the pre-DSL contract used
     /// by the realtime attachment host.
-    pub async fn attach_live(
+    pub(crate) async fn attach_live(
         &self,
         session_id: &SessionId,
     ) -> Result<crate::meerkat_machine_types::RealtimeAttachmentSignalAuthority, RuntimeDriverError>
@@ -809,6 +809,19 @@ impl MeerkatMachine {
         .await
         .map_err(|reason| RuntimeDriverError::ValidationFailed { reason })?;
         self.read_session_realtime_authority(session_id, "replace_realtime_attachment")
+            .await
+    }
+
+    /// Read the current runtime-owned realtime binding authority without
+    /// changing attachment lifecycle state. Provider hosts use this after the
+    /// capability-driven transport policy has already decided that a binding
+    /// should exist.
+    pub async fn current_realtime_attachment_authority(
+        &self,
+        session_id: &SessionId,
+    ) -> Result<crate::meerkat_machine_types::RealtimeAttachmentSignalAuthority, RuntimeDriverError>
+    {
+        self.read_session_realtime_authority(session_id, "current_realtime_attachment_authority")
             .await
     }
 
@@ -876,7 +889,10 @@ impl MeerkatMachine {
 
     /// Detach the runtime-owned binding. Preserves the durable intent bit so
     /// `realtime_attachment_status` can still project `IntentPresentUnbound`.
-    pub async fn detach_live(&self, session_id: &SessionId) -> Result<(), RuntimeDriverError> {
+    pub(crate) async fn detach_live(
+        &self,
+        session_id: &SessionId,
+    ) -> Result<(), RuntimeDriverError> {
         self.stage_session_dsl_input(
             session_id,
             dsl::MeerkatMachineInput::DetachRealtimeBinding,

--- a/meerkat-runtime/tests/peer_projection_producer_wiring.rs
+++ b/meerkat-runtime/tests/peer_projection_producer_wiring.rs
@@ -30,9 +30,12 @@ use std::collections::BTreeSet;
 use std::sync::Arc;
 
 use async_trait::async_trait;
-use meerkat_core::agent::CommsRuntime;
+use meerkat_core::agent::{CommsCapabilityError, CommsRuntime};
 use meerkat_core::comms::{SendError, TrustedPeerDescriptor};
 use meerkat_core::types::SessionId;
+use meerkat_core::{
+    PeerIngressAuthorityPhase, PeerIngressQueueSnapshot, PeerIngressRuntimeSnapshot,
+};
 use meerkat_runtime::MeerkatMachine;
 use meerkat_runtime::meerkat_machine::dsl::{
     PeerAddress, PeerEndpoint, PeerId, PeerName, PeerSigningKey,
@@ -55,6 +58,7 @@ fn endpoint(name: &str, peer_id_uuid: &str) -> PeerEndpoint {
 struct RecordingCommsRuntime {
     adds: std::sync::Mutex<Vec<TrustedPeerDescriptor>>,
     removes: std::sync::Mutex<Vec<String>>,
+    trusted: std::sync::Mutex<Vec<TrustedPeerDescriptor>>,
 }
 
 impl std::fmt::Debug for RecordingCommsRuntime {
@@ -77,6 +81,10 @@ impl CommsRuntime for RecordingCommsRuntime {
         self.adds
             .lock()
             .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .push(peer.clone());
+        self.trusted
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
             .push(peer);
         Ok(())
     }
@@ -86,7 +94,33 @@ impl CommsRuntime for RecordingCommsRuntime {
             .lock()
             .unwrap_or_else(std::sync::PoisonError::into_inner)
             .push(peer_id.to_string());
-        Ok(true)
+        let mut trusted = self
+            .trusted
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        let before = trusted.len();
+        trusted.retain(|peer| peer.peer_id.as_str() != peer_id);
+        Ok(before != trusted.len())
+    }
+
+    async fn peer_ingress_runtime_snapshot(
+        &self,
+    ) -> Result<PeerIngressRuntimeSnapshot, CommsCapabilityError> {
+        Ok(PeerIngressRuntimeSnapshot {
+            self_peer_id: meerkat_core::comms::PeerId::parse(
+                "00000000-0000-4000-8000-000000000000",
+            )
+            .expect("valid test peer id"),
+            auth_required: true,
+            authority_phase: PeerIngressAuthorityPhase::Received,
+            trusted_peers: self
+                .trusted
+                .lock()
+                .unwrap_or_else(std::sync::PoisonError::into_inner)
+                .clone(),
+            submission_queue_len: 0,
+            queue: PeerIngressQueueSnapshot::default(),
+        })
     }
 }
 

--- a/meerkat-runtime/tests/trust_reconcile_add_failure.rs
+++ b/meerkat-runtime/tests/trust_reconcile_add_failure.rs
@@ -13,9 +13,9 @@
 //!   (a) surface the failure as
 //!       `CommsTrustReconcileError::AddTrustFailed` with the typed
 //!       peer id echoed back,
-//!   (b) NOT advance its internal applied view — later reconciles
-//!       see the same "empty" state, so a retry will try to add the
-//!       same peer again rather than the reconciler leaking a
+//!   (b) NOT mutate the canonical trust store — later reconciles
+//!       re-read the same "empty" state, so a retry will try to add
+//!       the same peer again rather than the reconciler leaking a
 //!       phantom "already applied" entry.
 
 #![allow(clippy::unwrap_used, clippy::expect_used, clippy::panic)]
@@ -25,8 +25,11 @@ use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, Ordering};
 
 use async_trait::async_trait;
-use meerkat_core::agent::CommsRuntime;
+use meerkat_core::agent::{CommsCapabilityError, CommsRuntime};
 use meerkat_core::comms::{SendError, TrustedPeerDescriptor};
+use meerkat_core::{
+    PeerIngressAuthorityPhase, PeerIngressQueueSnapshot, PeerIngressRuntimeSnapshot,
+};
 use meerkat_runtime::comms_trust_reconcile::{CommsTrustReconcileError, CommsTrustReconciler};
 use meerkat_runtime::meerkat_machine::dsl::{
     PeerAddress, PeerEndpoint, PeerId, PeerName, PeerSigningKey,
@@ -83,6 +86,22 @@ impl CommsRuntime for AddFailingCommsRuntime {
     async fn remove_trusted_peer(&self, _peer_id: &str) -> Result<bool, SendError> {
         Ok(true)
     }
+
+    async fn peer_ingress_runtime_snapshot(
+        &self,
+    ) -> Result<PeerIngressRuntimeSnapshot, CommsCapabilityError> {
+        Ok(PeerIngressRuntimeSnapshot {
+            self_peer_id: meerkat_core::comms::PeerId::parse(
+                "00000000-0000-4000-8000-000000000000",
+            )
+            .expect("valid test peer id"),
+            auth_required: true,
+            authority_phase: PeerIngressAuthorityPhase::Received,
+            trusted_peers: self.successful_add_calls(),
+            submission_queue_len: 0,
+            queue: PeerIngressQueueSnapshot::default(),
+        })
+    }
 }
 
 impl AddFailingCommsRuntime {
@@ -95,11 +114,10 @@ impl AddFailingCommsRuntime {
 }
 
 /// Add failure surfaces a typed `AddTrustFailed` error. The
-/// reconciler's applied view is NOT advanced — a subsequent retry
-/// with the same peer set sees the peer as absent and tries the
-/// add again.
+/// canonical trust store is NOT mutated — a subsequent retry with the
+/// same peer set re-reads the peer as absent and tries the add again.
 #[tokio::test]
-async fn add_failure_surfaces_typed_error_and_preserves_applied_view() {
+async fn add_failure_surfaces_typed_error_and_preserves_canonical_store() {
     let comms = Arc::new(AddFailingCommsRuntime::default());
     comms.fail_next_add.store(true, Ordering::SeqCst);
     let reconciler = CommsTrustReconciler::new(comms.clone());
@@ -119,27 +137,16 @@ async fn add_failure_surfaces_typed_error_and_preserves_applied_view() {
         other => panic!("expected AddTrustFailed, got {other:?}"),
     }
 
-    // Applied view must NOT have been advanced — still empty at
-    // epoch 0.
-    let (applied_epoch, applied_peers) = reconciler.applied_snapshot().await;
-    assert_eq!(
-        applied_epoch, 0,
-        "applied epoch must NOT advance past a failed reconcile",
-    );
-    assert!(
-        applied_peers.is_empty(),
-        "applied peers must NOT contain the peer that failed to add",
-    );
+    // Canonical store must still be empty; the only attempted add
+    // errored before it could commit.
     assert!(
         comms.successful_add_calls().is_empty(),
         "no successful trust-store adds yet — the only attempt errored",
     );
 
     // Retry the same reconcile at the same epoch. Now the failure
-    // flag is cleared; the retry succeeds. The applied view advances
-    // because the peer is newly-present-in-effective-set from the
-    // reconciler's perspective (its internal view was not mutated
-    // by the earlier failure).
+    // flag is cleared; the retry succeeds because the reconciler
+    // re-reads the canonical store and still sees the peer absent.
     let retry = reconciler
         .reconcile(1, BTreeSet::from([endpoint("A", UUID_A)]))
         .await
@@ -152,11 +159,7 @@ async fn add_failure_surfaces_typed_error_and_preserves_applied_view() {
         1,
         "trust store now carries peer A after the retry",
     );
-    let (applied_epoch_after_retry, applied_peers_after_retry) =
-        reconciler.applied_snapshot().await;
-    assert_eq!(applied_epoch_after_retry, 1);
-    assert_eq!(
-        applied_peers_after_retry,
-        BTreeSet::from([endpoint("A", UUID_A)]),
-    );
+    let trusted_after_retry = comms.successful_add_calls();
+    assert_eq!(trusted_after_retry.len(), 1);
+    assert_eq!(trusted_after_retry[0].peer_id.to_string(), UUID_A);
 }

--- a/meerkat-runtime/tests/trust_reconcile_concurrency.rs
+++ b/meerkat-runtime/tests/trust_reconcile_concurrency.rs
@@ -14,13 +14,12 @@
 //!
 //! Invariants pinned:
 //!
-//! * §6 #1 — Concurrent reconciles serialize through the reconciler's
-//!   async mutex; there is no race between overlapping `reconcile()`
-//!   calls.
-//! * §6 #2 — A stale-epoch reconcile (arriving after a newer one has
-//!   committed) short-circuits inside the critical section without
-//!   mutating the trust store. The applied-epoch watermark never
-//!   regresses.
+//! * §6 #1 — Concurrent reconciles read from the canonical trust store;
+//!   there is no helper-local applied view for overlapping calls to
+//!   corrupt.
+//! * §6 #2 — Epoch is reported for observability only. A lower-epoch
+//!   reconcile still diffs against canonical runtime trust, not against
+//!   a reconciler-local watermark.
 
 #![allow(clippy::unwrap_used, clippy::expect_used, clippy::panic)]
 
@@ -29,8 +28,11 @@ use std::sync::Arc;
 use std::sync::atomic::{AtomicUsize, Ordering};
 
 use async_trait::async_trait;
-use meerkat_core::agent::CommsRuntime;
+use meerkat_core::agent::{CommsCapabilityError, CommsRuntime};
 use meerkat_core::comms::{SendError, TrustedPeerDescriptor};
+use meerkat_core::{
+    PeerIngressAuthorityPhase, PeerIngressQueueSnapshot, PeerIngressRuntimeSnapshot,
+};
 use meerkat_runtime::comms_trust_reconcile::{CommsTrustReconciler, ReconcileReport};
 use meerkat_runtime::meerkat_machine::dsl::{
     PeerAddress, PeerEndpoint, PeerId, PeerName, PeerSigningKey,
@@ -49,14 +51,14 @@ fn endpoint(name: &str, peer_id_uuid: &str) -> PeerEndpoint {
 }
 
 /// Mock `CommsRuntime` that records every trust-store interaction and
-/// exposes the accumulated history for assertion. The calls-vector
-/// mutex is `std::sync::Mutex` because we never hold it across an
-/// `.await`; the reconciler's own async mutex guards the critical
-/// section we're testing.
+/// exposes the accumulated history and current canonical trust store for
+/// assertion. The mutexes are `std::sync::Mutex` because we never hold them
+/// across an `.await`.
 #[derive(Default)]
 struct RecordingCommsRuntime {
     adds: std::sync::Mutex<Vec<TrustedPeerDescriptor>>,
     removes: std::sync::Mutex<Vec<String>>,
+    trusted: std::sync::Mutex<Vec<TrustedPeerDescriptor>>,
     add_count: AtomicUsize,
     remove_count: AtomicUsize,
 }
@@ -82,6 +84,10 @@ impl CommsRuntime for RecordingCommsRuntime {
         self.adds
             .lock()
             .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .push(peer.clone());
+        self.trusted
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
             .push(peer);
         Ok(())
     }
@@ -92,7 +98,33 @@ impl CommsRuntime for RecordingCommsRuntime {
             .lock()
             .unwrap_or_else(std::sync::PoisonError::into_inner)
             .push(peer_id.to_string());
-        Ok(true)
+        let mut trusted = self
+            .trusted
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        let before = trusted.len();
+        trusted.retain(|peer| peer.peer_id.to_string() != peer_id);
+        Ok(before != trusted.len())
+    }
+
+    async fn peer_ingress_runtime_snapshot(
+        &self,
+    ) -> Result<PeerIngressRuntimeSnapshot, CommsCapabilityError> {
+        Ok(PeerIngressRuntimeSnapshot {
+            self_peer_id: meerkat_core::comms::PeerId::parse(
+                "00000000-0000-4000-8000-000000000000",
+            )
+            .expect("valid test peer id"),
+            auth_required: true,
+            authority_phase: PeerIngressAuthorityPhase::Received,
+            trusted_peers: self
+                .trusted
+                .lock()
+                .unwrap_or_else(std::sync::PoisonError::into_inner)
+                .clone(),
+            submission_queue_len: 0,
+            queue: PeerIngressQueueSnapshot::default(),
+        })
     }
 }
 
@@ -103,17 +135,24 @@ impl RecordingCommsRuntime {
             .unwrap_or_else(std::sync::PoisonError::into_inner)
             .clone()
     }
+
+    fn trusted_peer_ids(&self) -> BTreeSet<String> {
+        self.trusted
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .iter()
+            .map(|peer| peer.peer_id.to_string())
+            .collect()
+    }
 }
 
-/// §6 #1 — concurrent reconciles are serialized end-to-end.
+/// §6 #1 — concurrent reconciles use canonical trust as their only state.
 ///
-/// Two reconciles spawn in parallel; whichever wins the mutex first
-/// runs to completion (including all trust-store awaits) before the
-/// other observes any state. After both complete, the applied view
-/// reflects the newer epoch exactly, and the trust store is
-/// consistent with the winner's peer set.
+/// Two reconciles spawn in parallel. Their exact interleaving is not
+/// semantically owned by the reconciler; the invariant is that no helper-local
+/// applied view exists for either call to corrupt.
 #[tokio::test]
-async fn concurrent_reconciles_are_serialised_and_stale_short_circuits() {
+async fn concurrent_reconciles_complete_against_canonical_store() {
     let comms = Arc::new(RecordingCommsRuntime::default());
     let reconciler = Arc::new(CommsTrustReconciler::new(comms.clone()));
 
@@ -138,37 +177,22 @@ async fn concurrent_reconciles_are_serialised_and_stale_short_circuits() {
         .expect("newer task joins")
         .expect("newer reconcile ok");
 
-    // Final applied view reflects the newer epoch, always.
-    let (applied_epoch, applied_peers) = reconciler.applied_snapshot().await;
-    assert_eq!(applied_epoch, 2);
-    assert_eq!(applied_peers, BTreeSet::from([endpoint("B", UUID_B)]));
-
-    // The newer reconcile's applied_epoch is 2 regardless of ordering.
-    assert_eq!(
-        newer_res.applied_epoch, 2,
-        "newer reconcile must apply its epoch (never stale against older): got {}",
-        newer_res.applied_epoch,
-    );
-    // The older one either reports 1 (ran first) or 2 (stale short-
-    // circuit after newer committed). Both are legal outcomes of
-    // serialization.
+    assert_eq!(older_res.applied_epoch, 1);
+    assert_eq!(newer_res.applied_epoch, 2);
+    let trusted = comms.trusted_peer_ids();
     assert!(
-        older_res.applied_epoch == 1 || older_res.applied_epoch == 2,
-        "older reconcile's applied_epoch must be 1 or 2: got {}",
-        older_res.applied_epoch,
+        !trusted.is_empty(),
+        "at least one reconcile must update canonical trust",
+    );
+    assert!(
+        trusted.is_subset(&BTreeSet::from([UUID_A.to_string(), UUID_B.to_string()])),
+        "canonical trust must contain only reconciled peers, got {trusted:?}",
     );
 }
 
-/// §6 #2 — a stale-epoch reconcile arriving after a newer one has
-/// committed short-circuits inside the critical section. Trust store
-/// is NOT touched for the stale reconcile's peer set; applied
-/// watermark does not regress.
-///
-/// Uses a sequential form because serialization is now strict —
-/// overlapping reconciles wait on the mutex, so the concurrency
-/// invariant reduces to the sequential one after ordering resolves.
+/// §6 #2 — lower-epoch reconciles still diff against canonical trust.
 #[tokio::test]
-async fn stale_reconcile_after_newer_commit_does_not_touch_trust_store() {
+async fn lower_epoch_reconcile_reads_canonical_store() {
     let comms = Arc::new(RecordingCommsRuntime::default());
     let reconciler = CommsTrustReconciler::new(comms.clone());
 
@@ -181,43 +205,38 @@ async fn stale_reconcile_after_newer_commit_does_not_touch_trust_store() {
     assert_eq!(comms.add_count.load(Ordering::SeqCst), 1);
     assert_eq!(comms.remove_count.load(Ordering::SeqCst), 0);
 
-    // Stale arrives at epoch=3 with a different set {B}. Expected:
-    // empty report, applied_epoch stays at 5, no trust-store calls.
-    let stale = reconciler
+    // Lower epoch arrives with a different set {B}. Expected: canonical diff
+    // removes A and adds B; no helper-local watermark short-circuits it.
+    let lower = reconciler
         .reconcile(3, BTreeSet::from([endpoint("B", UUID_B)]))
         .await
-        .expect("stale reconcile accepted as no-op");
-    assert!(stale.added.is_empty(), "stale added must be empty");
-    assert!(stale.removed.is_empty(), "stale removed must be empty");
-    assert_eq!(
-        stale.applied_epoch, 5,
-        "stale report must reflect the newer watermark",
-    );
+        .expect("lower-epoch reconcile");
+    assert_eq!(lower.applied_epoch, 3);
+    assert_eq!(lower.added, vec![endpoint("B", UUID_B)]);
+    assert_eq!(lower.removed, vec![endpoint("A", UUID_A)]);
 
-    // Trust store was not touched by the stale reconcile.
     assert_eq!(
         comms.add_count.load(Ordering::SeqCst),
-        1,
-        "stale reconcile must not leak add_trusted_peer calls",
+        2,
+        "lower-epoch reconcile adds peer B from canonical diff",
     );
     assert_eq!(
         comms.remove_count.load(Ordering::SeqCst),
-        0,
-        "stale reconcile must not leak remove_trusted_peer calls",
+        1,
+        "lower-epoch reconcile removes peer A from canonical diff",
     );
-    let added_peer_ids: Vec<String> = comms
+    let added_peer_ids: BTreeSet<String> = comms
         .add_calls()
         .into_iter()
         .map(|d| d.peer_id.to_string())
         .collect();
     assert_eq!(
         added_peer_ids,
-        vec![UUID_A.to_string()],
-        "only the newer reconcile's peer A must be in the trust store",
+        BTreeSet::from([UUID_A.to_string(), UUID_B.to_string()]),
+        "both successful adds should be recorded",
     );
-
-    // Applied view reflects only the newer reconcile.
-    let (applied_epoch, applied_peers) = reconciler.applied_snapshot().await;
-    assert_eq!(applied_epoch, 5);
-    assert_eq!(applied_peers, BTreeSet::from([endpoint("A", UUID_A)]));
+    assert_eq!(
+        comms.trusted_peer_ids(),
+        BTreeSet::from([UUID_B.to_string()])
+    );
 }

--- a/meerkat/src/surface/runtime_backed.rs
+++ b/meerkat/src/surface/runtime_backed.rs
@@ -329,6 +329,15 @@ mod tests {
         OpenAiRealtimeAttachmentOrchestrator, RealtimeAttachmentToolDispatchHost,
     };
     use meerkat_runtime::completion::CompletionOutcome;
+    #[cfg(all(
+        feature = "openai",
+        feature = "openai-realtime",
+        not(target_arch = "wasm32")
+    ))]
+    use meerkat_runtime::{
+        HydratedSessionLlmState, ResolvedSessionLlmReconfigure, SessionLlmCapabilitySurface,
+        SessionLlmCapabilitySurfaceStatus, SessionLlmReconfigureHost, SessionLlmReconfigureRequest,
+    };
     use meerkat_runtime::{Input, PromptInput, RuntimeState};
     use tempfile::TempDir;
     #[cfg(all(
@@ -967,6 +976,117 @@ mod tests {
         feature = "openai-realtime",
         not(target_arch = "wasm32")
     ))]
+    struct RuntimeBackedRealtimeTestReconfigureHost {
+        identity: meerkat_core::SessionLlmIdentity,
+        capability_surface: SessionLlmCapabilitySurface,
+    }
+
+    #[cfg(all(
+        feature = "openai",
+        feature = "openai-realtime",
+        not(target_arch = "wasm32")
+    ))]
+    #[async_trait]
+    impl SessionLlmReconfigureHost for RuntimeBackedRealtimeTestReconfigureHost {
+        async fn hydrate_session_llm_state(
+            &self,
+            _session_id: &SessionId,
+        ) -> Result<HydratedSessionLlmState, RuntimeDriverError> {
+            Ok(HydratedSessionLlmState {
+                current_identity: self.identity.clone(),
+                current_visibility_state: Default::default(),
+                current_capability_surface: Some(self.capability_surface.clone()),
+                capability_surface_status: SessionLlmCapabilitySurfaceStatus::Resolved,
+                base_tool_names: Default::default(),
+            })
+        }
+
+        async fn resolve_target_session_llm_identity(
+            &self,
+            _request: &SessionLlmReconfigureRequest,
+            _current_identity: &meerkat_core::SessionLlmIdentity,
+        ) -> Result<ResolvedSessionLlmReconfigure, RuntimeDriverError> {
+            Ok(ResolvedSessionLlmReconfigure {
+                target_identity: self.identity.clone(),
+                target_capability_surface: self.capability_surface.clone(),
+            })
+        }
+
+        async fn apply_live_session_llm_identity(
+            &self,
+            _session_id: &SessionId,
+            _identity: &meerkat_core::SessionLlmIdentity,
+        ) -> Result<(), RuntimeDriverError> {
+            Ok(())
+        }
+
+        async fn apply_live_session_tool_visibility_state(
+            &self,
+            _session_id: &SessionId,
+            _visibility_state: Option<meerkat_core::SessionToolVisibilityState>,
+        ) -> Result<(), RuntimeDriverError> {
+            Ok(())
+        }
+
+        async fn persist_live_session(
+            &self,
+            _session_id: &SessionId,
+        ) -> Result<(), RuntimeDriverError> {
+            Ok(())
+        }
+
+        async fn discard_live_session(
+            &self,
+            _session_id: &SessionId,
+        ) -> Result<(), RuntimeDriverError> {
+            Ok(())
+        }
+    }
+
+    #[cfg(all(
+        feature = "openai",
+        feature = "openai-realtime",
+        not(target_arch = "wasm32")
+    ))]
+    fn realtime_test_capability_surface() -> SessionLlmCapabilitySurface {
+        SessionLlmCapabilitySurface {
+            supports_temperature: true,
+            supports_thinking: false,
+            supports_reasoning: false,
+            inline_video: false,
+            vision: false,
+            image_tool_results: false,
+            supports_web_search: false,
+            realtime: true,
+            call_timeout_secs: None,
+        }
+    }
+
+    #[cfg(all(
+        feature = "openai",
+        feature = "openai-realtime",
+        not(target_arch = "wasm32")
+    ))]
+    fn install_realtime_test_reconfigure_host(adapter: &Arc<MeerkatMachine>) {
+        adapter.set_session_llm_reconfigure_host(Arc::new(
+            RuntimeBackedRealtimeTestReconfigureHost {
+                identity: meerkat_core::SessionLlmIdentity {
+                    model: "gpt-realtime".to_string(),
+                    provider: meerkat_core::Provider::OpenAI,
+                    self_hosted_server_id: None,
+                    provider_params: None,
+                    connection_ref: None,
+                },
+                capability_surface: realtime_test_capability_surface(),
+            },
+        ));
+    }
+
+    #[cfg(all(
+        feature = "openai",
+        feature = "openai-realtime",
+        not(target_arch = "wasm32")
+    ))]
     #[async_trait]
     impl RealtimeAttachmentToolDispatchHost for RuntimeBackedRealtimeAttachmentToolDispatchHost {
         async fn dispatch_external_tool_call(
@@ -995,11 +1115,14 @@ mod tests {
     async fn runtime_backed_openai_live_orchestrator_routes_tool_calls_through_service_host() {
         let temp = tempfile::tempdir().expect("tempdir");
         let (service, adapter) = build_test_service(&temp).await;
+        install_realtime_test_reconfigure_host(&adapter);
+        let mut request = make_request(SessionBuildOptions::default());
+        request.model = "gpt-realtime".to_string();
         let result = Box::pin(materialize_session(
             &service,
             &adapter,
             Session::new(),
-            make_request(SessionBuildOptions::default()),
+            request,
             {
                 let service = Arc::clone(&service);
                 let adapter = Arc::clone(&adapter);
@@ -1046,7 +1169,7 @@ mod tests {
             OpenAiLiveCallTarget::new("call_runtime_backed").expect("call target should succeed");
 
         orchestrator
-            .attach(&session_id, &target)
+            .ensure_attached_for_capable_session(&session_id, &target)
             .await
             .expect("attach should succeed");
 


### PR DESCRIPTION
## Summary

Implements PR 4: Mob/Comms/Realtime Authority.

- Moves mob spawn, kickoff cleanup, external wiring, and member lifecycle projections behind MobMachine-owned typed inputs/state reads.
- Makes comms drain and trust reconciliation honor canonical authority before mutating shell state.
- Converts the mob/runtime WorkOrigin seam to carry the typed enum instead of string slugs.
- Retires caller-driven realtime attach/detach paths from RPC/OpenAI surfaces in favor of capability-driven MeerkatMachine attachment authority.
- Removes the realtime attachment orchestrator from the `meerkat-client` compatibility re-export.

## Scope Expansion

No scope expansion beyond PR 4's declared ownership. The follow-up CI fix stays within an already-touched file, `meerkat/src/surface/runtime_backed.rs`, and only wires the test fixture's `SessionLlmReconfigureHost` required by the new capability-driven realtime attach path.

## Per-PR Merge Gate

PR 4 rows are covered in the final tree:

- Rows 12/33: spawn DSL admission now happens before overlay/event/provision/trust/roster side effects, with rollback for post-admission projection failures.
- Row 78: kickoff cleanup routes through `KickoffClear` instead of direct `dsl_authority.state` mutation.
- Row 32: external peer wire/unwire is gated through `WireMembers` / `UnwireMembers` and compensates trust/event failures.
- Row 13: member status materialization reads MobMachine projections via the actor command channel.
- Rows 11/31: drain slot mutation and trust reconciliation read/gate against canonical runtime authority.
- Rows 50/66: websocket/OpenAI attachment lifecycle is capability-driven; public caller-driven attach/detach seams are removed or internalized.
- Row 79: `WorkOrigin` crosses the mob seam as typed opaque data.

## Downstream Propagation Audit

- `meerkat-client` no longer re-exports `OpenAiRealtimeAttachmentOrchestrator`; downstream callers should use session/runtime capability-driven realtime attachment rather than orchestrator-level attach/detach.
- Production RPC runtime construction already installs `SessionLlmReconfigureHost`; the only missing wiring found was the runtime-backed OpenAI realtime test fixture, now fixed.
- `ensure_attached_for_capable_session` call sites were audited: current non-test production entry points flow through runtime/RPC setup that owns host installation.

## Validation

- `cargo fmt --check`
- `git diff --check`
- `./scripts/repo-cargo check -p meerkat-runtime`
- `./scripts/repo-cargo check -p meerkat-mob`
- `./scripts/repo-cargo check -p meerkat-rpc`
- `./scripts/repo-cargo check -p meerkat-openai`
- `./scripts/repo-cargo check -p meerkat-client`
- `cargo clippy -p meerkat-runtime --all-targets -- -D warnings`
- `cargo clippy -p meerkat-mob --all-targets -- -D warnings`
- `cargo test -p meerkat --features "jsonl-store session-store openai-realtime" runtime_backed_openai_live_orchestrator_routes_tool_calls_through_service_host --lib`
- `cargo nextest run -p meerkat --features "jsonl-store session-store openai-realtime"`
- `./scripts/repo-cargo test -p meerkat-runtime comms_trust_reconcile --lib`
- `./scripts/repo-cargo test -p meerkat-runtime meerkat_machine::composition --lib`
- `./scripts/repo-cargo test -p meerkat-runtime comms_drain --lib`
- `./scripts/repo-cargo test -p meerkat-runtime --test trust_reconcile_add_failure`
- `./scripts/repo-cargo test -p meerkat-runtime --test trust_reconcile_concurrency`
- `./scripts/repo-cargo test -p meerkat-mob runtime::composition --lib`
- `./scripts/repo-cargo test -p meerkat-mob mob_member_lifecycle_authority --lib`
- `./scripts/repo-cargo test -p meerkat-rpc realtime_ws --lib`
- `./scripts/repo-cargo test -p meerkat-openai --lib`
- Pre-push hooks: secrets, whitespace, format, changed-crate clippy, machine codegen/verify, generated-header audit, ResponseStatus bridge check, workspace deterministic gate.
