### PR TITLE
Remove legacy run DSL unregister string policy

### DIFF
--- a/meerkat-runtime/src/meerkat_machine/dispatch_ingress.rs
+++ b/meerkat-runtime/src/meerkat_machine/dispatch_ingress.rs
@@ -364,27 +364,6 @@ impl MeerkatMachine {
                 }
 
                 let run_id = RunId::new();
-                self.preview_session_dsl_input(
-                    &session_id,
-                    crate::meerkat_machine::dsl::MeerkatMachineInput::Prepare {
-                        session_id: crate::meerkat_machine::dsl::SessionId::from_domain(
-                            &session_id,
-                        ),
-                        run_id: crate::meerkat_machine::dsl::RunId::from_domain(&run_id),
-                    },
-                    "Prepare",
-                )
-                .await
-                .map_err(|reason| {
-                    tracing::error!(
-                        error = %reason,
-                        session_id = %session_id,
-                        "DSL rejected Prepare input"
-                    );
-                    let state = visible_state;
-                    Self::normalize_destroyed_error(RuntimeDriverError::NotReady { state })
-                })?;
-
                 let prepared = {
                     let mut driver = driver.lock().await;
                     let outcome = match driver
@@ -441,24 +420,47 @@ impl MeerkatMachine {
                         let next_phase = crate::runtime_state::run_return_phase_from_pre_run_phase(
                             driver.pre_run_phase(),
                         );
-                        let _ = machine_apply_run_return_projection(
+                        if let Err(rollback_err) = machine_apply_run_return_projection(
                             &mut driver,
                             &run_id,
                             crate::meerkat_machine::driver::RunReturnDisposition::Fail,
                             next_phase,
-                        );
+                        ) {
+                            return Err(RuntimeDriverError::Internal(format!(
+                                "failed to roll back runtime run after staging failure: {rollback_err}; staging failure: {err}"
+                            )));
+                        }
                         return Err(RuntimeDriverError::Internal(format!(
                             "failed to stage accepted input: {err}"
                         )));
                     }
 
-                    let primitive =
-                        crate::runtime_loop::input_to_primitive(&dequeued_input, dequeued_id)
-                            .map_err(|err| {
-                                RuntimeDriverError::Internal(format!(
-                                    "failed to build accepted input primitive: {err}"
-                                ))
-                            })?;
+                    let primitive = match crate::runtime_loop::input_to_primitive(
+                        &dequeued_input,
+                        dequeued_id.clone(),
+                    ) {
+                        Ok(primitive) => primitive,
+                        Err(err) => {
+                            let _ = driver.rollback_staged(std::slice::from_ref(&dequeued_id));
+                            let next_phase =
+                                crate::runtime_state::run_return_phase_from_pre_run_phase(
+                                    driver.pre_run_phase(),
+                                );
+                            if let Err(rollback_err) = machine_apply_run_return_projection(
+                                &mut driver,
+                                &run_id,
+                                crate::meerkat_machine::driver::RunReturnDisposition::Fail,
+                                next_phase,
+                            ) {
+                                return Err(RuntimeDriverError::Internal(format!(
+                                    "failed to roll back runtime run after primitive build failure: {rollback_err}; primitive build failure: {err}"
+                                )));
+                            }
+                            return Err(RuntimeDriverError::Internal(format!(
+                                "failed to build accepted input primitive: {err}"
+                            )));
+                        }
+                    };
 
                     MeerkatMachineRunPrepared {
                         input_id,
@@ -501,8 +503,8 @@ impl MeerkatMachine {
                 )
                 .await
                 {
-                    let should_unregister =
-                        !err.to_string().contains("runtime boundary commit failed");
+                    let should_unregister = err.should_unregister_session();
+                    let err = err.into_driver_error();
                     if should_unregister {
                         self.unregister_session_inner(&session_id).await;
                     }
@@ -536,7 +538,11 @@ impl MeerkatMachine {
                 };
 
                 if let Err(run_err) = fail_runtime_loop_run(&driver, run_id, error).await {
-                    self.unregister_session_inner(&session_id).await;
+                    let should_unregister = run_err.should_unregister_session();
+                    let run_err = run_err.into_driver_error();
+                    if should_unregister {
+                        self.unregister_session_inner(&session_id).await;
+                    }
                     return Err(RuntimeDriverError::Internal(format!(
                         "failed to persist runtime failure snapshot: {run_err}"
                     )));

--- a/meerkat-runtime/src/meerkat_machine/driver.rs
+++ b/meerkat-runtime/src/meerkat_machine/driver.rs
@@ -587,17 +587,24 @@ pub(crate) enum RunReturnDisposition<'a> {
 pub(crate) enum RuntimeLoopRunCommitError {
     Rejected(RuntimeDriverError),
     BoundaryCommit(RuntimeDriverError),
+    PostBoundaryValidation(RuntimeDriverError),
     TerminalSnapshot(RuntimeDriverError),
 }
 
 impl RuntimeLoopRunCommitError {
     pub(crate) fn should_unregister_session(&self) -> bool {
-        matches!(self, Self::TerminalSnapshot(_))
+        matches!(
+            self,
+            Self::PostBoundaryValidation(_) | Self::TerminalSnapshot(_)
+        )
     }
 
     pub(crate) fn into_driver_error(self) -> RuntimeDriverError {
         match self {
-            Self::Rejected(err) | Self::BoundaryCommit(err) | Self::TerminalSnapshot(err) => err,
+            Self::Rejected(err)
+            | Self::BoundaryCommit(err)
+            | Self::PostBoundaryValidation(err)
+            | Self::TerminalSnapshot(err) => err,
         }
     }
 }
@@ -605,9 +612,10 @@ impl RuntimeLoopRunCommitError {
 impl std::fmt::Display for RuntimeLoopRunCommitError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            Self::Rejected(err) | Self::BoundaryCommit(err) | Self::TerminalSnapshot(err) => {
-                write!(f, "{err}")
-            }
+            Self::Rejected(err)
+            | Self::BoundaryCommit(err)
+            | Self::PostBoundaryValidation(err)
+            | Self::TerminalSnapshot(err) => write!(f, "{err}"),
         }
     }
 }
@@ -940,6 +948,33 @@ pub(crate) fn machine_validate_run_completed(
     }
 
     Ok(())
+}
+
+pub(crate) fn machine_validate_run_commit_receipt(
+    driver: &DriverEntry,
+    run_id: &RunId,
+    consumed_input_ids: &[InputId],
+    receipt: &meerkat_core::lifecycle::RunBoundaryReceipt,
+) -> Result<(), RuntimeDriverError> {
+    if &receipt.run_id != run_id {
+        return Err(RuntimeDriverError::Internal(format!(
+            "run commit receipt run_id {:?} does not match active run {:?}",
+            receipt.run_id, run_id
+        )));
+    }
+
+    let same_contributors = consumed_input_ids.len() == receipt.contributing_input_ids.len()
+        && consumed_input_ids
+            .iter()
+            .all(|input_id| receipt.contributing_input_ids.contains(input_id));
+    if !same_contributors {
+        return Err(RuntimeDriverError::Internal(format!(
+            "run commit consumed inputs {:?} do not match receipt contributors {:?}",
+            consumed_input_ids, receipt.contributing_input_ids
+        )));
+    }
+
+    machine_validate_boundary_applied(driver, &receipt.contributing_input_ids)
 }
 
 pub(crate) fn machine_staged_contributors(driver: &DriverEntry) -> Vec<InputId> {
@@ -1665,7 +1700,7 @@ pub(crate) async fn commit_runtime_loop_run(
     // guards (input_id is informational), so firing once with any
     // contributing input is sufficient to flip `lifecycle_phase`.
     let commit_input_id = consumed_input_ids.first().cloned();
-    machine_validate_boundary_applied(&driver, &receipt.contributing_input_ids)
+    machine_validate_run_commit_receipt(&driver, &run_id, &consumed_input_ids, &receipt)
         .map_err(RuntimeLoopRunCommitError::Rejected)?;
     let completed_run_id = run_id.clone();
     machine_apply_turn_run_completed(&mut driver, &completed_run_id)
@@ -1690,8 +1725,11 @@ pub(crate) async fn commit_runtime_loop_run(
         ));
     }
 
-    machine_validate_run_completed(&driver, &consumed_input_ids)
-        .map_err(RuntimeLoopRunCommitError::Rejected)?;
+    machine_validate_run_completed(&driver, &consumed_input_ids).map_err(|err| {
+        RuntimeLoopRunCommitError::PostBoundaryValidation(RuntimeDriverError::Internal(format!(
+            "runtime completion validation failed after boundary commit: {err}"
+        )))
+    })?;
     driver
         .machine_realize_run_completed(completed_run_id.clone(), consumed_input_ids)
         .await

--- a/meerkat-runtime/src/meerkat_machine/driver.rs
+++ b/meerkat-runtime/src/meerkat_machine/driver.rs
@@ -583,6 +583,65 @@ pub(crate) enum RunReturnDisposition<'a> {
     Fail,
 }
 
