### PR TITLE
LUC-80 Move comms ingress policy to core authority

### DIFF
--- a/meerkat-comms/src/agent/types.rs
+++ b/meerkat-comms/src/agent/types.rs
@@ -351,57 +351,32 @@ impl CommsMessage {
                     Some(b) if !b.is_empty() => meerkat_core::types::text_content(b),
                     _ => body.clone(),
                 };
-                format!("[COMMS MESSAGE from {}]\n{}", self.from_peer, text)
+                meerkat_core::format_peer_message_projection(&self.from_peer, &text)
             }
             CommsContent::Request {
                 request_id,
                 intent,
                 params,
-            } => {
-                let params_str =
-                    if params.is_null() || params == &JsonValue::Object(Default::default()) {
-                        String::new()
-                    } else {
-                        format!(
-                            "\nParams: {}",
-                            serde_json::to_string_pretty(params).unwrap_or_default()
-                        )
-                    };
-                format!(
-                    "[COMMS REQUEST from {} (id: {})]\n\
-                     Intent: {}{}\n\
-                     \n\
-                     This is a correlated peer request. Reply with send_response using \
-                     to=\"{}\", in_reply_to=\"{}\", status=\"completed\" or \"failed\", and result=<JSON payload>. \
-                     Do not answer this request with send_message.",
-                    self.from_peer, request_id, intent, params_str, self.from_peer, request_id
-                )
-            }
+            } => meerkat_core::format_peer_request_projection(
+                &self.from_peer,
+                request_id,
+                intent.as_str(),
+                params,
+            ),
             CommsContent::Response {
                 in_reply_to,
                 status,
                 result,
-            } => {
-                let status_str = match status {
-                    CommsStatus::Accepted => "accepted",
-                    CommsStatus::Completed => "completed",
-                    CommsStatus::Failed => "failed",
-                };
-                let result_str =
-                    if result.is_null() || result == &JsonValue::Object(Default::default()) {
-                        String::new()
-                    } else {
-                        format!(
-                            "\nResult: {}",
-                            serde_json::to_string_pretty(result).unwrap_or_default()
-                        )
-                    };
-                format!(
-                    "[COMMS RESPONSE from {} (to request: {})]\n\
-                     Status: {}{}",
-                    self.from_peer, in_reply_to, status_str, result_str
-                )
-            }
+            } => meerkat_core::format_peer_response_projection(
+                &self.from_peer,
+                in_reply_to,
+                match status {
+                    CommsStatus::Accepted => meerkat_core::ResponseStatus::Accepted,
+                    CommsStatus::Completed => meerkat_core::ResponseStatus::Completed,
+                    CommsStatus::Failed => meerkat_core::ResponseStatus::Failed,
+                },
+                result,
+            ),
         }
     }
 }

--- a/meerkat-comms/src/classify.rs
+++ b/meerkat-comms/src/classify.rs
@@ -2,18 +2,15 @@
 //!
 //! Runs synchronously in the sending task using receiver-owned trust/auth state.
 
-use crate::agent::types::{CommsMessage, MessageIntent};
 use crate::inproc::InprocRegistry;
-use crate::peer_types::{ContentShape as PeerContentShape, RawPeerKind};
+use crate::peer_types::ContentShape as PeerContentShape;
 use crate::trust::TrustedPeers;
 use crate::types::{InboxItem, MessageKind};
-use meerkat_core::comms::PeerLifecycleKind;
-use meerkat_core::{PeerIngressKind, PeerInputClass};
-use std::collections::HashSet;
+use meerkat_core::{
+    PeerIngressAuthDecision, PeerIngressKind, PeerIngressMachinePolicy, PeerInputClass,
+};
 use std::sync::Arc;
 use uuid::Uuid;
-
-const AUTH_EXEMPT_REQUEST_INTENTS: &[&str] = &["supervisor.bridge"];
 
 /// Receiver-owned context for synchronous ingress classification.
 ///
@@ -22,7 +19,7 @@ const AUTH_EXEMPT_REQUEST_INTENTS: &[&str] = &["supervisor.bridge"];
 pub(crate) struct IngressClassificationContext {
     pub(crate) require_peer_auth: bool,
     pub(crate) trusted_peers: Arc<parking_lot::RwLock<TrustedPeers>>,
-    pub(crate) silent_intents: Arc<HashSet<String>>,
+    pub(crate) ingress_policy: Arc<PeerIngressMachinePolicy>,
 }
 
 /// Result of classifying an inbox item.
