### PR TITLE
Unify supervisor bridge protocol version ownership

### DIFF
--- a/meerkat-contracts/src/lib.rs
+++ b/meerkat-contracts/src/lib.rs
@@ -42,6 +42,10 @@ pub use wire::supervisor_bridge::{
     BridgeDeliveryResponse, BridgeDestroyResponse, BridgeMemberRuntimeState,
     BridgeObservationResponse, BridgePeerConnectivity, BridgePeerSpec, BridgePeerWiringPayload,
     BridgeReply, BridgeRetireResponse, BridgeSupervisorPayload,
+    SUPERVISOR_BRIDGE_CURRENT_PROTOCOL_VERSION, SUPERVISOR_BRIDGE_DEFAULT_PROTOCOL_VERSION,
+    SUPERVISOR_BRIDGE_PROTOCOL_VERSION, SUPERVISOR_BRIDGE_SUPPORTED_PROTOCOL_VERSIONS,
+    supervisor_bridge_current_protocol_version, supervisor_bridge_default_protocol_version,
+    supervisor_bridge_protocol_version_supported, supervisor_bridge_supported_protocol_versions,
 };
 pub use wire::{
     ApprovalActionKind,

--- a/meerkat-contracts/src/wire/mod.rs
+++ b/meerkat-contracts/src/wire/mod.rs
@@ -155,6 +155,11 @@ pub use supervisor_bridge::{
     BridgeDeliveryOutcome, BridgeDeliveryPayload, BridgeDeliveryRejectionCause,
     BridgeDeliveryResponse, BridgeDestroyResponse, BridgeMemberRuntimeState,
     BridgeObservationResponse, BridgePeerConnectivity, BridgePeerSpec, BridgePeerWiringPayload,
-    BridgeReply, BridgeRetireResponse, BridgeSupervisorPayload, SUPERVISOR_BRIDGE_INTENT,
+    BridgeReply, BridgeRetireResponse, BridgeSupervisorPayload,
+    SUPERVISOR_BRIDGE_CURRENT_PROTOCOL_VERSION, SUPERVISOR_BRIDGE_DEFAULT_PROTOCOL_VERSION,
+    SUPERVISOR_BRIDGE_INTENT, SUPERVISOR_BRIDGE_PROTOCOL_VERSION,
+    SUPERVISOR_BRIDGE_SUPPORTED_PROTOCOL_VERSIONS, supervisor_bridge_current_protocol_version,
+    supervisor_bridge_default_protocol_version, supervisor_bridge_protocol_version_supported,
+    supervisor_bridge_supported_protocol_versions,
 };
 pub use usage::WireUsage;

--- a/meerkat-contracts/src/wire/supervisor_bridge.rs
+++ b/meerkat-contracts/src/wire/supervisor_bridge.rs
@@ -24,6 +24,37 @@ pub const SUPERVISOR_BRIDGE_BOOTSTRAP_TOKEN_PARAM: &str = "mob_supervisor_bootst
 ///   carry typed `BridgeDeliveryRejectionCause` data; the string `reason`
 ///   remains diagnostic presentation only.
 pub const SUPERVISOR_BRIDGE_PROTOCOL_VERSION: u32 = 2;
+/// Canonical current supervisor bridge protocol version.
+pub const SUPERVISOR_BRIDGE_CURRENT_PROTOCOL_VERSION: u32 = SUPERVISOR_BRIDGE_PROTOCOL_VERSION;
+/// Canonical default supervisor bridge protocol version for new authorities.
+pub const SUPERVISOR_BRIDGE_DEFAULT_PROTOCOL_VERSION: u32 = SUPERVISOR_BRIDGE_PROTOCOL_VERSION;
+/// Canonical set of protocol versions this runtime/wire contract accepts.
+pub const SUPERVISOR_BRIDGE_SUPPORTED_PROTOCOL_VERSIONS: &[u32] =
+    &[SUPERVISOR_BRIDGE_PROTOCOL_VERSION];
+
+/// Return the canonical current supervisor bridge protocol version.
+pub const fn supervisor_bridge_current_protocol_version() -> u32 {
+    SUPERVISOR_BRIDGE_CURRENT_PROTOCOL_VERSION
+}
+
+/// Return the canonical default supervisor bridge protocol version.
+pub const fn supervisor_bridge_default_protocol_version() -> u32 {
+    SUPERVISOR_BRIDGE_DEFAULT_PROTOCOL_VERSION
+}
+
+/// Return the canonical list of supported supervisor bridge protocol versions.
+pub fn supervisor_bridge_supported_protocol_versions() -> &'static [u32] {
+    SUPERVISOR_BRIDGE_SUPPORTED_PROTOCOL_VERSIONS
+}
+
+/// Return `true` when `protocol_version` is accepted by this bridge contract.
+pub fn supervisor_bridge_protocol_version_supported(protocol_version: u32) -> bool {
+    supervisor_bridge_supported_protocol_versions().contains(&protocol_version)
+}
+
+fn default_supported_protocol_versions() -> Vec<u32> {
+    supervisor_bridge_supported_protocol_versions().to_vec()
+}
 
 /// Remove the one-time bind bootstrap token from an advertised bridge address.
 pub fn canonicalize_bridge_address(address: &str) -> String {
@@ -467,15 +498,48 @@ pub struct BridgeBindPayload {
 }
 
 /// Capabilities advertised by a member runtime on bind.
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Default)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct BridgeCapabilities {
+    /// Protocol version implemented by the responding member runtime.
+    #[serde(default = "supervisor_bridge_current_protocol_version")]
+    pub current_protocol_version: u32,
+    /// Protocol version new supervisors should use for fresh authority records.
+    #[serde(default = "supervisor_bridge_default_protocol_version")]
+    pub default_protocol_version: u32,
+    /// Protocol versions accepted by the responding member runtime.
+    #[serde(default = "default_supported_protocol_versions")]
+    pub supported_protocol_versions: Vec<u32>,
+    #[serde(default)]
     pub deliver_member_input: bool,
+    #[serde(default)]
     pub observe_member: bool,
+    #[serde(default)]
     pub interrupt_member: bool,
+    #[serde(default)]
     pub retire_member: bool,
+    #[serde(default)]
     pub destroy_member: bool,
+    #[serde(default)]
     pub wire_member: bool,
+    #[serde(default)]
     pub unwire_member: bool,
+}
+
+impl Default for BridgeCapabilities {
+    fn default() -> Self {
+        Self {
+            current_protocol_version: supervisor_bridge_current_protocol_version(),
+            default_protocol_version: supervisor_bridge_default_protocol_version(),
+            supported_protocol_versions: supervisor_bridge_supported_protocol_versions().to_vec(),
+            deliver_member_input: false,
+            observe_member: false,
+            interrupt_member: false,
+            retire_member: false,
+            destroy_member: false,
+            wire_member: false,
+            unwire_member: false,
+        }
+    }
 }
 
 // ---------------------------------------------------------------------------
