### PR TITLE
LUC-96 Tighten typed event and mob wire contracts

### DIFF
--- a/artifacts/schemas/events.json
+++ b/artifacts/schemas/events.json
@@ -1214,6 +1214,22 @@
               "phase"
             ],
             "type": "object"
+          },
+          {
+            "properties": {
+              "kind": {
+                "const": "legacy_status",
+                "type": "string"
+              },
+              "status": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "kind",
+              "status"
+            ],
+            "type": "object"
           }
         ]
       },
@@ -1258,14 +1274,7 @@
             "type": "string"
           },
           "status_info": {
-            "anyOf": [
-              {
-                "$ref": "#/$defs/ToolConfigChangeStatus"
-              },
-              {
-                "type": "null"
-              }
-            ]
+            "$ref": "#/$defs/ToolConfigChangeStatus"
           },
           "target": {
             "type": "string"
@@ -1275,6 +1284,7 @@
           "operation",
           "target",
           "status",
+          "status_info",
           "persisted"
         ],
         "type": "object"
@@ -4283,6 +4293,22 @@
               "phase"
             ],
             "type": "object"
+          },
+          {
+            "properties": {
+              "kind": {
+                "const": "legacy_status",
+                "type": "string"
+              },
+              "status": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "kind",
+              "status"
+            ],
+            "type": "object"
           }
         ]
       },
@@ -4327,14 +4353,7 @@
             "type": "string"
           },
           "status_info": {
-            "anyOf": [
-              {
-                "$ref": "#/$defs/ToolConfigChangeStatus"
-              },
-              {
-                "type": "null"
-              }
-            ]
+            "$ref": "#/$defs/ToolConfigChangeStatus"
           },
           "target": {
             "type": "string"
@@ -4344,6 +4363,7 @@
           "operation",
           "target",
           "status",
+          "status_info",
           "persisted"
         ],
         "type": "object"

--- a/artifacts/schemas/events.json
+++ b/artifacts/schemas/events.json
@@ -1274,7 +1274,14 @@
             "type": "string"
           },
           "status_info": {
-            "$ref": "#/$defs/ToolConfigChangeStatus"
+            "anyOf": [
+              {
+                "$ref": "#/$defs/ToolConfigChangeStatus"
+              },
+              {
+                "type": "null"
+              }
+            ]
           },
           "target": {
             "type": "string"
@@ -1284,7 +1291,6 @@
           "operation",
           "target",
           "status",
-          "status_info",
           "persisted"
         ],
         "type": "object"
@@ -4353,7 +4359,14 @@
             "type": "string"
           },
           "status_info": {
-            "$ref": "#/$defs/ToolConfigChangeStatus"
+            "anyOf": [
+              {
+                "$ref": "#/$defs/ToolConfigChangeStatus"
+              },
+              {
+                "type": "null"
+              }
+            ]
           },
           "target": {
             "type": "string"
@@ -4363,7 +4376,6 @@
           "operation",
           "target",
           "status",
-          "status_info",
           "persisted"
         ],
         "type": "object"

