### PR TITLE
Stabilize live smoke verification

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -75,7 +75,7 @@ e2e-fast = "nextest run -p meerkat-integration-tests --test e2e_fast_lane --no-f
 e2e-build = "nextest run -p meerkat-integration-tests --test e2e_build_lane --run-ignored ignored-only --no-fail-fast --show-progress none --status-level none --final-status-level fail --test-threads=1"
 e2e-system = "nextest run -p meerkat-integration-tests --test e2e_system_lane --run-ignored ignored-only --no-fail-fast --no-capture --show-progress none --status-level all --final-status-level fail"
 e2e-live = "nextest run -p meerkat-integration-tests --test e2e_live_lane --run-ignored ignored-only --no-fail-fast --show-progress none --status-level none --final-status-level fail --test-threads=1"
-e2e-smoke = "nextest run -p meerkat-integration-tests --test e2e_smoke_lane --run-ignored ignored-only --no-fail-fast --show-progress none --status-level none --final-status-level fail"
+e2e-smoke = "nextest run -p meerkat-integration-tests --test e2e_smoke_lane --run-ignored ignored-only --no-fail-fast --show-progress none --status-level none --final-status-level fail --test-threads=3"
 e2e-models = "nextest run -p meerkat-integration-tests --test e2e_models_lane --run-ignored ignored-only --no-fail-fast --show-progress none --status-level none --final-status-level fail --test-threads=1"
 e2e-auth = "nextest run -p meerkat-integration-tests --test e2e_auth_lane --run-ignored ignored-only --no-fail-fast --show-progress none --status-level none --final-status-level fail --test-threads=1"
 

--- a/meerkat-mob/tests/smoke_mob_pictionary.rs
+++ b/meerkat-mob/tests/smoke_mob_pictionary.rs
@@ -32,6 +32,7 @@ use meerkat_mob::{
 };
 use meerkat_session::PersistentSessionService;
 use meerkat_store::{JsonlStore, StoreAdapter};
+use reqwest::header::ACCEPT_ENCODING;
 use std::collections::BTreeMap;
 use std::sync::Arc;
 use tempfile::TempDir;
@@ -51,6 +52,30 @@ async fn generate_image(
     api_key: &str,
     prompt: &str,
 ) -> Result<(String, String), Box<dyn std::error::Error>> {
+    let mut errors = Vec::new();
+    for attempt in 1..=3 {
+        match generate_image_once(api_key, prompt).await {
+            Ok(image) => return Ok(image),
+            Err(error) => {
+                errors.push(format!("attempt {attempt}: {error}"));
+                if attempt < 3 {
+                    sleep(Duration::from_millis(500 * attempt)).await;
+                }
+            }
+        }
+    }
+
+    Err(format!(
+        "Gemini image generation failed after retries: {}",
+        errors.join("; ")
+    )
+    .into())
+}
+
+async fn generate_image_once(
+    api_key: &str,
+    prompt: &str,
+) -> Result<(String, String), Box<dyn std::error::Error>> {
     let client = reqwest::Client::new();
     let url = format!(
         "https://generativelanguage.googleapis.com/v1beta/models/\
@@ -64,13 +89,18 @@ async fn generate_image(
     let resp = client
         .post(&url)
         .header("Content-Type", "application/json")
+        .header(ACCEPT_ENCODING, "identity")
         .json(&body)
-        .timeout(Duration::from_secs(60))
+        .timeout(Duration::from_secs(120))
         .send()
-        .await?;
+        .await
+        .map_err(|error| sanitize_gemini_key_error(api_key, error))?;
 
     let status = resp.status();
-    let text = resp.text().await?;
+    let text = resp
+        .text()
+        .await
+        .map_err(|error| sanitize_gemini_key_error(api_key, error))?;
     if !status.is_success() {
         return Err(format!("Gemini API {status}: {text}").into());
     }
@@ -89,6 +119,10 @@ async fn generate_image(
         }
     }
     Err("no image in response".into())
+}
+
+fn sanitize_gemini_key_error(api_key: &str, error: reqwest::Error) -> String {
+    error.to_string().replace(api_key, "<redacted>")
 }
 
 fn comms_profile(model: &str, peer_desc: &str) -> Profile {
@@ -1069,7 +1103,7 @@ async fn e2e_pictionary_multimodal_comms_stress() {
             &["guesser-a"],
             label,
             &image_blocks,
-            Duration::from_secs(30),
+            Duration::from_secs(90),
         )
         .await
         .unwrap_or_else(|e| panic!("artist image delivery failed: {e}"));

--- a/tests/integration/tests/smoke_shared_realm.rs
+++ b/tests/integration/tests/smoke_shared_realm.rs
@@ -7209,7 +7209,7 @@ async fn e2e_scenario_72_rust_sdk_realtime_audio_member_model_switch_continuity(
             .await?;
         }
 
-        let turn2_pcm = openai_tts_pcm("Say only copper canyon.").await?;
+        let turn2_pcm = openai_tts_pcm("Say only pineapple.").await?;
         eprintln!("[scenario 72] send turn 2 audio");
         let mut turn2_capture = match send_realtime_audio_and_wait_for_commit(
             &mut sender,
@@ -7270,8 +7270,8 @@ async fn e2e_scenario_72_rust_sdk_realtime_audio_member_model_switch_continuity(
         let turn2_output_audio_text = normalized_output_audio_transcript(&turn2_capture).await?;
         if turn2_capture.output_audio_pcm.is_empty()
             || !pcm_has_non_silence(&turn2_capture.output_audio_pcm)
-            || !(turn2_output_audio_text.contains("copper canyon")
-                || turn2_output_text.contains("copper canyon"))
+            || !(turn2_output_audio_text.contains("pineapple")
+                || turn2_output_text.contains("pineapple"))
         {
             dump_realtime_audio_artifacts(scenario_name, "turn-2", &turn2_pcm, &turn2_capture)
                 .await?;


### PR DESCRIPTION
## Summary
- cap the live smoke lane at 3 parallel tests to avoid provider and nested-build overload
- harden the pictionary raw Gemini image request with identity encoding, retries, redacted transport errors, and a longer delivery window
- switch scenario 72's realtime audio witness to a less confusable phrase

## Verification
- RUST_LANE_ID=postbatch-final-smoke ./scripts/repo-cargo fmt --check
- RUST_LANE_ID=postbatch-final-smoke make check
- RUST_LANE_ID=postbatch-final-smoke make test
- RUST_LANE_ID=postbatch-final-smoke make lint
- RUST_LANE_ID=postbatch-final-smoke make e2e-smoke