### PR TITLE
Remove mob lifecycle clone-probe admission

### DIFF
--- a/meerkat-mob/src/runtime/actor.rs
+++ b/meerkat-mob/src/runtime/actor.rs
@@ -1108,6 +1108,48 @@ impl MobActor {
         Ok(effects)
     }
 
+    fn require_live_lifecycle_phase(
+        &self,
+        required: mob_dsl::MobPhase,
+        target: MobState,
+    ) -> Result<(), MobError> {
+        if self.dsl_authority.state.lifecycle_phase == required {
+            Ok(())
+        } else {
+            Err(MobError::InvalidTransition {
+                from: self.state(),
+                to: target,
+            })
+        }
+    }
+
+    fn require_live_reset_admission(&self) -> Result<(), MobError> {
+        if matches!(
+            self.dsl_authority.state.lifecycle_phase,
+            mob_dsl::MobPhase::Running | mob_dsl::MobPhase::Stopped | mob_dsl::MobPhase::Completed
+        ) {
+            Ok(())
+        } else {
+            Err(MobError::InvalidTransition {
+                from: self.state(),
+                to: MobState::Running,
+            })
+        }
+    }
+
+    fn require_live_stop_admission(&self) -> Result<(), MobError> {
+        if self.dsl_authority.state.lifecycle_phase == mob_dsl::MobPhase::Running
+            && self.dsl_authority.state.active_run_count == 0
+        {
+            Ok(())
+        } else {
+            Err(MobError::InvalidTransition {
+                from: self.state(),
+                to: MobState::Stopped,
+            })
+        }
+    }
+
     fn prepare_dsl_input(
         &self,
         input: mob_dsl::MobMachineInput,
@@ -1795,9 +1837,9 @@ impl MobActor {
 
     /// Probe a DSL input against a clone of current state — returns
     /// `InvalidTransition` if the DSL rejects the input, without
-    /// mutating the live authority. Used as the pre-admission gate for
-    /// simple lifecycle commands whose side effects can only run after the
-    /// target transition is known to be accepted.
+    /// mutating the live authority. This remains only for non-lifecycle
+    /// policy lookahead paths where the shell must avoid staging unrelated
+    /// side effects before a later live admission seam.
     ///
     /// `target` is used purely for the `InvalidTransition` error hint
     /// (the phase the caller is trying to reach). The DSL rejects on the
@@ -3224,9 +3266,7 @@ impl MobActor {
                     let _ = reply_tx.send(binding);
                 }
                 MobCommand::Stop { reply_tx } => {
-                    let result = match self
-                        .probe_mob_machine_input(mob_dsl::MobMachineInput::Stop, MobState::Stopped)
-                    {
+                    let result = match self.require_live_stop_admission() {
                         Ok(()) => {
                             self.fail_all_pending_spawns("mob is stopping").await;
                             self.notify_orchestrator_lifecycle(format!(
@@ -3284,7 +3324,6 @@ impl MobActor {
                                 }
                             }
                             if stop_result.is_err() {
-                                // Restore checkpointer state — mob stays Running.
                                 self.provisioner.rearm_all_checkpointers().await;
                             }
                             stop_result
@@ -3294,10 +3333,9 @@ impl MobActor {
                     let _ = reply_tx.send(result);
                 }
                 MobCommand::ResumeLifecycle { reply_tx } => {
-                    let result = match self.probe_mob_machine_input(
-                        mob_dsl::MobMachineInput::Resume,
-                        MobState::Running,
-                    ) {
+                    let result = match self
+                        .require_live_lifecycle_phase(mob_dsl::MobPhase::Stopped, MobState::Running)
+                    {
                         Ok(()) => {
                             // Re-enable checkpointers cancelled during stop.
                             self.provisioner.rearm_all_checkpointers().await;
@@ -3309,6 +3347,7 @@ impl MobActor {
                                         "resume cleanup failed while stopping mcp servers"
                                     );
                                 }
+                                self.provisioner.cancel_all_checkpointers().await;
                                 Err(error)
                             } else if let Err(error) =
                                 self.ensure_autonomous_runtimes_from_roster().await
@@ -3327,6 +3366,7 @@ impl MobActor {
                                         "resume cleanup failed while stopping mcp servers"
                                     );
                                 }
+                                self.provisioner.cancel_all_checkpointers().await;
                                 Err(error)
                             } else {
                                 let mut resume_result: Result<(), MobError> = Ok(());
@@ -3379,8 +3419,8 @@ impl MobActor {
                     let _ = reply_tx.send(result);
                 }
                 MobCommand::Complete { reply_tx } => {
-                    let result = match self.probe_mob_machine_input(
-                        mob_dsl::MobMachineInput::Complete,
+                    let result = match self.require_live_lifecycle_phase(
+                        mob_dsl::MobPhase::Running,
                         MobState::Completed,
                     ) {
                         Ok(()) => {
@@ -3405,14 +3445,13 @@ impl MobActor {
                     }
                 }
                 MobCommand::Reset { reply_tx } => {
-                    if let Err(error) = self
-                        .probe_mob_machine_input(mob_dsl::MobMachineInput::Reset, MobState::Running)
-                    {
+                    let prior_state = self.state();
+                    if let Err(error) = self.require_live_reset_admission() {
                         let _ = reply_tx.send(Err(error));
                         continue;
                     }
                     self.fail_all_pending_spawns("mob is resetting").await;
-                    let result = self.handle_reset().await;
+                    let result = self.handle_reset(prior_state).await;
                     let _ = reply_tx.send(result);
                 }
                 MobCommand::TaskCreate {
@@ -3728,11 +3767,20 @@ impl MobActor {
         for slot in self.pending_spawns.drain_all() {
             let spawn_ticket = slot.ticket;
             let agent_identity = slot.spawn.agent_identity.clone();
-            self.complete_orchestrator_spawn(
-                Some(spawn_ticket),
-                &agent_identity,
-                "lifecycle transition cleared pending spawn",
-            );
+            let dsl_identity =
+                mob_dsl::AgentIdentity::from_domain(&AgentIdentity::from(agent_identity.as_str()));
+            if self
+                .dsl_authority
+                .state
+                .pending_spawn_sessions
+                .contains_key(&dsl_identity)
+            {
+                self.complete_orchestrator_spawn(
+                    Some(spawn_ticket),
+                    &agent_identity,
+                    "lifecycle transition cleared pending spawn",
+                );
+            }
             self.abort_pending_spawn_slot(&slot, reason).await;
             slot.fail(&format!("spawn canceled for '{agent_identity}': {reason}"));
             tracing::debug!(
@@ -8462,11 +8510,10 @@ impl MobActor {
         }
     }
 
-    async fn handle_reset(&mut self) -> Result<(), MobError> {
+    async fn handle_reset(&mut self, prior_state: MobState) -> Result<(), MobError> {
         self.ensure_pending_spawn_alignment("handle_reset preflight")?;
         self.ensure_flow_tracker_alignment("handle_reset preflight")
             .await?;
-        let prior_state = self.state();
         let was_stopped = prior_state == MobState::Stopped;
         self.cancel_all_flow_tasks().await?;
 
@@ -8538,12 +8585,12 @@ impl MobActor {
             return Err(error);
         }
 
-        // The command handler already probes Reset before the destructive phase.
-        // Once side effects and epoch events have succeeded, realize that same
-        // typed transition as the single authority-owned lifecycle landing. The
-        // ResetToRunning transition owns active/pending run counters and
-        // coordinator binding, so reset does not need shell Stop/Resume or
-        // orchestrator stop/resume choreography.
+        // The command handler already checked Reset's live MobMachine phase
+        // guard before destructive shell work began. Once side effects and
+        // epoch events have succeeded, commit the typed ResetToRunning
+        // transition on the live authority. ResetToRunning owns active/pending
+        // run counters and coordinator binding, so reset does not need shell
+        // Stop/Resume or orchestrator stop/resume choreography.
         self.apply_dsl_input(mob_dsl::MobMachineInput::Reset, "reset_to_running")
             .map_err(|error| {
                 MobError::Internal(format!(

--- a/meerkat-mob/src/runtime/tests.rs
+++ b/meerkat-mob/src/runtime/tests.rs
@@ -5406,6 +5406,51 @@ async fn test_query_string_bootstrap_token_fallback_is_rejected() {
 }
 
 #[tokio::test]
+async fn test_concurrent_terminal_lifecycle_commands_observe_live_state_drift() {
+    let (handle, _service) = create_test_mob(sample_definition_with_mcp_servers()).await;
+
+    let stop = {
+        let handle = handle.clone();
+        tokio::spawn(async move { ("stop", handle.stop().await) })
+    };
+    let complete = {
+        let handle = handle.clone();
+        tokio::spawn(async move { ("complete", handle.complete().await) })
+    };
+
+    let (stop, complete) = tokio::join!(stop, complete);
+    let results = [stop.expect("stop join"), complete.expect("complete join")];
+    let successes = results.iter().filter(|(_, result)| result.is_ok()).count();
+    assert_eq!(
+        successes, 1,
+        "only the first admitted terminal lifecycle command may run shell mechanics: {results:?}"
+    );
+
+    let failed = results
+        .iter()
+        .find_map(|(_, result)| result.as_ref().err())
+        .expect("one command should observe live-state drift");
+    assert!(
+        matches!(failed, MobError::InvalidTransition { .. }),
+        "losing lifecycle command must fail at live admission, got {failed:?}"
+    );
+
+    let state = handle.status().await.expect("status after lifecycle race");
+    assert!(
+        matches!(state, MobState::Stopped | MobState::Completed),
+        "terminal lifecycle race should leave a terminal lifecycle phase, got {state:?}"
+    );
+    assert!(
+        handle
+            .mcp_server_states()
+            .await
+            .values()
+            .all(|running| !*running),
+        "terminal lifecycle shell mechanics should stop mcp servers exactly once"
+    );
+}
+
+#[tokio::test]
 async fn test_lifecycle_updates_mcp_server_states() {
     let (handle, _service) = create_test_mob(sample_definition_with_mcp_servers()).await;
     tokio::time::sleep(std::time::Duration::from_millis(10)).await;
@@ -14286,6 +14331,7 @@ async fn test_stop_fails_pending_spawns_and_cleans_up_provisioned_session() {
     tokio::time::sleep(Duration::from_millis(20)).await;
 
     handle.stop().await.expect("stop should succeed");
+    assert_eq!(handle.status().await.unwrap(), MobState::Stopped);
 
     let spawn_error = pending_spawn
         .await
@@ -15651,6 +15697,44 @@ fn test_flow_cleanup_uses_terminal_projection_not_authority_clone_probe() {
         !body.contains("authorities_expect_completion"),
         "flow cleanup must not infer terminality by probing whether authority signals would be accepted"
     );
+}
+
+#[test]
+fn test_lifecycle_commands_admit_on_live_authority_not_clone_probe() {
+    let source = include_str!("actor.rs");
+    let start = source
+        .find("MobCommand::Stop { reply_tx }")
+        .expect("Stop command arm exists");
+    let end = source[start..]
+        .find("MobCommand::TaskCreate")
+        .expect("TaskCreate command arm follows lifecycle command arms");
+    let lifecycle_arms = &source[start..start + end];
+
+    for command in ["Stop", "ResumeLifecycle", "Complete", "Reset"] {
+        let command_start = lifecycle_arms
+            .find(&format!("MobCommand::{command}"))
+            .unwrap_or_else(|| panic!("{command} command arm exists"));
+        let command_end = [
+            "MobCommand::ResumeLifecycle",
+            "MobCommand::Complete",
+            "MobCommand::Destroy",
+            "MobCommand::Reset",
+            "MobCommand::TaskCreate",
+        ]
+        .into_iter()
+        .filter_map(|marker| {
+            lifecycle_arms[command_start + 1..]
+                .find(marker)
+                .map(|offset| command_start + 1 + offset)
+        })
+        .min()
+        .unwrap_or(lifecycle_arms.len());
+        let arm = &lifecycle_arms[command_start..command_end];
+        assert!(
+            !arm.contains("probe_mob_machine_input"),
+            "{command} lifecycle admission must not be decided by cloned MobMachine probe truth"
+        );
+    }
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- replace stop/resume/complete/reset clone-probe admission with live MobMachine state guards or live authority commit
- keep lifecycle shell mechanics behind live admission and preserve pending-spawn stop/reset behavior
- add regression coverage for clone-probe removal and concurrent lifecycle live-state drift

Linear: LUC-123

## Validation
- ./scripts/repo-cargo test -p meerkat-mob lifecycle --lib
- ./scripts/repo-cargo test -p meerkat-mob reset --lib
- ./scripts/repo-cargo test -p meerkat-mob stop --lib
- ./scripts/repo-cargo test -p meerkat-mob resume --lib
- ./scripts/repo-cargo test -p meerkat-mob complete --lib
- make check (BuildBuddy invocation e6fb02b2-e220-4c1e-ac11-281644acf32e)