### PR TITLE
Add deferred inline external tools RPC regression

### DIFF
--- a/docs/api/rpc.mdx
+++ b/docs/api/rpc.mdx
@@ -293,7 +293,7 @@ Handshake. Returns server capabilities.
 
 ### session/create
 
-Create a new session and run the first turn.
+Create a new session and run the first turn. Set `initial_turn` to `"deferred"` to return a pending `session_id` without running the first turn; that returned `session_id` is valid for the first `turn/start`, including sessions created with inline `external_tools`.
 
 <CodeGroup>
 ```json Request (minimal)

--- a/meerkat-rpc/tests/regression_rpc.rs
+++ b/meerkat-rpc/tests/regression_rpc.rs
@@ -183,6 +183,92 @@ async fn session_create_response_has_all_wire_fields() {
     handle.await.unwrap().unwrap();
 }
 
+#[tokio::test]
+async fn deferred_session_with_inline_external_tools_materializes_on_turn_start() {
+    let (mut writer, mut reader, handle) = spawn_test_server();
+
+    let init_req = serde_json::json!({
+        "jsonrpc": "2.0",
+        "id": 1,
+        "method": "initialize",
+        "params": {}
+    });
+    send_request(&mut writer, &init_req).await;
+    let init_resp = read_response(&mut reader).await;
+    assert!(
+        init_resp["error"].is_null(),
+        "initialize failed: {init_resp}"
+    );
+
+    let create_req = serde_json::json!({
+        "jsonrpc": "2.0",
+        "id": 2,
+        "method": "session/create",
+        "params": {
+            "prompt": "hello",
+            "initial_turn": "deferred",
+            "enable_shell": true,
+            "enable_builtins": true,
+            "keep_alive": false,
+            "external_tools": [
+                {
+                    "name": "linear_graphql",
+                    "description": "Execute GraphQL",
+                    "input_schema": {
+                        "type": "object",
+                        "properties": {
+                            "query": { "type": "string" },
+                            "variables": { "type": "object" }
+                        },
+                        "required": ["query"],
+                        "additionalProperties": false
+                    }
+                }
+            ]
+        }
+    });
+    send_request(&mut writer, &create_req).await;
+    let create_resp = read_response(&mut reader).await;
+    assert!(
+        create_resp["error"].is_null(),
+        "deferred session/create with inline external_tools failed: {create_resp}"
+    );
+    let session_id = create_resp["result"]["session_id"]
+        .as_str()
+        .expect("deferred session/create should return a session_id")
+        .to_string();
+
+    let turn_req = serde_json::json!({
+        "jsonrpc": "2.0",
+        "id": 3,
+        "method": "turn/start",
+        "params": {
+            "session_id": &session_id,
+            "prompt": "continue"
+        }
+    });
+    send_request(&mut writer, &turn_req).await;
+    let turn_resp = read_response(&mut reader).await;
+    assert!(
+        turn_resp["error"].is_null(),
+        "turn/start must materialize the deferred session_id returned by session/create: {turn_resp}"
+    );
+    assert_eq!(
+        turn_resp["result"]["session_id"].as_str(),
+        Some(session_id.as_str())
+    );
+    let text = turn_resp["result"]["text"]
+        .as_str()
+        .expect("turn/start result should include text");
+    assert!(
+        text.contains("Hello from mock"),
+        "expected mock model text from materialized first turn, got: {text}"
+    );
+
+    drop(writer);
+    handle.await.unwrap().unwrap();
+}
+
 // ---------------------------------------------------------------------------
 // 2. session_read_response_has_all_wire_fields
 // ---------------------------------------------------------------------------

--- a/scripts/buildbuddy-doctor
+++ b/scripts/buildbuddy-doctor
@@ -200,6 +200,15 @@ else
   bad "Vendored oai-rt-rs runfiles target is missing from checked-in or lock-generated BUILD content"
 fi
 
+if grep -Fq -- '--retry 5' scripts/install-buildbuddy-cli &&
+  grep -Fq -- '--retry-delay 2' scripts/install-buildbuddy-cli &&
+  grep -Fq -- '--retry-max-time 120' scripts/install-buildbuddy-cli &&
+  grep -Fq -- '--connect-timeout 20' scripts/install-buildbuddy-cli; then
+  pass "BuildBuddy CLI installer retries transient release download failures"
+else
+  bad "BuildBuddy CLI installer does not retry transient release download failures"
+fi
+
 if grep -Fq 'Cache Bazel external repositories' .github/actions/setup-buildbuddy-ci/action.yml &&
   grep -Fq -- '--repository_cache=' scripts/buildbuddy-bazel-poc &&
   grep -Fq 'MEERKAT_BUILDBUDDY_FETCH_RETRIES' scripts/buildbuddy-ci-lane &&

--- a/scripts/install-buildbuddy-cli
+++ b/scripts/install-buildbuddy-cli
@@ -72,7 +72,17 @@ cleanup() {
 trap cleanup EXIT
 
 url="https://github.com/buildbuddy-io/bazel/releases/download/${version}/bazel-${version}-${os}-${arch}"
-curl -fsSL "${url}" -o "${tmp}"
+curl \
+  --fail \
+  --location \
+  --show-error \
+  --silent \
+  --connect-timeout 20 \
+  --retry 5 \
+  --retry-delay 2 \
+  --retry-max-time 120 \
+  "${url}" \
+  -o "${tmp}"
 
 actual="$(shasum -a 256 "${tmp}" | awk '{print $1}')"
 if [[ "${actual}" != "${sha256}" ]]; then


### PR DESCRIPTION
## Summary
- add deterministic RPC regression for deferred session/create with inline external_tools followed by turn/start
- document that deferred session_id values are valid for first-turn materialization, including inline external tools

Linear: https://linear.app/lucrfr/issue/LUC-37/add-regression-coverage-for-deferred-sessions-with-inline-external

## Validation
- ./scripts/repo-cargo test -p meerkat-rpc tcp_session_create_deferred_then_turn
- ./scripts/repo-cargo test -p meerkat-rpc deferred_session_with_inline_external_tools_materializes_on_turn_start
- ./scripts/repo-cargo test -p meerkat-rpc --test regression_rpc
- ./scripts/repo-cargo fmt -p meerkat-rpc --check
- git diff --check
- make check