### PR TITLE
Make Claude PR review post a visible report

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -3,21 +3,9 @@ name: Claude Code Review
 on:
   pull_request:
     types: [opened, synchronize, ready_for_review, reopened]
-    # Optional: Only run on specific file changes
-    # paths:
-    #   - "src/**/*.ts"
-    #   - "src/**/*.tsx"
-    #   - "src/**/*.js"
-    #   - "src/**/*.jsx"
 
 jobs:
   claude-review:
-    # Optional: Filter by PR author
-    # if: |
-    #   github.event.pull_request.user.login == 'external-contributor' ||
-    #   github.event.pull_request.user.login == 'new-developer' ||
-    #   github.event.pull_request.author_association == 'FIRST_TIME_CONTRIBUTOR'
-
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -39,6 +27,6 @@ jobs:
           plugin_marketplaces: 'https://github.com/anthropics/claude-code.git'
           plugins: 'code-review@claude-code-plugins'
           prompt: '/code-review:code-review ${{ github.repository }}/pull/${{ github.event.pull_request.number }}'
-          # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
-          # or https://code.claude.com/docs/en/cli-reference for available options
-
+          display_report: true
+          use_sticky_comment: true
+          show_full_output: false


### PR DESCRIPTION
## Summary
- Keep the always-on Claude Code Review pull_request workflow
- Configure it to post an auditable PR report via `display_report: true` and `use_sticky_comment: true`
- Keep `show_full_output: false` so raw execution logs stay hidden

## Rationale
The previous configuration could spend several minutes and API tokens, exit green, and produce no GitHub review, comment, inline comment, or visible report when it found no inline comments. That made the check unauditable as a review gate.

## Validation
- Inspected run logs from PR #490: action ran with `display_report=false`, `show_full_output=false`, `use_sticky_comment=false`, and posted no review artifact.
- `git diff --check` passed.
- Push hooks passed YAML validation and repo gates for this workflow-only change.