### PR TITLE
LUC-154 Type peer directory wire facts

### DIFF
--- a/artifacts/schemas/rest-openapi.json
+++ b/artifacts/schemas/rest-openapi.json
@@ -690,87 +690,6 @@
         "title": "CommsParams",
         "type": "object"
       },
-      "CommsPeerEntry": {
-        "description": "One peer entry in the `comms/peers` response.",
-        "properties": {
-          "address": {
-            "$ref": "#/components/schemas/PeerAddress"
-          },
-          "capabilities": true,
-          "last_unreachable_reason": {
-            "anyOf": [
-              {
-                "$ref": "#/components/schemas/CommsPeerUnreachableReason"
-              },
-              {
-                "type": "null"
-              }
-            ]
-          },
-          "meta": {
-            "$ref": "#/components/schemas/PeerMeta"
-          },
-          "name": {
-            "$ref": "#/components/schemas/PeerName"
-          },
-          "peer_id": {
-            "$ref": "#/components/schemas/PeerId"
-          },
-          "reachability": {
-            "$ref": "#/components/schemas/CommsPeerReachability"
-          },
-          "sendable_kinds": {
-            "items": {
-              "type": "string"
-            },
-            "type": "array"
-          },
-          "source": {
-            "$ref": "#/components/schemas/CommsPeerSource"
-          }
-        },
-        "required": [
-          "name",
-          "peer_id",
-          "address",
-          "source",
-          "sendable_kinds",
-          "capabilities",
-          "reachability",
-          "meta"
-        ],
-        "title": "CommsPeerEntry",
-        "type": "object"
-      },
-      "CommsPeerReachability": {
-        "description": "Stable public reachability labels for `comms/peers` entries.",
-        "enum": [
-          "unknown",
-          "reachable",
-          "unreachable"
-        ],
-        "type": "string"
-      },
-      "CommsPeerSource": {
-        "description": "Stable public source labels for `comms/peers` entries.",
-        "enum": [
-          "Trusted",
-          "Inproc",
-          "TrustedAndInproc",
-          "Unknown"
-        ],
-        "type": "string"
-      },
-      "CommsPeerUnreachableReason": {
-        "description": "Stable public unreachable-reason labels for `comms/peers` entries.",
-        "enum": [
-          "offline_or_no_ack",
-          "transport_error",
-          "admission_dropped",
-          "unknown"
-        ],
-        "type": "string"
-      },
       "CommsPeersParams": {
         "additionalProperties": false,
         "description": "Request payload for `comms/peers`.",
@@ -790,7 +709,7 @@
         "properties": {
           "peers": {
             "items": {
-              "$ref": "#/components/schemas/CommsPeerEntry"
+              "$ref": "#/components/schemas/PeerDirectoryEntry"
             },
             "type": "array"
           }
@@ -6500,8 +6419,106 @@
         ],
         "type": "object"
       },
+      "PeerCapabilitySet": {
+        "description": "Typed peer capability envelope for peer-directory output.\n\nExtensions are intentionally opaque display/integration metadata. Core\nrouting, admission, and policy decisions must use typed fields such as\n[`PeerDirectoryEntry::sendable_kinds`] instead of consulting this bag.",
+        "properties": {
+          "extensions": {
+            "additionalProperties": true,
+            "default": {},
+            "type": "object"
+          },
+          "version": {
+            "default": 1,
+            "format": "uint16",
+            "maximum": 65535,
+            "minimum": 0,
+            "type": "integer"
+          }
+        },
+        "type": "object"
+      },
       "PeerCorrelationId": {
         "description": "Canonical correlation identifier for the peer request/response lifecycle.\n\nOn the sender side, `PeerCorrelationId` is both the outbound request\nenvelope id and the reservation key for any stream subscription. On the\nreceiver side, every response envelope carries it as `in_reply_to`. The\nsender routes a reply back to its originating request by matching on this\nid — no local id-translation map.\n\nWrapping it in a newtype prevents raw-`Uuid` confusion at every site that\nfires a DSL input, inserts into the subscriber registry, or closes out an\ninbound request.",
+        "type": "string"
+      },
+      "PeerDirectoryEntry": {
+        "properties": {
+          "address": {
+            "$ref": "#/components/schemas/PeerAddress",
+            "description": "Typed transport atom + endpoint. Replaces the prior free-form\n`address: String` so the transport cannot be invented by string\nconcatenation at a call site."
+          },
+          "capabilities": {
+            "$ref": "#/components/schemas/PeerCapabilitySet"
+          },
+          "last_unreachable_reason": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/PeerReachabilityReason"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "meta": {
+            "$ref": "#/components/schemas/PeerMeta",
+            "description": "Supplementary discovery metadata (description, labels)."
+          },
+          "name": {
+            "$ref": "#/components/schemas/PeerName",
+            "description": "Display-only slug. Multiple entries may share a name; none share a\n`peer_id`."
+          },
+          "peer_id": {
+            "$ref": "#/components/schemas/PeerId",
+            "description": "Canonical runtime identity — the routing key."
+          },
+          "reachability": {
+            "$ref": "#/components/schemas/PeerReachability"
+          },
+          "sendable_kinds": {
+            "items": {
+              "$ref": "#/components/schemas/PeerSendability"
+            },
+            "type": "array"
+          },
+          "source": {
+            "$ref": "#/components/schemas/PeerDirectorySource"
+          }
+        },
+        "required": [
+          "peer_id",
+          "name",
+          "address",
+          "source",
+          "sendable_kinds",
+          "capabilities",
+          "reachability",
+          "meta"
+        ],
+        "type": "object"
+      },
+      "PeerDirectoryListing": {
+        "properties": {
+          "peers": {
+            "items": {
+              "$ref": "#/components/schemas/PeerDirectoryEntry"
+            },
+            "type": "array"
+          }
+        },
+        "required": [
+          "peers"
+        ],
+        "title": "PeerDirectoryListing",
+        "type": "object"
+      },
+      "PeerDirectorySource": {
+        "enum": [
+          "trusted",
+          "inproc",
+          "trusted_and_inproc",
+          "unknown"
+        ],
         "type": "string"
       },
       "PeerId": {
@@ -6541,6 +6558,30 @@
         "description": "Display-only slug for a peer.\n\n`PeerName` is **not** a routing key after Wave-B V5: the router resolves\nsends by [`PeerId`], and trust stores are keyed by [`PeerId`]. `PeerName`\nis retained so human-facing surfaces (CLI, REST `comms.peers`, logs) can\nrender a recognisable handle next to the opaque id.",
         "type": "string"
       },
+      "PeerReachability": {
+        "enum": [
+          "unknown",
+          "reachable",
+          "unreachable"
+        ],
+        "type": "string"
+      },
+      "PeerReachabilityReason": {
+        "oneOf": [
+          {
+            "enum": [
+              "offline_or_no_ack",
+              "transport_error"
+            ],
+            "type": "string"
+          },
+          {
+            "const": "admission_dropped",
+            "description": "The peer admitted the transport but rejected our envelope at its\ningress policy gate (untrusted sender, full inbox, etc.). The peer\nis still reachable at the transport level; policy denied us.",
+            "type": "string"
+          }
+        ]
+      },
       "PeerResponseTerminalStatusWire": {
         "description": "Terminal status for dedicated correlated peer-response ingress.",
         "enum": [
@@ -6549,6 +6590,14 @@
           "cancelled"
         ],
         "title": "PeerResponseTerminalStatusWire",
+        "type": "string"
+      },
+      "PeerSendability": {
+        "enum": [
+          "peer_message",
+          "peer_request",
+          "peer_response"
+        ],
         "type": "string"
       },
       "PeerTransport": {
@@ -15490,7 +15539,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/JsonValue"
+                  "$ref": "#/components/schemas/CommsPeersResult"
                 }
               }
             },

--- a/artifacts/schemas/wire-types.json
+++ b/artifacts/schemas/wire-types.json
@@ -404,37 +404,8 @@
     ],
     "title": "CommsCommandRequest"
   },
