### PR TITLE
Preserve WASM external auth lease truth

### DIFF
--- a/meerkat-web-runtime/src/external_auth.rs
+++ b/meerkat-web-runtime/src/external_auth.rs
@@ -9,7 +9,8 @@
 //! This module defines:
 //!
 //! - JS callback slot — wasm_bindgen-exposed registration that stores a
-//!   host callback returning a Promise<string> of a bearer token. The
+//!   host callback returning a Promise of either a legacy bearer string
+//!   or a typed auth envelope. The
 //!   callback survives across WASM calls (registered once, consulted
 //!   per-session).
 //! - [`register_external_auth_resolver`] — wasm_bindgen entry point
@@ -18,7 +19,7 @@
 //!   session-request builder that routes through the provider-runtime
 //!   registry. When the resolved binding uses an `ExternalResolver`
 //!   credential source, the registry looks up this resolver id's callback,
-//!   awaits it, and wires the returned token into the LLM client's
+//!   awaits it, and wires the returned typed lease into the LLM client's
 //!   Authorization header.
 //!
 //! The callback shape matches plan §Phase 4d.wasm:
@@ -26,11 +27,23 @@
 //! ```js
 //! // Host-page registration:
 //! meerkat.register_external_auth_resolver(async (connectionRef) => {
-//!   // host-owned OAuth flow; returns a bearer string
+//!   // host-owned OAuth flow; returns a typed lease envelope
 //!   const token = await my_oauth_client.fresh_token_for(connectionRef);
-//!   return token; // plain string; meerkat wraps as envelope internally
+//!   return {
+//!     kind: "inline_secret",
+//!     secret: token.accessToken,
+//!     metadata: { account_id: token.accountId },
+//!     expires_at: token.expiresAt,
+//!   };
 //! });
 //! ```
+//!
+//! For compatibility, resolving the Promise to a plain bearer string is
+//! still accepted and wrapped as `ResolvedAuthEnvelope::InlineSecret`
+//! with empty metadata and no expiration. To preserve typed failures,
+//! reject the Promise with a wire auth error object such as
+//! `{ kind: "interactive_login_required" }` or
+//! `{ kind: "refresh_failed", detail: "token endpoint returned 401" }`.
 
 #[cfg(target_arch = "wasm32")]
 use js_sys::{Function, Promise};
@@ -58,7 +71,16 @@ pub const WASM_EXTERNAL_AUTH_RESOLVER_HANDLE: &str = WASM_EXTERNAL_AUTH_RESOLVER
 
 /// Register a JS-side external-auth resolver. The callback receives a
 /// structural connection reference argument (`{ realm, binding, profile? }`)
-/// and must return a Promise that resolves to a bearer-token string.
+/// and must return a Promise that resolves to either a bearer-token string
+/// or a JSON-serializable `ResolvedAuthEnvelope` object.
+///
+/// For compatibility, a plain string is still accepted as
+/// `ResolvedAuthEnvelope::InlineSecret` with empty metadata and no expiry.
+/// Hosts that know lease truth should prefer the typed object form:
+/// `{ kind: "inline_secret", secret, metadata, expires_at? }`.
+/// Structured failures should reject the Promise with a wire auth error
+/// object, e.g. `{ kind: "interactive_login_required" }` or
+/// `{ kind: "refresh_failed", detail }`.
 ///
 /// Subsequent registrations overwrite the previous one. Passing
 /// `undefined` clears the registration.
