### PR TITLE
LUC-94 docs doctrine drift cleanup

### DIFF
--- a/.claude/skills/meerkat-architecture/SKILL.md
+++ b/.claude/skills/meerkat-architecture/SKILL.md
@@ -107,7 +107,7 @@ Exactly five canonical machines, each with a DSL source in `meerkat-machine-sche
 - **OccurrenceLifecycleMachine** — occurrence dispatch and delivery.
 - **AuthMachine** — auth/session authorization state that must remain machine-owned.
 
-Plus four composition protocols at the seams: `meerkat_mob_seam`, `schedule_bundle`, `schedule_runtime_bundle`, `schedule_mob_bundle`.
+Plus five composition protocols at the seams: `meerkat_mob_seam`, `schedule_bundle`, `schedule_runtime_bundle`, `schedule_mob_bundle`, `auth_lease_bundle`.
 
 **Primary semantic authority lives in the catalog-generated machines.** Production modules are bridge shells around catalog-owned DSL bodies and crate-local bridging types. Handwritten `*_authority.rs` helpers that still exist are adapter mechanics, projections, planners, or sealed mutators, not competing semantic owners.
 

--- a/.claude/skills/meerkat-architecture/references/machine-system.md
+++ b/.claude/skills/meerkat-architecture/references/machine-system.md
@@ -12,7 +12,7 @@ The final system has exactly five canonical machines:
 - **OccurrenceLifecycleMachine** — perimeter occurrence lifecycle
 - **AuthMachine** — auth/session authorization lifecycle
 
-Plus four composition protocols at the seams: `meerkat_mob_seam`, `schedule_bundle`, `schedule_runtime_bundle`, `schedule_mob_bundle`.
+Plus five canonical composition schemas at the seams: `meerkat_mob_seam`, `schedule_bundle`, `schedule_runtime_bundle`, `schedule_mob_bundle`, `auth_lease_bundle`.
 
 Catalog authoritative directory: `meerkat-machine-schema/src/catalog/dsl/` — contains exactly these five machine DSLs.
 
@@ -186,12 +186,13 @@ MobMachine in-crate access: `MobActor.dsl_authority: MobMachineAuthority` is dir
 
 ## Compositions
 
-Compositions live in `meerkat-machine-schema/src/catalog/compositions.rs`. Four canonical ones:
+Compositions live in `meerkat-machine-schema/src/catalog/compositions.rs`. Five canonical ones are exposed by `canonical_composition_schemas()`:
 
 - `meerkat_mob_seam_composition` — MeerkatMachine ↔ MobMachine handoff
 - `schedule_bundle_composition` — schedule + occurrence + delivery
 - `schedule_runtime_bundle_composition` — schedule + runtime boundary
 - `schedule_mob_bundle_composition` — schedule + mob boundary
+- `auth_lease_bundle_composition` — AuthMachine ↔ runtime/provider auth lease publication
 
 Compositions express effect-disposition rules: which effects emitted by one machine are consumed as inputs by another, which obligations must be realized before a terminal, and which protocol helpers get codegen'd.
 
@@ -209,7 +210,7 @@ Per `docs/architecture/meerkat-runtime-dogma.md`:
 ## What the workspace looks like in the target state
 
 - Exactly 5 canonical machine DSL files in `meerkat-machine-schema/src/catalog/dsl/` — one per machine. Shared catalog helpers in that directory are allowed; no production crate authors a competing machine body.
-- Exactly 4 compositions in `meerkat-machine-schema/src/catalog/compositions.rs`.
+- Exactly 5 canonical compositions in `meerkat-machine-schema/src/catalog/compositions.rs`, registered by `canonical_composition_schemas()`.
 - Zero `*_authority.rs` files containing handwritten match-table state machines. Files named `dsl_authority.rs` are runtime adapter plumbing (not state machines); other authority-named helpers must be projections, planners, or sealed mutators with no semantic transition table.
 - Runtime shell holds only: per-session `Arc<Mutex<MeerkatMachineAuthority>>` + `Arc<Mutex<MobMachineAuthority>>`, handle trait impls that route through the shared authorities, IO mechanics (channels, handles, wall-clock timestamps), and observability projections (history logs, diagnostic snapshots).
 - Handle traits in `meerkat-core/src/handles.rs` (`TurnStateHandle`, `CommsDrainHandle`, `ExternalToolSurfaceHandle`, `PeerCommsHandle`, `SessionAdmissionHandle`) give cross-crate access to MeerkatMachine transitions. Mob-internal callers use `MobActor.dsl_authority` directly.

--- a/artifacts/schemas/rest-openapi.json
+++ b/artifacts/schemas/rest-openapi.json
@@ -50,10 +50,10 @@
     },
     "/auth/profiles": {
       "get": {
-        "summary": "List auth profiles"
+        "summary": "List realm auth profiles, backend profiles, and bindings"
       },
       "post": {
-        "summary": "Create an auth profile"
+        "summary": "Store binding-scoped credentials"
       }
     },
     "/capabilities": {

--- a/artifacts/schemas/wire-types.json
+++ b/artifacts/schemas/wire-types.json
@@ -11135,7 +11135,7 @@
   },
   "WireAuthProfile": {
     "$schema": "https://json-schema.org/draft/2020-12/schema",
-    "description": "Wire projection of [`meerkat_core::AuthProfile`]. Sensitive credential\nmaterial is NOT wire-projected — callers that want to read secret\nmaterial have to go through the server-side\n`auth.profile.get` / `/auth/profiles/:id` endpoints which return\ntyped redacted shapes. `source_kind` is a discriminator for the\ncredential-source variant.",
+    "description": "Wire projection of [`meerkat_core::AuthProfile`]. Sensitive credential\nmaterial is NOT wire-projected; callers that inspect profile metadata use\nthe server-side `auth.profile.get` RPC or the\n`GET /auth/bindings/{binding_id}` REST path; both return typed redacted\nshapes. `source_kind` is a\ndiscriminator for the credential-source variant.",
     "properties": {
       "auth_method": {
         "type": "string"
@@ -11202,7 +11202,7 @@
       }
     },
     "$schema": "https://json-schema.org/draft/2020-12/schema",
-    "description": "`DELETE /auth/profiles/:binding_id` / `POST /auth/logout` success body.",
+    "description": "`DELETE /auth/bindings/{binding_id}` /\n`POST /auth/bindings/{binding_id}/logout` success body.",
     "properties": {
       "binding_id": {
         "type": "string"
@@ -11323,7 +11323,7 @@
         "type": "string"
       },
       "WireAuthProfile": {
-        "description": "Wire projection of [`meerkat_core::AuthProfile`]. Sensitive credential\nmaterial is NOT wire-projected — callers that want to read secret\nmaterial have to go through the server-side\n`auth.profile.get` / `/auth/profiles/:id` endpoints which return\ntyped redacted shapes. `source_kind` is a discriminator for the\ncredential-source variant.",
+        "description": "Wire projection of [`meerkat_core::AuthProfile`]. Sensitive credential\nmaterial is NOT wire-projected; callers that inspect profile metadata use\nthe server-side `auth.profile.get` RPC or the\n`GET /auth/bindings/{binding_id}` REST path; both return typed redacted\nshapes. `source_kind` is a\ndiscriminator for the credential-source variant.",
         "properties": {
           "auth_method": {
             "type": "string"
@@ -11375,7 +11375,7 @@
       }
     },
     "$schema": "https://json-schema.org/draft/2020-12/schema",
-    "description": "`GET /auth/profiles/:binding_id` success body.",
+    "description": "`GET /auth/bindings/{binding_id}` success body.",
     "properties": {
       "auth_profile": {
         "$ref": "#/$defs/WireAuthProfile"
@@ -11402,7 +11402,7 @@
   "WireAuthProfilesList": {
     "$defs": {
       "WireAuthProfile": {
-        "description": "Wire projection of [`meerkat_core::AuthProfile`]. Sensitive credential\nmaterial is NOT wire-projected — callers that want to read secret\nmaterial have to go through the server-side\n`auth.profile.get` / `/auth/profiles/:id` endpoints which return\ntyped redacted shapes. `source_kind` is a discriminator for the\ncredential-source variant.",
+        "description": "Wire projection of [`meerkat_core::AuthProfile`]. Sensitive credential\nmaterial is NOT wire-projected; callers that inspect profile metadata use\nthe server-side `auth.profile.get` RPC or the\n`GET /auth/bindings/{binding_id}` REST path; both return typed redacted\nshapes. `source_kind` is a\ndiscriminator for the credential-source variant.",
         "properties": {
           "auth_method": {
             "type": "string"
@@ -11680,7 +11680,7 @@
       }
     },
     "$schema": "https://json-schema.org/draft/2020-12/schema",
-    "description": "Wire projection of the auth-profile status. Returned from\n`auth.status.get` / `GET /auth/status/:id`.",
+    "description": "Wire projection of the auth-profile status. Returned from\n`auth.status.get` / `GET /auth/bindings/{binding_id}/status`.",
     "properties": {
       "account_id": {
         "type": [
@@ -11776,7 +11776,7 @@
       }
     },
     "$schema": "https://json-schema.org/draft/2020-12/schema",
-    "description": "`GET /auth/status/:binding_id` success body. Richer than\n[`WireAuthStatus`] — also carries `realm_id` / `binding_id` /\n`connection_ref` / `has_refresh_token` so the caller can key by\nbinding directly.",
+    "description": "`GET /auth/bindings/{binding_id}/status` success body. Richer than\n[`WireAuthStatus`] — also carries `realm_id` / `binding_id` /\n`connection_ref` / `has_refresh_token` so the caller can key by\nbinding directly.",
     "properties": {
       "account_id": {
         "type": [
@@ -15113,7 +15113,7 @@
   "WireRealmConnectionSet": {
     "$defs": {
       "WireAuthProfile": {
-        "description": "Wire projection of [`meerkat_core::AuthProfile`]. Sensitive credential\nmaterial is NOT wire-projected — callers that want to read secret\nmaterial have to go through the server-side\n`auth.profile.get` / `/auth/profiles/:id` endpoints which return\ntyped redacted shapes. `source_kind` is a discriminator for the\ncredential-source variant.",
+        "description": "Wire projection of [`meerkat_core::AuthProfile`]. Sensitive credential\nmaterial is NOT wire-projected; callers that inspect profile metadata use\nthe server-side `auth.profile.get` RPC or the\n`GET /auth/bindings/{binding_id}` REST path; both return typed redacted\nshapes. `source_kind` is a\ndiscriminator for the credential-source variant.",
         "properties": {
           "auth_method": {
             "type": "string"

--- a/artifacts/schemas/wire-types.json
+++ b/artifacts/schemas/wire-types.json
@@ -163,7 +163,7 @@
         "type": "string"
       },
       "PeerId": {
-        "description": "Canonical runtime identity for a peer.\n\n`PeerId` is the routing key: the router and trust store key by `PeerId`,\nnever by `PeerName`. Two peers may legitimately share a display `PeerName`\n(per the Wave-B V5 dogma note), but their `PeerId`s never collide — the\nunderlying UUID is globally unique.\n\nConstructed either freshly (`PeerId::new`) for a peer minted locally,\nor parsed from a hyphenated UUID (`PeerId::parse`) when we've been given\nan identity over the wire.",
+        "description": "Canonical runtime identity for a peer.\n\n`PeerId` is the routing key: the router and trust store key by `PeerId`,\nnever by `PeerName`. Two peers may legitimately share a display `PeerName`\n(per the Wave-B V5 dogma note), but their `PeerId`s never collide — the\nunderlying UUID is globally unique.\n\nConstructed freshly (`PeerId::new`) for a peer minted locally, parsed\nfrom a hyphenated UUID (`PeerId::parse`) when we've been given an identity\nover the wire, or derived from a 32-byte Ed25519 public key when a transport\nstill authenticates by raw signing key.",
         "type": "string"
       },
       "PeerLifecycleKind": {

--- a/docs/api/rest.mdx
+++ b/docs/api/rest.mdx
@@ -79,8 +79,8 @@ If `--realm` is omitted, the server creates a new isolated opaque realm (`realm-
 | `POST` | `/comms/send` | Push comms message into a session (comms feature) |
 | `GET` | `/comms/peers` | List discoverable peers (comms feature) |
 | `POST` | `/realtime/status` | Read product-layer realtime status |
