### PR TITLE
LUC-68: Remove SDK event semantic defaults

### DIFF
--- a/sdks/python/meerkat/events.py
+++ b/sdks/python/meerkat/events.py
@@ -4,8 +4,8 @@ Every event emitted by the agent loop is represented as a frozen dataclass,
 enabling ``match``/``case`` pattern matching (Python 3.10+) and IDE
 autocompletion on event fields.
 
-Most fields intentionally default to empty/zero values so partially delivered
-streaming payloads can still be parsed into typed events.
+Missing semantic fields remain absent so partially delivered streaming payloads
+do not become authoritative SDK state.
 
 Example::
 
@@ -129,14 +129,14 @@ class ToolResultReceived(Event):
 
     id: str = ""
     name: str = ""
-    is_error: bool = False
+    is_error: bool | None = None
 
 
 @dataclass(frozen=True, slots=True)
 class TurnCompleted(Event):
     """An LLM turn finished."""
 
-    stop_reason: str = ""
+    stop_reason: str | None = None
     usage: Usage = field(default_factory=Usage)
 
 
@@ -159,7 +159,7 @@ class ToolExecutionCompleted(Event):
     id: str = ""
     name: str = ""
     result: str = ""
-    is_error: bool = False
+    is_error: bool | None = None
     duration_ms: int = 0
 
 
@@ -304,7 +304,7 @@ class SkillsResolved(Event):
 class SkillResolutionFailureReason:
     """Structured reason a skill reference could not be resolved."""
 
-    reason_type: str = "unknown"
+    reason_type: str | None = None
     key: SkillKey | None = None
     capability: str | None = None
     message: str = ""
@@ -330,7 +330,7 @@ class SkillResolutionFailed(Event):
     """A skill reference could not be resolved."""
 
     skill_key: SkillKey | None = None
-    reason: SkillResolutionFailureReason = field(default_factory=SkillResolutionFailureReason)
+    reason: SkillResolutionFailureReason | None = None
     reference: str = ""
     error: str = ""
 
@@ -370,10 +370,10 @@ class StreamTruncated(Event):
 class ToolConfigChangedPayload:
     """Payload for tool configuration change notifications."""
 
-    operation: str = ""
-    target: str = ""
-    status: str = ""
-    persisted: bool = False
+    operation: str | None = None
+    target: str | None = None
+    status: str | None = None
+    persisted: bool | None = None
     applied_at_turn: int | None = None
 
 
@@ -418,6 +418,17 @@ class UnknownEvent(Event):
 # ---------------------------------------------------------------------------
 
 _USAGE_DEFAULTS = Usage()
+
+_STOP_REASONS = frozenset({
+    "end_turn",
+    "tool_use",
+    "max_tokens",
+    "stop_sequence",
+    "content_filter",
+    "cancelled",
+})
+
+_TOOL_CONFIG_OPERATIONS = frozenset({"add", "remove", "reload"})
 
 _EVENT_MAP: dict[str, type[Event]] = {
     "run_started": RunStarted,
@@ -475,14 +486,36 @@ def _parse_skill_key(raw: Any) -> SkillKey | None:
     )
 
 
+def _parse_optional_str(raw: Any) -> str | None:
+    return raw if isinstance(raw, str) else None
+
+
+def _parse_optional_bool(raw: Any) -> bool | None:
+    return raw if isinstance(raw, bool) else None
+
+
+def _parse_optional_int(raw: Any) -> int | None:
+    return raw if isinstance(raw, int) and not isinstance(raw, bool) else None
+
+
+def _parse_stop_reason(raw: Any) -> str | None:
+    return raw if isinstance(raw, str) and raw in _STOP_REASONS else None
+
+
+def _parse_tool_config_operation(raw: Any) -> str | None:
+    return raw if isinstance(raw, str) and raw in _TOOL_CONFIG_OPERATIONS else None
+
+
 def _parse_skill_resolution_failure_reason(
     raw: Any,
     fallback_message: str,
-) -> SkillResolutionFailureReason:
+) -> SkillResolutionFailureReason | None:
     if not isinstance(raw, dict):
