### PR TITLE
LUC-131: Move mob command admission into MobMachine guards

### DIFF
--- a/meerkat-mob/src/runtime/actor.rs
+++ b/meerkat-mob/src/runtime/actor.rs
@@ -8680,27 +8680,21 @@ impl MobActor {
         description: String,
         blocked_by: Vec<TaskId>,
     ) -> Result<TaskId, MobError> {
-        if subject.trim().is_empty() {
-            return Err(MobError::Internal(
-                "task subject cannot be empty".to_string(),
-            ));
-        }
         let task_id = TaskId::from(uuid::Uuid::new_v4().to_string());
         let dsl_input = mob_dsl::MobMachineInput::TaskCreate {
             task_id: mob_dsl::TaskId::from(task_id.as_str()),
             task_payload: Self::task_payload_to_dsl(&subject, &description, &blocked_by),
         };
         // MobMachine is the admission authority. Allocate the id in the
-        // actor, fail closed through the DSL, then append/project the
-        // shell task-board event using the same id. This prevents the
-        // prior event-sourced-board/DSL split-brain where DSL rejection
-        // was only logged after the shell write.
+        // actor, prepare through the DSL, append/project the shell
+        // task-board event using the same id, then commit the prepared DSL
+        // state only after the board write succeeds.
         let prepared =
             self.prepare_command_admission(dsl_input, MobState::Running, "handle_task_create")?;
-        self.commit_prepared_dsl_input(prepared);
         self.task_board_service
             .create_task_with_id(task_id.clone(), subject, description, blocked_by)
             .await?;
+        self.commit_prepared_dsl_input(prepared);
         Ok(task_id)
     }
 
@@ -8729,14 +8723,15 @@ impl MobActor {
                 )));
             }
         }
-        // Gate the status transition through the DSL guard set before
-        // applying the shell-side event-sourced update. Rolling back from
-        // a terminal status (Completed / Cancelled) is rejected here
-        // rather than by the event projection.
-        self.commit_prepared_dsl_input(prepared);
+        // Gate the status transition through the DSL guard set before the
+        // shell-side event-sourced update, but commit only after the board
+        // write succeeds. Rolling back from a terminal status (Completed /
+        // Cancelled) is rejected here rather than by the event projection.
         self.task_board_service
             .update_task(task_id, status, owner)
-            .await
+            .await?;
+        self.commit_prepared_dsl_input(prepared);
+        Ok(())
     }
 
     /// Unified work-lane entry.
