### PR TITLE
LUC-51: Route memory indexing through scoped API

### DIFF
--- a/examples/014-semantic-memory-rs/main.rs
+++ b/examples/014-semantic-memory-rs/main.rs
@@ -26,7 +26,9 @@
 use std::sync::Arc;
 
 use meerkat::{AgentBuilder, AgentFactory, AnthropicClient, ToolGatewayBuilder};
-use meerkat_core::memory::{MemoryMetadata, MemoryStore as _};
+use meerkat_core::memory::{
+    MemoryIndexRequest, MemoryIndexScope, MemoryMetadata, MemoryStore as _,
+};
 use meerkat_memory::{MemorySearchDispatcher, SimpleMemoryStore};
 use meerkat_store::{JsonlStore, StoreAdapter};
 
@@ -62,7 +64,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     // In normal operation, memory is populated during context compaction:
     // when the agent loop compacts old messages to save context space,
     // the discarded text is indexed into the memory store. Here we simulate
-    // that by directly indexing some facts.
+    // that by scoped indexing of some facts.
 
     let now = std::time::SystemTime::now();
     let facts = [
@@ -80,7 +82,12 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             turn: Some(i as u32 + 1),
             indexed_at: now,
         };
-        memory_store.index(fact, metadata).await?;
+        let request = MemoryIndexRequest::new(
+            MemoryIndexScope::for_session(memory_session_id.clone()),
+            (*fact).to_string(),
+            metadata,
+        )?;
+        memory_store.index_scoped(request).await?;
     }
 
     println!("Indexed {} facts into SimpleMemoryStore\n", facts.len());