--- a/artifacts/schemas/wire-types.json
+++ b/artifacts/schemas/wire-types.json
@@ -163,7 +163,7 @@
         "type": "string"
       },
       "PeerId": {
-        "description": "Canonical runtime identity for a peer.\n\n`PeerId` is the routing key: the router and trust store key by `PeerId`,\nnever by `PeerName`. Two peers may legitimately share a display `PeerName`\n(per the Wave-B V5 dogma note), but their `PeerId`s never collide — the\nunderlying UUID is globally unique.\n\nConstructed either freshly (`PeerId::new`) for a peer minted locally,\nor parsed from a hyphenated UUID (`PeerId::parse`) when we've been given\nan identity over the wire.",
+        "description": "Canonical runtime identity for a peer.\n\n`PeerId` is the routing key: the router and trust store key by `PeerId`,\nnever by `PeerName`. Two peers may legitimately share a display `PeerName`\n(per the Wave-B V5 dogma note), but their `PeerId`s never collide — the\nunderlying UUID is globally unique.\n\nConstructed freshly (`PeerId::new`) for a peer minted locally, parsed\nfrom a hyphenated UUID (`PeerId::parse`) when we've been given an identity\nover the wire, or derived from a 32-byte Ed25519 public key when a transport\nstill authenticates by raw signing key.",
         "type": "string"
       },
       "PeerLifecycleKind": {

--- a/meerkat-contracts/src/lib.rs
+++ b/meerkat-contracts/src/lib.rs
@@ -243,6 +243,7 @@ pub use wire::{
     WireMobBackendKind,
     WireMobLifecycleAction,
     WireMobMemberStatus,
+    WireMobReconcileStage,
     WireMobRuntimeMode,
     WireModelBetaHeader,
     WireModelProfile,

--- a/meerkat-contracts/src/wire/event.rs
+++ b/meerkat-contracts/src/wire/event.rs
@@ -236,16 +236,13 @@ mod tests {
             session_id: SessionId::new(),
             sequence: 42,
             event: AgentEvent::ToolConfigChanged {
-                payload: ToolConfigChangedPayload {
-                    operation: ToolConfigChangeOperation::Remove,
-                    target: "filesystem".to_string(),
-                    status: "staged".to_string(),
-                    status_info: None,
-                    persisted: false,
-                    applied_at_turn: Some(3),
-                    domain: None,
-                    deferred_catalog_delta: None,
-                },
+                payload: ToolConfigChangedPayload::new(
+                    ToolConfigChangeOperation::Remove,
+                    "filesystem",
+                    meerkat_core::ToolConfigChangeStatus::legacy_status("staged"),
+                    false,
+                )
+                .with_applied_at_turn(Some(3)),
             },
             contract_version: ContractVersion::CURRENT,
         };
@@ -256,7 +253,7 @@ mod tests {
             AgentEvent::ToolConfigChanged { payload } => {
                 assert_eq!(payload.operation, ToolConfigChangeOperation::Remove);
                 assert_eq!(payload.target, "filesystem");
-                assert_eq!(payload.status, "staged");
+                assert_eq!(payload.status_text(), "staged");
                 assert!(!payload.persisted);
                 assert_eq!(payload.applied_at_turn, Some(3));
             }

--- a/meerkat-contracts/src/wire/mob.rs
+++ b/meerkat-contracts/src/wire/mob.rs
@@ -947,6 +947,15 @@ pub struct MobReconcileOptionsWire {
     pub retire_stale: bool,
 }
 
+/// Closed wire stage for a per-identity `mob/reconcile` failure.
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
+#[serde(rename_all = "snake_case")]
+pub enum WireMobReconcileStage {
+    Spawn,
+    Retire,
+}
+
 /// Request payload for `mob/reconcile`.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 #[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
@@ -964,8 +973,7 @@ pub struct MobReconcileParams {
 #[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
 pub struct MobReconcileFailureWire {
     pub agent_identity: String,
-    /// One of `"spawn"` or `"retire"`.
-    pub stage: String,
+    pub stage: WireMobReconcileStage,
     /// Stringified mob error.
     pub error: String,
 }
@@ -1181,6 +1189,30 @@ mod tests {
         };
 
         assert!(spec.validate_public_surface_metadata().is_err());
+    }
+
+    #[test]
+    fn mob_reconcile_failure_stage_is_typed_wire_enum() {
+        let failure = MobReconcileFailureWire {
+            agent_identity: "worker-1".into(),
+            stage: WireMobReconcileStage::Spawn,
+            error: "spawn failed".into(),
+        };
+
+        let json = serde_json::to_value(&failure).expect("serialize failure");
+        assert_eq!(json["stage"], "spawn");
+
+        let round_trip: MobReconcileFailureWire =
+            serde_json::from_value(json).expect("deserialize failure");
+        assert_eq!(round_trip.stage, WireMobReconcileStage::Spawn);
+
+        let err = serde_json::from_value::<MobReconcileFailureWire>(serde_json::json!({
+            "agent_identity": "worker-1",
+            "stage": "restart",
+            "error": "bad stage"
+        }))
+        .expect_err("unknown reconcile stage must be rejected");
+        assert!(err.to_string().contains("unknown variant"));
     }
 
     #[test]

--- a/meerkat-contracts/src/wire/mod.rs
+++ b/meerkat-contracts/src/wire/mod.rs
@@ -86,8 +86,9 @@ pub use mob::{
     MobTopologyRuleInput, MobTopologySpecInput, MobUnwireParams, MobUnwireResult, MobWireParams,
     MobWireResult, MobWiringRulesInput, WireAgentRuntimeId, WireHandlingMode, WireMemberRef,
     WireMemberRefError, WireMemberState, WireMobBackendKind, WireMobLifecycleAction,
-    WireMobMemberStatus, WireMobRuntimeMode, WireRenderClass, WireRenderMetadata,
-    WireRenderSalience, WireRuntimeBinding, WireTrustedPeerSpec, WireWorkOrigin,
+    WireMobMemberStatus, WireMobReconcileStage, WireMobRuntimeMode, WireRenderClass,
+    WireRenderMetadata, WireRenderSalience, WireRuntimeBinding, WireTrustedPeerSpec,
+    WireWorkOrigin,
 };
 pub use models::{
     CatalogModelEntry, ModelsCatalogResponse, ProviderCatalog, WireModelBetaHeader,

--- a/meerkat-contracts/tests/regression_wire_types.rs
+++ b/meerkat-contracts/tests/regression_wire_types.rs
@@ -479,19 +479,16 @@ fn agent_event_all_variants_roundtrip() {
             reason: "channel full".to_string(),
         },
         AgentEvent::ToolConfigChanged {
-            payload: ToolConfigChangedPayload {
-                operation: ToolConfigChangeOperation::Add,
-                target: "filesystem".to_string(),
-                status: "applied".to_string(),
-                status_info: Some(ToolConfigChangeStatus::external_tool_delta(
+            payload: ToolConfigChangedPayload::new(
+                ToolConfigChangeOperation::Add,
+                "filesystem",
+                ToolConfigChangeStatus::external_tool_delta(
                     meerkat_core::ExternalToolDeltaPhase::Applied,
                     None,
-                )),
-                persisted: true,
-                applied_at_turn: Some(5),
-                domain: None,
-                deferred_catalog_delta: None,
-            },
+                ),
+                true,
+            )
+            .with_applied_at_turn(Some(5)),
         },
     ];
 
@@ -743,19 +740,16 @@ fn documented_event_catalog_covers_core_agent_event_discriminators() {
             reason: "lag".to_string(),
         },
         AgentEvent::ToolConfigChanged {
-            payload: ToolConfigChangedPayload {
-                operation: ToolConfigChangeOperation::Reload,
-                target: "external".to_string(),
-                status: "applied".to_string(),
-                status_info: Some(ToolConfigChangeStatus::external_tool_delta(
+            payload: ToolConfigChangedPayload::new(
+                ToolConfigChangeOperation::Reload,
+                "external",
+                ToolConfigChangeStatus::external_tool_delta(
                     meerkat_core::ExternalToolDeltaPhase::Applied,
                     None,
-                )),
-                persisted: true,
-                applied_at_turn: Some(1),
-                domain: None,
-                deferred_catalog_delta: None,
-            },
+                ),
+                true,
+            )
+            .with_applied_at_turn(Some(1)),
         },
     ];
 

--- a/meerkat-core/src/agent/state.rs
+++ b/meerkat-core/src/agent/state.rs
@@ -1299,16 +1299,14 @@ where
                                     );
                                     let status = status_info.status_text();
                                     emit_event!(AgentEvent::ToolConfigChanged {
-                                        payload: ToolConfigChangedPayload {
-                                            operation: ToolConfigChangeOperation::Reload,
-                                            target: "tool_scope".to_string(),
-                                            status: status.clone(),
-                                            status_info: Some(status_info),
-                                            persisted: false,
-                                            applied_at_turn: Some(turn_count),
-                                            domain: Some(ToolConfigChangeDomain::ToolScope),
-                                            deferred_catalog_delta: None,
-                                        },
+                                        payload: ToolConfigChangedPayload::new(
+                                            ToolConfigChangeOperation::Reload,
+                                            "tool_scope",
+                                            status_info,
+                                            false,
+                                        )
+                                        .with_applied_at_turn(Some(turn_count))
+                                        .with_domain(Some(ToolConfigChangeDomain::ToolScope)),
                                     });
                                     // Represent runtime notices as user-scoped synthetic context
                                     // (same pattern as peer lifecycle updates) so this does not
@@ -1371,22 +1369,20 @@ where
                                             removed_hidden_names.len(),
                                             pending_sources.len(),
                                         );
