### PR TITLE
Make flow projection persistence atomic

### DIFF
--- a/meerkat-mob/BUILD.bazel
+++ b/meerkat-mob/BUILD.bazel
@@ -41,7 +41,9 @@ rust_library(
     compile_data = [
         "Cargo.toml",
         "src/runtime/actor.rs",
+        "src/runtime/builder.rs",
         "src/runtime/flow_frame_engine.rs",
+        "src/runtime/recovery.rs",
     ],
     srcs = glob(["src/**/*.rs"]),
     visibility = ["//visibility:public"],
@@ -87,7 +89,9 @@ rust_test(
     compile_data = [
         "Cargo.toml",
         "src/runtime/actor.rs",
+        "src/runtime/builder.rs",
         "src/runtime/flow_frame_engine.rs",
+        "src/runtime/recovery.rs",
     ],
     srcs = glob(["src/**/*.rs"]),
     visibility = ["//visibility:public"],
@@ -150,7 +154,9 @@ rust_test(
     compile_data = [
         "Cargo.toml",
         "src/runtime/actor.rs",
+        "src/runtime/builder.rs",
         "src/runtime/flow_frame_engine.rs",
+        "src/runtime/recovery.rs",
     ],
     srcs = [
         "tests/dispatcher_rule_synthetic_injection.rs",
@@ -216,7 +222,9 @@ rust_test(
     compile_data = [
         "Cargo.toml",
         "src/runtime/actor.rs",
+        "src/runtime/builder.rs",
         "src/runtime/flow_frame_engine.rs",
+        "src/runtime/recovery.rs",
     ],
     srcs = [
         "tests/flow_frame_recovery_tests.rs",
@@ -280,7 +288,9 @@ rust_test(
     compile_data = [
         "Cargo.toml",
         "src/runtime/actor.rs",
+        "src/runtime/builder.rs",
         "src/runtime/flow_frame_engine.rs",
+        "src/runtime/recovery.rs",
     ],
     srcs = [
         "tests/member_session_bindings.rs",
@@ -344,7 +354,9 @@ rust_test(
     compile_data = [
         "Cargo.toml",
         "src/runtime/actor.rs",
+        "src/runtime/builder.rs",
         "src/runtime/flow_frame_engine.rs",
+        "src/runtime/recovery.rs",
     ],
     srcs = [
         "tests/mob_orchestrator_kernel.rs",
@@ -408,7 +420,9 @@ rust_test(
     compile_data = [
         "Cargo.toml",
         "src/runtime/actor.rs",
+        "src/runtime/builder.rs",
         "src/runtime/flow_frame_engine.rs",
+        "src/runtime/recovery.rs",
     ],
     srcs = [
         "tests/shadow_state_absent.rs",
@@ -472,7 +486,9 @@ rust_test(
     compile_data = [
         "Cargo.toml",
         "src/runtime/actor.rs",
+        "src/runtime/builder.rs",
         "src/runtime/flow_frame_engine.rs",
+        "src/runtime/recovery.rs",
     ],
     srcs = [
         "tests/smoke_mob_flow_runtime.rs",
@@ -536,7 +552,9 @@ rust_test(
     compile_data = [
         "Cargo.toml",
         "src/runtime/actor.rs",
+        "src/runtime/builder.rs",
         "src/runtime/flow_frame_engine.rs",
+        "src/runtime/recovery.rs",
     ],
     srcs = [
         "tests/smoke_mob_pictionary.rs",
@@ -600,7 +618,9 @@ rust_test(
     compile_data = [
         "Cargo.toml",
         "src/runtime/actor.rs",
+        "src/runtime/builder.rs",
         "src/runtime/flow_frame_engine.rs",
+        "src/runtime/recovery.rs",
     ],
     srcs = [
         "tests/smoke_mob_resume.rs",

--- a/meerkat-mob/src/machines/mob_machine.rs
+++ b/meerkat-mob/src/machines/mob_machine.rs
@@ -419,7 +419,19 @@ pub enum TaskStatus {
 }
 
 /// Dependency satisfaction mode for a step or frame node.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
+#[derive(
+    Debug,
+    Clone,
+    Copy,
+    PartialEq,
+    Eq,
+    PartialOrd,
+    Ord,
+    Hash,
+    Default,
+    serde::Serialize,
+    serde::Deserialize,
+)]
 pub enum DependencyMode {
     #[default]
     All,
@@ -427,7 +439,19 @@ pub enum DependencyMode {
 }
 
 /// Collection policy for a step's fan-out execution.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
+#[derive(
+    Debug,
+    Clone,
+    Copy,
+    PartialEq,
+    Eq,
+    PartialOrd,
+    Ord,
+    Hash,
+    Default,
+    serde::Serialize,
+    serde::Deserialize,
+)]
 pub enum CollectionPolicyKind {
     #[default]
     All,
@@ -436,7 +460,19 @@ pub enum CollectionPolicyKind {
 }
 
 /// Canonical flow-run lifecycle state once run-local semantics are absorbed.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
+#[derive(
+    Debug,
+    Clone,
+    Copy,
+    PartialEq,
+    Eq,
+    PartialOrd,
+    Ord,
+    Hash,
+    Default,
+    serde::Serialize,
+    serde::Deserialize,
+)]
 pub enum FlowRunStatus {
     #[default]
     Absent,
@@ -448,7 +484,19 @@ pub enum FlowRunStatus {
 }
 
 /// Canonical frame lifecycle state once frame-local semantics are absorbed.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
+#[derive(
+    Debug,
+    Clone,
+    Copy,
+    PartialEq,
+    Eq,
+    PartialOrd,
+    Ord,
+    Hash,
+    Default,
+    serde::Serialize,
+    serde::Deserialize,
+)]
 pub enum FrameStatus {
     #[default]
     Running,
@@ -458,7 +506,19 @@ pub enum FrameStatus {
 }
 
 /// Canonical loop lifecycle state once loop-local semantics are absorbed.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
+#[derive(
+    Debug,
+    Clone,
+    Copy,
+    PartialEq,
+    Eq,
+    PartialOrd,
+    Ord,
+    Hash,
+    Default,
+    serde::Serialize,
+    serde::Deserialize,
+)]
 pub enum LoopStatus {
     #[default]
     Running,
@@ -469,7 +529,19 @@ pub enum LoopStatus {
 }
 
 /// Canonical step execution status once run-local semantics are absorbed.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
+#[derive(
+    Debug,
+    Clone,
+    Copy,
+    PartialEq,
+    Eq,
+    PartialOrd,
+    Ord,
+    Hash,
+    Default,
+    serde::Serialize,
+    serde::Deserialize,
+)]
 pub enum StepRunStatus {
     #[default]
     Dispatched,
@@ -480,7 +552,19 @@ pub enum StepRunStatus {
 }
 
 /// Root-vs-body frame scope for a frame snapshot.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
+#[derive(
+    Debug,
+    Clone,
+    Copy,
+    PartialEq,
+    Eq,
+    PartialOrd,
+    Ord,
+    Hash,
+    Default,
+    serde::Serialize,
+    serde::Deserialize,
+)]
 pub enum FrameScope {
     #[default]
     Root,
@@ -488,7 +572,19 @@ pub enum FrameScope {
 }
 
 /// Flow node kind inside a frame DAG.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
+#[derive(
+    Debug,
+    Clone,
+    Copy,
+    PartialEq,
+    Eq,
+    PartialOrd,
+    Ord,
+    Hash,
+    Default,
+    serde::Serialize,
+    serde::Deserialize,
+)]
 pub enum FlowNodeKind {
     #[default]
     Step,
@@ -496,7 +592,19 @@ pub enum FlowNodeKind {
 }
 
 /// Per-node execution status within a frame.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
+#[derive(
+    Debug,
+    Clone,
+    Copy,
+    PartialEq,
+    Eq,
+    PartialOrd,
+    Ord,
+    Hash,
+    Default,
+    serde::Serialize,
+    serde::Deserialize,
+)]
 pub enum NodeRunStatus {
     Pending,
     #[default]
@@ -509,7 +617,19 @@ pub enum NodeRunStatus {
 }
 
 /// Loop-body/evaluate lifecycle stage for an active repeat-until node.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
+#[derive(
+    Debug,
+    Clone,
+    Copy,
+    PartialEq,
+    Eq,
+    PartialOrd,
+    Ord,
+    Hash,
+    Default,
+    serde::Serialize,
+    serde::Deserialize,
+)]
 pub enum LoopIterationStage {
     #[default]
     AwaitingBodyFrame,

--- a/meerkat-mob/src/run.rs
+++ b/meerkat-mob/src/run.rs
@@ -80,6 +80,7 @@ pub fn flow_projection_kernel_audit() -> &'static [FlowProjectionKernelAudit] {
 #[must_use]
 pub fn canonical_flow_authority_input_manifest() -> indexmap::IndexSet<&'static str> {
     [
+        MobMachineCatalogInput::RunFlow,
         MobMachineCatalogInput::CreateRunSeed,
         MobMachineCatalogInput::AuthorizeFlowRunReducerCommand,
         MobMachineCatalogInput::CreateFrameSeed,
@@ -632,6 +633,622 @@ impl MobMachineLoopIterationCommand {
         match self {
             Self::BodyFrameStarted(payload) => Some(&payload.frame_id),
             _ => None,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub enum FlowRunReducerCommandRecord {
+    CreateRun,
+    StartRun,
+    DispatchStep,
+    CompleteStep,
+    RecordStepOutput,
+    ConditionPassed,
+    ConditionRejected,
+    FailStep,
+    SkipStep,
+    ProjectFrameStepStatus,
+    CancelStep,
+    RegisterTargets,
+    RecordTargetSuccess,
+    RecordTargetTerminalFailure,
+    RecordTargetCanceled,
+    RecordTargetFailure,
+    RegisterReadyFrame,
+    PumpNodeScheduler,
+    RegisterPendingBodyFrame,
+    PumpFrameScheduler,
+    NodeExecutionReleased,
+    FrameTerminated,
+    TerminalizeCompleted,
+    TerminalizeFailed,
+    TerminalizeCanceled,
+}
+
+impl From<mob_dsl::FlowRunReducerCommandKind> for FlowRunReducerCommandRecord {
+    fn from(kind: mob_dsl::FlowRunReducerCommandKind) -> Self {
+        match kind {
+            mob_dsl::FlowRunReducerCommandKind::CreateRun => Self::CreateRun,
+            mob_dsl::FlowRunReducerCommandKind::StartRun => Self::StartRun,
+            mob_dsl::FlowRunReducerCommandKind::DispatchStep => Self::DispatchStep,
+            mob_dsl::FlowRunReducerCommandKind::CompleteStep => Self::CompleteStep,
+            mob_dsl::FlowRunReducerCommandKind::RecordStepOutput => Self::RecordStepOutput,
+            mob_dsl::FlowRunReducerCommandKind::ConditionPassed => Self::ConditionPassed,
+            mob_dsl::FlowRunReducerCommandKind::ConditionRejected => Self::ConditionRejected,
+            mob_dsl::FlowRunReducerCommandKind::FailStep => Self::FailStep,
+            mob_dsl::FlowRunReducerCommandKind::SkipStep => Self::SkipStep,
+            mob_dsl::FlowRunReducerCommandKind::ProjectFrameStepStatus => {
+                Self::ProjectFrameStepStatus
+            }
+            mob_dsl::FlowRunReducerCommandKind::CancelStep => Self::CancelStep,
+            mob_dsl::FlowRunReducerCommandKind::RegisterTargets => Self::RegisterTargets,
+            mob_dsl::FlowRunReducerCommandKind::RecordTargetSuccess => Self::RecordTargetSuccess,
+            mob_dsl::FlowRunReducerCommandKind::RecordTargetTerminalFailure => {
+                Self::RecordTargetTerminalFailure
+            }
+            mob_dsl::FlowRunReducerCommandKind::RecordTargetCanceled => Self::RecordTargetCanceled,
+            mob_dsl::FlowRunReducerCommandKind::RecordTargetFailure => Self::RecordTargetFailure,
+            mob_dsl::FlowRunReducerCommandKind::RegisterReadyFrame => Self::RegisterReadyFrame,
+            mob_dsl::FlowRunReducerCommandKind::PumpNodeScheduler => Self::PumpNodeScheduler,
+            mob_dsl::FlowRunReducerCommandKind::RegisterPendingBodyFrame => {
+                Self::RegisterPendingBodyFrame
+            }
+            mob_dsl::FlowRunReducerCommandKind::PumpFrameScheduler => Self::PumpFrameScheduler,
+            mob_dsl::FlowRunReducerCommandKind::NodeExecutionReleased => {
+                Self::NodeExecutionReleased
+            }
+            mob_dsl::FlowRunReducerCommandKind::FrameTerminated => Self::FrameTerminated,
+            mob_dsl::FlowRunReducerCommandKind::TerminalizeCompleted => Self::TerminalizeCompleted,
+            mob_dsl::FlowRunReducerCommandKind::TerminalizeFailed => Self::TerminalizeFailed,
+            mob_dsl::FlowRunReducerCommandKind::TerminalizeCanceled => Self::TerminalizeCanceled,
+        }
+    }
+}
+
+impl From<FlowRunReducerCommandRecord> for mob_dsl::FlowRunReducerCommandKind {
+    fn from(kind: FlowRunReducerCommandRecord) -> Self {
+        match kind {
+            FlowRunReducerCommandRecord::CreateRun => Self::CreateRun,
+            FlowRunReducerCommandRecord::StartRun => Self::StartRun,
+            FlowRunReducerCommandRecord::DispatchStep => Self::DispatchStep,
+            FlowRunReducerCommandRecord::CompleteStep => Self::CompleteStep,
+            FlowRunReducerCommandRecord::RecordStepOutput => Self::RecordStepOutput,
+            FlowRunReducerCommandRecord::ConditionPassed => Self::ConditionPassed,
+            FlowRunReducerCommandRecord::ConditionRejected => Self::ConditionRejected,
+            FlowRunReducerCommandRecord::FailStep => Self::FailStep,
+            FlowRunReducerCommandRecord::SkipStep => Self::SkipStep,
+            FlowRunReducerCommandRecord::ProjectFrameStepStatus => Self::ProjectFrameStepStatus,
+            FlowRunReducerCommandRecord::CancelStep => Self::CancelStep,
+            FlowRunReducerCommandRecord::RegisterTargets => Self::RegisterTargets,
+            FlowRunReducerCommandRecord::RecordTargetSuccess => Self::RecordTargetSuccess,
+            FlowRunReducerCommandRecord::RecordTargetTerminalFailure => {
+                Self::RecordTargetTerminalFailure
+            }
+            FlowRunReducerCommandRecord::RecordTargetCanceled => Self::RecordTargetCanceled,
+            FlowRunReducerCommandRecord::RecordTargetFailure => Self::RecordTargetFailure,
+            FlowRunReducerCommandRecord::RegisterReadyFrame => Self::RegisterReadyFrame,
+            FlowRunReducerCommandRecord::PumpNodeScheduler => Self::PumpNodeScheduler,
+            FlowRunReducerCommandRecord::RegisterPendingBodyFrame => Self::RegisterPendingBodyFrame,
+            FlowRunReducerCommandRecord::PumpFrameScheduler => Self::PumpFrameScheduler,
+            FlowRunReducerCommandRecord::NodeExecutionReleased => Self::NodeExecutionReleased,
+            FlowRunReducerCommandRecord::FrameTerminated => Self::FrameTerminated,
+            FlowRunReducerCommandRecord::TerminalizeCompleted => Self::TerminalizeCompleted,
+            FlowRunReducerCommandRecord::TerminalizeFailed => Self::TerminalizeFailed,
+            FlowRunReducerCommandRecord::TerminalizeCanceled => Self::TerminalizeCanceled,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub enum FlowFrameReducerCommandRecord {
+    StartRootFrame,
+    StartBodyFrame,
+    AdmitNextReadyNode,
+    CompleteNode,
+    RecordNodeOutput,
+    FailNode,
+    SkipNode,
+    CancelNode,
+    SealFrame,
+}
+
+impl From<mob_dsl::FlowFrameReducerCommandKind> for FlowFrameReducerCommandRecord {
+    fn from(kind: mob_dsl::FlowFrameReducerCommandKind) -> Self {
+        match kind {
+            mob_dsl::FlowFrameReducerCommandKind::StartRootFrame => Self::StartRootFrame,
+            mob_dsl::FlowFrameReducerCommandKind::StartBodyFrame => Self::StartBodyFrame,
+            mob_dsl::FlowFrameReducerCommandKind::AdmitNextReadyNode => Self::AdmitNextReadyNode,
+            mob_dsl::FlowFrameReducerCommandKind::CompleteNode => Self::CompleteNode,
+            mob_dsl::FlowFrameReducerCommandKind::RecordNodeOutput => Self::RecordNodeOutput,
+            mob_dsl::FlowFrameReducerCommandKind::FailNode => Self::FailNode,
+            mob_dsl::FlowFrameReducerCommandKind::SkipNode => Self::SkipNode,
+            mob_dsl::FlowFrameReducerCommandKind::CancelNode => Self::CancelNode,
+            mob_dsl::FlowFrameReducerCommandKind::SealFrame => Self::SealFrame,
+        }
+    }
+}
+
+impl From<FlowFrameReducerCommandRecord> for mob_dsl::FlowFrameReducerCommandKind {
+    fn from(kind: FlowFrameReducerCommandRecord) -> Self {
+        match kind {
+            FlowFrameReducerCommandRecord::StartRootFrame => Self::StartRootFrame,
+            FlowFrameReducerCommandRecord::StartBodyFrame => Self::StartBodyFrame,
+            FlowFrameReducerCommandRecord::AdmitNextReadyNode => Self::AdmitNextReadyNode,
+            FlowFrameReducerCommandRecord::CompleteNode => Self::CompleteNode,
+            FlowFrameReducerCommandRecord::RecordNodeOutput => Self::RecordNodeOutput,
+            FlowFrameReducerCommandRecord::FailNode => Self::FailNode,
+            FlowFrameReducerCommandRecord::SkipNode => Self::SkipNode,
+            FlowFrameReducerCommandRecord::CancelNode => Self::CancelNode,
+            FlowFrameReducerCommandRecord::SealFrame => Self::SealFrame,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub enum LoopIterationReducerCommandRecord {
+    StartLoop,
+    BodyFrameStarted,
+    BodyFrameCompleted,
+    BodyFrameFailed,
+    BodyFrameCanceled,
+    UntilConditionMet,
+    UntilConditionFailed,
+    CancelLoop,
+}
+
+impl From<mob_dsl::LoopIterationReducerCommandKind> for LoopIterationReducerCommandRecord {
+    fn from(kind: mob_dsl::LoopIterationReducerCommandKind) -> Self {
+        match kind {
+            mob_dsl::LoopIterationReducerCommandKind::StartLoop => Self::StartLoop,
+            mob_dsl::LoopIterationReducerCommandKind::BodyFrameStarted => Self::BodyFrameStarted,
+            mob_dsl::LoopIterationReducerCommandKind::BodyFrameCompleted => {
+                Self::BodyFrameCompleted
+            }
+            mob_dsl::LoopIterationReducerCommandKind::BodyFrameFailed => Self::BodyFrameFailed,
+            mob_dsl::LoopIterationReducerCommandKind::BodyFrameCanceled => Self::BodyFrameCanceled,
+            mob_dsl::LoopIterationReducerCommandKind::UntilConditionMet => Self::UntilConditionMet,
+            mob_dsl::LoopIterationReducerCommandKind::UntilConditionFailed => {
+                Self::UntilConditionFailed
+            }
+            mob_dsl::LoopIterationReducerCommandKind::CancelLoop => Self::CancelLoop,
+        }
+    }
+}
+
+impl From<LoopIterationReducerCommandRecord> for mob_dsl::LoopIterationReducerCommandKind {
+    fn from(kind: LoopIterationReducerCommandRecord) -> Self {
+        match kind {
+            LoopIterationReducerCommandRecord::StartLoop => Self::StartLoop,
+            LoopIterationReducerCommandRecord::BodyFrameStarted => Self::BodyFrameStarted,
+            LoopIterationReducerCommandRecord::BodyFrameCompleted => Self::BodyFrameCompleted,
+            LoopIterationReducerCommandRecord::BodyFrameFailed => Self::BodyFrameFailed,
+            LoopIterationReducerCommandRecord::BodyFrameCanceled => Self::BodyFrameCanceled,
+            LoopIterationReducerCommandRecord::UntilConditionMet => Self::UntilConditionMet,
+            LoopIterationReducerCommandRecord::UntilConditionFailed => Self::UntilConditionFailed,
+            LoopIterationReducerCommandRecord::CancelLoop => Self::CancelLoop,
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct FlowRunSeedAuthorityRecord {
+    pub run_id: mob_dsl::RunId,
+    pub step_ids: BTreeSet<mob_dsl::StepId>,
+    pub ordered_steps: Vec<mob_dsl::StepId>,
+    pub step_has_conditions: BTreeMap<mob_dsl::StepId, bool>,
+    pub step_dependencies: BTreeMap<mob_dsl::StepId, Vec<mob_dsl::StepId>>,
+    pub step_dependency_modes: BTreeMap<mob_dsl::StepId, mob_dsl::DependencyMode>,
+    pub step_branches: BTreeMap<mob_dsl::StepId, Option<mob_dsl::BranchId>>,
+    pub step_collection_policies: BTreeMap<mob_dsl::StepId, mob_dsl::CollectionPolicyKind>,
+    pub step_quorum_thresholds: BTreeMap<mob_dsl::StepId, u32>,
+    pub escalation_threshold: u32,
+    pub max_step_retries: u32,
+    pub max_active_nodes: u64,
+    pub max_active_frames: u64,
+    pub max_frame_depth: u64,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct FlowFrameSeedAuthorityRecord {
+    pub run_id: mob_dsl::RunId,
+    pub frame_id: mob_dsl::FrameId,
+    pub frame_scope: mob_dsl::FrameScope,
+    pub loop_instance_id: Option<mob_dsl::LoopInstanceId>,
+    pub iteration: u32,
+    pub tracked_nodes: BTreeSet<mob_dsl::FlowNodeId>,
+    pub ordered_nodes: Vec<mob_dsl::FlowNodeId>,
+    pub node_kind: BTreeMap<mob_dsl::FlowNodeId, mob_dsl::FlowNodeKind>,
+    pub node_dependencies: BTreeMap<mob_dsl::FlowNodeId, Vec<mob_dsl::FlowNodeId>>,
+    pub node_dependency_modes: BTreeMap<mob_dsl::FlowNodeId, mob_dsl::DependencyMode>,
+    pub node_branches: BTreeMap<mob_dsl::FlowNodeId, Option<mob_dsl::BranchId>>,
+    pub node_step_ids: BTreeMap<mob_dsl::FlowNodeId, mob_dsl::StepId>,
+    pub node_loop_ids: BTreeMap<mob_dsl::FlowNodeId, mob_dsl::LoopId>,
+    pub node_status: BTreeMap<mob_dsl::FlowNodeId, mob_dsl::NodeRunStatus>,
+    pub ready_queue: Vec<mob_dsl::FlowNodeId>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "input", content = "payload")]
+pub enum FlowAuthorityInputRecord {
+    RunFlow(FlowRunSeedAuthorityRecord),
+    CreateRunSeed(FlowRunSeedAuthorityRecord),
+    AuthorizeFlowRunReducerCommand {
+        run_id: mob_dsl::RunId,
+        command: FlowRunReducerCommandRecord,
+        step_id: Option<mob_dsl::StepId>,
+        run_step_key: Option<mob_dsl::RunStepKey>,
+        step_status: Option<mob_dsl::StepRunStatus>,
+        target_count: Option<u64>,
+        frame_id: Option<mob_dsl::FrameId>,
+        node_id: Option<mob_dsl::FlowNodeId>,
+        loop_instance_id: Option<mob_dsl::LoopInstanceId>,
+        retry_key: Option<String>,
+    },
+    CreateFrameSeed(FlowFrameSeedAuthorityRecord),
+    AuthorizeFlowFrameReducerCommand {
+        frame_id: mob_dsl::FrameId,
+        command: FlowFrameReducerCommandRecord,
+        node_id: Option<mob_dsl::FlowNodeId>,
+        frame_node_key: Option<mob_dsl::FrameNodeKey>,
+        node_status: Option<mob_dsl::NodeRunStatus>,
+        terminal_status: Option<mob_dsl::FrameStatus>,
+    },
+    CreateLoopSeed {
+        loop_instance_id: mob_dsl::LoopInstanceId,
+        parent_frame_id: mob_dsl::FrameId,
+        parent_node_id: mob_dsl::FlowNodeId,
+        loop_id: mob_dsl::LoopId,
+        depth: u32,
+        max_iterations: u64,
+    },
+    RecordLoopBodyFrameCompleted {
+        loop_instance_id: mob_dsl::LoopInstanceId,
+        iteration: u64,
+    },
+    RecordLoopUntilConditionMet {
+        loop_instance_id: mob_dsl::LoopInstanceId,
+        iteration: u64,
+    },
+    RecordLoopUntilConditionFailed {
+        loop_instance_id: mob_dsl::LoopInstanceId,
+        iteration: u64,
+    },
+    AuthorizeLoopIterationReducerCommand {
+        loop_instance_id: mob_dsl::LoopInstanceId,
+        command: LoopIterationReducerCommandRecord,
+        body_frame_id: Option<mob_dsl::FrameId>,
+        body_frame_iteration: Option<u64>,
+    },
+}
+
+impl FlowAuthorityInputRecord {
+    pub(crate) fn from_machine_input(input: mob_dsl::MobMachineInput) -> Result<Self, MobError> {
+        Ok(match input {
+            mob_dsl::MobMachineInput::RunFlow {
+                run_id,
+                step_ids,
+                ordered_steps,
+                step_has_conditions,
+                step_dependencies,
+                step_dependency_modes,
+                step_branches,
+                step_collection_policies,
+                step_quorum_thresholds,
+                escalation_threshold,
+                max_step_retries,
+                max_active_nodes,
+                max_active_frames,
+                max_frame_depth,
+            } => Self::RunFlow(FlowRunSeedAuthorityRecord {
+                run_id,
+                step_ids,
+                ordered_steps,
+                step_has_conditions,
+                step_dependencies,
+                step_dependency_modes,
+                step_branches,
+                step_collection_policies,
+                step_quorum_thresholds,
+                escalation_threshold,
+                max_step_retries,
+                max_active_nodes,
+                max_active_frames,
+                max_frame_depth,
+            }),
+            mob_dsl::MobMachineInput::CreateRunSeed {
+                run_id,
+                step_ids,
+                ordered_steps,
+                step_has_conditions,
+                step_dependencies,
+                step_dependency_modes,
+                step_branches,
+                step_collection_policies,
+                step_quorum_thresholds,
+                escalation_threshold,
+                max_step_retries,
+                max_active_nodes,
+                max_active_frames,
+                max_frame_depth,
+            } => Self::CreateRunSeed(FlowRunSeedAuthorityRecord {
+                run_id,
+                step_ids,
+                ordered_steps,
+                step_has_conditions,
+                step_dependencies,
+                step_dependency_modes,
+                step_branches,
+                step_collection_policies,
+                step_quorum_thresholds,
+                escalation_threshold,
+                max_step_retries,
+                max_active_nodes,
+                max_active_frames,
+                max_frame_depth,
+            }),
+            mob_dsl::MobMachineInput::AuthorizeFlowRunReducerCommand {
+                run_id,
+                command,
+                step_id,
+                run_step_key,
+                step_status,
+                target_count,
+                frame_id,
+                node_id,
+                loop_instance_id,
+                retry_key,
+            } => Self::AuthorizeFlowRunReducerCommand {
+                run_id,
+                command: command.into(),
+                step_id,
+                run_step_key,
+                step_status,
+                target_count,
+                frame_id,
+                node_id,
+                loop_instance_id,
+                retry_key,
+            },
+            mob_dsl::MobMachineInput::CreateFrameSeed {
+                run_id,
+                frame_id,
+                frame_scope,
+                loop_instance_id,
+                iteration,
+                tracked_nodes,
+                ordered_nodes,
+                node_kind,
+                node_dependencies,
+                node_dependency_modes,
+                node_branches,
+                node_step_ids,
+                node_loop_ids,
+                node_status,
+                ready_queue,
+            } => Self::CreateFrameSeed(FlowFrameSeedAuthorityRecord {
+                run_id,
+                frame_id,
+                frame_scope,
+                loop_instance_id,
+                iteration,
+                tracked_nodes,
+                ordered_nodes,
+                node_kind,
+                node_dependencies,
+                node_dependency_modes,
+                node_branches,
+                node_step_ids,
+                node_loop_ids,
+                node_status,
+                ready_queue,
+            }),
+            mob_dsl::MobMachineInput::AuthorizeFlowFrameReducerCommand {
+                frame_id,
+                command,
+                node_id,
+                frame_node_key,
+                node_status,
+                terminal_status,
+            } => Self::AuthorizeFlowFrameReducerCommand {
+                frame_id,
+                command: command.into(),
+                node_id,
+                frame_node_key,
+                node_status,
+                terminal_status,
+            },
+            mob_dsl::MobMachineInput::CreateLoopSeed {
+                loop_instance_id,
+                parent_frame_id,
+                parent_node_id,
+                loop_id,
+                depth,
+                max_iterations,
+            } => Self::CreateLoopSeed {
+                loop_instance_id,
+                parent_frame_id,
+                parent_node_id,
+                loop_id,
+                depth,
+                max_iterations,
+            },
+            mob_dsl::MobMachineInput::RecordLoopBodyFrameCompleted {
+                loop_instance_id,
+                iteration,
+            } => Self::RecordLoopBodyFrameCompleted {
+                loop_instance_id,
+                iteration,
+            },
+            mob_dsl::MobMachineInput::RecordLoopUntilConditionMet {
+                loop_instance_id,
+                iteration,
+            } => Self::RecordLoopUntilConditionMet {
+                loop_instance_id,
+                iteration,
+            },
+            mob_dsl::MobMachineInput::RecordLoopUntilConditionFailed {
+                loop_instance_id,
+                iteration,
+            } => Self::RecordLoopUntilConditionFailed {
+                loop_instance_id,
+                iteration,
+            },
+            mob_dsl::MobMachineInput::AuthorizeLoopIterationReducerCommand {
+                loop_instance_id,
+                command,
+                body_frame_id,
+                body_frame_iteration,
+            } => Self::AuthorizeLoopIterationReducerCommand {
+                loop_instance_id,
+                command: command.into(),
+                body_frame_id,
+                body_frame_iteration,
+            },
+            other => {
+                return Err(MobError::Internal(format!(
+                    "MobMachine input {other:?} is not a flow authority input"
+                )));
+            }
+        })
+    }
+
+    pub(crate) fn to_machine_input(&self) -> mob_dsl::MobMachineInput {
+        match self.clone() {
+            Self::RunFlow(record) => mob_dsl::MobMachineInput::RunFlow {
+                run_id: record.run_id,
+                step_ids: record.step_ids,
+                ordered_steps: record.ordered_steps,
+                step_has_conditions: record.step_has_conditions,
+                step_dependencies: record.step_dependencies,
+                step_dependency_modes: record.step_dependency_modes,
+                step_branches: record.step_branches,
+                step_collection_policies: record.step_collection_policies,
+                step_quorum_thresholds: record.step_quorum_thresholds,
+                escalation_threshold: record.escalation_threshold,
+                max_step_retries: record.max_step_retries,
+                max_active_nodes: record.max_active_nodes,
+                max_active_frames: record.max_active_frames,
+                max_frame_depth: record.max_frame_depth,
+            },
+            Self::CreateRunSeed(record) => mob_dsl::MobMachineInput::CreateRunSeed {
+                run_id: record.run_id,
+                step_ids: record.step_ids,
+                ordered_steps: record.ordered_steps,
+                step_has_conditions: record.step_has_conditions,
+                step_dependencies: record.step_dependencies,
+                step_dependency_modes: record.step_dependency_modes,
+                step_branches: record.step_branches,
+                step_collection_policies: record.step_collection_policies,
+                step_quorum_thresholds: record.step_quorum_thresholds,
+                escalation_threshold: record.escalation_threshold,
+                max_step_retries: record.max_step_retries,
+                max_active_nodes: record.max_active_nodes,
+                max_active_frames: record.max_active_frames,
+                max_frame_depth: record.max_frame_depth,
+            },
+            Self::AuthorizeFlowRunReducerCommand {
+                run_id,
+                command,
+                step_id,
+                run_step_key,
+                step_status,
+                target_count,
+                frame_id,
+                node_id,
+                loop_instance_id,
+                retry_key,
+            } => mob_dsl::MobMachineInput::AuthorizeFlowRunReducerCommand {
+                run_id,
+                command: command.into(),
+                step_id,
+                run_step_key,
+                step_status,
+                target_count,
+                frame_id,
+                node_id,
+                loop_instance_id,
+                retry_key,
+            },
+            Self::CreateFrameSeed(record) => mob_dsl::MobMachineInput::CreateFrameSeed {
+                run_id: record.run_id,
+                frame_id: record.frame_id,
+                frame_scope: record.frame_scope,
+                loop_instance_id: record.loop_instance_id,
+                iteration: record.iteration,
+                tracked_nodes: record.tracked_nodes,
+                ordered_nodes: record.ordered_nodes,
+                node_kind: record.node_kind,
+                node_dependencies: record.node_dependencies,
+                node_dependency_modes: record.node_dependency_modes,
+                node_branches: record.node_branches,
+                node_step_ids: record.node_step_ids,
+                node_loop_ids: record.node_loop_ids,
+                node_status: record.node_status,
+                ready_queue: record.ready_queue,
+            },
+            Self::AuthorizeFlowFrameReducerCommand {
+                frame_id,
+                command,
+                node_id,
+                frame_node_key,
+                node_status,
+                terminal_status,
+            } => mob_dsl::MobMachineInput::AuthorizeFlowFrameReducerCommand {
+                frame_id,
+                command: command.into(),
+                node_id,
+                frame_node_key,
+                node_status,
+                terminal_status,
+            },
+            Self::CreateLoopSeed {
+                loop_instance_id,
+                parent_frame_id,
+                parent_node_id,
+                loop_id,
+                depth,
+                max_iterations,
+            } => mob_dsl::MobMachineInput::CreateLoopSeed {
+                loop_instance_id,
+                parent_frame_id,
+                parent_node_id,
+                loop_id,
+                depth,
+                max_iterations,
+            },
+            Self::RecordLoopBodyFrameCompleted {
+                loop_instance_id,
+                iteration,
+            } => mob_dsl::MobMachineInput::RecordLoopBodyFrameCompleted {
+                loop_instance_id,
+                iteration,
+            },
+            Self::RecordLoopUntilConditionMet {
+                loop_instance_id,
+                iteration,
+            } => mob_dsl::MobMachineInput::RecordLoopUntilConditionMet {
+                loop_instance_id,
+                iteration,
+            },
+            Self::RecordLoopUntilConditionFailed {
+                loop_instance_id,
+                iteration,
+            } => mob_dsl::MobMachineInput::RecordLoopUntilConditionFailed {
+                loop_instance_id,
+                iteration,
+            },
+            Self::AuthorizeLoopIterationReducerCommand {
+                loop_instance_id,
+                command,
+                body_frame_id,
+                body_frame_iteration,
+            } => mob_dsl::MobMachineInput::AuthorizeLoopIterationReducerCommand {
+                loop_instance_id,
+                command: command.into(),
+                body_frame_id,
+                body_frame_iteration,
+            },
         }
     }
 }
@@ -2826,6 +3443,10 @@ pub struct MobRun {
     /// in stable key order without depending on insertion order.
     #[serde(default)]
     pub loop_iteration_outputs: BTreeMap<LoopId, Vec<IndexMap<StepId, serde_json::Value>>>,
+    /// Accepted MobMachine flow-authority inputs persisted in the same atomic
+    /// store operation as the derived run/frame/loop projection they authorize.
+    #[serde(default)]
+    pub flow_authority_inputs: Vec<FlowAuthorityInputRecord>,
 }
 
 impl MobRun {
@@ -2997,10 +3618,100 @@ impl MobRun {
             frames: BTreeMap::new(),
             loops: BTreeMap::new(),
             loop_iteration_ledger: Vec::new(),
-            schema_version: 5,
+            schema_version: 6,
             root_step_outputs: IndexMap::new(),
             loop_iteration_outputs: BTreeMap::new(),
+            flow_authority_inputs: Vec::new(),
         }
+    }
+
+    pub(crate) fn append_flow_authority_inputs(
+        &mut self,
+        inputs: impl IntoIterator<Item = mob_dsl::MobMachineInput>,
+    ) -> Result<(), MobError> {
+        let records = inputs
+            .into_iter()
+            .map(FlowAuthorityInputRecord::from_machine_input)
+            .collect::<Result<Vec<_>, _>>()?;
+        self.flow_authority_inputs.extend(records);
+        Ok(())
+    }
+
+    pub(crate) fn replay_flow_authority_inputs_into(
+        authority: &mut mob_dsl::MobMachineAuthority,
+        inputs: &[FlowAuthorityInputRecord],
+        context: &str,
+    ) -> Result<(), MobError> {
+        for record in inputs {
+            let input = record.to_machine_input();
+            let input_debug = format!("{input:?}");
+            let transition = mob_dsl::MobMachineMutator::apply(authority, input).map_err(
+                |error| {
+                    MobError::Internal(format!(
+                        "MobMachine flow authority replay ({context}) rejected {input_debug}: {error}"
+                    ))
+                },
+            )?;
+            if transition.from_phase != transition.to_phase {
+                authority.state.lifecycle_phase = transition.to_phase;
+            }
+        }
+        Ok(())
+    }
+
+    pub(crate) fn validate_flow_authority_projection(&self) -> Result<(), MobError> {
+        if self.flow_authority_inputs.is_empty() {
+            return Ok(());
+        }
+
+        let mut authority = mob_dsl::MobMachineAuthority::new();
+        authority.state.lifecycle_phase = mob_dsl::MobPhase::Running;
+        Self::replay_flow_authority_inputs_into(
+            &mut authority,
+            &self.flow_authority_inputs,
+            "recovery_validate_run_projection",
+        )?;
+
+        let projected_flow_state =
+            project_flow_run_state_from_machine(&authority.state, &self.run_id)?;
+        if projected_flow_state != self.flow_state {
+            return Err(MobError::Internal(format!(
+                "flow authority log projection mismatch for run '{}': flow_state diverged",
+                self.run_id
+            )));
+        }
+
+        let projected_status = mob_run_status_from_flow_phase(projected_flow_state.phase);
+        if projected_status != self.status {
+            return Err(MobError::Internal(format!(
+                "flow authority log projection mismatch for run '{}': status {:?} != {:?}",
+                self.run_id, self.status, projected_status
+            )));
+        }
+
+        for (frame_id, snapshot) in &self.frames {
+            let projected =
+                project_flow_frame_authority_state_from_machine(&authority.state, frame_id)?;
+            if projected != snapshot.kernel_state {
+                return Err(MobError::Internal(format!(
+                    "flow authority log projection mismatch for run '{}': frame '{}' diverged",
+                    self.run_id, frame_id
+                )));
+            }
+        }
+
+        for (loop_instance_id, snapshot) in &self.loops {
+            let projected =
+                project_loop_iteration_state_from_machine(&authority.state, loop_instance_id)?;
+            if projected != snapshot.kernel_state {
+                return Err(MobError::Internal(format!(
+                    "flow authority log projection mismatch for run '{}': loop '{}' diverged",
+                    self.run_id, loop_instance_id
+                )));
+            }
+        }
+
+        Ok(())
     }
 
     #[cfg(test)]
@@ -3372,6 +4083,16 @@ impl MobRun {
         mob_dsl::MobMachineMutator::apply(&mut authority, seed_input)
             .map_err(|error| MobError::Internal(format!("test CreateRunSeed rejected: {error}")))?;
         Self::flow_state_for_config_with_authority(&run_id, &config, &authority.state)
+    }
+}
+
+fn mob_run_status_from_flow_phase(phase: flow_run::Phase) -> MobRunStatus {
+    match phase {
+        flow_run::Phase::Absent | flow_run::Phase::Pending => MobRunStatus::Pending,
+        flow_run::Phase::Running => MobRunStatus::Running,
+        flow_run::Phase::Completed => MobRunStatus::Completed,
+        flow_run::Phase::Failed => MobRunStatus::Failed,
+        flow_run::Phase::Canceled => MobRunStatus::Canceled,
     }
 }
 
@@ -4147,6 +4868,7 @@ mod tests {
             schema_version: 4,
             root_step_outputs: IndexMap::new(),
             loop_iteration_outputs: BTreeMap::new(),
+            flow_authority_inputs: Vec::new(),
         };
 
         let encoded = serde_json::to_string(&run).unwrap();

--- a/meerkat-mob/src/run.rs
+++ b/meerkat-mob/src/run.rs
@@ -3689,6 +3689,22 @@ impl MobRun {
             )));
         }
 
+        let run_key = mob_dsl::RunId::from(self.run_id.to_string());
+        let projected_frame_ids = authority
+            .state
+            .frame_run
+            .iter()
+            .filter(|(_, frame_run_id)| *frame_run_id == &run_key)
+            .map(|(frame_id, _)| project_frame_id(frame_id))
+            .collect::<BTreeSet<_>>();
+        let persisted_frame_ids = self.frames.keys().cloned().collect::<BTreeSet<_>>();
+        if projected_frame_ids != persisted_frame_ids {
+            return Err(MobError::Internal(format!(
+                "flow authority log projection mismatch for run '{}': frame keyset diverged",
+                self.run_id
+            )));
+        }
+
         for (frame_id, snapshot) in &self.frames {
             let projected =
                 project_flow_frame_authority_state_from_machine(&authority.state, frame_id)?;
@@ -3698,6 +3714,28 @@ impl MobRun {
                     self.run_id, frame_id
                 )));
             }
+        }
+
+        let projected_loop_ids = authority
+            .state
+            .loop_phase
+            .keys()
+            .filter(|loop_instance_id| {
+                authority
+                    .state
+                    .loop_parent_frame
+                    .get(*loop_instance_id)
+                    .and_then(|frame_id| authority.state.frame_run.get(frame_id))
+                    == Some(&run_key)
+            })
+            .map(project_loop_instance_id)
+            .collect::<BTreeSet<_>>();
+        let persisted_loop_ids = self.loops.keys().cloned().collect::<BTreeSet<_>>();
+        if projected_loop_ids != persisted_loop_ids {
+            return Err(MobError::Internal(format!(
+                "flow authority log projection mismatch for run '{}': loop keyset diverged",
+                self.run_id
+            )));
         }
 
         for (loop_instance_id, snapshot) in &self.loops {

--- a/meerkat-mob/src/runtime/actor.rs
+++ b/meerkat-mob/src/runtime/actor.rs
@@ -8981,13 +8981,14 @@ impl MobActor {
         let run_flow = MobRun::run_flow_input(&run_id, &config)?;
         debug_assert!(matches!(run_flow, mob_dsl::MobMachineInput::RunFlow { .. }));
         let prepared_run_flow = self
-            .prepare_dsl_input(run_flow, "run_flow")
+            .prepare_dsl_input(run_flow.clone(), "run_flow")
             .map_err(|_| self.invalid_transition_to(MobState::Running))?;
         self.create_pending_run(
             run_id.clone(),
             &config,
             &prepared_run_flow.authority.state,
             activation_params.clone(),
+            vec![run_flow],
         )
         .await
         .inspect_err(|error| {
@@ -9141,16 +9142,18 @@ impl MobActor {
         config: &FlowRunConfig,
         machine_state: &mob_dsl::MobMachineState,
         activation_params: serde_json::Value,
+        authority_inputs: Vec<mob_dsl::MobMachineInput>,
     ) -> Result<RunId, MobError> {
         let flow_state =
             MobRun::flow_state_for_config_with_authority(&run_id, config, machine_state)?;
-        let run = MobRun::pending_with_run_id(
+        let mut run = MobRun::pending_with_run_id(
             run_id.clone(),
             self.definition.id.clone(),
             config.flow_id.clone(),
             flow_state,
             activation_params,
         );
+        run.append_flow_authority_inputs(authority_inputs)?;
         self.run_store.create_run(run).await?;
         Ok(run_id)
     }
@@ -9392,6 +9395,7 @@ impl MobActor {
         }
         let prepared =
             self.prepare_dsl_inputs(plan.machine_inputs(), "flow_frame_loop_store_plan")?;
+        let authority_inputs = plan.machine_inputs().to_vec();
         let won = match &plan {
             FlowFrameLoopStorePlan::InsertFrame {
                 frame_id,
@@ -9399,7 +9403,13 @@ impl MobActor {
                 ..
             } => self
                 .run_store
-                .cas_frame_state(run_id, frame_id, None, initial_frame.clone())
+                .cas_frame_state_with_authority(
+                    run_id,
+                    frame_id,
+                    None,
+                    initial_frame.clone(),
+                    authority_inputs,
+                )
                 .await
                 .map_err(MobError::from)?,
             FlowFrameLoopStorePlan::FrameState {
@@ -9409,7 +9419,13 @@ impl MobActor {
                 ..
             } => self
                 .run_store
-                .cas_frame_state(run_id, frame_id, Some(expected_frame), next_frame.clone())
+                .cas_frame_state_with_authority(
+                    run_id,
+                    frame_id,
+                    Some(expected_frame),
+                    next_frame.clone(),
+                    authority_inputs,
+                )
                 .await
                 .map_err(MobError::from)?,
             FlowFrameLoopStorePlan::CompleteStepAndRecordOutput {
@@ -9422,7 +9438,7 @@ impl MobActor {
                 ..
             } => self
                 .run_store
-                .cas_complete_step_and_record_output(
+                .cas_complete_step_and_record_output_with_authority(
                     run_id,
                     frame_id,
                     expected_frame,
@@ -9432,6 +9448,7 @@ impl MobActor {
                     loop_context
                         .as_ref()
                         .map(|(loop_id, iteration)| (loop_id, *iteration)),
+                    authority_inputs,
                 )
                 .await
                 .map_err(MobError::from)?,
@@ -9444,13 +9461,14 @@ impl MobActor {
                 ..
             } => self
                 .run_store
-                .cas_grant_node_slot(
+                .cas_grant_node_slot_with_authority(
                     run_id,
                     expected_run_state,
                     next_run_state.clone(),
                     frame_id,
                     expected_frame,
                     next_frame.clone(),
+                    authority_inputs,
                 )
                 .await
                 .map_err(MobError::from)?,
@@ -9465,7 +9483,7 @@ impl MobActor {
                 ..
             } => self
                 .run_store
-                .cas_start_loop(
+                .cas_start_loop_with_authority(
                     run_id,
                     loop_instance_id,
                     expected_run_state,
@@ -9474,6 +9492,7 @@ impl MobActor {
                     expected_frame,
                     next_frame.clone(),
                     initial_loop.clone(),
+                    authority_inputs,
                 )
                 .await
                 .map_err(MobError::from)?,
@@ -9489,7 +9508,7 @@ impl MobActor {
                 ..
             } => self
                 .run_store
-                .cas_grant_body_frame_start(
+                .cas_grant_body_frame_start_with_authority(
                     run_id,
                     loop_instance_id,
                     expected_loop,
@@ -9499,6 +9518,7 @@ impl MobActor {
                     ledger_entry.clone(),
                     expected_run_state,
                     next_run_state.clone(),
+                    authority_inputs,
                 )
                 .await
                 .map_err(MobError::from)?,
@@ -9508,7 +9528,12 @@ impl MobActor {
                 ..
             } => self
                 .run_store
-                .cas_flow_state(run_id, expected_run_state, next_run_state)
+                .cas_flow_state_with_authority(
+                    run_id,
+                    expected_run_state,
+                    next_run_state,
+                    authority_inputs,
+                )
                 .await
                 .map_err(MobError::from)?,
             FlowFrameLoopStorePlan::SealFrame {
@@ -9518,7 +9543,13 @@ impl MobActor {
                 ..
             } => self
                 .run_store
-                .cas_frame_state(run_id, frame_id, Some(expected_frame), next_frame.clone())
+                .cas_frame_state_with_authority(
+                    run_id,
+                    frame_id,
+                    Some(expected_frame),
+                    next_frame.clone(),
+                    authority_inputs,
+                )
                 .await
                 .map_err(MobError::from)?,
             FlowFrameLoopStorePlan::CompleteBodyFrame {
@@ -9533,7 +9564,7 @@ impl MobActor {
                 ..
             } => self
                 .run_store
-                .cas_complete_body_frame(
+                .cas_complete_body_frame_with_authority(
                     run_id,
                     loop_instance_id,
                     expected_loop,
@@ -9543,6 +9574,7 @@ impl MobActor {
                     next_frame.clone(),
                     expected_run_state,
                     next_run_state.clone(),
+                    authority_inputs,
                 )
                 .await
                 .map_err(MobError::from)?,
@@ -9555,13 +9587,14 @@ impl MobActor {
                 ..
             } => self
                 .run_store
-                .cas_loop_request_body_frame(
+                .cas_loop_request_body_frame_with_authority(
                     run_id,
                     loop_instance_id,
                     expected_loop,
                     next_loop.clone(),
                     expected_run_state,
                     next_run_state.clone(),
+                    authority_inputs,
                 )
                 .await
                 .map_err(MobError::from)?,
@@ -9577,7 +9610,7 @@ impl MobActor {
                 ..
             } => self
                 .run_store
-                .cas_complete_loop(
+                .cas_complete_loop_with_authority(
                     run_id,
                     loop_instance_id,
                     expected_loop,
@@ -9587,6 +9620,7 @@ impl MobActor {
                     next_frame.clone(),
                     expected_run_state,
                     next_run_state.clone(),
+                    authority_inputs,
                 )
                 .await
                 .map_err(MobError::from)?,

--- a/meerkat-mob/src/runtime/builder.rs
+++ b/meerkat-mob/src/runtime/builder.rs
@@ -148,6 +148,42 @@ fn seed_mob_authority_sync_from_roster(
     }
 }
 
+async fn seed_mob_authority_sync_from_flow_runs(
+    authority: &mut crate::machines::mob_machine::MobMachineAuthority,
+    run_store: Arc<dyn crate::store::MobRunStore>,
+    mob_id: &MobId,
+) -> Result<(), MobError> {
+    use crate::machines::mob_machine as mob_dsl;
+    use crate::run::MobRun;
+
+    let mut runs = run_store.list_runs(mob_id, None).await?;
+    runs.sort_by(|left, right| {
+        left.created_at
+            .cmp(&right.created_at)
+            .then_with(|| left.run_id.to_string().cmp(&right.run_id.to_string()))
+    });
+
+    let resumed_phase = authority.state.lifecycle_phase;
+    for mut run in runs {
+        super::recovery::reconcile_run_state(&mut run).map_err(|error| {
+            MobError::Internal(format!("cannot resume flow run '{}': {error}", run.run_id))
+        })?;
+        if run.status.is_terminal() || run.flow_authority_inputs.is_empty() {
+            continue;
+        }
+
+        authority.state.lifecycle_phase = mob_dsl::MobPhase::Running;
+        MobRun::replay_flow_authority_inputs_into(
+            authority,
+            &run.flow_authority_inputs,
+            &format!("resume_flow_run_{}", run.run_id),
+        )?;
+        authority.state.lifecycle_phase = resumed_phase;
+    }
+    authority.state.lifecycle_phase = resumed_phase;
+    Ok(())
+}
+
 struct RuntimeWiring {
     roster: Arc<RwLock<RosterAuthority>>,
     task_board: Arc<RwLock<TaskBoard>>,
@@ -664,6 +700,12 @@ impl MobBuilder {
         // lets MobMachine guards (SubmitWork legality, Retire membership,
         // etc.) see resumed members on the first command.
         seed_mob_authority_sync_from_roster(&mut wiring.dsl_authority, &roster, &definition);
+        seed_mob_authority_sync_from_flow_runs(
+            &mut wiring.dsl_authority,
+            storage.runs.clone(),
+            &definition.id,
+        )
+        .await?;
         *wiring.roster.write().await = RosterAuthority::from_roster(roster);
         *wiring.task_board.write().await = task_board;
 

--- a/meerkat-mob/src/runtime/builder.rs
+++ b/meerkat-mob/src/runtime/builder.rs
@@ -151,11 +151,17 @@ fn seed_mob_authority_sync_from_roster(
 async fn seed_mob_authority_sync_from_flow_runs(
     authority: &mut crate::machines::mob_machine::MobMachineAuthority,
     run_store: Arc<dyn crate::store::MobRunStore>,
+    event_store: Arc<dyn crate::store::MobEventStore>,
     mob_id: &MobId,
 ) -> Result<(), MobError> {
     use crate::machines::mob_machine as mob_dsl;
     use crate::run::MobRun;
 
+    let terminalization = super::terminalization::FlowTerminalizationAuthority::new(
+        run_store.clone(),
+        event_store,
+        mob_id.clone(),
+    );
     let mut runs = run_store.list_runs(mob_id, None).await?;
     runs.sort_by(|left, right| {
         left.created_at
@@ -179,8 +185,239 @@ async fn seed_mob_authority_sync_from_flow_runs(
             &format!("resume_flow_run_{}", run.run_id),
         )?;
         authority.state.lifecycle_phase = resumed_phase;
+        if flow_run_replayed_active_admission(&run) {
+            converge_recovered_active_flow_run(
+                authority,
+                run_store.clone(),
+                &terminalization,
+                run.run_id.clone(),
+            )
+            .await?;
+            authority.state.lifecycle_phase = resumed_phase;
+        }
     }
     authority.state.lifecycle_phase = resumed_phase;
+    Ok(())
+}
+
+fn flow_run_replayed_active_admission(run: &crate::run::MobRun) -> bool {
+    run.flow_authority_inputs
+        .iter()
+        .any(|record| matches!(record, crate::run::FlowAuthorityInputRecord::RunFlow(_)))
+}
+
+async fn converge_recovered_active_flow_run(
+    authority: &mut crate::machines::mob_machine::MobMachineAuthority,
+    run_store: Arc<dyn crate::store::MobRunStore>,
+    terminalization: &super::terminalization::FlowTerminalizationAuthority,
+    run_id: crate::ids::RunId,
+) -> Result<(), MobError> {
+    use crate::machines::mob_machine as mob_dsl;
+    use crate::run::{MobMachineFlowRunCommand, MobRunStatus, flow_run};
+
+    start_recovered_flow_run_if_pending(authority, run_store.clone(), &run_id).await?;
+    cancel_recovered_unfinished_steps(authority, run_store.clone(), &run_id).await?;
+
+    let before_terminal = run_store
+        .get_run(&run_id)
+        .await?
+        .ok_or_else(|| MobError::RunNotFound(run_id.clone()))?;
+    let transitioned = if before_terminal.status.is_terminal() {
+        false
+    } else {
+        commit_recovered_flow_run_command(
+            authority,
+            run_store.clone(),
+            &run_id,
+            MobMachineFlowRunCommand::TerminalizeCanceled(flow_run::inputs::TerminalizeCanceled {}),
+            Some(MobRunStatus::Canceled),
+            "resume_recovered_flow_terminalize_canceled",
+        )
+        .await?
+    };
+    if transitioned {
+        terminalization
+            .record_persisted_terminalization(
+                run_id.clone(),
+                before_terminal.flow_id,
+                super::terminalization::TerminalizationTarget::Canceled,
+            )
+            .await?;
+    }
+
+    apply_recovered_flow_signal(
+        authority,
+        mob_dsl::MobMachineSignal::CompleteFlow,
+        "resume_recovered_flow_complete",
+    )?;
+    apply_recovered_flow_signal(
+        authority,
+        mob_dsl::MobMachineSignal::FinishRun,
+        "resume_recovered_flow_finish",
+    )?;
+    Ok(())
+}
+
+async fn start_recovered_flow_run_if_pending(
+    authority: &mut crate::machines::mob_machine::MobMachineAuthority,
+    run_store: Arc<dyn crate::store::MobRunStore>,
+    run_id: &crate::ids::RunId,
+) -> Result<(), MobError> {
+    use crate::run::{MobMachineFlowRunCommand, MobRunStatus, flow_run};
+
+    let run = run_store
+        .get_run(run_id)
+        .await?
+        .ok_or_else(|| MobError::RunNotFound(run_id.clone()))?;
+    if run.status != MobRunStatus::Pending {
+        return Ok(());
+    }
+    let _ = commit_recovered_flow_run_command(
+        authority,
+        run_store,
+        run_id,
+        MobMachineFlowRunCommand::StartRun(flow_run::inputs::StartRun {}),
+        Some(MobRunStatus::Running),
+        "resume_recovered_flow_start",
+    )
+    .await?;
+    Ok(())
+}
+
+async fn cancel_recovered_unfinished_steps(
+    authority: &mut crate::machines::mob_machine::MobMachineAuthority,
+    run_store: Arc<dyn crate::store::MobRunStore>,
+    run_id: &crate::ids::RunId,
+) -> Result<(), MobError> {
+    use crate::run::{MobMachineFlowRunCommand, flow_run};
+
+    let run = run_store
+        .get_run(run_id)
+        .await?
+        .ok_or_else(|| MobError::RunNotFound(run_id.clone()))?;
+    for step_id in run.ordered_steps()? {
+        let is_terminal = run
+            .flow_state
+            .step_status
+            .get(&step_id)
+            .and_then(|status| *status)
+            .is_some_and(|status| {
+                matches!(
+                    status,
+                    flow_run::StepRunStatus::Completed
+                        | flow_run::StepRunStatus::Failed
+                        | flow_run::StepRunStatus::Skipped
+                        | flow_run::StepRunStatus::Canceled
+                )
+            });
+        if is_terminal {
+            continue;
+        }
+        let _ = commit_recovered_flow_run_command(
+            authority,
+            run_store.clone(),
+            run_id,
+            MobMachineFlowRunCommand::CancelStep(flow_run::inputs::CancelStep { step_id }),
+            None,
+            "resume_recovered_flow_cancel_step",
+        )
+        .await?;
+    }
+    Ok(())
+}
+
+async fn commit_recovered_flow_run_command(
+    authority: &mut crate::machines::mob_machine::MobMachineAuthority,
+    run_store: Arc<dyn crate::store::MobRunStore>,
+    run_id: &crate::ids::RunId,
+    command: crate::run::MobMachineFlowRunCommand,
+    next_status: Option<crate::run::MobRunStatus>,
+    context: &'static str,
+) -> Result<bool, MobError> {
+    use crate::machines::mob_machine as mob_dsl;
+    use crate::run::{MobMachineFlowAuthorityToken, apply_mob_machine_flow_run_command};
+
+    let authority_input = command.authority_input(run_id);
+    for attempt in 0..5u32 {
+        let run = run_store
+            .get_run(run_id)
+            .await?
+            .ok_or_else(|| MobError::RunNotFound(run_id.clone()))?;
+        if run.status.is_terminal() {
+            return Ok(false);
+        }
+
+        let mut prepared = mob_dsl::MobMachineAuthority::from_state(authority.state.clone());
+        let input_debug = format!("{authority_input:?}");
+        let transition =
+            mob_dsl::MobMachineMutator::apply(&mut prepared, authority_input.clone()).map_err(
+                |error| {
+                    MobError::Internal(format!(
+                        "MobMachine recovered flow authority ({context}) rejected {input_debug}: {error}"
+                    ))
+                },
+            )?;
+        if transition.from_phase != transition.to_phase {
+            prepared.state.lifecycle_phase = transition.to_phase;
+        }
+        let token =
+            MobMachineFlowAuthorityToken::from_accepted_mob_machine_input(&authority_input)?;
+        let outcome = apply_mob_machine_flow_run_command(
+            &run.flow_state,
+            &prepared.state,
+            run_id,
+            command.clone(),
+            token,
+        )?;
+
+        let won = if let Some(next_status) = &next_status {
+            run_store
+                .cas_run_snapshot_with_authority(
+                    run_id,
+                    run.status.clone(),
+                    &run.flow_state,
+                    next_status.clone(),
+                    &outcome.next_state,
+                    vec![authority_input.clone()],
+                )
+                .await?
+        } else {
+            run_store
+                .cas_flow_state_with_authority(
+                    run_id,
+                    &run.flow_state,
+                    &outcome.next_state,
+                    vec![authority_input.clone()],
+                )
+                .await?
+        };
+        if won {
+            *authority = prepared;
+            return Ok(true);
+        }
+        if attempt < 4 {
+            tracing::debug!(attempt, context, "recovered flow CAS contention, retrying");
+        }
+    }
+    Err(MobError::Internal(format!(
+        "{context}: CAS contention after 5 attempts for recovered run {run_id}"
+    )))
+}
+
+fn apply_recovered_flow_signal(
+    authority: &mut crate::machines::mob_machine::MobMachineAuthority,
+    signal: crate::machines::mob_machine::MobMachineSignal,
+    context: &'static str,
+) -> Result<(), MobError> {
+    let signal_debug = format!("{signal:?}");
+    let transition = authority.apply_signal(signal).map_err(|error| {
+        MobError::Internal(format!(
+            "MobMachine recovered flow signal ({context}) rejected {signal_debug}: {error}"
+        ))
+    })?;
+    if transition.from_phase != transition.to_phase {
+        authority.state.lifecycle_phase = transition.to_phase;
+    }
     Ok(())
 }
 
@@ -703,6 +940,7 @@ impl MobBuilder {
         seed_mob_authority_sync_from_flow_runs(
             &mut wiring.dsl_authority,
             storage.runs.clone(),
+            storage.events.clone(),
             &definition.id,
         )
         .await?;

--- a/meerkat-mob/src/runtime/flow.rs
+++ b/meerkat-mob/src/runtime/flow.rs
@@ -1199,6 +1199,7 @@ impl FlowEngine {
         context: &'static str,
     ) -> Result<Option<Vec<flow_run::Effect>>, MobError> {
         let command = MobMachineFlowRunCommand::StartRun(flow_run::inputs::StartRun {});
+        let authority_input = command.authority_input(run_id);
         for attempt in 0..5u32 {
             let run = self.run_snapshot(run_id).await?;
             if run.status != MobRunStatus::Pending {
@@ -1213,12 +1214,13 @@ impl FlowEngine {
             )?;
             let transitioned = self
                 .run_store
-                .cas_run_snapshot(
+                .cas_run_snapshot_with_authority(
                     run_id,
                     MobRunStatus::Pending,
                     &run.flow_state,
                     MobRunStatus::Running,
                     &outcome.next_state,
+                    vec![authority_input.clone()],
                 )
                 .await?;
             if transitioned {
@@ -1241,6 +1243,7 @@ impl FlowEngine {
         authority: MobMachineFlowAuthorityToken,
         context: &'static str,
     ) -> Result<Vec<flow_run::Effect>, MobError> {
+        let authority_input = command.authority_input(run_id);
         for attempt in 0..5u32 {
             let run = self.run_snapshot(run_id).await?;
             let outcome = apply_mob_machine_flow_run_command(
@@ -1252,7 +1255,12 @@ impl FlowEngine {
             )?;
             let transitioned = self
                 .run_store
-                .cas_flow_state(run_id, &run.flow_state, &outcome.next_state)
+                .cas_flow_state_with_authority(
+                    run_id,
+                    &run.flow_state,
+                    &outcome.next_state,
+                    vec![authority_input.clone()],
+                )
                 .await?;
             if transitioned {
                 return Ok(outcome.effects);
@@ -1631,6 +1639,7 @@ impl FlowEngine {
         authority: MobMachineFlowAuthorityToken,
     ) -> Result<TerminalizationOutcome, MobError> {
         let next_status = target.status();
+        let authority_input = input.authority_input(&run_id);
         self.verify_terminal_run_steps(&run_id).await?;
         for attempt in 0..5u32 {
             let run = self.run_snapshot(&run_id).await?;
@@ -1652,12 +1661,13 @@ impl FlowEngine {
             .next_state;
             let transitioned = self
                 .run_store
-                .cas_run_snapshot(
+                .cas_run_snapshot_with_authority(
                     &run_id,
                     run.status.clone(),
                     &run.flow_state,
                     next_status.clone(),
                     &next_state,
+                    vec![authority_input.clone()],
                 )
                 .await?;
             if transitioned {

--- a/meerkat-mob/src/runtime/recovery.rs
+++ b/meerkat-mob/src/runtime/recovery.rs
@@ -17,6 +17,8 @@ pub enum RestoreIncompatible {
     FrameInvariantViolation { frame_id: FrameId },
     #[error("run projection mismatch: {field}")]
     ProjectionMismatch { field: &'static str },
+    #[error("flow authority projection mismatch: {reason}")]
+    FlowAuthorityProjectionMismatch { reason: String },
 }
 
 /// Validate run scheduler state against frame/loop snapshots.
@@ -47,6 +49,12 @@ pub fn reconcile_run_state(run: &mut MobRun) -> Result<(), RestoreIncompatible> 
     validate_pending_body_frame_loops(run)?;
 
     validate_active_counts(run)?;
+
+    run.validate_flow_authority_projection().map_err(|error| {
+        RestoreIncompatible::FlowAuthorityProjectionMismatch {
+            reason: error.to_string(),
+        }
+    })?;
 
     Ok(())
 }
@@ -217,6 +225,7 @@ mod tests {
             schema_version: 4,
             root_step_outputs: indexmap::IndexMap::new(),
             loop_iteration_outputs: std::collections::BTreeMap::new(),
+            flow_authority_inputs: Vec::new(),
         }
     }
 

--- a/meerkat-mob/src/runtime/terminalization.rs
+++ b/meerkat-mob/src/runtime/terminalization.rs
@@ -448,6 +448,242 @@ mod tests {
                 )
                 .await
         }
+
+        async fn cas_flow_state_with_authority(
+            &self,
+            run_id: &RunId,
+            expected: &crate::run::flow_run::State,
+            next: &crate::run::flow_run::State,
+            authority_inputs: Vec<crate::machines::mob_machine::MobMachineInput>,
+        ) -> Result<bool, MobStoreError> {
+            self.inner
+                .cas_flow_state_with_authority(run_id, expected, next, authority_inputs)
+                .await
+        }
+
+        async fn cas_run_snapshot_with_authority(
+            &self,
+            run_id: &RunId,
+            expected_status: MobRunStatus,
+            expected_flow_state: &crate::run::flow_run::State,
+            next_status: MobRunStatus,
+            next_flow_state: &crate::run::flow_run::State,
+            authority_inputs: Vec<crate::machines::mob_machine::MobMachineInput>,
+        ) -> Result<bool, MobStoreError> {
+            self.inner
+                .cas_run_snapshot_with_authority(
+                    run_id,
+                    expected_status,
+                    expected_flow_state,
+                    next_status,
+                    next_flow_state,
+                    authority_inputs,
+                )
+                .await
+        }
+
+        async fn cas_frame_state_with_authority(
+            &self,
+            run_id: &RunId,
+            frame_id: &crate::ids::FrameId,
+            expected: Option<&crate::run::FrameSnapshot>,
+            next: crate::run::FrameSnapshot,
+            authority_inputs: Vec<crate::machines::mob_machine::MobMachineInput>,
+        ) -> Result<bool, MobStoreError> {
+            self.inner
+                .cas_frame_state_with_authority(run_id, frame_id, expected, next, authority_inputs)
+                .await
+        }
+
+        async fn cas_grant_node_slot_with_authority(
+            &self,
+            run_id: &RunId,
+            expected_run_state: &crate::run::flow_run::State,
+            next_run_state: crate::run::flow_run::State,
+            frame_id: &crate::ids::FrameId,
+            expected_frame: &crate::run::FrameSnapshot,
+            next_frame: crate::run::FrameSnapshot,
+            authority_inputs: Vec<crate::machines::mob_machine::MobMachineInput>,
+        ) -> Result<bool, MobStoreError> {
+            self.inner
+                .cas_grant_node_slot_with_authority(
+                    run_id,
+                    expected_run_state,
+                    next_run_state,
+                    frame_id,
+                    expected_frame,
+                    next_frame,
+                    authority_inputs,
+                )
+                .await
+        }
+
+        #[allow(clippy::too_many_arguments)]
+        async fn cas_complete_step_and_record_output_with_authority(
+            &self,
+            run_id: &RunId,
+            frame_id: &crate::ids::FrameId,
+            expected_frame: &crate::run::FrameSnapshot,
+            next_frame: crate::run::FrameSnapshot,
+            step_output_key: String,
+            step_output: serde_json::Value,
+            loop_context: Option<(&crate::ids::LoopId, u64)>,
+            authority_inputs: Vec<crate::machines::mob_machine::MobMachineInput>,
+        ) -> Result<bool, MobStoreError> {
+            self.inner
+                .cas_complete_step_and_record_output_with_authority(
+                    run_id,
+                    frame_id,
+                    expected_frame,
+                    next_frame,
+                    step_output_key,
+                    step_output,
+                    loop_context,
+                    authority_inputs,
+                )
+                .await
+        }
+
+        #[allow(clippy::too_many_arguments)]
+        async fn cas_start_loop_with_authority(
+            &self,
+            run_id: &RunId,
+            loop_instance_id: &crate::ids::LoopInstanceId,
+            expected_run_state: &crate::run::flow_run::State,
+            next_run_state: crate::run::flow_run::State,
+            frame_id: &crate::ids::FrameId,
+            expected_frame: &crate::run::FrameSnapshot,
+            next_frame: crate::run::FrameSnapshot,
+            initial_loop: crate::run::LoopSnapshot,
+            authority_inputs: Vec<crate::machines::mob_machine::MobMachineInput>,
+        ) -> Result<bool, MobStoreError> {
+            self.inner
+                .cas_start_loop_with_authority(
+                    run_id,
+                    loop_instance_id,
+                    expected_run_state,
+                    next_run_state,
+                    frame_id,
+                    expected_frame,
+                    next_frame,
+                    initial_loop,
+                    authority_inputs,
+                )
+                .await
+        }
+
+        async fn cas_loop_request_body_frame_with_authority(
+            &self,
+            run_id: &RunId,
+            loop_instance_id: &crate::ids::LoopInstanceId,
+            expected_loop: &crate::run::LoopSnapshot,
+            next_loop: crate::run::LoopSnapshot,
+            expected_run_state: &crate::run::flow_run::State,
+            next_run_state: crate::run::flow_run::State,
+            authority_inputs: Vec<crate::machines::mob_machine::MobMachineInput>,
+        ) -> Result<bool, MobStoreError> {
+            self.inner
+                .cas_loop_request_body_frame_with_authority(
+                    run_id,
+                    loop_instance_id,
+                    expected_loop,
+                    next_loop,
+                    expected_run_state,
+                    next_run_state,
+                    authority_inputs,
+                )
+                .await
+        }
+
+        #[allow(clippy::too_many_arguments)]
+        async fn cas_grant_body_frame_start_with_authority(
+            &self,
+            run_id: &RunId,
+            loop_instance_id: &crate::ids::LoopInstanceId,
+            expected_loop: &crate::run::LoopSnapshot,
+            next_loop: crate::run::LoopSnapshot,
+            frame_id: &crate::ids::FrameId,
+            initial_frame: crate::run::FrameSnapshot,
+            ledger_entry: crate::run::LoopIterationLedgerEntry,
+            expected_run_state: &crate::run::flow_run::State,
+            next_run_state: crate::run::flow_run::State,
+            authority_inputs: Vec<crate::machines::mob_machine::MobMachineInput>,
+        ) -> Result<bool, MobStoreError> {
+            self.inner
+                .cas_grant_body_frame_start_with_authority(
+                    run_id,
+                    loop_instance_id,
+                    expected_loop,
+                    next_loop,
+                    frame_id,
+                    initial_frame,
+                    ledger_entry,
+                    expected_run_state,
+                    next_run_state,
+                    authority_inputs,
+                )
+                .await
+        }
+
+        #[allow(clippy::too_many_arguments)]
+        async fn cas_complete_body_frame_with_authority(
+            &self,
+            run_id: &RunId,
+            loop_instance_id: &crate::ids::LoopInstanceId,
+            expected_loop: &crate::run::LoopSnapshot,
+            next_loop: crate::run::LoopSnapshot,
+            frame_id: &crate::ids::FrameId,
+            expected_frame: &crate::run::FrameSnapshot,
+            next_frame: crate::run::FrameSnapshot,
+            expected_run_state: &crate::run::flow_run::State,
+            next_run_state: crate::run::flow_run::State,
+            authority_inputs: Vec<crate::machines::mob_machine::MobMachineInput>,
+        ) -> Result<bool, MobStoreError> {
+            self.inner
+                .cas_complete_body_frame_with_authority(
+                    run_id,
+                    loop_instance_id,
+                    expected_loop,
+                    next_loop,
+                    frame_id,
+                    expected_frame,
+                    next_frame,
+                    expected_run_state,
+                    next_run_state,
+                    authority_inputs,
+                )
+                .await
+        }
+
+        #[allow(clippy::too_many_arguments)]
+        async fn cas_complete_loop_with_authority(
+            &self,
+            run_id: &RunId,
+            loop_instance_id: &crate::ids::LoopInstanceId,
+            expected_loop: &crate::run::LoopSnapshot,
+            next_loop: crate::run::LoopSnapshot,
+            frame_id: &crate::ids::FrameId,
+            expected_frame: &crate::run::FrameSnapshot,
+            next_frame: crate::run::FrameSnapshot,
+            expected_run_state: &crate::run::flow_run::State,
+            next_run_state: crate::run::flow_run::State,
+            authority_inputs: Vec<crate::machines::mob_machine::MobMachineInput>,
+        ) -> Result<bool, MobStoreError> {
+            self.inner
+                .cas_complete_loop_with_authority(
+                    run_id,
+                    loop_instance_id,
+                    expected_loop,
+                    next_loop,
+                    frame_id,
+                    expected_frame,
+                    next_frame,
+                    expected_run_state,
+                    next_run_state,
+                    authority_inputs,
+                )
+                .await
+        }
     }
 
     #[derive(Default)]
@@ -553,6 +789,7 @@ mod tests {
             schema_version: 4,
             root_step_outputs: indexmap::IndexMap::new(),
             loop_iteration_outputs: std::collections::BTreeMap::new(),
+            flow_authority_inputs: Vec::new(),
         }
     }
 

--- a/meerkat-mob/src/runtime/terminalization.rs
+++ b/meerkat-mob/src/runtime/terminalization.rs
@@ -495,6 +495,7 @@ mod tests {
                 .await
         }
 
+        #[allow(clippy::too_many_arguments)]
         async fn cas_grant_node_slot_with_authority(
             &self,
             run_id: &RunId,
@@ -572,6 +573,7 @@ mod tests {
                 .await
         }
 
+        #[allow(clippy::too_many_arguments)]
         async fn cas_loop_request_body_frame_with_authority(
             &self,
             run_id: &RunId,

--- a/meerkat-mob/src/runtime/tests.rs
+++ b/meerkat-mob/src/runtime/tests.rs
@@ -1975,6 +1975,247 @@ impl MobRunStore for RecordingRunStore {
             )
             .await
     }
+
+    async fn cas_flow_state_with_authority(
+        &self,
+        run_id: &RunId,
+        expected: &crate::run::flow_run::State,
+        next: &crate::run::flow_run::State,
+        authority_inputs: Vec<crate::machines::mob_machine::MobMachineInput>,
+    ) -> Result<bool, MobStoreError> {
+        self.inner
+            .cas_flow_state_with_authority(run_id, expected, next, authority_inputs)
+            .await
+    }
+
+    async fn cas_run_snapshot_with_authority(
+        &self,
+        run_id: &RunId,
+        expected_status: MobRunStatus,
+        expected_flow_state: &crate::run::flow_run::State,
+        next_status: MobRunStatus,
+        next_flow_state: &crate::run::flow_run::State,
+        authority_inputs: Vec<crate::machines::mob_machine::MobMachineInput>,
+    ) -> Result<bool, MobStoreError> {
+        self.snapshot_cas_history.write().await.push((
+            run_id.clone(),
+            expected_status.clone(),
+            next_status.clone(),
+        ));
+        self.inner
+            .cas_run_snapshot_with_authority(
+                run_id,
+                expected_status,
+                expected_flow_state,
+                next_status,
+                next_flow_state,
+                authority_inputs,
+            )
+            .await
+    }
+
+    async fn cas_frame_state_with_authority(
+        &self,
+        run_id: &RunId,
+        frame_id: &crate::ids::FrameId,
+        expected: Option<&crate::run::FrameSnapshot>,
+        next: crate::run::FrameSnapshot,
+        authority_inputs: Vec<crate::machines::mob_machine::MobMachineInput>,
+    ) -> Result<bool, MobStoreError> {
+        self.inner
+            .cas_frame_state_with_authority(run_id, frame_id, expected, next, authority_inputs)
+            .await
+    }
+
+    async fn cas_grant_node_slot_with_authority(
+        &self,
+        run_id: &RunId,
+        expected_run_state: &crate::run::flow_run::State,
+        next_run_state: crate::run::flow_run::State,
+        frame_id: &crate::ids::FrameId,
+        expected_frame: &crate::run::FrameSnapshot,
+        next_frame: crate::run::FrameSnapshot,
+        authority_inputs: Vec<crate::machines::mob_machine::MobMachineInput>,
+    ) -> Result<bool, MobStoreError> {
+        self.inner
+            .cas_grant_node_slot_with_authority(
+                run_id,
+                expected_run_state,
+                next_run_state,
+                frame_id,
+                expected_frame,
+                next_frame,
+                authority_inputs,
+            )
+            .await
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    async fn cas_complete_step_and_record_output_with_authority(
+        &self,
+        run_id: &RunId,
+        frame_id: &crate::ids::FrameId,
+        expected_frame: &crate::run::FrameSnapshot,
+        next_frame: crate::run::FrameSnapshot,
+        step_output_key: String,
+        step_output: serde_json::Value,
+        loop_context: Option<(&crate::ids::LoopId, u64)>,
+        authority_inputs: Vec<crate::machines::mob_machine::MobMachineInput>,
+    ) -> Result<bool, MobStoreError> {
+        self.inner
+            .cas_complete_step_and_record_output_with_authority(
+                run_id,
+                frame_id,
+                expected_frame,
+                next_frame,
+                step_output_key,
+                step_output,
+                loop_context,
+                authority_inputs,
+            )
+            .await
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    async fn cas_start_loop_with_authority(
+        &self,
+        run_id: &RunId,
+        loop_instance_id: &crate::ids::LoopInstanceId,
+        expected_run_state: &crate::run::flow_run::State,
+        next_run_state: crate::run::flow_run::State,
+        frame_id: &crate::ids::FrameId,
+        expected_frame: &crate::run::FrameSnapshot,
+        next_frame: crate::run::FrameSnapshot,
+        initial_loop: crate::run::LoopSnapshot,
+        authority_inputs: Vec<crate::machines::mob_machine::MobMachineInput>,
+    ) -> Result<bool, MobStoreError> {
+        self.inner
+            .cas_start_loop_with_authority(
+                run_id,
+                loop_instance_id,
+                expected_run_state,
+                next_run_state,
+                frame_id,
+                expected_frame,
+                next_frame,
+                initial_loop,
+                authority_inputs,
+            )
+            .await
+    }
+
+    async fn cas_loop_request_body_frame_with_authority(
+        &self,
+        run_id: &RunId,
+        loop_instance_id: &crate::ids::LoopInstanceId,
+        expected_loop: &crate::run::LoopSnapshot,
+        next_loop: crate::run::LoopSnapshot,
+        expected_run_state: &crate::run::flow_run::State,
+        next_run_state: crate::run::flow_run::State,
+        authority_inputs: Vec<crate::machines::mob_machine::MobMachineInput>,
+    ) -> Result<bool, MobStoreError> {
+        self.inner
+            .cas_loop_request_body_frame_with_authority(
+                run_id,
+                loop_instance_id,
+                expected_loop,
+                next_loop,
+                expected_run_state,
+                next_run_state,
+                authority_inputs,
+            )
+            .await
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    async fn cas_grant_body_frame_start_with_authority(
+        &self,
+        run_id: &RunId,
+        loop_instance_id: &crate::ids::LoopInstanceId,
+        expected_loop: &crate::run::LoopSnapshot,
+        next_loop: crate::run::LoopSnapshot,
+        frame_id: &crate::ids::FrameId,
+        initial_frame: crate::run::FrameSnapshot,
+        ledger_entry: crate::run::LoopIterationLedgerEntry,
+        expected_run_state: &crate::run::flow_run::State,
+        next_run_state: crate::run::flow_run::State,
+        authority_inputs: Vec<crate::machines::mob_machine::MobMachineInput>,
+    ) -> Result<bool, MobStoreError> {
+        self.inner
+            .cas_grant_body_frame_start_with_authority(
+                run_id,
+                loop_instance_id,
+                expected_loop,
+                next_loop,
+                frame_id,
+                initial_frame,
+                ledger_entry,
+                expected_run_state,
+                next_run_state,
+                authority_inputs,
+            )
+            .await
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    async fn cas_complete_body_frame_with_authority(
+        &self,
+        run_id: &RunId,
+        loop_instance_id: &crate::ids::LoopInstanceId,
+        expected_loop: &crate::run::LoopSnapshot,
+        next_loop: crate::run::LoopSnapshot,
+        frame_id: &crate::ids::FrameId,
+        expected_frame: &crate::run::FrameSnapshot,
+        next_frame: crate::run::FrameSnapshot,
+        expected_run_state: &crate::run::flow_run::State,
+        next_run_state: crate::run::flow_run::State,
+        authority_inputs: Vec<crate::machines::mob_machine::MobMachineInput>,
+    ) -> Result<bool, MobStoreError> {
+        self.inner
+            .cas_complete_body_frame_with_authority(
+                run_id,
+                loop_instance_id,
+                expected_loop,
+                next_loop,
+                frame_id,
+                expected_frame,
+                next_frame,
+                expected_run_state,
+                next_run_state,
+                authority_inputs,
+            )
+            .await
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    async fn cas_complete_loop_with_authority(
+        &self,
+        run_id: &RunId,
+        loop_instance_id: &crate::ids::LoopInstanceId,
+        expected_loop: &crate::run::LoopSnapshot,
+        next_loop: crate::run::LoopSnapshot,
+        frame_id: &crate::ids::FrameId,
+        expected_frame: &crate::run::FrameSnapshot,
+        next_frame: crate::run::FrameSnapshot,
+        expected_run_state: &crate::run::flow_run::State,
+        next_run_state: crate::run::flow_run::State,
+        authority_inputs: Vec<crate::machines::mob_machine::MobMachineInput>,
+    ) -> Result<bool, MobStoreError> {
+        self.inner
+            .cas_complete_loop_with_authority(
+                run_id,
+                loop_instance_id,
+                expected_loop,
+                next_loop,
+                frame_id,
+                expected_frame,
+                next_frame,
+                expected_run_state,
+                next_run_state,
+                authority_inputs,
+            )
+            .await
+    }
 }
 
 struct FaultInjectedRuntimeMetadataStore {
@@ -15722,6 +15963,231 @@ fn test_flow_frame_scheduler_start_run_routes_through_actor_authority() {
     }
 }
 
+fn serialized_flow_authority_inputs(run: &MobRun) -> Vec<serde_json::Value> {
+    let run_json = serde_json::to_value(run).expect("serialize MobRun");
+    run_json
+        .get("flow_authority_inputs")
+        .and_then(serde_json::Value::as_array)
+        .cloned()
+        .unwrap_or_else(|| panic!("MobRun must persist flow_authority_inputs with projections"))
+}
+
+fn flow_authority_log_text(run: &MobRun) -> String {
+    serde_json::to_string(&serialized_flow_authority_inputs(run))
+        .expect("serialize flow authority log")
+}
+
+fn assert_flow_authority_log_contains(run: &MobRun, needle: &str) {
+    let log = flow_authority_log_text(run);
+    assert!(
+        log.contains(needle),
+        "flow authority log should contain {needle}; log={log}"
+    );
+}
+
+#[tokio::test]
+async fn test_flow_frame_store_plan_persists_authority_input_with_projection() {
+    use crate::definition::{FlowNodeSpec, FrameSpec, FrameStepSpec};
+    use crate::ids::{FlowNodeId, FrameId};
+    use crate::runtime::flow_frame_engine::{FlowFrameKernel, FlowFrameMutator};
+
+    let store = Arc::new(InMemoryMobRunStore::new());
+    let run = MobRun::pending(
+        crate::ids::MobId::from("test-mob"),
+        FlowId::from("test-flow"),
+        crate::run::flow_run::initial_state(),
+        serde_json::json!({}),
+    );
+    let run_id = run.run_id.clone();
+    store.create_run(run).await.expect("create run");
+
+    let (handle, _) = create_test_mob_with_run_store(sample_definition(), store.clone()).await;
+    seed_test_run_in_mob_machine(&handle, &run_id).await;
+
+    let node_id = FlowNodeId::from("start-node");
+    let mut nodes = IndexMap::new();
+    nodes.insert(
+        node_id,
+        FlowNodeSpec::Step(FrameStepSpec {
+            step_id: step_id("start"),
+            depends_on: Vec::new(),
+            depends_on_mode: DependencyMode::All,
+            branch: None,
+        }),
+    );
+    let root_spec = FrameSpec { nodes };
+    let frame_id = FrameId::from(format!("{run_id}-root").as_str());
+    let frame_kernel = FlowFrameKernel::new(store.clone(), handle);
+
+    frame_kernel
+        .start_frame(&run_id, &frame_id, &root_spec)
+        .await
+        .expect("start root frame");
+    frame_kernel
+        .admit_next_ready_node_with_retry(&run_id, &frame_id, 5)
+        .await
+        .expect("admit next ready node")
+        .expect("admission effects");
+
+    let persisted = store
+        .get_run(&run_id)
+        .await
+        .expect("get run")
+        .expect("run exists");
+    let authority_inputs = serialized_flow_authority_inputs(&persisted);
+    assert!(
+        authority_inputs.len() >= 2,
+        "frame seed and admit projection commits must both record authority inputs"
+    );
+    assert_flow_authority_log_contains(&persisted, "CreateFrameSeed");
+    assert_flow_authority_log_contains(&persisted, "AuthorizeFlowFrameReducerCommand");
+    assert_flow_authority_log_contains(&persisted, "AdmitNextReadyNode");
+}
+
+#[tokio::test]
+async fn test_flow_run_start_and_completion_persist_authority_inputs_with_projection() {
+    let store = Arc::new(InMemoryMobRunStore::new());
+    let run = MobRun::pending(
+        crate::ids::MobId::from("test-mob"),
+        FlowId::from("test-flow"),
+        crate::run::flow_run::initial_state(),
+        serde_json::json!({}),
+    );
+    let run_id = run.run_id.clone();
+    store.create_run(run).await.expect("create run");
+
+    let (handle, _) = create_test_mob_with_run_store(sample_definition(), store.clone()).await;
+    seed_test_run_in_mob_machine(&handle, &run_id).await;
+
+    let effects = handle
+        .commit_flow_run_command(
+            &run_id,
+            crate::run::MobMachineFlowRunCommand::StartRun(
+                crate::run::flow_run::inputs::StartRun {},
+            ),
+            "test_start_run_authority_log",
+        )
+        .await
+        .expect("start run command")
+        .expect("start run should transition");
+    assert!(!effects.is_empty(), "start run should emit effects");
+
+    let started = store
+        .get_run(&run_id)
+        .await
+        .expect("get started run")
+        .expect("started run exists");
+    assert_eq!(started.status, MobRunStatus::Running);
+    assert_flow_authority_log_contains(&started, "StartRun");
+
+    let terminal = handle
+        .commit_flow_terminalization(
+            run_id.clone(),
+            FlowId::from("test-flow"),
+            super::terminalization::TerminalizationTarget::Completed,
+            crate::run::MobMachineFlowRunCommand::TerminalizeCompleted(
+                crate::run::flow_run::inputs::TerminalizeCompleted {},
+            ),
+            "test_completed_run_authority_log",
+        )
+        .await
+        .expect("terminalize completed");
+    assert_eq!(
+        terminal,
+        super::terminalization::TerminalizationOutcome::Transitioned
+    );
+
+    let completed = store
+        .get_run(&run_id)
+        .await
+        .expect("get completed run")
+        .expect("completed run exists");
+    assert_eq!(completed.status, MobRunStatus::Completed);
+    assert_flow_authority_log_contains(&completed, "TerminalizeCompleted");
+}
+
+#[tokio::test]
+async fn test_recovery_rejects_flow_authority_log_projection_divergence() {
+    let store = Arc::new(InMemoryMobRunStore::new());
+    let mut run = MobRun::pending(
+        crate::ids::MobId::from("test-mob"),
+        FlowId::from("test-flow"),
+        crate::run::flow_run::initial_state(),
+        serde_json::json!({}),
+    );
+    let run_id = run.run_id.clone();
+    let seed_input = crate::machines::mob_machine::MobMachineInput::CreateRunSeed {
+        run_id: crate::machines::mob_machine::RunId::from(run_id.to_string()),
+        step_ids: Default::default(),
+        ordered_steps: Vec::new(),
+        step_has_conditions: Default::default(),
+        step_dependencies: Default::default(),
+        step_dependency_modes: Default::default(),
+        step_branches: Default::default(),
+        step_collection_policies: Default::default(),
+        step_quorum_thresholds: Default::default(),
+        escalation_threshold: 0,
+        max_step_retries: 0,
+        max_active_nodes: 0,
+        max_active_frames: 0,
+        max_frame_depth: 0,
+    };
+    run.append_flow_authority_inputs(vec![seed_input.clone()])
+        .expect("append seed authority input");
+    store.create_run(run).await.expect("create run");
+
+    let (handle, _) = create_test_mob_with_run_store(sample_definition(), store.clone()).await;
+    handle
+        .project_machine_input(seed_input)
+        .await
+        .expect("seed run in MobMachine");
+    handle
+        .commit_flow_run_command(
+            &run_id,
+            crate::run::MobMachineFlowRunCommand::StartRun(
+                crate::run::flow_run::inputs::StartRun {},
+            ),
+            "test_start_run_recovery_authority_log",
+        )
+        .await
+        .expect("start run command")
+        .expect("start run should transition");
+
+    let mut persisted = store
+        .get_run(&run_id)
+        .await
+        .expect("get run")
+        .expect("run exists");
+    crate::runtime::recovery::reconcile_run_state(&mut persisted)
+        .expect("fresh persisted run should validate");
+
+    persisted.flow_state.phase = crate::run::flow_run::Phase::Pending;
+    let error = crate::runtime::recovery::reconcile_run_state(&mut persisted)
+        .expect_err("tampered projection must not validate against authority log");
+    assert!(
+        matches!(
+            error,
+            crate::runtime::recovery::RestoreIncompatible::FlowAuthorityProjectionMismatch { .. }
+        ),
+        "unexpected recovery error: {error}"
+    );
+}
+
+#[test]
+fn test_resume_path_replays_persisted_flow_authority_inputs() {
+    let builder = include_str!("builder.rs");
+    assert!(
+        builder.contains("seed_mob_authority_sync_from_flow_runs"),
+        "resume must seed MobMachine flow authority from persisted run authority inputs"
+    );
+
+    let recovery = include_str!("recovery.rs");
+    assert!(
+        recovery.contains("validate_flow_authority_projection"),
+        "recovery must validate projection snapshots against the persisted MobMachine authority input log"
+    );
+}
+
 #[test]
 fn test_actor_owned_terminalization_paths_do_not_reenter_actor_mailbox() {
     let source = include_str!("actor.rs");
@@ -15815,6 +16281,14 @@ async fn test_stale_flow_frame_store_plan_loses_cas_before_authority_prepare() {
         advanced_frame, initial_frame,
         "admission should advance the persisted frame before replaying stale plan"
     );
+    let authority_log_len_before_stale_replay = serialized_flow_authority_inputs(
+        &store
+            .get_run(&run_id)
+            .await
+            .expect("get run before stale replay")
+            .expect("run exists before stale replay"),
+    )
+    .len();
 
     let stale_admit = crate::run::MobMachineFlowFrameCommand::AdmitNextReadyNode(
         crate::run::flow_frame::inputs::AdmitNextReadyNode {
@@ -15851,6 +16325,18 @@ async fn test_stale_flow_frame_store_plan_loses_cas_before_authority_prepare() {
     assert_eq!(
         after_replay, advanced_frame,
         "losing stale plan must not mutate the persisted frame"
+    );
+    let authority_log_len_after_stale_replay = serialized_flow_authority_inputs(
+        &store
+            .get_run(&run_id)
+            .await
+            .expect("get run after stale replay")
+            .expect("run exists after stale replay"),
+    )
+    .len();
+    assert_eq!(
+        authority_log_len_after_stale_replay, authority_log_len_before_stale_replay,
+        "losing stale plan must not persist a MobMachine authority input"
     );
 }
 

--- a/meerkat-mob/src/runtime/tests.rs
+++ b/meerkat-mob/src/runtime/tests.rs
@@ -2027,6 +2027,7 @@ impl MobRunStore for RecordingRunStore {
             .await
     }
 
+    #[allow(clippy::too_many_arguments)]
     async fn cas_grant_node_slot_with_authority(
         &self,
         run_id: &RunId,
@@ -2104,6 +2105,7 @@ impl MobRunStore for RecordingRunStore {
             .await
     }
 
+    #[allow(clippy::too_many_arguments)]
     async fn cas_loop_request_body_frame_with_authority(
         &self,
         run_id: &RunId,

--- a/meerkat-mob/src/runtime/tests.rs
+++ b/meerkat-mob/src/runtime/tests.rs
@@ -15987,6 +15987,180 @@ fn assert_flow_authority_log_contains(run: &MobRun, needle: &str) {
     );
 }
 
+fn apply_authority_input_for_test(
+    authority: &mut crate::machines::mob_machine::MobMachineAuthority,
+    input: crate::machines::mob_machine::MobMachineInput,
+) {
+    let transition = crate::machines::mob_machine::MobMachineMutator::apply(authority, input)
+        .expect("test authority input should be accepted");
+    if transition.from_phase != transition.to_phase {
+        authority.state.lifecycle_phase = transition.to_phase;
+    }
+}
+
+fn authority_backed_root_frame_run(
+    include_loop_seed: bool,
+) -> (MobRun, crate::ids::FrameId, crate::ids::LoopInstanceId) {
+    use crate::ids::{FlowNodeId, LoopId, RunId};
+
+    let definition = sample_definition_with_single_step_flow(500, 8);
+    let config = crate::run::FlowRunConfig::from_definition(FlowId::from("demo"), &definition)
+        .expect("flow config");
+    let run_id = RunId::new();
+    let create_run = MobRun::create_run_seed_input(&run_id, &config).expect("create run seed");
+
+    let loop_node_id = FlowNodeId::from("loop-node");
+    let dependency_node_id = FlowNodeId::from("blocked-on");
+    let loop_id = LoopId::from("retry");
+    let frame_id = crate::ids::FrameId::from(format!("{run_id}-root").as_str());
+    let create_frame = crate::machines::mob_machine::MobMachineInput::CreateFrameSeed {
+        run_id: crate::machines::mob_machine::RunId::from(run_id.to_string()),
+        frame_id: crate::machines::mob_machine::FrameId::from(frame_id.as_str()),
+        frame_scope: crate::machines::mob_machine::FrameScope::Root,
+        loop_instance_id: None,
+        iteration: 0,
+        tracked_nodes: [crate::machines::mob_machine::FlowNodeId::from(
+            loop_node_id.as_str(),
+        )]
+        .into_iter()
+        .collect(),
+        ordered_nodes: vec![crate::machines::mob_machine::FlowNodeId::from(
+            loop_node_id.as_str(),
+        )],
+        node_kind: [(
+            crate::machines::mob_machine::FlowNodeId::from(loop_node_id.as_str()),
+            crate::machines::mob_machine::FlowNodeKind::Loop,
+        )]
+        .into_iter()
+        .collect(),
+        node_dependencies: [(
+            crate::machines::mob_machine::FlowNodeId::from(loop_node_id.as_str()),
+            vec![crate::machines::mob_machine::FlowNodeId::from(
+                dependency_node_id.as_str(),
+            )],
+        )]
+        .into_iter()
+        .collect(),
+        node_dependency_modes: [(
+            crate::machines::mob_machine::FlowNodeId::from(loop_node_id.as_str()),
+            crate::machines::mob_machine::DependencyMode::All,
+        )]
+        .into_iter()
+        .collect(),
+        node_branches: [(
+            crate::machines::mob_machine::FlowNodeId::from(loop_node_id.as_str()),
+            None,
+        )]
+        .into_iter()
+        .collect(),
+        node_step_ids: BTreeMap::new(),
+        node_loop_ids: [(
+            crate::machines::mob_machine::FlowNodeId::from(loop_node_id.as_str()),
+            crate::machines::mob_machine::LoopId::from(loop_id.as_str()),
+        )]
+        .into_iter()
+        .collect(),
+        node_status: [(
+            crate::machines::mob_machine::FlowNodeId::from(loop_node_id.as_str()),
+            crate::machines::mob_machine::NodeRunStatus::Pending,
+        )]
+        .into_iter()
+        .collect(),
+        ready_queue: Vec::new(),
+    };
+    let loop_instance_id =
+        crate::ids::LoopInstanceId::from(format!("{frame_id}::{loop_node_id}").as_str());
+    let create_loop = MobRun::create_loop_seed_input_for_start(
+        &loop_instance_id,
+        &frame_id,
+        &loop_node_id,
+        &loop_id,
+        1,
+        3,
+    );
+
+    let mut authority = crate::machines::mob_machine::MobMachineAuthority::new();
+    apply_authority_input_for_test(&mut authority, create_run.clone());
+    apply_authority_input_for_test(&mut authority, create_frame.clone());
+    if include_loop_seed {
+        apply_authority_input_for_test(&mut authority, create_loop.clone());
+    }
+
+    let mut run = MobRun::pending_with_run_id(
+        run_id.clone(),
+        definition.id.clone(),
+        FlowId::from("demo"),
+        MobRun::flow_state_for_config_with_authority(&run_id, &config, &authority.state)
+            .expect("project flow state"),
+        serde_json::json!({}),
+    );
+    let mut inputs = vec![create_run, create_frame];
+    if include_loop_seed {
+        inputs.push(create_loop);
+    }
+    run.append_flow_authority_inputs(inputs)
+        .expect("append authority inputs");
+    run.frames.insert(
+        frame_id.clone(),
+        crate::run::FrameSnapshot {
+            kernel_state: crate::run::project_flow_frame_authority_state_from_machine(
+                &authority.state,
+                &frame_id,
+            )
+            .expect("project frame state"),
+        },
+    );
+
+    (run, frame_id, loop_instance_id)
+}
+
+fn running_authority_backed_run(definition: &MobDefinition) -> MobRun {
+    use crate::ids::RunId;
+    use crate::run::{
+        MobMachineFlowAuthorityToken, MobMachineFlowRunCommand, apply_mob_machine_flow_run_command,
+        flow_run,
+    };
+
+    let flow_id = FlowId::from("demo");
+    let config = crate::run::FlowRunConfig::from_definition(flow_id.clone(), definition)
+        .expect("flow config");
+    let run_id = RunId::new();
+    let run_flow = MobRun::run_flow_input(&run_id, &config).expect("run flow input");
+    let mut authority = crate::machines::mob_machine::MobMachineAuthority::new();
+    apply_authority_input_for_test(&mut authority, run_flow.clone());
+
+    let mut run = MobRun::pending_with_run_id(
+        run_id.clone(),
+        definition.id.clone(),
+        flow_id,
+        MobRun::flow_state_for_config_with_authority(&run_id, &config, &authority.state)
+            .expect("project admitted flow state"),
+        serde_json::json!({}),
+    );
+    run.append_flow_authority_inputs(vec![run_flow])
+        .expect("append RunFlow authority input");
+
+    let start = MobMachineFlowRunCommand::StartRun(flow_run::inputs::StartRun {});
+    let start_input = start.authority_input(&run_id);
+    apply_authority_input_for_test(&mut authority, start_input.clone());
+    let authority_token =
+        MobMachineFlowAuthorityToken::from_accepted_mob_machine_input(&start_input)
+            .expect("start authority token");
+    let outcome = apply_mob_machine_flow_run_command(
+        &run.flow_state,
+        &authority.state,
+        &run_id,
+        start,
+        authority_token,
+    )
+    .expect("project started flow state");
+    run.status = MobRunStatus::Running;
+    run.flow_state = outcome.next_state;
+    run.append_flow_authority_inputs(vec![start_input])
+        .expect("append StartRun authority input");
+    run
+}
+
 #[tokio::test]
 async fn test_flow_frame_store_plan_persists_authority_input_with_projection() {
     use crate::definition::{FlowNodeSpec, FrameSpec, FrameStepSpec};
@@ -16173,6 +16347,95 @@ async fn test_recovery_rejects_flow_authority_log_projection_divergence() {
         ),
         "unexpected recovery error: {error}"
     );
+}
+
+#[test]
+fn test_recovery_rejects_authority_created_frame_missing_from_projection() {
+    let (mut run, frame_id, _) = authority_backed_root_frame_run(false);
+    run.frames.remove(&frame_id);
+
+    let error = crate::runtime::recovery::reconcile_run_state(&mut run)
+        .expect_err("authority-created frame missing from persisted projections must fail");
+    assert!(
+        matches!(
+            error,
+            crate::runtime::recovery::RestoreIncompatible::FlowAuthorityProjectionMismatch { .. }
+        ),
+        "unexpected recovery error: {error}"
+    );
+}
+
+#[test]
+fn test_recovery_rejects_authority_created_loop_missing_from_projection() {
+    let (mut run, _, loop_instance_id) = authority_backed_root_frame_run(true);
+    assert!(
+        !run.loops.contains_key(&loop_instance_id),
+        "test fixture intentionally omits the authority-created loop projection"
+    );
+
+    let error = crate::runtime::recovery::reconcile_run_state(&mut run)
+        .expect_err("authority-created loop missing from persisted projections must fail");
+    assert!(
+        matches!(
+            error,
+            crate::runtime::recovery::RestoreIncompatible::FlowAuthorityProjectionMismatch { .. }
+        ),
+        "unexpected recovery error: {error}"
+    );
+}
+
+#[tokio::test]
+async fn test_resume_converges_untracked_active_flow_runs() {
+    let definition = sample_definition_with_single_step_flow(60_000, 8);
+    let storage = MobStorage::in_memory();
+    let events = storage.events.clone();
+    let runs = storage.runs.clone();
+    let specs = storage.specs.clone();
+    let runtime_metadata = storage.runtime_metadata.clone();
+    let service = Arc::new(MockSessionService::new());
+    let _ = service.enable_runtime_adapter();
+    let handle = MobBuilder::new(definition.clone(), storage)
+        .with_session_service(service.clone())
+        .create()
+        .await
+        .expect("create mob");
+    handle.shutdown().await.expect("shutdown actor");
+
+    let active = running_authority_backed_run(&definition);
+    let run_id = active.run_id.clone();
+    runs.create_run(active)
+        .await
+        .expect("persist active run as crash residue");
+
+    let resumed = MobBuilder::for_resume(MobStorage::custom_with_runtime_metadata(
+        events,
+        runs.clone(),
+        specs,
+        runtime_metadata,
+    ))
+    .with_session_service(service)
+    .resume()
+    .await
+    .expect("resume mob");
+
+    let terminal = wait_for_run_terminal(&resumed, &run_id, Duration::from_secs(2)).await;
+    assert_eq!(
+        terminal.status,
+        MobRunStatus::Canceled,
+        "resume must converge persisted active runs that have no actor trackers"
+    );
+    let machine_state = resumed
+        .query_machine_state()
+        .await
+        .expect("query machine state");
+    assert_eq!(
+        machine_state.active_run_count, 0,
+        "recovered active flow must not leave MobMachine active_run_count blocking stop"
+    );
+    resumed
+        .stop()
+        .await
+        .expect("stop should not be blocked by an untracked recovered flow");
 }
 
 #[test]

--- a/meerkat-mob/src/storage.rs
+++ b/meerkat-mob/src/storage.rs
@@ -188,6 +188,7 @@ mod tests {
             schema_version: 4,
             root_step_outputs: indexmap::IndexMap::new(),
             loop_iteration_outputs: std::collections::BTreeMap::new(),
+            flow_authority_inputs: Vec::new(),
         };
         runs.create_run(run.clone()).await.unwrap();
         assert!(runs.get_run(&run.run_id).await.unwrap().is_some());
@@ -238,6 +239,7 @@ model = "test"
             schema_version: 4,
             root_step_outputs: indexmap::IndexMap::new(),
             loop_iteration_outputs: std::collections::BTreeMap::new(),
+            flow_authority_inputs: Vec::new(),
         };
         storage.runs.create_run(run.clone()).await.unwrap();
         assert!(storage.runs.get_run(&run.run_id).await.unwrap().is_some());

--- a/meerkat-mob/src/store/in_memory.rs
+++ b/meerkat-mob/src/store/in_memory.rs
@@ -10,6 +10,7 @@ use crate::event::{MobEvent, NewMobEvent};
 use crate::ids::{
     AgentIdentity, FlowId, FrameId, Generation, LoopId, LoopInstanceId, MobId, RunId, StepId,
 };
+use crate::machines::mob_machine as mob_dsl;
 use crate::profile::Profile;
 use crate::run::flow_run;
 use crate::run::{
@@ -26,6 +27,14 @@ use std::sync::Arc;
 use tokio::sync::{RwLock, broadcast};
 
 const EVENT_SUBSCRIPTION_CHANNEL_CAPACITY: usize = 4096;
+
+fn append_flow_authority_inputs(
+    run: &mut MobRun,
+    authority_inputs: Vec<mob_dsl::MobMachineInput>,
+) -> Result<(), MobStoreError> {
+    run.append_flow_authority_inputs(authority_inputs)
+        .map_err(|error| MobStoreError::Internal(error.to_string()))
+}
 
 /// In-memory event store for tests and ephemeral mobs.
 #[derive(Debug)]
@@ -346,6 +355,25 @@ impl MobRunStore for InMemoryMobRunStore {
         Ok(true)
     }
 
+    async fn cas_flow_state_with_authority(
+        &self,
+        run_id: &RunId,
+        expected: &flow_run::State,
+        next: &flow_run::State,
+        authority_inputs: Vec<mob_dsl::MobMachineInput>,
+    ) -> Result<bool, MobStoreError> {
+        let mut runs = self.runs.write().await;
+        let Some(run) = runs.get_mut(run_id) else {
+            return Ok(false);
+        };
+        if &run.flow_state != expected {
+            return Ok(false);
+        }
+        run.flow_state = next.clone();
+        append_flow_authority_inputs(run, authority_inputs)?;
+        Ok(true)
+    }
+
     async fn cas_run_snapshot(
         &self,
         run_id: &RunId,
@@ -370,6 +398,35 @@ impl MobRunStore for InMemoryMobRunStore {
         if terminal && run.completed_at.is_none() {
             run.completed_at = Some(Utc::now());
         }
+        Ok(true)
+    }
+
+    async fn cas_run_snapshot_with_authority(
+        &self,
+        run_id: &RunId,
+        expected_status: MobRunStatus,
+        expected_flow_state: &flow_run::State,
+        next_status: MobRunStatus,
+        next_flow_state: &flow_run::State,
+        authority_inputs: Vec<mob_dsl::MobMachineInput>,
+    ) -> Result<bool, MobStoreError> {
+        let mut runs = self.runs.write().await;
+        let Some(run) = runs.get_mut(run_id) else {
+            return Ok(false);
+        };
+        if run.status != expected_status
+            || run.status.is_terminal()
+            || &run.flow_state != expected_flow_state
+        {
+            return Ok(false);
+        }
+        let terminal = next_status.is_terminal();
+        run.status = next_status;
+        run.flow_state = next_flow_state.clone();
+        if terminal && run.completed_at.is_none() {
+            run.completed_at = Some(Utc::now());
+        }
+        append_flow_authority_inputs(run, authority_inputs)?;
         Ok(true)
     }
 
@@ -494,6 +551,34 @@ impl MobRunStore for InMemoryMobRunStore {
         }
     }
 
+    async fn cas_frame_state_with_authority(
+        &self,
+        run_id: &RunId,
+        frame_id: &FrameId,
+        expected: Option<&FrameSnapshot>,
+        next: FrameSnapshot,
+        authority_inputs: Vec<mob_dsl::MobMachineInput>,
+    ) -> Result<bool, MobStoreError> {
+        let mut runs = self.runs.write().await;
+        let run = runs
+            .get_mut(run_id)
+            .ok_or_else(|| MobStoreError::NotFound(format!("run not found: {run_id}")))?;
+        let current = run.frames.get(frame_id);
+        match (expected, current) {
+            (None, None) => {
+                run.frames.insert(frame_id.clone(), next);
+                append_flow_authority_inputs(run, authority_inputs)?;
+                Ok(true)
+            }
+            (Some(exp), Some(cur)) if exp == cur => {
+                run.frames.insert(frame_id.clone(), next);
+                append_flow_authority_inputs(run, authority_inputs)?;
+                Ok(true)
+            }
+            _ => Ok(false),
+        }
+    }
+
     async fn cas_grant_node_slot(
         &self,
         run_id: &RunId,
@@ -517,6 +602,32 @@ impl MobRunStore for InMemoryMobRunStore {
         // Apply all updates
         run.flow_state = next_run_state;
         run.frames.insert(frame_id.clone(), next_frame);
+        Ok(true)
+    }
+
+    async fn cas_grant_node_slot_with_authority(
+        &self,
+        run_id: &RunId,
+        expected_run_state: &flow_run::State,
+        next_run_state: flow_run::State,
+        frame_id: &FrameId,
+        expected_frame: &FrameSnapshot,
+        next_frame: FrameSnapshot,
+        authority_inputs: Vec<mob_dsl::MobMachineInput>,
+    ) -> Result<bool, MobStoreError> {
+        let mut runs = self.runs.write().await;
+        let run = runs
+            .get_mut(run_id)
+            .ok_or_else(|| MobStoreError::NotFound(format!("run not found: {run_id}")))?;
+        if &run.flow_state != expected_run_state {
+            return Ok(false);
+        }
+        if run.frames.get(frame_id) != Some(expected_frame) {
+            return Ok(false);
+        }
+        run.flow_state = next_run_state;
+        run.frames.insert(frame_id.clone(), next_frame);
+        append_flow_authority_inputs(run, authority_inputs)?;
         Ok(true)
     }
 
@@ -568,6 +679,56 @@ impl MobRunStore for InMemoryMobRunStore {
     }
 
     #[allow(clippy::too_many_arguments)]
+    async fn cas_complete_step_and_record_output_with_authority(
+        &self,
+        run_id: &RunId,
+        frame_id: &FrameId,
+        expected_frame: &FrameSnapshot,
+        next_frame: FrameSnapshot,
+        step_output_key: String,
+        step_output: serde_json::Value,
+        loop_context: Option<(&LoopId, u64)>,
+        authority_inputs: Vec<mob_dsl::MobMachineInput>,
+    ) -> Result<bool, MobStoreError> {
+        let mut runs = self.runs.write().await;
+        let run = runs
+            .get_mut(run_id)
+            .ok_or_else(|| MobStoreError::NotFound(format!("run not found: {run_id}")))?;
+        if run.frames.get(frame_id) != Some(expected_frame) {
+            return Ok(false);
+        }
+        run.frames.insert(frame_id.clone(), next_frame);
+        match loop_context {
+            None => {
+                run.root_step_outputs.insert(
+                    crate::ids::StepId::from(step_output_key.as_str()),
+                    step_output,
+                );
+            }
+            Some((loop_id, iteration)) => {
+                let iteration_index = usize::try_from(iteration).map_err(|_| {
+                    MobStoreError::Internal(format!(
+                        "loop iteration index {iteration} exceeds usize::MAX on this target"
+                    ))
+                })?;
+                let vec = run
+                    .loop_iteration_outputs
+                    .entry(loop_id.clone())
+                    .or_default();
+                while vec.len() <= iteration_index {
+                    vec.push(IndexMap::new());
+                }
+                vec[iteration_index].insert(
+                    crate::ids::StepId::from(step_output_key.as_str()),
+                    step_output,
+                );
+            }
+        }
+        append_flow_authority_inputs(run, authority_inputs)?;
+        Ok(true)
+    }
+
+    #[allow(clippy::too_many_arguments)]
     async fn cas_start_loop(
         &self,
         run_id: &RunId,
@@ -599,6 +760,39 @@ impl MobRunStore for InMemoryMobRunStore {
         Ok(true)
     }
 
+    #[allow(clippy::too_many_arguments)]
+    async fn cas_start_loop_with_authority(
+        &self,
+        run_id: &RunId,
+        loop_instance_id: &LoopInstanceId,
+        expected_run_state: &flow_run::State,
+        next_run_state: flow_run::State,
+        frame_id: &FrameId,
+        expected_frame: &FrameSnapshot,
+        next_frame: FrameSnapshot,
+        initial_loop: LoopSnapshot,
+        authority_inputs: Vec<mob_dsl::MobMachineInput>,
+    ) -> Result<bool, MobStoreError> {
+        let mut runs = self.runs.write().await;
+        let run = runs
+            .get_mut(run_id)
+            .ok_or_else(|| MobStoreError::NotFound(format!("run not found: {run_id}")))?;
+        if &run.flow_state != expected_run_state {
+            return Ok(false);
+        }
+        if run.frames.get(frame_id) != Some(expected_frame) {
+            return Ok(false);
+        }
+        if run.loops.contains_key(loop_instance_id) {
+            return Ok(false);
+        }
+        run.flow_state = next_run_state;
+        run.frames.insert(frame_id.clone(), next_frame);
+        run.loops.insert(loop_instance_id.clone(), initial_loop);
+        append_flow_authority_inputs(run, authority_inputs)?;
+        Ok(true)
+    }
+
     async fn cas_loop_request_body_frame(
         &self,
         run_id: &RunId,
@@ -620,6 +814,32 @@ impl MobRunStore for InMemoryMobRunStore {
         }
         run.flow_state = next_run_state;
         run.loops.insert(loop_instance_id.clone(), next_loop);
+        Ok(true)
+    }
+
+    async fn cas_loop_request_body_frame_with_authority(
+        &self,
+        run_id: &RunId,
+        loop_instance_id: &LoopInstanceId,
+        expected_loop: &LoopSnapshot,
+        next_loop: LoopSnapshot,
+        expected_run_state: &flow_run::State,
+        next_run_state: flow_run::State,
+        authority_inputs: Vec<mob_dsl::MobMachineInput>,
+    ) -> Result<bool, MobStoreError> {
+        let mut runs = self.runs.write().await;
+        let run = runs
+            .get_mut(run_id)
+            .ok_or_else(|| MobStoreError::NotFound(format!("run not found: {run_id}")))?;
+        if &run.flow_state != expected_run_state {
+            return Ok(false);
+        }
+        if run.loops.get(loop_instance_id) != Some(expected_loop) {
+            return Ok(false);
+        }
+        run.flow_state = next_run_state;
+        run.loops.insert(loop_instance_id.clone(), next_loop);
+        append_flow_authority_inputs(run, authority_inputs)?;
         Ok(true)
     }
 
@@ -664,6 +884,47 @@ impl MobRunStore for InMemoryMobRunStore {
     }
 
     #[allow(clippy::too_many_arguments)]
+    async fn cas_grant_body_frame_start_with_authority(
+        &self,
+        run_id: &RunId,
+        loop_instance_id: &LoopInstanceId,
+        expected_loop: &LoopSnapshot,
+        next_loop: LoopSnapshot,
+        frame_id: &FrameId,
+        initial_frame: FrameSnapshot,
+        ledger_entry: LoopIterationLedgerEntry,
+        expected_run_state: &flow_run::State,
+        next_run_state: flow_run::State,
+        authority_inputs: Vec<mob_dsl::MobMachineInput>,
+    ) -> Result<bool, MobStoreError> {
+        let mut runs = self.runs.write().await;
+        let run = runs
+            .get_mut(run_id)
+            .ok_or_else(|| MobStoreError::NotFound(format!("run not found: {run_id}")))?;
+        if &run.flow_state != expected_run_state {
+            return Ok(false);
+        }
+        if run.loops.get(loop_instance_id) != Some(expected_loop) {
+            return Ok(false);
+        }
+        if run.frames.contains_key(frame_id) {
+            return Ok(false);
+        }
+        run.flow_state = next_run_state;
+        run.loops.insert(loop_instance_id.clone(), next_loop);
+        run.frames.insert(frame_id.clone(), initial_frame);
+        if !run.loop_iteration_ledger.iter().any(|existing| {
+            existing.loop_instance_id == ledger_entry.loop_instance_id
+                && existing.iteration == ledger_entry.iteration
+                && existing.frame_id == ledger_entry.frame_id
+        }) {
+            run.loop_iteration_ledger.push(ledger_entry);
+        }
+        append_flow_authority_inputs(run, authority_inputs)?;
+        Ok(true)
+    }
+
+    #[allow(clippy::too_many_arguments)]
     async fn cas_complete_body_frame(
         &self,
         run_id: &RunId,
@@ -696,6 +957,40 @@ impl MobRunStore for InMemoryMobRunStore {
     }
 
     #[allow(clippy::too_many_arguments)]
+    async fn cas_complete_body_frame_with_authority(
+        &self,
+        run_id: &RunId,
+        loop_instance_id: &LoopInstanceId,
+        expected_loop: &LoopSnapshot,
+        next_loop: LoopSnapshot,
+        frame_id: &FrameId,
+        expected_frame: &FrameSnapshot,
+        next_frame: FrameSnapshot,
+        expected_run_state: &flow_run::State,
+        next_run_state: flow_run::State,
+        authority_inputs: Vec<mob_dsl::MobMachineInput>,
+    ) -> Result<bool, MobStoreError> {
+        let mut runs = self.runs.write().await;
+        let run = runs
+            .get_mut(run_id)
+            .ok_or_else(|| MobStoreError::NotFound(format!("run not found: {run_id}")))?;
+        if &run.flow_state != expected_run_state {
+            return Ok(false);
+        }
+        if run.loops.get(loop_instance_id) != Some(expected_loop) {
+            return Ok(false);
+        }
+        if run.frames.get(frame_id) != Some(expected_frame) {
+            return Ok(false);
+        }
+        run.flow_state = next_run_state;
+        run.loops.insert(loop_instance_id.clone(), next_loop);
+        run.frames.insert(frame_id.clone(), next_frame);
+        append_flow_authority_inputs(run, authority_inputs)?;
+        Ok(true)
+    }
+
+    #[allow(clippy::too_many_arguments)]
     async fn cas_complete_loop(
         &self,
         run_id: &RunId,
@@ -724,6 +1019,40 @@ impl MobRunStore for InMemoryMobRunStore {
         run.flow_state = next_run_state;
         run.loops.insert(loop_instance_id.clone(), next_loop);
         run.frames.insert(frame_id.clone(), next_frame);
+        Ok(true)
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    async fn cas_complete_loop_with_authority(
+        &self,
+        run_id: &RunId,
+        loop_instance_id: &LoopInstanceId,
+        expected_loop: &LoopSnapshot,
+        next_loop: LoopSnapshot,
+        frame_id: &FrameId,
+        expected_frame: &FrameSnapshot,
+        next_frame: FrameSnapshot,
+        expected_run_state: &flow_run::State,
+        next_run_state: flow_run::State,
+        authority_inputs: Vec<mob_dsl::MobMachineInput>,
+    ) -> Result<bool, MobStoreError> {
+        let mut runs = self.runs.write().await;
+        let run = runs
+            .get_mut(run_id)
+            .ok_or_else(|| MobStoreError::NotFound(format!("run not found: {run_id}")))?;
+        if &run.flow_state != expected_run_state {
+            return Ok(false);
+        }
+        if run.loops.get(loop_instance_id) != Some(expected_loop) {
+            return Ok(false);
+        }
+        if run.frames.get(frame_id) != Some(expected_frame) {
+            return Ok(false);
+        }
+        run.flow_state = next_run_state;
+        run.loops.insert(loop_instance_id.clone(), next_loop);
+        run.frames.insert(frame_id.clone(), next_frame);
+        append_flow_authority_inputs(run, authority_inputs)?;
         Ok(true)
     }
 }
@@ -962,6 +1291,7 @@ mod tests {
             schema_version: 4,
             root_step_outputs: IndexMap::new(),
             loop_iteration_outputs: BTreeMap::new(),
+            flow_authority_inputs: Vec::new(),
         }
     }
 

--- a/meerkat-mob/src/store/in_memory.rs
+++ b/meerkat-mob/src/store/in_memory.rs
@@ -605,6 +605,7 @@ impl MobRunStore for InMemoryMobRunStore {
         Ok(true)
     }
 
+    #[allow(clippy::too_many_arguments)]
     async fn cas_grant_node_slot_with_authority(
         &self,
         run_id: &RunId,
@@ -817,6 +818,7 @@ impl MobRunStore for InMemoryMobRunStore {
         Ok(true)
     }
 
+    #[allow(clippy::too_many_arguments)]
     async fn cas_loop_request_body_frame_with_authority(
         &self,
         run_id: &RunId,

--- a/meerkat-mob/src/store/mod.rs
+++ b/meerkat-mob/src/store/mod.rs
@@ -21,6 +21,7 @@ use crate::event::{MemberRef, MobEvent, NewMobEvent};
 use crate::ids::{
     AgentIdentity, FlowId, FrameId, Generation, LoopId, LoopInstanceId, MobId, RunId, StepId,
 };
+use crate::machines::mob_machine as mob_dsl;
 use crate::run::flow_run;
 use crate::run::{
     FailureLedgerEntry, FrameSnapshot, LoopIterationLedgerEntry, LoopSnapshot, MobRun,
@@ -305,6 +306,13 @@ pub trait MobRunStore: Send + Sync {
         expected: &flow_run::State,
         next: &flow_run::State,
     ) -> Result<bool, MobStoreError>;
+    async fn cas_flow_state_with_authority(
+        &self,
+        run_id: &RunId,
+        expected: &flow_run::State,
+        next: &flow_run::State,
+        authority_inputs: Vec<mob_dsl::MobMachineInput>,
+    ) -> Result<bool, MobStoreError>;
     async fn cas_run_snapshot(
         &self,
         run_id: &RunId,
@@ -312,6 +320,15 @@ pub trait MobRunStore: Send + Sync {
         expected_flow_state: &flow_run::State,
         next_status: MobRunStatus,
         next_flow_state: &flow_run::State,
+    ) -> Result<bool, MobStoreError>;
+    async fn cas_run_snapshot_with_authority(
+        &self,
+        run_id: &RunId,
+        expected_status: MobRunStatus,
+        expected_flow_state: &flow_run::State,
+        next_status: MobRunStatus,
+        next_flow_state: &flow_run::State,
+        authority_inputs: Vec<mob_dsl::MobMachineInput>,
     ) -> Result<bool, MobStoreError>;
     async fn append_step_entry(
         &self,
@@ -370,6 +387,14 @@ pub trait MobRunStore: Send + Sync {
         expected: Option<&FrameSnapshot>,
         next: FrameSnapshot,
     ) -> Result<bool, MobStoreError>;
+    async fn cas_frame_state_with_authority(
+        &self,
+        run_id: &RunId,
+        frame_id: &FrameId,
+        expected: Option<&FrameSnapshot>,
+        next: FrameSnapshot,
+        authority_inputs: Vec<mob_dsl::MobMachineInput>,
+    ) -> Result<bool, MobStoreError>;
 
     /// CAS wrapper 2: grant node slot — atomically update run flow state + frame state.
     ///
@@ -384,6 +409,16 @@ pub trait MobRunStore: Send + Sync {
         frame_id: &FrameId,
         expected_frame: &FrameSnapshot,
         next_frame: FrameSnapshot,
+    ) -> Result<bool, MobStoreError>;
+    async fn cas_grant_node_slot_with_authority(
+        &self,
+        run_id: &RunId,
+        expected_run_state: &flow_run::State,
+        next_run_state: flow_run::State,
+        frame_id: &FrameId,
+        expected_frame: &FrameSnapshot,
+        next_frame: FrameSnapshot,
+        authority_inputs: Vec<mob_dsl::MobMachineInput>,
     ) -> Result<bool, MobStoreError>;
 
     /// CAS wrapper 3: complete step — update frame state and record step output.
@@ -406,6 +441,18 @@ pub trait MobRunStore: Send + Sync {
         step_output: serde_json::Value,
         loop_context: Option<(&LoopId, u64)>,
     ) -> Result<bool, MobStoreError>;
+    #[allow(clippy::too_many_arguments)]
+    async fn cas_complete_step_and_record_output_with_authority(
+        &self,
+        run_id: &RunId,
+        frame_id: &FrameId,
+        expected_frame: &FrameSnapshot,
+        next_frame: FrameSnapshot,
+        step_output_key: String,
+        step_output: serde_json::Value,
+        loop_context: Option<(&LoopId, u64)>,
+        authority_inputs: Vec<mob_dsl::MobMachineInput>,
+    ) -> Result<bool, MobStoreError>;
 
     /// CAS wrapper 4: start loop — register loop + update run state + parent frame.
     ///
@@ -424,6 +471,19 @@ pub trait MobRunStore: Send + Sync {
         next_frame: FrameSnapshot,
         initial_loop: LoopSnapshot,
     ) -> Result<bool, MobStoreError>;
+    #[allow(clippy::too_many_arguments)]
+    async fn cas_start_loop_with_authority(
+        &self,
+        run_id: &RunId,
+        loop_instance_id: &LoopInstanceId,
+        expected_run_state: &flow_run::State,
+        next_run_state: flow_run::State,
+        frame_id: &FrameId,
+        expected_frame: &FrameSnapshot,
+        next_frame: FrameSnapshot,
+        initial_loop: LoopSnapshot,
+        authority_inputs: Vec<mob_dsl::MobMachineInput>,
+    ) -> Result<bool, MobStoreError>;
 
     /// CAS wrapper 5: register pending body frame — loop transition + run state update.
     ///
@@ -438,6 +498,16 @@ pub trait MobRunStore: Send + Sync {
         next_loop: LoopSnapshot,
         expected_run_state: &flow_run::State,
         next_run_state: flow_run::State,
+    ) -> Result<bool, MobStoreError>;
+    async fn cas_loop_request_body_frame_with_authority(
+        &self,
+        run_id: &RunId,
+        loop_instance_id: &LoopInstanceId,
+        expected_loop: &LoopSnapshot,
+        next_loop: LoopSnapshot,
+        expected_run_state: &flow_run::State,
+        next_run_state: flow_run::State,
+        authority_inputs: Vec<mob_dsl::MobMachineInput>,
     ) -> Result<bool, MobStoreError>;
 
     /// CAS wrapper 6: body frame start — loop transition + register new frame + run state update.
@@ -458,6 +528,20 @@ pub trait MobRunStore: Send + Sync {
         expected_run_state: &flow_run::State,
         next_run_state: flow_run::State,
     ) -> Result<bool, MobStoreError>;
+    #[allow(clippy::too_many_arguments)]
+    async fn cas_grant_body_frame_start_with_authority(
+        &self,
+        run_id: &RunId,
+        loop_instance_id: &LoopInstanceId,
+        expected_loop: &LoopSnapshot,
+        next_loop: LoopSnapshot,
+        frame_id: &FrameId,
+        initial_frame: FrameSnapshot,
+        ledger_entry: LoopIterationLedgerEntry,
+        expected_run_state: &flow_run::State,
+        next_run_state: flow_run::State,
+        authority_inputs: Vec<mob_dsl::MobMachineInput>,
+    ) -> Result<bool, MobStoreError>;
 
     /// CAS wrapper 7: body frame completion — terminalize frame + loop state update + run state.
     ///
@@ -477,6 +561,20 @@ pub trait MobRunStore: Send + Sync {
         expected_run_state: &flow_run::State,
         next_run_state: flow_run::State,
     ) -> Result<bool, MobStoreError>;
+    #[allow(clippy::too_many_arguments)]
+    async fn cas_complete_body_frame_with_authority(
+        &self,
+        run_id: &RunId,
+        loop_instance_id: &LoopInstanceId,
+        expected_loop: &LoopSnapshot,
+        next_loop: LoopSnapshot,
+        frame_id: &FrameId,
+        expected_frame: &FrameSnapshot,
+        next_frame: FrameSnapshot,
+        expected_run_state: &flow_run::State,
+        next_run_state: flow_run::State,
+        authority_inputs: Vec<mob_dsl::MobMachineInput>,
+    ) -> Result<bool, MobStoreError>;
 
     /// CAS wrapper 8: loop completion — loop state + run state + parent frame update.
     ///
@@ -495,6 +593,20 @@ pub trait MobRunStore: Send + Sync {
         next_frame: FrameSnapshot,
         expected_run_state: &flow_run::State,
         next_run_state: flow_run::State,
+    ) -> Result<bool, MobStoreError>;
+    #[allow(clippy::too_many_arguments)]
+    async fn cas_complete_loop_with_authority(
+        &self,
+        run_id: &RunId,
+        loop_instance_id: &LoopInstanceId,
+        expected_loop: &LoopSnapshot,
+        next_loop: LoopSnapshot,
+        frame_id: &FrameId,
+        expected_frame: &FrameSnapshot,
+        next_frame: FrameSnapshot,
+        expected_run_state: &flow_run::State,
+        next_run_state: flow_run::State,
+        authority_inputs: Vec<mob_dsl::MobMachineInput>,
     ) -> Result<bool, MobStoreError>;
 }
 

--- a/meerkat-mob/src/store/mod.rs
+++ b/meerkat-mob/src/store/mod.rs
@@ -410,6 +410,7 @@ pub trait MobRunStore: Send + Sync {
         expected_frame: &FrameSnapshot,
         next_frame: FrameSnapshot,
     ) -> Result<bool, MobStoreError>;
+    #[allow(clippy::too_many_arguments)]
     async fn cas_grant_node_slot_with_authority(
         &self,
         run_id: &RunId,
@@ -499,6 +500,7 @@ pub trait MobRunStore: Send + Sync {
         expected_run_state: &flow_run::State,
         next_run_state: flow_run::State,
     ) -> Result<bool, MobStoreError>;
+    #[allow(clippy::too_many_arguments)]
     async fn cas_loop_request_body_frame_with_authority(
         &self,
         run_id: &RunId,

--- a/meerkat-mob/src/store/sqlite.rs
+++ b/meerkat-mob/src/store/sqlite.rs
@@ -14,6 +14,7 @@ use crate::event::{MobEvent, NewMobEvent, decode_stored_mob_event, encode_stored
 use crate::ids::{
     AgentIdentity, FlowId, FrameId, Generation, LoopId, LoopInstanceId, MobId, RunId, StepId,
 };
+use crate::machines::mob_machine as mob_dsl;
 use crate::profile::Profile;
 use crate::run::flow_run;
 use crate::run::{
@@ -940,11 +941,57 @@ pub struct SqliteMobRunStore {
     path: PathBuf,
 }
 
+#[derive(Debug, Clone, Copy)]
+enum MissingRunCasBehavior {
+    ReturnFalse,
+    NotFound,
+}
+
 impl std::fmt::Debug for SqliteMobRunStore {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("SqliteMobRunStore")
             .field("path", &self.path)
             .finish()
+    }
+}
+
+impl SqliteMobRunStore {
+    async fn update_run_with_authority_if<F>(
+        &self,
+        run_id: &RunId,
+        missing_behavior: MissingRunCasBehavior,
+        authority_inputs: Vec<mob_dsl::MobMachineInput>,
+        update: F,
+    ) -> Result<bool, MobStoreError>
+    where
+        F: FnOnce(&mut MobRun) -> Result<bool, MobStoreError> + Send + 'static,
+    {
+        let path = self.path.clone();
+        let key = run_id.to_string();
+        let run_id = run_id.clone();
+        run_sqlite_task(move || {
+            let mut conn = open_connection(&path)?;
+            let tx = begin_immediate(&mut conn)?;
+            let bytes = load_run_bytes(&tx, &key)?;
+            let Some(bytes) = bytes else {
+                return match missing_behavior {
+                    MissingRunCasBehavior::ReturnFalse => Ok(false),
+                    MissingRunCasBehavior::NotFound => {
+                        Err(MobStoreError::NotFound(format!("run not found: {run_id}")))
+                    }
+                };
+            };
+            let mut run: MobRun = decode_json(&bytes)?;
+            if !update(&mut run)? {
+                return Ok(false);
+            }
+            run.append_flow_authority_inputs(authority_inputs)
+                .map_err(|error| MobStoreError::Internal(error.to_string()))?;
+            write_run_json(&tx, &key, &run)?;
+            tx.commit().map_err(se)?;
+            Ok(true)
+        })
+        .await
     }
 }
 
@@ -1117,6 +1164,30 @@ impl MobRunStore for SqliteMobRunStore {
         .await
     }
 
+    async fn cas_flow_state_with_authority(
+        &self,
+        run_id: &RunId,
+        expected: &flow_run::State,
+        next: &flow_run::State,
+        authority_inputs: Vec<mob_dsl::MobMachineInput>,
+    ) -> Result<bool, MobStoreError> {
+        let expected = expected.clone();
+        let next = next.clone();
+        self.update_run_with_authority_if(
+            run_id,
+            MissingRunCasBehavior::ReturnFalse,
+            authority_inputs,
+            move |run| {
+                if run.flow_state != expected {
+                    return Ok(false);
+                }
+                run.flow_state = next;
+                Ok(true)
+            },
+        )
+        .await
+    }
+
     async fn cas_run_snapshot(
         &self,
         run_id: &RunId,
@@ -1165,6 +1236,40 @@ impl MobRunStore for SqliteMobRunStore {
             tx.commit().map_err(se)?;
             Ok(true)
         })
+        .await
+    }
+
+    async fn cas_run_snapshot_with_authority(
+        &self,
+        run_id: &RunId,
+        expected_status: MobRunStatus,
+        expected_flow_state: &flow_run::State,
+        next_status: MobRunStatus,
+        next_flow_state: &flow_run::State,
+        authority_inputs: Vec<mob_dsl::MobMachineInput>,
+    ) -> Result<bool, MobStoreError> {
+        let expected_flow_state = expected_flow_state.clone();
+        let next_flow_state = next_flow_state.clone();
+        self.update_run_with_authority_if(
+            run_id,
+            MissingRunCasBehavior::ReturnFalse,
+            authority_inputs,
+            move |run| {
+                if run.status != expected_status
+                    || run.status.is_terminal()
+                    || run.flow_state != expected_flow_state
+                {
+                    return Ok(false);
+                }
+                let terminal = next_status.is_terminal();
+                run.status = next_status;
+                run.flow_state = next_flow_state;
+                if terminal && run.completed_at.is_none() {
+                    run.completed_at = Some(Utc::now());
+                }
+                Ok(true)
+            },
+        )
         .await
     }
 
@@ -1400,6 +1505,37 @@ impl MobRunStore for SqliteMobRunStore {
         .await
     }
 
+    async fn cas_frame_state_with_authority(
+        &self,
+        run_id: &RunId,
+        frame_id: &FrameId,
+        expected: Option<&FrameSnapshot>,
+        next: FrameSnapshot,
+        authority_inputs: Vec<mob_dsl::MobMachineInput>,
+    ) -> Result<bool, MobStoreError> {
+        let frame_id = frame_id.clone();
+        let expected = expected.cloned();
+        self.update_run_with_authority_if(
+            run_id,
+            MissingRunCasBehavior::NotFound,
+            authority_inputs,
+            move |run| {
+                let current = run.frames.get(&frame_id);
+                let matches = match (expected.as_ref(), current) {
+                    (None, None) => true,
+                    (Some(exp), Some(cur)) => exp == cur,
+                    _ => false,
+                };
+                if !matches {
+                    return Ok(false);
+                }
+                run.frames.insert(frame_id, next);
+                Ok(true)
+            },
+        )
+        .await
+    }
+
     async fn cas_grant_node_slot(
         &self,
         run_id: &RunId,
@@ -1435,6 +1571,38 @@ impl MobRunStore for SqliteMobRunStore {
             tx.commit().map_err(se)?;
             Ok(true)
         })
+        .await
+    }
+
+    async fn cas_grant_node_slot_with_authority(
+        &self,
+        run_id: &RunId,
+        expected_run_state: &flow_run::State,
+        next_run_state: flow_run::State,
+        frame_id: &FrameId,
+        expected_frame: &FrameSnapshot,
+        next_frame: FrameSnapshot,
+        authority_inputs: Vec<mob_dsl::MobMachineInput>,
+    ) -> Result<bool, MobStoreError> {
+        let expected_run_state = expected_run_state.clone();
+        let frame_id = frame_id.clone();
+        let expected_frame = expected_frame.clone();
+        self.update_run_with_authority_if(
+            run_id,
+            MissingRunCasBehavior::NotFound,
+            authority_inputs,
+            move |run| {
+                if run.flow_state != expected_run_state {
+                    return Ok(false);
+                }
+                if run.frames.get(&frame_id) != Some(&expected_frame) {
+                    return Ok(false);
+                }
+                run.flow_state = next_run_state;
+                run.frames.insert(frame_id, next_frame);
+                Ok(true)
+            },
+        )
         .await
     }
 
@@ -1494,6 +1662,55 @@ impl MobRunStore for SqliteMobRunStore {
     }
 
     #[allow(clippy::too_many_arguments)]
+    async fn cas_complete_step_and_record_output_with_authority(
+        &self,
+        run_id: &RunId,
+        frame_id: &FrameId,
+        expected_frame: &FrameSnapshot,
+        next_frame: FrameSnapshot,
+        step_output_key: String,
+        step_output: serde_json::Value,
+        loop_context: Option<(&LoopId, u64)>,
+        authority_inputs: Vec<mob_dsl::MobMachineInput>,
+    ) -> Result<bool, MobStoreError> {
+        let frame_id = frame_id.clone();
+        let expected_frame = expected_frame.clone();
+        let loop_context = loop_context.map(|(loop_id, iteration)| (loop_id.clone(), iteration));
+        self.update_run_with_authority_if(
+            run_id,
+            MissingRunCasBehavior::NotFound,
+            authority_inputs,
+            move |run| {
+                if run.frames.get(&frame_id) != Some(&expected_frame) {
+                    return Ok(false);
+                }
+                run.frames.insert(frame_id, next_frame);
+                match loop_context {
+                    None => {
+                        run.root_step_outputs
+                            .insert(StepId::from(step_output_key.as_str()), step_output);
+                    }
+                    Some((loop_id, iteration)) => {
+                        let iteration_index = usize::try_from(iteration).map_err(|_| {
+                            MobStoreError::Internal(format!(
+                                "loop iteration index {iteration} exceeds usize::MAX on this target"
+                            ))
+                        })?;
+                        let outputs = run.loop_iteration_outputs.entry(loop_id).or_default();
+                        while outputs.len() <= iteration_index {
+                            outputs.push(indexmap::IndexMap::new());
+                        }
+                        outputs[iteration_index]
+                            .insert(StepId::from(step_output_key.as_str()), step_output);
+                    }
+                }
+                Ok(true)
+            },
+        )
+        .await
+    }
+
+    #[allow(clippy::too_many_arguments)]
     async fn cas_start_loop(
         &self,
         run_id: &RunId,
@@ -1539,6 +1756,46 @@ impl MobRunStore for SqliteMobRunStore {
         .await
     }
 
+    #[allow(clippy::too_many_arguments)]
+    async fn cas_start_loop_with_authority(
+        &self,
+        run_id: &RunId,
+        loop_instance_id: &LoopInstanceId,
+        expected_run_state: &flow_run::State,
+        next_run_state: flow_run::State,
+        frame_id: &FrameId,
+        expected_frame: &FrameSnapshot,
+        next_frame: FrameSnapshot,
+        initial_loop: LoopSnapshot,
+        authority_inputs: Vec<mob_dsl::MobMachineInput>,
+    ) -> Result<bool, MobStoreError> {
+        let loop_instance_id = loop_instance_id.clone();
+        let expected_run_state = expected_run_state.clone();
+        let frame_id = frame_id.clone();
+        let expected_frame = expected_frame.clone();
+        self.update_run_with_authority_if(
+            run_id,
+            MissingRunCasBehavior::NotFound,
+            authority_inputs,
+            move |run| {
+                if run.flow_state != expected_run_state {
+                    return Ok(false);
+                }
+                if run.frames.get(&frame_id) != Some(&expected_frame) {
+                    return Ok(false);
+                }
+                if run.loops.contains_key(&loop_instance_id) {
+                    return Ok(false);
+                }
+                run.flow_state = next_run_state;
+                run.frames.insert(frame_id, next_frame);
+                run.loops.insert(loop_instance_id, initial_loop);
+                Ok(true)
+            },
+        )
+        .await
+    }
+
     async fn cas_loop_request_body_frame(
         &self,
         run_id: &RunId,
@@ -1574,6 +1831,38 @@ impl MobRunStore for SqliteMobRunStore {
             tx.commit().map_err(se)?;
             Ok(true)
         })
+        .await
+    }
+
+    async fn cas_loop_request_body_frame_with_authority(
+        &self,
+        run_id: &RunId,
+        loop_instance_id: &LoopInstanceId,
+        expected_loop: &LoopSnapshot,
+        next_loop: LoopSnapshot,
+        expected_run_state: &flow_run::State,
+        next_run_state: flow_run::State,
+        authority_inputs: Vec<mob_dsl::MobMachineInput>,
+    ) -> Result<bool, MobStoreError> {
+        let loop_instance_id = loop_instance_id.clone();
+        let expected_loop = expected_loop.clone();
+        let expected_run_state = expected_run_state.clone();
+        self.update_run_with_authority_if(
+            run_id,
+            MissingRunCasBehavior::NotFound,
+            authority_inputs,
+            move |run| {
+                if run.flow_state != expected_run_state {
+                    return Ok(false);
+                }
+                if run.loops.get(&loop_instance_id) != Some(&expected_loop) {
+                    return Ok(false);
+                }
+                run.flow_state = next_run_state;
+                run.loops.insert(loop_instance_id, next_loop);
+                Ok(true)
+            },
+        )
         .await
     }
 
@@ -1626,6 +1915,48 @@ impl MobRunStore for SqliteMobRunStore {
     }
 
     #[allow(clippy::too_many_arguments)]
+    async fn cas_grant_body_frame_start_with_authority(
+        &self,
+        run_id: &RunId,
+        loop_instance_id: &LoopInstanceId,
+        expected_loop: &LoopSnapshot,
+        next_loop: LoopSnapshot,
+        frame_id: &FrameId,
+        initial_frame: FrameSnapshot,
+        ledger_entry: LoopIterationLedgerEntry,
+        expected_run_state: &flow_run::State,
+        next_run_state: flow_run::State,
+        authority_inputs: Vec<mob_dsl::MobMachineInput>,
+    ) -> Result<bool, MobStoreError> {
+        let loop_instance_id = loop_instance_id.clone();
+        let expected_loop = expected_loop.clone();
+        let frame_id = frame_id.clone();
+        let expected_run_state = expected_run_state.clone();
+        self.update_run_with_authority_if(
+            run_id,
+            MissingRunCasBehavior::NotFound,
+            authority_inputs,
+            move |run| {
+                if run.flow_state != expected_run_state {
+                    return Ok(false);
+                }
+                if run.loops.get(&loop_instance_id) != Some(&expected_loop) {
+                    return Ok(false);
+                }
+                if run.frames.contains_key(&frame_id) {
+                    return Ok(false);
+                }
+                run.flow_state = next_run_state;
+                run.loops.insert(loop_instance_id, next_loop);
+                run.frames.insert(frame_id, initial_frame);
+                append_loop_iteration_ledger_if_absent(run, ledger_entry);
+                Ok(true)
+            },
+        )
+        .await
+    }
+
+    #[allow(clippy::too_many_arguments)]
     async fn cas_complete_body_frame(
         &self,
         run_id: &RunId,
@@ -1674,6 +2005,48 @@ impl MobRunStore for SqliteMobRunStore {
     }
 
     #[allow(clippy::too_many_arguments)]
+    async fn cas_complete_body_frame_with_authority(
+        &self,
+        run_id: &RunId,
+        loop_instance_id: &LoopInstanceId,
+        expected_loop: &LoopSnapshot,
+        next_loop: LoopSnapshot,
+        frame_id: &FrameId,
+        expected_frame: &FrameSnapshot,
+        next_frame: FrameSnapshot,
+        expected_run_state: &flow_run::State,
+        next_run_state: flow_run::State,
+        authority_inputs: Vec<mob_dsl::MobMachineInput>,
+    ) -> Result<bool, MobStoreError> {
+        let loop_instance_id = loop_instance_id.clone();
+        let expected_loop = expected_loop.clone();
+        let frame_id = frame_id.clone();
+        let expected_frame = expected_frame.clone();
+        let expected_run_state = expected_run_state.clone();
+        self.update_run_with_authority_if(
+            run_id,
+            MissingRunCasBehavior::NotFound,
+            authority_inputs,
+            move |run| {
+                if run.flow_state != expected_run_state {
+                    return Ok(false);
+                }
+                if run.loops.get(&loop_instance_id) != Some(&expected_loop) {
+                    return Ok(false);
+                }
+                if run.frames.get(&frame_id) != Some(&expected_frame) {
+                    return Ok(false);
+                }
+                run.flow_state = next_run_state;
+                run.loops.insert(loop_instance_id, next_loop);
+                run.frames.insert(frame_id, next_frame);
+                Ok(true)
+            },
+        )
+        .await
+    }
+
+    #[allow(clippy::too_many_arguments)]
     async fn cas_complete_loop(
         &self,
         run_id: &RunId,
@@ -1718,6 +2091,48 @@ impl MobRunStore for SqliteMobRunStore {
             tx.commit().map_err(se)?;
             Ok(true)
         })
+        .await
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    async fn cas_complete_loop_with_authority(
+        &self,
+        run_id: &RunId,
+        loop_instance_id: &LoopInstanceId,
+        expected_loop: &LoopSnapshot,
+        next_loop: LoopSnapshot,
+        frame_id: &FrameId,
+        expected_frame: &FrameSnapshot,
+        next_frame: FrameSnapshot,
+        expected_run_state: &flow_run::State,
+        next_run_state: flow_run::State,
+        authority_inputs: Vec<mob_dsl::MobMachineInput>,
+    ) -> Result<bool, MobStoreError> {
+        let loop_instance_id = loop_instance_id.clone();
+        let expected_loop = expected_loop.clone();
+        let frame_id = frame_id.clone();
+        let expected_frame = expected_frame.clone();
+        let expected_run_state = expected_run_state.clone();
+        self.update_run_with_authority_if(
+            run_id,
+            MissingRunCasBehavior::NotFound,
+            authority_inputs,
+            move |run| {
+                if run.flow_state != expected_run_state {
+                    return Ok(false);
+                }
+                if run.loops.get(&loop_instance_id) != Some(&expected_loop) {
+                    return Ok(false);
+                }
+                if run.frames.get(&frame_id) != Some(&expected_frame) {
+                    return Ok(false);
+                }
+                run.flow_state = next_run_state;
+                run.loops.insert(loop_instance_id, next_loop);
+                run.frames.insert(frame_id, next_frame);
+                Ok(true)
+            },
+        )
         .await
     }
 }
@@ -2272,6 +2687,7 @@ mod tests {
             schema_version: 4,
             root_step_outputs: IndexMap::new(),
             loop_iteration_outputs: std::collections::BTreeMap::new(),
+            flow_authority_inputs: Vec::new(),
         }
     }
 

--- a/meerkat-mob/src/store/sqlite.rs
+++ b/meerkat-mob/src/store/sqlite.rs
@@ -1574,6 +1574,7 @@ impl MobRunStore for SqliteMobRunStore {
         .await
     }
 
+    #[allow(clippy::too_many_arguments)]
     async fn cas_grant_node_slot_with_authority(
         &self,
         run_id: &RunId,
@@ -1834,6 +1835,7 @@ impl MobRunStore for SqliteMobRunStore {
         .await
     }
 
+    #[allow(clippy::too_many_arguments)]
     async fn cas_loop_request_body_frame_with_authority(
         &self,
         run_id: &RunId,

--- a/meerkat-mob/tests/flow_frame_recovery_tests.rs
+++ b/meerkat-mob/tests/flow_frame_recovery_tests.rs
@@ -31,6 +31,7 @@ fn minimal_run_with_schema_v2() -> MobRun {
         schema_version: 4,
         root_step_outputs: IndexMap::new(),
         loop_iteration_outputs: BTreeMap::new(),
+        flow_authority_inputs: Vec::new(),
     }
 }
 


### PR DESCRIPTION
## Summary
- Persist flow projections through the same store CAS + authority-input path that admits MobMachine flow transitions, so stale projection writes lose before authority is prepared.
- Replay persisted flow authority inputs during recovery and reject durable divergence between the authority log and stored flow/frame/loop projections.
- Fail closed when MobMachine authority contains frame/loop keys missing from persisted projections, and converge recovered active `RunFlow` residue to canceled before accepting new commands.

## Atomicity boundary
The durable boundary is the flow store CAS that writes the projection and its matching `FlowAuthorityInputRecord` together. MobMachine authority is only advanced from those persisted records; if the store CAS fails, authority is not prepared/committed. On recovery, the authority log is replayed and compared against the stored projections in both directions before runtime state is admitted.

## Rework boundary
Recovery now validates that every authority-created frame and loop for the run has a persisted projection, not only that persisted projections match replayed authority. If resume finds a non-terminal persisted flow whose authority log had already admitted `RunFlow`, it records terminal cancellation through the same authority-input path, applies `CompleteFlow`/`FinishRun`, and avoids restoring an untracked active authority count.

## Validation
- RED before implementation: `./scripts/repo-cargo test -p meerkat-mob recovery_rejects_authority_created -- --nocapture` failed for missing frame/loop projection fixtures.
- RED before implementation: `./scripts/repo-cargo test -p meerkat-mob resume_converges_untracked_active_flow_runs -- --nocapture` failed because resumed crash residue stayed `Running`.
- GREEN: `./scripts/repo-cargo test -p meerkat-mob recovery_rejects_authority_created -- --nocapture` passed, 2 tests.
- GREEN: `./scripts/repo-cargo test -p meerkat-mob resume_converges_untracked_active_flow_runs -- --nocapture` passed, 1 test.
- GREEN: `./scripts/repo-cargo test -p meerkat-mob authority -- --nocapture` passed, 20 tests.
- GREEN: `./scripts/repo-cargo test -p meerkat-mob --test flow_frame_recovery_tests -- --nocapture` passed, 9 tests.
- GREEN: `./scripts/repo-cargo fmt --check` passed.
- GREEN: `git diff --check` passed.
- GREEN: `MEERKAT_BUILDBUDDY=1 make check` passed after rebasing on `origin/main` `6a139f2`. BuildBuddy invocation: `e8939d47-d778-4075-b6dd-1da9ccf26576`.