+#[derive(Debug)]
+pub(crate) enum RuntimeLoopRunCommitError {
+    Rejected(RuntimeDriverError),
+    BoundaryCommit(RuntimeDriverError),
+    TerminalSnapshot(RuntimeDriverError),
+}
+
+impl RuntimeLoopRunCommitError {
+    pub(crate) fn should_unregister_session(&self) -> bool {
+        matches!(self, Self::TerminalSnapshot(_))
+    }
+
+    pub(crate) fn into_driver_error(self) -> RuntimeDriverError {
+        match self {
+            Self::Rejected(err) | Self::BoundaryCommit(err) | Self::TerminalSnapshot(err) => err,
+        }
+    }
+}
+
+impl std::fmt::Display for RuntimeLoopRunCommitError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Rejected(err) | Self::BoundaryCommit(err) | Self::TerminalSnapshot(err) => {
+                write!(f, "{err}")
+            }
+        }
+    }
+}
+
+impl std::error::Error for RuntimeLoopRunCommitError {}
+
+#[derive(Debug)]
+pub(crate) enum RuntimeLoopRunFailError {
+    Rejected(RuntimeDriverError),
+    TerminalSnapshot(RuntimeDriverError),
+}
+
+impl RuntimeLoopRunFailError {
+    pub(crate) fn should_unregister_session(&self) -> bool {
+        matches!(self, Self::TerminalSnapshot(_))
+    }
+
+    pub(crate) fn into_driver_error(self) -> RuntimeDriverError {
+        match self {
+            Self::Rejected(err) | Self::TerminalSnapshot(err) => err,
+        }
+    }
+}
+
+impl std::fmt::Display for RuntimeLoopRunFailError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Rejected(err) | Self::TerminalSnapshot(err) => write!(f, "{err}"),
+        }
+    }
+}
+
+impl std::error::Error for RuntimeLoopRunFailError {}
+
 pub(crate) fn machine_apply_run_return_projection(
     driver: &mut DriverEntry,
     run_id: &RunId,
@@ -625,7 +684,12 @@ pub(crate) fn machine_apply_run_return_projection(
                 run_id: crate::meerkat_machine::dsl::RunId::from_domain(run_id),
             },
         };
