### PR TITLE
Route public AgentBuilder through factory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -106,6 +106,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 #### Surface recipes replace RuntimeSessionHost
 - `RuntimeSessionHost` extracted and then replaced with free recipe functions at proper crate boundaries: `wire_runtime_bindings`, `materialize_session`, `configure_peer_ingress`, `default_persistent_executor`.
 
+#### AgentBuilder facade now uses AgentFactory
+- Public `meerkat::AgentBuilder` now routes builds through `AgentFactory::build_agent()` and returns `Result<DynAgent, BuildAgentError>`; use `CoreAgentBuilder` or `StandaloneAgentBuilder` for the older concrete `Agent<C, T, S>` standalone builder contract.
+- Standalone-only direct injections (`provider_tool_defaults`, `compactor`, `memory_store`, `with_turn_state_handle`) now fail loudly on the facade builder instead of being ignored; configure the factory path or use `CoreAgentBuilder` when intentionally owning core loop primitives.
+
 ### Removed
 - **Redb persistence**: All `RedbSessionIndex`, `RedbSessionStore`, and redb-backed storage removed. All persistence is now SQLite (WAL mode) via `SqliteSessionIndex`.
 - Unused MCP runtime ingress helper removed.

--- a/README.md
+++ b/README.md
@@ -281,7 +281,7 @@ let mut agent = AgentBuilder::new()
     .output_schema(OutputSchema::new(triage_schema)?)
     .budget(BudgetLimits::default().with_max_tokens(2000))
     .build(llm, tools, store)
-    .await;
+    .await?;
 
 let result = agent.run(raw_alert_text.into()).await?;
 let output = result.structured_output.ok_or("schema validation returned no output")?;

--- a/docs/guides/comms.mdx
+++ b/docs/guides/comms.mdx
@@ -571,7 +571,7 @@ let comms_manager = CommsManager::new(config)?;
 let agent = AgentBuilder::new()
     .model("claude-sonnet-4-6")
     .build(llm_client, tools, store)
-    .await;
+    .await?;
 
 let mut comms_agent = CommsAgent::new(agent, comms_manager);
 

--- a/docs/quickstart.mdx
+++ b/docs/quickstart.mdx
@@ -67,7 +67,7 @@ Before your first run, set up provider credentials. The fastest path is environm
         .system_prompt("You are a helpful assistant. Be concise in your responses.")
         .max_tokens_per_turn(1024)
         .build(Arc::new(llm), tools, store)
-        .await;
+        .await?;
 
     let result = agent
         .run("What is the capital of France? Answer in one sentence.".into())