@@ -32,6 +29,7 @@ pub(crate) struct IngressClassificationContext {
 #[cfg(test)]
 pub(crate) struct ClassificationResult {
     pub(crate) class: PeerInputClass,
+    pub(crate) auth: PeerIngressAuthDecision,
     pub(crate) from_peer: Option<String>,
     pub(crate) lifecycle_peer: Option<String>,
 }
@@ -43,9 +41,9 @@ pub(crate) struct ClassificationResult {
 pub(crate) struct PreparedIngressItem {
     pub(crate) item: InboxItem,
     pub(crate) raw_item_id: String,
-    pub(crate) raw_kind: RawPeerKind,
+    pub(crate) kind: PeerIngressKind,
     pub(crate) class: PeerInputClass,
-    pub(crate) auth_exempt: bool,
+    pub(crate) auth: PeerIngressAuthDecision,
     #[cfg_attr(not(test), allow(dead_code))]
     pub(crate) trusted_sender: bool,
     pub(crate) from_peer: Option<String>,
@@ -72,28 +70,6 @@ fn content_shape_for_text_and_blocks(
     }
 }
 
-fn ack_projection(from_peer: &str, in_reply_to: Uuid) -> String {
-    format!("[COMMS ACK from {from_peer} (to request: {in_reply_to})]")
-}
-
-impl PreparedIngressItem {
-    pub(crate) fn ingress_kind(&self) -> PeerIngressKind {
-        match &self.raw_kind {
-            RawPeerKind::Message => PeerIngressKind::Message,
-            RawPeerKind::Request
-            | RawPeerKind::PeerLifecycleAdded
-            | RawPeerKind::PeerLifecycleRetired
-            | RawPeerKind::PeerLifecycleUnwired
-            | RawPeerKind::SilentRequest => PeerIngressKind::Request,
-            RawPeerKind::ResponseTerminal | RawPeerKind::ResponseProgress => {
-                PeerIngressKind::Response
-            }
-            RawPeerKind::Ack => PeerIngressKind::Ack,
-            RawPeerKind::PlainEvent => PeerIngressKind::PlainEvent,
-        }
-    }
-}
-
 impl IngressClassificationContext {
     /// Prepare an inbox item for classified ingress.
     ///
@@ -112,156 +88,68 @@ impl IngressClassificationContext {
                         .unwrap_or_else(|| envelope.from.to_pubkey_string())
                 });
 
-                let (raw_kind, class, lifecycle_peer, request_id, auth_exempt) = match &envelope
-                    .kind
-                {
-                    MessageKind::Message { .. } => (
-                        RawPeerKind::Message,
-                        PeerInputClass::ActionableMessage,
-                        None,
-                        None,
-                        false,
-                    ),
+                let (classification, lifecycle_peer, request_id) = match &envelope.kind {
+                    MessageKind::Message { .. } => {
+                        (self.ingress_policy.classify_message(), None, None)
+                    }
                     MessageKind::Request { intent, params, .. } => {
-                        let typed_intent = MessageIntent::from(intent.as_str());
-                        let auth_exempt = AUTH_EXEMPT_REQUEST_INTENTS
-                            .iter()
-                            .any(|candidate| *candidate == intent);
-                        match typed_intent {
-                            MessageIntent::PeerAdded => {
-                                let peer = params
-                                    .get("peer")
-                                    .and_then(|v| v.as_str())
-                                    .filter(|s| !s.is_empty())
-                                    .unwrap_or(from_name.as_str())
-                                    .to_string();
-                                (
-                                    RawPeerKind::PeerLifecycleAdded,
-                                    PeerInputClass::PeerLifecycleAdded,
-                                    Some(peer),
-                                    Some(envelope.id.to_string()),
-                                    auth_exempt,
-                                )
-                            }
-                            MessageIntent::PeerRetired => {
-                                let peer = params
-                                    .get("peer")
-                                    .and_then(|v| v.as_str())
-                                    .filter(|s| !s.is_empty())
-                                    .unwrap_or(from_name.as_str())
-                                    .to_string();
-                                (
-                                    RawPeerKind::PeerLifecycleRetired,
-                                    PeerInputClass::PeerLifecycleRetired,
-                                    Some(peer),
-                                    Some(envelope.id.to_string()),
-                                    auth_exempt,
-                                )
-                            }
-                            _ if self.silent_intents.contains(intent.as_str()) => (
-                                RawPeerKind::SilentRequest,
-                                PeerInputClass::SilentRequest,
-                                None,
-                                Some(envelope.id.to_string()),
-                                auth_exempt,
-                            ),
-                            _ => (
-                                RawPeerKind::Request,
-                                PeerInputClass::ActionableRequest,
-                                None,
-                                Some(envelope.id.to_string()),
-                                auth_exempt,
-                            ),
-                        }
+                        let classification = self.ingress_policy.classify_request_intent(intent);
+                        let lifecycle_peer = classification.lifecycle_kind.map(|_| {
+                            meerkat_core::peer_lifecycle_subject(params, from_name.as_str())
+                        });
+                        (
+                            classification,
+                            lifecycle_peer,
+                            Some(envelope.id.to_string()),
+                        )
                     }
                     MessageKind::Lifecycle { kind, params } => {
-                        let peer = params
-                            .get("peer")
-                            .and_then(|v| v.as_str())
-                            .filter(|s| !s.is_empty())
-                            .unwrap_or(from_name.as_str())
-                            .to_string();
-                        match kind {
-                            PeerLifecycleKind::PeerAdded => (
-                                RawPeerKind::PeerLifecycleAdded,
-                                PeerInputClass::PeerLifecycleAdded,
-                                Some(peer),
-                                None,
-                                false,
-                            ),
-                            PeerLifecycleKind::PeerRetired => (
-                                RawPeerKind::PeerLifecycleRetired,
-                                PeerInputClass::PeerLifecycleRetired,
-                                Some(peer),
-                                None,
-                                false,
-                            ),
-                            PeerLifecycleKind::PeerUnwired => (
-                                RawPeerKind::PeerLifecycleUnwired,
-                                PeerInputClass::PeerLifecycleUnwired,
-                                Some(peer),
-                                None,
-                                false,
-                            ),
-                        }
+                        let classification = self.ingress_policy.classify_lifecycle(*kind);
+                        let peer = meerkat_core::peer_lifecycle_subject(params, from_name.as_str());
+                        (classification, Some(peer), None)
                     }
                     MessageKind::Response {
                         in_reply_to,
                         status,
                         ..
-                    } => {
-                        // Single source of truth for response terminality:
-                        // meerkat-core's `classify_response_terminality`.
-                        // No raw `ResponseStatus` matching here — that's
-                        // how "terminal" drifts from one call site to
-                        // another.
-                        let core_status: meerkat_core::interaction::ResponseStatus =
-                            (*status).into();
-                        let raw_kind =
-                            match meerkat_core::interaction::classify_response_terminality(
-                                core_status,
-                            ) {
-                                meerkat_core::interaction::TerminalityClass::Progress => {
-                                    RawPeerKind::ResponseProgress
-                                }
-                                meerkat_core::interaction::TerminalityClass::Terminal {
-                                    ..
-                                } => RawPeerKind::ResponseTerminal,
-                                other => {
-                                    tracing::warn!(
-                                        class = ?other,
-                                        "unknown terminality class; routing response as progress (non-terminal)"
-                                    );
-                                    RawPeerKind::ResponseProgress
-                                }
-                            };
-                        (
-                            raw_kind,
-                            PeerInputClass::Response,
-                            None,
-                            Some(in_reply_to.to_string()),
-                            false,
-                        )
-                    }
-                    MessageKind::Ack { in_reply_to } => (
-                        RawPeerKind::Ack,
-                        PeerInputClass::Ack,
+                    } => (
+                        self.ingress_policy.classify_response((*status).into()),
                         None,
                         Some(in_reply_to.to_string()),
-                        false,
+                    ),
+                    MessageKind::Ack { in_reply_to } => (
+                        self.ingress_policy.classify_ack(),
+                        None,
+                        Some(in_reply_to.to_string()),
                     ),
                 };
 
                 let text_projection = match &envelope.kind {
                     MessageKind::Message { body, .. } => {
-                        format!("[COMMS MESSAGE from {from_name}]\n{body}")
+                        meerkat_core::format_peer_message_projection(&from_name, body)
                     }
                     MessageKind::Lifecycle { .. } => String::new(),
-                    MessageKind::Ack { in_reply_to } => ack_projection(&from_name, *in_reply_to),
-                    _ => {
-                        CommsMessage::from_external_with_resolved_peer(&envelope, from_name.clone())
-                            .map(|message| message.to_user_message_text())
-                            .unwrap_or_default()
+                    MessageKind::Request { intent, params, .. } => {
+                        meerkat_core::format_peer_request_projection(
+                            &from_name,
+                            envelope.id,
+                            intent,
+                            params,
+                        )
+                    }
+                    MessageKind::Response {
+                        in_reply_to,
+                        status,
+                        result,
+                        ..
+                    } => meerkat_core::format_peer_response_projection(
+                        &from_name,
+                        *in_reply_to,
+                        (*status).into(),
+                        result,
+                    ),
+                    MessageKind::Ack { in_reply_to } => {
+                        meerkat_core::format_peer_ack_projection(&from_name, *in_reply_to)
                     }
                 };
 
@@ -277,9 +165,9 @@ impl IngressClassificationContext {
 
                 Some(PreparedIngressItem {
                     raw_item_id: envelope.id.to_string(),
-                    raw_kind,
-                    class,
-                    auth_exempt,
+                    kind: classification.kind,
+                    class: classification.class,
+                    auth: classification.auth,
                     trusted_sender,
                     from_peer: Some(from_name),
                     lifecycle_peer,
@@ -303,11 +191,12 @@ impl IngressClassificationContext {
                     Some(&body),
                 );
                 let content_shape = content_shape_for_text_and_blocks(&body, blocks.as_deref());
+                let classification = self.ingress_policy.classify_plain_event();
                 Some(PreparedIngressItem {
                     raw_item_id: interaction_id.to_string(),
-                    raw_kind: RawPeerKind::PlainEvent,
-                    class: PeerInputClass::PlainEvent,
-                    auth_exempt: false,
+                    kind: classification.kind,
+                    class: classification.class,
+                    auth: classification.auth,
                     trusted_sender: true,
                     from_peer: None,
                     lifecycle_peer: None,
@@ -335,12 +224,13 @@ impl IngressClassificationContext {
             let drop_untrusted_external = matches!(prepared.item, InboxItem::External { .. })
                 && self.require_peer_auth
                 && !prepared.trusted_sender
-                && !prepared.auth_exempt;
+                && !prepared.auth.is_exempt();
             if drop_untrusted_external {
                 return None;
             }
             Some(ClassificationResult {
                 class: prepared.class,
+                auth: prepared.auth,
                 from_peer: prepared.from_peer,
                 lifecycle_peer: prepared.lifecycle_peer,
             })
@@ -369,7 +259,9 @@ mod tests {
         IngressClassificationContext {
             require_peer_auth,
             trusted_peers: Arc::new(parking_lot::RwLock::new(trusted_peers)),
-            silent_intents: Arc::new(silent_intents.into_iter().map(String::from).collect()),
+            ingress_policy: Arc::new(PeerIngressMachinePolicy::from_silent_intents(
+                silent_intents,
+            )),
         }
     }
 
@@ -573,7 +465,7 @@ mod tests {
         let envelope = make_envelope(
             &sender,
             MessageKind::Request {
-                intent: "supervisor.bridge".to_string(),
+                intent: meerkat_core::SUPERVISOR_BRIDGE_INTENT.to_string(),
                 params: serde_json::json!({
                     "command": "bind_member",
                     "supervisor": {
@@ -594,6 +486,12 @@ mod tests {
             .classify(&item)
             .expect("bind_member should remain admissible");
         assert_eq!(result.class, PeerInputClass::ActionableRequest);
+        assert_eq!(
+            result.auth,
+            meerkat_core::PeerIngressAuthDecision::Exempt(
+                meerkat_core::PeerIngressAuthExemption::SupervisorBridge
+            )
+        );
         assert_eq!(
             result.from_peer,
             Some(sender.public_key().to_pubkey_string())
@@ -686,7 +584,7 @@ mod tests {
             .expect("plain event should prepare");
 
         assert_eq!(prepared.class, PeerInputClass::PlainEvent);
-        assert_eq!(prepared.raw_kind, RawPeerKind::PlainEvent);
+        assert_eq!(prepared.kind, PeerIngressKind::PlainEvent);
         assert!(
             Uuid::parse_str(&prepared.raw_item_id).is_ok(),
             "plain events should receive a stable generated ingress id"
@@ -705,19 +603,5 @@ mod tests {
             }
             other => panic!("expected normalized plain event, got {other:?}"),
         }
-    }
-
-    #[test]
-    fn message_intent_peer_added_roundtrip() {
-        let intent = MessageIntent::from("mob.peer_added");
-        assert_eq!(intent, MessageIntent::PeerAdded);
-        assert_eq!(intent.as_str(), "mob.peer_added");
-    }
-
-    #[test]
-    fn message_intent_peer_retired_roundtrip() {
-        let intent = MessageIntent::from("mob.peer_retired");
-        assert_eq!(intent, MessageIntent::PeerRetired);
-        assert_eq!(intent.as_str(), "mob.peer_retired");
     }
 }

--- a/meerkat-comms/src/inbox.rs
+++ b/meerkat-comms/src/inbox.rs
@@ -19,8 +19,8 @@ use crate::peer_types::PeerIngressState;
 use crate::trust::TrustedPeers;
 use crate::types::{Envelope, InboxItem, MessageKind};
 use meerkat_core::{
-    InteractionId, PeerIngressEntrySnapshot, PeerIngressKind, PeerIngressQueueSnapshot,
-    PeerInputClass,
+    InteractionId, PeerIngressAuthDecision, PeerIngressEntrySnapshot, PeerIngressKind,
+    PeerIngressMachinePolicy, PeerIngressQueueSnapshot, PeerInputClass,
 };
 
 const DEFAULT_INBOX_CAPACITY: usize = 1024;
@@ -94,7 +94,7 @@ pub(crate) struct ClassifiedInboxEntry {
     pub(crate) raw_item_id: String,
     pub(crate) item: InboxItem,
     pub(crate) class: PeerInputClass,
-    pub(crate) auth_exempt: bool,
+    pub(crate) auth: PeerIngressAuthDecision,
     pub(crate) kind: PeerIngressKind,
     pub(crate) from_peer: Option<String>,
     pub(crate) lifecycle_peer: Option<String>,
@@ -170,7 +170,7 @@ impl ClassifiedInboxQueue {
     ///
     /// Auth-exempt items (bridge bootstrap / idempotency-ack) bypass the
     /// peer-trust gate unconditionally so bootstrapping can complete
-    /// before trust edges exist. The `auth_exempt` argument flows from
+    /// before trust edges exist. The typed auth decision flows from
     /// the prepared item so this single admission seam can distinguish
     /// "admit as trusted" from "admit as exempt" — no parallel outer
     /// branch, no classification-time bool that can drift.
@@ -195,7 +195,7 @@ impl ClassifiedInboxQueue {
         // the authoritative trust read against the require_peer_auth
         // policy. The prepared classification snapshot is NOT consulted
         // here — only the admission-time read is authoritative.
-        let admitted = prepared.auth_exempt || trusted || !self.auth_required;
+        let admitted = prepared.auth.is_exempt() || trusted || !self.auth_required;
         let had_queued_work = !self.entries.is_empty();
 
         if admitted {
@@ -226,7 +226,7 @@ impl ClassifiedInboxQueue {
     /// drive the peer-ingress phase. Auth-exempt entries (bridge bootstrap
     /// / idempotency-ack envelopes) bypass the phase machinery entirely.
     fn note_peer_dequeue(&mut self, entry: &ClassifiedInboxEntry) {
-        if entry.auth_exempt {
+        if entry.auth.is_exempt() {
             return;
         }
         let InboxItem::External { .. } = &entry.item else {
@@ -285,7 +285,9 @@ impl ClassifiedInboxQueue {
             .filter(|entry| {
                 matches!(
                     entry.class,
-                    PeerInputClass::PeerLifecycleAdded | PeerInputClass::PeerLifecycleRetired
+                    PeerInputClass::PeerLifecycleAdded
+                        | PeerInputClass::PeerLifecycleRetired
+                        | PeerInputClass::PeerLifecycleUnwired
                 )
             })
             .count();
@@ -536,7 +538,7 @@ impl InboxSender {
         // flip trust state before admission runs. This is the critical
         // T0→T1 window that the pre-C-H3 code would have leaked.
         pause();
-        let kind = result.ingress_kind();
+        let kind = result.kind;
         let decision = {
             let mut queue = classified_queue.lock();
             queue.admit_peer_receive(&result)
@@ -548,7 +550,7 @@ impl InboxSender {
             raw_item_id: result.raw_item_id,
             item: result.item,
             class: result.class,
-            auth_exempt: result.auth_exempt,
+            auth: result.auth,
             kind,
             from_peer: result.from_peer,
             lifecycle_peer: result.lifecycle_peer,
@@ -582,12 +584,15 @@ impl InboxSender {
             return self.send_classified(InboxItem::External { envelope });
         }
 
-        let auth_exempt = is_auth_exempt_ingress(&envelope.kind);
-        if require_peer_auth && !auth_exempt && !trusted_peers.read().is_trusted(&envelope.from) {
+        let auth = ingress_auth_decision(&envelope.kind);
+        if require_peer_auth
+            && !auth.is_exempt()
+            && !trusted_peers.read().is_trusted(&envelope.from)
+        {
             tracing::warn!(
                 peer_id = %envelope.from.to_peer_id(),
                 auth_required = require_peer_auth,
-                auth_exempt,
+                auth_exempt = auth.is_exempt(),
                 reason = ?DropReason::UntrustedSender,
                 "raw inbox dropped external peer ingress at admission"
             );
@@ -686,7 +691,7 @@ impl InboxSender {
                 return self.record_drop(DropReason::ClassificationRejected);
             }
         };
-        let kind = result.ingress_kind();
+        let kind = result.kind;
         // C-H3 — the admission decision (trust re-check, auth-exempt
         // bypass, and phase update) happens inside a single queue-lock
         // scope so classification's T0 trust snapshot cannot admit an
@@ -718,7 +723,7 @@ impl InboxSender {
             raw_item_id: result.raw_item_id,
             item: result.item,
             class: result.class,
-            auth_exempt: result.auth_exempt,
+            auth: result.auth,
             kind,
             from_peer: result.from_peer,
             lifecycle_peer: result.lifecycle_peer,
@@ -775,11 +780,15 @@ impl Drop for Inbox {
     }
 }
 
-fn is_auth_exempt_ingress(kind: &MessageKind) -> bool {
-    matches!(
-        kind,
-        MessageKind::Request { intent, .. } if intent == "supervisor.bridge"
-    )
+fn ingress_auth_decision(kind: &MessageKind) -> PeerIngressAuthDecision {
+    match kind {
+        MessageKind::Request { intent, .. } => {
+            PeerIngressMachinePolicy::default()
+                .classify_request_intent(intent)
+                .auth
+        }
+        _ => PeerIngressAuthDecision::Required,
+    }
 }
 
 fn snapshot_entry(entry: &ClassifiedInboxEntry) -> PeerIngressEntrySnapshot {
@@ -794,6 +803,10 @@ fn snapshot_entry(entry: &ClassifiedInboxEntry) -> PeerIngressEntrySnapshot {
         from_peer: entry.from_peer.clone(),
         lifecycle_peer: entry.lifecycle_peer.clone(),
         request_id: entry.request_id.clone(),
+        auth: match &entry.item {
+            InboxItem::External { .. } => Some(entry.auth),
+            InboxItem::PlainEvent { .. } => None,
+        },
         trusted_snapshot: entry.trusted_snapshot,
     }
 }
@@ -1045,7 +1058,7 @@ mod tests {
         Arc::new(IngressClassificationContext {
             require_peer_auth: require_auth,
             trusted_peers: Arc::new(parking_lot::RwLock::new(trusted)),
-            silent_intents: Arc::new(std::collections::HashSet::new()),
+            ingress_policy: Arc::new(PeerIngressMachinePolicy::default()),
         })
     }
 
@@ -1291,6 +1304,11 @@ mod tests {
         assert_eq!(snapshot.queued_entries.len(), 2);
         assert_eq!(snapshot.queued_entries[0].kind, PeerIngressKind::Message);
         assert_eq!(snapshot.queued_entries[1].kind, PeerIngressKind::PlainEvent);
+        assert_eq!(
+            snapshot.queued_entries[0].auth,
+            Some(PeerIngressAuthDecision::Required)
+        );
+        assert_eq!(snapshot.queued_entries[1].auth, None);
         assert_eq!(snapshot.queued_entries[0].trusted_snapshot, Some(true));
         assert_eq!(snapshot.queued_entries[1].trusted_snapshot, None);
         assert!(
@@ -1437,7 +1455,7 @@ mod tests {
             from: sender.public_key(),
             to: receiver.public_key(),
             kind: MessageKind::Request {
-                intent: "supervisor.bridge".to_string(),
+                intent: meerkat_core::SUPERVISOR_BRIDGE_INTENT.to_string(),
                 params: serde_json::json!({}),
                 handling_mode: None,
             },
@@ -1456,7 +1474,8 @@ mod tests {
                 assert_eq!(envelope.id, envelope_id);
                 assert!(matches!(
                     envelope.kind,
-                    MessageKind::Request { ref intent, .. } if intent == "supervisor.bridge"
+                    MessageKind::Request { ref intent, .. }
+                        if intent == meerkat_core::SUPERVISOR_BRIDGE_INTENT
                 ));
             }
             _ => panic!("expected External ingress item"),

--- a/meerkat-comms/src/peer_types.rs
+++ b/meerkat-comms/src/peer_types.rs
@@ -7,21 +7,6 @@
 //! mechanics (trust set, queue order, dequeue emission) live directly on
 //! `ClassifiedInboxQueue` in `inbox.rs`.
 
-/// The raw kind tag from the wire envelope, before classification.
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub(crate) enum RawPeerKind {
-    Request,
-    PeerLifecycleAdded,
-    PeerLifecycleRetired,
-    PeerLifecycleUnwired,
-    ResponseTerminal,
-    ResponseProgress,
-    PlainEvent,
-    SilentRequest,
-    Ack,
-    Message,
-}
-
 /// Shape of the content payload (used for downstream rendering decisions).
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) enum ContentShape {

--- a/meerkat-comms/src/runtime/comms_runtime.rs
+++ b/meerkat-comms/src/runtime/comms_runtime.rs
@@ -916,6 +916,7 @@ impl CoreCommsRuntime for CommsRuntime {
                                 render_metadata: None,
                             },
                             class: entry.class,
+                            auth: Some(entry.auth),
                             lifecycle_peer: entry.lifecycle_peer,
                         })
                     }
@@ -939,6 +940,7 @@ impl CoreCommsRuntime for CommsRuntime {
                             render_metadata,
                         },
                         class: entry.class,
+                        auth: None,
                         lifecycle_peer: entry.lifecycle_peer,
                     }),
                 }
@@ -1121,8 +1123,8 @@ pub struct CommsRuntime {
     subscriber_registry: crate::event_injector::SubscriberRegistry,
     interaction_stream_registry: InteractionStreamRegistry,
     peer_directory_reachability: Arc<Mutex<PeerDirectoryReachabilityAuthority>>,
-    #[allow(dead_code)] // Kept alive — shared with IngressClassificationContext via Arc
-    silent_intents: Arc<HashSet<String>>,
+    #[allow(dead_code)] // Kept for runtime inspection symmetry with IngressClassificationContext.
+    ingress_policy: Arc<meerkat_core::PeerIngressMachinePolicy>,
     /// Narrow notify that fires only for actionable peer input (messages/requests).
     /// Set during construction when classified inbox is used.
     actionable_notify: Option<Arc<tokio::sync::Notify>>,
@@ -1154,6 +1156,14 @@ pub struct CommsRuntime {
 }
 
 impl CommsRuntime {
+    fn ingress_policy_from_silent_intents(
+        silent_intents: &Arc<HashSet<String>>,
+    ) -> Arc<meerkat_core::PeerIngressMachinePolicy> {
+        Arc::new(meerkat_core::PeerIngressMachinePolicy::from_silent_intents(
+            silent_intents.iter().cloned(),
+        ))
+    }
+
     fn derive_bridge_bootstrap_token(keypair: &Keypair) -> String {
         let mut digest = Sha256::new();
         digest.update(b"meerkat.supervisor-bridge.bootstrap-token.v1");
@@ -1186,12 +1196,13 @@ impl CommsRuntime {
         // Single source of truth for trust state — shared by the Router,
         // IngressClassificationContext, and callers of trusted_peers_shared().
         let trusted_peers = Arc::new(parking_lot::RwLock::new(trusted_peers));
+        let ingress_policy = Self::ingress_policy_from_silent_intents(&silent_intents);
 
         // Build classified inbox using the same trusted_peers Arc
         let classification_context = Arc::new(crate::classify::IngressClassificationContext {
             require_peer_auth: config.require_peer_auth,
             trusted_peers: trusted_peers.clone(),
-            silent_intents: silent_intents.clone(),
+            ingress_policy: ingress_policy.clone(),
         });
         let (inbox, inbox_sender) = crate::Inbox::new_classified(classification_context);
         let inbox_notify = inbox.notify();
@@ -1225,7 +1236,7 @@ impl CommsRuntime {
             peer_directory_reachability: Arc::new(Mutex::new(
                 PeerDirectoryReachabilityAuthority::new(),
             )),
-            silent_intents,
+            ingress_policy,
             actionable_notify,
             blob_store: None,
             peer_interaction_handle: parking_lot::RwLock::new(None),
@@ -1270,11 +1281,12 @@ impl CommsRuntime {
         let public_key = keypair.public_key();
         // Single source of truth — same Arc shared by Router, classification, and callers.
         let trusted_peers = Arc::new(parking_lot::RwLock::new(TrustedPeers::new()));
+        let ingress_policy = Self::ingress_policy_from_silent_intents(&silent_intents);
 
         let classification_context = Arc::new(crate::classify::IngressClassificationContext {
             require_peer_auth: true,
             trusted_peers: trusted_peers.clone(),
-            silent_intents: silent_intents.clone(),
+            ingress_policy: ingress_policy.clone(),
         });
         let (inbox, inbox_sender) = crate::Inbox::new_classified(classification_context);
         let inbox_notify = inbox.notify();
@@ -1332,7 +1344,7 @@ impl CommsRuntime {
             peer_directory_reachability: Arc::new(Mutex::new(
                 PeerDirectoryReachabilityAuthority::new(),
             )),
-            silent_intents,
+            ingress_policy,
             actionable_notify,
             blob_store: None,
             peer_interaction_handle: parking_lot::RwLock::new(None),
@@ -1398,11 +1410,12 @@ impl CommsRuntime {
             .map_err(|e| CommsRuntimeError::IdentityError(e.to_string()))?;
         let public_key = keypair.public_key();
         let trusted_peers = Arc::new(parking_lot::RwLock::new(TrustedPeers::new()));
+        let ingress_policy = Self::ingress_policy_from_silent_intents(&silent_intents);
 
         let classification_context = Arc::new(crate::classify::IngressClassificationContext {
             require_peer_auth: true,
             trusted_peers: trusted_peers.clone(),
-            silent_intents: silent_intents.clone(),
+            ingress_policy: ingress_policy.clone(),
         });
         let (inbox, inbox_sender) = crate::Inbox::new_classified(classification_context);
         let inbox_notify = inbox.notify();
@@ -1451,7 +1464,7 @@ impl CommsRuntime {
             peer_directory_reachability: Arc::new(Mutex::new(
                 PeerDirectoryReachabilityAuthority::new(),
             )),
-            silent_intents,
+            ingress_policy,
             actionable_notify,
             blob_store: None,
             peer_interaction_handle: parking_lot::RwLock::new(None),

--- a/meerkat-comms/tests/inbox_admission_toctou.rs
+++ b/meerkat-comms/tests/inbox_admission_toctou.rs
@@ -18,6 +18,7 @@ use meerkat_comms::runtime::comms_runtime::CommsRuntime;
 use meerkat_comms::types::{Envelope, InboxItem, MessageKind};
 use meerkat_comms::{AdmissionOutcome, DropReason};
 use meerkat_core::comms::{PeerAddress, PeerName, PeerTransport, TrustedPeerDescriptor};
+use meerkat_core::{PeerIngressAuthDecision, PeerIngressAuthExemption, SUPERVISOR_BRIDGE_INTENT};
 use uuid::Uuid;
 
 fn descriptor_for(name: &str, pubkey: &meerkat_comms::identity::PubKey) -> TrustedPeerDescriptor {
@@ -288,7 +289,7 @@ async fn auth_exempt_bridge_request_admits_without_trust_edge() {
         from: sender.public_key(),
         to: receiver.public_key(),
         kind: MessageKind::Request {
-            intent: "supervisor.bridge".to_string(),
+            intent: SUPERVISOR_BRIDGE_INTENT.to_string(),
             params: serde_json::json!({}),
             handling_mode: None,
         },
@@ -305,5 +306,16 @@ async fn auth_exempt_bridge_request_admits_without_trust_edge() {
         outcome,
         AdmissionOutcome::Admitted,
         "supervisor.bridge ingress is auth-exempt and must admit even without a trust edge"
+    );
+
+    let candidates =
+        meerkat_core::agent::CommsRuntime::drain_peer_input_candidates(&receiver).await;
+    assert_eq!(candidates.len(), 1);
+    assert_eq!(
+        candidates[0].auth,
+        Some(PeerIngressAuthDecision::Exempt(
+            PeerIngressAuthExemption::SupervisorBridge
+        )),
+        "runtime drain must expose the typed machine auth decision"
     );
 }

--- a/meerkat-contracts/src/wire/supervisor_bridge.rs
+++ b/meerkat-contracts/src/wire/supervisor_bridge.rs
@@ -11,7 +11,7 @@ use serde::{Deserialize, Serialize};
 ///
 /// The sender sets this as the request `intent`; the receiver checks for it
 /// before attempting to deserialize `params` as [`BridgeCommand`].
-pub const SUPERVISOR_BRIDGE_INTENT: &str = "supervisor.bridge";
+pub use meerkat_core::comms::SUPERVISOR_BRIDGE_INTENT;
 /// Address query parameter carrying the one-time bind bootstrap token.
 pub const SUPERVISOR_BRIDGE_BOOTSTRAP_TOKEN_PARAM: &str = "mob_supervisor_bootstrap_token";
 /// Current supervisor bridge wire protocol version.

--- a/meerkat-core/src/agent/state.rs
+++ b/meerkat-core/src/agent/state.rs
@@ -3788,6 +3788,7 @@ mod tests {
                         render_metadata: None,
                     },
                     class: crate::interaction::PeerInputClass::ActionableMessage,
+                    auth: Some(crate::interaction::PeerIngressAuthDecision::Required),
                     lifecycle_peer: None,
                 })
                 .collect()

--- a/meerkat-core/src/comms.rs
+++ b/meerkat-core/src/comms.rs
@@ -12,6 +12,14 @@ use serde::{Deserialize, Serialize};
 use std::pin::Pin;
 use uuid::Uuid;
 
+/// Comms request intent used for all supervisor bridge commands.
+///
+/// This is auth-exempt at peer ingress so a supervisor can complete the
+/// bootstrap handshake before the private trust edge exists. Keep the literal
+/// under core ingress authority; transport crates should compare through typed
+/// core policy rather than owning a local string exemption.
+pub const SUPERVISOR_BRIDGE_INTENT: &str = "supervisor.bridge";
+
 /// Canonical runtime identity for a peer.
 ///
 /// `PeerId` is the routing key: the router and trust store key by `PeerId`,

--- a/meerkat-core/src/interaction.rs
+++ b/meerkat-core/src/interaction.rs
@@ -6,9 +6,10 @@
 
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
+use std::collections::BTreeSet;
 use uuid::Uuid;
 
-use crate::comms::TrustedPeerDescriptor;
+use crate::comms::{PeerLifecycleKind, SUPERVISOR_BRIDGE_INTENT, TrustedPeerDescriptor};
 use crate::types::{ContentBlock, HandlingMode, RenderMetadata};
 
 /// Unique identifier for an interaction.
@@ -123,6 +124,69 @@ pub fn format_external_event_projection(source_name: &str, body: Option<&str>) -
     }
 }
 
+/// Canonical model-facing text projection for a peer message.
+pub fn format_peer_message_projection(from_peer: &str, body: &str) -> String {
+    format!("[COMMS MESSAGE from {from_peer}]\n{body}")
+}
+
+/// Canonical model-facing text projection for a correlated peer request.
+pub fn format_peer_request_projection(
+    from_peer: &str,
+    request_id: impl std::fmt::Display,
+    intent: &str,
+    params: &Value,
+) -> String {
+    let params_str = if params.is_null() || matches!(params, Value::Object(map) if map.is_empty()) {
+        String::new()
+    } else {
+        format!(
+            "\nParams: {}",
+            serde_json::to_string_pretty(params).unwrap_or_default()
+        )
+    };
+
+    format!(
+        "[COMMS REQUEST from {from_peer} (id: {request_id})]\n\
+         Intent: {intent}{params_str}\n\
+         \n\
+         This is a correlated peer request. Reply with send_response using \
+         to=\"{from_peer}\", in_reply_to=\"{request_id}\", status=\"completed\" or \"failed\", and result=<JSON payload>. \
+         Do not answer this request with send_message."
+    )
+}
+
+/// Canonical model-facing text projection for a peer response.
+pub fn format_peer_response_projection(
+    from_peer: &str,
+    in_reply_to: impl std::fmt::Display,
+    status: ResponseStatus,
+    result: &Value,
+) -> String {
+    let status_str = match status {
+        ResponseStatus::Accepted => "accepted",
+        ResponseStatus::Completed => "completed",
+        ResponseStatus::Failed => "failed",
+    };
+    let result_str = if result.is_null() || matches!(result, Value::Object(map) if map.is_empty()) {
+        String::new()
+    } else {
+        format!(
+            "\nResult: {}",
+            serde_json::to_string_pretty(result).unwrap_or_default()
+        )
+    };
+
+    format!(
+        "[COMMS RESPONSE from {from_peer} (to request: {in_reply_to})]\n\
+         Status: {status_str}{result_str}"
+    )
+}
+
+/// Canonical model-facing text projection for a peer ack.
+pub fn format_peer_ack_projection(from_peer: &str, in_reply_to: impl std::fmt::Display) -> String {
+    format!("[COMMS ACK from {from_peer} (to request: {in_reply_to})]")
+}
+
 /// Classification result for incoming peer/event traffic.
 ///
 /// Stored with each inbox entry at ingress time. Downstream consumers
@@ -168,6 +232,174 @@ impl PeerInputClass {
     }
 }
 
+/// Typed auth exemption recognized by peer ingress authority.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]
+pub enum PeerIngressAuthExemption {
+    /// Supervisor bridge bootstrap request.
+    SupervisorBridge,
+}
+
+impl PeerIngressAuthExemption {
+    pub const fn intent(self) -> &'static str {
+        match self {
+            Self::SupervisorBridge => SUPERVISOR_BRIDGE_INTENT,
+        }
+    }
+
+    pub fn matches_intent(self, intent: &str) -> bool {
+        self.intent() == intent
+    }
+}
+
+/// Auth decision attached to a classified peer ingress item.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum PeerIngressAuthDecision {
+    /// Sender must be trusted when peer auth is required.
+    Required,
+    /// The item is allowed through the trust gate for a typed bootstrap reason.
+    Exempt(PeerIngressAuthExemption),
+}
+
+impl PeerIngressAuthDecision {
+    pub const fn is_exempt(self) -> bool {
+        matches!(self, Self::Exempt(_))
+    }
+}
+
+/// Typed output of machine-owned peer ingress classification.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PeerIngressClassification {
+    pub class: PeerInputClass,
+    pub kind: PeerIngressKind,
+    pub auth: PeerIngressAuthDecision,
+    pub lifecycle_kind: Option<PeerLifecycleKind>,
+}
+
+impl PeerIngressClassification {
+    pub const fn required(class: PeerInputClass, kind: PeerIngressKind) -> Self {
+        Self {
+            class,
+            kind,
+            auth: PeerIngressAuthDecision::Required,
+            lifecycle_kind: None,
+        }
+    }
+
+    pub const fn lifecycle(kind: PeerLifecycleKind) -> Self {
+        let class = match kind {
+            PeerLifecycleKind::PeerAdded => PeerInputClass::PeerLifecycleAdded,
+            PeerLifecycleKind::PeerRetired => PeerInputClass::PeerLifecycleRetired,
+            PeerLifecycleKind::PeerUnwired => PeerInputClass::PeerLifecycleUnwired,
+        };
+        Self {
+            class,
+            kind: PeerIngressKind::Request,
+            auth: PeerIngressAuthDecision::Required,
+            lifecycle_kind: Some(kind),
+        }
+    }
+}
+
+/// Machine-owned policy used to classify peer ingress.
+///
+/// Transport code may parse envelopes, but auth exemptions, lifecycle intent
+/// mapping, and silent-request routing flow through this typed authority.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PeerIngressMachinePolicy {
+    silent_request_intents: BTreeSet<String>,
+    auth_exemptions: BTreeSet<PeerIngressAuthExemption>,
+}
+
+impl Default for PeerIngressMachinePolicy {
+    fn default() -> Self {
+        Self::from_silent_intents(std::iter::empty::<String>())
+    }
+}
+
+impl PeerIngressMachinePolicy {
+    pub fn from_silent_intents<I, S>(silent_intents: I) -> Self
+    where
+        I: IntoIterator<Item = S>,
+        S: Into<String>,
+    {
+        Self {
+            silent_request_intents: silent_intents.into_iter().map(Into::into).collect(),
+            auth_exemptions: BTreeSet::from([PeerIngressAuthExemption::SupervisorBridge]),
+        }
+    }
+
+    pub fn classify_message(&self) -> PeerIngressClassification {
+        PeerIngressClassification::required(
+            PeerInputClass::ActionableMessage,
+            PeerIngressKind::Message,
+        )
+    }
+
+    pub fn classify_request_intent(&self, intent: &str) -> PeerIngressClassification {
+        let auth = self
+            .auth_exemptions
+            .iter()
+            .copied()
+            .find(|exemption| exemption.matches_intent(intent))
+            .map(PeerIngressAuthDecision::Exempt)
+            .unwrap_or(PeerIngressAuthDecision::Required);
+
+        let mut classification = if let Some(kind) = classify_lifecycle_intent(intent) {
+            PeerIngressClassification::lifecycle(kind)
+        } else if self.silent_request_intents.contains(intent) {
+            PeerIngressClassification::required(
+                PeerInputClass::SilentRequest,
+                PeerIngressKind::Request,
+            )
+        } else {
+            PeerIngressClassification::required(
+                PeerInputClass::ActionableRequest,
+                PeerIngressKind::Request,
+            )
+        };
+        classification.auth = auth;
+        classification
+    }
+
+    pub fn classify_lifecycle(&self, kind: PeerLifecycleKind) -> PeerIngressClassification {
+        PeerIngressClassification::lifecycle(kind)
+    }
+
+    pub fn classify_response(&self, _status: ResponseStatus) -> PeerIngressClassification {
+        PeerIngressClassification::required(PeerInputClass::Response, PeerIngressKind::Response)
+    }
+
+    pub fn classify_ack(&self) -> PeerIngressClassification {
+        PeerIngressClassification::required(PeerInputClass::Ack, PeerIngressKind::Ack)
+    }
+
+    pub fn classify_plain_event(&self) -> PeerIngressClassification {
+        PeerIngressClassification::required(PeerInputClass::PlainEvent, PeerIngressKind::PlainEvent)
+    }
+}
+
+/// Extract the lifecycle subject from typed request/lifecycle parameters.
+pub fn peer_lifecycle_subject(params: &Value, fallback_peer: &str) -> String {
+    params
+        .get("peer")
+        .and_then(Value::as_str)
+        .filter(|peer| !peer.is_empty())
+        .unwrap_or(fallback_peer)
+        .to_string()
+}
+
+fn classify_lifecycle_intent(intent: &str) -> Option<PeerLifecycleKind> {
+    if intent == PeerLifecycleKind::PeerAdded.as_str() {
+        Some(PeerLifecycleKind::PeerAdded)
+    } else if intent == PeerLifecycleKind::PeerRetired.as_str() {
+        Some(PeerLifecycleKind::PeerRetired)
+    } else if intent == PeerLifecycleKind::PeerUnwired.as_str() {
+        Some(PeerLifecycleKind::PeerUnwired)
+    } else {
+        None
+    }
+}
+
 /// Canonical peer/event ingress candidate handed to runtime admission.
 ///
 /// This is the typed, machine-authored drain unit for runtime-backed peer
@@ -179,6 +411,9 @@ pub struct PeerInputCandidate {
     pub interaction: InboxInteraction,
     /// Pre-computed classification from ingress.
     pub class: PeerInputClass,
+    /// Auth decision that admitted this candidate when it came from peer
+    /// transport. Plain events and legacy producers may leave this unset.
+    pub auth: Option<PeerIngressAuthDecision>,
     /// For lifecycle events, the peer name that was added/retired.
     pub lifecycle_peer: Option<String>,
 }
@@ -216,6 +451,9 @@ pub struct PeerIngressEntrySnapshot {
     pub lifecycle_peer: Option<String>,
     /// Request envelope id or reply-to correlation when one exists.
     pub request_id: Option<String>,
+    /// Auth decision used by peer ingress admission, if this queued entry came
+    /// from authenticated peer transport. Plain events leave this unset.
+    pub auth: Option<PeerIngressAuthDecision>,
     /// Whether this entry was trusted at ingress time, when peer authority
     /// owns the entry. Plain external events leave this unset.
     pub trusted_snapshot: Option<bool>,
@@ -355,6 +593,34 @@ mod tests {
                 disposition: TerminalDisposition::Failed
             }
         );
+    }
+
+    #[test]
+    fn peer_ingress_policy_auth_exempts_supervisor_bridge() {
+        let policy = PeerIngressMachinePolicy::default();
+        let classification = policy.classify_request_intent(crate::SUPERVISOR_BRIDGE_INTENT);
+
+        assert_eq!(classification.class, PeerInputClass::ActionableRequest);
+        assert_eq!(
+            classification.auth,
+            PeerIngressAuthDecision::Exempt(PeerIngressAuthExemption::SupervisorBridge)
+        );
+    }
+
+    #[test]
+    fn peer_ingress_policy_owns_lifecycle_and_silent_routing() {
+        let policy = PeerIngressMachinePolicy::from_silent_intents(["probe.silent"]);
+
+        let lifecycle = policy.classify_request_intent(PeerLifecycleKind::PeerUnwired.as_str());
+        assert_eq!(lifecycle.class, PeerInputClass::PeerLifecycleUnwired);
+        assert_eq!(
+            lifecycle.lifecycle_kind,
+            Some(PeerLifecycleKind::PeerUnwired)
+        );
+
+        let silent = policy.classify_request_intent("probe.silent");
+        assert_eq!(silent.class, PeerInputClass::SilentRequest);
+        assert_eq!(silent.auth, PeerIngressAuthDecision::Required);
     }
 
     #[test]

--- a/meerkat-core/src/lib.rs
+++ b/meerkat-core/src/lib.rs
@@ -106,7 +106,7 @@ pub use checkpoint::SessionCheckpointer;
 pub use comms::{
     CommsCommand, EventStream, InputSource, InputStreamMode, PeerDirectoryEntry,
     PeerDirectorySource, PeerName, PeerReachability, PeerReachabilityReason, PeerRoute,
-    SendAndStreamError, SendError, SendReceipt, StreamError, StreamScope,
+    SUPERVISOR_BRIDGE_INTENT, SendAndStreamError, SendError, SendReceipt, StreamError, StreamScope,
 };
 pub use compact::{
     CompactionConfig, CompactionContext, CompactionResult, Compactor,
@@ -184,9 +184,12 @@ pub use image_content::{
 pub use image_generation::*;
 pub use interaction::{
     ClassifiedInboxInteraction, InboxInteraction, InteractionContent, InteractionId,
-    PeerIngressAuthorityPhase, PeerIngressEntrySnapshot, PeerIngressKind, PeerIngressQueueSnapshot,
-    PeerIngressRuntimeSnapshot, PeerInputClass, ResponseStatus, TerminalDisposition,
-    TerminalityClass, classify_response_terminality,
+    PeerIngressAuthDecision, PeerIngressAuthExemption, PeerIngressAuthorityPhase,
+    PeerIngressClassification, PeerIngressEntrySnapshot, PeerIngressKind, PeerIngressMachinePolicy,
+    PeerIngressQueueSnapshot, PeerIngressRuntimeSnapshot, PeerInputClass, ResponseStatus,
+    TerminalDisposition, TerminalityClass, classify_response_terminality,
+    format_peer_ack_projection, format_peer_message_projection, format_peer_request_projection,
+    format_peer_response_projection, peer_lifecycle_subject,
 };
 pub use lifecycle::{
     ConversationAppend, ConversationAppendRole, ConversationContextAppend, CoreExecutor,

--- a/meerkat-mob-mcp/src/agent_tools.rs
+++ b/meerkat-mob-mcp/src/agent_tools.rs
@@ -2063,6 +2063,7 @@ mod tests {
                 .map(|interaction| PeerInputCandidate {
                     interaction,
                     class: PeerInputClass::ActionableRequest,
+                    auth: Some(meerkat_core::PeerIngressAuthDecision::Required),
                     lifecycle_peer: None,
                 })
                 .collect()

--- a/meerkat-mob/src/runtime/supervisor_bridge.rs
+++ b/meerkat-mob/src/runtime/supervisor_bridge.rs
@@ -294,6 +294,7 @@ mod tests {
                 render_metadata: None,
             },
             class: PeerInputClass::Response,
+            auth: Some(meerkat_core::PeerIngressAuthDecision::Required),
             lifecycle_peer: None,
         }
     }

--- a/meerkat-runtime/src/comms_bridge.rs
+++ b/meerkat-runtime/src/comms_bridge.rs
@@ -300,6 +300,7 @@ mod tests {
     fn plain_event_to_external_event_input() {
         let classified = PeerInputCandidate {
             class: PeerInputClass::PlainEvent,
+            auth: None,
             lifecycle_peer: None,
             interaction: InboxInteraction {
                 from: "event:webhook".into(),
@@ -334,6 +335,7 @@ mod tests {
     fn peer_named_event_prefix_stays_peer_without_plain_event_class() {
         let classified = PeerInputCandidate {
             class: PeerInputClass::ActionableMessage,
+            auth: Some(meerkat_core::PeerIngressAuthDecision::Required),
             lifecycle_peer: None,
             interaction: InboxInteraction {
                 from: "event:webhook".into(),
@@ -469,6 +471,7 @@ mod tests {
         ];
         let classified = PeerInputCandidate {
             class: PeerInputClass::PlainEvent,
+            auth: None,
             lifecycle_peer: None,
             interaction: InboxInteraction {
                 from: "event:webhook".into(),
@@ -507,6 +510,7 @@ mod tests {
         };
         let classified = PeerInputCandidate {
             class: PeerInputClass::PlainEvent,
+            auth: None,
             lifecycle_peer: None,
             interaction: InboxInteraction {
                 from: "event:webhook".into(),

--- a/meerkat-runtime/src/comms_drain.rs
+++ b/meerkat-runtime/src/comms_drain.rs
@@ -1902,6 +1902,7 @@ mod tests {
                 render_metadata: None,
             },
             class,
+            auth: Some(meerkat_core::PeerIngressAuthDecision::Required),
             lifecycle_peer: Some("peer-1".to_string()),
         }
     }
@@ -2922,6 +2923,9 @@ mod tests {
                 render_metadata: None,
             },
             class: PeerInputClass::ActionableRequest,
+            auth: Some(meerkat_core::PeerIngressAuthDecision::Exempt(
+                meerkat_core::PeerIngressAuthExemption::SupervisorBridge,
+            )),
             lifecycle_peer: None,
         }
     }

--- a/meerkat-runtime/src/runtime_loop.rs
+++ b/meerkat-runtime/src/runtime_loop.rs
@@ -1529,6 +1529,7 @@ mod tests {
         let from_comms = peer_input_candidate_to_runtime_input(
             &PeerInputCandidate {
                 class: PeerInputClass::PlainEvent,
+                auth: None,
                 lifecycle_peer: None,
                 interaction: InboxInteraction {
                     id: meerkat_core::interaction::InteractionId(uuid::Uuid::new_v4()),


### PR DESCRIPTION
## Summary
- add typed core peer-ingress policy/auth decisions for auth exemptions, silent routing, lifecycle classification, and peer text projections
- refactor comms ingress classification/admission to consume that core policy instead of comms-local string policy
- expose typed auth decisions on queued peer ingress snapshots and drained peer input candidates

## Validation
- ./scripts/repo-cargo test -p meerkat-core peer_ingress_policy --lib
- ./scripts/repo-cargo test -p meerkat-comms --test inbox_admission_toctou auth_exempt_bridge_request_admits_without_trust_edge
- ./scripts/repo-cargo test -p meerkat-comms classify --lib
- make check (BuildBuddy invocation aa6efd7c-eec7-49ce-ad61-605a59b1fc90)

Linear: LUC-80