### PR TITLE
Type supervisor bridge rejections

### DIFF
--- a/meerkat-contracts/src/wire/supervisor_bridge.rs
+++ b/meerkat-contracts/src/wire/supervisor_bridge.rs
@@ -65,6 +65,23 @@ pub enum BridgeCommand {
     UnwireMember(BridgePeerWiringPayload),
 }
 
+impl BridgeCommand {
+    /// Protocol version carried by this command's payload.
+    pub fn protocol_version(&self) -> u32 {
+        match self {
+            Self::BindMember(payload) => payload.protocol_version,
+            Self::AuthorizeSupervisor(payload)
+            | Self::RevokeSupervisor(payload)
+            | Self::ObserveMember(payload)
+            | Self::InterruptMember(payload)
+            | Self::RetireMember(payload)
+            | Self::DestroyMember(payload) => payload.protocol_version,
+            Self::DeliverMemberInput(payload) => payload.protocol_version,
+            Self::WireMember(payload) | Self::UnwireMember(payload) => payload.protocol_version,
+        }
+    }
+}
+
 // ---------------------------------------------------------------------------
 // Reply envelope
 // ---------------------------------------------------------------------------
@@ -84,6 +101,88 @@ pub enum BridgeReply {
         cause: BridgeRejectionCause,
         reason: String,
     },
+}
+
+/// Decoded bridge rejection reply.
+///
+/// Protocol v2 rejections carry a typed [`BridgeRejectionCause`]. Bare JSON
+/// string replies are only a protocol-v1 compatibility shape; callers must not
+/// treat them as authoritative typed v2 causes.
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum BridgeRejectionReply {
+    Typed {
+        cause: BridgeRejectionCause,
+        reason: String,
+    },
+    LegacyV1RawString {
+        reason: String,
+    },
+}
+
+impl BridgeRejectionReply {
+    pub fn reason(&self) -> &str {
+        match self {
+            Self::Typed { reason, .. } | Self::LegacyV1RawString { reason } => reason,
+        }
+    }
+
+    pub fn typed_cause(&self) -> Option<BridgeRejectionCause> {
+        match self {
+            Self::Typed { cause, .. } => Some(*cause),
+            Self::LegacyV1RawString { .. } => None,
+        }
+    }
+
+    pub fn is_legacy_v1_raw_string(&self) -> bool {
+        matches!(self, Self::LegacyV1RawString { .. })
+    }
+}
+
+/// Decode a typed protocol-v2 bridge rejection.
+///
+/// Deliberately ignores bare JSON strings. Use
+/// [`decode_legacy_v1_raw_string_rejection`] only when the command was sent
+/// over the explicit protocol-v1 compatibility path.
+pub fn decode_protocol_v2_bridge_rejection(
+    value: &serde_json::Value,
+) -> Option<BridgeRejectionReply> {
+    match serde_json::from_value::<BridgeReply>(value.clone()).ok()? {
+        BridgeReply::Rejected { cause, reason } => {
+            Some(BridgeRejectionReply::Typed { cause, reason })
+        }
+        _ => None,
+    }
+}
+
+/// Decode the legacy protocol-v1 raw-string rejection compatibility shape.
+pub fn decode_legacy_v1_raw_string_rejection(
+    value: &serde_json::Value,
+) -> Option<BridgeRejectionReply> {
+    value
+        .as_str()
+        .map(|reason| BridgeRejectionReply::LegacyV1RawString {
+            reason: reason.to_string(),
+        })
+}
+
+/// Decode a bridge rejection according to the command protocol version.
+///
+/// Typed replies are accepted for every version so upgraded runtimes can reply
+/// precisely even while a persisted supervisor record still carries v1.
+/// Bare strings are accepted only for the explicit protocol-v1 compatibility
+/// path and never synthesize a typed cause.
+pub fn decode_bridge_rejection_reply(
+    protocol_version: u32,
+    value: &serde_json::Value,
+) -> Option<BridgeRejectionReply> {
+    decode_protocol_v2_bridge_rejection(value).or_else(|| {
+        if protocol_version == 1 {
+            decode_legacy_v1_raw_string_rejection(value)
+        } else {
+            None
+        }
+    })
 }
 
 /// Typed vocabulary for why a bridge command was rejected.
