### PR TITLE
LUC-59 Route skill source loads through identity registry

### DIFF
--- a/meerkat-core/src/skills/mod.rs
+++ b/meerkat-core/src/skills/mod.rs
@@ -735,11 +735,34 @@ pub trait SkillSource: Send + Sync {
         filter: &SkillFilter,
     ) -> impl Future<Output = Result<Vec<SkillDescriptor>, SkillError>> + Send;
 
-    /// Load a skill document by its canonical key.
+    /// Load a skill document by its already-resolved canonical key.
     fn load(
         &self,
         key: &SkillKey,
     ) -> impl Future<Output = Result<SkillDocument, SkillError>> + Send;
+
+    /// Resolve `key` through the canonical source-identity registry before
+    /// loading. Direct callers outside a registry-backed [`SkillEngine`] should
+    /// use this path so source lineage remaps and lifecycle gates remain
+    /// authoritative at resolution time.
+    fn load_with_source_identity_registry(
+        &self,
+        key: &SkillKey,
+        registry: &SourceIdentityRegistry,
+    ) -> impl Future<Output = Result<SkillDocument, SkillError>> + Send {
+        async move {
+            let canonical_key =
+                registry
+                    .resolve(key)
+                    .map(|resolved| resolved.key)
+                    .map_err(|e| {
+                        SkillError::Load(
+                            format!("source identity resolution failed for {key}: {e}").into(),
+                        )
+                    })?;
+            self.load(&canonical_key).await
+        }
+    }
 
     /// List collections with counts. Default derives from `list()`.
     fn collections(&self) -> impl Future<Output = Result<Vec<SkillCollection>, SkillError>> + Send {

--- a/meerkat-skills/src/resolve.rs
+++ b/meerkat-skills/src/resolve.rs
@@ -1,6 +1,7 @@
 //! Skill repository resolution.
 
 use std::path::Path;
+use std::sync::Arc;
 #[cfg(not(target_arch = "wasm32"))]
 use std::time::Duration;
 
@@ -41,7 +42,7 @@ pub async fn resolve_repositories_with_roots(
         return Ok(None);
     }
 
-    let registry = config.build_source_identity_registry()?;
+    let registry = Arc::new(config.build_source_identity_registry()?);
     let records = config.source_identity_records();
 
     #[cfg(target_arch = "wasm32")]
@@ -57,12 +58,13 @@ pub async fn resolve_repositories_with_roots(
             return Err(error);
         }
         let builtin_identity = active_source_identity(&registry, &records, &SourceUuid::builtin())?;
-        Ok(Some(CompositeSkillSource::from_named(vec![
-            NamedSource::new(
+        Ok(Some(CompositeSkillSource::from_named_with_registry(
+            vec![NamedSource::new(
                 builtin_identity,
                 SourceNode::Embedded(EmbeddedSkillSource::new()),
-            ),
-        ])))
+            )],
+            registry,
+        )))
     }
 
     #[cfg(not(target_arch = "wasm32"))]
@@ -235,7 +237,9 @@ pub async fn resolve_repositories_with_roots(
             }
         }
 
-        Ok(Some(CompositeSkillSource::from_named(sources)))
+        Ok(Some(CompositeSkillSource::from_named_with_registry(
+            sources, registry,
+        )))
     }
 }
 

--- a/meerkat-skills/src/source/composite.rs
+++ b/meerkat-skills/src/source/composite.rs
@@ -4,10 +4,11 @@ use crate::source::SourceNode;
 use meerkat_core::skills::{
     SkillArtifact, SkillArtifactContent, SkillDescriptor, SkillDocument, SkillError, SkillFilter,
     SkillIntrospectionEntry, SkillKey, SkillQuarantineDiagnostic, SkillSource,
-    SourceHealthSnapshot, SourceHealthState, SourceIdentityRecord, SourceIdentityStatus,
-    SourceTransportKind, SourceUuid, apply_filter,
+    SourceHealthSnapshot, SourceHealthState, SourceIdentityRecord, SourceIdentityRegistry,
+    SourceIdentityStatus, SourceTransportKind, SourceUuid, apply_filter,
 };
 use std::collections::HashMap;
+use std::sync::Arc;
 
 /// A named skill source for provenance tracking.
 pub struct NamedSource {
@@ -29,18 +30,141 @@ impl NamedSource {
     }
 }
 