@@ -92,25 +114,30 @@ pub fn has_external_auth_resolver() -> bool {
 /// resolver is registered.
 ///
 /// Caller awaits the Promise via wasm-bindgen-futures to obtain the
-/// bearer token string.
+/// typed auth envelope.
 #[cfg(target_arch = "wasm32")]
 #[allow(dead_code)] // wired in when the provider-runtime-registry WASM path consumes it
 pub(crate) fn invoke_external_auth_resolver(
     connection_ref: &meerkat_core::ConnectionRef,
-) -> Result<Promise, JsValue> {
+) -> Result<Promise, ExternalAuthInvokeError> {
     EXTERNAL_AUTH_RESOLVER.with(|slot| {
         let slot = slot.borrow();
-        let callback = slot.as_ref().ok_or_else(|| {
-            JsValue::from_str(
-                "external_auth: no resolver registered; call register_external_auth_resolver first",
-            )
-        })?;
+        let callback = slot.as_ref().ok_or(ExternalAuthInvokeError::NoResolver)?;
         let this = JsValue::NULL;
-        let result = callback.call1(&this, &connection_ref_js_value(connection_ref))?;
+        let result = callback
+            .call1(&this, &connection_ref_js_value(connection_ref))
+            .map_err(ExternalAuthInvokeError::Callback)?;
         result
             .dyn_into::<Promise>()
-            .map_err(|_| JsValue::from_str("external_auth: callback must return a Promise"))
+            .map_err(|_| ExternalAuthInvokeError::NonPromise)
     })
+}
+
+#[cfg(target_arch = "wasm32")]
+pub(crate) enum ExternalAuthInvokeError {
+    NoResolver,
+    Callback(JsValue),
+    NonPromise,
 }
 
 #[cfg(target_arch = "wasm32")]
@@ -157,34 +184,12 @@ impl meerkat_providers::ExternalAuthResolverHandle for WasmExternalAuthResolver 
         &self,
         binding: &meerkat_providers::ValidatedBinding,
     ) -> Result<meerkat_core::ResolvedAuthEnvelope, meerkat_core::AuthError> {
-        let promise = invoke_external_auth_resolver(&binding.connection_ref).map_err(|e| {
-            meerkat_core::AuthError::Other(format!(
-                "{} resolver: {}",
-                WASM_EXTERNAL_AUTH_RESOLVER_ID,
-                js_value_display(&e),
-            ))
-        })?;
+        let promise = invoke_external_auth_resolver(&binding.connection_ref)
+            .map_err(auth_error_from_invoke_error)?;
         let js_value = wasm_bindgen_futures::JsFuture::from(promise)
             .await
-            .map_err(|e| {
-                meerkat_core::AuthError::Other(format!(
-                    "{WASM_EXTERNAL_AUTH_RESOLVER_ID} resolver rejected: {}",
-                    js_value_display(&e)
-                ))
-            })?;
-        let token = js_value.as_string().ok_or_else(|| {
-            meerkat_core::AuthError::Other(format!(
-                "{WASM_EXTERNAL_AUTH_RESOLVER_ID} resolver must resolve its Promise to a string bearer token",
-            ))
-        })?;
-        if token.trim().is_empty() {
-            return Err(meerkat_core::AuthError::MissingSecret);
-        }
-        Ok(meerkat_core::ResolvedAuthEnvelope::InlineSecret {
-            secret: token,
-            metadata: meerkat_core::AuthMetadata::default(),
-            expires_at: None,
-        })
+            .map_err(auth_error_from_rejection)?;
+        auth_envelope_from_js_value(js_value)
     }
 }
 