--- a/meerkat-core/src/agent/state.rs
+++ b/meerkat-core/src/agent/state.rs
@@ -2476,7 +2476,8 @@ mod tests {
     use crate::compact::{CompactionContext, CompactionResult, Compactor};
     use crate::error::{AgentError, ToolError};
     use crate::memory::{
-        MemoryMetadata, MemoryResult, MemorySearchScope, MemoryStore, MemoryStoreError,
+        MemoryIndexReceipt, MemoryIndexRequest, MemoryIndexScope, MemoryMetadata, MemoryResult,
+        MemorySearchScope, MemoryStore, MemoryStoreError,
     };
     use crate::retry::select_retry_delay;
     use crate::skills::{
@@ -3028,7 +3029,7 @@ mod tests {
     }
 
     struct RecordingMemoryStore {
-        entries: Mutex<Vec<(String, MemoryMetadata)>>,
+        entries: Mutex<Vec<(MemoryIndexScope, String, MemoryMetadata)>>,
         fail_indexing: bool,
     }
 
@@ -3052,26 +3053,39 @@ mod tests {
                 .lock()
                 .unwrap()
                 .iter()
-                .map(|(content, _)| content.clone())
+                .map(|(_, content, _)| content.clone())
+                .collect()
+        }
+
+        fn scopes(&self) -> Vec<MemoryIndexScope> {
+            self.entries
+                .lock()
+                .unwrap()
+                .iter()
+                .map(|(scope, _, _)| scope.clone())
                 .collect()
         }
     }
 
     #[async_trait]
     impl MemoryStore for RecordingMemoryStore {
-        async fn index(
+        async fn index_scoped(
             &self,
-            content: &str,
-            metadata: MemoryMetadata,
-        ) -> Result<(), MemoryStoreError> {
+            request: MemoryIndexRequest,
+        ) -> Result<MemoryIndexReceipt, MemoryStoreError> {
             if self.fail_indexing {
                 return Err(MemoryStoreError::Index("injected failure".to_string()));
             }
+            let (scope, content, metadata) = request.into_parts();
+            let receipt_scope = scope.clone();
             self.entries
                 .lock()
                 .unwrap()
-                .push((content.to_string(), metadata));
-            Ok(())
+                .push((scope, content, metadata));
+            Ok(MemoryIndexReceipt {
+                scope: receipt_scope,
+                indexed_entries: 1,
+            })
         }
 
         async fn search(
@@ -3821,6 +3835,13 @@ mod tests {
         assert!(
             indexed.iter().any(|content| content.contains("first")),
             "discarded first turn should be indexed before compaction commits"
+        );
+        assert!(
+            memory_store
+                .scopes()
+                .iter()
+                .all(|scope| scope.session_id() == agent.session().id()),
+            "compaction must index discarded memory into the owning session scope"
         );
         assert!(
             !agent

--- a/meerkat-core/src/lib.rs
+++ b/meerkat-core/src/lib.rs
@@ -112,7 +112,10 @@ pub use compact::{
     CompactionConfig, CompactionContext, CompactionResult, Compactor,
     SESSION_COMPACTION_CADENCE_KEY, SessionCompactionCadence,
 };
-pub use memory::{MemoryMetadata, MemoryResult, MemorySearchScope, MemoryStore, MemoryStoreError};
+pub use memory::{
+    MemoryIndexReceipt, MemoryIndexRequest, MemoryIndexScope, MemoryMetadata, MemoryOwner,
+    MemoryResult, MemorySearchScope, MemoryStore, MemoryStoreError,
+};
 pub use model_registry::{ModelRegistry, ModelRegistryEntry, SelfHostedServerRef};
 pub use peer_correlation::{
     InboundPeerRequestState, InteractionStreamState, OutboundPeerRequestState, PeerCorrelationId,

--- a/meerkat-core/src/memory.rs
+++ b/meerkat-core/src/memory.rs
@@ -105,9 +105,9 @@ impl MemoryIndexScope {
 /// One scoped semantic-memory indexing request.
 #[derive(Debug, Clone)]
 pub struct MemoryIndexRequest {
-    pub scope: MemoryIndexScope,
-    pub content: String,
-    pub metadata: MemoryMetadata,
+    scope: MemoryIndexScope,
+    content: String,
+    metadata: MemoryMetadata,
 }
 
 impl MemoryIndexRequest {
@@ -128,6 +128,22 @@ impl MemoryIndexRequest {
             content,
             metadata,
         })
+    }
+
+    pub fn scope(&self) -> &MemoryIndexScope {
+        &self.scope
+    }
+
+    pub fn content(&self) -> &str {
+        &self.content
+    }
+
+    pub fn metadata(&self) -> &MemoryMetadata {
+        &self.metadata
+    }
+
+    pub fn into_parts(self) -> (MemoryIndexScope, String, MemoryMetadata) {
+        (self.scope, self.content, self.metadata)
     }
 }
 
@@ -156,26 +172,11 @@ pub enum MemoryIndexDelivery {
 #[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
 #[cfg_attr(not(target_arch = "wasm32"), async_trait)]
 pub trait MemoryStore: Send + Sync {
-    /// Index text content with associated metadata.
-    async fn index(&self, content: &str, metadata: MemoryMetadata) -> Result<(), MemoryStoreError>;
-
     /// Index a typed, owner-scoped memory request.
     async fn index_scoped(
         &self,
         request: MemoryIndexRequest,
-    ) -> Result<MemoryIndexReceipt, MemoryStoreError> {
-        let MemoryIndexRequest {
-            scope,
-            content,
-            metadata,
-        } = request;
-        let receipt_scope = scope.clone();
-        self.index(&content, metadata).await?;
-        Ok(MemoryIndexReceipt {
-            scope: receipt_scope,
-            indexed_entries: 1,
-        })
-    }
+    ) -> Result<MemoryIndexReceipt, MemoryStoreError>;
 
     /// Semantic search: return up to `limit` results ordered by relevance.
     async fn search(

--- a/meerkat-memory/src/hnsw.rs
+++ b/meerkat-memory/src/hnsw.rs
@@ -9,7 +9,8 @@
 use async_trait::async_trait;
 use hnsw_rs::prelude::{DistCosine, Hnsw};
 use meerkat_core::memory::{
-    MemoryMetadata, MemoryResult, MemorySearchScope, MemoryStore, MemoryStoreError,
+    MemoryIndexReceipt, MemoryIndexRequest, MemoryResult, MemorySearchScope, MemoryStore,
+    MemoryStoreError,
 };
 use rusqlite::{Connection, OptionalExtension, params};
 use std::path::{Path, PathBuf};
@@ -136,10 +137,14 @@ impl HnswMemoryStore {
 
 #[async_trait]
 impl MemoryStore for HnswMemoryStore {
-    async fn index(&self, content: &str, metadata: MemoryMetadata) -> Result<(), MemoryStoreError> {
+    async fn index_scoped(
+        &self,
+        request: MemoryIndexRequest,
+    ) -> Result<MemoryIndexReceipt, MemoryStoreError> {
+        let (scope, content, metadata) = request.into_parts();
+        let receipt_scope = scope.clone();
         let meta_json = serde_json::to_vec(&metadata)
             .map_err(|e| MemoryStoreError::Embedding(e.to_string()))?;
-        let content = content.to_owned();
         let db_path = self.db_path.clone();
         let index = Arc::clone(&self.index);
 
@@ -182,7 +187,10 @@ impl MemoryStore for HnswMemoryStore {
             .checked_add(1)
             .ok_or_else(|| MemoryStoreError::Index("point ID overflow".to_string()))?;
         self.next_id.store(next_id, Ordering::Release);
-        Ok(())
+        Ok(MemoryIndexReceipt {
+            scope: receipt_scope,
+            indexed_entries: 1,
+        })
     }
 
     async fn search(
@@ -299,6 +307,7 @@ fn text_to_embedding(text: &str) -> [f32; VOCAB_DIM] {
 #[allow(clippy::unwrap_used, clippy::expect_used)]
 mod tests {
     use super::*;
+    use meerkat_core::memory::{MemoryIndexScope, MemoryMetadata};
     use meerkat_core::types::SessionId;
     use std::time::SystemTime;
     use tempfile::TempDir;
@@ -311,32 +320,42 @@ mod tests {
         }
     }
 
+    fn request(content: impl Into<String>, session_id: &SessionId) -> MemoryIndexRequest {
+        MemoryIndexRequest::new(
+            MemoryIndexScope::for_session(session_id.clone()),
+            content.into(),
+            meta(session_id),
+        )
+        .unwrap()
+    }
+
     #[tokio::test]
     async fn test_hnsw_index_and_search() {
         let dir = TempDir::new().unwrap();
         let store = HnswMemoryStore::open(dir.path().join("memory")).unwrap();
         let session_id = SessionId::new();
         let scope = MemorySearchScope::for_session(session_id.clone());
+        let other_session_id = SessionId::new();
 
         store
-            .index(
+            .index_scoped(request(
                 "The user wants to implement a REST API with authentication",
-                meta(&session_id),
-            )
+                &session_id,
+            ))
             .await
             .unwrap();
         store
-            .index(
+            .index_scoped(request(
                 "Configuration files use TOML format for settings",
-                meta(&session_id),
-            )
+                &session_id,
+            ))
             .await
             .unwrap();
         store
-            .index(
+            .index_scoped(request(
                 "JWT tokens handle authentication and authorization",
-                meta(&SessionId::new()),
-            )
+                &other_session_id,
+            ))
             .await
             .unwrap();
 
@@ -376,10 +395,10 @@ mod tests {
 
         for i in 0..10 {
             store
-                .index(
-                    &format!("Item {i} with keyword test data"),
-                    meta(&session_id),
-                )
+                .index_scoped(request(
+                    format!("Item {i} with keyword test data"),
+                    &session_id,
+                ))
                 .await
                 .unwrap();
         }
@@ -398,10 +417,10 @@ mod tests {
         {
             let store = HnswMemoryStore::open(&memory_dir).unwrap();
             store
-                .index(
+                .index_scoped(request(
                     "Persistent memory entry about Rust programming",
-                    meta(&session_id),
-                )
+                    &session_id,
+                ))
                 .await
                 .unwrap();
         }
@@ -422,7 +441,7 @@ mod tests {
         let scope = MemorySearchScope::for_session(session_id.clone());
 
         store
-            .index("Exact match query text here", meta(&session_id))
+            .index_scoped(request("Exact match query text here", &session_id))
             .await
             .unwrap();
 

--- a/meerkat-memory/src/simple.rs
+++ b/meerkat-memory/src/simple.rs
@@ -5,13 +5,15 @@
 
 use async_trait::async_trait;
 use meerkat_core::memory::{
-    MemoryMetadata, MemoryResult, MemorySearchScope, MemoryStore, MemoryStoreError,
+    MemoryIndexReceipt, MemoryIndexRequest, MemoryIndexScope, MemoryMetadata, MemoryResult,
+    MemorySearchScope, MemoryStore, MemoryStoreError,
 };
 use tokio::sync::RwLock;
 
 /// Entry in the simple memory store.
 #[derive(Debug, Clone)]
 struct MemoryEntry {
+    scope: MemoryIndexScope,
     content: String,
     metadata: MemoryMetadata,
 }
@@ -42,13 +44,22 @@ impl Default for SimpleMemoryStore {
 
 #[async_trait]
 impl MemoryStore for SimpleMemoryStore {
-    async fn index(&self, content: &str, metadata: MemoryMetadata) -> Result<(), MemoryStoreError> {
+    async fn index_scoped(
+        &self,
+        request: MemoryIndexRequest,
+    ) -> Result<MemoryIndexReceipt, MemoryStoreError> {
+        let (scope, content, metadata) = request.into_parts();
+        let receipt_scope = scope.clone();
         let mut entries = self.entries.write().await;
         entries.push(MemoryEntry {
-            content: content.to_string(),
+            scope,
+            content,
             metadata,
         });
-        Ok(())
+        Ok(MemoryIndexReceipt {
+            scope: receipt_scope,
+            indexed_entries: 1,
+        })
     }
 
     async fn search(
@@ -64,7 +75,7 @@ impl MemoryStore for SimpleMemoryStore {
 
         let mut results: Vec<MemoryResult> = entries
             .iter()
-            .filter(|entry| scope.includes(&entry.metadata))
+            .filter(|entry| entry.scope.owner == scope.owner && scope.includes(&entry.metadata))
             .filter_map(|entry| {
                 let content_lower = entry.content.to_lowercase();
                 let matching_words = query_words
@@ -112,24 +123,47 @@ mod tests {
         }
     }
 
+    fn request(content: impl Into<String>, session_id: &SessionId) -> MemoryIndexRequest {
+        MemoryIndexRequest::new(
+            MemoryIndexScope::for_session(session_id.clone()),
+            content.into(),
+            meta(session_id),
+        )
+        .unwrap()
+    }
+
     #[tokio::test]
     async fn test_index_and_search() {
         let store = SimpleMemoryStore::new();
         let session_id = SessionId::new();
         let scope = MemorySearchScope::for_session(session_id.clone());
+        let other_session_id = SessionId::new();
 
         store
-            .index("The user wants to implement a REST API", meta(&session_id))
+            .index_scoped(request(
+                "The user wants to implement a REST API",
+                &session_id,
+            ))
             .await
             .unwrap();
         store
-            .index("Configuration uses TOML format", meta(&session_id))
+            .index_scoped(request("Configuration uses TOML format", &session_id))
             .await
             .unwrap();
         store
-            .index("Authentication uses JWT tokens", meta(&SessionId::new()))
+            .index_scoped(request("Authentication uses JWT tokens", &other_session_id))
             .await
             .unwrap();
+
+        {
+            let entries = store.entries.read().await;
+            assert!(
+                entries
+                    .iter()
+                    .all(|entry| entry.scope.includes(&entry.metadata))
+            );
+            assert_eq!(entries[0].scope.session_id(), &session_id);
+        }
 
         let results = store.search(&scope, "REST API", 10).await.unwrap();
         assert!(!results.is_empty());
@@ -157,7 +191,7 @@ mod tests {
 
         for i in 0..10 {
             store
-                .index(&format!("Item {i} with keyword test"), meta(&session_id))
+                .index_scoped(request(format!("Item {i} with keyword test"), &session_id))
                 .await
                 .unwrap();
         }
@@ -171,9 +205,26 @@ mod tests {
         let store = SimpleMemoryStore::new();
         let session_id = SessionId::new();
         let scope = MemorySearchScope::for_session(session_id.clone());
-        store.index("Hello world", meta(&session_id)).await.unwrap();
+        store
+            .index_scoped(request("Hello world", &session_id))
+            .await
+            .unwrap();
 
         let results = store.search(&scope, "quantum computing", 10).await.unwrap();
         assert!(results.is_empty());
+    }
+
+    #[test]
+    fn test_index_request_rejects_metadata_outside_scope() {
+        let session_id = SessionId::new();
+        let other_session_id = SessionId::new();
+        let error = MemoryIndexRequest::new(
+            MemoryIndexScope::for_session(session_id),
+            "outside scope".to_string(),
+            meta(&other_session_id),
+        )
+        .unwrap_err();
+
+        assert!(matches!(error, MemoryStoreError::Scope(_)));
     }
 }

--- a/meerkat-memory/src/tool.rs
+++ b/meerkat-memory/src/tool.rs
@@ -152,7 +152,7 @@ impl AgentToolDispatcher for MemorySearchDispatcher {
 #[allow(clippy::unwrap_used, clippy::expect_used)]
 mod tests {
     use super::*;
-    use meerkat_core::memory::{MemoryMetadata, MemoryStore};
+    use meerkat_core::memory::{MemoryIndexRequest, MemoryIndexScope, MemoryMetadata, MemoryStore};
     use meerkat_core::types::SessionId;
     use serde_json::value::RawValue;
     use std::time::SystemTime;
@@ -179,6 +179,15 @@ mod tests {
             turn: Some(1),
             indexed_at: SystemTime::now(),
         }
+    }
+
+    fn request(content: impl Into<String>, session_id: &SessionId) -> MemoryIndexRequest {
+        MemoryIndexRequest::new(
+            MemoryIndexScope::for_session(session_id.clone()),
+            content.into(),
+            meta(session_id),
+        )
+        .unwrap()
     }
 
     fn dispatcher(store: Arc<dyn MemoryStore>, session_id: &SessionId) -> MemorySearchDispatcher {
@@ -236,19 +245,20 @@ mod tests {
     async fn test_search_returns_results() {
         let store: Arc<dyn MemoryStore> = Arc::new(crate::SimpleMemoryStore::new());
         let session_id = SessionId::new();
+        let other_session_id = SessionId::new();
         store
-            .index("The project codename is AURORA-7", meta(&session_id))
+            .index_scoped(request("The project codename is AURORA-7", &session_id))
             .await
             .unwrap();
         store
-            .index("The budget was set at $42,000", meta(&session_id))
+            .index_scoped(request("The budget was set at $42,000", &session_id))
             .await
             .unwrap();
         store
-            .index(
+            .index_scoped(request(
                 "Meeting scheduled for next Tuesday",
-                meta(&SessionId::new()),
-            )
+                &other_session_id,
+            ))
             .await
             .unwrap();
 
@@ -291,10 +301,10 @@ mod tests {
         let session_id = SessionId::new();
         for i in 0..10 {
             store
-                .index(
-                    &format!("Memory entry {i} about testing"),
-                    meta(&session_id),
-                )
+                .index_scoped(request(
+                    format!("Memory entry {i} about testing"),
+                    &session_id,
+                ))
                 .await
                 .unwrap();
         }
@@ -314,10 +324,10 @@ mod tests {
         let session_id = SessionId::new();
         for i in 0..10 {
             store
-                .index(
-                    &format!("Entry {i} about Rust programming"),
-                    meta(&session_id),
-                )
+                .index_scoped(request(
+                    format!("Entry {i} about Rust programming"),
+                    &session_id,
+                ))
                 .await
                 .unwrap();
         }
@@ -336,7 +346,7 @@ mod tests {
         let store: Arc<dyn MemoryStore> = Arc::new(crate::SimpleMemoryStore::new());
         let session_id = SessionId::new();
         store
-            .index("The weather is sunny today", meta(&session_id))
+            .index_scoped(request("The weather is sunny today", &session_id))
             .await
             .unwrap();
 
@@ -387,7 +397,10 @@ mod tests {
         let session_id = SessionId::new();
         for i in 0..30 {
             store
-                .index(&format!("Data point {i} about science"), meta(&session_id))
+                .index_scoped(request(
+                    format!("Data point {i} about science"),
+                    &session_id,
+                ))
                 .await
                 .unwrap();
         }


### PR DESCRIPTION
## Summary
- remove the unscoped public MemoryStore indexing method and require scoped MemoryIndexRequest writes
- store scope context in SimpleMemoryStore entries and update HNSW/test/example callers to use index_scoped
- add focused assertions around scoped simple indexing and compaction memory indexing

## Validation
- rg -n "fn index\(|index_scoped|MemoryOwner|MemoryScope" meerkat-core/src/memory.rs meerkat-core/src/agent/state.rs meerkat-memory/src/simple.rs
- git diff --check
- ./scripts/repo-cargo test -p meerkat-memory
- ./scripts/repo-cargo test -p meerkat-core compaction_
- make check

Linear: https://linear.app/lucrfr/issue/LUC-51/dogma-route-memorystore-indexing-through-scoped-owner-api