### PR TITLE
Fix auth lifecycle authority

### DIFF
--- a/meerkat-cli/src/main.rs
+++ b/meerkat-cli/src/main.rs
@@ -2936,9 +2936,7 @@ async fn handle_auth_command(command: AuthCommands, scope: &RuntimeScope) -> any
                     .map_err(|e| anyhow::anyhow!("TokenStore load failed: {e}"))?
                 {
                     Some(tokens) => {
-                        let state_phase =
-                            AuthStatusPhase::from_persisted_tokens(Utc::now(), Some(&tokens));
-                        println!("state:       {}", state_phase.as_public_str());
+                        println!("state:       {}", AuthStatusPhase::Unknown.as_public_str());
                         println!("auth_mode:   {:?}", tokens.auth_mode);
                         println!(
                             "has_secret:  {}",
@@ -6733,9 +6731,11 @@ impl SurfaceScheduleSessionHost for CliScheduleSessionHost {
                     model: None,
                     provider: None,
                     provider_params: None,
+                    clear_provider_params: false,
                     render_metadata: dispatch.render_metadata.clone(),
                     execution_kind: None,
                     connection_ref: None,
+                    clear_connection_ref: false,
                 },
             ),
         );

--- a/meerkat-contracts/src/wire/runtime.rs
+++ b/meerkat-contracts/src/wire/runtime.rs
@@ -766,8 +766,12 @@ pub struct WireRuntimeTurnMetadata {
     pub provider: Option<meerkat_core::Provider>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub provider_params: Option<WireProviderParamsOverride>,
+    #[serde(default, skip_serializing_if = "is_false")]
+    pub clear_provider_params: bool,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub connection_ref: Option<crate::wire::connection::WireConnectionRef>,
+    #[serde(default, skip_serializing_if = "is_false")]
+    pub clear_connection_ref: bool,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub keep_alive: Option<WireKeepAlivePolicy>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -820,7 +824,9 @@ impl From<meerkat_core::lifecycle::run_primitive::RuntimeTurnMetadata> for WireR
             model: value.model.map(|m| m.as_str().to_string()),
             provider: value.provider,
             provider_params: value.provider_params.map(Into::into),
+            clear_provider_params: value.clear_provider_params,
             connection_ref: value.connection_ref.map(Into::into),
+            clear_connection_ref: value.clear_connection_ref,
             keep_alive: value.keep_alive.map(Into::into),
             render_metadata: value.render_metadata.map(Into::into),
             execution_kind: value.execution_kind.map(Into::into),
@@ -841,10 +847,16 @@ impl From<WireRuntimeTurnMetadata> for meerkat_core::lifecycle::run_primitive::R
             model: value.model.map(ModelId::new),
             provider: value.provider,
             provider_params: value.provider_params.map(Into::into),
+            clear_provider_params: value.clear_provider_params,
             connection_ref: value.connection_ref.map(Into::into),
+            clear_connection_ref: value.clear_connection_ref,
             keep_alive: value.keep_alive.map(Into::into),
             render_metadata: value.render_metadata.map(Into::into),
             execution_kind: value.execution_kind.map(Into::into),
         }
     }
+}
+
+fn is_false(value: &bool) -> bool {
+    !*value
 }

--- a/meerkat-core/src/auth/lifecycle.rs
+++ b/meerkat-core/src/auth/lifecycle.rs
@@ -1,0 +1,177 @@
+//! Auth lifecycle publication helpers.
+//!
+//! TokenStore owns credential material. AuthMachine owns lifecycle state.
+//! Surfaces that write or clear credentials use these helpers so the public
+//! status path observes the machine-owned lease instead of deriving phase from
+//! persisted token bytes.
+
+use chrono::{DateTime, Utc};
+
+use super::token_store::PersistedTokens;
+use crate::connection::ConnectionRef;
+use crate::handles::{AuthLeaseHandle, AuthLeaseSnapshot, DslTransitionError, LeaseKey};
+
+pub fn persisted_token_expires_at_epoch_secs(tokens: &PersistedTokens) -> u64 {
+    tokens
+        .expires_at
+        .map(|ts| ts.timestamp().max(0) as u64)
+        .unwrap_or(u64::MAX)
+}
+
+pub fn publish_token_lifecycle_acquired(
+    handle: &dyn AuthLeaseHandle,
+    connection_ref: &ConnectionRef,
+    tokens: &PersistedTokens,
+) -> Result<(), DslTransitionError> {
+    let lease_key = LeaseKey::from_connection_ref(connection_ref);
+    handle.acquire_lease(&lease_key, persisted_token_expires_at_epoch_secs(tokens))
+}
+
+pub fn publish_token_lifecycle_released(
+    handle: &dyn AuthLeaseHandle,
+    connection_ref: &ConnectionRef,
+) -> Result<(), DslTransitionError> {
+    let lease_key = LeaseKey::from_connection_ref(connection_ref);
+    handle.release_lease(&lease_key)
+}
+
+pub fn lease_snapshot_expires_at_datetime(snapshot: &AuthLeaseSnapshot) -> Option<DateTime<Utc>> {
+    snapshot
+        .expires_at
+        .and_then(|secs| i64::try_from(secs).ok())
+        .and_then(|secs| DateTime::<Utc>::from_timestamp(secs, 0))
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used)]
+mod tests {
+    use super::*;
+    use std::sync::Mutex;
+
+    use crate::auth::PersistedAuthMode;
+    use crate::connection::{BindingId, RealmId};
+    use crate::handles::{AuthLeasePhase, DslTransitionError};
+
+    #[derive(Default)]
+    struct RecordingAuthLeaseHandle {
+        acquired: Mutex<Vec<(LeaseKey, u64)>>,
+        released: Mutex<Vec<LeaseKey>>,
+    }
+
+    impl RecordingAuthLeaseHandle {
+        fn acquired(&self) -> Vec<(LeaseKey, u64)> {
+            self.acquired
+                .lock()
+                .unwrap_or_else(std::sync::PoisonError::into_inner)
+                .clone()
+        }
+    }
+
+    impl AuthLeaseHandle for RecordingAuthLeaseHandle {
+        fn acquire_lease(
+            &self,
+            lease_key: &LeaseKey,
+            expires_at: u64,
+        ) -> Result<(), DslTransitionError> {
+            self.acquired
+                .lock()
+                .unwrap_or_else(std::sync::PoisonError::into_inner)
+                .push((lease_key.clone(), expires_at));
+            Ok(())
+        }
+
+        fn mark_expiring(&self, _lease_key: &LeaseKey) -> Result<(), DslTransitionError> {
+            Ok(())
+        }
+
+        fn begin_refresh(&self, _lease_key: &LeaseKey) -> Result<(), DslTransitionError> {
+            Ok(())
+        }
+
+        fn complete_refresh(
+            &self,
+            _lease_key: &LeaseKey,
+            _new_expires_at: u64,
+            _now: u64,
+        ) -> Result<(), DslTransitionError> {
+            Ok(())
+        }
+
+        fn refresh_failed(
+            &self,
+            _lease_key: &LeaseKey,
+            _permanent: bool,
+        ) -> Result<(), DslTransitionError> {
+            Ok(())
+        }
+
+        fn mark_reauth_required(&self, _lease_key: &LeaseKey) -> Result<(), DslTransitionError> {
+            Ok(())
+        }
+
+        fn release_lease(&self, lease_key: &LeaseKey) -> Result<(), DslTransitionError> {
+            self.released
+                .lock()
+                .unwrap_or_else(std::sync::PoisonError::into_inner)
+                .push(lease_key.clone());
+            Ok(())
+        }
+
+        fn snapshot(&self, _lease_key: &LeaseKey) -> AuthLeaseSnapshot {
+            AuthLeaseSnapshot {
+                phase: Some(AuthLeasePhase::Valid),
+                expires_at: None,
+            }
+        }
+    }
+
+    fn connection_ref() -> ConnectionRef {
+        ConnectionRef {
+            realm: RealmId::parse("dev").expect("valid realm"),
+            binding: BindingId::parse("default_openai").expect("valid binding"),
+            profile: None,
+        }
+    }
+
+    fn tokens_with_expiry(expires_at: Option<DateTime<Utc>>) -> PersistedTokens {
+        PersistedTokens {
+            auth_mode: PersistedAuthMode::ApiKey,
+            primary_secret: Some("secret".into()),
+            refresh_token: None,
+            id_token: None,
+            expires_at,
+            last_refresh: None,
+            scopes: Vec::new(),
+            account_id: None,
+            metadata: serde_json::Value::Null,
+        }
+    }
+
+    #[test]
+    fn lifecycle_acquire_uses_persisted_token_expiry_as_machine_input() {
+        let handle = RecordingAuthLeaseHandle::default();
+        let expires_at = DateTime::<Utc>::from_timestamp(1_800_000_000, 0).unwrap();
+        let tokens = tokens_with_expiry(Some(expires_at));
+        let connection_ref = connection_ref();
+
+        publish_token_lifecycle_acquired(&handle, &connection_ref, &tokens).unwrap();
+
+        assert_eq!(
+            handle.acquired(),
+            vec![(
+                LeaseKey::from_connection_ref(&connection_ref),
+                1_800_000_000
+            )]
+        );
+    }
+
+    #[test]
+    fn lifecycle_acquire_maps_non_expiring_tokens_to_unbounded_lease() {
+        let handle = RecordingAuthLeaseHandle::default();
+        let tokens = tokens_with_expiry(None);
+
+        publish_token_lifecycle_acquired(&handle, &connection_ref(), &tokens).unwrap();
+
+        assert_eq!(handle.acquired()[0].1, u64::MAX);
+    }
+}

--- a/meerkat-core/src/auth/mod.rs
+++ b/meerkat-core/src/auth/mod.rs
@@ -7,6 +7,7 @@
 
 pub mod error;
 pub mod lease;
+pub mod lifecycle;
 pub mod metadata;
 pub mod principal;
 pub mod status;
@@ -16,6 +17,10 @@ pub use error::{AuthError, AuthErrorKind};
 pub use lease::{
     AuthConstraints, AuthLease, AuthRefreshReason, HttpAuthorizationRequest, HttpAuthorizer,
     ResolvedAuthEnvelope, ResolvedAuthKind,
+};
+pub use lifecycle::{
+    lease_snapshot_expires_at_datetime, persisted_token_expires_at_epoch_secs,
+    publish_token_lifecycle_acquired, publish_token_lifecycle_released,
 };
 pub use metadata::{
     AnthropicAuthMetadata, AnthropicRouteHints, AuthMetadata, AuthMetadataDefaults, AuthRouteHints,

--- a/meerkat-core/src/auth/status.rs
+++ b/meerkat-core/src/auth/status.rs
@@ -4,8 +4,7 @@ use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 
 use super::error::AuthErrorKind;
-use super::token_store::PersistedTokens;
-use crate::handles::{AUTH_LEASE_TTL_REFRESH_WINDOW_SECS, AuthLeasePhase};
+use crate::handles::{AUTH_LEASE_TTL_REFRESH_WINDOW_SECS, AuthLeasePhase, AuthLeaseSnapshot};
 use crate::provider::Provider;
 
 /// Public auth status phase shared by REST, RPC, CLI, and generated SDK wire
@@ -46,25 +45,41 @@ impl AuthStatusPhase {
         }
     }
 