@@ -669,6 +768,56 @@ mod tests {
         }
         let reencoded = serde_json::to_value(&decoded).expect("reserialize reply");
         assert_eq!(value, reencoded);
+    }
+
+    #[test]
+    fn bridge_rejection_decoder_accepts_typed_protocol_v2_rejection() {
+        let value = json!({
+            "result": "rejected",
+            "cause": "sender_mismatch",
+            "reason": "wrong supervisor",
+        });
+
+        let decoded = decode_bridge_rejection_reply(SUPERVISOR_BRIDGE_PROTOCOL_VERSION, &value)
+            .expect("typed rejection should decode");
+
+        assert_eq!(
+            decoded.typed_cause(),
+            Some(BridgeRejectionCause::SenderMismatch)
+        );
+        assert_eq!(decoded.reason(), "wrong supervisor");
+        assert!(!decoded.is_legacy_v1_raw_string());
+    }
+
+    #[test]
+    fn bridge_rejection_decoder_rejects_raw_string_for_protocol_v2() {
+        let value = json!("legacy rejection");
+
+        assert!(
+            decode_bridge_rejection_reply(SUPERVISOR_BRIDGE_PROTOCOL_VERSION, &value).is_none(),
+            "protocol v2 must not promote raw strings into typed rejection causes"
+        );
+    }
+
+    #[test]
+    fn bridge_rejection_decoder_isolates_raw_string_to_legacy_v1() {
+        let value = json!("legacy rejection");
+
+        let decoded =
+            decode_bridge_rejection_reply(1, &value).expect("legacy raw string should decode");
+
+        assert_eq!(decoded.typed_cause(), None);
+        assert_eq!(decoded.reason(), "legacy rejection");
+        assert!(decoded.is_legacy_v1_raw_string());
+    }
+
+    #[test]
+    fn bridge_command_reports_payload_protocol_version() {
+        let mut payload = sample_supervisor_payload();
+        payload.protocol_version = 7;
+        let command = BridgeCommand::AuthorizeSupervisor(payload);
+
+        assert_eq!(command.protocol_version(), 7);
     }
 
     // -----------------------------------------------------------------------

--- a/meerkat-mob/src/runtime/actor.rs
+++ b/meerkat-mob/src/runtime/actor.rs
@@ -746,21 +746,11 @@ impl MobActor {
             .await
     }
 
