### PR TITLE
LUC-67 Preserve typed tool unavailable reasons

### DIFF
--- a/meerkat-core/src/error.rs
+++ b/meerkat-core/src/error.rs
@@ -1,6 +1,7 @@
 //! Core error types for Meerkat
 
 use crate::hooks::{HookPoint, HookReasonCode};
+use crate::tool_catalog::ToolUnavailableReason;
 use crate::types::SessionId;
 
 #[derive(Debug, Clone, PartialEq)]
@@ -58,7 +59,10 @@ pub enum ToolError {
 
     /// The tool exists but is currently unavailable
     #[error("Tool '{name}' is currently unavailable: {reason}")]
-    Unavailable { name: String, reason: String },
+    Unavailable {
+        name: String,
+        reason: ToolUnavailableReason,
+    },
 
     /// The tool arguments failed validation
     #[error("Invalid arguments for tool '{name}': {reason}")]
@@ -116,10 +120,10 @@ impl ToolError {
     pub fn not_found(name: impl Into<String>) -> Self {
         Self::NotFound { name: name.into() }
     }
-    pub fn unavailable(name: impl Into<String>, reason: impl Into<String>) -> Self {
+    pub fn unavailable(name: impl Into<String>, reason: ToolUnavailableReason) -> Self {
         Self::Unavailable {
             name: name.into(),
-            reason: reason.into(),
+            reason,
         }
     }
     pub fn invalid_arguments(name: impl Into<String>, reason: impl Into<String>) -> Self {

--- a/meerkat-core/src/gateway.rs
+++ b/meerkat-core/src/gateway.rs
@@ -244,7 +244,7 @@ impl AgentToolDispatcher for ToolGateway {
             return Err(ToolError::not_found(call.name));
         };
         if let Some(reason) = catalog_entry.callability.unavailable_reason() {
-            return Err(ToolError::unavailable(call.name, reason.to_string()));
+            return Err(ToolError::unavailable(call.name, reason));
         }
         entry.dispatcher.dispatch(call).await
     }
@@ -494,10 +494,7 @@ impl AgentToolDispatcher for DynamicToolComposite {
                     .find(|entry| entry.tool.name == call.name)
                 {
                     if let Some(reason) = entry.callability.unavailable_reason() {
-                        return Err(crate::error::ToolError::unavailable(
-                            call.name,
-                            reason.to_string(),
-                        ));
+                        return Err(crate::error::ToolError::unavailable(call.name, reason));
                     }
                     return d.dispatch(call).await;
                 }
@@ -742,6 +739,28 @@ mod tests {
                 prefix: prefix.to_string(),
             }
         }
+
+        fn with_unavailable_reason(
+            prefix: &str,
+            name: &str,
+            reason: ToolUnavailableReason,
+        ) -> Self {
+            let tool = Arc::new(ToolDef {
+                name: name.into(),
+                description: format!("{prefix} tool: {name}"),
+                input_schema: empty_object_schema(),
+                provenance: None,
+            });
+            let catalog = Arc::from([crate::ToolCatalogEntry::session_inline_with_callability(
+                Arc::clone(&tool),
+                ToolCallability::unavailable(reason),
+            )]);
+            Self {
+                tools: Vec::<Arc<ToolDef>>::new().into(),
+                catalog,
+                prefix: prefix.to_string(),
+            }
+        }
     }
 
     struct LiveExactMockDispatcher {
@@ -841,7 +860,7 @@ mod tests {
                 return Err(ToolError::not_found(call.name));
             };
             if let Some(reason) = entry.callability.unavailable_reason() {
-                return Err(ToolError::unavailable(call.name, reason.to_string()));
+                return Err(ToolError::unavailable(call.name, reason));
             }
             Ok(ToolResult::new(
                 call.id.to_string(),
@@ -884,7 +903,7 @@ mod tests {
             if !self.callable.load(Ordering::SeqCst) {
                 return Err(ToolError::unavailable(
                     call.name,
-                    "tool is not currently callable",
+                    ToolUnavailableReason::NotCurrentlyCallable,
                 ));
             }
             Ok(ToolResult::new(
@@ -1165,6 +1184,30 @@ mod tests {
         let err = result.unwrap_err();
         assert!(matches!(err, ToolError::Unavailable { .. }));
         assert!(err.to_string().contains("not currently callable"));
+    }
+
+    #[tokio::test]
+    async fn gateway_preserves_typed_unavailable_reason() {
+        let exact = Arc::new(ExactMockDispatcher::with_unavailable_reason(
+            "exact",
+            "peers",
+            ToolUnavailableReason::NoPeersConfigured,
+        ));
+        let gateway = ToolGatewayBuilder::new()
+            .add_dispatcher(exact)
+            .build()
+            .unwrap();
+
+        let err = dispatch_json(&gateway, "peers", json!({}))
+            .await
+            .unwrap_err();
+
+        let reason = match &err {
+            ToolError::Unavailable { reason, .. } => Some(*reason),
+            _ => None,
+        };
+        assert_eq!(reason, Some(ToolUnavailableReason::NoPeersConfigured));
+        assert!(err.to_string().contains("no peers configured"));
     }
 
     #[test]

--- a/meerkat-tools/src/builtin/comms/surface.rs
+++ b/meerkat-tools/src/builtin/comms/surface.rs
@@ -122,7 +122,7 @@ impl AgentToolDispatcher for CommsToolSurface {
             });
         }
         if let Some(reason) = self.callability().unavailable_reason() {
-            return Err(ToolError::unavailable(call.name, reason.to_string()));
+            return Err(ToolError::unavailable(call.name, reason));
         }
 
         let args: Value = serde_json::from_str(call.args.get())

--- a/meerkat-tools/src/builtin/composite.rs
+++ b/meerkat-tools/src/builtin/composite.rs
@@ -538,7 +538,7 @@ impl AgentToolDispatcher for CompositeDispatcher {
                     .find(|entry| entry.tool.name == call.name)
                 {
                     if let Some(reason) = entry.callability.unavailable_reason() {
-                        return Err(ToolError::unavailable(call.name, reason.to_string()));
+                        return Err(ToolError::unavailable(call.name, reason));
                     }
                     return ext.dispatch(call).await;
                 }

--- a/meerkat-tools/src/dispatcher.rs
+++ b/meerkat-tools/src/dispatcher.rs
@@ -91,11 +91,11 @@ impl ToolDispatcher {
             else {
                 return Err(ToolError::unavailable(
                     name,
-                    ToolUnavailableReason::NotCurrentlyCallable.to_string(),
+                    ToolUnavailableReason::NotCurrentlyCallable,
                 ));
             };
             if let Some(reason) = entry.callability.unavailable_reason() {
-                return Err(ToolError::unavailable(name, reason.to_string()));
+                return Err(ToolError::unavailable(name, reason));
             }
             return Ok(entry.tool);
         }
@@ -106,10 +106,7 @@ impl ToolDispatcher {
             .find(|tool| tool.name == name)
             .cloned()
             .ok_or_else(|| {
-                ToolError::unavailable(
-                    name,
-                    ToolUnavailableReason::NotCurrentlyCallable.to_string(),
-                )
+                ToolError::unavailable(name, ToolUnavailableReason::NotCurrentlyCallable)
             })
     }
 
@@ -422,6 +419,20 @@ mod tests {
                 .into();
             Self { catalog }
         }
+
+        fn with_unavailable_reason(name: &str, reason: ToolUnavailableReason) -> Self {
+            let catalog = vec![ToolCatalogEntry::session_inline_with_callability(
+                Arc::new(ToolDef {
+                    name: name.into(),
+                    description: format!("{name} tool"),
+                    input_schema: json!({"type": "object"}),
+                    provenance: None,
+                }),
+                ToolCallability::unavailable(reason),
+            )]
+            .into();
+            Self { catalog }
+        }
     }
 
     fn make_call<'a>(name: &'a str, args_raw: &'a serde_json::value::RawValue) -> ToolCallView<'a> {
@@ -533,7 +544,7 @@ mod tests {
                 });
             };
             if let Some(reason) = entry.callability.unavailable_reason() {
-                return Err(ToolError::unavailable(call.name, reason.to_string()));
+                return Err(ToolError::unavailable(call.name, reason));
             }
             Ok(ToolResult::new(
                 call.id.to_string(),
@@ -586,6 +597,28 @@ mod tests {
             .dispatch(make_call("denied_hidden", &args_raw))
             .await;
         assert!(matches!(denied_result, Err(ToolError::AccessDenied { .. })));
+    }
+
+    #[tokio::test]
+    async fn dispatcher_preserves_typed_unavailable_reason() {
+        let router = Arc::new(ExactMockDispatcher::with_unavailable_reason(
+            "peers",
+            ToolUnavailableReason::NoPeersConfigured,
+        ));
+        let dispatcher = ToolDispatcher::new(router);
+
+        let args_raw = serde_json::value::RawValue::from_string(json!({}).to_string()).unwrap();
+        let err = dispatcher
+            .dispatch(make_call("peers", &args_raw))
+            .await
+            .unwrap_err();
+
+        let reason = match &err {
+            ToolError::Unavailable { reason, .. } => Some(*reason),
+            _ => None,
+        };
+        assert_eq!(reason, Some(ToolUnavailableReason::NoPeersConfigured));
+        assert!(err.to_string().contains("no peers configured"));
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary
- Store typed ToolUnavailableReason in ToolError::Unavailable
- Pass catalog callability denial reasons through gateway and dispatcher without string erasure
- Add focused propagation tests while keeping display messages useful

## Validation
- ./scripts/repo-cargo test -p meerkat-core gateway_preserves_typed_unavailable_reason
- ./scripts/repo-cargo test -p meerkat-tools dispatcher_preserves_typed_unavailable_reason
- make fmt
- rg -n "ToolUnavailableReason|ToolError::Unavailable|Unavailable|reason" meerkat-core/src/tool_catalog.rs meerkat-core/src/error.rs meerkat-core/src/gateway.rs meerkat-tools/src/dispatcher.rs
- make check

Linear: LUC-67