### PR TITLE
Guard provider overrides against catalog owners

### DIFF
--- a/meerkat-cli/src/main.rs
+++ b/meerkat-cli/src/main.rs
@@ -9580,6 +9580,11 @@ fn resolve_cli_provider(
     explicit: Option<Provider>,
 ) -> anyhow::Result<Provider> {
     if let Some(provider) = explicit {
+        if let Some(reason) = config.model_registry().ok().and_then(|registry| {
+            registry.provider_override_mismatch_reason(provider.as_core(), model)
+        }) {
+            anyhow::bail!(reason);
+        }
         return Ok(provider);
     }
 
@@ -13672,6 +13677,21 @@ supports_reasoning = true
         assert!(error.to_string().contains("Cannot infer provider"));
     }
 
+    #[test]
+    fn test_resolve_cli_provider_rejects_explicit_provider_contradicting_catalog_owner() {
+        let config = Config::default();
+        let error = resolve_cli_provider(&config, "gpt-5.4", Some(Provider::Anthropic))
+            .expect_err("explicit provider must match catalog ownership");
+        assert!(
+            error
+                .to_string()
+                .contains("registered for provider 'openai'")
+                && error.to_string().contains("not provider 'anthropic'")
+                && error.to_string().contains("gpt-5.4"),
+            "error should identify the rejected provider/model pair: {error}"
+        );
+    }
+
     #[cfg(feature = "comms")]
     #[test]
     fn test_comms_tool_dispatcher_provides_comms_tools() {
@@ -13934,6 +13954,7 @@ supports_reasoning = true
             step_ledger: Vec::new(),
             failure_ledger: Vec::new(),
             flow_state: Default::default(),
+            flow_authority_inputs: Vec::new(),
             frames: std::collections::BTreeMap::new(),
             loops: std::collections::BTreeMap::new(),
             loop_iteration_ledger: Vec::new(),
@@ -13978,6 +13999,7 @@ supports_reasoning = true
                             step_ledger: Vec::new(),
                             failure_ledger: Vec::new(),
                             flow_state: Default::default(),
+                            flow_authority_inputs: Vec::new(),
                             frames: std::collections::BTreeMap::new(),
                             loops: std::collections::BTreeMap::new(),
                             loop_iteration_ledger: Vec::new(),
@@ -13999,6 +14021,7 @@ supports_reasoning = true
                             step_ledger: Vec::new(),
                             failure_ledger: Vec::new(),
                             flow_state: Default::default(),
+                            flow_authority_inputs: Vec::new(),
                             frames: std::collections::BTreeMap::new(),
                             loops: std::collections::BTreeMap::new(),
                             loop_iteration_ledger: Vec::new(),

--- a/meerkat-core/src/model_registry.rs
+++ b/meerkat-core/src/model_registry.rs
@@ -108,6 +108,23 @@ impl ModelRegistry {
             .filter(|entry| entry.provider == provider)
     }
 
+    pub fn provider_override_mismatch_reason(
+        &self,
+        provider: Provider,
+        model_id: &str,
+    ) -> Option<String> {
+        let registered_provider = self.entry(model_id)?.provider;
+        if registered_provider == provider {
+            return None;
+        }
+
+        Some(format!(
+            "model '{model_id}' is registered for provider '{}', not provider '{}'; explicit provider overrides must match catalog ownership",
+            registered_provider.as_str(),
+            provider.as_str()
+        ))
+    }
+
     pub fn profile_for(&self, model_id: &str) -> Option<ModelProfile> {
         self.entry(model_id).map(|entry| entry.profile.clone())
     }
@@ -415,6 +432,35 @@ mod tests {
         assert!(
             registry.profile_for("gpt-5.4").is_some(),
             "legacy unambiguous model-id lookup remains available"
+        );
+    }
+
+    #[test]
+    fn provider_override_mismatch_reason_reports_catalog_owner_contradictions() {
+        let registry = match ModelRegistry::from_config(&Config::default()) {
+            Ok(registry) => registry,
+            Err(err) => panic!("registry construction failed: {err}"),
+        };
+
+        let reason = registry
+            .provider_override_mismatch_reason(Provider::Anthropic, "gpt-5.4")
+            .expect("wrong-provider override for a catalog model should be rejected");
+        assert!(reason.contains("model 'gpt-5.4'"));
+        assert!(reason.contains("registered for provider 'openai'"));
+        assert!(reason.contains("not provider 'anthropic'"));
+        assert!(reason.contains("explicit provider overrides"));
+
+        assert!(
+            registry
+                .provider_override_mismatch_reason(Provider::OpenAI, "gpt-5.4")
+                .is_none(),
+            "matching provider override should remain valid"
+        );
+        assert!(
+            registry
+                .provider_override_mismatch_reason(Provider::OpenAI, "uncatalogued-gpt-compatible")
+                .is_none(),
+            "uncatalogued models have no catalog owner to contradict"
         );
     }
 }

