### PR TITLE
LUC-156 Preserve typed bridge cleanup causes

### DIFF
--- a/meerkat-mob/src/error.rs
+++ b/meerkat-mob/src/error.rs
@@ -5,6 +5,7 @@ use crate::runtime::MobState;
 use crate::store::FrameAtomicOperation;
 use crate::validate::Diagnostic;
 use crate::{MobId, RunId, StepId};
+use meerkat_contracts::wire::supervisor_bridge::{BridgeRejectionCause, BridgeRejectionReply};
 
 /// Errors returned by mob operations.
 #[derive(Debug, thiserror::Error)]
@@ -40,6 +41,13 @@ pub enum MobError {
     /// A wiring operation failed.
     #[error("wiring error: {0}")]
     WiringError(String),
+
+    /// A supervisor bridge command was rejected by the remote member.
+    #[error("bridge command rejected ({cause:?}): {reason}")]
+    BridgeCommandRejected {
+        cause: BridgeRejectionCause,
+        reason: String,
+    },
 
     /// The member failed to restore durable session state and is broken until repaired.
     #[error(
@@ -232,6 +240,26 @@ impl From<crate::store::MobStoreError> for MobError {
     }
 }
 
+impl From<BridgeRejectionReply> for MobError {
+    fn from(rejection: BridgeRejectionReply) -> Self {
+        let cause = rejection.typed_cause();
+        let reason = rejection.reason().to_string();
+        match cause {
+            Some(cause) => Self::BridgeCommandRejected { cause, reason },
+            None => Self::WiringError(reason),
+        }
+    }
+}
+
+impl MobError {
+    pub fn bridge_rejection_cause(&self) -> Option<BridgeRejectionCause> {
+        match self {
+            Self::BridgeCommandRejected { cause, .. } => Some(*cause),
+            _ => None,
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -342,6 +370,10 @@ mod tests {
                 to: MobState::Running,
             },
             MobError::WiringError("w".to_string()),
+            MobError::BridgeCommandRejected {
+                cause: BridgeRejectionCause::NotBound,
+                reason: "bind required".to_string(),
+            },
             MobError::MemberRestoreFailed {
                 member_id: MeerkatId::from("m"),
                 session_id: Some(meerkat_core::types::SessionId::new()),

--- a/meerkat-mob/src/runtime/actor.rs
+++ b/meerkat-mob/src/runtime/actor.rs
@@ -279,6 +279,19 @@ struct RemoteDestroyOutcome {
     errors: Vec<String>,
 }
 
+#[cfg(not(target_arch = "wasm32"))]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum ExpectedRevokeCleanupFailure {
+    CommsPeerNotFound,
+    CommsPeerOffline,
+    CommsAdmissionDropped {
+        reason: meerkat_core::comms::AdmissionDropReason,
+    },
+    BridgeRejected {
+        cause: super::bridge_protocol::BridgeRejectionCause,
+    },
+}
+
 // ---------------------------------------------------------------------------
 // MobActor
 // ---------------------------------------------------------------------------
@@ -806,6 +819,20 @@ impl MobActor {
         super::bridge_protocol::decode_bridge_rejection_reply(protocol_version, value)
     }
 
+    fn bridge_rejection_error(rejection: super::bridge_protocol::BridgeRejectionReply) -> MobError {
+        MobError::from(rejection)
+    }
+
+    fn bridge_rejection_error_with_reason(
+        rejection: &super::bridge_protocol::BridgeRejectionReply,
+        reason: String,
+    ) -> MobError {
+        match rejection.typed_cause() {
+            Some(cause) => MobError::BridgeCommandRejected { cause, reason },
+            None => MobError::WiringError(reason),
+        }
+    }
+
     async fn persist_rebound_binding(
         &self,
         prior_binding: &crate::RuntimeBinding,
@@ -892,7 +919,7 @@ impl MobActor {
                     "ensure_supervisor_authorized rebound peer",
                 );
             }
-            return Err(MobError::WiringError(rejection.reason().to_string()));
+            return Err(Self::bridge_rejection_error(rejection));
         }
         let _ack: super::bridge_protocol::BridgeAck =
             serde_json::from_value(value).map_err(|error| {
@@ -915,7 +942,7 @@ impl MobActor {
             .send_bridge_command(peer, command, timeout)
             .await?;
         if let Some(rejection) = Self::bridge_rejection_reply(command.protocol_version(), &value) {
-            return Err(MobError::WiringError(rejection.reason().to_string()));
+            return Err(Self::bridge_rejection_error(rejection));
         }
         serde_json::from_value(value).map_err(|error| {
             MobError::Internal(format!("failed to decode bridge command response: {error}"))
@@ -7997,6 +8024,36 @@ impl MobActor {
     }
 
     #[cfg(not(target_arch = "wasm32"))]
+    fn expected_revoke_cleanup_failure(error: &MobError) -> Option<ExpectedRevokeCleanupFailure> {
+        match error {
+            MobError::CommsError(meerkat_core::comms::SendError::PeerNotFound(_)) => {
+                Some(ExpectedRevokeCleanupFailure::CommsPeerNotFound)
+            }
+            MobError::CommsError(meerkat_core::comms::SendError::PeerOffline) => {
+                Some(ExpectedRevokeCleanupFailure::CommsPeerOffline)
+            }
+            MobError::CommsError(meerkat_core::comms::SendError::AdmissionDropped { reason }) => {
+                match reason {
+                    meerkat_core::comms::AdmissionDropReason::UntrustedSender
+                    | meerkat_core::comms::AdmissionDropReason::SessionClosed => {
+                        Some(ExpectedRevokeCleanupFailure::CommsAdmissionDropped {
+                            reason: *reason,
+                        })
+                    }
+                    _ => None,
+                }
+            }
+            MobError::BridgeCommandRejected {
+                cause: super::bridge_protocol::BridgeRejectionCause::NotBound,
+                ..
+            } => Some(ExpectedRevokeCleanupFailure::BridgeRejected {
+                cause: super::bridge_protocol::BridgeRejectionCause::NotBound,
+            }),
+            _ => None,
+        }
+    }
+
+    #[cfg(not(target_arch = "wasm32"))]
     async fn destroy_remote_member_for_destroy(
         &mut self,
         entry: RosterEntry,
@@ -8080,18 +8137,17 @@ impl MobActor {
             .revoke_supervisor_for_binding(&binding, std::time::Duration::from_secs(5))
             .await
         {
-            let error_text = error.to_string().to_ascii_lowercase();
             let expected_after_destroy = remote_cleanup_complete
-                && (error_text.contains("peer not found")
-                    || error_text.contains("peer offline")
-                    || error_text.contains("no authorized supervisor registered"));
-            if expected_after_destroy {
+                .then(|| Self::expected_revoke_cleanup_failure(&error))
+                .flatten();
+            if let Some(cause) = expected_after_destroy {
                 let peer_id = match &binding {
                     crate::RuntimeBinding::External { peer_id, .. } => peer_id.as_str(),
                     crate::RuntimeBinding::Session => "session",
                 };
                 tracing::debug!(
                     peer_id = %peer_id,
+                    ?cause,
                     error = %error,
                     "destroy cleanup: supervisor revoke failed after terminal remote cleanup"
                 );
@@ -8397,7 +8453,6 @@ impl MobActor {
                         if let Some(rejection) =
                             Self::bridge_rejection_reply(next_payload.protocol_version, &value)
                         {
-                            let rejection_reason = rejection.reason().to_string();
                             if let Some(cause) = rejection.typed_cause()
                                 && super::bridge_fallback::should_fall_back_to_bind(cause)
                             {
@@ -8434,12 +8489,18 @@ impl MobActor {
                                         )?;
                                         None
                                     }
-                                    Err(bind_error) => Some(MobError::WiringError(format!(
-                                        "{rejection_reason}; bind fallback failed: {bind_error}"
-                                    ))),
+                                    Err(bind_error) => {
+                                        let reason = format!(
+                                            "{}; bind fallback failed: {bind_error}",
+                                            rejection.reason()
+                                        );
+                                        Some(Self::bridge_rejection_error_with_reason(
+                                            &rejection, reason,
+                                        ))
+                                    }
                                 }
                             } else {
-                                Some(MobError::WiringError(rejection_reason))
+                                Some(Self::bridge_rejection_error(rejection))
                             }
                         } else if let Err(error) =
                             serde_json::from_value::<super::bridge_protocol::BridgeAck>(value)
@@ -10639,11 +10700,38 @@ impl MobActor {
 #[cfg(test)]
 #[allow(clippy::expect_used)]
 mod bridge_rejection_tests {
-    use super::MobActor;
+    use super::{ExpectedRevokeCleanupFailure, MobActor};
+    use crate::MobError;
     use crate::runtime::bridge_protocol::{
         BridgeRejectionCause, SUPERVISOR_BRIDGE_PROTOCOL_VERSION,
     };
+    use meerkat_core::comms::{AdmissionDropReason, SendError};
     use serde_json::json;
+
+    fn known_bridge_rejection_causes() -> &'static [(BridgeRejectionCause, &'static str)] {
+        &[
+            (BridgeRejectionCause::NotBound, "not_bound"),
+            (BridgeRejectionCause::StaleSupervisor, "stale_supervisor"),
+            (BridgeRejectionCause::SenderMismatch, "sender_mismatch"),
+            (BridgeRejectionCause::AlreadyBound, "already_bound"),
+            (
+                BridgeRejectionCause::InvalidBootstrapToken,
+                "invalid_bootstrap_token",
+            ),
+            (
+                BridgeRejectionCause::UnsupportedProtocolVersion,
+                "unsupported_protocol_version",
+            ),
+            (
+                BridgeRejectionCause::InvalidSupervisorSpec,
+                "invalid_supervisor_spec",
+            ),
+            (BridgeRejectionCause::InvalidPeerSpec, "invalid_peer_spec"),
+            (BridgeRejectionCause::AddressMismatch, "address_mismatch"),
+            (BridgeRejectionCause::Unsupported, "unsupported"),
+            (BridgeRejectionCause::Internal, "internal"),
+        ]
+    }
 
     #[test]
     fn actor_decodes_typed_protocol_v2_bridge_rejection() {
@@ -10675,5 +10763,137 @@ mod bridge_rejection_tests {
             .expect("legacy raw string should decode only on protocol v1");
         assert_eq!(legacy.typed_cause(), None);
         assert!(legacy.is_legacy_v1_raw_string());
+    }
+
+    #[test]
+    fn actor_bridge_rejection_error_preserves_each_known_typed_cause() {
+        for (cause, wire_name) in known_bridge_rejection_causes() {
+            let reason = format!("typed bridge rejection: {wire_name}");
+            let value = json!({
+                "result": "rejected",
+                "cause": wire_name,
+                "reason": reason,
+            });
+            let rejection =
+                MobActor::bridge_rejection_reply(SUPERVISOR_BRIDGE_PROTOCOL_VERSION, &value)
+                    .expect("typed rejection should decode");
+
+            let error = MobActor::bridge_rejection_error(rejection);
+
+            match error {
+                MobError::BridgeCommandRejected {
+                    cause: actual,
+                    reason: actual_reason,
+                } => {
+                    assert_eq!(actual, *cause);
+                    assert_eq!(actual_reason, reason);
+                }
+                other => panic!("expected typed bridge rejection error, got {other:?}"),
+            }
+        }
+    }
+
+    #[test]
+    fn actor_legacy_bridge_rejection_error_stays_untyped() {
+        let value = json!("legacy rejection");
+        let legacy = MobActor::bridge_rejection_reply(1, &value)
+            .expect("legacy raw string should decode only on protocol v1");
+
+        let error = MobActor::bridge_rejection_error(legacy);
+
+        assert!(matches!(
+            error,
+            MobError::WiringError(reason) if reason == "legacy rejection"
+        ));
+    }
+
+    #[test]
+    fn revoke_cleanup_expected_failures_are_typed() {
+        let cases = [
+            (
+                MobError::CommsError(SendError::PeerNotFound("peer-1".to_string())),
+                ExpectedRevokeCleanupFailure::CommsPeerNotFound,
+            ),
+            (
+                MobError::CommsError(SendError::PeerOffline),
+                ExpectedRevokeCleanupFailure::CommsPeerOffline,
+            ),
+            (
+                MobError::CommsError(SendError::AdmissionDropped {
+                    reason: AdmissionDropReason::UntrustedSender,
+                }),
+                ExpectedRevokeCleanupFailure::CommsAdmissionDropped {
+                    reason: AdmissionDropReason::UntrustedSender,
+                },
+            ),
+            (
+                MobError::CommsError(SendError::AdmissionDropped {
+                    reason: AdmissionDropReason::SessionClosed,
+                }),
+                ExpectedRevokeCleanupFailure::CommsAdmissionDropped {
+                    reason: AdmissionDropReason::SessionClosed,
+                },
+            ),
+            (
+                MobError::BridgeCommandRejected {
+                    cause: BridgeRejectionCause::NotBound,
+                    reason: "no authorized supervisor registered".to_string(),
+                },
+                ExpectedRevokeCleanupFailure::BridgeRejected {
+                    cause: BridgeRejectionCause::NotBound,
+                },
+            ),
+        ];
+
+        for (error, expected) in cases {
+            assert_eq!(
+                MobActor::expected_revoke_cleanup_failure(&error),
+                Some(expected)
+            );
+        }
+    }
+
+    #[test]
+    fn revoke_cleanup_does_not_treat_error_text_as_a_semantic_cause() {
+        let cases = [
+            MobError::WiringError("peer offline".to_string()),
+            MobError::Internal("no authorized supervisor registered".to_string()),
+            MobError::CommsError(SendError::Validation("peer not found".to_string())),
+            MobError::CommsError(SendError::AdmissionDropped {
+                reason: AdmissionDropReason::InboxFull,
+            }),
+            MobError::BridgeCommandRejected {
+                cause: BridgeRejectionCause::SenderMismatch,
+                reason: "no authorized supervisor registered".to_string(),
+            },
+        ];
+
+        for error in cases {
+            assert_eq!(MobActor::expected_revoke_cleanup_failure(&error), None);
+        }
+    }
+
+    #[test]
+    fn revoke_cleanup_expected_failure_ratchet_rejects_string_parsing() {
+        let source = include_str!("actor.rs");
+        let start = source
+            .find("fn expected_revoke_cleanup_failure")
+            .expect("expected cleanup classifier exists");
+        let end = source[start..]
+            .find("\n    async fn destroy_remote_member_for_destroy")
+            .expect("cleanup classifier precedes remote destroy cleanup");
+        let body = &source[start..start + end];
+
+        for disallowed in [
+            "to_ascii_lowercase",
+            "to_lowercase",
+            "error.to_string()",
+            ".contains(",
+        ] {
+            assert!(
+                !body.contains(disallowed),
+                "expected revoke cleanup classifier must not parse error text with {disallowed}"
+            );
+        }
     }
 }

--- a/meerkat-mob/src/runtime/provisioner.rs
+++ b/meerkat-mob/src/runtime/provisioner.rs
@@ -1459,6 +1459,10 @@ impl MultiBackendProvisioner {
         super::bridge_protocol::decode_bridge_rejection_reply(protocol_version, value)
     }
 
+    fn bridge_rejection_error(rejection: super::bridge_protocol::BridgeRejectionReply) -> MobError {
+        MobError::from(rejection)
+    }
+
     async fn ensure_supervisor_authorized(
         &self,
         peer: &TrustedPeerDescriptor,
@@ -1490,7 +1494,7 @@ impl MultiBackendProvisioner {
                 .await?;
                 return Self::peer_only_spec_from_parts(&bind.peer_id, &bind.address);
             }
-            return Err(MobError::WiringError(rejection.reason().to_string()));
+            return Err(Self::bridge_rejection_error(rejection));
         }
         Ok(peer.clone())
     }
@@ -1507,7 +1511,7 @@ impl MultiBackendProvisioner {
             .send_bridge_command(peer, command, timeout)
             .await?;
         if let Some(rejection) = Self::bridge_rejection_reply(command.protocol_version(), &value) {
-            return Err(MobError::WiringError(rejection.reason().to_string()));
+            return Err(Self::bridge_rejection_error(rejection));
         }
         serde_json::from_value(value).map_err(|error| {
             MobError::Internal(format!("failed to decode bridge command response: {error}"))
@@ -1752,10 +1756,8 @@ impl MobProvisioner for MultiBackendProvisioner {
                     .await?;
                 let payload = self.bridge_supervisor_payload().await?;
                 let command = super::bridge_protocol::BridgeCommand::RetireMember(payload);
-                self.supervisor_bridge.trust_recipient(&peer).await?;
-                let _ = self
-                    .supervisor_bridge
-                    .send_bridge_command(&peer, &command, Duration::from_secs(10))
+                let _retire: super::bridge_protocol::BridgeRetireResponse = self
+                    .send_bridge_command_typed(&peer, &command, Duration::from_secs(10))
                     .await?;
                 self.session
                     .ops_adapter
@@ -1790,10 +1792,8 @@ impl MobProvisioner for MultiBackendProvisioner {
                     .await?;
                 let payload = self.bridge_supervisor_payload().await?;
                 let command = super::bridge_protocol::BridgeCommand::InterruptMember(payload);
-                self.supervisor_bridge.trust_recipient(&peer).await?;
-                let _ = self
-                    .supervisor_bridge
-                    .send_bridge_command(&peer, &command, Duration::from_secs(5))
+                let _ack: super::bridge_protocol::BridgeAck = self
+                    .send_bridge_command_typed(&peer, &command, Duration::from_secs(5))
                     .await?;
                 Ok(())
             }
@@ -2058,10 +2058,36 @@ impl MobProvisioner for MultiBackendProvisioner {
 #[allow(clippy::expect_used)]
 mod bridge_rejection_tests {
     use super::MultiBackendProvisioner;
+    use crate::MobError;
     use crate::runtime::bridge_protocol::{
         BridgeRejectionCause, SUPERVISOR_BRIDGE_PROTOCOL_VERSION,
     };
     use serde_json::json;
+
+    fn known_bridge_rejection_causes() -> &'static [(BridgeRejectionCause, &'static str)] {
+        &[
+            (BridgeRejectionCause::NotBound, "not_bound"),
+            (BridgeRejectionCause::StaleSupervisor, "stale_supervisor"),
+            (BridgeRejectionCause::SenderMismatch, "sender_mismatch"),
+            (BridgeRejectionCause::AlreadyBound, "already_bound"),
+            (
+                BridgeRejectionCause::InvalidBootstrapToken,
+                "invalid_bootstrap_token",
+            ),
+            (
+                BridgeRejectionCause::UnsupportedProtocolVersion,
+                "unsupported_protocol_version",
+            ),
+            (
+                BridgeRejectionCause::InvalidSupervisorSpec,
+                "invalid_supervisor_spec",
+            ),
+            (BridgeRejectionCause::InvalidPeerSpec, "invalid_peer_spec"),
+            (BridgeRejectionCause::AddressMismatch, "address_mismatch"),
+            (BridgeRejectionCause::Unsupported, "unsupported"),
+            (BridgeRejectionCause::Internal, "internal"),
+        ]
+    }
 
     #[test]
     fn provisioner_decodes_typed_protocol_v2_bridge_rejection() {
@@ -2099,5 +2125,49 @@ mod bridge_rejection_tests {
             .expect("legacy raw string should decode only on protocol v1");
         assert_eq!(legacy.typed_cause(), None);
         assert!(legacy.is_legacy_v1_raw_string());
+    }
+
+    #[test]
+    fn provisioner_bridge_rejection_error_preserves_each_known_typed_cause() {
+        for (cause, wire_name) in known_bridge_rejection_causes() {
+            let reason = format!("typed bridge rejection: {wire_name}");
+            let value = json!({
+                "result": "rejected",
+                "cause": wire_name,
+                "reason": reason,
+            });
+            let rejection = MultiBackendProvisioner::bridge_rejection_reply(
+                SUPERVISOR_BRIDGE_PROTOCOL_VERSION,
+                &value,
+            )
+            .expect("typed rejection should decode");
+
+            let error = MultiBackendProvisioner::bridge_rejection_error(rejection);
+
+            match error {
+                MobError::BridgeCommandRejected {
+                    cause: actual,
+                    reason: actual_reason,
+                } => {
+                    assert_eq!(actual, *cause);
+                    assert_eq!(actual_reason, reason);
+                }
+                other => panic!("expected typed bridge rejection error, got {other:?}"),
+            }
+        }
+    }
+
+    #[test]
+    fn provisioner_legacy_bridge_rejection_error_stays_untyped() {
+        let value = json!("legacy rejection");
+        let legacy = MultiBackendProvisioner::bridge_rejection_reply(1, &value)
+            .expect("legacy raw string should decode only on protocol v1");
+
+        let error = MultiBackendProvisioner::bridge_rejection_error(legacy);
+
+        assert!(matches!(
+            error,
+            MobError::WiringError(reason) if reason == "legacy rejection"
+        ));
     }
 }

--- a/meerkat-mob/src/runtime/tests.rs
+++ b/meerkat-mob/src/runtime/tests.rs
@@ -25005,6 +25005,9 @@ fn summarize_mob_runtime_error(error: &MobError) -> String {
             format!("invalid_transition:{}->{}", from.as_str(), to.as_str())
         }
         MobError::WiringError(_) => "wiring_error".to_string(),
+        MobError::BridgeCommandRejected { cause, .. } => {
+            format!("bridge_command_rejected:{cause:?}")
+        }
         MobError::MemberRestoreFailed { .. } => "member_restore_failed".to_string(),
         MobError::KickoffWaitTimedOut { .. } => "kickoff_wait_timed_out".to_string(),
         MobError::ReadyWaitTimedOut { .. } => "ready_wait_timed_out".to_string(),


### PR DESCRIPTION
## Summary
- add typed MobError bridge command rejection causes and use them in actor/provisioner bridge send paths
- classify revoke cleanup expected failures from typed bridge/comms causes instead of error text
- add focused tests and a ratchet against cleanup string parsing

## Validation
- ./scripts/repo-cargo test -p meerkat-mob bridge_rejection_tests --lib
- make check

Linear: LUC-156