### PR TITLE
LUC-23 Add local Rust build dependency installer

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,10 +13,14 @@ YELLOW := \033[0;33m
 RED := \033[0;31m
 NC := \033[0m
 
-.PHONY: all build test test-unit test-int e2e-fast e2e-build e2e-system e2e-live e2e-smoke test-int-real test-e2e test-all test-minimal test-feature-matrix-lib test-feature-matrix-surface test-feature-matrix test-surface-modularity test-sdk-python test-sdk-typescript test-sdk-suites lint lint-feature-matrix fmt fmt-check audit rust-lane-doctor agent-gate cargo-agent-gate buildbuddy-install buildbuddy-generate buildbuddy-generate-check buildbuddy-doctor buildbuddy-build buildbuddy-check buildbuddy-clippy buildbuddy-lint buildbuddy-test buildbuddy-test-all buildbuddy-test-unit buildbuddy-test-int buildbuddy-e2e-fast buildbuddy-e2e-system buildbuddy-e2e-live buildbuddy-e2e-smoke buildbuddy-agent-gate buildbuddy-ci-dispatch buildbuddy-fast buildbuddy-benchmark buildbuddy-ci buildbuddy-ci-warm buildbuddy-ci-full buildbuddy-ci-full-warm ci ci-smoke release-preflight release-preflight-smoke publish-dry-run publish-dry-run-python publish-dry-run-typescript release-dry-run release-dry-run-smoke clean doc release install-hooks coverage check help legacy-surface-gate legacy-surface-inventory session-control-gate deprecated-backend-gate deprecated-backend-inventory verify-version-parity verify-schema-freshness verify-rpc-surface-alignment verify-sdk-wrapper-freshness check-rust-release-packaging check-mini-skill-size bump-sdk-versions smoke-sdk-python-artifact smoke-sdk-typescript-artifact xtask-build machine-codegen machine-verify machine-check-drift seam-inventory rmat-audit audit-generated-headers
+.PHONY: all install-build-deps build test test-unit test-int e2e-fast e2e-build e2e-system e2e-live e2e-smoke test-int-real test-e2e test-all test-minimal test-feature-matrix-lib test-feature-matrix-surface test-feature-matrix test-surface-modularity test-sdk-python test-sdk-typescript test-sdk-suites lint lint-feature-matrix fmt fmt-check audit rust-lane-doctor agent-gate cargo-agent-gate buildbuddy-install buildbuddy-generate buildbuddy-generate-check buildbuddy-doctor buildbuddy-build buildbuddy-check buildbuddy-clippy buildbuddy-lint buildbuddy-test buildbuddy-test-all buildbuddy-test-unit buildbuddy-test-int buildbuddy-e2e-fast buildbuddy-e2e-system buildbuddy-e2e-live buildbuddy-e2e-smoke buildbuddy-agent-gate buildbuddy-ci-dispatch buildbuddy-fast buildbuddy-benchmark buildbuddy-ci buildbuddy-ci-warm buildbuddy-ci-full buildbuddy-ci-full-warm ci ci-smoke release-preflight release-preflight-smoke publish-dry-run publish-dry-run-python publish-dry-run-typescript release-dry-run release-dry-run-smoke clean doc release install-hooks coverage check help legacy-surface-gate legacy-surface-inventory session-control-gate deprecated-backend-gate deprecated-backend-inventory verify-version-parity verify-schema-freshness verify-rpc-surface-alignment verify-sdk-wrapper-freshness check-rust-release-packaging check-mini-skill-size bump-sdk-versions smoke-sdk-python-artifact smoke-sdk-typescript-artifact xtask-build machine-codegen machine-verify machine-check-drift seam-inventory rmat-audit audit-generated-headers
 
 # Default target
 all: ci
+
+install-build-deps:
+	@echo "$(GREEN)Installing local Rust build dependencies...$(NC)"
+	@scripts/install-build-deps
 
 # Build the project
 build:
@@ -617,6 +621,7 @@ help:
 	@echo "Available targets:"
 	@echo "  $(YELLOW)Cargo is the default backend. Set MEERKAT_BUILDBUDDY=1 to route supported local lanes through BuildBuddy.$(NC)"
 	@echo "  $(GREEN)build$(NC)         - Build the project (debug)"
+	@echo "  $(GREEN)install-build-deps$(NC) - Install the pinned Rust toolchain for local builds"
 	@echo "  $(GREEN)release$(NC)       - Build optimized release version"
 	@echo "  $(GREEN)test$(NC)          - Run fast tests (unit + integration-fast)"
 	@echo "  $(GREEN)test-unit$(NC)     - Run unit tests only"

--- a/README.md
+++ b/README.md
@@ -186,6 +186,23 @@ repository secret. Without that variable, GitHub CI stays on the Cargo path.
 
 Default CI requires `unit`, `int`, `e2e-fast`, and `e2e-system`. Live-provider lanes stay opt-in.
 
+## Development Setup
+
+Install the Rust toolchain required by the default local build lanes:
+
+```bash
+make install-build-deps
+```
+
+The installer reads `rust-toolchain.toml`, installs the pinned Rust toolchain
+with `rustfmt` and `clippy` through `rustup`, and leaves optional BuildBuddy
+setup to `make buildbuddy-doctor`. If your shell does not already include
+Cargo's bin directory, run:
+
+```bash
+source "$HOME/.cargo/env"
+```
+
 ## Capabilities
 
 **Providers and streaming.** Anthropic, OpenAI, and Gemini through a unified streaming interface. Provider is resolved from the built-in model catalog or configured self-hosted aliases -- switch models with a flag, not a code change.

--- a/scripts/install-build-deps
+++ b/scripts/install-build-deps
@@ -1,0 +1,72 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+script_dir="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+repo_root="$(cd "${script_dir}/.." && git rev-parse --path-format=absolute --show-toplevel)"
+toolchain_file="${repo_root}/rust-toolchain.toml"
+
+usage() {
+  cat <<'EOF'
+usage: scripts/install-build-deps
+
+Installs the Rust toolchain needed by the default Make/Cargo lanes.
+The Rust version and components come from rust-toolchain.toml.
+EOF
+}
+
+if [[ "${1-}" == "-h" || "${1-}" == "--help" ]]; then
+  usage
+  exit 0
+fi
+
+rust_channel="$(
+  awk -F '"' '/^[[:space:]]*channel[[:space:]]*=/ { print $2; exit }' "${toolchain_file}"
+)"
+
+if [[ -z "${rust_channel}" ]]; then
+  echo "error: could not read Rust channel from ${toolchain_file}" >&2
+  exit 1
+fi
+
+cargo_home="${CARGO_HOME:-${HOME}/.cargo}"
+export CARGO_HOME="${cargo_home}"
+export PATH="${CARGO_HOME}/bin:${PATH}"
+
+download_rustup_init() {
+  local output="$1"
+
+  if command -v curl >/dev/null 2>&1; then
+    curl --proto '=https' --tlsv1.2 -fsSL https://sh.rustup.rs -o "${output}"
+  elif command -v wget >/dev/null 2>&1; then
+    wget -qO "${output}" https://sh.rustup.rs
+  else
+    echo "error: curl or wget is required to install rustup" >&2
+    exit 1
+  fi
+}
+
+if ! command -v rustup >/dev/null 2>&1; then
+  tmp_rustup="$(mktemp)"
+  trap 'rm -f "${tmp_rustup}"' EXIT
+
+  echo "Installing rustup into ${CARGO_HOME}..."
+  download_rustup_init "${tmp_rustup}"
+  sh "${tmp_rustup}" -y --no-modify-path --profile minimal --default-toolchain none
+  hash -r
+fi
+
+echo "Installing Rust ${rust_channel} with rustfmt and clippy..."
+rustup toolchain install "${rust_channel}" \
+  --profile minimal \
+  --component rustfmt \
+  --component clippy
+
+echo
+rustup run "${rust_channel}" cargo --version
+rustup run "${rust_channel}" rustc --version
+rustup run "${rust_channel}" rustfmt --version
+rustup run "${rust_channel}" cargo clippy --version
+
+echo
+echo "Rust build dependencies are installed."
+echo "For interactive shells, add ${CARGO_HOME}/bin to PATH or source ${CARGO_HOME}/env."

--- a/scripts/repo-cargo
+++ b/scripts/repo-cargo
@@ -68,4 +68,22 @@ EOF
 fi
 
 cd "${workspace_root}"
-exec cargo "$@"
+
+if [[ -n "${CARGO_BIN:-}" ]]; then
+  cargo_cmd="${CARGO_BIN}"
+elif command -v cargo >/dev/null 2>&1; then
+  cargo_cmd="$(command -v cargo)"
+elif [[ -x "${HOME}/.cargo/bin/cargo" ]]; then
+  cargo_cmd="${HOME}/.cargo/bin/cargo"
+  export PATH="${HOME}/.cargo/bin:${PATH}"
+else
+  cat >&2 <<'EOF'
+error: cargo was not found on PATH.
+
+Run `make install-build-deps` to install the Rust toolchain pinned by
+rust-toolchain.toml, or set CARGO_BIN to an explicit cargo binary.
+EOF
+  exit 127
+fi
+
+exec "${cargo_cmd}" "$@"


### PR DESCRIPTION
## Summary
- add `make install-build-deps` backed by `scripts/install-build-deps`
- install the Rust toolchain pinned by `rust-toolchain.toml` with rustfmt and clippy
- make `scripts/repo-cargo` find `$HOME/.cargo/bin/cargo` and add the matching Rust proxy directory to PATH when Cargo is installed but not exported
- document local setup in README

## Validation
- `bash -n scripts/install-build-deps`
- `bash -n scripts/repo-cargo`
- `make help`
- `make install-build-deps`
- `./scripts/repo-cargo --version` -> `cargo 1.94.0 (85eff7c80 2026-01-15)`
- `make build` -> passed, finished dev profile in 9m08s

## Note
- `make check` now progresses past missing Cargo/Rust setup, then fails in unrelated existing test target `meerkat-client/tests/live_client_provider_matrix.rs` due image-generation plan imports from `meerkat_core` that are exposed by provider crates.

Linear: LUC-23