### PR TITLE
LUC-117 Fix provider-aware model policy lookups

### DIFF
--- a/meerkat-rpc/src/session_runtime.rs
+++ b/meerkat-rpc/src/session_runtime.rs
@@ -218,6 +218,23 @@ fn runtime_driver_error_to_rpc(err: RuntimeDriverError) -> RpcError {
     }
 }
 
+fn registered_model_provider_mismatch_reason(
+    registry: &meerkat_core::ModelRegistry,
+    provider: meerkat_core::Provider,
+    model: &str,
+) -> Option<String> {
+    let registered_provider = registry.entry(model)?.provider;
+    if registered_provider == provider {
+        return None;
+    }
+
+    Some(format!(
+        "model '{model}' is registered for provider '{}', not provider '{}'; specify a matching provider with the model override",
+        registered_provider.as_str(),
+        provider.as_str()
+    ))
+}
+
 fn profile_to_capability_surface(
     profile: &meerkat_models::profile::ModelProfile,
 ) -> SessionLlmCapabilitySurface {
@@ -384,6 +401,12 @@ impl SessionRuntimeLlmReconfigureHost {
         } else {
             current.provider
         };
+        if (request.model.is_some() || request.provider.is_some())
+            && let Some(reason) =
+                registered_model_provider_mismatch_reason(&registry, provider, &model)
+        {
+            return Err(RuntimeDriverError::ValidationFailed { reason });
+        }
         let provider_params = if request.clear_provider_params {
             None
         } else {
@@ -1383,6 +1406,16 @@ impl SessionRuntime {
         } else {
             current.provider
         };
+        if (ov.model.is_some() || ov.provider.is_some())
+            && let Some(reason) =
+                registered_model_provider_mismatch_reason(&registry, provider, &model)
+        {
+            return Err(RpcError {
+                code: error::INVALID_PARAMS,
+                message: reason,
+                data: None,
+            });
+        }
         let provider_params = if ov.clear_provider_params {
             None
         } else {
@@ -5973,7 +6006,36 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn turn_model_override_without_provider_preserves_current_provider() {
+    async fn turn_model_override_without_provider_preserves_current_provider_for_owned_model() {
+        let temp = tempfile::tempdir().unwrap();
+        let runtime = make_runtime(temp_factory(&temp), 10);
+        let current = SessionLlmIdentity {
+            model: "claude-sonnet-4-5".to_string(),
+            provider: meerkat_core::Provider::Anthropic,
+            self_hosted_server_id: None,
+            provider_params: None,
+            connection_ref: None,
+        };
+        let overrides = crate::handlers::turn::TurnOverrides {
+            model: Some("claude-opus-4-6".to_string()),
+            ..Default::default()
+        };
+
+        let resolved = runtime
+            .resolve_target_llm_identity(&current, &overrides)
+            .await
+            .expect("model-only override should resolve against the current provider");
+
+        assert_eq!(
+            resolved.provider,
+            meerkat_core::Provider::Anthropic,
+            "model-only turn overrides must not infer a new provider from model id alone"
+        );
+        assert_eq!(resolved.model, "claude-opus-4-6");
+    }
+
+    #[tokio::test]
+    async fn turn_model_override_without_provider_rejects_other_provider_catalog_model() {
         let temp = tempfile::tempdir().unwrap();
         let runtime = make_runtime(temp_factory(&temp), 10);
         let current = SessionLlmIdentity {
@@ -5988,15 +6050,18 @@ mod tests {
             ..Default::default()
         };
 
-        let resolved = runtime
+        let err = runtime
             .resolve_target_llm_identity(&current, &overrides)
             .await
-            .expect("model-only override should resolve against the current provider");
+            .expect_err("model owned by another provider must fail closed");
 
-        assert_eq!(
-            resolved.provider,
-            meerkat_core::Provider::Anthropic,
-            "model-only turn overrides must not infer a new provider from model id alone"
+        assert_eq!(err.code, error::INVALID_PARAMS);
+        assert!(
+            err.message.contains("openai")
+                && err.message.contains("anthropic")
+                && err.message.contains("gpt-5.4"),
+            "error should identify the rejected provider/model pair: {}",
+            err.message
         );
     }
 

--- a/meerkat-rpc/src/session_runtime.rs
+++ b/meerkat-rpc/src/session_runtime.rs
@@ -7914,6 +7914,7 @@ mod tests {
         // Hot-swap to an OpenAI model (does NOT support image_tool_results).
         let overrides = crate::handlers::turn::TurnOverrides {
             model: Some("gpt-5.4".to_string()),
+            provider: Some("openai".to_string()),
             ..Default::default()
         };
         let (event_tx2, _event_rx2) = mpsc::channel(100);
@@ -7981,6 +7982,7 @@ mod tests {
         // Hot-swap to OpenAI (deny view_image).
         let overrides = crate::handlers::turn::TurnOverrides {
             model: Some("gpt-5.4".to_string()),
+            provider: Some("openai".to_string()),
             ..Default::default()
         };
         let (event_tx2, _event_rx2) = mpsc::channel(100);
@@ -8000,6 +8002,7 @@ mod tests {
         // Hot-swap back to Anthropic (should clear the deny).
         let overrides = crate::handlers::turn::TurnOverrides {
             model: Some("claude-sonnet-4-5".to_string()),
+            provider: Some("anthropic".to_string()),
             ..Default::default()
         };
         let (event_tx3, _event_rx3) = mpsc::channel(100);
@@ -8076,6 +8079,7 @@ mod tests {
         // Hot-swap to OpenAI — should add view_image to the deny set, not replace it.
         let overrides = crate::handlers::turn::TurnOverrides {
             model: Some("gpt-5.4".to_string()),
+            provider: Some("openai".to_string()),
             ..Default::default()
         };
         let (event_tx2, _event_rx2) = mpsc::channel(100);
@@ -8344,6 +8348,7 @@ mod tests {
         });
         let overrides = crate::handlers::turn::TurnOverrides {
             model: Some("gpt-5.4".to_string()),
+            provider: Some("openai".to_string()),
             provider_params: Some(provider_params.clone()),
             ..Default::default()
         };

--- a/meerkat-rpc/src/session_runtime.rs
+++ b/meerkat-rpc/src/session_runtime.rs
@@ -381,12 +381,6 @@ impl SessionRuntimeLlmReconfigureHost {
             .unwrap_or_else(|| current.model.clone());
         let provider = if let Some(provider_name) = request.provider.as_ref() {
             meerkat_core::Provider::from_name(provider_name)
-        } else if request.model.is_some() {
-            registry
-                .entry(&model)
-                .map(|entry| entry.provider)
-                .or_else(|| meerkat_core::Provider::infer_from_model(&model))
-                .unwrap_or(current.provider)
         } else {
             current.provider
         };
@@ -402,12 +396,12 @@ impl SessionRuntimeLlmReconfigureHost {
             if request.model.is_none() {
                 current.self_hosted_server_id.clone().or_else(|| {
                     registry
-                        .entry(&model)
+                        .entry_for_provider(meerkat_core::Provider::SelfHosted, &model)
                         .and_then(|entry| entry.self_hosted.as_ref())
                         .map(|server| server.server_id.clone())
                 })
             } else {
-                match registry.entry(&model) {
+                match registry.entry_for_provider(meerkat_core::Provider::SelfHosted, &model) {
                     Some(entry) => entry
                         .self_hosted
                         .as_ref()
@@ -477,14 +471,15 @@ impl SessionLlmReconfigureHost for SessionRuntimeLlmReconfigureHost {
             .collect();
 
         let registry = self.model_registry().await?;
-        let (current_capability_surface, capability_surface_status) =
-            match registry.profile_for(&current_identity.model) {
-                Some(profile) => (
-                    Some(profile_to_capability_surface(&profile)),
-                    SessionLlmCapabilitySurfaceStatus::Resolved,
-                ),
-                None => (None, SessionLlmCapabilitySurfaceStatus::Unresolved),
-            };
+        let (current_capability_surface, capability_surface_status) = match registry
+            .profile_for_provider(current_identity.provider, &current_identity.model)
+        {
+            Some(profile) => (
+                Some(profile_to_capability_surface(&profile)),
+                SessionLlmCapabilitySurfaceStatus::Resolved,
+            ),
+            None => (None, SessionLlmCapabilitySurfaceStatus::Unresolved),
+        };
 
         Ok(HydratedSessionLlmState {
             current_identity,
@@ -505,10 +500,11 @@ impl SessionLlmReconfigureHost for SessionRuntimeLlmReconfigureHost {
             .await?;
         let registry = self.model_registry().await?;
         let profile = registry
-            .profile_for(&target_identity.model)
+            .profile_for_provider(target_identity.provider, &target_identity.model)
             .ok_or_else(|| RuntimeDriverError::ValidationFailed {
                 reason: format!(
-                    "no capability profile is registered for model '{}'",
+                    "no capability profile is registered for provider '{}' and model '{}'",
+                    target_identity.provider.as_str(),
                     target_identity.model
                 ),
             })?;
@@ -1273,7 +1269,6 @@ impl SessionRuntime {
             registry
                 .entry(&model)
                 .map(|entry| entry.provider)
-                .or_else(|| meerkat_core::Provider::infer_from_model(&model))
                 .unwrap_or(meerkat_core::Provider::Other)
         };
         let self_hosted_server_id = if provider == meerkat_core::Provider::SelfHosted {
@@ -1285,7 +1280,9 @@ impl SessionRuntime {
                 .and_then(Session::session_metadata)
             {
                 metadata.self_hosted_server_id
-            } else if let Some(entry) = registry.entry(&model) {
+            } else if let Some(entry) =
+                registry.entry_for_provider(meerkat_core::Provider::SelfHosted, &model)
+            {
                 entry
                     .self_hosted
                     .as_ref()
@@ -1315,7 +1312,7 @@ impl SessionRuntime {
         self.model_registry()
             .await
             .ok()
-            .and_then(|registry| registry.profile_for(&identity.model))
+            .and_then(|registry| registry.profile_for_provider(identity.provider, &identity.model))
             .map(|profile| profile.inline_video)
             .unwrap_or(false)
     }
@@ -1383,12 +1380,6 @@ impl SessionRuntime {
         let model = ov.model.clone().unwrap_or_else(|| current.model.clone());
         let provider = if let Some(provider_name) = ov.provider.as_ref() {
             meerkat_core::Provider::from_name(provider_name)
-        } else if ov.model.is_some() {
-            registry
-                .entry(&model)
-                .map(|entry| entry.provider)
-                .or_else(|| meerkat_core::Provider::infer_from_model(&model))
-                .unwrap_or(current.provider)
         } else {
             current.provider
         };
@@ -1403,12 +1394,12 @@ impl SessionRuntime {
             if ov.model.is_none() {
                 current.self_hosted_server_id.clone().or_else(|| {
                     registry
-                        .entry(&model)
+                        .entry_for_provider(meerkat_core::Provider::SelfHosted, &model)
                         .and_then(|entry| entry.self_hosted.as_ref())
                         .map(|server| server.server_id.clone())
                 })
             } else {
-                match registry.entry(&model) {
+                match registry.entry_for_provider(meerkat_core::Provider::SelfHosted, &model) {
                     Some(entry) => entry
                         .self_hosted
                         .as_ref()
@@ -5918,6 +5909,113 @@ mod tests {
                 data: "AAAA".to_string(),
             },
         }])
+    }
+
+    #[tokio::test]
+    async fn provider_supports_inline_video_requires_provider_owned_profile() {
+        let temp = tempfile::tempdir().unwrap();
+        let runtime = make_runtime(temp_factory(&temp), 10);
+        let gemini_video_model_on_openai = SessionLlmIdentity {
+            model: "gemini-3-flash-preview".to_string(),
+            provider: meerkat_core::Provider::OpenAI,
+            self_hosted_server_id: None,
+            provider_params: None,
+            connection_ref: None,
+        };
+        let gemini_video_model_on_gemini = SessionLlmIdentity {
+            provider: meerkat_core::Provider::Gemini,
+            ..gemini_video_model_on_openai.clone()
+        };
+
+        assert!(
+            !runtime
+                .provider_supports_inline_video(&gemini_video_model_on_openai)
+                .await,
+            "OpenAI identity must not inherit Gemini inline-video capability from model id alone"
+        );
+        assert!(
+            runtime
+                .provider_supports_inline_video(&gemini_video_model_on_gemini)
+                .await,
+            "owned Gemini inline-video capability should still resolve"
+        );
+    }
+
+    #[tokio::test]
+    async fn reconfigure_capability_lookup_rejects_provider_model_mismatch() {
+        let temp = tempfile::tempdir().unwrap();
+        let runtime = make_runtime(temp_factory(&temp), 10);
+        let host = runtime.llm_reconfigure_host();
+        let current = SessionLlmIdentity {
+            model: "claude-sonnet-4-5".to_string(),
+            provider: meerkat_core::Provider::Anthropic,
+            self_hosted_server_id: None,
+            provider_params: None,
+            connection_ref: None,
+        };
+        let request = SessionLlmReconfigureRequest {
+            model: Some("gpt-5.4".to_string()),
+            provider: Some("anthropic".to_string()),
+            provider_params: None,
+            clear_provider_params: false,
+            connection_ref: None,
+            clear_connection_ref: false,
+        };
+
+        let err = host
+            .resolve_target_session_llm_identity(&request, &current)
+            .await
+            .expect_err("target model not owned by provider must fail closed");
+        assert!(
+            err.to_string().contains("anthropic") && err.to_string().contains("gpt-5.4"),
+            "error should identify the rejected provider/model pair: {err}"
+        );
+    }
+
+    #[tokio::test]
+    async fn turn_model_override_without_provider_preserves_current_provider() {
+        let temp = tempfile::tempdir().unwrap();
+        let runtime = make_runtime(temp_factory(&temp), 10);
+        let current = SessionLlmIdentity {
+            model: "claude-sonnet-4-5".to_string(),
+            provider: meerkat_core::Provider::Anthropic,
+            self_hosted_server_id: None,
+            provider_params: None,
+            connection_ref: None,
+        };
+        let overrides = crate::handlers::turn::TurnOverrides {
+            model: Some("gpt-5.4".to_string()),
+            ..Default::default()
+        };
+
+        let resolved = runtime
+            .resolve_target_llm_identity(&current, &overrides)
+            .await
+            .expect("model-only override should resolve against the current provider");
+
+        assert_eq!(
+            resolved.provider,
+            meerkat_core::Provider::Anthropic,
+            "model-only turn overrides must not infer a new provider from model id alone"
+        );
+    }
+
+    #[tokio::test]
+    async fn initial_model_only_build_preserves_catalog_provider_inference_compatibility() {
+        let temp = tempfile::tempdir().unwrap();
+        let runtime = make_runtime(temp_factory(&temp), 10);
+        let build_config = AgentBuildConfig {
+            llm_client_override: Some(Arc::new(MockLlmClient)),
+            ..AgentBuildConfig::new("gpt-5.4")
+        };
+
+        let identity = runtime
+            .llm_identity_from_pending_build(&build_config)
+            .await
+            .expect("initial model-only build should infer catalog provider");
+
+        assert_eq!(identity.provider, meerkat_core::Provider::OpenAI);
+        assert_eq!(identity.model, "gpt-5.4");
     }
 
     #[cfg(feature = "mcp")]

--- a/meerkat/src/factory.rs
+++ b/meerkat/src/factory.rs
@@ -1816,7 +1816,7 @@ impl AgentFactory {
         let registry = config
             .model_registry()
             .map_err(|err| FactoryError::ClientCreationFailed(err.to_string()))?;
-        let model_profile = registry.profile_for(&identity.model);
+        let model_profile = registry.profile_for_provider(identity.provider, &identity.model);
         Ok(meerkat_core::SessionLlmRequestPolicy {
             model: identity.model.clone(),
             provider_params: identity.provider_params.clone(),
@@ -1843,12 +1843,14 @@ impl AgentFactory {
         if let Some(provider) = build_config.provider {
             return match provider {
                 Provider::SelfHosted => {
-                    let entry = registry.entry(&build_config.model).ok_or_else(|| {
-                        BuildAgentError::Config(format!(
-                            "self-hosted model '{}' is not registered in config",
-                            build_config.model
-                        ))
-                    })?;
+                    let entry = registry
+                        .entry_for_provider(Provider::SelfHosted, &build_config.model)
+                        .ok_or_else(|| {
+                            BuildAgentError::Config(format!(
+                                "self-hosted model '{}' is not registered in config",
+                                build_config.model
+                            ))
+                        })?;
                     let server_id = entry
                         .self_hosted
                         .as_ref()
@@ -1920,9 +1922,14 @@ impl AgentFactory {
 
         #[cfg(feature = "openai")]
         {
-            let entry = registry.entry(&identity.model).ok_or_else(|| {
-                FactoryError::ClientCreationFailed(format!("unknown model '{}'", identity.model))
-            })?;
+            let entry = registry
+                .entry_for_provider(Provider::SelfHosted, &identity.model)
+                .ok_or_else(|| {
+                    FactoryError::ClientCreationFailed(format!(
+                        "unknown model '{}'",
+                        identity.model
+                    ))
+                })?;
             let self_hosted = entry.self_hosted.as_ref().ok_or_else(|| {
                 FactoryError::ClientCreationFailed(format!(
                     "model '{}' is not self-hosted",
@@ -2470,7 +2477,7 @@ impl AgentFactory {
 
         // 4. Create LLM adapter (with optional provider_params, event channel, and shared event tap)
         let model = build_config.model.clone();
-        let model_profile = registry.profile_for(&model);
+        let model_profile = registry.profile_for_provider(provider, &model);
         if let meerkat_core::RuntimeBuildMode::SessionOwned(bindings) =
             &build_config.runtime_build_mode
         {
@@ -3567,6 +3574,41 @@ mod tests {
             ),
             None,
             "provider-aware default lookup must not reuse OpenAI defaults for Anthropic"
+        );
+    }
+
+    #[test]
+    fn request_policy_tool_defaults_require_provider_owned_profile() {
+        let temp = tempfile::tempdir().unwrap();
+        let factory = AgentFactory::new(temp.path().join("sessions"));
+        let config = Config::default();
+        let openai_identity = SessionLlmIdentity {
+            model: "gpt-5.4".to_string(),
+            provider: Provider::OpenAI,
+            self_hosted_server_id: None,
+            provider_params: None,
+            connection_ref: None,
+        };
+        let mismatched_identity = SessionLlmIdentity {
+            provider: Provider::Anthropic,
+            ..openai_identity.clone()
+        };
+
+        let openai_policy = factory
+            .request_policy_for_llm_identity(&config, &openai_identity, false)
+            .expect("OpenAI request policy");
+        assert_eq!(
+            openai_policy.provider_tool_defaults,
+            Some(serde_json::json!({"web_search": {"type": "web_search"}})),
+            "owned OpenAI web-search defaults should still resolve"
+        );
+
+        let mismatched_policy = factory
+            .request_policy_for_llm_identity(&config, &mismatched_identity, false)
+            .expect("mismatched request policy should fail closed, not error");
+        assert!(
+            mismatched_policy.provider_tool_defaults.is_none(),
+            "Anthropic policy must not reuse OpenAI model defaults from model id alone"
         );
     }
 

--- a/meerkat/src/service_factory.rs
+++ b/meerkat/src/service_factory.rs
@@ -507,7 +507,7 @@ impl SessionAgentBuilder for FactoryAgentBuilder {
             .await
             .model_registry()
             .ok()
-            .and_then(|registry| registry.profile_for(&identity.model))
+            .and_then(|registry| registry.profile_for_provider(identity.provider, &identity.model))
             .map(|profile| profile.inline_video)
             .or_else(|| {
                 meerkat_core::model_profile::inline_video_support_for(


### PR DESCRIPTION
## Summary
- use provider/model-aware registry profile lookups for request policy, inline-video capability, hot-swap capability surfaces, and model-routing realtime defaults
- stop inferring a new provider from model name for existing-session model-only overrides; keep current provider and fail closed on mismatches
- keep initial model-only build compatibility covered by test

## Validation
- ./scripts/repo-cargo test -p meerkat request_policy_tool_defaults_require_provider_owned_profile --lib
- ./scripts/repo-cargo test -p meerkat-rpc provider_supports_inline_video_requires_provider_owned_profile --lib
- ./scripts/repo-cargo test -p meerkat-rpc reconfigure_capability_lookup_rejects_provider_model_mismatch --lib
- ./scripts/repo-cargo test -p meerkat-rpc turn_model_override_without_provider_preserves_current_provider --lib
- ./scripts/repo-cargo test -p meerkat-rpc initial_model_only_build_preserves_catalog_provider_inference_compatibility --lib
- make check (BuildBuddy invocation e87daf15-c9bc-4413-b5d7-1a487f13f810)

Linear: LUC-117