### PR TITLE
Use model capability truth for inline video admission

### DIFF
--- a/meerkat-core/src/model_profile/mod.rs
+++ b/meerkat-core/src/model_profile/mod.rs
@@ -102,6 +102,13 @@ pub fn profile_for(provider: &str, model: &str) -> Option<ModelProfile> {
     capabilities_for(provider, model).map(project_to_profile)
 }
 
+/// Look up whether a model accepts inline video by provider string and model ID.
+///
+/// Returns `None` when the provider/model pair has no capability row.
+pub fn inline_video_support_for(provider: &str, model: &str) -> Option<bool> {
+    capabilities_for(provider, model).map(|caps| caps.inline_video)
+}
+
 /// Project a capability record into the [`ModelProfile`] surface.
 pub(crate) fn project_to_profile(caps: &ModelCapabilities) -> ModelProfile {
     ModelProfile {
@@ -202,6 +209,32 @@ mod tests {
             profile.inline_video,
             "Gemini models must support inline video"
         );
+    }
+
+    #[test]
+    fn all_gemini_profiles_preserve_inline_video_support() {
+        for entry in catalog::catalog()
+            .iter()
+            .filter(|entry| entry.provider == "gemini")
+        {
+            assert!(
+                profile_for(entry.provider, entry.id)
+                    .as_ref()
+                    .is_some_and(|profile| profile.inline_video),
+                "Gemini model '{}' must support inline video",
+                entry.id
+            );
+        }
+    }
+
+    #[test]
+    fn inline_video_support_for_reads_capability_truth() {
+        assert_eq!(
+            inline_video_support_for("gemini", "gemini-3-flash-preview"),
+            Some(true)
+        );
+        assert_eq!(inline_video_support_for("openai", "gpt-5.4"), Some(false));
+        assert_eq!(inline_video_support_for("gemini", "gemini-4-future"), None);
     }
 
     #[test]

--- a/meerkat-session/src/ephemeral.rs
+++ b/meerkat-session/src/ephemeral.rs
@@ -274,7 +274,7 @@ pub trait SessionAgentBuilder: Send + Sync {
     ///
     /// Implementations with a richer configured model registry can override
     /// this; the default uses the built-in model capability catalog.
-    fn model_supports_inline_video(&self, identity: &SessionLlmIdentity) -> Option<bool> {
+    async fn model_supports_inline_video(&self, identity: &SessionLlmIdentity) -> Option<bool> {
         meerkat_core::model_profile::inline_video_support_for(
             identity.provider.as_str(),
             &identity.model,
@@ -675,13 +675,14 @@ impl<B: SessionAgentBuilder + 'static> EphemeralSessionService<B> {
         })
     }
 
-    fn model_supports_inline_video(&self, identity: &SessionLlmIdentity) -> bool {
+    async fn model_supports_inline_video(&self, identity: &SessionLlmIdentity) -> bool {
         self.builder
             .model_supports_inline_video(identity)
+            .await
             .unwrap_or(false)
     }
 
-    fn validate_prompt_video_input(
+    async fn validate_prompt_video_input(
         &self,
         prompt: &ContentInput,
         identity: &SessionLlmIdentity,
@@ -689,7 +690,7 @@ impl<B: SessionAgentBuilder + 'static> EphemeralSessionService<B> {
         validate_prompt_video_input_against_capability(
             prompt,
             identity,
-            self.model_supports_inline_video(identity),
+            self.model_supports_inline_video(identity).await,
         )
     }
 
@@ -1450,7 +1451,8 @@ impl<B: SessionAgentBuilder + 'static> SessionService for EphemeralSessionServic
         let defer_initial_turn =
             req.initial_turn == meerkat_core::service::InitialTurnPolicy::Defer;
         let llm_identity = Self::llm_identity_from_create_request(&req);
-        self.validate_prompt_video_input(&prompt, &llm_identity)?;
+        self.validate_prompt_video_input(&prompt, &llm_identity)
+            .await?;
         let labels = req.labels.clone().unwrap_or_default();
         let resumed_session = req
             .build
@@ -1694,7 +1696,7 @@ impl<B: SessionAgentBuilder + 'static> SessionService for EphemeralSessionServic
                 .get(id)
                 .ok_or_else(|| SessionError::NotFound { id: id.clone() })?;
             let identity = handle.llm_identity_rx.borrow().clone();
-            self.validate_prompt_video_input(&prompt, &identity)?;
+            self.validate_prompt_video_input(&prompt, &identity).await?;
 
             // Atomic busy check via compare-and-swap. This is the single
             // point of admission — if two callers race, exactly one wins.

--- a/meerkat-session/src/ephemeral.rs
+++ b/meerkat-session/src/ephemeral.rs
@@ -270,6 +270,17 @@ pub trait SessionAgentBuilder: Send + Sync {
     #[cfg(target_arch = "wasm32")]
     type Agent: SessionAgent + 'static;
 
+    /// Resolve whether the selected model accepts inline video user content.
+    ///
+    /// Implementations with a richer configured model registry can override
+    /// this; the default uses the built-in model capability catalog.
+    fn model_supports_inline_video(&self, identity: &SessionLlmIdentity) -> Option<bool> {
+        meerkat_core::model_profile::inline_video_support_for(
+            identity.provider.as_str(),
+            &identity.model,
+        )
+    }
+
     /// Build an agent for a new session.
     async fn build_agent(
         &self,
@@ -547,6 +558,30 @@ pub trait SessionAgent: Send {
     }
 }
 
+fn validate_prompt_video_input_against_capability(
+    prompt: &ContentInput,
+    identity: &SessionLlmIdentity,
+    supports_inline_video: bool,
+) -> Result<(), SessionError> {
+    let blocks = match prompt {
+        ContentInput::Text(_) => return Ok(()),
+        ContentInput::Blocks(blocks) => blocks,
+    };
+
+    meerkat_core::validate_inline_video_blocks(blocks)
+        .map_err(|err| SessionError::Agent(AgentError::ConfigError(err)))?;
+
+    if meerkat_core::has_video(blocks) && !supports_inline_video {
+        return Err(SessionError::Agent(AgentError::ConfigError(format!(
+            "inline video input is not supported by model '{}' on provider '{}'",
+            identity.model,
+            identity.provider.as_str()
+        ))));
+    }
+
+    Ok(())
+}
+
 // ---------------------------------------------------------------------------
 // EphemeralSessionService
 // ---------------------------------------------------------------------------
@@ -640,30 +675,22 @@ impl<B: SessionAgentBuilder + 'static> EphemeralSessionService<B> {
         })
     }
 
-    fn provider_supports_inline_video(identity: &SessionLlmIdentity) -> bool {
-        identity.provider == meerkat_core::Provider::Gemini
+    fn model_supports_inline_video(&self, identity: &SessionLlmIdentity) -> bool {
+        self.builder
+            .model_supports_inline_video(identity)
+            .unwrap_or(false)
     }
 
     fn validate_prompt_video_input(
+        &self,
         prompt: &ContentInput,
         identity: &SessionLlmIdentity,
     ) -> Result<(), SessionError> {
-        let blocks = match prompt {
-            ContentInput::Text(_) => return Ok(()),
-            ContentInput::Blocks(blocks) => blocks,
-        };
-
-        meerkat_core::validate_inline_video_blocks(blocks)
-            .map_err(|err| SessionError::Agent(AgentError::ConfigError(err)))?;
-
-        if meerkat_core::has_video(blocks) && !Self::provider_supports_inline_video(identity) {
-            return Err(SessionError::Agent(AgentError::ConfigError(format!(
-                "inline video input requires a Gemini model; current provider is '{}'",
-                identity.provider.as_str()
-            ))));
-        }
-
-        Ok(())
+        validate_prompt_video_input_against_capability(
+            prompt,
+            identity,
+            self.model_supports_inline_video(identity),
+        )
     }
 
     fn validate_tool_result_video(results: &[ToolResult]) -> Result<(), SessionError> {
@@ -1423,7 +1450,7 @@ impl<B: SessionAgentBuilder + 'static> SessionService for EphemeralSessionServic
         let defer_initial_turn =
             req.initial_turn == meerkat_core::service::InitialTurnPolicy::Defer;
         let llm_identity = Self::llm_identity_from_create_request(&req);
-        Self::validate_prompt_video_input(&prompt, &llm_identity)?;
+        self.validate_prompt_video_input(&prompt, &llm_identity)?;
         let labels = req.labels.clone().unwrap_or_default();
         let resumed_session = req
             .build
@@ -1667,7 +1694,7 @@ impl<B: SessionAgentBuilder + 'static> SessionService for EphemeralSessionServic
                 .get(id)
                 .ok_or_else(|| SessionError::NotFound { id: id.clone() })?;
             let identity = handle.llm_identity_rx.borrow().clone();
-            Self::validate_prompt_video_input(&prompt, &identity)?;
+            self.validate_prompt_video_input(&prompt, &identity)?;
 
             // Atomic busy check via compare-and-swap. This is the single
             // point of admission — if two callers race, exactly one wins.
@@ -2848,6 +2875,69 @@ async fn session_task<A: SessionAgent>(
                 break;
             }
         }
+    }
+}
+
+#[cfg(test)]
+mod inline_video_admission_tests {
+    use super::*;
+    use meerkat_core::Provider;
+    use meerkat_core::types::{ContentBlock, VideoData};
+
+    fn identity(provider: Provider, model: &str) -> SessionLlmIdentity {
+        SessionLlmIdentity {
+            model: model.to_string(),
+            provider,
+            self_hosted_server_id: None,
+            provider_params: None,
+            connection_ref: None,
+        }
+    }
+
+    fn inline_video_prompt() -> ContentInput {
+        ContentInput::Blocks(vec![
+            ContentBlock::Text {
+                text: "describe this".to_string(),
+            },
+            ContentBlock::Video {
+                media_type: "video/mp4".to_string(),
+                duration_ms: 1_000,
+                data: VideoData::Inline {
+                    data: "AAAA".to_string(),
+                },
+            },
+        ])
+    }
+
+    #[test]
+    fn provider_gemini_capability_false_rejects_inline_video() {
+        let result = validate_prompt_video_input_against_capability(
+            &inline_video_prompt(),
+            &identity(Provider::Gemini, "gemini-3-flash-preview"),
+            false,
+        );
+
+        let message = match result {
+            Err(SessionError::Agent(AgentError::ConfigError(message))) => Some(message),
+            _ => None,
+        };
+
+        assert!(
+            message
+                .as_deref()
+                .is_some_and(|message| message.contains("not supported by model"))
+        );
+    }
+
+    #[test]
+    fn provider_not_gemini_capability_true_accepts_inline_video() {
+        let result = validate_prompt_video_input_against_capability(
+            &inline_video_prompt(),
+            &identity(Provider::OpenAI, "openai-video-capable-test-model"),
+            true,
+        );
+
+        assert!(result.is_ok());
     }
 }
 

--- a/meerkat/src/service_factory.rs
+++ b/meerkat/src/service_factory.rs
@@ -499,11 +499,12 @@ impl FactoryAgentBuilder {
 impl SessionAgentBuilder for FactoryAgentBuilder {
     type Agent = FactoryAgent;
 
-    fn model_supports_inline_video(
+    async fn model_supports_inline_video(
         &self,
         identity: &meerkat_core::SessionLlmIdentity,
     ) -> Option<bool> {
-        self.config_snapshot
+        self.resolve_config()
+            .await
             .model_registry()
             .ok()
             .and_then(|registry| registry.profile_for(&identity.model))
@@ -715,6 +716,68 @@ mod tests {
     }
 
     struct FakeImageGenerationExecutor;
+
+    #[cfg(not(target_arch = "wasm32"))]
+    fn self_hosted_inline_video_config(inline_video: bool) -> Config {
+        let mut config = Config::default();
+        config.self_hosted.servers.insert(
+            "local".to_string(),
+            meerkat_core::SelfHostedServerConfig {
+                transport: meerkat_core::SelfHostedTransport::OpenAiCompatible,
+                base_url: "http://127.0.0.1:11434".to_string(),
+                api_style: meerkat_core::SelfHostedApiStyle::Responses,
+                bearer_token: None,
+                bearer_token_env: None,
+            },
+        );
+        config.self_hosted.models.insert(
+            "video-alias".to_string(),
+            meerkat_core::SelfHostedModelConfig {
+                server: "local".to_string(),
+                remote_model: "video-model".to_string(),
+                display_name: "Video Alias".to_string(),
+                family: "video-family".to_string(),
+                tier: meerkat_core::model_profile::catalog::ModelTier::Supported,
+                context_window: None,
+                max_output_tokens: None,
+                vision: true,
+                image_tool_results: true,
+                inline_video,
+                supports_temperature: true,
+                supports_thinking: false,
+                supports_reasoning: false,
+                supports_web_search: false,
+                call_timeout_secs: None,
+            },
+        );
+        config
+    }
+
+    #[cfg(not(target_arch = "wasm32"))]
+    #[tokio::test]
+    async fn inline_video_capability_reads_current_config_store() {
+        let initial_config = self_hosted_inline_video_config(false);
+        let current_config = self_hosted_inline_video_config(true);
+        let store: Arc<dyn meerkat_core::ConfigStore> =
+            Arc::new(meerkat_core::MemoryConfigStore::new(current_config));
+        let builder = FactoryAgentBuilder::new_with_config_store(
+            AgentFactory::minimal(),
+            initial_config,
+            store,
+        );
+        let identity = meerkat_core::SessionLlmIdentity {
+            model: "video-alias".to_string(),
+            provider: Provider::SelfHosted,
+            self_hosted_server_id: Some("local".to_string()),
+            provider_params: None,
+            connection_ref: None,
+        };
+
+        assert_eq!(
+            builder.model_supports_inline_video(&identity).await,
+            Some(true)
+        );
+    }
 
     #[async_trait]
     impl ImageGenerationExecutor for FakeImageGenerationExecutor {

--- a/meerkat/src/service_factory.rs
+++ b/meerkat/src/service_factory.rs
@@ -499,6 +499,23 @@ impl FactoryAgentBuilder {
 impl SessionAgentBuilder for FactoryAgentBuilder {
     type Agent = FactoryAgent;
 
+    fn model_supports_inline_video(
+        &self,
+        identity: &meerkat_core::SessionLlmIdentity,
+    ) -> Option<bool> {
+        self.config_snapshot
+            .model_registry()
+            .ok()
+            .and_then(|registry| registry.profile_for(&identity.model))
+            .map(|profile| profile.inline_video)
+            .or_else(|| {
+                meerkat_core::model_profile::inline_video_support_for(
+                    identity.provider.as_str(),
+                    &identity.model,
+                )
+            })
+    }
+
     async fn build_agent(
         &self,
         req: &CreateSessionRequest,


### PR DESCRIPTION
## Summary
- route ephemeral inline-video admission through model capability/profile truth instead of provider-name policy
- add a catalog helper for `ModelCapabilities.inline_video` and preserve Gemini profile coverage
- add focused mismatch tests for Gemini provider + false capability and non-Gemini provider + true capability

## Validation
- `make fmt`
- `./scripts/repo-cargo test -p meerkat-session inline_video_admission_tests`
- `./scripts/repo-cargo test -p meerkat-core inline_video_support_for_reads_capability_truth`
- `./scripts/repo-cargo test -p meerkat-core all_gemini_profiles_preserve_inline_video_support`
- `./scripts/repo-cargo check -p meerkat`
- `make check` (BuildBuddy invocation `2bf85fa0-ef51-4561-a4a0-0cb471812a6d`)

Linear: LUC-57