### PR TITLE
Gate machine authority CI by changed paths

### DIFF
--- a/.github/workflows/buildbuddy.yml
+++ b/.github/workflows/buildbuddy.yml
@@ -8,6 +8,16 @@ on:
         required: false
         default: full-fresh
         type: string
+      machine_authority_base_sha:
+        description: Base revision for machine-authority change detection.
+        required: false
+        default: ""
+        type: string
+      machine_authority_head_sha:
+        description: Head revision for machine-authority change detection.
+        required: false
+        default: ""
+        type: string
     secrets:
       BUILDBUDDY_API_KEY:
         required: true
@@ -174,7 +184,36 @@ jobs:
         uses: actions/checkout@v6
         with:
           fetch-depth: 0
+      - name: Detect machine-authority changes
+        id: machine-changes
+        shell: bash
+        env:
+          MACHINE_AUTHORITY_BASE_SHA: ${{ inputs.machine_authority_base_sha || '' }}
+          MACHINE_AUTHORITY_HEAD_SHA: ${{ inputs.machine_authority_head_sha || github.sha }}
+        run: |
+          changed=true
+          if [[ -n "${MACHINE_AUTHORITY_BASE_SHA}" && "${MACHINE_AUTHORITY_BASE_SHA}" != "0000000000000000000000000000000000000000" ]]; then
+            set +e
+            scripts/machine-authority-changed --base "${MACHINE_AUTHORITY_BASE_SHA}" --head "${MACHINE_AUTHORITY_HEAD_SHA}"
+            status="$?"
+            set -e
+            case "${status}" in
+              0) changed=true ;;
+              1) changed=false ;;
+              *)
+                echo "Machine-authority diff failed; running conservative check."
+                changed=true
+                ;;
+            esac
+          else
+            echo "No reliable diff base; running machine authority."
+          fi
+          echo "changed=${changed}" >> "${GITHUB_OUTPUT}"
+      - name: Skip machine authority
+        if: ${{ steps.machine-changes.outputs.changed != 'true' }}
+        run: echo "No machine-authority inputs changed; skipping TLA+ machine checks."
       - uses: ./.github/actions/run-buildbuddy-ci-lane
+        if: ${{ steps.machine-changes.outputs.changed == 'true' }}
         with:
           lane: machine-authority
           profile: native

--- a/.github/workflows/cargo.yml
+++ b/.github/workflows/cargo.yml
@@ -2,6 +2,17 @@ name: Cargo CI
 
 on:
   workflow_call:
+    inputs:
+      machine_authority_base_sha:
+        description: Base revision for machine-authority change detection.
+        required: false
+        default: ""
+        type: string
+      machine_authority_head_sha:
+        description: Head revision for machine-authority change detection.
+        required: false
+        default: ""
+        type: string
   workflow_dispatch:
 
 permissions:
@@ -98,21 +109,57 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Detect machine-authority changes
+        id: machine-changes
+        shell: bash
+        env:
+          MACHINE_AUTHORITY_BASE_SHA: ${{ inputs.machine_authority_base_sha || '' }}
+          MACHINE_AUTHORITY_HEAD_SHA: ${{ inputs.machine_authority_head_sha || github.sha }}
+        run: |
+          changed=true
+          if [[ -n "${MACHINE_AUTHORITY_BASE_SHA}" && "${MACHINE_AUTHORITY_BASE_SHA}" != "0000000000000000000000000000000000000000" ]]; then
+            set +e
+            scripts/machine-authority-changed --base "${MACHINE_AUTHORITY_BASE_SHA}" --head "${MACHINE_AUTHORITY_HEAD_SHA}"
+            status="$?"
+            set -e
+            case "${status}" in
+              0) changed=true ;;
+              1) changed=false ;;
+              *)
+                echo "Machine-authority diff failed; running conservative check."
+                changed=true
+                ;;
+            esac
+          else
+            echo "No reliable diff base; running machine authority."
+          fi
+          echo "changed=${changed}" >> "${GITHUB_OUTPUT}"
+
+      - name: Skip machine authority
+        if: ${{ steps.machine-changes.outputs.changed != 'true' }}
+        run: echo "No machine-authority inputs changed; skipping TLA+ machine checks."
 
       - name: Install Rust
+        if: ${{ steps.machine-changes.outputs.changed == 'true' }}
         uses: dtolnay/rust-toolchain@stable
 
       - name: Cache cargo registry
+        if: ${{ steps.machine-changes.outputs.changed == 'true' }}
         uses: Swatinem/rust-cache@v2
         with:
           prefix-key: machine-authority
 
       - uses: actions/setup-java@v4
+        if: ${{ steps.machine-changes.outputs.changed == 'true' }}
         with:
           distribution: temurin
           java-version: 21
 
       - name: Install TLC