@@ -193,6 +198,148 @@ fn js_value_display(v: &JsValue) -> String {
     v.as_string()
         .or_else(|| v.dyn_ref::<js_sys::Error>().map(|e| e.message().into()))
         .unwrap_or_else(|| format!("{v:?}"))
+}
+
+#[cfg(target_arch = "wasm32")]
+fn auth_error_from_invoke_error(error: ExternalAuthInvokeError) -> meerkat_core::AuthError {
+    match error {
+        ExternalAuthInvokeError::NoResolver => meerkat_core::AuthError::MissingSecret,
+        ExternalAuthInvokeError::Callback(e) => meerkat_core::AuthError::Other(format!(
+            "{WASM_EXTERNAL_AUTH_RESOLVER_ID} resolver callback failed: {}",
+            js_value_display(&e),
+        )),
+        ExternalAuthInvokeError::NonPromise => meerkat_core::AuthError::Other(format!(
+            "{WASM_EXTERNAL_AUTH_RESOLVER_ID} resolver callback must return a Promise",
+        )),
+    }
+}
+
+#[cfg(target_arch = "wasm32")]
+fn auth_error_from_rejection(value: JsValue) -> meerkat_core::AuthError {
+    if let Some(error) = wire_auth_error_from_js_value(&value) {
+        return auth_error_from_wire(error);
+    }
+
+    meerkat_core::AuthError::Other(format!(
+        "{WASM_EXTERNAL_AUTH_RESOLVER_ID} resolver rejected: {}",
+        js_value_display(&value),
+    ))
+}
+
+#[cfg(target_arch = "wasm32")]
+fn auth_envelope_from_js_value(
+    value: JsValue,
+) -> Result<meerkat_core::ResolvedAuthEnvelope, meerkat_core::AuthError> {
+    if let Some(token) = value.as_string() {
+        return legacy_bearer_envelope(token);
+    }
+
+    if value.is_null() || value.is_undefined() {
+        return Err(meerkat_core::AuthError::MissingSecret);
+    }
+
+    let raw = json_string_from_js_value(&value).map_err(|detail| {
+        meerkat_core::AuthError::Other(format!(
+            "{WASM_EXTERNAL_AUTH_RESOLVER_ID} resolver returned unsupported credential envelope: {detail}",
+        ))
+    })?;
+    let envelope =
+        serde_json::from_str::<meerkat_core::ResolvedAuthEnvelope>(&raw).map_err(|e| {
+            meerkat_core::AuthError::Other(format!(
+                "{WASM_EXTERNAL_AUTH_RESOLVER_ID} resolver returned unsupported credential envelope: {e}",
+            ))
+        })?;
+    validate_auth_envelope(envelope)
+}
+
+#[cfg(target_arch = "wasm32")]
+fn legacy_bearer_envelope(
+    token: String,
+) -> Result<meerkat_core::ResolvedAuthEnvelope, meerkat_core::AuthError> {
+    if token.trim().is_empty() {
+        return Err(meerkat_core::AuthError::MissingSecret);
+    }
+
+    Ok(meerkat_core::ResolvedAuthEnvelope::InlineSecret {
+        secret: token,
+        metadata: meerkat_core::AuthMetadata::default(),
+        expires_at: None,
+    })
+}
+
+#[cfg(target_arch = "wasm32")]
+fn validate_auth_envelope(
+    envelope: meerkat_core::ResolvedAuthEnvelope,
+) -> Result<meerkat_core::ResolvedAuthEnvelope, meerkat_core::AuthError> {
+    match &envelope {
+        meerkat_core::ResolvedAuthEnvelope::InlineSecret { secret, .. } => {
+            if secret.trim().is_empty() {
+                return Err(meerkat_core::AuthError::MissingSecret);
+            }
+        }
+        meerkat_core::ResolvedAuthEnvelope::StaticHeaders { headers, .. } => {
+            if headers.is_empty()
+                || headers
+                    .iter()
+                    .any(|(name, value)| name.trim().is_empty() || value.trim().is_empty())
+            {
+                return Err(meerkat_core::AuthError::MissingSecret);
+            }
+        }
+        meerkat_core::ResolvedAuthEnvelope::DynamicAuthorizer { .. }
+        | meerkat_core::ResolvedAuthEnvelope::None { .. } => {}
+    }
+
+    Ok(envelope)
+}
+
+#[cfg(target_arch = "wasm32")]
+fn wire_auth_error_from_js_value(value: &JsValue) -> Option<meerkat_contracts::WireAuthError> {
+    let raw = json_string_from_js_value(value).ok()?;
+    serde_json::from_str::<meerkat_contracts::WireAuthError>(&raw).ok()
+}
+
+#[cfg(target_arch = "wasm32")]
+fn json_string_from_js_value(value: &JsValue) -> Result<String, String> {
+    if let Some(raw) = value.as_string() {
+        return Ok(raw);
+    }
+
+    let stringified = js_sys::JSON::stringify(value)
+        .map_err(|e| format!("JSON.stringify failed: {}", js_value_display(&e)))?;
+    stringified
+        .as_string()
+        .ok_or_else(|| "JSON.stringify returned undefined".to_string())
+}
+
+#[cfg(target_arch = "wasm32")]
+fn auth_error_from_wire(error: meerkat_contracts::WireAuthError) -> meerkat_core::AuthError {
+    match error {
+        meerkat_contracts::WireAuthError::MissingSecret => meerkat_core::AuthError::MissingSecret,
+        meerkat_contracts::WireAuthError::UnsupportedCombination { backend, auth } => {
+            meerkat_core::AuthError::UnsupportedCombination { backend, auth }
+        }
+        meerkat_contracts::WireAuthError::MissingRequiredMetadata { field } => {
+            meerkat_core::AuthError::MissingRequiredMetadata(field)
+        }
+        meerkat_contracts::WireAuthError::WorkspaceMismatch => {
+            meerkat_core::AuthError::WorkspaceMismatch
+        }
+        meerkat_contracts::WireAuthError::Expired => meerkat_core::AuthError::Expired,
+        meerkat_contracts::WireAuthError::RefreshFailed { detail } => {
+            meerkat_core::AuthError::RefreshFailed(detail)
+        }
+        meerkat_contracts::WireAuthError::InteractiveLoginRequired => {
+            meerkat_core::AuthError::InteractiveLoginRequired
+        }
+        meerkat_contracts::WireAuthError::HostOwnedUnavailable => {
+            meerkat_core::AuthError::HostOwnedUnavailable
+        }
+        meerkat_contracts::WireAuthError::Io { detail } => meerkat_core::AuthError::Io(detail),
+        meerkat_contracts::WireAuthError::Other { detail } => {
+            meerkat_core::AuthError::Other(detail)
+        }
+    }
 }
 
 // ---------------------------------------------------------------------------

