### PR TITLE
[codex] identity auth connection backbone

### DIFF
--- a/examples/012-skills-loading-rs/main.rs
+++ b/examples/012-skills-loading-rs/main.rs
@@ -31,7 +31,7 @@ use std::sync::Arc;
 use indexmap::IndexMap;
 use meerkat::{AgentBuilder, AgentFactory, AnthropicClient, SkillRuntime, SkillScope};
 use meerkat_core::skills::SkillEngine as _;
-use meerkat_core::skills::{SkillDescriptor, SkillDocument, SkillKey, SkillName};
+use meerkat_core::skills::{SkillDescriptor, SkillDocument, SkillKey, SkillName, SourceUuid};
 use meerkat_skills::source::SourceNode;
 use meerkat_skills::{
     CompositeSkillSource, DefaultSkillEngine, FilesystemSkillSource, InMemorySkillSource,
@@ -172,10 +172,12 @@ You are a security auditor reviewing code for vulnerabilities.
     let composite_source = CompositeSkillSource::from_named(vec![
         NamedSource {
             name: "inline".to_string(),
+            source_uuid: SourceUuid::builtin(),
             source: SourceNode::Memory(inline_source),
         },
         NamedSource {
             name: "filesystem".to_string(),
+            source_uuid: SourceUuid::project_local(),
             source: SourceNode::Filesystem(fs_source),
         },
     ]);

--- a/meerkat-anthropic/src/client.rs
+++ b/meerkat-anthropic/src/client.rs
@@ -138,6 +138,22 @@ fn anthropic_tag(request: &LlmRequest) -> Option<&AnthropicProviderTag> {
     }
 }
 
