### PR TITLE
LUC-110 Unify async stop terminalization

### DIFF
--- a/meerkat-runtime/BUILD.bazel
+++ b/meerkat-runtime/BUILD.bazel
@@ -330,7 +330,9 @@ rust_test(
         "fast",
     ],
     size = "small",
-    data = [],
+    data = [
+        ":package_runfiles",
+    ],
     env = {
         "RUST_MIN_STACK": "16777216",
     },

--- a/meerkat-runtime/src/control_plane.rs
+++ b/meerkat-runtime/src/control_plane.rs
@@ -5,42 +5,44 @@
 //! the per-session driver. These helpers keep the concrete stop/preemption
 //! behavior in one place.
 
-use std::sync::Weak;
-
 use meerkat_core::lifecycle::run_control::RunControlCommand;
-use meerkat_core::types::SessionId;
 
-use crate::meerkat_machine::{MeerkatMachine, SharedCompletionRegistry, SharedDriver};
+use crate::meerkat_machine::{SharedCompletionRegistry, SharedDriver, machine_stop_runtime};
 use crate::tokio::sync::mpsc;
 use crate::traits::RuntimeDriverError;
 
-async fn finalize_runtime_stopped(driver: &SharedDriver) -> Result<(), RuntimeDriverError> {
-    let mut driver = driver.lock().await;
-    if matches!(
-        driver.as_driver().runtime_state(),
-        crate::RuntimeState::Destroyed
-    ) {
-        return Ok(());
+/// Canonical terminalization for an async stop after the executor has accepted
+/// the stop control command.
+pub(crate) async fn terminalize_async_stop(
+    driver: &SharedDriver,
+    completions: Option<&SharedCompletionRegistry>,
+) -> Result<(), RuntimeDriverError> {
+    {
+        let mut driver = driver.lock().await;
+        if !matches!(driver.runtime_state(), crate::RuntimeState::Destroyed) {
+            machine_stop_runtime(&mut driver).await?;
+        }
     }
 
-    driver.finalize_stop_runtime().await?;
-    driver.sync_control_projection_from_dsl_authority();
+    if let Some(completions) = completions {
+        let mut reg = completions.lock().await;
+        reg.resolve_all_terminated("runtime stopped");
+    }
+
     Ok(())
 }
 
 /// Deliver one executor control command and report whether the runtime loop
 /// should stop after applying it.
 ///
-/// When a stop completes, fires the DSL `RuntimeExecutorExited` transition on
-/// the session's machine so the machine phase reflects the async realisation
-/// of the stop (driver → Stopped). No shell→DSL read-through bridge.
+/// When a stop completes, routes all semantic stop terminalization through
+/// [`terminalize_async_stop`] so DSL executor-exit, driver finalization, durable
+/// stopped truth, and waiter resolution cannot split.
 pub(crate) async fn apply_executor_control(
     driver: &SharedDriver,
     completions: Option<&SharedCompletionRegistry>,
     executor: &mut dyn meerkat_core::lifecycle::CoreExecutor,
     command: RunControlCommand,
-    machine: &Weak<MeerkatMachine>,
-    session_id: &SessionId,
 ) -> bool {
     let should_stop = matches!(command, RunControlCommand::StopRuntimeExecutor { .. });
 
@@ -48,20 +50,11 @@ pub(crate) async fn apply_executor_control(
         tracing::warn!(error = %err, "failed to deliver out-of-band executor control");
     }
 
-    if should_stop && let Some(machine) = machine.upgrade() {
-        machine.notify_runtime_executor_exited(session_id).await;
-    }
-
-    if should_stop && let Err(err) = finalize_runtime_stopped(driver).await {
+    if should_stop && let Err(err) = terminalize_async_stop(driver, completions).await {
         tracing::warn!(
             error = %err,
-            "failed to mark runtime stopped after stop-runtime-executor command"
+            "failed to terminalize runtime stop after stop-runtime-executor command"
         );
-    }
-
-    if should_stop && let Some(completions) = completions {
-        let mut reg = completions.lock().await;
-        reg.resolve_all_terminated("runtime stopped");
     }
 
     should_stop
@@ -74,22 +67,11 @@ pub(crate) async fn drain_ready_executor_controls(
     completions: Option<&SharedCompletionRegistry>,
     executor: &mut dyn meerkat_core::lifecycle::CoreExecutor,
     control_rx: &mut mpsc::Receiver<RunControlCommand>,
-    machine: &Weak<MeerkatMachine>,
-    session_id: &SessionId,
 ) -> bool {
     loop {
         match control_rx.try_recv() {
             Ok(command) => {
-                if apply_executor_control(
-                    driver,
-                    completions,
-                    executor,
-                    command,
-                    machine,
-                    session_id,
-                )
-                .await
-                {
+                if apply_executor_control(driver, completions, executor, command).await {
                     return true;
                 }
             }

--- a/meerkat-runtime/src/driver/persistent.rs
+++ b/meerkat-runtime/src/driver/persistent.rs
@@ -169,12 +169,6 @@ impl PersistentRuntimeDriver {
         self.inner.sync_control_projection_from_dsl_authority();
     }
 
-    pub(crate) fn apply_runtime_executor_exited_authority(
-        &mut self,
-    ) -> Result<(), RuntimeDriverError> {
-        self.inner.apply_runtime_executor_exited_authority()
-    }
-
     /// Get pending events (delegates to inner).
     pub fn drain_events(&mut self) -> Vec<RuntimeEventEnvelope> {
         self.inner.drain_events()
@@ -517,6 +511,20 @@ impl PersistentRuntimeDriver {
         .await
     }
 
+    pub(crate) async fn finalize_runtime_executor_exit(
+        &mut self,
+    ) -> Result<(), RuntimeDriverError> {
+        let checkpoint = self.inner.rollback_snapshot();
+        if let Err(err) = self.inner.apply_runtime_executor_exited_authority() {
+            self.inner.restore_rollback_snapshot(checkpoint);
+            return Err(err);
+        }
+        self.inner.sync_control_projection_from_dsl_authority();
+        self.inner.stop_runtime_cleanup();
+        self.commit_lifecycle_with_rollback(checkpoint, RuntimeState::Stopped, "stop")
+            .await
+    }
+
     pub(crate) async fn realize_stop_lifecycle(&mut self) -> Result<(), RuntimeDriverError> {
         let checkpoint = self.inner.rollback_snapshot();
         self.inner.apply_stop_runtime_executor_authority()?;
@@ -539,6 +547,14 @@ impl PersistentRuntimeDriver {
     #[doc(hidden)]
     pub async fn contract_finalize_stop_runtime(&mut self) -> Result<(), RuntimeDriverError> {
         self.finalize_stop_runtime().await
+    }
+
+    /// Low-level async executor-exit realization shim for external contract tests.
+    #[doc(hidden)]
+    pub async fn contract_finalize_runtime_executor_exit(
+        &mut self,
+    ) -> Result<(), RuntimeDriverError> {
+        self.finalize_runtime_executor_exit().await
     }
 
     pub async fn boundary_applied(

--- a/meerkat-runtime/src/meerkat_machine/dispatch_session.rs
+++ b/meerkat-runtime/src/meerkat_machine/dispatch_session.rs
@@ -686,10 +686,8 @@ impl MeerkatMachine {
         }
     }
 
-    /// Arc-requiring session dispatch: handles commands that spawn background
-    /// tasks holding `Weak<Self>` for async DSL transitions (currently
-    /// `EnsureSessionWithExecutor` for runtime-loop `RuntimeExecutorExited`
-    /// wiring).
+    /// Arc-requiring session dispatch: handles commands that spawn runtime-owned
+    /// background tasks.
     pub(super) async fn execute_meerkat_machine_ensure_session_command(
         self: &Arc<Self>,
         command: MeerkatMachineCommand,
@@ -707,9 +705,7 @@ impl MeerkatMachine {
                 }
                 // `inner` creates the session entry (if new), stages the DSL
                 // EnsureSessionWithExecutor transition BEFORE mutating the
-                // driver, attaches the executor, and spawns the runtime loop
-                // with `Weak<Self>` so the loop can fire
-                // `RuntimeExecutorExited` on async stop completion.
+                // driver, attaches the executor, and spawns the runtime loop.
                 self.ensure_session_with_executor_inner(session_id, executor)
                     .await;
                 Ok(MeerkatMachineCommandResult::Unit)

--- a/meerkat-runtime/src/meerkat_machine/driver.rs
+++ b/meerkat-runtime/src/meerkat_machine/driver.rs
@@ -464,16 +464,6 @@ impl DriverEntry {
             DriverEntry::Persistent(d) => d.destroy().await,
         }
     }
-
-    pub(crate) async fn finalize_stop_runtime(&mut self) -> Result<(), RuntimeDriverError> {
-        match self {
-            DriverEntry::Ephemeral(d) => {
-                d.finalize_stop_runtime();
-                Ok(())
-            }
-            DriverEntry::Persistent(d) => d.finalize_stop_runtime().await,
-        }
-    }
 }
 
 /// Shared completion registry (accessed by adapter for registration and loop for resolution).
@@ -1387,15 +1377,12 @@ pub(crate) async fn machine_stop_runtime(
 
     match driver {
         DriverEntry::Ephemeral(d) => {
-            let _ = d.apply_runtime_executor_exited_authority();
+            d.apply_runtime_executor_exited_authority()?;
             d.sync_control_projection_from_dsl_authority();
             d.finalize_stop_runtime();
             Ok(())
         }
-        DriverEntry::Persistent(d) => {
-            let _ = d.apply_runtime_executor_exited_authority();
-            d.finalize_stop_runtime().await
-        }
+        DriverEntry::Persistent(d) => d.finalize_runtime_executor_exit().await,
     }
 }
 

--- a/meerkat-runtime/src/meerkat_machine/mod.rs
+++ b/meerkat-runtime/src/meerkat_machine/mod.rs
@@ -470,36 +470,6 @@ impl MeerkatMachine {
             *authority = dsl::MeerkatMachineAuthority::from_state(*state);
         }
     }
-
-    /// Fire `RuntimeExecutorExited` on the session's DSL authority after the
-    /// runtime loop has realised an async stop into the driver's control
-    /// projection. Called via `Weak<Self>` from `control_plane`.
-    pub(crate) async fn notify_runtime_executor_exited(&self, session_id: &SessionId) {
-        let driver = {
-            let mut sessions = self.sessions.write().await;
-            let Some(entry) = sessions.get_mut(session_id) else {
-                return;
-            };
-            let mut authority = entry
-                .dsl_authority
-                .lock()
-                .unwrap_or_else(std::sync::PoisonError::into_inner);
-            if let Err(err) = dsl::MeerkatMachineMutator::apply(
-                &mut *authority,
-                dsl::MeerkatMachineInput::RuntimeExecutorExited,
-            ) {
-                tracing::debug!(
-                    %session_id,
-                    error = %dsl_authority::map_error(err, "RuntimeExecutorExited"),
-                    "DSL rejected RuntimeExecutorExited (terminal or phase-not-covered)"
-                );
-            }
-            Arc::clone(&entry.driver)
-        };
-
-        let mut driver = driver.lock().await;
-        driver.sync_control_projection_from_dsl_authority();
-    }
 }
 
 /// Per-session comms drain slot, driven by direct in-kernel state.

--- a/meerkat-runtime/src/meerkat_machine/runtime_control.rs
+++ b/meerkat-runtime/src/meerkat_machine/runtime_control.rs
@@ -133,13 +133,7 @@ impl MeerkatMachine {
         }
 
         if matches!(command, RunControlCommand::StopRuntimeExecutor { .. }) {
-            let mut driver = driver.lock().await;
-            machine_stop_runtime(&mut driver).await?;
-            drop(driver);
-            self.notify_runtime_executor_exited(session_id).await;
-            let mut completions = completions.lock().await;
-            completions.resolve_all_terminated("runtime stopped");
-            drop(completions);
+            crate::control_plane::terminalize_async_stop(&driver, Some(&completions)).await?;
 
             // No live control sender was available for this stop path. Scrub any
             // dead attachment capabilities that may still be published.

--- a/meerkat-runtime/src/meerkat_machine/session_management.rs
+++ b/meerkat-runtime/src/meerkat_machine/session_management.rs
@@ -222,9 +222,8 @@ impl MeerkatMachine {
     }
 
     /// Register a runtime driver for a session WITH a RuntimeLoop backed by a
-    /// `CoreExecutor`. Takes `self: &Arc<Self>` so the spawned runtime loop
-    /// can hold a `Weak<Self>` to fire `RuntimeExecutorExited` on async stop
-    /// realisation.
+    /// `CoreExecutor`. Takes `self: &Arc<Self>` because executor attachment is
+    /// routed through the Arc-backed command path that owns runtime-loop spawn.
     pub async fn register_session_with_executor(
         self: &Arc<Self>,
         session_id: SessionId,

--- a/meerkat-runtime/src/meerkat_machine/traits.rs
+++ b/meerkat-runtime/src/meerkat_machine/traits.rs
@@ -482,9 +482,9 @@ impl MeerkatMachine {
     ) -> Option<RuntimeState> {
         let sessions = self.sessions.read().await;
         let entry = sessions.get(session_id)?;
-        // DSL is the single source of truth. The async runtime-loop stop
-        // path fires `RuntimeExecutorExited` through `Weak<MeerkatMachine>`
-        // so `lifecycle_phase` is Stopped by the time any observer reads it.
+        // DSL is the single source of truth. The async runtime-loop stop path
+        // terminalizes through the shared driver authority, so
+        // `lifecycle_phase` is Stopped by the time any observer reads it.
         let authority = entry
             .dsl_authority
             .lock()

--- a/meerkat-runtime/src/runtime_loop.rs
+++ b/meerkat-runtime/src/runtime_loop.rs
@@ -316,8 +316,8 @@ pub(crate) fn spawn_runtime_loop_with_completions(
     completions: Option<crate::meerkat_machine::SharedCompletionRegistry>,
     completion_feed: Option<std::sync::Arc<dyn meerkat_core::completion_feed::CompletionFeed>>,
     epoch_cursor_state: Option<std::sync::Arc<meerkat_core::EpochCursorState>>,
-    machine_weak: std::sync::Weak<crate::meerkat_machine::MeerkatMachine>,
-    session_id: meerkat_core::types::SessionId,
+    _machine_weak: std::sync::Weak<crate::meerkat_machine::MeerkatMachine>,
+    _session_id: meerkat_core::types::SessionId,
 ) -> tokio::task::JoinHandle<()> {
     tokio::spawn(async move {
         // Feed-based idle wake state (local to this loop).
@@ -372,8 +372,6 @@ pub(crate) fn spawn_runtime_loop_with_completions(
                                 completions.as_ref(),
                                 &mut *executor,
                                 command,
-                                &machine_weak,
-                                &session_id,
                             )
                             .await
                             {
@@ -391,7 +389,7 @@ pub(crate) fn spawn_runtime_loop_with_completions(
                                 &mut *executor,
                                 &mut control_rx,
                                 completions.as_ref(),
-                            &machine_weak, &session_id,)
+                            )
                             .await
                             {
                                 break;
@@ -412,7 +410,7 @@ pub(crate) fn spawn_runtime_loop_with_completions(
                                     &mut *executor,
                                     &mut control_rx,
                                     completions.as_ref(),
-                                &machine_weak, &session_id,)
+                                )
                                 .await
                             {
                                 break;
@@ -464,7 +462,7 @@ pub(crate) fn spawn_runtime_loop_with_completions(
                                     &mut *executor,
                                     &mut control_rx,
                                     completions.as_ref(),
-                                &machine_weak, &session_id,)
+                                )
                                 .await
                                 {
                                     break;
@@ -564,8 +562,6 @@ async fn process_queue(
         meerkat_core::lifecycle::run_control::RunControlCommand,
     >,
     completions: Option<&crate::meerkat_machine::SharedCompletionRegistry>,
-    machine_weak: &std::sync::Weak<crate::meerkat_machine::MeerkatMachine>,
-    session_id: &meerkat_core::types::SessionId,
 ) -> bool {
     loop {
         if crate::control_plane::drain_ready_executor_controls(
@@ -573,8 +569,6 @@ async fn process_queue(
             completions,
             executor,
             control_rx,
-            machine_weak,
-            session_id,
         )
         .await
         {

--- a/meerkat-runtime/tests/control_plane_contract.rs
+++ b/meerkat-runtime/tests/control_plane_contract.rs
@@ -8,6 +8,7 @@ use std::sync::{
     Arc,
     atomic::{AtomicUsize, Ordering},
 };
+use std::{fs, path::Path};
 
 use chrono::Utc;
 use meerkat_core::lifecycle::core_executor::{CoreApplyOutput, CoreExecutor, CoreExecutorError};
@@ -22,8 +23,8 @@ use meerkat_runtime::input::{
     ResponseProgressPhase,
 };
 use meerkat_runtime::{
-    InputAbandonReason, InputLifecycleState, InputTerminalOutcome, MeerkatMachine, RuntimeState,
-    SessionServiceRuntimeExt,
+    InMemoryRuntimeStore, InputAbandonReason, InputLifecycleState, InputTerminalOutcome,
+    LogicalRuntimeId, MeerkatMachine, RuntimeState, RuntimeStore, SessionServiceRuntimeExt,
 };
 
 fn make_progress_input(label: &str) -> Input {
@@ -63,6 +64,41 @@ fn make_run_result(text: &str) -> RunResult {
         schema_warnings: None,
         skill_diagnostics: None,
     }
+}
+
+#[test]
+fn control_plane_contract_async_stop_terminalization_has_one_call_site() {
+    let crate_root = Path::new(env!("CARGO_MANIFEST_DIR"));
+    let source = fs::read_to_string(crate_root.join("src/control_plane.rs"))
+        .expect("control_plane.rs should be readable");
+    let start = source
+        .find("pub(crate) async fn apply_executor_control")
+        .expect("apply_executor_control should exist");
+    let end = source[start..]
+        .find("/// Drain any ready executor control commands")
+        .expect("drain_ready_executor_controls should follow apply_executor_control");
+    let apply_body = &source[start..start + end];
+
+    let split_terminalizers = [
+        "notify_runtime_executor_exited",
+        "finalize_runtime_stopped",
+        "resolve_all_terminated",
+    ];
+    let offenders = split_terminalizers
+        .iter()
+        .copied()
+        .filter(|needle| apply_body.contains(needle))
+        .collect::<Vec<_>>();
+    assert!(
+        offenders.is_empty(),
+        "async stop terminalization must be a single canonical call from \
+         apply_executor_control; found split terminalizers: {offenders:?}"
+    );
+    assert_eq!(
+        apply_body.matches("terminalize_async_stop(").count(),
+        1,
+        "apply_executor_control should call terminalize_async_stop exactly once"
+    );
 }
 
 struct RecordingExecutor {
@@ -232,6 +268,64 @@ async fn control_plane_contract_stop_runtime_executor_preempts_queued_progress_w
     assert!(
         runtime.list_active_inputs(&sid).await.unwrap().is_empty(),
         "stopping the runtime should drain active inputs from the ledger"
+    );
+
+    let stored = runtime.input_state(&sid, &input_id).await.unwrap().unwrap();
+    assert_eq!(stored.seed.phase, InputLifecycleState::Abandoned);
+    assert!(matches!(
+        stored.state.terminal_outcome(),
+        Some(InputTerminalOutcome::Abandoned {
+            reason: InputAbandonReason::Stopped,
+        })
+    ));
+}
+
+#[tokio::test]
+async fn control_plane_contract_stop_runtime_executor_persists_stopped_state_without_loop() {
+    let store = Arc::new(InMemoryRuntimeStore::new());
+    let adapter = Arc::new(MeerkatMachine::persistent_without_blobs(
+        Arc::clone(&store) as Arc<dyn RuntimeStore>
+    ));
+    let runtime: &dyn SessionServiceRuntimeExt = &*adapter;
+    let sid = SessionId::new();
+
+    adapter.register_session(sid.clone()).await;
+
+    let input = make_progress_input("persistent-stop");
+    let input_id = input.id().clone();
+    let (outcome, handle) = runtime
+        .accept_input_with_completion(&sid, input)
+        .await
+        .unwrap();
+    assert!(outcome.is_accepted());
+    let handle = handle.expect("accepted input should expose a wait handle");
+
+    adapter
+        .stop_runtime_executor(
+            &sid,
+            RunControlCommand::StopRuntimeExecutor {
+                reason: "persistent stopped state".into(),
+            },
+        )
+        .await
+        .unwrap();
+
+    match handle.wait().await {
+        CompletionOutcome::RuntimeTerminated(reason) => {
+            assert_eq!(reason, "runtime stopped");
+        }
+        other => panic!("expected runtime stopped termination, got {other:?}"),
+    }
+    assert_eq!(
+        runtime.runtime_state(&sid).await.unwrap(),
+        RuntimeState::Stopped
+    );
+
+    let runtime_id = LogicalRuntimeId::new(sid.to_string());
+    assert_eq!(
+        store.load_runtime_state(&runtime_id).await.unwrap(),
+        Some(RuntimeState::Stopped),
+        "persistent stop terminalization should commit Stopped as durable runtime truth"
     );
 
     let stored = runtime.input_state(&sid, &input_id).await.unwrap().unwrap();

--- a/meerkat-runtime/tests/driver_persistent.rs
+++ b/meerkat-runtime/tests/driver_persistent.rs
@@ -749,6 +749,53 @@ async fn stop_lifecycle_commit_failure_restores_running_projection() {
 }
 
 #[tokio::test]
+async fn runtime_executor_exit_commit_failure_restores_running_projection() {
+    let inner = Arc::new(InMemoryRuntimeStore::new());
+    let store: Arc<dyn RuntimeStore> = Arc::new(
+        FailPersistInputStore::fail_atomic_lifecycle_commit_once(inner.clone()),
+    );
+    let rid = LogicalRuntimeId::new("test");
+    let mut driver = PersistentRuntimeDriver::new(rid.clone(), store, memory_blob_store());
+
+    let input = make_prompt("executor exit rollback");
+    let input_id = input.id().clone();
+    driver.accept_input(input).await.unwrap();
+    let run_id = RunId::new();
+    bind_running(&mut driver, run_id.clone(), RuntimeState::Idle);
+    driver.stage_input(&input_id, &run_id).unwrap();
+
+    let err = driver
+        .contract_finalize_runtime_executor_exit()
+        .await
+        .expect_err("executor-exit lifecycle commit should fail");
+    assert!(
+        err.to_string()
+            .contains("synthetic atomic_lifecycle_commit failure"),
+        "unexpected error: {err}",
+    );
+    assert_eq!(
+        driver.runtime_state(),
+        RuntimeState::Running,
+        "failed executor-exit terminalization must restore running truth",
+    );
+    assert_eq!(
+        driver.inner_ref().input_phase(&input_id),
+        Some(meerkat_runtime::input_state::InputLifecycleState::Staged),
+        "failed executor-exit terminalization must restore staged work",
+    );
+    assert_eq!(
+        driver.inner_ref().current_run_id(),
+        Some(run_id),
+        "failed executor-exit terminalization must restore active run identity",
+    );
+    assert_eq!(
+        inner.load_runtime_state(&rid).await.unwrap(),
+        None,
+        "failed executor-exit terminalization must not persist stopped truth",
+    );
+}
+
+#[tokio::test]
 async fn destroy_lifecycle_commit_failure_restores_cleanup_projection() {
     let inner = Arc::new(InMemoryRuntimeStore::new());
     let store: Arc<dyn RuntimeStore> = Arc::new(


### PR DESCRIPTION
## Summary
- Fix dogma row: `Async stop has two terminalization paths` (`meerkat-runtime/src/control_plane.rs:51,55,62`).
- Route live-loop and no-loop stop completion through one `control_plane::terminalize_async_stop` path.
- Make persistent executor-exit stop finalization take its rollback snapshot before applying `RuntimeExecutorExited`, so failed persistence cannot leave split stopped truth.

## Test coverage
- Added source-shape regression asserting `apply_executor_control` has exactly one async stop terminalization call site.
- Added persistent stopped-state coverage for stop without a runtime loop.
- Added persistent executor-exit rollback coverage for no split/conflicting stopped truth on lifecycle commit failure.
- Reused focused stop-runtime filters covering attached-loop executor exit, waiter cleanup, wait-all separation, and duplicate stop control observation.

## Validation
- `./scripts/repo-cargo test -p meerkat-runtime --test control_plane_contract`
- `./scripts/repo-cargo test -p meerkat-runtime stop_runtime_executor`
- `./scripts/repo-cargo test -p meerkat-runtime --test driver_persistent runtime_executor_exit_commit_failure_restores_running_projection`
- `make check` (BuildBuddy invocation `95638a41-aa3c-482c-a883-ab78f89b25cf`)

Linear: LUC-110