### PR TITLE
LUC-91 Fix memory prompt extraction state

### DIFF
--- a/meerkat-core/BUILD.bazel
+++ b/meerkat-core/BUILD.bazel
@@ -442,7 +442,6 @@ rust_test(
     ],
     size = "small",
     data = [
-        ":package_runfiles",
         "//meerkat:package_runfiles",
     ],
     env = {

--- a/meerkat-core/src/agent.rs
+++ b/meerkat-core/src/agent.rs
@@ -985,12 +985,8 @@ where
     /// Explicit call-timeout override from the build/config composition seam.
     /// Takes precedence over profile-derived defaults.
     pub(crate) call_timeout_override: crate::config::CallTimeoutOverride,
-    /// Populated on successful extraction validation — carried into RunResult.
-    pub(crate) extraction_result: Option<serde_json::Value>,
-    /// Schema warnings from compilation — carried into RunResult.
-    pub(crate) extraction_schema_warnings: Option<Vec<crate::schema::SchemaWarning>>,
-    /// Last validation error (for retry prompt).
-    pub(crate) extraction_last_error: Option<String>,
+    /// Structured-output extraction state carried into RunResult.
+    pub(crate) extraction_state: extraction::ExtractionState,
     /// Last published hidden deferred-catalog names.
     pub(crate) last_hidden_deferred_catalog_names: BTreeSet<String>,
     /// Last published pending catalog sources.

--- a/meerkat-core/src/agent/builder.rs
+++ b/meerkat-core/src/agent/builder.rs
@@ -351,9 +351,7 @@ impl AgentBuilder {
             cancel_after_boundary_requested: Arc::new(std::sync::atomic::AtomicBool::new(false)),
             model_defaults_resolver: self.model_defaults_resolver,
             call_timeout_override: self.call_timeout_override,
-            extraction_result: None,
-            extraction_schema_warnings: None,
-            extraction_last_error: None,
+            extraction_state: super::extraction::ExtractionState::default(),
             last_hidden_deferred_catalog_names: Default::default(),
             last_pending_catalog_sources: Default::default(),
         };

--- a/meerkat-core/src/agent/extraction.rs
+++ b/meerkat-core/src/agent/extraction.rs
@@ -5,12 +5,106 @@
 //! extraction path: markdown code-fence stripping and named object wrapper
 //! unwrapping.
 
+use crate::error::AgentError;
+use crate::schema::SchemaWarning;
 use crate::types::OutputSchema;
 use serde_json::Value;
 
 /// Default prompt for the structured output extraction turn.
 pub const DEFAULT_EXTRACTION_PROMPT: &str = "Provide the final output as valid JSON matching \
     the required schema. Output ONLY the JSON, no additional text or markdown formatting.";
+
+#[derive(Debug, Default)]
+pub(crate) struct ExtractionState {
+    result: Option<Value>,
+    schema_warnings: Option<Vec<SchemaWarning>>,
+}
+
+impl ExtractionState {
+    pub(super) fn reset(&mut self) {
+        self.result = None;
+        self.schema_warnings = None;
+    }
+
+    pub(super) fn set_schema_warnings(&mut self, warnings: Vec<SchemaWarning>) {
+        self.schema_warnings = if warnings.is_empty() {
+            None
+        } else {
+            Some(warnings)
+        };
+    }
+
+    pub(super) fn record_success(&mut self, value: Value) {
+        self.result = Some(value);
+    }
+
+    pub(super) fn take_result(&mut self) -> Option<Value> {
+        self.result.take()
+    }
+
+    pub(super) fn take_schema_warnings(&mut self) -> Option<Vec<SchemaWarning>> {
+        self.schema_warnings.take()
+    }
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub(super) enum ExtractionValidation {
+    Passed(Value),
+    Failed { error: String, retry_prompt: String },
+}
+
+pub(super) fn validate_response_text(
+    content: &str,
+    output_schema: &OutputSchema,
+    compiled_schema: &Value,
+) -> Result<ExtractionValidation, AgentError> {
+    let json_content = strip_code_fences(content.trim());
+    let parsed = match serde_json::from_str::<Value>(json_content) {
+        Ok(parsed) => parsed,
+        Err(error) => {
+            return Ok(invalid_validation(format!("Invalid JSON: {error}")));
+        }
+    };
+
+    let normalized = unwrap_named_object_wrapper(parsed, output_schema);
+
+    #[cfg(feature = "jsonschema")]
+    {
+        let validator = jsonschema::Validator::new(compiled_schema)
+            .map_err(|error| AgentError::InvalidOutputSchema(error.to_string()))?;
+        if let Err(error) = validator.validate(&normalized) {
+            return Ok(invalid_validation(format!(
+                "Schema validation failed: {error}"
+            )));
+        }
+    }
+    #[cfg(not(feature = "jsonschema"))]
+    {
+        let _ = compiled_schema;
+        tracing::warn!(
+            "Structured output schema validation unavailable \
+            (jsonschema feature disabled). Accepting parsed JSON without schema validation."
+        );
+    }
+
+    Ok(ExtractionValidation::Passed(normalized))
+}
+
+fn invalid_validation(error: String) -> ExtractionValidation {
+    let retry_prompt = retry_prompt_for_error(&error);
+    ExtractionValidation::Failed {
+        error,
+        retry_prompt,
+    }
+}
+
+pub(super) fn retry_prompt_for_error(error: &str) -> String {
+    format!(
+        "The previous output was invalid: {error}. \
+        Please provide valid JSON matching the schema. \
+        Output ONLY the JSON, no additional text."
+    )
+}
 
 /// Strip markdown code fences from JSON content.
 ///
@@ -173,6 +267,79 @@ mod tests {
 
         let normalized = unwrap_named_object_wrapper(parsed.clone(), &schema);
         assert_eq!(normalized, parsed);
+        Ok(())
+    }
+
+    #[test]
+    fn test_validate_response_text_returns_retry_prompt_for_invalid_json()
+    -> Result<(), Box<dyn std::error::Error>> {
+        let schema = OutputSchema::new(json!({
+            "type": "object",
+            "properties": { "answer": { "type": "string" } },
+            "required": ["answer"]
+        }))?;
+
+        let result = validate_response_text("not json {{{", &schema, schema.schema.as_value())?;
+
+        match result {
+            ExtractionValidation::Failed {
+                error,
+                retry_prompt,
+            } => {
+                assert!(error.contains("Invalid JSON"));
+                assert!(retry_prompt.contains(&error));
+                assert!(retry_prompt.contains("Output ONLY the JSON"));
+            }
+            ExtractionValidation::Passed(value) => {
+                panic!("expected invalid JSON failure, got {value:?}")
+            }
+        }
+        Ok(())
+    }
+
+    #[test]
+    fn test_validate_response_text_rejects_schema_mismatch()
+    -> Result<(), Box<dyn std::error::Error>> {
+        let schema = OutputSchema::new(json!({
+            "type": "object",
+            "properties": { "count": { "type": "integer" } },
+            "required": ["count"]
+        }))?;
+
+        let result =
+            validate_response_text(r#"{"count":"wrong"}"#, &schema, schema.schema.as_value())?;
+
+        match result {
+            ExtractionValidation::Failed { error, .. } => {
+                assert!(error.contains("Schema validation failed"));
+            }
+            ExtractionValidation::Passed(value) => {
+                panic!("expected schema failure, got {value:?}")
+            }
+        }
+        Ok(())
+    }
+
+    #[test]
+    fn test_validate_response_text_accepts_unwrapped_schema_match()
+    -> Result<(), Box<dyn std::error::Error>> {
+        let schema = OutputSchema::new(json!({
+            "type": "object",
+            "properties": { "response": { "type": "string" } },
+            "required": ["response"]
+        }))?
+        .with_name("advisor");
+
+        let result = validate_response_text(
+            r#"{"advisor":{"response":"hello"}}"#,
+            &schema,
+            schema.schema.as_value(),
+        )?;
+
+        assert_eq!(
+            result,
+            ExtractionValidation::Passed(json!({"response": "hello"}))
+        );
         Ok(())
     }
 }

--- a/meerkat-core/src/agent/runner.rs
+++ b/meerkat-core/src/agent/runner.rs
@@ -899,9 +899,7 @@ where
         if self.runtime_execution_kind.is_none() {
             self.runtime_execution_kind = Some(crate::lifecycle::RuntimeExecutionKind::ContentTurn);
         }
-        self.extraction_result = None;
-        self.extraction_last_error = None;
-        self.extraction_schema_warnings = None;
+        self.extraction_state.reset();
 
         // Apply canonical per-turn skill references staged by the surface.
         // Skill refs are text-only so they operate on the text projection.
@@ -1000,9 +998,7 @@ where
             self.runtime_execution_kind =
                 Some(crate::lifecycle::RuntimeExecutionKind::ResumePending);
         }
-        self.extraction_result = None;
-        self.extraction_last_error = None;
-        self.extraction_schema_warnings = None;
+        self.extraction_state.reset();
 
         self.emit_run_started_event(ContentInput::Text(prompt.clone()), event_tx.as_ref())
             .await;

--- a/meerkat-core/src/agent/state.rs
+++ b/meerkat-core/src/agent/state.rs
@@ -898,8 +898,7 @@ where
         let Some(memory_store) = self.memory_store.as_ref() else {
             return crate::memory::MemoryIndexDelivery::NoStore { scope };
         };
-        let mut indexed_entries = 0;
-        let mut attempted_entries = 0;
+        let mut requests = Vec::new();
         for message in discarded {
             let content = message.as_indexable_text();
             if content.is_empty() {
@@ -914,6 +913,7 @@ where
                 match crate::memory::MemoryIndexRequest::new(scope.clone(), content, metadata) {
                     Ok(request) => request,
                     Err(error) => {
+                        let attempted_entries = requests.len() + 1;
                         return crate::memory::MemoryIndexDelivery::Rejected {
                             scope,
                             attempted_entries,
@@ -921,24 +921,37 @@ where
                         };
                     }
                 };
-            attempted_entries += 1;
-            match memory_store.index_scoped(request).await {
-                Ok(receipt) => {
-                    indexed_entries += receipt.indexed_entries;
-                }
-                Err(error) => {
-                    return crate::memory::MemoryIndexDelivery::Rejected {
-                        scope,
-                        attempted_entries,
-                        error,
-                    };
-                }
-            }
+            requests.push(request);
         }
-        crate::memory::MemoryIndexDelivery::Delivered(crate::memory::MemoryIndexReceipt {
-            scope,
-            indexed_entries,
-        })
+
+        let attempted_entries = requests.len();
+        if attempted_entries == 0 {
+            return crate::memory::MemoryIndexDelivery::Delivered(
+                crate::memory::MemoryIndexReceipt {
+                    scope,
+                    indexed_entries: 0,
+                },
+            );
+        }
+
+        let batch = match crate::memory::MemoryIndexBatch::new(scope.clone(), requests) {
+            Ok(batch) => batch,
+            Err(error) => {
+                return crate::memory::MemoryIndexDelivery::Rejected {
+                    scope,
+                    attempted_entries,
+                    error,
+                };
+            }
+        };
+        match memory_store.index_scoped_batch(batch).await {
+            Ok(receipt) => crate::memory::MemoryIndexDelivery::Delivered(receipt),
+            Err(error) => crate::memory::MemoryIndexDelivery::Rejected {
+                scope,
+                attempted_entries,
+                error,
+            },
+        }
     }
 
     fn observe_cancel_after_boundary_request(&mut self, run_id: &RunId) -> Result<(), AgentError> {
@@ -2093,95 +2106,60 @@ where
                             max_retries: self.config.structured_output_retries,
                         })?;
 
