### PR TITLE
LUC-48 Add profile overrides to TS/Web auth helpers

### DIFF
--- a/sdks/python/tests/test_audit_parity.py
+++ b/sdks/python/tests/test_audit_parity.py
@@ -289,15 +289,33 @@ async def test_python_auth_helpers_send_binding_scoped_params():
         "auth/status/get",
         {"realm_id": "prod", "binding_id": "claude-console"},
     )
+    await client.auth_status("prod", "claude-console", "primary")
+    client._request.assert_called_with(
+        "auth/status/get",
+        {
+            "realm_id": "prod",
+            "binding_id": "claude-console",
+            "profile_id": "primary",
+        },
+    )
 
     await client.auth_logout("prod", "claude-console")
     client._request.assert_called_with(
         "auth/logout",
         {"realm_id": "prod", "binding_id": "claude-console"},
     )
+    await client.auth_logout("prod", "claude-console", "primary")
+    client._request.assert_called_with(
+        "auth/logout",
+        {
+            "realm_id": "prod",
+            "binding_id": "claude-console",
+            "profile_id": "primary",
+        },
+    )
 
 
-def test_typescript_auth_status_logout_helpers_send_binding_scoped_params():
+def test_typescript_auth_status_logout_helpers_send_profile_scoped_params():
     import pathlib
 
     client_ts = pathlib.Path(__file__).parents[2] / "typescript" / "src" / "client.ts"
@@ -308,7 +326,22 @@ def test_typescript_auth_status_logout_helpers_send_binding_scoped_params():
         body = source[start:end]
         assert "bindingId" in body
         assert "binding_id" in body
-        assert "profile_id" not in body
+        assert "profileId?: string" in body
+        assert "params.profile_id = profileId" in body
+
+
+def test_web_auth_status_logout_helpers_send_profile_scoped_params():
+    import pathlib
+
+    auth_ts = pathlib.Path(__file__).parents[2] / "web" / "src" / "auth.ts"
+    source = auth_ts.read_text()
+    for method_name in ["status", "logout"]:
+        start = source.index(f"async {method_name}(")
+        end = source.index("\n  }\n", start)
+        body = source[start:end]
+        assert "binding_id" in body
+        assert "profile_id?: string" in body
+        assert "params.profile_id = profile_id" in body
 
 
 @pytest.mark.asyncio

--- a/sdks/python/tests/test_audit_parity.py
+++ b/sdks/python/tests/test_audit_parity.py
@@ -327,6 +327,7 @@ def test_typescript_auth_status_logout_helpers_send_profile_scoped_params():
         assert "bindingId" in body
         assert "binding_id" in body
         assert "profileId?: string" in body
+        assert "profileId !== undefined" in body
         assert "params.profile_id = profileId" in body
 
 
@@ -341,6 +342,7 @@ def test_web_auth_status_logout_helpers_send_profile_scoped_params():
         body = source[start:end]
         assert "binding_id" in body
         assert "profile_id?: string" in body
+        assert "profile_id !== undefined" in body
         assert "params.profile_id = profile_id" in body
 
 

--- a/sdks/typescript/src/client.ts
+++ b/sdks/typescript/src/client.ts
@@ -2017,22 +2017,26 @@ export class MeerkatClient {
   async authStatusGet(
     realmId: string,
     bindingId: string,
+    profileId?: string,
   ): Promise<unknown> {
     const params: Record<string, unknown> = {
       realm_id: realmId,
       binding_id: bindingId,
     };
+    if (profileId) params.profile_id = profileId;
     return this.request("auth/status/get", params);
   }
 
   async authLogout(
     realmId: string,
     bindingId: string,
+    profileId?: string,
   ): Promise<unknown> {
     const params: Record<string, unknown> = {
       realm_id: realmId,
       binding_id: bindingId,
     };
+    if (profileId) params.profile_id = profileId;
     return this.request("auth/logout", params);
   }
 

--- a/sdks/typescript/src/client.ts
+++ b/sdks/typescript/src/client.ts
@@ -2023,7 +2023,7 @@ export class MeerkatClient {
       realm_id: realmId,
       binding_id: bindingId,
     };
-    if (profileId) params.profile_id = profileId;
+    if (profileId !== undefined) params.profile_id = profileId;
     return this.request("auth/status/get", params);
   }
 