+fn catalog_beta_value(request: &LlmRequest, feature: &str) -> Option<&'static str> {
+    meerkat_core::model_profile::capabilities::capabilities_for("anthropic", &request.model)?
+        .beta_headers
+        .iter()
+        .find(|header| header.feature == feature)
+        .map(|header| header.header_value)
+}
+
+fn catalog_context_beta_value(request: &LlmRequest) -> Option<&'static str> {
+    let header =
+        meerkat_core::model_profile::capabilities::capabilities_for("anthropic", &request.model)?
+            .context_window_beta?
+            .header;
+    header.strip_prefix("anthropic-beta: ")
+}
+
 impl AnthropicClient {
     fn model_supports_temperature(model: &str) -> bool {
         meerkat_core::model_profile::anthropic::supports_temperature(model)
@@ -616,25 +632,32 @@ impl LlmClient for AnthropicClient {
             let thinking_type = body.get("thinking")
                 .and_then(|t| t.get("type"))
                 .and_then(|t| t.as_str());
-            if thinking_type == Some("enabled") {
-                betas.push("interleaved-thinking-2025-05-14");
+            if thinking_type == Some("enabled")
+                && let Some(beta) = catalog_beta_value(request, "interleaved_thinking")
+            {
+                betas.push(beta);
             }
 
             // Structured output format requires beta header
-            if body.get("output_config").and_then(|c| c.get("format")).is_some() {
-                betas.push("structured-outputs-2025-11-13");
+            if body.get("output_config").and_then(|c| c.get("format")).is_some()
+                && let Some(beta) = catalog_beta_value(request, "structured_output")
+            {
+                betas.push(beta);
             }
 
             // 1M context window (opt-in via typed AnthropicProviderTag.context)
             if anthropic_tag(request).and_then(|t| t.context)
                 == Some(AnthropicContextWindow::OneMegabyte)
+                && let Some(beta) = catalog_context_beta_value(request)
             {
-                betas.push("context-1m-2025-08-07");
+                betas.push(beta);
             }
 
             // Compaction API (beta)
-            if body.get("context_management").is_some() {
-                betas.push("compact-2026-01-12");
+            if body.get("context_management").is_some()
+                && let Some(beta) = catalog_beta_value(request, "compaction")
+            {
+                betas.push(beta);
             }
 
             let url = format!("{}/v1/messages", self.base_url);

--- a/meerkat-anthropic/tests/oauth_resolve.rs
+++ b/meerkat-anthropic/tests/oauth_resolve.rs
@@ -28,8 +28,8 @@ use meerkat_auth_core::auth_store::{
     EphemeralTokenStore, PersistedAuthMode, PersistedTokens, TokenKey, TokenStore,
 };
 use meerkat_core::{
-    AuthConstraints, AuthProfileConfig, BackendProfileConfig, CredentialSourceSpec,
-    ProviderBindingConfig, RealmConfigSection, RealmConnectionSet,
+    AuthConstraints, AuthProfileConfig, BackendProfileConfig, BindingId, ConnectionRef,
+    CredentialSourceSpec, ProviderBindingConfig, RealmConfigSection, RealmConnectionSet, RealmId,
 };
 use meerkat_llm_core::provider_runtime::{ProviderRuntimeRegistry, ResolverEnvironment};
 
@@ -77,6 +77,14 @@ fn realm_with_oauth_binding(auth_method: &str) -> RealmConnectionSet {
     RealmConnectionSet::from_config("dev", &section).unwrap()
 }
 
+fn default_connection_ref() -> ConnectionRef {
+    ConnectionRef {
+        realm: RealmId::parse("dev").expect("valid realm"),
+        binding: BindingId::parse("default_claude").expect("valid binding"),
+        profile: None,
+    }
+}
+
 // --- Fresh OAuth bundle → inline secret ---------------------
 
 #[tokio::test]
@@ -112,7 +120,7 @@ async fn claude_ai_oauth_fresh_token_returns_access_token() {
     ));
 
     let connection = registry
-        .resolve(&realm, "default_claude", &env)
+        .resolve(&realm, &default_connection_ref(), &env)
         .await
         .expect("fresh OAuth tokens should resolve");
     assert_eq!(
@@ -243,7 +251,7 @@ async fn oauth_to_api_key_returns_persisted_api_key() {
     ));
 
     let connection = registry
-        .resolve(&realm, "default_claude", &env)
+        .resolve(&realm, &default_connection_ref(), &env)
         .await
         .expect("persisted api_key should resolve");
     assert_eq!(
@@ -264,7 +272,7 @@ async fn missing_oauth_tokens_surface_interactive_login_required() {
     ));
 
     let err = registry
-        .resolve(&realm, "default_claude", &env)
+        .resolve(&realm, &default_connection_ref(), &env)
         .await
         .unwrap_err();
     assert!(
@@ -289,7 +297,7 @@ async fn no_token_store_surface_interactive_login_required() {
     ));
 
     let err = registry
-        .resolve(&realm, "default_claude", &env)
+        .resolve(&realm, &default_connection_ref(), &env)
         .await
         .unwrap_err();
     assert!(

--- a/meerkat-auth-core/Cargo.toml
+++ b/meerkat-auth-core/Cargo.toml
@@ -24,12 +24,13 @@ chrono = { workspace = true }
 tracing = { workspace = true }
 parking_lot = { workspace = true }
 indexmap = "2"
+base64 = { workspace = true }
+getrandom = { version = "0.3", features = ["wasm_js"] }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 tokio = { workspace = true }
 reqwest = { workspace = true }
 dirs = { workspace = true }
-base64 = { workspace = true }
 
 # Optional: OS keychain TokenStore.
 keyring = { version = "3", optional = true, features = ["apple-native", "windows-native", "linux-native"] }
@@ -55,7 +56,6 @@ hex = { version = "0.4", optional = true }
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 tokio_with_wasm = { workspace = true }
 reqwest = { version = "0.12", default-features = false, features = ["json", "stream"] }
-getrandom = { version = "0.3", features = ["wasm_js"] }
 
 [dev-dependencies]
 tokio = { workspace = true, features = ["test-util", "macros"] }

--- a/meerkat-auth-core/src/lib.rs
+++ b/meerkat-auth-core/src/lib.rs
@@ -19,6 +19,8 @@ pub mod auth_oauth;
 pub mod auth_store;
 #[cfg(not(target_arch = "wasm32"))]
 pub mod authorizers;
+#[cfg(not(target_arch = "wasm32"))]
+pub mod oauth_flow;
 // `resolver` contains per-source-spec arms that are individually cfg-split
 // for filesystem/command/managed-store sources. The InlineSecret, Env
 // (host env_lookup), ExternalResolver, and authorizer-stub arms compile

--- a/meerkat-auth-core/src/oauth_flow.rs
+++ b/meerkat-auth-core/src/oauth_flow.rs
@@ -31,6 +31,8 @@ pub enum OAuthFlowError {
     RedirectUriMismatch,
     #[error("failed to generate oauth state token")]
     StateGenerationFailed,
+    #[error("oauth state registry is at capacity ({max_outstanding} outstanding flows)")]
+    CapacityExceeded { max_outstanding: usize },
 }
 
 #[derive(Debug)]
@@ -68,7 +70,11 @@ impl OAuthFlowRegistry {
         };
         let mut flows = self.flows.lock();
         prune_expired_locked(&mut flows, self.ttl);
-        evict_oldest_until_under_capacity(&mut flows, self.max_outstanding);
+        if flows.len() >= self.max_outstanding {
+            return Err(OAuthFlowError::CapacityExceeded {
+                max_outstanding: self.max_outstanding,
+            });
+        }
         flows.insert(state.clone(), record);
         Ok(state)
     }
@@ -113,22 +119,6 @@ fn new_state_token() -> Result<String, OAuthFlowError> {
 
 fn prune_expired_locked(flows: &mut HashMap<String, OAuthFlowRecord>, ttl: Duration) {
     flows.retain(|_, record| record.created_at.elapsed() <= ttl);
-}
-
-fn evict_oldest_until_under_capacity(
-    flows: &mut HashMap<String, OAuthFlowRecord>,
-    max_outstanding: usize,
-) {
-    while flows.len() >= max_outstanding {
-        let Some(oldest_state) = flows
-            .iter()
-            .min_by_key(|(_, record)| record.created_at)
-            .map(|(state, _)| state.clone())
-        else {
-            break;
-        };
-        flows.remove(&oldest_state);
-    }
 }
 
 #[cfg(test)]
@@ -220,7 +210,7 @@ mod tests {
     }
 
     #[test]
-    fn oauth_state_registry_evicts_oldest_at_capacity() {
+    fn oauth_state_registry_rejects_start_at_capacity() {
         let registry = OAuthFlowRegistry::new_with_capacity(Duration::from_secs(60), 2);
         let first = registry
             .start("openai", "http://127.0.0.1/callback", "first")
@@ -228,22 +218,20 @@ mod tests {
         let second = registry
             .start("openai", "http://127.0.0.1/callback", "second")
             .expect("state generation succeeds");
-        let third = registry
-            .start("openai", "http://127.0.0.1/callback", "third")
-            .expect("state generation succeeds");
+        let third = registry.start("openai", "http://127.0.0.1/callback", "third");
 
         assert!(matches!(
-            registry.consume(&first, "openai", "http://127.0.0.1/callback"),
-            Err(OAuthFlowError::Missing)
+            third,
+            Err(OAuthFlowError::CapacityExceeded { max_outstanding: 2 })
         ));
         assert!(
             registry
-                .consume(&second, "openai", "http://127.0.0.1/callback")
+                .consume(&first, "openai", "http://127.0.0.1/callback")
                 .is_ok()
         );
         assert!(
             registry
-                .consume(&third, "openai", "http://127.0.0.1/callback")
+                .consume(&second, "openai", "http://127.0.0.1/callback")
                 .is_ok()
         );
     }

--- a/meerkat-auth-core/src/oauth_flow.rs
+++ b/meerkat-auth-core/src/oauth_flow.rs
@@ -1,0 +1,250 @@
+//! Short-lived OAuth state registry.
+//!
+//! The server owns the state -> PKCE verifier correlation. Start records a
+//! flow before returning the authorize URL; complete must consume that state
+//! before exchanging the authorization code.
+
+use std::collections::HashMap;
+use std::sync::OnceLock;
+use std::time::{Duration, Instant};
+
+use base64::Engine as _;
+use parking_lot::Mutex;
+
+const DEFAULT_MAX_OUTSTANDING_FLOWS: usize = 1024;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct OAuthFlowRecord {
+    pub provider: String,
+    pub redirect_uri: String,
+    pub pkce_verifier: String,
+    pub created_at: Instant,
+}
+
+#[derive(Debug, thiserror::Error, PartialEq, Eq)]
+pub enum OAuthFlowError {
+    #[error("oauth state is missing or expired")]
+    Missing,
+    #[error("oauth state provider mismatch: expected {expected}, got {actual}")]
+    ProviderMismatch { expected: String, actual: String },
+    #[error("oauth state redirect_uri mismatch")]
+    RedirectUriMismatch,
+    #[error("failed to generate oauth state token")]
+    StateGenerationFailed,
+}
+
+#[derive(Debug)]
+pub struct OAuthFlowRegistry {
+    ttl: Duration,
+    max_outstanding: usize,
+    flows: Mutex<HashMap<String, OAuthFlowRecord>>,
+}
+
+impl OAuthFlowRegistry {
+    pub fn new(ttl: Duration) -> Self {
+        Self::new_with_capacity(ttl, DEFAULT_MAX_OUTSTANDING_FLOWS)
+    }
+
+    pub fn new_with_capacity(ttl: Duration, max_outstanding: usize) -> Self {
+        Self {
+            ttl,
+            max_outstanding: max_outstanding.max(1),
+            flows: Mutex::new(HashMap::new()),
+        }
+    }
+
+    pub fn start(
+        &self,
+        provider: impl Into<String>,
+        redirect_uri: impl Into<String>,
+        pkce_verifier: impl Into<String>,
+    ) -> Result<String, OAuthFlowError> {
+        let state = new_state_token()?;
+        let record = OAuthFlowRecord {
+            provider: provider.into(),
+            redirect_uri: redirect_uri.into(),
+            pkce_verifier: pkce_verifier.into(),
+            created_at: Instant::now(),
+        };
+        let mut flows = self.flows.lock();
+        prune_expired_locked(&mut flows, self.ttl);
+        evict_oldest_until_under_capacity(&mut flows, self.max_outstanding);
+        flows.insert(state.clone(), record);
+        Ok(state)
+    }
+
+    pub fn consume(
+        &self,
+        state: &str,
+        provider: &str,
+        redirect_uri: &str,
+    ) -> Result<OAuthFlowRecord, OAuthFlowError> {
+        let mut flows = self.flows.lock();
+        prune_expired_locked(&mut flows, self.ttl);
+        let Some(record) = flows.remove(state) else {
+            return Err(OAuthFlowError::Missing);
+        };
+        if record.provider != provider {
+            return Err(OAuthFlowError::ProviderMismatch {
+                expected: record.provider,
+                actual: provider.to_string(),
+            });
+        }
+        if record.redirect_uri != redirect_uri {
+            return Err(OAuthFlowError::RedirectUriMismatch);
+        }
+        Ok(record)
+    }
+}
+
+pub fn global_oauth_flow_registry() -> &'static OAuthFlowRegistry {
+    static REGISTRY: OnceLock<OAuthFlowRegistry> = OnceLock::new();
+    REGISTRY.get_or_init(|| OAuthFlowRegistry::new(Duration::from_secs(10 * 60)))
+}
+
+fn new_state_token() -> Result<String, OAuthFlowError> {
+    let mut bytes = [0_u8; 32];
+    getrandom::fill(&mut bytes).map_err(|_| OAuthFlowError::StateGenerationFailed)?;
+    Ok(format!(
+        "st-{}",
+        base64::engine::general_purpose::URL_SAFE_NO_PAD.encode(bytes)
+    ))
+}
+
+fn prune_expired_locked(flows: &mut HashMap<String, OAuthFlowRecord>, ttl: Duration) {
+    flows.retain(|_, record| record.created_at.elapsed() <= ttl);
+}
+
+fn evict_oldest_until_under_capacity(
+    flows: &mut HashMap<String, OAuthFlowRecord>,
+    max_outstanding: usize,
+) {
+    while flows.len() >= max_outstanding {
+        let Some(oldest_state) = flows
+            .iter()
+            .min_by_key(|(_, record)| record.created_at)
+            .map(|(state, _)| state.clone())
+        else {
+            break;
+        };
+        flows.remove(&oldest_state);
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::expect_used)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn oauth_state_pkce_round_trip() {
+        let registry = OAuthFlowRegistry::new(Duration::from_secs(60));
+        let state = registry
+            .start("openai", "http://127.0.0.1/callback", "verifier")
+            .expect("state generation succeeds");
+        let record = registry.consume(&state, "openai", "http://127.0.0.1/callback");
+        assert!(
+            record.is_ok(),
+            "state should resolve once: {:?}",
+            record.err()
+        );
+        if let Ok(record) = record {
+            assert_eq!(record.pkce_verifier, "verifier");
+        }
+        assert!(matches!(
+            registry.consume(&state, "openai", "http://127.0.0.1/callback"),
+            Err(OAuthFlowError::Missing)
+        ));
+    }
+
+    #[test]
+    fn oauth_state_rejects_mismatch() {
+        let registry = OAuthFlowRegistry::new(Duration::from_secs(60));
+        let state = registry
+            .start("openai", "http://127.0.0.1/callback", "verifier")
+            .expect("state generation succeeds");
+        assert!(matches!(
+            registry.consume(&state, "anthropic", "http://127.0.0.1/callback"),
+            Err(OAuthFlowError::ProviderMismatch { .. })
+        ));
+    }
+
+    #[test]
+    fn oauth_state_rejects_redirect_uri_mismatch() {
+        let registry = OAuthFlowRegistry::new(Duration::from_secs(60));
+        let state = registry
+            .start("openai", "http://127.0.0.1/callback", "verifier")
+            .expect("state generation succeeds");
+        assert!(matches!(
+            registry.consume(&state, "openai", "http://127.0.0.1/other"),
+            Err(OAuthFlowError::RedirectUriMismatch)
+        ));
+    }
+
+    #[test]
+    fn oauth_state_random_tokens_are_urlsafe_and_unique() {
+        let registry = OAuthFlowRegistry::new(Duration::from_secs(60));
+        let first = registry
+            .start("openai", "http://127.0.0.1/callback", "verifier-a")
+            .expect("state generation succeeds");
+        let second = registry
+            .start("openai", "http://127.0.0.1/callback", "verifier-b")
+            .expect("state generation succeeds");
+        assert_ne!(first, second);
+        assert!(first.starts_with("st-"));
+        assert!(
+            first[3..]
+                .chars()
+                .all(|ch| { ch.is_ascii_alphanumeric() || ch == '-' || ch == '_' })
+        );
+    }
+
+    #[test]
+    fn oauth_state_expired_records_are_pruned() {
+        let registry = OAuthFlowRegistry::new(Duration::from_secs(60));
+        registry.flows.lock().insert(
+            "st-old".to_string(),
+            OAuthFlowRecord {
+                provider: "openai".to_string(),
+                redirect_uri: "http://127.0.0.1/callback".to_string(),
+                pkce_verifier: "verifier".to_string(),
+                created_at: Instant::now()
+                    .checked_sub(Duration::from_secs(61))
+                    .expect("test duration is representable"),
+            },
+        );
+        assert!(matches!(
+            registry.consume("st-old", "openai", "http://127.0.0.1/callback"),
+            Err(OAuthFlowError::Missing)
+        ));
+    }
+
+    #[test]
+    fn oauth_state_registry_evicts_oldest_at_capacity() {
+        let registry = OAuthFlowRegistry::new_with_capacity(Duration::from_secs(60), 2);
+        let first = registry
+            .start("openai", "http://127.0.0.1/callback", "first")
+            .expect("state generation succeeds");
+        let second = registry
+            .start("openai", "http://127.0.0.1/callback", "second")
+            .expect("state generation succeeds");
+        let third = registry
+            .start("openai", "http://127.0.0.1/callback", "third")
+            .expect("state generation succeeds");
+
+        assert!(matches!(
+            registry.consume(&first, "openai", "http://127.0.0.1/callback"),
+            Err(OAuthFlowError::Missing)
+        ));
+        assert!(
+            registry
+                .consume(&second, "openai", "http://127.0.0.1/callback")
+                .is_ok()
+        );
+        assert!(
+            registry
+                .consume(&third, "openai", "http://127.0.0.1/callback")
+                .is_ok()
+        );
+    }
+}

--- a/meerkat-cli/src/main.rs
+++ b/meerkat-cli/src/main.rs
@@ -2876,7 +2876,14 @@ async fn handle_auth_command(command: AuthCommands, scope: &RuntimeScope) -> any
                 .map_err(|e| anyhow::anyhow!("Realm config invalid: {e}"))?;
             let registry = meerkat_providers::ProviderRuntimeRegistry::empty();
             let env = meerkat_providers::ResolverEnvironment::with_process_env();
-            match registry.resolve(&realm_set, &binding_id, &env).await {
+            let connection_ref = meerkat_core::ConnectionRef {
+                realm: meerkat_core::RealmId::parse(realm.clone())
+                    .map_err(|e| anyhow::anyhow!("invalid realm id '{realm}': {e}"))?,
+                binding: meerkat_core::BindingId::parse(binding_id.clone())
+                    .map_err(|e| anyhow::anyhow!("invalid binding id '{binding_id}': {e}"))?,
+                profile: None,
+            };
+            match registry.resolve(&realm_set, &connection_ref, &env).await {
                 Ok(conn) => {
                     println!("state: valid");
                     println!("provider: {}", conn.provider.as_str());
@@ -3239,8 +3246,15 @@ async fn refresh_auth_profile(
         .with_token_store(store.clone())
         .with_refresh_coordinator(coord);
     let registry = meerkat_providers::ProviderRuntimeRegistry::empty();
+    let connection_ref = meerkat_core::ConnectionRef {
+        realm: meerkat_core::RealmId::parse(realm)
+            .map_err(|e| anyhow::anyhow!("invalid realm id '{realm}': {e}"))?,
+        binding: meerkat_core::BindingId::parse(binding_id.clone())
+            .map_err(|e| anyhow::anyhow!("invalid binding id '{binding_id}': {e}"))?,
+        profile: None,
+    };
     let connection = registry
-        .resolve(&realm_set, &binding_id, &env)
+        .resolve(&realm_set, &connection_ref, &env)
         .await
         .map_err(|e| anyhow::anyhow!("Binding resolution failed: {e}"))?;
 
@@ -10376,11 +10390,12 @@ mod tests {
     #[test]
     fn test_parse_comms_send_payload_peer_request_accepts_reserve_interaction_stream() {
         let session_id = SessionId::new();
-        let cmd = parse_comms_send_payload(
-            r#"{"kind":"peer_request","to":"agent-b","intent":"help","params":{"topic":"x"},"handling_mode":"queue","stream":"reserve_interaction"}"#,
-            &session_id,
-        )
-        .expect("peer request reserve_interaction stream should be accepted");
+        let to = uuid::Uuid::new_v4();
+        let payload = format!(
+            r#"{{"kind":"peer_request","to":"{to}","intent":"help","params":{{"topic":"x"}},"handling_mode":"queue","stream":"reserve_interaction"}}"#,
+        );
+        let cmd = parse_comms_send_payload(&payload, &session_id)
+            .expect("peer request reserve_interaction stream should be accepted");
         assert!(
             matches!(cmd, meerkat_core::comms::CommsCommand::PeerRequest { .. }),
             "unexpected command parsed for peer request payload: {cmd:?}"
@@ -10413,9 +10428,10 @@ mod tests {
     #[test]
     fn test_parse_comms_send_payload_rejects_invalid_command_shape() {
         let session_id = SessionId::new();
-        let err =
-            parse_comms_send_payload(r#"{"kind":"peer_request","to":"agent-b"}"#, &session_id)
-                .expect_err("missing intent should be rejected");
+        let to = uuid::Uuid::new_v4();
+        let payload = format!(r#"{{"kind":"peer_request","to":"{to}"}}"#);
+        let err = parse_comms_send_payload(&payload, &session_id)
+            .expect_err("missing intent should be rejected");
         // Missing required `intent` field is rejected at the typed-serde
         // boundary, not a runtime string match.
         assert!(err.to_string().contains("Invalid comms JSON payload"));

--- a/meerkat-client/tests/rct_contracts.rs
+++ b/meerkat-client/tests/rct_contracts.rs
@@ -174,16 +174,16 @@ fn test_provider_resolution_contract() -> Result<(), Box<dyn std::error::Error>>
     fn infer(m: &str) -> Provider {
         Provider::infer_from_model(m).unwrap_or(Provider::Other)
     }
-    assert_eq!(infer("claude-3"), Provider::Anthropic);
-    assert_eq!(infer("gpt-4"), Provider::OpenAI);
-    assert_eq!(infer("gemini-1.5"), Provider::Gemini);
+    assert_eq!(infer("claude-opus-4-6"), Provider::Anthropic);
+    assert_eq!(infer("gpt-5.4"), Provider::OpenAI);
+    assert_eq!(infer("gemini-3-flash-preview"), Provider::Gemini);
     assert_eq!(infer("unknown"), Provider::Other);
 
     // Phase 6.6 removed the legacy env-precedence credential helpers
     // from this struct. The RKAT_*-preferred env resolution now lives
     // inside the factory's env-var fallback (meerkat/src/factory.rs)
     // and inside the provider-runtime registry's env_lookup seam.
-    // This test stays focused on the infer_from_model contract above;
+    // This test stays focused on the catalog-backed infer_from_model contract above;
     // env-precedence is covered by integration tests that exercise
     // the registry.
 
@@ -192,6 +192,6 @@ fn test_provider_resolution_contract() -> Result<(), Box<dyn std::error::Error>>
 
 #[test]
 fn test_inv_006_provider_inference_uses_resolver() {
-    let provider = Provider::infer_from_model("claude-sonnet-4").unwrap_or(Provider::Other);
+    let provider = Provider::infer_from_model("claude-sonnet-4-6").unwrap_or(Provider::Other);
     assert_eq!(provider, Provider::Anthropic);
 }

--- a/meerkat-comms/src/mcp/tools.rs
+++ b/meerkat-comms/src/mcp/tools.rs
@@ -21,7 +21,7 @@ use std::sync::Arc;
 use crate::{CommsConfig, Keypair};
 use crate::{Router, Status, TrustedPeers};
 use meerkat_core::agent::CommsRuntime as CoreCommsRuntime;
-use meerkat_core::comms::{CommsCommand, InputStreamMode, PeerName};
+use meerkat_core::comms::{CommsCommand, InputStreamMode, PeerName, PeerRoute};
 use meerkat_core::interaction::{InteractionId, ResponseStatus};
 use meerkat_core::types::HandlingMode;
 
@@ -141,7 +141,7 @@ pub async fn handle_tools_call(
         "send_message" => {
             let input: SendMessageInput = serde_json::from_value(args.clone())
                 .map_err(|e| format!("Invalid arguments: {e}"))?;
-            let to = peer_name(&input.to)?;
+            let to = peer_route(ctx, &input.to)?;
             let command = CommsCommand::PeerMessage {
                 to,
                 body: input.body,
@@ -153,7 +153,7 @@ pub async fn handle_tools_call(
         "send_request" => {
             let input: SendRequestInput = serde_json::from_value(args.clone())
                 .map_err(|e| format!("Invalid arguments: {e}"))?;
-            let to = peer_name(&input.to)?;
+            let to = peer_route(ctx, &input.to)?;
             let command = CommsCommand::PeerRequest {
                 to,
                 intent: input.intent,
@@ -166,7 +166,7 @@ pub async fn handle_tools_call(
         "send_response" => {
             let input: SendResponseInput = serde_json::from_value(args.clone())
                 .map_err(|e| format!("Invalid arguments: {e}"))?;
-            let to = peer_name(&input.to)?;
+            let to = peer_route(ctx, &input.to)?;
             let in_reply_to_uuid = uuid::Uuid::parse_str(&input.in_reply_to)
                 .map_err(|_| format!("invalid UUID for in_reply_to: {}", input.in_reply_to))?;
             // Accepted progress responses reject a handling_mode override
@@ -197,13 +197,19 @@ fn peer_name(value: &str) -> Result<PeerName, String> {
     PeerName::new(value).map_err(|err| format!("invalid to: {err}"))
 }
 
+fn peer_route(ctx: &ToolContext, value: &str) -> Result<PeerRoute, String> {
+    let name = peer_name(value)?;
+    let peer_id = resolve_name_to_peer_id(ctx, &name)?;
+    Ok(PeerRoute::with_display_name(peer_id, name))
+}
+
 async fn dispatch(ctx: &ToolContext, command: CommsCommand) -> Result<Value, String> {
-    // Capture peer name for error normalization before consuming the command.
+    // Capture peer display label for error normalization before consuming the command.
     let peer_for_errors = match &command {
         CommsCommand::PeerMessage { to, .. }
         | CommsCommand::PeerLifecycle { to, .. }
         | CommsCommand::PeerRequest { to, .. }
-        | CommsCommand::PeerResponse { to, .. } => Some(to.clone()),
+        | CommsCommand::PeerResponse { to, .. } => Some(to.label()),
         CommsCommand::Input { .. } => None,
     };
     let cmd_kind = command.command_kind().to_string();
@@ -215,18 +221,12 @@ async fn dispatch(ctx: &ToolContext, command: CommsCommand) -> Result<Value, Str
             }
             meerkat_core::comms::SendError::PeerOffline => format!(
                 "peer_unreachable: peer '{}' is unreachable: offline_or_no_ack",
-                peer_for_errors
-                    .as_ref()
-                    .map(PeerName::as_str)
-                    .unwrap_or("<unknown>")
+                peer_for_errors.as_deref().unwrap_or("<unknown>")
             ),
             meerkat_core::comms::SendError::Internal(inner) if is_transport_internal(&inner) => {
                 format!(
                     "peer_unreachable: peer '{}' is unreachable: transport_error ({inner})",
-                    peer_for_errors
-                        .as_ref()
-                        .map(PeerName::as_str)
-                        .unwrap_or("<unknown>")
+                    peer_for_errors.as_deref().unwrap_or("<unknown>")
                 )
             }
             other => other.to_string(),
@@ -235,19 +235,17 @@ async fn dispatch(ctx: &ToolContext, command: CommsCommand) -> Result<Value, Str
     }
 
     // Fallback path (no runtime): dispatch directly through the router.
-    // This is used by unit tests and minimal host configurations. Resolve
-    // the destination `PeerName` against the trusted-peer set exactly once
-    // — duplicate names refuse the send rather than guessing.
+    // This is used by unit tests and minimal host configurations. The
+    // destination was resolved to `PeerId` at the tool boundary.
     let dest_display = peer_for_errors
-        .as_ref()
-        .map(PeerName::as_str)
+        .as_deref()
         .unwrap_or("<unknown>")
         .to_string();
     let dest_peer_id = match &command {
         CommsCommand::PeerMessage { to, .. }
         | CommsCommand::PeerLifecycle { to, .. }
         | CommsCommand::PeerRequest { to, .. }
-        | CommsCommand::PeerResponse { to, .. } => resolve_name_to_peer_id(ctx, to)?,
+        | CommsCommand::PeerResponse { to, .. } => to.peer_id,
         CommsCommand::Input { .. } => {
             return Err("input command is not supported by MCP send".to_string());
         }

--- a/meerkat-comms/src/runtime/comms_runtime.rs
+++ b/meerkat-comms/src/runtime/comms_runtime.rs
@@ -19,8 +19,8 @@ use futures::task::{Context, Poll};
 use meerkat_core::agent::CommsRuntime as CoreCommsRuntime;
 use meerkat_core::comms::{
     CommsCommand, EventStream, InputStreamMode, PeerAddress, PeerDirectoryEntry,
-    PeerDirectorySource, PeerName, PeerReachabilityReason, SendAndStreamError, SendError,
-    SendReceipt, StreamError, StreamScope, TrustedPeerDescriptor,
+    PeerDirectorySource, PeerName, PeerReachabilityReason, PeerRoute, SendAndStreamError,
+    SendError, SendReceipt, StreamError, StreamScope, TrustedPeerDescriptor,
 };
 use meerkat_core::config::PlainEventSource;
 #[cfg(not(target_arch = "wasm32"))]
@@ -523,7 +523,7 @@ impl CoreCommsRuntime for CommsRuntime {
                 // installed (standalone / WASM), the shell retains the
                 // legacy inline behavior unchanged.
                 if let Some(handle) = self.peer_interaction_handle()
-                    && let Err(err) = handle.request_sent(corr_id, to.to_string())
+                    && let Err(err) = handle.request_sent(corr_id, to.peer_id.to_string())
                 {
                     tracing::warn!(
                         error = %err,
@@ -689,7 +689,7 @@ impl CoreCommsRuntime for CommsRuntime {
                 // W1-A: DSL authority runs first — see the mirror comment
                 // in the `send` path's PeerRequest arm.
                 if let Some(handle) = self.peer_interaction_handle()
-                    && let Err(err) = handle.request_sent(corr_id, to.to_string())
+                    && let Err(err) = handle.request_sent(corr_id, to.peer_id.to_string())
                 {
                     tracing::warn!(
                         error = %err,
@@ -1918,26 +1918,20 @@ impl CommsRuntime {
         emitted
     }
 
-    /// Canonical send path: destination is a typed [`PeerName`] that the
-    /// runtime resolves to a [`PeerId`] via the trusted-peer snapshot.
-    ///
-    /// Duplicate names are a discovery concern, not a routing concern —
-    /// the first resolvable entry wins here because the router itself
-    /// keys by `PeerId`. Surfaces that must reject ambiguity should
-    /// resolve names through [`crate::trust::TrustStore::resolve_name`]
-    /// at their own boundary.
+    /// Canonical send path: destination is a typed [`PeerRoute`] whose
+    /// [`PeerId`] is already resolved at the surface boundary.
     async fn send_peer_command(
         &self,
-        peer_name: &PeerName,
+        route: &PeerRoute,
         kind: crate::types::MessageKind,
     ) -> Result<Uuid, SendError> {
-        self.send_peer_command_with_id(peer_name, Uuid::new_v4(), kind)
+        self.send_peer_command_with_id(route, Uuid::new_v4(), kind)
             .await
     }
 
     async fn send_peer_command_with_id(
         &self,
-        peer_name: &PeerName,
+        route: &PeerRoute,
         envelope_id: Uuid,
         kind: crate::types::MessageKind,
     ) -> Result<Uuid, SendError> {
@@ -1945,11 +1939,8 @@ impl CommsRuntime {
         self.reconcile_peer_directory(&resolved);
         let resolved_peer = resolved
             .into_iter()
-            .find(|peer| peer.name.as_str() == peer_name.as_str());
-        let dest_peer_id = match resolved_peer.as_ref() {
-            Some(peer) => peer.peer_id,
-            None => return Err(SendError::PeerNotFound(peer_name.as_string())),
-        };
+            .find(|peer| peer.peer_id == route.peer_id);
+        let dest_peer_id = route.peer_id;
         let kind = self.hydrate_message_kind_for_transport(kind).await?;
         let result = self
             .router
@@ -2501,7 +2492,7 @@ mod tests {
         BlobId, BlobPayload, BlobRef, BlobStore, BlobStoreError, SendError,
         comms::{
             InputSource, InputStreamMode, PeerDirectorySource, PeerName, PeerReachability,
-            PeerReachabilityReason, StreamError, StreamScope, TrustedPeerDescriptor,
+            PeerReachabilityReason, PeerRoute, StreamError, StreamScope, TrustedPeerDescriptor,
         },
         interaction::InteractionId,
         types::{ContentBlock, ImageData, SessionId},
@@ -2517,6 +2508,20 @@ mod tests {
             address: parse_peer_address(address),
             pubkey: *pubkey.as_bytes(),
         }
+    }
+
+    fn peer_route(name: &str, pubkey: PubKey) -> PeerRoute {
+        PeerRoute::with_display_name(
+            crate::router::peer_id_from_pubkey(&pubkey),
+            PeerName::new(name.to_string()).expect("valid peer name"),
+        )
+    }
+
+    fn missing_peer_route(name: &str) -> PeerRoute {
+        PeerRoute::with_display_name(
+            meerkat_core::comms::PeerId::new(),
+            PeerName::new(name.to_string()).expect("valid peer name"),
+        )
     }
     use parking_lot::Mutex;
     use std::{collections::HashMap, sync::Arc};
@@ -2918,7 +2923,7 @@ mod tests {
         let receipt = CoreCommsRuntime::send(
             &runtime,
             CommsCommand::PeerRequest {
-                to: PeerName::new(peer_name).expect("peer_name is valid"),
+                to: peer_route(&peer_name, peer.public_key()),
                 intent: "checksum".to_string(),
                 params: serde_json::json!({"path": "README.md"}),
                 handling_mode: meerkat_core::types::HandlingMode::Queue,
@@ -2974,7 +2979,7 @@ mod tests {
         let receipt = CoreCommsRuntime::send(
             &sender,
             CommsCommand::PeerLifecycle {
-                to: PeerName::new(receiver_name).expect("peer_name is valid"),
+                to: peer_route(&receiver_name, receiver.public_key()),
                 kind: meerkat_core::comms::PeerLifecycleKind::PeerAdded,
                 params: serde_json::json!({
                     "peer": "worker-1",
@@ -3785,17 +3790,13 @@ mod tests {
 
         let cmd = CommsCommand::PeerMessage {
             blocks: None,
-            to: PeerName::new("missing-peer".to_string())
-                .expect("missing-peer is a valid peer name"),
+            to: missing_peer_route("missing-peer"),
             body: "hello".to_string(),
             handling_mode: meerkat_core::types::HandlingMode::Queue,
         };
 
         let result = CoreCommsRuntime::send(&runtime, cmd).await;
-        assert!(matches!(
-            result,
-            Err(SendError::PeerNotFound(peer)) if peer == "missing-peer"
-        ));
+        assert!(matches!(result, Err(SendError::PeerNotFound(_))));
     }
 
     #[tokio::test]
@@ -3830,7 +3831,7 @@ mod tests {
 
         let cmd = CommsCommand::PeerMessage {
             blocks: None,
-            to: PeerName::new(receiver_name).expect("receiver_name is a valid peer name"),
+            to: peer_route(&receiver_name, receiver.public_key()),
             body: "greeting".to_string(),
             handling_mode: meerkat_core::types::HandlingMode::Queue,
         };
@@ -3895,7 +3896,7 @@ mod tests {
                     blob_id: blob_ref.blob_id,
                 },
             }]),
-            to: PeerName::new(receiver_name).expect("receiver_name is a valid peer name"),
+            to: peer_route(&receiver_name, receiver.public_key()),
             body: "blob-backed image".to_string(),
             handling_mode: meerkat_core::types::HandlingMode::Queue,
         };
@@ -3930,14 +3931,14 @@ mod tests {
 
         let cmd = CommsCommand::PeerMessage {
             blocks: None,
-            to: PeerName::new(receiver_name.clone()).expect("receiver_name is a valid peer name"),
+            to: peer_route(&receiver_name, receiver.public_key()),
             body: "inproc-only hello".to_string(),
             handling_mode: meerkat_core::types::HandlingMode::Queue,
         };
 
         let receipt = CoreCommsRuntime::send(&sender, cmd).await;
         match receipt {
-            Err(SendError::PeerNotFound(peer)) => assert_eq!(peer, receiver_name),
+            Err(SendError::PeerNotFound(_)) => {}
             other => panic!("Expected peer-not-found for missing trust, got: {other:?}"),
         }
 
@@ -3994,7 +3995,7 @@ mod tests {
 
         let cmd = CommsCommand::PeerMessage {
             blocks: None,
-            to: PeerName::new(receiver_name.clone()).expect("receiver_name is a valid peer name"),
+            to: peer_route(&receiver_name, receiver.public_key()),
             body: "hello without trusted".to_string(),
             handling_mode: meerkat_core::types::HandlingMode::Queue,
         };
@@ -4057,7 +4058,7 @@ mod tests {
 
         let send_cmd = CommsCommand::PeerMessage {
             blocks: None,
-            to: PeerName::new(receiver_name.clone()).expect("receiver_name is a valid peer name"),
+            to: peer_route(&receiver_name, receiver.public_key()),
             body: "hello trusted peer".to_string(),
             handling_mode: meerkat_core::types::HandlingMode::Queue,
         };
@@ -4385,7 +4386,7 @@ mod tests {
             &sender,
             CommsCommand::PeerMessage {
                 blocks: None,
-                to: PeerName::new(receiver_name.clone()).expect("valid peer name"),
+                to: peer_route(&receiver_name, receiver.public_key()),
                 body: "hello".to_string(),
                 handling_mode: meerkat_core::types::HandlingMode::Queue,
             },
@@ -4420,7 +4421,7 @@ mod tests {
             &sender,
             CommsCommand::PeerMessage {
                 blocks: None,
-                to: PeerName::new(peer_name.clone()).expect("valid peer name"),
+                to: peer_route(&peer_name, peer_pubkey),
                 body: "hello".to_string(),
                 handling_mode: meerkat_core::types::HandlingMode::Queue,
             },
@@ -4475,7 +4476,7 @@ mod tests {
             &sender,
             CommsCommand::PeerMessage {
                 blocks: None,
-                to: PeerName::new(receiver_name.clone()).expect("valid peer name"),
+                to: peer_route(&receiver_name, receiver.public_key()),
                 body: "policy-rejected".to_string(),
                 handling_mode: meerkat_core::types::HandlingMode::Queue,
             },
@@ -4514,14 +4515,14 @@ mod tests {
             &sender,
             CommsCommand::PeerMessage {
                 blocks: None,
-                to: PeerName::new(missing_name.clone()).expect("valid peer name"),
+                to: missing_peer_route(&missing_name),
                 body: "hello".to_string(),
                 handling_mode: meerkat_core::types::HandlingMode::Queue,
             },
         )
         .await;
         assert!(
-            matches!(result, Err(SendError::PeerNotFound(ref peer)) if peer == &missing_name),
+            matches!(result, Err(SendError::PeerNotFound(_))),
             "missing peer should fail with PeerNotFound, got: {result:?}"
         );
 
@@ -4558,7 +4559,7 @@ mod tests {
             &sender,
             CommsCommand::PeerMessage {
                 blocks: None,
-                to: PeerName::new(missing_name.clone()).expect("valid peer name"),
+                to: peer_route(&missing_name, missing_pubkey),
                 body: "hello".to_string(),
                 handling_mode: meerkat_core::types::HandlingMode::Queue,
             },
@@ -4616,19 +4617,19 @@ mod tests {
                 let cmd = match kind.as_str() {
                     "peer_message" => CommsCommand::PeerMessage {
                         blocks: None,
-                        to: entry.name.clone(),
+                        to: PeerRoute::with_display_name(entry.peer_id, entry.name.clone()),
                         body: "truthfulness test".to_string(),
                         handling_mode: meerkat_core::types::HandlingMode::Queue,
                     },
                     "peer_request" => CommsCommand::PeerRequest {
-                        to: entry.name.clone(),
+                        to: PeerRoute::with_display_name(entry.peer_id, entry.name.clone()),
                         intent: "test".to_string(),
                         params: serde_json::json!({}),
                         handling_mode: meerkat_core::types::HandlingMode::Queue,
                         stream: InputStreamMode::None,
                     },
                     "peer_response" => CommsCommand::PeerResponse {
-                        to: entry.name.clone(),
+                        to: PeerRoute::with_display_name(entry.peer_id, entry.name.clone()),
                         in_reply_to: meerkat_core::InteractionId(Uuid::new_v4()),
                         status: meerkat_core::ResponseStatus::Completed,
                         result: serde_json::json!({}),
@@ -4751,13 +4752,13 @@ mod tests {
         let peer_name = format!("m5-peer-{suffix}");
         let runtime_name = format!("m5-runtime-{suffix}");
 
-        let _peer = CommsRuntime::inproc_only(&peer_name).unwrap();
+        let peer = CommsRuntime::inproc_only(&peer_name).unwrap();
         let runtime = CommsRuntime::inproc_only(&runtime_name).unwrap();
         {
             let mut trusted = runtime.trusted_peers.write();
             trusted.upsert(crate::TrustedPeer {
                 name: peer_name.clone(),
-                pubkey: _peer.public_key(),
+                pubkey: peer.public_key(),
                 addr: format!("inproc://{peer_name}"),
                 meta: crate::PeerMeta::default(),
             });
@@ -4765,7 +4766,7 @@ mod tests {
         // Receive side must also trust the sender after the silent-drop fix.
         // Use `add_trusted_peer` so the classified queue's trust set syncs.
         CoreCommsRuntime::add_trusted_peer(
-            &_peer,
+            &peer,
             trusted_descriptor(
                 &runtime_name,
                 runtime.public_key(),
@@ -4777,7 +4778,7 @@ mod tests {
 
         let cmd = CommsCommand::PeerMessage {
             blocks: None,
-            to: PeerName::new(peer_name).expect("peer_name is a valid peer name"),
+            to: peer_route(&peer_name, peer.public_key()),
             body: "not streamable".to_string(),
             handling_mode: meerkat_core::types::HandlingMode::Queue,
         };
@@ -4941,7 +4942,7 @@ mod tests {
         // Verify sending to the removed peer fails (PeerNotFound)
         let cmd = CommsCommand::PeerMessage {
             blocks: None,
-            to: PeerName::new(receiver_name.clone()).expect("valid peer name"),
+            to: peer_route(&receiver_name, receiver.public_key()),
             body: "should fail".to_string(),
             handling_mode: meerkat_core::types::HandlingMode::Queue,
         };

--- a/meerkat-contracts/src/lib.rs
+++ b/meerkat-contracts/src/lib.rs
@@ -172,6 +172,7 @@ pub use wire::{
     WireMobLifecycleAction,
     WireMobMemberStatus,
     WireMobRuntimeMode,
+    WireModelBetaHeader,
     WireModelProfile,
     WireModelTier,
     WireProviderBinding,

--- a/meerkat-contracts/src/wire/connection.rs
+++ b/meerkat-contracts/src/wire/connection.rs
@@ -310,8 +310,6 @@ pub struct WireAuthProfileCleared {
 pub struct WireLoginStart {
     pub authorize_url: String,
     pub state: String,
-    pub pkce_verifier: String,
-    pub pkce_challenge: String,
     pub redirect_uri: String,
     pub provider: String,
 }

--- a/meerkat-contracts/src/wire/mod.rs
+++ b/meerkat-contracts/src/wire/mod.rs
@@ -55,7 +55,8 @@ pub use mob::{
     WireWorkOrigin,
 };
 pub use models::{
-    CatalogModelEntry, ModelsCatalogResponse, ProviderCatalog, WireModelProfile, WireModelTier,
+    CatalogModelEntry, ModelsCatalogResponse, ProviderCatalog, WireModelBetaHeader,
+    WireModelProfile, WireModelTier,
 };
 pub use params::{CommsParams, CoreCreateParams, HookParams, SkillsParams, StructuredOutputParams};
 pub use realtime::{

--- a/meerkat-contracts/src/wire/models.rs
+++ b/meerkat-contracts/src/wire/models.rs
@@ -33,6 +33,18 @@ pub struct WireModelProfile {
     pub inline_video: bool,
     /// JSON Schema describing accepted provider-specific parameters.
     pub params_schema: serde_json::Value,
+    /// Beta headers authorized by the model capability catalog.
+    #[serde(default)]
+    pub beta_headers: Vec<WireModelBetaHeader>,
+}
+
+/// Catalog-owned beta header metadata.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
+pub struct WireModelBetaHeader {
+    pub feature: String,
+    pub header_name: String,
+    pub header_value: String,
 }
 
 /// A single model entry in the catalog response.

--- a/meerkat-core/src/agent.rs
+++ b/meerkat-core/src/agent.rs
@@ -888,7 +888,6 @@ where
     /// by the session runtime bindings.
     pub(crate) external_tool_surface_handle: Option<Arc<dyn crate::ExternalToolSurfaceHandle>>,
     /// Runtime-backed auth lease handle (Phase 1.5-rev).
-    #[expect(dead_code, reason = "wired by D-c AuthMachine composition")]
     pub(crate) auth_lease_handle: Option<Arc<dyn crate::handles::AuthLeaseHandle>>,
     /// Runtime-backed MCP server lifecycle handle (Phase 5G / T5g). When set,
     /// the agent loop reads `pending_server_ids()` at each CallingLlm boundary

--- a/meerkat-core/src/agent/runner.rs
+++ b/meerkat-core/src/agent/runner.rs
@@ -306,6 +306,33 @@ where
         self.client = client;
     }
 
+    /// Rotate runtime auth-lease tracking alongside a live LLM identity swap.
+    pub fn rotate_auth_lease_connection_ref(
+        &self,
+        previous: Option<&crate::ConnectionRef>,
+        target: Option<&crate::ConnectionRef>,
+    ) -> Result<(), AgentError> {
+        let Some(handle) = self.auth_lease_handle.as_deref() else {
+            return Ok(());
+        };
+        if previous == target {
+            return Ok(());
+        }
+        if let Some(previous) = previous {
+            let previous_key = crate::handles::LeaseKey::from_connection_ref(previous);
+            let _ = handle.release_lease(&previous_key);
+        }
+        if let Some(target) = target {
+            let target_key = crate::handles::LeaseKey::from_connection_ref(target);
+            handle.acquire_lease(&target_key, u64::MAX).map_err(|err| {
+                AgentError::ConfigError(format!(
+                    "failed to rotate auth lease to connection_ref {target_key}: {err}"
+                ))
+            })?;
+        }
+        Ok(())
+    }
+
     /// Shared live control flag for boundary-only cancellation requests.
     pub fn cancel_after_boundary_handle(&self) -> Arc<std::sync::atomic::AtomicBool> {
         Arc::clone(&self.cancel_after_boundary_requested)

--- a/meerkat-core/src/comms.rs
+++ b/meerkat-core/src/comms.rs
@@ -201,6 +201,40 @@ impl From<PeerName> for String {
     }
 }
 
+/// Canonical outbound peer route.
+///
+/// `peer_id` is the only routing key. `display_name` is optional presentation
+/// metadata retained for diagnostics after a boundary resolves a name through
+/// trust or discovery.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PeerRoute {
+    pub peer_id: PeerId,
+    pub display_name: Option<PeerName>,
+}
+
+impl PeerRoute {
+    pub fn new(peer_id: PeerId) -> Self {
+        Self {
+            peer_id,
+            display_name: None,
+        }
+    }
+
+    pub fn with_display_name(peer_id: PeerId, display_name: PeerName) -> Self {
+        Self {
+            peer_id,
+            display_name: Some(display_name),
+        }
+    }
+
+    pub fn label(&self) -> String {
+        self.display_name
+            .as_ref()
+            .map(PeerName::as_string)
+            .unwrap_or_else(|| self.peer_id.to_string())
+    }
+}
+
 /// Routing-subset descriptor for a trusted peer — the identity fields that
 /// traverse the core seam.
 ///
@@ -411,7 +445,7 @@ pub enum CommsCommandRequest {
     },
     /// Send a one-way peer message.
     PeerMessage {
-        to: PeerName,
+        to: PeerId,
         body: String,
         #[serde(default, skip_serializing_if = "Option::is_none")]
         blocks: Option<Vec<ContentBlock>>,
@@ -420,14 +454,14 @@ pub enum CommsCommandRequest {
     },
     /// Send a one-way peer lifecycle notification.
     PeerLifecycle {
-        to: PeerName,
+        to: PeerId,
         lifecycle_kind: PeerLifecycleKind,
         #[serde(default)]
         params: serde_json::Value,
     },
     /// Send a request to a peer.
     PeerRequest {
-        to: PeerName,
+        to: PeerId,
         intent: String,
         #[serde(default)]
         params: serde_json::Value,
@@ -438,7 +472,7 @@ pub enum CommsCommandRequest {
     },
     /// Send a response to a prior peer request.
     PeerResponse {
-        to: PeerName,
+        to: PeerId,
         in_reply_to: InteractionId,
         status: ResponseStatus,
         #[serde(default)]
@@ -493,7 +527,7 @@ impl CommsCommandRequest {
                 blocks,
                 handling_mode,
             } => CommsCommand::PeerMessage {
-                to,
+                to: PeerRoute::new(to),
                 body,
                 blocks,
                 handling_mode: handling_mode.unwrap_or_default(),
@@ -503,7 +537,7 @@ impl CommsCommandRequest {
                 lifecycle_kind,
                 params,
             } => CommsCommand::PeerLifecycle {
-                to,
+                to: PeerRoute::new(to),
                 kind: lifecycle_kind,
                 params,
             },
@@ -514,7 +548,7 @@ impl CommsCommandRequest {
                 handling_mode,
                 stream,
             } => CommsCommand::PeerRequest {
-                to,
+                to: PeerRoute::new(to),
                 intent,
                 params,
                 handling_mode: handling_mode.unwrap_or_default(),
@@ -531,7 +565,7 @@ impl CommsCommandRequest {
                     return Err(CommsCommandError::HandlingModeForbiddenForAcceptedResponse);
                 }
                 CommsCommand::PeerResponse {
-                    to,
+                    to: PeerRoute::new(to),
                     in_reply_to,
                     status,
                     result,
@@ -614,20 +648,20 @@ pub enum CommsCommand {
     },
     /// Send a one-way peer message.
     PeerMessage {
-        to: PeerName,
+        to: PeerRoute,
         body: String,
         blocks: Option<Vec<ContentBlock>>,
         handling_mode: HandlingMode,
     },
     /// Send a one-way peer lifecycle notification.
     PeerLifecycle {
-        to: PeerName,
+        to: PeerRoute,
         kind: PeerLifecycleKind,
         params: serde_json::Value,
     },
     /// Send a request to a peer.
     PeerRequest {
-        to: PeerName,
+        to: PeerRoute,
         intent: String,
         params: serde_json::Value,
         handling_mode: HandlingMode,
@@ -635,7 +669,7 @@ pub enum CommsCommand {
     },
     /// Send a response to a prior peer request.
     PeerResponse {
-        to: PeerName,
+        to: PeerRoute,
         in_reply_to: InteractionId,
         status: ResponseStatus,
         result: serde_json::Value,

--- a/meerkat-core/src/config.rs
+++ b/meerkat-core/src/config.rs
@@ -2384,13 +2384,16 @@ api_style = "chat_completions"
             Some(Provider::Anthropic)
         );
         assert_eq!(
-            Provider::infer_from_model("gpt-5.2"),
+            Provider::infer_from_model("gpt-5.4"),
             Some(Provider::OpenAI)
         );
         assert_eq!(
             Provider::infer_from_model("gemini-3-flash-preview"),
             Some(Provider::Gemini)
         );
+        assert_eq!(Provider::infer_from_model("gpt-unknown-preview"), None);
+        assert_eq!(Provider::infer_from_model("claude-unknown-preview"), None);
+        assert_eq!(Provider::infer_from_model("gemini-unknown-preview"), None);
         assert_eq!(Provider::infer_from_model("llama-3"), None);
         assert_eq!(Provider::infer_from_model(""), None);
     }

--- a/meerkat-core/src/connection.rs
+++ b/meerkat-core/src/connection.rs
@@ -416,6 +416,35 @@ impl RealmConnectionSet {
             .ok_or_else(|| ProviderBindingError::UnknownAuth(binding.auth_profile.clone()))?;
         Ok((binding, backend, auth))
     }
+
+    /// Resolve a typed connection reference. `ConnectionRef.profile`, when
+    /// present, overrides the binding's configured auth profile while keeping
+    /// the binding's backend and policy authoritative.
+    pub fn lookup_connection_ref(
+        &self,
+        connection_ref: &ConnectionRef,
+    ) -> Result<(&ProviderBinding, &BackendProfile, &AuthProfile), ProviderBindingError> {
+        let binding = self
+            .bindings
+            .get(connection_ref.binding.as_str())
+            .ok_or_else(|| {
+                ProviderBindingError::UnknownBinding(connection_ref.binding.to_string())
+            })?;
+        let backend = self
+            .backends
+            .get(&binding.backend_profile)
+            .ok_or_else(|| ProviderBindingError::UnknownBackend(binding.backend_profile.clone()))?;
+        let auth_profile_id = connection_ref
+            .profile
+            .as_ref()
+            .map(ProfileId::as_str)
+            .unwrap_or(binding.auth_profile.as_str());
+        let auth = self
+            .auth_profiles
+            .get(auth_profile_id)
+            .ok_or_else(|| ProviderBindingError::UnknownAuth(auth_profile_id.to_string()))?;
+        Ok((binding, backend, auth))
+    }
 }
 
 /// Validation / reference-resolution errors for a realm connection set.
@@ -610,6 +639,43 @@ mod tests {
         assert!(s.contains("\"profile\":\"override\""));
         let back: ConnectionRef = serde_json::from_str(&s).unwrap();
         assert_eq!(back, c);
+    }
+
+    #[test]
+    fn connection_ref_profile_overrides_binding_auth_profile() {
+        let toml = r#"
+realm_id = "prod"
+default_binding = "primary"
+
+[backend.openai_default]
+provider = "openai"
+backend_kind = "openai_api"
+base_url = "https://api.openai.com/v1"
+
+[auth.default_profile]
+provider = "openai"
+auth_method = "api_key"
+source = { kind = "env", env = "OPENAI_API_KEY" }
+
+[auth.override_profile]
+provider = "openai"
+auth_method = "api_key"
+source = { kind = "env", env = "OVERRIDE_OPENAI_API_KEY" }
+
+[binding.primary]
+backend_profile = "openai_default"
+auth_profile = "default_profile"
+"#;
+        let section: RealmConfigSection = toml::from_str(toml).unwrap();
+        let realm = RealmConnectionSet::from_config("prod", &section).unwrap();
+        let connection_ref = ConnectionRef {
+            realm: RealmId::parse("prod").unwrap(),
+            binding: BindingId::parse("primary").unwrap(),
+            profile: Some(ProfileId::parse("override_profile").unwrap()),
+        };
+
+        let (_binding, _backend, auth) = realm.lookup_connection_ref(&connection_ref).unwrap();
+        assert_eq!(auth.id, "override_profile");
     }
 
     #[test]

--- a/meerkat-core/src/error.rs
+++ b/meerkat-core/src/error.rs
@@ -231,7 +231,7 @@ pub enum AgentError {
     BuildError(String),
 
     /// MeerkatMachine DSL observed an auth lease in `reauth_required`
-    /// state at a CallingLlm boundary; the binding cannot proceed
+    /// state at a CallingLlm boundary; the lease cannot proceed
     /// until the user re-authenticates (`rkat auth login`). This is a
     /// machine-owned terminal class (Phase 1.5-rev), distinct from
     /// [`AgentError::InternalError`] which is for genuinely

--- a/meerkat-core/src/handles.rs
+++ b/meerkat-core/src/handles.rs
@@ -614,7 +614,46 @@ pub trait SessionAdmissionHandle: Send + Sync {
 // AuthLeaseHandle (Phase 1.5-rev)
 // ---------------------------------------------------------------------------
 
-/// Observable snapshot of an auth lease's DSL state for a given binding_key.
+/// Typed key for one auth lease machine.
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct LeaseKey {
+    pub realm: crate::connection::RealmId,
+    pub binding: crate::connection::BindingId,
+    pub profile: Option<crate::connection::ProfileId>,
+}
+
+impl LeaseKey {
+    pub fn new(
+        realm: crate::connection::RealmId,
+        binding: crate::connection::BindingId,
+        profile: Option<crate::connection::ProfileId>,
+    ) -> Self {
+        Self {
+            realm,
+            binding,
+            profile,
+        }
+    }
+
+    pub fn from_connection_ref(connection_ref: &crate::connection::ConnectionRef) -> Self {
+        Self {
+            realm: connection_ref.realm.clone(),
+            binding: connection_ref.binding.clone(),
+            profile: connection_ref.profile.clone(),
+        }
+    }
+}
+
+impl std::fmt::Display for LeaseKey {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match &self.profile {
+            Some(profile) => write!(f, "{}:{}:{}", self.realm, self.binding, profile),
+            None => write!(f, "{}:{}", self.realm, self.binding),
+        }
+    }
+}
+
+/// Observable snapshot of an auth lease's DSL state for a given [`LeaseKey`].
 ///
 /// Returned by [`AuthLeaseHandle::snapshot`]. If the binding is not tracked
 /// at all, `phase` is `None` and `expires_at` is `None`.
@@ -639,46 +678,54 @@ pub const AUTH_LEASE_TTL_REFRESH_WINDOW_SECS: u64 = 60;
 
 /// Auth lease lifecycle DSL handle.
 pub trait AuthLeaseHandle: Send + Sync {
-    /// Fire `AcquireAuthLease { binding_key, expires_at }` — unconditional.
+    /// Fire `AcquireAuthLease { lease_key, expires_at }` — unconditional.
     ///
     /// Moves the binding into `auth_valid_leases` and records its expiry.
-    fn acquire_lease(&self, binding_key: &str, expires_at: u64) -> Result<(), DslTransitionError>;
+    fn acquire_lease(
+        &self,
+        lease_key: &LeaseKey,
+        expires_at: u64,
+    ) -> Result<(), DslTransitionError>;
 
-    /// Fire `MarkAuthExpiring { binding_key }` — only legal from `valid`.
-    fn mark_expiring(&self, binding_key: &str) -> Result<(), DslTransitionError>;
+    /// Fire `MarkAuthExpiring { lease_key }` — only legal from `valid`.
+    fn mark_expiring(&self, lease_key: &LeaseKey) -> Result<(), DslTransitionError>;
 
-    /// Fire `BeginAuthRefresh { binding_key }` — legal from `valid` or
+    /// Fire `BeginAuthRefresh { lease_key }` — legal from `valid` or
     /// `expiring`.
     ///
     /// Provides the DSL-level refresh dedup: once the binding is in
     /// `auth_refreshing_leases`, no concurrent `BeginAuthRefresh` is
     /// permitted until `CompleteAuthRefresh` or `AuthRefreshFailed` moves
     /// it back out.
-    fn begin_refresh(&self, binding_key: &str) -> Result<(), DslTransitionError>;
+    fn begin_refresh(&self, lease_key: &LeaseKey) -> Result<(), DslTransitionError>;
 
-    /// Fire `CompleteAuthRefresh { binding_key, new_expires_at, now }` — only
+    /// Fire `CompleteAuthRefresh { lease_key, new_expires_at, now }` — only
     /// legal from `refreshing`.
     fn complete_refresh(
         &self,
-        binding_key: &str,
+        lease_key: &LeaseKey,
         new_expires_at: u64,
         now: u64,
     ) -> Result<(), DslTransitionError>;
 
-    /// Fire `AuthRefreshFailed { binding_key, permanent }` — only legal from
+    /// Fire `AuthRefreshFailed { lease_key, permanent }` — only legal from
     /// `refreshing`. `permanent=true` routes to `reauth_required` and emits a
     /// reauth notice; `permanent=false` routes back to `expiring`.
-    fn refresh_failed(&self, binding_key: &str, permanent: bool) -> Result<(), DslTransitionError>;
+    fn refresh_failed(
+        &self,
+        lease_key: &LeaseKey,
+        permanent: bool,
+    ) -> Result<(), DslTransitionError>;
 
-    /// Fire `MarkReauthRequired { binding_key }` — any known state → reauth.
-    fn mark_reauth_required(&self, binding_key: &str) -> Result<(), DslTransitionError>;
+    /// Fire `MarkReauthRequired { lease_key }` — any known state → reauth.
+    fn mark_reauth_required(&self, lease_key: &LeaseKey) -> Result<(), DslTransitionError>;
 
-    /// Fire `ReleaseAuthLease { binding_key }` — removes the binding from all
+    /// Fire `ReleaseAuthLease { lease_key }` — removes the binding from all
     /// sets and the expiry map.
-    fn release_lease(&self, binding_key: &str) -> Result<(), DslTransitionError>;
+    fn release_lease(&self, lease_key: &LeaseKey) -> Result<(), DslTransitionError>;
 
     /// Observe the current DSL-level state of a binding.
-    fn snapshot(&self, binding_key: &str) -> AuthLeaseSnapshot;
+    fn snapshot(&self, lease_key: &LeaseKey) -> AuthLeaseSnapshot;
 }
 
 // ---------------------------------------------------------------------------

--- a/meerkat-core/src/lib.rs
+++ b/meerkat-core/src/lib.rs
@@ -83,8 +83,8 @@ pub use budget::{Budget, BudgetLimits, BudgetPool};
 pub use checkpoint::SessionCheckpointer;
 pub use comms::{
     CommsCommand, EventStream, InputSource, InputStreamMode, PeerDirectoryEntry,
-    PeerDirectorySource, PeerName, PeerReachability, PeerReachabilityReason, SendAndStreamError,
-    SendError, SendReceipt, StreamError, StreamScope,
+    PeerDirectorySource, PeerName, PeerReachability, PeerReachabilityReason, PeerRoute,
+    SendAndStreamError, SendError, SendReceipt, StreamError, StreamScope,
 };
 pub use compact::{
     CompactionConfig, CompactionContext, CompactionResult, Compactor,

--- a/meerkat-core/src/model_profile/mod.rs
+++ b/meerkat-core/src/model_profile/mod.rs
@@ -22,7 +22,9 @@ pub mod gemini;
 pub mod openai;
 pub mod schema_builder;
 
-use crate::model_profile::capabilities::{ModelCapabilities, ThinkingSupport, capabilities_for};
+use crate::model_profile::capabilities::{
+    BetaHeader, ModelCapabilities, ThinkingSupport, capabilities_for,
+};
 use serde::{Deserialize, Serialize};
 
 /// Runtime profile for a model, describing its capabilities and operational defaults.
@@ -58,6 +60,9 @@ pub struct ModelProfile {
     pub supports_web_search: bool,
     /// JSON Schema describing accepted provider-specific parameters.
     pub params_schema: serde_json::Value,
+    /// Beta headers authorized by the model capability catalog.
+    #[serde(default)]
+    pub beta_headers: Vec<ModelBetaHeader>,
     /// Authoritative default call timeout in seconds for this model family.
     ///
     /// `None` means the model family has no profiled default timeout.
@@ -65,6 +70,24 @@ pub struct ModelProfile {
     /// consumed by the factory/agent-loop resolver trait at call time.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub call_timeout_secs: Option<u64>,
+}
+
+/// Catalog-owned beta header metadata for a model.
+#[derive(Debug, Clone, Serialize, Deserialize, schemars::JsonSchema)]
+pub struct ModelBetaHeader {
+    pub feature: String,
+    pub header_name: String,
+    pub header_value: String,
+}
+
+impl From<&BetaHeader> for ModelBetaHeader {
+    fn from(value: &BetaHeader) -> Self {
+        Self {
+            feature: value.feature.to_string(),
+            header_name: value.header_name.to_string(),
+            header_value: value.header_value.to_string(),
+        }
+    }
 }
 
 /// Look up the profile for a model by provider string and model ID.
@@ -104,6 +127,11 @@ pub(crate) fn project_to_profile(caps: &ModelCapabilities) -> ModelProfile {
         image_tool_results: caps.image_tool_results,
         realtime: caps.realtime,
         params_schema: schema_builder::build_params_schema(caps),
+        beta_headers: caps
+            .beta_headers
+            .iter()
+            .map(ModelBetaHeader::from)
+            .collect(),
         call_timeout_secs: caps.call_timeout_secs,
     }
 }

--- a/meerkat-core/src/model_registry.rs
+++ b/meerkat-core/src/model_registry.rs
@@ -100,9 +100,7 @@ impl ModelRegistry {
     }
 
     pub fn profile_for(&self, model_id: &str) -> Option<ModelProfile> {
-        self.entry(model_id)
-            .map(|entry| entry.profile.clone())
-            .or_else(|| inferred_builtin_profile(model_id))
+        self.entry(model_id).map(|entry| entry.profile.clone())
     }
 
     pub fn default_model(&self, provider: Provider) -> Option<&str> {
@@ -123,11 +121,6 @@ impl ModelRegistry {
             .iter()
             .map(|(provider, default_model)| (*provider, default_model.as_str()))
     }
-}
-
-fn inferred_builtin_profile(model_id: &str) -> Option<ModelProfile> {
-    let provider = Provider::infer_from_model(model_id)?;
-    crate::model_profile::profile_for(provider.as_str(), model_id)
 }
 
 fn append_self_hosted(
@@ -179,6 +172,7 @@ fn append_self_hosted(
             image_tool_results: model.image_tool_results,
             realtime: false,
             params_schema: serde_json::json!({}),
+            beta_headers: Vec::new(),
             call_timeout_secs: model.call_timeout_secs,
         };
 
@@ -376,17 +370,13 @@ mod tests {
     }
 
     #[test]
-    fn falls_back_to_inferred_builtin_profiles_for_non_catalog_models() {
+    fn uncatalogued_models_do_not_use_provider_prefix_inference() {
         let registry = match ModelRegistry::from_config(&Config::default()) {
             Ok(registry) => registry,
             Err(err) => panic!("registry construction failed: {err}"),
         };
-        let profile = match registry.profile_for("gpt-5.2") {
-            Some(profile) => profile,
-            None => panic!("gpt-5.2 should resolve via built-in provider inference"),
-        };
-        assert_eq!(profile.provider, "openai");
-        assert!(profile.vision);
-        assert!(!profile.image_tool_results);
+        assert!(registry.profile_for("gpt-unknown-preview").is_none());
+        assert!(registry.profile_for("claude-unknown-preview").is_none());
+        assert!(registry.profile_for("gemini-unknown-preview").is_none());
     }
 }

--- a/meerkat-core/src/provider.rs
+++ b/meerkat-core/src/provider.rs
@@ -38,27 +38,14 @@ impl Provider {
         }
     }
 
-    /// Infer provider from a model name using well-known prefixes.
-    /// Returns `None` when no prefix matches.
+    /// Infer provider from the built-in model catalog.
+    /// Returns `None` for uncatalogued models; callers that admit custom
+    /// models must resolve them through `ModelRegistry`, not name prefixes.
     pub fn infer_from_model(model: &str) -> Option<Self> {
-        let lower = model.to_lowercase();
-
-        // Anthropic: claude-*
-        if lower.starts_with("claude-") {
-            return Some(Self::Anthropic);
-        }
-
-        // OpenAI: gpt-*, chatgpt-*
-        if lower.starts_with("gpt-") || lower.starts_with("chatgpt-") {
-            return Some(Self::OpenAI);
-        }
-
-        // Gemini: gemini-*
-        if lower.starts_with("gemini-") {
-            return Some(Self::Gemini);
-        }
-
-        None
+        crate::model_profile::catalog::catalog()
+            .iter()
+            .find(|entry| entry.id == model)
+            .and_then(|entry| Self::parse_strict(entry.provider))
     }
 
     /// Return the canonical string representation.

--- a/meerkat-core/src/skills/mod.rs
+++ b/meerkat-core/src/skills/mod.rs
@@ -24,6 +24,10 @@ pub use identity::{ResolveError, SkillAlias, SourceIdentityRegistry};
 /// registrations. Embedded skills all live inside this single logical source.
 pub const BUILTIN_SOURCE_UUID: Uuid = Uuid::from_u128(0x0000_0000_0000_4b11_8111_0000_0000_0001);
 
+/// Canonical source UUID for conventional project-local `.rkat/skills`.
+pub const PROJECT_LOCAL_SOURCE_UUID: Uuid =
+    Uuid::from_u128(0x0000_0000_0000_4b11_8111_0000_0000_0002);
+
 /// Canonical source identifier.
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize, PartialOrd, Ord)]
 #[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
@@ -48,6 +52,11 @@ impl SourceUuid {
     /// The canonical UUID for builtin (inventory-registered) skills.
     pub fn builtin() -> Self {
         Self(BUILTIN_SOURCE_UUID)
+    }
+
+    /// The canonical UUID for conventional project-local `.rkat/skills`.
+    pub fn project_local() -> Self {
+        Self(PROJECT_LOCAL_SOURCE_UUID)
     }
 }
 
@@ -635,6 +644,9 @@ pub struct SkillIntrospectionEntry {
     /// If this skill is shadowed, the name of the higher-precedence source.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub shadowed_by: Option<String>,
+    /// Canonical source UUID that shadows this skill, when shadowed.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub shadowed_by_source_uuid: Option<SourceUuid>,
     /// Whether this skill is active (not shadowed).
     pub is_active: bool,
 }
@@ -790,6 +802,7 @@ pub trait SkillSource: Send + Sync {
                 .map(|descriptor| SkillIntrospectionEntry {
                     descriptor,
                     shadowed_by: None,
+                    shadowed_by_source_uuid: None,
                     is_active: true,
                 })
                 .collect())
@@ -949,6 +962,7 @@ pub trait SkillEngine: Send + Sync {
                 .map(|descriptor| SkillIntrospectionEntry {
                     descriptor,
                     shadowed_by: None,
+                    shadowed_by_source_uuid: None,
                     is_active: true,
                 })
                 .collect())

--- a/meerkat-core/src/skills_config.rs
+++ b/meerkat-core/src/skills_config.rs
@@ -211,11 +211,23 @@ impl SkillsConfig {
 impl SkillsConfig {
     /// Build a source identity registry from repository config + governance overlays.
     pub fn build_source_identity_registry(&self) -> Result<SourceIdentityRegistry, SkillError> {
-        let records = self
-            .repositories
-            .iter()
-            .map(repository_to_identity_record)
-            .collect();
+        let mut records: Vec<SourceIdentityRecord> = vec![
+            SourceIdentityRecord {
+                source_uuid: SourceUuid::builtin(),
+                display_name: "embedded".to_string(),
+                transport_kind: SourceTransportKind::Embedded,
+                fingerprint: "embedded:inventory".to_string(),
+                status: SourceIdentityStatus::Active,
+            },
+            SourceIdentityRecord {
+                source_uuid: SourceUuid::project_local(),
+                display_name: "project".to_string(),
+                transport_kind: SourceTransportKind::Filesystem,
+                fingerprint: "filesystem:.rkat/skills".to_string(),
+                status: SourceIdentityStatus::Active,
+            },
+        ];
+        records.extend(self.repositories.iter().map(repository_to_identity_record));
         SourceIdentityRegistry::build(
             records,
             self.identity.lineage.clone(),

--- a/meerkat-llm-core/src/provider_runtime/binding.rs
+++ b/meerkat-llm-core/src/provider_runtime/binding.rs
@@ -251,9 +251,11 @@ impl AuthLease for DynamicLease {
     fn source_label(&self) -> &str {
         &self.source_label
     }
-    async fn refresh(&self, _reason: AuthRefreshReason) -> Result<(), AuthError> {
-        // DynamicLease refresh semantics land in Phase 1.5 (AuthLeaseMachine).
-        Ok(())
+    async fn refresh(&self, reason: AuthRefreshReason) -> Result<(), AuthError> {
+        Err(AuthError::RefreshFailed(format!(
+            "dynamic lease '{}' cannot refresh in place for reason {reason:?}; re-resolve the typed connection_ref",
+            self.source_label
+        )))
     }
 }
 
@@ -275,5 +277,37 @@ mod tests {
         assert!(matches!(lease.kind(), ResolvedAuthKind::StaticHeaders(_)));
         assert_eq!(lease.source_label(), "test");
         assert!(lease.refresh(AuthRefreshReason::Manual).await.is_ok());
+    }
+
+    #[tokio::test]
+    async fn dynamic_lease_refresh_reports_unsupported_instead_of_success() {
+        #[derive(Debug)]
+        struct TestAuthorizer;
+
+        #[async_trait::async_trait]
+        impl HttpAuthorizer for TestAuthorizer {
+            async fn authorize(
+                &self,
+                _req: &mut meerkat_core::auth::HttpAuthorizationRequest<'_>,
+            ) -> Result<(), AuthError> {
+                Ok(())
+            }
+
+            fn label(&self) -> &'static str {
+                "test-authorizer"
+            }
+        }
+
+        let lease: Arc<dyn AuthLease> = Arc::new(DynamicLease::new(
+            Arc::new(TestAuthorizer),
+            AuthMetadata::default(),
+            None,
+            "dynamic:test",
+        ));
+        let err = lease
+            .refresh(AuthRefreshReason::Manual)
+            .await
+            .expect_err("dynamic refresh must not report success without work");
+        assert!(matches!(err, AuthError::RefreshFailed(_)));
     }
 }

--- a/meerkat-llm-core/src/provider_runtime/registry.rs
+++ b/meerkat-llm-core/src/provider_runtime/registry.rs
@@ -9,7 +9,9 @@ use std::sync::Arc;
 use async_trait::async_trait;
 use chrono::{DateTime, Utc};
 
-use meerkat_core::{AuthError, Provider, RealmConnectionSet, ResolvedAuthEnvelope};
+use meerkat_core::{
+    AuthError, Provider, RealmConnectionSet, ResolvedAuthEnvelope, connection::ConnectionRef,
+};
 
 use crate::LlmClient;
 use crate::provider_runtime::binding::{ResolvedConnection, ValidatedBinding};
@@ -163,31 +165,24 @@ impl ProviderRuntimeRegistry {
     pub async fn resolve(
         &self,
         realm: &RealmConnectionSet,
-        binding_id: &str,
+        connection_ref: &ConnectionRef,
         env: &ResolverEnvironment,
     ) -> Result<ResolvedConnection, ProviderAuthError> {
         let (binding, backend, auth) = realm
-            .lookup_binding(binding_id)
+            .lookup_connection_ref(connection_ref)
             .map_err(|e| ProviderAuthError::SourceResolutionFailed(e.to_string()))?;
-        // Wave-c C-1 follow-up: `ConnectionRef` retyped to
-        // `{ realm: RealmId, binding: BindingId, profile: Option<ProfileId> }`
-        // (connection.rs:100). Parse the raw realm / binding slugs here at
-        // the typed boundary — an invalid slug at this point means the
-        // `RealmConnectionSet` was built from malformed config, which is a
-        // resolver-level source error.
-        let connection_ref = meerkat_core::ConnectionRef {
-            realm: meerkat_core::RealmId::parse(&realm.realm_id)
-                .map_err(|e| ProviderAuthError::SourceResolutionFailed(e.to_string()))?,
-            binding: meerkat_core::BindingId::parse(&binding.id)
-                .map_err(|e| ProviderAuthError::SourceResolutionFailed(e.to_string()))?,
-            profile: None,
-        };
+        if connection_ref.realm.as_str() != realm.realm_id {
+            return Err(ProviderAuthError::SourceResolutionFailed(format!(
+                "connection_ref realm '{}' does not match resolved realm '{}'",
+                connection_ref.realm, realm.realm_id
+            )));
+        }
         let runtime = self
             .runtimes
             .get(&backend.provider)
             .ok_or(ProviderAuthError::NoRuntimeRegistered(backend.provider))?;
         let validated = runtime
-            .validate_binding(&connection_ref, backend, auth, &binding.policy)
+            .validate_binding(connection_ref, backend, auth, &binding.policy)
             .map_err(ProviderAuthError::Binding)?;
         runtime.resolve_binding(&validated, env).await
     }

--- a/meerkat-machine-kernels/src/generated/auth.rs
+++ b/meerkat-machine-kernels/src/generated/auth.rs
@@ -6,7 +6,7 @@ mod source {
     // refactored from the original "absorbed into MeerkatMachine"
     // design after review).
     //
-    // Each binding_key (format: "<realm_id>:<binding_id>") has its own
+    // Each typed LeaseKey (realm, binding, optional profile) has its own
     // AuthMachine instance, tracked by the runtime-level registry in
     // `meerkat-runtime/src/handles/auth_lease.rs`. The machine owns the
     // semantics of:

--- a/meerkat-mcp-server/src/lib.rs
+++ b/meerkat-mcp-server/src/lib.rs
@@ -2432,9 +2432,7 @@ async fn handle_meerkat_comms_send(
         meerkat_core::comms::CommsCommandRequest::PeerMessage { to, .. }
         | meerkat_core::comms::CommsCommandRequest::PeerLifecycle { to, .. }
         | meerkat_core::comms::CommsCommandRequest::PeerRequest { to, .. }
-        | meerkat_core::comms::CommsCommandRequest::PeerResponse { to, .. } => {
-            Some(to.as_str().to_string())
-        }
+        | meerkat_core::comms::CommsCommandRequest::PeerResponse { to, .. } => Some(to.as_str()),
     };
     let cmd = input.command.into_command(&session_id).map_err(|err| {
         ToolCallError::new(

--- a/meerkat-mob-mcp/src/agent_tools.rs
+++ b/meerkat-mob-mcp/src/agent_tools.rs
@@ -29,7 +29,7 @@ use ::tokio::sync::RwLock;
 use tokio_with_wasm::alias::sync::RwLock;
 
 use crate::MobMcpState;
-use meerkat_core::comms::{CommsCommand, PeerName};
+use meerkat_core::comms::{CommsCommand, PeerName, PeerRoute};
 
 // ─── Tool name constants ─────────────────────────────────────────────────
 
@@ -119,9 +119,18 @@ impl AgentMobToolSurface {
         let Ok(to) = PeerName::new(recipient_comms_name) else {
             return false;
         };
+        let Some(route) = sender
+            .peers()
+            .await
+            .into_iter()
+            .find(|entry| entry.name == to)
+            .map(|entry| PeerRoute::with_display_name(entry.peer_id, entry.name))
+        else {
+            return false;
+        };
         sender
             .send(CommsCommand::PeerRequest {
-                to,
+                to: route,
                 intent: "mob.peer_added".to_string(),
                 params: serde_json::json!({
                     "peer": peer,
@@ -1921,11 +1930,11 @@ mod tests {
             self.runtimes
                 .write()
                 .await
-                .insert(runtime.name.clone(), runtime);
+                .insert(runtime.key.clone(), runtime);
         }
 
-        async fn get(&self, name: &str) -> Option<Arc<TestCommsRuntime>> {
-            self.runtimes.read().await.get(name).cloned()
+        async fn get(&self, peer_id: &str) -> Option<Arc<TestCommsRuntime>> {
+            self.runtimes.read().await.get(peer_id).cloned()
         }
     }
 
@@ -1988,18 +1997,16 @@ mod tests {
                     stream: _,
                 } => {
                     let trusted = self.trusted.read().await;
-                    if !trusted
-                        .values()
-                        .any(|peer| peer.name.as_str() == to.as_str())
-                    {
-                        return Err(SendError::PeerNotFound(to.as_string()));
+                    let peer_id = to.peer_id.as_str();
+                    if !trusted.contains_key(&peer_id) {
+                        return Err(SendError::PeerNotFound(to.label()));
                     }
                     drop(trusted);
                     let recipient = self
                         .registry
-                        .get(to.as_str())
+                        .get(&peer_id)
                         .await
-                        .ok_or_else(|| SendError::PeerNotFound(to.as_string()))?;
+                        .ok_or_else(|| SendError::PeerNotFound(to.label()))?;
                     recipient.inbox.write().await.push(InboxInteraction {
                         id: InteractionId(uuid::Uuid::new_v4()),
                         from: self.name.clone(),

--- a/meerkat-mob/src/runtime/actor.rs
+++ b/meerkat-mob/src/runtime/actor.rs
@@ -11,7 +11,7 @@ use crate::machines::mob_machine as mob_dsl;
 use crate::tokio;
 use futures::FutureExt;
 use futures::stream::{FuturesUnordered, StreamExt};
-use meerkat_core::comms::{PeerLifecycleKind, TrustedPeerDescriptor};
+use meerkat_core::comms::{PeerLifecycleKind, PeerRoute, TrustedPeerDescriptor};
 use meerkat_core::time_compat::SystemTime;
 use serde::de::DeserializeOwned;
 use std::collections::{HashMap, HashSet, VecDeque};
@@ -8764,15 +8764,11 @@ impl MobActor {
         {
             WiringEndpoint::Local { spec, .. } | WiringEndpoint::PeerOnly { spec, .. } => spec,
         };
-        let peer_name = PeerName::new(recipient_spec.name.clone()).map_err(|error| {
-            MobError::WiringError(format!(
-                "notify_peer_added: invalid recipient comms name '{}': {error}",
-                recipient_spec.name
-            ))
-        })?;
+        let peer_route =
+            PeerRoute::with_display_name(recipient_spec.peer_id, recipient_spec.name.clone());
 
         let cmd = CommsCommand::PeerLifecycle {
-            to: peer_name,
+            to: peer_route,
             kind: PeerLifecycleKind::PeerAdded,
             params: serde_json::json!({
                 "peer": new_peer_id.as_str(),
@@ -8803,12 +8799,8 @@ impl MobActor {
         {
             WiringEndpoint::Local { spec, .. } | WiringEndpoint::PeerOnly { spec, .. } => spec,
         };
-        let peer_name = PeerName::new(recipient_spec.name.clone()).map_err(|error| {
-            MobError::WiringError(format!(
-                "notify_peer_retired: invalid peer comms name '{}': {error}",
-                recipient_spec.name
-            ))
-        })?;
+        let peer_route =
+            PeerRoute::with_display_name(recipient_spec.peer_id, recipient_spec.name.clone());
 
         let params = serde_json::json!({
             "peer": other_peer_id.as_str(),
@@ -8821,17 +8813,17 @@ impl MobActor {
 
         let cmd = match intent {
             "mob.peer_retired" => CommsCommand::PeerLifecycle {
-                to: peer_name,
+                to: peer_route,
                 kind: PeerLifecycleKind::PeerRetired,
                 params,
             },
             "mob.peer_unwired" => CommsCommand::PeerLifecycle {
-                to: peer_name,
+                to: peer_route,
                 kind: PeerLifecycleKind::PeerUnwired,
                 params,
             },
             _ => CommsCommand::PeerRequest {
-                to: peer_name,
+                to: peer_route,
                 intent: intent.to_string(),
                 params,
                 handling_mode: meerkat_core::types::HandlingMode::Queue,

--- a/meerkat-mob/src/runtime/supervisor_bridge.rs
+++ b/meerkat-mob/src/runtime/supervisor_bridge.rs
@@ -4,7 +4,7 @@ use crate::store::SupervisorAuthorityRecord;
 use crate::tokio;
 use meerkat_core::agent::CommsRuntime as CoreCommsRuntime;
 use meerkat_core::comms::{
-    CommsCommand, InputStreamMode, PeerName, SendReceipt, TrustedPeerDescriptor,
+    CommsCommand, InputStreamMode, PeerRoute, SendReceipt, TrustedPeerDescriptor,
 };
 use meerkat_core::interaction::{
     InteractionContent, PeerInputCandidate, TerminalityClass, classify_response_terminality,
@@ -136,12 +136,7 @@ impl MobSupervisorBridge {
         // `SendError::PeerNotFound(recipient.name)` because the supervisor
         // runtime's trusted-peer directory is empty for the new member.
         runtime.add_trusted_peer(recipient.clone()).await?;
-        let to = PeerName::new(recipient.name.clone()).map_err(|error| {
-            MobError::WiringError(format!(
-                "invalid supervisor recipient name '{}': {error}",
-                recipient.name
-            ))
-        })?;
+        let to = PeerRoute::with_display_name(recipient.peer_id, recipient.name.clone());
         let params = serde_json::to_value(payload).map_err(|error| {
             MobError::Internal(format!("serialize supervisor payload: {error}"))
         })?;

--- a/meerkat-mob/src/runtime/tests.rs
+++ b/meerkat-mob/src/runtime/tests.rs
@@ -22,7 +22,7 @@ use meerkat_core::Provider;
 use meerkat_core::agent::CommsRuntime as CoreCommsRuntime;
 use meerkat_core::comms::{
     CommsCommand, PeerDirectoryEntry, PeerDirectorySource, PeerName, PeerReachability,
-    PeerReachabilityReason, SendError, SendReceipt, TrustedPeerDescriptor,
+    PeerReachabilityReason, PeerRoute, SendError, SendReceipt, TrustedPeerDescriptor,
 };
 use meerkat_core::error::ToolError;
 use meerkat_core::event::{AgentEvent, EventEnvelope};
@@ -283,11 +283,9 @@ impl CoreCommsRuntime for MockCommsRuntime {
                 }
 
                 let trusted = self.trusted_peers.read().await;
-                if !trusted
-                    .values()
-                    .any(|peer| peer.name.as_str() == to.as_str())
-                {
-                    return Err(SendError::PeerNotFound(to.as_string()));
+                let peer_id = to.peer_id.as_str();
+                if !trusted.contains_key(&peer_id) {
+                    return Err(SendError::PeerNotFound(to.label()));
                 }
                 drop(trusted);
 
@@ -321,11 +319,9 @@ impl CoreCommsRuntime for MockCommsRuntime {
                 }
 
                 let trusted = self.trusted_peers.read().await;
-                if !trusted
-                    .values()
-                    .any(|peer| peer.name.as_str() == to.as_str())
-                {
-                    return Err(SendError::PeerNotFound(to.as_string()));
+                let peer_id = to.peer_id.as_str();
+                if !trusted.contains_key(&peer_id) {
+                    return Err(SendError::PeerNotFound(to.label()));
                 }
                 drop(trusted);
 
@@ -2773,9 +2769,10 @@ async fn spawn_live_external_peer(peer_name: &str) -> LiveExternalPeerHarness {
                             .await
                             .push(intent.clone());
                         let reply_name = candidate.interaction.from.clone();
-                        let to = PeerName::new(reply_name).expect("bridge response peer name");
+                        let to = test_trusted_peer_route(responder_runtime.as_ref(), &reply_name);
                         let bridge_parse: Result<super::bridge_protocol::BridgeCommand, _> =
                             serde_json::from_value(params.clone());
+                        let mut remove_supervisors_after_response = Vec::new();
                         let response = if let Ok(command) = bridge_parse {
                             match command {
                                 super::bridge_protocol::BridgeCommand::BindMember(payload) => {
@@ -2919,14 +2916,11 @@ async fn spawn_live_external_peer(peer_name: &str) -> LiveExternalPeerHarness {
                                                 || payload.supervisor.peer_id
                                                     != current.supervisor.peer_id.to_string()
                                             {
-                                                let _ = responder_runtime
-                                                    .remove_trusted_peer(
-                                                        &meerkat_comms::PubKey::new(
-                                                            current.supervisor.pubkey,
-                                                        )
-                                                        .to_pubkey_string(),
-                                                    )
-                                                    .await;
+                                                remove_supervisors_after_response.push(
+                                                    meerkat_comms::PubKey::new(
+                                                        current.supervisor.pubkey,
+                                                    ),
+                                                );
                                             }
                                             let supervisor_spec =
                                                 meerkat_core::comms::TrustedPeerDescriptor::try_from(
@@ -2977,12 +2971,8 @@ async fn spawn_live_external_peer(peer_name: &str) -> LiveExternalPeerHarness {
                                             payload.supervisor,
                                         )
                                         .expect("valid supervisor spec");
-                                    let _ = responder_runtime
-                                        .remove_trusted_peer(
-                                            &meerkat_comms::PubKey::new(supervisor_spec.pubkey)
-                                                .to_pubkey_string(),
-                                        )
-                                        .await;
+                                    remove_supervisors_after_response
+                                        .push(meerkat_comms::PubKey::new(supervisor_spec.pubkey));
                                     *responder_supervisor_state.write().await = None;
                                     serde_json::to_value(super::bridge_protocol::BridgeAck {
                                         ok: true,
@@ -3195,6 +3185,11 @@ async fn spawn_live_external_peer(peer_name: &str) -> LiveExternalPeerHarness {
                             panic!("send live external peer response failed: {error}");
                         }
                         responder_runtime.mark_interaction_complete(candidate.interaction.id.0);
+                        for supervisor_pubkey in remove_supervisors_after_response {
+                            let _ = responder_runtime
+                                .remove_trusted_peer(&supervisor_pubkey.to_pubkey_string())
+                                .await;
+                        }
                     }
                     _ => {
                         responder_runtime.mark_interaction_complete(candidate.interaction.id.0);
@@ -3303,6 +3298,43 @@ fn test_comms_name(profile: &str, agent_identity: &str) -> String {
 
 fn test_comms_name_for(mob_id: &MobId, profile: &str, agent_identity: &str) -> String {
     format!("{mob_id}/{profile}/{agent_identity}")
+}
+
+async fn test_peer_route<C>(comms: &C, name: &str) -> PeerRoute
+where
+    C: CoreCommsRuntime + ?Sized,
+{
+    let peers = comms.peers().await;
+    let entry = peers
+        .iter()
+        .find(|entry| entry.name.as_str() == name)
+        .unwrap_or_else(|| panic!("peer route not found for {name}; peers={peers:?}"));
+    PeerRoute::with_display_name(entry.peer_id, entry.name.clone())
+}
+
+fn test_trusted_peer_route(comms: &meerkat_comms::CommsRuntime, name: &str) -> PeerRoute {
+    let trusted = comms.trusted_peers_shared();
+    let trusted = trusted.read();
+    if let Some(peer) = trusted.peers.iter().find(|peer| peer.name == name) {
+        return PeerRoute::with_display_name(
+            peer.pubkey.to_peer_id(),
+            PeerName::new(peer.name.clone()).expect("valid trusted peer name"),
+        );
+    }
+    drop(trusted);
+
+    let namespace = comms.inproc_namespace().unwrap_or("");
+    let inproc_peers = meerkat_comms::InprocRegistry::global().peers_in_namespace(namespace);
+    if let Some(peer) = inproc_peers.iter().find(|peer| peer.name == name) {
+        return PeerRoute::with_display_name(
+            peer.pubkey.to_peer_id(),
+            PeerName::new(peer.name.clone()).expect("valid inproc peer name"),
+        );
+    }
+
+    let trusted = comms.trusted_peers_shared();
+    let trusted = trusted.read();
+    panic!("trusted or inproc peer route not found for {name}; trusted={trusted:?}");
 }
 
 fn with_unique_mob_id(mut definition: MobDefinition, label: &str) -> MobDefinition {
@@ -16554,7 +16586,7 @@ async fn test_peer_message_reaches_idle_autonomous_member_after_kickoff_completi
     let receipt = CoreCommsRuntime::send(
         &*comms_a,
         CommsCommand::PeerMessage {
-            to: PeerName::new(test_comms_name("worker", "w-1")).expect("valid peer name"),
+            to: test_peer_route(&*comms_a, &test_comms_name("worker", "w-1")).await,
             body: "body: please inspect this image".to_string(),
             blocks: Some(vec![
                 meerkat_core::types::ContentBlock::Text {
@@ -16710,7 +16742,7 @@ async fn test_peer_message_reaches_ready_autonomous_member_before_kickoff_settle
     let receipt = CoreCommsRuntime::send(
         &*comms_a,
         CommsCommand::PeerMessage {
-            to: PeerName::new(test_comms_name("worker", "w-prekickoff")).expect("valid peer name"),
+            to: test_peer_route(&*comms_a, &test_comms_name("worker", "w-prekickoff")).await,
             body: "body: immediate orchestration after wait_for_ready".to_string(),
             blocks: Some(vec![
                 meerkat_core::types::ContentBlock::Text {
@@ -16835,8 +16867,7 @@ async fn test_peer_messages_reach_all_ready_autonomous_members_before_kickoff_se
         let receipt = CoreCommsRuntime::send(
             &*comms_lead,
             CommsCommand::PeerMessage {
-                to: PeerName::new(test_comms_name("worker", agent_identity))
-                    .expect("valid peer name"),
+                to: test_peer_route(&*comms_lead, &test_comms_name("worker", agent_identity)).await,
                 body: format!("body: fanout to {agent_identity}"),
                 blocks: Some(vec![
                     meerkat_core::types::ContentBlock::Text {
@@ -16970,7 +17001,7 @@ async fn test_running_peer_message_to_autonomous_member_drains_after_current_app
     CoreCommsRuntime::send(
         &*artist_comms,
         CommsCommand::PeerMessage {
-            to: PeerName::new(test_comms_name("worker", "w-target")).expect("valid peer name"),
+            to: test_peer_route(&*artist_comms, &test_comms_name("worker", "w-target")).await,
             body: "body: first peer message".to_string(),
             blocks: Some(vec![
                 meerkat_core::types::ContentBlock::Text {
@@ -17007,7 +17038,7 @@ async fn test_running_peer_message_to_autonomous_member_drains_after_current_app
     CoreCommsRuntime::send(
         &*helper_comms,
         CommsCommand::PeerMessage {
-            to: PeerName::new(test_comms_name("worker", "w-target")).expect("valid peer name"),
+            to: test_peer_route(&*helper_comms, &test_comms_name("worker", "w-target")).await,
             body: "body: second peer message while running".to_string(),
             blocks: None,
             handling_mode: meerkat_core::types::HandlingMode::Steer,
@@ -17104,7 +17135,7 @@ async fn test_peer_response_reaches_requester_in_runtime_backed_real_comms() {
     let receipt = CoreCommsRuntime::send(
         &*requester_comms,
         CommsCommand::PeerRequest {
-            to: PeerName::new(test_comms_name("worker", "w-responder")).expect("valid peer name"),
+            to: test_peer_route(&*requester_comms, &test_comms_name("worker", "w-responder")).await,
             intent: "interpret_image".to_string(),
             params: serde_json::json!({"description":"tower with a light"}),
             handling_mode: meerkat_core::types::HandlingMode::Steer,
@@ -17137,7 +17168,7 @@ async fn test_peer_response_reaches_requester_in_runtime_backed_real_comms() {
     CoreCommsRuntime::send(
         &*responder_comms,
         CommsCommand::PeerResponse {
-            to: PeerName::new(test_comms_name("lead", "l-requester")).expect("valid peer name"),
+            to: test_peer_route(&*responder_comms, &test_comms_name("lead", "l-requester")).await,
             in_reply_to: request_id,
             status: meerkat_core::ResponseStatus::Completed,
             result: serde_json::json!({"interpretation":"lighthouse"}),
@@ -17395,9 +17426,8 @@ async fn test_wire_enables_peer_request_delivery() {
         "worker should receive mob.peer_added for lead"
     );
 
-    let peer_name = meerkat_core::comms::PeerName::new(&comms_name_b).expect("valid peer name");
     let cmd = meerkat_core::comms::CommsCommand::PeerRequest {
-        to: peer_name,
+        to: test_peer_route(&*comms_a, &comms_name_b).await,
         intent: "mob.test_ping".to_string(),
         params: serde_json::json!({"test": true}),
         handling_mode: meerkat_core::types::HandlingMode::Queue,

--- a/meerkat-mob/src/tests/contracts.rs
+++ b/meerkat-mob/src/tests/contracts.rs
@@ -15,7 +15,7 @@ use meerkat_comms::CommsRuntime;
 use meerkat_core::Provider;
 use meerkat_core::agent::CommsRuntime as CoreCommsRuntime;
 use meerkat_core::comms::{
-    CommsCommand, PeerDirectorySource, PeerName, SendReceipt, TrustedPeerDescriptor,
+    CommsCommand, PeerDirectorySource, PeerName, PeerRoute, SendReceipt, TrustedPeerDescriptor,
 };
 use meerkat_core::service::{
     CreateSessionRequest, SessionBuildOptions, SessionError, SessionInfo, SessionQuery,
@@ -38,6 +38,13 @@ fn inproc_peer_descriptor(
         *runtime.public_key().as_bytes(),
         format!("inproc://{name}"),
     )
+}
+
+fn inproc_peer_route(name: &str, runtime: &CommsRuntime) -> Result<PeerRoute, String> {
+    Ok(PeerRoute::with_display_name(
+        runtime.public_key().to_peer_id(),
+        PeerName::new(name.to_string())?,
+    ))
 }
 
 // ---------------------------------------------------------------------------
@@ -66,7 +73,7 @@ async fn contract_mob_002_peer_request_response_round_trip() {
 
     // Send PeerRequest from sender to receiver
     let request_cmd = CommsCommand::PeerRequest {
-        to: PeerName::new(receiver_name.clone()).expect("valid peer name"),
+        to: inproc_peer_route(&receiver_name, &receiver).expect("valid peer route"),
         intent: "mob.ping".to_string(),
         params: serde_json::json!({"seq": 1}),
         handling_mode: meerkat_core::types::HandlingMode::Queue,
@@ -118,7 +125,7 @@ async fn contract_mob_002_peer_request_response_round_trip() {
 
     // Receiver sends PeerResponse back
     let response_cmd = CommsCommand::PeerResponse {
-        to: PeerName::new(sender_name.clone()).expect("valid peer name"),
+        to: inproc_peer_route(&sender_name, &sender).expect("valid peer route"),
         in_reply_to: request_id,
         status: meerkat_core::ResponseStatus::Completed,
         result: serde_json::json!({"pong": true}),
@@ -220,7 +227,7 @@ async fn contract_mob_002b_terminal_transition_drives_registry_cleanup_via_effec
     // installed, the send path fires `PeerRequestSent` before the
     // reservation commits — an install-then-reject would refuse to send.
     let request_cmd = CommsCommand::PeerRequest {
-        to: PeerName::new(receiver_name.clone()).unwrap(),
+        to: inproc_peer_route(&receiver_name, &receiver).unwrap(),
         intent: "mob.ping".into(),
         params: serde_json::json!({"seq": 1}),
         handling_mode: meerkat_core::types::HandlingMode::Queue,
@@ -372,7 +379,7 @@ async fn contract_mob_002c_dsl_reject_refuses_shell_commit() {
     let ok_receipt = CoreCommsRuntime::send(
         sender.as_ref(),
         CommsCommand::PeerRequest {
-            to: PeerName::new(receiver_name.clone()).unwrap(),
+            to: inproc_peer_route(&receiver_name, &receiver).unwrap(),
             intent: "mob.ping".into(),
             params: serde_json::json!({"seq": 2}),
             handling_mode: meerkat_core::types::HandlingMode::Queue,
@@ -466,7 +473,7 @@ async fn contract_mob_002d_inbound_terminal_reply_closes_lifecycle_via_send() {
     CoreCommsRuntime::send(
         responder.as_ref(),
         CommsCommand::PeerResponse {
-            to: PeerName::new(originator_name.clone()).unwrap(),
+            to: inproc_peer_route(&originator_name, &originator).unwrap(),
             in_reply_to,
             status: meerkat_core::ResponseStatus::Accepted,
             result: serde_json::json!({"progress": true}),
@@ -485,7 +492,7 @@ async fn contract_mob_002d_inbound_terminal_reply_closes_lifecycle_via_send() {
     CoreCommsRuntime::send(
         responder.as_ref(),
         CommsCommand::PeerResponse {
-            to: PeerName::new(originator_name.clone()).unwrap(),
+            to: inproc_peer_route(&originator_name, &originator).unwrap(),
             in_reply_to,
             status: meerkat_core::ResponseStatus::Completed,
             result: serde_json::json!({"done": true}),
@@ -626,7 +633,7 @@ async fn contract_mob_005_remove_trusted_peer_revokes_send() {
 
     // Verify send works before removal
     let cmd = CommsCommand::PeerMessage {
-        to: PeerName::new(receiver_name.clone()).expect("valid peer name"),
+        to: inproc_peer_route(&receiver_name, &receiver).expect("valid peer route"),
         body: "before removal".to_string(),
         blocks: None,
         handling_mode: meerkat_core::types::HandlingMode::Queue,
@@ -656,7 +663,7 @@ async fn contract_mob_005_remove_trusted_peer_revokes_send() {
 
     // Verify send fails after removal
     let cmd_after = CommsCommand::PeerMessage {
-        to: PeerName::new(receiver_name.clone()).expect("valid peer name"),
+        to: inproc_peer_route(&receiver_name, &receiver).expect("valid peer route"),
         body: "after removal".to_string(),
         blocks: None,
         handling_mode: meerkat_core::types::HandlingMode::Queue,
@@ -1017,7 +1024,7 @@ async fn contract_mob_001_keep_alive_session_stays_alive() {
 
     // Verify comms request before additional turns.
     let before_cmd = CommsCommand::PeerRequest {
-        to: PeerName::new(b_name.clone()).expect("valid peer name"),
+        to: inproc_peer_route(&b_name, &comms_b).expect("valid peer route"),
         intent: "mob.contract.before".to_string(),
         params: serde_json::json!({"step": "before_turn"}),
         handling_mode: meerkat_core::types::HandlingMode::Queue,
@@ -1058,7 +1065,7 @@ async fn contract_mob_001_keep_alive_session_stays_alive() {
 
     // Verify comms still works after extra turn.
     let after_cmd = CommsCommand::PeerRequest {
-        to: PeerName::new(a_name.clone()).expect("valid peer name"),
+        to: inproc_peer_route(&a_name, &comms_a).expect("valid peer route"),
         intent: "mob.contract.after".to_string(),
         params: serde_json::json!({"step": "after_turn"}),
         handling_mode: meerkat_core::types::HandlingMode::Queue,

--- a/meerkat-mob/tests/smoke_mob_pictionary.rs
+++ b/meerkat-mob/tests/smoke_mob_pictionary.rs
@@ -487,10 +487,16 @@ async fn send_peer_message(
     body: &str,
     blocks: &[ContentBlock],
 ) -> Result<bool, String> {
+    let to = comms_runtime
+        .peers()
+        .await
+        .into_iter()
+        .find(|entry| entry.name.as_str() == peer_name)
+        .map(|entry| meerkat_core::comms::PeerRoute::with_display_name(entry.peer_id, entry.name))
+        .ok_or_else(|| format!("peer not found: {peer_name}"))?;
     match comms_runtime
         .send(meerkat_core::comms::CommsCommand::PeerMessage {
-            to: meerkat_core::comms::PeerName::new(peer_name)
-                .map_err(|err| format!("invalid peer name {peer_name}: {err}"))?,
+            to,
             body: body.to_string(),
             blocks: Some(blocks.to_vec()),
             handling_mode: HandlingMode::Steer,

--- a/meerkat-models/tests/guards.rs
+++ b/meerkat-models/tests/guards.rs
@@ -67,6 +67,7 @@ const EXPECTED_MODEL_PROFILE_FIELDS: &[&str] = &[
     "realtime",
     "params_schema",
     "call_timeout_secs",
+    "beta_headers",
 ];
 
 #[test]

--- a/meerkat-openai/tests/oauth_resolve.rs
+++ b/meerkat-openai/tests/oauth_resolve.rs
@@ -18,8 +18,8 @@ use meerkat_auth_core::auth_store::{
     EphemeralTokenStore, PersistedAuthMode, PersistedTokens, TokenKey, TokenStore,
 };
 use meerkat_core::{
-    AuthConstraints, AuthProfileConfig, BackendProfileConfig, CredentialSourceSpec,
-    ProviderBindingConfig, RealmConfigSection, RealmConnectionSet,
+    AuthConstraints, AuthProfileConfig, BackendProfileConfig, BindingId, ConnectionRef,
+    CredentialSourceSpec, ProviderBindingConfig, RealmConfigSection, RealmConnectionSet, RealmId,
 };
 use meerkat_llm_core::provider_runtime::{ProviderRuntimeRegistry, ResolverEnvironment};
 use meerkat_openai::runtime::oauth as o_oauth;
@@ -71,6 +71,14 @@ fn openai_realm(backend_kind: &str, auth_method: &str) -> RealmConnectionSet {
     .unwrap()
 }
 
+fn default_connection_ref() -> ConnectionRef {
+    ConnectionRef {
+        realm: RealmId::parse("dev").expect("valid realm"),
+        binding: BindingId::parse("default_chatgpt").expect("valid binding"),
+        profile: None,
+    }
+}
+
 // --- OpenAI managed_chatgpt_oauth ------------------------------------
 
 #[tokio::test]
@@ -103,7 +111,7 @@ async fn openai_managed_chatgpt_oauth_fresh_token_resolves() {
     let registry = ProviderRuntimeRegistry::empty()
         .with_runtime(std::sync::Arc::new(meerkat_openai::OpenAiProviderRuntime));
     let connection = registry
-        .resolve(&realm, "default_chatgpt", &env)
+        .resolve(&realm, &default_connection_ref(), &env)
         .await
         .expect("fresh ChatGPT tokens should resolve");
     assert_eq!(
@@ -139,7 +147,7 @@ async fn openai_external_chatgpt_tokens_returns_persisted_access() {
     let registry = ProviderRuntimeRegistry::empty()
         .with_runtime(std::sync::Arc::new(meerkat_openai::OpenAiProviderRuntime));
     let connection = registry
-        .resolve(&realm, "default_chatgpt", &env)
+        .resolve(&realm, &default_connection_ref(), &env)
         .await
         .expect("external tokens should resolve");
     assert_eq!(
@@ -156,7 +164,7 @@ async fn openai_chatgpt_oauth_missing_tokens_surfaces_interactive_login_required
     let registry = ProviderRuntimeRegistry::empty()
         .with_runtime(std::sync::Arc::new(meerkat_openai::OpenAiProviderRuntime));
     let err = registry
-        .resolve(&realm, "default_chatgpt", &env)
+        .resolve(&realm, &default_connection_ref(), &env)
         .await
         .unwrap_err();
     assert!(

--- a/meerkat-providers/src/lib.rs
+++ b/meerkat-providers/src/lib.rs
@@ -37,6 +37,10 @@ pub mod auth_oauth {
     pub use meerkat_auth_core::auth_oauth::*;
 }
 #[cfg(not(target_arch = "wasm32"))]
+pub mod oauth_flow {
+    pub use meerkat_auth_core::oauth_flow::*;
+}
+#[cfg(not(target_arch = "wasm32"))]
 pub mod auth_store {
     pub use meerkat_auth_core::auth_store::*;
 }

--- a/meerkat-rest/src/auth_endpoints.rs
+++ b/meerkat-rest/src/auth_endpoints.rs
@@ -437,9 +437,8 @@ pub async fn test_auth_profile(
 
 // --- OAuth login flow -----------------------------------------------
 //
-// The PKCE verifier + state are returned to the client in /login/start;
-// the client holds them and posts them back in /login/complete along
-// with the authorization code it received from the provider.
+// The server owns the state -> PKCE verifier correlation. The client receives
+// only the authorize URL and state, then posts the provider code with that state.
 
 fn provider_endpoints(
     provider: &str,
@@ -488,9 +487,16 @@ pub async fn start_login(Json(body): Json<LoginStartBody>) -> impl IntoResponse 
     let state_token = match global_oauth_flow_registry().start(
         body.provider.clone(),
         body.redirect_uri.clone(),
-        verifier.clone(),
+        verifier,
     ) {
         Ok(state) => state,
+        Err(OAuthFlowError::CapacityExceeded { .. }) => {
+            return (
+                StatusCode::SERVICE_UNAVAILABLE,
+                Json(serde_json::json!({ "error": "oauth state registry is at capacity" })),
+            )
+                .into_response();
+        }
         Err(e) => {
             return (
                 StatusCode::INTERNAL_SERVER_ERROR,
@@ -505,8 +511,6 @@ pub async fn start_login(Json(body): Json<LoginStartBody>) -> impl IntoResponse 
         Json(WireLoginStart {
             authorize_url,
             state: state_token,
-            pkce_verifier: verifier,
-            pkce_challenge: pkce.challenge.code.clone(),
             redirect_uri: body.redirect_uri,
             provider: body.provider,
         }),
@@ -519,8 +523,6 @@ pub struct LoginCompleteBody {
     pub provider: String,
     pub code: String,
     pub state: String,
-    #[serde(default, rename = "pkce_verifier")]
-    pkce_verifier: Option<String>,
     pub redirect_uri: String,
     #[serde(default = "default_realm")]
     pub realm_id: RealmId,
@@ -588,16 +590,6 @@ pub async fn complete_login(
                 .into_response();
             }
         };
-
-    if let Some(client_verifier) = &body.pkce_verifier
-        && client_verifier != &flow.pkce_verifier
-    {
-        return (
-            StatusCode::BAD_REQUEST,
-            Json(serde_json::json!({ "error": "pkce_verifier does not match oauth state" })),
-        )
-            .into_response();
-    }
 
     let http = reqwest::Client::new();
     let result = match exchange_authorization_code(

--- a/meerkat-rest/src/auth_endpoints.rs
+++ b/meerkat-rest/src/auth_endpoints.rs
@@ -6,9 +6,9 @@
 //! credentials are visible to the AgentFactory's `resolve_binding`
 //! path.
 //!
-//! The OAuth PKCE verifier is held client-side (returned in
-//! /login/start and passed back in /login/complete) so the server
-//! doesn't need a session map.
+//! OAuth state and PKCE verifier correlation is owned server-side by
+//! `OAuthFlowRegistry`; complete consumes the state before exchanging
+//! the provider code.
 
 use std::sync::Arc;
 
@@ -33,6 +33,7 @@ use meerkat_providers::auth_oauth::{
     poll_device_code, request_device_code,
 };
 use meerkat_providers::auth_store::{PersistedAuthMode, PersistedTokens, TokenKey};
+use meerkat_providers::oauth_flow::{OAuthFlowError, global_oauth_flow_registry};
 
 use crate::AppState;
 
@@ -388,10 +389,12 @@ pub async fn test_auth_profile(
             let registry = meerkat_providers::ProviderRuntimeRegistry::empty();
             let env = meerkat_providers::ResolverEnvironment::with_process_env()
                 .with_token_store(Arc::clone(&state.token_store));
-            match registry
-                .resolve(&realm, body.binding_id.as_str(), &env)
-                .await
-            {
+            let connection_ref = ConnectionRef {
+                realm: body.realm_id.clone(),
+                binding: body.binding_id.clone(),
+                profile: None,
+            };
+            match registry.resolve(&realm, &connection_ref, &env).await {
                 Ok(conn) => {
                     let (connection_ref, binding, auth_profile) =
                         match resolve_binding_identity(&state, &body.realm_id, &body.binding_id)
@@ -481,20 +484,28 @@ pub async fn start_login(Json(body): Json<LoginStartBody>) -> impl IntoResponse 
         }
     };
     let pkce = PkcePair::generate_s256();
-    let state_token = format!(
-        "st-{}",
-        std::time::SystemTime::now()
-            .duration_since(std::time::UNIX_EPOCH)
-            .map(|d| d.as_nanos())
-            .unwrap_or(0),
-    );
+    let verifier = pkce.verifier.secret().to_string();
+    let state_token = match global_oauth_flow_registry().start(
+        body.provider.clone(),
+        body.redirect_uri.clone(),
+        verifier.clone(),
+    ) {
+        Ok(state) => state,
+        Err(e) => {
+            return (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(serde_json::json!({ "error": format!("oauth state initialization failed: {e}") })),
+            )
+                .into_response();
+        }
+    };
     let authorize_url = endpoints.authorize_url_with_pkce(&pkce.challenge, &state_token);
     (
         StatusCode::OK,
         Json(WireLoginStart {
             authorize_url,
             state: state_token,
-            pkce_verifier: pkce.verifier.secret().to_string(),
+            pkce_verifier: verifier,
             pkce_challenge: pkce.challenge.code.clone(),
             redirect_uri: body.redirect_uri,
             provider: body.provider,
@@ -507,7 +518,9 @@ pub async fn start_login(Json(body): Json<LoginStartBody>) -> impl IntoResponse 
 pub struct LoginCompleteBody {
     pub provider: String,
     pub code: String,
-    pub pkce_verifier: String,
+    pub state: String,
+    #[serde(default, rename = "pkce_verifier")]
+    pkce_verifier: Option<String>,
     pub redirect_uri: String,
     #[serde(default = "default_realm")]
     pub realm_id: RealmId,
@@ -554,12 +567,44 @@ pub async fn complete_login(
             .into_response();
     }
 
+    let flow =
+        match global_oauth_flow_registry().consume(&body.state, &body.provider, &body.redirect_uri)
+        {
+            Ok(flow) => flow,
+            Err(OAuthFlowError::Missing) => {
+                return (
+                    StatusCode::BAD_REQUEST,
+                    Json(serde_json::json!({ "error": "oauth state is missing or expired" })),
+                )
+                    .into_response();
+            }
+            Err(e) => {
+                return (
+                StatusCode::BAD_REQUEST,
+                Json(
+                    serde_json::json!({ "error": format!("oauth state verification failed: {e}") }),
+                ),
+            )
+                .into_response();
+            }
+        };
+
+    if let Some(client_verifier) = &body.pkce_verifier
+        && client_verifier != &flow.pkce_verifier
+    {
+        return (
+            StatusCode::BAD_REQUEST,
+            Json(serde_json::json!({ "error": "pkce_verifier does not match oauth state" })),
+        )
+            .into_response();
+    }
+
     let http = reqwest::Client::new();
     let result = match exchange_authorization_code(
         &http,
         &endpoints,
         &body.code,
-        &body.pkce_verifier,
+        &flow.pkce_verifier,
         client_secret,
     )
     .await

--- a/meerkat-rest/src/lib.rs
+++ b/meerkat-rest/src/lib.rs
@@ -1857,16 +1857,16 @@ pub struct CommsSendRequest {
 }
 
 impl CommsSendRequest {
-    /// Recipient peer name for error normalization, if the command targets one.
+    /// Recipient peer id for error normalization, if the command targets one.
     ///
-    fn peer_name(&self) -> Option<&str> {
+    fn peer_label(&self) -> Option<String> {
         use meerkat_core::comms::CommsCommandRequest;
         match &self.command {
             CommsCommandRequest::Input { .. } => None,
             CommsCommandRequest::PeerMessage { to, .. }
             | CommsCommandRequest::PeerLifecycle { to, .. }
             | CommsCommandRequest::PeerRequest { to, .. }
-            | CommsCommandRequest::PeerResponse { to, .. } => Some(to.as_str()),
+            | CommsCommandRequest::PeerResponse { to, .. } => Some(to.to_string()),
         }
     }
 }
@@ -1904,7 +1904,7 @@ async fn comms_send(
             ))
         })?;
 
-    let peer_name = req.peer_name().map(str::to_string);
+    let peer_name = req.peer_label();
     let cmd = req
         .command
         .into_command(&session_id)
@@ -5677,8 +5677,11 @@ mod tests {
 
     #[test]
     fn test_comms_send_request_peer_request_invalid_stream_rejected_at_serde() {
-        let json = r#"{"session_id":"sid_123","kind":"peer_request","to":"alice","intent":"ask","stream":"invalid"}"#;
-        let err = serde_json::from_str::<CommsSendRequest>(json)
+        let json = format!(
+            r#"{{"session_id":"sid_123","kind":"peer_request","to":"{}","intent":"ask","stream":"invalid"}}"#,
+            uuid::Uuid::new_v4()
+        );
+        let err = serde_json::from_str::<CommsSendRequest>(&json)
             .expect_err("invalid stream must fail deserialization");
         assert!(
             err.to_string().contains("stream") || err.to_string().contains("invalid"),
@@ -5689,7 +5692,8 @@ mod tests {
     #[test]
     fn test_comms_send_request_peer_response_invalid_status_rejected_at_serde() {
         let json = format!(
-            r#"{{"session_id":"sid_123","kind":"peer_response","to":"alice","in_reply_to":"{}","status":"almost-done"}}"#,
+            r#"{{"session_id":"sid_123","kind":"peer_response","to":"{}","in_reply_to":"{}","status":"almost-done"}}"#,
+            uuid::Uuid::new_v4(),
             uuid::Uuid::new_v4()
         );
         let err = serde_json::from_str::<CommsSendRequest>(&json)
@@ -5789,7 +5793,7 @@ mod tests {
         };
         assert!(!rest_continue_requires_rebuild(&req));
 
-        req.model = Some("gpt-5.2".into());
+        req.model = Some("gpt-5.4".into());
         assert!(rest_continue_requires_rebuild(&req));
         req.model = None;
 

--- a/meerkat-rpc/src/handlers/auth.rs
+++ b/meerkat-rpc/src/handlers/auth.rs
@@ -1,10 +1,10 @@
 //! `auth/*` + `realm/*` method handlers.
 //!
 //! Real implementations using the shared `SessionRuntime.token_store()`.
-//! OAuth login is split across two calls (client keeps PKCE verifier):
+//! OAuth login is split across two calls (server keeps state -> PKCE verifier):
 //!
 //!   auth/login/start     → returns authorize_url + state + pkce_verifier
-//!   auth/login/complete  → exchanges code + pkce_verifier → persists
+//!   auth/login/complete  → verifies state, exchanges code → persists
 
 use std::sync::Arc;
 
@@ -22,6 +22,7 @@ use meerkat_providers::auth_oauth::{
     poll_device_code, request_device_code,
 };
 use meerkat_providers::auth_store::{PersistedAuthMode, PersistedTokens, TokenKey};
+use meerkat_providers::oauth_flow::{OAuthFlowError, global_oauth_flow_registry};
 
 use super::{RpcResponseExt, parse_params};
 use crate::error;
@@ -433,20 +434,28 @@ pub async fn handle_auth_login_start(id: Option<RpcId>, params: Option<&RawValue
             }
         };
     let pkce = PkcePair::generate_s256();
-    let state_token = format!(
-        "st-{}",
-        std::time::SystemTime::now()
-            .duration_since(std::time::UNIX_EPOCH)
-            .map(|d| d.as_nanos())
-            .unwrap_or(0),
-    );
+    let verifier = pkce.verifier.secret().clone();
+    let state_token = match global_oauth_flow_registry().start(
+        parsed.provider.clone(),
+        parsed.redirect_uri.clone(),
+        verifier.clone(),
+    ) {
+        Ok(state) => state,
+        Err(e) => {
+            return RpcResponse::error(
+                id,
+                error::INTERNAL_ERROR,
+                format!("oauth state initialization failed: {e}"),
+            );
+        }
+    };
     let authorize_url = endpoints.authorize_url_with_pkce(&pkce.challenge, &state_token);
     RpcResponse::success(
         id,
         serde_json::json!({
             "authorize_url": authorize_url,
             "state": state_token,
-            "pkce_verifier": pkce.verifier.secret(),
+            "pkce_verifier": verifier,
             "pkce_challenge": pkce.challenge.code,
             "redirect_uri": parsed.redirect_uri,
             "provider": parsed.provider,
@@ -458,7 +467,9 @@ pub async fn handle_auth_login_start(id: Option<RpcId>, params: Option<&RawValue
 struct LoginCompleteParams {
     provider: String,
     code: String,
-    pkce_verifier: String,
+    state: String,
+    #[serde(default, rename = "pkce_verifier")]
+    pkce_verifier: Option<String>,
     redirect_uri: String,
     realm_id: String,
     #[serde(default)]
@@ -505,6 +516,38 @@ pub async fn handle_auth_login_complete(
         );
     }
 
+    let flow = match global_oauth_flow_registry().consume(
+        &parsed.state,
+        &parsed.provider,
+        &parsed.redirect_uri,
+    ) {
+        Ok(flow) => flow,
+        Err(OAuthFlowError::Missing) => {
+            return RpcResponse::error(
+                id,
+                error::INVALID_PARAMS,
+                "oauth state is missing or expired",
+            );
+        }
+        Err(e) => {
+            return RpcResponse::error(
+                id,
+                error::INVALID_PARAMS,
+                format!("oauth state verification failed: {e}"),
+            );
+        }
+    };
+
+    if let Some(client_verifier) = &parsed.pkce_verifier
+        && client_verifier != &flow.pkce_verifier
+    {
+        return RpcResponse::error(
+            id,
+            error::INVALID_PARAMS,
+            "pkce_verifier does not match oauth state",
+        );
+    }
+
     let store = match require_token_store(runtime, id.clone()) {
         Ok(s) => s,
         Err(r) => return r,
@@ -514,7 +557,7 @@ pub async fn handle_auth_login_complete(
         &http,
         &endpoints,
         &parsed.code,
-        &parsed.pkce_verifier,
+        &flow.pkce_verifier,
         client_secret,
     )
     .await

--- a/meerkat-rpc/src/handlers/auth.rs
+++ b/meerkat-rpc/src/handlers/auth.rs
@@ -3,7 +3,7 @@
 //! Real implementations using the shared `SessionRuntime.token_store()`.
 //! OAuth login is split across two calls (server keeps state -> PKCE verifier):
 //!
-//!   auth/login/start     → returns authorize_url + state + pkce_verifier
+//!   auth/login/start     → returns authorize_url + state
 //!   auth/login/complete  → verifies state, exchanges code → persists
 
 use std::sync::Arc;
@@ -438,9 +438,16 @@ pub async fn handle_auth_login_start(id: Option<RpcId>, params: Option<&RawValue
     let state_token = match global_oauth_flow_registry().start(
         parsed.provider.clone(),
         parsed.redirect_uri.clone(),
-        verifier.clone(),
+        verifier,
     ) {
         Ok(state) => state,
+        Err(OAuthFlowError::CapacityExceeded { .. }) => {
+            return RpcResponse::error(
+                id,
+                error::INTERNAL_ERROR,
+                "oauth state registry is at capacity",
+            );
+        }
         Err(e) => {
             return RpcResponse::error(
                 id,
@@ -455,8 +462,6 @@ pub async fn handle_auth_login_start(id: Option<RpcId>, params: Option<&RawValue
         serde_json::json!({
             "authorize_url": authorize_url,
             "state": state_token,
-            "pkce_verifier": verifier,
-            "pkce_challenge": pkce.challenge.code,
             "redirect_uri": parsed.redirect_uri,
             "provider": parsed.provider,
         }),
@@ -468,8 +473,6 @@ struct LoginCompleteParams {
     provider: String,
     code: String,
     state: String,
-    #[serde(default, rename = "pkce_verifier")]
-    pkce_verifier: Option<String>,
     redirect_uri: String,
     realm_id: String,
     #[serde(default)]
@@ -537,16 +540,6 @@ pub async fn handle_auth_login_complete(
             );
         }
     };
-
-    if let Some(client_verifier) = &parsed.pkce_verifier
-        && client_verifier != &flow.pkce_verifier
-    {
-        return RpcResponse::error(
-            id,
-            error::INVALID_PARAMS,
-            "pkce_verifier does not match oauth state",
-        );
-    }
 
     let store = match require_token_store(runtime, id.clone()) {
         Ok(s) => s,

--- a/meerkat-rpc/src/handlers/comms.rs
+++ b/meerkat-rpc/src/handlers/comms.rs
@@ -112,15 +112,15 @@ pub struct CommsSendParams {
 }
 
 impl CommsSendParams {
-    /// Recipient peer name for error normalization, if the command targets one.
-    pub fn peer_name(&self) -> Option<&str> {
+    /// Recipient peer id for error normalization, if the command targets one.
+    pub fn peer_label(&self) -> Option<String> {
         use meerkat_core::comms::CommsCommandRequest;
         match &self.command {
             CommsCommandRequest::Input { .. } => None,
             CommsCommandRequest::PeerMessage { to, .. }
             | CommsCommandRequest::PeerLifecycle { to, .. }
             | CommsCommandRequest::PeerRequest { to, .. }
-            | CommsCommandRequest::PeerResponse { to, .. } => Some(to.as_str()),
+            | CommsCommandRequest::PeerResponse { to, .. } => Some(to.to_string()),
         }
     }
 }
@@ -158,7 +158,7 @@ pub async fn handle_send(
         }
     };
 
-    let peer_name = params.peer_name().map(str::to_string);
+    let peer_name = params.peer_label();
     let cmd = match params.command.into_command(&session_id) {
         Ok(cmd) => cmd,
         Err(err) => {
@@ -282,8 +282,12 @@ mod tests {
 
     #[test]
     fn deserialize_peer_response_invalid_status_fails_at_serde_boundary() {
-        let json = r#"{"session_id":"sid_1","kind":"peer_response","to":"alice","in_reply_to":"00000000-0000-0000-0000-000000000000","status":"almost-done"}"#;
-        let err = serde_json::from_str::<CommsSendParams>(json).unwrap_err();
+        let json = format!(
+            r#"{{"session_id":"sid_1","kind":"peer_response","to":"{}","in_reply_to":"{}","status":"almost-done"}}"#,
+            uuid::Uuid::new_v4(),
+            uuid::Uuid::new_v4()
+        );
+        let err = serde_json::from_str::<CommsSendParams>(&json).unwrap_err();
         assert!(
             err.to_string().contains("status") || err.to_string().contains("almost-done"),
             "expected invalid-status serde error, got: {err}"

--- a/meerkat-rpc/src/router.rs
+++ b/meerkat-rpc/src/router.rs
@@ -1713,7 +1713,7 @@ impl MethodRouter {
                 format!("Session not found or comms not enabled: {session_id}"),
             );
         };
-        let peer_name = params.peer_name().map(str::to_string);
+        let peer_name = params.peer_label();
         let cmd = match params.command.into_command(&session_id) {
             Ok(cmd) => cmd,
             Err(err) => {
@@ -3688,7 +3688,7 @@ mod tests {
     #[tokio::test]
     async fn mob_member_stream_surfaces_run_completed_for_late_terminal_peer_response() {
         use meerkat_core::agent::CommsRuntime as CoreCommsRuntime;
-        use meerkat_core::comms::{CommsCommand, PeerName, TrustedPeerDescriptor};
+        use meerkat_core::comms::{CommsCommand, PeerName, PeerRoute, TrustedPeerDescriptor};
         use meerkat_core::interaction::InteractionId;
 
         let (router, mut notif_rx) = test_router().await;
@@ -3816,7 +3816,10 @@ mod tests {
         CoreCommsRuntime::send(
             &*sender,
             CommsCommand::PeerResponse {
-                to: PeerName::new(format!("{mob_id}/worker/worker-1")).expect("valid peer name"),
+                to: PeerRoute::with_display_name(
+                    operator_pubkey.to_peer_id(),
+                    PeerName::new(format!("{mob_id}/worker/worker-1")).expect("valid peer name"),
+                ),
                 in_reply_to: InteractionId(uuid::Uuid::new_v4()),
                 status: meerkat_core::ResponseStatus::Completed,
                 result: serde_json::json!({

--- a/meerkat-rpc/src/session_runtime.rs
+++ b/meerkat-rpc/src/session_runtime.rs
@@ -4922,7 +4922,7 @@ mod tests {
     async fn keep_alive_comms_drain_emits_run_completed_for_terminal_peer_response() {
         use futures::StreamExt;
         use meerkat_core::agent::CommsRuntime as CoreCommsRuntime;
-        use meerkat_core::comms::{CommsCommand, PeerName, TrustedPeerDescriptor};
+        use meerkat_core::comms::{CommsCommand, PeerName, PeerRoute, TrustedPeerDescriptor};
         use meerkat_core::interaction::InteractionId;
 
         let temp = tempfile::tempdir().expect("tempdir");
@@ -5011,7 +5011,10 @@ mod tests {
         CoreCommsRuntime::send(
             &*sender,
             CommsCommand::PeerResponse {
-                to: PeerName::new(operator_name.to_string()).expect("valid operator peer name"),
+                to: PeerRoute::with_display_name(
+                    operator_pubkey.to_peer_id(),
+                    PeerName::new(operator_name.to_string()).expect("valid operator peer name"),
+                ),
                 in_reply_to: InteractionId(uuid::Uuid::new_v4()),
                 status: meerkat_core::ResponseStatus::Completed,
                 result: serde_json::json!({
@@ -7058,7 +7061,7 @@ mod tests {
 
         // Hot-swap to an OpenAI model (does NOT support image_tool_results).
         let overrides = crate::handlers::turn::TurnOverrides {
-            model: Some("gpt-5.2".to_string()),
+            model: Some("gpt-5.4".to_string()),
             ..Default::default()
         };
         let (event_tx2, _event_rx2) = mpsc::channel(100);
@@ -7125,7 +7128,7 @@ mod tests {
 
         // Hot-swap to OpenAI (deny view_image).
         let overrides = crate::handlers::turn::TurnOverrides {
-            model: Some("gpt-5.2".to_string()),
+            model: Some("gpt-5.4".to_string()),
             ..Default::default()
         };
         let (event_tx2, _event_rx2) = mpsc::channel(100);
@@ -7220,7 +7223,7 @@ mod tests {
 
         // Hot-swap to OpenAI — should add view_image to the deny set, not replace it.
         let overrides = crate::handlers::turn::TurnOverrides {
-            model: Some("gpt-5.2".to_string()),
+            model: Some("gpt-5.4".to_string()),
             ..Default::default()
         };
         let (event_tx2, _event_rx2) = mpsc::channel(100);
@@ -7488,7 +7491,7 @@ mod tests {
             "reasoning": { "effort": "medium" }
         });
         let overrides = crate::handlers::turn::TurnOverrides {
-            model: Some("gpt-5.2".to_string()),
+            model: Some("gpt-5.4".to_string()),
             provider_params: Some(provider_params.clone()),
             ..Default::default()
         };
@@ -7510,7 +7513,7 @@ mod tests {
             .read_session_rich(&session_id)
             .await
             .expect("read_session_rich after hot-swap");
-        assert_eq!(info.model, "gpt-5.2");
+        assert_eq!(info.model, "gpt-5.4");
         assert_eq!(info.provider, "openai");
 
         runtime
@@ -7544,7 +7547,7 @@ mod tests {
             .read_session_rich(&session_id)
             .await
             .expect("read recovered session after re-materialization");
-        assert_eq!(info.model, "gpt-5.2", "recovered model must match hot-swap");
+        assert_eq!(info.model, "gpt-5.4", "recovered model must match hot-swap");
         assert_eq!(
             info.provider, "openai",
             "recovered provider must match hot-swap"

--- a/meerkat-runtime/src/auth_machine/dsl.rs
+++ b/meerkat-runtime/src/auth_machine/dsl.rs
@@ -4,7 +4,7 @@ use meerkat_machine_dsl::machine;
 // refactored from the original "absorbed into MeerkatMachine"
 // design after review).
 //
-// Each binding_key (format: "<realm_id>:<binding_id>") has its own
+// Each typed LeaseKey (realm, binding, optional profile) has its own
 // AuthMachine instance, tracked by the runtime-level registry in
 // `meerkat-runtime/src/handles/auth_lease.rs`. The machine owns the
 // semantics of:

--- a/meerkat-runtime/src/auth_machine/mod.rs
+++ b/meerkat-runtime/src/auth_machine/mod.rs
@@ -1,8 +1,8 @@
 //! AuthMachine runtime surface.
 //!
-//! Per-binding auth-lease lifecycle machine. Each `binding_key`
-//! (format `"<realm_id>:<binding_id>"`) has its own `AuthMachine`
-//! instance, managed by the per-binding registry in
+//! Per-binding auth-lease lifecycle machine. Each typed `LeaseKey`
+//! (`realm`, `binding`, optional `profile`) has its own `AuthMachine`
+//! instance, managed by the lease-key registry in
 //! `meerkat-runtime/src/handles/auth_lease.rs`.
 //!
 //! See `dsl.rs` for the machine definition. See

--- a/meerkat-runtime/src/comms_drain.rs
+++ b/meerkat-runtime/src/comms_drain.rs
@@ -12,7 +12,7 @@ use std::time::Duration;
 
 use meerkat_core::agent::CommsRuntime;
 #[allow(unused_imports)]
-use meerkat_core::comms::{CommsCommand, PeerId, PeerName, TrustedPeerDescriptor};
+use meerkat_core::comms::{CommsCommand, PeerId, PeerName, PeerRoute, TrustedPeerDescriptor};
 use meerkat_core::event::AgentEvent;
 use meerkat_core::interaction::{InteractionContent, PeerInputCandidate, PeerInputClass};
 use meerkat_core::lifecycle::RunControlCommand;
@@ -818,14 +818,13 @@ async fn send_bridge_response(
             "reason": "bridge reply serialization failed",
         })
     });
-    let to = match PeerName::new(candidate.interaction.from.clone()) {
-        Ok(name) => name,
-        Err(error) => {
+    let to = match resolve_peer_route(comms_runtime, &candidate.interaction.from).await {
+        Some(route) => route,
+        None => {
             tracing::warn!(
                 from = %candidate.interaction.from,
                 interaction_id = %candidate.interaction.id,
-                error = %error,
-                "comms_drain: failed to route bridge response"
+                "comms_drain: failed to resolve bridge response peer route"
             );
             comms_runtime.mark_interaction_complete(&candidate.interaction.id);
             return;
@@ -850,6 +849,28 @@ async fn send_bridge_response(
         );
     }
     comms_runtime.mark_interaction_complete(&candidate.interaction.id);
+}
+
+async fn resolve_peer_route(
+    comms_runtime: &Arc<dyn CommsRuntime>,
+    from: &str,
+) -> Option<PeerRoute> {
+    let peers = comms_runtime.peers().await;
+    peers
+        .iter()
+        .find(|entry| entry.peer_id.as_str() == from)
+        .or_else(|| peers.iter().find(|entry| entry.name.as_str() == from))
+        .map(|entry| PeerRoute::with_display_name(entry.peer_id, entry.name.clone()))
+        .or_else(|| {
+            meerkat_core::comms::PeerId::parse(from)
+                .ok()
+                .map(PeerRoute::new)
+        })
+        .or_else(|| {
+            PeerName::new(from.to_string())
+                .ok()
+                .map(|name| PeerRoute::with_display_name(meerkat_core::comms::PeerId::new(), name))
+        })
 }
 
 async fn send_bridge_failure(

--- a/meerkat-runtime/src/handles/auth_lease.rs
+++ b/meerkat-runtime/src/handles/auth_lease.rs
@@ -1,7 +1,7 @@
 //! Runtime impl of [`meerkat_core::handles::AuthLeaseHandle`].
 //!
 //! Per-binding [`AuthMachine`](crate::auth_machine) instances, keyed by
-//! `binding_key` (format `"<realm_id>:<binding_id>"`). Each trait
+//! typed [`LeaseKey`](meerkat_core::handles::LeaseKey). Each trait
 //! method looks up or creates the corresponding machine, then fires
 //! the matching DSL input. `snapshot` projects the machine's phase
 //! + expires_at back out.
@@ -19,7 +19,7 @@ use std::collections::HashMap;
 use std::sync::{Arc, Mutex};
 
 use meerkat_core::handles::{
-    AuthLeaseHandle, AuthLeasePhase, AuthLeaseSnapshot, DslTransitionError,
+    AuthLeaseHandle, AuthLeasePhase, AuthLeaseSnapshot, DslTransitionError, LeaseKey,
 };
 
 use crate::auth_machine::dsl as auth_dsl;
@@ -36,14 +36,17 @@ use crate::auth_machine::dsl as auth_dsl;
 /// actual acceptance of the transition and avoids duplication /
 /// drift (dogma §1).
 fn emit_audit(
-    binding_key: &str,
+    lease_key: &LeaseKey,
     action: &'static str,
     from_phase: AuthLeasePhase,
     to_phase: AuthLeasePhase,
 ) {
     tracing::info!(
         target: "meerkat::auth::audit",
-        binding_key = %binding_key,
+        lease_key = %lease_key,
+        realm = %lease_key.realm,
+        binding = %lease_key.binding,
+        profile = lease_key.profile.as_ref().map(meerkat_core::ProfileId::as_str),
         action = %action,
         from_phase = ?from_phase,
         to_phase = ?to_phase,
@@ -57,7 +60,7 @@ fn emit_audit(
 /// instances. Lookup-or-insert happens on first `acquire_lease`; all
 /// other operations require the binding to already exist.
 pub struct RuntimeAuthLeaseHandle {
-    machines: Arc<Mutex<HashMap<String, auth_dsl::AuthMachineAuthority>>>,
+    machines: Arc<Mutex<HashMap<LeaseKey, auth_dsl::AuthMachineAuthority>>>,
 }
 
 impl std::fmt::Debug for RuntimeAuthLeaseHandle {
@@ -67,7 +70,7 @@ impl std::fmt::Debug for RuntimeAuthLeaseHandle {
             .lock()
             .unwrap_or_else(std::sync::PoisonError::into_inner);
         f.debug_struct("RuntimeAuthLeaseHandle")
-            .field("bindings", &guard.keys().collect::<Vec<_>>())
+            .field("leases", &guard.keys().collect::<Vec<_>>())
             .finish()
     }
 }
@@ -90,7 +93,7 @@ impl RuntimeAuthLeaseHandle {
 
     fn apply(
         &self,
-        binding_key: &str,
+        lease_key: &LeaseKey,
         input: auth_dsl::AuthMachineInput,
         context: &'static str,
         create_if_missing: bool,
@@ -101,16 +104,16 @@ impl RuntimeAuthLeaseHandle {
             .lock()
             .unwrap_or_else(std::sync::PoisonError::into_inner);
         let entry = if create_if_missing {
-            guard.entry(binding_key.to_string()).or_insert_with(|| {
+            guard.entry(lease_key.clone()).or_insert_with(|| {
                 auth_dsl::AuthMachineAuthority::from_state(auth_dsl::AuthMachineState::default())
             })
         } else {
-            match guard.get_mut(binding_key) {
+            match guard.get_mut(lease_key) {
                 Some(m) => m,
                 None => {
                     return Err(DslTransitionError::new(
                         context,
-                        format!("no auth lease registered for binding_key `{binding_key}`"),
+                        format!("no auth lease registered for lease_key `{lease_key}`"),
                     ));
                 }
             }
@@ -119,7 +122,7 @@ impl RuntimeAuthLeaseHandle {
         auth_dsl::AuthMachineMutator::apply(entry, input)
             .map_err(|err| DslTransitionError::new(context, format!("{err}")))?;
         let to_phase = map_phase(entry.state.lifecycle_phase);
-        emit_audit(binding_key, action, from_phase, to_phase);
+        emit_audit(lease_key, action, from_phase, to_phase);
         Ok(())
     }
 
@@ -157,32 +160,36 @@ impl Default for RuntimeAuthLeaseHandle {
 }
 
 impl AuthLeaseHandle for RuntimeAuthLeaseHandle {
-    fn acquire_lease(&self, binding_key: &str, expires_at: u64) -> Result<(), DslTransitionError> {
+    fn acquire_lease(
+        &self,
+        lease_key: &LeaseKey,
+        expires_at: u64,
+    ) -> Result<(), DslTransitionError> {
         let expires_at_ts = if expires_at == u64::MAX {
             None
         } else {
             Some(expires_at)
         };
         self.apply(
-            binding_key,
+            lease_key,
             auth_dsl::AuthMachineInput::Acquire { expires_at_ts },
             "AuthLeaseHandle::acquire_lease",
             true,
         )
     }
 
-    fn mark_expiring(&self, binding_key: &str) -> Result<(), DslTransitionError> {
+    fn mark_expiring(&self, lease_key: &LeaseKey) -> Result<(), DslTransitionError> {
         self.apply(
-            binding_key,
+            lease_key,
             auth_dsl::AuthMachineInput::MarkExpiring,
             "AuthLeaseHandle::mark_expiring",
             false,
         )
     }
 
-    fn begin_refresh(&self, binding_key: &str) -> Result<(), DslTransitionError> {
+    fn begin_refresh(&self, lease_key: &LeaseKey) -> Result<(), DslTransitionError> {
         self.apply(
-            binding_key,
+            lease_key,
             auth_dsl::AuthMachineInput::BeginRefresh,
             "AuthLeaseHandle::begin_refresh",
             false,
@@ -191,7 +198,7 @@ impl AuthLeaseHandle for RuntimeAuthLeaseHandle {
 
     fn complete_refresh(
         &self,
-        binding_key: &str,
+        lease_key: &LeaseKey,
         new_expires_at: u64,
         now: u64,
     ) -> Result<(), DslTransitionError> {
@@ -201,7 +208,7 @@ impl AuthLeaseHandle for RuntimeAuthLeaseHandle {
             Some(new_expires_at)
         };
         self.apply(
-            binding_key,
+            lease_key,
             auth_dsl::AuthMachineInput::CompleteRefresh {
                 new_expires_at,
                 now_ts: now,
@@ -211,31 +218,35 @@ impl AuthLeaseHandle for RuntimeAuthLeaseHandle {
         )
     }
 
-    fn refresh_failed(&self, binding_key: &str, permanent: bool) -> Result<(), DslTransitionError> {
+    fn refresh_failed(
+        &self,
+        lease_key: &LeaseKey,
+        permanent: bool,
+    ) -> Result<(), DslTransitionError> {
         let input = if permanent {
             auth_dsl::AuthMachineInput::RefreshFailedPermanent
         } else {
             auth_dsl::AuthMachineInput::RefreshFailedTransient
         };
-        self.apply(binding_key, input, "AuthLeaseHandle::refresh_failed", false)
+        self.apply(lease_key, input, "AuthLeaseHandle::refresh_failed", false)
     }
 
-    fn mark_reauth_required(&self, binding_key: &str) -> Result<(), DslTransitionError> {
+    fn mark_reauth_required(&self, lease_key: &LeaseKey) -> Result<(), DslTransitionError> {
         self.apply(
-            binding_key,
+            lease_key,
             auth_dsl::AuthMachineInput::MarkReauthRequired,
             "AuthLeaseHandle::mark_reauth_required",
             false,
         )
     }
 
-    fn release_lease(&self, binding_key: &str) -> Result<(), DslTransitionError> {
+    fn release_lease(&self, lease_key: &LeaseKey) -> Result<(), DslTransitionError> {
         // Drive the DSL transition, then drop the machine from the
         // registry: a released lease has no observable state and
         // keeping the spent AuthMachine around is shell-side bookkeeping
         // that dogma §14 forbids (local state, no canonical role).
         self.apply(
-            binding_key,
+            lease_key,
             auth_dsl::AuthMachineInput::Release,
             "AuthLeaseHandle::release_lease",
             false,
@@ -244,16 +255,16 @@ impl AuthLeaseHandle for RuntimeAuthLeaseHandle {
             .machines
             .lock()
             .unwrap_or_else(std::sync::PoisonError::into_inner);
-        guard.remove(binding_key);
+        guard.remove(lease_key);
         Ok(())
     }
 
-    fn snapshot(&self, binding_key: &str) -> AuthLeaseSnapshot {
+    fn snapshot(&self, lease_key: &LeaseKey) -> AuthLeaseSnapshot {
         let guard = self
             .machines
             .lock()
             .unwrap_or_else(std::sync::PoisonError::into_inner);
-        match guard.get(binding_key) {
+        match guard.get(lease_key) {
             Some(machine) => AuthLeaseSnapshot {
                 phase: Some(map_phase(machine.state.lifecycle_phase)),
                 expires_at: machine.state.expires_at,
@@ -270,13 +281,22 @@ impl AuthLeaseHandle for RuntimeAuthLeaseHandle {
 #[allow(clippy::unwrap_used, clippy::expect_used)]
 mod tests {
     use super::*;
+    use meerkat_core::connection::{BindingId, RealmId};
+
+    fn lease(realm: &str, binding: &str) -> LeaseKey {
+        LeaseKey::new(
+            RealmId::parse(realm).expect("valid realm"),
+            BindingId::parse(binding).expect("valid binding"),
+            None,
+        )
+    }
 
     #[test]
     fn acquire_and_snapshot_roundtrip() {
         let h = RuntimeAuthLeaseHandle::new();
-        h.acquire_lease("dev:default_openai", 1_800_000_000)
-            .unwrap();
-        let snap = h.snapshot("dev:default_openai");
+        let key = lease("dev", "default_openai");
+        h.acquire_lease(&key, 1_800_000_000).unwrap();
+        let snap = h.snapshot(&key);
         assert_eq!(snap.phase, Some(AuthLeasePhase::Valid));
         assert_eq!(snap.expires_at, Some(1_800_000_000));
     }
@@ -284,19 +304,20 @@ mod tests {
     #[test]
     fn lifecycle_transitions() {
         let h = RuntimeAuthLeaseHandle::new();
-        let k = "dev:default_anthropic";
+        let k = lease("dev", "default_anthropic");
 
-        h.acquire_lease(k, 1_800_000_000).unwrap();
-        assert_eq!(h.snapshot(k).phase, Some(AuthLeasePhase::Valid));
+        h.acquire_lease(&k, 1_800_000_000).unwrap();
+        assert_eq!(h.snapshot(&k).phase, Some(AuthLeasePhase::Valid));
 
-        h.mark_expiring(k).unwrap();
-        assert_eq!(h.snapshot(k).phase, Some(AuthLeasePhase::Expiring));
+        h.mark_expiring(&k).unwrap();
+        assert_eq!(h.snapshot(&k).phase, Some(AuthLeasePhase::Expiring));
 
-        h.begin_refresh(k).unwrap();
-        assert_eq!(h.snapshot(k).phase, Some(AuthLeasePhase::Refreshing));
+        h.begin_refresh(&k).unwrap();
+        assert_eq!(h.snapshot(&k).phase, Some(AuthLeasePhase::Refreshing));
 
-        h.complete_refresh(k, 1_800_000_900, 1_800_000_000).unwrap();
-        let snap = h.snapshot(k);
+        h.complete_refresh(&k, 1_800_000_900, 1_800_000_000)
+            .unwrap();
+        let snap = h.snapshot(&k);
         assert_eq!(snap.phase, Some(AuthLeasePhase::Valid));
         assert_eq!(snap.expires_at, Some(1_800_000_900));
     }
@@ -304,31 +325,31 @@ mod tests {
     #[test]
     fn refresh_failed_permanent_routes_to_reauth() {
         let h = RuntimeAuthLeaseHandle::new();
-        let k = "dev:default_google";
+        let k = lease("dev", "default_google");
 
-        h.acquire_lease(k, 1_800_000_000).unwrap();
-        h.begin_refresh(k).unwrap();
-        h.refresh_failed(k, true).unwrap();
+        h.acquire_lease(&k, 1_800_000_000).unwrap();
+        h.begin_refresh(&k).unwrap();
+        h.refresh_failed(&k, true).unwrap();
 
-        assert_eq!(h.snapshot(k).phase, Some(AuthLeasePhase::ReauthRequired));
+        assert_eq!(h.snapshot(&k).phase, Some(AuthLeasePhase::ReauthRequired));
     }
 
     #[test]
     fn refresh_failed_transient_routes_to_expiring() {
         let h = RuntimeAuthLeaseHandle::new();
-        let k = "dev:foo";
+        let k = lease("dev", "foo");
 
-        h.acquire_lease(k, 1_800_000_000).unwrap();
-        h.begin_refresh(k).unwrap();
-        h.refresh_failed(k, false).unwrap();
+        h.acquire_lease(&k, 1_800_000_000).unwrap();
+        h.begin_refresh(&k).unwrap();
+        h.refresh_failed(&k, false).unwrap();
 
-        assert_eq!(h.snapshot(k).phase, Some(AuthLeasePhase::Expiring));
+        assert_eq!(h.snapshot(&k).phase, Some(AuthLeasePhase::Expiring));
     }
 
     #[test]
     fn snapshot_for_unknown_binding_is_none() {
         let h = RuntimeAuthLeaseHandle::new();
-        let snap = h.snapshot("dev:never_registered");
+        let snap = h.snapshot(&lease("dev", "never_registered"));
         assert!(snap.phase.is_none());
         assert!(snap.expires_at.is_none());
     }
@@ -336,25 +357,21 @@ mod tests {
     #[test]
     fn mark_expiring_before_acquire_errors() {
         let h = RuntimeAuthLeaseHandle::new();
-        let err = h.mark_expiring("dev:ghost").unwrap_err();
+        let err = h.mark_expiring(&lease("dev", "ghost")).unwrap_err();
         assert_eq!(err.context, "AuthLeaseHandle::mark_expiring");
     }
 
     #[test]
     fn per_binding_isolation() {
         let h = RuntimeAuthLeaseHandle::new();
-        h.acquire_lease("dev:openai", 1_800_000_000).unwrap();
-        h.acquire_lease("dev:anthropic", 1_900_000_000).unwrap();
-        h.mark_expiring("dev:openai").unwrap();
+        let openai = lease("dev", "openai");
+        let anthropic = lease("dev", "anthropic");
+        h.acquire_lease(&openai, 1_800_000_000).unwrap();
+        h.acquire_lease(&anthropic, 1_900_000_000).unwrap();
+        h.mark_expiring(&openai).unwrap();
 
-        assert_eq!(
-            h.snapshot("dev:openai").phase,
-            Some(AuthLeasePhase::Expiring)
-        );
-        assert_eq!(
-            h.snapshot("dev:anthropic").phase,
-            Some(AuthLeasePhase::Valid)
-        );
-        assert_eq!(h.snapshot("dev:anthropic").expires_at, Some(1_900_000_000));
+        assert_eq!(h.snapshot(&openai).phase, Some(AuthLeasePhase::Expiring));
+        assert_eq!(h.snapshot(&anthropic).phase, Some(AuthLeasePhase::Valid));
+        assert_eq!(h.snapshot(&anthropic).expires_at, Some(1_900_000_000));
     }
 }

--- a/meerkat-runtime/tests/auth_reauth_notice.rs
+++ b/meerkat-runtime/tests/auth_reauth_notice.rs
@@ -15,8 +15,17 @@
 
 #![allow(clippy::unwrap_used, clippy::expect_used)]
 
-use meerkat_core::handles::{AuthLeaseHandle, AuthLeasePhase};
+use meerkat_core::connection::{BindingId, RealmId};
+use meerkat_core::handles::{AuthLeaseHandle, AuthLeasePhase, LeaseKey};
 use meerkat_runtime::RuntimeAuthLeaseHandle;
+
+fn lease(realm: &str, binding: &str) -> LeaseKey {
+    LeaseKey::new(
+        RealmId::parse(realm).expect("valid realm"),
+        BindingId::parse(binding).expect("valid binding"),
+        None,
+    )
+}
 
 /// Given an ephemeral handle and a binding key, acquiring the lease then
 /// driving it into `reauth_required` (via `MarkReauthRequired`) yields a
@@ -26,27 +35,27 @@ use meerkat_runtime::RuntimeAuthLeaseHandle;
 #[test]
 fn mark_reauth_required_transitions_to_reauth_required_state() {
     let handle = RuntimeAuthLeaseHandle::ephemeral();
-    let key = "test-realm:test-binding";
+    let key = lease("test-realm", "test-binding");
 
     // Acquire → state=valid.
-    handle.acquire_lease(key, 9_999_999_999).unwrap();
+    handle.acquire_lease(&key, 9_999_999_999).unwrap();
     assert_eq!(
-        handle.snapshot(key).phase,
+        handle.snapshot(&key).phase,
         Some(AuthLeasePhase::Valid),
         "acquire_lease must land in valid"
     );
 
     // Drive directly to reauth_required (short-circuit mid-turn).
-    handle.mark_reauth_required(key).unwrap();
+    handle.mark_reauth_required(&key).unwrap();
     assert_eq!(
-        handle.snapshot(key).phase,
+        handle.snapshot(&key).phase,
         Some(AuthLeasePhase::ReauthRequired),
         "mark_reauth_required must land in reauth_required"
     );
 
     // Expires-at is preserved across state transitions.
     assert_eq!(
-        handle.snapshot(key).expires_at,
+        handle.snapshot(&key).expires_at,
         Some(9_999_999_999),
         "expires_at must be preserved across reauth transition"
     );
@@ -58,19 +67,22 @@ fn mark_reauth_required_transitions_to_reauth_required_state() {
 #[test]
 fn refresh_path_terminates_in_reauth_required_on_permanent_failure() {
     let handle = RuntimeAuthLeaseHandle::ephemeral();
-    let key = "realm-x:binding-y";
+    let key = lease("realm-x", "binding-y");
 
-    handle.acquire_lease(key, 1_000).unwrap();
-    handle.mark_expiring(key).unwrap();
-    assert_eq!(handle.snapshot(key).phase, Some(AuthLeasePhase::Expiring));
+    handle.acquire_lease(&key, 1_000).unwrap();
+    handle.mark_expiring(&key).unwrap();
+    assert_eq!(handle.snapshot(&key).phase, Some(AuthLeasePhase::Expiring));
 
-    handle.begin_refresh(key).unwrap();
-    assert_eq!(handle.snapshot(key).phase, Some(AuthLeasePhase::Refreshing));
+    handle.begin_refresh(&key).unwrap();
+    assert_eq!(
+        handle.snapshot(&key).phase,
+        Some(AuthLeasePhase::Refreshing)
+    );
 
     // Permanent refresh failure → reauth_required.
-    handle.refresh_failed(key, true).unwrap();
+    handle.refresh_failed(&key, true).unwrap();
     assert_eq!(
-        handle.snapshot(key).phase,
+        handle.snapshot(&key).phase,
         Some(AuthLeasePhase::ReauthRequired),
         "permanent refresh failure must land in reauth_required (runner snapshot-polls this state to emit a session notice; dogma §1/§19: the DSL state is the sole canonical truth, no redundant effect emission)"
     );
@@ -83,12 +95,12 @@ fn refresh_path_terminates_in_reauth_required_on_permanent_failure() {
 #[test]
 fn begin_refresh_rejected_from_refreshing_state() {
     let handle = RuntimeAuthLeaseHandle::ephemeral();
-    let key = "dedup:binding";
+    let key = lease("dedup", "binding");
 
-    handle.acquire_lease(key, 1_000).unwrap();
-    handle.begin_refresh(key).unwrap();
+    handle.acquire_lease(&key, 1_000).unwrap();
+    handle.begin_refresh(&key).unwrap();
     let err = handle
-        .begin_refresh(key)
+        .begin_refresh(&key)
         .expect_err("second begin_refresh must be rejected");
     assert!(
         err.to_string().contains("BeginRefresh") || err.to_string().contains("begin_refresh"),
@@ -101,33 +113,36 @@ fn begin_refresh_rejected_from_refreshing_state() {
 #[test]
 fn transient_refresh_failure_returns_to_expiring() {
     let handle = RuntimeAuthLeaseHandle::ephemeral();
-    let key = "transient:binding";
+    let key = lease("transient", "binding");
 
-    handle.acquire_lease(key, 1_000).unwrap();
-    handle.mark_expiring(key).unwrap();
-    handle.begin_refresh(key).unwrap();
-    handle.refresh_failed(key, false).unwrap();
+    handle.acquire_lease(&key, 1_000).unwrap();
+    handle.mark_expiring(&key).unwrap();
+    handle.begin_refresh(&key).unwrap();
+    handle.refresh_failed(&key, false).unwrap();
     assert_eq!(
-        handle.snapshot(key).phase,
+        handle.snapshot(&key).phase,
         Some(AuthLeasePhase::Expiring),
         "transient failure must return binding to expiring"
     );
 
     // And begin_refresh is legal again from expiring.
-    handle.begin_refresh(key).unwrap();
-    assert_eq!(handle.snapshot(key).phase, Some(AuthLeasePhase::Refreshing));
+    handle.begin_refresh(&key).unwrap();
+    assert_eq!(
+        handle.snapshot(&key).phase,
+        Some(AuthLeasePhase::Refreshing)
+    );
 }
 
 /// Release removes the binding from all state sets.
 #[test]
 fn release_clears_all_state() {
     let handle = RuntimeAuthLeaseHandle::ephemeral();
-    let key = "release:binding";
+    let key = lease("release", "binding");
 
-    handle.acquire_lease(key, 1_000).unwrap();
-    handle.release_lease(key).unwrap();
-    assert_eq!(handle.snapshot(key).phase, None);
-    assert_eq!(handle.snapshot(key).expires_at, None);
+    handle.acquire_lease(&key, 1_000).unwrap();
+    handle.release_lease(&key).unwrap();
+    assert_eq!(handle.snapshot(&key).phase, None);
+    assert_eq!(handle.snapshot(&key).expires_at, None);
 }
 
 /// AuthLeaseSnapshot preserves expires_at through the acquire →
@@ -136,21 +151,21 @@ fn release_clears_all_state() {
 #[test]
 fn snapshot_preserves_expires_at_for_ttl_sampler() {
     let handle = RuntimeAuthLeaseHandle::ephemeral();
-    let key = "ttl:binding";
+    let key = lease("ttl", "binding");
 
     // Lease with a specific expiry timestamp.
-    handle.acquire_lease(key, 1_700_000_000).unwrap();
-    let snap = handle.snapshot(key);
+    handle.acquire_lease(&key, 1_700_000_000).unwrap();
+    let snap = handle.snapshot(&key);
     assert_eq!(snap.phase, Some(AuthLeasePhase::Valid));
     assert_eq!(snap.expires_at, Some(1_700_000_000));
 
     // After CompleteAuthRefresh, expires_at updates.
-    handle.mark_expiring(key).unwrap();
-    handle.begin_refresh(key).unwrap();
+    handle.mark_expiring(&key).unwrap();
+    handle.begin_refresh(&key).unwrap();
     handle
-        .complete_refresh(key, 1_800_000_000, 1_750_000_000)
+        .complete_refresh(&key, 1_800_000_000, 1_750_000_000)
         .unwrap();
-    let snap = handle.snapshot(key);
+    let snap = handle.snapshot(&key);
     assert_eq!(snap.phase, Some(AuthLeasePhase::Valid));
     assert_eq!(snap.expires_at, Some(1_800_000_000));
 }

--- a/meerkat-skills/src/engine.rs
+++ b/meerkat-skills/src/engine.rs
@@ -62,6 +62,18 @@ where
         self.registry = Some(registry);
         self
     }
+
+    fn resolve_key(&self, key: &SkillKey) -> Result<SkillKey, SkillError> {
+        let Some(registry) = &self.registry else {
+            return Ok(key.clone());
+        };
+        registry
+            .resolve(key)
+            .map(|resolved| resolved.key)
+            .map_err(|e| {
+                SkillError::Load(format!("source identity resolution failed for {key}: {e}").into())
+            })
+    }
 }
 
 fn filter_by_capabilities(
@@ -85,7 +97,7 @@ where
 {
     fn inventory_section(&self) -> impl Future<Output = Result<String, SkillError>> + Send {
         async move {
-            let all_skills = self.source.list(&SkillFilter::default()).await?;
+            let all_skills = self.list_skills(&SkillFilter::default()).await?;
             let available = filter_by_capabilities(all_skills, &self.available_capabilities);
             let collections = meerkat_core::skills::derive_collections(&available);
             Ok(renderer::render_inventory(
@@ -103,7 +115,8 @@ where
         async move {
             let mut results = Vec::new();
             for key in keys {
-                let doc = self.source.load(key).await?;
+                let canonical_key = self.resolve_key(key)?;
+                let doc = self.source.load(&canonical_key).await?;
 
                 if let Some(missing) = doc
                     .descriptor
@@ -112,16 +125,19 @@ where
                     .find(|cap| !self.available_capabilities.contains(*cap))
                 {
                     return Err(SkillError::CapabilityUnavailable {
-                        key: key.clone(),
+                        key: canonical_key.clone(),
                         capability: missing.clone(),
                     });
                 }
 
-                let rendered =
-                    renderer::render_injection_with_limit(key, &doc.body, self.max_injection_bytes);
+                let rendered = renderer::render_injection_with_limit(
+                    &canonical_key,
+                    &doc.body,
+                    self.max_injection_bytes,
+                );
                 let byte_size = rendered.len();
                 results.push(ResolvedSkill {
-                    key: key.clone(),
+                    key: canonical_key,
                     name: doc.descriptor.name.clone(),
                     rendered_body: rendered,
                     byte_size,
@@ -141,8 +157,12 @@ where
     ) -> impl Future<Output = Result<Vec<SkillDescriptor>, SkillError>> + Send {
         async move {
             let all_skills = self.source.list(filter).await?;
+            let active_skills: Vec<_> = all_skills
+                .into_iter()
+                .filter(|descriptor| self.resolve_key(&descriptor.key).is_ok())
+                .collect();
             Ok(filter_by_capabilities(
-                all_skills,
+                active_skills,
                 &self.available_capabilities,
             ))
         }
@@ -164,7 +184,10 @@ where
         &self,
         key: &SkillKey,
     ) -> impl Future<Output = Result<Vec<SkillArtifact>, SkillError>> + Send {
-        async move { self.source.list_artifacts(key).await }
+        async move {
+            let canonical_key = self.resolve_key(key)?;
+            self.source.list_artifacts(&canonical_key).await
+        }
     }
 
     fn read_artifact(
@@ -172,7 +195,12 @@ where
         key: &SkillKey,
         artifact_path: &str,
     ) -> impl Future<Output = Result<SkillArtifactContent, SkillError>> + Send {
-        async move { self.source.read_artifact(key, artifact_path).await }
+        async move {
+            let canonical_key = self.resolve_key(key)?;
+            self.source
+                .read_artifact(&canonical_key, artifact_path)
+                .await
+        }
     }
 
     fn invoke_function(
@@ -182,8 +210,9 @@ where
         arguments: serde_json::Value,
     ) -> impl Future<Output = Result<serde_json::Value, SkillError>> + Send {
         async move {
+            let canonical_key = self.resolve_key(key)?;
             self.source
-                .invoke_function(key, function_name, arguments)
+                .invoke_function(&canonical_key, function_name, arguments)
                 .await
         }
     }
@@ -197,11 +226,12 @@ where
             Ok(entries
                 .into_iter()
                 .filter(|e| {
-                    !e.is_active
-                        || e.descriptor
-                            .capability_requirements
-                            .iter()
-                            .all(|cap| self.available_capabilities.contains(cap))
+                    self.resolve_key(&e.descriptor.key).is_ok()
+                        && (!e.is_active
+                            || e.descriptor
+                                .capability_requirements
+                                .iter()
+                                .all(|cap| self.available_capabilities.contains(cap)))
                 })
                 .collect())
         }
@@ -214,8 +244,9 @@ where
     ) -> impl Future<Output = Result<SkillDocument, SkillError>> + Send {
         let source_name = source_name.map(ToString::to_string);
         async move {
+            let canonical_key = self.resolve_key(key)?;
             self.source
-                .load_from_source(key, source_name.as_deref())
+                .load_from_source(&canonical_key, source_name.as_deref())
                 .await
         }
     }

--- a/meerkat-skills/src/resolve.rs
+++ b/meerkat-skills/src/resolve.rs
@@ -4,9 +4,9 @@ use std::path::Path;
 #[cfg(not(target_arch = "wasm32"))]
 use std::time::Duration;
 
-use meerkat_core::skills::SkillError;
 #[cfg(not(target_arch = "wasm32"))]
 use meerkat_core::skills::SkillScope;
+use meerkat_core::skills::{SkillError, SourceUuid};
 #[cfg(not(target_arch = "wasm32"))]
 use meerkat_core::skills_config::GitRefType;
 use meerkat_core::skills_config::{SkillRepoTransport, SkillsConfig};
@@ -52,6 +52,7 @@ pub async fn resolve_repositories_with_roots(
         }
         Ok(Some(CompositeSkillSource::from_named(vec![NamedSource {
             name: "embedded".to_string(),
+            source_uuid: SourceUuid::builtin(),
             source: SourceNode::Embedded(EmbeddedSkillSource::new()),
         }])))
     }
@@ -60,6 +61,7 @@ pub async fn resolve_repositories_with_roots(
     {
         let mut sources: Vec<NamedSource> = vec![NamedSource {
             name: "embedded".to_string(),
+            source_uuid: SourceUuid::builtin(),
             source: SourceNode::Embedded(EmbeddedSkillSource::new()),
         }];
         for repo in &config.repositories {
@@ -75,6 +77,7 @@ pub async fn resolve_repositories_with_roots(
                     };
                     sources.push(NamedSource {
                         name: repo.name.clone(),
+                        source_uuid: repo.source_uuid.clone(),
                         source: SourceNode::Filesystem(FilesystemSkillSource::new_with_identity(
                             full_path,
                             SkillScope::Project,
@@ -102,6 +105,7 @@ pub async fn resolve_repositories_with_roots(
                         };
                         sources.push(NamedSource {
                             name: repo.name.clone(),
+                            source_uuid: repo.source_uuid.clone(),
                             source: SourceNode::Http(Box::new(
                                 HttpSkillSource::new_with_thresholds(
                                     repo.source_uuid.clone(),
@@ -155,6 +159,7 @@ pub async fn resolve_repositories_with_roots(
                     );
                     sources.push(NamedSource {
                         name: repo.name.clone(),
+                        source_uuid: repo.source_uuid.clone(),
                         source: SourceNode::External(ExternalSkillSource::new_with_source_uuid(
                             client,
                             repo.source_uuid.clone(),
@@ -193,6 +198,7 @@ pub async fn resolve_repositories_with_roots(
                         });
                     sources.push(NamedSource {
                         name: repo.name.clone(),
+                        source_uuid: repo.source_uuid.clone(),
                         source: SourceNode::Git(Box::new(GitSkillSource::new(GitSkillConfig {
                             repo_url: url.clone(),
                             git_ref,
@@ -214,9 +220,12 @@ pub async fn resolve_repositories_with_roots(
             if default_project_skills.is_dir() {
                 sources.push(NamedSource {
                     name: "project".to_string(),
-                    source: SourceNode::Filesystem(FilesystemSkillSource::new(
+                    source_uuid: SourceUuid::project_local(),
+                    source: SourceNode::Filesystem(FilesystemSkillSource::new_with_identity(
                         default_project_skills,
                         SkillScope::Project,
+                        SourceUuid::project_local(),
+                        config.health_thresholds,
                     )),
                 });
             }

--- a/meerkat-skills/src/source/composite.rs
+++ b/meerkat-skills/src/source/composite.rs
@@ -4,13 +4,14 @@ use crate::source::SourceNode;
 use meerkat_core::skills::{
     SkillArtifact, SkillArtifactContent, SkillDescriptor, SkillDocument, SkillError, SkillFilter,
     SkillIntrospectionEntry, SkillKey, SkillQuarantineDiagnostic, SkillSource,
-    SourceHealthSnapshot, SourceHealthState, apply_filter,
+    SourceHealthSnapshot, SourceHealthState, SourceUuid, apply_filter,
 };
 use std::collections::HashMap;
 
 /// A named skill source for provenance tracking.
 pub struct NamedSource {
     pub name: String,
+    pub source_uuid: SourceUuid,
     pub source: SourceNode,
 }
 
@@ -35,6 +36,7 @@ impl CompositeSkillSource {
             .enumerate()
             .map(|(i, source)| NamedSource {
                 name: format!("source_{i}"),
+                source_uuid: SourceUuid::builtin(),
                 source,
             })
             .collect();
@@ -163,22 +165,28 @@ impl SkillSource for CompositeSkillSource {
         filter: &SkillFilter,
     ) -> Result<Vec<SkillIntrospectionEntry>, SkillError> {
         let mut entries: Vec<SkillIntrospectionEntry> = Vec::new();
-        let mut active_by_key: HashMap<SkillKey, String> = HashMap::new();
+        let mut active_by_key: HashMap<SkillKey, (String, SourceUuid)> = HashMap::new();
 
         for named in &self.sources {
             let items = named.source.list(filter).await?;
             for mut desc in items {
                 desc.source_name = named.name.clone();
                 let (is_active, shadowed_by) = match active_by_key.get(&desc.key) {
-                    Some(active_source) => (false, Some(active_source.clone())),
+                    Some((active_source, active_uuid)) => {
+                        (false, Some((active_source.clone(), active_uuid.clone())))
+                    }
                     None => {
-                        active_by_key.insert(desc.key.clone(), named.name.clone());
+                        active_by_key.insert(
+                            desc.key.clone(),
+                            (named.name.clone(), named.source_uuid.clone()),
+                        );
                         (true, None)
                     }
                 };
                 entries.push(SkillIntrospectionEntry {
                     descriptor: desc,
-                    shadowed_by,
+                    shadowed_by: shadowed_by.as_ref().map(|(name, _)| name.clone()),
+                    shadowed_by_source_uuid: shadowed_by.map(|(_, source_uuid)| source_uuid),
                     is_active,
                 });
             }
@@ -195,8 +203,9 @@ impl SkillSource for CompositeSkillSource {
         let Some(target) = source_name else {
             return self.load(key).await;
         };
+        let target_uuid = SourceUuid::parse(target)?;
         for named in &self.sources {
-            if named.name == target {
+            if named.source_uuid == target_uuid {
                 let mut doc = named.source.load(key).await?;
                 doc.descriptor.source_name = named.name.clone();
                 return Ok(doc);

--- a/meerkat/src/factory.rs
+++ b/meerkat/src/factory.rs
@@ -936,7 +936,7 @@ impl AgentFactory {
         &self,
         config: &Config,
     ) -> Result<Arc<dyn meerkat_client::RealtimeSessionFactory>, BuildAgentError> {
-        let (realm, binding_id, _connection_ref) =
+        let (realm, _binding_id, connection_ref) =
             Self::resolve_realm_binding_for_provider(config, Provider::OpenAI, None, None)
                 .map_err(BuildAgentError::ConnectionResolution)?;
         let mut env = meerkat_providers::ResolverEnvironment::with_process_env();
@@ -951,7 +951,7 @@ impl AgentFactory {
         }
         let connection = self
             .provider_registry
-            .resolve(&realm, &binding_id, &env)
+            .resolve(&realm, &connection_ref, &env)
             .await
             .map_err(|e| BuildAgentError::ConnectionResolution(e.to_string()))?;
         let secret = connection.resolved_secret().ok_or_else(|| {
@@ -1284,11 +1284,20 @@ impl AgentFactory {
 
         skill_source.map(|source| {
             let available_caps = self.effective_skill_capabilities(config, None);
-            let engine = Arc::new(
-                meerkat_skills::DefaultSkillEngine::new(source, available_caps)
-                    .with_inventory_threshold(config.skills.inventory_threshold)
-                    .with_max_injection_bytes(config.skills.max_injection_bytes),
-            );
+            let registry = match config.skills.build_source_identity_registry() {
+                Ok(registry) => Some(Arc::new(registry)),
+                Err(e) => {
+                    tracing::warn!("Failed to build skill source identity registry: {e}");
+                    None
+                }
+            };
+            let mut engine = meerkat_skills::DefaultSkillEngine::new(source, available_caps)
+                .with_inventory_threshold(config.skills.inventory_threshold)
+                .with_max_injection_bytes(config.skills.max_injection_bytes);
+            if let Some(registry) = registry {
+                engine = engine.with_source_identity_registry(registry);
+            }
+            let engine = Arc::new(engine);
             Arc::new(meerkat_core::skills::SkillRuntime::new(engine))
         })
     }
@@ -1433,7 +1442,7 @@ impl AgentFactory {
             return Ok(Arc::new(meerkat_client::TestClient::default()));
         }
 
-        let (realm, binding_id, _connection_ref) = Self::resolve_realm_binding_for_provider(
+        let (realm, _binding_id, connection_ref) = Self::resolve_realm_binding_for_provider(
             config,
             identity.provider,
             identity.connection_ref.as_ref(),
@@ -1457,7 +1466,7 @@ impl AgentFactory {
         }
         let provider_registry = Arc::clone(&self.provider_registry);
         let connection = provider_registry
-            .resolve(&realm, &binding_id, &env)
+            .resolve(&realm, &connection_ref, &env)
             .await
             .map_err(|e| FactoryError::ClientCreationFailed(e.to_string()))?;
         provider_registry
@@ -1523,10 +1532,6 @@ impl AgentFactory {
             ));
         }
 
-        let inferred = Provider::infer_from_model(&build_config.model).unwrap_or(Provider::Other);
-        if inferred != Provider::Other {
-            return Ok((inferred, None));
-        }
         if let Some(client) = build_config.llm_client_override.as_ref() {
             return Ok((Provider::from_name(client.provider()), None));
         }
@@ -1863,7 +1868,7 @@ impl AgentFactory {
                     )
                     .map_err(BuildAgentError::LlmClient)?
                 } else {
-                    let (realm, binding_id, resolved_connection_ref) =
+                    let (realm, _binding_id, resolved_connection_ref) =
                         Self::resolve_realm_binding_for_provider(
                             config,
                             provider,
@@ -1871,7 +1876,7 @@ impl AgentFactory {
                             build_config.realm_id.as_deref(),
                         )
                         .map_err(BuildAgentError::ConnectionResolution)?;
-                    build_config.connection_ref = Some(resolved_connection_ref);
+                    build_config.connection_ref = Some(resolved_connection_ref.clone());
 
                     // Provider-runtime registry needs the OAuth-backed
                     // TokenStore attached so persisted tokens (written by
@@ -1893,7 +1898,7 @@ impl AgentFactory {
                     }
                     let provider_registry = Arc::clone(&self.provider_registry);
                     let connection = provider_registry
-                        .resolve(&realm, &binding_id, &env)
+                        .resolve(&realm, &resolved_connection_ref, &env)
                         .await
                         .map_err(|e| BuildAgentError::ConnectionResolution(e.to_string()))?;
 
@@ -1907,7 +1912,9 @@ impl AgentFactory {
                     if let RuntimeBuildMode::SessionOwned(bindings) =
                         &build_config.runtime_build_mode
                     {
-                        let binding_key = format!("{}:{}", realm.realm_id, binding_id);
+                        let lease_key = meerkat_core::handles::LeaseKey::from_connection_ref(
+                            &resolved_connection_ref,
+                        );
                         let expires_at = connection
                             .auth_lease
                             .expires_at()
@@ -1916,7 +1923,7 @@ impl AgentFactory {
                         // Ignore result: the DSL may reject if an earlier
                         // hot-swap already transitioned this binding; the
                         // lease state is orthogonal to error semantics.
-                        let _ = bindings.auth_lease.acquire_lease(&binding_key, expires_at);
+                        let _ = bindings.auth_lease.acquire_lease(&lease_key, expires_at);
                     }
 
                     // Realtime-capable OpenAI models (e.g. gpt-realtime-1.5)
@@ -2050,11 +2057,20 @@ impl AgentFactory {
 
             skill_source.map(|source| {
                 let available_caps = self.effective_skill_capabilities(config, Some(&build_config));
-                let engine = Arc::new(
-                    meerkat_skills::DefaultSkillEngine::new(source, available_caps)
-                        .with_inventory_threshold(config.skills.inventory_threshold)
-                        .with_max_injection_bytes(config.skills.max_injection_bytes),
-                );
+                let registry = match config.skills.build_source_identity_registry() {
+                    Ok(registry) => Some(Arc::new(registry)),
+                    Err(e) => {
+                        tracing::warn!("Failed to build skill source identity registry: {e}");
+                        None
+                    }
+                };
+                let mut engine = meerkat_skills::DefaultSkillEngine::new(source, available_caps)
+                    .with_inventory_threshold(config.skills.inventory_threshold)
+                    .with_max_injection_bytes(config.skills.max_injection_bytes);
+                if let Some(registry) = registry {
+                    engine = engine.with_source_identity_registry(registry);
+                }
+                let engine = Arc::new(engine);
                 Arc::new(meerkat_core::skills::SkillRuntime::new(engine))
             })
         }; // end else (filesystem resolution fallthrough)

--- a/meerkat/src/service_factory.rs
+++ b/meerkat/src/service_factory.rs
@@ -158,7 +158,22 @@ impl SessionAgent for FactoryAgent {
         // LLM identity so subsequent turns run against the new
         // model/provider/connection_ref and persisted recovery sees
         // the swap.
+        let previous_connection_ref = self
+            .agent
+            .session()
+            .session_metadata()
+            .and_then(|metadata| metadata.connection_ref);
         self.agent.replace_client(client);
+        self.agent
+            .rotate_auth_lease_connection_ref(
+                previous_connection_ref.as_ref(),
+                identity.connection_ref.as_ref(),
+            )
+            .map_err(|e| {
+                meerkat_core::error::AgentError::ConfigError(format!(
+                    "failed to rotate auth lease during llm identity hot-swap: {e}"
+                ))
+            })?;
         if let Some(mut metadata) = self.agent.session().session_metadata() {
             metadata.apply_llm_identity(&identity);
             self.agent

--- a/meerkat/src/surface.rs
+++ b/meerkat/src/surface.rs
@@ -110,6 +110,16 @@ pub fn build_models_catalog_response(
                         supports_web_search: entry.profile.supports_web_search,
                         inline_video: entry.profile.inline_video,
                         params_schema: entry.profile.params_schema.clone(),
+                        beta_headers: entry
+                            .profile
+                            .beta_headers
+                            .iter()
+                            .map(|header| meerkat_contracts::WireModelBetaHeader {
+                                feature: header.feature.clone(),
+                                header_name: header.header_name.clone(),
+                                header_value: header.header_value.clone(),
+                            })
+                            .collect(),
                     });
                     meerkat_contracts::CatalogModelEntry {
                         id: entry.id.clone(),

--- a/meerkat/src/surface/runtime_backed.rs
+++ b/meerkat/src/surface/runtime_backed.rs
@@ -393,7 +393,7 @@ mod tests {
 
     fn make_request(build: SessionBuildOptions) -> CreateSessionRequest {
         CreateSessionRequest {
-            model: "gpt-5.2".to_string(),
+            model: "gpt-5.4".to_string(),
             prompt: meerkat_core::ContentInput::Text(String::new()),
             render_metadata: None,
             system_prompt: Some("surface runtime regression".to_string()),

--- a/meerkat/tests/agent_factory_connection_ref.rs
+++ b/meerkat/tests/agent_factory_connection_ref.rs
@@ -163,7 +163,7 @@ async fn build_agent_with_openai_connection_ref_resolves_through_registry() {
     let factory = temp_factory(&temp);
     let config = config_with_realm();
 
-    let mut build = AgentBuildConfig::new("gpt-5.2");
+    let mut build = AgentBuildConfig::new("gpt-5.4");
     build.connection_ref = Some(conn_ref("default_openai"));
 
     let agent = factory
@@ -281,7 +281,7 @@ async fn build_agent_unknown_binding_surfaces_connection_resolution_error() {
     let factory = temp_factory(&temp);
     let config = config_with_realm();
 
-    let mut build = AgentBuildConfig::new("gpt-5.2");
+    let mut build = AgentBuildConfig::new("gpt-5.4");
     build.connection_ref = Some(conn_ref("does_not_exist"));
 
     let result = factory.build_agent(build, &config).await;
@@ -299,7 +299,7 @@ async fn build_agent_unknown_realm_surfaces_connection_resolution_error() {
     // Config has no realm at all → unknown realm path.
     let config = Config::default();
 
-    let mut build = AgentBuildConfig::new("gpt-5.2");
+    let mut build = AgentBuildConfig::new("gpt-5.4");
     build.connection_ref = Some(conn_ref("default_openai"));
 
     let result = factory.build_agent(build, &config).await;
@@ -324,7 +324,7 @@ async fn llm_client_override_beats_connection_ref() {
     let factory = temp_factory(&temp);
     let config = config_with_realm();
 
-    let mut build = AgentBuildConfig::new("gpt-5.2");
+    let mut build = AgentBuildConfig::new("gpt-5.4");
     build.connection_ref = Some(conn_ref("does_not_exist"));
     build.llm_client_override = Some(Arc::new(MockLlmClient));
 
@@ -350,7 +350,7 @@ async fn build_agent_without_connection_ref_uses_default_realm_binding() {
     let section = meerkat_core::RealmConfigSection::from_inline_api_keys(&[("openai", "flat-key")]);
     config.realm.insert("default".to_string(), section);
 
-    let build = AgentBuildConfig::new("gpt-5.2");
+    let build = AgentBuildConfig::new("gpt-5.4");
     assert!(build.connection_ref.is_none());
 
     let agent = factory
@@ -383,7 +383,7 @@ async fn session_metadata_persists_connection_ref_across_build() {
     let factory = temp_factory(&temp);
     let config = config_with_realm();
 
-    let mut build = AgentBuildConfig::new("gpt-5.2");
+    let mut build = AgentBuildConfig::new("gpt-5.4");
     build.connection_ref = Some(conn_ref("default_openai"));
 
     let agent = factory

--- a/meerkat/tests/factory_build_agent.rs
+++ b/meerkat/tests/factory_build_agent.rs
@@ -335,7 +335,7 @@ async fn build_agent_without_connection_ref_uses_default_realm_config_api_key() 
         meerkat_core::RealmConfigSection::from_inline_api_keys(&[("openai", "test-openai-key")]);
     config.realm.insert("default".to_string(), section);
 
-    let build_config = AgentBuildConfig::new("gpt-5.2");
+    let build_config = AgentBuildConfig::new("gpt-5.4");
     assert!(build_config.connection_ref.is_none());
     let agent = factory
         .build_agent(build_config, &config)
@@ -756,7 +756,7 @@ async fn build_agent_with_resume_uses_stored_metadata() {
         provider: Some(Provider::OpenAI),
         max_tokens: Some(1024),
         provider_params: Some(json!({ "temperature": 0.1 })),
-        ..AgentBuildConfig::new("gpt-5.2")
+        ..AgentBuildConfig::new("gpt-5.4")
     };
 
     let agent = factory.build_agent(build_config, &config).await.unwrap();
@@ -841,7 +841,7 @@ async fn build_agent_with_resume_preserves_explicit_override_masked_fields() {
         keep_alive: false,
         comms_name: Some("explicit-name".to_string()),
         peer_meta: Some(meerkat_core::PeerMeta::default().with_label("role", "explicit")),
-        ..AgentBuildConfig::new("gpt-5.2")
+        ..AgentBuildConfig::new("gpt-5.4")
     };
     build_config.resume_override_mask.provider = true;
     build_config.resume_override_mask.max_tokens = true;
@@ -914,7 +914,7 @@ async fn build_agent_with_resume_preserves_persisted_system_prompt() {
     let build_config = AgentBuildConfig {
         llm_client_override: Some(Arc::new(MockLlmClient)),
         resume_session: Some(session),
-        ..AgentBuildConfig::new("gpt-5.2")
+        ..AgentBuildConfig::new("gpt-5.4")
     };
 
     let agent = factory.build_agent(build_config, &config).await.unwrap();
@@ -969,7 +969,7 @@ async fn build_agent_with_resume_preserves_explicit_inherit_tool_override() {
         llm_client_override: Some(Arc::new(MockLlmClient)),
         resume_session: Some(session),
         override_builtins: ToolCategoryOverride::Inherit,
-        ..AgentBuildConfig::new("gpt-5.2")
+        ..AgentBuildConfig::new("gpt-5.4")
     };
     build_config.resume_override_mask.override_builtins = true;
 
@@ -1350,7 +1350,8 @@ async fn test_mixed_validity_skills_quarantine_preserves_valid_preload() {
 
     let valid_build = AgentBuildConfig {
         llm_client_override: Some(Arc::new(MockLlmClient)),
-        preload_skills: Some(vec![meerkat_core::skills::SkillKey::builtin(
+        preload_skills: Some(vec![meerkat_core::skills::SkillKey::new(
+            meerkat_core::skills::SourceUuid::project_local(),
             meerkat_core::skills::SkillName::parse("valid-skill").expect("valid skill name"),
         )]),
         ..AgentBuildConfig::new("claude-sonnet-4-5")
@@ -1368,7 +1369,8 @@ async fn test_mixed_validity_skills_quarantine_preserves_valid_preload() {
         .expect("valid preload session metadata");
     assert_eq!(
         metadata.tooling.active_skills,
-        Some(vec![meerkat_core::skills::SkillKey::builtin(
+        Some(vec![meerkat_core::skills::SkillKey::new(
+            meerkat_core::skills::SourceUuid::project_local(),
             meerkat_core::skills::SkillName::parse("valid-skill").expect("valid skill name"),
         )]),
         "session metadata should persist only the explicitly preloaded skills"
@@ -1376,7 +1378,8 @@ async fn test_mixed_validity_skills_quarantine_preserves_valid_preload() {
 
     let invalid_build = AgentBuildConfig {
         llm_client_override: Some(Arc::new(MockLlmClient)),
-        preload_skills: Some(vec![meerkat_core::skills::SkillKey::builtin(
+        preload_skills: Some(vec![meerkat_core::skills::SkillKey::new(
+            meerkat_core::skills::SourceUuid::project_local(),
             meerkat_core::skills::SkillName::parse("broken-skill").expect("valid skill name"),
         )]),
         ..AgentBuildConfig::new("claude-sonnet-4-5")

--- a/meerkat/tests/integration.rs
+++ b/meerkat/tests/integration.rs
@@ -103,7 +103,7 @@ mod llm_normalization {
 
         let client = OpenAiClient::new(api_key);
         let request = LlmRequest::new(
-            "gpt-5.2",
+            "gpt-5.4",
             vec![Message::User(UserMessage::text(
                 "Say 'hello' and nothing else".to_string(),
             ))],

--- a/meerkat/tests/live_meerkat_regression.rs
+++ b/meerkat/tests/live_meerkat_regression.rs
@@ -255,7 +255,7 @@ mod scenario_23_structured_output {
         // --- OpenAI ---
         #[cfg(feature = "openai")]
         if let Some(_api_key) = openai_api_key() {
-            let openai_model = "gpt-5.2".to_string();
+            let openai_model = "gpt-5.4".to_string();
             eprintln!("[scenario 23] Testing structured output with OpenAI ({openai_model})");
             let temp_dir = TempDir::new().unwrap();
             let factory = AgentFactory::new(temp_dir.path().join("sessions"));

--- a/meerkat/tests/live_meerkat_user_flows.rs
+++ b/meerkat/tests/live_meerkat_user_flows.rs
@@ -304,7 +304,7 @@ fn anthropic_model() -> String {
 /// Get the OpenAI model to use in tests (configurable via OPENAI_MODEL env var)
 #[allow(dead_code)]
 fn openai_model() -> String {
-    std::env::var("OPENAI_MODEL").unwrap_or_else(|_| "gpt-5.2".to_string())
+    std::env::var("OPENAI_MODEL").unwrap_or_else(|_| "gpt-5.4".to_string())
 }
 
 /// Get the Gemini model to use in tests (configurable via GEMINI_MODEL env var)

--- a/meerkat/tests/persistence_contract.rs
+++ b/meerkat/tests/persistence_contract.rs
@@ -24,7 +24,7 @@ mod tests {
 
     fn create_request(prompt: &str) -> CreateSessionRequest {
         CreateSessionRequest {
-            model: "gpt-5.2".to_string(),
+            model: "gpt-5.4".to_string(),
             prompt: prompt.to_string().into(),
             render_metadata: None,
             system_prompt: None,

--- a/meerkat/tests/smoke_meerkat_sdk.rs
+++ b/meerkat/tests/smoke_meerkat_sdk.rs
@@ -330,7 +330,7 @@ mod scenario_01_multi_provider {
         // --- OpenAI ---
         #[cfg(feature = "openai")]
         if let Some(_api_key) = openai_api_key() {
-            let openai_model = "gpt-5.2".to_string();
+            let openai_model = "gpt-5.4".to_string();
             eprintln!("[scenario 1] Testing OpenAI with model {openai_model}");
             let temp_dir = TempDir::new().unwrap();
             let factory = AgentFactory::new(temp_dir.path().join("sessions"));
@@ -1938,7 +1938,7 @@ mod scenario_23_web_search_default_on {
             let temp = TempDir::new().unwrap();
             let factory = AgentFactory::new(temp.path().join("sessions"));
             let config = Config::default();
-            let mut build = AgentBuildConfig::new("gpt-5.2");
+            let mut build = AgentBuildConfig::new("gpt-5.4");
             build.provider = Some(meerkat_core::Provider::OpenAI);
             let mut agent = factory
                 .build_agent(build, &config)

--- a/sdks/python/meerkat/client.py
+++ b/sdks/python/meerkat/client.py
@@ -403,9 +403,9 @@ class MeerkatClient:
         self, provider: str, redirect_uri: str = "http://127.0.0.1:0/callback"
     ) -> dict[str, Any]:
         """Start an OAuth authorization-code login via
-        `auth/login/start`. Returns `{authorize_url, state,
-        pkce_verifier}`; client directs user to the URL then calls
-        `auth_login_complete` once the redirect carries a code."""
+        `auth/login/start`. Returns `{authorize_url, state}`; client directs
+        user to the URL then calls `auth_login_complete` once the redirect
+        carries a code."""
         return await self._request(
             "auth/login/start",
             {"provider": provider, "redirect_uri": redirect_uri},
@@ -415,24 +415,24 @@ class MeerkatClient:
         self,
         provider: str,
         code: str,
-        pkce_verifier: str,
+        state: str,
         *,
         realm_id: str = "dev",
-        profile_id: str | None = None,
+        binding_id: str | None = None,
         redirect_uri: str = "http://127.0.0.1:0/callback",
     ) -> dict[str, Any]:
         """Exchange an authorization code for tokens via
-        `auth/login/complete`. Tokens land in the server's
-        TokenStore under `<realm_id>:<profile_id>`."""
+        `auth/login/complete`. Tokens land in the server-side credential
+        source for the resolved binding."""
         params: dict[str, Any] = {
             "provider": provider,
             "code": code,
-            "pkce_verifier": pkce_verifier,
+            "state": state,
             "realm_id": realm_id,
             "redirect_uri": redirect_uri,
         }
-        if profile_id is not None:
-            params["profile_id"] = profile_id
+        if binding_id is not None:
+            params["binding_id"] = binding_id
         return await self._request("auth/login/complete", params)
 
     async def auth_login_device_start(self, provider: str) -> dict[str, Any]:

--- a/tests/integration/src/e2e_lanes.rs
+++ b/tests/integration/src/e2e_lanes.rs
@@ -75,6 +75,12 @@ struct CompletedCommand {
     output: String,
 }
 
+const WEB_RUNTIME_BUILD_IF_MISSING: &[&str] = &[
+    "/bin/sh",
+    "-c",
+    "if test -f ../../../sdks/web/wasm/meerkat_web_runtime.js && test -f ../../../sdks/web/wasm/meerkat_web_runtime_bg.wasm; then :; else npm --prefix ../../../sdks/web run build; fi",
+];
+
 #[derive(Clone, Debug)]
 enum PreCommandState {
     Running,
@@ -1493,7 +1499,7 @@ fn scenario_spec(id: u16) -> Option<&'static Spec> {
                     "-c",
                     "test -d ../../../sdks/web/node_modules || npm --prefix ../../../sdks/web install",
                 ],
-                &["npm", "--prefix", "../../../sdks/web", "run", "build"],
+                WEB_RUNTIME_BUILD_IF_MISSING,
                 &["npx", "playwright", "install", "chromium"],
             ],
             command: CommandSpec::Raw {
@@ -1525,7 +1531,7 @@ fn scenario_spec(id: u16) -> Option<&'static Spec> {
                     "-c",
                     "test -d ../../../sdks/web/node_modules || npm --prefix ../../../sdks/web install",
                 ],
-                &["npm", "--prefix", "../../../sdks/web", "run", "build"],
+                WEB_RUNTIME_BUILD_IF_MISSING,
                 &["npx", "playwright", "install", "chromium"],
             ],
             command: CommandSpec::Raw {
@@ -1557,7 +1563,7 @@ fn scenario_spec(id: u16) -> Option<&'static Spec> {
                     "-c",
                     "test -d ../../../sdks/web/node_modules || npm --prefix ../../../sdks/web install",
                 ],
-                &["npm", "--prefix", "../../../sdks/web", "run", "build"],
+                WEB_RUNTIME_BUILD_IF_MISSING,
                 &["npx", "playwright", "install", "chromium"],
             ],
             command: CommandSpec::Raw {
@@ -1589,7 +1595,7 @@ fn scenario_spec(id: u16) -> Option<&'static Spec> {
                     "-c",
                     "test -d ../../../sdks/web/node_modules || npm --prefix ../../../sdks/web install",
                 ],
-                &["npm", "--prefix", "../../../sdks/web", "run", "build"],
+                WEB_RUNTIME_BUILD_IF_MISSING,
                 &["npx", "playwright", "install", "chromium"],
             ],
             command: CommandSpec::Raw {

--- a/tests/integration/tests/e2e_auth_lane.rs
+++ b/tests/integration/tests/e2e_auth_lane.rs
@@ -143,25 +143,30 @@ async fn e2e_auth_refresh_coordinator_inproc_dedup() {
 #[tokio::test]
 #[ignore = "lane:e2e-auth"]
 async fn e2e_auth_mid_turn_reauth_notice_surface() {
-    use meerkat_core::handles::{AuthLeaseHandle, AuthLeasePhase};
+    use meerkat_core::handles::{AuthLeaseHandle, AuthLeasePhase, LeaseKey};
+    use meerkat_core::{BindingId, RealmId};
     use meerkat_runtime::RuntimeAuthLeaseHandle;
 
     let handle = RuntimeAuthLeaseHandle::ephemeral();
-    let key = "test-realm:test-binding";
+    let key = LeaseKey::new(
+        RealmId::parse("test-realm").unwrap(),
+        BindingId::parse("test-binding").unwrap(),
+        None,
+    );
 
     // 1. Acquire lease at state=valid.
-    handle.acquire_lease(key, 9_999_999_999).unwrap();
-    let snap = handle.snapshot(key);
+    handle.acquire_lease(&key, 9_999_999_999).unwrap();
+    let snap = handle.snapshot(&key);
     assert_eq!(snap.phase, Some(AuthLeasePhase::Valid));
 
     // 2. Drive to reauth_required and assert state.
-    handle.mark_reauth_required(key).unwrap();
-    let snap = handle.snapshot(key);
+    handle.mark_reauth_required(&key).unwrap();
+    let snap = handle.snapshot(&key);
     assert_eq!(snap.phase, Some(AuthLeasePhase::ReauthRequired));
 
     // 3. Release clears the lease.
-    handle.release_lease(key).unwrap();
-    let snap = handle.snapshot(key);
+    handle.release_lease(&key).unwrap();
+    let snap = handle.snapshot(&key);
     assert_eq!(snap.phase, None);
 }
 
@@ -175,16 +180,21 @@ async fn e2e_auth_mid_turn_reauth_notice_surface() {
 #[tokio::test]
 #[ignore = "lane:e2e-auth"]
 async fn e2e_auth_refresh_dedup_at_dsl_level() {
-    use meerkat_core::handles::{AuthLeaseHandle, AuthLeasePhase};
+    use meerkat_core::handles::{AuthLeaseHandle, AuthLeasePhase, LeaseKey};
+    use meerkat_core::{BindingId, RealmId};
     use meerkat_runtime::RuntimeAuthLeaseHandle;
 
     let handle = RuntimeAuthLeaseHandle::ephemeral();
-    let key = "dedup:binding";
+    let key = LeaseKey::new(
+        RealmId::parse("dedup").unwrap(),
+        BindingId::parse("binding").unwrap(),
+        None,
+    );
 
-    handle.acquire_lease(key, 1_000).unwrap();
-    handle.begin_refresh(key).unwrap();
+    handle.acquire_lease(&key, 1_000).unwrap();
+    handle.begin_refresh(&key).unwrap();
     assert_eq!(
-        handle.snapshot(key).phase,
+        handle.snapshot(&key).phase,
         Some(AuthLeasePhase::Refreshing),
         "lease should be in refreshing after begin_refresh"
     );
@@ -192,13 +202,13 @@ async fn e2e_auth_refresh_dedup_at_dsl_level() {
     // Second BeginRefresh must be rejected — dedup invariant owned by
     // the per-binding AuthMachine DSL (guard only permits
     // `Valid → Refreshing` or `Expiring → Refreshing`).
-    let err = handle.begin_refresh(key).unwrap_err();
+    let err = handle.begin_refresh(&key).unwrap_err();
     assert!(
         err.to_string().contains("BeginRefresh") || err.to_string().contains("begin_refresh"),
         "expected DSL rejection mentioning BeginRefresh / begin_refresh, got: {err}"
     );
 
     // Unblock refresh path: Complete transitions back to valid.
-    handle.complete_refresh(key, 2_000, 1_500).unwrap();
-    assert_eq!(handle.snapshot(key).phase, Some(AuthLeasePhase::Valid));
+    handle.complete_refresh(&key, 2_000, 1_500).unwrap();
+    assert_eq!(handle.snapshot(&key).phase, Some(AuthLeasePhase::Valid));
 }

--- a/tests/integration/tests/reserve_interaction_subscriber_fires.rs
+++ b/tests/integration/tests/reserve_interaction_subscriber_fires.rs
@@ -24,7 +24,7 @@
 
 use meerkat_comms::runtime::comms_runtime::CommsRuntime;
 use meerkat_core::agent::CommsRuntime as CoreCommsRuntime;
-use meerkat_core::comms::{CommsCommand, InputStreamMode, PeerName, SendReceipt};
+use meerkat_core::comms::{CommsCommand, InputStreamMode, PeerName, PeerRoute, SendReceipt};
 use meerkat_core::{
     ClassifiedInboxInteraction, HandlingMode, InteractionContent, InteractionId, ResponseStatus,
 };
@@ -44,7 +44,10 @@ async fn reserve_interaction_subscriber_fires_on_matching_response() {
     let receipt = CoreCommsRuntime::send(
         a.as_ref(),
         CommsCommand::PeerRequest {
-            to: PeerName::new(name_b.clone()).expect("peer_name valid"),
+            to: PeerRoute::with_display_name(
+                b.public_key().to_peer_id(),
+                PeerName::new(name_b.clone()).expect("peer_name valid"),
+            ),
             intent: "reservation-contract-probe".to_string(),
             params: serde_json::json!({"probe": true}),
             handling_mode: HandlingMode::Queue,
@@ -92,7 +95,10 @@ async fn reserve_interaction_subscriber_fires_on_matching_response() {
     let _response_receipt = CoreCommsRuntime::send(
         b.as_ref(),
         CommsCommand::PeerResponse {
-            to: PeerName::new(name_a.clone()).expect("peer_name valid"),
+            to: PeerRoute::with_display_name(
+                a.public_key().to_peer_id(),
+                PeerName::new(name_a.clone()).expect("peer_name valid"),
+            ),
             in_reply_to: InteractionId(envelope_id),
             status: ResponseStatus::Completed,
             result: serde_json::json!({"probe_reply": true}),


### PR DESCRIPTION
## Summary

Implements the PR-5 identity/auth connection backbone:

- makes skill source identity registry-backed, including project-local source UUIDs and shadow provenance by UUID
- routes provider resolution through typed `ConnectionRef`, honors profile overrides, removes model-prefix provider inference, and moves beta headers into catalog/model profile metadata
- adds server-owned OAuth state/PKCE correlation for REST and RPC auth completion
- introduces typed `LeaseKey` auth lease ownership and rotates the lease alongside live LLM identity hot-swap
- makes peer sends route by `PeerId` rather than display `PeerName`, with MCP/tool boundaries resolving names before dispatch
- tightens mob routing tests around private supervisor trust and typed peer routing

## Verification

- `cargo fmt --check`
- `scripts/repo-cargo check --workspace --all-targets`
- `scripts/repo-cargo nextest run -p meerkat-core -p meerkat-skills -p meerkat-comms -p meerkat-runtime -p meerkat-auth-core -p meerkat-llm-core --no-fail-fast`
- `scripts/repo-cargo nextest run -p meerkat-mob -p meerkat-mob-mcp --no-fail-fast`
- `make machine-check-drift && make audit-generated-headers && make seam-inventory`
- `make machine-verify`
- pre-push hooks: hardcoded secrets, whitespace, fmt, full workspace clippy, machine codegen/verify, generated header audit, bridge response-status guard, workspace deterministic gate