-| `GET` | `/auth/profiles` | List auth profiles |
-| `POST` | `/auth/profiles` | Create an auth profile |
+| `GET` | `/auth/profiles` | List realm auth profiles, backend profiles, and bindings |
+| `POST` | `/auth/profiles` | Store binding-scoped credentials |
 | `GET` | `/auth/bindings/{binding_id}` | Read a binding-scoped auth profile |
 | `DELETE` | `/auth/bindings/{binding_id}` | Delete binding-scoped credentials |
 | `POST` | `/auth/bindings/{binding_id}/test` | Test a binding resolve path |
@@ -764,6 +764,252 @@ Accepted request forms:
 
 If `expected_generation` is stale, the server returns `400` with a generation-conflict message.
 
+### GET /auth/profiles
+
+List the auth profiles, backend profiles, and provider bindings for a realm.
+
+<ParamField query="realm_id" type="string" required>
+  Realm to read.
+</ParamField>
+
+<ParamField query="profile_id" type="string | null">
+  Optional profile selector accepted by the shared auth query shape.
+</ParamField>
+
+```json Response
+{
+  "realm_id": "prod",
+  "auth_profiles": [],
+  "backend_profiles": [],
+  "bindings": []
+}
+```
+
+### POST /auth/profiles
+
+Store credentials for an existing binding-scoped auth profile. The binding must
+resolve to an auth profile whose source is `managed_store`; inline, env,
+external resolver, platform-default, command, and file-descriptor sources are
+configured outside this endpoint.
+
+```json Request
+{
+  "realm_id": "prod",
+  "binding_id": "openai",
+  "profile_id": "prod_openai",
+  "provider": "openai",
+  "auth_method": "api_key",
+  "secret": "sk-..."
+}
+```
+
+```json Response (201 Created)
+{
+  "realm_id": "prod",
+  "binding_id": "openai",
+  "connection_ref": {
+    "realm": "prod",
+    "binding": "openai",
+    "profile": "prod_openai"
+  },
+  "profile_id": "prod_openai",
+  "provider": "openai",
+  "auth_method": "api_key",
+  "stored": true
+}
+```
+
+<ParamField body="realm_id" type="string" required>
+  Realm containing the binding.
+</ParamField>
+
+<ParamField body="binding_id" type="string" required>
+  Binding whose configured auth profile will receive the stored credential.
+</ParamField>
+
+<ParamField body="profile_id" type="string | null">
+  Optional explicit profile override for the binding.
+</ParamField>
+
+<ParamField body="provider" type="string" required>
+  Provider expected from the resolved auth profile.
+</ParamField>
+
+<ParamField body="auth_method" type="string" required>
+  Stored-secret method: `"api_key"` or `"static_bearer"`.
+</ParamField>
+
+<ParamField body="secret" type="string" required>
+  Secret material to persist in the token store.
+</ParamField>
+
+### GET /auth/bindings/\{binding_id\}
+
+Read the auth profile resolved by a binding.
+
+<ParamField path="binding_id" type="string" required>
+  Binding to resolve.
+</ParamField>
+
+<ParamField query="realm_id" type="string" required>
+  Realm containing the binding.
+</ParamField>
+
+<ParamField query="profile_id" type="string | null">
+  Optional explicit profile override for the binding.
+</ParamField>
+
+### DELETE /auth/bindings/\{binding_id\}
+
+Clear stored credentials for the resolved binding-scoped auth profile.
+
+<ParamField path="binding_id" type="string" required>
+  Binding whose stored credentials should be cleared.
+</ParamField>
+
+<ParamField query="realm_id" type="string" required>
+  Realm containing the binding.
+</ParamField>
+
+<ParamField query="profile_id" type="string | null">
+  Optional explicit profile override for the binding.
+</ParamField>
+
+### POST /auth/bindings/\{binding_id\}/test
+
+Resolve a binding through the provider registry and report whether credential
+material or a dynamic authorizer is available.
+
+```json Request
+{
+  "realm_id": "prod",
+  "profile_id": "prod_openai"
+}
+```
+
+<ParamField path="binding_id" type="string" required>
+  Binding to test.
+</ParamField>
+
+<ParamField body="realm_id" type="string" required>
+  Realm containing the binding.
+</ParamField>
+
+<ParamField body="profile_id" type="string | null">
+  Optional explicit profile override for the binding.
+</ParamField>
+
+### POST /auth/login/start
+
+Begin a loopback OAuth login. The server owns the OAuth state and PKCE verifier.
+
+```json Request
+{
+  "provider": "anthropic",
+  "redirect_uri": "http://127.0.0.1:53682/callback"
+}
+```
+
+### POST /auth/login/complete
+
+Complete a loopback OAuth login and store the resulting tokens under an explicit
+binding-scoped `ConnectionRef`.
+
+```json Request
+{
+  "provider": "anthropic",
+  "code": "provider-code",
+  "state": "state-from-start",
+  "redirect_uri": "http://127.0.0.1:53682/callback",
+  "realm_id": "prod",
+  "binding_id": "anthropic",
+  "profile_id": "claude_oauth"
+}
+```
+
+<ParamField body="realm_id" type="string" required>
+  Realm containing the binding.
+</ParamField>
+
+<ParamField body="binding_id" type="string" required>
+  Binding that owns the stored OAuth tokens.
+</ParamField>
+
+<ParamField body="profile_id" type="string | null">
+  Optional explicit profile override for the binding.
+</ParamField>
+
+### POST /auth/login/device/start
+
+Begin a device-code OAuth login.
+
+```json Request
+{
+  "provider": "google"
+}
+```
+
+### POST /auth/login/device/complete
+
+Poll one device-code OAuth completion attempt and, when ready, store the tokens
+under an explicit binding-scoped `ConnectionRef`.
+
+```json Request
+{
+  "provider": "google",
+  "device_code": "device-code-from-start",
+  "realm_id": "prod",
+  "binding_id": "google",
+  "profile_id": "gemini_oauth"
+}
+```
+
+Returns `202` with `{ "state": "pending" }` when the provider has not finished,
+`429` with `{ "state": "slow_down" }` when the caller should back off, and `200`
+with a `ready` payload after tokens are persisted.
+
+### GET /auth/bindings/\{binding_id\}/status
+
+Read binding-scoped auth status. The response includes the flattened binding
+identity plus `profile_id`, `provider`, `auth_method`, public state,
+expiration, refresh timestamp, account ID, and refresh-token presence.
+
+<ParamField path="binding_id" type="string" required>
+  Binding whose status should be read.
+</ParamField>
+
+<ParamField query="realm_id" type="string" required>
+  Realm containing the binding.
+</ParamField>
+
+<ParamField query="profile_id" type="string | null">
+  Optional explicit profile override for the binding.
+</ParamField>
+
+### POST /auth/bindings/\{binding_id\}/logout
+
+Clear stored credentials for the binding and publish the auth lifecycle release.
+
+<ParamField path="binding_id" type="string" required>
+  Binding to log out.
+</ParamField>
+
+<ParamField query="realm_id" type="string" required>
+  Realm containing the binding.
+</ParamField>
+
+<ParamField query="profile_id" type="string | null">
+  Optional explicit profile override for the binding.
+</ParamField>
+
+### GET /realms
+
+List configured realm summaries.
+
+### GET /realms/\{id\}
+
+Read one realm connection set.
+
 ### POST /comms/send
 
 Push a canonical comms command into a running session. Requires the `comms` feature.
