### PR TITLE
Preserve typed tool result content in hooks and events

### DIFF
--- a/artifacts/schemas/events.json
+++ b/artifacts/schemas/events.json
@@ -1683,6 +1683,12 @@
       {
         "description": "Tool result received (injected into conversation)",
         "properties": {
+          "content": {
+            "items": {
+              "$ref": "#/$defs/ContentBlock"
+            },
+            "type": "array"
+          },
           "id": {
             "type": "string"
           },
@@ -1750,15 +1756,17 @@
       {
         "description": "Tool execution completed",
         "properties": {
+          "content": {
+            "description": "Canonical typed tool-result content.",
+            "items": {
+              "$ref": "#/$defs/ContentBlock"
+            },
+            "type": "array"
+          },
           "duration_ms": {
             "format": "uint64",
             "minimum": 0,
             "type": "integer"
-          },
-          "has_images": {
-            "default": false,
-            "description": "Whether the tool result contains image content blocks.",
-            "type": "boolean"
           },
           "id": {
             "type": "string"
@@ -1770,6 +1778,7 @@
             "type": "string"
           },
           "result": {
+            "description": "Legacy text projection retained for existing event consumers.",
             "type": "string"
           },
           "type": {
@@ -2874,6 +2883,12 @@
           {
             "description": "Tool result received (injected into conversation)",
             "properties": {
+              "content": {
+                "items": {
+                  "$ref": "#/$defs/ContentBlock"
+                },
+                "type": "array"
+              },
               "id": {
                 "type": "string"
               },
@@ -2941,15 +2956,17 @@
           {
             "description": "Tool execution completed",
             "properties": {
+              "content": {
+                "description": "Canonical typed tool-result content.",
+                "items": {
+                  "$ref": "#/$defs/ContentBlock"
+                },
+                "type": "array"
+              },
               "duration_ms": {
                 "format": "uint64",
                 "minimum": 0,
                 "type": "integer"
-              },
-              "has_images": {
-                "default": false,
-                "description": "Whether the tool result contains image content blocks.",
-                "type": "boolean"
               },
               "id": {
                 "type": "string"
@@ -2961,6 +2978,7 @@
                 "type": "string"
               },
               "result": {
+                "description": "Legacy text projection retained for existing event consumers.",
                 "type": "string"
               },
               "type": {

--- a/docs/guides/hooks.mdx
+++ b/docs/guides/hooks.mdx
@@ -217,10 +217,10 @@ Hooks receive a `HookInvocation` struct containing contextual data. Fields are p
 - **`HookLlmRequest`**: `max_tokens`, `temperature`, `provider_params`, `message_count`
 - **`HookLlmResponse`**: `assistant_text`, `tool_call_names`, `stop_reason`, `usage`
 - **`HookToolCall`**: `tool_use_id`, `name`, `args`
-- **`HookToolResult`**: `tool_use_id`, `name`, `content`, `is_error`, `has_images`
+- **`HookToolResult`**: `tool_use_id`, `name`, `content`, `content_blocks`, `is_error`
 </Accordion>
 
-`HookToolResult.content` is always the text projection of the tool result. If the original result also contains image blocks, `has_images` is set so hook authors know multimodal content exists. A `HookPatch::ToolResult` rewrite preserves those image blocks and replaces only the text projection plus optional `is_error`.
+`HookToolResult.content_blocks` carries the typed tool-result blocks, including image blocks, in original order. `HookToolResult.content` remains as a legacy text projection for existing hooks. A `HookPatch::ToolResult` rewrite preserves non-text blocks and replaces only the text projection plus optional `is_error`.
 
 ## Priority ordering and deny short-circuiting
 

--- a/docs/rust/overview.mdx
+++ b/docs/rust/overview.mdx
@@ -325,12 +325,12 @@ match event {
     AgentEvent::TextDelta { delta } => {}
     AgentEvent::TextComplete { content } => {}
     AgentEvent::ToolCallRequested { id, name, args } => {}
-    AgentEvent::ToolResultReceived { id, name, is_error } => {}
+    AgentEvent::ToolResultReceived { id, name, content, is_error } => {}
     AgentEvent::TurnCompleted { stop_reason, usage } => {}
 
     // Tool execution
     AgentEvent::ToolExecutionStarted { id, name } => {}
-    AgentEvent::ToolExecutionCompleted { id, name, result, is_error, duration_ms } => {}
+    AgentEvent::ToolExecutionCompleted { id, name, result, content, is_error, duration_ms } => {}
     AgentEvent::ToolExecutionTimedOut { id, name, timeout_ms } => {}
 
     // Compaction

--- a/docs/sdks/typescript/reference.mdx
+++ b/docs/sdks/typescript/reference.mdx
@@ -379,7 +379,7 @@ interface TurnStartedEvent        { type: "turn_started";         turnNumber: nu
 interface TextDeltaEvent          { type: "text_delta";            delta: string }
 interface TextCompleteEvent       { type: "text_complete";         content: string }
 interface ToolCallRequestedEvent  { type: "tool_call_requested";   id: string; name: string; args: unknown }
-interface ToolResultReceivedEvent { type: "tool_result_received";  id: string; name: string; isError: boolean }
+interface ToolResultReceivedEvent { type: "tool_result_received";  id: string; name: string; content: ContentBlock[]; isError: boolean }
 interface TurnCompletedEvent      { type: "turn_completed";        stopReason: StopReason; usage: Usage }
 ```
 
@@ -397,7 +397,7 @@ type StopReason =
 
 ```typescript
 interface ToolExecutionStartedEvent   { type: "tool_execution_started";    id: string; name: string }
-interface ToolExecutionCompletedEvent { type: "tool_execution_completed";   id: string; name: string; result: string; isError: boolean; durationMs: number }
+interface ToolExecutionCompletedEvent { type: "tool_execution_completed";   id: string; name: string; result: string; content: ContentBlock[]; isError: boolean; durationMs: number }
 interface ToolExecutionTimedOutEvent  { type: "tool_execution_timed_out";   id: string; name: string; timeoutMs: number }
 ```
 

--- a/meerkat-contracts/tests/regression_wire_types.rs
+++ b/meerkat-contracts/tests/regression_wire_types.rs
@@ -16,9 +16,9 @@ use meerkat_contracts::{
     WireSessionHistory, WireSessionInfo, WireSessionMessage, WireSessionSummary, WireUsage,
 };
 use meerkat_core::{
-    AgentErrorClass, AgentEvent, BudgetType, ContentInput, HookPatch, HookPoint, HookReasonCode,
-    RunResult, SessionId, SkillResolutionFailureReason, StopReason, ToolConfigChangeOperation,
-    ToolConfigChangeStatus, ToolConfigChangedPayload, Usage,
+    AgentErrorClass, AgentEvent, BudgetType, ContentBlock, ContentInput, HookPatch, HookPoint,
+    HookReasonCode, RunResult, SessionId, SkillResolutionFailureReason, StopReason,
+    ToolConfigChangeOperation, ToolConfigChangeStatus, ToolConfigChangedPayload, Usage,
 };
 
 // ---------------------------------------------------------------------------
@@ -410,6 +410,7 @@ fn agent_event_all_variants_roundtrip() {
         AgentEvent::ToolResultReceived {
             id: "tc1".to_string(),
             name: "read_file".to_string(),
+            content: ContentBlock::text_vec("ok".to_string()),
             is_error: false,
         },
         AgentEvent::TurnCompleted {
@@ -424,9 +425,9 @@ fn agent_event_all_variants_roundtrip() {
             id: "tc2".to_string(),
             name: "shell".to_string(),
             result: "ok".to_string(),
+            content: ContentBlock::text_vec("ok".to_string()),
             is_error: false,
             duration_ms: 100,
-            has_images: false,
         },
         AgentEvent::ToolExecutionTimedOut {
             id: "tc3".to_string(),
@@ -661,6 +662,7 @@ fn documented_event_catalog_covers_core_agent_event_discriminators() {
         AgentEvent::ToolResultReceived {
             id: "tool-1".to_string(),
             name: "search".to_string(),
+            content: ContentBlock::text_vec("ok".to_string()),
             is_error: false,
         },
         AgentEvent::TurnCompleted {
@@ -675,9 +677,9 @@ fn documented_event_catalog_covers_core_agent_event_discriminators() {
             id: "tool-1".to_string(),
             name: "search".to_string(),
             result: "ok".to_string(),
+            content: ContentBlock::text_vec("ok".to_string()),
             is_error: false,
             duration_ms: 1,
-            has_images: false,
         },
         AgentEvent::ToolExecutionTimedOut {
             id: "tool-1".to_string(),

--- a/meerkat-core/src/agent/state.rs
+++ b/meerkat-core/src/agent/state.rs
@@ -1919,13 +1919,13 @@ where
                                         llm_request: None,
                                         llm_response: None,
                                         tool_call: None,
-                                        tool_result: Some(HookToolResult {
-                                            tool_use_id: tc.id.clone(),
-                                            name: tc.name.clone(),
-                                            content: tool_result.text_content(),
-                                            is_error: tool_result.is_error,
-                                            has_images: tool_result.has_images(),
-                                        }),
+                                        tool_result: Some(
+                                            HookToolResult::from_tool_result_with_id(
+                                                tc.id.clone(),
+                                                tc.name.clone(),
+                                                &tool_result,
+                                            ),
+                                        ),
                                     },
                                     event_tx.as_ref(),
                                 )
@@ -1978,15 +1978,16 @@ where
                                 id: tc.id.clone(),
                                 name: tc.name.clone(),
                                 result: tool_result.text_content(),
+                                content: tool_result.content.clone(),
                                 is_error: tool_result.is_error,
                                 duration_ms,
-                                has_images: tool_result.has_images(),
                             });
 
                             // Emit result received
                             emit_event!(AgentEvent::ToolResultReceived {
                                 id: tc.id.clone(),
                                 name: tc.name.clone(),
+                                content: tool_result.content.clone(),
                                 is_error: tool_result.is_error,
                             });
 

--- a/meerkat-core/src/event.rs
+++ b/meerkat-core/src/event.rs
@@ -8,7 +8,7 @@ use crate::ops_lifecycle::{OperationStatus, OperationTerminalOutcome};
 use crate::retry::LlmRetrySchedule;
 use crate::skills::{CapabilityId, SkillError, SkillKey};
 use crate::time_compat::SystemTime;
-use crate::types::{ContentInput, SessionId, StopReason, Usage};
+use crate::types::{ContentBlock, ContentInput, SessionId, StopReason, Usage};
 use serde::de::{self, DeserializeOwned};
 use serde::ser::SerializeStruct;
 use serde::{Deserialize, Serialize};
@@ -1130,6 +1130,8 @@ pub enum AgentEvent {
     ToolResultReceived {
         id: String,
         name: String,
+        #[serde(default, skip_serializing_if = "Vec::is_empty")]
+        content: Vec<ContentBlock>,
         is_error: bool,
     },
 
@@ -1147,12 +1149,13 @@ pub enum AgentEvent {
     ToolExecutionCompleted {
         id: String,
         name: String,
+        /// Legacy text projection retained for existing event consumers.
         result: String,
+        /// Canonical typed tool-result content.
+        #[serde(default, skip_serializing_if = "Vec::is_empty")]
+        content: Vec<ContentBlock>,
         is_error: bool,
         duration_ms: u64,
-        /// Whether the tool result contains image content blocks.
-        #[serde(default)]
-        has_images: bool,
     },
 
     /// Tool execution timed out
@@ -1523,6 +1526,20 @@ mod tests {
     use super::*;
     use crate::retry::{LlmRetryFailure, LlmRetryFailureKind, LlmRetryPlan, LlmRetrySchedule};
     use crate::skills::SkillName;
+    use crate::types::ContentBlock;
+
+    fn text_block(text: &str) -> ContentBlock {
+        ContentBlock::Text {
+            text: text.to_string(),
+        }
+    }
+
+    fn image_block(media_type: &str, data: &str) -> ContentBlock {
+        ContentBlock::Image {
+            media_type: media_type.to_string(),
+            data: data.into(),
+        }
+    }
 
     #[test]
     fn tool_config_change_status_mirrors_legacy_status_text() {
@@ -1546,6 +1563,178 @@ mod tests {
             .status_text(),
             "failed: exit 1"
         );
+    }
+
+    #[test]
+    fn tool_result_events_carry_text_only_content_blocks() {
+        let content = vec![text_block("plain output")];
+        let completed = AgentEvent::ToolExecutionCompleted {
+            id: "tc_text".to_string(),
+            name: "text_tool".to_string(),
+            result: "plain output".to_string(),
+            content: content.clone(),
+            is_error: false,
+            duration_ms: 12,
+        };
+        let received = AgentEvent::ToolResultReceived {
+            id: "tc_text".to_string(),
+            name: "text_tool".to_string(),
+            content: content.clone(),
+            is_error: false,
+        };
+
+        let completed_json = serde_json::to_value(&completed).expect("serialize completed event");
+        assert_eq!(
+            completed_json["content"],
+            serde_json::json!([{"type": "text", "text": "plain output"}])
+        );
+        assert!(
+            completed_json.get("has_images").is_none(),
+            "typed content blocks should replace image side flags on event surfaces"
+        );
+
+        let received_json = serde_json::to_value(&received).expect("serialize received event");
+        assert_eq!(
+            received_json["content"],
+            serde_json::json!([{"type": "text", "text": "plain output"}])
+        );
+    }
+
+    #[test]
+    fn tool_result_events_carry_image_only_content_blocks() {
+        let content = vec![image_block("image/png", "AAAA")];
+        let completed = AgentEvent::ToolExecutionCompleted {
+            id: "tc_image".to_string(),
+            name: "view_image".to_string(),
+            result: "[image: image/png]".to_string(),
+            content: content.clone(),
+            is_error: false,
+            duration_ms: 12,
+        };
+        let received = AgentEvent::ToolResultReceived {
+            id: "tc_image".to_string(),
+            name: "view_image".to_string(),
+            content: content.clone(),
+            is_error: false,
+        };
+
+        let completed_json = serde_json::to_value(&completed).expect("serialize completed event");
+        assert_eq!(
+            completed_json["content"],
+            serde_json::json!([{
+                "type": "image",
+                "media_type": "image/png",
+                "source": "inline",
+                "data": "AAAA"
+            }])
+        );
+        assert!(
+            completed_json.get("has_images").is_none(),
+            "typed content blocks should replace image side flags on event surfaces"
+        );
+
+        let received_json = serde_json::to_value(&received).expect("serialize received event");
+        assert_eq!(received_json["content"], completed_json["content"]);
+    }
+
+    #[test]
+    fn tool_result_events_carry_mixed_content_blocks_in_order() {
+        let content = vec![
+            text_block("before"),
+            image_block("image/png", "AAAA"),
+            text_block("after"),
+        ];
+        let completed = AgentEvent::ToolExecutionCompleted {
+            id: "tc_mixed".to_string(),
+            name: "mixed_tool".to_string(),
+            result: "before\n[image: image/png]\nafter".to_string(),
+            content: content.clone(),
+            is_error: false,
+            duration_ms: 12,
+        };
+        let received = AgentEvent::ToolResultReceived {
+            id: "tc_mixed".to_string(),
+            name: "mixed_tool".to_string(),
+            content: content.clone(),
+            is_error: false,
+        };
+
+        let completed_json = serde_json::to_value(&completed).expect("serialize completed event");
+        assert_eq!(
+            completed_json["content"],
+            serde_json::json!([
+                {"type": "text", "text": "before"},
+                {
+                    "type": "image",
+                    "media_type": "image/png",
+                    "source": "inline",
+                    "data": "AAAA"
+                },
+                {"type": "text", "text": "after"}
+            ])
+        );
+        assert!(
+            completed_json.get("has_images").is_none(),
+            "typed content blocks should replace image side flags on event surfaces"
+        );
+
+        let roundtrip: AgentEvent = serde_json::from_value(completed_json).unwrap();
+        match roundtrip {
+            AgentEvent::ToolExecutionCompleted {
+                content: roundtrip_content,
+                ..
+            } => assert_eq!(roundtrip_content, content),
+            other => unreachable!("unexpected event: {other:?}"),
+        }
+
+        let received_json = serde_json::to_value(&received).expect("serialize received event");
+        assert_eq!(received_json["content"][0]["text"], "before");
+        assert_eq!(received_json["content"][1]["media_type"], "image/png");
+        assert_eq!(received_json["content"][2]["text"], "after");
+    }
+
+    #[test]
+    fn legacy_tool_result_event_payloads_deserialize_without_typed_content() {
+        let completed: AgentEvent = serde_json::from_value(serde_json::json!({
+            "type": "tool_execution_completed",
+            "id": "tc_legacy",
+            "name": "legacy_tool",
+            "result": "legacy output",
+            "is_error": false,
+            "duration_ms": 3,
+            "has_images": true
+        }))
+        .expect("legacy tool_execution_completed payload should deserialize");
+        match completed {
+            AgentEvent::ToolExecutionCompleted {
+                result,
+                content,
+                is_error,
+                ..
+            } => {
+                assert_eq!(result, "legacy output");
+                assert!(content.is_empty());
+                assert!(!is_error);
+            }
+            other => unreachable!("unexpected event: {other:?}"),
+        }
+
+        let received: AgentEvent = serde_json::from_value(serde_json::json!({
+            "type": "tool_result_received",
+            "id": "tc_legacy",
+            "name": "legacy_tool",
+            "is_error": false
+        }))
+        .expect("legacy tool_result_received payload should deserialize");
+        match received {
+            AgentEvent::ToolResultReceived {
+                content, is_error, ..
+            } => {
+                assert!(content.is_empty());
+                assert!(!is_error);
+            }
+            other => unreachable!("unexpected event: {other:?}"),
+        }
     }
 
     #[test]
@@ -1717,6 +1906,7 @@ mod tests {
             AgentEvent::ToolResultReceived {
                 id: "tc_1".to_string(),
                 name: "read_file".to_string(),
+                content: ContentBlock::text_vec("ok".to_string()),
                 is_error: false,
             },
             AgentEvent::BudgetWarning {
@@ -2194,6 +2384,7 @@ mod tests {
             AgentEvent::ToolResultReceived {
                 id: "tool-1".to_string(),
                 name: "search".to_string(),
+                content: ContentBlock::text_vec("ok".to_string()),
                 is_error: false,
             },
             AgentEvent::TurnCompleted {
@@ -2208,9 +2399,9 @@ mod tests {
                 id: "tool-1".to_string(),
                 name: "search".to_string(),
                 result: "ok".to_string(),
+                content: ContentBlock::text_vec("ok".to_string()),
                 is_error: false,
                 duration_ms: 1,
-                has_images: false,
             },
             AgentEvent::ToolExecutionTimedOut {
                 id: "tool-1".to_string(),

--- a/meerkat-core/src/hooks.rs
+++ b/meerkat-core/src/hooks.rs
@@ -2,7 +2,7 @@
 
 use crate::error::AgentError;
 use crate::event::{AgentErrorClass, AgentErrorReport};
-use crate::types::{ContentInput, SessionId, StopReason, Usage};
+use crate::types::{ContentBlock, ContentInput, SessionId, StopReason, ToolResult, Usage};
 use async_trait::async_trait;
 use chrono::{DateTime, Utc};
 use schemars::JsonSchema;
@@ -217,22 +217,44 @@ pub struct HookToolCall {
 
 /// Tool result view exposed to hooks.
 ///
-/// The `content` field is always the text projection of the tool result.
-/// When `ToolResult.content` migrates to `Vec<ContentBlock>`, this will
-/// contain the concatenated text and `has_images` will signal the presence
-/// of non-text blocks.
+/// `content_blocks` is the canonical typed tool-result content. `content` is
+/// retained as a legacy display projection for existing hook consumers.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 #[serde(rename_all = "snake_case")]
 pub struct HookToolResult {
     pub tool_use_id: String,
     pub name: String,
+    /// Legacy text projection retained for existing hooks.
     pub content: String,
+    /// Canonical typed tool-result content exposed to hooks.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub content_blocks: Vec<ContentBlock>,
     pub is_error: bool,
-    /// Whether the original tool result contains image blocks.
-    /// Hooks always see the text projection; this flag signals that
-    /// non-text content exists so hook authors can make informed decisions.
-    #[serde(default)]
+    /// Legacy side flag retained for Rust compatibility. New hook payloads
+    /// carry `content_blocks` instead of serializing this projection hint.
+    #[serde(default, skip_serializing)]
     pub has_images: bool,
+}
+
+impl HookToolResult {
+    pub fn from_tool_result(name: impl Into<String>, result: &ToolResult) -> Self {
+        Self::from_tool_result_with_id(result.tool_use_id.clone(), name, result)
+    }
+
+    pub fn from_tool_result_with_id(
+        tool_use_id: impl Into<String>,
+        name: impl Into<String>,
+        result: &ToolResult,
+    ) -> Self {
+        Self {
+            tool_use_id: tool_use_id.into(),
+            name: name.into(),
+            content: result.text_content(),
+            content_blocks: result.content.clone(),
+            is_error: result.is_error,
+            has_images: result.has_images(),
+        }
+    }
 }
 
 /// Full invocation payload passed into the hook engine.
@@ -357,27 +379,25 @@ pub fn default_failure_policy(capability: HookCapability) -> HookFailurePolicy {
     }
 }
 
-/// Apply a `HookPatch::ToolResult` to a `ToolResult`, preserving image blocks.
+/// Apply a `HookPatch::ToolResult` to a `ToolResult`, preserving non-text blocks.
 ///
 /// Deterministic rebuild rule:
 /// 1. Strip all `ContentBlock::Text` blocks from the original vec.
 /// 2. Prepend a single `ContentBlock::Text { text: patched_text }` at position 0.
-/// 3. Append all image blocks in their original relative order.
+/// 3. Append all non-text blocks in their original relative order.
 pub fn apply_tool_result_patch(
-    tool_result: &mut crate::types::ToolResult,
+    tool_result: &mut ToolResult,
     patched_text: String,
     is_error: Option<bool>,
 ) {
-    use crate::types::ContentBlock;
-
-    let image_blocks: Vec<ContentBlock> = tool_result
+    let non_text_blocks: Vec<ContentBlock> = tool_result
         .content
         .iter()
-        .filter(|b| matches!(b, ContentBlock::Image { .. }))
+        .filter(|b| !matches!(b, ContentBlock::Text { .. }))
         .cloned()
         .collect();
     let mut new_content = vec![ContentBlock::Text { text: patched_text }];
-    new_content.extend(image_blocks);
+    new_content.extend(non_text_blocks);
     tool_result.content = new_content;
     if let Some(value) = is_error {
         tool_result.is_error = value;
@@ -452,6 +472,7 @@ mod tests {
             tool_use_id: tr.tool_use_id.clone(),
             name: "test_tool".into(),
             content: tr.text_content(),
+            content_blocks: tr.content.clone(),
             is_error: tr.is_error,
             has_images: tr.has_images(),
         };
@@ -467,11 +488,87 @@ mod tests {
             tool_use_id: tr.tool_use_id.clone(),
             name: "test_tool".into(),
             content: tr.text_content(),
+            content_blocks: tr.content.clone(),
             is_error: tr.is_error,
             has_images: tr.has_images(),
         };
         assert_eq!(hook_result.content, "just text");
+        assert_eq!(hook_result.content_blocks, vec![text_block("just text")]);
         assert!(!hook_result.has_images);
+    }
+
+    #[test]
+    fn hook_result_text_only_serializes_typed_content_blocks() {
+        let tr = ToolResult::new("tc_1".into(), "just text".into(), false);
+        let hook_result = HookToolResult::from_tool_result("test_tool", &tr);
+
+        assert_eq!(hook_result.content, "just text");
+        assert_eq!(hook_result.content_blocks, vec![text_block("just text")]);
+
+        let json = serde_json::to_value(&hook_result).expect("serialize hook tool result");
+        assert_eq!(
+            json["content_blocks"],
+            serde_json::json!([{"type": "text", "text": "just text"}])
+        );
+        assert!(
+            json.get("has_images").is_none(),
+            "typed content blocks should replace the image side flag on the hook surface"
+        );
+    }
+
+    #[test]
+    fn hook_result_image_only_serializes_typed_content_blocks() {
+        let tr =
+            ToolResult::with_blocks("tc_1".into(), vec![image_block("image/png", "AAAA")], false);
+        let hook_result = HookToolResult::from_tool_result("view_image", &tr);
+
+        assert_eq!(hook_result.content, "[image: image/png]");
+        assert_eq!(
+            hook_result.content_blocks,
+            vec![image_block("image/png", "AAAA")]
+        );
+
+        let json = serde_json::to_value(&hook_result).expect("serialize hook tool result");
+        assert_eq!(
+            json["content_blocks"],
+            serde_json::json!([{
+                "type": "image",
+                "media_type": "image/png",
+                "source": "inline",
+                "data": "AAAA"
+            }])
+        );
+        assert!(
+            json.get("has_images").is_none(),
+            "typed content blocks should replace the image side flag on the hook surface"
+        );
+    }
+
+    #[test]
+    fn hook_result_mixed_content_preserves_block_order() {
+        let tr = ToolResult::with_blocks(
+            "tc_1".into(),
+            vec![
+                text_block("before"),
+                image_block("image/png", "AAAA"),
+                text_block("after"),
+            ],
+            false,
+        );
+        let hook_result = HookToolResult::from_tool_result("mixed_tool", &tr);
+
+        assert_eq!(hook_result.content, "before\n[image: image/png]\nafter");
+        assert_eq!(hook_result.content_blocks, tr.content);
+    }
+
+    #[test]
+    fn hook_result_can_use_authoritative_tool_call_id() {
+        let tr = ToolResult::new("stale_tool_id".into(), "ok".into(), false);
+        let hook_result =
+            HookToolResult::from_tool_result_with_id("active_tool_id", "test_tool", &tr);
+
+        assert_eq!(hook_result.tool_use_id, "active_tool_id");
+        assert_eq!(hook_result.content_blocks, vec![text_block("ok")]);
     }
 
     #[test]
@@ -582,16 +679,30 @@ mod tests {
     }
 
     #[test]
-    fn hook_tool_result_has_images_roundtrip() {
+    fn hook_tool_result_has_images_is_deserialize_only_legacy_flag() {
         let result = HookToolResult {
             tool_use_id: "tc_1".into(),
             name: "tool".into(),
             content: "text".into(),
+            content_blocks: vec![text_block("text")],
             is_error: false,
             has_images: true,
         };
-        let json = serde_json::to_string(&result).expect("should serialize");
-        let decoded: HookToolResult = serde_json::from_str(&json).expect("should deserialize");
+        let json = serde_json::to_value(&result).expect("should serialize");
+        assert!(
+            json.get("has_images").is_none(),
+            "new hook payloads carry content_blocks instead of has_images"
+        );
+
+        let decoded: HookToolResult = serde_json::from_value(serde_json::json!({
+            "tool_use_id": "tc_1",
+            "name": "tool",
+            "content": "text",
+            "content_blocks": [{"type": "text", "text": "text"}],
+            "is_error": false,
+            "has_images": true
+        }))
+        .expect("should deserialize");
         assert!(decoded.has_images);
     }
 }

--- a/sdks/python/meerkat/events.py
+++ b/sdks/python/meerkat/events.py
@@ -32,7 +32,8 @@ from typing import TYPE_CHECKING, Any, Literal, cast
 if TYPE_CHECKING:
     from .types import SkillKey
 
-ContentInput = str | list[dict[str, Any]]
+ContentBlock = dict[str, Any]
+ContentInput = str | list[ContentBlock]
 
 
 # ---------------------------------------------------------------------------
@@ -132,6 +133,7 @@ class ToolResultReceived(Event):
 
     id: str = ""
     name: str = ""
+    content: list[ContentBlock] = field(default_factory=list)
     is_error: bool | None = None
 
 
@@ -162,6 +164,7 @@ class ToolExecutionCompleted(Event):
     id: str = ""
     name: str = ""
     result: str = ""
+    content: list[ContentBlock] = field(default_factory=list)
     is_error: bool | None = None
     duration_ms: int | None = None
 
@@ -682,6 +685,16 @@ def _require_bool(raw: dict[str, Any], field_name: str) -> bool:
     return value
 
 
+def _parse_content_blocks(raw: Any, legacy_text: Any = None) -> list[ContentBlock]:
+    if isinstance(raw, list) and all(isinstance(block, dict) for block in raw):
+        return cast(list[ContentBlock], raw)
+    if raw is not None:
+        raise ValueError("content must be a content block list")
+    if isinstance(legacy_text, str) and legacy_text:
+        return [{"type": "text", "text": legacy_text}]
+    return []
+
+
 _STRING_FIELDS = {
     "session_id",
     "result",
@@ -844,6 +857,11 @@ def parse_event(raw: dict[str, Any]) -> Event:
         for f in cls.__dataclass_fields__:
             if f == "usage":
                 kwargs["usage"] = _parse_usage(raw.get("usage"))
+            elif f == "content" and cls in {ToolResultReceived, ToolExecutionCompleted}:
+                kwargs["content"] = _parse_content_blocks(
+                    raw.get("content"),
+                    raw.get("result") if cls is ToolExecutionCompleted else None,
+                )
             elif f == "is_error" and cls in {ToolResultReceived, ToolExecutionCompleted}:
                 kwargs["is_error"] = _parse_optional_bool(raw.get("is_error"))
             elif f == "duration_ms" and cls is ToolExecutionCompleted:

--- a/sdks/python/tests/test_types.py
+++ b/sdks/python/tests/test_types.py
@@ -72,6 +72,7 @@ from meerkat.events import (
     TextDelta,
     ToolCallRequested,
     ToolExecutionCompleted,
+    ToolResultReceived,
     TurnCompleted,
     TurnStarted,
     UnknownEvent,
@@ -831,6 +832,10 @@ def test_parse_tool_execution_completed():
         "id": "t1",
         "name": "search",
         "result": "found it",
+        "content": [
+            {"type": "text", "text": "found it"},
+            {"type": "image", "media_type": "image/png", "source": "inline", "data": "AAAA"},
+        ],
         "is_error": False,
         "duration_ms": 42,
     }
@@ -839,6 +844,40 @@ def test_parse_tool_execution_completed():
     assert event.name == "search"
     assert event.duration_ms == 42
     assert event.is_error is False
+    assert event.content == [
+        {"type": "text", "text": "found it"},
+        {"type": "image", "media_type": "image/png", "source": "inline", "data": "AAAA"},
+    ]
+
+
+def test_parse_tool_result_received_content_blocks():
+    raw = {
+        "type": "tool_result_received",
+        "id": "t1",
+        "name": "search",
+        "content": [{"type": "text", "text": "found it"}],
+        "is_error": False,
+    }
+    event = parse_event(raw)
+    assert isinstance(event, ToolResultReceived)
+    assert event.content == [{"type": "text", "text": "found it"}]
+    assert event.is_error is False
+
+
+def test_parse_tool_execution_completed_preserves_malformed_content_blocks():
+    raw = {
+        "type": "tool_execution_completed",
+        "id": "t1",
+        "name": "search",
+        "result": "found it",
+        "content": "not blocks",
+        "is_error": False,
+        "duration_ms": 42,
+    }
+    event = parse_event(raw)
+    assert isinstance(event, UnknownEvent)
+    assert event.type == "malformed_event"
+    assert event.data == raw
 
 
 def test_parse_tool_execution_completed_does_not_coerce_missing_or_malformed_is_error():
@@ -861,6 +900,8 @@ def test_parse_tool_execution_completed_does_not_coerce_missing_or_malformed_is_
     assert malformed.is_error is None
     assert missing.duration_ms is None
     assert malformed.duration_ms is None
+    assert missing.content == [{"type": "text", "text": "found it"}]
+    assert malformed.content == [{"type": "text", "text": "found it"}]
 
 
 def test_parse_unknown_event_type():

--- a/sdks/typescript/src/events.ts
+++ b/sdks/typescript/src/events.ts
@@ -26,7 +26,7 @@
  * ```
  */
 
-import type { ContentInput, SkillKey } from "./types.js";
+import type { ContentBlock, ContentInput, SkillKey } from "./types.js";
 
 // ---------------------------------------------------------------------------
 // Shared value types
@@ -139,6 +139,7 @@ export interface ToolResultReceivedEvent {
   readonly type: "tool_result_received";
   readonly id: string;
   readonly name: string;
+  readonly content: readonly ContentBlock[];
   readonly isError?: boolean;
 }
 
@@ -163,6 +164,7 @@ export interface ToolExecutionCompletedEvent {
   readonly id: string;
   readonly name: string;
   readonly result: string;
+  readonly content: readonly ContentBlock[];
   readonly isError?: boolean;
   readonly durationMs?: number;
 }
@@ -546,6 +548,15 @@ function parseContentInput(raw: unknown): ContentInput {
   return String(raw ?? "");
 }
 
+function parseContentBlocks(raw: unknown, legacyText?: unknown): readonly ContentBlock[] {
+  if (Array.isArray(raw)) return raw as readonly ContentBlock[];
+  if (raw != null) throw new Error("content must be a content block array");
+  if (typeof legacyText === "string" && legacyText.length > 0) {
+    return [{ type: "text", text: legacyText }];
+  }
+  return [];
+}
+
 function parseToolConfigChangeStatus(raw: unknown): ToolConfigChangeStatus | undefined {
   if (raw == null || typeof raw !== "object") {
     return undefined;
@@ -779,7 +790,13 @@ export function parseCoreEvent(raw: Record<string, unknown>): AgentEvent {
     case "tool_call_requested":
       return { type, id: requireStringField(raw, "id"), name: requireStringField(raw, "name"), args: raw.args };
     case "tool_result_received":
-      return { type, id: requireStringField(raw, "id"), name: requireStringField(raw, "name"), isError: requireBooleanField(raw, "is_error") };
+      return {
+        type,
+        id: requireStringField(raw, "id"),
+        name: requireStringField(raw, "name"),
+        content: parseContentBlocks(raw.content),
+        isError: requireBooleanField(raw, "is_error"),
+      };
     case "turn_completed":
       return {
         type,
@@ -800,6 +817,7 @@ export function parseCoreEvent(raw: Record<string, unknown>): AgentEvent {
         id: requireStringField(raw, "id"),
         name: requireStringField(raw, "name"),
         result: requireStringField(raw, "result"),
+        content: parseContentBlocks(raw.content, raw.result),
         ...(parseWireBoolean(raw.is_error) != null ? { isError: parseWireBoolean(raw.is_error) } : {}),
         ...(typeof raw.duration_ms === "number" && Number.isFinite(raw.duration_ms)
           ? { durationMs: raw.duration_ms }

--- a/sdks/typescript/tests/types.test.js
+++ b/sdks/typescript/tests/types.test.js
@@ -236,6 +236,10 @@ describe("Typed Events", () => {
       id: "t1",
       name: "search",
       result: "found it",
+      content: [
+        { type: "text", text: "found it" },
+        { type: "image", media_type: "image/png", source: "inline", data: "AAAA" },
+      ],
       is_error: false,
       duration_ms: 42,
     });
@@ -244,6 +248,42 @@ describe("Typed Events", () => {
       assert.equal(event.name, "search");
       assert.equal(event.durationMs, 42);
       assert.equal(event.isError, false);
+      assert.deepEqual(event.content, [
+        { type: "text", text: "found it" },
+        { type: "image", media_type: "image/png", source: "inline", data: "AAAA" },
+      ]);
+    }
+  });
+
+  it("should parse tool_result_received content blocks", () => {
+    const event = parseEvent({
+      type: "tool_result_received",
+      id: "t1",
+      name: "search",
+      content: [{ type: "text", text: "found it" }],
+      is_error: false,
+    });
+    assert.equal(event.type, "tool_result_received");
+    if (event.type === "tool_result_received") {
+      assert.deepEqual(event.content, [{ type: "text", text: "found it" }]);
+      assert.equal(event.isError, false);
+    }
+  });
+
+  it("should preserve malformed tool result content blocks", () => {
+    const event = parseEvent({
+      type: "tool_execution_completed",
+      id: "t1",
+      name: "search",
+      result: "found it",
+      content: "not blocks",
+      is_error: false,
+      duration_ms: 42,
+    });
+
+    assert.equal(event.type, "malformed_event");
+    if (event.type === "malformed_event") {
+      assert.equal(event.error, "content must be a content block array");
     }
   });
 
@@ -269,6 +309,8 @@ describe("Typed Events", () => {
       assert.equal(malformed.isError, undefined);
       assert.equal(missing.durationMs, undefined);
       assert.equal(malformed.durationMs, undefined);
+      assert.deepEqual(missing.content, [{ type: "text", text: "found it" }]);
+      assert.deepEqual(malformed.content, [{ type: "text", text: "found it" }]);
     }
   });
 

--- a/sdks/web/src/generated/events.ts
+++ b/sdks/web/src/generated/events.ts
@@ -356,6 +356,7 @@ export interface ToolCallRequestedEvent {
 }
 
 export interface ToolResultReceivedEvent {
+  content?: ContentBlock[];
   id: string;
   is_error: boolean;
   name: string;
@@ -375,8 +376,8 @@ export interface ToolExecutionStartedEvent {
 }
 
 export interface ToolExecutionCompletedEvent {
+  content?: ContentBlock[];
   duration_ms: number;
-  has_images?: boolean;
   id: string;
   is_error: boolean;
   name: string;


### PR DESCRIPTION
## Summary
- add typed tool-result content blocks to hook/event surfaces while keeping legacy text mirrors
- stop emitting hook/event image side flags in favor of typed content blocks
- update schema, generated web event types, SDK parsers/tests, and docs

## Validation
- ./scripts/repo-cargo test -p meerkat-core tool_result -- --nocapture
- ./scripts/repo-cargo check -p meerkat-core -p meerkat-contracts -p rkat
- make regen-schemas
- make test-sdk-typescript
- sdks/python/.venv/bin/python -m pytest -q sdks/python/tests/test_types.py (venv workaround after make test-sdk-python hit PEP 668)
- ./scripts/repo-cargo test -p meerkat-contracts --test regression_wire_types -- --nocapture
- git diff --check
- make check (BuildBuddy): https://app.buildbuddy.io/invocation/8a194f57-385b-4cb1-933c-4769fd7643ab

Linear: LUC-121