### PR TITLE
Fix mob lifecycle projection authority

### DIFF
--- a/meerkat-mob/src/machines/mob_machine.rs
+++ b/meerkat-mob/src/machines/mob_machine.rs
@@ -830,6 +830,79 @@ impl From<[u8; 32]> for PeerSigningKey {
 
 meerkat_machine_schema::mob_catalog_machine_dsl!("meerkat-mob", "machines::mob_machine");
 
+// ---------------------------------------------------------------------------
+// MobMachine-owned projection helpers
+// ---------------------------------------------------------------------------
+
+/// Machine-owned lifecycle status for a mob member.
+///
+/// Runtime projections may map this into public handle DTOs, but the decision
+/// itself is derived from `MobMachineState` so projection code does not invent
+/// terminal/member truth from roster or session observations.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum MobMemberLifecycleStatus {
+    Unknown,
+    Active,
+    Retiring,
+    Completed,
+}
+
+/// Machine-owned terminal classification for a mob member.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum MobMemberTerminalClass {
+    Running,
+    TerminalFailure,
+    TerminalUnknown,
+    TerminalCompleted,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct MobMemberLifecycleMaterial {
+    pub status: MobMemberLifecycleStatus,
+    pub terminal_class: MobMemberTerminalClass,
+}
+
+impl MobMemberLifecycleStatus {
+    pub const fn terminal_class(self) -> MobMemberTerminalClass {
+        match self {
+            Self::Active | Self::Retiring => MobMemberTerminalClass::Running,
+            Self::Completed => MobMemberTerminalClass::TerminalCompleted,
+            Self::Unknown => MobMemberTerminalClass::TerminalUnknown,
+        }
+    }
+}
+
+impl MobMachineState {
+    /// Project lifecycle truth for an identity from the machine's membership
+    /// maps. `member_present` is the roster/event-projection presence bit; it
+    /// only tells the machine whether a public member row exists for this
+    /// identity, not what lifecycle state that row should report.
+    pub fn member_lifecycle_for_identity(
+        &self,
+        agent_identity: &AgentIdentity,
+        member_present: bool,
+    ) -> MobMemberLifecycleMaterial {
+        let status = if !member_present {
+            MobMemberLifecycleStatus::Unknown
+        } else if let Some(runtime_id) = self.identity_to_runtime.get(agent_identity) {
+            if self.member_state_markers.get(runtime_id) == Some(&MobMemberState::Retiring) {
+                MobMemberLifecycleStatus::Retiring
+            } else if self.live_runtime_ids.contains(runtime_id) {
+                MobMemberLifecycleStatus::Active
+            } else {
+                MobMemberLifecycleStatus::Completed
+            }
+        } else {
+            MobMemberLifecycleStatus::Unknown
+        };
+
+        MobMemberLifecycleMaterial {
+            status,
+            terminal_class: status.terminal_class(),
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -1200,5 +1273,61 @@ mod tests {
                 .contains_key(&runtime_id)
         );
         assert_eq!(authority.state.active_run_count, 0);
+    }
+
+    #[test]
+    fn member_lifecycle_projection_is_derived_from_machine_membership() {
+        let mut authority = MobMachineAuthority::new();
+        let identity = AgentIdentity::from("worker");
+        let runtime_id = AgentRuntimeId::from("worker:1");
+
+        assert_eq!(
+            authority
+                .state
+                .member_lifecycle_for_identity(&identity, true),
+            MobMemberLifecycleMaterial {
+                status: MobMemberLifecycleStatus::Unknown,
+                terminal_class: MobMemberTerminalClass::TerminalUnknown,
+            }
+        );
+
+        authority
+            .state
+            .identity_to_runtime
+            .insert(identity.clone(), runtime_id.clone());
+        authority.state.live_runtime_ids.insert(runtime_id.clone());
+        assert_eq!(
+            authority
+                .state
+                .member_lifecycle_for_identity(&identity, true)
+                .status,
+            MobMemberLifecycleStatus::Active
+        );
+
+        authority
+            .state
+            .member_state_markers
+            .insert(runtime_id.clone(), MobMemberState::Retiring);
+        assert_eq!(
+            authority
+                .state
+                .member_lifecycle_for_identity(&identity, true),
+            MobMemberLifecycleMaterial {
+                status: MobMemberLifecycleStatus::Retiring,
+                terminal_class: MobMemberTerminalClass::Running,
+            }
+        );
+
+        authority.state.member_state_markers.remove(&runtime_id);
+        authority.state.live_runtime_ids.remove(&runtime_id);
+        assert_eq!(
+            authority
+                .state
+                .member_lifecycle_for_identity(&identity, true),
+            MobMemberLifecycleMaterial {
+                status: MobMemberLifecycleStatus::Completed,
+                terminal_class: MobMemberTerminalClass::TerminalCompleted,
+            }
+        );
     }
 }

--- a/meerkat-mob/src/runtime/actor.rs
+++ b/meerkat-mob/src/runtime/actor.rs
@@ -1998,6 +1998,91 @@ impl MobActor {
         .map_err(|_| self.invalid_transition_to(MobState::Running))
     }
 
+    fn submit_work_rejection_for_machine_state(
+        &self,
+        machine_state: &mob_dsl::MobMachineState,
+        dsl_runtime_id: &mob_dsl::AgentRuntimeId,
+        origin: WorkOrigin,
+        agent_identity: &MeerkatId,
+    ) -> MobError {
+        if project_dsl_phase(machine_state.lifecycle_phase) != MobState::Running {
+            return MobError::InvalidTransition {
+                from: self.state(),
+                to: MobState::Running,
+            };
+        }
+        if !machine_state.live_runtime_ids.contains(dsl_runtime_id) {
+            return MobError::MemberNotFound(agent_identity.clone());
+        }
+        if matches!(origin, WorkOrigin::External)
+            && !machine_state
+                .externally_addressable_runtime_ids
+                .contains(dsl_runtime_id)
+        {
+            return MobError::NotExternallyAddressable(agent_identity.clone());
+        }
+        match origin {
+            WorkOrigin::External => MobError::NotExternallyAddressable(agent_identity.clone()),
+            WorkOrigin::Internal => MobError::MemberNotFound(agent_identity.clone()),
+        }
+    }
+
+    fn preview_policy_spawn_submit_work_admission(
+        &self,
+        agent_identity: &MeerkatId,
+        external_addressable: bool,
+        work_ref: &WorkRef,
+        origin: WorkOrigin,
+    ) -> Result<(), MobError> {
+        let domain_identity = AgentIdentity::from(agent_identity.as_str());
+        let dsl_identity = mob_dsl::AgentIdentity::from_domain(&domain_identity);
+        let domain_runtime_id =
+            crate::ids::AgentRuntimeId::new(domain_identity, crate::ids::Generation::INITIAL);
+        let dsl_runtime_id = mob_dsl::AgentRuntimeId::from_domain(&domain_runtime_id);
+        let dsl_fence_token = mob_dsl::FenceToken::from_domain(self.next_fence_token_preview());
+        let replacing = self
+            .dsl_authority
+            .state
+            .member_session_bindings
+            .get(&dsl_identity)
+            .cloned();
+        let mut authority =
+            mob_dsl::MobMachineAuthority::from_state(self.dsl_authority.state.clone());
+        let spawn = mob_dsl::MobMachineInput::Spawn {
+            agent_identity: dsl_identity,
+            agent_runtime_id: dsl_runtime_id.clone(),
+            fence_token: dsl_fence_token,
+            generation: mob_dsl::Generation::from_domain(crate::ids::Generation::INITIAL),
+            external_addressable,
+            bridge_session_id: mob_dsl::SessionId::default(),
+            replacing,
+        };
+        let transition = mob_dsl::MobMachineMutator::apply(&mut authority, spawn)
+            .map_err(|_| self.invalid_transition_to(MobState::Running))?;
+        if transition.from_phase != transition.to_phase {
+            authority.state.lifecycle_phase = transition.to_phase;
+        }
+
+        mob_dsl::MobMachineMutator::apply(
+            &mut authority,
+            mob_dsl::MobMachineInput::SubmitWork {
+                agent_runtime_id: dsl_runtime_id.clone(),
+                fence_token: dsl_fence_token,
+                work_id: mob_dsl::WorkId::from_work_ref(work_ref),
+                origin: mob_dsl::WorkOrigin::from(origin),
+            },
+        )
+        .map(|_| ())
+        .map_err(|_| {
+            self.submit_work_rejection_for_machine_state(
+                &authority.state,
+                &dsl_runtime_id,
+                origin,
+                agent_identity,
+            )
+        })
+    }
+
     fn complete_orchestrator_spawn(
         &mut self,
         spawn_ticket: Option<u64>,
@@ -8538,6 +8623,16 @@ impl MobActor {
                 }
                 let identity = AgentIdentity::from(agent_identity.as_str());
                 if let Some(spec) = self.spawn_policy.resolve(&identity).await {
+                    let profile = self
+                        .definition
+                        .resolve_profile(&spec.profile, self.realm_profile_store.as_ref())
+                        .await?;
+                    self.preview_policy_spawn_submit_work_admission(
+                        &identity,
+                        profile.external_addressable,
+                        &work_ref,
+                        origin,
+                    )?;
                     Box::pin(self.spawn_from_policy_inline(&identity, spec))
                         .await
                         .map_err(|error| {
@@ -8586,35 +8681,13 @@ impl MobActor {
             },
         ) {
             Ok(transition) => transition,
-            Err(_) if self.state() != MobState::Running => {
-                return Err(self.invalid_transition_to(MobState::Running));
-            }
-            Err(_)
-                if !self
-                    .dsl_authority
-                    .state
-                    .live_runtime_ids
-                    .contains(&dsl_runtime_id) =>
-            {
-                return Err(MobError::MemberNotFound(agent_identity.clone()));
-            }
-            Err(_)
-                if matches!(origin, WorkOrigin::External)
-                    && !self
-                        .dsl_authority
-                        .state
-                        .externally_addressable_runtime_ids
-                        .contains(&dsl_runtime_id) =>
-            {
-                return Err(MobError::NotExternallyAddressable(agent_identity.clone()));
-            }
             Err(_) => {
-                return Err(match origin {
-                    WorkOrigin::External => {
-                        MobError::NotExternallyAddressable(agent_identity.clone())
-                    }
-                    WorkOrigin::Internal => MobError::MemberNotFound(agent_identity.clone()),
-                });
+                return Err(self.submit_work_rejection_for_machine_state(
+                    &self.dsl_authority.state,
+                    &dsl_runtime_id,
+                    origin,
+                    &agent_identity,
+                ));
             }
         };
         if transition.from_phase != transition.to_phase {

--- a/meerkat-mob/src/runtime/actor.rs
+++ b/meerkat-mob/src/runtime/actor.rs
@@ -2,8 +2,7 @@ use super::disposal::{
     BulkBestEffort, DisposalContext, DisposalReport, DisposalStep, ErrorPolicy, WarnAndContinue,
 };
 use super::mob_member_lifecycle_projection::{
-    CanonicalMemberSnapshotMaterial, CanonicalMemberStatus, CanonicalSessionObservation,
-    MobMemberLifecycleInput, MobMemberLifecycleProjection,
+    CanonicalMemberSnapshotMaterial, MobMemberLifecycleInput, MobMemberLifecycleProjection,
 };
 use super::mob_runtime_bridge_authority::{MobRuntimeBridgeAuthority, MobRuntimeBridgeEffect};
 use super::provision_guard::PendingProvision;
@@ -983,6 +982,20 @@ impl MobActor {
         crate::ids::FenceToken::new(val)
     }
 
+    fn next_fence_token_preview(&self) -> crate::ids::FenceToken {
+        crate::ids::FenceToken::new(
+            self.next_fence_token
+                .load(std::sync::atomic::Ordering::Relaxed),
+        )
+    }
+
+    fn invalid_transition_to(&self, target: MobState) -> MobError {
+        MobError::InvalidTransition {
+            from: self.state(),
+            to: target,
+        }
+    }
+
     async fn restore_failure_for(
         &self,
         agent_identity: &MeerkatId,
@@ -1250,24 +1263,17 @@ impl MobActor {
         };
         let domain_identity = crate::ids::AgentIdentity::from(agent_identity.as_str());
         let machine_projection = self.machine_projection_for_identity(&domain_identity);
+        let dsl_identity = mob_dsl::AgentIdentity::from_domain(&domain_identity);
         let machine_bridge_session_id = machine_projection
             .bound_session_id
             .as_ref()
             .and_then(|dsl_session_id| SessionId::parse(&dsl_session_id.0).ok());
         let current_bridge_session_id = current_bridge_session_id.or(machine_bridge_session_id);
         let member_present = roster_entry.is_some();
-        let mut machine_status = MobMemberLifecycleProjection::machine_status(
-            member_present,
-            machine_projection.runtime_id.is_some(),
-            machine_projection.state_marker,
-            machine_projection.live_runtime,
-        );
-        if roster_entry
-            .as_ref()
-            .is_some_and(|entry| entry.state == crate::roster::MemberState::Retiring)
-        {
-            machine_status = CanonicalMemberStatus::Retiring;
-        }
+        let machine_lifecycle = self
+            .dsl_authority
+            .state
+            .member_lifecycle_for_identity(&dsl_identity, member_present);
 
         let restore_failure = {
             self.restore_diagnostics
@@ -1279,8 +1285,7 @@ impl MobActor {
         if let Some(diag) = restore_failure {
             return MobMemberLifecycleProjection::materialize(MobMemberLifecycleInput {
                 member_present,
-                machine_status,
-                session_observation: CanonicalSessionObservation::Missing,
+                machine_lifecycle,
                 restore_failure: Some(diag.reason),
                 output_preview: None,
                 tokens_used: 0,
@@ -1304,42 +1309,24 @@ impl MobActor {
             });
         }
 
-        let (output_preview, tokens_used, session_observation) =
-            match current_bridge_session_id.as_ref() {
-                None => {
-                    let session_observation =
-                        match roster_entry.as_ref().map(|entry| &entry.member_ref) {
-                            Some(MemberRef::BackendPeer {
-                                session_id: None, ..
-                            }) => CanonicalSessionObservation::Unknown,
-                            _ => CanonicalSessionObservation::Missing,
-                        };
-                    (None, 0, session_observation)
+        let (output_preview, tokens_used) = match current_bridge_session_id.as_ref() {
+            None => (None, 0),
+            Some(bridge_session_id) if include_session_details => {
+                match self.session_service.read(bridge_session_id).await {
+                    Ok(view) => (
+                        view.state.last_assistant_text.clone(),
+                        view.billing.total_tokens,
+                    ),
+                    Err(meerkat_core::service::SessionError::NotFound { .. }) => (None, 0),
+                    Err(_) => (None, 0),
                 }
-                Some(bridge_session_id) if include_session_details => {
-                    match self.session_service.read(bridge_session_id).await {
-                        Ok(view) => (
-                            view.state.last_assistant_text.clone(),
-                            view.billing.total_tokens,
-                            if view.state.is_active {
-                                CanonicalSessionObservation::Active
-                            } else {
-                                CanonicalSessionObservation::Inactive
-                            },
-                        ),
-                        Err(meerkat_core::service::SessionError::NotFound { .. }) => {
-                            (None, 0, CanonicalSessionObservation::Missing)
-                        }
-                        Err(_) => (None, 0, CanonicalSessionObservation::Unknown),
-                    }
-                }
-                Some(_) => (None, 0, CanonicalSessionObservation::Unknown),
-            };
+            }
+            Some(_) => (None, 0),
+        };
 
         MobMemberLifecycleProjection::materialize(MobMemberLifecycleInput {
             member_present,
-            machine_status,
-            session_observation,
+            machine_lifecycle,
             restore_failure: None,
             output_preview,
             tokens_used,
@@ -1707,12 +1694,6 @@ impl MobActor {
         })
     }
 
-    fn machine_coordinator_bound(&self) -> bool {
-        // Plain mobs (no orchestrator) are always considered coordinator-bound
-        // for the purposes of spawn/run-flow admission checks.
-        !self.has_orchestrator || self.dsl_authority.state.coordinator_bound
-    }
-
     /// Probe a DSL input against a clone of current state — returns
     /// `InvalidTransition` if the DSL rejects the input, without
     /// mutating the live authority. Used as the pre-admission gate for
@@ -1982,6 +1963,39 @@ impl MobActor {
             )?;
         }
         Ok(())
+    }
+
+    fn preview_spawn_admission(
+        &self,
+        agent_identity: &MeerkatId,
+        external_addressable: bool,
+        bridge_session_id: &SessionId,
+    ) -> Result<(), MobError> {
+        let domain_identity = AgentIdentity::from(agent_identity.as_str());
+        let dsl_identity = mob_dsl::AgentIdentity::from_domain(&domain_identity);
+        let replacing = self
+            .dsl_authority
+            .state
+            .member_session_bindings
+            .get(&dsl_identity)
+            .cloned();
+
+        self.preview_dsl_input(
+            mob_dsl::MobMachineInput::Spawn {
+                agent_identity: dsl_identity,
+                agent_runtime_id: mob_dsl::AgentRuntimeId::from_domain(
+                    &crate::ids::AgentRuntimeId::initial(domain_identity),
+                ),
+                fence_token: mob_dsl::FenceToken::from_domain(self.next_fence_token_preview()),
+                generation: mob_dsl::Generation::from_domain(crate::ids::Generation::INITIAL),
+                external_addressable,
+                bridge_session_id: mob_dsl::SessionId::from_domain(bridge_session_id),
+                replacing,
+            },
+            "spawn_command_admission",
+        )
+        .map(|_| ())
+        .map_err(|_| self.invalid_transition_to(MobState::Running))
     }
 
     fn complete_orchestrator_spawn(
@@ -2742,13 +2756,6 @@ impl MobActor {
                     ops_registry,
                     reply_tx,
                 } => {
-                    if self.state() != MobState::Running || !self.machine_coordinator_bound() {
-                        let _ = reply_tx.send(Err(MobError::InvalidTransition {
-                            from: self.state(),
-                            to: MobState::Running,
-                        }));
-                        continue;
-                    }
                     Box::pin(self.enqueue_spawn(
                         *spec,
                         owner_bridge_session_id,
@@ -2815,16 +2822,7 @@ impl MobActor {
                     reply_tx,
                 } => {
                     let result =
-                        if self.state() != MobState::Running || !self.machine_coordinator_bound() {
-                            Err(super::handle::MobRespawnError::from(
-                                MobError::InvalidTransition {
-                                    from: self.state(),
-                                    to: MobState::Running,
-                                },
-                            ))
-                        } else {
-                            Box::pin(self.handle_respawn(agent_identity, initial_message)).await
-                        };
+                        Box::pin(self.handle_respawn(agent_identity, initial_message)).await;
                     let _ = reply_tx.send(result);
                 }
                 MobCommand::RetireAll { reply_tx } => {
@@ -2835,10 +2833,7 @@ impl MobActor {
                     let _ = reply_tx.send(result);
                 }
                 MobCommand::SubmitWork { payload, reply_tx } => {
-                    let result = match self.require_state(&[MobState::Running]) {
-                        Ok(()) => Box::pin(self.handle_submit_work(payload)).await,
-                        Err(error) => Err(error),
-                    };
+                    let result = Box::pin(self.handle_submit_work(payload)).await;
                     let _ = reply_tx.send(result);
                 }
                 #[cfg(feature = "runtime-adapter")]
@@ -2863,16 +2858,9 @@ impl MobActor {
                     scoped_event_tx,
                     reply_tx,
                 } => {
-                    let result =
-                        if self.state() != MobState::Running || !self.machine_coordinator_bound() {
-                            Err(MobError::InvalidTransition {
-                                from: self.state(),
-                                to: MobState::Running,
-                            })
-                        } else {
-                            self.handle_run_flow(flow_id, activation_params, scoped_event_tx)
-                                .await
-                        };
+                    let result = self
+                        .handle_run_flow(flow_id, activation_params, scoped_event_tx)
+                        .await;
                     let _ = reply_tx.send(result);
                 }
                 MobCommand::CancelFlow { run_id, reply_tx } => {
@@ -3766,6 +3754,7 @@ impl MobActor {
             };
 
             let selected_runtime_mode = runtime_mode.unwrap_or(profile.runtime_mode);
+            let profile_external_addressable = profile.external_addressable;
 
             // ---------- Resume bridge-session fast-path ----------
             // When resume_bridge_session_id is set, skip provisioning and go
@@ -3819,6 +3808,7 @@ impl MobActor {
                         agent_identity,
                         prompt,
                         selected_runtime_mode,
+                        profile_external_addressable,
                         resolved_labels,
                         Some(member_ref),
                         None,
@@ -3895,6 +3885,7 @@ impl MobActor {
                         agent_identity,
                         prompt,
                         selected_runtime_mode,
+                        profile_external_addressable,
                         resolved_labels,
                         None::<MemberRef>,
                         Some(provision_request),
@@ -4034,6 +4025,7 @@ impl MobActor {
                 agent_identity,
                 prompt,
                 selected_runtime_mode,
+                profile_external_addressable,
                 resolved_labels,
                 None::<MemberRef>,
                 Some(provision_request),
@@ -4049,6 +4041,7 @@ impl MobActor {
             agent_identity,
             prompt,
             selected_runtime_mode,
+            external_addressable,
             resolved_labels,
             resume_member_ref,
             maybe_provision_request,
@@ -4065,6 +4058,20 @@ impl MobActor {
 
         // ---------- Resume fast-path: skip async provisioning ----------
         if let Some(member_ref) = resume_member_ref {
+            let Some(bridge_session_id) = member_ref.bridge_session_id().cloned() else {
+                let _ = reply_tx.send(Err(MobError::Internal(format!(
+                    "resumed member '{agent_identity}' has no bridge session id"
+                ))));
+                return;
+            };
+            if let Err(error) = self.preview_spawn_admission(
+                &agent_identity,
+                external_addressable,
+                &bridge_session_id,
+            ) {
+                let _ = reply_tx.send(Err(error));
+                return;
+            }
             if let (Some(owner_bridge_session_id), Some(ops_registry)) =
                 (owner_bridge_session_id.clone(), ops_registry.clone())
                 && let Err(error) = self
@@ -4126,6 +4133,15 @@ impl MobActor {
         };
         let admitted_bridge_session_id =
             admit_bridge_session_for_spawn(&mut provision_request.create_session);
+
+        if let Err(error) = self.preview_spawn_admission(
+            &agent_identity,
+            external_addressable,
+            &admitted_bridge_session_id,
+        ) {
+            let _ = reply_tx.send(Err(error));
+            return;
+        }
 
         let spawn_ticket = self.next_spawn_ticket;
         self.next_spawn_ticket = self.next_spawn_ticket.wrapping_add(1);
@@ -4986,46 +5002,29 @@ impl MobActor {
             }
         }
 
-        // D31 restore: re-fire peer wiring captured from the prior generation
-        // on respawn. The pre-DSL respawn path ran this fan-out imperatively;
-        // wave-A removed the call sites alongside the shell-authority wire
-        // symbols. For local peers we re-use `handle_wire` so the canonical
-        // `MembersWired` event + DSL `WireMembers` input + roster projection
-        // all line up with a fresh spawn. For external peers (whose
-        // `handle_wire` path was deleted in `0ad584cde` and is pending the
-        // d-external-peer-wire agent's restoration), we install comms trust
-        // directly and restore the `external_peer_specs` + `wired_to`
-        // projection so member_status/get_member surfaces the edge.
-        // Failures are accumulated in `failed_restore_peer_ids` so
-        // `handle_respawn` can surface `TopologyRestoreFailed` without
-        // tearing down the replacement member.
+        // Respawn restore: re-fire topology captured from MobMachine, not
+        // from roster projection fields. `handle_wire` repairs live comms and
+        // read-model projection after MobMachine admits or already owns the
+        // edge, so respawn never writes roster wiring directly.
         let mut failed_restore_peer_ids: Vec<MeerkatId> = Vec::new();
         if let Some(plan) = restore_wiring {
-            let local_identity = crate::ids::AgentIdentity::from(agent_identity.as_str());
             for peer_identity in plan.local_peers {
                 if peer_identity == *agent_identity {
                     continue;
                 }
-                // Re-project the edge into the roster. The DSL `wiring_edges`
-                // set survived retire (Retire does not clear it), so
-                // `handle_wire` would hit the `edge_not_already_wired` guard
-                // rejection's idempotent-success path and never emit a
-                // `MembersWired` event — leaving the fresh `RosterEntry` for
-                // the replacement member with an empty `wired_to`. Direct
-                // projection restores the bidirectional edge so
-                // `get_member` / `member_status` surface the wiring again
-                // without duplicating the canonical event in the log.
                 let peer_agent_identity = crate::ids::AgentIdentity::from(peer_identity.as_str());
-                let projected = self
-                    .roster
-                    .write()
+                if let Err(error) = self
+                    .handle_wire(
+                        agent_identity.clone(),
+                        super::handle::PeerTarget::Local(peer_agent_identity),
+                    )
                     .await
-                    .restore_local_peer_edge(&local_identity, &peer_agent_identity);
-                if !projected {
+                {
                     tracing::warn!(
                         agent_identity = %agent_identity,
                         peer = %peer_identity,
-                        "respawn: local peer missing from roster while restoring wiring projection"
+                        %error,
+                        "respawn: failed to restore machine-owned local peer edge"
                     );
                     failed_restore_peer_ids.push(peer_identity);
                 }
@@ -5033,34 +5032,19 @@ impl MobActor {
             for peer_spec in plan.external_peers {
                 let peer_name_id = MeerkatId::from(peer_spec.name.as_str());
                 if let Err(error) = self
-                    .restore_external_peer_trust(agent_identity, &member_ref, peer_spec.clone())
+                    .handle_wire(
+                        agent_identity.clone(),
+                        super::handle::PeerTarget::External(peer_spec.clone()),
+                    )
                     .await
                 {
                     tracing::warn!(
                         agent_identity = %agent_identity,
                         peer = %peer_spec.name,
                         %error,
-                        "respawn: failed to restore external peer trust"
+                        "respawn: failed to restore machine-owned external peer edge"
                     );
                     failed_restore_peer_ids.push(peer_name_id);
-                    continue;
-                }
-                // Preserve the roster projection of the external edge so
-                // `member_status`/`get_member` callers observe the restored
-                // `wired_to` + `external_peer_specs` without relying on a
-                // replayed `ExternalPeerWired` event (that event variant is
-                // pending the d-external-peer-wire agent's restoration).
-                let local_identity = crate::ids::AgentIdentity::from(agent_identity.as_str());
-                let inserted = self
-                    .roster
-                    .write()
-                    .await
-                    .restore_external_peer_edge(&local_identity, peer_spec);
-                if !inserted {
-                    tracing::warn!(
-                        agent_identity = %agent_identity,
-                        "respawn: roster entry missing while restoring external peer edge"
-                    );
                 }
             }
         }
@@ -6832,15 +6816,6 @@ impl MobActor {
             entry
         };
 
-        // Append retire event (event-first for crash recovery).
-        let retire_event_already_present = self
-            .retire_event_exists(agent_identity, &entry.member_ref)
-            .await?;
-        if !retire_event_already_present {
-            self.append_retire_event(agent_identity, &entry.role, &entry.member_ref)
-                .await?;
-        }
-
         // Mark as Retiring in the DSL (blocks re-spawn with same ID).
         // Shell roster does not carry authoritative state; `member_state_markers`
         // in the DSL is the source of truth and overlays the read-only projection
@@ -6873,16 +6848,30 @@ impl MobActor {
                     .cloned()
             })
             .unwrap_or_else(mob_dsl::SessionId::default);
-        let effects = self.apply_dsl_input_collect_effects(
-            mob_dsl::MobMachineInput::Retire {
-                mob_id: mob_dsl::MobId::from_domain(&self.definition.id),
-                agent_runtime_id: mob_dsl::AgentRuntimeId::from_domain(&entry.agent_runtime_id),
-                agent_identity: dsl_identity,
-                releasing,
-                session_id: session_id_for_route,
-            },
-            "handle_retire_inner_mark_retiring",
-        )?;
+        let retire_input = mob_dsl::MobMachineInput::Retire {
+            mob_id: mob_dsl::MobId::from_domain(&self.definition.id),
+            agent_runtime_id: mob_dsl::AgentRuntimeId::from_domain(&entry.agent_runtime_id),
+            agent_identity: dsl_identity,
+            releasing,
+            session_id: session_id_for_route,
+        };
+
+        // MobMachine admits the command before the event projection records
+        // retirement. The actual transition is still applied after the durable
+        // event append so crash recovery keeps its event-first ordering.
+        self.preview_dsl_input(retire_input.clone(), "handle_retire_inner_admission")?;
+
+        // Append retire event (event-first for crash recovery).
+        let retire_event_already_present = self
+            .retire_event_exists(agent_identity, &entry.member_ref)
+            .await?;
+        if !retire_event_already_present {
+            self.append_retire_event(agent_identity, &entry.role, &entry.member_ref)
+                .await?;
+        }
+
+        let effects = self
+            .apply_dsl_input_collect_effects(retire_input, "handle_retire_inner_mark_retiring")?;
         let mut detach_obligations =
             crate::generated::protocol_mob_destroying_session_ingress::extract_obligations(
                 &effects,
@@ -6997,7 +6986,10 @@ impl MobActor {
             );
         }
 
-        // 1. Snapshot all replacement inputs before retiring.
+        // 1. Snapshot all replacement inputs before retiring. Topology comes
+        // from the MobMachine authority; the roster is only the read model
+        // that supplies profile/runtime binding details for the old member.
+        let restore_wiring = self.machine_restore_wiring_plan(&agent_identity)?;
         let snapshot = {
             let roster = self.roster.read().await;
             let entry = roster
@@ -7025,22 +7017,19 @@ impl MobActor {
                 old_runtime_id: entry.agent_runtime_id.clone(),
                 old_fence_token: entry.fence_token,
                 generation: entry.generation,
-                restore_wiring: RestoreWiringPlan {
-                    local_peers: entry
-                        .wired_to
-                        .iter()
-                        .filter_map(|peer_id| {
-                            roster
-                                .get_by_identity(peer_id)
-                                .map(|e| e.agent_identity.clone())
-                        })
-                        .collect(),
-                    external_peers: entry.external_peer_specs.values().cloned().collect(),
-                },
+                restore_wiring,
                 binding,
                 effective_profile_override: entry.effective_profile_override,
             }
         };
+
+        self.preview_dsl_input(
+            mob_dsl::MobMachineInput::Respawn {
+                agent_runtime_id: mob_dsl::AgentRuntimeId::from_domain(&snapshot.old_runtime_id),
+            },
+            "handle_respawn_admission",
+        )
+        .map_err(|_| MobRespawnError::from(self.invalid_transition_to(MobState::Running)))?;
 
         let replacement_generation = snapshot.generation.next();
 
@@ -8562,19 +8551,47 @@ impl MobActor {
         // legality: `SubmitWorkRunningExternal` / `SubmitWorkRunningInternal`
         // encode the origin + addressability + live-runtime + phase guards.
         // A rejection is a state-legality violation, not a freshness issue.
-        let transition = mob_dsl::MobMachineMutator::apply(
+        let transition = match mob_dsl::MobMachineMutator::apply(
             &mut self.dsl_authority,
             mob_dsl::MobMachineInput::SubmitWork {
-                agent_runtime_id: dsl_runtime_id,
+                agent_runtime_id: dsl_runtime_id.clone(),
                 fence_token: dsl_fence_token,
                 work_id: dsl_work_id,
                 origin: dsl_origin,
             },
-        )
-        .map_err(|_| match origin {
-            WorkOrigin::External => MobError::NotExternallyAddressable(agent_identity.clone()),
-            WorkOrigin::Internal => MobError::MemberNotFound(agent_identity.clone()),
-        })?;
+        ) {
+            Ok(transition) => transition,
+            Err(_) if self.state() != MobState::Running => {
+                return Err(self.invalid_transition_to(MobState::Running));
+            }
+            Err(_)
+                if !self
+                    .dsl_authority
+                    .state
+                    .live_runtime_ids
+                    .contains(&dsl_runtime_id) =>
+            {
+                return Err(MobError::MemberNotFound(agent_identity.clone()));
+            }
+            Err(_)
+                if matches!(origin, WorkOrigin::External)
+                    && !self
+                        .dsl_authority
+                        .state
+                        .externally_addressable_runtime_ids
+                        .contains(&dsl_runtime_id) =>
+            {
+                return Err(MobError::NotExternallyAddressable(agent_identity.clone()));
+            }
+            Err(_) => {
+                return Err(match origin {
+                    WorkOrigin::External => {
+                        MobError::NotExternallyAddressable(agent_identity.clone())
+                    }
+                    WorkOrigin::Internal => MobError::MemberNotFound(agent_identity.clone()),
+                });
+            }
+        };
         if transition.from_phase != transition.to_phase {
             self.dsl_authority.state.lifecycle_phase = transition.to_phase;
             let _ = self.phase_watch_tx.send(self.state());
@@ -8723,11 +8740,7 @@ impl MobActor {
         let run_flow = MobRun::run_flow_input(&run_id, &config)?;
         debug_assert!(matches!(run_flow, mob_dsl::MobMachineInput::RunFlow { .. }));
         self.apply_dsl_input(run_flow, "run_flow")
-            .map_err(|error| {
-                MobError::Internal(format!(
-                    "canonical RunFlow transition failed during flow admission: {error}"
-                ))
-            })?;
+            .map_err(|_| self.invalid_transition_to(MobState::Running))?;
         self.create_pending_run(
             run_id.clone(),
             &config,
@@ -9468,29 +9481,64 @@ impl MobActor {
         self.provisioner.comms_runtime(member_ref).await
     }
 
-    /// Install comms trust for a restored external peer edge.
-    ///
-    /// Used by the D31 respawn restore loop in `finalize_spawn_from_pending`
-    /// to re-establish the comms trust that was dropped when the prior
-    /// generation of the member was retired. The corresponding `wired_to` +
-    /// `external_peer_specs` roster projection is restored separately via
-    /// [`RosterAuthority::restore_external_peer_edge`].
-    async fn restore_external_peer_trust(
+    fn trusted_peer_descriptor_from_machine_endpoint(
+        endpoint: &mob_dsl::ExternalPeerEndpoint,
+    ) -> Result<TrustedPeerDescriptor, MobError> {
+        TrustedPeerDescriptor::unsigned_with_pubkey(
+            endpoint.name.0.clone(),
+            &endpoint.peer_id.0,
+            endpoint.signing_key.0,
+            &endpoint.address.0,
+        )
+        .map_err(|error| {
+            MobError::WiringError(format!(
+                "MobMachine external peer edge has invalid descriptor '{}': {error}",
+                endpoint.name.0
+            ))
+        })
+    }
+
+    fn machine_restore_wiring_plan(
         &self,
         agent_identity: &MeerkatId,
-        member_ref: &MemberRef,
-        spec: TrustedPeerDescriptor,
-    ) -> Result<(), MobError> {
-        let comms = self.provisioner_comms(member_ref).await.ok_or_else(|| {
-            MobError::WiringError(format!(
-                "respawn cannot restore external peer trust for '{agent_identity}': \
-                 comms runtime unavailable"
-            ))
-        })?;
-        comms.add_trusted_peer(spec).await.map_err(|error| {
-            MobError::WiringError(format!(
-                "respawn failed to restore external peer trust for '{agent_identity}': {error}"
-            ))
+    ) -> Result<RestoreWiringPlan, MobError> {
+        let local =
+            mob_dsl::AgentIdentity::from_domain(&AgentIdentity::from(agent_identity.as_str()));
+        let mut local_peers = Vec::new();
+        for edge in &self.dsl_authority.state.wiring_edges {
+            let peer = if edge.a == local {
+                Some(&edge.b)
+            } else if edge.b == local {
+                Some(&edge.a)
+            } else {
+                None
+            };
+            if let Some(peer) = peer {
+                local_peers.push(MeerkatId::from(peer.0.as_str()));
+            }
+        }
+        local_peers.sort();
+        local_peers.dedup();
+
+        let mut external_peers = Vec::new();
+        for edge in &self.dsl_authority.state.external_peer_edges {
+            if edge.local == local {
+                external_peers.push(Self::trusted_peer_descriptor_from_machine_endpoint(
+                    &edge.endpoint,
+                )?);
+            }
+        }
+        external_peers.sort_by(|a, b| {
+            a.name
+                .as_str()
+                .cmp(b.name.as_str())
+                .then_with(|| a.peer_id.to_string().cmp(&b.peer_id.to_string()))
+        });
+        external_peers.dedup_by(|a, b| a.name == b.name && a.peer_id == b.peer_id);
+
+        Ok(RestoreWiringPlan {
+            local_peers,
+            external_peers,
         })
     }
 

--- a/meerkat-mob/src/runtime/actor.rs
+++ b/meerkat-mob/src/runtime/actor.rs
@@ -6988,14 +6988,21 @@ impl MobActor {
 
         // 1. Snapshot all replacement inputs before retiring. Topology comes
         // from the MobMachine authority; the roster is only the read model
-        // that supplies profile/runtime binding details for the old member.
-        let restore_wiring = self.machine_restore_wiring_plan(&agent_identity)?;
+        // that supplies profile/runtime binding details for the old member and
+        // filters stale local edges whose peers are no longer live.
         let snapshot = {
             let roster = self.roster.read().await;
             let entry = roster
                 .get(&agent_identity)
                 .cloned()
                 .ok_or_else(|| MobError::MemberNotFound(agent_identity.clone()))?;
+            let live_local_identities = roster
+                .list()
+                .map(|entry| MeerkatId::from(entry.agent_identity.as_str()))
+                .collect::<HashSet<_>>();
+            let restore_wiring = self
+                .machine_restore_wiring_plan(&agent_identity, &live_local_identities)
+                .map_err(MobRespawnError::from)?;
             let binding = match &entry.member_ref {
                 crate::event::MemberRef::BackendPeer {
                     peer_id,
@@ -9501,6 +9508,7 @@ impl MobActor {
     fn machine_restore_wiring_plan(
         &self,
         agent_identity: &MeerkatId,
+        live_local_identities: &HashSet<MeerkatId>,
     ) -> Result<RestoreWiringPlan, MobError> {
         let local =
             mob_dsl::AgentIdentity::from_domain(&AgentIdentity::from(agent_identity.as_str()));
@@ -9514,7 +9522,10 @@ impl MobActor {
                 None
             };
             if let Some(peer) = peer {
-                local_peers.push(MeerkatId::from(peer.0.as_str()));
+                let peer_identity = MeerkatId::from(peer.0.as_str());
+                if live_local_identities.contains(&peer_identity) {
+                    local_peers.push(peer_identity);
+                }
             }
         }
         local_peers.sort();

--- a/meerkat-mob/src/runtime/actor.rs
+++ b/meerkat-mob/src/runtime/actor.rs
@@ -8488,6 +8488,24 @@ impl MobActor {
 
         let agent_identity = MeerkatId::from(&runtime_id.identity);
 
+        // SubmitWork admission belongs to MobMachine even when the shell may
+        // need to auto-spawn an absent external target. Probe the declared
+        // command before policy resolution so stopped/completed mobs reject
+        // without staging spawn side effects.
+        if let Err(error) = self.probe_mob_machine_input(
+            mob_dsl::MobMachineInput::SubmitWork {
+                agent_runtime_id: mob_dsl::AgentRuntimeId::from_domain(&runtime_id),
+                fence_token: mob_dsl::FenceToken::from_domain(fence_token),
+                work_id: mob_dsl::WorkId::from_work_ref(&work_ref),
+                origin: mob_dsl::WorkOrigin::from(origin),
+            },
+            MobState::Running,
+        ) {
+            if self.state() != MobState::Running {
+                return Err(error);
+            }
+        }
+
         // Resolve entry + validate fence freshness in a single roster read.
         // Fence-token freshness is a shell-owned concurrency invariant (a
         // stale token means the caller is talking to a superseded

--- a/meerkat-mob/src/runtime/builder.rs
+++ b/meerkat-mob/src/runtime/builder.rs
@@ -77,10 +77,13 @@ fn seed_mob_authority(
 /// This helper replays every live roster entry into the DSL exactly as a
 /// fresh spawn would have done, populating `live_runtime_ids`,
 /// `runtime_fence_tokens`, `externally_addressable_runtime_ids`, and
-/// `identity_to_runtime`. `external_addressable` is resolved from the
-/// definition's inline profile (realm-profile overrides are resolved
-/// asynchronously elsewhere; callers that need realm overrides can re-feed
-/// spawn events through the live pipeline).
+/// `identity_to_runtime`. It also rehydrates machine-owned local and external
+/// wiring edges from the event-projected roster so respawn/reconcile restore
+/// logic can read topology from MobMachine instead of using roster fields as
+/// authority. `external_addressable` is resolved from the definition's inline
+/// profile (realm-profile overrides are resolved asynchronously elsewhere;
+/// callers that need realm overrides can re-feed spawn events through the live
+/// pipeline).
 fn seed_mob_authority_sync_from_roster(
     authority: &mut crate::machines::mob_machine::MobMachineAuthority,
     roster: &Roster,
@@ -121,6 +124,27 @@ fn seed_mob_authority_sync_from_roster(
             .state
             .identity_to_runtime
             .insert(dsl_identity, dsl_runtime_id);
+
+        for peer_identity in &entry.wired_to {
+            if let Some(peer_entry) = roster.get_by_identity(peer_identity) {
+                authority
+                    .state
+                    .wiring_edges
+                    .insert(mob_dsl::WiringEdge::new(
+                        mob_dsl::AgentIdentity::from_domain(&entry.agent_identity),
+                        mob_dsl::AgentIdentity::from_domain(&peer_entry.agent_identity),
+                    ));
+            }
+        }
+        for spec in entry.external_peer_specs.values() {
+            authority
+                .state
+                .external_peer_edges
+                .insert(mob_dsl::ExternalPeerEdge::new(
+                    mob_dsl::AgentIdentity::from_domain(&entry.agent_identity),
+                    mob_dsl::ExternalPeerEndpoint::from(spec),
+                ));
+        }
     }
 }
 
@@ -520,10 +544,10 @@ impl MobBuilder {
             .into_iter()
             .filter(|event| event.mob_id == definition.id)
             .collect();
-        // Runtime metadata is authoritative for supervisor and external-binding
-        // normalization state. Older mobs created before bridge metadata
-        // existed will not have a supervisor record yet, so resume must seed
-        // one before treating absence as corruption.
+        // Runtime metadata owns supervisor authority and carries
+        // external-binding reconciliation facts. Roster membership still
+        // comes from the event log, then MobMachine is seeded from that
+        // reconciled projection.
         Self::ensure_supervisor_authority(storage.runtime_metadata.clone(), definition.id.clone())
             .await?;
         let supervisor_authority = storage
@@ -540,19 +564,19 @@ impl MobBuilder {
             &definition.id,
             supervisor_authority,
         )?);
+        let mut roster = Roster::project(&mob_events);
+        #[cfg(not(target_arch = "wasm32"))]
+        Self::normalize_sessionless_backend_runtime_modes(&mut roster);
         #[cfg(not(target_arch = "wasm32"))]
         let seeded_restore_diagnostics = {
             let binding_overlays = storage
                 .runtime_metadata
                 .list_external_binding_overlays(&definition.id)
                 .await?;
-            Self::apply_external_binding_overlays(&mut mob_events, &binding_overlays)
+            Self::reconcile_external_binding_overlays(&mut roster, &binding_overlays)
         };
         #[cfg(target_arch = "wasm32")]
         let seeded_restore_diagnostics = HashMap::new();
-        #[cfg(not(target_arch = "wasm32"))]
-        Self::normalize_sessionless_backend_runtime_modes(&mut mob_events);
-        let mut roster = Roster::project(&mob_events);
         let task_board = TaskBoard::project(&mob_events);
         // Determine resumed state from events in the current epoch (after the
         // last MobReset, or all events if no reset has occurred).
@@ -707,8 +731,8 @@ impl MobBuilder {
     }
 
     #[cfg(not(target_arch = "wasm32"))]
-    fn apply_external_binding_overlays(
-        mob_events: &mut [crate::event::MobEvent],
+    fn reconcile_external_binding_overlays(
+        roster: &mut Roster,
         overlays: &[crate::store::ExternalBindingOverlayRecord],
     ) -> HashMap<MeerkatId, super::handle::RestoreFailureDiagnostic> {
         let overlay_index = overlays
@@ -722,57 +746,58 @@ impl MobBuilder {
             .collect::<HashMap<_, _>>();
         let mut diagnostics = HashMap::new();
 
-        for event in mob_events {
-            let Some(member_spawned) = event.kind.member_spawned_mut() else {
+        let identities = roster
+            .list_all()
+            .map(|entry| entry.agent_identity.clone())
+            .collect::<Vec<_>>();
+        for identity in identities {
+            let Some(entry) = roster.get_by_identity_mut(&identity) else {
                 continue;
             };
-            let Some(overlay) = overlay_index.get(&(
-                member_spawned.agent_identity.clone(),
-                member_spawned.generation,
-            )) else {
+            let Some(overlay) =
+                overlay_index.get(&(entry.agent_identity.clone(), entry.generation))
+            else {
+                entry.runtime_mode = Self::normalize_runtime_mode_for_member_ref(
+                    entry.runtime_mode,
+                    Some(&entry.member_ref),
+                );
                 continue;
             };
 
-            let original_member_ref = member_spawned.bridge_member_ref.clone();
+            let original_member_ref = entry.member_ref.clone();
             match &overlay.status {
                 crate::store::ExternalBindingOverlayStatus::Normalized => {
                     if let Some(normalized_member_ref) = overlay.normalized_member_ref.clone() {
-                        member_spawned.bridge_member_ref =
-                            Some(Self::member_ref_with_bootstrap_token(
-                                normalized_member_ref,
-                                overlay.bootstrap_token.clone(),
-                            ));
+                        entry.member_ref = Self::member_ref_with_bootstrap_token(
+                            normalized_member_ref,
+                            overlay.bootstrap_token.clone(),
+                        );
                     }
                 }
                 crate::store::ExternalBindingOverlayStatus::Failed { reason } => {
-                    let normalized_member_ref =
-                        overlay.normalized_member_ref.clone().or_else(|| {
-                            original_member_ref
-                                .as_ref()
-                                .and_then(Self::sessionless_member_ref)
-                        });
-                    member_spawned.bridge_member_ref = normalized_member_ref.map(|member_ref| {
-                        Self::member_ref_with_bootstrap_token(
-                            member_ref,
+                    let normalized_member_ref = overlay
+                        .normalized_member_ref
+                        .clone()
+                        .or_else(|| Self::sessionless_member_ref(&original_member_ref));
+                    if let Some(normalized_member_ref) = normalized_member_ref {
+                        entry.member_ref = Self::member_ref_with_bootstrap_token(
+                            normalized_member_ref,
                             overlay.bootstrap_token.clone(),
-                        )
-                    });
+                        );
+                    }
                     diagnostics.insert(
-                        MeerkatId::from(member_spawned.agent_identity.as_str()),
+                        MeerkatId::from(entry.agent_identity.as_str()),
                         super::handle::RestoreFailureDiagnostic {
-                            bridge_session_id: original_member_ref
-                                .as_ref()
-                                .and_then(crate::event::MemberRef::bridge_session_id)
-                                .cloned(),
+                            bridge_session_id: original_member_ref.bridge_session_id().cloned(),
                             reason: reason.clone(),
                         },
                     );
                 }
             }
 
-            member_spawned.runtime_mode = Self::normalize_runtime_mode_for_member_ref(
-                member_spawned.runtime_mode,
-                member_spawned.bridge_member_ref.as_ref(),
+            entry.runtime_mode = Self::normalize_runtime_mode_for_member_ref(
+                entry.runtime_mode,
+                Some(&entry.member_ref),
             );
         }
 
@@ -780,15 +805,18 @@ impl MobBuilder {
     }
 
     #[cfg(not(target_arch = "wasm32"))]
-    fn normalize_sessionless_backend_runtime_modes(mob_events: &mut [crate::event::MobEvent]) {
-        for event in mob_events {
-            let Some(member_spawned) = event.kind.member_spawned_mut() else {
-                continue;
-            };
-            member_spawned.runtime_mode = Self::normalize_runtime_mode_for_member_ref(
-                member_spawned.runtime_mode,
-                member_spawned.bridge_member_ref.as_ref(),
-            );
+    fn normalize_sessionless_backend_runtime_modes(roster: &mut Roster) {
+        let identities = roster
+            .list_all()
+            .map(|entry| entry.agent_identity.clone())
+            .collect::<Vec<_>>();
+        for identity in identities {
+            if let Some(entry) = roster.get_by_identity_mut(&identity) {
+                entry.runtime_mode = Self::normalize_runtime_mode_for_member_ref(
+                    entry.runtime_mode,
+                    Some(&entry.member_ref),
+                );
+            }
         }
     }
 

--- a/meerkat-mob/src/runtime/handle.rs
+++ b/meerkat-mob/src/runtime/handle.rs
@@ -7,7 +7,7 @@ use crate::roster::MobMemberKickoffSnapshot;
 use crate::runtime::MobLifecycleSnapshot;
 #[cfg(test)]
 use crate::runtime::mob_member_lifecycle_projection::{
-    CanonicalMemberSnapshotMaterial, CanonicalMemberStatus, CanonicalSessionObservation,
+    CanonicalMemberSnapshotMaterial, CanonicalMemberStatus,
 };
 use crate::runtime::reconcile::{
     EnsureMemberOutcome, MemberFilter, ReconcileFailure, ReconcileOptions, ReconcileReport,
@@ -3765,7 +3765,7 @@ mod tests {
         let snapshot = CanonicalMemberSnapshotMaterial {
             member_present: true,
             status: CanonicalMemberStatus::Active,
-            session_observation: CanonicalSessionObservation::Active,
+            terminal_class: mob_dsl::MobMemberTerminalClass::Running,
             error: None,
             output_preview: None,
             tokens_used: 0,

--- a/meerkat-mob/src/runtime/mob_member_lifecycle_projection.rs
+++ b/meerkat-mob/src/runtime/mob_member_lifecycle_projection.rs
@@ -1,4 +1,5 @@
 use crate::ids::{AgentRuntimeId, FenceToken};
+use crate::machines::mob_machine as mob_dsl;
 use crate::roster::MobMemberKickoffSnapshot;
 use crate::runtime::handle::{
     HelperResult, MobMemberSnapshot, MobMemberStatus, MobPeerConnectivitySnapshot,
@@ -14,27 +15,11 @@ pub(super) enum CanonicalMemberStatus {
     Completed,
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub(super) enum CanonicalSessionObservation {
-    Active,
-    Inactive,
-    Missing,
-    Unknown,
-}
-
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub(super) enum MobMemberTerminalClass {
-    Running,
-    TerminalFailure,
-    TerminalUnknown,
-    TerminalCompleted,
-}
-
 #[derive(Debug, Clone)]
 pub(super) struct CanonicalMemberSnapshotMaterial {
     pub(super) member_present: bool,
     pub(super) status: CanonicalMemberStatus,
-    pub(super) session_observation: CanonicalSessionObservation,
+    pub(super) terminal_class: mob_dsl::MobMemberTerminalClass,
     pub(super) error: Option<String>,
     pub(super) output_preview: Option<String>,
     pub(super) tokens_used: u64,
@@ -87,8 +72,7 @@ impl CanonicalMemberSnapshotMaterial {
 #[derive(Debug, Clone)]
 pub(super) struct MobMemberLifecycleInput {
     pub(super) member_present: bool,
-    pub(super) machine_status: CanonicalMemberStatus,
-    pub(super) session_observation: CanonicalSessionObservation,
+    pub(super) machine_lifecycle: mob_dsl::MobMemberLifecycleMaterial,
     pub(super) restore_failure: Option<String>,
     pub(super) output_preview: Option<String>,
     pub(super) tokens_used: u64,
@@ -102,28 +86,13 @@ pub(super) struct MobMemberLifecycleInput {
 pub(super) struct MobMemberLifecycleProjection;
 
 impl MobMemberLifecycleProjection {
-    pub(super) fn machine_status(
-        member_present: bool,
-        runtime_id_present: bool,
-        state_marker: Option<crate::machines::mob_machine::MobMemberState>,
-        runtime_live: bool,
-    ) -> CanonicalMemberStatus {
-        if !member_present {
-            return CanonicalMemberStatus::Unknown;
+    fn canonical_status(status: mob_dsl::MobMemberLifecycleStatus) -> CanonicalMemberStatus {
+        match status {
+            mob_dsl::MobMemberLifecycleStatus::Unknown => CanonicalMemberStatus::Unknown,
+            mob_dsl::MobMemberLifecycleStatus::Active => CanonicalMemberStatus::Active,
+            mob_dsl::MobMemberLifecycleStatus::Retiring => CanonicalMemberStatus::Retiring,
+            mob_dsl::MobMemberLifecycleStatus::Completed => CanonicalMemberStatus::Completed,
         }
-        if matches!(
-            state_marker,
-            Some(crate::machines::mob_machine::MobMemberState::Retiring)
-        ) {
-            return CanonicalMemberStatus::Retiring;
-        }
-        if runtime_id_present && runtime_live {
-            return CanonicalMemberStatus::Active;
-        }
-        if runtime_id_present {
-            return CanonicalMemberStatus::Completed;
-        }
-        CanonicalMemberStatus::Unknown
     }
 
     pub(super) fn materialize(input: MobMemberLifecycleInput) -> CanonicalMemberSnapshotMaterial {
@@ -135,7 +104,7 @@ impl MobMemberLifecycleProjection {
                 } else {
                     CanonicalMemberStatus::Unknown
                 },
-                session_observation: CanonicalSessionObservation::Missing,
+                terminal_class: mob_dsl::MobMemberTerminalClass::TerminalFailure,
                 error: Some(reason),
                 output_preview: None,
                 tokens_used: 0,
@@ -149,8 +118,8 @@ impl MobMemberLifecycleProjection {
 
         CanonicalMemberSnapshotMaterial {
             member_present: input.member_present,
-            status: input.machine_status,
-            session_observation: input.session_observation,
+            status: Self::canonical_status(input.machine_lifecycle.status),
+            terminal_class: input.machine_lifecycle.terminal_class,
             error: None,
             output_preview: input.output_preview,
             tokens_used: input.tokens_used,
@@ -162,25 +131,12 @@ impl MobMemberLifecycleProjection {
         }
     }
 
-    pub(super) fn classify(material: &CanonicalMemberSnapshotMaterial) -> MobMemberTerminalClass {
-        if !material.member_present {
-            return MobMemberTerminalClass::TerminalUnknown;
-        }
-        match material.status {
-            CanonicalMemberStatus::Retiring => MobMemberTerminalClass::Running,
-            CanonicalMemberStatus::Broken => MobMemberTerminalClass::TerminalFailure,
-            CanonicalMemberStatus::Active => MobMemberTerminalClass::Running,
-            CanonicalMemberStatus::Completed => MobMemberTerminalClass::TerminalCompleted,
-            CanonicalMemberStatus::Unknown => MobMemberTerminalClass::TerminalUnknown,
-        }
-    }
-
     pub(super) fn is_terminal(material: &CanonicalMemberSnapshotMaterial) -> bool {
         matches!(
-            Self::classify(material),
-            MobMemberTerminalClass::TerminalFailure
-                | MobMemberTerminalClass::TerminalUnknown
-                | MobMemberTerminalClass::TerminalCompleted
+            material.terminal_class,
+            mob_dsl::MobMemberTerminalClass::TerminalFailure
+                | mob_dsl::MobMemberTerminalClass::TerminalUnknown
+                | mob_dsl::MobMemberTerminalClass::TerminalCompleted
         )
     }
 }
@@ -194,8 +150,10 @@ mod tests {
     fn restore_failure_breaks_present_member() {
         let material = MobMemberLifecycleProjection::materialize(MobMemberLifecycleInput {
             member_present: true,
-            machine_status: CanonicalMemberStatus::Active,
-            session_observation: CanonicalSessionObservation::Active,
+            machine_lifecycle: mob_dsl::MobMemberLifecycleMaterial {
+                status: mob_dsl::MobMemberLifecycleStatus::Active,
+                terminal_class: mob_dsl::MobMemberTerminalClass::Running,
+            },
             restore_failure: Some("restore mismatch".into()),
             output_preview: Some("ignored".into()),
             tokens_used: 12,
@@ -213,13 +171,10 @@ mod tests {
     fn missing_active_session_means_completed_not_broken() {
         let material = MobMemberLifecycleProjection::materialize(MobMemberLifecycleInput {
             member_present: true,
-            machine_status: MobMemberLifecycleProjection::machine_status(
-                true,
-                true,
-                Some(crate::machines::mob_machine::MobMemberState::Active),
-                false,
-            ),
-            session_observation: CanonicalSessionObservation::Missing,
+            machine_lifecycle: mob_dsl::MobMemberLifecycleMaterial {
+                status: mob_dsl::MobMemberLifecycleStatus::Completed,
+                terminal_class: mob_dsl::MobMemberTerminalClass::TerminalCompleted,
+            },
             restore_failure: None,
             output_preview: None,
             tokens_used: 0,
@@ -237,13 +192,10 @@ mod tests {
     fn unknown_active_sessionless_member_stays_non_terminal() {
         let material = MobMemberLifecycleProjection::materialize(MobMemberLifecycleInput {
             member_present: true,
-            machine_status: MobMemberLifecycleProjection::machine_status(
-                true,
-                true,
-                Some(crate::machines::mob_machine::MobMemberState::Active),
-                true,
-            ),
-            session_observation: CanonicalSessionObservation::Unknown,
+            machine_lifecycle: mob_dsl::MobMemberLifecycleMaterial {
+                status: mob_dsl::MobMemberLifecycleStatus::Active,
+                terminal_class: mob_dsl::MobMemberTerminalClass::Running,
+            },
             restore_failure: None,
             output_preview: None,
             tokens_used: 0,
@@ -261,13 +213,10 @@ mod tests {
     fn retiring_member_is_non_terminal_even_if_session_missing() {
         let material = MobMemberLifecycleProjection::materialize(MobMemberLifecycleInput {
             member_present: true,
-            machine_status: MobMemberLifecycleProjection::machine_status(
-                true,
-                true,
-                Some(crate::machines::mob_machine::MobMemberState::Retiring),
-                false,
-            ),
-            session_observation: CanonicalSessionObservation::Missing,
+            machine_lifecycle: mob_dsl::MobMemberLifecycleMaterial {
+                status: mob_dsl::MobMemberLifecycleStatus::Retiring,
+                terminal_class: mob_dsl::MobMemberTerminalClass::Running,
+            },
             restore_failure: None,
             output_preview: None,
             tokens_used: 0,

--- a/meerkat-mob/src/runtime/roster_authority.rs
+++ b/meerkat-mob/src/runtime/roster_authority.rs
@@ -1,7 +1,6 @@
 use crate::event::MobEvent;
 use crate::ids::{AgentIdentity, Generation, MeerkatId, ProfileName};
 use crate::roster::{MobMemberKickoffSnapshot, Roster, RosterAddEntry, RosterEntry};
-use meerkat_core::comms::TrustedPeerDescriptor;
 
 mod sealed {
     pub trait Sealed {}
@@ -84,57 +83,6 @@ impl RosterAuthority {
     /// path's `Roster::apply` — same match arms, same mutations.
     pub(crate) fn apply_event(&mut self, event: &MobEvent) {
         self.roster.apply(event);
-    }
-
-    /// Restore a bidirectional local peer-wiring edge on the roster projection.
-    ///
-    /// Used by respawn wire-restoration: after a retire+spawn cycle the DSL
-    /// `wiring_edges` set still carries the edge (Retire does not clear it)
-    /// but the new `RosterEntry` for the replacement member starts with an
-    /// empty `wired_to` set. This helper re-projects the edge into both
-    /// endpoints without re-emitting `MembersWired` (the event is already in
-    /// the log from the original wire).
-    ///
-    /// Returns `true` if both endpoints were present and projected; `false`
-    /// if either endpoint was missing from the roster.
-    pub(crate) fn restore_local_peer_edge(&mut self, a: &AgentIdentity, b: &AgentIdentity) -> bool {
-        let a_present = self.roster.get_by_identity(a).is_some();
-        let b_present = self.roster.get_by_identity(b).is_some();
-        if !a_present || !b_present {
-            return false;
-        }
-        if let Some(entry_a) = self.roster.get_mut(a) {
-            entry_a.wired_to.insert(b.clone());
-        }
-        if let Some(entry_b) = self.roster.get_mut(b) {
-            entry_b.wired_to.insert(a.clone());
-        }
-        true
-    }
-
-    /// Restore an external peer-wiring edge on the roster projection.
-    ///
-    /// Mirrors what the (wave-A-deleted) `ExternalPeerWired` event projection
-    /// used to do: inserts the peer name into the local member's `wired_to`
-    /// set and records the `TrustedPeerDescriptor` in `external_peer_specs`.
-    /// Returns `true` if the local entry was present and mutated.
-    ///
-    /// Used by respawn/resume wire-restoration paths which must preserve
-    /// `RosterEntry.external_peer_specs` and `wired_to` across member
-    /// replacement (D31 restore).
-    pub(crate) fn restore_external_peer_edge(
-        &mut self,
-        local: &AgentIdentity,
-        spec: TrustedPeerDescriptor,
-    ) -> bool {
-        let peer_name = AgentIdentity::from(spec.name.as_str());
-        if let Some(entry) = self.roster.get_mut(local) {
-            entry.wired_to.insert(peer_name.clone());
-            entry.external_peer_specs.insert(peer_name, spec);
-            true
-        } else {
-            false
-        }
     }
 
     /// Flip a roster entry to `Retiring` state. Mirrors

--- a/meerkat-mob/src/runtime/tests.rs
+++ b/meerkat-mob/src/runtime/tests.rs
@@ -5362,6 +5362,63 @@ async fn test_stopped_runtime_commands_are_rejected_by_machine_admission() {
     );
 }
 
+struct StaticWorkerSpawnPolicy;
+
+#[async_trait]
+impl super::spawn_policy::SpawnPolicy for StaticWorkerSpawnPolicy {
+    async fn resolve(&self, _target: &AgentIdentity) -> Option<super::spawn_policy::SpawnSpec> {
+        Some(super::spawn_policy::SpawnSpec {
+            profile: ProfileName::from("worker"),
+            runtime_mode: Some(crate::MobRuntimeMode::TurnDriven),
+        })
+    }
+}
+
+#[tokio::test]
+async fn test_stopped_submit_work_auto_spawn_rejects_before_policy_provisioning() {
+    let (handle, service) = create_test_mob(sample_definition()).await;
+    handle
+        .set_spawn_policy(Some(Arc::new(StaticWorkerSpawnPolicy)))
+        .await
+        .expect("set spawn policy");
+    handle.stop().await.expect("stop");
+
+    let target = AgentIdentity::from("auto-stopped");
+    let result = handle
+        .submit_work(
+            AgentRuntimeId::initial(target.clone()),
+            FenceToken::new(0),
+            WorkRef::new(),
+            WorkSpec::new("queued while stopped".to_string(), WorkOrigin::External),
+        )
+        .await;
+
+    assert!(
+        matches!(
+            result,
+            Err(MobError::InvalidTransition {
+                from: MobState::Stopped,
+                to: MobState::Running,
+            })
+        ),
+        "stopped auto-spawn SubmitWork must surface MobMachine phase admission: {result:?}"
+    );
+    assert!(
+        handle.get_member(&target).await.is_none(),
+        "stopped SubmitWork must not auto-spawn the absent target"
+    );
+    assert_eq!(
+        service.recorded_create_requests().await.len(),
+        0,
+        "stopped SubmitWork must reject before policy provisioning side effects"
+    );
+    assert_eq!(
+        service.active_session_count().await,
+        0,
+        "stopped SubmitWork must not leak a provisioned session"
+    );
+}
+
 #[tokio::test]
 async fn test_register_tool_bundle_is_wired_into_spawn() {
     let definition = sample_definition_with_tool_bundle("bundle-a");

--- a/meerkat-mob/src/runtime/tests.rs
+++ b/meerkat-mob/src/runtime/tests.rs
@@ -5993,6 +5993,70 @@ async fn test_respawn_restores_local_wiring_from_mob_machine_edge() {
 }
 
 #[tokio::test]
+async fn test_respawn_ignores_machine_local_edge_to_retired_peer() {
+    let (handle, _service) = create_test_mob(sample_definition()).await;
+    let left = MeerkatId::from("respawn-stale-left");
+    let right = MeerkatId::from("respawn-stale-right");
+    handle
+        .spawn_with_options(
+            ProfileName::from("worker"),
+            left.clone(),
+            None,
+            Some(crate::MobRuntimeMode::TurnDriven),
+            None,
+        )
+        .await
+        .expect("spawn left");
+    handle
+        .spawn_with_options(
+            ProfileName::from("worker"),
+            right.clone(),
+            None,
+            Some(crate::MobRuntimeMode::TurnDriven),
+            None,
+        )
+        .await
+        .expect("spawn right");
+    handle
+        .wire(
+            AgentIdentity::from(left.as_str()),
+            PeerTarget::Local(AgentIdentity::from(right.as_str())),
+        )
+        .await
+        .expect("wire peers");
+
+    handle
+        .retire(AgentIdentity::from(right.as_str()))
+        .await
+        .expect("retire old peer");
+    assert!(
+        handle
+            .get_member(&AgentIdentity::from(right.as_str()))
+            .await
+            .is_none(),
+        "test setup should remove the old peer from the live roster"
+    );
+
+    handle
+        .respawn(
+            AgentIdentity::from(left.as_str()),
+            Some("ignore stale peer".into()),
+        )
+        .await
+        .expect("respawn should ignore machine edge to retired peer");
+    let left_after = handle
+        .get_member(&AgentIdentity::from(left.as_str()))
+        .await
+        .expect("left after respawn");
+    assert!(
+        !left_after
+            .wired_to
+            .contains(&AgentIdentity::from(right.as_str())),
+        "stale machine edge to retired peer must not be restored into roster projection"
+    );
+}
+
+#[tokio::test]
 async fn test_respawn_archive_failure_returns_cleanup_ambiguous_report() {
     let (handle, service) = create_test_mob(sample_definition()).await;
     let member_id = MeerkatId::from("respawn-ambiguous");

--- a/meerkat-mob/src/runtime/tests.rs
+++ b/meerkat-mob/src/runtime/tests.rs
@@ -5292,6 +5292,74 @@ async fn test_stop_persists_all_state_and_rejects_mutations() {
         .await
         .expect_err("spawn must be rejected while stopped");
     assert!(matches!(err, MobError::InvalidTransition { .. }));
+    assert_eq!(
+        service.active_session_count().await,
+        1,
+        "MobMachine spawn admission must reject before provisioning a stopped mob"
+    );
+}
+
+#[tokio::test]
+async fn test_stopped_runtime_commands_are_rejected_by_machine_admission() {
+    let (handle, _service) =
+        create_test_mob(sample_definition_with_single_step_flow(60_000, 8)).await;
+    handle
+        .spawn(ProfileName::from("worker"), MeerkatId::from("w-1"), None)
+        .await
+        .expect("spawn worker");
+    let entry = handle
+        .get_member(&AgentIdentity::from("w-1"))
+        .await
+        .expect("member exists");
+
+    handle.stop().await.expect("stop");
+
+    let submit = handle
+        .submit_work(
+            entry.agent_runtime_id.clone(),
+            entry.fence_token,
+            WorkRef::new(),
+            WorkSpec::new("queued while stopped".to_string(), WorkOrigin::Internal),
+        )
+        .await;
+    assert!(
+        matches!(
+            submit,
+            Err(MobError::InvalidTransition {
+                from: MobState::Stopped,
+                to: MobState::Running,
+            })
+        ),
+        "SubmitWork must surface the MobMachine stopped-phase rejection: {submit:?}"
+    );
+
+    let run_flow = handle
+        .run_flow(FlowId::from("demo"), serde_json::json!({}))
+        .await;
+    assert!(
+        matches!(
+            run_flow,
+            Err(MobError::InvalidTransition {
+                from: MobState::Stopped,
+                to: MobState::Running,
+            })
+        ),
+        "RunFlow must surface the MobMachine stopped-phase rejection: {run_flow:?}"
+    );
+
+    let respawn = handle.respawn(AgentIdentity::from("w-1"), None).await;
+    assert!(
+        matches!(
+            respawn,
+            Err(crate::runtime::handle::MobRespawnError::Mob(
+                MobError::InvalidTransition {
+                    from: MobState::Stopped,
+                    to: MobState::Running,
+                }
+            ))
+        ),
+        "Respawn must surface the MobMachine stopped-phase rejection: {respawn:?}"
+    );
 }
 
 #[tokio::test]
@@ -5848,6 +5916,79 @@ async fn test_respawn_success_restores_existing_peer_wiring() {
     assert_eq!(
         left_entry.agent_runtime_id, receipt.agent_runtime_id,
         "respawn receipt must align with the replacement member's canonical session binding"
+    );
+}
+
+#[tokio::test]
+async fn test_respawn_restores_local_wiring_from_mob_machine_edge() {
+    let (handle, _service) = create_test_mob(sample_definition()).await;
+    let left = MeerkatId::from("respawn-machine-left");
+    let right = MeerkatId::from("respawn-machine-right");
+    handle
+        .spawn_with_options(
+            ProfileName::from("worker"),
+            left.clone(),
+            None,
+            Some(crate::MobRuntimeMode::TurnDriven),
+            None,
+        )
+        .await
+        .expect("spawn left");
+    handle
+        .spawn_with_options(
+            ProfileName::from("worker"),
+            right.clone(),
+            None,
+            Some(crate::MobRuntimeMode::TurnDriven),
+            None,
+        )
+        .await
+        .expect("spawn right");
+
+    let edge = crate::machines::mob_machine::WiringEdge::new(
+        crate::machines::mob_machine::AgentIdentity::from(left.as_str()),
+        crate::machines::mob_machine::AgentIdentity::from(right.as_str()),
+    );
+    handle
+        .project_machine_input(crate::machines::mob_machine::MobMachineInput::WireMembers { edge })
+        .await
+        .expect("seed machine-owned edge without roster projection");
+    let left_before = handle
+        .get_member(&AgentIdentity::from(left.as_str()))
+        .await
+        .expect("left before respawn");
+    assert!(
+        !left_before
+            .wired_to
+            .contains(&AgentIdentity::from(right.as_str())),
+        "test setup must leave roster projection empty so MobMachine is the only topology source"
+    );
+
+    handle
+        .respawn(
+            AgentIdentity::from(left.as_str()),
+            Some("restore machine edge".into()),
+        )
+        .await
+        .expect("respawn succeeds");
+
+    let left_after = handle
+        .get_member(&AgentIdentity::from(left.as_str()))
+        .await
+        .expect("left after respawn");
+    let right_after = handle
+        .get_member(&AgentIdentity::from(right.as_str()))
+        .await
+        .expect("right after respawn");
+    assert!(
+        left_after
+            .wired_to
+            .contains(&AgentIdentity::from(right.as_str()))
+    );
+    assert!(
+        right_after
+            .wired_to
+            .contains(&AgentIdentity::from(left.as_str()))
     );
 }
 
@@ -8033,7 +8174,7 @@ async fn test_resume_recreates_missing_external_bridge_preserving_backend_identi
 }
 
 #[tokio::test]
-async fn test_resume_applies_normalized_external_binding_overlay_before_projection() {
+async fn test_resume_reconciles_normalized_external_binding_overlay_after_event_projection() {
     let service = Arc::new(MockSessionService::new());
     let _ = service.enable_runtime_adapter();
     let definition = sample_definition_with_external_backend();
@@ -8116,10 +8257,10 @@ async fn test_resume_applies_normalized_external_binding_overlay_before_projecti
             assert_eq!(address, old_address, "overlay must preserve peer address");
             assert_eq!(
                 session_id, None,
-                "normalized overlay must remove the legacy bridge session from replay"
+                "normalized overlay must remove the legacy bridge session from the effective binding"
             );
         }
-        other => panic!("expected backend peer after overlay replay, got {other:?}"),
+        other => panic!("expected backend peer after overlay reconciliation, got {other:?}"),
     }
 
     let snapshot = resumed
@@ -8255,7 +8396,7 @@ async fn test_resume_failed_external_binding_overlay_marks_member_broken() {
                 "failed normalization should still strip the legacy bridge session from replay"
             );
         }
-        other => panic!("expected backend peer after failed overlay replay, got {other:?}"),
+        other => panic!("expected backend peer after failed overlay reconciliation, got {other:?}"),
     }
 
     let snapshot = resumed
@@ -10248,6 +10389,79 @@ async fn test_respawn_restores_external_wiring_from_roster_spec() {
 }
 
 #[tokio::test]
+async fn test_respawn_restores_external_wiring_from_mob_machine_edge() {
+    let (handle, service) = create_test_mob(sample_definition()).await;
+    let old_sid = handle
+        .spawn(
+            ProfileName::from("lead"),
+            MeerkatId::from("l-machine"),
+            None,
+        )
+        .await
+        .expect("spawn lead")
+        .bridge_session_id()
+        .expect("session-backed")
+        .clone();
+
+    let external = TrustedPeerDescriptor::test_only_unsigned_typed(
+        "remote-mob/worker/machine-agent",
+        meerkat_core::comms::PeerId::new(),
+        "inproc://remote-mob/worker/machine-agent",
+    )
+    .expect("valid external peer");
+    let machine_edge = crate::machines::mob_machine::ExternalPeerEdge::new(
+        crate::machines::mob_machine::AgentIdentity::from("l-machine"),
+        crate::machines::mob_machine::ExternalPeerEndpoint::from(&external),
+    );
+    handle
+        .project_machine_input(
+            crate::machines::mob_machine::MobMachineInput::WireExternalPeer { edge: machine_edge },
+        )
+        .await
+        .expect("seed machine-owned external edge without roster projection");
+    let entry_before = handle
+        .get_member(&AgentIdentity::from("l-machine"))
+        .await
+        .expect("member before respawn");
+    assert!(
+        !entry_before
+            .external_peer_specs
+            .contains_key(&AgentIdentity::from(external.name.as_str())),
+        "test setup must leave roster projection empty so MobMachine is the only topology source"
+    );
+
+    let receipt = handle
+        .respawn(AgentIdentity::from("l-machine"), Some("resume".into()))
+        .await
+        .expect("respawn");
+    let entry = handle
+        .get_member(&AgentIdentity::from("l-machine"))
+        .await
+        .expect("member should exist");
+    let new_sid = entry
+        .member_ref
+        .bridge_session_id()
+        .cloned()
+        .expect("respawn should produce replacement session");
+    assert_ne!(new_sid, old_sid, "respawn should replace the session");
+
+    let trusted = service.trusted_peer_names(&new_sid).await;
+    assert!(
+        trusted.iter().any(|n| n == external.name.as_str()),
+        "respawn should restore external trust from MobMachine topology"
+    );
+    assert_eq!(
+        entry
+            .external_peer_specs
+            .get(&MeerkatId::from(external.name.as_str()))
+            .cloned(),
+        Some(external)
+    );
+    assert_eq!(entry.agent_runtime_id, receipt.agent_runtime_id);
+    assert_eq!(entry.fence_token, receipt.fence_token);
+}
+
+#[tokio::test]
 async fn test_unwire_external_removes_trust_and_projection() {
     let (handle, service) = create_test_mob(sample_definition()).await;
     let sid_l = handle
@@ -10317,6 +10531,81 @@ async fn test_unwire_external_removes_trust_and_projection() {
             .iter()
             .all(|edge| edge.a.0 != external.name.as_str() && edge.b.0 != external.name.as_str()),
         "external unwire should not touch member wiring_edges"
+    );
+}
+
+#[tokio::test]
+async fn test_resume_seeds_mob_machine_topology_from_event_projection() {
+    let service = Arc::new(MockSessionService::new());
+    let _ = service.enable_runtime_adapter();
+    let definition = sample_definition();
+    let storage = MobStorage::in_memory();
+    let events = storage.events.clone();
+    let runtime_metadata = storage.runtime_metadata.clone();
+    let handle = MobBuilder::new(definition.clone(), storage)
+        .with_session_service(service.clone())
+        .create()
+        .await
+        .expect("create mob");
+    handle
+        .spawn(ProfileName::from("lead"), MeerkatId::from("l-resume"), None)
+        .await
+        .expect("spawn lead");
+    handle
+        .spawn(
+            ProfileName::from("worker"),
+            MeerkatId::from("w-resume"),
+            None,
+        )
+        .await
+        .expect("spawn worker");
+    handle
+        .wire(AgentIdentity::from("l-resume"), MeerkatId::from("w-resume"))
+        .await
+        .expect("wire local peers");
+    let external = TrustedPeerDescriptor::test_only_unsigned_typed(
+        "remote-mob/worker/resume-agent",
+        meerkat_core::comms::PeerId::new(),
+        "inproc://remote-mob/worker/resume-agent",
+    )
+    .expect("valid external peer");
+    handle
+        .wire(
+            AgentIdentity::from("l-resume"),
+            PeerTarget::External(external.clone()),
+        )
+        .await
+        .expect("wire external peer");
+    handle.stop().await.expect("stop before resume");
+
+    let resumed = MobBuilder::for_resume(MobStorage::with_events_and_runtime_metadata(
+        events,
+        runtime_metadata,
+    ))
+    .with_session_service(service)
+    .resume()
+    .await
+    .expect("resume mob");
+
+    let dsl = resumed
+        .debug_dsl_t2_snapshot()
+        .await
+        .expect("debug dsl snapshot");
+    let local_edge = crate::machines::mob_machine::WiringEdge::new(
+        crate::machines::mob_machine::AgentIdentity::from("l-resume"),
+        crate::machines::mob_machine::AgentIdentity::from("w-resume"),
+    );
+    assert!(
+        dsl.wiring_edges.contains(&local_edge),
+        "resume must seed machine-owned local topology from event projection"
+    );
+    let external_edge = crate::machines::mob_machine::ExternalPeerEdge::new(
+        crate::machines::mob_machine::AgentIdentity::from("l-resume"),
+        crate::machines::mob_machine::ExternalPeerEndpoint::from(&external),
+    );
+    assert!(
+        dsl.external_peer_edges.contains(&external_edge),
+        "resume must seed machine-owned external topology from event projection"
     );
 }
 

--- a/meerkat-mob/src/runtime/tests.rs
+++ b/meerkat-mob/src/runtime/tests.rs
@@ -5420,6 +5420,47 @@ async fn test_stopped_submit_work_auto_spawn_rejects_before_policy_provisioning(
 }
 
 #[tokio::test]
+async fn test_running_submit_work_auto_spawn_non_addressable_rejects_before_policy_provisioning() {
+    let (handle, service) = create_test_mob(sample_definition()).await;
+    handle
+        .set_spawn_policy(Some(Arc::new(StaticWorkerSpawnPolicy)))
+        .await
+        .expect("set spawn policy");
+
+    let target = AgentIdentity::from("auto-running");
+    let result = handle
+        .submit_work(
+            AgentRuntimeId::initial(target.clone()),
+            FenceToken::new(0),
+            WorkRef::new(),
+            WorkSpec::new(
+                "queued for non-addressable policy profile".to_string(),
+                WorkOrigin::External,
+            ),
+        )
+        .await;
+
+    assert!(
+        matches!(result, Err(MobError::NotExternallyAddressable(_))),
+        "running external auto-spawn SubmitWork must surface MobMachine addressability admission: {result:?}"
+    );
+    assert!(
+        handle.get_member(&target).await.is_none(),
+        "non-addressable auto-spawn SubmitWork must not insert the rejected target"
+    );
+    assert_eq!(
+        service.recorded_create_requests().await.len(),
+        0,
+        "non-addressable auto-spawn SubmitWork must reject before policy provisioning side effects"
+    );
+    assert_eq!(
+        service.active_session_count().await,
+        0,
+        "non-addressable auto-spawn SubmitWork must not leak a provisioned session"
+    );
+}
+
+#[tokio::test]
 async fn test_register_tool_bundle_is_wired_into_spawn() {
     let definition = sample_definition_with_tool_bundle("bundle-a");
     let service = Arc::new(MockSessionService::new());

--- a/meerkat-mob/src/store/mod.rs
+++ b/meerkat-mob/src/store/mod.rs
@@ -136,7 +136,7 @@ impl SupervisorAuthorityRecord {
     }
 }
 
-/// Normalization status for a legacy external binding overlay.
+/// Reconciliation status for legacy external binding metadata.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub enum ExternalBindingOverlayStatus {
     /// The legacy external binding was normalized to a peer-only member ref.
@@ -145,7 +145,11 @@ pub enum ExternalBindingOverlayStatus {
     Failed { reason: String },
 }
 
-/// Authoritative runtime metadata for an external binding overlay.
+/// Runtime reconciliation metadata for a legacy external binding.
+///
+/// This record never creates roster membership. Resume first rebuilds the
+/// roster from `MemberSpawned`/`MemberRetired` events, then applies this
+/// generation-scoped record to the matching member's effective runtime binding.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct ExternalBindingOverlayRecord {
     /// Stable member identity.
@@ -225,7 +229,7 @@ pub trait MobRuntimeMetadataStore: Send + Sync {
     /// Delete the mob-owned supervisor authority record.
     async fn delete_supervisor_authority(&self, mob_id: &MobId) -> Result<(), MobStoreError>;
 
-    /// List all authoritative external binding overlays for a mob.
+    /// List all external binding reconciliation records for a mob.
     async fn list_external_binding_overlays(
         &self,
         mob_id: &MobId,


### PR DESCRIPTION
## Summary
- move mob member lifecycle/terminal classification into MobMachine-owned material and keep runtime projection as DTO mapping
- reconcile external binding overlay metadata after event projection without creating roster membership
- route spawn/respawn/submit/run-flow admission through MobMachine checks and restore respawn topology through normal wire paths

## Dogma Row Verification
- `/Users/luka/.codex/dogma-violations.md` was unavailable in this Linux workspace, so the Linear row text was used as the verification source.
- All four requested rows were still present in current code before edits; none were skipped as already solved.

## Validation
- `./scripts/repo-cargo test -p meerkat-mob mob_member_lifecycle_projection --lib`
- `./scripts/repo-cargo test -p meerkat-mob member_lifecycle_projection_is_derived_from_machine_membership --lib`
- `./scripts/repo-cargo test -p meerkat-mob respawn_restores --lib`
- `./scripts/repo-cargo test -p meerkat-mob test_respawn_success_restores_existing_peer_wiring --lib`
- `./scripts/repo-cargo test -p meerkat-mob external_binding_overlay --lib`
- `./scripts/repo-cargo test -p meerkat-mob test_resume_seeds_mob_machine_topology_from_event_projection --lib`
- `./scripts/repo-cargo test -p meerkat-mob test_stopped_runtime_commands_are_rejected_by_machine_admission --lib`
- `./scripts/repo-cargo test -p meerkat-mob test_stop_persists_all_state_and_rejects_mutations --lib`
- `./scripts/repo-cargo test -p meerkat-mob submit_work --lib`
- `./scripts/repo-cargo test -p meerkat-mob --test member_session_bindings`
- `./scripts/repo-cargo check -p meerkat-mob`
- `make check` (BuildBuddy invocation `8306ec0e-e242-4749-959d-5b2efd36e7df`)
- `make test` (BuildBuddy invocations `a17371f9-9f51-4e2a-94eb-e5bbcbef2840`, `a075b84e-768b-4cf4-8493-edb3402c594e`)
- `make lint` (BuildBuddy invocation `c470bf2b-4a5b-4ee1-9809-027742a50cfa`)
- `git diff --check`

Linear: LUC-89