@@ -866,6 +930,80 @@ mod tests {
         assert_eq!(command.protocol_version(), 7);
     }
 
+    #[test]
+    fn supervisor_bridge_protocol_versions_are_reported_from_single_authority() {
+        assert_eq!(
+            supervisor_bridge_current_protocol_version(),
+            SUPERVISOR_BRIDGE_PROTOCOL_VERSION
+        );
+        assert_eq!(
+            supervisor_bridge_default_protocol_version(),
+            SUPERVISOR_BRIDGE_PROTOCOL_VERSION
+        );
+        assert_eq!(
+            supervisor_bridge_supported_protocol_versions(),
+            &[SUPERVISOR_BRIDGE_PROTOCOL_VERSION]
+        );
+        assert!(supervisor_bridge_protocol_version_supported(
+            SUPERVISOR_BRIDGE_PROTOCOL_VERSION
+        ));
+        assert!(!supervisor_bridge_protocol_version_supported(1));
+        assert!(!supervisor_bridge_protocol_version_supported(
+            SUPERVISOR_BRIDGE_PROTOCOL_VERSION + 1
+        ));
+    }
+
+    #[test]
+    fn bridge_capabilities_default_reports_canonical_protocol_versions() {
+        let capabilities = BridgeCapabilities::default();
+        assert_eq!(
+            capabilities.current_protocol_version,
+            SUPERVISOR_BRIDGE_PROTOCOL_VERSION
+        );
+        assert_eq!(
+            capabilities.default_protocol_version,
+            SUPERVISOR_BRIDGE_PROTOCOL_VERSION
+        );
+        assert_eq!(
+            capabilities.supported_protocol_versions,
+            vec![SUPERVISOR_BRIDGE_PROTOCOL_VERSION]
+        );
+    }
+
+    #[test]
+    fn bridge_capabilities_deserialize_legacy_without_protocol_report() {
+        let capabilities: BridgeCapabilities = serde_json::from_value(json!({
+            "deliver_member_input": true,
+            "observe_member": true,
+            "interrupt_member": true,
+            "retire_member": true,
+            "destroy_member": true,
+            "wire_member": true,
+            "unwire_member": true,
+        }))
+        .expect("legacy capability payload without protocol report should decode");
+
+        assert_eq!(
+            capabilities.current_protocol_version,
+            SUPERVISOR_BRIDGE_PROTOCOL_VERSION
+        );
+        assert_eq!(
+            capabilities.default_protocol_version,
+            SUPERVISOR_BRIDGE_PROTOCOL_VERSION
+        );
+        assert_eq!(
+            capabilities.supported_protocol_versions,
+            vec![SUPERVISOR_BRIDGE_PROTOCOL_VERSION]
+        );
+        assert!(capabilities.deliver_member_input);
+        assert!(capabilities.observe_member);
+        assert!(capabilities.interrupt_member);
+        assert!(capabilities.retire_member);
+        assert!(capabilities.destroy_member);
+        assert!(capabilities.wire_member);
+        assert!(capabilities.unwire_member);
+    }
+
     // -----------------------------------------------------------------------
     // 3. BridgeObservationResponse round-trip with all-present / all-absent
     //    optional fields. `skip_serializing_if = "Option::is_none"` must