+        if: ${{ steps.machine-changes.outputs.changed == 'true' }}
         run: |
           mkdir -p $HOME/.local/lib $HOME/.local/bin
           curl -sL -o $HOME/.local/lib/tla2tools.jar \
@@ -122,24 +169,31 @@ jobs:
           echo "$HOME/.local/bin" >> $GITHUB_PATH
 
       - name: Machine code generation
+        if: ${{ steps.machine-changes.outputs.changed == 'true' }}
         run: ./scripts/repo-cargo xtask machine-codegen --all
 
       - name: Generated artifacts stay clean
+        if: ${{ steps.machine-changes.outputs.changed == 'true' }}
         run: git diff --exit-code
 
       - name: Machine drift check
+        if: ${{ steps.machine-changes.outputs.changed == 'true' }}
         run: ./scripts/repo-cargo xtask machine-check-drift --all
 
       - name: Machine verification
+        if: ${{ steps.machine-changes.outputs.changed == 'true' }}
         run: ./scripts/repo-cargo xtask machine-verify --all
 
       - name: Protocol codegen
+        if: ${{ steps.machine-changes.outputs.changed == 'true' }}
         run: ./scripts/repo-cargo xtask protocol-codegen
 
       - name: Protocol codegen stays clean
+        if: ${{ steps.machine-changes.outputs.changed == 'true' }}
         run: git diff --exit-code
 
       - name: Audit @generated header truthfulness
+        if: ${{ steps.machine-changes.outputs.changed == 'true' }}
         run: ./scripts/repo-cargo xtask audit-generated-headers
 
   rmat-audit:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,6 +21,9 @@ jobs:
     name: Cargo CI
     if: ${{ !(vars.MEERKAT_BUILDBUDDY == 'true' || vars.MEERKAT_BUILDBUDDY == '1') || (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository) }}
     uses: ./.github/workflows/cargo.yml
+    with:
+      machine_authority_base_sha: ${{ github.event_name == 'pull_request' && github.event.pull_request.base.sha || github.event_name == 'push' && github.event.before || '' }}
+      machine_authority_head_sha: ${{ github.sha }}
 
   buildbuddy:
     name: BuildBuddy CI
@@ -28,6 +31,8 @@ jobs:
     uses: ./.github/workflows/buildbuddy.yml
     with:
       mode: ${{ vars.MEERKAT_BUILDBUDDY_CI_MODE || 'full-fresh' }}
+      machine_authority_base_sha: ${{ github.event_name == 'pull_request' && github.event.pull_request.base.sha || github.event_name == 'push' && github.event.before || '' }}
+      machine_authority_head_sha: ${{ github.sha }}
     secrets: inherit
 
   gate:

--- a/scripts/machine-authority-changed
+++ b/scripts/machine-authority-changed
@@ -87,7 +87,7 @@ machine_authority_path() {
     meerkat-runtime/src/meerkat_machine/*|meerkat-runtime/src/auth_machine/*|meerkat-mob/src/machines/*|meerkat-schedule/src/machines/*)
       return 0
       ;;
-    meerkat-machine-kernels/src/generated/*|*/src/generated/protocol_*.rs|meerkat-core/src/generated/terminal_surface_mapping.rs)
+    meerkat-machine-kernels/src/generated/*|meerkat-core/src/generated/*|meerkat-mob/src/generated/*|meerkat-runtime/src/generated/*|meerkat-schedule/src/generated/*|*/src/generated/protocol_*.rs)
       return 0
       ;;
     xtask/Cargo.toml|xtask/BUILD.bazel|xtask/src/lib.rs|xtask/src/main.rs|xtask/src/machines*.rs|xtask/src/protocol_codegen.rs|xtask/src/audit_generated_headers.rs|xtask/src/public_contracts.rs)