--- a/meerkat-web-runtime/tests/wasm_external_resolver.rs
+++ b/meerkat-web-runtime/tests/wasm_external_resolver.rs
@@ -15,12 +15,66 @@
 
 #![cfg(target_arch = "wasm32")]
 
+use std::sync::Arc;
+
 use js_sys::Function;
+use meerkat_core::{
+    AuthError, AuthMetadata, AuthProfile, BackendProfile, BindingPolicy, ConnectionRef,
+    CredentialSourceSpec, Provider, ResolvedAuthEnvelope,
+    connection::{BindingId, ProfileId, RealmId},
+    provider_matrix::openai::{OpenAiAuthMethod, OpenAiBackendKind},
+};
+use meerkat_providers::{
+    ExternalAuthResolverHandle, NormalizedAuthMethod, NormalizedBackendKind, ValidatedBinding,
+};
 use meerkat_web_runtime::external_auth::{
-    has_external_auth_resolver, register_external_auth_resolver,
+    WasmExternalAuthResolver, has_external_auth_resolver, register_external_auth_resolver,
 };
 use wasm_bindgen::{JsCast, JsValue};
 use wasm_bindgen_test::wasm_bindgen_test;
+
+fn test_binding() -> ValidatedBinding {
+    ValidatedBinding {
+        connection_ref: ConnectionRef {
+            realm: RealmId::parse("browser").expect("realm"),
+            binding: BindingId::parse("chatgpt").expect("binding"),
+            profile: Some(ProfileId::parse("primary").expect("profile")),
+        },
+        provider: Provider::OpenAI,
+        backend: NormalizedBackendKind::OpenAi(OpenAiBackendKind::ChatGptBackend),
+        auth: NormalizedAuthMethod::OpenAi(OpenAiAuthMethod::ExternalAuthorizer),
+        backend_profile: Arc::new(BackendProfile {
+            id: "chatgpt-backend".into(),
+            provider: Provider::OpenAI,
+            backend_kind: "chatgpt_backend".into(),
+            base_url: None,
+            options: serde_json::Value::Null,
+        }),
+        auth_profile: Arc::new(AuthProfile {
+            id: "host-oauth".into(),
+            provider: Provider::OpenAI,
+            auth_method: "external_authorizer".into(),
+            source: CredentialSourceSpec::ExternalResolver {
+                handle: "wasm_host".into(),
+            },
+            constraints: Default::default(),
+            metadata_defaults: Default::default(),
+        }),
+        policy: BindingPolicy::default(),
+    }
+}
+
+fn register_eval_callback(source: &str) {
+    let cb = js_sys::eval(source)
+        .expect("eval callback")
+        .dyn_into::<Function>()
+        .expect("cast to Function");
+    register_external_auth_resolver(JsValue::from(cb)).expect("register callback");
+}
+
+async fn resolve_with_registered_callback() -> Result<ResolvedAuthEnvelope, AuthError> {
+    WasmExternalAuthResolver.resolve(&test_binding()).await
+}
 
 /// Before registration: `has_external_auth_resolver()` returns false.
 #[wasm_bindgen_test]
