### PR TITLE
Clean up SDK, WASM, and OpenAPI surface contracts

### DIFF
--- a/artifacts/schemas/rest-openapi.json
+++ b/artifacts/schemas/rest-openapi.json
@@ -1,318 +1,15128 @@
 {
+  "components": {
+    "schemas": {
+      "ApprovalId": {
+        "description": "Durable approval id.",
+        "type": "string"
+      },
+      "AssistantImageId": {
+        "type": "string"
+      },
+      "AssistantImageRef": {
+        "properties": {
+          "blob_ref": {
+            "$ref": "#/components/schemas/BlobRef"
+          },
+          "height": {
+            "format": "uint32",
+            "minimum": 0,
+            "type": "integer"
+          },
+          "image_id": {
+            "$ref": "#/components/schemas/AssistantImageId"
+          },
+          "media_type": {
+            "type": "string"
+          },
+          "width": {
+            "format": "uint32",
+            "minimum": 0,
+            "type": "integer"
+          }
+        },
+        "required": [
+          "image_id",
+          "blob_ref",
+          "media_type",
+          "width",
+          "height"
+        ],
+        "type": "object"
+      },
+      "AudioFormatMismatchContext": {
+        "description": "Typed context carried alongside a [`RealtimeErrorCode::AudioFormatMismatch`].",
+        "properties": {
+          "actual": {
+            "$ref": "#/components/schemas/RealtimeAudioFormat"
+          },
+          "expected": {
+            "$ref": "#/components/schemas/RealtimeAudioFormat"
+          }
+        },
+        "required": [
+          "expected",
+          "actual"
+        ],
+        "type": "object"
+      },
+      "BindingId": {
+        "description": "Opaque slug identifying a binding inside a realm.",
+        "type": "string"
+      },
+      "BindingIdParams": {
+        "description": "Request payload for binding-scoped auth methods.",
+        "properties": {
+          "binding_id": {
+            "type": "string"
+          },
+          "profile_id": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "realm_id": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "realm_id",
+          "binding_id"
+        ],
+        "title": "BindingIdParams",
+        "type": "object"
+      },
+      "BlobId": {
+        "description": "Canonical realm-local blob identifier.\n\nThe identifier is content-addressed, but storage and GC semantics remain\nrealm-scoped.",
+        "type": "string"
+      },
+      "BlobRef": {
+        "description": "Durable image reference owned by transcript/runtime state.",
+        "properties": {
+          "blob_id": {
+            "$ref": "#/components/schemas/BlobId"
+          },
+          "media_type": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "blob_id",
+          "media_type"
+        ],
+        "type": "object"
+      },
+      "BlockId": {
+        "type": "string"
+      },
+      "BridgeBootstrapToken": {
+        "description": "One-time bootstrap proof exchanged between a mob supervisor and a\nmember runtime on initial bind.\n\nTransparent over the wire (`#[serde(transparent)]` — a bare JSON string),\nbut carries a redacting `Debug` impl and has no `Display` impl so the\nraw secret cannot accidentally land in logs or panic messages. Treat it\nlike an API key: read `as_str()` only at the comms/transport boundary.",
+        "type": "string"
+      },
+      "CalendarFieldSpec": {
+        "oneOf": [
+          {
+            "properties": {
+              "kind": {
+                "const": "any",
+                "type": "string"
+              }
+            },
+            "required": [
+              "kind"
+            ],
+            "type": "object"
+          },
+          {
+            "properties": {
+              "kind": {
+                "const": "values",
+                "type": "string"
+              },
+              "values": {
+                "items": {
+                  "format": "uint32",
+                  "minimum": 0,
+                  "type": "integer"
+                },
+                "type": "array"
+              }
+            },
+            "required": [
+              "kind",
+              "values"
+            ],
+            "type": "object"
+          }
+        ]
+      },
+      "CalendarTriggerSpec": {
+        "properties": {
+          "day_of_month": {
+            "$ref": "#/components/schemas/CalendarFieldSpec",
+            "default": {
+              "kind": "any"
+            }
+          },
+          "day_of_week": {
+            "$ref": "#/components/schemas/CalendarFieldSpec",
+            "default": {
+              "kind": "any"
+            }
+          },
+          "hour": {
+            "$ref": "#/components/schemas/CalendarFieldSpec",
+            "default": {
+              "kind": "any"
+            }
+          },
+          "minute": {
+            "$ref": "#/components/schemas/CalendarFieldSpec",
+            "default": {
+              "kind": "any"
+            }
+          },
+          "month": {
+            "$ref": "#/components/schemas/CalendarFieldSpec",
+            "default": {
+              "kind": "any"
+            }
+          },
+          "timezone": {
+            "type": "string"
+          },
+          "year": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/CalendarFieldSpec"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          }
+        },
+        "required": [
+          "timezone"
+        ],
+        "type": "object"
+      },
+      "CapabilitiesResponse": {
+        "description": "Response to a `capabilities/get` request.",
+        "properties": {
+          "capabilities": {
+            "items": {
+              "$ref": "#/components/schemas/CapabilityEntry"
+            },
+            "type": "array"
+          },
+          "contract_version": {
+            "$ref": "#/components/schemas/ContractVersion"
+          }
+        },
+        "required": [
+          "contract_version",
+          "capabilities"
+        ],
+        "title": "CapabilitiesResponse",
+        "type": "object"
+      },
+      "CapabilityEntry": {
+        "description": "A single capability's status in the current runtime.",
+        "properties": {
+          "description": {
+            "type": "string"
+          },
+          "id": {
+            "$ref": "#/components/schemas/CapabilityId"
+          },
+          "status": {
+            "$ref": "#/components/schemas/CapabilityStatus"
+          }
+        },
+        "required": [
+          "id",
+          "description",
+          "status"
+        ],
+        "type": "object"
+      },
+      "CapabilityHint": {
+        "description": "Hint about which capability is needed.",
+        "properties": {
+          "capability_id": {
+            "$ref": "#/components/schemas/CapabilityId"
+          },
+          "message": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "capability_id",
+          "message"
+        ],
+        "title": "CapabilityHint",
+        "type": "object"
+      },
+      "CapabilityId": {
+        "description": "Every capability known to Meerkat. Adding a variant forces updates to\nthe registry, error mappings, and codegen templates.",
+        "enum": [
+          "sessions",
+          "streaming",
+          "structured_output",
+          "hooks",
+          "builtins",
+          "shell",
+          "comms",
+          "memory_store",
+          "session_store",
+          "session_compaction",
+          "skills",
+          "mcp_live"
+        ],
+        "type": "string"
+      },
+      "CapabilityScope": {
+        "description": "Where a capability applies.",
+        "oneOf": [
+          {
+            "const": "Universal",
+            "description": "Available on all protocol surfaces.",
+            "type": "string"
+          },
+          {
+            "additionalProperties": false,
+            "description": "Available only on specific protocols.",
+            "properties": {
+              "Extension": {
+                "properties": {
+                  "protocols": {
+                    "items": {
+                      "$ref": "#/components/schemas/Protocol"
+                    },
+                    "type": "array"
+                  }
+                },
+                "required": [
+                  "protocols"
+                ],
+                "type": "object"
+              }
+            },
+            "required": [
+              "Extension"
+            ],
+            "type": "object"
+          }
+        ],
+        "title": "CapabilityScope"
+      },
+      "CapabilityStatus": {
+        "description": "Runtime status of a capability.",
+        "oneOf": [
+          {
+            "const": "Available",
+            "description": "Compiled in, config-enabled, protocol supports it.",
+            "type": "string"
+          },
+          {
+            "additionalProperties": false,
+            "description": "Compiled in but disabled by policy.\n\n`description` summarizes why — this is intentionally a human-readable\nstring, not a config path, because the reality is multi-layered:\nalways-compiled features like `Builtins` and `Shell` are controlled by\n`AgentFactory` flags, per-build `AgentBuildConfig` overrides, and\n`BuiltinToolConfig` policy layers (soft + enforced). A single\n\"config_path\" can't represent that resolution chain.",
+            "properties": {
+              "DisabledByPolicy": {
+                "properties": {
+                  "description": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "description"
+                ],
+                "type": "object"
+              }
+            },
+            "required": [
+              "DisabledByPolicy"
+            ],
+            "type": "object"
+          },
+          {
+            "additionalProperties": false,
+            "description": "Not compiled into this build (feature flag absent).",
+            "properties": {
+              "NotCompiled": {
+                "properties": {
+                  "feature": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "feature"
+                ],
+                "type": "object"
+              }
+            },
+            "required": [
+              "NotCompiled"
+            ],
+            "type": "object"
+          },
+          {
+            "additionalProperties": false,
+            "description": "This protocol surface doesn't support it.",
+            "properties": {
+              "NotSupportedByProtocol": {
+                "properties": {
+                  "reason": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "reason"
+                ],
+                "type": "object"
+              }
+            },
+            "required": [
+              "NotSupportedByProtocol"
+            ],
+            "type": "object"
+          }
+        ]
+      },
+      "CatalogModelEntry": {
+        "description": "A single model entry in the catalog response.",
+        "properties": {
+          "context_window": {
+            "description": "Maximum input context window in tokens.",
+            "format": "uint32",
+            "minimum": 0,
+            "type": [
+              "integer",
+              "null"
+            ]
+          },
+          "display_name": {
+            "description": "Human-readable display name.",
+            "type": "string"
+          },
+          "id": {
+            "description": "Model identifier (e.g., `\"claude-sonnet-4-6\"`).",
+            "type": "string"
+          },
+          "max_output_tokens": {
+            "description": "Maximum output tokens per response.",
+            "format": "uint32",
+            "minimum": 0,
+            "type": [
+              "integer",
+              "null"
+            ]
+          },
+          "profile": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/WireModelProfile"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Model profile with capability flags and parameter schema."
+          },
+          "server_id": {
+            "description": "Backing self-hosted server ID for configured aliases.",
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "tier": {
+            "$ref": "#/components/schemas/WireModelTier",
+            "description": "Recommendation tier."
+          }
+        },
+        "required": [
+          "id",
+          "display_name",
+          "tier"
+        ],
+        "title": "CatalogModelEntry",
+        "type": "object"
+      },
+      "CommsCommandRequest": {
+        "description": "Typed wire request for `comms/send`.\n\nVariants are serde-tagged on `kind` and validated structurally at the\ndeserialization boundary. Required fields per kind are enforced by the\ntype system; invalid discriminators (`source`, `stream`, `handling_mode`,\n`status`) become serde deserialization errors rather than runtime\nstring-match failures.\n\nCross-field invariants that cannot be expressed structurally (e.g.\n`handling_mode` is forbidden on `Accepted` peer responses) are checked\nin [`CommsCommandRequest::into_command`].",
+        "oneOf": [
+          {
+            "description": "Inject input into the local session.",
+            "properties": {
+              "allow_self_session": {
+                "type": [
+                  "boolean",
+                  "null"
+                ]
+              },
+              "blocks": {
+                "items": {
+                  "$ref": "#/components/schemas/ContentBlock"
+                },
+                "type": [
+                  "array",
+                  "null"
+                ]
+              },
+              "body": {
+                "type": "string"
+              },
+              "handling_mode": {
+                "anyOf": [
+                  {
+                    "$ref": "#/components/schemas/HandlingMode"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
+              },
+              "kind": {
+                "const": "input",
+                "type": "string"
+              },
+              "source": {
+                "anyOf": [
+                  {
+                    "$ref": "#/components/schemas/InputSource"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
+              },
+              "stream": {
+                "anyOf": [
+                  {
+                    "$ref": "#/components/schemas/InputStreamMode"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
+              }
+            },
+            "required": [
+              "kind",
+              "body"
+            ],
+            "type": "object"
+          },
+          {
+            "description": "Send a one-way peer message.",
+            "properties": {
+              "blocks": {
+                "items": {
+                  "$ref": "#/components/schemas/ContentBlock"
+                },
+                "type": [
+                  "array",
+                  "null"
+                ]
+              },
+              "body": {
+                "type": "string"
+              },
+              "handling_mode": {
+                "anyOf": [
+                  {
+                    "$ref": "#/components/schemas/HandlingMode"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
+              },
+              "kind": {
+                "const": "peer_message",
+                "type": "string"
+              },
+              "to": {
+                "$ref": "#/components/schemas/PeerId"
+              }
+            },
+            "required": [
+              "kind",
+              "to",
+              "body"
+            ],
+            "type": "object"
+          },
+          {
+            "description": "Send a one-way peer lifecycle notification.",
+            "properties": {
+              "kind": {
+                "const": "peer_lifecycle",
+                "type": "string"
+              },
+              "lifecycle_kind": {
+                "$ref": "#/components/schemas/PeerLifecycleKind"
+              },
+              "params": {
+                "default": null
+              },
+              "to": {
+                "$ref": "#/components/schemas/PeerId"
+              }
+            },
+            "required": [
+              "kind",
+              "to",
+              "lifecycle_kind"
+            ],
+            "type": "object"
+          },
+          {
+            "description": "Send a request to a peer.",
+            "properties": {
+              "handling_mode": {
+                "anyOf": [
+                  {
+                    "$ref": "#/components/schemas/HandlingMode"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
+              },
+              "intent": {
+                "type": "string"
+              },
+              "kind": {
+                "const": "peer_request",
+                "type": "string"
+              },
+              "params": {
+                "default": null
+              },
+              "stream": {
+                "anyOf": [
+                  {
+                    "$ref": "#/components/schemas/InputStreamMode"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
+              },
+              "to": {
+                "$ref": "#/components/schemas/PeerId"
+              }
+            },
+            "required": [
+              "kind",
+              "to",
+              "intent"
+            ],
+            "type": "object"
+          },
+          {
+            "description": "Send a response to a prior peer request.",
+            "properties": {
+              "handling_mode": {
+                "anyOf": [
+                  {
+                    "$ref": "#/components/schemas/HandlingMode"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
+              },
+              "in_reply_to": {
+                "$ref": "#/components/schemas/InteractionId"
+              },
+              "kind": {
+                "const": "peer_response",
+                "type": "string"
+              },
+              "result": {
+                "default": null
+              },
+              "status": {
+                "$ref": "#/components/schemas/ResponseStatus"
+              },
+              "to": {
+                "$ref": "#/components/schemas/PeerId"
+              }
+            },
+            "required": [
+              "kind",
+              "to",
+              "in_reply_to",
+              "status"
+            ],
+            "type": "object"
+          }
+        ],
+        "title": "CommsCommandRequest"
+      },
+      "CommsParams": {
+        "description": "Comms parameters.",
+        "properties": {
+          "comms_name": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "keep_alive": {
+            "description": "None = inherit persisted session intent, Some(true) = enable, Some(false) = disable.",
+            "type": [
+              "boolean",
+              "null"
+            ]
+          },
+          "peer_meta": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/PeerMeta"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Friendly metadata for peer discovery."
+          }
+        },
+        "title": "CommsParams",
+        "type": "object"
+      },
+      "ConfigEnvelope": {
+        "properties": {
+          "backend": {
+            "type": "string"
+          },
+          "config": {
+            "$ref": "#/components/schemas/JsonValue"
+          },
+          "generation": {
+            "minimum": 0,
+            "type": "integer"
+          },
+          "instance_id": {
+            "type": "string"
+          },
+          "realm_id": {
+            "type": "string"
+          },
+          "resolved_paths": {
+            "additionalProperties": {
+              "type": "string"
+            },
+            "type": "object"
+          }
+        },
+        "required": [
+          "config",
+          "generation"
+        ],
+        "type": "object"
+      },
+      "ContentBlock": {
+        "oneOf": [
+          {
+            "description": "Plain text content.",
+            "properties": {
+              "text": {
+                "type": "string"
+              },
+              "type": {
+                "const": "text",
+                "type": "string"
+              }
+            },
+            "required": [
+              "type",
+              "text"
+            ],
+            "type": "object"
+          },
+          {
+            "description": "Base64-encoded image content.",
+            "oneOf": [
+              {
+                "description": "Base64-encoded inline bytes used for ingress and live execution.",
+                "properties": {
+                  "data": {
+                    "type": "string"
+                  },
+                  "source": {
+                    "const": "inline",
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "source",
+                  "data"
+                ],
+                "type": "object"
+              },
+              {
+                "description": "Durable blob reference used by persisted history/runtime state.",
+                "properties": {
+                  "blob_id": {
+                    "$ref": "#/components/schemas/BlobId"
+                  },
+                  "source": {
+                    "const": "blob",
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "source",
+                  "blob_id"
+                ],
+                "type": "object"
+              }
+            ],
+            "properties": {
+              "media_type": {
+                "description": "MIME type (e.g. \"image/png\", \"image/jpeg\").",
+                "type": "string"
+              },
+              "type": {
+                "const": "image",
+                "type": "string"
+              }
+            },
+            "required": [
+              "type",
+              "media_type"
+            ],
+            "type": "object"
+          },
+          {
+            "description": "Base64-encoded video content.",
+            "oneOf": [
+              {
+                "description": "Base64-encoded inline bytes used for ingress and live execution.",
+                "properties": {
+                  "data": {
+                    "type": "string"
+                  },
+                  "source": {
+                    "const": "inline",
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "source",
+                  "data"
+                ],
+                "type": "object"
+              }
+            ],
+            "properties": {
+              "duration_ms": {
+                "description": "Caller-provided clip duration in milliseconds.",
+                "format": "uint64",
+                "minimum": 0,
+                "type": "integer"
+              },
+              "media_type": {
+                "description": "MIME type (e.g. \"video/mp4\", \"video/webm\").",
+                "type": "string"
+              },
+              "type": {
+                "const": "video",
+                "type": "string"
+              }
+            },
+            "required": [
+              "type",
+              "media_type",
+              "duration_ms"
+            ],
+            "type": "object"
+          }
+        ]
+      },
+      "ContentInput": {
+        "anyOf": [
+          {
+            "description": "Plain text input.",
+            "type": "string"
+          },
+          {
+            "description": "Multimodal content blocks (text + images).",
+            "items": {
+              "$ref": "#/components/schemas/ContentBlock"
+            },
+            "type": "array"
+          }
+        ],
+        "description": "Input content that can be either a plain text string or multimodal content blocks.\n\nDeserializes from either `\"text\"` or `[{type: \"text\", text: \"...\"}, ...]`.\nProvides `From<String>` and `From<&str>` for ergonomic construction."
+      },
+      "ContractVersion": {
+        "description": "Semantic version for the Meerkat wire contract.\n\nStart at 0.1.0 — allow breaking changes during Phase 1-3 development.\nBump to 1.0.0 when the SDK Builder ships (Phase 5) and external\nconsumers exist. Before 1.0.0, minor bumps can be breaking.",
+        "properties": {
+          "major": {
+            "format": "uint32",
+            "minimum": 0,
+            "type": "integer"
+          },
+          "minor": {
+            "format": "uint32",
+            "minimum": 0,
+            "type": "integer"
+          },
+          "patch": {
+            "format": "uint32",
+            "minimum": 0,
+            "type": "integer"
+          }
+        },
+        "required": [
+          "major",
+          "minor",
+          "patch"
+        ],
+        "title": "ContractVersion",
+        "type": "object"
+      },
+      "CoreCreateParams": {
+        "description": "Core session creation parameters.",
+        "properties": {
+          "additional_instructions": {
+            "items": {
+              "type": "string"
+            },
+            "type": [
+              "array",
+              "null"
+            ]
+          },
+          "app_context": true,
+          "connection_ref": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/WireConnectionRef"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Phase 4c — realm-scoped binding reference. When set, the session\nis built through the realm connection set; when omitted, the\nlegacy flat `provider + api_key` path is used."
+          },
+          "labels": {
+            "additionalProperties": {
+              "type": "string"
+            },
+            "type": [
+              "object",
+              "null"
+            ]
+          },
+          "max_tokens": {
+            "format": "uint32",
+            "minimum": 0,
+            "type": [
+              "integer",
+              "null"
+            ]
+          },
+          "model": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "prompt": {
+            "type": "string"
+          },
+          "provider": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/Provider"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "shell_env": {
+            "additionalProperties": {
+              "type": "string"
+            },
+            "description": "Per-agent environment variables injected into shell tool subprocesses.",
+            "type": [
+              "object",
+              "null"
+            ]
+          },
+          "system_prompt": {
+            "type": [
+              "string",
+              "null"
+            ]
+          }
+        },
+        "required": [
+          "prompt"
+        ],
+        "title": "CoreCreateParams",
+        "type": "object"
+      },
+      "CreateProfileParams": {
+        "description": "Request payload for `auth/profile/create`.",
+        "properties": {
+          "auth_method": {
+            "type": "string"
+          },
+          "binding_id": {
+            "type": "string"
+          },
+          "profile_id": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "realm_id": {
+            "type": "string"
+          },
+          "secret": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "realm_id",
+          "binding_id",
+          "auth_method",
+          "secret"
+        ],
+        "title": "CreateProfileParams",
+        "type": "object"
+      },
+      "DeliveryReceipt": {
+        "properties": {
+          "attempt": {
+            "format": "uint32",
+            "minimum": 0,
+            "type": "integer"
+          },
+          "correlation_id": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "detail": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "failure_class": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/OccurrenceFailureClass"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "materialized_session_id": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/SessionId"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "occurrence_id": {
+            "$ref": "#/components/schemas/OccurrenceId"
+          },
+          "receipt_id": {
+            "type": "string"
+          },
+          "recorded_at_utc": {
+            "format": "date-time",
+            "type": "string"
+          },
+          "runtime_outcome": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/RuntimeDeliveryOutcome"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "stage": {
+            "$ref": "#/components/schemas/DeliveryReceiptStage"
+          }
+        },
+        "required": [
+          "receipt_id",
+          "occurrence_id",
+          "attempt",
+          "stage",
+          "recorded_at_utc"
+        ],
+        "type": "object"
+      },
+      "DeliveryReceiptStage": {
+        "enum": [
+          "planned",
+          "claimed",
+          "dispatch_started",
+          "dispatch_accepted",
+          "awaiting_completion",
+          "completed",
+          "skipped",
+          "misfired",
+          "superseded",
+          "delivery_failed",
+          "lease_expired"
+        ],
+        "type": "string"
+      },
+      "DeviceCompleteParams": {
+        "description": "Request payload for `auth/login/device_complete`.",
+        "properties": {
+          "binding_id": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "device_code": {
+            "type": "string"
+          },
+          "profile_id": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "provider": {
+            "type": "string"
+          },
+          "realm_id": {
+            "type": [
+              "string",
+              "null"
+            ]
+          }
+        },
+        "required": [
+          "provider",
+          "device_code"
+        ],
+        "title": "DeviceCompleteParams",
+        "type": "object"
+      },
+      "DeviceStartParams": {
+        "description": "Request payload for `auth/login/device_start`.",
+        "properties": {
+          "provider": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "provider"
+        ],
+        "title": "DeviceStartParams",
+        "type": "object"
+      },
+      "ErrorCategory": {
+        "description": "Error category for grouping.",
+        "enum": [
+          "session",
+          "request",
+          "provider",
+          "budget",
+          "hook",
+          "agent",
+          "capability",
+          "skill",
+          "validation",
+          "internal"
+        ],
+        "title": "ErrorCategory",
+        "type": "string"
+      },
+      "ErrorCode": {
+        "description": "Stable error codes for wire protocol.",
+        "enum": [
+          "SESSION_NOT_FOUND",
+          "SCHEDULE_NOT_FOUND",
+          "SESSION_BUSY",
+          "SESSION_NOT_RUNNING",
+          "REQUEST_CANCELLED",
+          "PROVIDER_ERROR",
+          "BUDGET_EXHAUSTED",
+          "HOOK_DENIED",
+          "AGENT_ERROR",
+          "CAPABILITY_UNAVAILABLE",
+          "SKILL_NOT_FOUND",
+          "SKILL_RESOLUTION_FAILED",
+          "INVALID_PARAMS",
+          "INTERNAL_ERROR",
+          "DUPLICATE_INPUT"
+        ],
+        "title": "ErrorCode",
+        "type": "string"
+      },
+      "ExecutionPlacement": {
+        "description": "Structured metadata for where a tool or shell command executed.\n\nThis type deliberately avoids policy enforcement. It records facts that were\nalready established by the owning shell/tool/runtime path.",
+        "properties": {
+          "allowed_roots": {
+            "description": "Canonical roots that bounded execution, when safely known.",
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "host_id": {
+            "description": "Stable runtime host identifier, when safely known.",
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "working_root": {
+            "description": "Canonical working root used for execution, when safely known.",
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "worktree_id": {
+            "description": "Stable worktree identifier, when safely known.",
+            "type": [
+              "string",
+              "null"
+            ]
+          }
+        },
+        "title": "ExecutionPlacement",
+        "type": "object"
+      },
+      "ExecutionPlacementIdentity": {
+        "description": "Stable, non-path placement identity facts.\n\nWorking directories and allowed roots are intentionally excluded. Paths are\nexecution metadata; callers must not use them as the semantic identity of a\nsession, run, mob member, or operation.",
+        "properties": {
+          "host_id": {
+            "description": "Stable runtime host identifier, when a trusted runtime owner supplied it.",
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "worktree_id": {
+            "description": "Stable worktree identifier, when a trusted runtime owner supplied it.",
+            "type": [
+              "string",
+              "null"
+            ]
+          }
+        },
+        "title": "ExecutionPlacementIdentity",
+        "type": "object"
+      },
+      "FiniteScopedTurnDuration": {
+        "oneOf": [
+          {
+            "properties": {
+              "duration": {
+                "const": "one_turn",
+                "type": "string"
+              }
+            },
+            "required": [
+              "duration"
+            ],
+            "type": "object"
+          },
+          {
+            "properties": {
+              "duration": {
+                "const": "turns",
+                "type": "string"
+              },
+              "turns": {
+                "format": "uint32",
+                "minimum": 1,
+                "type": "integer"
+              }
+            },
+            "required": [
+              "duration",
+              "turns"
+            ],
+            "type": "object"
+          }
+        ]
+      },
+      "ForkContextSpec": {
+        "oneOf": [
+          {
+            "properties": {
+              "type": {
+                "const": "full_history",
+                "type": "string"
+              }
+            },
+            "required": [
+              "type"
+            ],
+            "type": "object"
+          },
+          {
+            "properties": {
+              "count": {
+                "format": "uint32",
+                "minimum": 0,
+                "type": "integer"
+              },
+              "type": {
+                "const": "last_messages",
+                "type": "string"
+              }
+            },
+            "required": [
+              "type",
+              "count"
+            ],
+            "type": "object"
+          }
+        ]
+      },
+      "GeminiImageMetadata": {
+        "properties": {
+          "continuity_ref": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "response_id": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "target_model": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "target_model"
+        ],
+        "type": "object"
+      },
+      "HandlingMode": {
+        "description": "Handling mode for ordinary content-bearing work.\n\n`Queue` means outer-loop / next-turn handling and leaves the current run\nuntouched.\n`Steer` means inner-loop handling and requests injection at the earliest\nadmissible cooperative boundary, while remaining ordinary work rather than\nan out-of-band control-plane command.",
+        "enum": [
+          "queue",
+          "steer"
+        ],
+        "type": "string"
+      },
+      "HelperOptionsSpec": {
+        "additionalProperties": false,
+        "properties": {
+          "backend": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/ScheduledMobBackendKind"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "role_name": {
+            "description": "Role name (profile key) for the helper in the mob roster.",
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "runtime_mode": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/ScheduledMobRuntimeMode"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "tool_access_policy": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/ToolAccessPolicy"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          }
+        },
+        "type": "object"
+      },
+      "ImageContinuityDisposition": {
+        "oneOf": [
+          {
+            "properties": {
+              "disposition": {
+                "const": "not_provided",
+                "type": "string"
+              }
+            },
+            "required": [
+              "disposition"
+            ],
+            "type": "object"
+          },
+          {
+            "properties": {
+              "disposition": {
+                "const": "unsupported_by_source_provider",
+                "type": "string"
+              }
+            },
+            "required": [
+              "disposition"
+            ],
+            "type": "object"
+          },
+          {
+            "properties": {
+              "continuity_ref": {
+                "type": "string"
+              },
+              "disposition": {
+                "const": "available",
+                "type": "string"
+              }
+            },
+            "required": [
+              "disposition",
+              "continuity_ref"
+            ],
+            "type": "object"
+          }
+        ]
+      },
+      "ImageContinuityTokenSupport": {
+        "enum": [
+          "unsupported",
+          "same_provider_only",
+          "cross_provider"
+        ],
+        "type": "string"
+      },
+      "ImageFormatPreference": {
+        "enum": [
+          "auto",
+          "png",
+          "jpeg",
+          "webp"
+        ],
+        "type": "string"
+      },
+      "ImageGenerationBackendKind": {
+        "enum": [
+          "hosted_tool",
+          "provider_api",
+          "native_model"
+        ],
+        "type": "string"
+      },
+      "ImageGenerationIntent": {
+        "oneOf": [
+          {
+            "properties": {
+              "intent": {
+                "const": "generate",
+                "type": "string"
+              },
+              "prompt": {
+                "$ref": "#/components/schemas/PromptText"
+              },
+              "prompt_source": {
+                "$ref": "#/components/schemas/PromptSource"
+              },
+              "reference_images": {
+                "items": {
+                  "$ref": "#/components/schemas/ImageSourceRef"
+                },
+                "type": "array"
+              }
+            },
+            "required": [
+              "intent",
+              "prompt",
+              "prompt_source"
+            ],
+            "type": "object"
+          },
+          {
+            "properties": {
+              "instruction": {
+                "$ref": "#/components/schemas/PromptText"
+              },
+              "instruction_source": {
+                "$ref": "#/components/schemas/PromptSource"
+              },
+              "intent": {
+                "const": "edit",
+                "type": "string"
+              },
+              "source_images": {
+                "items": {
+                  "$ref": "#/components/schemas/ImageSourceRef"
+                },
+                "type": "array"
+              }
+            },
+            "required": [
+              "intent",
+              "instruction",
+              "instruction_source",
+              "source_images"
+            ],
+            "type": "object"
+          }
+        ]
+      },
+      "ImageGenerationTargetCapabilities": {
+        "properties": {
+          "custom_tools": {
+            "type": "boolean"
+          },
+          "hosted_image_generation_tool": {
+            "type": "boolean"
+          },
+          "image_continuity_tokens": {
+            "$ref": "#/components/schemas/ImageContinuityTokenSupport"
+          },
+          "image_search_grounding": {
+            "type": "boolean"
+          },
+          "native_image_output": {
+            "type": "boolean"
+          }
+        },
+        "required": [
+          "hosted_image_generation_tool",
+          "native_image_output",
+          "custom_tools",
+          "image_search_grounding",
+          "image_continuity_tokens"
+        ],
+        "type": "object"
+      },
+      "ImageGenerationTargetPreference": {
+        "oneOf": [
+          {
+            "properties": {
+              "target": {
+                "const": "auto",
+                "type": "string"
+              }
+            },
+            "required": [
+              "target"
+            ],
+            "type": "object"
+          },
+          {
+            "properties": {
+              "provider": {
+                "type": "string"
+              },
+              "target": {
+                "const": "provider_default",
+                "type": "string"
+              }
+            },
+            "required": [
+              "target",
+              "provider"
+            ],
+            "type": "object"
+          },
+          {
+            "properties": {
+              "model": {
+                "type": "string"
+              },
+              "provider": {
+                "type": "string"
+              },
+              "target": {
+                "const": "model",
+                "type": "string"
+              }
+            },
+            "required": [
+              "target",
+              "provider",
+              "model"
+            ],
+            "type": "object"
+          }
+        ]
+      },
+      "ImageGenerationWarning": {
+        "oneOf": [
+          {
+            "properties": {
+              "warning": {
+                "const": "continuity_degraded",
+                "type": "string"
+              }
+            },
+            "required": [
+              "warning"
+            ],
+            "type": "object"
+          },
+          {
+            "properties": {
+              "warning": {
+                "const": "unsupported_artifact_dropped",
+                "type": "string"
+              }
+            },
+            "required": [
+              "warning"
+            ],
+            "type": "object"
+          },
+          {
+            "properties": {
+              "requested": {
+                "format": "uint32",
+                "minimum": 1,
+                "type": "integer"
+              },
+              "returned": {
+                "format": "uint32",
+                "minimum": 1,
+                "type": "integer"
+              },
+              "warning": {
+                "const": "provider_returned_fewer_images",
+                "type": "string"
+              }
+            },
+            "required": [
+              "warning",
+              "requested",
+              "returned"
+            ],
+            "type": "object"
+          },
+          {
+            "properties": {
+              "message": {
+                "type": "string"
+              },
+              "warning": {
+                "const": "provider_execution_failed",
+                "type": "string"
+              }
+            },
+            "required": [
+              "warning",
+              "message"
+            ],
+            "type": "object"
+          },
+          {
+            "properties": {
+              "message": {
+                "type": "string"
+              },
+              "warning": {
+                "const": "blob_commit_failed",
+                "type": "string"
+              }
+            },
+            "required": [
+              "warning",
+              "message"
+            ],
+            "type": "object"
+          },
+          {
+            "properties": {
+              "message": {
+                "type": "string"
+              },
+              "warning": {
+                "const": "provider_text_capture_failed",
+                "type": "string"
+              }
+            },
+            "required": [
+              "warning",
+              "message"
+            ],
+            "type": "object"
+          }
+        ]
+      },
+      "ImageOperationApprovalReason": {
+        "enum": [
+          "cross_provider",
+          "cost_exceeds_threshold",
+          "safety_hold",
+          "realtime_detach_required"
+        ],
+        "type": "string"
+      },
+      "ImageOperationDenialReason": {
+        "oneOf": [
+          {
+            "properties": {
+              "reason": {
+                "const": "unsupported_target",
+                "type": "string"
+              }
+            },
+            "required": [
+              "reason"
+            ],
+            "type": "object"
+          },
+          {
+            "properties": {
+              "reason": {
+                "const": "unsupported_count",
+                "type": "string"
+              }
+            },
+            "required": [
+              "reason"
+            ],
+            "type": "object"
+          },
+          {
+            "properties": {
+              "reason": {
+                "const": "capability_policy",
+                "type": "string"
+              }
+            },
+            "required": [
+              "reason"
+            ],
+            "type": "object"
+          },
+          {
+            "properties": {
+              "reason": {
+                "const": "cost_policy",
+                "type": "string"
+              }
+            },
+            "required": [
+              "reason"
+            ],
+            "type": "object"
+          },
+          {
+            "properties": {
+              "reason": {
+                "const": "safety_policy",
+                "type": "string"
+              }
+            },
+            "required": [
+              "reason"
+            ],
+            "type": "object"
+          },
+          {
+            "properties": {
+              "reason": {
+                "const": "approval_required_but_unavailable",
+                "type": "string"
+              }
+            },
+            "required": [
+              "reason"
+            ],
+            "type": "object"
+          },
+          {
+            "properties": {
+              "approvable": {
+                "$ref": "#/components/schemas/ImageOperationApprovalReason"
+              },
+              "reason": {
+                "const": "denied_during_approval",
+                "type": "string"
+              }
+            },
+            "required": [
+              "reason",
+              "approvable"
+            ],
+            "type": "object"
+          },
+          {
+            "properties": {
+              "reason": {
+                "const": "scoped_override_conflict",
+                "type": "string"
+              }
+            },
+            "required": [
+              "reason"
+            ],
+            "type": "object"
+          },
+          {
+            "properties": {
+              "reason": {
+                "const": "realtime_transport_conflict",
+                "type": "string"
+              }
+            },
+            "required": [
+              "reason"
+            ],
+            "type": "object"
+          },
+          {
+            "properties": {
+              "reason": {
+                "const": "projection_unsupported",
+                "type": "string"
+              }
+            },
+            "required": [
+              "reason"
+            ],
+            "type": "object"
+          }
+        ]
+      },
+      "ImageOperationId": {
+        "type": "string"
+      },
+      "ImageOperationTerminalClass": {
+        "oneOf": [
+          {
+            "properties": {
+              "terminal": {
+                "const": "generated",
+                "type": "string"
+              }
+            },
+            "required": [
+              "terminal"
+            ],
+            "type": "object"
+          },
+          {
+            "properties": {
+              "provider_text": {
+                "$ref": "#/components/schemas/ProviderTextDisposition"
+              },
+              "terminal": {
+                "const": "empty_result",
+                "type": "string"
+              }
+            },
+            "required": [
+              "terminal",
+              "provider_text"
+            ],
+            "type": "object"
+          },
+          {
+            "properties": {
+              "reason": {
+                "$ref": "#/components/schemas/ImageOperationDenialReason"
+              },
+              "terminal": {
+                "const": "denied",
+                "type": "string"
+              }
+            },
+            "required": [
+              "terminal",
+              "reason"
+            ],
+            "type": "object"
+          },
+          {
+            "properties": {
+              "terminal": {
+                "const": "refused_by_provider",
+                "type": "string"
+              }
+            },
+            "required": [
+              "terminal"
+            ],
+            "type": "object"
+          },
+          {
+            "properties": {
+              "terminal": {
+                "const": "safety_filtered",
+                "type": "string"
+              }
+            },
+            "required": [
+              "terminal"
+            ],
+            "type": "object"
+          },
+          {
+            "properties": {
+              "terminal": {
+                "const": "failed",
+                "type": "string"
+              }
+            },
+            "required": [
+              "terminal"
+            ],
+            "type": "object"
+          },
+          {
+            "properties": {
+              "terminal": {
+                "const": "cancelled",
+                "type": "string"
+              }
+            },
+            "required": [
+              "terminal"
+            ],
+            "type": "object"
+          },
+          {
+            "properties": {
+              "terminal": {
+                "const": "timeout",
+                "type": "string"
+              }
+            },
+            "required": [
+              "terminal"
+            ],
+            "type": "object"
+          },
+          {
+            "properties": {
+              "terminal": {
+                "const": "scoped_restore_failed",
+                "type": "string"
+              },
+              "trigger": {
+                "$ref": "#/components/schemas/PostActivationImageTerminal"
+              }
+            },
+            "required": [
+              "terminal",
+              "trigger"
+            ],
+            "type": "object"
+          }
+        ]
+      },
+      "ImageQualityPreference": {
+        "enum": [
+          "auto",
+          "low",
+          "medium",
+          "high"
+        ],
+        "type": "string"
+      },
+      "ImageSizePreference": {
+        "oneOf": [
+          {
+            "properties": {
+              "size": {
+                "const": "auto",
+                "type": "string"
+              }
+            },
+            "required": [
+              "size"
+            ],
+            "type": "object"
+          },
+          {
+            "properties": {
+              "size": {
+                "const": "square1024",
+                "type": "string"
+              }
+            },
+            "required": [
+              "size"
+            ],
+            "type": "object"
+          },
+          {
+            "properties": {
+              "size": {
+                "const": "portrait1024x1536",
+                "type": "string"
+              }
+            },
+            "required": [
+              "size"
+            ],
+            "type": "object"
+          },
+          {
+            "properties": {
+              "size": {
+                "const": "landscape1536x1024",
+                "type": "string"
+              }
+            },
+            "required": [
+              "size"
+            ],
+            "type": "object"
+          },
+          {
+            "properties": {
+              "height": {
+                "format": "uint32",
+                "minimum": 1,
+                "type": "integer"
+              },
+              "size": {
+                "const": "custom",
+                "type": "string"
+              },
+              "width": {
+                "format": "uint32",
+                "minimum": 1,
+                "type": "integer"
+              }
+            },
+            "required": [
+              "size",
+              "width",
+              "height"
+            ],
+            "type": "object"
+          }
+        ]
+      },
+      "ImageSourceRef": {
+        "oneOf": [
+          {
+            "properties": {
+              "blob_ref": {
+                "$ref": "#/components/schemas/BlobRef"
+              },
+              "kind": {
+                "const": "blob",
+                "type": "string"
+              }
+            },
+            "required": [
+              "kind",
+              "blob_ref"
+            ],
+            "type": "object"
+          },
+          {
+            "properties": {
+              "block_id": {
+                "$ref": "#/components/schemas/BlockId"
+              },
+              "kind": {
+                "const": "transcript_block",
+                "type": "string"
+              },
+              "message_id": {
+                "$ref": "#/components/schemas/MessageId"
+              }
+            },
+            "required": [
+              "kind",
+              "message_id",
+              "block_id"
+            ],
+            "type": "object"
+          },
+          {
+            "properties": {
+              "image_id": {
+                "$ref": "#/components/schemas/AssistantImageId"
+              },
+              "kind": {
+                "const": "assistant_image",
+                "type": "string"
+              }
+            },
+            "required": [
+              "kind",
+              "image_id"
+            ],
+            "type": "object"
+          },
+          {
+            "properties": {
+              "continuity": {
+                "$ref": "#/components/schemas/ImageContinuityDisposition"
+              },
+              "fallback_blob_ref": {
+                "$ref": "#/components/schemas/BlobRef"
+              },
+              "handle": {
+                "type": "string"
+              },
+              "kind": {
+                "const": "provider_native",
+                "type": "string"
+              },
+              "provider": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "kind",
+              "provider",
+              "handle",
+              "continuity",
+              "fallback_blob_ref"
+            ],
+            "type": "object"
+          }
+        ]
+      },
+      "InputListParams": {
+        "description": "Request payload for `runtime/session_submissions`.",
+        "properties": {
+          "session_id": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "session_id"
+        ],
+        "title": "InputListParams",
+        "type": "object"
+      },
+      "InputListResult": {
+        "description": "Response payload for `runtime/session_submissions`.",
+        "properties": {
+          "inputs": {
+            "items": {
+              "$ref": "#/components/schemas/WireInputState"
+            },
+            "type": "array"
+          }
+        },
+        "required": [
+          "inputs"
+        ],
+        "title": "InputListResult",
+        "type": "object"
+      },
+      "InputSource": {
+        "description": "Source for an input event posted to an agent.",
+        "enum": [
+          "tcp",
+          "uds",
+          "stdin",
+          "webhook",
+          "rpc"
+        ],
+        "type": "string"
+      },
+      "InputStateParams": {
+        "description": "Request payload for `runtime/session_submission`.",
+        "properties": {
+          "input_id": {
+            "type": "string"
+          },
+          "session_id": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "session_id",
+          "input_id"
+        ],
+        "title": "InputStateParams",
+        "type": "object"
+      },
+      "InputStateResult": {
+        "anyOf": [
+          {
+            "$ref": "#/components/schemas/WireInputState"
+          },
+          {
+            "type": "null"
+          }
+        ],
+        "title": "Nullable_WireInputState"
+      },
+      "InputStreamMode": {
+        "description": "Whether this input/peer command should reserve a local interaction stream.",
+        "oneOf": [
+          {
+            "const": "none",
+            "description": "Do not reserve any stream.",
+            "type": "string"
+          },
+          {
+            "const": "reserve_interaction",
+            "description": "Reserve an interaction stream for the command.",
+            "type": "string"
+          }
+        ]
+      },
+      "InteractionId": {
+        "description": "Unique identifier for an interaction.",
+        "type": "string"
+      },
+      "IntervalTriggerSpec": {
+        "properties": {
+          "end_at_utc": {
+            "format": "date-time",
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "every_seconds": {
+            "format": "uint64",
+            "minimum": 0,
+            "type": "integer"
+          },
+          "start_at_utc": {
+            "format": "date-time",
+            "type": "string"
+          }
+        },
+        "required": [
+          "start_at_utc",
+          "every_seconds"
+        ],
+        "type": "object"
+      },
+      "JsonValue": {
+        "description": "Arbitrary JSON value."
+      },
+      "ListSchedulesParams": {
+        "properties": {
+          "labels": {
+            "additionalProperties": {
+              "type": "string"
+            },
+            "type": [
+              "object",
+              "null"
+            ]
+          },
+          "limit": {
+            "format": "uint",
+            "minimum": 0,
+            "type": [
+              "integer",
+              "null"
+            ]
+          },
+          "offset": {
+            "format": "uint",
+            "minimum": 0,
+            "type": [
+              "integer",
+              "null"
+            ]
+          }
+        },
+        "title": "ListSchedulesParams",
+        "type": "object"
+      },
+      "ListSessionsResponse": {
+        "properties": {
+          "sessions": {
+            "items": {
+              "$ref": "#/components/schemas/WireSessionSummary"
+            },
+            "type": "array"
+          }
+        },
+        "required": [
+          "sessions"
+        ],
+        "type": "object"
+      },
+      "LoginCompleteParams": {
+        "description": "Request payload for `auth/login/complete`.",
+        "properties": {
+          "binding_id": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "code": {
+            "type": "string"
+          },
+          "profile_id": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "provider": {
+            "type": "string"
+          },
+          "realm_id": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "redirect_uri": {
+            "type": "string"
+          },
+          "state": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "provider",
+          "code",
+          "state",
+          "redirect_uri"
+        ],
+        "title": "LoginCompleteParams",
+        "type": "object"
+      },
+      "LoginStartParams": {
+        "description": "Request payload for `auth/login/start`.",
+        "properties": {
+          "provider": {
+            "type": "string"
+          },
+          "redirect_uri": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "provider",
+          "redirect_uri"
+        ],
+        "title": "LoginStartParams",
+        "type": "object"
+      },
+      "McpAddParams": {
+        "description": "Request payload for `mcp/add`.",
+        "properties": {
+          "persisted": {
+            "default": false,
+            "type": "boolean"
+          },
+          "server_config": true,
+          "server_name": {
+            "type": "string"
+          },
+          "session_id": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "session_id",
+          "server_name",
+          "server_config"
+        ],
+        "title": "McpAddParams",
+        "type": "object"
+      },
+      "McpLiveOpResponse": {
+        "description": "Response payload for live MCP operations.",
+        "properties": {
+          "applied_at_turn": {
+            "format": "uint32",
+            "minimum": 0,
+            "type": [
+              "integer",
+              "null"
+            ]
+          },
+          "operation": {
+            "$ref": "#/components/schemas/McpLiveOperation"
+          },
+          "persisted": {
+            "type": "boolean"
+          },
+          "server_name": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "session_id": {
+            "type": "string"
+          },
+          "status": {
+            "$ref": "#/components/schemas/McpLiveOpStatus"
+          }
+        },
+        "required": [
+          "session_id",
+          "operation",
+          "status",
+          "persisted"
+        ],
+        "title": "McpLiveOpResponse",
+        "type": "object"
+      },
+      "McpLiveOpStatus": {
+        "description": "Shared status for live MCP operations.",
+        "enum": [
+          "staged",
+          "applied",
+          "rejected"
+        ],
+        "type": "string"
+      },
+      "McpLiveOperation": {
+        "description": "Shared operation kind for live MCP operations.",
+        "enum": [
+          "add",
+          "remove",
+          "reload"
+        ],
+        "type": "string"
+      },
+      "McpReloadParams": {
+        "description": "Request payload for optional `mcp/reload`.",
+        "properties": {
+          "persisted": {
+            "default": false,
+            "type": "boolean"
+          },
+          "server_name": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "session_id": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "session_id"
+        ],
+        "title": "McpReloadParams",
+        "type": "object"
+      },
+      "McpRemoveParams": {
+        "description": "Request payload for `mcp/remove`.",
+        "properties": {
+          "persisted": {
+            "default": false,
+            "type": "boolean"
+          },
+          "server_name": {
+            "type": "string"
+          },
+          "session_id": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "session_id",
+          "server_name"
+        ],
+        "title": "McpRemoveParams",
+        "type": "object"
+      },
+      "MeerkatSchema": {
+        "description": "A Meerkat-native JSON schema."
+      },
+      "MessageId": {
+        "type": "string"
+      },
+      "MisfirePolicy": {
+        "oneOf": [
+          {
+            "description": "Skip materially late pending occurrences instead of catching them up.\n\nThe scheduler applies a small internal grace window so normal tick\njitter does not immediately misfire on-time work.",
+            "properties": {
+              "type": {
+                "const": "skip",
+                "type": "string"
+              }
+            },
+            "required": [
+              "type"
+            ],
+            "type": "object"
+          },
+          {
+            "description": "Catch up overdue pending occurrences only while they remain within the\nconfigured lateness window.",
+            "properties": {
+              "type": {
+                "const": "catch_up_within",
+                "type": "string"
+              },
+              "window_seconds": {
+                "format": "uint64",
+                "minimum": 0,
+                "type": "integer"
+              }
+            },
+            "required": [
+              "type",
+              "window_seconds"
+            ],
+            "type": "object"
+          }
+        ]
+      },
+      "MissingTargetPolicy": {
+        "enum": [
+          "skip",
+          "mark_misfired"
+        ],
+        "type": "string"
+      },
+      "MobBackendConfigInput": {
+        "additionalProperties": false,
+        "properties": {
+          "default": {
+            "$ref": "#/components/schemas/WireMobBackendKind",
+            "default": "session"
+          },
+          "external": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/MobExternalBackendConfigInput"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          }
+        },
+        "type": "object"
+      },
+      "MobCancelAllWorkParams": {
+        "additionalProperties": false,
+        "description": "Request payload for `mob/cancel_all_work`.",
+        "properties": {
+          "member_ref": {
+            "$ref": "#/components/schemas/WireMemberRef"
+          }
+        },
+        "required": [
+          "member_ref"
+        ],
+        "title": "MobCancelAllWorkParams",
+        "type": "object"
+      },
+      "MobCancelWorkParams": {
+        "additionalProperties": false,
+        "description": "Request payload for `mob/cancel_work`.",
+        "properties": {
+          "mob_id": {
+            "type": "string"
+          },
+          "work_ref": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "mob_id",
+          "work_ref"
+        ],
+        "title": "MobCancelWorkParams",
+        "type": "object"
+      },
+      "MobCollectionPolicyInput": {
+        "oneOf": [
+          {
+            "properties": {
+              "type": {
+                "const": "all",
+                "type": "string"
+              }
+            },
+            "required": [
+              "type"
+            ],
+            "type": "object"
+          },
+          {
+            "properties": {
+              "type": {
+                "const": "any",
+                "type": "string"
+              }
+            },
+            "required": [
+              "type"
+            ],
+            "type": "object"
+          },
+          {
+            "properties": {
+              "n": {
+                "format": "uint8",
+                "maximum": 255,
+                "minimum": 0,
+                "type": "integer"
+              },
+              "type": {
+                "const": "quorum",
+                "type": "string"
+              }
+            },
+            "required": [
+              "type",
+              "n"
+            ],
+            "type": "object"
+          }
+        ]
+      },
+      "MobConditionExprInput": {
+        "oneOf": [
+          {
+            "properties": {
+              "op": {
+                "const": "eq",
+                "type": "string"
+              },
+              "path": {
+                "type": "string"
+              },
+              "value": true
+            },
+            "required": [
+              "op",
+              "path",
+              "value"
+            ],
+            "type": "object"
+          },
+          {
+            "properties": {
+              "op": {
+                "const": "in",
+                "type": "string"
+              },
+              "path": {
+                "type": "string"
+              },
+              "values": {
+                "items": true,
+                "type": "array"
+              }
+            },
+            "required": [
+              "op",
+              "path",
+              "values"
+            ],
+            "type": "object"
+          },
+          {
+            "properties": {
+              "op": {
+                "const": "gt",
+                "type": "string"
+              },
+              "path": {
+                "type": "string"
+              },
+              "value": true
+            },
+            "required": [
+              "op",
+              "path",
+              "value"
+            ],
+            "type": "object"
+          },
+          {
+            "properties": {
+              "op": {
+                "const": "lt",
+                "type": "string"
+              },
+              "path": {
+                "type": "string"
+              },
+              "value": true
+            },
+            "required": [
+              "op",
+              "path",
+              "value"
+            ],
+            "type": "object"
+          },
+          {
+            "properties": {
+              "exprs": {
+                "items": {
+                  "$ref": "#/components/schemas/MobConditionExprInput"
+                },
+                "type": "array"
+              },
+              "op": {
+                "const": "and",
+                "type": "string"
+              }
+            },
+            "required": [
+              "op",
+              "exprs"
+            ],
+            "type": "object"
+          },
+          {
+            "properties": {
+              "exprs": {
+                "items": {
+                  "$ref": "#/components/schemas/MobConditionExprInput"
+                },
+                "type": "array"
+              },
+              "op": {
+                "const": "or",
+                "type": "string"
+              }
+            },
+            "required": [
+              "op",
+              "exprs"
+            ],
+            "type": "object"
+          },
+          {
+            "properties": {
+              "expr": {
+                "$ref": "#/components/schemas/MobConditionExprInput"
+              },
+              "op": {
+                "const": "not",
+                "type": "string"
+              }
+            },
+            "required": [
+              "op",
+              "expr"
+            ],
+            "type": "object"
+          }
+        ]
+      },
+      "MobCreateParams": {
+        "additionalProperties": false,
+        "description": "Request payload for `mob/create`.",
+        "properties": {
+          "definition": {
+            "$ref": "#/components/schemas/MobDefinitionInput"
+          }
+        },
+        "required": [
+          "definition"
+        ],
+        "title": "MobCreateParams",
+        "type": "object"
+      },
+      "MobCreateResult": {
+        "description": "Response payload for `mob/create`.",
+        "properties": {
+          "mob_id": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "mob_id"
+        ],
+        "title": "MobCreateResult",
+        "type": "object"
+      },
+      "MobDefinitionInput": {
+        "additionalProperties": false,
+        "description": "Public mob definition input for `mob/create`.\n\nThis mirrors the public creation contract shape. Runtime-owned lifecycle and\nbookkeeping fields such as internal owner/runtime bindings,\n`session_cleanup_policy`, `is_implicit`, and internal-only profile tool\nbundles are intentionally not part of this schema.\n\nNot `Eq`: `profiles` transitively carries float provider params.",
+        "properties": {
+          "backend": {
+            "$ref": "#/components/schemas/MobBackendConfigInput",
+            "default": {
+              "default": "session"
+            }
+          },
+          "event_router": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/MobEventRouterConfigInput"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "flows": {
+            "additionalProperties": {
+              "$ref": "#/components/schemas/MobFlowSpecInput"
+            },
+            "type": "object"
+          },
+          "id": {
+            "type": "string"
+          },
+          "limits": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/MobLimitsSpecInput"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "mcp_servers": {
+            "additionalProperties": {
+              "$ref": "#/components/schemas/MobMcpServerConfigInput"
+            },
+            "type": "object"
+          },
+          "orchestrator": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/MobOrchestratorInput"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "profiles": {
+            "additionalProperties": {
+              "$ref": "#/components/schemas/MobProfileBindingInput"
+            },
+            "type": "object"
+          },
+          "skills": {
+            "additionalProperties": {
+              "$ref": "#/components/schemas/MobSkillSourceInput"
+            },
+            "type": "object"
+          },
+          "spawn_policy": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/MobSpawnPolicyInput"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "supervisor": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/MobSupervisorSpecInput"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "topology": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/MobTopologySpecInput"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "wiring": {
+            "$ref": "#/components/schemas/MobWiringRulesInput",
+            "default": {
+              "auto_wire_orchestrator": false
+            }
+          }
+        },
+        "required": [
+          "id",
+          "profiles"
+        ],
+        "title": "MobDefinitionInput",
+        "type": "object"
+      },
+      "MobDependencyModeInput": {
+        "enum": [
+          "all",
+          "any"
+        ],
+        "type": "string"
+      },
+      "MobDispatchModeInput": {
+        "enum": [
+          "fan_out",
+          "one_to_one",
+          "fan_in"
+        ],
+        "type": "string"
+      },
+      "MobEnsureMemberOutcomeWire": {
+        "description": "Outcome of a `mob/ensure_member` call.\n\n`Existed` returns the typed [`MobMemberListEntryWire`] roster snapshot so\npublic consumers do not need out-of-band knowledge of the Rust domain\n`MobMemberListEntry` shape.",
+        "oneOf": [
+          {
+            "additionalProperties": false,
+            "properties": {
+              "spawned": {
+                "$ref": "#/components/schemas/MobSpawnReceiptWire"
+              }
+            },
+            "required": [
+              "spawned"
+            ],
+            "type": "object"
+          },
+          {
+            "additionalProperties": false,
+            "properties": {
+              "existed": {
+                "$ref": "#/components/schemas/MobMemberListEntryWire"
+              }
+            },
+            "required": [
+              "existed"
+            ],
+            "type": "object"
+          }
+        ]
+      },
+      "MobEnsureMemberParams": {
+        "additionalProperties": false,
+        "description": "Request payload for `mob/ensure_member`.",
+        "properties": {
+          "mob_id": {
+            "type": "string"
+          },
+          "spec": {
+            "$ref": "#/components/schemas/MobMemberSpecWire"
+          }
+        },
+        "required": [
+          "mob_id",
+          "spec"
+        ],
+        "title": "MobEnsureMemberParams",
+        "type": "object"
+      },
+      "MobEnsureMemberResult": {
+        "description": "Response payload for `mob/ensure_member`.",
+        "properties": {
+          "outcome": {
+            "$ref": "#/components/schemas/MobEnsureMemberOutcomeWire"
+          }
+        },
+        "required": [
+          "outcome"
+        ],
+        "title": "MobEnsureMemberResult",
+        "type": "object"
+      },
+      "MobEventRouterConfigInput": {
+        "additionalProperties": false,
+        "properties": {
+          "buffer_size": {
+            "default": 256,
+            "format": "uint",
+            "minimum": 0,
+            "type": "integer"
+          },
+          "exclude_patterns": {
+            "items": {
+              "type": "string"
+            },
+            "type": [
+              "array",
+              "null"
+            ]
+          },
+          "include_patterns": {
+            "items": {
+              "type": "string"
+            },
+            "type": [
+              "array",
+              "null"
+            ]
+          }
+        },
+        "type": "object"
+      },
+      "MobExternalBackendConfigInput": {
+        "additionalProperties": false,
+        "properties": {
+          "address_base": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "address_base"
+        ],
+        "type": "object"
+      },
+      "MobFlowNodeInput": {
+        "oneOf": [
+          {
+            "additionalProperties": false,
+            "properties": {
+              "branch": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "depends_on": {
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              },
+              "depends_on_mode": {
+                "$ref": "#/components/schemas/MobDependencyModeInput",
+                "default": "all"
+              },
+              "kind": {
+                "const": "step",
+                "type": "string"
+              },
+              "step_id": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "kind",
+              "step_id"
+            ],
+            "type": "object"
+          },
+          {
+            "additionalProperties": false,
+            "properties": {
+              "body": {
+                "$ref": "#/components/schemas/MobFrameSpecInput"
+              },
+              "depends_on": {
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              },
+              "depends_on_mode": {
+                "$ref": "#/components/schemas/MobDependencyModeInput",
+                "default": "all"
+              },
+              "kind": {
+                "const": "repeat_until",
+                "type": "string"
+              },
+              "loop_id": {
+                "type": "string"
+              },
+              "max_iterations": {
+                "format": "uint32",
+                "minimum": 0,
+                "type": "integer"
+              },
+              "until": {
+                "$ref": "#/components/schemas/MobConditionExprInput"
+              }
+            },
+            "required": [
+              "kind",
+              "loop_id",
+              "body",
+              "until",
+              "max_iterations"
+            ],
+            "type": "object"
+          }
+        ]
+      },
+      "MobFlowSpecInput": {
+        "additionalProperties": false,
+        "properties": {
+          "description": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "root": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/MobFrameSpecInput"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "steps": {
+            "additionalProperties": {
+              "$ref": "#/components/schemas/MobFlowStepInput"
+            },
+            "type": "object"
+          }
+        },
+        "type": "object"
+      },
+      "MobFlowStepInput": {
+        "additionalProperties": false,
+        "properties": {
+          "allowed_tools": {
+            "items": {
+              "type": "string"
+            },
+            "type": [
+              "array",
+              "null"
+            ]
+          },
+          "blocked_tools": {
+            "items": {
+              "type": "string"
+            },
+            "type": [
+              "array",
+              "null"
+            ]
+          },
+          "branch": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "collection_policy": {
+            "$ref": "#/components/schemas/MobCollectionPolicyInput",
+            "default": {
+              "type": "all"
+            }
+          },
+          "condition": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/MobConditionExprInput"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "depends_on": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "depends_on_mode": {
+            "$ref": "#/components/schemas/MobDependencyModeInput",
+            "default": "all"
+          },
+          "dispatch_mode": {
+            "$ref": "#/components/schemas/MobDispatchModeInput",
+            "default": "fan_out"
+          },
+          "expected_schema_ref": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "message": {
+            "$ref": "#/components/schemas/WireContentInput"
+          },
+          "output_format": {
+            "$ref": "#/components/schemas/MobStepOutputFormatInput",
+            "default": "json"
+          },
+          "role": {
+            "type": "string"
+          },
+          "timeout_ms": {
+            "format": "uint64",
+            "minimum": 0,
+            "type": [
+              "integer",
+              "null"
+            ]
+          }
+        },
+        "required": [
+          "role",
+          "message"
+        ],
+        "type": "object"
+      },
+      "MobFrameSpecInput": {
+        "additionalProperties": false,
+        "properties": {
+          "nodes": {
+            "additionalProperties": {
+              "$ref": "#/components/schemas/MobFlowNodeInput"
+            },
+            "type": "object"
+          }
+        },
+        "required": [
+          "nodes"
+        ],
+        "type": "object"
+      },
+      "MobIngressInteractionParams": {
+        "additionalProperties": false,
+        "description": "Request payload for `mob/ingress_interaction`.\n\nThis is the ergonomic \"ensure an ingress member, then deliver user input\"\npath. It composes the existing declarative roster and member-send\nsemantics without introducing a separate thread/project runtime.",
+        "properties": {
+          "content": {
+            "$ref": "#/components/schemas/WireContentInput"
+          },
+          "handling_mode": {
+            "$ref": "#/components/schemas/WireHandlingMode",
+            "default": "queue"
+          },
+          "mob_id": {
+            "type": "string"
+          },
+          "render_metadata": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/WireRenderMetadata"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "spec": {
+            "$ref": "#/components/schemas/MobMemberSpecWire"
+          }
+        },
+        "required": [
+          "mob_id",
+          "spec",
+          "content"
+        ],
+        "title": "MobIngressInteractionParams",
+        "type": "object"
+      },
+      "MobIngressInteractionResult": {
+        "description": "Response payload for `mob/ingress_interaction`.",
+        "properties": {
+          "agent_identity": {
+            "type": "string"
+          },
+          "delivery": {
+            "$ref": "#/components/schemas/MobMemberSendResult"
+          },
+          "ensure_outcome": {
+            "$ref": "#/components/schemas/MobEnsureMemberOutcomeWire"
+          },
+          "events_after_cursor": {
+            "description": "Cursor observed immediately before the ensure/send composition.",
+            "format": "uint64",
+            "minimum": 0,
+            "type": "integer"
+          },
+          "latest_event_cursor": {
+            "description": "Cursor observed after delivery was accepted.",
+            "format": "uint64",
+            "minimum": 0,
+            "type": "integer"
+          },
+          "member_ref": {
+            "$ref": "#/components/schemas/WireMemberRef"
+          },
+          "mob_id": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "mob_id",
+          "agent_identity",
+          "member_ref",
+          "ensure_outcome",
+          "delivery",
+          "events_after_cursor",
+          "latest_event_cursor"
+        ],
+        "title": "MobIngressInteractionResult",
+        "type": "object"
+      },
+      "MobLifecycleParams": {
+        "additionalProperties": false,
+        "description": "Request payload for `mob/lifecycle`.",
+        "properties": {
+          "action": {
+            "$ref": "#/components/schemas/WireMobLifecycleAction"
+          },
+          "mob_id": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "mob_id",
+          "action"
+        ],
+        "title": "MobLifecycleParams",
+        "type": "object"
+      },
+      "MobLimitsSpecInput": {
+        "additionalProperties": false,
+        "properties": {
+          "cancel_grace_timeout_ms": {
+            "format": "uint64",
+            "minimum": 0,
+            "type": [
+              "integer",
+              "null"
+            ]
+          },
+          "max_active_frames": {
+            "format": "uint64",
+            "minimum": 0,
+            "type": [
+              "integer",
+              "null"
+            ]
+          },
+          "max_active_nodes": {
+            "format": "uint64",
+            "minimum": 0,
+            "type": [
+              "integer",
+              "null"
+            ]
+          },
+          "max_flow_duration_ms": {
+            "format": "uint64",
+            "minimum": 0,
+            "type": [
+              "integer",
+              "null"
+            ]
+          },
+          "max_frame_depth": {
+            "format": "uint64",
+            "minimum": 0,
+            "type": [
+              "integer",
+              "null"
+            ]
+          },
+          "max_orphaned_turns": {
+            "format": "uint32",
+            "minimum": 0,
+            "type": [
+              "integer",
+              "null"
+            ]
+          },
+          "max_step_retries": {
+            "format": "uint32",
+            "minimum": 0,
+            "type": [
+              "integer",
+              "null"
+            ]
+          }
+        },
+        "type": "object"
+      },
+      "MobListMembersMatchingParams": {
+        "additionalProperties": false,
+        "description": "Request payload for `mob/list_members_matching`.",
+        "properties": {
+          "filter": {
+            "$ref": "#/components/schemas/MobMemberFilterWire",
+            "default": {}
+          },
+          "mob_id": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "mob_id"
+        ],
+        "title": "MobListMembersMatchingParams",
+        "type": "object"
+      },
+      "MobListMembersMatchingResult": {
+        "description": "Response payload for `mob/list_members_matching`. Each member is the raw\nroster entry JSON.",
+        "properties": {
+          "members": {
+            "default": [],
+            "items": true,
+            "type": "array"
+          }
+        },
+        "title": "MobListMembersMatchingResult",
+        "type": "object"
+      },
+      "MobMcpServerConfigInput": {
+        "additionalProperties": false,
+        "properties": {
+          "command": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "env": {
+            "additionalProperties": {
+              "type": "string"
+            },
+            "type": "object"
+          },
+          "url": {
+            "type": [
+              "string",
+              "null"
+            ]
+          }
+        },
+        "type": "object"
+      },
+      "MobMemberFilterWire": {
+        "additionalProperties": false,
+        "description": "Filter for `mob/list_members_matching`. Non-empty / `Some` fields are\ncombined conjunctively; an empty filter matches every member.",
+        "properties": {
+          "labels": {
+            "additionalProperties": {
+              "type": "string"
+            },
+            "description": "Required exact matches on member labels.",
+            "type": "object"
+          },
+          "role": {
+            "description": "Required profile name (role).",
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "state": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/WireMemberState"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Required roster state."
+          }
+        },
+        "type": "object"
+      },
+      "MobMemberListEntryWire": {
+        "description": "Public roster entry returned by `mob/ensure_member`'s `Existed` outcome\n(and other surfaces that want a typed snapshot of a single member). Mirrors\nthe public-facing fields of `meerkat_mob::runtime::MobMemberListEntry`\nwithout leaking bridge-internal fields.",
+        "properties": {
+          "agent_identity": {
+            "type": "string"
+          },
+          "error": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "is_final": {
+            "type": "boolean"
+          },
+          "labels": {
+            "additionalProperties": {
+              "type": "string"
+            },
+            "type": "object"
+          },
+          "member_ref": {
+            "$ref": "#/components/schemas/WireMemberRef"
+          },
+          "role": {
+            "type": "string"
+          },
+          "runtime_mode": {
+            "$ref": "#/components/schemas/WireMobRuntimeMode"
+          },
+          "state": {
+            "$ref": "#/components/schemas/WireMemberState"
+          },
+          "status": {
+            "$ref": "#/components/schemas/WireMobMemberStatus"
+          },
+          "wired_to": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          }
+        },
+        "required": [
+          "agent_identity",
+          "member_ref",
+          "role",
+          "runtime_mode",
+          "state",
+          "status",
+          "is_final"
+        ],
+        "type": "object"
+      },
+      "MobMemberSendParams": {
+        "additionalProperties": false,
+        "description": "Request payload for host-side mob member delivery.",
+        "properties": {
+          "agent_identity": {
+            "type": "string"
+          },
+          "content": {
+            "$ref": "#/components/schemas/WireContentInput"
+          },
+          "handling_mode": {
+            "$ref": "#/components/schemas/WireHandlingMode",
+            "default": "queue"
+          },
+          "mob_id": {
+            "type": "string"
+          },
+          "render_metadata": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/WireRenderMetadata"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          }
+        },
+        "required": [
+          "mob_id",
+          "agent_identity",
+          "content"
+        ],
+        "title": "MobMemberSendParams",
+        "type": "object"
+      },
+      "MobMemberSendResult": {
+        "description": "Response payload for host-side mob member delivery.",
+        "properties": {
+          "agent_identity": {
+            "description": "Identity-native member identity (0.6).",
+            "type": "string"
+          },
+          "handling_mode": {
+            "$ref": "#/components/schemas/WireHandlingMode"
+          },
+          "member_ref": {
+            "$ref": "#/components/schemas/WireMemberRef",
+            "description": "Server-resolved opaque handle for subsequent member-targeted calls.\nApp code routes through `member_ref`; the binding-era\n`{identity, generation}` pair carried by `WireAgentRuntimeId` is\nretired from app-facing responses per dogma #10."
+          },
+          "mob_id": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "mob_id",
+          "agent_identity",
+          "member_ref",
+          "handling_mode"
+        ],
+        "type": "object"
+      },
+      "MobMemberSpecWire": {
+        "description": "Per-member spec for `mob/ensure_member` and the `desired` entries of\n`mob/reconcile`.\n\nMirrors the essential, codegen-friendly fields of\n[`meerkat_mob::SpawnMemberSpec`]. Complex sub-types (tool access policy,\nbudget split, inherited tool filter, override profile) are not on this\nwire surface — callers that need that parity should use the non-declarative\n`mob/spawn` method.",
+        "properties": {
+          "additional_instructions": {
+            "items": {
+              "type": "string"
+            },
+            "type": [
+              "array",
+              "null"
+            ]
+          },
+          "agent_identity": {
+            "description": "Stable member identity within the mob.",
+            "type": "string"
+          },
+          "auto_wire_parent": {
+            "type": [
+              "boolean",
+              "null"
+            ]
+          },
+          "backend": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/WireMobBackendKind"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "binding": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/WireRuntimeBinding"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "context": true,
+          "initial_message": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/WireContentInput"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "labels": {
+            "additionalProperties": {
+              "type": "string"
+            },
+            "type": [
+              "object",
+              "null"
+            ]
+          },
+          "profile": {
+            "description": "Profile name (role) in the mob definition.",
+            "type": "string"
+          },
+          "runtime_mode": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/WireMobRuntimeMode"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          }
+        },
+        "required": [
+          "profile",
+          "agent_identity"
+        ],
+        "type": "object"
+      },
+      "MobOrchestratorInput": {
+        "additionalProperties": false,
+        "properties": {
+          "profile": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "profile"
+        ],
+        "type": "object"
+      },
+      "MobPeerTarget": {
+        "description": "Target for a mob wire/unwire call.",
+        "oneOf": [
+          {
+            "additionalProperties": false,
+            "properties": {
+              "local": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "local"
+            ],
+            "type": "object"
+          },
+          {
+            "additionalProperties": false,
+            "properties": {
+              "external": {
+                "$ref": "#/components/schemas/WireTrustedPeerSpec"
+              }
+            },
+            "required": [
+              "external"
+            ],
+            "type": "object"
+          }
+        ],
+        "title": "MobPeerTarget"
+      },
+      "MobPolicyModeInput": {
+        "enum": [
+          "advisory",
+          "strict"
+        ],
+        "type": "string"
+      },
+      "MobProfileBindingInput": {
+        "anyOf": [
+          {
+            "description": "Reference to a realm-scoped profile.",
+            "properties": {
+              "realm_profile": {
+                "description": "Name of the realm profile.",
+                "type": "string"
+              }
+            },
+            "required": [
+              "realm_profile"
+            ],
+            "type": "object"
+          },
+          {
+            "$ref": "#/components/schemas/MobProfileInput",
+            "description": "Inline profile definition."
+          }
+        ],
+        "description": "Profile binding input: either an inline profile or a realm profile reference.\n\nNot `Eq`: `Inline(MobProfileInput)` transitively carries float provider\nparams (`temperature`, `top_p`) so `Eq` cannot be derived without\nlosing fidelity."
+      },
+      "MobProfileInput": {
+        "additionalProperties": false,
+        "properties": {
+          "backend": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/WireMobBackendKind"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "external_addressable": {
+            "default": false,
+            "type": "boolean"
+          },
+          "max_inline_peer_notifications": {
+            "format": "int32",
+            "type": [
+              "integer",
+              "null"
+            ]
+          },
+          "model": {
+            "type": "string"
+          },
+          "output_schema": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/OutputSchema"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "peer_description": {
+            "type": "string"
+          },
+          "provider_params": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/WireProviderParamsOverride"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Non-`Eq` field: `WireProviderParamsOverride` contains float scalars\n(`temperature`, `top_p`) so the struct can't derive `Eq` without\nlosing fidelity."
+          },
+          "runtime_mode": {
+            "$ref": "#/components/schemas/WireMobRuntimeMode",
+            "default": "autonomous_host"
+          },
+          "skills": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "tools": {
+            "$ref": "#/components/schemas/MobToolConfigInput",
+            "default": {
+              "builtins": false,
+              "comms": false,
+              "memory": false,
+              "mob": false,
+              "mob_tasks": false,
+              "schedule": false,
+              "shell": false
+            }
+          }
+        },
+        "required": [
+          "model"
+        ],
+        "type": "object"
+      },
+      "MobReconcileFailureWire": {
+        "description": "Per-identity failure in a `mob/reconcile` pass.",
+        "properties": {
+          "agent_identity": {
+            "type": "string"
+          },
+          "error": {
+            "description": "Stringified mob error.",
+            "type": "string"
+          },
+          "stage": {
+            "$ref": "#/components/schemas/WireMobReconcileStage"
+          }
+        },
+        "required": [
+          "agent_identity",
+          "stage",
+          "error"
+        ],
+        "type": "object"
+      },
+      "MobReconcileOptionsWire": {
+        "additionalProperties": false,
+        "description": "Options controlling a `mob/reconcile` pass.",
+        "properties": {
+          "retire_stale": {
+            "default": false,
+            "description": "When `true`, members on the roster whose identity is not in the\n`desired` set are retired.",
+            "type": "boolean"
+          }
+        },
+        "type": "object"
+      },
+      "MobReconcileParams": {
+        "additionalProperties": false,
+        "description": "Request payload for `mob/reconcile`.",
+        "properties": {
+          "desired": {
+            "default": [],
+            "items": {
+              "$ref": "#/components/schemas/MobMemberSpecWire"
+            },
+            "type": "array"
+          },
+          "mob_id": {
+            "type": "string"
+          },
+          "options": {
+            "$ref": "#/components/schemas/MobReconcileOptionsWire",
+            "default": {
+              "retire_stale": false
+            }
+          }
+        },
+        "required": [
+          "mob_id"
+        ],
+        "title": "MobReconcileParams",
+        "type": "object"
+      },
+      "MobReconcileReportWire": {
+        "description": "Summary produced by a `mob/reconcile` pass.",
+        "properties": {
+          "desired": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "failures": {
+            "items": {
+              "$ref": "#/components/schemas/MobReconcileFailureWire"
+            },
+            "type": "array"
+          },
+          "retained": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "retired": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "spawned": {
+            "items": {
+              "$ref": "#/components/schemas/MobSpawnReceiptWire"
+            },
+            "type": "array"
+          }
+        },
+        "type": "object"
+      },
+      "MobReconcileResult": {
+        "description": "Response payload for `mob/reconcile`.",
+        "properties": {
+          "report": {
+            "$ref": "#/components/schemas/MobReconcileReportWire"
+          }
+        },
+        "required": [
+          "report"
+        ],
+        "title": "MobReconcileResult",
+        "type": "object"
+      },
+      "MobRoleWiringRuleInput": {
+        "additionalProperties": false,
+        "properties": {
+          "a": {
+            "type": "string"
+          },
+          "b": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "a",
+          "b"
+        ],
+        "type": "object"
+      },
+      "MobSkillSourceInput": {
+        "oneOf": [
+          {
+            "properties": {
+              "content": {
+                "type": "string"
+              },
+              "source": {
+                "const": "inline",
+                "type": "string"
+              }
+            },
+            "required": [
+              "source",
+              "content"
+            ],
+            "type": "object"
+          },
+          {
+            "properties": {
+              "path": {
+                "type": "string"
+              },
+              "source": {
+                "const": "path",
+                "type": "string"
+              }
+            },
+            "required": [
+              "source",
+              "path"
+            ],
+            "type": "object"
+          }
+        ]
+      },
+      "MobSpawnPolicyInput": {
+        "oneOf": [
+          {
+            "properties": {
+              "mode": {
+                "const": "none",
+                "type": "string"
+              }
+            },
+            "required": [
+              "mode"
+            ],
+            "type": "object"
+          },
+          {
+            "properties": {
+              "mode": {
+                "const": "auto",
+                "type": "string"
+              },
+              "profile_map": {
+                "additionalProperties": {
+                  "type": "string"
+                },
+                "type": "object"
+              }
+            },
+            "required": [
+              "mode",
+              "profile_map"
+            ],
+            "type": "object"
+          }
+        ]
+      },
+      "MobSpawnReceiptWire": {
+        "description": "Identity-native payload for `EnsureMemberOutcome::Spawned`.",
+        "properties": {
+          "agent_identity": {
+            "type": "string"
+          },
+          "member_ref": {
+            "$ref": "#/components/schemas/WireMemberRef",
+            "description": "Server-resolved opaque handle for subsequent member-targeted calls\n(work submission, cancellation, lifecycle). Replaces the binding-era\n`generation` / `fence_token` pair on app-facing surfaces."
+          }
+        },
+        "required": [
+          "agent_identity",
+          "member_ref"
+        ],
+        "type": "object"
+      },
+      "MobStepOutputFormatInput": {
+        "enum": [
+          "json",
+          "text"
+        ],
+        "type": "string"
+      },
+      "MobSubmitWorkParams": {
+        "additionalProperties": false,
+        "description": "Request payload for `mob/submit_work`.\n\nIdentifies the member through the opaque [`WireMemberRef`] handle the\nserver resolves against the live roster — callers do not pass\n`generation` or `fence_token`.",
+        "properties": {
+          "content": {
+            "$ref": "#/components/schemas/WireContentInput"
+          },
+          "member_ref": {
+            "$ref": "#/components/schemas/WireMemberRef"
+          },
+          "origin": {
+            "$ref": "#/components/schemas/WireWorkOrigin",
+            "default": "external"
+          },
+          "work_ref": {
+            "description": "Optional caller-supplied work reference. When absent the server\ngenerates a fresh UUID.",
+            "type": [
+              "string",
+              "null"
+            ]
+          }
+        },
+        "required": [
+          "member_ref",
+          "content"
+        ],
+        "title": "MobSubmitWorkParams",
+        "type": "object"
+      },
+      "MobSubmitWorkResult": {
+        "description": "Response payload for `mob/submit_work`.",
+        "properties": {
+          "member_ref": {
+            "$ref": "#/components/schemas/WireMemberRef"
+          },
+          "mob_id": {
+            "type": "string"
+          },
+          "work_ref": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "mob_id",
+          "work_ref",
+          "member_ref"
+        ],
+        "title": "MobSubmitWorkResult",
+        "type": "object"
+      },
+      "MobSupervisorSpecInput": {
+        "additionalProperties": false,
+        "properties": {
+          "escalation_threshold": {
+            "format": "uint32",
+            "minimum": 0,
+            "type": "integer"
+          },
+          "role": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "role",
+          "escalation_threshold"
+        ],
+        "type": "object"
+      },
+      "MobTargetBinding": {
+        "oneOf": [
+          {
+            "properties": {
+              "action": {
+                "$ref": "#/components/schemas/ScheduledMobAction"
+              },
+              "member_id": {
+                "type": "string"
+              },
+              "mob_id": {
+                "type": "string"
+              },
+              "type": {
+                "const": "member",
+                "type": "string"
+              }
+            },
+            "required": [
+              "type",
+              "mob_id",
+              "member_id",
+              "action"
+            ],
+            "type": "object"
+          },
+          {
+            "properties": {
+              "flow_id": {
+                "type": "string"
+              },
+              "mob_id": {
+                "type": "string"
+              },
+              "params": true,
+              "type": {
+                "const": "flow",
+                "type": "string"
+              }
+            },
+            "required": [
+              "type",
+              "mob_id",
+              "flow_id",
+              "params"
+            ],
+            "type": "object"
+          },
+          {
+            "properties": {
+              "member_id": {
+                "type": "string"
+              },
+              "mob_id": {
+                "type": "string"
+              },
+              "options": {
+                "$ref": "#/components/schemas/HelperOptionsSpec",
+                "default": {}
+              },
+              "prompt": {
+                "type": "string"
+              },
+              "type": {
+                "const": "spawn_helper",
+                "type": "string"
+              }
+            },
+            "required": [
+              "type",
+              "mob_id",
+              "member_id",
+              "prompt"
+            ],
+            "type": "object"
+          },
+          {
+            "properties": {
+              "fork_context": {
+                "$ref": "#/components/schemas/ForkContextSpec",
+                "default": {
+                  "type": "full_history"
+                }
+              },
+              "member_id": {
+                "type": "string"
+              },
+              "mob_id": {
+                "type": "string"
+              },
+              "options": {
+                "$ref": "#/components/schemas/HelperOptionsSpec",
+                "default": {}
+              },
+              "prompt": {
+                "type": "string"
+              },
+              "source_member_id": {
+                "type": "string"
+              },
+              "type": {
+                "const": "fork_helper",
+                "type": "string"
+              }
+            },
+            "required": [
+              "type",
+              "mob_id",
+              "source_member_id",
+              "member_id",
+              "prompt"
+            ],
+            "type": "object"
+          }
+        ]
+      },
+      "MobToolConfigInput": {
+        "additionalProperties": false,
+        "properties": {
+          "builtins": {
+            "default": false,
+            "type": "boolean"
+          },
+          "comms": {
+            "default": false,
+            "type": "boolean"
+          },
+          "mcp": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "memory": {
+            "default": false,
+            "type": "boolean"
+          },
+          "mob": {
+            "default": false,
+            "type": "boolean"
+          },
+          "mob_tasks": {
+            "default": false,
+            "type": "boolean"
+          },
+          "schedule": {
+            "default": false,
+            "type": "boolean"
+          },
+          "shell": {
+            "default": false,
+            "type": "boolean"
+          }
+        },
+        "type": "object"
+      },
+      "MobTopologyRuleInput": {
+        "additionalProperties": false,
+        "properties": {
+          "allowed": {
+            "type": "boolean"
+          },
+          "from_role": {
+            "type": "string"
+          },
+          "to_role": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "from_role",
+          "to_role",
+          "allowed"
+        ],
+        "type": "object"
+      },
+      "MobTopologySpecInput": {
+        "additionalProperties": false,
+        "properties": {
+          "mode": {
+            "$ref": "#/components/schemas/MobPolicyModeInput"
+          },
+          "rules": {
+            "items": {
+              "$ref": "#/components/schemas/MobTopologyRuleInput"
+            },
+            "type": "array"
+          }
+        },
+        "required": [
+          "mode",
+          "rules"
+        ],
+        "type": "object"
+      },
+      "MobUnwireParams": {
+        "additionalProperties": false,
+        "description": "Request payload for `mob/unwire`.",
+        "properties": {
+          "member": {
+            "type": "string"
+          },
+          "mob_id": {
+            "type": "string"
+          },
+          "peer": {
+            "$ref": "#/components/schemas/MobPeerTarget"
+          }
+        },
+        "required": [
+          "mob_id",
+          "member",
+          "peer"
+        ],
+        "title": "MobUnwireParams",
+        "type": "object"
+      },
+      "MobUnwireResult": {
+        "description": "Response payload for `mob/unwire`.",
+        "properties": {
+          "unwired": {
+            "type": "boolean"
+          }
+        },
+        "required": [
+          "unwired"
+        ],
+        "title": "MobUnwireResult",
+        "type": "object"
+      },
+      "MobWireParams": {
+        "additionalProperties": false,
+        "description": "Request payload for `mob/wire`.",
+        "properties": {
+          "member": {
+            "type": "string"
+          },
+          "mob_id": {
+            "type": "string"
+          },
+          "peer": {
+            "$ref": "#/components/schemas/MobPeerTarget"
+          }
+        },
+        "required": [
+          "mob_id",
+          "member",
+          "peer"
+        ],
+        "title": "MobWireParams",
+        "type": "object"
+      },
+      "MobWireResult": {
+        "description": "Response payload for `mob/wire`.",
+        "properties": {
+          "wired": {
+            "type": "boolean"
+          }
+        },
+        "required": [
+          "wired"
+        ],
+        "title": "MobWireResult",
+        "type": "object"
+      },
+      "MobWiringRulesInput": {
+        "additionalProperties": false,
+        "properties": {
+          "auto_wire_orchestrator": {
+            "default": false,
+            "type": "boolean"
+          },
+          "role_wiring": {
+            "items": {
+              "$ref": "#/components/schemas/MobRoleWiringRuleInput"
+            },
+            "type": "array"
+          }
+        },
+        "type": "object"
+      },
+      "ModelRoutingApprovalTerminalClass": {
+        "enum": [
+          "approved",
+          "denied_by_user",
+          "expired",
+          "interrupted",
+          "session_archived",
+          "surface_detached"
+        ],
+        "type": "string"
+      },
+      "ModelsCatalogResponse": {
+        "description": "Response for `models/catalog` — the compiled-in model catalog.",
+        "properties": {
+          "contract_version": {
+            "$ref": "#/components/schemas/ContractVersion",
+            "description": "Contract version."
+          },
+          "providers": {
+            "description": "Provider-grouped catalog data.",
+            "items": {
+              "$ref": "#/components/schemas/ProviderCatalog"
+            },
+            "type": "array"
+          }
+        },
+        "required": [
+          "contract_version",
+          "providers"
+        ],
+        "title": "ModelsCatalogResponse",
+        "type": "object"
+      },
+      "Occurrence": {
+        "properties": {
+          "attempt_count": {
+            "default": 0,
+            "format": "uint32",
+            "minimum": 0,
+            "type": "integer"
+          },
+          "claimed_at_utc": {
+            "format": "date-time",
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "claimed_by": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "completed_at_utc": {
+            "format": "date-time",
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "created_at_utc": {
+            "format": "date-time",
+            "type": "string"
+          },
+          "delivery_correlation_id": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "dispatched_at_utc": {
+            "format": "date-time",
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "due_at_utc": {
+            "format": "date-time",
+            "type": "string"
+          },
+          "failure_class": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/OccurrenceFailureClass"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "failure_detail": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "last_receipt": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/DeliveryReceipt"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "lease_expires_at_utc": {
+            "format": "date-time",
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "misfire_policy": {
+            "$ref": "#/components/schemas/MisfirePolicy"
+          },
+          "missing_target_policy": {
+            "$ref": "#/components/schemas/MissingTargetPolicy"
+          },
+          "occurrence_id": {
+            "$ref": "#/components/schemas/OccurrenceId"
+          },
+          "occurrence_ordinal": {
+            "format": "uint64",
+            "minimum": 0,
+            "type": "integer"
+          },
+          "overlap_policy": {
+            "$ref": "#/components/schemas/OverlapPolicy"
+          },
+          "phase": {
+            "$ref": "#/components/schemas/OccurrencePhase"
+          },
+          "runtime_outcome": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/RuntimeDeliveryOutcome"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "schedule_id": {
+            "$ref": "#/components/schemas/ScheduleId"
+          },
+          "schedule_revision": {
+            "format": "uint64",
+            "minimum": 0,
+            "type": "integer"
+          },
+          "superseded_by_revision": {
+            "format": "uint64",
+            "minimum": 0,
+            "type": [
+              "integer",
+              "null"
+            ]
+          },
+          "target_snapshot": {
+            "$ref": "#/components/schemas/TargetBinding"
+          },
+          "trigger_snapshot": {
+            "$ref": "#/components/schemas/TriggerSpec"
+          }
+        },
+        "required": [
+          "occurrence_id",
+          "schedule_id",
+          "schedule_revision",
+          "occurrence_ordinal",
+          "phase",
+          "due_at_utc",
+          "trigger_snapshot",
+          "target_snapshot",
+          "misfire_policy",
+          "overlap_policy",
+          "missing_target_policy",
+          "created_at_utc"
+        ],
+        "type": "object"
+      },
+      "OccurrenceFailureClass": {
+        "enum": [
+          "target_materialization_failed",
+          "target_missing",
+          "target_busy",
+          "runtime_rejected",
+          "mob_rejected",
+          "lease_lost",
+          "transport_error",
+          "internal_error"
+        ],
+        "type": "string"
+      },
+      "OccurrenceId": {
+        "description": "Opaque identifier for a persisted occurrence.",
+        "type": "string"
+      },
+      "OccurrencePhase": {
+        "enum": [
+          "pending",
+          "claimed",
+          "dispatching",
+          "awaiting_completion",
+          "completed",
+          "skipped",
+          "misfired",
+          "superseded",
+          "delivery_failed"
+        ],
+        "type": "string"
+      },
+      "OpenAiImageMetadata": {
+        "properties": {
+          "image_generation_call_id": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "response_id": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "target_model": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "target_model"
+        ],
+        "type": "object"
+      },
+      "OutputSchema": {
+        "description": "Configuration for structured output extraction.\n\nWhen provided to an agent, the agent will perform an extraction turn after\ncompleting the agentic work, forcing the LLM to output validated JSON that\nconforms to the provided schema. The extraction JSON becomes the final\nresponse text (schema-only) in [`RunResult`].",
+        "properties": {
+          "compat": {
+            "$ref": "#/components/schemas/SchemaCompat",
+            "default": "lossy",
+            "description": "Compatibility mode for provider lowering (lossy or strict)"
+          },
+          "format": {
+            "$ref": "#/components/schemas/SchemaFormat",
+            "default": "meerkat_v1",
+            "description": "Schema format version"
+          },
+          "name": {
+            "description": "Optional name for the schema (used by some providers)",
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "schema": {
+            "$ref": "#/components/schemas/MeerkatSchema",
+            "description": "The JSON schema that the output must conform to"
+          },
+          "strict": {
+            "default": false,
+            "description": "Whether to enforce strict schema validation (provider-specific)",
+            "type": "boolean"
+          }
+        },
+        "required": [
+          "schema"
+        ],
+        "type": "object"
+      },
+      "OverlapPolicy": {
+        "enum": [
+          "allow_concurrent",
+          "skip_if_running"
+        ],
+        "type": "string"
+      },
+      "PeerId": {
+        "description": "Canonical runtime identity for a peer.\n\n`PeerId` is the routing key: the router and trust store key by `PeerId`,\nnever by `PeerName`. Two peers may legitimately share a display `PeerName`\n(per the Wave-B V5 dogma note), but their `PeerId`s never collide — the\nunderlying UUID is globally unique.\n\nConstructed freshly (`PeerId::new`) for a peer minted locally, parsed\nfrom a hyphenated UUID (`PeerId::parse`) when we've been given an identity\nover the wire, or derived from a 32-byte Ed25519 public key when a transport\nstill authenticates by raw signing key.",
+        "type": "string"
+      },
+      "PeerLifecycleKind": {
+        "description": "One-way peer lifecycle notification kind.\n\nThese notifications are control-plane topology updates, not correlated\npeer work requests. They intentionally do not create request/response\nlifecycles and must never require an LLM-authored reply.",
+        "enum": [
+          "mob.peer_added",
+          "mob.peer_retired",
+          "mob.peer_unwired"
+        ],
+        "type": "string"
+      },
+      "PeerMeta": {
+        "description": "Supplementary metadata attached to a peer for discovery.\n\nThe peer's routing name lives in `TrustedPeer.name` / `comms_name`.\n`PeerMeta` carries additional context: what the agent does and\narbitrary key/value labels.\n\n# Serde\n\nBoth fields use `skip_serializing_if`, so `PeerMeta::default()`\nserializes to `{}`.",
+        "properties": {
+          "description": {
+            "description": "What this agent does (e.g. \"Reviews pull requests for style issues\").",
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "labels": {
+            "additionalProperties": {
+              "type": "string"
+            },
+            "description": "Arbitrary key/value labels (e.g. `{\"lang\": \"rust\", \"team\": \"infra\"}`).\n\n`BTreeMap` keeps keys sorted for deterministic serialization.",
+            "type": "object"
+          }
+        },
+        "type": "object"
+      },
+      "PeerName": {
+        "description": "Display-only slug for a peer.\n\n`PeerName` is **not** a routing key after Wave-B V5: the router resolves\nsends by [`PeerId`], and trust stores are keyed by [`PeerId`]. `PeerName`\nis retained so human-facing surfaces (CLI, REST `comms.peers`, logs) can\nrender a recognisable handle next to the opaque id.",
+        "type": "string"
+      },
+      "PlainTextResponse": {
+        "type": "string"
+      },
+      "PostActivationImageDenialReason": {
+        "oneOf": [
+          {
+            "properties": {
+              "reason": {
+                "const": "cost_policy",
+                "type": "string"
+              }
+            },
+            "required": [
+              "reason"
+            ],
+            "type": "object"
+          },
+          {
+            "properties": {
+              "reason": {
+                "const": "safety_policy",
+                "type": "string"
+              }
+            },
+            "required": [
+              "reason"
+            ],
+            "type": "object"
+          },
+          {
+            "properties": {
+              "approvable": {
+                "$ref": "#/components/schemas/ImageOperationApprovalReason"
+              },
+              "reason": {
+                "const": "denied_during_approval",
+                "type": "string"
+              }
+            },
+            "required": [
+              "reason",
+              "approvable"
+            ],
+            "type": "object"
+          },
+          {
+            "properties": {
+              "reason": {
+                "const": "scoped_override_conflict",
+                "type": "string"
+              }
+            },
+            "required": [
+              "reason"
+            ],
+            "type": "object"
+          },
+          {
+            "properties": {
+              "reason": {
+                "const": "realtime_transport_conflict",
+                "type": "string"
+              }
+            },
+            "required": [
+              "reason"
+            ],
+            "type": "object"
+          },
+          {
+            "properties": {
+              "reason": {
+                "const": "projection_unsupported",
+                "type": "string"
+              }
+            },
+            "required": [
+              "reason"
+            ],
+            "type": "object"
+          }
+        ]
+      },
+      "PostActivationImageTerminal": {
+        "oneOf": [
+          {
+            "properties": {
+              "terminal": {
+                "const": "generated",
+                "type": "string"
+              }
+            },
+            "required": [
+              "terminal"
+            ],
+            "type": "object"
+          },
+          {
+            "properties": {
+              "terminal": {
+                "const": "empty_result",
+                "type": "string"
+              }
+            },
+            "required": [
+              "terminal"
+            ],
+            "type": "object"
+          },
+          {
+            "properties": {
+              "reason": {
+                "$ref": "#/components/schemas/PostActivationImageDenialReason"
+              },
+              "terminal": {
+                "const": "denied",
+                "type": "string"
+              }
+            },
+            "required": [
+              "terminal",
+              "reason"
+            ],
+            "type": "object"
+          },
+          {
+            "properties": {
+              "terminal": {
+                "const": "refused_by_provider",
+                "type": "string"
+              }
+            },
+            "required": [
+              "terminal"
+            ],
+            "type": "object"
+          },
+          {
+            "properties": {
+              "terminal": {
+                "const": "safety_filtered",
+                "type": "string"
+              }
+            },
+            "required": [
+              "terminal"
+            ],
+            "type": "object"
+          },
+          {
+            "properties": {
+              "terminal": {
+                "const": "failed",
+                "type": "string"
+              }
+            },
+            "required": [
+              "terminal"
+            ],
+            "type": "object"
+          },
+          {
+            "properties": {
+              "terminal": {
+                "const": "cancelled",
+                "type": "string"
+              }
+            },
+            "required": [
+              "terminal"
+            ],
+            "type": "object"
+          },
+          {
+            "properties": {
+              "terminal": {
+                "const": "timeout",
+                "type": "string"
+              }
+            },
+            "required": [
+              "terminal"
+            ],
+            "type": "object"
+          }
+        ]
+      },
+      "ProfileId": {
+        "description": "Opaque slug identifying an auth profile override on a connection.",
+        "type": "string"
+      },
+      "PromptSource": {
+        "oneOf": [
+          {
+            "properties": {
+              "message_id": {
+                "$ref": "#/components/schemas/MessageId"
+              },
+              "source": {
+                "const": "user_provided",
+                "type": "string"
+              }
+            },
+            "required": [
+              "source",
+              "message_id"
+            ],
+            "type": "object"
+          },
+          {
+            "properties": {
+              "source": {
+                "const": "model_distilled",
+                "type": "string"
+              },
+              "tool_call_id": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "source",
+              "tool_call_id"
+            ],
+            "type": "object"
+          },
+          {
+            "properties": {
+              "source": {
+                "const": "hybrid",
+                "type": "string"
+              },
+              "tool_call_id": {
+                "type": "string"
+              },
+              "user_message_ids": {
+                "items": {
+                  "$ref": "#/components/schemas/MessageId"
+                },
+                "type": "array"
+              }
+            },
+            "required": [
+              "source",
+              "user_message_ids",
+              "tool_call_id"
+            ],
+            "type": "object"
+          }
+        ]
+      },
+      "PromptText": {
+        "properties": {
+          "content": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "content"
+        ],
+        "type": "object"
+      },
+      "Protocol": {
+        "description": "Protocol surfaces supported by Meerkat.",
+        "enum": [
+          "rpc",
+          "rest",
+          "mcp",
+          "cli"
+        ],
+        "type": "string"
+      },
+      "Provider": {
+        "description": "Supported LLM providers.",
+        "enum": [
+          "anthropic",
+          "open_a_i",
+          "gemini",
+          "self_hosted",
+          "other"
+        ],
+        "type": "string"
+      },
+      "ProviderCatalog": {
+        "description": "Provider-level grouping in the catalog response.",
+        "properties": {
+          "default_model_id": {
+            "description": "Default model ID for this provider.",
+            "type": "string"
+          },
+          "models": {
+            "description": "All catalog models for this provider.",
+            "items": {
+              "$ref": "#/components/schemas/CatalogModelEntry"
+            },
+            "type": "array"
+          },
+          "provider": {
+            "description": "Canonical provider name.",
+            "type": "string"
+          }
+        },
+        "required": [
+          "provider",
+          "default_model_id",
+          "models"
+        ],
+        "type": "object"
+      },
+      "ProviderImageMetadata": {
+        "oneOf": [
+          {
+            "properties": {
+              "provider": {
+                "const": "not_emitted",
+                "type": "string"
+              }
+            },
+            "required": [
+              "provider"
+            ],
+            "type": "object"
+          },
+          {
+            "$ref": "#/components/schemas/OpenAiImageMetadata",
+            "properties": {
+              "provider": {
+                "const": "open_ai",
+                "type": "string"
+              }
+            },
+            "required": [
+              "provider"
+            ],
+            "type": "object"
+          },
+          {
+            "$ref": "#/components/schemas/GeminiImageMetadata",
+            "properties": {
+              "provider": {
+                "const": "gemini",
+                "type": "string"
+              }
+            },
+            "required": [
+              "provider"
+            ],
+            "type": "object"
+          }
+        ]
+      },
+      "ProviderTextDisposition": {
+        "oneOf": [
+          {
+            "properties": {
+              "disposition": {
+                "const": "not_emitted",
+                "type": "string"
+              }
+            },
+            "required": [
+              "disposition"
+            ],
+            "type": "object"
+          },
+          {
+            "properties": {
+              "disposition": {
+                "const": "unsupported_by_backend",
+                "type": "string"
+              }
+            },
+            "required": [
+              "disposition"
+            ],
+            "type": "object"
+          },
+          {
+            "properties": {
+              "disposition": {
+                "const": "emitted_but_not_stored",
+                "type": "string"
+              }
+            },
+            "required": [
+              "disposition"
+            ],
+            "type": "object"
+          },
+          {
+            "properties": {
+              "disposition": {
+                "const": "captured",
+                "type": "string"
+              },
+              "text_artifact_ref": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "disposition",
+              "text_artifact_ref"
+            ],
+            "type": "object"
+          }
+        ]
+      },
+      "ProvisionApiKeyParams": {
+        "description": "Request payload for `auth/login/provision_api_key`.",
+        "properties": {
+          "access_token": {
+            "description": "Access token acquired from a prior Console-OAuth flow.",
+            "type": "string"
+          },
+          "binding_id": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "profile_id": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "realm_id": {
+            "type": [
+              "string",
+              "null"
+            ]
+          }
+        },
+        "required": [
+          "access_token"
+        ],
+        "title": "ProvisionApiKeyParams",
+        "type": "object"
+      },
+      "RealmId": {
+        "description": "Opaque slug identifying a realm.",
+        "type": "string"
+      },
+      "RealmIdParams": {
+        "description": "Request payload for `auth/profile/list` and `realm/get`.",
+        "properties": {
+          "realm_id": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "realm_id"
+        ],
+        "title": "RealmIdParams",
+        "type": "object"
+      },
+      "RealtimeAudioChunk": {
+        "description": "An opaque realtime audio chunk with MIME + format metadata.\n\nBoth sender and receiver MUST stamp `sample_rate_hz` and `channels` so the\ntransport layer can validate against the provider session's negotiated\nformat instead of silently producing garbled audio when an ESP32 or browser\nclient ships the wrong rate.",
+        "properties": {
+          "channels": {
+            "format": "uint8",
+            "maximum": 255,
+            "minimum": 0,
+            "type": "integer"
+          },
+          "data": {
+            "type": "string"
+          },
+          "mime_type": {
+            "type": "string"
+          },
+          "sample_rate_hz": {
+            "format": "uint32",
+            "minimum": 0,
+            "type": "integer"
+          }
+        },
+        "required": [
+          "mime_type",
+          "sample_rate_hz",
+          "channels",
+          "data"
+        ],
+        "title": "RealtimeAudioChunk",
+        "type": "object"
+      },
+      "RealtimeAudioFormat": {
+        "description": "Descriptor for an expected or actual realtime audio format.",
+        "properties": {
+          "channels": {
+            "description": "Channel count; `1` for mono.",
+            "format": "uint8",
+            "maximum": 255,
+            "minimum": 0,
+            "type": "integer"
+          },
+          "mime_type": {
+            "description": "IANA-style MIME type, e.g. `audio/pcm`.",
+            "type": "string"
+          },
+          "sample_rate_hz": {
+            "description": "Sample rate in hertz, e.g. `24000`.",
+            "format": "uint32",
+            "minimum": 0,
+            "type": "integer"
+          }
+        },
+        "required": [
+          "mime_type",
+          "sample_rate_hz",
+          "channels"
+        ],
+        "type": "object"
+      },
+      "RealtimeBargeInTruncateFrame": {
+        "description": "Payload for `channel.barge_in_truncate`.\n\nSent by the client the moment it detects the user starting to speak over\nthe assistant's audio, to tell the server what prefix was actually heard.\nField names mirror OpenAI Realtime's `conversation.item.truncate` so the\nprovider adapter can map straight through without re-encoding.",
+        "properties": {
+          "audio_played_ms": {
+            "description": "Milliseconds of assistant audio the client actually played back\nbefore the user interrupted. Must not exceed the true elapsed duration\nof the audio content.",
+            "format": "uint64",
+            "minimum": 0,
+            "type": "integer"
+          },
+          "content_index": {
+            "description": "Content index within the item (0 for the primary audio/text stream).",
+            "format": "uint32",
+            "minimum": 0,
+            "type": "integer"
+          },
+          "item_id": {
+            "description": "Assistant item whose output is being truncated. Matches the `item_id`\nemitted in the public `RealtimeEvent::AssistantTranscriptTruncated`.",
+            "type": "string"
+          }
+        },
+        "required": [
+          "item_id",
+          "content_index",
+          "audio_played_ms"
+        ],
+        "type": "object"
+      },
+      "RealtimeCapabilities": {
+        "description": "Product-facing realtime capability set for one target/provider combination.",
+        "properties": {
+          "audio_input_format": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/RealtimeAudioFormat"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Audio format the provider session accepts for client audio input.\nClients MUST stamp incoming [`RealtimeAudioChunk`]s with the same\n`sample_rate_hz` and `channels`; mismatches are rejected server-side."
+          },
+          "audio_output_format": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/RealtimeAudioFormat"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Audio format the provider session emits for output audio chunks."
+          },
+          "input_kinds": {
+            "items": {
+              "$ref": "#/components/schemas/RealtimeInputKind"
+            },
+            "type": "array"
+          },
+          "interrupt_supported": {
+            "type": "boolean"
+          },
+          "output_kinds": {
+            "items": {
+              "$ref": "#/components/schemas/RealtimeOutputKind"
+            },
+            "type": "array"
+          },
+          "tool_lifecycle_events_supported": {
+            "type": "boolean"
+          },
+          "transcript_supported": {
+            "type": "boolean"
+          },
+          "turning_modes": {
+            "items": {
+              "$ref": "#/components/schemas/RealtimeTurningMode"
+            },
+            "type": "array"
+          },
+          "video_supported": {
+            "type": "boolean"
+          }
+        },
+        "required": [
+          "interrupt_supported",
+          "transcript_supported",
+          "tool_lifecycle_events_supported",
+          "video_supported"
+        ],
+        "title": "RealtimeCapabilities",
+        "type": "object"
+      },
+      "RealtimeCapabilitiesParams": {
+        "description": "Request payload for `realtime/capabilities`.",
+        "properties": {
+          "target": {
+            "$ref": "#/components/schemas/RealtimeChannelTarget"
+          }
+        },
+        "required": [
+          "target"
+        ],
+        "title": "RealtimeCapabilitiesParams",
+        "type": "object"
+      },
+      "RealtimeCapabilitiesResult": {
+        "description": "Response payload for `realtime/capabilities`.",
+        "properties": {
+          "capabilities": {
+            "$ref": "#/components/schemas/RealtimeCapabilities"
+          }
+        },
+        "required": [
+          "capabilities"
+        ],
+        "title": "RealtimeCapabilitiesResult",
+        "type": "object"
+      },
+      "RealtimeChannelClosedFrame": {
+        "description": "Payload for `channel.closed`.",
+        "properties": {
+          "reason": {
+            "type": [
+              "string",
+              "null"
+            ]
+          }
+        },
+        "title": "RealtimeChannelClosedFrame",
+        "type": "object"
+      },
+      "RealtimeChannelConfig": {
+        "description": "Per-channel runtime knobs negotiated at open time.\n\nAdditive fields only — clients that do not carry this struct inherit the\nserver-default behavior via `#[serde(default)]` on the parent\n[`RealtimeOpenRequest`].",
+        "properties": {
+          "tool_timeout_ms": {
+            "description": "Maximum wall-clock time a tool dispatch may take before the channel\ngives up and injects a synthetic tool-error result. `None` disables the\ndeadline (product explicitly opted into unlimited tools); omitting the\nfield leaves the server default in place.",
+            "format": "uint64",
+            "minimum": 0,
+            "type": [
+              "integer",
+              "null"
+            ]
+          }
+        },
+        "type": "object"
+      },
+      "RealtimeChannelErrorFrame": {
+        "description": "Payload for `channel.error`.",
+        "properties": {
+          "code": {
+            "$ref": "#/components/schemas/RealtimeErrorCode",
+            "description": "Typed error code. Single source of truth for branching in SDKs."
+          },
+          "details": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/RealtimeErrorDetails"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Structured context keyed to the code, when additional fields are useful."
+          },
+          "message": {
+            "description": "Human-readable message suitable for logs and operator surfaces.",
+            "type": "string"
+          }
+        },
+        "required": [
+          "code",
+          "message"
+        ],
+        "title": "RealtimeChannelErrorFrame",
+        "type": "object"
+      },
+      "RealtimeChannelEventFrame": {
+        "description": "Payload for `channel.event`.",
+        "properties": {
+          "event": {
+            "$ref": "#/components/schemas/RealtimeEvent"
+          }
+        },
+        "required": [
+          "event"
+        ],
+        "title": "RealtimeChannelEventFrame",
+        "type": "object"
+      },
+      "RealtimeChannelInputFrame": {
+        "description": "Payload for `channel.input`.",
+        "properties": {
+          "chunk": {
+            "$ref": "#/components/schemas/RealtimeInputChunk"
+          }
+        },
+        "required": [
+          "chunk"
+        ],
+        "title": "RealtimeChannelInputFrame",
+        "type": "object"
+      },
+      "RealtimeChannelOpenFrame": {
+        "description": "Payload for `channel.open`.",
+        "properties": {
+          "open_token": {
+            "type": "string"
+          },
+          "protocol_version": {
+            "type": "string"
+          },
+          "role": {
+            "$ref": "#/components/schemas/RealtimeChannelRole"
+          },
+          "turning_mode": {
+            "$ref": "#/components/schemas/RealtimeTurningMode"
+          }
+        },
+        "required": [
+          "protocol_version",
+          "open_token",
+          "role",
+          "turning_mode"
+        ],
+        "title": "RealtimeChannelOpenFrame",
+        "type": "object"
+      },
+      "RealtimeChannelOpenedFrame": {
+        "description": "Payload for `channel.opened`.",
+        "properties": {
+          "capabilities": {
+            "$ref": "#/components/schemas/RealtimeCapabilities"
+          },
+          "protocol_version": {
+            "type": "string"
+          },
+          "role": {
+            "$ref": "#/components/schemas/RealtimeChannelRole"
+          },
+          "status": {
+            "$ref": "#/components/schemas/RealtimeChannelStatus"
+          }
+        },
+        "required": [
+          "protocol_version",
+          "status",
+          "capabilities",
+          "role"
+        ],
+        "title": "RealtimeChannelOpenedFrame",
+        "type": "object"
+      },
+      "RealtimeChannelRole": {
+        "description": "Opening role for a realtime channel.",
+        "enum": [
+          "primary",
+          "observer"
+        ],
+        "type": "string"
+      },
+      "RealtimeChannelState": {
+        "description": "Lifecycle state for a realtime channel.",
+        "enum": [
+          "opening",
+          "ready",
+          "interrupted",
+          "reconnecting",
+          "closed",
+          "error"
+        ],
+        "type": "string"
+      },
+      "RealtimeChannelStatus": {
+        "description": "Public realtime channel status projection.",
+        "properties": {
+          "attempt_count": {
+            "default": 0,
+            "format": "uint32",
+            "minimum": 0,
+            "type": "integer"
+          },
+          "deadline_at": {
+            "description": "Wall-clock deadline after which the reconnect cycle will be abandoned\nand the channel will close with `ReconnectExhausted`. Derived from the\nreconnect policy's `max_total_ms` on top of the cycle's start time. RFC\n3339 encoded, matches `next_retry_at`. Present only while the channel\nis actively reconnecting.",
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "next_retry_at": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "reason": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "state": {
+            "$ref": "#/components/schemas/RealtimeChannelState"
+          }
+        },
+        "required": [
+          "state"
+        ],
+        "type": "object"
+      },
+      "RealtimeChannelStatusFrame": {
+        "description": "Payload for `channel.status`.",
+        "properties": {
+          "status": {
+            "$ref": "#/components/schemas/RealtimeChannelStatus"
+          }
+        },
+        "required": [
+          "status"
+        ],
+        "title": "RealtimeChannelStatusFrame",
+        "type": "object"
+      },
+      "RealtimeChannelTarget": {
+        "description": "Target for a public realtime channel.\n\nTwo variants, one for each addressing mode:\n\n- `SessionTarget` — standalone sessions (no mob-member continuity). The\n  session id is pinned for the channel's lifetime; when that session\n  ends, the channel ends.\n\n- `MobMember` — mob-member continuity (W3-H / dogma #4). Identity is the\n  canonical anchor, and the server resolves the current bridge session\n  on every tick from the MobMachine's `member_session_bindings` map.\n  Respawn atomically rotates the bridge session via the\n  `MemberSessionBindingChanged { old: Some, new: Some }` effect; the\n  channel survives without any SDK round-trip. A terminal\n  `MemberSessionBindingChanged { old: Some, new: None }` closes the\n  channel with `RealtimeErrorCode::BindingReleased`.",
+        "oneOf": [
+          {
+            "properties": {
+              "session_id": {
+                "type": "string"
+              },
+              "type": {
+                "const": "session_target",
+                "type": "string"
+              }
+            },
+            "required": [
+              "type",
+              "session_id"
+            ],
+            "type": "object"
+          },
+          {
+            "properties": {
+              "agent_identity": {
+                "type": "string"
+              },
+              "mob_id": {
+                "type": "string"
+              },
+              "type": {
+                "const": "mob_member",
+                "type": "string"
+              }
+            },
+            "required": [
+              "type",
+              "mob_id",
+              "agent_identity"
+            ],
+            "type": "object"
+          }
+        ],
+        "title": "RealtimeChannelTarget"
+      },
+      "RealtimeClientFrame": {
+        "description": "Client-to-server realtime frame.",
+        "oneOf": [
+          {
+            "$ref": "#/components/schemas/RealtimeChannelOpenFrame",
+            "properties": {
+              "type": {
+                "const": "channel.open",
+                "type": "string"
+              }
+            },
+            "required": [
+              "type"
+            ],
+            "type": "object"
+          },
+          {
+            "$ref": "#/components/schemas/RealtimeChannelInputFrame",
+            "properties": {
+              "type": {
+                "const": "channel.input",
+                "type": "string"
+              }
+            },
+            "required": [
+              "type"
+            ],
+            "type": "object"
+          },
+          {
+            "properties": {
+              "type": {
+                "const": "channel.commit_turn",
+                "type": "string"
+              }
+            },
+            "required": [
+              "type"
+            ],
+            "type": "object"
+          },
+          {
+            "properties": {
+              "type": {
+                "const": "channel.interrupt",
+                "type": "string"
+              }
+            },
+            "required": [
+              "type"
+            ],
+            "type": "object"
+          },
+          {
+            "$ref": "#/components/schemas/RealtimeBargeInTruncateFrame",
+            "description": "Report a client-side barge-in with the playback cursor, so the server\ncan truncate the canonical transcript to what the user actually heard.",
+            "properties": {
+              "type": {
+                "const": "channel.barge_in_truncate",
+                "type": "string"
+              }
+            },
+            "required": [
+              "type"
+            ],
+            "type": "object"
+          },
+          {
+            "properties": {
+              "type": {
+                "const": "channel.close",
+                "type": "string"
+              }
+            },
+            "required": [
+              "type"
+            ],
+            "type": "object"
+          }
+        ],
+        "title": "RealtimeClientFrame"
+      },
+      "RealtimeErrorCode": {
+        "description": "Typed realtime channel error code. Replaces the prior freeform `String` on\n[`RealtimeChannelErrorFrame`]; all paths that mint a channel error pick\nexactly one variant so downstream SDKs can match without string folklore.",
+        "oneOf": [
+          {
+            "const": "invalid_frame",
+            "description": "Incoming frame could not be parsed.",
+            "type": "string"
+          },
+          {
+            "const": "expected_channel_open",
+            "description": "The first frame on a new socket was not `channel.open`.",
+            "type": "string"
+          },
+          {
+            "const": "invalid_open_token",
+            "description": "The open token did not match any pending reservation.",
+            "type": "string"
+          },
+          {
+            "const": "open_token_expired",
+            "description": "The open token was valid but its TTL elapsed before use.",
+            "type": "string"
+          },
+          {
+            "const": "role_mismatch",
+            "description": "The client-requested role does not match the reservation.",
+            "type": "string"
+          },
+          {
+            "const": "turning_mode_mismatch",
+            "description": "The client-requested turning mode does not match the reservation.",
+            "type": "string"
+          },
+          {
+            "const": "unsupported_turning_mode",
+            "description": "The reservation requested a turning mode this host does not support.",
+            "type": "string"
+          },
+          {
+            "const": "target_busy",
+            "description": "The target already has an active primary channel.",
+            "type": "string"
+          },
+          {
+            "const": "unsupported_protocol_version",
+            "description": "The client handshake requested a protocol version this host cannot serve.",
+            "type": "string"
+          },
+          {
+            "const": "audio_format_mismatch",
+            "description": "An input audio chunk's sample rate or channel count did not match the\nformat the provider session is negotiated for.",
+            "type": "string"
+          },
+          {
+            "const": "unauthorized_realm",
+            "description": "The open token was minted for a different realm than the one the\nwebsocket session currently resolves to. Enforced server-side.",
+            "type": "string"
+          },
+          {
+            "const": "tool_call_timeout",
+            "description": "A tool dispatch exceeded its configured budget.",
+            "type": "string"
+          },
+          {
+            "const": "internal_error",
+            "description": "Generic internal runtime error (fallback when no better code fits).",
+            "type": "string"
+          },
+          {
+            "const": "reconnect_exhausted",
+            "description": "Reconnect budget exhausted; channel is closing.",
+            "type": "string"
+          },
+          {
+            "const": "invalid_target",
+            "description": "Realtime target did not parse or resolve.",
+            "type": "string"
+          },
+          {
+            "const": "channel_not_bound",
+            "description": "No realtime binding exists for this channel (driver not ready).",
+            "type": "string"
+          },
+          {
+            "const": "runtime_internal",
+            "description": "Runtime layer returned an internal error that has no more-specific code.",
+            "type": "string"
+          },
+          {
+            "const": "runtime_not_ready",
+            "description": "Runtime driver is not in a state that can accept this operation.",
+            "type": "string"
+          },
+          {
+            "const": "provider_session_closed",
+            "description": "Upstream provider session is closed.",
+            "type": "string"
+          },
+          {
+            "const": "provider_session_failed",
+            "description": "Upstream provider session failed to open or progressed fatally.",
+            "type": "string"
+          },
+          {
+            "const": "provider_session_unavailable",
+            "description": "Upstream provider session is temporarily unavailable.",
+            "type": "string"
+          },
+          {
+            "const": "unsupported_input_kind",
+            "description": "Input modality is not supported by the negotiated capabilities.",
+            "type": "string"
+          },
+          {
+            "const": "no_pending_turn",
+            "description": "No pending turn on this channel to commit or interrupt.",
+            "type": "string"
+          },
+          {
+            "const": "observer_read_only",
+            "description": "Observer channels may not send input or control frames.",
+            "type": "string"
+          },
+          {
+            "const": "unexpected_channel_open",
+            "description": "`channel.open` is valid only as the first frame on a new socket.",
+            "type": "string"
+          },
+          {
+            "const": "commit_turn_unavailable",
+            "description": "`channel.commit_turn` is only valid for explicit-commit turning mode.",
+            "type": "string"
+          },
+          {
+            "const": "channel_reconnecting",
+            "description": "Channel is reconnecting; the caller must wait for a ready state.",
+            "type": "string"
+          },
+          {
+            "const": "binding_released",
+            "description": "W3-H: the mob member this channel was bound to has been retired and\nits realtime binding released by the MobMachine\n(`MemberSessionBindingChanged { old: Some, new: None }` effect).\nSignalled only for `MobMember` targets; `SessionTarget` channels\ndo not encounter this.",
+            "type": "string"
+          },
+          {
+            "const": "authentication_failed",
+            "description": "Provider authentication rejected the connection or request. Maps\nfrom `meerkat_client::LlmError::AuthenticationFailed` so the wire\nsurfaces a typed code instead of collapsing into\n`InvalidTarget`.",
+            "type": "string"
+          },
+          {
+            "const": "content_filtered",
+            "description": "Provider returned a content-filter rejection\n(`meerkat_client::LlmError::ContentFiltered`). Typed so clients\ncan distinguish policy rejection from transport failure.",
+            "type": "string"
+          },
+          {
+            "const": "model_not_found",
+            "description": "Provider rejected the request because the configured model is\nunknown or unavailable\n(`meerkat_client::LlmError::ModelNotFound`). Typed so clients\ncan distinguish model-catalog drift from realtime transport\nmisconfiguration.",
+            "type": "string"
+          },
+          {
+            "const": "invalid_request",
+            "description": "Provider returned `InvalidRequest` for a shape the realtime\nlayer cannot classify more specifically. Kept distinct from\n`InvalidTarget` (which is about parse/resolve of the target\nitself, not the outgoing request payload).",
+            "type": "string"
+          }
+        ]
+      },
+      "RealtimeErrorDetails": {
+        "description": "Structured typed context carried on a channel error frame. Each variant\ncorresponds to a specific [`RealtimeErrorCode`] and lets clients match\nthe reason without parsing the message string.",
+        "oneOf": [
+          {
+            "$ref": "#/components/schemas/AudioFormatMismatchContext",
+            "properties": {
+              "kind": {
+                "const": "audio_format_mismatch",
+                "type": "string"
+              }
+            },
+            "required": [
+              "kind"
+            ],
+            "type": "object"
+          },
+          {
+            "$ref": "#/components/schemas/ToolCallTimeoutContext",
+            "properties": {
+              "kind": {
+                "const": "tool_call_timeout",
+                "type": "string"
+              }
+            },
+            "required": [
+              "kind"
+            ],
+            "type": "object"
+          },
+          {
+            "properties": {
+              "kind": {
+                "const": "unsupported_protocol_version",
+                "type": "string"
+              },
+              "requested": {
+                "type": "string"
+              },
+              "supported": {
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              }
+            },
+            "required": [
+              "kind",
+              "requested",
+              "supported"
+            ],
+            "type": "object"
+          }
+        ]
+      },
+      "RealtimeEvent": {
+        "description": "Normalized realtime event stream payload.",
+        "oneOf": [
+          {
+            "properties": {
+              "text": {
+                "type": "string"
+              },
+              "type": {
+                "const": "input_transcript_partial",
+                "type": "string"
+              }
+            },
+            "required": [
+              "type",
+              "text"
+            ],
+            "type": "object"
+          },
+          {
+            "properties": {
+              "prosody_hint": {
+                "description": "Opaque, provider-specific prosody annotation (tone / sentiment /\npitch hints). Additive field. Providers that do not surface\nstructured prosody leave it `None`; compactors and downstream\ntools may use this as a hint only — the authoritative transcript\nis still `text`.",
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "text": {
+                "type": "string"
+              },
+              "type": {
+                "const": "input_transcript_final",
+                "type": "string"
+              }
+            },
+            "required": [
+              "type",
+              "text"
+            ],
+            "type": "object"
+          },
+          {
+            "properties": {
+              "type": {
+                "const": "turn_started",
+                "type": "string"
+              }
+            },
+            "required": [
+              "type"
+            ],
+            "type": "object"
+          },
+          {
+            "properties": {
+              "type": {
+                "const": "turn_committed",
+                "type": "string"
+              }
+            },
+            "required": [
+              "type"
+            ],
+            "type": "object"
+          },
+          {
+            "properties": {
+              "type": {
+                "const": "turn_completed",
+                "type": "string"
+              }
+            },
+            "required": [
+              "type"
+            ],
+            "type": "object"
+          },
+          {
+            "properties": {
+              "delta": {
+                "type": "string"
+              },
+              "type": {
+                "const": "output_text_delta",
+                "type": "string"
+              }
+            },
+            "required": [
+              "type",
+              "delta"
+            ],
+            "type": "object"
+          },
+          {
+            "properties": {
+              "chunk": {
+                "$ref": "#/components/schemas/RealtimeAudioChunk"
+              },
+              "type": {
+                "const": "output_audio_chunk",
+                "type": "string"
+              }
+            },
+            "required": [
+              "type",
+              "chunk"
+            ],
+            "type": "object"
+          },
+          {
+            "properties": {
+              "chunk": {
+                "$ref": "#/components/schemas/RealtimeVideoChunk"
+              },
+              "type": {
+                "const": "output_video_chunk",
+                "type": "string"
+              }
+            },
+            "required": [
+              "type",
+              "chunk"
+            ],
+            "type": "object"
+          },
+          {
+            "properties": {
+              "type": {
+                "const": "interrupted",
+                "type": "string"
+              }
+            },
+            "required": [
+              "type"
+            ],
+            "type": "object"
+          },
+          {
+            "properties": {
+              "call_id": {
+                "type": "string"
+              },
+              "tool_name": {
+                "type": "string"
+              },
+              "type": {
+                "const": "tool_call_requested",
+                "type": "string"
+              }
+            },
+            "required": [
+              "type",
+              "call_id",
+              "tool_name"
+            ],
+            "type": "object"
+          },
+          {
+            "properties": {
+              "call_id": {
+                "type": "string"
+              },
+              "type": {
+                "const": "tool_call_completed",
+                "type": "string"
+              }
+            },
+            "required": [
+              "type",
+              "call_id"
+            ],
+            "type": "object"
+          },
+          {
+            "properties": {
+              "call_id": {
+                "type": "string"
+              },
+              "error": {
+                "type": "string"
+              },
+              "type": {
+                "const": "tool_call_failed",
+                "type": "string"
+              }
+            },
+            "required": [
+              "type",
+              "call_id",
+              "error"
+            ],
+            "type": "object"
+          },
+          {
+            "description": "The tool dispatch exceeded its configured budget and was aborted;\na synthetic `ToolResult::Error` was injected back into the provider\nsession so the model sees a concrete failure instead of silence.",
+            "properties": {
+              "call_id": {
+                "type": "string"
+              },
+              "elapsed_ms": {
+                "format": "uint64",
+                "minimum": 0,
+                "type": "integer"
+              },
+              "type": {
+                "const": "tool_call_timed_out",
+                "type": "string"
+              }
+            },
+            "required": [
+              "type",
+              "call_id",
+              "elapsed_ms"
+            ],
+            "type": "object"
+          },
+          {
+            "description": "The assistant output for `item_id` was truncated at\n`audio_played_ms` because the user barged in. `truncated_text` is the\ntranscript prefix the user actually heard, as reported by the\nprovider; when the provider has not yet supplied a re-projected\ntranscript the field is omitted (`None`) and downstream projectors\nshould keep the existing transcript until a later emission fills it in.",
+            "properties": {
+              "audio_played_ms": {
+                "format": "uint64",
+                "minimum": 0,
+                "type": "integer"
+              },
+              "item_id": {
+                "type": "string"
+              },
+              "truncated_text": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "type": {
+                "const": "assistant_transcript_truncated",
+                "type": "string"
+              }
+            },
+            "required": [
+              "type",
+              "item_id",
+              "audio_played_ms"
+            ],
+            "type": "object"
+          },
+          {
+            "properties": {
+              "status": {
+                "$ref": "#/components/schemas/RealtimeChannelStatus"
+              },
+              "type": {
+                "const": "status_changed",
+                "type": "string"
+              }
+            },
+            "required": [
+              "type",
+              "status"
+            ],
+            "type": "object"
+          },
+          {
+            "properties": {
+              "type": {
+                "const": "needs_reattach",
+                "type": "string"
+              }
+            },
+            "required": [
+              "type"
+            ],
+            "type": "object"
+          }
+        ]
+      },
+      "RealtimeInputChunk": {
+        "description": "Modality-neutral input chunk.",
+        "oneOf": [
+          {
+            "$ref": "#/components/schemas/RealtimeTextChunk",
+            "properties": {
+              "kind": {
+                "const": "text_chunk",
+                "type": "string"
+              }
+            },
+            "required": [
+              "kind"
+            ],
+            "type": "object"
+          },
+          {
+            "$ref": "#/components/schemas/RealtimeAudioChunk",
+            "properties": {
+              "kind": {
+                "const": "audio_chunk",
+                "type": "string"
+              }
+            },
+            "required": [
+              "kind"
+            ],
+            "type": "object"
+          },
+          {
+            "$ref": "#/components/schemas/RealtimeVideoChunk",
+            "properties": {
+              "kind": {
+                "const": "video_chunk",
+                "type": "string"
+              }
+            },
+            "required": [
+              "kind"
+            ],
+            "type": "object"
+          }
+        ]
+      },
+      "RealtimeInputKind": {
+        "description": "Input modality kind supported by a realtime channel.",
+        "enum": [
+          "text",
+          "audio",
+          "video"
+        ],
+        "type": "string"
+      },
+      "RealtimeOpenInfo": {
+        "description": "Response payload for `realtime/open_info`.",
+        "properties": {
+          "capabilities": {
+            "$ref": "#/components/schemas/RealtimeCapabilities"
+          },
+          "default_protocol_version": {
+            "type": "string"
+          },
+          "expires_at": {
+            "type": "string"
+          },
+          "open_token": {
+            "type": "string"
+          },
+          "supported_protocol_versions": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "target": {
+            "$ref": "#/components/schemas/RealtimeChannelTarget"
+          },
+          "ws_url": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "ws_url",
+          "open_token",
+          "expires_at",
+          "target",
+          "default_protocol_version",
+          "capabilities"
+        ],
+        "title": "RealtimeOpenInfo",
+        "type": "object"
+      },
+      "RealtimeOpenRequest": {
+        "description": "Request payload for `realtime/open_info`.",
+        "properties": {
+          "channel_config": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/RealtimeChannelConfig"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Optional per-channel runtime knobs (tool budget, etc.). Omitted means\n\"use server defaults\"."
+          },
+          "reconnect_policy": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/RealtimeReconnectPolicy"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "role": {
+            "$ref": "#/components/schemas/RealtimeChannelRole"
+          },
+          "target": {
+            "$ref": "#/components/schemas/RealtimeChannelTarget"
+          },
+          "turning_mode": {
+            "$ref": "#/components/schemas/RealtimeTurningMode"
+          }
+        },
+        "required": [
+          "target",
+          "role",
+          "turning_mode"
+        ],
+        "title": "RealtimeOpenRequest",
+        "type": "object"
+      },
+      "RealtimeOutputChunk": {
+        "description": "Modality-neutral output chunk.",
+        "oneOf": [
+          {
+            "$ref": "#/components/schemas/RealtimeTextDelta",
+            "properties": {
+              "kind": {
+                "const": "text_delta",
+                "type": "string"
+              }
+            },
+            "required": [
+              "kind"
+            ],
+            "type": "object"
+          },
+          {
+            "$ref": "#/components/schemas/RealtimeAudioChunk",
+            "properties": {
+              "kind": {
+                "const": "audio_chunk",
+                "type": "string"
+              }
+            },
+            "required": [
+              "kind"
+            ],
+            "type": "object"
+          },
+          {
+            "$ref": "#/components/schemas/RealtimeVideoChunk",
+            "properties": {
+              "kind": {
+                "const": "video_chunk",
+                "type": "string"
+              }
+            },
+            "required": [
+              "kind"
+            ],
+            "type": "object"
+          }
+        ],
+        "title": "RealtimeOutputChunk"
+      },
+      "RealtimeOutputKind": {
+        "description": "Output modality kind supported by a realtime channel.",
+        "enum": [
+          "text",
+          "audio",
+          "video"
+        ],
+        "type": "string"
+      },
+      "RealtimeReconnectPolicy": {
+        "description": "Public reconnect policy for a realtime channel.",
+        "properties": {
+          "initial_backoff_ms": {
+            "format": "uint64",
+            "minimum": 0,
+            "type": "integer"
+          },
+          "max_attempts": {
+            "format": "uint32",
+            "minimum": 0,
+            "type": "integer"
+          },
+          "max_backoff_ms": {
+            "format": "uint64",
+            "minimum": 0,
+            "type": "integer"
+          },
+          "max_total_ms": {
+            "format": "uint64",
+            "minimum": 0,
+            "type": "integer"
+          }
+        },
+        "required": [
+          "max_attempts",
+          "initial_backoff_ms",
+          "max_backoff_ms",
+          "max_total_ms"
+        ],
+        "title": "RealtimeReconnectPolicy",
+        "type": "object"
+      },
+      "RealtimeServerFrame": {
+        "description": "Server-to-client realtime frame.",
+        "oneOf": [
+          {
+            "$ref": "#/components/schemas/RealtimeChannelOpenedFrame",
+            "properties": {
+              "type": {
+                "const": "channel.opened",
+                "type": "string"
+              }
+            },
+            "required": [
+              "type"
+            ],
+            "type": "object"
+          },
+          {
+            "$ref": "#/components/schemas/RealtimeChannelStatusFrame",
+            "properties": {
+              "type": {
+                "const": "channel.status",
+                "type": "string"
+              }
+            },
+            "required": [
+              "type"
+            ],
+            "type": "object"
+          },
+          {
+            "$ref": "#/components/schemas/RealtimeChannelEventFrame",
+            "properties": {
+              "type": {
+                "const": "channel.event",
+                "type": "string"
+              }
+            },
+            "required": [
+              "type"
+            ],
+            "type": "object"
+          },
+          {
+            "$ref": "#/components/schemas/RealtimeChannelErrorFrame",
+            "properties": {
+              "type": {
+                "const": "channel.error",
+                "type": "string"
+              }
+            },
+            "required": [
+              "type"
+            ],
+            "type": "object"
+          },
+          {
+            "$ref": "#/components/schemas/RealtimeChannelClosedFrame",
+            "properties": {
+              "type": {
+                "const": "channel.closed",
+                "type": "string"
+              }
+            },
+            "required": [
+              "type"
+            ],
+            "type": "object"
+          }
+        ],
+        "title": "RealtimeServerFrame"
+      },
+      "RealtimeStatusParams": {
+        "description": "Request payload for `realtime/status`.",
+        "properties": {
+          "target": {
+            "$ref": "#/components/schemas/RealtimeChannelTarget"
+          }
+        },
+        "required": [
+          "target"
+        ],
+        "title": "RealtimeStatusParams",
+        "type": "object"
+      },
+      "RealtimeStatusResult": {
+        "description": "Response payload for `realtime/status`.",
+        "properties": {
+          "status": {
+            "$ref": "#/components/schemas/RealtimeChannelStatus"
+          }
+        },
+        "required": [
+          "status"
+        ],
+        "title": "RealtimeStatusResult",
+        "type": "object"
+      },
+      "RealtimeTextChunk": {
+        "description": "A text chunk for realtime ingress/egress.",
+        "properties": {
+          "text": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "text"
+        ],
+        "type": "object"
+      },
+      "RealtimeTextDelta": {
+        "description": "A text delta chunk for realtime output.",
+        "properties": {
+          "delta": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "delta"
+        ],
+        "type": "object"
+      },
+      "RealtimeTurningMode": {
+        "description": "Turning mode for a realtime channel.",
+        "enum": [
+          "provider_managed",
+          "explicit_commit"
+        ],
+        "type": "string"
+      },
+      "RealtimeVideoChunk": {
+        "description": "An opaque realtime video chunk with MIME metadata.",
+        "properties": {
+          "data": {
+            "type": "string"
+          },
+          "mime_type": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "mime_type",
+          "data"
+        ],
+        "type": "object"
+      },
+      "RenderClass": {
+        "description": "Standardized rendering class for injected ordinary work.\n\nThis metadata is for normalization/injection rendering, not for core\nruntime scheduling. It lets the system consistently frame peer messages,\nexternal events, tool-scope notices, and similar inputs when they are\nrendered into model-visible context.",
+        "enum": [
+          "user_prompt",
+          "peer_message",
+          "peer_request",
+          "peer_response",
+          "external_event",
+          "flow_step",
+          "continuation",
+          "system_notice",
+          "tool_scope_notice",
+          "ops_progress"
+        ],
+        "type": "string"
+      },
+      "RenderMetadata": {
+        "description": "Optional rendering metadata carried alongside ordinary work content.",
+        "properties": {
+          "class": {
+            "$ref": "#/components/schemas/RenderClass"
+          },
+          "salience": {
+            "$ref": "#/components/schemas/RenderSalience",
+            "default": "normal"
+          }
+        },
+        "required": [
+          "class"
+        ],
+        "type": "object"
+      },
+      "RenderSalience": {
+        "description": "Constrained salience metadata for injected ordinary work.\n\nThis is intentionally a small closed enum so call sites do not invent\narbitrary free-text urgency language.",
+        "enum": [
+          "background",
+          "normal",
+          "important",
+          "urgent"
+        ],
+        "type": "string"
+      },
+      "ResponseStatus": {
+        "description": "Typed status for response interactions.\n\nMirrors `CommsStatus` from `meerkat-comms` — the comms runtime converts at the boundary.",
+        "enum": [
+          "accepted",
+          "completed",
+          "failed"
+        ],
+        "type": "string"
+      },
+      "RestAppendSystemContextRequest": {
+        "properties": {
+          "idempotency_key": {
+            "type": "string"
+          },
+          "source": {
+            "type": "string"
+          },
+          "text": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "text"
+        ],
+        "type": "object"
+      },
+      "RestAuthBindingRequest": {
+        "properties": {
+          "binding_id": {
+            "type": "string"
+          },
+          "profile_id": {
+            "type": "string"
+          },
+          "realm_id": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "realm_id",
+          "binding_id"
+        ],
+        "type": "object"
+      },
+      "RestAuthLoginStartRequest": {
+        "additionalProperties": true,
+        "required": [
+          "provider"
+        ],
+        "type": "object"
+      },
+      "RestAuthProfileCreateRequest": {
+        "additionalProperties": true,
+        "required": [
+          "realm_id",
+          "binding_id",
+          "auth_method"
+        ],
+        "type": "object"
+      },
+      "RestCommsSendRequest": {
+        "properties": {
+          "command": {
+            "$ref": "#/components/schemas/CommsCommandRequest"
+          },
+          "session_id": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "session_id",
+          "command"
+        ],
+        "type": "object"
+      },
+      "RestContinueSessionRequest": {
+        "properties": {
+          "additional_instructions": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "comms_name": {
+            "type": "string"
+          },
+          "flow_tool_overlay": {
+            "$ref": "#/components/schemas/JsonValue"
+          },
+          "hooks_override": {
+            "$ref": "#/components/schemas/JsonValue"
+          },
+          "keep_alive": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "max_tokens": {
+            "minimum": 0,
+            "type": "integer"
+          },
+          "model": {
+            "type": "string"
+          },
+          "output_schema": {
+            "$ref": "#/components/schemas/JsonValue"
+          },
+          "peer_meta": {
+            "$ref": "#/components/schemas/JsonValue"
+          },
+          "prompt": {
+            "oneOf": [
+              {
+                "type": "string"
+              },
+              {
+                "$ref": "#/components/schemas/WireContentInput"
+              }
+            ]
+          },
+          "provider": {
+            "type": "string"
+          },
+          "session_id": {
+            "type": "string"
+          },
+          "skill_refs": {
+            "items": {
+              "$ref": "#/components/schemas/JsonValue"
+            },
+            "type": "array"
+          },
+          "structured_output_retries": {
+            "minimum": 0,
+            "type": "integer"
+          },
+          "system_prompt": {
+            "type": "string"
+          },
+          "verbose": {
+            "type": "boolean"
+          }
+        },
+        "required": [
+          "session_id",
+          "prompt"
+        ],
+        "type": "object"
+      },
+      "RestCreateSessionRequest": {
+        "properties": {
+          "additional_instructions": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "app_context": {
+            "$ref": "#/components/schemas/JsonValue"
+          },
+          "budget_limits": {
+            "$ref": "#/components/schemas/JsonValue"
+          },
+          "comms_name": {
+            "type": "string"
+          },
+          "enable_builtins": {
+            "type": "boolean"
+          },
+          "enable_memory": {
+            "type": "boolean"
+          },
+          "enable_mob": {
+            "type": "boolean"
+          },
+          "enable_shell": {
+            "type": "boolean"
+          },
+          "hooks_override": {
+            "$ref": "#/components/schemas/JsonValue"
+          },
+          "keep_alive": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "labels": {
+            "additionalProperties": {
+              "type": "string"
+            },
+            "type": "object"
+          },
+          "max_tokens": {
+            "minimum": 0,
+            "type": "integer"
+          },
+          "model": {
+            "type": "string"
+          },
+          "output_schema": {
+            "$ref": "#/components/schemas/JsonValue"
+          },
+          "peer_meta": {
+            "$ref": "#/components/schemas/JsonValue"
+          },
+          "preload_skills": {
+            "items": {
+              "$ref": "#/components/schemas/JsonValue"
+            },
+            "type": "array"
+          },
+          "prompt": {
+            "oneOf": [
+              {
+                "type": "string"
+              },
+              {
+                "$ref": "#/components/schemas/WireContentInput"
+              }
+            ]
+          },
+          "provider": {
+            "type": "string"
+          },
+          "provider_params": {
+            "$ref": "#/components/schemas/JsonValue"
+          },
+          "shell_env": {
+            "additionalProperties": {
+              "type": "string"
+            },
+            "type": "object"
+          },
+          "skill_refs": {
+            "items": {
+              "$ref": "#/components/schemas/JsonValue"
+            },
+            "type": "array"
+          },
+          "structured_output_retries": {
+            "minimum": 0,
+            "type": "integer"
+          },
+          "system_prompt": {
+            "type": "string"
+          },
+          "verbose": {
+            "type": "boolean"
+          }
+        },
+        "required": [
+          "prompt"
+        ],
+        "type": "object"
+      },
+      "RestMobForkHelperRequest": {
+        "properties": {
+          "agent_identity": {
+            "type": "string"
+          },
+          "backend": {
+            "type": "string"
+          },
+          "fork_context": {
+            "$ref": "#/components/schemas/JsonValue"
+          },
+          "prompt": {
+            "type": "string"
+          },
+          "role_name": {
+            "type": "string"
+          },
+          "runtime_mode": {
+            "type": "string"
+          },
+          "source_member_id": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "source_member_id",
+          "prompt"
+        ],
+        "type": "object"
+      },
+      "RestMobHelperRequest": {
+        "properties": {
+          "agent_identity": {
+            "type": "string"
+          },
+          "backend": {
+            "type": "string"
+          },
+          "prompt": {
+            "type": "string"
+          },
+          "role_name": {
+            "type": "string"
+          },
+          "runtime_mode": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "prompt"
+        ],
+        "type": "object"
+      },
+      "RestMobWaitRequest": {
+        "properties": {
+          "member_ids": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "timeout_ms": {
+            "minimum": 0,
+            "type": "integer"
+          }
+        },
+        "required": [],
+        "type": "object"
+      },
+      "RestPatchConfigRequest": {
+        "oneOf": [
+          {
+            "$ref": "#/components/schemas/JsonValue"
+          },
+          {
+            "properties": {
+              "expected_generation": {
+                "minimum": 0,
+                "type": "integer"
+              },
+              "patch": {
+                "$ref": "#/components/schemas/JsonValue"
+              }
+            },
+            "required": [
+              "patch"
+            ],
+            "type": "object"
+          }
+        ]
+      },
+      "RestPeerResponseTerminalRequest": {
+        "properties": {
+          "peer_name": {
+            "type": "string"
+          },
+          "request_id": {
+            "type": "string"
+          },
+          "result": {
+            "$ref": "#/components/schemas/JsonValue"
+          },
+          "status": {
+            "enum": [
+              "completed",
+              "failed"
+            ],
+            "type": "string"
+          }
+        },
+        "required": [
+          "peer_name",
+          "request_id",
+          "status",
+          "result"
+        ],
+        "type": "object"
+      },
+      "RestScheduleToolCallRequest": {
+        "properties": {
+          "arguments": {
+            "$ref": "#/components/schemas/JsonValue"
+          },
+          "name": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "name"
+        ],
+        "type": "object"
+      },
+      "RestSetConfigRequest": {
+        "oneOf": [
+          {
+            "$ref": "#/components/schemas/JsonValue"
+          },
+          {
+            "properties": {
+              "config": {
+                "$ref": "#/components/schemas/JsonValue"
+              },
+              "expected_generation": {
+                "minimum": 0,
+                "type": "integer"
+              }
+            },
+            "required": [
+              "config"
+            ],
+            "type": "object"
+          }
+        ]
+      },
+      "RevisedPromptDisposition": {
+        "oneOf": [
+          {
+            "properties": {
+              "disposition": {
+                "const": "not_requested",
+                "type": "string"
+              }
+            },
+            "required": [
+              "disposition"
+            ],
+            "type": "object"
+          },
+          {
+            "properties": {
+              "disposition": {
+                "const": "unsupported_by_backend",
+                "type": "string"
+              }
+            },
+            "required": [
+              "disposition"
+            ],
+            "type": "object"
+          },
+          {
+            "properties": {
+              "disposition": {
+                "const": "unchanged",
+                "type": "string"
+              }
+            },
+            "required": [
+              "disposition"
+            ],
+            "type": "object"
+          },
+          {
+            "properties": {
+              "disposition": {
+                "const": "revised",
+                "type": "string"
+              },
+              "source": {
+                "$ref": "#/components/schemas/RevisedPromptSource"
+              },
+              "text": {
+                "$ref": "#/components/schemas/PromptText"
+              }
+            },
+            "required": [
+              "disposition",
+              "text",
+              "source"
+            ],
+            "type": "object"
+          }
+        ]
+      },
+      "RevisedPromptSource": {
+        "enum": [
+          "provider",
+          "meerkat_projection"
+        ],
+        "type": "string"
+      },
+      "RuntimeAcceptOutcomeType": {
+        "description": "Discriminator for `runtime/session_submit` responses.",
+        "enum": [
+          "accepted",
+          "deduplicated",
+          "rejected"
+        ],
+        "title": "RuntimeAcceptOutcomeType",
+        "type": "string"
+      },
+      "RuntimeAcceptParams": {
+        "description": "Request payload for `runtime/session_submit`.\n\nThe runtime input body is owned by `meerkat-runtime`; contracts cannot\ndepend on the runtime crate without inverting the dependency graph. The\nenvelope is canonical here and the runtime crate remains the typed\nauthority over the `input` discriminator and variant body.",
+        "properties": {
+          "input": true,
+          "session_id": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "session_id",
+          "input"
+        ],
+        "title": "RuntimeAcceptParams",
+        "type": "object"
+      },
+      "RuntimeAcceptResult": {
+        "description": "Response payload for `runtime/session_submit`.",
+        "properties": {
+          "existing_id": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "input_id": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "outcome_type": {
+            "$ref": "#/components/schemas/RuntimeAcceptOutcomeType"
+          },
+          "policy": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/WireInputPolicy"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "reason": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "state": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/WireInputState"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          }
+        },
+        "required": [
+          "outcome_type"
+        ],
+        "title": "RuntimeAcceptResult",
+        "type": "object"
+      },
+      "RuntimeDeliveryOutcome": {
+        "oneOf": [
+          {
+            "properties": {
+              "detail": {
+                "type": "string"
+              },
+              "kind": {
+                "const": "admission_rejected",
+                "type": "string"
+              }
+            },
+            "required": [
+              "kind",
+              "detail"
+            ],
+            "type": "object"
+          },
+          {
+            "properties": {
+              "detail": {
+                "type": "string"
+              },
+              "kind": {
+                "const": "completion_abandoned",
+                "type": "string"
+              }
+            },
+            "required": [
+              "kind",
+              "detail"
+            ],
+            "type": "object"
+          },
+          {
+            "properties": {
+              "kind": {
+                "const": "completion_callback_pending",
+                "type": "string"
+              },
+              "payload": true,
+              "tool_name": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "kind",
+              "tool_name",
+              "payload"
+            ],
+            "type": "object"
+          },
+          {
+            "properties": {
+              "detail": {
+                "type": "string"
+              },
+              "kind": {
+                "const": "completion_runtime_terminated",
+                "type": "string"
+              }
+            },
+            "required": [
+              "kind",
+              "detail"
+            ],
+            "type": "object"
+          }
+        ]
+      },
+      "RuntimeHostCapabilities": {
+        "description": "Runtime capability surface for a host.",
+        "properties": {
+          "contract_version": {
+            "$ref": "#/components/schemas/ContractVersion"
+          },
+          "features": {
+            "$ref": "#/components/schemas/RuntimeHostFeatureFlags"
+          }
+        },
+        "required": [
+          "contract_version",
+          "features"
+        ],
+        "title": "RuntimeHostCapabilities",
+        "type": "object"
+      },
+      "RuntimeHostEndpointProjection": {
+        "description": "Endpoint metadata that reports surface reachability without owning it.",
+        "properties": {
+          "rest_base_url": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "rest_paths": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "rpc_methods": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "rpc_transport": {
+            "type": [
+              "string",
+              "null"
+            ]
+          }
+        },
+        "title": "RuntimeHostEndpointProjection",
+        "type": "object"
+      },
+      "RuntimeHostFeatureFlags": {
+        "description": "Existing host capability facts exposed as typed booleans.",
+        "properties": {
+          "approvals": {
+            "type": "boolean"
+          },
+          "artifacts": {
+            "type": "boolean"
+          },
+          "blobs": {
+            "type": "boolean"
+          },
+          "comms": {
+            "type": "boolean"
+          },
+          "event_replay": {
+            "type": "boolean"
+          },
+          "external_members": {
+            "type": "boolean"
+          },
+          "mcp_live": {
+            "type": "boolean"
+          },
+          "mobs": {
+            "type": "boolean"
+          },
+          "runtime_backed_sessions": {
+            "type": "boolean"
+          },
+          "schedules": {
+            "type": "boolean"
+          },
+          "secure_remote_rpc": {
+            "type": "boolean"
+          },
+          "session_events": {
+            "type": "boolean"
+          },
+          "session_streams": {
+            "type": "boolean"
+          },
+          "skills": {
+            "type": "boolean"
+          }
+        },
+        "required": [
+          "runtime_backed_sessions",
+          "mobs",
+          "mcp_live",
+          "comms",
+          "blobs",
+          "session_events",
+          "session_streams",
+          "schedules",
+          "skills",
+          "event_replay",
+          "artifacts",
+          "approvals",
+          "external_members",
+          "secure_remote_rpc"
+        ],
+        "type": "object"
+      },
+      "RuntimeHostHealth": {
+        "description": "Runtime health projection for a host.",
+        "properties": {
+          "checks": {
+            "additionalProperties": {
+              "$ref": "#/components/schemas/RuntimeHostHealthStatus"
+            },
+            "type": "object"
+          },
+          "contract_version": {
+            "$ref": "#/components/schemas/ContractVersion"
+          },
+          "status": {
+            "$ref": "#/components/schemas/RuntimeHostHealthStatus"
+          }
+        },
+        "required": [
+          "contract_version",
+          "status"
+        ],
+        "title": "RuntimeHostHealth",
+        "type": "object"
+      },
+      "RuntimeHostHealthStatus": {
+        "description": "Health state of the host process as observed by the reporting surface.",
+        "enum": [
+          "ok",
+          "degraded",
+          "unhealthy"
+        ],
+        "type": "string"
+      },
+      "RuntimeHostIdScope": {
+        "description": "Scope of stability for a reported runtime host id.",
+        "oneOf": [
+          {
+            "const": "process",
+            "description": "Stable for the current runtime process only.",
+            "type": "string"
+          },
+          {
+            "const": "realm_instance",
+            "description": "Derived from an explicit realm and instance pairing.",
+            "type": "string"
+          }
+        ],
+        "title": "RuntimeHostIdScope"
+      },
+      "RuntimeHostInfo": {
+        "description": "Read-only host information. This is a projection, not a registry entry.",
+        "properties": {
+          "capabilities": {
+            "$ref": "#/components/schemas/RuntimeHostCapabilities"
+          },
+          "contract_version": {
+            "$ref": "#/components/schemas/ContractVersion"
+          },
+          "endpoints": {
+            "$ref": "#/components/schemas/RuntimeHostEndpointProjection"
+          },
+          "health": {
+            "$ref": "#/components/schemas/RuntimeHostHealth"
+          },
+          "host_id": {
+            "type": "string"
+          },
+          "host_id_scope": {
+            "$ref": "#/components/schemas/RuntimeHostIdScope"
+          },
+          "placement_labels": {
+            "additionalProperties": {
+              "type": "string"
+            },
+            "type": "object"
+          },
+          "policy_profile_summary": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "process_name": {
+            "type": "string"
+          },
+          "process_version": {
+            "type": "string"
+          },
+          "realm": {
+            "$ref": "#/components/schemas/RuntimeHostRealmProjection"
+          }
+        },
+        "required": [
+          "contract_version",
+          "host_id",
+          "host_id_scope",
+          "process_name",
+          "process_version",
+          "capabilities",
+          "health",
+          "realm",
+          "endpoints"
+        ],
+        "title": "RuntimeHostInfo",
+        "type": "object"
+      },
+      "RuntimeHostRealmProjection": {
+        "description": "Realm/config metadata projected from the owning config store.",
+        "properties": {
+          "backend": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "context_root": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "instance_id": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "realm_id": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "state_root": {
+            "type": [
+              "string",
+              "null"
+            ]
+          }
+        },
+        "type": "object"
+      },
+      "RuntimeRealtimeAttachmentStatusParams": {
+        "description": "Request payload for `session/realtime_attachment_status`.",
+        "properties": {
+          "session_id": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "session_id"
+        ],
+        "title": "RuntimeRealtimeAttachmentStatusParams",
+        "type": "object"
+      },
+      "RuntimeRealtimeAttachmentStatusResult": {
+        "description": "Response payload for `session/realtime_attachment_status`.",
+        "properties": {
+          "status": {
+            "$ref": "#/components/schemas/WireRealtimeAttachmentStatus"
+          }
+        },
+        "required": [
+          "status"
+        ],
+        "title": "RuntimeRealtimeAttachmentStatusResult",
+        "type": "object"
+      },
+      "RuntimeResetParams": {
+        "description": "Request payload for `runtime/session_reset`.",
+        "properties": {
+          "session_id": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "session_id"
+        ],
+        "title": "RuntimeResetParams",
+        "type": "object"
+      },
+      "RuntimeResetResult": {
+        "description": "Response payload for `runtime/session_reset`.",
+        "properties": {
+          "inputs_abandoned": {
+            "format": "uint",
+            "minimum": 0,
+            "type": "integer"
+          }
+        },
+        "required": [
+          "inputs_abandoned"
+        ],
+        "title": "RuntimeResetResult",
+        "type": "object"
+      },
+      "RuntimeRetireParams": {
+        "description": "Request payload for `runtime/session_retire`.",
+        "properties": {
+          "session_id": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "session_id"
+        ],
+        "title": "RuntimeRetireParams",
+        "type": "object"
+      },
+      "RuntimeRetireResult": {
+        "description": "Response payload for `runtime/session_retire`.",
+        "properties": {
+          "inputs_abandoned": {
+            "format": "uint",
+            "minimum": 0,
+            "type": "integer"
+          },
+          "inputs_pending_drain": {
+            "default": 0,
+            "format": "uint",
+            "minimum": 0,
+            "type": "integer"
+          }
+        },
+        "required": [
+          "inputs_abandoned"
+        ],
+        "title": "RuntimeRetireResult",
+        "type": "object"
+      },
+      "RuntimeStateParams": {
+        "description": "Request payload for `runtime/session_status`.",
+        "properties": {
+          "session_id": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "session_id"
+        ],
+        "title": "RuntimeStateParams",
+        "type": "object"
+      },
+      "RuntimeStateResult": {
+        "description": "Response payload for `runtime/session_status`.",
+        "properties": {
+          "state": {
+            "$ref": "#/components/schemas/WireRuntimeState"
+          }
+        },
+        "required": [
+          "state"
+        ],
+        "title": "RuntimeStateResult",
+        "type": "object"
+      },
+      "Schedule": {
+        "properties": {
+          "created_at_utc": {
+            "format": "date-time",
+            "type": "string"
+          },
+          "deleted_at_utc": {
+            "format": "date-time",
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "description": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "labels": {
+            "additionalProperties": {
+              "type": "string"
+            },
+            "type": "object"
+          },
+          "misfire_policy": {
+            "$ref": "#/components/schemas/MisfirePolicy",
+            "default": {
+              "type": "skip"
+            }
+          },
+          "missing_target_policy": {
+            "$ref": "#/components/schemas/MissingTargetPolicy",
+            "default": "mark_misfired"
+          },
+          "name": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "next_occurrence_ordinal": {
+            "format": "uint64",
+            "minimum": 0,
+            "type": "integer"
+          },
+          "overlap_policy": {
+            "$ref": "#/components/schemas/OverlapPolicy",
+            "default": "skip_if_running"
+          },
+          "phase": {
+            "$ref": "#/components/schemas/SchedulePhase"
+          },
+          "planning_cursor_utc": {
+            "format": "date-time",
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "planning_horizon_days": {
+            "default": 30,
+            "format": "uint32",
+            "minimum": 0,
+            "type": "integer"
+          },
+          "planning_horizon_occurrences": {
+            "default": 64,
+            "format": "uint32",
+            "minimum": 0,
+            "type": "integer"
+          },
+          "revision": {
+            "format": "uint64",
+            "minimum": 0,
+            "type": "integer"
+          },
+          "schedule_id": {
+            "$ref": "#/components/schemas/ScheduleId"
+          },
+          "superseded_ack_ids": {
+            "items": {
+              "$ref": "#/components/schemas/OccurrenceId"
+            },
+            "type": "array",
+            "uniqueItems": true
+          },
+          "target": {
+            "$ref": "#/components/schemas/TargetBinding"
+          },
+          "trigger": {
+            "$ref": "#/components/schemas/TriggerSpec"
+          },
+          "updated_at_utc": {
+            "format": "date-time",
+            "type": "string"
+          }
+        },
+        "required": [
+          "schedule_id",
+          "phase",
+          "revision",
+          "trigger",
+          "target",
+          "next_occurrence_ordinal",
+          "created_at_utc",
+          "updated_at_utc"
+        ],
+        "type": "object"
+      },
+      "ScheduleId": {
+        "description": "Opaque identifier for a persisted schedule.",
+        "type": "string"
+      },
+      "ScheduleIdParams": {
+        "properties": {
+          "schedule_id": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "schedule_id"
+        ],
+        "title": "ScheduleIdParams",
+        "type": "object"
+      },
+      "ScheduleListResult": {
+        "properties": {
+          "schedules": {
+            "items": {
+              "$ref": "#/components/schemas/Schedule"
+            },
+            "type": "array"
+          }
+        },
+        "required": [
+          "schedules"
+        ],
+        "title": "ScheduleListResult",
+        "type": "object"
+      },
+      "ScheduleOccurrencesParams": {
+        "properties": {
+          "include_terminal": {
+            "type": [
+              "boolean",
+              "null"
+            ]
+          },
+          "schedule_id": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "schedule_id"
+        ],
+        "title": "ScheduleOccurrencesParams",
+        "type": "object"
+      },
+      "ScheduleOccurrencesResult": {
+        "properties": {
+          "occurrences": {
+            "items": {
+              "$ref": "#/components/schemas/Occurrence"
+            },
+            "type": "array"
+          }
+        },
+        "required": [
+          "occurrences"
+        ],
+        "title": "ScheduleOccurrencesResult",
+        "type": "object"
+      },
+      "SchedulePhase": {
+        "enum": [
+          "active",
+          "paused",
+          "deleted"
+        ],
+        "type": "string"
+      },
+      "ScheduledMobAction": {
+        "oneOf": [
+          {
+            "properties": {
+              "content": {
+                "$ref": "#/components/schemas/ContentInput"
+              },
+              "render_metadata": {
+                "anyOf": [
+                  {
+                    "$ref": "#/components/schemas/RenderMetadata"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
+              },
+              "type": {
+                "const": "send",
+                "type": "string"
+              }
+            },
+            "required": [
+              "type",
+              "content"
+            ],
+            "type": "object"
+          }
+        ]
+      },
+      "ScheduledMobBackendKind": {
+        "enum": [
+          "session",
+          "external"
+        ],
+        "type": "string"
+      },
+      "ScheduledMobRuntimeMode": {
+        "enum": [
+          "autonomous_host",
+          "turn_driven"
+        ],
+        "type": "string"
+      },
+      "ScheduledSessionAction": {
+        "oneOf": [
+          {
+            "properties": {
+              "additional_instructions": {
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              },
+              "prompt": {
+                "$ref": "#/components/schemas/ContentInput"
+              },
+              "render_metadata": {
+                "anyOf": [
+                  {
+                    "$ref": "#/components/schemas/RenderMetadata"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
+              },
+              "skill_refs": {
+                "items": {
+                  "$ref": "#/components/schemas/SkillRef"
+                },
+                "type": "array"
+              },
+              "system_prompt": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "type": {
+                "const": "prompt",
+                "type": "string"
+              }
+            },
+            "required": [
+              "type",
+              "prompt"
+            ],
+            "type": "object"
+          },
+          {
+            "properties": {
+              "event_type": {
+                "type": "string"
+              },
+              "payload": true,
+              "render_metadata": {
+                "anyOf": [
+                  {
+                    "$ref": "#/components/schemas/RenderMetadata"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
+              },
+              "type": {
+                "const": "event",
+                "type": "string"
+              }
+            },
+            "required": [
+              "type",
+              "event_type",
+              "payload"
+            ],
+            "type": "object"
+          }
+        ]
+      },
+      "SchemaCompat": {
+        "description": "Compatibility mode for provider lowering.",
+        "enum": [
+          "lossy",
+          "strict"
+        ],
+        "type": "string"
+      },
+      "SchemaFormat": {
+        "description": "Schema format versions supported by Meerkat.",
+        "enum": [
+          "meerkat_v1"
+        ],
+        "type": "string"
+      },
+      "SchemaWarning": {
+        "description": "Warnings emitted during schema lowering.",
+        "properties": {
+          "message": {
+            "type": "string"
+          },
+          "path": {
+            "type": "string"
+          },
+          "provider": {
+            "$ref": "#/components/schemas/Provider"
+          }
+        },
+        "required": [
+          "provider",
+          "path",
+          "message"
+        ],
+        "type": "object"
+      },
+      "ScopedModelOverrideId": {
+        "type": "string"
+      },
+      "ScopedModelOverrideKind": {
+        "oneOf": [
+          {
+            "properties": {
+              "kind": {
+                "const": "image_operation",
+                "type": "string"
+              },
+              "operation_id": {
+                "$ref": "#/components/schemas/ImageOperationId"
+              }
+            },
+            "required": [
+              "kind",
+              "operation_id"
+            ],
+            "type": "object"
+          },
+          {
+            "properties": {
+              "duration": {
+                "$ref": "#/components/schemas/FiniteScopedTurnDuration"
+              },
+              "kind": {
+                "const": "finite_switch_turn",
+                "type": "string"
+              },
+              "request_id": {
+                "$ref": "#/components/schemas/SwitchTurnRequestId"
+              }
+            },
+            "required": [
+              "kind",
+              "request_id",
+              "duration"
+            ],
+            "type": "object"
+          }
+        ]
+      },
+      "ScopedModelOverrideSummary": {
+        "properties": {
+          "id": {
+            "$ref": "#/components/schemas/ScopedModelOverrideId"
+          },
+          "kind": {
+            "$ref": "#/components/schemas/ScopedModelOverrideKind"
+          },
+          "target_model": {
+            "type": "string"
+          },
+          "topology_epoch": {
+            "format": "uint64",
+            "minimum": 0,
+            "type": "integer"
+          }
+        },
+        "required": [
+          "id",
+          "kind",
+          "target_model",
+          "topology_epoch"
+        ],
+        "type": "object"
+      },
+      "SessionDetailsResponse": {
+        "properties": {
+          "created_at": {
+            "type": "string"
+          },
+          "labels": {
+            "additionalProperties": {
+              "type": "string"
+            },
+            "type": "object"
+          },
+          "message_count": {
+            "minimum": 0,
+            "type": "integer"
+          },
+          "session_id": {
+            "type": "string"
+          },
+          "session_ref": {
+            "type": "string"
+          },
+          "total_tokens": {
+            "minimum": 0,
+            "type": "integer"
+          },
+          "updated_at": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "session_id",
+          "session_ref",
+          "created_at",
+          "updated_at",
+          "message_count",
+          "total_tokens"
+        ],
+        "type": "object"
+      },
+      "SessionId": {
+        "description": "Unique identifier for a session (UUID v7 for time-ordering)",
+        "type": "string"
+      },
+      "SessionMaterializationSpec": {
+        "properties": {
+          "additional_instructions": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "app_context": true,
+          "backend": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "comms_name": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "config_generation": {
+            "format": "uint64",
+            "minimum": 0,
+            "type": [
+              "integer",
+              "null"
+            ]
+          },
+          "instance_id": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "keep_alive": {
+            "default": false,
+            "type": "boolean"
+          },
+          "labels": {
+            "additionalProperties": {
+              "type": "string"
+            },
+            "type": "object"
+          },
+          "max_tokens": {
+            "format": "uint32",
+            "minimum": 0,
+            "type": [
+              "integer",
+              "null"
+            ]
+          },
+          "model": {
+            "type": "string"
+          },
+          "output_schema": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/OutputSchema"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "peer_meta": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/PeerMeta"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "preload_skills": {
+            "items": {
+              "$ref": "#/components/schemas/SkillKey"
+            },
+            "type": "array"
+          },
+          "provider": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/Provider"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "provider_params": true,
+          "realm_id": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "structured_output_retries": {
+            "default": 0,
+            "format": "uint32",
+            "minimum": 0,
+            "type": "integer"
+          },
+          "system_prompt": {
+            "type": [
+              "string",
+              "null"
+            ]
+          }
+        },
+        "required": [
+          "model"
+        ],
+        "type": "object"
+      },
+      "SessionTargetBinding": {
+        "oneOf": [
+          {
+            "properties": {
+              "action": {
+                "$ref": "#/components/schemas/ScheduledSessionAction"
+              },
+              "session_id": {
+                "$ref": "#/components/schemas/SessionId"
+              },
+              "type": {
+                "const": "exact_session",
+                "type": "string"
+              }
+            },
+            "required": [
+              "type",
+              "session_id",
+              "action"
+            ],
+            "type": "object"
+          },
+          {
+            "properties": {
+              "action": {
+                "$ref": "#/components/schemas/ScheduledSessionAction"
+              },
+              "session_id": {
+                "$ref": "#/components/schemas/SessionId"
+              },
+              "type": {
+                "const": "resumable_session",
+                "type": "string"
+              }
+            },
+            "required": [
+              "type",
+              "session_id",
+              "action"
+            ],
+            "type": "object"
+          },
+          {
+            "properties": {
+              "action": {
+                "$ref": "#/components/schemas/ScheduledSessionAction"
+              },
+              "bound_session_id": {
+                "anyOf": [
+                  {
+                    "$ref": "#/components/schemas/SessionId"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
+              },
+              "create": {
+                "$ref": "#/components/schemas/SessionMaterializationSpec"
+              },
+              "type": {
+                "const": "materialize_on_demand_session",
+                "type": "string"
+              }
+            },
+            "required": [
+              "type",
+              "create",
+              "action"
+            ],
+            "type": "object"
+          }
+        ]
+      },
+      "SkillEntry": {
+        "description": "Wire representation of a skill entry (for list responses).",
+        "properties": {
+          "description": {
+            "description": "Short description.",
+            "type": "string"
+          },
+          "is_active": {
+            "description": "Whether this skill is active (not shadowed by a higher-precedence source).",
+            "type": "boolean"
+          },
+          "key": {
+            "$ref": "#/components/schemas/SkillKey",
+            "description": "Canonical skill identity."
+          },
+          "name": {
+            "description": "Human-readable name.",
+            "type": "string"
+          },
+          "scope": {
+            "description": "Scope: \"builtin\", \"project\", or \"user\".",
+            "type": "string"
+          },
+          "shadowed_by": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/SkillSourceProvenance"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "If shadowed, the higher-precedence source identity."
+          },
+          "source": {
+            "$ref": "#/components/schemas/SkillSourceProvenance",
+            "description": "Typed source provenance."
+          }
+        },
+        "required": [
+          "key",
+          "name",
+          "description",
+          "scope",
+          "source",
+          "is_active"
+        ],
+        "title": "SkillEntry",
+        "type": "object"
+      },
+      "SkillInspectResponse": {
+        "description": "Wire response for inspecting a single skill.",
+        "properties": {
+          "body": {
+            "description": "Full skill body (markdown content).",
+            "type": "string"
+          },
+          "description": {
+            "description": "Short description.",
+            "type": "string"
+          },
+          "key": {
+            "$ref": "#/components/schemas/SkillKey",
+            "description": "Canonical skill identity."
+          },
+          "name": {
+            "description": "Human-readable name.",
+            "type": "string"
+          },
+          "scope": {
+            "description": "Scope: \"builtin\", \"project\", or \"user\".",
+            "type": "string"
+          },
+          "source": {
+            "$ref": "#/components/schemas/SkillSourceProvenance",
+            "description": "Typed source provenance."
+          }
+        },
+        "required": [
+          "key",
+          "name",
+          "description",
+          "scope",
+          "source",
+          "body"
+        ],
+        "title": "SkillInspectResponse",
+        "type": "object"
+      },
+      "SkillKey": {
+        "description": "Canonical runtime identity for a skill.\n\nThis is the single identity carried across every surface — the wire parses\ndirectly into this struct, tools receive this struct, the registry stores\nthis struct. There is no slash-delimited string path form.",
+        "properties": {
+          "skill_name": {
+            "$ref": "#/components/schemas/SkillName"
+          },
+          "source_uuid": {
+            "$ref": "#/components/schemas/SourceUuid"
+          }
+        },
+        "required": [
+          "source_uuid",
+          "skill_name"
+        ],
+        "type": "object"
+      },
+      "SkillListResponse": {
+        "description": "Wire response for listing skills with introspection data.",
+        "properties": {
+          "skills": {
+            "items": {
+              "$ref": "#/components/schemas/SkillEntry"
+            },
+            "type": "array"
+          }
+        },
+        "required": [
+          "skills"
+        ],
+        "title": "SkillListResponse",
+        "type": "object"
+      },
+      "SkillName": {
+        "description": "Canonical skill slug (lowercase, dash-separated).",
+        "type": "string"
+      },
+      "SkillQuarantineDiagnostic": {
+        "description": "Per-skill quarantine diagnostic.",
+        "properties": {
+          "error_class": {
+            "type": "string"
+          },
+          "error_code": {
+            "type": "string"
+          },
+          "first_seen_unix_secs": {
+            "format": "uint64",
+            "minimum": 0,
+            "type": "integer"
+          },
+          "key": {
+            "$ref": "#/components/schemas/SkillKey"
+          },
+          "last_seen_unix_secs": {
+            "format": "uint64",
+            "minimum": 0,
+            "type": "integer"
+          },
+          "location": {
+            "type": "string"
+          },
+          "message": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "key",
+          "location",
+          "error_code",
+          "error_class",
+          "message",
+          "first_seen_unix_secs",
+          "last_seen_unix_secs"
+        ],
+        "type": "object"
+      },
+      "SkillRef": {
+        "description": "Structured skill reference for wire/surface input.\n\nPost-V4 this has exactly one variant — `Structured` — and is kept only as a\ntyped enum to leave room for future source-scoped variants (e.g. alias or\ncapability-scoped forms) without changing the trait surface. No legacy\nstring form, no slash-delimited path, no untagged fallback.",
+        "oneOf": [
+          {
+            "$ref": "#/components/schemas/SkillKey",
+            "properties": {
+              "kind": {
+                "const": "structured",
+                "type": "string"
+              }
+            },
+            "required": [
+              "kind"
+            ],
+            "type": "object"
+          }
+        ]
+      },
+      "SkillRuntimeDiagnostics": {
+        "description": "Runtime-visible diagnostics for skill health and quarantined entries.",
+        "properties": {
+          "quarantined": {
+            "items": {
+              "$ref": "#/components/schemas/SkillQuarantineDiagnostic"
+            },
+            "type": "array"
+          },
+          "source_health": {
+            "$ref": "#/components/schemas/SourceHealthSnapshot"
+          }
+        },
+        "required": [
+          "source_health",
+          "quarantined"
+        ],
+        "type": "object"
+      },
+      "SkillSourceProvenance": {
+        "description": "Typed source provenance for a skill entry. `display_name` is presentation\nmetadata only; `source_uuid` is the stable identity.",
+        "properties": {
+          "display_name": {
+            "type": "string"
+          },
+          "fingerprint": {
+            "type": "string"
+          },
+          "source_uuid": {
+            "$ref": "#/components/schemas/SourceUuid"
+          },
+          "status": {
+            "$ref": "#/components/schemas/SourceIdentityStatus",
+            "default": "active"
+          },
+          "transport_kind": {
+            "$ref": "#/components/schemas/SourceTransportKind"
+          }
+        },
+        "required": [
+          "source_uuid",
+          "display_name",
+          "transport_kind",
+          "fingerprint"
+        ],
+        "type": "object"
+      },
+      "SkillsParams": {
+        "description": "Skills parameters for session/turn requests.\n\n`preload_skills` and `skill_refs` both carry typed `SkillKey`s — there is\nno legacy string path. Wire ingress parses JSON objects directly to\n`SkillKey` (`{\"source_uuid\":\"…\",\"skill_name\":\"…\"}`); malformed input is a\ntyped ingress error, not a legacy-upgrade.\n\n`Some([])` is normalized to `None` to prevent silent misconfiguration.",
+        "properties": {
+          "preload_skills": {
+            "items": {
+              "$ref": "#/components/schemas/SkillKey"
+            },
+            "type": [
+              "array",
+              "null"
+            ]
+          },
+          "skill_refs": {
+            "items": {
+              "$ref": "#/components/schemas/SkillRef"
+            },
+            "type": [
+              "array",
+              "null"
+            ]
+          }
+        },
+        "title": "SkillsParams",
+        "type": "object"
+      },
+      "SourceHealthSnapshot": {
+        "description": "Source health snapshot reported by sources.",
+        "properties": {
+          "failure_streak": {
+            "format": "uint32",
+            "minimum": 0,
+            "type": "integer"
+          },
+          "handshake_failed": {
+            "type": "boolean"
+          },
+          "invalid_count": {
+            "format": "uint32",
+            "minimum": 0,
+            "type": "integer"
+          },
+          "invalid_ratio": {
+            "format": "float",
+            "type": "number"
+          },
+          "state": {
+            "$ref": "#/components/schemas/SourceHealthState"
+          },
+          "total_count": {
+            "format": "uint32",
+            "minimum": 0,
+            "type": "integer"
+          }
+        },
+        "required": [
+          "state",
+          "invalid_ratio",
+          "invalid_count",
+          "total_count",
+          "failure_streak",
+          "handshake_failed"
+        ],
+        "type": "object"
+      },
+      "SourceHealthState": {
+        "description": "Source health state.",
+        "enum": [
+          "healthy",
+          "degraded",
+          "unhealthy"
+        ],
+        "type": "string"
+      },
+      "SourceIdentityStatus": {
+        "description": "Source lifecycle status in the identity registry.",
+        "enum": [
+          "active",
+          "disabled",
+          "retired"
+        ],
+        "type": "string"
+      },
+      "SourceTransportKind": {
+        "description": "Source transport class used for identity governance.",
+        "enum": [
+          "embedded",
+          "filesystem",
+          "git",
+          "http",
+          "stdio"
+        ],
+        "type": "string"
+      },
+      "SourceUuid": {
+        "description": "Canonical source identifier.",
+        "type": "string"
+      },
+      "SseEventStream": {
+        "description": "Server-sent event stream.",
+        "type": "string"
+      },
+      "StatusResponse": {
+        "additionalProperties": true,
+        "type": "object"
+      },
+      "StructuredProviderExtension": {
+        "description": "Typed non-semantic opaque bag for per-turn provider knobs that cannot be\nfully typed without blocking a wave boundary. Explicitly marked\nnon-semantic and RMAT-exempt.\n\nUse of this type is a deliberate boundary marker: content is passed\nthrough without interpretation. Any consumer that needs to interpret the\ncontent must promote the relevant structure into a proper typed variant\nin its own wave.\n\nRelocated from `meerkat_contracts::wire::runtime` into core so\n`ProviderTag::Unknown { bag }` can name the bag without a cross-crate\ncycle (adversarial review flaw 5). `meerkat-contracts` re-exports this\ntype so the wire path is preserved.",
+        "properties": {
+          "body": {
+            "default": "",
+            "description": "Opaque body. Non-semantic — never pattern matched across the wire.",
+            "type": "string"
+          },
+          "key": {
+            "description": "Opaque key identifying the extension within the namespace.",
+            "type": "string"
+          },
+          "namespace": {
+            "description": "Free-form provider namespace discriminator (e.g. `\"anthropic\"`).",
+            "type": "string"
+          }
+        },
+        "required": [
+          "namespace",
+          "key"
+        ],
+        "type": "object"
+      },
+      "SwitchTurnApprovalReason": {
+        "enum": [
+          "cross_provider",
+          "cost_exceeds_threshold",
+          "safety_hold",
+          "until_changed_from_model_origin",
+          "realtime_detach_required"
+        ],
+        "type": "string"
+      },
+      "SwitchTurnDenialReason": {
+        "oneOf": [
+          {
+            "properties": {
+              "reason": {
+                "const": "unsupported_model",
+                "type": "string"
+              }
+            },
+            "required": [
+              "reason"
+            ],
+            "type": "object"
+          },
+          {
+            "properties": {
+              "reason": {
+                "const": "capability_policy",
+                "type": "string"
+              }
+            },
+            "required": [
+              "reason"
+            ],
+            "type": "object"
+          },
+          {
+            "properties": {
+              "reason": {
+                "const": "cost_policy",
+                "type": "string"
+              }
+            },
+            "required": [
+              "reason"
+            ],
+            "type": "object"
+          },
+          {
+            "properties": {
+              "reason": {
+                "const": "safety_policy",
+                "type": "string"
+              }
+            },
+            "required": [
+              "reason"
+            ],
+            "type": "object"
+          },
+          {
+            "properties": {
+              "reason": {
+                "const": "approval_required_but_unavailable",
+                "type": "string"
+              }
+            },
+            "required": [
+              "reason"
+            ],
+            "type": "object"
+          },
+          {
+            "properties": {
+              "approvable": {
+                "$ref": "#/components/schemas/SwitchTurnApprovalReason"
+              },
+              "reason": {
+                "const": "denied_during_approval",
+                "type": "string"
+              }
+            },
+            "required": [
+              "reason",
+              "approvable"
+            ],
+            "type": "object"
+          },
+          {
+            "properties": {
+              "reason": {
+                "const": "scoped_override_conflict",
+                "type": "string"
+              }
+            },
+            "required": [
+              "reason"
+            ],
+            "type": "object"
+          },
+          {
+            "properties": {
+              "reason": {
+                "const": "realtime_transport_conflict",
+                "type": "string"
+              }
+            },
+            "required": [
+              "reason"
+            ],
+            "type": "object"
+          },
+          {
+            "properties": {
+              "reason": {
+                "const": "projection_unsupported",
+                "type": "string"
+              }
+            },
+            "required": [
+              "reason"
+            ],
+            "type": "object"
+          }
+        ]
+      },
+      "SwitchTurnDuration": {
+        "oneOf": [
+          {
+            "properties": {
+              "duration": {
+                "$ref": "#/components/schemas/FiniteScopedTurnDuration"
+              },
+              "duration_type": {
+                "const": "finite",
+                "type": "string"
+              }
+            },
+            "required": [
+              "duration_type",
+              "duration"
+            ],
+            "type": "object"
+          },
+          {
+            "properties": {
+              "duration_type": {
+                "const": "until_changed",
+                "type": "string"
+              }
+            },
+            "required": [
+              "duration_type"
+            ],
+            "type": "object"
+          }
+        ]
+      },
+      "SwitchTurnOrigin": {
+        "oneOf": [
+          {
+            "properties": {
+              "origin": {
+                "const": "user",
+                "type": "string"
+              },
+              "reason": {
+                "$ref": "#/components/schemas/SwitchTurnReasonTextDisposition"
+              }
+            },
+            "required": [
+              "origin",
+              "reason"
+            ],
+            "type": "object"
+          },
+          {
+            "properties": {
+              "origin": {
+                "const": "model",
+                "type": "string"
+              },
+              "reason": {
+                "$ref": "#/components/schemas/SwitchTurnReasonTextDisposition"
+              }
+            },
+            "required": [
+              "origin",
+              "reason"
+            ],
+            "type": "object"
+          },
+          {
+            "properties": {
+              "origin": {
+                "const": "system_policy",
+                "type": "string"
+              },
+              "reason": {
+                "$ref": "#/components/schemas/SwitchTurnPolicyReason"
+              }
+            },
+            "required": [
+              "origin",
+              "reason"
+            ],
+            "type": "object"
+          }
+        ]
+      },
+      "SwitchTurnPhase": {
+        "oneOf": [
+          {
+            "properties": {
+              "phase": {
+                "const": "requested",
+                "type": "string"
+              }
+            },
+            "required": [
+              "phase"
+            ],
+            "type": "object"
+          },
+          {
+            "properties": {
+              "phase": {
+                "const": "validating",
+                "type": "string"
+              }
+            },
+            "required": [
+              "phase"
+            ],
+            "type": "object"
+          },
+          {
+            "properties": {
+              "phase": {
+                "const": "pending_for_boundary",
+                "type": "string"
+              }
+            },
+            "required": [
+              "phase"
+            ],
+            "type": "object"
+          },
+          {
+            "properties": {
+              "approval_id": {
+                "$ref": "#/components/schemas/ApprovalId"
+              },
+              "phase": {
+                "const": "awaiting_approval",
+                "type": "string"
+              }
+            },
+            "required": [
+              "phase",
+              "approval_id"
+            ],
+            "type": "object"
+          },
+          {
+            "properties": {
+              "phase": {
+                "const": "applying_finite_override",
+                "type": "string"
+              }
+            },
+            "required": [
+              "phase"
+            ],
+            "type": "object"
+          },
+          {
+            "properties": {
+              "phase": {
+                "const": "applying_persistent_reconfigure",
+                "type": "string"
+              }
+            },
+            "required": [
+              "phase"
+            ],
+            "type": "object"
+          },
+          {
+            "properties": {
+              "phase": {
+                "const": "active_finite_override",
+                "type": "string"
+              }
+            },
+            "required": [
+              "phase"
+            ],
+            "type": "object"
+          },
+          {
+            "properties": {
+              "phase": {
+                "const": "restoring_finite_override",
+                "type": "string"
+              }
+            },
+            "required": [
+              "phase"
+            ],
+            "type": "object"
+          },
+          {
+            "properties": {
+              "phase": {
+                "const": "terminal",
+                "type": "string"
+              },
+              "terminal": {
+                "$ref": "#/components/schemas/SwitchTurnTerminalClass"
+              }
+            },
+            "required": [
+              "phase",
+              "terminal"
+            ],
+            "type": "object"
+          }
+        ]
+      },
+      "SwitchTurnPolicyReason": {
+        "enum": [
+          "budget_downgrade",
+          "safety_handoff",
+          "release_temporary_hold"
+        ],
+        "type": "string"
+      },
+      "SwitchTurnReasonText": {
+        "properties": {
+          "content": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "content"
+        ],
+        "type": "object"
+      },
+      "SwitchTurnReasonTextDisposition": {
+        "oneOf": [
+          {
+            "properties": {
+              "disposition": {
+                "const": "not_provided",
+                "type": "string"
+              }
+            },
+            "required": [
+              "disposition"
+            ],
+            "type": "object"
+          },
+          {
+            "properties": {
+              "disposition": {
+                "const": "provided",
+                "type": "string"
+              },
+              "reason": {
+                "$ref": "#/components/schemas/SwitchTurnReasonText"
+              }
+            },
+            "required": [
+              "disposition",
+              "reason"
+            ],
+            "type": "object"
+          }
+        ]
+      },
+      "SwitchTurnRequestId": {
+        "type": "string"
+      },
+      "SwitchTurnRequestSummary": {
+        "properties": {
+          "duration": {
+            "$ref": "#/components/schemas/SwitchTurnDuration"
+          },
+          "phase": {
+            "$ref": "#/components/schemas/SwitchTurnPhase"
+          },
+          "request_id": {
+            "$ref": "#/components/schemas/SwitchTurnRequestId"
+          },
+          "target_model": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "request_id",
+          "target_model",
+          "duration",
+          "phase"
+        ],
+        "type": "object"
+      },
+      "SwitchTurnRestoreTrigger": {
+        "enum": [
+          "consumed",
+          "interrupted"
+        ],
+        "type": "string"
+      },
+      "SwitchTurnTerminalClass": {
+        "oneOf": [
+          {
+            "properties": {
+              "reason": {
+                "$ref": "#/components/schemas/SwitchTurnDenialReason"
+              },
+              "terminal": {
+                "const": "denied",
+                "type": "string"
+              }
+            },
+            "required": [
+              "terminal",
+              "reason"
+            ],
+            "type": "object"
+          },
+          {
+            "properties": {
+              "terminal": {
+                "const": "consumed_and_restored",
+                "type": "string"
+              }
+            },
+            "required": [
+              "terminal"
+            ],
+            "type": "object"
+          },
+          {
+            "properties": {
+              "terminal": {
+                "const": "interrupted_and_restored",
+                "type": "string"
+              }
+            },
+            "required": [
+              "terminal"
+            ],
+            "type": "object"
+          },
+          {
+            "properties": {
+              "terminal": {
+                "const": "persistent_reconfigure_applied",
+                "type": "string"
+              }
+            },
+            "required": [
+              "terminal"
+            ],
+            "type": "object"
+          },
+          {
+            "properties": {
+              "terminal": {
+                "const": "persistent_reconfigure_failed",
+                "type": "string"
+              }
+            },
+            "required": [
+              "terminal"
+            ],
+            "type": "object"
+          },
+          {
+            "properties": {
+              "terminal": {
+                "const": "restore_failed",
+                "type": "string"
+              },
+              "trigger": {
+                "$ref": "#/components/schemas/SwitchTurnRestoreTrigger"
+              }
+            },
+            "required": [
+              "terminal",
+              "trigger"
+            ],
+            "type": "object"
+          }
+        ]
+      },
+      "SystemNoticeKind": {
+        "description": "Typed system notice content carried in the transcript.",
+        "oneOf": [
+          {
+            "enum": [
+              "generic",
+              "mcp_pending",
+              "background_job",
+              "tool_scope",
+              "tool_scope_warning"
+            ],
+            "type": "string"
+          },
+          {
+            "const": "auth_reauth_required",
+            "description": "Auth lease transitioned to `reauth_required` — the active\n`connection_ref` needs manual re-authentication before the next LLM\ncall can proceed (Phase 1.5-rev).",
+            "type": "string"
+          }
+        ]
+      },
+      "TargetBinding": {
+        "oneOf": [
+          {
+            "$ref": "#/components/schemas/SessionTargetBinding",
+            "properties": {
+              "target_kind": {
+                "const": "session",
+                "type": "string"
+              }
+            },
+            "required": [
+              "target_kind"
+            ],
+            "type": "object"
+          },
+          {
+            "$ref": "#/components/schemas/MobTargetBinding",
+            "properties": {
+              "target_kind": {
+                "const": "mob",
+                "type": "string"
+              }
+            },
+            "required": [
+              "target_kind"
+            ],
+            "type": "object"
+          }
+        ]
+      },
+      "ToolAccessPolicy": {
+        "description": "Tool access control for delegated branches",
+        "oneOf": [
+          {
+            "description": "Inherit all tools from parent",
+            "properties": {
+              "type": {
+                "const": "inherit",
+                "type": "string"
+              }
+            },
+            "required": [
+              "type"
+            ],
+            "type": "object"
+          },
+          {
+            "description": "Only allow specific tools",
+            "properties": {
+              "type": {
+                "const": "allow_list",
+                "type": "string"
+              },
+              "value": {
+                "$ref": "#/components/schemas/ToolNameSet"
+              }
+            },
+            "required": [
+              "type",
+              "value"
+            ],
+            "type": "object"
+          },
+          {
+            "description": "Block specific tools",
+            "properties": {
+              "type": {
+                "const": "deny_list",
+                "type": "string"
+              },
+              "value": {
+                "$ref": "#/components/schemas/ToolNameSet"
+              }
+            },
+            "required": [
+              "type",
+              "value"
+            ],
+            "type": "object"
+          }
+        ]
+      },
+      "ToolCallTimeoutContext": {
+        "description": "Typed context carried alongside a [`RealtimeErrorCode::ToolCallTimeout`].",
+        "properties": {
+          "call_id": {
+            "type": "string"
+          },
+          "elapsed_ms": {
+            "format": "uint64",
+            "minimum": 0,
+            "type": "integer"
+          },
+          "timeout_ms": {
+            "format": "uint64",
+            "minimum": 0,
+            "type": "integer"
+          }
+        },
+        "required": [
+          "call_id",
+          "elapsed_ms",
+          "timeout_ms"
+        ],
+        "type": "object"
+      },
+      "ToolName": {
+        "description": "Canonical typed name for an LLM-callable tool.\n\nThe model-facing wire shape is still the provider's string tool name, but\ninternal policy, routing, and registry surfaces carry this handle so raw\nstrings do not become the tool identity owner.",
+        "type": "string"
+      },
+      "ToolNameSet": {
+        "description": "Set of canonical tool names.",
+        "items": {
+          "$ref": "#/components/schemas/ToolName"
+        },
+        "type": "array",
+        "uniqueItems": true
+      },
+      "TriggerSpec": {
+        "oneOf": [
+          {
+            "properties": {
+              "due_at_utc": {
+                "format": "date-time",
+                "type": "string"
+              },
+              "type": {
+                "const": "once",
+                "type": "string"
+              }
+            },
+            "required": [
+              "type",
+              "due_at_utc"
+            ],
+            "type": "object"
+          },
+          {
+            "$ref": "#/components/schemas/IntervalTriggerSpec",
+            "properties": {
+              "type": {
+                "const": "interval",
+                "type": "string"
+              }
+            },
+            "required": [
+              "type"
+            ],
+            "type": "object"
+          },
+          {
+            "$ref": "#/components/schemas/CalendarTriggerSpec",
+            "properties": {
+              "type": {
+                "const": "calendar",
+                "type": "string"
+              }
+            },
+            "required": [
+              "type"
+            ],
+            "type": "object"
+          }
+        ]
+      },
+      "UpdateScheduleParams": {
+        "properties": {
+          "description": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "expected_revision": {
+            "format": "uint64",
+            "minimum": 0,
+            "type": [
+              "integer",
+              "null"
+            ]
+          },
+          "labels": {
+            "additionalProperties": {
+              "type": "string"
+            },
+            "type": [
+              "object",
+              "null"
+            ]
+          },
+          "misfire_policy": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/MisfirePolicy"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "missing_target_policy": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/MissingTargetPolicy"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "name": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "overlap_policy": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/OverlapPolicy"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "planning_horizon_days": {
+            "format": "uint32",
+            "minimum": 0,
+            "type": [
+              "integer",
+              "null"
+            ]
+          },
+          "planning_horizon_occurrences": {
+            "format": "uint32",
+            "minimum": 0,
+            "type": [
+              "integer",
+              "null"
+            ]
+          },
+          "schedule_id": {
+            "type": "string"
+          },
+          "target": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/TargetBinding"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "trigger": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/TriggerSpec"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          }
+        },
+        "required": [
+          "schedule_id"
+        ],
+        "title": "UpdateScheduleParams",
+        "type": "object"
+      },
+      "WireAssistantBlock": {
+        "description": "Transcript block inside a block-assistant message.\n\nNot `PartialEq`: `ToolUse.args` is `Box<RawValue>` for pass-through\nfidelity (core invariant — opaque from provider to dispatcher), and\n`RawValue` does not derive equality. Equivalence checks should\nround-trip through serialization and compare the serialized bytes.",
+        "oneOf": [
+          {
+            "properties": {
+              "block_type": {
+                "const": "text",
+                "type": "string"
+              },
+              "data": {
+                "properties": {
+                  "meta": {
+                    "anyOf": [
+                      {
+                        "$ref": "#/components/schemas/WireProviderMeta"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ]
+                  },
+                  "text": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "text"
+                ],
+                "type": "object"
+              }
+            },
+            "required": [
+              "block_type",
+              "data"
+            ],
+            "type": "object"
+          },
+          {
+            "properties": {
+              "block_type": {
+                "const": "reasoning",
+                "type": "string"
+              },
+              "data": {
+                "properties": {
+                  "meta": {
+                    "anyOf": [
+                      {
+                        "$ref": "#/components/schemas/WireProviderMeta"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ]
+                  },
+                  "text": {
+                    "default": "",
+                    "type": "string"
+                  }
+                },
+                "type": "object"
+              }
+            },
+            "required": [
+              "block_type",
+              "data"
+            ],
+            "type": "object"
+          },
+          {
+            "properties": {
+              "block_type": {
+                "const": "tool_use",
+                "type": "string"
+              },
+              "data": {
+                "properties": {
+                  "args": {
+                    "description": "Wire-projected tool-call args. Carries the opaque JSON payload\nas `Box<RawValue>` to mirror the core `AssistantBlock::ToolUse`\ninvariant (\"tool-call args pass through un-parsed from provider\nto dispatcher\") — see `CLAUDE.md` Rust design principles §3.\nAllow-listed by dogma-blind-spots §7."
+                  },
+                  "id": {
+                    "type": "string"
+                  },
+                  "meta": {
+                    "anyOf": [
+                      {
+                        "$ref": "#/components/schemas/WireProviderMeta"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ]
+                  },
+                  "name": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "id",
+                  "name",
+                  "args"
+                ],
+                "type": "object"
+              }
+            },
+            "required": [
+              "block_type",
+              "data"
+            ],
+            "type": "object"
+          },
+          {
+            "properties": {
+              "block_type": {
+                "const": "image",
+                "type": "string"
+              },
+              "data": {
+                "properties": {
+                  "blob_ref": {
+                    "$ref": "#/components/schemas/BlobRef"
+                  },
+                  "height": {
+                    "format": "uint32",
+                    "minimum": 0,
+                    "type": "integer"
+                  },
+                  "image_id": {
+                    "$ref": "#/components/schemas/AssistantImageId"
+                  },
+                  "media_type": {
+                    "type": "string"
+                  },
+                  "meta": {
+                    "$ref": "#/components/schemas/ProviderImageMetadata"
+                  },
+                  "revised_prompt": {
+                    "$ref": "#/components/schemas/RevisedPromptDisposition"
+                  },
+                  "width": {
+                    "format": "uint32",
+                    "minimum": 0,
+                    "type": "integer"
+                  }
+                },
+                "required": [
+                  "image_id",
+                  "blob_ref",
+                  "media_type",
+                  "width",
+                  "height",
+                  "revised_prompt",
+                  "meta"
+                ],
+                "type": "object"
+              }
+            },
+            "required": [
+              "block_type",
+              "data"
+            ],
+            "type": "object"
+          },
+          {
+            "properties": {
+              "block_type": {
+                "const": "unknown",
+                "type": "string"
+              }
+            },
+            "required": [
+              "block_type"
+            ],
+            "type": "object"
+          }
+        ],
+        "title": "WireAssistantBlock"
+      },
+      "WireAssistantImageRef": {
+        "properties": {
+          "blob_ref": {
+            "$ref": "#/components/schemas/BlobRef"
+          },
+          "height": {
+            "format": "uint32",
+            "minimum": 0,
+            "type": "integer"
+          },
+          "image_id": {
+            "$ref": "#/components/schemas/AssistantImageId"
+          },
+          "media_type": {
+            "type": "string"
+          },
+          "width": {
+            "format": "uint32",
+            "minimum": 0,
+            "type": "integer"
+          }
+        },
+        "required": [
+          "image_id",
+          "blob_ref",
+          "media_type",
+          "width",
+          "height"
+        ],
+        "title": "AssistantImageRef",
+        "type": "object"
+      },
+      "WireAuthError": {
+        "description": "Stable wire kind for auth errors. Mirrors `meerkat_core::AuthErrorKind`\non the wire as a normalized string.",
+        "oneOf": [
+          {
+            "properties": {
+              "kind": {
+                "const": "missing_secret",
+                "type": "string"
+              }
+            },
+            "required": [
+              "kind"
+            ],
+            "type": "object"
+          },
+          {
+            "properties": {
+              "auth": {
+                "type": "string"
+              },
+              "backend": {
+                "type": "string"
+              },
+              "kind": {
+                "const": "unsupported_combination",
+                "type": "string"
+              }
+            },
+            "required": [
+              "kind",
+              "backend",
+              "auth"
+            ],
+            "type": "object"
+          },
+          {
+            "properties": {
+              "field": {
+                "type": "string"
+              },
+              "kind": {
+                "const": "missing_required_metadata",
+                "type": "string"
+              }
+            },
+            "required": [
+              "kind",
+              "field"
+            ],
+            "type": "object"
+          },
+          {
+            "properties": {
+              "kind": {
+                "const": "workspace_mismatch",
+                "type": "string"
+              }
+            },
+            "required": [
+              "kind"
+            ],
+            "type": "object"
+          },
+          {
+            "properties": {
+              "kind": {
+                "const": "expired",
+                "type": "string"
+              }
+            },
+            "required": [
+              "kind"
+            ],
+            "type": "object"
+          },
+          {
+            "properties": {
+              "detail": {
+                "type": "string"
+              },
+              "kind": {
+                "const": "refresh_failed",
+                "type": "string"
+              }
+            },
+            "required": [
+              "kind",
+              "detail"
+            ],
+            "type": "object"
+          },
+          {
+            "properties": {
+              "kind": {
+                "const": "interactive_login_required",
+                "type": "string"
+              }
+            },
+            "required": [
+              "kind"
+            ],
+            "type": "object"
+          },
+          {
+            "properties": {
+              "kind": {
+                "const": "host_owned_unavailable",
+                "type": "string"
+              }
+            },
+            "required": [
+              "kind"
+            ],
+            "type": "object"
+          },
+          {
+            "properties": {
+              "detail": {
+                "type": "string"
+              },
+              "kind": {
+                "const": "io",
+                "type": "string"
+              }
+            },
+            "required": [
+              "kind",
+              "detail"
+            ],
+            "type": "object"
+          },
+          {
+            "properties": {
+              "detail": {
+                "type": "string"
+              },
+              "kind": {
+                "const": "other",
+                "type": "string"
+              }
+            },
+            "required": [
+              "kind",
+              "detail"
+            ],
+            "type": "object"
+          }
+        ],
+        "title": "WireAuthError"
+      },
+      "WireAuthProfile": {
+        "description": "Wire projection of [`meerkat_core::AuthProfile`]. Sensitive credential\nmaterial is NOT wire-projected; callers that inspect profile metadata use\nthe server-side `auth.profile.get` RPC or the\n`GET /auth/bindings/{binding_id}` REST path; both return typed redacted\nshapes. `source_kind` is a\ndiscriminator for the credential-source variant.",
+        "properties": {
+          "auth_method": {
+            "type": "string"
+          },
+          "id": {
+            "type": "string"
+          },
+          "provider": {
+            "type": "string"
+          },
+          "source_kind": {
+            "description": "Discriminator: \"inline_secret\" / \"managed_store\" / \"env\" /\n\"external_resolver\" / \"platform_default\" / \"command\" /\n\"file_descriptor\".",
+            "type": "string"
+          }
+        },
+        "required": [
+          "id",
+          "provider",
+          "auth_method",
+          "source_kind"
+        ],
+        "title": "WireAuthProfile",
+        "type": "object"
+      },
+      "WireAuthProfileCleared": {
+        "description": "`DELETE /auth/bindings/{binding_id}` /\n`POST /auth/bindings/{binding_id}/logout` success body.",
+        "properties": {
+          "binding_id": {
+            "type": "string"
+          },
+          "cleared": {
+            "type": "boolean"
+          },
+          "connection_ref": {
+            "$ref": "#/components/schemas/WireConnectionRef"
+          },
+          "profile_id": {
+            "type": "string"
+          },
+          "realm_id": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "realm_id",
+          "binding_id",
+          "connection_ref",
+          "profile_id",
+          "cleared"
+        ],
+        "title": "WireAuthProfileCleared",
+        "type": "object"
+      },
+      "WireAuthProfileCreated": {
+        "description": "`POST /auth/profiles` (create) success body.",
+        "properties": {
+          "auth_method": {
+            "type": "string"
+          },
+          "binding_id": {
+            "type": "string"
+          },
+          "connection_ref": {
+            "$ref": "#/components/schemas/WireConnectionRef"
+          },
+          "profile_id": {
+            "type": "string"
+          },
+          "provider": {
+            "type": "string"
+          },
+          "realm_id": {
+            "type": "string"
+          },
+          "stored": {
+            "type": "boolean"
+          }
+        },
+        "required": [
+          "realm_id",
+          "binding_id",
+          "connection_ref",
+          "profile_id",
+          "provider",
+          "auth_method",
+          "stored"
+        ],
+        "title": "WireAuthProfileCreated",
+        "type": "object"
+      },
+      "WireAuthProfileDetail": {
+        "description": "`GET /auth/bindings/{binding_id}` success body.",
+        "properties": {
+          "auth_profile": {
+            "$ref": "#/components/schemas/WireAuthProfile"
+          },
+          "binding_id": {
+            "type": "string"
+          },
+          "connection_ref": {
+            "$ref": "#/components/schemas/WireConnectionRef"
+          },
+          "profile_id": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "connection_ref",
+          "binding_id",
+          "profile_id",
+          "auth_profile"
+        ],
+        "title": "WireAuthProfileDetail",
+        "type": "object"
+      },
+      "WireAuthProfilesList": {
+        "description": "`GET /auth/profiles` success body — realm-scoped lists of backend,\nauth, and binding profiles.",
+        "properties": {
+          "auth_profiles": {
+            "items": {
+              "$ref": "#/components/schemas/WireAuthProfile"
+            },
+            "type": "array"
+          },
+          "backend_profiles": {
+            "items": {
+              "$ref": "#/components/schemas/WireBackendProfile"
+            },
+            "type": "array"
+          },
+          "bindings": {
+            "items": {
+              "$ref": "#/components/schemas/WireProviderBinding"
+            },
+            "type": "array"
+          },
+          "realm_id": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "realm_id",
+          "auth_profiles",
+          "backend_profiles",
+          "bindings"
+        ],
+        "title": "WireAuthProfilesList",
+        "type": "object"
+      },
+      "WireAuthStatus": {
+        "description": "Wire projection of the auth-profile status. Returned from\n`auth.status.get` / `GET /auth/bindings/{binding_id}/status`.",
+        "properties": {
+          "account_id": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "auth_method": {
+            "type": "string"
+          },
+          "expires_at": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "last_error": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/WireAuthError"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Most recent auth error, if any."
+          },
+          "last_refresh_at": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "profile_id": {
+            "type": "string"
+          },
+          "provider": {
+            "type": "string"
+          },
+          "state": {
+            "description": "High-level health: \"valid\" / \"expiring\" / \"expired\" /\n\"reauth_required\" / \"refresh_failed\" / \"unknown\".",
+            "type": "string"
+          }
+        },
+        "required": [
+          "profile_id",
+          "provider",
+          "auth_method",
+          "state"
+        ],
+        "title": "WireAuthStatus",
+        "type": "object"
+      },
+      "WireAuthStatusDetail": {
+        "description": "`GET /auth/bindings/{binding_id}/status` success body. Richer than\n[`WireAuthStatus`] — also carries `realm_id` / `binding_id` /\n`connection_ref` / `has_refresh_token` so the caller can key by\nbinding directly.",
+        "properties": {
+          "account_id": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "auth_method": {
+            "type": "string"
+          },
+          "binding_id": {
+            "type": "string"
+          },
+          "connection_ref": {
+            "$ref": "#/components/schemas/WireConnectionRef"
+          },
+          "expires_at": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "has_refresh_token": {
+            "type": "boolean"
+          },
+          "last_refresh_at": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "profile_id": {
+            "type": "string"
+          },
+          "provider": {
+            "type": "string"
+          },
+          "realm_id": {
+            "type": "string"
+          },
+          "state": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "realm_id",
+          "binding_id",
+          "connection_ref",
+          "profile_id",
+          "provider",
+          "auth_method",
+          "state",
+          "has_refresh_token"
+        ],
+        "title": "WireAuthStatusDetail",
+        "type": "object"
+      },
+      "WireBackendProfile": {
+        "description": "Wire projection of [`meerkat_core::BackendProfile`].",
+        "properties": {
+          "backend_kind": {
+            "type": "string"
+          },
+          "base_url": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "id": {
+            "type": "string"
+          },
+          "options": true,
+          "provider": {
+            "description": "Provider as a normalized string: `\"openai\"` / `\"anthropic\"` /\n`\"gemini\"` / `\"self_hosted\"`. Wire types don't carry the strict\n`Provider` enum so consumers aren't forced to update their\nschema when we add new providers.",
+            "type": "string"
+          }
+        },
+        "required": [
+          "id",
+          "provider",
+          "backend_kind"
+        ],
+        "type": "object"
+      },
+      "WireBindingIdentity": {
+        "description": "Identifies a binding inside a realm on the wire. Shared by every\nauth REST response that returns a `{realm_id, binding_id, connection_ref}`\ntrio. Built from a typed [`meerkat_core::ConnectionRef`] so the three\nfields always agree; the `realm_id`/`binding_id` strings carry the\nslug form for wire consumers that key by string.",
+        "properties": {
+          "binding_id": {
+            "type": "string"
+          },
+          "connection_ref": {
+            "$ref": "#/components/schemas/WireConnectionRef"
+          },
+          "realm_id": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "realm_id",
+          "binding_id",
+          "connection_ref"
+        ],
+        "title": "WireBindingIdentity",
+        "type": "object"
+      },
+      "WireConnectionRef": {
+        "description": "Wire projection of [`meerkat_core::ConnectionRef`].\n\nPure structural shape — no `\"realm:binding\"` string form. Wave-b deleted\n`parse` and `Display` on both the core type and the wire projection so\nthe colon-joined form cannot travel across wire boundaries.",
+        "properties": {
+          "binding": {
+            "$ref": "#/components/schemas/BindingId"
+          },
+          "profile": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/ProfileId"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "realm": {
+            "$ref": "#/components/schemas/RealmId"
+          }
+        },
+        "required": [
+          "realm",
+          "binding"
+        ],
+        "type": "object"
+      },
+      "WireContentBlock": {
+        "description": "Wire-safe content block (no `source_path` — internal only).",
+        "oneOf": [
+          {
+            "properties": {
+              "text": {
+                "type": "string"
+              },
+              "type": {
+                "const": "text",
+                "type": "string"
+              }
+            },
+            "required": [
+              "type",
+              "text"
+            ],
+            "type": "object"
+          },
+          {
+            "oneOf": [
+              {
+                "properties": {
+                  "data": {
+                    "type": "string"
+                  },
+                  "source": {
+                    "const": "inline",
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "source",
+                  "data"
+                ],
+                "type": "object"
+              },
+              {
+                "properties": {
+                  "blob_id": {
+                    "type": "string"
+                  },
+                  "source": {
+                    "const": "blob",
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "source",
+                  "blob_id"
+                ],
+                "type": "object"
+              }
+            ],
+            "properties": {
+              "media_type": {
+                "type": "string"
+              },
+              "type": {
+                "const": "image",
+                "type": "string"
+              }
+            },
+            "required": [
+              "type",
+              "media_type"
+            ],
+            "type": "object"
+          },
+          {
+            "oneOf": [
+              {
+                "properties": {
+                  "data": {
+                    "type": "string"
+                  },
+                  "source": {
+                    "const": "inline",
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "source",
+                  "data"
+                ],
+                "type": "object"
+              }
+            ],
+            "properties": {
+              "duration_ms": {
+                "format": "uint64",
+                "minimum": 0,
+                "type": "integer"
+              },
+              "media_type": {
+                "type": "string"
+              },
+              "type": {
+                "const": "video",
+                "type": "string"
+              }
+            },
+            "required": [
+              "type",
+              "media_type",
+              "duration_ms"
+            ],
+            "type": "object"
+          },
+          {
+            "description": "Forward-compatibility for unknown block types.",
+            "properties": {
+              "type": {
+                "const": "unknown",
+                "type": "string"
+              }
+            },
+            "required": [
+              "type"
+            ],
+            "type": "object"
+          }
+        ]
+      },
+      "WireContentInput": {
+        "anyOf": [
+          {
+            "type": "string"
+          },
+          {
+            "items": {
+              "$ref": "#/components/schemas/WireContentBlock"
+            },
+            "type": "array"
+          }
+        ],
+        "description": "Wire-safe content input (mirrors `ContentInput`)."
+      },
+      "WireDeviceCompleteResult": {
+        "description": "`auth/login/device_complete` success body.",
+        "oneOf": [
+          {
+            "properties": {
+              "state": {
+                "const": "pending",
+                "type": "string"
+              }
+            },
+            "required": [
+              "state"
+            ],
+            "type": "object"
+          },
+          {
+            "properties": {
+              "state": {
+                "const": "slow_down",
+                "type": "string"
+              }
+            },
+            "required": [
+              "state"
+            ],
+            "type": "object"
+          },
+          {
+            "properties": {
+              "state": {
+                "const": "access_denied",
+                "type": "string"
+              }
+            },
+            "required": [
+              "state"
+            ],
+            "type": "object"
+          },
+          {
+            "properties": {
+              "state": {
+                "const": "expired",
+                "type": "string"
+              }
+            },
+            "required": [
+              "state"
+            ],
+            "type": "object"
+          },
+          {
+            "description": "Identifies a binding inside a realm on the wire. Shared by every\nauth REST response that returns a `{realm_id, binding_id, connection_ref}`\ntrio. Built from a typed [`meerkat_core::ConnectionRef`] so the three\nfields always agree; the `realm_id`/`binding_id` strings carry the\nslug form for wire consumers that key by string.",
+            "properties": {
+              "binding_id": {
+                "type": "string"
+              },
+              "connection_ref": {
+                "$ref": "#/components/schemas/WireConnectionRef"
+              },
+              "expires_at": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "has_refresh_token": {
+                "type": "boolean"
+              },
+              "profile_id": {
+                "type": "string"
+              },
+              "provider": {
+                "type": "string"
+              },
+              "realm_id": {
+                "type": "string"
+              },
+              "scopes": {
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              },
+              "state": {
+                "const": "ready",
+                "type": "string"
+              }
+            },
+            "required": [
+              "state",
+              "realm_id",
+              "binding_id",
+              "connection_ref",
+              "profile_id",
+              "provider",
+              "has_refresh_token",
+              "scopes"
+            ],
+            "type": "object"
+          }
+        ],
+        "title": "WireDeviceCompleteResult"
+      },
+      "WireDeviceStart": {
+        "description": "`POST /auth/login/device/start` success body.",
+        "properties": {
+          "device_code": {
+            "type": "string"
+          },
+          "expires_in": {
+            "format": "uint64",
+            "minimum": 0,
+            "type": "integer"
+          },
+          "interval": {
+            "format": "uint64",
+            "minimum": 0,
+            "type": "integer"
+          },
+          "provider": {
+            "type": "string"
+          },
+          "user_code": {
+            "type": "string"
+          },
+          "verification_uri": {
+            "type": "string"
+          },
+          "verification_uri_complete": {
+            "type": [
+              "string",
+              "null"
+            ]
+          }
+        },
+        "required": [
+          "device_code",
+          "user_code",
+          "verification_uri",
+          "expires_in",
+          "interval",
+          "provider"
+        ],
+        "title": "WireDeviceStart",
+        "type": "object"
+      },
+      "WireError": {
+        "description": "Canonical wire error envelope.\n\nSurfaces map this to their native format (RPC error, HTTP response, CLI exit).",
+        "properties": {
+          "capability_hint": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/CapabilityHint"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "category": {
+            "$ref": "#/components/schemas/ErrorCategory"
+          },
+          "code": {
+            "$ref": "#/components/schemas/ErrorCode"
+          },
+          "details": true,
+          "message": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "code",
+          "category",
+          "message"
+        ],
+        "title": "WireError",
+        "type": "object"
+      },
+      "WireGenerateImageExecutionPlan": {
+        "properties": {
+          "backend": {
+            "$ref": "#/components/schemas/ImageGenerationBackendKind"
+          },
+          "capabilities": {
+            "$ref": "#/components/schemas/ImageGenerationTargetCapabilities"
+          },
+          "max_count": {
+            "format": "uint32",
+            "minimum": 1,
+            "type": "integer"
+          },
+          "provider": {
+            "type": "string"
+          },
+          "provider_plan": {
+            "default": null
+          },
+          "requires_scoped_override": {
+            "type": "boolean"
+          }
+        },
+        "required": [
+          "provider",
+          "backend",
+          "max_count",
+          "capabilities",
+          "requires_scoped_override"
+        ],
+        "title": "GenerateImageExecutionPlan",
+        "type": "object"
+      },
+      "WireGenerateImageRequest": {
+        "properties": {
+          "count": {
+            "format": "uint32",
+            "minimum": 1,
+            "type": "integer"
+          },
+          "format": {
+            "$ref": "#/components/schemas/ImageFormatPreference"
+          },
+          "intent": {
+            "$ref": "#/components/schemas/ImageGenerationIntent"
+          },
+          "provider_params": true,
+          "quality": {
+            "$ref": "#/components/schemas/ImageQualityPreference"
+          },
+          "size": {
+            "$ref": "#/components/schemas/ImageSizePreference"
+          },
+          "target": {
+            "$ref": "#/components/schemas/ImageGenerationTargetPreference"
+          }
+        },
+        "required": [
+          "intent",
+          "target",
+          "size",
+          "quality",
+          "format",
+          "count"
+        ],
+        "title": "GenerateImageRequest",
+        "type": "object"
+      },
+      "WireHandlingMode": {
+        "description": "Public handling mode for mob member delivery.",
+        "enum": [
+          "queue",
+          "steer"
+        ],
+        "type": "string"
+      },
+      "WireImageGenerationToolResult": {
+        "properties": {
+          "images": {
+            "items": {
+              "$ref": "#/components/schemas/AssistantImageRef"
+            },
+            "type": "array"
+          },
+          "native_metadata": {
+            "$ref": "#/components/schemas/ProviderImageMetadata"
+          },
+          "operation_id": {
+            "$ref": "#/components/schemas/ImageOperationId"
+          },
+          "provider_text": {
+            "$ref": "#/components/schemas/ProviderTextDisposition"
+          },
+          "revised_prompt": {
+            "$ref": "#/components/schemas/RevisedPromptDisposition"
+          },
+          "terminal": {
+            "$ref": "#/components/schemas/ImageOperationTerminalClass"
+          },
+          "warnings": {
+            "items": {
+              "$ref": "#/components/schemas/ImageGenerationWarning"
+            },
+            "type": "array"
+          }
+        },
+        "required": [
+          "operation_id",
+          "terminal",
+          "provider_text",
+          "revised_prompt",
+          "native_metadata"
+        ],
+        "title": "ImageGenerationToolResult",
+        "type": "object"
+      },
+      "WireImageOperationPhase": {
+        "oneOf": [
+          {
+            "properties": {
+              "phase": {
+                "const": "requested",
+                "type": "string"
+              }
+            },
+            "required": [
+              "phase"
+            ],
+            "type": "object"
+          },
+          {
+            "properties": {
+              "phase": {
+                "const": "validating",
+                "type": "string"
+              }
+            },
+            "required": [
+              "phase"
+            ],
+            "type": "object"
+          },
+          {
+            "properties": {
+              "approval_id": {
+                "$ref": "#/components/schemas/ApprovalId"
+              },
+              "phase": {
+                "const": "awaiting_approval",
+                "type": "string"
+              }
+            },
+            "required": [
+              "phase",
+              "approval_id"
+            ],
+            "type": "object"
+          },
+          {
+            "properties": {
+              "phase": {
+                "const": "plan_resolved",
+                "type": "string"
+              }
+            },
+            "required": [
+              "phase"
+            ],
+            "type": "object"
+          },
+          {
+            "properties": {
+              "phase": {
+                "const": "projection_snapshotted",
+                "type": "string"
+              }
+            },
+            "required": [
+              "phase"
+            ],
+            "type": "object"
+          },
+          {
+            "properties": {
+              "phase": {
+                "const": "scoped_override_active",
+                "type": "string"
+              }
+            },
+            "required": [
+              "phase"
+            ],
+            "type": "object"
+          },
+          {
+            "properties": {
+              "phase": {
+                "const": "provider_call_in_flight",
+                "type": "string"
+              }
+            },
+            "required": [
+              "phase"
+            ],
+            "type": "object"
+          },
+          {
+            "properties": {
+              "phase": {
+                "const": "provider_result_captured",
+                "type": "string"
+              }
+            },
+            "required": [
+              "phase"
+            ],
+            "type": "object"
+          },
+          {
+            "properties": {
+              "phase": {
+                "const": "blob_commit_pending",
+                "type": "string"
+              }
+            },
+            "required": [
+              "phase"
+            ],
+            "type": "object"
+          },
+          {
+            "properties": {
+              "phase": {
+                "const": "result_committed",
+                "type": "string"
+              }
+            },
+            "required": [
+              "phase"
+            ],
+            "type": "object"
+          },
+          {
+            "properties": {
+              "phase": {
+                "const": "restoring_scoped_override",
+                "type": "string"
+              }
+            },
+            "required": [
+              "phase"
+            ],
+            "type": "object"
+          },
+          {
+            "properties": {
+              "phase": {
+                "const": "terminal",
+                "type": "string"
+              },
+              "terminal": {
+                "$ref": "#/components/schemas/ImageOperationTerminalClass"
+              }
+            },
+            "required": [
+              "phase",
+              "terminal"
+            ],
+            "type": "object"
+          }
+        ],
+        "title": "ImageOperationPhase"
+      },
+      "WireInputDurability": {
+        "description": "Typed wire projection of an input's durability class.",
+        "enum": [
+          "durable",
+          "volatile",
+          "ephemeral"
+        ],
+        "type": "string"
+      },
+      "WireInputLifecycleState": {
+        "description": "Public input lifecycle state projection used by RPC surfaces.",
+        "enum": [
+          "accepted",
+          "queued",
+          "staged",
+          "applied",
+          "applied_pending_consumption",
+          "consumed",
+          "superseded",
+          "coalesced",
+          "abandoned"
+        ],
+        "type": "string"
+      },
+      "WireInputPolicy": {
+        "description": "Typed wire projection of the input admission policy.\n\nFormerly `serde_json::Value`; wave-b retyped it so callers can pattern\nmatch on admission behavior instead of parsing opaque JSON.",
+        "enum": [
+          "stage",
+          "queue",
+          "immediate"
+        ],
+        "type": "string"
+      },
+      "WireInputState": {
+        "description": "RPC-facing input state snapshot.\n\nAll fields are typed. Wave B replaced six former `serde_json::Value`\nfields with typed projections so the wire carries no untyped carriers.",
+        "properties": {
+          "attempt_count": {
+            "default": 0,
+            "format": "uint32",
+            "minimum": 0,
+            "type": "integer"
+          },
+          "created_at": {
+            "type": "string"
+          },
+          "current_state": {
+            "$ref": "#/components/schemas/WireInputLifecycleState"
+          },
+          "durability": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/WireInputDurability"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "history": {
+            "items": {
+              "$ref": "#/components/schemas/WireInputStateHistoryEntry"
+            },
+            "type": "array"
+          },
+          "idempotency_key": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "input_id": {
+            "type": "string"
+          },
+          "last_boundary_sequence": {
+            "format": "uint64",
+            "minimum": 0,
+            "type": [
+              "integer",
+              "null"
+            ]
+          },
+          "last_run_id": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "persisted_input": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/WirePersistedInput"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "policy": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/WireInputPolicy"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "reconstruction_source": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/WireReconstructionSource"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "recovery_count": {
+            "default": 0,
+            "format": "uint32",
+            "minimum": 0,
+            "type": "integer"
+          },
+          "terminal_outcome": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/WireInputTerminalOutcome"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "updated_at": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "input_id",
+          "current_state",
+          "created_at",
+          "updated_at"
+        ],
+        "type": "object"
+      },
+      "WireInputStateHistoryEntry": {
+        "description": "Input transition history entry for RPC-facing snapshots.",
+        "properties": {
+          "from": {
+            "$ref": "#/components/schemas/WireInputLifecycleState"
+          },
+          "reason": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "timestamp": {
+            "type": "string"
+          },
+          "to": {
+            "$ref": "#/components/schemas/WireInputLifecycleState"
+          }
+        },
+        "required": [
+          "timestamp",
+          "from",
+          "to"
+        ],
+        "type": "object"
+      },
+      "WireInputTerminalOutcome": {
+        "description": "Typed wire projection of an input's terminal outcome.",
+        "enum": [
+          "completed",
+          "abandoned",
+          "superseded",
+          "coalesced",
+          "cancelled"
+        ],
+        "type": "string"
+      },
+      "WireLoginReady": {
+        "description": "`POST /auth/login/complete` / ready leg of device-code success body.\n\nThe optional `state` field distinguishes the flat `POST\n/auth/login/complete` response (no `state` set) from the device-code\nready leg (`state = \"ready\"`) which is part of the pending/slow_down/\naccess_denied/expired/ready tagged protocol.",
+        "properties": {
+          "binding_id": {
+            "type": "string"
+          },
+          "connection_ref": {
+            "$ref": "#/components/schemas/WireConnectionRef"
+          },
+          "expires_at": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "has_refresh_token": {
+            "type": "boolean"
+          },
+          "profile_id": {
+            "type": "string"
+          },
+          "provider": {
+            "type": "string"
+          },
+          "realm_id": {
+            "type": "string"
+          },
+          "scopes": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "state": {
+            "type": [
+              "string",
+              "null"
+            ]
+          }
+        },
+        "required": [
+          "realm_id",
+          "binding_id",
+          "connection_ref",
+          "profile_id",
+          "provider",
+          "has_refresh_token",
+          "scopes"
+        ],
+        "title": "WireLoginReady",
+        "type": "object"
+      },
+      "WireLoginStart": {
+        "description": "`POST /auth/login/start` success body.",
+        "properties": {
+          "authorize_url": {
+            "type": "string"
+          },
+          "provider": {
+            "type": "string"
+          },
+          "redirect_uri": {
+            "type": "string"
+          },
+          "state": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "authorize_url",
+          "state",
+          "redirect_uri",
+          "provider"
+        ],
+        "title": "WireLoginStart",
+        "type": "object"
+      },
+      "WireMemberRef": {
+        "description": "Server-resolved opaque handle for a mob member.\n\nEncodes `{mob_id, agent_identity}` as a single base64url-encoded token\nthat callers treat as opaque. The server resolves the current\n`AgentRuntimeId` and fence token against the live mob roster on every\ndispatch — clients never reason about `generation` or `fence_token`\ndirectly.\n\nUse [`WireMemberRef::encode`] to produce a token and\n[`WireMemberRef::decode`] inside an RPC handler to recover the\n`(mob_id, agent_identity)` pair before resolving against the runtime.",
+        "type": "string"
+      },
+      "WireMemberState": {
+        "description": "Roster member lifecycle state for `MobMemberFilterWire`.",
+        "enum": [
+          "active",
+          "retiring"
+        ],
+        "type": "string"
+      },
+      "WireMobBackendKind": {
+        "enum": [
+          "session",
+          "external"
+        ],
+        "type": "string"
+      },
+      "WireMobLifecycleAction": {
+        "description": "Typed lifecycle action for `mob/lifecycle`. Replaces the prior\n`action: String` discriminator with an exhaustive enum so callers and\nhandlers reason about lifecycle transitions through the type system\nrather than string folklore.",
+        "enum": [
+          "stop",
+          "resume",
+          "complete",
+          "reset",
+          "destroy"
+        ],
+        "type": "string"
+      },
+      "WireMobMemberStatus": {
+        "description": "Execution status mirroring `meerkat_mob::runtime::MobMemberStatus`.",
+        "enum": [
+          "active",
+          "retiring",
+          "broken",
+          "completed",
+          "unknown"
+        ],
+        "type": "string"
+      },
+      "WireMobReconcileStage": {
+        "description": "Closed wire stage for a per-identity `mob/reconcile` failure.",
+        "enum": [
+          "spawn",
+          "retire"
+        ],
+        "type": "string"
+      },
+      "WireMobRuntimeMode": {
+        "enum": [
+          "autonomous_host",
+          "turn_driven"
+        ],
+        "type": "string"
+      },
+      "WireModelBetaHeader": {
+        "description": "Catalog-owned beta header metadata.",
+        "properties": {
+          "feature": {
+            "type": "string"
+          },
+          "header_name": {
+            "type": "string"
+          },
+          "header_value": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "feature",
+          "header_name",
+          "header_value"
+        ],
+        "type": "object"
+      },
+      "WireModelProfile": {
+        "description": "Runtime profile for a model — capabilities and parameter schema.",
+        "properties": {
+          "beta_headers": {
+            "default": [],
+            "description": "Beta headers authorized by the model capability catalog.",
+            "items": {
+              "$ref": "#/components/schemas/WireModelBetaHeader"
+            },
+            "type": "array"
+          },
+          "inline_video": {
+            "description": "Whether the model accepts inline video content in user messages.",
+            "type": "boolean"
+          },
+          "model_family": {
+            "description": "Model family identifier (e.g., `\"claude-opus-4\"`, `\"gpt-5\"`).",
+            "type": "string"
+          },
+          "params_schema": {
+            "description": "JSON Schema describing accepted provider-specific parameters."
+          },
+          "supports_reasoning": {
+            "description": "Whether the model supports explicit reasoning effort control.",
+            "type": "boolean"
+          },
+          "supports_temperature": {
+            "description": "Whether the model accepts a `temperature` parameter.",
+            "type": "boolean"
+          },
+          "supports_thinking": {
+            "description": "Whether the model supports extended thinking.",
+            "type": "boolean"
+          },
+          "supports_web_search": {
+            "default": false,
+            "description": "Whether the model supports provider-native web search tools.",
+            "type": "boolean"
+          }
+        },
+        "required": [
+          "model_family",
+          "supports_temperature",
+          "supports_thinking",
+          "supports_reasoning",
+          "inline_video",
+          "params_schema"
+        ],
+        "type": "object"
+      },
+      "WireModelRoutingApprovalPhase": {
+        "oneOf": [
+          {
+            "properties": {
+              "phase": {
+                "const": "pending",
+                "type": "string"
+              }
+            },
+            "required": [
+              "phase"
+            ],
+            "type": "object"
+          },
+          {
+            "properties": {
+              "phase": {
+                "const": "presented_to_user",
+                "type": "string"
+              }
+            },
+            "required": [
+              "phase"
+            ],
+            "type": "object"
+          },
+          {
+            "properties": {
+              "phase": {
+                "const": "terminal",
+                "type": "string"
+              },
+              "terminal": {
+                "$ref": "#/components/schemas/ModelRoutingApprovalTerminalClass"
+              }
+            },
+            "required": [
+              "phase",
+              "terminal"
+            ],
+            "type": "object"
+          }
+        ],
+        "title": "ModelRoutingApprovalPhase"
+      },
+      "WireModelRoutingApprovalRequest": {
+        "oneOf": [
+          {
+            "properties": {
+              "parent": {
+                "const": "switch_turn",
+                "type": "string"
+              },
+              "reason": {
+                "$ref": "#/components/schemas/SwitchTurnApprovalReason"
+              },
+              "request_id": {
+                "$ref": "#/components/schemas/SwitchTurnRequestId"
+              }
+            },
+            "required": [
+              "parent",
+              "request_id",
+              "reason"
+            ],
+            "type": "object"
+          },
+          {
+            "properties": {
+              "operation_id": {
+                "$ref": "#/components/schemas/ImageOperationId"
+              },
+              "parent": {
+                "const": "image_operation",
+                "type": "string"
+              },
+              "reason": {
+                "$ref": "#/components/schemas/ImageOperationApprovalReason"
+              }
+            },
+            "required": [
+              "parent",
+              "operation_id",
+              "reason"
+            ],
+            "type": "object"
+          }
+        ],
+        "title": "ModelRoutingApprovalRequest"
+      },
+      "WireModelTier": {
+        "description": "Model recommendation tier.",
+        "oneOf": [
+          {
+            "const": "recommended",
+            "description": "Tested and recommended for production use.",
+            "type": "string"
+          },
+          {
+            "const": "supported",
+            "description": "Supported but not the primary recommendation.",
+            "type": "string"
+          }
+        ]
+      },
+      "WirePersistedInput": {
+        "description": "Typed wire projection of the persisted input carrier.\n\nThe carrier is a structural discriminator. Untypeable provider-specific\nbody bytes should be projected via `StructuredProviderExtension` — a\ntyped opaque-bag newtype explicitly marked non-semantic.",
+        "oneOf": [
+          {
+            "properties": {
+              "kind": {
+                "const": "prompt",
+                "type": "string"
+              },
+              "text_preview": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              }
+            },
+            "required": [
+              "kind"
+            ],
+            "type": "object"
+          },
+          {
+            "properties": {
+              "event_type": {
+                "type": "string"
+              },
+              "kind": {
+                "const": "external_event",
+                "type": "string"
+              }
+            },
+            "required": [
+              "kind",
+              "event_type"
+            ],
+            "type": "object"
+          },
+          {
+            "properties": {
+              "kind": {
+                "const": "peer_message",
+                "type": "string"
+              },
+              "peer_name": {
+                "$ref": "#/components/schemas/PeerName"
+              }
+            },
+            "required": [
+              "kind",
+              "peer_name"
+            ],
+            "type": "object"
+          },
+          {
+            "properties": {
+              "kind": {
+                "const": "continuation",
+                "type": "string"
+              }
+            },
+            "required": [
+              "kind"
+            ],
+            "type": "object"
+          },
+          {
+            "properties": {
+              "carrier": {
+                "type": "string"
+              },
+              "kind": {
+                "const": "other",
+                "type": "string"
+              }
+            },
+            "required": [
+              "kind",
+              "carrier"
+            ],
+            "type": "object"
+          }
+        ]
+      },
+      "WireProviderBinding": {
+        "description": "Wire projection of [`meerkat_core::ProviderBinding`].",
+        "properties": {
+          "allow_auth_override": {
+            "default": false,
+            "type": "boolean"
+          },
+          "auth_profile": {
+            "type": "string"
+          },
+          "backend_profile": {
+            "type": "string"
+          },
+          "default_model": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "id": {
+            "type": "string"
+          },
+          "require_metadata_account": {
+            "default": false,
+            "type": "boolean"
+          },
+          "require_metadata_workspace": {
+            "default": false,
+            "type": "boolean"
+          }
+        },
+        "required": [
+          "id",
+          "backend_profile",
+          "auth_profile"
+        ],
+        "type": "object"
+      },
+      "WireProviderMeta": {
+        "description": "Provider continuity metadata for transcript blocks.",
+        "oneOf": [
+          {
+            "properties": {
+              "provider": {
+                "const": "anthropic",
+                "type": "string"
+              },
+              "signature": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "provider",
+              "signature"
+            ],
+            "type": "object"
+          },
+          {
+            "properties": {
+              "data": {
+                "type": "string"
+              },
+              "provider": {
+                "const": "anthropic_redacted",
+                "type": "string"
+              }
+            },
+            "required": [
+              "provider",
+              "data"
+            ],
+            "type": "object"
+          },
+          {
+            "properties": {
+              "content": {
+                "type": "string"
+              },
+              "provider": {
+                "const": "anthropic_compaction",
+                "type": "string"
+              }
+            },
+            "required": [
+              "provider",
+              "content"
+            ],
+            "type": "object"
+          },
+          {
+            "properties": {
+              "provider": {
+                "const": "gemini",
+                "type": "string"
+              },
+              "thoughtSignature": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "provider",
+              "thoughtSignature"
+            ],
+            "type": "object"
+          },
+          {
+            "properties": {
+              "encrypted_content": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "id": {
+                "type": "string"
+              },
+              "provider": {
+                "const": "open_ai",
+                "type": "string"
+              }
+            },
+            "required": [
+              "provider",
+              "id"
+            ],
+            "type": "object"
+          },
+          {
+            "properties": {
+              "provider": {
+                "const": "unknown",
+                "type": "string"
+              }
+            },
+            "required": [
+              "provider"
+            ],
+            "type": "object"
+          }
+        ]
+      },
+      "WireProviderParamsOverride": {
+        "description": "Typed wire projection of [`meerkat_core::lifecycle::run_primitive::ProviderParamsOverride`].",
+        "properties": {
+          "max_output_tokens": {
+            "format": "uint32",
+            "minimum": 0,
+            "type": [
+              "integer",
+              "null"
+            ]
+          },
+          "provider_tag": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/WireProviderTag"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "reasoning": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/WireReasoningMode"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "temperature": {
+            "format": "float",
+            "type": [
+              "number",
+              "null"
+            ]
+          },
+          "thinking_budget_tokens": {
+            "format": "uint32",
+            "minimum": 0,
+            "type": [
+              "integer",
+              "null"
+            ]
+          },
+          "top_p": {
+            "format": "float",
+            "type": [
+              "number",
+              "null"
+            ]
+          }
+        },
+        "type": "object"
+      },
+      "WireProviderTag": {
+        "description": "Typed wire projection of [`meerkat_core::lifecycle::run_primitive::ProviderTag`].",
+        "oneOf": [
+          {
+            "properties": {
+              "provider": {
+                "const": "anthropic",
+                "type": "string"
+              },
+              "thinking_budget_tokens": {
+                "format": "uint32",
+                "minimum": 0,
+                "type": [
+                  "integer",
+                  "null"
+                ]
+              }
+            },
+            "required": [
+              "provider"
+            ],
+            "type": "object"
+          },
+          {
+            "properties": {
+              "provider": {
+                "const": "open_ai",
+                "type": "string"
+              },
+              "reasoning_effort": {
+                "anyOf": [
+                  {
+                    "$ref": "#/components/schemas/WireReasoningEffort"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
+              }
+            },
+            "required": [
+              "provider"
+            ],
+            "type": "object"
+          },
+          {
+            "properties": {
+              "candidate_count": {
+                "format": "uint32",
+                "minimum": 0,
+                "type": [
+                  "integer",
+                  "null"
+                ]
+              },
+              "provider": {
+                "const": "gemini",
+                "type": "string"
+              }
+            },
+            "required": [
+              "provider"
+            ],
+            "type": "object"
+          },
+          {
+            "description": "Wire projection of `ProviderTag::Unknown { bag }` — the typed\nescape hatch for V3 legacy-row provider knobs that don't (yet) map\nto a typed variant.",
+            "properties": {
+              "bag": {
+                "$ref": "#/components/schemas/StructuredProviderExtension"
+              },
+              "provider": {
+                "const": "unknown",
+                "type": "string"
+              }
+            },
+            "required": [
+              "provider",
+              "bag"
+            ],
+            "type": "object"
+          }
+        ]
+      },
+      "WireProvisionApiKeyResult": {
+        "description": "`auth/login/provision_api_key` success body.",
+        "properties": {
+          "auth_mode": {
+            "type": "string"
+          },
+          "binding_id": {
+            "type": "string"
+          },
+          "connection_ref": {
+            "$ref": "#/components/schemas/WireConnectionRef"
+          },
+          "has_api_key": {
+            "type": "boolean"
+          },
+          "profile_id": {
+            "type": "string"
+          },
+          "provider": {
+            "type": "string"
+          },
+          "realm_id": {
+            "type": "string"
+          },
+          "scopes": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          }
+        },
+        "required": [
+          "realm_id",
+          "binding_id",
+          "connection_ref",
+          "profile_id",
+          "provider",
+          "auth_mode",
+          "has_api_key",
+          "scopes"
+        ],
+        "title": "WireProvisionApiKeyResult",
+        "type": "object"
+      },
+      "WireRealmConnectionSet": {
+        "description": "Wire projection of [`meerkat_core::RealmConnectionSet`]. Returned\nfrom the `realm/get` / `GET /realm/:id` endpoints.",
+        "properties": {
+          "auth_profiles": {
+            "additionalProperties": {
+              "$ref": "#/components/schemas/WireAuthProfile"
+            },
+            "type": "object"
+          },
+          "backends": {
+            "additionalProperties": {
+              "$ref": "#/components/schemas/WireBackendProfile"
+            },
+            "type": "object"
+          },
+          "bindings": {
+            "additionalProperties": {
+              "$ref": "#/components/schemas/WireProviderBinding"
+            },
+            "type": "object"
+          },
+          "default_binding": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "realm_id": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "realm_id",
+          "backends",
+          "auth_profiles",
+          "bindings"
+        ],
+        "title": "WireRealmConnectionSet",
+        "type": "object"
+      },
+      "WireRealmList": {
+        "description": "`GET /realms` success body.",
+        "properties": {
+          "realms": {
+            "items": {
+              "$ref": "#/components/schemas/WireRealmSummary"
+            },
+            "type": "array"
+          }
+        },
+        "required": [
+          "realms"
+        ],
+        "title": "WireRealmList",
+        "type": "object"
+      },
+      "WireRealmSummary": {
+        "description": "Realm summary entry returned by `GET /realms`.",
+        "properties": {
+          "auth_profile_count": {
+            "format": "uint",
+            "minimum": 0,
+            "type": "integer"
+          },
+          "backend_count": {
+            "format": "uint",
+            "minimum": 0,
+            "type": "integer"
+          },
+          "binding_count": {
+            "format": "uint",
+            "minimum": 0,
+            "type": "integer"
+          },
+          "default_binding": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "realm_id": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "realm_id",
+          "backend_count",
+          "auth_profile_count",
+          "binding_count"
+        ],
+        "type": "object"
+      },
+      "WireRealtimeAttachmentStatus": {
+        "description": "Public live attachment status projection used by runtime and mob surfaces.",
+        "enum": [
+          "unattached",
+          "intent_present_unbound",
+          "binding_not_ready",
+          "binding_ready",
+          "replacement_pending",
+          "reattach_required"
+        ],
+        "type": "string"
+      },
+      "WireReasoningEffort": {
+        "description": "Typed wire projection of [`meerkat_core::lifecycle::run_primitive::ReasoningEffort`].",
+        "enum": [
+          "low",
+          "medium",
+          "high"
+        ],
+        "type": "string"
+      },
+      "WireReasoningMode": {
+        "description": "Typed wire projection of [`meerkat_core::lifecycle::run_primitive::ReasoningMode`].",
+        "enum": [
+          "emit",
+          "silent",
+          "off"
+        ],
+        "type": "string"
+      },
+      "WireReconstructionSource": {
+        "description": "Typed wire projection of where an input state was reconstructed from.",
+        "enum": [
+          "live",
+          "event_store",
+          "snapshot",
+          "replay"
+        ],
+        "type": "string"
+      },
+      "WireRenderClass": {
+        "description": "Public render class contract for mob member delivery.",
+        "enum": [
+          "user_prompt",
+          "peer_message",
+          "peer_request",
+          "peer_response",
+          "external_event",
+          "flow_step",
+          "continuation",
+          "system_notice",
+          "tool_scope_notice",
+          "ops_progress"
+        ],
+        "type": "string"
+      },
+      "WireRenderMetadata": {
+        "description": "Public render metadata contract for mob member delivery.",
+        "properties": {
+          "class": {
+            "$ref": "#/components/schemas/WireRenderClass"
+          },
+          "salience": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/WireRenderSalience"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          }
+        },
+        "required": [
+          "class"
+        ],
+        "type": "object"
+      },
+      "WireRenderSalience": {
+        "description": "Public render salience contract for mob member delivery.",
+        "enum": [
+          "background",
+          "normal",
+          "important",
+          "urgent"
+        ],
+        "type": "string"
+      },
+      "WireRunResult": {
+        "description": "Canonical run result for wire protocol.",
+        "properties": {
+          "schema_warnings": {
+            "items": {
+              "$ref": "#/components/schemas/SchemaWarning"
+            },
+            "type": [
+              "array",
+              "null"
+            ]
+          },
+          "session_id": {
+            "$ref": "#/components/schemas/SessionId"
+          },
+          "session_ref": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "skill_diagnostics": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/SkillRuntimeDiagnostics"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "structured_output": true,
+          "text": {
+            "type": "string"
+          },
+          "tool_calls": {
+            "format": "uint32",
+            "minimum": 0,
+            "type": "integer"
+          },
+          "turns": {
+            "format": "uint32",
+            "minimum": 0,
+            "type": "integer"
+          },
+          "usage": {
+            "$ref": "#/components/schemas/WireUsage"
+          }
+        },
+        "required": [
+          "session_id",
+          "text",
+          "turns",
+          "tool_calls",
+          "usage"
+        ],
+        "title": "WireRunResult",
+        "type": "object"
+      },
+      "WireRuntimeBinding": {
+        "description": "Runtime binding for spawn requests.\n\nFirst step toward identity-first mobs. Carries backend-specific binding\ndetails at spawn time. `External` requires real process identity.",
+        "oneOf": [
+          {
+            "properties": {
+              "kind": {
+                "const": "session",
+                "type": "string"
+              }
+            },
+            "required": [
+              "kind"
+            ],
+            "type": "object"
+          },
+          {
+            "properties": {
+              "address": {
+                "type": "string"
+              },
+              "bootstrap_token": {
+                "anyOf": [
+                  {
+                    "$ref": "#/components/schemas/BridgeBootstrapToken"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
+              },
+              "kind": {
+                "const": "external",
+                "type": "string"
+              },
+              "peer_id": {
+                "type": "string"
+              },
+              "pubkey": {
+                "description": "Ed25519 signing pubkey (32 bytes) of the external peer. Required\nfor the supervisor to install a non-zero-pubkey trust entry so\nreal-comms signed-envelope replies admit past ingress trust\ncheck. Absent on legacy bindings that pre-date pubkey plumbing.",
+                "items": {
+                  "format": "uint8",
+                  "maximum": 255,
+                  "minimum": 0,
+                  "type": "integer"
+                },
+                "maxItems": 32,
+                "minItems": 32,
+                "type": [
+                  "array",
+                  "null"
+                ]
+              }
+            },
+            "required": [
+              "kind",
+              "peer_id",
+              "address"
+            ],
+            "type": "object"
+          }
+        ]
+      },
+      "WireRuntimeState": {
+        "description": "Public runtime state projection used by RPC surfaces.",
+        "enum": [
+          "initializing",
+          "idle",
+          "attached",
+          "running",
+          "retired",
+          "stopped",
+          "destroyed"
+        ],
+        "type": "string"
+      },
+      "WireScopedModelOverride": {
+        "properties": {
+          "baseline_model_snapshot": {
+            "type": "string"
+          },
+          "id": {
+            "$ref": "#/components/schemas/ScopedModelOverrideId"
+          },
+          "kind": {
+            "$ref": "#/components/schemas/ScopedModelOverrideKind"
+          },
+          "previous_effective_model": {
+            "type": "string"
+          },
+          "target_model": {
+            "type": "string"
+          },
+          "topology_epoch": {
+            "format": "uint64",
+            "minimum": 0,
+            "type": "integer"
+          }
+        },
+        "required": [
+          "id",
+          "kind",
+          "previous_effective_model",
+          "baseline_model_snapshot",
+          "target_model",
+          "topology_epoch"
+        ],
+        "title": "ScopedModelOverride",
+        "type": "object"
+      },
+      "WireSessionHistory": {
+        "description": "Full session history in canonical wire format.\n\nNot `PartialEq`: `messages` carries `WireSessionMessage` which\ntransitively holds opaque tool-call args; compare via serialization\nround-trip rather than field equality.",
+        "properties": {
+          "has_more": {
+            "type": "boolean"
+          },
+          "limit": {
+            "format": "uint",
+            "minimum": 0,
+            "type": [
+              "integer",
+              "null"
+            ]
+          },
+          "message_count": {
+            "format": "uint",
+            "minimum": 0,
+            "type": "integer"
+          },
+          "messages": {
+            "items": {
+              "$ref": "#/components/schemas/WireSessionMessage"
+            },
+            "type": "array"
+          },
+          "offset": {
+            "format": "uint",
+            "minimum": 0,
+            "type": "integer"
+          },
+          "session_id": {
+            "type": "string"
+          },
+          "session_ref": {
+            "type": [
+              "string",
+              "null"
+            ]
+          }
+        },
+        "required": [
+          "session_id",
+          "message_count",
+          "offset",
+          "has_more",
+          "messages"
+        ],
+        "title": "WireSessionHistory",
+        "type": "object"
+      },
+      "WireSessionInfo": {
+        "description": "Canonical session info for wire protocol.",
+        "properties": {
+          "created_at": {
+            "format": "uint64",
+            "minimum": 0,
+            "type": "integer"
+          },
+          "is_active": {
+            "type": "boolean"
+          },
+          "labels": {
+            "additionalProperties": {
+              "type": "string"
+            },
+            "type": "object"
+          },
+          "last_assistant_text": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "message_count": {
+            "format": "uint",
+            "minimum": 0,
+            "type": "integer"
+          },
+          "model": {
+            "type": "string"
+          },
+          "provider": {
+            "type": "string"
+          },
+          "session_id": {
+            "type": "string"
+          },
+          "session_ref": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "updated_at": {
+            "format": "uint64",
+            "minimum": 0,
+            "type": "integer"
+          }
+        },
+        "required": [
+          "session_id",
+          "created_at",
+          "updated_at",
+          "message_count",
+          "is_active",
+          "model",
+          "provider"
+        ],
+        "title": "WireSessionInfo",
+        "type": "object"
+      },
+      "WireSessionMessage": {
+        "description": "Canonical transcript message for public wire surfaces.\n\nNot `PartialEq`: the `BlockAssistant.blocks` variant carries\n`WireAssistantBlock`s which hold opaque tool-call args as\n`Box<RawValue>`. See `WireAssistantBlock` doc.",
+        "oneOf": [
+          {
+            "properties": {
+              "content": {
+                "type": "string"
+              },
+              "created_at": {
+                "type": "string"
+              },
+              "role": {
+                "const": "system",
+                "type": "string"
+              }
+            },
+            "required": [
+              "role",
+              "content",
+              "created_at"
+            ],
+            "type": "object"
+          },
+          {
+            "properties": {
+              "body": {
+                "type": "string"
+              },
+              "created_at": {
+                "type": "string"
+              },
+              "kind": {
+                "$ref": "#/components/schemas/SystemNoticeKind"
+              },
+              "role": {
+                "const": "system_notice",
+                "type": "string"
+              }
+            },
+            "required": [
+              "role",
+              "kind",
+              "body",
+              "created_at"
+            ],
+            "type": "object"
+          },
+          {
+            "properties": {
+              "content": {
+                "$ref": "#/components/schemas/WireContentInput"
+              },
+              "created_at": {
+                "type": "string"
+              },
+              "role": {
+                "const": "user",
+                "type": "string"
+              }
+            },
+            "required": [
+              "role",
+              "content",
+              "created_at"
+            ],
+            "type": "object"
+          },
+          {
+            "properties": {
+              "content": {
+                "type": "string"
+              },
+              "created_at": {
+                "type": "string"
+              },
+              "role": {
+                "const": "assistant",
+                "type": "string"
+              },
+              "stop_reason": {
+                "$ref": "#/components/schemas/WireStopReason"
+              },
+              "tool_calls": {
+                "items": {
+                  "$ref": "#/components/schemas/WireToolCall"
+                },
+                "type": "array"
+              }
+            },
+            "required": [
+              "role",
+              "content",
+              "stop_reason",
+              "created_at"
+            ],
+            "type": "object"
+          },
+          {
+            "properties": {
+              "blocks": {
+                "items": {
+                  "$ref": "#/components/schemas/WireAssistantBlock"
+                },
+                "type": "array"
+              },
+              "created_at": {
+                "type": "string"
+              },
+              "role": {
+                "const": "block_assistant",
+                "type": "string"
+              },
+              "stop_reason": {
+                "$ref": "#/components/schemas/WireStopReason"
+              }
+            },
+            "required": [
+              "role",
+              "blocks",
+              "stop_reason",
+              "created_at"
+            ],
+            "type": "object"
+          },
+          {
+            "properties": {
+              "created_at": {
+                "type": "string"
+              },
+              "results": {
+                "items": {
+                  "$ref": "#/components/schemas/WireToolResult"
+                },
+                "type": "array"
+              },
+              "role": {
+                "const": "tool_results",
+                "type": "string"
+              }
+            },
+            "required": [
+              "role",
+              "results",
+              "created_at"
+            ],
+            "type": "object"
+          }
+        ]
+      },
+      "WireSessionModelRoutingStatus": {
+        "properties": {
+          "active_operation_override": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/ScopedModelOverrideSummary"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "active_turn_override": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/ScopedModelOverrideSummary"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "baseline_model": {
+            "type": "string"
+          },
+          "effective_model": {
+            "type": "string"
+          },
+          "pending_switch_turn": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/SwitchTurnRequestSummary"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          }
+        },
+        "required": [
+          "baseline_model",
+          "effective_model"
+        ],
+        "title": "SessionModelRoutingStatus",
+        "type": "object"
+      },
+      "WireSessionSummary": {
+        "description": "Canonical session summary for wire protocol.",
+        "properties": {
+          "created_at": {
+            "format": "uint64",
+            "minimum": 0,
+            "type": "integer"
+          },
+          "is_active": {
+            "type": "boolean"
+          },
+          "labels": {
+            "additionalProperties": {
+              "type": "string"
+            },
+            "type": "object"
+          },
+          "message_count": {
+            "format": "uint",
+            "minimum": 0,
+            "type": "integer"
+          },
+          "session_id": {
+            "type": "string"
+          },
+          "session_ref": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "total_tokens": {
+            "format": "uint64",
+            "minimum": 0,
+            "type": "integer"
+          },
+          "updated_at": {
+            "format": "uint64",
+            "minimum": 0,
+            "type": "integer"
+          }
+        },
+        "required": [
+          "session_id",
+          "created_at",
+          "updated_at",
+          "message_count",
+          "total_tokens",
+          "is_active"
+        ],
+        "title": "WireSessionSummary",
+        "type": "object"
+      },
+      "WireStopReason": {
+        "description": "Canonical stop reason for transcript messages.",
+        "enum": [
+          "end_turn",
+          "tool_use",
+          "max_tokens",
+          "stop_sequence",
+          "content_filter",
+          "cancelled"
+        ],
+        "type": "string"
+      },
+      "WireSwitchTurnControlResult": {
+        "oneOf": [
+          {
+            "properties": {
+              "duration": {
+                "$ref": "#/components/schemas/SwitchTurnDuration"
+              },
+              "request_id": {
+                "$ref": "#/components/schemas/SwitchTurnRequestId"
+              },
+              "result": {
+                "const": "applied",
+                "type": "string"
+              },
+              "target_model": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "result",
+              "request_id",
+              "target_model",
+              "duration"
+            ],
+            "type": "object"
+          },
+          {
+            "properties": {
+              "approval_id": {
+                "$ref": "#/components/schemas/ApprovalId"
+              },
+              "duration": {
+                "$ref": "#/components/schemas/SwitchTurnDuration"
+              },
+              "reason": {
+                "$ref": "#/components/schemas/SwitchTurnApprovalReason"
+              },
+              "result": {
+                "const": "awaiting_approval",
+                "type": "string"
+              },
+              "target_model": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "result",
+              "approval_id",
+              "target_model",
+              "duration",
+              "reason"
+            ],
+            "type": "object"
+          },
+          {
+            "properties": {
+              "reason": {
+                "$ref": "#/components/schemas/SwitchTurnDenialReason"
+              },
+              "request_id": {
+                "$ref": "#/components/schemas/SwitchTurnRequestId"
+              },
+              "result": {
+                "const": "denied",
+                "type": "string"
+              }
+            },
+            "required": [
+              "result",
+              "request_id",
+              "reason"
+            ],
+            "type": "object"
+          }
+        ],
+        "title": "SwitchTurnControlResult"
+      },
+      "WireSwitchTurnIntent": {
+        "properties": {
+          "duration": {
+            "$ref": "#/components/schemas/SwitchTurnDuration"
+          },
+          "origin": {
+            "$ref": "#/components/schemas/SwitchTurnOrigin"
+          },
+          "target_model": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "target_model",
+          "duration",
+          "origin"
+        ],
+        "title": "SwitchTurnIntent",
+        "type": "object"
+      },
+      "WireSwitchTurnPhase": {
+        "oneOf": [
+          {
+            "properties": {
+              "phase": {
+                "const": "requested",
+                "type": "string"
+              }
+            },
+            "required": [
+              "phase"
+            ],
+            "type": "object"
+          },
+          {
+            "properties": {
+              "phase": {
+                "const": "validating",
+                "type": "string"
+              }
+            },
+            "required": [
+              "phase"
+            ],
+            "type": "object"
+          },
+          {
+            "properties": {
+              "phase": {
+                "const": "pending_for_boundary",
+                "type": "string"
+              }
+            },
+            "required": [
+              "phase"
+            ],
+            "type": "object"
+          },
+          {
+            "properties": {
+              "approval_id": {
+                "$ref": "#/components/schemas/ApprovalId"
+              },
+              "phase": {
+                "const": "awaiting_approval",
+                "type": "string"
+              }
+            },
+            "required": [
+              "phase",
+              "approval_id"
+            ],
+            "type": "object"
+          },
+          {
+            "properties": {
+              "phase": {
+                "const": "applying_finite_override",
+                "type": "string"
+              }
+            },
+            "required": [
+              "phase"
+            ],
+            "type": "object"
+          },
+          {
+            "properties": {
+              "phase": {
+                "const": "applying_persistent_reconfigure",
+                "type": "string"
+              }
+            },
+            "required": [
+              "phase"
+            ],
+            "type": "object"
+          },
+          {
+            "properties": {
+              "phase": {
+                "const": "active_finite_override",
+                "type": "string"
+              }
+            },
+            "required": [
+              "phase"
+            ],
+            "type": "object"
+          },
+          {
+            "properties": {
+              "phase": {
+                "const": "restoring_finite_override",
+                "type": "string"
+              }
+            },
+            "required": [
+              "phase"
+            ],
+            "type": "object"
+          },
+          {
+            "properties": {
+              "phase": {
+                "const": "terminal",
+                "type": "string"
+              },
+              "terminal": {
+                "$ref": "#/components/schemas/SwitchTurnTerminalClass"
+              }
+            },
+            "required": [
+              "phase",
+              "terminal"
+            ],
+            "type": "object"
+          }
+        ],
+        "title": "SwitchTurnPhase"
+      },
+      "WireToolCall": {
+        "description": "Legacy assistant tool call payload.\n\nNot `PartialEq`: `args` rides as `Box<RawValue>` for pass-through\nfidelity with `meerkat_core::types::AssistantBlock::ToolUse.args` —\nopaque from provider to dispatcher, never re-parsed on the wire.\nEquivalence checks should round-trip through serialization.",
+        "properties": {
+          "args": true,
+          "id": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "id",
+          "name",
+          "args"
+        ],
+        "type": "object"
+      },
+      "WireToolResult": {
+        "description": "Tool result payload in a transcript.",
+        "properties": {
+          "content": {
+            "$ref": "#/components/schemas/WireToolResultContent"
+          },
+          "is_error": {
+            "default": false,
+            "type": "boolean"
+          },
+          "tool_use_id": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "tool_use_id",
+          "content"
+        ],
+        "type": "object"
+      },
+      "WireToolResultContent": {
+        "anyOf": [
+          {
+            "type": "string"
+          },
+          {
+            "items": {
+              "$ref": "#/components/schemas/WireContentBlock"
+            },
+            "type": "array"
+          }
+        ],
+        "description": "Wire-safe tool result content that handles both legacy string and array formats."
+      },
+      "WireTrustedPeerSpec": {
+        "description": "Minimal trusted peer spec for public mob wiring surfaces.\n\n`pubkey` is the Ed25519 signing public key (32 bytes) required so the\nreceiver can verify envelope signatures after trust registration.\nSerialized as a 32-element JSON array of numbers (matching\n`BridgePeerSpec`). Defaults to a zero pubkey for legacy clients —\nthe corresponding `TrustedPeerDescriptor::pubkey` will then be all\nzeros, which makes signature verification fail closed. Production\nclients MUST send the real pubkey.",
+        "properties": {
+          "address": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "peer_id": {
+            "type": "string"
+          },
+          "pubkey": {
+            "default": [
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0
+            ],
+            "items": {
+              "format": "uint8",
+              "maximum": 255,
+              "minimum": 0,
+              "type": "integer"
+            },
+            "maxItems": 32,
+            "minItems": 32,
+            "type": "array"
+          }
+        },
+        "required": [
+          "name",
+          "peer_id",
+          "address"
+        ],
+        "type": "object"
+      },
+      "WireUsage": {
+        "description": "Canonical token usage for wire protocol.",
+        "properties": {
+          "cache_creation_tokens": {
+            "format": "uint64",
+            "minimum": 0,
+            "type": [
+              "integer",
+              "null"
+            ]
+          },
+          "cache_read_tokens": {
+            "format": "uint64",
+            "minimum": 0,
+            "type": [
+              "integer",
+              "null"
+            ]
+          },
+          "input_tokens": {
+            "format": "uint64",
+            "minimum": 0,
+            "type": "integer"
+          },
+          "output_tokens": {
+            "format": "uint64",
+            "minimum": 0,
+            "type": "integer"
+          },
+          "total_tokens": {
+            "format": "uint64",
+            "minimum": 0,
+            "type": "integer"
+          }
+        },
+        "required": [
+          "input_tokens",
+          "output_tokens",
+          "total_tokens"
+        ],
+        "type": "object"
+      },
+      "WireWorkOrigin": {
+        "description": "Origin for `MobSubmitWorkParams`. Replaces the prior free-form\n`origin: Option<String>` shape.",
+        "enum": [
+          "external",
+          "internal"
+        ],
+        "type": "string"
+      }
+    }
+  },
   "info": {
     "title": "Meerkat REST API",
     "version": "0.6.0"
   },
-  "openapi": "3.0.0",
+  "openapi": "3.1.0",
   "paths": {
     "/auth/bindings/{binding_id}": {
       "delete": {
+        "operationId": "delete_auth_bindings_binding_id",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "binding_id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/WireAuthProfileCleared"
+                }
+              }
+            },
+            "description": "Successful response"
+          },
+          "default": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/WireError"
+                }
+              }
+            },
+            "description": "Error response"
+          }
+        },
         "summary": "Delete binding-scoped credentials"
       },
       "get": {
+        "operationId": "get_auth_bindings_binding_id",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "binding_id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/WireAuthProfileDetail"
+                }
+              }
+            },
+            "description": "Successful response"
+          },
+          "default": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/WireError"
+                }
+              }
+            },
+            "description": "Error response"
+          }
+        },
         "summary": "Get binding-scoped auth profile"
       }
     },
     "/auth/bindings/{binding_id}/logout": {
       "post": {
+        "operationId": "post_auth_bindings_binding_id_logout",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "binding_id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/WireAuthProfileCleared"
+                }
+              }
+            },
+            "description": "Successful response"
+          },
+          "default": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/WireError"
+                }
+              }
+            },
+            "description": "Error response"
+          }
+        },
         "summary": "Log out a binding"
       }
     },
     "/auth/bindings/{binding_id}/status": {
       "get": {
+        "operationId": "get_auth_bindings_binding_id_status",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "binding_id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/WireAuthStatusDetail"
+                }
+              }
+            },
+            "description": "Successful response"
+          },
+          "default": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/WireError"
+                }
+              }
+            },
+            "description": "Error response"
+          }
+        },
         "summary": "Get binding auth status"
       }
     },
     "/auth/bindings/{binding_id}/test": {
       "post": {
+        "operationId": "post_auth_bindings_binding_id_test",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "binding_id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/WireAuthStatusDetail"
+                }
+              }
+            },
+            "description": "Successful response"
+          },
+          "default": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/WireError"
+                }
+              }
+            },
+            "description": "Error response"
+          }
+        },
         "summary": "Test a binding resolve path"
       }
     },
     "/auth/login/complete": {
       "post": {
+        "operationId": "post_auth_login_complete",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/JsonValue"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/WireLoginReady"
+                }
+              }
+            },
+            "description": "Successful response"
+          },
+          "default": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/WireError"
+                }
+              }
+            },
+            "description": "Error response"
+          }
+        },
         "summary": "Finish OAuth login with an authorization code"
       }
     },
     "/auth/login/device/complete": {
       "post": {
+        "operationId": "post_auth_login_device_complete",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/JsonValue"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/WireLoginReady"
+                }
+              }
+            },
+            "description": "Successful response"
+          },
+          "default": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/WireError"
+                }
+              }
+            },
+            "description": "Error response"
+          }
+        },
         "summary": "Complete device-code OAuth login"
       }
     },
     "/auth/login/device/start": {
       "post": {
+        "operationId": "post_auth_login_device_start",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/JsonValue"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/WireDeviceStart"
+                }
+              }
+            },
+            "description": "Successful response"
+          },
+          "default": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/WireError"
+                }
+              }
+            },
+            "description": "Error response"
+          }
+        },
         "summary": "Begin device-code OAuth login"
       }
     },
     "/auth/login/start": {
       "post": {
+        "operationId": "post_auth_login_start",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/RestAuthLoginStartRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/WireLoginStart"
+                }
+              }
+            },
+            "description": "Successful response"
+          },
+          "default": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/WireError"
+                }
+              }
+            },
+            "description": "Error response"
+          }
+        },
         "summary": "Begin OAuth login (loopback flow)"
       }
     },
     "/auth/profiles": {
       "get": {
+        "operationId": "get_auth_profiles",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/WireAuthProfilesList"
+                }
+              }
+            },
+            "description": "Successful response"
+          },
+          "default": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/WireError"
+                }
+              }
+            },
+            "description": "Error response"
+          }
+        },
         "summary": "List realm auth profiles, backend profiles, and bindings"
       },
       "post": {
+        "operationId": "post_auth_profiles",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/RestAuthProfileCreateRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/WireAuthProfileCreated"
+                }
+              }
+            },
+            "description": "Successful response"
+          },
+          "default": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/WireError"
+                }
+              }
+            },
+            "description": "Error response"
+          }
+        },
         "summary": "Store binding-scoped credentials"
       }
     },
     "/capabilities": {
       "get": {
+        "operationId": "get_capabilities",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CapabilitiesResponse"
+                }
+              }
+            },
+            "description": "Successful response"
+          },
+          "default": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/WireError"
+                }
+              }
+            },
+            "description": "Error response"
+          }
+        },
         "summary": "Get runtime capabilities"
       }
     },
     "/comms/peers": {
       "get": {
+        "operationId": "get_comms_peers",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/JsonValue"
+                }
+              }
+            },
+            "description": "Successful response"
+          },
+          "default": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/WireError"
+                }
+              }
+            },
+            "description": "Error response"
+          }
+        },
         "summary": "List resolved comms peers"
       }
     },
     "/comms/send": {
       "post": {
+        "operationId": "post_comms_send",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/RestCommsSendRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/JsonValue"
+                }
+              }
+            },
+            "description": "Successful response"
+          },
+          "default": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/WireError"
+                }
+              }
+            },
+            "description": "Error response"
+          }
+        },
         "summary": "Send a comms message"
       }
     },
     "/config": {
       "get": {
+        "operationId": "get_config",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ConfigEnvelope"
+                }
+              }
+            },
+            "description": "Successful response"
+          },
+          "default": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/WireError"
+                }
+              }
+            },
+            "description": "Error response"
+          }
+        },
         "summary": "Read config"
       },
       "patch": {
+        "operationId": "patch_config",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/RestPatchConfigRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ConfigEnvelope"
+                }
+              }
+            },
+            "description": "Successful response"
+          },
+          "default": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/WireError"
+                }
+              }
+            },
+            "description": "Error response"
+          }
+        },
         "summary": "Merge-patch config"
       },
       "put": {
+        "operationId": "put_config",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/RestSetConfigRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ConfigEnvelope"
+                }
+              }
+            },
+            "description": "Successful response"
+          },
+          "default": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/WireError"
+                }
+              }
+            },
+            "description": "Error response"
+          }
+        },
         "summary": "Replace config"
       }
     },
     "/health": {
       "get": {
+        "operationId": "get_health",
+        "responses": {
+          "200": {
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/PlainTextResponse"
+                }
+              }
+            },
+            "description": "Successful response"
+          },
+          "default": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/WireError"
+                }
+              }
+            },
+            "description": "Error response"
+          }
+        },
         "summary": "Health check"
       }
     },
     "/mob/{id}/events": {
       "get": {
+        "operationId": "get_mob_id_events",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "text/event-stream": {
+                "schema": {
+                  "$ref": "#/components/schemas/SseEventStream"
+                }
+              }
+            },
+            "description": "Successful response"
+          },
+          "default": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/WireError"
+                }
+              }
+            },
+            "description": "Error response"
+          }
+        },
         "summary": "SSE mob event stream"
       }
     },
     "/mob/{id}/fork-helper": {
       "post": {
+        "operationId": "post_mob_id_fork_helper",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/RestMobForkHelperRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/JsonValue"
+                }
+              }
+            },
+            "description": "Successful response"
+          },
+          "default": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/WireError"
+                }
+              }
+            },
+            "description": "Error response"
+          }
+        },
         "summary": "Fork a helper member in a mob"
       }
     },
     "/mob/{id}/members/{agent_identity}/cancel": {
       "post": {
+        "operationId": "post_mob_id_members_agent_identity_cancel",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "in": "path",
+            "name": "agent_identity",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/JsonValue"
+                }
+              }
+            },
+            "description": "Successful response"
+          },
+          "default": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/WireError"
+                }
+              }
+            },
+            "description": "Error response"
+          }
+        },
         "summary": "Force-cancel a mob member"
       }
     },
     "/mob/{id}/members/{agent_identity}/respawn": {
       "post": {
+        "operationId": "post_mob_id_members_agent_identity_respawn",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "in": "path",
+            "name": "agent_identity",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/JsonValue"
+                }
+              }
+            },
+            "description": "Successful response"
+          },
+          "default": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/WireError"
+                }
+              }
+            },
+            "description": "Error response"
+          }
+        },
         "summary": "Respawn a mob member with topology restore"
       }
     },
     "/mob/{id}/members/{agent_identity}/status": {
       "get": {
         "description": "Returns the current execution/status snapshot for the named mob member.",
+        "operationId": "get_mob_id_members_agent_identity_status",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "in": "path",
+            "name": "agent_identity",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/JsonValue"
+                }
+              }
+            },
+            "description": "Successful response"
+          },
+          "default": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/WireError"
+                }
+              }
+            },
+            "description": "Error response"
+          }
+        },
         "summary": "Get a mob member execution status snapshot"
       }
     },
     "/mob/{id}/spawn-helper": {
       "post": {
+        "operationId": "post_mob_id_spawn_helper",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/RestMobHelperRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/JsonValue"
+                }
+              }
+            },
+            "description": "Successful response"
+          },
+          "default": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/WireError"
+                }
+              }
+            },
+            "description": "Error response"
+          }
+        },
         "summary": "Spawn a helper member in a mob"
+      }
+    },
+    "/mob/{id}/wait-kickoff": {
+      "post": {
+        "operationId": "post_mob_id_wait_kickoff",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/RestMobWaitRequest"
+              }
+            }
+          },
+          "required": false
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/JsonValue"
+                }
+              }
+            },
+            "description": "Successful response"
+          },
+          "default": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/WireError"
+                }
+              }
+            },
+            "description": "Error response"
+          }
+        },
+        "summary": "Wait for autonomous kickoff completion"
       }
     },
     "/models/catalog": {
       "get": {
+        "operationId": "get_models_catalog",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ModelsCatalogResponse"
+                }
+              }
+            },
+            "description": "Successful response"
+          },
+          "default": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/WireError"
+                }
+              }
+            },
+            "description": "Error response"
+          }
+        },
         "summary": "Get the compiled-in model catalog"
       }
     },
     "/realms": {
       "get": {
+        "operationId": "get_realms",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/WireRealmList"
+                }
+              }
+            },
+            "description": "Successful response"
+          },
+          "default": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/WireError"
+                }
+              }
+            },
+            "description": "Error response"
+          }
+        },
         "summary": "List realm summaries"
       }
     },
     "/realms/{id}": {
       "get": {
+        "operationId": "get_realms_id",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/WireRealmConnectionSet"
+                }
+              }
+            },
+            "description": "Successful response"
+          },
+          "default": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/WireError"
+                }
+              }
+            },
+            "description": "Error response"
+          }
+        },
         "summary": "Get a realm's connection set"
       }
     },
     "/realtime/capabilities": {
       "post": {
+        "operationId": "post_realtime_capabilities",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/RealtimeCapabilitiesParams"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/RealtimeCapabilitiesResult"
+                }
+              }
+            },
+            "description": "Successful response"
+          },
+          "default": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/WireError"
+                }
+              }
+            },
+            "description": "Error response"
+          }
+        },
         "summary": "Get product-layer realtime capabilities for a target"
       }
     },
     "/realtime/open_info": {
       "post": {
+        "operationId": "post_realtime_open_info",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/RealtimeOpenRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/RealtimeOpenInfo"
+                }
+              }
+            },
+            "description": "Successful response"
+          },
+          "default": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/WireError"
+                }
+              }
+            },
+            "description": "Error response"
+          }
+        },
         "summary": "Get bootstrap metadata for opening a realtime channel"
       }
     },
     "/realtime/status": {
       "post": {
+        "operationId": "post_realtime_status",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/RealtimeStatusParams"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/RealtimeStatusResult"
+                }
+              }
+            },
+            "description": "Successful response"
+          },
+          "default": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/WireError"
+                }
+              }
+            },
+            "description": "Error response"
+          }
+        },
         "summary": "Get product-layer realtime channel status for a target"
       }
     },
     "/runtime/capabilities": {
       "get": {
+        "operationId": "get_runtime_capabilities",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/RuntimeHostCapabilities"
+                }
+              }
+            },
+            "description": "Successful response"
+          },
+          "default": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/WireError"
+                }
+              }
+            },
+            "description": "Error response"
+          }
+        },
         "summary": "Get runtime host capability flags"
       }
     },
     "/runtime/health": {
       "get": {
+        "operationId": "get_runtime_health",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/RuntimeHostHealth"
+                }
+              }
+            },
+            "description": "Successful response"
+          },
+          "default": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/WireError"
+                }
+              }
+            },
+            "description": "Error response"
+          }
+        },
         "summary": "Get runtime host health"
       }
     },
     "/runtime/host_info": {
       "get": {
+        "operationId": "get_runtime_host_info",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/RuntimeHostInfo"
+                }
+              }
+            },
+            "description": "Successful response"
+          },
+          "default": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/WireError"
+                }
+              }
+            },
+            "description": "Error response"
+          }
+        },
         "summary": "Get read-only runtime host information"
       }
     },
     "/schedule/call": {
       "post": {
+        "operationId": "post_schedule_call",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/RestScheduleToolCallRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/JsonValue"
+                }
+              }
+            },
+            "description": "Successful response"
+          },
+          "default": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/WireError"
+                }
+              }
+            },
+            "description": "Error response"
+          }
+        },
         "summary": "Invoke a schedule tool"
       }
     },
     "/schedule/tools": {
       "get": {
+        "operationId": "get_schedule_tools",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/JsonValue"
+                }
+              }
+            },
+            "description": "Successful response"
+          },
+          "default": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/WireError"
+                }
+              }
+            },
+            "description": "Error response"
+          }
+        },
         "summary": "List schedule tools"
       }
     },
     "/schedules": {
       "get": {
+        "operationId": "get_schedules",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ScheduleListResult"
+                }
+              }
+            },
+            "description": "Successful response"
+          },
+          "default": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/WireError"
+                }
+              }
+            },
+            "description": "Error response"
+          }
+        },
         "summary": "List schedules"
       },
       "post": {
+        "operationId": "post_schedules",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/JsonValue"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/JsonValue"
+                }
+              }
+            },
+            "description": "Successful response"
+          },
+          "default": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/WireError"
+                }
+              }
+            },
+            "description": "Error response"
+          }
+        },
         "summary": "Create schedule"
       }
     },
     "/schedules/{id}": {
       "delete": {
+        "operationId": "delete_schedules_id",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/JsonValue"
+                }
+              }
+            },
+            "description": "Successful response"
+          },
+          "default": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/WireError"
+                }
+              }
+            },
+            "description": "Error response"
+          }
+        },
         "summary": "Delete schedule"
       },
       "get": {
+        "operationId": "get_schedules_id",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/JsonValue"
+                }
+              }
+            },
+            "description": "Successful response"
+          },
+          "default": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/WireError"
+                }
+              }
+            },
+            "description": "Error response"
+          }
+        },
         "summary": "Get schedule"
       },
       "patch": {
+        "operationId": "patch_schedules_id",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/JsonValue"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/JsonValue"
+                }
+              }
+            },
+            "description": "Successful response"
+          },
+          "default": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/WireError"
+                }
+              }
+            },
+            "description": "Error response"
+          }
+        },
         "summary": "Update schedule"
       }
     },
     "/schedules/{id}/occurrences": {
       "get": {
+        "operationId": "get_schedules_id_occurrences",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ScheduleOccurrencesResult"
+                }
+              }
+            },
+            "description": "Successful response"
+          },
+          "default": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/WireError"
+                }
+              }
+            },
+            "description": "Error response"
+          }
+        },
         "summary": "List schedule occurrences"
       }
     },
     "/schedules/{id}/pause": {
       "post": {
+        "operationId": "post_schedules_id_pause",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/JsonValue"
+                }
+              }
+            },
+            "description": "Successful response"
+          },
+          "default": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/WireError"
+                }
+              }
+            },
+            "description": "Error response"
+          }
+        },
         "summary": "Pause schedule"
       }
     },
     "/schedules/{id}/resume": {
       "post": {
+        "operationId": "post_schedules_id_resume",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/JsonValue"
+                }
+              }
+            },
+            "description": "Successful response"
+          },
+          "default": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/WireError"
+                }
+              }
+            },
+            "description": "Error response"
+          }
+        },
         "summary": "Resume schedule"
       }
     },
     "/sessions": {
       "get": {
+        "operationId": "get_sessions",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ListSessionsResponse"
+                }
+              }
+            },
+            "description": "Successful response"
+          },
+          "default": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/WireError"
+                }
+              }
+            },
+            "description": "Error response"
+          }
+        },
         "summary": "List sessions"
       },
       "post": {
+        "operationId": "post_sessions",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/RestCreateSessionRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/WireRunResult"
+                }
+              }
+            },
+            "description": "Successful response"
+          },
+          "default": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/WireError"
+                }
+              }
+            },
+            "description": "Error response"
+          }
+        },
         "summary": "Create and run a new session"
       }
     },
     "/sessions/{id}": {
       "delete": {
+        "operationId": "delete_sessions_id",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/StatusResponse"
+                }
+              }
+            },
+            "description": "Successful response"
+          },
+          "default": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/WireError"
+                }
+              }
+            },
+            "description": "Error response"
+          }
+        },
         "summary": "Archive a session"
       },
       "get": {
+        "operationId": "get_sessions_id",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SessionDetailsResponse"
+                }
+              }
+            },
+            "description": "Successful response"
+          },
+          "default": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/WireError"
+                }
+              }
+            },
+            "description": "Error response"
+          }
+        },
         "summary": "Get session details"
       }
     },
     "/sessions/{id}/events": {
       "get": {
+        "operationId": "get_sessions_id_events",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "text/event-stream": {
+                "schema": {
+                  "$ref": "#/components/schemas/SseEventStream"
+                }
+              }
+            },
+            "description": "Successful response"
+          },
+          "default": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/WireError"
+                }
+              }
+            },
+            "description": "Error response"
+          }
+        },
         "summary": "SSE event stream"
       }
     },
     "/sessions/{id}/external-events": {
       "post": {
+        "operationId": "post_sessions_id_external_events",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/JsonValue"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/StatusResponse"
+                }
+              }
+            },
+            "description": "Successful response"
+          },
+          "default": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/WireError"
+                }
+              }
+            },
+            "description": "Error response"
+          }
+        },
         "summary": "Queue a runtime-backed external event"
       }
     },
     "/sessions/{id}/history": {
       "get": {
+        "operationId": "get_sessions_id_history",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/WireSessionHistory"
+                }
+              }
+            },
+            "description": "Successful response"
+          },
+          "default": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/WireError"
+                }
+              }
+            },
+            "description": "Error response"
+          }
+        },
         "summary": "Get full session history"
       }
     },
     "/sessions/{id}/interrupt": {
       "post": {
+        "operationId": "post_sessions_id_interrupt",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/StatusResponse"
+                }
+              }
+            },
+            "description": "Successful response"
+          },
+          "default": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/WireError"
+                }
+              }
+            },
+            "description": "Error response"
+          }
+        },
         "summary": "Interrupt a running session"
       }
     },
     "/sessions/{id}/mcp/add": {
       "post": {
         "description": "Requires mcp_live capability. Check GET /capabilities.",
+        "operationId": "post_sessions_id_mcp_add",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/McpAddParams"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/McpLiveOpResponse"
+                }
+              }
+            },
+            "description": "Successful response"
+          },
+          "default": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/WireError"
+                }
+              }
+            },
+            "description": "Error response"
+          }
+        },
         "summary": "Stage live MCP server addition"
       }
     },
     "/sessions/{id}/mcp/reload": {
       "post": {
         "description": "Requires mcp_live capability. Check GET /capabilities.",
+        "operationId": "post_sessions_id_mcp_reload",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/McpReloadParams"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/McpLiveOpResponse"
+                }
+              }
+            },
+            "description": "Successful response"
+          },
+          "default": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/WireError"
+                }
+              }
+            },
+            "description": "Error response"
+          }
+        },
         "summary": "Stage live MCP server reload"
       }
     },
     "/sessions/{id}/mcp/remove": {
       "post": {
         "description": "Requires mcp_live capability. Check GET /capabilities.",
+        "operationId": "post_sessions_id_mcp_remove",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/McpRemoveParams"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/McpLiveOpResponse"
+                }
+              }
+            },
+            "description": "Successful response"
+          },
+          "default": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/WireError"
+                }
+              }
+            },
+            "description": "Error response"
+          }
+        },
         "summary": "Stage live MCP server removal"
       }
     },
     "/sessions/{id}/messages": {
       "post": {
+        "operationId": "post_sessions_id_messages",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/RestContinueSessionRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/WireRunResult"
+                }
+              }
+            },
+            "description": "Successful response"
+          },
+          "default": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/WireError"
+                }
+              }
+            },
+            "description": "Error response"
+          }
+        },
         "summary": "Continue session with new message"
       }
     },
     "/sessions/{id}/peer-response-terminal": {
       "post": {
+        "operationId": "post_sessions_id_peer_response_terminal",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/RestPeerResponseTerminalRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/StatusResponse"
+                }
+              }
+            },
+            "description": "Successful response"
+          },
+          "default": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/WireError"
+                }
+              }
+            },
+            "description": "Error response"
+          }
+        },
         "summary": "Admit a correlated terminal peer response through the typed runtime ingress"
       }
     },
     "/sessions/{id}/realtime-attachment-status": {
       "get": {
+        "operationId": "get_sessions_id_realtime_attachment_status",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/RuntimeRealtimeAttachmentStatusResult"
+                }
+              }
+            },
+            "description": "Successful response"
+          },
+          "default": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/WireError"
+                }
+              }
+            },
+            "description": "Error response"
+          }
+        },
         "summary": "Get a session's realtime attachment status"
       }
     },
     "/sessions/{id}/reset": {
       "post": {
+        "operationId": "post_sessions_id_reset",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/RuntimeResetResult"
+                }
+              }
+            },
+            "description": "Successful response"
+          },
+          "default": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/WireError"
+                }
+              }
+            },
+            "description": "Error response"
+          }
+        },
         "summary": "Reset a session runtime"
       }
     },
     "/sessions/{id}/retire": {
       "post": {
+        "operationId": "post_sessions_id_retire",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/RuntimeRetireResult"
+                }
+              }
+            },
+            "description": "Successful response"
+          },
+          "default": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/WireError"
+                }
+              }
+            },
+            "description": "Error response"
+          }
+        },
         "summary": "Retire a session runtime"
       }
     },
     "/sessions/{id}/status": {
       "get": {
+        "operationId": "get_sessions_id_status",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/RuntimeStateResult"
+                }
+              }
+            },
+            "description": "Successful response"
+          },
+          "default": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/WireError"
+                }
+              }
+            },
+            "description": "Error response"
+          }
+        },
         "summary": "Get a session's current runtime state"
       }
     },
     "/sessions/{id}/submissions": {
       "get": {
+        "operationId": "get_sessions_id_submissions",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/InputListResult"
+                }
+              }
+            },
+            "description": "Successful response"
+          },
+          "default": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/WireError"
+                }
+              }
+            },
+            "description": "Error response"
+          }
+        },
         "summary": "List active inputs for a session"
       }
     },
     "/sessions/{id}/submit": {
       "post": {
+        "operationId": "post_sessions_id_submit",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/RuntimeAcceptParams"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/RuntimeAcceptResult"
+                }
+              }
+            },
+            "description": "Successful response"
+          },
+          "default": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/WireError"
+                }
+              }
+            },
+            "description": "Error response"
+          }
+        },
         "summary": "Accept a runtime input for a session"
       }
     },
     "/sessions/{id}/system_context": {
       "post": {
+        "operationId": "post_sessions_id_system_context",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/RestAppendSystemContextRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/StatusResponse"
+                }
+              }
+            },
+            "description": "Successful response"
+          },
+          "default": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/WireError"
+                }
+              }
+            },
+            "description": "Error response"
+          }
+        },
         "summary": "Append system context to a session"
       }
     },
     "/sessions/{session_id}/submissions/{submission_id}": {
       "get": {
+        "operationId": "get_sessions_session_id_submissions_submission_id",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "session_id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "in": "path",
+            "name": "submission_id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/InputStateResult"
+                }
+              }
+            },
+            "description": "Successful response"
+          },
+          "default": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/WireError"
+                }
+              }
+            },
+            "description": "Error response"
+          }
+        },
         "summary": "Get the state of a specific input on a session"
       }
     },
     "/skills": {
       "get": {
+        "operationId": "get_skills",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SkillListResponse"
+                }
+              }
+            },
+            "description": "Successful response"
+          },
+          "default": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/WireError"
+                }
+              }
+            },
+            "description": "Error response"
+          }
+        },
         "summary": "List available skills"
       }
     }

--- a/artifacts/schemas/wire-types.json
+++ b/artifacts/schemas/wire-types.json
@@ -3702,8 +3702,7 @@
             "type": "string"
           },
           "stage": {
-            "description": "One of `\"spawn\"` or `\"retire\"`.",
-            "type": "string"
+            "$ref": "#/$defs/WireMobReconcileStage"
           }
         },
         "required": [
@@ -3768,6 +3767,14 @@
       },
       "WireMemberRef": {
         "description": "Server-resolved opaque handle for a mob member.\n\nEncodes `{mob_id, agent_identity}` as a single base64url-encoded token\nthat callers treat as opaque. The server resolves the current\n`AgentRuntimeId` and fence token against the live mob roster on every\ndispatch — clients never reason about `generation` or `fence_token`\ndirectly.\n\nUse [`WireMemberRef::encode`] to produce a token and\n[`WireMemberRef::decode`] inside an RPC handler to recover the\n`(mob_id, agent_identity)` pair before resolving against the runtime.",
+        "type": "string"
+      },
+      "WireMobReconcileStage": {
+        "description": "Closed wire stage for a per-identity `mob/reconcile` failure.",
+        "enum": [
+          "spawn",
+          "retire"
+        ],
         "type": "string"
       }
     },
@@ -10733,6 +10740,385 @@
     "title": "ScheduleOccurrencesResult",
     "type": "object"
   },
+  "SkillEntry": {
+    "$defs": {
+      "SkillKey": {
+        "description": "Canonical runtime identity for a skill.\n\nThis is the single identity carried across every surface — the wire parses\ndirectly into this struct, tools receive this struct, the registry stores\nthis struct. There is no slash-delimited string path form.",
+        "properties": {
+          "skill_name": {
+            "$ref": "#/$defs/SkillName"
+          },
+          "source_uuid": {
+            "$ref": "#/$defs/SourceUuid"
+          }
+        },
+        "required": [
+          "source_uuid",
+          "skill_name"
+        ],
+        "type": "object"
+      },
+      "SkillName": {
+        "description": "Canonical skill slug (lowercase, dash-separated).",
+        "type": "string"
+      },
+      "SkillSourceProvenance": {
+        "description": "Typed source provenance for a skill entry. `display_name` is presentation\nmetadata only; `source_uuid` is the stable identity.",
+        "properties": {
+          "display_name": {
+            "type": "string"
+          },
+          "fingerprint": {
+            "type": "string"
+          },
+          "source_uuid": {
+            "$ref": "#/$defs/SourceUuid"
+          },
+          "status": {
+            "$ref": "#/$defs/SourceIdentityStatus",
+            "default": "active"
+          },
+          "transport_kind": {
+            "$ref": "#/$defs/SourceTransportKind"
+          }
+        },
+        "required": [
+          "source_uuid",
+          "display_name",
+          "transport_kind",
+          "fingerprint"
+        ],
+        "type": "object"
+      },
+      "SourceIdentityStatus": {
+        "description": "Source lifecycle status in the identity registry.",
+        "enum": [
+          "active",
+          "disabled",
+          "retired"
+        ],
+        "type": "string"
+      },
+      "SourceTransportKind": {
+        "description": "Source transport class used for identity governance.",
+        "enum": [
+          "embedded",
+          "filesystem",
+          "git",
+          "http",
+          "stdio"
+        ],
+        "type": "string"
+      },
+      "SourceUuid": {
+        "description": "Canonical source identifier.",
+        "type": "string"
+      }
+    },
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "description": "Wire representation of a skill entry (for list responses).",
+    "properties": {
+      "description": {
+        "description": "Short description.",
+        "type": "string"
+      },
+      "is_active": {
+        "description": "Whether this skill is active (not shadowed by a higher-precedence source).",
+        "type": "boolean"
+      },
+      "key": {
+        "$ref": "#/$defs/SkillKey",
+        "description": "Canonical skill identity."
+      },
+      "name": {
+        "description": "Human-readable name.",
+        "type": "string"
+      },
+      "scope": {
+        "description": "Scope: \"builtin\", \"project\", or \"user\".",
+        "type": "string"
+      },
+      "shadowed_by": {
+        "anyOf": [
+          {
+            "$ref": "#/$defs/SkillSourceProvenance"
+          },
+          {
+            "type": "null"
+          }
+        ],
+        "description": "If shadowed, the higher-precedence source identity."
+      },
+      "source": {
+        "$ref": "#/$defs/SkillSourceProvenance",
+        "description": "Typed source provenance."
+      }
+    },
+    "required": [
+      "key",
+      "name",
+      "description",
+      "scope",
+      "source",
+      "is_active"
+    ],
+    "title": "SkillEntry",
+    "type": "object"
+  },
+  "SkillInspectResponse": {
+    "$defs": {
+      "SkillKey": {
+        "description": "Canonical runtime identity for a skill.\n\nThis is the single identity carried across every surface — the wire parses\ndirectly into this struct, tools receive this struct, the registry stores\nthis struct. There is no slash-delimited string path form.",
+        "properties": {
+          "skill_name": {
+            "$ref": "#/$defs/SkillName"
+          },
+          "source_uuid": {
+            "$ref": "#/$defs/SourceUuid"
+          }
+        },
+        "required": [
+          "source_uuid",
+          "skill_name"
+        ],
+        "type": "object"
+      },
+      "SkillName": {
+        "description": "Canonical skill slug (lowercase, dash-separated).",
+        "type": "string"
+      },
+      "SkillSourceProvenance": {
+        "description": "Typed source provenance for a skill entry. `display_name` is presentation\nmetadata only; `source_uuid` is the stable identity.",
+        "properties": {
+          "display_name": {
+            "type": "string"
+          },
+          "fingerprint": {
+            "type": "string"
+          },
+          "source_uuid": {
+            "$ref": "#/$defs/SourceUuid"
+          },
+          "status": {
+            "$ref": "#/$defs/SourceIdentityStatus",
+            "default": "active"
+          },
+          "transport_kind": {
+            "$ref": "#/$defs/SourceTransportKind"
+          }
+        },
+        "required": [
+          "source_uuid",
+          "display_name",
+          "transport_kind",
+          "fingerprint"
+        ],
+        "type": "object"
+      },
+      "SourceIdentityStatus": {
+        "description": "Source lifecycle status in the identity registry.",
+        "enum": [
+          "active",
+          "disabled",
+          "retired"
+        ],
+        "type": "string"
+      },
+      "SourceTransportKind": {
+        "description": "Source transport class used for identity governance.",
+        "enum": [
+          "embedded",
+          "filesystem",
+          "git",
+          "http",
+          "stdio"
+        ],
+        "type": "string"
+      },
+      "SourceUuid": {
+        "description": "Canonical source identifier.",
+        "type": "string"
+      }
+    },
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "description": "Wire response for inspecting a single skill.",
+    "properties": {
+      "body": {
+        "description": "Full skill body (markdown content).",
+        "type": "string"
+      },
+      "description": {
+        "description": "Short description.",
+        "type": "string"
+      },
+      "key": {
+        "$ref": "#/$defs/SkillKey",
+        "description": "Canonical skill identity."
+      },
+      "name": {
+        "description": "Human-readable name.",
+        "type": "string"
+      },
+      "scope": {
+        "description": "Scope: \"builtin\", \"project\", or \"user\".",
+        "type": "string"
+      },
+      "source": {
+        "$ref": "#/$defs/SkillSourceProvenance",
+        "description": "Typed source provenance."
+      }
+    },
+    "required": [
+      "key",
+      "name",
+      "description",
+      "scope",
+      "source",
+      "body"
+    ],
+    "title": "SkillInspectResponse",
+    "type": "object"
+  },
+  "SkillListResponse": {
+    "$defs": {
+      "SkillEntry": {
+        "description": "Wire representation of a skill entry (for list responses).",
+        "properties": {
+          "description": {
+            "description": "Short description.",
+            "type": "string"
+          },
+          "is_active": {
+            "description": "Whether this skill is active (not shadowed by a higher-precedence source).",
+            "type": "boolean"
+          },
+          "key": {
+            "$ref": "#/$defs/SkillKey",
+            "description": "Canonical skill identity."
+          },
+          "name": {
+            "description": "Human-readable name.",
+            "type": "string"
+          },
+          "scope": {
+            "description": "Scope: \"builtin\", \"project\", or \"user\".",
+            "type": "string"
+          },
+          "shadowed_by": {
+            "anyOf": [
+              {
+                "$ref": "#/$defs/SkillSourceProvenance"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "If shadowed, the higher-precedence source identity."
+          },
+          "source": {
+            "$ref": "#/$defs/SkillSourceProvenance",
+            "description": "Typed source provenance."
+          }
+        },
+        "required": [
+          "key",
+          "name",
+          "description",
+          "scope",
+          "source",
+          "is_active"
+        ],
+        "type": "object"
+      },
+      "SkillKey": {
+        "description": "Canonical runtime identity for a skill.\n\nThis is the single identity carried across every surface — the wire parses\ndirectly into this struct, tools receive this struct, the registry stores\nthis struct. There is no slash-delimited string path form.",
+        "properties": {
+          "skill_name": {
+            "$ref": "#/$defs/SkillName"
+          },
+          "source_uuid": {
+            "$ref": "#/$defs/SourceUuid"
+          }
+        },
+        "required": [
+          "source_uuid",
+          "skill_name"
+        ],
+        "type": "object"
+      },
+      "SkillName": {
+        "description": "Canonical skill slug (lowercase, dash-separated).",
+        "type": "string"
+      },
+      "SkillSourceProvenance": {
+        "description": "Typed source provenance for a skill entry. `display_name` is presentation\nmetadata only; `source_uuid` is the stable identity.",
+        "properties": {
+          "display_name": {
+            "type": "string"
+          },
+          "fingerprint": {
+            "type": "string"
+          },
+          "source_uuid": {
+            "$ref": "#/$defs/SourceUuid"
+          },
+          "status": {
+            "$ref": "#/$defs/SourceIdentityStatus",
+            "default": "active"
+          },
+          "transport_kind": {
+            "$ref": "#/$defs/SourceTransportKind"
+          }
+        },
+        "required": [
+          "source_uuid",
+          "display_name",
+          "transport_kind",
+          "fingerprint"
+        ],
+        "type": "object"
+      },
+      "SourceIdentityStatus": {
+        "description": "Source lifecycle status in the identity registry.",
+        "enum": [
+          "active",
+          "disabled",
+          "retired"
+        ],
+        "type": "string"
+      },
+      "SourceTransportKind": {
+        "description": "Source transport class used for identity governance.",
+        "enum": [
+          "embedded",
+          "filesystem",
+          "git",
+          "http",
+          "stdio"
+        ],
+        "type": "string"
+      },
+      "SourceUuid": {
+        "description": "Canonical source identifier.",
+        "type": "string"
+      }
+    },
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "description": "Wire response for listing skills with introspection data.",
+    "properties": {
+      "skills": {
+        "items": {
+          "$ref": "#/$defs/SkillEntry"
+        },
+        "type": "array"
+      }
+    },
+    "required": [
+      "skills"
+    ],
+    "title": "SkillListResponse",
+    "type": "object"
+  },
   "WireAssistantBlock": {
     "$defs": {
       "AssistantImageId": {
@@ -15944,6 +16330,276 @@
     ],
     "title": "WireRenderSalience",
     "type": "string"
+  },
+  "WireRunResult": {
+    "$defs": {
+      "Provider": {
+        "description": "Supported LLM providers.",
+        "enum": [
+          "anthropic",
+          "open_a_i",
+          "gemini",
+          "self_hosted",
+          "other"
+        ],
+        "type": "string"
+      },
+      "SchemaWarning": {
+        "description": "Warnings emitted during schema lowering.",
+        "properties": {
+          "message": {
+            "type": "string"
+          },
+          "path": {
+            "type": "string"
+          },
+          "provider": {
+            "$ref": "#/$defs/Provider"
+          }
+        },
+        "required": [
+          "provider",
+          "path",
+          "message"
+        ],
+        "type": "object"
+      },
+      "SessionId": {
+        "description": "Unique identifier for a session (UUID v7 for time-ordering)",
+        "type": "string"
+      },
+      "SkillKey": {
+        "description": "Canonical runtime identity for a skill.\n\nThis is the single identity carried across every surface — the wire parses\ndirectly into this struct, tools receive this struct, the registry stores\nthis struct. There is no slash-delimited string path form.",
+        "properties": {
+          "skill_name": {
+            "$ref": "#/$defs/SkillName"
+          },
+          "source_uuid": {
+            "$ref": "#/$defs/SourceUuid"
+          }
+        },
+        "required": [
+          "source_uuid",
+          "skill_name"
+        ],
+        "type": "object"
+      },
+      "SkillName": {
+        "description": "Canonical skill slug (lowercase, dash-separated).",
+        "type": "string"
+      },
+      "SkillQuarantineDiagnostic": {
+        "description": "Per-skill quarantine diagnostic.",
+        "properties": {
+          "error_class": {
+            "type": "string"
+          },
+          "error_code": {
+            "type": "string"
+          },
+          "first_seen_unix_secs": {
+            "format": "uint64",
+            "minimum": 0,
+            "type": "integer"
+          },
+          "key": {
+            "$ref": "#/$defs/SkillKey"
+          },
+          "last_seen_unix_secs": {
+            "format": "uint64",
+            "minimum": 0,
+            "type": "integer"
+          },
+          "location": {
+            "type": "string"
+          },
+          "message": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "key",
+          "location",
+          "error_code",
+          "error_class",
+          "message",
+          "first_seen_unix_secs",
+          "last_seen_unix_secs"
+        ],
+        "type": "object"
+      },
+      "SkillRuntimeDiagnostics": {
+        "description": "Runtime-visible diagnostics for skill health and quarantined entries.",
+        "properties": {
+          "quarantined": {
+            "items": {
+              "$ref": "#/$defs/SkillQuarantineDiagnostic"
+            },
+            "type": "array"
+          },
+          "source_health": {
+            "$ref": "#/$defs/SourceHealthSnapshot"
+          }
+        },
+        "required": [
+          "source_health",
+          "quarantined"
+        ],
+        "type": "object"
+      },
+      "SourceHealthSnapshot": {
+        "description": "Source health snapshot reported by sources.",
+        "properties": {
+          "failure_streak": {
+            "format": "uint32",
+            "minimum": 0,
+            "type": "integer"
+          },
+          "handshake_failed": {
+            "type": "boolean"
+          },
+          "invalid_count": {
+            "format": "uint32",
+            "minimum": 0,
+            "type": "integer"
+          },
+          "invalid_ratio": {
+            "format": "float",
+            "type": "number"
+          },
+          "state": {
+            "$ref": "#/$defs/SourceHealthState"
+          },
+          "total_count": {
+            "format": "uint32",
+            "minimum": 0,
+            "type": "integer"
+          }
+        },
+        "required": [
+          "state",
+          "invalid_ratio",
+          "invalid_count",
+          "total_count",
+          "failure_streak",
+          "handshake_failed"
+        ],
+        "type": "object"
+      },
+      "SourceHealthState": {
+        "description": "Source health state.",
+        "enum": [
+          "healthy",
+          "degraded",
+          "unhealthy"
+        ],
+        "type": "string"
+      },
+      "SourceUuid": {
+        "description": "Canonical source identifier.",
+        "type": "string"
+      },
+      "WireUsage": {
+        "description": "Canonical token usage for wire protocol.",
+        "properties": {
+          "cache_creation_tokens": {
+            "format": "uint64",
+            "minimum": 0,
+            "type": [
+              "integer",
+              "null"
+            ]
+          },
+          "cache_read_tokens": {
+            "format": "uint64",
+            "minimum": 0,
+            "type": [
+              "integer",
+              "null"
+            ]
+          },
+          "input_tokens": {
+            "format": "uint64",
+            "minimum": 0,
+            "type": "integer"
+          },
+          "output_tokens": {
+            "format": "uint64",
+            "minimum": 0,
+            "type": "integer"
+          },
+          "total_tokens": {
+            "format": "uint64",
+            "minimum": 0,
+            "type": "integer"
+          }
+        },
+        "required": [
+          "input_tokens",
+          "output_tokens",
+          "total_tokens"
+        ],
+        "type": "object"
+      }
+    },
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "description": "Canonical run result for wire protocol.",
+    "properties": {
+      "schema_warnings": {
+        "items": {
+          "$ref": "#/$defs/SchemaWarning"
+        },
+        "type": [
+          "array",
+          "null"
+        ]
+      },
+      "session_id": {
+        "$ref": "#/$defs/SessionId"
+      },
+      "session_ref": {
+        "type": [
+          "string",
+          "null"
+        ]
+      },
+      "skill_diagnostics": {
+        "anyOf": [
+          {
+            "$ref": "#/$defs/SkillRuntimeDiagnostics"
+          },
+          {
+            "type": "null"
+          }
+        ]
+      },
+      "structured_output": true,
+      "text": {
+        "type": "string"
+      },
+      "tool_calls": {
+        "format": "uint32",
+        "minimum": 0,
+        "type": "integer"
+      },
+      "turns": {
+        "format": "uint32",
+        "minimum": 0,
+        "type": "integer"
+      },
+      "usage": {
+        "$ref": "#/$defs/WireUsage"
+      }
+    },
+    "required": [
+      "session_id",
+      "text",
+      "turns",
+      "tool_calls",
+      "usage"
+    ],
+    "title": "WireRunResult",
+    "type": "object"
   },
   "WireRuntimeState": {
     "$schema": "https://json-schema.org/draft/2020-12/schema",

--- a/meerkat-contracts/src/emit.rs
+++ b/meerkat-contracts/src/emit.rs
@@ -32,6 +32,7 @@ pub fn emit_all_schemas(output_dir: &std::path::Path) -> Result<(), Box<dyn std:
     let wire_types = serde_json::json!({
         "WireUsage": schema_for!(crate::wire::WireUsage),
         "ContractVersion": schema_for!(crate::version::ContractVersion),
+        "WireRunResult": schema_for!(crate::wire::WireRunResult),
         "McpLiveOpStatus": schema_for!(crate::wire::McpLiveOpStatus),
         "McpLiveOperation": schema_for!(crate::wire::McpLiveOperation),
         "McpLiveOpResponse": schema_for!(crate::wire::McpLiveOpResponse),
@@ -143,6 +144,9 @@ pub fn emit_all_schemas(output_dir: &std::path::Path) -> Result<(), Box<dyn std:
         "WireAuthStatus": schema_for!(crate::wire::WireAuthStatus),
         "WireAuthStatusDetail": schema_for!(crate::wire::WireAuthStatusDetail),
         "WireAuthError": schema_for!(crate::wire::WireAuthError),
+        "SkillEntry": schema_for!(crate::wire::SkillEntry),
+        "SkillListResponse": schema_for!(crate::wire::SkillListResponse),
+        "SkillInspectResponse": schema_for!(crate::wire::SkillInspectResponse),
         "CommsCommandRequest": schema_for!(crate::wire::CommsCommandRequest),
     });
     write_pretty_json(output_dir.join("wire-types.json"), &wire_types)?;
@@ -275,9 +279,694 @@ pub fn emit_all_schemas(output_dir: &std::path::Path) -> Result<(), Box<dyn std:
     });
     write_pretty_json(output_dir.join("rpc-methods.json"), &rpc_methods)?;
 
-    // REST OpenAPI — endpoint listing snapshot, not a full OpenAPI spec.
-    // Request/response body schemas are intentionally omitted, but the path
-    // inventory should stay aligned with the live router surface.
+    fn schema_ref(name: &str) -> Value {
+        serde_json::json!({ "$ref": format!("#/components/schemas/{name}") })
+    }
+
+    fn media_content(content_type: &str, schema_name: &str) -> Value {
+        serde_json::json!({
+            content_type: {
+                "schema": schema_ref(schema_name),
+            }
+        })
+    }
+
+    fn rewrite_component_refs(value: &mut Value) {
+        match value {
+            Value::Object(object) => {
+                if let Some(Value::String(reference)) = object.get_mut("$ref")
+                    && let Some(name) = reference.strip_prefix("#/$defs/")
+                {
+                    *reference = format!("#/components/schemas/{name}");
+                }
+                for nested in object.values_mut() {
+                    rewrite_component_refs(nested);
+                }
+            }
+            Value::Array(values) => {
+                for nested in values {
+                    rewrite_component_refs(nested);
+                }
+            }
+            _ => {}
+        }
+    }
+
+    fn add_component_schema(components: &mut Map<String, Value>, name: String, mut schema: Value) {
+        let defs = schema
+            .as_object_mut()
+            .and_then(|object| object.remove("$defs"));
+        if let Some(Value::Object(defs)) = defs {
+            for (def_name, def_schema) in defs {
+                add_component_schema(components, def_name, def_schema);
+            }
+        }
+        if let Some(object) = schema.as_object_mut() {
+            object.remove("$schema");
+        }
+        rewrite_component_refs(&mut schema);
+        components.entry(name).or_insert(schema);
+    }
+
+    fn add_component_section(components: &mut Map<String, Value>, section: &Value) {
+        if let Some(schemas) = section.as_object() {
+            for (name, schema) in schemas {
+                add_component_schema(components, name.clone(), schema.clone());
+            }
+        }
+    }
+
+    fn object_schema(properties: Vec<(&str, Value)>, required: Vec<&str>) -> Value {
+        let mut property_map = Map::new();
+        for (name, schema) in properties {
+            property_map.insert(name.to_string(), schema);
+        }
+        serde_json::json!({
+            "type": "object",
+            "properties": Value::Object(property_map),
+            "required": required,
+        })
+    }
+
+    fn string_schema() -> Value {
+        serde_json::json!({ "type": "string" })
+    }
+
+    fn bool_schema() -> Value {
+        serde_json::json!({ "type": "boolean" })
+    }
+
+    fn integer_schema() -> Value {
+        serde_json::json!({ "type": "integer", "minimum": 0 })
+    }
+
+    fn json_value_schema() -> Value {
+        serde_json::json!({
+            "description": "Arbitrary JSON value.",
+        })
+    }
+
+    fn nullable(schema: Value) -> Value {
+        serde_json::json!({ "anyOf": [schema, { "type": "null" }] })
+    }
+
+    fn rest_manual_components() -> Map<String, Value> {
+        let mut components = Map::new();
+        let json_value = schema_ref("JsonValue");
+        let content_input = serde_json::json!({
+            "oneOf": [
+                { "type": "string" },
+                schema_ref("WireContentInput")
+            ]
+        });
+        let labels = serde_json::json!({
+            "type": "object",
+            "additionalProperties": { "type": "string" }
+        });
+        let string_array = serde_json::json!({
+            "type": "array",
+            "items": { "type": "string" }
+        });
+
+        components.insert("JsonValue".to_string(), json_value_schema());
+        components.insert(
+            "PlainTextResponse".to_string(),
+            serde_json::json!({ "type": "string" }),
+        );
+        components.insert(
+            "SseEventStream".to_string(),
+            serde_json::json!({
+                "type": "string",
+                "description": "Server-sent event stream."
+            }),
+        );
+        components.insert(
+            "StatusResponse".to_string(),
+            serde_json::json!({
+                "type": "object",
+                "additionalProperties": true
+            }),
+        );
+        components.insert(
+            "ListSessionsResponse".to_string(),
+            object_schema(
+                vec![(
+                    "sessions",
+                    serde_json::json!({
+                        "type": "array",
+                        "items": schema_ref("WireSessionSummary")
+                    }),
+                )],
+                vec!["sessions"],
+            ),
+        );
+        components.insert(
+            "SessionDetailsResponse".to_string(),
+            object_schema(
+                vec![
+                    ("session_id", string_schema()),
+                    ("session_ref", string_schema()),
+                    ("created_at", string_schema()),
+                    ("updated_at", string_schema()),
+                    ("message_count", integer_schema()),
+                    ("total_tokens", integer_schema()),
+                    ("labels", labels.clone()),
+                ],
+                vec![
+                    "session_id",
+                    "session_ref",
+                    "created_at",
+                    "updated_at",
+                    "message_count",
+                    "total_tokens",
+                ],
+            ),
+        );
+        components.insert(
+            "ConfigEnvelope".to_string(),
+            object_schema(
+                vec![
+                    ("config", json_value.clone()),
+                    ("generation", integer_schema()),
+                    ("realm_id", string_schema()),
+                    ("instance_id", string_schema()),
+                    ("backend", string_schema()),
+                    (
+                        "resolved_paths",
+                        serde_json::json!({
+                            "type": "object",
+                            "additionalProperties": { "type": "string" }
+                        }),
+                    ),
+                ],
+                vec!["config", "generation"],
+            ),
+        );
+        components.insert(
+            "RestCreateSessionRequest".to_string(),
+            object_schema(
+                vec![
+                    ("prompt", content_input.clone()),
+                    ("system_prompt", string_schema()),
+                    ("model", string_schema()),
+                    ("provider", string_schema()),
+                    ("max_tokens", integer_schema()),
+                    ("output_schema", json_value.clone()),
+                    ("structured_output_retries", integer_schema()),
+                    ("verbose", bool_schema()),
+                    ("keep_alive", nullable(bool_schema())),
+                    ("comms_name", string_schema()),
+                    ("peer_meta", json_value.clone()),
+                    ("hooks_override", json_value.clone()),
+                    ("enable_builtins", bool_schema()),
+                    ("enable_shell", bool_schema()),
+                    ("enable_memory", bool_schema()),
+                    ("enable_mob", bool_schema()),
+                    ("budget_limits", json_value.clone()),
+                    ("provider_params", json_value.clone()),
+                    (
+                        "preload_skills",
+                        serde_json::json!({
+                            "type": "array",
+                            "items": json_value
+                        }),
+                    ),
+                    (
+                        "skill_refs",
+                        serde_json::json!({
+                            "type": "array",
+                            "items": json_value
+                        }),
+                    ),
+                    ("labels", labels),
+                    ("additional_instructions", string_array.clone()),
+                    ("app_context", json_value.clone()),
+                    (
+                        "shell_env",
+                        serde_json::json!({
+                            "type": "object",
+                            "additionalProperties": { "type": "string" }
+                        }),
+                    ),
+                ],
+                vec!["prompt"],
+            ),
+        );
+        components.insert(
+            "RestContinueSessionRequest".to_string(),
+            object_schema(
+                vec![
+                    ("session_id", string_schema()),
+                    ("prompt", content_input),
+                    ("system_prompt", string_schema()),
+                    ("output_schema", json_value.clone()),
+                    ("structured_output_retries", integer_schema()),
+                    ("keep_alive", nullable(bool_schema())),
+                    ("comms_name", string_schema()),
+                    ("peer_meta", json_value.clone()),
+                    ("verbose", bool_schema()),
+                    ("model", string_schema()),
+                    ("provider", string_schema()),
+                    ("max_tokens", integer_schema()),
+                    ("hooks_override", json_value.clone()),
+                    (
+                        "skill_refs",
+                        serde_json::json!({
+                            "type": "array",
+                            "items": json_value
+                        }),
+                    ),
+                    ("flow_tool_overlay", json_value.clone()),
+                    ("additional_instructions", string_array),
+                ],
+                vec!["session_id", "prompt"],
+            ),
+        );
+        components.insert(
+            "RestAppendSystemContextRequest".to_string(),
+            object_schema(
+                vec![
+                    ("text", string_schema()),
+                    ("source", string_schema()),
+                    ("idempotency_key", string_schema()),
+                ],
+                vec!["text"],
+            ),
+        );
+        components.insert(
+            "RestPeerResponseTerminalRequest".to_string(),
+            object_schema(
+                vec![
+                    ("peer_name", string_schema()),
+                    ("request_id", string_schema()),
+                    (
+                        "status",
+                        serde_json::json!({
+                            "type": "string",
+                            "enum": ["completed", "failed"]
+                        }),
+                    ),
+                    ("result", json_value.clone()),
+                ],
+                vec!["peer_name", "request_id", "status", "result"],
+            ),
+        );
+        components.insert(
+            "RestSetConfigRequest".to_string(),
+            serde_json::json!({
+                "oneOf": [
+                    schema_ref("JsonValue"),
+                    object_schema(
+                        vec![
+                            ("config", schema_ref("JsonValue")),
+                            ("expected_generation", integer_schema()),
+                        ],
+                        vec!["config"],
+                    )
+                ]
+            }),
+        );
+        components.insert(
+            "RestPatchConfigRequest".to_string(),
+            serde_json::json!({
+                "oneOf": [
+                    schema_ref("JsonValue"),
+                    object_schema(
+                        vec![
+                            ("patch", schema_ref("JsonValue")),
+                            ("expected_generation", integer_schema()),
+                        ],
+                        vec!["patch"],
+                    )
+                ]
+            }),
+        );
+        components.insert(
+            "RestScheduleToolCallRequest".to_string(),
+            object_schema(
+                vec![("name", string_schema()), ("arguments", json_value.clone())],
+                vec!["name"],
+            ),
+        );
+        components.insert(
+            "RestCommsSendRequest".to_string(),
+            object_schema(
+                vec![
+                    ("session_id", string_schema()),
+                    ("command", schema_ref("CommsCommandRequest")),
+                ],
+                vec!["session_id", "command"],
+            ),
+        );
+        components.insert(
+            "RestAuthBindingRequest".to_string(),
+            object_schema(
+                vec![
+                    ("realm_id", string_schema()),
+                    ("binding_id", string_schema()),
+                    ("profile_id", string_schema()),
+                ],
+                vec!["realm_id", "binding_id"],
+            ),
+        );
+        components.insert(
+            "RestAuthProfileCreateRequest".to_string(),
+            serde_json::json!({
+                "type": "object",
+                "additionalProperties": true,
+                "required": ["realm_id", "binding_id", "auth_method"],
+            }),
+        );
+        components.insert(
+            "RestAuthLoginStartRequest".to_string(),
+            serde_json::json!({
+                "type": "object",
+                "additionalProperties": true,
+                "required": ["provider"],
+            }),
+        );
+        components.insert(
+            "RestMobHelperRequest".to_string(),
+            object_schema(
+                vec![
+                    ("prompt", string_schema()),
+                    ("agent_identity", string_schema()),
+                    ("role_name", string_schema()),
+                    ("runtime_mode", string_schema()),
+                    ("backend", string_schema()),
+                ],
+                vec!["prompt"],
+            ),
+        );
+        components.insert(
+            "RestMobForkHelperRequest".to_string(),
+            object_schema(
+                vec![
+                    ("source_member_id", string_schema()),
+                    ("prompt", string_schema()),
+                    ("agent_identity", string_schema()),
+                    ("role_name", string_schema()),
+                    ("fork_context", json_value),
+                    ("runtime_mode", string_schema()),
+                    ("backend", string_schema()),
+                ],
+                vec!["source_member_id", "prompt"],
+            ),
+        );
+        components.insert(
+            "RestMobWaitRequest".to_string(),
+            object_schema(
+                vec![
+                    (
+                        "member_ids",
+                        serde_json::json!({
+                            "type": "array",
+                            "items": { "type": "string" }
+                        }),
+                    ),
+                    ("timeout_ms", integer_schema()),
+                ],
+                vec![],
+            ),
+        );
+        components
+    }
+
+    #[derive(Clone, Copy)]
+    struct RestOperationContract {
+        request_schema: Option<&'static str>,
+        request_required: bool,
+        response_schema: &'static str,
+        response_content_type: &'static str,
+    }
+
+    impl RestOperationContract {
+        const fn json(response_schema: &'static str) -> Self {
+            Self {
+                request_schema: None,
+                request_required: false,
+                response_schema,
+                response_content_type: "application/json",
+            }
+        }
+
+        const fn with_json_request(
+            request_schema: &'static str,
+            response_schema: &'static str,
+        ) -> Self {
+            Self {
+                request_schema: Some(request_schema),
+                request_required: true,
+                response_schema,
+                response_content_type: "application/json",
+            }
+        }
+
+        const fn with_optional_json_request(
+            request_schema: &'static str,
+            response_schema: &'static str,
+        ) -> Self {
+            Self {
+                request_schema: Some(request_schema),
+                request_required: false,
+                response_schema,
+                response_content_type: "application/json",
+            }
+        }
+
+        const fn text(response_schema: &'static str) -> Self {
+            Self {
+                request_schema: None,
+                request_required: false,
+                response_schema,
+                response_content_type: "text/plain",
+            }
+        }
+
+        const fn event_stream(response_schema: &'static str) -> Self {
+            Self {
+                request_schema: None,
+                request_required: false,
+                response_schema,
+                response_content_type: "text/event-stream",
+            }
+        }
+    }
+
+    fn rest_operation_contract(path: &str, method: &str) -> RestOperationContract {
+        match (path, method) {
+            ("/sessions", "get") => RestOperationContract::json("ListSessionsResponse"),
+            ("/sessions", "post") => RestOperationContract::with_json_request(
+                "RestCreateSessionRequest",
+                "WireRunResult",
+            ),
+            ("/sessions/{id}", "get") => RestOperationContract::json("SessionDetailsResponse"),
+            ("/sessions/{id}", "delete") => RestOperationContract::json("StatusResponse"),
+            ("/sessions/{id}/history", "get") => RestOperationContract::json("WireSessionHistory"),
+            ("/sessions/{id}/interrupt", "post") => RestOperationContract::json("StatusResponse"),
+            ("/sessions/{id}/system_context", "post") => RestOperationContract::with_json_request(
+                "RestAppendSystemContextRequest",
+                "StatusResponse",
+            ),
+            ("/sessions/{id}/messages", "post") => RestOperationContract::with_json_request(
+                "RestContinueSessionRequest",
+                "WireRunResult",
+            ),
+            ("/sessions/{id}/external-events", "post") => {
+                RestOperationContract::with_json_request("JsonValue", "StatusResponse")
+            }
+            ("/sessions/{id}/peer-response-terminal", "post") => {
+                RestOperationContract::with_json_request(
+                    "RestPeerResponseTerminalRequest",
+                    "StatusResponse",
+                )
+            }
+            ("/sessions/{id}/mcp/add", "post") => {
+                RestOperationContract::with_json_request("McpAddParams", "McpLiveOpResponse")
+            }
+            ("/sessions/{id}/mcp/remove", "post") => {
+                RestOperationContract::with_json_request("McpRemoveParams", "McpLiveOpResponse")
+            }
+            ("/sessions/{id}/mcp/reload", "post") => {
+                RestOperationContract::with_json_request("McpReloadParams", "McpLiveOpResponse")
+            }
+            ("/sessions/{id}/events" | "/mob/{id}/events", "get") => {
+                RestOperationContract::event_stream("SseEventStream")
+            }
+            ("/sessions/{id}/status", "get") => RestOperationContract::json("RuntimeStateResult"),
+            ("/sessions/{id}/realtime-attachment-status", "get") => {
+                RestOperationContract::json("RuntimeRealtimeAttachmentStatusResult")
+            }
+            ("/sessions/{id}/submit", "post") => RestOperationContract::with_json_request(
+                "RuntimeAcceptParams",
+                "RuntimeAcceptResult",
+            ),
+            ("/sessions/{id}/retire", "post") => RestOperationContract::json("RuntimeRetireResult"),
+            ("/sessions/{id}/reset", "post") => RestOperationContract::json("RuntimeResetResult"),
+            ("/sessions/{id}/submissions", "get") => RestOperationContract::json("InputListResult"),
+            ("/sessions/{session_id}/submissions/{submission_id}", "get") => {
+                RestOperationContract::json("InputStateResult")
+            }
+            ("/schedule/call", "post") => {
+                RestOperationContract::with_json_request("RestScheduleToolCallRequest", "JsonValue")
+            }
+            ("/schedules", "get") => RestOperationContract::json("ScheduleListResult"),
+            ("/schedules", "post") => {
+                RestOperationContract::with_json_request("JsonValue", "JsonValue")
+            }
+            ("/schedules/{id}", "get" | "delete")
+            | ("/schedules/{id}/pause" | "/schedules/{id}/resume", "post") => {
+                RestOperationContract::json("JsonValue")
+            }
+            ("/schedules/{id}", "patch") => {
+                RestOperationContract::with_json_request("JsonValue", "JsonValue")
+            }
+            ("/schedules/{id}/occurrences", "get") => {
+                RestOperationContract::json("ScheduleOccurrencesResult")
+            }
+            ("/comms/send", "post") => {
+                RestOperationContract::with_json_request("RestCommsSendRequest", "JsonValue")
+            }
+            ("/config", "get") => RestOperationContract::json("ConfigEnvelope"),
+            ("/config", "put") => {
+                RestOperationContract::with_json_request("RestSetConfigRequest", "ConfigEnvelope")
+            }
+            ("/config", "patch") => {
+                RestOperationContract::with_json_request("RestPatchConfigRequest", "ConfigEnvelope")
+            }
+            ("/skills", "get") => RestOperationContract::json("SkillListResponse"),
+            ("/capabilities", "get") => RestOperationContract::json("CapabilitiesResponse"),
+            ("/runtime/host_info", "get") => RestOperationContract::json("RuntimeHostInfo"),
+            ("/runtime/capabilities", "get") => {
+                RestOperationContract::json("RuntimeHostCapabilities")
+            }
+            ("/runtime/health", "get") => RestOperationContract::json("RuntimeHostHealth"),
+            ("/models/catalog", "get") => RestOperationContract::json("ModelsCatalogResponse"),
+            ("/realtime/open_info", "post") => {
+                RestOperationContract::with_json_request("RealtimeOpenRequest", "RealtimeOpenInfo")
+            }
+            ("/realtime/status", "post") => RestOperationContract::with_json_request(
+                "RealtimeStatusParams",
+                "RealtimeStatusResult",
+            ),
+            ("/realtime/capabilities", "post") => RestOperationContract::with_json_request(
+                "RealtimeCapabilitiesParams",
+                "RealtimeCapabilitiesResult",
+            ),
+            ("/mob/{id}/spawn-helper", "post") => {
+                RestOperationContract::with_json_request("RestMobHelperRequest", "JsonValue")
+            }
+            ("/mob/{id}/fork-helper", "post") => {
+                RestOperationContract::with_json_request("RestMobForkHelperRequest", "JsonValue")
+            }
+            ("/mob/{id}/wait-kickoff", "post") => {
+                RestOperationContract::with_optional_json_request("RestMobWaitRequest", "JsonValue")
+            }
+            ("/mob/{id}/members/{agent_identity}/status", "get")
+            | (
+                "/mob/{id}/members/{agent_identity}/cancel"
+                | "/mob/{id}/members/{agent_identity}/respawn",
+                "post",
+            ) => RestOperationContract::json("JsonValue"),
+            ("/health", "get") => RestOperationContract::text("PlainTextResponse"),
+            ("/auth/profiles", "get") => RestOperationContract::json("WireAuthProfilesList"),
+            ("/auth/profiles", "post") => RestOperationContract::with_json_request(
+                "RestAuthProfileCreateRequest",
+                "WireAuthProfileCreated",
+            ),
+            ("/auth/bindings/{binding_id}", "get") => {
+                RestOperationContract::json("WireAuthProfileDetail")
+            }
+            ("/auth/bindings/{binding_id}", "delete")
+            | ("/auth/bindings/{binding_id}/logout", "post") => {
+                RestOperationContract::json("WireAuthProfileCleared")
+            }
+            ("/auth/bindings/{binding_id}/test", "post")
+            | ("/auth/bindings/{binding_id}/status", "get") => {
+                RestOperationContract::json("WireAuthStatusDetail")
+            }
+            ("/auth/login/start", "post") => RestOperationContract::with_json_request(
+                "RestAuthLoginStartRequest",
+                "WireLoginStart",
+            ),
+            ("/auth/login/complete", "post") => {
+                RestOperationContract::with_json_request("JsonValue", "WireLoginReady")
+            }
+            ("/auth/login/device/start", "post") => {
+                RestOperationContract::with_json_request("JsonValue", "WireDeviceStart")
+            }
+            ("/auth/login/device/complete", "post") => {
+                RestOperationContract::with_json_request("JsonValue", "WireLoginReady")
+            }
+            ("/realms", "get") => RestOperationContract::json("WireRealmList"),
+            ("/realms/{id}", "get") => RestOperationContract::json("WireRealmConnectionSet"),
+            _ => RestOperationContract::json("JsonValue"),
+        }
+    }
+
+    fn rest_operation_id(method: &str, path: &str) -> String {
+        let mut operation_id = method.to_string();
+        for segment in path.split('/').filter(|segment| !segment.is_empty()) {
+            operation_id.push('_');
+            operation_id.push_str(
+                &segment
+                    .trim_start_matches('{')
+                    .trim_end_matches('}')
+                    .replace('-', "_"),
+            );
+        }
+        operation_id
+    }
+
+    fn rest_path_parameters(path: &str) -> Vec<Value> {
+        let mut seen = Vec::new();
+        for segment in path.split('/') {
+            if let Some(name) = segment
+                .strip_prefix('{')
+                .and_then(|value| value.strip_suffix('}'))
+                && !seen.contains(&name)
+            {
+                seen.push(name);
+            }
+        }
+        seen.into_iter()
+            .map(|name| {
+                serde_json::json!({
+                    "name": name,
+                    "in": "path",
+                    "required": true,
+                    "schema": { "type": "string" },
+                })
+            })
+            .collect()
+    }
+
+    fn rest_responses(contract: RestOperationContract) -> Value {
+        serde_json::json!({
+            "200": {
+                "description": "Successful response",
+                "content": media_content(contract.response_content_type, contract.response_schema),
+            },
+            "default": {
+                "description": "Error response",
+                "content": media_content("application/json", "WireError"),
+            }
+        })
+    }
+
+    let mut rest_components = rest_manual_components();
+    for section in [
+        &wire_types,
+        &params,
+        &errors,
+        &capabilities,
+        &runtime_host,
+        &models,
+    ] {
+        add_component_section(&mut rest_components, section);
+    }
+
+    // REST OpenAPI — generated wire contract for the documented route surface.
     let rest_paths: Map<String, Value> = crate::rest_path_catalog()
         .into_iter()
         .map(|path| {
@@ -285,7 +974,12 @@ pub fn emit_all_schemas(output_dir: &std::path::Path) -> Result<(), Box<dyn std:
                 .operations
                 .into_iter()
                 .map(|operation| {
+                    let contract = rest_operation_contract(path.path, operation.method);
                     let mut operation_map = Map::new();
+                    operation_map.insert(
+                        "operationId".to_string(),
+                        Value::String(rest_operation_id(operation.method, path.path)),
+                    );
                     operation_map.insert(
                         "summary".to_string(),
                         Value::String(operation.summary.to_string()),
@@ -296,6 +990,20 @@ pub fn emit_all_schemas(output_dir: &std::path::Path) -> Result<(), Box<dyn std:
                             Value::String(description.to_string()),
                         );
                     }
+                    let parameters = rest_path_parameters(path.path);
+                    if !parameters.is_empty() {
+                        operation_map.insert("parameters".to_string(), Value::Array(parameters));
+                    }
+                    if let Some(request_schema) = contract.request_schema {
+                        operation_map.insert(
+                            "requestBody".to_string(),
+                            serde_json::json!({
+                                "required": contract.request_required,
+                                "content": media_content("application/json", request_schema),
+                            }),
+                        );
+                    }
+                    operation_map.insert("responses".to_string(), rest_responses(contract));
                     (operation.method.to_string(), Value::Object(operation_map))
                 })
                 .collect();
@@ -303,12 +1011,15 @@ pub fn emit_all_schemas(output_dir: &std::path::Path) -> Result<(), Box<dyn std:
         })
         .collect();
     let rest_openapi = serde_json::json!({
-        "openapi": "3.0.0",
+        "openapi": "3.1.0",
         "info": {
             "title": "Meerkat REST API",
             "version": crate::version::ContractVersion::CURRENT.to_string(),
         },
         "paths": Value::Object(rest_paths),
+        "components": {
+            "schemas": Value::Object(rest_components),
+        },
     });
     write_pretty_json(output_dir.join("rest-openapi.json"), &rest_openapi)?;
 
@@ -446,6 +1157,116 @@ mod tests {
         assert!(
             cancel_all_work.get("result_type").is_none(),
             "mob/cancel_all_work must not advertise a phantom result contract"
+        );
+
+        fs::remove_dir_all(&output_dir).unwrap();
+    }
+
+    #[test]
+    fn emitted_rest_openapi_contains_wire_contracts_not_only_paths() {
+        let output_dir = temp_output_dir("rest-openapi-contracts");
+        emit_all_schemas(&output_dir).expect("emit schemas");
+
+        let rest_openapi: serde_json::Value =
+            serde_json::from_slice(&fs::read(output_dir.join("rest-openapi.json")).unwrap())
+                .unwrap();
+        let components = rest_openapi
+            .pointer("/components/schemas")
+            .and_then(serde_json::Value::as_object)
+            .expect("rest OpenAPI should publish schema components");
+        for expected in [
+            "RestCreateSessionRequest",
+            "WireRunResult",
+            "WireError",
+            "ConfigEnvelope",
+        ] {
+            assert!(
+                components.contains_key(expected),
+                "rest OpenAPI components missing {expected}"
+            );
+        }
+
+        let create_session = &rest_openapi["paths"]["/sessions"]["post"];
+        assert_eq!(
+            create_session
+                .pointer("/requestBody/content/application~1json/schema/$ref")
+                .and_then(serde_json::Value::as_str),
+            Some("#/components/schemas/RestCreateSessionRequest")
+        );
+        assert_eq!(
+            create_session
+                .pointer("/responses/200/content/application~1json/schema/$ref")
+                .and_then(serde_json::Value::as_str),
+            Some("#/components/schemas/WireRunResult")
+        );
+        assert_eq!(
+            create_session
+                .pointer("/responses/default/content/application~1json/schema/$ref")
+                .and_then(serde_json::Value::as_str),
+            Some("#/components/schemas/WireError")
+        );
+
+        let get_session = &rest_openapi["paths"]["/sessions/{id}"]["get"];
+        assert_eq!(
+            get_session
+                .pointer("/parameters/0/name")
+                .and_then(serde_json::Value::as_str),
+            Some("id")
+        );
+        assert_eq!(
+            get_session
+                .pointer("/responses/200/content/application~1json/schema/$ref")
+                .and_then(serde_json::Value::as_str),
+            Some("#/components/schemas/SessionDetailsResponse")
+        );
+
+        for (path, request_schema) in [
+            ("/sessions/{id}/mcp/add", "McpAddParams"),
+            ("/sessions/{id}/mcp/remove", "McpRemoveParams"),
+            ("/sessions/{id}/mcp/reload", "McpReloadParams"),
+        ] {
+            let operation = &rest_openapi["paths"][path]["post"];
+            let expected_request = format!("#/components/schemas/{request_schema}");
+            assert_eq!(
+                operation
+                    .pointer("/requestBody/content/application~1json/schema/$ref")
+                    .and_then(serde_json::Value::as_str),
+                Some(expected_request.as_str()),
+                "{path} request body contract drifted"
+            );
+            assert_eq!(
+                operation
+                    .pointer("/responses/200/content/application~1json/schema/$ref")
+                    .and_then(serde_json::Value::as_str),
+                Some("#/components/schemas/McpLiveOpResponse"),
+                "{path} response contract drifted"
+            );
+        }
+
+        let wait_kickoff = &rest_openapi["paths"]["/mob/{id}/wait-kickoff"]["post"];
+        assert_eq!(
+            wait_kickoff
+                .pointer("/requestBody/content/application~1json/schema/$ref")
+                .and_then(serde_json::Value::as_str),
+            Some("#/components/schemas/RestMobWaitRequest")
+        );
+        assert_eq!(
+            wait_kickoff
+                .pointer("/requestBody/required")
+                .and_then(serde_json::Value::as_bool),
+            Some(false)
+        );
+        assert_eq!(
+            wait_kickoff
+                .pointer("/responses/200/content/application~1json/schema/$ref")
+                .and_then(serde_json::Value::as_str),
+            Some("#/components/schemas/JsonValue")
+        );
+
+        let body = serde_json::to_string(&rest_openapi).unwrap();
+        assert!(
+            !body.contains("#/$defs/"),
+            "OpenAPI component refs must resolve through #/components/schemas"
         );
 
         fs::remove_dir_all(&output_dir).unwrap();

--- a/meerkat-contracts/src/rest_catalog.rs
+++ b/meerkat-contracts/src/rest_catalog.rs
@@ -316,6 +316,13 @@ pub fn rest_path_catalog() -> Vec<RestPathDescriptor> {
             )],
         ),
         RestPathDescriptor::new(
+            "/mob/{id}/wait-kickoff",
+            vec![RestOperationDescriptor::new(
+                "post",
+                "Wait for autonomous kickoff completion",
+            )],
+        ),
+        RestPathDescriptor::new(
             "/mob/{id}/members/{agent_identity}/status",
             vec![RestOperationDescriptor::with_description(
                 "get",
@@ -444,6 +451,7 @@ mod tests {
             "/auth/login/device/complete",
             "/auth/bindings/{binding_id}/status",
             "/auth/bindings/{binding_id}/logout",
+            "/mob/{id}/wait-kickoff",
             "/mob/{id}/members/{agent_identity}/status",
             "/mob/{id}/members/{agent_identity}/cancel",
             "/mob/{id}/members/{agent_identity}/respawn",

--- a/meerkat-contracts/src/wire/result.rs
+++ b/meerkat-contracts/src/wire/result.rs
@@ -52,6 +52,7 @@ impl From<&meerkat_core::error::ToolError> for WireToolErrorClass {
 
 /// Canonical run result for wire protocol.
 #[derive(Debug, Clone, Serialize, Deserialize)]
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
 pub struct WireRunResult {
     pub session_id: SessionId,
     #[serde(skip_serializing_if = "Option::is_none")]

--- a/meerkat-mob/src/runtime/supervisor_bridge.rs
+++ b/meerkat-mob/src/runtime/supervisor_bridge.rs
@@ -9,10 +9,10 @@ use meerkat_core::comms::{
 use meerkat_core::interaction::{
     InteractionContent, PeerInputCandidate, TerminalityClass, classify_response_terminality,
 };
+use meerkat_core::time_compat::{Duration, Instant};
 use meerkat_core::types::HandlingMode;
 use std::collections::{HashSet, VecDeque};
 use std::sync::Arc;
-use std::time::Duration;
 use tokio::sync::{Mutex, RwLock};
 
 pub(crate) struct MobSupervisorBridge {
@@ -165,7 +165,7 @@ impl MobSupervisorBridge {
             return Ok(result);
         }
 
-        let started = std::time::Instant::now();
+        let deadline = BridgeRequestDeadline::start(timeout);
         loop {
             let drained = runtime.drain_peer_input_candidates().await;
             if let Some(result) = self
@@ -175,7 +175,7 @@ impl MobSupervisorBridge {
                 return Ok(result);
             }
 
-            let remaining = timeout.saturating_sub(started.elapsed());
+            let remaining = deadline.remaining();
             if remaining.is_zero() {
                 return Err(MobError::Internal(format!(
                     "supervisor request '{request_envelope_id}' timed out after {}ms",
@@ -265,6 +265,29 @@ impl MobSupervisorBridge {
             TerminalityClass::Progress => Ok(None),
             _ => Ok(None),
         }
+    }
+}
+
+#[derive(Debug)]
+struct BridgeRequestDeadline {
+    started: Instant,
+    timeout: Duration,
+}
+
+impl BridgeRequestDeadline {
+    fn start(timeout: Duration) -> Self {
+        Self {
+            started: Instant::now(),
+            timeout,
+        }
+    }
+
+    fn remaining(&self) -> Duration {
+        Self::remaining_after(self.timeout, self.started.elapsed())
+    }
+
+    fn remaining_after(timeout: Duration, elapsed: Duration) -> Duration {
+        timeout.saturating_sub(elapsed)
     }
 }
 
@@ -404,6 +427,24 @@ mod tests {
         assert!(
             value.is_none(),
             "response for a different envelope must not satisfy the current wait"
+        );
+    }
+
+    #[test]
+    fn bridge_request_deadline_saturates_elapsed_timeout() {
+        assert_eq!(
+            BridgeRequestDeadline::remaining_after(
+                Duration::from_millis(25),
+                Duration::from_millis(30)
+            ),
+            Duration::ZERO
+        );
+        assert_eq!(
+            BridgeRequestDeadline::remaining_after(
+                Duration::from_millis(25),
+                Duration::from_millis(10)
+            ),
+            Duration::from_millis(15)
         );
     }
 }

--- a/meerkat-web-runtime/src/lib.rs
+++ b/meerkat-web-runtime/src/lib.rs
@@ -1728,6 +1728,10 @@ struct SpawnSpecInput {
     /// Opaque application context passed through to the agent build pipeline.
     #[serde(default)]
     context: Option<serde_json::Value>,
+    /// Legacy 0.6 pre-release SDKs exposed `generation` even though the
+    /// runtime owns member generations. Accept and ignore it for raw JS callers.
+    #[serde(default, rename = "generation")]
+    _generation: Option<u64>,
     /// Additional instruction sections appended to the system prompt.
     #[serde(default)]
     additional_instructions: Option<Vec<String>>,
@@ -2798,6 +2802,21 @@ capabilities = [{capability_values}]
 
         let specs: Vec<super::SpawnSpecInput> =
             serde_json::from_value(payload).expect("legacy meerkat_id alias should deserialize");
+        assert_eq!(specs.len(), 1);
+        assert_eq!(specs[0].agent_identity, "worker-1");
+    }
+
+    #[allow(clippy::expect_used)]
+    #[test]
+    fn spawn_spec_input_ignores_legacy_generation() {
+        let payload = json!([{
+            "profile": "worker",
+            "agent_identity": "worker-1",
+            "generation": 99,
+        }]);
+
+        let specs: Vec<super::SpawnSpecInput> =
+            serde_json::from_value(payload).expect("legacy generation should be ignored");
         assert_eq!(specs.len(), 1);
         assert_eq!(specs[0].agent_identity, "worker-1");
     }

--- a/sdks/typescript/package.json
+++ b/sdks/typescript/package.json
@@ -17,7 +17,7 @@
   ],
   "scripts": {
     "build": "tsc",
-    "test": "node --test tests/*.test.js tests/*.test.mjs",
+    "test": "tsc --noEmit -p tests/tsconfig.json && node --test tests/*.test.js tests/*.test.mjs",
     "test:e2e": "npm run build && node --test tests/e2e_smoke.test.mjs tests/e2e_sdk_smoke.test.mjs",
     "test:live-smoke": "npm run build && node --test tests/e2e_smoke.test.mjs"
   },

--- a/sdks/typescript/src/types.ts
+++ b/sdks/typescript/src/types.ts
@@ -269,7 +269,6 @@ export interface SpawnSpec {
   readonly backend?: "session" | "external";
   readonly labels?: Record<string, string>;
   readonly context?: Record<string, unknown>;
-  readonly generation?: number;
   readonly additionalInstructions?: string[];
 }
 

--- a/sdks/typescript/tests/public-types.test.ts
+++ b/sdks/typescript/tests/public-types.test.ts
@@ -1,0 +1,17 @@
+import type { SpawnSpec } from "../src/index.js";
+
+const spawnSpec: SpawnSpec = {
+  profile: "worker",
+  agentIdentity: "worker-1",
+};
+
+void spawnSpec;
+
+const spawnSpecWithGeneration: SpawnSpec = {
+  profile: "worker",
+  agentIdentity: "worker-2",
+  // @ts-expect-error generation is runtime-owned and not a public spawn knob.
+  generation: 1,
+};
+
+void spawnSpecWithGeneration;

--- a/sdks/typescript/tests/tsconfig.json
+++ b/sdks/typescript/tests/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "Node16",
+    "moduleResolution": "Node16",
+    "lib": ["ES2022"],
+    "types": ["node"],
+    "strict": true,
+    "esModuleInterop": true,
+    "noEmit": true,
+    "skipLibCheck": true,
+    "rootDir": "..",
+    "baseUrl": ".."
+  },
+  "include": ["./**/*.ts", "../src/**/*.ts"]
+}

--- a/sdks/web/package.json
+++ b/sdks/web/package.json
@@ -28,7 +28,7 @@
     "build:ts": "tsc",
     "build": "npm run build:wasm && npm run build:ts",
     "prepublishOnly": "npm run build",
-    "test": "tsc --noEmit -p tests/tsconfig.json",
+    "test": "npm run build:ts && tsc --noEmit -p tests/tsconfig.json && node --test tests/*.unit.mjs",
     "test:e2e": "npm run build && node --test tests/e2e_wasm_runtime.test.mjs",
     "test:live-smoke": "npm run build && node --test tests/live_smoke.test.mjs"
   },

--- a/sdks/web/src/mob.ts
+++ b/sdks/web/src/mob.ts
@@ -73,6 +73,18 @@ function encodeMemberRef(mobId: string, agentIdentity: string): string {
   return encodeBase64UrlJson({ m: mobId, a: agentIdentity });
 }
 
+function spawnSpecPayload(spec: SpawnSpec): Record<string, unknown> {
+  return {
+    profile: spec.profile,
+    agent_identity: spec.agent_identity,
+    runtime_mode: spec.runtime_mode,
+    initial_message: spec.initial_message,
+    labels: spec.labels,
+    context: spec.context,
+    additional_instructions: spec.additional_instructions,
+  };
+}
+
 function normalizeEventEnvelope(raw: unknown, mobId: string): MemberEventItem {
   if (!raw || typeof raw !== 'object') {
     return raw as MemberEventItem;
@@ -189,7 +201,7 @@ export class Mob {
   async spawn(specs: SpawnSpec[]): Promise<SpawnResult[]> {
     const json = await this.bindings.mob_spawn(
       this.mobId,
-      JSON.stringify(specs),
+      JSON.stringify(specs.map(spawnSpecPayload)),
     );
     return (JSON.parse(json) as Array<Partial<SpawnResult> & Record<string, unknown>>).map((entry) => {
       if (typeof entry.agent_identity !== 'string' || entry.agent_identity.length === 0) {

--- a/sdks/web/src/types.ts
+++ b/sdks/web/src/types.ts
@@ -325,7 +325,6 @@ export interface SpawnSpec {
   initial_message?: string | ContentBlock[];
   labels?: Record<string, string>;
   context?: Record<string, unknown>;
-  generation?: number;
   additional_instructions?: string[];
 }
 

--- a/sdks/web/tests/e2e_wasm_runtime.test.mjs
+++ b/sdks/web/tests/e2e_wasm_runtime.test.mjs
@@ -447,7 +447,8 @@ test("MeerkatRuntime forwards canonical mob status/helper methods through the wa
     async mob_events() {
       return JSON.stringify([]);
     },
-    async mob_spawn() {
+    async mob_spawn(mobId, specsJson) {
+      calls.push(["spawn", mobId, JSON.parse(specsJson)]);
       return JSON.stringify([
         {
           mob_id: "mob-web-parity",
@@ -575,6 +576,7 @@ test("MeerkatRuntime forwards canonical mob status/helper methods through the wa
       {
         profile: "worker",
         agent_identity: "worker-1",
+        generation: 7,
       },
     ]);
     assert.equal(spawned[0].agent_identity, "worker-1");
@@ -584,6 +586,16 @@ test("MeerkatRuntime forwards canonical mob status/helper methods through the wa
       undefined,
       "binding-era agent_runtime_id must not leak to app-facing spawn result",
     );
+    assert.deepEqual(calls[0], [
+      "spawn",
+      "mob-web-parity",
+      [
+        {
+          profile: "worker",
+          agent_identity: "worker-1",
+        },
+      ],
+    ]);
 
     const listed = await mob.listMembers();
     assert.equal(listed[0].agent_identity, "worker-1");

--- a/sdks/web/tests/mob_payload.unit.mjs
+++ b/sdks/web/tests/mob_payload.unit.mjs
@@ -1,0 +1,39 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import { Mob } from '../dist/mob.js';
+
+test('Mob.spawn strips legacy generation from wasm payloads', async () => {
+  let captured;
+  const mob = new Mob('mob-web-unit', {
+    async mob_spawn(mobId, specsJson) {
+      captured = { mobId, specs: JSON.parse(specsJson) };
+      return JSON.stringify([
+        {
+          mob_id: mobId,
+          agent_identity: 'worker-1',
+          member_ref: 'ref-worker-1',
+        },
+      ]);
+    },
+  });
+
+  const result = await mob.spawn([
+    {
+      profile: 'worker',
+      agent_identity: 'worker-1',
+      generation: 7,
+    },
+  ]);
+
+  assert.equal(result[0].agent_identity, 'worker-1');
+  assert.deepEqual(captured, {
+    mobId: 'mob-web-unit',
+    specs: [
+      {
+        profile: 'worker',
+        agent_identity: 'worker-1',
+      },
+    ],
+  });
+});

--- a/sdks/web/tests/types.test.ts
+++ b/sdks/web/tests/types.test.ts
@@ -166,6 +166,14 @@ const spawnSpec: SpawnSpec = {
   labels: { role: 'worker' },
 };
 
+const spawnSpecWithoutGeneration: SpawnSpec = {
+  profile: 'worker',
+  agent_identity: 'w2',
+};
+
+// @ts-expect-error generation is runtime-owned and not a public spawn knob.
+spawnSpecWithoutGeneration.generation = 1;
+
 // ─── Event narrowing (matches Rust AgentEvent serde) ────────────
 
 function handleEvent(event: AgentEvent): string {
@@ -223,7 +231,7 @@ function handleEvent(event: AgentEvent): string {
     case 'skills_resolved':
       return `${event.skills.length}`;
     case 'skill_resolution_failed':
-      return event.reference;
+      return event.reference ?? '';
     case 'interaction_complete':
       return event.result;
     case 'interaction_callback_pending':


### PR DESCRIPTION
## Summary
- remove the phantom `SpawnSpec.generation` public knob from the TypeScript and web SDK types while stripping legacy JS payloads before the WASM spawn bridge
- switch the mob supervisor bridge deadline handling to `time_compat::{Duration, Instant}` and accept ignored legacy `generation` in raw web runtime spawn JSON
- regenerate REST OpenAPI as a wire contract with component schemas, request bodies, responses, and path parameters instead of a path-only inventory

## Linear
LUC-97: https://linear.app/lucrfr/issue/LUC-97/low-risk-dogma-cleanup-sdk-wasm-and-openapi-surface-contracts

## Dogma Rows
Verified all requested rows still existed on current `main` before editing; none were skipped.

## Validation
- `./scripts/repo-cargo fmt --all`
- `./scripts/repo-cargo test -p meerkat-contracts --features schema emitted_rest_openapi_contains_wire_contracts_not_only_paths`
- `./scripts/repo-cargo test -p meerkat-mob bridge_request_deadline_saturates_elapsed_timeout`
- `./scripts/repo-cargo test -p meerkat-web-runtime spawn_spec_input_ignores_legacy_generation`
- `make regen-schemas`
- OpenAPI `$ref` resolution check over `artifacts/schemas/rest-openapi.json`
- `make test-sdk-typescript`
- `cd sdks/web && npm install --ignore-scripts && npm test`
- `make check` (BuildBuddy `d8d98b1f-efff-4159-bad5-30e4640a6eae`)
- `make test` (BuildBuddy `14b6a5ba-f387-4494-bb70-b2b04cc8f4c9`, `8b813e4a-5ee0-4acf-84ee-c5aa32939b58`)
- `make lint` (BuildBuddy `89e57aa8-53c1-46af-861f-3e733ac1c8b6`)
- `make verify-sdk-wrapper-freshness`
- `make verify-schema-freshness`
