### PR TITLE
Close residual P0 dogma paths

### DIFF
--- a/meerkat-auth-core/src/authorizers/azure.rs
+++ b/meerkat-auth-core/src/authorizers/azure.rs
@@ -197,14 +197,20 @@ impl AzureAdAuthorizer {
 
     async fn get_token(&self) -> Result<String, AuthError> {
         // Check cache without taking the refresh path.
-        {
+        let cached = {
             let guard = self.cache.lock();
             if let Some(t) = guard.as_ref()
                 && t.expires_at - Utc::now()
                     > Duration::seconds(AUTH_LEASE_TTL_REFRESH_WINDOW_SECS as i64)
             {
-                return Ok(t.access_token.clone());
+                Some((t.access_token.clone(), t.expires_at))
+            } else {
+                None
             }
+        };
+        if let Some((access_token, expires_at)) = cached {
+            self.publish_expires_at(expires_at);
+            return Ok(access_token);
         }
         // Miss — fetch a fresh token.
         let new_token = self.fetch_token().await?;

--- a/meerkat-auth-core/src/authorizers/google.rs
+++ b/meerkat-auth-core/src/authorizers/google.rs
@@ -221,14 +221,20 @@ impl GoogleAuthAuthorizer {
     }
 
     async fn get_token(&self) -> Result<String, AuthError> {
-        {
+        let cached = {
             let guard = self.cache.lock();
             if let Some(t) = guard.as_ref()
                 && t.expires_at - Utc::now()
                     > Duration::seconds(AUTH_LEASE_TTL_REFRESH_WINDOW_SECS as i64)
             {
-                return Ok(t.access_token.clone());
+                Some((t.access_token.clone(), t.expires_at))
+            } else {
+                None
             }
+        };
+        if let Some((access_token, expires_at)) = cached {
+            self.publish_expires_at(expires_at);
+            return Ok(access_token);
         }
 
         let token = match self.chain {

--- a/meerkat-auth-core/tests/azure_ad_authorizer.rs
+++ b/meerkat-auth-core/tests/azure_ad_authorizer.rs
@@ -269,20 +269,36 @@ async fn authorize_publishes_token_expiry_to_auth_lease_handle() {
     .with_auth_lease_observer(lease_handle, lease_key.clone())
     .with_token_url_override(format!("{}/tenant-id/oauth2/v2.0/token", mock.base_url));
 
-    let mut headers = Vec::new();
-    let mut req = HttpAuthorizationRequest {
-        method: "POST",
-        url: "https://example.foundry.azure.com/v1/messages",
-        headers: &mut headers,
-    };
-    authorizer.authorize(&mut req).await.unwrap();
+    for _ in 0..2 {
+        let mut headers = Vec::new();
+        let mut req = HttpAuthorizationRequest {
+            method: "POST",
+            url: "https://example.foundry.azure.com/v1/messages",
+            headers: &mut headers,
+        };
+        authorizer.authorize(&mut req).await.unwrap();
+    }
 
     let acquired = handle.acquired.lock().unwrap();
-    assert_eq!(acquired.len(), 1);
+    assert_eq!(
+        mock.counter.load(Ordering::SeqCst),
+        1,
+        "second authorize should reuse the cached token"
+    );
+    assert_eq!(
+        acquired.len(),
+        2,
+        "cached token use must still publish auth-machine lease freshness"
+    );
     assert_eq!(acquired[0].0, lease_key);
+    assert_eq!(acquired[1].0, lease_key);
     assert!(
         acquired[0].1 > Utc::now().timestamp().max(0) as u64,
         "published auth-machine expiry must reflect the fetched token"
+    );
+    assert_eq!(
+        acquired[0].1, acquired[1].1,
+        "cached token lease observation should carry the same expiry"
     );
 }
 

--- a/meerkat-auth-core/tests/google_auth_authorizer.rs
+++ b/meerkat-auth-core/tests/google_auth_authorizer.rs
@@ -29,7 +29,8 @@ use serde::Deserialize;
 use tokio::net::TcpListener;
 
 use meerkat_auth_core::authorizers::{GoogleAuthAuthorizer, GoogleAuthChain};
-use meerkat_core::{HttpAuthorizationRequest, HttpAuthorizer};
+use meerkat_core::handles::{AuthLeaseHandle, AuthLeaseSnapshot, DslTransitionError, LeaseKey};
+use meerkat_core::{BindingId, HttpAuthorizationRequest, HttpAuthorizer, ProfileId, RealmId};
 
 const TEST_PRIVATE_KEY: &str = include_str!("fixtures/test_sa_key.pem");
 
@@ -88,6 +89,65 @@ struct MockServer {
     base_url: String,
     counter: Arc<AtomicUsize>,
     captured: Arc<Mutex<Vec<OAuthForm>>>,
+}
+
+#[derive(Default)]
+struct RecordingAuthLeaseHandle {
+    acquired: Mutex<Vec<(LeaseKey, u64)>>,
+}
+
+impl AuthLeaseHandle for RecordingAuthLeaseHandle {
+    fn acquire_lease(
+        &self,
+        lease_key: &LeaseKey,
+        expires_at: u64,
+    ) -> Result<(), DslTransitionError> {
+        self.acquired
+            .lock()
+            .unwrap()
+            .push((lease_key.clone(), expires_at));
+        Ok(())
+    }
+
+    fn mark_expiring(&self, _lease_key: &LeaseKey) -> Result<(), DslTransitionError> {
+        Ok(())
+    }
+
+    fn begin_refresh(&self, _lease_key: &LeaseKey) -> Result<(), DslTransitionError> {
+        Ok(())
+    }
+
+    fn complete_refresh(
+        &self,
+        _lease_key: &LeaseKey,
+        _new_expires_at: u64,
+        _now: u64,
+    ) -> Result<(), DslTransitionError> {
+        Ok(())
+    }
+
+    fn refresh_failed(
+        &self,
+        _lease_key: &LeaseKey,
+        _permanent: bool,
+    ) -> Result<(), DslTransitionError> {
+        Ok(())
+    }
+
+    fn mark_reauth_required(&self, _lease_key: &LeaseKey) -> Result<(), DslTransitionError> {
+        Ok(())
+    }
+
+    fn release_lease(&self, _lease_key: &LeaseKey) -> Result<(), DslTransitionError> {
+        Ok(())
+    }
+
+    fn snapshot(&self, _lease_key: &LeaseKey) -> AuthLeaseSnapshot {
+        AuthLeaseSnapshot {
+            phase: None,
+            expires_at: None,
+        }
+    }
 }
 
 async fn start_mock(token_value: &str) -> MockServer {
@@ -335,6 +395,66 @@ async fn token_is_cached_between_calls() {
         mock.counter.load(Ordering::SeqCst),
         1,
         "expected single fetch with caching"
+    );
+}
+
+#[tokio::test]
+async fn cached_token_authorize_publishes_token_expiry_to_auth_lease_handle() {
+    let mock = start_mock("lease-tracked-sa-token").await;
+    let tempdir = tempfile::tempdir().unwrap();
+    let sa_path = write_sa_key(tempdir.path(), &format!("{}/token", mock.base_url));
+    let env_lookup = {
+        let sa_path = sa_path.clone();
+        Arc::new(move |k: &str| {
+            if k == "GOOGLE_APPLICATION_CREDENTIALS" {
+                Some(sa_path.to_string_lossy().to_string())
+            } else {
+                None
+            }
+        }) as Arc<dyn Fn(&str) -> Option<String> + Send + Sync>
+    };
+    let handle = Arc::new(RecordingAuthLeaseHandle::default());
+    let lease_key = LeaseKey::new(
+        RealmId::parse("dev").unwrap(),
+        BindingId::parse("gemini").unwrap(),
+        Some(ProfileId::parse("google_adc").unwrap()),
+    );
+    let lease_handle: Arc<dyn AuthLeaseHandle> = handle.clone();
+    let authorizer = GoogleAuthAuthorizer::with_env_lookup(GoogleAuthChain::Default, env_lookup)
+        .with_home_dir(tempdir.path())
+        .with_auth_lease_observer(lease_handle, lease_key.clone())
+        .with_token_url_override(format!("{}/token", mock.base_url));
+
+    for _ in 0..2 {
+        let mut headers = Vec::new();
+        let mut req = HttpAuthorizationRequest {
+            method: "POST",
+            url: "https://x.googleapis.com/",
+            headers: &mut headers,
+        };
+        authorizer.authorize(&mut req).await.unwrap();
+    }
+
+    let acquired = handle.acquired.lock().unwrap();
+    assert_eq!(
+        mock.counter.load(Ordering::SeqCst),
+        1,
+        "second authorize should reuse the cached token"
+    );
+    assert_eq!(
+        acquired.len(),
+        2,
+        "cached token use must still publish auth-machine lease freshness"
+    );
+    assert_eq!(acquired[0].0, lease_key);
+    assert_eq!(acquired[1].0, lease_key);
+    assert!(
+        acquired[0].1 > Utc::now().timestamp().max(0) as u64,
+        "published auth-machine expiry must reflect the fetched token"
+    );
+    assert_eq!(
+        acquired[0].1, acquired[1].1,
+        "cached token lease observation should carry the same expiry"
     );
 }
 

--- a/meerkat-cli/src/main.rs
+++ b/meerkat-cli/src/main.rs
@@ -4976,31 +4976,16 @@ fn compose_external_tool_dispatchers(
 }
 
 /// Build an `EphemeralSessionService` backed by the factory.
+#[cfg(test)]
 #[derive(Default)]
 struct CliServiceBuildDefaults {
     default_schedule_tools: Option<Arc<dyn AgentToolDispatcher>>,
     image_generation_machine: Option<Arc<meerkat_runtime::MeerkatMachine>>,
     default_blob_store: Option<Arc<dyn meerkat_core::BlobStore>>,
-    #[cfg(test)]
     default_image_generation_executor: Option<Arc<dyn meerkat_llm_core::ImageGenerationExecutor>>,
 }
 
-impl CliServiceBuildDefaults {
-    fn runtime_owned(
-        default_schedule_tools: Option<Arc<dyn AgentToolDispatcher>>,
-        image_generation_machine: Arc<meerkat_runtime::MeerkatMachine>,
-        default_blob_store: Arc<dyn meerkat_core::BlobStore>,
-    ) -> Self {
-        Self {
-            default_schedule_tools,
-            image_generation_machine: Some(image_generation_machine),
-            default_blob_store: Some(default_blob_store),
-            #[cfg(test)]
-            default_image_generation_executor: None,
-        }
-    }
-}
-
+#[cfg(test)]
 fn build_cli_service_with_defaults(
     factory: AgentFactory,
     config: Config,
@@ -5011,12 +4996,24 @@ fn build_cli_service_with_defaults(
         builder = builder.with_image_generation_machine(machine);
     }
     builder.default_blob_store = defaults.default_blob_store;
-    #[cfg(test)]
-    {
-        builder.default_image_generation_executor = defaults.default_image_generation_executor;
-    }
+    builder.default_image_generation_executor = defaults.default_image_generation_executor;
     meerkat::surface::set_default_schedule_tools(&builder, defaults.default_schedule_tools);
     meerkat::surface::build_embedded_service_from_builder(builder, 64)
+}
+
+#[cfg(feature = "session-store")]
+fn build_cli_runtime_backed_service_with_defaults(
+    factory: AgentFactory,
+    config: Config,
+    persistence: PersistenceBundle,
+    default_schedule_tools: Option<Arc<dyn AgentToolDispatcher>>,
+) -> (
+    meerkat::PersistentSessionService<FactoryAgentBuilder>,
+    Arc<meerkat_runtime::MeerkatMachine>,
+) {
+    let builder = FactoryAgentBuilder::new(factory, config);
+    meerkat::surface::set_default_schedule_tools(&builder, default_schedule_tools);
+    meerkat::surface::build_runtime_backed_service(builder, 64, persistence)
 }
 
 #[cfg(test)]
@@ -5354,21 +5351,19 @@ async fn run_agent(
             config.comms.address = Some(addr.clone());
         }
 
-        // Build the parent session service with the same explicit scheduler tools the
-        // persistent CLI surface injects on resumed/runtime-backed paths.
-        let runtime_adapter = persistence.runtime_adapter();
+        // Build the parent session service on the runtime-backed persistent
+        // surface. CLI one-shots must leave the runtime snapshot as durable
+        // authority so shared RPC/REST realms can read them without trusting
+        // the compatibility SessionStore projection.
         let schedule_service = ScheduleService::new(persistence.schedule_store());
         let default_schedule_tools =
             Some(Arc::new(ScheduleToolDispatcher::new(schedule_service))
                 as Arc<dyn AgentToolDispatcher>);
-        let service = build_cli_service_with_defaults(
+        let (service, runtime_adapter) = build_cli_runtime_backed_service_with_defaults(
             factory,
             config.clone(),
-            CliServiceBuildDefaults::runtime_owned(
-                default_schedule_tools,
-                runtime_adapter.clone(),
-                persistence.blob_store(),
-            ),
+            persistence.clone(),
+            default_schedule_tools,
         );
 
         if keep_alive {
@@ -5543,7 +5538,7 @@ async fn run_agent(
             let executor = Box::new(CliRuntimeExecutor {
                 service: service.clone() as Arc<dyn meerkat_core::service::SessionService>,
                 #[cfg(feature = "session-store")]
-                persistent_service: None,
+                persistent_service: Some(service.clone()),
                 session_id: session_id.clone(),
                 runtime_adapter: runtime_adapter.clone(),
                 event_tx: output_pipeline.event_sender(),
@@ -6423,15 +6418,15 @@ fn get_or_create_cli_persistent_surface_from_bundle(
     }
 
     let schedule_service = ScheduleService::new(persistence.schedule_store());
-    let builder = FactoryAgentBuilder::new(factory, config);
-    meerkat::surface::set_default_schedule_tools(
-        &builder,
-        Some(Arc::new(ScheduleToolDispatcher::new(
-            schedule_service.clone(),
-        ))),
+    let default_schedule_tools = Some(Arc::new(ScheduleToolDispatcher::new(
+        schedule_service.clone(),
+    )) as Arc<dyn AgentToolDispatcher>);
+    let (service, runtime_adapter) = build_cli_runtime_backed_service_with_defaults(
+        factory,
+        config,
+        persistence,
+        default_schedule_tools,
     );
-    let (service, runtime_adapter) =
-        meerkat::surface::build_runtime_backed_service(builder, 64, persistence);
     let service = Arc::new(service);
     let schedule_host = if schedule_host_supported(schedule_service.store().kind()) {
         let session_host: Arc<dyn SurfaceScheduleSessionHost> = Arc::new(CliScheduleSessionHost {
@@ -12953,6 +12948,84 @@ capabilities = ["definitely_missing_capability"]
         assert!(names.contains("meerkat_schedule_create"));
         assert!(names.contains("meerkat_schedule_list"));
         assert!(names.contains("meerkat_schedule_occurrences"));
+    }
+
+    #[cfg(feature = "session-store")]
+    #[tokio::test]
+    async fn test_cli_runtime_backed_service_persists_authority_snapshot_for_one_shot() {
+        let temp = tempfile::tempdir().expect("tempdir must be created");
+        let session_store: Arc<dyn meerkat::SessionStore> = Arc::new(meerkat::MemoryStore::new());
+        let runtime_store: Arc<dyn meerkat_runtime::RuntimeStore> =
+            Arc::new(meerkat_runtime::InMemoryRuntimeStore::new());
+        let persistence = PersistenceBundle::new(
+            Arc::clone(&session_store),
+            Some(Arc::clone(&runtime_store)),
+            Arc::new(meerkat_store::MemoryBlobStore::default()),
+        );
+        let factory = AgentFactory::new(temp.path().join("sessions"))
+            .session_store(session_store)
+            .builtins(false)
+            .shell(false);
+        let (service, runtime_adapter) = build_cli_runtime_backed_service_with_defaults(
+            factory,
+            Config::default(),
+            persistence,
+            None,
+        );
+
+        let session = Session::new();
+        let session_id = session.id().clone();
+        let bindings = runtime_adapter
+            .prepare_bindings(session_id.clone())
+            .await
+            .expect("runtime bindings should be prepared");
+        let llm_override: Arc<dyn LlmClient> = Arc::new(CapturingLlmClient::new(
+            Arc::new(Mutex::new(Vec::new())),
+            Arc::new(Mutex::new(None)),
+        ));
+
+        let created = service
+            .create_session(CreateSessionRequest {
+                model: "gpt-5.4".to_string(),
+                prompt: "seed".to_string().into(),
+                render_metadata: None,
+                system_prompt: None,
+                max_tokens: Some(32),
+                event_tx: None,
+                skill_references: None,
+                initial_turn: meerkat_core::service::InitialTurnPolicy::Defer,
+                deferred_prompt_policy: DeferredPromptPolicy::Discard,
+                build: Some(SessionBuildOptions {
+                    resume_session: Some(session),
+                    runtime_build_mode: meerkat_core::RuntimeBuildMode::SessionOwned(bindings),
+                    llm_client_override: Some(meerkat::encode_llm_client_override_for_service(
+                        llm_override,
+                    )),
+                    ..SessionBuildOptions::default()
+                }),
+                labels: None,
+            })
+            .await
+            .expect("runtime-backed CLI service should create deferred session");
+
+        assert_eq!(created.session_id, session_id);
+        let runtime_id = meerkat_runtime::LogicalRuntimeId::new(session_id.to_string());
+        assert!(
+            runtime_store
+                .load_session_snapshot(&runtime_id)
+                .await
+                .expect("runtime snapshot load should succeed")
+                .is_some(),
+            "runtime-backed CLI one-shot service must write runtime authority"
+        );
+        assert!(
+            service
+                .load_authoritative_session(&session_id)
+                .await
+                .expect("authoritative load should succeed")
+                .is_some(),
+            "authoritative reads must resolve through the runtime snapshot"
+        );
     }
 
     #[tokio::test]

--- a/meerkat-comms/src/identity.rs
+++ b/meerkat-comms/src/identity.rs
@@ -2,26 +2,12 @@
 
 use base64::{Engine, engine::general_purpose::STANDARD as BASE64};
 use ed25519_dalek::{Signer, SigningKey, Verifier, VerifyingKey};
-use meerkat_core::comms::PeerId;
 use rand_core::OsRng;
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 #[cfg(not(target_arch = "wasm32"))]
 use std::path::Path;
 use thiserror::Error;
 use zeroize::Zeroize;
-
-/// UUIDv5 namespace for deriving [`PeerId`] from a signing pubkey.
-///
-/// `PeerId` is the canonical runtime routing key: both the router and the
-/// trust store index peers by `PeerId`, never by display name. The
-/// derivation is a content hash (UUIDv5) of the 32-byte Ed25519 pubkey
-/// so a given pubkey always resolves to the same `PeerId` across runtimes.
-///
-/// Kept in `identity.rs` (next to [`PubKey`]) so the namespace travels
-/// with the type it hashes. Router and runtime helpers call back into
-/// [`PubKey::to_peer_id`] rather than duplicating this constant.
-const PEER_ID_UUID_NAMESPACE: uuid::Uuid =
-    uuid::Uuid::from_u128(0x6d65_6572_6b61_7450_6565_7249_6430_0001);
 
 /// Errors that can occur during identity operations.
 #[derive(Debug, Error)]
@@ -110,19 +96,20 @@ impl PubKey {
         &self.0
     }
 
-    /// Derive the canonical [`PeerId`] for this signing pubkey (typed).
+    /// Derive the canonical [`meerkat_core::comms::PeerId`] for this signing
+    /// pubkey (typed).
     ///
     /// The derivation is a UUIDv5 hash of the 32-byte pubkey under
-    /// [`PEER_ID_UUID_NAMESPACE`]. A given pubkey always maps to the
-    /// same `PeerId`, so the router and trust store can index by
+    /// the core-owned peer-id namespace. A given pubkey always maps to the
+    /// same peer id, so the router and trust store can index by
     /// `PeerId` without handing around the raw pubkey everywhere.
     ///
     /// Note: this is a one-way derivation — `PeerId` is a content hash,
     /// not a reversible encoding. To round-trip the pubkey bytes through
     /// a string (for CBOR/JSON carriers, bootstrap tokens, etc.) use
     /// [`Self::to_pubkey_string`] / [`Self::from_pubkey_string`].
-    pub fn to_peer_id(&self) -> PeerId {
-        PeerId::from_uuid(uuid::Uuid::new_v5(&PEER_ID_UUID_NAMESPACE, &self.0))
+    pub fn to_peer_id(&self) -> meerkat_core::comms::PeerId {
+        meerkat_core::comms::PeerId::from_ed25519_pubkey(&self.0)
     }
 
     /// Encode this pubkey as `"ed25519:<base64>"`.
@@ -282,6 +269,7 @@ impl Keypair {
 #[allow(clippy::unwrap_used, clippy::expect_used)]
 mod tests {
     use super::*;
+    use meerkat_core::comms::PeerId;
     use std::mem::size_of;
     use tempfile::TempDir;
 

--- a/meerkat-contracts/src/wire/supervisor_bridge.rs
+++ b/meerkat-contracts/src/wire/supervisor_bridge.rs
@@ -303,8 +303,10 @@ impl std::fmt::Display for BridgeMemberRuntimeState {
 /// Mirrors `meerkat_core::comms::TrustedPeerDescriptor` (post-C-TRP) but is
 /// self-contained in the contracts crate so neither sender nor receiver
 /// needs a cross-crate dependency for deserialization. Fields stay
-/// stringly at the wire boundary — the typed `PeerId`/`PeerName`/
-/// `PeerAddress` atoms are only re-hydrated on the receiving side.
+/// stringly at the wire boundary — `peer_id` is the canonical comms routing
+/// UUID, while raw Ed25519 public key material is carried only in `pubkey`.
+/// The typed `PeerId`/`PeerName`/`PeerAddress` atoms are re-hydrated on the
+/// receiving side.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct BridgePeerSpec {
     pub name: String,
@@ -458,6 +460,7 @@ pub struct BridgeBindPayload {
     pub supervisor: BridgePeerSpec,
     pub epoch: u64,
     pub protocol_version: u32,
+    /// Expected canonical member `PeerId`; not an Ed25519 public-key string.
     pub expected_peer_id: String,
     pub expected_address: String,
     pub bootstrap_token: BridgeBootstrapToken,
@@ -482,6 +485,7 @@ pub struct BridgeCapabilities {
 /// Response to a bind command.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct BridgeBindResponse {
+    /// Canonical member `PeerId`; transport public-key bytes stay out of this field.
     pub peer_id: String,
     pub address: String,
     pub capabilities: BridgeCapabilities,
@@ -1222,12 +1226,12 @@ mod tests {
         let raw = json!({
             "supervisor": {
                 "name": "mob/__mob_supervisor__",
-                "peer_id": "ed25519:supervisor",
+                "peer_id": "00000000-0000-0000-0000-00000000bbbb",
                 "address": "inproc://mob/__mob_supervisor__",
             },
             "epoch": 7,
             "protocol_version": SUPERVISOR_BRIDGE_PROTOCOL_VERSION,
-            "expected_peer_id": "ed25519:member",
+            "expected_peer_id": "00000000-0000-0000-0000-00000000aaaa",
             "expected_address": "inproc://member",
             "bootstrap_token": "tok-raw-string",
         });

--- a/meerkat-core/src/comms.rs
+++ b/meerkat-core/src/comms.rs
@@ -27,12 +27,22 @@ pub const SUPERVISOR_BRIDGE_INTENT: &str = "supervisor.bridge";
 /// (per the Wave-B V5 dogma note), but their `PeerId`s never collide — the
 /// underlying UUID is globally unique.
 ///
-/// Constructed either freshly (`PeerId::new`) for a peer minted locally,
-/// or parsed from a hyphenated UUID (`PeerId::parse`) when we've been given
-/// an identity over the wire.
+/// Constructed freshly (`PeerId::new`) for a peer minted locally, parsed
+/// from a hyphenated UUID (`PeerId::parse`) when we've been given an identity
+/// over the wire, or derived from a 32-byte Ed25519 public key when a transport
+/// still authenticates by raw signing key.
 #[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord, Serialize, Deserialize)]
 pub struct PeerId(#[cfg_attr(feature = "schema", schemars(with = "String"))] pub Uuid);
+
+/// UUIDv5 namespace for deriving [`PeerId`] from an Ed25519 signing pubkey.
+///
+/// `PeerId` is the canonical runtime routing key: both the router and the
+/// trust store index peers by `PeerId`, never by display name. The derivation
+/// is a content hash of the 32-byte public key so a given key always resolves
+/// to the same `PeerId` across runtimes.
+const PEER_ID_ED25519_PUBKEY_NAMESPACE: Uuid =
+    Uuid::from_u128(0x6d65_6572_6b61_7450_6565_7249_6430_0001);
 
 impl PeerId {
     /// Mint a new `PeerId` with a fresh UUID v7 (time-ordered).
@@ -53,6 +63,11 @@ impl PeerId {
                 input: s.to_string(),
                 source,
             })
+    }
+
+    /// Derive the canonical routing id for a 32-byte Ed25519 public key.
+    pub fn from_ed25519_pubkey(pubkey: &[u8; 32]) -> Self {
+        Self(Uuid::new_v5(&PEER_ID_ED25519_PUBKEY_NAMESPACE, pubkey))
     }
 
     /// Hyphenated UUID string form.

--- a/meerkat-runtime/src/comms_drain.rs
+++ b/meerkat-runtime/src/comms_drain.rs
@@ -895,6 +895,16 @@ async fn resolve_bridge_response_route(
         }
         return Some(sender_route);
     }
+    if let Some(supervisor) = bridge_response_supervisor(candidate)
+        && let Some(route) = resolve_bridge_display_name_sender_route(
+            comms_runtime,
+            &candidate.interaction.from,
+            &supervisor,
+        )
+        .await
+    {
+        return Some(route);
+    }
 
     resolve_peer_route(comms_runtime, &candidate.interaction.from).await
 }
@@ -909,6 +919,27 @@ fn bridge_response_route_from_sender(sender: &str, peer: &BridgePeerSpec) -> Opt
         return None;
     }
     Some(PeerRoute::new(PeerId::from_ed25519_pubkey(&peer.pubkey)))
+}
+
+async fn resolve_bridge_display_name_sender_route(
+    comms_runtime: &Arc<dyn CommsRuntime>,
+    sender: &str,
+    peer: &BridgePeerSpec,
+) -> Option<PeerRoute> {
+    if sender != peer.name {
+        return None;
+    }
+    let expected_peer_id = PeerId::parse(&peer.peer_id).ok()?;
+    let peers = comms_runtime.peers().await;
+    let mut matches = peers.iter().filter(|entry| entry.name.as_str() == sender);
+    let entry = matches.next()?;
+    if matches.next().is_some() || entry.peer_id != expected_peer_id {
+        return None;
+    }
+    Some(PeerRoute::with_display_name(
+        entry.peer_id,
+        entry.name.clone(),
+    ))
 }
 
 fn bridge_response_supervisor(candidate: &PeerInputCandidate) -> Option<BridgePeerSpec> {
@@ -1949,6 +1980,58 @@ mod tests {
             route.peer_id.as_str(),
             spoofed_peer_id,
             "bridge replies must not route to the caller-supplied supervisor.peer_id"
+        );
+    }
+
+    #[tokio::test]
+    async fn bridge_response_route_accepts_trusted_display_name_sender() {
+        let peer = meerkat_comms::Keypair::generate();
+        let peer_pubkey = peer.public_key();
+        let peer_spec = TrustedPeerDescriptor::unsigned_with_pubkey(
+            "mob/__mob_supervisor__",
+            peer_pubkey.to_peer_id().as_str(),
+            *peer_pubkey.as_bytes(),
+            "inproc://mob/__mob_supervisor__",
+        )
+        .expect("valid peer spec");
+        let runtime: Arc<dyn CommsRuntime> = Arc::new(
+            meerkat_comms::CommsRuntime::inproc_only("bridge-response-display").expect("runtime"),
+        );
+        runtime
+            .add_trusted_peer(peer_spec.clone())
+            .await
+            .expect("trust peer");
+
+        let command = BridgeCommand::ObserveMember(BridgeSupervisorPayload {
+            supervisor: BridgePeerSpec::from(peer_spec.clone()),
+            epoch: 1,
+            protocol_version: SUPERVISOR_BRIDGE_PROTOCOL_VERSION,
+        });
+        let candidate = bridge_candidate(peer_spec.name.as_str(), &command);
+        let route = resolve_bridge_response_route(&runtime, &candidate)
+            .await
+            .expect("trusted display-name sender should resolve through peer directory");
+
+        assert_eq!(route.peer_id, peer_spec.peer_id);
+        assert_eq!(
+            route.display_name.as_ref().map(|name| name.as_str()),
+            Some(peer_spec.name.as_str())
+        );
+
+        let spoofed = BridgeCommand::ObserveMember(BridgeSupervisorPayload {
+            supervisor: BridgePeerSpec {
+                peer_id: PeerId::new().as_str(),
+                ..BridgePeerSpec::from(peer_spec.clone())
+            },
+            epoch: 1,
+            protocol_version: SUPERVISOR_BRIDGE_PROTOCOL_VERSION,
+        });
+        let spoofed_candidate = bridge_candidate(peer_spec.name.as_str(), &spoofed);
+        assert!(
+            resolve_bridge_response_route(&runtime, &spoofed_candidate)
+                .await
+                .is_none(),
+            "display-name senders must not route to a spoofed payload peer_id"
         );
     }
 

--- a/meerkat-runtime/src/comms_drain.rs
+++ b/meerkat-runtime/src/comms_drain.rs
@@ -12,7 +12,7 @@ use std::time::Duration;
 
 use meerkat_core::agent::CommsRuntime;
 #[allow(unused_imports)]
-use meerkat_core::comms::{CommsCommand, PeerId, PeerName, PeerRoute, TrustedPeerDescriptor};
+use meerkat_core::comms::{CommsCommand, PeerId, PeerRoute, TrustedPeerDescriptor};
 use meerkat_core::event::AgentEvent;
 use meerkat_core::interaction::{InteractionContent, PeerInputCandidate, PeerInputClass};
 use meerkat_core::lifecycle::RunControlCommand;
@@ -43,10 +43,6 @@ use crate::traits::RuntimeControlPlane;
 
 /// Default idle timeout for session-backed comms drains.
 pub const DEFAULT_IDLE_TIMEOUT: Duration = Duration::from_secs(300);
-
-const ED25519_PUBKEY_PREFIX: &str = "ed25519:";
-const PEER_ID_UUID_NAMESPACE: uuid::Uuid =
-    uuid::Uuid::from_u128(0x6d65_6572_6b61_7450_6565_7249_6430_0001);
 
 /// Spawn a background task that drains the comms inbox and routes
 /// classified interactions through the runtime adapter.
@@ -365,7 +361,17 @@ fn sender_matches_bound_supervisor(sender: &str, name: &str, peer_id: &str) -> b
 }
 
 fn sender_matches_bridge_peer(sender: &str, peer: &BridgePeerSpec) -> bool {
-    sender == peer.name || sender == peer.peer_id
+    sender == peer.name
+        || sender == peer.peer_id
+        || bridge_peer_pubkey_sender(peer).is_some_and(|pubkey| sender == pubkey)
+}
+
+fn bridge_peer_pubkey_sender(peer: &BridgePeerSpec) -> Option<String> {
+    if peer.pubkey == [0u8; 32] {
+        return None;
+    }
+    use base64::{Engine as _, engine::general_purpose::STANDARD as BASE64};
+    Some(format!("ed25519:{}", BASE64.encode(peer.pubkey)))
 }
 
 /// Require the caller to be the currently authorized supervisor for the
@@ -595,14 +601,14 @@ fn validate_bind_request(
             ),
         ));
     }
-    // Canonical identity must be present to validate the request's
+    // Canonical peer identity must be present to validate the request's
     // expected_peer_id. Missing runtime identity is a typed internal
     // invariant failure, not a silent "skip the check" path — otherwise
     // caller-supplied `expected_peer_id` would never be challenged.
-    let Some(actual_peer_id) = comms_runtime.public_key() else {
+    let Some(actual_peer_id) = comms_runtime.peer_id().map(|peer_id| peer_id.as_str()) else {
         return Err((
             BridgeRejectionCause::Internal,
-            "bind member failed: runtime public key unavailable".to_string(),
+            "bind member failed: runtime peer_id unavailable".to_string(),
         ));
     };
     if actual_peer_id != payload.expected_peer_id {
@@ -842,7 +848,7 @@ async fn send_bridge_response(
             "reason": "bridge reply serialization failed",
         })
     });
-    let to = match resolve_peer_route(comms_runtime, &candidate.interaction.from).await {
+    let to = match resolve_bridge_response_route(comms_runtime, candidate).await {
         Some(route) => route,
         None => {
             tracing::warn!(
@@ -875,6 +881,48 @@ async fn send_bridge_response(
     comms_runtime.mark_interaction_complete(&candidate.interaction.id);
 }
 
+async fn resolve_bridge_response_route(
+    comms_runtime: &Arc<dyn CommsRuntime>,
+    candidate: &PeerInputCandidate,
+) -> Option<PeerRoute> {
+    if let Some(supervisor) = bridge_response_supervisor(candidate)
+        && sender_matches_bridge_peer(&candidate.interaction.from, &supervisor)
+    {
+        if let Some(route) = resolve_peer_route(comms_runtime, &supervisor.peer_id).await {
+            return Some(route);
+        }
+        if let Ok(peer_id) = PeerId::parse(&supervisor.peer_id) {
+            return Some(PeerRoute::new(peer_id));
+        }
+    }
+
+    resolve_peer_route(comms_runtime, &candidate.interaction.from).await
+}
+
+fn bridge_response_supervisor(candidate: &PeerInputCandidate) -> Option<BridgePeerSpec> {
+    let InteractionContent::Request { intent, params } = &candidate.interaction.content else {
+        return None;
+    };
+    if intent != SUPERVISOR_BRIDGE_INTENT {
+        return None;
+    }
+    let command: BridgeCommand = serde_json::from_value(params.clone()).ok()?;
+    Some(match command {
+        BridgeCommand::BindMember(payload) => payload.supervisor,
+        BridgeCommand::AuthorizeSupervisor(payload)
+        | BridgeCommand::RevokeSupervisor(payload)
+        | BridgeCommand::ObserveMember(payload)
+        | BridgeCommand::InterruptMember(payload)
+        | BridgeCommand::RetireMember(payload)
+        | BridgeCommand::DestroyMember(payload) => payload.supervisor,
+        BridgeCommand::DeliverMemberInput(payload) => payload.supervisor,
+        BridgeCommand::WireMember(payload) | BridgeCommand::UnwireMember(payload) => {
+            payload.supervisor
+        }
+        _ => return None,
+    })
+}
+
 async fn resolve_peer_route(
     comms_runtime: &Arc<dyn CommsRuntime>,
     from: &str,
@@ -883,33 +931,7 @@ async fn resolve_peer_route(
     peers
         .iter()
         .find(|entry| entry.peer_id.as_str() == from)
-        .or_else(|| peers.iter().find(|entry| entry.name.as_str() == from))
         .map(|entry| PeerRoute::with_display_name(entry.peer_id, entry.name.clone()))
-        .or_else(|| peer_route_from_pubkey_string(from))
-        .or_else(|| {
-            meerkat_core::comms::PeerId::parse(from)
-                .ok()
-                .map(PeerRoute::new)
-        })
-        .or_else(|| {
-            PeerName::new(from.to_string())
-                .ok()
-                .map(|name| PeerRoute::with_display_name(meerkat_core::comms::PeerId::new(), name))
-        })
-}
-
-fn peer_route_from_pubkey_string(from: &str) -> Option<PeerRoute> {
-    use base64::{Engine as _, engine::general_purpose::STANDARD as BASE64};
-
-    let encoded = from.strip_prefix(ED25519_PUBKEY_PREFIX)?;
-    let decoded = BASE64.decode(encoded).ok()?;
-    if decoded.len() != 32 {
-        return None;
-    }
-    Some(PeerRoute::new(PeerId::from_uuid(uuid::Uuid::new_v5(
-        &PEER_ID_UUID_NAMESPACE,
-        &decoded,
-    ))))
 }
 
 async fn send_bridge_failure(
@@ -1013,7 +1035,8 @@ async fn try_handle_supervisor_bridge_command(
                         .await;
                         return true;
                     };
-                    let Some(peer_id) = comms_runtime.public_key() else {
+                    let Some(peer_id) = comms_runtime.peer_id().map(|peer_id| peer_id.as_str())
+                    else {
                         send_bridge_failure(
                             comms_runtime,
                             candidate,
@@ -1047,17 +1070,17 @@ async fn try_handle_supervisor_bridge_command(
                     }
                 };
             // Canonical identity only: the BindMember reply echoes
-            // the runtime's own public key, never `payload.expected_peer_id`.
+            // the runtime's own peer ID, never `payload.expected_peer_id`.
             // A caller-supplied identity can't cross the canonical
             // boundary — if the runtime cannot produce its own
             // identity, that is a typed internal invariant failure,
             // not a silent fallback.
-            let Some(peer_id) = comms_runtime.public_key() else {
+            let Some(peer_id) = comms_runtime.peer_id().map(|peer_id| peer_id.as_str()) else {
                 send_bridge_failure(
                     comms_runtime,
                     candidate,
                     BridgeRejectionCause::Internal,
-                    "bind member failed: runtime public key unavailable",
+                    "bind member failed: runtime peer_id unavailable",
                 )
                 .await;
                 return true;
@@ -1805,18 +1828,49 @@ mod tests {
     const PEER_ID_OLD_SUPERVISOR: &str = "00000000-0000-0000-0000-00000000dddd"; // "old-supervisor"
 
     #[tokio::test]
-    async fn bridge_response_route_accepts_pubkey_string_sender() {
-        let sender = meerkat_comms::Keypair::generate();
-        let sender_pubkey = sender.public_key();
+    async fn bridge_response_route_requires_known_canonical_peer_id() {
+        let peer = meerkat_comms::Keypair::generate();
+        let peer_pubkey = peer.public_key();
+        let peer_spec = TrustedPeerDescriptor::unsigned_with_pubkey(
+            "bridge-response-peer",
+            peer_pubkey.to_peer_id().as_str(),
+            *peer_pubkey.as_bytes(),
+            "inproc://bridge-response-peer",
+        )
+        .expect("valid peer spec");
         let runtime: Arc<dyn CommsRuntime> = Arc::new(
             meerkat_comms::CommsRuntime::inproc_only("bridge-response-route").expect("runtime"),
         );
-
-        let route = resolve_peer_route(&runtime, &sender_pubkey.to_pubkey_string())
+        runtime
+            .add_trusted_peer(peer_spec.clone())
             .await
-            .expect("pubkey string sender should resolve to derived peer route");
+            .expect("trust peer");
 
-        assert_eq!(route.peer_id, sender_pubkey.to_peer_id());
+        let peer_id = peer_spec.peer_id.as_str();
+        let route = resolve_peer_route(&runtime, &peer_id)
+            .await
+            .expect("canonical peer id should resolve through the peer directory");
+
+        assert_eq!(route.peer_id, peer_spec.peer_id);
+        assert!(
+            resolve_peer_route(&runtime, &peer_pubkey.to_pubkey_string())
+                .await
+                .is_none(),
+            "raw public-key strings must not synthesize bridge response routes"
+        );
+        assert!(
+            resolve_peer_route(&runtime, peer_spec.name.as_str())
+                .await
+                .is_none(),
+            "display names must not be routing keys"
+        );
+        let unknown_peer_id = PeerId::new().as_str();
+        assert!(
+            resolve_peer_route(&runtime, &unknown_peer_id)
+                .await
+                .is_none(),
+            "arbitrary UUID strings must not synthesize bridge response routes"
+        );
     }
 
     struct BootstrapRuntime {
@@ -2084,6 +2138,38 @@ mod tests {
     }
 
     #[test]
+    fn validate_bind_request_accepts_pubkey_sender_with_canonical_supervisor_peer_id() {
+        let runtime: Arc<dyn CommsRuntime> = Arc::new(bootstrap_runtime(
+            PEER_ID_RECEIVER,
+            "inproc://receiver",
+            Some("expected-token"),
+        ));
+        let supervisor_key = meerkat_comms::Keypair::generate();
+        let supervisor_pubkey = supervisor_key.public_key();
+        let supervisor = BridgePeerSpec {
+            name: "mob/__mob_supervisor__".to_string(),
+            peer_id: supervisor_pubkey.to_peer_id().as_str(),
+            address: "inproc://mob/__mob_supervisor__".to_string(),
+            pubkey: *supervisor_pubkey.as_bytes(),
+        };
+        let payload = meerkat_contracts::wire::supervisor_bridge::BridgeBindPayload {
+            supervisor: supervisor.clone(),
+            epoch: 0,
+            protocol_version: SUPERVISOR_BRIDGE_PROTOCOL_VERSION,
+            expected_peer_id: PEER_ID_RECEIVER.to_string(),
+            expected_address: runtime.advertised_address().unwrap(),
+            bootstrap_token: "expected-token".into(),
+        };
+
+        let (authorized, advertised_address) =
+            validate_bind_request(&runtime, &supervisor_pubkey.to_pubkey_string(), &payload)
+                .expect("bind should accept raw transport sender when payload carries pubkey");
+        assert_eq!(authorized.peer_id.as_str(), supervisor.peer_id);
+        assert_eq!(authorized.pubkey, supervisor.pubkey);
+        assert_eq!(advertised_address, runtime.advertised_address().unwrap());
+    }
+
+    #[test]
     fn validate_bind_request_returns_runtime_advertised_address() {
         let runtime: Arc<dyn CommsRuntime> = Arc::new(bootstrap_runtime(
             PEER_ID_RECEIVER,
@@ -2285,9 +2371,10 @@ mod tests {
         let current_payload = sample_bind_payload();
         let state = authorized_state_for(&current_payload);
         let mut takeover = sample_bind_payload();
+        let takeover_peer_id = PeerId::new().as_str();
         takeover.supervisor = BridgePeerSpec {
             name: "mob/__mob_supervisor__".to_string(),
-            peer_id: "ed25519:adversary".to_string(),
+            peer_id: takeover_peer_id,
             address: "inproc://mob/__mob_supervisor__".to_string(),
             pubkey: [0u8; 32],
         };
@@ -2351,9 +2438,9 @@ mod tests {
         let current_payload = sample_bind_payload();
         let state = authorized_state_for(&current_payload);
         let retry = sample_bind_payload();
-        let (cause, error) =
-            validate_bind_request_against_state("ed25519:attacker", &retry, &state)
-                .expect_err("bind from an unauthorized sender must be rejected");
+        let attacker_peer_id = PeerId::new().as_str();
+        let (cause, error) = validate_bind_request_against_state(&attacker_peer_id, &retry, &state)
+            .expect_err("bind from an unauthorized sender must be rejected");
         assert_eq!(cause, BridgeRejectionCause::SenderMismatch);
         assert!(
             error.contains("request sender"),
@@ -2424,9 +2511,10 @@ mod tests {
             )
             .await
             .expect("initial bind must succeed");
+        let adversary_peer_id = PeerId::new().as_str();
         let adversary_supervisor = BridgePeerSpec {
             name: "mob/__mob_supervisor__".to_string(),
-            peer_id: "ed25519:adversary".to_string(),
+            peer_id: adversary_peer_id.clone(),
             address: "inproc://mob/__mob_supervisor__".to_string(),
             pubkey: [0u8; 32],
         };
@@ -2436,7 +2524,8 @@ mod tests {
                 epoch: 2,
                 protocol_version: SUPERVISOR_BRIDGE_PROTOCOL_VERSION,
                 expected_peer_id: runtime
-                    .public_key()
+                    .peer_id()
+                    .map(|peer_id| peer_id.as_str())
                     .unwrap_or_else(|| PEER_ID_RECEIVER.to_string()),
                 expected_address: runtime
                     .advertised_address()
@@ -2445,7 +2534,7 @@ mod tests {
                 bootstrap_token: runtime.bridge_bootstrap_token().unwrap_or_default().into(),
             },
         );
-        let candidate = bridge_candidate("ed25519:adversary", &command);
+        let candidate = bridge_candidate(&adversary_peer_id, &command);
 
         assert!(
             try_handle_supervisor_bridge_command(&adapter, &session_id, &runtime, &candidate,)
@@ -2509,9 +2598,10 @@ mod tests {
         // A different supervisor tries to rebind. Under the strict gate this
         // must be rejected with typed `AlreadyBound` — the mob-side bridge
         // fallback logic branches on the typed cause, not on reason text.
+        let adversary_peer_id = PeerId::new().as_str();
         let adversary = BridgePeerSpec {
             name: "mob/__mob_supervisor__".to_string(),
-            peer_id: "ed25519:different-supervisor".to_string(),
+            peer_id: adversary_peer_id.clone(),
             address: "inproc://mob/__mob_supervisor__".to_string(),
             pubkey: [0u8; 32],
         };
@@ -2525,7 +2615,7 @@ mod tests {
                 bootstrap_token: "expected-token".into(),
             },
         );
-        let candidate = bridge_candidate("ed25519:different-supervisor", &command);
+        let candidate = bridge_candidate(&adversary_peer_id, &command);
 
         assert!(
             try_handle_supervisor_bridge_command(&adapter, &session_id, &runtime, &candidate,)
@@ -2673,7 +2763,7 @@ mod tests {
         // Attacker sets expected_address/expected_peer_id to unique tokens we
         // can grep for in the reply to prove they are NOT echoed back.
         let attacker_address = "inproc://ATTACKER-ADDRESS-DO-NOT-ECHO".to_string();
-        let attacker_peer_id = "ed25519:ATTACKER-PEER-ID-DO-NOT-ECHO".to_string();
+        let attacker_peer_id = format!("{}-ATTACKER-PEER-ID-DO-NOT-ECHO", PeerId::new().as_str());
         let command = BridgeCommand::BindMember(
             meerkat_contracts::wire::supervisor_bridge::BridgeBindPayload {
                 // Sender/supervisor match stored state so validation returns
@@ -2977,9 +3067,10 @@ mod tests {
             "inproc://mob/__mob_supervisor__",
         )
         .expect("valid old supervisor");
+        let new_supervisor_peer_id = PeerId::new().as_str();
         let new_supervisor = BridgePeerSpec {
             name: "mob/__mob_supervisor__".to_string(),
-            peer_id: "ed25519:new-supervisor".to_string(),
+            peer_id: new_supervisor_peer_id,
             address: "inproc://mob/__mob_supervisor__".to_string(),
             pubkey: [0u8; 32],
         };
@@ -3051,9 +3142,10 @@ mod tests {
             "inproc://mob/__mob_supervisor__",
         )
         .expect("valid old supervisor");
+        let new_supervisor_peer_id = PeerId::new().as_str();
         let new_supervisor = BridgePeerSpec {
             name: "mob/__mob_supervisor__".to_string(),
-            peer_id: "ed25519:new-supervisor".to_string(),
+            peer_id: new_supervisor_peer_id,
             address: "inproc://mob/__mob_supervisor__".to_string(),
             pubkey: [0u8; 32],
         };
@@ -3458,7 +3550,7 @@ mod tests {
                 protocol_version: SUPERVISOR_BRIDGE_PROTOCOL_VERSION,
                 peer_spec: BridgePeerSpec {
                     name: "".to_string(),
-                    peer_id: "ed25519:peer".to_string(),
+                    peer_id: PeerId::new().as_str(),
                     address: "inproc://peer".to_string(),
                     pubkey: [0u8; 32],
                 },

--- a/meerkat-runtime/src/comms_drain.rs
+++ b/meerkat-runtime/src/comms_drain.rs
@@ -886,17 +886,29 @@ async fn resolve_bridge_response_route(
     candidate: &PeerInputCandidate,
 ) -> Option<PeerRoute> {
     if let Some(supervisor) = bridge_response_supervisor(candidate)
-        && sender_matches_bridge_peer(&candidate.interaction.from, &supervisor)
+        && let Some(sender_route) =
+            bridge_response_route_from_sender(&candidate.interaction.from, &supervisor)
     {
-        if let Some(route) = resolve_peer_route(comms_runtime, &supervisor.peer_id).await {
+        let sender_peer_id = sender_route.peer_id.as_str();
+        if let Some(route) = resolve_peer_route(comms_runtime, &sender_peer_id).await {
             return Some(route);
         }
-        if let Ok(peer_id) = PeerId::parse(&supervisor.peer_id) {
-            return Some(PeerRoute::new(peer_id));
-        }
+        return Some(sender_route);
     }
 
     resolve_peer_route(comms_runtime, &candidate.interaction.from).await
+}
+
+fn bridge_response_route_from_sender(sender: &str, peer: &BridgePeerSpec) -> Option<PeerRoute> {
+    if sender == peer.peer_id {
+        return PeerId::parse(sender).ok().map(PeerRoute::new);
+    }
+
+    let sender_pubkey = bridge_peer_pubkey_sender(peer)?;
+    if sender != sender_pubkey {
+        return None;
+    }
+    Some(PeerRoute::new(PeerId::from_ed25519_pubkey(&peer.pubkey)))
 }
 
 fn bridge_response_supervisor(candidate: &PeerInputCandidate) -> Option<BridgePeerSpec> {
@@ -1870,6 +1882,73 @@ mod tests {
                 .await
                 .is_none(),
             "arbitrary UUID strings must not synthesize bridge response routes"
+        );
+    }
+
+    #[tokio::test]
+    async fn bridge_response_route_uses_pubkey_sender_not_spoofed_payload_peer_id() {
+        let runtime: Arc<dyn CommsRuntime> = Arc::new(
+            meerkat_comms::CommsRuntime::inproc_only("bridge-response-spoof").expect("runtime"),
+        );
+        let spoofed_peer_id = PeerId::new();
+        runtime
+            .add_trusted_peer(
+                TrustedPeerDescriptor::test_only_unsigned_typed(
+                    "spoofed-target",
+                    spoofed_peer_id.clone(),
+                    "inproc://spoofed-target",
+                )
+                .expect("valid spoofed target"),
+            )
+            .await
+            .expect("trust spoofed target");
+
+        let sender_key = meerkat_comms::Keypair::generate();
+        let sender_pubkey = sender_key.public_key();
+        let spoofed_peer_id = spoofed_peer_id.as_str();
+        let command = BridgeCommand::BindMember(
+            meerkat_contracts::wire::supervisor_bridge::BridgeBindPayload {
+                supervisor: BridgePeerSpec {
+                    name: "mob/__mob_supervisor__".to_string(),
+                    peer_id: spoofed_peer_id.clone(),
+                    address: "inproc://mob/__mob_supervisor__".to_string(),
+                    pubkey: *sender_pubkey.as_bytes(),
+                },
+                epoch: 1,
+                protocol_version: SUPERVISOR_BRIDGE_PROTOCOL_VERSION,
+                expected_peer_id: PEER_ID_RECEIVER.to_string(),
+                expected_address: "inproc://receiver".to_string(),
+                bootstrap_token: "bootstrap".to_string().into(),
+            },
+        );
+        let candidate = PeerInputCandidate {
+            interaction: InboxInteraction {
+                id: InteractionId(Uuid::new_v4()),
+                from: sender_pubkey.to_pubkey_string(),
+                content: InteractionContent::Request {
+                    intent: SUPERVISOR_BRIDGE_INTENT.to_string(),
+                    params: serde_json::to_value(command).expect("serialize bridge command"),
+                },
+                rendered_text: String::new(),
+                handling_mode: HandlingMode::Queue,
+                render_metadata: None,
+            },
+            class: PeerInputClass::ActionableRequest,
+            auth: Some(meerkat_core::PeerIngressAuthDecision::Exempt(
+                meerkat_core::PeerIngressAuthExemption::SupervisorBridge,
+            )),
+            lifecycle_peer: None,
+        };
+
+        let route = resolve_bridge_response_route(&runtime, &candidate)
+            .await
+            .expect("raw pubkey sender should resolve to its derived route");
+
+        assert_eq!(route.peer_id, sender_pubkey.to_peer_id());
+        assert_ne!(
+            route.peer_id.as_str(),
+            spoofed_peer_id,
+            "bridge replies must not route to the caller-supplied supervisor.peer_id"
         );
     }
 

--- a/meerkat-session/src/persistent.rs
+++ b/meerkat-session/src/persistent.rs
@@ -578,30 +578,81 @@ impl<B: SessionAgentBuilder + 'static> PersistentSessionService<B> {
     ) -> Result<Option<Session>, SessionError> {
         if let Some(runtime_store) = self.runtime_store.as_ref() {
             let runtime_id = Self::runtime_id_for_session(id);
-            runtime_store
-                .load_session_snapshot(&runtime_id)
+            if let Some(runtime) =
+                Self::load_runtime_session_snapshot(runtime_store, &runtime_id).await?
+            {
+                return Ok(Some(runtime));
+            }
+            self.promote_store_only_session_to_runtime_authority(id, &runtime_id, runtime_store)
                 .await
-                .map_err(|err| {
-                    SessionError::Agent(meerkat_core::error::AgentError::InternalError(format!(
-                        "failed to load runtime session snapshot: {err}"
-                    )))
-                })?
-                .map(|bytes| {
-                    meerkat_core::session_migrations::deserialize_session_migrating(&bytes).map_err(
-                        |err| {
-                            SessionError::Agent(meerkat_core::error::AgentError::InternalError(
-                                format!("failed to deserialize runtime session snapshot: {err}"),
-                            ))
-                        },
-                    )
-                })
-                .transpose()
         } else {
             self.store
                 .load(id)
                 .await
                 .map_err(|e| SessionError::Store(Box::new(e)))
         }
+    }
+
+    async fn load_runtime_session_snapshot(
+        runtime_store: &Arc<dyn RuntimeStore>,
+        runtime_id: &LogicalRuntimeId,
+    ) -> Result<Option<Session>, SessionError> {
+        runtime_store
+            .load_session_snapshot(runtime_id)
+            .await
+            .map_err(|err| {
+                SessionError::Agent(meerkat_core::error::AgentError::InternalError(format!(
+                    "failed to load runtime session snapshot: {err}"
+                )))
+            })?
+            .map(|bytes| {
+                meerkat_core::session_migrations::deserialize_session_migrating(&bytes).map_err(
+                    |err| {
+                        SessionError::Agent(meerkat_core::error::AgentError::InternalError(
+                            format!("failed to deserialize runtime session snapshot: {err}"),
+                        ))
+                    },
+                )
+            })
+            .transpose()
+    }
+
+    async fn promote_store_only_session_to_runtime_authority(
+        &self,
+        id: &SessionId,
+        runtime_id: &LogicalRuntimeId,
+        runtime_store: &Arc<dyn RuntimeStore>,
+    ) -> Result<Option<Session>, SessionError> {
+        let Some(stored) = self
+            .store
+            .load(id)
+            .await
+            .map_err(|e| SessionError::Store(Box::new(e)))?
+        else {
+            return Ok(None);
+        };
+        if stored.id() != id {
+            return Err(SessionError::Agent(
+                meerkat_core::error::AgentError::InternalError(format!(
+                    "session-store projection key {id} returned session {}",
+                    stored.id()
+                )),
+            ));
+        }
+
+        tracing::info!(
+            session_id = %id,
+            "promoting legacy store-only session projection to runtime authority"
+        );
+        self.save_normalized_session(stored).await?;
+        Self::load_runtime_session_snapshot(runtime_store, runtime_id)
+            .await?
+            .ok_or_else(|| {
+                SessionError::Agent(meerkat_core::error::AgentError::InternalError(format!(
+                    "runtime authority promotion did not persist session snapshot for {id}"
+                )))
+            })
+            .map(Some)
     }
 
     fn store_only_control_mutation_error(id: &SessionId, operation: &str) -> SessionError {
@@ -2123,7 +2174,9 @@ impl<B: SessionAgentBuilder + 'static> PersistentSessionService<B> {
     ///
     /// Runtime snapshots are the session authority when a runtime store is
     /// available. The `SessionStore` row is only a compatibility projection in
-    /// that mode and is not promoted or merged into the authoritative view.
+    /// that mode. Legacy store-only rows are first committed into the runtime
+    /// store before being exposed; existing runtime snapshots are never merged
+    /// with projection metadata.
     pub async fn load_authoritative_session(
         &self,
         id: &SessionId,
@@ -4538,7 +4591,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_runtime_backed_authoritative_load_rejects_store_only_projection() {
+    async fn test_runtime_backed_authoritative_load_promotes_store_only_projection() {
         let store: Arc<dyn SessionStore> = Arc::new(MemoryStore::new());
         let runtime_store = Arc::new(InMemoryRuntimeStore::new());
         let service = PersistentSessionService::new(
@@ -4563,31 +4616,40 @@ mod tests {
             .load_authoritative_session(&id)
             .await
             .expect("authoritative load should succeed");
-        assert!(
-            authoritative.is_none(),
-            "runtime-backed authority must not expose a store-only projection"
+        let authoritative =
+            authoritative.expect("store-only projection should be promoted into runtime authority");
+        assert_eq!(
+            authoritative.messages().len(),
+            raw_projection.messages().len(),
+            "promoted runtime authority must preserve the legacy transcript"
         );
-        assert!(
-            runtime_store
-                .load_session_snapshot(
-                    &PersistentSessionService::<DummyBuilder>::runtime_id_for_session(&id),
-                )
-                .await
-                .expect("runtime snapshot load should succeed")
-                .is_none(),
-            "store-only projection must not be migrated into runtime authority by read"
+        let runtime_snapshot = runtime_store
+            .load_session_snapshot(
+                &PersistentSessionService::<DummyBuilder>::runtime_id_for_session(&id),
+            )
+            .await
+            .expect("runtime snapshot load should succeed")
+            .expect("store-only projection should be committed into runtime authority");
+        let runtime_session =
+            meerkat_core::session_migrations::deserialize_session_migrating(&runtime_snapshot)
+                .expect("runtime snapshot should deserialize");
+        assert_eq!(
+            runtime_session.messages().len(),
+            raw_projection.messages().len(),
+            "runtime snapshot is the durable authority after promotion"
         );
-        assert!(
-            matches!(service.read(&id).await, Err(SessionError::NotFound { .. })),
-            "read() must not expose a store-only projection in runtime-backed mode"
-        );
+        let view = service
+            .read(&id)
+            .await
+            .expect("read should recover session");
+        assert_eq!(view.state.session_id, id);
         let listed = service
             .list(SessionQuery::default())
             .await
             .expect("list should succeed");
         assert!(
-            listed.iter().all(|summary| summary.session_id != id),
-            "list() must not expose store-only projections in runtime-backed mode"
+            listed.iter().any(|summary| summary.session_id == id),
+            "list() should include the recovered runtime-authoritative session"
         );
         let raw_store_row = store
             .load(&id)
@@ -4598,16 +4660,6 @@ mod tests {
             raw_store_row.messages().len(),
             raw_projection.messages().len(),
             "compatibility projection should remain inert in the raw store"
-        );
-        assert!(
-            runtime_store
-                .load_session_snapshot(
-                    &PersistentSessionService::<DummyBuilder>::runtime_id_for_session(&id),
-                )
-                .await
-                .expect("runtime snapshot load should succeed")
-                .is_none(),
-            "store-only projection must remain outside runtime authority"
         );
     }
 

--- a/meerkat-session/src/persistent.rs
+++ b/meerkat-session/src/persistent.rs
@@ -578,7 +578,7 @@ impl<B: SessionAgentBuilder + 'static> PersistentSessionService<B> {
     ) -> Result<Option<Session>, SessionError> {
         if let Some(runtime_store) = self.runtime_store.as_ref() {
             let runtime_id = Self::runtime_id_for_session(id);
-            let runtime_snapshot = runtime_store
+            runtime_store
                 .load_session_snapshot(&runtime_id)
                 .await
                 .map_err(|err| {
@@ -595,63 +595,13 @@ impl<B: SessionAgentBuilder + 'static> PersistentSessionService<B> {
                         },
                     )
                 })
-                .transpose()?;
-
-            if let Some(runtime) = runtime_snapshot {
-                let store_snapshot = match self.store.load(id).await {
-                    Ok(store_snapshot) => store_snapshot,
-                    Err(error) => {
-                        tracing::warn!(
-                            session_id = %id,
-                            error = %error,
-                            "failed to load non-authoritative session-store projection for metadata backfill"
-                        );
-                        None
-                    }
-                };
-
-                Ok(match store_snapshot {
-                    Some(store) => Some(Self::runtime_session_with_store_metadata(runtime, &store)),
-                    None => Some(runtime),
-                })
-            } else {
-                let Some(store_only) = self
-                    .store
-                    .load(id)
-                    .await
-                    .map_err(|e| SessionError::Store(Box::new(e)))?
-                else {
-                    return Ok(None);
-                };
-                tracing::info!(
-                    session_id = %id,
-                    "migrating legacy session-store projection into runtime authority"
-                );
-                self.save_normalized_session(store_only).await.map(Some)
-            }
+                .transpose()
         } else {
             self.store
                 .load(id)
                 .await
                 .map_err(|e| SessionError::Store(Box::new(e)))
         }
-    }
-
-    fn runtime_session_with_store_metadata(mut runtime: Session, store: &Session) -> Session {
-        if store.updated_at() > runtime.updated_at() {
-            return runtime;
-        }
-
-        for key in [
-            meerkat_core::session::SESSION_METADATA_KEY,
-            meerkat_core::SESSION_BUILD_STATE_KEY,
-            crate::SESSION_LABELS_KEY,
-        ] {
-            if let Some(value) = store.metadata().get(key) {
-                runtime.backfill_metadata_if_absent(key, value.clone());
-            }
-        }
-        runtime
     }
 
     fn store_only_control_mutation_error(id: &SessionId, operation: &str) -> SessionError {
@@ -669,13 +619,8 @@ impl<B: SessionAgentBuilder + 'static> PersistentSessionService<B> {
             return Ok(None);
         };
 
-        let store_snapshot = self
-            .store
-            .load(id)
-            .await
-            .map_err(|e| SessionError::Store(Box::new(e)))?;
         let runtime_id = Self::runtime_id_for_session(id);
-        let runtime_snapshot = runtime_store
+        if let Some(runtime) = runtime_store
             .load_session_snapshot(&runtime_id)
             .await
             .map_err(|err| {
@@ -692,18 +637,21 @@ impl<B: SessionAgentBuilder + 'static> PersistentSessionService<B> {
                     },
                 )
             })
-            .transpose()?;
+            .transpose()?
+        {
+            return Ok(Some(runtime));
+        }
 
-        Ok(match (runtime_snapshot, store_snapshot) {
-            (Some(runtime), Some(store)) => {
-                Some(Self::runtime_session_with_store_metadata(runtime, &store))
-            }
-            (Some(runtime), None) => Some(runtime),
-            (None, Some(_)) => {
-                return Err(Self::store_only_control_mutation_error(id, operation));
-            }
-            (None, None) => None,
-        })
+        if self
+            .store
+            .exists(id)
+            .await
+            .map_err(|e| SessionError::Store(Box::new(e)))?
+        {
+            return Err(Self::store_only_control_mutation_error(id, operation));
+        }
+
+        Ok(None)
     }
 
     async fn load_persisted_session_for_control(
@@ -2174,8 +2122,8 @@ impl<B: SessionAgentBuilder + 'static> PersistentSessionService<B> {
     /// Load the authoritative durable session view.
     ///
     /// Runtime snapshots are the session authority when a runtime store is
-    /// available. The `SessionStore` row is a compatibility projection and a
-    /// source for store-owned metadata that older runtime snapshots may lack.
+    /// available. The `SessionStore` row is only a compatibility projection in
+    /// that mode and is not promoted or merged into the authoritative view.
     pub async fn load_authoritative_session(
         &self,
         id: &SessionId,
@@ -4506,7 +4454,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_authoritative_runtime_snapshot_preserves_store_owned_session_metadata() {
+    async fn test_authoritative_runtime_snapshot_ignores_store_owned_session_metadata() {
         let store: Arc<dyn SessionStore> = Arc::new(MemoryStore::new());
         let runtime_store = Arc::new(InMemoryRuntimeStore::new());
         let service = PersistentSessionService::new(
@@ -4535,12 +4483,6 @@ mod tests {
                 ..Default::default()
             })
             .expect("build state should serialize");
-        let expected_metadata = store_session
-            .session_metadata()
-            .expect("initial snapshot should carry durable session metadata");
-        let expected_build_state = store_session
-            .build_state()
-            .expect("test projection should carry store-owned build state");
         store
             .save(&store_session)
             .await
@@ -4583,25 +4525,20 @@ mod tests {
         assert_eq!(
             authoritative.updated_at(),
             runtime_session.updated_at(),
-            "metadata backfill from an older store projection must not change runtime snapshot timestamps"
+            "store projection metadata must not change runtime snapshot timestamps"
         );
-        let actual_metadata = authoritative
-            .session_metadata()
-            .expect("authoritative session should preserve durable metadata");
-        assert_eq!(actual_metadata.model, expected_metadata.model);
-        assert_eq!(actual_metadata.provider, expected_metadata.provider);
-        assert_eq!(actual_metadata.max_tokens, expected_metadata.max_tokens);
-        let actual_build_state = authoritative
-            .build_state()
-            .expect("authoritative session should preserve store-owned build state");
-        assert_eq!(
-            actual_build_state.system_prompt,
-            expected_build_state.system_prompt
+        assert!(
+            authoritative.session_metadata().is_none(),
+            "runtime authority must not backfill metadata from the store projection"
+        );
+        assert!(
+            authoritative.build_state().is_none(),
+            "runtime authority must not backfill build state from the store projection"
         );
     }
 
     #[tokio::test]
-    async fn test_runtime_backed_authoritative_load_migrates_store_only_projection() {
+    async fn test_runtime_backed_authoritative_load_rejects_store_only_projection() {
         let store: Arc<dyn SessionStore> = Arc::new(MemoryStore::new());
         let runtime_store = Arc::new(InMemoryRuntimeStore::new());
         let service = PersistentSessionService::new(
@@ -4625,34 +4562,52 @@ mod tests {
         let authoritative = service
             .load_authoritative_session(&id)
             .await
-            .expect("authoritative load should succeed")
-            .expect("store-only projection should be migrated before exposure");
-        assert_eq!(
-            authoritative.messages().len(),
-            raw_projection.messages().len()
-        );
-        let migrated_snapshot = runtime_store
-            .load_session_snapshot(
-                &PersistentSessionService::<DummyBuilder>::runtime_id_for_session(&id),
-            )
-            .await
-            .expect("runtime snapshot load should succeed")
-            .expect("legacy store projection should be committed into runtime authority");
-        let migrated: Session = serde_json::from_slice(&migrated_snapshot)
-            .expect("migrated runtime snapshot should deserialize");
-        assert_eq!(migrated.messages().len(), raw_projection.messages().len());
-
+            .expect("authoritative load should succeed");
         assert!(
-            service.read(&id).await.is_ok(),
-            "read() may expose a legacy store-only row only after runtime migration"
+            authoritative.is_none(),
+            "runtime-backed authority must not expose a store-only projection"
+        );
+        assert!(
+            runtime_store
+                .load_session_snapshot(
+                    &PersistentSessionService::<DummyBuilder>::runtime_id_for_session(&id),
+                )
+                .await
+                .expect("runtime snapshot load should succeed")
+                .is_none(),
+            "store-only projection must not be migrated into runtime authority by read"
+        );
+        assert!(
+            matches!(service.read(&id).await, Err(SessionError::NotFound { .. })),
+            "read() must not expose a store-only projection in runtime-backed mode"
         );
         let listed = service
             .list(SessionQuery::default())
             .await
             .expect("list should succeed");
         assert!(
-            listed.iter().any(|summary| summary.session_id == id),
-            "list() may expose a legacy store-only row only after runtime migration"
+            listed.iter().all(|summary| summary.session_id != id),
+            "list() must not expose store-only projections in runtime-backed mode"
+        );
+        let raw_store_row = store
+            .load(&id)
+            .await
+            .expect("raw store load should succeed")
+            .expect("test projection should remain present");
+        assert_eq!(
+            raw_store_row.messages().len(),
+            raw_projection.messages().len(),
+            "compatibility projection should remain inert in the raw store"
+        );
+        assert!(
+            runtime_store
+                .load_session_snapshot(
+                    &PersistentSessionService::<DummyBuilder>::runtime_id_for_session(&id),
+                )
+                .await
+                .expect("runtime snapshot load should succeed")
+                .is_none(),
+            "store-only projection must remain outside runtime authority"
         );
     }
 


### PR DESCRIPTION
## Summary
- keep runtime-backed session authority on runtime snapshots only, with store-only rows left inert instead of migrated or metadata-merged
- publish Google/Azure cached token expiry back through the AuthMachine lease observer
- make supervisor bridge bind/response routing use canonical peer IDs while preserving raw-pubkey bootstrap sender validation through typed bridge payloads

Linear: LUC-82

## Validation
- ./scripts/repo-cargo fmt --all --check
- ./scripts/repo-cargo test -p meerkat-session --features session-store runtime_backed -- --nocapture
- ./scripts/repo-cargo test -p meerkat-session --features session-store authoritative_runtime_snapshot -- --nocapture
- ./scripts/repo-cargo test -p meerkat-auth-core --features azure-ad,gcp-auth authorize_publishes_token_expiry -- --nocapture
- ./scripts/repo-cargo test -p meerkat-runtime bridge_response_route_requires_known_canonical_peer_id -- --nocapture
- ./scripts/repo-cargo test -p meerkat-runtime validate_bind_request_accepts_pubkey_sender_with_canonical_supervisor_peer_id -- --nocapture
- ./scripts/repo-cargo test -p meerkat-runtime bind_member -- --nocapture
- ./scripts/repo-cargo test -p meerkat-runtime authorize_supervisor -- --nocapture
- ./scripts/repo-cargo test -p meerkat image_binding -- --nocapture
- ./scripts/repo-cargo test -p meerkat-contracts bridge_bind_payload_wire_compat_with_plain_string_bootstrap_token -- --nocapture
- make check
- make test
- make lint
- git diff --check