### PR TITLE
LUC-74: Project cloud authorizer freshness into auth leases

### DIFF
--- a/meerkat-anthropic/src/runtime/mod.rs
+++ b/meerkat-anthropic/src/runtime/mod.rs
@@ -207,10 +207,9 @@ impl ProviderRuntime for AnthropicProviderRuntime {
                             ..Default::default()
                         },
                     )?;
-                    Arc::new(DynamicLease::new(
+                    Arc::new(DynamicLease::from_authorizer(
                         authorizer,
                         metadata,
-                        None,
                         source_label.clone(),
                     ))
                 }
@@ -225,12 +224,20 @@ impl ProviderRuntime for AnthropicProviderRuntime {
             AnthropicAuthMethod::VertexGoogleAuth => {
                 #[cfg(all(not(target_arch = "wasm32"), feature = "vertex"))]
                 {
-                    let authorizer: Arc<dyn HttpAuthorizer> = Arc::new(
+                    let mut authorizer =
                         meerkat_auth_core::authorizers::GoogleAuthAuthorizer::with_env_lookup(
                             meerkat_auth_core::authorizers::GoogleAuthChain::Default,
                             env.env_lookup.clone(),
-                        ),
-                    );
+                        );
+                    if let Some(handle) = env.auth_lease_handle.clone() {
+                        authorizer = authorizer.with_auth_lease_observer(
+                            handle,
+                            meerkat_core::handles::LeaseKey::from_connection_ref(
+                                &binding.connection_ref,
+                            ),
+                        );
+                    }
+                    let authorizer: Arc<dyn HttpAuthorizer> = Arc::new(authorizer);
                     let metadata = finalize_auth_metadata(
                         binding,
                         AuthMetadata {
@@ -250,10 +257,9 @@ impl ProviderRuntime for AnthropicProviderRuntime {
                             ..Default::default()
                         },
                     )?;
-                    Arc::new(DynamicLease::new(
+                    Arc::new(DynamicLease::from_authorizer(
                         authorizer,
                         metadata,
-                        None,
                         source_label.clone(),
                     ))
                 }
@@ -273,11 +279,19 @@ impl ProviderRuntime for AnthropicProviderRuntime {
                         move |key| lookup(key),
                     )
                     .map_err(|err| ProviderAuthError::Auth(err.into()))?;
-                    let authorizer: Arc<dyn HttpAuthorizer> =
-                        Arc::new(meerkat_auth_core::authorizers::AzureAdAuthorizer::new(
-                            "https://cognitiveservices.azure.com/.default",
-                            creds,
-                        ));
+                    let mut authorizer = meerkat_auth_core::authorizers::AzureAdAuthorizer::new(
+                        "https://cognitiveservices.azure.com/.default",
+                        creds,
+                    );
+                    if let Some(handle) = env.auth_lease_handle.clone() {
+                        authorizer = authorizer.with_auth_lease_observer(
+                            handle,
+                            meerkat_core::handles::LeaseKey::from_connection_ref(
+                                &binding.connection_ref,
+                            ),
+                        );
+                    }
+                    let authorizer: Arc<dyn HttpAuthorizer> = Arc::new(authorizer);
                     let metadata = finalize_auth_metadata(
                         binding,
                         AuthMetadata {
@@ -290,10 +304,9 @@ impl ProviderRuntime for AnthropicProviderRuntime {
                             ..Default::default()
                         },
                     )?;
-                    Arc::new(DynamicLease::new(
+                    Arc::new(DynamicLease::from_authorizer(
                         authorizer,
                         metadata,
-                        None,
                         source_label.clone(),
                     ))
                 }

--- a/meerkat-auth-core/src/authorizers/azure.rs
+++ b/meerkat-auth-core/src/authorizers/azure.rs
@@ -23,10 +23,11 @@ use parking_lot::Mutex;
 use serde::Deserialize;
 use thiserror::Error;
 
+use super::LeaseFreshnessObserver;
+use meerkat_core::handles::{AUTH_LEASE_TTL_REFRESH_WINDOW_SECS, AuthLeaseHandle, LeaseKey};
 use meerkat_core::{AuthError, HttpAuthorizationRequest, HttpAuthorizer};
 
 const DEFAULT_AUTHORITY: &str = "https://login.microsoftonline.com";
-const REFRESH_WINDOW_SECS: i64 = 60;
 
 #[derive(Clone, Debug)]
 pub struct AzureClientCredentials {
@@ -102,6 +103,7 @@ pub struct AzureAdAuthorizer {
     cache: Arc<Mutex<Option<CachedToken>>>,
     label: String,
     token_url_override: Option<String>,
+    lease_observer: Option<LeaseFreshnessObserver>,
 }
 
 impl AzureAdAuthorizer {
@@ -115,6 +117,7 @@ impl AzureAdAuthorizer {
             cache: Arc::new(Mutex::new(None)),
             label,
             token_url_override: None,
+            lease_observer: None,
         }
     }
 
@@ -122,6 +125,15 @@ impl AzureAdAuthorizer {
     /// mock server. Production code should not call this.
     pub fn with_token_url_override(mut self, url: impl Into<String>) -> Self {
         self.token_url_override = Some(url.into());
+        self
+    }
+
+    pub fn with_auth_lease_observer(
+        mut self,
+        handle: Arc<dyn AuthLeaseHandle>,
+        lease_key: LeaseKey,
+    ) -> Self {
+        self.lease_observer = Some(LeaseFreshnessObserver::new(handle, lease_key));
         self
     }
 
@@ -173,12 +185,23 @@ impl AzureAdAuthorizer {
         })
     }
 
+    fn cached_expires_at(&self) -> Option<DateTime<Utc>> {
+        self.cache.lock().as_ref().map(|token| token.expires_at)
+    }
+
+    fn publish_expires_at(&self, expires_at: DateTime<Utc>) {
+        if let Some(observer) = &self.lease_observer {
+            observer.observe_expires_at(&self.label, expires_at);
+        }
+    }
+
     async fn get_token(&self) -> Result<String, AuthError> {
         // Check cache without taking the refresh path.
         {
             let guard = self.cache.lock();
             if let Some(t) = guard.as_ref()
-                && t.expires_at - Utc::now() > Duration::seconds(REFRESH_WINDOW_SECS)
+                && t.expires_at - Utc::now()
+                    > Duration::seconds(AUTH_LEASE_TTL_REFRESH_WINDOW_SECS as i64)
             {
                 return Ok(t.access_token.clone());
             }
@@ -186,7 +209,9 @@ impl AzureAdAuthorizer {
         // Miss — fetch a fresh token.
         let new_token = self.fetch_token().await?;
         let access = new_token.access_token.clone();
+        let expires_at = new_token.expires_at;
         *self.cache.lock() = Some(new_token);
+        self.publish_expires_at(expires_at);
         Ok(access)
     }
 }
@@ -202,5 +227,9 @@ impl HttpAuthorizer for AzureAdAuthorizer {
 
     fn label(&self) -> &str {
         &self.label
+    }
+
+    fn expires_at(&self) -> Option<DateTime<Utc>> {
+        self.cached_expires_at()
     }
 }

--- a/meerkat-auth-core/src/authorizers/google.rs
+++ b/meerkat-auth-core/src/authorizers/google.rs
@@ -24,14 +24,14 @@ use parking_lot::Mutex;
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
 
-use super::EnvLookup;
+use super::{EnvLookup, LeaseFreshnessObserver};
+use meerkat_core::handles::{AUTH_LEASE_TTL_REFRESH_WINDOW_SECS, AuthLeaseHandle, LeaseKey};
 use meerkat_core::{AuthError, HttpAuthorizationRequest, HttpAuthorizer};
 
 const DEFAULT_SCOPE: &str = "https://www.googleapis.com/auth/cloud-platform";
 const GOOGLE_TOKEN_URL_DEFAULT: &str = "https://oauth2.googleapis.com/token";
 const METADATA_URL_DEFAULT: &str =
     "http://metadata.google.internal/computeMetadata/v1/instance/service-accounts/default/token";
-const REFRESH_WINDOW_SECS: i64 = 60;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum GoogleAuthChain {
@@ -127,6 +127,7 @@ pub struct GoogleAuthAuthorizer {
     label: String,
     token_url_override: Option<String>,
     metadata_url_override: Option<String>,
+    lease_observer: Option<LeaseFreshnessObserver>,
 }
 
 impl GoogleAuthAuthorizer {
@@ -160,6 +161,7 @@ impl GoogleAuthAuthorizer {
             label,
             token_url_override: None,
             metadata_url_override: None,
+            lease_observer: None,
         }
     }
 
@@ -183,6 +185,15 @@ impl GoogleAuthAuthorizer {
         self
     }
 
+    pub fn with_auth_lease_observer(
+        mut self,
+        handle: Arc<dyn AuthLeaseHandle>,
+        lease_key: LeaseKey,
+    ) -> Self {
+        self.lease_observer = Some(LeaseFreshnessObserver::new(handle, lease_key));
+        self
+    }
+
     pub fn chain(&self) -> GoogleAuthChain {
         self.chain
     }
@@ -199,11 +210,22 @@ impl GoogleAuthAuthorizer {
             .unwrap_or_else(|| METADATA_URL_DEFAULT.into())
     }
 
+    fn cached_expires_at(&self) -> Option<DateTime<Utc>> {
+        self.cache.lock().as_ref().map(|token| token.expires_at)
+    }
+
+    fn publish_expires_at(&self, expires_at: DateTime<Utc>) {
+        if let Some(observer) = &self.lease_observer {
+            observer.observe_expires_at(&self.label, expires_at);
+        }
+    }
+
     async fn get_token(&self) -> Result<String, AuthError> {
         {
             let guard = self.cache.lock();
             if let Some(t) = guard.as_ref()
-                && t.expires_at - Utc::now() > Duration::seconds(REFRESH_WINDOW_SECS)
+                && t.expires_at - Utc::now()
+                    > Duration::seconds(AUTH_LEASE_TTL_REFRESH_WINDOW_SECS as i64)
             {
                 return Ok(t.access_token.clone());
             }
@@ -214,7 +236,9 @@ impl GoogleAuthAuthorizer {
             GoogleAuthChain::Default => self.fetch_full_chain().await?,
         };
         let access = token.access_token.clone();
+        let expires_at = token.expires_at;
         *self.cache.lock() = Some(token);
+        self.publish_expires_at(expires_at);
         Ok(access)
     }
 
@@ -386,5 +410,9 @@ impl HttpAuthorizer for GoogleAuthAuthorizer {
 
     fn label(&self) -> &str {
         &self.label
+    }
+
+    fn expires_at(&self) -> Option<DateTime<Utc>> {
+        self.cached_expires_at()
     }
 }

--- a/meerkat-auth-core/src/authorizers/mod.rs
+++ b/meerkat-auth-core/src/authorizers/mod.rs
@@ -8,11 +8,43 @@
 
 use std::sync::Arc;
 
+#[cfg(any(feature = "azure-ad", feature = "gcp-auth"))]
+use chrono::{DateTime, Utc};
+#[cfg(any(feature = "azure-ad", feature = "gcp-auth"))]
+use meerkat_core::handles::{AuthLeaseHandle, LeaseKey};
+
 /// Shared closure type for env-variable lookup. Used by authorizers that
 /// want to remain hermetic in tests by taking a closure rather than
 /// reading `std::env::var` directly. The process-env implementation is
 /// `Arc::new(|k| std::env::var(k).ok())`.
 pub type EnvLookup = Arc<dyn Fn(&str) -> Option<String> + Send + Sync>;
+
+#[derive(Clone)]
+#[cfg(any(feature = "azure-ad", feature = "gcp-auth"))]
+pub(crate) struct LeaseFreshnessObserver {
+    handle: Arc<dyn AuthLeaseHandle>,
+    lease_key: LeaseKey,
+}
+
+#[cfg(any(feature = "azure-ad", feature = "gcp-auth"))]
+impl LeaseFreshnessObserver {
+    pub(crate) fn new(handle: Arc<dyn AuthLeaseHandle>, lease_key: LeaseKey) -> Self {
+        Self { handle, lease_key }
+    }
+
+    pub(crate) fn observe_expires_at(&self, authorizer_label: &str, expires_at: DateTime<Utc>) {
+        let expires_at = expires_at.timestamp().max(0) as u64;
+        if let Err(err) = self.handle.acquire_lease(&self.lease_key, expires_at) {
+            tracing::warn!(
+                authorizer = %authorizer_label,
+                lease_key = %self.lease_key,
+                expires_at,
+                error = %err,
+                "failed to publish cloud authorizer freshness to auth lease truth"
+            );
+        }
+    }
+}
 
 #[cfg(feature = "aws-sigv4")]
 pub mod aws;

--- a/meerkat-auth-core/tests/azure_ad_authorizer.rs
+++ b/meerkat-auth-core/tests/azure_ad_authorizer.rs
@@ -12,18 +12,20 @@
 #![cfg(all(not(target_arch = "wasm32"), feature = "azure-ad"))]
 #![allow(clippy::unwrap_used, clippy::expect_used, clippy::panic)]
 
-use std::sync::Arc;
 use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::{Arc, Mutex};
 
 use axum::Router;
 use axum::extract::{Form, State};
 use axum::response::Json;
 use axum::routing::post;
+use chrono::Utc;
 use serde::Deserialize;
 use tokio::net::TcpListener;
 
 use meerkat_auth_core::authorizers::{AzureAdAuthorizer, AzureClientCredentials};
-use meerkat_core::{HttpAuthorizationRequest, HttpAuthorizer};
+use meerkat_core::handles::{AuthLeaseHandle, AuthLeaseSnapshot, DslTransitionError, LeaseKey};
+use meerkat_core::{BindingId, HttpAuthorizationRequest, HttpAuthorizer, ProfileId, RealmId};
 
 #[derive(Deserialize, Clone)]
 struct TokenForm {
@@ -58,6 +60,65 @@ struct MockServer {
     base_url: String,
     counter: Arc<AtomicUsize>,
     captured: Arc<std::sync::Mutex<Vec<TokenForm>>>,
+}
+
+#[derive(Default)]
+struct RecordingAuthLeaseHandle {
+    acquired: Mutex<Vec<(LeaseKey, u64)>>,
+}
+
+impl AuthLeaseHandle for RecordingAuthLeaseHandle {
+    fn acquire_lease(
+        &self,
+        lease_key: &LeaseKey,
+        expires_at: u64,
+    ) -> Result<(), DslTransitionError> {
+        self.acquired
+            .lock()
+            .unwrap()
+            .push((lease_key.clone(), expires_at));
+        Ok(())
+    }
+
+    fn mark_expiring(&self, _lease_key: &LeaseKey) -> Result<(), DslTransitionError> {
+        Ok(())
+    }
+
+    fn begin_refresh(&self, _lease_key: &LeaseKey) -> Result<(), DslTransitionError> {
+        Ok(())
+    }
+
+    fn complete_refresh(
+        &self,
+        _lease_key: &LeaseKey,
+        _new_expires_at: u64,
+        _now: u64,
+    ) -> Result<(), DslTransitionError> {
+        Ok(())
+    }
+
+    fn refresh_failed(
+        &self,
+        _lease_key: &LeaseKey,
+        _permanent: bool,
+    ) -> Result<(), DslTransitionError> {
+        Ok(())
+    }
+
+    fn mark_reauth_required(&self, _lease_key: &LeaseKey) -> Result<(), DslTransitionError> {
+        Ok(())
+    }
+
+    fn release_lease(&self, _lease_key: &LeaseKey) -> Result<(), DslTransitionError> {
+        Ok(())
+    }
+
+    fn snapshot(&self, _lease_key: &LeaseKey) -> AuthLeaseSnapshot {
+        AuthLeaseSnapshot {
+            phase: None,
+            expires_at: None,
+        }
+    }
 }
 
 async fn start_mock(token_value: &str, expires_in: u64) -> MockServer {
@@ -116,6 +177,10 @@ async fn authorize_adds_bearer_header_from_token_endpoint() {
         .find(|(k, _)| k.eq_ignore_ascii_case("authorization"))
         .unwrap();
     assert_eq!(auth.1, "Bearer azure-access-token-xyz");
+    assert!(
+        authorizer.expires_at().is_some(),
+        "Azure AD token expiry must be observable through HttpAuthorizer"
+    );
 
     let captured = mock.captured.lock().unwrap();
     assert_eq!(captured.len(), 1);
@@ -151,6 +216,73 @@ async fn token_is_cached_between_authorize_calls() {
         1,
         "expected 1 token fetch, got {}",
         mock.counter.load(Ordering::SeqCst),
+    );
+}
+
+#[tokio::test]
+async fn short_lived_token_expiry_is_observable_and_refetched() {
+    let mock = start_mock("short-lived-token", 30).await;
+    let authorizer = AzureAdAuthorizer::new(
+        "https://cognitiveservices.azure.com/.default",
+        creds(&mock.base_url),
+    )
+    .with_token_url_override(format!("{}/tenant-id/oauth2/v2.0/token", mock.base_url));
+
+    for _ in 0..2 {
+        let mut headers = Vec::new();
+        let mut req = HttpAuthorizationRequest {
+            method: "POST",
+            url: "https://example.foundry.azure.com/v1/messages",
+            headers: &mut headers,
+        };
+        authorizer.authorize(&mut req).await.unwrap();
+    }
+
+    let expires_at = authorizer
+        .expires_at()
+        .expect("short-lived token expiry should be projected");
+    assert!(
+        expires_at > Utc::now(),
+        "cached expiry should carry the token endpoint's expires_in"
+    );
+    assert_eq!(
+        mock.counter.load(Ordering::SeqCst),
+        2,
+        "token inside the canonical refresh window must be refetched"
+    );
+}
+
+#[tokio::test]
+async fn authorize_publishes_token_expiry_to_auth_lease_handle() {
+    let mock = start_mock("lease-tracked-token", 3600).await;
+    let handle = Arc::new(RecordingAuthLeaseHandle::default());
+    let lease_key = LeaseKey::new(
+        RealmId::parse("dev").unwrap(),
+        BindingId::parse("azure_foundry").unwrap(),
+        Some(ProfileId::parse("foundry_azure_ad").unwrap()),
+    );
+    let lease_handle: Arc<dyn AuthLeaseHandle> = handle.clone();
+    let authorizer = AzureAdAuthorizer::new(
+        "https://cognitiveservices.azure.com/.default",
+        creds(&mock.base_url),
+    )
+    .with_auth_lease_observer(lease_handle, lease_key.clone())
+    .with_token_url_override(format!("{}/tenant-id/oauth2/v2.0/token", mock.base_url));
+
+    let mut headers = Vec::new();
+    let mut req = HttpAuthorizationRequest {
+        method: "POST",
+        url: "https://example.foundry.azure.com/v1/messages",
+        headers: &mut headers,
+    };
+    authorizer.authorize(&mut req).await.unwrap();
+
+    let acquired = handle.acquired.lock().unwrap();
+    assert_eq!(acquired.len(), 1);
+    assert_eq!(acquired[0].0, lease_key);
+    assert!(
+        acquired[0].1 > Utc::now().timestamp().max(0) as u64,
+        "published auth-machine expiry must reflect the fetched token"
     );
 }
 

--- a/meerkat-auth-core/tests/google_auth_authorizer.rs
+++ b/meerkat-auth-core/tests/google_auth_authorizer.rs
@@ -24,6 +24,7 @@ use axum::Router;
 use axum::extract::{Form, State};
 use axum::response::{IntoResponse, Json};
 use axum::routing::{get, post};
+use chrono::Utc;
 use serde::Deserialize;
 use tokio::net::TcpListener;
 
@@ -51,6 +52,7 @@ struct MockState {
     counter: Arc<AtomicUsize>,
     captured: Arc<Mutex<Vec<OAuthForm>>>,
     token_value: String,
+    expires_in: u64,
 }
 
 async fn token_endpoint(
@@ -62,7 +64,7 @@ async fn token_endpoint(
     Json(serde_json::json!({
         "access_token": state.token_value,
         "token_type": "Bearer",
-        "expires_in": 3600,
+        "expires_in": state.expires_in,
     }))
 }
 
@@ -78,7 +80,7 @@ async fn metadata_endpoint(
     Ok(Json(serde_json::json!({
         "access_token": state.token_value,
         "token_type": "Bearer",
-        "expires_in": 3600,
+        "expires_in": state.expires_in,
     })))
 }
 
@@ -89,12 +91,17 @@ struct MockServer {
 }
 
 async fn start_mock(token_value: &str) -> MockServer {
+    start_mock_with_expiry(token_value, 3600).await
+}
+
+async fn start_mock_with_expiry(token_value: &str, expires_in: u64) -> MockServer {
     let counter = Arc::new(AtomicUsize::new(0));
     let captured = Arc::new(Mutex::new(Vec::new()));
     let state = MockState {
         counter: counter.clone(),
         captured: captured.clone(),
         token_value: token_value.into(),
+        expires_in,
     };
     let app = Router::new()
         .route("/token", post(token_endpoint))
@@ -180,6 +187,10 @@ async fn service_account_path_signs_jwt_and_gets_token() {
         .find(|(k, _)| k.eq_ignore_ascii_case("authorization"))
         .unwrap();
     assert_eq!(auth.1, "Bearer sa-access-token");
+    assert!(
+        authorizer.expires_at().is_some(),
+        "service-account token expiry must be observable through HttpAuthorizer"
+    );
     assert_eq!(mock.counter.load(Ordering::SeqCst), 1);
     let captured = mock.captured.lock().unwrap();
     assert_eq!(
@@ -324,6 +335,49 @@ async fn token_is_cached_between_calls() {
         mock.counter.load(Ordering::SeqCst),
         1,
         "expected single fetch with caching"
+    );
+}
+
+#[tokio::test]
+async fn short_lived_token_expiry_is_observable_and_refetched() {
+    let mock = start_mock_with_expiry("short-lived-sa-token", 30).await;
+    let tempdir = tempfile::tempdir().unwrap();
+    let sa_path = write_sa_key(tempdir.path(), &format!("{}/token", mock.base_url));
+    let env_lookup = {
+        let sa_path = sa_path.clone();
+        Arc::new(move |k: &str| {
+            if k == "GOOGLE_APPLICATION_CREDENTIALS" {
+                Some(sa_path.to_string_lossy().to_string())
+            } else {
+                None
+            }
+        }) as Arc<dyn Fn(&str) -> Option<String> + Send + Sync>
+    };
+    let authorizer = GoogleAuthAuthorizer::with_env_lookup(GoogleAuthChain::Default, env_lookup)
+        .with_home_dir(tempdir.path())
+        .with_token_url_override(format!("{}/token", mock.base_url));
+
+    for _ in 0..2 {
+        let mut headers = Vec::new();
+        let mut req = HttpAuthorizationRequest {
+            method: "POST",
+            url: "https://x.googleapis.com/",
+            headers: &mut headers,
+        };
+        authorizer.authorize(&mut req).await.unwrap();
+    }
+
+    let expires_at = authorizer
+        .expires_at()
+        .expect("short-lived token expiry should be projected");
+    assert!(
+        expires_at > Utc::now(),
+        "cached expiry should carry the token endpoint's expires_in"
+    );
+    assert_eq!(
+        mock.counter.load(Ordering::SeqCst),
+        2,
+        "token inside the canonical refresh window must be refetched"
     );
 }
 

--- a/meerkat-core/src/auth/lease.rs
+++ b/meerkat-core/src/auth/lease.rs
@@ -121,6 +121,13 @@ pub struct HttpAuthorizationRequest<'a> {
 pub trait HttpAuthorizer: Send + Sync {
     async fn authorize(&self, req: &mut HttpAuthorizationRequest<'_>) -> Result<(), AuthError>;
     fn label(&self) -> &str;
+
+    /// Non-secret freshness projection for authorizers that cache expiring
+    /// token material internally. Implementations that never observe an
+    /// expiring credential should keep the default `None`.
+    fn expires_at(&self) -> Option<DateTime<Utc>> {
+        None
+    }
 }
 
 /// Trait contract for a resolved credential lease. `meerkat-core` declares

--- a/meerkat-gemini/src/runtime/mod.rs
+++ b/meerkat-gemini/src/runtime/mod.rs
@@ -148,12 +148,20 @@ impl ProviderRuntime for GoogleProviderRuntime {
             GoogleAuthMethod::Adc => {
                 #[cfg(all(not(target_arch = "wasm32"), feature = "adc"))]
                 {
-                    let authorizer: Arc<dyn HttpAuthorizer> = Arc::new(
+                    let mut authorizer =
                         meerkat_auth_core::authorizers::GoogleAuthAuthorizer::with_env_lookup(
                             meerkat_auth_core::authorizers::GoogleAuthChain::Default,
                             env.env_lookup.clone(),
-                        ),
-                    );
+                        );
+                    if let Some(handle) = env.auth_lease_handle.clone() {
+                        authorizer = authorizer.with_auth_lease_observer(
+                            handle,
+                            meerkat_core::handles::LeaseKey::from_connection_ref(
+                                &binding.connection_ref,
+                            ),
+                        );
+                    }
+                    let authorizer: Arc<dyn HttpAuthorizer> = Arc::new(authorizer);
                     let metadata = finalize_auth_metadata(
                         binding,
                         AuthMetadata {
@@ -167,10 +175,9 @@ impl ProviderRuntime for GoogleProviderRuntime {
                             ..Default::default()
                         },
                     )?;
-                    Arc::new(DynamicLease::new(
+                    Arc::new(DynamicLease::from_authorizer(
                         authorizer,
                         metadata,
-                        None,
                         source_label.clone(),
                     ))
                 }
@@ -184,12 +191,20 @@ impl ProviderRuntime for GoogleProviderRuntime {
             GoogleAuthMethod::ComputeAdc => {
                 #[cfg(all(not(target_arch = "wasm32"), feature = "adc"))]
                 {
-                    let authorizer: Arc<dyn HttpAuthorizer> = Arc::new(
+                    let mut authorizer =
                         meerkat_auth_core::authorizers::GoogleAuthAuthorizer::with_env_lookup(
                             meerkat_auth_core::authorizers::GoogleAuthChain::ComputeOnly,
                             env.env_lookup.clone(),
-                        ),
-                    );
+                        );
+                    if let Some(handle) = env.auth_lease_handle.clone() {
+                        authorizer = authorizer.with_auth_lease_observer(
+                            handle,
+                            meerkat_core::handles::LeaseKey::from_connection_ref(
+                                &binding.connection_ref,
+                            ),
+                        );
+                    }
+                    let authorizer: Arc<dyn HttpAuthorizer> = Arc::new(authorizer);
                     let metadata = finalize_auth_metadata(
                         binding,
                         AuthMetadata {
@@ -203,10 +218,9 @@ impl ProviderRuntime for GoogleProviderRuntime {
                             ..Default::default()
                         },
                     )?;
-                    Arc::new(DynamicLease::new(
+                    Arc::new(DynamicLease::from_authorizer(
                         authorizer,
                         metadata,
-                        None,
                         source_label.clone(),
                     ))
                 }

--- a/meerkat-llm-core/src/provider_runtime/binding.rs
+++ b/meerkat-llm-core/src/provider_runtime/binding.rs
@@ -231,6 +231,17 @@ impl DynamicLease {
         }
     }
 
+    /// Construct a dynamic lease whose freshness is projected from the
+    /// underlying authorizer. This is for authorizer-backed flows such as
+    /// Google ADC and Azure AD where the token is fetched lazily per request.
+    pub fn from_authorizer(
+        authorizer: Arc<dyn HttpAuthorizer>,
+        metadata: AuthMetadata,
+        source_label: impl Into<String>,
+    ) -> Self {
+        Self::new(authorizer, metadata, None, source_label)
+    }
+
     pub fn authorizer(&self) -> &Arc<dyn HttpAuthorizer> {
         &self.authorizer
     }
@@ -246,7 +257,7 @@ impl AuthLease for DynamicLease {
         &self.metadata
     }
     fn expires_at(&self) -> Option<DateTime<Utc>> {
-        self.expires_at
+        self.expires_at.or_else(|| self.authorizer.expires_at())
     }
     fn source_label(&self) -> &str {
         &self.source_label
@@ -309,5 +320,41 @@ mod tests {
             .await
             .expect_err("dynamic refresh must not report success without work");
         assert!(matches!(err, AuthError::RefreshFailed(_)));
+    }
+
+    #[tokio::test]
+    async fn dynamic_lease_projects_authorizer_freshness() {
+        #[derive(Debug)]
+        struct ExpiringAuthorizer {
+            expires_at: DateTime<Utc>,
+        }
+
+        #[async_trait::async_trait]
+        impl HttpAuthorizer for ExpiringAuthorizer {
+            async fn authorize(
+                &self,
+                _req: &mut meerkat_core::auth::HttpAuthorizationRequest<'_>,
+            ) -> Result<(), AuthError> {
+                Ok(())
+            }
+
+            fn label(&self) -> &'static str {
+                "expiring-authorizer"
+            }
+
+            fn expires_at(&self) -> Option<DateTime<Utc>> {
+                Some(self.expires_at)
+            }
+        }
+
+        let expires_at =
+            chrono::TimeZone::with_ymd_and_hms(&chrono::Utc, 2026, 4, 28, 12, 0, 0).unwrap();
+        let lease: Arc<dyn AuthLease> = Arc::new(DynamicLease::from_authorizer(
+            Arc::new(ExpiringAuthorizer { expires_at }),
+            AuthMetadata::default(),
+            "dynamic:expiring",
+        ));
+
+        assert_eq!(lease.expires_at(), Some(expires_at));
     }
 }

--- a/meerkat-llm-core/src/provider_runtime/registry.rs
+++ b/meerkat-llm-core/src/provider_runtime/registry.rs
@@ -11,6 +11,7 @@ use chrono::{DateTime, Utc};
 
 use meerkat_core::{
     AuthError, Provider, RealmConnectionSet, ResolvedAuthEnvelope, connection::ConnectionRef,
+    handles::AuthLeaseHandle,
 };
 
 use crate::provider_runtime::binding::{ResolvedConnection, ValidatedBinding};
@@ -47,6 +48,7 @@ pub struct ResolverEnvironment {
     pub env_lookup: EnvLookup,
     pub external_resolvers: BTreeMap<String, Arc<dyn ExternalAuthResolverHandle>>,
     pub now: NowFn,
+    pub auth_lease_handle: Option<Arc<dyn AuthLeaseHandle>>,
     #[cfg(not(target_arch = "wasm32"))]
     pub token_store: Option<Arc<dyn meerkat_core::auth::TokenStore>>,
     #[cfg(not(target_arch = "wasm32"))]
@@ -61,6 +63,7 @@ impl ResolverEnvironment {
             env_lookup: Arc::new(|_| None),
             external_resolvers: BTreeMap::new(),
             now: Arc::new(Utc::now),
+            auth_lease_handle: None,
             #[cfg(not(target_arch = "wasm32"))]
             token_store: None,
             #[cfg(not(target_arch = "wasm32"))]
@@ -75,6 +78,7 @@ impl ResolverEnvironment {
             env_lookup: Arc::new(|key| std::env::var(key).ok()),
             external_resolvers: BTreeMap::new(),
             now: Arc::new(Utc::now),
+            auth_lease_handle: None,
             #[cfg(not(target_arch = "wasm32"))]
             token_store: None,
             #[cfg(not(target_arch = "wasm32"))]
@@ -107,6 +111,14 @@ impl ResolverEnvironment {
         resolver: Arc<dyn ExternalAuthResolverHandle>,
     ) -> Self {
         self.external_resolvers.insert(handle.into(), resolver);
+        self
+    }
+
+    /// Attach the session-owned auth lease handle so dynamic cloud
+    /// authorizers can publish observed token freshness into AuthMachine
+    /// truth after a lazy token exchange.
+    pub fn with_auth_lease_handle(mut self, handle: Arc<dyn AuthLeaseHandle>) -> Self {
+        self.auth_lease_handle = Some(handle);
         self
     }
 

--- a/meerkat/src/factory.rs
+++ b/meerkat/src/factory.rs
@@ -2178,6 +2178,11 @@ impl AgentFactory {
                             env = env.with_refresh_coordinator(coord);
                         }
                     }
+                    if let RuntimeBuildMode::SessionOwned(bindings) =
+                        &build_config.runtime_build_mode
+                    {
+                        env = env.with_auth_lease_handle(Arc::clone(&bindings.auth_lease));
+                    }
                     for (handle, resolver) in &self.external_auth_resolvers {
                         env = env.with_external_resolver(handle.clone(), resolver.clone());
                     }
@@ -2294,6 +2299,9 @@ impl AgentFactory {
                     if let Some(coord) = self.refresh_coord.clone() {
                         env = env.with_refresh_coordinator(coord);
                     }
+                }
+                if let RuntimeBuildMode::SessionOwned(bindings) = &build_config.runtime_build_mode {
+                    env = env.with_auth_lease_handle(Arc::clone(&bindings.auth_lease));
                 }
                 for (handle, resolver) in &self.external_auth_resolvers {
                     env = env.with_external_resolver(handle.clone(), resolver.clone());


### PR DESCRIPTION
## Summary
- expose dynamic authorizer token expiry through `HttpAuthorizer::expires_at()` and `DynamicLease` projection
- publish Google/Azure fetched token expiry into session `AuthLeaseHandle` truth when provider resolution has a session-owned handle
- replace Google/Azure private refresh-window constants with the canonical auth lease TTL window and add focused expiry/refetch regressions

Linear: LUC-74

## Validation
- `./scripts/repo-cargo test -p meerkat-llm-core dynamic_lease_projects_authorizer_freshness`
- `./scripts/repo-cargo test -p meerkat-auth-core --features gcp-auth,azure-ad --test google_auth_authorizer --test azure_ad_authorizer`
- `./scripts/repo-cargo check -p meerkat-gemini --features adc`
- `./scripts/repo-cargo check -p meerkat-anthropic --features vertex,foundry,bedrock`
- `./scripts/repo-cargo check -p meerkat`
- `make check` via BuildBuddy/Bazel invocation `33a17660-d488-447e-b970-db1d562f5543`