@@ -871,13 +1117,13 @@ List discoverable peers for a session. Requires the `comms` feature.
 ## Realtime attachment
 
 Realtime is a delivery mode of the session's LLM, driven by
-`ModelCapabilities.realtime`. To enable realtime audio on a session,
+`ModelCapabilities.realtime`. To run a session through the realtime transport,
 create it with a realtime-capable model (for example `gpt-realtime-1.5`):
 
 ```bash
 curl -X POST http://127.0.0.1:8080/sessions \
   -H 'content-type: application/json' \
-  -d '{"prompt":"Ready for voice.","model":"gpt-realtime-1.5","provider":"openai"}'
+  -d '{"prompt":"Ready for realtime interaction.","model":"gpt-realtime-1.5","provider":"openai"}'
 ```
 
 The runtime attaches the OpenAI Realtime transport automatically and

--- a/docs/architecture/formal-seam-closure.md
+++ b/docs/architecture/formal-seam-closure.md
@@ -243,8 +243,10 @@ actors from `actors.iter().map(|a| a.name)`. The `MachineInstance.actor` field
 still exists and must reference a `Machine`-kind actor. This means existing
 compositions must add `actors: vec![...]` declarations.
 
-**Migration**: All 8 canonical compositions get `actors` declarations matching
-their current implicit actor sets, all with `ActorKind::Machine`.
+**Migration**: Every composition exposed by `canonical_composition_schemas()`
+gets `actors` declarations matching its current implicit actor set, using
+`ActorKind::Machine` for machine authorities. Compatibility-only helper bundles
+are not counted as canonical unless the registry exposes them.
 
 ### Step 7: `EffectHandoffProtocol` on `CompositionSchema`
 
