### PR TITLE
LUC-152 Type peer ingress snapshot diagnostics

### DIFF
--- a/docs/architecture/rebuild-trigger-audit.md
+++ b/docs/architecture/rebuild-trigger-audit.md
@@ -30,7 +30,7 @@ it further):
   added here rather than in a follow-up audit.
 - Field-name patterns `_cache`, `_snapshot`, `_shadow`, `_mirror`,
   `_projection`. The surviving hits beyond fields 1–12 are covered in
-  fields 13–15; other hits (`trusted_snapshot` on queue entries,
+  fields 13–15; other hits (`admission_diagnostic` on queue entries,
   `session_snapshot` in run-ledger records, `config_snapshot` on
   `FactoryAgentBuilder`) were examined and are frozen-point-in-time
   captures or fallback defaults, not live projections — noted here so

--- a/meerkat-comms/src/classify.rs
+++ b/meerkat-comms/src/classify.rs
@@ -7,8 +7,8 @@ use crate::peer_types::ContentShape as PeerContentShape;
 use crate::trust::TrustedPeers;
 use crate::types::{InboxItem, MessageKind};
 use meerkat_core::{
-    PeerIngressAuthDecision, PeerIngressKind, PeerIngressMachinePolicy, PeerInputClass,
-    handles::PeerCommsHandle,
+    InteractionId, PeerIngressAuthDecision, PeerIngressKind, PeerIngressMachinePolicy,
+    PeerInputClass, handles::PeerCommsHandle,
 };
 use std::sync::Arc;
 use uuid::Uuid;
@@ -44,7 +44,7 @@ pub(crate) struct ClassificationResult {
 /// inbox queue can enqueue entries with full correlation context.
 pub(crate) struct PreparedIngressItem {
     pub(crate) item: InboxItem,
-    pub(crate) raw_item_id: String,
+    pub(crate) raw_item_id: InteractionId,
     pub(crate) kind: PeerIngressKind,
     pub(crate) class: PeerInputClass,
     pub(crate) auth: PeerIngressAuthDecision,
@@ -55,7 +55,7 @@ pub(crate) struct PreparedIngressItem {
     pub(crate) text_projection: String,
     #[allow(dead_code)]
     pub(crate) content_shape: PeerContentShape,
-    pub(crate) request_id: Option<String>,
+    pub(crate) request_id: Option<InteractionId>,
 }
 
 fn content_shape_for_text_and_blocks(
@@ -147,7 +147,7 @@ impl IngressClassificationContext {
                         (
                             classification,
                             lifecycle_peer,
-                            Some(envelope.id.to_string()),
+                            Some(InteractionId(envelope.id)),
                         )
                     }
                     MessageKind::Lifecycle { kind, params } => {
@@ -162,12 +162,12 @@ impl IngressClassificationContext {
                     } => (
                         self.ingress_policy.classify_response((*status).into()),
                         None,
-                        Some(in_reply_to.to_string()),
+                        Some(InteractionId(*in_reply_to)),
                     ),
                     MessageKind::Ack { in_reply_to } => (
                         self.ingress_policy.classify_ack(),
                         None,
-                        Some(in_reply_to.to_string()),
+                        Some(InteractionId(*in_reply_to)),
                     ),
                 };
 
@@ -211,7 +211,7 @@ impl IngressClassificationContext {
                 };
 
                 Some(PreparedIngressItem {
-                    raw_item_id: envelope.id.to_string(),
+                    raw_item_id: InteractionId(envelope.id),
                     kind: classification.kind,
                     class: classification.class,
                     auth: classification.auth,
@@ -244,7 +244,7 @@ impl IngressClassificationContext {
                 let content_shape = content_shape_for_text_and_blocks(&body, blocks.as_deref());
                 let classification = self.ingress_policy.classify_plain_event();
                 Some(PreparedIngressItem {
-                    raw_item_id: interaction_id.to_string(),
+                    raw_item_id: InteractionId(interaction_id),
                     kind: classification.kind,
                     class: classification.class,
                     auth: classification.auth,
@@ -757,7 +757,8 @@ mod tests {
             .expect("machine accepted request should prepare");
 
         assert_eq!(prepared.class, PeerInputClass::ActionableRequest);
-        assert_eq!(prepared.request_id.as_deref(), Some(request_id.as_str()));
+        let prepared_request_id = prepared.request_id.map(|id| id.to_string());
+        assert_eq!(prepared_request_id.as_deref(), Some(request_id.as_str()));
         assert!(prepared.text_projection.starts_with(&format!(
             "[COMMS REQUEST from sender-agent (id: {request_id})]\nIntent: review"
         )));
@@ -883,7 +884,7 @@ mod tests {
         assert_eq!(prepared.class, PeerInputClass::PlainEvent);
         assert_eq!(prepared.kind, PeerIngressKind::PlainEvent);
         assert!(
-            Uuid::parse_str(&prepared.raw_item_id).is_ok(),
+            Uuid::parse_str(&prepared.raw_item_id.to_string()).is_ok(),
             "plain events should receive a stable generated ingress id"
         );
         assert_eq!(
@@ -894,7 +895,7 @@ mod tests {
         match prepared.item {
             InboxItem::PlainEvent { interaction_id, .. } => {
                 assert_eq!(
-                    interaction_id.map(|id| id.to_string()),
+                    interaction_id.map(meerkat_core::InteractionId),
                     Some(prepared.raw_item_id)
                 );
             }

--- a/meerkat-comms/src/inbox.rs
+++ b/meerkat-comms/src/inbox.rs
@@ -19,7 +19,8 @@ use crate::peer_types::PeerIngressState;
 use crate::trust::TrustedPeers;
 use crate::types::{Envelope, InboxItem, MessageKind};
 use meerkat_core::{
-    InteractionId, PeerIngressAuthDecision, PeerIngressEntrySnapshot, PeerIngressKind,
+    InteractionId, PeerIngressAdmissionDiagnostic, PeerIngressAuthDecision,
+    PeerIngressDiagnosticDisplay, PeerIngressEntrySnapshot, PeerIngressKind,
     PeerIngressMachinePolicy, PeerIngressQueueSnapshot, PeerInputClass,
 };
 
@@ -91,25 +92,25 @@ impl From<DropReason> for meerkat_core::comms::AdmissionDropReason {
 /// A classified inbox entry, pairing an item with its ingress classification.
 #[derive(Debug)]
 pub(crate) struct ClassifiedInboxEntry {
-    pub(crate) raw_item_id: String,
+    pub(crate) raw_item_id: InteractionId,
     pub(crate) item: InboxItem,
     pub(crate) class: PeerInputClass,
     pub(crate) auth: PeerIngressAuthDecision,
     pub(crate) kind: PeerIngressKind,
     pub(crate) from_peer: Option<String>,
     pub(crate) lifecycle_peer: Option<String>,
-    pub(crate) request_id: Option<String>,
-    pub(crate) trusted_snapshot: Option<bool>,
+    pub(crate) request_id: Option<InteractionId>,
+    pub(crate) admission_diagnostic: Option<PeerIngressAdmissionDiagnostic>,
     pub(crate) text_projection: String,
 }
 
-/// Internal admission decision paired with the peer-trust snapshot that the
+/// Internal admission decision paired with the peer-trust diagnostic that the
 /// enqueue site still needs to stamp on the entry. `AdmissionOutcome` is the
-/// public face; `trusted_snapshot` stays crate-internal.
+/// public face; the trust copy is diagnostic and never a live trust oracle.
 #[derive(Debug, Clone, Copy)]
 pub(crate) struct AdmissionDecision {
     pub(crate) outcome: AdmissionOutcome,
-    pub(crate) trusted_snapshot: Option<bool>,
+    pub(crate) admission_diagnostic: Option<PeerIngressAdmissionDiagnostic>,
 }
 
 #[derive(Debug)]
@@ -152,11 +153,11 @@ impl ClassifiedInboxQueue {
     /// Admit a prepared item into the peer-ingress lifecycle.
     ///
     /// Returns a typed `AdmissionDecision`:
-    /// - Plain events are always admitted, with no trust snapshot.
+    /// - Plain events are always admitted, with no trust diagnostic.
     /// - External envelopes consult the canonical trust set
     ///   (`Arc<RwLock<TrustedPeers>>` shared with the router) plus the
     ///   auth-required policy. Untrusted senders with auth required are
-    ///   `Dropped { reason: UntrustedSender }`; the trust snapshot still
+    ///   `Dropped { reason: UntrustedSender }`; the trust diagnostic still
     ///   records the decision for queue visibility.
     ///
     /// C-H3 — the trust check is re-read from the canonical
@@ -165,7 +166,7 @@ impl ClassifiedInboxQueue {
     /// computed at classification time (T0); a trust revoke between T0
     /// and this admission point (T2) must be observed, and it is — a
     /// revoked sender is dropped here even when the classification
-    /// snapshot said trusted. The prepared bool is retained for
+    /// observation said trusted. The prepared bool is retained for
     /// diagnostics only (TOCTOU observability).
     ///
     /// Auth-exempt items (bridge bootstrap / idempotency-ack) bypass the
@@ -183,7 +184,7 @@ impl ClassifiedInboxQueue {
         let InboxItem::External { envelope } = &prepared.item else {
             return AdmissionDecision {
                 outcome: AdmissionOutcome::Admitted,
-                trusted_snapshot: None,
+                admission_diagnostic: None,
             };
         };
         // Authoritative trust check at admission time. The read lock on
@@ -193,7 +194,7 @@ impl ClassifiedInboxQueue {
         let trusted = self.trusted_peers.read().is_trusted(&envelope.from);
         // Auth-exempt items always admit; otherwise admission is gated by
         // the authoritative trust read against the require_peer_auth
-        // policy. The prepared classification snapshot is NOT consulted
+        // policy. The prepared classification observation is NOT consulted
         // here — only the admission-time read is authoritative.
         let admitted = prepared.auth.is_exempt() || trusted || !self.auth_required;
         let had_queued_work = !self.entries.is_empty();
@@ -202,7 +203,7 @@ impl ClassifiedInboxQueue {
             self.phase = PeerIngressState::Received;
             AdmissionDecision {
                 outcome: AdmissionOutcome::Admitted,
-                trusted_snapshot: Some(trusted),
+                admission_diagnostic: Some(PeerIngressAdmissionDiagnostic::from_trusted(trusted)),
             }
         } else {
             if had_queued_work {
@@ -214,7 +215,7 @@ impl ClassifiedInboxQueue {
                 outcome: AdmissionOutcome::Dropped {
                     reason: DropReason::UntrustedSender,
                 },
-                trusted_snapshot: Some(false),
+                admission_diagnostic: Some(PeerIngressAdmissionDiagnostic::UntrustedAtAdmission),
             }
         }
     }
@@ -555,7 +556,7 @@ impl InboxSender {
             from_peer: result.from_peer,
             lifecycle_peer: result.lifecycle_peer,
             request_id: result.request_id,
-            trusted_snapshot: decision.trusted_snapshot,
+            admission_diagnostic: decision.admission_diagnostic,
             text_projection: result.text_projection,
         };
         match classified_queue.lock().try_push(entry) {
@@ -694,7 +695,7 @@ impl InboxSender {
         let kind = result.kind;
         // C-H3 — the admission decision (trust re-check, auth-exempt
         // bypass, and phase update) happens inside a single queue-lock
-        // scope so classification's T0 trust snapshot cannot admit an
+        // scope so classification's T0 trust observation cannot admit an
         // envelope that was revoked at T2.
         let decision = {
             let mut queue = classified_queue.lock();
@@ -704,12 +705,14 @@ impl InboxSender {
             AdmissionOutcome::Admitted => {}
             AdmissionOutcome::Dropped { reason } => {
                 if let InboxItem::External { envelope } = &result.item {
+                    let request_id_for_log =
+                        result.request_id.map(|request_id| request_id.to_string());
                     tracing::warn!(
                         peer_id = %envelope.from.to_peer_id(),
                         from_peer = result.from_peer.as_deref().unwrap_or("<unresolved>"),
                         class = ?result.class,
                         kind = ?kind,
-                        request_id = result.request_id.as_deref().unwrap_or("<none>"),
+                        request_id = request_id_for_log.as_deref().unwrap_or("<none>"),
                         auth_required = ctx.require_peer_auth,
                         trusted_sender = result.trusted_sender,
                         reason = ?reason,
@@ -728,7 +731,7 @@ impl InboxSender {
             from_peer: result.from_peer,
             lifecycle_peer: result.lifecycle_peer,
             request_id: result.request_id,
-            trusted_snapshot: decision.trusted_snapshot,
+            admission_diagnostic: decision.admission_diagnostic,
             text_projection: result.text_projection,
         };
         // Enqueue only on classified queue (no raw double-enqueue).
@@ -793,21 +796,27 @@ fn ingress_auth_decision(kind: &MessageKind) -> PeerIngressAuthDecision {
 
 fn snapshot_entry(entry: &ClassifiedInboxEntry) -> PeerIngressEntrySnapshot {
     PeerIngressEntrySnapshot {
-        raw_item_id: entry.raw_item_id.clone(),
+        raw_item_id: entry.raw_item_id,
         interaction_id: match &entry.item {
             InboxItem::External { envelope } => Some(InteractionId(envelope.id)),
             InboxItem::PlainEvent { interaction_id, .. } => interaction_id.map(InteractionId),
         },
         class: entry.class,
         kind: entry.kind,
-        from_peer: entry.from_peer.clone(),
-        lifecycle_peer: entry.lifecycle_peer.clone(),
-        request_id: entry.request_id.clone(),
+        from_peer_display: entry
+            .from_peer
+            .as_ref()
+            .map(|peer| PeerIngressDiagnosticDisplay::new(peer.clone())),
+        lifecycle_peer_display: entry
+            .lifecycle_peer
+            .as_ref()
+            .map(|peer| PeerIngressDiagnosticDisplay::new(peer.clone())),
+        request_correlation_id: entry.request_id,
         auth: match &entry.item {
             InboxItem::External { .. } => Some(entry.auth),
             InboxItem::PlainEvent { .. } => None,
         },
-        trusted_snapshot: entry.trusted_snapshot,
+        admission_diagnostic: entry.admission_diagnostic,
     }
 }
 
@@ -854,6 +863,26 @@ mod tests {
             },
             sig: crate::identity::Signature::new([0u8; 64]),
         }
+    }
+
+    fn make_response_envelope(in_reply_to: Uuid) -> Envelope {
+        let mut envelope = make_test_envelope();
+        envelope.kind = MessageKind::Response {
+            in_reply_to,
+            status: crate::types::Status::Completed,
+            result: serde_json::json!({"ok": true}),
+            handling_mode: None,
+        };
+        envelope
+    }
+
+    fn make_lifecycle_envelope(peer: &str) -> Envelope {
+        let mut envelope = make_test_envelope();
+        envelope.kind = MessageKind::Lifecycle {
+            kind: meerkat_core::comms::PeerLifecycleKind::PeerAdded,
+            params: serde_json::json!({ "peer": peer }),
+        };
+        envelope
     }
 
     #[test]
@@ -1286,7 +1315,7 @@ mod tests {
 
         let entries = inbox.try_drain_classified();
         assert_eq!(entries.len(), 1);
-        assert!(!entries[0].raw_item_id.is_empty());
+        assert!(!entries[0].raw_item_id.to_string().is_empty());
         assert_eq!(
             entries[0].class,
             meerkat_core::PeerInputClass::ActionableMessage
@@ -1358,10 +1387,16 @@ mod tests {
             Some(PeerIngressAuthDecision::Required)
         );
         assert_eq!(snapshot.queued_entries[1].auth, None);
-        assert_eq!(snapshot.queued_entries[0].trusted_snapshot, Some(true));
-        assert_eq!(snapshot.queued_entries[1].trusted_snapshot, None);
+        assert_eq!(
+            snapshot.queued_entries[0].admission_diagnostic,
+            Some(PeerIngressAdmissionDiagnostic::TrustedAtAdmission)
+        );
+        assert_eq!(snapshot.queued_entries[1].admission_diagnostic, None);
         assert!(
-            !snapshot.queued_entries[0].raw_item_id.is_empty(),
+            !snapshot.queued_entries[0]
+                .raw_item_id
+                .to_string()
+                .is_empty(),
             "external items should keep a stable ingress raw item id"
         );
         assert!(
@@ -1373,7 +1408,6 @@ mod tests {
             snapshot.queued_entries[1]
                 .interaction_id
                 .expect("plain event interaction id should be present")
-                .to_string()
         );
 
         let drained = inbox.try_drain_classified();
@@ -1387,7 +1421,7 @@ mod tests {
         let (inbox, sender) = Inbox::new_classified(ctx);
 
         let envelope = make_request_envelope();
-        let request_id = envelope.id.to_string();
+        let request_id = InteractionId(envelope.id);
 
         sender
             .send_classified(InboxItem::External { envelope })
@@ -1400,8 +1434,158 @@ mod tests {
         assert_eq!(snapshot.total_count, 1);
         assert_eq!(snapshot.queued_entries.len(), 1);
         assert_eq!(snapshot.queued_entries[0].kind, PeerIngressKind::Request);
-        assert_eq!(snapshot.queued_entries[0].request_id, Some(request_id));
-        assert_eq!(snapshot.queued_entries[0].trusted_snapshot, Some(true));
+        assert_eq!(
+            snapshot.queued_entries[0].request_correlation_id,
+            Some(request_id)
+        );
+        assert_eq!(
+            snapshot.queued_entries[0].admission_diagnostic,
+            Some(PeerIngressAdmissionDiagnostic::TrustedAtAdmission)
+        );
+    }
+
+    #[tokio::test]
+    async fn test_classified_snapshot_diagnostics_cover_admitted_shapes() {
+        let sender_pubkey = PubKey::new([1u8; 32]);
+        let ctx = make_classification_context(make_trusted("peer", &sender_pubkey), false);
+        let (inbox, sender) = Inbox::new_classified(ctx);
+
+        let message = make_test_envelope();
+        let message_id = InteractionId(message.id);
+        let request = make_request_envelope();
+        let request_id = InteractionId(request.id);
+        let response_reply_to = Uuid::new_v4();
+        let response = make_response_envelope(response_reply_to);
+        let lifecycle = make_lifecycle_envelope("worker-1");
+
+        for envelope in [message, request, response, lifecycle] {
+            sender
+                .send_classified(InboxItem::External { envelope })
+                .into_result()
+                .unwrap();
+        }
+        sender
+            .send_classified(InboxItem::PlainEvent {
+                body: "event".to_string(),
+                source: meerkat_core::PlainEventSource::Tcp,
+                handling_mode: meerkat_core::types::HandlingMode::Queue,
+                interaction_id: None,
+                blocks: None,
+                render_metadata: None,
+            })
+            .into_result()
+            .unwrap();
+
+        let snapshot = inbox
+            .classified_snapshot()
+            .expect("classified snapshot should exist");
+        assert_eq!(snapshot.total_count, 5);
+        assert_eq!(snapshot.actionable_count, 4);
+        assert_eq!(snapshot.response_count, 1);
+        assert_eq!(snapshot.lifecycle_count, 1);
+        assert_eq!(snapshot.plain_event_count, 1);
+        assert_eq!(snapshot.ack_count, 0);
+        assert_eq!(snapshot.silent_request_count, 0);
+
+        let entries = &snapshot.queued_entries;
+        assert_eq!(entries[0].kind, PeerIngressKind::Message);
+        assert_eq!(entries[0].raw_item_id, message_id);
+        assert_eq!(entries[0].interaction_id, Some(message_id));
+        assert_eq!(
+            entries[0]
+                .from_peer_display
+                .as_ref()
+                .map(|peer| peer.as_str()),
+            Some("peer")
+        );
+        assert_eq!(entries[0].lifecycle_peer_display, None);
+        assert_eq!(entries[0].request_correlation_id, None);
+        assert_eq!(
+            entries[0].admission_diagnostic,
+            Some(PeerIngressAdmissionDiagnostic::TrustedAtAdmission)
+        );
+
+        assert_eq!(entries[1].kind, PeerIngressKind::Request);
+        assert_eq!(entries[1].request_correlation_id, Some(request_id));
+        assert_eq!(
+            entries[1]
+                .from_peer_display
+                .as_ref()
+                .map(|peer| peer.as_str()),
+            Some("peer")
+        );
+
+        assert_eq!(entries[2].kind, PeerIngressKind::Response);
+        assert_eq!(
+            entries[2].request_correlation_id,
+            Some(InteractionId(response_reply_to))
+        );
+        assert_eq!(
+            entries[2]
+                .from_peer_display
+                .as_ref()
+                .map(|peer| peer.as_str()),
+            Some("peer")
+        );
+
+        assert_eq!(entries[3].kind, PeerIngressKind::Request);
+        assert_eq!(entries[3].class, PeerInputClass::PeerLifecycleAdded);
+        assert_eq!(
+            entries[3]
+                .lifecycle_peer_display
+                .as_ref()
+                .map(|peer| peer.as_str()),
+            Some("worker-1")
+        );
+        assert_eq!(
+            entries[3]
+                .from_peer_display
+                .as_ref()
+                .map(|peer| peer.as_str()),
+            Some("peer")
+        );
+
+        assert_eq!(entries[4].kind, PeerIngressKind::PlainEvent);
+        assert_eq!(entries[4].from_peer_display, None);
+        assert_eq!(entries[4].lifecycle_peer_display, None);
+        assert_eq!(entries[4].request_correlation_id, None);
+        assert_eq!(entries[4].auth, None);
+        assert_eq!(entries[4].admission_diagnostic, None);
+        assert_eq!(entries[4].raw_item_id, entries[4].interaction_id.unwrap());
+    }
+
+    #[tokio::test]
+    async fn test_classified_snapshot_trust_observation_is_diagnostic_only() {
+        let ctx = make_classification_context(TrustedPeers::new(), false);
+        let (mut inbox, sender) = Inbox::new_classified(ctx);
+
+        sender
+            .send_classified(InboxItem::External {
+                envelope: make_test_envelope(),
+            })
+            .into_result()
+            .unwrap();
+
+        let snapshot = inbox
+            .classified_snapshot()
+            .expect("classified snapshot should exist");
+        assert_eq!(snapshot.queued_entries.len(), 1);
+        assert_eq!(
+            snapshot.queued_entries[0].admission_diagnostic,
+            Some(PeerIngressAdmissionDiagnostic::UntrustedAtAdmission),
+            "the queued row records an observation, not an admission oracle"
+        );
+        assert!(
+            snapshot.queued_entries[0].from_peer_display.is_some(),
+            "the fallback sender label is display-only diagnostics"
+        );
+
+        let drained = inbox.try_drain_classified();
+        assert_eq!(
+            drained.len(),
+            1,
+            "admission was governed by policy, not reconstructed from the snapshot"
+        );
     }
 
     #[tokio::test]

--- a/meerkat-comms/src/runtime/comms_runtime.rs
+++ b/meerkat-comms/src/runtime/comms_runtime.rs
@@ -3319,7 +3319,7 @@ mod tests {
             .0;
         assert_eq!(
             snapshot.queued_entries[0].raw_item_id,
-            ingress_id.to_string(),
+            meerkat_core::InteractionId(ingress_id),
             "the queue snapshot should expose the same stable ingress id it uses as the raw item key"
         );
 
@@ -3434,13 +3434,12 @@ mod tests {
             snapshot.queue.queued_entries[0].kind,
             meerkat_core::PeerIngressKind::PlainEvent
         );
-        assert_eq!(snapshot.queue.queued_entries[0].trusted_snapshot, None);
+        assert_eq!(snapshot.queue.queued_entries[0].admission_diagnostic, None);
         assert_eq!(
             snapshot.queue.queued_entries[0].raw_item_id,
             snapshot.queue.queued_entries[0]
                 .interaction_id
                 .expect("plain event should retain an ingress interaction id")
-                .to_string()
         );
     }
 
@@ -3577,8 +3576,8 @@ mod tests {
         assert_eq!(snapshot.submission_queue_len, 1);
         assert_eq!(snapshot.queue.total_count, 1);
         assert_eq!(
-            snapshot.queue.queued_entries[0].trusted_snapshot,
-            Some(true)
+            snapshot.queue.queued_entries[0].admission_diagnostic,
+            Some(meerkat_core::PeerIngressAdmissionDiagnostic::TrustedAtAdmission)
         );
 
         {

--- a/meerkat-core/src/interaction.rs
+++ b/meerkat-core/src/interaction.rs
@@ -434,29 +434,84 @@ pub enum PeerIngressKind {
     PlainEvent,
 }
 
+/// Display-only peer or source label captured for ingress diagnostics.
+///
+/// This is deliberately not a routing, trust, or admission identity. Canonical
+/// peer authority lives in the admitted ingress fact and runtime/machine
+/// admission state; snapshot rows only expose this label so operators can read
+/// queue diagnostics.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PeerIngressDiagnosticDisplay(String);
+
+impl PeerIngressDiagnosticDisplay {
+    pub fn new(value: impl Into<String>) -> Self {
+        Self(value.into())
+    }
+
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+impl std::fmt::Display for PeerIngressDiagnosticDisplay {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        self.0.fmt(f)
+    }
+}
+
+/// Diagnostic copy of the admission-time trust observation for a queued item.
+///
+/// This records what admission observed when the item was queued. It is not a
+/// live trust oracle and must not be used to reconstruct routing or admission
+/// authority from a snapshot row.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PeerIngressAdmissionDiagnostic {
+    TrustedAtAdmission,
+    UntrustedAtAdmission,
+}
+
+impl PeerIngressAdmissionDiagnostic {
+    pub const fn from_trusted(trusted: bool) -> Self {
+        if trusted {
+            Self::TrustedAtAdmission
+        } else {
+            Self::UntrustedAtAdmission
+        }
+    }
+
+    pub const fn trusted_at_admission(self) -> bool {
+        matches!(self, Self::TrustedAtAdmission)
+    }
+}
+
 /// Snapshot of one queued peer-ingress item.
+///
+/// Snapshot rows are diagnostics derived from the canonical admitted ingress
+/// candidate. They are intentionally incomplete for route/trust reconstruction:
+/// peer labels are display-only, correlation ids are typed, and admission
+/// details are diagnostic copies rather than authority.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct PeerIngressEntrySnapshot {
-    /// Stable ingress-time identity for this queued raw item.
-    pub raw_item_id: String,
+    /// Stable typed ingress-time identity for this queued raw item.
+    pub raw_item_id: InteractionId,
     /// Interaction/correlation identifier when one exists.
     pub interaction_id: Option<InteractionId>,
     /// Pre-computed ingress classification.
     pub class: PeerInputClass,
     /// Coarse admitted kind.
     pub kind: PeerIngressKind,
-    /// Sender identity fixed at ingress time, if applicable.
-    pub from_peer: Option<String>,
-    /// Lifecycle peer identity for add/retire notices, if applicable.
-    pub lifecycle_peer: Option<String>,
+    /// Display-only sender label, if applicable. Not route/trust authority.
+    pub from_peer_display: Option<PeerIngressDiagnosticDisplay>,
+    /// Display-only lifecycle peer label, if applicable. Not route/trust authority.
+    pub lifecycle_peer_display: Option<PeerIngressDiagnosticDisplay>,
     /// Request envelope id or reply-to correlation when one exists.
-    pub request_id: Option<String>,
+    pub request_correlation_id: Option<InteractionId>,
     /// Auth decision used by peer ingress admission, if this queued entry came
     /// from authenticated peer transport. Plain events leave this unset.
     pub auth: Option<PeerIngressAuthDecision>,
-    /// Whether this entry was trusted at ingress time, when peer authority
-    /// owns the entry. Plain external events leave this unset.
-    pub trusted_snapshot: Option<bool>,
+    /// Admission-time trust diagnostic, when peer authority owns the entry.
+    /// Plain external events leave this unset.
+    pub admission_diagnostic: Option<PeerIngressAdmissionDiagnostic>,
 }
 
 /// Non-destructive snapshot of the queued peer-ingress surface.

--- a/meerkat-core/src/lib.rs
+++ b/meerkat-core/src/lib.rs
@@ -184,11 +184,12 @@ pub use image_content::{
 pub use image_generation::*;
 pub use interaction::{
     ClassifiedInboxInteraction, InboxInteraction, InteractionContent, InteractionId,
-    PeerIngressAuthDecision, PeerIngressAuthExemption, PeerIngressAuthorityPhase,
-    PeerIngressClassification, PeerIngressEntrySnapshot, PeerIngressKind, PeerIngressMachinePolicy,
-    PeerIngressQueueSnapshot, PeerIngressRuntimeSnapshot, PeerInputClass, ResponseStatus,
-    TerminalDisposition, TerminalityClass, classify_response_terminality,
-    format_peer_ack_projection, format_peer_message_projection, format_peer_request_projection,
+    PeerIngressAdmissionDiagnostic, PeerIngressAuthDecision, PeerIngressAuthExemption,
+    PeerIngressAuthorityPhase, PeerIngressClassification, PeerIngressDiagnosticDisplay,
+    PeerIngressEntrySnapshot, PeerIngressKind, PeerIngressMachinePolicy, PeerIngressQueueSnapshot,
+    PeerIngressRuntimeSnapshot, PeerInputClass, ResponseStatus, TerminalDisposition,
+    TerminalityClass, classify_response_terminality, format_peer_ack_projection,
+    format_peer_message_projection, format_peer_request_projection,
     format_peer_response_projection, peer_lifecycle_subject,
 };
 pub use lifecycle::{


### PR DESCRIPTION
## Summary
- type queued ingress snapshot IDs as InteractionId and rename peer labels to display-only diagnostics
- replace queued trust boolean with a typed admission diagnostic
- add snapshot coverage for message, request, response, lifecycle, and plain-event queue rows

## Validation
- ./scripts/repo-cargo test -p meerkat-comms classified_snapshot --lib
- ./scripts/repo-cargo test -p meerkat-comms peer_ingress --lib
- ./scripts/repo-cargo test -p meerkat-comms plain_event_without_interaction_id_gets_stable_id_between_snapshot_and_drain --lib
- make check

Linear: LUC-152