-        return SkillResolutionFailureReason(message=fallback_message)
+        return None
 
-    reason_type = str(raw.get("reason_type", raw.get("reasonType", "unknown")))
+    reason_type = raw.get("reason_type", raw.get("reasonType"))
+    if not isinstance(reason_type, str):
+        return None
     known_reason_types = {
         "not_found",
         "capability_unavailable",
@@ -552,6 +585,10 @@ def parse_event(raw: dict[str, Any]) -> Event:
     for f in cls.__dataclass_fields__:
         if f == "usage":
             kwargs["usage"] = _parse_usage(raw.get("usage"))
+        elif f == "stop_reason" and cls is TurnCompleted:
+            kwargs["stop_reason"] = _parse_stop_reason(raw.get("stop_reason"))
+        elif f == "is_error" and cls in {ToolResultReceived, ToolExecutionCompleted}:
+            kwargs["is_error"] = _parse_optional_bool(raw.get("is_error"))
         elif f == "skill_key" and cls is SkillResolutionFailed:
             kwargs["skill_key"] = _parse_skill_key(raw.get("skill_key"))
         elif f == "reason" and cls is SkillResolutionFailed:
@@ -562,19 +599,12 @@ def parse_event(raw: dict[str, Any]) -> Event:
         elif f == "payload" and cls is ToolConfigChanged:
             payload_raw = raw.get("payload", {})
             if isinstance(payload_raw, dict):
-                applied_at_turn_raw = payload_raw.get("applied_at_turn")
-                applied_at_turn: int | None
-                if isinstance(applied_at_turn_raw, int):
-                    applied_at_turn = applied_at_turn_raw
-                else:
-                    applied_at_turn = None
-                persisted_raw = payload_raw.get("persisted", False)
                 kwargs["payload"] = ToolConfigChangedPayload(
-                    operation=str(payload_raw.get("operation", "")),
-                    target=str(payload_raw.get("target", "")),
-                    status=str(payload_raw.get("status", "")),
-                    persisted=persisted_raw if isinstance(persisted_raw, bool) else False,
-                    applied_at_turn=applied_at_turn,
+                    operation=_parse_tool_config_operation(payload_raw.get("operation")),
+                    target=_parse_optional_str(payload_raw.get("target")),
+                    status=_parse_optional_str(payload_raw.get("status")),
+                    persisted=_parse_optional_bool(payload_raw.get("persisted")),
+                    applied_at_turn=_parse_optional_int(payload_raw.get("applied_at_turn")),
                 )
             else:
                 kwargs["payload"] = ToolConfigChangedPayload()

--- a/sdks/python/tests/test_types.py
+++ b/sdks/python/tests/test_types.py
@@ -630,10 +630,10 @@ def test_parse_tool_config_changed_with_malformed_payload():
     }
     event = parse_event(raw)
     assert isinstance(event, ToolConfigChanged)
-    assert event.payload.operation == ""
-    assert event.payload.target == ""
-    assert event.payload.status == ""
-    assert event.payload.persisted is False
+    assert event.payload.operation is None
+    assert event.payload.target is None
+    assert event.payload.status is None
+    assert event.payload.persisted is None
     assert event.payload.applied_at_turn is None
 
 
@@ -665,7 +665,25 @@ def test_parse_tool_config_changed_with_non_boolean_persisted():
     }
     event = parse_event(raw)
     assert isinstance(event, ToolConfigChanged)
-    assert event.payload.persisted is False
+    assert event.payload.persisted is None
+
+
+def test_parse_tool_config_changed_with_malformed_operation_status_semantics():
+    raw = {
+        "type": "tool_config_changed",
+        "payload": {
+            "operation": "bogus",
+            "target": 0,
+            "status": 0,
+            "persisted": "false",
+        },
+    }
+    event = parse_event(raw)
+    assert isinstance(event, ToolConfigChanged)
+    assert event.payload.operation is None
+    assert event.payload.target is None
+    assert event.payload.status is None
+    assert event.payload.persisted is None
 
 
 def test_parse_turn_completed_with_usage():
