### PR TITLE
Use typed identities for MCP mob wiring

### DIFF
--- a/artifacts/schemas/params.json
+++ b/artifacts/schemas/params.json
@@ -2199,9 +2199,10 @@
         "type": "string"
       },
       "WireRuntimeBinding": {
-        "description": "Runtime binding for spawn requests.\n\nFirst step toward identity-first mobs. Carries backend-specific binding\ndetails at spawn time. `External` requires real process identity.",
+        "description": "Runtime binding for spawn requests.\n\nFirst step toward identity-first mobs. Carries backend-specific binding\ndetails at spawn time. `External` requires typed process identity; callers\ndo not supply raw comms peer IDs.",
         "oneOf": [
           {
+            "additionalProperties": false,
             "properties": {
               "kind": {
                 "const": "session",
@@ -2214,6 +2215,7 @@
             "type": "object"
           },
           {
+            "additionalProperties": false,
             "properties": {
               "address": {
                 "type": "string"
@@ -2228,33 +2230,42 @@
                   }
                 ]
               },
+              "identity": {
+                "$ref": "#/$defs/WireTrustedPeerIdentity",
+                "description": "Typed Ed25519 signing identity for the external process. The\ncanonical comms `PeerId` is derived from this key after the wire\nboundary, so callers cannot spoof an unrelated raw peer id."
+              },
               "kind": {
                 "const": "external",
                 "type": "string"
-              },
-              "peer_id": {
-                "type": "string"
-              },
-              "pubkey": {
-                "description": "Ed25519 signing pubkey (32 bytes) of the external peer. Required\nfor the supervisor to install a non-zero-pubkey trust entry so\nreal-comms signed-envelope replies admit past ingress trust\ncheck. Absent on legacy bindings that pre-date pubkey plumbing.",
-                "items": {
-                  "format": "uint8",
-                  "maximum": 255,
-                  "minimum": 0,
-                  "type": "integer"
-                },
-                "maxItems": 32,
-                "minItems": 32,
-                "type": [
-                  "array",
-                  "null"
-                ]
               }
             },
             "required": [
               "kind",
-              "peer_id",
-              "address"
+              "address",
+              "identity"
+            ],
+            "type": "object"
+          }
+        ]
+      },
+      "WireTrustedPeerIdentity": {
+        "description": "Typed external peer identity for public mob wiring surfaces.",
+        "oneOf": [
+          {
+            "additionalProperties": false,
+            "description": "Recoverable Ed25519 public key string in `ed25519:<base64>` form.",
+            "properties": {
+              "kind": {
+                "const": "ed25519_public_key",
+                "type": "string"
+              },
+              "public_key": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "kind",
+              "public_key"
             ],
             "type": "object"
           }
@@ -2755,9 +2766,10 @@
         "type": "string"
       },
       "WireRuntimeBinding": {
-        "description": "Runtime binding for spawn requests.\n\nFirst step toward identity-first mobs. Carries backend-specific binding\ndetails at spawn time. `External` requires real process identity.",
+        "description": "Runtime binding for spawn requests.\n\nFirst step toward identity-first mobs. Carries backend-specific binding\ndetails at spawn time. `External` requires typed process identity; callers\ndo not supply raw comms peer IDs.",
         "oneOf": [
           {
+            "additionalProperties": false,
             "properties": {
               "kind": {
                 "const": "session",
@@ -2770,6 +2782,7 @@
             "type": "object"
           },
           {
+            "additionalProperties": false,
             "properties": {
               "address": {
                 "type": "string"
@@ -2784,33 +2797,42 @@
                   }
                 ]
               },
+              "identity": {
+                "$ref": "#/$defs/WireTrustedPeerIdentity",
+                "description": "Typed Ed25519 signing identity for the external process. The\ncanonical comms `PeerId` is derived from this key after the wire\nboundary, so callers cannot spoof an unrelated raw peer id."
+              },
               "kind": {
                 "const": "external",
                 "type": "string"
-              },
-              "peer_id": {
-                "type": "string"
-              },
-              "pubkey": {
-                "description": "Ed25519 signing pubkey (32 bytes) of the external peer. Required\nfor the supervisor to install a non-zero-pubkey trust entry so\nreal-comms signed-envelope replies admit past ingress trust\ncheck. Absent on legacy bindings that pre-date pubkey plumbing.",
-                "items": {
-                  "format": "uint8",
-                  "maximum": 255,
-                  "minimum": 0,
-                  "type": "integer"
-                },
-                "maxItems": 32,
-                "minItems": 32,
-                "type": [
-                  "array",
-                  "null"
-                ]
               }
             },
             "required": [
               "kind",
-              "peer_id",
-              "address"
+              "address",
+              "identity"
+            ],
+            "type": "object"
+          }
+        ]
+      },
+      "WireTrustedPeerIdentity": {
+        "description": "Typed external peer identity for public mob wiring surfaces.",
+        "oneOf": [
+          {
+            "additionalProperties": false,
+            "description": "Recoverable Ed25519 public key string in `ed25519:<base64>` form.",
+            "properties": {
+              "kind": {
+                "const": "ed25519_public_key",
+                "type": "string"
+              },
+              "public_key": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "kind",
+              "public_key"
             ],
             "type": "object"
           }
@@ -4270,9 +4292,10 @@
         "type": "string"
       },
       "WireRuntimeBinding": {
-        "description": "Runtime binding for spawn requests.\n\nFirst step toward identity-first mobs. Carries backend-specific binding\ndetails at spawn time. `External` requires real process identity.",
+        "description": "Runtime binding for spawn requests.\n\nFirst step toward identity-first mobs. Carries backend-specific binding\ndetails at spawn time. `External` requires typed process identity; callers\ndo not supply raw comms peer IDs.",
         "oneOf": [
           {
+            "additionalProperties": false,
             "properties": {
               "kind": {
                 "const": "session",
@@ -4285,6 +4308,7 @@
             "type": "object"
           },
           {
+            "additionalProperties": false,
             "properties": {
               "address": {
                 "type": "string"
@@ -4299,33 +4323,42 @@
                   }
                 ]
               },
+              "identity": {
+                "$ref": "#/$defs/WireTrustedPeerIdentity",
+                "description": "Typed Ed25519 signing identity for the external process. The\ncanonical comms `PeerId` is derived from this key after the wire\nboundary, so callers cannot spoof an unrelated raw peer id."
+              },
               "kind": {
                 "const": "external",
                 "type": "string"
-              },
-              "peer_id": {
-                "type": "string"
-              },
-              "pubkey": {
-                "description": "Ed25519 signing pubkey (32 bytes) of the external peer. Required\nfor the supervisor to install a non-zero-pubkey trust entry so\nreal-comms signed-envelope replies admit past ingress trust\ncheck. Absent on legacy bindings that pre-date pubkey plumbing.",
-                "items": {
-                  "format": "uint8",
-                  "maximum": 255,
-                  "minimum": 0,
-                  "type": "integer"
-                },
-                "maxItems": 32,
-                "minItems": 32,
-                "type": [
-                  "array",
-                  "null"
-                ]
               }
             },
             "required": [
               "kind",
-              "peer_id",
-              "address"
+              "address",
+              "identity"
+            ],
+            "type": "object"
+          }
+        ]
+      },
+      "WireTrustedPeerIdentity": {
+        "description": "Typed external peer identity for public mob wiring surfaces.",
+        "oneOf": [
+          {
+            "additionalProperties": false,
+            "description": "Recoverable Ed25519 public key string in `ed25519:<base64>` form.",
+            "properties": {
+              "kind": {
+                "const": "ed25519_public_key",
+                "type": "string"
+              },
+              "public_key": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "kind",
+              "public_key"
             ],
             "type": "object"
           }
@@ -5082,9 +5115,10 @@
         "type": "string"
       },
       "WireRuntimeBinding": {
-        "description": "Runtime binding for spawn requests.\n\nFirst step toward identity-first mobs. Carries backend-specific binding\ndetails at spawn time. `External` requires real process identity.",
+        "description": "Runtime binding for spawn requests.\n\nFirst step toward identity-first mobs. Carries backend-specific binding\ndetails at spawn time. `External` requires typed process identity; callers\ndo not supply raw comms peer IDs.",
         "oneOf": [
           {
+            "additionalProperties": false,
             "properties": {
               "kind": {
                 "const": "session",
@@ -5097,6 +5131,7 @@
             "type": "object"
           },
           {
+            "additionalProperties": false,
             "properties": {
               "address": {
                 "type": "string"
@@ -5111,33 +5146,42 @@
                   }
                 ]
               },
+              "identity": {
+                "$ref": "#/$defs/WireTrustedPeerIdentity",
+                "description": "Typed Ed25519 signing identity for the external process. The\ncanonical comms `PeerId` is derived from this key after the wire\nboundary, so callers cannot spoof an unrelated raw peer id."
+              },
               "kind": {
                 "const": "external",
                 "type": "string"
-              },
-              "peer_id": {
-                "type": "string"
-              },
-              "pubkey": {
-                "description": "Ed25519 signing pubkey (32 bytes) of the external peer. Required\nfor the supervisor to install a non-zero-pubkey trust entry so\nreal-comms signed-envelope replies admit past ingress trust\ncheck. Absent on legacy bindings that pre-date pubkey plumbing.",
-                "items": {
-                  "format": "uint8",
-                  "maximum": 255,
-                  "minimum": 0,
-                  "type": "integer"
-                },
-                "maxItems": 32,
-                "minItems": 32,
-                "type": [
-                  "array",
-                  "null"
-                ]
               }
             },
             "required": [
               "kind",
-              "peer_id",
-              "address"
+              "address",
+              "identity"
+            ],
+            "type": "object"
+          }
+        ]
+      },
+      "WireTrustedPeerIdentity": {
+        "description": "Typed external peer identity for public mob wiring surfaces.",
+        "oneOf": [
+          {
+            "additionalProperties": false,
+            "description": "Recoverable Ed25519 public key string in `ed25519:<base64>` form.",
+            "properties": {
+              "kind": {
+                "const": "ed25519_public_key",
+                "type": "string"
+              },
+              "public_key": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "kind",
+              "public_key"
             ],
             "type": "object"
           }
@@ -5525,68 +5569,47 @@
           }
         ]
       },
+      "WireTrustedPeerIdentity": {
+        "description": "Typed external peer identity for public mob wiring surfaces.",
+        "oneOf": [
+          {
+            "additionalProperties": false,
+            "description": "Recoverable Ed25519 public key string in `ed25519:<base64>` form.",
+            "properties": {
+              "kind": {
+                "const": "ed25519_public_key",
+                "type": "string"
+              },
+              "public_key": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "kind",
+              "public_key"
+            ],
+            "type": "object"
+          }
+        ]
+      },
       "WireTrustedPeerSpec": {
-        "description": "Minimal trusted peer spec for public mob wiring surfaces.\n\n`pubkey` is the Ed25519 signing public key (32 bytes) required so the\nreceiver can verify envelope signatures after trust registration.\nSerialized as a 32-element JSON array of numbers (matching\n`BridgePeerSpec`). Defaults to a zero pubkey for legacy clients —\nthe corresponding `TrustedPeerDescriptor::pubkey` will then be all\nzeros, which makes signature verification fail closed. Production\nclients MUST send the real pubkey.",
+        "additionalProperties": false,
+        "description": "Minimal trusted peer spec for public mob wiring surfaces.\n\n`identity` is required and resolves to the Ed25519 signing public key\nplus the canonical comms `PeerId` derived from that key. MCP callers do\nnot provide raw peer IDs, and missing key material fails at the boundary.",
         "properties": {
           "address": {
             "type": "string"
           },
+          "identity": {
+            "$ref": "#/$defs/WireTrustedPeerIdentity"
+          },
           "name": {
             "type": "string"
-          },
-          "peer_id": {
-            "type": "string"
-          },
-          "pubkey": {
-            "default": [
-              0,
-              0,
-              0,
-              0,
-              0,
-              0,
-              0,
-              0,
-              0,
-              0,
-              0,
-              0,
-              0,
-              0,
-              0,
-              0,
-              0,
-              0,
-              0,
-              0,
-              0,
-              0,
-              0,
-              0,
-              0,
-              0,
-              0,
-              0,
-              0,
-              0,
-              0,
-              0
-            ],
-            "items": {
-              "format": "uint8",
-              "maximum": 255,
-              "minimum": 0,
-              "type": "integer"
-            },
-            "maxItems": 32,
-            "minItems": 32,
-            "type": "array"
           }
         },
         "required": [
           "name",
-          "peer_id",
-          "address"
+          "address",
+          "identity"
         ],
         "type": "object"
       }
@@ -5676,68 +5699,47 @@
           }
         ]
       },
