### PR TITLE
PR 3: Runtime/session authority

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -285,7 +285,9 @@ jobs:
           prefix-key: integration-fast
 
       - name: Install wasm-pack
-        run: curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh
+        uses: taiki-e/install-action@v2
+        with:
+          tool: wasm-pack
 
       - name: Install nextest
         uses: taiki-e/install-action@nextest
@@ -333,7 +335,9 @@ jobs:
           prefix-key: e2e-system
 
       - name: Install wasm-pack
-        run: curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh
+        uses: taiki-e/install-action@v2
+        with:
+          tool: wasm-pack
 
       - name: Install nextest
         uses: taiki-e/install-action@nextest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -345,6 +345,102 @@ jobs:
       - name: Run e2e-system lane
         run: cargo e2e-system
 
+  e2e-live:
+    name: E2E live lane
+    runs-on: ubuntu-latest
+    env:
+      ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+      RKAT_ANTHROPIC_API_KEY: ${{ secrets.RKAT_ANTHROPIC_API_KEY }}
+      OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+      RKAT_OPENAI_API_KEY: ${{ secrets.RKAT_OPENAI_API_KEY }}
+      GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
+      RKAT_GEMINI_API_KEY: ${{ secrets.RKAT_GEMINI_API_KEY }}
+      GOOGLE_API_KEY: ${{ secrets.GOOGLE_API_KEY }}
+      MEERKAT_CLEAN_E2E_SCENARIO_TARGETS: "1"
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Add wasm32 target
+        run: rustup target add wasm32-unknown-unknown
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.14"
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+
+      - name: Cache cargo registry
+        uses: Swatinem/rust-cache@v2
+        with:
+          prefix-key: e2e-live
+
+      - name: Install wasm-pack
+        uses: taiki-e/install-action@v2
+        with:
+          tool: wasm-pack
+
+      - name: Install nextest
+        uses: taiki-e/install-action@nextest
+
+      - name: Run e2e-live lane
+        run: cargo e2e-live
+
+  e2e-smoke:
+    name: E2E smoke lane
+    runs-on: ubuntu-latest
+    env:
+      ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+      RKAT_ANTHROPIC_API_KEY: ${{ secrets.RKAT_ANTHROPIC_API_KEY }}
+      OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+      RKAT_OPENAI_API_KEY: ${{ secrets.RKAT_OPENAI_API_KEY }}
+      GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
+      RKAT_GEMINI_API_KEY: ${{ secrets.RKAT_GEMINI_API_KEY }}
+      GOOGLE_API_KEY: ${{ secrets.GOOGLE_API_KEY }}
+      MEERKAT_CLEAN_E2E_SCENARIO_TARGETS: "1"
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Add wasm32 target
+        run: rustup target add wasm32-unknown-unknown
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.14"
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+
+      - name: Cache cargo registry
+        uses: Swatinem/rust-cache@v2
+        with:
+          prefix-key: e2e-smoke
+
+      - name: Install wasm-pack
+        uses: taiki-e/install-action@v2
+        with:
+          tool: wasm-pack
+
+      - name: Install nextest
+        uses: taiki-e/install-action@nextest
+
+      - name: Run e2e-smoke lane
+        run: cargo e2e-smoke
+
   test-minimal:
     name: Minimal feature builds
     runs-on: ubuntu-latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -475,7 +475,9 @@ jobs:
           fi
 
       - name: Install wasm-pack
-        run: curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh
+        uses: taiki-e/install-action@v2
+        with:
+          tool: wasm-pack
 
       - name: Add wasm32 target
         run: rustup target add wasm32-unknown-unknown

--- a/examples/024-host-mode-event-mesh-rs/main.rs
+++ b/examples/024-host-mode-event-mesh-rs/main.rs
@@ -153,6 +153,8 @@ Production surfaces (CLI, REST, RPC, MCP) use the runtime-backed path.
                 event_tx: Some(event_tx),
                 skill_references: None,
                 flow_tool_overlay: None,
+                turn_metadata: None,
+                execution_kind: None,
             },
         )
         .await?;
@@ -189,6 +191,8 @@ Production surfaces (CLI, REST, RPC, MCP) use the runtime-backed path.
                 event_tx: Some(event_tx),
                 skill_references: None,
                 flow_tool_overlay: None,
+                turn_metadata: None,
+                execution_kind: None,
             },
         )
         .await?;

--- a/examples/034-codemob-mcp/src/tools/consult.rs
+++ b/examples/034-codemob-mcp/src/tools/consult.rs
@@ -80,6 +80,7 @@ pub async fn handle(
             skill_references: None,
             flow_tool_overlay: None,
             additional_instructions: None,
+            turn_metadata: None,
             execution_kind: None,
         };
 

--- a/examples/035-mdm-tux-rs/src/bin/target.rs
+++ b/examples/035-mdm-tux-rs/src/bin/target.rs
@@ -1126,6 +1126,7 @@ impl CoreExecutor for TargetCoreExecutor {
             additional_instructions: primitive
                 .turn_metadata()
                 .and_then(|meta| meta.additional_instructions.clone()),
+            turn_metadata: primitive.turn_metadata().cloned(),
             execution_kind: primitive.turn_metadata().and_then(|m| m.execution_kind),
         };
 
@@ -2577,6 +2578,7 @@ mod tests {
                     skill_references: None,
                     flow_tool_overlay: None,
                     additional_instructions: None,
+                    turn_metadata: None,
                     execution_kind: None,
                 },
             )

