### PR TITLE
Reject unknown comms address schemes

### DIFF
--- a/meerkat-comms/src/router.rs
+++ b/meerkat-comms/src/router.rs
@@ -366,7 +366,7 @@ impl Router {
                 }
             })
             .ok_or(SendError::PeerNotFound(dest))?;
-        let addr = PeerAddr::parse(&peer.addr)?;
+        let addr = PeerAddr::parse_legacy_schemeless_tcp(&peer.addr)?;
         let mut envelope = Envelope {
             id: envelope_id,
             from: self.keypair.public_key(),

--- a/meerkat-comms/src/runtime/comms_runtime.rs
+++ b/meerkat-comms/src/runtime/comms_runtime.rs
@@ -126,20 +126,11 @@ fn peer_id_from_pubkey(pubkey: &crate::identity::PubKey) -> meerkat_core::comms:
     crate::router::peer_id_from_pubkey(pubkey)
 }
 
-fn parse_peer_address(raw: &str) -> meerkat_core::comms::PeerAddress {
-    use meerkat_core::comms::{PeerAddress, PeerTransport};
-    if let Some(rest) = raw.strip_prefix("inproc://") {
-        PeerAddress::new(PeerTransport::Inproc, rest)
-    } else if let Some(rest) = raw.strip_prefix("uds://") {
-        PeerAddress::new(PeerTransport::Uds, rest)
-    } else if let Some(rest) = raw.strip_prefix("tcp://") {
-        PeerAddress::new(PeerTransport::Tcp, rest)
-    } else {
-        // Unknown scheme: default to TCP so legacy callers remain addressable.
-        // Wave-C will tighten this into a typed parse error at the ingress
-        // boundary so no unknown-scheme peers enter the directory.
-        PeerAddress::new(PeerTransport::Tcp, raw)
-    }
+fn parse_peer_address_legacy_schemeless_tcp(
+    raw: &str,
+) -> Result<meerkat_core::comms::PeerAddress, String> {
+    meerkat_core::comms::PeerAddress::parse_legacy_schemeless_tcp(raw)
+        .map_err(|err| err.to_string())
 }
 
 /// Build a core-seam [`TrustedPeerDescriptor`] for an inproc peer with a
@@ -992,10 +983,23 @@ impl CoreCommsRuntime for CommsRuntime {
                         return None;
                     }
                 };
+                let address = match parse_peer_address_legacy_schemeless_tcp(&peer.addr) {
+                    Ok(address) => address,
+                    Err(err) => {
+                        tracing::warn!(
+                            peer_name = %peer.name,
+                            peer_id = %peer.pubkey.to_peer_id(),
+                            address = %peer.addr,
+                            error = %err,
+                            "skipping trusted peer with invalid address in snapshot"
+                        );
+                        return None;
+                    }
+                };
                 Some(TrustedPeerDescriptor {
                     peer_id: self.router.peer_id_for_pubkey(&peer.pubkey),
                     name,
-                    address: parse_peer_address(&peer.addr),
+                    address,
                     pubkey: *peer.pubkey.as_bytes(),
                 })
             })
