### PR TITLE
LUC-58 Derive auth status from typed phase

### DIFF
--- a/meerkat-cli/src/main.rs
+++ b/meerkat-cli/src/main.rs
@@ -37,8 +37,8 @@ use meerkat_core::service::{
     SessionService, SessionServiceCommsExt, StartTurnRequest, TurnToolOverlay,
 };
 use meerkat_core::{
-    AgentEvent, BlobId, ConnectionRef, EventEnvelope, RealmConfig, RealmLocator, RealmSelection,
-    ScopedAgentEvent, StreamScopeFrame, format_verbose_event,
+    AgentEvent, AuthStatusPhase, BlobId, ConnectionRef, EventEnvelope, RealmConfig, RealmLocator,
+    RealmSelection, ScopedAgentEvent, StreamScopeFrame, format_verbose_event,
 };
 use meerkat_core::{
     Config, ConfigDelta, ConfigEnvelope, ConfigEnvelopePolicy, ConfigStore, FileConfigStore,
@@ -2891,7 +2891,7 @@ async fn handle_auth_command(command: AuthCommands, scope: &RuntimeScope) -> any
             };
             match registry.resolve(&realm_set, &connection_ref, &env).await {
                 Ok(conn) => {
-                    println!("state: valid");
+                    println!("state: {}", AuthStatusPhase::Valid.as_public_str());
                     println!("provider: {}", conn.provider.as_str());
                     println!("backend_profile_id: {}", conn.backend_profile.id);
                     println!(
@@ -2936,7 +2936,9 @@ async fn handle_auth_command(command: AuthCommands, scope: &RuntimeScope) -> any
                     .map_err(|e| anyhow::anyhow!("TokenStore load failed: {e}"))?
                 {
                     Some(tokens) => {
-                        println!("state:       present");
+                        let state_phase =
+                            AuthStatusPhase::from_persisted_tokens(Utc::now(), Some(&tokens));
+                        println!("state:       {}", state_phase.as_public_str());
                         println!("auth_mode:   {:?}", tokens.auth_mode);
                         println!(
                             "has_secret:  {}",
@@ -2969,7 +2971,7 @@ async fn handle_auth_command(command: AuthCommands, scope: &RuntimeScope) -> any
                         println!("backend:     {}", store.backend_name());
                     }
                     None => {
-                        println!("state:       absent");
+                        println!("state:       {}", AuthStatusPhase::Unknown.as_public_str());
                         println!("backend:     {}", store.backend_name());
                         println!(
                             "note:        no persisted credential for '{realm}:{profile_id}';"
@@ -2983,7 +2985,10 @@ async fn handle_auth_command(command: AuthCommands, scope: &RuntimeScope) -> any
             }
             #[cfg(not(all(feature = "anthropic", feature = "openai", feature = "gemini")))]
             {
-                println!("state:       unknown (TokenStore disabled at build time)");
+                println!(
+                    "state:       {} (TokenStore disabled at build time)",
+                    AuthStatusPhase::Unknown.as_public_str()
+                );
             }
         }
         AuthCommands::ProfileDelete {

--- a/meerkat-core/src/auth/mod.rs
+++ b/meerkat-core/src/auth/mod.rs
@@ -27,7 +27,7 @@ pub use principal::{
     PrincipalKind, PrincipalRef, VisibilityClass, can_observe_visibility,
     metadata_grants_no_visibility,
 };
-pub use status::{AuthErrorSummary, AuthStatus};
+pub use status::{AuthErrorSummary, AuthStatus, AuthStatusPhase};
 pub use token_store::{
     PersistedAuthMode, PersistedTokens, RefreshCoordinator, RefreshError, RefreshFn, TokenKey,
     TokenStore, TokenStoreError,

--- a/meerkat-core/src/auth/status.rs
+++ b/meerkat-core/src/auth/status.rs
@@ -4,7 +4,68 @@ use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 
 use super::error::AuthErrorKind;
+use super::token_store::PersistedTokens;
+use crate::handles::{AUTH_LEASE_TTL_REFRESH_WINDOW_SECS, AuthLeasePhase};
 use crate::provider::Provider;
+
+/// Public auth status phase shared by REST, RPC, CLI, and generated SDK wire
+/// payloads.
+///
+/// This is the compatibility projection of typed auth lease truth. Surfaces
+/// should map to this enum first and only then emit [`Self::as_public_str`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
+#[serde(rename_all = "snake_case")]
+pub enum AuthStatusPhase {
+    Valid,
+    Expiring,
+    Expired,
+    ReauthRequired,
+    RefreshFailed,
+    Unknown,
+}
+
+impl AuthStatusPhase {
+    pub const fn as_public_str(self) -> &'static str {
+        match self {
+            Self::Valid => "valid",
+            Self::Expiring => "expiring",
+            Self::Expired => "expired",
+            Self::ReauthRequired => "reauth_required",
+            Self::RefreshFailed => "refresh_failed",
+            Self::Unknown => "unknown",
+        }
+    }
+
+    pub const fn from_lease_phase(phase: Option<AuthLeasePhase>) -> Self {
+        match phase {
+            Some(AuthLeasePhase::Valid) => Self::Valid,
+            Some(AuthLeasePhase::Expiring) | Some(AuthLeasePhase::Refreshing) => Self::Expiring,
+            Some(AuthLeasePhase::ReauthRequired) => Self::ReauthRequired,
+            Some(AuthLeasePhase::Released) | None => Self::Unknown,
+        }
+    }
+
+    pub fn from_persisted_tokens(now: DateTime<Utc>, tokens: Option<&PersistedTokens>) -> Self {
+        match tokens {
+            Some(tokens) => Self::from_expires_at(now, tokens.expires_at),
+            None => Self::Unknown,
+        }
+    }
+
+    pub fn from_expires_at(now: DateTime<Utc>, expires_at: Option<DateTime<Utc>>) -> Self {
+        match expires_at {
+            Some(expires_at) if expires_at <= now => Self::Expired,
+            Some(expires_at)
+                if expires_at - now
+                    < chrono::Duration::seconds(AUTH_LEASE_TTL_REFRESH_WINDOW_SECS as i64) =>
+            {
+                Self::Expiring
+            }
+            Some(_) | None => Self::Valid,
+        }
+    }
+}
 
 /// Status snapshot of a resolved (or unresolved) auth profile.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
@@ -44,6 +105,21 @@ pub struct AuthErrorSummary {
 #[allow(clippy::unwrap_used, clippy::expect_used, clippy::panic)]
 mod tests {
     use super::*;
+    use chrono::{Duration, TimeZone};
+
+    fn tokens_with_expiry(expires_at: Option<DateTime<Utc>>) -> PersistedTokens {
+        PersistedTokens {
+            auth_mode: crate::auth::PersistedAuthMode::ApiKey,
+            primary_secret: Some("secret".into()),
+            refresh_token: None,
+            id_token: None,
+            expires_at,
+            last_refresh: None,
+            scopes: Vec::new(),
+            account_id: None,
+            metadata: serde_json::Value::Null,
+        }
+    }
 
     #[test]
     fn auth_status_roundtrip() {
@@ -76,6 +152,44 @@ mod tests {
         let back: AuthErrorSummary = serde_json::from_str(&s).unwrap();
         assert_eq!(back.kind, summary.kind);
         assert_eq!(back.message, summary.message);
+    }
+
+    #[test]
+    fn auth_status_phase_maps_persisted_token_expiry_to_public_values() {
+        let now = Utc.with_ymd_and_hms(2026, 4, 28, 12, 0, 0).unwrap();
+
+        let valid = tokens_with_expiry(Some(now + Duration::minutes(10)));
+        assert_eq!(
+            AuthStatusPhase::from_persisted_tokens(now, Some(&valid)).as_public_str(),
+            "valid"
+        );
+
+        let expired = tokens_with_expiry(Some(now - Duration::seconds(1)));
+        assert_eq!(
+            AuthStatusPhase::from_persisted_tokens(now, Some(&expired)).as_public_str(),
+            "expired"
+        );
+
+        assert_eq!(
+            AuthStatusPhase::from_persisted_tokens(now, None).as_public_str(),
+            "unknown"
+        );
+    }
+
+    #[test]
+    fn auth_status_phase_maps_typed_lease_phase_to_public_values() {
+        assert_eq!(
+            AuthStatusPhase::from_lease_phase(Some(AuthLeasePhase::Valid)).as_public_str(),
+            "valid"
+        );
+        assert_eq!(
+            AuthStatusPhase::from_lease_phase(Some(AuthLeasePhase::Expiring)).as_public_str(),
+            "expiring"
+        );
+        assert_eq!(
+            AuthStatusPhase::from_lease_phase(None).as_public_str(),
+            "unknown"
+        );
     }
 
     #[cfg(feature = "schema")]

--- a/meerkat-core/src/auth/status.rs
+++ b/meerkat-core/src/auth/status.rs
@@ -40,7 +40,7 @@ impl AuthStatusPhase {
     pub const fn from_lease_phase(phase: Option<AuthLeasePhase>) -> Self {
         match phase {
             Some(AuthLeasePhase::Valid) => Self::Valid,
-            Some(AuthLeasePhase::Expiring) | Some(AuthLeasePhase::Refreshing) => Self::Expiring,
+            Some(AuthLeasePhase::Expiring | AuthLeasePhase::Refreshing) => Self::Expiring,
             Some(AuthLeasePhase::ReauthRequired) => Self::ReauthRequired,
             Some(AuthLeasePhase::Released) | None => Self::Unknown,
         }

--- a/meerkat-core/src/lib.rs
+++ b/meerkat-core/src/lib.rs
@@ -282,9 +282,9 @@ pub use types::{
 pub use auth::{
     AnthropicAuthMetadata, AnthropicRouteHints, AuthConstraints, AuthError, AuthErrorKind,
     AuthErrorSummary, AuthLease, AuthMetadata, AuthMetadataDefaults, AuthRefreshReason,
-    AuthRouteHints, AuthStatus, GoogleAuthMetadata, GoogleRouteHints, HttpAuthorizationRequest,
-    HttpAuthorizer, OpenAiAuthMetadata, OpenAiRouteHints, ProviderAuthMetadata,
-    ResolvedAuthEnvelope, ResolvedAuthKind,
+    AuthRouteHints, AuthStatus, AuthStatusPhase, GoogleAuthMetadata, GoogleRouteHints,
+    HttpAuthorizationRequest, HttpAuthorizer, OpenAiAuthMetadata, OpenAiRouteHints,
+    ProviderAuthMetadata, ResolvedAuthEnvelope, ResolvedAuthKind,
 };
 pub use connection::{
     AuthProfile, AuthProfileConfig, BackendProfile, BackendProfileConfig, BindingId, BindingPolicy,

--- a/meerkat-rest/src/auth_endpoints.rs
+++ b/meerkat-rest/src/auth_endpoints.rs
@@ -26,7 +26,8 @@ use meerkat_contracts::{
 };
 use meerkat_core::connection::{BindingId, ConnectionTargetError, ProfileId, RealmId};
 use meerkat_core::{
-    ConnectionRef, CredentialSourceSpec, Provider, RealmConnectionSet, ResolvedConnectionTarget,
+    AuthStatusPhase, ConnectionRef, CredentialSourceSpec, Provider, RealmConnectionSet,
+    ResolvedConnectionTarget,
 };
 use meerkat_gemini::runtime::oauth as g_oauth;
 use meerkat_openai::runtime::oauth as o_oauth;
@@ -1028,22 +1029,7 @@ pub async fn get_auth_status(
                 .into_response();
         }
     };
-    let state_label = match &stored {
-        Some(t) => {
-            if let Some(expiry) = t.expires_at {
-                if expiry - chrono::Utc::now() < chrono::Duration::zero() {
-                    "expired"
-                } else if expiry - chrono::Utc::now() < chrono::Duration::seconds(60) {
-                    "expiring"
-                } else {
-                    "valid"
-                }
-            } else {
-                "valid"
-            }
-        }
-        None => "unknown",
-    };
+    let state_phase = AuthStatusPhase::from_persisted_tokens(chrono::Utc::now(), stored.as_ref());
     (
         StatusCode::OK,
         Json(WireAuthStatusDetail {
@@ -1051,7 +1037,7 @@ pub async fn get_auth_status(
             profile_id: auth_profile.id.clone(),
             provider: auth_profile.provider.as_str().to_string(),
             auth_method: auth_profile.auth_method.clone(),
-            state: state_label.to_string(),
+            state: state_phase.as_public_str().to_string(),
             expires_at: stored
                 .as_ref()
                 .and_then(|t| t.expires_at.map(|e| e.to_rfc3339())),

--- a/meerkat-rpc/src/handlers/auth.rs
+++ b/meerkat-rpc/src/handlers/auth.rs
@@ -16,8 +16,8 @@ use meerkat_contracts::{
     WireProviderBinding, WireRealmConnectionSet,
 };
 use meerkat_core::{
-    ConnectionRef, ConnectionTargetError, CredentialSourceSpec, Provider, RealmConnectionSet,
-    ResolvedConnectionTarget,
+    AuthStatusPhase, ConnectionRef, ConnectionTargetError, CredentialSourceSpec, Provider,
+    RealmConnectionSet, ResolvedConnectionTarget,
 };
 use meerkat_gemini::runtime::oauth as g_oauth;
 use meerkat_openai::runtime::oauth as o_oauth;
@@ -1055,14 +1055,7 @@ pub async fn handle_auth_status_get(
     } else {
         None
     };
-    let state_label = match &stored {
-        Some(t) => match t.expires_at {
-            Some(exp) if exp - chrono::Utc::now() < chrono::Duration::zero() => "expired",
-            Some(exp) if exp - chrono::Utc::now() < chrono::Duration::seconds(60) => "expiring",
-            _ => "valid",
-        },
-        None => "unknown",
-    };
+    let state_phase = AuthStatusPhase::from_persisted_tokens(chrono::Utc::now(), stored.as_ref());
     RpcResponse::success(
         id,
         WireAuthStatusDetail {
@@ -1070,7 +1063,7 @@ pub async fn handle_auth_status_get(
             profile_id: auth_profile.id,
             provider: auth_profile.provider.as_str().to_string(),
             auth_method: auth_profile.auth_method,
-            state: state_label.to_string(),
+            state: state_phase.as_public_str().to_string(),
             expires_at: stored
                 .as_ref()
                 .and_then(|t| t.expires_at.map(|e| e.to_rfc3339())),


### PR DESCRIPTION
## Summary
- add shared `AuthStatusPhase` projection for typed auth lease/status truth and public compatibility strings
- route REST, RPC, and CLI auth status output through the shared phase helper
- cover valid, expired, unknown, and typed lease phase mappings in focused core tests

## Validation
- `make fmt`
- `./scripts/repo-cargo test -p meerkat-core auth_status_phase`
- `./scripts/repo-cargo check -p meerkat-core -p meerkat-rpc -p meerkat-rest -p rkat`
- `make check` (`MEERKAT_BUILDBUDDY=1`)
- `git diff --check`

Linear: https://linear.app/lucrfr/issue/LUC-58/dogma-derive-auth-status-phase-from-typed-auth-lease-truth