--- a/meerkat-rest/src/lib.rs
+++ b/meerkat-rest/src/lib.rs
@@ -497,12 +497,17 @@ async fn resolve_validation_identity(
     config_runtime: &meerkat_core::ConfigRuntime,
     model: &str,
     provider: Option<meerkat_core::Provider>,
-) -> SessionLlmIdentity {
+) -> Result<SessionLlmIdentity, String> {
     let snapshot = config_runtime.get().await.ok().map(|state| state.config);
     let registry = snapshot
         .as_ref()
         .and_then(|config| config.model_registry().ok());
     let entry = registry.as_ref().and_then(|registry| registry.entry(model));
+    if let (Some(registry), Some(provider)) = (registry.as_ref(), provider)
+        && let Some(reason) = registry.provider_override_mismatch_reason(provider, model)
+    {
+        return Err(reason);
+    }
     let provider = provider
         .or_else(|| entry.map(|entry| entry.provider))
         .or_else(|| meerkat_core::Provider::infer_from_model(model))
@@ -515,13 +520,13 @@ async fn resolve_validation_identity(
         None
     };
 
-    SessionLlmIdentity {
+    Ok(SessionLlmIdentity {
         model: model.to_string(),
         provider,
         self_hosted_server_id,
         provider_params: None,
         connection_ref: None,
-    }
+    })
 }
 
 async fn validate_prompt_video_input(
@@ -2820,7 +2825,14 @@ async fn create_session_inner(
 
     let current_generation = state.config_runtime.get().await.ok().map(|s| s.generation);
     let initial_identity =
-        resolve_validation_identity(&state.config_runtime, &model, req.provider).await;
+        match resolve_validation_identity(&state.config_runtime, &model, req.provider).await {
+            Ok(identity) => identity,
+            Err(err) => {
+                drop(caller_event_tx);
+                drain_event_forwarder(&session_id, forward_task).await;
+                return RequestTerminal::RespondWithoutPublish(Err(ApiError::BadRequest(err)));
+            }
+        };
     let mut build = SessionBuildOptions {
         provider: req.provider,
         self_hosted_server_id: initial_identity.self_hosted_server_id.clone(),
@@ -2897,7 +2909,14 @@ async fn create_session_inner(
     };
 
     let validation_identity =
-        resolve_validation_identity(&state.config_runtime, &svc_req.model, create_provider).await;
+        match resolve_validation_identity(&state.config_runtime, &svc_req.model, create_provider)
+            .await
+        {
+            Ok(identity) => identity,
+            Err(err) => {
+                return RequestTerminal::RespondWithoutPublish(Err(ApiError::BadRequest(err)));
+            }
+        };
     if let Err(err) =
         validate_prompt_video_input(&state.config_runtime, &svc_req.prompt, &validation_identity)
             .await
@@ -3646,9 +3665,20 @@ async fn continue_session_inner(
             labels: None,
         };
         let create_provider = create_req.build.as_ref().and_then(|build| build.provider);
-        let validation_identity =
-            resolve_validation_identity(&state.config_runtime, &create_req.model, create_provider)
-                .await;
+        let validation_identity = match resolve_validation_identity(
+            &state.config_runtime,
+            &create_req.model,
+            create_provider,
+        )
+        .await
+        {
+            Ok(identity) => identity,
+            Err(err) => {
+                drop(caller_event_tx);
+                drain_event_forwarder(&session_id, forward_task).await;
+                return RequestTerminal::RespondWithoutPublish(Err(ApiError::BadRequest(err)));
+            }
+        };
         if let Err(err) = validate_prompt_video_input(
             &state.config_runtime,
             &create_req.prompt,
@@ -3797,7 +3827,16 @@ async fn continue_session_inner(
         }
 
         let fallback_identity =
-            resolve_validation_identity(&state.config_runtime, &state.default_model, None).await;
+            match resolve_validation_identity(&state.config_runtime, &state.default_model, None)
+                .await
+            {
+                Ok(identity) => identity,
+                Err(err) => {
+                    drop(caller_event_tx);
+                    drain_event_forwarder(&session_id, forward_task).await;
+                    return RequestTerminal::RespondWithoutPublish(Err(ApiError::BadRequest(err)));
+                }
+            };
         let current_identity = stored_metadata
             .as_ref()
             .map(meerkat::SessionMetadata::llm_identity)
@@ -4657,12 +4696,35 @@ mod tests {
         let config_runtime =
             meerkat_core::ConfigRuntime::new(store, temp.path().join("config_state.json"));
 
-        let identity = resolve_validation_identity(&config_runtime, "gemma-4-e2b", None).await;
+        let identity = resolve_validation_identity(&config_runtime, "gemma-4-e2b", None)
+            .await
+            .expect("self-hosted alias should resolve");
         assert_eq!(identity.provider, Provider::SelfHosted);
 
         validate_prompt_video_input(&config_runtime, &inline_video_prompt(), &identity)
             .await
             .expect("self-hosted aliases should validate inline video against the active registry");
+    }
+
+    #[tokio::test]
+    async fn validation_identity_rejects_explicit_provider_that_contradicts_catalog_owner() {
+        let temp = TempDir::new().unwrap();
+        let store: Arc<dyn meerkat_core::ConfigStore> =
+            Arc::new(MemoryConfigStore::new(Config::default()));
+        let config_runtime =
+            meerkat_core::ConfigRuntime::new(store, temp.path().join("config_state.json"));
+
+        let err =
+            resolve_validation_identity(&config_runtime, "gpt-5.4", Some(Provider::Anthropic))
+                .await
+                .expect_err("validation identity should fail closed for wrong-provider overrides");
+
+        assert!(
+            err.contains("registered for provider 'openai'")
+                && err.contains("not provider 'anthropic'")
+                && err.contains("gpt-5.4"),
+            "error should identify the rejected provider/model pair: {err}"
+        );
     }
 
     #[test]

--- a/meerkat-rpc/src/session_runtime.rs
+++ b/meerkat-rpc/src/session_runtime.rs
@@ -223,16 +223,7 @@ fn registered_model_provider_mismatch_reason(
     provider: meerkat_core::Provider,
     model: &str,
 ) -> Option<String> {
-    let registered_provider = registry.entry(model)?.provider;
-    if registered_provider == provider {
-        return None;
-    }
-
-    Some(format!(
-        "model '{model}' is registered for provider '{}', not provider '{}'; specify a matching provider with the model override",
-        registered_provider.as_str(),
-        provider.as_str()
-    ))
+    registry.provider_override_mismatch_reason(provider, model)
 }
 
 fn profile_to_capability_surface(
@@ -1287,6 +1278,15 @@ impl SessionRuntime {
         let registry = self.model_registry().await?;
         let model = build_config.model.clone();
         let provider = if let Some(provider) = build_config.provider {
+            if let Some(reason) =
+                registered_model_provider_mismatch_reason(&registry, provider, &model)
+            {
+                return Err(RpcError {
+                    code: error::INVALID_PARAMS,
+                    message: reason,
+                    data: None,
+                });
+            }
             provider
         } else {
             registry
@@ -6006,6 +6006,29 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn pending_build_rejects_explicit_provider_that_contradicts_catalog_owner() {
+        let temp = tempfile::tempdir().unwrap();
+        let runtime = make_runtime(temp_factory(&temp), 10);
+        let mut build_config = AgentBuildConfig::new("gpt-5.4");
+        build_config.provider = Some(meerkat_core::Provider::Anthropic);
+        build_config.llm_client_override = Some(Arc::new(MockLlmClient));
+
+        let err = runtime
+            .llm_identity_from_pending_build(&build_config)
+            .await
+            .expect_err("pending explicit provider must match catalog owner");
+
+        assert_eq!(err.code, error::INVALID_PARAMS);
+        assert!(
+            err.message.contains("registered for provider 'openai'")
+                && err.message.contains("not provider 'anthropic'")
+                && err.message.contains("gpt-5.4"),
+            "error should identify the rejected provider/model pair: {}",
+            err.message
+        );
+    }
+
+    #[tokio::test]
     async fn turn_model_override_without_provider_preserves_current_provider_for_owned_model() {
         let temp = tempfile::tempdir().unwrap();
         let runtime = make_runtime(temp_factory(&temp), 10);
@@ -6059,6 +6082,38 @@ mod tests {
         assert!(
             err.message.contains("openai")
                 && err.message.contains("anthropic")
+                && err.message.contains("gpt-5.4"),
+            "error should identify the rejected provider/model pair: {}",
+            err.message
+        );
+    }
+
+    #[tokio::test]
+    async fn turn_explicit_provider_model_override_rejects_catalog_owner_mismatch() {
+        let temp = tempfile::tempdir().unwrap();
+        let runtime = make_runtime(temp_factory(&temp), 10);
+        let current = SessionLlmIdentity {
+            model: "claude-sonnet-4-5".to_string(),
+            provider: meerkat_core::Provider::Anthropic,
+            self_hosted_server_id: None,
+            provider_params: None,
+            connection_ref: None,
+        };
+        let overrides = crate::handlers::turn::TurnOverrides {
+            model: Some("gpt-5.4".to_string()),
+            provider: Some("anthropic".to_string()),
+            ..Default::default()
+        };
+
+        let err = runtime
+            .resolve_target_llm_identity(&current, &overrides)
+            .await
+            .expect_err("explicit turn provider must match catalog owner");
+
+        assert_eq!(err.code, error::INVALID_PARAMS);
+        assert!(
+            err.message.contains("registered for provider 'openai'")
+                && err.message.contains("not provider 'anthropic'")
                 && err.message.contains("gpt-5.4"),
             "error should identify the rejected provider/model pair: {}",
             err.message

--- a/meerkat/src/factory.rs
+++ b/meerkat/src/factory.rs
@@ -1841,6 +1841,12 @@ impl AgentFactory {
         build_config: &AgentBuildConfig,
     ) -> Result<(Provider, Option<String>), BuildAgentError> {
         if let Some(provider) = build_config.provider {
+            if let Some(reason) =
+                registry.provider_override_mismatch_reason(provider, &build_config.model)
+            {
+                return Err(BuildAgentError::Config(reason));
+            }
+
             return match provider {
                 Provider::SelfHosted => {
                     let entry = registry
@@ -3575,6 +3581,62 @@ mod tests {
             None,
             "provider-aware default lookup must not reuse OpenAI defaults for Anthropic"
         );
+    }
+
+    #[test]
+    fn default_provider_resolution_uses_catalog_owner_without_explicit_override() {
+        let temp = tempfile::tempdir().unwrap();
+        let factory = AgentFactory::new(temp.path().join("sessions"));
+        let registry = factory
+            .model_registry(&Config::default())
+            .expect("registry");
+        let build = AgentBuildConfig::new("gpt-5.4");
+
+        let (provider, server_id) = factory
+            .resolve_provider_from_registry(&registry, &build)
+            .expect("catalog model should infer provider");
+
+        assert_eq!(provider, Provider::OpenAI);
+        assert_eq!(server_id, None);
+    }
+
+    #[test]
+    fn explicit_provider_override_rejects_catalog_owner_contradiction() {
+        let temp = tempfile::tempdir().unwrap();
+        let factory = AgentFactory::new(temp.path().join("sessions"));
+        let registry = factory
+            .model_registry(&Config::default())
+            .expect("registry");
+        let mut build = AgentBuildConfig::new("gpt-5.4");
+        build.provider = Some(Provider::Anthropic);
+
+        let err = factory
+            .resolve_provider_from_registry(&registry, &build)
+            .expect_err("explicit provider must match catalog ownership");
+        assert!(
+            err.to_string().contains("registered for provider 'openai'")
+                && err.to_string().contains("not provider 'anthropic'")
+                && err.to_string().contains("gpt-5.4"),
+            "error should identify the rejected provider/model pair: {err}"
+        );
+    }
+
+    #[test]
+    fn explicit_provider_override_allows_uncatalogued_model_without_catalog_owner() {
+        let temp = tempfile::tempdir().unwrap();
+        let factory = AgentFactory::new(temp.path().join("sessions"));
+        let registry = factory
+            .model_registry(&Config::default())
+            .expect("registry");
+        let mut build = AgentBuildConfig::new("custom-openai-compatible");
+        build.provider = Some(Provider::OpenAI);
+
+        let (provider, server_id) = factory
+            .resolve_provider_from_registry(&registry, &build)
+            .expect("uncatalogued explicit provider has no catalog owner to contradict");
+
+        assert_eq!(provider, Provider::OpenAI);
+        assert_eq!(server_id, None);
     }
 
     #[test]

--- a/meerkat/tests/factory_build_agent.rs
+++ b/meerkat/tests/factory_build_agent.rs
@@ -846,6 +846,7 @@ async fn build_agent_with_resume_preserves_explicit_override_masked_fields() {
         peer_meta: Some(meerkat_core::PeerMeta::default().with_label("role", "explicit")),
         ..AgentBuildConfig::new("gpt-5.4")
     };
+    build_config.resume_override_mask.model = true;
     build_config.resume_override_mask.provider = true;
     build_config.resume_override_mask.max_tokens = true;
     build_config.resume_override_mask.provider_params = true;
@@ -859,7 +860,7 @@ async fn build_agent_with_resume_preserves_explicit_override_masked_fields() {
         .session_metadata()
         .expect("session should have metadata");
 
-    assert_eq!(metadata.model, "claude-sonnet-4-5");
+    assert_eq!(metadata.model, "gpt-5.4");
     assert_eq!(metadata.provider, Provider::OpenAI);
     assert_eq!(metadata.max_tokens, 1024);
     assert_eq!(


### PR DESCRIPTION
## Summary
- add a shared model-registry provider ownership guard for explicit provider overrides
- reject catalog/provider contradictions in factory, RPC pending/turn resolution, REST validation identity, and CLI provider resolution
- add focused regression coverage for default inference, explicit mismatch failures, validation errors, and turn override behavior

## Validation
- ./scripts/repo-cargo test -p meerkat-core provider_override_mismatch_reason_reports_catalog_owner_contradictions
- ./scripts/repo-cargo test -p meerkat explicit_provider_override
- ./scripts/repo-cargo test -p meerkat-rpc catalog_owner
- ./scripts/repo-cargo test -p meerkat-rest validation_identity
- ./scripts/repo-cargo test -p rkat test_resolve_cli_provider_rejects_explicit_provider_contradicting_catalog_owner
- make fmt-check
- make check

Linear: LUC-133