@@ -338,8 +340,8 @@ pub struct CompositionSchema {
 9. `TerminalClosure` requires the producer machine to have at least one terminal
    phase (in `validate_against()`).
 
-**Migration**: All 8 canonical compositions get `handoff_protocols: vec![]`
-initially (no protocols until step 12).
+**Migration**: Every composition exposed by `canonical_composition_schemas()`
+gets `handoff_protocols: vec![]` initially (no protocols until step 12).
 
 ### Step 8: Closed-World Obligation Validation
 

--- a/docs/guides/comms.mdx
+++ b/docs/guides/comms.mdx
@@ -43,7 +43,7 @@ graph TD
     subgraph rt["Runtime (meerkat-runtime)"]
         DRAIN["comms_drain"]
         BRIDGE["comms_bridge"]
-        INGRESS["RuntimeIngressAuthority"]
+        INGRESS["MeerkatMachine input admission"]
         POLICY["PolicyTable (Queue/Steer)"]
     end
 

--- a/meerkat-contracts/src/rest_catalog.rs
+++ b/meerkat-contracts/src/rest_catalog.rs
@@ -345,8 +345,11 @@ pub fn rest_path_catalog() -> Vec<RestPathDescriptor> {
         RestPathDescriptor::new(
             "/auth/profiles",
             vec![
-                RestOperationDescriptor::new("get", "List auth profiles"),
-                RestOperationDescriptor::new("post", "Create an auth profile"),
+                RestOperationDescriptor::new(
+                    "get",
+                    "List realm auth profiles, backend profiles, and bindings",
+                ),
+                RestOperationDescriptor::new("post", "Store binding-scoped credentials"),
             ],
         ),
         RestPathDescriptor::new(

--- a/meerkat-contracts/src/wire/connection.rs
+++ b/meerkat-contracts/src/wire/connection.rs
@@ -78,11 +78,11 @@ impl From<&meerkat_core::BackendProfile> for WireBackendProfile {
 }
 
 /// Wire projection of [`meerkat_core::AuthProfile`]. Sensitive credential
-/// material is NOT wire-projected — callers that want to read secret
-/// material have to go through the server-side
-/// `auth.profile.get` / `/auth/profiles/:id` endpoints which return
-/// typed redacted shapes. `source_kind` is a discriminator for the
-/// credential-source variant.
+/// material is NOT wire-projected; callers that inspect profile metadata use
+/// the server-side `auth.profile.get` RPC or the
+/// `GET /auth/bindings/{binding_id}` REST path; both return typed redacted
+/// shapes. `source_kind` is a
+/// discriminator for the credential-source variant.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
 pub struct WireAuthProfile {
@@ -225,7 +225,7 @@ impl From<meerkat_core::AuthError> for WireAuthError {
 }
 
 /// Wire projection of the auth-profile status. Returned from
-/// `auth.status.get` / `GET /auth/status/:id`.
+/// `auth.status.get` / `GET /auth/bindings/{binding_id}/status`.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
 pub struct WireAuthStatus {
@@ -285,7 +285,7 @@ pub struct WireAuthProfileCreated {
     pub stored: bool,
 }
 
-/// `GET /auth/profiles/:binding_id` success body.
+/// `GET /auth/bindings/{binding_id}` success body.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
 pub struct WireAuthProfileDetail {
@@ -295,7 +295,8 @@ pub struct WireAuthProfileDetail {
     pub auth_profile: WireAuthProfile,
 }
 
-/// `DELETE /auth/profiles/:binding_id` / `POST /auth/logout` success body.
+/// `DELETE /auth/bindings/{binding_id}` /
+/// `POST /auth/bindings/{binding_id}/logout` success body.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
 pub struct WireAuthProfileCleared {
@@ -380,7 +381,7 @@ pub struct WireAuthProfilesList {
     pub bindings: Vec<WireProviderBinding>,
 }
 
-/// `GET /auth/status/:binding_id` success body. Richer than
+/// `GET /auth/bindings/{binding_id}/status` success body. Richer than
 /// [`WireAuthStatus`] — also carries `realm_id` / `binding_id` /
 /// `connection_ref` / `has_refresh_token` so the caller can key by
 /// binding directly.

--- a/meerkat-rest/tests/rest_auth_endpoints.rs
+++ b/meerkat-rest/tests/rest_auth_endpoints.rs
@@ -20,7 +20,7 @@
 )]
 
 use axum::body::Body;
-use axum::http::{Request, StatusCode};
+use axum::http::{Request, StatusCode, header::CONTENT_TYPE};
 use http_body_util::BodyExt;
 use meerkat::{
     AgentFactory, Config, FactoryAgentBuilder, MemoryStore, PersistenceBundle,
@@ -156,11 +156,14 @@ async fn auth_routes_are_registered_and_dispatch() {
     }
 
     // Per-resource routes: must match the router (not return 404 for
-    // unknown-route reasons) — body content may still indicate
-    // resource-not-found via a 4xx/5xx, which is fine.
+    // unknown-route reasons) — structured handler 404s for missing
+    // resources are fine.
     for (method, path) in [
-        ("GET", "/auth/profiles/nonexistent"),
-        ("GET", "/auth/status/nonexistent"),
+        ("GET", "/auth/bindings/nonexistent?realm_id=test-realm"),
+        (
+            "GET",
+            "/auth/bindings/nonexistent/status?realm_id=test-realm",
+        ),
         ("GET", "/realms/test-realm"),
     ] {
         let req = Request::builder()
@@ -169,13 +172,33 @@ async fn auth_routes_are_registered_and_dispatch() {
             .body(Body::empty())
             .unwrap();
         let resp = app.clone().oneshot(req).await.unwrap();
-        // Accept any valid HTTP status (including 404 with a structured
-        // JSON body); the important thing is the handler ran.
         let status = resp.status();
+        let content_type = resp
+            .headers()
+            .get(CONTENT_TYPE)
+            .and_then(|value| value.to_str().ok())
+            .map(str::to_owned);
+        let bytes = resp.into_body().collect().await.unwrap().to_bytes();
         assert!(
-            status.as_u16() >= 200 && status.as_u16() < 600,
+            status.is_success() || status.is_client_error() || status.is_server_error(),
             "route {method} {path} must return a valid HTTP status, got {status}"
         );
+
+        if status == StatusCode::NOT_FOUND {
+            assert!(
+                content_type
+                    .as_deref()
+                    .is_some_and(|value| value.starts_with("application/json")),
+                "route {method} {path} returned 404 without a JSON handler body; \
+                 this looks like an unknown-route 404"
+            );
+            let body: Value =
+                serde_json::from_slice(&bytes).expect("handler 404 body must be structured JSON");
+            assert!(
+                body.get("error").is_some(),
+                "route {method} {path} returned 404 JSON without an error field: {body}"
+            );
+        }
     }
 }
 

--- a/meerkat-rest/tests/rest_auth_endpoints.rs
+++ b/meerkat-rest/tests/rest_auth_endpoints.rs
@@ -5,8 +5,8 @@
 //! reachable through the router and return well-formed responses
 //! (status code + JSON content-type) even without live credentials.
 //!
-//! Plan choke point K6 reads: "POST /auth/profiles → GET
-//! /auth/profiles/:id → POST /sessions with connection_ref". The
+//! Plan choke point K6 reads: "POST /auth/profiles -> GET
+//! /auth/bindings/{binding_id} -> POST /sessions with connection_ref". The
 //! live-provider half belongs in the `e2e-auth` lane; this file
 //! exercises the offline router half: each route is registered,
 //! dispatches, and returns a structured response.

--- a/sdks/python/meerkat/generated/types.py
+++ b/sdks/python/meerkat/generated/types.py
@@ -734,11 +734,11 @@ class WireBackendProfile:
 @dataclass
 class WireAuthProfile:
     """Wire projection of [`meerkat_core::AuthProfile`]. Sensitive credential
-material is NOT wire-projected — callers that want to read secret
-material have to go through the server-side
-`auth.profile.get` / `/auth/profiles/:id` endpoints which return
-typed redacted shapes. `source_kind` is a discriminator for the
-credential-source variant."""
+material is NOT wire-projected; callers that inspect profile metadata use
+the server-side `auth.profile.get` RPC or the
+`GET /auth/bindings/{binding_id}` REST path; both return typed redacted
+shapes. `source_kind` is a
+discriminator for the credential-source variant."""
     auth_method: str
     id: str
     provider: str
@@ -794,7 +794,7 @@ class WireAuthProfileCreated:
 
 @dataclass
 class WireAuthProfileDetail:
-    """`GET /auth/profiles/:binding_id` success body."""
+    """`GET /auth/bindings/{binding_id}` success body."""
     auth_profile: dict[str, Any]
     binding_id: str
     connection_ref: dict[str, Any]
@@ -803,7 +803,8 @@ class WireAuthProfileDetail:
 
 @dataclass
 class WireAuthProfileCleared:
-    """`DELETE /auth/profiles/:binding_id` / `POST /auth/logout` success body."""
+    """`DELETE /auth/bindings/{binding_id}` /
+`POST /auth/bindings/{binding_id}/logout` success body."""
     binding_id: str
     cleared: bool
     connection_ref: dict[str, Any]
@@ -880,7 +881,7 @@ auth, and binding profiles."""
 @dataclass
 class WireAuthStatus:
     """Wire projection of the auth-profile status. Returned from
-`auth.status.get` / `GET /auth/status/:id`."""
+`auth.status.get` / `GET /auth/bindings/{binding_id}/status`."""
     auth_method: str
     profile_id: str
     provider: str
@@ -893,7 +894,7 @@ class WireAuthStatus:
 
 @dataclass
 class WireAuthStatusDetail:
-    """`GET /auth/status/:binding_id` success body. Richer than
+    """`GET /auth/bindings/{binding_id}/status` success body. Richer than
 [`WireAuthStatus`] — also carries `realm_id` / `binding_id` /
 `connection_ref` / `has_refresh_token` so the caller can key by
 binding directly."""


### PR DESCRIPTION
## Summary
- remove stale REST realtime voice wording and document live binding-scoped auth REST request/query shapes
- replace the deleted `RuntimeIngressAuthority` label in the comms guide
- update machine doctrine references from stale 4/8-composition wording to the five canonical catalog compositions
- refresh REST OpenAPI summaries for `/auth/profiles`; schema emission also refreshed the generated `PeerId` description in `wire-types.json`

## Verification on current main before edits
- `docs/api/rest.mdx` still contained `realtime audio` and `Ready for voice.`
- `docs/api/rest.mdx` auth docs did not document the live binding-scoped `realm_id`/`binding_id` shapes registered by `meerkat-rest/src/lib.rs` and handled in `auth_endpoints.rs`
- `docs/guides/comms.mdx` still presented `RuntimeIngressAuthority`
- `.claude/skills/meerkat-architecture/references/machine-system.md` still said four canonical compositions; `meerkat-machine-schema/src/catalog/mod.rs` registers five including `auth_lease_bundle`
- `docs/architecture/formal-seam-closure.md` still said `All 8 canonical compositions`

## Validation
- `./scripts/repo-cargo run -p meerkat-contracts --features schema --bin emit-schemas`
- `./scripts/repo-cargo test -p meerkat-contracts rest_catalog -- --nocapture`
- `make check` (BuildBuddy invocation `d618b79e-7f0e-4f97-a700-bab9e07eeb8e`)
- `make fmt-check`
- `make lint` (BuildBuddy invocation `45ddd610-5697-4b88-8fc7-b06f06618765`)
- `make verify-schema-freshness`
- stale-string scan for the requested drift terms in touched docs (no matches)

Linear: LUC-94
