### PR TITLE
Make ops lifecycle persistence lossless

### DIFF
--- a/meerkat-runtime/src/lib.rs
+++ b/meerkat-runtime/src/lib.rs
@@ -128,7 +128,10 @@ pub use meerkat_machine_types::{
     MeerkatOpsSnapshot, canonical_meerkat_machine_command_classifications,
     canonical_meerkat_machine_command_manifest,
 };
-pub use ops_lifecycle::{OpsLifecycleConfig, PersistedOpsSnapshot, RuntimeOpsLifecycleRegistry};
+pub use ops_lifecycle::{
+    OpsLifecycleConfig, OpsLifecyclePersistenceRequest, PersistedOpsSnapshot,
+    RuntimeOpsLifecycleRegistry,
+};
 
 #[doc(hidden)]
 pub mod machine_schema_exports {

--- a/meerkat-runtime/src/meerkat_machine/session_management.rs
+++ b/meerkat-runtime/src/meerkat_machine/session_management.rs
@@ -1,5 +1,85 @@
 use super::*;
 
+type OpsLifecyclePersistenceReceiver = crate::tokio::sync::mpsc::UnboundedReceiver<
+    crate::ops_lifecycle::OpsLifecyclePersistenceRequest,
+>;
+
+async fn persist_ops_lifecycle_request(
+    store: &Arc<dyn RuntimeStore>,
+    runtime_id: &LogicalRuntimeId,
+    request: crate::ops_lifecycle::OpsLifecyclePersistenceRequest,
+) {
+    let result = store
+        .persist_ops_lifecycle(runtime_id, request.snapshot())
+        .await
+        .map_err(|error| {
+            meerkat_core::ops_lifecycle::OpsLifecycleError::Internal(format!(
+                "failed to persist ops lifecycle snapshot: {error}"
+            ))
+        });
+    if let Err(error) = &result {
+        tracing::warn!(
+            %runtime_id,
+            error = %error,
+            "failed to persist ops lifecycle snapshot"
+        );
+    }
+    request.complete(result);
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+fn spawn_ops_lifecycle_persistence_worker(
+    store: Arc<dyn RuntimeStore>,
+    runtime_id: LogicalRuntimeId,
+    mut persist_rx: OpsLifecyclePersistenceReceiver,
+) {
+    let thread_name = format!("ops-lifecycle-persist-{runtime_id}");
+    let worker_runtime_id = runtime_id.clone();
+    let spawn_result = std::thread::Builder::new()
+        .name(thread_name)
+        .spawn(move || {
+            let runtime = match crate::tokio::runtime::Builder::new_current_thread()
+                .enable_all()
+                .build()
+            {
+                Ok(runtime) => runtime,
+                Err(error) => {
+                    tracing::error!(
+                        %worker_runtime_id,
+                        error = %error,
+                        "failed to start ops lifecycle persistence worker runtime"
+                    );
+                    return;
+                }
+            };
+            runtime.block_on(async move {
+                while let Some(request) = persist_rx.recv().await {
+                    persist_ops_lifecycle_request(&store, &worker_runtime_id, request).await;
+                }
+            });
+        });
+    if let Err(error) = spawn_result {
+        tracing::error!(
+            %runtime_id,
+            error = %error,
+            "failed to spawn ops lifecycle persistence worker"
+        );
+    }
+}
+
+#[cfg(target_arch = "wasm32")]
+fn spawn_ops_lifecycle_persistence_worker(
+    store: Arc<dyn RuntimeStore>,
+    runtime_id: LogicalRuntimeId,
+    mut persist_rx: OpsLifecyclePersistenceReceiver,
+) {
+    crate::tokio::spawn(async move {
+        while let Some(request) = persist_rx.recv().await {
+            persist_ops_lifecycle_request(&store, &runtime_id, request).await;
+        }
+    });
+}
+
 impl MeerkatMachine {
     fn replay_recovered_runtime_phase_through_dsl_authority(
         session_id: &SessionId,
@@ -342,8 +422,8 @@ impl MeerkatMachine {
 
         // Wire persistence channel if a durable store is available.
         if let Some(ref store) = self.store {
-            let (persist_tx, mut persist_rx) = crate::tokio::sync::mpsc::unbounded_channel::<
-                crate::ops_lifecycle::PersistedOpsSnapshot,
+            let (persist_tx, persist_rx) = crate::tokio::sync::mpsc::unbounded_channel::<
+                crate::ops_lifecycle::OpsLifecyclePersistenceRequest,
             >();
             let entry_epoch_id = {
                 let sessions = self.sessions.read().await;
@@ -359,24 +439,9 @@ impl MeerkatMachine {
                     .map(|e| Arc::clone(&e.cursor_state))
                     .unwrap_or_else(|| Arc::new(meerkat_core::EpochCursorState::new()))
             };
-            ops_lifecycle.set_persistence_channel(persist_tx, entry_epoch_id, entry_cursor);
-
-            // Spawn persistence task
-            let store_clone = Arc::clone(store);
             let runtime_id = crate::identifiers::LogicalRuntimeId::new(session_id.to_string());
-            crate::tokio::spawn(async move {
-                while let Some(snapshot) = persist_rx.recv().await {
-                    if let Err(e) = store_clone
-                        .persist_ops_lifecycle(&runtime_id, &snapshot)
-                        .await
-                    {
-                        tracing::warn!(
-                            error = %e,
-                            "failed to persist ops lifecycle snapshot"
-                        );
-                    }
-                }
-            });
+            spawn_ops_lifecycle_persistence_worker(Arc::clone(store), runtime_id, persist_rx);
+            ops_lifecycle.set_persistence_channel(persist_tx, entry_epoch_id, entry_cursor);
         }
 
         // Get the completion feed from the registry for feed-based idle wake.

--- a/meerkat-runtime/src/meerkat_machine/session_management.rs
+++ b/meerkat-runtime/src/meerkat_machine/session_management.rs
@@ -342,8 +342,9 @@ impl MeerkatMachine {
 
         // Wire persistence channel if a durable store is available.
         if let Some(ref store) = self.store {
-            let (persist_tx, mut persist_rx) =
-                crate::tokio::sync::mpsc::channel::<crate::ops_lifecycle::PersistedOpsSnapshot>(16);
+            let (persist_tx, mut persist_rx) = crate::tokio::sync::mpsc::unbounded_channel::<
+                crate::ops_lifecycle::PersistedOpsSnapshot,
+            >();
             let entry_epoch_id = {
                 let sessions = self.sessions.read().await;
                 sessions

--- a/meerkat-runtime/src/ops_lifecycle.rs
+++ b/meerkat-runtime/src/ops_lifecycle.rs
@@ -326,7 +326,7 @@ struct ShellState {
     /// Shared feed buffer for completion events.
     feed_buffer: Arc<FeedBuffer>,
     /// Persistence channel for durable snapshot writes (set via `set_persistence_channel`).
-    persist_tx: Option<crate::tokio::sync::mpsc::Sender<PersistedOpsSnapshot>>,
+    persist_tx: Option<crate::tokio::sync::mpsc::UnboundedSender<PersistedOpsSnapshot>>,
     /// Epoch ID for persistence snapshots.
     persist_epoch_id: Option<meerkat_core::RuntimeEpochId>,
     /// Shared cursor state for persistence snapshots.
@@ -812,22 +812,25 @@ impl ShellState {
     ///
     /// Called after terminal transitions. Captures authority + entries + cursors
     /// under the write lock (caller already holds it) and queues to the channel.
-    fn maybe_persist(&self) {
+    fn maybe_persist(&self) -> Result<(), OpsLifecycleError> {
         let (tx, epoch_id, cursor_state) = match (
             &self.persist_tx,
             &self.persist_epoch_id,
             &self.persist_cursor_state,
         ) {
             (Some(tx), Some(epoch_id), Some(cs)) => (tx, epoch_id, cs),
-            _ => return,
+            _ => return Ok(()),
         };
 
         let snapshot = self.capture_snapshot(epoch_id.clone(), cursor_state);
 
-        // Non-blocking send — bounded-loss is the acknowledged contract.
-        if tx.try_send(snapshot).is_err() {
-            tracing::warn!("ops lifecycle persistence channel full or closed; snapshot dropped");
-        }
+        tx.send(snapshot).map_err(|_| {
+            OpsLifecycleError::Internal(
+                "ops lifecycle persistence channel closed before terminal snapshot could be queued"
+                    .into(),
+            )
+        })?;
+        Ok(())
     }
 
     /// Capture the full persisted snapshot for the current state.
@@ -1005,7 +1008,7 @@ impl RuntimeOpsLifecycleRegistry {
     /// persistence task should drain the channel and write to the store.
     pub fn set_persistence_channel(
         &self,
-        tx: crate::tokio::sync::mpsc::Sender<PersistedOpsSnapshot>,
+        tx: crate::tokio::sync::mpsc::UnboundedSender<PersistedOpsSnapshot>,
         epoch_id: meerkat_core::RuntimeEpochId,
         cursor_state: Arc<meerkat_core::EpochCursorState>,
     ) {
@@ -1440,7 +1443,7 @@ impl OpsLifecycleRegistry for RuntimeOpsLifecycleRegistry {
         }
 
         state.finalize_terminal(id);
-        state.maybe_persist();
+        state.maybe_persist()?;
         Ok(())
     }
 
@@ -1536,7 +1539,7 @@ impl OpsLifecycleRegistry for RuntimeOpsLifecycleRegistry {
         }
 
         state.finalize_terminal(id);
-        state.maybe_persist();
+        state.maybe_persist()?;
         Ok(())
     }
 
@@ -1559,7 +1562,7 @@ impl OpsLifecycleRegistry for RuntimeOpsLifecycleRegistry {
         }
 
         state.finalize_terminal(id);
-        state.maybe_persist();
+        state.maybe_persist()?;
         Ok(())
     }
 
@@ -1586,7 +1589,7 @@ impl OpsLifecycleRegistry for RuntimeOpsLifecycleRegistry {
         }
 
         state.finalize_terminal(id);
-        state.maybe_persist();
+        state.maybe_persist()?;
         Ok(())
     }
 
@@ -1613,7 +1616,7 @@ impl OpsLifecycleRegistry for RuntimeOpsLifecycleRegistry {
         }
 
         state.finalize_terminal(id);
-        state.maybe_persist();
+        state.maybe_persist()?;
         Ok(())
     }
 
@@ -1651,7 +1654,7 @@ impl OpsLifecycleRegistry for RuntimeOpsLifecycleRegistry {
         }
 
         state.finalize_terminal(id);
-        state.maybe_persist();
+        state.maybe_persist()?;
         Ok(())
     }
 
@@ -1702,7 +1705,7 @@ impl OpsLifecycleRegistry for RuntimeOpsLifecycleRegistry {
         }
 
         if !to_terminate.is_empty() {
-            state.maybe_persist();
+            state.maybe_persist()?;
         }
         Ok(())
     }

--- a/meerkat-runtime/src/ops_lifecycle.rs
+++ b/meerkat-runtime/src/ops_lifecycle.rs
@@ -112,6 +112,22 @@ pub struct PersistedOpsSnapshot {
     pub cursors: meerkat_core::EpochCursorSnapshot,
 }
 
+#[derive(Debug)]
+pub struct OpsLifecyclePersistenceRequest {
+    snapshot: PersistedOpsSnapshot,
+    result_tx: std::sync::mpsc::SyncSender<Result<(), OpsLifecycleError>>,
+}
+
+impl OpsLifecyclePersistenceRequest {
+    pub fn snapshot(&self) -> &PersistedOpsSnapshot {
+        &self.snapshot
+    }
+
+    pub fn complete(self, result: Result<(), OpsLifecycleError>) {
+        let _ = self.result_tx.send(result);
+    }
+}
+
 // ---------------------------------------------------------------------------
 // Concrete completion feed buffer
 // ---------------------------------------------------------------------------
@@ -326,7 +342,7 @@ struct ShellState {
     /// Shared feed buffer for completion events.
     feed_buffer: Arc<FeedBuffer>,
     /// Persistence channel for durable snapshot writes (set via `set_persistence_channel`).
-    persist_tx: Option<crate::tokio::sync::mpsc::UnboundedSender<PersistedOpsSnapshot>>,
+    persist_tx: Option<crate::tokio::sync::mpsc::UnboundedSender<OpsLifecyclePersistenceRequest>>,
     /// Epoch ID for persistence snapshots.
     persist_epoch_id: Option<meerkat_core::RuntimeEpochId>,
     /// Shared cursor state for persistence snapshots.
@@ -808,10 +824,11 @@ impl ShellState {
         }
     }
 
-    /// Queue a persistence snapshot if a persistence channel is wired.
+    /// Persist a terminal snapshot if a persistence channel is wired.
     ///
-    /// Called after terminal transitions. Captures authority + entries + cursors
-    /// under the write lock (caller already holds it) and queues to the channel.
+    /// Called after terminal transitions. Captures authority + entries + cursors under the write
+    /// lock (caller already holds it), submits a persistence request, and waits for the worker's
+    /// durable-store result. Returning success only means the snapshot write itself succeeded.
     fn maybe_persist(&self) -> Result<(), OpsLifecycleError> {
         let (tx, epoch_id, cursor_state) = match (
             &self.persist_tx,
@@ -823,14 +840,24 @@ impl ShellState {
         };
 
         let snapshot = self.capture_snapshot(epoch_id.clone(), cursor_state);
+        let (result_tx, result_rx) = std::sync::mpsc::sync_channel(1);
+        let request = OpsLifecyclePersistenceRequest {
+            snapshot,
+            result_tx,
+        };
 
-        tx.send(snapshot).map_err(|_| {
+        tx.send(request).map_err(|_| {
             OpsLifecycleError::Internal(
                 "ops lifecycle persistence channel closed before terminal snapshot could be queued"
                     .into(),
             )
         })?;
-        Ok(())
+        result_rx.recv().map_err(|_| {
+            OpsLifecycleError::Internal(
+                "ops lifecycle persistence worker dropped terminal snapshot before confirming durability"
+                    .into(),
+            )
+        })?
     }
 
     /// Capture the full persisted snapshot for the current state.
@@ -1008,7 +1035,7 @@ impl RuntimeOpsLifecycleRegistry {
     /// persistence task should drain the channel and write to the store.
     pub fn set_persistence_channel(
         &self,
-        tx: crate::tokio::sync::mpsc::UnboundedSender<PersistedOpsSnapshot>,
+        tx: crate::tokio::sync::mpsc::UnboundedSender<OpsLifecyclePersistenceRequest>,
         epoch_id: meerkat_core::RuntimeEpochId,
         cursor_state: Arc<meerkat_core::EpochCursorState>,
     ) {

--- a/meerkat-runtime/src/store/mod.rs
+++ b/meerkat-runtime/src/store/mod.rs
@@ -34,6 +34,9 @@ pub enum RuntimeStoreError {
     /// Not found.
     #[error("Not found: {0}")]
     NotFound(String),
+    /// Operation is not supported by this store implementation.
+    #[error("Unsupported store operation: {0}")]
+    Unsupported(String),
     /// Internal error.
     #[error("Internal error: {0}")]
     Internal(String),
@@ -183,7 +186,9 @@ pub trait RuntimeStore: Send + Sync {
         snapshot: &crate::ops_lifecycle::PersistedOpsSnapshot,
     ) -> Result<(), RuntimeStoreError> {
         let _ = (runtime_id, snapshot);
-        Ok(())
+        Err(RuntimeStoreError::Unsupported(
+            "persist_ops_lifecycle".into(),
+        ))
     }
 
     /// Load a previously persisted ops lifecycle snapshot.
@@ -192,7 +197,7 @@ pub trait RuntimeStore: Send + Sync {
         runtime_id: &LogicalRuntimeId,
     ) -> Result<Option<crate::ops_lifecycle::PersistedOpsSnapshot>, RuntimeStoreError> {
         let _ = runtime_id;
-        Ok(None)
+        Err(RuntimeStoreError::Unsupported("load_ops_lifecycle".into()))
     }
 }
 

--- a/meerkat-runtime/tests/driver_persistent.rs
+++ b/meerkat-runtime/tests/driver_persistent.rs
@@ -192,6 +192,21 @@ impl RuntimeStore for FailPersistInputStore {
             .atomic_lifecycle_commit(runtime_id, runtime_state, input_states)
             .await
     }
+
+    async fn persist_ops_lifecycle(
+        &self,
+        runtime_id: &LogicalRuntimeId,
+        snapshot: &meerkat_runtime::PersistedOpsSnapshot,
+    ) -> Result<(), RuntimeStoreError> {
+        self.inner.persist_ops_lifecycle(runtime_id, snapshot).await
+    }
+
+    async fn load_ops_lifecycle(
+        &self,
+        runtime_id: &LogicalRuntimeId,
+    ) -> Result<Option<meerkat_runtime::PersistedOpsSnapshot>, RuntimeStoreError> {
+        self.inner.load_ops_lifecycle(runtime_id).await
+    }
 }
 
 fn make_prompt(text: &str) -> Input {

--- a/meerkat-runtime/tests/meerkat_machine.rs
+++ b/meerkat-runtime/tests/meerkat_machine.rs
@@ -302,6 +302,21 @@ impl RuntimeStore for HarnessRuntimeStore {
             .atomic_lifecycle_commit(runtime_id, runtime_state, input_states)
             .await
     }
+
+    async fn persist_ops_lifecycle(
+        &self,
+        runtime_id: &meerkat_runtime::identifiers::LogicalRuntimeId,
+        snapshot: &meerkat_runtime::PersistedOpsSnapshot,
+    ) -> Result<(), RuntimeStoreError> {
+        self.inner.persist_ops_lifecycle(runtime_id, snapshot).await
+    }
+
+    async fn load_ops_lifecycle(
+        &self,
+        runtime_id: &meerkat_runtime::identifiers::LogicalRuntimeId,
+    ) -> Result<Option<meerkat_runtime::PersistedOpsSnapshot>, RuntimeStoreError> {
+        self.inner.load_ops_lifecycle(runtime_id).await
+    }
 }
 
 #[tokio::test]

--- a/meerkat-runtime/tests/ops_lifecycle_persistence.rs
+++ b/meerkat-runtime/tests/ops_lifecycle_persistence.rs
@@ -300,6 +300,80 @@ fn snapshot_captures_entries_beyond_authority_retention() {
     );
 }
 
+#[test]
+fn terminal_persistence_queue_captures_burst_without_loss_for_recovery() {
+    const TERMINAL_COUNT: usize = 32;
+
+    let registry = RuntimeOpsLifecycleRegistry::new();
+    let cursor_state = Arc::new(EpochCursorState::new());
+    let epoch_id = RuntimeEpochId::new();
+    let (persist_tx, mut persist_rx) =
+        tokio::sync::mpsc::unbounded_channel::<PersistedOpsSnapshot>();
+    registry.set_persistence_channel(persist_tx, epoch_id.clone(), Arc::clone(&cursor_state));
+
+    for i in 0..TERMINAL_COUNT {
+        let spec = bg_spec(&format!("queued-terminal-{i}"));
+        let id = spec.id.clone();
+        registry.register_operation(spec).unwrap();
+        registry.provisioning_succeeded(&id).unwrap();
+        registry.complete_operation(&id, op_result(&id)).unwrap();
+    }
+
+    let mut snapshots = Vec::new();
+    while let Ok(snapshot) = persist_rx.try_recv() {
+        snapshots.push(snapshot);
+    }
+
+    assert_eq!(
+        snapshots.len(),
+        TERMINAL_COUNT,
+        "every terminal transition must queue a snapshot"
+    );
+    let latest_snapshot = snapshots
+        .last()
+        .expect("at least one terminal snapshot")
+        .clone();
+    assert_eq!(latest_snapshot.epoch_id, epoch_id);
+    assert_eq!(
+        latest_snapshot.completion_entries.len(),
+        TERMINAL_COUNT,
+        "latest persisted snapshot must include the full terminal completion feed"
+    );
+
+    let recovered = RuntimeOpsLifecycleRegistry::from_recovered(latest_snapshot);
+    let recovered_feed = recovered
+        .completion_feed()
+        .expect("recovered registry should expose completion feed");
+    let batch = recovered_feed.list_since(0);
+    assert_eq!(
+        batch.entries.len(),
+        TERMINAL_COUNT,
+        "restart recovery must see every terminal completion from the queued snapshot"
+    );
+}
+
+#[test]
+fn terminal_persistence_channel_closed_fails_terminal_transition() {
+    let registry = RuntimeOpsLifecycleRegistry::new();
+    let cursor_state = Arc::new(EpochCursorState::new());
+    let (persist_tx, persist_rx) = tokio::sync::mpsc::unbounded_channel::<PersistedOpsSnapshot>();
+    drop(persist_rx);
+    registry.set_persistence_channel(persist_tx, RuntimeEpochId::new(), cursor_state);
+
+    let spec = bg_spec("closed-persist-channel");
+    let id = spec.id.clone();
+    registry.register_operation(spec).unwrap();
+    registry.provisioning_succeeded(&id).unwrap();
+
+    let err = registry
+        .complete_operation(&id, op_result(&id))
+        .expect_err("closed persistence channel must fail the terminal transition");
+    assert!(
+        err.to_string().contains("persistence channel closed"),
+        "unexpected error: {err}"
+    );
+}
+
 // ─── Regression: cold ensure_session_with_executor recovers persisted epoch ───
 
 /// Simple executor for recovery tests.

--- a/meerkat-runtime/tests/ops_lifecycle_persistence.rs
+++ b/meerkat-runtime/tests/ops_lifecycle_persistence.rs
@@ -1,7 +1,8 @@
 #![allow(clippy::expect_used, clippy::panic, clippy::unwrap_used)]
 //! Phase 2 contract tests for ops lifecycle persistence and recovery.
 
-use std::sync::Arc;
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::{Arc, Mutex};
 
 use meerkat_core::completion_feed::CompletionFeed;
 use meerkat_core::lifecycle::core_executor::{CoreApplyOutput, CoreExecutorError};
@@ -14,7 +15,9 @@ use meerkat_core::ops_lifecycle::{
 use meerkat_core::runtime_epoch::{EpochCursorState, RuntimeEpochId};
 use meerkat_core::types::SessionId;
 use meerkat_runtime::RuntimeStore; // needed for trait method calls
-use meerkat_runtime::{PersistedOpsSnapshot, RuntimeOpsLifecycleRegistry};
+use meerkat_runtime::{
+    OpsLifecyclePersistenceRequest, PersistedOpsSnapshot, RuntimeOpsLifecycleRegistry,
+};
 
 fn bg_spec(name: &str) -> OperationSpec {
     OperationSpec {
@@ -308,7 +311,18 @@ fn terminal_persistence_queue_captures_burst_without_loss_for_recovery() {
     let cursor_state = Arc::new(EpochCursorState::new());
     let epoch_id = RuntimeEpochId::new();
     let (persist_tx, mut persist_rx) =
-        tokio::sync::mpsc::unbounded_channel::<PersistedOpsSnapshot>();
+        tokio::sync::mpsc::unbounded_channel::<OpsLifecyclePersistenceRequest>();
+    let snapshots = Arc::new(Mutex::new(Vec::new()));
+    let worker_snapshots = Arc::clone(&snapshots);
+    let worker = std::thread::spawn(move || {
+        while let Some(request) = persist_rx.blocking_recv() {
+            worker_snapshots
+                .lock()
+                .unwrap()
+                .push(request.snapshot().clone());
+            request.complete(Ok(()));
+        }
+    });
     registry.set_persistence_channel(persist_tx, epoch_id.clone(), Arc::clone(&cursor_state));
 
     for i in 0..TERMINAL_COUNT {
@@ -318,11 +332,10 @@ fn terminal_persistence_queue_captures_burst_without_loss_for_recovery() {
         registry.provisioning_succeeded(&id).unwrap();
         registry.complete_operation(&id, op_result(&id)).unwrap();
     }
+    drop(registry);
+    worker.join().unwrap();
 
-    let mut snapshots = Vec::new();
-    while let Ok(snapshot) = persist_rx.try_recv() {
-        snapshots.push(snapshot);
-    }
+    let snapshots = snapshots.lock().unwrap();
 
     assert_eq!(
         snapshots.len(),
@@ -356,7 +369,8 @@ fn terminal_persistence_queue_captures_burst_without_loss_for_recovery() {
 fn terminal_persistence_channel_closed_fails_terminal_transition() {
     let registry = RuntimeOpsLifecycleRegistry::new();
     let cursor_state = Arc::new(EpochCursorState::new());
-    let (persist_tx, persist_rx) = tokio::sync::mpsc::unbounded_channel::<PersistedOpsSnapshot>();
+    let (persist_tx, persist_rx) =
+        tokio::sync::mpsc::unbounded_channel::<OpsLifecyclePersistenceRequest>();
     drop(persist_rx);
     registry.set_persistence_channel(persist_tx, RuntimeEpochId::new(), cursor_state);
 
@@ -371,6 +385,201 @@ fn terminal_persistence_channel_closed_fails_terminal_transition() {
     assert!(
         err.to_string().contains("persistence channel closed"),
         "unexpected error: {err}"
+    );
+}
+
+struct FailingOpsLifecycleStore {
+    inner: meerkat_runtime::InMemoryRuntimeStore,
+    persist_calls: AtomicUsize,
+}
+
+impl FailingOpsLifecycleStore {
+    fn new() -> Self {
+        Self {
+            inner: meerkat_runtime::InMemoryRuntimeStore::new(),
+            persist_calls: AtomicUsize::new(0),
+        }
+    }
+
+    fn persist_calls(&self) -> usize {
+        self.persist_calls.load(Ordering::SeqCst)
+    }
+}
+
+#[async_trait::async_trait]
+impl RuntimeStore for FailingOpsLifecycleStore {
+    async fn commit_session_boundary(
+        &self,
+        runtime_id: &meerkat_runtime::identifiers::LogicalRuntimeId,
+        session_delta: meerkat_runtime::SessionDelta,
+        run_id: RunId,
+        boundary: RunApplyBoundary,
+        contributing_input_ids: Vec<meerkat_core::lifecycle::InputId>,
+        input_updates: Vec<meerkat_runtime::input_state::StoredInputState>,
+    ) -> Result<meerkat_core::lifecycle::RunBoundaryReceipt, meerkat_runtime::RuntimeStoreError>
+    {
+        self.inner
+            .commit_session_boundary(
+                runtime_id,
+                session_delta,
+                run_id,
+                boundary,
+                contributing_input_ids,
+                input_updates,
+            )
+            .await
+    }
+
+    async fn atomic_apply(
+        &self,
+        runtime_id: &meerkat_runtime::identifiers::LogicalRuntimeId,
+        session_delta: Option<meerkat_runtime::SessionDelta>,
+        receipt: meerkat_core::lifecycle::RunBoundaryReceipt,
+        input_updates: Vec<meerkat_runtime::input_state::StoredInputState>,
+        session_store_key: Option<SessionId>,
+    ) -> Result<(), meerkat_runtime::RuntimeStoreError> {
+        self.inner
+            .atomic_apply(
+                runtime_id,
+                session_delta,
+                receipt,
+                input_updates,
+                session_store_key,
+            )
+            .await
+    }
+
+    async fn load_input_states(
+        &self,
+        runtime_id: &meerkat_runtime::identifiers::LogicalRuntimeId,
+    ) -> Result<
+        Vec<meerkat_runtime::input_state::StoredInputState>,
+        meerkat_runtime::RuntimeStoreError,
+    > {
+        self.inner.load_input_states(runtime_id).await
+    }
+
+    async fn load_boundary_receipt(
+        &self,
+        runtime_id: &meerkat_runtime::identifiers::LogicalRuntimeId,
+        run_id: &RunId,
+        sequence: u64,
+    ) -> Result<
+        Option<meerkat_core::lifecycle::RunBoundaryReceipt>,
+        meerkat_runtime::RuntimeStoreError,
+    > {
+        self.inner
+            .load_boundary_receipt(runtime_id, run_id, sequence)
+            .await
+    }
+
+    async fn load_session_snapshot(
+        &self,
+        runtime_id: &meerkat_runtime::identifiers::LogicalRuntimeId,
+    ) -> Result<Option<Vec<u8>>, meerkat_runtime::RuntimeStoreError> {
+        self.inner.load_session_snapshot(runtime_id).await
+    }
+
+    async fn persist_input_state(
+        &self,
+        runtime_id: &meerkat_runtime::identifiers::LogicalRuntimeId,
+        state: &meerkat_runtime::input_state::StoredInputState,
+    ) -> Result<(), meerkat_runtime::RuntimeStoreError> {
+        self.inner.persist_input_state(runtime_id, state).await
+    }
+
+    async fn load_input_state(
+        &self,
+        runtime_id: &meerkat_runtime::identifiers::LogicalRuntimeId,
+        input_id: &meerkat_core::lifecycle::InputId,
+    ) -> Result<
+        Option<meerkat_runtime::input_state::StoredInputState>,
+        meerkat_runtime::RuntimeStoreError,
+    > {
+        self.inner.load_input_state(runtime_id, input_id).await
+    }
+
+    async fn persist_runtime_state(
+        &self,
+        runtime_id: &meerkat_runtime::identifiers::LogicalRuntimeId,
+        state: meerkat_runtime::RuntimeState,
+    ) -> Result<(), meerkat_runtime::RuntimeStoreError> {
+        self.inner.persist_runtime_state(runtime_id, state).await
+    }
+
+    async fn load_runtime_state(
+        &self,
+        runtime_id: &meerkat_runtime::identifiers::LogicalRuntimeId,
+    ) -> Result<Option<meerkat_runtime::RuntimeState>, meerkat_runtime::RuntimeStoreError> {
+        self.inner.load_runtime_state(runtime_id).await
+    }
+
+    async fn atomic_lifecycle_commit(
+        &self,
+        runtime_id: &meerkat_runtime::identifiers::LogicalRuntimeId,
+        runtime_state: meerkat_runtime::RuntimeState,
+        input_states: &[meerkat_runtime::input_state::StoredInputState],
+    ) -> Result<(), meerkat_runtime::RuntimeStoreError> {
+        self.inner
+            .atomic_lifecycle_commit(runtime_id, runtime_state, input_states)
+            .await
+    }
+
+    async fn persist_ops_lifecycle(
+        &self,
+        _runtime_id: &meerkat_runtime::identifiers::LogicalRuntimeId,
+        _snapshot: &PersistedOpsSnapshot,
+    ) -> Result<(), meerkat_runtime::RuntimeStoreError> {
+        self.persist_calls.fetch_add(1, Ordering::SeqCst);
+        Err(meerkat_runtime::RuntimeStoreError::WriteFailed(
+            "synthetic ops lifecycle persist failure".to_string(),
+        ))
+    }
+
+    async fn load_ops_lifecycle(
+        &self,
+        runtime_id: &meerkat_runtime::identifiers::LogicalRuntimeId,
+    ) -> Result<Option<PersistedOpsSnapshot>, meerkat_runtime::RuntimeStoreError> {
+        self.inner.load_ops_lifecycle(runtime_id).await
+    }
+}
+
+#[tokio::test]
+async fn terminal_transition_surfaces_store_write_failure_after_persistence_request_is_accepted() {
+    let store = Arc::new(FailingOpsLifecycleStore::new());
+    let adapter = Arc::new(meerkat_runtime::MeerkatMachine::persistent_without_blobs(
+        Arc::clone(&store) as Arc<dyn RuntimeStore>,
+    ));
+    let session_id = SessionId::new();
+    adapter
+        .register_session_with_executor(session_id.clone(), Box::new(NoopExecutor))
+        .await;
+    let bindings = adapter
+        .prepare_bindings(session_id.clone())
+        .await
+        .expect("persistent session should prepare bindings");
+
+    let spec = bg_spec("durable-store-rejection");
+    let op_id = spec.id.clone();
+    bindings.ops_lifecycle.register_operation(spec).unwrap();
+    bindings
+        .ops_lifecycle
+        .provisioning_succeeded(&op_id)
+        .unwrap();
+
+    let err = bindings
+        .ops_lifecycle
+        .complete_operation(&op_id, op_result(&op_id))
+        .expect_err("terminal transition must fail when the durable store rejects the snapshot");
+    assert!(
+        err.to_string()
+            .contains("synthetic ops lifecycle persist failure"),
+        "unexpected error: {err}"
+    );
+    assert_eq!(
+        store.persist_calls(),
+        1,
+        "terminal transition should wait for the accepted persistence request"
     );
 }
 


### PR DESCRIPTION
## Summary
- replace bounded best-effort ops lifecycle snapshot queueing with an unbounded queue that errors when the persistence receiver is closed
- change default RuntimeStore ops lifecycle persistence methods from no-op success to explicit unsupported failures
- add focused regressions for burst terminal snapshot recovery and closed-channel terminal failure

## Validation
- ./scripts/repo-cargo test -p meerkat-runtime --test ops_lifecycle_persistence
- ./scripts/repo-cargo test -p meerkat-runtime --test driver_persistent --test meerkat_machine --no-run
- make test-int
- git diff --check

Linear: LUC-78