### PR TITLE
Fix Mintlify docs publish checks

### DIFF
--- a/docs/architecture/formal-seam-closure.md
+++ b/docs/architecture/formal-seam-closure.md
@@ -115,7 +115,7 @@ fairness assumption explicitly. Liveness is verified by:
 
 ### Tranche 2 Proves
 
-**Structural + safety + scoped liveness** for TurnExecution <-> OpsLifecycle
+**Structural + safety + scoped liveness** for TurnExecution &lt;-&gt; OpsLifecycle
 barrier composition:
 - OpsLifecycle `WaitAllSatisfied` effect routes to TurnExecution
   `OpsBarrierSatisfied` input through a declared handoff protocol

--- a/docs/architecture/machine-simplification-proposal.md
+++ b/docs/architecture/machine-simplification-proposal.md
@@ -507,7 +507,7 @@ The report is written as `meerkat-runtime-phase-parity.json` in the system temp
 directory.
 
 The checked-in row ledger for that audit now lives in
-[`docs/architecture/meerkat-runtime-schema-parity-ledger.md`](meerkat-runtime-schema-parity-ledger.md).
+[`docs/architecture/meerkat-runtime-schema-parity-ledger.md`](/architecture/meerkat-runtime-schema-parity-ledger).
 
 ### Current Meerkat coverage
 
