### PR TITLE
Stop raw session rows escaping as authority

### DIFF
--- a/meerkat-core/src/session.rs
+++ b/meerkat-core/src/session.rs
@@ -752,6 +752,20 @@ impl Session {
         self.updated_at = SystemTime::now();
     }
 
+    /// Backfill a missing metadata value without changing `updated_at`.
+    ///
+    /// This is only for compatibility reads that need to hydrate metadata from
+    /// an older projection. Semantic metadata mutations must use
+    /// [`Session::set_metadata`] so the session timestamp advances.
+    pub fn backfill_metadata_if_absent(&mut self, key: &str, value: serde_json::Value) -> bool {
+        if self.metadata.contains_key(key) {
+            false
+        } else {
+            self.metadata.insert(key.to_string(), value);
+            true
+        }
+    }
+
     /// Remove a metadata value.
     pub fn remove_metadata(&mut self, key: &str) {
         self.metadata.remove(key);
@@ -1346,6 +1360,21 @@ mod tests {
         session.set_metadata("key", serde_json::json!("value"));
 
         assert_eq!(session.metadata().get("key").unwrap(), "value");
+    }
+
+    #[test]
+    fn test_session_metadata_backfill_preserves_timestamp() {
+        let mut session = Session::new();
+        let initial_updated = session.updated_at();
+
+        std::thread::sleep(std::time::Duration::from_millis(10));
+
+        assert!(session.backfill_metadata_if_absent("key", serde_json::json!("value")));
+        assert_eq!(session.metadata().get("key").unwrap(), "value");
+        assert_eq!(session.updated_at(), initial_updated);
+        assert!(!session.backfill_metadata_if_absent("key", serde_json::json!("other")));
+        assert_eq!(session.metadata().get("key").unwrap(), "value");
+        assert_eq!(session.updated_at(), initial_updated);
     }
 
     #[test]

--- a/meerkat-session/src/persistent.rs
+++ b/meerkat-session/src/persistent.rs
@@ -576,15 +576,9 @@ impl<B: SessionAgentBuilder + 'static> PersistentSessionService<B> {
         &self,
         id: &SessionId,
     ) -> Result<Option<Session>, SessionError> {
-        let store_snapshot = self
-            .store
-            .load(id)
-            .await
-            .map_err(|e| SessionError::Store(Box::new(e)))?;
-
-        let runtime_snapshot = if let Some(runtime_store) = self.runtime_store.as_ref() {
+        if let Some(runtime_store) = self.runtime_store.as_ref() {
             let runtime_id = Self::runtime_id_for_session(id);
-            runtime_store
+            let Some(runtime) = runtime_store
                 .load_session_snapshot(&runtime_id)
                 .await
                 .map_err(|err| {
@@ -602,30 +596,46 @@ impl<B: SessionAgentBuilder + 'static> PersistentSessionService<B> {
                     )
                 })
                 .transpose()?
-        } else {
-            None
-        };
+            else {
+                return Ok(None);
+            };
 
-        Ok(match (store_snapshot, runtime_snapshot) {
-            (Some(store), Some(runtime)) => {
-                Some(Self::runtime_session_with_store_metadata(runtime, &store))
-            }
-            (Some(store), None) => Some(store),
-            (None, Some(runtime)) => Some(runtime),
-            (None, None) => None,
-        })
+            let store_snapshot = match self.store.load(id).await {
+                Ok(store_snapshot) => store_snapshot,
+                Err(error) => {
+                    tracing::warn!(
+                        session_id = %id,
+                        error = %error,
+                        "failed to load non-authoritative session-store projection for metadata backfill"
+                    );
+                    None
+                }
+            };
+
+            return Ok(match store_snapshot {
+                Some(store) => Some(Self::runtime_session_with_store_metadata(runtime, &store)),
+                None => Some(runtime),
+            });
+        } else {
+            self.store
+                .load(id)
+                .await
+                .map_err(|e| SessionError::Store(Box::new(e)))
+        }
     }
 
     fn runtime_session_with_store_metadata(mut runtime: Session, store: &Session) -> Session {
+        if store.updated_at() > runtime.updated_at() {
+            return runtime;
+        }
+
         for key in [
             meerkat_core::session::SESSION_METADATA_KEY,
             meerkat_core::SESSION_BUILD_STATE_KEY,
             crate::SESSION_LABELS_KEY,
         ] {
-            if let Some(value) = store.metadata().get(key)
-                && !runtime.metadata().contains_key(key)
-            {
-                runtime.set_metadata(key, value.clone());
+            if let Some(value) = store.metadata().get(key) {
+                runtime.backfill_metadata_if_absent(key, value.clone());
             }
         }
         runtime
@@ -4335,6 +4345,11 @@ mod tests {
             runtime_session.messages().len(),
             "newer runtime snapshot still owns committed conversation state"
         );
+        assert_eq!(
+            authoritative.updated_at(),
+            runtime_session.updated_at(),
+            "metadata backfill from an older store projection must not change runtime snapshot timestamps"
+        );
         let actual_metadata = authoritative
             .session_metadata()
             .expect("authoritative session should preserve durable metadata");
@@ -4347,6 +4362,50 @@ mod tests {
         assert_eq!(
             actual_build_state.system_prompt,
             expected_build_state.system_prompt
+        );
+    }
+
+    #[tokio::test]
+    async fn test_runtime_backed_authoritative_load_rejects_store_only_projection() {
+        let store: Arc<dyn SessionStore> = Arc::new(MemoryStore::new());
+        let runtime_store = Arc::new(InMemoryRuntimeStore::new());
+        let service = PersistentSessionService::new(
+            DummyBuilder,
+            4,
+            Arc::clone(&store),
+            Some(runtime_store),
+            memory_blob_store(),
+        );
+
+        let mut raw_projection = Session::new();
+        raw_projection.push(Message::User(UserMessage::text(
+            "legacy raw store row".to_string(),
+        )));
+        let id = raw_projection.id().clone();
+        store
+            .save(&raw_projection)
+            .await
+            .expect("test should seed a raw store projection");
+
+        assert!(
+            service
+                .load_authoritative_session(&id)
+                .await
+                .expect("authoritative load should succeed")
+                .is_none(),
+            "runtime-backed reads must not promote store-only rows to authoritative sessions"
+        );
+        assert!(
+            matches!(service.read(&id).await, Err(SessionError::NotFound { .. })),
+            "read() must hide store-only compatibility rows when runtime authority is configured"
+        );
+        let listed = service
+            .list(SessionQuery::default())
+            .await
+            .expect("list should succeed");
+        assert!(
+            listed.iter().all(|summary| summary.session_id != id),
+            "list() must not expose store-only compatibility rows when runtime authority is configured"
         );
     }
 
@@ -4393,6 +4452,92 @@ mod tests {
             authoritative.messages().len(),
             runtime_authority.messages().len(),
             "raw session-store rows must not override an existing runtime authority snapshot"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_authoritative_load_ignores_newer_raw_store_metadata_projection() {
+        let store: Arc<dyn SessionStore> = Arc::new(MemoryStore::new());
+        let runtime_store = Arc::new(InMemoryRuntimeStore::new());
+        let service = PersistentSessionService::new(
+            DummyBuilder,
+            4,
+            Arc::clone(&store),
+            Some(runtime_store),
+            memory_blob_store(),
+        );
+
+        let result = service
+            .create_session(create_request(
+                "hello",
+                meerkat_core::service::InitialTurnPolicy::Defer,
+            ))
+            .await
+            .expect("create_session should succeed");
+        let runtime_authority = service
+            .load_authoritative_session(&result.session_id)
+            .await
+            .expect("authoritative load should succeed")
+            .expect("runtime authority should exist");
+
+        tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+        let mut raw_store_projection = runtime_authority.clone();
+        raw_store_projection.set_metadata(
+            SESSION_LABELS_KEY,
+            serde_json::json!({
+                "source": "raw-store",
+            }),
+        );
+        store
+            .save(&raw_store_projection)
+            .await
+            .expect("test should be able to write a stale raw projection");
+        service
+            .discard_live_session(&result.session_id)
+            .await
+            .expect("test should evict the live session so read/list use durable state");
+
+        let authoritative = service
+            .load_authoritative_session(&result.session_id)
+            .await
+            .expect("authoritative load should succeed")
+            .expect("authoritative session should exist");
+        assert_eq!(
+            authoritative.updated_at(),
+            runtime_authority.updated_at(),
+            "newer raw metadata projections must not advance runtime-authoritative timestamps"
+        );
+        assert!(
+            !authoritative.metadata().contains_key(SESSION_LABELS_KEY),
+            "newer raw metadata projections must not be backfilled into runtime authority"
+        );
+
+        let view = service
+            .read(&result.session_id)
+            .await
+            .expect("read should use runtime authority");
+        assert!(
+            view.state.labels.is_empty(),
+            "read() must not expose labels from a newer raw store projection"
+        );
+        let listed = service
+            .list(SessionQuery::default())
+            .await
+            .expect("list should use runtime authority");
+        let summary = listed
+            .iter()
+            .find(|summary| summary.session_id == result.session_id)
+            .expect(
+                "runtime-backed session should still be listed via its compatibility projection",
+            );
+        assert!(
+            summary.labels.is_empty(),
+            "list() must not expose labels from a newer raw store projection"
+        );
+        assert_eq!(
+            summary.updated_at,
+            runtime_authority.updated_at(),
+            "list() must report the runtime-authoritative timestamp"
         );
     }
 

--- a/meerkat-session/src/persistent.rs
+++ b/meerkat-session/src/persistent.rs
@@ -578,7 +578,7 @@ impl<B: SessionAgentBuilder + 'static> PersistentSessionService<B> {
     ) -> Result<Option<Session>, SessionError> {
         if let Some(runtime_store) = self.runtime_store.as_ref() {
             let runtime_id = Self::runtime_id_for_session(id);
-            let Some(runtime) = runtime_store
+            let runtime_snapshot = runtime_store
                 .load_session_snapshot(&runtime_id)
                 .await
                 .map_err(|err| {
@@ -595,27 +595,40 @@ impl<B: SessionAgentBuilder + 'static> PersistentSessionService<B> {
                         },
                     )
                 })
-                .transpose()?
-            else {
-                return Ok(None);
-            };
+                .transpose()?;
 
-            let store_snapshot = match self.store.load(id).await {
-                Ok(store_snapshot) => store_snapshot,
-                Err(error) => {
-                    tracing::warn!(
-                        session_id = %id,
-                        error = %error,
-                        "failed to load non-authoritative session-store projection for metadata backfill"
-                    );
-                    None
-                }
-            };
+            if let Some(runtime) = runtime_snapshot {
+                let store_snapshot = match self.store.load(id).await {
+                    Ok(store_snapshot) => store_snapshot,
+                    Err(error) => {
+                        tracing::warn!(
+                            session_id = %id,
+                            error = %error,
+                            "failed to load non-authoritative session-store projection for metadata backfill"
+                        );
+                        None
+                    }
+                };
 
-            return Ok(match store_snapshot {
-                Some(store) => Some(Self::runtime_session_with_store_metadata(runtime, &store)),
-                None => Some(runtime),
-            });
+                Ok(match store_snapshot {
+                    Some(store) => Some(Self::runtime_session_with_store_metadata(runtime, &store)),
+                    None => Some(runtime),
+                })
+            } else {
+                let Some(store_only) = self
+                    .store
+                    .load(id)
+                    .await
+                    .map_err(|e| SessionError::Store(Box::new(e)))?
+                else {
+                    return Ok(None);
+                };
+                tracing::info!(
+                    session_id = %id,
+                    "migrating legacy session-store projection into runtime authority"
+                );
+                self.save_normalized_session(store_only).await.map(Some)
+            }
         } else {
             self.store
                 .load(id)
@@ -4366,14 +4379,14 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_runtime_backed_authoritative_load_rejects_store_only_projection() {
+    async fn test_runtime_backed_authoritative_load_migrates_store_only_projection() {
         let store: Arc<dyn SessionStore> = Arc::new(MemoryStore::new());
         let runtime_store = Arc::new(InMemoryRuntimeStore::new());
         let service = PersistentSessionService::new(
             DummyBuilder,
             4,
             Arc::clone(&store),
-            Some(runtime_store),
+            Some(runtime_store.clone()),
             memory_blob_store(),
         );
 
@@ -4387,25 +4400,37 @@ mod tests {
             .await
             .expect("test should seed a raw store projection");
 
-        assert!(
-            service
-                .load_authoritative_session(&id)
-                .await
-                .expect("authoritative load should succeed")
-                .is_none(),
-            "runtime-backed reads must not promote store-only rows to authoritative sessions"
+        let authoritative = service
+            .load_authoritative_session(&id)
+            .await
+            .expect("authoritative load should succeed")
+            .expect("store-only projection should be migrated before exposure");
+        assert_eq!(
+            authoritative.messages().len(),
+            raw_projection.messages().len()
         );
+        let migrated_snapshot = runtime_store
+            .load_session_snapshot(
+                &PersistentSessionService::<DummyBuilder>::runtime_id_for_session(&id),
+            )
+            .await
+            .expect("runtime snapshot load should succeed")
+            .expect("legacy store projection should be committed into runtime authority");
+        let migrated: Session = serde_json::from_slice(&migrated_snapshot)
+            .expect("migrated runtime snapshot should deserialize");
+        assert_eq!(migrated.messages().len(), raw_projection.messages().len());
+
         assert!(
-            matches!(service.read(&id).await, Err(SessionError::NotFound { .. })),
-            "read() must hide store-only compatibility rows when runtime authority is configured"
+            service.read(&id).await.is_ok(),
+            "read() may expose a legacy store-only row only after runtime migration"
         );
         let listed = service
             .list(SessionQuery::default())
             .await
             .expect("list should succeed");
         assert!(
-            listed.iter().all(|summary| summary.session_id != id),
-            "list() must not expose store-only compatibility rows when runtime authority is configured"
+            listed.iter().any(|summary| summary.session_id == id),
+            "list() may expose a legacy store-only row only after runtime migration"
         );
     }
 


### PR DESCRIPTION
## Summary
- require runtime-backed authoritative session loads to have a runtime snapshot instead of falling back to raw SessionStore rows
- make compatibility metadata backfill timestamp-preserving and ignore newer raw projections
- add regressions for store-only raw rows, newer raw metadata projections, and timestamp-preserving backfill

## Validation
- make fmt
- git diff --check
- ./scripts/repo-cargo test -p meerkat-core test_session_metadata_backfill_preserves_timestamp
- ./scripts/repo-cargo test -p meerkat-session --features session-store authoritative
- MEERKAT_BUILDBUDDY=1 make check

Linear: LUC-77