### PR TITLE
Type bridge delivery rejections

### DIFF
--- a/meerkat-contracts/src/lib.rs
+++ b/meerkat-contracts/src/lib.rs
@@ -38,9 +38,10 @@ pub use session_locator::{SessionLocator, SessionLocatorError, format_session_re
 pub use version::ContractVersion;
 pub use wire::supervisor_bridge::{
     BridgeAck, BridgeBindPayload, BridgeBindResponse, BridgeCapabilities, BridgeCommand,
-    BridgeDeliveryOutcome, BridgeDeliveryPayload, BridgeDeliveryResponse, BridgeDestroyResponse,
-    BridgeMemberRuntimeState, BridgeObservationResponse, BridgePeerConnectivity, BridgePeerSpec,
-    BridgePeerWiringPayload, BridgeReply, BridgeRetireResponse, BridgeSupervisorPayload,
+    BridgeDeliveryOutcome, BridgeDeliveryPayload, BridgeDeliveryRejectionCause,
+    BridgeDeliveryResponse, BridgeDestroyResponse, BridgeMemberRuntimeState,
+    BridgeObservationResponse, BridgePeerConnectivity, BridgePeerSpec, BridgePeerWiringPayload,
+    BridgeReply, BridgeRetireResponse, BridgeSupervisorPayload,
 };
 pub use wire::{
     ApprovalActionKind,

--- a/meerkat-contracts/src/wire/mod.rs
+++ b/meerkat-contracts/src/wire/mod.rs
@@ -148,9 +148,9 @@ pub use session::{
 pub use skills::{SkillEntry, SkillInspectResponse, SkillListResponse, SkillSourceProvenance};
 pub use supervisor_bridge::{
     BridgeAck, BridgeBindPayload, BridgeBindResponse, BridgeCapabilities, BridgeCommand,
-    BridgeDeliveryOutcome, BridgeDeliveryPayload, BridgeDeliveryResponse, BridgeDestroyResponse,
-    BridgeMemberRuntimeState, BridgeObservationResponse, BridgePeerConnectivity, BridgePeerSpec,
-    BridgePeerWiringPayload, BridgeReply, BridgeRetireResponse, BridgeSupervisorPayload,
-    SUPERVISOR_BRIDGE_INTENT,
+    BridgeDeliveryOutcome, BridgeDeliveryPayload, BridgeDeliveryRejectionCause,
+    BridgeDeliveryResponse, BridgeDestroyResponse, BridgeMemberRuntimeState,
+    BridgeObservationResponse, BridgePeerConnectivity, BridgePeerSpec, BridgePeerWiringPayload,
+    BridgeReply, BridgeRetireResponse, BridgeSupervisorPayload, SUPERVISOR_BRIDGE_INTENT,
 };
 pub use usage::WireUsage;

--- a/meerkat-contracts/src/wire/supervisor_bridge.rs
+++ b/meerkat-contracts/src/wire/supervisor_bridge.rs
@@ -20,7 +20,9 @@ pub const SUPERVISOR_BRIDGE_BOOTSTRAP_TOKEN_PARAM: &str = "mob_supervisor_bootst
 /// - `1`: initial protocol with untyped `BridgeReply::Rejected { reason: String }`.
 /// - `2`: `BridgeReply::Rejected { cause: BridgeRejectionCause, reason: String }`
 ///   so callers branch on typed cause; runtime-side emitters pass typed
-///   `BridgeReply` values through to the transport.
+///   `BridgeReply` values through to the transport. Delivery rejections
+///   carry typed `BridgeDeliveryRejectionCause` data; the string `reason`
+///   remains diagnostic presentation only.
 pub const SUPERVISOR_BRIDGE_PROTOCOL_VERSION: u32 = 2;
 
 /// Remove the one-time bind bootstrap token from an advertised bridge address.
@@ -507,8 +509,48 @@ pub struct BridgeDeliveryPayload {
 #[serde(tag = "outcome", rename_all = "snake_case")]
 pub enum BridgeDeliveryOutcome {
     Accepted,
-    Deduplicated { existing_input_id: String },
-    Rejected { reason: String },
+    Deduplicated {
+        existing_input_id: String,
+    },
+    Rejected {
+        cause: BridgeDeliveryRejectionCause,
+        reason: String,
+    },
+}
+
+/// Typed vocabulary for why member input delivery was rejected.
+///
+/// This mirrors the runtime accept-boundary rejection vocabulary at the
+/// bridge wire boundary. Callers should branch on this typed cause and treat
+/// the sibling `reason` string on [`BridgeDeliveryOutcome::Rejected`] as
+/// operator-facing presentation only.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(tag = "kind", rename_all = "snake_case")]
+#[non_exhaustive]
+pub enum BridgeDeliveryRejectionCause {
+    /// Runtime was not in a state that accepts input.
+    NotReady { state: String },
+    /// Input failed durability validation.
+    DurabilityViolation { detail: String },
+    /// Peer input carried a forbidden handling mode.
+    PeerHandlingModeInvalid { detail: String },
+    /// The bridge could not map the rejection to a known typed cause.
+    Internal { detail: String },
+}
+
+impl std::fmt::Display for BridgeDeliveryRejectionCause {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::NotReady { state } => write!(f, "not_ready(state={state})"),
+            Self::DurabilityViolation { detail } => {
+                write!(f, "durability_violation(detail={detail})")
+            }
+            Self::PeerHandlingModeInvalid { detail } => {
+                write!(f, "peer_handling_mode_invalid(detail={detail})")
+            }
+            Self::Internal { detail } => write!(f, "internal(detail={detail})"),
+        }
+    }
 }
 
 /// Full response to a delivery command.
@@ -1058,6 +1100,32 @@ mod tests {
                 "input_id": "in-1",
                 "canonical_input_id": null,
                 "outcome": { "outcome": "accepted" },
+            }),
+        );
+
+        assert_reply_round_trip(
+            BridgeReply::Delivery(BridgeDeliveryResponse {
+                input_id: "in-2".to_string(),
+                canonical_input_id: None,
+                outcome: BridgeDeliveryOutcome::Rejected {
+                    cause: BridgeDeliveryRejectionCause::DurabilityViolation {
+                        detail: "derived durable input cannot be accepted".to_string(),
+                    },
+                    reason: "derived durable input cannot be accepted".to_string(),
+                },
+            }),
+            json!({
+                "result": "delivery",
+                "input_id": "in-2",
+                "canonical_input_id": null,
+                "outcome": {
+                    "outcome": "rejected",
+                    "cause": {
+                        "kind": "durability_violation",
+                        "detail": "derived durable input cannot be accepted",
+                    },
+                    "reason": "derived durable input cannot be accepted",
+                },
             }),
         );
     }