-    pub fn from_persisted_tokens(now: DateTime<Utc>, tokens: Option<&PersistedTokens>) -> Self {
-        match tokens {
-            Some(tokens) => Self::from_expires_at(now, tokens.expires_at),
-            None => Self::Unknown,
+    pub fn from_lease_snapshot(now: DateTime<Utc>, snapshot: &AuthLeaseSnapshot) -> Self {
+        match snapshot.phase {
+            Some(AuthLeasePhase::Valid) => Self::from_lease_expires_at(now, snapshot.expires_at),
+            Some(AuthLeasePhase::Expiring | AuthLeasePhase::Refreshing) => {
+                match snapshot.expires_at {
+                    Some(expires_at) if epoch_secs_expired(now, expires_at) => Self::Expired,
+                    _ => Self::Expiring,
+                }
+            }
+            Some(AuthLeasePhase::ReauthRequired) => Self::ReauthRequired,
+            Some(AuthLeasePhase::Released) | None => Self::Unknown,
         }
     }
 
-    pub fn from_expires_at(now: DateTime<Utc>, expires_at: Option<DateTime<Utc>>) -> Self {
+    pub fn from_lease_expires_at(now: DateTime<Utc>, expires_at: Option<u64>) -> Self {
         match expires_at {
-            Some(expires_at) if expires_at <= now => Self::Expired,
+            Some(expires_at) if epoch_secs_expired(now, expires_at) => Self::Expired,
             Some(expires_at)
-                if expires_at - now
-                    < chrono::Duration::seconds(AUTH_LEASE_TTL_REFRESH_WINDOW_SECS as i64) =>
+                if epoch_secs_until(now, expires_at)
+                    < AUTH_LEASE_TTL_REFRESH_WINDOW_SECS as i64 =>
             {
                 Self::Expiring
             }
             Some(_) | None => Self::Valid,
         }
     }
+}
+
+fn epoch_secs_expired(now: DateTime<Utc>, expires_at: u64) -> bool {
+    epoch_secs_until(now, expires_at) <= 0
+}
+
+fn epoch_secs_until(now: DateTime<Utc>, expires_at: u64) -> i64 {
+    let expires_at = i64::try_from(expires_at).unwrap_or(i64::MAX);
+    expires_at.saturating_sub(now.timestamp())
 }
 
 /// Status snapshot of a resolved (or unresolved) auth profile.
@@ -107,20 +122,6 @@ mod tests {
     use super::*;
     use chrono::{Duration, TimeZone};
 
-    fn tokens_with_expiry(expires_at: Option<DateTime<Utc>>) -> PersistedTokens {
-        PersistedTokens {
-            auth_mode: crate::auth::PersistedAuthMode::ApiKey,
-            primary_secret: Some("secret".into()),
-            refresh_token: None,
-            id_token: None,
-            expires_at,
-            last_refresh: None,
-            scopes: Vec::new(),
-            account_id: None,
-            metadata: serde_json::Value::Null,
-        }
-    }
-
     #[test]
     fn auth_status_roundtrip() {
         let status = AuthStatus {
@@ -155,23 +156,33 @@ mod tests {
     }
 
     #[test]
-    fn auth_status_phase_maps_persisted_token_expiry_to_public_values() {
+    fn auth_status_phase_maps_lease_snapshot_expiry_to_public_values() {
         let now = Utc.with_ymd_and_hms(2026, 4, 28, 12, 0, 0).unwrap();
 
-        let valid = tokens_with_expiry(Some(now + Duration::minutes(10)));
+        let valid = AuthLeaseSnapshot {
+            phase: Some(AuthLeasePhase::Valid),
+            expires_at: Some((now + Duration::minutes(10)).timestamp() as u64),
+        };
         assert_eq!(
-            AuthStatusPhase::from_persisted_tokens(now, Some(&valid)).as_public_str(),
+            AuthStatusPhase::from_lease_snapshot(now, &valid).as_public_str(),
             "valid"
         );
 
-        let expired = tokens_with_expiry(Some(now - Duration::seconds(1)));
+        let expired = AuthLeaseSnapshot {
+            phase: Some(AuthLeasePhase::Valid),
+            expires_at: Some((now - Duration::seconds(1)).timestamp() as u64),
+        };
         assert_eq!(
-            AuthStatusPhase::from_persisted_tokens(now, Some(&expired)).as_public_str(),
+            AuthStatusPhase::from_lease_snapshot(now, &expired).as_public_str(),
             "expired"
         );
 
+        let stale_token_without_machine = AuthLeaseSnapshot {
+            phase: None,
+            expires_at: Some((now + Duration::minutes(10)).timestamp() as u64),
+        };
         assert_eq!(
-            AuthStatusPhase::from_persisted_tokens(now, None).as_public_str(),
+            AuthStatusPhase::from_lease_snapshot(now, &stale_token_without_machine).as_public_str(),
             "unknown"
         );
     }
@@ -185,6 +196,10 @@ mod tests {
         assert_eq!(
             AuthStatusPhase::from_lease_phase(Some(AuthLeasePhase::Expiring)).as_public_str(),
             "expiring"
+        );
+        assert_eq!(
+            AuthStatusPhase::from_lease_phase(Some(AuthLeasePhase::ReauthRequired)).as_public_str(),
+            "reauth_required"
         );
         assert_eq!(
             AuthStatusPhase::from_lease_phase(None).as_public_str(),

--- a/meerkat-core/src/connection.rs
+++ b/meerkat-core/src/connection.rs
@@ -112,6 +112,14 @@ pub struct ConnectionRef {
     pub profile: Option<ProfileId>,
 }
 
+impl ConnectionRef {
+    pub fn is_env_default(&self) -> bool {
+        self.realm.as_str() == "env_default"
+            && self.binding.as_str() == "default"
+            && self.profile.is_none()
+    }
+}
+
 /// Backend profile: where requests go and which backend contract applies.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 #[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
@@ -390,14 +398,8 @@ pub fn resolve_connection_ref_or_default_for_provider(
 ) -> Result<ResolvedConnectionTarget, ConnectionTargetError> {
     if let Some(connection_ref) = connection_ref {
         let realm_id = connection_ref.realm.as_str();
-        if realm_id == "env_default" && connection_ref.binding.as_str() == "default" {
-            let realm = RealmConnectionSet::synthesize_env_default(provider);
-            return materialize_connection_target(
-                realm,
-                provider,
-                connection_ref.binding.clone(),
-                connection_ref.profile.clone(),
-            );
+        if connection_ref.is_env_default() {
+            return Err(ConnectionTargetError::UnknownRealm(realm_id.to_string()));
         }
         let section = config
             .realm

--- a/meerkat-core/src/lib.rs
+++ b/meerkat-core/src/lib.rs
@@ -289,6 +289,8 @@ pub use auth::{
     AuthRouteHints, AuthStatus, AuthStatusPhase, GoogleAuthMetadata, GoogleRouteHints,
     HttpAuthorizationRequest, HttpAuthorizer, OpenAiAuthMetadata, OpenAiRouteHints,
     ProviderAuthMetadata, ResolvedAuthEnvelope, ResolvedAuthKind,
+    lease_snapshot_expires_at_datetime, persisted_token_expires_at_epoch_secs,
+    publish_token_lifecycle_acquired, publish_token_lifecycle_released,
 };
 pub use connection::{
     AuthProfile, AuthProfileConfig, BackendProfile, BackendProfileConfig, BindingId, BindingPolicy,

--- a/meerkat-core/src/lifecycle/run_primitive.rs
+++ b/meerkat-core/src/lifecycle/run_primitive.rs
@@ -927,9 +927,17 @@ pub struct RuntimeTurnMetadata {
     /// Override provider-specific parameters for this turn (typed; no Value).
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub provider_params: Option<ProviderParamsOverride>,
+    /// Explicitly clear durable provider params. Omitted `provider_params`
+    /// means inherit the current session value.
+    #[serde(default, skip_serializing_if = "is_false")]
+    pub clear_provider_params: bool,
     /// Explicit connection reference this turn must resolve against.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub connection_ref: Option<ConnectionRef>,
+    /// Explicitly clear durable connection_ref. Omitted `connection_ref`
+    /// means inherit the current session value.
+    #[serde(default, skip_serializing_if = "is_false")]
+    pub clear_connection_ref: bool,
     /// Keep-alive policy for materialized resources for this turn.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub keep_alive: Option<KeepAlivePolicy>,
@@ -957,7 +965,9 @@ impl RuntimeTurnMetadata {
             && self.model.is_none()
             && self.provider.is_none()
             && self.provider_params.is_none()
+            && !self.clear_provider_params
             && self.connection_ref.is_none()
+            && !self.clear_connection_ref
             && self.keep_alive.is_none()
             && self.render_metadata.is_none()
             && self.execution_kind.is_none()
@@ -981,16 +991,32 @@ impl RuntimeTurnMetadata {
         )?;
         merge_scalar(&mut self.model, other.model, "model")?;
         merge_scalar(&mut self.provider, other.provider, "provider")?;
+        reject_set_clear_conflict(
+            self.provider_params.is_some(),
+            self.clear_provider_params,
+            other.provider_params.is_some(),
+            other.clear_provider_params,
+            "provider_params",
+        )?;
         merge_scalar(
             &mut self.provider_params,
             other.provider_params,
             "provider_params",
+        )?;
+        self.clear_provider_params |= other.clear_provider_params;
+        reject_set_clear_conflict(
+            self.connection_ref.is_some(),
+            self.clear_connection_ref,
+            other.connection_ref.is_some(),
+            other.clear_connection_ref,
+            "connection_ref",
         )?;
         merge_scalar(
             &mut self.connection_ref,
             other.connection_ref,
             "connection_ref",
         )?;
+        self.clear_connection_ref |= other.clear_connection_ref;
         merge_scalar(&mut self.keep_alive, other.keep_alive, "keep_alive")?;
         merge_scalar(
             &mut self.render_metadata,
@@ -1016,6 +1042,26 @@ impl RuntimeTurnMetadata {
         }
         Ok(())
     }
+}
+
+fn is_false(value: &bool) -> bool {
+    !*value
+}
+
+fn reject_set_clear_conflict(
+    lhs_set: bool,
+    lhs_clear: bool,
+    rhs_set: bool,
+    rhs_clear: bool,
+    field: &'static str,
+) -> Result<(), TurnMetadataMergeConflict> {
+    if (lhs_set && rhs_clear) || (lhs_clear && rhs_set) {
+        return Err(TurnMetadataMergeConflict {
+            field,
+            reason: "one input sets the field while another clears it",
+        });
+    }
+    Ok(())
 }
 
 fn merge_scalar<T: PartialEq>(

--- a/meerkat-core/tests/runtime_turn_metadata_typed_round_trip.rs
+++ b/meerkat-core/tests/runtime_turn_metadata_typed_round_trip.rs
@@ -51,12 +51,14 @@ fn sample_metadata() -> RuntimeTurnMetadata {
                 ..Default::default()
             })),
         }),
+        clear_provider_params: false,
         connection_ref: Some(ConnectionRef {
             realm: meerkat_core::connection::RealmId::parse("dev").expect("valid realm"),
             binding: meerkat_core::connection::BindingId::parse("default_anthropic")
                 .expect("valid binding"),
             profile: None,
         }),
+        clear_connection_ref: false,
         keep_alive: Some(KeepAlivePolicy {
             ttl: Duration::from_secs(60),
             policy: KeepAliveMode::Pinned,
@@ -119,6 +121,27 @@ fn empty_metadata_round_trips_without_allocating_fields() {
     assert!(meta.is_empty());
     let json = serde_json::to_value(&meta).expect("serialize");
     assert_eq!(json, serde_json::json!({}), "empty metadata must emit {{}}");
+    let parsed: RuntimeTurnMetadata = serde_json::from_value(json).expect("deserialize");
+    assert_eq!(meta, parsed);
+}
+
+#[test]
+fn clear_flags_round_trip_and_are_not_empty() {
+    let meta = RuntimeTurnMetadata {
+        clear_provider_params: true,
+        clear_connection_ref: true,
+        ..Default::default()
+    };
+    assert!(!meta.is_empty());
+
+    let json = serde_json::to_value(&meta).expect("serialize");
+    assert_eq!(
+        json,
+        serde_json::json!({
+            "clear_provider_params": true,
+            "clear_connection_ref": true,
+        })
+    );
     let parsed: RuntimeTurnMetadata = serde_json::from_value(json).expect("deserialize");
     assert_eq!(meta, parsed);
 }
@@ -210,6 +233,67 @@ fn merge_scalar_conflict_refuses_connection_ref() {
             binding: meerkat_core::connection::BindingId::parse("b").expect("valid binding"),
             profile: None,
         }),
+        ..Default::default()
+    };
+    let err = left.merge(right).expect_err("conflict expected");
+    assert_eq!(err.field, "connection_ref");
+}
+
+#[test]
+fn merge_refuses_provider_params_set_and_clear() {
+    let mut left = RuntimeTurnMetadata {
+        provider_params: Some(ProviderParamsOverride {
+            temperature: Some(0.2),
+            ..Default::default()
+        }),
+        ..Default::default()
+    };
+    let right = RuntimeTurnMetadata {
+        clear_provider_params: true,
+        ..Default::default()
+    };
+    let err = left.merge(right).expect_err("conflict expected");
+    assert_eq!(err.field, "provider_params");
+
+    let mut left = RuntimeTurnMetadata {
+        clear_provider_params: true,
+        ..Default::default()
+    };
+    let right = RuntimeTurnMetadata {
+        provider_params: Some(ProviderParamsOverride {
+            top_p: Some(0.9),
+            ..Default::default()
+        }),
+        ..Default::default()
+    };
+    let err = left.merge(right).expect_err("conflict expected");
+    assert_eq!(err.field, "provider_params");
+}
+
+#[test]
+fn merge_refuses_connection_ref_set_and_clear() {
+    let connection_ref = ConnectionRef {
+        realm: meerkat_core::connection::RealmId::parse("dev").expect("valid realm"),
+        binding: meerkat_core::connection::BindingId::parse("default").expect("valid binding"),
+        profile: None,
+    };
+    let mut left = RuntimeTurnMetadata {
+        connection_ref: Some(connection_ref.clone()),
+        ..Default::default()
+    };
+    let right = RuntimeTurnMetadata {
+        clear_connection_ref: true,
+        ..Default::default()
+    };
+    let err = left.merge(right).expect_err("conflict expected");
+    assert_eq!(err.field, "connection_ref");
+
+    let mut left = RuntimeTurnMetadata {
+        clear_connection_ref: true,
+        ..Default::default()
+    };
+    let right = RuntimeTurnMetadata {
+        connection_ref: Some(connection_ref),
         ..Default::default()
     };
     let err = left.merge(right).expect_err("conflict expected");

--- a/meerkat-rest/src/auth_endpoints.rs
+++ b/meerkat-rest/src/auth_endpoints.rs
@@ -24,6 +24,7 @@ use meerkat_contracts::{
     WireRealmList, WireRealmSummary,
 };
 use meerkat_core::connection::{BindingId, ConnectionTargetError, ProfileId, RealmId};
+use meerkat_core::handles::LeaseKey;
 use meerkat_core::{
     AuthStatusPhase, ConnectionRef, CredentialSourceSpec, Provider, RealmConnectionSet,
     ResolvedConnectionTarget,
@@ -32,7 +33,7 @@ use meerkat_providers::auth_oauth::{
     DevicePollOutcome, OAuthError, PkcePair, exchange_authorization_code, poll_device_code,
     request_device_code,
 };
-use meerkat_providers::auth_store::{PersistedAuthMode, PersistedTokens, TokenKey};
+use meerkat_providers::auth_store::{PersistedAuthMode, PersistedTokens, TokenKey, TokenStore};
 use meerkat_providers::oauth_flow::{
     OAuthFlowError, global_oauth_flow_registry, resolve_oauth_provider,
 };
@@ -172,6 +173,51 @@ fn source_kind_label(source: &CredentialSourceSpec) -> &'static str {
         CredentialSourceSpec::Command { .. } => "command",
         CredentialSourceSpec::FileDescriptor { .. } => "file_descriptor",
     }
+}
+
+async fn save_tokens_and_publish_lifecycle(
+    token_store: &dyn TokenStore,
+    auth_lease: &dyn meerkat_core::handles::AuthLeaseHandle,
+    connection_ref: &ConnectionRef,
+    tokens: &PersistedTokens,
+) -> Result<(), (StatusCode, String)> {
+    let key = TokenKey::from_connection_ref(connection_ref);
+    token_store.save(&key, tokens).await.map_err(|e| {
+        (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            format!("TokenStore save failed: {e}"),
+        )
+    })?;
+    if let Err(e) =
+        meerkat_core::publish_token_lifecycle_acquired(auth_lease, connection_ref, tokens)
+    {
+        let _ = token_store.clear(&key).await;
+        return Err((
+            StatusCode::INTERNAL_SERVER_ERROR,
+            format!("AuthMachine lifecycle acquire failed: {e}"),
+        ));
+    }
+    Ok(())
+}
+
+async fn clear_tokens_and_publish_lifecycle(
+    token_store: &dyn TokenStore,
+    auth_lease: &dyn meerkat_core::handles::AuthLeaseHandle,
+    connection_ref: &ConnectionRef,
+) -> Result<(), (StatusCode, String)> {
+    let key = TokenKey::from_connection_ref(connection_ref);
+    token_store.clear(&key).await.map_err(|e| {
+        (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            format!("TokenStore clear failed: {e}"),
+        )
+    })?;
+    meerkat_core::publish_token_lifecycle_released(auth_lease, connection_ref).map_err(|e| {
+        (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            format!("AuthMachine lifecycle release failed: {e}"),
+        )
+    })
 }
 
 // --- Realm endpoints -------------------------------------------------
@@ -345,35 +391,35 @@ pub async fn create_auth_profile(
         account_id: None,
         metadata: serde_json::Value::Null,
     };
-    let key = TokenKey::from_connection_ref(&connection_ref);
-    match state.token_store.save(&key, &tokens).await {
-        Ok(()) => {
-            tracing::info!(
-                target: "meerkat::auth::audit",
-                binding_key = ?connection_ref,
-                action = "create_profile",
-                provider = %auth_profile.provider.as_str(),
-                auth_method = %auth_profile.auth_method,
-                "binding-scoped auth credentials stored via REST"
-            );
-            (
-                StatusCode::CREATED,
-                Json(WireAuthProfileCreated {
-                    identity: WireBindingIdentity::from(&connection_ref),
-                    profile_id: auth_profile.id.clone(),
-                    provider: auth_profile.provider.as_str().to_string(),
-                    auth_method: auth_profile.auth_method.clone(),
-                    stored: true,
-                }),
-            )
-                .into_response()
-        }
-        Err(e) => (
-            StatusCode::INTERNAL_SERVER_ERROR,
-            Json(serde_json::json!({ "error": format!("TokenStore save failed: {e}") })),
-        )
-            .into_response(),
+    if let Err((status, msg)) = save_tokens_and_publish_lifecycle(
+        state.token_store.as_ref(),
+        state.auth_lease.as_ref(),
+        &connection_ref,
+        &tokens,
+    )
+    .await
+    {
+        return (status, Json(serde_json::json!({ "error": msg }))).into_response();
     }
+    tracing::info!(
+        target: "meerkat::auth::audit",
+        binding_key = ?connection_ref,
+        action = "create_profile",
+        provider = %auth_profile.provider.as_str(),
+        auth_method = %auth_profile.auth_method,
+        "binding-scoped auth credentials stored via REST"
+    );
+    (
+        StatusCode::CREATED,
+        Json(WireAuthProfileCreated {
+            identity: WireBindingIdentity::from(&connection_ref),
+            profile_id: auth_profile.id.clone(),
+            provider: auth_profile.provider.as_str().to_string(),
+            auth_method: auth_profile.auth_method.clone(),
+            stored: true,
+        }),
+    )
+        .into_response()
 }
 
 pub async fn get_auth_profile(
@@ -421,31 +467,30 @@ pub async fn delete_auth_profile(
             return (status, Json(serde_json::json!({ "error": msg }))).into_response();
         }
     };
-    let key = TokenKey::from_connection_ref(&connection_ref);
-    match state.token_store.clear(&key).await {
-        Ok(()) => {
-            tracing::info!(
-                target: "meerkat::auth::audit",
-                binding_key = ?connection_ref,
-                action = "delete_profile",
-                "binding-scoped auth credentials deleted via REST"
-            );
-            (
-                StatusCode::NO_CONTENT,
-                Json(WireAuthProfileCleared {
-                    identity: WireBindingIdentity::from(&connection_ref),
-                    profile_id: auth_profile.id.clone(),
-                    cleared: true,
-                }),
-            )
-                .into_response()
-        }
-        Err(e) => (
-            StatusCode::INTERNAL_SERVER_ERROR,
-            Json(serde_json::json!({ "error": format!("TokenStore clear failed: {e}") })),
-        )
-            .into_response(),
+    if let Err((status, msg)) = clear_tokens_and_publish_lifecycle(
+        state.token_store.as_ref(),
+        state.auth_lease.as_ref(),
+        &connection_ref,
+    )
+    .await
+    {
+        return (status, Json(serde_json::json!({ "error": msg }))).into_response();
     }
+    tracing::info!(
+        target: "meerkat::auth::audit",
+        binding_key = ?connection_ref,
+        action = "delete_profile",
+        "binding-scoped auth credentials deleted via REST"
+    );
+    (
+        StatusCode::NO_CONTENT,
+        Json(WireAuthProfileCleared {
+            identity: WireBindingIdentity::from(&connection_ref),
+            profile_id: auth_profile.id.clone(),
+            cleared: true,
+        }),
+    )
+        .into_response()
 }
 
 #[derive(serde::Deserialize)]
@@ -722,13 +767,15 @@ pub async fn complete_login(
         metadata: serde_json::Value::Null,
     };
 
-    let key = TokenKey::from_connection_ref(&connection_ref);
-    if let Err(e) = state.token_store.save(&key, &tokens).await {
-        return (
-            StatusCode::INTERNAL_SERVER_ERROR,
-            Json(serde_json::json!({ "error": format!("TokenStore save failed: {e}") })),
-        )
-            .into_response();
+    if let Err((status, msg)) = save_tokens_and_publish_lifecycle(
+        state.token_store.as_ref(),
+        state.auth_lease.as_ref(),
+        &connection_ref,
+        &tokens,
+    )
+    .await
+    {
+        return (status, Json(serde_json::json!({ "error": msg }))).into_response();
     }
 
     tracing::info!(
@@ -953,15 +1000,15 @@ pub async fn complete_device_login(
                 account_id: None,
                 metadata: serde_json::Value::Null,
             };
-            let key = TokenKey::from_connection_ref(&connection_ref);
-            if let Err(e) = state.token_store.save(&key, &tokens).await {
-                return (
-                    StatusCode::INTERNAL_SERVER_ERROR,
-                    Json(serde_json::json!({
-                        "error": format!("TokenStore save failed: {e}"),
-                    })),
-                )
-                    .into_response();
+            if let Err((status, msg)) = save_tokens_and_publish_lifecycle(
+                state.token_store.as_ref(),
+                state.auth_lease.as_ref(),
+                &connection_ref,
+                &tokens,
+            )
+            .await
+            {
+                return (status, Json(serde_json::json!({ "error": msg }))).into_response();
             }
             tracing::info!(
                 target: "meerkat::auth::audit",
@@ -1017,7 +1064,11 @@ pub async fn get_auth_status(
                 .into_response();
         }
     };
-    let state_phase = AuthStatusPhase::from_persisted_tokens(chrono::Utc::now(), stored.as_ref());
+    let snapshot = state
+        .auth_lease
+        .snapshot(&LeaseKey::from_connection_ref(&connection_ref));
+    let state_phase = AuthStatusPhase::from_lease_snapshot(chrono::Utc::now(), &snapshot);
+    let lease_expires_at = meerkat_core::lease_snapshot_expires_at_datetime(&snapshot);
     (
         StatusCode::OK,
         Json(WireAuthStatusDetail {
@@ -1026,9 +1077,9 @@ pub async fn get_auth_status(
             provider: auth_profile.provider.as_str().to_string(),
             auth_method: auth_profile.auth_method.clone(),
             state: state_phase.as_public_str().to_string(),
-            expires_at: stored
-                .as_ref()
-                .and_then(|t| t.expires_at.map(|e| e.to_rfc3339())),
+            expires_at: lease_expires_at
+                .or_else(|| stored.as_ref().and_then(|t| t.expires_at))
+                .map(|e| e.to_rfc3339()),
             last_refresh_at: stored
                 .as_ref()
                 .and_then(|t| t.last_refresh.map(|e| e.to_rfc3339())),
@@ -1060,37 +1111,87 @@ pub async fn logout(
             return (status, Json(serde_json::json!({ "error": msg }))).into_response();
         }
     };
-    let key = TokenKey::from_connection_ref(&connection_ref);
-    match state.token_store.clear(&key).await {
-        Ok(()) => {
-            tracing::info!(
-                target: "meerkat::auth::audit",
-                binding_key = ?connection_ref,
-                action = "logout",
-                "binding-scoped auth credentials logged out via REST"
-            );
-            (
-                StatusCode::OK,
-                Json(WireAuthProfileCleared {
-                    identity: WireBindingIdentity::from(&connection_ref),
-                    profile_id: auth_profile.id.clone(),
-                    cleared: true,
-                }),
-            )
-                .into_response()
-        }
-        Err(e) => (
-            StatusCode::INTERNAL_SERVER_ERROR,
-            Json(serde_json::json!({ "error": format!("TokenStore clear failed: {e}") })),
-        )
-            .into_response(),
+    if let Err((status, msg)) = clear_tokens_and_publish_lifecycle(
+        state.token_store.as_ref(),
+        state.auth_lease.as_ref(),
+        &connection_ref,
+    )
+    .await
+    {
+        return (status, Json(serde_json::json!({ "error": msg }))).into_response();
     }
+    tracing::info!(
+        target: "meerkat::auth::audit",
+        binding_key = ?connection_ref,
+        action = "logout",
+        "binding-scoped auth credentials logged out via REST"
+    );
+    (
+        StatusCode::OK,
+        Json(WireAuthProfileCleared {
+            identity: WireBindingIdentity::from(&connection_ref),
+            profile_id: auth_profile.id.clone(),
+            cleared: true,
+        }),
+    )
+        .into_response()
 }
 
 #[cfg(test)]
 #[allow(clippy::unwrap_used)]
 mod tests {
     use super::*;
+    use meerkat_core::handles::{AuthLeaseHandle, AuthLeasePhase, LeaseKey};
+    use meerkat_providers::auth_store::EphemeralTokenStore;
+    use meerkat_runtime::RuntimeAuthLeaseHandle;
+
+    fn managed_connection_ref() -> ConnectionRef {
+        ConnectionRef {
+            realm: RealmId::parse("rest-test").unwrap(),
+            binding: BindingId::parse("managed").unwrap(),
+            profile: None,
+        }
+    }
+
+    fn api_key_tokens() -> PersistedTokens {
+        PersistedTokens {
+            auth_mode: PersistedAuthMode::ApiKey,
+            primary_secret: Some("sk-test".to_string()),
+            refresh_token: None,
+            id_token: None,
+            expires_at: None,
+            last_refresh: Some(chrono::Utc::now()),
+            scopes: Vec::new(),
+            account_id: None,
+            metadata: serde_json::Value::Null,
+        }
+    }
+
+    #[tokio::test]
+    async fn rest_token_write_helpers_publish_auth_machine_lifecycle() {
+        let store = EphemeralTokenStore::new();
+        let auth_lease = RuntimeAuthLeaseHandle::new();
+        let connection_ref = managed_connection_ref();
+        let key = TokenKey::from_connection_ref(&connection_ref);
+        let tokens = api_key_tokens();
+
+        save_tokens_and_publish_lifecycle(&store, &auth_lease, &connection_ref, &tokens)
+            .await
+            .unwrap();
+
+        assert!(store.load(&key).await.unwrap().is_some());
+        let snapshot = auth_lease.snapshot(&LeaseKey::from_connection_ref(&connection_ref));
+        assert_eq!(snapshot.phase, Some(AuthLeasePhase::Valid));
+
+        clear_tokens_and_publish_lifecycle(&store, &auth_lease, &connection_ref)
+            .await
+            .unwrap();
+
+        assert!(store.load(&key).await.unwrap().is_none());
+        let snapshot = auth_lease.snapshot(&LeaseKey::from_connection_ref(&connection_ref));
+        assert_eq!(snapshot.phase, None);
+        assert_eq!(snapshot.expires_at, None);
+    }
 
     #[test]
     fn login_complete_body_does_not_invent_default_identity() {

--- a/meerkat-rest/src/auth_endpoints.rs
+++ b/meerkat-rest/src/auth_endpoints.rs
@@ -182,6 +182,12 @@ async fn save_tokens_and_publish_lifecycle(
     tokens: &PersistedTokens,
 ) -> Result<(), (StatusCode, String)> {
     let key = TokenKey::from_connection_ref(connection_ref);
+    let previous = token_store.load(&key).await.map_err(|e| {
+        (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            format!("TokenStore load failed: {e}"),
+        )
+    })?;
     token_store.save(&key, tokens).await.map_err(|e| {
         (
             StatusCode::INTERNAL_SERVER_ERROR,
@@ -191,13 +197,33 @@ async fn save_tokens_and_publish_lifecycle(
     if let Err(e) =
         meerkat_core::publish_token_lifecycle_acquired(auth_lease, connection_ref, tokens)
     {
-        let _ = token_store.clear(&key).await;
+        if let Err(rollback_error) =
+            restore_tokens_after_lifecycle_failure(token_store, &key, previous.as_ref()).await
+        {
+            return Err((
+                StatusCode::INTERNAL_SERVER_ERROR,
+                format!(
+                    "AuthMachine lifecycle acquire failed: {e}; TokenStore rollback failed: {rollback_error}"
+                ),
+            ));
+        }
         return Err((
             StatusCode::INTERNAL_SERVER_ERROR,
             format!("AuthMachine lifecycle acquire failed: {e}"),
         ));
     }
     Ok(())
+}
+
+async fn restore_tokens_after_lifecycle_failure(
+    token_store: &dyn TokenStore,
+    key: &TokenKey,
+    previous: Option<&PersistedTokens>,
+) -> Result<(), meerkat_providers::auth_store::TokenStoreError> {
+    match previous {
+        Some(tokens) => token_store.save(key, tokens).await,
+        None => token_store.clear(key).await,
+    }
 }
 
 async fn clear_tokens_and_publish_lifecycle(
@@ -1142,7 +1168,9 @@ pub async fn logout(
 mod tests {
     use super::*;
     use axum::body::to_bytes;
-    use meerkat_core::handles::{AuthLeaseHandle, AuthLeasePhase, LeaseKey};
+    use meerkat_core::handles::{
+        AuthLeaseHandle, AuthLeasePhase, AuthLeaseSnapshot, DslTransitionError, LeaseKey,
+    };
     use meerkat_providers::auth_store::EphemeralTokenStore;
     use meerkat_runtime::RuntimeAuthLeaseHandle;
 
@@ -1155,9 +1183,13 @@ mod tests {
     }
 
     fn api_key_tokens() -> PersistedTokens {
+        api_key_tokens_with_secret("sk-test")
+    }
+
+    fn api_key_tokens_with_secret(secret: &str) -> PersistedTokens {
         PersistedTokens {
             auth_mode: PersistedAuthMode::ApiKey,
-            primary_secret: Some("sk-test".to_string()),
+            primary_secret: Some(secret.to_string()),
             refresh_token: None,
             id_token: None,
             expires_at: None,
@@ -1165,6 +1197,61 @@ mod tests {
             scopes: Vec::new(),
             account_id: None,
             metadata: serde_json::Value::Null,
+        }
+    }
+
+    struct RejectingAuthLeaseHandle;
+
+    impl AuthLeaseHandle for RejectingAuthLeaseHandle {
+        fn acquire_lease(
+            &self,
+            _lease_key: &LeaseKey,
+            _expires_at: u64,
+        ) -> Result<(), DslTransitionError> {
+            Err(DslTransitionError::guard_rejected(
+                "acquire_lease",
+                "test rejection",
+            ))
+        }
+
+        fn mark_expiring(&self, _lease_key: &LeaseKey) -> Result<(), DslTransitionError> {
+            Ok(())
+        }
+
+        fn begin_refresh(&self, _lease_key: &LeaseKey) -> Result<(), DslTransitionError> {
+            Ok(())
+        }
+
+        fn complete_refresh(
+            &self,
+            _lease_key: &LeaseKey,
+            _new_expires_at: u64,
+            _now: u64,
+        ) -> Result<(), DslTransitionError> {
+            Ok(())
+        }
+
+        fn refresh_failed(
+            &self,
+            _lease_key: &LeaseKey,
+            _permanent: bool,
+        ) -> Result<(), DslTransitionError> {
+            Ok(())
+        }
+
+        fn mark_reauth_required(&self, _lease_key: &LeaseKey) -> Result<(), DslTransitionError> {
+            Ok(())
+        }
+
+        fn release_lease(&self, _lease_key: &LeaseKey) -> Result<(), DslTransitionError> {
+            Ok(())
+        }
+
+        fn snapshot(&self, _lease_key: &LeaseKey) -> AuthLeaseSnapshot {
+            AuthLeaseSnapshot {
+                phase: None,
+                expires_at: None,
+            }
         }
     }
 
@@ -1235,6 +1322,27 @@ mod tests {
         let snapshot = auth_lease.snapshot(&LeaseKey::from_connection_ref(&connection_ref));
         assert_eq!(snapshot.phase, None);
         assert_eq!(snapshot.expires_at, None);
+    }
+
+    #[tokio::test]
+    async fn rest_token_save_lifecycle_failure_restores_existing_credentials() {
+        let store = EphemeralTokenStore::new();
+        let auth_lease = RejectingAuthLeaseHandle;
+        let connection_ref = managed_connection_ref();
+        let key = TokenKey::from_connection_ref(&connection_ref);
+        let previous = api_key_tokens_with_secret("sk-old");
+        let replacement = api_key_tokens_with_secret("sk-new");
+        store.save(&key, &previous).await.unwrap();
+
+        let err =
+            save_tokens_and_publish_lifecycle(&store, &auth_lease, &connection_ref, &replacement)
+                .await
+                .unwrap_err();
+
+        assert_eq!(err.0, StatusCode::INTERNAL_SERVER_ERROR);
+        assert!(err.1.contains("AuthMachine lifecycle acquire failed"));
+        let stored = store.load(&key).await.unwrap().unwrap();
+        assert_eq!(stored.primary_secret.as_deref(), Some("sk-old"));
     }
 
     #[tokio::test]

--- a/meerkat-rest/src/auth_endpoints.rs
+++ b/meerkat-rest/src/auth_endpoints.rs
@@ -1141,6 +1141,7 @@ pub async fn logout(
 #[allow(clippy::unwrap_used)]
 mod tests {
     use super::*;
+    use axum::body::to_bytes;
     use meerkat_core::handles::{AuthLeaseHandle, AuthLeasePhase, LeaseKey};
     use meerkat_providers::auth_store::EphemeralTokenStore;
     use meerkat_runtime::RuntimeAuthLeaseHandle;
@@ -1167,6 +1168,49 @@ mod tests {
         }
     }
 
+    fn config_with_openai_managed_store_binding() -> meerkat_core::Config {
+        let mut config = meerkat_core::Config::default();
+        let mut section = meerkat_core::RealmConfigSection::default();
+        section.backend.insert(
+            "openai_backend".into(),
+            meerkat_core::BackendProfileConfig {
+                provider: "openai".into(),
+                backend_kind: "openai_api".into(),
+                base_url: None,
+                options: serde_json::json!({}),
+            },
+        );
+        section.auth.insert(
+            "openai_managed".into(),
+            meerkat_core::AuthProfileConfig {
+                provider: "openai".into(),
+                auth_method: "api_key".into(),
+                source: CredentialSourceSpec::ManagedStore,
+                constraints: Default::default(),
+                metadata_defaults: Default::default(),
+            },
+        );
+        section.binding.insert(
+            "default_openai".into(),
+            meerkat_core::ProviderBindingConfig {
+                backend_profile: "openai_backend".into(),
+                auth_profile: "openai_managed".into(),
+                default_model: None,
+                policy: Default::default(),
+            },
+        );
+        section.default_binding = Some("default_openai".into());
+        config.realm.insert("dev".into(), section);
+        config
+    }
+
+    async fn auth_status_detail(response: impl IntoResponse) -> WireAuthStatusDetail {
+        let response = response.into_response();
+        assert_eq!(response.status(), StatusCode::OK);
+        let body = to_bytes(response.into_body(), usize::MAX).await.unwrap();
+        serde_json::from_slice(&body).unwrap()
+    }
+
     #[tokio::test]
     async fn rest_token_write_helpers_publish_auth_machine_lifecycle() {
         let store = EphemeralTokenStore::new();
@@ -1191,6 +1235,72 @@ mod tests {
         let snapshot = auth_lease.snapshot(&LeaseKey::from_connection_ref(&connection_ref));
         assert_eq!(snapshot.phase, None);
         assert_eq!(snapshot.expires_at, None);
+    }
+
+    #[tokio::test]
+    async fn rest_auth_status_observes_session_runtime_binding_lifecycle() {
+        let temp = tempfile::tempdir().unwrap();
+        let state = AppState::load_from(temp.path().to_path_buf())
+            .await
+            .unwrap();
+        state
+            .config_runtime
+            .set(config_with_openai_managed_store_binding(), None)
+            .await
+            .unwrap();
+        let connection_ref = ConnectionRef {
+            realm: RealmId::parse("dev").unwrap(),
+            binding: BindingId::parse("default_openai").unwrap(),
+            profile: None,
+        };
+        let lease_key = LeaseKey::from_connection_ref(&connection_ref);
+        let now = chrono::Utc::now().timestamp() as u64;
+        let query = || RealmQuery {
+            realm_id: RealmId::parse("dev").unwrap(),
+            profile_id: None,
+        };
+        let binding_id = || BindingId::parse("default_openai").unwrap();
+
+        let bindings = state
+            .runtime_adapter
+            .prepare_bindings(meerkat_core::SessionId::new())
+            .await
+            .unwrap();
+        bindings
+            .auth_lease
+            .acquire_lease(&lease_key, now + 3600)
+            .unwrap();
+        let detail = auth_status_detail(
+            get_auth_status(State(state.clone()), Path(binding_id()), Query(query())).await,
+        )
+        .await;
+        assert_eq!(detail.state, "valid");
+
+        let bindings = state
+            .runtime_adapter
+            .prepare_bindings(meerkat_core::SessionId::new())
+            .await
+            .unwrap();
+        bindings.auth_lease.begin_refresh(&lease_key).unwrap();
+        let detail = auth_status_detail(
+            get_auth_status(State(state.clone()), Path(binding_id()), Query(query())).await,
+        )
+        .await;
+        assert_eq!(detail.state, "expiring");
+
+        bindings
+            .auth_lease
+            .complete_refresh(&lease_key, now + 7200, now)
+            .unwrap();
+        bindings
+            .auth_lease
+            .mark_reauth_required(&lease_key)
+            .unwrap();
+        let detail = auth_status_detail(
+            get_auth_status(State(state), Path(binding_id()), Query(query())).await,
+        )
+        .await;
+        assert_eq!(detail.state, "reauth_required");
     }
 
     #[test]

--- a/meerkat-rest/src/lib.rs
+++ b/meerkat-rest/src/lib.rs
@@ -354,6 +354,7 @@ impl AppState {
         );
         let (session_service, runtime_adapter) =
             meerkat::surface::build_runtime_backed_service(builder, 100, persistence);
+        runtime_adapter.set_auth_lease_handle(Arc::clone(&auth_lease));
         let session_service = Arc::new(session_service);
         #[cfg(feature = "mob")]
         let mob_session_service = session_service.clone();

--- a/meerkat-rest/src/lib.rs
+++ b/meerkat-rest/src/lib.rs
@@ -172,6 +172,8 @@ pub struct AppState {
     /// AgentFactory so both read and write paths (login, resolve,
     /// logout) see the same credentials.
     pub token_store: Arc<dyn meerkat_providers::auth_store::TokenStore>,
+    /// Process-local AuthMachine lifecycle registry for auth endpoints.
+    pub auth_lease: Arc<dyn meerkat_core::handles::AuthLeaseHandle>,
     /// Provider-runtime registry shared with the AgentFactory's auth
     /// resolution path.
     pub provider_registry: Arc<meerkat_providers::ProviderRuntimeRegistry>,
@@ -313,6 +315,8 @@ impl AppState {
                 Ok(store) => store,
                 Err(_) => Arc::new(meerkat_providers::auth_store::EphemeralTokenStore::new()),
             };
+        let auth_lease: Arc<dyn meerkat_core::handles::AuthLeaseHandle> =
+            Arc::new(meerkat_runtime::RuntimeAuthLeaseHandle::new());
         let mut factory = AgentFactory::new(store_path.clone())
             .with_token_store(Arc::clone(&token_store))
             .session_store(session_store.clone())
@@ -401,6 +405,7 @@ impl AppState {
                 std::time::Duration::from_secs(5),
             )),
             token_store,
+            auth_lease,
             provider_registry,
         })
     }

--- a/meerkat-rest/tests/live_continue_tmp.rs
+++ b/meerkat-rest/tests/live_continue_tmp.rs
@@ -107,6 +107,7 @@ async fn integration_real_live_continue_hangs() {
         #[cfg(feature = "mcp")]
         mcp_sessions: Arc::new(tokio::sync::RwLock::new(std::collections::HashMap::new())),
         token_store: Arc::new(meerkat_providers::auth_store::EphemeralTokenStore::new()),
+        auth_lease: Arc::new(meerkat_runtime::RuntimeAuthLeaseHandle::new()),
         provider_registry,
     };
 

--- a/meerkat-rest/tests/live_rest_regression.rs
+++ b/meerkat-rest/tests/live_rest_regression.rs
@@ -127,6 +127,7 @@ fn build_app_state(client: Arc<dyn LlmClient>) -> (AppState, axum::Router) {
         #[cfg(feature = "mcp")]
         mcp_sessions: Arc::new(tokio::sync::RwLock::new(std::collections::HashMap::new())),
         token_store: Arc::new(meerkat_providers::auth_store::EphemeralTokenStore::new()),
+        auth_lease: Arc::new(meerkat_runtime::RuntimeAuthLeaseHandle::new()),
         provider_registry,
     };
 

--- a/meerkat-rest/tests/regression_persistent.rs
+++ b/meerkat-rest/tests/regression_persistent.rs
@@ -117,6 +117,7 @@ fn build_state(
         #[cfg(feature = "mcp")]
         mcp_sessions: Arc::new(tokio::sync::RwLock::new(std::collections::HashMap::new())),
         token_store: Arc::new(meerkat_providers::auth_store::EphemeralTokenStore::new()),
+        auth_lease: Arc::new(meerkat_runtime::RuntimeAuthLeaseHandle::new()),
         provider_registry,
     }
 }

--- a/meerkat-rest/tests/rest_auth_endpoints.rs
+++ b/meerkat-rest/tests/rest_auth_endpoints.rs
@@ -123,6 +123,7 @@ fn build_app() -> axum::Router {
         #[cfg(feature = "mcp")]
         mcp_sessions: Arc::new(tokio::sync::RwLock::new(std::collections::HashMap::new())),
         token_store: Arc::new(meerkat_providers::auth_store::EphemeralTokenStore::new()),
+        auth_lease: Arc::new(meerkat_runtime::RuntimeAuthLeaseHandle::new()),
         provider_registry,
         realtime_rpc_tcp_addr: None,
     };

--- a/meerkat-rest/tests/runtime_backed_ingress.rs
+++ b/meerkat-rest/tests/runtime_backed_ingress.rs
@@ -151,6 +151,7 @@ async fn runtime_backed_external_events_stay_queued_without_waking_idle_sessions
             std::time::Duration::from_secs(5),
         )),
         token_store: Arc::new(meerkat_providers::auth_store::EphemeralTokenStore::new()),
+        auth_lease: Arc::new(meerkat_runtime::RuntimeAuthLeaseHandle::new()),
         provider_registry,
         #[cfg(feature = "mob")]
         mob_state,

--- a/meerkat-rest/tests/system_rest_resume.rs
+++ b/meerkat-rest/tests/system_rest_resume.rs
@@ -123,6 +123,7 @@ async fn inner_test_rest_resume_metadata() {
         #[cfg(feature = "mcp")]
         mcp_sessions: Arc::new(tokio::sync::RwLock::new(std::collections::HashMap::new())),
         token_store: Arc::new(meerkat_providers::auth_store::EphemeralTokenStore::new()),
+        auth_lease: Arc::new(meerkat_runtime::RuntimeAuthLeaseHandle::new()),
         provider_registry,
     };
 
@@ -254,6 +255,7 @@ async fn inner_test_rest_resume_metadata() {
         #[cfg(feature = "mcp")]
         mcp_sessions: Arc::new(tokio::sync::RwLock::new(std::collections::HashMap::new())),
         token_store: Arc::new(meerkat_providers::auth_store::EphemeralTokenStore::new()),
+        auth_lease: Arc::new(meerkat_runtime::RuntimeAuthLeaseHandle::new()),
         provider_registry: provider_registry2,
     };
 

--- a/meerkat-rpc/src/handlers/auth.rs
+++ b/meerkat-rpc/src/handlers/auth.rs
@@ -15,6 +15,7 @@ use meerkat_contracts::{
     WireAuthProfile, WireAuthStatusDetail, WireBackendProfile, WireBindingIdentity,
     WireProviderBinding, WireRealmConnectionSet,
 };
+use meerkat_core::handles::LeaseKey;
 use meerkat_core::{
     AuthStatusPhase, ConnectionRef, ConnectionTargetError, CredentialSourceSpec, Provider,
     RealmConnectionSet, ResolvedConnectionTarget,
@@ -23,7 +24,7 @@ use meerkat_providers::auth_oauth::{
     DevicePollOutcome, OAuthError, PkcePair, exchange_authorization_code, poll_device_code,
     request_device_code,
 };
-use meerkat_providers::auth_store::{PersistedAuthMode, PersistedTokens, TokenKey};
+use meerkat_providers::auth_store::{PersistedAuthMode, PersistedTokens, TokenKey, TokenStore};
 use meerkat_providers::oauth_flow::{
     OAuthFlowError, global_oauth_flow_registry, resolve_oauth_provider,
 };
@@ -248,6 +249,61 @@ fn source_kind_label(source: &CredentialSourceSpec) -> &'static str {
     }
 }
 
+async fn save_tokens_and_publish_lifecycle(
+    id: Option<RpcId>,
+    store: &Arc<dyn TokenStore>,
+    runtime: &SessionRuntime,
+    connection_ref: &ConnectionRef,
+    tokens: &PersistedTokens,
+) -> Result<(), RpcResponse> {
+    let key = TokenKey::from_connection_ref(connection_ref);
+    if let Err(e) = store.save(&key, tokens).await {
+        return Err(RpcResponse::error(
+            id,
+            error::INTERNAL_ERROR,
+            format!("TokenStore save failed: {e}"),
+        ));
+    }
+    let auth_lease = runtime.auth_lease_handle();
+    if let Err(e) =
+        meerkat_core::publish_token_lifecycle_acquired(auth_lease.as_ref(), connection_ref, tokens)
+    {
+        let _ = store.clear(&key).await;
+        return Err(RpcResponse::error(
+            id,
+            error::INTERNAL_ERROR,
+            format!("AuthMachine lifecycle acquire failed: {e}"),
+        ));
+    }
+    Ok(())
+}
+
+async fn clear_tokens_and_publish_lifecycle(
+    id: Option<RpcId>,
+    store: &Arc<dyn TokenStore>,
+    runtime: &SessionRuntime,
+    connection_ref: &ConnectionRef,
+) -> Result<(), RpcResponse> {
+    let key = TokenKey::from_connection_ref(connection_ref);
+    if let Err(e) = store.clear(&key).await {
+        return Err(RpcResponse::error(
+            id,
+            error::INTERNAL_ERROR,
+            format!("TokenStore clear failed: {e}"),
+        ));
+    }
+    let auth_lease = runtime.auth_lease_handle();
+    meerkat_core::publish_token_lifecycle_released(auth_lease.as_ref(), connection_ref).map_err(
+        |e| {
+            RpcResponse::error(
+                id,
+                error::INTERNAL_ERROR,
+                format!("AuthMachine lifecycle release failed: {e}"),
+            )
+        },
+    )
+}
+
 // --- Realm projection -------------------------------------------------
 
 pub async fn handle_realm_list(id: Option<RpcId>, runtime: &SessionRuntime) -> RpcResponse {
@@ -435,36 +491,32 @@ pub async fn handle_auth_profile_create(
         account_id: None,
         metadata: serde_json::Value::Null,
     };
-    let key = TokenKey::from_connection_ref(&connection_ref);
-    match store.save(&key, &tokens).await {
-        Ok(()) => {
-            tracing::info!(
-                target: "meerkat::auth::audit",
-                binding_key = ?connection_ref,
-                action = "create_profile",
-                provider = %auth_profile.provider.as_str(),
-                auth_method = %auth_profile.auth_method,
-                "binding-scoped auth credentials stored via RPC"
-            );
-            RpcResponse::success(
-                id,
-                serde_json::json!({
-                    "realm_id": connection_ref.realm.as_str(),
-                    "binding_id": connection_ref.binding.as_str(),
-                    "connection_ref": &connection_ref,
-                    "profile_id": &auth_profile.id,
-                    "provider": auth_profile.provider.as_str(),
-                    "auth_method": &auth_profile.auth_method,
-                    "stored": true,
-                }),
-            )
-        }
-        Err(e) => RpcResponse::error(
-            id,
-            error::INTERNAL_ERROR,
-            format!("TokenStore save failed: {e}"),
-        ),
+    if let Err(resp) =
+        save_tokens_and_publish_lifecycle(id.clone(), &store, runtime, &connection_ref, &tokens)
+            .await
+    {
+        return resp;
     }
+    tracing::info!(
+        target: "meerkat::auth::audit",
+        binding_key = ?connection_ref,
+        action = "create_profile",
+        provider = %auth_profile.provider.as_str(),
+        auth_method = %auth_profile.auth_method,
+        "binding-scoped auth credentials stored via RPC"
+    );
+    RpcResponse::success(
+        id,
+        serde_json::json!({
+            "realm_id": connection_ref.realm.as_str(),
+            "binding_id": connection_ref.binding.as_str(),
+            "connection_ref": &connection_ref,
+            "profile_id": &auth_profile.id,
+            "provider": auth_profile.provider.as_str(),
+            "auth_method": &auth_profile.auth_method,
+            "stored": true,
+        }),
+    )
 }
 
 pub async fn handle_auth_profile_delete(
@@ -491,32 +543,27 @@ pub async fn handle_auth_profile_delete(
         Ok(s) => s,
         Err(r) => return r,
     };
-    let key = TokenKey::from_connection_ref(&connection_ref);
-    match store.clear(&key).await {
-        Ok(()) => {
-            tracing::info!(
-                target: "meerkat::auth::audit",
-                binding_key = ?connection_ref,
-                action = "delete_profile",
-                "binding-scoped auth credentials deleted via RPC"
-            );
-            RpcResponse::success(
-                id,
-                serde_json::json!({
-                    "realm_id": connection_ref.realm.as_str(),
-                    "binding_id": connection_ref.binding.as_str(),
-                    "connection_ref": &connection_ref,
-                    "profile_id": &auth_profile.id,
-                    "cleared": true,
-                }),
-            )
-        }
-        Err(e) => RpcResponse::error(
-            id,
-            error::INTERNAL_ERROR,
-            format!("TokenStore clear failed: {e}"),
-        ),
+    if let Err(resp) =
+        clear_tokens_and_publish_lifecycle(id.clone(), &store, runtime, &connection_ref).await
+    {
+        return resp;
     }
+    tracing::info!(
+        target: "meerkat::auth::audit",
+        binding_key = ?connection_ref,
+        action = "delete_profile",
+        "binding-scoped auth credentials deleted via RPC"
+    );
+    RpcResponse::success(
+        id,
+        serde_json::json!({
+            "realm_id": connection_ref.realm.as_str(),
+            "binding_id": connection_ref.binding.as_str(),
+            "connection_ref": &connection_ref,
+            "profile_id": &auth_profile.id,
+            "cleared": true,
+        }),
+    )
 }
 
 // --- OAuth login ------------------------------------------------------
@@ -711,13 +758,11 @@ pub async fn handle_auth_login_complete(
         account_id: None,
         metadata: serde_json::Value::Null,
     };
-    let key = TokenKey::from_connection_ref(&connection_ref);
-    if let Err(e) = store.save(&key, &tokens).await {
-        return RpcResponse::error(
-            id,
-            error::INTERNAL_ERROR,
-            format!("TokenStore save failed: {e}"),
-        );
+    if let Err(resp) =
+        save_tokens_and_publish_lifecycle(id.clone(), &store, runtime, &connection_ref, &tokens)
+            .await
+    {
+        return resp;
     }
     tracing::info!(
         target: "meerkat::auth::audit",
@@ -924,13 +969,16 @@ pub async fn handle_auth_login_device_complete(
                 account_id: None,
                 metadata: serde_json::Value::Null,
             };
-            let key = TokenKey::from_connection_ref(&connection_ref);
-            if let Err(e) = store.save(&key, &tokens).await {
-                return RpcResponse::error(
-                    id,
-                    error::INTERNAL_ERROR,
-                    format!("TokenStore save failed: {e}"),
-                );
+            if let Err(resp) = save_tokens_and_publish_lifecycle(
+                id.clone(),
+                &store,
+                runtime,
+                &connection_ref,
+                &tokens,
+            )
+            .await
+            {
+                return resp;
             }
             tracing::info!(
                 target: "meerkat::auth::audit",
@@ -1021,22 +1069,40 @@ pub async fn handle_auth_login_provision_api_key(
     // API_KEY_CREATE_URL with `Authorization: Bearer <access_token>`
     // and persists the returned api_key via `save_persisted`.
     let endpoints = a_oauth::console_endpoints(a_oauth::MANUAL_REDIRECT_URL);
-    let oauth_runtime =
-        a_oauth::AnthropicOAuthRuntime::new_with_default_coordinator(store, endpoints, key);
+    let oauth_runtime = a_oauth::AnthropicOAuthRuntime::new_with_default_coordinator(
+        Arc::clone(&store),
+        endpoints,
+        key.clone(),
+    );
     match oauth_runtime.provision_api_key(&parsed.access_token).await {
-        Ok(tokens) => RpcResponse::success(
-            id,
-            serde_json::json!({
-                "realm_id": connection_ref.realm.as_str(),
-                "binding_id": connection_ref.binding.as_str(),
-                "connection_ref": &connection_ref,
-                "profile_id": &auth_profile.id,
-                "provider": "anthropic",
-                "auth_mode": "oauth_to_api_key",
-                "has_api_key": tokens.primary_secret.is_some(),
-                "scopes": tokens.scopes,
-            }),
-        ),
+        Ok(tokens) => {
+            let auth_lease = runtime.auth_lease_handle();
+            if let Err(e) = meerkat_core::publish_token_lifecycle_acquired(
+                auth_lease.as_ref(),
+                &connection_ref,
+                &tokens,
+            ) {
+                let _ = store.clear(&key).await;
+                return RpcResponse::error(
+                    id,
+                    error::INTERNAL_ERROR,
+                    format!("AuthMachine lifecycle acquire failed: {e}"),
+                );
+            }
+            RpcResponse::success(
+                id,
+                serde_json::json!({
+                    "realm_id": connection_ref.realm.as_str(),
+                    "binding_id": connection_ref.binding.as_str(),
+                    "connection_ref": &connection_ref,
+                    "profile_id": &auth_profile.id,
+                    "provider": "anthropic",
+                    "auth_mode": "oauth_to_api_key",
+                    "has_api_key": tokens.primary_secret.is_some(),
+                    "scopes": tokens.scopes,
+                }),
+            )
+        }
         Err(e) => RpcResponse::error(
             id,
             error::INTERNAL_ERROR,
@@ -1073,7 +1139,10 @@ pub async fn handle_auth_status_get(
     } else {
         None
     };
-    let state_phase = AuthStatusPhase::from_persisted_tokens(chrono::Utc::now(), stored.as_ref());
+    let auth_lease = runtime.auth_lease_handle();
+    let snapshot = auth_lease.snapshot(&LeaseKey::from_connection_ref(&connection_ref));
+    let state_phase = AuthStatusPhase::from_lease_snapshot(chrono::Utc::now(), &snapshot);
+    let lease_expires_at = meerkat_core::lease_snapshot_expires_at_datetime(&snapshot);
     RpcResponse::success(
         id,
         WireAuthStatusDetail {
@@ -1082,9 +1151,9 @@ pub async fn handle_auth_status_get(
             provider: auth_profile.provider.as_str().to_string(),
             auth_method: auth_profile.auth_method,
             state: state_phase.as_public_str().to_string(),
-            expires_at: stored
-                .as_ref()
-                .and_then(|t| t.expires_at.map(|e| e.to_rfc3339())),
+            expires_at: lease_expires_at
+                .or_else(|| stored.as_ref().and_then(|t| t.expires_at))
+                .map(|e| e.to_rfc3339()),
             last_refresh_at: stored
                 .as_ref()
                 .and_then(|t| t.last_refresh.map(|e| e.to_rfc3339())),
@@ -1121,32 +1190,27 @@ pub async fn handle_auth_logout(
         Ok(s) => s,
         Err(r) => return r,
     };
-    let key = TokenKey::from_connection_ref(&connection_ref);
-    match store.clear(&key).await {
-        Ok(()) => {
-            tracing::info!(
-                target: "meerkat::auth::audit",
-                binding_key = ?connection_ref,
-                action = "logout",
-                "binding-scoped auth credentials logged out via RPC"
-            );
-            RpcResponse::success(
-                id,
-                serde_json::json!({
-                    "realm_id": connection_ref.realm.as_str(),
-                    "binding_id": connection_ref.binding.as_str(),
-                    "connection_ref": &connection_ref,
-                    "profile_id": &auth_profile.id,
-                    "cleared": true,
-                }),
-            )
-        }
-        Err(e) => RpcResponse::error(
-            id,
-            error::INTERNAL_ERROR,
-            format!("TokenStore clear failed: {e}"),
-        ),
+    if let Err(resp) =
+        clear_tokens_and_publish_lifecycle(id.clone(), &store, runtime, &connection_ref).await
+    {
+        return resp;
     }
+    tracing::info!(
+        target: "meerkat::auth::audit",
+        binding_key = ?connection_ref,
+        action = "logout",
+        "binding-scoped auth credentials logged out via RPC"
+    );
+    RpcResponse::success(
+        id,
+        serde_json::json!({
+            "realm_id": connection_ref.realm.as_str(),
+            "binding_id": connection_ref.binding.as_str(),
+            "connection_ref": &connection_ref,
+            "profile_id": &auth_profile.id,
+            "cleared": true,
+        }),
+    )
 }
 
 #[cfg(test)]
@@ -1164,7 +1228,10 @@ mod tests {
 
     fn test_runtime_with_config(config: meerkat_core::Config) -> SessionRuntime {
         let temp = tempfile::tempdir().unwrap();
-        let factory = meerkat::AgentFactory::new(temp.path().join("sessions"));
+        let token_store: Arc<dyn meerkat_providers::auth_store::TokenStore> =
+            Arc::new(meerkat_providers::auth_store::EphemeralTokenStore::new());
+        let factory =
+            meerkat::AgentFactory::new(temp.path().join("sessions")).with_token_store(token_store);
         let store: Arc<dyn meerkat::SessionStore> = Arc::new(meerkat::MemoryStore::new());
         let blob_store: Arc<dyn meerkat_core::BlobStore> =
             Arc::new(meerkat_store::MemoryBlobStore::new());
@@ -1191,6 +1258,53 @@ mod tests {
             meerkat_core::RealmConfigSection::from_inline_api_keys(&[("anthropic", "secret")]),
         );
         config
+    }
+
+    fn config_with_openai_managed_store_binding() -> meerkat_core::Config {
+        let mut config = meerkat_core::Config::default();
+        let mut section = meerkat_core::RealmConfigSection::default();
+        section.backend.insert(
+            "openai_backend".into(),
+            meerkat_core::BackendProfileConfig {
+                provider: "openai".into(),
+                backend_kind: "openai_api".into(),
+                base_url: None,
+                options: serde_json::Value::Null,
+            },
+        );
+        section.auth.insert(
+            "openai_managed".into(),
+            meerkat_core::AuthProfileConfig {
+                provider: "openai".into(),
+                auth_method: "api_key".into(),
+                source: CredentialSourceSpec::ManagedStore,
+                constraints: Default::default(),
+                metadata_defaults: Default::default(),
+            },
+        );
+        section.binding.insert(
+            "default_openai".into(),
+            meerkat_core::ProviderBindingConfig {
+                backend_profile: "openai_backend".into(),
+                auth_profile: "openai_managed".into(),
+                default_model: None,
+                policy: Default::default(),
+            },
+        );
+        section.default_binding = Some("default_openai".into());
+        config.realm.insert("dev".into(), section);
+        config
+    }
+
+    fn auth_status_state(resp: RpcResponse) -> String {
+        assert!(
+            resp.error.is_none(),
+            "status response error: {:?}",
+            resp.error
+        );
+        let value: serde_json::Value =
+            serde_json::from_str(resp.result.as_ref().expect("result").get()).unwrap();
+        value["state"].as_str().expect("state").to_string()
     }
 
     fn assert_invalid_params_message(resp: RpcResponse, expected: &str) {
@@ -1296,6 +1410,52 @@ mod tests {
         .await;
 
         assert_invalid_params_message(resp, "realm_id is required for OAuth login completion");
+    }
+
+    #[tokio::test]
+    async fn auth_status_ignores_stale_token_without_auth_machine_lifecycle() {
+        let runtime = test_runtime_with_config(config_with_openai_managed_store_binding());
+        let connection_ref = ConnectionRef {
+            realm: meerkat_core::RealmId::parse("dev").unwrap(),
+            binding: meerkat_core::BindingId::parse("default_openai").unwrap(),
+            profile: None,
+        };
+        let store = runtime.token_store().expect("test token store");
+        store
+            .save(
+                &TokenKey::from_connection_ref(&connection_ref),
+                &PersistedTokens::api_key("sk-stale"),
+            )
+            .await
+            .unwrap();
+        let params = raw_params(serde_json::json!({
+            "realm_id": "dev",
+            "binding_id": "default_openai"
+        }));
+
+        let resp =
+            handle_auth_status_get(Some(RpcId::Num(1)), Some(params.as_ref()), &runtime).await;
+
+        assert_eq!(auth_status_state(resp), "unknown");
+    }
+
+    #[tokio::test]
+    async fn auth_profile_create_publishes_auth_machine_lifecycle() {
+        let runtime = test_runtime_with_config(config_with_openai_managed_store_binding());
+        let params = raw_params(serde_json::json!({
+            "realm_id": "dev",
+            "binding_id": "default_openai",
+            "auth_method": "api_key",
+            "secret": "sk-test"
+        }));
+
+        let create =
+            handle_auth_profile_create(Some(RpcId::Num(1)), Some(params.as_ref()), &runtime).await;
+        assert!(create.error.is_none(), "create error: {:?}", create.error);
+
+        let status =
+            handle_auth_status_get(Some(RpcId::Num(2)), Some(params.as_ref()), &runtime).await;
+        assert_eq!(auth_status_state(status), "valid");
     }
 
     #[tokio::test]

--- a/meerkat-rpc/src/handlers/auth.rs
+++ b/meerkat-rpc/src/handlers/auth.rs
@@ -257,6 +257,16 @@ async fn save_tokens_and_publish_lifecycle(
     tokens: &PersistedTokens,
 ) -> Result<(), RpcResponse> {
     let key = TokenKey::from_connection_ref(connection_ref);
+    let previous = match store.load(&key).await {
+        Ok(previous) => previous,
+        Err(e) => {
+            return Err(RpcResponse::error(
+                id,
+                error::INTERNAL_ERROR,
+                format!("TokenStore load failed: {e}"),
+            ));
+        }
+    };
     if let Err(e) = store.save(&key, tokens).await {
         return Err(RpcResponse::error(
             id,
@@ -265,10 +275,41 @@ async fn save_tokens_and_publish_lifecycle(
         ));
     }
     let auth_lease = runtime.auth_lease_handle();
+    publish_saved_tokens_and_restore_on_lifecycle_failure(
+        id,
+        store.as_ref(),
+        auth_lease.as_ref(),
+        connection_ref,
+        &key,
+        tokens,
+        previous.as_ref(),
+    )
+    .await
+}
+
+async fn publish_saved_tokens_and_restore_on_lifecycle_failure(
+    id: Option<RpcId>,
+    store: &dyn TokenStore,
+    auth_lease: &dyn meerkat_core::handles::AuthLeaseHandle,
+    connection_ref: &ConnectionRef,
+    key: &TokenKey,
+    tokens: &PersistedTokens,
+    previous: Option<&PersistedTokens>,
+) -> Result<(), RpcResponse> {
     if let Err(e) =
-        meerkat_core::publish_token_lifecycle_acquired(auth_lease.as_ref(), connection_ref, tokens)
+        meerkat_core::publish_token_lifecycle_acquired(auth_lease, connection_ref, tokens)
     {
-        let _ = store.clear(&key).await;
+        if let Err(rollback_error) =
+            restore_tokens_after_lifecycle_failure(store, key, previous).await
+        {
+            return Err(RpcResponse::error(
+                id,
+                error::INTERNAL_ERROR,
+                format!(
+                    "AuthMachine lifecycle acquire failed: {e}; TokenStore rollback failed: {rollback_error}"
+                ),
+            ));
+        }
         return Err(RpcResponse::error(
             id,
             error::INTERNAL_ERROR,
@@ -276,6 +317,17 @@ async fn save_tokens_and_publish_lifecycle(
         ));
     }
     Ok(())
+}
+
+async fn restore_tokens_after_lifecycle_failure(
+    store: &dyn TokenStore,
+    key: &TokenKey,
+    previous: Option<&PersistedTokens>,
+) -> Result<(), meerkat_providers::auth_store::TokenStoreError> {
+    match previous {
+        Some(tokens) => store.save(key, tokens).await,
+        None => store.clear(key).await,
+    }
 }
 
 async fn clear_tokens_and_publish_lifecycle(
@@ -1064,6 +1116,16 @@ pub async fn handle_auth_login_provision_api_key(
         Err(r) => return r,
     };
     let key = TokenKey::from_connection_ref(&connection_ref);
+    let previous = match store.load(&key).await {
+        Ok(previous) => previous,
+        Err(e) => {
+            return RpcResponse::error(
+                id,
+                error::INTERNAL_ERROR,
+                format!("TokenStore load failed: {e}"),
+            );
+        }
+    };
     // Console endpoints drive `scope = org:create_api_key user:profile`.
     // The runtime wrapper's `provision_api_key` POSTs to
     // API_KEY_CREATE_URL with `Authorization: Bearer <access_token>`
@@ -1077,17 +1139,18 @@ pub async fn handle_auth_login_provision_api_key(
     match oauth_runtime.provision_api_key(&parsed.access_token).await {
         Ok(tokens) => {
             let auth_lease = runtime.auth_lease_handle();
-            if let Err(e) = meerkat_core::publish_token_lifecycle_acquired(
+            if let Err(resp) = publish_saved_tokens_and_restore_on_lifecycle_failure(
+                id.clone(),
+                store.as_ref(),
                 auth_lease.as_ref(),
                 &connection_ref,
+                &key,
                 &tokens,
-            ) {
-                let _ = store.clear(&key).await;
-                return RpcResponse::error(
-                    id,
-                    error::INTERNAL_ERROR,
-                    format!("AuthMachine lifecycle acquire failed: {e}"),
-                );
+                previous.as_ref(),
+            )
+            .await
+            {
+                return resp;
             }
             RpcResponse::success(
                 id,
@@ -1217,6 +1280,7 @@ pub async fn handle_auth_logout(
 #[allow(clippy::unwrap_used)]
 mod tests {
     use super::*;
+    use meerkat_core::handles::{AuthLeaseHandle, AuthLeaseSnapshot, DslTransitionError};
 
     fn raw_params(value: serde_json::Value) -> Box<RawValue> {
         serde_json::value::to_raw_value(&value).unwrap()
@@ -1318,6 +1382,61 @@ mod tests {
             "expected error message to contain `{expected}`, got `{}`",
             error.message
         );
+    }
+
+    struct RejectingAuthLeaseHandle;
+
+    impl AuthLeaseHandle for RejectingAuthLeaseHandle {
+        fn acquire_lease(
+            &self,
+            _lease_key: &LeaseKey,
+            _expires_at: u64,
+        ) -> Result<(), DslTransitionError> {
+            Err(DslTransitionError::guard_rejected(
+                "acquire_lease",
+                "test rejection",
+            ))
+        }
+
+        fn mark_expiring(&self, _lease_key: &LeaseKey) -> Result<(), DslTransitionError> {
+            Ok(())
+        }
+
+        fn begin_refresh(&self, _lease_key: &LeaseKey) -> Result<(), DslTransitionError> {
+            Ok(())
+        }
+
+        fn complete_refresh(
+            &self,
+            _lease_key: &LeaseKey,
+            _new_expires_at: u64,
+            _now: u64,
+        ) -> Result<(), DslTransitionError> {
+            Ok(())
+        }
+
+        fn refresh_failed(
+            &self,
+            _lease_key: &LeaseKey,
+            _permanent: bool,
+        ) -> Result<(), DslTransitionError> {
+            Ok(())
+        }
+
+        fn mark_reauth_required(&self, _lease_key: &LeaseKey) -> Result<(), DslTransitionError> {
+            Ok(())
+        }
+
+        fn release_lease(&self, _lease_key: &LeaseKey) -> Result<(), DslTransitionError> {
+            Ok(())
+        }
+
+        fn snapshot(&self, _lease_key: &LeaseKey) -> AuthLeaseSnapshot {
+            AuthLeaseSnapshot {
+                phase: None,
+                expires_at: None,
+            }
+        }
     }
 
     #[test]
@@ -1456,6 +1575,84 @@ mod tests {
         let status =
             handle_auth_status_get(Some(RpcId::Num(2)), Some(params.as_ref()), &runtime).await;
         assert_eq!(auth_status_state(status), "valid");
+    }
+
+    #[tokio::test]
+    async fn auth_profile_create_lifecycle_failure_restores_existing_credentials() {
+        let runtime = test_runtime_with_config(config_with_openai_managed_store_binding());
+        runtime
+            .runtime_adapter()
+            .set_auth_lease_handle(Arc::new(RejectingAuthLeaseHandle));
+        let connection_ref = ConnectionRef {
+            realm: meerkat_core::RealmId::parse("dev").unwrap(),
+            binding: meerkat_core::BindingId::parse("default_openai").unwrap(),
+            profile: None,
+        };
+        let key = TokenKey::from_connection_ref(&connection_ref);
+        let store = runtime.token_store().expect("test token store");
+        store
+            .save(&key, &PersistedTokens::api_key("sk-old"))
+            .await
+            .unwrap();
+        let params = raw_params(serde_json::json!({
+            "realm_id": "dev",
+            "binding_id": "default_openai",
+            "auth_method": "api_key",
+            "secret": "sk-new"
+        }));
+
+        let resp =
+            handle_auth_profile_create(Some(RpcId::Num(1)), Some(params.as_ref()), &runtime).await;
+
+        let error = resp.error.expect("create should fail");
+        assert_eq!(error.code, crate::error::INTERNAL_ERROR);
+        assert!(
+            error
+                .message
+                .contains("AuthMachine lifecycle acquire failed")
+        );
+        let stored = store.load(&key).await.unwrap().unwrap();
+        assert_eq!(stored.primary_secret.as_deref(), Some("sk-old"));
+    }
+
+    #[tokio::test]
+    async fn provisioned_api_key_lifecycle_failure_restores_existing_credentials() {
+        let store: Arc<dyn TokenStore> =
+            Arc::new(meerkat_providers::auth_store::EphemeralTokenStore::new());
+        let auth_lease = RejectingAuthLeaseHandle;
+        let connection_ref = ConnectionRef {
+            realm: meerkat_core::RealmId::parse("dev").unwrap(),
+            binding: meerkat_core::BindingId::parse("default_openai").unwrap(),
+            profile: None,
+        };
+        let key = TokenKey::from_connection_ref(&connection_ref);
+        let previous = PersistedTokens::api_key("sk-old");
+        let replacement = PersistedTokens::api_key("sk-new");
+        store.save(&key, &previous).await.unwrap();
+        let previous_snapshot = store.load(&key).await.unwrap();
+        store.save(&key, &replacement).await.unwrap();
+
+        let err = publish_saved_tokens_and_restore_on_lifecycle_failure(
+            Some(RpcId::Num(1)),
+            store.as_ref(),
+            &auth_lease,
+            &connection_ref,
+            &key,
+            &replacement,
+            previous_snapshot.as_ref(),
+        )
+        .await
+        .unwrap_err();
+
+        let error = err.error.expect("publish should fail");
+        assert_eq!(error.code, crate::error::INTERNAL_ERROR);
+        assert!(
+            error
+                .message
+                .contains("AuthMachine lifecycle acquire failed")
+        );
+        let stored = store.load(&key).await.unwrap().unwrap();
+        assert_eq!(stored.primary_secret.as_deref(), Some("sk-old"));
     }
 
     #[tokio::test]

--- a/meerkat-rpc/src/handlers/auth.rs
+++ b/meerkat-rpc/src/handlers/auth.rs
@@ -1459,6 +1459,57 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn auth_status_observes_session_runtime_binding_lifecycle() {
+        let runtime = test_runtime_with_config(config_with_openai_managed_store_binding());
+        let connection_ref = ConnectionRef {
+            realm: meerkat_core::RealmId::parse("dev").unwrap(),
+            binding: meerkat_core::BindingId::parse("default_openai").unwrap(),
+            profile: None,
+        };
+        let lease_key = LeaseKey::from_connection_ref(&connection_ref);
+        let now = chrono::Utc::now().timestamp() as u64;
+        let params = raw_params(serde_json::json!({
+            "realm_id": "dev",
+            "binding_id": "default_openai"
+        }));
+
+        let bindings = runtime
+            .runtime_adapter()
+            .prepare_bindings(meerkat_core::SessionId::new())
+            .await
+            .unwrap();
+        bindings
+            .auth_lease
+            .acquire_lease(&lease_key, now + 3600)
+            .unwrap();
+        let status =
+            handle_auth_status_get(Some(RpcId::Num(1)), Some(params.as_ref()), &runtime).await;
+        assert_eq!(auth_status_state(status), "valid");
+
+        let bindings = runtime
+            .runtime_adapter()
+            .prepare_bindings(meerkat_core::SessionId::new())
+            .await
+            .unwrap();
+        bindings.auth_lease.begin_refresh(&lease_key).unwrap();
+        let status =
+            handle_auth_status_get(Some(RpcId::Num(2)), Some(params.as_ref()), &runtime).await;
+        assert_eq!(auth_status_state(status), "expiring");
+
+        bindings
+            .auth_lease
+            .complete_refresh(&lease_key, now + 7200, now)
+            .unwrap();
+        bindings
+            .auth_lease
+            .mark_reauth_required(&lease_key)
+            .unwrap();
+        let status =
+            handle_auth_status_get(Some(RpcId::Num(3)), Some(params.as_ref()), &runtime).await;
+        assert_eq!(auth_status_state(status), "reauth_required");
+    }
+
+    #[tokio::test]
     async fn oauth_completion_requires_binding_when_realm_is_present() {
         let runtime = test_runtime();
         let params = raw_params(serde_json::json!({

--- a/meerkat-rpc/src/handlers/turn.rs
+++ b/meerkat-rpc/src/handlers/turn.rs
@@ -71,6 +71,10 @@ pub struct StartTurnParams {
     /// Override provider-specific parameters. Applied alongside model/provider override.
     #[serde(default)]
     pub provider_params: Option<serde_json::Value>,
+    /// Clear durable provider-specific parameters. Omitted `provider_params`
+    /// inherits the current value; this flag explicitly disables it.
+    #[serde(default)]
+    pub clear_provider_params: bool,
     /// Override realm-scoped connection binding for this turn (deferral
     /// §2). On materialized sessions this scopes the hot-swap credential
     /// fetch to a specific realm + binding — preventing cross-realm
@@ -80,6 +84,10 @@ pub struct StartTurnParams {
     /// `Some(...)` sets a new one explicitly.
     #[serde(default)]
     pub connection_ref: Option<meerkat_core::ConnectionRef>,
+    /// Clear the durable connection binding. Omitted `connection_ref`
+    /// inherits the current value; this flag explicitly disables it.
+    #[serde(default)]
+    pub clear_connection_ref: bool,
 }
 
 /// Parameters for `turn/interrupt`.
@@ -121,7 +129,9 @@ pub struct TurnOverrides {
     pub output_schema: Option<serde_json::Value>,
     pub structured_output_retries: Option<u32>,
     pub provider_params: Option<serde_json::Value>,
+    pub clear_provider_params: bool,
     pub connection_ref: Option<meerkat_core::ConnectionRef>,
+    pub clear_connection_ref: bool,
 }
 
 impl TurnOverrides {
@@ -134,7 +144,9 @@ impl TurnOverrides {
             && self.output_schema.is_none()
             && self.structured_output_retries.is_none()
             && self.provider_params.is_none()
+            && !self.clear_provider_params
             && self.connection_ref.is_none()
+            && !self.clear_connection_ref
     }
 }
 
@@ -210,7 +222,9 @@ pub async fn handle_start(
         output_schema: params.output_schema,
         structured_output_retries: params.structured_output_retries,
         provider_params: params.provider_params,
+        clear_provider_params: params.clear_provider_params,
         connection_ref: params.connection_ref,
+        clear_connection_ref: params.clear_connection_ref,
     };
 
     // Lazy-register executor if not already registered.

--- a/meerkat-rpc/src/session_runtime.rs
+++ b/meerkat-rpc/src/session_runtime.rs
@@ -671,7 +671,6 @@ pub struct SessionRuntime {
     backend: Option<String>,
     config_runtime: Arc<StdRwLock<Option<Arc<meerkat_core::ConfigRuntime>>>>,
     runtime_adapter: Arc<MeerkatMachine>,
-    auth_lease: Arc<dyn meerkat_core::handles::AuthLeaseHandle>,
     /// Notification sink for event forwarding to the RPC transport.
     /// Wrapped in `RwLock` so it can be updated when a new TCP client
     /// connects (each connection has its own transport sink).
@@ -876,6 +875,7 @@ impl SessionRuntime {
         let approval_service = approval_service_from_persistence(&persistence);
         let (service, runtime_adapter) =
             meerkat::surface::build_runtime_backed_service(builder, max_sessions, persistence);
+        runtime_adapter.set_auth_lease_handle(Arc::clone(&auth_lease));
         let service = Arc::new(service);
         runtime_adapter.set_session_llm_reconfigure_host(Arc::new(
             SessionRuntimeLlmReconfigureHost {
@@ -901,7 +901,6 @@ impl SessionRuntime {
             backend: None,
             config_runtime,
             runtime_adapter,
-            auth_lease,
             notification_sink: StdRwLock::new(notification_sink),
             skill_identity_registry: Arc::new(StdRwLock::new(SkillIdentityRegistryState {
                 generation: 0,
@@ -953,6 +952,7 @@ impl SessionRuntime {
         let approval_service = approval_service_from_persistence(&persistence);
         let (service, runtime_adapter) =
             meerkat::surface::build_runtime_backed_service(builder, max_sessions, persistence);
+        runtime_adapter.set_auth_lease_handle(Arc::clone(&auth_lease));
         let service = Arc::new(service);
         runtime_adapter.set_session_llm_reconfigure_host(Arc::new(
             SessionRuntimeLlmReconfigureHost {
@@ -978,7 +978,6 @@ impl SessionRuntime {
             backend: None,
             config_runtime,
             runtime_adapter,
-            auth_lease,
             notification_sink: StdRwLock::new(notification_sink),
             skill_identity_registry: Arc::new(StdRwLock::new(SkillIdentityRegistryState {
                 generation: 0,
@@ -1081,7 +1080,7 @@ impl SessionRuntime {
     }
 
     pub fn auth_lease_handle(&self) -> Arc<dyn meerkat_core::handles::AuthLeaseHandle> {
-        Arc::clone(&self.auth_lease)
+        self.runtime_adapter.auth_lease_handle()
     }
 
     /// Override the shared default LLM client used by this runtime.

--- a/meerkat-rpc/src/session_runtime.rs
+++ b/meerkat-rpc/src/session_runtime.rs
@@ -363,6 +363,16 @@ impl SessionRuntimeLlmReconfigureHost {
                 reason: "provider override requires model on an existing session".to_string(),
             });
         }
+        if request.clear_provider_params && request.provider_params.is_some() {
+            return Err(RuntimeDriverError::ValidationFailed {
+                reason: "clear_provider_params cannot be combined with provider_params".to_string(),
+            });
+        }
+        if request.clear_connection_ref && request.connection_ref.is_some() {
+            return Err(RuntimeDriverError::ValidationFailed {
+                reason: "clear_connection_ref cannot be combined with connection_ref".to_string(),
+            });
+        }
 
         let registry = self.model_registry().await?;
         let model = request
@@ -380,10 +390,14 @@ impl SessionRuntimeLlmReconfigureHost {
         } else {
             current.provider
         };
-        let provider_params = request
-            .provider_params
-            .clone()
-            .or_else(|| current.provider_params.clone());
+        let provider_params = if request.clear_provider_params {
+            None
+        } else {
+            request
+                .provider_params
+                .clone()
+                .or_else(|| current.provider_params.clone())
+        };
         let self_hosted_server_id = if provider == meerkat_core::Provider::SelfHosted {
             if request.model.is_none() {
                 current.self_hosted_server_id.clone().or_else(|| {
@@ -411,14 +425,14 @@ impl SessionRuntimeLlmReconfigureHost {
             None
         };
 
-        // Dogma §10 inherit/set: `None` on the request preserves the
-        // session's existing binding, `Some(...)` sets a new one
-        // explicitly for this hot-swap. Prevents cross-realm credential
-        // bleed in multi-tenant swaps.
-        let connection_ref = request
-            .connection_ref
-            .clone()
-            .or_else(|| current.connection_ref.clone());
+        let connection_ref = if request.clear_connection_ref {
+            None
+        } else {
+            request
+                .connection_ref
+                .clone()
+                .or_else(|| current.connection_ref.clone())
+        };
 
         Ok(SessionLlmIdentity {
             model,
@@ -657,6 +671,7 @@ pub struct SessionRuntime {
     backend: Option<String>,
     config_runtime: Arc<StdRwLock<Option<Arc<meerkat_core::ConfigRuntime>>>>,
     runtime_adapter: Arc<MeerkatMachine>,
+    auth_lease: Arc<dyn meerkat_core::handles::AuthLeaseHandle>,
     /// Notification sink for event forwarding to the RPC transport.
     /// Wrapped in `RwLock` so it can be updated when a new TCP client
     /// connects (each connection has its own transport sink).
@@ -782,9 +797,11 @@ impl SessionRuntime {
                 .and_then(|ov| ov.provider.as_ref())
                 .map(|provider| meerkat_core::Provider::from_name(provider)),
             provider_params: None,
+            clear_provider_params: overrides.is_some_and(|ov| ov.clear_provider_params),
             render_metadata: None,
             execution_kind: None,
             connection_ref: overrides.and_then(|ov| ov.connection_ref.clone()),
+            clear_connection_ref: overrides.is_some_and(|ov| ov.clear_connection_ref),
         };
         (!metadata.is_empty()).then_some(metadata)
     }
@@ -800,7 +817,9 @@ impl SessionRuntime {
                 .provider
                 .map(|provider| provider.as_str().to_string()),
             provider_params: None,
+            clear_provider_params: metadata.clear_provider_params,
             connection_ref: metadata.connection_ref.clone(),
+            clear_connection_ref: metadata.clear_connection_ref,
             ..Default::default()
         };
         (!overrides.is_empty()).then_some(overrides)
@@ -846,6 +865,8 @@ impl SessionRuntime {
         let builder_schedule_tools_slot = Arc::clone(&builder.default_schedule_tools);
         let default_llm_client = Arc::new(StdRwLock::new(None));
         let config_runtime = Arc::new(StdRwLock::new(None));
+        let auth_lease: Arc<dyn meerkat_core::handles::AuthLeaseHandle> =
+            Arc::new(meerkat_runtime::RuntimeAuthLeaseHandle::new());
         meerkat::surface::set_default_schedule_tools(
             &builder,
             Some(Arc::new(ScheduleToolDispatcher::new(
@@ -880,6 +901,7 @@ impl SessionRuntime {
             backend: None,
             config_runtime,
             runtime_adapter,
+            auth_lease,
             notification_sink: StdRwLock::new(notification_sink),
             skill_identity_registry: Arc::new(StdRwLock::new(SkillIdentityRegistryState {
                 generation: 0,
@@ -920,6 +942,8 @@ impl SessionRuntime {
         let builder_schedule_tools_slot = Arc::clone(&builder.default_schedule_tools);
         let default_llm_client = Arc::new(StdRwLock::new(None));
         let config_runtime = Arc::new(StdRwLock::new(None));
+        let auth_lease: Arc<dyn meerkat_core::handles::AuthLeaseHandle> =
+            Arc::new(meerkat_runtime::RuntimeAuthLeaseHandle::new());
         meerkat::surface::set_default_schedule_tools(
             &builder,
             Some(Arc::new(ScheduleToolDispatcher::new(
@@ -954,6 +978,7 @@ impl SessionRuntime {
             backend: None,
             config_runtime,
             runtime_adapter,
+            auth_lease,
             notification_sink: StdRwLock::new(notification_sink),
             skill_identity_registry: Arc::new(StdRwLock::new(SkillIdentityRegistryState {
                 generation: 0,
@@ -1053,6 +1078,10 @@ impl SessionRuntime {
     /// credentials).
     pub fn token_store(&self) -> Option<Arc<dyn meerkat_providers::auth_store::TokenStore>> {
         self.factory.token_store.clone()
+    }
+
+    pub fn auth_lease_handle(&self) -> Arc<dyn meerkat_core::handles::AuthLeaseHandle> {
+        Arc::clone(&self.auth_lease)
     }
 
     /// Override the shared default LLM client used by this runtime.
@@ -1335,6 +1364,21 @@ impl SessionRuntime {
                 data: None,
             });
         }
+        if ov.clear_provider_params && ov.provider_params.is_some() {
+            return Err(RpcError {
+                code: error::INVALID_PARAMS,
+                message: "clear_provider_params cannot be combined with provider_params"
+                    .to_string(),
+                data: None,
+            });
+        }
+        if ov.clear_connection_ref && ov.connection_ref.is_some() {
+            return Err(RpcError {
+                code: error::INVALID_PARAMS,
+                message: "clear_connection_ref cannot be combined with connection_ref".to_string(),
+                data: None,
+            });
+        }
 
         let registry = self.model_registry().await?;
         let model = ov.model.clone().unwrap_or_else(|| current.model.clone());
@@ -1349,10 +1393,13 @@ impl SessionRuntime {
         } else {
             current.provider
         };
-        let provider_params = ov
-            .provider_params
-            .clone()
-            .or_else(|| current.provider_params.clone());
+        let provider_params = if ov.clear_provider_params {
+            None
+        } else {
+            ov.provider_params
+                .clone()
+                .or_else(|| current.provider_params.clone())
+        };
         let self_hosted_server_id = if provider == meerkat_core::Provider::SelfHosted {
             if ov.model.is_none() {
                 current.self_hosted_server_id.clone().or_else(|| {
@@ -1382,14 +1429,13 @@ impl SessionRuntime {
             None
         };
 
-        // Dogma §10 inherit/set: `None` on the override preserves the
-        // session's existing binding, `Some(...)` sets a new one
-        // explicitly for this turn. Prevents cross-realm credential
-        // bleed when the override is the only changed field.
-        let connection_ref = ov
-            .connection_ref
-            .clone()
-            .or_else(|| current.connection_ref.clone());
+        let connection_ref = if ov.clear_connection_ref {
+            None
+        } else {
+            ov.connection_ref
+                .clone()
+                .or_else(|| current.connection_ref.clone())
+        };
 
         Ok(SessionLlmIdentity {
             model,
@@ -1609,7 +1655,9 @@ impl SessionRuntime {
             model: ov.model.clone(),
             provider: ov.provider.clone(),
             provider_params: ov.provider_params.clone(),
+            clear_provider_params: ov.clear_provider_params,
             connection_ref: ov.connection_ref.clone(),
+            clear_connection_ref: ov.clear_connection_ref,
         };
 
         if !self.runtime_adapter.contains_session(session_id).await
@@ -2377,7 +2425,9 @@ impl SessionRuntime {
                 && (ov.model.is_some()
                     || ov.provider.is_some()
                     || ov.provider_params.is_some()
-                    || ov.connection_ref.is_some())
+                    || ov.clear_provider_params
+                    || ov.connection_ref.is_some()
+                    || ov.clear_connection_ref)
             {
                 self.hot_swap_llm_client(session_id, ov).await?;
             }
@@ -3141,7 +3191,12 @@ impl SessionRuntime {
 
         // Hot-swap LLM client if model/provider/provider_params changed.
         if let Some(ref ov) = overrides
-            && (ov.model.is_some() || ov.provider.is_some() || ov.provider_params.is_some())
+            && (ov.model.is_some()
+                || ov.provider.is_some()
+                || ov.provider_params.is_some()
+                || ov.clear_provider_params
+                || ov.connection_ref.is_some()
+                || ov.clear_connection_ref)
         {
             self.hot_swap_llm_client(session_id, ov).await?;
         }
@@ -6095,6 +6150,115 @@ mod tests {
         );
     }
 
+    #[tokio::test]
+    async fn turn_clear_provider_params_removes_current_policy() {
+        let temp = tempfile::tempdir().unwrap();
+        let runtime = make_runtime(temp_factory(&temp), 10);
+        let current = SessionLlmIdentity {
+            model: "claude-sonnet-4-5".to_string(),
+            provider: meerkat_core::Provider::Anthropic,
+            self_hosted_server_id: None,
+            provider_params: Some(serde_json::json!({ "temperature": 0.7 })),
+            connection_ref: None,
+        };
+        let overrides = crate::handlers::turn::TurnOverrides {
+            clear_provider_params: true,
+            ..Default::default()
+        };
+
+        let resolved = runtime
+            .resolve_target_llm_identity(&current, &overrides)
+            .await
+            .expect("clear override should resolve");
+
+        assert!(resolved.provider_params.is_none());
+    }
+
+    #[tokio::test]
+    async fn turn_clear_connection_ref_removes_current_binding() {
+        let temp = tempfile::tempdir().unwrap();
+        let runtime = make_runtime(temp_factory(&temp), 10);
+        let current = SessionLlmIdentity {
+            model: "claude-sonnet-4-5".to_string(),
+            provider: meerkat_core::Provider::Anthropic,
+            self_hosted_server_id: None,
+            provider_params: None,
+            connection_ref: Some(meerkat_core::ConnectionRef {
+                realm: meerkat_core::RealmId::parse("tenant_a").expect("valid realm"),
+                binding: meerkat_core::BindingId::parse("anthropic_default")
+                    .expect("valid binding"),
+                profile: None,
+            }),
+        };
+        let overrides = crate::handlers::turn::TurnOverrides {
+            clear_connection_ref: true,
+            ..Default::default()
+        };
+
+        let resolved = runtime
+            .resolve_target_llm_identity(&current, &overrides)
+            .await
+            .expect("clear override should resolve");
+
+        assert!(resolved.connection_ref.is_none());
+    }
+
+    #[tokio::test]
+    async fn turn_rejects_set_and_clear_connection_ref_together() {
+        let temp = tempfile::tempdir().unwrap();
+        let runtime = make_runtime(temp_factory(&temp), 10);
+        let current = SessionLlmIdentity {
+            model: "claude-sonnet-4-5".to_string(),
+            provider: meerkat_core::Provider::Anthropic,
+            self_hosted_server_id: None,
+            provider_params: None,
+            connection_ref: None,
+        };
+        let overrides = crate::handlers::turn::TurnOverrides {
+            connection_ref: Some(meerkat_core::ConnectionRef {
+                realm: meerkat_core::RealmId::parse("tenant_b").expect("valid realm"),
+                binding: meerkat_core::BindingId::parse("anthropic_vip").expect("valid binding"),
+                profile: None,
+            }),
+            clear_connection_ref: true,
+            ..Default::default()
+        };
+
+        let err = runtime
+            .resolve_target_llm_identity(&current, &overrides)
+            .await
+            .expect_err("set+clear must be rejected");
+
+        assert_eq!(err.code, error::INVALID_PARAMS);
+        assert!(err.message.contains("clear_connection_ref"));
+    }
+
+    #[tokio::test]
+    async fn turn_rejects_set_and_clear_provider_params_together() {
+        let temp = tempfile::tempdir().unwrap();
+        let runtime = make_runtime(temp_factory(&temp), 10);
+        let current = SessionLlmIdentity {
+            model: "claude-sonnet-4-5".to_string(),
+            provider: meerkat_core::Provider::Anthropic,
+            self_hosted_server_id: None,
+            provider_params: None,
+            connection_ref: None,
+        };
+        let overrides = crate::handlers::turn::TurnOverrides {
+            provider_params: Some(serde_json::json!({ "temperature": 0.2 })),
+            clear_provider_params: true,
+            ..Default::default()
+        };
+
+        let err = runtime
+            .resolve_target_llm_identity(&current, &overrides)
+            .await
+            .expect_err("set+clear must be rejected");
+
+        assert_eq!(err.code, error::INVALID_PARAMS);
+        assert!(err.message.contains("clear_provider_params"));
+    }
+
     #[cfg(feature = "mcp")]
     fn collect_tool_config_events(
         event_rx: &mut mpsc::Receiver<EventEnvelope<AgentEvent>>,
@@ -7471,7 +7635,9 @@ mod tests {
             "system_prompt": "You are helpful",
             "output_schema": {"type": "object"},
             "structured_output_retries": 3,
-            "provider_params": {"thinking": true}
+            "provider_params": {"thinking": true},
+            "clear_provider_params": false,
+            "clear_connection_ref": true
         });
         let params: StartTurnParams = serde_json::from_value(json).unwrap();
         assert_eq!(params.session_id, "test-id");
@@ -7484,6 +7650,8 @@ mod tests {
         assert!(params.output_schema.is_some());
         assert_eq!(params.structured_output_retries, Some(3));
         assert!(params.provider_params.is_some());
+        assert!(!params.clear_provider_params);
+        assert!(params.clear_connection_ref);
     }
 
     // -----------------------------------------------------------------------

--- a/meerkat-rpc/src/session_runtime/schedule_host.rs
+++ b/meerkat-rpc/src/session_runtime/schedule_host.rs
@@ -559,9 +559,11 @@ impl SessionRuntime {
                 model: None,
                 provider: None,
                 provider_params: None,
+                clear_provider_params: false,
                 render_metadata: dispatch.render_metadata.clone(),
                 execution_kind: None,
                 connection_ref: None,
+                clear_connection_ref: false,
             },
         );
         let mut prompt_input =

--- a/meerkat-runtime/src/handles/auth_lease.rs
+++ b/meerkat-runtime/src/handles/auth_lease.rs
@@ -57,8 +57,9 @@ fn emit_audit(
 /// Runtime-backed [`AuthLeaseHandle`] impl.
 ///
 /// Holds a mutex-guarded registry of per-binding [`auth_dsl::AuthMachineAuthority`]
-/// instances. Lookup-or-insert happens on first `acquire_lease`; all
-/// other operations require the binding to already exist.
+/// instances. Lookup-or-insert happens on first `acquire_lease`; release is
+/// also allowed before acquire so token-clear surfaces remain idempotent after
+/// process restart.
 pub struct RuntimeAuthLeaseHandle {
     machines: Arc<Mutex<HashMap<LeaseKey, auth_dsl::AuthMachineAuthority>>>,
 }
@@ -244,12 +245,15 @@ impl AuthLeaseHandle for RuntimeAuthLeaseHandle {
         // Drive the DSL transition, then drop the machine from the
         // registry: a released lease has no observable state and
         // keeping the spent AuthMachine around is shell-side bookkeeping
-        // that dogma §14 forbids (local state, no canonical role).
+        // that dogma §14 forbids (local state, no canonical role). Release
+        // is idempotent for logout/clear surfaces: clearing stale token
+        // material after process restart must not fail just because no
+        // in-memory AuthMachine has observed that binding yet.
         self.apply(
             lease_key,
             auth_dsl::AuthMachineInput::Release,
             "AuthLeaseHandle::release_lease",
-            false,
+            true,
         )?;
         let mut guard = self
             .machines
@@ -359,6 +363,31 @@ mod tests {
         let h = RuntimeAuthLeaseHandle::new();
         let err = h.mark_expiring(&lease("dev", "ghost")).unwrap_err();
         assert_eq!(err.context, "AuthLeaseHandle::mark_expiring");
+    }
+
+    #[test]
+    fn release_before_acquire_is_idempotent() {
+        let h = RuntimeAuthLeaseHandle::new();
+        let key = lease("dev", "ghost");
+
+        h.release_lease(&key).unwrap();
+
+        let snap = h.snapshot(&key);
+        assert!(snap.phase.is_none());
+        assert!(snap.expires_at.is_none());
+    }
+
+    #[test]
+    fn repeated_acquire_updates_existing_lease() {
+        let h = RuntimeAuthLeaseHandle::new();
+        let key = lease("dev", "default");
+
+        h.acquire_lease(&key, 1_800_000_000).unwrap();
+        h.acquire_lease(&key, 1_900_000_000).unwrap();
+
+        let snap = h.snapshot(&key);
+        assert_eq!(snap.phase, Some(AuthLeasePhase::Valid));
+        assert_eq!(snap.expires_at, Some(1_900_000_000));
     }
 
     #[test]

--- a/meerkat-runtime/src/meerkat_machine/dispatch_control.rs
+++ b/meerkat-runtime/src/meerkat_machine/dispatch_control.rs
@@ -600,7 +600,9 @@ impl MeerkatMachine {
                                         model: Some(request.intent.target_model.to_string()),
                                         provider: None,
                                         provider_params: None,
+                                        clear_provider_params: false,
                                         connection_ref: None,
+                                        clear_connection_ref: false,
                                     },
                                 )
                                 .await

--- a/meerkat-runtime/src/meerkat_machine/dispatch_session.rs
+++ b/meerkat-runtime/src/meerkat_machine/dispatch_session.rs
@@ -76,6 +76,7 @@ impl MeerkatMachine {
         let shared_handle_authority = Arc::new(crate::handles::HandleDslAuthority::from_shared(
             dsl_authority_shared,
         ));
+        let auth_lease = self.auth_lease_handle();
         Ok(MeerkatMachineCommandResult::Bindings(
             meerkat_core::SessionRuntimeBindings {
                 session_id,
@@ -104,7 +105,7 @@ impl MeerkatMachine {
                 model_routing: Arc::new(crate::handles::RuntimeModelRoutingHandle::new(
                     Arc::clone(&shared_handle_authority),
                 )),
-                auth_lease: Arc::new(crate::handles::RuntimeAuthLeaseHandle::new()),
+                auth_lease,
                 mcp_server_lifecycle: Arc::new(
                     crate::handles::RuntimeMcpServerLifecycleHandle::new(Arc::clone(
                         &shared_handle_authority,

--- a/meerkat-runtime/src/meerkat_machine/mod.rs
+++ b/meerkat-runtime/src/meerkat_machine/mod.rs
@@ -477,6 +477,9 @@ pub struct MeerkatMachine {
     blob_store: Option<Arc<dyn BlobStore>>,
     /// Runtime-owned shell seam for live session LLM reconfiguration I/O.
     llm_reconfigure_host: StdRwLock<Option<Arc<dyn SessionLlmReconfigureHost>>>,
+    /// AuthMachine lifecycle authority shared by runtime-backed auth
+    /// resolution/refresh paths and public auth-status surfaces.
+    auth_lease: StdRwLock<Arc<dyn meerkat_core::handles::AuthLeaseHandle>>,
     /// Canonical owner of "this session id is currently active" — replaces
     /// the deleted process-global `SESSION_IDENTITY_CLAIMS` static in the
     /// comms shell (dogma #2). Comms runtimes acquire a typed
@@ -509,6 +512,7 @@ impl MeerkatMachine {
             store: None,
             blob_store: None,
             llm_reconfigure_host: StdRwLock::new(None),
+            auth_lease: StdRwLock::new(Arc::new(crate::handles::RuntimeAuthLeaseHandle::new())),
             session_claims: Arc::new(crate::handles::RuntimeSessionClaimRegistry::new()),
             composition_signal_dispatcher: StdRwLock::new(None),
         }
@@ -522,6 +526,7 @@ impl MeerkatMachine {
             store: Some(store),
             blob_store: Some(blob_store),
             llm_reconfigure_host: StdRwLock::new(None),
+            auth_lease: StdRwLock::new(Arc::new(crate::handles::RuntimeAuthLeaseHandle::new())),
             session_claims: Arc::new(crate::handles::RuntimeSessionClaimRegistry::new()),
             composition_signal_dispatcher: StdRwLock::new(None),
         }
@@ -540,9 +545,33 @@ impl MeerkatMachine {
             store: Some(store),
             blob_store: None,
             llm_reconfigure_host: StdRwLock::new(None),
+            auth_lease: StdRwLock::new(Arc::new(crate::handles::RuntimeAuthLeaseHandle::new())),
             session_claims: Arc::new(crate::handles::RuntimeSessionClaimRegistry::new()),
             composition_signal_dispatcher: StdRwLock::new(None),
         }
+    }
+
+    /// Shared auth lifecycle handle used by all runtime-backed session
+    /// bindings created by this adapter.
+    pub fn auth_lease_handle(&self) -> Arc<dyn meerkat_core::handles::AuthLeaseHandle> {
+        Arc::clone(
+            &self
+                .auth_lease
+                .read()
+                .unwrap_or_else(std::sync::PoisonError::into_inner),
+        )
+    }
+
+    /// Install the auth lifecycle authority that public surfaces also read.
+    ///
+    /// Surfaces construct the adapter before all state fields are available, so
+    /// this setter lets them align the adapter's runtime-backed traffic with
+    /// the surface-visible status handle without creating a competing registry.
+    pub fn set_auth_lease_handle(&self, handle: Arc<dyn meerkat_core::handles::AuthLeaseHandle>) {
+        *self
+            .auth_lease
+            .write()
+            .unwrap_or_else(std::sync::PoisonError::into_inner) = handle;
     }
 
     /// The canonical session-identity claim handle owned by this

--- a/meerkat-runtime/src/meerkat_machine_tests.rs
+++ b/meerkat-runtime/src/meerkat_machine_tests.rs
@@ -11422,7 +11422,9 @@ async fn modeled_stage_persistent_filter_matches_runtime_after_active_ahead_reco
             model: Some("gpt-5.2".to_string()),
             provider: Some("openai".to_string()),
             provider_params: None,
+            clear_provider_params: false,
             connection_ref: None,
+            clear_connection_ref: false,
         },
     )
     .await
@@ -11484,7 +11486,9 @@ async fn modeled_request_deferred_tools_matches_runtime_after_active_ahead_recon
             model: Some("gpt-5.2".to_string()),
             provider: Some("openai".to_string()),
             provider_params: None,
+            clear_provider_params: false,
             connection_ref: None,
+            clear_connection_ref: false,
         },
     )
     .await
@@ -11710,7 +11714,9 @@ async fn reconfigure_session_llm_identity_rejects_idle_session() {
                 model: Some("gpt-5.2".to_string()),
                 provider: Some("openai".to_string()),
                 provider_params: None,
+                clear_provider_params: false,
                 connection_ref: None,
+                clear_connection_ref: false,
             },
         )
         .await
@@ -11802,7 +11808,9 @@ async fn reconfigure_session_llm_identity_updates_machine_owned_visibility_on_at
                 model: Some("gpt-5.2".to_string()),
                 provider: Some("openai".to_string()),
                 provider_params: Some(serde_json::json!({ "reasoning_effort": "high" })),
+                clear_provider_params: false,
                 connection_ref: None,
+                clear_connection_ref: false,
             },
         )
         .await
@@ -11940,7 +11948,9 @@ async fn reconfigure_session_llm_identity_succeeds_while_running() {
                 model: Some("gpt-5.2".to_string()),
                 provider: Some("openai".to_string()),
                 provider_params: None,
+                clear_provider_params: false,
                 connection_ref: None,
+                clear_connection_ref: false,
             },
         )
         .await
@@ -12053,7 +12063,9 @@ async fn reconfigure_session_llm_identity_rolls_back_on_persist_failure() {
                 model: Some("gpt-5.2".to_string()),
                 provider: Some("openai".to_string()),
                 provider_params: None,
+                clear_provider_params: false,
                 connection_ref: None,
+                clear_connection_ref: false,
             },
         )
         .await
@@ -12243,7 +12255,9 @@ async fn reconfigure_session_llm_identity_discards_live_session_when_rollback_fa
                 model: Some("gpt-5.2".to_string()),
                 provider: Some("openai".to_string()),
                 provider_params: None,
+                clear_provider_params: false,
                 connection_ref: None,
+                clear_connection_ref: false,
             },
         )
         .await
@@ -12398,7 +12412,9 @@ async fn reconfigure_live_topology_drives_running_session_to_boundary_and_rebind
                         model: Some("gpt-realtime".to_string()),
                         provider: Some("openai".to_string()),
                         provider_params: None,
+                        clear_provider_params: false,
                         connection_ref: None,
+                        clear_connection_ref: false,
                     },
                 )
                 .await
@@ -12540,7 +12556,9 @@ async fn reconfigure_live_topology_failure_before_detach_restores_prior_binding(
                 model: Some("gpt-5.2".to_string()),
                 provider: Some("openai".to_string()),
                 provider_params: None,
+                clear_provider_params: false,
                 connection_ref: None,
+                clear_connection_ref: false,
             },
         )
         .await
@@ -12678,7 +12696,9 @@ async fn reconfigure_live_topology_failure_after_detach_discards_and_requires_re
                 model: Some("gpt-5.2".to_string()),
                 provider: Some("openai".to_string()),
                 provider_params: None,
+                clear_provider_params: false,
                 connection_ref: None,
+                clear_connection_ref: false,
             },
         )
         .await
@@ -15175,7 +15195,9 @@ async fn execute_runtime_parity_probe(
                 model: Some("gpt-5.2".to_string()),
                 provider: Some("openai".to_string()),
                 provider_params: None,
+                clear_provider_params: false,
                 connection_ref: None,
+                clear_connection_ref: false,
             },
         )
         .await

--- a/meerkat-runtime/src/meerkat_machine_types.rs
+++ b/meerkat-runtime/src/meerkat_machine_types.rs
@@ -166,13 +166,26 @@ pub struct SessionLlmReconfigureRequest {
     pub provider: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub provider_params: Option<serde_json::Value>,
+    /// Explicitly clear the session's durable provider params. This is
+    /// distinct from omitting `provider_params`, which inherits the current
+    /// value for compatibility.
+    #[serde(default, skip_serializing_if = "is_false")]
+    pub clear_provider_params: bool,
     /// Optional realm-scoped connection override. When present, the
     /// hot-swap uses this binding to resolve credentials; when absent,
-    /// the session's existing `SessionLlmIdentity.connection_ref` is
-    /// preserved. Dogma §10 inherit/set — `None` inherits the current
-    /// binding, `Some(ref)` sets a new one explicitly.
+    /// the session's existing `SessionLlmIdentity.connection_ref` is preserved
+    /// unless `clear_connection_ref` is true.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub connection_ref: Option<meerkat_core::ConnectionRef>,
+    /// Explicitly clear the session's durable connection reference. This is
+    /// distinct from omitting `connection_ref`, which inherits the current
+    /// binding for compatibility.
+    #[serde(default, skip_serializing_if = "is_false")]
+    pub clear_connection_ref: bool,
+}
+
+fn is_false(value: &bool) -> bool {
+    !*value
 }
 
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq, Default)]

--- a/meerkat/src/factory.rs
+++ b/meerkat/src/factory.rs
@@ -1595,7 +1595,10 @@ impl AgentFactory {
         // through the same realm binding. The caller keeps precedence —
         // if build_config already carries a connection_ref, leave it.
         if build_config.connection_ref.is_none() {
-            build_config.connection_ref = metadata.connection_ref.clone();
+            build_config.connection_ref = metadata
+                .connection_ref
+                .clone()
+                .filter(|connection_ref| !connection_ref.is_env_default());
         }
         if !mask.override_builtins {
             build_config.override_builtins = metadata.tooling.builtins;
@@ -2169,7 +2172,17 @@ impl AgentFactory {
                             build_config.realm_id.as_deref(),
                         )
                         .map_err(BuildAgentError::ConnectionResolution)?;
-                    build_config.connection_ref = Some(resolved_connection_ref.clone());
+                    if resolved_connection_ref.is_env_default()
+                        && build_config
+                            .connection_ref
+                            .as_ref()
+                            .map(ConnectionRef::is_env_default)
+                            .unwrap_or(true)
+                    {
+                        build_config.connection_ref = None;
+                    } else {
+                        build_config.connection_ref = Some(resolved_connection_ref.clone());
+                    }
 
                     // Provider-runtime registry needs the OAuth-backed
                     // TokenStore attached so persisted tokens (written by
@@ -3566,31 +3579,25 @@ mod tests {
     }
 
     #[test]
-    fn persisted_env_default_connection_ref_rehydrates_without_config_realm() {
+    fn explicit_env_default_connection_ref_is_not_rehydrated_as_durable_identity() {
         let config = Config::default();
         let connection_ref = ConnectionRef {
             realm: RealmId::parse("env_default").expect("valid realm"),
             binding: BindingId::parse("default").expect("valid binding"),
             profile: None,
         };
-        let (realm, binding_id, resolved_ref) = AgentFactory::resolve_realm_binding_for_provider(
+        let err = AgentFactory::resolve_realm_binding_for_provider(
             &config,
             Provider::OpenAI,
             Some(&connection_ref),
             None,
         )
-        .expect("persisted env_default ref should rehydrate");
+        .expect_err("env_default is a synthetic fallback, not a durable identity");
 
-        assert_eq!(realm.realm_id, "env_default");
-        assert_eq!(binding_id, "default");
-        assert_eq!(resolved_ref, connection_ref);
-        let (_binding, backend, auth) = realm.lookup_binding("default").unwrap();
-        assert_eq!(backend.provider, Provider::OpenAI);
-        assert!(matches!(
-            &auth.source,
-            CredentialSourceSpec::Env { env, fallback }
-                if env == "OPENAI_API_KEY" && fallback.is_empty()
-        ));
+        assert!(
+            err.contains("env_default"),
+            "error should name the rejected synthetic realm: {err}"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- route auth status state through AuthMachine lease snapshots instead of TokenStore-derived phase
- publish AuthMachine lifecycle on REST/RPC token save and clear paths, with rollback on lifecycle publish failure
- prevent durable persisted env_default connection refs while preserving unscoped env fallback
- add explicit clear_provider_params and clear_connection_ref semantics through turn metadata, runtime wire, and hot-swap validation

## Validation
- ./scripts/repo-cargo fmt --all
- ./scripts/repo-cargo check -p meerkat-core
- ./scripts/repo-cargo check -p meerkat-rpc
- ./scripts/repo-cargo check -p meerkat-rest
- ./scripts/repo-cargo check -p rkat
- ./scripts/repo-cargo test -p meerkat-core auth
- ./scripts/repo-cargo test -p meerkat-core --test runtime_turn_metadata_typed_round_trip
- ./scripts/repo-cargo test -p meerkat-runtime auth_lease
- ./scripts/repo-cargo test -p meerkat --lib explicit_env_default_connection_ref_is_not_rehydrated_as_durable_identity
- ./scripts/repo-cargo test -p meerkat-rpc auth_
- ./scripts/repo-cargo test -p meerkat-rpc turn_clear
- ./scripts/repo-cargo test -p meerkat-rpc turn_rejects_set_and_clear
- ./scripts/repo-cargo test -p meerkat-rest auth_
- git diff --check
- make check
- make test
- make lint

Linear: LUC-85