-        let _ = crate::meerkat_machine::dsl::MeerkatMachineMutator::apply(&mut *auth, input);
+        if crate::meerkat_machine::dsl::MeerkatMachineMutator::apply(&mut *auth, input).is_err() {
+            return Err(crate::runtime_state::RuntimeStateTransitionError {
+                from: current_phase,
+                to: next_phase,
+            });
+        }
     }
 
     // Shell `control_projection` update is retained as mechanical event
@@ -1568,12 +1632,16 @@ pub(crate) async fn prepare_runtime_loop_batch_start(
         let _ = driver.rollback_staged(staged_ids);
         let next_phase =
             crate::runtime_state::run_return_phase_from_pre_run_phase(driver.pre_run_phase());
-        let _ = machine_apply_run_return_projection(
+        if let Err(rollback_err) = machine_apply_run_return_projection(
             &mut driver,
             &run_id,
             RunReturnDisposition::Fail,
             next_phase,
-        );
+        ) {
+            return Err(RuntimeDriverError::Internal(format!(
+                "failed to roll back runtime run after batch staging failure: {rollback_err}; staging failure: {err}"
+            )));
+        }
         return Err(RuntimeDriverError::Internal(format!(
             "failed to stage accepted input batch: {err}"
         )));
@@ -1588,7 +1656,7 @@ pub(crate) async fn commit_runtime_loop_run(
     consumed_input_ids: Vec<InputId>,
     receipt: meerkat_core::lifecycle::RunBoundaryReceipt,
     session_snapshot: Option<Vec<u8>>,
-) -> Result<(), RuntimeDriverError> {
+) -> Result<(), RuntimeLoopRunCommitError> {
     let mut driver = driver.lock().await;
     let next_phase =
         crate::runtime_state::run_return_phase_from_pre_run_phase(driver.pre_run_phase());
@@ -1597,37 +1665,40 @@ pub(crate) async fn commit_runtime_loop_run(
     // guards (input_id is informational), so firing once with any
     // contributing input is sufficient to flip `lifecycle_phase`.
     let commit_input_id = consumed_input_ids.first().cloned();
-    machine_validate_boundary_applied(&driver, &receipt.contributing_input_ids)?;
+    machine_validate_boundary_applied(&driver, &receipt.contributing_input_ids)
+        .map_err(RuntimeLoopRunCommitError::Rejected)?;
     let completed_run_id = run_id.clone();
-    machine_apply_turn_run_completed(&mut driver, &completed_run_id)?;
+    machine_apply_turn_run_completed(&mut driver, &completed_run_id)
+        .map_err(RuntimeLoopRunCommitError::Rejected)?;
     let disposition = match commit_input_id.as_ref() {
         Some(input_id) => RunReturnDisposition::Commit { input_id },
         None => RunReturnDisposition::Fail,
     };
     machine_apply_run_return_projection(&mut driver, &completed_run_id, disposition, next_phase)
         .map_err(|err| {
-            RuntimeDriverError::Internal(format!(
+            RuntimeLoopRunCommitError::Rejected(RuntimeDriverError::Internal(format!(
                 "failed to apply runtime return projection after completion: {err}"
-            ))
+            )))
         })?;
     if let Err(err) = driver
         .machine_realize_boundary_applied(run_id.clone(), receipt, session_snapshot)
         .await
     {
         let _ = driver.rollback_staged(&consumed_input_ids);
-        return Err(RuntimeDriverError::Internal(format!(
-            "runtime boundary commit failed: {err}"
-        )));
+        return Err(RuntimeLoopRunCommitError::BoundaryCommit(
+            RuntimeDriverError::Internal(format!("runtime boundary commit failed: {err}")),
+        ));
     }
 
-    machine_validate_run_completed(&driver, &consumed_input_ids)?;
+    machine_validate_run_completed(&driver, &consumed_input_ids)
+        .map_err(RuntimeLoopRunCommitError::Rejected)?;
     driver
         .machine_realize_run_completed(completed_run_id.clone(), consumed_input_ids)
         .await
         .map_err(|err| {
-            RuntimeDriverError::Internal(format!(
+            RuntimeLoopRunCommitError::TerminalSnapshot(RuntimeDriverError::Internal(format!(
                 "failed to persist runtime completion snapshot: {err}"
-            ))
+            )))
         })?;
 
     Ok(())
@@ -1637,14 +1708,16 @@ pub(crate) async fn fail_runtime_loop_run(
     driver: &SharedDriver,
     run_id: RunId,
     error: String,
-) -> Result<(), RuntimeDriverError> {
+) -> Result<(), RuntimeLoopRunFailError> {
     let mut driver = driver.lock().await;
     let next_phase =
         crate::runtime_state::run_return_phase_from_pre_run_phase(driver.pre_run_phase());
     let failed_run_id = run_id.clone();
     let staged_input_ids = machine_staged_contributors(&driver);
-    machine_validate_run_failed(&driver, &staged_input_ids)?;
-    machine_apply_turn_run_failed(&mut driver, &failed_run_id, error.clone())?;
+    machine_validate_run_failed(&driver, &staged_input_ids)
+        .map_err(RuntimeLoopRunFailError::Rejected)?;
+    machine_apply_turn_run_failed(&mut driver, &failed_run_id, error.clone())
+        .map_err(RuntimeLoopRunFailError::Rejected)?;
     let replay_plan = machine_build_replay_plan(&driver, &staged_input_ids, "RunFailed");
     machine_apply_run_return_projection(
         &mut driver,
@@ -1653,9 +1726,9 @@ pub(crate) async fn fail_runtime_loop_run(
         next_phase,
     )
     .map_err(|err| {
-        RuntimeDriverError::Internal(format!(
+        RuntimeLoopRunFailError::Rejected(RuntimeDriverError::Internal(format!(
             "failed to apply runtime return projection after failure: {err}"
-        ))
+        )))
     })?;
     driver
         .machine_realize_run_failed(
@@ -1667,6 +1740,8 @@ pub(crate) async fn fail_runtime_loop_run(
         )
         .await
         .map_err(|run_err| {
-            RuntimeDriverError::Internal(format!("failed to record run-failed event: {run_err}"))
+            RuntimeLoopRunFailError::TerminalSnapshot(RuntimeDriverError::Internal(format!(
+                "failed to record run-failed event: {run_err}"
+            )))
         })
 }

--- a/meerkat-runtime/src/meerkat_machine/driver.rs
+++ b/meerkat-runtime/src/meerkat_machine/driver.rs
@@ -963,13 +963,9 @@ pub(crate) fn machine_validate_run_commit_receipt(
         )));
     }
 
-    let same_contributors = consumed_input_ids.len() == receipt.contributing_input_ids.len()
-        && consumed_input_ids
-            .iter()
-            .all(|input_id| receipt.contributing_input_ids.contains(input_id));
-    if !same_contributors {
+    if consumed_input_ids != receipt.contributing_input_ids.as_slice() {
         return Err(RuntimeDriverError::Internal(format!(
-            "run commit consumed inputs {:?} do not match receipt contributors {:?}",
+            "run commit consumed inputs {:?} do not exactly match receipt contributors {:?}",
             consumed_input_ids, receipt.contributing_input_ids
         )));
     }

--- a/meerkat-runtime/src/meerkat_machine_tests.rs
+++ b/meerkat-runtime/src/meerkat_machine_tests.rs
@@ -11686,6 +11686,65 @@ async fn legacy_run_commit_rejection_preserves_registered_running_session() {
 }
 
 #[tokio::test]
+async fn legacy_run_commit_mismatched_input_rejection_preserves_active_run() {
+    let adapter = Arc::new(MeerkatMachine::ephemeral());
+    let session_id = SessionId::new();
+    adapter.register_session(session_id.clone()).await;
+
+    let prepared =
+        prepare_legacy_run_for_authority_test(&adapter, &session_id, "commit input mismatch").await;
+    let wrong_input_id = InputId::new();
+    let result = adapter
+        .execute_meerkat_machine_command(
+            None,
+            MeerkatMachineCommand::Commit {
+                session_id: session_id.clone(),
+                input_id: wrong_input_id,
+                run_id: prepared.run_id.clone(),
+                output: legacy_run_test_output(prepared.run_id.clone(), prepared.input_id.clone()),
+            },
+        )
+        .await;
+
+    assert!(result.is_err(), "mismatched commit input should reject");
+    assert!(
+        adapter.contains_session(&session_id).await,
+        "typed commit rejection must not unregister the session"
+    );
+    assert_eq!(
+        adapter.runtime_state(&session_id).await.unwrap(),
+        RuntimeState::Running,
+        "malformed commit must preserve the active runtime run"
+    );
+    let input_state = adapter
+        .input_state(&session_id, &prepared.input_id)
+        .await
+        .expect("input state read should succeed")
+        .expect("prepared input should remain visible");
+    assert_eq!(
+        input_state.seed.phase,
+        crate::input_state::InputLifecycleState::Staged,
+        "malformed commit must not leave the contributor pending consumption"
+    );
+
+    adapter
+        .execute_meerkat_machine_command(
+            None,
+            MeerkatMachineCommand::Fail {
+                session_id: session_id.clone(),
+                run_id: prepared.run_id.clone(),
+                error: "unwind malformed commit".to_string(),
+            },
+        )
+        .await
+        .expect("preserved active run should still be terminalizable");
+    assert_eq!(
+        adapter.runtime_state(&session_id).await.unwrap(),
+        RuntimeState::Idle
+    );
+}
+
+#[tokio::test]
 async fn legacy_run_fail_rejection_preserves_registered_running_session() {
     let adapter = Arc::new(MeerkatMachine::ephemeral());
     let session_id = SessionId::new();

--- a/meerkat-runtime/src/meerkat_machine_tests.rs
+++ b/meerkat-runtime/src/meerkat_machine_tests.rs
@@ -186,6 +186,38 @@ fn legacy_run_handler_does_not_restore_dsl_snapshots_by_hand() {
     );
 }
 
+#[test]
+fn legacy_run_handler_does_not_preflight_run_dsl_from_shell() {
+    let source = include_str!("meerkat_machine/dispatch_ingress.rs");
+    let start = source
+        .find("pub(super) async fn execute_meerkat_machine_legacy_run_command")
+        .expect("legacy run handler should exist");
+    let legacy_run_handler = &source[start..];
+
+    assert!(
+        !legacy_run_handler.contains("preview_session_dsl_input"),
+        "legacy run prepare must let the machine-owned run transition decide authority",
+    );
+}
+
+#[test]
+fn legacy_run_handler_does_not_string_match_commit_unregister_policy() {
+    let source = include_str!("meerkat_machine/dispatch_ingress.rs");
+    let start = source
+        .find("pub(super) async fn execute_meerkat_machine_legacy_run_command")
+        .expect("legacy run handler should exist");
+    let legacy_run_handler = &source[start..];
+
+    assert!(
+        !legacy_run_handler.contains("to_string().contains"),
+        "legacy run unregister policy must use typed machine-owned semantics",
+    );
+    assert!(
+        !legacy_run_handler.contains("runtime boundary commit failed"),
+        "legacy run unregister policy must not key off boundary failure text",
+    );
+}
+
 #[tokio::test]
 async fn provisional_dsl_stage_does_not_emit_routed_signal_until_authoritative_apply() {
     let machine = MeerkatMachine::ephemeral();
@@ -11515,6 +11547,43 @@ async fn accept_input_with_completion_rejects_destroyed_session() {
 // A5: Legacy run command guards (TLA+ RunningHasActiveRunInvariant)
 // ---------------------------------------------------------------
 
+async fn prepare_legacy_run_for_authority_test(
+    adapter: &MeerkatMachine,
+    session_id: &SessionId,
+    text: &str,
+) -> MeerkatMachineRunPrepared {
+    let result = adapter
+        .execute_meerkat_machine_command(
+            None,
+            MeerkatMachineCommand::Prepare {
+                session_id: session_id.clone(),
+                input: make_prompt(text),
+            },
+        )
+        .await
+        .expect("legacy run prepare should succeed");
+    match result {
+        MeerkatMachineCommandResult::Prepared(prepared) => prepared,
+        other => panic!("unexpected prepare result: {other:?}"),
+    }
+}
+
+fn legacy_run_test_output(run_id: RunId, input_id: InputId) -> CoreApplyOutput {
+    CoreApplyOutput {
+        receipt: RunBoundaryReceipt {
+            run_id,
+            boundary: RunApplyBoundary::RunStart,
+            contributing_input_ids: vec![input_id],
+            conversation_digest: None,
+            message_count: 0,
+            sequence: 0,
+        },
+        session_snapshot: None,
+        terminal: None,
+        run_result: None,
+    }
+}
+
 #[tokio::test]
 async fn legacy_run_prepare_rejects_retired_session() {
     let adapter = Arc::new(MeerkatMachine::ephemeral());
@@ -11567,6 +11636,133 @@ async fn legacy_run_prepare_rejects_destroyed_session() {
     assert!(
         matches!(err, RuntimeDriverError::Destroyed),
         "expected Destroyed, got {err:?}"
+    );
+}
+
+#[tokio::test]
+async fn legacy_run_commit_rejection_preserves_registered_running_session() {
+    let adapter = Arc::new(MeerkatMachine::ephemeral());
+    let session_id = SessionId::new();
+    adapter.register_session(session_id.clone()).await;
+
+    let prepared =
+        prepare_legacy_run_for_authority_test(&adapter, &session_id, "commit rejection").await;
+    let rejected_run_id = RunId::new();
+    let result = adapter
+        .execute_meerkat_machine_command(
+            None,
+            MeerkatMachineCommand::Commit {
+                session_id: session_id.clone(),
+                input_id: prepared.input_id.clone(),
+                run_id: rejected_run_id.clone(),
+                output: legacy_run_test_output(rejected_run_id, prepared.input_id.clone()),
+            },
+        )
+        .await;
+
+    assert!(
+        result.is_err(),
+        "commit with a non-active run id should be rejected"
+    );
+    assert!(
+        adapter.contains_session(&session_id).await,
+        "typed commit rejection must not unregister the session"
+    );
+    assert_eq!(
+        adapter.runtime_state(&session_id).await.unwrap(),
+        RuntimeState::Running,
+        "rejected commit must leave canonical DSL lifecycle on the active run"
+    );
+    let input_state = adapter
+        .input_state(&session_id, &prepared.input_id)
+        .await
+        .expect("input state read should succeed")
+        .expect("prepared input should remain visible");
+    assert_eq!(
+        input_state.seed.phase,
+        crate::input_state::InputLifecycleState::Staged,
+        "rejected commit must not fake input completion"
+    );
+}
+
+#[tokio::test]
+async fn legacy_run_fail_rejection_preserves_registered_running_session() {
+    let adapter = Arc::new(MeerkatMachine::ephemeral());
+    let session_id = SessionId::new();
+    adapter.register_session(session_id.clone()).await;
+
+    let prepared =
+        prepare_legacy_run_for_authority_test(&adapter, &session_id, "fail rejection").await;
+    let result = adapter
+        .execute_meerkat_machine_command(
+            None,
+            MeerkatMachineCommand::Fail {
+                session_id: session_id.clone(),
+                run_id: RunId::new(),
+                error: "reject the wrong run".to_string(),
+            },
+        )
+        .await;
+
+    assert!(
+        result.is_err(),
+        "fail with a non-active run id should be rejected"
+    );
+    assert!(
+        adapter.contains_session(&session_id).await,
+        "typed fail rejection must not unregister the session"
+    );
+    assert_eq!(
+        adapter.runtime_state(&session_id).await.unwrap(),
+        RuntimeState::Running,
+        "rejected fail must leave canonical DSL lifecycle on the active run"
+    );
+    let input_state = adapter
+        .input_state(&session_id, &prepared.input_id)
+        .await
+        .expect("input state read should succeed")
+        .expect("prepared input should remain visible");
+    assert_eq!(
+        input_state.seed.phase,
+        crate::input_state::InputLifecycleState::Staged,
+        "rejected fail must not roll back the active input from shell policy"
+    );
+}
+
+#[tokio::test]
+async fn legacy_run_fail_terminalizes_through_machine_authority() {
+    let adapter = Arc::new(MeerkatMachine::ephemeral());
+    let session_id = SessionId::new();
+    adapter.register_session(session_id.clone()).await;
+
+    let prepared =
+        prepare_legacy_run_for_authority_test(&adapter, &session_id, "fail terminalization").await;
+    adapter
+        .execute_meerkat_machine_command(
+            None,
+            MeerkatMachineCommand::Fail {
+                session_id: session_id.clone(),
+                run_id: prepared.run_id.clone(),
+                error: "executor failed".to_string(),
+            },
+        )
+        .await
+        .expect("active fail should terminalize the run");
+
+    assert!(adapter.contains_session(&session_id).await);
+    assert_eq!(
+        adapter.runtime_state(&session_id).await.unwrap(),
+        RuntimeState::Idle
+    );
+    let input_state = adapter
+        .input_state(&session_id, &prepared.input_id)
+        .await
+        .expect("input state read should succeed")
+        .expect("prepared input should remain visible");
+    assert_eq!(
+        input_state.seed.phase,
+        crate::input_state::InputLifecycleState::Queued,
+        "machine fail should roll the recoverable input back for retry"
     );
 }
 

--- a/meerkat-runtime/src/meerkat_machine_tests.rs
+++ b/meerkat-runtime/src/meerkat_machine_tests.rs
@@ -11825,6 +11825,127 @@ async fn legacy_run_fail_terminalizes_through_machine_authority() {
     );
 }
 
+async fn staged_batch_commit_driver(
+    first: Input,
+    second: Input,
+) -> (SharedDriver, RunId, Vec<InputId>) {
+    let adapter = Arc::new(MeerkatMachine::ephemeral());
+    let session_id = SessionId::new();
+    adapter.register_session(session_id.clone()).await;
+
+    let first = match adapter
+        .accept_input(&session_id, first)
+        .await
+        .expect("first input should queue")
+    {
+        AcceptOutcome::Accepted { input_id, .. } => input_id,
+        other => panic!("expected accepted first input, got {other:?}"),
+    };
+    let second = match adapter
+        .accept_input(&session_id, second)
+        .await
+        .expect("second input should queue")
+    {
+        AcceptOutcome::Accepted { input_id, .. } => input_id,
+        other => panic!("expected accepted second input, got {other:?}"),
+    };
+    let staged_ids = vec![first, second];
+    let driver = {
+        let sessions = adapter.sessions.read().await;
+        Arc::clone(
+            &sessions
+                .get(&session_id)
+                .expect("registered session should exist")
+                .driver,
+        )
+    };
+    let run_id = RunId::new();
+    prepare_runtime_loop_batch_start(&driver, run_id.clone(), &staged_ids)
+        .await
+        .expect("batch prepare should stage both inputs");
+    (driver, run_id, staged_ids)
+}
+
+fn batch_receipt(run_id: RunId, contributing_input_ids: Vec<InputId>) -> RunBoundaryReceipt {
+    RunBoundaryReceipt {
+        run_id,
+        boundary: RunApplyBoundary::RunStart,
+        contributing_input_ids,
+        conversation_digest: None,
+        message_count: 0,
+        sequence: 0,
+    }
+}
+
+async fn assert_commit_rejection_preserved_staged_batch(
+    driver: &SharedDriver,
+    run_id: &RunId,
+    staged_ids: &[InputId],
+) {
+    let entry = driver.lock().await;
+    assert_eq!(
+        entry.runtime_state(),
+        RuntimeState::Running,
+        "rejected commit must preserve the active run"
+    );
+    assert_eq!(
+        entry.current_run_id(),
+        Some(run_id.clone()),
+        "rejected commit must preserve the active run id"
+    );
+    for input_id in staged_ids {
+        assert_eq!(
+            entry.input_phase(input_id),
+            Some(crate::input_state::InputLifecycleState::Staged),
+            "rejected commit must leave every contributor staged"
+        );
+    }
+}
+
+#[tokio::test]
+async fn legacy_run_commit_rejects_receipt_run_id_mismatch_before_mutation() {
+    let (driver, run_id, staged_ids) =
+        staged_batch_commit_driver(make_prompt("first"), make_prompt("second")).await;
+
+    let result = commit_runtime_loop_run(
+        &driver,
+        run_id.clone(),
+        staged_ids.clone(),
+        batch_receipt(RunId::new(), staged_ids.clone()),
+        None,
+    )
+    .await;
+
+    assert!(
+        result.is_err(),
+        "receipt for a different run id must reject before commit mutation"
+    );
+    assert_commit_rejection_preserved_staged_batch(&driver, &run_id, &staged_ids).await;
+}
+
+#[tokio::test]
+async fn legacy_run_commit_rejects_reordered_receipt_contributors_before_mutation() {
+    let (driver, run_id, staged_ids) =
+        staged_batch_commit_driver(make_prompt("first"), make_prompt("second")).await;
+    let mut receipt_contributors = staged_ids.clone();
+    receipt_contributors.reverse();
+
+    let result = commit_runtime_loop_run(
+        &driver,
+        run_id.clone(),
+        staged_ids.clone(),
+        batch_receipt(run_id.clone(), receipt_contributors),
+        None,
+    )
+    .await;
+
+    assert!(
+        result.is_err(),
+        "receipt contributors must exactly match consumed input ids"
+    );
+    assert_commit_rejection_preserved_staged_batch(&driver, &run_id, &staged_ids).await;
+}
+
 // ---------------------------------------------------------------
 // A6: Deep invariant region validation via spine snapshot
 // ---------------------------------------------------------------

--- a/meerkat-runtime/tests/meerkat_machine.rs
+++ b/meerkat-runtime/tests/meerkat_machine.rs
@@ -1551,6 +1551,10 @@ async fn boundary_commit_failure_unwinds_sync_runtime_state() {
         err.to_string().contains("runtime boundary commit failed"),
         "unexpected error: {err}"
     );
+    assert!(
+        adapter.contains_session(&sid).await,
+        "boundary commit rollback should preserve the registered session"
+    );
     assert_eq!(
         adapter.runtime_state(&sid).await.unwrap(),
         RuntimeState::Idle


### PR DESCRIPTION
## Summary
- remove the legacy-run Prepare DSL preflight so run-start authority is decided by the machine-owned transition path
- classify commit/fail failures with typed runtime-loop error categories instead of matching error strings in dispatch
- preserve sessions on rejected commit/fail and boundary commit rollback; keep terminal snapshot failures unregistering

## Migration / compatibility
- Legacy `accept_input_and_run` keeps the existing compatibility behavior for durable terminal persistence failures: terminal snapshot failures still unregister the session so callers do not observe a half-persisted terminal state.
- Boundary commit persistence failures continue to roll the input back and preserve the registered session for retry.
- Rejected commit/fail commands now leave the canonical DSL run binding intact instead of destroying the session from shell policy.

## Validation
- `./scripts/repo-cargo test -p meerkat-runtime legacy_run_ --lib`
- `./scripts/repo-cargo test -p meerkat-runtime --test meerkat_machine boundary_commit_failure`
- `./scripts/repo-cargo test -p meerkat-runtime --test meerkat_machine terminal_snapshot_failure`
- `./scripts/repo-cargo test -p meerkat-runtime --test meerkat_machine boundary_commit_failure_unwinds_sync_runtime_state`
- `git diff --check`
- `make check` (BuildBuddy invocation afed5652-77d4-4070-98f0-eeb750176e60)

Fixes LUC-113