-  "CommsPeerEntry": {
+  "CommsPeersResult": {
     "$defs": {
-      "CommsPeerReachability": {
-        "description": "Stable public reachability labels for `comms/peers` entries.",
-        "enum": [
-          "unknown",
-          "reachable",
-          "unreachable"
-        ],
-        "type": "string"
-      },
-      "CommsPeerSource": {
-        "description": "Stable public source labels for `comms/peers` entries.",
-        "enum": [
-          "Trusted",
-          "Inproc",
-          "TrustedAndInproc",
-          "Unknown"
-        ],
-        "type": "string"
-      },
-      "CommsPeerUnreachableReason": {
-        "description": "Stable public unreachable-reason labels for `comms/peers` entries.",
-        "enum": [
-          "offline_or_no_ack",
-          "transport_error",
-          "admission_dropped",
-          "unknown"
-        ],
-        "type": "string"
-      },
       "PeerAddress": {
         "description": "Typed peer address: transport atom plus endpoint string.\n\nThe `endpoint` is transport-specific (path for `Uds`, `host:port` for\n`Tcp`, agent name for `Inproc`) but is carried as a validated `String`\nso the transport atom can be branched on without re-parsing.",
         "properties": {
@@ -451,155 +422,37 @@
         ],
         "type": "object"
       },
-      "PeerId": {
-        "description": "Canonical runtime identity for a peer.\n\n`PeerId` is the routing key: the router and trust store key by `PeerId`,\nnever by `PeerName`. Two peers may legitimately share a display `PeerName`\n(per the Wave-B V5 dogma note), but their `PeerId`s never collide — the\nunderlying UUID is globally unique.\n\nConstructed freshly (`PeerId::new`) for a peer minted locally, parsed\nfrom a hyphenated UUID (`PeerId::parse`) when we've been given an identity\nover the wire, or derived from a 32-byte Ed25519 public key when a transport\nstill authenticates by raw signing key.",
-        "type": "string"
-      },
-      "PeerMeta": {
-        "description": "Supplementary metadata attached to a peer for discovery.\n\nThe peer's routing name lives in `TrustedPeer.name` / `comms_name`.\n`PeerMeta` carries additional context: what the agent does and\narbitrary key/value labels.\n\n# Serde\n\nBoth fields use `skip_serializing_if`, so `PeerMeta::default()`\nserializes to `{}`.",
+      "PeerCapabilitySet": {
+        "description": "Typed peer capability envelope for peer-directory output.\n\nExtensions are intentionally opaque display/integration metadata. Core\nrouting, admission, and policy decisions must use typed fields such as\n[`PeerDirectoryEntry::sendable_kinds`] instead of consulting this bag.",
         "properties": {
-          "description": {
-            "description": "What this agent does (e.g. \"Reviews pull requests for style issues\").",
-            "type": [
-              "string",
-              "null"
-            ]
-          },
-          "labels": {
-            "additionalProperties": {
-              "type": "string"
-            },
-            "description": "Arbitrary key/value labels (e.g. `{\"lang\": \"rust\", \"team\": \"infra\"}`).\n\n`BTreeMap` keeps keys sorted for deterministic serialization.",
+          "extensions": {
+            "additionalProperties": true,
+            "default": {},
             "type": "object"
+          },
+          "version": {
+            "default": 1,
+            "format": "uint16",
+            "maximum": 65535,
+            "minimum": 0,
+            "type": "integer"
           }
         },
         "type": "object"
       },
-      "PeerName": {
-        "description": "Display-only slug for a peer.\n\n`PeerName` is **not** a routing key after Wave-B V5: the router resolves\nsends by [`PeerId`], and trust stores are keyed by [`PeerId`]. `PeerName`\nis retained so human-facing surfaces (CLI, REST `comms.peers`, logs) can\nrender a recognisable handle next to the opaque id.",
-        "type": "string"
-      },
-      "PeerTransport": {
-        "description": "Typed transport atom for a peer address.\n\nReplaces the old free-form `address: String` on `PeerDirectoryEntry` so\ncallers cannot accidentally invent new transports by string concatenation\nat a call site.",
-        "oneOf": [
-          {
-            "const": "inproc",
-            "description": "In-process routing within this runtime (no network hop).",
-            "type": "string"
-          },
-          {
-            "const": "uds",
-            "description": "Unix domain socket.",
-            "type": "string"
-          },
-          {
-            "const": "tcp",
-            "description": "TCP endpoint.",
-            "type": "string"
-          }
-        ]
-      }
-    },
-    "$schema": "https://json-schema.org/draft/2020-12/schema",
-    "description": "One peer entry in the `comms/peers` response.",
-    "properties": {
-      "address": {
-        "$ref": "#/$defs/PeerAddress"
-      },
-      "capabilities": true,
-      "last_unreachable_reason": {
-        "anyOf": [
-          {
-            "$ref": "#/$defs/CommsPeerUnreachableReason"
-          },
-          {
-            "type": "null"
-          }
-        ]
-      },
-      "meta": {
-        "$ref": "#/$defs/PeerMeta"
-      },
-      "name": {
-        "$ref": "#/$defs/PeerName"
-      },
-      "peer_id": {
-        "$ref": "#/$defs/PeerId"
-      },
-      "reachability": {
-        "$ref": "#/$defs/CommsPeerReachability"
-      },
-      "sendable_kinds": {
-        "items": {
-          "type": "string"
-        },
-        "type": "array"
-      },
-      "source": {
-        "$ref": "#/$defs/CommsPeerSource"
-      }
-    },
-    "required": [
-      "name",
-      "peer_id",
-      "address",
-      "source",
-      "sendable_kinds",
-      "capabilities",
-      "reachability",
-      "meta"
-    ],
-    "title": "CommsPeerEntry",
-    "type": "object"
-  },
-  "CommsPeerReachability": {
-    "$schema": "https://json-schema.org/draft/2020-12/schema",
-    "description": "Stable public reachability labels for `comms/peers` entries.",
-    "enum": [
-      "unknown",
-      "reachable",
-      "unreachable"
-    ],
-    "title": "CommsPeerReachability",
-    "type": "string"
-  },
-  "CommsPeerSource": {
-    "$schema": "https://json-schema.org/draft/2020-12/schema",
-    "description": "Stable public source labels for `comms/peers` entries.",
-    "enum": [
-      "Trusted",
-      "Inproc",
-      "TrustedAndInproc",
-      "Unknown"
-    ],
-    "title": "CommsPeerSource",
-    "type": "string"
-  },
-  "CommsPeerUnreachableReason": {
-    "$schema": "https://json-schema.org/draft/2020-12/schema",
-    "description": "Stable public unreachable-reason labels for `comms/peers` entries.",
-    "enum": [
-      "offline_or_no_ack",
-      "transport_error",
-      "admission_dropped",
-      "unknown"
-    ],
-    "title": "CommsPeerUnreachableReason",
-    "type": "string"
-  },
-  "CommsPeersResult": {
-    "$defs": {
-      "CommsPeerEntry": {
-        "description": "One peer entry in the `comms/peers` response.",
+      "PeerDirectoryEntry": {
         "properties": {
           "address": {
-            "$ref": "#/$defs/PeerAddress"
+            "$ref": "#/$defs/PeerAddress",
+            "description": "Typed transport atom + endpoint. Replaces the prior free-form\n`address: String` so the transport cannot be invented by string\nconcatenation at a call site."
           },
-          "capabilities": true,
+          "capabilities": {
+            "$ref": "#/$defs/PeerCapabilitySet"
+          },
           "last_unreachable_reason": {
             "anyOf": [
               {
-                "$ref": "#/$defs/CommsPeerUnreachableReason"
+                "$ref": "#/$defs/PeerReachabilityReason"
               },
               {
                 "type": "null"
@@ -607,30 +460,33 @@
             ]
           },
           "meta": {
-            "$ref": "#/$defs/PeerMeta"
+            "$ref": "#/$defs/PeerMeta",
+            "description": "Supplementary discovery metadata (description, labels)."
           },
           "name": {
-            "$ref": "#/$defs/PeerName"
+            "$ref": "#/$defs/PeerName",
+            "description": "Display-only slug. Multiple entries may share a name; none share a\n`peer_id`."
           },
           "peer_id": {
-            "$ref": "#/$defs/PeerId"
+            "$ref": "#/$defs/PeerId",
+            "description": "Canonical runtime identity — the routing key."
           },
           "reachability": {
-            "$ref": "#/$defs/CommsPeerReachability"
+            "$ref": "#/$defs/PeerReachability"
           },
           "sendable_kinds": {
             "items": {
-              "type": "string"
+              "$ref": "#/$defs/PeerSendability"
             },
             "type": "array"
           },
           "source": {
-            "$ref": "#/$defs/CommsPeerSource"
+            "$ref": "#/$defs/PeerDirectorySource"
           }
         },
         "required": [
-          "name",
           "peer_id",
+          "name",
           "address",
           "source",
           "sendable_kinds",
@@ -640,50 +496,14 @@
         ],
         "type": "object"
       },
-      "CommsPeerReachability": {
-        "description": "Stable public reachability labels for `comms/peers` entries.",
+      "PeerDirectorySource": {
         "enum": [
-          "unknown",
-          "reachable",
-          "unreachable"
-        ],
-        "type": "string"
-      },
-      "CommsPeerSource": {
-        "description": "Stable public source labels for `comms/peers` entries.",
-        "enum": [
-          "Trusted",
-          "Inproc",
-          "TrustedAndInproc",
-          "Unknown"
-        ],
-        "type": "string"
-      },
-      "CommsPeerUnreachableReason": {
-        "description": "Stable public unreachable-reason labels for `comms/peers` entries.",
-        "enum": [
-          "offline_or_no_ack",
-          "transport_error",
-          "admission_dropped",
+          "trusted",
+          "inproc",
+          "trusted_and_inproc",
           "unknown"
         ],
         "type": "string"
-      },
-      "PeerAddress": {
-        "description": "Typed peer address: transport atom plus endpoint string.\n\nThe `endpoint` is transport-specific (path for `Uds`, `host:port` for\n`Tcp`, agent name for `Inproc`) but is carried as a validated `String`\nso the transport atom can be branched on without re-parsing.",
-        "properties": {
-          "endpoint": {
-            "type": "string"
-          },
-          "transport": {
-            "$ref": "#/$defs/PeerTransport"
-          }
-        },
-        "required": [
-          "transport",
-          "endpoint"
-        ],
-        "type": "object"
       },
       "PeerId": {
         "description": "Canonical runtime identity for a peer.\n\n`PeerId` is the routing key: the router and trust store key by `PeerId`,\nnever by `PeerName`. Two peers may legitimately share a display `PeerName`\n(per the Wave-B V5 dogma note), but their `PeerId`s never collide — the\nunderlying UUID is globally unique.\n\nConstructed freshly (`PeerId::new`) for a peer minted locally, parsed\nfrom a hyphenated UUID (`PeerId::parse`) when we've been given an identity\nover the wire, or derived from a 32-byte Ed25519 public key when a transport\nstill authenticates by raw signing key.",
@@ -711,6 +531,38 @@
       },
       "PeerName": {
         "description": "Display-only slug for a peer.\n\n`PeerName` is **not** a routing key after Wave-B V5: the router resolves\nsends by [`PeerId`], and trust stores are keyed by [`PeerId`]. `PeerName`\nis retained so human-facing surfaces (CLI, REST `comms.peers`, logs) can\nrender a recognisable handle next to the opaque id.",
+        "type": "string"
+      },
+      "PeerReachability": {
+        "enum": [
+          "unknown",
+          "reachable",
+          "unreachable"
+        ],
+        "type": "string"
+      },
+      "PeerReachabilityReason": {
+        "oneOf": [
+          {
+            "enum": [
+              "offline_or_no_ack",
+              "transport_error"
+            ],
+            "type": "string"
+          },
+          {
+            "const": "admission_dropped",
+            "description": "The peer admitted the transport but rejected our envelope at its\ningress policy gate (untrusted sender, full inbox, etc.). The peer\nis still reachable at the transport level; policy denied us.",
+            "type": "string"
+          }
+        ]
+      },
+      "PeerSendability": {
+        "enum": [
+          "peer_message",
+          "peer_request",
+          "peer_response"
+        ],
         "type": "string"
       },
       "PeerTransport": {
@@ -739,7 +591,7 @@
     "properties": {
       "peers": {
         "items": {
-          "$ref": "#/$defs/CommsPeerEntry"
+          "$ref": "#/$defs/PeerDirectoryEntry"
         },
         "type": "array"
       }
@@ -5121,6 +4973,497 @@
     "title": "MobWireResult",
     "type": "object"
   },
+  "PeerAddress": {
+    "$defs": {
+      "PeerTransport": {
+        "description": "Typed transport atom for a peer address.\n\nReplaces the old free-form `address: String` on `PeerDirectoryEntry` so\ncallers cannot accidentally invent new transports by string concatenation\nat a call site.",
+        "oneOf": [
+          {
+            "const": "inproc",
+            "description": "In-process routing within this runtime (no network hop).",
+            "type": "string"
+          },
+          {
+            "const": "uds",
+            "description": "Unix domain socket.",
+            "type": "string"
+          },
+          {
+            "const": "tcp",
+            "description": "TCP endpoint.",
+            "type": "string"
+          }
+        ]
+      }
+    },
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "description": "Typed peer address: transport atom plus endpoint string.\n\nThe `endpoint` is transport-specific (path for `Uds`, `host:port` for\n`Tcp`, agent name for `Inproc`) but is carried as a validated `String`\nso the transport atom can be branched on without re-parsing.",
+    "properties": {
+      "endpoint": {
+        "type": "string"
+      },
+      "transport": {
+        "$ref": "#/$defs/PeerTransport"
+      }
+    },
+    "required": [
+      "transport",
+      "endpoint"
+    ],
+    "title": "PeerAddress",
+    "type": "object"
+  },
+  "PeerCapabilitySet": {
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "description": "Typed peer capability envelope for peer-directory output.\n\nExtensions are intentionally opaque display/integration metadata. Core\nrouting, admission, and policy decisions must use typed fields such as\n[`PeerDirectoryEntry::sendable_kinds`] instead of consulting this bag.",
+    "properties": {
+      "extensions": {
+        "additionalProperties": true,
+        "default": {},
+        "type": "object"
+      },
+      "version": {
+        "default": 1,
+        "format": "uint16",
+        "maximum": 65535,
+        "minimum": 0,
+        "type": "integer"
+      }
+    },
+    "title": "PeerCapabilitySet",
+    "type": "object"
+  },
+  "PeerDirectoryEntry": {
+    "$defs": {
+      "PeerAddress": {
+        "description": "Typed peer address: transport atom plus endpoint string.\n\nThe `endpoint` is transport-specific (path for `Uds`, `host:port` for\n`Tcp`, agent name for `Inproc`) but is carried as a validated `String`\nso the transport atom can be branched on without re-parsing.",
+        "properties": {
+          "endpoint": {
+            "type": "string"
+          },
+          "transport": {
+            "$ref": "#/$defs/PeerTransport"
+          }
+        },
+        "required": [
+          "transport",
+          "endpoint"
+        ],
+        "type": "object"
+      },
+      "PeerCapabilitySet": {
+        "description": "Typed peer capability envelope for peer-directory output.\n\nExtensions are intentionally opaque display/integration metadata. Core\nrouting, admission, and policy decisions must use typed fields such as\n[`PeerDirectoryEntry::sendable_kinds`] instead of consulting this bag.",
+        "properties": {
+          "extensions": {
+            "additionalProperties": true,
+            "default": {},
+            "type": "object"
+          },
+          "version": {
+            "default": 1,
+            "format": "uint16",
+            "maximum": 65535,
+            "minimum": 0,
+            "type": "integer"
+          }
+        },
+        "type": "object"
+      },
+      "PeerDirectorySource": {
+        "enum": [
+          "trusted",
+          "inproc",
+          "trusted_and_inproc",
+          "unknown"
+        ],
+        "type": "string"
+      },
+      "PeerId": {
+        "description": "Canonical runtime identity for a peer.\n\n`PeerId` is the routing key: the router and trust store key by `PeerId`,\nnever by `PeerName`. Two peers may legitimately share a display `PeerName`\n(per the Wave-B V5 dogma note), but their `PeerId`s never collide — the\nunderlying UUID is globally unique.\n\nConstructed freshly (`PeerId::new`) for a peer minted locally, parsed\nfrom a hyphenated UUID (`PeerId::parse`) when we've been given an identity\nover the wire, or derived from a 32-byte Ed25519 public key when a transport\nstill authenticates by raw signing key.",
+        "type": "string"
+      },
+      "PeerMeta": {
+        "description": "Supplementary metadata attached to a peer for discovery.\n\nThe peer's routing name lives in `TrustedPeer.name` / `comms_name`.\n`PeerMeta` carries additional context: what the agent does and\narbitrary key/value labels.\n\n# Serde\n\nBoth fields use `skip_serializing_if`, so `PeerMeta::default()`\nserializes to `{}`.",
+        "properties": {
+          "description": {
+            "description": "What this agent does (e.g. \"Reviews pull requests for style issues\").",
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "labels": {
+            "additionalProperties": {
+              "type": "string"
+            },
+            "description": "Arbitrary key/value labels (e.g. `{\"lang\": \"rust\", \"team\": \"infra\"}`).\n\n`BTreeMap` keeps keys sorted for deterministic serialization.",
+            "type": "object"
+          }
+        },
+        "type": "object"
+      },
+      "PeerName": {
+        "description": "Display-only slug for a peer.\n\n`PeerName` is **not** a routing key after Wave-B V5: the router resolves\nsends by [`PeerId`], and trust stores are keyed by [`PeerId`]. `PeerName`\nis retained so human-facing surfaces (CLI, REST `comms.peers`, logs) can\nrender a recognisable handle next to the opaque id.",
+        "type": "string"
+      },
+      "PeerReachability": {
+        "enum": [
+          "unknown",
+          "reachable",
+          "unreachable"
+        ],
+        "type": "string"
+      },
+      "PeerReachabilityReason": {
+        "oneOf": [
+          {
+            "enum": [
+              "offline_or_no_ack",
+              "transport_error"
+            ],
+            "type": "string"
+          },
+          {
+            "const": "admission_dropped",
+            "description": "The peer admitted the transport but rejected our envelope at its\ningress policy gate (untrusted sender, full inbox, etc.). The peer\nis still reachable at the transport level; policy denied us.",
+            "type": "string"
+          }
+        ]
+      },
+      "PeerSendability": {
+        "enum": [
+          "peer_message",
+          "peer_request",
+          "peer_response"
+        ],
+        "type": "string"
+      },
+      "PeerTransport": {
+        "description": "Typed transport atom for a peer address.\n\nReplaces the old free-form `address: String` on `PeerDirectoryEntry` so\ncallers cannot accidentally invent new transports by string concatenation\nat a call site.",
+        "oneOf": [
+          {
+            "const": "inproc",
+            "description": "In-process routing within this runtime (no network hop).",
+            "type": "string"
+          },
+          {
+            "const": "uds",
+            "description": "Unix domain socket.",
+            "type": "string"
+          },
+          {
+            "const": "tcp",
+            "description": "TCP endpoint.",
+            "type": "string"
+          }
+        ]
+      }
+    },
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "properties": {
+      "address": {
+        "$ref": "#/$defs/PeerAddress",
+        "description": "Typed transport atom + endpoint. Replaces the prior free-form\n`address: String` so the transport cannot be invented by string\nconcatenation at a call site."
+      },
+      "capabilities": {
+        "$ref": "#/$defs/PeerCapabilitySet"
+      },
+      "last_unreachable_reason": {
+        "anyOf": [
+          {
+            "$ref": "#/$defs/PeerReachabilityReason"
+          },
+          {
+            "type": "null"
+          }
+        ]
+      },
+      "meta": {
+        "$ref": "#/$defs/PeerMeta",
+        "description": "Supplementary discovery metadata (description, labels)."
+      },
+      "name": {
+        "$ref": "#/$defs/PeerName",
+        "description": "Display-only slug. Multiple entries may share a name; none share a\n`peer_id`."
+      },
+      "peer_id": {
+        "$ref": "#/$defs/PeerId",
+        "description": "Canonical runtime identity — the routing key."
+      },
+      "reachability": {
+        "$ref": "#/$defs/PeerReachability"
+      },
+      "sendable_kinds": {
+        "items": {
+          "$ref": "#/$defs/PeerSendability"
+        },
+        "type": "array"
+      },
+      "source": {
+        "$ref": "#/$defs/PeerDirectorySource"
+      }
+    },
+    "required": [
+      "peer_id",
+      "name",
+      "address",
+      "source",
+      "sendable_kinds",
+      "capabilities",
+      "reachability",
+      "meta"
+    ],
+    "title": "PeerDirectoryEntry",
+    "type": "object"
+  },
+  "PeerDirectoryListing": {
+    "$defs": {
+      "PeerAddress": {
+        "description": "Typed peer address: transport atom plus endpoint string.\n\nThe `endpoint` is transport-specific (path for `Uds`, `host:port` for\n`Tcp`, agent name for `Inproc`) but is carried as a validated `String`\nso the transport atom can be branched on without re-parsing.",
+        "properties": {
+          "endpoint": {
+            "type": "string"
+          },
+          "transport": {
+            "$ref": "#/$defs/PeerTransport"
+          }
+        },
+        "required": [
+          "transport",
+          "endpoint"
+        ],
+        "type": "object"
+      },
+      "PeerCapabilitySet": {
+        "description": "Typed peer capability envelope for peer-directory output.\n\nExtensions are intentionally opaque display/integration metadata. Core\nrouting, admission, and policy decisions must use typed fields such as\n[`PeerDirectoryEntry::sendable_kinds`] instead of consulting this bag.",
+        "properties": {
+          "extensions": {
+            "additionalProperties": true,
+            "default": {},
+            "type": "object"
+          },
+          "version": {
+            "default": 1,
+            "format": "uint16",
+            "maximum": 65535,
+            "minimum": 0,
+            "type": "integer"
+          }
+        },
+        "type": "object"
+      },
+      "PeerDirectoryEntry": {
+        "properties": {
+          "address": {
+            "$ref": "#/$defs/PeerAddress",
+            "description": "Typed transport atom + endpoint. Replaces the prior free-form\n`address: String` so the transport cannot be invented by string\nconcatenation at a call site."
+          },
+          "capabilities": {
+            "$ref": "#/$defs/PeerCapabilitySet"
+          },
+          "last_unreachable_reason": {
+            "anyOf": [
+              {
+                "$ref": "#/$defs/PeerReachabilityReason"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "meta": {
+            "$ref": "#/$defs/PeerMeta",
+            "description": "Supplementary discovery metadata (description, labels)."
+          },
+          "name": {
+            "$ref": "#/$defs/PeerName",
+            "description": "Display-only slug. Multiple entries may share a name; none share a\n`peer_id`."
+          },
+          "peer_id": {
+            "$ref": "#/$defs/PeerId",
+            "description": "Canonical runtime identity — the routing key."
+          },
+          "reachability": {
+            "$ref": "#/$defs/PeerReachability"
+          },
+          "sendable_kinds": {
+            "items": {
+              "$ref": "#/$defs/PeerSendability"
+            },
+            "type": "array"
+          },
+          "source": {
+            "$ref": "#/$defs/PeerDirectorySource"
+          }
+        },
+        "required": [
+          "peer_id",
+          "name",
+          "address",
+          "source",
+          "sendable_kinds",
+          "capabilities",
+          "reachability",
+          "meta"
+        ],
+        "type": "object"
+      },
+      "PeerDirectorySource": {
+        "enum": [
+          "trusted",
+          "inproc",
+          "trusted_and_inproc",
+          "unknown"
+        ],
+        "type": "string"
+      },
+      "PeerId": {
+        "description": "Canonical runtime identity for a peer.\n\n`PeerId` is the routing key: the router and trust store key by `PeerId`,\nnever by `PeerName`. Two peers may legitimately share a display `PeerName`\n(per the Wave-B V5 dogma note), but their `PeerId`s never collide — the\nunderlying UUID is globally unique.\n\nConstructed freshly (`PeerId::new`) for a peer minted locally, parsed\nfrom a hyphenated UUID (`PeerId::parse`) when we've been given an identity\nover the wire, or derived from a 32-byte Ed25519 public key when a transport\nstill authenticates by raw signing key.",
+        "type": "string"
+      },
+      "PeerMeta": {
+        "description": "Supplementary metadata attached to a peer for discovery.\n\nThe peer's routing name lives in `TrustedPeer.name` / `comms_name`.\n`PeerMeta` carries additional context: what the agent does and\narbitrary key/value labels.\n\n# Serde\n\nBoth fields use `skip_serializing_if`, so `PeerMeta::default()`\nserializes to `{}`.",
+        "properties": {
+          "description": {
+            "description": "What this agent does (e.g. \"Reviews pull requests for style issues\").",
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "labels": {
+            "additionalProperties": {
+              "type": "string"
+            },
+            "description": "Arbitrary key/value labels (e.g. `{\"lang\": \"rust\", \"team\": \"infra\"}`).\n\n`BTreeMap` keeps keys sorted for deterministic serialization.",
+            "type": "object"
+          }
+        },
+        "type": "object"
+      },
+      "PeerName": {
+        "description": "Display-only slug for a peer.\n\n`PeerName` is **not** a routing key after Wave-B V5: the router resolves\nsends by [`PeerId`], and trust stores are keyed by [`PeerId`]. `PeerName`\nis retained so human-facing surfaces (CLI, REST `comms.peers`, logs) can\nrender a recognisable handle next to the opaque id.",
+        "type": "string"
+      },
+      "PeerReachability": {
+        "enum": [
+          "unknown",
+          "reachable",
+          "unreachable"
+        ],
+        "type": "string"
+      },
+      "PeerReachabilityReason": {
+        "oneOf": [
+          {
+            "enum": [
+              "offline_or_no_ack",
+              "transport_error"
+            ],
+            "type": "string"
+          },
+          {
+            "const": "admission_dropped",
+            "description": "The peer admitted the transport but rejected our envelope at its\ningress policy gate (untrusted sender, full inbox, etc.). The peer\nis still reachable at the transport level; policy denied us.",
+            "type": "string"
+          }
+        ]
+      },
+      "PeerSendability": {
+        "enum": [
+          "peer_message",
+          "peer_request",
+          "peer_response"
+        ],
+        "type": "string"
+      },
+      "PeerTransport": {
+        "description": "Typed transport atom for a peer address.\n\nReplaces the old free-form `address: String` on `PeerDirectoryEntry` so\ncallers cannot accidentally invent new transports by string concatenation\nat a call site.",
+        "oneOf": [
+          {
+            "const": "inproc",
+            "description": "In-process routing within this runtime (no network hop).",
+            "type": "string"
+          },
+          {
+            "const": "uds",
+            "description": "Unix domain socket.",
+            "type": "string"
+          },
+          {
+            "const": "tcp",
+            "description": "TCP endpoint.",
+            "type": "string"
+          }
+        ]
+      }
+    },
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "properties": {
+      "peers": {
+        "items": {
+          "$ref": "#/$defs/PeerDirectoryEntry"
+        },
+        "type": "array"
+      }
+    },
+    "required": [
+      "peers"
+    ],
+    "title": "PeerDirectoryListing",
+    "type": "object"
+  },
+  "PeerDirectorySource": {
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "enum": [
+      "trusted",
+      "inproc",
+      "trusted_and_inproc",
+      "unknown"
+    ],
+    "title": "PeerDirectorySource",
+    "type": "string"
+  },
+  "PeerId": {
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "description": "Canonical runtime identity for a peer.\n\n`PeerId` is the routing key: the router and trust store key by `PeerId`,\nnever by `PeerName`. Two peers may legitimately share a display `PeerName`\n(per the Wave-B V5 dogma note), but their `PeerId`s never collide — the\nunderlying UUID is globally unique.\n\nConstructed freshly (`PeerId::new`) for a peer minted locally, parsed\nfrom a hyphenated UUID (`PeerId::parse`) when we've been given an identity\nover the wire, or derived from a 32-byte Ed25519 public key when a transport\nstill authenticates by raw signing key.",
+    "title": "PeerId",
+    "type": "string"
+  },
+  "PeerName": {
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "description": "Display-only slug for a peer.\n\n`PeerName` is **not** a routing key after Wave-B V5: the router resolves\nsends by [`PeerId`], and trust stores are keyed by [`PeerId`]. `PeerName`\nis retained so human-facing surfaces (CLI, REST `comms.peers`, logs) can\nrender a recognisable handle next to the opaque id.",
+    "title": "PeerName",
+    "type": "string"
+  },
+  "PeerReachability": {
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "enum": [
+      "unknown",
+      "reachable",
+      "unreachable"
+    ],
+    "title": "PeerReachability",
+    "type": "string"
+  },
+  "PeerReachabilityReason": {
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "oneOf": [
+      {
+        "enum": [
+          "offline_or_no_ack",
+          "transport_error"
+        ],
+        "type": "string"
+      },
+      {
+        "const": "admission_dropped",
+        "description": "The peer admitted the transport but rejected our envelope at its\ningress policy gate (untrusted sender, full inbox, etc.). The peer\nis still reachable at the transport level; policy denied us.",
+        "type": "string"
+      }
+    ],
+    "title": "PeerReachabilityReason"
+  },
   "PeerResponseTerminalStatusWire": {
     "$schema": "https://json-schema.org/draft/2020-12/schema",
     "description": "Terminal status for dedicated correlated peer-response ingress.",
@@ -5131,6 +5474,38 @@
     ],
     "title": "PeerResponseTerminalStatusWire",
     "type": "string"
+  },
+  "PeerSendability": {
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "enum": [
+      "peer_message",
+      "peer_request",
+      "peer_response"
+    ],
+    "title": "PeerSendability",
+    "type": "string"
+  },
+  "PeerTransport": {
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "description": "Typed transport atom for a peer address.\n\nReplaces the old free-form `address: String` on `PeerDirectoryEntry` so\ncallers cannot accidentally invent new transports by string concatenation\nat a call site.",
+    "oneOf": [
+      {
+        "const": "inproc",
+        "description": "In-process routing within this runtime (no network hop).",
+        "type": "string"
+      },
+      {
+        "const": "uds",
+        "description": "Unix domain socket.",
+        "type": "string"
+      },
+      {
+        "const": "tcp",
+        "description": "TCP endpoint.",
+        "type": "string"
+      }
+    ],
+    "title": "PeerTransport"
   },
   "RealtimeAudioChunk": {
     "$schema": "https://json-schema.org/draft/2020-12/schema",

--- a/meerkat-comms/src/mcp/tools.rs
+++ b/meerkat-comms/src/mcp/tools.rs
@@ -19,9 +19,11 @@ use std::sync::Arc;
 #[cfg(test)]
 use crate::{CommsConfig, Keypair};
 use crate::{Router, TrustedPeers};
+use meerkat_contracts::CommsPeersResult;
 use meerkat_core::agent::CommsRuntime as CoreCommsRuntime;
 use meerkat_core::comms::{
-    CommsCommand, InputStreamMode, PeerDirectoryEntry, PeerId, PeerName, PeerRoute, SendError,
+    CommsCommand, InputStreamMode, PeerAddress, PeerCapabilitySet, PeerDirectoryEntry,
+    PeerDirectorySource, PeerId, PeerName, PeerReachability, PeerRoute, PeerSendability, SendError,
     SendReceipt,
 };
 use meerkat_core::interaction::{InteractionId, ResponseStatus};
@@ -454,52 +456,64 @@ fn is_transport_internal(message: &str) -> bool {
 }
 
 async fn handle_peers(ctx: &ToolContext) -> Result<Value, String> {
-    if let Some(runtime) = &ctx.runtime {
-        let peer_list: Vec<Value> = runtime
-            .peers()
-            .await
-            .into_iter()
-            .map(|peer| {
-                json!({
-                    "name": peer.name.to_string(),
-                    "peer_id": peer.peer_id,
-                    "address": peer.address,
-                    "source": format!("{:?}", peer.source),
-                    "sendable_kinds": peer.sendable_kinds,
-                    "capabilities": peer.capabilities,
-                    "reachability": peer.reachability,
-                    "last_unreachable_reason": peer.last_unreachable_reason,
-                    "meta": peer.meta,
-                })
-            })
-            .collect();
-        return Ok(json!({ "peers": peer_list }));
-    }
+    let entries = if let Some(runtime) = &ctx.runtime {
+        runtime.peers().await
+    } else {
+        runtime_less_peer_directory(ctx)
+    };
 
+    serde_json::to_value(CommsPeersResult::from_entries(&entries))
+        .map_err(|err| format!("failed to serialize peer directory: {err}"))
+}
+
+fn runtime_less_peer_directory(ctx: &ToolContext) -> Vec<PeerDirectoryEntry> {
     let self_pubkey = ctx.router.keypair_arc().public_key();
     let peers = ctx.trusted_peers.read();
-    let peer_list: Vec<Value> = peers
+    let sendable_kinds = PeerSendability::directory_defaults();
+    peers
         .peers
         .iter()
         .filter(|p| p.pubkey != self_pubkey)
-        .map(|p| {
-            let mut entry = json!({
-                "name": p.name,
-                "peer_id": p.pubkey.to_peer_id(),
-                "address": p.addr
-            });
-            if let Some(desc) = &p.meta.description {
-                entry["description"] = json!(desc);
-            }
-            if !p.meta.labels.is_empty() {
-                entry["labels"] = json!(p.meta.labels);
-            }
-            entry
+        .filter_map(|p| {
+            let peer_id = p.pubkey.to_peer_id();
+            let name = match PeerName::new(p.name.clone()) {
+                Ok(name) => name,
+                Err(err) => {
+                    tracing::warn!(
+                        peer_name = %p.name,
+                        peer_id = %peer_id,
+                        error = %err,
+                        "skipping trusted peer with invalid name in MCP peer directory"
+                    );
+                    return None;
+                }
+            };
+            let address = match PeerAddress::parse(&p.addr) {
+                Ok(address) => address,
+                Err(err) => {
+                    tracing::warn!(
+                        peer_name = %p.name,
+                        peer_id = %peer_id,
+                        address = %p.addr,
+                        error = %err,
+                        "skipping trusted peer with invalid address in MCP peer directory"
+                    );
+                    return None;
+                }
+            };
+            Some(PeerDirectoryEntry {
+                name,
+                peer_id,
+                address,
+                source: PeerDirectorySource::Trusted,
+                sendable_kinds: sendable_kinds.clone(),
+                capabilities: PeerCapabilitySet::default(),
+                reachability: PeerReachability::Unknown,
+                last_unreachable_reason: None,
+                meta: p.meta.clone(),
+            })
         })
-        .collect();
-    drop(peers);
-
-    Ok(json!({ "peers": peer_list }))
+        .collect()
 }
 
 #[cfg(test)]
@@ -507,6 +521,10 @@ async fn handle_peers(ctx: &ToolContext) -> Result<Value, String> {
 mod tests {
     use super::*;
     use crate::{PubKey, TrustedPeer};
+    use meerkat_core::comms::{
+        PeerAddress, PeerCapabilitySet, PeerDirectorySource, PeerReachability, PeerSendability,
+        PeerTransport,
+    };
     use parking_lot::Mutex;
     use std::sync::LazyLock;
     use tokio::sync::Notify;
@@ -534,6 +552,7 @@ mod tests {
 
     struct RecordingRuntime {
         sent: Mutex<Vec<CommsCommand>>,
+        peers: Vec<PeerDirectoryEntry>,
         notify: Arc<Notify>,
     }
 
@@ -541,6 +560,15 @@ mod tests {
         fn new() -> Self {
             Self {
                 sent: Mutex::new(Vec::new()),
+                peers: Vec::new(),
+                notify: Arc::new(Notify::new()),
+            }
+        }
+
+        fn with_peers(peers: Vec<PeerDirectoryEntry>) -> Self {
+            Self {
+                sent: Mutex::new(Vec::new()),
+                peers,
                 notify: Arc::new(Notify::new()),
             }
         }
@@ -587,6 +615,10 @@ mod tests {
 
         fn inbox_notify(&self) -> Arc<Notify> {
             Arc::clone(&self.notify)
+        }
+
+        async fn peers(&self) -> Vec<PeerDirectoryEntry> {
+            self.peers.clone()
         }
     }
 
@@ -869,6 +901,69 @@ mod tests {
             peers.iter().all(|p| p["peer_id"].is_string()),
             "peers must expose canonical peer_id for routing",
         );
+    }
+
+    #[tokio::test]
+    async fn test_handle_peers_runtime_payload_uses_typed_directory_contract() {
+        let peer_id = PeerId::new();
+        let entry = PeerDirectoryEntry {
+            peer_id,
+            name: PeerName::new("runtime-peer").expect("valid peer name"),
+            address: PeerAddress::new(PeerTransport::Inproc, "runtime-peer"),
+            source: PeerDirectorySource::Inproc,
+            sendable_kinds: vec![PeerSendability::PeerMessage, PeerSendability::PeerRequest],
+            capabilities: PeerCapabilitySet::default()
+                .with_extension("vendor.echo", json!({ "enabled": true })),
+            reachability: PeerReachability::Reachable,
+            last_unreachable_reason: None,
+            meta: crate::PeerMeta::default(),
+        };
+        let peer_keypair = Keypair::generate();
+        let (mut ctx, _) = make_trusted_runtime_less_context(&peer_keypair);
+        let runtime = Arc::new(RecordingRuntime::with_peers(vec![entry]));
+        ctx.runtime = Some(RuntimeCommsCommandHandle::new(runtime));
+
+        let value = handle_tools_call(&ctx, "peers", &json!({}))
+            .await
+            .expect("runtime-backed peers should serialize");
+        let peer = &value["peers"][0];
+
+        assert_eq!(peer["peer_id"], peer_id.to_string());
+        assert_eq!(peer["source"], "inproc");
+        assert_ne!(peer["source"], "Inproc");
+        assert_eq!(
+            peer["sendable_kinds"],
+            json!(["peer_message", "peer_request"])
+        );
+        assert_eq!(peer["capabilities"]["version"], 1);
+        assert_eq!(
+            peer["capabilities"]["extensions"]["vendor.echo"]["enabled"],
+            true
+        );
+        assert_eq!(peer["reachability"], "reachable");
+    }
+
+    #[tokio::test]
+    async fn test_handle_peers_runtime_less_payload_uses_typed_directory_defaults() {
+        let peer_keypair = Keypair::generate();
+        let (ctx, peer_id) = make_trusted_runtime_less_context(&peer_keypair);
+
+        let value = handle_tools_call(&ctx, "peers", &json!({}))
+            .await
+            .expect("runtime-less peers should serialize");
+        let peer = &value["peers"][0];
+
+        assert_eq!(peer["peer_id"], peer_id.to_string());
+        assert_eq!(peer["source"], "trusted");
+        assert_eq!(
+            peer["sendable_kinds"],
+            json!(["peer_message", "peer_request", "peer_response"])
+        );
+        assert_eq!(peer["capabilities"]["version"], 1);
+        assert_eq!(peer["capabilities"]["extensions"], json!({}));
+        assert_eq!(peer["reachability"], "unknown");
+        assert_eq!(peer["last_unreachable_reason"], Value::Null);
+        assert!(peer["meta"].is_object());
     }
 
     #[tokio::test]

--- a/meerkat-comms/src/mcp/tools.rs
+++ b/meerkat-comms/src/mcp/tools.rs
@@ -469,7 +469,7 @@ async fn handle_peers(ctx: &ToolContext) -> Result<Value, String> {
 fn runtime_less_peer_directory(ctx: &ToolContext) -> Vec<PeerDirectoryEntry> {
     let self_pubkey = ctx.router.keypair_arc().public_key();
     let peers = ctx.trusted_peers.read();
-    let sendable_kinds = PeerSendability::directory_defaults();
+    let sendable_kinds = peer_sendability_authorized_by_tools(ctx);
     peers
         .peers
         .iter()
@@ -514,6 +514,23 @@ fn runtime_less_peer_directory(ctx: &ToolContext) -> Vec<PeerDirectoryEntry> {
             })
         })
         .collect()
+}
+
+fn peer_sendability_authorized_by_tools(ctx: &ToolContext) -> Vec<PeerSendability> {
+    PeerSendability::directory_defaults()
+        .into_iter()
+        .filter(|kind| {
+            comms_tool_unavailable_reason(ctx, peer_sendability_tool_name(*kind)).is_none()
+        })
+        .collect()
+}
+
+fn peer_sendability_tool_name(kind: PeerSendability) -> &'static str {
+    match kind {
+        PeerSendability::PeerMessage => "send_message",
+        PeerSendability::PeerRequest => "send_request",
+        PeerSendability::PeerResponse => "send_response",
+    }
 }
 
 #[cfg(test)]
@@ -944,7 +961,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_handle_peers_runtime_less_payload_uses_typed_directory_defaults() {
+    async fn test_handle_peers_runtime_less_payload_uses_authorized_sendability() {
         let peer_keypair = Keypair::generate();
         let (ctx, peer_id) = make_trusted_runtime_less_context(&peer_keypair);
 
@@ -955,10 +972,7 @@ mod tests {
 
         assert_eq!(peer["peer_id"], peer_id.to_string());
         assert_eq!(peer["source"], "trusted");
-        assert_eq!(
-            peer["sendable_kinds"],
-            json!(["peer_message", "peer_request", "peer_response"])
-        );
+        assert_eq!(peer["sendable_kinds"], json!(["peer_message"]));
         assert_eq!(peer["capabilities"]["version"], 1);
         assert_eq!(peer["capabilities"]["extensions"], json!({}));
         assert_eq!(peer["reachability"], "unknown");

--- a/meerkat-comms/src/runtime/comms_runtime.rs
+++ b/meerkat-comms/src/runtime/comms_runtime.rs
@@ -18,9 +18,9 @@ use futures::Stream;
 use futures::task::{Context, Poll};
 use meerkat_core::agent::CommsRuntime as CoreCommsRuntime;
 use meerkat_core::comms::{
-    CommsCommand, EventStream, InputStreamMode, PeerAddress, PeerDirectoryEntry,
-    PeerDirectorySource, PeerId, PeerName, PeerReachabilityReason, PeerRoute, SendAndStreamError,
-    SendError, SendReceipt, StreamError, StreamScope, TrustedPeerDescriptor,
+    CommsCommand, EventStream, InputStreamMode, PeerAddress, PeerCapabilitySet, PeerDirectoryEntry,
+    PeerDirectorySource, PeerId, PeerName, PeerReachabilityReason, PeerRoute, PeerSendability,
+    SendAndStreamError, SendError, SendReceipt, StreamError, StreamScope, TrustedPeerDescriptor,
 };
 use meerkat_core::config::PlainEventSource;
 #[cfg(not(target_arch = "wasm32"))]
@@ -1718,11 +1718,11 @@ impl CommsRuntime {
         })
     }
 
-    fn peer_request_response_sendable_kinds(&self) -> Vec<String> {
-        let mut kinds = vec!["peer_message".to_string()];
+    fn peer_request_response_sendable_kinds(&self) -> Vec<PeerSendability> {
+        let mut kinds = vec![PeerSendability::PeerMessage];
         if self.peer_interaction_handle().is_some() {
-            kinds.push("peer_request".to_string());
-            kinds.push("peer_response".to_string());
+            kinds.push(PeerSendability::PeerRequest);
+            kinds.push(PeerSendability::PeerResponse);
         }
         kinds
     }
@@ -1993,7 +1993,7 @@ impl CommsRuntime {
                 address: peer.address,
                 source: peer.source,
                 sendable_kinds: sendable_kinds.clone(),
-                capabilities: serde_json::json!({}),
+                capabilities: PeerCapabilitySet::default(),
                 reachability: snapshot.reachability,
                 last_unreachable_reason: snapshot.last_unreachable_reason,
                 meta: peer.meta,
@@ -2740,7 +2740,8 @@ mod tests {
         BlobId, BlobPayload, BlobRef, BlobStore, BlobStoreError, SendError,
         comms::{
             InputSource, InputStreamMode, PeerDirectorySource, PeerId, PeerName, PeerReachability,
-            PeerReachabilityReason, PeerRoute, StreamError, StreamScope, TrustedPeerDescriptor,
+            PeerReachabilityReason, PeerRoute, PeerSendability, StreamError, StreamScope,
+            TrustedPeerDescriptor,
         },
         interaction::InteractionId,
         types::{ContentBlock, ImageData, SessionId},
@@ -3667,7 +3668,7 @@ mod tests {
             .find(|entry| entry.name.as_str() == peer_name)
             .expect("trusted peer should be listed");
 
-        assert_eq!(entry.sendable_kinds, vec!["peer_message".to_string()]);
+        assert_eq!(entry.sendable_kinds, vec![PeerSendability::PeerMessage]);
     }
 
     #[tokio::test]
@@ -3699,9 +3700,9 @@ mod tests {
         assert_eq!(
             entry.sendable_kinds,
             vec![
-                "peer_message".to_string(),
-                "peer_request".to_string(),
-                "peer_response".to_string(),
+                PeerSendability::PeerMessage,
+                PeerSendability::PeerRequest,
+                PeerSendability::PeerResponse,
             ]
         );
     }
@@ -5140,7 +5141,7 @@ mod tests {
             peer.source
         );
         assert_eq!(peer.address.to_string(), format!("inproc://{peer_name}"));
-        assert_eq!(peer.sendable_kinds, vec!["peer_message".to_string()]);
+        assert_eq!(peer.sendable_kinds, vec![PeerSendability::PeerMessage]);
         assert_eq!(peer.reachability, PeerReachability::Unknown);
         assert_eq!(peer.last_unreachable_reason, None);
     }
@@ -5553,28 +5554,27 @@ mod tests {
 
         for entry in peers {
             for kind in &entry.sendable_kinds {
-                let cmd = match kind.as_str() {
-                    "peer_message" => CommsCommand::PeerMessage {
+                let cmd = match kind {
+                    PeerSendability::PeerMessage => CommsCommand::PeerMessage {
                         blocks: None,
                         to: PeerRoute::with_display_name(entry.peer_id, entry.name.clone()),
                         body: "truthfulness test".to_string(),
                         handling_mode: meerkat_core::types::HandlingMode::Queue,
                     },
-                    "peer_request" => CommsCommand::PeerRequest {
+                    PeerSendability::PeerRequest => CommsCommand::PeerRequest {
                         to: PeerRoute::with_display_name(entry.peer_id, entry.name.clone()),
                         intent: "test".to_string(),
                         params: serde_json::json!({}),
                         handling_mode: meerkat_core::types::HandlingMode::Queue,
                         stream: InputStreamMode::None,
                     },
-                    "peer_response" => CommsCommand::PeerResponse {
+                    PeerSendability::PeerResponse => CommsCommand::PeerResponse {
                         to: PeerRoute::with_display_name(entry.peer_id, entry.name.clone()),
                         in_reply_to: meerkat_core::InteractionId(Uuid::new_v4()),
                         status: meerkat_core::ResponseStatus::Completed,
                         result: serde_json::json!({}),
                         handling_mode: None,
                     },
-                    _ => continue,
                 };
                 let result = CoreCommsRuntime::send(&runtime, cmd).await;
                 assert!(

--- a/meerkat-contracts/src/emit.rs
+++ b/meerkat-contracts/src/emit.rs
@@ -189,10 +189,17 @@ pub fn emit_all_schemas(output_dir: &std::path::Path) -> Result<(), Box<dyn std:
         "SkillInspectResponse": schema_for!(crate::wire::SkillInspectResponse),
         "CommsCommandRequest": schema_for!(crate::wire::CommsCommandRequest),
         "CommsSendResult": schema_for!(crate::wire::CommsSendResult),
-        "CommsPeerSource": schema_for!(crate::wire::CommsPeerSource),
-        "CommsPeerReachability": schema_for!(crate::wire::CommsPeerReachability),
-        "CommsPeerUnreachableReason": schema_for!(crate::wire::CommsPeerUnreachableReason),
-        "CommsPeerEntry": schema_for!(crate::wire::CommsPeerEntry),
+        "PeerId": schema_for!(crate::wire::PeerId),
+        "PeerName": schema_for!(crate::wire::WireCommsPeerName),
+        "PeerTransport": schema_for!(crate::wire::PeerTransport),
+        "PeerAddress": schema_for!(crate::wire::PeerAddress),
+        "PeerDirectorySource": schema_for!(crate::wire::PeerDirectorySource),
+        "PeerSendability": schema_for!(crate::wire::PeerSendability),
+        "PeerCapabilitySet": schema_for!(crate::wire::PeerCapabilitySet),
+        "PeerReachability": schema_for!(crate::wire::PeerReachability),
+        "PeerReachabilityReason": schema_for!(crate::wire::PeerReachabilityReason),
+        "PeerDirectoryEntry": schema_for!(crate::wire::PeerDirectoryEntry),
+        "PeerDirectoryListing": schema_for!(crate::wire::PeerDirectoryListing),
         "CommsPeersResult": schema_for!(crate::wire::CommsPeersResult),
         "SessionStreamOpenResult": schema_for!(crate::wire::SessionStreamOpenResult),
         "SessionStreamCloseResult": schema_for!(crate::wire::SessionStreamCloseResult),
@@ -903,6 +910,7 @@ pub fn emit_all_schemas(output_dir: &std::path::Path) -> Result<(), Box<dyn std:
             ("/comms/send", "post") => {
                 RestOperationContract::with_json_request("RestCommsSendRequest", "JsonValue")
             }
+            ("/comms/peers", "get") => RestOperationContract::json("CommsPeersResult"),
             ("/config", "get") => RestOperationContract::json("ConfigEnvelope"),
             ("/config", "put") => {
                 RestOperationContract::with_json_request("RestSetConfigRequest", "ConfigEnvelope")

--- a/meerkat-contracts/src/lib.rs
+++ b/meerkat-contracts/src/lib.rs
@@ -1,4 +1,4 @@
-#![recursion_limit = "512"]
+#![recursion_limit = "1024"]
 
 //! Meerkat contracts — canonical wire types, capability model, and error contracts.
 //!
@@ -82,9 +82,6 @@ pub use wire::{
     CommsCommandRequest,
     CommsParams,
     CommsPeerEntry,
-    CommsPeerReachability,
-    CommsPeerSource,
-    CommsPeerUnreachableReason,
     CommsPeersParams,
     CommsPeersResult,
     CommsSendParams,
@@ -205,7 +202,17 @@ pub use wire::{
     MobWireParams,
     MobWireResult,
     ModelsCatalogResponse,
+    PeerAddress,
+    PeerCapabilitySet,
+    PeerDirectoryEntry,
+    PeerDirectoryListing,
+    PeerDirectorySource,
+    PeerId,
+    PeerReachability,
+    PeerReachabilityReason,
     PeerResponseTerminalStatusWire,
+    PeerSendability,
+    PeerTransport,
     PrincipalId,
     PrincipalKind,
     PrincipalRef,

--- a/meerkat-contracts/src/wire/comms.rs
+++ b/meerkat-contracts/src/wire/comms.rs
@@ -8,8 +8,10 @@
 //! `{ "session_id": "...", "kind": "<variant>", ... }`.
 
 pub use meerkat_core::comms::{
-    CommsCommandError, CommsCommandRequest, InputSource, InputStreamMode, PeerAddress, PeerId,
-    PeerLifecycleKind, PeerName,
+    CommsCommandError, CommsCommandRequest, InputSource, InputStreamMode, PeerAddress,
+    PeerCapabilitySet, PeerDirectoryEntry, PeerDirectoryListing, PeerDirectorySource, PeerId,
+    PeerLifecycleKind, PeerName, PeerReachability, PeerReachabilityReason, PeerSendability,
+    PeerTransport,
 };
 pub use meerkat_core::interaction::ResponseStatus;
 pub use meerkat_core::types::HandlingMode;
@@ -249,112 +251,27 @@ impl From<meerkat_core::comms::SendReceipt> for CommsSendResult {
     }
 }
 
-/// Stable public source labels for `comms/peers` entries.
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
-#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
-pub enum CommsPeerSource {
-    Trusted,
-    Inproc,
-    TrustedAndInproc,
-    Unknown,
-}
-
-impl From<&meerkat_core::comms::PeerDirectorySource> for CommsPeerSource {
-    fn from(source: &meerkat_core::comms::PeerDirectorySource) -> Self {
-        match source {
-            meerkat_core::comms::PeerDirectorySource::Trusted => Self::Trusted,
-            meerkat_core::comms::PeerDirectorySource::Inproc => Self::Inproc,
-            meerkat_core::comms::PeerDirectorySource::TrustedAndInproc => Self::TrustedAndInproc,
-            meerkat_core::comms::PeerDirectorySource::Unknown => Self::Unknown,
-        }
-    }
-}
-
-/// Stable public reachability labels for `comms/peers` entries.
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
-#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
-#[serde(rename_all = "snake_case")]
-pub enum CommsPeerReachability {
-    Unknown,
-    Reachable,
-    Unreachable,
-}
-
-impl From<meerkat_core::comms::PeerReachability> for CommsPeerReachability {
-    fn from(reachability: meerkat_core::comms::PeerReachability) -> Self {
-        match reachability {
-            meerkat_core::comms::PeerReachability::Unknown => Self::Unknown,
-            meerkat_core::comms::PeerReachability::Reachable => Self::Reachable,
-            meerkat_core::comms::PeerReachability::Unreachable => Self::Unreachable,
-        }
-    }
-}
-
-/// Stable public unreachable-reason labels for `comms/peers` entries.
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
-#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
-#[serde(rename_all = "snake_case")]
-pub enum CommsPeerUnreachableReason {
-    OfflineOrNoAck,
-    TransportError,
-    AdmissionDropped,
-    Unknown,
-}
-
-impl From<meerkat_core::comms::PeerReachabilityReason> for CommsPeerUnreachableReason {
-    fn from(reason: meerkat_core::comms::PeerReachabilityReason) -> Self {
-        match reason {
-            meerkat_core::comms::PeerReachabilityReason::OfflineOrNoAck => Self::OfflineOrNoAck,
-            meerkat_core::comms::PeerReachabilityReason::TransportError => Self::TransportError,
-            meerkat_core::comms::PeerReachabilityReason::AdmissionDropped => Self::AdmissionDropped,
-            _ => Self::Unknown,
-        }
-    }
-}
-
-/// One peer entry in the `comms/peers` response.
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
-#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
-pub struct CommsPeerEntry {
-    pub name: PeerName,
-    pub peer_id: PeerId,
-    pub address: PeerAddress,
-    pub source: CommsPeerSource,
-    pub sendable_kinds: Vec<String>,
-    pub capabilities: serde_json::Value,
-    pub reachability: CommsPeerReachability,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub last_unreachable_reason: Option<CommsPeerUnreachableReason>,
-    pub meta: meerkat_core::PeerMeta,
-}
-
-impl From<&meerkat_core::comms::PeerDirectoryEntry> for CommsPeerEntry {
-    fn from(entry: &meerkat_core::comms::PeerDirectoryEntry) -> Self {
-        Self {
-            name: entry.name.clone(),
-            peer_id: entry.peer_id,
-            address: entry.address.clone(),
-            source: CommsPeerSource::from(&entry.source),
-            sendable_kinds: entry.sendable_kinds.clone(),
-            capabilities: entry.capabilities.clone(),
-            reachability: CommsPeerReachability::from(entry.reachability),
-            last_unreachable_reason: entry.last_unreachable_reason.map(Into::into),
-            meta: entry.meta.clone(),
-        }
-    }
-}
+pub type CommsPeerEntry = PeerDirectoryEntry;
 
 /// Response payload for `comms/peers`.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 #[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
 pub struct CommsPeersResult {
-    pub peers: Vec<CommsPeerEntry>,
+    pub peers: Vec<PeerDirectoryEntry>,
 }
 
 impl CommsPeersResult {
     pub fn from_entries(entries: &[meerkat_core::comms::PeerDirectoryEntry]) -> Self {
         Self {
-            peers: entries.iter().map(CommsPeerEntry::from).collect(),
+            peers: entries.to_vec(),
+        }
+    }
+}
+
+impl From<PeerDirectoryListing> for CommsPeersResult {
+    fn from(listing: PeerDirectoryListing) -> Self {
+        Self {
+            peers: listing.peers,
         }
     }
 }

--- a/meerkat-contracts/src/wire/mod.rs
+++ b/meerkat-contracts/src/wire/mod.rs
@@ -28,11 +28,12 @@ pub use approval::{
     ApprovalRequestParams, ApprovalResourceKind, ApprovalResourceRef, ApprovalRisk, ApprovalStatus,
 };
 pub use comms::{
-    CommsCommandError, CommsCommandRequest, CommsPeerEntry, CommsPeerReachability, CommsPeerSource,
-    CommsPeerUnreachableReason, CommsPeersParams, CommsPeersResult, CommsSendParams,
-    CommsSendResult, HandlingMode as WireCommsHandlingMode, InputSource as WireCommsInputSource,
-    InputStreamMode as WireCommsInputStreamMode, PeerName as WireCommsPeerName,
-    ResponseStatus as WireCommsResponseStatus,
+    CommsCommandError, CommsCommandRequest, CommsPeerEntry, CommsPeersParams, CommsPeersResult,
+    CommsSendParams, CommsSendResult, HandlingMode as WireCommsHandlingMode,
+    InputSource as WireCommsInputSource, InputStreamMode as WireCommsInputStreamMode, PeerAddress,
+    PeerCapabilitySet, PeerDirectoryEntry, PeerDirectoryListing, PeerDirectorySource, PeerId,
+    PeerName as WireCommsPeerName, PeerReachability, PeerReachabilityReason, PeerSendability,
+    PeerTransport, ResponseStatus as WireCommsResponseStatus,
 };
 pub use connection::{
     BindingIdParams, CreateProfileParams, DeviceCompleteParams, DeviceStartParams,

--- a/meerkat-core/src/comms.rs
+++ b/meerkat-core/src/comms.rs
@@ -9,6 +9,7 @@ use crate::interaction::{InteractionId, ResponseStatus};
 use crate::types::{ContentBlock, HandlingMode};
 use futures::Stream;
 use serde::{Deserialize, Serialize};
+use std::collections::BTreeMap;
 use std::pin::Pin;
 use uuid::Uuid;
 
@@ -778,7 +779,9 @@ pub enum SendReceipt {
     },
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
 pub enum PeerDirectorySource {
     Trusted,
     Inproc,
@@ -786,6 +789,92 @@ pub enum PeerDirectorySource {
     Unknown,
 }
 
+impl PeerDirectorySource {
+    pub const fn as_str(&self) -> &'static str {
+        match self {
+            Self::Trusted => "trusted",
+            Self::Inproc => "inproc",
+            Self::TrustedAndInproc => "trusted_and_inproc",
+            Self::Unknown => "unknown",
+        }
+    }
+}
+
+impl std::fmt::Display for PeerDirectorySource {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum PeerSendability {
+    PeerMessage,
+    PeerRequest,
+    PeerResponse,
+}
+
+impl PeerSendability {
+    pub const DIRECTORY_DEFAULTS: [Self; 3] =
+        [Self::PeerMessage, Self::PeerRequest, Self::PeerResponse];
+
+    pub fn directory_defaults() -> Vec<Self> {
+        Self::DIRECTORY_DEFAULTS.to_vec()
+    }
+
+    pub const fn as_str(&self) -> &'static str {
+        match self {
+            Self::PeerMessage => "peer_message",
+            Self::PeerRequest => "peer_request",
+            Self::PeerResponse => "peer_response",
+        }
+    }
+}
+
+impl std::fmt::Display for PeerSendability {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
+/// Typed peer capability envelope for peer-directory output.
+///
+/// Extensions are intentionally opaque display/integration metadata. Core
+/// routing, admission, and policy decisions must use typed fields such as
+/// [`PeerDirectoryEntry::sendable_kinds`] instead of consulting this bag.
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct PeerCapabilitySet {
+    #[serde(default = "PeerCapabilitySet::default_version")]
+    pub version: u16,
+    #[serde(default)]
+    pub extensions: BTreeMap<String, serde_json::Value>,
+}
+
+impl PeerCapabilitySet {
+    pub const CURRENT_VERSION: u16 = 1;
+
+    const fn default_version() -> u16 {
+        Self::CURRENT_VERSION
+    }
+
+    pub fn with_extension(mut self, key: impl Into<String>, value: serde_json::Value) -> Self {
+        self.extensions.insert(key.into(), value);
+        self
+    }
+}
+
+impl Default for PeerCapabilitySet {
+    fn default() -> Self {
+        Self {
+            version: Self::CURRENT_VERSION,
+            extensions: BTreeMap::new(),
+        }
+    }
+}
+
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum PeerReachability {
@@ -794,6 +883,7 @@ pub enum PeerReachability {
     Unreachable,
 }
 
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 #[non_exhaustive]
@@ -806,7 +896,8 @@ pub enum PeerReachabilityReason {
     AdmissionDropped,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct PeerDirectoryEntry {
     /// Canonical runtime identity — the routing key.
     pub peer_id: PeerId,
@@ -818,12 +909,30 @@ pub struct PeerDirectoryEntry {
     /// concatenation at a call site.
     pub address: PeerAddress,
     pub source: PeerDirectorySource,
-    pub sendable_kinds: Vec<String>,
-    pub capabilities: serde_json::Value,
+    pub sendable_kinds: Vec<PeerSendability>,
+    pub capabilities: PeerCapabilitySet,
     pub reachability: PeerReachability,
     pub last_unreachable_reason: Option<PeerReachabilityReason>,
     /// Supplementary discovery metadata (description, labels).
     pub meta: crate::PeerMeta,
+}
+
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct PeerDirectoryListing {
+    pub peers: Vec<PeerDirectoryEntry>,
+}
+
+impl PeerDirectoryListing {
+    pub fn new(peers: Vec<PeerDirectoryEntry>) -> Self {
+        Self { peers }
+    }
+}
+
+impl From<Vec<PeerDirectoryEntry>> for PeerDirectoryListing {
+    fn from(peers: Vec<PeerDirectoryEntry>) -> Self {
+        Self::new(peers)
+    }
 }
 
 /// Scope for streaming event output.
@@ -931,7 +1040,6 @@ pub enum SendAndStreamError {
 #[allow(clippy::unwrap_used, clippy::expect_used, clippy::panic)]
 mod tests {
     use super::*;
-    use serde_json::Value;
 
     #[test]
     fn peer_name_validation() {
@@ -947,8 +1055,8 @@ mod tests {
             name: PeerName::new("agent")?,
             address: PeerAddress::new(PeerTransport::Inproc, "agent"),
             source: PeerDirectorySource::Inproc,
-            sendable_kinds: vec!["peer_message".to_string()],
-            capabilities: Value::Object(serde_json::Map::default()),
+            sendable_kinds: vec![PeerSendability::PeerMessage],
+            capabilities: PeerCapabilitySet::default(),
             reachability: PeerReachability::Unknown,
             last_unreachable_reason: None,
             meta: crate::PeerMeta::default(),
@@ -957,6 +1065,39 @@ mod tests {
         assert_eq!(entry.address.transport(), PeerTransport::Inproc);
         assert_eq!(entry.address.endpoint(), "agent");
         assert_eq!(entry.source, PeerDirectorySource::Inproc);
+        Ok(())
+    }
+
+    #[test]
+    fn peer_directory_listing_serializes_typed_source_sendability_and_capabilities()
+    -> Result<(), String> {
+        let entry = PeerDirectoryEntry {
+            peer_id: PeerId::new(),
+            name: PeerName::new("agent")?,
+            address: PeerAddress::new(PeerTransport::Inproc, "agent"),
+            source: PeerDirectorySource::Inproc,
+            sendable_kinds: vec![PeerSendability::PeerMessage, PeerSendability::PeerRequest],
+            capabilities: PeerCapabilitySet::default()
+                .with_extension("vendor.echo", serde_json::json!({ "enabled": true })),
+            reachability: PeerReachability::Reachable,
+            last_unreachable_reason: None,
+            meta: crate::PeerMeta::default(),
+        };
+
+        let value = serde_json::to_value(PeerDirectoryListing::new(vec![entry]))
+            .map_err(|err| err.to_string())?;
+        let peer = &value["peers"][0];
+
+        assert_eq!(peer["source"], "inproc");
+        assert_eq!(
+            peer["sendable_kinds"],
+            serde_json::json!(["peer_message", "peer_request"])
+        );
+        assert_eq!(peer["capabilities"]["version"], 1);
+        assert_eq!(
+            peer["capabilities"]["extensions"]["vendor.echo"]["enabled"],
+            true
+        );
         Ok(())
     }
 

--- a/meerkat-mcp-server/src/lib.rs
+++ b/meerkat-mcp-server/src/lib.rs
@@ -2492,23 +2492,14 @@ async fn handle_meerkat_comms_peers(
         .comms_runtime(&session_id)
         .await
         .ok_or_else(|| format!("Session not found or comms not enabled: {session_id}"))?;
-    let peers = comms.peers().await;
-    let payload = json!({
-        "peers": peers.iter().map(|p| {
-            json!({
-                "name": p.name.to_string(),
-                "peer_id": p.peer_id,
-                "address": p.address,
-                "source": format!("{:?}", p.source),
-                "sendable_kinds": p.sendable_kinds,
-                "capabilities": p.capabilities,
-                "reachability": p.reachability,
-                "last_unreachable_reason": p.last_unreachable_reason,
-                "meta": p.meta,
-            })
-        }).collect::<Vec<_>>()
-    });
-    Ok(wrap_tool_payload(payload))
+    Ok(comms_peers_tool_payload(comms.peers().await))
+}
+
+#[cfg(feature = "comms")]
+fn comms_peers_tool_payload(peers: Vec<meerkat_core::comms::PeerDirectoryEntry>) -> Value {
+    wrap_tool_payload(json!(meerkat_contracts::CommsPeersResult::from_entries(
+        &peers
+    )))
 }
 
 #[cfg(feature = "comms")]
@@ -3418,6 +3409,53 @@ mod tests {
         assert_eq!(
             payload["interaction_id"],
             serde_json::json!(interaction_id.0.to_string())
+        );
+    }
+
+    #[cfg(feature = "comms")]
+    #[test]
+    fn test_comms_peers_tool_payload_uses_typed_core_wire_contract() {
+        let wrapped = comms_peers_tool_payload(vec![sample_peer_directory_entry()]);
+        let payload = unwrap_payload(wrapped);
+
+        assert_peer_directory_wire(&payload);
+    }
+
+    #[cfg(feature = "comms")]
+    fn sample_peer_directory_entry() -> meerkat_core::comms::PeerDirectoryEntry {
+        meerkat_core::comms::PeerDirectoryEntry {
+            peer_id: meerkat_core::comms::PeerId::new(),
+            name: meerkat_core::comms::PeerName::new("agent").unwrap(),
+            address: meerkat_core::comms::PeerAddress::new(
+                meerkat_core::comms::PeerTransport::Inproc,
+                "agent",
+            ),
+            source: meerkat_core::comms::PeerDirectorySource::Inproc,
+            sendable_kinds: vec![
+                meerkat_core::comms::PeerSendability::PeerMessage,
+                meerkat_core::comms::PeerSendability::PeerRequest,
+            ],
+            capabilities: meerkat_core::comms::PeerCapabilitySet::default()
+                .with_extension("vendor.echo", serde_json::json!({ "enabled": true })),
+            reachability: meerkat_core::comms::PeerReachability::Reachable,
+            last_unreachable_reason: None,
+            meta: meerkat_core::PeerMeta::default(),
+        }
+    }
+
+    #[cfg(feature = "comms")]
+    fn assert_peer_directory_wire(result: &Value) {
+        let peer = &result["peers"][0];
+
+        assert_eq!(peer["source"], "inproc");
+        assert_eq!(
+            peer["sendable_kinds"],
+            serde_json::json!(["peer_message", "peer_request"])
+        );
+        assert_eq!(peer["capabilities"]["version"], 1);
+        assert_eq!(
+            peer["capabilities"]["extensions"]["vendor.echo"]["enabled"],
+            true
         );
     }
 

--- a/meerkat-mob-mcp/src/agent_tools.rs
+++ b/meerkat-mob-mcp/src/agent_tools.rs
@@ -1883,8 +1883,8 @@ mod tests {
     use async_trait::async_trait;
     use meerkat_core::agent::CommsRuntime as CoreCommsRuntime;
     use meerkat_core::comms::{
-        CommsCommand, PeerDirectoryEntry, PeerDirectorySource, PeerReachability, SendError,
-        SendReceipt, TrustedPeerDescriptor,
+        CommsCommand, PeerCapabilitySet, PeerDirectoryEntry, PeerDirectorySource, PeerReachability,
+        PeerSendability, SendError, SendReceipt, TrustedPeerDescriptor,
     };
     use meerkat_core::event::AgentEvent;
     use meerkat_core::event_injector::{InteractionSubscription, SubscribableInjector};
@@ -2215,8 +2215,8 @@ mod tests {
                         peer_id: peer.peer_id.clone(),
                         address: peer.address.clone(),
                         source: PeerDirectorySource::Trusted,
-                        sendable_kinds: vec!["peer_request".to_string()],
-                        capabilities: serde_json::json!({}),
+                        sendable_kinds: vec![PeerSendability::PeerRequest],
+                        capabilities: PeerCapabilitySet::default(),
                         reachability: PeerReachability::Reachable,
                         last_unreachable_reason: None,
                         meta: Default::default(),

--- a/meerkat-mob/src/runtime/tests.rs
+++ b/meerkat-mob/src/runtime/tests.rs
@@ -21,8 +21,9 @@ use indexmap::IndexMap;
 use meerkat_core::Provider;
 use meerkat_core::agent::CommsRuntime as CoreCommsRuntime;
 use meerkat_core::comms::{
-    CommsCommand, PeerDirectoryEntry, PeerDirectorySource, PeerId, PeerName, PeerReachability,
-    PeerReachabilityReason, PeerRoute, SendError, SendReceipt, TrustedPeerDescriptor,
+    CommsCommand, PeerCapabilitySet, PeerDirectoryEntry, PeerDirectorySource, PeerId, PeerName,
+    PeerReachability, PeerReachabilityReason, PeerRoute, PeerSendability, SendError, SendReceipt,
+    TrustedPeerDescriptor,
 };
 use meerkat_core::error::ToolError;
 use meerkat_core::event::{AgentEvent, EventEnvelope};
@@ -416,12 +417,8 @@ impl CoreCommsRuntime for MockCommsRuntime {
                     peer_id,
                     address: peer.address.clone(),
                     source: PeerDirectorySource::Trusted,
-                    sendable_kinds: vec![
-                        "peer_message".to_string(),
-                        "peer_request".to_string(),
-                        "peer_response".to_string(),
-                    ],
-                    capabilities: serde_json::json!({}),
+                    sendable_kinds: PeerSendability::directory_defaults(),
+                    capabilities: PeerCapabilitySet::default(),
                     reachability,
                     last_unreachable_reason,
                     meta: meerkat_core::PeerMeta::default(),

--- a/meerkat-rest/src/lib.rs
+++ b/meerkat-rest/src/lib.rs
@@ -2023,25 +2023,11 @@ async fn comms_peers(
             ))
         })?;
 
-    let peers = comms.peers().await;
-    let entries: Vec<Value> = peers
-        .iter()
-        .map(|p| {
-            json!({
-                "name": p.name.to_string(),
-                "peer_id": p.peer_id,
-                "address": p.address,
-                "source": format!("{:?}", p.source),
-                "sendable_kinds": p.sendable_kinds,
-                "capabilities": p.capabilities,
-                "reachability": p.reachability,
-                "last_unreachable_reason": p.last_unreachable_reason,
-                "meta": p.meta,
-            })
-        })
-        .collect();
+    Ok(Json(comms_peers_payload(comms.peers().await)))
+}
 
-    Ok(Json(json!({ "peers": entries })))
+fn comms_peers_payload(peers: Vec<meerkat_core::comms::PeerDirectoryEntry>) -> Value {
+    json!(meerkat_contracts::CommsPeersResult::from_entries(&peers))
 }
 
 fn make_runtime_external_event_input(
@@ -4912,6 +4898,52 @@ mod tests {
         assert_eq!(
             payload["interaction_id"],
             serde_json::json!(interaction_id.0.to_string())
+        );
+    }
+
+    #[cfg(feature = "comms")]
+    #[test]
+    fn test_comms_peers_payload_uses_typed_core_wire_contract() {
+        let payload = comms_peers_payload(vec![sample_peer_directory_entry()]);
+
+        assert_peer_directory_wire(&payload);
+    }
+
+    #[cfg(feature = "comms")]
+    fn sample_peer_directory_entry() -> meerkat_core::comms::PeerDirectoryEntry {
+        meerkat_core::comms::PeerDirectoryEntry {
+            peer_id: meerkat_core::comms::PeerId::new(),
+            name: meerkat_core::comms::PeerName::new("agent").unwrap(),
+            address: meerkat_core::comms::PeerAddress::new(
+                meerkat_core::comms::PeerTransport::Inproc,
+                "agent",
+            ),
+            source: meerkat_core::comms::PeerDirectorySource::Inproc,
+            sendable_kinds: vec![
+                meerkat_core::comms::PeerSendability::PeerMessage,
+                meerkat_core::comms::PeerSendability::PeerRequest,
+            ],
+            capabilities: meerkat_core::comms::PeerCapabilitySet::default()
+                .with_extension("vendor.echo", serde_json::json!({ "enabled": true })),
+            reachability: meerkat_core::comms::PeerReachability::Reachable,
+            last_unreachable_reason: None,
+            meta: meerkat_core::PeerMeta::default(),
+        }
+    }
+
+    #[cfg(feature = "comms")]
+    fn assert_peer_directory_wire(result: &Value) {
+        let peer = &result["peers"][0];
+
+        assert_eq!(peer["source"], "inproc");
+        assert_eq!(
+            peer["sendable_kinds"],
+            serde_json::json!(["peer_message", "peer_request"])
+        );
+        assert_eq!(peer["capabilities"]["version"], 1);
+        assert_eq!(
+            peer["capabilities"]["extensions"]["vendor.echo"]["enabled"],
+            true
         );
     }
 

--- a/meerkat-rpc/src/handlers/comms.rs
+++ b/meerkat-rpc/src/handlers/comms.rs
@@ -163,7 +163,10 @@ pub async fn handle_peers(
 #[allow(clippy::unwrap_used, clippy::expect_used)]
 mod tests {
     use super::*;
-    use meerkat_core::comms::CommsCommandRequest;
+    use meerkat_core::comms::{
+        CommsCommandRequest, PeerAddress, PeerCapabilitySet, PeerDirectoryEntry,
+        PeerDirectorySource, PeerId, PeerName, PeerReachability, PeerSendability, PeerTransport,
+    };
 
     #[test]
     fn deserialize_input_command() {
@@ -248,6 +251,44 @@ mod tests {
         assert_eq!(
             payload["interaction_id"],
             serde_json::json!(interaction_id.0.to_string())
+        );
+    }
+
+    #[test]
+    fn rpc_peer_directory_response_uses_typed_core_wire_contract() {
+        let result = CommsPeersResult::from_entries(&[sample_peer_directory_entry()]);
+        let value = serde_json::to_value(result).unwrap();
+
+        assert_peer_directory_wire(&value);
+    }
+
+    fn sample_peer_directory_entry() -> PeerDirectoryEntry {
+        PeerDirectoryEntry {
+            peer_id: PeerId::new(),
+            name: PeerName::new("agent").unwrap(),
+            address: PeerAddress::new(PeerTransport::Inproc, "agent"),
+            source: PeerDirectorySource::Inproc,
+            sendable_kinds: vec![PeerSendability::PeerMessage, PeerSendability::PeerRequest],
+            capabilities: PeerCapabilitySet::default()
+                .with_extension("vendor.echo", serde_json::json!({ "enabled": true })),
+            reachability: PeerReachability::Reachable,
+            last_unreachable_reason: None,
+            meta: meerkat_core::PeerMeta::default(),
+        }
+    }
+
+    fn assert_peer_directory_wire(result: &serde_json::Value) {
+        let peer = &result["peers"][0];
+
+        assert_eq!(peer["source"], "inproc");
+        assert_eq!(
+            peer["sendable_kinds"],
+            serde_json::json!(["peer_message", "peer_request"])
+        );
+        assert_eq!(peer["capabilities"]["version"], 1);
+        assert_eq!(
+            peer["capabilities"]["extensions"]["vendor.echo"]["enabled"],
+            true
         );
     }
 }

--- a/sdks/python/meerkat/generated/types.py
+++ b/sdks/python/meerkat/generated/types.py
@@ -1007,23 +1007,45 @@ class CommsPeersParams:
 
 
 @dataclass
-class CommsPeerEntry:
-    """One peer entry in the `comms/peers` response."""
-    address: dict[str, Any]
-    capabilities: Any
+class PeerAddress:
+    """Typed peer address: transport atom plus endpoint string.
+
+The `endpoint` is transport-specific (path for `Uds`, `host:port` for
+`Tcp`, agent name for `Inproc`) but is carried as a validated `String`
+so the transport atom can be branched on without re-parsing."""
+    endpoint: str
+    transport: PeerTransport
+
+
+@dataclass
+class PeerCapabilitySet:
+    """Typed peer capability envelope for peer-directory output.
+
+Extensions are intentionally opaque display/integration metadata. Core
+routing, admission, and policy decisions must use typed fields such as
+[`PeerDirectoryEntry::sendable_kinds`] instead of consulting this bag."""
+    extensions: Optional[dict[str, Any]] = None
+    version: Optional[int] = None
+
+
+@dataclass
+class PeerDirectoryEntry:
+    """Wire payload for PeerDirectoryEntry."""
+    address: PeerAddress
+    capabilities: PeerCapabilitySet
     meta: dict[str, Any]
-    name: str
-    peer_id: str
-    reachability: CommsPeerReachability
-    sendable_kinds: list[str]
-    source: CommsPeerSource
-    last_unreachable_reason: Optional[CommsPeerUnreachableReason] = None
+    name: PeerName
+    peer_id: PeerId
+    reachability: PeerReachability
+    sendable_kinds: list[PeerSendability]
+    source: PeerDirectorySource
+    last_unreachable_reason: Optional[PeerReachabilityReason] = None
 
 
 @dataclass
 class CommsPeersResult:
     """Response payload for `comms/peers`."""
-    peers: list[CommsPeerEntry]
+    peers: list[PeerDirectoryEntry]
 
 
 @dataclass
@@ -2426,13 +2448,13 @@ class CommsCommandPeerMessage(TypedDict, total=False):
     body: Required[str]
     handling_mode: NotRequired[Literal['queue', 'steer']]
     kind: Required[Literal['peer_message']]
-    to: Required[str]
+    to: Required[PeerId]
 
 class CommsCommandPeerLifecycle(TypedDict, total=False):
     kind: Required[Literal['peer_lifecycle']]
     lifecycle_kind: Required[Literal['mob.peer_added', 'mob.peer_retired', 'mob.peer_unwired']]
     params: NotRequired[Any]
-    to: Required[str]
+    to: Required[PeerId]
 
 class CommsCommandPeerRequest(TypedDict, total=False):
     handling_mode: NotRequired[Literal['queue', 'steer']]
@@ -2440,7 +2462,7 @@ class CommsCommandPeerRequest(TypedDict, total=False):
     kind: Required[Literal['peer_request']]
     params: NotRequired[Any]
     stream: NotRequired[Literal['none', 'reserve_interaction']]
-    to: Required[str]
+    to: Required[PeerId]
 
 class CommsCommandPeerResponse(TypedDict, total=False):
     handling_mode: NotRequired[Literal['queue', 'steer']]
@@ -2448,7 +2470,7 @@ class CommsCommandPeerResponse(TypedDict, total=False):
     kind: Required[Literal['peer_response']]
     result: NotRequired[Any]
     status: Required[Literal['accepted', 'completed', 'failed']]
-    to: Required[str]
+    to: Required[PeerId]
 
 CommsCommandRequest = CommsCommandInput | CommsCommandPeerMessage | CommsCommandPeerLifecycle | CommsCommandPeerRequest | CommsCommandPeerResponse
 
@@ -2469,14 +2491,14 @@ class CommsSendParamsPeerMessage(TypedDict, total=False):
     handling_mode: NotRequired[Literal['queue', 'steer']]
     kind: Required[Literal['peer_message']]
     session_id: Required[str]
-    to: Required[str]
+    to: Required[PeerId]
 
 class CommsSendParamsPeerLifecycle(TypedDict, total=False):
     kind: Required[Literal['peer_lifecycle']]
     lifecycle_kind: Required[Literal['mob.peer_added', 'mob.peer_retired', 'mob.peer_unwired']]
     params: NotRequired[Any]
     session_id: Required[str]
-    to: Required[str]
+    to: Required[PeerId]
 
 class CommsSendParamsPeerRequest(TypedDict, total=False):
     handling_mode: NotRequired[Literal['queue', 'steer']]
@@ -2485,7 +2507,7 @@ class CommsSendParamsPeerRequest(TypedDict, total=False):
     params: NotRequired[Any]
     session_id: Required[str]
     stream: NotRequired[Literal['none', 'reserve_interaction']]
-    to: Required[str]
+    to: Required[PeerId]
 
 class CommsSendParamsPeerResponse(TypedDict, total=False):
     handling_mode: NotRequired[Literal['queue', 'steer']]
@@ -2494,7 +2516,7 @@ class CommsSendParamsPeerResponse(TypedDict, total=False):
     result: NotRequired[Any]
     session_id: Required[str]
     status: Required[Literal['accepted', 'completed', 'failed']]
-    to: Required[str]
+    to: Required[PeerId]
 
 CommsSendParams = CommsSendParamsInput | CommsSendParamsPeerMessage | CommsSendParamsPeerLifecycle | CommsSendParamsPeerRequest | CommsSendParamsPeerResponse
 
@@ -2527,14 +2549,45 @@ class CommsSendResultPeerResponseSent(TypedDict, total=False):
 
 CommsSendResult = CommsSendResultInputAccepted | CommsSendResultPeerMessageSent | CommsSendResultPeerLifecycleSent | CommsSendResultPeerRequestSent | CommsSendResultPeerResponseSent
 
-# Stable public source labels for `comms/peers` entries.
-CommsPeerSource = Literal['Trusted', 'Inproc', 'TrustedAndInproc', 'Unknown']
+# Canonical runtime identity for a peer.
+#
+# `PeerId` is the routing key: the router and trust store key by `PeerId`,
+# never by `PeerName`. Two peers may legitimately share a display `PeerName`
+# (per the Wave-B V5 dogma note), but their `PeerId`s never collide — the
+# underlying UUID is globally unique.
+#
+# Constructed freshly (`PeerId::new`) for a peer minted locally, parsed
+# from a hyphenated UUID (`PeerId::parse`) when we've been given an identity
+# over the wire, or derived from a 32-byte Ed25519 public key when a transport
+# still authenticates by raw signing key.
+PeerId = str
 
-# Stable public reachability labels for `comms/peers` entries.
-CommsPeerReachability = Literal['unknown', 'reachable', 'unreachable']
+# Display-only slug for a peer.
+#
+# `PeerName` is **not** a routing key after Wave-B V5: the router resolves
+# sends by [`PeerId`], and trust stores are keyed by [`PeerId`]. `PeerName`
+# is retained so human-facing surfaces (CLI, REST `comms.peers`, logs) can
+# render a recognisable handle next to the opaque id.
+PeerName = str
 
-# Stable public unreachable-reason labels for `comms/peers` entries.
-CommsPeerUnreachableReason = Literal['offline_or_no_ack', 'transport_error', 'admission_dropped', 'unknown']
+# Typed transport atom for a peer address.
+#
+# Replaces the old free-form `address: String` on `PeerDirectoryEntry` so
+# callers cannot accidentally invent new transports by string concatenation
+# at a call site.
+PeerTransport = Literal['inproc', 'uds', 'tcp']
+
+# Comms/session-stream RPC contract for PeerDirectorySource.
+PeerDirectorySource = Literal['trusted', 'inproc', 'trusted_and_inproc', 'unknown']
+
+# Comms/session-stream RPC contract for PeerSendability.
+PeerSendability = Literal['peer_message', 'peer_request', 'peer_response']
+
+# Comms/session-stream RPC contract for PeerReachability.
+PeerReachability = Literal['unknown', 'reachable', 'unreachable']
+
+# Comms/session-stream RPC contract for PeerReachabilityReason.
+PeerReachabilityReason = Literal['offline_or_no_ack', 'transport_error'] | Literal['admission_dropped']
 
 # Response payload for `runtime/session_submission`.
 InputStateResult = Optional[WireInputState]

--- a/sdks/typescript/src/generated/types.ts
+++ b/sdks/typescript/src/generated/types.ts
@@ -746,20 +746,30 @@ export interface CommsPeersParams {
   session_id: string;
 }
 
-export interface CommsPeerEntry {
-  address: Record<string, unknown>;
-  capabilities: unknown;
-  last_unreachable_reason?: CommsPeerUnreachableReason;
+export interface PeerAddress {
+  endpoint: string;
+  transport: PeerTransport;
+}
+
+export interface PeerCapabilitySet {
+  extensions?: Record<string, unknown>;
+  version?: number;
+}
+
+export interface PeerDirectoryEntry {
+  address: PeerAddress;
+  capabilities: PeerCapabilitySet;
+  last_unreachable_reason?: PeerReachabilityReason;
   meta: Record<string, unknown>;
-  name: string;
-  peer_id: string;
-  reachability: CommsPeerReachability;
-  sendable_kinds: string[];
-  source: CommsPeerSource;
+  name: PeerName;
+  peer_id: PeerId;
+  reachability: PeerReachability;
+  sendable_kinds: PeerSendability[];
+  source: PeerDirectorySource;
 }
 
 export interface CommsPeersResult {
-  peers: CommsPeerEntry[];
+  peers: PeerDirectoryEntry[];
 }
 
 export interface SessionStreamOpenParams {
@@ -1370,14 +1380,14 @@ export interface CommsCommandPeerMessage {
   body: string;
   handling_mode?: "queue" | "steer";
   kind: "peer_message";
-  to: string;
+  to: PeerId;
 }
 
 export interface CommsCommandPeerLifecycle {
   kind: "peer_lifecycle";
   lifecycle_kind: "mob.peer_added" | "mob.peer_retired" | "mob.peer_unwired";
   params?: unknown;
-  to: string;
+  to: PeerId;
 }
 
 export interface CommsCommandPeerRequest {
@@ -1386,7 +1396,7 @@ export interface CommsCommandPeerRequest {
   kind: "peer_request";
   params?: unknown;
   stream?: "none" | "reserve_interaction";
-  to: string;
+  to: PeerId;
 }
 
 export interface CommsCommandPeerResponse {
@@ -1395,7 +1405,7 @@ export interface CommsCommandPeerResponse {
   kind: "peer_response";
   result?: unknown;
   status: "accepted" | "completed" | "failed";
-  to: string;
+  to: PeerId;
 }
 
 export type CommsCommandRequest = CommsCommandInput | CommsCommandPeerMessage | CommsCommandPeerLifecycle | CommsCommandPeerRequest | CommsCommandPeerResponse;
@@ -1417,7 +1427,7 @@ export interface CommsSendParamsPeerMessage {
   handling_mode?: "queue" | "steer";
   kind: "peer_message";
   session_id: string;
-  to: string;
+  to: PeerId;
 }
 
 export interface CommsSendParamsPeerLifecycle {
@@ -1425,7 +1435,7 @@ export interface CommsSendParamsPeerLifecycle {
   lifecycle_kind: "mob.peer_added" | "mob.peer_retired" | "mob.peer_unwired";
   params?: unknown;
   session_id: string;
-  to: string;
+  to: PeerId;
 }
 
 export interface CommsSendParamsPeerRequest {
@@ -1435,7 +1445,7 @@ export interface CommsSendParamsPeerRequest {
   params?: unknown;
   session_id: string;
   stream?: "none" | "reserve_interaction";
-  to: string;
+  to: PeerId;
 }
 
 export interface CommsSendParamsPeerResponse {
@@ -1445,7 +1455,7 @@ export interface CommsSendParamsPeerResponse {
   result?: unknown;
   session_id: string;
   status: "accepted" | "completed" | "failed";
-  to: string;
+  to: PeerId;
 }
 
 export type CommsSendParams = CommsSendParamsInput | CommsSendParamsPeerMessage | CommsSendParamsPeerLifecycle | CommsSendParamsPeerRequest | CommsSendParamsPeerResponse;
@@ -1483,11 +1493,19 @@ export interface CommsSendResultPeerResponseSent {
 
 export type CommsSendResult = CommsSendResultInputAccepted | CommsSendResultPeerMessageSent | CommsSendResultPeerLifecycleSent | CommsSendResultPeerRequestSent | CommsSendResultPeerResponseSent;
 
-export type CommsPeerSource = "Trusted" | "Inproc" | "TrustedAndInproc" | "Unknown";
+export type PeerId = string;
 
-export type CommsPeerReachability = "unknown" | "reachable" | "unreachable";
+export type PeerName = string;
 
-export type CommsPeerUnreachableReason = "offline_or_no_ack" | "transport_error" | "admission_dropped" | "unknown";
+export type PeerTransport = "inproc" | "uds" | "tcp";
+
+export type PeerDirectorySource = "trusted" | "inproc" | "trusted_and_inproc" | "unknown";
+
+export type PeerSendability = "peer_message" | "peer_request" | "peer_response";
+
+export type PeerReachability = "unknown" | "reachable" | "unreachable";
+
+export type PeerReachabilityReason = "offline_or_no_ack" | "transport_error" | "admission_dropped";
 
 export interface WireRenderMetadata {
   class: "user_prompt" | "peer_message" | "peer_request" | "peer_response" | "external_event" | "flow_step" | "continuation" | "system_notice" | "tool_scope_notice" | "ops_progress";

--- a/tools/sdk-codegen/generate.py
+++ b/tools/sdk-codegen/generate.py
@@ -94,7 +94,9 @@ MOB_RPC_CONTRACT_TYPES = [
 
 COMMS_SESSION_STREAM_RPC_CONTRACT_TYPES = [
     "CommsPeersParams",
-    "CommsPeerEntry",
+    "PeerAddress",
+    "PeerCapabilitySet",
+    "PeerDirectoryEntry",
     "CommsPeersResult",
     "SessionStreamOpenParams",
     "SessionStreamOpenResult",
@@ -105,9 +107,13 @@ COMMS_SESSION_STREAM_RPC_CONTRACT_TYPES = [
 COMMS_SESSION_STREAM_RPC_CONTRACT_ALIAS_TYPES = [
     "CommsSendParams",
     "CommsSendResult",
-    "CommsPeerSource",
-    "CommsPeerReachability",
-    "CommsPeerUnreachableReason",
+    "PeerId",
+    "PeerName",
+    "PeerTransport",
+    "PeerDirectorySource",
+    "PeerSendability",
+    "PeerReachability",
+    "PeerReachabilityReason",
 ]
 
 MOB_RPC_CONTRACT_ALIAS_TYPES = [


### PR DESCRIPTION
## Summary
- Add typed core peer-directory wire owners for source, sendability, capability envelope, and listing output.
- Switch RPC/REST/MCP peer listings to serialize the core PeerDirectoryListing instead of rebuilding peer JSON with debug strings.
- Regenerate schema artifacts and Python/TypeScript SDK generated types for PeerDirectoryListing.

## Validation
- ./scripts/repo-cargo test -p meerkat-core peer_directory_listing_serializes_typed_source_sendability_and_capabilities
- ./scripts/repo-cargo test -p meerkat-rpc rpc_peer_directory_response_uses_typed_core_wire_contract
- ./scripts/repo-cargo test -p meerkat-rest test_comms_peers_payload_uses_typed_core_wire_contract
- ./scripts/repo-cargo test -p meerkat-mcp-server test_comms_peers_tool_payload_uses_typed_core_wire_contract
- ./scripts/repo-cargo test -p meerkat-comms test_core_peers_includes_trusted_without_self
- ./scripts/repo-cargo test -p meerkat-comms test_m3_truthfulness_invariant_all_advertised_peers_are_sendable
- make regen-schemas
- python3 -m py_compile sdks/python/meerkat/generated/types.py
- make fmt-check
- make verify-schema-freshness
- make check

Linear: LUC-154