+#[cfg(test)]
+#[allow(clippy::unwrap_used)]
+mod tests {
+    use super::*;
+    use crate::source::InMemorySkillSource;
+    use indexmap::IndexMap;
+    use meerkat_core::skills::{
+        SkillKeyRemap, SkillName, SkillScope, SourceIdentityLineage, SourceIdentityLineageEvent,
+    };
+
+    fn source_uuid(raw: &str) -> SourceUuid {
+        SourceUuid::parse(raw).unwrap()
+    }
+
+    fn skill_key(source_uuid: &SourceUuid, skill: &str) -> SkillKey {
+        SkillKey::new(source_uuid.clone(), SkillName::parse(skill).unwrap())
+    }
+
+    fn skill_doc(key: SkillKey, display: &str, body: &str) -> SkillDocument {
+        SkillDocument {
+            descriptor: SkillDescriptor {
+                key,
+                name: display.to_string(),
+                description: format!("description for {display}"),
+                scope: SkillScope::Project,
+                metadata: IndexMap::new(),
+                capability_requirements: Vec::new(),
+                source_name: String::new(),
+            },
+            body: body.to_string(),
+            extensions: IndexMap::new(),
+        }
+    }
+
+    fn source_record(source_uuid: SourceUuid, name: &str) -> SourceIdentityRecord {
+        SourceIdentityRecord {
+            source_uuid,
+            display_name: name.to_string(),
+            transport_kind: SourceTransportKind::Filesystem,
+            fingerprint: format!("fixture:{name}"),
+            status: SourceIdentityStatus::Active,
+        }
+    }
+
+    #[tokio::test]
+    async fn load_applies_registry_remap_before_first_wins_lookup() {
+        let legacy_source = source_uuid("aaaaaaaa-aaaa-4aaa-aaaa-aaaaaaaaaaaa");
+        let canonical_source = source_uuid("bbbbbbbb-bbbb-4bbb-bbbb-bbbbbbbbbbbb");
+        let legacy_key = skill_key(&legacy_source, "alpha");
+        let canonical_key = skill_key(&canonical_source, "alpha");
+        let registry = SourceIdentityRegistry::build(
+            vec![
+                source_record(legacy_source.clone(), "legacy"),
+                source_record(canonical_source.clone(), "canonical"),
+            ],
+            vec![SourceIdentityLineage {
+                event_id: "legacy-to-canonical".to_string(),
+                recorded_at_unix_secs: 1,
+                required_from_skills: Vec::new(),
+                event: SourceIdentityLineageEvent::RenameOrRelocate {
+                    from: legacy_source.clone(),
+                    to: canonical_source.clone(),
+                },
+            }],
+            vec![SkillKeyRemap {
+                from: legacy_key.clone(),
+                to: canonical_key.clone(),
+                reason: Some("test remap".to_string()),
+            }],
+            Vec::new(),
+        )
+        .unwrap();
+        let legacy = NamedSource::new(
+            source_record(legacy_source, "legacy"),
+            SourceNode::Memory(InMemorySkillSource::new(vec![skill_doc(
+                legacy_key.clone(),
+                "Legacy Alpha",
+                "legacy body",
+            )])),
+        );
+        let canonical = NamedSource::new(
+            source_record(canonical_source, "canonical"),
+            SourceNode::Memory(InMemorySkillSource::new(vec![skill_doc(
+                canonical_key.clone(),
+                "Canonical Alpha",
+                "canonical body",
+            )])),
+        );
+        let composite = CompositeSkillSource::from_named_with_registry(
+            vec![legacy, canonical],
+            Arc::new(registry),
+        );
+
+        let doc = composite.load(&legacy_key).await.unwrap();
+
+        assert_eq!(doc.descriptor.key, canonical_key);
+        assert_eq!(doc.descriptor.name, "Canonical Alpha");
+        assert_eq!(doc.descriptor.source_name, "canonical");
+        assert_eq!(doc.body, "canonical body");
+    }
+}
+
 /// Merges skills from multiple named sources with precedence.
 ///
 /// First source wins for duplicate `SkillKey`s. Each skill's `source_name`
 /// field is populated from the `NamedSource.name` that provided it.
 pub struct CompositeSkillSource {
     sources: Vec<NamedSource>,
+    registry: Option<Arc<SourceIdentityRegistry>>,
 }
 
 impl CompositeSkillSource {
     /// Create from named sources (precedence = order).
     pub fn from_named(sources: Vec<NamedSource>) -> Self {
-        Self { sources }
+        Self {
+            sources,
+            registry: None,
+        }
+    }
+
+    /// Create from named sources with source-identity resolution applied
+    /// before direct composite loads.
+    pub fn from_named_with_registry(
+        sources: Vec<NamedSource>,
+        registry: Arc<SourceIdentityRegistry>,
+    ) -> Self {
+        Self {
+            sources,
+            registry: Some(registry),
+        }
+    }
+
+    pub fn with_source_identity_registry(mut self, registry: Arc<SourceIdentityRegistry>) -> Self {
+        self.registry = Some(registry);
+        self
     }
 
     /// Create from unnamed sources (backward compatibility).
@@ -59,7 +183,36 @@ impl CompositeSkillSource {
                 source,
             })
             .collect();