--- a/meerkat-mob/src/error.rs
+++ b/meerkat-mob/src/error.rs
@@ -125,6 +125,13 @@ pub enum MobError {
         to_role: ProfileName,
     },
 
+    /// A bridge accepted the delivery command but rejected the member input.
+    #[error("bridge delivery rejected ({cause}): {reason}")]
+    BridgeDeliveryRejected {
+        cause: meerkat_contracts::wire::supervisor_bridge::BridgeDeliveryRejectionCause,
+        reason: String,
+    },
+
     /// Supervisor escalation happened.
     #[error("supervisor escalation: {0}")]
     SupervisorEscalation(String),

--- a/meerkat-mob/src/lib.rs
+++ b/meerkat-mob/src/lib.rs
@@ -116,9 +116,10 @@ pub use runtime::bridge::{
 };
 pub use runtime::bridge_protocol::{
     BridgeAck, BridgeBindPayload, BridgeBindResponse, BridgeCapabilities, BridgeCommand,
-    BridgeDeliveryOutcome, BridgeDeliveryPayload, BridgeDeliveryResponse, BridgeDestroyResponse,
-    BridgeMemberRuntimeState, BridgeObservationResponse, BridgePeerConnectivity, BridgePeerSpec,
-    BridgePeerWiringPayload, BridgeReply, BridgeRetireResponse, BridgeSupervisorPayload,
+    BridgeDeliveryOutcome, BridgeDeliveryPayload, BridgeDeliveryRejectionCause,
+    BridgeDeliveryResponse, BridgeDestroyResponse, BridgeMemberRuntimeState,
+    BridgeObservationResponse, BridgePeerConnectivity, BridgePeerSpec, BridgePeerWiringPayload,
+    BridgeReply, BridgeRetireResponse, BridgeSupervisorPayload,
 };
 #[cfg(feature = "runtime-adapter")]
 pub use runtime::local_bridge::LocalMobRuntimeBridge;

