### PR TITLE
Fix projector checkpoint recovery and secret envelopes

### DIFF
--- a/meerkat-auth-core/src/resolver.rs
+++ b/meerkat-auth-core/src/resolver.rs
@@ -2,9 +2,9 @@
 //!
 //! Plan §6.11 closure: resolvers return typed credential material that
 //! provider runtimes wrap into real leases. Simple-secret paths cover
-//! `InlineSecret` / `Env` / `ExternalResolver` (via the typed
+//! `InlineSecret` / `Env` / `ExternalResolver` (only via the typed
 //! `ResolvedAuthEnvelope::InlineSecret` variant — dogma §5 closure
-//! replaced the `"__secret__"` synthetic-header-key convention) for
+//! rejects the `"__secret__"` synthetic-header-key convention) for
 //! `api_key` / `static_bearer` auth methods. External-authorizer
 //! resolution now returns typed auth material rather than `()`, so
 //! provider runtimes no longer end in placeholder empty leases.
@@ -324,26 +324,21 @@ pub async fn resolve_external_authorizer(
 
 /// Extract a simple secret from a resolved envelope. Dogma §5:
 /// `ResolvedAuthEnvelope::InlineSecret` is the typed canonical
-/// variant. The legacy `StaticHeaders` shape is still accepted
-/// transitively — a single header maps to the secret — but external
-/// resolvers should produce the typed variant directly.
+/// variant. `StaticHeaders` is intentionally rejected on
+/// api_key/static_bearer paths so header material cannot become an
+/// implicit secret shape.
 fn extract_secret_from_envelope(
     envelope: ResolvedAuthEnvelope,
 ) -> Result<String, ProviderAuthError> {
     match envelope {
         ResolvedAuthEnvelope::InlineSecret { secret, .. } => Ok(secret),
-        ResolvedAuthEnvelope::StaticHeaders { headers, .. } => {
-            if let [(_, value)] = headers.as_slice() {
-                Ok(value.clone())
-            } else {
-                Err(ProviderAuthError::SourceResolutionFailed(
-                    "external resolver returned StaticHeaders with \
-                     multiple entries; api_key/static_bearer path \
-                     requires InlineSecret or a single-entry \
-                     StaticHeaders envelope"
-                        .into(),
-                ))
-            }
+        ResolvedAuthEnvelope::StaticHeaders { .. } => {
+            Err(ProviderAuthError::SourceResolutionFailed(
+                "external resolver returned StaticHeaders envelope; \
+                 api_key/static_bearer path requires InlineSecret, \
+                 or use external_authorizer for header material"
+                    .into(),
+            ))
         }
         ResolvedAuthEnvelope::DynamicAuthorizer { .. } => {
             Err(ProviderAuthError::SourceResolutionFailed(
@@ -464,18 +459,17 @@ mod tests {
     }
 
     #[test]
-    fn extract_secret_single_header_legacy() {
-        // Back-compat: a single-header StaticHeaders envelope is still
-        // accepted. Multi-header envelopes (which previously carried
-        // the `__secret__` key alongside other wire headers) are an
-        // error — external resolvers should use the typed InlineSecret
-        // variant.
+    fn extract_secret_static_headers_errors_for_simple_secret() {
+        // Simple-secret resolvers fail closed: StaticHeaders are only
+        // valid for external_authorizer leases, not as an implicit
+        // api_key/static_bearer secret shape.
         let env = ResolvedAuthEnvelope::StaticHeaders {
             headers: vec![("Authorization".into(), "Bearer sk-y".into())],
             metadata: Default::default(),
             expires_at: None,
         };
-        assert_eq!(extract_secret_from_envelope(env).unwrap(), "Bearer sk-y");
+        let err = extract_secret_from_envelope(env).unwrap_err();
+        assert!(matches!(err, ProviderAuthError::SourceResolutionFailed(_)));
     }
 
     #[test]
@@ -571,6 +565,46 @@ mod tests {
             metadata_defaults: Default::default(),
         });
         binding
+    }
+
+    struct StaticEnvelopeResolver(ResolvedAuthEnvelope);
+
+    #[async_trait::async_trait]
+    impl meerkat_llm_core::provider_runtime::registry::ExternalAuthResolverHandle
+        for StaticEnvelopeResolver
+    {
+        async fn resolve(
+            &self,
+            _binding: &ValidatedBinding,
+        ) -> Result<ResolvedAuthEnvelope, AuthError> {
+            Ok(self.0.clone())
+        }
+    }
+
+    #[tokio::test]
+    async fn simple_secret_external_static_headers_fails_closed() {
+        let binding = simple_secret_binding(
+            CredentialSourceSpec::ExternalResolver {
+                handle: "host".into(),
+            },
+            "api_key",
+        );
+        let env = ResolverEnvironment::testing().with_external_resolver(
+            "host",
+            Arc::new(StaticEnvelopeResolver(
+                ResolvedAuthEnvelope::StaticHeaders {
+                    headers: vec![("Authorization".into(), "Bearer sk-y".into())],
+                    metadata: Default::default(),
+                    expires_at: None,
+                },
+            )),
+        );
+
+        let err = resolve_simple_secret(&binding.auth_profile.source, &env, &binding)
+            .await
+            .unwrap_err();
+
+        assert!(matches!(err, ProviderAuthError::SourceResolutionFailed(_)));
     }
 
     #[cfg(not(target_arch = "wasm32"))]

--- a/meerkat-session/src/projector.rs
+++ b/meerkat-session/src/projector.rs
@@ -24,6 +24,13 @@ pub struct SessionProjector {
     output_dir: PathBuf,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum CheckpointState {
+    Valid(u64),
+    Missing,
+    Invalid,
+}
+
 impl SessionProjector {
     /// Create a new projector targeting the given output directory.
     pub fn new(output_dir: impl Into<PathBuf>) -> Self {
@@ -137,25 +144,32 @@ impl SessionProjector {
 
     /// Read the last checkpoint seq for a session (0 if no checkpoint).
     pub async fn read_checkpoint(&self, session_id: &SessionId) -> u64 {
+        match self.read_checkpoint_state(session_id).await {
+            CheckpointState::Valid(seq) => seq,
+            CheckpointState::Missing | CheckpointState::Invalid => 0,
+        }
+    }
+
+    async fn read_checkpoint_state(&self, session_id: &SessionId) -> CheckpointState {
         let path = self.session_dir(session_id).join("checkpoint");
         match tokio::fs::read_to_string(&path).await {
             Ok(s) => match s.trim().parse() {
-                Ok(seq) => seq,
+                Ok(seq) => CheckpointState::Valid(seq),
                 Err(err) => {
                     tracing::warn!(
                         checkpoint = ?path,
-                        "invalid checkpoint contents (defaulting to 0): {err}"
+                        "invalid checkpoint contents: {err}"
                     );
-                    0
+                    CheckpointState::Invalid
                 }
             },
-            Err(err) if err.kind() == std::io::ErrorKind::NotFound => 0,
+            Err(err) if err.kind() == std::io::ErrorKind::NotFound => CheckpointState::Missing,
             Err(err) => {
                 tracing::warn!(
                     checkpoint = ?path,
-                    "failed to read checkpoint (defaulting to 0): {err}"
+                    "failed to read checkpoint: {err}"
                 );
-                0
+                CheckpointState::Invalid
             }
         }
     }
@@ -174,11 +188,7 @@ impl SessionProjector {
         // Remove derived files that may no longer be rewritten by the replay.
         for file_name in ["events.jsonl", "summary.txt", "checkpoint"] {
             let path = dir.join(file_name);
-            match tokio::fs::remove_file(&path).await {
-                Ok(()) => {}
-                Err(err) if err.kind() == std::io::ErrorKind::NotFound => {}
-                Err(err) => return Err(ProjectionError::Io(err)),
-            }
+            remove_derived_path(&path).await?;
         }
 
         // Replay from seq 1, replacing any previous derived output.
@@ -192,8 +202,39 @@ impl SessionProjector {
         event_store: &E,
         session_id: &SessionId,
     ) -> Result<u64, ProjectionError> {
-        let checkpoint = self.read_checkpoint(session_id).await;
-        self.project(event_store, session_id, checkpoint + 1).await
+        match self.read_checkpoint_state(session_id).await {
+            CheckpointState::Valid(checkpoint) => {
+                self.project(event_store, session_id, checkpoint + 1).await
+            }
+            CheckpointState::Missing => self.project(event_store, session_id, 1).await,
+            CheckpointState::Invalid => self.replay(event_store, session_id).await,
+        }
+    }
+}
+
+async fn remove_derived_path(path: &Path) -> Result<(), ProjectionError> {
+    match tokio::fs::remove_file(path).await {
+        Ok(()) => Ok(()),
+        Err(err) if err.kind() == std::io::ErrorKind::NotFound => Ok(()),
+        Err(err) if err.kind() == std::io::ErrorKind::IsADirectory => {
+            tokio::fs::remove_dir_all(path)
+                .await
+                .map_err(ProjectionError::Io)
+        }
+        Err(err) => {
+            // macOS reports remove_file(directory) as PermissionDenied.
+            if err.kind() == std::io::ErrorKind::PermissionDenied {
+                match tokio::fs::metadata(path).await {
+                    Ok(metadata) if metadata.is_dir() => {
+                        return tokio::fs::remove_dir_all(path)
+                            .await
+                            .map_err(ProjectionError::Io);
+                    }
+                    Ok(_) | Err(_) => {}
+                }
+            }
+            Err(ProjectionError::Io(err))
+        }
     }
 }
 
@@ -400,5 +441,76 @@ mod tests {
             std::fs::read_to_string(projector.session_dir(&sid).join("events.jsonl")).unwrap();
         let lines: Vec<&str> = events_content.trim().lines().collect();
         assert_eq!(lines.len(), 3);
+    }
+
+    #[tokio::test]
+    async fn test_projector_resume_rebuilds_after_invalid_checkpoint_without_duplicates() {
+        let dir = TempDir::new().unwrap();
+        let projector = SessionProjector::new(dir.path().join(".rkat"));
+        let store = MemEventStore::new();
+        let sid = SessionId::new();
+
+        store.add_events(
+            &sid,
+            &[
+                AgentEvent::TurnStarted { turn_number: 0 },
+                AgentEvent::TextComplete {
+                    content: "first".to_string(),
+                },
+            ],
+        );
+        projector.project(&store, &sid, 1).await.unwrap();
+
+        let session_dir = projector.session_dir(&sid);
+        tokio::fs::write(session_dir.join("checkpoint"), b"not-a-seq")
+            .await
+            .unwrap();
+        store.add_events(&sid, &[AgentEvent::TurnStarted { turn_number: 1 }]);
+
+        let seq = projector.resume(&store, &sid).await.unwrap();
+        assert_eq!(seq, 3);
+
+        let events_content = std::fs::read_to_string(session_dir.join("events.jsonl")).unwrap();
+        let lines: Vec<&str> = events_content.trim().lines().collect();
+        assert_eq!(lines.len(), 3);
+
+        let checkpoint = std::fs::read_to_string(session_dir.join("checkpoint")).unwrap();
+        assert_eq!(checkpoint.trim(), "3");
+    }
+
+    #[tokio::test]
+    async fn test_projector_resume_rebuilds_after_unreadable_checkpoint_without_duplicates() {
+        let dir = TempDir::new().unwrap();
+        let projector = SessionProjector::new(dir.path().join(".rkat"));
+        let store = MemEventStore::new();
+        let sid = SessionId::new();
+
+        store.add_events(
+            &sid,
+            &[
+                AgentEvent::TurnStarted { turn_number: 0 },
+                AgentEvent::TextComplete {
+                    content: "first".to_string(),
+                },
+            ],
+        );
+        projector.project(&store, &sid, 1).await.unwrap();
+
+        let session_dir = projector.session_dir(&sid);
+        let checkpoint_path = session_dir.join("checkpoint");
+        tokio::fs::remove_file(&checkpoint_path).await.unwrap();
+        tokio::fs::create_dir(&checkpoint_path).await.unwrap();
+        store.add_events(&sid, &[AgentEvent::TurnStarted { turn_number: 1 }]);
+
+        let seq = projector.resume(&store, &sid).await.unwrap();
+        assert_eq!(seq, 3);
+
+        let events_content = std::fs::read_to_string(session_dir.join("events.jsonl")).unwrap();
+        let lines: Vec<&str> = events_content.trim().lines().collect();
+        assert_eq!(lines.len(), 3);
+
+        assert!(checkpoint_path.is_file());
+        let checkpoint = std::fs::read_to_string(checkpoint_path).unwrap();
+        assert_eq!(checkpoint.trim(), "3");
     }
 }


### PR DESCRIPTION
## Summary
- Rebuild projector output when checkpoint contents are invalid or unreadable so resume does not duplicate derived events.
- Remove the simple-secret fallback that treated `StaticHeaders` as an implicit secret envelope.
- Keep `StaticHeaders` supported for `external_authorizer` lease materialization only.

## Linear
- LUC-95: https://linear.app/lucrfr/issue/LUC-95/low-risk-dogma-cleanup-projector-and-secret-resolver-fallback-truth

## Row Verification
- `Projector resume appends after invalid checkpoint instead of rebuilding`: confirmed present on current `origin/main`; fixed.
- `External secret resolver still accepts StaticHeaders as implicit secret shape`: confirmed present on current `origin/main`; fixed by failing closed for simple-secret extraction.
- No rows were already solved or skipped.

## Validation
- `./scripts/repo-cargo test -p meerkat-session --features session-store projector::tests`
- `./scripts/repo-cargo test -p meerkat-auth-core resolver::tests`
- `make check`
- `make test`
- `make lint`
- `git diff --check`