### PR TITLE
Fix runtime control authority projection

### DIFF
--- a/meerkat-runtime/BUILD.bazel
+++ b/meerkat-runtime/BUILD.bazel
@@ -39,6 +39,7 @@ rust_library(
     edition = "2024",
     compile_data = [
         "Cargo.toml",
+        "src/meerkat_machine/dispatch_ingress.rs",
     ],
     srcs = glob(["src/**/*.rs"]),
     visibility = ["//visibility:public"],
@@ -77,6 +78,7 @@ rust_test(
     edition = "2024",
     compile_data = [
         "Cargo.toml",
+        "src/meerkat_machine/dispatch_ingress.rs",
     ],
     srcs = glob(["src/**/*.rs"]),
     visibility = ["//visibility:public"],
@@ -133,6 +135,7 @@ rust_test(
     edition = "2024",
     compile_data = [
         "Cargo.toml",
+        "src/meerkat_machine/dispatch_ingress.rs",
     ],
     srcs = [
         "tests/auth_reauth_notice.rs",
@@ -193,6 +196,7 @@ rust_test(
     edition = "2024",
     compile_data = [
         "Cargo.toml",
+        "src/meerkat_machine/dispatch_ingress.rs",
     ],
     srcs = [
         "tests/composition_dispatch_is_the_path.rs",
@@ -252,6 +256,7 @@ rust_test(
     edition = "2024",
     compile_data = [
         "Cargo.toml",
+        "src/meerkat_machine/dispatch_ingress.rs",
     ],
     srcs = [
         "tests/composition_driver_contract.rs",
@@ -311,6 +316,7 @@ rust_test(
     edition = "2024",
     compile_data = [
         "Cargo.toml",
+        "src/meerkat_machine/dispatch_ingress.rs",
     ],
     srcs = [
         "tests/control_plane_contract.rs",
@@ -368,6 +374,7 @@ rust_test(
     edition = "2024",
     compile_data = [
         "Cargo.toml",
+        "src/meerkat_machine/dispatch_ingress.rs",
     ],
     srcs = [
         "tests/detached_wake_contract.rs",
@@ -425,6 +432,7 @@ rust_test(
     edition = "2024",
     compile_data = [
         "Cargo.toml",
+        "src/meerkat_machine/dispatch_ingress.rs",
     ],
     srcs = [
         "tests/driver_ephemeral.rs",
@@ -482,6 +490,7 @@ rust_test(
     edition = "2024",
     compile_data = [
         "Cargo.toml",
+        "src/meerkat_machine/dispatch_ingress.rs",
     ],
     srcs = [
         "tests/driver_persistent.rs",
@@ -539,6 +548,7 @@ rust_test(
     edition = "2024",
     compile_data = [
         "Cargo.toml",
+        "src/meerkat_machine/dispatch_ingress.rs",
     ],
     srcs = [
         "tests/handles_dispatch_through_dispatcher.rs",
@@ -601,6 +611,7 @@ rust_test(
     edition = "2024",
     compile_data = [
         "Cargo.toml",
+        "src/meerkat_machine/dispatch_ingress.rs",
     ],
     srcs = [
         "tests/meerkat_machine.rs",
@@ -658,6 +669,7 @@ rust_test(
     edition = "2024",
     compile_data = [
         "Cargo.toml",
+        "src/meerkat_machine/dispatch_ingress.rs",
     ],
     srcs = [
         "tests/ops_lifecycle_contract.rs",
@@ -715,6 +727,7 @@ rust_test(
     edition = "2024",
     compile_data = [
         "Cargo.toml",
+        "src/meerkat_machine/dispatch_ingress.rs",
     ],
     srcs = [
         "tests/ops_lifecycle_persistence.rs",
@@ -772,6 +785,7 @@ rust_test(
     edition = "2024",
     compile_data = [
         "Cargo.toml",
+        "src/meerkat_machine/dispatch_ingress.rs",
     ],
     srcs = [
         "tests/peer_handling_mode_contract.rs",
@@ -829,6 +843,7 @@ rust_test(
     edition = "2024",
     compile_data = [
         "Cargo.toml",
+        "src/meerkat_machine/dispatch_ingress.rs",
     ],
     srcs = [
         "tests/peer_interaction_dsl.rs",
@@ -886,6 +901,7 @@ rust_test(
     edition = "2024",
     compile_data = [
         "Cargo.toml",
+        "src/meerkat_machine/dispatch_ingress.rs",
     ],
     srcs = [
         "tests/peer_projection_dsl.rs",
@@ -943,6 +959,7 @@ rust_test(
     edition = "2024",
     compile_data = [
         "Cargo.toml",
+        "src/meerkat_machine/dispatch_ingress.rs",
     ],
     srcs = [
         "tests/peer_projection_producer_wiring.rs",
@@ -1002,6 +1019,7 @@ rust_test(
     edition = "2024",
     compile_data = [
         "Cargo.toml",
+        "src/meerkat_machine/dispatch_ingress.rs",
     ],
     srcs = [
         "tests/recovery_contract.rs",
@@ -1059,6 +1077,7 @@ rust_test(
     edition = "2024",
     compile_data = [
         "Cargo.toml",
+        "src/meerkat_machine/dispatch_ingress.rs",
     ],
     srcs = [
         "tests/recovery_replay.rs",
@@ -1116,6 +1135,7 @@ rust_test(
     edition = "2024",
     compile_data = [
         "Cargo.toml",
+        "src/meerkat_machine/dispatch_ingress.rs",
     ],
     srcs = [
         "tests/regression_comms_runtime.rs",
@@ -1175,6 +1195,7 @@ rust_test(
     edition = "2024",
     compile_data = [
         "Cargo.toml",
+        "src/meerkat_machine/dispatch_ingress.rs",
     ],
     srcs = [
         "tests/runtime_bindings_contract.rs",
@@ -1232,6 +1253,7 @@ rust_test(
     edition = "2024",
     compile_data = [
         "Cargo.toml",
+        "src/meerkat_machine/dispatch_ingress.rs",
     ],
     srcs = [
         "tests/runtime_ingress_control.rs",
@@ -1289,6 +1311,7 @@ rust_test(
     edition = "2024",
     compile_data = [
         "Cargo.toml",
+        "src/meerkat_machine/dispatch_ingress.rs",
     ],
     srcs = [
         "tests/session_context_observer_race.rs",
@@ -1346,6 +1369,7 @@ rust_test(
     edition = "2024",
     compile_data = [
         "Cargo.toml",
+        "src/meerkat_machine/dispatch_ingress.rs",
     ],
     srcs = [
         "tests/trust_reconcile_add_failure.rs",
@@ -1406,6 +1430,7 @@ rust_test(
     edition = "2024",
     compile_data = [
         "Cargo.toml",
+        "src/meerkat_machine/dispatch_ingress.rs",
     ],
     srcs = [
         "tests/trust_reconcile_concurrency.rs",
@@ -1466,6 +1491,7 @@ rust_test(
     edition = "2024",
     compile_data = [
         "Cargo.toml",
+        "src/meerkat_machine/dispatch_ingress.rs",
     ],
     srcs = [
         "tests/turn_metadata_single_construction_site.rs",

--- a/meerkat-runtime/src/control_plane.rs
+++ b/meerkat-runtime/src/control_plane.rs
@@ -11,21 +11,21 @@ use meerkat_core::lifecycle::run_control::RunControlCommand;
 use meerkat_core::types::SessionId;
 
 use crate::meerkat_machine::{MeerkatMachine, SharedCompletionRegistry, SharedDriver};
-use crate::runtime_state::RuntimeState;
 use crate::tokio::sync::mpsc;
 use crate::traits::RuntimeDriverError;
 
-async fn mark_runtime_stopped(driver: &SharedDriver) -> Result<(), RuntimeDriverError> {
+async fn finalize_runtime_stopped(driver: &SharedDriver) -> Result<(), RuntimeDriverError> {
     let mut driver = driver.lock().await;
     if matches!(
         driver.as_driver().runtime_state(),
-        RuntimeState::Stopped | RuntimeState::Destroyed
+        crate::RuntimeState::Destroyed
     ) {
         return Ok(());
     }
 
-    driver.set_control_projection(RuntimeState::Stopped, None, None);
-    driver.finalize_stop_runtime().await
+    driver.finalize_stop_runtime().await?;
+    driver.sync_control_projection_from_dsl_authority();
+    Ok(())
 }
 
 /// Deliver one executor control command and report whether the runtime loop
@@ -48,7 +48,11 @@ pub(crate) async fn apply_executor_control(
         tracing::warn!(error = %err, "failed to deliver out-of-band executor control");
     }
 
-    if should_stop && let Err(err) = mark_runtime_stopped(driver).await {
+    if should_stop && let Some(machine) = machine.upgrade() {
+        machine.notify_runtime_executor_exited(session_id).await;
+    }
+
+    if should_stop && let Err(err) = finalize_runtime_stopped(driver).await {
         tracing::warn!(
             error = %err,
             "failed to mark runtime stopped after stop-runtime-executor command"
@@ -58,10 +62,6 @@ pub(crate) async fn apply_executor_control(
     if should_stop && let Some(completions) = completions {
         let mut reg = completions.lock().await;
         reg.resolve_all_terminated("runtime stopped");
-    }
-
-    if should_stop && let Some(machine) = machine.upgrade() {
-        machine.notify_runtime_executor_exited(session_id).await;
     }
 
     should_stop

--- a/meerkat-runtime/src/driver/ephemeral.rs
+++ b/meerkat-runtime/src/driver/ephemeral.rs
@@ -1090,6 +1090,37 @@ impl EphemeralRuntimeDriver {
         current_run_id: Option<RunId>,
         pre_run_phase: Option<RuntimeState>,
     ) {
+        if self.control_snapshot().phase == next_phase {
+            self.write_control_projection().phase = next_phase;
+        } else {
+            self.transition_phase(next_phase);
+        }
+        let mut control = self.write_control_projection();
+        control.current_run_id = current_run_id;
+        control.pre_run_phase = pre_run_phase;
+    }
+
+    pub(crate) fn sync_control_projection_from_dsl_authority(&mut self) {
+        let (phase, current_run_id, pre_run_phase) = {
+            let authority = self.shared_dsl_authority();
+            let authority = authority
+                .lock()
+                .unwrap_or_else(std::sync::PoisonError::into_inner);
+            (
+                crate::meerkat_machine::dsl_authority::runtime_phase_from_authority(&authority),
+                crate::meerkat_machine::dsl_authority::current_run_id_from_authority(&authority),
+                crate::meerkat_machine::dsl_authority::pre_run_phase_from_authority(&authority),
+            )
+        };
+        self.set_control_projection(phase, current_run_id, pre_run_phase);
+    }
+
+    pub(crate) fn force_runtime_authority(
+        &mut self,
+        next_phase: RuntimeState,
+        current_run_id: Option<RunId>,
+        pre_run_phase: Option<RuntimeState>,
+    ) {
         {
             let authority = self.shared_dsl_authority();
             let mut authority = authority
@@ -1103,15 +1134,35 @@ impl EphemeralRuntimeDriver {
             authority.state.pre_run_phase = pre_run_phase
                 .and_then(crate::meerkat_machine::dsl_authority::pre_run_phase_from_runtime_state);
         }
+        self.set_control_projection(next_phase, current_run_id, pre_run_phase);
+    }
 
-        if self.control_snapshot().phase == next_phase {
-            self.write_control_projection().phase = next_phase;
-        } else {
-            self.transition_phase(next_phase);
-        }
-        let mut control = self.write_control_projection();
-        control.current_run_id = current_run_id;
-        control.pre_run_phase = pre_run_phase;
+    #[doc(hidden)]
+    pub fn contract_force_runtime_authority(
+        &mut self,
+        next_phase: RuntimeState,
+        current_run_id: Option<RunId>,
+        pre_run_phase: Option<RuntimeState>,
+    ) {
+        self.force_runtime_authority(next_phase, current_run_id, pre_run_phase);
+    }
+
+    pub(crate) fn apply_runtime_executor_exited_authority(
+        &mut self,
+    ) -> Result<(), RuntimeDriverError> {
+        self.dsl_apply(
+            mm_dsl::MeerkatMachineInput::RuntimeExecutorExited,
+            "RuntimeExecutorExited",
+        )
+    }
+
+    pub(crate) fn apply_stop_runtime_executor_authority(
+        &mut self,
+    ) -> Result<(), RuntimeDriverError> {
+        self.dsl_apply(
+            mm_dsl::MeerkatMachineInput::StopRuntimeExecutor,
+            "StopRuntimeExecutor",
+        )
     }
     /// Drain and return the accumulated post-admission signal.
     ///
@@ -1690,7 +1741,7 @@ impl EphemeralRuntimeDriver {
     }
 
     pub(crate) fn resolve_admission(&self, input: &Input) -> crate::accept::ResolvedAdmission {
-        let runtime_idle = self.read_control_projection().phase.is_idle_or_attached();
+        let runtime_idle = self.runtime_phase_snapshot().is_idle_or_attached();
         self.resolve_admission_for_runtime_idle(input, runtime_idle)
     }
 
@@ -1699,10 +1750,11 @@ impl EphemeralRuntimeDriver {
         input: Input,
         resolved: crate::accept::ResolvedAdmission,
     ) -> Result<AcceptOutcome, RuntimeDriverError> {
-        match self.read_control_projection().phase {
+        let runtime_phase = self.runtime_phase_snapshot();
+        match runtime_phase {
             RuntimeState::Retired | RuntimeState::Stopped => {
                 return Err(RuntimeDriverError::NotReady {
-                    state: self.read_control_projection().phase,
+                    state: runtime_phase,
                 });
             }
             RuntimeState::Destroyed => return Err(RuntimeDriverError::Destroyed),
@@ -1773,7 +1825,7 @@ impl EphemeralRuntimeDriver {
             },
         ));
 
-        let runtime_idle = self.read_control_projection().phase.is_idle_or_attached();
+        let runtime_idle = runtime_phase.is_idle_or_attached();
         let handling_mode = resolved.handling_mode;
         let content_shape = ContentShape(input.kind_id().to_string());
         let is_prompt = matches!(input, Input::Prompt(_));
@@ -2123,6 +2175,7 @@ mod tests {
         Input, InputDurability, InputHeader, InputOrigin, InputVisibility, PeerConvention,
         PeerInput,
     };
+    use crate::traits::RuntimeDriver;
     use crate::{RuntimeState, WakeMode};
     use chrono::Utc;
     use meerkat_core::lifecycle::{InputId, RunId};
@@ -2150,10 +2203,64 @@ mod tests {
         })
     }
 
+    fn force_control_shadow(
+        driver: &mut EphemeralRuntimeDriver,
+        phase: RuntimeState,
+        current_run_id: Option<RunId>,
+        pre_run_phase: Option<RuntimeState>,
+    ) {
+        let mut control = driver.write_control_projection();
+        control.phase = phase;
+        control.current_run_id = current_run_id;
+        control.pre_run_phase = pre_run_phase;
+    }
+
+    #[test]
+    fn set_control_projection_does_not_write_dsl_authority() {
+        let mut driver = EphemeralRuntimeDriver::new(LogicalRuntimeId::new("projection-only"));
+        let run_id = RunId::new();
+
+        driver.set_control_projection(
+            RuntimeState::Running,
+            Some(run_id),
+            Some(RuntimeState::Attached),
+        );
+
+        assert_eq!(
+            driver.runtime_phase_snapshot(),
+            RuntimeState::Idle,
+            "control projection writes must not mutate DSL lifecycle truth",
+        );
+        assert_eq!(
+            driver.current_run_id(),
+            None,
+            "control projection writes must not mutate DSL run binding truth",
+        );
+        assert_eq!(
+            driver.control_snapshot().phase,
+            RuntimeState::Running,
+            "the shell projection still records the mechanical projection",
+        );
+    }
+
+    #[tokio::test]
+    async fn direct_accept_uses_dsl_phase_not_control_projection_shadow() {
+        let mut driver = EphemeralRuntimeDriver::new(LogicalRuntimeId::new("admission-shadow"));
+        force_control_shadow(&mut driver, RuntimeState::Stopped, None, None);
+
+        let outcome = driver.accept_input(peer_message_input()).await.unwrap();
+
+        assert!(
+            outcome.is_accepted(),
+            "direct RuntimeDriver admission should follow DSL phase, not a stale control shadow",
+        );
+    }
+
     #[test]
     fn resolve_admission_for_runtime_idle_uses_explicit_machine_phase_not_control_projection() {
         let mut driver = EphemeralRuntimeDriver::new(LogicalRuntimeId::new("phase-drift"));
-        driver.set_control_projection(
+        force_control_shadow(
+            &mut driver,
             RuntimeState::Running,
             Some(RunId::new()),
             Some(RuntimeState::Attached),
@@ -2161,8 +2268,8 @@ mod tests {
 
         let input = peer_message_input();
         let projected = driver.resolve_admission(&input);
-        assert_eq!(projected.policy.wake_mode, WakeMode::InterruptYielding);
-        assert!(projected.coarse_flags.interrupt_yielding);
+        assert_eq!(projected.policy.wake_mode, WakeMode::WakeIfIdle);
+        assert!(!projected.coarse_flags.interrupt_yielding);
 
         let machine_owned = driver.resolve_admission_for_runtime_idle(&input, true);
         assert_eq!(machine_owned.policy.wake_mode, WakeMode::WakeIfIdle);

--- a/meerkat-runtime/src/driver/persistent.rs
+++ b/meerkat-runtime/src/driver/persistent.rs
@@ -154,6 +154,27 @@ impl PersistentRuntimeDriver {
         self.set_control_projection(next_phase, current_run_id, pre_run_phase);
     }
 
+    #[doc(hidden)]
+    pub fn contract_force_runtime_authority(
+        &mut self,
+        next_phase: RuntimeState,
+        current_run_id: Option<RunId>,
+        pre_run_phase: Option<RuntimeState>,
+    ) {
+        self.inner
+            .contract_force_runtime_authority(next_phase, current_run_id, pre_run_phase);
+    }
+
+    pub(crate) fn sync_control_projection_from_dsl_authority(&mut self) {
+        self.inner.sync_control_projection_from_dsl_authority();
+    }
+
+    pub(crate) fn apply_runtime_executor_exited_authority(
+        &mut self,
+    ) -> Result<(), RuntimeDriverError> {
+        self.inner.apply_runtime_executor_exited_authority()
+    }
+
     /// Get pending events (delegates to inner).
     pub fn drain_events(&mut self) -> Vec<RuntimeEventEnvelope> {
         self.inner.drain_events()
@@ -486,6 +507,7 @@ impl PersistentRuntimeDriver {
 
     pub async fn finalize_stop_runtime(&mut self) -> Result<(), RuntimeDriverError> {
         let checkpoint = self.inner.rollback_snapshot();
+        self.inner.sync_control_projection_from_dsl_authority();
         self.inner.stop_runtime_cleanup();
         self.commit_lifecycle_with_rollback(
             checkpoint,
@@ -497,8 +519,9 @@ impl PersistentRuntimeDriver {
 
     pub(crate) async fn realize_stop_lifecycle(&mut self) -> Result<(), RuntimeDriverError> {
         let checkpoint = self.inner.rollback_snapshot();
-        self.inner
-            .set_control_projection(RuntimeState::Stopped, None, None);
+        self.inner.apply_stop_runtime_executor_authority()?;
+        let _ = self.inner.apply_runtime_executor_exited_authority();
+        self.inner.sync_control_projection_from_dsl_authority();
         self.inner.stop_runtime_cleanup();
         self.commit_lifecycle_with_rollback(checkpoint, RuntimeState::Stopped, "stop")
             .await

--- a/meerkat-runtime/src/meerkat_machine/dispatch_control.rs
+++ b/meerkat-runtime/src/meerkat_machine/dispatch_control.rs
@@ -419,17 +419,12 @@ impl MeerkatMachine {
                 if matches!(state, RuntimeState::Initializing) {
                     return Err(RuntimeControlPlaneError::InvalidState { state });
                 }
-                self.preview_session_dsl_input(
-                    &session_id,
-                    crate::meerkat_machine::dsl::MeerkatMachineInput::Destroy {
-                        session_id: crate::meerkat_machine::dsl::SessionId::from_domain(
-                            &session_id,
-                        ),
-                    },
-                    "Destroy",
-                )
-                .await
-                .map_err(RuntimeControlPlaneError::Internal)?;
+                let destroy_input = crate::meerkat_machine::dsl::MeerkatMachineInput::Destroy {
+                    session_id: crate::meerkat_machine::dsl::SessionId::from_domain(&session_id),
+                };
+                self.preview_session_dsl_input(&session_id, destroy_input.clone(), "Destroy")
+                    .await
+                    .map_err(RuntimeControlPlaneError::Internal)?;
 
                 let mut drv = driver.lock().await;
                 let report = match machine_destroy(&mut drv).await {
@@ -438,17 +433,13 @@ impl MeerkatMachine {
                 };
                 drop(drv);
 
-                self.apply_session_dsl_input(
-                    &session_id,
-                    crate::meerkat_machine::dsl::MeerkatMachineInput::Destroy {
-                        session_id: crate::meerkat_machine::dsl::SessionId::from_domain(
-                            &session_id,
-                        ),
-                    },
-                    "Destroy",
-                )
-                .await
-                .map_err(RuntimeControlPlaneError::Internal)?;
+                self.apply_session_dsl_input(&session_id, destroy_input, "Destroy")
+                    .await
+                    .map_err(RuntimeControlPlaneError::Internal)?;
+                driver
+                    .lock()
+                    .await
+                    .sync_control_projection_from_dsl_authority();
 
                 let mut comp = completions.lock().await;
                 comp.resolve_all_terminated("runtime destroyed");

--- a/meerkat-runtime/src/meerkat_machine/dispatch_ingress.rs
+++ b/meerkat-runtime/src/meerkat_machine/dispatch_ingress.rs
@@ -363,41 +363,27 @@ impl MeerkatMachine {
                     return Err(err);
                 }
 
-                // Driver preconditions above are read-only and run before the
-                // machine transition. Once `Prepare` is accepted, every later
-                // failure is an effect-realization failure and must explicitly
-                // unwind both sides rather than treating driver projection as a
-                // veto over an accepted transition.
                 let run_id = RunId::new();
-                let previous_dsl_state = match self
-                    .stage_session_dsl_input(
-                        &session_id,
-                        crate::meerkat_machine::dsl::MeerkatMachineInput::Prepare {
-                            session_id: crate::meerkat_machine::dsl::SessionId::from_domain(
-                                &session_id,
-                            ),
-                            run_id: crate::meerkat_machine::dsl::RunId::from_domain(&run_id),
-                        },
-                        "Prepare",
-                    )
-                    .await
-                {
-                    Ok(state) => state,
-                    Err(reason) => {
-                        tracing::error!(
-                            error = %reason,
-                            session_id = %session_id,
-                            "DSL rejected Prepare input"
-                        );
-                        let state = self
-                            .existing_session_runtime_state(&session_id)
-                            .await
-                            .unwrap_or(RuntimeState::Destroyed);
-                        return Err(Self::normalize_destroyed_error(
-                            RuntimeDriverError::NotReady { state },
-                        ));
-                    }
-                };
+                self.preview_session_dsl_input(
+                    &session_id,
+                    crate::meerkat_machine::dsl::MeerkatMachineInput::Prepare {
+                        session_id: crate::meerkat_machine::dsl::SessionId::from_domain(
+                            &session_id,
+                        ),
+                        run_id: crate::meerkat_machine::dsl::RunId::from_domain(&run_id),
+                    },
+                    "Prepare",
+                )
+                .await
+                .map_err(|reason| {
+                    tracing::error!(
+                        error = %reason,
+                        session_id = %session_id,
+                        "DSL rejected Prepare input"
+                    );
+                    let state = visible_state;
+                    Self::normalize_destroyed_error(RuntimeDriverError::NotReady { state })
+                })?;
 
                 let prepared = {
                     let mut driver = driver.lock().await;
@@ -408,17 +394,11 @@ impl MeerkatMachine {
                         .map_err(Self::normalize_destroyed_error)
                     {
                         Ok(o) => o,
-                        Err(err) => {
-                            self.restore_session_dsl_state(&session_id, previous_dsl_state)
-                                .await;
-                            return Err(err);
-                        }
+                        Err(err) => return Err(err),
                     };
                     let input_id = match outcome {
                         AcceptOutcome::Accepted { input_id, .. } => input_id,
                         AcceptOutcome::Deduplicated { existing_id, .. } => {
-                            self.restore_session_dsl_state(&session_id, previous_dsl_state)
-                                .await;
                             return Err(RuntimeDriverError::ValidationFailed {
                                 reason: format!(
                                     "accept_input_and_run does not support deduplicated admission; existing input {existing_id} already owns execution"
@@ -426,8 +406,6 @@ impl MeerkatMachine {
                             });
                         }
                         AcceptOutcome::Rejected { reason } => {
-                            self.restore_session_dsl_state(&session_id, previous_dsl_state)
-                                .await;
                             return Err(RuntimeDriverError::ValidationFailed {
                                 reason: reason.to_string(),
                             });
@@ -437,16 +415,12 @@ impl MeerkatMachine {
                     let (dequeued_id, dequeued_input) = match driver.dequeue_next() {
                         Some(pair) => pair,
                         None => {
-                            self.restore_session_dsl_state(&session_id, previous_dsl_state)
-                                .await;
                             return Err(RuntimeDriverError::Internal(
                                 "accepted input was not queued for execution".into(),
                             ));
                         }
                     };
                     if dequeued_id != input_id {
-                        self.restore_session_dsl_state(&session_id, previous_dsl_state)
-                            .await;
                         return Err(Self::normalize_destroyed_error(
                             RuntimeDriverError::NotReady {
                                 state: self
@@ -458,8 +432,6 @@ impl MeerkatMachine {
                     }
 
                     if let Err(err) = machine_begin_run(&mut driver, run_id.clone()) {
-                        self.restore_session_dsl_state(&session_id, previous_dsl_state)
-                            .await;
                         return Err(RuntimeDriverError::Internal(format!(
                             "failed to start runtime run: {err}"
                         )));
@@ -475,8 +447,6 @@ impl MeerkatMachine {
                             crate::meerkat_machine::driver::RunReturnDisposition::Fail,
                             next_phase,
                         );
-                        self.restore_session_dsl_state(&session_id, previous_dsl_state)
-                            .await;
                         return Err(RuntimeDriverError::Internal(format!(
                             "failed to stage accepted input: {err}"
                         )));
@@ -505,8 +475,6 @@ impl MeerkatMachine {
                 run_id,
                 output,
             } => {
-                let shadow_input_id = input_id.clone();
-                let shadow_run_id = run_id.clone();
                 let driver = {
                     let sessions = self.sessions.read().await;
                     sessions
@@ -524,21 +492,6 @@ impl MeerkatMachine {
                     None => None,
                 };
 
-                let previous_dsl_state = self
-                    .stage_session_dsl_input(
-                        &session_id,
-                        crate::meerkat_machine::dsl::MeerkatMachineInput::Commit {
-                            input_id: crate::meerkat_machine::dsl::InputId::from_domain(
-                                &shadow_input_id,
-                            ),
-                            run_id: crate::meerkat_machine::dsl::RunId::from_domain(&shadow_run_id),
-                        },
-                        "Commit",
-                    )
-                    .await
-                    .map_err(|reason| RuntimeDriverError::ValidationFailed { reason })?;
-
-                let commit_run_id = run_id.clone();
                 if let Err(err) = commit_runtime_loop_run(
                     &driver,
                     run_id,
@@ -548,28 +501,6 @@ impl MeerkatMachine {
                 )
                 .await
                 {
-                    let _ = previous_dsl_state;
-                    // Driver already unwinds the shared canonical ingress state
-                    // on commit failure. Only the coarse Fail transition remains
-                    // to keep the top-level machine phase in sync.
-                    if let Err(dsl_err) = self
-                        .stage_session_dsl_input(
-                            &session_id,
-                            crate::meerkat_machine::dsl::MeerkatMachineInput::Fail {
-                                run_id: crate::meerkat_machine::dsl::RunId::from_domain(
-                                    &commit_run_id,
-                                ),
-                            },
-                            "Fail(commit_unwind)",
-                        )
-                        .await
-                    {
-                        tracing::warn!(
-                            session_id = %session_id,
-                            error = %dsl_err,
-                            "DSL rejected Fail unwind after commit failure"
-                        );
-                    }
                     let should_unregister =
                         !err.to_string().contains("runtime boundary commit failed");
                     if should_unregister {
@@ -587,7 +518,6 @@ impl MeerkatMachine {
                 run_id,
                 error,
             } => {
-                let shadow_fail_run_id = run_id.clone();
                 let driver = {
                     let sessions = self.sessions.read().await;
                     sessions
@@ -605,22 +535,7 @@ impl MeerkatMachine {
                     None => None,
                 };
 
-                let previous_dsl_state = self
-                    .stage_session_dsl_input(
-                        &session_id,
-                        crate::meerkat_machine::dsl::MeerkatMachineInput::Fail {
-                            run_id: crate::meerkat_machine::dsl::RunId::from_domain(
-                                &shadow_fail_run_id,
-                            ),
-                        },
-                        "Fail",
-                    )
-                    .await
-                    .map_err(|reason| RuntimeDriverError::ValidationFailed { reason })?;
-
                 if let Err(run_err) = fail_runtime_loop_run(&driver, run_id, error).await {
-                    self.restore_session_dsl_state(&session_id, previous_dsl_state)
-                        .await;
                     self.unregister_session_inner(&session_id).await;
                     return Err(RuntimeDriverError::Internal(format!(
                         "failed to persist runtime failure snapshot: {run_err}"

--- a/meerkat-runtime/src/meerkat_machine/driver.rs
+++ b/meerkat-runtime/src/meerkat_machine/driver.rs
@@ -314,6 +314,13 @@ impl DriverEntry {
         }
     }
 
+    pub(crate) fn sync_control_projection_from_dsl_authority(&mut self) {
+        match self {
+            DriverEntry::Ephemeral(d) => d.sync_control_projection_from_dsl_authority(),
+            DriverEntry::Persistent(d) => d.sync_control_projection_from_dsl_authority(),
+        }
+    }
+
     pub(crate) fn control_projection_handle(
         &self,
     ) -> Arc<std::sync::RwLock<crate::driver::ephemeral::RuntimeControlProjection>> {
@@ -609,11 +616,9 @@ pub(crate) fn machine_apply_run_return_projection(
     // DSL input; the DSL's `CommitRunningTo{Idle,Attached,Retired}` /
     // `FailRunningTo{Idle,Attached,Retired}` transitions dispatch on
     // `pre_run_phase` (set by `Prepare` during `machine_begin_run`) and
-    // flip `lifecycle_phase` accordingly. The runtime-loop path now goes
-    // through this DSL transition uniformly with the dispatch-ingress
-    // Commit path. Idempotent when the dispatch-ingress Commit handler
-    // already staged Commit before entering here — the second apply hits
-    // `lifecycle_phase == Running` guard and no-ops.
+    // flip `lifecycle_phase` accordingly. The runtime-loop path owns this
+    // DSL transition uniformly; dispatch-ingress no longer snapshots or
+    // pre-stages the return input.
     let authority = driver.shared_dsl_authority();
     {
         let mut auth = authority
@@ -635,7 +640,8 @@ pub(crate) fn machine_apply_run_return_projection(
 
     // Shell `control_projection` update is retained as mechanical event
     // plumbing. DSL's Commit/Fail transition is the authoritative
-    // lifecycle/run writer above; DriverEntry readers consult DSL state.
+    // lifecycle/run writer above; DriverEntry readers consult DSL state, so
+    // this projection must stay mechanical.
     driver.set_control_projection(next_phase, None, None);
     Ok(())
 }
@@ -1125,14 +1131,21 @@ pub(crate) fn machine_realize_recovered_runtime_state(
             let mut auth = authority
                 .lock()
                 .unwrap_or_else(std::sync::PoisonError::into_inner);
-            if let Some(session_id) = auth.state.session_id.clone() {
-                let _ = crate::meerkat_machine::dsl::MeerkatMachineMutator::apply(
+            let applied = if let Some(session_id) = auth.state.session_id.clone() {
+                crate::meerkat_machine::dsl::MeerkatMachineMutator::apply(
                     &mut *auth,
                     crate::meerkat_machine::dsl::MeerkatMachineInput::Retire { session_id },
-                );
-            }
+                )
+                .is_ok()
+            } else {
+                false
+            };
             drop(auth);
-            driver.set_control_projection(RuntimeState::Retired, None, None);
+            if applied {
+                driver.sync_control_projection_from_dsl_authority();
+            } else {
+                driver.force_runtime_authority(RuntimeState::Retired, None, None);
+            }
         }
         RuntimeState::Stopped
             if driver.runtime_state() != RuntimeState::Stopped
@@ -1142,12 +1155,17 @@ pub(crate) fn machine_realize_recovered_runtime_state(
             let mut auth = authority
                 .lock()
                 .unwrap_or_else(std::sync::PoisonError::into_inner);
-            let _ = crate::meerkat_machine::dsl::MeerkatMachineMutator::apply(
+            let applied = crate::meerkat_machine::dsl::MeerkatMachineMutator::apply(
                 &mut *auth,
                 crate::meerkat_machine::dsl::MeerkatMachineInput::StopRuntimeExecutor,
-            );
+            )
+            .is_ok();
             drop(auth);
-            driver.set_control_projection(RuntimeState::Stopped, None, None);
+            if applied {
+                driver.sync_control_projection_from_dsl_authority();
+            } else {
+                driver.force_runtime_authority(RuntimeState::Stopped, None, None);
+            }
             driver.stop_runtime_cleanup();
         }
         RuntimeState::Destroyed if driver.runtime_state() != RuntimeState::Destroyed => {
@@ -1155,14 +1173,21 @@ pub(crate) fn machine_realize_recovered_runtime_state(
             let mut auth = authority
                 .lock()
                 .unwrap_or_else(std::sync::PoisonError::into_inner);
-            if let Some(session_id) = auth.state.session_id.clone() {
-                let _ = crate::meerkat_machine::dsl::MeerkatMachineMutator::apply(
+            let applied = if let Some(session_id) = auth.state.session_id.clone() {
+                crate::meerkat_machine::dsl::MeerkatMachineMutator::apply(
                     &mut *auth,
                     crate::meerkat_machine::dsl::MeerkatMachineInput::Destroy { session_id },
-                );
-            }
+                )
+                .is_ok()
+            } else {
+                false
+            };
             drop(auth);
-            driver.set_control_projection(RuntimeState::Destroyed, None, None);
+            if applied {
+                driver.sync_control_projection_from_dsl_authority();
+            } else {
+                driver.force_runtime_authority(RuntimeState::Destroyed, None, None);
+            }
             driver.destroy_cleanup();
         }
         _ => {}
@@ -1362,14 +1387,15 @@ pub(crate) async fn machine_stop_runtime(
 
     match driver {
         DriverEntry::Ephemeral(d) => {
-            // The session DSL has already accepted `StopRuntimeExecutor`
-            // before this realization path runs. Mirror that machine-owned
-            // terminal phase into the concrete projection before finalizing.
-            d.set_control_projection(RuntimeState::Stopped, None, None);
+            let _ = d.apply_runtime_executor_exited_authority();
+            d.sync_control_projection_from_dsl_authority();
             d.finalize_stop_runtime();
             Ok(())
         }
-        DriverEntry::Persistent(d) => d.realize_stop_lifecycle().await,
+        DriverEntry::Persistent(d) => {
+            let _ = d.apply_runtime_executor_exited_authority();
+            d.finalize_stop_runtime().await
+        }
     }
 }
 
@@ -1377,7 +1403,7 @@ pub(crate) async fn machine_destroy(
     driver: &mut DriverEntry,
 ) -> Result<DestroyReport, RuntimeDriverError> {
     match driver.runtime_state() {
-        RuntimeState::Initializing | RuntimeState::Destroyed => {
+        RuntimeState::Initializing => {
             return Err(RuntimeDriverError::Internal(
                 crate::runtime_state::RuntimeStateTransitionError {
                     from: driver.runtime_state(),
@@ -1390,10 +1416,13 @@ pub(crate) async fn machine_destroy(
         | RuntimeState::Attached
         | RuntimeState::Running
         | RuntimeState::Retired
-        | RuntimeState::Stopped => {}
+        | RuntimeState::Stopped
+        | RuntimeState::Destroyed => {}
     }
 
-    driver.destroy().await
+    let report = driver.destroy().await?;
+    driver.sync_control_projection_from_dsl_authority();
+    Ok(report)
 }
 
 pub(crate) async fn machine_retire(

--- a/meerkat-runtime/src/meerkat_machine/mod.rs
+++ b/meerkat-runtime/src/meerkat_machine/mod.rs
@@ -439,8 +439,11 @@ impl MeerkatMachine {
     /// runtime loop has realised an async stop into the driver's control
     /// projection. Called via `Weak<Self>` from `control_plane`.
     pub(crate) async fn notify_runtime_executor_exited(&self, session_id: &SessionId) {
-        let mut sessions = self.sessions.write().await;
-        if let Some(entry) = sessions.get_mut(session_id) {
+        let driver = {
+            let mut sessions = self.sessions.write().await;
+            let Some(entry) = sessions.get_mut(session_id) else {
+                return;
+            };
             let mut authority = entry
                 .dsl_authority
                 .lock()
@@ -455,7 +458,11 @@ impl MeerkatMachine {
                     "DSL rejected RuntimeExecutorExited (terminal or phase-not-covered)"
                 );
             }
-        }
+            Arc::clone(&entry.driver)
+        };
+
+        let mut driver = driver.lock().await;
+        driver.sync_control_projection_from_dsl_authority();
     }
 }
 

--- a/meerkat-runtime/src/meerkat_machine_tests.rs
+++ b/meerkat-runtime/src/meerkat_machine_tests.rs
@@ -49,6 +49,28 @@ fn realtime_policy(target_realtime_capable: bool) -> ModelRoutingRealtimePolicy 
     }
 }
 
+fn memory_blob_store() -> Arc<dyn meerkat_core::BlobStore> {
+    Arc::new(meerkat_store::MemoryBlobStore::new())
+}
+
+#[test]
+fn legacy_run_handler_does_not_restore_dsl_snapshots_by_hand() {
+    let source = include_str!("meerkat_machine/dispatch_ingress.rs");
+    let start = source
+        .find("pub(super) async fn execute_meerkat_machine_legacy_run_command")
+        .expect("legacy run handler should exist");
+    let legacy_run_handler = &source[start..];
+
+    assert!(
+        !legacy_run_handler.contains("previous_dsl_state"),
+        "legacy run must not manually snapshot DSL authority",
+    );
+    assert!(
+        !legacy_run_handler.contains("restore_session_dsl_state"),
+        "legacy run must not manually restore DSL authority",
+    );
+}
+
 fn finite_switch_request(
     n: u128,
     target_model: &str,
@@ -1960,6 +1982,43 @@ async fn meerkat_machine_spine_snapshot_clears_completion_waiters_after_destroy(
         }
         other => panic!("expected runtime destroyed termination, got {other:?}"),
     }
+}
+
+#[tokio::test]
+async fn persistent_destroy_synchronizes_driver_control_projection_shadow() {
+    let store = Arc::new(crate::store::InMemoryRuntimeStore::new());
+    let adapter = Arc::new(MeerkatMachine::persistent(
+        store as Arc<dyn crate::store::RuntimeStore>,
+        memory_blob_store(),
+    ));
+    let session_id = SessionId::new();
+
+    adapter.register_session(session_id.clone()).await;
+
+    let runtime_id = crate::identifiers::LogicalRuntimeId::new(session_id.to_string());
+    let report = crate::traits::RuntimeControlPlane::destroy(&*adapter, &runtime_id)
+        .await
+        .expect("persistent destroy should succeed");
+    assert_eq!(report.inputs_abandoned, 0);
+
+    let sessions = adapter.sessions.read().await;
+    let entry = sessions
+        .get(&session_id)
+        .expect("destroy keeps the session entry available for terminal snapshots");
+    assert_eq!(
+        entry.control_snapshot().phase,
+        RuntimeState::Destroyed,
+        "persistent destroy must not leave a stale driver-side control shadow",
+    );
+    let authority = entry
+        .dsl_authority
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner);
+    assert_eq!(
+        crate::meerkat_machine::dsl_authority::runtime_phase_from_authority(&authority),
+        RuntimeState::Destroyed,
+        "DSL remains the canonical destroyed authority",
+    );
 }
 
 #[tokio::test]

--- a/meerkat-runtime/tests/driver_ephemeral.rs
+++ b/meerkat-runtime/tests/driver_ephemeral.rs
@@ -106,7 +106,7 @@ fn assert_machine_owned_admission_signal(
 }
 
 fn bind_running(driver: &mut EphemeralRuntimeDriver, run_id: RunId, pre_run_phase: RuntimeState) {
-    driver.contract_set_control_projection(
+    driver.contract_force_runtime_authority(
         RuntimeState::Running,
         Some(run_id),
         Some(pre_run_phase),
@@ -114,27 +114,27 @@ fn bind_running(driver: &mut EphemeralRuntimeDriver, run_id: RunId, pre_run_phas
 }
 
 fn complete_run_projection(driver: &mut EphemeralRuntimeDriver, next_phase: RuntimeState) {
-    driver.contract_set_control_projection(next_phase, None, None);
+    driver.contract_force_runtime_authority(next_phase, None, None);
 }
 
 fn retire_runtime(driver: &mut EphemeralRuntimeDriver) -> meerkat_runtime::RetireReport {
-    driver.contract_set_control_projection(RuntimeState::Retired, None, None);
+    driver.contract_force_runtime_authority(RuntimeState::Retired, None, None);
     driver.contract_finalize_retire()
 }
 
 fn reset_runtime(driver: &mut EphemeralRuntimeDriver) -> meerkat_runtime::ResetReport {
-    driver.contract_set_control_projection(RuntimeState::Idle, None, None);
+    driver.contract_force_runtime_authority(RuntimeState::Idle, None, None);
     driver.contract_reset_cleanup()
 }
 
 fn destroy_runtime(driver: &mut EphemeralRuntimeDriver) -> usize {
     let abandoned = driver.contract_destroy_cleanup();
-    driver.contract_set_control_projection(RuntimeState::Destroyed, None, None);
+    driver.contract_force_runtime_authority(RuntimeState::Destroyed, None, None);
     abandoned
 }
 
 fn stop_runtime(driver: &mut EphemeralRuntimeDriver) {
-    driver.contract_set_control_projection(RuntimeState::Stopped, None, None);
+    driver.contract_force_runtime_authority(RuntimeState::Stopped, None, None);
     driver.contract_finalize_stop_runtime();
 }
 

--- a/meerkat-runtime/tests/driver_persistent.rs
+++ b/meerkat-runtime/tests/driver_persistent.rs
@@ -256,7 +256,7 @@ fn make_multimodal_prompt(text: &str, label: &str) -> Input {
 }
 
 fn bind_running(driver: &mut PersistentRuntimeDriver, run_id: RunId, pre_run_phase: RuntimeState) {
-    driver.contract_set_control_projection(
+    driver.contract_force_runtime_authority(
         RuntimeState::Running,
         Some(run_id),
         Some(pre_run_phase),
@@ -266,14 +266,14 @@ fn bind_running(driver: &mut PersistentRuntimeDriver, run_id: RunId, pre_run_pha
 async fn retire_runtime(
     driver: &mut PersistentRuntimeDriver,
 ) -> Result<meerkat_runtime::RetireReport, meerkat_runtime::RuntimeDriverError> {
-    driver.contract_set_control_projection(RuntimeState::Retired, None, None);
+    driver.contract_force_runtime_authority(RuntimeState::Retired, None, None);
     driver.contract_finalize_retire().await
 }
 
 async fn reset_runtime(
     driver: &mut PersistentRuntimeDriver,
 ) -> Result<meerkat_runtime::ResetReport, meerkat_runtime::RuntimeDriverError> {
-    driver.contract_set_control_projection(RuntimeState::Idle, None, None);
+    driver.contract_force_runtime_authority(RuntimeState::Idle, None, None);
     driver.contract_finalize_reset().await
 }
 

--- a/meerkat-runtime/tests/peer_handling_mode_contract.rs
+++ b/meerkat-runtime/tests/peer_handling_mode_contract.rs
@@ -19,7 +19,7 @@ fn runtime_id() -> LogicalRuntimeId {
 }
 
 fn bind_running(driver: &mut EphemeralRuntimeDriver) {
-    driver.contract_set_control_projection(
+    driver.contract_force_runtime_authority(
         meerkat_runtime::RuntimeState::Running,
         Some(RunId::new()),
         Some(meerkat_runtime::RuntimeState::Idle),

--- a/meerkat-runtime/tests/recovery_contract.rs
+++ b/meerkat-runtime/tests/recovery_contract.rs
@@ -138,7 +138,7 @@ fn sorted_id_strings(ids: impl IntoIterator<Item = InputId>) -> Vec<String> {
 }
 
 fn bind_running(driver: &mut EphemeralRuntimeDriver, run_id: RunId, pre_run_phase: RuntimeState) {
-    driver.contract_set_control_projection(
+    driver.contract_force_runtime_authority(
         RuntimeState::Running,
         Some(run_id),
         Some(pre_run_phase),
@@ -148,7 +148,7 @@ fn bind_running(driver: &mut EphemeralRuntimeDriver, run_id: RunId, pre_run_phas
 async fn retire_runtime(
     driver: &mut PersistentRuntimeDriver,
 ) -> Result<meerkat_runtime::RetireReport, meerkat_runtime::RuntimeDriverError> {
-    driver.contract_set_control_projection(RuntimeState::Retired, None, None);
+    driver.contract_force_runtime_authority(RuntimeState::Retired, None, None);
     driver.contract_finalize_retire().await
 }
 

--- a/meerkat-runtime/tests/regression_comms_runtime.rs
+++ b/meerkat-runtime/tests/regression_comms_runtime.rs
@@ -37,7 +37,7 @@ fn assert_machine_owned_admission_signal(
 }
 
 fn bind_running(driver: &mut EphemeralRuntimeDriver) {
-    driver.contract_set_control_projection(
+    driver.contract_force_runtime_authority(
         RuntimeState::Running,
         Some(meerkat_core::lifecycle::RunId::new()),
         Some(RuntimeState::Idle),
@@ -274,7 +274,7 @@ async fn response_after_completed_turn_wakes() {
 
     // Simulate a completed run by starting and completing
     bind_running(&mut driver);
-    driver.contract_set_control_projection(RuntimeState::Idle, None, None);
+    driver.contract_force_runtime_authority(RuntimeState::Idle, None, None);
 
     // Now idle — accept a terminal response
     let resp = make_response("peer-1", ResponseStatus::Completed);


### PR DESCRIPTION
## Summary
- make runtime control projections mechanical so lifecycle/run truth stays in the Meerkat DSL authority
- make direct RuntimeDriver admission and stop/destroy terminalization sync from DSL authority instead of stale control shadows
- remove legacy run-path manual DSL snapshot/restore handling and add defensive authority tests

## Linear
- LUC-86: https://linear.app/lucrfr/issue/LUC-86/p0p1-dogma-batch-runtime-control-stop-destroy-authority

## Dogma Rows
Verified against current `main` before editing; all requested rows still existed and none were skipped:
- `Bidirectional control projection writes DSL truth`
- `RuntimeDriver direct accept path still lets control projection decide admission`
- `Persistent destroy can leave driver-side control shadow truth behind`
- `Async stop has two terminalization paths`
- `Legacy run path manually snapshots/restores DSL authority`

## Validation
- `./scripts/repo-cargo test -p meerkat-runtime --lib`
- `./scripts/repo-cargo test -p meerkat-runtime --test driver_ephemeral --test driver_persistent --test control_plane_contract --test runtime_ingress_control --test recovery_contract --test peer_handling_mode_contract --test regression_comms_runtime`
- `make check`
- `make test`
- `make lint`
- `git diff --check`