--- a/meerkat-mob/src/runtime/bridge_protocol.rs
+++ b/meerkat-mob/src/runtime/bridge_protocol.rs
@@ -6,10 +6,11 @@
 
 pub use meerkat_contracts::wire::supervisor_bridge::{
     BridgeAck, BridgeBindPayload, BridgeBindResponse, BridgeBootstrapToken, BridgeCapabilities,
-    BridgeCommand, BridgeDeliveryOutcome, BridgeDeliveryPayload, BridgeDeliveryResponse,
-    BridgeDestroyResponse, BridgeMemberRuntimeState, BridgeObservationResponse,
-    BridgePeerConnectivity, BridgePeerSpec, BridgePeerWiringPayload, BridgeRejectionCause,
-    BridgeRejectionClass, BridgeRejectionReply, BridgeReply, BridgeRetireResponse,
-    BridgeSupervisorPayload, SUPERVISOR_BRIDGE_BOOTSTRAP_TOKEN_PARAM, SUPERVISOR_BRIDGE_INTENT,
-    SUPERVISOR_BRIDGE_PROTOCOL_VERSION, canonicalize_bridge_address, decode_bridge_rejection_reply,
+    BridgeCommand, BridgeDeliveryOutcome, BridgeDeliveryPayload, BridgeDeliveryRejectionCause,
+    BridgeDeliveryResponse, BridgeDestroyResponse, BridgeMemberRuntimeState,
+    BridgeObservationResponse, BridgePeerConnectivity, BridgePeerSpec, BridgePeerWiringPayload,
+    BridgeRejectionCause, BridgeRejectionClass, BridgeRejectionReply, BridgeReply,
+    BridgeRetireResponse, BridgeSupervisorPayload, SUPERVISOR_BRIDGE_BOOTSTRAP_TOKEN_PARAM,
+    SUPERVISOR_BRIDGE_INTENT, SUPERVISOR_BRIDGE_PROTOCOL_VERSION, canonicalize_bridge_address,
+    decode_bridge_rejection_reply,
 };

--- a/meerkat-mob/src/runtime/local_bridge.rs
+++ b/meerkat-mob/src/runtime/local_bridge.rs
@@ -5,9 +5,9 @@
 use crate::error::MobError;
 use crate::runtime::bridge::MobBoundMemberRuntimeBridge;
 use crate::runtime::bridge_protocol::{
-    BridgeAck, BridgeDeliveryOutcome, BridgeDeliveryResponse, BridgeDestroyResponse,
-    BridgeMemberRuntimeState, BridgeObservationResponse, BridgePeerConnectivity, BridgePeerSpec,
-    BridgeRetireResponse,
+    BridgeAck, BridgeDeliveryOutcome, BridgeDeliveryRejectionCause, BridgeDeliveryResponse,
+    BridgeDestroyResponse, BridgeMemberRuntimeState, BridgeObservationResponse,
+    BridgePeerConnectivity, BridgePeerSpec, BridgeRetireResponse,
 };
 use async_trait::async_trait;
 use meerkat_core::types::{ContentInput, HandlingMode, SessionId};
