### PR TITLE
Gate comms ingress classification on machine

### DIFF
--- a/meerkat-comms/src/classify.rs
+++ b/meerkat-comms/src/classify.rs
@@ -8,9 +8,12 @@ use crate::trust::TrustedPeers;
 use crate::types::{InboxItem, MessageKind};
 use meerkat_core::{
     PeerIngressAuthDecision, PeerIngressKind, PeerIngressMachinePolicy, PeerInputClass,
+    handles::PeerCommsHandle,
 };
 use std::sync::Arc;
 use uuid::Uuid;
+
+pub(crate) type PeerCommsHandleSlot = Arc<parking_lot::RwLock<Option<Arc<dyn PeerCommsHandle>>>>;
 
 /// Receiver-owned context for synchronous ingress classification.
 ///
@@ -20,6 +23,7 @@ pub(crate) struct IngressClassificationContext {
     pub(crate) require_peer_auth: bool,
     pub(crate) trusted_peers: Arc<parking_lot::RwLock<TrustedPeers>>,
     pub(crate) ingress_policy: Arc<PeerIngressMachinePolicy>,
+    pub(crate) peer_comms_handle: PeerCommsHandleSlot,
 }
 
 /// Result of classifying an inbox item.
@@ -71,13 +75,56 @@ fn content_shape_for_text_and_blocks(
 }
 
 impl IngressClassificationContext {
+    fn machine_classify_external_envelope(&self) -> bool {
+        let handle = self.peer_comms_handle.read().clone();
+        let Some(handle) = handle else {
+            return true;
+        };
+
+        match handle.classify_external_envelope() {
+            Ok(()) => true,
+            Err(error) => {
+                tracing::warn!(
+                    error = %error,
+                    "classified ingress rejected external envelope before shell auth/routing classification"
+                );
+                false
+            }
+        }
+    }
+
+    fn machine_classify_plain_event(&self) -> bool {
+        let handle = self.peer_comms_handle.read().clone();
+        let Some(handle) = handle else {
+            return true;
+        };
+
+        match handle.classify_plain_event() {
+            Ok(()) => true,
+            Err(error) => {
+                tracing::warn!(
+                    error = %error,
+                    "classified ingress rejected plain event before shell routing classification"
+                );
+                false
+            }
+        }
+    }
+
     /// Prepare an inbox item for classified ingress.
     ///
-    /// This normalizes plain-event identities and computes the same
-    /// high-level ingress facts that the peer machine will need later.
+    /// Runtime-backed inboxes first hand the raw ingress shape to the
+    /// MeerkatMachine DSL. Only after that machine classification accepts do
+    /// we compute the compatibility projection stored on the queue. Standalone
+    /// comms runtimes leave `peer_comms_handle` unset and keep the historical
+    /// in-process behavior.
     pub(crate) fn prepare(&self, item: InboxItem) -> Option<PreparedIngressItem> {
         match item {
             InboxItem::External { envelope } => {
+                if !self.machine_classify_external_envelope() {
+                    return None;
+                }
+
                 let trusted = self.trusted_peers.read();
                 let from_peer = trusted.get_peer(&envelope.from).map(|p| p.name.clone());
                 let trusted_sender = from_peer.is_some();
@@ -185,6 +232,10 @@ impl IngressClassificationContext {
                 blocks,
                 render_metadata,
             } => {
+                if !self.machine_classify_plain_event() {
+                    return None;
+                }
+
                 let interaction_id = interaction_id.unwrap_or_else(Uuid::new_v4);
                 let text_projection = meerkat_core::interaction::format_external_event_projection(
                     &source.to_string(),
@@ -245,7 +296,87 @@ mod tests {
     use crate::identity::{Keypair, PubKey, Signature};
     use crate::trust::TrustedPeer;
     use crate::types::Envelope;
+    use std::sync::atomic::{AtomicUsize, Ordering};
     use uuid::Uuid;
+
+    struct RecordingPeerCommsHandle {
+        external_calls: AtomicUsize,
+        plain_calls: AtomicUsize,
+        reject_external: bool,
+        reject_plain: bool,
+    }
+
+    impl RecordingPeerCommsHandle {
+        fn accepting() -> Arc<Self> {
+            Arc::new(Self {
+                external_calls: AtomicUsize::new(0),
+                plain_calls: AtomicUsize::new(0),
+                reject_external: false,
+                reject_plain: false,
+            })
+        }
+
+        fn rejecting_external() -> Arc<Self> {
+            Arc::new(Self {
+                external_calls: AtomicUsize::new(0),
+                plain_calls: AtomicUsize::new(0),
+                reject_external: true,
+                reject_plain: false,
+            })
+        }
+
+        fn rejecting_plain() -> Arc<Self> {
+            Arc::new(Self {
+                external_calls: AtomicUsize::new(0),
+                plain_calls: AtomicUsize::new(0),
+                reject_external: false,
+                reject_plain: true,
+            })
+        }
+
+        fn external_calls(&self) -> usize {
+            self.external_calls.load(Ordering::SeqCst)
+        }
+
+        fn plain_calls(&self) -> usize {
+            self.plain_calls.load(Ordering::SeqCst)
+        }
+    }
+
+    impl meerkat_core::handles::PeerCommsHandle for RecordingPeerCommsHandle {
+        fn classify_external_envelope(
+            &self,
+        ) -> Result<(), meerkat_core::handles::DslTransitionError> {
+            self.external_calls.fetch_add(1, Ordering::SeqCst);
+            if self.reject_external {
+                Err(meerkat_core::handles::DslTransitionError::guard_rejected(
+                    "test_peer_comms::classify_external_envelope",
+                    "machine rejected external ingress",
+                ))
+            } else {
+                Ok(())
+            }
+        }
+
+        fn classify_plain_event(&self) -> Result<(), meerkat_core::handles::DslTransitionError> {
+            self.plain_calls.fetch_add(1, Ordering::SeqCst);
+            if self.reject_plain {
+                Err(meerkat_core::handles::DslTransitionError::guard_rejected(
+                    "test_peer_comms::classify_plain_event",
+                    "machine rejected plain ingress",
+                ))
+            } else {
+                Ok(())
+            }
+        }
+
+        fn set_peer_ingress_context(
+            &self,
+            _keep_alive: bool,
+        ) -> Result<(), meerkat_core::handles::DslTransitionError> {
+            Ok(())
+        }
+    }
 
     fn make_keypair() -> Keypair {
         Keypair::generate()
@@ -256,12 +387,22 @@ mod tests {
         trusted_peers: TrustedPeers,
         silent_intents: Vec<&str>,
     ) -> IngressClassificationContext {
+        make_context_with_machine(require_peer_auth, trusted_peers, silent_intents, None)
+    }
+
+    fn make_context_with_machine(
+        require_peer_auth: bool,
+        trusted_peers: TrustedPeers,
+        silent_intents: Vec<&str>,
+        peer_comms_handle: Option<Arc<dyn meerkat_core::handles::PeerCommsHandle>>,
+    ) -> IngressClassificationContext {
         IngressClassificationContext {
             require_peer_auth,
             trusted_peers: Arc::new(parking_lot::RwLock::new(trusted_peers)),
             ingress_policy: Arc::new(PeerIngressMachinePolicy::from_silent_intents(
                 silent_intents,
             )),
+            peer_comms_handle: Arc::new(parking_lot::RwLock::new(peer_comms_handle)),
         }
     }
 
@@ -499,6 +640,34 @@ mod tests {
     }
 
     #[test]
+    fn auth_exempt_supervisor_intent_cannot_bypass_machine_rejection() {
+        let sender = make_keypair();
+        let machine = RecordingPeerCommsHandle::rejecting_external();
+        let ctx = make_context_with_machine(
+            true,
+            TrustedPeers::new(),
+            vec![],
+            Some(machine.clone() as Arc<dyn meerkat_core::handles::PeerCommsHandle>),
+        );
+        let envelope = make_envelope(
+            &sender,
+            MessageKind::Request {
+                intent: meerkat_core::SUPERVISOR_BRIDGE_INTENT.to_string(),
+                params: serde_json::json!({}),
+                handling_mode: None,
+            },
+        );
+
+        let result = ctx.classify(&InboxItem::External { envelope });
+
+        assert!(
+            result.is_none(),
+            "machine rejection must fail closed before auth exemptions apply"
+        );
+        assert_eq!(machine.external_calls(), 1);
+    }
+
+    #[test]
     fn classify_untrusted_legacy_bridge_intent_drops_at_ingress() {
         let sender = make_keypair();
         let trusted = TrustedPeers::new(); // sender NOT trusted yet
@@ -520,6 +689,82 @@ mod tests {
     }
 
     #[test]
+    fn machine_handoff_precedes_silent_routing_and_lifecycle_extraction() {
+        let sender = make_keypair();
+        let trusted = make_trusted_peers("orchestrator", &sender.public_key());
+        let machine = RecordingPeerCommsHandle::accepting();
+        let ctx = make_context_with_machine(
+            true,
+            trusted,
+            vec!["review"],
+            Some(machine.clone() as Arc<dyn meerkat_core::handles::PeerCommsHandle>),
+        );
+
+        let silent = ctx
+            .classify(&InboxItem::External {
+                envelope: make_envelope(
+                    &sender,
+                    MessageKind::Request {
+                        intent: "review".to_string(),
+                        params: serde_json::json!({}),
+                        handling_mode: None,
+                    },
+                ),
+            })
+            .expect("machine-accepted silent request should classify");
+        assert_eq!(silent.class, PeerInputClass::SilentRequest);
+
+        let lifecycle = ctx
+            .classify(&InboxItem::External {
+                envelope: make_envelope(
+                    &sender,
+                    MessageKind::Request {
+                        intent: "mob.peer_added".to_string(),
+                        params: serde_json::json!({"peer": "new-agent"}),
+                        handling_mode: None,
+                    },
+                ),
+            })
+            .expect("machine-accepted lifecycle request should classify");
+        assert_eq!(lifecycle.class, PeerInputClass::PeerLifecycleAdded);
+        assert_eq!(lifecycle.lifecycle_peer.as_deref(), Some("new-agent"));
+        assert_eq!(machine.external_calls(), 2);
+    }
+
+    #[test]
+    fn rendered_request_projection_is_created_only_after_machine_accepts() {
+        let sender = make_keypair();
+        let trusted = make_trusted_peers("sender-agent", &sender.public_key());
+        let machine = RecordingPeerCommsHandle::accepting();
+        let ctx = make_context_with_machine(
+            true,
+            trusted,
+            vec![],
+            Some(machine.clone() as Arc<dyn meerkat_core::handles::PeerCommsHandle>),
+        );
+        let envelope = make_envelope(
+            &sender,
+            MessageKind::Request {
+                intent: "review".to_string(),
+                params: serde_json::json!({"pr": 42}),
+                handling_mode: None,
+            },
+        );
+        let request_id = envelope.id.to_string();
+
+        let prepared = ctx
+            .prepare(InboxItem::External { envelope })
+            .expect("machine accepted request should prepare");
+
+        assert_eq!(prepared.class, PeerInputClass::ActionableRequest);
+        assert_eq!(prepared.request_id.as_deref(), Some(request_id.as_str()));
+        assert!(prepared.text_projection.starts_with(&format!(
+            "[COMMS REQUEST from sender-agent (id: {request_id})]\nIntent: review"
+        )));
+        assert_eq!(machine.external_calls(), 1);
+    }
+
+    #[test]
     fn classify_plain_event() {
         let ctx = make_context(false, TrustedPeers::new(), vec![]);
         let item = InboxItem::PlainEvent {
@@ -533,6 +778,58 @@ mod tests {
         let result = ctx.classify(&item).expect("should classify");
         assert_eq!(result.class, PeerInputClass::PlainEvent);
         assert!(result.from_peer.is_none());
+    }
+
+    #[test]
+    fn plain_event_projection_requires_machine_classification() {
+        let machine = RecordingPeerCommsHandle::accepting();
+        let ctx = make_context_with_machine(
+            false,
+            TrustedPeers::new(),
+            vec![],
+            Some(machine.clone() as Arc<dyn meerkat_core::handles::PeerCommsHandle>),
+        );
+
+        let prepared = ctx
+            .prepare(InboxItem::PlainEvent {
+                blocks: None,
+                body: "event body".to_string(),
+                source: meerkat_core::PlainEventSource::Tcp,
+                handling_mode: meerkat_core::types::HandlingMode::Queue,
+                interaction_id: None,
+                render_metadata: None,
+            })
+            .expect("machine accepted plain event should prepare");
+
+        assert_eq!(prepared.class, PeerInputClass::PlainEvent);
+        assert_eq!(prepared.text_projection, "[EVENT via tcp] event body");
+        assert_eq!(machine.plain_calls(), 1);
+    }
+
+    #[test]
+    fn plain_event_machine_rejection_fails_closed() {
+        let machine = RecordingPeerCommsHandle::rejecting_plain();
+        let ctx = make_context_with_machine(
+            false,
+            TrustedPeers::new(),
+            vec![],
+            Some(machine.clone() as Arc<dyn meerkat_core::handles::PeerCommsHandle>),
+        );
+
+        let prepared = ctx.prepare(InboxItem::PlainEvent {
+            blocks: None,
+            body: "event body".to_string(),
+            source: meerkat_core::PlainEventSource::Tcp,
+            handling_mode: meerkat_core::types::HandlingMode::Queue,
+            interaction_id: None,
+            render_metadata: None,
+        });
+
+        assert!(
+            prepared.is_none(),
+            "machine rejection must fail closed before plain-event routing"
+        );
+        assert_eq!(machine.plain_calls(), 1);
     }
 
     #[test]

--- a/meerkat-comms/src/inbox.rs
+++ b/meerkat-comms/src/inbox.rs
@@ -1050,15 +1050,25 @@ mod tests {
 
     use crate::classify::IngressClassificationContext;
     use crate::trust::{TrustedPeer, TrustedPeers};
+    use std::sync::atomic::AtomicUsize;
 
     fn make_classification_context(
         trusted: TrustedPeers,
         require_auth: bool,
     ) -> Arc<IngressClassificationContext> {
+        make_classification_context_with_machine(trusted, require_auth, None)
+    }
+
+    fn make_classification_context_with_machine(
+        trusted: TrustedPeers,
+        require_auth: bool,
+        peer_comms_handle: Option<Arc<dyn meerkat_core::handles::PeerCommsHandle>>,
+    ) -> Arc<IngressClassificationContext> {
         Arc::new(IngressClassificationContext {
             require_peer_auth: require_auth,
             trusted_peers: Arc::new(parking_lot::RwLock::new(trusted)),
             ingress_policy: Arc::new(PeerIngressMachinePolicy::default()),
+            peer_comms_handle: Arc::new(parking_lot::RwLock::new(peer_comms_handle)),
         })
     }
 
@@ -1070,6 +1080,45 @@ mod tests {
                 addr: "inproc://test".to_string(),
                 meta: crate::PeerMeta::default(),
             }],
+        }
+    }
+
+    struct RejectingPeerCommsHandle {
+        external_calls: AtomicUsize,
+    }
+
+    impl RejectingPeerCommsHandle {
+        fn new() -> Arc<Self> {
+            Arc::new(Self {
+                external_calls: AtomicUsize::new(0),
+            })
+        }
+
+        fn external_calls(&self) -> usize {
+            self.external_calls.load(Ordering::SeqCst)
+        }
+    }
+
+    impl meerkat_core::handles::PeerCommsHandle for RejectingPeerCommsHandle {
+        fn classify_external_envelope(
+            &self,
+        ) -> Result<(), meerkat_core::handles::DslTransitionError> {
+            self.external_calls.fetch_add(1, Ordering::SeqCst);
+            Err(meerkat_core::handles::DslTransitionError::guard_rejected(
+                "test_peer_comms::classify_external_envelope",
+                "machine rejected external ingress",
+            ))
+        }
+
+        fn classify_plain_event(&self) -> Result<(), meerkat_core::handles::DslTransitionError> {
+            Ok(())
+        }
+
+        fn set_peer_ingress_context(
+            &self,
+            _keep_alive: bool,
+        ) -> Result<(), meerkat_core::handles::DslTransitionError> {
+            Ok(())
         }
     }
 
@@ -1394,6 +1443,32 @@ mod tests {
             }
         );
         assert_eq!(inbox.dropped_count(), Some(1));
+    }
+
+    #[tokio::test]
+    async fn test_machine_rejection_returns_classification_rejected_drop_reason() {
+        let sender_pubkey = PubKey::new([1u8; 32]);
+        let machine = RejectingPeerCommsHandle::new();
+        let ctx = make_classification_context_with_machine(
+            make_trusted("peer", &sender_pubkey),
+            true,
+            Some(machine.clone() as Arc<dyn meerkat_core::handles::PeerCommsHandle>),
+        );
+        let (mut inbox, sender) = Inbox::new_classified(ctx);
+
+        let outcome = sender.send_classified(InboxItem::External {
+            envelope: make_test_envelope(),
+        });
+
+        assert_eq!(
+            outcome,
+            AdmissionOutcome::Dropped {
+                reason: DropReason::ClassificationRejected
+            }
+        );
+        assert_eq!(inbox.dropped_count(), Some(1));
+        assert_eq!(inbox.try_drain_classified().len(), 0);
+        assert_eq!(machine.external_calls(), 1);
     }
 
     #[tokio::test]

--- a/meerkat-comms/src/runtime/comms_runtime.rs
+++ b/meerkat-comms/src/runtime/comms_runtime.rs
@@ -1130,6 +1130,7 @@ pub struct CommsRuntime {
     peer_directory_reachability: Arc<Mutex<PeerDirectoryReachabilityAuthority>>,
     #[allow(dead_code)] // Kept for runtime inspection symmetry with IngressClassificationContext.
     ingress_policy: Arc<meerkat_core::PeerIngressMachinePolicy>,
+    peer_comms_handle: crate::classify::PeerCommsHandleSlot,
     /// Narrow notify that fires only for actionable peer input (messages/requests).
     /// Set during construction when classified inbox is used.
     actionable_notify: Option<Arc<tokio::sync::Notify>>,
@@ -1204,10 +1205,12 @@ impl CommsRuntime {
         let ingress_policy = Self::ingress_policy_from_silent_intents(&silent_intents);
 
         // Build classified inbox using the same trusted_peers Arc
+        let peer_comms_handle = Arc::new(parking_lot::RwLock::new(None));
         let classification_context = Arc::new(crate::classify::IngressClassificationContext {
             require_peer_auth: config.require_peer_auth,
             trusted_peers: trusted_peers.clone(),
             ingress_policy: ingress_policy.clone(),
+            peer_comms_handle: peer_comms_handle.clone(),
         });
         let (inbox, inbox_sender) = crate::Inbox::new_classified(classification_context);
         let inbox_notify = inbox.notify();
@@ -1242,6 +1245,7 @@ impl CommsRuntime {
                 PeerDirectoryReachabilityAuthority::new(),
             )),
             ingress_policy,
+            peer_comms_handle,
             actionable_notify,
             blob_store: None,
             peer_interaction_handle: parking_lot::RwLock::new(None),
@@ -1288,10 +1292,12 @@ impl CommsRuntime {
         let trusted_peers = Arc::new(parking_lot::RwLock::new(TrustedPeers::new()));
         let ingress_policy = Self::ingress_policy_from_silent_intents(&silent_intents);
 
+        let peer_comms_handle = Arc::new(parking_lot::RwLock::new(None));
         let classification_context = Arc::new(crate::classify::IngressClassificationContext {
             require_peer_auth: true,
             trusted_peers: trusted_peers.clone(),
             ingress_policy: ingress_policy.clone(),
+            peer_comms_handle: peer_comms_handle.clone(),
         });
         let (inbox, inbox_sender) = crate::Inbox::new_classified(classification_context);
         let inbox_notify = inbox.notify();
@@ -1350,6 +1356,7 @@ impl CommsRuntime {
                 PeerDirectoryReachabilityAuthority::new(),
             )),
             ingress_policy,
+            peer_comms_handle,
             actionable_notify,
             blob_store: None,
             peer_interaction_handle: parking_lot::RwLock::new(None),
@@ -1417,10 +1424,12 @@ impl CommsRuntime {
         let trusted_peers = Arc::new(parking_lot::RwLock::new(TrustedPeers::new()));
         let ingress_policy = Self::ingress_policy_from_silent_intents(&silent_intents);
 
+        let peer_comms_handle = Arc::new(parking_lot::RwLock::new(None));
         let classification_context = Arc::new(crate::classify::IngressClassificationContext {
             require_peer_auth: true,
             trusted_peers: trusted_peers.clone(),
             ingress_policy: ingress_policy.clone(),
+            peer_comms_handle: peer_comms_handle.clone(),
         });
         let (inbox, inbox_sender) = crate::Inbox::new_classified(classification_context);
         let inbox_notify = inbox.notify();
@@ -1470,6 +1479,7 @@ impl CommsRuntime {
                 PeerDirectoryReachabilityAuthority::new(),
             )),
             ingress_policy,
+            peer_comms_handle,
             actionable_notify,
             blob_store: None,
             peer_interaction_handle: parking_lot::RwLock::new(None),
@@ -1501,6 +1511,25 @@ impl CommsRuntime {
     /// boundary.
     pub fn set_blob_store(&mut self, blob_store: Arc<dyn BlobStore>) {
         self.blob_store = Some(blob_store);
+    }
+
+    /// Install the session's peer-comms ingress DSL handle.
+    ///
+    /// When present, every classified inbox item first fires the
+    /// MeerkatMachine `ClassifyExternalEnvelope` / `ClassifyPlainEvent`
+    /// signal. A DSL rejection fails closed before the comms shell computes
+    /// auth exemptions, silent routing, lifecycle subjects, or rendered text.
+    /// Standalone comms runtimes leave this unset for wire-compatible local
+    /// operation without a session DSL.
+    pub fn install_peer_comms_handle(
+        &self,
+        handle: Arc<dyn meerkat_core::handles::PeerCommsHandle>,
+    ) {
+        *self.peer_comms_handle.write() = Some(handle);
+    }
+
+    pub fn peer_comms_handle(&self) -> Option<Arc<dyn meerkat_core::handles::PeerCommsHandle>> {
+        self.peer_comms_handle.read().clone()
     }
 
     /// Install the session's peer-interaction DSL handle (W1-A).

--- a/meerkat-core/src/handles.rs
+++ b/meerkat-core/src/handles.rs
@@ -662,9 +662,12 @@ pub trait ExternalToolSurfaceHandle: Send + Sync {
 /// Peer comms ingress classification DSL handle.
 ///
 /// Covers the peer-envelope classification signals on the MeerkatMachine DSL.
-/// Envelope state (raw_item_id, peer_id, request_id, etc.) is staged via
-/// other DSL inputs before these signals fire; the signals themselves are
-/// parameterless — they advance the classification lifecycle phase.
+/// Runtime-backed comms ingress must fire one of these signals before the
+/// comms shell computes its stored compatibility projection (`PeerInputClass`,
+/// auth exemption, lifecycle subject, rendered text). A rejection is
+/// authoritative and callers fail closed. Standalone comms runtimes may have
+/// no session DSL handle; those retain the historical in-process projection
+/// path for wire compatibility.
 pub trait PeerCommsHandle: Send + Sync {
     /// Fire the `ClassifyExternalEnvelope` signal.
     fn classify_external_envelope(&self) -> Result<(), DslTransitionError>;

--- a/meerkat/src/factory.rs
+++ b/meerkat/src/factory.rs
@@ -2716,6 +2716,13 @@ impl AgentFactory {
         if let RuntimeBuildMode::SessionOwned(bindings) = resolved_mode {
             tools.bind_external_tool_surface_handle(Arc::clone(&bindings.external_tool_surface));
             tools.bind_mcp_server_lifecycle_handle(Arc::clone(&bindings.mcp_server_lifecycle));
+            // LUC-104: classified comms ingress must hand raw external/plain
+            // ingress through the session's MeerkatMachine before the comms
+            // shell computes compatibility auth/routing projections.
+            #[cfg(feature = "comms")]
+            if let Some(runtime) = &comms_runtime {
+                runtime.install_peer_comms_handle(Arc::clone(&bindings.peer_comms));
+            }
             // W1-A: install the peer-interaction DSL handle on the session's
             // comms runtime so outbound PeerRequest sends record into
             // `pending_peer_requests` and `comms_drain` fires response


### PR DESCRIPTION
## Summary
- Install the session `PeerCommsHandle` on comms runtimes built with session-owned runtime bindings.
- Gate classified external envelopes and plain events on `ClassifyExternalEnvelope` / `ClassifyPlainEvent` before comms computes auth exemptions, silent routing, lifecycle peer extraction, or rendered projections.
- Fail closed as `ClassificationRejected` when the machine rejects, with focused tests for auth-exempt intents, silent routing, lifecycle extraction, rendered text projection, and machine handoff.

## Compatibility
Existing wire payloads keep their current shape. For session-owned runtimes, the MeerkatMachine classification signal must accept before the stored comms compatibility projection is computed. Standalone or no-handle comms runtimes retain the historical in-process projection path so local/inproc and legacy tests without a session DSL continue to accept the same inputs.

## Validation
- `./scripts/repo-cargo test -p meerkat-comms machine_ --lib` (red before implementation, green after)
- `./scripts/repo-cargo test -p meerkat-comms --lib`
- `./scripts/repo-cargo check -p meerkat --features comms`
- `make check` (BuildBuddy invocation `b1be74f8-fe89-4f2c-844f-6fdaa40e2fcc`)
- `git diff --check`

Linear: LUC-104