@@ -72,5 +126,166 @@ fn register_non_function_returns_error() {
     assert!(
         s.contains("must be a function"),
         "error must mention callback must be a function: {s}"
+    );
+}
+
+/// Back-compat: host pages that still resolve the Promise to a plain bearer
+/// string keep working, but the runtime wraps it in the typed envelope shape.
+#[wasm_bindgen_test(async)]
+async fn resolver_preserves_legacy_bearer_string_as_inline_secret() {
+    register_eval_callback(
+        r#"
+            (function (connectionRef) {
+                return Promise.resolve("bearer-" + connectionRef.realm + "-" + connectionRef.binding);
+            })
+        "#,
+    );
+
+    let envelope = resolve_with_registered_callback()
+        .await
+        .expect("resolve bearer string");
+
+    match envelope {
+        ResolvedAuthEnvelope::InlineSecret {
+            secret,
+            metadata,
+            expires_at,
+        } => {
+            assert_eq!(secret, "bearer-browser-chatgpt");
+            assert_eq!(metadata, AuthMetadata::default());
+            assert_eq!(expires_at, None);
+        }
+        other => panic!("unexpected envelope: {other:?}"),
+    }
+}
+
+/// Typed JS resolver objects must cross the WASM boundary without losing lease
+/// expiration or non-secret provenance metadata.
+#[wasm_bindgen_test(async)]
+async fn resolver_preserves_typed_inline_secret_expiration_and_metadata() {
+    register_eval_callback(
+        r#"
+            (function (connectionRef) {
+                if (
+                    connectionRef.realm !== "browser" ||
+                    connectionRef.binding !== "chatgpt" ||
+                    connectionRef.profile !== "primary"
+                ) {
+                    return Promise.reject({
+                        kind: "other",
+                        detail: "connectionRef projection changed: " + JSON.stringify(connectionRef)
+                    });
+                }
+                return Promise.resolve({
+                    kind: "inline_secret",
+                    secret: "typed-access-token",
+                    metadata: {
+                        account_id: "acct_browser",
+                        workspace_id: "workspace_browser",
+                        user_id: "user_browser"
+                    },
+                    expires_at: "2030-01-02T03:04:05Z"
+                });
+            })
+        "#,
+    );
+
+    let envelope = resolve_with_registered_callback()
+        .await
+        .expect("resolve typed envelope");
+
+    match envelope {
+        ResolvedAuthEnvelope::InlineSecret {
+            secret,
+            metadata,
+            expires_at,
+        } => {
+            assert_eq!(secret, "typed-access-token");
+            assert_eq!(metadata.account_id.as_deref(), Some("acct_browser"));
+            assert_eq!(metadata.workspace_id.as_deref(), Some("workspace_browser"));
+            assert_eq!(metadata.user_id.as_deref(), Some("user_browser"));
+            assert_eq!(
+                expires_at.expect("expiration").to_rfc3339(),
+                "2030-01-02T03:04:05+00:00"
+            );
+        }
+        other => panic!("unexpected envelope: {other:?}"),
+    }
+}
+
+/// Structured JS rejections preserve stable auth-failure truth instead of
+/// collapsing every rejection into `AuthError::Other`.
+#[wasm_bindgen_test(async)]
+async fn resolver_preserves_structured_refresh_and_denial_failures() {
+    register_eval_callback(
+        r#"
+            (function (_) {
+                return Promise.reject({
+                    kind: "refresh_failed",
+                    detail: "browser refresh token revoked"
+                });
+            })
+        "#,
+    );
+    let err = resolve_with_registered_callback()
+        .await
+        .expect_err("refresh failure should remain typed");
+    match err {
+        AuthError::RefreshFailed(detail) => {
+            assert_eq!(detail, "browser refresh token revoked");
+        }
+        other => panic!("unexpected refresh error: {other:?}"),
+    }
+
+    register_eval_callback(
+        r#"
+            (function (_) {
+                return Promise.reject({ kind: "interactive_login_required" });
+            })
+        "#,
+    );
+    let err = resolve_with_registered_callback()
+        .await
+        .expect_err("denial should remain typed");
+    assert!(matches!(err, AuthError::InteractiveLoginRequired));
+}
+
+/// Missing credentials fail closed whether the host forgot to register a
+/// resolver, produced an empty token, or resolved to JS null.
+#[wasm_bindgen_test(async)]
+async fn resolver_fails_closed_for_missing_credentials() {
+    register_external_auth_resolver(JsValue::NULL).expect("clear");
+    let err = resolve_with_registered_callback()
+        .await
+        .expect_err("missing resolver should fail closed");
+    assert!(matches!(err, AuthError::MissingSecret));
+
+    register_eval_callback("(function (_) { return Promise.resolve('   '); })");
+    let err = resolve_with_registered_callback()
+        .await
+        .expect_err("blank token should fail closed");
+    assert!(matches!(err, AuthError::MissingSecret));
+
+    register_eval_callback("(function (_) { return Promise.resolve(null); })");
+    let err = resolve_with_registered_callback()
+        .await
+        .expect_err("null token should fail closed");
+    assert!(matches!(err, AuthError::MissingSecret));
+}
+
+/// Raw wasm-bindgen registration intentionally requires a Promise. The
+/// TypeScript SDK adapter provides the JS-facing convenience for callbacks
+/// that return a string synchronously.
+#[wasm_bindgen_test(async)]
+async fn resolver_rejects_non_promise_js_results() {
+    register_eval_callback("(function (_) { return 'bearer-without-promise'; })");
+
+    let err = resolve_with_registered_callback()
+        .await
+        .expect_err("raw WASM callback must return Promise");
+    let message = err.to_string();
+    assert!(
+        message.contains("must return a Promise"),
+        "unexpected error: {message}"
     );
 }