-    fn bridge_rejection_reason(
+    fn bridge_rejection_reply(
+        protocol_version: u32,
         value: &serde_json::Value,
-    ) -> Option<(super::bridge_protocol::BridgeRejectionCause, String)> {
-        if let Some(reason) = value.as_str() {
-            return Some((
-                super::bridge_protocol::BridgeRejectionCause::Internal,
-                reason.to_string(),
-            ));
-        }
-        match serde_json::from_value::<super::bridge_protocol::BridgeReply>(value.clone()).ok()? {
-            super::bridge_protocol::BridgeReply::Rejected { cause, reason } => {
-                Some((cause, reason))
-            }
-            _ => None,
-        }
+    ) -> Option<super::bridge_protocol::BridgeRejectionReply> {
+        super::bridge_protocol::decode_bridge_rejection_reply(protocol_version, value)
     }
 
     async fn persist_rebound_binding(
@@ -817,14 +807,16 @@ impl MobActor {
         binding: Option<&crate::RuntimeBinding>,
     ) -> Result<TrustedPeerDescriptor, MobError> {
         let payload = self.bridge_supervisor_payload().await?;
+        let protocol_version = payload.protocol_version;
         let command = super::bridge_protocol::BridgeCommand::AuthorizeSupervisor(payload);
         self.supervisor_bridge.trust_recipient(peer).await?;
         let value = self
             .supervisor_bridge
             .send_bridge_command(peer, &command, std::time::Duration::from_secs(30))
             .await?;
-        if let Some((cause, reason)) = Self::bridge_rejection_reason(&value) {
-            if super::bridge_fallback::should_fall_back_to_bind(cause)
+        if let Some(rejection) = Self::bridge_rejection_reply(protocol_version, &value) {
+            if let Some(cause) = rejection.typed_cause()
+                && super::bridge_fallback::should_fall_back_to_bind(cause)
                 && let Some(binding) = binding
             {
                 let bind = self
@@ -847,7 +839,7 @@ impl MobActor {
                     "ensure_supervisor_authorized rebound peer",
                 );
             }
-            return Err(MobError::WiringError(reason));
+            return Err(MobError::WiringError(rejection.reason().to_string()));
         }
         let _ack: super::bridge_protocol::BridgeAck =
             serde_json::from_value(value).map_err(|error| {
@@ -869,8 +861,8 @@ impl MobActor {
             .supervisor_bridge
             .send_bridge_command(peer, command, timeout)
             .await?;
-        if let Some((_cause, reason)) = Self::bridge_rejection_reason(&value) {
-            return Err(MobError::WiringError(reason));
+        if let Some(rejection) = Self::bridge_rejection_reply(command.protocol_version(), &value) {
+            return Err(MobError::WiringError(rejection.reason().to_string()));
         }
         serde_json::from_value(value).map_err(|error| {
             MobError::Internal(format!("failed to decode bridge command response: {error}"))
@@ -8074,8 +8066,13 @@ impl MobActor {
                     .await;
                 let authorize_error = match authorize_result {
                     Ok(value) => {
-                        if let Some((cause, reason)) = Self::bridge_rejection_reason(&value) {
-                            if super::bridge_fallback::should_fall_back_to_bind(cause) {
+                        if let Some(rejection) =
+                            Self::bridge_rejection_reply(next_payload.protocol_version, &value)
+                        {
+                            let rejection_reason = rejection.reason().to_string();
+                            if let Some(cause) = rejection.typed_cause()
+                                && super::bridge_fallback::should_fall_back_to_bind(cause)
+                            {
                                 let bind = self
                                     .bind_peer_only_member_for_binding_with_payload(
                                         &peer,
@@ -8110,11 +8107,11 @@ impl MobActor {
                                         None
                                     }
                                     Err(bind_error) => Some(MobError::WiringError(format!(
-                                        "{reason}; bind fallback failed: {bind_error}"
+                                        "{rejection_reason}; bind fallback failed: {bind_error}"
                                     ))),
                                 }
                             } else {
-                                Some(MobError::WiringError(reason))
+                                Some(MobError::WiringError(rejection_reason))
                             }
                         } else if let Err(error) =
                             serde_json::from_value::<super::bridge_protocol::BridgeAck>(value)
@@ -9757,5 +9754,47 @@ impl MobActor {
             sender_comms,
         )
         .await
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::expect_used)]
+mod bridge_rejection_tests {
+    use super::MobActor;
+    use crate::runtime::bridge_protocol::{
+        BridgeRejectionCause, SUPERVISOR_BRIDGE_PROTOCOL_VERSION,
+    };
+    use serde_json::json;
+
+    #[test]
+    fn actor_decodes_typed_protocol_v2_bridge_rejection() {
+        let value = json!({
+            "result": "rejected",
+            "cause": "stale_supervisor",
+            "reason": "epoch too low",
+        });
+
+        let rejection =
+            MobActor::bridge_rejection_reply(SUPERVISOR_BRIDGE_PROTOCOL_VERSION, &value)
+                .expect("typed rejection should decode");
+
+        assert_eq!(
+            rejection.typed_cause(),
+            Some(BridgeRejectionCause::StaleSupervisor)
+        );
+        assert_eq!(rejection.reason(), "epoch too low");
+    }
+
+    #[test]
+    fn actor_does_not_promote_raw_string_as_protocol_v2_rejection() {
+        let value = json!("legacy rejection");
+
+        assert!(
+            MobActor::bridge_rejection_reply(SUPERVISOR_BRIDGE_PROTOCOL_VERSION, &value).is_none()
+        );
+        let legacy = MobActor::bridge_rejection_reply(1, &value)
+            .expect("legacy raw string should decode only on protocol v1");
+        assert_eq!(legacy.typed_cause(), None);
+        assert!(legacy.is_legacy_v1_raw_string());
     }
 }

--- a/meerkat-mob/src/runtime/bridge_protocol.rs
+++ b/meerkat-mob/src/runtime/bridge_protocol.rs
@@ -9,6 +9,7 @@ pub use meerkat_contracts::wire::supervisor_bridge::{
     BridgeCommand, BridgeDeliveryOutcome, BridgeDeliveryPayload, BridgeDeliveryResponse,
     BridgeDestroyResponse, BridgeMemberRuntimeState, BridgeObservationResponse,
     BridgePeerConnectivity, BridgePeerSpec, BridgePeerWiringPayload, BridgeRejectionCause,
-    BridgeRejectionClass, BridgeReply, BridgeRetireResponse, BridgeSupervisorPayload,
-    SUPERVISOR_BRIDGE_BOOTSTRAP_TOKEN_PARAM, SUPERVISOR_BRIDGE_INTENT, canonicalize_bridge_address,
+    BridgeRejectionClass, BridgeRejectionReply, BridgeReply, BridgeRetireResponse,
+    BridgeSupervisorPayload, SUPERVISOR_BRIDGE_BOOTSTRAP_TOKEN_PARAM, SUPERVISOR_BRIDGE_INTENT,
+    SUPERVISOR_BRIDGE_PROTOCOL_VERSION, canonicalize_bridge_address, decode_bridge_rejection_reply,
 };

--- a/meerkat-mob/src/runtime/provisioner.rs
+++ b/meerkat-mob/src/runtime/provisioner.rs
@@ -1452,21 +1452,11 @@ impl MultiBackendProvisioner {
         })
     }
 
-    fn bridge_rejection_reason(
+    fn bridge_rejection_reply(
+        protocol_version: u32,
         value: &serde_json::Value,
-    ) -> Option<(super::bridge_protocol::BridgeRejectionCause, String)> {
-        if let Some(reason) = value.as_str() {
-            return Some((
-                super::bridge_protocol::BridgeRejectionCause::Internal,
-                reason.to_string(),
-            ));
-        }
-        match serde_json::from_value::<super::bridge_protocol::BridgeReply>(value.clone()).ok()? {
-            super::bridge_protocol::BridgeReply::Rejected { cause, reason } => {
-                Some((cause, reason))
-            }
-            _ => None,
-        }
+    ) -> Option<super::bridge_protocol::BridgeRejectionReply> {
+        super::bridge_protocol::decode_bridge_rejection_reply(protocol_version, value)
     }
 
     async fn ensure_supervisor_authorized(
@@ -1475,14 +1465,16 @@ impl MultiBackendProvisioner {
         binding: Option<(&str, &str, Option<&str>)>,
     ) -> Result<TrustedPeerDescriptor, MobError> {
         let payload = self.bridge_supervisor_payload().await?;
+        let protocol_version = payload.protocol_version;
         let command = super::bridge_protocol::BridgeCommand::AuthorizeSupervisor(payload);
         self.supervisor_bridge.trust_recipient(peer).await?;
         let value = self
             .supervisor_bridge
             .send_bridge_command(peer, &command, Duration::from_secs(30))
             .await?;
-        if let Some((cause, reason)) = Self::bridge_rejection_reason(&value) {
-            if super::bridge_fallback::should_fall_back_to_bind(cause)
+        if let Some(rejection) = Self::bridge_rejection_reply(protocol_version, &value) {
+            if let Some(cause) = rejection.typed_cause()
+                && super::bridge_fallback::should_fall_back_to_bind(cause)
                 && let Some((peer_id, address, bootstrap_token)) = binding
             {
                 let bind: super::bridge_protocol::BridgeBindResponse = self
@@ -1498,7 +1490,7 @@ impl MultiBackendProvisioner {
                 .await?;
                 return Self::peer_only_spec_from_parts(&bind.peer_id, &bind.address);
             }
-            return Err(MobError::WiringError(reason));
+            return Err(MobError::WiringError(rejection.reason().to_string()));
         }
         Ok(peer.clone())
     }
@@ -1514,8 +1506,8 @@ impl MultiBackendProvisioner {
             .supervisor_bridge
             .send_bridge_command(peer, command, timeout)
             .await?;
-        if let Some((_cause, reason)) = Self::bridge_rejection_reason(&value) {
-            return Err(MobError::WiringError(reason));
+        if let Some(rejection) = Self::bridge_rejection_reply(command.protocol_version(), &value) {
+            return Err(MobError::WiringError(rejection.reason().to_string()));
         }
         serde_json::from_value(value).map_err(|error| {
             MobError::Internal(format!("failed to decode bridge command response: {error}"))
@@ -2061,5 +2053,53 @@ impl MobProvisioner for MultiBackendProvisioner {
 
     async fn rearm_all_checkpointers(&self) {
         self.session.rearm_all_checkpointers().await;
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::expect_used)]
+mod bridge_rejection_tests {
+    use super::MultiBackendProvisioner;
+    use crate::runtime::bridge_protocol::{
+        BridgeRejectionCause, SUPERVISOR_BRIDGE_PROTOCOL_VERSION,
+    };
+    use serde_json::json;
+
+    #[test]
+    fn provisioner_decodes_typed_protocol_v2_bridge_rejection() {
+        let value = json!({
+            "result": "rejected",
+            "cause": "not_bound",
+            "reason": "bind required",
+        });
+
+        let rejection = MultiBackendProvisioner::bridge_rejection_reply(
+            SUPERVISOR_BRIDGE_PROTOCOL_VERSION,
+            &value,
+        )
+        .expect("typed rejection should decode");
+
+        assert_eq!(
+            rejection.typed_cause(),
+            Some(BridgeRejectionCause::NotBound)
+        );
+        assert_eq!(rejection.reason(), "bind required");
+    }
+
+    #[test]
+    fn provisioner_does_not_promote_raw_string_as_protocol_v2_rejection() {
+        let value = json!("legacy rejection");
+
+        assert!(
+            MultiBackendProvisioner::bridge_rejection_reply(
+                SUPERVISOR_BRIDGE_PROTOCOL_VERSION,
+                &value,
+            )
+            .is_none()
+        );
+        let legacy = MultiBackendProvisioner::bridge_rejection_reply(1, &value)
+            .expect("legacy raw string should decode only on protocol v1");
+        assert_eq!(legacy.typed_cause(), None);
+        assert!(legacy.is_legacy_v1_raw_string());
     }
 }


### PR DESCRIPTION
## Summary
- add protocol-aware supervisor bridge rejection decoding in contracts
- require typed causes for protocol v2 and isolate raw string replies as legacy v1 compatibility
- update actor/provisioner rejection handling and focused tests

## Validation
- `./scripts/repo-cargo fmt`
- `./scripts/repo-cargo test -p meerkat-contracts bridge_rejection_decoder`
- `./scripts/repo-cargo test -p meerkat-contracts bridge_command_reports_payload_protocol_version`
- `./scripts/repo-cargo test -p meerkat-mob bridge_rejection_tests`
- `git diff --check`
- `make check`

Linear: https://linear.app/lucrfr/issue/LUC-69/dogma-type-supervisor-bridge-compatibility-rejections