--- a/scripts/machine-authority-changed
+++ b/scripts/machine-authority-changed
@@ -1,0 +1,120 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  cat <<'EOF'
+usage: machine-authority-changed [--base <rev> --head <rev>] [changed-path ...]
+
+Exits 0 when any changed path can affect the machine-authority CI lane.
+Exits 1 when the supplied or diffed paths are unrelated.
+EOF
+}
+
+base=""
+head=""
+paths=()
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --base)
+      if [[ $# -lt 2 ]]; then
+        echo "error: --base requires a revision" >&2
+        usage >&2
+        exit 2
+      fi
+      base="$2"
+      shift 2
+      ;;
+    --head)
+      if [[ $# -lt 2 ]]; then
+        echo "error: --head requires a revision" >&2
+        usage >&2
+        exit 2
+      fi
+      head="$2"
+      shift 2
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    --)
+      shift
+      while [[ $# -gt 0 ]]; do
+        paths+=("$1")
+        shift
+      done
+      ;;
+    -*)
+      echo "unknown argument: $1" >&2
+      usage >&2
+      exit 2
+      ;;
+    *)
+      paths+=("$1")
+      shift
+      ;;
+  esac
+done
+
+if [[ -n "${base}" || -n "${head}" ]]; then
+  if [[ -z "${base}" || -z "${head}" ]]; then
+    echo "error: --base and --head must be supplied together" >&2
+    usage >&2
+    exit 2
+  fi
+  diff_output="$(git diff --name-only "${base}" "${head}" --)" || {
+    echo "error: cannot diff ${base}..${head}" >&2
+    exit 2
+  }
+  paths=()
+  if [[ -n "${diff_output}" ]]; then
+    while IFS= read -r path; do
+      paths+=("${path}")
+    done <<<"${diff_output}"
+  fi
+fi
+
+machine_authority_path() {
+  local path="${1#./}"
+  case "${path}" in
+    specs/machines/*|specs/compositions/*)
+      return 0
+      ;;
+    meerkat-machine-codegen/*|meerkat-machine-derive/*|meerkat-machine-dsl/*|meerkat-machine-dsl-core/*|meerkat-machine-kernels/*|meerkat-machine-schema/*)
+      return 0
+      ;;
+    meerkat-runtime/src/meerkat_machine/*|meerkat-runtime/src/auth_machine/*|meerkat-mob/src/machines/*|meerkat-schedule/src/machines/*)
+      return 0
+      ;;
+    meerkat-machine-kernels/src/generated/*|*/src/generated/protocol_*.rs|meerkat-core/src/generated/terminal_surface_mapping.rs)
+      return 0
+      ;;
+    xtask/Cargo.toml|xtask/BUILD.bazel|xtask/src/lib.rs|xtask/src/main.rs|xtask/src/machines*.rs|xtask/src/protocol_codegen.rs|xtask/src/audit_generated_headers.rs|xtask/src/public_contracts.rs)
+      return 0
+      ;;
+    xtask/tests/machine_verify_all_tlc_test.sh|xtask/tests/machines_contracts.rs|xtask/tests/protocol_codegen_drift.rs)
+      return 0
+      ;;
+    scripts/machine-authority-changed|scripts/pre-push-machines.sh|scripts/pre-push-audit-generated-headers.sh|scripts/buildbuddy-bazel-poc|scripts/buildbuddy-ci-lane|scripts/buildbuddy-doctor|scripts/generate-bazel-rust-builds.mjs|scripts/compare-machine-verify-stats.sh)
+      return 0
+      ;;
+    .github/workflows/ci.yml|.github/workflows/cargo.yml|.github/workflows/buildbuddy.yml|.github/actions/run-buildbuddy-ci-lane/*|.github/actions/setup-buildbuddy-ci/*)
+      return 0
+      ;;
+    Cargo.toml|Cargo.lock|BUILD.bazel|MODULE.bazel|MODULE.bazel.lock|.bazelrc)
+      return 0
+      ;;
+  esac
+  return 1
+}
+
+for path in "${paths[@]}"; do
+  if machine_authority_path "${path}"; then
+    echo "machine-authority changed: ${path}"
+    exit 0
+  fi
+done
+
+echo "machine-authority unchanged"
+exit 1

--- a/xtask/BUILD.bazel
+++ b/xtask/BUILD.bazel
@@ -259,6 +259,10 @@ rust_test(
     data = [
         ":package_runfiles",
         "//:github_workflows",
+        "//meerkat-core:package_runfiles",
+        "//meerkat-machine-schema:package_runfiles",
+        "//meerkat-mob:package_runfiles",
+        "//meerkat-runtime:package_runfiles",
         "@@rules_rust++rust+rustfmt_nightly-2026-04-16__aarch64-apple-darwin_tools//:rustfmt_bin",
         "@@rules_rust++rust+rustfmt_nightly-2026-04-16__aarch64-apple-darwin_tools//:rustc_lib",
     ],

--- a/xtask/tests/ci_gate_requires_rmat.rs
+++ b/xtask/tests/ci_gate_requires_rmat.rs
@@ -272,6 +272,8 @@ fn machine_authority_changed_detector_classifies_paths() {
         &["meerkat-core/src/generated/terminal_surface_mapping.rs"],
         true,
     );
+    assert_machine_authority_detector(&["meerkat-runtime/src/generated/meerkat_mob_seam.rs"], true);
+    assert_machine_authority_detector(&["meerkat-mob/src/generated/mod.rs"], true);
     assert_machine_authority_detector(&[".github/workflows/cargo.yml"], true);
     assert_machine_authority_detector(&["scripts/machine-authority-changed"], true);
 }

--- a/xtask/tests/ci_gate_requires_rmat.rs
+++ b/xtask/tests/ci_gate_requires_rmat.rs
@@ -20,6 +20,7 @@
 //! would let both ends of the contract drift together.
 
 use std::path::{Path, PathBuf};
+use std::process::Command;
 
 /// Every governance lane that wave-b requires to block merges. Adding
 /// to this list expands the gate; removing requires a reviewer to
@@ -56,11 +57,33 @@ fn workflow_yml_path(name: &str) -> PathBuf {
     path
 }
 
+fn repo_path(path: &str) -> PathBuf {
+    let mut root = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    root.pop();
+    root.push(path);
+    root
+}
+
 fn read_workflow(path: &Path) -> serde_yaml::Value {
     let text = std::fs::read_to_string(path)
         .unwrap_or_else(|e| panic!("cannot read {}: {e}", path.display()));
     serde_yaml::from_str(&text)
         .unwrap_or_else(|e| panic!("cannot parse {} as YAML: {e}", path.display()))
+}
+
+fn assert_machine_authority_detector(paths: &[&str], should_match: bool) {
+    let script = repo_path("scripts/machine-authority-changed");
+    let output = Command::new(&script)
+        .args(paths)
+        .output()
+        .unwrap_or_else(|e| panic!("run {}: {e}", script.display()));
+    assert_eq!(
+        output.status.success(),
+        should_match,
+        "machine-authority detector mismatch for {paths:?}\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr),
+    );
 }
 
 fn gate_needs(doc: &serde_yaml::Value, path: &Path) -> Vec<String> {
@@ -207,4 +230,48 @@ fn gate_results_loop_enumerates_every_needed_lane() {
             path.display(),
         );
     }
+}
+
+#[test]
+fn machine_authority_jobs_use_changed_path_detector() {
+    let ci = std::fs::read_to_string(ci_yml_path()).expect("read ci.yml");
+    assert!(
+        ci.contains("machine_authority_base_sha")
+            && ci.contains("machine_authority_head_sha")
+            && ci.contains("github.event.pull_request.base.sha")
+            && ci.contains("github.event.before"),
+        "top-level CI workflow must pass a diff range into reusable backends"
+    );
+
+    for workflow in ["cargo.yml", "buildbuddy.yml"] {
+        let path = workflow_yml_path(workflow);
+        let text = std::fs::read_to_string(&path)
+            .unwrap_or_else(|e| panic!("read {}: {e}", path.display()));
+        assert!(
+            text.contains("scripts/machine-authority-changed --base")
+                && text.contains("steps.machine-changes.outputs.changed == 'true'")
+                && text
+                    .contains("No machine-authority inputs changed; skipping TLA+ machine checks."),
+            "{} machine-authority job must gate the expensive TLA+ lane with the changed-path detector",
+            path.display(),
+        );
+    }
+}
+
+#[test]
+fn machine_authority_changed_detector_classifies_paths() {
+    assert_machine_authority_detector(&["README.md"], false);
+    assert_machine_authority_detector(&["specs/machines/auth/model.tla"], true);
+    assert_machine_authority_detector(&["specs/compositions/schedule_bundle/model.tla"], true);
+    assert_machine_authority_detector(
+        &["meerkat-machine-schema/src/catalog/dsl/auth_machine.rs"],
+        true,
+    );
+    assert_machine_authority_detector(&["meerkat-runtime/src/meerkat_machine/dsl.rs"], true);
+    assert_machine_authority_detector(
+        &["meerkat-core/src/generated/terminal_surface_mapping.rs"],
+        true,
+    );
+    assert_machine_authority_detector(&[".github/workflows/cargo.yml"], true);
+    assert_machine_authority_detector(&["scripts/machine-authority-changed"], true);
 }


### PR DESCRIPTION
## Summary
- add a shared `scripts/machine-authority-changed` classifier for machine-authority inputs
- pass CI diff ranges into Cargo and BuildBuddy reusable workflows
- skip TLC/machine-authority work when no relevant files changed while keeping the required CI job green
- extend CI workflow self-tests for the detector and workflow wiring

## Validation
- `bash -n scripts/machine-authority-changed`
- `scripts/machine-authority-changed README.md` -> exit 1, unchanged
- `scripts/machine-authority-changed specs/machines/auth/model.tla` -> exit 0, changed
- `scripts/machine-authority-changed .github/workflows/cargo.yml` -> exit 0, changed
- `git diff --check`
- `./scripts/repo-cargo test -p xtask --test ci_gate_requires_rmat`
- `make fmt-check`
- `./scripts/repo-cargo test -p xtask --test buildbuddy_static_lanes`
- `scripts/machine-authority-changed --base origin/main --head HEAD`
- `make check`

## Note
- `make agent-gate` was attempted first but stopped in `rust-lane-doctor` because `cargo nextest` is not installed in this workspace; `make check` completed successfully afterward.

Linear: LUC-34