### PR TITLE
LUC-55: Use PeerId for comms trust removal

### DIFF
--- a/examples/035-mdm-tux-rs/src/bin/target.rs
+++ b/examples/035-mdm-tux-rs/src/bin/target.rs
@@ -789,7 +789,7 @@ async fn apply_target_attachment_effects(
                     .map(|p| p.pubkey)
                     .collect();
                 for pk in stale_keys {
-                    router.remove_trusted_peer(&pk);
+                    router.remove_trusted_peer(&pk.to_peer_id());
                 }
                 comms_runtime
                     .register_trusted_peer(TrustedPeer {
@@ -1676,7 +1676,7 @@ async fn run_kennel_mode(args: &[String]) -> anyhow::Result<()> {
                         }
                         KennelPayload::PeerUnwire { peer_id } => {
                             if let Ok(pk) = meerkat_comms::identity::PubKey::from_pubkey_string(&peer_id) {
-                                comms_runtime.router_arc().remove_trusted_peer(&pk);
+                                comms_runtime.router_arc().remove_trusted_peer(&pk.to_peer_id());
                                 eprintln!("[target] peer unwired: {peer_id}");
                             }
                         }

--- a/meerkat-comms/src/router.rs
+++ b/meerkat-comms/src/router.rs
@@ -100,6 +100,11 @@ pub struct Router {
     /// `trusted_peers_shared()`. Uses `parking_lot::RwLock` so ingress
     /// classification can read synchronously.
     trusted_peers: Arc<RwLock<TrustedPeers>>,
+    /// Canonical peer IDs supplied at descriptor registration time, keyed by
+    /// signing pubkey. This preserves explicit `PeerId`s for legacy
+    /// zero-pubkey descriptors where deriving from the pubkey would collapse
+    /// every entry onto the all-zero pubkey hash.
+    trusted_peer_ids: Arc<RwLock<std::collections::HashMap<crate::identity::PubKey, PeerId>>>,
     /// Directory-filter side-channel for private (control-plane) trust
     /// edges. Membership here is additive to `trusted_peers`: the peer
     /// is still admitted AND send-resolvable, but `resolve_peer_directory()`
@@ -123,6 +128,7 @@ impl Router {
         Self {
             keypair: Arc::new(keypair),
             trusted_peers: Arc::new(RwLock::new(trusted_peers)),
+            trusted_peer_ids: Arc::new(RwLock::new(std::collections::HashMap::new())),
             private_peer_ids: Arc::new(RwLock::new(std::collections::HashSet::new())),
             config,
             require_peer_auth,
@@ -141,6 +147,7 @@ impl Router {
         Self {
             keypair: Arc::new(keypair),
             trusted_peers,
+            trusted_peer_ids: Arc::new(RwLock::new(std::collections::HashMap::new())),
             private_peer_ids: Arc::new(RwLock::new(std::collections::HashSet::new())),
             config,
             require_peer_auth,
@@ -151,9 +158,12 @@ impl Router {
 
     /// Mark a peer as private (hidden from `resolve_peer_directory`).
     pub fn mark_private(&self, pubkey: crate::identity::PubKey) {
-        self.private_peer_ids
-            .write()
-            .insert(peer_id_from_pubkey(&pubkey));
+        self.mark_private_peer_id(self.peer_id_for_pubkey(&pubkey));
+    }
+
+    /// Mark a peer as private by canonical `PeerId`.
+    pub(crate) fn mark_private_peer_id(&self, peer_id: PeerId) {
+        self.private_peer_ids.write().insert(peer_id);
     }
 
     /// Remove the private marker for a peer. Returns `true` if the marker
@@ -171,6 +181,14 @@ impl Router {
 
     pub(crate) fn private_peer_ids(&self) -> std::collections::HashSet<PeerId> {
         self.private_peer_ids.read().clone()
+    }
+
+    pub(crate) fn peer_id_for_pubkey(&self, pubkey: &crate::identity::PubKey) -> PeerId {
+        self.trusted_peer_ids
+            .read()
+            .get(pubkey)
+            .copied()
+            .unwrap_or_else(|| peer_id_from_pubkey(pubkey))
     }
 
     /// Scope in-process routing to a namespace.
@@ -194,14 +212,49 @@ impl Router {
     }
 
     pub fn add_trusted_peer(&self, peer: TrustedPeer) {
+        let peer_id = peer_id_from_pubkey(&peer.pubkey);
+        self.add_trusted_peer_with_peer_id(peer_id, peer);
+    }
+
+    pub(crate) fn add_trusted_peer_with_peer_id(&self, peer_id: PeerId, peer: TrustedPeer) {
+        self.trusted_peer_ids.write().insert(peer.pubkey, peer_id);
         self.trusted_peers.write().upsert(peer);
     }
 
     pub fn remove_trusted_peer(&self, peer_id: &PeerId) -> bool {
+        let peer_ids = self.trusted_peer_ids.read().clone();
+        let removed = {
+            let mut trusted = self.trusted_peers.write();
+            let Some(index) = trusted.peers.iter().position(|peer| {
+                peer_ids
+                    .get(&peer.pubkey)
+                    .copied()
+                    .unwrap_or_else(|| peer_id_from_pubkey(&peer.pubkey))
+                    == *peer_id
+            }) else {
+                return false;
+            };
+            trusted.peers.remove(index)
+        };
+        self.trusted_peer_ids.write().remove(&removed.pubkey);
+        self.private_peer_ids.write().remove(peer_id);
+        true
+    }
+
+    fn trusted_peer_by_peer_id(&self, peer_id: &PeerId) -> Option<TrustedPeer> {
+        let peer_ids = self.trusted_peer_ids.read().clone();
         self.trusted_peers
-            .write()
-            .remove_by_peer_id(peer_id)
-            .is_some()
+            .read()
+            .peers
+            .iter()
+            .find(|peer| {
+                peer_ids
+                    .get(&peer.pubkey)
+                    .copied()
+                    .unwrap_or_else(|| peer_id_from_pubkey(&peer.pubkey))
+                    == *peer_id
+            })
+            .cloned()
     }
 
     /// Get the trusted peers Arc.
@@ -291,30 +344,28 @@ impl Router {
         kind: MessageKind,
     ) -> Result<Uuid, SendError> {
         let inproc_namespace = self.inproc_namespace.as_deref().unwrap_or("");
-        let peer = {
-            let peers = self.trusted_peers.read();
-            peers.find_by_peer_id(&dest).cloned()
-        }
-        .or_else(|| {
-            if self.require_peer_auth {
-                None
-            } else {
-                // Auth-disabled fallback: scan the inproc registry for an
-                // entry whose derived PeerId matches. Display names remain
-                // the inproc lookup key, but the routing match is PeerId.
-                InprocRegistry::global()
-                    .peers_in_namespace(inproc_namespace)
-                    .into_iter()
-                    .find(|p| peer_id_from_pubkey(&p.pubkey) == dest)
-                    .map(|p| TrustedPeer {
-                        name: p.name.clone(),
-                        pubkey: p.pubkey,
-                        addr: format!("inproc://{}", p.name),
-                        meta: p.meta,
-                    })
-            }
-        })
-        .ok_or(SendError::PeerNotFound(dest))?;
+        let peer = self
+            .trusted_peer_by_peer_id(&dest)
+            .or_else(|| {
+                if self.require_peer_auth {
+                    None
+                } else {
+                    // Auth-disabled fallback: scan the inproc registry for an
+                    // entry whose derived PeerId matches. Display names remain
+                    // the inproc lookup key, but the routing match is PeerId.
+                    InprocRegistry::global()
+                        .peers_in_namespace(inproc_namespace)
+                        .into_iter()
+                        .find(|p| peer_id_from_pubkey(&p.pubkey) == dest)
+                        .map(|p| TrustedPeer {
+                            name: p.name.clone(),
+                            pubkey: p.pubkey,
+                            addr: format!("inproc://{}", p.name),
+                            meta: p.meta,
+                        })
+                }
+            })
+            .ok_or(SendError::PeerNotFound(dest))?;
         let addr = PeerAddr::parse(&peer.addr)?;
         let mut envelope = Envelope {
             id: envelope_id,

--- a/meerkat-comms/src/router.rs
+++ b/meerkat-comms/src/router.rs
@@ -105,7 +105,7 @@ pub struct Router {
     /// is still admitted AND send-resolvable, but `resolve_peer_directory()`
     /// filters it out of the `comms.peers` REST/RPC/MCP surface. Used e.g.
     /// for the supervisor bridge in session-backed mob members.
-    private_pubkeys: Arc<RwLock<std::collections::HashSet<crate::identity::PubKey>>>,
+    private_peer_ids: Arc<RwLock<std::collections::HashSet<PeerId>>>,
     config: CommsConfig,
     require_peer_auth: bool,
     inbox_sender: InboxSender,
@@ -123,7 +123,7 @@ impl Router {
         Self {
             keypair: Arc::new(keypair),
             trusted_peers: Arc::new(RwLock::new(trusted_peers)),
-            private_pubkeys: Arc::new(RwLock::new(std::collections::HashSet::new())),
+            private_peer_ids: Arc::new(RwLock::new(std::collections::HashSet::new())),
             config,
             require_peer_auth,
             inbox_sender,
@@ -141,7 +141,7 @@ impl Router {
         Self {
             keypair: Arc::new(keypair),
             trusted_peers,
-            private_pubkeys: Arc::new(RwLock::new(std::collections::HashSet::new())),
+            private_peer_ids: Arc::new(RwLock::new(std::collections::HashSet::new())),
             config,
             require_peer_auth,
             inbox_sender,
@@ -151,22 +151,26 @@ impl Router {
 
     /// Mark a peer as private (hidden from `resolve_peer_directory`).
     pub fn mark_private(&self, pubkey: crate::identity::PubKey) {
-        self.private_pubkeys.write().insert(pubkey);
+        self.private_peer_ids
+            .write()
+            .insert(peer_id_from_pubkey(&pubkey));
     }
 
     /// Remove the private marker for a peer. Returns `true` if the marker
     /// was present and removed.
-    pub fn unmark_private(&self, pubkey: &crate::identity::PubKey) -> bool {
-        self.private_pubkeys.write().remove(pubkey)
+    pub fn unmark_private(&self, peer_id: &PeerId) -> bool {
+        self.private_peer_ids.write().remove(peer_id)
     }
 
     /// Returns `true` if the peer is currently marked private.
     pub fn is_private(&self, pubkey: &crate::identity::PubKey) -> bool {
-        self.private_pubkeys.read().contains(pubkey)
+        self.private_peer_ids
+            .read()
+            .contains(&peer_id_from_pubkey(pubkey))
     }
 
-    pub(crate) fn private_pubkeys(&self) -> std::collections::HashSet<crate::identity::PubKey> {
-        self.private_pubkeys.read().clone()
+    pub(crate) fn private_peer_ids(&self) -> std::collections::HashSet<PeerId> {
+        self.private_peer_ids.read().clone()
     }
 
     /// Scope in-process routing to a namespace.
@@ -193,8 +197,11 @@ impl Router {
         self.trusted_peers.write().upsert(peer);
     }
 
-    pub fn remove_trusted_peer(&self, pubkey: &crate::identity::PubKey) -> bool {
-        self.trusted_peers.write().remove(pubkey)
+    pub fn remove_trusted_peer(&self, peer_id: &PeerId) -> bool {
+        self.trusted_peers
+            .write()
+            .remove_by_peer_id(peer_id)
+            .is_some()
     }
 
     /// Get the trusted peers Arc.

--- a/meerkat-comms/src/runtime/comms_runtime.rs
+++ b/meerkat-comms/src/runtime/comms_runtime.rs
@@ -301,8 +301,7 @@ impl CoreCommsRuntime for CommsRuntime {
     }
 
     async fn add_trusted_peer(&self, peer: TrustedPeerDescriptor) -> Result<(), SendError> {
-        let trusted_peer = descriptor_to_trusted_peer(peer)?;
-        self.register_trusted_peer(trusted_peer).await
+        self.register_trusted_peer_descriptor(peer).await
     }
 
     async fn remove_trusted_peer(&self, peer_id: &str) -> Result<bool, SendError> {
@@ -310,8 +309,7 @@ impl CoreCommsRuntime for CommsRuntime {
     }
 
     async fn add_private_trusted_peer(&self, peer: TrustedPeerDescriptor) -> Result<(), SendError> {
-        let trusted_peer = descriptor_to_trusted_peer(peer)?;
-        self.register_private_trusted_peer(trusted_peer).await
+        self.register_private_trusted_peer_descriptor(peer).await
     }
 
     async fn remove_private_trusted_peer(&self, peer_id: &str) -> Result<bool, SendError> {
@@ -988,7 +986,7 @@ impl CoreCommsRuntime for CommsRuntime {
                     }
                 };
                 Some(TrustedPeerDescriptor {
-                    peer_id: peer_id_from_pubkey(&peer.pubkey),
+                    peer_id: self.router.peer_id_for_pubkey(&peer.pubkey),
                     name,
                     address: parse_peer_address(&peer.addr),
                     pubkey: *peer.pubkey.as_bytes(),
@@ -1704,6 +1702,16 @@ impl CommsRuntime {
         Ok(())
     }
 
+    async fn register_trusted_peer_descriptor(
+        &self,
+        descriptor: TrustedPeerDescriptor,
+    ) -> Result<(), SendError> {
+        let peer_id = descriptor.peer_id;
+        let peer = descriptor_to_trusted_peer(descriptor)?;
+        self.router.add_trusted_peer_with_peer_id(peer_id, peer);
+        Ok(())
+    }
+
     /// Canonical runtime trust-removal seam using a canonical [`PeerId`]
     /// string.
     pub async fn unregister_trusted_peer(&self, peer_id: &str) -> Result<bool, SendError> {
@@ -1728,6 +1736,17 @@ impl CommsRuntime {
         let pubkey = peer.pubkey;
         self.router.add_trusted_peer(peer);
         self.router.mark_private(pubkey);
+        Ok(())
+    }
+
+    async fn register_private_trusted_peer_descriptor(
+        &self,
+        descriptor: TrustedPeerDescriptor,
+    ) -> Result<(), SendError> {
+        let peer_id = descriptor.peer_id;
+        let peer = descriptor_to_trusted_peer(descriptor)?;
+        self.router.add_trusted_peer_with_peer_id(peer_id, peer);
+        self.router.mark_private_peer_id(peer_id);
         Ok(())
     }
 
@@ -1839,7 +1858,8 @@ impl CommsRuntime {
                 }
                 trusted_names.insert(peer.name.clone());
                 trusted_pubkeys.insert(peer.pubkey);
-                if private_peer_ids.contains(&peer_id_from_pubkey(&peer.pubkey)) {
+                let peer_id = self.router.peer_id_for_pubkey(&peer.pubkey);
+                if private_peer_ids.contains(&peer_id) {
                     continue;
                 }
                 let source = if inproc_by_name
@@ -1863,7 +1883,7 @@ impl CommsRuntime {
                 };
                 on_peer(ResolvedPeer {
                     name,
-                    peer_id: peer_id_from_pubkey(&peer.pubkey),
+                    peer_id,
                     address: parse_peer_address(&peer.addr),
                     source,
                     meta: peer.meta.clone(),
@@ -2487,7 +2507,7 @@ mod tests {
     use meerkat_core::{
         BlobId, BlobPayload, BlobRef, BlobStore, BlobStoreError, SendError,
         comms::{
-            InputSource, InputStreamMode, PeerDirectorySource, PeerName, PeerReachability,
+            InputSource, InputStreamMode, PeerDirectorySource, PeerId, PeerName, PeerReachability,
             PeerReachabilityReason, PeerRoute, StreamError, StreamScope, TrustedPeerDescriptor,
         },
         interaction::InteractionId,
@@ -4945,6 +4965,83 @@ mod tests {
         assert!(
             matches!(result, Err(SendError::PeerNotFound(_))),
             "send to removed peer should fail with PeerNotFound, got: {result:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_remove_trusted_peer_preserves_descriptor_peer_id_for_zero_pubkey() {
+        let suffix = Uuid::new_v4().simple().to_string();
+        let runtime = CommsRuntime::inproc_only(&format!("rm-zero-pubkey-{suffix}")).unwrap();
+        let peer_id = PeerId::new();
+        let peer_name = format!("legacy-peer-{suffix}");
+        let spec = TrustedPeerDescriptor::test_only_unsigned_typed(
+            peer_name.clone(),
+            peer_id,
+            format!("inproc://{peer_name}"),
+        )
+        .expect("valid zero-pubkey descriptor");
+
+        CoreCommsRuntime::add_trusted_peer(&runtime, spec)
+            .await
+            .expect("add zero-pubkey trusted peer");
+
+        let peers = CoreCommsRuntime::peers(&runtime).await;
+        let entry = peers
+            .iter()
+            .find(|entry| entry.name.as_str() == peer_name)
+            .expect("zero-pubkey peer should be listed");
+        assert_eq!(
+            entry.peer_id, peer_id,
+            "directory must preserve descriptor PeerId rather than derive from zero pubkey"
+        );
+
+        let removed = CoreCommsRuntime::remove_trusted_peer(&runtime, &peer_id.to_string())
+            .await
+            .expect("remove zero-pubkey peer by PeerId");
+        assert!(
+            removed,
+            "zero-pubkey peer should remove by descriptor PeerId"
+        );
+        assert!(
+            CoreCommsRuntime::peers(&runtime)
+                .await
+                .iter()
+                .all(|entry| entry.name.as_str() != peer_name),
+            "zero-pubkey peer should not remain listed after removal"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_remove_private_trusted_peer_preserves_descriptor_peer_id_for_zero_pubkey() {
+        let suffix = Uuid::new_v4().simple().to_string();
+        let runtime = CommsRuntime::inproc_only(&format!("rm-private-zero-{suffix}")).unwrap();
+        let peer_id = PeerId::new();
+        let peer_name = format!("private-legacy-peer-{suffix}");
+        let spec = TrustedPeerDescriptor::test_only_unsigned_typed(
+            peer_name.clone(),
+            peer_id,
+            format!("inproc://{peer_name}"),
+        )
+        .expect("valid zero-pubkey descriptor");
+
+        CoreCommsRuntime::add_private_trusted_peer(&runtime, spec)
+            .await
+            .expect("add private zero-pubkey trusted peer");
+
+        assert!(
+            CoreCommsRuntime::peers(&runtime)
+                .await
+                .iter()
+                .all(|entry| entry.name.as_str() != peer_name),
+            "private zero-pubkey peer should be hidden from public directory"
+        );
+
+        let removed = CoreCommsRuntime::remove_private_trusted_peer(&runtime, &peer_id.to_string())
+            .await
+            .expect("remove private zero-pubkey peer by PeerId");
+        assert!(
+            removed,
+            "private zero-pubkey peer should remove by descriptor PeerId"
         );
     }
 

--- a/meerkat-comms/src/runtime/comms_runtime.rs
+++ b/meerkat-comms/src/runtime/comms_runtime.rs
@@ -315,9 +315,7 @@ impl CoreCommsRuntime for CommsRuntime {
     }
 
     async fn remove_private_trusted_peer(&self, peer_id: &str) -> Result<bool, SendError> {
-        let public_key = PubKey::from_pubkey_string(peer_id)
-            .map_err(|err| SendError::Validation(err.to_string()))?;
-        self.unregister_private_trusted_peer(&public_key).await
+        self.unregister_private_trusted_peer(peer_id).await
     }
 
     fn dismiss_received(&self) -> bool {
@@ -1706,13 +1704,12 @@ impl CommsRuntime {
         Ok(())
     }
 
-    /// Canonical runtime trust-removal seam using a pubkey string
-    /// (`"ed25519:<base64>"`, the round-trippable encoding emitted by
-    /// [`PubKey::to_pubkey_string`]).
+    /// Canonical runtime trust-removal seam using a canonical [`PeerId`]
+    /// string.
     pub async fn unregister_trusted_peer(&self, peer_id: &str) -> Result<bool, SendError> {
-        let public_key = PubKey::from_pubkey_string(peer_id)
+        let peer_id = meerkat_core::comms::PeerId::parse(peer_id)
             .map_err(|err| SendError::Validation(err.to_string()))?;
-        Ok(self.router.remove_trusted_peer(&public_key))
+        Ok(self.router.remove_trusted_peer(&peer_id))
     }
 
     /// Register a trust edge whose peer entry is marked private.
@@ -1720,7 +1717,7 @@ impl CommsRuntime {
     /// The peer goes through the same router + classified-inbox sync as
     /// [`register_trusted_peer`](Self::register_trusted_peer) — admission
     /// and send-resolution behave identically — but its pubkey is added
-    /// to the router's private-pubkey directory filter so
+    /// to the router's private peer-id directory filter so
     /// `resolve_peer_directory()` (and downstream `comms.peers`
     /// REST/RPC/MCP handlers) filter it out. Intended for control-plane
     /// edges such as the supervisor→member lifecycle channel for
@@ -1735,18 +1732,17 @@ impl CommsRuntime {
     }
 
     /// Remove a previously registered private-trust edge.
-    pub async fn unregister_private_trusted_peer(
-        &self,
-        public_key: &PubKey,
-    ) -> Result<bool, SendError> {
-        let removed = self.router.remove_trusted_peer(public_key);
-        self.router.unmark_private(public_key);
+    pub async fn unregister_private_trusted_peer(&self, peer_id: &str) -> Result<bool, SendError> {
+        let peer_id = meerkat_core::comms::PeerId::parse(peer_id)
+            .map_err(|err| SendError::Validation(err.to_string()))?;
+        let removed = self.router.remove_trusted_peer(&peer_id);
+        self.router.unmark_private(&peer_id);
         Ok(removed)
     }
 
-    /// Canonical runtime trust-removal seam using a public key.
+    /// Explicit compatibility helper for callers that still hold a public key.
     pub async fn unregister_trusted_pubkey(&self, public_key: &PubKey) -> Result<bool, SendError> {
-        self.unregister_trusted_peer(&public_key.to_pubkey_string())
+        self.unregister_trusted_peer(&public_key.to_peer_id().to_string())
             .await
     }
 
@@ -1830,7 +1826,7 @@ impl CommsRuntime {
                 .map(|p| (p.name.clone(), p.pubkey))
                 .collect();
         let participant_name = self.participant_name().to_string();
-        let private_pubkeys = self.router.private_pubkeys();
+        let private_peer_ids = self.router.private_peer_ids();
         let mut trusted_names = HashSet::new();
         let mut trusted_pubkeys = HashSet::new();
         let mut emitted = 0usize;
@@ -1843,7 +1839,7 @@ impl CommsRuntime {
                 }
                 trusted_names.insert(peer.name.clone());
                 trusted_pubkeys.insert(peer.pubkey);
-                if private_pubkeys.contains(&peer.pubkey) {
+                if private_peer_ids.contains(&peer_id_from_pubkey(&peer.pubkey)) {
                     continue;
                 }
                 let source = if inproc_by_name
@@ -1881,7 +1877,7 @@ impl CommsRuntime {
         }
 
         for inproc in &inproc_peers {
-            if private_pubkeys.contains(&inproc.pubkey) {
+            if private_peer_ids.contains(&peer_id_from_pubkey(&inproc.pubkey)) {
                 continue;
             }
             let name = match PeerName::new(inproc.name.clone()) {
@@ -3519,7 +3515,7 @@ mod tests {
 
         let removed = CoreCommsRuntime::remove_trusted_peer(
             &runtime,
-            &pubkey_for_authority_check.to_pubkey_string(),
+            &pubkey_for_authority_check.to_peer_id().to_string(),
         )
         .await
         .expect("remove_trusted_peer should succeed");
@@ -4920,10 +4916,9 @@ mod tests {
             "receiver should appear in sender's peers after add"
         );
 
-        // Remove the trusted peer — `remove_trusted_peer` keys on the
-        // pubkey-string form so the pubkey bytes survive the lookup.
-        let peer_pubkey_string = receiver.public_key().to_pubkey_string();
-        let removed = CoreCommsRuntime::remove_trusted_peer(&sender, &peer_pubkey_string)
+        // Remove the trusted peer by canonical PeerId.
+        let peer_id = receiver.public_key().to_peer_id().to_string();
+        let removed = CoreCommsRuntime::remove_trusted_peer(&sender, &peer_id)
             .await
             .expect("remove_trusted_peer should succeed");
         assert!(removed, "remove should return true for existing peer");
@@ -4959,13 +4954,28 @@ mod tests {
         let sender = CommsRuntime::inproc_only(&format!("rm-absent-{suffix}")).unwrap();
         let other = CommsRuntime::inproc_only(&format!("rm-absent-other-{suffix}")).unwrap();
 
-        let peer_pubkey_string = other.public_key().to_pubkey_string();
-        let removed = CoreCommsRuntime::remove_trusted_peer(&sender, &peer_pubkey_string)
+        let peer_id = other.public_key().to_peer_id().to_string();
+        let removed = CoreCommsRuntime::remove_trusted_peer(&sender, &peer_id)
             .await
             .expect("remove_trusted_peer should succeed even for absent peer");
         assert!(
             !removed,
             "remove should return false for peer that was never trusted"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_remove_trusted_peer_rejects_pubkey_string_argument() {
+        let suffix = Uuid::new_v4().simple().to_string();
+        let sender = CommsRuntime::inproc_only(&format!("rm-pubkey-sender-{suffix}")).unwrap();
+        let receiver = CommsRuntime::inproc_only(&format!("rm-pubkey-receiver-{suffix}")).unwrap();
+
+        let peer_pubkey_string = receiver.public_key().to_pubkey_string();
+        let result = CoreCommsRuntime::remove_trusted_peer(&sender, &peer_pubkey_string).await;
+
+        assert!(
+            matches!(result, Err(SendError::Validation(_))),
+            "remove_trusted_peer should validate its argument as PeerId, got: {result:?}"
         );
     }
 }

--- a/meerkat-comms/src/trust.rs
+++ b/meerkat-comms/src/trust.rs
@@ -294,10 +294,23 @@ impl TrustedPeers {
     }
 
     /// Remove a peer by pubkey.
+    ///
+    /// Legacy helper retained for direct trust-list tests and low-level
+    /// callers. Runtime trust removal is keyed by [`PeerId`]; use
+    /// [`Self::remove_by_peer_id`] on control-plane paths.
     pub fn remove(&mut self, pubkey: &PubKey) -> bool {
         let len_before = self.peers.len();
         self.peers.retain(|p| &p.pubkey != pubkey);
         self.peers.len() != len_before
+    }
+
+    /// Remove a peer by canonical [`PeerId`].
+    pub fn remove_by_peer_id(&mut self, peer_id: &PeerId) -> Option<TrustedPeer> {
+        let index = self
+            .peers
+            .iter()
+            .position(|p| crate::router::peer_id_from_pubkey(&p.pubkey) == *peer_id)?;
+        Some(self.peers.remove(index))
     }
 
     /// Insert or replace a peer, keyed by `pubkey`.
@@ -633,6 +646,36 @@ mod tests {
 
         let removed = peers.remove(&PubKey::new([1u8; 32]));
         assert!(removed);
+        assert_eq!(peers.peers.len(), 1);
+        assert_eq!(peers.peers[0].name, "peer2");
+    }
+
+    #[test]
+    fn test_remove_existing_peer_by_peer_id() {
+        let mut peers = TrustedPeers {
+            peers: vec![
+                TrustedPeer {
+                    name: "peer1".to_string(),
+                    pubkey: PubKey::new([1u8; 32]),
+                    addr: "tcp://localhost:4201".to_string(),
+                    meta: crate::PeerMeta::default(),
+                },
+                TrustedPeer {
+                    name: "peer2".to_string(),
+                    pubkey: PubKey::new([2u8; 32]),
+                    addr: "tcp://localhost:4202".to_string(),
+                    meta: crate::PeerMeta::default(),
+                },
+            ],
+        };
+        let peer_id = PubKey::new([1u8; 32]).to_peer_id();
+
+        let removed = peers.remove_by_peer_id(&peer_id);
+
+        assert_eq!(
+            removed.as_ref().map(|peer| peer.name.as_str()),
+            Some("peer1")
+        );
         assert_eq!(peers.peers.len(), 1);
         assert_eq!(peers.peers[0].name, "peer2");
     }

--- a/meerkat-comms/tests/inbox_admission_toctou.rs
+++ b/meerkat-comms/tests/inbox_admission_toctou.rs
@@ -105,7 +105,7 @@ async fn revoked_sender_is_rejected_at_admission() {
     .expect("seed trust");
     let removed = meerkat_core::agent::CommsRuntime::remove_trusted_peer(
         &receiver,
-        &sender.public_key().to_pubkey_string(),
+        &sender.public_key().to_peer_id().to_string(),
     )
     .await
     .expect("revoke trust");
@@ -191,7 +191,7 @@ async fn concurrent_revokes_and_admissions_never_admit_untrusted() {
                 if i % 2 == 0 {
                     let _ = meerkat_core::agent::CommsRuntime::remove_trusted_peer(
                         receiver_for_task.as_ref(),
-                        &sender_for_task.public_key().to_pubkey_string(),
+                        &sender_for_task.public_key().to_peer_id().to_string(),
                     )
                     .await;
                 } else {

--- a/meerkat-core/src/agent.rs
+++ b/meerkat-core/src/agent.rs
@@ -611,7 +611,7 @@ pub enum CommsCapabilityError {
 pub trait CommsRuntime: Send + Sync {
     /// Runtime-local public key identifier, if available.
     ///
-    /// Returns a peer ID string in `ed25519:<base64>` format.
+    /// Returns an Ed25519 public key string in `ed25519:<base64>` format.
     fn public_key(&self) -> Option<String> {
         None
     }
@@ -1032,8 +1032,9 @@ mod tests {
         let runtime = NoopCommsRuntime {
             notify: Arc::new(Notify::new()),
         };
+        let peer_id = PeerId::new().to_string();
         let result =
-            <NoopCommsRuntime as CommsRuntime>::remove_trusted_peer(&runtime, "ed25519:test").await;
+            <NoopCommsRuntime as CommsRuntime>::remove_trusted_peer(&runtime, &peer_id).await;
         assert!(matches!(result, Err(SendError::Unsupported(_))));
     }
 

--- a/meerkat-mob/src/runtime/actor.rs
+++ b/meerkat-mob/src/runtime/actor.rs
@@ -410,20 +410,8 @@ impl MobActor {
         }
     }
 
-    fn trusted_peer_pubkey_string(peer: &TrustedPeerDescriptor) -> String {
-        meerkat_comms::PubKey::new(peer.pubkey).to_pubkey_string()
-    }
-
     fn trusted_peer_removal_key(peer: &TrustedPeerDescriptor) -> String {
-        Self::trusted_peer_pubkey_string(peer)
-    }
-
-    fn supervisor_peer_removal_key(peer_id: &str) -> String {
-        if peer_id.starts_with("ed25519:") {
-            peer_id.to_string()
-        } else {
-            format!("ed25519:{peer_id}")
-        }
+        peer.peer_id.to_string()
     }
 
     async fn remove_trusted_peer_by_descriptor(
@@ -431,23 +419,7 @@ impl MobActor {
         peer: &TrustedPeerDescriptor,
     ) -> Result<bool, meerkat_core::comms::SendError> {
         let peer_id = peer.peer_id.to_string();
-        match comms.remove_trusted_peer(&peer_id).await {
-            Ok(true) => Ok(true),
-            Ok(false) => {
-                let pubkey_key = Self::trusted_peer_removal_key(peer);
-                comms.remove_trusted_peer(&pubkey_key).await
-            }
-            Err(peer_id_error) => match comms.remove_trusted_peer(&peer_id).await {
-                Ok(removed) => Ok(removed),
-                Err(_) => {
-                    let pubkey_key = Self::trusted_peer_removal_key(peer);
-                    match comms.remove_trusted_peer(&pubkey_key).await {
-                        Ok(removed) => Ok(removed),
-                        Err(_) => Err(peer_id_error),
-                    }
-                }
-            },
-        }
+        comms.remove_trusted_peer(&peer_id).await
     }
 
     fn supervisor_spec_for_authority(
@@ -594,7 +566,7 @@ impl MobActor {
             {
                 let previous_removal_key = previous_private_trust_removal_key
                     .map(str::to_string)
-                    .unwrap_or_else(|| Self::supervisor_peer_removal_key(previous_peer_id));
+                    .unwrap_or_else(|| previous_peer_id.clone());
                 if let Err(error) = comms
                     .remove_private_trusted_peer(&previous_removal_key)
                     .await
@@ -608,7 +580,7 @@ impl MobActor {
                             next_epoch,
                         )
                         .await;
-                    let next_removal_key = Self::trusted_peer_pubkey_string(&spec);
+                    let next_removal_key = Self::trusted_peer_removal_key(&spec);
                     let cleanup = comms.remove_private_trusted_peer(&next_removal_key).await;
                     let mut reason = format!(
                         "previous supervisor private trust removal failed for session '{session_id}': {error}"
@@ -628,7 +600,7 @@ impl MobActor {
             Ok(SupervisorPrivateTrustInstall {
                 peer_id: next_peer_id,
                 epoch: next_epoch,
-                removal_key: Self::trusted_peer_pubkey_string(&spec),
+                removal_key: Self::trusted_peer_removal_key(&spec),
             })
         }
     }
@@ -8228,7 +8200,7 @@ impl MobActor {
             .put_supervisor_authority(&self.definition.id, next)
             .await?;
         self.supervisor_bridge.rotate(next.clone()).await?;
-        let previous_private_trust_removal_key = current.keypair().public_key().to_pubkey_string();
+        let previous_private_trust_removal_key = current.public_peer_id.clone();
         let session_member_refs = {
             let roster = self.roster.read().await;
             roster

--- a/meerkat-mob/src/runtime/tests.rs
+++ b/meerkat-mob/src/runtime/tests.rs
@@ -234,16 +234,7 @@ impl CoreCommsRuntime for MockCommsRuntime {
             }
         }
         let mut peers = self.trusted_peers.write().await;
-        if peers.remove(peer_id).is_some() {
-            return Ok(true);
-        }
-        let matching_peer_id = peers.iter().find_map(|(stored_peer_id, peer)| {
-            (meerkat_comms::PubKey::new(peer.pubkey).to_pubkey_string() == peer_id)
-                .then(|| stored_peer_id.clone())
-        });
-        Ok(matching_peer_id
-            .and_then(|stored_peer_id| peers.remove(&stored_peer_id))
-            .is_some())
+        Ok(peers.remove(peer_id).is_some())
     }
 
     async fn remove_private_trusted_peer(&self, peer_id: &str) -> Result<bool, SendError> {
@@ -2649,22 +2640,9 @@ impl LiveExternalPeerHarness {
             .collect()
     }
 
-    async fn remove_trusted_peer(&self, peer_id_or_pubkey: &str) {
-        let Some(remove_key) = (if peer_id_or_pubkey.starts_with("ed25519:") {
-            Some(peer_id_or_pubkey.to_string())
-        } else {
-            self.runtime
-                .trusted_peers_shared()
-                .read()
-                .peers
-                .iter()
-                .find(|entry| entry.pubkey.to_peer_id().as_str() == peer_id_or_pubkey)
-                .map(|entry| entry.pubkey.to_pubkey_string())
-        }) else {
-            return;
-        };
+    async fn remove_trusted_peer(&self, peer_id: &str) {
         self.runtime
-            .remove_trusted_peer(&remove_key)
+            .remove_trusted_peer(peer_id)
             .await
             .expect("remove trusted peer from harness runtime");
     }
@@ -2674,7 +2652,7 @@ impl LiveExternalPeerHarness {
         peer: &meerkat_core::comms::TrustedPeerDescriptor,
     ) {
         runtime
-            .remove_trusted_peer(&meerkat_comms::PubKey::new(peer.pubkey).to_pubkey_string())
+            .remove_trusted_peer(&peer.peer_id.to_string())
             .await
             .expect("remove trusted peer from harness runtime");
     }
@@ -3080,10 +3058,7 @@ async fn spawn_live_external_peer(peer_name: &str) -> LiveExternalPeerHarness {
                                         )
                                         .expect("valid peer spec");
                                     let _ = responder_runtime
-                                        .remove_trusted_peer(
-                                            &meerkat_comms::PubKey::new(peer_spec.pubkey)
-                                                .to_pubkey_string(),
-                                        )
+                                        .remove_trusted_peer(&peer_spec.peer_id.to_string())
                                         .await;
                                     serde_json::to_value(super::bridge_protocol::BridgeAck {
                                         ok: true,
@@ -3163,10 +3138,7 @@ async fn spawn_live_external_peer(peer_name: &str) -> LiveExternalPeerHarness {
                                         )
                                         .expect("peer lifecycle trusted peer spec");
                                     let _ = responder_runtime
-                                        .remove_trusted_peer(
-                                            &meerkat_comms::PubKey::new(peer_spec.pubkey)
-                                                .to_pubkey_string(),
-                                        )
+                                        .remove_trusted_peer(&peer_spec.peer_id.to_string())
                                         .await;
                                     serde_json::json!({ "ok": true })
                                 }
@@ -3188,7 +3160,7 @@ async fn spawn_live_external_peer(peer_name: &str) -> LiveExternalPeerHarness {
                         responder_runtime.mark_interaction_complete(candidate.interaction.id.0);
                         for supervisor_pubkey in remove_supervisors_after_response {
                             let _ = responder_runtime
-                                .remove_trusted_peer(&supervisor_pubkey.to_pubkey_string())
+                                .remove_trusted_peer(&supervisor_pubkey.to_peer_id().to_string())
                                 .await;
                         }
                     }
@@ -8654,16 +8626,8 @@ async fn test_resume_reconciles_mixed_topology_without_losing_external_member_re
         .real_comms(&old_sub_sid)
         .await
         .expect("session-backed member comms");
-    let old_ext_pubkey = old_sub_comms
-        .trusted_peers_shared()
-        .read()
-        .peers
-        .iter()
-        .find(|peer| peer.pubkey.to_peer_id().as_str() == old_ext_peer_id)
-        .map(|peer| peer.pubkey.to_pubkey_string())
-        .expect("external trust should exist before resume removal");
     old_sub_comms
-        .remove_trusted_peer(&old_ext_pubkey)
+        .remove_trusted_peer(&old_ext_peer_id)
         .await
         .expect("remove external trust before resume");
     if let Some(old_ext_sid) = &old_ext_sid {
@@ -19022,7 +18986,7 @@ async fn test_supervisor_trust_does_not_leak_into_member_peer_directory() {
     // it's a control-plane edge and would otherwise surface as an ordinary
     // sendable peer in the member's `comms.peers` output (and downstream
     // REST/RPC/MCP). The private-trust seam uses the router's
-    // `private_pubkeys` directory-filter to keep the entry invisible.
+    // private peer-id directory-filter to keep the entry invisible.
     //
     // The *positive* complement — "the supervisor is still trusted enough
     // for the member to send back to it" — is enforced by

--- a/meerkat-mob/src/tests/contracts.rs
+++ b/meerkat-mob/src/tests/contracts.rs
@@ -647,9 +647,9 @@ async fn contract_mob_005_remove_trusted_peer_revokes_send() {
     // Drain the message so it doesn't interfere
     let _ = CoreCommsRuntime::drain_inbox_interactions(&receiver).await;
 
-    // Remove trusted peer
-    let peer_pubkey = receiver.public_key().to_pubkey_string();
-    let removed = CoreCommsRuntime::remove_trusted_peer(&sender, &peer_pubkey)
+    // Remove trusted peer by canonical PeerId.
+    let peer_id = receiver.public_key().to_peer_id().to_string();
+    let removed = CoreCommsRuntime::remove_trusted_peer(&sender, &peer_id)
         .await
         .expect("remove should succeed");
     assert!(removed, "should return true for existing peer");
@@ -688,7 +688,6 @@ async fn contract_mobx_001_trust_accepts_non_inproc_addresses_and_preserves_peer
     let runtime = CommsRuntime::inproc_only(&runtime_name).unwrap();
     let peer = CommsRuntime::inproc_only(&peer_name).unwrap();
     let peer_id = peer.public_key().to_peer_id().to_string();
-    let peer_pubkey = peer.public_key().to_pubkey_string();
     let backend_address = format!("tcp://backend.example.invalid:{}", 10_000 + suffix.len());
 
     let spec = TrustedPeerDescriptor::unsigned_with_pubkey(
@@ -718,7 +717,7 @@ async fn contract_mobx_001_trust_accepts_non_inproc_addresses_and_preserves_peer
         "runtime should preserve backend-provided address string"
     );
 
-    let removed = CoreCommsRuntime::remove_trusted_peer(&runtime, &peer_pubkey)
+    let removed = CoreCommsRuntime::remove_trusted_peer(&runtime, &peer_id)
         .await
         .expect("remove_trusted_peer should succeed by peer_id");
     assert!(


### PR DESCRIPTION
## Summary
- Make runtime/router trusted-peer removal parse and remove by canonical PeerId instead of ed25519 pubkey strings.
- Key private trust directory markers by PeerId and remove mob pubkey fallback cleanup paths.
- Update focused comms/mob tests to assert PeerId removal and reject pubkey-string removal arguments.

## Validation
- ./scripts/repo-cargo test -p meerkat-comms remove_trusted_peer --lib
- ./scripts/repo-cargo test -p meerkat-comms test_remove_existing_peer_by_peer_id --lib
- ./scripts/repo-cargo test -p meerkat-comms --test inbox_admission_toctou
- ./scripts/repo-cargo test -p meerkat-mob contract_mob_005_remove_trusted_peer_revokes_send
- ./scripts/repo-cargo test -p meerkat-mob contract_mobx_001_trust_accepts_non_inproc_addresses_and_preserves_peer_id
- ./scripts/repo-cargo test -p meerkat-runtime trust_reconcile
- make check (BuildBuddy invocation edd20658-7232-42eb-9ee6-845bf21ff8b1)
- git diff --check

Linear: LUC-55