@@ -48,6 +48,31 @@ fn runtime_state_to_bridge(
         )),
     };
     Ok(state)
+}
+
+fn bridge_delivery_rejection_cause(
+    reason: &meerkat_runtime::RejectReason,
+) -> BridgeDeliveryRejectionCause {
+    match reason {
+        meerkat_runtime::RejectReason::NotReady { state } => {
+            BridgeDeliveryRejectionCause::NotReady {
+                state: state.clone(),
+            }
+        }
+        meerkat_runtime::RejectReason::DurabilityViolation { detail } => {
+            BridgeDeliveryRejectionCause::DurabilityViolation {
+                detail: detail.clone(),
+            }
+        }
+        meerkat_runtime::RejectReason::PeerHandlingModeInvalid { detail } => {
+            BridgeDeliveryRejectionCause::PeerHandlingModeInvalid {
+                detail: detail.clone(),
+            }
+        }
+        _ => BridgeDeliveryRejectionCause::Internal {
+            detail: reason.to_string(),
+        },
+    }
 }
 
 #[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
@@ -132,17 +157,24 @@ impl MobBoundMemberRuntimeBridge for LocalMobRuntimeBridge {
                             },
                         }
                     }
-                    meerkat_runtime::AcceptOutcome::Rejected { reason } => BridgeDeliveryResponse {
-                        input_id: input_id.to_string(),
-                        canonical_input_id: None,
-                        outcome: BridgeDeliveryOutcome::Rejected {
-                            reason: reason.to_string(),
-                        },
-                    },
+                    meerkat_runtime::AcceptOutcome::Rejected { reason } => {
+                        let cause = bridge_delivery_rejection_cause(&reason);
+                        BridgeDeliveryResponse {
+                            input_id: input_id.to_string(),
+                            canonical_input_id: None,
+                            outcome: BridgeDeliveryOutcome::Rejected {
+                                cause,
+                                reason: reason.to_string(),
+                            },
+                        }
+                    }
                     _ => BridgeDeliveryResponse {
                         input_id: input_id.to_string(),
                         canonical_input_id: None,
                         outcome: BridgeDeliveryOutcome::Rejected {
+                            cause: BridgeDeliveryRejectionCause::Internal {
+                                detail: "unexpected accept outcome".to_string(),
+                            },
                             reason: "unexpected accept outcome".to_string(),
                         },
                     },

