### PR TITLE
Centralize OAuth provider resolution

### DIFF
--- a/meerkat-auth-core/src/oauth_flow.rs
+++ b/meerkat-auth-core/src/oauth_flow.rs
@@ -9,13 +9,180 @@ use std::sync::OnceLock;
 use std::time::{Duration, Instant};
 
 use base64::Engine as _;
+use meerkat_core::Provider;
 use parking_lot::Mutex;
+
+use crate::auth_oauth::OAuthEndpoints;
+use crate::auth_store::PersistedAuthMode;
 
 const DEFAULT_MAX_OUTSTANDING_FLOWS: usize = 1024;
 
+const ANTHROPIC_CLIENT_ID: &str = "9d1c250a-e61b-44d9-88ed-5944d1962f5e";
+const ANTHROPIC_AUTHORIZE_URL: &str = "https://claude.com/cai/oauth/authorize";
+const ANTHROPIC_TOKEN_URL: &str = "https://platform.claude.com/v1/oauth/token";
+const ANTHROPIC_SCOPES: &[&str] = &[
+    "user:profile",
+    "user:inference",
+    "user:sessions:claude_code",
+    "user:mcp_servers",
+    "user:file_upload",
+];
+const ANTHROPIC_BETA_HEADER_NAME: &str = "anthropic-beta";
+const ANTHROPIC_BETA_HEADER_VALUE: &str = "oauth-2025-04-20";
+
+const OPENAI_CLIENT_ID: &str = "app_EMoamEEZ73f0CkXaXp7hrann";
+const OPENAI_AUTHORIZE_URL: &str = "https://auth.openai.com/oauth/authorize";
+const OPENAI_TOKEN_URL: &str = "https://auth.openai.com/oauth/token";
+const OPENAI_SCOPES: &[&str] = &[
+    "openid",
+    "profile",
+    "email",
+    "offline_access",
+    "api.connectors.read",
+    "api.connectors.invoke",
+];
+
+const GOOGLE_CLIENT_ID: &str = concat!(
+    "6812558",
+    "09395-oo8ft2oprdrnp9e3aqf6av3hmdib135j",
+    ".apps.googleusercontent.com",
+);
+const GOOGLE_CLIENT_SECRET: &str = concat!("GOCSP", "X-4uHgMPm", "-1o7Sk-geV6Cu5clXFsxl");
+const GOOGLE_AUTHORIZE_URL: &str = "https://accounts.google.com/o/oauth2/v2/auth";
+const GOOGLE_TOKEN_URL: &str = "https://oauth2.googleapis.com/token";
+const GOOGLE_DEVICE_CODE_URL: &str = "https://oauth2.googleapis.com/device/code";
+const GOOGLE_SCOPES: &[&str] = &[
+    "https://www.googleapis.com/auth/cloud-platform",
+    "https://www.googleapis.com/auth/userinfo.email",
+    "https://www.googleapis.com/auth/userinfo.profile",
+];
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum OAuthProviderIdentity {
+    AnthropicClaudeAi,
+    OpenAiChatGpt,
+    GoogleCodeAssist,
+}
+
+impl OAuthProviderIdentity {
+    pub fn from_alias(alias: &str) -> Option<Self> {
+        match alias {
+            "anthropic" | "claude" | "claude.ai" => Some(Self::AnthropicClaudeAi),
+            "openai" | "chatgpt" => Some(Self::OpenAiChatGpt),
+            "google" | "gemini" | "code_assist" => Some(Self::GoogleCodeAssist),
+            _ => None,
+        }
+    }
+
+    pub fn canonical_alias(self) -> &'static str {
+        match self {
+            Self::AnthropicClaudeAi => "anthropic",
+            Self::OpenAiChatGpt => "openai",
+            Self::GoogleCodeAssist => "google",
+        }
+    }
+
+    pub fn provider(self) -> Provider {
+        match self {
+            Self::AnthropicClaudeAi => Provider::Anthropic,
+            Self::OpenAiChatGpt => Provider::OpenAI,
+            Self::GoogleCodeAssist => Provider::Gemini,
+        }
+    }
+
+    pub fn auth_mode(self) -> PersistedAuthMode {
+        match self {
+            Self::AnthropicClaudeAi => PersistedAuthMode::ClaudeAiOauth,
+            Self::OpenAiChatGpt => PersistedAuthMode::ChatgptOauth,
+            Self::GoogleCodeAssist => PersistedAuthMode::GoogleOauth,
+        }
+    }
+
+    pub fn client_secret(self) -> Option<&'static str> {
+        match self {
+            Self::AnthropicClaudeAi | Self::OpenAiChatGpt => None,
+            Self::GoogleCodeAssist => Some(GOOGLE_CLIENT_SECRET),
+        }
+    }
+
+    pub fn endpoints(self, redirect_uri: impl Into<String>) -> OAuthEndpoints {
+        match self {
+            Self::AnthropicClaudeAi => OAuthEndpoints {
+                client_id: ANTHROPIC_CLIENT_ID.into(),
+                authorize_url: ANTHROPIC_AUTHORIZE_URL.into(),
+                token_url: ANTHROPIC_TOKEN_URL.into(),
+                device_code_url: None,
+                redirect_uri: redirect_uri.into(),
+                scopes: strings(ANTHROPIC_SCOPES),
+                extra_headers: vec![(
+                    ANTHROPIC_BETA_HEADER_NAME.into(),
+                    ANTHROPIC_BETA_HEADER_VALUE.into(),
+                )],
+            },
+            Self::OpenAiChatGpt => OAuthEndpoints {
+                client_id: OPENAI_CLIENT_ID.into(),
+                authorize_url: OPENAI_AUTHORIZE_URL.into(),
+                token_url: OPENAI_TOKEN_URL.into(),
+                device_code_url: None,
+                redirect_uri: redirect_uri.into(),
+                scopes: strings(OPENAI_SCOPES),
+                extra_headers: Vec::new(),
+            },
+            Self::GoogleCodeAssist => OAuthEndpoints {
+                client_id: GOOGLE_CLIENT_ID.into(),
+                authorize_url: GOOGLE_AUTHORIZE_URL.into(),
+                token_url: GOOGLE_TOKEN_URL.into(),
+                device_code_url: Some(GOOGLE_DEVICE_CODE_URL.into()),
+                redirect_uri: redirect_uri.into(),
+                scopes: strings(GOOGLE_SCOPES),
+                extra_headers: Vec::new(),
+            },
+        }
+    }
+}
+
+impl std::fmt::Display for OAuthProviderIdentity {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(self.canonical_alias())
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct OAuthProviderResolution {
+    pub identity: OAuthProviderIdentity,
+    pub provider: Provider,
+    pub endpoints: OAuthEndpoints,
+    pub auth_mode: PersistedAuthMode,
+    pub client_secret: Option<&'static str>,
+}
+
+#[derive(Debug, thiserror::Error, PartialEq, Eq)]
+#[error("Unknown provider '{provider}'. Supported: anthropic, openai, google.")]
+pub struct OAuthProviderResolutionError {
+    pub provider: String,
+}
+
+pub fn resolve_oauth_provider(
+    provider: &str,
+    redirect_uri: impl Into<String>,
+) -> Result<OAuthProviderResolution, OAuthProviderResolutionError> {
+    let identity = OAuthProviderIdentity::from_alias(provider).ok_or_else(|| {
+        OAuthProviderResolutionError {
+            provider: provider.to_string(),
+        }
+    })?;
+    Ok(OAuthProviderResolution {
+        identity,
+        provider: identity.provider(),
+        endpoints: identity.endpoints(redirect_uri),
+        auth_mode: identity.auth_mode(),
+        client_secret: identity.client_secret(),
+    })
+}
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct OAuthFlowRecord {
-    pub provider: String,
+    pub provider: OAuthProviderIdentity,
     pub redirect_uri: String,
     pub pkce_verifier: String,
     pub created_at: Instant,
@@ -26,7 +193,10 @@ pub enum OAuthFlowError {
     #[error("oauth state is missing or expired")]
     Missing,
     #[error("oauth state provider mismatch: expected {expected}, got {actual}")]
-    ProviderMismatch { expected: String, actual: String },
+    ProviderMismatch {
+        expected: OAuthProviderIdentity,
+        actual: OAuthProviderIdentity,
+    },
     #[error("oauth state redirect_uri mismatch")]
     RedirectUriMismatch,
     #[error("failed to generate oauth state token")]
@@ -57,13 +227,13 @@ impl OAuthFlowRegistry {
 
     pub fn start(
         &self,
-        provider: impl Into<String>,
+        provider: OAuthProviderIdentity,
         redirect_uri: impl Into<String>,
         pkce_verifier: impl Into<String>,
     ) -> Result<String, OAuthFlowError> {
         let state = new_state_token()?;
         let record = OAuthFlowRecord {
-            provider: provider.into(),
+            provider,
             redirect_uri: redirect_uri.into(),
             pkce_verifier: pkce_verifier.into(),
             created_at: Instant::now(),
@@ -82,7 +252,7 @@ impl OAuthFlowRegistry {
     pub fn consume(
         &self,
         state: &str,
-        provider: &str,
+        provider: OAuthProviderIdentity,
         redirect_uri: &str,
     ) -> Result<OAuthFlowRecord, OAuthFlowError> {
         let mut flows = self.flows.lock();
@@ -93,7 +263,7 @@ impl OAuthFlowRegistry {
         if record.provider != provider {
             return Err(OAuthFlowError::ProviderMismatch {
                 expected: record.provider,
-                actual: provider.to_string(),
+                actual: provider,
             });
         }
         if record.redirect_uri != redirect_uri {
@@ -121,6 +291,10 @@ fn prune_expired_locked(flows: &mut HashMap<String, OAuthFlowRecord>, ttl: Durat
     flows.retain(|_, record| record.created_at.elapsed() <= ttl);
 }
 
+fn strings(values: &[&str]) -> Vec<String> {
+    values.iter().map(|value| (*value).to_string()).collect()
+}
+
 #[cfg(test)]
 #[allow(clippy::expect_used)]
 mod tests {
@@ -130,9 +304,17 @@ mod tests {
     fn oauth_state_pkce_round_trip() {
         let registry = OAuthFlowRegistry::new(Duration::from_secs(60));
         let state = registry
-            .start("openai", "http://127.0.0.1/callback", "verifier")
+            .start(
+                OAuthProviderIdentity::OpenAiChatGpt,
+                "http://127.0.0.1/callback",
+                "verifier",
+            )
             .expect("state generation succeeds");
-        let record = registry.consume(&state, "openai", "http://127.0.0.1/callback");
+        let record = registry.consume(
+            &state,
+            OAuthProviderIdentity::OpenAiChatGpt,
+            "http://127.0.0.1/callback",
+        );
         assert!(
             record.is_ok(),
             "state should resolve once: {:?}",
@@ -142,7 +324,11 @@ mod tests {
             assert_eq!(record.pkce_verifier, "verifier");
         }
         assert!(matches!(
-            registry.consume(&state, "openai", "http://127.0.0.1/callback"),
+            registry.consume(
+                &state,
+                OAuthProviderIdentity::OpenAiChatGpt,
+                "http://127.0.0.1/callback"
+            ),
             Err(OAuthFlowError::Missing)
         ));
     }
@@ -151,10 +337,18 @@ mod tests {
     fn oauth_state_rejects_mismatch() {
         let registry = OAuthFlowRegistry::new(Duration::from_secs(60));
         let state = registry
-            .start("openai", "http://127.0.0.1/callback", "verifier")
+            .start(
+                OAuthProviderIdentity::OpenAiChatGpt,
+                "http://127.0.0.1/callback",
+                "verifier",
+            )
             .expect("state generation succeeds");
         assert!(matches!(
-            registry.consume(&state, "anthropic", "http://127.0.0.1/callback"),
+            registry.consume(
+                &state,
+                OAuthProviderIdentity::AnthropicClaudeAi,
+                "http://127.0.0.1/callback"
+            ),
             Err(OAuthFlowError::ProviderMismatch { .. })
         ));
     }
@@ -163,10 +357,18 @@ mod tests {
     fn oauth_state_rejects_redirect_uri_mismatch() {
         let registry = OAuthFlowRegistry::new(Duration::from_secs(60));
         let state = registry
-            .start("openai", "http://127.0.0.1/callback", "verifier")
+            .start(
+                OAuthProviderIdentity::OpenAiChatGpt,
+                "http://127.0.0.1/callback",
+                "verifier",
+            )
             .expect("state generation succeeds");
         assert!(matches!(
-            registry.consume(&state, "openai", "http://127.0.0.1/other"),
+            registry.consume(
+                &state,
+                OAuthProviderIdentity::OpenAiChatGpt,
+                "http://127.0.0.1/other"
+            ),
             Err(OAuthFlowError::RedirectUriMismatch)
         ));
     }
@@ -175,10 +377,18 @@ mod tests {
     fn oauth_state_random_tokens_are_urlsafe_and_unique() {
         let registry = OAuthFlowRegistry::new(Duration::from_secs(60));
         let first = registry
-            .start("openai", "http://127.0.0.1/callback", "verifier-a")
+            .start(
+                OAuthProviderIdentity::OpenAiChatGpt,
+                "http://127.0.0.1/callback",
+                "verifier-a",
+            )
             .expect("state generation succeeds");
         let second = registry
-            .start("openai", "http://127.0.0.1/callback", "verifier-b")
+            .start(
+                OAuthProviderIdentity::OpenAiChatGpt,
+                "http://127.0.0.1/callback",
+                "verifier-b",
+            )
             .expect("state generation succeeds");
         assert_ne!(first, second);
         assert!(first.starts_with("st-"));
@@ -195,7 +405,7 @@ mod tests {
         registry.flows.lock().insert(
             "st-old".to_string(),
             OAuthFlowRecord {
-                provider: "openai".to_string(),
+                provider: OAuthProviderIdentity::OpenAiChatGpt,
                 redirect_uri: "http://127.0.0.1/callback".to_string(),
                 pkce_verifier: "verifier".to_string(),
                 created_at: Instant::now()
@@ -204,7 +414,11 @@ mod tests {
             },
         );
         assert!(matches!(
-            registry.consume("st-old", "openai", "http://127.0.0.1/callback"),
+            registry.consume(
+                "st-old",
+                OAuthProviderIdentity::OpenAiChatGpt,
+                "http://127.0.0.1/callback"
+            ),
             Err(OAuthFlowError::Missing)
         ));
     }
@@ -213,12 +427,24 @@ mod tests {
     fn oauth_state_registry_rejects_start_at_capacity() {
         let registry = OAuthFlowRegistry::new_with_capacity(Duration::from_secs(60), 2);
         let first = registry
-            .start("openai", "http://127.0.0.1/callback", "first")
+            .start(
+                OAuthProviderIdentity::OpenAiChatGpt,
+                "http://127.0.0.1/callback",
+                "first",
+            )
             .expect("state generation succeeds");
         let second = registry
-            .start("openai", "http://127.0.0.1/callback", "second")
+            .start(
+                OAuthProviderIdentity::OpenAiChatGpt,
+                "http://127.0.0.1/callback",
+                "second",
+            )
             .expect("state generation succeeds");
-        let third = registry.start("openai", "http://127.0.0.1/callback", "third");
+        let third = registry.start(
+            OAuthProviderIdentity::OpenAiChatGpt,
+            "http://127.0.0.1/callback",
+            "third",
+        );
 
         assert!(matches!(
             third,
@@ -226,13 +452,94 @@ mod tests {
         ));
         assert!(
             registry
-                .consume(&first, "openai", "http://127.0.0.1/callback")
+                .consume(
+                    &first,
+                    OAuthProviderIdentity::OpenAiChatGpt,
+                    "http://127.0.0.1/callback"
+                )
                 .is_ok()
         );
         assert!(
             registry
-                .consume(&second, "openai", "http://127.0.0.1/callback")
+                .consume(
+                    &second,
+                    OAuthProviderIdentity::OpenAiChatGpt,
+                    "http://127.0.0.1/callback"
+                )
                 .is_ok()
         );
+    }
+
+    #[test]
+    fn oauth_provider_resolution_preserves_aliases() {
+        let cases = [
+            (
+                "anthropic",
+                OAuthProviderIdentity::AnthropicClaudeAi,
+                Provider::Anthropic,
+                PersistedAuthMode::ClaudeAiOauth,
+            ),
+            (
+                "claude",
+                OAuthProviderIdentity::AnthropicClaudeAi,
+                Provider::Anthropic,
+                PersistedAuthMode::ClaudeAiOauth,
+            ),
+            (
+                "claude.ai",
+                OAuthProviderIdentity::AnthropicClaudeAi,
+                Provider::Anthropic,
+                PersistedAuthMode::ClaudeAiOauth,
+            ),
+            (
+                "openai",
+                OAuthProviderIdentity::OpenAiChatGpt,
+                Provider::OpenAI,
+                PersistedAuthMode::ChatgptOauth,
+            ),
+            (
+                "chatgpt",
+                OAuthProviderIdentity::OpenAiChatGpt,
+                Provider::OpenAI,
+                PersistedAuthMode::ChatgptOauth,
+            ),
+            (
+                "google",
+                OAuthProviderIdentity::GoogleCodeAssist,
+                Provider::Gemini,
+                PersistedAuthMode::GoogleOauth,
+            ),
+            (
+                "gemini",
+                OAuthProviderIdentity::GoogleCodeAssist,
+                Provider::Gemini,
+                PersistedAuthMode::GoogleOauth,
+            ),
+            (
+                "code_assist",
+                OAuthProviderIdentity::GoogleCodeAssist,
+                Provider::Gemini,
+                PersistedAuthMode::GoogleOauth,
+            ),
+        ];
+
+        for (alias, identity, provider, auth_mode) in cases {
+            let resolved =
+                resolve_oauth_provider(alias, "http://127.0.0.1/callback").expect("alias resolves");
+            assert_eq!(resolved.identity, identity);
+            assert_eq!(resolved.provider, provider);
+            assert_eq!(resolved.auth_mode, auth_mode);
+            assert_eq!(resolved.endpoints.redirect_uri, "http://127.0.0.1/callback");
+        }
+    }
+
+    #[test]
+    fn oauth_provider_resolution_exposes_google_device_secret() {
+        let resolved =
+            resolve_oauth_provider("code_assist", "").expect("google code assist resolves");
+
+        assert_eq!(resolved.identity, OAuthProviderIdentity::GoogleCodeAssist);
+        assert!(resolved.endpoints.device_code_url.is_some());
+        assert_eq!(resolved.client_secret, Some(GOOGLE_CLIENT_SECRET));
     }
 }

--- a/meerkat-rest/src/auth_endpoints.rs
+++ b/meerkat-rest/src/auth_endpoints.rs
@@ -17,7 +17,6 @@ use axum::extract::{Path, Query, State};
 use axum::http::StatusCode;
 use axum::response::IntoResponse;
 
-use meerkat_anthropic::runtime::oauth as a_oauth;
 use meerkat_contracts::{
     WireAuthProfile, WireAuthProfileCleared, WireAuthProfileCreated, WireAuthProfileDetail,
     WireAuthProfilesList, WireAuthStatusDetail, WireBackendProfile, WireBindingIdentity,
@@ -29,23 +28,16 @@ use meerkat_core::{
     AuthStatusPhase, ConnectionRef, CredentialSourceSpec, Provider, RealmConnectionSet,
     ResolvedConnectionTarget,
 };
-use meerkat_gemini::runtime::oauth as g_oauth;
-use meerkat_openai::runtime::oauth as o_oauth;
 use meerkat_providers::auth_oauth::{
-    DevicePollOutcome, OAuthEndpoints, OAuthError, PkcePair, exchange_authorization_code,
-    poll_device_code, request_device_code,
+    DevicePollOutcome, OAuthError, PkcePair, exchange_authorization_code, poll_device_code,
+    request_device_code,
 };
 use meerkat_providers::auth_store::{PersistedAuthMode, PersistedTokens, TokenKey};
-use meerkat_providers::oauth_flow::{OAuthFlowError, global_oauth_flow_registry};
+use meerkat_providers::oauth_flow::{
+    OAuthFlowError, global_oauth_flow_registry, resolve_oauth_provider,
+};
 
 use crate::AppState;
-
-type ProviderEndpointResolution = (
-    Provider,
-    OAuthEndpoints,
-    PersistedAuthMode,
-    Option<&'static str>,
-);
 
 async fn load_config(state: &AppState) -> Result<meerkat_core::Config, (StatusCode, String)> {
     state
@@ -531,36 +523,6 @@ pub async fn test_auth_binding(
 // The server owns the state -> PKCE verifier correlation. The client receives
 // only the authorize URL and state, then posts the provider code with that state.
 
-fn provider_endpoints(
-    provider: &str,
-    redirect_uri: &str,
-) -> Result<ProviderEndpointResolution, (StatusCode, String)> {
-    match provider {
-        "anthropic" | "claude" | "claude.ai" => Ok((
-            Provider::Anthropic,
-            a_oauth::claude_ai_endpoints(redirect_uri),
-            PersistedAuthMode::ClaudeAiOauth,
-            None,
-        )),
-        "openai" | "chatgpt" => Ok((
-            Provider::OpenAI,
-            o_oauth::chatgpt_endpoints(redirect_uri),
-            PersistedAuthMode::ChatgptOauth,
-            None,
-        )),
-        "google" | "gemini" | "code_assist" => Ok((
-            Provider::Gemini,
-            g_oauth::code_assist_endpoints(redirect_uri),
-            PersistedAuthMode::GoogleOauth,
-            Some(g_oauth::CODE_ASSIST_CLIENT_SECRET),
-        )),
-        other => Err((
-            StatusCode::BAD_REQUEST,
-            format!("Unknown provider '{other}'. Supported: anthropic, openai, google."),
-        )),
-    }
-}
-
 #[derive(serde::Deserialize)]
 pub struct LoginStartBody {
     pub provider: String,
@@ -570,17 +532,20 @@ pub struct LoginStartBody {
 }
 
 pub async fn start_login(Json(body): Json<LoginStartBody>) -> impl IntoResponse {
-    let (_provider, endpoints, _mode, _secret) =
-        match provider_endpoints(&body.provider, &body.redirect_uri) {
-            Ok(v) => v,
-            Err((status, msg)) => {
-                return (status, Json(serde_json::json!({ "error": msg }))).into_response();
-            }
-        };
+    let resolved = match resolve_oauth_provider(&body.provider, &body.redirect_uri) {
+        Ok(v) => v,
+        Err(e) => {
+            return (
+                StatusCode::BAD_REQUEST,
+                Json(serde_json::json!({ "error": e.to_string() })),
+            )
+                .into_response();
+        }
+    };
     let pkce = PkcePair::generate_s256();
     let verifier = pkce.verifier.secret().to_string();
     let state_token = match global_oauth_flow_registry().start(
-        body.provider.clone(),
+        resolved.identity,
         body.redirect_uri.clone(),
         verifier,
     ) {
@@ -600,7 +565,9 @@ pub async fn start_login(Json(body): Json<LoginStartBody>) -> impl IntoResponse 
                 .into_response();
         }
     };
-    let authorize_url = endpoints.authorize_url_with_pkce(&pkce.challenge, &state_token);
+    let authorize_url = resolved
+        .endpoints
+        .authorize_url_with_pkce(&pkce.challenge, &state_token);
     (
         StatusCode::OK,
         Json(WireLoginStart {
@@ -631,13 +598,17 @@ pub async fn complete_login(
     State(state): State<AppState>,
     Json(body): Json<LoginCompleteBody>,
 ) -> impl IntoResponse {
-    let (provider, endpoints, mode, client_secret) =
-        match provider_endpoints(&body.provider, &body.redirect_uri) {
-            Ok(v) => v,
-            Err((status, msg)) => {
-                return (status, Json(serde_json::json!({ "error": msg }))).into_response();
-            }
-        };
+    let resolved = match resolve_oauth_provider(&body.provider, &body.redirect_uri) {
+        Ok(v) => v,
+        Err(e) => {
+            return (
+                StatusCode::BAD_REQUEST,
+                Json(serde_json::json!({ "error": e.to_string() })),
+            )
+                .into_response();
+        }
+    };
+    let provider = resolved.provider;
     let (realm_id, binding_id) =
         match require_explicit_oauth_identity(body.realm_id.as_ref(), body.binding_id.as_ref()) {
             Ok(v) => v,
@@ -677,35 +648,37 @@ pub async fn complete_login(
             .into_response();
     }
 
-    let flow =
-        match global_oauth_flow_registry().consume(&body.state, &body.provider, &body.redirect_uri)
-        {
-            Ok(flow) => flow,
-            Err(OAuthFlowError::Missing) => {
-                return (
-                    StatusCode::BAD_REQUEST,
-                    Json(serde_json::json!({ "error": "oauth state is missing or expired" })),
-                )
-                    .into_response();
-            }
-            Err(e) => {
-                return (
+    let flow = match global_oauth_flow_registry().consume(
+        &body.state,
+        resolved.identity,
+        &body.redirect_uri,
+    ) {
+        Ok(flow) => flow,
+        Err(OAuthFlowError::Missing) => {
+            return (
+                StatusCode::BAD_REQUEST,
+                Json(serde_json::json!({ "error": "oauth state is missing or expired" })),
+            )
+                .into_response();
+        }
+        Err(e) => {
+            return (
                 StatusCode::BAD_REQUEST,
                 Json(
                     serde_json::json!({ "error": format!("oauth state verification failed: {e}") }),
                 ),
             )
                 .into_response();
-            }
-        };
+        }
+    };
 
     let http = reqwest::Client::new();
     let result = match exchange_authorization_code(
         &http,
-        &endpoints,
+        &resolved.endpoints,
         &body.code,
         &flow.pkce_verifier,
-        client_secret,
+        resolved.client_secret,
     )
     .await
     {
@@ -734,7 +707,7 @@ pub async fn complete_login(
         .expires_in_secs
         .map(|s| chrono::Utc::now() + chrono::Duration::seconds(s as i64));
     let tokens = PersistedTokens {
-        auth_mode: mode,
+        auth_mode: resolved.auth_mode,
         primary_secret: Some(result.access_token),
         refresh_token: result.refresh_token,
         id_token: result.id_token,
@@ -788,13 +761,17 @@ pub struct DeviceStartBody {
 }
 
 pub async fn start_device_login(Json(body): Json<DeviceStartBody>) -> impl IntoResponse {
-    let (_provider, endpoints, _mode, _secret) = match provider_endpoints(&body.provider, "") {
+    let resolved = match resolve_oauth_provider(&body.provider, "") {
         Ok(v) => v,
-        Err((status, msg)) => {
-            return (status, Json(serde_json::json!({ "error": msg }))).into_response();
+        Err(e) => {
+            return (
+                StatusCode::BAD_REQUEST,
+                Json(serde_json::json!({ "error": e.to_string() })),
+            )
+                .into_response();
         }
     };
-    if endpoints.device_code_url.is_none() {
+    if resolved.endpoints.device_code_url.is_none() {
         return (
             StatusCode::BAD_REQUEST,
             Json(serde_json::json!({
@@ -807,7 +784,7 @@ pub async fn start_device_login(Json(body): Json<DeviceStartBody>) -> impl IntoR
             .into_response();
     }
     let http = reqwest::Client::new();
-    match request_device_code(&http, &endpoints).await {
+    match request_device_code(&http, &resolved.endpoints).await {
         Ok(resp) => (
             StatusCode::OK,
             Json(WireDeviceStart {
@@ -855,13 +832,18 @@ pub async fn complete_device_login(
     State(state): State<AppState>,
     Json(body): Json<DeviceCompleteBody>,
 ) -> impl IntoResponse {
-    let (provider, endpoints, mode, client_secret) = match provider_endpoints(&body.provider, "") {
+    let resolved = match resolve_oauth_provider(&body.provider, "") {
         Ok(v) => v,
-        Err((status, msg)) => {
-            return (status, Json(serde_json::json!({ "error": msg }))).into_response();
+        Err(e) => {
+            return (
+                StatusCode::BAD_REQUEST,
+                Json(serde_json::json!({ "error": e.to_string() })),
+            )
+                .into_response();
         }
     };
-    if endpoints.device_code_url.is_none() {
+    let provider = resolved.provider;
+    if resolved.endpoints.device_code_url.is_none() {
         return (
             StatusCode::BAD_REQUEST,
             Json(serde_json::json!({
@@ -912,7 +894,13 @@ pub async fn complete_device_login(
             .into_response();
     }
     let http = reqwest::Client::new();
-    let outcome = match poll_device_code(&http, &endpoints, &body.device_code, client_secret).await
+    let outcome = match poll_device_code(
+        &http,
+        &resolved.endpoints,
+        &body.device_code,
+        resolved.client_secret,
+    )
+    .await
     {
         Ok(o) => o,
         Err(e) => {
@@ -951,7 +939,7 @@ pub async fn complete_device_login(
                 .expires_in_secs
                 .map(|s| chrono::Utc::now() + chrono::Duration::seconds(s as i64));
             let tokens = PersistedTokens {
-                auth_mode: mode,
+                auth_mode: resolved.auth_mode,
                 primary_secret: Some(result.access_token),
                 refresh_token: result.refresh_token,
                 id_token: result.id_token,

--- a/meerkat-rpc/src/handlers/auth.rs
+++ b/meerkat-rpc/src/handlers/auth.rs
@@ -19,26 +19,19 @@ use meerkat_core::{
     AuthStatusPhase, ConnectionRef, ConnectionTargetError, CredentialSourceSpec, Provider,
     RealmConnectionSet, ResolvedConnectionTarget,
 };
-use meerkat_gemini::runtime::oauth as g_oauth;
-use meerkat_openai::runtime::oauth as o_oauth;
 use meerkat_providers::auth_oauth::{
-    DevicePollOutcome, OAuthEndpoints, OAuthError, PkcePair, exchange_authorization_code,
-    poll_device_code, request_device_code,
+    DevicePollOutcome, OAuthError, PkcePair, exchange_authorization_code, poll_device_code,
+    request_device_code,
 };
 use meerkat_providers::auth_store::{PersistedAuthMode, PersistedTokens, TokenKey};
-use meerkat_providers::oauth_flow::{OAuthFlowError, global_oauth_flow_registry};
+use meerkat_providers::oauth_flow::{
+    OAuthFlowError, global_oauth_flow_registry, resolve_oauth_provider,
+};
 
 use super::{RpcResponseExt, parse_params};
 use crate::error;
 use crate::protocol::{RpcId, RpcResponse};
 use crate::session_runtime::SessionRuntime;
-
-type ProviderEndpointResolution = (
-    Provider,
-    OAuthEndpoints,
-    PersistedAuthMode,
-    Option<&'static str>,
-);
 
 #[derive(serde::Deserialize)]
 struct RealmIdParams {
@@ -229,35 +222,6 @@ fn source_kind_label(source: &CredentialSourceSpec) -> &'static str {
         CredentialSourceSpec::PlatformDefault => "platform_default",
         CredentialSourceSpec::Command { .. } => "command",
         CredentialSourceSpec::FileDescriptor { .. } => "file_descriptor",
-    }
-}
-
-fn provider_endpoints(
-    provider: &str,
-    redirect_uri: &str,
-) -> Result<ProviderEndpointResolution, String> {
-    match provider {
-        "anthropic" | "claude" | "claude.ai" => Ok((
-            Provider::Anthropic,
-            a_oauth::claude_ai_endpoints(redirect_uri),
-            PersistedAuthMode::ClaudeAiOauth,
-            None,
-        )),
-        "openai" | "chatgpt" => Ok((
-            Provider::OpenAI,
-            o_oauth::chatgpt_endpoints(redirect_uri),
-            PersistedAuthMode::ChatgptOauth,
-            None,
-        )),
-        "google" | "gemini" | "code_assist" => Ok((
-            Provider::Gemini,
-            g_oauth::code_assist_endpoints(redirect_uri),
-            PersistedAuthMode::GoogleOauth,
-            Some(g_oauth::CODE_ASSIST_CLIENT_SECRET),
-        )),
-        other => Err(format!(
-            "Unknown provider '{other}'. Supported: anthropic, openai, google."
-        )),
     }
 }
 
@@ -545,17 +509,16 @@ pub async fn handle_auth_login_start(id: Option<RpcId>, params: Option<&RawValue
         Ok(v) => v,
         Err(r) => return r.with_id(id),
     };
-    let (_provider, endpoints, _mode, _secret) =
-        match provider_endpoints(&parsed.provider, &parsed.redirect_uri) {
-            Ok(v) => v,
-            Err(msg) => {
-                return RpcResponse::error(id, error::INVALID_PARAMS, msg);
-            }
-        };
+    let resolved = match resolve_oauth_provider(&parsed.provider, &parsed.redirect_uri) {
+        Ok(v) => v,
+        Err(e) => {
+            return RpcResponse::error(id, error::INVALID_PARAMS, e.to_string());
+        }
+    };
     let pkce = PkcePair::generate_s256();
     let verifier = pkce.verifier.secret().clone();
     let state_token = match global_oauth_flow_registry().start(
-        parsed.provider.clone(),
+        resolved.identity,
         parsed.redirect_uri.clone(),
         verifier,
     ) {
@@ -575,7 +538,9 @@ pub async fn handle_auth_login_start(id: Option<RpcId>, params: Option<&RawValue
             );
         }
     };
-    let authorize_url = endpoints.authorize_url_with_pkce(&pkce.challenge, &state_token);
+    let authorize_url = resolved
+        .endpoints
+        .authorize_url_with_pkce(&pkce.challenge, &state_token);
     RpcResponse::success(
         id,
         serde_json::json!({
@@ -610,13 +575,13 @@ pub async fn handle_auth_login_complete(
         Ok(v) => v,
         Err(r) => return r.with_id(id),
     };
-    let (provider, endpoints, mode, client_secret) =
-        match provider_endpoints(&parsed.provider, &parsed.redirect_uri) {
-            Ok(v) => v,
-            Err(msg) => {
-                return RpcResponse::error(id, error::INVALID_PARAMS, msg);
-            }
-        };
+    let resolved = match resolve_oauth_provider(&parsed.provider, &parsed.redirect_uri) {
+        Ok(v) => v,
+        Err(e) => {
+            return RpcResponse::error(id, error::INVALID_PARAMS, e.to_string());
+        }
+    };
+    let provider = resolved.provider;
     let target = match resolve_oauth_target(
         runtime,
         provider,
@@ -647,7 +612,7 @@ pub async fn handle_auth_login_complete(
 
     let flow = match global_oauth_flow_registry().consume(
         &parsed.state,
-        &parsed.provider,
+        resolved.identity,
         &parsed.redirect_uri,
     ) {
         Ok(flow) => flow,
@@ -674,10 +639,10 @@ pub async fn handle_auth_login_complete(
     let http = reqwest::Client::new();
     let result = match exchange_authorization_code(
         &http,
-        &endpoints,
+        &resolved.endpoints,
         &parsed.code,
         &flow.pkce_verifier,
-        client_secret,
+        resolved.client_secret,
     )
     .await
     {
@@ -701,7 +666,7 @@ pub async fn handle_auth_login_complete(
         .expires_in_secs
         .map(|s| chrono::Utc::now() + chrono::Duration::seconds(s as i64));
     let tokens = PersistedTokens {
-        auth_mode: mode,
+        auth_mode: resolved.auth_mode,
         primary_secret: Some(result.access_token),
         refresh_token: result.refresh_token,
         id_token: result.id_token,
@@ -759,11 +724,11 @@ pub async fn handle_auth_login_device_start(
         Ok(v) => v,
         Err(r) => return r.with_id(id),
     };
-    let (_provider, endpoints, _mode, _secret) = match provider_endpoints(&parsed.provider, "") {
+    let resolved = match resolve_oauth_provider(&parsed.provider, "") {
         Ok(v) => v,
-        Err(msg) => return RpcResponse::error(id, error::INVALID_PARAMS, msg),
+        Err(e) => return RpcResponse::error(id, error::INVALID_PARAMS, e.to_string()),
     };
-    if endpoints.device_code_url.is_none() {
+    if resolved.endpoints.device_code_url.is_none() {
         return RpcResponse::error(
             id,
             error::INVALID_PARAMS,
@@ -774,7 +739,7 @@ pub async fn handle_auth_login_device_start(
         );
     }
     let http = reqwest::Client::new();
-    match request_device_code(&http, &endpoints).await {
+    match request_device_code(&http, &resolved.endpoints).await {
         Ok(resp) => RpcResponse::success(
             id,
             serde_json::json!({
@@ -824,12 +789,12 @@ pub async fn handle_auth_login_device_complete(
         Ok(v) => v,
         Err(r) => return r.with_id(id),
     };
-    let (provider, endpoints, mode, client_secret) = match provider_endpoints(&parsed.provider, "")
-    {
+    let resolved = match resolve_oauth_provider(&parsed.provider, "") {
         Ok(v) => v,
-        Err(msg) => return RpcResponse::error(id, error::INVALID_PARAMS, msg),
+        Err(e) => return RpcResponse::error(id, error::INVALID_PARAMS, e.to_string()),
     };
-    if endpoints.device_code_url.is_none() {
+    let provider = resolved.provider;
+    if resolved.endpoints.device_code_url.is_none() {
         return RpcResponse::error(
             id,
             error::INVALID_PARAMS,
@@ -867,17 +832,23 @@ pub async fn handle_auth_login_device_complete(
         );
     }
     let http = reqwest::Client::new();
-    let outcome =
-        match poll_device_code(&http, &endpoints, &parsed.device_code, client_secret).await {
-            Ok(o) => o,
-            Err(e) => {
-                return RpcResponse::error(
-                    id,
-                    error::INTERNAL_ERROR,
-                    format!("device-code poll failed: {e}"),
-                );
-            }
-        };
+    let outcome = match poll_device_code(
+        &http,
+        &resolved.endpoints,
+        &parsed.device_code,
+        resolved.client_secret,
+    )
+    .await
+    {
+        Ok(o) => o,
+        Err(e) => {
+            return RpcResponse::error(
+                id,
+                error::INTERNAL_ERROR,
+                format!("device-code poll failed: {e}"),
+            );
+        }
+    };
     match outcome {
         DevicePollOutcome::Pending => {
             RpcResponse::success(id, serde_json::json!({ "state": "pending" }))
@@ -900,7 +871,7 @@ pub async fn handle_auth_login_device_complete(
                 .expires_in_secs
                 .map(|s| chrono::Utc::now() + chrono::Duration::seconds(s as i64));
             let tokens = PersistedTokens {
-                auth_mode: mode,
+                auth_mode: resolved.auth_mode,
                 primary_secret: Some(result.access_token),
                 refresh_token: result.refresh_token,
                 id_token: result.id_token,


### PR DESCRIPTION
## Summary
- centralize OAuth provider alias, endpoint, auth mode, and client secret resolution in auth-core
- route REST and RPC OAuth login/device flows through the shared typed resolver
- store typed OAuth provider identity in server-side OAuth state instead of raw provider strings

## Validation
- ./scripts/repo-cargo test -p meerkat-auth-core oauth_flow
- ./scripts/repo-cargo check -p meerkat-rpc -p meerkat-rest
- rg -n "provider|alias|endpoint|client_secret|oauth" meerkat-rpc/src/handlers/auth.rs meerkat-rest/src/auth_endpoints.rs meerkat-auth-core/src/oauth_flow.rs
- make check (BuildBuddy invocation 0885c5a7-070f-4e41-b90f-8c14fcd375dc)

Linear: https://linear.app/lucrfr/issue/LUC-65/dogma-centralize-oauth-provider-alias-and-endpoint-identity