### PR TITLE
LUC-115: Fix provisional DSL dispatch rollback

### DIFF
--- a/meerkat-runtime/src/meerkat_machine/dispatch_control.rs
+++ b/meerkat-runtime/src/meerkat_machine/dispatch_control.rs
@@ -445,9 +445,13 @@ impl MeerkatMachine {
                 };
                 drop(drv);
 
-                self.apply_session_dsl_input(&session_id, destroy_input, "Destroy")
-                    .await
-                    .map_err(RuntimeControlPlaneError::Internal)?;
+                let apply_result = self
+                    .apply_session_dsl_input_preserving_committed_state(
+                        &session_id,
+                        destroy_input,
+                        "Destroy",
+                    )
+                    .await;
                 driver
                     .lock()
                     .await
@@ -455,6 +459,9 @@ impl MeerkatMachine {
 
                 let mut comp = completions.lock().await;
                 comp.resolve_all_terminated("runtime destroyed");
+                if let Err(reason) = apply_result {
+                    return Err(RuntimeControlPlaneError::Internal(reason));
+                }
                 Ok(MeerkatMachineCommandResult::DestroyReport(report))
             }
             MeerkatMachineCommand::RuntimeState { runtime_id } => {

--- a/meerkat-runtime/src/meerkat_machine/dispatch_control.rs
+++ b/meerkat-runtime/src/meerkat_machine/dispatch_control.rs
@@ -178,7 +178,7 @@ impl MeerkatMachine {
                 if matches!(state, RuntimeState::Destroyed | RuntimeState::Stopped) {
                     return Err(RuntimeControlPlaneError::InvalidState { state });
                 }
-                let previous_dsl_state = if state == RuntimeState::Retired {
+                let staged_dsl = if state == RuntimeState::Retired {
                     // The DSL Retire transition is intentionally not
                     // self-looping. Command-level idempotence belongs here,
                     // after reading the DSL-authoritative phase, while the
@@ -186,7 +186,7 @@ impl MeerkatMachine {
                     None
                 } else {
                     Some(
-                        self.stage_session_dsl_input(
+                        self.stage_session_dsl_transition(
                             &session_id,
                             crate::meerkat_machine::dsl::MeerkatMachineInput::Retire {
                                 session_id: crate::meerkat_machine::dsl::SessionId::from_domain(
@@ -205,14 +205,26 @@ impl MeerkatMachine {
                     Ok(report) => report,
                     Err(err) => {
                         drop(drv);
-                        if let Some(previous_dsl_state) = previous_dsl_state {
-                            self.restore_session_dsl_state(&session_id, previous_dsl_state)
+                        if let Some(staged_dsl) = staged_dsl {
+                            self.restore_session_dsl_state(&session_id, staged_dsl.previous_state)
                                 .await;
                         }
                         return Err(RuntimeControlPlaneError::Internal(err.to_string()));
                     }
                 };
                 drop(drv);
+
+                if let Some(staged_dsl) = staged_dsl
+                    && let Err(reason) = self
+                        .commit_session_dsl_transition(&session_id, staged_dsl, "Retire")
+                        .await
+                {
+                    driver
+                        .lock()
+                        .await
+                        .sync_control_projection_from_dsl_authority();
+                    return Err(RuntimeControlPlaneError::Internal(reason));
+                }
 
                 if report.inputs_pending_drain > 0 {
                     if let Some(ref tx) = wake_tx

--- a/meerkat-runtime/src/meerkat_machine/dispatch_control.rs
+++ b/meerkat-runtime/src/meerkat_machine/dispatch_control.rs
@@ -214,22 +214,30 @@ impl MeerkatMachine {
                 };
                 drop(drv);
 
+                let mut commit_error = None;
                 if let Some(staged_dsl) = staged_dsl
                     && let Err(reason) = self
-                        .commit_session_dsl_transition(&session_id, staged_dsl, "Retire")
+                        .commit_session_dsl_transition_preserving_committed_state(
+                            &session_id,
+                            staged_dsl,
+                            "Retire",
+                        )
                         .await
                 {
                     driver
                         .lock()
                         .await
                         .sync_control_projection_from_dsl_authority();
-                    return Err(RuntimeControlPlaneError::Internal(reason));
+                    commit_error = Some(reason);
                 }
 
                 if report.inputs_pending_drain > 0 {
                     if let Some(ref tx) = wake_tx
                         && tx.send(()).await.is_ok()
                     {
+                        if let Some(reason) = commit_error {
+                            return Err(RuntimeControlPlaneError::Internal(reason));
+                        }
                         return Ok(MeerkatMachineCommandResult::RetireReport(report));
                     }
 
@@ -243,6 +251,9 @@ impl MeerkatMachine {
                     comp.resolve_all_terminated("retired without runtime loop");
                     report.inputs_abandoned += abandoned;
                     report.inputs_pending_drain = 0;
+                }
+                if let Some(reason) = commit_error {
+                    return Err(RuntimeControlPlaneError::Internal(reason));
                 }
                 Ok(MeerkatMachineCommandResult::RetireReport(report))
             }

--- a/meerkat-runtime/src/meerkat_machine/dispatch_session.rs
+++ b/meerkat-runtime/src/meerkat_machine/dispatch_session.rs
@@ -59,13 +59,28 @@ impl MeerkatMachine {
                 generation: crate::meerkat_machine::dsl::Generation::from(0),
                 session_id: crate::meerkat_machine::dsl::SessionId::from_domain(&session_id),
             };
-            let _ = self
-                .stage_session_dsl_input(&session_id, dsl_input, "PrepareBindings")
+            let staged = self
+                .stage_session_dsl_transition(&session_id, dsl_input, "PrepareBindings")
                 .await
                 .map_err(|reason| RuntimeDriverError::ValidationFailed { reason })?;
             {
                 let mut driver = driver_handle.lock().await;
-                machine_prepare_bindings_projection(&mut driver)?;
+                if let Err(err) = machine_prepare_bindings_projection(&mut driver) {
+                    drop(driver);
+                    self.restore_session_dsl_state(&session_id, staged.previous_state)
+                        .await;
+                    return Err(err);
+                }
+            }
+            if let Err(reason) = self
+                .commit_session_dsl_transition(&session_id, staged, "PrepareBindings")
+                .await
+            {
+                driver_handle
+                    .lock()
+                    .await
+                    .sync_control_projection_from_dsl_authority();
+                return Err(RuntimeDriverError::Internal(reason));
             }
         }
         // Share ONE HandleDslAuthority across all 5 handles so their

--- a/meerkat-runtime/src/meerkat_machine/mod.rs
+++ b/meerkat-runtime/src/meerkat_machine/mod.rs
@@ -156,6 +156,11 @@ pub use comms_drain::{
 pub(crate) use comms_drain::{CommsDrainSlot, abort_slot};
 pub(crate) use visibility::MachineToolVisibilityOwner;
 
+struct StagedSessionDslInput {
+    previous_state: Box<dsl::MeerkatMachineState>,
+    effects: Vec<dsl::MeerkatMachineEffect>,
+}
+
 /// Per-session state: driver + registration phase.
 struct RuntimeSessionEntry {
     /// Per-session mutation gate.
@@ -404,9 +409,29 @@ impl MeerkatMachine {
         input: dsl::MeerkatMachineInput,
         context: &str,
     ) -> Result<Box<dsl::MeerkatMachineState>, String> {
-        self.apply_session_dsl_input(session_id, input, context)
+        self.stage_session_dsl_transition(session_id, input, context)
             .await
-            .map(|(previous_state, _)| previous_state)
+            .map(|staged| staged.previous_state)
+    }
+
+    async fn stage_session_dsl_transition(
+        &self,
+        session_id: &SessionId,
+        input: dsl::MeerkatMachineInput,
+        context: &str,
+    ) -> Result<StagedSessionDslInput, String> {
+        let authority = self.session_dsl_authority(session_id).await?;
+        let mut authority = authority
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        let previous_state = Box::new(authority.state.clone());
+        let effects = dsl::MeerkatMachineMutator::apply(&mut *authority, input)
+            .map(|transition| transition.effects)
+            .map_err(|err| dsl_authority::map_error(err, context))?;
+        Ok(StagedSessionDslInput {
+            previous_state,
+            effects,
+        })
     }
 
     async fn apply_session_dsl_input(
@@ -432,8 +457,33 @@ impl MeerkatMachine {
                 .map_err(|err| dsl_authority::map_error(err, context))?;
             (previous_state, effects)
         };
-        self.dispatch_routed_signals_from_effects(&effects).await?;
+        if let Err(error) = self.dispatch_routed_signals_from_effects(&effects).await {
+            self.restore_session_dsl_state(session_id, previous_state)
+                .await;
+            return Err(format!(
+                "DSL authority ({context}): committed effect dispatch failed: {error}"
+            ));
+        }
         Ok((previous_state, effects))
+    }
+
+    async fn commit_session_dsl_transition(
+        &self,
+        session_id: &SessionId,
+        staged: StagedSessionDslInput,
+        context: &str,
+    ) -> Result<(), String> {
+        if let Err(error) = self
+            .dispatch_routed_signals_from_effects(&staged.effects)
+            .await
+        {
+            self.restore_session_dsl_state(session_id, staged.previous_state)
+                .await;
+            return Err(format!(
+                "DSL authority ({context}): committed effect dispatch failed: {error}"
+            ));
+        }
+        Ok(())
     }
 
     async fn dispatch_routed_signals_from_effects(
@@ -632,15 +682,24 @@ impl MeerkatMachine {
         let authority = Arc::clone(&entry.dsl_authority);
         drop(sessions);
 
-        let effects = {
+        let (previous_state, effects) = {
             let mut guard = authority
                 .lock()
                 .unwrap_or_else(std::sync::PoisonError::into_inner);
-            dsl::MeerkatMachineMutator::apply(&mut *guard, input)
+            let previous_state = Box::new(guard.state.clone());
+            let effects = dsl::MeerkatMachineMutator::apply(&mut *guard, input)
                 .map(|transition| transition.effects)
-                .map_err(|err| format!("{err}"))?
+                .map_err(|err| format!("{err}"))?;
+            (previous_state, effects)
         };
-        self.dispatch_routed_signals_from_effects(&effects).await
+        if let Err(error) = self.dispatch_routed_signals_from_effects(&effects).await {
+            self.restore_session_dsl_state(session_id, previous_state)
+                .await;
+            return Err(format!(
+                "routed MeerkatMachine input committed effect dispatch failed: {error}"
+            ));
+        }
+        Ok(())
     }
 
     #[cfg(test)]

--- a/meerkat-runtime/src/meerkat_machine/mod.rs
+++ b/meerkat-runtime/src/meerkat_machine/mod.rs
@@ -527,12 +527,48 @@ impl MeerkatMachine {
         staged: StagedSessionDslInput,
         context: &str,
     ) -> Result<(), String> {
+        self.commit_session_dsl_transition_with_dispatch_failure(
+            session_id,
+            staged,
+            context,
+            CommittedEffectDispatchFailure::RestorePreviousDslState,
+        )
+        .await
+    }
+
+    async fn commit_session_dsl_transition_preserving_committed_state(
+        &self,
+        session_id: &SessionId,
+        staged: StagedSessionDslInput,
+        context: &str,
+    ) -> Result<(), String> {
+        self.commit_session_dsl_transition_with_dispatch_failure(
+            session_id,
+            staged,
+            context,
+            CommittedEffectDispatchFailure::PreserveCommittedDslState,
+        )
+        .await
+    }
+
+    async fn commit_session_dsl_transition_with_dispatch_failure(
+        &self,
+        session_id: &SessionId,
+        staged: StagedSessionDslInput,
+        context: &str,
+        dispatch_failure: CommittedEffectDispatchFailure,
+    ) -> Result<(), String> {
         if let Err(error) = self
             .dispatch_routed_signals_from_effects(&staged.effects)
             .await
         {
-            self.restore_session_dsl_state(session_id, staged.previous_state)
-                .await;
+            match dispatch_failure {
+                CommittedEffectDispatchFailure::PreserveCommittedDslState => {}
+                CommittedEffectDispatchFailure::RestorePreviousDslState => {
+                    self.restore_session_dsl_state(session_id, staged.previous_state)
+                        .await;
+                }
+            }
             return Err(format!(
                 "DSL authority ({context}): committed effect dispatch failed: {error}"
             ));

--- a/meerkat-runtime/src/meerkat_machine/mod.rs
+++ b/meerkat-runtime/src/meerkat_machine/mod.rs
@@ -161,6 +161,12 @@ struct StagedSessionDslInput {
     effects: Vec<dsl::MeerkatMachineEffect>,
 }
 
+#[derive(Clone, Copy)]
+enum CommittedEffectDispatchFailure {
+    PreserveCommittedDslState,
+    RestorePreviousDslState,
+}
+
 /// Per-session state: driver + registration phase.
 struct RuntimeSessionEntry {
     /// Per-session mutation gate.
@@ -446,6 +452,49 @@ impl MeerkatMachine {
         ),
         String,
     > {
+        self.apply_session_dsl_input_with_dispatch_failure(
+            session_id,
+            input,
+            context,
+            CommittedEffectDispatchFailure::RestorePreviousDslState,
+        )
+        .await
+    }
+
+    async fn apply_session_dsl_input_preserving_committed_state(
+        &self,
+        session_id: &SessionId,
+        input: dsl::MeerkatMachineInput,
+        context: &str,
+    ) -> Result<
+        (
+            Box<dsl::MeerkatMachineState>,
+            Vec<dsl::MeerkatMachineEffect>,
+        ),
+        String,
+    > {
+        self.apply_session_dsl_input_with_dispatch_failure(
+            session_id,
+            input,
+            context,
+            CommittedEffectDispatchFailure::PreserveCommittedDslState,
+        )
+        .await
+    }
+
+    async fn apply_session_dsl_input_with_dispatch_failure(
+        &self,
+        session_id: &SessionId,
+        input: dsl::MeerkatMachineInput,
+        context: &str,
+        dispatch_failure: CommittedEffectDispatchFailure,
+    ) -> Result<
+        (
+            Box<dsl::MeerkatMachineState>,
+            Vec<dsl::MeerkatMachineEffect>,
+        ),
+        String,
+    > {
         let authority = self.session_dsl_authority(session_id).await?;
         let (previous_state, effects) = {
             let mut authority = authority
@@ -458,8 +507,13 @@ impl MeerkatMachine {
             (previous_state, effects)
         };
         if let Err(error) = self.dispatch_routed_signals_from_effects(&effects).await {
-            self.restore_session_dsl_state(session_id, previous_state)
-                .await;
+            match dispatch_failure {
+                CommittedEffectDispatchFailure::PreserveCommittedDslState => {}
+                CommittedEffectDispatchFailure::RestorePreviousDslState => {
+                    self.restore_session_dsl_state(session_id, previous_state)
+                        .await;
+                }
+            }
             return Err(format!(
                 "DSL authority ({context}): committed effect dispatch failed: {error}"
             ));

--- a/meerkat-runtime/src/meerkat_machine_tests.rs
+++ b/meerkat-runtime/src/meerkat_machine_tests.rs
@@ -283,6 +283,31 @@ async fn authoritative_dsl_apply_rolls_back_state_when_effect_dispatch_fails() {
 }
 
 #[tokio::test]
+async fn destroy_keeps_committed_dsl_state_when_runtime_destroyed_signal_dispatch_fails() {
+    let machine = MeerkatMachine::ephemeral();
+    let session_id = SessionId::new();
+    machine
+        .prepare_bindings(session_id.clone())
+        .await
+        .expect("prepare bindings before destroy");
+    install_rejecting_meerkat_signal_dispatcher(&machine);
+
+    let runtime_id = LogicalRuntimeId::new(session_id.to_string());
+    let err = crate::traits::RuntimeControlPlane::destroy(&machine, &runtime_id)
+        .await
+        .expect_err("signal dispatch failure should surface");
+    assert!(
+        err.to_string().contains("injected signal commit failure"),
+        "{err}"
+    );
+    assert_eq!(
+        machine.existing_session_runtime_state(&session_id).await,
+        Some(RuntimeState::Destroyed),
+        "irreversible shell destroy must not roll DSL authority back to an earlier phase"
+    );
+}
+
+#[tokio::test]
 async fn prepare_bindings_dispatches_runtime_bound_after_shell_commit() {
     let machine = MeerkatMachine::ephemeral();
     let session_id = SessionId::new();

--- a/meerkat-runtime/src/meerkat_machine_tests.rs
+++ b/meerkat-runtime/src/meerkat_machine_tests.rs
@@ -308,6 +308,50 @@ async fn destroy_keeps_committed_dsl_state_when_runtime_destroyed_signal_dispatc
 }
 
 #[tokio::test]
+async fn persistent_retire_keeps_committed_dsl_state_when_runtime_retired_signal_dispatch_fails() {
+    let store = Arc::new(crate::store::InMemoryRuntimeStore::new());
+    let machine = MeerkatMachine::persistent(
+        store.clone() as Arc<dyn crate::store::RuntimeStore>,
+        memory_blob_store(),
+    );
+    let session_id = SessionId::new();
+    machine.register_session(session_id.clone()).await;
+    install_rejecting_meerkat_signal_dispatcher(&machine);
+
+    let runtime_id = LogicalRuntimeId::new(session_id.to_string());
+    let err = crate::traits::RuntimeControlPlane::retire(&machine, &runtime_id)
+        .await
+        .expect_err("signal dispatch failure should surface");
+    assert!(
+        err.to_string().contains("injected signal commit failure"),
+        "{err}"
+    );
+    assert_eq!(
+        machine.existing_session_runtime_state(&session_id).await,
+        Some(RuntimeState::Retired),
+        "durably committed retire must not roll live DSL authority back to an earlier phase"
+    );
+    assert_eq!(
+        crate::store::RuntimeStore::load_runtime_state(store.as_ref(), &runtime_id)
+            .await
+            .expect("load persisted runtime state"),
+        Some(RuntimeState::Retired),
+        "persistent retire shell commit remains authoritative after routed-effect failure"
+    );
+
+    let recovered = MeerkatMachine::persistent(
+        store as Arc<dyn crate::store::RuntimeStore>,
+        memory_blob_store(),
+    );
+    recovered.register_session(session_id.clone()).await;
+    assert_eq!(
+        recovered.existing_session_runtime_state(&session_id).await,
+        Some(RuntimeState::Retired),
+        "cold restart must agree with the live process after failed retire signal dispatch"
+    );
+}
+
+#[tokio::test]
 async fn prepare_bindings_dispatches_runtime_bound_after_shell_commit() {
     let machine = MeerkatMachine::ephemeral();
     let session_id = SessionId::new();

--- a/meerkat-runtime/src/meerkat_machine_tests.rs
+++ b/meerkat-runtime/src/meerkat_machine_tests.rs
@@ -53,6 +53,121 @@ fn memory_blob_store() -> Arc<dyn meerkat_core::BlobStore> {
     Arc::new(meerkat_store::MemoryBlobStore::new())
 }
 
+#[derive(Default)]
+struct RecordingMeerkatSignalSurface {
+    log: tokio::sync::Mutex<
+        Vec<(
+            meerkat_machine_schema::identity::SignalVariantId,
+            Vec<(
+                meerkat_machine_schema::identity::FieldId,
+                crate::composition::OwnedFieldValue,
+            )>,
+        )>,
+    >,
+}
+
+#[async_trait::async_trait]
+impl crate::composition::SignalConsumerSurface for RecordingMeerkatSignalSurface {
+    fn instance_id(&self) -> &meerkat_machine_schema::identity::MachineInstanceId {
+        static ID: std::sync::OnceLock<meerkat_machine_schema::identity::MachineInstanceId> =
+            std::sync::OnceLock::new();
+        ID.get_or_init(|| {
+            meerkat_machine_schema::identity::MachineInstanceId::parse("mob")
+                .expect("canonical instance id")
+        })
+    }
+
+    async fn receive_signal(
+        &self,
+        variant: meerkat_machine_schema::identity::SignalVariantId,
+        projected_fields: Vec<(
+            meerkat_machine_schema::identity::FieldId,
+            crate::composition::OwnedFieldValue,
+        )>,
+    ) -> Result<(), String> {
+        self.log.lock().await.push((variant, projected_fields));
+        Ok(())
+    }
+}
+
+struct RejectingMeerkatSignalSurface;
+
+#[async_trait::async_trait]
+impl crate::composition::SignalConsumerSurface for RejectingMeerkatSignalSurface {
+    fn instance_id(&self) -> &meerkat_machine_schema::identity::MachineInstanceId {
+        static ID: std::sync::OnceLock<meerkat_machine_schema::identity::MachineInstanceId> =
+            std::sync::OnceLock::new();
+        ID.get_or_init(|| {
+            meerkat_machine_schema::identity::MachineInstanceId::parse("mob")
+                .expect("canonical instance id")
+        })
+    }
+
+    async fn receive_signal(
+        &self,
+        _variant: meerkat_machine_schema::identity::SignalVariantId,
+        _projected_fields: Vec<(
+            meerkat_machine_schema::identity::FieldId,
+            crate::composition::OwnedFieldValue,
+        )>,
+    ) -> Result<(), String> {
+        Err("injected signal commit failure".to_string())
+    }
+}
+
+fn prepare_bindings_input(
+    session_id: &SessionId,
+    runtime_id: &str,
+    fence_token: u64,
+) -> dsl::MeerkatMachineInput {
+    dsl::MeerkatMachineInput::PrepareBindings {
+        agent_runtime_id: dsl::AgentRuntimeId::from(runtime_id.to_string()),
+        fence_token: dsl::FenceToken(fence_token),
+        generation: dsl::Generation(0),
+        session_id: dsl::SessionId::from_domain(session_id),
+    }
+}
+
+fn install_recording_meerkat_signal_dispatcher(
+    machine: &MeerkatMachine,
+) -> Arc<RecordingMeerkatSignalSurface> {
+    let signal_surface = Arc::new(RecordingMeerkatSignalSurface::default());
+    let schema = meerkat_machine_schema::catalog::meerkat_mob_seam_composition();
+    let table = crate::composition::RouteTable::from_schema(&schema).expect("catalog routes");
+    let dispatcher: crate::composition::CatalogCompositionSignalDispatcher<
+        crate::meerkat_machine::composition::MeerkatSeamSignal,
+    > = crate::composition::CatalogCompositionSignalDispatcher::new(schema.name.clone(), table)
+        .with_consumer(signal_surface.clone());
+    machine.set_composition_signal_dispatcher(Arc::new(dispatcher));
+    signal_surface
+}
+
+fn install_rejecting_meerkat_signal_dispatcher(machine: &MeerkatMachine) {
+    let signal_surface = Arc::new(RejectingMeerkatSignalSurface);
+    let schema = meerkat_machine_schema::catalog::meerkat_mob_seam_composition();
+    let table = crate::composition::RouteTable::from_schema(&schema).expect("catalog routes");
+    let dispatcher: crate::composition::CatalogCompositionSignalDispatcher<
+        crate::meerkat_machine::composition::MeerkatSeamSignal,
+    > = crate::composition::CatalogCompositionSignalDispatcher::new(schema.name.clone(), table)
+        .with_consumer(signal_surface);
+    machine.set_composition_signal_dispatcher(Arc::new(dispatcher));
+}
+
+async fn assert_no_runtime_binding(machine: &MeerkatMachine, session_id: &SessionId) {
+    let state = machine
+        .session_dsl_state(session_id)
+        .await
+        .expect("session DSL state");
+    assert!(
+        state.active_runtime_id.is_none(),
+        "rollback must not leave a staged active_runtime_id"
+    );
+    assert!(
+        state.active_fence_token.is_none(),
+        "rollback must not leave a staged active_fence_token"
+    );
+}
+
 #[test]
 fn legacy_run_handler_does_not_restore_dsl_snapshots_by_hand() {
     let source = include_str!("meerkat_machine/dispatch_ingress.rs");
@@ -69,6 +184,154 @@ fn legacy_run_handler_does_not_restore_dsl_snapshots_by_hand() {
         !legacy_run_handler.contains("restore_session_dsl_state"),
         "legacy run must not manually restore DSL authority",
     );
+}
+
+#[tokio::test]
+async fn provisional_dsl_stage_does_not_emit_routed_signal_until_authoritative_apply() {
+    let machine = MeerkatMachine::ephemeral();
+    let session_id = SessionId::new();
+    machine.register_session(session_id.clone()).await;
+    let signal_surface = install_recording_meerkat_signal_dispatcher(&machine);
+
+    let previous_state = machine
+        .stage_session_dsl_input(
+            &session_id,
+            prepare_bindings_input(&session_id, "rt-provisional", 7),
+            "PrepareBindings(test provisional)",
+        )
+        .await
+        .expect("provisional stage");
+
+    assert!(
+        signal_surface.log.lock().await.is_empty(),
+        "provisional DSL effects must not be observable before commit"
+    );
+
+    machine
+        .restore_session_dsl_state(&session_id, previous_state)
+        .await;
+
+    let (_, effects) = machine
+        .apply_session_dsl_input(
+            &session_id,
+            prepare_bindings_input(&session_id, "rt-authoritative", 11),
+            "PrepareBindings(test authoritative)",
+        )
+        .await
+        .expect("authoritative apply");
+    assert!(
+        effects
+            .iter()
+            .any(|effect| matches!(effect, dsl::MeerkatMachineEffect::RuntimeBound { .. }))
+    );
+
+    let log = signal_surface.log.lock().await;
+    assert_eq!(log.len(), 1);
+    assert_eq!(log[0].0.as_str(), "ObserveRuntimeReady");
+    assert_eq!(log[0].1[0].0.as_str(), "agent_runtime_id");
+    assert!(
+        matches!(&log[0].1[0].1, crate::composition::OwnedFieldValue::Str(value) if value == "rt-authoritative")
+    );
+}
+
+#[tokio::test]
+async fn provisional_dsl_rollback_after_shell_failure_leaks_no_routed_signal_or_state() {
+    let machine = MeerkatMachine::ephemeral();
+    let session_id = SessionId::new();
+    machine.register_session(session_id.clone()).await;
+    let signal_surface = install_recording_meerkat_signal_dispatcher(&machine);
+
+    let previous_state = machine
+        .stage_session_dsl_input(
+            &session_id,
+            prepare_bindings_input(&session_id, "rt-rolled-back", 17),
+            "PrepareBindings(test rollback)",
+        )
+        .await
+        .expect("provisional stage");
+    machine
+        .restore_session_dsl_state(&session_id, previous_state)
+        .await;
+
+    assert!(
+        signal_surface.log.lock().await.is_empty(),
+        "rolled-back provisional effects must not leak routed signals"
+    );
+    assert_no_runtime_binding(&machine, &session_id).await;
+}
+
+#[tokio::test]
+async fn authoritative_dsl_apply_rolls_back_state_when_effect_dispatch_fails() {
+    let machine = MeerkatMachine::ephemeral();
+    let session_id = SessionId::new();
+    machine.register_session(session_id.clone()).await;
+    install_rejecting_meerkat_signal_dispatcher(&machine);
+
+    let err = match machine
+        .apply_session_dsl_input(
+            &session_id,
+            prepare_bindings_input(&session_id, "rt-dispatch-fails", 23),
+            "PrepareBindings(test dispatch failure)",
+        )
+        .await
+    {
+        Ok(_) => panic!("dispatch failure should reject authoritative apply"),
+        Err(err) => err,
+    };
+    assert!(err.contains("injected signal commit failure"), "{err}");
+    assert_no_runtime_binding(&machine, &session_id).await;
+}
+
+#[tokio::test]
+async fn prepare_bindings_dispatches_runtime_bound_after_shell_commit() {
+    let machine = MeerkatMachine::ephemeral();
+    let session_id = SessionId::new();
+    let signal_surface = install_recording_meerkat_signal_dispatcher(&machine);
+
+    let bindings = machine
+        .prepare_bindings(session_id.clone())
+        .await
+        .expect("prepare bindings commits");
+    assert_eq!(bindings.session_id, session_id);
+
+    let log = signal_surface.log.lock().await;
+    assert_eq!(log.len(), 1);
+    assert_eq!(log[0].0.as_str(), "ObserveRuntimeReady");
+    assert_eq!(log[0].1[0].0.as_str(), "agent_runtime_id");
+    assert!(matches!(
+        &log[0].1[0].1,
+        crate::composition::OwnedFieldValue::Str(value) if value == &session_id.to_string()
+    ));
+}
+
+#[tokio::test]
+async fn rejected_provisional_dsl_transition_emits_no_routed_signal_or_state() {
+    let machine = MeerkatMachine::ephemeral();
+    let session_id = SessionId::new();
+    machine.register_session(session_id.clone()).await;
+    let signal_surface = install_recording_meerkat_signal_dispatcher(&machine);
+
+    let err = machine
+        .stage_session_dsl_input(
+            &session_id,
+            dsl::MeerkatMachineInput::Commit {
+                input_id: dsl::InputId::from("missing-input"),
+                run_id: dsl::RunId::from("missing-run"),
+            },
+            "Commit(test rejected provisional)",
+        )
+        .await
+        .expect_err("commit is invalid outside Running");
+
+    assert!(
+        err.contains("no matching transition") || err.contains("guard rejected"),
+        "{err}"
+    );
+    assert!(
+        signal_surface.log.lock().await.is_empty(),
+        "rejected provisional transition must not publish routed signals"
+    );
+    assert_no_runtime_binding(&machine, &session_id).await;
 }
 
 fn finite_switch_request(


### PR DESCRIPTION
## Summary

- Split provisional MeerkatMachine DSL staging from routed-effect dispatch so staged effects are buffered until an authoritative commit boundary.
- Commit staged routed effects for `PrepareBindings` and `Retire` only after the shell mutation succeeds; rollback restores staged DSL state without publishing routed signals.
- Restore DSL state if committed routed-effect dispatch fails for authoritative and routed MeerkatMachine inputs.

## Validation

- `./scripts/repo-cargo test -p meerkat-runtime provisional_dsl_stage_does_not_emit_routed_signal_until_authoritative_apply` failed before implementation, then passed after the fix.
- `./scripts/repo-cargo test -p meerkat-runtime provisional_dsl_rollback_after_shell_failure_leaks_no_routed_signal_or_state`
- `./scripts/repo-cargo test -p meerkat-runtime authoritative_dsl_apply_rolls_back_state_when_effect_dispatch_fails`
- `./scripts/repo-cargo test -p meerkat-runtime rejected_provisional_dsl_transition_emits_no_routed_signal_or_state`
- `./scripts/repo-cargo test -p meerkat-runtime prepare_bindings_dispatches_runtime_bound_after_shell_commit`
- `./scripts/repo-cargo test -p meerkat-runtime routed_prepare_bindings_dispatches_runtime_bound_signal`
- `./scripts/repo-cargo test -p meerkat-runtime local_session_bindings_do_not_dispatch_runtime_bound_signal`
- `./scripts/repo-cargo test -p meerkat-runtime --lib` (508 tests)
- `MEERKAT_BUILDBUDDY=1 make check` after rebase, BuildBuddy invocation `58965f30-b3ae-48fa-950d-364e23f70862`

## Projection-only compatibility

`PrepareLocalSessionBindings` remains resource-only and intentionally does not publish the cross-machine `RuntimeBound` composition signal. The existing `local_session_bindings_do_not_dispatch_runtime_bound_signal` coverage is preserved for that compatibility behavior.

Linear: LUC-115
