### PR TITLE
Fix deferred RPC turn with inline external tools

### DIFF
--- a/meerkat-rpc/src/session_runtime.rs
+++ b/meerkat-rpc/src/session_runtime.rs
@@ -2471,6 +2471,18 @@ impl SessionRuntime {
                 }
             }
 
+            if let Err(err) = Self::validate_keep_alive_has_comms_name(&build_config) {
+                self.restore_pending_from_promoting(
+                    session_id,
+                    build_config,
+                    labels,
+                    saved_deferred_prompt,
+                    created_at_secs,
+                    updated_at_secs,
+                )
+                .await;
+                return Err(err);
+            }
             if build_config.llm_client_override.is_none()
                 && let Some(client) = self.default_llm_client()
             {
@@ -2913,6 +2925,18 @@ impl SessionRuntime {
                 if let Some(keep_alive) = ov.keep_alive {
                     build_config.keep_alive = keep_alive;
                 }
+            }
+            if let Err(err) = Self::validate_keep_alive_has_comms_name(&build_config) {
+                self.restore_pending_from_promoting(
+                    session_id,
+                    build_config,
+                    labels,
+                    saved_deferred_prompt,
+                    saved_created_at_secs,
+                    saved_updated_at_secs,
+                )
+                .await;
+                return Err(err);
             }
             // Inject default LLM client if the caller didn't provide one.
             if build_config.llm_client_override.is_none()
@@ -3388,12 +3412,28 @@ impl SessionRuntime {
                 message: format!("session {session_id} is already being materialized"),
                 data: None,
             }),
+            Err(meerkat::StagedLifecycleError::KeepAliveRequiresCommsName) => Err(RpcError {
+                code: error::INVALID_PARAMS,
+                message: "keep_alive requires a session created with comms_name".to_string(),
+                data: None,
+            }),
             Err(err) => Err(RpcError {
                 code: error::INTERNAL_ERROR,
                 message: format!("staged session lifecycle error: {err}"),
                 data: None,
             }),
         }
+    }
+
+    fn validate_keep_alive_has_comms_name(build_config: &AgentBuildConfig) -> Result<(), RpcError> {
+        if build_config.keep_alive && build_config.comms_name.is_none() {
+            return Err(RpcError {
+                code: error::INVALID_PARAMS,
+                message: "keep_alive requires a session created with comms_name".to_string(),
+                data: None,
+            });
+        }
+        Ok(())
     }
 
     /// Read the authoritative session view from the owning session service.
@@ -7925,6 +7965,61 @@ mod tests {
                 err.message
             );
         }
+    }
+
+    #[cfg(feature = "comms")]
+    #[tokio::test]
+    async fn runtime_turn_keep_alive_override_on_pending_requires_comms_name() {
+        use crate::handlers::turn::TurnOverrides;
+
+        let temp = tempfile::tempdir().unwrap();
+        let runtime = Arc::new(make_runtime(temp_factory(&temp), 10));
+
+        let session_id = runtime
+            .create_session(mock_build_config(), None, None)
+            .await
+            .unwrap();
+
+        let (tx, _rx) = mpsc::channel(100);
+        let err = runtime
+            .start_turn_via_runtime(
+                &session_id,
+                "test".into(),
+                tx,
+                None,
+                None,
+                None,
+                Some(TurnOverrides {
+                    keep_alive: Some(true),
+                    ..Default::default()
+                }),
+            )
+            .await
+            .expect_err("keep_alive=true must require comms_name on pending sessions");
+
+        assert_eq!(err.code, error::INVALID_PARAMS);
+        assert_eq!(
+            err.message,
+            "keep_alive requires a session created with comms_name"
+        );
+        assert!(
+            runtime.pending_session_exists(&session_id).await,
+            "invalid staged keep_alive override must leave the session staged"
+        );
+
+        let (tx, _rx) = mpsc::channel(100);
+        runtime
+            .start_turn(
+                &session_id,
+                "after rejection".into(),
+                tx,
+                None,
+                None,
+                None,
+                None,
+            )
+            .await
+            .expect("staged session should remain promotable after rejected override");
     }
 
     /// W2-G regression: once a mob has claimed peer-ingress ownership on a

