### PR TITLE
Surface skill source identity inventory failures

### DIFF
--- a/meerkat-skills/src/engine.rs
+++ b/meerkat-skills/src/engine.rs
@@ -112,8 +112,14 @@ where
 {
     fn inventory_section(&self) -> impl Future<Output = Result<String, SkillError>> + Send {
         async move {
-            let all_skills = self.list_skills(&SkillFilter::default()).await?;
-            let available = filter_by_capabilities(all_skills, &self.available_capabilities);
+            let entries = self
+                .list_all_with_provenance(&SkillFilter::default())
+                .await?;
+            let available: Vec<_> = entries
+                .into_iter()
+                .filter(|entry| entry.is_active)
+                .map(|entry| entry.descriptor)
+                .collect();
             let collections = meerkat_core::skills::derive_collections(&available);
             Ok(renderer::render_inventory(
                 &available,
@@ -240,11 +246,8 @@ where
             let entries = self.source.list_all_with_provenance(filter).await?;
             let mut active_entries = Vec::new();
             for mut entry in entries {
-                let Ok((canonical_key, source_identity)) =
-                    self.resolve_source_identity(&entry.descriptor.key)
-                else {
-                    continue;
-                };
+                let (canonical_key, source_identity) =
+                    self.resolve_source_identity(&entry.descriptor.key)?;
                 if entry.is_active
                     && !entry
                         .descriptor
@@ -260,10 +263,9 @@ where
                 entry.source_identity = Some(source_identity);
                 if let Some(source_uuid) = entry.shadowed_by_source_uuid.clone() {
                     let shadow_key = SkillKey::new(source_uuid, skill_name);
-                    if let Ok((_, shadow_identity)) = self.resolve_source_identity(&shadow_key) {
-                        entry.shadowed_by = Some(shadow_identity.display_name.clone());
-                        entry.shadowed_by_identity = Some(shadow_identity);
-                    }
+                    let (_, shadow_identity) = self.resolve_source_identity(&shadow_key)?;
+                    entry.shadowed_by = Some(shadow_identity.display_name.clone());
+                    entry.shadowed_by_identity = Some(shadow_identity);
                 }
                 active_entries.push(entry);
             }
@@ -299,15 +301,42 @@ where
 #[allow(clippy::unwrap_used)]
 mod tests {
     use super::*;
-    use crate::source::InMemorySkillSource;
+    use crate::source::{CompositeSkillSource, InMemorySkillSource, NamedSource, SourceNode};
     use indexmap::IndexMap;
-    use meerkat_core::skills::{SkillName, SkillScope, SourceUuid};
+    use meerkat_core::skills::{
+        SkillName, SkillScope, SourceIdentityRecord, SourceIdentityStatus, SourceTransportKind,
+        SourceUuid,
+    };
 
     fn test_key(skill: &str) -> SkillKey {
         SkillKey {
             source_uuid: SourceUuid::builtin(),
             skill_name: SkillName::parse(skill).unwrap(),
         }
+    }
+
+    fn source_uuid(raw: &str) -> SourceUuid {
+        SourceUuid::parse(raw).unwrap()
+    }
+
+    fn source_record(
+        source_uuid: SourceUuid,
+        display_name: &str,
+        status: SourceIdentityStatus,
+    ) -> SourceIdentityRecord {
+        SourceIdentityRecord {
+            source_uuid,
+            display_name: display_name.to_string(),
+            transport_kind: SourceTransportKind::Filesystem,
+            fingerprint: format!("fixture:{display_name}"),
+            status,
+        }
+    }
+
+    fn test_skill_from_source(source_uuid: SourceUuid, skill: &str, name: &str) -> SkillDocument {
+        let mut doc = test_skill(skill, name, &[]);
+        doc.descriptor.key.source_uuid = source_uuid;
+        doc
     }
 
     fn test_skill(skill: &str, name: &str, caps: &[&str]) -> SkillDocument {
@@ -363,6 +392,206 @@ mod tests {
         let section = engine.inventory_section().await.unwrap();
         assert!(section.contains("task-workflow"));
         assert!(!section.contains("shell-patterns"));
+    }
+
+    #[tokio::test]
+    async fn inventory_section_reports_source_identity_resolution_failures() {
+        let unknown_source = source_uuid("aaaaaaaa-aaaa-4aaa-aaaa-aaaaaaaaaaaa");
+        let source = InMemorySkillSource::new(vec![test_skill_from_source(
+            unknown_source.clone(),
+            "orphaned",
+            "Orphaned",
+        )]);
+        let registry = SourceIdentityRegistry::default();
+        let engine = DefaultSkillEngine::new(source, vec![])
+            .with_source_identity_registry(Arc::new(registry));
+
+        let err = engine.inventory_section().await.unwrap_err();
+        let message = err.to_string();
+
+        assert!(
+            message.contains("source identity resolution failed"),
+            "inventory error must name source identity resolution; got {message}"
+        );
+        assert!(
+            message.contains(&unknown_source.to_string()),
+            "inventory error must identify the failing source; got {message}"
+        );
+        assert!(
+            message.contains("source unknown"),
+            "inventory error must include the registry failure; got {message}"
+        );
+    }
+
+    #[tokio::test]
+    async fn list_all_with_provenance_reports_source_identity_failures() {
+        let disabled_source = source_uuid("bbbbbbbb-bbbb-4bbb-bbbb-bbbbbbbbbbbb");
+        let source = InMemorySkillSource::new(vec![test_skill_from_source(
+            disabled_source.clone(),
+            "disabled",
+            "Disabled",
+        )]);
+        let registry = SourceIdentityRegistry::build(
+            vec![source_record(
+                disabled_source.clone(),
+                "disabled fixture",
+                SourceIdentityStatus::Disabled,
+            )],
+            Vec::new(),
+            Vec::new(),
+            Vec::new(),
+        )
+        .unwrap();
+        let engine = DefaultSkillEngine::new(source, vec![])
+            .with_source_identity_registry(Arc::new(registry));
+
+        let err = engine
+            .list_all_with_provenance(&SkillFilter::default())
+            .await
+            .unwrap_err();
+        let message = err.to_string();
+
+        assert!(
+            message.contains("source identity resolution failed"),
+            "provenance listing error must name source identity resolution; got {message}"
+        );
+        assert!(
+            message.contains(&disabled_source.to_string()),
+            "provenance listing error must identify the failing source; got {message}"
+        );
+        assert!(
+            message.contains("Disabled"),
+            "provenance listing error must include the registry status; got {message}"
+        );
+    }
+
+    #[tokio::test]
+    async fn list_skills_preserves_valid_entries_when_another_source_identity_fails() {
+        let active_source = source_uuid("99999999-9999-4999-8999-999999999999");
+        let unknown_source = source_uuid("88888888-8888-4888-8888-888888888888");
+        let source = InMemorySkillSource::new(vec![
+            test_skill_from_source(active_source.clone(), "valid", "Valid"),
+            test_skill_from_source(unknown_source, "orphaned", "Orphaned"),
+        ]);
+        let registry = SourceIdentityRegistry::build(
+            vec![source_record(
+                active_source.clone(),
+                "active fixture",
+                SourceIdentityStatus::Active,
+            )],
+            Vec::new(),
+            Vec::new(),
+            Vec::new(),
+        )
+        .unwrap();
+        let engine = DefaultSkillEngine::new(source, vec![])
+            .with_source_identity_registry(Arc::new(registry));
+
+        let listed = engine.list_skills(&SkillFilter::default()).await.unwrap();
+
+        assert_eq!(listed.len(), 1);
+        assert_eq!(listed[0].key.source_uuid, active_source);
+        assert_eq!(listed[0].key.skill_name.as_str(), "valid");
+    }
+
+    #[tokio::test]
+    async fn list_all_with_provenance_reports_composite_source_identity_failures() {
+        let active_source = source_uuid("cccccccc-cccc-4ccc-8ccc-cccccccccccc");
+        let unknown_source = source_uuid("dddddddd-dddd-4ddd-8ddd-dddddddddddd");
+        let skill = "shadowed";
+        let unknown_key = SkillKey::new(unknown_source.clone(), SkillName::parse(skill).unwrap());
+        let active_named = NamedSource::new(
+            source_record(
+                active_source.clone(),
+                "active fixture",
+                SourceIdentityStatus::Active,
+            ),
+            SourceNode::Memory(InMemorySkillSource::new(vec![test_skill_from_source(
+                active_source.clone(),
+                skill,
+                "Active",
+            )])),
+        );
+        let unknown_named = NamedSource::new(
+            source_record(
+                unknown_source.clone(),
+                "unknown fixture",
+                SourceIdentityStatus::Active,
+            ),
+            SourceNode::Memory(InMemorySkillSource::new(vec![test_skill_from_source(
+                unknown_source,
+                skill,
+                "Unknown",
+            )])),
+        );
+        let registry = SourceIdentityRegistry::build(
+            vec![source_record(
+                active_source,
+                "active fixture",
+                SourceIdentityStatus::Active,
+            )],
+            Vec::new(),
+            Vec::new(),
+            Vec::new(),
+        )
+        .unwrap();
+        let composite = CompositeSkillSource::from_named(vec![active_named, unknown_named]);
+        let engine = DefaultSkillEngine::new(composite, vec![])
+            .with_source_identity_registry(Arc::new(registry));
+
+        let err = engine
+            .list_all_with_provenance(&SkillFilter::default())
+            .await
+            .unwrap_err();
+        let message = err.to_string();
+
+        assert!(
+            message.contains(&unknown_key.to_string()),
+            "composite provenance listing must identify the failing source; got {message}"
+        );
+        assert!(
+            message.contains("source unknown"),
+            "composite provenance listing must include the registry failure; got {message}"
+        );
+    }
+
+    #[tokio::test]
+    async fn direct_load_from_source_reports_source_identity_failures() {
+        let disabled_source = source_uuid("eeeeeeee-eeee-4eee-8eee-eeeeeeeeeeee");
+        let source = InMemorySkillSource::new(vec![test_skill_from_source(
+            disabled_source.clone(),
+            "disabled-load",
+            "Disabled Load",
+        )]);
+        let registry = SourceIdentityRegistry::build(
+            vec![source_record(
+                disabled_source.clone(),
+                "disabled fixture",
+                SourceIdentityStatus::Disabled,
+            )],
+            Vec::new(),
+            Vec::new(),
+            Vec::new(),
+        )
+        .unwrap();
+        let engine = DefaultSkillEngine::new(source, vec![])
+            .with_source_identity_registry(Arc::new(registry));
+        let key = SkillKey::new(
+            disabled_source.clone(),
+            SkillName::parse("disabled-load").unwrap(),
+        );
+
+        let err = engine.load_from_source(&key, None).await.unwrap_err();
+        let message = err.to_string();
+
+        assert!(
+            message.contains("source identity resolution failed"),
+            "direct load error must name source identity resolution; got {message}"
+        );
+        assert!(
+            message.contains(&disabled_source.to_string()),
+            "direct load error must identify the failing source; got {message}"
+        );
     }
 
     #[tokio::test]

--- a/meerkat-skills/src/renderer.rs
+++ b/meerkat-skills/src/renderer.rs
@@ -50,6 +50,14 @@ pub fn render_inventory(
     }
 }
 
+/// Render an explicit inventory failure block for prompt surfaces.
+pub fn render_inventory_failure(message: &str) -> String {
+    format!(
+        "<available_skills state=\"unavailable\">\n  <inventory_failure>{}</inventory_failure>\n</available_skills>",
+        escape_xml(message)
+    )
+}
+
 /// Escape XML-special characters in text content.
 /// Note: O(5n) worst case — five sequential replace() calls, each allocating.
 /// Acceptable for short strings (skill names/descriptions). For large content,
@@ -235,6 +243,16 @@ mod tests {
     fn test_render_inventory_empty() {
         let output = render_inventory(&[], &[], 12);
         assert!(output.is_empty());
+    }
+
+    #[test]
+    fn test_render_inventory_failure_xml() {
+        let output = render_inventory_failure("source identity resolution failed: <bad>");
+
+        assert!(output.starts_with("<available_skills state=\"unavailable\">"));
+        assert!(output.ends_with("</available_skills>"));
+        assert!(output.contains("<inventory_failure>"));
+        assert!(output.contains("&lt;bad&gt;"));
     }
 
     // --- Injection tests ---

--- a/meerkat-tools/src/builtin/skills/browse.rs
+++ b/meerkat-tools/src/builtin/skills/browse.rs
@@ -76,15 +76,17 @@ impl BuiltinTool for BrowseSkillsTool {
 
         let filter = SkillFilter { query, source_uuid };
 
-        let skills = self
+        let entries = self
             .engine
-            .list_skills(&filter)
+            .list_all_with_provenance(&filter)
             .await
             .map_err(|e| BuiltinToolError::ExecutionFailed(e.to_string()))?;
 
-        let skill_values: Vec<Value> = skills
+        let skill_values: Vec<Value> = entries
             .iter()
-            .map(|s| {
+            .filter(|entry| entry.is_active)
+            .map(|entry| {
+                let s = &entry.descriptor;
                 json!({
                     "source_uuid": s.key.source_uuid.to_string(),
                     "skill_name": s.key.skill_name.as_str(),

--- a/meerkat-tools/tests/browse_load_surface.rs
+++ b/meerkat-tools/tests/browse_load_surface.rs
@@ -97,6 +97,19 @@ fn fixture_runtime() -> (Arc<SkillRuntime>, SourceUuid, SourceUuid) {
     (runtime, primary, secondary)
 }
 
+fn runtime_with_unknown_source_identity() -> (Arc<SkillRuntime>, SourceUuid) {
+    let unknown = SourceUuid::parse("aaaaaaaa-aaaa-4aaa-aaaa-aaaaaaaaaaaa").unwrap();
+    let source = InMemorySkillSource::new(vec![skill_doc(
+        &unknown,
+        "orphaned",
+        "Orphaned",
+        "# Orphaned\n\nbody-orphaned",
+    )]);
+    let engine = DefaultSkillEngine::new(source, Vec::new())
+        .with_source_identity_registry(Arc::new(SourceIdentityRegistry::default()));
+    (Arc::new(SkillRuntime::new(Arc::new(engine))), unknown)
+}
+
 #[tokio::test]
 async fn browse_no_filter_returns_all_skills() {
     let (runtime, _primary, _secondary) = fixture_runtime();
@@ -178,6 +191,32 @@ async fn browse_rejects_unparseable_source_uuid() {
             );
         }
         other => panic!("expected ExecutionFailed for bad uuid, got {other:?}"),
+    }
+}
+
+#[tokio::test]
+async fn browse_surfaces_source_identity_registry_failures() {
+    let (runtime, unknown) = runtime_with_unknown_source_identity();
+    let tool = BrowseSkillsTool::new(runtime);
+
+    let err = tool.call(serde_json::json!({})).await.unwrap_err();
+
+    match &err {
+        meerkat_tools::BuiltinToolError::ExecutionFailed(msg) => {
+            assert!(
+                msg.contains("source identity resolution failed"),
+                "browse failure must name source identity resolution; got {msg:?}",
+            );
+            assert!(
+                msg.contains(&unknown.to_string()),
+                "browse failure must identify the failing source; got {msg:?}",
+            );
+            assert!(
+                msg.contains("source unknown"),
+                "browse failure must include the registry failure; got {msg:?}",
+            );
+        }
+        other => panic!("expected ExecutionFailed for source identity failure, got {other:?}"),
     }
 }
 

--- a/meerkat/src/factory.rs
+++ b/meerkat/src/factory.rs
@@ -3067,7 +3067,7 @@ impl AgentFactory {
                     Ok(s) => s,
                     Err(e) => {
                         tracing::warn!("Failed to generate skill inventory section: {e}");
-                        String::new()
+                        meerkat_skills::renderer::render_inventory_failure(&e.to_string())
                     }
                 };
 


### PR DESCRIPTION
## Summary
- fail skill inventory/provenance listings explicitly when source identity resolution fails instead of silently dropping entries
- render a visible unavailable inventory block for prompt surfaces when inventory generation fails
- add focused coverage for registry failures, composite source behavior, direct load paths, and the browse_skills public surface

## Validation
- ./scripts/repo-cargo test -p meerkat-skills
- ./scripts/repo-cargo test -p meerkat-tools browse_surfaces_source_identity_registry_failures
- make check

Linear: LUC-126