@@ -1052,6 +1190,9 @@ mod tests {
                 "peer_id": "peer-x",
                 "address": "inproc://peer-x",
                 "capabilities": {
+                    "current_protocol_version": SUPERVISOR_BRIDGE_PROTOCOL_VERSION,
+                    "default_protocol_version": SUPERVISOR_BRIDGE_PROTOCOL_VERSION,
+                    "supported_protocol_versions": [SUPERVISOR_BRIDGE_PROTOCOL_VERSION],
                     "deliver_member_input": false,
                     "observe_member": false,
                     "interrupt_member": false,

--- a/meerkat-mob/src/runtime/bridge_protocol.rs
+++ b/meerkat-mob/src/runtime/bridge_protocol.rs
@@ -11,6 +11,10 @@ pub use meerkat_contracts::wire::supervisor_bridge::{
     BridgeObservationResponse, BridgePeerConnectivity, BridgePeerSpec, BridgePeerWiringPayload,
     BridgeRejectionCause, BridgeRejectionClass, BridgeRejectionReply, BridgeReply,
     BridgeRetireResponse, BridgeSupervisorPayload, SUPERVISOR_BRIDGE_BOOTSTRAP_TOKEN_PARAM,
-    SUPERVISOR_BRIDGE_INTENT, SUPERVISOR_BRIDGE_PROTOCOL_VERSION, canonicalize_bridge_address,
-    decode_bridge_rejection_reply,
+    SUPERVISOR_BRIDGE_CURRENT_PROTOCOL_VERSION, SUPERVISOR_BRIDGE_DEFAULT_PROTOCOL_VERSION,
+    SUPERVISOR_BRIDGE_INTENT, SUPERVISOR_BRIDGE_PROTOCOL_VERSION,
+    SUPERVISOR_BRIDGE_SUPPORTED_PROTOCOL_VERSIONS, canonicalize_bridge_address,
+    decode_bridge_rejection_reply, supervisor_bridge_current_protocol_version,
+    supervisor_bridge_default_protocol_version, supervisor_bridge_protocol_version_supported,
+    supervisor_bridge_supported_protocol_versions,
 };

--- a/meerkat-mob/src/runtime/builder.rs
+++ b/meerkat-mob/src/runtime/builder.rs
@@ -713,19 +713,34 @@ impl MobBuilder {
         runtime_metadata: Arc<dyn crate::store::MobRuntimeMetadataStore>,
         mob_id: MobId,
     ) -> Result<(), MobError> {
-        const MOB_RUNTIME_BRIDGE_PROTOCOL_VERSION: u32 = 1;
-
-        if runtime_metadata
-            .load_supervisor_authority(&mob_id)
-            .await?
-            .is_none()
-        {
-            let record = crate::store::SupervisorAuthorityRecord::generate(
-                MOB_RUNTIME_BRIDGE_PROTOCOL_VERSION,
-            );
-            runtime_metadata
-                .put_supervisor_authority_if_absent(&mob_id, &record)
-                .await?;
+        let default_protocol_version =
+            super::bridge_protocol::supervisor_bridge_default_protocol_version();
+        match runtime_metadata.load_supervisor_authority(&mob_id).await? {
+            None => {
+                let record =
+                    crate::store::SupervisorAuthorityRecord::generate(default_protocol_version);
+                runtime_metadata
+                    .put_supervisor_authority_if_absent(&mob_id, &record)
+                    .await?;
+            }
+            Some(record)
+                if super::bridge_protocol::supervisor_bridge_protocol_version_supported(
+                    record.protocol_version,
+                ) => {}
+            Some(mut record) if record.protocol_version < default_protocol_version => {
+                record.protocol_version = default_protocol_version;
+                runtime_metadata
+                    .put_supervisor_authority(&mob_id, &record)
+                    .await?;
+            }
+            Some(record) => {
+                return Err(MobError::WiringError(format!(
+                    "unsupported supervisor bridge protocol version {} (supported {:?}; default {})",
+                    record.protocol_version,
+                    super::bridge_protocol::supervisor_bridge_supported_protocol_versions(),
+                    default_protocol_version
+                )));
+            }
         }
 
         Ok(())

--- a/meerkat-mob/src/runtime/tests.rs
+++ b/meerkat-mob/src/runtime/tests.rs
@@ -62,6 +62,12 @@ use std::time::{Duration, Instant, SystemTime};
 use tempfile::NamedTempFile;
 use uuid::Uuid;
 
+fn default_supervisor_authority_record() -> SupervisorAuthorityRecord {
+    SupervisorAuthorityRecord::generate(
+        super::bridge_protocol::supervisor_bridge_default_protocol_version(),
+    )
+}
+
 // -----------------------------------------------------------------------
 // Mock CommsRuntime
 // -----------------------------------------------------------------------
@@ -2667,6 +2673,7 @@ struct LiveExternalPeerHarness {
     binding: crate::RuntimeBinding,
     runtime: Arc<meerkat_comms::CommsRuntime>,
     bind_count: Arc<std::sync::atomic::AtomicUsize>,
+    bind_protocol_versions: Arc<RwLock<Vec<u32>>>,
     delivered_inputs: Arc<RwLock<Vec<String>>>,
     received_intents: Arc<RwLock<Vec<String>>>,
     supervisor_state: Arc<RwLock<Option<HarnessSupervisorState>>>,
@@ -2708,6 +2715,10 @@ impl LiveExternalPeerHarness {
 
     fn bind_count(&self) -> usize {
         self.bind_count.load(Ordering::Relaxed)
+    }
+
+    async fn bind_protocol_versions(&self) -> Vec<u32> {
+        self.bind_protocol_versions.read().await.clone()
     }
 
     async fn delivered_input_ids(&self) -> Vec<String> {
@@ -2762,6 +2773,8 @@ async fn spawn_live_external_peer(peer_name: &str) -> LiveExternalPeerHarness {
     let responder_runtime = runtime.clone();
     let bind_count = Arc::new(std::sync::atomic::AtomicUsize::new(0));
     let responder_bind_count = bind_count.clone();
+    let bind_protocol_versions = Arc::new(RwLock::new(Vec::new()));
+    let responder_bind_protocol_versions = bind_protocol_versions.clone();
     let delivered_inputs = Arc::new(RwLock::new(Vec::new()));
     let responder_delivered_inputs = delivered_inputs.clone();
     let delivery_responses = Arc::new(RwLock::new(HashMap::new()));
@@ -2804,7 +2817,26 @@ async fn spawn_live_external_peer(peer_name: &str) -> LiveExternalPeerHarness {
                         let response = if let Ok(command) = bridge_parse {
                             match command {
                                 super::bridge_protocol::BridgeCommand::BindMember(payload) => {
-                                    if responder_fail_next_bind.swap(false, Ordering::Relaxed) {
+                                    responder_bind_protocol_versions
+                                        .write()
+                                        .await
+                                        .push(payload.protocol_version);
+                                    if !super::bridge_protocol::supervisor_bridge_protocol_version_supported(
+                                        payload.protocol_version,
+                                    ) {
+                                        serde_json::to_value(
+                                            super::bridge_protocol::BridgeReply::Rejected {
+                                                cause:
+                                                    super::bridge_protocol::BridgeRejectionCause::UnsupportedProtocolVersion,
+                                                reason: format!(
+                                                    "unsupported bridge protocol version {} (supported {:?})",
+                                                    payload.protocol_version,
+                                                    super::bridge_protocol::supervisor_bridge_supported_protocol_versions()
+                                                ),
+                                            },
+                                        )
+                                        .expect("unsupported protocol rejection")
+                                    } else if responder_fail_next_bind.swap(false, Ordering::Relaxed) {
                                         serde_json::to_value(
                                             super::bridge_protocol::BridgeReply::Rejected {
                                                 cause: super::bridge_protocol::BridgeRejectionCause::Internal,
@@ -2903,6 +2935,7 @@ async fn spawn_live_external_peer(peer_name: &str) -> LiveExternalPeerHarness {
                                                                 destroy_member: true,
                                                                 wire_member: true,
                                                                 unwire_member: true,
+                                                                ..super::bridge_protocol::BridgeCapabilities::default()
                                                         },
                                                     },
                                                 )
@@ -3225,6 +3258,7 @@ async fn spawn_live_external_peer(peer_name: &str) -> LiveExternalPeerHarness {
         binding,
         runtime,
         bind_count,
+        bind_protocol_versions,
         delivered_inputs,
         received_intents,
         supervisor_state,
@@ -4399,8 +4433,110 @@ async fn test_mob_builder_persists_supervisor_runtime_metadata_on_create() {
         "persisted public peer id should match the reconstructed keypair"
     );
     assert_eq!(
-        record.protocol_version, 1,
-        "phase-1 bridge metadata should persist protocol version 1"
+        record.protocol_version,
+        meerkat_contracts::wire::supervisor_bridge::supervisor_bridge_default_protocol_version(),
+        "fresh supervisor metadata should persist the canonical default bridge protocol version"
+    );
+}
+
+#[tokio::test]
+async fn test_mob_resume_upgrades_legacy_supervisor_protocol_metadata() {
+    let definition = sample_definition();
+    let mob_id = definition.id.clone();
+    let events: Arc<dyn MobEventStore> = Arc::new(InMemoryMobEventStore::new());
+    events
+        .append(NewMobEvent {
+            mob_id: mob_id.clone(),
+            timestamp: None,
+            kind: MobEventKind::MobCreated {
+                definition: Box::new(definition),
+            },
+        })
+        .await
+        .expect("append mob created");
+    let runtime_metadata: Arc<dyn MobRuntimeMetadataStore> =
+        Arc::new(InMemoryMobRuntimeMetadataStore::new());
+    let legacy = SupervisorAuthorityRecord::generate(1);
+    runtime_metadata
+        .put_supervisor_authority(&mob_id, &legacy)
+        .await
+        .expect("persist legacy supervisor metadata");
+
+    let service = Arc::new(MockSessionService::new());
+    let _ = service.enable_runtime_adapter();
+    let _handle = MobBuilder::for_resume(MobStorage::with_events_and_runtime_metadata(
+        events,
+        runtime_metadata.clone(),
+    ))
+    .with_session_service(service)
+    .resume()
+    .await
+    .expect("legacy supervisor protocol metadata should be upgraded on resume");
+
+    let upgraded = runtime_metadata
+        .load_supervisor_authority(&mob_id)
+        .await
+        .expect("load upgraded authority")
+        .expect("authority should remain present");
+    assert_eq!(
+        upgraded.protocol_version,
+        super::bridge_protocol::supervisor_bridge_default_protocol_version(),
+        "resume should rewrite legacy supervisor protocol metadata to the canonical default"
+    );
+    assert_eq!(
+        upgraded.public_peer_id, legacy.public_peer_id,
+        "protocol metadata upgrade must preserve supervisor identity"
+    );
+    assert_eq!(
+        upgraded.epoch, legacy.epoch,
+        "protocol metadata upgrade must preserve authority epoch"
+    );
+}
+
+#[tokio::test]
+async fn test_mob_resume_rejects_newer_unsupported_supervisor_protocol_metadata() {
+    let definition = sample_definition();
+    let mob_id = definition.id.clone();
+    let events: Arc<dyn MobEventStore> = Arc::new(InMemoryMobEventStore::new());
+    events
+        .append(NewMobEvent {
+            mob_id: mob_id.clone(),
+            timestamp: None,
+            kind: MobEventKind::MobCreated {
+                definition: Box::new(definition),
+            },
+        })
+        .await
+        .expect("append mob created");
+    let runtime_metadata: Arc<dyn MobRuntimeMetadataStore> =
+        Arc::new(InMemoryMobRuntimeMetadataStore::new());
+    let unsupported = SupervisorAuthorityRecord::generate(
+        super::bridge_protocol::supervisor_bridge_default_protocol_version() + 1,
+    );
+    runtime_metadata
+        .put_supervisor_authority(&mob_id, &unsupported)
+        .await
+        .expect("persist unsupported supervisor metadata");
+
+    let service = Arc::new(MockSessionService::new());
+    let _ = service.enable_runtime_adapter();
+    let result = MobBuilder::for_resume(MobStorage::with_events_and_runtime_metadata(
+        events,
+        runtime_metadata,
+    ))
+    .with_session_service(service)
+    .resume()
+    .await;
+    let error = match result {
+        Ok(_) => panic!("newer unsupported supervisor protocol metadata should fail clearly"),
+        Err(error) => error,
+    };
+
+    assert!(
+        error
+            .to_string()
+            .contains("unsupported supervisor bridge protocol version"),
+        "resume error should report protocol incompatibility, got: {error}"
     );
 }
 
@@ -4516,7 +4652,7 @@ depends_on_mode = "any"
     let runtime_metadata: Arc<dyn MobRuntimeMetadataStore> =
         Arc::new(InMemoryMobRuntimeMetadataStore::new());
     runtime_metadata
-        .put_supervisor_authority(&definition.id, &SupervisorAuthorityRecord::generate(1))
+        .put_supervisor_authority(&definition.id, &default_supervisor_authority_record())
         .await
         .expect("persist supervisor metadata");
 
@@ -4566,7 +4702,7 @@ message = "x"
     let runtime_metadata: Arc<dyn MobRuntimeMetadataStore> =
         Arc::new(InMemoryMobRuntimeMetadataStore::new());
     runtime_metadata
-        .put_supervisor_authority(&definition.id, &SupervisorAuthorityRecord::generate(1))
+        .put_supervisor_authority(&definition.id, &default_supervisor_authority_record())
         .await
         .expect("persist supervisor metadata");
 
@@ -5184,7 +5320,14 @@ async fn test_restarted_peer_only_member_rebinds_when_supervisor_state_is_lost()
         )
         .await
         .expect("spawn live external worker");
+    let default_protocol_version =
+        meerkat_contracts::wire::supervisor_bridge::supervisor_bridge_default_protocol_version();
     assert_eq!(external.bind_count(), 1, "initial spawn should bind once");
+    assert_eq!(
+        external.bind_protocol_versions().await,
+        vec![default_protocol_version],
+        "initial bridge bind should use the canonical default protocol version"
+    );
 
     external.forget_supervisor().await;
 
@@ -5199,6 +5342,11 @@ async fn test_restarted_peer_only_member_rebinds_when_supervisor_state_is_lost()
         external.bind_count(),
         2,
         "restart recovery should re-establish supervisor authority via BindMember"
+    );
+    assert_eq!(
+        external.bind_protocol_versions().await,
+        vec![default_protocol_version, default_protocol_version],
+        "restart rebind should keep reporting the canonical bridge protocol version"
     );
     assert_eq!(
         external.delivered_input_ids().await.len(),
@@ -9448,7 +9596,7 @@ async fn test_for_resume_allows_ephemeral_session_service_when_opted_in() {
         .runtime_metadata
         .put_supervisor_authority(
             &MobId::from("test-mob"),
-            &SupervisorAuthorityRecord::generate(1),
+            &default_supervisor_authority_record(),
         )
         .await
         .expect("persist supervisor metadata");

--- a/meerkat-mob/src/store/in_memory.rs
+++ b/meerkat-mob/src/store/in_memory.rs
@@ -903,6 +903,10 @@ mod tests {
     use futures::future::join_all;
     use std::collections::BTreeMap;
 
+    fn default_bridge_protocol_version() -> u32 {
+        meerkat_contracts::wire::supervisor_bridge::supervisor_bridge_default_protocol_version()
+    }
+
     fn sample_definition() -> MobDefinition {
         let mut profiles = BTreeMap::new();
         profiles.insert(
@@ -1133,7 +1137,7 @@ mod tests {
     async fn test_runtime_metadata_store_roundtrips_supervisor_and_overlay_records() {
         let store = InMemoryMobRuntimeMetadataStore::new();
         let mob_id = MobId::from("mob-runtime");
-        let supervisor = SupervisorAuthorityRecord::generate(1);
+        let supervisor = SupervisorAuthorityRecord::generate(default_bridge_protocol_version());
         store
             .put_supervisor_authority(&mob_id, &supervisor)
             .await
@@ -1196,8 +1200,8 @@ mod tests {
     async fn test_runtime_metadata_store_put_supervisor_if_absent_preserves_existing_record() {
         let store = InMemoryMobRuntimeMetadataStore::new();
         let mob_id = MobId::from("mob-runtime");
-        let first = SupervisorAuthorityRecord::generate(1);
-        let second = SupervisorAuthorityRecord::generate(1);
+        let first = SupervisorAuthorityRecord::generate(default_bridge_protocol_version());
+        let second = SupervisorAuthorityRecord::generate(default_bridge_protocol_version());
 
         assert!(
             store

--- a/meerkat-mob/src/store/sqlite.rs
+++ b/meerkat-mob/src/store/sqlite.rs
@@ -2196,6 +2196,10 @@ mod tests {
     use futures::future::join_all;
     use indexmap::IndexMap;
 
+    fn default_bridge_protocol_version() -> u32 {
+        meerkat_contracts::wire::supervisor_bridge::supervisor_bridge_default_protocol_version()
+    }
+
     fn temp_db_path() -> (tempfile::TempDir, std::path::PathBuf) {
         let dir = tempfile::tempdir().unwrap();
         let path = dir.path().join("mob.db");
@@ -2515,7 +2519,7 @@ mod tests {
             .unwrap()
             .runtime_metadata_store();
         let mob_id = MobId::from("mob");
-        let supervisor = SupervisorAuthorityRecord::generate(1);
+        let supervisor = SupervisorAuthorityRecord::generate(default_bridge_protocol_version());
         let overlay = ExternalBindingOverlayRecord {
             agent_identity: AgentIdentity::from("worker-1"),
             generation: Generation::new(2),
@@ -2606,8 +2610,8 @@ mod tests {
             .unwrap()
             .runtime_metadata_store();
         let mob_id = MobId::from("mob");
-        let first = SupervisorAuthorityRecord::generate(1);
-        let second = SupervisorAuthorityRecord::generate(1);
+        let first = SupervisorAuthorityRecord::generate(default_bridge_protocol_version());
+        let second = SupervisorAuthorityRecord::generate(default_bridge_protocol_version());
 
         assert!(
             store

--- a/meerkat-runtime/src/comms_drain.rs
+++ b/meerkat-runtime/src/comms_drain.rs
@@ -18,15 +18,18 @@ use meerkat_core::interaction::{InteractionContent, PeerInputCandidate, PeerInpu
 use meerkat_core::lifecycle::RunControlCommand;
 use meerkat_core::types::SessionId;
 
-#[cfg(test)]
-use meerkat_contracts::wire::supervisor_bridge::SUPERVISOR_BRIDGE_BOOTSTRAP_TOKEN_PARAM;
 use meerkat_contracts::wire::supervisor_bridge::{
     BridgeAck, BridgeBindResponse, BridgeCapabilities, BridgeCommand, BridgeDeliveryOutcome,
     BridgeDeliveryPayload, BridgeDeliveryRejectionCause, BridgeDeliveryResponse,
     BridgeDestroyResponse, BridgeMemberRuntimeState, BridgeObservationResponse,
     BridgePeerConnectivity, BridgePeerSpec, BridgeRejectionCause, BridgeReply,
     BridgeRetireResponse, BridgeSupervisorPayload, SUPERVISOR_BRIDGE_INTENT,
-    SUPERVISOR_BRIDGE_PROTOCOL_VERSION, canonicalize_bridge_address,
+    canonicalize_bridge_address, supervisor_bridge_default_protocol_version,
+    supervisor_bridge_protocol_version_supported, supervisor_bridge_supported_protocol_versions,
+};
+#[cfg(test)]
+use meerkat_contracts::wire::supervisor_bridge::{
+    SUPERVISOR_BRIDGE_BOOTSTRAP_TOKEN_PARAM, SUPERVISOR_BRIDGE_PROTOCOL_VERSION,
 };
 
 use crate::comms_bridge::classified_interaction_to_runtime_input;
@@ -376,6 +379,14 @@ fn bridge_peer_pubkey_sender(peer: &BridgePeerSpec) -> Option<String> {
     Some(format!("ed25519:{}", BASE64.encode(peer.pubkey)))
 }
 
+fn unsupported_bridge_protocol_version_message(context: &str, protocol_version: u32) -> String {
+    format!(
+        "{context}: unsupported bridge protocol version {protocol_version} (supported {:?}; default {})",
+        supervisor_bridge_supported_protocol_versions(),
+        supervisor_bridge_default_protocol_version()
+    )
+}
+
 /// Require the caller to be the currently authorized supervisor for the
 /// session. Shared validation gate for all post-bind bridge commands
 /// (`AuthorizeSupervisor` / `RevokeSupervisor` / `DeliverMemberInput` /
@@ -388,12 +399,12 @@ fn require_authorized_supervisor(
     payload: &BridgeSupervisorPayload,
     current: &SupervisorBinding,
 ) -> Result<(), (BridgeRejectionCause, String)> {
-    if payload.protocol_version != SUPERVISOR_BRIDGE_PROTOCOL_VERSION {
+    if !supervisor_bridge_protocol_version_supported(payload.protocol_version) {
         return Err((
             BridgeRejectionCause::UnsupportedProtocolVersion,
-            format!(
-                "unsupported bridge protocol version {} (expected {})",
-                payload.protocol_version, SUPERVISOR_BRIDGE_PROTOCOL_VERSION
+            unsupported_bridge_protocol_version_message(
+                "supervisor bridge request",
+                payload.protocol_version,
             ),
         ));
     }
@@ -456,6 +467,7 @@ fn bridge_capabilities() -> BridgeCapabilities {
         destroy_member: true,
         wire_member: true,
         unwire_member: true,
+        ..BridgeCapabilities::default()
     }
 }
 
@@ -540,12 +552,12 @@ fn validate_bind_request(
     sender: &str,
     payload: &meerkat_contracts::wire::supervisor_bridge::BridgeBindPayload,
 ) -> Result<(TrustedPeerDescriptor, String), (BridgeRejectionCause, String)> {
-    if payload.protocol_version != SUPERVISOR_BRIDGE_PROTOCOL_VERSION {
+    if !supervisor_bridge_protocol_version_supported(payload.protocol_version) {
         return Err((
             BridgeRejectionCause::UnsupportedProtocolVersion,
-            format!(
-                "unsupported bridge protocol version {} (expected {})",
-                payload.protocol_version, SUPERVISOR_BRIDGE_PROTOCOL_VERSION
+            unsupported_bridge_protocol_version_message(
+                "bind member failed",
+                payload.protocol_version,
             ),
         ));
     }
@@ -699,12 +711,12 @@ fn validate_bind_request_against_state(
     payload: &meerkat_contracts::wire::supervisor_bridge::BridgeBindPayload,
     current: &SupervisorBinding,
 ) -> Result<BindMemberGate, (BridgeRejectionCause, String)> {
-    if payload.protocol_version != SUPERVISOR_BRIDGE_PROTOCOL_VERSION {
+    if !supervisor_bridge_protocol_version_supported(payload.protocol_version) {
         return Err((
             BridgeRejectionCause::UnsupportedProtocolVersion,
-            format!(
-                "unsupported bridge protocol version {} (expected {})",
-                payload.protocol_version, SUPERVISOR_BRIDGE_PROTOCOL_VERSION
+            unsupported_bridge_protocol_version_message(
+                "bind member failed",
+                payload.protocol_version,
             ),
         ));
     }
@@ -750,12 +762,12 @@ fn validate_authorize_supervisor_request(
     payload: &BridgeSupervisorPayload,
     current: &SupervisorBinding,
 ) -> Result<AuthorizeSupervisorGate, (BridgeRejectionCause, String)> {
-    if payload.protocol_version != SUPERVISOR_BRIDGE_PROTOCOL_VERSION {
+    if !supervisor_bridge_protocol_version_supported(payload.protocol_version) {
         return Err((
             BridgeRejectionCause::UnsupportedProtocolVersion,
-            format!(
-                "authorize supervisor failed: unsupported bridge protocol version {} (expected {})",
-                payload.protocol_version, SUPERVISOR_BRIDGE_PROTOCOL_VERSION
+            unsupported_bridge_protocol_version_message(
+                "authorize supervisor failed",
+                payload.protocol_version,
             ),
         ));
     }
@@ -1823,6 +1835,10 @@ fn interaction_terminal_event(
 mod tests {
     use super::*;
     use meerkat_contracts::BridgePeerWiringPayload;
+    use meerkat_contracts::wire::supervisor_bridge::{
+        supervisor_bridge_current_protocol_version, supervisor_bridge_default_protocol_version,
+        supervisor_bridge_supported_protocol_versions,
+    };
     use meerkat_core::InteractionId;
     use meerkat_core::SendError;
     use meerkat_core::interaction::InboxInteraction;
@@ -2212,6 +2228,23 @@ mod tests {
                 .iter()
                 .any(|entry| entry.name.as_str() == "peer-removed"),
             "peer lifecycle retire must not revoke comms trust before topology validation"
+        );
+    }
+
+    #[test]
+    fn bridge_capabilities_report_canonical_protocol_versions() {
+        let capabilities = bridge_capabilities();
+        assert_eq!(
+            capabilities.current_protocol_version,
+            supervisor_bridge_current_protocol_version()
+        );
+        assert_eq!(
+            capabilities.default_protocol_version,
+            supervisor_bridge_default_protocol_version()
+        );
+        assert_eq!(
+            capabilities.supported_protocol_versions,
+            supervisor_bridge_supported_protocol_versions()
         );
     }
 
@@ -2858,6 +2891,77 @@ mod tests {
             self.sent.lock().await.push(cmd);
             Ok(receipt)
         }
+    }
+
+    #[tokio::test]
+    async fn bind_member_handler_response_reports_canonical_protocol_versions() {
+        let sent: Arc<tokio::sync::Mutex<Vec<CommsCommand>>> =
+            Arc::new(tokio::sync::Mutex::new(Vec::new()));
+        let runtime: Arc<dyn CommsRuntime> = Arc::new(CapturingRuntime {
+            peer_id: PEER_ID_RECEIVER.to_string(),
+            advertised_address: Some("inproc://receiver".to_string()),
+            bootstrap_token: Some("expected-token".to_string()),
+            inbox_notify: Arc::new(tokio::sync::Notify::new()),
+            sent: sent.clone(),
+        });
+        let adapter = Arc::new(MeerkatMachine::ephemeral());
+        let session_id = SessionId::new();
+        adapter.register_session(session_id.clone()).await;
+        let supervisor = BridgePeerSpec {
+            name: "mob/__mob_supervisor__".to_string(),
+            peer_id: PEER_ID_SUPERVISOR.to_string(),
+            address: "inproc://mob/__mob_supervisor__".to_string(),
+            pubkey: [0u8; 32],
+        };
+        let command = BridgeCommand::BindMember(
+            meerkat_contracts::wire::supervisor_bridge::BridgeBindPayload {
+                supervisor: supervisor.clone(),
+                epoch: 0,
+                protocol_version: supervisor_bridge_default_protocol_version(),
+                expected_peer_id: PEER_ID_RECEIVER.to_string(),
+                expected_address: "inproc://receiver".to_string(),
+                bootstrap_token: "expected-token".into(),
+            },
+        );
+        let candidate = bridge_candidate(&supervisor.peer_id, &command);
+
+        assert!(
+            try_handle_supervisor_bridge_command(&adapter, &session_id, &runtime, &candidate,)
+                .await,
+            "bridge handler must own the BindMember command"
+        );
+
+        let (result, status) = sent
+            .lock()
+            .await
+            .iter()
+            .find_map(|cmd| match cmd {
+                CommsCommand::PeerResponse { result, status, .. } => {
+                    Some((result.clone(), *status))
+                }
+                _ => None,
+            })
+            .expect("handler must send a bind response");
+        assert!(matches!(
+            status,
+            meerkat_core::interaction::ResponseStatus::Completed
+        ));
+        let reply: BridgeReply = serde_json::from_value(result).expect("typed bridge reply");
+        let BridgeReply::BindMember(response) = reply else {
+            panic!("expected bind response");
+        };
+        assert_eq!(
+            response.capabilities.current_protocol_version,
+            supervisor_bridge_current_protocol_version()
+        );
+        assert_eq!(
+            response.capabilities.default_protocol_version,
+            supervisor_bridge_default_protocol_version()
+        );
+        assert_eq!(
+            response.capabilities.supported_protocol_versions,
+            supervisor_bridge_supported_protocol_versions()
+        );
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary
- make `meerkat-contracts::wire::supervisor_bridge` the canonical owner for current/default/supported supervisor bridge protocol versions
- route mob supervisor authority creation/resume and runtime validation through the canonical helpers
- report current/default/supported protocol versions in bind capabilities, while preserving decode compatibility for older capability payloads that omit those fields

## Compatibility
Existing bridge clients that deserialize bind capabilities without the new protocol-report fields remain compatible: missing `current_protocol_version`, `default_protocol_version`, and `supported_protocol_versions` default to the canonical contract values. New bind replies include those fields additively. Persisted legacy v1 supervisor authority metadata is upgraded to the canonical default on mob resume; newer unsupported metadata is rejected with a clear compatibility error instead of silently sending unsupported bridge commands.

Linear: LUC-114

## Validation
- `./scripts/repo-cargo fmt --all --check`
- `./scripts/repo-cargo test -p meerkat-contracts supervisor_bridge -- --nocapture`
- `./scripts/repo-cargo test -p meerkat-runtime bind_member_handler_response_reports_canonical_protocol_versions -- --nocapture`
- `./scripts/repo-cargo test -p meerkat-runtime protocol_version_mismatch -- --nocapture`
- `./scripts/repo-cargo test -p meerkat-mob supervisor_protocol_metadata -- --nocapture`
- `./scripts/repo-cargo test -p meerkat-mob test_mob_builder_persists_supervisor_runtime_metadata_on_create -- --nocapture`
- `./scripts/repo-cargo test -p meerkat-mob test_restarted_peer_only_member_rebinds_when_supervisor_state_is_lost -- --nocapture`
- `./scripts/repo-cargo test -p meerkat-mob runtime_metadata_store -- --nocapture`
- `MEERKAT_BUILDBUDDY=1 make check` (BuildBuddy invocation `4f0bf115-58f4-4ad3-9cce-7e7866f51ef3`)
- `git diff --check`