--- a/meerkat-cli/src/main.rs
+++ b/meerkat-cli/src/main.rs
@@ -4535,12 +4535,8 @@ impl meerkat_core::lifecycle::CoreExecutor for CliRuntimeExecutor {
         meerkat_core::lifecycle::core_executor::CoreApplyOutput,
         meerkat_core::lifecycle::core_executor::CoreExecutorError,
     > {
-        // Post-wave-a: `StartTurnRequest.additional_instructions` /
-        // `execution_kind` were collapsed into the typed `RuntimeTurnMetadata`
-        // seam on `PromptInput.turn_metadata`; they no longer live on the
-        // session-service request literal. The primitive's metadata is still
-        // consulted for `skill_references` + `flow_tool_overlay`, which remain
-        // part of the request surface.
+        // Forward the primitive metadata carrier as the single runtime-authored
+        // source for per-turn policy.
         let turn_req = StartTurnRequest {
             prompt: primitive.extract_content_input(),
             system_prompt: None,
@@ -4553,6 +4549,10 @@ impl meerkat_core::lifecycle::CoreExecutor for CliRuntimeExecutor {
             flow_tool_overlay: primitive
                 .turn_metadata()
                 .and_then(|meta| meta.flow_tool_overlay.clone()),
+            turn_metadata: primitive.turn_metadata().cloned(),
+            execution_kind: primitive
+                .turn_metadata()
+                .and_then(|meta| meta.execution_kind),
         };
 
         // Persistent path: use apply_runtime_turn_with_result for real receipt + snapshot.

--- a/meerkat-contracts/tests/regression_wire_types.rs
+++ b/meerkat-contracts/tests/regression_wire_types.rs
@@ -16,8 +16,8 @@ use meerkat_contracts::{
     WireSessionHistory, WireSessionInfo, WireSessionMessage, WireSessionSummary, WireUsage,
 };
 use meerkat_core::{
-    AgentEvent, BudgetType, HookPatch, HookPoint, HookReasonCode, RunResult, SessionId, StopReason,
-    ToolConfigChangeOperation, ToolConfigChangedPayload, Usage,
+    AgentErrorClass, AgentEvent, BudgetType, ContentInput, HookPatch, HookPoint, HookReasonCode,
+    RunResult, SessionId, StopReason, ToolConfigChangeOperation, ToolConfigChangedPayload, Usage,
 };
 
 // ---------------------------------------------------------------------------
@@ -335,7 +335,7 @@ fn agent_event_all_variants_roundtrip() {
     let direct_variants: Vec<AgentEvent> = vec![
         AgentEvent::RunStarted {
             session_id: session_id.clone(),
-            prompt: "hello".to_string(),
+            prompt: ContentInput::Text("hello".to_string()),
         },
         AgentEvent::RunCompleted {
             session_id: session_id.clone(),
@@ -349,6 +349,7 @@ fn agent_event_all_variants_roundtrip() {
         },
         AgentEvent::RunFailed {
             session_id,
+            error_class: AgentErrorClass::Internal,
             error: "boom".to_string(),
         },
         AgentEvent::HookStarted {
@@ -558,7 +559,7 @@ fn documented_event_catalog_covers_core_agent_event_discriminators() {
     let events = vec![
         AgentEvent::RunStarted {
             session_id: SessionId::new(),
-            prompt: "hello".to_string(),
+            prompt: ContentInput::Text("hello".to_string()),
         },
         AgentEvent::RunCompleted {
             session_id: SessionId::new(),
@@ -567,6 +568,7 @@ fn documented_event_catalog_covers_core_agent_event_discriminators() {
         },
         AgentEvent::RunFailed {
             session_id: SessionId::new(),
+            error_class: AgentErrorClass::Internal,
             error: "nope".to_string(),
         },
         AgentEvent::HookStarted {

--- a/meerkat-core/src/agent.rs
+++ b/meerkat-core/src/agent.rs
@@ -817,7 +817,6 @@ where
     session: Session,
     budget: Budget,
     retry_policy: RetryPolicy,
-    state: LoopState,
     depth: u32,
     pub(super) comms_runtime: Option<Arc<dyn CommsRuntime>>,
     pub(super) hook_engine: Option<Arc<dyn HookEngine>>,

--- a/meerkat-core/src/agent/builder.rs
+++ b/meerkat-core/src/agent/builder.rs
@@ -9,7 +9,6 @@ use crate::ops::ConcurrencyLimits;
 use crate::prompt::SystemPromptConfig;
 use crate::retry::RetryPolicy;
 use crate::session::{SESSION_TOOL_VISIBILITY_STATE_KEY, Session, SessionToolVisibilityState};
-use crate::state::LoopState;
 #[cfg(target_arch = "wasm32")]
 use crate::tokio;
 use crate::tool_catalog::{ToolCatalogDeferredEligibility, ToolCatalogMode, ToolPlaneClass};
@@ -294,7 +293,6 @@ impl AgentBuilder {
             session,
             budget,
             retry_policy: self.retry_policy,
-            state: LoopState::CallingLlm,
             depth: self.depth,
             comms_runtime: self.comms_runtime,
             hook_engine: self.hook_engine,

--- a/meerkat-core/src/agent/runner.rs
+++ b/meerkat-core/src/agent/runner.rs
@@ -412,8 +412,10 @@ where
     }
 
     /// Get the current state
-    pub fn state(&self) -> &LoopState {
-        &self.state
+    pub fn state(&self) -> LoopState {
+        self.execution_snapshot()
+            .map(|snapshot| snapshot.loop_state)
+            .unwrap_or(LoopState::CallingLlm)
     }
 
     /// Snapshot the agent's live execution state for diagnostics and mapping.
@@ -847,10 +849,6 @@ where
         if self.runtime_execution_kind.is_none() {
             self.runtime_execution_kind = Some(crate::lifecycle::RuntimeExecutionKind::ContentTurn);
         }
-        self.state = self
-            .turn_phase()
-            .map(crate::turn_execution_authority::TurnPhase::to_loop_state)
-            .unwrap_or(LoopState::CallingLlm);
         self.extraction_result = None;
         self.extraction_last_error = None;
         self.extraction_schema_warnings = None;
@@ -949,10 +947,6 @@ where
             self.runtime_execution_kind =
                 Some(crate::lifecycle::RuntimeExecutionKind::ResumePending);
         }
-        self.state = self
-            .turn_phase()
-            .map(crate::turn_execution_authority::TurnPhase::to_loop_state)
-            .unwrap_or(LoopState::CallingLlm);
         self.extraction_result = None;
         self.extraction_last_error = None;
         self.extraction_schema_warnings = None;

--- a/meerkat-core/src/agent/runner.rs
+++ b/meerkat-core/src/agent/runner.rs
@@ -681,7 +681,7 @@ where
 
     async fn emit_run_started_event(
         &self,
-        prompt: &str,
+        prompt: ContentInput,
         event_tx: Option<&mpsc::Sender<AgentEvent>>,
     ) {
         let _ = crate::event_tap::tap_emit(
@@ -689,7 +689,7 @@ where
             event_tx,
             AgentEvent::RunStarted {
                 session_id: self.session.id().clone(),
-                prompt: prompt.to_string(),
+                prompt,
             },
         )
         .await;
@@ -705,6 +705,7 @@ where
             event_tx,
             AgentEvent::RunFailed {
                 session_id: self.session.id().clone(),
+                error_class: crate::event::AgentErrorClass::from(error),
                 error: error.to_string(),
             },
         )
@@ -843,10 +844,13 @@ where
         // attaches pair `runtime_execution_kind` with every live-run path,
         // and `runtime_turn_authority_snapshot` (state.rs) panics on an
         // unclassified handle. See #32 W2 / PR #299 follow-up.
-        self.state = LoopState::CallingLlm;
         if self.runtime_execution_kind.is_none() {
             self.runtime_execution_kind = Some(crate::lifecycle::RuntimeExecutionKind::ContentTurn);
         }
+        self.state = self
+            .turn_phase()
+            .map(crate::turn_execution_authority::TurnPhase::to_loop_state)
+            .unwrap_or(LoopState::CallingLlm);
         self.extraction_result = None;
         self.extraction_last_error = None;
         self.extraction_schema_warnings = None;
@@ -871,6 +875,7 @@ where
 
         // Hooks/events always see the text projection.
         let run_prompt = user_input.text_content();
+        let run_prompt_input = user_input.clone();
 
         // Add user message — preserve image blocks when present.
         let user_message = if user_input.has_non_text_content() {
@@ -880,7 +885,7 @@ where
         };
         self.session.push(Message::User(user_message));
 
-        self.emit_run_started_event(&run_prompt, event_tx.as_ref())
+        self.emit_run_started_event(run_prompt_input, event_tx.as_ref())
             .await;
 
         if let Err(err) = self.run_started_hooks(&run_prompt, event_tx.as_ref()).await {
@@ -940,16 +945,19 @@ where
         // that resumes pending work at a boundary. Default the classification
         // to `ResumePending` unless the caller staged an explicit kind via
         // `set_runtime_execution_kind`. See #32 W2 / PR #299 follow-up.
-        self.state = LoopState::CallingLlm;
         if self.runtime_execution_kind.is_none() {
             self.runtime_execution_kind =
                 Some(crate::lifecycle::RuntimeExecutionKind::ResumePending);
         }
+        self.state = self
+            .turn_phase()
+            .map(crate::turn_execution_authority::TurnPhase::to_loop_state)
+            .unwrap_or(LoopState::CallingLlm);
         self.extraction_result = None;
         self.extraction_last_error = None;
         self.extraction_schema_warnings = None;
 
-        self.emit_run_started_event(&prompt, event_tx.as_ref())
+        self.emit_run_started_event(ContentInput::Text(prompt.clone()), event_tx.as_ref())
             .await;
 
         if let Err(err) = self.run_started_hooks(&prompt, event_tx.as_ref()).await {

--- a/meerkat-core/src/agent/state.rs
+++ b/meerkat-core/src/agent/state.rs
@@ -902,9 +902,7 @@ where
                 return self.build_result(turn_count, tool_call_count).await;
             }
 
-            let loop_state = self.turn_phase()?.to_loop_state();
-            self.state = loop_state.clone();
-            match loop_state {
+            match self.turn_phase()?.to_loop_state() {
                 LoopState::CallingLlm => {
                     // 0. Auth lease refresh loop (Phase 1.5-rev).
                     //    The canonical auth-state owner is the MeerkatMachine
@@ -2192,8 +2190,6 @@ where
 
         let outcome = self.turn_terminal_outcome()?;
         let classification = classify_terminal(&outcome);
-        self.state = self.turn_phase()?.to_loop_state();
-
         match classification {
             Some(SurfaceResultClass::HardFailure) => {
                 // Consume the pending diagnostic once — prefer the originating
@@ -4420,7 +4416,6 @@ mod tests {
         // must be routed to BudgetExhausted -> Success, not raw Err.
         let mut agent = build_agent(Arc::new(HighUsageLlmClient)).await;
         agent.config.max_turns = Some(10);
-        agent.state = LoopState::CallingLlm;
         agent.budget = Budget::new(BudgetLimits {
             max_tokens: Some(100),
             max_duration: None,
@@ -4435,7 +4430,7 @@ mod tests {
              not escape as raw AgentError: {:?}",
             result.err()
         );
-        assert_eq!(agent.state, LoopState::Completed);
+        assert_eq!(agent.state(), LoopState::Completed);
     }
 
     /// Regression test: tool-call budget exhaustion detected anywhere in the
@@ -4444,7 +4439,6 @@ mod tests {
     async fn tool_call_budget_exhausted_routes_through_authority() {
         let mut agent = build_agent(Arc::new(StaticLlmClient)).await;
         agent.config.max_turns = Some(10);
-        agent.state = LoopState::CallingLlm;
         agent.budget = Budget::new(BudgetLimits {
             max_tokens: None,
             max_duration: None,
@@ -4458,7 +4452,7 @@ mod tests {
              not escape as raw AgentError: {:?}",
             result.err()
         );
-        assert_eq!(agent.state, LoopState::Completed);
+        assert_eq!(agent.state(), LoopState::Completed);
     }
 
     // -- Retry delay hint tests (PR #156 port) --

--- a/meerkat-core/src/agent/state.rs
+++ b/meerkat-core/src/agent/state.rs
@@ -46,6 +46,17 @@ enum CallTimeoutSource {
     TurnBudget,
 }
 
+struct LlmRetryRequest<'a> {
+    run_id: &'a RunId,
+    turn_count: u32,
+    event_tx: &'a Option<mpsc::Sender<AgentEvent>>,
+    messages: &'a [Message],
+    tools: &'a [Arc<ToolDef>],
+    max_tokens: u32,
+    temperature: Option<f32>,
+    provider_params: Option<&'a Value>,
+}
+
 fn turn_input_run_id(input: &TurnExecutionInput) -> Option<RunId> {
     match input {
         TurnExecutionInput::StartConversationRun { run_id }
@@ -184,7 +195,7 @@ where
         Ok(self.runtime_turn_authority_snapshot()?.active_run_id)
     }
 
-    fn turn_phase(&self) -> Result<TurnPhase, AgentError> {
+    pub(super) fn turn_phase(&self) -> Result<TurnPhase, AgentError> {
         Ok(self.runtime_turn_authority_snapshot()?.turn_phase)
     }
 
@@ -271,13 +282,20 @@ where
     /// - per-call timeout from override/profile, wrapped with remaining turn budget
     /// - typed timeout-origin selection before await
     async fn call_llm_with_retry(
-        &self,
-        messages: &[Message],
-        tools: &[Arc<ToolDef>],
-        max_tokens: u32,
-        temperature: Option<f32>,
-        provider_params: Option<&Value>,
+        &mut self,
+        request: LlmRetryRequest<'_>,
     ) -> Result<LlmStreamResult, AgentError> {
+        let LlmRetryRequest {
+            run_id,
+            turn_count,
+            event_tx,
+            messages,
+            tools,
+            max_tokens,
+            temperature,
+            provider_params,
+        } = request;
+
         let hydrated_messages = if let Some(blob_store) = self.blob_store.as_ref() {
             let mut hydrated = messages.to_vec();
             hydrate_messages_for_execution(
@@ -403,9 +421,31 @@ where
                             capped.as_millis(),
                             e
                         );
+                        let recover =
+                            self.apply_turn_input(TurnExecutionInput::RecoverableFailure {
+                                run_id: run_id.clone(),
+                            })?;
+                        self.execute_turn_effects(&recover, turn_count, event_tx)
+                            .await;
+                        let _ = crate::event_tap::tap_emit(
+                            &self.event_tap,
+                            event_tx.as_ref(),
+                            AgentEvent::Retrying {
+                                attempt: attempt + 1,
+                                max_attempts: self.retry_policy.max_retries,
+                                error: e.to_string(),
+                                delay_ms: capped.as_millis() as u64,
+                            },
+                        )
+                        .await;
                         attempt += 1;
                         tokio::time::sleep(capped).await;
                         self.budget.check()?;
+                        let retry = self.apply_turn_input(TurnExecutionInput::RetryRequested {
+                            run_id: run_id.clone(),
+                        })?;
+                        self.execute_turn_effects(&retry, turn_count, event_tx)
+                            .await;
                         continue;
                     }
                     return Err(e);
@@ -862,7 +902,9 @@ where
                 return self.build_result(turn_count, tool_call_count).await;
             }
 
-            match self.state {
+            let loop_state = self.turn_phase()?.to_loop_state();
+            self.state = loop_state.clone();
+            match loop_state {
                 LoopState::CallingLlm => {
                     // 0. Auth lease refresh loop (Phase 1.5-rev).
                     //    The canonical auth-state owner is the MeerkatMachine
@@ -904,14 +946,14 @@ where
                     self.session.messages_mut_internal().retain(|message| {
                         !is_synthetic_notice(message, SystemNoticeKind::McpPending)
                     });
-                    // Prefer the DSL-authoritative handshake state (Phase 5G /
-                    // T5g); fall back to the shell's `ext.pending` projection
-                    // when no runtime handle is wired (standalone, tests).
-                    let pending_servers: Vec<String> =
-                        match self.mcp_server_lifecycle_handle.as_deref() {
-                            Some(handle) => handle.pending_server_ids().into_iter().collect(),
-                            None => ext.pending.clone(),
-                        };
+                    // The MCP lifecycle handle is the only authoritative read
+                    // side for pending server notices. Without it, core has no
+                    // typed owner to project from.
+                    let pending_servers: Vec<String> = self
+                        .mcp_server_lifecycle_handle
+                        .as_deref()
+                        .map(|handle| handle.pending_server_ids().into_iter().collect())
+                        .unwrap_or_default();
                     if !pending_servers.is_empty() {
                         self.session.push(synthetic_notice_message(
                             SystemNoticeKind::McpPending,
@@ -1355,13 +1397,16 @@ where
                     let request_messages =
                         self.llm_messages_with_runtime_system_context(&boundary_system_context);
                     let result = match self
-                        .call_llm_with_retry(
-                            &request_messages,
-                            call_tool_defs,
-                            effective_max_tokens,
-                            effective_temperature,
-                            effective_provider_params.as_ref(),
-                        )
+                        .call_llm_with_retry(LlmRetryRequest {
+                            run_id: &run_id,
+                            turn_count,
+                            event_tx: &event_tx,
+                            messages: &request_messages,
+                            tools: call_tool_defs,
+                            max_tokens: effective_max_tokens,
+                            temperature: effective_temperature,
+                            provider_params: effective_provider_params.as_ref(),
+                        })
                         .await
                     {
                         Ok(r) => r,
@@ -2147,9 +2192,7 @@ where
 
         let outcome = self.turn_terminal_outcome()?;
         let classification = classify_terminal(&outcome);
-        if classification.is_some() {
-            self.state = LoopState::Completed;
-        }
+        self.state = self.turn_phase()?.to_loop_state();
 
         match classification {
             Some(SurfaceResultClass::HardFailure) => {

--- a/meerkat-core/src/agent/test_turn_state_handle.rs
+++ b/meerkat-core/src/agent/test_turn_state_handle.rs
@@ -481,10 +481,10 @@ fn invalid(from: TurnPhase, input: &TurnExecutionInput) -> DslTransitionError {
 /// so the caller can drive a terminal transition (BudgetExhausted,
 /// TurnLimitReached, etc.) from the expected phase.
 ///
-/// Tests that directly invoke `agent.run_loop(None)` with pre-staged
-/// `agent.state = LoopState::CallingLlm` never call `primitive_applied`,
-/// so the stub would otherwise panic on the first terminal-routing
-/// transition. This helper keeps the stub permissive for such tests.
+/// Tests that directly invoke `agent.run_loop(None)` without a surface-staged
+/// primitive never call `primitive_applied`, so the stub would otherwise panic
+/// on the first terminal-routing transition. This helper keeps the stub
+/// permissive for such tests.
 fn ensure_active_conversation_run(state: &mut LocalState) -> Result<(), DslTransitionError> {
     let is_terminal = matches!(
         state.phase,

--- a/meerkat-core/src/event.rs
+++ b/meerkat-core/src/event.rs
@@ -2,9 +2,10 @@
 //!
 //! These events form the streaming API for consumers.
 
+use crate::error::AgentError;
 use crate::hooks::{HookPatch, HookPatchEnvelope, HookPoint, HookReasonCode};
 use crate::time_compat::SystemTime;
-use crate::types::{SessionId, StopReason, Usage};
+use crate::types::{ContentInput, SessionId, StopReason, Usage};
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use std::cmp::Ordering;
@@ -19,6 +20,73 @@ pub struct EventEnvelope<T> {
     pub mob_id: Option<String>,
     pub timestamp_ms: u64,
     pub payload: T,
+}
+
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum AgentErrorClass {
+    Llm,
+    Store,
+    Tool,
+    Mcp,
+    SessionNotFound,
+    Budget,
+    MaxTokens,
+    ContentFiltered,
+    MaxTurns,
+    Cancelled,
+    InvalidState,
+    OperationNotFound,
+    DepthLimit,
+    ConcurrencyLimit,
+    Config,
+    Internal,
+    Build,
+    Auth,
+    CallbackPending,
+    StructuredOutput,
+    InvalidOutputSchema,
+    Hook,
+    Terminal,
+    NoPendingBoundary,
+}
+
+impl From<&AgentError> for AgentErrorClass {
+    fn from(error: &AgentError) -> Self {
+        match error {
+            AgentError::Llm { .. } => Self::Llm,
+            AgentError::StoreError(_) => Self::Store,
+            AgentError::ToolError(_) => Self::Tool,
+            AgentError::McpError(_) => Self::Mcp,
+            AgentError::SessionNotFound(_) => Self::SessionNotFound,
+            AgentError::TokenBudgetExceeded { .. }
+            | AgentError::TimeBudgetExceeded { .. }
+            | AgentError::ToolCallBudgetExceeded { .. } => Self::Budget,
+            AgentError::MaxTokensReached { .. } => Self::MaxTokens,
+            AgentError::ContentFiltered { .. } => Self::ContentFiltered,
+            AgentError::MaxTurnsReached { .. } => Self::MaxTurns,
+            AgentError::Cancelled => Self::Cancelled,
+            AgentError::InvalidStateTransition { .. } => Self::InvalidState,
+            AgentError::OperationNotFound(_) => Self::OperationNotFound,
+            AgentError::DepthLimitExceeded { .. } => Self::DepthLimit,
+            AgentError::ConcurrencyLimitExceeded => Self::ConcurrencyLimit,
+            AgentError::ConfigError(_) => Self::Config,
+            AgentError::InvalidToolAccess { .. } => Self::Tool,
+            AgentError::InternalError(_) => Self::Internal,
+            AgentError::BuildError(_) => Self::Build,
+            AgentError::AuthReauthRequired { .. } => Self::Auth,
+            AgentError::CallbackPending { .. } => Self::CallbackPending,
+            AgentError::StructuredOutputValidationFailed { .. } => Self::StructuredOutput,
+            AgentError::InvalidOutputSchema(_) => Self::InvalidOutputSchema,
+            AgentError::HookDenied { .. }
+            | AgentError::HookTimeout { .. }
+            | AgentError::HookExecutionFailed { .. }
+            | AgentError::HookConfigInvalid { .. } => Self::Hook,
+            AgentError::TerminalFailure { .. } => Self::Terminal,
+            AgentError::NoPendingBoundary => Self::NoPendingBoundary,
+        }
+    }
 }
 
 impl<T> EventEnvelope<T> {
@@ -246,7 +314,7 @@ pub enum AgentEvent {
     /// Agent run started
     RunStarted {
         session_id: SessionId,
-        prompt: String,
+        prompt: ContentInput,
     },
 
     /// Agent run completed successfully
@@ -259,6 +327,7 @@ pub enum AgentEvent {
     /// Agent run failed
     RunFailed {
         session_id: SessionId,
+        error_class: AgentErrorClass,
         error: String,
     },
 
@@ -702,7 +771,7 @@ mod tests {
         let events = vec![
             AgentEvent::RunStarted {
                 session_id: SessionId::new(),
-                prompt: "Hello".to_string(),
+                prompt: ContentInput::Text("Hello".to_string()),
             },
             AgentEvent::TextDelta {
                 delta: "chunk".to_string(),
@@ -746,6 +815,7 @@ mod tests {
             },
             AgentEvent::RunFailed {
                 session_id: SessionId::new(),
+                error_class: AgentErrorClass::Budget,
                 error: "Budget exceeded".to_string(),
             },
             AgentEvent::CompactionStarted {
@@ -817,7 +887,7 @@ mod tests {
         let events = vec![
             AgentEvent::RunStarted {
                 session_id: SessionId::new(),
-                prompt: "Hello".to_string(),
+                prompt: ContentInput::Text("Hello".to_string()),
             },
             AgentEvent::RunCompleted {
                 session_id: SessionId::new(),
@@ -826,6 +896,7 @@ mod tests {
             },
             AgentEvent::RunFailed {
                 session_id: SessionId::new(),
+                error_class: AgentErrorClass::Internal,
                 error: "failed".to_string(),
             },
             AgentEvent::HookStarted {

--- a/meerkat-core/src/lib.rs
+++ b/meerkat-core/src/lib.rs
@@ -120,10 +120,10 @@ pub use config_store::{
 };
 pub use error::{AgentError, ToolError};
 pub use event::{
-    AgentEvent, BudgetType, EventEnvelope, ExternalToolDelta, ExternalToolDeltaPhase,
-    ScopedAgentEvent, StreamScopeFrame, ToolConfigChangeOperation, ToolConfigChangedPayload,
-    VerboseEventConfig, agent_event_type, compare_event_envelopes, format_verbose_event,
-    format_verbose_event_with_config,
+    AgentErrorClass, AgentEvent, BudgetType, EventEnvelope, ExternalToolDelta,
+    ExternalToolDeltaPhase, ScopedAgentEvent, StreamScopeFrame, ToolConfigChangeOperation,
+    ToolConfigChangedPayload, VerboseEventConfig, agent_event_type, compare_event_envelopes,
+    format_verbose_event, format_verbose_event_with_config,
 };
 pub use event_injector::{EventInjector, EventInjectorError};
 pub use event_tap::{

--- a/meerkat-core/src/lifecycle/core_executor.rs
+++ b/meerkat-core/src/lifecycle/core_executor.rs
@@ -37,6 +37,8 @@ pub enum CoreExecutorError {
 pub enum CoreApplyTerminal {
     /// The run completed and produced a result.
     RunResult(RunResult),
+    /// A resume-pending request reached the session with no pending boundary.
+    NoPendingBoundary,
     /// The run committed a continuation boundary and is waiting for external
     /// tool results before it can continue.
     CallbackPending { tool_name: String, args: Value },

--- a/meerkat-core/src/runtime_epoch.rs
+++ b/meerkat-core/src/runtime_epoch.rs
@@ -140,9 +140,8 @@ pub struct EpochCursorSnapshot {
 
 /// Bundle of epoch-local runtime facts.
 ///
-/// Created by the runtime epoch owner ([`MeerkatMachine::prepare_bindings`]),
-/// consumed by the factory. The factory never creates competing registries
-/// when it receives this bundle.
+/// Created by the runtime epoch owner, consumed by the factory. The factory
+/// never creates competing registries when it receives this bundle.
 ///
 /// The `session_id` field acts as an identity witness: the factory validates
 /// that `bindings.session_id == session.id()` to catch cross-wired bindings.

--- a/meerkat-core/src/service/mod.rs
+++ b/meerkat-core/src/service/mod.rs
@@ -7,6 +7,8 @@ pub mod transport;
 
 use crate::event::AgentEvent;
 use crate::event::EventEnvelope;
+use crate::lifecycle::RuntimeExecutionKind;
+use crate::lifecycle::run_primitive::RuntimeTurnMetadata;
 use crate::session::SystemContextStageError;
 use crate::time_compat::SystemTime;
 #[cfg(target_arch = "wasm32")]
@@ -729,6 +731,18 @@ pub struct StartTurnRequest {
     pub skill_references: Option<Vec<crate::skills::SkillKey>>,
     /// Optional per-turn flow tool overlay (ephemeral, non-persistent).
     pub flow_tool_overlay: Option<TurnToolOverlay>,
+    /// Canonical runtime-authored metadata for this turn.
+    ///
+    /// Runtime-backed callers populate this once at the machine boundary and
+    /// the session layer derives per-turn policy from this typed carrier
+    /// instead of re-inferring or dropping fields.
+    pub turn_metadata: Option<RuntimeTurnMetadata>,
+    /// Runtime-authored execution intent for the session task.
+    ///
+    /// This is intentionally duplicated out of `turn_metadata` as the narrow
+    /// session dispatch key so non-runtime callers can remain explicit without
+    /// constructing a full metadata carrier.
+    pub execution_kind: Option<RuntimeExecutionKind>,
 }
 
 /// Request to append runtime system context to an existing session.

--- a/meerkat-machine-codegen/tests/runtime_alphabet_parity.rs
+++ b/meerkat-machine-codegen/tests/runtime_alphabet_parity.rs
@@ -61,7 +61,17 @@ fn meerkat_machine_inputs_equal_runtime_manifest_exactly() {
         .collect();
     let runtime_commands: BTreeSet<&str> = canonical_meerkat_machine_command_manifest()
         .into_iter()
-        .filter(|name| *name != "RuntimeRealtimeChannelStatus")
+        .filter(|name| {
+            !matches!(
+                *name,
+                // Diagnostic/status helper, not a DSL semantic input.
+                "RuntimeRealtimeChannelStatus"
+                    // Local resource preparation deliberately does not route
+                    // through DSL authority; authoritative binding remains
+                    // `PrepareBindings`.
+                    | "PrepareLocalSessionBindings"
+            )
+        })
         .collect();
 
     assert_runtime_manifest_matches_schema(

--- a/meerkat-machine-schema/src/catalog/dsl/meerkat_machine.rs
+++ b/meerkat-machine-schema/src/catalog/dsl/meerkat_machine.rs
@@ -1937,7 +1937,7 @@ machine! {
             guard {
                 self.lifecycle_phase == Phase::Idle || self.lifecycle_phase == Phase::Retired
             }
-            guard "runtime_is_bound" { self.active_runtime_id != None }
+            guard "session_registered" { self.session_id != None }
             update {
                 self.active_fence_token = None;
                 self.current_run_id = None;
@@ -1948,7 +1948,7 @@ machine! {
         transition RecycleFromAttached {
             on input Recycle
             guard { self.lifecycle_phase == Phase::Attached }
-            guard "runtime_is_bound" { self.active_runtime_id != None }
+            guard "session_registered" { self.session_id != None }
             update {
                 self.active_fence_token = None;
                 self.current_run_id = None;

--- a/meerkat-mcp-server/src/lib.rs
+++ b/meerkat-mcp-server/src/lib.rs
@@ -3064,6 +3064,8 @@ async fn handle_meerkat_resume(
 
             skill_references: skill_references.clone(),
             flow_tool_overlay: input.flow_tool_overlay.clone().map(Into::into),
+            turn_metadata: None,
+            execution_kind: None,
         };
         match state.service.start_turn(&session_id, turn_req).await {
             Ok(run_result) => Ok(run_result),

--- a/meerkat-mcp-server/src/runtime_ingress.rs
+++ b/meerkat-mcp-server/src/runtime_ingress.rs
@@ -520,6 +520,10 @@ async fn apply_runtime_turn(
         flow_tool_overlay: primitive
             .turn_metadata()
             .and_then(|meta| meta.flow_tool_overlay.clone()),
+        turn_metadata: primitive.turn_metadata().cloned(),
+        execution_kind: primitive
+            .turn_metadata()
+            .and_then(|meta| meta.execution_kind),
     };
 
     match context
@@ -555,6 +559,10 @@ async fn apply_runtime_turn(
                         flow_tool_overlay: primitive
                             .turn_metadata()
                             .and_then(|meta| meta.flow_tool_overlay.clone()),
+                        turn_metadata: primitive.turn_metadata().cloned(),
+                        execution_kind: primitive
+                            .turn_metadata()
+                            .and_then(|meta| meta.execution_kind),
                     },
                     boundary,
                     contributing_input_ids,

--- a/meerkat-mob-mcp/src/lib.rs
+++ b/meerkat-mob-mcp/src/lib.rs
@@ -1678,7 +1678,7 @@ impl SessionService for LocalSessionService {
                 None,
                 AgentEvent::RunStarted {
                     session_id: id.clone(),
-                    prompt: effective_prompt.text_content(),
+                    prompt: effective_prompt.clone(),
                 },
             ));
             let _ = event_tx.send(EventEnvelope::new(
@@ -3355,6 +3355,8 @@ mod tests {
                     event_tx: None,
                     skill_references: None,
                     flow_tool_overlay: None,
+                    turn_metadata: None,
+                    execution_kind: None,
                 },
             )
             .await
@@ -3363,6 +3365,7 @@ mod tests {
         let first = stream.next().await.expect("first event");
         match first.payload {
             AgentEvent::RunStarted { prompt, .. } => {
+                let prompt = prompt.text_content();
                 assert!(prompt.contains("Remember the customer preference."));
                 assert!(prompt.contains("hello"));
             }
@@ -3539,6 +3542,8 @@ mod tests {
                     event_tx: None,
                     skill_references: None,
                     flow_tool_overlay: None,
+                    turn_metadata: None,
+                    execution_kind: None,
                 },
             )
             .await;
@@ -4981,6 +4986,8 @@ mod tests {
                 event_tx: None,
                 skill_references: None,
                 flow_tool_overlay: None,
+                turn_metadata: None,
+                execution_kind: None,
             },
             meerkat_core::lifecycle::run_primitive::RunApplyBoundary::RunStart,
             vec![],

--- a/meerkat-mob/src/runtime/actor.rs
+++ b/meerkat-mob/src/runtime/actor.rs
@@ -1377,6 +1377,8 @@ impl MobActor {
 
                                 skill_references: None,
                                 flow_tool_overlay: None,
+                                turn_metadata: None,
+                                execution_kind: None,
                             },
                         )
                         .await
@@ -7753,6 +7755,8 @@ impl MobActor {
                     event_tx: None,
                     skill_references: None,
                     flow_tool_overlay: None,
+                    turn_metadata: None,
+                    execution_kind: None,
                 };
                 self.provisioner.start_turn(&entry.member_ref, req).await?;
                 Ok(())

--- a/meerkat-mob/src/runtime/actor.rs
+++ b/meerkat-mob/src/runtime/actor.rs
@@ -820,10 +820,17 @@ impl MobActor {
         signal: mob_dsl::MobMachineSignal,
         context: &str,
     ) -> Result<(), MobError> {
+        let signal_debug = format!("{signal:?}");
         let transition = self
             .dsl_authority
             .apply_signal(signal)
-            .map_err(|e| MobError::Internal(format!("DSL authority ({context}): {e}")))?;
+            .map_err(|e| {
+                MobError::Internal(format!(
+                    "DSL authority ({context}): {e}; signal={signal_debug}; live_runtime_ids={:?}; runtime_fence_tokens={:?}",
+                    self.dsl_authority.state.live_runtime_ids,
+                    self.dsl_authority.state.runtime_fence_tokens,
+                ))
+            })?;
         self.queue_routed_effects_from(&transition.effects);
         if transition.from_phase != transition.to_phase {
             self.dsl_authority.state.lifecycle_phase = transition.to_phase;
@@ -4190,6 +4197,27 @@ impl MobActor {
                     },
                 )
                 .await?;
+            // Spawn emits RequestRuntimeBinding. Drain it before startup can
+            // publish RuntimeBound, otherwise the session may emit a fallback
+            // runtime id that MobMachine correctly rejects as not live.
+            if let Err(binding_error) = self.flush_routed_effects().await {
+                self.clear_kickoff_state(agent_identity).await;
+                if let Err(rollback_error) = self
+                    .rollback_failed_spawn(
+                        agent_identity,
+                        profile_name,
+                        &member_ref,
+                        &wired_spawn_targets,
+                        &planned_wiring_targets,
+                    )
+                    .await
+                {
+                    return Err(MobError::Internal(format!(
+                        "spawn runtime binding failed for '{agent_identity}': {binding_error}; rollback failed: {rollback_error}"
+                    )));
+                }
+                return Err(binding_error);
+            }
             if let Err(start_error) = self
                 .start_autonomous_member(agent_identity, &member_ref, prompt)
                 .await

--- a/meerkat-mob/src/runtime/actor_turn_executor.rs
+++ b/meerkat-mob/src/runtime/actor_turn_executor.rs
@@ -367,6 +367,8 @@ impl FlowTurnExecutor for ActorFlowTurnExecutor {
                             event_tx: Some(event_tx),
                             skill_references: None,
                             flow_tool_overlay,
+                            turn_metadata: None,
+                            execution_kind: None,
                         },
                     )
                     .await

--- a/meerkat-mob/src/runtime/builder.rs
+++ b/meerkat-mob/src/runtime/builder.rs
@@ -1308,6 +1308,8 @@ impl MobBuilder {
                                 event_tx: None,
                                 skill_references: None,
                                 flow_tool_overlay: None,
+                                turn_metadata: None,
+                                execution_kind: None,
                             },
                         )
                         .await?;

--- a/meerkat-mob/src/runtime/provisioner.rs
+++ b/meerkat-mob/src/runtime/provisioner.rs
@@ -783,6 +783,10 @@ impl CoreExecutor for MobSessionRuntimeExecutor {
                     reason: err.to_string(),
                 }),
             RunControlCommand::StopRuntimeExecutor { .. } => {
+                tracing::debug!(
+                    bridge_session_id = %self.bridge_session_id,
+                    "mob runtime executor received StopRuntimeExecutor; discarding live session"
+                );
                 let discard_result = self
                     .session_service
                     .discard_live_session(&self.bridge_session_id)
@@ -853,9 +857,11 @@ impl MobProvisioner for SessionBackend {
                     id
                 });
             let bindings = adapter
-                .prepare_bindings(member_bridge_session_id.clone())
+                .prepare_local_session_bindings(member_bridge_session_id.clone())
                 .await
-                .map_err(|e| MobError::Internal(format!("prepare_bindings failed: {e}")))?;
+                .map_err(|e| {
+                    MobError::Internal(format!("prepare_local_session_bindings failed: {e}"))
+                })?;
             if let Some(ref mut build) = req.create_session.build {
                 build.runtime_build_mode =
                     meerkat_core::runtime_epoch::RuntimeBuildMode::SessionOwned(bindings);

--- a/meerkat-mob/src/runtime/provisioner.rs
+++ b/meerkat-mob/src/runtime/provisioner.rs
@@ -750,6 +750,10 @@ impl CoreExecutor for MobSessionRuntimeExecutor {
             flow_tool_overlay: primitive
                 .turn_metadata()
                 .and_then(|meta| meta.flow_tool_overlay.clone()),
+            turn_metadata: primitive.turn_metadata().cloned(),
+            execution_kind: primitive
+                .turn_metadata()
+                .and_then(|meta| meta.execution_kind),
         };
 
         self.session_service

--- a/meerkat-mob/src/runtime/session_service.rs
+++ b/meerkat-mob/src/runtime/session_service.rs
@@ -287,7 +287,9 @@ where
         boundary: RunApplyBoundary,
         contributing_input_ids: Vec<InputId>,
     ) -> Result<CoreApplyOutput, SessionError> {
-        meerkat_session::EphemeralSessionService::<B>::start_turn(self, session_id, req).await?;
+        let run_result =
+            meerkat_session::EphemeralSessionService::<B>::start_turn(self, session_id, req)
+                .await?;
         let session =
             meerkat_session::EphemeralSessionService::<B>::export_session(self, session_id).await?;
         let receipt = build_runtime_receipt(run_id, boundary, contributing_input_ids, &session)?;
@@ -296,9 +298,10 @@ where
                 "failed to serialize session snapshot for runtime commit: {err}"
             )))
         })?;
-        Ok(CoreApplyOutput::without_terminal(
+        Ok(CoreApplyOutput::with_run_result(
             receipt,
             Some(session_snapshot),
+            run_result,
         ))
     }
 

--- a/meerkat-mob/src/runtime/tests.rs
+++ b/meerkat-mob/src/runtime/tests.rs
@@ -1120,6 +1120,7 @@ impl SessionService for MockSessionService {
                             None,
                             AgentEvent::RunFailed {
                                 session_id,
+                                error_class: meerkat_core::event::AgentErrorClass::Internal,
                                 error: "mock flow turn failure".to_string(),
                             },
                         ))
@@ -6376,6 +6377,8 @@ async fn test_flow_step_tool_overlay_is_step_scoped() {
                 event_tx: None,
                 skill_references: None,
                 flow_tool_overlay: None,
+                turn_metadata: None,
+                execution_kind: None,
             },
         )
         .await

--- a/meerkat-mob/src/tests/contracts.rs
+++ b/meerkat-mob/src/tests/contracts.rs
@@ -1049,6 +1049,8 @@ async fn contract_mob_001_keep_alive_session_stays_alive() {
                 event_tx: None,
                 skill_references: None,
                 flow_tool_overlay: None,
+                turn_metadata: None,
+                execution_kind: None,
             },
         )
         .await
@@ -1122,6 +1124,8 @@ async fn contract_mob_007_session_archive_removes_from_active_list() {
                 event_tx: None,
                 skill_references: None,
                 flow_tool_overlay: None,
+                turn_metadata: None,
+                execution_kind: None,
             },
         )
         .await;

--- a/meerkat-mob/tests/smoke_mob_pictionary.rs
+++ b/meerkat-mob/tests/smoke_mob_pictionary.rs
@@ -312,6 +312,25 @@ async fn wait_for_comms_mesh_ready(
             return true;
         }
         if Instant::now() > deadline {
+            for member in members {
+                let Some(session_id) = handle
+                    .resolve_bridge_session_id(&AgentIdentity::from(member))
+                    .await
+                else {
+                    eprintln!("mesh diagnostics: {member}: missing bridge session id");
+                    continue;
+                };
+                let Some(comms_runtime) = service.comms_runtime(&session_id).await else {
+                    eprintln!("mesh diagnostics: {member}: missing comms runtime for {session_id}");
+                    continue;
+                };
+                let peers = comms_runtime.peers().await;
+                let names = peers
+                    .iter()
+                    .map(|peer| peer.name.as_str().to_string())
+                    .collect::<Vec<_>>();
+                eprintln!("mesh diagnostics: {member}: peers={names:?}");
+            }
             return false;
         }
         sleep(Duration::from_secs(1)).await;
@@ -1124,7 +1143,7 @@ async fn e2e_pictionary_multimodal_comms_stress() {
         let guess_reached_artist = wait_for_artist_guess_after_discussion(
             &handle,
             service.as_ref(),
-            Duration::from_secs(180),
+            Duration::from_secs(300),
         )
         .await;
 

--- a/meerkat-rest/src/lib.rs
+++ b/meerkat-rest/src/lib.rs
@@ -598,6 +598,10 @@ async fn apply_runtime_turn(
         flow_tool_overlay: primitive
             .turn_metadata()
             .and_then(|meta| meta.flow_tool_overlay.clone()),
+        turn_metadata: primitive.turn_metadata().cloned(),
+        execution_kind: primitive
+            .turn_metadata()
+            .and_then(|meta| meta.execution_kind),
     };
 
     let session_identity = context
@@ -711,6 +715,10 @@ async fn apply_runtime_turn(
                         flow_tool_overlay: primitive
                             .turn_metadata()
                             .and_then(|meta| meta.flow_tool_overlay.clone()),
+                        turn_metadata: primitive.turn_metadata().cloned(),
+                        execution_kind: primitive
+                            .turn_metadata()
+                            .and_then(|meta| meta.execution_kind),
                     },
                     boundary,
                     contributing_input_ids,
@@ -5569,6 +5577,8 @@ mod tests {
 
                     skill_references: None,
                     flow_tool_overlay: None,
+                    turn_metadata: None,
+                    execution_kind: None,
                 },
             )
             .await

--- a/meerkat-rpc/src/session_executor.rs
+++ b/meerkat-rpc/src/session_executor.rs
@@ -263,6 +263,10 @@ impl CoreExecutor for MobRpcRuntimeExecutor {
             flow_tool_overlay: primitive
                 .turn_metadata()
                 .and_then(|meta| meta.flow_tool_overlay.clone()),
+            turn_metadata: primitive.turn_metadata().cloned(),
+            execution_kind: primitive
+                .turn_metadata()
+                .and_then(|meta| meta.execution_kind),
         };
 
         let result = self

--- a/meerkat-rpc/src/session_runtime.rs
+++ b/meerkat-rpc/src/session_runtime.rs
@@ -2295,6 +2295,10 @@ impl SessionRuntime {
 
                 skill_references: skill_references.clone(),
                 flow_tool_overlay: flow_tool_overlay.clone(),
+                turn_metadata: primitive.turn_metadata().cloned(),
+                execution_kind: primitive
+                    .turn_metadata()
+                    .and_then(|meta| meta.execution_kind),
             };
 
             match self
@@ -2507,6 +2511,10 @@ impl SessionRuntime {
 
                         skill_references,
                         flow_tool_overlay,
+                        turn_metadata: primitive.turn_metadata().cloned(),
+                        execution_kind: primitive
+                            .turn_metadata()
+                            .and_then(|meta| meta.execution_kind),
                     },
                     match primitive {
                         RunPrimitive::StagedInput(staged) => staged.boundary,
@@ -2565,6 +2573,10 @@ impl SessionRuntime {
 
                     skill_references,
                     flow_tool_overlay,
+                    turn_metadata: primitive.turn_metadata().cloned(),
+                    execution_kind: primitive
+                        .turn_metadata()
+                        .and_then(|meta| meta.execution_kind),
                 },
                 match primitive {
                     RunPrimitive::StagedInput(staged) => staged.boundary,
@@ -2960,6 +2972,8 @@ impl SessionRuntime {
             event_tx: Some(event_tx.clone()),
             skill_references: skill_references.clone(),
             flow_tool_overlay: flow_tool_overlay.clone(),
+            turn_metadata: None,
+            execution_kind: None,
         };
 
         if self.live_session_is_stale(session_id).await? {
@@ -4870,14 +4884,14 @@ mod tests {
             .expect("run_started event should exist");
         match started.payload {
             AgentEvent::RunStarted { prompt, .. } => {
-                let normalized = prompt.to_lowercase();
+                let normalized = prompt.text_content().to_lowercase();
                 assert!(
                     normalized.contains("peer_response_terminal:analyst-rt:req-123"),
-                    "run_started prompt should expose runtime system-context source: {prompt}"
+                    "run_started prompt should expose runtime system-context source: {normalized}"
                 );
                 assert!(
                     normalized.contains("birch seventeen"),
-                    "run_started prompt should expose authoritative terminal peer payload: {prompt}"
+                    "run_started prompt should expose authoritative terminal peer payload: {normalized}"
                 );
             }
             other => panic!("expected run_started, got {other:?}"),

--- a/meerkat-runtime/src/handles/mod.rs
+++ b/meerkat-runtime/src/handles/mod.rs
@@ -72,10 +72,10 @@ pub use turn_state::RuntimeTurnStateHandle;
 
 /// Shared handle over a session's real `MeerkatMachineAuthority`.
 ///
-/// Constructed by [`crate::meerkat_machine::MeerkatMachine::prepare_bindings`]
-/// from the session's [`crate::meerkat_machine::RuntimeSessionEntry::dsl_authority`]
-/// `Arc`; cloned into each of the 5 handle impls so all routes mutate the same
-/// underlying authority.
+/// Constructed from the session's
+/// [`crate::meerkat_machine::RuntimeSessionEntry::dsl_authority`] `Arc`; cloned
+/// into each of the 5 handle impls so all routes mutate the same underlying
+/// authority.
 ///
 /// A standalone ephemeral constructor ([`HandleDslAuthority::ephemeral`]) is
 /// also provided for legacy code paths (recovery fallback, test sites) that

--- a/meerkat-runtime/src/input.rs
+++ b/meerkat-runtime/src/input.rs
@@ -10,8 +10,9 @@ use meerkat_core::lifecycle::run_primitive::RuntimeTurnMetadata;
 use meerkat_core::ops::{OpEvent, OperationId};
 use meerkat_core::types::HandlingMode;
 use meerkat_core::{
-    BlobStore, BlobStoreError, MissingBlobBehavior, externalize_content_blocks,
-    hydrate_content_blocks,
+    BlobStore, BlobStoreError, MissingBlobBehavior, PeerConversationProjection,
+    PeerResponseProgressProjectionPhase, PeerResponseTerminalProjectionStatus,
+    externalize_content_blocks, hydrate_content_blocks,
 };
 use serde::{Deserialize, Serialize};
 
@@ -484,6 +485,96 @@ pub struct OperationInput {
     pub operation_id: OperationId,
     /// Typed lifecycle event for the operation.
     pub event: OpEvent,
+}
+
+/// Build the core-owned peer conversation projection for a runtime peer input.
+///
+/// The runtime loop consumes this classification but does not own the peer
+/// response semantic mapping. That mapping belongs at the input boundary,
+/// where typed peer convention/status fields are still present.
+pub(crate) fn peer_projection_from_peer_input(
+    peer: &PeerInput,
+) -> Option<PeerConversationProjection> {
+    let InputOrigin::Peer { peer_id, .. } = &peer.header.source else {
+        return None;
+    };
+
+    match &peer.convention {
+        Some(PeerConvention::Message) => Some(PeerConversationProjection::Message {
+            peer_id: peer_id.clone(),
+        }),
+        Some(PeerConvention::Request { request_id, intent }) => {
+            Some(PeerConversationProjection::Request {
+                peer_id: peer_id.clone(),
+                request_id: request_id.clone(),
+                intent: intent.clone(),
+                payload: peer.payload.clone(),
+            })
+        }
+        Some(PeerConvention::ResponseProgress { request_id, phase }) => {
+            Some(PeerConversationProjection::ResponseProgress {
+                peer_id: peer_id.clone(),
+                request_id: request_id.clone(),
+                phase: match phase {
+                    ResponseProgressPhase::Accepted => {
+                        PeerResponseProgressProjectionPhase::Accepted
+                    }
+                    ResponseProgressPhase::InProgress => {
+                        PeerResponseProgressProjectionPhase::InProgress
+                    }
+                    ResponseProgressPhase::PartialResult => {
+                        PeerResponseProgressProjectionPhase::PartialResult
+                    }
+                },
+                payload: peer.payload.clone(),
+            })
+        }
+        Some(PeerConvention::ResponseTerminal { request_id, status }) => {
+            Some(PeerConversationProjection::ResponseTerminal {
+                peer_id: peer_id.clone(),
+                request_id: request_id.clone(),
+                status: match status {
+                    ResponseTerminalStatus::Completed => {
+                        PeerResponseTerminalProjectionStatus::Completed
+                    }
+                    ResponseTerminalStatus::Failed => PeerResponseTerminalProjectionStatus::Failed,
+                    ResponseTerminalStatus::Cancelled => {
+                        PeerResponseTerminalProjectionStatus::Cancelled
+                    }
+                },
+                payload: peer.payload.clone(),
+            })
+        }
+        None => None,
+    }
+}
+
+/// Lift an [`Input`] to its core peer projection when it is a peer input with a
+/// peer-origin header.
+pub(crate) fn peer_projection(input: &Input) -> Option<PeerConversationProjection> {
+    let Input::Peer(peer) = input else {
+        return None;
+    };
+    peer_projection_from_peer_input(peer)
+}
+
+/// Rendered prompt-text projection for a peer input.
+pub(crate) fn peer_prompt_text(peer: &PeerInput) -> String {
+    peer_projection_from_peer_input(peer)
+        .map(|projection| {
+            let prompt = projection.prompt_text();
+            if prompt.is_empty() {
+                peer.body.clone()
+            } else {
+                prompt
+            }
+        })
+        .unwrap_or_else(|| peer.body.clone())
+}
+
+/// Optional block prefix for peer message inputs.
+pub(crate) fn peer_block_prefix_text(peer: &PeerInput) -> Option<String> {
+    peer_projection_from_peer_input(peer).and_then(|projection| projection.block_prefix_text())
 }
 
 /// Classify an input's typed execution intent for the runtime loop.

--- a/meerkat-runtime/src/meerkat_machine/composition.rs
+++ b/meerkat-runtime/src/meerkat_machine/composition.rs
@@ -688,4 +688,80 @@ mod tests {
         assert_eq!(log[0].1[1].0.as_str(), "fence_token");
         assert!(matches!(log[0].1[1].1, OwnedFieldValue::U64(11)));
     }
+
+    #[tokio::test]
+    async fn local_session_bindings_do_not_dispatch_runtime_bound_signal() {
+        let machine = Arc::new(MeerkatMachine::ephemeral());
+        let session_id = SessionId::new();
+
+        let signal_surface = Arc::new(RecordingSignalSurface::default());
+        let schema = meerkat_machine_schema::catalog::meerkat_mob_seam_composition();
+        let table = RouteTable::from_schema(&schema).expect("catalog routes");
+        let dispatcher: CatalogCompositionSignalDispatcher<MeerkatSeamSignal> =
+            CatalogCompositionSignalDispatcher::new(schema.name.clone(), table)
+                .with_consumer(signal_surface.clone());
+        machine.set_composition_signal_dispatcher(Arc::new(dispatcher));
+
+        let bindings = machine
+            .prepare_local_session_bindings(session_id.clone())
+            .await
+            .expect("local bindings prepare");
+
+        assert_eq!(bindings.session_id, session_id);
+        assert!(
+            signal_surface.log.lock().await.is_empty(),
+            "local resource preparation must not publish cross-machine runtime readiness"
+        );
+        {
+            let sessions = machine.sessions.read().await;
+            let entry = sessions.get(&session_id).expect("session registered");
+            let authority = entry
+                .dsl_authority
+                .lock()
+                .unwrap_or_else(std::sync::PoisonError::into_inner);
+            assert!(
+                authority.state.active_runtime_id.is_none(),
+                "local resource preparation must leave binding identity unclaimed"
+            );
+            assert!(
+                authority.state.active_fence_token.is_none(),
+                "local resource preparation must leave binding fence unclaimed"
+            );
+        }
+
+        machine
+            .apply_routed_meerkat_input(
+                &session_id,
+                mm_dsl::MeerkatMachineInput::PrepareBindings {
+                    agent_runtime_id: mm_dsl::AgentRuntimeId("rt-authoritative".into()),
+                    fence_token: mm_dsl::FenceToken(13),
+                    generation: mm_dsl::Generation(0),
+                    session_id: mm_dsl::SessionId(session_id.to_string()),
+                },
+            )
+            .await
+            .expect("authoritative binding still applies after local resource prep");
+
+        let log = signal_surface.log.lock().await;
+        assert_eq!(log.len(), 1);
+        assert_eq!(log[0].0.as_str(), "ObserveRuntimeReady");
+        assert!(
+            matches!(&log[0].1[0].1, OwnedFieldValue::Str(value) if value == "rt-authoritative")
+        );
+        {
+            let sessions = machine.sessions.read().await;
+            let entry = sessions.get(&session_id).expect("session registered");
+            let authority = entry
+                .dsl_authority
+                .lock()
+                .unwrap_or_else(std::sync::PoisonError::into_inner);
+            assert!(
+                matches!(&authority.state.active_runtime_id, Some(value) if value.0 == "rt-authoritative")
+            );
+            assert!(matches!(
+                authority.state.active_fence_token,
+                Some(mm_dsl::FenceToken(13))
+            ));
+        }
+    }
 }

--- a/meerkat-runtime/src/meerkat_machine/dispatch_ingress.rs
+++ b/meerkat-runtime/src/meerkat_machine/dispatch_ingress.rs
@@ -473,13 +473,18 @@ impl MeerkatMachine {
                         )));
                     }
 
+                    let primitive =
+                        crate::runtime_loop::input_to_primitive(&dequeued_input, dequeued_id)
+                            .map_err(|err| {
+                                RuntimeDriverError::Internal(format!(
+                                    "failed to build accepted input primitive: {err}"
+                                ))
+                            })?;
+
                     MeerkatMachineRunPrepared {
                         input_id,
                         run_id,
-                        primitive: crate::runtime_loop::input_to_primitive(
-                            &dequeued_input,
-                            dequeued_id,
-                        ),
+                        primitive,
                     }
                 };
 

--- a/meerkat-runtime/src/meerkat_machine/dispatch_session.rs
+++ b/meerkat-runtime/src/meerkat_machine/dispatch_session.rs
@@ -1,6 +1,135 @@
 use super::*;
 
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum SessionBindingPreparation {
+    /// The runtime binding itself is the semantic event: apply
+    /// `PrepareBindings` to MeerkatMachine and publish any routed seam signals.
+    AuthoritativeRuntimeBinding,
+    /// Only create the session-local handle bundle. A separate owner will
+    /// route the authoritative binding later.
+    LocalSessionResources,
+}
+
 impl MeerkatMachine {
+    async fn prepare_session_runtime_bindings(
+        &self,
+        session_id: SessionId,
+        preparation: SessionBindingPreparation,
+    ) -> Result<MeerkatMachineCommandResult, RuntimeDriverError> {
+        if matches!(
+            self.existing_session_runtime_state(&session_id).await,
+            Some(RuntimeState::Destroyed)
+        ) {
+            return Err(RuntimeDriverError::Destroyed);
+        }
+        self.register_session_inner(session_id.clone()).await;
+        let (
+            driver_handle,
+            epoch_id,
+            ops_lifecycle,
+            cursor_state,
+            tool_visibility_owner,
+            dsl_authority_shared,
+        ) = {
+            let sessions = self.sessions.read().await;
+            let entry = sessions
+                .get(&session_id)
+                .ok_or(RuntimeDriverError::Internal(format!(
+                    "session {session_id} missing after register_session_inner"
+                )))?;
+            (
+                Arc::clone(&entry.driver),
+                entry.epoch_id.clone(),
+                Arc::clone(&entry.ops_lifecycle),
+                Arc::clone(&entry.cursor_state),
+                Arc::clone(&entry.tool_visibility_owner),
+                Arc::clone(&entry.dsl_authority),
+            )
+        };
+        if preparation == SessionBindingPreparation::AuthoritativeRuntimeBinding {
+            let runtime_id = {
+                let driver = driver_handle.lock().await;
+                driver.runtime_id().clone()
+            };
+            let dsl_input = crate::meerkat_machine::dsl::MeerkatMachineInput::PrepareBindings {
+                agent_runtime_id: crate::meerkat_machine::dsl::AgentRuntimeId::from_domain(
+                    &runtime_id,
+                ),
+                fence_token: crate::meerkat_machine::dsl::FenceToken::from(0),
+                generation: crate::meerkat_machine::dsl::Generation::from(0),
+                session_id: crate::meerkat_machine::dsl::SessionId::from_domain(&session_id),
+            };
+            let _ = self
+                .stage_session_dsl_input(&session_id, dsl_input, "PrepareBindings")
+                .await
+                .map_err(|reason| RuntimeDriverError::ValidationFailed { reason })?;
+            {
+                let mut driver = driver_handle.lock().await;
+                machine_prepare_bindings_projection(&mut driver)?;
+            }
+        }
+        // Share ONE HandleDslAuthority across all 5 handles so their
+        // transitions land on the session's real DSL state (same Arc
+        // as RuntimeSessionEntry.dsl_authority). Phase 5F/1-5 callsites
+        // rely on this — parallel private authorities would silently
+        // diverge from the session DSL.
+        let shared_handle_authority = Arc::new(crate::handles::HandleDslAuthority::from_shared(
+            dsl_authority_shared,
+        ));
+        Ok(MeerkatMachineCommandResult::Bindings(
+            meerkat_core::SessionRuntimeBindings {
+                session_id,
+                epoch_id,
+                ops_lifecycle: ops_lifecycle as Arc<dyn meerkat_core::OpsLifecycleRegistry>,
+                cursor_state,
+                tool_visibility_owner: tool_visibility_owner
+                    as Arc<dyn meerkat_core::ToolVisibilityOwner>,
+                turn_state: Arc::new(crate::handles::RuntimeTurnStateHandle::new(Arc::clone(
+                    &shared_handle_authority,
+                ))),
+                comms_drain: Arc::new(crate::handles::RuntimeCommsDrainHandle::new(Arc::clone(
+                    &shared_handle_authority,
+                ))),
+                external_tool_surface: Arc::new(
+                    crate::handles::RuntimeExternalToolSurfaceHandle::new(Arc::clone(
+                        &shared_handle_authority,
+                    )),
+                ),
+                peer_comms: Arc::new(crate::handles::RuntimePeerCommsHandle::new(Arc::clone(
+                    &shared_handle_authority,
+                ))),
+                session_admission: Arc::new(crate::handles::RuntimeSessionAdmissionHandle::new(
+                    Arc::clone(&shared_handle_authority),
+                )),
+                auth_lease: Arc::new(crate::handles::RuntimeAuthLeaseHandle::new()),
+                mcp_server_lifecycle: Arc::new(
+                    crate::handles::RuntimeMcpServerLifecycleHandle::new(Arc::clone(
+                        &shared_handle_authority,
+                    )),
+                ),
+                peer_interaction: Some(Arc::new(
+                    crate::handles::RuntimePeerInteractionHandle::new(Arc::clone(
+                        &shared_handle_authority,
+                    )),
+                )),
+                session_context: Arc::new(crate::handles::RuntimeSessionContextHandle::new(
+                    Arc::clone(&shared_handle_authority),
+                )),
+                session_claim_handle: self.session_claim_handle(),
+                interaction_stream: Some(Arc::new(
+                    crate::handles::RuntimeInteractionStreamHandle::new(Arc::clone(
+                        &shared_handle_authority,
+                    )),
+                )),
+                realtime_product_turn: Arc::new(
+                    crate::handles::RuntimeRealtimeProductTurnHandle::new(Arc::clone(
+                        &shared_handle_authority,
+                    )),
+                ),
+            },
+        ))
+    }
+
     pub(super) async fn execute_meerkat_machine_session_command(
         &self,
         command: MeerkatMachineCommand,
@@ -235,120 +364,18 @@ impl MeerkatMachine {
                 ))
             }
             MeerkatMachineCommand::PrepareBindings { session_id } => {
-                if matches!(
-                    self.existing_session_runtime_state(&session_id).await,
-                    Some(RuntimeState::Destroyed)
-                ) {
-                    return Err(RuntimeDriverError::Destroyed);
-                }
-                self.register_session_inner(session_id.clone()).await;
-                let (
-                    driver_handle,
-                    epoch_id,
-                    ops_lifecycle,
-                    cursor_state,
-                    tool_visibility_owner,
-                    dsl_authority_shared,
-                ) = {
-                    let sessions = self.sessions.read().await;
-                    let entry = sessions
-                        .get(&session_id)
-                        .ok_or(RuntimeDriverError::Internal(format!(
-                            "session {session_id} missing after register_session_inner"
-                        )))?;
-                    (
-                        Arc::clone(&entry.driver),
-                        entry.epoch_id.clone(),
-                        Arc::clone(&entry.ops_lifecycle),
-                        Arc::clone(&entry.cursor_state),
-                        Arc::clone(&entry.tool_visibility_owner),
-                        Arc::clone(&entry.dsl_authority),
-                    )
-                };
-                let runtime_id = {
-                    let driver = driver_handle.lock().await;
-                    driver.runtime_id().clone()
-                };
-                let dsl_input = crate::meerkat_machine::dsl::MeerkatMachineInput::PrepareBindings {
-                    agent_runtime_id: crate::meerkat_machine::dsl::AgentRuntimeId::from_domain(
-                        &runtime_id,
-                    ),
-                    fence_token: crate::meerkat_machine::dsl::FenceToken::from(0),
-                    generation: crate::meerkat_machine::dsl::Generation::from(0),
-                    session_id: crate::meerkat_machine::dsl::SessionId::from_domain(&session_id),
-                };
-                let _ = self
-                    .stage_session_dsl_input(&session_id, dsl_input, "PrepareBindings")
-                    .await
-                    .map_err(|reason| RuntimeDriverError::ValidationFailed { reason })?;
-                {
-                    let mut driver = driver_handle.lock().await;
-                    machine_prepare_bindings_projection(&mut driver)?;
-                }
-                // Share ONE HandleDslAuthority across all 5 handles so their
-                // transitions land on the session's real DSL state (same Arc
-                // as RuntimeSessionEntry.dsl_authority). Phase 5F/1-5 callsites
-                // rely on this — parallel private authorities would silently
-                // diverge from the session DSL.
-                let shared_handle_authority = Arc::new(
-                    crate::handles::HandleDslAuthority::from_shared(dsl_authority_shared),
-                );
-                Ok(MeerkatMachineCommandResult::Bindings(
-                    meerkat_core::SessionRuntimeBindings {
-                        session_id,
-                        epoch_id,
-                        ops_lifecycle: ops_lifecycle as Arc<dyn meerkat_core::OpsLifecycleRegistry>,
-                        cursor_state,
-                        tool_visibility_owner: tool_visibility_owner
-                            as Arc<dyn meerkat_core::ToolVisibilityOwner>,
-                        turn_state: Arc::new(crate::handles::RuntimeTurnStateHandle::new(
-                            Arc::clone(&shared_handle_authority),
-                        )),
-                        comms_drain: Arc::new(crate::handles::RuntimeCommsDrainHandle::new(
-                            Arc::clone(&shared_handle_authority),
-                        )),
-                        external_tool_surface: Arc::new(
-                            crate::handles::RuntimeExternalToolSurfaceHandle::new(Arc::clone(
-                                &shared_handle_authority,
-                            )),
-                        ),
-                        peer_comms: Arc::new(crate::handles::RuntimePeerCommsHandle::new(
-                            Arc::clone(&shared_handle_authority),
-                        )),
-                        session_admission: Arc::new(
-                            crate::handles::RuntimeSessionAdmissionHandle::new(Arc::clone(
-                                &shared_handle_authority,
-                            )),
-                        ),
-                        auth_lease: Arc::new(crate::handles::RuntimeAuthLeaseHandle::new()),
-                        mcp_server_lifecycle: Arc::new(
-                            crate::handles::RuntimeMcpServerLifecycleHandle::new(Arc::clone(
-                                &shared_handle_authority,
-                            )),
-                        ),
-                        peer_interaction: Some(Arc::new(
-                            crate::handles::RuntimePeerInteractionHandle::new(Arc::clone(
-                                &shared_handle_authority,
-                            )),
-                        )),
-                        session_context: Arc::new(
-                            crate::handles::RuntimeSessionContextHandle::new(Arc::clone(
-                                &shared_handle_authority,
-                            )),
-                        ),
-                        session_claim_handle: self.session_claim_handle(),
-                        interaction_stream: Some(Arc::new(
-                            crate::handles::RuntimeInteractionStreamHandle::new(Arc::clone(
-                                &shared_handle_authority,
-                            )),
-                        )),
-                        realtime_product_turn: Arc::new(
-                            crate::handles::RuntimeRealtimeProductTurnHandle::new(Arc::clone(
-                                &shared_handle_authority,
-                            )),
-                        ),
-                    },
-                ))
+                self.prepare_session_runtime_bindings(
+                    session_id,
+                    SessionBindingPreparation::AuthoritativeRuntimeBinding,
+                )
+                .await
+            }
+            MeerkatMachineCommand::PrepareLocalSessionBindings { session_id } => {
+                self.prepare_session_runtime_bindings(
+                    session_id,
+                    SessionBindingPreparation::LocalSessionResources,
+                )
+                .await
             }
             MeerkatMachineCommand::InputState {
                 session_id,

--- a/meerkat-runtime/src/meerkat_machine/dispatch_session.rs
+++ b/meerkat-runtime/src/meerkat_machine/dispatch_session.rs
@@ -265,21 +265,26 @@ impl MeerkatMachine {
                         Arc::clone(&entry.dsl_authority),
                     )
                 };
-                let mut driver = driver_handle.lock().await;
+                let runtime_id = {
+                    let driver = driver_handle.lock().await;
+                    driver.runtime_id().clone()
+                };
                 let dsl_input = crate::meerkat_machine::dsl::MeerkatMachineInput::PrepareBindings {
                     agent_runtime_id: crate::meerkat_machine::dsl::AgentRuntimeId::from_domain(
-                        driver.runtime_id(),
+                        &runtime_id,
                     ),
                     fence_token: crate::meerkat_machine::dsl::FenceToken::from(0),
                     generation: crate::meerkat_machine::dsl::Generation::from(0),
                     session_id: crate::meerkat_machine::dsl::SessionId::from_domain(&session_id),
                 };
-                machine_prepare_bindings_projection(&mut driver)?;
-                drop(driver);
                 let _ = self
                     .stage_session_dsl_input(&session_id, dsl_input, "PrepareBindings")
                     .await
                     .map_err(|reason| RuntimeDriverError::ValidationFailed { reason })?;
+                {
+                    let mut driver = driver_handle.lock().await;
+                    machine_prepare_bindings_projection(&mut driver)?;
+                }
                 // Share ONE HandleDslAuthority across all 5 handles so their
                 // transitions land on the session's real DSL state (same Arc
                 // as RuntimeSessionEntry.dsl_authority). Phase 5F/1-5 callsites

--- a/meerkat-runtime/src/meerkat_machine/dsl.rs
+++ b/meerkat-runtime/src/meerkat_machine/dsl.rs
@@ -4892,7 +4892,7 @@ machine! {
             guard {
                 self.lifecycle_phase == Phase::Idle || self.lifecycle_phase == Phase::Retired
             }
-            guard "runtime_is_bound" { self.active_runtime_id != None }
+            guard "session_registered" { self.session_id != None }
             update {
                 self.active_fence_token = None;
                 self.current_run_id = None;
@@ -4903,7 +4903,7 @@ machine! {
         transition RecycleFromAttached {
             on input Recycle
             guard { self.lifecycle_phase == Phase::Attached }
-            guard "runtime_is_bound" { self.active_runtime_id != None }
+            guard "session_registered" { self.session_id != None }
             update {
                 self.active_fence_token = None;
                 self.current_run_id = None;

--- a/meerkat-runtime/src/meerkat_machine/mod.rs
+++ b/meerkat-runtime/src/meerkat_machine/mod.rs
@@ -732,6 +732,7 @@ impl MeerkatMachine {
             | MeerkatMachineCommand::SessionHasComms { .. }
             | MeerkatMachineCommand::OpsLifecycleRegistry { .. }
             | MeerkatMachineCommand::PrepareBindings { .. }
+            | MeerkatMachineCommand::PrepareLocalSessionBindings { .. }
             | MeerkatMachineCommand::InputState { .. }
             | MeerkatMachineCommand::ListActiveInputs { .. }
             | MeerkatMachineCommand::ReconfigureSessionLlmIdentity { .. }

--- a/meerkat-runtime/src/meerkat_machine/runtime_control.rs
+++ b/meerkat-runtime/src/meerkat_machine/runtime_control.rs
@@ -341,4 +341,36 @@ impl MeerkatMachine {
             Err(_) => Err(RuntimeBindingsError::SessionNotFound(session_id)),
         }
     }
+
+    /// Prepare factory-consumable session runtime resources without emitting
+    /// cross-machine binding signals.
+    ///
+    /// Mob provisioning uses this to pre-create the session-owned handle bundle
+    /// before `MobMachine::Spawn` has committed the member runtime id. The
+    /// authoritative mob binding is routed later through
+    /// `RequestRuntimeBinding -> PrepareBindings`, which emits the typed
+    /// `RuntimeBound` signal with the mob-owned `AgentRuntimeId` and fence.
+    pub async fn prepare_local_session_bindings(
+        &self,
+        session_id: SessionId,
+    ) -> Result<meerkat_core::SessionRuntimeBindings, RuntimeBindingsError> {
+        match self
+            .execute_meerkat_machine_command(
+                None,
+                MeerkatMachineCommand::PrepareLocalSessionBindings {
+                    session_id: session_id.clone(),
+                },
+            )
+            .await
+        {
+            Ok(MeerkatMachineCommandResult::Bindings(bindings)) => Ok(bindings),
+            Ok(_) => {
+                tracing::error!(
+                    "prepare_local_session_bindings: unexpected command result variant"
+                );
+                Err(RuntimeBindingsError::SessionNotFound(session_id))
+            }
+            Err(_) => Err(RuntimeBindingsError::SessionNotFound(session_id)),
+        }
+    }
 }

--- a/meerkat-runtime/src/meerkat_machine/session_management.rs
+++ b/meerkat-runtime/src/meerkat_machine/session_management.rs
@@ -27,27 +27,36 @@ impl MeerkatMachine {
             tracing::error!(%session_id, error = %err, "failed to recover runtime driver during registration");
             return;
         }
-        // Cold-restart: when `recover()` realizes a stored terminal
-        // runtime state (Retired / Stopped / Destroyed) on the driver's
-        // shell `control_projection`, the DSL authority still holds the
-        // construction-time `Idle`. Re-project the DSL state from the
-        // recovered phase so `existing_session_runtime_state` (which reads
-        // `dsl_authority.state.lifecycle_phase` as the canonical source
-        // post-e5c5ecaf3) surfaces the true stored phase.
+        // Cold-restart: when `recover()` realizes a stored terminal runtime
+        // state on the driver, replay that fact through the DSL authority
+        // before publishing the session entry. The shell projection remains a
+        // persistence witness; it never directly seeds `authority.state`.
         let recovered_phase = entry.as_driver().runtime_state();
         if recovered_phase != RuntimeState::Idle {
             let mut authority = dsl_authority
                 .lock()
                 .unwrap_or_else(std::sync::PoisonError::into_inner);
-            authority.state = super::dsl_authority::project_state(
-                &session_id,
-                recovered_phase,
-                Some(&runtime_id),
-                None,
-                None,
-                std::collections::BTreeSet::new(),
-                None,
-            );
+            let input = match recovered_phase {
+                RuntimeState::Retired => Some(super::dsl::MeerkatMachineInput::Retire {
+                    session_id: super::dsl::SessionId::from_domain(&session_id),
+                }),
+                RuntimeState::Stopped => Some(super::dsl::MeerkatMachineInput::StopRuntimeExecutor),
+                RuntimeState::Destroyed => Some(super::dsl::MeerkatMachineInput::Destroy {
+                    session_id: super::dsl::SessionId::from_domain(&session_id),
+                }),
+                RuntimeState::Attached | RuntimeState::Running | RuntimeState::Initializing => None,
+                RuntimeState::Idle => None,
+            };
+            if let Some(input) = input
+                && let Err(err) = super::dsl::MeerkatMachineMutator::apply(&mut *authority, input)
+            {
+                tracing::error!(
+                    %session_id,
+                    ?recovered_phase,
+                    error = ?err,
+                    "failed to replay recovered runtime phase through DSL authority"
+                );
+            }
         }
         let control_projection = entry.control_projection_handle();
 

--- a/meerkat-runtime/src/meerkat_machine/session_management.rs
+++ b/meerkat-runtime/src/meerkat_machine/session_management.rs
@@ -10,12 +10,11 @@ impl MeerkatMachine {
             }
         }
 
-        let runtime_id = LogicalRuntimeId::new(session_id.to_string());
         let dsl_authority = Arc::new(std::sync::Mutex::new(
             super::dsl::MeerkatMachineAuthority::from_state(super::dsl_authority::project_state(
                 &session_id,
                 RuntimeState::Idle,
-                Some(&runtime_id),
+                None,
                 None,
                 None,
                 std::collections::BTreeSet::new(),
@@ -195,13 +194,12 @@ impl MeerkatMachine {
                 }
                 (driver, completions, ops_lifecycle)
             } else {
-                let runtime_id = LogicalRuntimeId::new(session_id.to_string());
                 let dsl_authority = Arc::new(std::sync::Mutex::new(
                     super::dsl::MeerkatMachineAuthority::from_state(
                         super::dsl_authority::project_state(
                             &session_id,
                             RuntimeState::Idle,
-                            Some(&runtime_id),
+                            None,
                             None,
                             None,
                             std::collections::BTreeSet::new(),

--- a/meerkat-runtime/src/meerkat_machine_types.rs
+++ b/meerkat-runtime/src/meerkat_machine_types.rs
@@ -322,6 +322,9 @@ pub(crate) enum MeerkatMachineCommand {
     PrepareBindings {
         session_id: SessionId,
     },
+    PrepareLocalSessionBindings {
+        session_id: SessionId,
+    },
     InputState {
         session_id: SessionId,
         input_id: InputId,

--- a/meerkat-runtime/src/runtime_loop.rs
+++ b/meerkat-runtime/src/runtime_loop.rs
@@ -104,12 +104,14 @@ pub(crate) fn for_input(
 
 /// Merge the per-input turn metadata carried by a staged batch into a single
 /// typed carrier. Scalar conflicts (two inputs disagreeing on e.g. `model`)
-/// are refused with a typed error and the batch is treated as if no metadata
-/// could be synthesized safely — the caller falls back to `None` and the
-/// conflict is surfaced through structured tracing.
+/// are refused with a typed error so caller policy is not silently replaced by
+/// shell defaults.
 pub(crate) fn merge_batch_turn_metadata(
     inputs: &[(meerkat_core::lifecycle::InputId, Input)],
-) -> Option<meerkat_core::lifecycle::run_primitive::RuntimeTurnMetadata> {
+) -> Result<
+    Option<meerkat_core::lifecycle::run_primitive::RuntimeTurnMetadata>,
+    meerkat_core::lifecycle::run_primitive::TurnMetadataMergeConflict,
+> {
     use meerkat_core::lifecycle::run_primitive::RuntimeTurnMetadata;
     let mut acc: Option<RuntimeTurnMetadata> = None;
     for (_, input) in inputs {
@@ -119,18 +121,11 @@ pub(crate) fn merge_batch_turn_metadata(
         match acc.as_mut() {
             None => acc = Some(meta),
             Some(existing) => {
-                if let Err(conflict) = existing.merge(meta) {
-                    tracing::error!(
-                        field = conflict.field,
-                        reason = conflict.reason,
-                        "batch turn-metadata merge conflict; dropping batch metadata"
-                    );
-                    return None;
-                }
+                existing.merge(meta)?;
             }
         }
     }
-    acc.filter(|m| !m.is_empty())
+    Ok(acc.filter(|m| !m.is_empty()))
 }
 
 fn resolve_completion_waiters(
@@ -154,7 +149,7 @@ fn resolve_completion_waiters(
     }
 
     match terminal {
-        Some(CoreApplyTerminal::RunResult(_)) | None => {
+        Some(CoreApplyTerminal::RunResult(_) | CoreApplyTerminal::NoPendingBoundary) | None => {
             for input_id in input_ids {
                 registry.resolve_without_result(input_id);
             }
@@ -474,10 +469,10 @@ fn input_to_context_append(input: &Input) -> Option<ConversationContextAppend> {
     })
 }
 
-pub(crate) fn inputs_to_primitive_with_boundary(
+pub(crate) fn try_inputs_to_primitive_with_boundary(
     inputs: &[(InputId, Input)],
     boundary: RunApplyBoundary,
-) -> RunPrimitive {
+) -> Result<RunPrimitive, meerkat_core::lifecycle::run_primitive::TurnMetadataMergeConflict> {
     let appends = inputs
         .iter()
         .filter_map(|(_, input)| input_to_append(input))
@@ -491,8 +486,8 @@ pub(crate) fn inputs_to_primitive_with_boundary(
         .map(|(input_id, _)| input_id.clone())
         .collect::<Vec<_>>();
     // Merge turn metadata from ALL inputs in the batch, not just the first.
-    // Later inputs override scalar fields; collection fields accumulate.
-    let turn_metadata = merge_batch_turn_metadata(inputs);
+    // Scalar conflicts are typed errors; collection fields accumulate.
+    let turn_metadata = merge_batch_turn_metadata(inputs)?;
 
     // Derive typed execution intent from the full batch.
     // If ANY input is ContentTurn, the whole batch is ContentTurn (safe default).
@@ -513,16 +508,25 @@ pub(crate) fn inputs_to_primitive_with_boundary(
         Some(meta)
     };
 
-    RunPrimitive::StagedInput(StagedRunInput {
+    Ok(RunPrimitive::StagedInput(StagedRunInput {
         boundary,
         appends,
         context_appends,
         contributing_input_ids,
         turn_metadata,
-    })
+    }))
 }
 
-pub(crate) fn inputs_to_primitive(inputs: &[(InputId, Input)]) -> RunPrimitive {
+pub(crate) fn inputs_to_primitive_with_boundary(
+    inputs: &[(InputId, Input)],
+    boundary: RunApplyBoundary,
+) -> Result<RunPrimitive, meerkat_core::lifecycle::run_primitive::TurnMetadataMergeConflict> {
+    try_inputs_to_primitive_with_boundary(inputs, boundary)
+}
+
+pub(crate) fn inputs_to_primitive(
+    inputs: &[(InputId, Input)],
+) -> Result<RunPrimitive, meerkat_core::lifecycle::run_primitive::TurnMetadataMergeConflict> {
     let boundary = inputs
         .first()
         .map(|(_, input)| input_boundary(input))
@@ -531,7 +535,10 @@ pub(crate) fn inputs_to_primitive(inputs: &[(InputId, Input)]) -> RunPrimitive {
 }
 
 /// Convert an `Input` + its ID to a `RunPrimitive` for `CoreExecutor::apply()`.
-pub(crate) fn input_to_primitive(input: &Input, input_id: InputId) -> RunPrimitive {
+pub(crate) fn input_to_primitive(
+    input: &Input,
+    input_id: InputId,
+) -> Result<RunPrimitive, meerkat_core::lifecycle::run_primitive::TurnMetadataMergeConflict> {
     inputs_to_primitive(&[(input_id, input.clone())])
 }
 
@@ -861,11 +868,11 @@ async fn process_queue(
                 .first()
                 .map(|(id, _)| crate::meerkat_machine::machine_input_boundary(&d, id))
                 .unwrap_or(RunApplyBoundary::RunStart);
-            let primitive = inputs_to_primitive_with_boundary(&staged_inputs, boundary);
             let contributing_input_ids = staged_inputs
                 .iter()
                 .map(|(staged_input_id, _)| staged_input_id.clone())
                 .collect::<Vec<_>>();
+            let primitive = try_inputs_to_primitive_with_boundary(&staged_inputs, boundary);
             Some((contributing_input_ids, staged_ids, run_id, primitive))
         };
 
@@ -881,6 +888,24 @@ async fn process_queue(
                     tracing::error!(%run_id, error = %err, "failed to prepare runtime loop batch");
                     return false;
                 }
+                let primitive = match primitive {
+                    Ok(primitive) => primitive,
+                    Err(conflict) => {
+                        tracing::error!(
+                            %run_id,
+                            field = conflict.field,
+                            reason = conflict.reason,
+                            "batch turn-metadata merge conflict"
+                        );
+                        let _ = crate::meerkat_machine::fail_runtime_loop_run(
+                            driver,
+                            run_id,
+                            conflict.to_string(),
+                        )
+                        .await;
+                        return false;
+                    }
+                };
                 if let Err(error) =
                     prepare_turn_state_for_primitive(driver, &run_id, &primitive).await
                 {
@@ -1235,7 +1260,8 @@ mod tests {
     fn input_to_primitive_creates_staged() -> Result<(), String> {
         let input = make_prompt("test prompt");
         let input_id = input.id().clone();
-        let primitive = input_to_primitive(&input, input_id.clone());
+        let primitive = input_to_primitive(&input, input_id.clone())
+            .expect("single input metadata cannot conflict");
 
         let staged = match primitive {
             RunPrimitive::StagedInput(staged) => staged,
@@ -1256,7 +1282,8 @@ mod tests {
     fn staged_conversation_input_starts_conversation_turn_state() -> Result<(), String> {
         let input = make_prompt("test prompt");
         let input_id = input.id().clone();
-        let primitive = input_to_primitive(&input, input_id);
+        let primitive =
+            input_to_primitive(&input, input_id).expect("single input metadata cannot conflict");
         let run_id = RunId::new();
 
         let start_input = primitive_turn_start_input(&run_id, &primitive)
@@ -1317,7 +1344,8 @@ mod tests {
         let primitive = inputs_to_primitive_with_boundary(
             &[(input_id.clone(), input)],
             RunApplyBoundary::Immediate,
-        );
+        )
+        .expect("single input metadata cannot conflict");
         let staged = match primitive {
             RunPrimitive::StagedInput(staged) => staged,
             other => return Err(format!("expected staged input, got {other:?}")),
@@ -1377,7 +1405,8 @@ mod tests {
 
         assert_eq!(input_boundary(&input), RunApplyBoundary::RunStart);
 
-        let primitive = inputs_to_primitive(&[(input.id().clone(), input)]);
+        let primitive = inputs_to_primitive(&[(input.id().clone(), input)])
+            .expect("single input metadata cannot conflict");
         let staged = match primitive {
             RunPrimitive::StagedInput(staged) => staged,
             other => return Err(format!("expected staged input, got {other:?}")),
@@ -1423,7 +1452,8 @@ mod tests {
             handling_mode: None,
         });
         let input_id = input.id().clone();
-        let primitive = input_to_primitive(&input, input_id);
+        let primitive =
+            input_to_primitive(&input, input_id).expect("single input metadata cannot conflict");
 
         let staged = match primitive {
             RunPrimitive::StagedInput(staged) => staged,
@@ -1478,7 +1508,9 @@ mod tests {
             blocks: Some(blocks.clone()),
             handling_mode: None,
         });
-        let staged = match input_to_primitive(&input, input.id().clone()) {
+        let staged = match input_to_primitive(&input, input.id().clone())
+            .expect("single input metadata cannot conflict")
+        {
             RunPrimitive::StagedInput(staged) => staged,
             other => return Err(format!("expected staged input, got {other:?}")),
         };
@@ -1527,7 +1559,9 @@ mod tests {
             blocks: Some(blocks.clone()),
             handling_mode: None,
         });
-        let staged = match input_to_primitive(&input, input.id().clone()) {
+        let staged = match input_to_primitive(&input, input.id().clone())
+            .expect("single input metadata cannot conflict")
+        {
             RunPrimitive::StagedInput(staged) => staged,
             other => return Err(format!("expected staged input, got {other:?}")),
         };
@@ -1579,7 +1613,8 @@ mod tests {
             turn_metadata: None,
         });
         let input_id = input.id().clone();
-        let primitive = input_to_primitive(&input, input_id);
+        let primitive =
+            input_to_primitive(&input, input_id).expect("single input metadata cannot conflict");
 
         let staged = match primitive {
             RunPrimitive::StagedInput(staged) => staged,
@@ -1624,7 +1659,8 @@ mod tests {
             render_metadata: None,
         });
         let input_id = input.id().clone();
-        let primitive = input_to_primitive(&input, input_id);
+        let primitive =
+            input_to_primitive(&input, input_id).expect("single input metadata cannot conflict");
 
         let staged = match primitive {
             RunPrimitive::StagedInput(staged) => staged,
@@ -1668,7 +1704,8 @@ mod tests {
             handling_mode: meerkat_core::types::HandlingMode::Queue,
             render_metadata: None,
         });
-        let primitive = input_to_primitive(&input, input.id().clone());
+        let primitive = input_to_primitive(&input, input.id().clone())
+            .expect("single input metadata cannot conflict");
 
         let staged = match primitive {
             RunPrimitive::StagedInput(staged) => staged,
@@ -1789,7 +1826,9 @@ mod tests {
             render_metadata: Some(render_metadata.clone()),
         });
 
-        let staged = match input_to_primitive(&input, input.id().clone()) {
+        let staged = match input_to_primitive(&input, input.id().clone())
+            .expect("single input metadata cannot conflict")
+        {
             RunPrimitive::StagedInput(staged) => staged,
             other => return Err(format!("expected staged input, got {other:?}")),
         };
@@ -1944,7 +1983,8 @@ mod tests {
     fn primitive_from_prompt_has_content_turn() {
         let input = make_prompt("hello");
         let id = input.id().clone();
-        let primitive = input_to_primitive(&input, id);
+        let primitive =
+            input_to_primitive(&input, id).expect("single input metadata cannot conflict");
         let meta = primitive
             .turn_metadata()
             .expect("should have turn_metadata");
@@ -1958,7 +1998,8 @@ mod tests {
     fn primitive_from_continuation_has_resume_pending() {
         let input = Input::Continuation(ContinuationInput::detached_background_op_completed());
         let id = input.id().clone();
-        let primitive = input_to_primitive(&input, id);
+        let primitive =
+            input_to_primitive(&input, id).expect("single input metadata cannot conflict");
         let meta = primitive
             .turn_metadata()
             .expect("should have turn_metadata");
@@ -1994,7 +2035,8 @@ mod tests {
             handling_mode: None,
         });
         let id = input.id().clone();
-        let primitive = input_to_primitive(&input, id);
+        let primitive =
+            input_to_primitive(&input, id).expect("single input metadata cannot conflict");
         let meta = primitive
             .turn_metadata()
             .expect("should have turn_metadata");
@@ -2034,7 +2076,8 @@ mod tests {
             (peer.id().clone(), peer),
             (continuation.id().clone(), continuation),
         ];
-        let primitive = inputs_to_primitive_with_boundary(&inputs, RunApplyBoundary::RunCheckpoint);
+        let primitive = inputs_to_primitive_with_boundary(&inputs, RunApplyBoundary::RunCheckpoint)
+            .expect("mixed test batch metadata should not conflict");
         let meta = primitive
             .turn_metadata()
             .expect("should have turn_metadata");
@@ -2043,5 +2086,37 @@ mod tests {
             Some(meerkat_core::lifecycle::RuntimeExecutionKind::ContentTurn),
             "mixed batch must default to ContentTurn"
         );
+    }
+
+    #[test]
+    fn batch_metadata_conflict_surfaces_typed_error() {
+        let mut first = make_prompt("first");
+        if let Input::Prompt(prompt) = &mut first {
+            prompt.turn_metadata = Some(
+                meerkat_core::lifecycle::run_primitive::RuntimeTurnMetadata {
+                    model: Some(meerkat_core::lifecycle::run_primitive::ModelId::new(
+                        "model-a",
+                    )),
+                    ..Default::default()
+                },
+            );
+        }
+        let mut second = make_prompt("second");
+        if let Input::Prompt(prompt) = &mut second {
+            prompt.turn_metadata = Some(
+                meerkat_core::lifecycle::run_primitive::RuntimeTurnMetadata {
+                    model: Some(meerkat_core::lifecycle::run_primitive::ModelId::new(
+                        "model-b",
+                    )),
+                    ..Default::default()
+                },
+            );
+        }
+        let inputs = vec![(first.id().clone(), first), (second.id().clone(), second)];
+
+        let err = try_inputs_to_primitive_with_boundary(&inputs, RunApplyBoundary::RunStart)
+            .expect_err("conflicting batch metadata should be rejected");
+
+        assert_eq!(err.field, "model");
     }
 }

--- a/meerkat-runtime/src/runtime_loop.rs
+++ b/meerkat-runtime/src/runtime_loop.rs
@@ -12,12 +12,8 @@ use meerkat_core::lifecycle::run_primitive::{
     RunApplyBoundary, RunPrimitive, StagedRunInput,
 };
 use meerkat_core::lifecycle::{InputId, RunId};
-use meerkat_core::{
-    PeerConversationProjection, PeerResponseProgressProjectionPhase,
-    PeerResponseTerminalProjectionStatus,
-};
 
-use crate::input::Input;
+use crate::input::{Input, peer_block_prefix_text, peer_projection, peer_prompt_text};
 use crate::runtime_state::RuntimeState;
 use crate::tokio;
 
@@ -276,116 +272,6 @@ fn external_event_projection_text(event: &crate::input::ExternalEventInput) -> S
         .map(str::trim);
 
     meerkat_core::interaction::format_external_event_projection(source_name, body)
-}
-
-/// Build a core-owned [`PeerConversationProjection`] from a runtime
-/// [`crate::input::PeerInput`]. Returns `None` when the input has no
-/// peer-originated source (e.g. a mob-internal peer input without a
-/// `peer_id` header) or carries no convention — both shapes are
-/// legitimate "no projection available" rather than errors, so the
-/// caller falls through to the legacy body-as-text path.
-///
-/// The projection carries the full peer metadata (peer_id, request_id,
-/// intent, payload, phase/status) and owns the semantic rendering
-/// primitives (`prompt_text`, `block_prefix_text`, `context_key`) so
-/// the runtime-loop shell never needs to format peer messages itself.
-fn peer_projection_from_peer_input(
-    peer: &crate::input::PeerInput,
-) -> Option<PeerConversationProjection> {
-    let crate::input::InputOrigin::Peer { peer_id, .. } = &peer.header.source else {
-        return None;
-    };
-
-    match &peer.convention {
-        Some(crate::input::PeerConvention::Message) => Some(PeerConversationProjection::Message {
-            peer_id: peer_id.clone(),
-        }),
-        Some(crate::input::PeerConvention::Request { request_id, intent }) => {
-            Some(PeerConversationProjection::Request {
-                peer_id: peer_id.clone(),
-                request_id: request_id.clone(),
-                intent: intent.clone(),
-                payload: peer.payload.clone(),
-            })
-        }
-        Some(crate::input::PeerConvention::ResponseProgress { request_id, phase }) => {
-            Some(PeerConversationProjection::ResponseProgress {
-                peer_id: peer_id.clone(),
-                request_id: request_id.clone(),
-                phase: match phase {
-                    crate::input::ResponseProgressPhase::Accepted => {
-                        PeerResponseProgressProjectionPhase::Accepted
-                    }
-                    crate::input::ResponseProgressPhase::InProgress => {
-                        PeerResponseProgressProjectionPhase::InProgress
-                    }
-                    crate::input::ResponseProgressPhase::PartialResult => {
-                        PeerResponseProgressProjectionPhase::PartialResult
-                    }
-                },
-                payload: peer.payload.clone(),
-            })
-        }
-        Some(crate::input::PeerConvention::ResponseTerminal { request_id, status }) => {
-            Some(PeerConversationProjection::ResponseTerminal {
-                peer_id: peer_id.clone(),
-                request_id: request_id.clone(),
-                status: match status {
-                    crate::input::ResponseTerminalStatus::Completed => {
-                        PeerResponseTerminalProjectionStatus::Completed
-                    }
-                    crate::input::ResponseTerminalStatus::Failed => {
-                        PeerResponseTerminalProjectionStatus::Failed
-                    }
-                    crate::input::ResponseTerminalStatus::Cancelled => {
-                        PeerResponseTerminalProjectionStatus::Cancelled
-                    }
-                },
-                payload: peer.payload.clone(),
-            })
-        }
-        None => None,
-    }
-}
-
-/// Borrowing shim — lift an [`Input`] to its core peer projection when
-/// the input is a `PeerInput` with a peer-origin header. Used by the
-/// context-append path where the caller already has an `&Input`.
-fn peer_projection(input: &Input) -> Option<PeerConversationProjection> {
-    let Input::Peer(peer) = input else {
-        return None;
-    };
-    peer_projection_from_peer_input(peer)
-}
-
-/// Rendered prompt-text projection for a peer input.
-///
-/// For peer-originated inputs this returns the core-owned
-/// `PeerConversationProjection::prompt_text()` (the typed semantic
-/// rendering). For non-peer-originated sources (e.g. mob-internal
-/// peer inputs with no `peer_id` header, or convention=None), the
-/// raw `body` is the shell's best available fallback — the core
-/// projection would return an empty string and the runtime would
-/// otherwise ferry an empty prompt.
-fn peer_prompt_text(peer: &crate::input::PeerInput) -> String {
-    peer_projection_from_peer_input(peer)
-        .map(|projection| {
-            let prompt = projection.prompt_text();
-            if prompt.is_empty() {
-                peer.body.clone()
-            } else {
-                prompt
-            }
-        })
-        .unwrap_or_else(|| peer.body.clone())
-}
-
-/// Optional block prefix (`"[COMMS MESSAGE from <peer_id>]"`) for peer
-/// inputs that carry a `PeerConvention::Message`. Returns `None` for
-/// request / response conventions (those route through the
-/// context-append path instead) and for non-peer-originated inputs.
-fn peer_block_prefix_text(peer: &crate::input::PeerInput) -> Option<String> {
-    peer_projection_from_peer_input(peer).and_then(|projection| projection.block_prefix_text())
 }
 
 /// Convert an `Input` into a `ConversationAppend` on the `User` role,

--- a/meerkat-session/src/ephemeral.rs
+++ b/meerkat-session/src/ephemeral.rs
@@ -628,6 +628,12 @@ impl<B: SessionAgentBuilder + 'static> EphemeralSessionService<B> {
                     args,
                 )
             }
+            Some(CoreApplyTerminal::NoPendingBoundary) => CoreApplyOutput {
+                receipt,
+                session_snapshot: Some(session_snapshot),
+                run_result: None,
+                terminal: Some(CoreApplyTerminal::NoPendingBoundary),
+            },
             None => CoreApplyOutput::without_terminal(receipt, Some(session_snapshot)),
         })
     }
@@ -1142,11 +1148,14 @@ impl<B: SessionAgentBuilder + 'static> EphemeralSessionService<B> {
                 .await
             }
             Err(SessionError::Agent(meerkat_core::error::AgentError::NoPendingBoundary)) => {
-                // ResumePending with no boundary — succeed as no-op through
-                // the canonical boundary-apply path. contributing_input_ids
-                // are consumed normally.
-                self.build_runtime_output(id, run_id, boundary, contributing_input_ids, None)
-                    .await
+                self.build_runtime_output(
+                    id,
+                    run_id,
+                    boundary,
+                    contributing_input_ids,
+                    Some(CoreApplyTerminal::NoPendingBoundary),
+                )
+                .await
             }
             Err(error) => {
                 if let Some(terminal) = Self::callback_pending_terminal(&error) {
@@ -1700,17 +1709,43 @@ impl<B: SessionAgentBuilder + 'static> SessionService for EphemeralSessionServic
                 })?;
             }
 
+            let metadata = req.turn_metadata;
+            let render_metadata = req.render_metadata.or_else(|| {
+                metadata
+                    .as_ref()
+                    .and_then(|metadata| metadata.render_metadata.clone())
+            });
+            let handling_mode = metadata
+                .as_ref()
+                .and_then(|metadata| metadata.handling_mode)
+                .unwrap_or(req.handling_mode);
+            let skill_references = req.skill_references.or_else(|| {
+                metadata
+                    .as_ref()
+                    .and_then(|metadata| metadata.skill_references.clone())
+            });
+            let flow_tool_overlay = req.flow_tool_overlay.or_else(|| {
+                metadata
+                    .as_ref()
+                    .and_then(|metadata| metadata.flow_tool_overlay.clone())
+            });
+            let execution_kind = req.execution_kind.or_else(|| {
+                metadata
+                    .as_ref()
+                    .and_then(|metadata| metadata.execution_kind)
+            });
+
             handle
                 .command_tx
                 .send(SessionCommand::StartTurn {
                     prompt,
-                    render_metadata: req.render_metadata,
-                    handling_mode: req.handling_mode,
+                    render_metadata,
+                    handling_mode,
                     event_tx: req.event_tx,
                     result_tx,
-                    skill_references: req.skill_references,
-                    flow_tool_overlay: req.flow_tool_overlay,
-                    execution_kind: None,
+                    skill_references,
+                    flow_tool_overlay,
+                    execution_kind,
                 })
                 .await
                 .map_err(|_| {
@@ -2680,7 +2715,7 @@ async fn session_task<A: SessionAgent>(
                         &source_id,
                         AgentEvent::RunStarted {
                             session_id: session_id.clone(),
-                            prompt,
+                            prompt: ContentInput::Text(prompt),
                         },
                     );
                     let _ = control.session_event_tx.send(started);

--- a/meerkat-session/src/persistent.rs
+++ b/meerkat-session/src/persistent.rs
@@ -643,12 +643,16 @@ impl<B: SessionAgentBuilder + 'static> PersistentSessionService<B> {
             return Ok(false);
         };
 
-        let stored_is_newer = stored.updated_at() > live.updated_at()
-            || (stored.updated_at() == live.updated_at()
-                && stored.messages().len() > live.messages().len());
+        let stored_has_more_transcript = stored.messages().len() > live.messages().len();
         let stored_is_archived = metadata_marks_archived(stored.metadata());
 
-        if !stored_is_newer && !stored_is_archived {
+        // A durable snapshot timestamp is a projection witness, not live-session
+        // authority. Runtime commits can normalize/persist an equivalent
+        // transcript a few microseconds after the live session updates itself;
+        // evicting the live handle on timestamp alone drops mechanical runtime
+        // resources such as comms. Only terminal archive state or a strictly
+        // longer durable transcript can evict the live session.
+        if !stored_has_more_transcript && !stored_is_archived {
             return Ok(false);
         }
 
@@ -4368,6 +4372,48 @@ mod tests {
                 .contains("stored-session recovery via non-canonical runtime-binding providers has been deleted"),
             "unexpected error: {error}"
         );
+    }
+
+    #[tokio::test]
+    async fn test_metadata_only_projection_does_not_discard_live_session() {
+        let store: Arc<dyn SessionStore> = Arc::new(MemoryStore::new());
+        let service = PersistentSessionService::new(
+            DummyBuilder,
+            4,
+            Arc::clone(&store),
+            None,
+            memory_blob_store(),
+        );
+
+        let created = service
+            .create_session(create_request("hello", InitialTurnPolicy::Defer))
+            .await
+            .expect("create deferred session");
+        let id = created.session_id;
+
+        let mut projected = service
+            .export_live_session(&id)
+            .await
+            .expect("live session should export");
+        projected.set_metadata("projection_only", serde_json::json!(true));
+        store
+            .save(&projected)
+            .await
+            .expect("projection snapshot should save");
+
+        let discarded = service
+            .discard_stale_live_session_if_needed(&id)
+            .await
+            .expect("discard check should succeed");
+
+        assert!(
+            !discarded,
+            "metadata/timestamp-only durable projection must not evict live runtime mechanics"
+        );
+        service
+            .export_live_session(&id)
+            .await
+            .expect("live session should remain available");
     }
 
     #[tokio::test]

--- a/meerkat-session/src/persistent.rs
+++ b/meerkat-session/src/persistent.rs
@@ -639,12 +639,7 @@ impl<B: SessionAgentBuilder + 'static> PersistentSessionService<B> {
             Err(err) => return Err(err),
         };
 
-        let Some(stored) = self
-            .store
-            .load(id)
-            .await
-            .map_err(|e| SessionError::Store(Box::new(e)))?
-        else {
+        let Some(stored) = self.load_authoritative_session_base(id).await? else {
             return Ok(false);
         };
 
@@ -1049,6 +1044,12 @@ impl<B: SessionAgentBuilder + 'static> PersistentSessionService<B> {
                     args,
                 )
             }
+            Some(CoreApplyTerminal::NoPendingBoundary) => CoreApplyOutput {
+                receipt,
+                session_snapshot: Some(session_snapshot),
+                run_result: None,
+                terminal: Some(CoreApplyTerminal::NoPendingBoundary),
+            },
             None => CoreApplyOutput::without_terminal(receipt, Some(session_snapshot)),
         };
 
@@ -1095,11 +1096,14 @@ impl<B: SessionAgentBuilder + 'static> PersistentSessionService<B> {
                 Ok((run_result, output))
             }
             Err(SessionError::Agent(meerkat_core::error::AgentError::NoPendingBoundary)) => {
-                // ResumePending with no boundary — no-op through canonical path.
-                // Callers (CLI, RPC) discard the RunResult — this is a legacy
-                // placeholder.
                 let output = self
-                    .build_runtime_output(id, run_id, boundary, contributing_input_ids, None)
+                    .build_runtime_output(
+                        id,
+                        run_id,
+                        boundary,
+                        contributing_input_ids,
+                        Some(CoreApplyTerminal::NoPendingBoundary),
+                    )
                     .await?;
                 let noop_result = RunResult {
                     text: String::new(),
@@ -1138,9 +1142,14 @@ impl<B: SessionAgentBuilder + 'static> PersistentSessionService<B> {
                 .await
             }
             Err(SessionError::Agent(meerkat_core::error::AgentError::NoPendingBoundary)) => {
-                // ResumePending with no boundary — no-op through canonical path.
-                self.build_runtime_output(id, run_id, boundary, contributing_input_ids, None)
-                    .await
+                self.build_runtime_output(
+                    id,
+                    run_id,
+                    boundary,
+                    contributing_input_ids,
+                    Some(CoreApplyTerminal::NoPendingBoundary),
+                )
+                .await
             }
             Err(error) => {
                 if let Some(terminal) = Self::callback_pending_terminal(&error) {
@@ -2484,11 +2493,10 @@ mod tests {
             event_tx: tokio::sync::mpsc::Sender<meerkat_core::event::AgentEvent>,
         ) -> Result<RunResult, meerkat_core::error::AgentError> {
             let session_id = self.inner.session_id();
-            let prompt_text = prompt.text_content();
             let _ = event_tx
                 .send(AgentEvent::RunStarted {
                     session_id: session_id.clone(),
-                    prompt: prompt_text,
+                    prompt: prompt.clone(),
                 })
                 .await;
             let result = self.inner.run_with_events(prompt, event_tx.clone()).await?;
@@ -3138,6 +3146,8 @@ mod tests {
             event_tx: None,
             skill_references: None,
             flow_tool_overlay: None,
+            turn_metadata: None,
+            execution_kind: None,
         }
     }
 
@@ -3153,6 +3163,8 @@ mod tests {
             event_tx: None,
             skill_references: None,
             flow_tool_overlay: None,
+            turn_metadata: None,
+            execution_kind: None,
         }
     }
 
@@ -4406,14 +4418,14 @@ mod tests {
             .expect("run_started event should exist");
         match started.payload {
             AgentEvent::RunStarted { prompt, .. } => {
-                let normalized = prompt.to_lowercase();
+                let normalized = prompt.text_content().to_lowercase();
                 assert!(
                     normalized.contains("peer_response_terminal:analyst-rt:req-123"),
-                    "run_started prompt should expose runtime system-context source: {prompt}"
+                    "run_started prompt should expose runtime system-context source: {normalized}"
                 );
                 assert!(
                     normalized.contains("birch seventeen"),
-                    "run_started prompt should expose authoritative terminal peer payload: {prompt}"
+                    "run_started prompt should expose authoritative terminal peer payload: {normalized}"
                 );
             }
             other => panic!("expected run_started, got {other:?}"),

--- a/meerkat-session/src/projector.rs
+++ b/meerkat-session/src/projector.rs
@@ -300,7 +300,7 @@ mod tests {
             &[
                 AgentEvent::RunStarted {
                     session_id: sid.clone(),
-                    prompt: "Hello".to_string(),
+                    prompt: meerkat_core::ContentInput::Text("Hello".to_string()),
                 },
                 AgentEvent::TextComplete {
                     content: "Hi there!".to_string(),

--- a/meerkat-session/tests/ephemeral_contract.rs
+++ b/meerkat-session/tests/ephemeral_contract.rs
@@ -67,7 +67,7 @@ impl SessionAgent for MockAgent {
         let _ = event_tx
             .send(AgentEvent::RunStarted {
                 session_id: self.session_id.clone(),
-                prompt: "test".to_string(),
+                prompt: meerkat_core::ContentInput::Text("test".to_string()),
             })
             .await;
 
@@ -808,6 +808,8 @@ fn turn_req(prompt: &str) -> StartTurnRequest {
         event_tx: None,
         skill_references: None,
         flow_tool_overlay: None,
+        turn_metadata: None,
+        execution_kind: None,
     }
 }
 
@@ -1442,6 +1444,50 @@ async fn test_apply_runtime_turn_returns_callback_pending_terminal() -> Result<(
     };
     assert_eq!(tool_name, "external_mock");
     assert_eq!(args, json!({ "value": "browser" }));
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_apply_runtime_turn_resume_pending_no_boundary_is_typed_terminal() -> Result<(), String>
+{
+    let service = make_service(MockAgentBuilder::new());
+    let _ = service
+        .create_session(create_req_deferred("Hello"))
+        .await
+        .expect("create deferred session");
+    let session_id = service
+        .list(SessionQuery::default())
+        .await
+        .expect("list sessions")[0]
+        .session_id
+        .clone();
+    let run_id = meerkat_core::lifecycle::RunId::new();
+    let contributing_input_ids = vec![meerkat_core::lifecycle::InputId::new()];
+    let mut req = turn_req("");
+    req.execution_kind = Some(meerkat_core::lifecycle::RuntimeExecutionKind::ResumePending);
+
+    let output = service
+        .apply_runtime_turn(
+            &session_id,
+            run_id.clone(),
+            req,
+            RunApplyBoundary::RunStart,
+            contributing_input_ids.clone(),
+        )
+        .await
+        .expect("runtime apply should surface no-pending as terminal");
+
+    assert_eq!(output.receipt.run_id, run_id);
+    assert_eq!(
+        output.receipt.contributing_input_ids,
+        contributing_input_ids
+    );
+    assert!(output.session_snapshot.is_some());
+    assert!(output.run_result.is_none());
+    assert!(matches!(
+        output.terminal,
+        Some(CoreApplyTerminal::NoPendingBoundary)
+    ));
     Ok(())
 }
 

--- a/meerkat-session/tests/regression_lifecycle.rs
+++ b/meerkat-session/tests/regression_lifecycle.rs
@@ -79,6 +79,7 @@ impl SessionAgent for MockAgent {
             let _ = event_tx
                 .send(AgentEvent::RunFailed {
                     session_id: self.session_id.clone(),
+                    error_class: meerkat_core::event::AgentErrorClass::Internal,
                     error: "simulated failure".to_string(),
                 })
                 .await;
@@ -90,7 +91,7 @@ impl SessionAgent for MockAgent {
         let _ = event_tx
             .send(AgentEvent::RunStarted {
                 session_id: self.session_id.clone(),
-                prompt: "test".to_string(),
+                prompt: meerkat_core::ContentInput::Text("test".to_string()),
             })
             .await;
 
@@ -597,6 +598,8 @@ fn turn_req(prompt: &str) -> StartTurnRequest {
         event_tx: None,
         skill_references: None,
         flow_tool_overlay: None,
+        turn_metadata: None,
+        execution_kind: None,
     }
 }
 
@@ -1174,6 +1177,8 @@ async fn start_turn_forwards_handling_mode_and_render_metadata() {
                 event_tx: None,
                 skill_references: None,
                 flow_tool_overlay: None,
+                turn_metadata: None,
+                execution_kind: None,
             },
         )
         .await

--- a/meerkat-web-runtime/src/lib.rs
+++ b/meerkat-web-runtime/src/lib.rs
@@ -1491,6 +1491,8 @@ pub async fn start_turn(handle: u32, prompt: &str) -> Result<JsValue, JsValue> {
                 event_tx: None,
                 skill_references: None,
                 flow_tool_overlay: None,
+                turn_metadata: None,
+                execution_kind: None,
             },
         )
         .await;

--- a/meerkat/src/surface/runtime_backed.rs
+++ b/meerkat/src/surface/runtime_backed.rs
@@ -2,7 +2,7 @@ use std::sync::Arc;
 
 use meerkat_core::lifecycle::core_executor::{CoreApplyOutput, CoreExecutor, CoreExecutorError};
 use meerkat_core::lifecycle::run_control::RunControlCommand;
-use meerkat_core::lifecycle::run_primitive::{CoreRenderable, RunPrimitive, RuntimeTurnMetadata};
+use meerkat_core::lifecycle::run_primitive::{CoreRenderable, RunPrimitive};
 use meerkat_core::service::SessionService;
 use meerkat_core::types::HandlingMode;
 use meerkat_runtime::meerkat_machine::RuntimeBindingsError;
@@ -178,44 +178,10 @@ fn pending_system_context_appends(
     )
 }
 
-fn unsupported_runtime_metadata_fields(metadata: &RuntimeTurnMetadata) -> Vec<&'static str> {
-    let mut fields = Vec::new();
-    if metadata.model.is_some() {
-        fields.push("model");
-    }
-    if metadata.provider.is_some() {
-        fields.push("provider");
-    }
-    if metadata.provider_params.is_some() {
-        fields.push("provider_params");
-    }
-    if metadata.connection_ref.is_some() {
-        fields.push("connection_ref");
-    }
-    if metadata.keep_alive.is_some() {
-        fields.push("keep_alive");
-    }
-    if metadata.additional_instructions.is_some() {
-        fields.push("additional_instructions");
-    }
-    fields
-}
-
 fn start_turn_request_from_primitive(
     primitive: &RunPrimitive,
 ) -> Result<meerkat_core::service::StartTurnRequest, CoreExecutorError> {
     let metadata = primitive.turn_metadata();
-    if let Some(metadata) = metadata {
-        let unsupported = unsupported_runtime_metadata_fields(metadata);
-        if !unsupported.is_empty() {
-            return Err(CoreExecutorError::ApplyFailed {
-                reason: format!(
-                    "runtime-backed apply cannot yet project {} through StartTurnRequest; refusing to drop canonical RuntimeTurnMetadata fields",
-                    unsupported.join(", ")
-                ),
-            });
-        }
-    }
 
     Ok(meerkat_core::service::StartTurnRequest {
         prompt: primitive.extract_content_input(),
@@ -227,6 +193,8 @@ fn start_turn_request_from_primitive(
         event_tx: None,
         skill_references: metadata.and_then(|metadata| metadata.skill_references.clone()),
         flow_tool_overlay: metadata.and_then(|metadata| metadata.flow_tool_overlay.clone()),
+        turn_metadata: metadata.cloned(),
+        execution_kind: metadata.and_then(|metadata| metadata.execution_kind),
     })
 }
 
@@ -336,6 +304,7 @@ mod tests {
     use async_trait::async_trait;
     use meerkat_client::TestClient;
     use meerkat_core::SessionBuildOptions;
+    use meerkat_core::lifecycle::run_primitive::RuntimeTurnMetadata;
     #[cfg(all(
         feature = "openai",
         feature = "openai-realtime",
@@ -379,6 +348,39 @@ mod tests {
         not(target_arch = "wasm32")
     ))]
     use meerkat_runtime::{RealtimeAttachmentStatus, SessionServiceRuntimeExt};
+
+    #[test]
+    fn run_primitive_carries_runtime_metadata_into_start_turn_request() {
+        let metadata = RuntimeTurnMetadata {
+            execution_kind: Some(meerkat_core::lifecycle::RuntimeExecutionKind::ResumePending),
+            model: Some(meerkat_core::lifecycle::run_primitive::ModelId::new(
+                "model-from-runtime",
+            )),
+            ..Default::default()
+        };
+        let primitive =
+            RunPrimitive::StagedInput(meerkat_core::lifecycle::run_primitive::StagedRunInput {
+                boundary: meerkat_core::lifecycle::run_primitive::RunApplyBoundary::RunStart,
+                appends: vec![meerkat_core::lifecycle::run_primitive::ConversationAppend {
+                    role: meerkat_core::lifecycle::run_primitive::ConversationAppendRole::User,
+                    content: CoreRenderable::Text {
+                        text: "hello".to_string(),
+                    },
+                }],
+                context_appends: Vec::new(),
+                contributing_input_ids: vec![meerkat_core::lifecycle::InputId::new()],
+                turn_metadata: Some(metadata.clone()),
+            });
+
+        let req = start_turn_request_from_primitive(&primitive)
+            .expect("metadata should be carried, not rejected");
+
+        assert_eq!(req.turn_metadata, Some(metadata));
+        assert_eq!(
+            req.execution_kind,
+            Some(meerkat_core::lifecycle::RuntimeExecutionKind::ResumePending)
+        );
+    }
 
     fn make_request(build: SessionBuildOptions) -> CreateSessionRequest {
         CreateSessionRequest {

--- a/meerkat/tests/live_meerkat_regression.rs
+++ b/meerkat/tests/live_meerkat_regression.rs
@@ -116,6 +116,8 @@ mod scenario_22_session_service_lifecycle {
 
                     skill_references: None,
                     flow_tool_overlay: None,
+                    turn_metadata: None,
+                    execution_kind: None,
                 },
             )
             .await

--- a/meerkat/tests/live_meerkat_user_flows.rs
+++ b/meerkat/tests/live_meerkat_user_flows.rs
@@ -834,7 +834,7 @@ mod budget_exhaustion {
 
         // Verify agent is in valid state
         assert!(
-            agent.state().is_terminal() || *agent.state() == LoopState::CallingLlm,
+            agent.state().is_terminal() || agent.state() == LoopState::CallingLlm,
             "Agent should be in valid state"
         );
     }

--- a/meerkat/tests/smoke_meerkat_sdk.rs
+++ b/meerkat/tests/smoke_meerkat_sdk.rs
@@ -1221,6 +1221,8 @@ mod scenario_09_session_service {
 
             skill_references: None,
             flow_tool_overlay: None,
+            turn_metadata: None,
+            execution_kind: None,
         };
 
         let turn_result = service
@@ -1684,6 +1686,8 @@ mod scenario_22_runtime_host_comms {
                 event_tx: None,
                 skill_references: None,
                 flow_tool_overlay: None,
+                turn_metadata: None,
+                execution_kind: None,
             };
 
             let result = self

--- a/sdks/python/meerkat/events.py
+++ b/sdks/python/meerkat/events.py
@@ -26,6 +26,8 @@ from __future__ import annotations
 from dataclasses import dataclass, field
 from typing import Any
 
+ContentInput = str | list[dict[str, Any]]
+
 
 # ---------------------------------------------------------------------------
 # Shared value types (also re-exported from types.py)
@@ -63,7 +65,7 @@ class RunStarted(Event):
     """Agent run has started."""
 
     session_id: str = ""
-    prompt: str = ""
+    prompt: ContentInput = ""
 
 
 @dataclass(frozen=True, slots=True)
@@ -80,6 +82,7 @@ class RunFailed(Event):
     """Agent run failed."""
 
     session_id: str = ""
+    error_class: str = ""
     error: str = ""
 
 

--- a/sdks/typescript/src/events.ts
+++ b/sdks/typescript/src/events.ts
@@ -25,6 +25,7 @@
  */
 
 import { Buffer } from "node:buffer";
+import type { ContentInput } from "./types.js";
 
 // ---------------------------------------------------------------------------
 // Shared value types
@@ -126,7 +127,7 @@ export interface ScopedAgentEvent {
 export interface RunStartedEvent {
   readonly type: "run_started";
   readonly sessionId: string;
-  readonly prompt: string;
+  readonly prompt: ContentInput;
 }
 
 export interface RunCompletedEvent {
@@ -139,6 +140,7 @@ export interface RunCompletedEvent {
 export interface RunFailedEvent {
   readonly type: "run_failed";
   readonly sessionId: string;
+  readonly errorClass: string;
   readonly error: string;
 }
 
@@ -455,6 +457,11 @@ function parseUsage(raw: Record<string, unknown> | undefined): Usage {
   };
 }
 
+function parseContentInput(raw: unknown): ContentInput {
+  if (Array.isArray(raw)) return raw as ContentInput;
+  return String(raw ?? "");
+}
+
 /**
  * Parse a raw wire event dict into a typed {@link StreamEvent}.
  *
@@ -513,11 +520,11 @@ export function parseCoreEvent(raw: Record<string, unknown>): AgentEvent {
   switch (type) {
     // Session lifecycle
     case "run_started":
-      return { type, sessionId: String(raw.session_id ?? ""), prompt: String(raw.prompt ?? "") };
+      return { type, sessionId: String(raw.session_id ?? ""), prompt: parseContentInput(raw.prompt) };
     case "run_completed":
       return { type, sessionId: String(raw.session_id ?? ""), result: String(raw.result ?? ""), usage: parseUsage(raw.usage as Record<string, unknown>) };
     case "run_failed":
-      return { type, sessionId: String(raw.session_id ?? ""), error: String(raw.error ?? "") };
+      return { type, sessionId: String(raw.session_id ?? ""), errorClass: String(raw.error_class ?? ""), error: String(raw.error ?? "") };
 
     // Turn / LLM
     case "turn_started":

--- a/sdks/web/src/generated/events.ts
+++ b/sdks/web/src/generated/events.ts
@@ -1,6 +1,8 @@
 // Generated raw event types for @rkat/web
 // Source: artifacts/schemas/events.json
 
+import type { ContentInput } from "../types";
+
 export type BudgetType = "tokens" | "time" | "tool_calls";
 
 export interface DeferredCatalogDelta {
@@ -82,7 +84,7 @@ export type Usage = {
 };
 
 export interface RunStartedEvent {
-  prompt: string;
+  prompt: ContentInput;
   session_id: SessionId;
   type: "run_started";
 }
@@ -96,6 +98,7 @@ export interface RunCompletedEvent {
 
 export interface RunFailedEvent {
   error: string;
+  error_class: string;
   session_id: SessionId;
   type: "run_failed";
 }

--- a/sdks/web/tests/types.test.ts
+++ b/sdks/web/tests/types.test.ts
@@ -46,10 +46,9 @@ const fullConfig: RuntimeConfig = {
 
 const sessionConfig: SessionConfig = {
   model: 'claude-sonnet-4-5',
-  apiKey: 'sk-test',
+  connectionRef: 'default:anthropic',
   systemPrompt: 'You are helpful.',
   maxTokens: 1024,
-  anthropicBaseUrl: 'https://proxy.example.com/anthropic',
   labels: { env: 'test' },
   additionalInstructions: ['Be concise.'],
 };
@@ -116,7 +115,9 @@ const spawnSpec: SpawnSpec = {
 function handleEvent(event: AgentEvent): string {
   switch (event.type) {
     case 'run_started':
-      return event.prompt;
+      return typeof event.prompt === 'string'
+        ? event.prompt
+        : event.prompt.map((block) => (block.type === 'text' ? block.text : '')).join('');
     case 'hook_started':
       return `${event.hook_id}:${event.point}`;
     case 'hook_completed':

--- a/specs/compositions/meerkat_mob_seam/model.tla
+++ b/specs/compositions/meerkat_mob_seam/model.tla
@@ -3244,7 +3244,7 @@ meerkat_RecycleFromIdleOrRetired ==
        /\ packet.variant = "Recycle"
        /\ ~HigherPriorityReady("meerkat_kernel")
        /\ meerkat_phase = "Idle" \/ meerkat_phase = "Retired"
-       /\ (meerkat_active_runtime_id # None)
+       /\ (meerkat_session_id # None)
        /\ meerkat_phase' = "Idle"
        /\ meerkat_active_fence_token' = None
        /\ meerkat_current_run_id' = None
@@ -3265,7 +3265,7 @@ meerkat_RecycleFromAttached ==
        /\ packet.variant = "Recycle"
        /\ ~HigherPriorityReady("meerkat_kernel")
        /\ meerkat_phase = "Attached"
-       /\ (meerkat_active_runtime_id # None)
+       /\ (meerkat_session_id # None)
        /\ meerkat_phase' = "Attached"
        /\ meerkat_active_fence_token' = None
        /\ meerkat_current_run_id' = None
@@ -12592,8 +12592,8 @@ EntryPacketAdmissible_meerkat(packet) ==
     \/ /\ (packet.variant = "PendingFailed") /\ (meerkat_phase = "Running") /\ ((meerkat_session_id # None))
     \/ /\ (packet.variant = "SnapshotAligned") /\ (meerkat_phase = "Attached") /\ ((meerkat_session_id # None))
     \/ /\ (packet.variant = "SnapshotAligned") /\ (meerkat_phase = "Running") /\ ((meerkat_session_id # None))
-    \/ /\ (packet.variant = "Recycle") /\ (meerkat_phase = "Idle" \/ meerkat_phase = "Retired") /\ ((meerkat_active_runtime_id # None))
-    \/ /\ (packet.variant = "Recycle") /\ (meerkat_phase = "Attached") /\ ((meerkat_active_runtime_id # None))
+    \/ /\ (packet.variant = "Recycle") /\ (meerkat_phase = "Idle" \/ meerkat_phase = "Retired") /\ ((meerkat_session_id # None))
+    \/ /\ (packet.variant = "Recycle") /\ (meerkat_phase = "Attached") /\ ((meerkat_session_id # None))
     \/ /\ (packet.variant = "ProjectRealtimeIntent") /\ (meerkat_phase = "Idle") /\ ((meerkat_session_id # None))
     \/ /\ (packet.variant = "ProjectRealtimeIntent") /\ (meerkat_phase = "Attached") /\ ((meerkat_session_id # None))
     \/ /\ (packet.variant = "ProjectRealtimeIntent") /\ (meerkat_phase = "Running") /\ ((meerkat_session_id # None))

--- a/specs/machines/meerkat_machine/contract.md
+++ b/specs/machines/meerkat_machine/contract.md
@@ -1297,7 +1297,7 @@ _Generated from the Rust machine catalog. Do not edit by hand._
 - From: `Idle`, `Retired`
 - On: `Recycle`()
 - Guards:
-  - `runtime_is_bound`
+  - `session_registered`
 - Emits: `InitiateRecycle`
 - To: `Idle`
 
@@ -1305,7 +1305,7 @@ _Generated from the Rust machine catalog. Do not edit by hand._
 - From: `Attached`
 - On: `Recycle`()
 - Guards:
-  - `runtime_is_bound`
+  - `session_registered`
 - Emits: `InitiateRecycle`
 - To: `Attached`
 

--- a/specs/machines/meerkat_machine/model.tla
+++ b/specs/machines/meerkat_machine/model.tla
@@ -1299,7 +1299,7 @@ ShutdownSurfaceRunning ==
 
 RecycleFromIdleOrRetired ==
     /\ phase = "Idle" \/ phase = "Retired"
-    /\ (active_runtime_id # None)
+    /\ (session_id # None)
     /\ phase' = "Idle"
     /\ model_step_count' = model_step_count + 1
     /\ active_fence_token' = None
@@ -1309,7 +1309,7 @@ RecycleFromIdleOrRetired ==
 
 RecycleFromAttached ==
     /\ phase = "Attached"
-    /\ (active_runtime_id # None)
+    /\ (session_id # None)
     /\ phase' = "Attached"
     /\ model_step_count' = model_step_count + 1
     /\ active_fence_token' = None

--- a/tests/integration/src/e2e_lanes.rs
+++ b/tests/integration/src/e2e_lanes.rs
@@ -113,38 +113,50 @@ async fn run_spec(spec: &'static Spec) -> Result<(), String> {
     }
 
     let cwd = workspace_root().join(spec.cwd);
-    let env_overrides = scenario_env(spec)?;
+    let scenario_target_dir = scenario_cargo_target_dir(spec)?;
+    let env_overrides = match scenario_env(spec, &scenario_target_dir) {
+        Ok(env_overrides) => env_overrides,
+        Err(error) => {
+            clean_scenario_target_dir_if_requested(spec, &scenario_target_dir);
+            return Err(error);
+        }
+    };
     let (pre_commands, command, output_policy) = build_commands(spec);
 
-    for pre_command in pre_commands {
-        run_pre_command(
-            CommandEntry {
-                spec,
-                command: pre_command,
-            },
-            &cwd,
-            &env_overrides,
-        )
-        .await?;
+    let result = async {
+        for pre_command in pre_commands {
+            run_pre_command(
+                CommandEntry {
+                    spec,
+                    command: pre_command,
+                },
+                &cwd,
+                &env_overrides,
+            )
+            .await?;
+        }
+
+        // macOS 26.3.1+ `codeSigningMonitor=2` SIGKILLs adhoc/linker-signed
+        // binaries whose content hash was invalidated after signing (which
+        // happens when any cargo invocation re-links between scenario runs).
+        // Re-sign every `CARGO_BIN_EXE_*` binary with a fresh adhoc signature
+        // so the scenario can `exec` them cleanly. No-op on non-macOS.
+        ensure_binary_signatures_fresh(spec, &env_overrides).await;
+
+        let completed = run_command(command, &cwd, &env_overrides, spec.timeout_secs).await?;
+        if let Some(problem) = analyze_success_output(output_policy, &completed.output) {
+            return Err(format!(
+                "{}: {} ({problem})",
+                run_label(spec),
+                command_display(command)
+            ));
+        }
+
+        Ok(())
     }
-
-    // macOS 26.3.1+ `codeSigningMonitor=2` SIGKILLs adhoc/linker-signed
-    // binaries whose content hash was invalidated after signing (which
-    // happens when any cargo invocation re-links between scenario runs).
-    // Re-sign every `CARGO_BIN_EXE_*` binary with a fresh adhoc signature
-    // so the scenario can `exec` them cleanly. No-op on non-macOS.
-    ensure_binary_signatures_fresh(spec, &env_overrides).await;
-
-    let completed = run_command(command, &cwd, &env_overrides, spec.timeout_secs).await?;
-    if let Some(problem) = analyze_success_output(output_policy, &completed.output) {
-        return Err(format!(
-            "{}: {} ({problem})",
-            run_label(spec),
-            command_display(command)
-        ));
-    }
-
-    Ok(())
+    .await;
+    clean_scenario_target_dir_if_requested(spec, &scenario_target_dir);
+    result
 }
 
 #[allow(clippy::await_holding_lock)] // Lock is explicitly dropped before await
@@ -454,9 +466,8 @@ fn prereq_failure(spec: &Spec) -> Option<String> {
     }
 }
 
-fn scenario_env(spec: &Spec) -> Result<Vec<(String, String)>, String> {
+fn scenario_env(spec: &Spec, cargo_target_dir: &Path) -> Result<Vec<(String, String)>, String> {
     let mut env = BTreeMap::new();
-    let cargo_target_dir = scenario_cargo_target_dir(spec)?;
     std::fs::create_dir_all(&cargo_target_dir).map_err(|error| {
         format!(
             "failed to create scenario cargo target dir {}: {error}",
@@ -512,6 +523,19 @@ fn scenario_env(spec: &Spec) -> Result<Vec<(String, String)>, String> {
         env.insert("MEERKAT_PYTHON_BIN".to_string(), python.to_string());
     }
     Ok(env.into_iter().collect())
+}
+
+fn clean_scenario_target_dir_if_requested(spec: &Spec, cargo_target_dir: &Path) {
+    if !clean_e2e_scenario_targets_enabled() || !cargo_target_dir.exists() {
+        return;
+    }
+    if let Err(error) = std::fs::remove_dir_all(cargo_target_dir) {
+        eprintln!(
+            "failed to clean e2e scenario target for {} at {}: {error}",
+            run_label(spec),
+            cargo_target_dir.display()
+        );
+    }
 }
 
 fn scenario_cargo_target_dir(spec: &Spec) -> Result<PathBuf, String> {
@@ -740,6 +764,13 @@ fn cargo_target_dir() -> Result<PathBuf, String> {
 fn strict_prereqs_enabled() -> bool {
     matches!(
         std::env::var("MEERKAT_STRICT_E2E_PREREQS").as_deref(),
+        Ok("1") | Ok("true") | Ok("TRUE") | Ok("yes") | Ok("YES")
+    )
+}
+
+fn clean_e2e_scenario_targets_enabled() -> bool {
+    matches!(
+        std::env::var("MEERKAT_CLEAN_E2E_SCENARIO_TARGETS").as_deref(),
         Ok("1") | Ok("true") | Ok("TRUE") | Ok("yes") | Ok("YES")
     )
 }

--- a/tests/integration/src/e2e_lanes.rs
+++ b/tests/integration/src/e2e_lanes.rs
@@ -468,7 +468,7 @@ fn prereq_failure(spec: &Spec) -> Option<String> {
 
 fn scenario_env(spec: &Spec, cargo_target_dir: &Path) -> Result<Vec<(String, String)>, String> {
     let mut env = BTreeMap::new();
-    std::fs::create_dir_all(&cargo_target_dir).map_err(|error| {
+    std::fs::create_dir_all(cargo_target_dir).map_err(|error| {
         format!(
             "failed to create scenario cargo target dir {}: {error}",
             cargo_target_dir.display()
@@ -502,10 +502,7 @@ fn scenario_env(spec: &Spec, cargo_target_dir: &Path) -> Result<Vec<(String, Str
     env.entry("RUST_MIN_STACK".to_string())
         .or_insert_with(|| (16 * 1024 * 1024).to_string());
     for (key, value) in spec.env {
-        env.insert(
-            (*key).to_string(),
-            expand_template(value, &cargo_target_dir),
-        );
+        env.insert((*key).to_string(), expand_template(value, cargo_target_dir));
     }
     for binary in spec.cargo_bin_env {
         env.insert(


### PR DESCRIPTION
## Summary

Implements PR 3 runtime/session authority cleanup and the follow-up root-cause fixes from live/smoke validation:

- carries `RuntimeTurnMetadata` and execution intent through `StartTurnRequest` instead of dropping or re-inferring it
- makes batch turn-metadata conflicts typed terminal failures in the runtime loop
- moves peer response semantic projection to the typed runtime input boundary
- removes the writable `Agent.state: LoopState` shadow; public loop state is derived from turn authority snapshots
- returns typed `NoPendingBoundary` terminals for resume-pending paths without a boundary
- routes run-started/run-failed, retry attempts/exhaustion, budget exhaustion, and MCP pending notices through typed authority/event shapes; `retry.rs` and `budget.rs` remain policy/check modules, not authorities
- replays recovered terminal runtime state through machine transitions and stages `PrepareBindings` before projection
- splits local session resource preparation from authoritative runtime binding, so mob provisioning can create handle bundles without publishing fallback readiness
- stops registration from seeding `active_runtime_id`; only `PrepareBindings` claims the runtime identity/fence
- treats durable session timestamps as projection witnesses, not authority to evict live runtime mechanics
- forwards the new request/event shape across CLI, REST, RPC, MCP, Mob MCP, WASM, examples, and SDKs
- adds CI `E2E smoke lane` and `E2E live lane` jobs, with `wasm-pack` installed through `taiki-e/install-action` and per-scenario target cleanup enabled

## Root Cause Map

The smoke pictionary failure was not a one-off timeout. It exposed a semantic ownership leak:

1. `SessionBackend::provision_member` called public `prepare_bindings()` while MobMachine had not yet committed the member runtime id/fence.
2. `prepare_bindings()` both created session-local handles and applied Meerkat `PrepareBindings`, so it emitted `RuntimeBound` with the bridge session id/fence `0` as fallback runtime identity.
3. MobMachine correctly rejected that `ObserveRuntimeReady`, because the id/fence were not the mob-owned live member runtime identity.
4. Adjacent leak: session registration itself pre-seeded `active_runtime_id` from the session id, making an unbound registered session look bound to downstream guards.
5. Adjacent leak: persistent session reconciliation evicted live sessions on durable timestamp freshness alone, even when the durable snapshot carried only equivalent transcript plus metadata/projection updates. That dropped live comms/runtime mechanics during mob mesh setup.

The root fix is to keep authority facts single-owned:

- local session resources are now prepared with `PrepareLocalSessionBindings`, which returns the handle bundle without applying `PrepareBindings` or emitting cross-machine readiness
- mob startup flushes the routed `RequestRuntimeBinding -> PrepareBindings` effect before starting the member runtime, so readiness is published only with the mob-owned id/fence
- new registered sessions remain unbound until `PrepareBindings` claims `active_runtime_id` and `active_fence_token`
- persistent snapshots can evict a live session only for terminal archive state or a strictly longer durable transcript, not for timestamp-only projection freshness

## Scope Expansion

- CI wasm-pack setup: integration-fast previously failed before tests ran because the raw rustwasm installer received a GitHub 502 fetching the `wasm-pack` release tarball. CI now uses `taiki-e/install-action@v2` for `wasm-pack`, matching the WASM contract lane.
- CI coverage: added explicit `E2E smoke lane` and `E2E live lane` jobs so these previously sidecar lanes run before merge.
- E2E disk pressure: live/smoke scenarios can build separate target trees; `MEERKAT_CLEAN_E2E_SCENARIO_TARGETS=1` cleans each scenario target after completion in CI.
- Mob/session authority: smoke validation found the local-resource-vs-authoritative-binding split and timestamp-only live eviction issue described above.

## Per-PR Merge Gate

- [x] Row 1 — Runtime-loop peer-response projection: mapping moved from `runtime_loop.rs` into typed runtime input classification.
- [x] Row 2 — LoopState shadow: writable `Agent.state` removed; loop dispatch and public state derive from turn authority snapshots.
- [x] Row 3 — Turn-override carrier: `RuntimeTurnMetadata` threads through `StartTurnRequest`.
- [x] Row 4 — Raw session-store rows: runtime-backed session reads prefer authoritative runtime snapshots; store rows remain durable backing/metadata repair only.
- [x] Row 5 — Recovery re-seeds DSL from projection: recovery stages typed inputs through the machine; shell projection is witness state.
- [x] Row 22 — Persistent lifecycle/control shadow: production dispatch paths stage/preview authority before driver projection and project only after accepted/successful authority transitions.
- [x] Row 38 — ResumePending no-boundary: `NoPendingBoundary` is a typed terminal class.
- [x] Row 59 — Run lifecycle text erasure: `RunStarted` carries typed `ContentInput`; `RunFailed` carries typed `AgentErrorClass`.
- [x] Row 60 — LLM retry visibility: retry attempts/exhaustion route through turn-state inputs/events; retry policy remains pure policy.
- [x] Row 61 — MCP pending shell fallback: pending notices come from the lifecycle handle; `ext.pending` shell fallback is removed.
- [x] Row 62 — Ephemeral mob runtime terminal: successful ephemeral runtime turns return typed `RunResult` terminal output.
- [x] Row 69 — Batch metadata conflicts: conflicts return typed `TurnMetadataMergeConflict` errors instead of defaulting.
- [x] Row 70 — Runtime execution kind: execution kind forwards through `StartTurnRequest`.
- [x] Row 71 — Budget terminal truth: budget/time-budget exhaustion routes through machine inputs/effects.
- [x] Row 72 — PrepareBindings ordering: binding preparation stages authority before projection.

## Downstream Propagation Audit

- CLI/REST/RPC/MCP/Mob MCP: request construction updated for `turn_metadata` and `execution_kind` carriers.
- Runtime/session/mob services: typed terminal and run-result paths forwarded through ephemeral, persistent, and mob runtime services.
- Mob runtime provisioning: local handle preparation no longer publishes binding readiness; mob-owned routed binding is the sole readiness authority.
- WASM/web runtime: generated/event surfaces updated for typed run lifecycle event payloads.
- Python/TypeScript/Web SDKs: event typings updated for typed prompt/error payloads and parity tests adjusted.
- Examples/tests: examples and regression tests updated for the new request/event shapes.
- CI/release: wasm-pack install path aligned and live/smoke e2e lanes added to PR CI.

## Validation

- `cargo fmt --check`
- `ruby -e 'require "yaml"; YAML.load_file(ARGV[0]); puts "ok #{ARGV[0]}"' .github/workflows/ci.yml`
- `cargo test -p meerkat-runtime bindings_do_not_dispatch_runtime_bound_signal`
- `cargo test -p meerkat-runtime routed_prepare_bindings_dispatches_runtime_bound_signal`
- `cargo test -p meerkat-session --features session-store --lib test_metadata_only_projection_does_not_discard_live_session`
- `cargo test -p meerkat-integration-tests e2e_lanes::tests::`
- `MEERKAT_CLEAN_E2E_SCENARIO_TARGETS=1 cargo nextest run -p meerkat-integration-tests --test e2e_smoke_lane e2e_smoke_mob_pictionary --run-ignored ignored-only --test-threads=1 --no-fail-fast --show-progress none --status-level none --final-status-level fail` — passed in 350s
- `MEERKAT_CLEAN_E2E_SCENARIO_TARGETS=1 cargo nextest run -p meerkat-integration-tests --test e2e_live_lane e2e_live_cli_structured_output --run-ignored ignored-only --test-threads=1 --no-fail-fast --show-progress none --status-level none --final-status-level fail` — passed in 285s
- Live mob probe: `e2e_live_s29_cli_mob_member_turn_probe` passed in the local two-test live slice before the browser/WASM case was manually stopped after entering long local release-WASM compilation.
- Push hooks: secret scan, whitespace/YAML checks, `cargo fmt --check`, changed-crates clippy, machine codegen verify, generated-header audit, bridge status audit, workspace deterministic gate.

## CI Notes

The previous setup-only `wasm-pack` 502 failure was infrastructure, but this PR now removes that brittle installer path and adds the smoke/live lanes as first-class PR checks. The latest push (`be0b43d41`) should trigger a fresh run with the new `E2E smoke lane` and `E2E live lane` jobs.