@@ -1744,7 +1748,10 @@ impl CommsRuntime {
     /// Trust truth lives in the router's `Arc<RwLock<TrustedPeers>>`, which
     /// the classified inbox queue and ingress classifier consult directly.
     /// There is no separate inbox-side mirror to keep in sync.
-    pub async fn register_trusted_peer(&self, peer: TrustedPeer) -> Result<(), SendError> {
+    pub async fn register_trusted_peer(&self, mut peer: TrustedPeer) -> Result<(), SendError> {
+        peer.addr = parse_peer_address_legacy_schemeless_tcp(&peer.addr)
+            .map_err(SendError::Validation)?
+            .to_string();
         self.router.add_trusted_peer(peer);
         Ok(())
     }
@@ -1779,7 +1786,13 @@ impl CommsRuntime {
     /// session-backed mob members, where delivery AND reply-routing must
     /// work but the recipient must not appear as an ordinary sendable
     /// peer on user-facing surfaces.
-    pub async fn register_private_trusted_peer(&self, peer: TrustedPeer) -> Result<(), SendError> {
+    pub async fn register_private_trusted_peer(
+        &self,
+        mut peer: TrustedPeer,
+    ) -> Result<(), SendError> {
+        peer.addr = parse_peer_address_legacy_schemeless_tcp(&peer.addr)
+            .map_err(SendError::Validation)?
+            .to_string();
         let pubkey = peer.pubkey;
         self.router.add_trusted_peer(peer);
         self.router.mark_private(pubkey);
@@ -1928,10 +1941,23 @@ impl CommsRuntime {
                         continue;
                     }
                 };
+                let address = match parse_peer_address_legacy_schemeless_tcp(&peer.addr) {
+                    Ok(address) => address,
+                    Err(err) => {
+                        tracing::warn!(
+                            peer_name = %peer.name,
+                            peer_id = %peer_id,
+                            address = %peer.addr,
+                            error = %err,
+                            "skipping trusted peer with invalid address in peer directory"
+                        );
+                        continue;
+                    }
+                };
                 on_peer(ResolvedPeer {
                     name,
                     peer_id,
-                    address: parse_peer_address(&peer.addr),
+                    address,
                     source,
                     meta: peer.meta.clone(),
                 });
@@ -2555,7 +2581,8 @@ mod tests {
         BlobId, BlobPayload, BlobRef, BlobStore, BlobStoreError, SendError,
         comms::{
             InputSource, InputStreamMode, PeerDirectorySource, PeerId, PeerName, PeerReachability,
-            PeerReachabilityReason, PeerRoute, StreamError, StreamScope, TrustedPeerDescriptor,
+            PeerReachabilityReason, PeerRoute, PeerTransport, StreamError, StreamScope,
+            TrustedPeerDescriptor,
         },
         interaction::InteractionId,
         types::{ContentBlock, ImageData, SessionId},
@@ -2568,7 +2595,7 @@ mod tests {
         TrustedPeerDescriptor {
             peer_id: crate::router::peer_id_from_pubkey(&pubkey),
             name: PeerName::new(name.to_string()).expect("valid peer name"),
-            address: parse_peer_address(address),
+            address: parse_peer_address_legacy_schemeless_tcp(address).expect("valid peer address"),
             pubkey: *pubkey.as_bytes(),
         }
     }
@@ -4402,6 +4429,101 @@ mod tests {
         assert!(peer.sendable_kinds.contains(&"peer_response".to_string()));
         assert_eq!(peer.reachability, PeerReachability::Unknown);
         assert_eq!(peer.last_unreachable_reason, None);
+    }
+
+    #[tokio::test]
+    async fn test_core_peers_rejects_unknown_scheme_but_keeps_schemeless_tcp_legacy() {
+        let suffix = Uuid::new_v4().simple().to_string();
+        let runtime_name = format!("runtime-address-parse-{suffix}");
+        let unknown_name = format!("unknown-scheme-{suffix}");
+        let legacy_name = format!("legacy-schemeless-{suffix}");
+        let runtime = CommsRuntime::inproc_only(&runtime_name).unwrap();
+        let unknown_pubkey = Keypair::generate().public_key();
+        let legacy_pubkey = Keypair::generate().public_key();
+
+        {
+            let mut trusted = runtime.trusted_peers.write();
+            trusted.upsert(crate::TrustedPeer {
+                name: unknown_name.clone(),
+                pubkey: unknown_pubkey,
+                addr: "http://127.0.0.1:4200".to_string(),
+                meta: crate::PeerMeta::default(),
+            });
+            trusted.upsert(crate::TrustedPeer {
+                name: legacy_name.clone(),
+                pubkey: legacy_pubkey,
+                addr: "127.0.0.1:4201".to_string(),
+                meta: crate::PeerMeta::default(),
+            });
+        }
+
+        let peers = CoreCommsRuntime::peers(&runtime).await;
+        assert!(
+            peers
+                .iter()
+                .all(|entry| entry.name.as_str() != unknown_name),
+            "unknown-scheme trusted peer must not be advertised as TCP"
+        );
+        let legacy = peers
+            .iter()
+            .find(|entry| entry.name.as_str() == legacy_name)
+            .expect("schemeless legacy TCP peer should remain visible");
+        assert_eq!(legacy.address.transport(), PeerTransport::Tcp);
+        assert_eq!(legacy.address.endpoint(), "127.0.0.1:4201");
+        assert_eq!(legacy.address.to_string(), "tcp://127.0.0.1:4201");
+    }
+
+    #[tokio::test]
+    async fn test_register_trusted_peer_rejects_unknown_scheme_and_normalizes_legacy_tcp() {
+        let suffix = Uuid::new_v4().simple().to_string();
+        let runtime =
+            CommsRuntime::inproc_only(&format!("runtime-register-address-{suffix}")).unwrap();
+        let unknown_name = format!("register-unknown-{suffix}");
+        let legacy_name = format!("register-legacy-{suffix}");
+
+        let err = runtime
+            .register_trusted_peer(crate::TrustedPeer {
+                name: unknown_name.clone(),
+                pubkey: Keypair::generate().public_key(),
+                addr: "http://127.0.0.1:4202".to_string(),
+                meta: crate::PeerMeta::default(),
+            })
+            .await
+            .expect_err("unknown address scheme must be rejected at registration");
+        assert!(
+            matches!(err, SendError::Validation(ref message) if message.contains("unknown peer address transport")),
+            "unexpected error: {err:?}",
+        );
+
+        runtime
+            .register_trusted_peer(crate::TrustedPeer {
+                name: legacy_name.clone(),
+                pubkey: Keypair::generate().public_key(),
+                addr: "127.0.0.1:4203".to_string(),
+                meta: crate::PeerMeta::default(),
+            })
+            .await
+            .expect("schemeless legacy TCP address should register");
+
+        let stored_addr = runtime
+            .trusted_peers
+            .read()
+            .peers
+            .iter()
+            .find(|peer| peer.name == legacy_name)
+            .expect("legacy peer stored")
+            .addr
+            .clone();
+        assert_eq!(stored_addr, "tcp://127.0.0.1:4203");
+        assert!(
+            runtime
+                .trusted_peers
+                .read()
+                .peers
+                .iter()
+                .all(|peer| peer.name != unknown_name),
+            "unknown-scheme peer must not be stored"
+        );
     }
 
     #[tokio::test]

--- a/meerkat-comms/src/transport/mod.rs
+++ b/meerkat-comms/src/transport/mod.rs
@@ -92,6 +92,21 @@ impl PeerAddr {
         }
     }
 
+    /// Parse with the explicit legacy rule that schemeless input is TCP.
+    ///
+    /// Unknown `scheme://...` input still fails closed through [`Self::parse`].
+    pub fn parse_legacy_schemeless_tcp(s: &str) -> Result<Self, TransportError> {
+        if s.contains("://") {
+            return Self::parse(s);
+        }
+        if !s.contains(':') {
+            return Err(TransportError::InvalidAddress(
+                "TCP address must include port (host:port)".to_string(),
+            ));
+        }
+        Ok(PeerAddr::Tcp(s.to_string()))
+    }
+
     /// Check if this is an in-process address.
     pub fn is_inproc(&self) -> bool {
         matches!(self, PeerAddr::Inproc(_))
@@ -241,6 +256,20 @@ mod tests {
     #[test]
     fn test_parse_invalid_addr() {
         let result = PeerAddr::parse("http://example.com");
+        assert!(result.is_err());
+        let err = result.unwrap_err();
+        assert!(err.to_string().contains("unknown scheme"));
+    }
+
+    #[test]
+    fn test_parse_legacy_schemeless_tcp_addr() {
+        let addr = PeerAddr::parse_legacy_schemeless_tcp("localhost:4200").unwrap();
+        match addr {
+            PeerAddr::Tcp(a) => assert_eq!(a, "localhost:4200"),
+            _ => panic!("expected Tcp variant"),
+        }
+
+        let result = PeerAddr::parse_legacy_schemeless_tcp("http://example.com:4200");
         assert!(result.is_err());
         let err = result.unwrap_err();
         assert!(err.to_string().contains("unknown scheme"));

--- a/meerkat-contracts/src/wire/supervisor_bridge.rs
+++ b/meerkat-contracts/src/wire/supervisor_bridge.rs
@@ -399,17 +399,7 @@ impl TryFrom<&BridgePeerSpec> for meerkat_core::comms::TrustedPeerDescriptor {
 }
 
 fn parse_peer_address(raw: &str) -> Result<meerkat_core::comms::PeerAddress, String> {
-    use meerkat_core::comms::{PeerAddress, PeerTransport};
-    let (scheme, endpoint) = raw
-        .split_once("://")
-        .ok_or_else(|| format!("peer address missing transport scheme: {raw}"))?;
-    let transport = match scheme {
-        "inproc" => PeerTransport::Inproc,
-        "uds" => PeerTransport::Uds,
-        "tcp" => PeerTransport::Tcp,
-        other => return Err(format!("unknown peer address transport: {other}")),
-    };
-    Ok(PeerAddress::new(transport, endpoint))
+    meerkat_core::comms::PeerAddress::parse(raw).map_err(|err| err.to_string())
 }
 
 // ---------------------------------------------------------------------------
@@ -781,6 +771,23 @@ mod tests {
             bootstrap_token: "bootstrap-secret".into(),
         });
         assert_command_round_trip(&cmd);
+    }
+
+    #[test]
+    fn bridge_peer_spec_rejects_unknown_address_scheme() {
+        let spec = BridgePeerSpec {
+            name: "member-a".to_string(),
+            peer_id: "aaaaaaaa-0000-4000-8000-000000000001".to_string(),
+            address: "http://127.0.0.1:7000".to_string(),
+            pubkey: [0u8; 32],
+        };
+
+        let err = meerkat_core::comms::TrustedPeerDescriptor::try_from(&spec)
+            .expect_err("supervisor bridge peer specs must fail closed on unknown schemes");
+        assert!(
+            err.contains("unknown peer address transport"),
+            "unexpected error: {err}",
+        );
     }
 
     #[test]

--- a/meerkat-core/src/comms.rs
+++ b/meerkat-core/src/comms.rs
@@ -151,6 +151,15 @@ pub struct PeerAddress {
     pub endpoint: String,
 }
 
+/// Error parsing a typed [`PeerAddress`] from its URI-shaped string form.
+#[derive(Debug, Clone, thiserror::Error, PartialEq, Eq)]
+pub enum PeerAddressParseError {
+    #[error("peer address missing transport scheme: {input}")]
+    MissingTransportScheme { input: String },
+    #[error("unknown peer address transport {scheme:?} in address {input:?}")]
+    UnknownTransport { input: String, scheme: String },
+}
+
 impl PeerAddress {
     pub fn new(transport: PeerTransport, endpoint: impl Into<String>) -> Self {
         Self {
@@ -166,11 +175,78 @@ impl PeerAddress {
     pub fn endpoint(&self) -> &str {
         &self.endpoint
     }
+
+    /// Strictly parse `scheme://endpoint` peer addresses.
+    ///
+    /// Only the currently supported transport schemes are accepted. Unknown
+    /// schemes and schemeless input fail closed so callers cannot silently
+    /// reinterpret address truth as TCP.
+    pub fn parse(raw: impl AsRef<str>) -> Result<Self, PeerAddressParseError> {
+        let raw = raw.as_ref();
+        let (scheme, endpoint) =
+            raw.split_once("://")
+                .ok_or_else(|| PeerAddressParseError::MissingTransportScheme {
+                    input: raw.to_string(),
+                })?;
+        let transport = match scheme {
+            "inproc" => PeerTransport::Inproc,
+            "uds" => PeerTransport::Uds,
+            "tcp" => PeerTransport::Tcp,
+            other => {
+                return Err(PeerAddressParseError::UnknownTransport {
+                    input: raw.to_string(),
+                    scheme: other.to_string(),
+                });
+            }
+        };
+        Ok(Self::new(transport, endpoint))
+    }
+
+    /// Parse with the explicit legacy compatibility rule that schemeless
+    /// addresses are TCP endpoints.
+    ///
+    /// This compatibility path is intentionally separate from [`Self::parse`]:
+    /// it accepts `host:port` as `tcp://host:port`, but still rejects any
+    /// unknown `scheme://...` input.
+    pub fn parse_legacy_schemeless_tcp(
+        raw: impl AsRef<str>,
+    ) -> Result<Self, PeerAddressParseError> {
+        let raw = raw.as_ref();
+        if raw.contains("://") {
+            Self::parse(raw)
+        } else {
+            Ok(Self::new(PeerTransport::Tcp, raw))
+        }
+    }
 }
 
 impl std::fmt::Display for PeerAddress {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}://{}", self.transport.as_scheme(), self.endpoint)
+    }
+}
+
+impl std::str::FromStr for PeerAddress {
+    type Err = PeerAddressParseError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        Self::parse(s)
+    }
+}
+
+impl TryFrom<&str> for PeerAddress {
+    type Error = PeerAddressParseError;
+
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        Self::parse(value)
+    }
+}
+
+impl TryFrom<String> for PeerAddress {
+    type Error = PeerAddressParseError;
+
+    fn try_from(value: String) -> Result<Self, Self::Error> {
+        Self::parse(value)
     }
 }
 
@@ -306,20 +382,11 @@ impl TrustedPeerDescriptor {
         let name = PeerName::new(name).map_err(|e| format!("invalid peer name: {e}"))?;
         let peer_id =
             PeerId::parse(peer_id.as_ref()).map_err(|e| format!("invalid peer_id: {e}"))?;
-        let address_raw = address.as_ref();
-        let (scheme, endpoint) = address_raw
-            .split_once("://")
-            .ok_or_else(|| format!("peer address missing transport scheme: {address_raw}"))?;
-        let transport = match scheme {
-            "inproc" => PeerTransport::Inproc,
-            "uds" => PeerTransport::Uds,
-            "tcp" => PeerTransport::Tcp,
-            other => return Err(format!("unknown peer address transport: {other}")),
-        };
+        let address = PeerAddress::parse(address.as_ref()).map_err(|e| e.to_string())?;
         Ok(Self {
             peer_id,
             name,
-            address: PeerAddress::new(transport, endpoint),
+            address,
             pubkey: [0u8; 32],
         })
     }
@@ -349,20 +416,11 @@ impl TrustedPeerDescriptor {
         address: impl AsRef<str>,
     ) -> Result<Self, String> {
         let name = PeerName::new(name).map_err(|e| format!("invalid peer name: {e}"))?;
-        let address_raw = address.as_ref();
-        let (scheme, endpoint) = address_raw
-            .split_once("://")
-            .ok_or_else(|| format!("peer address missing transport scheme: {address_raw}"))?;
-        let transport = match scheme {
-            "inproc" => PeerTransport::Inproc,
-            "uds" => PeerTransport::Uds,
-            "tcp" => PeerTransport::Tcp,
-            other => return Err(format!("unknown peer address transport: {other}")),
-        };
+        let address = PeerAddress::parse(address.as_ref()).map_err(|e| e.to_string())?;
         Ok(Self {
             peer_id,
             name,
-            address: PeerAddress::new(transport, endpoint),
+            address,
             pubkey: [0u8; 32],
         })
     }
@@ -938,6 +996,62 @@ mod tests {
     fn peer_address_display() {
         let addr = PeerAddress::new(PeerTransport::Tcp, "127.0.0.1:4200");
         assert_eq!(addr.to_string(), "tcp://127.0.0.1:4200");
+    }
+
+    #[test]
+    fn peer_address_parse_round_trips_supported_schemes() {
+        let cases = [
+            ("inproc://agent-a", PeerTransport::Inproc, "agent-a"),
+            (
+                "uds:///tmp/meerkat.sock",
+                PeerTransport::Uds,
+                "/tmp/meerkat.sock",
+            ),
+            ("tcp://127.0.0.1:4200", PeerTransport::Tcp, "127.0.0.1:4200"),
+        ];
+
+        for (raw, transport, endpoint) in cases {
+            let parsed = PeerAddress::parse(raw).expect("supported address parses");
+            assert_eq!(parsed.transport(), transport);
+            assert_eq!(parsed.endpoint(), endpoint);
+            assert_eq!(parsed.to_string(), raw);
+        }
+    }
+
+    #[test]
+    fn peer_address_parse_rejects_unknown_scheme() {
+        let err = PeerAddress::parse("http://127.0.0.1:4200")
+            .expect_err("unknown transport schemes must fail closed");
+        assert!(
+            err.to_string().contains("unknown peer address transport"),
+            "unexpected error: {err}",
+        );
+    }
+
+    #[test]
+    fn peer_address_parse_rejects_schemeless_input() {
+        let err = PeerAddress::parse("127.0.0.1:4200")
+            .expect_err("strict parser requires an address scheme");
+        assert!(
+            err.to_string().contains("missing transport scheme"),
+            "unexpected error: {err}",
+        );
+    }
+
+    #[test]
+    fn peer_address_legacy_schemeless_tcp_is_explicit() {
+        let parsed = PeerAddress::parse_legacy_schemeless_tcp("127.0.0.1:4200")
+            .expect("legacy schemeless TCP input remains explicit");
+        assert_eq!(parsed.transport(), PeerTransport::Tcp);
+        assert_eq!(parsed.endpoint(), "127.0.0.1:4200");
+        assert_eq!(parsed.to_string(), "tcp://127.0.0.1:4200");
+
+        let err = PeerAddress::parse_legacy_schemeless_tcp("http://127.0.0.1:4200")
+            .expect_err("legacy schemeless compatibility must not accept unknown schemes");
+        assert!(
+            err.to_string().contains("unknown peer address transport"),
+            "unexpected error: {err}",
+        );
     }
 
     #[test]

--- a/meerkat-runtime/src/comms_trust_reconcile.rs
+++ b/meerkat-runtime/src/comms_trust_reconcile.rs
@@ -41,9 +41,7 @@ use std::sync::Arc;
 
 use crate::meerkat_machine::dsl::PeerEndpoint;
 use meerkat_core::agent::{CommsCapabilityError, CommsRuntime};
-use meerkat_core::comms::{
-    PeerAddress, PeerId, PeerName, PeerTransport, SendError, TrustedPeerDescriptor,
-};
+use meerkat_core::comms::{PeerAddress, PeerId, PeerName, SendError, TrustedPeerDescriptor};
 
 /// Typed error surfaced by the reconciliation handler.
 #[derive(Debug, thiserror::Error)]
@@ -220,16 +218,7 @@ fn endpoint_to_descriptor(
 }
 
 fn parse_peer_address(raw: &str) -> Result<PeerAddress, String> {
-    let (scheme, endpoint) = raw
-        .split_once("://")
-        .ok_or_else(|| format!("address missing transport scheme: {raw}"))?;
-    let transport = match scheme {
-        "inproc" => PeerTransport::Inproc,
-        "uds" => PeerTransport::Uds,
-        "tcp" => PeerTransport::Tcp,
-        other => return Err(format!("unknown transport `{other}` in address `{raw}`")),
-    };
-    Ok(PeerAddress::new(transport, endpoint))
+    PeerAddress::parse(raw).map_err(|err| err.to_string())
 }
 
 fn descriptor_to_endpoint(
@@ -517,6 +506,27 @@ mod tests {
             matches!(err, CommsTrustReconcileError::InvalidEndpoint { .. }),
             "expected InvalidEndpoint, got {err:?}",
         );
+        assert!(comms.add_calls().is_empty());
+    }
+
+    #[tokio::test]
+    async fn unknown_address_scheme_surfaces_typed_error_without_touching_trust_store() {
+        let comms = Arc::new(RecordingCommsRuntime::default());
+        let reconciler = CommsTrustReconciler::new(comms.clone());
+        let mut bad = endpoint("bad", UUID_A);
+        bad.address = crate::meerkat_machine::dsl::PeerAddress("http://127.0.0.1:4200".into());
+
+        let err = reconciler
+            .reconcile(1, BTreeSet::from([bad]))
+            .await
+            .expect_err("unknown address scheme must surface a typed error");
+        match err {
+            CommsTrustReconcileError::InvalidEndpoint { detail, .. } => assert!(
+                detail.contains("unknown peer address transport"),
+                "unexpected detail: {detail}",
+            ),
+            other => panic!("expected InvalidEndpoint, got {other:?}"),
+        }
         assert!(comms.add_calls().is_empty());
     }
 }


### PR DESCRIPTION
## Summary
- Add canonical strict `PeerAddress` parsing that rejects unknown schemes and schemeless input by default.
- Add explicit legacy schemeless TCP parsing for comms runtime/transport compatibility without accepting unknown `scheme://` inputs.
- Wire core helpers, supervisor bridge parsing, runtime trust reconcile, peer directory snapshots, and trusted-peer registration through fail-closed parsing.

## Validation
- TDD red before implementation: `./scripts/repo-cargo test -p meerkat-core peer_address_parse_round_trips_supported_schemes` failed because the parser API did not exist.
- `./scripts/repo-cargo test -p meerkat-core peer_address`
- `./scripts/repo-cargo test -p meerkat-comms legacy_schemeless`
- `./scripts/repo-cargo test -p meerkat-comms rejects_unknown_scheme`
- `./scripts/repo-cargo test -p meerkat-contracts bridge_peer_spec_rejects_unknown_address_scheme`
- `./scripts/repo-cargo test -p meerkat-runtime unknown_address_scheme_surfaces_typed_error_without_touching_trust_store`
- `make fmt-check`
- `make check` via BuildBuddy invocation `10bf2190-1b25-4c11-9310-2fc419c03884`
- Rebased on updated `origin/main`, reran focused checks, and reran `make check` via BuildBuddy invocation `3bb14969-b467-41b4-aa14-18a5841bc735`

## Review
- Review pass 1: semantic diff review plus `git diff --check`; no blockers found.
- Review pass 2: fallback-pattern search for unknown-scheme TCP defaults plus parser-boundary review; no blockers found.

Linear: LUC-122