@@ -623,7 +623,7 @@ cargo test -p meerkat-mob audit_mob_runtime_phase_parity_map \
 ```
 
 The checked-in row ledger for that audit now lives in
-[`docs/architecture/mob-runtime-schema-parity-ledger.md`](mob-runtime-schema-parity-ledger.md).
+[`docs/architecture/mob-runtime-schema-parity-ledger.md`](/architecture/mob-runtime-schema-parity-ledger).
 
 ### Current Mob coverage
 

--- a/docs/architecture/meerkat-runtime-schema-parity-ledger.md
+++ b/docs/architecture/meerkat-runtime-schema-parity-ledger.md
@@ -313,7 +313,7 @@ Current exact-parity state:
   run identity but still owns contributor queues and reset / stop / destroy /
   recover bookkeeping below the two checked-in machines
 - a second checked-in gap on the formal side is now closed too: the
-  `meerkat_mob_seam` composition models both the Mob <- Meerkat return leg and
+  `meerkat_mob_seam` composition models both the Mob &lt;- Meerkat return leg and
   the forward Mob -> Meerkat runtime-ingress request route. The checked-in seam
   still leaves `WorkRef -> InputId` translation below the machine boundary, but
   it no longer omits the behavior-bearing forward request itself
@@ -626,13 +626,13 @@ Outcome:
    raw `19,459 -> 459`, phase `19,459 -> 464`, full `19,459 -> 19,070`,
    TLC `1,814,665 generated / 19,459 distinct / depth 9`.
 4. Read that baseline together with the largest-block field projection from
-   [`docs/architecture/machine-simplification-proposal.md`](machine-simplification-proposal.md):
+   [`docs/architecture/machine-simplification-proposal.md`](/architecture/machine-simplification-proposal):
    the dominant Meerkat mixed block is now measured as `8,897` states over
    `4,560` extended-state tuples, with `3,096` tuples reused across multiple
    phases.
 5. Read that baseline together with the now-green Mob lifecycle-triangle
    ledger in
-   [`docs/architecture/mob-runtime-schema-parity-ledger.md`](mob-runtime-schema-parity-ledger.md).
+   [`docs/architecture/mob-runtime-schema-parity-ledger.md`](/architecture/mob-runtime-schema-parity-ledger).
 6. The remaining Meerkat edge is now narrower and mostly terminal/batch
    mechanics. `RuntimeIngressAuthority` no longer treats contributor staging,
    boundary application, run completion, replay rollback, or admission

--- a/docs/architecture/parallel-feature-lanes-plan.md
+++ b/docs/architecture/parallel-feature-lanes-plan.md
@@ -495,7 +495,7 @@ The total output of this effort should be a pull request from
 The PR is not ready until:
 
 - no violations of
-  [`meerkat-runtime-dogma.md`](meerkat-runtime-dogma.md) are
+  [`meerkat-runtime-dogma.md`](/architecture/meerkat-runtime-dogma) are
   introduced in any shape or form
 - every lane has contract-first tests and defensive tests for its high-risk
   failure modes

--- a/docs/dogma-wave-a-straggler-report.md
+++ b/docs/dogma-wave-a-straggler-report.md
@@ -110,7 +110,7 @@ No surviving non-test unimplemented/todo/panic("not implemented") in this branch
 | `meerkat-contracts/src/wire/mob.rs:701` | `context: Option<Value>` | Mob work context. |
 | `meerkat-contracts/src/wire/runtime.rs:33,45,57` | `result`, `payload`, `result` fields | Runtime command results. |
 | `meerkat-contracts/src/wire/runtime.rs:168,170,172,182,184,214` | `policy`, `terminal_outcome`, `durability`, `reconstruction_source`, `persisted_input`, `policy` | **All semantic state carried as untyped Value.** Overlaps violations #31/#38. |
-| `meerkat-contracts/src/wire/session.rs:402` | `args: Value` | Tool-call args — pragmatic per design (Box<RawValue> territory). |
+| `meerkat-contracts/src/wire/session.rs:402` | `args: Value` | Tool-call args — pragmatic per design (Box&lt;RawValue&gt; territory). |
 | `meerkat-core/src/lifecycle/run_primitive.rs:40` | `Json { value: serde_json::Value }` | ConversationContextAppend variant. |
 | `meerkat-core/src/lifecycle/core_executor.rs:42,82` | `CallbackPending { … args: Value }` | Callback routing. |
 

--- a/docs/wave-c-prep/agent-operating-envelope.md
+++ b/docs/wave-c-prep/agent-operating-envelope.md
@@ -34,7 +34,7 @@ Meerkat is pre-1.0. Cleanup waves delete freely. If you encounter anything named
 
 Everything else named Legacy/V0/Compat is delete-on-sight.
 
-### 3. No silent defaults on Option<typed-authority>
+### 3. No silent defaults on Option&lt;typed-authority&gt;
 
 If you encounter `Option<T>` where `T` is typed authority state (turn phase, session handle, trust descriptor, dispatcher binding): do NOT use `.unwrap_or_default()` or `.unwrap_or(T::default())` to fill in the `None` case. That's a silent-drop class.
 

--- a/docs/wave-c-prep/machine-boundary-stability.md
+++ b/docs/wave-c-prep/machine-boundary-stability.md
@@ -80,7 +80,7 @@ Kept for grounding — useful regardless of boundary policy. Citations are to `m
 2. Expiry watermark (31).
 3. Refresh bookkeeping (32-33).
 
-Per-binding instance, <200 LOC including transitions. The header (3-23) documents that absorption into MeerkatMachine was tried, reviewed, and reversed — but the review rationale was "orthogonal per-binding fact," which is a *preference* argument, not a *forcing* one. It remains a merge candidate.
+Per-binding instance, &lt;200 LOC including transitions. The header (3-23) documents that absorption into MeerkatMachine was tried, reviewed, and reversed — but the review rationale was "orthogonal per-binding fact," which is a *preference* argument, not a *forcing* one. It remains a merge candidate.
 
 ## 3. Split risk — out of scope
 


### PR DESCRIPTION
## Summary
- escape MDX-sensitive angle-bracket text in non-nav docs
- update internal architecture links to Mintlify route paths
- unblock Mintlify broken-link validation for docs republish

## Validation
- npx --yes mint@latest broken-links (from docs/) -> success no broken links found
- npx --yes mint@latest validate (from docs/) -> success build validation passed
- git diff --check

Linear: LUC-83