### PR TITLE
Close raw comms atoms in mob MCP wiring

### DIFF
--- a/meerkat-mob-mcp/src/agent_tools.rs
+++ b/meerkat-mob-mcp/src/agent_tools.rs
@@ -1461,7 +1461,8 @@ fn build_tool_defs_with_profile_support(
                                 "properties": {
                                     "local": {"type": "string", "description": "Another member in this mob"}
                                 },
-                                "required": ["local"]
+                                "required": ["local"],
+                                "additionalProperties": false
                             },
                             {
                                 "type": "object",
@@ -1485,7 +1486,8 @@ fn build_tool_defs_with_profile_support(
                                         "additionalProperties": false
                                     }
                                 },
-                                "required": ["external_binding"]
+                                "required": ["external_binding"],
+                                "additionalProperties": false
                             }
                         ],
                         "description": "Target peer: local member or typed external binding"
@@ -1512,7 +1514,8 @@ fn build_tool_defs_with_profile_support(
                                 "properties": {
                                     "local": {"type": "string"}
                                 },
-                                "required": ["local"]
+                                "required": ["local"],
+                                "additionalProperties": false
                             },
                             {
                                 "type": "object",
@@ -1526,7 +1529,8 @@ fn build_tool_defs_with_profile_support(
                                         "additionalProperties": false
                                     }
                                 },
-                                "required": ["external"]
+                                "required": ["external"],
+                                "additionalProperties": false
                             }
                         ],
                         "description": "Target peer to unwire"
