### PR TITLE
LUC-107 Centralize surface request lifecycle authority

### DIFF
--- a/meerkat-mcp-server/src/main.rs
+++ b/meerkat-mcp-server/src/main.rs
@@ -2,7 +2,7 @@
 
 use clap::{Parser, ValueEnum};
 use meerkat::surface::{
-    CompleteOutcome, PublishOutcome, RequestTerminal, StdioJsonWriter, SurfaceRequestExecutor,
+    RequestTerminal, RequestTerminalResolution, StdioJsonWriter, SurfaceRequestExecutor,
     SurfaceRequestSemantics, noop_request_action, spawn_stdio_json_writer,
 };
 use meerkat_contracts::ErrorCode;
@@ -231,7 +231,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                         let state = Arc::clone(&state);
                         let completion_tx = completion_tx.clone();
                         let tool_name = name.clone();
-                        let semantics = tool_call_request_semantics(&tool_name);
+                        let semantics = SurfaceRequestSemantics::for_mcp_tool_call(&tool_name);
                         let request_id_for_task = request_id.clone();
                         let request_key_for_task = request_key.clone();
                         let handle = tokio::spawn(async move {
@@ -310,10 +310,6 @@ fn request_key(id: &Value) -> String {
     serde_json::to_string(id).unwrap_or_else(|_| id.to_string())
 }
 
-fn tool_call_request_semantics(tool_name: &str) -> SurfaceRequestSemantics {
-    SurfaceRequestSemantics::for_mcp_tool_call(tool_name)
-}
-
 fn request_cancel_target(params: Option<&Value>) -> Option<String> {
     let request_id = params?.get("requestId")?;
     Some(request_key(request_id))
@@ -324,37 +320,20 @@ async fn write_tool_completion(
     request_executor: &SurfaceRequestExecutor,
     completion: ToolCompletion,
 ) -> bool {
-    // Lifecycle truth lives in the executor's typed state machine:
-    // publish responses must claim Published before transport emission, while
-    // uncommitted responses yield to a prior cancel via CompleteOutcome.
-    let to_write = match completion.terminal {
-        RequestTerminal::Publish(response) => {
-            let cancel_id = response.get("id").cloned();
-            match request_executor
-                .publish_or_cancelled(&completion.request_key)
-                .await
-            {
-                Ok(PublishOutcome::Published) => response,
-                Ok(PublishOutcome::CancelledBeforePublish) => request_cancelled_response(cancel_id),
-                Err(err) => {
-                    tracing::warn!(
-                        request_key = %completion.request_key,
-                        error = %err,
-                        "request lifecycle rejected publish response"
-                    );
-                    request_lifecycle_error_response(cancel_id, err)
-                }
-            }
-        }
-        RequestTerminal::RespondWithoutPublish(response) => {
-            let cancel_id = response.get("id").cloned();
-            let outcome = request_executor
-                .finish_unpublished(&completion.request_key)
-                .await;
-            match outcome {
-                CompleteOutcome::Completed => response,
-                CompleteOutcome::SupersededByCancel => request_cancelled_response(cancel_id),
-            }
+    let cancel_id = completion.terminal.payload().get("id").cloned();
+    let to_write = match request_executor
+        .resolve_terminal(Some(&completion.request_key), completion.terminal)
+        .await
+    {
+        RequestTerminalResolution::Emit(response) => response,
+        RequestTerminalResolution::Cancelled => request_cancelled_response(cancel_id),
+        RequestTerminalResolution::LifecycleError(err) => {
+            tracing::warn!(
+                request_key = %completion.request_key,
+                error = %err,
+                "request lifecycle rejected publish response"
+            );
+            request_lifecycle_error_response(cancel_id, err)
         }
     };
 
@@ -393,15 +372,17 @@ mod tests {
     #[test]
     fn meerkat_run_and_resume_publish_on_success() {
         assert!(matches!(
-            tool_call_request_semantics("meerkat_run").classify_terminal(true, ()),
+            SurfaceRequestSemantics::for_mcp_tool_call("meerkat_run").classify_terminal(true, ()),
             RequestTerminal::Publish(())
         ));
         assert!(matches!(
-            tool_call_request_semantics("meerkat_resume").classify_terminal(true, ()),
+            SurfaceRequestSemantics::for_mcp_tool_call("meerkat_resume")
+                .classify_terminal(true, ()),
             RequestTerminal::Publish(())
         ));
         assert!(matches!(
-            tool_call_request_semantics("meerkat_sessions").classify_terminal(true, ()),
+            SurfaceRequestSemantics::for_mcp_tool_call("meerkat_sessions")
+                .classify_terminal(true, ()),
             RequestTerminal::RespondWithoutPublish(())
         ));
     }

--- a/meerkat-rest/src/lib.rs
+++ b/meerkat-rest/src/lib.rs
@@ -43,7 +43,7 @@ use axum::{
 use chrono::{DateTime, Utc};
 use futures::stream::Stream;
 use meerkat::surface::{
-    CompleteOutcome, PublishOutcome, RequestAlreadyExists, RequestContext, RequestTerminal,
+    RequestAlreadyExists, RequestContext, RequestTerminal, RequestTerminalResolution,
     SurfaceRequestExecutor, SurfaceSessionRecoveryContext, SurfaceSessionRecoveryOverrides,
     build_recovered_session, noop_request_action, request_action,
 };
@@ -2662,29 +2662,16 @@ async fn with_request_lifecycle(
     ctx: Option<RequestContext>,
     outcome: RequestTerminal<Result<Json<SessionResponse>, ApiError>>,
 ) -> Result<Json<SessionResponse>, ApiError> {
-    match ctx {
-        Some(ctx) => match outcome {
-            RequestTerminal::Publish(val) => match executor.publish_or_cancelled(ctx.key()).await {
-                Ok(PublishOutcome::Published) => val,
-                Ok(PublishOutcome::CancelledBeforePublish) => {
-                    Err(ApiError::RequestCancelled { details: None })
-                }
-                Err(err) => Err(ApiError::Internal(format!(
-                    "request lifecycle rejected publish response: {err}"
-                ))),
-            },
-            RequestTerminal::RespondWithoutPublish(val) => {
-                match executor.finish_unpublished(ctx.key()).await {
-                    CompleteOutcome::Completed => val,
-                    CompleteOutcome::SupersededByCancel => {
-                        Err(ApiError::RequestCancelled { details: None })
-                    }
-                }
-            }
-        },
-        None => match outcome {
-            RequestTerminal::Publish(val) | RequestTerminal::RespondWithoutPublish(val) => val,
-        },
+    let request_key = ctx.as_ref().map(|ctx| ctx.key().to_string());
+    match executor
+        .resolve_terminal(request_key.as_deref(), outcome)
+        .await
+    {
+        RequestTerminalResolution::Emit(val) => val,
+        RequestTerminalResolution::Cancelled => Err(ApiError::RequestCancelled { details: None }),
+        RequestTerminalResolution::LifecycleError(err) => Err(ApiError::Internal(format!(
+            "request lifecycle rejected publish response: {err}"
+        ))),
     }
 }
 

--- a/meerkat-rpc/src/server.rs
+++ b/meerkat-rpc/src/server.rs
@@ -9,8 +9,8 @@ use std::sync::Arc;
 use std::sync::atomic::AtomicU64;
 
 use meerkat::surface::{
-    CompleteOutcome, PublishOutcome, RequestTerminal, SurfaceRequestExecutor,
-    SurfaceRequestSemantics, noop_request_action,
+    RequestTerminal, RequestTerminalResolution, SurfaceRequestExecutor, SurfaceRequestSemantics,
+    noop_request_action,
 };
 use tokio::io::{AsyncBufRead, BufReader};
 use tokio::sync::{mpsc, oneshot};
@@ -363,45 +363,21 @@ impl<R: AsyncBufRead + Unpin, W: TransportWriter> RpcServer<R, W> {
     }
 
     async fn write_long_running_response(&mut self, response: LongRunningResponse) -> bool {
-        // Lifecycle truth lives in the executor's typed state machine:
-        // publish responses must claim Published before transport emission,
-        // while uncommitted responses yield to a prior cancel via CompleteOutcome.
-        let to_write = match response.terminal {
-            RequestTerminal::Publish(rpc_response) => {
-                let cancel_id = rpc_response.id.clone();
-                match self
-                    .request_executor
-                    .publish_or_cancelled(&response.request_key)
-                    .await
-                {
-                    Ok(PublishOutcome::Published) => rpc_response,
-                    Ok(PublishOutcome::CancelledBeforePublish) => {
-                        request_cancelled_response(cancel_id)
-                    }
-                    Err(err) => {
-                        tracing::warn!(
-                            request_key = %response.request_key,
-                            error = %err,
-                            "request lifecycle rejected publish response"
-                        );
-                        request_lifecycle_error_response(cancel_id, err)
-                    }
-                }
-            }
-            RequestTerminal::RespondWithoutPublish(rpc_response) => {
-                // Uncommitted terminal: the executor tells us whether cancel
-                // landed first. No shell-side rewriting — SupersededByCancel
-                // means we emit the cancel response the caller requested, not
-                // the task's stale payload.
-                let cancel_id = rpc_response.id.clone();
-                let outcome = self
-                    .request_executor
-                    .finish_unpublished(&response.request_key)
-                    .await;
-                match outcome {
-                    CompleteOutcome::Completed => rpc_response,
-                    CompleteOutcome::SupersededByCancel => request_cancelled_response(cancel_id),
-                }
+        let cancel_id = response.terminal.payload().id.clone();
+        let to_write = match self
+            .request_executor
+            .resolve_terminal(Some(&response.request_key), response.terminal)
+            .await
+        {
+            RequestTerminalResolution::Emit(rpc_response) => rpc_response,
+            RequestTerminalResolution::Cancelled => request_cancelled_response(cancel_id),
+            RequestTerminalResolution::LifecycleError(err) => {
+                tracing::warn!(
+                    request_key = %response.request_key,
+                    error = %err,
+                    "request lifecycle rejected publish response"
+                );
+                request_lifecycle_error_response(cancel_id, err)
             }
         };
 
@@ -492,24 +468,9 @@ fn request_lifecycle_error_response(
 }
 
 fn request_semantics(request: &RpcRequest) -> SurfaceRequestSemantics {
-    SurfaceRequestSemantics::for_rpc_method(
+    SurfaceRequestSemantics::for_rpc_request(
         request.method.as_str(),
-        session_create_runs_immediately(request.params.as_deref()),
-    )
-}
-
-fn session_create_runs_immediately(params: Option<&serde_json::value::RawValue>) -> bool {
-    let Some(params) = params else {
-        return true;
-    };
-    let Ok(value) = serde_json::from_str::<serde_json::Value>(params.get()) else {
-        return true;
-    };
-    !matches!(
-        value
-            .get("initial_turn")
-            .and_then(serde_json::Value::as_str),
-        Some("deferred")
+        request.params.as_deref().map(|params| params.get()),
     )
 }
 

--- a/meerkat/src/surface.rs
+++ b/meerkat/src/surface.rs
@@ -24,9 +24,9 @@ pub use meerkat_core::{
 pub use request_execution::{
     CancelActionInstallOutcome, CancelOutcome, CompleteOutcome, PreparedSurfaceSession,
     PublishOutcome, RequestAlreadyExists, RequestAsyncAction, RequestContext, RequestTerminal,
-    RequestTransitionError, SurfaceRequestExecution, SurfaceRequestExecutor, SurfaceRequestPhase,
-    SurfaceRequestSemantics, SurfaceRequestTerminalPolicy, noop_request_action,
-    prepare_surface_session, request_action,
+    RequestTerminalResolution, RequestTransitionError, SurfaceRequestExecution,
+    SurfaceRequestExecutor, SurfaceRequestPhase, SurfaceRequestSemantics,
+    SurfaceRequestTerminalPolicy, noop_request_action, prepare_surface_session, request_action,
 };
 #[cfg(all(feature = "session-store", feature = "comms"))]
 pub use runtime_backed::configure_peer_ingress;

--- a/meerkat/src/surface/request_execution.rs
+++ b/meerkat/src/surface/request_execution.rs
@@ -57,6 +57,34 @@ pub enum RequestTerminal<T> {
     RespondWithoutPublish(T),
 }
 
+impl<T> RequestTerminal<T> {
+    /// Borrow the terminal payload without exposing whether it was classified as
+    /// committed or observational.
+    pub fn payload(&self) -> &T {
+        match self {
+            Self::Publish(payload) | Self::RespondWithoutPublish(payload) => payload,
+        }
+    }
+
+    fn into_payload(self) -> T {
+        match self {
+            Self::Publish(payload) | Self::RespondWithoutPublish(payload) => payload,
+        }
+    }
+}
+
+/// Canonical resolution of a surface terminal through the lifecycle machine.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum RequestTerminalResolution<T> {
+    /// The surface may emit or return the request's terminal payload.
+    Emit(T),
+    /// Cancel won before terminal publication. The surface should emit its
+    /// protocol-specific cancellation response instead of the stale payload.
+    Cancelled,
+    /// The lifecycle machine rejected a committed publication transition.
+    LifecycleError(RequestTransitionError),
+}
+
 /// Whether a surface request needs tracked asynchronous execution.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum SurfaceRequestExecution {
@@ -104,11 +132,9 @@ impl SurfaceRequestSemantics {
         }
     }
 
-    /// Canonical RPC request semantics.
-    ///
-    /// The RPC surface supplies only the already-parsed "does session/create
-    /// run immediately?" fact. Method-to-publication policy lives here so RPC
-    /// transports do not each grow their own terminal classifier.
+    /// Canonical RPC request semantics for an already-parsed `session/create`
+    /// initial-turn policy. Prefer [`Self::for_rpc_request`] at protocol
+    /// boundaries so request lifecycle classification stays machine-owned.
     pub fn for_rpc_method(method: &str, session_create_runs_immediately: bool) -> Self {
         match method {
             "turn/start" | "mob/turn_start" => Self::long_running_publish_on_success(),
@@ -117,6 +143,13 @@ impl SurfaceRequestSemantics {
             }
             _ => Self::inline_observation(),
         }
+    }
+
+    /// Canonical RPC request semantics, including wire-parameter classification.
+    pub fn for_rpc_request(method: &str, params_json: Option<&str>) -> Self {
+        let session_create_runs_immediately =
+            rpc_session_create_runs_immediately(method, params_json);
+        Self::for_rpc_method(method, session_create_runs_immediately)
     }
 
     /// Canonical MCP tool-call request semantics.
@@ -143,6 +176,24 @@ impl SurfaceRequestSemantics {
             RequestTerminal::RespondWithoutPublish(response)
         }
     }
+}
+
+fn rpc_session_create_runs_immediately(method: &str, params_json: Option<&str>) -> bool {
+    if method != "session/create" {
+        return false;
+    }
+    let Some(params_json) = params_json else {
+        return true;
+    };
+    let Ok(value) = serde_json::from_str::<serde_json::Value>(params_json) else {
+        return true;
+    };
+    !matches!(
+        value
+            .get("initial_turn")
+            .and_then(serde_json::Value::as_str),
+        Some("deferred")
+    )
 }
 
 /// Canonical lifecycle phase of a tracked request.
@@ -597,6 +648,35 @@ impl SurfaceRequestExecutor {
         self.lifecycle.finish_unpublished(key).await
     }
 
+    /// Resolve a surface terminal through the canonical lifecycle machine.
+    ///
+    /// This is the shared publish/cancel/complete authority used by RPC, MCP,
+    /// and REST. Surfaces still own wire formatting for cancellation and
+    /// lifecycle errors, but they do not decide which terminal wins.
+    pub async fn resolve_terminal<T>(
+        &self,
+        key: Option<&str>,
+        terminal: RequestTerminal<T>,
+    ) -> RequestTerminalResolution<T> {
+        let Some(key) = key else {
+            return RequestTerminalResolution::Emit(terminal.into_payload());
+        };
+
+        match terminal {
+            RequestTerminal::Publish(payload) => match self.publish_or_cancelled(key).await {
+                Ok(PublishOutcome::Published) => RequestTerminalResolution::Emit(payload),
+                Ok(PublishOutcome::CancelledBeforePublish) => RequestTerminalResolution::Cancelled,
+                Err(err) => RequestTerminalResolution::LifecycleError(err),
+            },
+            RequestTerminal::RespondWithoutPublish(payload) => {
+                match self.finish_unpublished(key).await {
+                    CompleteOutcome::Completed => RequestTerminalResolution::Emit(payload),
+                    CompleteOutcome::SupersededByCancel => RequestTerminalResolution::Cancelled,
+                }
+            }
+        }
+    }
+
     /// Cancel every tracked request. Honours the same typed transitions as
     /// [`Self::cancel_request`]; already-terminal entries are left alone.
     pub async fn cancel_all(&self) {
@@ -661,6 +741,190 @@ pub async fn prepare_surface_session(
 mod tests {
     use super::*;
     use std::sync::atomic::{AtomicUsize, Ordering};
+
+    #[test]
+    fn canonical_request_classifiers_cover_rpc_and_mcp_names() {
+        assert_eq!(
+            SurfaceRequestSemantics::for_rpc_request("turn/start", None),
+            SurfaceRequestSemantics::long_running_publish_on_success()
+        );
+        assert_eq!(
+            SurfaceRequestSemantics::for_rpc_request("mob/turn_start", Some("{}")),
+            SurfaceRequestSemantics::long_running_publish_on_success()
+        );
+        assert_eq!(
+            SurfaceRequestSemantics::for_rpc_request("session/create", None),
+            SurfaceRequestSemantics::long_running_publish_on_success()
+        );
+        assert_eq!(
+            SurfaceRequestSemantics::for_rpc_request(
+                "session/create",
+                Some(r#"{"initial_turn":"immediate"}"#),
+            ),
+            SurfaceRequestSemantics::long_running_publish_on_success()
+        );
+        assert_eq!(
+            SurfaceRequestSemantics::for_rpc_request(
+                "session/create",
+                Some(r#"{"initial_turn":"deferred"}"#),
+            ),
+            SurfaceRequestSemantics::inline_observation()
+        );
+        assert_eq!(
+            SurfaceRequestSemantics::for_rpc_request("session/create", Some("{not json")),
+            SurfaceRequestSemantics::long_running_publish_on_success()
+        );
+        assert_eq!(
+            SurfaceRequestSemantics::for_rpc_request("session/list", None),
+            SurfaceRequestSemantics::inline_observation()
+        );
+
+        assert_eq!(
+            SurfaceRequestSemantics::for_mcp_tool_call("meerkat_run"),
+            SurfaceRequestSemantics::long_running_publish_on_success()
+        );
+        assert_eq!(
+            SurfaceRequestSemantics::for_mcp_tool_call("meerkat_resume"),
+            SurfaceRequestSemantics::long_running_publish_on_success()
+        );
+        assert_eq!(
+            SurfaceRequestSemantics::for_mcp_tool_call("meerkat_sessions"),
+            SurfaceRequestSemantics::long_running_observation()
+        );
+    }
+
+    #[test]
+    fn terminal_policy_publishes_only_successful_commits() {
+        assert!(matches!(
+            SurfaceRequestSemantics::long_running_publish_on_success()
+                .classify_terminal(true, "committed"),
+            RequestTerminal::Publish("committed")
+        ));
+        assert!(matches!(
+            SurfaceRequestSemantics::long_running_publish_on_success()
+                .classify_terminal(false, "failed"),
+            RequestTerminal::RespondWithoutPublish("failed")
+        ));
+        assert!(matches!(
+            SurfaceRequestSemantics::long_running_observation()
+                .classify_terminal(true, "observation"),
+            RequestTerminal::RespondWithoutPublish("observation")
+        ));
+    }
+
+    #[tokio::test]
+    async fn terminal_resolution_policy_is_shared_for_rpc_mcp_and_rest() {
+        for surface in ["rpc", "mcp", "rest"] {
+            let executor = SurfaceRequestExecutor::new(Duration::from_millis(1));
+
+            let publish_key = format!("{surface}-publish");
+            let publish_context = executor.begin_request(&publish_key, noop_request_action());
+            assert_eq!(
+                executor
+                    .resolve_terminal(
+                        Some(publish_context.key()),
+                        RequestTerminal::Publish(format!("{surface}-committed")),
+                    )
+                    .await,
+                RequestTerminalResolution::Emit(format!("{surface}-committed"))
+            );
+            assert_eq!(executor.phase(&publish_key), None);
+            assert_eq!(
+                executor.cancel_request(&publish_key).await,
+                CancelOutcome::NotFound
+            );
+
+            let cancel_publish_key = format!("{surface}-cancel-publish");
+            let cancel_publish_context =
+                executor.begin_request(&cancel_publish_key, noop_request_action());
+            assert_eq!(
+                executor.cancel_request(cancel_publish_context.key()).await,
+                CancelOutcome::Cancelled
+            );
+            assert_eq!(
+                executor
+                    .resolve_terminal(
+                        Some(cancel_publish_context.key()),
+                        RequestTerminal::Publish(format!("{surface}-stale-publish")),
+                    )
+                    .await,
+                RequestTerminalResolution::Cancelled
+            );
+            assert_eq!(executor.phase(&cancel_publish_key), None);
+
+            let cancel_observation_key = format!("{surface}-cancel-observation");
+            let cancel_observation_context =
+                executor.begin_request(&cancel_observation_key, noop_request_action());
+            assert_eq!(
+                executor
+                    .cancel_request(cancel_observation_context.key())
+                    .await,
+                CancelOutcome::Cancelled
+            );
+            assert_eq!(
+                executor
+                    .resolve_terminal(
+                        Some(cancel_observation_context.key()),
+                        RequestTerminal::RespondWithoutPublish(format!(
+                            "{surface}-stale-observation"
+                        )),
+                    )
+                    .await,
+                RequestTerminalResolution::Cancelled
+            );
+            assert_eq!(executor.phase(&cancel_observation_key), None);
+
+            assert_eq!(
+                executor
+                    .resolve_terminal(
+                        None,
+                        RequestTerminal::Publish(format!("{surface}-untracked")),
+                    )
+                    .await,
+                RequestTerminalResolution::Emit(format!("{surface}-untracked"))
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn terminal_resolution_runs_cancelled_cleanup_once() {
+        let executor = SurfaceRequestExecutor::new(Duration::from_millis(1));
+        let cleanup_count = Arc::new(AtomicUsize::new(0));
+        let context = executor.begin_request("cancelled-terminal-cleanup", noop_request_action());
+        context.set_unpublished_cleanup(request_action({
+            let cleanup_count = Arc::clone(&cleanup_count);
+            move || {
+                let cleanup_count = Arc::clone(&cleanup_count);
+                async move {
+                    cleanup_count.fetch_add(1, Ordering::SeqCst);
+                }
+            }
+        }));
+
+        assert_eq!(
+            executor.cancel_request(context.key()).await,
+            CancelOutcome::Cancelled
+        );
+        assert_eq!(
+            executor
+                .resolve_terminal(
+                    Some(context.key()),
+                    RequestTerminal::Publish("cancelled-publish"),
+                )
+                .await,
+            RequestTerminalResolution::Cancelled
+        );
+        assert_eq!(
+            executor
+                .resolve_terminal(
+                    Some(context.key()),
+                    RequestTerminal::RespondWithoutPublish("late-observation"),
+                )
+                .await,
+            RequestTerminalResolution::Emit("late-observation")
+        );
+        assert_eq!(cleanup_count.load(Ordering::SeqCst), 1);
+    }
 
     #[tokio::test]
     async fn lifecycle_machine_owns_cancel_publish_complete_transitions() {


### PR DESCRIPTION
## Summary
- Added a shared `SurfaceRequestExecutor::resolve_terminal` path and `RequestTerminalResolution` so RPC, MCP, and REST no longer choose publish/cancel/complete winners locally.
- Moved RPC `session/create` initial-turn classification into shared `SurfaceRequestSemantics::for_rpc_request`.
- Removed the MCP-local tool semantics shim; MCP now calls the canonical classifier directly.

## Validation
- `./scripts/repo-cargo test -p meerkat surface::request_execution::tests --lib` (failed first under TDD, then passed after implementation)
- `./scripts/repo-cargo test -p meerkat-rpc server::tests --lib`
- `./scripts/repo-cargo test -p meerkat-mcp-server --bin rkat-mcp publish_completion_after_cancel_writes_cancel_response`
- `./scripts/repo-cargo test -p meerkat-mcp-server --bin rkat-mcp meerkat_run_and_resume_publish_on_success`
- `./scripts/repo-cargo test -p meerkat-rest publish_terminal_after_cancel --lib`
- `make check` (BuildBuddy invocation `510570a6-84b6-4bd9-b6da-e8e5a628467d`)
- `git diff --check`

## Intentionally Surface-Specific Behavior
- RPC still formats cancellation and lifecycle rejection as JSON-RPC errors with the original response id.
- MCP still formats cancellation and lifecycle rejection as JSON-RPC tool responses with the original request id value.
- REST still maps cancelled tracked requests to `REQUEST_CANCELLED` / HTTP 499 and lifecycle rejection to an internal API error.

Linear: LUC-107