-                                    let status = status_info.status_text();
                                     emit_event!(AgentEvent::ToolConfigChanged {
-                                        payload: ToolConfigChangedPayload {
-                                            operation: ToolConfigChangeOperation::Reload,
-                                            target: "deferred_catalog".to_string(),
-                                            status: status.clone(),
-                                            status_info: Some(status_info),
-                                            persisted: false,
-                                            applied_at_turn: Some(turn_count),
-                                            domain: Some(ToolConfigChangeDomain::DeferredCatalog,),
-                                            deferred_catalog_delta: Some(DeferredCatalogDelta {
-                                                added_hidden_names: added_hidden_names.clone(),
-                                                removed_hidden_names: removed_hidden_names.clone(),
-                                                pending_sources: pending_sources.clone(),
-                                            },),
-                                        },
+                                        payload: ToolConfigChangedPayload::new(
+                                            ToolConfigChangeOperation::Reload,
+                                            "deferred_catalog",
+                                            status_info,
+                                            false,
+                                        )
+                                        .with_applied_at_turn(Some(turn_count))
+                                        .with_domain(Some(ToolConfigChangeDomain::DeferredCatalog))
+                                        .with_deferred_catalog_delta(Some(DeferredCatalogDelta {
+                                            added_hidden_names: added_hidden_names.clone(),
+                                            removed_hidden_names: removed_hidden_names.clone(),
+                                            pending_sources: pending_sources.clone(),
+                                        },)),
                                     });
                                     let mut notice_parts = Vec::new();
                                     if !added_hidden_names.is_empty() {
@@ -1424,22 +1420,19 @@ where
                             Err(err) => {
                                 let status_info =
                                     ToolConfigChangeStatus::warning_failed_closed(err.to_string());
-                                let status = status_info.status_text();
                                 tracing::warn!(
                                     error = %err,
                                     "tool scope boundary apply failed; closing visible tool set for this boundary"
                                 );
                                 emit_event!(AgentEvent::ToolConfigChanged {
-                                    payload: ToolConfigChangedPayload {
-                                        operation: ToolConfigChangeOperation::Reload,
-                                        target: "tool_scope".to_string(),
-                                        status: status.clone(),
-                                        status_info: Some(status_info),
-                                        persisted: false,
-                                        applied_at_turn: Some(turn_count),
-                                        domain: Some(ToolConfigChangeDomain::ToolScope),
-                                        deferred_catalog_delta: None,
-                                    },
+                                    payload: ToolConfigChangedPayload::new(
+                                        ToolConfigChangeOperation::Reload,
+                                        "tool_scope",
+                                        status_info,
+                                        false,
+                                    )
+                                    .with_applied_at_turn(Some(turn_count))
+                                    .with_domain(Some(ToolConfigChangeDomain::ToolScope)),
                                 });
                                 self.session.push(synthetic_notice_message(
                                     SystemNoticeKind::ToolScopeWarning,
@@ -4755,20 +4748,20 @@ mod tests {
         while let Ok(event) = rx.try_recv() {
             if let crate::event::AgentEvent::ToolConfigChanged { payload } = event
                 && payload.domain == Some(crate::event::ToolConfigChangeDomain::DeferredCatalog)
-                && let Some(delta) = payload.deferred_catalog_delta
+                && let Some(delta) = payload.deferred_catalog_delta.as_ref()
             {
-                added_hidden_batches.push(delta.added_hidden_names);
-                removed_hidden_batches.push(delta.removed_hidden_names);
-                if let Some(crate::event::ToolConfigChangeStatus::DeferredCatalogDelta {
+                added_hidden_batches.push(delta.added_hidden_names.clone());
+                removed_hidden_batches.push(delta.removed_hidden_names.clone());
+                if let crate::event::ToolConfigChangeStatus::DeferredCatalogDelta {
                     added_hidden_count,
                     removed_hidden_count,
                     pending_source_count,
-                }) = payload.status_info
+                } = payload.status_info()
                 {
                     deferred_status_counts.push((
-                        added_hidden_count,
-                        removed_hidden_count,
-                        pending_source_count,
+                        *added_hidden_count,
+                        *removed_hidden_count,
+                        *pending_source_count,
                     ));
                 }
             }
@@ -4897,9 +4890,9 @@ mod tests {
         let mut saw_warning_event = false;
         while let Ok(event) = rx.try_recv() {
             if let crate::event::AgentEvent::ToolConfigChanged { payload } = event
-                && payload.status.contains("warning_failed_closed")
-                && let Some(crate::event::ToolConfigChangeStatus::WarningFailedClosed { error }) =
-                    payload.status_info
+                && payload.status_text().contains("warning_failed_closed")
+                && let crate::event::ToolConfigChangeStatus::WarningFailedClosed { error } =
+                    payload.status_info()
             {
                 assert!(
                     error.contains("Injected"),

--- a/meerkat-core/src/event.rs
+++ b/meerkat-core/src/event.rs
@@ -787,7 +787,8 @@ impl schemars::JsonSchema for ToolConfigChangedPayload {
             operation: ToolConfigChangeOperation,
             target: String,
             status: String,
-            status_info: ToolConfigChangeStatus,
+            #[serde(default, skip_serializing_if = "Option::is_none")]
+            status_info: Option<ToolConfigChangeStatus>,
             persisted: bool,
             #[serde(skip_serializing_if = "Option::is_none")]
             applied_at_turn: Option<u32>,
@@ -1636,6 +1637,60 @@ mod tests {
                 )
             );
         }
+    }
+
+    #[test]
+    fn tool_config_changed_payload_prefers_typed_status_over_legacy_mirror() {
+        let event: AgentEvent = serde_json::from_value(serde_json::json!({
+            "type": "tool_config_changed",
+            "payload": {
+                "operation": "reload",
+                "target": "tool_scope",
+                "status": "legacy stale status",
+                "status_info": {
+                    "kind": "boundary_applied",
+                    "base_changed": true,
+                    "visible_changed": false,
+                    "revision": 9
+                },
+                "persisted": false,
+                "domain": "tool_scope"
+            }
+        }))
+        .unwrap();
+
+        if let AgentEvent::ToolConfigChanged { payload } = event {
+            assert_eq!(
+                payload.status_info(),
+                &ToolConfigChangeStatus::boundary_applied(true, false, 9)
+            );
+            assert_eq!(
+                payload.status_text(),
+                "boundary_applied(base_changed=true,visible_changed=false,revision=9)"
+            );
+        } else {
+            panic!("expected tool_config_changed event");
+        }
+    }
+
+    #[cfg(feature = "schema")]
+    #[test]
+    fn tool_config_changed_payload_schema_allows_legacy_status_only_replays() {
+        let schema = serde_json::to_value(schemars::schema_for!(ToolConfigChangedPayload)).unwrap();
+        let required = schema["required"].as_array().expect("required array");
+
+        assert!(
+            required.iter().any(|field| field == "status"),
+            "legacy status mirror remains required while it is emitted publicly"
+        );
+        assert!(
+            !required.iter().any(|field| field == "status_info"),
+            "legacy status-only event replays must remain schema-compatible"
+        );
+        assert!(
+            schema["properties"]["status_info"].is_object(),
+            "typed status_info remains part of the schema when present"
+        );
     }
 
     #[test]

--- a/meerkat-core/src/event.rs
+++ b/meerkat-core/src/event.rs
@@ -10,6 +10,7 @@ use crate::skills::{CapabilityId, SkillError, SkillKey};
 use crate::time_compat::SystemTime;
 use crate::types::{ContentInput, SessionId, StopReason, Usage};
 use serde::de::{self, DeserializeOwned};
+use serde::ser::SerializeStruct;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use std::cmp::Ordering;
@@ -646,21 +647,158 @@ pub fn compare_event_envelopes<T>(a: &EventEnvelope<T>, b: &EventEnvelope<T>) ->
 }
 
 /// Payload for tool configuration change notifications.
-#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ToolConfigChangedPayload {
     pub operation: ToolConfigChangeOperation,
     pub target: String,
-    pub status: String,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub status_info: Option<ToolConfigChangeStatus>,
+    status_info: ToolConfigChangeStatus,
     pub persisted: bool,
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub applied_at_turn: Option<u32>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub domain: Option<ToolConfigChangeDomain>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub deferred_catalog_delta: Option<DeferredCatalogDelta>,
+}
+
+impl ToolConfigChangedPayload {
+    #[must_use]
+    pub fn new(
+        operation: ToolConfigChangeOperation,
+        target: impl Into<String>,
+        status_info: ToolConfigChangeStatus,
+        persisted: bool,
+    ) -> Self {
+        Self {
+            operation,
+            target: target.into(),
+            status_info,
+            persisted,
+            applied_at_turn: None,
+            domain: None,
+            deferred_catalog_delta: None,
+        }
+    }
+
+    #[must_use]
+    pub fn status_info(&self) -> &ToolConfigChangeStatus {
+        &self.status_info
+    }
+
+    #[must_use]
+    pub fn status_text(&self) -> String {
+        self.status_info.status_text()
+    }
+
+    #[must_use]
+    pub fn with_applied_at_turn(mut self, applied_at_turn: Option<u32>) -> Self {
+        self.applied_at_turn = applied_at_turn;
+        self
+    }
+
+    #[must_use]
+    pub fn with_domain(mut self, domain: Option<ToolConfigChangeDomain>) -> Self {
+        self.domain = domain;
+        self
+    }
+
+    #[must_use]
+    pub fn with_deferred_catalog_delta(
+        mut self,
+        deferred_catalog_delta: Option<DeferredCatalogDelta>,
+    ) -> Self {
+        self.deferred_catalog_delta = deferred_catalog_delta;
+        self
+    }
+}
+
+impl Serialize for ToolConfigChangedPayload {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        let mut state = serializer.serialize_struct("ToolConfigChangedPayload", 8)?;
+        state.serialize_field("operation", &self.operation)?;
+        state.serialize_field("target", &self.target)?;
+        state.serialize_field("status", &self.status_text())?;
+        state.serialize_field("status_info", &self.status_info)?;
+        state.serialize_field("persisted", &self.persisted)?;
+        if let Some(applied_at_turn) = self.applied_at_turn {
+            state.serialize_field("applied_at_turn", &applied_at_turn)?;
+        }
+        if let Some(domain) = &self.domain {
+            state.serialize_field("domain", domain)?;
+        }
+        if let Some(delta) = &self.deferred_catalog_delta {
+            state.serialize_field("deferred_catalog_delta", delta)?;
+        }
+        state.end()
+    }
+}
+
+impl<'de> Deserialize<'de> for ToolConfigChangedPayload {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        #[derive(Deserialize)]
+        struct WirePayload {
+            operation: ToolConfigChangeOperation,
+            target: String,
+            #[serde(default)]
+            status: Option<String>,
+            #[serde(default)]
+            status_info: Option<ToolConfigChangeStatus>,
+            persisted: bool,
+            #[serde(default)]
+            applied_at_turn: Option<u32>,
+            #[serde(default)]
+            domain: Option<ToolConfigChangeDomain>,
+            #[serde(default)]
+            deferred_catalog_delta: Option<DeferredCatalogDelta>,
+        }
+
+        let wire = WirePayload::deserialize(deserializer)?;
+        let status_info = wire
+            .status_info
+            .or_else(|| wire.status.map(ToolConfigChangeStatus::legacy_status))
+            .ok_or_else(|| de::Error::missing_field("status_info"))?;
+
+        Ok(Self {
+            operation: wire.operation,
+            target: wire.target,
+            status_info,
+            persisted: wire.persisted,
+            applied_at_turn: wire.applied_at_turn,
+            domain: wire.domain,
+            deferred_catalog_delta: wire.deferred_catalog_delta,
+        })
+    }
+}
+
+#[cfg(feature = "schema")]
+impl schemars::JsonSchema for ToolConfigChangedPayload {
+    fn schema_name() -> std::borrow::Cow<'static, str> {
+        "ToolConfigChangedPayload".into()
+    }
+
+    fn json_schema(generator: &mut schemars::SchemaGenerator) -> schemars::Schema {
+        /// Payload for tool configuration change notifications.
+        #[allow(dead_code)]
+        #[derive(schemars::JsonSchema)]
+        struct ToolConfigChangedPayloadSchema {
+            operation: ToolConfigChangeOperation,
+            target: String,
+            status: String,
+            status_info: ToolConfigChangeStatus,
+            persisted: bool,
+            #[serde(skip_serializing_if = "Option::is_none")]
+            applied_at_turn: Option<u32>,
+            #[serde(default, skip_serializing_if = "Option::is_none")]
+            domain: Option<ToolConfigChangeDomain>,
+            #[serde(default, skip_serializing_if = "Option::is_none")]
+            deferred_catalog_delta: Option<DeferredCatalogDelta>,
+        }
+
+        ToolConfigChangedPayloadSchema::json_schema(generator)
+    }
 }
 
 /// Optional typed domain for tool-configuration change payloads.
@@ -742,6 +880,9 @@ pub enum ToolConfigChangeStatus {
         #[serde(default, skip_serializing_if = "Option::is_none")]
         detail: Option<String>,
     },
+    LegacyStatus {
+        status: String,
+    },
 }
 
 impl ToolConfigChangeStatus {
@@ -780,6 +921,13 @@ impl ToolConfigChangeStatus {
     }
 
     #[must_use]
+    pub fn legacy_status(status: impl Into<String>) -> Self {
+        Self::LegacyStatus {
+            status: status.into(),
+        }
+    }
+
+    #[must_use]
     pub fn status_text(&self) -> String {
         match self {
             Self::BoundaryApplied {
@@ -808,6 +956,7 @@ impl ToolConfigChangeStatus {
                 }
                 status
             }
+            Self::LegacyStatus { status } => status.clone(),
         }
     }
 }
@@ -869,16 +1018,13 @@ impl ExternalToolDelta {
     pub fn to_tool_config_changed_payload(&self) -> ToolConfigChangedPayload {
         let status_info =
             ToolConfigChangeStatus::external_tool_delta(self.phase, self.detail.clone());
-        ToolConfigChangedPayload {
-            operation: self.operation.clone(),
-            target: self.target.clone(),
-            status: status_info.status_text(),
-            status_info: Some(status_info),
-            persisted: self.persisted,
-            applied_at_turn: self.applied_at_turn,
-            domain: None,
-            deferred_catalog_delta: None,
-        }
+        ToolConfigChangedPayload::new(
+            self.operation.clone(),
+            self.target.clone(),
+            status_info,
+            self.persisted,
+        )
+        .with_applied_at_turn(self.applied_at_turn)
     }
 }
 
@@ -1405,16 +1551,14 @@ mod tests {
     fn tool_config_changed_payload_carries_structured_status_with_legacy_mirror() {
         let status_info = ToolConfigChangeStatus::boundary_applied(true, true, 42);
         let event = AgentEvent::ToolConfigChanged {
-            payload: ToolConfigChangedPayload {
-                operation: ToolConfigChangeOperation::Reload,
-                target: "tool_scope".to_string(),
-                status: status_info.status_text(),
-                status_info: Some(status_info),
-                persisted: false,
-                applied_at_turn: Some(3),
-                domain: Some(ToolConfigChangeDomain::ToolScope),
-                deferred_catalog_delta: None,
-            },
+            payload: ToolConfigChangedPayload::new(
+                ToolConfigChangeOperation::Reload,
+                "tool_scope",
+                status_info,
+                false,
+            )
+            .with_applied_at_turn(Some(3))
+            .with_domain(Some(ToolConfigChangeDomain::ToolScope)),
         };
 
         let json = serde_json::to_value(event).unwrap();
@@ -1426,6 +1570,39 @@ mod tests {
         assert_eq!(json["payload"]["status_info"]["base_changed"], true);
         assert_eq!(json["payload"]["status_info"]["visible_changed"], true);
         assert_eq!(json["payload"]["status_info"]["revision"], 42);
+    }
+
+    #[test]
+    fn tool_config_changed_payload_derives_legacy_status_from_typed_status() {
+        let status = ToolConfigChangeStatus::boundary_applied(true, false, 9);
+        let event = AgentEvent::ToolConfigChanged {
+            payload: ToolConfigChangedPayload::new(
+                ToolConfigChangeOperation::Reload,
+                "tool_scope",
+                status.clone(),
+                false,
+            )
+            .with_applied_at_turn(Some(4))
+            .with_domain(Some(ToolConfigChangeDomain::ToolScope)),
+        };
+
+        let json = serde_json::to_value(event).unwrap();
+        assert_eq!(
+            json["payload"]["status"],
+            "boundary_applied(base_changed=true,visible_changed=false,revision=9)"
+        );
+        assert_eq!(json["payload"]["status_info"]["kind"], "boundary_applied");
+
+        let event: AgentEvent = serde_json::from_value(json).unwrap();
+        if let AgentEvent::ToolConfigChanged { payload } = event {
+            assert_eq!(payload.status_info(), &status);
+            assert_eq!(
+                payload.status_text(),
+                "boundary_applied(base_changed=true,visible_changed=false,revision=9)"
+            );
+        } else {
+            panic!("expected tool_config_changed event");
+        }
     }
 
     #[test]
@@ -1449,10 +1626,15 @@ mod tests {
         );
         if let AgentEvent::ToolConfigChanged { payload } = event {
             assert_eq!(
-                payload.status,
+                payload.status_text(),
                 "boundary_applied(base_changed=true,visible_changed=true,revision=42)"
             );
-            assert_eq!(payload.status_info, None);
+            assert_eq!(
+                payload.status_info(),
+                &ToolConfigChangeStatus::legacy_status(
+                    "boundary_applied(base_changed=true,visible_changed=true,revision=42)"
+                )
+            );
         }
     }
 
@@ -1545,16 +1727,13 @@ mod tests {
                 reason: "channel full".to_string(),
             },
             AgentEvent::ToolConfigChanged {
-                payload: ToolConfigChangedPayload {
-                    operation: ToolConfigChangeOperation::Remove,
-                    target: "filesystem".to_string(),
-                    status: "staged".to_string(),
-                    status_info: None,
-                    persisted: false,
-                    applied_at_turn: Some(12),
-                    domain: None,
-                    deferred_catalog_delta: None,
-                },
+                payload: ToolConfigChangedPayload::new(
+                    ToolConfigChangeOperation::Remove,
+                    "filesystem",
+                    ToolConfigChangeStatus::legacy_status("staged"),
+                    false,
+                )
+                .with_applied_at_turn(Some(12)),
             },
             AgentEvent::BackgroundJobCompleted {
                 job_id: "j_123".to_string(),
@@ -2038,19 +2217,16 @@ mod tests {
                 reason: "lag".to_string(),
             },
             AgentEvent::ToolConfigChanged {
-                payload: ToolConfigChangedPayload {
-                    operation: ToolConfigChangeOperation::Reload,
-                    target: "external".to_string(),
-                    status: "applied".to_string(),
-                    status_info: Some(ToolConfigChangeStatus::external_tool_delta(
+                payload: ToolConfigChangedPayload::new(
+                    ToolConfigChangeOperation::Reload,
+                    "external",
+                    ToolConfigChangeStatus::external_tool_delta(
                         ExternalToolDeltaPhase::Applied,
                         None,
-                    )),
-                    persisted: true,
-                    applied_at_turn: Some(1),
-                    domain: None,
-                    deferred_catalog_delta: None,
-                },
+                    ),
+                    true,
+                )
+                .with_applied_at_turn(Some(1)),
             },
             AgentEvent::BackgroundJobCompleted {
                 job_id: "j_123".to_string(),

--- a/meerkat-mcp-server/src/lib.rs
+++ b/meerkat-mcp-server/src/lib.rs
@@ -951,9 +951,16 @@ pub struct MeerkatMcpReloadInput {
     pub persisted: bool,
 }
 
+#[derive(Debug, Clone, Copy, Deserialize, JsonSchema, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum MeerkatSkillsAction {
+    List,
+    Inspect,
+}
+
 #[derive(Debug, Deserialize, JsonSchema)]
 pub struct MeerkatSkillsInput {
-    pub action: String,
+    pub action: MeerkatSkillsAction,
     /// Typed skill identity for the `inspect` action.
     #[serde(default)]
     pub skill_key: Option<meerkat_core::skills::SkillKey>,
@@ -1614,8 +1621,8 @@ async fn handle_meerkat_skills(
         .as_ref()
         .ok_or_else(|| "skills not enabled".to_string())?;
 
-    match input.action.as_str() {
-        "list" => {
+    match input.action {
+        MeerkatSkillsAction::List => {
             let entries = runtime
                 .list_all_with_provenance(&meerkat_core::skills::SkillFilter::default())
                 .await
@@ -1643,7 +1650,7 @@ async fn handle_meerkat_skills(
             serde_json::to_value(meerkat_contracts::SkillListResponse { skills: wire })
                 .map_err(|e| format!("serialization failed: {e}"))
         }
-        "inspect" => {
+        MeerkatSkillsAction::Inspect => {
             let skill_key = input
                 .skill_key
                 .as_ref()
@@ -1673,7 +1680,6 @@ async fn handle_meerkat_skills(
             })
             .map_err(|e| format!("serialization failed: {e}"))
         }
-        _ => Err(format!("unknown action: {}", input.action)),
     }
 }
 
@@ -3890,6 +3896,34 @@ mod tests {
             skills_tool["inputSchema"]["properties"]["source"].is_object(),
             "skills inspect should expose optional source selector"
         );
+    }
+
+    #[test]
+    fn test_tools_list_skills_schema_has_typed_action_enum() {
+        let tools = tools_list();
+        let skills_tool = tools
+            .iter()
+            .find(|t| t["name"] == "meerkat_skills")
+            .expect("meerkat_skills tool must exist");
+        let action_schema = &skills_tool["inputSchema"]["properties"]["action"];
+        let action_enum = action_schema.get("enum").or_else(|| {
+            let action_ref = action_schema["$ref"].as_str()?;
+            let definition = action_ref
+                .strip_prefix("#/$defs/")
+                .or_else(|| action_ref.strip_prefix("#/definitions/"))?;
+            skills_tool["inputSchema"]["$defs"][definition]
+                .get("enum")
+                .or_else(|| skills_tool["inputSchema"]["definitions"][definition].get("enum"))
+        });
+        assert_eq!(
+            action_enum,
+            Some(&serde_json::json!(["list", "inspect"])),
+            "skills action should be a closed typed enum, got {action_schema}"
+        );
+
+        let input: MeerkatSkillsInput =
+            serde_json::from_value(serde_json::json!({ "action": "list" })).unwrap();
+        assert!(matches!(input.action, MeerkatSkillsAction::List));
     }
 
     #[cfg(not(feature = "comms"))]

--- a/meerkat-rpc/src/handlers/mob.rs
+++ b/meerkat-rpc/src/handlers/mob.rs
@@ -1952,8 +1952,12 @@ pub async fn handle_reconcile(
                     .map(|f| meerkat_contracts::MobReconcileFailureWire {
                         agent_identity: f.agent_identity.to_string(),
                         stage: match f.stage {
-                            meerkat_mob::runtime::ReconcileStage::Spawn => "spawn".to_string(),
-                            meerkat_mob::runtime::ReconcileStage::Retire => "retire".to_string(),
+                            meerkat_mob::runtime::ReconcileStage::Spawn => {
+                                meerkat_contracts::WireMobReconcileStage::Spawn
+                            }
+                            meerkat_mob::runtime::ReconcileStage::Retire => {
+                                meerkat_contracts::WireMobReconcileStage::Retire
+                            }
                         },
                         error: f.error.to_string(),
                     })

--- a/meerkat-rpc/src/session_runtime.rs
+++ b/meerkat-rpc/src/session_runtime.rs
@@ -6758,7 +6758,7 @@ mod tests {
             first_events.iter().any(|payload| {
                 payload.operation == ToolConfigChangeOperation::Add
                     && payload.target == "broken-server"
-                    && payload.status == "pending"
+                    && payload.status_text() == "pending"
             }),
             "should emit pending event for staged add"
         );
@@ -6817,7 +6817,7 @@ mod tests {
         assert!(add_events.iter().any(|payload| {
             payload.operation == ToolConfigChangeOperation::Add
                 && payload.target == "test-server"
-                && payload.status == "pending"
+                && payload.status_text() == "pending"
         }));
 
         runtime
@@ -6841,7 +6841,7 @@ mod tests {
         assert!(remove_events.iter().any(|payload| {
             payload.operation == ToolConfigChangeOperation::Remove
                 && payload.target == "test-server"
-                && (payload.status == "applied" || payload.status == "draining")
+                && matches!(payload.status_text().as_str(), "applied" | "draining")
         }));
     }
 
@@ -6918,7 +6918,7 @@ mod tests {
         assert!(first_turn_events.iter().any(|payload| {
             payload.operation == ToolConfigChangeOperation::Remove
                 && payload.target == "timeout-server"
-                && payload.status == "draining"
+                && payload.status_text() == "draining"
         }));
 
         tokio::time::timeout(Duration::from_secs(2), async {
@@ -6964,7 +6964,7 @@ mod tests {
             second_turn_events.iter().any(|payload| {
                 payload.operation == ToolConfigChangeOperation::Remove
                     && payload.target == "timeout-server"
-                    && (payload.status == "forced" || payload.status == "applied")
+                    && matches!(payload.status_text().as_str(), "forced" | "applied")
             }),
             "expected forced removal event on a follow-up boundary, got: {second_turn_events:?}"
         );
@@ -7040,7 +7040,7 @@ mod tests {
         assert!(first_turn_events.iter().any(|payload| {
             payload.operation == ToolConfigChangeOperation::Remove
                 && payload.target == "server-draining"
-                && payload.status == "draining"
+                && payload.status_text() == "draining"
         }));
         assert!(
             adapter.tools().is_empty(),
@@ -7080,7 +7080,7 @@ mod tests {
             next_turn_events.iter().any(|payload| {
                 payload.operation == ToolConfigChangeOperation::Add
                     && payload.target == "server-staged"
-                    && payload.status == "pending"
+                    && payload.status_text() == "pending"
             }),
             "expected Add+pending for server-staged at boundary, got: {next_turn_events:?}"
         );
@@ -7225,7 +7225,7 @@ mod tests {
             fail_turn_events.iter().any(|payload| {
                 payload.operation == ToolConfigChangeOperation::Remove
                     && payload.target == "lossless-server"
-                    && (payload.status == "forced" || payload.status == "applied")
+                    && matches!(payload.status_text().as_str(), "forced" | "applied")
             }),
             "removal of lossless-server should survive alongside broken add, got: {fail_turn_events:?}"
         );

--- a/sdks/web/src/generated/events.ts
+++ b/sdks/web/src/generated/events.ts
@@ -248,7 +248,7 @@ export type ToolConfigChangedPayload = {
   operation: ToolConfigChangeOperation;
   persisted: boolean;
   status: string;
-  status_info: ToolConfigChangeStatus;
+  status_info?: ToolConfigChangeStatus | null;
   target: string;
 };
 

--- a/sdks/web/src/generated/events.ts
+++ b/sdks/web/src/generated/events.ts
@@ -236,6 +236,9 @@ export type ToolConfigChangeStatus = {
   detail?: string | null;
   kind: "external_tool_delta";
   phase: ExternalToolDeltaPhase;
+} | {
+  kind: "legacy_status";
+  status: string;
 };
 
 export type ToolConfigChangedPayload = {
@@ -245,7 +248,7 @@ export type ToolConfigChangedPayload = {
   operation: ToolConfigChangeOperation;
   persisted: boolean;
   status: string;
-  status_info?: ToolConfigChangeStatus | null;
+  status_info: ToolConfigChangeStatus;
   target: string;
 };
 


### PR DESCRIPTION
Linear: LUC-96

## Summary
- make tool-config events construct typed status while preserving the legacy status string on the wire
- replace MCP skills action and mob reconcile failure stage string fields with typed enums
- regenerate event schema and web SDK event types

## Validation
- ./scripts/repo-cargo test -p meerkat-core tool_config_changed_payload_
- ./scripts/repo-cargo test -p meerkat-mcp-server test_tools_list_skills_schema_has_typed_action_enum
- ./scripts/repo-cargo test -p meerkat-contracts mob_reconcile_failure_stage_is_typed_wire_enum
- ./scripts/repo-cargo test -p meerkat-contracts wire_event_roundtrip_tool_config_changed
- ./scripts/repo-cargo test -p meerkat-rpc --lib mob_reconcile
- make fmt
- make regen-schemas
- make verify-schema-freshness
- make verify-sdk-wrapper-freshness
- make check
- make lint