+      "WireTrustedPeerIdentity": {
+        "description": "Typed external peer identity for public mob wiring surfaces.",
+        "oneOf": [
+          {
+            "additionalProperties": false,
+            "description": "Recoverable Ed25519 public key string in `ed25519:<base64>` form.",
+            "properties": {
+              "kind": {
+                "const": "ed25519_public_key",
+                "type": "string"
+              },
+              "public_key": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "kind",
+              "public_key"
+            ],
+            "type": "object"
+          }
+        ]
+      },
       "WireTrustedPeerSpec": {
-        "description": "Minimal trusted peer spec for public mob wiring surfaces.\n\n`pubkey` is the Ed25519 signing public key (32 bytes) required so the\nreceiver can verify envelope signatures after trust registration.\nSerialized as a 32-element JSON array of numbers (matching\n`BridgePeerSpec`). Defaults to a zero pubkey for legacy clients —\nthe corresponding `TrustedPeerDescriptor::pubkey` will then be all\nzeros, which makes signature verification fail closed. Production\nclients MUST send the real pubkey.",
+        "additionalProperties": false,
+        "description": "Minimal trusted peer spec for public mob wiring surfaces.\n\n`identity` is required and resolves to the Ed25519 signing public key\nplus the canonical comms `PeerId` derived from that key. MCP callers do\nnot provide raw peer IDs, and missing key material fails at the boundary.",
         "properties": {
           "address": {
             "type": "string"
           },
+          "identity": {
+            "$ref": "#/$defs/WireTrustedPeerIdentity"
+          },
           "name": {
             "type": "string"
-          },
-          "peer_id": {
-            "type": "string"
-          },
-          "pubkey": {
-            "default": [
-              0,
-              0,
-              0,
-              0,
-              0,
-              0,
-              0,
-              0,
-              0,
-              0,
-              0,
-              0,
-              0,
-              0,
-              0,
-              0,
-              0,
-              0,
-              0,
-              0,
-              0,
-              0,
-              0,
-              0,
-              0,
-              0,
-              0,
-              0,
-              0,
-              0,
-              0,
-              0
-            ],
-            "items": {
-              "format": "uint8",
-              "maximum": 255,
-              "minimum": 0,
-              "type": "integer"
-            },
-            "maxItems": 32,
-            "minItems": 32,
-            "type": "array"
           }
         },
         "required": [
           "name",
-          "peer_id",
-          "address"
+          "address",
+          "identity"
         ],
         "type": "object"
       }

--- a/artifacts/schemas/rest-openapi.json
+++ b/artifacts/schemas/rest-openapi.json
@@ -13002,9 +13002,10 @@
         "type": "object"
       },
       "WireRuntimeBinding": {
-        "description": "Runtime binding for spawn requests.\n\nFirst step toward identity-first mobs. Carries backend-specific binding\ndetails at spawn time. `External` requires real process identity.",
+        "description": "Runtime binding for spawn requests.\n\nFirst step toward identity-first mobs. Carries backend-specific binding\ndetails at spawn time. `External` requires typed process identity; callers\ndo not supply raw comms peer IDs.",
         "oneOf": [
           {
+            "additionalProperties": false,
             "properties": {
               "kind": {
                 "const": "session",
@@ -13017,6 +13018,7 @@
             "type": "object"
           },
           {
+            "additionalProperties": false,
             "properties": {
               "address": {
                 "type": "string"
@@ -13031,33 +13033,19 @@
                   }
                 ]
               },
+              "identity": {
+                "$ref": "#/components/schemas/WireTrustedPeerIdentity",
+                "description": "Typed Ed25519 signing identity for the external process. The\ncanonical comms `PeerId` is derived from this key after the wire\nboundary, so callers cannot spoof an unrelated raw peer id."
+              },
               "kind": {
                 "const": "external",
                 "type": "string"
-              },
-              "peer_id": {
-                "type": "string"
-              },
-              "pubkey": {
-                "description": "Ed25519 signing pubkey (32 bytes) of the external peer. Required\nfor the supervisor to install a non-zero-pubkey trust entry so\nreal-comms signed-envelope replies admit past ingress trust\ncheck. Absent on legacy bindings that pre-date pubkey plumbing.",
-                "items": {
-                  "format": "uint8",
-                  "maximum": 255,
-                  "minimum": 0,
-                  "type": "integer"
-                },
-                "maxItems": 32,
-                "minItems": 32,
-                "type": [
-                  "array",
-                  "null"
-                ]
               }
             },
             "required": [
               "kind",
-              "peer_id",
-              "address"
+              "address",
+              "identity"
             ],
             "type": "object"
           }
@@ -13751,68 +13739,47 @@
         ],
         "description": "Wire-safe tool result content that handles both legacy string and array formats."
       },
+      "WireTrustedPeerIdentity": {
+        "description": "Typed external peer identity for public mob wiring surfaces.",
+        "oneOf": [
+          {
+            "additionalProperties": false,
+            "description": "Recoverable Ed25519 public key string in `ed25519:<base64>` form.",
+            "properties": {
+              "kind": {
+                "const": "ed25519_public_key",
+                "type": "string"
+              },
+              "public_key": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "kind",
+              "public_key"
+            ],
+            "type": "object"
+          }
+        ]
+      },
       "WireTrustedPeerSpec": {
-        "description": "Minimal trusted peer spec for public mob wiring surfaces.\n\n`pubkey` is the Ed25519 signing public key (32 bytes) required so the\nreceiver can verify envelope signatures after trust registration.\nSerialized as a 32-element JSON array of numbers (matching\n`BridgePeerSpec`). Defaults to a zero pubkey for legacy clients —\nthe corresponding `TrustedPeerDescriptor::pubkey` will then be all\nzeros, which makes signature verification fail closed. Production\nclients MUST send the real pubkey.",
+        "additionalProperties": false,
+        "description": "Minimal trusted peer spec for public mob wiring surfaces.\n\n`identity` is required and resolves to the Ed25519 signing public key\nplus the canonical comms `PeerId` derived from that key. MCP callers do\nnot provide raw peer IDs, and missing key material fails at the boundary.",
         "properties": {
           "address": {
             "type": "string"
           },
+          "identity": {
+            "$ref": "#/components/schemas/WireTrustedPeerIdentity"
+          },
           "name": {
             "type": "string"
-          },
-          "peer_id": {
-            "type": "string"
-          },
-          "pubkey": {
-            "default": [
-              0,
-              0,
-              0,
-              0,
-              0,
-              0,
-              0,
-              0,
-              0,
-              0,
-              0,
-              0,
-              0,
-              0,
-              0,
-              0,
-              0,
-              0,
-              0,
-              0,
-              0,
-              0,
-              0,
-              0,
-              0,
-              0,
-              0,
-              0,
-              0,
-              0,
-              0,
-              0
-            ],
-            "items": {
-              "format": "uint8",
-              "maximum": 255,
-              "minimum": 0,
-              "type": "integer"
-            },
-            "maxItems": 32,
-            "minItems": 32,
-            "type": "array"
           }
         },
         "required": [
           "name",
-          "peer_id",
-          "address"
+          "address",
+          "identity"
         ],
         "type": "object"
       },

