### PR TITLE
Correct mob member status OpenAPI label

### DIFF
--- a/artifacts/schemas/rest-openapi.json
+++ b/artifacts/schemas/rest-openapi.json
@@ -109,7 +109,8 @@
     },
     "/mob/{id}/members/{agent_identity}/status": {
       "get": {
-        "summary": "Get realtime attachment status for a mob member"
+        "description": "Returns the current execution/status snapshot for the named mob member.",
+        "summary": "Get a mob member execution status snapshot"
       }
     },
     "/mob/{id}/spawn-helper": {

--- a/meerkat-contracts/src/rest_catalog.rs
+++ b/meerkat-contracts/src/rest_catalog.rs
@@ -317,9 +317,10 @@ pub fn rest_path_catalog() -> Vec<RestPathDescriptor> {
         ),
         RestPathDescriptor::new(
             "/mob/{id}/members/{agent_identity}/status",
-            vec![RestOperationDescriptor::new(
+            vec![RestOperationDescriptor::with_description(
                 "get",
-                "Get realtime attachment status for a mob member",
+                "Get a mob member execution status snapshot",
+                "Returns the current execution/status snapshot for the named mob member.",
             )],
         ),
         RestPathDescriptor::new(
@@ -478,6 +479,34 @@ mod tests {
         assert_eq!(
             post.description,
             Some("Requires mcp_live capability. Check GET /capabilities.")
+        );
+    }
+
+    #[test]
+    #[allow(clippy::expect_used)]
+    fn catalog_labels_mob_member_status_as_execution_snapshot() {
+        let catalog = rest_path_catalog();
+        let member_status = catalog
+            .iter()
+            .find(|entry| entry.path == "/mob/{id}/members/{agent_identity}/status")
+            .expect("mob member status path should remain documented");
+        let get = member_status
+            .operations
+            .iter()
+            .find(|operation| operation.method == "get")
+            .expect("mob member status GET should remain documented");
+
+        assert_eq!(get.summary, "Get a mob member execution status snapshot");
+        assert_eq!(
+            get.description,
+            Some("Returns the current execution/status snapshot for the named mob member.")
+        );
+        assert!(
+            !get.summary.contains("realtime attachment")
+                && get
+                    .description
+                    .is_none_or(|description| !description.contains("realtime attachment")),
+            "mob member status route must not be labelled as realtime attachment status"
         );
     }
 }


### PR DESCRIPTION
## Summary
- relabel `/mob/{id}/members/{agent_identity}/status` as a mob member execution status snapshot
- refresh the emitted REST OpenAPI artifact for the route
- add a focused REST catalog assertion to prevent realtime attachment wording from returning

Linear: https://linear.app/lucrfr/issue/LUC-47/dogma-correct-rest-mob-member-status-openapi-labeling

## Validation
- `rg -n "realtime attachment|member.*status|members/\{agent_identity\}/status" meerkat-contracts/src/rest_catalog.rs artifacts/schemas/rest-openapi.json meerkat-rest/src/lib.rs`
- `make regen-schemas`
- `./scripts/repo-cargo test -p meerkat-contracts catalog_labels_mob_member_status_as_execution_snapshot`
- `make fmt-check`
- `make check`