### PR TITLE
LUC-125 Make auth token clear release atomic

### DIFF
--- a/meerkat-cli/BUILD.bazel
+++ b/meerkat-cli/BUILD.bazel
@@ -186,6 +186,7 @@ rust_test(
         ":package_runfiles",
         "//:workspace_cargo_manifests",
         "//:workspace_metadata",
+        "//meerkat:package_runfiles",
         "//meerkat-cli:rkat",
         "//meerkat-cli:rkat_mini_bin",
     ],

--- a/meerkat-cli/src/main.rs
+++ b/meerkat-cli/src/main.rs
@@ -2936,6 +2936,7 @@ async fn handle_auth_command(command: AuthCommands, scope: &RuntimeScope) -> any
             // TokenStore lookup: `<realm>:<profile_id>` is the canonical key.
             #[cfg(all(feature = "anthropic", feature = "openai", feature = "gemini"))]
             {
+                use meerkat_core::handles::{AuthLeaseHandle, LeaseKey};
                 use meerkat_providers::auth_store::{TokenKey, TokenStoreBackend};
                 let store = TokenStoreBackend::default_auto()
                     .map_err(|e| anyhow::anyhow!("Cannot open TokenStore: {e}"))?
@@ -2943,13 +2944,25 @@ async fn handle_auth_command(command: AuthCommands, scope: &RuntimeScope) -> any
                     .map_err(|e| anyhow::anyhow!("Cannot open TokenStore: {e}"))?;
                 let key = TokenKey::parse(&realm, &profile_id)
                     .map_err(|e| anyhow::anyhow!("invalid token-key realm/profile: {e}"))?;
-                match store
+                let stored = store
                     .load(&key)
                     .await
-                    .map_err(|e| anyhow::anyhow!("TokenStore load failed: {e}"))?
-                {
+                    .map_err(|e| anyhow::anyhow!("TokenStore load failed: {e}"))?;
+                let connection_ref = meerkat_core::ConnectionRef {
+                    realm: key.realm.clone(),
+                    binding: key.binding.clone(),
+                    profile: key.profile.clone(),
+                };
+                let auth_lease = meerkat_runtime::RuntimeAuthLeaseHandle::new();
+                let snapshot = auth_lease.snapshot(&LeaseKey::from_connection_ref(&connection_ref));
+                let projection = meerkat_core::project_published_auth_status(
+                    chrono::Utc::now(),
+                    stored.as_ref(),
+                    &snapshot,
+                );
+                match projection.tokens {
                     Some(tokens) => {
-                        println!("state:       {}", AuthStatusPhase::Unknown.as_public_str());
+                        println!("state:       {}", projection.phase.as_public_str());
                         println!("auth_mode:   {:?}", tokens.auth_mode);
                         println!(
                             "has_secret:  {}",
@@ -2982,15 +2995,21 @@ async fn handle_auth_command(command: AuthCommands, scope: &RuntimeScope) -> any
                         println!("backend:     {}", store.backend_name());
                     }
                     None => {
-                        println!("state:       {}", AuthStatusPhase::Unknown.as_public_str());
+                        println!("state:       {}", projection.phase.as_public_str());
                         println!("backend:     {}", store.backend_name());
-                        println!(
-                            "note:        no persisted credential for '{realm}:{profile_id}';"
-                        );
-                        println!(
-                            "             run `rkat auth login {}` or rely on env-var fallback.",
-                            profile.provider.as_str(),
-                        );
+                        if stored.is_none() {
+                            println!(
+                                "note:        no persisted credential for '{realm}:{profile_id}';"
+                            );
+                            println!(
+                                "             run `rkat auth login {}` or rely on env-var fallback.",
+                                profile.provider.as_str(),
+                            );
+                        } else {
+                            println!(
+                                "note:        persisted credential metadata hidden until AuthMachine lifecycle is live."
+                            );
+                        }
                     }
                 }
             }
@@ -3040,15 +3059,25 @@ async fn handle_auth_command(command: AuthCommands, scope: &RuntimeScope) -> any
                     .map_err(|e| anyhow::anyhow!("Cannot open TokenStore: {e}"))?;
                 let key = TokenKey::parse(&realm, &profile_id)
                     .map_err(|e| anyhow::anyhow!("invalid token-key realm/profile: {e}"))?;
-                let present = store
-                    .load(&key)
+                let should_clear = match store.load(&key).await {
+                    Ok(present) => present.is_some(),
+                    Err(e) if token_store_load_error_allows_clear(&e) => true,
+                    Err(e) => return Err(anyhow::anyhow!("TokenStore load failed: {e}")),
+                };
+                if should_clear {
+                    let connection_ref = meerkat_core::ConnectionRef {
+                        realm: key.realm.clone(),
+                        binding: key.binding.clone(),
+                        profile: key.profile.clone(),
+                    };
+                    let auth_lease = meerkat_runtime::RuntimeAuthLeaseHandle::new();
+                    meerkat_core::clear_tokens_and_publish_lifecycle_released(
+                        store.as_ref(),
+                        &auth_lease,
+                        &connection_ref,
+                    )
                     .await
-                    .map_err(|e| anyhow::anyhow!("TokenStore load failed: {e}"))?;
-                if present.is_some() {
-                    store
-                        .clear(&key)
-                        .await
-                        .map_err(|e| anyhow::anyhow!("TokenStore clear failed: {e}"))?;
+                    .map_err(|e| anyhow::anyhow!("Token lifecycle clear failed: {e}"))?;
                     println!("deleted: {}:{}", key.realm.as_str(), key.binding.as_str());
                 } else {
                     println!(
@@ -3882,6 +3911,11 @@ async fn interactive_login(
 }
 
 #[cfg(all(feature = "anthropic", feature = "openai", feature = "gemini"))]
+fn token_store_load_error_allows_clear(e: &meerkat_providers::auth_store::TokenStoreError) -> bool {
+    matches!(e, meerkat_providers::auth_store::TokenStoreError::Serde(_))
+}
+
+#[cfg(all(feature = "anthropic", feature = "openai", feature = "gemini"))]
 async fn interactive_logout(profile_id: &str, _scope: &RuntimeScope) -> anyhow::Result<()> {
     use meerkat_providers::auth_store::{TokenKey, TokenStoreBackend};
 
@@ -3905,16 +3939,26 @@ async fn interactive_logout(profile_id: &str, _scope: &RuntimeScope) -> anyhow::
         ],
     };
     let mut cleared = 0;
+    let auth_lease = meerkat_runtime::RuntimeAuthLeaseHandle::new();
     for key in keys {
-        let present = store
-            .load(&key)
+        let should_clear = match store.load(&key).await {
+            Ok(present) => present.is_some(),
+            Err(e) if token_store_load_error_allows_clear(&e) => true,
+            Err(e) => return Err(anyhow::anyhow!("TokenStore load failed: {e}")),
+        };
+        if should_clear {
+            let connection_ref = meerkat_core::ConnectionRef {
+                realm: key.realm.clone(),
+                binding: key.binding.clone(),
+                profile: key.profile.clone(),
+            };
+            meerkat_core::clear_tokens_and_publish_lifecycle_released(
+                store.as_ref(),
+                &auth_lease,
+                &connection_ref,
+            )
             .await
-            .map_err(|e| anyhow::anyhow!("TokenStore load failed: {e}"))?;
-        if present.is_some() {
-            store
-                .clear(&key)
-                .await
-                .map_err(|e| anyhow::anyhow!("TokenStore clear failed: {e}"))?;
+            .map_err(|e| anyhow::anyhow!("Token lifecycle clear failed: {e}"))?;
             eprintln!(
                 "{} Cleared {}:{}",
                 auth_green("✓"),

--- a/meerkat-cli/tests/cli_auth_flow.rs
+++ b/meerkat-cli/tests/cli_auth_flow.rs
@@ -15,6 +15,51 @@
 use std::path::PathBuf;
 use std::process::{Command, Stdio};
 
+fn seed_managed_openai_realm_config(root: &std::path::Path) {
+    let realm_dir = root.join("realms").join("dev");
+    std::fs::create_dir_all(&realm_dir).expect("mkdir realm config dir");
+    std::fs::write(
+        realm_dir.join("config.toml"),
+        r#"
+[realm.dev]
+default_binding = "default_openai"
+
+[realm.dev.backend.openai_backend]
+provider = "openai"
+backend_kind = "openai_api"
+
+[realm.dev.auth.default_openai]
+provider = "openai"
+auth_method = "api_key"
+source = { kind = "managed_store" }
+
+[realm.dev.binding.default_openai]
+backend_profile = "openai_backend"
+auth_profile = "default_openai"
+"#,
+    )
+    .expect("write realm config");
+}
+
+fn seed_token_file(root: &std::path::Path, body: &str) {
+    let token_dir = root
+        .join("config")
+        .join("meerkat")
+        .join("credentials")
+        .join("dev");
+    std::fs::create_dir_all(&token_dir).expect("mkdir token dir");
+    std::fs::write(token_dir.join("default_openai.json"), body).expect("write token file");
+}
+
+fn token_file_exists(root: &std::path::Path) -> bool {
+    root.join("config")
+        .join("meerkat")
+        .join("credentials")
+        .join("dev")
+        .join("default_openai.json")
+        .exists()
+}
+
 fn rkat_binary() -> Option<PathBuf> {
     if let Some(path) = std::env::var_os("CARGO_BIN_EXE_rkat") {
         let p = PathBuf::from(path);
@@ -68,6 +113,153 @@ fn rkat_auth_help_lists_all_subcommands() {
         assert!(
             stdout.contains(subcommand),
             "rkat auth --help must mention `{subcommand}` subcommand; stdout:\n{stdout}"
+        );
+    }
+}
+
+#[test]
+fn rkat_auth_logout_clears_malformed_token_file() {
+    let Some(rkat) = rkat_binary() else {
+        eprintln!("SKIP: rkat binary unavailable");
+        return;
+    };
+
+    let tmp = tempfile::TempDir::new().expect("tempdir");
+    seed_token_file(tmp.path(), "{ malformed token json");
+
+    let logout = Command::new(&rkat)
+        .args(["auth", "logout", "default_openai"])
+        .env("HOME", tmp.path())
+        .env("XDG_CONFIG_HOME", tmp.path().join("config"))
+        .stdin(Stdio::null())
+        .output()
+        .expect("rkat auth logout must spawn");
+    if !logout.status.success() {
+        let stderr = String::from_utf8_lossy(&logout.stderr);
+        if stderr.contains("requires the `anthropic`, `openai`, and `gemini`") {
+            eprintln!("SKIP: auth provider features unavailable");
+            return;
+        }
+        panic!("logout must clear malformed token file; stderr={stderr}");
+    }
+
+    assert!(
+        !token_file_exists(tmp.path()),
+        "logout must remove malformed persisted credentials"
+    );
+}
+
+#[test]
+fn rkat_auth_profile_delete_clears_malformed_token_file() {
+    let Some(rkat) = rkat_binary() else {
+        eprintln!("SKIP: rkat binary unavailable");
+        return;
+    };
+
+    let tmp = tempfile::TempDir::new().expect("tempdir");
+    seed_managed_openai_realm_config(tmp.path());
+    seed_token_file(tmp.path(), "{ malformed token json");
+
+    let delete = Command::new(&rkat)
+        .args([
+            "--state-root",
+            tmp.path().join("realms").to_str().expect("utf8 path"),
+            "--realm",
+            "dev",
+            "auth",
+            "profile-delete",
+            "--realm",
+            "dev",
+            "default_openai",
+            "--yes",
+        ])
+        .env("HOME", tmp.path())
+        .env("XDG_CONFIG_HOME", tmp.path().join("config"))
+        .stdin(Stdio::null())
+        .output()
+        .expect("rkat auth profile-delete must spawn");
+    if !delete.status.success() {
+        let stderr = String::from_utf8_lossy(&delete.stderr);
+        if stderr.contains("requires the `anthropic`, `openai`, and `gemini`") {
+            eprintln!("SKIP: auth provider features unavailable");
+            return;
+        }
+        panic!("profile delete must clear malformed token file; stderr={stderr}");
+    }
+
+    assert!(
+        !token_file_exists(tmp.path()),
+        "profile delete must remove malformed persisted credentials"
+    );
+}
+
+#[test]
+fn rkat_auth_status_hides_token_metadata_without_lifecycle() {
+    let Some(rkat) = rkat_binary() else {
+        eprintln!("SKIP: rkat binary unavailable");
+        return;
+    };
+
+    let tmp = tempfile::TempDir::new().expect("tempdir");
+    seed_managed_openai_realm_config(tmp.path());
+    seed_token_file(
+        tmp.path(),
+        r#"{
+  "auth_mode": "api_key",
+  "primary_secret": "sk-stale",
+  "refresh_token": "refresh-stale",
+  "expires_at": 1800000000,
+  "last_refresh": 1700000000,
+  "scopes": ["email"],
+  "account_id": "acct-stale"
+}"#,
+    );
+
+    let status = Command::new(&rkat)
+        .args([
+            "--state-root",
+            tmp.path().join("realms").to_str().expect("utf8 path"),
+            "--realm",
+            "dev",
+            "auth",
+            "status",
+            "--realm",
+            "dev",
+            "default_openai",
+        ])
+        .env("HOME", tmp.path())
+        .env("XDG_CONFIG_HOME", tmp.path().join("config"))
+        .stdin(Stdio::null())
+        .output()
+        .expect("rkat auth status must spawn");
+    if !status.status.success() {
+        let stderr = String::from_utf8_lossy(&status.stderr);
+        if stderr.contains("requires the `anthropic`, `openai`, and `gemini`") {
+            eprintln!("SKIP: auth provider features unavailable");
+            return;
+        }
+        panic!("status must succeed with seeded config; stderr={stderr}");
+    }
+
+    let stdout = String::from_utf8_lossy(&status.stdout);
+    assert!(
+        stdout.contains("state:       unknown"),
+        "status should report unknown without a live AuthMachine lifecycle; stdout:\n{stdout}"
+    );
+    for forbidden in [
+        "auth_mode:",
+        "has_secret:",
+        "has_refresh:",
+        "expires_at:",
+        "last_refresh:",
+        "account_id:",
+        "scopes:",
+        "acct-stale",
+        "email",
+    ] {
+        assert!(
+            !stdout.contains(forbidden),
+            "status must not expose token-derived `{forbidden}` without lifecycle; stdout:\n{stdout}"
         );
     }
 }
@@ -146,5 +338,74 @@ fn rkat_run_connection_ref_flag_is_registered_and_routes() {
     assert!(
         !stderr.contains("thread 'main' panicked"),
         "rkat run must not panic on unknown realm; stderr:\n{stderr}"
+    );
+}
+
+/// `rkat auth logout` clears the same TokenStore key written by scripted login
+/// and fails closed on a repeat clear instead of reporting success for stale
+/// credentials.
+#[test]
+fn rkat_auth_logout_clears_scripted_login_token_key() {
+    let Some(rkat) = rkat_binary() else {
+        eprintln!("SKIP: rkat binary unavailable");
+        return;
+    };
+
+    let tmp = tempfile::TempDir::new().expect("tempdir");
+    let login = Command::new(&rkat)
+        .args([
+            "auth",
+            "login",
+            "openai",
+            "--non-interactive",
+            "--secret",
+            "sk-test",
+        ])
+        .env("HOME", tmp.path())
+        .env("XDG_CONFIG_HOME", tmp.path())
+        .stdin(Stdio::null())
+        .output()
+        .expect("rkat auth login must spawn");
+    if !login.status.success() {
+        let stderr = String::from_utf8_lossy(&login.stderr);
+        if stderr.contains("requires the `anthropic`, `openai`, and `gemini`") {
+            eprintln!("SKIP: auth provider features unavailable");
+            return;
+        }
+        panic!("scripted login failed: {stderr}");
+    }
+
+    let logout = Command::new(&rkat)
+        .args(["auth", "logout", "default_openai"])
+        .env("HOME", tmp.path())
+        .env("XDG_CONFIG_HOME", tmp.path())
+        .stdin(Stdio::null())
+        .output()
+        .expect("rkat auth logout must spawn");
+    assert!(
+        logout.status.success(),
+        "logout must clear scripted login token; stderr={}",
+        String::from_utf8_lossy(&logout.stderr)
+    );
+
+    let repeat = Command::new(&rkat)
+        .args(["auth", "logout", "default_openai"])
+        .env("HOME", tmp.path())
+        .env("XDG_CONFIG_HOME", tmp.path())
+        .stdin(Stdio::null())
+        .output()
+        .expect("repeat rkat auth logout must spawn");
+    assert!(
+        !repeat.status.success(),
+        "repeat logout must not report success for already-cleared credentials"
+    );
+    let stderr = String::from_utf8_lossy(&repeat.stderr);
+    assert!(
+        stderr.contains("No credentials found"),
+        "repeat logout should explain that no token remains; stderr={stderr}"
+    );
+    assert!(
+        !stderr.contains("thread 'main' panicked"),
+        "repeat logout must not panic; stderr={stderr}"
     );
 }

--- a/meerkat-core/src/auth/lifecycle.rs
+++ b/meerkat-core/src/auth/lifecycle.rs
@@ -6,10 +6,14 @@
 //! persisted token bytes.
 
 use chrono::{DateTime, Utc};
+use thiserror::Error;
 
-use super::token_store::PersistedTokens;
+use super::status::AuthStatusPhase;
+use super::token_store::{PersistedTokens, TokenKey, TokenStore, TokenStoreError};
 use crate::connection::ConnectionRef;
-use crate::handles::{AuthLeaseHandle, AuthLeaseSnapshot, DslTransitionError, LeaseKey};
+use crate::handles::{
+    AuthLeaseHandle, AuthLeasePhase, AuthLeaseSnapshot, DslTransitionError, LeaseKey,
+};
 
 pub fn persisted_token_expires_at_epoch_secs(tokens: &PersistedTokens) -> u64 {
     tokens
@@ -35,11 +39,143 @@ pub fn publish_token_lifecycle_released(
     handle.release_lease(&lease_key)
 }
 
+#[derive(Debug, Error)]
+pub enum TokenLifecycleClearError {
+    #[error("AuthMachine lifecycle release failed: {0}")]
+    AuthMachineRelease(DslTransitionError),
+    #[error("TokenStore clear failed: {0}")]
+    TokenStoreClear(TokenStoreError),
+    #[error("TokenStore load failed: {load_error}; TokenStore clear failed: {clear_error}")]
+    TokenStoreLoadAndClear {
+        load_error: TokenStoreError,
+        clear_error: TokenStoreError,
+    },
+    #[error(
+        "TokenStore clear failed: {clear_error}; AuthMachine lifecycle restore failed: {restore_error}"
+    )]
+    TokenStoreClearAndLifecycleRestore {
+        clear_error: TokenStoreError,
+        restore_error: DslTransitionError,
+    },
+}
+
+/// Clear persisted token material and release the AuthMachine lifecycle as one
+/// fail-closed boundary.
+///
+/// When the previous token snapshot can be loaded, the AuthMachine release
+/// happens first. If the token clear then fails, the previous lifecycle snapshot
+/// is restored so public status does not commit a split "token exists but
+/// lifecycle is gone" state. When token material is unreadable, there is no
+/// durable token snapshot to restore, so release is delayed until clear succeeds.
+pub async fn clear_tokens_and_publish_lifecycle_released(
+    store: &dyn TokenStore,
+    handle: &dyn AuthLeaseHandle,
+    connection_ref: &ConnectionRef,
+) -> Result<(), TokenLifecycleClearError> {
+    let key = TokenKey::from_connection_ref(connection_ref);
+    let lease_key = LeaseKey::from_connection_ref(connection_ref);
+    let previous_lifecycle = handle.snapshot(&lease_key);
+    let previous = match store.load(&key).await {
+        Ok(previous) => previous,
+        Err(load_error) => {
+            if let Err(clear_error) = store.clear(&key).await {
+                return Err(TokenLifecycleClearError::TokenStoreLoadAndClear {
+                    load_error,
+                    clear_error,
+                });
+            }
+            publish_token_lifecycle_released(handle, connection_ref)
+                .map_err(TokenLifecycleClearError::AuthMachineRelease)?;
+            return Ok(());
+        }
+    };
+    publish_token_lifecycle_released(handle, connection_ref)
+        .map_err(TokenLifecycleClearError::AuthMachineRelease)?;
+    if let Err(clear_error) = store.clear(&key).await {
+        if let Err(restore_error) = restore_token_lifecycle_snapshot(
+            handle,
+            &lease_key,
+            &previous_lifecycle,
+            previous.as_ref(),
+        ) {
+            return Err(
+                TokenLifecycleClearError::TokenStoreClearAndLifecycleRestore {
+                    clear_error,
+                    restore_error,
+                },
+            );
+        }
+        return Err(TokenLifecycleClearError::TokenStoreClear(clear_error));
+    }
+    Ok(())
+}
+
+fn restore_token_lifecycle_snapshot(
+    handle: &dyn AuthLeaseHandle,
+    lease_key: &LeaseKey,
+    snapshot: &AuthLeaseSnapshot,
+    previous: Option<&PersistedTokens>,
+) -> Result<(), DslTransitionError> {
+    let Some(phase) = snapshot.phase else {
+        return Ok(());
+    };
+    if phase == AuthLeasePhase::Released {
+        return Ok(());
+    }
+
+    let expires_at = snapshot
+        .expires_at
+        .or_else(|| previous.map(persisted_token_expires_at_epoch_secs))
+        .unwrap_or(u64::MAX);
+    handle.acquire_lease(lease_key, expires_at)?;
+    match phase {
+        AuthLeasePhase::Valid => Ok(()),
+        AuthLeasePhase::Expiring => handle.mark_expiring(lease_key),
+        AuthLeasePhase::Refreshing => handle.begin_refresh(lease_key),
+        AuthLeasePhase::ReauthRequired => handle.mark_reauth_required(lease_key),
+        AuthLeasePhase::Released => Ok(()),
+    }
+}
+
 pub fn lease_snapshot_expires_at_datetime(snapshot: &AuthLeaseSnapshot) -> Option<DateTime<Utc>> {
     snapshot
         .expires_at
         .and_then(|secs| i64::try_from(secs).ok())
         .and_then(|secs| DateTime::<Utc>::from_timestamp(secs, 0))
+}
+
+#[derive(Debug)]
+pub struct PublishedAuthStatus<'a> {
+    pub phase: AuthStatusPhase,
+    pub expires_at: Option<DateTime<Utc>>,
+    pub tokens: Option<&'a PersistedTokens>,
+}
+
+pub fn project_published_auth_status<'a>(
+    now: DateTime<Utc>,
+    stored: Option<&'a PersistedTokens>,
+    snapshot: &AuthLeaseSnapshot,
+) -> PublishedAuthStatus<'a> {
+    let Some(tokens) = stored else {
+        return PublishedAuthStatus {
+            phase: AuthStatusPhase::Unknown,
+            expires_at: None,
+            tokens: None,
+        };
+    };
+    let phase = AuthStatusPhase::from_lease_snapshot(now, snapshot);
+    if phase == AuthStatusPhase::Unknown {
+        return PublishedAuthStatus {
+            phase,
+            expires_at: None,
+            tokens: None,
+        };
+    }
+    PublishedAuthStatus {
+        phase,
+        expires_at: lease_snapshot_expires_at_datetime(snapshot).or(tokens.expires_at),
+        tokens: Some(tokens),
+    }
 }
 
 #[cfg(test)]
@@ -51,6 +187,7 @@ mod tests {
     use crate::auth::PersistedAuthMode;
     use crate::connection::{BindingId, RealmId};
     use crate::handles::{AuthLeasePhase, DslTransitionError};
+    use async_trait::async_trait;
 
     #[derive(Default)]
     struct RecordingAuthLeaseHandle {
@@ -61,6 +198,13 @@ mod tests {
     impl RecordingAuthLeaseHandle {
         fn acquired(&self) -> Vec<(LeaseKey, u64)> {
             self.acquired
+                .lock()
+                .unwrap_or_else(std::sync::PoisonError::into_inner)
+                .clone()
+        }
+
+        fn released(&self) -> Vec<LeaseKey> {
+            self.released
                 .lock()
                 .unwrap_or_else(std::sync::PoisonError::into_inner)
                 .clone()
@@ -147,6 +291,116 @@ mod tests {
         }
     }
 
+    struct ClearFailingTokenStore {
+        tokens: Mutex<Option<PersistedTokens>>,
+    }
+
+    impl ClearFailingTokenStore {
+        fn new(tokens: PersistedTokens) -> Self {
+            Self {
+                tokens: Mutex::new(Some(tokens)),
+            }
+        }
+    }
+
+    struct LoadFailingTokenStore {
+        cleared: Mutex<bool>,
+        clear_error: bool,
+    }
+
+    impl LoadFailingTokenStore {
+        fn new() -> Self {
+            Self {
+                cleared: Mutex::new(false),
+                clear_error: false,
+            }
+        }
+
+        fn new_with_clear_error() -> Self {
+            Self {
+                cleared: Mutex::new(false),
+                clear_error: true,
+            }
+        }
+
+        fn cleared(&self) -> bool {
+            *self
+                .cleared
+                .lock()
+                .unwrap_or_else(std::sync::PoisonError::into_inner)
+        }
+    }
+
+    #[async_trait]
+    impl TokenStore for LoadFailingTokenStore {
+        async fn load(&self, _key: &TokenKey) -> Result<Option<PersistedTokens>, TokenStoreError> {
+            Err(TokenStoreError::Serde("corrupt token".into()))
+        }
+
+        async fn save(
+            &self,
+            _key: &TokenKey,
+            _tokens: &PersistedTokens,
+        ) -> Result<(), TokenStoreError> {
+            Ok(())
+        }
+
+        async fn clear(&self, _key: &TokenKey) -> Result<(), TokenStoreError> {
+            *self
+                .cleared
+                .lock()
+                .unwrap_or_else(std::sync::PoisonError::into_inner) = true;
+            if self.clear_error {
+                Err(TokenStoreError::Unavailable("clear unavailable".into()))
+            } else {
+                Ok(())
+            }
+        }
+
+        async fn list(&self) -> Result<Vec<TokenKey>, TokenStoreError> {
+            Ok(Vec::new())
+        }
+
+        fn backend_name(&self) -> &'static str {
+            "load_failing"
+        }
+    }
+
+    #[async_trait]
+    impl TokenStore for ClearFailingTokenStore {
+        async fn load(&self, _key: &TokenKey) -> Result<Option<PersistedTokens>, TokenStoreError> {
+            Ok(self
+                .tokens
+                .lock()
+                .unwrap_or_else(std::sync::PoisonError::into_inner)
+                .clone())
+        }
+
+        async fn save(
+            &self,
+            _key: &TokenKey,
+            tokens: &PersistedTokens,
+        ) -> Result<(), TokenStoreError> {
+            *self
+                .tokens
+                .lock()
+                .unwrap_or_else(std::sync::PoisonError::into_inner) = Some(tokens.clone());
+            Ok(())
+        }
+
+        async fn clear(&self, _key: &TokenKey) -> Result<(), TokenStoreError> {
+            Err(TokenStoreError::Unavailable("clear unavailable".into()))
+        }
+
+        async fn list(&self) -> Result<Vec<TokenKey>, TokenStoreError> {
+            Ok(Vec::new())
+        }
+
+        fn backend_name(&self) -> &'static str {
+            "clear_failing"
+        }
+    }
+
     #[test]
     fn lifecycle_acquire_uses_persisted_token_expiry_as_machine_input() {
         let handle = RecordingAuthLeaseHandle::default();
@@ -173,5 +427,81 @@ mod tests {
         publish_token_lifecycle_acquired(&handle, &connection_ref(), &tokens).unwrap();
 
         assert_eq!(handle.acquired()[0].1, u64::MAX);
+    }
+
+    #[tokio::test]
+    async fn clear_boundary_restores_lifecycle_when_token_clear_fails() {
+        let handle = RecordingAuthLeaseHandle::default();
+        let expires_at = DateTime::<Utc>::from_timestamp(1_800_000_000, 0).unwrap();
+        let tokens = tokens_with_expiry(Some(expires_at));
+        let store = ClearFailingTokenStore::new(tokens.clone());
+        let connection_ref = connection_ref();
+
+        let err = clear_tokens_and_publish_lifecycle_released(&store, &handle, &connection_ref)
+            .await
+            .unwrap_err();
+
+        assert!(matches!(err, TokenLifecycleClearError::TokenStoreClear(_)));
+        assert_eq!(
+            handle.released(),
+            vec![LeaseKey::from_connection_ref(&connection_ref)]
+        );
+        assert_eq!(
+            handle.acquired(),
+            vec![(
+                LeaseKey::from_connection_ref(&connection_ref),
+                persisted_token_expires_at_epoch_secs(&tokens),
+            )]
+        );
+        assert!(
+            store
+                .load(&TokenKey::from_connection_ref(&connection_ref))
+                .await
+                .unwrap()
+                .is_some()
+        );
+    }
+
+    #[tokio::test]
+    async fn clear_boundary_allows_clear_when_previous_token_load_fails() {
+        let handle = RecordingAuthLeaseHandle::default();
+        let store = LoadFailingTokenStore::new();
+        let connection_ref = connection_ref();
+
+        clear_tokens_and_publish_lifecycle_released(&store, &handle, &connection_ref)
+            .await
+            .unwrap();
+
+        assert_eq!(
+            handle.released(),
+            vec![LeaseKey::from_connection_ref(&connection_ref)]
+        );
+        assert!(store.cleared());
+        assert!(
+            handle.acquired().is_empty(),
+            "unreadable previous tokens cannot be used to restore a lease"
+        );
+    }
+
+    #[tokio::test]
+    async fn clear_boundary_does_not_release_lifecycle_when_load_and_clear_fail() {
+        let handle = RecordingAuthLeaseHandle::default();
+        let store = LoadFailingTokenStore::new_with_clear_error();
+        let connection_ref = connection_ref();
+
+        let err = clear_tokens_and_publish_lifecycle_released(&store, &handle, &connection_ref)
+            .await
+            .unwrap_err();
+
+        assert!(matches!(
+            err,
+            TokenLifecycleClearError::TokenStoreLoadAndClear { .. }
+        ));
+        assert!(store.cleared());
+        assert!(
+            handle.released().is_empty(),
+            "lifecycle must remain untouched when unreadable token material cannot be cleared"
+        );
+        assert!(handle.acquired().is_empty());
     }
 }

--- a/meerkat-core/src/auth/mod.rs
+++ b/meerkat-core/src/auth/mod.rs
@@ -19,8 +19,10 @@ pub use lease::{
     ResolvedAuthEnvelope, ResolvedAuthKind,
 };
 pub use lifecycle::{
+    PublishedAuthStatus, TokenLifecycleClearError, clear_tokens_and_publish_lifecycle_released,
     lease_snapshot_expires_at_datetime, persisted_token_expires_at_epoch_secs,
-    publish_token_lifecycle_acquired, publish_token_lifecycle_released,
+    project_published_auth_status, publish_token_lifecycle_acquired,
+    publish_token_lifecycle_released,
 };
 pub use metadata::{
     AnthropicAuthMetadata, AnthropicRouteHints, AuthMetadata, AuthMetadataDefaults, AuthRouteHints,

--- a/meerkat-core/src/lib.rs
+++ b/meerkat-core/src/lib.rs
@@ -288,9 +288,11 @@ pub use auth::{
     AuthErrorSummary, AuthLease, AuthMetadata, AuthMetadataDefaults, AuthRefreshReason,
     AuthRouteHints, AuthStatus, AuthStatusPhase, GoogleAuthMetadata, GoogleRouteHints,
     HttpAuthorizationRequest, HttpAuthorizer, OpenAiAuthMetadata, OpenAiRouteHints,
-    ProviderAuthMetadata, ResolvedAuthEnvelope, ResolvedAuthKind,
+    ProviderAuthMetadata, PublishedAuthStatus, ResolvedAuthEnvelope, ResolvedAuthKind,
+    TokenLifecycleClearError, clear_tokens_and_publish_lifecycle_released,
     lease_snapshot_expires_at_datetime, persisted_token_expires_at_epoch_secs,
-    publish_token_lifecycle_acquired, publish_token_lifecycle_released,
+    project_published_auth_status, publish_token_lifecycle_acquired,
+    publish_token_lifecycle_released,
 };
 pub use connection::{
     AuthProfile, AuthProfileConfig, BackendProfile, BackendProfileConfig, BindingId, BindingPolicy,

--- a/meerkat-rest/src/auth_endpoints.rs
+++ b/meerkat-rest/src/auth_endpoints.rs
@@ -26,8 +26,7 @@ use meerkat_contracts::{
 use meerkat_core::connection::{BindingId, ConnectionTargetError, ProfileId, RealmId};
 use meerkat_core::handles::LeaseKey;
 use meerkat_core::{
-    AuthStatusPhase, ConnectionRef, CredentialSourceSpec, Provider, RealmConnectionSet,
-    ResolvedConnectionTarget,
+    ConnectionRef, CredentialSourceSpec, Provider, RealmConnectionSet, ResolvedConnectionTarget,
 };
 use meerkat_providers::auth_oauth::{
     DevicePollOutcome, OAuthError, PkcePair, exchange_authorization_code, poll_device_code,
@@ -231,19 +230,13 @@ async fn clear_tokens_and_publish_lifecycle(
     auth_lease: &dyn meerkat_core::handles::AuthLeaseHandle,
     connection_ref: &ConnectionRef,
 ) -> Result<(), (StatusCode, String)> {
-    let key = TokenKey::from_connection_ref(connection_ref);
-    token_store.clear(&key).await.map_err(|e| {
-        (
-            StatusCode::INTERNAL_SERVER_ERROR,
-            format!("TokenStore clear failed: {e}"),
-        )
-    })?;
-    meerkat_core::publish_token_lifecycle_released(auth_lease, connection_ref).map_err(|e| {
-        (
-            StatusCode::INTERNAL_SERVER_ERROR,
-            format!("AuthMachine lifecycle release failed: {e}"),
-        )
-    })
+    meerkat_core::clear_tokens_and_publish_lifecycle_released(
+        token_store,
+        auth_lease,
+        connection_ref,
+    )
+    .await
+    .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))
 }
 
 // --- Realm endpoints -------------------------------------------------
@@ -1093,8 +1086,9 @@ pub async fn get_auth_status(
     let snapshot = state
         .auth_lease
         .snapshot(&LeaseKey::from_connection_ref(&connection_ref));
-    let state_phase = AuthStatusPhase::from_lease_snapshot(chrono::Utc::now(), &snapshot);
-    let lease_expires_at = meerkat_core::lease_snapshot_expires_at_datetime(&snapshot);
+    let projection =
+        meerkat_core::project_published_auth_status(chrono::Utc::now(), stored.as_ref(), &snapshot);
+    let tokens = projection.tokens;
     (
         StatusCode::OK,
         Json(WireAuthStatusDetail {
@@ -1102,18 +1096,11 @@ pub async fn get_auth_status(
             profile_id: auth_profile.id.clone(),
             provider: auth_profile.provider.as_str().to_string(),
             auth_method: auth_profile.auth_method.clone(),
-            state: state_phase.as_public_str().to_string(),
-            expires_at: lease_expires_at
-                .or_else(|| stored.as_ref().and_then(|t| t.expires_at))
-                .map(|e| e.to_rfc3339()),
-            last_refresh_at: stored
-                .as_ref()
-                .and_then(|t| t.last_refresh.map(|e| e.to_rfc3339())),
-            account_id: stored.as_ref().and_then(|t| t.account_id.clone()),
-            has_refresh_token: stored
-                .as_ref()
-                .map(|t| t.refresh_token.is_some())
-                .unwrap_or(false),
+            state: projection.phase.as_public_str().to_string(),
+            expires_at: projection.expires_at.map(|e| e.to_rfc3339()),
+            last_refresh_at: tokens.and_then(|t| t.last_refresh.map(|e| e.to_rfc3339())),
+            account_id: tokens.and_then(|t| t.account_id.clone()),
+            has_refresh_token: tokens.map(|t| t.refresh_token.is_some()).unwrap_or(false),
         }),
     )
         .into_response()
@@ -1255,6 +1242,61 @@ mod tests {
         }
     }
 
+    struct ReleaseRejectingAuthLeaseHandle;
+
+    impl AuthLeaseHandle for ReleaseRejectingAuthLeaseHandle {
+        fn acquire_lease(
+            &self,
+            _lease_key: &LeaseKey,
+            _expires_at: u64,
+        ) -> Result<(), DslTransitionError> {
+            Ok(())
+        }
+
+        fn mark_expiring(&self, _lease_key: &LeaseKey) -> Result<(), DslTransitionError> {
+            Ok(())
+        }
+
+        fn begin_refresh(&self, _lease_key: &LeaseKey) -> Result<(), DslTransitionError> {
+            Ok(())
+        }
+
+        fn complete_refresh(
+            &self,
+            _lease_key: &LeaseKey,
+            _new_expires_at: u64,
+            _now: u64,
+        ) -> Result<(), DslTransitionError> {
+            Ok(())
+        }
+
+        fn refresh_failed(
+            &self,
+            _lease_key: &LeaseKey,
+            _permanent: bool,
+        ) -> Result<(), DslTransitionError> {
+            Ok(())
+        }
+
+        fn mark_reauth_required(&self, _lease_key: &LeaseKey) -> Result<(), DslTransitionError> {
+            Ok(())
+        }
+
+        fn release_lease(&self, _lease_key: &LeaseKey) -> Result<(), DslTransitionError> {
+            Err(DslTransitionError::guard_rejected(
+                "release_lease",
+                "test rejection",
+            ))
+        }
+
+        fn snapshot(&self, _lease_key: &LeaseKey) -> AuthLeaseSnapshot {
+            AuthLeaseSnapshot {
+                phase: Some(AuthLeasePhase::Valid),
+                expires_at: Some(1_800_000_000),
+            }
+        }
+    }
+
     fn config_with_openai_managed_store_binding() -> meerkat_core::Config {
         let mut config = meerkat_core::Config::default();
         let mut section = meerkat_core::RealmConfigSection::default();
@@ -1296,6 +1338,15 @@ mod tests {
         assert_eq!(response.status(), StatusCode::OK);
         let body = to_bytes(response.into_body(), usize::MAX).await.unwrap();
         serde_json::from_slice(&body).unwrap()
+    }
+
+    fn install_ephemeral_auth_state(state: &mut AppState) {
+        let auth_lease: Arc<dyn AuthLeaseHandle> = Arc::new(RuntimeAuthLeaseHandle::new());
+        state
+            .runtime_adapter
+            .set_auth_lease_handle(Arc::clone(&auth_lease));
+        state.auth_lease = auth_lease;
+        state.token_store = Arc::new(EphemeralTokenStore::new());
     }
 
     #[tokio::test]
@@ -1346,11 +1397,135 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn rest_auth_status_observes_session_runtime_binding_lifecycle() {
+    async fn rest_token_clear_release_failure_keeps_credentials() {
+        let store = EphemeralTokenStore::new();
+        let auth_lease = ReleaseRejectingAuthLeaseHandle;
+        let connection_ref = managed_connection_ref();
+        let key = TokenKey::from_connection_ref(&connection_ref);
+        store.save(&key, &api_key_tokens()).await.unwrap();
+
+        let err = clear_tokens_and_publish_lifecycle(&store, &auth_lease, &connection_ref)
+            .await
+            .unwrap_err();
+
+        assert_eq!(err.0, StatusCode::INTERNAL_SERVER_ERROR);
+        assert!(err.1.contains("AuthMachine lifecycle release failed"));
+        assert!(
+            store.load(&key).await.unwrap().is_some(),
+            "token clear must not commit when AuthMachine release fails"
+        );
+    }
+
+    #[tokio::test]
+    async fn rest_auth_status_hides_stale_token_without_auth_machine_lifecycle() {
         let temp = tempfile::tempdir().unwrap();
-        let state = AppState::load_from(temp.path().to_path_buf())
+        let mut state = AppState::load_from(temp.path().to_path_buf())
             .await
             .unwrap();
+        install_ephemeral_auth_state(&mut state);
+        state
+            .config_runtime
+            .set(config_with_openai_managed_store_binding(), None)
+            .await
+            .unwrap();
+        let connection_ref = ConnectionRef {
+            realm: RealmId::parse("dev").unwrap(),
+            binding: BindingId::parse("default_openai").unwrap(),
+            profile: None,
+        };
+        state
+            .token_store
+            .save(
+                &TokenKey::from_connection_ref(&connection_ref),
+                &PersistedTokens {
+                    auth_mode: PersistedAuthMode::ApiKey,
+                    primary_secret: Some("sk-stale".into()),
+                    refresh_token: Some("refresh-stale".into()),
+                    id_token: None,
+                    expires_at: Some(chrono::DateTime::from_timestamp(1_800_000_000, 0).unwrap()),
+                    last_refresh: Some(chrono::DateTime::from_timestamp(1_700_000_000, 0).unwrap()),
+                    scopes: Vec::new(),
+                    account_id: Some("acct-stale".into()),
+                    metadata: serde_json::Value::Null,
+                },
+            )
+            .await
+            .unwrap();
+
+        let detail = auth_status_detail(
+            get_auth_status(
+                State(state),
+                Path(BindingId::parse("default_openai").unwrap()),
+                Query(RealmQuery {
+                    realm_id: RealmId::parse("dev").unwrap(),
+                    profile_id: None,
+                }),
+            )
+            .await,
+        )
+        .await;
+
+        assert_eq!(detail.state, "unknown");
+        assert_eq!(detail.expires_at, None);
+        assert_eq!(detail.last_refresh_at, None);
+        assert_eq!(detail.account_id, None);
+        assert!(!detail.has_refresh_token);
+    }
+
+    #[tokio::test]
+    async fn rest_auth_status_does_not_report_valid_when_token_is_missing() {
+        let temp = tempfile::tempdir().unwrap();
+        let mut state = AppState::load_from(temp.path().to_path_buf())
+            .await
+            .unwrap();
+        install_ephemeral_auth_state(&mut state);
+        state
+            .config_runtime
+            .set(config_with_openai_managed_store_binding(), None)
+            .await
+            .unwrap();
+        let connection_ref = ConnectionRef {
+            realm: RealmId::parse("dev").unwrap(),
+            binding: BindingId::parse("default_openai").unwrap(),
+            profile: None,
+        };
+        let lease_key = LeaseKey::from_connection_ref(&connection_ref);
+        let now = chrono::Utc::now().timestamp() as u64;
+        let bindings = state
+            .runtime_adapter
+            .prepare_bindings(meerkat_core::SessionId::new())
+            .await
+            .unwrap();
+        bindings
+            .auth_lease
+            .acquire_lease(&lease_key, now + 3600)
+            .unwrap();
+
+        let detail = auth_status_detail(
+            get_auth_status(
+                State(state),
+                Path(BindingId::parse("default_openai").unwrap()),
+                Query(RealmQuery {
+                    realm_id: RealmId::parse("dev").unwrap(),
+                    profile_id: None,
+                }),
+            )
+            .await,
+        )
+        .await;
+
+        assert_eq!(detail.state, "unknown");
+        assert_eq!(detail.expires_at, None);
+        assert!(!detail.has_refresh_token);
+    }
+
+    #[tokio::test]
+    async fn rest_auth_status_observes_session_runtime_binding_lifecycle() {
+        let temp = tempfile::tempdir().unwrap();
+        let mut state = AppState::load_from(temp.path().to_path_buf())
+            .await
+            .unwrap();
+        install_ephemeral_auth_state(&mut state);
         state
             .config_runtime
             .set(config_with_openai_managed_store_binding(), None)
@@ -1368,6 +1543,14 @@ mod tests {
             profile_id: None,
         };
         let binding_id = || BindingId::parse("default_openai").unwrap();
+        state
+            .token_store
+            .save(
+                &TokenKey::from_connection_ref(&connection_ref),
+                &PersistedTokens::api_key("sk-live"),
+            )
+            .await
+            .unwrap();
 
         let bindings = state
             .runtime_adapter

--- a/meerkat-rpc/src/handlers/auth.rs
+++ b/meerkat-rpc/src/handlers/auth.rs
@@ -19,8 +19,8 @@ use meerkat_contracts::{
 };
 use meerkat_core::handles::LeaseKey;
 use meerkat_core::{
-    AuthStatusPhase, ConnectionRef, ConnectionTargetError, CredentialSourceSpec, Provider,
-    RealmConnectionSet, ResolvedConnectionTarget,
+    ConnectionRef, ConnectionTargetError, CredentialSourceSpec, Provider, RealmConnectionSet,
+    ResolvedConnectionTarget,
 };
 use meerkat_providers::auth_oauth::{
     DevicePollOutcome, OAuthError, PkcePair, exchange_authorization_code, poll_device_code,
@@ -325,24 +325,14 @@ async fn clear_tokens_and_publish_lifecycle(
     runtime: &SessionRuntime,
     connection_ref: &ConnectionRef,
 ) -> Result<(), RpcResponse> {
-    let key = TokenKey::from_connection_ref(connection_ref);
-    if let Err(e) = store.clear(&key).await {
-        return Err(RpcResponse::error(
-            id,
-            error::INTERNAL_ERROR,
-            format!("TokenStore clear failed: {e}"),
-        ));
-    }
     let auth_lease = runtime.auth_lease_handle();
-    meerkat_core::publish_token_lifecycle_released(auth_lease.as_ref(), connection_ref).map_err(
-        |e| {
-            RpcResponse::error(
-                id,
-                error::INTERNAL_ERROR,
-                format!("AuthMachine lifecycle release failed: {e}"),
-            )
-        },
+    meerkat_core::clear_tokens_and_publish_lifecycle_released(
+        store.as_ref(),
+        auth_lease.as_ref(),
+        connection_ref,
     )
+    .await
+    .map_err(|e| RpcResponse::error(id, error::INTERNAL_ERROR, e.to_string()))
 }
 
 // --- Realm projection -------------------------------------------------
@@ -1114,17 +1104,27 @@ pub async fn handle_auth_status_get(
         Err(r) => return r.with_id(id),
     };
     let stored = if let Some(store) = runtime.token_store() {
-        store
+        match store
             .load(&TokenKey::from_connection_ref(&connection_ref))
             .await
-            .unwrap_or(None)
+        {
+            Ok(stored) => stored,
+            Err(e) => {
+                return RpcResponse::error(
+                    id,
+                    error::INTERNAL_ERROR,
+                    format!("TokenStore load failed: {e}"),
+                );
+            }
+        }
     } else {
         None
     };
     let auth_lease = runtime.auth_lease_handle();
     let snapshot = auth_lease.snapshot(&LeaseKey::from_connection_ref(&connection_ref));
-    let state_phase = AuthStatusPhase::from_lease_snapshot(chrono::Utc::now(), &snapshot);
-    let lease_expires_at = meerkat_core::lease_snapshot_expires_at_datetime(&snapshot);
+    let projection =
+        meerkat_core::project_published_auth_status(chrono::Utc::now(), stored.as_ref(), &snapshot);
+    let tokens = projection.tokens;
     RpcResponse::success(
         id,
         WireAuthStatusDetail {
@@ -1132,18 +1132,11 @@ pub async fn handle_auth_status_get(
             profile_id: auth_profile.id,
             provider: auth_profile.provider.as_str().to_string(),
             auth_method: auth_profile.auth_method,
-            state: state_phase.as_public_str().to_string(),
-            expires_at: lease_expires_at
-                .or_else(|| stored.as_ref().and_then(|t| t.expires_at))
-                .map(|e| e.to_rfc3339()),
-            last_refresh_at: stored
-                .as_ref()
-                .and_then(|t| t.last_refresh.map(|e| e.to_rfc3339())),
-            account_id: stored.as_ref().and_then(|t| t.account_id.clone()),
-            has_refresh_token: stored
-                .as_ref()
-                .map(|t| t.refresh_token.is_some())
-                .unwrap_or(false),
+            state: projection.phase.as_public_str().to_string(),
+            expires_at: projection.expires_at.map(|e| e.to_rfc3339()),
+            last_refresh_at: tokens.and_then(|t| t.last_refresh.map(|e| e.to_rfc3339())),
+            account_id: tokens.and_then(|t| t.account_id.clone()),
+            has_refresh_token: tokens.map(|t| t.refresh_token.is_some()).unwrap_or(false),
         },
     )
 }
@@ -1290,6 +1283,15 @@ mod tests {
         value["state"].as_str().expect("state").to_string()
     }
 
+    fn auth_status_value(resp: RpcResponse) -> serde_json::Value {
+        assert!(
+            resp.error.is_none(),
+            "status response error: {:?}",
+            resp.error
+        );
+        serde_json::from_str(resp.result.as_ref().expect("result").get()).unwrap()
+    }
+
     fn assert_invalid_params_message(resp: RpcResponse, expected: &str) {
         assert!(resp.error.is_some(), "response should be an error");
         let Some(error) = resp.error else {
@@ -1354,6 +1356,61 @@ mod tests {
             AuthLeaseSnapshot {
                 phase: None,
                 expires_at: None,
+            }
+        }
+    }
+
+    struct ReleaseRejectingAuthLeaseHandle;
+
+    impl AuthLeaseHandle for ReleaseRejectingAuthLeaseHandle {
+        fn acquire_lease(
+            &self,
+            _lease_key: &LeaseKey,
+            _expires_at: u64,
+        ) -> Result<(), DslTransitionError> {
+            Ok(())
+        }
+
+        fn mark_expiring(&self, _lease_key: &LeaseKey) -> Result<(), DslTransitionError> {
+            Ok(())
+        }
+
+        fn begin_refresh(&self, _lease_key: &LeaseKey) -> Result<(), DslTransitionError> {
+            Ok(())
+        }
+
+        fn complete_refresh(
+            &self,
+            _lease_key: &LeaseKey,
+            _new_expires_at: u64,
+            _now: u64,
+        ) -> Result<(), DslTransitionError> {
+            Ok(())
+        }
+
+        fn refresh_failed(
+            &self,
+            _lease_key: &LeaseKey,
+            _permanent: bool,
+        ) -> Result<(), DslTransitionError> {
+            Ok(())
+        }
+
+        fn mark_reauth_required(&self, _lease_key: &LeaseKey) -> Result<(), DslTransitionError> {
+            Ok(())
+        }
+
+        fn release_lease(&self, _lease_key: &LeaseKey) -> Result<(), DslTransitionError> {
+            Err(DslTransitionError::guard_rejected(
+                "release_lease",
+                "test rejection",
+            ))
+        }
+
+        fn snapshot(&self, _lease_key: &LeaseKey) -> AuthLeaseSnapshot {
+            AuthLeaseSnapshot {
+                phase: Some(meerkat_core::handles::AuthLeasePhase::Valid),
+                expires_at: Some(1_800_000_000),
             }
         }
     }
@@ -1462,7 +1519,17 @@ mod tests {
         store
             .save(
                 &TokenKey::from_connection_ref(&connection_ref),
-                &PersistedTokens::api_key("sk-stale"),
+                &PersistedTokens {
+                    auth_mode: PersistedAuthMode::ApiKey,
+                    primary_secret: Some("sk-stale".into()),
+                    refresh_token: Some("refresh-stale".into()),
+                    id_token: None,
+                    expires_at: Some(chrono::DateTime::from_timestamp(1_800_000_000, 0).unwrap()),
+                    last_refresh: Some(chrono::DateTime::from_timestamp(1_700_000_000, 0).unwrap()),
+                    scopes: Vec::new(),
+                    account_id: Some("acct-stale".into()),
+                    metadata: serde_json::Value::Null,
+                },
             )
             .await
             .unwrap();
@@ -1474,7 +1541,45 @@ mod tests {
         let resp =
             handle_auth_status_get(Some(RpcId::Num(1)), Some(params.as_ref()), &runtime).await;
 
-        assert_eq!(auth_status_state(resp), "unknown");
+        let status = auth_status_value(resp);
+        assert_eq!(status["state"], "unknown");
+        assert!(status.get("expires_at").is_none());
+        assert!(status.get("last_refresh_at").is_none());
+        assert!(status.get("account_id").is_none());
+        assert_eq!(status["has_refresh_token"], false);
+    }
+
+    #[tokio::test]
+    async fn auth_status_does_not_report_valid_when_token_is_missing() {
+        let runtime = test_runtime_with_config(config_with_openai_managed_store_binding());
+        let connection_ref = ConnectionRef {
+            realm: meerkat_core::RealmId::parse("dev").unwrap(),
+            binding: meerkat_core::BindingId::parse("default_openai").unwrap(),
+            profile: None,
+        };
+        let lease_key = LeaseKey::from_connection_ref(&connection_ref);
+        let now = chrono::Utc::now().timestamp() as u64;
+        let bindings = runtime
+            .runtime_adapter()
+            .prepare_bindings(meerkat_core::SessionId::new())
+            .await
+            .unwrap();
+        bindings
+            .auth_lease
+            .acquire_lease(&lease_key, now + 3600)
+            .unwrap();
+        let params = raw_params(serde_json::json!({
+            "realm_id": "dev",
+            "binding_id": "default_openai"
+        }));
+
+        let resp =
+            handle_auth_status_get(Some(RpcId::Num(1)), Some(params.as_ref()), &runtime).await;
+
+        let status = auth_status_value(resp);
+        assert_eq!(status["state"], "unknown");
+        assert!(status.get("expires_at").is_none());
+        assert_eq!(status["has_refresh_token"], false);
     }
 
     #[tokio::test]
@@ -1535,6 +1640,44 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn auth_logout_release_failure_does_not_clear_tokens() {
+        let runtime = test_runtime_with_config(config_with_openai_managed_store_binding());
+        runtime
+            .runtime_adapter()
+            .set_auth_lease_handle(Arc::new(ReleaseRejectingAuthLeaseHandle));
+        let connection_ref = ConnectionRef {
+            realm: meerkat_core::RealmId::parse("dev").unwrap(),
+            binding: meerkat_core::BindingId::parse("default_openai").unwrap(),
+            profile: None,
+        };
+        let key = TokenKey::from_connection_ref(&connection_ref);
+        let store = runtime.token_store().expect("test token store");
+        store
+            .save(&key, &PersistedTokens::api_key("sk-old"))
+            .await
+            .unwrap();
+        let params = raw_params(serde_json::json!({
+            "realm_id": "dev",
+            "binding_id": "default_openai"
+        }));
+
+        let resp = handle_auth_logout(Some(RpcId::Num(1)), Some(params.as_ref()), &runtime).await;
+
+        let error = resp.error.expect("logout should fail");
+        assert_eq!(error.code, crate::error::INTERNAL_ERROR);
+        assert!(
+            error
+                .message
+                .contains("AuthMachine lifecycle release failed")
+        );
+        let stored = store.load(&key).await.unwrap();
+        assert!(
+            stored.is_some(),
+            "token clear must not commit when AuthMachine release fails"
+        );
+    }
+
+    #[tokio::test]
     async fn provisioned_api_key_lifecycle_failure_restores_existing_credentials() {
         let store: Arc<dyn TokenStore> =
             Arc::new(meerkat_providers::auth_store::EphemeralTokenStore::new());
@@ -1588,6 +1731,14 @@ mod tests {
             "realm_id": "dev",
             "binding_id": "default_openai"
         }));
+        let store = runtime.token_store().expect("test token store");
+        store
+            .save(
+                &TokenKey::from_connection_ref(&connection_ref),
+                &PersistedTokens::api_key("sk-live"),
+            )
+            .await
+            .unwrap();
 
         let bindings = runtime
             .runtime_adapter()


### PR DESCRIPTION
## Summary
- Add a shared fail-closed token-clear/AuthMachine-release boundary that releases first and restores the lease if token clearing fails.
- Route REST, RPC, and CLI clear paths through the shared boundary.
- Project public REST/RPC auth status only when token and lease truth agree; stale token-only or lease-only states now report unknown without token metadata.

## Validation
- Red first: `./scripts/repo-cargo test -p meerkat-rpc auth_logout_release_failure_does_not_clear_tokens --lib` failed before implementation because token clear committed before AuthMachine release failure.
- `./scripts/repo-cargo test -p meerkat-rpc handlers::auth::tests --lib`
- `./scripts/repo-cargo test -p meerkat-rest auth_endpoints::tests --lib`
- `./scripts/repo-cargo test -p meerkat-core auth::lifecycle --lib`
- `./scripts/repo-cargo test -p rkat --test cli_auth_flow`
- `make check` with `MEERKAT_BUILDBUDDY=1` after rebase, BuildBuddy invocation `bcba3259-15dc-4dbd-9b32-17135162a69f`

Linear: LUC-125