@@ -8936,6 +8931,10 @@ impl MobActor {
         fence_token: FenceToken,
     ) -> Result<(), MobError> {
         let agent_identity = MeerkatId::from(&runtime_id.identity);
+        let entry = {
+            let roster = self.roster.read().await;
+            roster.get(&agent_identity).cloned()
+        };
         let dsl_runtime_id = mob_dsl::AgentRuntimeId::from_domain(&runtime_id);
         let dsl_fence_token = mob_dsl::FenceToken::from_domain(fence_token);
         let prepared = self
@@ -8950,6 +8949,15 @@ impl MobActor {
                 if self.state() != MobState::Running {
                     return self.invalid_transition_to(MobState::Running);
                 }
+                if let Some(entry) = &entry
+                    && entry.fence_token != fence_token
+                {
+                    return MobError::StaleFenceToken {
+                        runtime_id: runtime_id.clone(),
+                        expected: entry.fence_token,
+                        actual: fence_token,
+                    };
+                }
                 if !self
                     .dsl_authority
                     .state
@@ -8961,13 +8969,7 @@ impl MobActor {
                 self.invalid_transition_to(MobState::Running)
             })?;
 
-        let entry = {
-            let roster = self.roster.read().await;
-            roster
-                .get(&agent_identity)
-                .cloned()
-                .ok_or_else(|| MobError::MemberNotFound(agent_identity.clone()))?
-        };
+        let entry = entry.ok_or_else(|| MobError::MemberNotFound(agent_identity.clone()))?;
         if entry.fence_token != fence_token {
             return Err(MobError::StaleFenceToken {
                 runtime_id,

--- a/meerkat-mob/src/runtime/actor.rs
+++ b/meerkat-mob/src/runtime/actor.rs
@@ -2167,6 +2167,37 @@ impl MobActor {
         .map_err(|_| self.invalid_transition_to(MobState::Running))
     }
 
+    fn preview_spawn_command_admission(&self, agent_identity: &MeerkatId) -> Result<(), MobError> {
+        // This is only the command-admission barrier; the real spawn payload is
+        // previewed again after profile resolution and before provisioning.
+        let placeholder_bridge_session_id = SessionId::new();
+        self.preview_spawn_admission(agent_identity, false, &placeholder_bridge_session_id)
+    }
+
+    fn preview_run_flow_command_admission(&self, run_id: &RunId) -> Result<(), MobError> {
+        self.prepare_command_admission(
+            mob_dsl::MobMachineInput::RunFlow {
+                run_id: mob_dsl::RunId::from(run_id.to_string()),
+                step_ids: Default::default(),
+                ordered_steps: Vec::new(),
+                step_has_conditions: Default::default(),
+                step_dependencies: Default::default(),
+                step_dependency_modes: Default::default(),
+                step_branches: Default::default(),
+                step_collection_policies: Default::default(),
+                step_quorum_thresholds: Default::default(),
+                escalation_threshold: 0,
+                max_step_retries: 0,
+                max_active_nodes: 0,
+                max_active_frames: 0,
+                max_frame_depth: 0,
+            },
+            MobState::Running,
+            "run_flow_command_admission",
+        )
+        .map(|_| ())
+    }
+
     fn submit_work_rejection_for_machine_state(
         &self,
         machine_state: &mob_dsl::MobMachineState,
@@ -3976,6 +4007,10 @@ impl MobActor {
             connection_ref,
         } = spec;
         let agent_identity = MeerkatId::from(identity.as_str());
+        if let Err(error) = self.preview_spawn_command_admission(&agent_identity) {
+            let _ = reply_tx.send(Err(error));
+            return;
+        }
         // Normalize launch-mode resume/fork details for the provisioning path.
         let resume_bridge_session_id = launch_mode.resume_bridge_session_id().cloned();
         let fork_spec = match launch_mode {
@@ -9055,8 +9090,9 @@ impl MobActor {
         self.ensure_pending_spawn_alignment("handle_run_flow preflight")?;
         self.ensure_flow_tracker_alignment("handle_run_flow preflight")
             .await?;
-        let config = FlowRunConfig::from_definition(flow_id, &self.definition)?;
         let run_id = RunId::new();
+        self.preview_run_flow_command_admission(&run_id)?;
+        let config = FlowRunConfig::from_definition(flow_id, &self.definition)?;
         let run_flow = MobRun::run_flow_input(&run_id, &config)?;
         debug_assert!(matches!(run_flow, mob_dsl::MobMachineInput::RunFlow { .. }));
         let prepared_run_flow = self

--- a/meerkat-mob/src/runtime/actor.rs
+++ b/meerkat-mob/src/runtime/actor.rs
@@ -1225,6 +1225,39 @@ impl MobActor {
         self.publish_machine_state_projection();
     }
 
+    fn prepare_command_admission(
+        &self,
+        input: mob_dsl::MobMachineInput,
+        target: MobState,
+        context: &str,
+    ) -> Result<PreparedDslInput, MobError> {
+        self.prepare_dsl_input(input, context).map_err(|error| {
+            tracing::debug!(
+                context,
+                error = %error,
+                "MobMachine command admission rejected input"
+            );
+            self.invalid_transition_to(target)
+        })
+    }
+
+    fn apply_command_admission(
+        &mut self,
+        input: mob_dsl::MobMachineInput,
+        target: MobState,
+        context: &str,
+    ) -> Result<Vec<mob_dsl::MobMachineEffect>, MobError> {
+        self.apply_dsl_input_collect_effects(input, context)
+            .map_err(|error| {
+                tracing::debug!(
+                    context,
+                    error = %error,
+                    "MobMachine command admission rejected input"
+                );
+                self.invalid_transition_to(target)
+            })
+    }
+
     fn preview_dsl_input(
         &self,
         input: mob_dsl::MobMachineInput,
@@ -3085,10 +3118,7 @@ impl MobActor {
                     let _ = reply_tx.send(result);
                 }
                 MobCommand::CancelFlow { run_id, reply_tx } => {
-                    let result = match self.require_state(&[MobState::Running]) {
-                        Ok(()) => self.handle_cancel_flow(run_id).await,
-                        Err(error) => Err(error),
-                    };
+                    let result = self.handle_cancel_flow(run_id).await;
                     let _ = reply_tx.send(result);
                 }
                 MobCommand::FlowStatus { run_id, reply_tx } => {
@@ -3456,13 +3486,9 @@ impl MobActor {
                     blocked_by,
                     reply_tx,
                 } => {
-                    let result = match self.require_state(&[MobState::Running]) {
-                        Ok(()) => {
-                            self.handle_task_create(subject, description, blocked_by)
-                                .await
-                        }
-                        Err(error) => Err(error),
-                    };
+                    let result = self
+                        .handle_task_create(subject, description, blocked_by)
+                        .await;
                     let _ = reply_tx.send(result);
                 }
                 MobCommand::TaskUpdate {
@@ -3471,10 +3497,7 @@ impl MobActor {
                     owner,
                     reply_tx,
                 } => {
-                    let result = match self.require_state(&[MobState::Running]) {
-                        Ok(()) => self.handle_task_update(task_id, status, owner).await,
-                        Err(error) => Err(error),
-                    };
+                    let result = self.handle_task_update(task_id, status, owner).await;
                     let _ = reply_tx.send(result);
                 }
                 MobCommand::TaskList { reply_tx } => {
@@ -3644,10 +3667,7 @@ impl MobActor {
                     fence_token,
                     reply_tx,
                 } => {
-                    let result = match self.require_state(&[MobState::Running]) {
-                        Ok(()) => self.handle_cancel_all_work(runtime_id, fence_token).await,
-                        Err(error) => Err(error),
-                    };
+                    let result = self.handle_cancel_all_work(runtime_id, fence_token).await;
                     let _ = reply_tx.send(result);
                 }
                 MobCommand::SetSpawnPolicy { policy, reply_tx } => {
@@ -8675,12 +8695,9 @@ impl MobActor {
         // shell task-board event using the same id. This prevents the
         // prior event-sourced-board/DSL split-brain where DSL rejection
         // was only logged after the shell write.
-        self.apply_dsl_input(dsl_input, "handle_task_create")
-            .map_err(|error| {
-                MobError::Internal(format!(
-                    "task create rejected by MobMachine guards before task-board write: {error}"
-                ))
-            })?;
+        let prepared =
+            self.prepare_command_admission(dsl_input, MobState::Running, "handle_task_create")?;
+        self.commit_prepared_dsl_input(prepared);
         self.task_board_service
             .create_task_with_id(task_id.clone(), subject, description, blocked_by)
             .await?;
@@ -8693,6 +8710,15 @@ impl MobActor {
         status: TaskStatus,
         owner: Option<AgentIdentity>,
     ) -> Result<(), MobError> {
+        let prepared = self.prepare_command_admission(
+            mob_dsl::MobMachineInput::TaskUpdate {
+                task_id: mob_dsl::TaskId::from(task_id.as_str()),
+                new_status: Self::task_status_to_dsl(status),
+            },
+            MobState::Running,
+            "handle_task_update",
+        )?;
+
         // TLA+ TaskBindingInvariant: owner must be a known identity (roster member).
         if let Some(ref owner_id) = owner {
             let roster = self.roster.read().await;
@@ -8707,18 +8733,7 @@ impl MobActor {
         // applying the shell-side event-sourced update. Rolling back from
         // a terminal status (Completed / Cancelled) is rejected here
         // rather than by the event projection.
-        self.apply_dsl_input(
-            mob_dsl::MobMachineInput::TaskUpdate {
-                task_id: mob_dsl::TaskId::from(task_id.as_str()),
-                new_status: Self::task_status_to_dsl(status),
-            },
-            "handle_task_update",
-        )
-        .map_err(|error| {
-            MobError::Internal(format!(
-                "task update rejected by MobMachine guards: {error}"
-            ))
-        })?;
+        self.commit_prepared_dsl_input(prepared);
         self.task_board_service
             .update_task(task_id, status, owner)
             .await
@@ -8921,6 +8936,30 @@ impl MobActor {
         fence_token: FenceToken,
     ) -> Result<(), MobError> {
         let agent_identity = MeerkatId::from(&runtime_id.identity);
+        let dsl_runtime_id = mob_dsl::AgentRuntimeId::from_domain(&runtime_id);
+        let dsl_fence_token = mob_dsl::FenceToken::from_domain(fence_token);
+        let prepared = self
+            .prepare_dsl_input(
+                mob_dsl::MobMachineInput::CancelAllWork {
+                    agent_runtime_id: dsl_runtime_id.clone(),
+                    fence_token: dsl_fence_token,
+                },
+                "handle_cancel_all_work",
+            )
+            .map_err(|_| {
+                if self.state() != MobState::Running {
+                    return self.invalid_transition_to(MobState::Running);
+                }
+                if !self
+                    .dsl_authority
+                    .state
+                    .live_runtime_ids
+                    .contains(&dsl_runtime_id)
+                {
+                    return MobError::MemberNotFound(agent_identity.clone());
+                }
+                self.invalid_transition_to(MobState::Running)
+            })?;
 
         let entry = {
             let roster = self.roster.read().await;
@@ -8940,15 +8979,7 @@ impl MobActor {
         // Feed the DSL CancelAllWork input. Guards enforce live-runtime
         // membership + phase == Running. A rejection here is a state
         // legality violation.
-        let dsl_runtime_id = mob_dsl::AgentRuntimeId::from_domain(&entry.agent_runtime_id);
-        let dsl_fence_token = mob_dsl::FenceToken::from_domain(entry.fence_token);
-        self.apply_dsl_input(
-            mob_dsl::MobMachineInput::CancelAllWork {
-                agent_runtime_id: dsl_runtime_id,
-                fence_token: dsl_fence_token,
-            },
-            "handle_cancel_all_work",
-        )?;
+        self.commit_prepared_dsl_input(prepared);
 
         // Dispatch the interrupt now that the machine has authorized.
         self.provisioner.interrupt_member(&entry.member_ref).await
@@ -9249,10 +9280,11 @@ impl MobActor {
 
     async fn handle_cancel_flow(&mut self, run_id: RunId) -> Result<(), MobError> {
         self.ensure_pending_spawn_alignment("handle_cancel_flow preflight")?;
-        self.apply_dsl_input(
+        self.apply_command_admission(
             mob_dsl::MobMachineInput::CancelFlow {
                 run_id: mob_dsl::RunId::from(run_id.to_string()),
             },
+            MobState::Running,
             "cancel_flow",
         )?;
         let Some((cancel_token, flow_id)) = self

--- a/meerkat-mob/src/runtime/tests.rs
+++ b/meerkat-mob/src/runtime/tests.rs
@@ -5880,6 +5880,31 @@ async fn test_stopped_runtime_commands_are_rejected_by_machine_admission() {
     );
 }
 
+#[tokio::test]
+async fn test_stopped_empty_task_create_is_rejected_by_machine_admission() {
+    let (handle, _service) = create_test_mob(sample_definition()).await;
+    handle.stop().await.expect("stop");
+
+    let result = handle
+        .task_create(
+            "   ".to_string(),
+            "empty subject must not shadow stopped admission".to_string(),
+            vec![],
+        )
+        .await;
+
+    assert!(
+        matches!(
+            result,
+            Err(MobError::InvalidTransition {
+                from: MobState::Stopped,
+                to: MobState::Running,
+            })
+        ),
+        "empty task subject must not shadow MobMachine stopped-phase admission: {result:?}"
+    );
+}
+
 fn mob_command_arm_source<'a>(source: &'a str, command: &str) -> &'a str {
     let marker = format!("                MobCommand::{command}");
     let start = source
@@ -5918,6 +5943,149 @@ fn test_mob_command_admission_arms_do_not_shadow_mob_machine_guards() {
                 "MobCommand::{command} admission must be delegated to MobMachine guards, not shell `{disallowed}`"
             );
         }
+    }
+}
+
+#[tokio::test]
+async fn test_task_create_store_failure_does_not_commit_mob_machine_task() {
+    let events = Arc::new(FaultInjectedMobEventStore::new());
+    let (handle, _service) = create_test_mob_with_events(sample_definition(), events.clone()).await;
+
+    events.fail_appends_for("TaskCreated").await;
+    let error = handle
+        .task_create(
+            "uncommitted task".to_string(),
+            "fault-injected append failure".to_string(),
+            vec![],
+        )
+        .await
+        .expect_err("fault-injected TaskCreated append failure should reject task creation");
+    assert!(
+        error.to_string().contains("TaskCreated"),
+        "task create should surface the task-board append failure, got: {error}"
+    );
+
+    let dsl = handle
+        .debug_dsl_t2_snapshot()
+        .await
+        .expect("query DSL task state after failed create");
+    assert!(
+        dsl.tasks.is_empty(),
+        "TaskCreated append failure must not commit MobMachine task projection: {:?}",
+        dsl.tasks
+    );
+    assert!(
+        handle.task_list().await.expect("task list").is_empty(),
+        "TaskCreated append failure must not project a shell task"
+    );
+}
+
+#[tokio::test]
+async fn test_task_update_board_failure_does_not_commit_mob_machine_status() {
+    let (handle, _service) = create_test_mob(sample_definition()).await;
+    handle
+        .spawn(ProfileName::from("worker"), MeerkatId::from("w-1"), None)
+        .await
+        .expect("spawn task owner");
+    let blocker = handle
+        .task_create(
+            "blocker".to_string(),
+            "must complete before dependent can be claimed".to_string(),
+            vec![],
+        )
+        .await
+        .expect("create blocker");
+    let dependent = handle
+        .task_create(
+            "dependent".to_string(),
+            "blocked task".to_string(),
+            vec![blocker],
+        )
+        .await
+        .expect("create dependent");
+
+    let error = handle
+        .task_update(
+            dependent.clone(),
+            crate::tasks::TaskStatus::InProgress,
+            Some(AgentIdentity::from("w-1")),
+        )
+        .await
+        .expect_err("blocked dependency should reject task update");
+    assert!(
+        error
+            .to_string()
+            .contains("blocked by incomplete dependencies"),
+        "task update should surface task-board validation failure, got: {error}"
+    );
+
+    let dsl_task_id = crate::machines::mob_machine::TaskId::from(dependent.as_str());
+    let dsl = handle
+        .debug_dsl_t2_snapshot()
+        .await
+        .expect("query DSL task state after failed update");
+    assert_eq!(
+        dsl.tasks.get(&dsl_task_id).map(|task| task.status),
+        Some(crate::machines::mob_machine::TaskStatus::Pending),
+        "task-board validation failure must leave the MobMachine task status pending"
+    );
+    assert!(
+        !dsl.in_progress_task_ids.contains(&dsl_task_id),
+        "task-board validation failure must not insert the task into the MobMachine in-progress index"
+    );
+}
+
+#[tokio::test]
+async fn test_cancel_all_work_after_respawn_preserves_stale_fence_error() {
+    let (handle, _service) = create_test_mob(sample_definition()).await;
+    let member_id = AgentIdentity::from("w-1");
+    handle
+        .spawn_with_options(
+            ProfileName::from("worker"),
+            MeerkatId::from(member_id.as_str()),
+            None,
+            Some(crate::MobRuntimeMode::TurnDriven),
+            None,
+        )
+        .await
+        .expect("spawn original member");
+    let original = handle
+        .get_member(&member_id)
+        .await
+        .expect("original member exists");
+    let old_runtime_id = original.agent_runtime_id.clone();
+    let old_fence_token = original.fence_token;
+
+    let receipt = handle
+        .respawn(member_id.clone(), None)
+        .await
+        .expect("respawn member");
+    let replacement = handle
+        .get_member(&member_id)
+        .await
+        .expect("replacement member exists");
+    assert_eq!(replacement.agent_runtime_id, receipt.agent_runtime_id);
+    assert_ne!(
+        old_runtime_id, replacement.agent_runtime_id,
+        "respawn should replace the runtime generation"
+    );
+
+    let result = handle
+        .cancel_all_work(old_runtime_id.clone(), old_fence_token)
+        .await;
+    match result {
+        Err(MobError::StaleFenceToken {
+            runtime_id,
+            expected,
+            actual,
+        }) => {
+            assert_eq!(runtime_id, old_runtime_id);
+            assert_eq!(expected, replacement.fence_token);
+            assert_eq!(actual, old_fence_token);
+        }
+        other => panic!(
+            "cancel_all_work with a pre-respawn runtime id/fence must preserve StaleFenceToken, got {other:?}"
+        ),
     }
 }
 

--- a/meerkat-mob/src/runtime/tests.rs
+++ b/meerkat-mob/src/runtime/tests.rs
@@ -5786,6 +5786,20 @@ async fn test_stopped_runtime_commands_are_rejected_by_machine_admission() {
 
     handle.stop().await.expect("stop");
 
+    let spawn = handle
+        .spawn(ProfileName::from("worker"), MeerkatId::from("w-2"), None)
+        .await;
+    assert!(
+        matches!(
+            spawn,
+            Err(MobError::InvalidTransition {
+                from: MobState::Stopped,
+                to: MobState::Running,
+            })
+        ),
+        "Spawn must surface the MobMachine stopped-phase rejection: {spawn:?}"
+    );
+
     let submit = handle
         .submit_work(
             entry.agent_runtime_id.clone(),
@@ -5805,6 +5819,20 @@ async fn test_stopped_runtime_commands_are_rejected_by_machine_admission() {
         "SubmitWork must surface the MobMachine stopped-phase rejection: {submit:?}"
     );
 
+    let cancel_all_work = handle
+        .cancel_all_work(entry.agent_runtime_id.clone(), entry.fence_token)
+        .await;
+    assert!(
+        matches!(
+            cancel_all_work,
+            Err(MobError::InvalidTransition {
+                from: MobState::Stopped,
+                to: MobState::Running,
+            })
+        ),
+        "CancelAllWork must surface the MobMachine stopped-phase rejection: {cancel_all_work:?}"
+    );
+
     let run_flow = handle
         .run_flow(FlowId::from("demo"), serde_json::json!({}))
         .await;
@@ -5817,6 +5845,24 @@ async fn test_stopped_runtime_commands_are_rejected_by_machine_admission() {
             })
         ),
         "RunFlow must surface the MobMachine stopped-phase rejection: {run_flow:?}"
+    );
+
+    let task_create = handle
+        .task_create(
+            "stopped task".to_string(),
+            "must be admitted by MobMachine".to_string(),
+            vec![],
+        )
+        .await;
+    assert!(
+        matches!(
+            task_create,
+            Err(MobError::InvalidTransition {
+                from: MobState::Stopped,
+                to: MobState::Running,
+            })
+        ),
+        "TaskCreate must surface the MobMachine stopped-phase rejection: {task_create:?}"
     );
 
     let respawn = handle.respawn(AgentIdentity::from("w-1"), None).await;
@@ -5832,6 +5878,47 @@ async fn test_stopped_runtime_commands_are_rejected_by_machine_admission() {
         ),
         "Respawn must surface the MobMachine stopped-phase rejection: {respawn:?}"
     );
+}
+
+fn mob_command_arm_source<'a>(source: &'a str, command: &str) -> &'a str {
+    let marker = format!("                MobCommand::{command}");
+    let start = source
+        .find(&marker)
+        .unwrap_or_else(|| panic!("MobCommand::{command} arm exists"));
+    let rest = &source[start + marker.len()..];
+    let end = rest
+        .find("\n                MobCommand::")
+        .map(|offset| start + marker.len() + offset)
+        .unwrap_or(source.len());
+    &source[start..end]
+}
+
+#[test]
+fn test_mob_command_admission_arms_do_not_shadow_mob_machine_guards() {
+    let source = include_str!("actor.rs");
+    for command in [
+        "Spawn",
+        "Respawn",
+        "RunFlow",
+        "CancelFlow",
+        "SubmitWork",
+        "CancelAllWork",
+        "TaskCreate",
+        "TaskUpdate",
+    ] {
+        let arm = mob_command_arm_source(source, command);
+        for disallowed in [
+            "require_state(",
+            "require_live_lifecycle_phase(",
+            "require_live_reset_admission(",
+            "require_live_stop_admission(",
+        ] {
+            assert!(
+                !arm.contains(disallowed),
+                "MobCommand::{command} admission must be delegated to MobMachine guards, not shell `{disallowed}`"
+            );
+        }
+    }
 }
 
 struct StaticWorkerSpawnPolicy;

--- a/meerkat-mob/src/runtime/tests.rs
+++ b/meerkat-mob/src/runtime/tests.rs
@@ -5905,6 +5905,58 @@ async fn test_stopped_empty_task_create_is_rejected_by_machine_admission() {
     );
 }
 
+#[tokio::test]
+async fn test_stopped_unknown_profile_spawn_is_rejected_by_machine_admission() {
+    let (handle, service) = create_test_mob(sample_definition()).await;
+    handle.stop().await.expect("stop");
+
+    let result = handle
+        .spawn(
+            ProfileName::from("missing-profile"),
+            MeerkatId::from("w-missing-profile"),
+            None,
+        )
+        .await;
+
+    assert!(
+        matches!(
+            result,
+            Err(MobError::InvalidTransition {
+                from: MobState::Stopped,
+                to: MobState::Running,
+            })
+        ),
+        "unknown profile must not shadow MobMachine stopped-phase admission: {result:?}"
+    );
+    assert_eq!(
+        service.active_session_count().await,
+        0,
+        "stopped rejected spawn must not provision a session"
+    );
+}
+
+#[tokio::test]
+async fn test_stopped_unknown_flow_run_flow_is_rejected_by_machine_admission() {
+    let (handle, _service) =
+        create_test_mob(sample_definition_with_single_step_flow(60_000, 8)).await;
+    handle.stop().await.expect("stop");
+
+    let result = handle
+        .run_flow(FlowId::from("missing-flow"), serde_json::json!({}))
+        .await;
+
+    assert!(
+        matches!(
+            result,
+            Err(MobError::InvalidTransition {
+                from: MobState::Stopped,
+                to: MobState::Running,
+            })
+        ),
+        "unknown flow must not shadow MobMachine stopped-phase admission: {result:?}"
+    );
+}
+
 fn mob_command_arm_source<'a>(source: &'a str, command: &str) -> &'a str {
     let marker = format!("                MobCommand::{command}");
     let start = source


### PR DESCRIPTION
## Summary
- Move runtime mob command admission for task/work/flow cancellation paths through MobMachine input preparation/application.
- Add defensive stopped-state coverage for spawn, respawn, flow, task, and work commands.
- Add a source guard preventing scoped mob command arms from reintroducing shell phase gates.

## Validation
- `./scripts/repo-cargo test -p meerkat-mob test_mob_command_admission_arms_do_not_shadow_mob_machine_guards -- --nocapture`
- `./scripts/repo-cargo test -p meerkat-mob test_stopped_runtime_commands_are_rejected_by_machine_admission -- --nocapture`
- `./scripts/repo-cargo test -p meerkat-mob admission -- --nocapture`
- `./scripts/repo-cargo test -p meerkat-mob`
- `./scripts/repo-cargo fmt --all`
- `git diff --check`
- `make check` via BuildBuddy invocation `6b771000-eea7-4b43-83d1-10bc6596d958`

Linear: LUC-131 https://linear.app/lucrfr/issue/LUC-131/p0p1-dogma-move-mob-command-admission-into-mobmachine-guards