@@ -2036,7 +2036,7 @@ export class MeerkatClient {
       realm_id: realmId,
       binding_id: bindingId,
     };
-    if (profileId) params.profile_id = profileId;
+    if (profileId !== undefined) params.profile_id = profileId;
     return this.request("auth/logout", params);
   }
 

--- a/sdks/typescript/tests/types.test.js
+++ b/sdks/typescript/tests/types.test.js
@@ -975,6 +975,68 @@ describe("Comms methods", () => {
   });
 });
 
+describe("Auth wrappers", () => {
+  it("forwards optional profile overrides for status and logout", async () => {
+    const client = new MeerkatClient();
+    const calls = [];
+    client.request = async (method, params) => {
+      calls.push({ method, params });
+      return {};
+    };
+
+    await client.authStatusGet("prod", "claude-console", "primary");
+    await client.authLogout("prod", "claude-console", "primary");
+
+    assert.deepEqual(calls, [
+      {
+        method: "auth/status/get",
+        params: {
+          realm_id: "prod",
+          binding_id: "claude-console",
+          profile_id: "primary",
+        },
+      },
+      {
+        method: "auth/logout",
+        params: {
+          realm_id: "prod",
+          binding_id: "claude-console",
+          profile_id: "primary",
+        },
+      },
+    ]);
+  });
+
+  it("keeps status and logout params unchanged without profile overrides", async () => {
+    const client = new MeerkatClient();
+    const calls = [];
+    client.request = async (method, params) => {
+      calls.push({ method, params });
+      return {};
+    };
+
+    await client.authStatusGet("prod", "claude-console");
+    await client.authLogout("prod", "claude-console");
+
+    assert.deepEqual(calls, [
+      {
+        method: "auth/status/get",
+        params: {
+          realm_id: "prod",
+          binding_id: "claude-console",
+        },
+      },
+      {
+        method: "auth/logout",
+        params: {
+          realm_id: "prod",
+          binding_id: "claude-console",
+        },
+      },
+    ]);
+  });
+});
+
 describe("Parity wrappers", () => {
   it("adds wrappers for session external events and model catalog", async () => {
     const client = new MeerkatClient();

--- a/sdks/typescript/tests/types.test.js
+++ b/sdks/typescript/tests/types.test.js
@@ -1007,6 +1007,37 @@ describe("Auth wrappers", () => {
     ]);
   });
 
+  it("preserves explicit empty profile overrides for backend validation", async () => {
+    const client = new MeerkatClient();
+    const calls = [];
+    client.request = async (method, params) => {
+      calls.push({ method, params });
+      return {};
+    };
+
+    await client.authStatusGet("prod", "claude-console", "");
+    await client.authLogout("prod", "claude-console", "");
+
+    assert.deepEqual(calls, [
+      {
+        method: "auth/status/get",
+        params: {
+          realm_id: "prod",
+          binding_id: "claude-console",
+          profile_id: "",
+        },
+      },
+      {
+        method: "auth/logout",
+        params: {
+          realm_id: "prod",
+          binding_id: "claude-console",
+          profile_id: "",
+        },
+      },
+    ]);
+  });
+
   it("keeps status and logout params unchanged without profile overrides", async () => {
     const client = new MeerkatClient();
     const calls = [];

--- a/sdks/web/src/auth.ts
+++ b/sdks/web/src/auth.ts
@@ -244,13 +244,22 @@ export class Auth {
   }
 
   /** `auth/status/get` — current status for a binding's stored credentials. */
-  async status(realm_id: string, binding_id: string): Promise<AuthStatus> {
+  async status(
+    realm_id: string,
+    binding_id: string,
+    profile_id?: string,
+  ): Promise<AuthStatus> {
+    const params: { realm_id: string; binding_id: string; profile_id?: string } = {
+      realm_id,
+      binding_id,
+    };
+    if (profile_id) params.profile_id = profile_id;
     return this.transport.request<
-      { realm_id: string; binding_id: string },
+      typeof params,
       AuthStatus
     >(
       'auth/status/get',
-      { realm_id, binding_id },
+      params,
     );
   }
 
@@ -258,13 +267,19 @@ export class Auth {
   async logout(
     realm_id: string,
     binding_id: string,
+    profile_id?: string,
   ): Promise<AuthCredentialsCleared> {
+    const params: { realm_id: string; binding_id: string; profile_id?: string } = {
+      realm_id,
+      binding_id,
+    };
+    if (profile_id) params.profile_id = profile_id;
     return this.transport.request<
-      { realm_id: string; binding_id: string },
+      typeof params,
       AuthCredentialsCleared
     >(
       'auth/logout',
-      { realm_id, binding_id },
+      params,
     );
   }
 }

--- a/sdks/web/src/auth.ts
+++ b/sdks/web/src/auth.ts
@@ -253,7 +253,7 @@ export class Auth {
       realm_id,
       binding_id,
     };
-    if (profile_id) params.profile_id = profile_id;
+    if (profile_id !== undefined) params.profile_id = profile_id;
     return this.transport.request<
       typeof params,
       AuthStatus
@@ -273,7 +273,7 @@ export class Auth {
       realm_id,
       binding_id,
     };
-    if (profile_id) params.profile_id = profile_id;
+    if (profile_id !== undefined) params.profile_id = profile_id;
     return this.transport.request<
       typeof params,
       AuthCredentialsCleared

--- a/sdks/web/tests/types.test.ts
+++ b/sdks/web/tests/types.test.ts
@@ -92,6 +92,16 @@ const authLogin: Promise<AuthLoginReady> = auth.loginComplete({
 });
 const authStatus: Promise<AuthStatus> = auth.status('default', 'openai');
 const authLogout: Promise<AuthCredentialsCleared> = auth.logout('default', 'openai');
+const authStatusWithProfile: Promise<AuthStatus> = auth.status(
+  'default',
+  'openai',
+  'openai_apikey',
+);
+const authLogoutWithProfile: Promise<AuthCredentialsCleared> = auth.logout(
+  'default',
+  'openai',
+  'openai_apikey',
+);
 const authBinding: AuthBindingIdentity = {
   realm_id: 'default',
   binding_id: 'openai',
@@ -276,6 +286,8 @@ void authDelete;
 void authLogin;
 void authStatus;
 void authLogout;
+void authStatusWithProfile;
+void authLogoutWithProfile;
 void authBinding;
 void sessionState;
 void appendSystemContextOptions;


### PR DESCRIPTION
## Summary
- Add optional TypeScript SDK `profileId` forwarding for auth status/logout helpers.
- Add optional Web SDK `profile_id` forwarding for auth status/logout helpers.
- Update focused TS runtime, Web type, and SDK parity assertions for profile overrides and no-override behavior.

## Validation
- `npm_config_package_lock=false make test-sdk-typescript`
- `cd sdks/web && npm_config_package_lock=false npm install --ignore-scripts && npm test`
- `PYTHONPATH=sdks/python python3 - <<'PY' ...` stdlib auth helper assertions
- source parity check for TS/Web auth status/logout `profile_id` forwarding
- `make check` (BuildBuddy invocation 025a8389-6822-4710-b938-da16e2628625)
- `git diff --check`

Linear: LUC-48

Note: local system Python lacks `pytest`, `pip`, and `python3.12-venv`, so I validated the Python helper request shape with a stdlib assertion script rather than the pytest harness.