### PR TITLE
Preserve typed preload skills in schedule materializers

### DIFF
--- a/meerkat-cli/src/main.rs
+++ b/meerkat-cli/src/main.rs
@@ -6589,6 +6589,13 @@ fn scheduled_skill_keys(
     ))
 }
 
+#[cfg(any(feature = "session-store", test))]
+fn materialized_preload_skills(
+    preload_skills: &[meerkat_core::skills::SkillKey],
+) -> Option<Vec<meerkat_core::skills::SkillKey>> {
+    (!preload_skills.is_empty()).then(|| preload_skills.to_vec())
+}
+
 #[cfg(feature = "session-store")]
 #[async_trait::async_trait]
 impl SurfaceScheduleSessionHost for CliScheduleSessionHost {
@@ -6646,16 +6653,7 @@ impl SurfaceScheduleSessionHost for CliScheduleSessionHost {
             peer_meta: create.peer_meta.clone(),
             resume_session: Some(session),
             provider_params: create.provider_params.clone(),
-            // Post-wave-a: `SessionMaterializationSpec.preload_skills` is
-            // `Vec<String>` (slug halves); the typed seam expects
-            // `Option<Vec<SkillKey>>` (source_uuid + skill_name). No lossless
-            // projection exists, so drop the legacy path. Typed ingress flows
-            // via `skill_refs` on the schedule dispatch. Mirrors
-            // `meerkat/src/surface/runtime_schedule_host.rs`.
-            preload_skills: {
-                let _ = &create.preload_skills;
-                None
-            },
+            preload_skills: materialized_preload_skills(&create.preload_skills),
             additional_instructions: (!create.additional_instructions.is_empty())
                 .then(|| create.additional_instructions.clone()),
             realm_id: create.realm_id.clone(),
@@ -9484,6 +9482,29 @@ mod tests {
 
     fn hooks_override_fixture_path() -> PathBuf {
         PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("../test-fixtures/hooks/run_override.json")
+    }
+
+    fn fixture_skill_key(name: &str) -> meerkat_core::skills::SkillKey {
+        let skill_name = meerkat_core::skills::SkillName::parse(name)
+            .expect("fixture skill name should be valid");
+        meerkat_core::skills::SkillKey::new(meerkat_core::skills::SourceUuid::builtin(), skill_name)
+    }
+
+    #[test]
+    fn materialized_preload_skills_preserves_typed_skill_keys() {
+        let key = fixture_skill_key("email");
+
+        assert_eq!(
+            materialized_preload_skills(std::slice::from_ref(&key)),
+            Some(vec![key])
+        );
+    }
+
+    #[test]
+    fn materialized_preload_skills_leaves_empty_preload_unset() {
+        let preload_skills: Vec<meerkat_core::skills::SkillKey> = Vec::new();
+
+        assert_eq!(materialized_preload_skills(&preload_skills), None);
     }
 
     fn test_scope(state_root: PathBuf, realm_id: &str) -> RuntimeScope {

--- a/meerkat-mcp-server/src/schedule_host.rs
+++ b/meerkat-mcp-server/src/schedule_host.rs
@@ -49,6 +49,12 @@ use crate::{
     MeerkatMcpState, canonical_skill_keys, compose_external_tool_dispatchers, runtime_ingress,
 };
 
+fn materialized_preload_skills(
+    preload_skills: &[meerkat_core::skills::SkillKey],
+) -> Option<Vec<meerkat_core::skills::SkillKey>> {
+    (!preload_skills.is_empty()).then(|| preload_skills.to_vec())
+}
+
 #[derive(Clone)]
 struct McpScheduleContext {
     service: Arc<meerkat::PersistentSessionService<meerkat::FactoryAgentBuilder>>,
@@ -189,12 +195,7 @@ impl McpScheduleContext {
             override_mob: meerkat_core::ToolCategoryOverride::Inherit,
             schedule_tools: None,
             mob_tool_authority_context: None,
-            // Schedule wire type `preload_skills: Vec<String>` carries
-            // only the slug half — no lossless projection to the typed
-            // `SkillKey` (source_uuid + skill_name) required by the
-            // session build. Callers use `skill_refs` / `skill_references`
-            // for typed per-turn skill injection.
-            preload_skills: None,
+            preload_skills: materialized_preload_skills(&create.preload_skills),
             realm_id: create
                 .realm_id
                 .clone()
@@ -763,4 +764,32 @@ fn mob_flow_completion_future(
             }
         }
     })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use meerkat_core::skills::{SkillKey, SkillName, SourceUuid};
+
+    fn fixture_skill_key(name: &str) -> SkillKey {
+        let skill_name = SkillName::parse(name).expect("fixture skill name should be valid");
+        SkillKey::new(SourceUuid::builtin(), skill_name)
+    }
+
+    #[test]
+    fn materialized_preload_skills_preserves_typed_skill_keys() {
+        let key = fixture_skill_key("email");
+
+        assert_eq!(
+            materialized_preload_skills(std::slice::from_ref(&key)),
+            Some(vec![key])
+        );
+    }
+
+    #[test]
+    fn materialized_preload_skills_leaves_empty_preload_unset() {
+        let preload_skills: Vec<SkillKey> = Vec::new();
+
+        assert_eq!(materialized_preload_skills(&preload_skills), None);
+    }
 }

--- a/meerkat-rest/src/schedule_host.rs
+++ b/meerkat-rest/src/schedule_host.rs
@@ -47,6 +47,12 @@ use crate::{
     session_metadata_marks_archived,
 };
 
+fn materialized_preload_skills(
+    preload_skills: &[meerkat_core::skills::SkillKey],
+) -> Option<Vec<meerkat_core::skills::SkillKey>> {
+    (!preload_skills.is_empty()).then(|| preload_skills.to_vec())
+}
+
 #[derive(Default)]
 pub struct ScheduleHostState {
     inner: Mutex<Option<meerkat::surface::ScheduleHostHandle>>,
@@ -137,12 +143,7 @@ impl RestScheduleContext {
         build_config.provider_params = create.provider_params.clone();
         build_config.comms_name = create.comms_name.clone();
         build_config.peer_meta = create.peer_meta.clone();
-        // Schedule wire type `SessionMaterializationSpec.preload_skills: Vec<String>`
-        // carries only slug halves — no lossless projection to the typed
-        // `SkillKey` (source_uuid + skill_name) required by the session
-        // build. Callers use `skill_refs` / `skill_references` for typed
-        // per-turn skill injection.
-        build_config.preload_skills = None;
+        build_config.preload_skills = materialized_preload_skills(&create.preload_skills);
         build_config.additional_instructions = (!create.additional_instructions.is_empty())
             .then(|| create.additional_instructions.clone());
         build_config.realm_id = create
@@ -648,4 +649,32 @@ fn mob_flow_completion_future(
             }
         }
     })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use meerkat_core::skills::{SkillKey, SkillName, SourceUuid};
+
+    fn fixture_skill_key(name: &str) -> SkillKey {
+        let skill_name = SkillName::parse(name).expect("fixture skill name should be valid");
+        SkillKey::new(SourceUuid::builtin(), skill_name)
+    }
+
+    #[test]
+    fn materialized_preload_skills_preserves_typed_skill_keys() {
+        let key = fixture_skill_key("email");
+
+        assert_eq!(
+            materialized_preload_skills(std::slice::from_ref(&key)),
+            Some(vec![key])
+        );
+    }
+
+    #[test]
+    fn materialized_preload_skills_leaves_empty_preload_unset() {
+        let preload_skills: Vec<SkillKey> = Vec::new();
+
+        assert_eq!(materialized_preload_skills(&preload_skills), None);
+    }
 }


### PR DESCRIPTION
## Summary
- Forward typed schedule preload skill keys into REST, MCP, and CLI session build configs.
- Preserve empty preload behavior as unset build preloads.
- Add focused regression coverage for REST, MCP, and CLI materializers.

## Validation
- make fmt
- git diff --check
- ./scripts/repo-cargo test -p meerkat-rest --lib materialized_preload_skills
- ./scripts/repo-cargo test -p meerkat-mcp-server --lib materialized_preload_skills
- ./scripts/repo-cargo test -p rkat --bin rkat materialized_preload_skills
- make check

Linear: LUC-50