@@ -1755,19 +1759,33 @@ struct UnwireArgs {
 #[derive(Debug, Deserialize)]
 #[serde(untagged)]
 enum WirePeerArg {
-    Local {
-        local: String,
-    },
-    ExternalBinding {
-        external_binding: ExternalPeerBindingArg,
-    },
+    Local(LocalPeerArg),
+    ExternalBinding(WireExternalPeerBindingArg),
 }
 
 #[derive(Debug, Deserialize)]
 #[serde(untagged)]
 enum UnwirePeerArg {
-    Local { local: String },
-    External { external: ExternalPeerHandleArg },
+    Local(LocalPeerArg),
+    External(UnwireExternalPeerHandleArg),
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct LocalPeerArg {
+    local: String,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct WireExternalPeerBindingArg {
+    external_binding: ExternalPeerBindingArg,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct UnwireExternalPeerHandleArg {
+    external: ExternalPeerHandleArg,
 }
 
 #[derive(Debug, Deserialize)]
@@ -1786,8 +1804,8 @@ struct ExternalPeerHandleArg {
 
 fn wire_peer_target_from_args(peer: WirePeerArg) -> meerkat_mob::PeerTarget {
     match peer {
-        WirePeerArg::Local { local } => meerkat_mob::PeerTarget::Local(local.into()),
-        WirePeerArg::ExternalBinding { external_binding } => {
+        WirePeerArg::Local(LocalPeerArg { local }) => meerkat_mob::PeerTarget::Local(local.into()),
+        WirePeerArg::ExternalBinding(WireExternalPeerBindingArg { external_binding }) => {
             meerkat_mob::PeerTarget::ExternalBinding(meerkat_mob::ExternalPeerBindingSpec::new(
                 external_binding.name,
                 external_binding.address,
@@ -1801,8 +1819,10 @@ fn unwire_peer_target_from_args(
     peer: UnwirePeerArg,
 ) -> Result<meerkat_mob::PeerTarget, meerkat_core::error::ToolError> {
     match peer {
-        UnwirePeerArg::Local { local } => Ok(meerkat_mob::PeerTarget::Local(local.into())),
-        UnwirePeerArg::External { external } => {
+        UnwirePeerArg::Local(LocalPeerArg { local }) => {
+            Ok(meerkat_mob::PeerTarget::Local(local.into()))
+        }
+        UnwirePeerArg::External(UnwireExternalPeerHandleArg { external }) => {
             let peer_name = PeerName::new(external.name)
                 .map_err(|e| meerkat_core::error::ToolError::invalid_arguments("mob_unwire", e))?;
             Ok(meerkat_mob::PeerTarget::ExternalName(peer_name))
@@ -1957,6 +1977,30 @@ mod tests {
     }
 
     #[test]
+    fn agent_mcp_wire_rejects_ambiguous_peer_target_shape() {
+        let err = serde_json::from_value::<WirePeerArg>(serde_json::json!({
+            "local": "worker-a",
+            "external_binding": {
+                "name": "external-worker",
+                "address": "inproc://external-worker",
+                "identity": {
+                    "kind": "ed25519_public_key",
+                    "public_key": ED25519_PUBLIC_KEY_7
+                }
+            }
+        }))
+        .expect_err("agent MCP wire peer target must not accept multiple target shapes");
+
+        let msg = err.to_string();
+        assert!(
+            msg.contains("did not match")
+                || msg.contains("unknown field")
+                || msg.contains("external_binding"),
+            "unexpected error: {msg}"
+        );
+    }
+
+    #[test]
     fn agent_mcp_unwire_accepts_external_peer_name_handle() {
         let target = unwire_peer_target_from_args(
             serde_json::from_value::<UnwirePeerArg>(serde_json::json!({
@@ -1970,6 +2014,21 @@ mod tests {
             panic!("unwire external should use the external peer handle");
         };
         assert_eq!(peer_name.as_str(), "external-worker");
+    }
+
+    #[test]
+    fn agent_mcp_unwire_rejects_ambiguous_peer_target_shape() {
+        let err = serde_json::from_value::<UnwirePeerArg>(serde_json::json!({
+            "local": "worker-a",
+            "external": { "name": "external-worker" }
+        }))
+        .expect_err("agent MCP unwire peer target must not accept multiple target shapes");
+
+        let msg = err.to_string();
+        assert!(
+            msg.contains("did not match") || msg.contains("unknown field"),
+            "unexpected error: {msg}"
+        );
     }
 
     #[test]

--- a/meerkat-mob-mcp/src/agent_tools.rs
+++ b/meerkat-mob-mcp/src/agent_tools.rs
@@ -903,7 +903,7 @@ impl AgentMobToolSurface {
             .map_err(|e| ToolError::invalid_arguments(call.name, e.to_string()))?;
         let mob_id = meerkat_mob::MobId::from(args.mob_id.as_str());
         let local = AgentIdentity::from(args.member_id.as_str());
-        let target = peer_target_from_args(args.peer)?;
+        let target = wire_peer_target_from_args(args.peer);
         self.state
             .mob_wire(&mob_id, local, target)
             .await
@@ -915,12 +915,12 @@ impl AgentMobToolSurface {
         &self,
         call: ToolCallView<'_>,
     ) -> Result<meerkat_core::ToolDispatchOutcome, ToolError> {
-        let args: WireArgs = call
+        let args: UnwireArgs = call
             .parse_args()
             .map_err(|e| ToolError::invalid_arguments(call.name, e.to_string()))?;
         let mob_id = meerkat_mob::MobId::from(args.mob_id.as_str());
         let local = AgentIdentity::from(args.member_id.as_str());
-        let target = peer_target_from_args(args.peer)?;
+        let target = unwire_peer_target_from_args(args.peer)?;
         self.state
             .mob_unwire(&mob_id, local, target)
             .await
@@ -1440,15 +1440,15 @@ fn build_tool_defs_with_profile_support(
         ),
         tool_def(
             TOOL_MOB_WIRE,
-            "Wire a mob member to another local member or an external peer.\n\n\
+            "Wire a mob member to another local member or an external binding.\n\n\
              Creates a comms trust relationship so the wired members can exchange messages. \
              For local members (both in the same mob roster), wiring is bidirectional. \
              For external peers (outside the roster), trust is added on the local member's side.\n\n\
              PEER TARGET TYPES:\n\
              - {\"local\": \"member-id\"} — another member in the same mob roster.\n\
-             - {\"external\": {\"name\": \"peer-name\", \"address\": \"tcp://host:port\", \
+             - {\"external_binding\": {\"name\": \"peer-name\", \"address\": \"tcp://host:port\", \
                \"identity\": {\"kind\": \"ed25519_public_key\", \"public_key\": \"ed25519:...\"}}} \
-               — a trusted peer outside the roster.",
+               — a typed external binding request resolved by the mob authority.",
             json!({
                 "type": "object",
                 "properties": {
@@ -1466,7 +1466,7 @@ fn build_tool_defs_with_profile_support(
                             {
                                 "type": "object",
                                 "properties": {
-                                    "external": {
+                                    "external_binding": {
                                         "type": "object",
                                         "properties": {
                                             "name": {"type": "string"},
@@ -1485,10 +1485,10 @@ fn build_tool_defs_with_profile_support(
                                         "additionalProperties": false
                                     }
                                 },
-                                "required": ["external"]
+                                "required": ["external_binding"]
                             }
                         ],
-                        "description": "Target peer: local member or external trusted peer"
+                        "description": "Target peer: local member or typed external binding"
                     }
                 },
                 "required": ["mob_id", "member_id", "peer"]
@@ -1498,7 +1498,8 @@ fn build_tool_defs_with_profile_support(
             TOOL_MOB_UNWIRE,
             "Remove a wiring relationship between a mob member and a peer.\n\n\
              Removes the comms trust relationship established by mob_wire. \
-             Same peer target format as mob_wire.",
+             Use {\"local\": \"member-id\"} for roster peers or \
+             {\"external\": {\"name\": \"peer-name\"}} for an external binding handle.",
             json!({
                 "type": "object",
                 "properties": {
@@ -1519,19 +1520,9 @@ fn build_tool_defs_with_profile_support(
                                     "external": {
                                         "type": "object",
                                         "properties": {
-                                            "name": {"type": "string"},
-                                            "address": {"type": "string"},
-                                            "identity": {
-                                                "type": "object",
-                                                "properties": {
-                                                    "kind": {"type": "string", "enum": ["ed25519_public_key"]},
-                                                    "public_key": {"type": "string"}
-                                                },
-                                                "required": ["kind", "public_key"],
-                                                "additionalProperties": false
-                                            }
+                                            "name": {"type": "string"}
                                         },
-                                        "required": ["name", "address", "identity"],
+                                        "required": ["name"],
                                         "additionalProperties": false
                                     }
                                 },
@@ -1755,33 +1746,66 @@ struct WireArgs {
 }
 
 #[derive(Debug, Deserialize)]
+struct UnwireArgs {
+    mob_id: String,
+    member_id: String,
+    peer: UnwirePeerArg,
+}
+
+#[derive(Debug, Deserialize)]
 #[serde(untagged)]
 enum WirePeerArg {
+    Local {
+        local: String,
+    },
+    ExternalBinding {
+        external_binding: ExternalPeerBindingArg,
+    },
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(untagged)]
+enum UnwirePeerArg {
     Local { local: String },
-    External { external: ExternalPeerArg },
+    External { external: ExternalPeerHandleArg },
 }
 
 #[derive(Debug, Deserialize)]
 #[serde(deny_unknown_fields)]
-struct ExternalPeerArg {
+struct ExternalPeerBindingArg {
     name: String,
     address: String,
     identity: meerkat_contracts::WireTrustedPeerIdentity,
 }
 
-fn peer_target_from_args(
-    peer: WirePeerArg,
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct ExternalPeerHandleArg {
+    name: String,
+}
+
+fn wire_peer_target_from_args(peer: WirePeerArg) -> meerkat_mob::PeerTarget {
+    match peer {
+        WirePeerArg::Local { local } => meerkat_mob::PeerTarget::Local(local.into()),
+        WirePeerArg::ExternalBinding { external_binding } => {
+            meerkat_mob::PeerTarget::ExternalBinding(meerkat_mob::ExternalPeerBindingSpec::new(
+                external_binding.name,
+                external_binding.address,
+                external_binding.identity,
+            ))
+        }
+    }
+}
+
+fn unwire_peer_target_from_args(
+    peer: UnwirePeerArg,
 ) -> Result<meerkat_mob::PeerTarget, meerkat_core::error::ToolError> {
     match peer {
-        WirePeerArg::Local { local } => Ok(meerkat_mob::PeerTarget::Local(local.into())),
-        WirePeerArg::External { external } => {
-            let descriptor = crate::trusted_peer_descriptor_from_wire_parts(
-                external.name,
-                external.address,
-                external.identity,
-            )
-            .map_err(|e| meerkat_core::error::ToolError::invalid_arguments("mob_wire", e))?;
-            Ok(meerkat_mob::PeerTarget::External(descriptor))
+        UnwirePeerArg::Local { local } => Ok(meerkat_mob::PeerTarget::Local(local.into())),
+        UnwirePeerArg::External { external } => {
+            let peer_name = PeerName::new(external.name)
+                .map_err(|e| meerkat_core::error::ToolError::invalid_arguments("mob_unwire", e))?;
+            Ok(meerkat_mob::PeerTarget::ExternalName(peer_name))
         }
     }
 }
@@ -1868,7 +1892,7 @@ mod tests {
 
     fn canonical_agent_wire_peer_arg() -> WirePeerArg {
         serde_json::from_value(serde_json::json!({
-            "external": {
+            "external_binding": {
                 "name": "external-worker",
                 "address": "inproc://external-worker",
                 "identity": {
@@ -1881,21 +1905,14 @@ mod tests {
     }
 
     #[test]
-    fn agent_mcp_wire_accepts_canonical_external_peer_identity() {
-        let target = peer_target_from_args(canonical_agent_wire_peer_arg())
-            .expect("canonical agent external peer identity should resolve");
+    fn agent_mcp_wire_accepts_typed_external_binding_request() {
+        let target = wire_peer_target_from_args(canonical_agent_wire_peer_arg());
 
-        let meerkat_mob::PeerTarget::External(descriptor) = target else {
-            panic!("canonical agent external peer should resolve to an external descriptor");
+        let meerkat_mob::PeerTarget::ExternalBinding(binding) = target else {
+            panic!("canonical agent external peer should remain a mob-resolved external binding");
         };
-        let pubkey = [7u8; 32];
-        assert_eq!(descriptor.name.as_str(), "external-worker");
-        assert_eq!(descriptor.address.to_string(), "inproc://external-worker");
-        assert_eq!(descriptor.pubkey, pubkey);
-        assert_eq!(
-            descriptor.peer_id,
-            meerkat_core::comms::PeerId::from_ed25519_pubkey(&pubkey)
-        );
+        assert_eq!(binding.name, "external-worker");
+        assert_eq!(binding.address, "inproc://external-worker");
     }
 
     #[test]
@@ -1912,7 +1929,9 @@ mod tests {
 
         let msg = err.to_string();
         assert!(
-            msg.contains("peer_id") || msg.contains("identity") || msg.contains("did not match"),
+            msg.contains("external")
+                || msg.contains("external_binding")
+                || msg.contains("did not match"),
             "unexpected error: {msg}"
         );
     }
@@ -1920,7 +1939,7 @@ mod tests {
     #[test]
     fn agent_mcp_wire_rejects_external_peer_missing_pubkey_material() {
         let err = serde_json::from_value::<WirePeerArg>(serde_json::json!({
-            "external": {
+            "external_binding": {
                 "name": "external-worker",
                 "address": "inproc://external-worker",
                 "identity": {
@@ -1934,6 +1953,39 @@ mod tests {
         assert!(
             msg.contains("public_key") || msg.contains("identity") || msg.contains("did not match"),
             "unexpected error: {msg}"
+        );
+    }
+
+    #[test]
+    fn agent_mcp_unwire_accepts_external_peer_name_handle() {
+        let target = unwire_peer_target_from_args(
+            serde_json::from_value::<UnwirePeerArg>(serde_json::json!({
+                "external": { "name": "external-worker" }
+            }))
+            .expect("external handle should deserialize"),
+        )
+        .expect("external handle should convert");
+
+        let meerkat_mob::PeerTarget::ExternalName(peer_name) = target else {
+            panic!("unwire external should use the external peer handle");
+        };
+        assert_eq!(peer_name.as_str(), "external-worker");
+    }
+
+    #[test]
+    fn agent_mcp_wire_schema_uses_external_binding_without_raw_peer_atoms() {
+        let tools = build_tool_defs();
+        let schema = tools
+            .iter()
+            .find(|tool| tool.name == TOOL_MOB_WIRE)
+            .map(|tool| &tool.input_schema)
+            .expect("wire tool schema present");
+        let schema_text = serde_json::to_string(schema).expect("schema should encode");
+
+        assert!(schema_text.contains("external_binding"));
+        assert!(
+            !schema_text.contains("\"peer_id\"") && !schema_text.contains("\"pubkey\""),
+            "wire schema must not expose raw comms identity atoms: {schema_text}"
         );
     }
 

--- a/meerkat-mob-mcp/src/lib.rs
+++ b/meerkat-mob-mcp/src/lib.rs
@@ -30,11 +30,11 @@ mod tokio {
 use async_trait::async_trait;
 
 use meerkat_client::LlmClient;
-use meerkat_contracts::{MobDefinitionInput, MobPeerTarget};
+use meerkat_contracts::MobDefinitionInput;
 use meerkat_core::AppendSystemContextStatus;
 use meerkat_core::ScopedAgentEvent;
 use meerkat_core::agent::{AgentToolDispatcher, CommsRuntime as CoreCommsRuntime};
-use meerkat_core::comms::{CommsCommand, SendError, SendReceipt, TrustedPeerDescriptor};
+use meerkat_core::comms::{CommsCommand, PeerName, SendError, SendReceipt, TrustedPeerDescriptor};
 use meerkat_core::error::ToolError;
 use meerkat_core::interaction::{InteractionId, PeerInputCandidate};
 use meerkat_core::service::{
@@ -2088,8 +2088,8 @@ impl MobMcpDispatcher {
             ),
             tool(
                 "mob_wire",
-                &format!("Wire or unwire bidirectional trust between a local member and a peer target. \
-                     action: wire | unwire. {COMMON}"),
+	                &format!("Wire or unwire bidirectional trust between a local member and a peer target. \
+	                     action: wire | unwire. Use external_binding for wire and external name handles for unwire. {COMMON}"),
                 json!({
                     "type":"object",
                     "properties":{
@@ -2105,10 +2105,10 @@ impl MobMcpDispatcher {
                                 {
                                     "type":"object",
                                     "properties":{
-                                        "external":{
-                                            "type":"object",
-                                            "properties":{
-                                                "name":{"type":"string"},
+	                                        "external_binding":{
+	                                            "type":"object",
+	                                            "properties":{
+	                                                "name":{"type":"string"},
                                                 "address":{"type":"string"},
                                                 "identity":{
                                                     "type":"object",
@@ -2119,15 +2119,29 @@ impl MobMcpDispatcher {
                                                     "required":["kind","public_key"],
                                                     "additionalProperties":false
                                                 }
-                                            },
-                                            "required":["name","address","identity"],
-                                            "additionalProperties":false
-                                        }
-                                    },
-                                    "required":["external"]
-                                }
-                            ]
-                        },
+	                                            },
+	                                            "required":["name","address","identity"],
+	                                            "additionalProperties":false
+	                                        }
+	                                    },
+	                                    "required":["external_binding"]
+	                                },
+	                                {
+	                                    "type":"object",
+	                                    "properties":{
+	                                        "external":{
+	                                            "type":"object",
+	                                            "properties":{
+	                                                "name":{"type":"string"}
+	                                            },
+	                                            "required":["name"],
+	                                            "additionalProperties":false
+	                                        }
+	                                    },
+	                                    "required":["external"]
+	                                }
+	                            ]
+	                        },
                         "action":{"type":"string","enum":["wire","unwire"]}
                     },
                     "required":["mob_id","agent_identity","peer","action"]
@@ -2328,31 +2342,36 @@ struct RetireArgs {
 struct WireActionArgs {
     mob_id: String,
     agent_identity: String,
-    peer: MobPeerTarget,
+    peer: WireActionPeerTarget,
     action: String,
 }
 
-fn trusted_peer_descriptor_from_wire_spec(
-    spec: meerkat_contracts::WireTrustedPeerSpec,
-) -> Result<TrustedPeerDescriptor, String> {
-    trusted_peer_descriptor_from_wire_parts(spec.name, spec.address, spec.identity)
+#[derive(Debug, Deserialize)]
+#[serde(untagged)]
+enum WireActionPeerTarget {
+    Local {
+        local: String,
+    },
+    ExternalBinding {
+        external_binding: WireActionExternalBinding,
+    },
+    External {
+        external: WireActionExternalHandle,
+    },
 }
 
-fn trusted_peer_descriptor_from_wire_parts(
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct WireActionExternalBinding {
     name: String,
     address: String,
     identity: meerkat_contracts::WireTrustedPeerIdentity,
-) -> Result<TrustedPeerDescriptor, String> {
-    let name = meerkat_core::comms::PeerName::new(name.clone())
-        .map_err(|e| format!("invalid peer name '{name}': {e}"))?;
-    let resolved = identity.resolve().map_err(|e| e.to_string())?;
-    let address = parse_wire_peer_address(&address)?;
-    Ok(TrustedPeerDescriptor {
-        name,
-        peer_id: resolved.peer_id,
-        address,
-        pubkey: resolved.pubkey,
-    })
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct WireActionExternalHandle {
+    name: String,
 }
 
 fn runtime_binding_from_wire(
@@ -2378,31 +2397,32 @@ fn runtime_binding_from_wire(
 
 impl WireActionArgs {
     fn resolve(self) -> Result<(String, AgentIdentity, meerkat_mob::PeerTarget, String), String> {
+        let action = self.action;
+        let target = match self.peer {
+            WireActionPeerTarget::Local { local } => meerkat_mob::PeerTarget::Local(local.into()),
+            WireActionPeerTarget::ExternalBinding { external_binding } => {
+                meerkat_mob::PeerTarget::ExternalBinding(meerkat_mob::ExternalPeerBindingSpec::new(
+                    external_binding.name,
+                    external_binding.address,
+                    external_binding.identity,
+                ))
+            }
+            WireActionPeerTarget::External { external } => {
+                if action == "wire" {
+                    return Err("wire external peer requires external_binding".to_string());
+                }
+                let peer_name = PeerName::new(external.name)
+                    .map_err(|e| format!("invalid external peer name: {e}"))?;
+                meerkat_mob::PeerTarget::ExternalName(peer_name)
+            }
+        };
         Ok((
             self.mob_id,
             AgentIdentity::from(self.agent_identity),
-            match self.peer {
-                MobPeerTarget::Local(member_id) => meerkat_mob::PeerTarget::Local(member_id.into()),
-                MobPeerTarget::External(spec) => {
-                    meerkat_mob::PeerTarget::External(trusted_peer_descriptor_from_wire_spec(spec)?)
-                }
-            },
-            self.action,
+            target,
+            action,
         ))
     }
-}
-
-fn parse_wire_peer_address(raw: &str) -> Result<meerkat_core::comms::PeerAddress, String> {
-    let (scheme, endpoint) = raw
-        .split_once("://")
-        .ok_or_else(|| format!("peer address missing transport scheme: {raw}"))?;
-    let transport = match scheme {
-        "inproc" => meerkat_core::comms::PeerTransport::Inproc,
-        "uds" => meerkat_core::comms::PeerTransport::Uds,
-        "tcp" => meerkat_core::comms::PeerTransport::Tcp,
-        other => return Err(format!("unknown peer address transport: {other}")),
-    };
-    Ok(meerkat_core::comms::PeerAddress::new(transport, endpoint))
 }
 #[derive(Deserialize)]
 struct RunFlowArgs {
@@ -2980,16 +3000,19 @@ mod tests {
     use tokio::time::{Duration, Instant, sleep};
 
     const ED25519_PUBLIC_KEY_7: &str = "ed25519:BwcHBwcHBwcHBwcHBwcHBwcHBwcHBwcHBwcHBwcHBwc=";
-    const ED25519_PUBLIC_KEY_ZERO: &str = "ed25519:AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=";
 
-    fn external_peer_target(public_key: &str) -> MobPeerTarget {
-        MobPeerTarget::External(meerkat_contracts::WireTrustedPeerSpec {
-            name: "external-worker".to_string(),
-            address: "inproc://external-worker".to_string(),
-            identity: meerkat_contracts::WireTrustedPeerIdentity::Ed25519PublicKey {
-                public_key: public_key.to_string(),
-            },
-        })
+    fn external_peer_target(public_key: &str) -> WireActionPeerTarget {
+        serde_json::from_value(json!({
+            "external_binding": {
+                "name": "external-worker",
+                "address": "inproc://external-worker",
+                "identity": {
+                    "kind": "ed25519_public_key",
+                    "public_key": public_key
+                }
+            }
+        }))
+        .expect("external binding target should deserialize")
     }
 
     #[test]
@@ -3058,24 +3081,68 @@ mod tests {
     }
 
     #[test]
-    fn wire_action_args_rejects_external_peer_zero_pubkey() {
-        let err = WireActionArgs {
-            mob_id: "mob".to_string(),
-            agent_identity: "worker".to_string(),
-            peer: external_peer_target(ED25519_PUBLIC_KEY_ZERO),
-            action: "wire".to_string(),
-        }
-        .resolve()
-        .expect_err("zero pubkey external peers must be rejected");
+    fn wire_action_args_rejects_raw_external_peer_atoms() {
+        let err = serde_json::from_value::<WireActionPeerTarget>(json!({
+            "external": {
+                "name": "external-worker",
+                "peer_id": meerkat_core::comms::PeerId::from_ed25519_pubkey(&[7u8; 32]).to_string(),
+                "address": "inproc://external-worker",
+                "pubkey": vec![7u8; 32]
+            }
+        }))
+        .expect_err("raw peer_id/pubkey external peer shape must be rejected");
 
+        let msg = err.to_string();
         assert!(
-            err.contains("public_key") || err.contains("non-zero"),
-            "expected pubkey validation error, got: {err}"
+            msg.contains("external")
+                || msg.contains("external_binding")
+                || msg.contains("did not match"),
+            "unexpected error: {msg}"
         );
     }
 
     #[test]
-    fn wire_action_args_resolves_canonical_external_peer_identity() {
+    fn wire_action_args_rejects_missing_external_binding_pubkey_material() {
+        let err = serde_json::from_value::<WireActionPeerTarget>(json!({
+            "external_binding": {
+                "name": "external-worker",
+                "address": "inproc://external-worker",
+                "identity": {
+                    "kind": "ed25519_public_key"
+                }
+            }
+        }))
+        .expect_err("missing external binding pubkey material must fail closed");
+
+        let msg = err.to_string();
+        assert!(
+            msg.contains("public_key") || msg.contains("identity") || msg.contains("did not match"),
+            "unexpected error: {msg}"
+        );
+    }
+
+    #[test]
+    fn wire_action_args_rejects_external_handle_for_wire_action() {
+        let err = WireActionArgs {
+            mob_id: "mob".to_string(),
+            agent_identity: "worker".to_string(),
+            peer: serde_json::from_value(json!({
+                "external": { "name": "external-worker" }
+            }))
+            .expect("external handle should deserialize"),
+            action: "wire".to_string(),
+        }
+        .resolve()
+        .expect_err("wire action must require external_binding");
+
+        assert!(
+            err.contains("external_binding"),
+            "expected external_binding validation error, got: {err}"
+        );
+    }
+
+    #[test]
+    fn wire_action_args_passes_external_binding_to_mob_authority() {
         let resolved = WireActionArgs {
             mob_id: "mob".to_string(),
             agent_identity: "worker".to_string(),
@@ -3083,18 +3150,35 @@ mod tests {
             action: "wire".to_string(),
         }
         .resolve()
-        .expect("canonical external peer identity should resolve");
+        .expect("canonical external peer binding should resolve as request");
 
         let (_mob_id, _local, target, _action) = resolved;
-        let meerkat_mob::PeerTarget::External(descriptor) = target else {
-            panic!("canonical external peer should resolve to an external descriptor");
+        let meerkat_mob::PeerTarget::ExternalBinding(binding) = target else {
+            panic!("canonical external peer should remain mob-resolved external binding");
         };
-        let pubkey = [7u8; 32];
-        assert_eq!(descriptor.pubkey, pubkey);
-        assert_eq!(
-            descriptor.peer_id,
-            meerkat_core::comms::PeerId::from_ed25519_pubkey(&pubkey)
-        );
+        assert_eq!(binding.name, "external-worker");
+        assert_eq!(binding.address, "inproc://external-worker");
+    }
+
+    #[test]
+    fn wire_action_args_unwire_accepts_external_name_handle() {
+        let resolved = WireActionArgs {
+            mob_id: "mob".to_string(),
+            agent_identity: "worker".to_string(),
+            peer: serde_json::from_value(json!({
+                "external": { "name": "external-worker" }
+            }))
+            .expect("external handle should deserialize"),
+            action: "unwire".to_string(),
+        }
+        .resolve()
+        .expect("external handle should be valid for unwire");
+
+        let (_mob_id, _local, target, _action) = resolved;
+        let meerkat_mob::PeerTarget::ExternalName(peer_name) = target else {
+            panic!("unwire external should use the external peer handle");
+        };
+        assert_eq!(peer_name.as_str(), "external-worker");
     }
 
     struct MockComms {
@@ -3840,6 +3924,23 @@ mod tests {
                 "mob_wait_kickoff",
                 "mob_wait_ready",
             ]
+        );
+    }
+
+    #[test]
+    fn test_mob_wire_schema_uses_external_binding_without_raw_peer_atoms() {
+        let tools = tools_list();
+        let schema = tools
+            .iter()
+            .find(|tool| tool["name"] == "mob_wire")
+            .and_then(|tool| tool.get("inputSchema"))
+            .expect("mob_wire schema present");
+        let schema_text = serde_json::to_string(schema).expect("schema should encode");
+
+        assert!(schema_text.contains("external_binding"));
+        assert!(
+            !schema_text.contains("\"peer_id\"") && !schema_text.contains("\"pubkey\""),
+            "mob_wire schema must not expose raw comms identity atoms: {schema_text}"
         );
     }
 

--- a/meerkat-mob-mcp/src/lib.rs
+++ b/meerkat-mob-mcp/src/lib.rs
@@ -2100,7 +2100,8 @@ impl MobMcpDispatcher {
                                 {
                                     "type":"object",
                                     "properties":{"local":{"type":"string"}},
-                                    "required":["local"]
+                                    "required":["local"],
+                                    "additionalProperties":false
                                 },
                                 {
                                     "type":"object",
@@ -2124,7 +2125,8 @@ impl MobMcpDispatcher {
 	                                            "additionalProperties":false
 	                                        }
 	                                    },
-	                                    "required":["external_binding"]
+	                                    "required":["external_binding"],
+	                                    "additionalProperties":false
 	                                },
 	                                {
 	                                    "type":"object",
@@ -2138,7 +2140,8 @@ impl MobMcpDispatcher {
 	                                            "additionalProperties":false
 	                                        }
 	                                    },
-	                                    "required":["external"]
+	                                    "required":["external"],
+	                                    "additionalProperties":false
 	                                }
 	                            ]
 	                        },
@@ -2349,15 +2352,27 @@ struct WireActionArgs {
 #[derive(Debug, Deserialize)]
 #[serde(untagged)]
 enum WireActionPeerTarget {
-    Local {
-        local: String,
-    },
-    ExternalBinding {
-        external_binding: WireActionExternalBinding,
-    },
-    External {
-        external: WireActionExternalHandle,
-    },
+    Local(WireActionLocalPeerTarget),
+    ExternalBinding(WireActionExternalBindingTarget),
+    External(WireActionExternalHandleTarget),
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct WireActionLocalPeerTarget {
+    local: String,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct WireActionExternalBindingTarget {
+    external_binding: WireActionExternalBinding,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct WireActionExternalHandleTarget {
+    external: WireActionExternalHandle,
 }
 
 #[derive(Debug, Deserialize)]
@@ -2399,15 +2414,19 @@ impl WireActionArgs {
     fn resolve(self) -> Result<(String, AgentIdentity, meerkat_mob::PeerTarget, String), String> {
         let action = self.action;
         let target = match self.peer {
-            WireActionPeerTarget::Local { local } => meerkat_mob::PeerTarget::Local(local.into()),
-            WireActionPeerTarget::ExternalBinding { external_binding } => {
+            WireActionPeerTarget::Local(WireActionLocalPeerTarget { local }) => {
+                meerkat_mob::PeerTarget::Local(local.into())
+            }
+            WireActionPeerTarget::ExternalBinding(WireActionExternalBindingTarget {
+                external_binding,
+            }) => {
                 meerkat_mob::PeerTarget::ExternalBinding(meerkat_mob::ExternalPeerBindingSpec::new(
                     external_binding.name,
                     external_binding.address,
                     external_binding.identity,
                 ))
             }
-            WireActionPeerTarget::External { external } => {
+            WireActionPeerTarget::External(WireActionExternalHandleTarget { external }) => {
                 if action == "wire" {
                     return Err("wire external peer requires external_binding".to_string());
                 }
@@ -3117,6 +3136,30 @@ mod tests {
         let msg = err.to_string();
         assert!(
             msg.contains("public_key") || msg.contains("identity") || msg.contains("did not match"),
+            "unexpected error: {msg}"
+        );
+    }
+
+    #[test]
+    fn wire_action_args_rejects_ambiguous_peer_target_shape() {
+        let err = serde_json::from_value::<WireActionPeerTarget>(json!({
+            "local": "worker-a",
+            "external_binding": {
+                "name": "external-worker",
+                "address": "inproc://external-worker",
+                "identity": {
+                    "kind": "ed25519_public_key",
+                    "public_key": ED25519_PUBLIC_KEY_7
+                }
+            }
+        }))
+        .expect_err("legacy wire action must not accept multiple peer target shapes");
+
+        let msg = err.to_string();
+        assert!(
+            msg.contains("did not match")
+                || msg.contains("unknown field")
+                || msg.contains("external_binding"),
             "unexpected error: {msg}"
         );
     }

--- a/meerkat-mob-mcp/src/public_mcp.rs
+++ b/meerkat-mob-mcp/src/public_mcp.rs
@@ -2,10 +2,10 @@
 
 use crate::{McpToolError, MobMcpState, decode_public_mob_definition};
 use meerkat_contracts::{
-    MobCreateParams, MobMemberSendParams, MobPeerTarget, MobUnwireParams, MobWireParams,
-    RealtimeCapabilities, RealtimeCapabilitiesParams, RealtimeCapabilitiesResult,
-    RealtimeChannelTarget, RealtimeOpenRequest, RealtimeStatusParams, RealtimeStatusResult,
-    WireContentInput, WireMobBackendKind, WireMobRuntimeMode, WireRuntimeBinding,
+    MobCreateParams, MobMemberSendParams, RealtimeCapabilities, RealtimeCapabilitiesParams,
+    RealtimeCapabilitiesResult, RealtimeChannelTarget, RealtimeOpenRequest, RealtimeStatusParams,
+    RealtimeStatusResult, WireContentInput, WireMobBackendKind, WireMobRuntimeMode,
+    WireRuntimeBinding, WireTrustedPeerIdentity,
 };
 use schemars::{JsonSchema, schema_for};
 use serde::Deserialize;
@@ -119,6 +119,50 @@ struct MeerkatMobRespawnInput {
     agent_identity: String,
     #[serde(default)]
     initial_message: Option<WireContentInput>,
+}
+
+#[derive(Debug, Deserialize, JsonSchema)]
+#[serde(deny_unknown_fields)]
+struct MeerkatMobWireInput {
+    mob_id: String,
+    member: String,
+    peer: MeerkatMobWirePeerTarget,
+}
+
+#[derive(Debug, Deserialize, JsonSchema)]
+#[serde(deny_unknown_fields)]
+struct MeerkatMobUnwireInput {
+    mob_id: String,
+    member: String,
+    peer: MeerkatMobUnwirePeerTarget,
+}
+
+#[derive(Debug, Deserialize, JsonSchema)]
+#[serde(rename_all = "snake_case")]
+enum MeerkatMobWirePeerTarget {
+    Local(String),
+    ExternalBinding(MeerkatExternalPeerBindingInput),
+}
+
+#[derive(Debug, Deserialize, JsonSchema)]
+#[serde(rename_all = "snake_case")]
+enum MeerkatMobUnwirePeerTarget {
+    Local(String),
+    External(MeerkatExternalPeerHandleInput),
+}
+
+#[derive(Debug, Deserialize, JsonSchema)]
+#[serde(deny_unknown_fields)]
+struct MeerkatExternalPeerBindingInput {
+    name: String,
+    address: String,
+    identity: WireTrustedPeerIdentity,
+}
+
+#[derive(Debug, Deserialize, JsonSchema)]
+#[serde(deny_unknown_fields)]
+struct MeerkatExternalPeerHandleInput {
+    name: String,
 }
 
 #[derive(Debug, Deserialize, JsonSchema)]
@@ -339,13 +383,13 @@ pub fn public_tools_list() -> Vec<Value> {
         ),
         tool(
             "meerkat_mob_wire",
-            "Wire a mob member to a local or external peer.",
-            schema_for!(MobWireParams),
+            "Wire a mob member to a local peer or typed external binding.",
+            schema_for!(MeerkatMobWireInput),
         ),
         tool(
             "meerkat_mob_unwire",
             "Remove a mob wiring relationship.",
-            schema_for!(MobUnwireParams),
+            schema_for!(MeerkatMobUnwireInput),
         ),
         tool(
             "meerkat_mob_member_send",
@@ -667,9 +711,9 @@ pub async fn handle_public_tools_call(
             }
         }
         "meerkat_mob_wire" => {
-            let input: MobWireParams = parse_args(arguments)?;
+            let input: MeerkatMobWireInput = parse_args(arguments)?;
             let mob_id = parse_mob_id(&input.mob_id)?;
-            let target = peer_target_from_wire(input.peer)?;
+            let target = wire_peer_target_from_wire(input.peer);
             state
                 .mob_wire(
                     &mob_id,
@@ -681,9 +725,9 @@ pub async fn handle_public_tools_call(
             Ok(json!({ "wired": true }))
         }
         "meerkat_mob_unwire" => {
-            let input: MobUnwireParams = parse_args(arguments)?;
+            let input: MeerkatMobUnwireInput = parse_args(arguments)?;
             let mob_id = parse_mob_id(&input.mob_id)?;
-            let target = peer_target_from_wire(input.peer)?;
+            let target = unwire_peer_target_from_wire(input.peer)?;
             state
                 .mob_unwire(
                     &mob_id,
@@ -915,12 +959,33 @@ fn content_input_from_wire(
     meerkat_core::types::ContentInput::try_from(input).map_err(McpToolError::invalid_params)
 }
 
-fn peer_target_from_wire(peer: MobPeerTarget) -> Result<meerkat_mob::PeerTarget, McpToolError> {
+fn wire_peer_target_from_wire(peer: MeerkatMobWirePeerTarget) -> meerkat_mob::PeerTarget {
     match peer {
-        MobPeerTarget::Local(member_id) => Ok(meerkat_mob::PeerTarget::Local(member_id.into())),
-        MobPeerTarget::External(spec) => crate::trusted_peer_descriptor_from_wire_spec(spec)
-            .map(meerkat_mob::PeerTarget::External)
-            .map_err(McpToolError::invalid_params),
+        MeerkatMobWirePeerTarget::Local(member_id) => {
+            meerkat_mob::PeerTarget::Local(member_id.into())
+        }
+        MeerkatMobWirePeerTarget::ExternalBinding(spec) => {
+            meerkat_mob::PeerTarget::ExternalBinding(meerkat_mob::ExternalPeerBindingSpec::new(
+                spec.name,
+                spec.address,
+                spec.identity,
+            ))
+        }
+    }
+}
+
+fn unwire_peer_target_from_wire(
+    peer: MeerkatMobUnwirePeerTarget,
+) -> Result<meerkat_mob::PeerTarget, McpToolError> {
+    match peer {
+        MeerkatMobUnwirePeerTarget::Local(member_id) => {
+            Ok(meerkat_mob::PeerTarget::Local(member_id.into()))
+        }
+        MeerkatMobUnwirePeerTarget::External(spec) => {
+            let peer_name = meerkat_core::comms::PeerName::new(spec.name)
+                .map_err(McpToolError::invalid_params)?;
+            Ok(meerkat_mob::PeerTarget::ExternalName(peer_name))
+        }
     }
 }
 
@@ -1018,9 +1083,9 @@ mod tests {
     const ED25519_PUBLIC_KEY_7: &str = "ed25519:BwcHBwcHBwcHBwcHBwcHBwcHBwcHBwcHBwcHBwcHBwc=";
     const ED25519_PUBLIC_KEY_ZERO: &str = "ed25519:AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=";
 
-    fn canonical_external_peer_target() -> meerkat_contracts::MobPeerTarget {
+    fn canonical_external_peer_target() -> MeerkatMobWirePeerTarget {
         serde_json::from_value(serde_json::json!({
-            "external": {
+            "external_binding": {
                 "name": "external-worker",
                 "address": "inproc://external-worker",
                 "identity": {
@@ -1030,16 +1095,6 @@ mod tests {
             }
         }))
         .expect("canonical external peer target should deserialize")
-    }
-
-    fn external_peer_target(public_key: &str) -> meerkat_contracts::MobPeerTarget {
-        meerkat_contracts::MobPeerTarget::External(meerkat_contracts::WireTrustedPeerSpec {
-            name: "external-worker".to_string(),
-            address: "inproc://external-worker".to_string(),
-            identity: meerkat_contracts::WireTrustedPeerIdentity::Ed25519PublicKey {
-                public_key: public_key.to_string(),
-            },
-        })
     }
 
     fn external_runtime_binding(public_key: &str) -> meerkat_contracts::WireRuntimeBinding {
@@ -1055,26 +1110,19 @@ mod tests {
     }
 
     #[test]
-    fn public_mcp_wire_accepts_canonical_external_peer_identity() {
-        let target = peer_target_from_wire(canonical_external_peer_target())
-            .expect("canonical external peer identity should resolve");
+    fn public_mcp_wire_accepts_typed_external_binding_request() {
+        let target = wire_peer_target_from_wire(canonical_external_peer_target());
 
-        let meerkat_mob::PeerTarget::External(descriptor) = target else {
-            panic!("canonical external peer should resolve to an external descriptor");
+        let meerkat_mob::PeerTarget::ExternalBinding(binding) = target else {
+            panic!("canonical external peer should remain a mob-resolved external binding");
         };
-        let pubkey = [7u8; 32];
-        assert_eq!(descriptor.name.as_str(), "external-worker");
-        assert_eq!(descriptor.address.to_string(), "inproc://external-worker");
-        assert_eq!(descriptor.pubkey, pubkey);
-        assert_eq!(
-            descriptor.peer_id,
-            meerkat_core::comms::PeerId::from_ed25519_pubkey(&pubkey)
-        );
+        assert_eq!(binding.name, "external-worker");
+        assert_eq!(binding.address, "inproc://external-worker");
     }
 
     #[test]
     fn public_mcp_wire_rejects_external_peer_raw_peer_id_shape() {
-        let err = serde_json::from_value::<meerkat_contracts::MobPeerTarget>(serde_json::json!({
+        let err = serde_json::from_value::<MeerkatMobWirePeerTarget>(serde_json::json!({
             "external": {
                 "name": "external-worker",
                 "peer_id": meerkat_core::comms::PeerId::from_ed25519_pubkey(&[7u8; 32]).to_string(),
@@ -1086,15 +1134,15 @@ mod tests {
 
         let msg = err.to_string();
         assert!(
-            msg.contains("peer_id") || msg.contains("identity"),
+            msg.contains("external") || msg.contains("external_binding"),
             "unexpected error: {msg}"
         );
     }
 
     #[test]
     fn public_mcp_wire_rejects_external_peer_missing_pubkey_material() {
-        let err = serde_json::from_value::<meerkat_contracts::MobPeerTarget>(serde_json::json!({
-            "external": {
+        let err = serde_json::from_value::<MeerkatMobWirePeerTarget>(serde_json::json!({
+            "external_binding": {
                 "name": "external-worker",
                 "address": "inproc://external-worker",
                 "identity": {
@@ -1112,26 +1160,35 @@ mod tests {
     }
 
     #[test]
-    fn public_mcp_wire_rejects_external_peer_zero_pubkey() {
-        let err = peer_target_from_wire(external_peer_target(ED25519_PUBLIC_KEY_ZERO))
-            .expect_err("zero pubkey external peers must be rejected");
+    fn public_mcp_unwire_accepts_external_peer_name_handle() {
+        let target = unwire_peer_target_from_wire(
+            serde_json::from_value::<MeerkatMobUnwirePeerTarget>(serde_json::json!({
+                "external": { "name": "external-worker" }
+            }))
+            .expect("external handle should deserialize"),
+        )
+        .expect("external handle should convert");
 
-        assert!(
-            err.message.contains("public_key") || err.message.contains("non-zero"),
-            "expected pubkey validation error, got: {}",
-            err.message
-        );
+        let meerkat_mob::PeerTarget::ExternalName(peer_name) = target else {
+            panic!("unwire external should use the external peer handle");
+        };
+        assert_eq!(peer_name.as_str(), "external-worker");
     }
 
     #[test]
-    fn public_mcp_wire_rejects_invalid_external_peer_identity() {
-        let err = peer_target_from_wire(external_peer_target("not-a-typed-public-key"))
-            .expect_err("invalid canonical external peer identity must be rejected");
+    fn public_mcp_wire_schema_uses_external_binding_without_raw_peer_atoms() {
+        let tools = public_tools_list();
+        let schema = tools
+            .iter()
+            .find(|tool| tool["name"] == "meerkat_mob_wire")
+            .and_then(|tool| tool.get("inputSchema"))
+            .expect("wire schema present");
+        let schema_text = serde_json::to_string(schema).expect("schema should encode");
 
+        assert!(schema_text.contains("external_binding"));
         assert!(
-            err.message.contains("public_key") || err.message.contains("ed25519"),
-            "expected typed identity validation error, got: {}",
-            err.message
+            !schema_text.contains("\"peer_id\"") && !schema_text.contains("\"pubkey\""),
+            "wire schema must not expose raw comms identity atoms: {schema_text}"
         );
     }
 

--- a/meerkat-mob/src/lib.rs
+++ b/meerkat-mob/src/lib.rs
@@ -123,16 +123,17 @@ pub use runtime::bridge_protocol::{
 };
 #[cfg(feature = "runtime-adapter")]
 pub use runtime::local_bridge::LocalMobRuntimeBridge;
+pub use runtime::{
+    ExternalPeerBindingSpec, HelperOptions, HelperResult, MemberDeliveryReceipt, MemberHandle,
+    MemberRespawnReceipt, MobBuilder, MobDestroyError, MobDestroyReport, MobEventRouterConfig,
+    MobEventRouterHandle, MobEventsSubscription, MobEventsSubscriptionConfig, MobHandle,
+    MobMemberSnapshot, MobMemberStatus, MobPeerConnectivitySnapshot, MobRespawnError,
+    MobSessionService, MobState, MobUnreachablePeer, PeerTarget, PreviousMemberCleanupReport,
+    SpawnMemberSpec, SpawnPolicy, SpawnResult, SpawnSpec, SupervisorRotationReport,
+    WorkDeliveryReceipt,
+};
 pub use runtime::{FlowFrameKernel, FlowFrameMutator};
 pub use runtime::{FlowTurnExecutor, FlowTurnOutcome, FlowTurnTicket, TimeoutDisposition};
-pub use runtime::{
-    HelperOptions, HelperResult, MemberDeliveryReceipt, MemberHandle, MemberRespawnReceipt,
-    MobBuilder, MobDestroyError, MobDestroyReport, MobEventRouterConfig, MobEventRouterHandle,
-    MobEventsSubscription, MobEventsSubscriptionConfig, MobHandle, MobMemberSnapshot,
-    MobMemberStatus, MobPeerConnectivitySnapshot, MobRespawnError, MobSessionService, MobState,
-    MobUnreachablePeer, PeerTarget, PreviousMemberCleanupReport, SpawnMemberSpec, SpawnPolicy,
-    SpawnResult, SpawnSpec, SupervisorRotationReport, WorkDeliveryReceipt,
-};
 pub use runtime_mode::MobRuntimeMode;
 pub use snapshot::ParentToolScopeSnapshot;
 pub use spec::SpecValidator;

--- a/meerkat-mob/src/runtime/actor.rs
+++ b/meerkat-mob/src/runtime/actor.rs
@@ -18,7 +18,9 @@ use crate::run::{MobMachineFlowAuthorityToken, MobMachineFlowRunCommand, MobRunS
 use crate::tokio;
 use futures::FutureExt;
 use futures::stream::{FuturesUnordered, StreamExt};
-use meerkat_core::comms::{PeerLifecycleKind, PeerRoute, TrustedPeerDescriptor};
+use meerkat_core::comms::{
+    PeerAddress, PeerLifecycleKind, PeerName, PeerRoute, TrustedPeerDescriptor,
+};
 use meerkat_core::time_compat::SystemTime;
 use serde::de::DeserializeOwned;
 use std::collections::{BTreeMap, HashMap, HashSet, VecDeque};
@@ -5551,10 +5553,13 @@ impl MobActor {
     /// 5. Append `MembersWired` event and project it through the roster.
     ///    Append failure also rolls back trust + DSL wire.
     ///
-    /// External peer targets ([`PeerTarget::External`]) are routed to
-    /// [`Self::handle_wire_external`], whose descriptor-bearing trust edge is
-    /// admitted by `MobMachineInput::WireExternalPeer` instead of being
-    /// coerced into a member `WiringEdge`.
+    /// External peer targets are routed to [`Self::handle_wire_external`],
+    /// whose descriptor-bearing trust edge is admitted by
+    /// `MobMachineInput::WireExternalPeer` instead of being coerced into a
+    /// member `WiringEdge`. Public surfaces should pass
+    /// [`PeerTarget::ExternalBinding`], which this actor resolves before trust
+    /// installation; pre-resolved [`PeerTarget::External`] is retained for
+    /// internal callers and tests.
     async fn handle_wire(
         &mut self,
         local: MeerkatId,
@@ -5562,6 +5567,15 @@ impl MobActor {
     ) -> Result<(), MobError> {
         let peer_identity = match target {
             super::handle::PeerTarget::Local(id) => id,
+            super::handle::PeerTarget::ExternalName(name) => {
+                return Err(MobError::WiringError(format!(
+                    "wire external peer '{name}' requires external_binding"
+                )));
+            }
+            super::handle::PeerTarget::ExternalBinding(binding) => {
+                let descriptor = Self::trusted_peer_descriptor_from_external_binding(binding)?;
+                return self.handle_wire_external(local, descriptor).await;
+            }
             super::handle::PeerTarget::External(descriptor) => {
                 return self.handle_wire_external(local, descriptor).await;
             }
@@ -6203,13 +6217,18 @@ impl MobActor {
                 }
                 id
             }
+            super::handle::PeerTarget::ExternalName(peer_name) => {
+                return self.handle_unwire_external(local, peer_name, None).await;
+            }
+            super::handle::PeerTarget::ExternalBinding(binding) => {
+                let descriptor = Self::trusted_peer_descriptor_from_external_binding(binding)?;
+                let peer_name = descriptor.name.clone();
+                return self
+                    .handle_unwire_external(local, peer_name, Some(descriptor))
+                    .await;
+            }
             super::handle::PeerTarget::External(descriptor) => {
-                let peer_name = meerkat_core::comms::PeerName::new(descriptor.name.clone())
-                    .map_err(|error| {
-                        MobError::WiringError(format!(
-                            "unwire external peer has invalid peer name: {error}",
-                        ))
-                    })?;
+                let peer_name = descriptor.name.clone();
                 return self
                     .handle_unwire_external(local, peer_name, Some(descriptor))
                     .await;
@@ -6769,6 +6788,33 @@ impl MobActor {
                 );
             }
         }
+    }
+
+    fn trusted_peer_descriptor_from_external_binding(
+        binding: super::handle::ExternalPeerBindingSpec,
+    ) -> Result<TrustedPeerDescriptor, MobError> {
+        let name = PeerName::new(binding.name.clone()).map_err(|error| {
+            MobError::WiringError(format!(
+                "external binding has invalid peer name '{}': {error}",
+                binding.name
+            ))
+        })?;
+        let resolved = binding
+            .identity
+            .resolve()
+            .map_err(|error| MobError::WiringError(error.to_string()))?;
+        let address = PeerAddress::parse(&binding.address).map_err(|error| {
+            MobError::WiringError(format!(
+                "external binding has invalid peer address '{}': {error}",
+                binding.address
+            ))
+        })?;
+        Ok(TrustedPeerDescriptor {
+            name,
+            peer_id: resolved.peer_id,
+            address,
+            pubkey: resolved.pubkey,
+        })
     }
 
     /// Wire a local member to an external trusted peer.

--- a/meerkat-mob/src/runtime/handle.rs
+++ b/meerkat-mob/src/runtime/handle.rs
@@ -684,8 +684,39 @@ pub struct HelperResult {
 pub enum PeerTarget {
     /// Another member in the same mob roster.
     Local(AgentIdentity),
+    /// External peer handle for operations that only need the mob-owned edge.
+    ExternalName(meerkat_core::comms::PeerName),
+    /// A typed external binding request resolved by the mob actor before trust install.
+    ExternalBinding(ExternalPeerBindingSpec),
     /// A trusted peer that lives outside the local mob roster.
     External(TrustedPeerDescriptor),
+}
+
+/// Typed request to bind a local member to an external peer.
+///
+/// App-facing surfaces provide this shape instead of comms-owned `peer_id` /
+/// `pubkey` atoms. The mob actor resolves the evidence into a
+/// `TrustedPeerDescriptor` immediately before the machine admits the external
+/// edge and before any trust is installed.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ExternalPeerBindingSpec {
+    pub name: String,
+    pub address: String,
+    pub identity: meerkat_contracts::WireTrustedPeerIdentity,
+}
+
+impl ExternalPeerBindingSpec {
+    pub fn new(
+        name: impl Into<String>,
+        address: impl Into<String>,
+        identity: meerkat_contracts::WireTrustedPeerIdentity,
+    ) -> Self {
+        Self {
+            name: name.into(),
+            address: address.into(),
+            identity,
+        }
+    }
 }
 
 // DELETE_ME A5 DSL-schema migration: `MeerkatId` is now a type alias

--- a/meerkat-mob/src/runtime/mod.rs
+++ b/meerkat-mob/src/runtime/mod.rs
@@ -124,9 +124,9 @@ pub(crate) use handle::{CanonicalOpsOwnerContext, MemberSpawnReceipt};
 pub use handle::{
     ExternalMemberBindingMode, ExternalMemberForwardingHookRef, ExternalMemberForwardingHooks,
     ExternalMemberForwardingStatus, ExternalMemberObservationSnapshot, ExternalMemberOwnerRef,
-    ExternalMemberReachability, ExternalMemberRebindStatus, HelperOptions, HelperResult,
-    MemberDeliveryReceipt, MemberHandle, MemberRespawnReceipt, MobDestroyError, MobDestroyReport,
-    MobEventsSubscription, MobEventsSubscriptionConfig, MobEventsView, MobHandle,
+    ExternalMemberReachability, ExternalMemberRebindStatus, ExternalPeerBindingSpec, HelperOptions,
+    HelperResult, MemberDeliveryReceipt, MemberHandle, MemberRespawnReceipt, MobDestroyError,
+    MobDestroyReport, MobEventsSubscription, MobEventsSubscriptionConfig, MobEventsView, MobHandle,
     MobMemberListEntry, MobMemberSnapshot, MobMemberStatus, MobPeerConnectivitySnapshot,
     MobRespawnError, MobUnreachablePeer, PeerTarget, PreviousMemberCleanupReport, SpawnMemberSpec,
     SpawnResult, SupervisorRotationReport, WorkDeliveryReceipt,

--- a/meerkat-mob/src/runtime/tests.rs
+++ b/meerkat-mob/src/runtime/tests.rs
@@ -11724,6 +11724,106 @@ async fn test_unwire_external_removes_trust_and_projection() {
     );
 }
 
+const ED25519_PUBLIC_KEY_7: &str = "ed25519:BwcHBwcHBwcHBwcHBwcHBwcHBwcHBwcHBwcHBwcHBwc=";
+const ED25519_PUBLIC_KEY_ZERO: &str = "ed25519:AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=";
+
+fn external_binding_peer_target(public_key: &str) -> PeerTarget {
+    PeerTarget::ExternalBinding(ExternalPeerBindingSpec::new(
+        "external-worker",
+        "inproc://external-worker",
+        meerkat_contracts::WireTrustedPeerIdentity::Ed25519PublicKey {
+            public_key: public_key.to_string(),
+        },
+    ))
+}
+
+#[tokio::test]
+async fn test_wire_external_binding_resolves_inside_mob_authority() {
+    let (handle, service) = create_test_mob(sample_definition()).await;
+    let sid_l = handle
+        .spawn(
+            ProfileName::from("lead"),
+            MeerkatId::from("l-binding"),
+            None,
+        )
+        .await
+        .expect("spawn lead")
+        .bridge_session_id()
+        .expect("session-backed")
+        .clone();
+
+    handle
+        .wire(
+            AgentIdentity::from("l-binding"),
+            external_binding_peer_target(ED25519_PUBLIC_KEY_7),
+        )
+        .await
+        .expect("wire external binding");
+
+    let entry = handle
+        .get_member(&AgentIdentity::from("l-binding"))
+        .await
+        .expect("member should exist");
+    let descriptor = entry
+        .external_peer_specs
+        .get(&AgentIdentity::from("external-worker"))
+        .expect("external binding should project descriptor");
+    let expected_pubkey = [7u8; 32];
+    assert_eq!(descriptor.pubkey, expected_pubkey);
+    assert_eq!(
+        descriptor.peer_id,
+        PeerId::from_ed25519_pubkey(&expected_pubkey)
+    );
+
+    let trusted = service.trusted_peer_names(&sid_l).await;
+    assert!(
+        trusted.iter().any(|name| name == "external-worker"),
+        "mob authority should install trust after resolving external binding"
+    );
+}
+
+#[tokio::test]
+async fn test_wire_external_binding_rejects_zero_pubkey_before_trust_install() {
+    let (handle, service) = create_test_mob(sample_definition()).await;
+    let sid_l = handle
+        .spawn(ProfileName::from("lead"), MeerkatId::from("l-zero"), None)
+        .await
+        .expect("spawn lead")
+        .bridge_session_id()
+        .expect("session-backed")
+        .clone();
+
+    let err = handle
+        .wire(
+            AgentIdentity::from("l-zero"),
+            external_binding_peer_target(ED25519_PUBLIC_KEY_ZERO),
+        )
+        .await
+        .expect_err("zero pubkey external binding must fail closed");
+    let message = err.to_string();
+    assert!(
+        message.contains("public_key") || message.contains("non-zero"),
+        "expected pubkey validation error, got: {message}"
+    );
+
+    let entry = handle
+        .get_member(&AgentIdentity::from("l-zero"))
+        .await
+        .expect("member should exist");
+    assert!(
+        !entry
+            .external_peer_specs
+            .contains_key(&AgentIdentity::from("external-worker")),
+        "failed external binding must not project an external edge"
+    );
+
+    let trusted = service.trusted_peer_names(&sid_l).await;
+    assert!(
+        !trusted.iter().any(|name| name == "external-worker"),
+        "failed external binding must not install comms trust"
+    );
+}
+
 #[tokio::test]
 async fn test_resume_seeds_mob_machine_topology_from_event_projection() {
     let service = Arc::new(MockSessionService::new());


### PR DESCRIPTION
## Summary
- replace MCP external mob wiring descriptor inputs with typed external_binding requests and external-name handles for unwire
- resolve external binding evidence inside the mob actor immediately before machine admission/trust install
- add MCP schema and mob runtime tests for raw atom rejection and zero-pubkey fail-closed behavior

## Validation
- ./scripts/repo-cargo test -p meerkat-mob-mcp external_peer
- ./scripts/repo-cargo test -p meerkat-mob-mcp external_binding
- ./scripts/repo-cargo test -p meerkat-mob-mcp
- ./scripts/repo-cargo test -p meerkat-mob test_wire_external_binding
- ./scripts/repo-cargo test -p meerkat-mob test_unwire_external
- make check

Linear: LUC-155