-        Self { sources: named }
+        Self {
+            sources: named,
+            registry: None,
+        }
+    }
+
+    fn resolve_key_for_load(&self, key: &SkillKey) -> Result<SkillKey, SkillError> {
+        let Some(registry) = &self.registry else {
+            return Ok(key.clone());
+        };
+        registry
+            .resolve(key)
+            .map(|resolved| resolved.key)
+            .map_err(|e| {
+                SkillError::Load(format!("source identity resolution failed for {key}: {e}").into())
+            })
+    }
+
+    async fn load_canonical(&self, key: &SkillKey) -> Result<SkillDocument, SkillError> {
+        for named in &self.sources {
+            match named.source.load(key).await {
+                Ok(mut doc) => {
+                    doc.descriptor.source_name = named.display_name().to_string();
+                    return Ok(doc);
+                }
+                Err(SkillError::NotFound { .. }) => continue,
+                Err(e) => return Err(e),
+            }
+        }
+        Err(SkillError::NotFound { key: key.clone() })
     }
 }
 
@@ -82,17 +235,8 @@ impl SkillSource for CompositeSkillSource {
     }
 
     async fn load(&self, key: &SkillKey) -> Result<SkillDocument, SkillError> {
-        for named in &self.sources {
-            match named.source.load(key).await {
-                Ok(mut doc) => {
-                    doc.descriptor.source_name = named.display_name().to_string();
-                    return Ok(doc);
-                }
-                Err(SkillError::NotFound { .. }) => continue,
-                Err(e) => return Err(e),
-            }
-        }
-        Err(SkillError::NotFound { key: key.clone() })
+        let canonical_key = self.resolve_key_for_load(key)?;
+        self.load_canonical(&canonical_key).await
     }
 
     async fn quarantined_diagnostics(&self) -> Result<Vec<SkillQuarantineDiagnostic>, SkillError> {
@@ -218,17 +362,22 @@ impl SkillSource for CompositeSkillSource {
         key: &SkillKey,
         source_name: Option<&str>,
     ) -> Result<SkillDocument, SkillError> {
+        let canonical_key = self.resolve_key_for_load(key)?;
         let Some(target) = source_name else {
-            return self.load(key).await;
+            return self.load_canonical(&canonical_key).await;
         };
-        let target_uuid = SourceUuid::parse(target)?;
+        let target_uuid = {
+            let parsed = SourceUuid::parse(target)?;
+            let target_key = SkillKey::new(parsed, canonical_key.skill_name.clone());
+            self.resolve_key_for_load(&target_key)?.source_uuid
+        };
         for named in &self.sources {
             if named.source_uuid() == &target_uuid {
-                let mut doc = named.source.load(key).await?;
+                let mut doc = named.source.load(&canonical_key).await?;
                 doc.descriptor.source_name = named.display_name().to_string();
                 return Ok(doc);
             }
         }
-        Err(SkillError::NotFound { key: key.clone() })
+        Err(SkillError::NotFound { key: canonical_key })
     }
 }