--- a/sdks/web/src/auth.ts
+++ b/sdks/web/src/auth.ts
@@ -10,7 +10,8 @@
  *   - `registerExternalAuthResolver` — wraps the WASM-bundled
  *     `register_external_auth_resolver` binding so a browser host page
  *     can install an OAuth-backed resolver callback that hands Meerkat
- *     a resolved bearer token per structural connection reference.
+ *     either a legacy bearer token string or a typed lease envelope per
+ *     structural connection reference.
  *   - `withConnectionRef` — convenience helper that wires an existing
  *     session config with a connection reference for `createSession`.
  *
@@ -27,12 +28,66 @@ import type { ConnectionRef, SessionConfig } from './types.js';
 /** Canonical WASM external-auth resolver handle for host-owned browser auth. */
 export const WASM_EXTERNAL_AUTH_RESOLVER_HANDLE = 'wasm_host' as const;
 
+/** Non-secret metadata attached to a resolved host-owned auth lease. */
+export interface ExternalAuthMetadata {
+  account_id?: string;
+  workspace_id?: string;
+  organization_id?: string;
+  user_id?: string;
+  plan?: string;
+  route_hints?: unknown;
+  provider_metadata?: unknown;
+}
+
+/** Typed auth lease shape accepted by the WASM external-auth resolver. */
+export type ExternalAuthLease =
+  | {
+      kind: 'inline_secret';
+      secret: string;
+      metadata: ExternalAuthMetadata;
+      expires_at?: string | null;
+    }
+  | {
+      kind: 'static_headers';
+      headers: Array<[string, string]>;
+      metadata: ExternalAuthMetadata;
+      expires_at?: string | null;
+    }
+  | {
+      kind: 'dynamic_authorizer';
+      metadata: ExternalAuthMetadata;
+      expires_at?: string | null;
+    }
+  | {
+      kind: 'none';
+      metadata: ExternalAuthMetadata;
+    };
+
+/** Structured auth failure shape that host resolvers may reject with. */
+export type ExternalAuthFailure =
+  | { kind: 'missing_secret' }
+  | { kind: 'unsupported_combination'; backend: string; auth: string }
+  | { kind: 'missing_required_metadata'; field: string }
+  | { kind: 'workspace_mismatch' }
+  | { kind: 'expired' }
+  | { kind: 'refresh_failed'; detail: string }
+  | { kind: 'interactive_login_required' }
+  | { kind: 'host_owned_unavailable' }
+  | { kind: 'io'; detail: string }
+  | { kind: 'other'; detail: string };
+
+/** Successful resolver result. A string is the legacy compatibility shape;
+ * typed leases preserve expiration and metadata across the WASM boundary. */
+export type ExternalAuthResolverResult = string | ExternalAuthLease;
+
 /** Host-page resolver callback that the WASM runtime invokes when the
  * selected binding's credential source is `external_resolver`. Takes a
- * structural connection reference, returns a bearer token string (or a promise). */
+ * structural connection reference, returns a bearer token string or typed
+ * lease envelope. Reject the returned promise with `ExternalAuthFailure`
+ * to preserve stable failure truth. */
 export type ExternalAuthResolver = (
   connectionRef: ConnectionRef,
-) => string | Promise<string>;
+) => ExternalAuthResolverResult | Promise<ExternalAuthResolverResult>;
 
 /** JSON-RPC-style transport used by the `Auth` class. Minimal: just
  * async request/response of (method, params) -> result. */
