### PR TITLE
Type LLM provider error retry metadata

### DIFF
--- a/artifacts/schemas/events.json
+++ b/artifacts/schemas/events.json
@@ -107,6 +107,12 @@
           {
             "properties": {
               "provider_error": true,
+              "provider_error_kind": {
+                "$ref": "#/$defs/LlmProviderErrorKind"
+              },
+              "provider_error_retryability": {
+                "$ref": "#/$defs/LlmProviderErrorRetryability"
+              },
               "reason_type": {
                 "const": "llm_provider_error",
                 "type": "string"
@@ -114,6 +120,8 @@
             },
             "required": [
               "reason_type",
+              "provider_error_kind",
+              "provider_error_retryability",
               "provider_error"
             ],
             "type": "object"
@@ -704,6 +712,26 @@
       },
       "InteractionId": {
         "description": "Unique identifier for an interaction.",
+        "type": "string"
+      },
+      "LlmProviderErrorKind": {
+        "enum": [
+          "invalid_request",
+          "content_filtered",
+          "server_error",
+          "server_overloaded",
+          "connection_reset",
+          "unknown",
+          "stream_parse_error",
+          "incomplete_response"
+        ],
+        "type": "string"
+      },
+      "LlmProviderErrorRetryability": {
+        "enum": [
+          "retryable",
+          "non_retryable"
+        ],
         "type": "string"
       },
       "LlmRetryFailure": {
@@ -2295,6 +2323,12 @@
           {
             "properties": {
               "provider_error": true,
+              "provider_error_kind": {
+                "$ref": "#/$defs/LlmProviderErrorKind"
+              },
+              "provider_error_retryability": {
+                "$ref": "#/$defs/LlmProviderErrorRetryability"
+              },
               "reason_type": {
                 "const": "llm_provider_error",
                 "type": "string"
@@ -2302,6 +2336,8 @@
             },
             "required": [
               "reason_type",
+              "provider_error_kind",
+              "provider_error_retryability",
               "provider_error"
             ],
             "type": "object"
@@ -3746,6 +3782,26 @@
       },
       "InteractionId": {
         "description": "Unique identifier for an interaction.",
+        "type": "string"
+      },
+      "LlmProviderErrorKind": {
+        "enum": [
+          "invalid_request",
+          "content_filtered",
+          "server_error",
+          "server_overloaded",
+          "connection_reset",
+          "unknown",
+          "stream_parse_error",
+          "incomplete_response"
+        ],
+        "type": "string"
+      },
+      "LlmProviderErrorRetryability": {
+        "enum": [
+          "retryable",
+          "non_retryable"
+        ],
         "type": "string"
       },
       "LlmRetryFailure": {

--- a/meerkat-core/src/error.rs
+++ b/meerkat-core/src/error.rs
@@ -3,6 +3,7 @@
 use crate::hooks::{HookPoint, HookReasonCode};
 use crate::tool_catalog::ToolUnavailableReason;
 use crate::types::SessionId;
+use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive]
@@ -16,7 +17,7 @@ pub enum LlmFailureReason {
     },
     AuthError,
     InvalidModel(String),
-    ProviderError(serde_json::Value),
+    ProviderError(LlmProviderError),
     /// Provider/client-native network timeout (owned by client layer)
     NetworkTimeout {
         duration_ms: u64,
@@ -25,6 +26,69 @@ pub enum LlmFailureReason {
     CallTimeout {
         duration_ms: u64,
     },
+}
+
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum LlmProviderErrorKind {
+    InvalidRequest,
+    ContentFiltered,
+    ServerError,
+    ServerOverloaded,
+    ConnectionReset,
+    Unknown,
+    StreamParseError,
+    IncompleteResponse,
+}
+
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum LlmProviderErrorRetryability {
+    Retryable,
+    NonRetryable,
+}
+
+impl LlmProviderErrorRetryability {
+    pub fn is_retryable(self) -> bool {
+        matches!(self, Self::Retryable)
+    }
+}
+
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct LlmProviderError {
+    pub kind: LlmProviderErrorKind,
+    pub retryability: LlmProviderErrorRetryability,
+    #[serde(default, skip_serializing_if = "serde_json::Value::is_null")]
+    pub details: serde_json::Value,
+}
+
+impl LlmProviderError {
+    pub fn new(
+        kind: LlmProviderErrorKind,
+        retryability: LlmProviderErrorRetryability,
+        details: serde_json::Value,
+    ) -> Self {
+        Self {
+            kind,
+            retryability,
+            details,
+        }
+    }
+
+    pub fn retryable(kind: LlmProviderErrorKind, details: serde_json::Value) -> Self {
+        Self::new(kind, LlmProviderErrorRetryability::Retryable, details)
+    }
+
+    pub fn non_retryable(kind: LlmProviderErrorKind, details: serde_json::Value) -> Self {
+        Self::new(kind, LlmProviderErrorRetryability::NonRetryable, details)
+    }
+
+    pub fn is_retryable(&self) -> bool {
+        self.retryability.is_retryable()
+    }
 }
 
 /// Errors that can occur during tool validation
@@ -344,9 +408,7 @@ impl AgentError {
                 LlmFailureReason::RateLimited { .. } => true,
                 LlmFailureReason::NetworkTimeout { .. } => true,
                 LlmFailureReason::CallTimeout { .. } => true,
-                LlmFailureReason::ProviderError(value) => {
-                    value.get("retryable").and_then(serde_json::Value::as_bool) == Some(true)
-                }
+                LlmFailureReason::ProviderError(provider_error) => provider_error.is_retryable(),
                 _ => false,
             },
             _ => false,
@@ -424,6 +486,40 @@ mod tests {
     #[test]
     fn test_auth_error_not_recoverable() {
         let err = AgentError::llm("anthropic", LlmFailureReason::AuthError, "bad key");
+        assert!(!err.is_recoverable());
+    }
+
+    #[test]
+    fn provider_error_uses_typed_retryability_for_recovery() {
+        let err = AgentError::llm(
+            "anthropic",
+            LlmFailureReason::ProviderError(LlmProviderError::retryable(
+                LlmProviderErrorKind::ServerOverloaded,
+                serde_json::json!({
+                    "message": "provider overloaded"
+                }),
+            )),
+            "provider overloaded",
+        );
+
+        assert!(err.is_recoverable());
+    }
+
+    #[test]
+    fn provider_error_fails_closed_when_json_claims_retryable() {
+        let err = AgentError::llm(
+            "anthropic",
+            LlmFailureReason::ProviderError(LlmProviderError::non_retryable(
+                LlmProviderErrorKind::InvalidRequest,
+                serde_json::json!({
+                    "kind": "server_overloaded",
+                    "retryable": true,
+                    "message": "json payload must not control retryability"
+                }),
+            )),
+            "invalid request",
+        );
+
         assert!(!err.is_recoverable());
     }
 

--- a/meerkat-core/src/event.rs
+++ b/meerkat-core/src/event.rs
@@ -2,7 +2,9 @@
 //!
 //! These events form the streaming API for consumers.
 
-use crate::error::{AgentError, LlmFailureReason};
+use crate::error::{
+    AgentError, LlmFailureReason, LlmProviderErrorKind, LlmProviderErrorRetryability,
+};
 use crate::hooks::{HookPatch, HookPatchEnvelope, HookPoint, HookReasonCode};
 use crate::ops_lifecycle::{OperationStatus, OperationTerminalOutcome};
 use crate::retry::LlmRetrySchedule;
@@ -125,6 +127,8 @@ pub enum AgentErrorReason {
         model: String,
     },
     LlmProviderError {
+        provider_error_kind: LlmProviderErrorKind,
+        provider_error_retryability: LlmProviderErrorRetryability,
         provider_error: Value,
     },
     LlmNetworkTimeout {
@@ -181,8 +185,10 @@ impl AgentErrorReason {
             LlmFailureReason::InvalidModel(model) => Self::LlmInvalidModel {
                 model: model.clone(),
             },
-            LlmFailureReason::ProviderError(value) => Self::LlmProviderError {
-                provider_error: value.clone(),
+            LlmFailureReason::ProviderError(provider_error) => Self::LlmProviderError {
+                provider_error_kind: provider_error.kind,
+                provider_error_retryability: provider_error.retryability,
+                provider_error: provider_error.details.clone(),
             },
             LlmFailureReason::NetworkTimeout { duration_ms } => Self::LlmNetworkTimeout {
                 duration_ms: *duration_ms,
@@ -2108,6 +2114,34 @@ mod tests {
             })
         );
         assert_eq!(report.message, error.to_string());
+    }
+
+    #[test]
+    fn agent_error_report_carries_typed_provider_error_reason() {
+        let error = crate::error::AgentError::llm(
+            "anthropic",
+            LlmFailureReason::ProviderError(crate::error::LlmProviderError::retryable(
+                LlmProviderErrorKind::ServerOverloaded,
+                serde_json::json!({
+                    "message": "provider overloaded"
+                }),
+            )),
+            "provider overloaded",
+        );
+
+        let report = AgentErrorReport::from_agent_error(&error);
+
+        assert_eq!(report.class, AgentErrorClass::Llm);
+        assert_eq!(
+            report.reason,
+            Some(AgentErrorReason::LlmProviderError {
+                provider_error_kind: LlmProviderErrorKind::ServerOverloaded,
+                provider_error_retryability: LlmProviderErrorRetryability::Retryable,
+                provider_error: serde_json::json!({
+                    "message": "provider overloaded"
+                }),
+            })
+        );
     }
 
     #[test]

--- a/meerkat-core/src/retry.rs
+++ b/meerkat-core/src/retry.rs
@@ -4,6 +4,8 @@
 //! typed retry plan admitted by the turn authority.
 
 use crate::error::{AgentError, LlmFailureReason};
+#[cfg(test)]
+use crate::error::{LlmProviderError, LlmProviderErrorKind};
 use serde::{Deserialize, Serialize};
 use std::time::Duration;
 
@@ -62,9 +64,8 @@ impl LlmRetryFailure {
                     duration_ms: Some(*duration_ms),
                     message: message.clone(),
                 }),
-                LlmFailureReason::ProviderError(value)
-                    if value.get("retryable").and_then(serde_json::Value::as_bool)
-                        == Some(true) =>
+                LlmFailureReason::ProviderError(provider_error)
+                    if provider_error.is_retryable() =>
                 {
                     Some(Self {
                         provider: (*provider).to_string(),
@@ -399,6 +400,48 @@ mod tests {
             provider: "test",
             reason: LlmFailureReason::AuthError,
             message: "auth".to_string(),
+        };
+
+        assert!(policy.schedule_retry(&error, 0, None).is_none());
+    }
+
+    #[test]
+    fn retry_schedule_reads_typed_provider_retryability() {
+        let policy = RetryPolicy::default().with_max_retries(3);
+        let error = AgentError::Llm {
+            provider: "test",
+            reason: LlmFailureReason::ProviderError(LlmProviderError::retryable(
+                LlmProviderErrorKind::ServerOverloaded,
+                serde_json::json!({
+                    "retryable": false,
+                    "message": "json payload must not suppress typed retryability"
+                }),
+            )),
+            message: "provider overloaded".to_string(),
+        };
+
+        let schedule = policy
+            .schedule_retry(&error, 0, None)
+            .expect("typed retryable provider error should be scheduled");
+        assert_eq!(
+            schedule.failure.kind,
+            LlmRetryFailureKind::RetryableProviderError
+        );
+    }
+
+    #[test]
+    fn retry_schedule_ignores_json_only_provider_retryability() {
+        let policy = RetryPolicy::default().with_max_retries(3);
+        let error = AgentError::Llm {
+            provider: "test",
+            reason: LlmFailureReason::ProviderError(LlmProviderError::non_retryable(
+                LlmProviderErrorKind::InvalidRequest,
+                serde_json::json!({
+                    "retryable": true,
+                    "message": "json payload must not admit retries"
+                }),
+            )),
+            message: "invalid request".to_string(),
         };
 
         assert!(policy.schedule_retry(&error, 0, None).is_none());

--- a/meerkat-llm-core/src/error.rs
+++ b/meerkat-llm-core/src/error.rs
@@ -2,7 +2,7 @@
 //!
 //! Categorized by whether they're retryable.
 
-use meerkat_core::error::LlmFailureReason;
+use meerkat_core::error::{LlmFailureReason, LlmProviderError, LlmProviderErrorKind};
 use serde::{Deserialize, Serialize};
 use serde_json::json;
 use std::time::Duration;
@@ -136,50 +136,78 @@ impl LlmError {
             },
             Self::AuthenticationFailed { .. } | Self::InvalidApiKey => LlmFailureReason::AuthError,
             Self::ModelNotFound { model } => LlmFailureReason::InvalidModel(model.clone()),
-            Self::InvalidRequest { message } => LlmFailureReason::ProviderError(json!({
-                "kind": "invalid_request",
-                "retryable": false,
-                "message": message,
-            })),
-            Self::ContentFiltered { reason } => LlmFailureReason::ProviderError(json!({
-                "kind": "content_filtered",
-                "retryable": false,
-                "message": reason,
-            })),
-            Self::ServerError { status, message } => LlmFailureReason::ProviderError(json!({
-                "kind": "server_error",
-                "retryable": *status >= 500,
-                "status": status,
-                "message": message,
-            })),
-            Self::ServerOverloaded => LlmFailureReason::ProviderError(json!({
-                "kind": "server_overloaded",
-                "retryable": true,
-                "message": self.to_string(),
-            })),
+            Self::InvalidRequest { message } => {
+                LlmFailureReason::ProviderError(LlmProviderError::non_retryable(
+                    LlmProviderErrorKind::InvalidRequest,
+                    json!({
+                        "message": message,
+                    }),
+                ))
+            }
+            Self::ContentFiltered { reason } => {
+                LlmFailureReason::ProviderError(LlmProviderError::non_retryable(
+                    LlmProviderErrorKind::ContentFiltered,
+                    json!({
+                        "message": reason,
+                    }),
+                ))
+            }
+            Self::ServerError { status, message } => {
+                let details = json!({
+                    "status": status,
+                    "message": message,
+                });
+                if self.is_retryable() {
+                    LlmFailureReason::ProviderError(LlmProviderError::retryable(
+                        LlmProviderErrorKind::ServerError,
+                        details,
+                    ))
+                } else {
+                    LlmFailureReason::ProviderError(LlmProviderError::non_retryable(
+                        LlmProviderErrorKind::ServerError,
+                        details,
+                    ))
+                }
+            }
+            Self::ServerOverloaded => LlmFailureReason::ProviderError(LlmProviderError::retryable(
+                LlmProviderErrorKind::ServerOverloaded,
+                json!({
+                    "message": self.to_string(),
+                }),
+            )),
             Self::NetworkTimeout { duration_ms } => LlmFailureReason::NetworkTimeout {
                 duration_ms: *duration_ms,
             },
-            Self::ConnectionReset => LlmFailureReason::ProviderError(json!({
-                "kind": "connection_reset",
-                "retryable": true,
-                "message": self.to_string(),
-            })),
-            Self::Unknown { message } => LlmFailureReason::ProviderError(json!({
-                "kind": "unknown",
-                "retryable": self.is_retryable(),
-                "message": message,
-            })),
-            Self::StreamParseError { message } => LlmFailureReason::ProviderError(json!({
-                "kind": "stream_parse_error",
-                "retryable": self.is_retryable(),
-                "message": message,
-            })),
-            Self::IncompleteResponse { message } => LlmFailureReason::ProviderError(json!({
-                "kind": "incomplete_response",
-                "retryable": self.is_retryable(),
-                "message": message,
-            })),
+            Self::ConnectionReset => LlmFailureReason::ProviderError(LlmProviderError::retryable(
+                LlmProviderErrorKind::ConnectionReset,
+                json!({
+                    "message": self.to_string(),
+                }),
+            )),
+            Self::Unknown { message } => {
+                LlmFailureReason::ProviderError(LlmProviderError::non_retryable(
+                    LlmProviderErrorKind::Unknown,
+                    json!({
+                        "message": message,
+                    }),
+                ))
+            }
+            Self::StreamParseError { message } => {
+                LlmFailureReason::ProviderError(LlmProviderError::non_retryable(
+                    LlmProviderErrorKind::StreamParseError,
+                    json!({
+                        "message": message,
+                    }),
+                ))
+            }
+            Self::IncompleteResponse { message } => {
+                LlmFailureReason::ProviderError(LlmProviderError::non_retryable(
+                    LlmProviderErrorKind::IncompleteResponse,
+                    json!({
+                        "message": message,
+                    }),
+                ))
+            }
         }
     }
 }
@@ -307,6 +335,35 @@ mod tests {
         assert_eq!(
             reason,
             LlmFailureReason::NetworkTimeout { duration_ms: 30000 }
+        );
+    }
+
+    #[test]
+    fn provider_failure_reason_uses_typed_kind_and_retryability() {
+        let reason = LlmError::ServerOverloaded.failure_reason();
+        let LlmFailureReason::ProviderError(provider_error) = reason else {
+            panic!("expected provider error");
+        };
+
+        assert_eq!(
+            provider_error.kind,
+            meerkat_core::error::LlmProviderErrorKind::ServerOverloaded
+        );
+        assert_eq!(
+            provider_error.retryability,
+            meerkat_core::error::LlmProviderErrorRetryability::Retryable
+        );
+        assert_eq!(
+            provider_error.details["message"],
+            serde_json::json!("Server overloaded (503)")
+        );
+        assert!(
+            provider_error.details.get("kind").is_none(),
+            "provider error kind must not be carried in untyped JSON"
+        );
+        assert!(
+            provider_error.details.get("retryable").is_none(),
+            "provider error retryability must not be carried in untyped JSON"
         );
     }
 

--- a/sdks/web/src/generated/events.ts
+++ b/sdks/web/src/generated/events.ts
@@ -17,6 +17,8 @@ export type AgentErrorReason = {
   reason_type: "llm_invalid_model";
 } | {
   provider_error: unknown;
+  provider_error_kind: LlmProviderErrorKind;
+  provider_error_retryability: LlmProviderErrorRetryability;
   reason_type: "llm_provider_error";
 } | {
   duration_ms: number;
@@ -131,6 +133,10 @@ export type HookReasonCode = "policy_violation" | "safety_violation" | "schema_v
 export type HookRevision = number;
 
 export type InteractionId = string;
+
+export type LlmProviderErrorKind = "invalid_request" | "content_filtered" | "server_error" | "server_overloaded" | "connection_reset" | "unknown" | "stream_parse_error" | "incomplete_response";
+
+export type LlmProviderErrorRetryability = "retryable" | "non_retryable";
 
 export type LlmRetryFailure = {
   duration_ms?: number | null;


### PR DESCRIPTION
## Summary
- add typed LLM provider error kind and retryability metadata
- stop retry/recovery policy from scraping provider error JSON for retryability
- expose typed provider error metadata in event schema and generated web event types

## Validation
- ./scripts/repo-cargo test -p meerkat-core provider_error
- ./scripts/repo-cargo test -p meerkat-core retry_schedule
- ./scripts/repo-cargo test -p meerkat-core agent_error_report_carries_typed_provider_error_reason
- ./scripts/repo-cargo test -p meerkat-llm-core provider_failure
- make regen-schemas
- MEERKAT_BUILDBUDDY=1 make check
- make verify-schema-freshness

Linear: LUC-118