### PR TITLE
Fix stale generated Bazel MCP server target

### DIFF
--- a/meerkat-mcp-server/BUILD.bazel
+++ b/meerkat-mcp-server/BUILD.bazel
@@ -35,7 +35,6 @@ rust_library(
     crate_root = "src/lib.rs",
     crate_features = [
         "comms",
-        "mob",
         "schedule",
     ],
     edition = "2024",
@@ -136,7 +135,6 @@ rust_binary(
     crate_root = "src/main.rs",
     crate_features = [
         "comms",
-        "mob",
         "schedule",
     ],
     edition = "2024",


### PR DESCRIPTION
Regenerates Bazel Rust BUILD files after the LUC-104 merge left meerkat-mcp-server/BUILD.bazel stale.\n\nValidation:\n- make buildbuddy-doctor