@@ -291,13 +346,19 @@ export class Auth {
  *
  * Plan §4d.wasm.1 + §4d.wasm.3: browser OAuth flows run in the host
  * page; the resolver hands Meerkat a resolved bearer token on
- * demand. Meerkat never touches the host's refresh token.
+ * demand. For compatibility the resolver may still return a plain string;
+ * hosts that know expiration/provenance should return an `ExternalAuthLease`.
+ * Meerkat never touches the host's refresh token. Reject with
+ * `ExternalAuthFailure` to preserve denial, refresh, or missing-credential
+ * truth across the WASM boundary.
  */
 export function registerExternalAuthResolver(
   wasm: { register_external_auth_resolver: (cb: unknown) => void },
   resolver: ExternalAuthResolver,
 ): void {
-  const adapter = (connectionRef: ConnectionRef): Promise<string> =>
+  const adapter = (
+    connectionRef: ConnectionRef,
+  ): Promise<ExternalAuthResolverResult> =>
     Promise.resolve(resolver(connectionRef));
   wasm.register_external_auth_resolver(adapter);
 }

--- a/sdks/web/src/index.ts
+++ b/sdks/web/src/index.ts
@@ -13,7 +13,11 @@ export {
   withConnectionRef,
 } from './auth.js';
 export type {
+  ExternalAuthFailure,
+  ExternalAuthLease,
+  ExternalAuthMetadata,
   ExternalAuthResolver,
+  ExternalAuthResolverResult,
   AuthTransport,
   AuthProfile,
   AuthBindingIdentity,

--- a/sdks/web/tests/types.test.ts
+++ b/sdks/web/tests/types.test.ts
@@ -15,6 +15,10 @@ import type {
   AuthLoginReady,
   AuthStatus,
   AuthTransport,
+  ExternalAuthFailure,
+  ExternalAuthLease,
+  ExternalAuthResolver,
+  ExternalAuthResolverResult,
   RuntimeConfig,
   SessionConfig,
   SessionState,
@@ -108,6 +112,25 @@ const authBinding: AuthBindingIdentity = {
   connection_ref: { realm: 'default', binding: 'openai' },
   profile_id: 'openai_apikey',
 };
+
+const externalAuthLease: ExternalAuthLease = {
+  kind: 'inline_secret',
+  secret: 'browser-access-token',
+  metadata: {
+    account_id: 'acct_browser',
+    workspace_id: 'workspace_browser',
+    user_id: 'user_browser',
+  },
+  expires_at: '2030-01-02T03:04:05Z',
+};
+const externalAuthFailure: ExternalAuthFailure = {
+  kind: 'refresh_failed',
+  detail: 'browser refresh token revoked',
+};
+const legacyExternalAuthResolver: ExternalAuthResolver = (connectionRef) =>
+  `bearer-${connectionRef.realm}-${connectionRef.binding}`;
+const typedExternalAuthResolver: ExternalAuthResolver = async () => externalAuthLease;
+const externalAuthResult: ExternalAuthResolverResult = externalAuthLease;
 
 const appendSystemContextOptions: AppendSystemContextOptions = {
   text: 'Coordinate with the orchestrator.',
@@ -297,6 +320,11 @@ void authLogout;
 void authStatusWithProfile;
 void authLogoutWithProfile;
 void authBinding;
+void externalAuthLease;
+void externalAuthFailure;
+void legacyExternalAuthResolver;
+void typedExternalAuthResolver;
+void externalAuthResult;
 void sessionState;
 void appendSystemContextOptions;
 void appendSystemContextResult;


### PR DESCRIPTION
## Summary
- accept typed WASM external auth lease envelopes while preserving legacy bearer-string compatibility
- map structured JS auth rejection objects back to stable AuthError variants and fail closed for missing credentials
- document and type the JS-facing lease/failure compatibility contract in the web SDK

## Validation
- RUSTFLAGS='--cfg getrandom_backend="wasm_js"' ./scripts/repo-cargo test -p meerkat-web-runtime --target wasm32-unknown-unknown --test wasm_external_resolver --no-run
- PATH=<repo cargo cache>/bin:$PATH RUSTFLAGS='--cfg getrandom_backend="wasm_js"' wasm-pack test --node meerkat-web-runtime --test wasm_external_resolver
- npm --prefix sdks/web test -- --test-reporter=spec
- ./scripts/repo-cargo fmt --check
- make check

Linear: LUC-127