### PR TITLE
Resolve model defaults by provider

### DIFF
--- a/meerkat-core/src/model_registry.rs
+++ b/meerkat-core/src/model_registry.rs
@@ -99,8 +99,22 @@ impl ModelRegistry {
         self.entries.get(model_id)
     }
 
+    pub fn entry_for_provider(
+        &self,
+        provider: Provider,
+        model_id: &str,
+    ) -> Option<&ModelRegistryEntry> {
+        self.entry(model_id)
+            .filter(|entry| entry.provider == provider)
+    }
+
     pub fn profile_for(&self, model_id: &str) -> Option<ModelProfile> {
         self.entry(model_id).map(|entry| entry.profile.clone())
+    }
+
+    pub fn profile_for_provider(&self, provider: Provider, model_id: &str) -> Option<ModelProfile> {
+        self.entry_for_provider(provider, model_id)
+            .map(|entry| entry.profile.clone())
     }
 
     pub fn default_model(&self, provider: Provider) -> Option<&str> {
@@ -378,5 +392,29 @@ mod tests {
         assert!(registry.profile_for("gpt-unknown-preview").is_none());
         assert!(registry.profile_for("claude-unknown-preview").is_none());
         assert!(registry.profile_for("gemini-unknown-preview").is_none());
+    }
+
+    #[test]
+    fn provider_aware_profile_lookup_requires_matching_provider() {
+        let registry = match ModelRegistry::from_config(&Config::default()) {
+            Ok(registry) => registry,
+            Err(err) => panic!("registry construction failed: {err}"),
+        };
+
+        let profile = registry.profile_for_provider(Provider::OpenAI, "gpt-5.4");
+        assert_eq!(
+            profile.and_then(|profile| profile.call_timeout_secs),
+            Some(600)
+        );
+        assert!(
+            registry
+                .profile_for_provider(Provider::Anthropic, "gpt-5.4")
+                .is_none(),
+            "provider-aware lookup must not share OpenAI defaults with Anthropic"
+        );
+        assert!(
+            registry.profile_for("gpt-5.4").is_some(),
+            "legacy unambiguous model-id lookup remains available"
+        );
     }
 }

--- a/meerkat/src/factory.rs
+++ b/meerkat/src/factory.rs
@@ -654,21 +654,21 @@ pub enum BuildAgentError {
     KeepAliveRequiresCommsName,
 }
 
-/// Resolver that delegates to `meerkat_models::profile::profile_for()`
-/// to look up model-specific operational defaults at call time.
+/// Resolver that delegates to [`ModelRegistry`] to look up model-specific
+/// operational defaults at call time.
 ///
 /// This struct bridges the dependency gap: `meerkat-core` owns the
 /// `ModelOperationalDefaultsResolver` trait, and this facade-layer
-/// implementation provides the concrete `meerkat-models` lookup.
+/// implementation provides the concrete registry lookup.
 struct RegistryBackedDefaultsResolver {
     registry: Arc<ModelRegistry>,
 }
 
 impl meerkat_core::ModelOperationalDefaultsResolver for RegistryBackedDefaultsResolver {
     fn call_timeout_for(&self, provider: &str, model: &str) -> Option<std::time::Duration> {
-        let _ = provider;
+        let provider = Provider::parse_strict(provider)?;
         self.registry
-            .profile_for(model)
+            .profile_for_provider(provider, model)
             .and_then(|p| p.call_timeout_secs)
             .map(std::time::Duration::from_secs)
     }
@@ -3391,6 +3391,30 @@ mod tests {
         RealmConfigSection, SelfHostedApiStyle, SelfHostedModelConfig, SelfHostedServerConfig,
         SelfHostedTransport,
     };
+
+    #[test]
+    fn registry_backed_defaults_resolver_respects_provider_identity() {
+        let registry = ModelRegistry::from_config(&Config::default()).expect("registry");
+        let resolver = RegistryBackedDefaultsResolver {
+            registry: Arc::new(registry),
+        };
+
+        assert_eq!(
+            meerkat_core::ModelOperationalDefaultsResolver::call_timeout_for(
+                &resolver, "openai", "gpt-5.4"
+            ),
+            Some(std::time::Duration::from_secs(600))
+        );
+        assert_eq!(
+            meerkat_core::ModelOperationalDefaultsResolver::call_timeout_for(
+                &resolver,
+                "anthropic",
+                "gpt-5.4"
+            ),
+            None,
+            "provider-aware default lookup must not reuse OpenAI defaults for Anthropic"
+        );
+    }
 
     #[cfg(feature = "skills")]
     fn test_skill_key(source_uuid: &str, skill_name: &str) -> SkillKey {


### PR DESCRIPTION
## Summary
- Add provider-aware ModelRegistry entry/profile lookup helpers while retaining the existing model-id lookup.
- Use provider-aware lookup in the runtime operational defaults resolver so mismatched providers do not inherit another provider's call timeout.
- Add focused coverage for provider mismatch and stable unambiguous model lookup behavior.

Linear: LUC-64

## Validation
- ./scripts/repo-cargo test -p meerkat-core model_registry --lib
- ./scripts/repo-cargo test -p meerkat registry_backed_defaults_resolver_respects_provider_identity --lib
- rg -n "operational|provider|model.*default|ModelProfile|ModelRegistry" meerkat-core/src/model_profile/mod.rs meerkat-core/src/agent/state.rs meerkat/src/factory.rs meerkat-core/src/model_registry.rs
- make check (BuildBuddy invocation 9b67171a-83b2-4cdd-9a86-1a49286a9fd2)