--- a/meerkat-skills/src/source/memory.rs
+++ b/meerkat-skills/src/source/memory.rs
@@ -35,7 +35,11 @@ impl SkillSource for InMemorySkillSource {
 mod tests {
     use super::*;
     use indexmap::IndexMap;
-    use meerkat_core::skills::{SkillName, SkillScope, SourceUuid};
+    use meerkat_core::skills::{
+        SkillKeyRemap, SkillName, SkillScope, SourceIdentityLineage, SourceIdentityLineageEvent,
+        SourceIdentityRecord, SourceIdentityRegistry, SourceIdentityStatus, SourceTransportKind,
+        SourceUuid,
+    };
 
     fn test_key(skill: &str) -> SkillKey {
         SkillKey {
@@ -57,6 +61,32 @@ mod tests {
             },
             body: format!("Body for {skill}"),
             extensions: IndexMap::new(),
+        }
+    }
+
+    fn make_skill_with_key(key: SkillKey, name: &str) -> SkillDocument {
+        SkillDocument {
+            descriptor: SkillDescriptor {
+                key,
+                name: name.into(),
+                description: format!("Desc for {name}"),
+                scope: SkillScope::Builtin,
+                metadata: IndexMap::new(),
+                capability_requirements: Vec::new(),
+                source_name: String::new(),
+            },
+            body: format!("Body for {name}"),
+            extensions: IndexMap::new(),
+        }
+    }
+
+    fn source_record(source_uuid: SourceUuid, name: &str) -> SourceIdentityRecord {
+        SourceIdentityRecord {
+            source_uuid,
+            display_name: name.to_string(),
+            transport_kind: SourceTransportKind::Filesystem,
+            fingerprint: format!("fixture:{name}"),
+            status: SourceIdentityStatus::Active,
         }
     }
 
@@ -88,5 +118,52 @@ mod tests {
         let source = InMemorySkillSource::new(vec![make_skill("email", "email")]);
         let result = source.load(&test_key("email")).await.unwrap();
         assert_eq!(result.descriptor.name, "email");
+    }
+
+    #[tokio::test]
+    async fn test_load_with_source_identity_registry_applies_remap() {
+        let legacy_source = SourceUuid::parse("aaaaaaaa-aaaa-4aaa-aaaa-aaaaaaaaaaaa").unwrap();
+        let canonical_source = SourceUuid::parse("bbbbbbbb-bbbb-4bbb-bbbb-bbbbbbbbbbbb").unwrap();
+        let skill_name = SkillName::parse("email").unwrap();
+        let legacy_key = SkillKey::new(legacy_source.clone(), skill_name.clone());
+        let canonical_key = SkillKey::new(canonical_source.clone(), skill_name);
+        let registry = SourceIdentityRegistry::build(
+            vec![
+                source_record(legacy_source.clone(), "legacy"),
+                source_record(canonical_source.clone(), "canonical"),
+            ],
+            vec![SourceIdentityLineage {
+                event_id: "legacy-to-canonical".to_string(),
+                recorded_at_unix_secs: 1,
+                required_from_skills: Vec::new(),
+                event: SourceIdentityLineageEvent::RenameOrRelocate {
+                    from: legacy_source,
+                    to: canonical_source,
+                },
+            }],
+            vec![SkillKeyRemap {
+                from: legacy_key.clone(),
+                to: canonical_key.clone(),
+                reason: Some("test remap".to_string()),
+            }],
+            Vec::new(),
+        )
+        .unwrap();
+        let source = InMemorySkillSource::new(vec![make_skill_with_key(
+            canonical_key.clone(),
+            "canonical-email",
+        )]);
+
+        assert!(matches!(
+            source.load(&legacy_key).await,
+            Err(SkillError::NotFound { .. })
+        ));
+
+        let result = source
+            .load_with_source_identity_registry(&legacy_key, &registry)
+            .await
+            .unwrap();
+        assert_eq!(result.descriptor.key, canonical_key);
+        assert_eq!(result.descriptor.name, "canonical-email");
     }
 }

--- a/meerkat-skills/tests/resolver_precedence.rs
+++ b/meerkat-skills/tests/resolver_precedence.rs
@@ -23,8 +23,13 @@
 //! See `docs/wave-c-prep/test-coverage-audit.md` §6 #14.
 #![allow(clippy::unwrap_used, clippy::expect_used)]
 
-use meerkat_core::skills::{SkillFilter, SkillSource, SourceUuid};
-use meerkat_core::skills_config::{SkillRepoTransport, SkillRepositoryConfig, SkillsConfig};
+use meerkat_core::skills::{
+    SkillFilter, SkillKey, SkillKeyRemap, SkillName, SkillSource, SourceIdentityLineage,
+    SourceIdentityLineageEvent, SourceUuid,
+};
+use meerkat_core::skills_config::{
+    SkillRepoTransport, SkillRepositoryConfig, SkillsConfig, SkillsIdentityConfig,
+};
 use meerkat_skills::resolve_repositories_with_roots;
 use std::fs;
 use std::path::Path;
@@ -34,6 +39,10 @@ use wiremock::matchers::{header, method, path};
 use wiremock::{Mock, MockServer, ResponseTemplate};
 
 fn write_skill(root: &Path, skill: &str) {
+    write_skill_with_body(root, skill, &format!("Body for {skill}."));
+}
+
+fn write_skill_with_body(root: &Path, skill: &str, body: &str) {
     let dir = root.join(skill);
     fs::create_dir_all(&dir).unwrap();
     fs::write(
@@ -43,7 +52,7 @@ fn write_skill(root: &Path, skill: &str) {
              name: {skill}\n\
              description: {skill}\n\
              ---\n\
-             Body for {skill}.\n"
+             {body}\n"
         ),
     )
     .unwrap();
@@ -239,6 +248,57 @@ async fn absolute_path_ignores_roots() {
         "absolute path must ignore context_root; got {names:?} (decoy at \
          {:?})",
         decoy.path(),
+    );
+}
+
+#[tokio::test]
+async fn resolved_composite_load_applies_source_identity_remap_directly() {
+    let tmp = tempfile::tempdir().unwrap();
+    write_skill_with_body(&tmp.path().join("legacy"), "alpha", "legacy body");
+    write_skill_with_body(&tmp.path().join("canonical"), "alpha", "canonical body");
+
+    let legacy_source = source_uuid("dc256086-0d2f-4f61-a307-320d4148107f");
+    let canonical_source = source_uuid("fe52aa61-1111-4a22-9999-bbbbbbbbbbbb");
+    let skill_name = SkillName::parse("alpha").unwrap();
+    let legacy_key = SkillKey::new(legacy_source.clone(), skill_name.clone());
+    let canonical_key = SkillKey::new(canonical_source.clone(), skill_name);
+    let cfg = SkillsConfig {
+        repositories: vec![
+            fs_repo("legacy", &legacy_source.to_string(), "legacy"),
+            fs_repo("canonical", &canonical_source.to_string(), "canonical"),
+        ],
+        identity: SkillsIdentityConfig {
+            lineage: vec![SourceIdentityLineage {
+                event_id: "legacy-to-canonical".to_string(),
+                recorded_at_unix_secs: 1,
+                required_from_skills: Vec::new(),
+                event: SourceIdentityLineageEvent::RenameOrRelocate {
+                    from: legacy_source,
+                    to: canonical_source,
+                },
+            }],
+            remaps: vec![SkillKeyRemap {
+                from: legacy_key.clone(),
+                to: canonical_key.clone(),
+                reason: Some("test remap".to_string()),
+            }],
+            aliases: Vec::new(),
+        },
+        ..Default::default()
+    };
+
+    let composite = resolve_repositories_with_roots(&cfg, Some(tmp.path()), None, None)
+        .await
+        .unwrap()
+        .expect("resolver returns Some");
+    let doc = composite.load(&legacy_key).await.unwrap();
+
+    assert_eq!(doc.descriptor.key, canonical_key);
+    assert_eq!(doc.descriptor.source_name, "canonical");
+    assert!(
+        doc.body.contains("canonical body"),
+        "remapped direct load must use canonical source body; got {:?}",
+        doc.body
     );
 }
 


### PR DESCRIPTION
## Summary
- Add a registry-aware direct SkillSource load helper for callers outside DefaultSkillEngine.
- Make resolver-built CompositeSkillSource retain the SourceIdentityRegistry and resolve remaps before direct composite loads.
- Add focused direct-source, manual-composite, and resolver-built composite remap coverage.

## Validation
- rg -n "SourceIdentityRegistry|SkillSource::load|CompositeSkillSource|resolve" meerkat-skills/src/engine.rs meerkat-core/src/skills/mod.rs meerkat-skills/src/source/composite.rs
- ./scripts/repo-cargo test -p meerkat-skills source_identity
- ./scripts/repo-cargo test -p meerkat-skills registry_remap
- git diff --check
- make check (BuildBuddy invocation 640d71d3-f04a-4540-a24e-f54f73865a96)

Linear: LUC-59
https://linear.app/lucrfr/issue/LUC-59/dogma-route-direct-skill-source-loads-through-identity-registry