-                        // Validate extraction response
-                        let content = assistant_text.trim();
-                        let json_content = super::extraction::strip_code_fences(content);
+                        let output_schema =
+                            self.config.output_schema.as_ref().ok_or_else(|| {
+                                AgentError::InternalError(
+                                    "extraction flow without output_schema".into(),
+                                )
+                            })?;
+                        let compiled = self
+                            .client
+                            .compile_schema(output_schema)
+                            .map_err(|e| AgentError::InvalidOutputSchema(e.to_string()))?;
+                        let validation = super::extraction::validate_response_text(
+                            &assistant_text,
+                            output_schema,
+                            &compiled.schema,
+                        )?;
 
-                        let validation_error =
-                            match serde_json::from_str::<serde_json::Value>(json_content) {
-                                Ok(parsed) => {
-                                    let output_schema =
-                                        self.config.output_schema.as_ref().ok_or_else(|| {
-                                            AgentError::InternalError(
-                                                "extraction flow without output_schema".into(),
-                                            )
-                                        })?;
-                                    let normalized = super::extraction::unwrap_named_object_wrapper(
-                                        parsed,
-                                        output_schema,
-                                    );
+                        match validation {
+                            super::extraction::ExtractionValidation::Failed {
+                                error,
+                                retry_prompt,
+                            } => {
+                                // Validation failed — authority decides retry vs exhaust
+                                let t = self.apply_turn_input(
+                                    TurnExecutionInput::ExtractionValidationFailed {
+                                        run_id: run_id.clone(),
+                                        error: error.clone(),
+                                    },
+                                )?;
 
-                                    // Validate against schema (when jsonschema feature is available)
-                                    let schema_error: Option<String>;
-                                    #[cfg(feature = "jsonschema")]
-                                    {
-                                        let compiled =
-                                            self.client.compile_schema(output_schema).map_err(
-                                                |e| AgentError::InvalidOutputSchema(e.to_string()),
-                                            )?;
-                                        let validator =
-                                            jsonschema::Validator::new(&compiled.schema).map_err(
-                                                |e| AgentError::InvalidOutputSchema(e.to_string()),
-                                            )?;
-                                        schema_error =
-                                            if let Err(error) = validator.validate(&normalized) {
-                                                Some(format!("Schema validation failed: {error}"))
-                                            } else {
-                                                None
-                                            };
-                                    }
-                                    #[cfg(not(feature = "jsonschema"))]
-                                    {
-                                        tracing::warn!(
-                                            "Structured output schema validation unavailable \
-                                        (jsonschema feature disabled). Accepting parsed \
-                                        JSON without schema validation."
-                                        );
-                                        schema_error = None;
-                                    }
-
-                                    if schema_error.is_none() {
-                                        // Validation passed — store result
-                                        self.extraction_result = Some(normalized);
-                                    }
-                                    schema_error
+                                if !self.turn_phase()?.is_terminal() {
+                                    // Authority decided to retry — push retry prompt
+                                    self.session
+                                        .push(Message::User(UserMessage::text(retry_prompt)));
+                                    self.execute_turn_effects(&t, turn_count, &event_tx).await;
+                                    turn_count += 1;
+                                    continue;
                                 }
-                                Err(e) => Some(format!("Invalid JSON: {e}")),
-                            };
 
-                        if let Some(error) = validation_error {
-                            // Validation failed — authority decides retry vs exhaust
-                            self.extraction_last_error = Some(error.clone());
-                            let t = self.apply_turn_input(
-                                TurnExecutionInput::ExtractionValidationFailed {
-                                    run_id: run_id.clone(),
-                                    error: error.clone(),
-                                },
-                            )?;
-
-                            if !self.turn_phase()?.is_terminal() {
-                                // Authority decided to retry — push retry prompt
-                                let retry_prompt = format!(
-                                    "The previous output was invalid: {error}. \
-                                    Please provide valid JSON matching the schema. \
-                                    Output ONLY the JSON, no additional text."
-                                );
-                                self.session
-                                    .push(Message::User(UserMessage::text(retry_prompt)));
-                                self.execute_turn_effects(&t, turn_count, &event_tx).await;
-                                turn_count += 1;
-                                continue;
+                                // Authority decided retries exhausted
+                                if let Err(e) = self.store.save(&self.session).await {
+                                    tracing::warn!("Failed to save session: {}", e);
+                                }
+                                return Err(AgentError::StructuredOutputValidationFailed {
+                                    attempts: self.turn_extraction_attempts()?,
+                                    reason: error,
+                                    last_output: self
+                                        .session
+                                        .last_assistant_text()
+                                        .unwrap_or_default(),
+                                });
                             }
-
-                            // Authority decided retries exhausted
-                            if let Err(e) = self.store.save(&self.session).await {
-                                tracing::warn!("Failed to save session: {}", e);
+                            super::extraction::ExtractionValidation::Passed(normalized) => {
+                                self.extraction_state.record_success(normalized);
                             }
-                            return Err(AgentError::StructuredOutputValidationFailed {
-                                attempts: self.turn_extraction_attempts()?,
-                                reason: error,
-                                last_output: self.session.last_assistant_text().unwrap_or_default(),
-                            });
                         }
 
                         // Validation passed — complete via authority
@@ -2200,8 +2178,8 @@ where
                             usage: self.session.total_usage(),
                             turns: turn_count + 1,
                             tool_calls: tool_call_count,
-                            structured_output: self.extraction_result.take(),
-                            schema_warnings: self.extraction_schema_warnings.take(),
+                            structured_output: self.extraction_state.take_result(),
+                            schema_warnings: self.extraction_state.take_schema_warnings(),
                             skill_diagnostics: None,
                         });
                     } else {
@@ -2225,19 +2203,15 @@ where
                             && !self.turn_in_extraction_flow()?
                         {
                             // Enter extraction mode via authority
-                            self.extraction_result = None;
-                            self.extraction_last_error = None;
+                            self.extraction_state.reset();
 
                             // Compile schema and capture warnings
                             let compiled = self
                                 .client
                                 .compile_schema(output_schema)
                                 .map_err(|e| AgentError::InvalidOutputSchema(e.to_string()))?;
-                            self.extraction_schema_warnings = if compiled.warnings.is_empty() {
-                                None
-                            } else {
-                                Some(compiled.warnings.clone())
-                            };
+                            self.extraction_state
+                                .set_schema_warnings(compiled.warnings.clone());
 
                             // Push extraction prompt as user message
                             let prompt =
@@ -2485,7 +2459,7 @@ mod tests {
     use crate::compact::{CompactionContext, CompactionResult, Compactor};
     use crate::error::{AgentError, ToolError};
     use crate::memory::{
-        MemoryIndexReceipt, MemoryIndexRequest, MemoryIndexScope, MemoryMetadata, MemoryResult,
+        MemoryIndexBatch, MemoryIndexReceipt, MemoryIndexScope, MemoryMetadata, MemoryResult,
         MemorySearchScope, MemoryStore, MemoryStoreError,
     };
     use crate::retry::select_retry_delay;
@@ -3040,6 +3014,7 @@ mod tests {
     struct RecordingMemoryStore {
         entries: Mutex<Vec<(MemoryIndexScope, String, MemoryMetadata)>>,
         fail_indexing: bool,
+        fail_after_successful_entries: Option<usize>,
     }
 
     impl RecordingMemoryStore {
@@ -3047,6 +3022,7 @@ mod tests {
             Self {
                 entries: Mutex::new(Vec::new()),
                 fail_indexing: false,
+                fail_after_successful_entries: None,
             }
         }
 
@@ -3054,6 +3030,15 @@ mod tests {
             Self {
                 entries: Mutex::new(Vec::new()),
                 fail_indexing: true,
+                fail_after_successful_entries: None,
+            }
+        }
+
+        fn failing_after(successful_entries: usize) -> Self {
+            Self {
+                entries: Mutex::new(Vec::new()),
+                fail_indexing: false,
+                fail_after_successful_entries: Some(successful_entries),
             }
         }
 
@@ -3078,22 +3063,29 @@ mod tests {
 
     #[async_trait]
     impl MemoryStore for RecordingMemoryStore {
-        async fn index_scoped(
+        async fn index_scoped_batch(
             &self,
-            request: MemoryIndexRequest,
+            batch: MemoryIndexBatch,
         ) -> Result<MemoryIndexReceipt, MemoryStoreError> {
             if self.fail_indexing {
                 return Err(MemoryStoreError::Index("injected failure".to_string()));
             }
-            let (scope, content, metadata) = request.into_parts();
-            let receipt_scope = scope.clone();
-            self.entries
-                .lock()
-                .unwrap()
-                .push((scope, content, metadata));
+            let (receipt_scope, requests) = batch.into_parts();
+            let indexed_entries = requests.len();
+            let mut entries = self.entries.lock().unwrap();
+            if self
+                .fail_after_successful_entries
+                .is_some_and(|successful_entries| indexed_entries > successful_entries)
+            {
+                return Err(MemoryStoreError::Index("injected failure".to_string()));
+            }
+            for request in requests {
+                let (scope, content, metadata) = request.into_parts();
+                entries.push((scope, content, metadata));
+            }
             Ok(MemoryIndexReceipt {
                 scope: receipt_scope,
-                indexed_entries: 1,
+                indexed_entries,
             })
         }
 
@@ -3913,6 +3905,37 @@ mod tests {
         assert!(
             !saw_completed,
             "compaction must not complete when memory indexing rejects discarded history"
+        );
+    }
+
+    #[tokio::test]
+    async fn compaction_partial_memory_index_failure_leaves_no_projection() {
+        let client = Arc::new(CompactionAwareLlmClient::new());
+        let compactor = Arc::new(DiscardingCompactor::new(1));
+        let memory_store = Arc::new(RecordingMemoryStore::failing_after(1));
+        let mut agent = with_test_turn_state_handle(AgentBuilder::new())
+            .compactor(compactor)
+            .memory_store(memory_store.clone())
+            .build(client, Arc::new(NoTools), Arc::new(NoopStore))
+            .await;
+
+        agent.run("first".into()).await.unwrap();
+        agent
+            .run("second".into())
+            .await
+            .expect("indexing failure should preserve history and continue the turn");
+
+        assert!(
+            memory_store.contents().is_empty(),
+            "failed compaction indexing must not leave a partial memory projection"
+        );
+        assert!(
+            agent
+                .session()
+                .messages()
+                .iter()
+                .any(|message| message.as_indexable_text().contains("first")),
+            "failed indexing must preserve the authoritative source history"
         );
     }
 

--- a/meerkat-core/src/lib.rs
+++ b/meerkat-core/src/lib.rs
@@ -113,8 +113,8 @@ pub use compact::{
     SESSION_COMPACTION_CADENCE_KEY, SessionCompactionCadence,
 };
 pub use memory::{
-    MemoryIndexReceipt, MemoryIndexRequest, MemoryIndexScope, MemoryMetadata, MemoryOwner,
-    MemoryResult, MemorySearchScope, MemoryStore, MemoryStoreError,
+    MemoryIndexBatch, MemoryIndexReceipt, MemoryIndexRequest, MemoryIndexScope, MemoryMetadata,
+    MemoryOwner, MemoryResult, MemorySearchScope, MemoryStore, MemoryStoreError,
 };
 pub use model_registry::{ModelRegistry, ModelRegistryEntry, SelfHostedServerRef};
 pub use peer_correlation::{

--- a/meerkat-core/src/memory.rs
+++ b/meerkat-core/src/memory.rs
@@ -147,6 +147,54 @@ impl MemoryIndexRequest {
     }
 }
 
+/// Atomic scoped semantic-memory indexing batch.
+#[derive(Debug, Clone)]
+pub struct MemoryIndexBatch {
+    scope: MemoryIndexScope,
+    requests: Vec<MemoryIndexRequest>,
+}
+
+impl MemoryIndexBatch {
+    pub fn new(
+        scope: MemoryIndexScope,
+        requests: Vec<MemoryIndexRequest>,
+    ) -> Result<Self, MemoryStoreError> {
+        for request in &requests {
+            if request.scope() != &scope {
+                return Err(MemoryStoreError::Scope(format!(
+                    "memory index request scope {} is outside batch scope {}",
+                    request.scope().session_id(),
+                    scope.session_id()
+                )));
+            }
+        }
+        Ok(Self { scope, requests })
+    }
+
+    pub fn single(request: MemoryIndexRequest) -> Self {
+        Self {
+            scope: request.scope.clone(),
+            requests: vec![request],
+        }
+    }
+
+    pub fn scope(&self) -> &MemoryIndexScope {
+        &self.scope
+    }
+
+    pub fn len(&self) -> usize {
+        self.requests.len()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.requests.is_empty()
+    }
+
+    pub fn into_parts(self) -> (MemoryIndexScope, Vec<MemoryIndexRequest>) {
+        (self.scope, self.requests)
+    }
+}
+
 /// Successful delivery receipt for a scoped memory index request.
 #[derive(Debug, Clone)]
 pub struct MemoryIndexReceipt {
@@ -176,6 +224,18 @@ pub trait MemoryStore: Send + Sync {
     async fn index_scoped(
         &self,
         request: MemoryIndexRequest,
+    ) -> Result<MemoryIndexReceipt, MemoryStoreError> {
+        self.index_scoped_batch(MemoryIndexBatch::single(request))
+            .await
+    }
+
+    /// Atomically index a typed, owner-scoped memory batch.
+    ///
+    /// Implementations must either make every request in the batch visible or
+    /// make none of them visible.
+    async fn index_scoped_batch(
+        &self,
+        batch: MemoryIndexBatch,
     ) -> Result<MemoryIndexReceipt, MemoryStoreError>;
 
     /// Semantic search: return up to `limit` results ordered by relevance.

--- a/meerkat-core/src/prompt.rs
+++ b/meerkat-core/src/prompt.rs
@@ -1,21 +1,7 @@
-//! System prompt configuration and AGENTS.md support
+//! Pure system prompt rendering and AGENTS.md section support.
 //!
-//! Provides configurable system prompts with support for:
-//! - Default system prompt
-//! - Custom system prompt override
-//! - AGENTS.md file injection (global + project)
-//!
-//! AGENTS.md discovery:
-//! - Global: ~/.rkat/AGENTS.md
-//! - Project: ./AGENTS.md or ./.rkat/AGENTS.md
-//!
-//! The final prompt is composed as:
-//! 1. System prompt (custom or default)
-//! 2. AGENTS.md content (if found), wrapped in a marker
-
-#[cfg(target_arch = "wasm32")]
-use crate::tokio;
-use std::path::{Path, PathBuf};
+//! Filesystem discovery and loading are owned by outer surfaces. Core only
+//! receives already-loaded instruction content and renders it deterministically.
 
 /// Default system prompt for Meerkat agents
 pub const DEFAULT_SYSTEM_PROMPT: &str = r"You are an autonomous agent. Your task is to accomplish the user's goal by systematically using the tools available to you.
@@ -39,172 +25,111 @@ pub const DEFAULT_SYSTEM_PROMPT: &str = r"You are an autonomous agent. Your task
 /// Maximum size for AGENTS.md files (32 KiB, matching Codex default)
 pub const AGENTS_MD_MAX_BYTES: usize = 32 * 1024;
 
-/// Configuration for system prompt composition
+/// Already-loaded AGENTS.md content plus its display source.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct AgentsMdSection {
+    source: String,
+    content: String,
+}
+
+/// Configuration for pure system prompt composition.
 #[derive(Debug, Clone, Default)]
 pub struct SystemPromptConfig {
     /// Custom system prompt (overrides default if set)
     pub system_prompt: Option<String>,
-    /// Whether to load AGENTS.md files
-    pub load_agents_md: bool,
-    /// Custom path to global AGENTS.md (defaults to ~/.rkat/AGENTS.md)
-    pub global_agents_md_path: Option<PathBuf>,
-    /// Custom path to project AGENTS.md (defaults to ./AGENTS.md or ./.rkat/AGENTS.md)
-    pub project_agents_md_path: Option<PathBuf>,
+    agents_md_sections: Vec<AgentsMdSection>,
 }
 
 impl SystemPromptConfig {
-    /// Create a new config with defaults
+    /// Create a new config with defaults.
     pub fn new() -> Self {
         Self {
             system_prompt: None,
-            load_agents_md: true,
-            global_agents_md_path: None,
-            project_agents_md_path: None,
+            agents_md_sections: Vec::new(),
         }
     }
 
-    /// Set a custom system prompt
+    /// Set a custom system prompt.
     pub fn with_system_prompt(mut self, prompt: impl Into<String>) -> Self {
         self.system_prompt = Some(prompt.into());
         self
     }
 
-    /// Disable AGENTS.md loading
+    /// Clear caller-supplied AGENTS.md sections.
     pub fn without_agents_md(mut self) -> Self {
-        self.load_agents_md = false;
+        self.agents_md_sections.clear();
         self
     }
 
-    /// Set custom global AGENTS.md path
-    pub fn with_global_agents_md(mut self, path: impl Into<PathBuf>) -> Self {
-        self.global_agents_md_path = Some(path.into());
+    /// Add already-loaded global AGENTS.md content.
+    pub fn with_global_agents_md_content(self, content: impl Into<String>) -> Self {
+        self.with_agents_md_section("global AGENTS.md", content)
+    }
+
+    /// Add already-loaded project AGENTS.md content.
+    pub fn with_project_agents_md_content(self, content: impl Into<String>) -> Self {
+        self.with_agents_md_section("AGENTS.md", content)
+    }
+
+    /// Add an already-loaded AGENTS.md section with a display source.
+    pub fn with_agents_md_section(
+        mut self,
+        source: impl Into<String>,
+        content: impl Into<String>,
+    ) -> Self {
+        if let Some(content) = normalize_agents_md_content(&content.into()) {
+            self.agents_md_sections.push(AgentsMdSection {
+                source: source.into(),
+                content,
+            });
+        }
         self
     }
 
-    /// Set custom project AGENTS.md path
-    pub fn with_project_agents_md(mut self, path: impl Into<PathBuf>) -> Self {
-        self.project_agents_md_path = Some(path.into());
-        self
-    }
-
-    /// Compose the final system prompt
-    pub async fn compose(&self) -> String {
+    /// Compose the final system prompt.
+    pub fn compose_sync(&self) -> String {
         let base = self
             .system_prompt
             .as_deref()
             .unwrap_or(DEFAULT_SYSTEM_PROMPT);
 
-        if !self.load_agents_md {
-            return base.to_string();
-        }
-
         let mut parts = vec![base.to_string()];
-
-        // Load global AGENTS.md
-        if let Some(content) = self.load_global_agents_md().await {
+        for section in &self.agents_md_sections {
             parts.push(format!(
-                "\n# Project Instructions (from global AGENTS.md)\n\n{content}"
-            ));
-        }
-
-        // Load project AGENTS.md
-        if let Some(content) = self.load_project_agents_md().await {
-            parts.push(format!(
-                "\n# Project Instructions (from AGENTS.md)\n\n{content}"
+                "\n# Project Instructions (from {})\n\n{}",
+                section.source, section.content
             ));
         }
 
         parts.join("\n")
     }
 
-    async fn load_global_agents_md(&self) -> Option<String> {
-        match self.global_agents_md_path.as_deref() {
-            Some(path) => load_agents_md_file(path).await,
-            None => {
-                let path = default_global_agents_md_path()?;
-                load_agents_md_file(&path).await
-            }
-        }
-    }
-
-    async fn load_project_agents_md(&self) -> Option<String> {
-        if let Some(path) = self.project_agents_md_path.as_deref() {
-            return load_agents_md_file(path).await;
-        }
-
-        let cwd = std::env::current_dir().ok()?;
-
-        for candidate in [cwd.join("AGENTS.md"), cwd.join(".rkat/AGENTS.md")] {
-            if let Some(content) = load_agents_md_file(&candidate).await {
-                return Some(content);
-            }
-        }
-
-        None
+    /// Compose the final system prompt.
+    ///
+    /// This remains async for API compatibility with earlier filesystem-backed
+    /// composition, but core rendering is synchronous and side-effect free.
+    pub async fn compose(&self) -> String {
+        self.compose_sync()
     }
 }
 
-/// Get the default global AGENTS.md path: ~/.rkat/AGENTS.md
-pub fn default_global_agents_md_path() -> Option<PathBuf> {
-    std::env::var_os("HOME")
-        .map(PathBuf::from)
-        .map(|h| h.join(".rkat/AGENTS.md"))
-}
-
-/// Find project AGENTS.md in current directory
-/// Checks: ./AGENTS.md, ./.rkat/AGENTS.md
-pub fn find_project_agents_md() -> Option<PathBuf> {
-    let cwd = std::env::current_dir().ok()?;
-    find_project_agents_md_in(&cwd)
-}
-
-/// Find project AGENTS.md in a specific directory
-/// Checks: <dir>/AGENTS.md, <dir>/.rkat/AGENTS.md
-pub fn find_project_agents_md_in(dir: &Path) -> Option<PathBuf> {
-    // Check ./AGENTS.md first
-    let root_path = dir.join("AGENTS.md");
-    if root_path.exists() {
-        return Some(root_path);
-    }
-
-    // Check ./.rkat/AGENTS.md
-    let meerkat_path = dir.join(".rkat/AGENTS.md");
-    if meerkat_path.exists() {
-        return Some(meerkat_path);
-    }
-
-    None
-}
-
-/// Load an AGENTS.md file, respecting size limits
-async fn load_agents_md_file(path: &Path) -> Option<String> {
-    if !tokio::fs::try_exists(path).await.ok()? {
+/// Normalize already-loaded AGENTS.md content for prompt inclusion.
+pub fn normalize_agents_md_content(content: &str) -> Option<String> {
+    if content.trim().is_empty() {
         return None;
     }
 
-    let content = tokio::fs::read_to_string(path).await.ok()?;
-
-    // Skip empty files
-    let trimmed = content.trim();
-    if trimmed.is_empty() {
-        return None;
-    }
-
-    // Enforce size limit
     if content.len() > AGENTS_MD_MAX_BYTES {
-        // Truncate to limit
-        let truncated: String = content.chars().take(AGENTS_MD_MAX_BYTES).collect();
-        return Some(truncated);
+        return Some(content.chars().take(AGENTS_MD_MAX_BYTES).collect());
     }
 
-    Some(content)
+    Some(content.to_string())
 }
 
 #[cfg(test)]
 #[allow(clippy::unwrap_used, clippy::expect_used)]
 mod tests {
     use super::*;
-    use tempfile::TempDir;
 
     #[tokio::test]
     async fn test_default_prompt_used_when_no_override() {
@@ -214,39 +139,26 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn test_core_prompt_does_not_read_process_filesystem() {
+        let prompt = SystemPromptConfig::new().compose().await;
+
+        assert!(
+            !prompt.contains("BuildBuddy"),
+            "core prompt composition must not read the repository AGENTS.md from cwd"
+        );
+    }
+
+    #[tokio::test]
     async fn test_custom_prompt_overrides_default() {
-        let config = SystemPromptConfig::new()
-            .with_system_prompt("Custom prompt")
-            .without_agents_md();
+        let config = SystemPromptConfig::new().with_system_prompt("Custom prompt");
         let prompt = config.compose().await;
         assert_eq!(prompt, "Custom prompt");
     }
 
     #[tokio::test]
-    async fn test_agents_md_disabled() {
-        let temp = TempDir::new().unwrap();
-        let agents_path = temp.path().join("AGENTS.md");
-        tokio::fs::write(&agents_path, "# Should not appear")
-            .await
-            .unwrap();
-
+    async fn test_project_agents_md_content_injected() {
         let config = SystemPromptConfig::new()
-            .with_project_agents_md(&agents_path)
-            .without_agents_md();
-
-        let prompt = config.compose().await;
-        assert!(!prompt.contains("Should not appear"));
-    }
-
-    #[tokio::test]
-    async fn test_project_agents_md_injected() {
-        let temp = TempDir::new().unwrap();
-        let agents_path = temp.path().join("AGENTS.md");
-        tokio::fs::write(&agents_path, "# Build Instructions\nRun `make build`")
-            .await
-            .unwrap();
-
-        let config = SystemPromptConfig::new().with_project_agents_md(&agents_path);
+            .with_project_agents_md_content("# Build Instructions\nRun `make build`");
 
         let prompt = config.compose().await;
         assert!(prompt.contains(DEFAULT_SYSTEM_PROMPT));
@@ -256,14 +168,9 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_global_agents_md_injected() {
-        let temp = TempDir::new().unwrap();
-        let global_path = temp.path().join("global-agents.md");
-        tokio::fs::write(&global_path, "# Global rules\nAlways be nice")
-            .await
-            .unwrap();
-
-        let config = SystemPromptConfig::new().with_global_agents_md(&global_path);
+    async fn test_global_agents_md_content_injected() {
+        let config = SystemPromptConfig::new()
+            .with_global_agents_md_content("# Global rules\nAlways be nice");
 
         let prompt = config.compose().await;
         assert!(prompt.contains("# Project Instructions (from global AGENTS.md)"));
@@ -271,26 +178,12 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_both_global_and_project_agents_md() {
-        let temp = TempDir::new().unwrap();
-
-        let global_path = temp.path().join("global.md");
-        tokio::fs::write(&global_path, "Global instructions")
-            .await
-            .unwrap();
-
-        let project_path = temp.path().join("project.md");
-        tokio::fs::write(&project_path, "Project instructions")
-            .await
-            .unwrap();
-
+    async fn test_agents_md_sections_preserve_order() {
         let config = SystemPromptConfig::new()
-            .with_global_agents_md(&global_path)
-            .with_project_agents_md(&project_path);
+            .with_global_agents_md_content("Global instructions")
+            .with_project_agents_md_content("Project instructions");
 
         let prompt = config.compose().await;
-
-        // Global should come before project
         let global_pos = prompt.find("Global instructions").unwrap();
         let project_pos = prompt.find("Project instructions").unwrap();
         assert!(global_pos < project_pos);
@@ -298,11 +191,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_empty_agents_md_ignored() {
-        let temp = TempDir::new().unwrap();
-        let agents_path = temp.path().join("AGENTS.md");
-        tokio::fs::write(&agents_path, "   \n\n  ").await.unwrap(); // whitespace only
-
-        let config = SystemPromptConfig::new().with_project_agents_md(&agents_path);
+        let config = SystemPromptConfig::new().with_project_agents_md_content("   \n\n  ");
 
         let prompt = config.compose().await;
         assert!(!prompt.contains("Project Instructions"));
@@ -310,70 +199,17 @@ mod tests {
 
     #[tokio::test]
     async fn test_agents_md_size_limit() {
-        let temp = TempDir::new().unwrap();
-        let agents_path = temp.path().join("AGENTS.md");
-
-        // Create content larger than limit
         let large_content = "x".repeat(AGENTS_MD_MAX_BYTES + 1000);
-        tokio::fs::write(&agents_path, &large_content)
-            .await
-            .unwrap();
-
-        let config = SystemPromptConfig::new().with_project_agents_md(&agents_path);
+        let config = SystemPromptConfig::new().with_project_agents_md_content(&large_content);
 
         let prompt = config.compose().await;
-
-        // Should be truncated
         let agents_section_start = prompt.find("# Project Instructions").unwrap();
         let agents_content = &prompt[agents_section_start..];
-        assert!(agents_content.len() <= AGENTS_MD_MAX_BYTES + 100); // some buffer for header
-    }
-
-    #[tokio::test]
-    async fn test_find_project_agents_md_root() {
-        let temp = TempDir::new().unwrap();
-        let agents_path = temp.path().join("AGENTS.md");
-        tokio::fs::write(&agents_path, "content").await.unwrap();
-
-        let found = find_project_agents_md_in(temp.path());
-        assert_eq!(found, Some(agents_path));
-    }
-
-    #[tokio::test]
-    async fn test_find_project_agents_md_in_meerkat_dir() {
-        let temp = TempDir::new().unwrap();
-        let meerkat_dir = temp.path().join(".rkat");
-        tokio::fs::create_dir_all(&meerkat_dir).await.unwrap();
-        let agents_path = meerkat_dir.join("AGENTS.md");
-        tokio::fs::write(&agents_path, "content").await.unwrap();
-
-        let found = find_project_agents_md_in(temp.path());
-        assert_eq!(found, Some(agents_path));
-    }
-
-    #[tokio::test]
-    async fn test_find_project_agents_md_root_takes_precedence() {
-        let temp = TempDir::new().unwrap();
-
-        // Create both
-        let root_path = temp.path().join("AGENTS.md");
-        tokio::fs::write(&root_path, "root content").await.unwrap();
-
-        let meerkat_dir = temp.path().join(".rkat");
-        tokio::fs::create_dir_all(&meerkat_dir).await.unwrap();
-        tokio::fs::write(meerkat_dir.join("AGENTS.md"), "test content")
-            .await
-            .unwrap();
-
-        // Root should win
-        let found = find_project_agents_md_in(temp.path());
-        assert_eq!(found, Some(root_path));
+        assert!(agents_content.len() <= AGENTS_MD_MAX_BYTES + 100);
     }
 
     #[test]
-    fn test_missing_agents_md_returns_none() {
-        let temp = TempDir::new().unwrap();
-        let found = find_project_agents_md_in(temp.path());
-        assert_eq!(found, None);
+    fn test_normalize_agents_md_content_rejects_empty() {
+        assert_eq!(normalize_agents_md_content(" \n\t "), None);
     }
 }

--- a/meerkat-core/tests/rct_contracts.rs
+++ b/meerkat-core/tests/rct_contracts.rs
@@ -383,12 +383,8 @@ fn test_tool_category_override_resolution() {
 
 #[tokio::test]
 async fn test_inv_005_agents_md_injected() -> Result<(), Box<dyn std::error::Error>> {
-    let dir = tempfile::tempdir()?;
-    let agents_path = dir.path().join("AGENTS.md");
-    std::fs::write(&agents_path, "custom instructions")?;
-
     let prompt = SystemPromptConfig::new()
-        .with_project_agents_md(&agents_path)
+        .with_project_agents_md_content("custom instructions")
         .compose()
         .await;
 

--- a/meerkat-memory/src/hnsw.rs
+++ b/meerkat-memory/src/hnsw.rs
@@ -9,7 +9,7 @@
 use async_trait::async_trait;
 use hnsw_rs::prelude::{DistCosine, Hnsw};
 use meerkat_core::memory::{
-    MemoryIndexReceipt, MemoryIndexRequest, MemoryResult, MemorySearchScope, MemoryStore,
+    MemoryIndexBatch, MemoryIndexReceipt, MemoryResult, MemorySearchScope, MemoryStore,
     MemoryStoreError,
 };
 use rusqlite::{Connection, OptionalExtension, params};
@@ -137,59 +137,114 @@ impl HnswMemoryStore {
 
 #[async_trait]
 impl MemoryStore for HnswMemoryStore {
-    async fn index_scoped(
+    async fn index_scoped_batch(
         &self,
-        request: MemoryIndexRequest,
+        batch: MemoryIndexBatch,
     ) -> Result<MemoryIndexReceipt, MemoryStoreError> {
-        let (scope, content, metadata) = request.into_parts();
-        let receipt_scope = scope.clone();
-        let meta_json = serde_json::to_vec(&metadata)
-            .map_err(|e| MemoryStoreError::Embedding(e.to_string()))?;
+        let (receipt_scope, requests) = batch.into_parts();
+        let indexed_entries = requests.len();
+        if requests.is_empty() {
+            return Ok(MemoryIndexReceipt {
+                scope: receipt_scope,
+                indexed_entries: 0,
+            });
+        }
+
+        let mut entries = Vec::with_capacity(indexed_entries);
+        for request in requests {
+            let (_scope, content, metadata) = request.into_parts();
+            let meta_json = serde_json::to_vec(&metadata)
+                .map_err(|e| MemoryStoreError::Embedding(e.to_string()))?;
+            let embedding = text_to_embedding(&content);
+            entries.push((content, meta_json, embedding));
+        }
+
         let db_path = self.db_path.clone();
         let index = Arc::clone(&self.index);
 
         // Keep point ID allocation coupled to a successful write.
         let _guard = self.insert_lock.lock().await;
         let point_id = self.next_id.load(Ordering::Acquire);
-        let point_id_i64 = i64::try_from(point_id)
-            .map_err(|_| MemoryStoreError::Index("point ID out of range".to_string()))?;
+        let next_id = point_id
+            .checked_add(indexed_entries)
+            .ok_or_else(|| MemoryStoreError::Index("point ID overflow".to_string()))?;
+        let point_ids: Vec<i64> = (point_id..next_id)
+            .map(|id| {
+                i64::try_from(id)
+                    .map_err(|_| MemoryStoreError::Index("point ID out of range".to_string()))
+            })
+            .collect::<Result<_, _>>()?;
 
-        tokio::task::spawn_blocking(move || {
-            let embedding = text_to_embedding(&content);
+        let insert_result = tokio::task::spawn_blocking(move || {
             let mut conn = open_connection(&db_path)?;
             let tx = conn
                 .transaction()
                 .map_err(|e| MemoryStoreError::Index(e.to_string()))?;
-            tx.execute(
-                "INSERT INTO memory_metadata (point_id, metadata_json) VALUES (?1, ?2)",
-                params![point_id_i64, meta_json],
-            )
-            .map_err(|e| MemoryStoreError::Index(e.to_string()))?;
-            tx.execute(
-                "INSERT INTO memory_text (point_id, content) VALUES (?1, ?2)",
-                params![point_id_i64, content.as_bytes()],
-            )
-            .map_err(|e| MemoryStoreError::Index(e.to_string()))?;
+            for (point_id_i64, (content, meta_json, _embedding)) in point_ids.iter().zip(&entries) {
+                tx.execute(
+                    "INSERT INTO memory_metadata (point_id, metadata_json) VALUES (?1, ?2)",
+                    params![point_id_i64, meta_json],
+                )
+                .map_err(|e| MemoryStoreError::Index(e.to_string()))?;
+                tx.execute(
+                    "INSERT INTO memory_text (point_id, content) VALUES (?1, ?2)",
+                    params![point_id_i64, content.as_bytes()],
+                )
+                .map_err(|e| MemoryStoreError::Index(e.to_string()))?;
+            }
             tx.commit()
                 .map_err(|e| MemoryStoreError::Index(e.to_string()))?;
 
-            let index = index
-                .write()
-                .map_err(|_| MemoryStoreError::Index("HNSW index lock poisoned".to_string()))?;
-            index.insert((&embedding, point_id));
+            let index_result = (|| {
+                let index = index
+                    .write()
+                    .map_err(|_| MemoryStoreError::Index("HNSW index lock poisoned".to_string()))?;
+                for (point_id, (_content, _meta_json, embedding)) in point_ids.iter().zip(&entries)
+                {
+                    let point_id = usize::try_from(*point_id).map_err(|_| {
+                        MemoryStoreError::Index("point ID out of range".to_string())
+                    })?;
+                    index.insert((embedding, point_id));
+                }
+                Ok::<(), MemoryStoreError>(())
+            })();
+
+            if let Err(error) = index_result {
+                let mut cleanup = open_connection(&db_path)?;
+                let tx = cleanup
+                    .transaction()
+                    .map_err(|e| MemoryStoreError::Index(e.to_string()))?;
+                for point_id_i64 in &point_ids {
+                    tx.execute(
+                        "DELETE FROM memory_metadata WHERE point_id = ?1",
+                        params![point_id_i64],
+                    )
+                    .map_err(|e| MemoryStoreError::Index(e.to_string()))?;
+                    tx.execute(
+                        "DELETE FROM memory_text WHERE point_id = ?1",
+                        params![point_id_i64],
+                    )
+                    .map_err(|e| MemoryStoreError::Index(e.to_string()))?;
+                }
+                tx.commit()
+                    .map_err(|e| MemoryStoreError::Index(e.to_string()))?;
+                return Err(error);
+            }
 
             Ok::<(), MemoryStoreError>(())
         })
         .await
-        .map_err(|e| MemoryStoreError::Index(format!("index task join failed: {e}")))??;
+        .map_err(|e| MemoryStoreError::Index(format!("index task join failed: {e}")))?;
 
-        let next_id = point_id
-            .checked_add(1)
-            .ok_or_else(|| MemoryStoreError::Index("point ID overflow".to_string()))?;
+        if let Err(error) = insert_result {
+            self.next_id.store(next_id, Ordering::Release);
+            return Err(error);
+        }
+
         self.next_id.store(next_id, Ordering::Release);
         Ok(MemoryIndexReceipt {
             scope: receipt_scope,
-            indexed_entries: 1,
+            indexed_entries,
         })
     }
 
@@ -205,68 +260,53 @@ impl MemoryStore for HnswMemoryStore {
         let query = query.to_owned();
         let scope = scope.clone();
         let db_path = self.db_path.clone();
-        let index = Arc::clone(&self.index);
 
         tokio::task::spawn_blocking(move || {
-            let embedding = text_to_embedding(&query);
-            let candidate_limit = limit.saturating_mul(8).max(limit).max(1);
-            let ef_search = candidate_limit.max(EF_CONSTRUCTION);
-            let neighbors = {
-                let index = index
-                    .read()
-                    .map_err(|_| MemoryStoreError::Index("HNSW index lock poisoned".to_string()))?;
-                index.search(&embedding, candidate_limit, ef_search)
-            };
-
+            let query_embedding = text_to_embedding(&query);
             let conn = open_connection(&db_path)?;
-            let mut results = Vec::with_capacity(neighbors.len());
-            for neighbor in &neighbors {
-                let point_id = i64::try_from(neighbor.d_id)
-                    .map_err(|_| MemoryStoreError::Index("point ID out of range".to_string()))?;
+            let mut stmt = conn
+                .prepare(
+                    "SELECT t.content, m.metadata_json \
+                     FROM memory_text t \
+                     JOIN memory_metadata m ON m.point_id = t.point_id",
+                )
+                .map_err(|e| MemoryStoreError::Index(e.to_string()))?;
+            let rows = stmt
+                .query_map([], |row| {
+                    Ok((row.get::<_, Vec<u8>>(0)?, row.get::<_, Vec<u8>>(1)?))
+                })
+                .map_err(|e| MemoryStoreError::Index(e.to_string()))?;
 
-                let content = match conn
-                    .query_row(
-                        "SELECT content FROM memory_text WHERE point_id = ?1",
-                        params![point_id],
-                        |row| row.get::<_, Vec<u8>>(0),
-                    )
-                    .optional()
-                    .map_err(|e| MemoryStoreError::Index(e.to_string()))?
-                {
-                    Some(bytes) => String::from_utf8_lossy(&bytes).into_owned(),
-                    None => continue,
-                };
-
-                let metadata = match conn
-                    .query_row(
-                        "SELECT metadata_json FROM memory_metadata WHERE point_id = ?1",
-                        params![point_id],
-                        |row| row.get::<_, Vec<u8>>(0),
-                    )
-                    .optional()
-                    .map_err(|e| MemoryStoreError::Index(e.to_string()))?
-                {
-                    Some(bytes) => serde_json::from_slice(&bytes)
-                        .map_err(|e| MemoryStoreError::Embedding(e.to_string()))?,
-                    None => continue,
-                };
+            let mut results = Vec::new();
+            for row in rows {
+                let (content, metadata_json) =
+                    row.map_err(|e| MemoryStoreError::Index(e.to_string()))?;
+                let metadata = serde_json::from_slice(&metadata_json)
+                    .map_err(|e| MemoryStoreError::Embedding(e.to_string()))?;
                 if !scope.includes(&metadata) {
                     continue;
                 }
 
-                // HNSW distance is cosine distance (0 = identical, 2 = opposite).
-                // Convert to a 0..1 similarity score.
-                let score = 1.0 - (neighbor.distance / 2.0);
+                let content = String::from_utf8_lossy(&content).into_owned();
+                let content_embedding = text_to_embedding(&content);
+                let score = embedding_similarity(&query_embedding, &content_embedding);
+                if score <= 0.0 {
+                    continue;
+                }
 
                 results.push(MemoryResult {
                     content,
                     metadata,
                     score,
                 });
-                if results.len() >= limit {
-                    break;
-                }
             }
+
+            results.sort_by(|a, b| {
+                b.score
+                    .partial_cmp(&a.score)
+                    .unwrap_or(std::cmp::Ordering::Equal)
+            });
+            results.truncate(limit);
 
             Ok::<Vec<MemoryResult>, MemoryStoreError>(results)
         })
@@ -303,11 +343,19 @@ fn text_to_embedding(text: &str) -> [f32; VOCAB_DIM] {
     vec
 }
 
+fn embedding_similarity(left: &[f32; VOCAB_DIM], right: &[f32; VOCAB_DIM]) -> f32 {
+    left.iter()
+        .zip(right)
+        .map(|(l, r)| l * r)
+        .sum::<f32>()
+        .clamp(0.0, 1.0)
+}
+
 #[cfg(test)]
 #[allow(clippy::unwrap_used, clippy::expect_used)]
 mod tests {
     use super::*;
-    use meerkat_core::memory::{MemoryIndexScope, MemoryMetadata};
+    use meerkat_core::memory::{MemoryIndexRequest, MemoryIndexScope, MemoryMetadata};
     use meerkat_core::types::SessionId;
     use std::time::SystemTime;
     use tempfile::TempDir;
@@ -405,6 +453,41 @@ mod tests {
 
         let results = store.search(&scope, "test", 3).await.unwrap();
         assert!(results.len() <= 3);
+    }
+
+    #[tokio::test]
+    async fn test_hnsw_search_scopes_before_candidate_selection() {
+        let dir = TempDir::new().unwrap();
+        let store = HnswMemoryStore::open(dir.path().join("memory")).unwrap();
+        let session_id = SessionId::new();
+        let scope = MemorySearchScope::for_session(session_id.clone());
+
+        for _ in 0..32 {
+            let other_session_id = SessionId::new();
+            store
+                .index_scoped(request(
+                    "needle recall exact global candidate",
+                    &other_session_id,
+                ))
+                .await
+                .unwrap();
+        }
+        store
+            .index_scoped(request("needle recall scoped survivor", &session_id))
+            .await
+            .unwrap();
+
+        let results = store
+            .search(&scope, "needle recall exact global candidate", 1)
+            .await
+            .unwrap();
+
+        assert_eq!(results.len(), 1);
+        assert_eq!(results[0].metadata.session_id, session_id);
+        assert!(
+            results[0].content.contains("scoped survivor"),
+            "scoped candidates must be ranked before the limit is applied"
+        );
     }
 
     #[tokio::test]

--- a/meerkat-memory/src/hnsw.rs
+++ b/meerkat-memory/src/hnsw.rs
@@ -9,10 +9,12 @@
 use async_trait::async_trait;
 use hnsw_rs::prelude::{DistCosine, Hnsw};
 use meerkat_core::memory::{
-    MemoryIndexBatch, MemoryIndexReceipt, MemoryResult, MemorySearchScope, MemoryStore,
-    MemoryStoreError,
+    MemoryIndexBatch, MemoryIndexReceipt, MemoryMetadata, MemoryResult, MemorySearchScope,
+    MemoryStore, MemoryStoreError,
 };
+use meerkat_core::types::SessionId;
 use rusqlite::{Connection, OptionalExtension, params};
+use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use std::sync::atomic::{AtomicUsize, Ordering};
@@ -59,12 +61,22 @@ fn open_connection(path: &Path) -> Result<Connection, MemoryStoreError> {
     Ok(conn)
 }
 
+fn new_hnsw_index() -> Hnsw<'static, f32, DistCosine> {
+    Hnsw::<'static, f32, DistCosine>::new(
+        MAX_NB_CONNECTION,
+        DEFAULT_MAX_ELEMENTS,
+        MAX_LAYER,
+        EF_CONSTRUCTION,
+        DistCosine {},
+    )
+}
+
 /// HNSW-backed memory store with SQLite metadata persistence.
 pub struct HnswMemoryStore {
     // SAFETY NOTE: we use `'static` because `hnsw_rs` 0.3 copies inserted vectors
     // into owned internal storage. If a future `hnsw_rs` release changes this to
     // borrow caller memory, this type must be revisited before upgrading.
-    index: Arc<std::sync::RwLock<Hnsw<'static, f32, DistCosine>>>,
+    indices: Arc<std::sync::RwLock<HashMap<SessionId, Hnsw<'static, f32, DistCosine>>>>,
     db_path: PathBuf,
     next_id: AtomicUsize,
     insert_lock: Mutex<()>,
@@ -95,33 +107,42 @@ impl HnswMemoryStore {
             }
         };
 
-        let hnsw = Hnsw::<'static, f32, DistCosine>::new(
-            MAX_NB_CONNECTION,
-            DEFAULT_MAX_ELEMENTS,
-            MAX_LAYER,
-            EF_CONSTRUCTION,
-            DistCosine {},
-        );
+        let mut indices = HashMap::<SessionId, Hnsw<'static, f32, DistCosine>>::new();
 
         let mut stmt = conn
-            .prepare("SELECT point_id, content FROM memory_text ORDER BY point_id ASC")
+            .prepare(
+                "SELECT t.point_id, t.content, m.metadata_json \
+                 FROM memory_text t \
+                 JOIN memory_metadata m ON m.point_id = t.point_id \
+                 ORDER BY t.point_id ASC",
+            )
             .map_err(|e| MemoryStoreError::Index(e.to_string()))?;
         let rows = stmt
             .query_map([], |row| {
-                Ok((row.get::<_, i64>(0)?, row.get::<_, Vec<u8>>(1)?))
+                Ok((
+                    row.get::<_, i64>(0)?,
+                    row.get::<_, Vec<u8>>(1)?,
+                    row.get::<_, Vec<u8>>(2)?,
+                ))
             })
             .map_err(|e| MemoryStoreError::Index(e.to_string()))?;
         for row in rows {
-            let (point_id, text) = row.map_err(|e| MemoryStoreError::Index(e.to_string()))?;
+            let (point_id, text, metadata_json) =
+                row.map_err(|e| MemoryStoreError::Index(e.to_string()))?;
             let point_id = usize::try_from(point_id)
                 .map_err(|_| MemoryStoreError::Index("point ID out of range".to_string()))?;
+            let metadata: MemoryMetadata = serde_json::from_slice(&metadata_json)
+                .map_err(|e| MemoryStoreError::Embedding(e.to_string()))?;
             let text = String::from_utf8_lossy(&text);
             let embedding = text_to_embedding(&text);
-            hnsw.insert((&embedding, point_id));
+            indices
+                .entry(metadata.session_id)
+                .or_insert_with(new_hnsw_index)
+                .insert((&embedding, point_id));
         }
 
         Ok(Self {
-            index: Arc::new(std::sync::RwLock::new(hnsw)),
+            indices: Arc::new(std::sync::RwLock::new(indices)),
             db_path,
             next_id: AtomicUsize::new(next_id),
             insert_lock: Mutex::new(()),
@@ -160,7 +181,8 @@ impl MemoryStore for HnswMemoryStore {
         }
 
         let db_path = self.db_path.clone();
-        let index = Arc::clone(&self.index);
+        let indices = Arc::clone(&self.indices);
+        let session_id = receipt_scope.session_id().clone();
 
         // Keep point ID allocation coupled to a successful write.
         let _guard = self.insert_lock.lock().await;
@@ -196,9 +218,10 @@ impl MemoryStore for HnswMemoryStore {
                 .map_err(|e| MemoryStoreError::Index(e.to_string()))?;
 
             let index_result = (|| {
-                let index = index
+                let mut indices = indices
                     .write()
                     .map_err(|_| MemoryStoreError::Index("HNSW index lock poisoned".to_string()))?;
+                let index = indices.entry(session_id).or_insert_with(new_hnsw_index);
                 for (point_id, (_content, _meta_json, embedding)) in point_ids.iter().zip(&entries)
                 {
                     let point_id = usize::try_from(*point_id).map_err(|_| {
@@ -260,39 +283,59 @@ impl MemoryStore for HnswMemoryStore {
         let query = query.to_owned();
         let scope = scope.clone();
         let db_path = self.db_path.clone();
+        let indices = Arc::clone(&self.indices);
 
         tokio::task::spawn_blocking(move || {
-            let query_embedding = text_to_embedding(&query);
-            let conn = open_connection(&db_path)?;
-            let mut stmt = conn
-                .prepare(
-                    "SELECT t.content, m.metadata_json \
-                     FROM memory_text t \
-                     JOIN memory_metadata m ON m.point_id = t.point_id",
-                )
-                .map_err(|e| MemoryStoreError::Index(e.to_string()))?;
-            let rows = stmt
-                .query_map([], |row| {
-                    Ok((row.get::<_, Vec<u8>>(0)?, row.get::<_, Vec<u8>>(1)?))
-                })
-                .map_err(|e| MemoryStoreError::Index(e.to_string()))?;
+            let embedding = text_to_embedding(&query);
+            let neighbors = {
+                let indices = indices
+                    .read()
+                    .map_err(|_| MemoryStoreError::Index("HNSW index lock poisoned".to_string()))?;
+                let Some(index) = indices.get(scope.session_id()) else {
+                    return Ok(Vec::new());
+                };
+                index.search(&embedding, limit, limit.max(EF_CONSTRUCTION))
+            };
 
-            let mut results = Vec::new();
-            for row in rows {
-                let (content, metadata_json) =
-                    row.map_err(|e| MemoryStoreError::Index(e.to_string()))?;
-                let metadata = serde_json::from_slice(&metadata_json)
-                    .map_err(|e| MemoryStoreError::Embedding(e.to_string()))?;
+            let conn = open_connection(&db_path)?;
+            let mut results = Vec::with_capacity(neighbors.len());
+            for neighbor in &neighbors {
+                let point_id = i64::try_from(neighbor.d_id)
+                    .map_err(|_| MemoryStoreError::Index("point ID out of range".to_string()))?;
+
+                let content = match conn
+                    .query_row(
+                        "SELECT content FROM memory_text WHERE point_id = ?1",
+                        params![point_id],
+                        |row| row.get::<_, Vec<u8>>(0),
+                    )
+                    .optional()
+                    .map_err(|e| MemoryStoreError::Index(e.to_string()))?
+                {
+                    Some(bytes) => String::from_utf8_lossy(&bytes).into_owned(),
+                    None => continue,
+                };
+
+                let metadata = match conn
+                    .query_row(
+                        "SELECT metadata_json FROM memory_metadata WHERE point_id = ?1",
+                        params![point_id],
+                        |row| row.get::<_, Vec<u8>>(0),
+                    )
+                    .optional()
+                    .map_err(|e| MemoryStoreError::Index(e.to_string()))?
+                {
+                    Some(bytes) => serde_json::from_slice(&bytes)
+                        .map_err(|e| MemoryStoreError::Embedding(e.to_string()))?,
+                    None => continue,
+                };
                 if !scope.includes(&metadata) {
                     continue;
                 }
 
-                let content = String::from_utf8_lossy(&content).into_owned();
-                let content_embedding = text_to_embedding(&content);
-                let score = embedding_similarity(&query_embedding, &content_embedding);
-                if score <= 0.0 {
-                    continue;
-                }
+                // HNSW distance is cosine distance (0 = identical, 2 = opposite).
+                // Convert to a 0..1 similarity score.
+                let score = 1.0 - (neighbor.distance / 2.0);
 
                 results.push(MemoryResult {
                     content,
@@ -300,13 +343,6 @@ impl MemoryStore for HnswMemoryStore {
                     score,
                 });
             }
-
-            results.sort_by(|a, b| {
-                b.score
-                    .partial_cmp(&a.score)
-                    .unwrap_or(std::cmp::Ordering::Equal)
-            });
-            results.truncate(limit);
 
             Ok::<Vec<MemoryResult>, MemoryStoreError>(results)
         })
@@ -341,14 +377,6 @@ fn text_to_embedding(text: &str) -> [f32; VOCAB_DIM] {
     }
 
     vec
-}
-
-fn embedding_similarity(left: &[f32; VOCAB_DIM], right: &[f32; VOCAB_DIM]) -> f32 {
-    left.iter()
-        .zip(right)
-        .map(|(l, r)| l * r)
-        .sum::<f32>()
-        .clamp(0.0, 1.0)
 }
 
 #[cfg(test)]

--- a/meerkat-memory/src/hnsw.rs
+++ b/meerkat-memory/src/hnsw.rs
@@ -42,8 +42,8 @@ const MAX_NB_CONNECTION: usize = 16;
 const MAX_LAYER: usize = 16;
 /// Construction-time exploration factor.
 const EF_CONSTRUCTION: usize = 200;
-/// Default max elements hint.
-const DEFAULT_MAX_ELEMENTS: usize = 100_000;
+/// Minimum max-elements hint for an allocated HNSW index.
+const MIN_INDEX_ELEMENTS_HINT: usize = 1;
 
 fn open_connection(path: &Path) -> Result<Connection, MemoryStoreError> {
     if let Some(parent) = path.parent() {
@@ -61,14 +61,41 @@ fn open_connection(path: &Path) -> Result<Connection, MemoryStoreError> {
     Ok(conn)
 }
 
-fn new_hnsw_index() -> Hnsw<'static, f32, DistCosine> {
+type MemoryHnswIndex = Hnsw<'static, f32, DistCosine>;
+
+fn bounded_index_elements_hint(entries: usize) -> usize {
+    entries.max(MIN_INDEX_ELEMENTS_HINT)
+}
+
+fn new_hnsw_index(max_elements_hint: usize) -> MemoryHnswIndex {
     Hnsw::<'static, f32, DistCosine>::new(
         MAX_NB_CONNECTION,
-        DEFAULT_MAX_ELEMENTS,
+        bounded_index_elements_hint(max_elements_hint),
         MAX_LAYER,
         EF_CONSTRUCTION,
         DistCosine {},
     )
+}
+
+struct ScopedHnswIndex {
+    index: MemoryHnswIndex,
+    #[cfg(test)]
+    max_elements_hint: usize,
+}
+
+impl ScopedHnswIndex {
+    fn new(max_elements_hint: usize) -> Self {
+        let max_elements_hint = bounded_index_elements_hint(max_elements_hint);
+        Self {
+            index: new_hnsw_index(max_elements_hint),
+            #[cfg(test)]
+            max_elements_hint,
+        }
+    }
+
+    fn insert(&self, embedding: &[f32], point_id: usize) {
+        self.index.insert((embedding, point_id));
+    }
 }
 
 /// HNSW-backed memory store with SQLite metadata persistence.
@@ -76,7 +103,7 @@ pub struct HnswMemoryStore {
     // SAFETY NOTE: we use `'static` because `hnsw_rs` 0.3 copies inserted vectors
     // into owned internal storage. If a future `hnsw_rs` release changes this to
     // borrow caller memory, this type must be revisited before upgrading.
-    indices: Arc<std::sync::RwLock<HashMap<SessionId, Hnsw<'static, f32, DistCosine>>>>,
+    indices: Arc<std::sync::RwLock<HashMap<SessionId, ScopedHnswIndex>>>,
     db_path: PathBuf,
     next_id: AtomicUsize,
     insert_lock: Mutex<()>,
@@ -107,7 +134,24 @@ impl HnswMemoryStore {
             }
         };
 
-        let mut indices = HashMap::<SessionId, Hnsw<'static, f32, DistCosine>>::new();
+        let mut session_counts = HashMap::<SessionId, usize>::new();
+        {
+            let mut count_stmt = conn
+                .prepare("SELECT metadata_json FROM memory_metadata")
+                .map_err(|e| MemoryStoreError::Index(e.to_string()))?;
+            let metadata_rows = count_stmt
+                .query_map([], |row| row.get::<_, Vec<u8>>(0))
+                .map_err(|e| MemoryStoreError::Index(e.to_string()))?;
+            for metadata_json in metadata_rows {
+                let metadata_json =
+                    metadata_json.map_err(|e| MemoryStoreError::Index(e.to_string()))?;
+                let metadata: MemoryMetadata = serde_json::from_slice(&metadata_json)
+                    .map_err(|e| MemoryStoreError::Embedding(e.to_string()))?;
+                *session_counts.entry(metadata.session_id).or_default() += 1;
+            }
+        }
+
+        let mut indices = HashMap::<SessionId, ScopedHnswIndex>::new();
 
         let mut stmt = conn
             .prepare(
@@ -135,10 +179,13 @@ impl HnswMemoryStore {
                 .map_err(|e| MemoryStoreError::Embedding(e.to_string()))?;
             let text = String::from_utf8_lossy(&text);
             let embedding = text_to_embedding(&text);
+            let max_elements_hint = *session_counts
+                .get(&metadata.session_id)
+                .unwrap_or(&MIN_INDEX_ELEMENTS_HINT);
             indices
                 .entry(metadata.session_id)
-                .or_insert_with(new_hnsw_index)
-                .insert((&embedding, point_id));
+                .or_insert_with(|| ScopedHnswIndex::new(max_elements_hint))
+                .insert(&embedding, point_id);
         }
 
         Ok(Self {
@@ -153,6 +200,31 @@ impl HnswMemoryStore {
     /// Get the storage directory path.
     pub fn path(&self) -> &Path {
         &self.path
+    }
+
+    #[cfg(test)]
+    fn hnsw_index_count(&self) -> usize {
+        self.indices.read().unwrap().len()
+    }
+
+    #[cfg(test)]
+    fn hnsw_point_count(&self) -> usize {
+        self.indices
+            .read()
+            .unwrap()
+            .values()
+            .map(|index| index.index.get_nb_point())
+            .sum()
+    }
+
+    #[cfg(test)]
+    fn hnsw_index_hints(&self) -> Vec<usize> {
+        self.indices
+            .read()
+            .unwrap()
+            .values()
+            .map(|index| index.max_elements_hint)
+            .collect()
     }
 }
 
@@ -221,13 +293,15 @@ impl MemoryStore for HnswMemoryStore {
                 let mut indices = indices
                     .write()
                     .map_err(|_| MemoryStoreError::Index("HNSW index lock poisoned".to_string()))?;
-                let index = indices.entry(session_id).or_insert_with(new_hnsw_index);
+                let index = indices
+                    .entry(session_id)
+                    .or_insert_with(|| ScopedHnswIndex::new(indexed_entries));
                 for (point_id, (_content, _meta_json, embedding)) in point_ids.iter().zip(&entries)
                 {
                     let point_id = usize::try_from(*point_id).map_err(|_| {
                         MemoryStoreError::Index("point ID out of range".to_string())
                     })?;
-                    index.insert((embedding, point_id));
+                    index.insert(embedding, point_id);
                 }
                 Ok::<(), MemoryStoreError>(())
             })();
@@ -294,7 +368,9 @@ impl MemoryStore for HnswMemoryStore {
                 let Some(index) = indices.get(scope.session_id()) else {
                     return Ok(Vec::new());
                 };
-                index.search(&embedding, limit, limit.max(EF_CONSTRUCTION))
+                index
+                    .index
+                    .search(&embedding, limit, limit.max(EF_CONSTRUCTION))
             };
 
             let conn = open_connection(&db_path)?;
@@ -516,6 +592,71 @@ mod tests {
             results[0].content.contains("scoped survivor"),
             "scoped candidates must be ranked before the limit is applied"
         );
+    }
+
+    #[tokio::test]
+    async fn test_hnsw_many_small_scopes_use_bounded_index_hints_across_reopen() {
+        let dir = TempDir::new().unwrap();
+        let memory_dir = dir.path().join("memory");
+        let mut session_ids = Vec::new();
+
+        {
+            let store = HnswMemoryStore::open(&memory_dir).unwrap();
+            for i in 0..48 {
+                let session_id = SessionId::new();
+                store
+                    .index_scoped(request(
+                        format!("single scoped memory entry {i}"),
+                        &session_id,
+                    ))
+                    .await
+                    .unwrap();
+                session_ids.push(session_id);
+            }
+
+            assert_eq!(
+                store.hnsw_index_count(),
+                session_ids.len(),
+                "one-entry scopes keep separate scoped indexes for recall"
+            );
+            assert!(
+                store
+                    .hnsw_index_hints()
+                    .iter()
+                    .all(|hint| *hint == MIN_INDEX_ELEMENTS_HINT),
+                "many one-entry scopes must not allocate oversized HNSW indexes"
+            );
+            assert_eq!(store.hnsw_point_count(), session_ids.len());
+        }
+
+        {
+            let store = HnswMemoryStore::open(&memory_dir).unwrap();
+            assert_eq!(
+                store.hnsw_index_count(),
+                session_ids.len(),
+                "reopen keeps scoped indexes for recall"
+            );
+            assert!(
+                store
+                    .hnsw_index_hints()
+                    .iter()
+                    .all(|hint| *hint == MIN_INDEX_ELEMENTS_HINT),
+                "reopen must rebuild one-entry scoped indexes with bounded hints"
+            );
+            assert_eq!(store.hnsw_point_count(), session_ids.len());
+
+            let last_session = session_ids.last().unwrap();
+            let results = store
+                .search(
+                    &MemorySearchScope::for_session(last_session.clone()),
+                    "single scoped memory entry 47",
+                    1,
+                )
+                .await
+                .unwrap();
+            assert_eq!(results.len(), 1);
+            assert_eq!(results[0].metadata.session_id, *last_session);
+        }
     }
 
     #[tokio::test]

--- a/meerkat-memory/src/simple.rs
+++ b/meerkat-memory/src/simple.rs
@@ -5,7 +5,7 @@
 
 use async_trait::async_trait;
 use meerkat_core::memory::{
-    MemoryIndexReceipt, MemoryIndexRequest, MemoryIndexScope, MemoryMetadata, MemoryResult,
+    MemoryIndexBatch, MemoryIndexReceipt, MemoryIndexScope, MemoryMetadata, MemoryResult,
     MemorySearchScope, MemoryStore, MemoryStoreError,
 };
 use tokio::sync::RwLock;
@@ -44,21 +44,24 @@ impl Default for SimpleMemoryStore {
 
 #[async_trait]
 impl MemoryStore for SimpleMemoryStore {
-    async fn index_scoped(
+    async fn index_scoped_batch(
         &self,
-        request: MemoryIndexRequest,
+        batch: MemoryIndexBatch,
     ) -> Result<MemoryIndexReceipt, MemoryStoreError> {
-        let (scope, content, metadata) = request.into_parts();
-        let receipt_scope = scope.clone();
+        let (receipt_scope, requests) = batch.into_parts();
+        let indexed_entries = requests.len();
         let mut entries = self.entries.write().await;
-        entries.push(MemoryEntry {
-            scope,
-            content,
-            metadata,
-        });
+        for request in requests {
+            let (scope, content, metadata) = request.into_parts();
+            entries.push(MemoryEntry {
+                scope,
+                content,
+                metadata,
+            });
+        }
         Ok(MemoryIndexReceipt {
             scope: receipt_scope,
-            indexed_entries: 1,
+            indexed_entries,
         })
     }
 
@@ -112,6 +115,7 @@ impl MemoryStore for SimpleMemoryStore {
 #[allow(clippy::unwrap_used, clippy::expect_used)]
 mod tests {
     use super::*;
+    use meerkat_core::memory::MemoryIndexRequest;
     use meerkat_core::types::SessionId;
     use std::time::SystemTime;
 

--- a/meerkat/src/prompt_assembly.rs
+++ b/meerkat/src/prompt_assembly.rs
@@ -11,7 +11,7 @@
 //! 6. Dispatcher-provided tool usage instructions (appended last).
 
 use meerkat_core::{Config, SystemPromptConfig, prompt::normalize_agents_md_content};
-use std::path::{Path, PathBuf};
+use std::path::Path;
 
 /// Assemble the final system prompt. Single canonical path.
 ///
@@ -51,8 +51,7 @@ pub async fn assemble_system_prompt(
 
     // AGENTS.md is resolved only from explicit context roots.
     if let Some(context) = context_root
-        && let Some(project_agents) = find_project_agents_md_in(context)
-        && let Some(content) = load_agents_md_file(&project_agents).await
+        && let Some(content) = load_project_agents_md_in(context).await
     {
         spc = spc.with_project_agents_md_content(content);
     }
@@ -77,10 +76,13 @@ pub async fn assemble_system_prompt(
     )
 }
 
-fn find_project_agents_md_in(dir: &Path) -> Option<PathBuf> {
-    [dir.join("AGENTS.md"), dir.join(".rkat/AGENTS.md")]
-        .into_iter()
-        .find(|candidate| candidate.exists())
+async fn load_project_agents_md_in(dir: &Path) -> Option<String> {
+    for candidate in [dir.join("AGENTS.md"), dir.join(".rkat/AGENTS.md")] {
+        if let Some(content) = load_agents_md_file(&candidate).await {
+            return Some(content);
+        }
+    }
+    None
 }
 
 async fn load_agents_md_file(path: &Path) -> Option<String> {
@@ -261,6 +263,22 @@ mod tests {
         let agents_section_start = result.find("# Project Instructions").unwrap();
         let agents_content = &result[agents_section_start..];
         assert!(agents_content.len() <= AGENTS_MD_MAX_BYTES + 100);
+    }
+
+    #[tokio::test]
+    async fn test_context_root_agents_md_falls_back_when_root_file_is_unusable() {
+        let temp = TempDir::new().unwrap();
+        let agents_path = temp.path().join("AGENTS.md");
+        tokio::fs::write(&agents_path, [0xff, 0xfe]).await.unwrap();
+        let rkat_dir = temp.path().join(".rkat");
+        tokio::fs::create_dir_all(&rkat_dir).await.unwrap();
+        tokio::fs::write(rkat_dir.join("AGENTS.md"), "Fallback instructions")
+            .await
+            .unwrap();
+
+        let config = default_config();
+        let result = assemble_system_prompt(&config, None, Some(temp.path()), &[], "").await;
+        assert!(result.contains("Fallback instructions"));
     }
 
     // --- Precedence level 4: default prompt ---

--- a/meerkat/src/prompt_assembly.rs
+++ b/meerkat/src/prompt_assembly.rs
@@ -10,8 +10,8 @@
 //! 5. Config-level tool instructions (`config.agent.tool_instructions`).
 //! 6. Dispatcher-provided tool usage instructions (appended last).
 
-use meerkat_core::{Config, SystemPromptConfig};
-use std::path::Path;
+use meerkat_core::{Config, SystemPromptConfig, prompt::normalize_agents_md_content};
+use std::path::{Path, PathBuf};
 
 /// Assemble the final system prompt. Single canonical path.
 ///
@@ -30,12 +30,8 @@ pub async fn assemble_system_prompt(
         return append_sections(prompt, extra_sections, &[], tool_usage_instructions);
     }
 
-    // 2-4. Use SystemPromptConfig to compose the base prompt.
-    //
-    // Wire config overrides INTO SystemPromptConfig rather than bypassing it.
-    // This preserves AGENTS.md loading when config-level overrides are set —
-    // a user setting `agent.system_prompt` in config wants to override the
-    // DEFAULT prompt, not lose AGENTS.md content.
+    // 2-4. This crate owns filesystem reads and prompt precedence, then passes
+    // already-loaded content into core's pure renderer.
     let mut spc = SystemPromptConfig::new();
 
     // 2. Config-level file override → feeds into SystemPromptConfig.
@@ -54,16 +50,11 @@ pub async fn assemble_system_prompt(
     }
 
     // AGENTS.md is resolved only from explicit context roots.
-    if let Some(context) = context_root {
-        if let Some(project_agents) = meerkat_core::prompt::find_project_agents_md_in(context) {
-            spc = spc.with_project_agents_md(project_agents);
-        } else {
-            spc = spc.with_project_agents_md(context.join("AGENTS.md"));
-        }
-        // Disable global AGENTS.md lookup.
-        spc = spc.with_global_agents_md(context.join(".rkat/__disabled_global_agents__.md"));
-    } else {
-        spc = spc.without_agents_md();
+    if let Some(context) = context_root
+        && let Some(project_agents) = find_project_agents_md_in(context)
+        && let Some(content) = load_agents_md_file(&project_agents).await
+    {
+        spc = spc.with_project_agents_md_content(content);
     }
 
     // 4. compose() uses the override if set, otherwise DEFAULT_SYSTEM_PROMPT.
@@ -84,6 +75,21 @@ pub async fn assemble_system_prompt(
         &config_tool_sections,
         tool_usage_instructions,
     )
+}
+
+fn find_project_agents_md_in(dir: &Path) -> Option<PathBuf> {
+    [dir.join("AGENTS.md"), dir.join(".rkat/AGENTS.md")]
+        .into_iter()
+        .find(|candidate| candidate.exists())
+}
+
+async fn load_agents_md_file(path: &Path) -> Option<String> {
+    if !tokio::fs::try_exists(path).await.ok()? {
+        return None;
+    }
+
+    let content = tokio::fs::read_to_string(path).await.ok()?;
+    normalize_agents_md_content(&content)
 }
 
 /// Append extra sections and tool instructions to a base prompt.
@@ -117,7 +123,7 @@ fn append_sections(
 #[allow(clippy::unwrap_used, clippy::expect_used)]
 mod tests {
     use super::*;
-    use meerkat_core::prompt::DEFAULT_SYSTEM_PROMPT;
+    use meerkat_core::prompt::{AGENTS_MD_MAX_BYTES, DEFAULT_SYSTEM_PROMPT};
     use std::path::PathBuf;
     use tempfile::TempDir;
 
@@ -220,6 +226,41 @@ mod tests {
         let result = assemble_system_prompt(&config, None, None, &[], "").await;
         assert!(result.contains("Inline prompt"));
         assert!(!result.contains(DEFAULT_SYSTEM_PROMPT));
+    }
+
+    #[tokio::test]
+    async fn test_context_root_agents_md_appended_to_config_inline() {
+        let temp = TempDir::new().unwrap();
+        let agents_path = temp.path().join("AGENTS.md");
+        tokio::fs::write(&agents_path, "Context root instructions")
+            .await
+            .unwrap();
+
+        let mut config = default_config();
+        config.agent.system_prompt = Some("Inline prompt".to_string());
+
+        let result = assemble_system_prompt(&config, None, Some(temp.path()), &[], "").await;
+        assert!(result.contains("Inline prompt"));
+        assert!(result.contains("Context root instructions"));
+        assert!(!result.contains(DEFAULT_SYSTEM_PROMPT));
+        let inline_pos = result.find("Inline prompt").unwrap();
+        let agents_pos = result.find("Context root instructions").unwrap();
+        assert!(inline_pos < agents_pos);
+    }
+
+    #[tokio::test]
+    async fn test_context_root_agents_md_size_limit_owned_by_prompt_assembly() {
+        let temp = TempDir::new().unwrap();
+        let agents_path = temp.path().join("AGENTS.md");
+        tokio::fs::write(&agents_path, "x".repeat(AGENTS_MD_MAX_BYTES + 1000))
+            .await
+            .unwrap();
+
+        let config = default_config();
+        let result = assemble_system_prompt(&config, None, Some(temp.path()), &[], "").await;
+        let agents_section_start = result.find("# Project Instructions").unwrap();
+        let agents_content = &result[agents_section_start..];
+        assert!(agents_content.len() <= AGENTS_MD_MAX_BYTES + 100);
     }
 
     // --- Precedence level 4: default prompt ---


### PR DESCRIPTION
## Summary
- add atomic scoped memory batch indexing for compaction discards and cover mid-batch failure recovery
- make HNSW memory recall rank scoped persisted candidates before applying limits
- move core prompt rendering to pure loaded-content composition while `meerkat` owns filesystem prompt assembly precedence
- centralize structured-output validation, retry prompts, and extraction result state in `agent/extraction.rs`

## Dogma Row Verification
- `Compaction memory index failure leaves partial projection while preserving source history`: still present; fixed, not skipped.
- `HNSW memory search scopes after global candidate selection`: still present; fixed, not skipped.
- `Core prompt assembly owns filesystem and duplicate prompt precedence`: still present; fixed, not skipped.
- `Structured-output extraction keeps validation/result/retry prompt truth in agent shell`: still present; fixed, not skipped.

Note: `/Users/luka/.codex/dogma-violations.md` was not present in this Linux workspace, so verification was against the issue row titles and current `origin/main` code.

## Validation
- `./scripts/repo-cargo test -p meerkat-core memory_index_failure -- --nocapture`
- `./scripts/repo-cargo test -p meerkat-memory hnsw -- --nocapture`
- `./scripts/repo-cargo test -p meerkat-core extraction -- --nocapture`
- `./scripts/repo-cargo test -p meerkat prompt_assembly -- --nocapture`
- `./scripts/repo-cargo test -p meerkat-core prompt -- --nocapture`
- `git diff --check`
- `make check`
- `make test`
- `make lint`