--- a/artifacts/schemas/wire-types.json
+++ b/artifacts/schemas/wire-types.json
@@ -3199,9 +3199,10 @@
         "type": "string"
       },
       "WireRuntimeBinding": {
-        "description": "Runtime binding for spawn requests.\n\nFirst step toward identity-first mobs. Carries backend-specific binding\ndetails at spawn time. `External` requires real process identity.",
+        "description": "Runtime binding for spawn requests.\n\nFirst step toward identity-first mobs. Carries backend-specific binding\ndetails at spawn time. `External` requires typed process identity; callers\ndo not supply raw comms peer IDs.",
         "oneOf": [
           {
+            "additionalProperties": false,
             "properties": {
               "kind": {
                 "const": "session",
@@ -3214,6 +3215,7 @@
             "type": "object"
           },
           {
+            "additionalProperties": false,
             "properties": {
               "address": {
                 "type": "string"
@@ -3228,33 +3230,42 @@
                   }
                 ]
               },
+              "identity": {
+                "$ref": "#/$defs/WireTrustedPeerIdentity",
+                "description": "Typed Ed25519 signing identity for the external process. The\ncanonical comms `PeerId` is derived from this key after the wire\nboundary, so callers cannot spoof an unrelated raw peer id."
+              },
               "kind": {
                 "const": "external",
                 "type": "string"
-              },
-              "peer_id": {
-                "type": "string"
-              },
-              "pubkey": {
-                "description": "Ed25519 signing pubkey (32 bytes) of the external peer. Required\nfor the supervisor to install a non-zero-pubkey trust entry so\nreal-comms signed-envelope replies admit past ingress trust\ncheck. Absent on legacy bindings that pre-date pubkey plumbing.",
-                "items": {
-                  "format": "uint8",
-                  "maximum": 255,
-                  "minimum": 0,
-                  "type": "integer"
-                },
-                "maxItems": 32,
-                "minItems": 32,
-                "type": [
-                  "array",
-                  "null"
-                ]
               }
             },
             "required": [
               "kind",
-              "peer_id",
-              "address"
+              "address",
+              "identity"
+            ],
+            "type": "object"
+          }
+        ]
+      },
+      "WireTrustedPeerIdentity": {
+        "description": "Typed external peer identity for public mob wiring surfaces.",
+        "oneOf": [
+          {
+            "additionalProperties": false,
+            "description": "Recoverable Ed25519 public key string in `ed25519:<base64>` form.",
+            "properties": {
+              "kind": {
+                "const": "ed25519_public_key",
+                "type": "string"
+              },
+              "public_key": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "kind",
+              "public_key"
             ],
             "type": "object"
           }
@@ -4039,68 +4050,47 @@
   },
   "MobPeerTarget": {
     "$defs": {
+      "WireTrustedPeerIdentity": {
+        "description": "Typed external peer identity for public mob wiring surfaces.",
+        "oneOf": [
+          {
+            "additionalProperties": false,
+            "description": "Recoverable Ed25519 public key string in `ed25519:<base64>` form.",
+            "properties": {
+              "kind": {
+                "const": "ed25519_public_key",
+                "type": "string"
+              },
+              "public_key": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "kind",
+              "public_key"
+            ],
+            "type": "object"
+          }
+        ]
+      },
       "WireTrustedPeerSpec": {
-        "description": "Minimal trusted peer spec for public mob wiring surfaces.\n\n`pubkey` is the Ed25519 signing public key (32 bytes) required so the\nreceiver can verify envelope signatures after trust registration.\nSerialized as a 32-element JSON array of numbers (matching\n`BridgePeerSpec`). Defaults to a zero pubkey for legacy clients —\nthe corresponding `TrustedPeerDescriptor::pubkey` will then be all\nzeros, which makes signature verification fail closed. Production\nclients MUST send the real pubkey.",
+        "additionalProperties": false,
+        "description": "Minimal trusted peer spec for public mob wiring surfaces.\n\n`identity` is required and resolves to the Ed25519 signing public key\nplus the canonical comms `PeerId` derived from that key. MCP callers do\nnot provide raw peer IDs, and missing key material fails at the boundary.",
         "properties": {
           "address": {
             "type": "string"
           },
+          "identity": {
+            "$ref": "#/$defs/WireTrustedPeerIdentity"
+          },
           "name": {
             "type": "string"
-          },
-          "peer_id": {
-            "type": "string"
-          },
-          "pubkey": {
-            "default": [
-              0,
-              0,
-              0,
-              0,
-              0,
-              0,
-              0,
-              0,
-              0,
-              0,
-              0,
-              0,
-              0,
-              0,
-              0,
-              0,
-              0,
-              0,
-              0,
-              0,
-              0,
-              0,
-              0,
-              0,
-              0,
-              0,
-              0,
-              0,
-              0,
-              0,
-              0,
-              0
-            ],
-            "items": {
-              "format": "uint8",
-              "maximum": 255,
-              "minimum": 0,
-              "type": "integer"
-            },
-            "maxItems": 32,
-            "minItems": 32,
-            "type": "array"
           }
         },
         "required": [
           "name",
-          "peer_id",
-          "address"
+          "address",
+          "identity"
         ],
         "type": "object"
       }
@@ -21119,68 +21109,49 @@
     "title": "WireToolResultContent"
   },
   "WireTrustedPeerSpec": {
+    "$defs": {
+      "WireTrustedPeerIdentity": {
+        "description": "Typed external peer identity for public mob wiring surfaces.",
+        "oneOf": [
+          {
+            "additionalProperties": false,
+            "description": "Recoverable Ed25519 public key string in `ed25519:<base64>` form.",
+            "properties": {
+              "kind": {
+                "const": "ed25519_public_key",
+                "type": "string"
+              },
+              "public_key": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "kind",
+              "public_key"
+            ],
+            "type": "object"
+          }
+        ]
+      }
+    },
     "$schema": "https://json-schema.org/draft/2020-12/schema",
-    "description": "Minimal trusted peer spec for public mob wiring surfaces.\n\n`pubkey` is the Ed25519 signing public key (32 bytes) required so the\nreceiver can verify envelope signatures after trust registration.\nSerialized as a 32-element JSON array of numbers (matching\n`BridgePeerSpec`). Defaults to a zero pubkey for legacy clients —\nthe corresponding `TrustedPeerDescriptor::pubkey` will then be all\nzeros, which makes signature verification fail closed. Production\nclients MUST send the real pubkey.",
+    "additionalProperties": false,
+    "description": "Minimal trusted peer spec for public mob wiring surfaces.\n\n`identity` is required and resolves to the Ed25519 signing public key\nplus the canonical comms `PeerId` derived from that key. MCP callers do\nnot provide raw peer IDs, and missing key material fails at the boundary.",
     "properties": {
       "address": {
         "type": "string"
       },
+      "identity": {
+        "$ref": "#/$defs/WireTrustedPeerIdentity"
+      },
       "name": {
         "type": "string"
-      },
-      "peer_id": {
-        "type": "string"
-      },
-      "pubkey": {
-        "default": [
-          0,
-          0,
-          0,
-          0,
-          0,
-          0,
-          0,
-          0,
-          0,
-          0,
-          0,
-          0,
-          0,
-          0,
-          0,
-          0,
-          0,
-          0,
-          0,
-          0,
-          0,
-          0,
-          0,
-          0,
-          0,
-          0,
-          0,
-          0,
-          0,
-          0,
-          0,
-          0
-        ],
-        "items": {
-          "format": "uint8",
-          "maximum": 255,
-          "minimum": 0,
-          "type": "integer"
-        },
-        "maxItems": 32,
-        "minItems": 32,
-        "type": "array"
       }
     },
     "required": [
       "name",
-      "peer_id",
-      "address"
+      "address",
+      "identity"
     ],
     "title": "WireTrustedPeerSpec",
     "type": "object"

--- a/meerkat-contracts/src/lib.rs
+++ b/meerkat-contracts/src/lib.rs
@@ -341,6 +341,7 @@ pub use wire::{
     WireToolCall,
     WireToolResult,
     WireToolResultContent,
+    WireTrustedPeerIdentity,
     WireTrustedPeerSpec,
     WireUsage,
     WireWorkOrigin,

--- a/meerkat-contracts/src/wire/mob.rs
+++ b/meerkat-contracts/src/wire/mob.rs
@@ -27,23 +27,21 @@ pub enum WireMobBackendKind {
 /// Runtime binding for spawn requests.
 ///
 /// First step toward identity-first mobs. Carries backend-specific binding
-/// details at spawn time. `External` requires real process identity.
+/// details at spawn time. `External` requires typed process identity; callers
+/// do not supply raw comms peer IDs.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 #[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
-#[serde(tag = "kind", rename_all = "snake_case")]
+#[serde(tag = "kind", rename_all = "snake_case", deny_unknown_fields)]
 pub enum WireRuntimeBinding {
     Session,
     External {
-        peer_id: String,
         address: String,
         #[serde(default, skip_serializing_if = "Option::is_none")]
         bootstrap_token: Option<BridgeBootstrapToken>,
-        /// Ed25519 signing pubkey (32 bytes) of the external peer. Required
-        /// for the supervisor to install a non-zero-pubkey trust entry so
-        /// real-comms signed-envelope replies admit past ingress trust
-        /// check. Absent on legacy bindings that pre-date pubkey plumbing.
-        #[serde(default, skip_serializing_if = "Option::is_none")]
-        pubkey: Option<[u8; 32]>,
+        /// Typed Ed25519 signing identity for the external process. The
+        /// canonical comms `PeerId` is derived from this key after the wire
+        /// boundary, so callers cannot spoof an unrelated raw peer id.
+        identity: WireTrustedPeerIdentity,
     },
 }
 
@@ -1904,6 +1902,66 @@ mod tests {
             }
         }))
         .expect_err("missing external peer pubkey material must fail closed");
+
+        let msg = err.to_string();
+        assert!(
+            msg.contains("public_key") || msg.contains("identity"),
+            "unexpected error: {msg}"
+        );
+    }
+
+    #[test]
+    fn runtime_binding_accepts_canonical_external_peer_identity() {
+        let binding = serde_json::from_value::<WireRuntimeBinding>(serde_json::json!({
+            "kind": "external",
+            "address": "inproc://external-worker",
+            "identity": {
+                "kind": "ed25519_public_key",
+                "public_key": "ed25519:BwcHBwcHBwcHBwcHBwcHBwcHBwcHBwcHBwcHBwcHBwc="
+            }
+        }))
+        .expect("canonical external runtime binding identity should deserialize");
+
+        let WireRuntimeBinding::External {
+            identity, address, ..
+        } = binding
+        else {
+            panic!("expected external runtime binding");
+        };
+        assert_eq!(address, "inproc://external-worker");
+        assert_eq!(
+            identity.resolve().expect("identity resolves").pubkey,
+            [7u8; 32]
+        );
+    }
+
+    #[test]
+    fn runtime_binding_rejects_raw_external_peer_id_shape() {
+        let err = serde_json::from_value::<WireRuntimeBinding>(serde_json::json!({
+            "kind": "external",
+            "peer_id": meerkat_core::comms::PeerId::from_ed25519_pubkey(&[7u8; 32]).to_string(),
+            "address": "inproc://external-worker",
+            "pubkey": vec![7u8; 32]
+        }))
+        .expect_err("raw peer_id/pubkey external runtime binding shape must be rejected");
+
+        let msg = err.to_string();
+        assert!(
+            msg.contains("peer_id") || msg.contains("identity"),
+            "unexpected error: {msg}"
+        );
+    }
+
+    #[test]
+    fn runtime_binding_rejects_missing_external_peer_pubkey_material() {
+        let err = serde_json::from_value::<WireRuntimeBinding>(serde_json::json!({
+            "kind": "external",
+            "address": "inproc://external-worker",
+            "identity": {
+                "kind": "ed25519_public_key"
+            }
+        }))
+        .expect_err("missing external runtime binding pubkey material must fail closed");
 
         let msg = err.to_string();
         assert!(

--- a/meerkat-contracts/src/wire/mob.rs
+++ b/meerkat-contracts/src/wire/mob.rs
@@ -3,6 +3,7 @@
 use super::connection::WireConnectionRef;
 use super::session::WireContentInput;
 use super::supervisor_bridge::BridgeBootstrapToken;
+use base64::{Engine, engine::general_purpose::STANDARD as BASE64};
 use meerkat_core::OutputSchema;
 use meerkat_core::{
     HandlingMode,
@@ -662,23 +663,79 @@ pub struct MobEventsResult {
     pub events: Vec<Value>,
 }
 
-/// Minimal trusted peer spec for public mob wiring surfaces.
-///
-/// `pubkey` is the Ed25519 signing public key (32 bytes) required so the
-/// receiver can verify envelope signatures after trust registration.
-/// Serialized as a 32-element JSON array of numbers (matching
-/// `BridgePeerSpec`). Defaults to a zero pubkey for legacy clients —
-/// the corresponding `TrustedPeerDescriptor::pubkey` will then be all
-/// zeros, which makes signature verification fail closed. Production
-/// clients MUST send the real pubkey.
+/// Typed external peer identity for public mob wiring surfaces.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 #[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
+#[serde(tag = "kind", rename_all = "snake_case", deny_unknown_fields)]
+pub enum WireTrustedPeerIdentity {
+    /// Recoverable Ed25519 public key string in `ed25519:<base64>` form.
+    Ed25519PublicKey { public_key: String },
+}
+
+/// Resolved external peer identity atoms used after the wire boundary.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct ResolvedWireTrustedPeerIdentity {
+    pub peer_id: meerkat_core::comms::PeerId,
+    pub pubkey: [u8; 32],
+}
+
+/// Failure modes for resolving a typed external peer identity.
+#[derive(Debug, Clone, thiserror::Error, PartialEq, Eq)]
+pub enum WireTrustedPeerIdentityError {
+    #[error("external peer identity public_key must start with 'ed25519:'")]
+    MissingEd25519Prefix,
+    #[error("external peer identity public_key is not valid base64: {0}")]
+    InvalidBase64(String),
+    #[error("external peer identity public_key must decode to 32 bytes, got {actual}")]
+    InvalidLength { actual: usize },
+    #[error("external peer identity public_key must be non-zero")]
+    ZeroPublicKey,
+}
+
+impl WireTrustedPeerIdentity {
+    pub fn resolve(&self) -> Result<ResolvedWireTrustedPeerIdentity, WireTrustedPeerIdentityError> {
+        match self {
+            Self::Ed25519PublicKey { public_key } => {
+                let pubkey = parse_ed25519_public_key(public_key)?;
+                if pubkey == [0u8; 32] {
+                    return Err(WireTrustedPeerIdentityError::ZeroPublicKey);
+                }
+                Ok(ResolvedWireTrustedPeerIdentity {
+                    peer_id: meerkat_core::comms::PeerId::from_ed25519_pubkey(&pubkey),
+                    pubkey,
+                })
+            }
+        }
+    }
+}
+
+fn parse_ed25519_public_key(raw: &str) -> Result<[u8; 32], WireTrustedPeerIdentityError> {
+    const PREFIX: &str = "ed25519:";
+    let encoded = raw
+        .strip_prefix(PREFIX)
+        .ok_or(WireTrustedPeerIdentityError::MissingEd25519Prefix)?;
+    let bytes = BASE64
+        .decode(encoded)
+        .map_err(|err| WireTrustedPeerIdentityError::InvalidBase64(err.to_string()))?;
+    let actual = bytes.len();
+    let pubkey: [u8; 32] = bytes
+        .try_into()
+        .map_err(|_| WireTrustedPeerIdentityError::InvalidLength { actual })?;
+    Ok(pubkey)
+}
+
+/// Minimal trusted peer spec for public mob wiring surfaces.
+///
+/// `identity` is required and resolves to the Ed25519 signing public key
+/// plus the canonical comms `PeerId` derived from that key. MCP callers do
+/// not provide raw peer IDs, and missing key material fails at the boundary.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
+#[serde(deny_unknown_fields)]
 pub struct WireTrustedPeerSpec {
     pub name: String,
-    pub peer_id: String,
     pub address: String,
-    #[serde(default)]
-    pub pubkey: [u8; 32],
+    pub identity: WireTrustedPeerIdentity,
 }
 
 /// Target for a mob wire/unwire call.
@@ -1780,6 +1837,77 @@ mod tests {
         let msg = err.to_string();
         assert!(
             msg.contains("unknown field `local`") || msg.contains("missing field `member`"),
+            "unexpected error: {msg}"
+        );
+    }
+
+    #[test]
+    fn mob_wire_params_accept_canonical_external_peer_identity() {
+        let params = serde_json::from_value::<MobWireParams>(serde_json::json!({
+            "mob_id": "mob-1",
+            "member": "member-a",
+            "peer": {
+                "external": {
+                    "name": "external-worker",
+                    "address": "inproc://external-worker",
+                    "identity": {
+                        "kind": "ed25519_public_key",
+                        "public_key": "ed25519:BwcHBwcHBwcHBwcHBwcHBwcHBwcHBwcHBwcHBwcHBwc="
+                    }
+                }
+            }
+        }))
+        .expect("canonical external peer identity should deserialize");
+
+        let MobPeerTarget::External(spec) = params.peer else {
+            panic!("expected external peer target");
+        };
+        assert_eq!(spec.name, "external-worker");
+    }
+
+    #[test]
+    fn mob_wire_params_reject_raw_external_peer_id_shape() {
+        let err = serde_json::from_value::<MobWireParams>(serde_json::json!({
+            "mob_id": "mob-1",
+            "member": "member-a",
+            "peer": {
+                "external": {
+                    "name": "external-worker",
+                    "peer_id": meerkat_core::comms::PeerId::from_ed25519_pubkey(&[7u8; 32]).to_string(),
+                    "address": "inproc://external-worker",
+                    "pubkey": vec![7u8; 32]
+                }
+            }
+        }))
+        .expect_err("raw peer_id/pubkey external peer shape must be rejected");
+
+        let msg = err.to_string();
+        assert!(
+            msg.contains("peer_id") || msg.contains("identity"),
+            "unexpected error: {msg}"
+        );
+    }
+
+    #[test]
+    fn mob_wire_params_reject_missing_external_peer_pubkey_material() {
+        let err = serde_json::from_value::<MobWireParams>(serde_json::json!({
+            "mob_id": "mob-1",
+            "member": "member-a",
+            "peer": {
+                "external": {
+                    "name": "external-worker",
+                    "address": "inproc://external-worker",
+                    "identity": {
+                        "kind": "ed25519_public_key"
+                    }
+                }
+            }
+        }))
+        .expect_err("missing external peer pubkey material must fail closed");
+
+        let msg = err.to_string();
+        assert!(
+            msg.contains("public_key") || msg.contains("identity"),
             "unexpected error: {msg}"
         );
     }

--- a/meerkat-contracts/src/wire/mod.rs
+++ b/meerkat-contracts/src/wire/mod.rs
@@ -101,8 +101,8 @@ pub use mob::{
     MobWireParams, MobWireResult, MobWiringRulesInput, WireAgentRuntimeId, WireHandlingMode,
     WireMemberRef, WireMemberRefError, WireMemberState, WireMobBackendKind, WireMobLifecycleAction,
     WireMobMemberStatus, WireMobReconcileStage, WireMobRuntimeMode, WireRenderClass,
-    WireRenderMetadata, WireRenderSalience, WireRuntimeBinding, WireTrustedPeerSpec,
-    WireWorkOrigin,
+    WireRenderMetadata, WireRenderSalience, WireRuntimeBinding, WireTrustedPeerIdentity,
+    WireTrustedPeerSpec, WireWorkOrigin,
 };
 pub use models::{
     CatalogModelEntry, ModelsCatalogResponse, ProviderCatalog, WireModelBetaHeader,

--- a/meerkat-mob-mcp/src/agent_tools.rs
+++ b/meerkat-mob-mcp/src/agent_tools.rs
@@ -1762,6 +1762,7 @@ enum WirePeerArg {
 }
 
 #[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
 struct ExternalPeerArg {
     name: String,
     address: String,

--- a/meerkat-mob-mcp/src/agent_tools.rs
+++ b/meerkat-mob-mcp/src/agent_tools.rs
@@ -1446,8 +1446,9 @@ fn build_tool_defs_with_profile_support(
              For external peers (outside the roster), trust is added on the local member's side.\n\n\
              PEER TARGET TYPES:\n\
              - {\"local\": \"member-id\"} — another member in the same mob roster.\n\
-             - {\"external\": {\"name\": \"peer-name\", \"peer_id\": \"ed25519:...\", \
-               \"address\": \"tcp://host:port\"}} — a trusted peer outside the roster.",
+             - {\"external\": {\"name\": \"peer-name\", \"address\": \"tcp://host:port\", \
+               \"identity\": {\"kind\": \"ed25519_public_key\", \"public_key\": \"ed25519:...\"}}} \
+               — a trusted peer outside the roster.",
             json!({
                 "type": "object",
                 "properties": {
@@ -1469,10 +1470,19 @@ fn build_tool_defs_with_profile_support(
                                         "type": "object",
                                         "properties": {
                                             "name": {"type": "string"},
-                                            "peer_id": {"type": "string"},
-                                            "address": {"type": "string"}
+                                            "address": {"type": "string"},
+                                            "identity": {
+                                                "type": "object",
+                                                "properties": {
+                                                    "kind": {"type": "string", "enum": ["ed25519_public_key"]},
+                                                    "public_key": {"type": "string"}
+                                                },
+                                                "required": ["kind", "public_key"],
+                                                "additionalProperties": false
+                                            }
                                         },
-                                        "required": ["name", "peer_id", "address"]
+                                        "required": ["name", "address", "identity"],
+                                        "additionalProperties": false
                                     }
                                 },
                                 "required": ["external"]
@@ -1510,10 +1520,19 @@ fn build_tool_defs_with_profile_support(
                                         "type": "object",
                                         "properties": {
                                             "name": {"type": "string"},
-                                            "peer_id": {"type": "string"},
-                                            "address": {"type": "string"}
+                                            "address": {"type": "string"},
+                                            "identity": {
+                                                "type": "object",
+                                                "properties": {
+                                                    "kind": {"type": "string", "enum": ["ed25519_public_key"]},
+                                                    "public_key": {"type": "string"}
+                                                },
+                                                "required": ["kind", "public_key"],
+                                                "additionalProperties": false
+                                            }
                                         },
-                                        "required": ["name", "peer_id", "address"]
+                                        "required": ["name", "address", "identity"],
+                                        "additionalProperties": false
                                     }
                                 },
                                 "required": ["external"]
@@ -1728,31 +1747,25 @@ struct MemberArgs {
     member_id: String,
 }
 
-#[derive(Deserialize)]
+#[derive(Debug, Deserialize)]
 struct WireArgs {
     mob_id: String,
     member_id: String,
     peer: WirePeerArg,
 }
 
-#[derive(Deserialize)]
+#[derive(Debug, Deserialize)]
 #[serde(untagged)]
 enum WirePeerArg {
     Local { local: String },
     External { external: ExternalPeerArg },
 }
 
-#[derive(Deserialize)]
+#[derive(Debug, Deserialize)]
 struct ExternalPeerArg {
     name: String,
-    peer_id: String,
     address: String,
-    /// Ed25519 signing public key (32 bytes). Defaults to zero — the
-    /// resulting descriptor will fail envelope signature verification,
-    /// which is the correct fail-closed property for agents that do
-    /// not supply a real key.
-    #[serde(default)]
-    pubkey: [u8; 32],
+    identity: meerkat_contracts::WireTrustedPeerIdentity,
 }
 
 fn peer_target_from_args(
@@ -1761,43 +1774,15 @@ fn peer_target_from_args(
     match peer {
         WirePeerArg::Local { local } => Ok(meerkat_mob::PeerTarget::Local(local.into())),
         WirePeerArg::External { external } => {
-            let name = meerkat_core::comms::PeerName::new(external.name.clone()).map_err(|e| {
-                meerkat_core::error::ToolError::invalid_arguments(
-                    "mob_wire",
-                    format!("invalid peer name '{}': {e}", external.name),
-                )
-            })?;
-            let peer_id = meerkat_core::comms::PeerId::parse(&external.peer_id).map_err(|e| {
-                meerkat_core::error::ToolError::invalid_arguments(
-                    "mob_wire",
-                    format!("invalid peer_id '{}': {e}", external.peer_id),
-                )
-            })?;
-            let address = parse_agent_peer_address(&external.address)
-                .map_err(|e| meerkat_core::error::ToolError::invalid_arguments("mob_wire", e))?;
-            Ok(meerkat_mob::PeerTarget::External(
-                meerkat_core::comms::TrustedPeerDescriptor {
-                    name,
-                    peer_id,
-                    address,
-                    pubkey: external.pubkey,
-                },
-            ))
+            let descriptor = crate::trusted_peer_descriptor_from_wire_parts(
+                external.name,
+                external.address,
+                external.identity,
+            )
+            .map_err(|e| meerkat_core::error::ToolError::invalid_arguments("mob_wire", e))?;
+            Ok(meerkat_mob::PeerTarget::External(descriptor))
         }
     }
-}
-
-fn parse_agent_peer_address(raw: &str) -> Result<meerkat_core::comms::PeerAddress, String> {
-    let (scheme, endpoint) = raw
-        .split_once("://")
-        .ok_or_else(|| format!("peer address missing transport scheme: {raw}"))?;
-    let transport = match scheme {
-        "inproc" => meerkat_core::comms::PeerTransport::Inproc,
-        "uds" => meerkat_core::comms::PeerTransport::Uds,
-        "tcp" => meerkat_core::comms::PeerTransport::Tcp,
-        other => return Err(format!("unknown peer address transport: {other}")),
-    };
-    Ok(meerkat_core::comms::PeerAddress::new(transport, endpoint))
 }
 
 #[derive(Deserialize)]
@@ -1877,6 +1862,79 @@ mod tests {
     use std::collections::HashMap;
     use std::sync::Arc;
     use std::sync::atomic::{AtomicU64, Ordering};
+
+    const ED25519_PUBLIC_KEY_7: &str = "ed25519:BwcHBwcHBwcHBwcHBwcHBwcHBwcHBwcHBwcHBwcHBwc=";
+
+    fn canonical_agent_wire_peer_arg() -> WirePeerArg {
+        serde_json::from_value(serde_json::json!({
+            "external": {
+                "name": "external-worker",
+                "address": "inproc://external-worker",
+                "identity": {
+                    "kind": "ed25519_public_key",
+                    "public_key": ED25519_PUBLIC_KEY_7
+                }
+            }
+        }))
+        .expect("canonical agent external peer target should deserialize")
+    }
+
+    #[test]
+    fn agent_mcp_wire_accepts_canonical_external_peer_identity() {
+        let target = peer_target_from_args(canonical_agent_wire_peer_arg())
+            .expect("canonical agent external peer identity should resolve");
+
+        let meerkat_mob::PeerTarget::External(descriptor) = target else {
+            panic!("canonical agent external peer should resolve to an external descriptor");
+        };
+        let pubkey = [7u8; 32];
+        assert_eq!(descriptor.name.as_str(), "external-worker");
+        assert_eq!(descriptor.address.to_string(), "inproc://external-worker");
+        assert_eq!(descriptor.pubkey, pubkey);
+        assert_eq!(
+            descriptor.peer_id,
+            meerkat_core::comms::PeerId::from_ed25519_pubkey(&pubkey)
+        );
+    }
+
+    #[test]
+    fn agent_mcp_wire_rejects_external_peer_raw_peer_id_shape() {
+        let err = serde_json::from_value::<WirePeerArg>(serde_json::json!({
+            "external": {
+                "name": "external-worker",
+                "peer_id": meerkat_core::comms::PeerId::from_ed25519_pubkey(&[7u8; 32]).to_string(),
+                "address": "inproc://external-worker",
+                "pubkey": vec![7u8; 32]
+            }
+        }))
+        .expect_err("agent MCP raw peer_id/pubkey external peer shape must be rejected");
+
+        let msg = err.to_string();
+        assert!(
+            msg.contains("peer_id") || msg.contains("identity") || msg.contains("did not match"),
+            "unexpected error: {msg}"
+        );
+    }
+
+    #[test]
+    fn agent_mcp_wire_rejects_external_peer_missing_pubkey_material() {
+        let err = serde_json::from_value::<WirePeerArg>(serde_json::json!({
+            "external": {
+                "name": "external-worker",
+                "address": "inproc://external-worker",
+                "identity": {
+                    "kind": "ed25519_public_key"
+                }
+            }
+        }))
+        .expect_err("agent MCP external peer identity must not default missing pubkey material");
+
+        let msg = err.to_string();
+        assert!(
+            msg.contains("public_key") || msg.contains("identity") || msg.contains("did not match"),
+            "unexpected error: {msg}"
+        );
+    }
 
     #[derive(Default)]
     struct TestCommsRegistry {

--- a/meerkat-mob-mcp/src/lib.rs
+++ b/meerkat-mob-mcp/src/lib.rs
@@ -2064,6 +2064,7 @@ impl MobMcpDispatcher {
                                     "agent_identity":{"type":"string"},
                                     "initial_message": content_input_schema(),
                                     "backend":{"type":"string","enum":["session","external"]},
+                                    "binding": runtime_binding_schema(),
                                     "runtime_mode":{"type":"string","enum":["autonomous_host","turn_driven"]},
                                     "labels":{"type":"object","additionalProperties":{"type":"string"}},
                                     "context":{"type":"object"}
@@ -2232,6 +2233,40 @@ fn content_input_schema() -> serde_json::Value {
     })
 }
 
+fn runtime_binding_schema() -> serde_json::Value {
+    json!({
+        "oneOf": [
+            {
+                "type": "object",
+                "properties": {
+                    "kind": { "const": "session" }
+                },
+                "required": ["kind"],
+                "additionalProperties": false
+            },
+            {
+                "type": "object",
+                "properties": {
+                    "kind": { "const": "external" },
+                    "address": { "type": "string" },
+                    "bootstrap_token": { "type": "string" },
+                    "identity": {
+                        "type": "object",
+                        "properties": {
+                            "kind": { "const": "ed25519_public_key" },
+                            "public_key": { "type": "string" }
+                        },
+                        "required": ["kind", "public_key"],
+                        "additionalProperties": false
+                    }
+                },
+                "required": ["kind", "address", "identity"],
+                "additionalProperties": false
+            }
+        ]
+    })
+}
+
 fn encode(call: ToolCallView<'_>, payload: serde_json::Value) -> Result<ToolResult, ToolError> {
     let content = serde_json::to_string(&payload)
         .map_err(|e| ToolError::execution_failed(format!("encode result: {e}")))?;
@@ -2260,7 +2295,7 @@ struct LifecycleArgs {
 struct MobIdArgs {
     mob_id: String,
 }
-#[derive(Deserialize)]
+#[derive(Debug, Deserialize)]
 struct MobSpawnMeerkatArgs {
     profile: String,
     agent_identity: String,
@@ -2269,7 +2304,7 @@ struct MobSpawnMeerkatArgs {
     #[serde(default)]
     backend: Option<MobBackendKind>,
     #[serde(default)]
-    binding: Option<meerkat_mob::RuntimeBinding>,
+    binding: Option<meerkat_contracts::WireRuntimeBinding>,
     #[serde(default)]
     runtime_mode: Option<MobRuntimeMode>,
     #[serde(default)]
@@ -2279,7 +2314,7 @@ struct MobSpawnMeerkatArgs {
     #[serde(default)]
     additional_instructions: Option<Vec<String>>,
 }
-#[derive(Deserialize)]
+#[derive(Debug, Deserialize)]
 struct SpawnManyMeerkatsArgs {
     mob_id: String,
     specs: Vec<MobSpawnMeerkatArgs>,
@@ -2318,6 +2353,27 @@ fn trusted_peer_descriptor_from_wire_parts(
         address,
         pubkey: resolved.pubkey,
     })
+}
+
+fn runtime_binding_from_wire(
+    binding: meerkat_contracts::WireRuntimeBinding,
+) -> Result<meerkat_mob::RuntimeBinding, String> {
+    match binding {
+        meerkat_contracts::WireRuntimeBinding::Session => Ok(meerkat_mob::RuntimeBinding::Session),
+        meerkat_contracts::WireRuntimeBinding::External {
+            address,
+            bootstrap_token,
+            identity,
+        } => {
+            let resolved = identity.resolve().map_err(|err| err.to_string())?;
+            Ok(meerkat_mob::RuntimeBinding::External {
+                peer_id: resolved.peer_id.to_string(),
+                address,
+                bootstrap_token,
+                pubkey: Some(resolved.pubkey),
+            })
+        }
+    }
 }
 
 impl WireActionArgs {
@@ -2569,7 +2625,11 @@ impl AgentToolDispatcher for MobMcpDispatcher {
                         s.initial_message = spec.initial_message;
                         s.runtime_mode = spec.runtime_mode;
                         s.backend = spec.backend;
-                        s.binding = spec.binding;
+                        s.binding = spec
+                            .binding
+                            .map(runtime_binding_from_wire)
+                            .transpose()
+                            .map_err(|e| ToolError::invalid_arguments(call.name, e))?;
                         s.context = spec.context;
                         s.labels = spec.labels;
                         s.additional_instructions = spec.additional_instructions;
@@ -2930,6 +2990,71 @@ mod tests {
                 public_key: public_key.to_string(),
             },
         })
+    }
+
+    #[test]
+    fn mob_spawn_member_args_accept_canonical_external_runtime_binding() {
+        let args = serde_json::from_value::<SpawnManyMeerkatsArgs>(json!({
+            "mob_id": "mob",
+            "specs": [{
+                "profile": "worker",
+                "agent_identity": "w-ext",
+                "binding": {
+                    "kind": "external",
+                    "address": "inproc://external-worker",
+                    "identity": {
+                        "kind": "ed25519_public_key",
+                        "public_key": ED25519_PUBLIC_KEY_7
+                    }
+                }
+            }]
+        }))
+        .expect("canonical external runtime binding should deserialize");
+
+        let binding = args
+            .specs
+            .into_iter()
+            .next()
+            .and_then(|spec| spec.binding)
+            .expect("binding present");
+        let resolved = runtime_binding_from_wire(binding)
+            .expect("canonical external runtime binding resolves");
+        let meerkat_mob::RuntimeBinding::External {
+            peer_id, pubkey, ..
+        } = resolved
+        else {
+            panic!("expected external runtime binding");
+        };
+        let expected_pubkey = [7u8; 32];
+        assert_eq!(
+            peer_id,
+            meerkat_core::comms::PeerId::from_ed25519_pubkey(&expected_pubkey).to_string()
+        );
+        assert_eq!(pubkey, Some(expected_pubkey));
+    }
+
+    #[test]
+    fn mob_spawn_member_args_reject_raw_external_runtime_binding_atoms() {
+        let err = serde_json::from_value::<SpawnManyMeerkatsArgs>(json!({
+            "mob_id": "mob",
+            "specs": [{
+                "profile": "worker",
+                "agent_identity": "w-ext",
+                "binding": {
+                    "kind": "external",
+                    "peer_id": meerkat_core::comms::PeerId::from_ed25519_pubkey(&[7u8; 32]).to_string(),
+                    "address": "inproc://external-worker",
+                    "pubkey": vec![7u8; 32]
+                }
+            }]
+        }))
+        .expect_err("raw peer_id/pubkey external runtime binding shape must be rejected");
+
+        let msg = err.to_string();
+        assert!(
+            msg.contains("peer_id") || msg.contains("identity"),
+            "unexpected error: {msg}"
+        );
     }
 
     #[test]
@@ -4266,7 +4391,18 @@ mod tests {
             "mob_spawn_member",
             json!({
                 "mob_id": mob_id,
-                "specs": [{"profile": "worker", "agent_identity": "w-ext", "binding": {"kind": "external", "peer_id": "ed25519:QUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUE=", "address": "inproc://test-w-ext"}}]
+                "specs": [{
+                    "profile": "worker",
+                    "agent_identity": "w-ext",
+                    "binding": {
+                        "kind": "external",
+                        "address": "inproc://test-w-ext",
+                        "identity": {
+                            "kind": "ed25519_public_key",
+                            "public_key": ED25519_PUBLIC_KEY_7
+                        }
+                    }
+                }]
             }),
         )
         .await;

--- a/meerkat-mob-mcp/src/lib.rs
+++ b/meerkat-mob-mcp/src/lib.rs
@@ -2108,16 +2108,19 @@ impl MobMcpDispatcher {
                                             "type":"object",
                                             "properties":{
                                                 "name":{"type":"string"},
-                                                "peer_id":{"type":"string"},
                                                 "address":{"type":"string"},
-                                                "pubkey":{
-                                                    "type":"array",
-                                                    "items":{"type":"integer","minimum":0,"maximum":255},
-                                                    "minItems":32,
-                                                    "maxItems":32
+                                                "identity":{
+                                                    "type":"object",
+                                                    "properties":{
+                                                        "kind":{"type":"string","enum":["ed25519_public_key"]},
+                                                        "public_key":{"type":"string"}
+                                                    },
+                                                    "required":["kind","public_key"],
+                                                    "additionalProperties":false
                                                 }
                                             },
-                                            "required":["name","peer_id","address","pubkey"]
+                                            "required":["name","address","identity"],
+                                            "additionalProperties":false
                                         }
                                     },
                                     "required":["external"]
@@ -2297,25 +2300,23 @@ struct WireActionArgs {
 fn trusted_peer_descriptor_from_wire_spec(
     spec: meerkat_contracts::WireTrustedPeerSpec,
 ) -> Result<TrustedPeerDescriptor, String> {
-    let name = meerkat_core::comms::PeerName::new(spec.name.clone())
-        .map_err(|e| format!("invalid peer name '{}': {e}", spec.name))?;
-    let peer_id = meerkat_core::comms::PeerId::parse(&spec.peer_id)
-        .map_err(|e| format!("invalid peer_id '{}': {e}", spec.peer_id))?;
-    if spec.pubkey == [0u8; 32] {
-        return Err("external peer pubkey must be non-zero".to_string());
-    }
-    let derived_peer_id = meerkat_core::comms::PeerId::from_ed25519_pubkey(&spec.pubkey);
-    if peer_id != derived_peer_id {
-        return Err(format!(
-            "external peer_id '{peer_id}' does not match pubkey-derived peer_id '{derived_peer_id}'"
-        ));
-    }
-    let address = parse_wire_peer_address(&spec.address)?;
+    trusted_peer_descriptor_from_wire_parts(spec.name, spec.address, spec.identity)
+}
+
+fn trusted_peer_descriptor_from_wire_parts(
+    name: String,
+    address: String,
+    identity: meerkat_contracts::WireTrustedPeerIdentity,
+) -> Result<TrustedPeerDescriptor, String> {
+    let name = meerkat_core::comms::PeerName::new(name.clone())
+        .map_err(|e| format!("invalid peer name '{name}': {e}"))?;
+    let resolved = identity.resolve().map_err(|e| e.to_string())?;
+    let address = parse_wire_peer_address(&address)?;
     Ok(TrustedPeerDescriptor {
         name,
-        peer_id,
+        peer_id: resolved.peer_id,
         address,
-        pubkey: spec.pubkey,
+        pubkey: resolved.pubkey,
     })
 }
 
@@ -2918,12 +2919,16 @@ mod tests {
     use tokio::sync::Notify;
     use tokio::time::{Duration, Instant, sleep};
 
-    fn external_peer_target(peer_id: String, pubkey: [u8; 32]) -> MobPeerTarget {
+    const ED25519_PUBLIC_KEY_7: &str = "ed25519:BwcHBwcHBwcHBwcHBwcHBwcHBwcHBwcHBwcHBwcHBwc=";
+    const ED25519_PUBLIC_KEY_ZERO: &str = "ed25519:AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=";
+
+    fn external_peer_target(public_key: &str) -> MobPeerTarget {
         MobPeerTarget::External(meerkat_contracts::WireTrustedPeerSpec {
             name: "external-worker".to_string(),
-            peer_id,
             address: "inproc://external-worker".to_string(),
-            pubkey,
+            identity: meerkat_contracts::WireTrustedPeerIdentity::Ed25519PublicKey {
+                public_key: public_key.to_string(),
+            },
         })
     }
 
@@ -2932,39 +2937,38 @@ mod tests {
         let err = WireActionArgs {
             mob_id: "mob".to_string(),
             agent_identity: "worker".to_string(),
-            peer: external_peer_target(meerkat_core::comms::PeerId::new().to_string(), [0u8; 32]),
+            peer: external_peer_target(ED25519_PUBLIC_KEY_ZERO),
             action: "wire".to_string(),
         }
         .resolve()
         .expect_err("zero pubkey external peers must be rejected");
 
         assert!(
-            err.contains("pubkey"),
+            err.contains("public_key") || err.contains("non-zero"),
             "expected pubkey validation error, got: {err}"
         );
     }
 
     #[test]
-    fn wire_action_args_rejects_external_peer_pubkey_peer_id_mismatch() {
-        let pubkey = [7u8; 32];
-        let mismatched_peer_id = meerkat_core::comms::PeerId::new().to_string();
-        assert_ne!(
-            mismatched_peer_id,
-            meerkat_core::comms::PeerId::from_ed25519_pubkey(&pubkey).to_string()
-        );
-
-        let err = WireActionArgs {
+    fn wire_action_args_resolves_canonical_external_peer_identity() {
+        let resolved = WireActionArgs {
             mob_id: "mob".to_string(),
             agent_identity: "worker".to_string(),
-            peer: external_peer_target(mismatched_peer_id, pubkey),
+            peer: external_peer_target(ED25519_PUBLIC_KEY_7),
             action: "wire".to_string(),
         }
         .resolve()
-        .expect_err("external peer_id must match the supplied pubkey");
+        .expect("canonical external peer identity should resolve");
 
-        assert!(
-            err.contains("peer_id") && err.contains("pubkey"),
-            "expected peer_id/pubkey validation error, got: {err}"
+        let (_mob_id, _local, target, _action) = resolved;
+        let meerkat_mob::PeerTarget::External(descriptor) = target else {
+            panic!("canonical external peer should resolve to an external descriptor");
+        };
+        let pubkey = [7u8; 32];
+        assert_eq!(descriptor.pubkey, pubkey);
+        assert_eq!(
+            descriptor.peer_id,
+            meerkat_core::comms::PeerId::from_ed25519_pubkey(&pubkey)
         );
     }
 

--- a/meerkat-mob-mcp/src/public_mcp.rs
+++ b/meerkat-mob-mcp/src/public_mcp.rs
@@ -956,9 +956,9 @@ fn build_spawn_spec(
     // Resolve binding: explicit binding takes precedence over legacy backend tag.
     // Conflicting backend + binding is rejected.
     spec.binding = match (binding, backend) {
-        (Some(wb), None) => Some(runtime_binding_from_wire(wb)),
+        (Some(wb), None) => Some(runtime_binding_from_wire(wb)?),
         (Some(wb), Some(bk)) => {
-            let resolved = runtime_binding_from_wire(wb);
+            let resolved = runtime_binding_from_wire(wb)?;
             if resolved.kind() != backend_kind_from_wire(bk) {
                 return Err(McpToolError::invalid_params(
                     "conflicting 'backend' and 'binding' fields",
@@ -986,20 +986,26 @@ fn build_spawn_spec(
     Ok(spec)
 }
 
-fn runtime_binding_from_wire(wb: WireRuntimeBinding) -> meerkat_mob::RuntimeBinding {
+fn runtime_binding_from_wire(
+    wb: WireRuntimeBinding,
+) -> Result<meerkat_mob::RuntimeBinding, McpToolError> {
     match wb {
-        WireRuntimeBinding::Session => meerkat_mob::RuntimeBinding::Session,
+        WireRuntimeBinding::Session => Ok(meerkat_mob::RuntimeBinding::Session),
         WireRuntimeBinding::External {
-            peer_id,
             address,
             bootstrap_token,
-            pubkey,
-        } => meerkat_mob::RuntimeBinding::External {
-            peer_id,
-            address,
-            bootstrap_token,
-            pubkey,
-        },
+            identity,
+        } => {
+            let resolved = identity
+                .resolve()
+                .map_err(|err| McpToolError::invalid_params(err.to_string()))?;
+            Ok(meerkat_mob::RuntimeBinding::External {
+                peer_id: resolved.peer_id.to_string(),
+                address,
+                bootstrap_token,
+                pubkey: Some(resolved.pubkey),
+            })
+        }
     }
 }
 
@@ -1034,6 +1040,18 @@ mod tests {
                 public_key: public_key.to_string(),
             },
         })
+    }
+
+    fn external_runtime_binding(public_key: &str) -> meerkat_contracts::WireRuntimeBinding {
+        serde_json::from_value(serde_json::json!({
+            "kind": "external",
+            "address": "inproc://external-worker",
+            "identity": {
+                "kind": "ed25519_public_key",
+                "public_key": public_key
+            }
+        }))
+        .expect("canonical external runtime binding should deserialize")
     }
 
     #[test]
@@ -1113,6 +1131,59 @@ mod tests {
         assert!(
             err.message.contains("public_key") || err.message.contains("ed25519"),
             "expected typed identity validation error, got: {}",
+            err.message
+        );
+    }
+
+    #[test]
+    fn public_mcp_spawn_binding_resolves_canonical_external_identity() {
+        let binding = runtime_binding_from_wire(external_runtime_binding(ED25519_PUBLIC_KEY_7))
+            .expect("canonical runtime binding identity should resolve");
+
+        let meerkat_mob::RuntimeBinding::External {
+            peer_id,
+            address,
+            pubkey,
+            ..
+        } = binding
+        else {
+            panic!("expected external runtime binding");
+        };
+        let expected_pubkey = [7u8; 32];
+        assert_eq!(address, "inproc://external-worker");
+        assert_eq!(
+            peer_id,
+            meerkat_core::comms::PeerId::from_ed25519_pubkey(&expected_pubkey).to_string()
+        );
+        assert_eq!(pubkey, Some(expected_pubkey));
+    }
+
+    #[test]
+    fn public_mcp_spawn_binding_rejects_raw_peer_id_shape() {
+        let err =
+            serde_json::from_value::<meerkat_contracts::WireRuntimeBinding>(serde_json::json!({
+                "kind": "external",
+                "peer_id": meerkat_core::comms::PeerId::from_ed25519_pubkey(&[7u8; 32]).to_string(),
+                "address": "inproc://external-worker",
+                "pubkey": vec![7u8; 32]
+            }))
+            .expect_err("raw peer_id/pubkey external runtime binding shape must be rejected");
+
+        let msg = err.to_string();
+        assert!(
+            msg.contains("peer_id") || msg.contains("identity"),
+            "unexpected error: {msg}"
+        );
+    }
+
+    #[test]
+    fn public_mcp_spawn_binding_rejects_zero_pubkey() {
+        let err = runtime_binding_from_wire(external_runtime_binding(ED25519_PUBLIC_KEY_ZERO))
+            .expect_err("zero pubkey external runtime binding must be rejected");
+
+        assert!(
+            err.message.contains("public_key") || err.message.contains("non-zero"),
+            "expected pubkey validation error, got: {}",
             err.message
         );
     }

--- a/meerkat-mob-mcp/src/public_mcp.rs
+++ b/meerkat-mob-mcp/src/public_mcp.rs
@@ -1009,45 +1009,110 @@ mod tests {
     use super::*;
     use crate::MobMcpState;
 
-    fn external_peer_target(peer_id: String, pubkey: [u8; 32]) -> meerkat_contracts::MobPeerTarget {
+    const ED25519_PUBLIC_KEY_7: &str = "ed25519:BwcHBwcHBwcHBwcHBwcHBwcHBwcHBwcHBwcHBwcHBwc=";
+    const ED25519_PUBLIC_KEY_ZERO: &str = "ed25519:AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=";
+
+    fn canonical_external_peer_target() -> meerkat_contracts::MobPeerTarget {
+        serde_json::from_value(serde_json::json!({
+            "external": {
+                "name": "external-worker",
+                "address": "inproc://external-worker",
+                "identity": {
+                    "kind": "ed25519_public_key",
+                    "public_key": ED25519_PUBLIC_KEY_7
+                }
+            }
+        }))
+        .expect("canonical external peer target should deserialize")
+    }
+
+    fn external_peer_target(public_key: &str) -> meerkat_contracts::MobPeerTarget {
         meerkat_contracts::MobPeerTarget::External(meerkat_contracts::WireTrustedPeerSpec {
             name: "external-worker".to_string(),
-            peer_id,
             address: "inproc://external-worker".to_string(),
-            pubkey,
+            identity: meerkat_contracts::WireTrustedPeerIdentity::Ed25519PublicKey {
+                public_key: public_key.to_string(),
+            },
         })
     }
 
     #[test]
+    fn public_mcp_wire_accepts_canonical_external_peer_identity() {
+        let target = peer_target_from_wire(canonical_external_peer_target())
+            .expect("canonical external peer identity should resolve");
+
+        let meerkat_mob::PeerTarget::External(descriptor) = target else {
+            panic!("canonical external peer should resolve to an external descriptor");
+        };
+        let pubkey = [7u8; 32];
+        assert_eq!(descriptor.name.as_str(), "external-worker");
+        assert_eq!(descriptor.address.to_string(), "inproc://external-worker");
+        assert_eq!(descriptor.pubkey, pubkey);
+        assert_eq!(
+            descriptor.peer_id,
+            meerkat_core::comms::PeerId::from_ed25519_pubkey(&pubkey)
+        );
+    }
+
+    #[test]
+    fn public_mcp_wire_rejects_external_peer_raw_peer_id_shape() {
+        let err = serde_json::from_value::<meerkat_contracts::MobPeerTarget>(serde_json::json!({
+            "external": {
+                "name": "external-worker",
+                "peer_id": meerkat_core::comms::PeerId::from_ed25519_pubkey(&[7u8; 32]).to_string(),
+                "address": "inproc://external-worker",
+                "pubkey": vec![7u8; 32]
+            }
+        }))
+        .expect_err("raw peer_id/pubkey external peer shape must be rejected");
+
+        let msg = err.to_string();
+        assert!(
+            msg.contains("peer_id") || msg.contains("identity"),
+            "unexpected error: {msg}"
+        );
+    }
+
+    #[test]
+    fn public_mcp_wire_rejects_external_peer_missing_pubkey_material() {
+        let err = serde_json::from_value::<meerkat_contracts::MobPeerTarget>(serde_json::json!({
+            "external": {
+                "name": "external-worker",
+                "address": "inproc://external-worker",
+                "identity": {
+                    "kind": "ed25519_public_key"
+                }
+            }
+        }))
+        .expect_err("external peer identity must not default missing pubkey material");
+
+        let msg = err.to_string();
+        assert!(
+            msg.contains("public_key") || msg.contains("identity"),
+            "unexpected error: {msg}"
+        );
+    }
+
+    #[test]
     fn public_mcp_wire_rejects_external_peer_zero_pubkey() {
-        let err = peer_target_from_wire(external_peer_target(
-            meerkat_core::comms::PeerId::new().to_string(),
-            [0u8; 32],
-        ))
-        .expect_err("zero pubkey external peers must be rejected");
+        let err = peer_target_from_wire(external_peer_target(ED25519_PUBLIC_KEY_ZERO))
+            .expect_err("zero pubkey external peers must be rejected");
 
         assert!(
-            err.message.contains("pubkey"),
+            err.message.contains("public_key") || err.message.contains("non-zero"),
             "expected pubkey validation error, got: {}",
             err.message
         );
     }
 
     #[test]
-    fn public_mcp_wire_rejects_external_peer_pubkey_peer_id_mismatch() {
-        let pubkey = [7u8; 32];
-        let mismatched_peer_id = meerkat_core::comms::PeerId::new().to_string();
-        assert_ne!(
-            mismatched_peer_id,
-            meerkat_core::comms::PeerId::from_ed25519_pubkey(&pubkey).to_string()
-        );
-
-        let err = peer_target_from_wire(external_peer_target(mismatched_peer_id, pubkey))
-            .expect_err("external peer_id must match the supplied pubkey");
+    fn public_mcp_wire_rejects_invalid_external_peer_identity() {
+        let err = peer_target_from_wire(external_peer_target("not-a-typed-public-key"))
+            .expect_err("invalid canonical external peer identity must be rejected");
 
         assert!(
-            err.message.contains("peer_id") && err.message.contains("pubkey"),
-            "expected peer_id/pubkey validation error, got: {}",
+            err.message.contains("public_key") || err.message.contains("ed25519"),
+            "expected typed identity validation error, got: {}",
             err.message
         );
     }

--- a/meerkat-rpc/src/handlers/mob.rs
+++ b/meerkat-rpc/src/handlers/mob.rs
@@ -74,6 +74,27 @@ fn project_member_status(status: MobMemberStatus) -> WireMobMemberStatus {
     }
 }
 
+fn runtime_binding_from_wire(
+    binding: meerkat_contracts::WireRuntimeBinding,
+) -> Result<meerkat_mob::RuntimeBinding, String> {
+    match binding {
+        meerkat_contracts::WireRuntimeBinding::Session => Ok(meerkat_mob::RuntimeBinding::Session),
+        meerkat_contracts::WireRuntimeBinding::External {
+            address,
+            bootstrap_token,
+            identity,
+        } => {
+            let resolved = identity.resolve().map_err(|err| err.to_string())?;
+            Ok(meerkat_mob::RuntimeBinding::External {
+                peer_id: resolved.peer_id.to_string(),
+                address,
+                bootstrap_token,
+                pubkey: Some(resolved.pubkey),
+            })
+        }
+    }
+}
+
 /// Convert a mob roster entry into the public typed wire shape. Used for
 /// `mob/ensure_member`'s `Existed` outcome and for typed member-list
 /// responses.
@@ -318,20 +339,10 @@ pub async fn handle_spawn(
     spec.labels = params.labels;
     spec.additional_instructions = params.additional_instructions;
     if let Some(binding) = params.binding {
-        spec.binding = Some(match binding {
-            meerkat_contracts::WireRuntimeBinding::Session => meerkat_mob::RuntimeBinding::Session,
-            meerkat_contracts::WireRuntimeBinding::External {
-                peer_id,
-                address,
-                bootstrap_token,
-                pubkey,
-            } => meerkat_mob::RuntimeBinding::External {
-                peer_id,
-                address,
-                bootstrap_token,
-                pubkey,
-            },
-        });
+        match runtime_binding_from_wire(binding) {
+            Ok(binding) => spec.binding = Some(binding),
+            Err(err) => return invalid_params(id, err),
+        }
     }
     if let Some(shell_env) = params.shell_env {
         spec.shell_env = Some(shell_env);
@@ -1824,20 +1835,7 @@ fn spawn_spec_from_wire(
     spec.labels = spec_wire.labels.clone();
     spec.additional_instructions = spec_wire.additional_instructions.clone();
     if let Some(binding) = spec_wire.binding.clone() {
-        spec.binding = Some(match binding {
-            meerkat_contracts::WireRuntimeBinding::Session => meerkat_mob::RuntimeBinding::Session,
-            meerkat_contracts::WireRuntimeBinding::External {
-                peer_id,
-                address,
-                bootstrap_token,
-                pubkey,
-            } => meerkat_mob::RuntimeBinding::External {
-                peer_id,
-                address,
-                bootstrap_token,
-                pubkey,
-            },
-        });
+        spec.binding = Some(runtime_binding_from_wire(binding)?);
     }
     if let Some(auto_wire_parent) = spec_wire.auto_wire_parent {
         spec.auto_wire_parent = auto_wire_parent;

--- a/sdks/python/meerkat/generated/types.py
+++ b/sdks/python/meerkat/generated/types.py
@@ -290,14 +290,12 @@ class WireRenderMetadata:
     salience: Optional[Literal['background', 'normal', 'important', 'urgent']] = None
 
 
+# Typed external peer identity for public mob wiring surfaces.
 class WireTrustedPeerIdentityEd25519PublicKey(TypedDict, total=False):
-    """Recoverable Ed25519 public key string in `ed25519:<base64>` form."""
     kind: Required[Literal['ed25519_public_key']]
     public_key: Required[str]
 
-
 WireTrustedPeerIdentity = WireTrustedPeerIdentityEd25519PublicKey
-
 
 @dataclass
 class WireTrustedPeerSpec:

--- a/sdks/python/meerkat/generated/types.py
+++ b/sdks/python/meerkat/generated/types.py
@@ -290,21 +290,25 @@ class WireRenderMetadata:
     salience: Optional[Literal['background', 'normal', 'important', 'urgent']] = None
 
 
+class WireTrustedPeerIdentityEd25519PublicKey(TypedDict, total=False):
+    """Recoverable Ed25519 public key string in `ed25519:<base64>` form."""
+    kind: Required[Literal['ed25519_public_key']]
+    public_key: Required[str]
+
+
+WireTrustedPeerIdentity = WireTrustedPeerIdentityEd25519PublicKey
+
+
 @dataclass
 class WireTrustedPeerSpec:
     """Minimal trusted peer spec for public mob wiring surfaces.
 
-`pubkey` is the Ed25519 signing public key (32 bytes) required so the
-receiver can verify envelope signatures after trust registration.
-Serialized as a 32-element JSON array of numbers (matching
-`BridgePeerSpec`). Defaults to a zero pubkey for legacy clients —
-the corresponding `TrustedPeerDescriptor::pubkey` will then be all
-zeros, which makes signature verification fail closed. Production
-clients MUST send the real pubkey."""
+`identity` is required and resolves to the Ed25519 signing public key
+plus the canonical comms `PeerId` derived from that key. MCP callers do
+not provide raw peer IDs, and missing key material fails at the boundary."""
     address: str
+    identity: WireTrustedPeerIdentity
     name: str
-    peer_id: str
-    pubkey: Optional[list[int]] = None
 
 
 @dataclass

--- a/sdks/python/tests/test_types.py
+++ b/sdks/python/tests/test_types.py
@@ -1474,7 +1474,16 @@ async def test_client_mob_lifecycle_and_send_methods_use_explicit_rpc_methods():
     await client.unwire_mob_members(
         "mob-1",
         "a",
-        {"external": {"name": "remote", "peer_id": "ed25519:remote", "address": "inproc://remote"}},
+        {
+            "external": {
+                "name": "remote",
+                "address": "inproc://remote",
+                "identity": {
+                    "kind": "ed25519_public_key",
+                    "public_key": "ed25519:BwcHBwcHBwcHBwcHBwcHBwcHBwcHBwcHBwcHBwcHBwc=",
+                },
+            }
+        },
     )
     await client.mob_lifecycle("mob-1", "start")
     wait_members = await client.wait_mob_kickoff(
@@ -1540,8 +1549,11 @@ async def test_client_mob_lifecycle_and_send_methods_use_explicit_rpc_methods():
         "peer": {
             "external": {
                 "name": "remote",
-                "peer_id": "ed25519:remote",
                 "address": "inproc://remote",
+                "identity": {
+                    "kind": "ed25519_public_key",
+                    "public_key": "ed25519:BwcHBwcHBwcHBwcHBwcHBwcHBwcHBwcHBwcHBwcHBwc=",
+                },
             }
         },
     }

--- a/sdks/typescript/src/generated/types.ts
+++ b/sdks/typescript/src/generated/types.ts
@@ -543,11 +543,17 @@ export interface WireRenderMetadata {
   salience?: "background" | "normal" | "important" | "urgent";
 }
 
+export interface WireTrustedPeerIdentityEd25519PublicKey {
+  kind: "ed25519_public_key";
+  public_key: string;
+}
+
+export type WireTrustedPeerIdentity = WireTrustedPeerIdentityEd25519PublicKey;
+
 export interface WireTrustedPeerSpec {
   address: string;
+  identity: WireTrustedPeerIdentity;
   name: string;
-  peer_id: string;
-  pubkey?: number[];
 }
 
 export interface MobWireResult {

--- a/sdks/typescript/src/mob.ts
+++ b/sdks/typescript/src/mob.ts
@@ -88,8 +88,11 @@ export type MobReadyMemberSnapshot = MobKickoffMemberSnapshot;
 export interface ExternalPeerTarget {
   readonly external: {
     readonly name: string;
-    readonly peer_id: string;
     readonly address: string;
+    readonly identity: {
+      readonly kind: "ed25519_public_key";
+      readonly public_key: string;
+    };
   };
 }
 

--- a/sdks/web/src/types.ts
+++ b/sdks/web/src/types.ts
@@ -366,8 +366,11 @@ export interface MobMember {
 export interface ExternalPeerTarget {
   external: {
     name: string;
-    peer_id: string;
     address: string;
+    identity: {
+      kind: "ed25519_public_key";
+      public_key: string;
+    };
   };
 }
 

--- a/tools/sdk-codegen/generate.py
+++ b/tools/sdk-codegen/generate.py
@@ -90,6 +90,7 @@ def _promote_nested_schema_def(name: str) -> bool:
     return name.startswith("Realtime") or name in {
         "AudioFormatMismatchContext",
         "ToolCallTimeoutContext",
+        "WireTrustedPeerIdentity",
     }
 
 
@@ -579,6 +580,7 @@ def generate_python_types(schemas: dict, output_dir: Path, *, has_comms: bool = 
     append_python_dataclass("UpdateScheduleParams", params_schema, "Request payload for schedule/update.")
     append_python_dataclass("McpLiveOpResponse", wire_schema, "Response payload for mcp/add|remove|reload.")
     append_python_dataclass("WireRenderMetadata", wire_schema, "Render metadata for mob member delivery.")
+    append_python_alias("WireTrustedPeerIdentity", wire_schema, "Typed external peer identity.")
     append_python_dataclass("WireTrustedPeerSpec", wire_schema, "Minimal trusted peer spec for mob wiring.")
     append_python_dataclass("MobWireResult", wire_schema, "Response payload for mob/wire.")
     append_python_dataclass("MobUnwireResult", wire_schema, "Response payload for mob/unwire.")
@@ -931,6 +933,7 @@ def generate_typescript_types(schemas: dict, output_dir: Path, *, has_comms: boo
     append_typescript_alias("WireModelTier", schemas.get("models", {}))
     append_typescript_alias("CommsCommandRequest", wire_schema)
     append_typescript_interface("WireRenderMetadata", wire_schema)
+    append_typescript_alias("WireTrustedPeerIdentity", wire_schema)
     append_typescript_interface("WireTrustedPeerSpec", wire_schema)
     append_typescript_interface("MobWireResult", wire_schema)
     append_typescript_interface("MobUnwireResult", wire_schema)


### PR DESCRIPTION
## Summary
- replace external MCP mob wiring peer specs with required typed Ed25519 identities
- derive canonical comms PeerId from the typed identity at the MCP boundary
- update public/agent MCP tests plus SDK wire types for the new contract

## Validation
- ./scripts/repo-cargo test -p meerkat-contracts --lib
- ./scripts/repo-cargo test -p meerkat-mob-mcp --lib
- python3 -m pytest sdks/python/tests/test_types.py -q
- make check (BuildBuddy invocation b6279266-808c-4399-b26b-4fd1a1443b75)

Linear: https://linear.app/lucrfr/issue/LUC-132/p0p1-dogma-remove-raw-comms-atoms-from-mcp-mob-external-wiring