--- a/meerkat-rpc/src/session_runtime.rs
+++ b/meerkat-rpc/src/session_runtime.rs
@@ -2073,6 +2073,13 @@ impl SessionRuntime {
         #[cfg(feature = "comms")]
         {
             let keep_alive_override = overrides.as_ref().and_then(|ov| ov.keep_alive);
+            let pending_keep_alive_override_applied = if let Some(keep_alive) = keep_alive_override
+            {
+                self.apply_pending_keep_alive_override(session_id, keep_alive)
+                    .await?
+            } else {
+                false
+            };
             let keep_alive = match keep_alive_override {
                 Some(val) => val,
                 None => self
@@ -2081,57 +2088,60 @@ impl SessionRuntime {
                     .and_then(|s| s.session_metadata().map(|m| m.keep_alive))
                     .unwrap_or(false),
             };
-            let comms_rt = self.service.comms_runtime(session_id).await;
-            if keep_alive && comms_rt.is_none() {
-                // Check if the runtime adapter already has comms configured
-                // for this session (e.g., via enable_comms_drain). If so,
-                // the session-service comms check is not authoritative.
-                let adapter_has_comms = self.runtime_adapter.session_has_comms(session_id).await;
-                if !adapter_has_comms {
-                    return Err(RpcError {
-                        code: error::INVALID_PARAMS,
-                        message: "keep_alive requires a session created with comms_name"
-                            .to_string(),
-                        data: None,
-                    });
+            if !pending_keep_alive_override_applied {
+                let comms_rt = self.service.comms_runtime(session_id).await;
+                if keep_alive && comms_rt.is_none() {
+                    // Check if the runtime adapter already has comms configured
+                    // for this session (e.g., via enable_comms_drain). If so,
+                    // the session-service comms check is not authoritative.
+                    let adapter_has_comms =
+                        self.runtime_adapter.session_has_comms(session_id).await;
+                    if !adapter_has_comms {
+                        return Err(RpcError {
+                            code: error::INVALID_PARAMS,
+                            message: "keep_alive requires a session created with comms_name"
+                                .to_string(),
+                            data: None,
+                        });
+                    }
                 }
-            }
-            // Persist explicit override so subsequent inheriting calls observe it.
-            if keep_alive_override.is_some() {
-                self.service
-                    .apply_runtime_session_keep_alive(session_id, keep_alive)
-                    .await
-                    .map_err(session_error_to_rpc)?;
-            }
-            // W2-G: never reconfigure a mob-owned drain from the session-runtime
-            // turn-start path. The mob provisioner owns peer-ingress for its
-            // members; the session runtime has no visibility into the mob's
-            // comms context and must not substitute its own (this is the
-            // s71 silent-downgrade class). The DSL's
-            // `AttachSessionIngress` guard would already reject the swap,
-            // but we short-circuit here so the turn-start path doesn't emit
-            // a spurious WARN for every turn on every mob-owned member.
-            let owner = self.runtime_adapter.peer_ingress_owner(session_id).await;
-            if owner.is_mob_owned() {
-                tracing::debug!(
-                    %session_id,
-                    ?owner,
-                    "start_turn_via_runtime: mob-owned peer ingress — skipping drain reconfigure"
-                );
-            } else {
-                let peer_ingress_enabled = self
-                    .preserve_existing_peer_ingress(session_id, keep_alive)
-                    .await;
-                // Preserve an already-active peer ingress channel for
-                // externally-enabled sessions even when the persisted
-                // keep_alive bit is false. Without this, ordinary turn
-                // routing can accidentally tear down the persistent comms
-                // drain that autonomous peers rely on for between-turn
-                // responses.
-                if comms_rt.is_some() || peer_ingress_enabled {
-                    self.runtime_adapter
-                        .update_peer_ingress_context(session_id, peer_ingress_enabled, comms_rt)
+                // Persist explicit override so subsequent inheriting calls observe it.
+                if keep_alive_override.is_some() {
+                    self.service
+                        .apply_runtime_session_keep_alive(session_id, keep_alive)
+                        .await
+                        .map_err(session_error_to_rpc)?;
+                }
+                // W2-G: never reconfigure a mob-owned drain from the session-runtime
+                // turn-start path. The mob provisioner owns peer-ingress for its
+                // members; the session runtime has no visibility into the mob's
+                // comms context and must not substitute its own (this is the
+                // s71 silent-downgrade class). The DSL's
+                // `AttachSessionIngress` guard would already reject the swap,
+                // but we short-circuit here so the turn-start path doesn't emit
+                // a spurious WARN for every turn on every mob-owned member.
+                let owner = self.runtime_adapter.peer_ingress_owner(session_id).await;
+                if owner.is_mob_owned() {
+                    tracing::debug!(
+                        %session_id,
+                        ?owner,
+                        "start_turn_via_runtime: mob-owned peer ingress — skipping drain reconfigure"
+                    );
+                } else {
+                    let peer_ingress_enabled = self
+                        .preserve_existing_peer_ingress(session_id, keep_alive)
                         .await;
+                    // Preserve an already-active peer ingress channel for
+                    // externally-enabled sessions even when the persisted
+                    // keep_alive bit is false. Without this, ordinary turn
+                    // routing can accidentally tear down the persistent comms
+                    // drain that autonomous peers rely on for between-turn
+                    // responses.
+                    if comms_rt.is_some() || peer_ingress_enabled {
+                        self.runtime_adapter
+                            .update_peer_ingress_context(session_id, peer_ingress_enabled, comms_rt)
+                            .await;
+                    }
                 }
             }
         }
@@ -3360,6 +3370,30 @@ impl SessionRuntime {
 
     pub async fn pending_session_exists(&self, session_id: &SessionId) -> bool {
         self.staged_sessions.contains(session_id).await
+    }
+
+    async fn apply_pending_keep_alive_override(
+        &self,
+        session_id: &SessionId,
+        keep_alive: bool,
+    ) -> Result<bool, RpcError> {
+        match self
+            .staged_sessions
+            .update_keep_alive(session_id, keep_alive, now_unix_secs())
+            .await
+        {
+            Ok(applied) => Ok(applied),
+            Err(meerkat::StagedLifecycleError::AlreadyPromoting(_)) => Err(RpcError {
+                code: error::SESSION_BUSY,
+                message: format!("session {session_id} is already being materialized"),
+                data: None,
+            }),
+            Err(err) => Err(RpcError {
+                code: error::INTERNAL_ERROR,
+                message: format!("staged session lifecycle error: {err}"),
+                data: None,
+            }),
+        }
     }
 
     /// Read the authoritative session view from the owning session service.

--- a/meerkat-rpc/tests/integration_server.rs
+++ b/meerkat-rpc/tests/integration_server.rs
@@ -409,6 +409,95 @@ async fn deferred_callback_direct_sessions_expose_control_plane_tools_on_first_t
 }
 
 #[tokio::test]
+async fn deferred_inline_external_tools_accept_explicit_keep_alive_false_turn() {
+    let client = Arc::new(RecordingToolClient::default());
+    let (mut writer, mut reader, server_handle) = spawn_test_server_with_client(client.clone());
+
+    send_request(
+        &mut writer,
+        &serde_json::json!({
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": "initialize",
+            "params": {}
+        }),
+    )
+    .await;
+    let init_resp = read_response(&mut reader).await;
+    assert!(
+        init_resp["error"].is_null(),
+        "initialize failed: {init_resp}"
+    );
+
+    send_request(
+        &mut writer,
+        &serde_json::json!({
+            "jsonrpc": "2.0",
+            "id": 2,
+            "method": "session/create",
+            "params": {
+                "prompt": "Bootstrap deferred session",
+                "initial_turn": "deferred",
+                "enable_builtins": false,
+                "enable_shell": false,
+                "enable_memory": false,
+                "enable_mob": false,
+                "keep_alive": false,
+                "external_tools": [{
+                    "name": "linear_graphql",
+                    "description": "Execute GraphQL",
+                    "input_schema": {
+                        "type": "object",
+                        "properties": {
+                            "query": {"type": "string"},
+                            "variables": {"type": "object"}
+                        },
+                        "required": ["query"],
+                        "additionalProperties": false
+                    }
+                }]
+            }
+        }),
+    )
+    .await;
+    let create_resp = read_response(&mut reader).await;
+    assert!(
+        create_resp["error"].is_null(),
+        "session/create failed: {create_resp}"
+    );
+    let session_id = create_resp["result"]["session_id"]
+        .as_str()
+        .expect("session_id missing")
+        .to_string();
+
+    send_request(
+        &mut writer,
+        &serde_json::json!({
+            "jsonrpc": "2.0",
+            "id": 3,
+            "method": "turn/start",
+            "params": {
+                "session_id": session_id,
+                "prompt": "Inspect the deferred inline callback tool surface.",
+                "keep_alive": false
+            }
+        }),
+    )
+    .await;
+    let turn_resp = read_response(&mut reader).await;
+    assert!(
+        turn_resp["error"].is_null(),
+        "turn/start failed: {turn_resp}"
+    );
+
+    let seen = client.seen_tools();
+    assert_eq!(seen.len(), 1, "expected exactly one LLM call, got {seen:?}");
+
+    drop(writer);
+    server_handle.await.unwrap().unwrap();
+}
+
+#[tokio::test]
 async fn late_registered_deferred_callbacks_keep_control_plane_after_inline_build() {
     let client = Arc::new(RecordingToolClient::default());
     let (mut writer, mut reader, server_handle) = spawn_test_server_with_client(client.clone());

--- a/meerkat/src/staged_sessions.rs
+++ b/meerkat/src/staged_sessions.rs
@@ -96,6 +96,9 @@ pub enum StagedLifecycleError {
     /// No staged slot exists for the session.
     #[error("staged session not found: {0}")]
     NotFound(SessionId),
+    /// A staged keep-alive override requires a comms participant name.
+    #[error("keep_alive requires a session created with comms_name")]
+    KeepAliveRequiresCommsName,
 }
 
 /// Canonical staged-session registry.
@@ -153,6 +156,9 @@ impl StagedSessionRegistry {
         };
         match &mut slot.phase {
             StagedPhase::Staged { build_config } => {
+                if keep_alive && build_config.comms_name.is_none() {
+                    return Err(StagedLifecycleError::KeepAliveRequiresCommsName);
+                }
                 build_config.keep_alive = keep_alive;
                 slot.updated_at_secs = updated_at_secs;
                 Ok(true)

--- a/meerkat/src/staged_sessions.rs
+++ b/meerkat/src/staged_sessions.rs
@@ -139,6 +139,30 @@ impl StagedSessionRegistry {
         slots.get(id).map(|s| s.effective_llm_identity.clone())
     }
 
+    /// Apply a keep-alive override to a staged session before its first turn
+    /// materializes it in the session service.
+    pub async fn update_keep_alive(
+        &self,
+        id: &SessionId,
+        keep_alive: bool,
+        updated_at_secs: u64,
+    ) -> Result<bool, StagedLifecycleError> {
+        let mut slots = self.slots.write().await;
+        let Some(slot) = slots.get_mut(id) else {
+            return Ok(false);
+        };
+        match &mut slot.phase {
+            StagedPhase::Staged { build_config } => {
+                build_config.keep_alive = keep_alive;
+                slot.updated_at_secs = updated_at_secs;
+                Ok(true)
+            }
+            StagedPhase::Promoting { .. } => {
+                Err(StagedLifecycleError::AlreadyPromoting(id.clone()))
+            }
+        }
+    }
+
     /// All slots, optionally filtered by labels, as (id, info) pairs.
     pub async fn list(
         &self,


### PR DESCRIPTION
## Summary
- Preserve explicit keep_alive overrides on staged deferred sessions instead of applying them to the live session service before materialization
- Add an RPC regression for deferred session/create with inline external_tools followed by turn/start keep_alive=false

## Validation
- ./scripts/repo-cargo test -p meerkat-rpc --test integration_server deferred_inline_external_tools_accept_explicit_keep_alive_false_turn -- --nocapture
- make check
- Rebuilt rkat-rpc and reran the original wire repro; it no longer returns session not found and proceeds to provider auth resolution in this environment

Linear: LUC-32