--- a/docs/reference/api-reference.mdx
+++ b/docs/reference/api-reference.mdx
@@ -11,7 +11,8 @@ This page is a quick-lookup index. For current session/runtime semantics, see [S
 | Type | Module | Purpose |
 |------|--------|---------|
 | `Agent` | `meerkat_core` | Main agent execution engine |
-| `AgentBuilder` | `meerkat_core` | Builder pattern for agent construction |
+| `AgentBuilder` | `meerkat` | Public facade builder that routes through `AgentFactory` |
+| `CoreAgentBuilder` | `meerkat_core` | Low-level primitive builder for explicit standalone construction |
 | `Session` | `meerkat_core` | Conversation state container |
 | `SessionId` | `meerkat_core` | Unique session identifier (UUIDv7) |
 | `Message` | `meerkat_core` | Conversation message enum (`System`, `SystemNotice`, `User`, `Assistant`, `BlockAssistant`, `ToolResults`, with runtime notices carried through `SystemNotice`) |

--- a/docs/reference/builtin-tools.mdx
+++ b/docs/reference/builtin-tools.mdx
@@ -55,7 +55,7 @@ icon: "wrench"
 | `enable_comms` | `.comms(bool)` | `false` | All comms tools (requires `comms` feature) |
 | `enable_mob` | `.mob(bool)` | `false` | Mob orchestration tools (`mob_*`, `meerkat_*`) |
 
-`AgentFactory` is the only place tool categories are composed. `AgentBuilder` (in `meerkat-core`) has no dependency on `meerkat-tools` and does not auto-register any tools — it takes a pre-built dispatcher. See [AgentBuilder vs AgentFactory](/rust/advanced#agentbuilder-vs-agentfactory).
+`AgentFactory` is the only place tool categories are composed. The public `meerkat::AgentBuilder` delegates to the factory path with explicit client/tool/store overrides. `meerkat::CoreAgentBuilder` is the lower-level `meerkat-core` escape hatch; it has no dependency on `meerkat-tools` and does not auto-register any tools. See [AgentBuilder vs AgentFactory](/rust/advanced#agentbuilder-vs-agentfactory).
 
 **Source:** `meerkat/src/factory.rs` -- `AgentFactory` struct and builder methods.
 </Accordion>

--- a/docs/rust/advanced.mdx
+++ b/docs/rust/advanced.mdx
@@ -20,11 +20,13 @@ recovery-safe background completion handling.
 
 ## AgentBuilder vs AgentFactory
 
-`AgentBuilder` (in `meerkat-core`) wires the agent loop primitives: LLM client, tool dispatcher, and session store. It has no dependency on `meerkat-tools` and no opinions about which tools exist.
+`meerkat::AgentBuilder` is the public facade builder. It accepts explicit client/tool/store overrides for embedded use, then still routes through `AgentFactory::build_agent()` so provider defaults, session metadata, hook wiring, and runtime build-mode defaults stay aligned with the factory path.
 
 `AgentFactory` (in the `meerkat` facade) is the opinionated composition layer. It knows about tool categories, runtime resources, comms, memory, mobs, and skills, and wires them into the dispatcher before passing them to `AgentBuilder`. All public surfaces go through the runtime-backed session path built on top of `AgentFactory`.
 
-**Use `AgentFactory` via `build_persistent_service()` (main path) or `build_ephemeral_service()` (substrate/testing path) unless you explicitly need to bypass session lifecycle orchestration.** Direct `AgentBuilder` usage means you own composition, persistence, event handling, and any drift from the standard runtime-backed path.
+`meerkat::CoreAgentBuilder` is the lower-level `meerkat-core` builder. It is the intentional builder-only escape hatch for tests or embeddings that own every primitive directly and do not want facade-owned provider/auth/session/runtime composition.
+
+**Use `AgentFactory` via `build_persistent_service()` (main path), `build_ephemeral_service()` (substrate/testing path), or the public `meerkat::AgentBuilder` facade unless you explicitly need to bypass session lifecycle orchestration.** Direct `CoreAgentBuilder` usage means you own composition, persistence, event handling, and any drift from the standard runtime-backed path.
 
 If you are building a runtime-backed surface around `SessionService`, avoid the
 old hand-rolled `register_session()` + registry extraction pattern. Prefer the
@@ -34,12 +36,13 @@ binding seam above so the runtime/session owner stays canonical.
 
 <Note>
 For most use cases, prefer `SessionService` via the runtime-backed persistent path (see
-[overview](/rust/overview)). `AgentBuilder` is used internally by `AgentFactory::build_agent()`.
-Direct usage is only needed when bypassing the session service entirely.
+[overview](/rust/overview)). The public `AgentBuilder` delegates to the factory
+pipeline. Use `CoreAgentBuilder` only when bypassing the session service and
+facade composition entirely.
 </Note>
 
 <Warning>
-If you are embedding Meerkat into an application, start with `SessionService`. Reach for `AgentBuilder` only when you deliberately want an expert-only execution API with no runtime-managed session identity.
+If you are embedding Meerkat into an application, start with `SessionService`. Reach for `CoreAgentBuilder` only when you deliberately want an expert-only execution API with no runtime-managed session identity.
 </Warning>
 
 ```rust
@@ -51,7 +54,7 @@ let mut agent = AgentBuilder::new()
     .max_tokens_per_turn(4096)
     .temperature(0.7)
     .build(llm_client, tool_dispatcher, session_store)
-    .await;
+    .await?;
 ```
 
 <Accordion title="All builder methods">

--- a/docs/rust/advanced.mdx
+++ b/docs/rust/advanced.mdx
@@ -26,6 +26,8 @@ recovery-safe background completion handling.
 
 `meerkat::CoreAgentBuilder` is the lower-level `meerkat-core` builder. It is the intentional builder-only escape hatch for tests or embeddings that own every primitive directly and do not want facade-owned provider/auth/session/runtime composition.
 
+`meerkat::StandaloneAgentBuilder` is an alias for `CoreAgentBuilder` for code migrating from the older concrete `Agent<C, T, S>` builder contract. The facade `AgentBuilder::build(...)` now returns `Result<DynAgent, BuildAgentError>` because the factory pipeline may wrap or compose the supplied resources before the agent is runnable.
+
 **Use `AgentFactory` via `build_persistent_service()` (main path), `build_ephemeral_service()` (substrate/testing path), or the public `meerkat::AgentBuilder` facade unless you explicitly need to bypass session lifecycle orchestration.** Direct `CoreAgentBuilder` usage means you own composition, persistence, event handling, and any drift from the standard runtime-backed path.
 
 If you are building a runtime-backed surface around `SessionService`, avoid the
@@ -42,7 +44,7 @@ facade composition entirely.
 </Note>
 
 <Warning>
-If you are embedding Meerkat into an application, start with `SessionService`. Reach for `CoreAgentBuilder` only when you deliberately want an expert-only execution API with no runtime-managed session identity.
+If you are embedding Meerkat into an application, start with `SessionService`. Reach for `CoreAgentBuilder` or `StandaloneAgentBuilder` only when you deliberately want an expert-only execution API with no runtime-managed session identity. Facade `AgentBuilder` rejects direct `provider_tool_defaults`, `compactor`, `memory_store`, and `with_turn_state_handle` injection so those standalone-only behaviors cannot be silently dropped.
 </Warning>
 
 ```rust

--- a/examples/005-streaming-events-rs/main.rs
+++ b/examples/005-streaming-events-rs/main.rs
@@ -44,7 +44,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         .system_prompt("You are a creative writing assistant.")
         .max_tokens_per_turn(1024)
         .build(Arc::new(llm), Arc::new(EmptyToolDispatcher), store)
-        .await;
+        .await?;
 
     // --- Option A: Use the built-in event logger (simplest) ---
     println!("=== Streaming with built-in logger ===\n");

--- a/examples/006-custom-tools-rs/main.rs
+++ b/examples/006-custom-tools-rs/main.rs
@@ -172,7 +172,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         )
         .max_tokens_per_turn(2048)
         .build(Arc::new(llm), Arc::new(WeatherAndConvertDispatcher), store)
-        .await;
+        .await?;
 
     let result = agent
         .run(

--- a/examples/009-budget-and-retry-rs/main.rs
+++ b/examples/009-budget-and-retry-rs/main.rs
@@ -50,7 +50,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         .max_tokens_per_turn(512)
         .budget(budget)
         .build(Arc::new(llm), Arc::new(EmptyToolDispatcher), store.clone())
-        .await;
+        .await?;
 
     let result = agent
         .run("Explain quantum computing in simple terms.".into())
@@ -95,7 +95,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         .max_tokens_per_turn(50)
         .budget(tight_budget)
         .build(Arc::new(llm2), Arc::new(EmptyToolDispatcher), store2)
-        .await;
+        .await?;
 
     match agent2
         .run("Write a 500-word essay about machine learning.".into())

--- a/examples/011-hooks-guardrails-rs/main.rs
+++ b/examples/011-hooks-guardrails-rs/main.rs
@@ -202,7 +202,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         .max_tokens_per_turn(1024)
         .with_hook_engine(hook_engine)
         .build(Arc::new(llm), Arc::new(WeatherDispatcher), store)
-        .await;
+        .await?;
 
     // ── Run the agent with event monitoring ────────────────────────────────
 

--- a/examples/012-skills-loading-rs/main.rs
+++ b/examples/012-skills-loading-rs/main.rs
@@ -243,7 +243,7 @@ You are a security auditor reviewing code for vulnerabilities.
         .max_tokens_per_turn(2048)
         .with_skill_engine(skill_runtime)
         .build(Arc::new(llm), Arc::new(EmptyToolDispatcher), store)
-        .await;
+        .await?;
 
     // ── Step 7: Run the agent with skills ────────────────────────────────────
 

--- a/examples/013-context-compaction-rs/main.rs
+++ b/examples/013-context-compaction-rs/main.rs
@@ -17,7 +17,7 @@
 
 use std::sync::Arc;
 
-use meerkat::{AgentBuilder, AgentEvent, AgentFactory, AnthropicClient, DefaultCompactor};
+use meerkat::{AgentEvent, AgentFactory, AnthropicClient, CoreAgentBuilder, DefaultCompactor};
 use meerkat_core::compact::CompactionConfig;
 use meerkat_store::{JsonlStore, StoreAdapter};
 use meerkat_tools::EmptyToolDispatcher;
@@ -56,8 +56,8 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     println!("Compaction threshold: 2000 tokens (low for demo purposes)");
     println!("Recent turns preserved: 2\n");
 
-    // Build agent with the compactor wired in.
-    let mut agent = AgentBuilder::new()
+    // Build a low-level core agent with the compactor wired in directly.
+    let mut agent = CoreAgentBuilder::new()
         .model("claude-sonnet-4-6")
         .system_prompt(
             "You are a patient tutor. Build on previous conversation context. \
@@ -66,6 +66,9 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         )
         .max_tokens_per_turn(1024)
         .compactor(compactor)
+        .with_turn_state_handle(Arc::new(
+            meerkat_runtime::RuntimeTurnStateHandle::ephemeral(),
+        ))
         .build(Arc::new(llm), Arc::new(EmptyToolDispatcher), store)
         .await;
 

--- a/examples/014-semantic-memory-rs/main.rs
+++ b/examples/014-semantic-memory-rs/main.rs
@@ -8,7 +8,7 @@
 //! - Creates a `SimpleMemoryStore` (in-memory keyword-matching implementation)
 //! - Wraps it in a `MemorySearchDispatcher` to expose the `memory_search` tool
 //! - Composes the memory tool into the agent's tool dispatcher via `ToolGatewayBuilder`
-//! - Wires the memory store into the `AgentBuilder` so compaction can index into it
+//! - Wires the memory store into the `CoreAgentBuilder` so compaction can index into it
 //! - Pre-seeds the memory store with facts (simulating prior compaction indexing)
 //! - Asks the agent to recall those facts using the `memory_search` tool
 //!
@@ -25,7 +25,7 @@
 
 use std::sync::Arc;
 
-use meerkat::{AgentBuilder, AgentFactory, AnthropicClient, ToolGatewayBuilder};
+use meerkat::{AgentFactory, AnthropicClient, CoreAgentBuilder, ToolGatewayBuilder};
 use meerkat_core::memory::{
     MemoryIndexRequest, MemoryIndexScope, MemoryMetadata, MemoryStore as _,
 };
@@ -120,12 +120,12 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     // ── Step 5: Build the agent with memory wired in ─────────────────────────
     //
     // Two things are wired:
-    //   1. `.memory_store()` on AgentBuilder -- so the agent loop can index
+    //   1. `.memory_store()` on CoreAgentBuilder -- so the agent loop can index
     //      discarded messages during compaction
     //   2. The ToolGateway containing MemorySearchDispatcher -- so the agent
     //      can call `memory_search` to retrieve indexed content
 
-    let mut agent = AgentBuilder::new()
+    let mut agent = CoreAgentBuilder::new()
         .model("claude-sonnet-4-6")
         .system_prompt(
             "You are a helpful assistant with access to a semantic memory store.\n\n\
@@ -139,6 +139,9 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         .max_tokens_per_turn(1024)
         .resume_session(memory_session)
         .memory_store(Arc::clone(&memory_store) as Arc<dyn meerkat_core::memory::MemoryStore>)
+        .with_turn_state_handle(Arc::new(
+            meerkat_runtime::RuntimeTurnStateHandle::ephemeral(),
+        ))
         .build(Arc::new(llm), Arc::new(gateway), store)
         .await;
 
@@ -181,7 +184,7 @@ Two implementations:
 
 Wiring in the factory (AgentFactory::build_agent):
   1. Creates HnswMemoryStore from .rkat/memory/ directory
-  2. Passes it to AgentBuilder::memory_store() for compaction indexing
+  2. Passes it to CoreAgentBuilder::memory_store() for compaction indexing
   3. Wraps it in MemorySearchDispatcher for the memory_search tool
   4. Composes into ToolGateway alongside other dispatchers
 

--- a/examples/015-session-persistence-rs/main.rs
+++ b/examples/015-session-persistence-rs/main.rs
@@ -45,7 +45,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         .system_prompt("You are a persistent assistant. You remember across restarts.")
         .max_tokens_per_turn(512)
         .build(Arc::new(llm), Arc::new(EmptyToolDispatcher), adapted_store)
-        .await;
+        .await?;
 
     // Turn 1: Create session
     let result = agent

--- a/examples/020-comms-peer-messaging-rs/main.rs
+++ b/examples/020-comms-peer-messaging-rs/main.rs
@@ -171,7 +171,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
              Use the peers tool to discover available peers, then send messages to them.",
         )
         .build(Arc::new(llm_a), tools_a, store_a)
-        .await;
+        .await?;
 
     let agent_b_inner = AgentBuilder::new()
         .model(&model)
@@ -181,7 +181,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
              acknowledge them and respond thoughtfully.",
         )
         .build(Arc::new(llm_b), tools_b, store_b)
-        .await;
+        .await?;
 
     // Wrap each agent with its CommsManager so inbox messages are
     // automatically injected into the conversation.

--- a/examples/025-full-stack-agent-rs/main.rs
+++ b/examples/025-full-stack-agent-rs/main.rs
@@ -182,7 +182,7 @@ Professional, concise, action-oriented. Always provide next steps.
         .max_tokens_per_turn(2048)
         .budget(budget)
         .build(Arc::new(llm), tools, store)
-        .await;
+        .await?;
 
     // ── 5. Run with event streaming ────────────────────────────────────────
     println!("=== Full-Stack Agent: Production Support ===\n");

--- a/meerkat-comms/src/agent/mod.rs
+++ b/meerkat-comms/src/agent/mod.rs
@@ -30,9 +30,9 @@ use tokio::sync::watch;
 /// Agent wrapper that integrates comms inbox.
 pub struct CommsAgent<C, T, S>
 where
-    C: AgentLlmClient + 'static,
-    T: AgentToolDispatcher + 'static,
-    S: AgentSessionStore + 'static,
+    C: AgentLlmClient + ?Sized + 'static,
+    T: AgentToolDispatcher + ?Sized + 'static,
+    S: AgentSessionStore + ?Sized + 'static,
 {
     agent: Agent<C, T, S>,
     comms_manager: CommsManager,
@@ -40,9 +40,9 @@ where
 
 impl<C, T, S> CommsAgent<C, T, S>
 where
-    C: AgentLlmClient + 'static,
-    T: AgentToolDispatcher + 'static,
-    S: AgentSessionStore + 'static,
+    C: AgentLlmClient + ?Sized + 'static,
+    T: AgentToolDispatcher + ?Sized + 'static,
+    S: AgentSessionStore + ?Sized + 'static,
 {
     pub fn new(agent: Agent<C, T, S>, comms_manager: CommsManager) -> Self {
         Self {

--- a/meerkat/examples/comms_verbose.rs
+++ b/meerkat/examples/comms_verbose.rs
@@ -406,7 +406,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
              Use peers to see available peers.",
         )
         .build(llm_a, tools_a, store.clone())
-        .await;
+        .await?;
     println!("Agent A built with system prompt and comms tools");
 
     let agent_b_inner = AgentBuilder::new()
@@ -416,7 +416,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             "You are Agent B. When you receive messages from other agents, acknowledge them.",
         )
         .build(llm_b, tools_b, store)
-        .await;
+        .await?;
     println!("Agent B built with system prompt and comms tools");
 
     let mut agent_a = CommsAgent::new(agent_a_inner, comms_manager_a);

--- a/meerkat/examples/multi_turn_tools.rs
+++ b/meerkat/examples/multi_turn_tools.rs
@@ -204,7 +204,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         )
         .max_tokens_per_turn(2048)
         .build(Arc::new(llm), tools, store)
-        .await;
+        .await?;
 
     println!("=== Multi-Turn Tool Usage Example ===\n");
 

--- a/meerkat/examples/simple.rs
+++ b/meerkat/examples/simple.rs
@@ -35,7 +35,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         .system_prompt("You are a helpful assistant. Be concise in your responses.")
         .max_tokens_per_turn(1024)
         .build(Arc::new(llm), tools, store)
-        .await;
+        .await?;
 
     let result = agent
         .run("What is the capital of France? Answer in one sentence.".into())

--- a/meerkat/examples/with_tools.rs
+++ b/meerkat/examples/with_tools.rs
@@ -94,7 +94,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         .system_prompt("You are a math assistant. Use the provided tools to perform calculations.")
         .max_tokens_per_turn(1024)
         .build(Arc::new(llm), tools, store)
-        .await;
+        .await?;
 
     let result = agent
         .run("What is 25 + 17, and then multiply the result by 3?".into())

--- a/meerkat/src/agent_builder.rs
+++ b/meerkat/src/agent_builder.rs
@@ -1,0 +1,249 @@
+//! Public facade AgentBuilder.
+//!
+//! The facade builder routes through [`AgentFactory::build_agent`] so public
+//! construction observes the same provider, session metadata, runtime-handle,
+//! hook, and tool/store override semantics as the factory path. The lower-level
+//! core builder remains available as [`crate::CoreAgentBuilder`] for tests and
+//! embeddings that intentionally own all agent loop primitives themselves.
+
+use std::sync::Arc;
+
+use meerkat_client::LlmClient;
+use meerkat_core::{
+    AgentLlmClient, AgentSessionStore, AgentToolDispatcher, BudgetLimits, Config, HookEngine,
+    HookRunOverrides, OutputSchema, Provider, RetryPolicy, RuntimeBuildMode, Session,
+};
+#[cfg(not(target_arch = "wasm32"))]
+use tokio::sync::mpsc;
+#[cfg(target_arch = "wasm32")]
+use tokio_with_wasm::alias::sync::mpsc;
+
+use crate::{AgentBuildConfig, AgentFactory, BuildAgentError, DynAgent};
+
+/// Public builder for creating agents through the canonical facade pipeline.
+pub struct AgentBuilder {
+    factory: AgentFactory,
+    config: Config,
+    build_config: AgentBuildConfig,
+    model_explicit: bool,
+}
+
+impl Default for AgentBuilder {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl AgentBuilder {
+    /// Create a builder with default config and the default user state root.
+    pub fn new() -> Self {
+        let config = Config::default();
+        let model = config.agent.model.clone();
+        let factory = AgentFactory::new(meerkat_core::default_state_root().join("sessions"));
+        Self {
+            factory,
+            config,
+            build_config: AgentBuildConfig::new(model),
+            model_explicit: false,
+        }
+    }
+
+    /// Use a specific factory for store roots, provider registry state, and
+    /// surface resource defaults.
+    pub fn with_factory(mut self, factory: AgentFactory) -> Self {
+        self.factory = factory;
+        self
+    }
+
+    /// Use a specific config snapshot for the factory build.
+    pub fn with_config(mut self, config: Config) -> Self {
+        if !self.model_explicit {
+            self.build_config.model = config.agent.model.clone();
+        }
+        self.config = config;
+        self
+    }
+
+    /// Set the model to use.
+    pub fn model(mut self, model: impl Into<String>) -> Self {
+        self.build_config.model = model.into();
+        self.model_explicit = true;
+        self
+    }
+
+    /// Set an explicit provider instead of resolving from the model registry.
+    pub fn provider(mut self, provider: Provider) -> Self {
+        self.build_config.provider = Some(provider);
+        self
+    }
+
+    /// Set max tokens per turn.
+    pub fn max_tokens_per_turn(mut self, tokens: u32) -> Self {
+        self.build_config.max_tokens = Some(tokens);
+        self
+    }
+
+    /// Set the system prompt.
+    pub fn system_prompt(mut self, prompt: impl Into<String>) -> Self {
+        self.build_config.system_prompt = Some(prompt.into());
+        self
+    }
+
+    /// Set temperature on the config snapshot used by the factory build.
+    pub fn temperature(mut self, temp: f32) -> Self {
+        self.config.agent.temperature = Some(temp);
+        self
+    }
+
+    /// Set budget limits.
+    pub fn budget(mut self, limits: BudgetLimits) -> Self {
+        self.build_config.budget_limits = Some(limits);
+        self
+    }
+
+    /// Set provider-specific parameters.
+    pub fn provider_params(mut self, params: serde_json::Value) -> Self {
+        self.build_config.provider_params = Some(params);
+        self
+    }
+
+    /// Provider-native tool defaults are owned by the factory pipeline.
+    ///
+    /// Public facade builds intentionally derive these defaults from
+    /// `Config.provider_tools` and the model profile. Use `provider_params` for
+    /// explicit per-build provider overrides.
+    pub fn provider_tool_defaults(self, _defaults: serde_json::Value) -> Self {
+        self
+    }
+
+    /// Set retry policy on the config snapshot used by the factory build.
+    pub fn retry_policy(mut self, policy: RetryPolicy) -> Self {
+        self.config.retry.max_retries = policy.max_retries;
+        self.config.retry.initial_delay = policy.initial_delay;
+        self.config.retry.max_delay = policy.max_delay;
+        self.config.retry.multiplier = policy.multiplier;
+        self
+    }
+
+    /// Set output schema for structured output extraction.
+    pub fn output_schema(mut self, schema: OutputSchema) -> Self {
+        self.build_config.output_schema = Some(schema);
+        self
+    }
+
+    /// Set maximum retries for structured output validation.
+    pub fn structured_output_retries(mut self, retries: u32) -> Self {
+        self.build_config.structured_output_retries = retries;
+        self
+    }
+
+    /// Resume from an existing session.
+    pub fn resume_session(mut self, session: Session) -> Self {
+        self.build_config.resume_session = Some(session);
+        self
+    }
+
+    /// Set run-scoped hook overrides.
+    pub fn with_hook_run_overrides(mut self, overrides: HookRunOverrides) -> Self {
+        self.build_config.hooks_override = overrides;
+        self
+    }
+
+    /// Set a pre-built hook engine.
+    pub fn with_hook_engine(mut self, hook_engine: Arc<dyn HookEngine>) -> Self {
+        self.build_config.hook_engine_override = Some(hook_engine);
+        self
+    }
+
+    /// Set a pre-built skill runtime.
+    pub fn with_skill_engine(mut self, engine: Arc<meerkat_core::skills::SkillRuntime>) -> Self {
+        self.build_config.skill_engine_override = Some(engine);
+        self
+    }
+
+    /// Set the runtime build mode used by the factory.
+    pub fn runtime_build_mode(mut self, mode: RuntimeBuildMode) -> Self {
+        self.build_config.runtime_build_mode = mode;
+        self
+    }
+
+    /// Set an LLM client override and build through the factory.
+    pub fn llm_client(mut self, client: Arc<dyn LlmClient>) -> Self {
+        self.build_config.llm_client_override = Some(client);
+        self
+    }
+
+    /// Set a tool dispatcher override and build through the factory.
+    pub fn tools(mut self, tools: Arc<dyn AgentToolDispatcher>) -> Self {
+        self.build_config.tool_dispatcher_override = Some(tools);
+        self
+    }
+
+    /// Set a session store override and build through the factory.
+    pub fn session_store(mut self, store: Arc<dyn AgentSessionStore>) -> Self {
+        self.build_config.session_store_override = Some(store);
+        self
+    }
+
+    /// Set a default event channel used when run methods are called without
+    /// per-call event channels.
+    pub fn with_default_event_tx(
+        mut self,
+        event_tx: mpsc::Sender<meerkat_core::AgentEvent>,
+    ) -> Self {
+        self.build_config.event_tx = Some(event_tx);
+        self
+    }
+
+    /// Set a context compactor.
+    ///
+    /// This is intentionally a builder-only core escape hatch. Facade builds
+    /// route compaction through the factory/config pipeline; use
+    /// [`crate::CoreAgentBuilder`] when a test or embedding must inject a
+    /// bespoke compactor directly into the core agent loop.
+    pub fn compactor(self, _compactor: Arc<dyn meerkat_core::compact::Compactor>) -> Self {
+        self
+    }
+
+    /// Set the memory store for indexing compaction discards.
+    ///
+    /// This direct core-loop injection is intentionally not a facade authority;
+    /// the factory owns memory tool/session composition. Use
+    /// [`crate::CoreAgentBuilder`] for low-level standalone tests.
+    pub fn memory_store(self, _store: Arc<dyn meerkat_core::memory::MemoryStore>) -> Self {
+        self
+    }
+
+    /// Runtime-backed turn-state handles are owned by the factory runtime mode.
+    ///
+    /// The facade builder keeps this method as a compatibility no-op for older
+    /// direct-builder tests. Use `runtime_build_mode` to supply session-owned
+    /// runtime bindings.
+    pub fn with_turn_state_handle(self, _handle: Arc<dyn meerkat_core::TurnStateHandle>) -> Self {
+        self
+    }
+
+    /// Build an agent from already-created low-level client/tool/store parts.
+    ///
+    /// The supplied resources are treated as explicit overrides, then the build
+    /// still routes through [`AgentFactory::build_agent`] for shared session,
+    /// provider, runtime, hook, and metadata semantics.
+    pub async fn build(
+        mut self,
+        client: Arc<dyn AgentLlmClient>,
+        tools: Arc<dyn AgentToolDispatcher>,
+        store: Arc<dyn AgentSessionStore>,
+    ) -> Result<DynAgent, BuildAgentError> {
+        self.build_config.agent_llm_client_override = Some(client);
+        self.build_config.tool_dispatcher_override = Some(tools);
+        self.build_config.session_store_override = Some(store);
+        self.try_build().await
+    }
+
+    /// Build an agent using the factory resources already set on this builder.
+    pub async fn try_build(self) -> Result<DynAgent, BuildAgentError> {
+        self.factory
+            .build_agent(self.build_config, &self.config)
+            .await
+    }
+}

--- a/meerkat/src/agent_builder.rs
+++ b/meerkat/src/agent_builder.rs
@@ -26,6 +26,7 @@ pub struct AgentBuilder {
     config: Config,
     build_config: AgentBuildConfig,
     model_explicit: bool,
+    unsupported_core_injections: Vec<&'static str>,
 }
 
 impl Default for AgentBuilder {
@@ -45,6 +46,7 @@ impl AgentBuilder {
             config,
             build_config: AgentBuildConfig::new(model),
             model_explicit: false,
+            unsupported_core_injections: Vec::new(),
         }
     }
 
@@ -111,8 +113,12 @@ impl AgentBuilder {
     ///
     /// Public facade builds intentionally derive these defaults from
     /// `Config.provider_tools` and the model profile. Use `provider_params` for
-    /// explicit per-build provider overrides.
-    pub fn provider_tool_defaults(self, _defaults: serde_json::Value) -> Self {
+    /// explicit per-build provider overrides. Calling this standalone-only
+    /// injection method makes `try_build` return a configuration error instead
+    /// of silently dropping the supplied defaults.
+    pub fn provider_tool_defaults(mut self, _defaults: serde_json::Value) -> Self {
+        self.unsupported_core_injections
+            .push("provider_tool_defaults");
         self
     }
 
@@ -200,8 +206,10 @@ impl AgentBuilder {
     /// This is intentionally a builder-only core escape hatch. Facade builds
     /// route compaction through the factory/config pipeline; use
     /// [`crate::CoreAgentBuilder`] when a test or embedding must inject a
-    /// bespoke compactor directly into the core agent loop.
-    pub fn compactor(self, _compactor: Arc<dyn meerkat_core::compact::Compactor>) -> Self {
+    /// bespoke compactor directly into the core agent loop. Calling this on the
+    /// facade builder makes `try_build` return a configuration error.
+    pub fn compactor(mut self, _compactor: Arc<dyn meerkat_core::compact::Compactor>) -> Self {
+        self.unsupported_core_injections.push("compactor");
         self
     }
 
@@ -209,17 +217,24 @@ impl AgentBuilder {
     ///
     /// This direct core-loop injection is intentionally not a facade authority;
     /// the factory owns memory tool/session composition. Use
-    /// [`crate::CoreAgentBuilder`] for low-level standalone tests.
-    pub fn memory_store(self, _store: Arc<dyn meerkat_core::memory::MemoryStore>) -> Self {
+    /// [`crate::CoreAgentBuilder`] for low-level standalone tests. Calling this
+    /// on the facade builder makes `try_build` return a configuration error.
+    pub fn memory_store(mut self, _store: Arc<dyn meerkat_core::memory::MemoryStore>) -> Self {
+        self.unsupported_core_injections.push("memory_store");
         self
     }
 
     /// Runtime-backed turn-state handles are owned by the factory runtime mode.
     ///
-    /// The facade builder keeps this method as a compatibility no-op for older
-    /// direct-builder tests. Use `runtime_build_mode` to supply session-owned
-    /// runtime bindings.
-    pub fn with_turn_state_handle(self, _handle: Arc<dyn meerkat_core::TurnStateHandle>) -> Self {
+    /// Use `runtime_build_mode` to supply session-owned runtime bindings.
+    /// Calling this standalone-only injection method makes `try_build` return a
+    /// configuration error instead of silently dropping the supplied handle.
+    pub fn with_turn_state_handle(
+        mut self,
+        _handle: Arc<dyn meerkat_core::TurnStateHandle>,
+    ) -> Self {
+        self.unsupported_core_injections
+            .push("with_turn_state_handle");
         self
     }
 
@@ -234,6 +249,9 @@ impl AgentBuilder {
         tools: Arc<dyn AgentToolDispatcher>,
         store: Arc<dyn AgentSessionStore>,
     ) -> Result<DynAgent, BuildAgentError> {
+        if !self.model_explicit {
+            self.build_config.model = client.model().to_string();
+        }
         self.build_config.agent_llm_client_override = Some(client);
         self.build_config.tool_dispatcher_override = Some(tools);
         self.build_config.session_store_override = Some(store);
@@ -242,6 +260,16 @@ impl AgentBuilder {
 
     /// Build an agent using the factory resources already set on this builder.
     pub async fn try_build(self) -> Result<DynAgent, BuildAgentError> {
+        if !self.unsupported_core_injections.is_empty() {
+            return Err(BuildAgentError::Config(format!(
+                "public AgentBuilder cannot accept standalone core injection method(s): {}. \
+                 Facade builds route through AgentFactory-owned provider/session/runtime \
+                 composition; use AgentFactory/AgentBuildConfig for facade-owned settings or \
+                 CoreAgentBuilder for explicit standalone construction.",
+                self.unsupported_core_injections.join(", ")
+            )));
+        }
+
         self.factory
             .build_agent(self.build_config, &self.config)
             .await

--- a/meerkat/src/agent_builder.rs
+++ b/meerkat/src/agent_builder.rs
@@ -6,7 +6,7 @@
 //! core builder remains available as [`crate::CoreAgentBuilder`] for tests and
 //! embeddings that intentionally own all agent loop primitives themselves.
 
-use std::sync::Arc;
+use std::{future::Future, pin::Pin, sync::Arc};
 
 use meerkat_client::LlmClient;
 use meerkat_core::{
@@ -19,6 +19,12 @@ use tokio::sync::mpsc;
 use tokio_with_wasm::alias::sync::mpsc;
 
 use crate::{AgentBuildConfig, AgentFactory, BuildAgentError, DynAgent};
+
+#[cfg(not(target_arch = "wasm32"))]
+pub type AgentBuilderBuildFuture =
+    Pin<Box<dyn Future<Output = Result<DynAgent, BuildAgentError>> + Send>>;
+#[cfg(target_arch = "wasm32")]
+pub type AgentBuilderBuildFuture = Pin<Box<dyn Future<Output = Result<DynAgent, BuildAgentError>>>>;
 
 /// Public builder for creating agents through the canonical facade pipeline.
 pub struct AgentBuilder {
@@ -243,19 +249,21 @@ impl AgentBuilder {
     /// The supplied resources are treated as explicit overrides, then the build
     /// still routes through [`AgentFactory::build_agent`] for shared session,
     /// provider, runtime, hook, and metadata semantics.
-    pub async fn build(
+    pub fn build(
         mut self,
         client: Arc<dyn AgentLlmClient>,
         tools: Arc<dyn AgentToolDispatcher>,
         store: Arc<dyn AgentSessionStore>,
-    ) -> Result<DynAgent, BuildAgentError> {
-        if !self.model_explicit {
-            self.build_config.model = client.model().to_string();
-        }
-        self.build_config.agent_llm_client_override = Some(client);
-        self.build_config.tool_dispatcher_override = Some(tools);
-        self.build_config.session_store_override = Some(store);
-        self.try_build().await
+    ) -> AgentBuilderBuildFuture {
+        Box::pin(async move {
+            if !self.model_explicit {
+                self.build_config.model = client.model().to_string();
+            }
+            self.build_config.agent_llm_client_override = Some(client);
+            self.build_config.tool_dispatcher_override = Some(tools);
+            self.build_config.session_store_override = Some(store);
+            self.try_build().await
+        })
     }
 
     /// Build an agent using the factory resources already set on this builder.

--- a/meerkat/src/factory.rs
+++ b/meerkat/src/factory.rs
@@ -1910,6 +1910,9 @@ impl AgentFactory {
         if let Some(client) = build_config.llm_client_override.as_ref() {
             return Ok((Provider::from_name(client.provider()), None));
         }
+        if let Some(client) = build_config.agent_llm_client_override.as_ref() {
+            return Ok((Provider::from_name(client.provider()), None));
+        }
 
         Err(BuildAgentError::UnknownProvider {
             model: build_config.model.clone(),

--- a/meerkat/src/factory.rs
+++ b/meerkat/src/factory.rs
@@ -216,6 +216,13 @@ pub struct AgentBuildConfig {
     pub event_tx: Option<mpsc::Sender<AgentEvent>>,
     /// Override LLM client (for testing or embedding).
     pub llm_client_override: Option<Arc<dyn LlmClient>>,
+    /// Override pre-adapted low-level agent LLM client.
+    ///
+    /// This preserves full `AssistantBlock` output for compatibility surfaces
+    /// that already own the core agent client, while the surrounding factory
+    /// still owns provider defaults, hooks, session metadata, and runtime
+    /// setup.
+    pub agent_llm_client_override: Option<Arc<dyn AgentLlmClient>>,
     /// Provider-specific parameters (e.g., thinking config, reasoning effort).
     pub provider_params: Option<serde_json::Value>,
     /// External tool dispatcher to compose with builtins (e.g., MCP callback tools).
@@ -370,6 +377,10 @@ impl std::fmt::Debug for AgentBuildConfig {
             .field("budget_limits", &self.budget_limits)
             .field("event_tx", &self.event_tx.is_some())
             .field("llm_client_override", &self.llm_client_override.is_some())
+            .field(
+                "agent_llm_client_override",
+                &self.agent_llm_client_override.is_some(),
+            )
             .field("provider_params", &self.provider_params.is_some())
             .field("external_tools", &self.external_tools.is_some())
             .field("recoverable_tool_defs", &self.recoverable_tool_defs)
@@ -441,6 +452,7 @@ impl AgentBuildConfig {
             budget_limits: None,
             event_tx: None,
             llm_client_override: None,
+            agent_llm_client_override: None,
             provider_params: None,
             external_tools: None,
             recoverable_tool_defs: None,
@@ -2255,168 +2267,176 @@ impl AgentFactory {
         let mut auto_image_generation_executor: Option<
             Arc<dyn meerkat_llm_core::ImageGenerationExecutor>,
         > = None;
-        let llm_client: Arc<dyn LlmClient> = match build_config.llm_client_override.as_ref() {
-            Some(client) => Arc::clone(client),
-            None if std::env::var("RKAT_TEST_CLIENT").ok().as_deref() == Some("1") => {
-                // Test shim: when RKAT_TEST_CLIENT=1 is set by integration
-                // tests, short-circuit to an in-process TestClient so tests
-                // don't need real provider credentials.
-                Arc::new(meerkat_client::TestClient::default())
-            }
-            None => {
-                // Self-hosted routes through the legacy path until it's
-                // folded into the backend-kind taxonomy.
-                if matches!(provider, Provider::SelfHosted) && build_config.connection_ref.is_none()
-                {
-                    self.build_self_hosted_client_from_registry(
-                        &registry,
-                        &SessionLlmIdentity {
-                            model: build_config.model.clone(),
-                            provider,
-                            self_hosted_server_id: self_hosted_server_id.clone(),
-                            provider_params: build_config.provider_params.clone(),
-                            connection_ref: None,
-                        },
-                    )
-                    .map_err(BuildAgentError::LlmClient)?
-                } else {
-                    let (realm, _binding_id, resolved_connection_ref) =
-                        Self::resolve_realm_binding_for_provider(
-                            config,
-                            provider,
-                            build_config.connection_ref.as_ref(),
-                            build_config.realm_id.as_deref(),
+        let llm_client: Option<Arc<dyn LlmClient>> = if build_config
+            .agent_llm_client_override
+            .is_some()
+        {
+            None
+        } else {
+            Some(match build_config.llm_client_override.as_ref() {
+                Some(client) => Arc::clone(client),
+                None if std::env::var("RKAT_TEST_CLIENT").ok().as_deref() == Some("1") => {
+                    // Test shim: when RKAT_TEST_CLIENT=1 is set by integration
+                    // tests, short-circuit to an in-process TestClient so tests
+                    // don't need real provider credentials.
+                    Arc::new(meerkat_client::TestClient::default())
+                }
+                None => {
+                    // Self-hosted routes through the legacy path until it's
+                    // folded into the backend-kind taxonomy.
+                    if matches!(provider, Provider::SelfHosted)
+                        && build_config.connection_ref.is_none()
+                    {
+                        self.build_self_hosted_client_from_registry(
+                            &registry,
+                            &SessionLlmIdentity {
+                                model: build_config.model.clone(),
+                                provider,
+                                self_hosted_server_id: self_hosted_server_id.clone(),
+                                provider_params: build_config.provider_params.clone(),
+                                connection_ref: None,
+                            },
                         )
-                        .map_err(BuildAgentError::ConnectionResolution)?;
-                    if resolved_connection_ref.is_env_default()
-                        && build_config
-                            .connection_ref
-                            .as_ref()
-                            .map(ConnectionRef::is_env_default)
-                            .unwrap_or(true)
-                    {
-                        build_config.connection_ref = None;
+                        .map_err(BuildAgentError::LlmClient)?
                     } else {
-                        build_config.connection_ref = Some(resolved_connection_ref.clone());
-                    }
-
-                    // Provider-runtime registry needs the OAuth-backed
-                    // TokenStore attached so persisted tokens (written by
-                    // `rkat auth login`, server-side OAuth completion, etc.)
-                    // are read during resolve_binding.
-                    #[allow(unused_mut)]
-                    let mut env = meerkat_providers::ResolverEnvironment::with_process_env();
-                    #[cfg(not(target_arch = "wasm32"))]
-                    {
-                        if let Some(store) = self.token_store.clone() {
-                            env = env.with_token_store(store);
-                        }
-                        if let Some(coord) = self.refresh_coord.clone() {
-                            env = env.with_refresh_coordinator(coord);
-                        }
-                    }
-                    if let RuntimeBuildMode::SessionOwned(bindings) =
-                        &build_config.runtime_build_mode
-                    {
-                        env = env.with_auth_lease_handle(Arc::clone(&bindings.auth_lease));
-                    }
-                    for (handle, resolver) in &self.external_auth_resolvers {
-                        env = env.with_external_resolver(handle.clone(), resolver.clone());
-                    }
-                    let provider_registry = Arc::clone(&self.provider_registry);
-                    let connection = provider_registry
-                        .resolve(&realm, &resolved_connection_ref, &env)
-                        .await
-                        .map_err(|e| BuildAgentError::ConnectionResolution(e.to_string()))?;
-                    provider = connection.provider;
-                    #[cfg(not(target_arch = "wasm32"))]
-                    {
-                        let selected_realm = build_config.realm_id.as_deref();
-                        let connection_is_in_selected_realm = selected_realm
-                            .map(|realm| resolved_connection_ref.realm.as_str() == realm)
-                            .unwrap_or(true);
-                        if connection_is_in_selected_realm {
-                            auto_image_generation_executor = provider_registry
-                                .build_image_generation_executor(connection.clone())
-                                .map_err(|e| {
-                                    BuildAgentError::ConnectionResolution(e.to_string())
-                                })?;
+                        let (realm, _binding_id, resolved_connection_ref) =
+                            Self::resolve_realm_binding_for_provider(
+                                config,
+                                provider,
+                                build_config.connection_ref.as_ref(),
+                                build_config.realm_id.as_deref(),
+                            )
+                            .map_err(BuildAgentError::ConnectionResolution)?;
+                        if resolved_connection_ref.is_env_default()
+                            && build_config
+                                .connection_ref
+                                .as_ref()
+                                .map(ConnectionRef::is_env_default)
+                                .unwrap_or(true)
+                        {
+                            build_config.connection_ref = None;
                         } else {
-                            tracing::debug!(
-                                provider = provider.as_str(),
-                                ?selected_realm,
-                                resolved_realm = resolved_connection_ref.realm.as_str(),
-                                "skipping image executor reuse for LLM connection outside selected realm"
-                            );
+                            build_config.connection_ref = Some(resolved_connection_ref.clone());
                         }
-                    }
 
-                    // Phase 1.5-rev loop closure — refresh-loop middle:
-                    // The DSL tracks per-binding auth lifecycle state.
-                    // On successful resolve, record the lease's expiry
-                    // in the DSL so the runner's CallingLlm arm can
-                    // observe `valid` / `expiring` / `reauth_required`
-                    // states for this binding. Connects the resolver
-                    // side to the state the agent runner consults.
-                    if let RuntimeBuildMode::SessionOwned(bindings) =
-                        &build_config.runtime_build_mode
-                    {
-                        let lease_key = meerkat_core::handles::LeaseKey::from_connection_ref(
-                            &resolved_connection_ref,
-                        );
-                        let expires_at = connection
-                            .auth_lease
-                            .expires_at()
-                            .map(|ts| ts.timestamp().max(0) as u64)
-                            .unwrap_or(u64::MAX);
-                        // Ignore result: the DSL may reject if an earlier
-                        // hot-swap already transitioned this binding; the
-                        // lease state is orthogonal to error semantics.
-                        let _ = bindings.auth_lease.acquire_lease(&lease_key, expires_at);
-                    }
+                        // Provider-runtime registry needs the OAuth-backed
+                        // TokenStore attached so persisted tokens (written by
+                        // `rkat auth login`, server-side OAuth completion, etc.)
+                        // are read during resolve_binding.
+                        #[allow(unused_mut)]
+                        let mut env = meerkat_providers::ResolverEnvironment::with_process_env();
+                        #[cfg(not(target_arch = "wasm32"))]
+                        {
+                            if let Some(store) = self.token_store.clone() {
+                                env = env.with_token_store(store);
+                            }
+                            if let Some(coord) = self.refresh_coord.clone() {
+                                env = env.with_refresh_coordinator(coord);
+                            }
+                        }
+                        if let RuntimeBuildMode::SessionOwned(bindings) =
+                            &build_config.runtime_build_mode
+                        {
+                            env = env.with_auth_lease_handle(Arc::clone(&bindings.auth_lease));
+                        }
+                        for (handle, resolver) in &self.external_auth_resolvers {
+                            env = env.with_external_resolver(handle.clone(), resolver.clone());
+                        }
+                        let provider_registry = Arc::clone(&self.provider_registry);
+                        let connection = provider_registry
+                            .resolve(&realm, &resolved_connection_ref, &env)
+                            .await
+                            .map_err(|e| BuildAgentError::ConnectionResolution(e.to_string()))?;
+                        provider = connection.provider;
+                        #[cfg(not(target_arch = "wasm32"))]
+                        {
+                            let selected_realm = build_config.realm_id.as_deref();
+                            let connection_is_in_selected_realm = selected_realm
+                                .map(|realm| resolved_connection_ref.realm.as_str() == realm)
+                                .unwrap_or(true);
+                            if connection_is_in_selected_realm {
+                                auto_image_generation_executor = provider_registry
+                                    .build_image_generation_executor(connection.clone())
+                                    .map_err(|e| {
+                                        BuildAgentError::ConnectionResolution(e.to_string())
+                                    })?;
+                            } else {
+                                tracing::debug!(
+                                    provider = provider.as_str(),
+                                    ?selected_realm,
+                                    resolved_realm = resolved_connection_ref.realm.as_str(),
+                                    "skipping image executor reuse for LLM connection outside selected realm"
+                                );
+                            }
+                        }
 
-                    // Realtime-capable OpenAI models (e.g. gpt-realtime-1.5)
-                    // cannot go through the Responses API — POST /v1/responses
-                    // returns 404 model_not_found. Route those through the
-                    // OpenAI Realtime WebSocket via `OpenAiRealtimeTextAdapter`.
-                    // Capability-driven routing owns this decision at the
-                    // composition seam (dogma §9).
-                    let realtime_route = matches!(provider, Provider::OpenAI)
-                        && is_openai_realtime_capable(&build_config.model);
-                    #[cfg(not(feature = "openai-realtime"))]
-                    if realtime_route {
-                        return Err(BuildAgentError::ConnectionResolution(format!(
-                            "model '{}' advertises ModelCapabilities.realtime=true; \
+                        // Phase 1.5-rev loop closure — refresh-loop middle:
+                        // The DSL tracks per-binding auth lifecycle state.
+                        // On successful resolve, record the lease's expiry
+                        // in the DSL so the runner's CallingLlm arm can
+                        // observe `valid` / `expiring` / `reauth_required`
+                        // states for this binding. Connects the resolver
+                        // side to the state the agent runner consults.
+                        if let RuntimeBuildMode::SessionOwned(bindings) =
+                            &build_config.runtime_build_mode
+                        {
+                            let lease_key = meerkat_core::handles::LeaseKey::from_connection_ref(
+                                &resolved_connection_ref,
+                            );
+                            let expires_at = connection
+                                .auth_lease
+                                .expires_at()
+                                .map(|ts| ts.timestamp().max(0) as u64)
+                                .unwrap_or(u64::MAX);
+                            // Ignore result: the DSL may reject if an earlier
+                            // hot-swap already transitioned this binding; the
+                            // lease state is orthogonal to error semantics.
+                            let _ = bindings.auth_lease.acquire_lease(&lease_key, expires_at);
+                        }
+
+                        // Realtime-capable OpenAI models (e.g. gpt-realtime-1.5)
+                        // cannot go through the Responses API — POST /v1/responses
+                        // returns 404 model_not_found. Route those through the
+                        // OpenAI Realtime WebSocket via `OpenAiRealtimeTextAdapter`.
+                        // Capability-driven routing owns this decision at the
+                        // composition seam (dogma §9).
+                        let realtime_route = matches!(provider, Provider::OpenAI)
+                            && is_openai_realtime_capable(&build_config.model);
+                        #[cfg(not(feature = "openai-realtime"))]
+                        if realtime_route {
+                            return Err(BuildAgentError::ConnectionResolution(format!(
+                                "model '{}' advertises ModelCapabilities.realtime=true; \
                              the meerkat facade must be built with the \
                              `openai-realtime` feature to route text turns over the \
                              Realtime WebSocket",
-                            build_config.model
-                        )));
-                    }
-                    #[cfg(feature = "openai-realtime")]
-                    if realtime_route {
-                        let secret = connection.resolved_secret().ok_or_else(|| {
-                            BuildAgentError::ConnectionResolution(
-                                "openai realtime text adapter requires an inline API key (\
+                                build_config.model
+                            )));
+                        }
+                        #[cfg(feature = "openai-realtime")]
+                        if realtime_route {
+                            let secret = connection.resolved_secret().ok_or_else(|| {
+                                BuildAgentError::ConnectionResolution(
+                                    "openai realtime text adapter requires an inline API key (\
                                  dynamic authorizers for realtime WS are not yet supported)"
-                                    .to_string(),
-                            )
-                        })?;
-                        Arc::new(meerkat_openai::OpenAiRealtimeTextAdapter::new(secret))
-                            as Arc<dyn LlmClient>
-                    } else {
-                        provider_registry
-                            .build_client(connection)
-                            .map_err(|e| BuildAgentError::ConnectionResolution(e.to_string()))?
-                    }
-                    #[cfg(not(feature = "openai-realtime"))]
-                    {
-                        provider_registry
-                            .build_client(connection)
-                            .map_err(|e| BuildAgentError::ConnectionResolution(e.to_string()))?
+                                        .to_string(),
+                                )
+                            })?;
+                            Arc::new(meerkat_openai::OpenAiRealtimeTextAdapter::new(secret))
+                                as Arc<dyn LlmClient>
+                        } else {
+                            provider_registry
+                                .build_client(connection)
+                                .map_err(|e| BuildAgentError::ConnectionResolution(e.to_string()))?
+                        }
+                        #[cfg(not(feature = "openai-realtime"))]
+                        {
+                            provider_registry
+                                .build_client(connection)
+                                .map_err(|e| BuildAgentError::ConnectionResolution(e.to_string()))?
+                        }
                     }
                 }
-            }
+            })
         };
         #[cfg(not(target_arch = "wasm32"))]
         if build_config.image_generation_executor_override.is_none() {
@@ -2498,44 +2518,55 @@ impl AgentFactory {
                 .map_err(|err| BuildAgentError::Config(format!("model routing baseline: {err}")))?;
         }
         let event_tap = meerkat_core::new_event_tap();
-        let mut llm_adapter_inner = match build_config.event_tx.clone() {
-            Some(tx) => LlmClientAdapter::with_event_channel(llm_client, model.clone(), tx),
-            None => LlmClientAdapter::new(llm_client, model.clone()),
-        };
-        llm_adapter_inner = llm_adapter_inner.with_event_tap(event_tap.clone());
-        if let Some(params_value) = build_config.provider_params.as_ref() {
-            // Project the legacy `Option<serde_json::Value>` per-turn
-            // blob into the typed `ProviderTag` the adapter wants.
-            // Per-provider `from_legacy_value` maps well-known shapes;
-            // unknown keys surface as `LegacyProviderParamsError`
-            // (lossless round-trip via `ProviderTag::Unknown { bag }`
-            // is the runtime-boundary responsibility, not this seam).
-            use meerkat_core::lifecycle::run_primitive::{
-                AnthropicProviderTag, GeminiProviderTag, OpenAiProviderTag, ProviderTag,
-            };
-            let typed_tag = match provider {
-                Provider::Anthropic => AnthropicProviderTag::from_legacy_value(params_value)
-                    .map(ProviderTag::Anthropic),
-                Provider::OpenAI => {
-                    OpenAiProviderTag::from_legacy_value(params_value).map(ProviderTag::OpenAi)
-                }
-                Provider::Gemini => {
-                    GeminiProviderTag::from_legacy_value(params_value).map(ProviderTag::Gemini)
-                }
-                Provider::SelfHosted | Provider::Other => {
-                    // Self-hosted and Other route through OpenAI-compatible
-                    // APIs; use the OpenAI shape for per-turn overrides.
-                    OpenAiProviderTag::from_legacy_value(params_value).map(ProviderTag::OpenAi)
-                }
-            }
-            .map_err(|e| {
-                BuildAgentError::Config(format!(
-                    "invalid provider_params for provider {provider:?}: {e}"
-                ))
+        let llm_adapter: Arc<dyn AgentLlmClient> = if let Some(agent_client) =
+            build_config.agent_llm_client_override.take()
+        {
+            agent_client
+        } else {
+            let llm_client = llm_client.ok_or_else(|| {
+                BuildAgentError::Config(
+                    "internal error: missing LLM client for adapter build".to_string(),
+                )
             })?;
-            llm_adapter_inner = llm_adapter_inner.with_provider_params(Some(typed_tag));
-        }
-        let llm_adapter: Arc<dyn AgentLlmClient> = Arc::new(llm_adapter_inner);
+            let mut llm_adapter_inner = match build_config.event_tx.clone() {
+                Some(tx) => LlmClientAdapter::with_event_channel(llm_client, model.clone(), tx),
+                None => LlmClientAdapter::new(llm_client, model.clone()),
+            };
+            llm_adapter_inner = llm_adapter_inner.with_event_tap(event_tap.clone());
+            if let Some(params_value) = build_config.provider_params.as_ref() {
+                // Project the legacy `Option<serde_json::Value>` per-turn
+                // blob into the typed `ProviderTag` the adapter wants.
+                // Per-provider `from_legacy_value` maps well-known shapes;
+                // unknown keys surface as `LegacyProviderParamsError`
+                // (lossless round-trip via `ProviderTag::Unknown { bag }`
+                // is the runtime-boundary responsibility, not this seam).
+                use meerkat_core::lifecycle::run_primitive::{
+                    AnthropicProviderTag, GeminiProviderTag, OpenAiProviderTag, ProviderTag,
+                };
+                let typed_tag = match provider {
+                    Provider::Anthropic => AnthropicProviderTag::from_legacy_value(params_value)
+                        .map(ProviderTag::Anthropic),
+                    Provider::OpenAI => {
+                        OpenAiProviderTag::from_legacy_value(params_value).map(ProviderTag::OpenAi)
+                    }
+                    Provider::Gemini => {
+                        GeminiProviderTag::from_legacy_value(params_value).map(ProviderTag::Gemini)
+                    }
+                    Provider::SelfHosted | Provider::Other => {
+                        // Self-hosted and Other route through OpenAI-compatible
+                        // APIs; use the OpenAI shape for per-turn overrides.
+                        OpenAiProviderTag::from_legacy_value(params_value).map(ProviderTag::OpenAi)
+                    }
+                }
+                .map_err(|e| {
+                    BuildAgentError::Config(format!(
+                        "invalid provider_params for provider {provider:?}: {e}"
+                    ))
+                })?;
+                llm_adapter_inner = llm_adapter_inner.with_provider_params(Some(typed_tag));
+            }
+            Arc::new(llm_adapter_inner)
+        };
 
         // 5. Resolve max_tokens
         let max_tokens = build_config.max_tokens.unwrap_or(config.max_tokens);

--- a/meerkat/src/lib.rs
+++ b/meerkat/src/lib.rs
@@ -37,7 +37,6 @@ pub mod tokio {
 pub use meerkat_core::{
     // Agent
     Agent,
-    AgentBuilder,
     AgentConfig,
     // Errors
     AgentError,
@@ -142,6 +141,10 @@ pub use meerkat_core::{
     // Operations
     WorkKind,
 };
+
+mod agent_builder;
+pub use agent_builder::AgentBuilder;
+pub use meerkat_core::AgentBuilder as CoreAgentBuilder;
 
 // Config store types (filesystem-dependent — not available on wasm32)
 #[cfg(not(target_arch = "wasm32"))]

--- a/meerkat/src/lib.rs
+++ b/meerkat/src/lib.rs
@@ -145,6 +145,7 @@ pub use meerkat_core::{
 mod agent_builder;
 pub use agent_builder::AgentBuilder;
 pub use meerkat_core::AgentBuilder as CoreAgentBuilder;
+pub use meerkat_core::AgentBuilder as StandaloneAgentBuilder;
 
 // Config store types (filesystem-dependent — not available on wasm32)
 #[cfg(not(target_arch = "wasm32"))]

--- a/meerkat/tests/live_meerkat_comms.rs
+++ b/meerkat/tests/live_meerkat_comms.rs
@@ -25,6 +25,8 @@ use std::collections::HashMap;
 use std::sync::Arc;
 use tempfile::TempDir;
 
+type DynCommsAgent = CommsAgent<dyn AgentLlmClient, dyn AgentToolDispatcher, dyn AgentSessionStore>;
+
 // ============================================================================
 // ADAPTERS - Bridge LlmClient/SessionStore to Agent traits
 // ============================================================================
@@ -257,16 +259,8 @@ async fn create_temp_store() -> (
 async fn create_agent_pair(
     api_key: &str,
 ) -> (
-    CommsAgent<
-        LlmClientAdapter<AnthropicClient>,
-        CommsToolDispatcher,
-        SessionStoreAdapter<JsonlStore>,
-    >,
-    CommsAgent<
-        LlmClientAdapter<AnthropicClient>,
-        CommsToolDispatcher,
-        SessionStoreAdapter<JsonlStore>,
-    >,
+    DynCommsAgent,
+    DynCommsAgent,
     meerkat_comms::agent::ListenerHandle,
     meerkat_comms::agent::ListenerHandle,
     TempDir,
@@ -375,7 +369,8 @@ async fn create_agent_pair(
              Use the peers tool to see available peers.",
         )
         .build(llm_adapter_a, tools_a, store_adapter_a)
-        .await;
+        .await
+            .expect("public builder build");
 
     let agent_b_inner = AgentBuilder::new()
         .model(anthropic_model())
@@ -386,7 +381,8 @@ async fn create_agent_pair(
              Use the peers tool to see available peers.",
         )
         .build(llm_adapter_b, tools_b, store_adapter_b)
-        .await;
+        .await
+            .expect("public builder build");
 
     let agent_a = CommsAgent::new(agent_a_inner, comms_manager_a);
     let agent_b = CommsAgent::new(agent_b_inner, comms_manager_b);
@@ -736,7 +732,8 @@ mod three_agent_coordination {
                  Use peers to see available peers and send to communicate.",
             )
             .build(llm_adapter_a, tools_a, store_adapter_a)
-            .await;
+            .await
+            .expect("public builder build");
 
         let agent_b_inner = AgentBuilder::new()
             .model(anthropic_model())
@@ -745,7 +742,8 @@ mod three_agent_coordination {
                 "You are Agent B, a worker. You can communicate with Agent A and Agent C.",
             )
             .build(llm_adapter_b, tools_b, store_adapter_b)
-            .await;
+            .await
+            .expect("public builder build");
 
         let agent_c_inner = AgentBuilder::new()
             .model(anthropic_model())
@@ -754,7 +752,8 @@ mod three_agent_coordination {
                 "You are Agent C, a worker. You can communicate with Agent A and Agent B.",
             )
             .build(llm_adapter_c, tools_c, store_adapter_c)
-            .await;
+            .await
+            .expect("public builder build");
 
         let mut agent_a = CommsAgent::new(agent_a_inner, comms_manager_a);
         let mut agent_b = CommsAgent::new(agent_b_inner, comms_manager_b);

--- a/meerkat/tests/live_meerkat_user_flows.rs
+++ b/meerkat/tests/live_meerkat_user_flows.rs
@@ -377,7 +377,8 @@ mod simple_chat {
             .max_tokens_per_turn(256)
             .system_prompt("You are a helpful assistant. Respond briefly.")
             .build(llm_adapter, tools, store_adapter)
-            .await;
+            .await
+            .expect("public builder build");
 
         // Run with simple prompt
         let result = agent
@@ -429,7 +430,8 @@ mod simple_chat {
             .max_tokens_per_turn(256)
             .system_prompt("You are a helpful assistant. Respond briefly.")
             .build(llm_adapter, tools, store_adapter)
-            .await;
+            .await
+            .expect("public builder build");
 
         let result = agent
             .run("What is 2+2? Answer with just the number.".into())
@@ -463,7 +465,8 @@ mod simple_chat {
             .max_tokens_per_turn(256)
             .system_prompt("You are a helpful assistant. Respond briefly.")
             .build(llm_adapter, tools, store_adapter)
-            .await;
+            .await
+            .expect("public builder build");
 
         let result = agent
             .run("What is 2+2? Answer with just the number.".into())
@@ -585,7 +588,8 @@ mod tool_invocation {
                 "You have access to an 'echo' tool. When asked to echo something, use it.",
             )
             .build(llm_adapter, dispatcher, store_adapter)
-            .await;
+            .await
+            .expect("public builder build");
 
         // Run agent with prompt that should trigger tool use
         let result = agent
@@ -633,7 +637,8 @@ mod multi_turn {
             .max_tokens_per_turn(256)
             .system_prompt("You are a helpful assistant. Keep your responses brief.")
             .build(llm_adapter, tools, store_adapter)
-            .await;
+            .await
+            .expect("public builder build");
 
         // Turn 1: Establish context
         let result1 = agent
@@ -726,7 +731,8 @@ mod session_resume {
                 .max_tokens_per_turn(256)
                 .system_prompt("You are a helpful assistant. Keep your responses brief.")
                 .build(llm_adapter, tools, store_adapter)
-                .await;
+                .await
+                .expect("public builder build");
 
             // Establish context
             let _ = agent
@@ -759,7 +765,8 @@ mod session_resume {
                 .max_tokens_per_turn(256)
                 .resume_session(saved_session)
                 .build(llm_adapter, tools, store_adapter)
-                .await;
+                .await
+                .expect("public builder build");
 
             // Verify context is maintained
             let result = agent
@@ -811,7 +818,8 @@ mod budget_exhaustion {
                 max_tool_calls: None,
             })
             .build(llm_adapter, tools, store_adapter)
-            .await;
+            .await
+            .expect("public builder build");
 
         // First turn should succeed
         let result1 = agent
@@ -880,7 +888,8 @@ mod budget_exhaustion {
                 max_tool_calls: Some(2), // Very low tool call limit
             })
             .build(llm_adapter, tools, store_adapter)
-            .await;
+            .await
+            .expect("public builder build");
 
         // Run a query that might trigger tool calls
         let result = agent
@@ -987,7 +996,8 @@ mod parallel_tools {
             .max_tokens_per_turn(512)
             .system_prompt("You have access to an 'add' tool that adds two numbers.")
             .build(llm_adapter, dispatcher, store_adapter)
-            .await;
+            .await
+            .expect("public builder build");
 
         // Ask for multiple calculations - LLM may issue multiple tool calls
         let result = agent
@@ -1126,7 +1136,8 @@ mod parallel_tools {
                  Do not call them one at a time.",
             )
             .build(llm_adapter, dispatcher.clone(), store_adapter)
-            .await;
+            .await
+            .expect("public builder build");
 
         // Ask for multiple pieces of info to encourage parallel tool calls
         let overall_start = std::time::Instant::now();
@@ -1203,7 +1214,8 @@ mod parallel_tools {
                  Use multiple tools when appropriate.",
             )
             .build(llm_adapter, dispatcher.clone(), store_adapter)
-            .await;
+            .await
+            .expect("public builder build");
 
         // Turn 1: Multiple tool calls
         let result1 = agent
@@ -1326,7 +1338,8 @@ mod parallel_tools {
                  If a tool fails, acknowledge the error and report results from successful tools.",
             )
             .build(llm_adapter, dispatcher, store_adapter)
-            .await;
+            .await
+            .expect("public builder build");
 
         // Request that should trigger all three tools
         let result = agent
@@ -1445,6 +1458,7 @@ mod sanity {
             .model("test-model")
             .system_prompt("test prompt")
             .build(client, tools, store)
-            .await;
+            .await
+            .expect("public builder build");
     }
 }

--- a/meerkat/tests/sdk_agentfactory.rs
+++ b/meerkat/tests/sdk_agentfactory.rs
@@ -7,13 +7,14 @@ use std::sync::{
 use async_trait::async_trait;
 use futures::stream;
 use meerkat::{
-    AgentBuildConfig, AgentBuilder, AgentFactory, AgentLlmClient, AgentToolDispatcher, Config,
-    CoreAgentBuilder, LlmDoneOutcome, LlmEvent, LlmRequest, ToolDef, ToolError, ToolResult,
+    AgentBuildConfig, AgentBuilder, AgentFactory, AgentLlmClient, AgentToolDispatcher,
+    BuildAgentError, Config, CoreAgentBuilder, LlmDoneOutcome, LlmEvent, LlmRequest, ToolDef,
+    ToolError, ToolResult,
 };
 use meerkat_client::LlmClient;
 use meerkat_core::ToolDispatchOutcome;
 use meerkat_core::{
-    AssistantBlock, BlobId, BlobRef, LlmStreamResult, Message, ProviderImageMetadata,
+    AssistantBlock, BlobId, BlobRef, LlmStreamResult, Message, Provider, ProviderImageMetadata,
     RevisedPromptDisposition, StopReason, ToolCallView, Usage,
 };
 use meerkat_core::{HookEngine, HookEngineError, HookExecutionReport, HookId, HookInvocation};
@@ -151,6 +152,90 @@ impl AgentLlmClient for ImageAgentLlmClient {
     }
 }
 
+struct CustomAgentLlmClient;
+
+#[async_trait]
+impl AgentLlmClient for CustomAgentLlmClient {
+    async fn stream_response(
+        &self,
+        _messages: &[Message],
+        _tools: &[Arc<ToolDef>],
+        _max_tokens: u32,
+        _temperature: Option<f32>,
+        _provider_params: Option<&meerkat_core::lifecycle::run_primitive::ProviderParamsOverride>,
+    ) -> Result<LlmStreamResult, meerkat::AgentError> {
+        Ok(LlmStreamResult::new(
+            vec![AssistantBlock::Text {
+                text: "custom ok".to_string(),
+                meta: None,
+            }],
+            StopReason::EndTurn,
+            Usage::default(),
+        ))
+    }
+
+    fn provider(&self) -> &'static str {
+        "custom-provider"
+    }
+
+    fn model(&self) -> &str {
+        "custom-agent-model"
+    }
+}
+
+struct NoopCompactor;
+
+impl meerkat_core::compact::Compactor for NoopCompactor {
+    fn should_compact(&self, _ctx: &meerkat_core::compact::CompactionContext) -> bool {
+        false
+    }
+
+    fn compaction_prompt(&self) -> &str {
+        ""
+    }
+
+    fn max_summary_tokens(&self) -> u32 {
+        1
+    }
+
+    fn rebuild_history(
+        &self,
+        messages: &[Message],
+        _summary: &str,
+    ) -> meerkat_core::compact::CompactionResult {
+        meerkat_core::compact::CompactionResult {
+            messages: messages.to_vec(),
+            discarded: Vec::new(),
+        }
+    }
+}
+
+struct NoopMemoryStore;
+
+#[async_trait]
+impl meerkat_core::memory::MemoryStore for NoopMemoryStore {
+    async fn index_scoped_batch(
+        &self,
+        batch: meerkat_core::memory::MemoryIndexBatch,
+    ) -> Result<meerkat_core::memory::MemoryIndexReceipt, meerkat_core::memory::MemoryStoreError>
+    {
+        Ok(meerkat_core::memory::MemoryIndexReceipt {
+            scope: batch.scope().clone(),
+            indexed_entries: batch.len(),
+        })
+    }
+
+    async fn search(
+        &self,
+        _scope: &meerkat_core::memory::MemorySearchScope,
+        _query: &str,
+        _limit: usize,
+    ) -> Result<Vec<meerkat_core::memory::MemoryResult>, meerkat_core::memory::MemoryStoreError>
+    {
+        Ok(Vec::new())
+    }
+}
+
 struct ParamsCaptureClient {
     captured: Mutex<serde_json::Value>,
 }
@@ -250,9 +335,6 @@ async fn test_sdk_agentfactory_tool_dispatch() {
     let mut agent = AgentBuilder::new()
         .model("claude-sonnet-4-6")
         .max_tokens_per_turn(64)
-        .with_turn_state_handle(std::sync::Arc::new(
-            meerkat_runtime::RuntimeTurnStateHandle::ephemeral(),
-        ))
         .build(llm_adapter, tools, store_adapter)
         .await
         .expect("public builder build");
@@ -485,6 +567,143 @@ async fn public_agentbuilder_preserves_agent_llm_image_blocks() {
         BlobId::new("image-blob-124"),
         "public builder compatibility path must preserve AgentLlmClient image blocks"
     );
+}
+
+#[tokio::test]
+async fn public_agentbuilder_build_uses_agent_llm_provider_for_uncatalogued_model() {
+    let temp = tempfile::tempdir().expect("tempdir");
+    let factory = AgentFactory::new(temp.path().join("sessions"));
+    let custom_client: Arc<dyn AgentLlmClient> = Arc::new(CustomAgentLlmClient);
+    let tools: Arc<dyn AgentToolDispatcher> = Arc::new(RecordingDispatcher {
+        called: Arc::new(AtomicBool::new(false)),
+    });
+    let store = Arc::new(TestSessionStore::new());
+    let store = Arc::new(factory.build_store_adapter(store).await);
+
+    let agent = AgentBuilder::new()
+        .with_factory(factory)
+        .model("custom-agent-model")
+        .build(custom_client, tools, store)
+        .await
+        .expect("public builder should accept AgentLlmClient provider identity");
+
+    let metadata = agent
+        .session()
+        .session_metadata()
+        .expect("factory metadata");
+    assert_eq!(metadata.provider, Provider::Other);
+    assert_eq!(metadata.model, "custom-agent-model");
+}
+
+#[tokio::test]
+async fn public_agentbuilder_build_defaults_to_agent_llm_identity_when_model_is_not_explicit() {
+    let temp = tempfile::tempdir().expect("tempdir");
+    let factory = AgentFactory::new(temp.path().join("sessions"));
+    let custom_client: Arc<dyn AgentLlmClient> = Arc::new(CustomAgentLlmClient);
+    let tools: Arc<dyn AgentToolDispatcher> = Arc::new(RecordingDispatcher {
+        called: Arc::new(AtomicBool::new(false)),
+    });
+    let store = Arc::new(TestSessionStore::new());
+    let store = Arc::new(factory.build_store_adapter(store).await);
+
+    let agent = AgentBuilder::new()
+        .with_factory(factory)
+        .build(custom_client, tools, store)
+        .await
+        .expect("public builder should derive default identity from AgentLlmClient");
+
+    let metadata = agent
+        .session()
+        .session_metadata()
+        .expect("factory metadata");
+    assert_eq!(metadata.provider, Provider::Other);
+    assert_eq!(
+        metadata.model, "custom-agent-model",
+        "implicit public builder model should not fall back to Config::default() when an AgentLlmClient override supplies identity"
+    );
+}
+
+fn assert_unsupported_builder_injection(error: BuildAgentError, method: &str) {
+    let BuildAgentError::Config(message) = error else {
+        panic!("expected Config error for {method}, got {error:?}");
+    };
+    assert!(
+        message.contains(method),
+        "error should name unsupported method {method}: {message}"
+    );
+    assert!(
+        message.contains("CoreAgentBuilder"),
+        "error should point callers to the standalone builder: {message}"
+    );
+}
+
+fn unwrap_build_error(
+    result: Result<meerkat::DynAgent, BuildAgentError>,
+    context: &str,
+) -> BuildAgentError {
+    match result {
+        Ok(_) => panic!("{context}"),
+        Err(error) => error,
+    }
+}
+
+#[tokio::test]
+async fn public_agentbuilder_rejects_standalone_core_injections_loudly() {
+    let temp = tempfile::tempdir().expect("tempdir");
+    let factory = AgentFactory::new(temp.path().join("sessions"));
+    let client: Arc<dyn LlmClient> = Arc::new(MockLlmClient {
+        calls: Arc::new(AtomicUsize::new(1)),
+    });
+
+    let provider_defaults_error = AgentBuilder::new()
+        .with_factory(factory.clone())
+        .model("claude-sonnet-4-6")
+        .llm_client(Arc::clone(&client))
+        .provider_tool_defaults(json!({"web_search": {"type": "custom"}}))
+        .try_build()
+        .await;
+    let provider_defaults_error = unwrap_build_error(
+        provider_defaults_error,
+        "provider_tool_defaults should not be silently ignored",
+    );
+    assert_unsupported_builder_injection(provider_defaults_error, "provider_tool_defaults");
+
+    let compactor_error = AgentBuilder::new()
+        .with_factory(factory.clone())
+        .model("claude-sonnet-4-6")
+        .llm_client(Arc::clone(&client))
+        .compactor(Arc::new(NoopCompactor))
+        .try_build()
+        .await;
+    let compactor_error =
+        unwrap_build_error(compactor_error, "compactor should not be silently ignored");
+    assert_unsupported_builder_injection(compactor_error, "compactor");
+
+    let memory_error = AgentBuilder::new()
+        .with_factory(factory.clone())
+        .model("claude-sonnet-4-6")
+        .llm_client(Arc::clone(&client))
+        .memory_store(Arc::new(NoopMemoryStore))
+        .try_build()
+        .await;
+    let memory_error =
+        unwrap_build_error(memory_error, "memory_store should not be silently ignored");
+    assert_unsupported_builder_injection(memory_error, "memory_store");
+
+    let turn_state_error = AgentBuilder::new()
+        .with_factory(factory)
+        .model("claude-sonnet-4-6")
+        .llm_client(client)
+        .with_turn_state_handle(Arc::new(
+            meerkat_runtime::RuntimeTurnStateHandle::ephemeral(),
+        ))
+        .try_build()
+        .await;
+    let turn_state_error = unwrap_build_error(
+        turn_state_error,
+        "with_turn_state_handle should not be silently ignored",
+    );
+    assert_unsupported_builder_injection(turn_state_error, "with_turn_state_handle");
 }
 
 #[tokio::test]

--- a/meerkat/tests/sdk_agentfactory.rs
+++ b/meerkat/tests/sdk_agentfactory.rs
@@ -1,18 +1,22 @@
 #![allow(clippy::unwrap_used, clippy::expect_used, clippy::panic)]
 use std::sync::{
-    Arc,
+    Arc, Mutex,
     atomic::{AtomicBool, AtomicUsize, Ordering},
 };
 
 use async_trait::async_trait;
 use futures::stream;
 use meerkat::{
-    AgentBuilder, AgentFactory, AgentToolDispatcher, LlmDoneOutcome, LlmEvent, LlmRequest, ToolDef,
-    ToolError, ToolResult,
+    AgentBuildConfig, AgentBuilder, AgentFactory, AgentLlmClient, AgentToolDispatcher, Config,
+    CoreAgentBuilder, LlmDoneOutcome, LlmEvent, LlmRequest, ToolDef, ToolError, ToolResult,
 };
 use meerkat_client::LlmClient;
-use meerkat_core::ToolCallView;
 use meerkat_core::ToolDispatchOutcome;
+use meerkat_core::{
+    AssistantBlock, BlobId, BlobRef, LlmStreamResult, Message, ProviderImageMetadata,
+    RevisedPromptDisposition, StopReason, ToolCallView, Usage,
+};
+use meerkat_core::{HookEngine, HookEngineError, HookExecutionReport, HookId, HookInvocation};
 use meerkat_tools::schema_for;
 use schemars::JsonSchema;
 use serde::Deserialize;
@@ -104,6 +108,125 @@ impl AgentToolDispatcher for RecordingDispatcher {
     }
 }
 
+struct ImageAgentLlmClient;
+
+#[async_trait]
+impl AgentLlmClient for ImageAgentLlmClient {
+    async fn stream_response(
+        &self,
+        _messages: &[Message],
+        _tools: &[Arc<ToolDef>],
+        _max_tokens: u32,
+        _temperature: Option<f32>,
+        _provider_params: Option<&meerkat_core::lifecycle::run_primitive::ProviderParamsOverride>,
+    ) -> Result<LlmStreamResult, meerkat::AgentError> {
+        Ok(LlmStreamResult::new(
+            vec![AssistantBlock::Image {
+                image_id: meerkat_core::AssistantImageId::new(
+                    "00000000-0000-4000-8000-000000000124"
+                        .parse()
+                        .expect("valid uuid"),
+                ),
+                blob_ref: BlobRef {
+                    blob_id: BlobId::new("image-blob-124"),
+                    media_type: "image/png".to_string(),
+                },
+                media_type: meerkat_core::MediaType("image/png".to_string()),
+                width: 64,
+                height: 32,
+                revised_prompt: RevisedPromptDisposition::NotRequested,
+                meta: ProviderImageMetadata::NotEmitted,
+            }],
+            StopReason::EndTurn,
+            Usage::default(),
+        ))
+    }
+
+    fn provider(&self) -> &'static str {
+        "anthropic"
+    }
+
+    fn model(&self) -> &str {
+        "claude-sonnet-4-6"
+    }
+}
+
+struct ParamsCaptureClient {
+    captured: Mutex<serde_json::Value>,
+}
+
+impl ParamsCaptureClient {
+    fn new() -> Self {
+        Self {
+            captured: Mutex::new(serde_json::Value::Null),
+        }
+    }
+
+    fn captured_params(&self) -> Option<serde_json::Value> {
+        let value = self.captured.lock().expect("capture mutex").clone();
+        if value.is_null() { None } else { Some(value) }
+    }
+}
+
+#[async_trait]
+impl LlmClient for ParamsCaptureClient {
+    fn stream<'a>(
+        &'a self,
+        request: &'a LlmRequest,
+    ) -> std::pin::Pin<
+        Box<dyn futures::Stream<Item = Result<LlmEvent, meerkat_client::LlmError>> + Send + 'a>,
+    > {
+        *self.captured.lock().expect("capture mutex") = request
+            .provider_params
+            .as_ref()
+            .map(|tag| serde_json::to_value(tag).unwrap_or(serde_json::json!({})))
+            .unwrap_or(serde_json::json!({}));
+        Box::pin(stream::iter(vec![
+            Ok(LlmEvent::TextDelta {
+                delta: "ok".to_string(),
+                meta: None,
+            }),
+            Ok(LlmEvent::Done {
+                outcome: LlmDoneOutcome::Success {
+                    stop_reason: meerkat::StopReason::EndTurn,
+                },
+            }),
+        ]))
+    }
+
+    fn provider(&self) -> &'static str {
+        "anthropic"
+    }
+
+    async fn health_check(&self) -> Result<(), meerkat_client::LlmError> {
+        Ok(())
+    }
+}
+
+struct CountingHookEngine {
+    executions: Arc<AtomicUsize>,
+}
+
+#[async_trait]
+impl HookEngine for CountingHookEngine {
+    fn matching_hooks(
+        &self,
+        _invocation: &HookInvocation,
+        _overrides: Option<&meerkat::HookRunOverrides>,
+    ) -> Result<Vec<HookId>, HookEngineError> {
+        Ok(vec![HookId("counting-hook".to_string())])
+    }
+
+    async fn execute(
+        &self,
+        _invocation: HookInvocation,
+        _overrides: Option<&meerkat::HookRunOverrides>,
+    ) -> Result<HookExecutionReport, HookEngineError> {
+        self.executions.fetch_add(1, Ordering::SeqCst);
+        Ok(HookExecutionReport::empty())
+    }
+}
+
 #[tokio::test]
 async fn test_sdk_agentfactory_tool_dispatch() {
     let calls = Arc::new(AtomicUsize::new(0));
@@ -111,7 +234,11 @@ async fn test_sdk_agentfactory_tool_dispatch() {
 
     let factory = AgentFactory::new(".rkat/sessions");
     let llm_client = Arc::new(MockLlmClient { calls });
-    let llm_adapter = Arc::new(factory.build_llm_adapter(llm_client, "mock-model").await);
+    let llm_adapter = Arc::new(
+        factory
+            .build_llm_adapter(llm_client, "claude-sonnet-4-6")
+            .await,
+    );
 
     let store = Arc::new(TestSessionStore::new());
     let store_adapter = Arc::new(factory.build_store_adapter(store).await);
@@ -121,13 +248,14 @@ async fn test_sdk_agentfactory_tool_dispatch() {
     });
 
     let mut agent = AgentBuilder::new()
-        .model("mock-model")
+        .model("claude-sonnet-4-6")
         .max_tokens_per_turn(64)
         .with_turn_state_handle(std::sync::Arc::new(
             meerkat_runtime::RuntimeTurnStateHandle::ephemeral(),
         ))
         .build(llm_adapter, tools, store_adapter)
-        .await;
+        .await
+        .expect("public builder build");
 
     let result = agent
         .run("Use the echo tool.".to_string().into())
@@ -141,5 +269,249 @@ async fn test_sdk_agentfactory_tool_dispatch() {
     assert!(
         result.text.contains("done"),
         "agent should complete after tool call"
+    );
+}
+
+#[tokio::test]
+async fn public_agentbuilder_matches_factory_session_runtime_invariants() {
+    let temp = tempfile::tempdir().expect("tempdir");
+    let factory = AgentFactory::new(temp.path().join("sessions"));
+    let config = Config::default();
+    let model = "claude-sonnet-4-6";
+    let prompt = "builder parity prompt";
+
+    let factory_client = Arc::new(MockLlmClient {
+        calls: Arc::new(AtomicUsize::new(0)),
+    });
+    let factory_tools: Arc<dyn AgentToolDispatcher> = Arc::new(RecordingDispatcher {
+        called: Arc::new(AtomicBool::new(false)),
+    });
+    let factory_store = Arc::new(TestSessionStore::new());
+    let factory_store = Arc::new(factory.build_store_adapter(factory_store).await);
+    let factory_agent = factory
+        .build_agent(
+            AgentBuildConfig {
+                max_tokens: Some(64),
+                system_prompt: Some(prompt.to_string()),
+                llm_client_override: Some(factory_client),
+                tool_dispatcher_override: Some(factory_tools),
+                session_store_override: Some(factory_store),
+                ..AgentBuildConfig::new(model)
+            },
+            &config,
+        )
+        .await
+        .expect("factory build");
+
+    let public_client = Arc::new(MockLlmClient {
+        calls: Arc::new(AtomicUsize::new(0)),
+    });
+    let public_llm = Arc::new(factory.build_llm_adapter(public_client, model).await);
+    let public_tools: Arc<dyn AgentToolDispatcher> = Arc::new(RecordingDispatcher {
+        called: Arc::new(AtomicBool::new(false)),
+    });
+    let public_store = Arc::new(TestSessionStore::new());
+    let public_store = Arc::new(factory.build_store_adapter(public_store).await);
+
+    let public_agent = AgentBuilder::new()
+        .model(model)
+        .max_tokens_per_turn(64)
+        .system_prompt(prompt)
+        .build(public_llm, public_tools, public_store)
+        .await
+        .expect("public builder build");
+
+    let factory_metadata = factory_agent
+        .session()
+        .session_metadata()
+        .expect("factory session metadata");
+    let public_metadata = public_agent
+        .session()
+        .session_metadata()
+        .expect("public builder should persist factory session metadata");
+    assert_eq!(public_metadata.model, factory_metadata.model);
+    assert_eq!(public_metadata.provider, factory_metadata.provider);
+    assert_eq!(public_metadata.max_tokens, factory_metadata.max_tokens);
+    assert_eq!(
+        public_metadata.structured_output_retries,
+        factory_metadata.structured_output_retries
+    );
+
+    let factory_build_state = factory_agent
+        .session()
+        .build_state()
+        .expect("factory build state");
+    let public_build_state = public_agent
+        .session()
+        .build_state()
+        .expect("public builder should persist factory build state");
+    assert_eq!(
+        public_build_state.system_prompt,
+        factory_build_state.system_prompt
+    );
+    assert_eq!(
+        public_build_state.call_timeout_override,
+        factory_build_state.call_timeout_override
+    );
+
+    assert!(
+        factory_agent.execution_snapshot().is_some(),
+        "factory path wires runtime turn-state"
+    );
+    assert!(
+        public_agent.execution_snapshot().is_some(),
+        "public AgentBuilder must wire the same runtime turn-state default"
+    );
+}
+
+#[tokio::test]
+async fn public_agentbuilder_uses_factory_provider_defaults() {
+    let temp = tempfile::tempdir().expect("tempdir");
+    let client = Arc::new(ParamsCaptureClient::new());
+    let override_client: Arc<dyn LlmClient> = client.clone();
+    let mut agent = AgentBuilder::new()
+        .with_factory(AgentFactory::new(temp.path().join("sessions")))
+        .with_config(Config::default())
+        .model("claude-sonnet-4-6")
+        .llm_client(override_client)
+        .try_build()
+        .await
+        .expect("public builder build");
+
+    agent.run("test".to_string().into()).await.expect("run");
+
+    let params = client
+        .captured_params()
+        .expect("factory provider defaults should produce provider params");
+    assert!(
+        params.get("web_search").is_some(),
+        "public AgentBuilder should inherit factory provider defaults: {params}"
+    );
+}
+
+#[tokio::test]
+async fn public_agentbuilder_routes_hook_engine_through_factory() {
+    let temp = tempfile::tempdir().expect("tempdir");
+    let executions = Arc::new(AtomicUsize::new(0));
+    let hook_engine = Arc::new(CountingHookEngine {
+        executions: Arc::clone(&executions),
+    });
+    let client: Arc<dyn LlmClient> = Arc::new(MockLlmClient {
+        calls: Arc::new(AtomicUsize::new(1)),
+    });
+
+    let mut agent = AgentBuilder::new()
+        .with_factory(AgentFactory::new(temp.path().join("sessions")))
+        .with_config(Config::default())
+        .model("claude-sonnet-4-6")
+        .llm_client(client)
+        .with_hook_engine(hook_engine)
+        .try_build()
+        .await
+        .expect("public builder build");
+
+    agent.run("test".to_string().into()).await.expect("run");
+    assert!(
+        executions.load(Ordering::SeqCst) > 0,
+        "public AgentBuilder should route hook engine through factory build"
+    );
+}
+
+#[tokio::test]
+async fn public_agentbuilder_with_config_supplies_default_model() {
+    let temp = tempfile::tempdir().expect("tempdir");
+    let mut config = Config::default();
+    config.agent.model = "claude-sonnet-4-6".to_string();
+    let client: Arc<dyn LlmClient> = Arc::new(MockLlmClient {
+        calls: Arc::new(AtomicUsize::new(1)),
+    });
+
+    let agent = AgentBuilder::new()
+        .with_factory(AgentFactory::new(temp.path().join("sessions")))
+        .with_config(config)
+        .llm_client(client)
+        .try_build()
+        .await
+        .expect("public builder build");
+
+    let metadata = agent
+        .session()
+        .session_metadata()
+        .expect("factory session metadata");
+    assert_eq!(
+        metadata.model, "claude-sonnet-4-6",
+        "with_config should update the default build model unless .model() was explicit"
+    );
+}
+
+#[tokio::test]
+async fn public_agentbuilder_preserves_agent_llm_image_blocks() {
+    let temp = tempfile::tempdir().expect("tempdir");
+    let factory = AgentFactory::new(temp.path().join("sessions"));
+    let image_client: Arc<dyn AgentLlmClient> = Arc::new(ImageAgentLlmClient);
+    let tools: Arc<dyn AgentToolDispatcher> = Arc::new(RecordingDispatcher {
+        called: Arc::new(AtomicBool::new(false)),
+    });
+    let store = Arc::new(TestSessionStore::new());
+    let store = Arc::new(factory.build_store_adapter(store).await);
+
+    let mut agent = AgentBuilder::new()
+        .with_factory(factory)
+        .model("claude-sonnet-4-6")
+        .build(image_client, tools, store)
+        .await
+        .expect("public builder build");
+
+    agent.run("return an image".into()).await.expect("run");
+
+    let image_block = agent.session().messages().iter().find_map(|message| {
+        if let Message::BlockAssistant(assistant) = message {
+            assistant.blocks.iter().find_map(|block| {
+                if let AssistantBlock::Image { blob_ref, .. } = block {
+                    Some(blob_ref.clone())
+                } else {
+                    None
+                }
+            })
+        } else {
+            None
+        }
+    });
+
+    assert_eq!(
+        image_block
+            .expect("image block should be persisted")
+            .blob_id,
+        BlobId::new("image-blob-124"),
+        "public builder compatibility path must preserve AgentLlmClient image blocks"
+    );
+}
+
+#[tokio::test]
+async fn core_agentbuilder_remains_explicit_standalone_escape_hatch() {
+    let factory = AgentFactory::new(".rkat/sessions");
+    let llm_client = Arc::new(MockLlmClient {
+        calls: Arc::new(AtomicUsize::new(1)),
+    });
+    let llm_adapter = Arc::new(factory.build_llm_adapter(llm_client, "mock-model").await);
+    let tools: Arc<dyn AgentToolDispatcher> = Arc::new(RecordingDispatcher {
+        called: Arc::new(AtomicBool::new(false)),
+    });
+    let store = Arc::new(TestSessionStore::new());
+    let store_adapter = Arc::new(factory.build_store_adapter(store).await);
+
+    let agent = CoreAgentBuilder::new()
+        .model("mock-model")
+        .max_tokens_per_turn(64)
+        .with_turn_state_handle(Arc::new(
+            meerkat_runtime::RuntimeTurnStateHandle::ephemeral(),
+        ))
+        .build(llm_adapter, tools, store_adapter)
+        .await;
+
+    assert!(
+        agent.session().session_metadata().is_none(),
+        "CoreAgentBuilder intentionally remains a standalone primitive builder; \
+         facade metadata is owned by meerkat::AgentBuilder/AgentFactory"
     );
 }

--- a/meerkat/tests/sdk_agentfactory.rs
+++ b/meerkat/tests/sdk_agentfactory.rs
@@ -147,7 +147,7 @@ impl AgentLlmClient for ImageAgentLlmClient {
         "anthropic"
     }
 
-    fn model(&self) -> &str {
+    fn model(&self) -> &'static str {
         "claude-sonnet-4-6"
     }
 }
@@ -178,7 +178,7 @@ impl AgentLlmClient for CustomAgentLlmClient {
         "custom-provider"
     }
 
-    fn model(&self) -> &str {
+    fn model(&self) -> &'static str {
         "custom-agent-model"
     }
 }
@@ -190,7 +190,7 @@ impl meerkat_core::compact::Compactor for NoopCompactor {
         false
     }
 
-    fn compaction_prompt(&self) -> &str {
+    fn compaction_prompt(&self) -> &'static str {
         ""
     }
 

--- a/meerkat/tests/sdk_structured_output.rs
+++ b/meerkat/tests/sdk_structured_output.rs
@@ -250,9 +250,6 @@ async fn sdk_structured_output_extraction_succeeds() -> Result<(), Box<dyn std::
         .model("claude-sonnet-4-6")
         .max_tokens_per_turn(64)
         .output_schema(OutputSchema::new(person_schema())?)
-        .with_turn_state_handle(std::sync::Arc::new(
-            meerkat_runtime::RuntimeTurnStateHandle::ephemeral(),
-        ))
         .build(llm_adapter, tools, store_adapter)
         .await?;
 
@@ -303,9 +300,6 @@ async fn sdk_structured_output_retry_on_invalid_json() -> Result<(), Box<dyn std
         .max_tokens_per_turn(64)
         .output_schema(OutputSchema::new(person_schema())?)
         .structured_output_retries(2) // Allow retries
-        .with_turn_state_handle(std::sync::Arc::new(
-            meerkat_runtime::RuntimeTurnStateHandle::ephemeral(),
-        ))
         .build(llm_adapter, tools, store_adapter)
         .await?;
 
@@ -347,9 +341,6 @@ async fn sdk_no_structured_output_without_schema() {
     let mut agent = AgentBuilder::new()
         .model("claude-sonnet-4-6")
         .max_tokens_per_turn(64)
-        .with_turn_state_handle(std::sync::Arc::new(
-            meerkat_runtime::RuntimeTurnStateHandle::ephemeral(),
-        ))
         .build(llm_adapter, tools, store_adapter)
         .await
         .expect("public builder build");
@@ -404,9 +395,6 @@ async fn sdk_structured_output_unwraps_named_envelope() -> Result<(), Box<dyn st
         .model("claude-sonnet-4-6")
         .max_tokens_per_turn(64)
         .output_schema(OutputSchema::new(person_schema())?.with_name("advisor"))
-        .with_turn_state_handle(std::sync::Arc::new(
-            meerkat_runtime::RuntimeTurnStateHandle::ephemeral(),
-        ))
         .build(llm_adapter, tools, store_adapter)
         .await?;
 

--- a/meerkat/tests/sdk_structured_output.rs
+++ b/meerkat/tests/sdk_structured_output.rs
@@ -235,7 +235,11 @@ async fn sdk_structured_output_extraction_succeeds() -> Result<(), Box<dyn std::
     let llm_client = Arc::new(MockLlmClientWithStructuredOutput {
         calls: calls.clone(),
     });
-    let llm_adapter = Arc::new(factory.build_llm_adapter(llm_client, "mock-model").await);
+    let llm_adapter = Arc::new(
+        factory
+            .build_llm_adapter(llm_client, "claude-sonnet-4-6")
+            .await,
+    );
 
     let store = Arc::new(TestSessionStore::new());
     let store_adapter = Arc::new(factory.build_store_adapter(store).await);
@@ -243,14 +247,14 @@ async fn sdk_structured_output_extraction_succeeds() -> Result<(), Box<dyn std::
     let tools: Arc<dyn AgentToolDispatcher> = Arc::new(EmptyDispatcher);
 
     let mut agent = AgentBuilder::new()
-        .model("mock-model")
+        .model("claude-sonnet-4-6")
         .max_tokens_per_turn(64)
         .output_schema(OutputSchema::new(person_schema())?)
         .with_turn_state_handle(std::sync::Arc::new(
             meerkat_runtime::RuntimeTurnStateHandle::ephemeral(),
         ))
         .build(llm_adapter, tools, store_adapter)
-        .await;
+        .await?;
 
     let result = agent
         .run("Tell me about a person.".to_string().into())
@@ -283,7 +287,11 @@ async fn sdk_structured_output_retry_on_invalid_json() -> Result<(), Box<dyn std
     let llm_client = Arc::new(MockLlmClientWithRetry {
         calls: calls.clone(),
     });
-    let llm_adapter = Arc::new(factory.build_llm_adapter(llm_client, "mock-model").await);
+    let llm_adapter = Arc::new(
+        factory
+            .build_llm_adapter(llm_client, "claude-sonnet-4-6")
+            .await,
+    );
 
     let store = Arc::new(TestSessionStore::new());
     let store_adapter = Arc::new(factory.build_store_adapter(store).await);
@@ -291,7 +299,7 @@ async fn sdk_structured_output_retry_on_invalid_json() -> Result<(), Box<dyn std
     let tools: Arc<dyn AgentToolDispatcher> = Arc::new(EmptyDispatcher);
 
     let mut agent = AgentBuilder::new()
-        .model("mock-model")
+        .model("claude-sonnet-4-6")
         .max_tokens_per_turn(64)
         .output_schema(OutputSchema::new(person_schema())?)
         .structured_output_retries(2) // Allow retries
@@ -299,7 +307,7 @@ async fn sdk_structured_output_retry_on_invalid_json() -> Result<(), Box<dyn std
             meerkat_runtime::RuntimeTurnStateHandle::ephemeral(),
         ))
         .build(llm_adapter, tools, store_adapter)
-        .await;
+        .await?;
 
     let result = agent
         .run("Tell me about a person.".to_string().into())
@@ -324,7 +332,11 @@ async fn sdk_no_structured_output_without_schema() {
 
     let factory = AgentFactory::new(".rkat/sessions");
     let llm_client = Arc::new(MockLlmClientWithStructuredOutput { calls });
-    let llm_adapter = Arc::new(factory.build_llm_adapter(llm_client, "mock-model").await);
+    let llm_adapter = Arc::new(
+        factory
+            .build_llm_adapter(llm_client, "claude-sonnet-4-6")
+            .await,
+    );
 
     let store = Arc::new(TestSessionStore::new());
     let store_adapter = Arc::new(factory.build_store_adapter(store).await);
@@ -333,13 +345,14 @@ async fn sdk_no_structured_output_without_schema() {
 
     // NO output_schema configured
     let mut agent = AgentBuilder::new()
-        .model("mock-model")
+        .model("claude-sonnet-4-6")
         .max_tokens_per_turn(64)
         .with_turn_state_handle(std::sync::Arc::new(
             meerkat_runtime::RuntimeTurnStateHandle::ephemeral(),
         ))
         .build(llm_adapter, tools, store_adapter)
-        .await;
+        .await
+        .expect("public builder build");
 
     let result = agent
         .run("Hello".to_string().into())
@@ -376,7 +389,11 @@ async fn sdk_structured_output_unwraps_named_envelope() -> Result<(), Box<dyn st
     let llm_client = Arc::new(MockLlmClientWithNamedWrapper {
         calls: calls.clone(),
     });
-    let llm_adapter = Arc::new(factory.build_llm_adapter(llm_client, "mock-model").await);
+    let llm_adapter = Arc::new(
+        factory
+            .build_llm_adapter(llm_client, "claude-sonnet-4-6")
+            .await,
+    );
 
     let store = Arc::new(TestSessionStore::new());
     let store_adapter = Arc::new(factory.build_store_adapter(store).await);
@@ -384,14 +401,14 @@ async fn sdk_structured_output_unwraps_named_envelope() -> Result<(), Box<dyn st
     let tools: Arc<dyn AgentToolDispatcher> = Arc::new(EmptyDispatcher);
 
     let mut agent = AgentBuilder::new()
-        .model("mock-model")
+        .model("claude-sonnet-4-6")
         .max_tokens_per_turn(64)
         .output_schema(OutputSchema::new(person_schema())?.with_name("advisor"))
         .with_turn_state_handle(std::sync::Arc::new(
             meerkat_runtime::RuntimeTurnStateHandle::ephemeral(),
         ))
         .build(llm_adapter, tools, store_adapter)
-        .await;
+        .await?;
 
     let result = agent
         .run("Tell me about a person.".to_string().into())

--- a/meerkat/tests/smoke_meerkat_sdk.rs
+++ b/meerkat/tests/smoke_meerkat_sdk.rs
@@ -9,7 +9,7 @@
 //! E2E smoke tests for the Meerkat native Rust SDK.
 //!
 //! These tests verify compound, realistic scenario-based workflows through
-//! the AgentFactory path (and AgentBuilder where injection is needed).
+//! the AgentFactory path (and CoreAgentBuilder where low-level injection is needed).
 //!
 //! Each test requires API keys and makes real API calls. When keys are missing,
 //! tests skip gracefully with an informational message.
@@ -25,6 +25,13 @@ use serde_json::Value;
 use std::collections::HashMap;
 use std::sync::Arc;
 use tempfile::TempDir;
+
+#[cfg(feature = "comms")]
+type DynCommsAgent = meerkat_comms::agent::CommsAgent<
+    dyn AgentLlmClient,
+    dyn AgentToolDispatcher,
+    dyn AgentSessionStore,
+>;
 
 // ============================================================================
 // ADAPTERS - Bridge LlmClient/SessionStore to Agent traits
@@ -821,7 +828,8 @@ mod scenario_06_hooks {
             .system_prompt("You are a helpful assistant. Keep responses brief.")
             .with_hook_engine(hook_engine)
             .build(llm_adapter, tools, store_adapter)
-            .await;
+            .await
+            .expect("public builder build");
 
         let result = agent
             .run("Say hello.".into())
@@ -956,16 +964,8 @@ mod scenario_08_comms {
     async fn create_agent_pair(
         api_key: &str,
     ) -> (
-        CommsAgent<
-            LlmClientAdapter<AnthropicClient>,
-            CommsToolDispatcher,
-            SessionStoreAdapter<JsonlStore>,
-        >,
-        CommsAgent<
-            LlmClientAdapter<AnthropicClient>,
-            CommsToolDispatcher,
-            SessionStoreAdapter<JsonlStore>,
-        >,
+        DynCommsAgent,
+        DynCommsAgent,
         meerkat_comms::agent::ListenerHandle,
         meerkat_comms::agent::ListenerHandle,
         TempDir,
@@ -1062,7 +1062,8 @@ mod scenario_08_comms {
                  To message agent-b, call `send` with kind `peer_message`.",
             )
             .build(llm_adapter_a, tools_a, store_adapter_a)
-            .await;
+            .await
+            .expect("public builder build");
 
         let agent_b_inner = AgentBuilder::new()
             .model(smoke_model())
@@ -1072,7 +1073,8 @@ mod scenario_08_comms {
                  Acknowledge any messages you receive.",
             )
             .build(llm_adapter_b, tools_b, store_adapter_b)
-            .await;
+            .await
+            .expect("public builder build");
 
         let agent_a = CommsAgent::new(agent_a_inner, comms_manager_a);
         let agent_b = CommsAgent::new(agent_b_inner, comms_manager_b);
@@ -1311,12 +1313,12 @@ mod scenario_10_memory {
         );
         let memory_tools: Arc<dyn AgentToolDispatcher> = Arc::new(memory_dispatcher);
 
-        // Build agent with memory store + compactor + memory_search tool
+        // Build a low-level core agent with memory store + compactor + memory_search tool
         let llm_client = Arc::new(AnthropicClient::new(api_key_val).unwrap());
         let llm_adapter = Arc::new(self::LlmClientAdapter::new(llm_client, smoke_model()));
         let (_store, store_adapter, _temp_dir) = create_temp_store().await;
 
-        let mut agent = AgentBuilder::new()
+        let mut agent = CoreAgentBuilder::new()
             .model(smoke_model())
             .max_tokens_per_turn(512)
             .system_prompt(
@@ -1327,6 +1329,9 @@ mod scenario_10_memory {
             .resume_session(memory_session)
             .memory_store(Arc::clone(&memory_store))
             .compactor(compactor)
+            .with_turn_state_handle(Arc::new(
+                meerkat_runtime::RuntimeTurnStateHandle::ephemeral(),
+            ))
             .build(llm_adapter, memory_tools, store_adapter)
             .await;
 


### PR DESCRIPTION
## Summary
- Replace the public `meerkat::AgentBuilder` re-export with a facade builder that routes through `AgentFactory::build_agent`.
- Keep `meerkat::CoreAgentBuilder` as the documented standalone primitive escape hatch.
- Add builder-vs-factory parity coverage for session/runtime invariants, provider defaults, hook routing, and the intentional core-builder escape hatch.

## Validation
- `./scripts/repo-cargo test -p meerkat --test sdk_agentfactory -- --nocapture`
- `./scripts/repo-cargo test -p meerkat --test sdk_structured_output -- --nocapture`
- `./scripts/repo-cargo check -p meerkat --all-targets --all-features`
- `make check` (BuildBuddy invocation `291d6ab3-04f2-4748-9a50-44e6c90a8043`)

Linear: LUC-124
