### PR TITLE
Preserve canonical mob peer ids

### DIFF
--- a/meerkat-comms/src/runtime/comms_runtime.rs
+++ b/meerkat-comms/src/runtime/comms_runtime.rs
@@ -19,7 +19,7 @@ use futures::task::{Context, Poll};
 use meerkat_core::agent::CommsRuntime as CoreCommsRuntime;
 use meerkat_core::comms::{
     CommsCommand, EventStream, InputStreamMode, PeerAddress, PeerDirectoryEntry,
-    PeerDirectorySource, PeerName, PeerReachabilityReason, PeerRoute, SendAndStreamError,
+    PeerDirectorySource, PeerId, PeerName, PeerReachabilityReason, PeerRoute, SendAndStreamError,
     SendError, SendReceipt, StreamError, StreamScope, TrustedPeerDescriptor,
 };
 use meerkat_core::config::PlainEventSource;
@@ -281,6 +281,11 @@ impl CoreCommsRuntime for CommsRuntime {
     fn inbox_notify(&self) -> Arc<tokio::sync::Notify> {
         self.inbox_notify.clone()
     }
+
+    fn peer_id(&self) -> Option<PeerId> {
+        Some(self.public_key.to_peer_id())
+    }
+
     fn public_key(&self) -> Option<String> {
         Some(self.public_key.to_pubkey_string())
     }

--- a/meerkat-core/src/agent.rs
+++ b/meerkat-core/src/agent.rs
@@ -14,8 +14,8 @@ mod state;
 pub mod test_turn_state_handle;
 use crate::budget::Budget;
 use crate::comms::{
-    CommsCommand, EventStream, PeerDirectoryEntry, SendAndStreamError, SendError, SendReceipt,
-    StreamError, StreamScope, TrustedPeerDescriptor,
+    CommsCommand, EventStream, PeerDirectoryEntry, PeerId, SendAndStreamError, SendError,
+    SendReceipt, StreamError, StreamScope, TrustedPeerDescriptor,
 };
 use crate::compact::SessionCompactionCadence;
 use crate::completion_feed::CompletionSeq;
@@ -609,9 +609,24 @@ pub enum CommsCapabilityError {
 #[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
 #[cfg_attr(not(target_arch = "wasm32"), async_trait)]
 pub trait CommsRuntime: Send + Sync {
-    /// Runtime-local public key identifier, if available.
+    /// Canonical runtime routing identity for this peer, if available.
+    ///
+    /// `PeerId` is the UUID-shaped routing key used by peer directories and
+    /// trust stores. Implementations that only have the legacy string carrier
+    /// may return a parsed UUID-shaped `public_key()` value; implementations
+    /// with Ed25519 public keys should override this and return the pubkey-
+    /// derived canonical [`PeerId`].
+    fn peer_id(&self) -> Option<PeerId> {
+        self.public_key()
+            .as_deref()
+            .and_then(|public_key| PeerId::parse(public_key).ok())
+    }
+
+    /// Runtime-local transport/auth public key, if available.
     ///
     /// Returns an Ed25519 public key string in `ed25519:<base64>` format.
+    /// This is not the canonical routing [`PeerId`]; use [`Self::peer_id`]
+    /// for roster/projection identity and peer-directory lookups.
     fn public_key(&self) -> Option<String> {
         None
     }

--- a/meerkat-mob-mcp/src/agent_tools.rs
+++ b/meerkat-mob-mcp/src/agent_tools.rs
@@ -29,7 +29,7 @@ use ::tokio::sync::RwLock;
 use tokio_with_wasm::alias::sync::RwLock;
 
 use crate::MobMcpState;
-use meerkat_core::comms::{CommsCommand, PeerName, PeerRoute};
+use meerkat_core::comms::{CommsCommand, PeerId, PeerName, PeerRoute};
 
 // ─── Tool name constants ─────────────────────────────────────────────────
 
@@ -84,8 +84,8 @@ pub struct AgentMobToolSurface {
     model: String,
     /// Parent agent's comms name (for building TrustedPeerDescriptor when wiring helpers).
     comms_name: Option<String>,
-    /// Parent agent's comms peer ID (ed25519 public key).
-    comms_peer_id: Option<String>,
+    /// Parent agent's canonical comms peer ID.
+    comms_peer_id: Option<PeerId>,
     /// Parent agent's comms runtime for bidirectional wiring.
     comms_runtime: Option<Arc<dyn meerkat_core::agent::CommsRuntime>>,
     /// Context for capturing a parent agent's tool scope snapshot.
@@ -159,7 +159,7 @@ impl AgentMobToolSurface {
         model: String,
         owner_bridge_session_id: SessionId,
         comms_name: Option<String>,
-        comms_peer_id: Option<String>,
+        comms_peer_id: Option<PeerId>,
         comms_runtime: Option<Arc<dyn meerkat_core::agent::CommsRuntime>>,
     ) -> Self {
         Self::new_with_effective_authority(
@@ -187,7 +187,7 @@ impl AgentMobToolSurface {
         model: String,
         owner_bridge_session_id: SessionId,
         comms_name: Option<String>,
-        comms_peer_id: Option<String>,
+        comms_peer_id: Option<PeerId>,
         comms_runtime: Option<Arc<dyn meerkat_core::agent::CommsRuntime>>,
         snapshot_context: meerkat_core::service::MobToolSnapshotContext,
     ) -> Self {
@@ -497,12 +497,12 @@ impl AgentMobToolSurface {
 
         // Inproc delegation wiring: the parent and helper live on the same
         // node, so identity authorization is the router's identity map, not
-        // envelope signatures. `test_only_unsigned` stamps a zero pubkey —
+        // envelope signatures. `test_only_unsigned_typed` stamps a zero pubkey —
         // signature verification would fail closed, which is the correct
         // property here because the inproc transport bypasses it.
-        let Ok(parent_spec) = meerkat_core::comms::TrustedPeerDescriptor::test_only_unsigned(
+        let Ok(parent_spec) = meerkat_core::comms::TrustedPeerDescriptor::test_only_unsigned_typed(
             name.as_str(),
-            peer_id.as_str(),
+            *peer_id,
             format!("inproc://{name}"),
         ) else {
             return false;
@@ -1087,8 +1087,8 @@ impl meerkat_core::service::MobToolsFactory for AgentMobToolSurfaceFactory {
             .find_implicit_mob_for_bridge_session(&session_id_str)
             .await;
 
-        // Extract parent comms identity for wiring helpers.
-        let comms_peer_id = args.comms_runtime.as_ref().and_then(|r| r.public_key());
+        // Extract parent canonical comms identity for wiring helpers.
+        let comms_peer_id = args.comms_runtime.as_ref().and_then(|r| r.peer_id());
         // Use the shared effective-authority handle if provided (runtime-backed
         // sessions). The agent/turn owner updates this handle via
         // apply_session_effects; mob tools read from it for authorization.
@@ -1929,7 +1929,7 @@ mod tests {
             self.runtimes
                 .write()
                 .await
-                .insert(runtime.key.clone(), runtime);
+                .insert(runtime.peer_id.as_str(), runtime);
         }
 
         async fn get(&self, peer_id: &str) -> Option<Arc<TestCommsRuntime>> {
@@ -1939,7 +1939,8 @@ mod tests {
 
     struct TestCommsRuntime {
         name: String,
-        key: String,
+        peer_id: PeerId,
+        public_key: String,
         trusted: tokio::sync::RwLock<HashMap<String, TrustedPeerDescriptor>>,
         inbox: tokio::sync::RwLock<Vec<InboxInteraction>>,
         notify: Arc<tokio::sync::Notify>,
@@ -1950,7 +1951,8 @@ mod tests {
         async fn new(name: &str, registry: Arc<TestCommsRegistry>) -> Arc<Self> {
             let runtime = Arc::new(Self {
                 name: name.into(),
-                key: meerkat_core::comms::PeerId::new().to_string(),
+                peer_id: PeerId::new(),
+                public_key: "ed25519:AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=".to_string(),
                 trusted: tokio::sync::RwLock::new(HashMap::new()),
                 inbox: tokio::sync::RwLock::new(Vec::new()),
                 notify: Arc::new(tokio::sync::Notify::new()),
@@ -1963,8 +1965,12 @@ mod tests {
 
     #[async_trait]
     impl CoreCommsRuntime for TestCommsRuntime {
+        fn peer_id(&self) -> Option<PeerId> {
+            Some(self.peer_id)
+        }
+
         fn public_key(&self) -> Option<String> {
-            Some(self.key.clone())
+            Some(self.public_key.clone())
         }
 
         async fn add_trusted_peer(&self, peer: TrustedPeerDescriptor) -> Result<(), SendError> {
@@ -3000,7 +3006,17 @@ mod tests {
         let state = Arc::new(MobMcpState::new(service.clone()));
         let parent_name = "parent/lead/l-1".to_string();
         let parent_comms = service.register_external_comms(&parent_name).await;
-        let parent_peer_id = parent_comms.public_key().expect("parent public key");
+        let parent_peer_id = parent_comms.peer_id().expect("parent peer id");
+        let parent_public_key = parent_comms.public_key().expect("parent public key");
+        assert!(
+            parent_public_key.starts_with("ed25519:"),
+            "test fixture should expose transport public-key material separately"
+        );
+        assert_ne!(
+            parent_peer_id.to_string(),
+            parent_public_key,
+            "regression fixture must keep canonical peer id distinct from public key"
+        );
         let session_id = SessionId::new();
         let surface = AgentMobToolSurface::new(
             Arc::clone(&state),
@@ -3009,7 +3025,7 @@ mod tests {
             "claude-sonnet-4-5".to_string(),
             session_id.clone(),
             Some(parent_name.clone()),
-            Some(parent_peer_id.clone()),
+            Some(parent_peer_id),
             Some(parent_comms.clone() as Arc<dyn CoreCommsRuntime>),
         );
 

--- a/meerkat-mob-mcp/src/agent_tools.rs
+++ b/meerkat-mob-mcp/src/agent_tools.rs
@@ -537,7 +537,7 @@ impl AgentMobToolSurface {
         }
         // Same reasoning as `parent_spec` above: inproc transport, zero
         // pubkey by design.
-        let Ok(helper_spec) = meerkat_core::comms::TrustedPeerDescriptor::test_only_unsigned(
+        let Ok(helper_spec) = meerkat_core::comms::TrustedPeerDescriptor::test_only_unsigned_typed(
             &helper_comms_name,
             helper_peer_id,
             format!("inproc://{helper_comms_name}"),

--- a/meerkat-mob/src/roster.rs
+++ b/meerkat-mob/src/roster.rs
@@ -14,11 +14,19 @@
 use crate::event::{MemberRef, MobEvent, MobEventKind};
 use crate::ids::{AgentIdentity, AgentRuntimeId, FenceToken, Generation, ProfileName};
 use crate::runtime_mode::MobRuntimeMode;
-use meerkat_core::comms::TrustedPeerDescriptor;
+use meerkat_core::comms::{PeerId, TrustedPeerDescriptor};
 use meerkat_core::time_compat::SystemTime;
 use meerkat_core::types::SessionId;
-use serde::{Deserialize, Serialize};
+use serde::{Deserialize, Deserializer, Serialize};
 use std::collections::{BTreeMap, BTreeSet};
+
+fn deserialize_optional_peer_id<'de, D>(deserializer: D) -> Result<Option<PeerId>, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    let raw = Option::<String>::deserialize(deserializer)?;
+    Ok(raw.and_then(|value| PeerId::parse(&value).ok()))
+}
 
 /// Lifecycle state for a roster member.
 ///
@@ -94,9 +102,16 @@ pub struct RosterEntry {
     // --- Internal bridge fields (pub(crate)) ---
     /// Backend-neutral bridge identity.
     pub(crate) member_ref: MemberRef,
-    /// Public comms peer identifier when this member exposes a comms runtime.
+    /// Canonical comms peer identifier when this member exposes a comms runtime.
+    #[serde(
+        default,
+        skip_serializing_if = "Option::is_none",
+        deserialize_with = "deserialize_optional_peer_id"
+    )]
+    pub(crate) peer_id: Option<PeerId>,
+    /// Transport/auth signing public key for this member's comms runtime.
     #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub(crate) peer_id: Option<String>,
+    pub(crate) transport_public_key: Option<String>,
     /// Trusted specs for external peers keyed by their projected peer name.
     #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
     pub(crate) external_peer_specs: BTreeMap<AgentIdentity, TrustedPeerDescriptor>,
@@ -121,7 +136,8 @@ pub(crate) struct RosterAddEntry {
     pub(crate) role: ProfileName,
     pub(crate) runtime_mode: MobRuntimeMode,
     pub(crate) member_ref: MemberRef,
-    pub(crate) peer_id: Option<String>,
+    pub(crate) peer_id: Option<PeerId>,
+    pub(crate) transport_public_key: Option<String>,
     pub(crate) labels: BTreeMap<String, String>,
     pub(crate) effective_profile_override: Option<crate::profile::Profile>,
 }
@@ -168,6 +184,7 @@ impl Roster {
                     runtime_mode: member_spawned.runtime_mode,
                     member_ref,
                     peer_id: None,
+                    transport_public_key: None,
                     labels: member_spawned.labels.clone(),
                     effective_profile_override: None,
                 });
@@ -255,6 +272,7 @@ impl Roster {
                     member_ref: entry.member_ref,
                     runtime_mode: entry.runtime_mode,
                     peer_id: entry.peer_id,
+                    transport_public_key: entry.transport_public_key,
                     state: MemberState::default(),
                     wired_to: BTreeSet::new(),
                     external_peer_specs: BTreeMap::new(),
@@ -401,14 +419,16 @@ impl Roster {
         false
     }
 
-    /// Update the resolved comms peer id for an existing meerkat.
-    pub(crate) fn set_peer_id(
+    /// Update the resolved comms identity for an existing meerkat.
+    pub(crate) fn set_comms_identity(
         &mut self,
         agent_identity: &AgentIdentity,
-        peer_id: Option<String>,
+        peer_id: Option<PeerId>,
+        transport_public_key: Option<String>,
     ) -> bool {
         if let Some(entry) = self.get_mut(agent_identity) {
             entry.peer_id = peer_id;
+            entry.transport_public_key = transport_public_key;
             return true;
         }
         false
@@ -560,9 +580,14 @@ impl RosterEntry {
         self.member_ref.bridge_session_id()
     }
 
-    /// Bridge-internal peer ID for comms wiring.
-    pub fn peer_id(&self) -> Option<&str> {
-        self.peer_id.as_deref()
+    /// Canonical comms peer ID for this roster entry.
+    pub fn peer_id(&self) -> Option<PeerId> {
+        self.peer_id
+    }
+
+    /// Transport/auth public key for comms wiring, if known.
+    pub fn transport_public_key(&self) -> Option<&str> {
+        self.transport_public_key.as_deref()
     }
 }
 
@@ -594,6 +619,7 @@ mod tests {
             runtime_mode,
             member_ref,
             peer_id: None,
+            transport_public_key: None,
             labels,
             effective_profile_override: None,
         }
@@ -828,6 +854,7 @@ mod tests {
             member_ref: MemberRef::from_bridge_session_id(session_id()),
             runtime_mode: MobRuntimeMode::AutonomousHost,
             peer_id: None,
+            transport_public_key: None,
             state: MemberState::default(),
             wired_to: {
                 let mut s = BTreeSet::new();
@@ -856,6 +883,7 @@ mod tests {
             member_ref: MemberRef::from_bridge_session_id(session_id()),
             runtime_mode: MobRuntimeMode::AutonomousHost,
             peer_id: None,
+            transport_public_key: None,
             state: MemberState::Active,
             wired_to: BTreeSet::new(),
             external_peer_specs: BTreeMap::new(),

--- a/meerkat-mob/src/runtime/actor.rs
+++ b/meerkat-mob/src/runtime/actor.rs
@@ -1388,6 +1388,7 @@ impl MobActor {
                     role: entry.role,
                     runtime_mode: entry.runtime_mode,
                     peer_id: entry.peer_id,
+                    transport_public_key: entry.transport_public_key,
                     state: entry.state,
                     wired_to: entry.wired_to,
                     external_peer_specs: entry.external_peer_specs,
@@ -4789,17 +4790,18 @@ impl MobActor {
         // and fails with `"autonomous member '{id}' missing roster entry for
         // startup readiness"` (#30 D-spawn-readiness-lookup).
         //
-        // `peer_id` is resolved from the session's comms runtime public key;
-        // callers like `list_members` project it directly from the roster
-        // entry (see `test_member_roster_surfaces_peer_id`).
-        let peer_id = if let Some(session_id) = member_ref.bridge_session_id() {
-            self.session_service
-                .comms_runtime(session_id)
-                .await
-                .and_then(|runtime| runtime.public_key())
-        } else {
-            None
-        };
+        // `peer_id` is the canonical comms routing UUID. Keep the Ed25519
+        // public key in its own transport/auth slot so roster projections do
+        // not bind peer-directory lookups to key material.
+        let (peer_id, transport_public_key) =
+            if let Some(session_id) = member_ref.bridge_session_id() {
+                match self.session_service.comms_runtime(session_id).await {
+                    Some(runtime) => (runtime.peer_id(), runtime.public_key()),
+                    None => (None, None),
+                }
+            } else {
+                (None, None)
+            };
         {
             let mut roster = self.roster.write().await;
             roster.add_member(crate::roster::RosterAddEntry {
@@ -4811,6 +4813,7 @@ impl MobActor {
                 runtime_mode,
                 member_ref: Self::sanitized_member_ref(&member_ref),
                 peer_id,
+                transport_public_key,
                 labels: labels.clone(),
                 effective_profile_override: effective_profile_override.clone(),
             });
@@ -9373,7 +9376,8 @@ impl MobActor {
                     role: profile_name.clone(),
                     member_ref: member_ref.clone(),
                     runtime_mode: crate::MobRuntimeMode::TurnDriven,
-                    peer_id: spawned_comms.as_ref().and_then(|c| c.public_key()),
+                    peer_id: spawned_comms.as_ref().and_then(|c| c.peer_id()),
+                    transport_public_key: spawned_comms.as_ref().and_then(|c| c.public_key()),
                     state: crate::roster::MemberState::Active,
                     wired_to: std::collections::BTreeSet::new(),
                     external_peer_specs: std::collections::BTreeMap::new(),

--- a/meerkat-mob/src/runtime/builder.rs
+++ b/meerkat-mob/src/runtime/builder.rs
@@ -1072,18 +1072,28 @@ impl MobBuilder {
             .collect::<HashSet<_>>();
         for entry in &entries {
             if broken_members.contains(&entry.agent_identity) {
-                let _ = roster.set_peer_id(&entry.agent_identity, None);
+                let _ = roster.set_comms_identity(&entry.agent_identity, None, None);
                 continue;
             }
             let local_comms = provisioner.comms_runtime(&entry.member_ref).await;
             if let Some(comms_a) = &local_comms {
+                let peer_id_a = comms_a.peer_id().ok_or_else(|| {
+                    MobError::WiringError(format!(
+                        "resume requires peer id for wired member '{}'",
+                        entry.agent_identity
+                    ))
+                })?;
                 let key_a = comms_a.public_key().ok_or_else(|| {
                     MobError::WiringError(format!(
                         "resume requires public key for wired member '{}'",
                         entry.agent_identity
                     ))
                 })?;
-                let _ = roster.set_peer_id(&entry.agent_identity, Some(key_a.clone()));
+                let _ = roster.set_comms_identity(
+                    &entry.agent_identity,
+                    Some(peer_id_a),
+                    Some(key_a.clone()),
+                );
             } else if entry.wired_to.is_empty() {
                 continue;
             }

--- a/meerkat-mob/src/runtime/disposal.rs
+++ b/meerkat-mob/src/runtime/disposal.rs
@@ -201,6 +201,7 @@ mod tests {
                 member_ref: MemberRef::from_bridge_session_id(SessionId::new()),
                 runtime_mode: crate::MobRuntimeMode::TurnDriven,
                 peer_id: None,
+                transport_public_key: None,
                 state: MemberState::Retiring,
                 wired_to: BTreeSet::new(),
                 external_peer_specs: std::collections::BTreeMap::new(),

--- a/meerkat-mob/src/runtime/handle.rs
+++ b/meerkat-mob/src/runtime/handle.rs
@@ -16,7 +16,7 @@ use crate::runtime::reconcile::{
 #[cfg(target_arch = "wasm32")]
 use crate::tokio;
 use meerkat_core::comms::{
-    PeerDirectoryEntry, PeerReachability, PeerReachabilityReason, TrustedPeerDescriptor,
+    PeerDirectoryEntry, PeerId, PeerReachability, PeerReachabilityReason, TrustedPeerDescriptor,
 };
 use meerkat_core::ops::OperationId;
 use meerkat_core::ops_lifecycle::OpsLifecycleRegistry;
@@ -201,8 +201,12 @@ pub struct MobMemberListEntry {
     pub(crate) agent_runtime_id: AgentRuntimeId,
     #[serde(skip)]
     pub(crate) fence_token: FenceToken,
+    /// Canonical comms routing ID for bridge-internal peer lookup.
     #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub(crate) peer_id: Option<String>,
+    pub(crate) peer_id: Option<PeerId>,
+    /// Transport/auth public key material, separate from canonical `peer_id`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub(crate) transport_public_key: Option<String>,
     #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
     pub(crate) external_peer_specs: BTreeMap<AgentIdentity, TrustedPeerDescriptor>,
     #[serde(skip)]
@@ -1563,10 +1567,8 @@ impl MobHandle {
             .comms_runtime(bridge_session_id)
             .await?;
         let peers = comms.peers().await;
-        let peers_by_id: HashMap<String, &PeerDirectoryEntry> = peers
-            .iter()
-            .map(|peer| (peer.peer_id.as_str(), peer))
-            .collect();
+        let peers_by_id: HashMap<PeerId, &PeerDirectoryEntry> =
+            peers.iter().map(|peer| (peer.peer_id, peer)).collect();
         let peers_by_name: HashMap<&str, &PeerDirectoryEntry> = peers
             .iter()
             .map(|peer| (peer.name.as_str(), peer))
@@ -1580,7 +1582,7 @@ impl MobHandle {
             let wired_peer_meerkat = MeerkatId::from(wired_peer);
             let matched = if let Some(spec) = entry.external_peer_specs.get(&wired_peer_meerkat) {
                 peers_by_id
-                    .get(&spec.peer_id.as_str())
+                    .get(&spec.peer_id)
                     .copied()
                     .or_else(|| peers_by_name.get(spec.name.as_str()).copied())
             } else {
@@ -1592,15 +1594,14 @@ impl MobHandle {
                         .session_service
                         .comms_runtime(target_session_id)
                         .await
-                        .and_then(|runtime| runtime.public_key()),
+                        .and_then(|runtime| runtime.peer_id()),
                     None => None,
                 };
                 live_peer_id
-                    .as_deref()
-                    .and_then(|peer_id| peers_by_id.get(peer_id).copied())
+                    .and_then(|peer_id| peers_by_id.get(&peer_id).copied())
                     .or_else(|| {
                         local_entry
-                            .and_then(|peer_entry| peer_entry.peer_id.as_deref())
+                            .and_then(|peer_entry| peer_entry.peer_id.as_ref())
                             .and_then(|peer_id| peers_by_id.get(peer_id).copied())
                     })
                     .or_else(|| {
@@ -1674,7 +1675,8 @@ impl MobHandle {
                     fence_token: entry.fence_token,
                     role: entry.role.clone(),
                     runtime_mode: entry.runtime_mode,
-                    peer_id: entry.peer_id.clone(),
+                    peer_id: entry.peer_id,
+                    transport_public_key: entry.transport_public_key.clone(),
                     state: entry.state,
                     wired_to: entry.wired_to.clone(),
                     external_peer_specs: entry.external_peer_specs.clone(),

--- a/meerkat-mob/src/runtime/provisioner.rs
+++ b/meerkat-mob/src/runtime/provisioner.rs
@@ -177,13 +177,12 @@ impl SessionBackend {
         //
         // Pre-#24 `PeerId::parse` accepted arbitrary strings (including
         // the `"ed25519:…"` form); post-#24 it only accepts hyphenated
-        // UUIDs. Tests with `MockCommsRuntime` pass a UUID-shaped peer_id
-        // directly (the mock synthesizes one off the name bytes, not a
-        // real keypair), so we fall back to the legacy
-        // `test_only_unsigned` zero-pubkey descriptor when the caller
-        // supplies a non-ed25519 peer_id string. Those paths remain
-        // inproc-only — signature verification is bypassed there, so a
-        // zero-pubkey descriptor is admission-safe.
+        // UUIDs. Some legacy test/runtime shims still pass a UUID-shaped
+        // peer_id directly instead of an Ed25519 public-key carrier, so we
+        // fall back to the legacy `test_only_unsigned` zero-pubkey descriptor
+        // for non-ed25519 strings. Those paths remain inproc-only —
+        // signature verification is bypassed there, so a zero-pubkey
+        // descriptor is admission-safe.
         if let Some(pubkey_b64) = fallback_peer_id.strip_prefix("ed25519:") {
             let _ = pubkey_b64; // pattern anchor; full parse delegates below.
             let pubkey =

--- a/meerkat-mob/src/runtime/tests.rs
+++ b/meerkat-mob/src/runtime/tests.rs
@@ -21,7 +21,7 @@ use indexmap::IndexMap;
 use meerkat_core::Provider;
 use meerkat_core::agent::CommsRuntime as CoreCommsRuntime;
 use meerkat_core::comms::{
-    CommsCommand, PeerDirectoryEntry, PeerDirectorySource, PeerName, PeerReachability,
+    CommsCommand, PeerDirectoryEntry, PeerDirectorySource, PeerId, PeerName, PeerReachability,
     PeerReachabilityReason, PeerRoute, SendError, SendReceipt, TrustedPeerDescriptor,
 };
 use meerkat_core::error::ToolError;
@@ -78,6 +78,7 @@ struct MockCommsBehavior {
 }
 
 struct MockCommsRuntime {
+    default_peer_id: PeerId,
     default_public_key: String,
     behavior: std::sync::RwLock<MockCommsBehavior>,
     remove_failures_remaining: std::sync::Mutex<usize>,
@@ -96,10 +97,10 @@ impl MockCommsRuntime {
                 .wrapping_add(byte)
                 .rotate_left((index % 8) as u32);
         }
+        let public_key = meerkat_comms::PubKey::new(key_bytes);
         Self {
-            default_public_key: meerkat_comms::PubKey::new(key_bytes)
-                .to_peer_id()
-                .to_string(),
+            default_peer_id: public_key.to_peer_id(),
+            default_public_key: public_key.to_pubkey_string(),
             behavior: std::sync::RwLock::new(behavior),
             remove_failures_remaining: std::sync::Mutex::new(usize::from(
                 behavior.fail_remove_trust_once,
@@ -178,6 +179,18 @@ impl MockCommsRuntime {
 
 #[async_trait]
 impl CoreCommsRuntime for MockCommsRuntime {
+    fn peer_id(&self) -> Option<PeerId> {
+        let behavior = self
+            .behavior
+            .read()
+            .expect("poisoned behavior lock in mock runtime");
+        if behavior.missing_public_key {
+            None
+        } else {
+            Some(self.default_peer_id)
+        }
+    }
+
     fn public_key(&self) -> Option<String> {
         let behavior = self
             .behavior
@@ -817,9 +830,9 @@ impl MockSessionService {
             )
         };
         if let (Some(from_runtime), Some(to_runtime)) = (from_runtime, to_runtime)
-            && let Some(to_key) = to_runtime.public_key()
+            && let Some(to_key) = to_runtime.peer_id()
         {
-            let _ = from_runtime.remove_trusted_peer(&to_key).await;
+            let _ = from_runtime.remove_trusted_peer(&to_key.to_string()).await;
         }
     }
 
@@ -9919,14 +9932,29 @@ async fn test_member_roster_surfaces_peer_id() {
         .comms_runtime(&lead_sid)
         .await
         .expect("lead comms runtime")
-        .public_key()
+        .peer_id()
         .expect("lead peer id");
+    let transport_public_key = service
+        .comms_runtime(&lead_sid)
+        .await
+        .expect("lead comms runtime")
+        .public_key()
+        .expect("lead transport public key");
 
     let entry = handle
         .get_member(&AgentIdentity::from("l-1"))
         .await
         .expect("member should exist");
-    assert_eq!(entry.peer_id.as_deref(), Some(expected_peer_id.as_str()));
+    assert_eq!(entry.peer_id, Some(expected_peer_id));
+    assert_eq!(
+        entry.transport_public_key.as_deref(),
+        Some(transport_public_key.as_str())
+    );
+    assert_ne!(
+        expected_peer_id.to_string(),
+        transport_public_key,
+        "roster peer_id must be the canonical UUID, not the Ed25519 public key"
+    );
 }
 
 #[tokio::test]
@@ -9980,6 +10008,80 @@ async fn test_member_status_projects_unreachable_peer_connectivity() {
     assert_eq!(connectivity.unknown_peer_count, 0);
     assert_eq!(connectivity.unreachable_peers.len(), 1);
     assert_eq!(connectivity.unreachable_peers[0].peer, right_name);
+    assert_eq!(
+        connectivity.unreachable_peers[0].reason,
+        Some(PeerReachabilityReason::OfflineOrNoAck)
+    );
+}
+
+#[tokio::test]
+async fn test_member_status_matches_connectivity_by_canonical_peer_id_when_public_key_differs() {
+    let (handle, service) = create_test_mob(sample_definition()).await;
+    let left_id = MeerkatId::from("l-1");
+    let right_id = MeerkatId::from("w-1");
+    let left_session_id = handle
+        .spawn(ProfileName::from("lead"), left_id.clone(), None)
+        .await
+        .expect("spawn lead")
+        .bridge_session_id()
+        .expect("session-backed")
+        .clone();
+    let right_session_id = handle
+        .spawn(ProfileName::from("worker"), right_id.clone(), None)
+        .await
+        .expect("spawn worker")
+        .bridge_session_id()
+        .expect("session-backed")
+        .clone();
+    handle
+        .wire(AgentIdentity::from(left_id.as_str()), right_id.clone())
+        .await
+        .expect("wire local peers");
+
+    let right_runtime = service
+        .comms_runtime(&right_session_id)
+        .await
+        .expect("right comms runtime");
+    let right_peer_id = right_runtime.peer_id().expect("right canonical peer id");
+    let right_public_key = right_runtime
+        .public_key()
+        .expect("right transport public key");
+    assert_ne!(
+        right_peer_id.to_string(),
+        right_public_key,
+        "test fixture must exercise distinct canonical peer id and public key carriers"
+    );
+
+    let alias_name = format!("{}/worker/right-alias", handle.mob_id());
+    let alias_spec = TrustedPeerDescriptor::test_only_unsigned_typed(
+        alias_name.clone(),
+        right_peer_id,
+        format!("inproc://{alias_name}"),
+    )
+    .expect("valid alias peer spec");
+    service
+        .force_add_trust_from_spec(&left_session_id, alias_spec)
+        .await;
+    service
+        .set_peer_status(
+            &left_session_id,
+            &alias_name,
+            PeerReachability::Unreachable,
+            Some(PeerReachabilityReason::OfflineOrNoAck),
+        )
+        .await;
+
+    let snapshot = handle
+        .member_status(&AgentIdentity::from(left_id.as_str()))
+        .await
+        .expect("member status should succeed");
+    let connectivity = snapshot
+        .peer_connectivity
+        .expect("live comms runtime should project peer connectivity");
+    assert_eq!(connectivity.reachable_peer_count, 0);
+    assert_eq!(connectivity.unknown_peer_count, 0);
+    assert_eq!(connectivity.unreachable_peers.len(), 1);
+    assert_eq!(connectivity.unreachable_peers[0].peer, alias_name);
     assert_eq!(
         connectivity.unreachable_peers[0].reason,
         Some(PeerReachabilityReason::OfflineOrNoAck)


### PR DESCRIPTION
## Summary
- Add a typed `CommsRuntime::peer_id()` contract for canonical UUID-shaped routing identity.
- Store mob roster/list `peer_id` as canonical `PeerId` and keep Ed25519 public-key material in an explicit transport-public-key slot.
- Fix roster/connectivity lookup to match peer directories by canonical `PeerId`, with regression coverage where the public key string differs.

Linear: LUC-81

## Validation
- `./scripts/repo-cargo fmt --check`
- `./scripts/repo-cargo check -p meerkat-mob`
- `./scripts/repo-cargo test -p meerkat-mob test_member_roster_surfaces_peer_id`
- `./scripts/repo-cargo test -p meerkat-mob test_member_status_matches_connectivity_by_canonical_peer_id_when_public_key_differs`
- `./scripts/repo-cargo check -p meerkat-mob-mcp`
- `make check` (BuildBuddy invocation `f36ee820-b97e-4fdc-bd71-e88735f20d4f`)