--- a/meerkat-mob/src/runtime/provisioner.rs
+++ b/meerkat-mob/src/runtime/provisioner.rs
@@ -1851,10 +1851,8 @@ impl MobProvisioner for MultiBackendProvisioner {
                 match response.outcome {
                     super::bridge_protocol::BridgeDeliveryOutcome::Accepted
                     | super::bridge_protocol::BridgeDeliveryOutcome::Deduplicated { .. } => {}
-                    super::bridge_protocol::BridgeDeliveryOutcome::Rejected { reason } => {
-                        return Err(MobError::Internal(format!(
-                            "peer-only turn delivery rejected: {reason}"
-                        )));
+                    super::bridge_protocol::BridgeDeliveryOutcome::Rejected { cause, reason } => {
+                        return Err(MobError::BridgeDeliveryRejected { cause, reason });
                     }
                 }
                 self.session

--- a/meerkat-mob/src/runtime/tests.rs
+++ b/meerkat-mob/src/runtime/tests.rs
@@ -22284,6 +22284,9 @@ fn summarize_mob_runtime_error(error: &MobError) -> String {
         MobError::SchemaValidation { .. } => "schema_validation".to_string(),
         MobError::InsufficientTargets { .. } => "insufficient_targets".to_string(),
         MobError::TopologyViolation { .. } => "topology_violation".to_string(),
+        MobError::BridgeDeliveryRejected { cause, .. } => {
+            format!("bridge_delivery_rejected:{cause}")
+        }
         MobError::SupervisorEscalation(_) => "supervisor_escalation".to_string(),
         MobError::UnsupportedForMode { .. } => "unsupported_for_mode".to_string(),
         MobError::ResetBarrier => "reset_barrier".to_string(),

--- a/meerkat-runtime/src/comms_drain.rs
+++ b/meerkat-runtime/src/comms_drain.rs
@@ -20,11 +20,11 @@ use meerkat_core::types::SessionId;
 
 use meerkat_contracts::wire::supervisor_bridge::{
     BridgeAck, BridgeBindResponse, BridgeCapabilities, BridgeCommand, BridgeDeliveryOutcome,
-    BridgeDeliveryPayload, BridgeDeliveryResponse, BridgeDestroyResponse, BridgeMemberRuntimeState,
-    BridgeObservationResponse, BridgePeerConnectivity, BridgePeerSpec, BridgeRejectionCause,
-    BridgeReply, BridgeRetireResponse, BridgeSupervisorPayload,
-    SUPERVISOR_BRIDGE_BOOTSTRAP_TOKEN_PARAM, SUPERVISOR_BRIDGE_INTENT,
-    SUPERVISOR_BRIDGE_PROTOCOL_VERSION, canonicalize_bridge_address,
+    BridgeDeliveryPayload, BridgeDeliveryRejectionCause, BridgeDeliveryResponse,
+    BridgeDestroyResponse, BridgeMemberRuntimeState, BridgeObservationResponse,
+    BridgePeerConnectivity, BridgePeerSpec, BridgeRejectionCause, BridgeReply,
+    BridgeRetireResponse, BridgeSupervisorPayload, SUPERVISOR_BRIDGE_BOOTSTRAP_TOKEN_PARAM,
+    SUPERVISOR_BRIDGE_INTENT, SUPERVISOR_BRIDGE_PROTOCOL_VERSION, canonicalize_bridge_address,
 };
 
 use crate::comms_bridge::classified_interaction_to_runtime_input;
@@ -491,6 +491,26 @@ fn peer_input_from_delivery_payload(
             mode => Some(mode),
         },
     })
+}
+
+fn bridge_delivery_rejection_cause(
+    reason: &crate::accept::RejectReason,
+) -> BridgeDeliveryRejectionCause {
+    match reason {
+        crate::accept::RejectReason::NotReady { state } => BridgeDeliveryRejectionCause::NotReady {
+            state: state.clone(),
+        },
+        crate::accept::RejectReason::DurabilityViolation { detail } => {
+            BridgeDeliveryRejectionCause::DurabilityViolation {
+                detail: detail.clone(),
+            }
+        }
+        crate::accept::RejectReason::PeerHandlingModeInvalid { detail } => {
+            BridgeDeliveryRejectionCause::PeerHandlingModeInvalid {
+                detail: detail.clone(),
+            }
+        }
+    }
 }
 
 fn advertised_bind_bootstrap_token(
@@ -1410,10 +1430,12 @@ async fn try_handle_supervisor_bridge_command(
                             }
                         }
                         crate::accept::AcceptOutcome::Rejected { reason } => {
+                            let cause = bridge_delivery_rejection_cause(&reason);
                             BridgeDeliveryResponse {
                                 input_id: request_input_id,
                                 canonical_input_id: None,
                                 outcome: BridgeDeliveryOutcome::Rejected {
+                                    cause,
                                     reason: reason.to_string(),
                                 },
                             }


### PR DESCRIPTION
## Summary
- Add typed bridge delivery rejection causes to the supervisor bridge wire outcome.
- Translate runtime/local accept rejection reasons into bridge delivery causes.
- Preserve peer-only delivery rejections as MobError::BridgeDeliveryRejected instead of generic internal errors.

## Validation
- make fmt
- ./scripts/repo-cargo check -p meerkat-contracts -p meerkat-runtime -p meerkat-mob
- ./scripts/repo-cargo test -p meerkat-contracts bridge_reply_delivery_round_trip
- make check

Linear: LUC-70