@@ -680,6 +698,19 @@ def test_parse_turn_completed_with_usage():
     assert event.usage.input_tokens == 50
     assert event.usage.output_tokens == 20
     assert event.usage.cache_creation_tokens is None
+
+
+def test_parse_turn_completed_does_not_default_missing_or_malformed_stop_reason():
+    missing = parse_event({"type": "turn_completed"})
+    invalid_string = parse_event({"type": "turn_completed", "stop_reason": "not_real"})
+    non_string = parse_event({"type": "turn_completed", "stop_reason": 0})
+
+    assert isinstance(missing, TurnCompleted)
+    assert isinstance(invalid_string, TurnCompleted)
+    assert isinstance(non_string, TurnCompleted)
+    assert missing.stop_reason is None
+    assert invalid_string.stop_reason is None
+    assert non_string.stop_reason is None
 
 
 def test_parse_run_completed():
@@ -709,6 +740,27 @@ def test_parse_tool_execution_completed():
     assert isinstance(event, ToolExecutionCompleted)
     assert event.name == "search"
     assert event.duration_ms == 42
+    assert event.is_error is False
+
+
+def test_parse_tool_execution_completed_does_not_coerce_missing_or_malformed_is_error():
+    missing = parse_event({
+        "type": "tool_execution_completed",
+        "id": "t1",
+        "name": "search",
+        "result": "found it",
+    })
+    malformed = parse_event({
+        "type": "tool_execution_completed",
+        "id": "t1",
+        "name": "search",
+        "result": "found it",
+        "is_error": "false",
+    })
+    assert isinstance(missing, ToolExecutionCompleted)
+    assert isinstance(malformed, ToolExecutionCompleted)
+    assert missing.is_error is None
+    assert malformed.is_error is None
 
 
 def test_parse_unknown_event_type():
@@ -781,10 +833,21 @@ def test_parse_legacy_skill_resolution_failed_payload():
     event = parse_event(raw)
     assert isinstance(event, SkillResolutionFailed)
     assert event.skill_key is None
-    assert event.reason.reason_type == "unknown"
-    assert event.reason.message == "missing"
+    assert event.reason is None
     assert event.reference == "legacy/ref"
     assert event.error == "missing"
+
+
+def test_parse_skill_resolution_failed_does_not_fabricate_malformed_reason():
+    raw = {
+        "type": "skill_resolution_failed",
+        "reason": {"reason_type": 0, "message": "bad"},
+        "reference": "legacy/ref",
+        "error": "missing",
+    }
+    event = parse_event(raw)
+    assert isinstance(event, SkillResolutionFailed)
+    assert event.reason is None
 
 
 def test_parse_inline_video_content_block():

