### PR TITLE
LUC-101 Move cloud token freshness under auth leases

### DIFF
--- a/meerkat-auth-core/src/authorizers/azure.rs
+++ b/meerkat-auth-core/src/authorizers/azure.rs
@@ -23,7 +23,7 @@ use parking_lot::Mutex;
 use serde::Deserialize;
 use thiserror::Error;
 
-use super::{LeaseFreshnessObserver, token_is_fresh_at};
+use super::{LeaseFreshnessObserver, oauth_endpoint_failure_is_permanent, token_is_fresh_at};
 use meerkat_core::handles::{AuthLeaseHandle, LeaseKey};
 use meerkat_core::{AuthError, HttpAuthorizationRequest, HttpAuthorizer};
 
@@ -101,6 +101,7 @@ pub struct AzureAdAuthorizer {
     creds: AzureClientCredentials,
     http: reqwest::Client,
     cache: Arc<Mutex<Option<CachedToken>>>,
+    refresh_lock: Arc<tokio::sync::Mutex<()>>,
     label: String,
     token_url_override: Option<String>,
     lease_observer: Option<LeaseFreshnessObserver>,
@@ -115,6 +116,7 @@ impl AzureAdAuthorizer {
             creds,
             http: reqwest::Client::new(),
             cache: Arc::new(Mutex::new(None)),
+            refresh_lock: Arc::new(tokio::sync::Mutex::new(())),
             label,
             token_url_override: None,
             lease_observer: None,
@@ -189,9 +191,7 @@ impl AzureAdAuthorizer {
         self.cache.lock().as_ref().map(|token| token.expires_at)
     }
 
-    async fn get_token(&self) -> Result<String, AuthError> {
-        // Check cache without taking the refresh path.
-        let now = Utc::now();
+    fn fresh_cached_token(&self, now: DateTime<Utc>) -> Result<Option<String>, AuthError> {
         if let Some((access_token, expires_at)) = {
             let guard = self.cache.lock();
             guard
@@ -204,8 +204,21 @@ impl AzureAdAuthorizer {
                 token_is_fresh_at(expires_at, now)
             };
             if fresh {
-                return Ok(access_token);
+                return Ok(Some(access_token));
             }
+        }
+        Ok(None)
+    }
+
+    async fn get_token(&self) -> Result<String, AuthError> {
+        // Check cache without taking the refresh path.
+        if let Some(access_token) = self.fresh_cached_token(Utc::now())? {
+            return Ok(access_token);
+        }
+
+        let _refresh_guard = self.refresh_lock.lock().await;
+        if let Some(access_token) = self.fresh_cached_token(Utc::now())? {
+            return Ok(access_token);
         }
 
         let lifecycle = if let Some(observer) = &self.lease_observer {
@@ -239,12 +252,13 @@ impl AzureAdAuthorizer {
 }
 
 fn azure_refresh_failure_is_permanent(err: &AzureAuthError) -> bool {
-    matches!(
-        err,
-        AzureAuthError::MissingEnv(_)
-            | AzureAuthError::TokenEndpoint { .. }
-            | AzureAuthError::InvalidResponse(_)
-    )
+    match err {
+        AzureAuthError::MissingEnv(_) | AzureAuthError::InvalidResponse(_) => true,
+        AzureAuthError::Network(_) => false,
+        AzureAuthError::TokenEndpoint { status, body } => {
+            oauth_endpoint_failure_is_permanent(*status, body)
+        }
+    }
 }
 
 #[async_trait]

--- a/meerkat-auth-core/src/authorizers/azure.rs
+++ b/meerkat-auth-core/src/authorizers/azure.rs
@@ -222,7 +222,7 @@ impl AzureAdAuthorizer {
         }
 
         let lifecycle = if let Some(observer) = &self.lease_observer {
-            Some(observer.begin_refresh(&self.label)?)
+            Some(observer.begin_refresh(&self.label).await?)
         } else {
             None
         };

--- a/meerkat-auth-core/src/authorizers/azure.rs
+++ b/meerkat-auth-core/src/authorizers/azure.rs
@@ -23,8 +23,8 @@ use parking_lot::Mutex;
 use serde::Deserialize;
 use thiserror::Error;
 
-use super::LeaseFreshnessObserver;
-use meerkat_core::handles::{AUTH_LEASE_TTL_REFRESH_WINDOW_SECS, AuthLeaseHandle, LeaseKey};
+use super::{LeaseFreshnessObserver, token_is_fresh_at};
+use meerkat_core::handles::{AuthLeaseHandle, LeaseKey};
 use meerkat_core::{AuthError, HttpAuthorizationRequest, HttpAuthorizer};
 
 const DEFAULT_AUTHORITY: &str = "https://login.microsoftonline.com";
@@ -189,37 +189,62 @@ impl AzureAdAuthorizer {
         self.cache.lock().as_ref().map(|token| token.expires_at)
     }
 
-    fn publish_expires_at(&self, expires_at: DateTime<Utc>) {
-        if let Some(observer) = &self.lease_observer {
-            observer.observe_expires_at(&self.label, expires_at);
-        }
-    }
-
     async fn get_token(&self) -> Result<String, AuthError> {
         // Check cache without taking the refresh path.
-        let cached = {
+        let now = Utc::now();
+        if let Some((access_token, expires_at)) = {
             let guard = self.cache.lock();
-            if let Some(t) = guard.as_ref()
-                && t.expires_at - Utc::now()
-                    > Duration::seconds(AUTH_LEASE_TTL_REFRESH_WINDOW_SECS as i64)
-            {
-                Some((t.access_token.clone(), t.expires_at))
+            guard
+                .as_ref()
+                .map(|t| (t.access_token.clone(), t.expires_at))
+        } {
+            let fresh = if let Some(observer) = &self.lease_observer {
+                observer.cached_token_is_fresh(&self.label, expires_at, now)?
             } else {
-                None
+                token_is_fresh_at(expires_at, now)
+            };
+            if fresh {
+                return Ok(access_token);
+            }
+        }
+
+        let lifecycle = if let Some(observer) = &self.lease_observer {
+            Some(observer.begin_refresh(&self.label)?)
+        } else {
+            None
+        };
+
+        // Miss — fetch a fresh token.
+        let new_token = match self.fetch_token().await {
+            Ok(token) => token,
+            Err(err) => {
+                if let (Some(observer), Some(lifecycle)) = (&self.lease_observer, lifecycle) {
+                    observer.refresh_failed(
+                        &self.label,
+                        lifecycle,
+                        azure_refresh_failure_is_permanent(&err),
+                    )?;
+                }
+                return Err(err.into());
             }
         };
-        if let Some((access_token, expires_at)) = cached {
-            self.publish_expires_at(expires_at);
-            return Ok(access_token);
-        }
-        // Miss — fetch a fresh token.
-        let new_token = self.fetch_token().await?;
         let access = new_token.access_token.clone();
         let expires_at = new_token.expires_at;
+        if let (Some(observer), Some(lifecycle)) = (&self.lease_observer, lifecycle) {
+            observer.complete_refresh(&self.label, lifecycle, expires_at, Utc::now())?;
+        }
         *self.cache.lock() = Some(new_token);
-        self.publish_expires_at(expires_at);
         Ok(access)
     }
+}
+
+fn azure_refresh_failure_is_permanent(err: &AzureAuthError) -> bool {
+    matches!(
+        err,
+        AzureAuthError::MissingEnv(_)
+            | AzureAuthError::TokenEndpoint { .. }
+            | AzureAuthError::InvalidResponse(_)
+    )
 }
 
 #[async_trait]

--- a/meerkat-auth-core/src/authorizers/google.rs
+++ b/meerkat-auth-core/src/authorizers/google.rs
@@ -24,7 +24,9 @@ use parking_lot::Mutex;
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
 
-use super::{EnvLookup, LeaseFreshnessObserver, token_is_fresh_at};
+use super::{
+    EnvLookup, LeaseFreshnessObserver, oauth_endpoint_failure_is_permanent, token_is_fresh_at,
+};
 use meerkat_core::handles::{AuthLeaseHandle, LeaseKey};
 use meerkat_core::{AuthError, HttpAuthorizationRequest, HttpAuthorizer};
 
@@ -124,6 +126,7 @@ pub struct GoogleAuthAuthorizer {
     env_lookup: EnvLookup,
     home_dir: Option<PathBuf>,
     http: reqwest::Client,
+    refresh_lock: Arc<tokio::sync::Mutex<()>>,
     label: String,
     token_url_override: Option<String>,
     metadata_url_override: Option<String>,
@@ -158,6 +161,7 @@ impl GoogleAuthAuthorizer {
             env_lookup,
             home_dir: dirs::home_dir(),
             http: reqwest::Client::new(),
+            refresh_lock: Arc::new(tokio::sync::Mutex::new(())),
             label,
             token_url_override: None,
             metadata_url_override: None,
@@ -214,8 +218,7 @@ impl GoogleAuthAuthorizer {
         self.cache.lock().as_ref().map(|token| token.expires_at)
     }
 
-    async fn get_token(&self) -> Result<String, AuthError> {
-        let now = Utc::now();
+    fn fresh_cached_token(&self, now: DateTime<Utc>) -> Result<Option<String>, AuthError> {
         if let Some((access_token, expires_at)) = {
             let guard = self.cache.lock();
             guard
@@ -228,8 +231,20 @@ impl GoogleAuthAuthorizer {
                 token_is_fresh_at(expires_at, now)
             };
             if fresh {
-                return Ok(access_token);
+                return Ok(Some(access_token));
             }
+        }
+        Ok(None)
+    }
+
+    async fn get_token(&self) -> Result<String, AuthError> {
+        if let Some(access_token) = self.fresh_cached_token(Utc::now())? {
+            return Ok(access_token);
+        }
+
+        let _refresh_guard = self.refresh_lock.lock().await;
+        if let Some(access_token) = self.fresh_cached_token(Utc::now())? {
+            return Ok(access_token);
         }
 
         let lifecycle = if let Some(observer) = &self.lease_observer {
@@ -433,14 +448,16 @@ impl GoogleAuthAuthorizer {
 }
 
 fn google_refresh_failure_is_permanent(err: &GoogleAuthError) -> bool {
-    matches!(
-        err,
+    match err {
         GoogleAuthError::NoCredentialSource
-            | GoogleAuthError::Json(_)
-            | GoogleAuthError::JwtSign(_)
-            | GoogleAuthError::TokenEndpoint { .. }
-            | GoogleAuthError::MetadataEndpoint { .. }
-    )
+        | GoogleAuthError::Json(_)
+        | GoogleAuthError::JwtSign(_) => true,
+        GoogleAuthError::Io(_) | GoogleAuthError::Network(_) => false,
+        GoogleAuthError::TokenEndpoint { status, body } => {
+            oauth_endpoint_failure_is_permanent(*status, body)
+        }
+        GoogleAuthError::MetadataEndpoint { .. } => false,
+    }
 }
 
 #[async_trait]

--- a/meerkat-auth-core/src/authorizers/google.rs
+++ b/meerkat-auth-core/src/authorizers/google.rs
@@ -25,7 +25,8 @@ use serde::{Deserialize, Serialize};
 use thiserror::Error;
 
 use super::{
-    EnvLookup, LeaseFreshnessObserver, oauth_endpoint_failure_is_permanent, token_is_fresh_at,
+    EnvLookup, LeaseFreshnessObserver, endpoint_failure_is_transient,
+    oauth_endpoint_failure_is_permanent, token_is_fresh_at,
 };
 use meerkat_core::handles::{AuthLeaseHandle, LeaseKey};
 use meerkat_core::{AuthError, HttpAuthorizationRequest, HttpAuthorizer};
@@ -66,9 +67,11 @@ impl From<GoogleAuthError> for AuthError {
         match e {
             GoogleAuthError::NoCredentialSource => AuthError::MissingSecret,
             GoogleAuthError::Io(msg) | GoogleAuthError::Network(msg) => AuthError::Io(msg),
-            GoogleAuthError::TokenEndpoint { status, body }
-            | GoogleAuthError::MetadataEndpoint { status, body } => {
+            GoogleAuthError::TokenEndpoint { status, body } => {
                 AuthError::RefreshFailed(format!("google token endpoint {status}: {body}"))
+            }
+            GoogleAuthError::MetadataEndpoint { status, body } => {
+                AuthError::RefreshFailed(format!("google metadata endpoint {status}: {body}"))
             }
             GoogleAuthError::Json(msg) => AuthError::Other(format!("google json: {msg}")),
             GoogleAuthError::JwtSign(msg) => AuthError::Other(format!("google jwt sign: {msg}")),
@@ -248,7 +251,7 @@ impl GoogleAuthAuthorizer {
         }
 
         let lifecycle = if let Some(observer) = &self.lease_observer {
-            Some(observer.begin_refresh(&self.label)?)
+            Some(observer.begin_refresh(&self.label).await?)
         } else {
             None
         };
@@ -308,6 +311,7 @@ impl GoogleAuthAuthorizer {
         // 3. Metadata server
         match self.fetch_from_metadata().await {
             Ok(t) => Ok(t),
+            Err(err) if default_chain_metadata_error_is_retryable(&err) => Err(err),
             Err(_) => Err(GoogleAuthError::NoCredentialSource),
         }
     }
@@ -457,6 +461,15 @@ fn google_refresh_failure_is_permanent(err: &GoogleAuthError) -> bool {
             oauth_endpoint_failure_is_permanent(*status, body)
         }
         GoogleAuthError::MetadataEndpoint { .. } => false,
+    }
+}
+
+fn default_chain_metadata_error_is_retryable(err: &GoogleAuthError) -> bool {
+    match err {
+        GoogleAuthError::MetadataEndpoint { status, body } => {
+            endpoint_failure_is_transient(*status, body)
+        }
+        _ => false,
     }
 }
 

--- a/meerkat-auth-core/src/authorizers/google.rs
+++ b/meerkat-auth-core/src/authorizers/google.rs
@@ -24,8 +24,8 @@ use parking_lot::Mutex;
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
 
-use super::{EnvLookup, LeaseFreshnessObserver};
-use meerkat_core::handles::{AUTH_LEASE_TTL_REFRESH_WINDOW_SECS, AuthLeaseHandle, LeaseKey};
+use super::{EnvLookup, LeaseFreshnessObserver, token_is_fresh_at};
+use meerkat_core::handles::{AuthLeaseHandle, LeaseKey};
 use meerkat_core::{AuthError, HttpAuthorizationRequest, HttpAuthorizer};
 
 const DEFAULT_SCOPE: &str = "https://www.googleapis.com/auth/cloud-platform";
@@ -214,37 +214,64 @@ impl GoogleAuthAuthorizer {
         self.cache.lock().as_ref().map(|token| token.expires_at)
     }
 
-    fn publish_expires_at(&self, expires_at: DateTime<Utc>) {
-        if let Some(observer) = &self.lease_observer {
-            observer.observe_expires_at(&self.label, expires_at);
-        }
-    }
-
     async fn get_token(&self) -> Result<String, AuthError> {
-        let cached = {
+        let now = Utc::now();
+        if let Some((access_token, expires_at)) = {
             let guard = self.cache.lock();
-            if let Some(t) = guard.as_ref()
-                && t.expires_at - Utc::now()
-                    > Duration::seconds(AUTH_LEASE_TTL_REFRESH_WINDOW_SECS as i64)
-            {
-                Some((t.access_token.clone(), t.expires_at))
+            guard
+                .as_ref()
+                .map(|t| (t.access_token.clone(), t.expires_at))
+        } {
+            let fresh = if let Some(observer) = &self.lease_observer {
+                observer.cached_token_is_fresh(&self.label, expires_at, now)?
             } else {
-                None
+                token_is_fresh_at(expires_at, now)
+            };
+            if fresh {
+                return Ok(access_token);
             }
-        };
-        if let Some((access_token, expires_at)) = cached {
-            self.publish_expires_at(expires_at);
-            return Ok(access_token);
         }
+
+        let lifecycle = if let Some(observer) = &self.lease_observer {
+            Some(observer.begin_refresh(&self.label)?)
+        } else {
+            None
+        };
 
         let token = match self.chain {
-            GoogleAuthChain::ComputeOnly => self.fetch_from_metadata().await?,
-            GoogleAuthChain::Default => self.fetch_full_chain().await?,
+            GoogleAuthChain::ComputeOnly => match self.fetch_from_metadata().await {
+                Ok(token) => token,
+                Err(err) => {
+                    if let (Some(observer), Some(lifecycle)) = (&self.lease_observer, lifecycle) {
+                        observer.refresh_failed(
+                            &self.label,
+                            lifecycle,
+                            google_refresh_failure_is_permanent(&err),
+                        )?;
+                    }
+                    return Err(err.into());
+                }
+            },
+            GoogleAuthChain::Default => match self.fetch_full_chain().await {
+                Ok(token) => token,
+                Err(err) => {
+                    if let (Some(observer), Some(lifecycle)) = (&self.lease_observer, lifecycle) {
+                        observer.refresh_failed(
+                            &self.label,
+                            lifecycle,
+                            google_refresh_failure_is_permanent(&err),
+                        )?;
+                    }
+                    return Err(err.into());
+                }
+            },
         };
         let access = token.access_token.clone();
         let expires_at = token.expires_at;
+        if let (Some(observer), Some(lifecycle)) = (&self.lease_observer, lifecycle) {
+            observer.complete_refresh(&self.label, lifecycle, expires_at, Utc::now())?;
+        }
         *self.cache.lock() = Some(token);
-        self.publish_expires_at(expires_at);
         Ok(access)
     }
 
@@ -403,6 +430,17 @@ impl GoogleAuthAuthorizer {
             expires_at: Utc::now() + Duration::seconds(body.expires_in as i64),
         })
     }
+}
+
+fn google_refresh_failure_is_permanent(err: &GoogleAuthError) -> bool {
+    matches!(
+        err,
+        GoogleAuthError::NoCredentialSource
+            | GoogleAuthError::Json(_)
+            | GoogleAuthError::JwtSign(_)
+            | GoogleAuthError::TokenEndpoint { .. }
+            | GoogleAuthError::MetadataEndpoint { .. }
+    )
 }
 
 #[async_trait]

--- a/meerkat-auth-core/src/authorizers/mod.rs
+++ b/meerkat-auth-core/src/authorizers/mod.rs
@@ -155,6 +155,59 @@ pub(crate) fn token_is_fresh_at(expires_at: DateTime<Utc>, now: DateTime<Utc>) -
 }
 
 #[cfg(any(feature = "azure-ad", feature = "gcp-auth"))]
+pub(crate) fn oauth_endpoint_failure_is_permanent(status: u16, body: &str) -> bool {
+    if endpoint_failure_is_transient(status, body) {
+        return false;
+    }
+
+    if matches!(status, 401 | 403) {
+        return true;
+    }
+
+    matches!(status, 400) && body_mentions_permanent_oauth_error(body)
+}
+
+#[cfg(any(feature = "azure-ad", feature = "gcp-auth"))]
+pub(crate) fn endpoint_failure_is_transient(status: u16, body: &str) -> bool {
+    matches!(status, 408 | 409 | 425 | 429 | 500..=599)
+        || body_mentions_any(
+            body,
+            &[
+                "temporarily_unavailable",
+                "temporary_unavailable",
+                "server_error",
+                "rate_limit",
+                "rate_limited",
+                "too_many_requests",
+                "timeout",
+                "timed out",
+                "try again",
+            ],
+        )
+}
+
+#[cfg(any(feature = "azure-ad", feature = "gcp-auth"))]
+fn body_mentions_permanent_oauth_error(body: &str) -> bool {
+    body_mentions_any(
+        body,
+        &[
+            "invalid_client",
+            "invalid_grant",
+            "unauthorized_client",
+            "invalid_scope",
+            "access_denied",
+            "permission_denied",
+        ],
+    )
+}
+
+#[cfg(any(feature = "azure-ad", feature = "gcp-auth"))]
+fn body_mentions_any(body: &str, needles: &[&str]) -> bool {
+    let body = body.to_ascii_lowercase();
+    needles.iter().any(|needle| body.contains(needle))
+}
+
+#[cfg(any(feature = "azure-ad", feature = "gcp-auth"))]
 fn epoch_secs(ts: DateTime<Utc>) -> u64 {
     ts.timestamp().max(0) as u64
 }

--- a/meerkat-auth-core/src/authorizers/mod.rs
+++ b/meerkat-auth-core/src/authorizers/mod.rs
@@ -32,6 +32,11 @@ pub(crate) struct LeaseFreshnessObserver {
 }
 
 #[cfg(any(feature = "azure-ad", feature = "gcp-auth"))]
+const AUTH_LEASE_REFRESH_WAIT_POLL_MS: u64 = 10;
+#[cfg(any(feature = "azure-ad", feature = "gcp-auth"))]
+const AUTH_LEASE_REFRESH_WAIT_TIMEOUT_SECS: u64 = 30;
+
+#[cfg(any(feature = "azure-ad", feature = "gcp-auth"))]
 impl LeaseFreshnessObserver {
     pub(crate) fn new(handle: Arc<dyn AuthLeaseHandle>, lease_key: LeaseKey) -> Self {
         Self { handle, lease_key }
@@ -70,23 +75,44 @@ impl LeaseFreshnessObserver {
         Ok(token_is_fresh_at(expires_at, now))
     }
 
-    pub(crate) fn begin_refresh(
+    pub(crate) async fn begin_refresh(
         &self,
         authorizer_label: &str,
     ) -> Result<LeaseRefreshLifecycle, AuthError> {
+        let deadline = tokio::time::Instant::now()
+            + std::time::Duration::from_secs(AUTH_LEASE_REFRESH_WAIT_TIMEOUT_SECS);
+        loop {
+            match self.try_begin_refresh(authorizer_label)? {
+                LeaseRefreshStart::Started(lifecycle) => return Ok(lifecycle),
+                LeaseRefreshStart::WaitForInFlight => {
+                    if tokio::time::Instant::now() >= deadline {
+                        return Err(AuthError::RefreshFailed(format!(
+                            "{authorizer_label} auth lease {} remained refreshing for {AUTH_LEASE_REFRESH_WAIT_TIMEOUT_SECS}s",
+                            self.lease_key
+                        )));
+                    }
+                    tokio::time::sleep(std::time::Duration::from_millis(
+                        AUTH_LEASE_REFRESH_WAIT_POLL_MS,
+                    ))
+                    .await;
+                }
+            }
+        }
+    }
+
+    fn try_begin_refresh(&self, authorizer_label: &str) -> Result<LeaseRefreshStart, AuthError> {
         match self.handle.snapshot(&self.lease_key).phase {
             Some(AuthLeasePhase::Valid | AuthLeasePhase::Expiring) => {
                 self.handle
                     .begin_refresh(&self.lease_key)
                     .map_err(|err| self.observer_error(authorizer_label, "begin_refresh", err))?;
-                Ok(LeaseRefreshLifecycle::Refresh)
+                Ok(LeaseRefreshStart::Started(LeaseRefreshLifecycle::Refresh))
             }
             Some(AuthLeasePhase::ReauthRequired) => Err(AuthError::Expired),
-            Some(AuthLeasePhase::Refreshing) => Err(AuthError::RefreshFailed(format!(
-                "{authorizer_label} auth lease {} is already refreshing",
-                self.lease_key
-            ))),
-            Some(AuthLeasePhase::Released) | None => Ok(LeaseRefreshLifecycle::InitialAcquire),
+            Some(AuthLeasePhase::Refreshing) => Ok(LeaseRefreshStart::WaitForInFlight),
+            Some(AuthLeasePhase::Released) | None => Ok(LeaseRefreshStart::Started(
+                LeaseRefreshLifecycle::InitialAcquire,
+            )),
         }
     }
 
@@ -147,6 +173,13 @@ impl LeaseFreshnessObserver {
 pub(crate) enum LeaseRefreshLifecycle {
     InitialAcquire,
     Refresh,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[cfg(any(feature = "azure-ad", feature = "gcp-auth"))]
+enum LeaseRefreshStart {
+    Started(LeaseRefreshLifecycle),
+    WaitForInFlight,
 }
 
 #[cfg(any(feature = "azure-ad", feature = "gcp-auth"))]

--- a/meerkat-auth-core/src/authorizers/mod.rs
+++ b/meerkat-auth-core/src/authorizers/mod.rs
@@ -9,9 +9,14 @@
 use std::sync::Arc;
 
 #[cfg(any(feature = "azure-ad", feature = "gcp-auth"))]
-use chrono::{DateTime, Utc};
+use chrono::{DateTime, Duration, Utc};
 #[cfg(any(feature = "azure-ad", feature = "gcp-auth"))]
-use meerkat_core::handles::{AuthLeaseHandle, LeaseKey};
+use meerkat_core::AuthError;
+#[cfg(any(feature = "azure-ad", feature = "gcp-auth"))]
+use meerkat_core::handles::{
+    AUTH_LEASE_TTL_REFRESH_WINDOW_SECS, AuthLeaseHandle, AuthLeasePhase, DslTransitionError,
+    LeaseKey,
+};
 
 /// Shared closure type for env-variable lookup. Used by authorizers that
 /// want to remain hermetic in tests by taking a closure rather than
@@ -32,18 +37,126 @@ impl LeaseFreshnessObserver {
         Self { handle, lease_key }
     }
 
-    pub(crate) fn observe_expires_at(&self, authorizer_label: &str, expires_at: DateTime<Utc>) {
-        let expires_at = expires_at.timestamp().max(0) as u64;
-        if let Err(err) = self.handle.acquire_lease(&self.lease_key, expires_at) {
+    pub(crate) fn cached_token_is_fresh(
+        &self,
+        authorizer_label: &str,
+        expires_at: DateTime<Utc>,
+        now: DateTime<Utc>,
+    ) -> Result<bool, AuthError> {
+        let snapshot = self.handle.snapshot(&self.lease_key);
+        match snapshot.phase {
+            Some(AuthLeasePhase::Valid) => {}
+            Some(AuthLeasePhase::ReauthRequired) => {
+                return Err(AuthError::Expired);
+            }
+            Some(
+                AuthLeasePhase::Expiring | AuthLeasePhase::Refreshing | AuthLeasePhase::Released,
+            )
+            | None => return Ok(false),
+        }
+
+        let expected_expires_at = epoch_secs(expires_at);
+        if snapshot.expires_at != Some(expected_expires_at) {
             tracing::warn!(
                 authorizer = %authorizer_label,
                 lease_key = %self.lease_key,
-                expires_at,
-                error = %err,
-                "failed to publish cloud authorizer freshness to auth lease truth"
+                cached_expires_at = expected_expires_at,
+                lease_expires_at = snapshot.expires_at,
+                "cloud authorizer cache disagrees with auth lease truth; refreshing"
             );
+            return Ok(false);
+        }
+
+        Ok(token_is_fresh_at(expires_at, now))
+    }
+
+    pub(crate) fn begin_refresh(
+        &self,
+        authorizer_label: &str,
+    ) -> Result<LeaseRefreshLifecycle, AuthError> {
+        match self.handle.snapshot(&self.lease_key).phase {
+            Some(AuthLeasePhase::Valid | AuthLeasePhase::Expiring) => {
+                self.handle
+                    .begin_refresh(&self.lease_key)
+                    .map_err(|err| self.observer_error(authorizer_label, "begin_refresh", err))?;
+                Ok(LeaseRefreshLifecycle::Refresh)
+            }
+            Some(AuthLeasePhase::ReauthRequired) => Err(AuthError::Expired),
+            Some(AuthLeasePhase::Refreshing) => Err(AuthError::RefreshFailed(format!(
+                "{authorizer_label} auth lease {} is already refreshing",
+                self.lease_key
+            ))),
+            Some(AuthLeasePhase::Released) | None => Ok(LeaseRefreshLifecycle::InitialAcquire),
         }
     }
+
+    pub(crate) fn complete_refresh(
+        &self,
+        authorizer_label: &str,
+        lifecycle: LeaseRefreshLifecycle,
+        expires_at: DateTime<Utc>,
+        now: DateTime<Utc>,
+    ) -> Result<(), AuthError> {
+        let expires_at = epoch_secs(expires_at);
+        match lifecycle {
+            LeaseRefreshLifecycle::InitialAcquire => {
+                self.handle
+                    .acquire_lease(&self.lease_key, expires_at)
+                    .map_err(|err| self.observer_error(authorizer_label, "acquire_lease", err))?;
+            }
+            LeaseRefreshLifecycle::Refresh => {
+                self.handle
+                    .complete_refresh(&self.lease_key, expires_at, epoch_secs(now))
+                    .map_err(|err| {
+                        self.observer_error(authorizer_label, "complete_refresh", err)
+                    })?;
+            }
+        }
+        Ok(())
+    }
+
+    pub(crate) fn refresh_failed(
+        &self,
+        authorizer_label: &str,
+        lifecycle: LeaseRefreshLifecycle,
+        permanent: bool,
+    ) -> Result<(), AuthError> {
+        if lifecycle == LeaseRefreshLifecycle::Refresh {
+            self.handle
+                .refresh_failed(&self.lease_key, permanent)
+                .map_err(|err| self.observer_error(authorizer_label, "refresh_failed", err))?;
+        }
+        Ok(())
+    }
+
+    fn observer_error(
+        &self,
+        authorizer_label: &str,
+        action: &'static str,
+        err: DslTransitionError,
+    ) -> AuthError {
+        AuthError::Other(format!(
+            "{authorizer_label} auth lease {action} failed for {}: {err}",
+            self.lease_key
+        ))
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[cfg(any(feature = "azure-ad", feature = "gcp-auth"))]
+pub(crate) enum LeaseRefreshLifecycle {
+    InitialAcquire,
+    Refresh,
+}
+
+#[cfg(any(feature = "azure-ad", feature = "gcp-auth"))]
+pub(crate) fn token_is_fresh_at(expires_at: DateTime<Utc>, now: DateTime<Utc>) -> bool {
+    expires_at - now > Duration::seconds(AUTH_LEASE_TTL_REFRESH_WINDOW_SECS as i64)
+}
+
+#[cfg(any(feature = "azure-ad", feature = "gcp-auth"))]
+fn epoch_secs(ts: DateTime<Utc>) -> u64 {
+    ts.timestamp().max(0) as u64
 }
 
 #[cfg(feature = "aws-sigv4")]

--- a/meerkat-auth-core/tests/azure_ad_authorizer.rs
+++ b/meerkat-auth-core/tests/azure_ad_authorizer.rs
@@ -22,6 +22,7 @@ use axum::routing::post;
 use chrono::Utc;
 use serde::Deserialize;
 use tokio::net::TcpListener;
+use tokio::time::{Duration as TokioDuration, sleep, timeout};
 
 use meerkat_auth_core::authorizers::{AzureAdAuthorizer, AzureClientCredentials};
 use meerkat_core::handles::{
@@ -42,27 +43,43 @@ struct MockState {
     counter: Arc<AtomicUsize>,
     captured: Arc<std::sync::Mutex<Vec<TokenForm>>>,
     token_value: String,
-    expires_in: u64,
-    fail_from_call: Option<usize>,
+    expires_in_by_call: Vec<u64>,
+    failure: Option<MockFailure>,
+    delay_from_call: Option<usize>,
+    delay: TokioDuration,
+}
+
+#[derive(Clone)]
+struct MockFailure {
+    from_call: usize,
+    status: axum::http::StatusCode,
+    body: serde_json::Value,
 }
 
 async fn token_handler(State(state): State<MockState>, Form(form): Form<TokenForm>) -> Response {
     let call = state.counter.fetch_add(1, Ordering::SeqCst) + 1;
     state.captured.lock().unwrap().push(form);
     if state
-        .fail_from_call
-        .is_some_and(|fail_from_call| call >= fail_from_call)
+        .delay_from_call
+        .is_some_and(|delay_from_call| call >= delay_from_call)
     {
-        return (
-            axum::http::StatusCode::UNAUTHORIZED,
-            Json(serde_json::json!({"error": "invalid_client"})),
-        )
-            .into_response();
+        sleep(state.delay).await;
     }
+    if let Some(failure) = &state.failure {
+        if call >= failure.from_call {
+            return (failure.status, Json(failure.body.clone())).into_response();
+        }
+    }
+    let expires_in = state
+        .expires_in_by_call
+        .get(call.saturating_sub(1))
+        .or_else(|| state.expires_in_by_call.last())
+        .copied()
+        .unwrap_or(3600);
     Json(serde_json::json!({
         "access_token": state.token_value,
         "token_type": "Bearer",
-        "expires_in": state.expires_in,
+        "expires_in": expires_in,
     }))
     .into_response()
 }
@@ -244,7 +261,7 @@ impl AuthLeaseHandle for RecordingAuthLeaseHandle {
 }
 
 async fn start_mock(token_value: &str, expires_in: u64) -> MockServer {
-    start_mock_with_failure(token_value, expires_in, None).await
+    start_mock_with_config(token_value, vec![expires_in], None, None).await
 }
 
 async fn start_mock_with_failure(
@@ -252,14 +269,30 @@ async fn start_mock_with_failure(
     expires_in: u64,
     fail_from_call: Option<usize>,
 ) -> MockServer {
+    let failure = fail_from_call.map(|from_call| MockFailure {
+        from_call,
+        status: axum::http::StatusCode::UNAUTHORIZED,
+        body: serde_json::json!({"error": "invalid_client"}),
+    });
+    start_mock_with_config(token_value, vec![expires_in], failure, None).await
+}
+
+async fn start_mock_with_config(
+    token_value: &str,
+    expires_in_by_call: Vec<u64>,
+    failure: Option<MockFailure>,
+    delay_from_call: Option<usize>,
+) -> MockServer {
     let counter = Arc::new(AtomicUsize::new(0));
     let captured = Arc::new(std::sync::Mutex::new(Vec::new()));
     let state = MockState {
         counter: counter.clone(),
         captured: captured.clone(),
         token_value: token_value.into(),
-        expires_in,
-        fail_from_call,
+        expires_in_by_call,
+        failure,
+        delay_from_call,
+        delay: TokioDuration::from_millis(150),
     };
     let app = Router::new()
         .route("/tenant-id/oauth2/v2.0/token", post(token_handler))
@@ -561,6 +594,154 @@ async fn refresh_failure_is_visible_on_auth_lease_snapshot() {
         snapshot.phase,
         Some(AuthLeasePhase::ReauthRequired),
         "failed cloud token refresh must leave a visible AuthMachine failure state"
+    );
+    assert!(
+        handle
+            .events()
+            .iter()
+            .any(|event| matches!(event, LeaseEvent::RefreshFailed(_, true))),
+        "invalid Azure client refresh failure should be marked permanent"
+    );
+}
+
+#[tokio::test]
+async fn transient_token_endpoint_failure_keeps_auth_lease_retryable() {
+    let mock = start_mock_with_config(
+        "expires-before-transient-refresh",
+        vec![30],
+        Some(MockFailure {
+            from_call: 2,
+            status: axum::http::StatusCode::SERVICE_UNAVAILABLE,
+            body: serde_json::json!({"error": "temporarily_unavailable"}),
+        }),
+        None,
+    )
+    .await;
+    let handle = Arc::new(RecordingAuthLeaseHandle::default());
+    let lease_key = LeaseKey::new(
+        RealmId::parse("dev").unwrap(),
+        BindingId::parse("azure_foundry").unwrap(),
+        Some(ProfileId::parse("foundry_azure_ad").unwrap()),
+    );
+    let lease_handle: Arc<dyn AuthLeaseHandle> = handle.clone();
+    let authorizer = AzureAdAuthorizer::new(
+        "https://cognitiveservices.azure.com/.default",
+        creds(&mock.base_url),
+    )
+    .with_auth_lease_observer(lease_handle, lease_key.clone())
+    .with_token_url_override(format!("{}/tenant-id/oauth2/v2.0/token", mock.base_url));
+
+    let mut headers = Vec::new();
+    let mut req = HttpAuthorizationRequest {
+        method: "POST",
+        url: "https://example.foundry.azure.com/v1/messages",
+        headers: &mut headers,
+    };
+    authorizer.authorize(&mut req).await.unwrap();
+
+    let mut headers = Vec::new();
+    let mut req = HttpAuthorizationRequest {
+        method: "POST",
+        url: "https://example.foundry.azure.com/v1/messages",
+        headers: &mut headers,
+    };
+    let err = authorizer.authorize(&mut req).await.unwrap_err();
+    assert!(
+        matches!(err, meerkat_core::AuthError::RefreshFailed(_)),
+        "token endpoint outage should still fail the caller visibly, got {err:?}"
+    );
+
+    let snapshot = handle.snapshot(&lease_key);
+    assert_eq!(
+        snapshot.phase,
+        Some(AuthLeasePhase::Expiring),
+        "transient Azure endpoint failure must remain retryable in AuthMachine"
+    );
+    assert!(
+        handle
+            .events()
+            .iter()
+            .any(|event| matches!(event, LeaseEvent::RefreshFailed(_, false))),
+        "transient Azure endpoint failure should not force reauth"
+    );
+}
+
+#[tokio::test]
+async fn concurrent_refresh_observers_wait_for_inflight_refresh() {
+    let mock =
+        start_mock_with_config("concurrent-refresh-token", vec![30, 3600], None, Some(2)).await;
+    let handle = Arc::new(RecordingAuthLeaseHandle::default());
+    let lease_key = LeaseKey::new(
+        RealmId::parse("dev").unwrap(),
+        BindingId::parse("azure_foundry").unwrap(),
+        Some(ProfileId::parse("foundry_azure_ad").unwrap()),
+    );
+    let lease_handle: Arc<dyn AuthLeaseHandle> = handle.clone();
+    let authorizer = Arc::new(
+        AzureAdAuthorizer::new(
+            "https://cognitiveservices.azure.com/.default",
+            creds(&mock.base_url),
+        )
+        .with_auth_lease_observer(lease_handle, lease_key)
+        .with_token_url_override(format!("{}/tenant-id/oauth2/v2.0/token", mock.base_url)),
+    );
+
+    let mut headers = Vec::new();
+    let mut req = HttpAuthorizationRequest {
+        method: "POST",
+        url: "https://example.foundry.azure.com/v1/messages",
+        headers: &mut headers,
+    };
+    authorizer.authorize(&mut req).await.unwrap();
+
+    let first = {
+        let authorizer = authorizer.clone();
+        tokio::spawn(async move {
+            let mut headers = Vec::new();
+            let mut req = HttpAuthorizationRequest {
+                method: "POST",
+                url: "https://example.foundry.azure.com/v1/messages",
+                headers: &mut headers,
+            };
+            authorizer.authorize(&mut req).await
+        })
+    };
+
+    timeout(TokioDuration::from_secs(1), async {
+        loop {
+            if handle
+                .events()
+                .iter()
+                .any(|event| matches!(event, LeaseEvent::BeginRefresh(_)))
+            {
+                break;
+            }
+            sleep(TokioDuration::from_millis(5)).await;
+        }
+    })
+    .await
+    .expect("first task should enter the refresh lease window");
+
+    let second = {
+        let authorizer = authorizer.clone();
+        tokio::spawn(async move {
+            let mut headers = Vec::new();
+            let mut req = HttpAuthorizationRequest {
+                method: "POST",
+                url: "https://example.foundry.azure.com/v1/messages",
+                headers: &mut headers,
+            };
+            authorizer.authorize(&mut req).await
+        })
+    };
+
+    let (first, second) = tokio::join!(first, second);
+    first.unwrap().unwrap();
+    second.unwrap().unwrap();
+    assert_eq!(
+        mock.counter.load(Ordering::SeqCst),
+        2,
+        "concurrent observer should wait for the in-flight refresh instead of starting another"
     );
 }
 

--- a/meerkat-auth-core/tests/azure_ad_authorizer.rs
+++ b/meerkat-auth-core/tests/azure_ad_authorizer.rs
@@ -746,6 +746,97 @@ async fn concurrent_refresh_observers_wait_for_inflight_refresh() {
 }
 
 #[tokio::test]
+async fn separate_authorizers_wait_when_shared_lease_is_refreshing() {
+    let mock =
+        start_mock_with_config("shared-lease-refresh-token", vec![30, 3600], None, Some(2)).await;
+    let handle = Arc::new(RecordingAuthLeaseHandle::default());
+    let lease_key = LeaseKey::new(
+        RealmId::parse("dev").unwrap(),
+        BindingId::parse("azure_foundry").unwrap(),
+        Some(ProfileId::parse("foundry_azure_ad").unwrap()),
+    );
+    let lease_handle_a: Arc<dyn AuthLeaseHandle> = handle.clone();
+    let lease_handle_b: Arc<dyn AuthLeaseHandle> = handle.clone();
+    let token_url = format!("{}/tenant-id/oauth2/v2.0/token", mock.base_url);
+    let authorizer_a = Arc::new(
+        AzureAdAuthorizer::new(
+            "https://cognitiveservices.azure.com/.default",
+            creds(&mock.base_url),
+        )
+        .with_auth_lease_observer(lease_handle_a, lease_key.clone())
+        .with_token_url_override(token_url.clone()),
+    );
+    let authorizer_b = Arc::new(
+        AzureAdAuthorizer::new(
+            "https://cognitiveservices.azure.com/.default",
+            creds(&mock.base_url),
+        )
+        .with_auth_lease_observer(lease_handle_b, lease_key)
+        .with_token_url_override(token_url),
+    );
+
+    let mut headers = Vec::new();
+    let mut req = HttpAuthorizationRequest {
+        method: "POST",
+        url: "https://example.foundry.azure.com/v1/messages",
+        headers: &mut headers,
+    };
+    authorizer_a.authorize(&mut req).await.unwrap();
+
+    let first = {
+        let authorizer = authorizer_a.clone();
+        tokio::spawn(async move {
+            let mut headers = Vec::new();
+            let mut req = HttpAuthorizationRequest {
+                method: "POST",
+                url: "https://example.foundry.azure.com/v1/messages",
+                headers: &mut headers,
+            };
+            authorizer.authorize(&mut req).await
+        })
+    };
+
+    timeout(TokioDuration::from_secs(1), async {
+        loop {
+            if handle
+                .events()
+                .iter()
+                .any(|event| matches!(event, LeaseEvent::BeginRefresh(_)))
+            {
+                break;
+            }
+            sleep(TokioDuration::from_millis(5)).await;
+        }
+    })
+    .await
+    .expect("first authorizer should enter the shared refresh lease window");
+
+    let second = {
+        let authorizer = authorizer_b.clone();
+        tokio::spawn(async move {
+            let mut headers = Vec::new();
+            let mut req = HttpAuthorizationRequest {
+                method: "POST",
+                url: "https://example.foundry.azure.com/v1/messages",
+                headers: &mut headers,
+            };
+            authorizer.authorize(&mut req).await
+        })
+    };
+
+    let (first, second) = tokio::join!(first, second);
+    first.unwrap().unwrap();
+    second
+        .unwrap()
+        .expect("shared lease Refreshing must not fail a separate authorizer");
+    assert_eq!(
+        mock.counter.load(Ordering::SeqCst),
+        3,
+        "second authorizer has no private cache, but must wait for lease truth before refreshing"
+    );
+}
+
+#[tokio::test]
 async fn from_env_reads_azure_credentials() {
     let c = AzureClientCredentials::from_env(|k| match k {
         "AZURE_TENANT_ID" => Some("env-tenant".into()),

--- a/meerkat-auth-core/tests/azure_ad_authorizer.rs
+++ b/meerkat-auth-core/tests/azure_ad_authorizer.rs
@@ -17,14 +17,16 @@ use std::sync::{Arc, Mutex};
 
 use axum::Router;
 use axum::extract::{Form, State};
-use axum::response::Json;
+use axum::response::{IntoResponse, Json, Response};
 use axum::routing::post;
 use chrono::Utc;
 use serde::Deserialize;
 use tokio::net::TcpListener;
 
 use meerkat_auth_core::authorizers::{AzureAdAuthorizer, AzureClientCredentials};
-use meerkat_core::handles::{AuthLeaseHandle, AuthLeaseSnapshot, DslTransitionError, LeaseKey};
+use meerkat_core::handles::{
+    AuthLeaseHandle, AuthLeasePhase, AuthLeaseSnapshot, DslTransitionError, LeaseKey,
+};
 use meerkat_core::{BindingId, HttpAuthorizationRequest, HttpAuthorizer, ProfileId, RealmId};
 
 #[derive(Deserialize, Clone)]
@@ -41,19 +43,28 @@ struct MockState {
     captured: Arc<std::sync::Mutex<Vec<TokenForm>>>,
     token_value: String,
     expires_in: u64,
+    fail_from_call: Option<usize>,
 }
 
-async fn token_handler(
-    State(state): State<MockState>,
-    Form(form): Form<TokenForm>,
-) -> Json<serde_json::Value> {
-    state.counter.fetch_add(1, Ordering::SeqCst);
+async fn token_handler(State(state): State<MockState>, Form(form): Form<TokenForm>) -> Response {
+    let call = state.counter.fetch_add(1, Ordering::SeqCst) + 1;
     state.captured.lock().unwrap().push(form);
+    if state
+        .fail_from_call
+        .is_some_and(|fail_from_call| call >= fail_from_call)
+    {
+        return (
+            axum::http::StatusCode::UNAUTHORIZED,
+            Json(serde_json::json!({"error": "invalid_client"})),
+        )
+            .into_response();
+    }
     Json(serde_json::json!({
         "access_token": state.token_value,
         "token_type": "Bearer",
         "expires_in": state.expires_in,
     }))
+    .into_response()
 }
 
 struct MockServer {
@@ -62,9 +73,68 @@ struct MockServer {
     captured: Arc<std::sync::Mutex<Vec<TokenForm>>>,
 }
 
-#[derive(Default)]
+#[derive(Debug, Clone, PartialEq, Eq)]
+enum LeaseEvent {
+    Snapshot,
+    Acquire(LeaseKey, u64),
+    BeginRefresh(LeaseKey),
+    CompleteRefresh(LeaseKey, u64),
+    RefreshFailed(LeaseKey, bool),
+    MarkExpiring(LeaseKey),
+    MarkReauthRequired(LeaseKey),
+    Release(LeaseKey),
+}
+
 struct RecordingAuthLeaseHandle {
-    acquired: Mutex<Vec<(LeaseKey, u64)>>,
+    events: Mutex<Vec<LeaseEvent>>,
+    snapshot: Mutex<AuthLeaseSnapshot>,
+    fail_action: Mutex<Option<&'static str>>,
+}
+
+impl Default for RecordingAuthLeaseHandle {
+    fn default() -> Self {
+        Self {
+            events: Mutex::new(Vec::new()),
+            snapshot: Mutex::new(AuthLeaseSnapshot {
+                phase: None,
+                expires_at: None,
+            }),
+            fail_action: Mutex::new(None),
+        }
+    }
+}
+
+impl RecordingAuthLeaseHandle {
+    fn fail_on(action: &'static str) -> Self {
+        Self {
+            fail_action: Mutex::new(Some(action)),
+            ..Self::default()
+        }
+    }
+
+    fn events(&self) -> Vec<LeaseEvent> {
+        self.events.lock().unwrap().clone()
+    }
+
+    fn acquired(&self) -> Vec<(LeaseKey, u64)> {
+        self.events()
+            .into_iter()
+            .filter_map(|event| match event {
+                LeaseEvent::Acquire(lease_key, expires_at) => Some((lease_key, expires_at)),
+                _ => None,
+            })
+            .collect()
+    }
+
+    fn maybe_fail(&self, action: &'static str) -> Result<(), DslTransitionError> {
+        if self.fail_action.lock().unwrap().as_deref() == Some(action) {
+            return Err(DslTransitionError::new(
+                action,
+                "injected auth lease observer failure",
+            ));
+        }
+        Ok(())
+    }
 }
 
 impl AuthLeaseHandle for RecordingAuthLeaseHandle {
@@ -73,55 +143,115 @@ impl AuthLeaseHandle for RecordingAuthLeaseHandle {
         lease_key: &LeaseKey,
         expires_at: u64,
     ) -> Result<(), DslTransitionError> {
-        self.acquired
+        self.maybe_fail("acquire_lease")?;
+        self.events
             .lock()
             .unwrap()
-            .push((lease_key.clone(), expires_at));
+            .push(LeaseEvent::Acquire(lease_key.clone(), expires_at));
+        *self.snapshot.lock().unwrap() = AuthLeaseSnapshot {
+            phase: Some(AuthLeasePhase::Valid),
+            expires_at: Some(expires_at),
+        };
         Ok(())
     }
 
-    fn mark_expiring(&self, _lease_key: &LeaseKey) -> Result<(), DslTransitionError> {
+    fn mark_expiring(&self, lease_key: &LeaseKey) -> Result<(), DslTransitionError> {
+        self.maybe_fail("mark_expiring")?;
+        self.events
+            .lock()
+            .unwrap()
+            .push(LeaseEvent::MarkExpiring(lease_key.clone()));
+        self.snapshot.lock().unwrap().phase = Some(AuthLeasePhase::Expiring);
         Ok(())
     }
 
-    fn begin_refresh(&self, _lease_key: &LeaseKey) -> Result<(), DslTransitionError> {
+    fn begin_refresh(&self, lease_key: &LeaseKey) -> Result<(), DslTransitionError> {
+        self.maybe_fail("begin_refresh")?;
+        self.events
+            .lock()
+            .unwrap()
+            .push(LeaseEvent::BeginRefresh(lease_key.clone()));
+        self.snapshot.lock().unwrap().phase = Some(AuthLeasePhase::Refreshing);
         Ok(())
     }
 
     fn complete_refresh(
         &self,
-        _lease_key: &LeaseKey,
-        _new_expires_at: u64,
+        lease_key: &LeaseKey,
+        new_expires_at: u64,
         _now: u64,
     ) -> Result<(), DslTransitionError> {
+        self.maybe_fail("complete_refresh")?;
+        self.events
+            .lock()
+            .unwrap()
+            .push(LeaseEvent::CompleteRefresh(
+                lease_key.clone(),
+                new_expires_at,
+            ));
+        *self.snapshot.lock().unwrap() = AuthLeaseSnapshot {
+            phase: Some(AuthLeasePhase::Valid),
+            expires_at: Some(new_expires_at),
+        };
         Ok(())
     }
 
     fn refresh_failed(
         &self,
-        _lease_key: &LeaseKey,
-        _permanent: bool,
+        lease_key: &LeaseKey,
+        permanent: bool,
     ) -> Result<(), DslTransitionError> {
+        self.maybe_fail("refresh_failed")?;
+        self.events
+            .lock()
+            .unwrap()
+            .push(LeaseEvent::RefreshFailed(lease_key.clone(), permanent));
+        self.snapshot.lock().unwrap().phase = Some(if permanent {
+            AuthLeasePhase::ReauthRequired
+        } else {
+            AuthLeasePhase::Expiring
+        });
         Ok(())
     }
 
-    fn mark_reauth_required(&self, _lease_key: &LeaseKey) -> Result<(), DslTransitionError> {
+    fn mark_reauth_required(&self, lease_key: &LeaseKey) -> Result<(), DslTransitionError> {
+        self.maybe_fail("mark_reauth_required")?;
+        self.events
+            .lock()
+            .unwrap()
+            .push(LeaseEvent::MarkReauthRequired(lease_key.clone()));
+        self.snapshot.lock().unwrap().phase = Some(AuthLeasePhase::ReauthRequired);
         Ok(())
     }
 
-    fn release_lease(&self, _lease_key: &LeaseKey) -> Result<(), DslTransitionError> {
+    fn release_lease(&self, lease_key: &LeaseKey) -> Result<(), DslTransitionError> {
+        self.maybe_fail("release_lease")?;
+        self.events
+            .lock()
+            .unwrap()
+            .push(LeaseEvent::Release(lease_key.clone()));
+        *self.snapshot.lock().unwrap() = AuthLeaseSnapshot {
+            phase: None,
+            expires_at: None,
+        };
         Ok(())
     }
 
     fn snapshot(&self, _lease_key: &LeaseKey) -> AuthLeaseSnapshot {
-        AuthLeaseSnapshot {
-            phase: None,
-            expires_at: None,
-        }
+        self.events.lock().unwrap().push(LeaseEvent::Snapshot);
+        self.snapshot.lock().unwrap().clone()
     }
 }
 
 async fn start_mock(token_value: &str, expires_in: u64) -> MockServer {
+    start_mock_with_failure(token_value, expires_in, None).await
+}
+
+async fn start_mock_with_failure(
+    token_value: &str,
+    expires_in: u64,
+    fail_from_call: Option<usize>,
+) -> MockServer {
     let counter = Arc::new(AtomicUsize::new(0));
     let captured = Arc::new(std::sync::Mutex::new(Vec::new()));
     let state = MockState {
@@ -129,6 +259,7 @@ async fn start_mock(token_value: &str, expires_in: u64) -> MockServer {
         captured: captured.clone(),
         token_value: token_value.into(),
         expires_in,
+        fail_from_call,
     };
     let app = Router::new()
         .route("/tenant-id/oauth2/v2.0/token", post(token_handler))
@@ -279,7 +410,7 @@ async fn authorize_publishes_token_expiry_to_auth_lease_handle() {
         authorizer.authorize(&mut req).await.unwrap();
     }
 
-    let acquired = handle.acquired.lock().unwrap();
+    let acquired = handle.acquired();
     assert_eq!(
         mock.counter.load(Ordering::SeqCst),
         1,
@@ -287,18 +418,149 @@ async fn authorize_publishes_token_expiry_to_auth_lease_handle() {
     );
     assert_eq!(
         acquired.len(),
-        2,
-        "cached token use must still publish auth-machine lease freshness"
+        1,
+        "cached token freshness must be observed through auth-machine snapshot truth"
     );
     assert_eq!(acquired[0].0, lease_key);
-    assert_eq!(acquired[1].0, lease_key);
+    let events = handle.events();
+    assert!(
+        events
+            .iter()
+            .any(|event| matches!(event, LeaseEvent::Snapshot)),
+        "cached token reuse must check auth-machine lease truth"
+    );
     assert!(
         acquired[0].1 > Utc::now().timestamp().max(0) as u64,
         "published auth-machine expiry must reflect the fetched token"
     );
+}
+
+#[tokio::test]
+async fn observer_failure_fails_closed_without_authorization_header() {
+    let mock = start_mock("lease-observer-fails", 3600).await;
+    let handle = Arc::new(RecordingAuthLeaseHandle::fail_on("acquire_lease"));
+    let lease_key = LeaseKey::new(
+        RealmId::parse("dev").unwrap(),
+        BindingId::parse("azure_foundry").unwrap(),
+        Some(ProfileId::parse("foundry_azure_ad").unwrap()),
+    );
+    let lease_handle: Arc<dyn AuthLeaseHandle> = handle;
+    let authorizer = AzureAdAuthorizer::new(
+        "https://cognitiveservices.azure.com/.default",
+        creds(&mock.base_url),
+    )
+    .with_auth_lease_observer(lease_handle, lease_key)
+    .with_token_url_override(format!("{}/tenant-id/oauth2/v2.0/token", mock.base_url));
+
+    let mut headers = Vec::new();
+    let mut req = HttpAuthorizationRequest {
+        method: "POST",
+        url: "https://example.foundry.azure.com/v1/messages",
+        headers: &mut headers,
+    };
+    let err = authorizer.authorize(&mut req).await.unwrap_err();
+
+    assert!(
+        matches!(err, meerkat_core::AuthError::Other(_)),
+        "auth lease publication failure must be visible, got {err:?}"
+    );
+    assert!(
+        headers
+            .iter()
+            .all(|(name, _)| !name.eq_ignore_ascii_case("authorization")),
+        "authorizer must not attach a bearer token when lease truth rejected publication"
+    );
+}
+
+#[tokio::test]
+async fn short_lived_token_refresh_uses_auth_lease_lifecycle() {
+    let mock = start_mock("short-lived-lease-token", 30).await;
+    let handle = Arc::new(RecordingAuthLeaseHandle::default());
+    let lease_key = LeaseKey::new(
+        RealmId::parse("dev").unwrap(),
+        BindingId::parse("azure_foundry").unwrap(),
+        Some(ProfileId::parse("foundry_azure_ad").unwrap()),
+    );
+    let lease_handle: Arc<dyn AuthLeaseHandle> = handle.clone();
+    let authorizer = AzureAdAuthorizer::new(
+        "https://cognitiveservices.azure.com/.default",
+        creds(&mock.base_url),
+    )
+    .with_auth_lease_observer(lease_handle, lease_key)
+    .with_token_url_override(format!("{}/tenant-id/oauth2/v2.0/token", mock.base_url));
+
+    for _ in 0..2 {
+        let mut headers = Vec::new();
+        let mut req = HttpAuthorizationRequest {
+            method: "POST",
+            url: "https://example.foundry.azure.com/v1/messages",
+            headers: &mut headers,
+        };
+        authorizer.authorize(&mut req).await.unwrap();
+    }
+
+    let events = handle.events();
+    assert!(
+        events
+            .iter()
+            .any(|event| matches!(event, LeaseEvent::BeginRefresh(_))),
+        "refresh start must be published to AuthMachine"
+    );
+    assert!(
+        events
+            .iter()
+            .any(|event| matches!(event, LeaseEvent::CompleteRefresh(_, _))),
+        "refresh success must complete through AuthMachine"
+    );
     assert_eq!(
-        acquired[0].1, acquired[1].1,
-        "cached token lease observation should carry the same expiry"
+        handle.acquired().len(),
+        1,
+        "post-acquire refreshes must use begin/complete instead of repeated acquire"
+    );
+}
+
+#[tokio::test]
+async fn refresh_failure_is_visible_on_auth_lease_snapshot() {
+    let mock = start_mock_with_failure("expires-before-refresh", 30, Some(2)).await;
+    let handle = Arc::new(RecordingAuthLeaseHandle::default());
+    let lease_key = LeaseKey::new(
+        RealmId::parse("dev").unwrap(),
+        BindingId::parse("azure_foundry").unwrap(),
+        Some(ProfileId::parse("foundry_azure_ad").unwrap()),
+    );
+    let lease_handle: Arc<dyn AuthLeaseHandle> = handle.clone();
+    let authorizer = AzureAdAuthorizer::new(
+        "https://cognitiveservices.azure.com/.default",
+        creds(&mock.base_url),
+    )
+    .with_auth_lease_observer(lease_handle, lease_key.clone())
+    .with_token_url_override(format!("{}/tenant-id/oauth2/v2.0/token", mock.base_url));
+
+    let mut headers = Vec::new();
+    let mut req = HttpAuthorizationRequest {
+        method: "POST",
+        url: "https://example.foundry.azure.com/v1/messages",
+        headers: &mut headers,
+    };
+    authorizer.authorize(&mut req).await.unwrap();
+
+    let mut headers = Vec::new();
+    let mut req = HttpAuthorizationRequest {
+        method: "POST",
+        url: "https://example.foundry.azure.com/v1/messages",
+        headers: &mut headers,
+    };
+    let err = authorizer.authorize(&mut req).await.unwrap_err();
+    assert!(
+        matches!(err, meerkat_core::AuthError::RefreshFailed(_)),
+        "token endpoint failure should still surface as refresh failure, got {err:?}"
+    );
+
+    let snapshot = handle.snapshot(&lease_key);
+    assert_eq!(
+        snapshot.phase,
+        Some(AuthLeasePhase::ReauthRequired),
+        "failed cloud token refresh must leave a visible AuthMachine failure state"
     );
 }
 

--- a/meerkat-auth-core/tests/google_auth_authorizer.rs
+++ b/meerkat-auth-core/tests/google_auth_authorizer.rs
@@ -836,6 +836,71 @@ async fn metadata_endpoint_transient_failure_keeps_auth_lease_retryable() {
     );
 }
 
+#[tokio::test]
+async fn default_chain_metadata_transient_failure_keeps_auth_lease_retryable() {
+    let mock = start_mock_with_config(
+        "default-metadata-transient-token",
+        vec![30],
+        Some(MockFailure {
+            from_call: 2,
+            status: axum::http::StatusCode::SERVICE_UNAVAILABLE,
+            body: serde_json::json!({"error": "temporarily_unavailable"}),
+        }),
+    )
+    .await;
+    let tempdir = tempfile::tempdir().unwrap();
+    let env_lookup =
+        Arc::new(|_: &str| None::<String>) as Arc<dyn Fn(&str) -> Option<String> + Send + Sync>;
+    let handle = Arc::new(RecordingAuthLeaseHandle::default());
+    let lease_key = LeaseKey::new(
+        RealmId::parse("dev").unwrap(),
+        BindingId::parse("gemini").unwrap(),
+        Some(ProfileId::parse("google_default_metadata").unwrap()),
+    );
+    let lease_handle: Arc<dyn AuthLeaseHandle> = handle.clone();
+    let authorizer = GoogleAuthAuthorizer::with_env_lookup(GoogleAuthChain::Default, env_lookup)
+        .with_home_dir(tempdir.path())
+        .with_auth_lease_observer(lease_handle, lease_key.clone())
+        .with_metadata_url_override(format!(
+            "{}/computeMetadata/v1/instance/service-accounts/default/token",
+            mock.base_url
+        ));
+
+    let mut headers = Vec::new();
+    let mut req = HttpAuthorizationRequest {
+        method: "POST",
+        url: "https://generativelanguage.googleapis.com/v1/models",
+        headers: &mut headers,
+    };
+    authorizer.authorize(&mut req).await.unwrap();
+
+    let mut headers = Vec::new();
+    let mut req = HttpAuthorizationRequest {
+        method: "POST",
+        url: "https://generativelanguage.googleapis.com/v1/models",
+        headers: &mut headers,
+    };
+    let err = authorizer.authorize(&mut req).await.unwrap_err();
+    assert!(
+        matches!(err, meerkat_core::AuthError::RefreshFailed(_)),
+        "metadata outage should still fail the caller visibly, got {err:?}"
+    );
+
+    let snapshot = handle.snapshot(&lease_key);
+    assert_eq!(
+        snapshot.phase,
+        Some(AuthLeasePhase::Expiring),
+        "Default ADC metadata transient failure must remain retryable in AuthMachine"
+    );
+    assert!(
+        handle
+            .events()
+            .iter()
+            .any(|event| matches!(event, LeaseEvent::RefreshFailed(_, false))),
+        "Default ADC metadata transient failure should not force reauth"
+    );
+}
+
 // --- Error propagation ------------------------------------------------
 
 #[tokio::test]

--- a/meerkat-auth-core/tests/google_auth_authorizer.rs
+++ b/meerkat-auth-core/tests/google_auth_authorizer.rs
@@ -22,7 +22,7 @@ use std::sync::{Arc, Mutex};
 
 use axum::Router;
 use axum::extract::{Form, State};
-use axum::response::{IntoResponse, Json};
+use axum::response::{IntoResponse, Json, Response};
 use axum::routing::{get, post};
 use chrono::Utc;
 use serde::Deserialize;
@@ -55,36 +55,65 @@ struct MockState {
     counter: Arc<AtomicUsize>,
     captured: Arc<Mutex<Vec<OAuthForm>>>,
     token_value: String,
-    expires_in: u64,
+    expires_in_by_call: Vec<u64>,
+    failure: Option<MockFailure>,
 }
 
-async fn token_endpoint(
-    State(state): State<MockState>,
-    Form(form): Form<OAuthForm>,
-) -> Json<serde_json::Value> {
-    state.counter.fetch_add(1, Ordering::SeqCst);
+#[derive(Clone)]
+struct MockFailure {
+    from_call: usize,
+    status: axum::http::StatusCode,
+    body: serde_json::Value,
+}
+
+async fn token_endpoint(State(state): State<MockState>, Form(form): Form<OAuthForm>) -> Response {
+    let call = state.counter.fetch_add(1, Ordering::SeqCst) + 1;
     state.captured.lock().unwrap().push(form);
+    if let Some(failure) = &state.failure {
+        if call >= failure.from_call {
+            return (failure.status, Json(failure.body.clone())).into_response();
+        }
+    }
+    let expires_in = state
+        .expires_in_by_call
+        .get(call.saturating_sub(1))
+        .or_else(|| state.expires_in_by_call.last())
+        .copied()
+        .unwrap_or(3600);
     Json(serde_json::json!({
         "access_token": state.token_value,
         "token_type": "Bearer",
-        "expires_in": state.expires_in,
+        "expires_in": expires_in,
     }))
+    .into_response()
 }
 
 async fn metadata_endpoint(
     State(state): State<MockState>,
     headers: axum::http::HeaderMap,
-) -> Result<Json<serde_json::Value>, axum::http::StatusCode> {
+) -> Response {
     // GCE metadata server requires Metadata-Flavor: Google header.
     if headers.get("metadata-flavor").and_then(|v| v.to_str().ok()) != Some("Google") {
-        return Err(axum::http::StatusCode::FORBIDDEN);
+        return axum::http::StatusCode::FORBIDDEN.into_response();
     }
-    state.counter.fetch_add(1, Ordering::SeqCst);
-    Ok(Json(serde_json::json!({
+    let call = state.counter.fetch_add(1, Ordering::SeqCst) + 1;
+    if let Some(failure) = &state.failure {
+        if call >= failure.from_call {
+            return (failure.status, Json(failure.body.clone())).into_response();
+        }
+    }
+    let expires_in = state
+        .expires_in_by_call
+        .get(call.saturating_sub(1))
+        .or_else(|| state.expires_in_by_call.last())
+        .copied()
+        .unwrap_or(3600);
+    Json(serde_json::json!({
         "access_token": state.token_value,
         "token_type": "Bearer",
-        "expires_in": state.expires_in,
-    })))
+        "expires_in": expires_in,
+    }))
+    .into_response()
 }
 
 struct MockServer {
@@ -268,13 +297,22 @@ async fn start_mock(token_value: &str) -> MockServer {
 }
 
 async fn start_mock_with_expiry(token_value: &str, expires_in: u64) -> MockServer {
+    start_mock_with_config(token_value, vec![expires_in], None).await
+}
+
+async fn start_mock_with_config(
+    token_value: &str,
+    expires_in_by_call: Vec<u64>,
+    failure: Option<MockFailure>,
+) -> MockServer {
     let counter = Arc::new(AtomicUsize::new(0));
     let captured = Arc::new(Mutex::new(Vec::new()));
     let state = MockState {
         counter: counter.clone(),
         captured: captured.clone(),
         token_value: token_value.into(),
-        expires_in,
+        expires_in_by_call,
+        failure,
     };
     let app = Router::new()
         .route("/token", post(token_endpoint))
@@ -660,6 +698,141 @@ async fn short_lived_token_expiry_is_observable_and_refetched() {
         mock.counter.load(Ordering::SeqCst),
         2,
         "token inside the canonical refresh window must be refetched"
+    );
+}
+
+#[tokio::test]
+async fn token_endpoint_transient_failure_keeps_auth_lease_retryable() {
+    let mock = start_mock_with_config(
+        "google-transient-token",
+        vec![30],
+        Some(MockFailure {
+            from_call: 2,
+            status: axum::http::StatusCode::SERVICE_UNAVAILABLE,
+            body: serde_json::json!({"error": "temporarily_unavailable"}),
+        }),
+    )
+    .await;
+    let tempdir = tempfile::tempdir().unwrap();
+    let sa_path = write_sa_key(tempdir.path(), &format!("{}/token", mock.base_url));
+    let env_lookup = {
+        let sa_path = sa_path.clone();
+        Arc::new(move |k: &str| {
+            if k == "GOOGLE_APPLICATION_CREDENTIALS" {
+                Some(sa_path.to_string_lossy().to_string())
+            } else {
+                None
+            }
+        }) as Arc<dyn Fn(&str) -> Option<String> + Send + Sync>
+    };
+    let handle = Arc::new(RecordingAuthLeaseHandle::default());
+    let lease_key = LeaseKey::new(
+        RealmId::parse("dev").unwrap(),
+        BindingId::parse("gemini").unwrap(),
+        Some(ProfileId::parse("google_adc").unwrap()),
+    );
+    let lease_handle: Arc<dyn AuthLeaseHandle> = handle.clone();
+    let authorizer = GoogleAuthAuthorizer::with_env_lookup(GoogleAuthChain::Default, env_lookup)
+        .with_home_dir(tempdir.path())
+        .with_auth_lease_observer(lease_handle, lease_key.clone())
+        .with_token_url_override(format!("{}/token", mock.base_url));
+
+    let mut headers = Vec::new();
+    let mut req = HttpAuthorizationRequest {
+        method: "POST",
+        url: "https://x.googleapis.com/",
+        headers: &mut headers,
+    };
+    authorizer.authorize(&mut req).await.unwrap();
+
+    let mut headers = Vec::new();
+    let mut req = HttpAuthorizationRequest {
+        method: "POST",
+        url: "https://x.googleapis.com/",
+        headers: &mut headers,
+    };
+    let err = authorizer.authorize(&mut req).await.unwrap_err();
+    assert!(
+        matches!(err, meerkat_core::AuthError::RefreshFailed(_)),
+        "token endpoint outage should still fail the caller visibly, got {err:?}"
+    );
+
+    let snapshot = handle.snapshot(&lease_key);
+    assert_eq!(
+        snapshot.phase,
+        Some(AuthLeasePhase::Expiring),
+        "transient Google token endpoint failure must remain retryable in AuthMachine"
+    );
+    assert!(
+        handle
+            .events()
+            .iter()
+            .any(|event| matches!(event, LeaseEvent::RefreshFailed(_, false))),
+        "transient Google token endpoint failure should not force reauth"
+    );
+}
+
+#[tokio::test]
+async fn metadata_endpoint_transient_failure_keeps_auth_lease_retryable() {
+    let mock = start_mock_with_config(
+        "metadata-transient-token",
+        vec![30],
+        Some(MockFailure {
+            from_call: 2,
+            status: axum::http::StatusCode::SERVICE_UNAVAILABLE,
+            body: serde_json::json!({"error": "temporarily_unavailable"}),
+        }),
+    )
+    .await;
+    let env_lookup =
+        Arc::new(|_: &str| None::<String>) as Arc<dyn Fn(&str) -> Option<String> + Send + Sync>;
+    let handle = Arc::new(RecordingAuthLeaseHandle::default());
+    let lease_key = LeaseKey::new(
+        RealmId::parse("dev").unwrap(),
+        BindingId::parse("gemini").unwrap(),
+        Some(ProfileId::parse("google_metadata").unwrap()),
+    );
+    let lease_handle: Arc<dyn AuthLeaseHandle> = handle.clone();
+    let authorizer =
+        GoogleAuthAuthorizer::with_env_lookup(GoogleAuthChain::ComputeOnly, env_lookup)
+            .with_auth_lease_observer(lease_handle, lease_key.clone())
+            .with_metadata_url_override(format!(
+                "{}/computeMetadata/v1/instance/service-accounts/default/token",
+                mock.base_url
+            ));
+
+    let mut headers = Vec::new();
+    let mut req = HttpAuthorizationRequest {
+        method: "POST",
+        url: "https://generativelanguage.googleapis.com/v1/models",
+        headers: &mut headers,
+    };
+    authorizer.authorize(&mut req).await.unwrap();
+
+    let mut headers = Vec::new();
+    let mut req = HttpAuthorizationRequest {
+        method: "POST",
+        url: "https://generativelanguage.googleapis.com/v1/models",
+        headers: &mut headers,
+    };
+    let err = authorizer.authorize(&mut req).await.unwrap_err();
+    assert!(
+        matches!(err, meerkat_core::AuthError::RefreshFailed(_)),
+        "metadata outage should still fail the caller visibly, got {err:?}"
+    );
+
+    let snapshot = handle.snapshot(&lease_key);
+    assert_eq!(
+        snapshot.phase,
+        Some(AuthLeasePhase::Expiring),
+        "transient metadata failure must remain retryable in AuthMachine"
+    );
+    assert!(
+        handle
+            .events()
+            .iter()
+            .any(|event| matches!(event, LeaseEvent::RefreshFailed(_, false))),
+        "transient metadata failure should not force reauth"
     );
 }
 

--- a/meerkat-auth-core/tests/google_auth_authorizer.rs
+++ b/meerkat-auth-core/tests/google_auth_authorizer.rs
@@ -29,7 +29,9 @@ use serde::Deserialize;
 use tokio::net::TcpListener;
 
 use meerkat_auth_core::authorizers::{GoogleAuthAuthorizer, GoogleAuthChain};
-use meerkat_core::handles::{AuthLeaseHandle, AuthLeaseSnapshot, DslTransitionError, LeaseKey};
+use meerkat_core::handles::{
+    AuthLeaseHandle, AuthLeasePhase, AuthLeaseSnapshot, DslTransitionError, LeaseKey,
+};
 use meerkat_core::{BindingId, HttpAuthorizationRequest, HttpAuthorizer, ProfileId, RealmId};
 
 const TEST_PRIVATE_KEY: &str = include_str!("fixtures/test_sa_key.pem");
@@ -91,9 +93,68 @@ struct MockServer {
     captured: Arc<Mutex<Vec<OAuthForm>>>,
 }
 
-#[derive(Default)]
+#[derive(Debug, Clone, PartialEq, Eq)]
+enum LeaseEvent {
+    Snapshot,
+    Acquire(LeaseKey, u64),
+    BeginRefresh(LeaseKey),
+    CompleteRefresh(LeaseKey, u64),
+    RefreshFailed(LeaseKey, bool),
+    MarkExpiring(LeaseKey),
+    MarkReauthRequired(LeaseKey),
+    Release(LeaseKey),
+}
+
 struct RecordingAuthLeaseHandle {
-    acquired: Mutex<Vec<(LeaseKey, u64)>>,
+    events: Mutex<Vec<LeaseEvent>>,
+    snapshot: Mutex<AuthLeaseSnapshot>,
+    fail_action: Mutex<Option<&'static str>>,
+}
+
+impl Default for RecordingAuthLeaseHandle {
+    fn default() -> Self {
+        Self {
+            events: Mutex::new(Vec::new()),
+            snapshot: Mutex::new(AuthLeaseSnapshot {
+                phase: None,
+                expires_at: None,
+            }),
+            fail_action: Mutex::new(None),
+        }
+    }
+}
+
+impl RecordingAuthLeaseHandle {
+    fn fail_on(action: &'static str) -> Self {
+        Self {
+            fail_action: Mutex::new(Some(action)),
+            ..Self::default()
+        }
+    }
+
+    fn events(&self) -> Vec<LeaseEvent> {
+        self.events.lock().unwrap().clone()
+    }
+
+    fn acquired(&self) -> Vec<(LeaseKey, u64)> {
+        self.events()
+            .into_iter()
+            .filter_map(|event| match event {
+                LeaseEvent::Acquire(lease_key, expires_at) => Some((lease_key, expires_at)),
+                _ => None,
+            })
+            .collect()
+    }
+
+    fn maybe_fail(&self, action: &'static str) -> Result<(), DslTransitionError> {
+        if self.fail_action.lock().unwrap().as_deref() == Some(action) {
+            return Err(DslTransitionError::new(
+                action,
+                "injected auth lease observer failure",
+            ));
+        }
+        Ok(())
+    }
 }
 
 impl AuthLeaseHandle for RecordingAuthLeaseHandle {
@@ -102,51 +163,103 @@ impl AuthLeaseHandle for RecordingAuthLeaseHandle {
         lease_key: &LeaseKey,
         expires_at: u64,
     ) -> Result<(), DslTransitionError> {
-        self.acquired
+        self.maybe_fail("acquire_lease")?;
+        self.events
             .lock()
             .unwrap()
-            .push((lease_key.clone(), expires_at));
+            .push(LeaseEvent::Acquire(lease_key.clone(), expires_at));
+        *self.snapshot.lock().unwrap() = AuthLeaseSnapshot {
+            phase: Some(AuthLeasePhase::Valid),
+            expires_at: Some(expires_at),
+        };
         Ok(())
     }
 
-    fn mark_expiring(&self, _lease_key: &LeaseKey) -> Result<(), DslTransitionError> {
+    fn mark_expiring(&self, lease_key: &LeaseKey) -> Result<(), DslTransitionError> {
+        self.maybe_fail("mark_expiring")?;
+        self.events
+            .lock()
+            .unwrap()
+            .push(LeaseEvent::MarkExpiring(lease_key.clone()));
+        self.snapshot.lock().unwrap().phase = Some(AuthLeasePhase::Expiring);
         Ok(())
     }
 
-    fn begin_refresh(&self, _lease_key: &LeaseKey) -> Result<(), DslTransitionError> {
+    fn begin_refresh(&self, lease_key: &LeaseKey) -> Result<(), DslTransitionError> {
+        self.maybe_fail("begin_refresh")?;
+        self.events
+            .lock()
+            .unwrap()
+            .push(LeaseEvent::BeginRefresh(lease_key.clone()));
+        self.snapshot.lock().unwrap().phase = Some(AuthLeasePhase::Refreshing);
         Ok(())
     }
 
     fn complete_refresh(
         &self,
-        _lease_key: &LeaseKey,
-        _new_expires_at: u64,
+        lease_key: &LeaseKey,
+        new_expires_at: u64,
         _now: u64,
     ) -> Result<(), DslTransitionError> {
+        self.maybe_fail("complete_refresh")?;
+        self.events
+            .lock()
+            .unwrap()
+            .push(LeaseEvent::CompleteRefresh(
+                lease_key.clone(),
+                new_expires_at,
+            ));
+        *self.snapshot.lock().unwrap() = AuthLeaseSnapshot {
+            phase: Some(AuthLeasePhase::Valid),
+            expires_at: Some(new_expires_at),
+        };
         Ok(())
     }
 
     fn refresh_failed(
         &self,
-        _lease_key: &LeaseKey,
-        _permanent: bool,
+        lease_key: &LeaseKey,
+        permanent: bool,
     ) -> Result<(), DslTransitionError> {
+        self.maybe_fail("refresh_failed")?;
+        self.events
+            .lock()
+            .unwrap()
+            .push(LeaseEvent::RefreshFailed(lease_key.clone(), permanent));
+        self.snapshot.lock().unwrap().phase = Some(if permanent {
+            AuthLeasePhase::ReauthRequired
+        } else {
+            AuthLeasePhase::Expiring
+        });
         Ok(())
     }
 
-    fn mark_reauth_required(&self, _lease_key: &LeaseKey) -> Result<(), DslTransitionError> {
+    fn mark_reauth_required(&self, lease_key: &LeaseKey) -> Result<(), DslTransitionError> {
+        self.maybe_fail("mark_reauth_required")?;
+        self.events
+            .lock()
+            .unwrap()
+            .push(LeaseEvent::MarkReauthRequired(lease_key.clone()));
+        self.snapshot.lock().unwrap().phase = Some(AuthLeasePhase::ReauthRequired);
         Ok(())
     }
 
-    fn release_lease(&self, _lease_key: &LeaseKey) -> Result<(), DslTransitionError> {
+    fn release_lease(&self, lease_key: &LeaseKey) -> Result<(), DslTransitionError> {
+        self.maybe_fail("release_lease")?;
+        self.events
+            .lock()
+            .unwrap()
+            .push(LeaseEvent::Release(lease_key.clone()));
+        *self.snapshot.lock().unwrap() = AuthLeaseSnapshot {
+            phase: None,
+            expires_at: None,
+        };
         Ok(())
     }
 
     fn snapshot(&self, _lease_key: &LeaseKey) -> AuthLeaseSnapshot {
-        AuthLeaseSnapshot {
-            phase: None,
-            expires_at: None,
-        }
+        self.events.lock().unwrap().push(LeaseEvent::Snapshot);
+        self.snapshot.lock().unwrap().clone()
     }
 }
 
@@ -435,7 +548,7 @@ async fn cached_token_authorize_publishes_token_expiry_to_auth_lease_handle() {
         authorizer.authorize(&mut req).await.unwrap();
     }
 
-    let acquired = handle.acquired.lock().unwrap();
+    let acquired = handle.acquired();
     assert_eq!(
         mock.counter.load(Ordering::SeqCst),
         1,
@@ -443,18 +556,67 @@ async fn cached_token_authorize_publishes_token_expiry_to_auth_lease_handle() {
     );
     assert_eq!(
         acquired.len(),
-        2,
-        "cached token use must still publish auth-machine lease freshness"
+        1,
+        "cached token freshness must be observed through auth-machine snapshot truth"
     );
     assert_eq!(acquired[0].0, lease_key);
-    assert_eq!(acquired[1].0, lease_key);
+    let events = handle.events();
+    assert!(
+        events
+            .iter()
+            .any(|event| matches!(event, LeaseEvent::Snapshot)),
+        "cached token reuse must check auth-machine lease truth"
+    );
     assert!(
         acquired[0].1 > Utc::now().timestamp().max(0) as u64,
         "published auth-machine expiry must reflect the fetched token"
     );
-    assert_eq!(
-        acquired[0].1, acquired[1].1,
-        "cached token lease observation should carry the same expiry"
+}
+
+#[tokio::test]
+async fn observer_failure_fails_closed_without_authorization_header() {
+    let mock = start_mock("lease-observer-fails").await;
+    let tempdir = tempfile::tempdir().unwrap();
+    let sa_path = write_sa_key(tempdir.path(), &format!("{}/token", mock.base_url));
+    let env_lookup = {
+        let sa_path = sa_path.clone();
+        Arc::new(move |k: &str| {
+            if k == "GOOGLE_APPLICATION_CREDENTIALS" {
+                Some(sa_path.to_string_lossy().to_string())
+            } else {
+                None
+            }
+        }) as Arc<dyn Fn(&str) -> Option<String> + Send + Sync>
+    };
+    let handle = Arc::new(RecordingAuthLeaseHandle::fail_on("acquire_lease"));
+    let lease_key = LeaseKey::new(
+        RealmId::parse("dev").unwrap(),
+        BindingId::parse("gemini").unwrap(),
+        Some(ProfileId::parse("google_adc").unwrap()),
+    );
+    let lease_handle: Arc<dyn AuthLeaseHandle> = handle;
+    let authorizer = GoogleAuthAuthorizer::with_env_lookup(GoogleAuthChain::Default, env_lookup)
+        .with_home_dir(tempdir.path())
+        .with_auth_lease_observer(lease_handle, lease_key)
+        .with_token_url_override(format!("{}/token", mock.base_url));
+
+    let mut headers = Vec::new();
+    let mut req = HttpAuthorizationRequest {
+        method: "POST",
+        url: "https://x.googleapis.com/",
+        headers: &mut headers,
+    };
+    let err = authorizer.authorize(&mut req).await.unwrap_err();
+
+    assert!(
+        matches!(err, meerkat_core::AuthError::Other(_)),
+        "auth lease publication failure must be visible, got {err:?}"
+    );
+    assert!(
+        headers
+            .iter()
+            .all(|(name, _)| !name.eq_ignore_ascii_case("authorization")),
+        "authorizer must not attach a bearer token when lease truth rejected publication"
     );
 }
 


### PR DESCRIPTION
## Summary
- keep Azure AD and Google cloud token freshness/lifecycle visible through AuthMachine lease truth when an auth lease observer is configured
- classify Azure/Google token endpoint refresh failures by status/body so transient outages stay retryable while credential/config failures can still force reauth
- handle shared-lease `Refreshing` observations by waiting and rechecking lease truth instead of failing separate authorizer instances
- preserve retryable Default Google ADC metadata HTTP failures as visible refresh failures instead of collapsing them to missing credentials

## Remaining compatibility behavior
Direct `AzureAdAuthorizer` / `GoogleAuthAuthorizer` construction without `with_auth_lease_observer` keeps the existing private cache plus refresh-window fallback. Provider runtime paths that pass `auth_lease_handle` use AuthMachine lease truth for cache freshness and refresh lifecycle visibility.

Default Google ADC fallback still reports missing credentials for non-retryable metadata fallback failures so local non-GCE environments keep existing missing-secret behavior. Retryable metadata HTTP failures, such as 503/429 or `temporarily_unavailable`, remain visible refresh failures and leave the lease retryable.

A separate authorizer instance that observes the same lease already `Refreshing` now waits for bounded lease progress and rechecks before refreshing. If the lease remains stuck in `Refreshing`, authorization fails visibly instead of attaching a token outside lease truth.

## Validation
- TDD red: `./scripts/repo-cargo test -p meerkat-auth-core --features gcp-auth,azure-ad --test azure_ad_authorizer --test google_auth_authorizer` failed as expected in `separate_authorizers_wait_when_shared_lease_is_refreshing`: second authorizer returned `AuthError::RefreshFailed` while the shared lease was `Refreshing`
- TDD red: `./scripts/repo-cargo test -p meerkat-auth-core --features gcp-auth,azure-ad --test google_auth_authorizer default_chain_metadata_transient_failure_keeps_auth_lease_retryable` failed as expected with `MissingSecret` because Default ADC metadata fallback discarded the transient metadata endpoint failure
- `./scripts/repo-cargo fmt --all`
- `./scripts/repo-cargo test -p meerkat-auth-core --features gcp-auth,azure-ad --test azure_ad_authorizer --test google_auth_authorizer`
- `./scripts/repo-cargo check -p meerkat-auth-core --features gcp-auth,azure-ad`
- `git diff --check`
- `make check` via BuildBuddy/Bazel invocation `8d0b627c-cf6e-43b6-bf16-dc6aed838216`
- Final rebase before Human Review: `origin/main` advanced to `eec397b`; `git rebase origin/main` succeeded
- Post-rebase: `./scripts/repo-cargo test -p meerkat-auth-core --features gcp-auth,azure-ad --test azure_ad_authorizer --test google_auth_authorizer`
- Post-rebase: `./scripts/repo-cargo check -p meerkat-auth-core --features gcp-auth,azure-ad`
- Post-rebase: `git diff --check`
- Post-rebase: `make check` via BuildBuddy/Bazel invocation `d6ff0fe6-c5c8-4e94-bd00-a2359ab1c7c6`

Linear: LUC-101