--- a/sdks/typescript/src/client.ts
+++ b/sdks/typescript/src/client.ts
@@ -1664,13 +1664,29 @@ export class MeerkatClient {
   }
 
   private static parseAgentEventEnvelope(raw: Record<string, unknown>): AgentEventEnvelope {
+    const eventId = MeerkatClient.parseOptionalString(raw.event_id ?? raw.eventId);
+    const sourceId = MeerkatClient.parseOptionalString(raw.source_id ?? raw.sourceId);
+    const seq = MeerkatClient.parseOptionalNumber(raw.seq);
+    const timestampMs = MeerkatClient.parseOptionalNumber(raw.timestamp_ms ?? raw.timestampMs);
+    const payloadRaw = raw.payload;
+    const payload = payloadRaw && typeof payloadRaw === "object"
+      ? parseCoreEvent(payloadRaw as Record<string, unknown>)
+      : undefined;
     return {
-      eventId: String(raw.event_id ?? raw.eventId ?? ""),
-      sourceId: String(raw.source_id ?? raw.sourceId ?? ""),
-      seq: Number(raw.seq ?? 0),
-      timestampMs: Number(raw.timestamp_ms ?? raw.timestampMs ?? 0),
-      payload: parseCoreEvent((raw.payload ?? {}) as Record<string, unknown>),
+      ...(eventId != null ? { eventId } : {}),
+      ...(sourceId != null ? { sourceId } : {}),
+      ...(seq != null ? { seq } : {}),
+      ...(timestampMs != null ? { timestampMs } : {}),
+      ...(payload ? { payload } : {}),
     };
+  }
+
+  private static parseOptionalString(raw: unknown): string | undefined {
+    return typeof raw === "string" ? raw : undefined;
+  }
+
+  private static parseOptionalNumber(raw: unknown): number | undefined {
+    return typeof raw === "number" && Number.isFinite(raw) ? raw : undefined;
   }
 
   private static parseAttributedMobEvent(raw: Record<string, unknown>): AttributedMobEvent {

--- a/sdks/typescript/src/events.ts
+++ b/sdks/typescript/src/events.ts
@@ -3,8 +3,8 @@
  *
  * Events form a discriminated union on the `type` field (snake_case to match
  * the wire protocol).  All other fields use idiomatic camelCase.
- * Missing fields are defaulted during parsing so partial streaming payloads
- * can still be represented as typed events.
+ * Missing semantic fields remain absent during parsing so partial streaming
+ * payloads do not become authoritative SDK state.
  *
  * @example
  * ```ts
@@ -174,12 +174,12 @@ export interface ToolResultReceivedEvent {
   readonly type: "tool_result_received";
   readonly id: string;
   readonly name: string;
-  readonly isError: boolean;
+  readonly isError?: boolean;
 }
 
 export interface TurnCompletedEvent {
   readonly type: "turn_completed";
-  readonly stopReason: StopReason;
+  readonly stopReason?: StopReason;
   readonly usage: Usage;
 }
 
@@ -198,7 +198,7 @@ export interface ToolExecutionCompletedEvent {
   readonly id: string;
   readonly name: string;
   readonly result: string;
-  readonly isError: boolean;
+  readonly isError?: boolean;
   readonly durationMs: number;
 }
 
@@ -345,7 +345,7 @@ export type SkillResolutionFailureReason =
 export interface SkillResolutionFailedEvent {
   readonly type: "skill_resolution_failed";
   readonly skillKey?: SkillKey;
-  readonly reason: SkillResolutionFailureReason;
+  readonly reason?: SkillResolutionFailureReason;
   /** Legacy display mirror. Prefer `skillKey` when present. */
   readonly reference: string;
   /** Legacy display mirror. Prefer `reason` for structured handling. */
@@ -380,10 +380,10 @@ export interface StreamTruncatedEvent {
 export type ToolConfigChangeOperation = "add" | "remove" | "reload";
 
 export interface ToolConfigChangedPayload {
-  readonly operation: ToolConfigChangeOperation;
-  readonly target: string;
-  readonly status: string;
-  readonly persisted: boolean;
+  readonly operation?: ToolConfigChangeOperation;
+  readonly target?: string;
+  readonly status?: string;
+  readonly persisted?: boolean;
   readonly applied_at_turn?: number;
 }
 
@@ -510,16 +510,55 @@ function emptySkillKey(): SkillKey {
   return { sourceUuid: "", skillName: "" };
 }
 
+const STOP_REASONS = new Set<StopReason>([
+  "end_turn",
+  "tool_use",
+  "max_tokens",
+  "stop_sequence",
+  "content_filter",
+  "cancelled",
+]);
+
+function parseStopReason(raw: unknown): StopReason | undefined {
+  return typeof raw === "string" && STOP_REASONS.has(raw as StopReason)
+    ? (raw as StopReason)
+    : undefined;
+}
+
+const TOOL_CONFIG_CHANGE_OPERATIONS = new Set<ToolConfigChangeOperation>([
+  "add",
+  "remove",
+  "reload",
+]);
+
+function parseToolConfigChangeOperation(raw: unknown): ToolConfigChangeOperation | undefined {
+  return typeof raw === "string" && TOOL_CONFIG_CHANGE_OPERATIONS.has(raw as ToolConfigChangeOperation)
+    ? (raw as ToolConfigChangeOperation)
+    : undefined;
+}
+
+function parseWireString(raw: unknown): string | undefined {
+  return typeof raw === "string" ? raw : undefined;
+}
+
+function parseWireBoolean(raw: unknown): boolean | undefined {
+  return typeof raw === "boolean" ? raw : undefined;
+}
+
 function parseSkillResolutionFailureReason(
   raw: unknown,
   fallbackMessage: string,
-): SkillResolutionFailureReason {
+): SkillResolutionFailureReason | undefined {
   if (raw == null || typeof raw !== "object") {
-    return { reasonType: "unknown", message: fallbackMessage };
+    return undefined;
   }
 
   const value = raw as Record<string, unknown>;
-  const reasonType = String(value.reason_type ?? value.reasonType ?? "unknown");
+  const reasonTypeRaw = value.reason_type ?? value.reasonType;
+  if (typeof reasonTypeRaw !== "string") {
+    return undefined;
+  }
+  const reasonType = reasonTypeRaw;
   switch (reasonType) {
     case "not_found":
       return { reasonType, key: parseSkillKey(value.key) ?? emptySkillKey() };
@@ -652,16 +691,38 @@ export function parseCoreEvent(raw: Record<string, unknown>): AgentEvent {
       return { type, content: String(raw.content ?? "") };
     case "tool_call_requested":
       return { type, id: String(raw.id ?? ""), name: String(raw.name ?? ""), args: raw.args };
-    case "tool_result_received":
-      return { type, id: String(raw.id ?? ""), name: String(raw.name ?? ""), isError: Boolean(raw.is_error) };
-    case "turn_completed":
-      return { type, stopReason: String(raw.stop_reason ?? "end_turn") as StopReason, usage: parseUsage(raw.usage as Record<string, unknown>) };
+    case "tool_result_received": {
+      const isError = parseWireBoolean(raw.is_error);
+      return {
+        type,
+        id: String(raw.id ?? ""),
+        name: String(raw.name ?? ""),
+        ...(isError != null ? { isError } : {}),
+      };
+    }
+    case "turn_completed": {
+      const stopReason = parseStopReason(raw.stop_reason);
+      return {
+        type,
+        ...(stopReason != null ? { stopReason } : {}),
+        usage: parseUsage(raw.usage as Record<string, unknown>),
+      };
+    }
 
     // Tool execution
     case "tool_execution_started":
       return { type, id: String(raw.id ?? ""), name: String(raw.name ?? "") };
-    case "tool_execution_completed":
-      return { type, id: String(raw.id ?? ""), name: String(raw.name ?? ""), result: String(raw.result ?? ""), isError: Boolean(raw.is_error), durationMs: Number(raw.duration_ms ?? 0) };
+    case "tool_execution_completed": {
+      const isError = parseWireBoolean(raw.is_error);
+      return {
+        type,
+        id: String(raw.id ?? ""),
+        name: String(raw.name ?? ""),
+        result: String(raw.result ?? ""),
+        ...(isError != null ? { isError } : {}),
+        durationMs: Number(raw.duration_ms ?? 0),
+      };
+    }
     case "tool_execution_timed_out":
       return { type, id: String(raw.id ?? ""), name: String(raw.name ?? ""), timeoutMs: Number(raw.timeout_ms ?? 0) };
 
@@ -701,10 +762,11 @@ export function parseCoreEvent(raw: Record<string, unknown>): AgentEvent {
     case "skill_resolution_failed": {
       const error = String(raw.error ?? "");
       const skillKey = parseSkillKey(raw.skill_key);
+      const reason = parseSkillResolutionFailureReason(raw.reason, error);
       return {
         type,
         ...(skillKey ? { skillKey } : {}),
-        reason: parseSkillResolutionFailureReason(raw.reason, error),
+        ...(reason ? { reason } : {}),
         reference: String(raw.reference ?? ""),
         error,
       };
@@ -722,18 +784,22 @@ export function parseCoreEvent(raw: Record<string, unknown>): AgentEvent {
     case "tool_config_changed": {
       const payloadRaw = typeof raw.payload === "object" && raw.payload !== null
         ? (raw.payload as Record<string, unknown>)
-        : {};
-      const appliedAtTurnRaw = payloadRaw.applied_at_turn;
+        : undefined;
+      const appliedAtTurnRaw = payloadRaw?.applied_at_turn;
       const appliedAtTurn = typeof appliedAtTurnRaw === "number" && Number.isFinite(appliedAtTurnRaw)
         ? appliedAtTurnRaw
         : undefined;
+      const operation = parseToolConfigChangeOperation(payloadRaw?.operation);
+      const target = parseWireString(payloadRaw?.target);
+      const status = parseWireString(payloadRaw?.status);
+      const persisted = parseWireBoolean(payloadRaw?.persisted);
       return {
         type,
         payload: {
-          operation: String(payloadRaw.operation ?? "reload") as ToolConfigChangeOperation,
-          target: String(payloadRaw.target ?? ""),
-          status: String(payloadRaw.status ?? ""),
-          persisted: typeof payloadRaw.persisted === "boolean" ? payloadRaw.persisted : false,
+          ...(operation != null ? { operation } : {}),
+          ...(target != null ? { target } : {}),
+          ...(status != null ? { status } : {}),
+          ...(persisted != null ? { persisted } : {}),
           ...(appliedAtTurn != null ? { applied_at_turn: appliedAtTurn } : {}),
         },
       };

--- a/sdks/typescript/src/types.ts
+++ b/sdks/typescript/src/types.ts
@@ -611,11 +611,11 @@ export interface SessionOptions {
 
 /** Explicit standalone session-event envelope. */
 export interface AgentEventEnvelope {
-  readonly eventId: string;
-  readonly sourceId: string;
-  readonly seq: number;
-  readonly timestampMs: number;
-  readonly payload: import("./events.js").AgentEvent;
+  readonly eventId?: string;
+  readonly sourceId?: string;
+  readonly seq?: number;
+  readonly timestampMs?: number;
+  readonly payload?: import("./events.js").AgentEvent;
 }
 
 /** Mob-wide attributed event emitted by member/mob observation streams. */

--- a/sdks/typescript/tests/types.test.js
+++ b/sdks/typescript/tests/types.test.js
@@ -152,6 +152,25 @@ describe("Typed Events", () => {
     }
   });
 
+  it("should not default missing or malformed turn_completed stop_reason", () => {
+    const missing = parseEvent({ type: "turn_completed" });
+    const invalidString = parseEvent({ type: "turn_completed", stop_reason: "not_real" });
+    const nonString = parseEvent({ type: "turn_completed", stop_reason: 0 });
+
+    assert.equal(missing.type, "turn_completed");
+    assert.equal(invalidString.type, "turn_completed");
+    assert.equal(nonString.type, "turn_completed");
+    if (
+      missing.type === "turn_completed" &&
+      invalidString.type === "turn_completed" &&
+      nonString.type === "turn_completed"
+    ) {
+      assert.equal(missing.stopReason, undefined);
+      assert.equal(invalidString.stopReason, undefined);
+      assert.equal(nonString.stopReason, undefined);
+    }
+  });
+
   it("should parse run_completed", () => {
     const event = parseEvent({
       type: "run_completed",
@@ -196,6 +215,29 @@ describe("Typed Events", () => {
       assert.equal(event.name, "search");
       assert.equal(event.durationMs, 42);
       assert.equal(event.isError, false);
+    }
+  });
+
+  it("should not coerce missing or malformed tool is_error", () => {
+    const missing = parseEvent({
+      type: "tool_execution_completed",
+      id: "t1",
+      name: "search",
+      result: "found it",
+    });
+    const malformed = parseEvent({
+      type: "tool_execution_completed",
+      id: "t1",
+      name: "search",
+      result: "found it",
+      is_error: "false",
+    });
+
+    assert.equal(missing.type, "tool_execution_completed");
+    assert.equal(malformed.type, "tool_execution_completed");
+    if (missing.type === "tool_execution_completed" && malformed.type === "tool_execution_completed") {
+      assert.equal(missing.isError, undefined);
+      assert.equal(malformed.isError, undefined);
     }
   });
 
@@ -285,12 +327,23 @@ describe("Typed Events", () => {
     assert.equal(event.type, "skill_resolution_failed");
     if (event.type === "skill_resolution_failed") {
       assert.equal(event.skillKey, undefined);
-      assert.deepEqual(event.reason, {
-        reasonType: "unknown",
-        message: "missing",
-      });
+      assert.equal(event.reason, undefined);
       assert.equal(event.reference, "legacy/ref");
       assert.equal(event.error, "missing");
+    }
+  });
+
+  it("should not fabricate skill resolution reasons from malformed semantics", () => {
+    const event = parseEvent({
+      type: "skill_resolution_failed",
+      reason: { reason_type: 0, message: "bad" },
+      reference: "legacy/ref",
+      error: "missing",
+    });
+
+    assert.equal(event.type, "skill_resolution_failed");
+    if (event.type === "skill_resolution_failed") {
+      assert.equal(event.reason, undefined);
     }
   });
 
@@ -519,10 +572,10 @@ describe("Typed Events", () => {
     });
     assert.equal(event.type, "tool_config_changed");
     if (event.type === "tool_config_changed") {
-      assert.equal(event.payload.operation, "reload");
-      assert.equal(event.payload.target, "");
-      assert.equal(event.payload.status, "");
-      assert.equal(event.payload.persisted, false);
+      assert.equal(event.payload.operation, undefined);
+      assert.equal(event.payload.target, undefined);
+      assert.equal(event.payload.status, undefined);
+      assert.equal(event.payload.persisted, undefined);
       assert.equal(event.payload.applied_at_turn, undefined);
     }
   });
@@ -544,7 +597,7 @@ describe("Typed Events", () => {
     }
   });
 
-  it("should treat non-boolean persisted in tool_config_changed as false", () => {
+  it("should not coerce non-boolean persisted in tool_config_changed", () => {
     const event = parseEvent({
       type: "tool_config_changed",
       payload: {
@@ -556,8 +609,42 @@ describe("Typed Events", () => {
     });
     assert.equal(event.type, "tool_config_changed");
     if (event.type === "tool_config_changed") {
-      assert.equal(event.payload.persisted, false);
+      assert.equal(event.payload.persisted, undefined);
     }
+  });
+
+  it("should not default malformed tool_config_changed operation/status semantics", () => {
+    const event = parseEvent({
+      type: "tool_config_changed",
+      payload: {
+        operation: "bogus",
+        target: 0,
+        status: 0,
+        persisted: "false",
+      },
+    });
+
+    assert.equal(event.type, "tool_config_changed");
+    if (event.type === "tool_config_changed") {
+      assert.equal(event.payload.operation, undefined);
+      assert.equal(event.payload.target, undefined);
+      assert.equal(event.payload.status, undefined);
+      assert.equal(event.payload.persisted, undefined);
+    }
+  });
+
+  it("should not fabricate standalone event envelope metadata or payload", () => {
+    const envelope = MeerkatClient.parseAgentEventEnvelope({
+      event_id: 3,
+      seq: "0",
+      timestamp_ms: "0",
+      payload: "not-an-object",
+    });
+
+    assert.equal(envelope.eventId, undefined);
+    assert.equal(envelope.seq, undefined);
+    assert.equal(envelope.timestampMs, undefined);
+    assert.equal(envelope.payload, undefined);
   });
 });
 


### PR DESCRIPTION
## Summary
- Preserve absent/malformed TS event semantics as undefined instead of defaulting stop reasons, tool config operation/status/persisted, tool error flags, skill failure reasons, and event envelope metadata.
- Preserve absent/malformed Python event semantics as None for the same lifecycle/status fields.
- Add focused TS/Python regression coverage for absent and malformed semantic fields while keeping valid decoding stable.

## Validation
- rg -n "end_turn|reload|unknown|unwrap_or|default|false|0" sdks/typescript/src/events.ts sdks/typescript/src/client.ts sdks/python/meerkat/events.py
- make test-sdk-typescript
- PIP_BREAK_SYSTEM_PACKAGES=1 make test-sdk-python
- make check
- git diff --check

Linear: LUC-68