### PR TITLE
LUC-158 Type peer response terminal projection

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -74,6 +74,7 @@ filegroup(
             ".git/**",
             "bazel-*",
             "bazel-*/**",
+            "**/node_modules/**",
             "target/**",
             "**/BUILD",
             "**/BUILD.bazel",

--- a/artifacts/schemas/rest-openapi.json
+++ b/artifacts/schemas/rest-openapi.json
@@ -8281,7 +8281,7 @@
       },
       "RestPeerResponseTerminalRequest": {
         "properties": {
-          "peer_name": {
+          "display_identity": {
             "type": "string"
           },
           "request_id": {
@@ -8290,16 +8290,24 @@
           "result": {
             "$ref": "#/components/schemas/JsonValue"
           },
+          "route_identity": {
+            "type": "string"
+          },
           "status": {
             "enum": [
               "completed",
-              "failed"
+              "failed",
+              "cancelled"
             ],
+            "type": "string"
+          },
+          "transport_identity": {
             "type": "string"
           }
         },
         "required": [
-          "peer_name",
+          "route_identity",
+          "display_identity",
           "request_id",
           "status",
           "result"

--- a/meerkat-auth-core/tests/google_auth_authorizer.rs
+++ b/meerkat-auth-core/tests/google_auth_authorizer.rs
@@ -69,10 +69,10 @@ struct MockFailure {
 async fn token_endpoint(State(state): State<MockState>, Form(form): Form<OAuthForm>) -> Response {
     let call = state.counter.fetch_add(1, Ordering::SeqCst) + 1;
     state.captured.lock().unwrap().push(form);
-    if let Some(failure) = &state.failure {
-        if call >= failure.from_call {
-            return (failure.status, Json(failure.body.clone())).into_response();
-        }
+    if let Some(failure) = &state.failure
+        && call >= failure.from_call
+    {
+        return (failure.status, Json(failure.body.clone())).into_response();
     }
     let expires_in = state
         .expires_in_by_call
@@ -97,10 +97,10 @@ async fn metadata_endpoint(
         return axum::http::StatusCode::FORBIDDEN.into_response();
     }
     let call = state.counter.fetch_add(1, Ordering::SeqCst) + 1;
-    if let Some(failure) = &state.failure {
-        if call >= failure.from_call {
-            return (failure.status, Json(failure.body.clone())).into_response();
-        }
+    if let Some(failure) = &state.failure
+        && call >= failure.from_call
+    {
+        return (failure.status, Json(failure.body.clone())).into_response();
     }
     let expires_in = state
         .expires_in_by_call

--- a/meerkat-cli/tests/cli_auth_flow.rs
+++ b/meerkat-cli/tests/cli_auth_flow.rs
@@ -41,23 +41,28 @@ auth_profile = "default_openai"
     .expect("write realm config");
 }
 
-fn seed_token_file(root: &std::path::Path, body: &str) {
-    let token_dir = root
-        .join("config")
-        .join("meerkat")
-        .join("credentials")
-        .join("dev");
-    std::fs::create_dir_all(&token_dir).expect("mkdir token dir");
-    std::fs::write(token_dir.join("default_openai.json"), body).expect("write token file");
-}
+fn token_file_path(root: &std::path::Path) -> PathBuf {
+    #[cfg(target_os = "macos")]
+    let config_root = root.join("Library").join("Application Support");
+    #[cfg(not(target_os = "macos"))]
+    let config_root = root.join("config");
 
-fn token_file_exists(root: &std::path::Path) -> bool {
-    root.join("config")
+    config_root
         .join("meerkat")
         .join("credentials")
         .join("dev")
         .join("default_openai.json")
-        .exists()
+}
+
+fn seed_token_file(root: &std::path::Path, body: &str) {
+    let token_file = token_file_path(root);
+    let token_dir = token_file.parent().expect("token file has parent");
+    std::fs::create_dir_all(token_dir).expect("mkdir token dir");
+    std::fs::write(token_file, body).expect("write token file");
+}
+
+fn token_file_exists(root: &std::path::Path) -> bool {
+    token_file_path(root).exists()
 }
 
 fn rkat_binary() -> Option<PathBuf> {

--- a/meerkat-comms/src/classify.rs
+++ b/meerkat-comms/src/classify.rs
@@ -484,7 +484,7 @@ mod tests {
     }
 
     #[test]
-    fn classify_response_as_response() {
+    fn classify_completed_response_as_terminal_response() {
         let sender = make_keypair();
         let trusted = make_trusted_peers("sender-agent", &sender.public_key());
         let ctx = make_context(true, trusted, vec![]);
@@ -499,7 +499,7 @@ mod tests {
         );
         let item = InboxItem::External { envelope };
         let result = ctx.classify(&item).expect("should classify");
-        assert_eq!(result.class, PeerInputClass::Response);
+        assert_eq!(result.class, PeerInputClass::ResponseTerminal);
     }
 
     #[test]

--- a/meerkat-comms/src/classify.rs
+++ b/meerkat-comms/src/classify.rs
@@ -500,6 +500,11 @@ mod tests {
         let item = InboxItem::External { envelope };
         let result = ctx.classify(&item).expect("should classify");
         assert_eq!(result.class, PeerInputClass::ResponseTerminal);
+        let expected_peer_id = sender.public_key().to_peer_id().to_string();
+        assert_eq!(
+            result.from_peer_id.as_deref(),
+            Some(expected_peer_id.as_str())
+        );
     }
 
     #[test]

--- a/meerkat-comms/src/inbox.rs
+++ b/meerkat-comms/src/inbox.rs
@@ -280,7 +280,12 @@ impl ClassifiedInboxQueue {
             .count();
         let response_count = queued_entries
             .iter()
-            .filter(|entry| entry.class == PeerInputClass::Response)
+            .filter(|entry| {
+                matches!(
+                    entry.class,
+                    PeerInputClass::ResponseProgress | PeerInputClass::ResponseTerminal
+                )
+            })
             .count();
         let lifecycle_count = queued_entries
             .iter()

--- a/meerkat-comms/src/runtime/comms_runtime.rs
+++ b/meerkat-comms/src/runtime/comms_runtime.rs
@@ -822,6 +822,7 @@ impl CoreCommsRuntime for CommsRuntime {
             .filter_map(|entry| {
                 let from_peer = entry.from_peer.unwrap_or_else(|| "unknown".to_string());
                 let source_peer_id = entry.from_peer_id;
+                let from_peer_id = entry.from_peer_id;
                 let rendered_text = entry.text_projection.clone();
 
                 match entry.item {
@@ -903,6 +904,7 @@ impl CoreCommsRuntime for CommsRuntime {
                         Some(meerkat_core::ClassifiedInboxInteraction {
                             interaction: meerkat_core::InboxInteraction {
                                 id: meerkat_core::InteractionId(envelope.id),
+                                from_route: from_peer_id,
                                 from: from_peer,
                                 content,
                                 rendered_text,
@@ -912,7 +914,7 @@ impl CoreCommsRuntime for CommsRuntime {
                             source_peer_id,
                             class: entry.class,
                             auth: Some(entry.auth),
-                            from_peer_id: entry.from_peer_id,
+                            from_peer_id,
                             lifecycle_peer: entry.lifecycle_peer,
                         })
                     }
@@ -929,6 +931,7 @@ impl CoreCommsRuntime for CommsRuntime {
                             id: meerkat_core::InteractionId(
                                 interaction_id.unwrap_or_else(uuid::Uuid::new_v4),
                             ),
+                            from_route: None,
                             from: format!("event:{source}"),
                             content: meerkat_core::InteractionContent::Message { body, blocks },
                             rendered_text,

--- a/meerkat-contracts/src/emit.rs
+++ b/meerkat-contracts/src/emit.rs
@@ -615,18 +615,26 @@ pub fn emit_all_schemas(output_dir: &std::path::Path) -> Result<(), Box<dyn std:
             "RestPeerResponseTerminalRequest".to_string(),
             object_schema(
                 vec![
-                    ("peer_name", string_schema()),
+                    ("transport_identity", string_schema()),
+                    ("route_identity", string_schema()),
+                    ("display_identity", string_schema()),
                     ("request_id", string_schema()),
                     (
                         "status",
                         serde_json::json!({
                             "type": "string",
-                            "enum": ["completed", "failed"]
+                            "enum": ["completed", "failed", "cancelled"]
                         }),
                     ),
                     ("result", json_value.clone()),
                 ],
-                vec!["peer_name", "request_id", "status", "result"],
+                vec![
+                    "route_identity",
+                    "display_identity",
+                    "request_id",
+                    "status",
+                    "result",
+                ],
             ),
         );
         components.insert(

--- a/meerkat-contracts/src/wire/runtime.rs
+++ b/meerkat-contracts/src/wire/runtime.rs
@@ -91,7 +91,10 @@ pub enum PeerResponseTerminalStatusWire {
 #[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
 pub struct SessionPeerResponseTerminalParams {
     pub session_id: String,
-    pub peer_name: PeerName,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub transport_identity: Option<String>,
+    pub route_identity: String,
+    pub display_identity: String,
     pub request_id: String,
     pub status: PeerResponseTerminalStatusWire,
     #[cfg_attr(feature = "schema", schemars(with = "serde_json::Value"))]
@@ -123,7 +126,10 @@ pub enum SessionExternalEventEnvelope {
     /// instead of routing terminal peer responses through the generic event
     /// ingress.
     PeerResponseTerminal {
-        peer_name: PeerName,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        transport_identity: Option<String>,
+        route_identity: String,
+        display_identity: String,
         request_id: String,
         status: PeerResponseTerminalStatusWire,
         #[serde(deserialize_with = "deserialize_raw_json_box")]

--- a/meerkat-core/src/agent.rs
+++ b/meerkat-core/src/agent.rs
@@ -773,6 +773,7 @@ pub trait CommsRuntime: Send + Sync {
             .into_iter()
             .map(|text| crate::interaction::InboxInteraction {
                 id: crate::interaction::InteractionId(uuid::Uuid::new_v4()),
+                from_route: None,
                 from: "unknown".into(),
                 content: crate::interaction::InteractionContent::Message {
                     body: text.clone(),

--- a/meerkat-core/src/agent/state.rs
+++ b/meerkat-core/src/agent/state.rs
@@ -3786,6 +3786,7 @@ mod tests {
                 .map(|text| crate::interaction::PeerInputCandidate {
                     interaction: crate::interaction::InboxInteraction {
                         id: crate::interaction::InteractionId(uuid::Uuid::new_v4()),
+                        from_route: None,
                         from: "unknown".into(),
                         content: crate::interaction::InteractionContent::Message {
                             body: text.clone(),

--- a/meerkat-core/src/handles.rs
+++ b/meerkat-core/src/handles.rs
@@ -225,6 +225,85 @@ impl PeerResponseTerminalProjectionStatus {
     }
 }
 
+#[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
+pub enum PeerResponseTerminalFactError {
+    #[error("route identity cannot be empty")]
+    EmptyRouteIdentity,
+    #[error("display identity cannot be empty")]
+    EmptyDisplayIdentity,
+    #[error("correlation id cannot be empty")]
+    EmptyCorrelationId,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PeerResponseTerminalSource {
+    pub transport_identity: Option<String>,
+    pub route_identity: String,
+    pub display_identity: String,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct PeerResponseTerminalFact {
+    pub source: PeerResponseTerminalSource,
+    pub correlation_id: String,
+    pub status: PeerResponseTerminalProjectionStatus,
+    pub render_payload: Option<serde_json::Value>,
+}
+
+impl PeerResponseTerminalFact {
+    pub fn new(
+        transport_identity: Option<String>,
+        route_identity: impl Into<String>,
+        display_identity: impl Into<String>,
+        correlation_id: impl Into<String>,
+        status: PeerResponseTerminalProjectionStatus,
+        render_payload: Option<serde_json::Value>,
+    ) -> Result<Self, PeerResponseTerminalFactError> {
+        let route_identity = route_identity.into();
+        if route_identity.trim().is_empty() {
+            return Err(PeerResponseTerminalFactError::EmptyRouteIdentity);
+        }
+
+        let display_identity = display_identity.into();
+        if display_identity.trim().is_empty() {
+            return Err(PeerResponseTerminalFactError::EmptyDisplayIdentity);
+        }
+
+        let correlation_id = correlation_id.into();
+        if correlation_id.trim().is_empty() {
+            return Err(PeerResponseTerminalFactError::EmptyCorrelationId);
+        }
+
+        let transport_identity = transport_identity
+            .and_then(|identity| (!identity.trim().is_empty()).then_some(identity));
+
+        Ok(Self {
+            source: PeerResponseTerminalSource {
+                transport_identity,
+                route_identity,
+                display_identity,
+            },
+            correlation_id,
+            status,
+            render_payload,
+        })
+    }
+
+    pub fn prompt_text(&self) -> String {
+        format!(
+            "[SYSTEM NOTICE][PEER_RESPONSE_TERMINAL] Correlated peer response from {}. Request ID: {}. Status: {}. Result: {}.",
+            self.source.display_identity,
+            self.correlation_id,
+            self.status.label(),
+            format_peer_projection_payload(self.render_payload.as_ref())
+        )
+    }
+
+    pub fn context_key(&self) -> String {
+        peer_response_terminal_context_key(&self.source.route_identity, &self.correlation_id)
+    }
+}
+
 #[derive(Debug, Clone, PartialEq)]
 pub enum PeerConversationProjection {
     Message {
@@ -244,14 +323,15 @@ pub enum PeerConversationProjection {
         payload: Option<serde_json::Value>,
     },
     ResponseTerminal {
-        peer_id: String,
-        request_id: String,
-        status: PeerResponseTerminalProjectionStatus,
-        payload: Option<serde_json::Value>,
+        fact: PeerResponseTerminalFact,
     },
 }
 
 impl PeerConversationProjection {
+    pub fn response_terminal(fact: PeerResponseTerminalFact) -> Self {
+        Self::ResponseTerminal { fact }
+    }
+
     pub fn block_prefix_text(&self) -> Option<String> {
         match self {
             Self::Message { peer_id } => Some(format!("[COMMS MESSAGE from {peer_id}]")),
@@ -298,26 +378,13 @@ impl PeerConversationProjection {
                 phase.label(),
                 format_peer_projection_payload(payload.as_ref())
             ),
-            Self::ResponseTerminal {
-                peer_id,
-                request_id,
-                status,
-                payload,
-            } => format!(
-                "[SYSTEM NOTICE][PEER_RESPONSE_TERMINAL] Correlated peer response from {peer_id}. Request ID: {request_id}. Status: {}. Result: {}.",
-                status.label(),
-                format_peer_projection_payload(payload.as_ref())
-            ),
+            Self::ResponseTerminal { fact } => fact.prompt_text(),
         }
     }
 
     pub fn context_key(&self) -> Option<String> {
         match self {
-            Self::ResponseTerminal {
-                peer_id,
-                request_id,
-                ..
-            } => Some(peer_response_terminal_context_key(peer_id, request_id)),
+            Self::ResponseTerminal { fact } => Some(fact.context_key()),
             Self::Message { .. } | Self::Request { .. } | Self::ResponseProgress { .. } => None,
         }
     }
@@ -1578,20 +1645,25 @@ pub trait RealtimeProductTurnHandle: Send + Sync {
 #[allow(clippy::unwrap_used)]
 mod tests {
     use super::{
-        PeerConversationProjection, PeerResponseProgressProjectionPhase,
+        PeerConversationProjection, PeerResponseProgressProjectionPhase, PeerResponseTerminalFact,
         PeerResponseTerminalProjectionStatus, peer_response_terminal_context_key,
     };
 
     #[test]
     fn peer_terminal_projection_owns_prompt_and_context_key() {
         let projection = PeerConversationProjection::ResponseTerminal {
-            peer_id: "analyst-rt".into(),
-            request_id: "req-123".into(),
-            status: PeerResponseTerminalProjectionStatus::Completed,
-            payload: Some(serde_json::json!({
-                "request_intent": "checksum_token",
-                "token": "birch seventeen"
-            })),
+            fact: PeerResponseTerminalFact::new(
+                Some("transport-runtime-1".into()),
+                "analyst-rt",
+                "Analyst",
+                "req-123",
+                PeerResponseTerminalProjectionStatus::Completed,
+                Some(serde_json::json!({
+                    "request_intent": "checksum_token",
+                    "token": "birch seventeen"
+                })),
+            )
+            .unwrap(),
         };
 
         assert_eq!(
@@ -1600,7 +1672,7 @@ mod tests {
         );
         assert_eq!(
             projection.prompt_text(),
-            "[SYSTEM NOTICE][PEER_RESPONSE_TERMINAL] Correlated peer response from analyst-rt. Request ID: req-123. Status: completed. Result: {\n  \"request_intent\": \"checksum_token\",\n  \"token\": \"birch seventeen\"\n}."
+            "[SYSTEM NOTICE][PEER_RESPONSE_TERMINAL] Correlated peer response from Analyst. Request ID: req-123. Status: completed. Result: {\n  \"request_intent\": \"checksum_token\",\n  \"token\": \"birch seventeen\"\n}."
         );
     }
 

--- a/meerkat-core/src/handles.rs
+++ b/meerkat-core/src/handles.rs
@@ -227,66 +227,205 @@ impl PeerResponseTerminalProjectionStatus {
 
 #[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
 pub enum PeerResponseTerminalFactError {
+    #[error("transport identity cannot be empty")]
+    EmptyTransportIdentity,
     #[error("route identity cannot be empty")]
     EmptyRouteIdentity,
+    #[error("route identity cannot contain control characters")]
+    InvalidRouteIdentity,
+    #[error("display identity is required")]
+    MissingDisplayIdentity,
     #[error("display identity cannot be empty")]
     EmptyDisplayIdentity,
+    #[error("display identity cannot contain control characters")]
+    InvalidDisplayIdentity,
     #[error("correlation id cannot be empty")]
     EmptyCorrelationId,
+    #[error("correlation id must be a UUID: {input}")]
+    InvalidCorrelationId { input: String },
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PeerResponseTerminalTransportIdentity(String);
+
+impl PeerResponseTerminalTransportIdentity {
+    pub fn parse(raw: impl Into<String>) -> Result<Self, PeerResponseTerminalFactError> {
+        let raw = raw.into();
+        if raw.trim().is_empty() {
+            return Err(PeerResponseTerminalFactError::EmptyTransportIdentity);
+        }
+        Ok(Self(raw))
+    }
+
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+impl std::fmt::Display for PeerResponseTerminalTransportIdentity {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        self.0.fmt(f)
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PeerResponseTerminalRouteIdentity(String);
+
+impl PeerResponseTerminalRouteIdentity {
+    pub fn parse(raw: impl Into<String>) -> Result<Self, PeerResponseTerminalFactError> {
+        let raw = raw.into();
+        if raw.trim().is_empty() {
+            return Err(PeerResponseTerminalFactError::EmptyRouteIdentity);
+        }
+        if raw.chars().any(char::is_control) {
+            return Err(PeerResponseTerminalFactError::InvalidRouteIdentity);
+        }
+        Ok(Self(raw))
+    }
+
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+impl std::fmt::Display for PeerResponseTerminalRouteIdentity {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        self.0.fmt(f)
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PeerResponseTerminalDisplayIdentity(String);
+
+impl PeerResponseTerminalDisplayIdentity {
+    pub fn parse(raw: impl Into<String>) -> Result<Self, PeerResponseTerminalFactError> {
+        let raw = raw.into();
+        if raw.trim().is_empty() {
+            return Err(PeerResponseTerminalFactError::EmptyDisplayIdentity);
+        }
+        if raw.chars().any(char::is_control) {
+            return Err(PeerResponseTerminalFactError::InvalidDisplayIdentity);
+        }
+        Ok(Self(raw))
+    }
+
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+impl std::fmt::Display for PeerResponseTerminalDisplayIdentity {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        self.0.fmt(f)
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct PeerResponseTerminalCorrelationId(PeerCorrelationId);
+
+impl PeerResponseTerminalCorrelationId {
+    pub fn parse(raw: impl AsRef<str>) -> Result<Self, PeerResponseTerminalFactError> {
+        let raw = raw.as_ref();
+        if raw.trim().is_empty() {
+            return Err(PeerResponseTerminalFactError::EmptyCorrelationId);
+        }
+        uuid::Uuid::parse_str(raw)
+            .map(|uuid| Self(PeerCorrelationId::from_uuid(uuid)))
+            .map_err(|_| PeerResponseTerminalFactError::InvalidCorrelationId {
+                input: raw.to_string(),
+            })
+    }
+
+    pub const fn from_peer_correlation_id(correlation_id: PeerCorrelationId) -> Self {
+        Self(correlation_id)
+    }
+
+    pub const fn as_peer_correlation_id(self) -> PeerCorrelationId {
+        self.0
+    }
+}
+
+impl std::fmt::Display for PeerResponseTerminalCorrelationId {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        self.0.fmt(f)
+    }
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct PeerResponseTerminalRenderPayload(Option<serde_json::Value>);
+
+impl PeerResponseTerminalRenderPayload {
+    pub fn new(payload: Option<serde_json::Value>) -> Self {
+        Self(payload)
+    }
+
+    pub fn as_ref(&self) -> Option<&serde_json::Value> {
+        self.0.as_ref()
+    }
+}
+
+impl From<Option<serde_json::Value>> for PeerResponseTerminalRenderPayload {
+    fn from(payload: Option<serde_json::Value>) -> Self {
+        Self::new(payload)
+    }
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct PeerResponseTerminalSource {
-    pub transport_identity: Option<String>,
-    pub route_identity: String,
-    pub display_identity: String,
+    pub transport_identity: Option<PeerResponseTerminalTransportIdentity>,
+    pub route_identity: PeerResponseTerminalRouteIdentity,
+    pub display_identity: PeerResponseTerminalDisplayIdentity,
+}
+
+impl PeerResponseTerminalSource {
+    pub fn new(
+        transport_identity: Option<PeerResponseTerminalTransportIdentity>,
+        route_identity: PeerResponseTerminalRouteIdentity,
+        display_identity: PeerResponseTerminalDisplayIdentity,
+    ) -> Self {
+        Self {
+            transport_identity,
+            route_identity,
+            display_identity,
+        }
+    }
+
+    pub fn parse(
+        transport_identity: Option<impl Into<String>>,
+        route_identity: impl Into<String>,
+        display_identity: impl Into<String>,
+    ) -> Result<Self, PeerResponseTerminalFactError> {
+        Ok(Self::new(
+            transport_identity
+                .map(PeerResponseTerminalTransportIdentity::parse)
+                .transpose()?,
+            PeerResponseTerminalRouteIdentity::parse(route_identity)?,
+            PeerResponseTerminalDisplayIdentity::parse(display_identity)?,
+        ))
+    }
 }
 
 #[derive(Debug, Clone, PartialEq)]
 pub struct PeerResponseTerminalFact {
     pub source: PeerResponseTerminalSource,
-    pub correlation_id: String,
+    pub correlation_id: PeerResponseTerminalCorrelationId,
     pub status: PeerResponseTerminalProjectionStatus,
-    pub render_payload: Option<serde_json::Value>,
+    pub render_payload: PeerResponseTerminalRenderPayload,
 }
 
 impl PeerResponseTerminalFact {
     pub fn new(
-        transport_identity: Option<String>,
-        route_identity: impl Into<String>,
-        display_identity: impl Into<String>,
-        correlation_id: impl Into<String>,
+        source: PeerResponseTerminalSource,
+        correlation_id: PeerResponseTerminalCorrelationId,
         status: PeerResponseTerminalProjectionStatus,
-        render_payload: Option<serde_json::Value>,
-    ) -> Result<Self, PeerResponseTerminalFactError> {
-        let route_identity = route_identity.into();
-        if route_identity.trim().is_empty() {
-            return Err(PeerResponseTerminalFactError::EmptyRouteIdentity);
-        }
-
-        let display_identity = display_identity.into();
-        if display_identity.trim().is_empty() {
-            return Err(PeerResponseTerminalFactError::EmptyDisplayIdentity);
-        }
-
-        let correlation_id = correlation_id.into();
-        if correlation_id.trim().is_empty() {
-            return Err(PeerResponseTerminalFactError::EmptyCorrelationId);
-        }
-
-        let transport_identity = transport_identity
-            .and_then(|identity| (!identity.trim().is_empty()).then_some(identity));
-
-        Ok(Self {
-            source: PeerResponseTerminalSource {
-                transport_identity,
-                route_identity,
-                display_identity,
-            },
+        render_payload: PeerResponseTerminalRenderPayload,
+    ) -> Self {
+        Self {
+            source,
             correlation_id,
             status,
             render_payload,
-        })
+        }
     }
 
     pub fn prompt_text(&self) -> String {
@@ -300,7 +439,7 @@ impl PeerResponseTerminalFact {
     }
 
     pub fn context_key(&self) -> String {
-        peer_response_terminal_context_key(&self.source.route_identity, &self.correlation_id)
+        peer_response_terminal_context_key(&self.source.route_identity, self.correlation_id)
     }
 }
 
@@ -390,8 +529,11 @@ impl PeerConversationProjection {
     }
 }
 
-pub fn peer_response_terminal_context_key(peer_id: &str, request_id: &str) -> String {
-    format!("peer_response_terminal:{peer_id}:{request_id}")
+pub fn peer_response_terminal_context_key(
+    route_identity: &PeerResponseTerminalRouteIdentity,
+    correlation_id: PeerResponseTerminalCorrelationId,
+) -> String {
+    format!("peer_response_terminal:{route_identity}:{correlation_id}")
 }
 
 fn format_peer_projection_payload(payload: Option<&serde_json::Value>) -> String {
@@ -1645,34 +1787,48 @@ pub trait RealtimeProductTurnHandle: Send + Sync {
 #[allow(clippy::unwrap_used)]
 mod tests {
     use super::{
-        PeerConversationProjection, PeerResponseProgressProjectionPhase, PeerResponseTerminalFact,
-        PeerResponseTerminalProjectionStatus, peer_response_terminal_context_key,
+        PeerConversationProjection, PeerResponseProgressProjectionPhase,
+        PeerResponseTerminalCorrelationId, PeerResponseTerminalDisplayIdentity,
+        PeerResponseTerminalFact, PeerResponseTerminalProjectionStatus,
+        PeerResponseTerminalRenderPayload, PeerResponseTerminalRouteIdentity,
+        PeerResponseTerminalSource, PeerResponseTerminalTransportIdentity,
+        peer_response_terminal_context_key,
     };
 
     #[test]
     fn peer_terminal_projection_owns_prompt_and_context_key() {
+        let route_identity =
+            PeerResponseTerminalRouteIdentity::parse("analyst-rt").expect("route identity");
+        let correlation_id =
+            PeerResponseTerminalCorrelationId::parse("018f6f79-7a82-7c4e-a552-a3b86f9630f1")
+                .expect("correlation id");
         let projection = PeerConversationProjection::ResponseTerminal {
             fact: PeerResponseTerminalFact::new(
-                Some("transport-runtime-1".into()),
-                "analyst-rt",
-                "Analyst",
-                "req-123",
+                PeerResponseTerminalSource::new(
+                    Some(
+                        PeerResponseTerminalTransportIdentity::parse("transport-runtime-1")
+                            .expect("transport identity"),
+                    ),
+                    route_identity.clone(),
+                    PeerResponseTerminalDisplayIdentity::parse("Analyst")
+                        .expect("display identity"),
+                ),
+                correlation_id,
                 PeerResponseTerminalProjectionStatus::Completed,
-                Some(serde_json::json!({
+                PeerResponseTerminalRenderPayload::new(Some(serde_json::json!({
                     "request_intent": "checksum_token",
                     "token": "birch seventeen"
-                })),
-            )
-            .unwrap(),
+                }))),
+            ),
         };
 
         assert_eq!(
             projection.context_key().as_deref(),
-            Some("peer_response_terminal:analyst-rt:req-123")
+            Some("peer_response_terminal:analyst-rt:018f6f79-7a82-7c4e-a552-a3b86f9630f1")
         );
         assert_eq!(
             projection.prompt_text(),
-            "[SYSTEM NOTICE][PEER_RESPONSE_TERMINAL] Correlated peer response from Analyst. Request ID: req-123. Status: completed. Result: {\n  \"request_intent\": \"checksum_token\",\n  \"token\": \"birch seventeen\"\n}."
+            "[SYSTEM NOTICE][PEER_RESPONSE_TERMINAL] Correlated peer response from Analyst. Request ID: 018f6f79-7a82-7c4e-a552-a3b86f9630f1. Status: completed. Result: {\n  \"request_intent\": \"checksum_token\",\n  \"token\": \"birch seventeen\"\n}."
         );
     }
 
@@ -1694,9 +1850,14 @@ mod tests {
 
     #[test]
     fn peer_terminal_context_key_helper_stays_canonical() {
+        let route_identity =
+            PeerResponseTerminalRouteIdentity::parse("peer-a").expect("route identity");
+        let correlation_id =
+            PeerResponseTerminalCorrelationId::parse("018f6f79-7a82-7c4e-a552-a3b86f9630f1")
+                .expect("correlation id");
         assert_eq!(
-            peer_response_terminal_context_key("peer-a", "req-z"),
-            "peer_response_terminal:peer-a:req-z"
+            peer_response_terminal_context_key(&route_identity, correlation_id),
+            "peer_response_terminal:peer-a:018f6f79-7a82-7c4e-a552-a3b86f9630f1"
         );
     }
 }

--- a/meerkat-core/src/interaction.rs
+++ b/meerkat-core/src/interaction.rs
@@ -280,8 +280,10 @@ pub enum PeerInputClass {
     ActionableMessage,
     /// A peer request that should route through canonical runtime admission.
     ActionableRequest,
-    /// A response to a previous outbound request (non-interrupting context).
-    Response,
+    /// A non-terminal response to a previous outbound request.
+    ResponseProgress,
+    /// A terminal response to a previous outbound request.
+    ResponseTerminal,
     /// Peer added lifecycle event.
     PeerLifecycleAdded,
     /// Peer retired lifecycle event.
@@ -307,7 +309,8 @@ impl PeerInputClass {
             self,
             Self::ActionableMessage
                 | Self::ActionableRequest
-                | Self::Response
+                | Self::ResponseProgress
+                | Self::ResponseTerminal
                 | Self::PlainEvent
                 | Self::PeerLifecycleKickoffFailed
                 | Self::PeerLifecycleKickoffCancelled
@@ -448,8 +451,12 @@ impl PeerIngressMachinePolicy {
         PeerIngressClassification::lifecycle(kind)
     }
 
-    pub fn classify_response(&self, _status: ResponseStatus) -> PeerIngressClassification {
-        PeerIngressClassification::required(PeerInputClass::Response, PeerIngressKind::Response)
+    pub fn classify_response(&self, status: ResponseStatus) -> PeerIngressClassification {
+        let class = match classify_response_terminality(status) {
+            TerminalityClass::Progress => PeerInputClass::ResponseProgress,
+            TerminalityClass::Terminal { .. } => PeerInputClass::ResponseTerminal,
+        };
+        PeerIngressClassification::required(class, PeerIngressKind::Response)
     }
 
     pub fn classify_ack(&self) -> PeerIngressClassification {
@@ -745,6 +752,24 @@ mod tests {
             TerminalityClass::Terminal {
                 disposition: TerminalDisposition::Failed
             }
+        );
+    }
+
+    #[test]
+    fn peer_ingress_policy_owns_response_terminal_classification() {
+        let policy = PeerIngressMachinePolicy::default();
+
+        assert_eq!(
+            policy.classify_response(ResponseStatus::Accepted).class,
+            PeerInputClass::ResponseProgress
+        );
+        assert_eq!(
+            policy.classify_response(ResponseStatus::Completed).class,
+            PeerInputClass::ResponseTerminal
+        );
+        assert_eq!(
+            policy.classify_response(ResponseStatus::Failed).class,
+            PeerInputClass::ResponseTerminal
         );
     }
 

--- a/meerkat-core/src/interaction.rs
+++ b/meerkat-core/src/interaction.rs
@@ -97,7 +97,10 @@ pub enum InteractionContent {
 pub struct InboxInteraction {
     /// Unique identifier for this interaction.
     pub id: InteractionId,
-    /// Who sent this interaction (peer name or source label).
+    /// Machine route identity for peer senders. Plain external events leave
+    /// this unset because they are source-labelled, not peer-routed.
+    pub from_route: Option<PeerId>,
+    /// Who sent this interaction (peer display name or source label).
     pub from: String,
     /// The interaction content.
     pub content: InteractionContent,
@@ -826,6 +829,7 @@ mod tests {
     fn inbox_interaction_preserves_runtime_hints() {
         let interaction = InboxInteraction {
             id: InteractionId(Uuid::new_v4()),
+            from_route: None,
             from: "event:webhook".into(),
             content: InteractionContent::Message {
                 body: "hello".into(),

--- a/meerkat-core/src/lib.rs
+++ b/meerkat-core/src/lib.rs
@@ -165,11 +165,13 @@ pub use gateway::{DynamicToolComposite, ToolGateway, ToolGatewayBuilder};
 pub use handles::{
     AuthLeasePhase, CommsDrainHandle, DrainExitReason, DrainMode, DslRejectionKind,
     DslTransitionError, ExternalToolSurfaceHandle, McpServerLifecycleHandle, PeerCommsHandle,
-    PeerConversationProjection, PeerResponseProgressProjectionPhase, PeerResponseTerminalFact,
-    PeerResponseTerminalFactError, PeerResponseTerminalProjectionStatus,
-    PeerResponseTerminalSource, RealtimeProductTurnHandle, RealtimeProductTurnPhase,
-    SessionAdmissionHandle, SurfaceDiagnosticSnapshot, SurfaceSnapshot, TurnStateHandle,
-    TurnStateSnapshot,
+    PeerConversationProjection, PeerResponseProgressProjectionPhase,
+    PeerResponseTerminalCorrelationId, PeerResponseTerminalDisplayIdentity,
+    PeerResponseTerminalFact, PeerResponseTerminalFactError, PeerResponseTerminalProjectionStatus,
+    PeerResponseTerminalRenderPayload, PeerResponseTerminalRouteIdentity,
+    PeerResponseTerminalSource, PeerResponseTerminalTransportIdentity, RealtimeProductTurnHandle,
+    RealtimeProductTurnPhase, SessionAdmissionHandle, SurfaceDiagnosticSnapshot, SurfaceSnapshot,
+    TurnStateHandle, TurnStateSnapshot,
 };
 pub use hooks::{
     HookCapability, HookDecision, HookEngine, HookEngineError, HookExecutionMode,

--- a/meerkat-core/src/lib.rs
+++ b/meerkat-core/src/lib.rs
@@ -165,8 +165,9 @@ pub use gateway::{DynamicToolComposite, ToolGateway, ToolGatewayBuilder};
 pub use handles::{
     AuthLeasePhase, CommsDrainHandle, DrainExitReason, DrainMode, DslRejectionKind,
     DslTransitionError, ExternalToolSurfaceHandle, McpServerLifecycleHandle, PeerCommsHandle,
-    PeerConversationProjection, PeerResponseProgressProjectionPhase,
-    PeerResponseTerminalProjectionStatus, RealtimeProductTurnHandle, RealtimeProductTurnPhase,
+    PeerConversationProjection, PeerResponseProgressProjectionPhase, PeerResponseTerminalFact,
+    PeerResponseTerminalFactError, PeerResponseTerminalProjectionStatus,
+    PeerResponseTerminalSource, RealtimeProductTurnHandle, RealtimeProductTurnPhase,
     SessionAdmissionHandle, SurfaceDiagnosticSnapshot, SurfaceSnapshot, TurnStateHandle,
     TurnStateSnapshot,
 };

--- a/meerkat-core/src/session.rs
+++ b/meerkat-core/src/session.rs
@@ -1519,8 +1519,11 @@ mod tests {
             .stage_append(
                 &AppendSystemContextRequest {
                     text: "Authoritative peer token is birch seventeen.".to_string(),
-                    source: Some("peer_response_terminal:analyst:req-123".to_string()),
-                    idempotency_key: Some("req-123".to_string()),
+                    source: Some(
+                        "peer_response_terminal:analyst:018f6f79-7a82-7c4e-a552-a3b86f9630f1"
+                            .to_string(),
+                    ),
+                    idempotency_key: Some("018f6f79-7a82-7c4e-a552-a3b86f9630f1".to_string()),
                 },
                 accepted_at,
             )
@@ -1536,7 +1539,7 @@ mod tests {
         );
         assert_eq!(
             state.applied[0].source.as_deref(),
-            Some("peer_response_terminal:analyst:req-123")
+            Some("peer_response_terminal:analyst:018f6f79-7a82-7c4e-a552-a3b86f9630f1")
         );
 
         let round_tripped: SessionSystemContextState =
@@ -1549,8 +1552,10 @@ mod tests {
     fn append_system_context_blocks_records_typed_applied_context() {
         let append = PendingSystemContextAppend {
             text: "Authoritative peer token is birch seventeen.".to_string(),
-            source: Some("peer_response_terminal:analyst:req-123".to_string()),
-            idempotency_key: Some("req-123".to_string()),
+            source: Some(
+                "peer_response_terminal:analyst:018f6f79-7a82-7c4e-a552-a3b86f9630f1".to_string(),
+            ),
+            idempotency_key: Some("018f6f79-7a82-7c4e-a552-a3b86f9630f1".to_string()),
             accepted_at: SystemTime::UNIX_EPOCH,
         };
         let mut session = Session::new();

--- a/meerkat-mob-mcp/src/agent_tools.rs
+++ b/meerkat-mob-mcp/src/agent_tools.rs
@@ -2184,6 +2184,7 @@ mod tests {
                         .ok_or_else(|| SendError::PeerNotFound(to.label()))?;
                     recipient.inbox.write().await.push(InboxInteraction {
                         id: InteractionId(uuid::Uuid::new_v4()),
+                        from_route: Some(self.peer_id),
                         from: self.name.clone(),
                         content: InteractionContent::Request { intent, params },
                         rendered_text: String::new(),

--- a/meerkat-mob/src/runtime/local_bridge.rs
+++ b/meerkat-mob/src/runtime/local_bridge.rs
@@ -120,6 +120,7 @@ impl MobBoundMemberRuntimeBridge for LocalMobRuntimeBridge {
                 timestamp: chrono::Utc::now(),
                 source: InputOrigin::Peer {
                     peer_id: format!("local-bridge:{}", self.session_id),
+                    display_identity: Some(format!("local-bridge:{}", self.session_id)),
                     runtime_id: Some(LogicalRuntimeId::new(self.session_id.to_string())),
                 },
                 durability: InputDurability::Durable,

--- a/meerkat-mob/src/runtime/supervisor_bridge.rs
+++ b/meerkat-mob/src/runtime/supervisor_bridge.rs
@@ -295,7 +295,7 @@ impl BridgeRequestDeadline {
 mod tests {
     use super::*;
 
-    use meerkat_core::PeerInputClass;
+    use meerkat_core::PeerIngressMachinePolicy;
     use meerkat_core::interaction::{InboxInteraction, InteractionId, ResponseStatus};
 
     fn response_candidate(
@@ -316,7 +316,9 @@ mod tests {
                 handling_mode: HandlingMode::Queue,
                 render_metadata: None,
             },
-            class: PeerInputClass::Response,
+            class: PeerIngressMachinePolicy::default()
+                .classify_response(status)
+                .class,
             auth: Some(meerkat_core::PeerIngressAuthDecision::Required),
             from_peer_id: None,
             lifecycle_peer: None,

--- a/meerkat-mob/src/runtime/supervisor_bridge.rs
+++ b/meerkat-mob/src/runtime/supervisor_bridge.rs
@@ -4,7 +4,7 @@ use crate::store::SupervisorAuthorityRecord;
 use crate::tokio;
 use meerkat_core::agent::CommsRuntime as CoreCommsRuntime;
 use meerkat_core::comms::{
-    CommsCommand, InputStreamMode, PeerRoute, SendReceipt, TrustedPeerDescriptor,
+    CommsCommand, InputStreamMode, PeerId, PeerRoute, SendReceipt, TrustedPeerDescriptor,
 };
 use meerkat_core::interaction::{
     InteractionContent, PeerInputCandidate, TerminalityClass, classify_response_terminality,
@@ -306,6 +306,10 @@ mod tests {
         PeerInputCandidate {
             interaction: InboxInteraction {
                 id: InteractionId(uuid::Uuid::new_v4()),
+                from_route: Some(PeerId::from_uuid(
+                    uuid::Uuid::parse_str("018f6f79-7a82-7c4e-a552-a3b86f9630f5")
+                        .expect("valid worker route id"),
+                )),
                 from: "worker-rt".to_string(),
                 content: InteractionContent::Response {
                     in_reply_to: InteractionId(request_envelope_id),

--- a/meerkat-mob/src/runtime/tests.rs
+++ b/meerkat-mob/src/runtime/tests.rs
@@ -20126,6 +20126,8 @@ async fn test_peer_response_reaches_requester_in_runtime_backed_real_comms() {
         .real_comms(&sid_responder)
         .await
         .expect("responder comms");
+    let responder_route_identity = responder_comms.public_key().to_peer_id().to_string();
+    let responder_display_identity = test_comms_name("worker", "w-responder");
 
     let receipt = CoreCommsRuntime::send(
         &*requester_comms,
@@ -20185,14 +20187,13 @@ async fn test_peer_response_reaches_requester_in_runtime_backed_real_comms() {
                     let text = append.text.as_str();
                     let source = append.source.as_deref().unwrap_or_default();
                     let idempotency_key = append.idempotency_key.as_deref().unwrap_or_default();
+                    let expected_source =
+                        format!("peer_response_terminal:{responder_route_identity}:{request_id}");
                     text.contains("[SYSTEM NOTICE][PEER_RESPONSE_TERMINAL]")
                         && text.contains("from test-mob/worker/w-responder")
                         && text.contains("lighthouse")
                         && text.contains(&format!("Request ID: {request_id}"))
-                        && source
-                            == format!(
-                                "peer_response_terminal:test-mob/worker/w-responder:{request_id}"
-                            )
+                        && source == expected_source
                         && idempotency_key == source
                 })
             {
@@ -20272,8 +20273,15 @@ async fn test_peer_response_reaches_requester_in_runtime_backed_real_comms() {
         "terminal peer response reaction should be system-triggered, not a new user prompt"
     );
 
+    let duplicate_source = meerkat_core::PeerResponseTerminalSource::new(
+        None,
+        meerkat_core::PeerResponseTerminalRouteIdentity::parse(responder_route_identity)
+            .expect("responder route identity"),
+        meerkat_core::PeerResponseTerminalDisplayIdentity::parse(responder_display_identity)
+            .expect("responder display identity"),
+    );
     let duplicate = meerkat_runtime::peer_response_terminal_input(
-        &PeerName::new(test_comms_name("worker", "w-responder")).expect("peer name"),
+        duplicate_source,
         request_id.to_string(),
         meerkat_contracts::PeerResponseTerminalStatusWire::Completed,
         serde_json::json!({"interpretation":"lighthouse"}),
@@ -20482,8 +20490,7 @@ async fn test_mcp_send_request_response_terminal_steer_is_visible_to_requester()
     .await
     .expect("requester should apply terminal peer response context after sent tool result");
 
-    let expected_context_key =
-        format!("peer_response_terminal:test-mob/worker/w-mcp-responder:{request_id}");
+    let expected_context_key = format!("peer_response_terminal:{responder_peer_id}:{request_id}");
     assert_eq!(
         requester_terminal_context.source.as_deref(),
         Some(expected_context_key.as_str())

--- a/meerkat-rest/src/lib.rs
+++ b/meerkat-rest/src/lib.rs
@@ -2102,7 +2102,10 @@ enum RestSessionExternalEventEnvelope {
 
 #[derive(Debug, Deserialize)]
 struct RestPeerResponseTerminalBody {
-    peer_name: meerkat_core::comms::PeerName,
+    #[serde(default)]
+    transport_identity: Option<String>,
+    route_identity: String,
+    display_identity: String,
     request_id: String,
     status: meerkat_contracts::PeerResponseTerminalStatusWire,
     result: Value,
@@ -2158,15 +2161,18 @@ async fn post_peer_response_terminal(
     webhook::verify_webhook(&headers, &state.webhook_auth)
         .map_err(|msg| ApiError::Unauthorized(msg.to_string()).into_response())?;
 
-    let peer_name = meerkat_core::comms::PeerName::new(body.peer_name.as_str().to_string())
-        .map_err(ApiError::BadRequest)
-        .map_err(IntoResponse::into_response)?;
+    let source = meerkat_core::PeerResponseTerminalSource::parse(
+        body.transport_identity,
+        body.route_identity,
+        body.display_identity,
+    )
+    .map_err(|err| ApiError::BadRequest(err.to_string()).into_response())?;
 
     let session_id =
         resolve_session_id_for_state(&id, &state).map_err(IntoResponse::into_response)?;
 
     let input = meerkat_runtime::peer_response_terminal_input(
-        &peer_name,
+        source,
         body.request_id,
         body.status,
         body.result,

--- a/meerkat-rpc/src/handlers/event.rs
+++ b/meerkat-rpc/src/handlers/event.rs
@@ -26,7 +26,10 @@ pub struct ExternalEventParams {
 #[derive(Debug, Deserialize)]
 pub struct PeerResponseTerminalParams {
     pub session_id: String,
-    pub peer_name: meerkat_core::comms::PeerName,
+    #[serde(default)]
+    pub transport_identity: Option<String>,
+    pub route_identity: String,
+    pub display_identity: String,
     pub request_id: String,
     pub status: PeerResponseTerminalStatusWire,
     pub result: serde_json::Value,
@@ -104,10 +107,19 @@ pub async fn handle_peer_response_terminal(
         Err(resp) => return resp,
     };
 
+    let source = match meerkat_core::PeerResponseTerminalSource::parse(
+        params.transport_identity,
+        params.route_identity,
+        params.display_identity,
+    ) {
+        Ok(source) => source,
+        Err(err) => return RpcResponse::error(id, crate::error::INVALID_PARAMS, err.to_string()),
+    };
+
     let outcome = runtime
         .accept_peer_response_terminal_via_runtime(
             &session_id,
-            params.peer_name,
+            source,
             params.request_id,
             params.status,
             params.result,
@@ -224,20 +236,23 @@ mod tests {
 
     #[test]
     fn test_external_event_params_reject_variant_deserialization() {
-        let json = r#"{"session_id":"sid_123","kind":"peer_response_terminal","peer_name":"analyst","request_id":"req-1","status":"completed","result":{"token":"amber"}}"#;
+        let json = r#"{"session_id":"sid_123","kind":"peer_response_terminal","route_identity":"analyst-rt","display_identity":"Analyst","request_id":"req-1","status":"completed","result":{"token":"amber"}}"#;
         let params: ExternalEventParams = serde_json::from_str(json).unwrap();
         assert!(matches!(
             params.event,
             SessionExternalEventEnvelope::PeerResponseTerminal { .. }
         ));
         if let SessionExternalEventEnvelope::PeerResponseTerminal {
-            peer_name,
+            route_identity,
+            display_identity,
             request_id,
             status,
             result,
+            ..
         } = params.event
         {
-            assert_eq!(peer_name.as_str(), "analyst");
+            assert_eq!(route_identity, "analyst-rt");
+            assert_eq!(display_identity, "Analyst");
             assert_eq!(request_id, "req-1");
             assert_eq!(status, PeerResponseTerminalStatusWire::Completed);
             let result_value: serde_json::Value =
@@ -248,10 +263,11 @@ mod tests {
 
     #[test]
     fn test_peer_response_terminal_params_deserialization() {
-        let json = r#"{"session_id":"sid_123","peer_name":"analyst","request_id":"req-1","status":"failed","result":null}"#;
+        let json = r#"{"session_id":"sid_123","route_identity":"analyst-rt","display_identity":"Analyst","request_id":"req-1","status":"failed","result":null}"#;
         let params: PeerResponseTerminalParams = serde_json::from_str(json).unwrap();
         assert_eq!(params.session_id, "sid_123");
-        assert_eq!(params.peer_name.as_str(), "analyst");
+        assert_eq!(params.route_identity, "analyst-rt");
+        assert_eq!(params.display_identity, "Analyst");
         assert_eq!(params.request_id, "req-1");
         assert_eq!(params.status, PeerResponseTerminalStatusWire::Failed);
         assert_eq!(params.result, serde_json::Value::Null);

--- a/meerkat-rpc/src/realtime_ws.rs
+++ b/meerkat-rpc/src/realtime_ws.rs
@@ -3413,27 +3413,45 @@ async fn handle_product_session_tool_call(
     };
 
     match outcome_result {
-        Ok(outcome) => match submit_product_session_tool_result(
-            runtime,
-            binding,
-            product_session,
-            outcome.result,
-        )
-        .await
-        {
-            Ok(()) => {
-                frames.push(channel_event(RealtimeEvent::ToolCallCompleted { call_id }));
-                Ok(frames)
+        Ok(outcome) if outcome.result.is_error => {
+            let error_message = outcome.result.text_content();
+            let _ = submit_product_session_tool_error(
+                runtime,
+                binding,
+                product_session,
+                call_id.clone(),
+                error_message.clone(),
+            )
+            .await;
+            frames.push(channel_event(RealtimeEvent::ToolCallFailed {
+                call_id,
+                error: error_message,
+            }));
+            Ok(frames)
+        }
+        Ok(outcome) => {
+            match submit_product_session_tool_result(
+                runtime,
+                binding,
+                product_session,
+                outcome.result,
+            )
+            .await
+            {
+                Ok(()) => {
+                    frames.push(channel_event(RealtimeEvent::ToolCallCompleted { call_id }));
+                    Ok(frames)
+                }
+                Err(error) => {
+                    let error_message = error.message;
+                    frames.push(channel_event(RealtimeEvent::ToolCallFailed {
+                        call_id,
+                        error: error_message,
+                    }));
+                    Ok(frames)
+                }
             }
-            Err(error) => {
-                let error_message = error.message;
-                frames.push(channel_event(RealtimeEvent::ToolCallFailed {
-                    call_id,
-                    error: error_message,
-                }));
-                Ok(frames)
-            }
-        },
+        }
         Err(error) => {
             let error_message = error.to_string();
             let _ = submit_product_session_tool_error(

--- a/meerkat-rpc/src/session_runtime.rs
+++ b/meerkat-rpc/src/session_runtime.rs
@@ -2322,7 +2322,7 @@ impl SessionRuntime {
     pub async fn accept_peer_response_terminal_via_runtime(
         self: &Arc<Self>,
         session_id: &SessionId,
-        peer_name: meerkat_core::comms::PeerName,
+        source: meerkat_core::PeerResponseTerminalSource,
         request_id: String,
         status: meerkat_contracts::PeerResponseTerminalStatusWire,
         result: serde_json::Value,
@@ -2334,20 +2334,13 @@ impl SessionRuntime {
 
         self.ensure_runtime_executor(session_id).await?;
 
-        let peer_name = meerkat_core::comms::PeerName::new(peer_name.as_str().to_string())
-            .map_err(|message| RpcError {
-                code: error::INVALID_PARAMS,
-                message,
-                data: None,
-            })?;
-
         let input =
-            meerkat_runtime::peer_response_terminal_input(&peer_name, request_id, status, result)
+            meerkat_runtime::peer_response_terminal_input(source, request_id, status, result)
                 .map_err(|err| RpcError {
-                code: error::INVALID_PARAMS,
-                message: err.to_string(),
-                data: None,
-            })?;
+                    code: error::INVALID_PARAMS,
+                    message: err.to_string(),
+                    data: None,
+                })?;
 
         self.runtime_adapter
             .accept_input(session_id, input)
@@ -4602,8 +4595,11 @@ mod tests {
             .stage_append(
                 &AppendSystemContextRequest {
                     text: "Authoritative peer token is birch seventeen.".to_string(),
-                    source: Some("peer_response_terminal:analyst:req-123".to_string()),
-                    idempotency_key: Some("req-123".to_string()),
+                    source: Some(
+                        "peer_response_terminal:analyst:018f6f79-7a82-7c4e-a552-a3b86f9630f1"
+                            .to_string(),
+                    ),
+                    idempotency_key: Some("018f6f79-7a82-7c4e-a552-a3b86f9630f1".to_string()),
                 },
                 meerkat_core::time_compat::SystemTime::UNIX_EPOCH,
             )
@@ -4624,7 +4620,7 @@ mod tests {
         );
         assert_eq!(
             runtime_context[0].source.as_deref(),
-            Some("peer_response_terminal:analyst:req-123")
+            Some("peer_response_terminal:analyst:018f6f79-7a82-7c4e-a552-a3b86f9630f1")
         );
     }
 
@@ -4758,8 +4754,14 @@ mod tests {
                 &session_id,
                 AppendSystemContextRequest {
                     text: "Authoritative peer token is birch seventeen.".to_string(),
-                    source: Some("peer_response_terminal:analyst:req-123".to_string()),
-                    idempotency_key: Some("peer_response_terminal:analyst:req-123".to_string()),
+                    source: Some(
+                        "peer_response_terminal:analyst:018f6f79-7a82-7c4e-a552-a3b86f9630f1"
+                            .to_string(),
+                    ),
+                    idempotency_key: Some(
+                        "peer_response_terminal:analyst:018f6f79-7a82-7c4e-a552-a3b86f9630f1"
+                            .to_string(),
+                    ),
                 },
             )
             .await
@@ -4780,7 +4782,7 @@ mod tests {
         );
         assert_eq!(
             open_config.runtime_system_context[0].source.as_deref(),
-            Some("peer_response_terminal:analyst:req-123")
+            Some("peer_response_terminal:analyst:018f6f79-7a82-7c4e-a552-a3b86f9630f1")
         );
         let seed_system_text = open_config
             .seed_messages
@@ -4994,6 +4996,7 @@ mod tests {
                         timestamp: chrono::Utc::now(),
                         source: meerkat_runtime::InputOrigin::Peer {
                             peer_id: "analyst-rt".to_string(),
+                            display_identity: Some("Analyst".to_string()),
                             runtime_id: None,
                         },
                         durability: meerkat_runtime::InputDurability::Durable,
@@ -5003,7 +5006,7 @@ mod tests {
                         correlation_id: None,
                     },
                     convention: Some(meerkat_runtime::PeerConvention::ResponseTerminal {
-                        request_id: "req-123".to_string(),
+                        request_id: "018f6f79-7a82-7c4e-a552-a3b86f9630f1".to_string(),
                         status: meerkat_runtime::ResponseTerminalStatus::Completed,
                     }),
                     body: "done".to_string(),
@@ -5036,8 +5039,9 @@ mod tests {
                     })
                     .collect::<Vec<_>>();
                 if projected.iter().any(|text| {
-                    text.contains("peer_response_terminal:analyst-rt:req-123")
-                        && text.contains("birch seventeen")
+                    text.contains(
+                        "peer_response_terminal:analyst-rt:018f6f79-7a82-7c4e-a552-a3b86f9630f1",
+                    ) && text.contains("birch seventeen")
                 }) {
                     break open_config;
                 }
@@ -5057,8 +5061,9 @@ mod tests {
             .collect::<Vec<_>>();
         assert!(
             projected.iter().any(|text| {
-                text.contains("peer_response_terminal:analyst-rt:req-123")
-                    && text.contains("birch seventeen")
+                text.contains(
+                    "peer_response_terminal:analyst-rt:018f6f79-7a82-7c4e-a552-a3b86f9630f1",
+                ) && text.contains("birch seventeen")
             }),
             "expected realtime projection to include runtime-owned terminal peer response: {projected:?}"
         );
@@ -5103,6 +5108,7 @@ mod tests {
                         timestamp: chrono::Utc::now(),
                         source: meerkat_runtime::InputOrigin::Peer {
                             peer_id: "analyst-rt".to_string(),
+                            display_identity: Some("Analyst".to_string()),
                             runtime_id: None,
                         },
                         durability: meerkat_runtime::InputDurability::Durable,
@@ -5112,7 +5118,7 @@ mod tests {
                         correlation_id: None,
                     },
                     convention: Some(meerkat_runtime::PeerConvention::ResponseTerminal {
-                        request_id: "req-123".to_string(),
+                        request_id: "018f6f79-7a82-7c4e-a552-a3b86f9630f1".to_string(),
                         status: meerkat_runtime::ResponseTerminalStatus::Completed,
                     }),
                     body: "done".to_string(),
@@ -5145,8 +5151,9 @@ mod tests {
                     })
                     .collect::<Vec<_>>();
                 if projected.iter().any(|text| {
-                    text.contains("peer_response_terminal:analyst-rt:req-123")
-                        && text.contains("birch seventeen")
+                    text.contains(
+                        "peer_response_terminal:analyst-rt:018f6f79-7a82-7c4e-a552-a3b86f9630f1",
+                    ) && text.contains("birch seventeen")
                 }) {
                     break session;
                 }
@@ -5166,8 +5173,9 @@ mod tests {
             .collect::<Vec<_>>();
         assert!(
             authoritative_projected.iter().any(|text| {
-                text.contains("peer_response_terminal:analyst-rt:req-123")
-                    && text.contains("birch seventeen")
+                text.contains(
+                    "peer_response_terminal:analyst-rt:018f6f79-7a82-7c4e-a552-a3b86f9630f1",
+                ) && text.contains("birch seventeen")
             }),
             "expected authoritative snapshot to include runtime-owned terminal peer response: {authoritative_projected:?}"
         );
@@ -5210,8 +5218,9 @@ mod tests {
                     })
                     .collect::<Vec<_>>();
                 if projected.iter().any(|text| {
-                    text.contains("peer_response_terminal:analyst-rt:req-123")
-                        && text.contains("birch seventeen")
+                    text.contains(
+                        "peer_response_terminal:analyst-rt:018f6f79-7a82-7c4e-a552-a3b86f9630f1",
+                    ) && text.contains("birch seventeen")
                 }) {
                     break open_config;
                 }
@@ -5231,8 +5240,9 @@ mod tests {
             .collect::<Vec<_>>();
         assert!(
             projected.iter().any(|text| {
-                text.contains("peer_response_terminal:analyst-rt:req-123")
-                    && text.contains("birch seventeen")
+                text.contains(
+                    "peer_response_terminal:analyst-rt:018f6f79-7a82-7c4e-a552-a3b86f9630f1",
+                ) && text.contains("birch seventeen")
             }),
             "expected recovered realtime projection to include authoritative terminal peer response: {projected:?}"
         );
@@ -5277,6 +5287,7 @@ mod tests {
                         timestamp: chrono::Utc::now(),
                         source: meerkat_runtime::InputOrigin::Peer {
                             peer_id: "analyst-rt".to_string(),
+                            display_identity: Some("Analyst".to_string()),
                             runtime_id: None,
                         },
                         durability: meerkat_runtime::InputDurability::Durable,
@@ -5286,7 +5297,7 @@ mod tests {
                         correlation_id: None,
                     },
                     convention: Some(meerkat_runtime::PeerConvention::ResponseTerminal {
-                        request_id: "req-123".to_string(),
+                        request_id: "018f6f79-7a82-7c4e-a552-a3b86f9630f1".to_string(),
                         status: meerkat_runtime::ResponseTerminalStatus::Completed,
                     }),
                     body: "done".to_string(),
@@ -5322,8 +5333,9 @@ mod tests {
                     })
                     .collect::<Vec<_>>();
                 if projected.iter().any(|text| {
-                    text.contains("peer_response_terminal:analyst-rt:req-123")
-                        && text.contains("birch seventeen")
+                    text.contains(
+                        "peer_response_terminal:analyst-rt:018f6f79-7a82-7c4e-a552-a3b86f9630f1",
+                    ) && text.contains("birch seventeen")
                 }) {
                     break session;
                 }
@@ -5343,8 +5355,9 @@ mod tests {
             .collect::<Vec<_>>();
         assert!(
             projected.iter().any(|text| {
-                text.contains("peer_response_terminal:analyst-rt:req-123")
-                    && text.contains("birch seventeen")
+                text.contains(
+                    "peer_response_terminal:analyst-rt:018f6f79-7a82-7c4e-a552-a3b86f9630f1",
+                ) && text.contains("birch seventeen")
             }),
             "expected accept_input_with_completion to persist runtime-owned terminal peer response: {projected:?}"
         );
@@ -5401,6 +5414,7 @@ mod tests {
                         timestamp: chrono::Utc::now(),
                         source: meerkat_runtime::InputOrigin::Peer {
                             peer_id: "analyst-rt".to_string(),
+                            display_identity: Some("Analyst".to_string()),
                             runtime_id: None,
                         },
                         durability: meerkat_runtime::InputDurability::Durable,
@@ -5410,7 +5424,7 @@ mod tests {
                         correlation_id: None,
                     },
                     convention: Some(meerkat_runtime::PeerConvention::ResponseTerminal {
-                        request_id: "req-123".to_string(),
+                        request_id: "018f6f79-7a82-7c4e-a552-a3b86f9630f1".to_string(),
                         status: meerkat_runtime::ResponseTerminalStatus::Completed,
                     }),
                     body: "done".to_string(),
@@ -5436,7 +5450,9 @@ mod tests {
             AgentEvent::RunStarted { prompt, .. } => {
                 let normalized = prompt.text_content().to_lowercase();
                 assert!(
-                    normalized.contains("peer_response_terminal:analyst-rt:req-123"),
+                    normalized.contains(
+                        "peer_response_terminal:analyst-rt:018f6f79-7a82-7c4e-a552-a3b86f9630f1"
+                    ),
                     "run_started prompt should expose runtime system-context source: {normalized}"
                 );
                 assert!(
@@ -5632,9 +5648,9 @@ mod tests {
                 &session_id,
                 RunId::new(),
                 vec![PendingSystemContextAppend {
-                    text: "[SYSTEM NOTICE][PEER_RESPONSE_TERMINAL] Correlated peer response from analyst-rt. Request ID: req-123. Status: completed. Result: {\"request_intent\":\"checksum_token\",\"token\":\"birch seventeen\"}. For checksum_token requests, the exact token answer is `birch seventeen`.".to_string(),
-                    source: Some("peer_response_terminal:analyst-rt:req-123".to_string()),
-                    idempotency_key: Some("peer_response_terminal:analyst-rt:req-123".to_string()),
+                    text: "[SYSTEM NOTICE][PEER_RESPONSE_TERMINAL] Correlated peer response from analyst-rt. Request ID: 018f6f79-7a82-7c4e-a552-a3b86f9630f1. Status: completed. Result: {\"request_intent\":\"checksum_token\",\"token\":\"birch seventeen\"}. For checksum_token requests, the exact token answer is `birch seventeen`.".to_string(),
+                    source: Some("peer_response_terminal:analyst-rt:018f6f79-7a82-7c4e-a552-a3b86f9630f1".to_string()),
+                    idempotency_key: Some("peer_response_terminal:analyst-rt:018f6f79-7a82-7c4e-a552-a3b86f9630f1".to_string()),
                     accepted_at: meerkat_core::time_compat::SystemTime::now(),
                 }],
                 vec![],
@@ -5660,8 +5676,9 @@ mod tests {
             .collect::<Vec<_>>();
         assert!(
             projected.iter().any(|text| {
-                text.contains("peer_response_terminal:analyst-rt:req-123")
-                    && text.contains("birch seventeen")
+                text.contains(
+                    "peer_response_terminal:analyst-rt:018f6f79-7a82-7c4e-a552-a3b86f9630f1",
+                ) && text.contains("birch seventeen")
             }),
             "expected realtime projection to include runtime context applied via session service: {projected:?}"
         );
@@ -5745,9 +5762,9 @@ mod tests {
                 &session_id,
                 RunId::new(),
                 vec![PendingSystemContextAppend {
-                    text: "[SYSTEM NOTICE][PEER_RESPONSE_TERMINAL] Correlated peer response from analyst-rt. Request ID: req-123. Status: completed. Result: {\"request_intent\":\"checksum_token\",\"token\":\"birch seventeen\"}. For checksum_token requests, the exact token answer is `birch seventeen`.".to_string(),
-                    source: Some("peer_response_terminal:analyst-rt:req-123".to_string()),
-                    idempotency_key: Some("peer_response_terminal:analyst-rt:req-123".to_string()),
+                    text: "[SYSTEM NOTICE][PEER_RESPONSE_TERMINAL] Correlated peer response from analyst-rt. Request ID: 018f6f79-7a82-7c4e-a552-a3b86f9630f1. Status: completed. Result: {\"request_intent\":\"checksum_token\",\"token\":\"birch seventeen\"}. For checksum_token requests, the exact token answer is `birch seventeen`.".to_string(),
+                    source: Some("peer_response_terminal:analyst-rt:018f6f79-7a82-7c4e-a552-a3b86f9630f1".to_string()),
+                    idempotency_key: Some("peer_response_terminal:analyst-rt:018f6f79-7a82-7c4e-a552-a3b86f9630f1".to_string()),
                     accepted_at: meerkat_core::time_compat::SystemTime::now(),
                 }],
                 vec![],
@@ -5805,8 +5822,9 @@ mod tests {
         );
         assert!(
             system_messages.iter().any(|text| {
-                text.contains("peer_response_terminal:analyst-rt:req-123")
-                    && text.contains("birch seventeen")
+                text.contains(
+                    "peer_response_terminal:analyst-rt:018f6f79-7a82-7c4e-a552-a3b86f9630f1",
+                ) && text.contains("birch seventeen")
             }),
             "expected realtime projection to preserve authoritative token system context: {system_messages:?}"
         );

--- a/meerkat-runtime/src/accept.rs
+++ b/meerkat-runtime/src/accept.rs
@@ -85,6 +85,11 @@ pub enum RejectReason {
         /// Description of the violation.
         detail: String,
     },
+    /// Peer response terminal fact failed typed validation.
+    PeerResponseTerminalInvalid {
+        /// Description of the violation.
+        detail: String,
+    },
 }
 
 impl fmt::Display for RejectReason {
@@ -95,6 +100,7 @@ impl fmt::Display for RejectReason {
             }
             Self::DurabilityViolation { detail } => write!(f, "{detail}"),
             Self::PeerHandlingModeInvalid { detail } => write!(f, "{detail}"),
+            Self::PeerResponseTerminalInvalid { detail } => write!(f, "{detail}"),
         }
     }
 }
@@ -395,6 +401,11 @@ mod tests {
             peer.to_string(),
             "handling_mode is forbidden on ResponseProgress peer inputs"
         );
+
+        let terminal = RejectReason::PeerResponseTerminalInvalid {
+            detail: "correlation id cannot be empty".into(),
+        };
+        assert_eq!(terminal.to_string(), "correlation id cannot be empty");
     }
 
     #[test]
@@ -408,6 +419,9 @@ mod tests {
             },
             RejectReason::PeerHandlingModeInvalid {
                 detail: "forbidden".into(),
+            },
+            RejectReason::PeerResponseTerminalInvalid {
+                detail: "bad terminal".into(),
             },
         ];
         for reason in reasons {

--- a/meerkat-runtime/src/comms_bridge.rs
+++ b/meerkat-runtime/src/comms_bridge.rs
@@ -5,8 +5,6 @@
 
 use chrono::Utc;
 use meerkat_core::comms::PeerId;
-#[cfg(test)]
-use meerkat_core::interaction::ResponseStatus;
 use meerkat_core::interaction::{
     InboxInteraction, InteractionContent, PeerInputCandidate, PeerInputClass,
 };
@@ -56,10 +54,11 @@ pub fn classified_interaction_to_runtime_input(
         });
     }
 
-    interaction_to_peer_input_with_source_peer_id(
+    interaction_to_peer_input_with_authority(
         interaction,
         runtime_id,
         classified.source_peer_id,
+        classified.from_peer_id,
     )
 }
 
@@ -76,18 +75,21 @@ pub fn interaction_to_peer_input(
     interaction: &InboxInteraction,
     runtime_id: &LogicalRuntimeId,
 ) -> Input {
-    interaction_to_peer_input_with_source_peer_id(interaction, runtime_id, None)
+    interaction_to_peer_input_with_authority(interaction, runtime_id, None, None)
 }
 
-fn interaction_to_peer_input_with_source_peer_id(
+fn interaction_to_peer_input_with_authority(
     interaction: &InboxInteraction,
     runtime_id: &LogicalRuntimeId,
     source_peer_id: Option<PeerId>,
+    terminal_route_peer_id: Option<PeerId>,
 ) -> Input {
     let convention = map_convention(interaction);
     let durability = map_durability(&convention);
-    let source_peer = match (&interaction.content, source_peer_id) {
-        (InteractionContent::Request { .. }, Some(peer_id)) => peer_id.to_string(),
+    let source_peer = match (&convention, source_peer_id, terminal_route_peer_id) {
+        (PeerConvention::ResponseTerminal { .. }, _, Some(peer_id)) => peer_id.to_string(),
+        (PeerConvention::ResponseTerminal { .. }, _, None) => String::new(),
+        (PeerConvention::Request { .. }, Some(peer_id), _) => peer_id.to_string(),
         _ => interaction.from.clone(),
     };
 
@@ -97,6 +99,7 @@ fn interaction_to_peer_input_with_source_peer_id(
             timestamp: Utc::now(),
             source: InputOrigin::Peer {
                 peer_id: source_peer,
+                display_identity: Some(interaction.from.clone()),
                 runtime_id: Some(runtime_id.clone()),
             },
             durability,
@@ -112,11 +115,18 @@ fn interaction_to_peer_input_with_source_peer_id(
         body: peer_rendered_body(interaction),
         payload: peer_payload(interaction),
         blocks: peer_blocks(interaction),
-        handling_mode: match interaction.handling_mode {
-            meerkat_core::types::HandlingMode::Queue => None,
-            mode => Some(mode),
-        },
+        handling_mode: peer_handling_mode(interaction),
     })
+}
+
+fn peer_handling_mode(interaction: &InboxInteraction) -> Option<meerkat_core::types::HandlingMode> {
+    if matches!(&interaction.content, InteractionContent::Response { .. }) {
+        return None;
+    }
+    match interaction.handling_mode {
+        meerkat_core::types::HandlingMode::Queue => None,
+        mode => Some(mode),
+    }
 }
 
 fn map_convention(interaction: &InboxInteraction) -> PeerConvention {
@@ -133,7 +143,7 @@ fn map_convention(interaction: &InboxInteraction) -> PeerConvention {
         } => {
             // Single source of truth for response terminality: meerkat-core's
             // `classify_response_terminality`. No raw `ResponseStatus`
-            // matching here — the inbox classifier and comms drain delegate
+            // matching here -- the inbox classifier and comms drain delegate
             // to the same call.
             let request_id = in_reply_to.to_string();
             match meerkat_core::interaction::classify_response_terminality(*status) {
@@ -636,6 +646,42 @@ mod tests {
                 p.payload,
                 Some(serde_json::json!({"ok": true})),
                 "terminal response result must remain structured on PeerInput so runtime prompt projection stays runtime-owned"
+            );
+        } else {
+            panic!("Expected PeerInput");
+        }
+    }
+
+    #[test]
+    fn classified_response_uses_ingress_terminal_class() {
+        let in_reply_to = make_interaction_id();
+        let classified = PeerInputCandidate {
+            class: PeerInputClass::ResponseProgress,
+            auth: Some(meerkat_core::PeerIngressAuthDecision::Required),
+            lifecycle_peer: None,
+            interaction: InboxInteraction {
+                from: "peer-1".into(),
+                content: InteractionContent::Response {
+                    status: ResponseStatus::Completed,
+                    result: serde_json::json!({"ok": true}),
+                    in_reply_to,
+                },
+                id: make_interaction_id(),
+                rendered_text: String::new(),
+                handling_mode: meerkat_core::types::HandlingMode::Queue,
+                render_metadata: None,
+            },
+        };
+
+        let input =
+            classified_interaction_to_runtime_input(&classified, &LogicalRuntimeId::new("test"));
+        if let Input::Peer(peer) = input {
+            assert!(
+                matches!(
+                    peer.convention,
+                    Some(PeerConvention::ResponseProgress { .. })
+                ),
+                "classified bridge must consume ingress-owned response class"
             );
         } else {
             panic!("Expected PeerInput");

--- a/meerkat-runtime/src/comms_bridge.rs
+++ b/meerkat-runtime/src/comms_bridge.rs
@@ -59,6 +59,7 @@ pub fn classified_interaction_to_runtime_input(
         runtime_id,
         classified.source_peer_id,
         classified.from_peer_id,
+        Some(classified.class),
     )
 }
 
@@ -75,7 +76,7 @@ pub fn interaction_to_peer_input(
     interaction: &InboxInteraction,
     runtime_id: &LogicalRuntimeId,
 ) -> Input {
-    interaction_to_peer_input_with_authority(interaction, runtime_id, None, None)
+    interaction_to_peer_input_with_authority(interaction, runtime_id, None, None, None)
 }
 
 fn interaction_to_peer_input_with_authority(
@@ -83,9 +84,11 @@ fn interaction_to_peer_input_with_authority(
     runtime_id: &LogicalRuntimeId,
     source_peer_id: Option<PeerId>,
     terminal_route_peer_id: Option<PeerId>,
+    ingress_class: Option<PeerInputClass>,
 ) -> Input {
-    let convention = map_convention(interaction);
+    let convention = map_convention(interaction, ingress_class);
     let durability = map_durability(&convention);
+    let terminal_route_peer_id = terminal_route_peer_id.or(interaction.from_route);
     let source_peer = match (&convention, source_peer_id, terminal_route_peer_id) {
         (PeerConvention::ResponseTerminal { .. }, _, Some(peer_id)) => peer_id.to_string(),
         (PeerConvention::ResponseTerminal { .. }, _, None) => String::new(),
@@ -120,16 +123,16 @@ fn interaction_to_peer_input_with_authority(
 }
 
 fn peer_handling_mode(interaction: &InboxInteraction) -> Option<meerkat_core::types::HandlingMode> {
-    if matches!(&interaction.content, InteractionContent::Response { .. }) {
-        return None;
-    }
     match interaction.handling_mode {
         meerkat_core::types::HandlingMode::Queue => None,
         mode => Some(mode),
     }
 }
 
-fn map_convention(interaction: &InboxInteraction) -> PeerConvention {
+fn map_convention(
+    interaction: &InboxInteraction,
+    ingress_class: Option<PeerInputClass>,
+) -> PeerConvention {
     match &interaction.content {
         InteractionContent::Message { .. } => PeerConvention::Message,
         InteractionContent::Request { intent, .. } => PeerConvention::Request {
@@ -146,7 +149,29 @@ fn map_convention(interaction: &InboxInteraction) -> PeerConvention {
             // matching here -- the inbox classifier and comms drain delegate
             // to the same call.
             let request_id = in_reply_to.to_string();
-            match meerkat_core::interaction::classify_response_terminality(*status) {
+            let terminality = match ingress_class {
+                Some(PeerInputClass::ResponseProgress) => {
+                    meerkat_core::interaction::TerminalityClass::Progress
+                }
+                Some(PeerInputClass::ResponseTerminal) => {
+                    match meerkat_core::interaction::classify_response_terminality(*status) {
+                        terminal @ meerkat_core::interaction::TerminalityClass::Terminal {
+                            ..
+                        } => terminal,
+                        other => {
+                            tracing::warn!(
+                                class = ?other,
+                                "terminal ingress class conflicted with response status; failing closed as terminal failure"
+                            );
+                            meerkat_core::interaction::TerminalityClass::Terminal {
+                                disposition: meerkat_core::interaction::TerminalDisposition::Failed,
+                            }
+                        }
+                    }
+                }
+                _ => meerkat_core::interaction::classify_response_terminality(*status),
+            };
+            match terminality {
                 meerkat_core::interaction::TerminalityClass::Progress => {
                     PeerConvention::ResponseProgress {
                         request_id,
@@ -262,6 +287,7 @@ fn map_durability(convention: &PeerConvention) -> InputDurability {
 #[allow(clippy::unwrap_used, clippy::panic)]
 mod tests {
     use super::*;
+    use meerkat_core::interaction::ResponseStatus;
 
     fn make_interaction_id() -> meerkat_core::interaction::InteractionId {
         meerkat_core::interaction::InteractionId(uuid::Uuid::now_v7())
@@ -270,6 +296,7 @@ mod tests {
     #[test]
     fn message_to_peer_input() {
         let interaction = InboxInteraction {
+            from_route: None,
             from: "peer-1".into(),
             content: InteractionContent::Message {
                 body: "hello".into(),
@@ -293,6 +320,7 @@ mod tests {
     #[test]
     fn request_to_peer_input() {
         let interaction = InboxInteraction {
+            from_route: None,
             from: "peer-1".into(),
             content: InteractionContent::Request {
                 intent: "mob.peer_added".into(),
@@ -330,6 +358,7 @@ mod tests {
         let request_id = make_interaction_id();
         let classified = PeerInputCandidate {
             interaction: InboxInteraction {
+                from_route: None,
                 from: "test-mob/lead/l-requester".into(),
                 content: InteractionContent::Request {
                     intent: "interpret_image".into(),
@@ -377,6 +406,7 @@ mod tests {
             lifecycle_peer: None,
             source_peer_id: None,
             interaction: InboxInteraction {
+                from_route: None,
                 from: "event:webhook".into(),
                 content: InteractionContent::Message {
                     body: "{\"ok\":true}".into(),
@@ -414,6 +444,7 @@ mod tests {
             lifecycle_peer: None,
             source_peer_id: None,
             interaction: InboxInteraction {
+                from_route: None,
                 from: "event:webhook".into(),
                 content: InteractionContent::Message {
                     body: "hello".into(),
@@ -447,6 +478,7 @@ mod tests {
         // relies on. The structured JSON still flows through `payload` for
         // consumers that need the raw params.
         let interaction = InboxInteraction {
+            from_route: None,
             from: "event:webhook".into(),
             content: InteractionContent::Request {
                 intent: "mob.peer_added".into(),
@@ -482,6 +514,7 @@ mod tests {
             },
         ];
         let interaction = InboxInteraction {
+            from_route: None,
             from: "peer-1".into(),
             content: InteractionContent::Message {
                 body: "see image".into(),
@@ -513,6 +546,7 @@ mod tests {
             },
         ];
         let interaction = InboxInteraction {
+            from_route: None,
             from: "peer-1".into(),
             content: InteractionContent::Message {
                 body: "please inspect this image".into(),
@@ -552,6 +586,7 @@ mod tests {
             lifecycle_peer: None,
             source_peer_id: None,
             interaction: InboxInteraction {
+                from_route: None,
                 from: "event:webhook".into(),
                 content: InteractionContent::Message {
                     body: "see image".into(),
@@ -593,6 +628,7 @@ mod tests {
             lifecycle_peer: None,
             source_peer_id: None,
             interaction: InboxInteraction {
+                from_route: None,
                 from: "event:webhook".into(),
                 content: InteractionContent::Message {
                     body: "urgent".into(),
@@ -620,8 +656,12 @@ mod tests {
     #[test]
     fn response_completed_to_terminal() {
         let in_reply_to = make_interaction_id();
+        let route_id = meerkat_core::comms::PeerId::from_uuid(
+            uuid::Uuid::parse_str("018f6f79-7a82-7c4e-a552-a3b86f9630f2").unwrap(),
+        );
         let interaction = InboxInteraction {
-            from: "peer-1".into(),
+            from_route: Some(route_id),
+            from: "Peer One".into(),
             content: InteractionContent::Response {
                 status: ResponseStatus::Completed,
                 result: serde_json::json!({"ok": true}),
@@ -634,6 +674,17 @@ mod tests {
         };
         let input = interaction_to_peer_input(&interaction, &LogicalRuntimeId::new("test"));
         if let Input::Peer(p) = &input {
+            match &p.header.source {
+                InputOrigin::Peer {
+                    peer_id,
+                    display_identity,
+                    ..
+                } => {
+                    assert_eq!(peer_id, &route_id.to_string());
+                    assert_eq!(display_identity.as_deref(), Some("Peer One"));
+                }
+                other => panic!("Expected Peer source, got {other:?}"),
+            }
             assert!(matches!(
                 p.convention,
                 Some(PeerConvention::ResponseTerminal {
@@ -650,6 +701,17 @@ mod tests {
         } else {
             panic!("Expected PeerInput");
         }
+        let projection = crate::input::peer_projection(&input).expect("terminal projection");
+        let expected_key = format!("peer_response_terminal:{route_id}:{in_reply_to}");
+        assert_eq!(
+            projection.context_key().as_deref(),
+            Some(expected_key.as_str())
+        );
+        assert!(
+            projection.prompt_text().contains("from Peer One"),
+            "terminal prompt should use display identity: {}",
+            projection.prompt_text()
+        );
     }
 
     #[test]
@@ -658,8 +720,11 @@ mod tests {
         let classified = PeerInputCandidate {
             class: PeerInputClass::ResponseProgress,
             auth: Some(meerkat_core::PeerIngressAuthDecision::Required),
+            source_peer_id: None,
+            from_peer_id: None,
             lifecycle_peer: None,
             interaction: InboxInteraction {
+                from_route: None,
                 from: "peer-1".into(),
                 content: InteractionContent::Response {
                     status: ResponseStatus::Completed,
@@ -689,9 +754,37 @@ mod tests {
     }
 
     #[test]
-    fn response_failed_to_terminal() {
+    fn response_terminal_without_route_fails_typed_projection() {
         let in_reply_to = make_interaction_id();
         let interaction = InboxInteraction {
+            from_route: None,
+            from: "Peer One".into(),
+            content: InteractionContent::Response {
+                status: ResponseStatus::Completed,
+                result: serde_json::json!({"ok": true}),
+                in_reply_to,
+            },
+            id: make_interaction_id(),
+            rendered_text: String::new(),
+            handling_mode: meerkat_core::types::HandlingMode::Queue,
+            render_metadata: None,
+        };
+        let input = interaction_to_peer_input(&interaction, &LogicalRuntimeId::new("test"));
+        let err = crate::input::validate_peer_response_terminal_fact(&input).unwrap_err();
+        assert!(matches!(
+            err,
+            meerkat_core::PeerResponseTerminalFactError::EmptyRouteIdentity
+        ));
+    }
+
+    #[test]
+    fn response_failed_to_terminal() {
+        let in_reply_to = make_interaction_id();
+        let route_id = meerkat_core::comms::PeerId::from_uuid(
+            uuid::Uuid::parse_str("018f6f79-7a82-7c4e-a552-a3b86f9630f3").unwrap(),
+        );
+        let interaction = InboxInteraction {
+            from_route: Some(route_id),
             from: "peer-1".into(),
             content: InteractionContent::Response {
                 status: ResponseStatus::Failed,
@@ -721,6 +814,7 @@ mod tests {
     fn response_accepted_to_progress() {
         let in_reply_to = make_interaction_id();
         let interaction = InboxInteraction {
+            from_route: None,
             from: "peer-1".into(),
             content: InteractionContent::Response {
                 status: ResponseStatus::Accepted,
@@ -750,6 +844,7 @@ mod tests {
     #[test]
     fn peer_source_includes_runtime_id() {
         let interaction = InboxInteraction {
+            from_route: None,
             from: "peer-1".into(),
             content: InteractionContent::Message {
                 body: "hi".into(),
@@ -766,6 +861,7 @@ mod tests {
             if let InputOrigin::Peer {
                 peer_id,
                 runtime_id,
+                ..
             } = &p.header.source
             {
                 assert_eq!(peer_id, "peer-1");
@@ -783,6 +879,7 @@ mod tests {
         let in_reply_to = make_interaction_id();
         let interactions = vec![
             InboxInteraction {
+                from_route: None,
                 from: "p".into(),
                 content: InteractionContent::Message {
                     body: "m".into(),
@@ -794,6 +891,7 @@ mod tests {
                 render_metadata: None,
             },
             InboxInteraction {
+                from_route: None,
                 from: "p".into(),
                 content: InteractionContent::Request {
                     intent: "i".into(),
@@ -805,6 +903,9 @@ mod tests {
                 render_metadata: None,
             },
             InboxInteraction {
+                from_route: Some(meerkat_core::comms::PeerId::from_uuid(
+                    uuid::Uuid::parse_str("018f6f79-7a82-7c4e-a552-a3b86f9630f6").unwrap(),
+                )),
                 from: "p".into(),
                 content: InteractionContent::Response {
                     status: ResponseStatus::Completed,

--- a/meerkat-runtime/src/comms_drain.rs
+++ b/meerkat-runtime/src/comms_drain.rs
@@ -509,6 +509,7 @@ fn peer_input_from_delivery_payload(
             timestamp: chrono::Utc::now(),
             source: InputOrigin::Peer {
                 peer_id: sender_peer_id.as_str(),
+                display_identity: None,
                 runtime_id: Some(LogicalRuntimeId::new(session_id.to_string())),
             },
             durability: InputDurability::Durable,
@@ -1879,6 +1880,7 @@ mod tests {
         let candidate = PeerInputCandidate {
             interaction: InboxInteraction {
                 id: InteractionId(Uuid::new_v4()),
+                from_route: None,
                 from: sender_pubkey.to_pubkey_string(),
                 content: InteractionContent::Request {
                     intent: SUPERVISOR_BRIDGE_INTENT.to_string(),
@@ -2124,6 +2126,7 @@ mod tests {
         PeerInputCandidate {
             interaction: InboxInteraction {
                 id: InteractionId(Uuid::new_v4()),
+                from_route: None,
                 from: "test-mob/__mob_supervisor__".to_string(),
                 content: InteractionContent::Request {
                     intent: intent.to_string(),
@@ -3340,6 +3343,7 @@ mod tests {
         PeerInputCandidate {
             interaction: InboxInteraction {
                 id: InteractionId(Uuid::new_v4()),
+                from_route: None,
                 from: sender.to_string(),
                 content: InteractionContent::Request {
                     intent: SUPERVISOR_BRIDGE_INTENT.to_string(),

--- a/meerkat-runtime/src/comms_drain.rs
+++ b/meerkat-runtime/src/comms_drain.rs
@@ -147,17 +147,11 @@ pub fn spawn_comms_drain(
                             "comms_drain: consumed silent peer lifecycle notice"
                         );
                     }
-                    PeerInputClass::Response => {
-                        // Distinguish progress responses from terminal responses
-                        // via the canonical classifier in meerkat-core. Raw
-                        // `ResponseStatus` matching here is forbidden — all
-                        // consumers must read `TerminalityClass` so "terminal"
-                        // stays lock-stepped across the codebase.
-                        //
-                        // W1-A also needs to route terminal status → the DSL
-                        // peer-interaction handle's `PeerTerminalDisposition`.
-                        // Compute both from the single classifier call so the
-                        // "terminal" and "disposition" facts never drift.
+                    PeerInputClass::ResponseProgress | PeerInputClass::ResponseTerminal => {
+                        // Terminal-vs-progress class is fixed at peer ingress
+                        // by `PeerIngressMachinePolicy`; the drain only maps a
+                        // terminal response's already-typed status into the
+                        // peer-interaction DSL disposition companion.
                         let terminal_status = match &candidate.interaction.content {
                             meerkat_core::interaction::InteractionContent::Response {
                                 status,
@@ -181,13 +175,15 @@ pub fn spawn_comms_drain(
                             },
                             _ => None,
                         };
-                        let is_terminal = terminal_status.is_some();
+                        let is_terminal =
+                            matches!(candidate.class, PeerInputClass::ResponseTerminal);
 
                         if is_terminal {
                             // Terminal response — single admission with
                             // completion tracking. The PeerInput already
                             // carries ResponseTerminal convention which the
-                            // policy table maps to WakeIfIdle/Steer as needed.
+                            // policy table maps to the machine-owned WakeIfIdle
+                            // terminal policy.
                             // No synthetic Continuation required.
                             let interaction_id = match &candidate.interaction.content {
                                 meerkat_core::interaction::InteractionContent::Response {
@@ -549,6 +545,11 @@ fn bridge_delivery_rejection_cause(
         }
         crate::accept::RejectReason::PeerHandlingModeInvalid { detail } => {
             BridgeDeliveryRejectionCause::PeerHandlingModeInvalid {
+                detail: detail.clone(),
+            }
+        }
+        crate::accept::RejectReason::PeerResponseTerminalInvalid { detail } => {
+            BridgeDeliveryRejectionCause::Internal {
                 detail: detail.clone(),
             }
         }

--- a/meerkat-runtime/src/driver/ephemeral.rs
+++ b/meerkat-runtime/src/driver/ephemeral.rs
@@ -1783,6 +1783,13 @@ impl EphemeralRuntimeDriver {
                 },
             });
         }
+        if let Err(e) = crate::input::validate_peer_response_terminal_fact(&input) {
+            return Ok(AcceptOutcome::Rejected {
+                reason: crate::accept::RejectReason::PeerResponseTerminalInvalid {
+                    detail: e.to_string(),
+                },
+            });
+        }
 
         let input_id = input.id().clone();
         let mut state = InputState::new_accepted(input_id.clone());

--- a/meerkat-runtime/src/driver/ephemeral.rs
+++ b/meerkat-runtime/src/driver/ephemeral.rs
@@ -2194,6 +2194,7 @@ mod tests {
                 timestamp: Utc::now(),
                 source: InputOrigin::Peer {
                     peer_id: "peer-1".into(),
+                    display_identity: None,
                     runtime_id: None,
                 },
                 durability: InputDurability::Durable,

--- a/meerkat-runtime/src/input.rs
+++ b/meerkat-runtime/src/input.rs
@@ -14,8 +14,8 @@ use meerkat_core::ops::{OpEvent, OperationId};
 use meerkat_core::types::HandlingMode;
 use meerkat_core::{
     BlobStore, BlobStoreError, MissingBlobBehavior, PeerConversationProjection,
-    PeerResponseProgressProjectionPhase, PeerResponseTerminalProjectionStatus,
-    externalize_content_blocks, hydrate_content_blocks,
+    PeerResponseProgressProjectionPhase, PeerResponseTerminalFact, PeerResponseTerminalFactError,
+    PeerResponseTerminalProjectionStatus, externalize_content_blocks, hydrate_content_blocks,
 };
 use serde::{Deserialize, Serialize};
 
@@ -532,9 +532,8 @@ pub struct OperationInput {
 
 /// Build the core-owned peer conversation projection for a runtime peer input.
 ///
-/// The runtime loop consumes this classification but does not own the peer
-/// response semantic mapping. That mapping belongs at the input boundary,
-/// where typed peer convention/status fields are still present.
+/// The runtime loop consumes this typed projection instead of reconstructing
+/// peer-response terminal render/context semantics from strings.
 pub(crate) fn peer_projection_from_peer_input(
     peer: &PeerInput,
 ) -> Option<PeerConversationProjection> {
@@ -574,16 +573,46 @@ pub(crate) fn peer_projection_from_peer_input(
                 payload: peer.payload.clone(),
             })
         }
-        Some(PeerConvention::ResponseTerminal { request_id, status }) => {
-            Some(PeerConversationProjection::ResponseTerminal {
-                peer_id: peer_id.clone(),
-                request_id: request_id.clone(),
-                status: *status,
-                payload: peer.payload.clone(),
-            })
-        }
+        Some(PeerConvention::ResponseTerminal { .. }) => peer_response_terminal_fact(peer)
+            .ok()
+            .flatten()
+            .map(PeerConversationProjection::response_terminal),
         None => None,
     }
+}
+
+pub(crate) fn peer_response_terminal_fact(
+    peer: &PeerInput,
+) -> Result<Option<PeerResponseTerminalFact>, PeerResponseTerminalFactError> {
+    let InputOrigin::Peer {
+        peer_id,
+        runtime_id,
+    } = &peer.header.source
+    else {
+        return Ok(None);
+    };
+    let Some(PeerConvention::ResponseTerminal { request_id, status }) = &peer.convention else {
+        return Ok(None);
+    };
+
+    PeerResponseTerminalFact::new(
+        runtime_id.as_ref().map(ToString::to_string),
+        peer_id.clone(),
+        peer_id.clone(),
+        request_id.clone(),
+        *status,
+        peer.payload.clone(),
+    )
+    .map(Some)
+}
+
+pub(crate) fn validate_peer_response_terminal_fact(
+    input: &Input,
+) -> Result<(), PeerResponseTerminalFactError> {
+    let Input::Peer(peer) = input else {
+        return Ok(());
+    };
+    peer_response_terminal_fact(peer).map(|_| ())
 }
 
 /// Lift an [`Input`] to its core peer projection when it is a peer input with a

--- a/meerkat-runtime/src/input.rs
+++ b/meerkat-runtime/src/input.rs
@@ -14,8 +14,11 @@ use meerkat_core::ops::{OpEvent, OperationId};
 use meerkat_core::types::HandlingMode;
 use meerkat_core::{
     BlobStore, BlobStoreError, MissingBlobBehavior, PeerConversationProjection,
-    PeerResponseProgressProjectionPhase, PeerResponseTerminalFact, PeerResponseTerminalFactError,
-    PeerResponseTerminalProjectionStatus, externalize_content_blocks, hydrate_content_blocks,
+    PeerResponseProgressProjectionPhase, PeerResponseTerminalCorrelationId,
+    PeerResponseTerminalDisplayIdentity, PeerResponseTerminalFact, PeerResponseTerminalFactError,
+    PeerResponseTerminalProjectionStatus, PeerResponseTerminalRenderPayload,
+    PeerResponseTerminalRouteIdentity, PeerResponseTerminalSource,
+    PeerResponseTerminalTransportIdentity, externalize_content_blocks, hydrate_content_blocks,
 };
 use serde::{Deserialize, Serialize};
 
@@ -58,6 +61,8 @@ pub enum InputOrigin {
     /// Peer agent (comms).
     Peer {
         peer_id: String,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        display_identity: Option<String>,
         #[serde(skip_serializing_if = "Option::is_none")]
         runtime_id: Option<LogicalRuntimeId>,
     },
@@ -382,6 +387,8 @@ pub type ResponseTerminalStatus = PeerResponseTerminalProjectionStatus;
 pub enum PeerResponseTerminalInputError {
     #[error("request_id cannot be empty")]
     EmptyRequestId,
+    #[error("request_id must be a UUID: {input}")]
+    InvalidRequestId { input: String },
 }
 
 pub fn response_terminal_status_from_wire(
@@ -401,7 +408,7 @@ pub fn response_terminal_status_from_wire(
 }
 
 pub fn peer_response_terminal_input(
-    peer_name: &meerkat_core::comms::PeerName,
+    source: PeerResponseTerminalSource,
     request_id: impl Into<String>,
     status: meerkat_contracts::PeerResponseTerminalStatusWire,
     result: serde_json::Value,
@@ -410,14 +417,23 @@ pub fn peer_response_terminal_input(
     if request_id.trim().is_empty() {
         return Err(PeerResponseTerminalInputError::EmptyRequestId);
     }
+    PeerResponseTerminalCorrelationId::parse(&request_id).map_err(|_| {
+        PeerResponseTerminalInputError::InvalidRequestId {
+            input: request_id.clone(),
+        }
+    })?;
 
     Ok(Input::Peer(PeerInput {
         header: InputHeader {
             id: InputId::new(),
             timestamp: Utc::now(),
             source: InputOrigin::Peer {
-                peer_id: peer_name.as_string(),
-                runtime_id: None,
+                peer_id: source.route_identity.as_str().to_string(),
+                display_identity: Some(source.display_identity.as_str().to_string()),
+                runtime_id: source
+                    .transport_identity
+                    .as_ref()
+                    .map(|identity| LogicalRuntimeId::new(identity.as_str().to_string())),
             },
             durability: InputDurability::Durable,
             visibility: InputVisibility::default(),
@@ -586,6 +602,7 @@ pub(crate) fn peer_response_terminal_fact(
 ) -> Result<Option<PeerResponseTerminalFact>, PeerResponseTerminalFactError> {
     let InputOrigin::Peer {
         peer_id,
+        display_identity,
         runtime_id,
     } = &peer.header.source
     else {
@@ -595,15 +612,27 @@ pub(crate) fn peer_response_terminal_fact(
         return Ok(None);
     };
 
-    PeerResponseTerminalFact::new(
-        runtime_id.as_ref().map(ToString::to_string),
-        peer_id.clone(),
-        peer_id.clone(),
-        request_id.clone(),
+    let transport_identity = runtime_id
+        .as_ref()
+        .map(ToString::to_string)
+        .map(PeerResponseTerminalTransportIdentity::parse)
+        .transpose()?;
+    let source = PeerResponseTerminalSource::new(
+        transport_identity,
+        PeerResponseTerminalRouteIdentity::parse(peer_id.clone())?,
+        PeerResponseTerminalDisplayIdentity::parse(
+            display_identity
+                .as_ref()
+                .ok_or(PeerResponseTerminalFactError::MissingDisplayIdentity)?
+                .clone(),
+        )?,
+    );
+    Ok(Some(PeerResponseTerminalFact::new(
+        source,
+        PeerResponseTerminalCorrelationId::parse(request_id)?,
         *status,
-        peer.payload.clone(),
-    )
-    .map(Some)
+        PeerResponseTerminalRenderPayload::new(peer.payload.clone()),
+    )))
 }
 
 pub(crate) fn validate_peer_response_terminal_fact(
@@ -768,6 +797,14 @@ mod tests {
             supersession_key: None,
             correlation_id: None,
         }
+    }
+
+    fn terminal_source(peer: &str) -> PeerResponseTerminalSource {
+        PeerResponseTerminalSource::new(
+            None,
+            PeerResponseTerminalRouteIdentity::parse(peer).unwrap(),
+            PeerResponseTerminalDisplayIdentity::parse(peer).unwrap(),
+        )
     }
 
     #[test]
@@ -1059,6 +1096,7 @@ mod tests {
             InputOrigin::Operator,
             InputOrigin::Peer {
                 peer_id: "p1".into(),
+                display_identity: None,
                 runtime_id: None,
             },
             InputOrigin::Flow {
@@ -1127,10 +1165,9 @@ mod tests {
 
     #[test]
     fn peer_response_terminal_input_owns_wire_status_mapping() {
-        let peer_name = meerkat_core::comms::PeerName::new("analyst").unwrap();
         let input = peer_response_terminal_input(
-            &peer_name,
-            "req-1",
+            terminal_source("analyst"),
+            "018f6f79-7a82-7c4e-a552-a3b86f9630f1",
             meerkat_contracts::PeerResponseTerminalStatusWire::Cancelled,
             serde_json::json!({"ok": false}),
         )
@@ -1150,7 +1187,7 @@ mod tests {
                 ..
             }) => {
                 assert_eq!(peer_id, "analyst");
-                assert_eq!(request_id, "req-1");
+                assert_eq!(request_id, "018f6f79-7a82-7c4e-a552-a3b86f9630f1");
                 assert_eq!(status, ResponseTerminalStatus::Cancelled);
                 assert_eq!(payload["ok"], false);
             }
@@ -1160,9 +1197,8 @@ mod tests {
 
     #[test]
     fn peer_response_terminal_input_rejects_empty_request_id() {
-        let peer_name = meerkat_core::comms::PeerName::new("analyst").unwrap();
         let err = peer_response_terminal_input(
-            &peer_name,
+            terminal_source("analyst"),
             " ",
             meerkat_contracts::PeerResponseTerminalStatusWire::Completed,
             serde_json::json!({}),
@@ -1170,6 +1206,24 @@ mod tests {
         .unwrap_err();
 
         assert_eq!(err, PeerResponseTerminalInputError::EmptyRequestId);
+    }
+
+    #[test]
+    fn peer_response_terminal_input_rejects_invalid_request_id() {
+        let err = peer_response_terminal_input(
+            terminal_source("analyst"),
+            "req-1",
+            meerkat_contracts::PeerResponseTerminalStatusWire::Completed,
+            serde_json::json!({}),
+        )
+        .unwrap_err();
+
+        assert_eq!(
+            err,
+            PeerResponseTerminalInputError::InvalidRequestId {
+                input: "req-1".to_string()
+            }
+        );
     }
 
     #[test]

--- a/meerkat-runtime/src/meerkat_machine_tests.rs
+++ b/meerkat-runtime/src/meerkat_machine_tests.rs
@@ -516,6 +516,7 @@ fn make_progress_input(label: &str) -> Input {
             timestamp: Utc::now(),
             source: crate::input::InputOrigin::Peer {
                 peer_id: "peer-1".into(),
+                display_identity: None,
                 runtime_id: None,
             },
             durability: crate::input::InputDurability::Ephemeral,
@@ -4290,6 +4291,7 @@ async fn running_peer_message_interrupt_yielding_drains_before_next_apply() {
             timestamp: Utc::now(),
             source: crate::input::InputOrigin::Peer {
                 peer_id: "peer-interrupt".into(),
+                display_identity: None,
                 runtime_id: None,
             },
             durability: crate::input::InputDurability::Durable,
@@ -15480,6 +15482,7 @@ fn runtime_parity_peer_message(text: &str) -> Input {
             timestamp: Utc::now(),
             source: crate::input::InputOrigin::Peer {
                 peer_id: "runtime-parity".into(),
+                display_identity: None,
                 runtime_id: None,
             },
             durability: crate::input::InputDurability::Durable,

--- a/meerkat-runtime/src/peer_handling_mode.rs
+++ b/meerkat-runtime/src/peer_handling_mode.rs
@@ -1,8 +1,8 @@
-//! Peer handling-mode validation — reject handling_mode on peer response conventions.
+//! Peer handling-mode validation — reject handling_mode on response progress conventions.
 //!
 //! Rules:
-//! - handling_mode is FORBIDDEN for: PeerInput(ResponseProgress), PeerInput(ResponseTerminal)
-//! - handling_mode is ALLOWED for: PeerInput(Message), PeerInput(Request), PeerInput(no convention)
+//! - handling_mode is FORBIDDEN for: PeerInput(ResponseProgress)
+//! - handling_mode is ALLOWED for: PeerInput(Message), PeerInput(Request), PeerInput(ResponseTerminal), PeerInput(no convention)
 //! - Non-peer inputs are always accepted (validation is a no-op)
 
 use crate::input::{Input, PeerConvention};
@@ -14,12 +14,9 @@ pub enum PeerHandlingModeError {
     /// handling_mode is not allowed on ResponseProgress peer inputs.
     #[error("handling_mode is forbidden on ResponseProgress peer inputs")]
     ForbiddenForResponseProgress,
-    /// handling_mode is not allowed on ResponseTerminal peer inputs.
-    #[error("handling_mode is forbidden on ResponseTerminal peer inputs")]
-    ForbiddenForResponseTerminal,
 }
 
-/// Validate that a peer input does not carry handling_mode on response conventions.
+/// Validate that a peer input does not carry handling_mode on response progress.
 pub fn validate_peer_handling_mode(input: &Input) -> Result<(), PeerHandlingModeError> {
     let Input::Peer(peer) = input else {
         return Ok(());
@@ -30,9 +27,6 @@ pub fn validate_peer_handling_mode(input: &Input) -> Result<(), PeerHandlingMode
     match &peer.convention {
         Some(PeerConvention::ResponseProgress { .. }) => {
             Err(PeerHandlingModeError::ForbiddenForResponseProgress)
-        }
-        Some(PeerConvention::ResponseTerminal { .. }) => {
-            Err(PeerHandlingModeError::ForbiddenForResponseTerminal)
         }
         _ => Ok(()),
     }
@@ -53,6 +47,7 @@ mod tests {
             timestamp: Utc::now(),
             source: InputOrigin::Peer {
                 peer_id: "peer-1".into(),
+                display_identity: None,
                 runtime_id: None,
             },
             durability: InputDurability::Durable,
@@ -84,7 +79,7 @@ mod tests {
     }
 
     #[test]
-    fn response_terminal_with_handling_mode_rejected() {
+    fn response_terminal_with_handling_mode_accepted() {
         let input = Input::Peer(PeerInput {
             header: make_header(),
             convention: Some(PeerConvention::ResponseTerminal {
@@ -96,15 +91,11 @@ mod tests {
             blocks: None,
             handling_mode: Some(HandlingMode::Steer),
         });
-        let err = validate_peer_handling_mode(&input).unwrap_err();
-        assert!(matches!(
-            err,
-            PeerHandlingModeError::ForbiddenForResponseTerminal
-        ));
+        assert!(validate_peer_handling_mode(&input).is_ok());
     }
 
     #[test]
-    fn response_terminal_with_queue_handling_mode_rejected() {
+    fn response_terminal_with_queue_handling_mode_accepted() {
         let input = Input::Peer(PeerInput {
             header: make_header(),
             convention: Some(PeerConvention::ResponseTerminal {
@@ -116,11 +107,7 @@ mod tests {
             blocks: None,
             handling_mode: Some(HandlingMode::Queue),
         });
-        let err = validate_peer_handling_mode(&input).unwrap_err();
-        assert!(matches!(
-            err,
-            PeerHandlingModeError::ForbiddenForResponseTerminal
-        ));
+        assert!(validate_peer_handling_mode(&input).is_ok());
     }
 
     #[test]

--- a/meerkat-runtime/src/peer_handling_mode.rs
+++ b/meerkat-runtime/src/peer_handling_mode.rs
@@ -1,8 +1,8 @@
-//! Peer handling-mode validation — reject handling_mode on response progress conventions.
+//! Peer handling-mode validation — reject handling_mode on peer response conventions.
 //!
 //! Rules:
-//! - handling_mode is FORBIDDEN for: PeerInput(ResponseProgress)
-//! - handling_mode is ALLOWED for: PeerInput(Message), PeerInput(Request), PeerInput(ResponseTerminal), PeerInput(no convention)
+//! - handling_mode is FORBIDDEN for: PeerInput(ResponseProgress), PeerInput(ResponseTerminal)
+//! - handling_mode is ALLOWED for: PeerInput(Message), PeerInput(Request), PeerInput(no convention)
 //! - Non-peer inputs are always accepted (validation is a no-op)
 
 use crate::input::{Input, PeerConvention};
@@ -14,6 +14,9 @@ pub enum PeerHandlingModeError {
     /// handling_mode is not allowed on ResponseProgress peer inputs.
     #[error("handling_mode is forbidden on ResponseProgress peer inputs")]
     ForbiddenForResponseProgress,
+    /// handling_mode is not allowed on ResponseTerminal peer inputs.
+    #[error("handling_mode is forbidden on ResponseTerminal peer inputs")]
+    ForbiddenForResponseTerminal,
 }
 
 /// Validate that a peer input does not carry handling_mode on response conventions.
@@ -27,6 +30,9 @@ pub fn validate_peer_handling_mode(input: &Input) -> Result<(), PeerHandlingMode
     match &peer.convention {
         Some(PeerConvention::ResponseProgress { .. }) => {
             Err(PeerHandlingModeError::ForbiddenForResponseProgress)
+        }
+        Some(PeerConvention::ResponseTerminal { .. }) => {
+            Err(PeerHandlingModeError::ForbiddenForResponseTerminal)
         }
         _ => Ok(()),
     }
@@ -78,7 +84,7 @@ mod tests {
     }
 
     #[test]
-    fn response_terminal_with_handling_mode_accepted() {
+    fn response_terminal_with_handling_mode_rejected() {
         let input = Input::Peer(PeerInput {
             header: make_header(),
             convention: Some(PeerConvention::ResponseTerminal {
@@ -90,11 +96,15 @@ mod tests {
             blocks: None,
             handling_mode: Some(HandlingMode::Steer),
         });
-        assert!(validate_peer_handling_mode(&input).is_ok());
+        let err = validate_peer_handling_mode(&input).unwrap_err();
+        assert!(matches!(
+            err,
+            PeerHandlingModeError::ForbiddenForResponseTerminal
+        ));
     }
 
     #[test]
-    fn response_terminal_with_queue_handling_mode_accepted() {
+    fn response_terminal_with_queue_handling_mode_rejected() {
         let input = Input::Peer(PeerInput {
             header: make_header(),
             convention: Some(PeerConvention::ResponseTerminal {
@@ -106,7 +116,11 @@ mod tests {
             blocks: None,
             handling_mode: Some(HandlingMode::Queue),
         });
-        assert!(validate_peer_handling_mode(&input).is_ok());
+        let err = validate_peer_handling_mode(&input).unwrap_err();
+        assert!(matches!(
+            err,
+            PeerHandlingModeError::ForbiddenForResponseTerminal
+        ));
     }
 
     #[test]

--- a/meerkat-runtime/src/policy_table.rs
+++ b/meerkat-runtime/src/policy_table.rs
@@ -681,6 +681,7 @@ mod tests {
                 timestamp: Utc::now(),
                 source: InputOrigin::Peer {
                     peer_id: "p".into(),
+                    display_identity: None,
                     runtime_id: None,
                 },
                 durability: InputDurability::Durable,
@@ -796,7 +797,7 @@ mod tests {
             }),
             Some(HandlingMode::Queue),
         );
-        let decision = DefaultPolicyTable::resolve(&input, false);
+        let decision = DefaultPolicyTable::resolve(&input, true);
         assert_eq!(decision.routing_disposition, RoutingDisposition::Queue);
         assert_eq!(decision.apply_mode, ApplyMode::StageRunStart);
         assert_eq!(decision.wake_mode, WakeMode::WakeIfIdle);

--- a/meerkat-runtime/src/policy_table.rs
+++ b/meerkat-runtime/src/policy_table.rs
@@ -744,7 +744,7 @@ mod tests {
     }
 
     // -----------------------------------------------------------------------
-    // P2: Policy table refuses to honor handling_mode for response conventions
+    // P2: Policy table refuses to honor handling_mode for response progress
     // -----------------------------------------------------------------------
 
     #[test]
@@ -796,7 +796,7 @@ mod tests {
             }),
             Some(HandlingMode::Queue),
         );
-        let decision = DefaultPolicyTable::resolve(&input, true);
+        let decision = DefaultPolicyTable::resolve(&input, false);
         assert_eq!(decision.routing_disposition, RoutingDisposition::Queue);
         assert_eq!(decision.apply_mode, ApplyMode::StageRunStart);
         assert_eq!(decision.wake_mode, WakeMode::WakeIfIdle);

--- a/meerkat-runtime/src/runtime_loop.rs
+++ b/meerkat-runtime/src/runtime_loop.rs
@@ -835,6 +835,10 @@ mod tests {
     };
     use meerkat_core::types::SessionId;
 
+    const TEST_PEER_RESPONSE_ROUTE_ID: &str = "11111111-1111-4111-8111-111111111111";
+    const TEST_PEER_RESPONSE_REQUEST_ID: &str = "22222222-2222-4222-8222-222222222222";
+    const TEST_PEER_RESPONSE_REQUEST_ID_2: &str = "33333333-3333-4333-8333-333333333333";
+
     fn background_spec(name: &str) -> OperationSpec {
         OperationSpec {
             id: meerkat_core::ops_lifecycle::OperationId::new(),
@@ -899,6 +903,7 @@ mod tests {
                 timestamp: Utc::now(),
                 source: InputOrigin::Peer {
                     peer_id: "p".into(),
+                    display_identity: Some("Peer P".into()),
                     runtime_id: None,
                 },
                 durability: InputDurability::Durable,
@@ -924,6 +929,7 @@ mod tests {
                 timestamp: Utc::now(),
                 source: InputOrigin::Peer {
                     peer_id: "peer-1".into(),
+                    display_identity: None,
                     runtime_id: None,
                 },
                 durability: InputDurability::Durable,
@@ -953,6 +959,7 @@ mod tests {
                 timestamp: Utc::now(),
                 source: InputOrigin::Peer {
                     peer_id: "11111111-1111-4111-8111-111111111111".into(),
+                    display_identity: None,
                     runtime_id: None,
                 },
                 durability: InputDurability::Durable,
@@ -990,6 +997,7 @@ mod tests {
                 timestamp: Utc::now(),
                 source: InputOrigin::Peer {
                     peer_id: "analyst-rt".into(),
+                    display_identity: Some("Analyst".into()),
                     runtime_id: None,
                 },
                 durability: InputDurability::Durable,
@@ -999,7 +1007,7 @@ mod tests {
                 correlation_id: None,
             },
             convention: Some(crate::input::PeerConvention::ResponseTerminal {
-                request_id: "req-123".into(),
+                request_id: "018f6f79-7a82-7c4e-a552-a3b86f9630f1".into(),
                 status: crate::input::ResponseTerminalStatus::Completed,
             }),
             body: "stale helper-local comms prose".into(),
@@ -1013,7 +1021,7 @@ mod tests {
 
         assert_eq!(
             input_to_prompt(&input),
-            "[SYSTEM NOTICE][PEER_RESPONSE_TERMINAL] Correlated peer response from analyst-rt. Request ID: req-123. Status: completed. Result: {\n  \"request_intent\": \"checksum_token\",\n  \"token\": \"birch seventeen\"\n}."
+            "[SYSTEM NOTICE][PEER_RESPONSE_TERMINAL] Correlated peer response from Analyst. Request ID: 018f6f79-7a82-7c4e-a552-a3b86f9630f1. Status: completed. Result: {\n  \"request_intent\": \"checksum_token\",\n  \"token\": \"birch seventeen\"\n}."
         );
     }
 
@@ -1030,6 +1038,7 @@ mod tests {
                 timestamp: Utc::now(),
                 source: InputOrigin::Peer {
                     peer_id: "analyst-rt".into(),
+                    display_identity: Some("Analyst".into()),
                     runtime_id: None,
                 },
                 durability: InputDurability::Durable,
@@ -1039,7 +1048,7 @@ mod tests {
                 correlation_id: None,
             },
             convention: Some(crate::input::PeerConvention::ResponseTerminal {
-                request_id: "req-123".into(),
+                request_id: "018f6f79-7a82-7c4e-a552-a3b86f9630f1".into(),
                 status: crate::input::ResponseTerminalStatus::Completed,
             }),
             body: "stale helper-local comms prose".into(),
@@ -1130,6 +1139,7 @@ mod tests {
                 timestamp: Utc::now(),
                 source: InputOrigin::Peer {
                     peer_id: "analyst-rt".into(),
+                    display_identity: Some("Analyst".into()),
                     runtime_id: None,
                 },
                 durability: InputDurability::Durable,
@@ -1139,7 +1149,7 @@ mod tests {
                 correlation_id: None,
             },
             convention: Some(crate::input::PeerConvention::ResponseTerminal {
-                request_id: "req-123".into(),
+                request_id: "018f6f79-7a82-7c4e-a552-a3b86f9630f1".into(),
                 status: crate::input::ResponseTerminalStatus::Completed,
             }),
             body: "stale helper-local comms prose".into(),
@@ -1174,7 +1184,7 @@ mod tests {
         assert_eq!(staged.context_appends.len(), 1);
         assert_eq!(
             staged.context_appends[0].key,
-            "peer_response_terminal:analyst-rt:req-123"
+            "peer_response_terminal:analyst-rt:018f6f79-7a82-7c4e-a552-a3b86f9630f1"
         );
         match &staged.context_appends[0].content {
             CoreRenderable::Text { text } => {
@@ -1200,6 +1210,7 @@ mod tests {
                 timestamp: Utc::now(),
                 source: InputOrigin::Peer {
                     peer_id: "analyst-rt".into(),
+                    display_identity: Some("Analyst".into()),
                     runtime_id: None,
                 },
                 durability: InputDurability::Durable,
@@ -1209,7 +1220,7 @@ mod tests {
                 correlation_id: None,
             },
             convention: Some(crate::input::PeerConvention::ResponseTerminal {
-                request_id: "req-123".into(),
+                request_id: "018f6f79-7a82-7c4e-a552-a3b86f9630f1".into(),
                 status: crate::input::ResponseTerminalStatus::Completed,
             }),
             body: "done".into(),
@@ -1243,7 +1254,8 @@ mod tests {
                 id: InputId::new(),
                 timestamp: Utc::now(),
                 source: InputOrigin::Peer {
-                    peer_id: "analyst-rt".into(),
+                    peer_id: TEST_PEER_RESPONSE_ROUTE_ID.into(),
+                    display_identity: Some("analyst-rt".into()),
                     runtime_id: None,
                 },
                 durability: InputDurability::Durable,
@@ -1253,7 +1265,7 @@ mod tests {
                 correlation_id: None,
             },
             convention: Some(crate::input::PeerConvention::ResponseTerminal {
-                request_id: "req-123".into(),
+                request_id: TEST_PEER_RESPONSE_REQUEST_ID.into(),
                 status: crate::input::ResponseTerminalStatus::Completed,
             }),
             body: String::new(),
@@ -1302,7 +1314,8 @@ mod tests {
                 id: InputId::new(),
                 timestamp: Utc::now(),
                 source: InputOrigin::Peer {
-                    peer_id: "analyst-rt".into(),
+                    peer_id: TEST_PEER_RESPONSE_ROUTE_ID.into(),
+                    display_identity: Some("analyst-rt".into()),
                     runtime_id: None,
                 },
                 durability: InputDurability::Durable,
@@ -1312,7 +1325,7 @@ mod tests {
                 correlation_id: None,
             },
             convention: Some(crate::input::PeerConvention::ResponseTerminal {
-                request_id: "req-123".into(),
+                request_id: TEST_PEER_RESPONSE_REQUEST_ID.into(),
                 status: crate::input::ResponseTerminalStatus::Completed,
             }),
             body: String::new(),
@@ -1376,6 +1389,7 @@ mod tests {
                 timestamp: Utc::now(),
                 source: InputOrigin::Peer {
                     peer_id: peer_id.into(),
+                    display_identity: Some("analyst-rt".into()),
                     runtime_id: None,
                 },
                 durability: InputDurability::Durable,
@@ -1399,6 +1413,7 @@ mod tests {
                 timestamp: Utc::now(),
                 source: InputOrigin::Peer {
                     peer_id: peer_id.into(),
+                    display_identity: Some("analyst-rt".into()),
                     runtime_id: None,
                 },
                 durability: InputDurability::Durable,
@@ -1439,7 +1454,7 @@ mod tests {
         let terminal_first = make_shared_ephemeral_driver("terminal-first");
         let terminal_id = accept_queued_input_id(
             &terminal_first,
-            make_terminal_peer_response("analyst-rt", "req-terminal-first"),
+            make_terminal_peer_response(TEST_PEER_RESPONSE_ROUTE_ID, TEST_PEER_RESPONSE_REQUEST_ID),
         )
         .await;
         let _message_id = accept_queued_input_id(
@@ -1469,7 +1484,10 @@ mod tests {
             accept_queued_input_id(&message_first, make_peer_message("analyst-rt", "first")).await;
         let _terminal_id = accept_queued_input_id(
             &message_first,
-            make_terminal_peer_response("analyst-rt", "req-message-first"),
+            make_terminal_peer_response(
+                TEST_PEER_RESPONSE_ROUTE_ID,
+                TEST_PEER_RESPONSE_REQUEST_ID_2,
+            ),
         )
         .await;
 
@@ -1505,6 +1523,7 @@ mod tests {
                 timestamp: Utc::now(),
                 source: InputOrigin::Peer {
                     peer_id: "p".into(),
+                    display_identity: None,
                     runtime_id: None,
                 },
                 durability: InputDurability::Durable,
@@ -1562,6 +1581,7 @@ mod tests {
                 timestamp: Utc::now(),
                 source: InputOrigin::Peer {
                     peer_id: "peer-1".into(),
+                    display_identity: None,
                     runtime_id: None,
                 },
                 durability: InputDurability::Durable,
@@ -1613,6 +1633,7 @@ mod tests {
                 timestamp: Utc::now(),
                 source: InputOrigin::Peer {
                     peer_id: "peer-1".into(),
+                    display_identity: None,
                     runtime_id: None,
                 },
                 durability: InputDurability::Durable,
@@ -1833,6 +1854,7 @@ mod tests {
                 source_peer_id: None,
                 interaction: InboxInteraction {
                     id: meerkat_core::interaction::InteractionId(uuid::Uuid::new_v4()),
+                    from_route: None,
                     from: "event:webhook".into(),
                     content: InteractionContent::Message {
                         body: "build failed".into(),
@@ -2088,6 +2110,7 @@ mod tests {
                 timestamp: Utc::now(),
                 source: InputOrigin::Peer {
                     peer_id: "p".into(),
+                    display_identity: None,
                     runtime_id: None,
                 },
                 durability: InputDurability::Durable,
@@ -2097,7 +2120,7 @@ mod tests {
                 correlation_id: None,
             },
             convention: Some(PeerConvention::ResponseTerminal {
-                request_id: "r".into(),
+                request_id: "018f6f79-7a82-7c4e-a552-a3b86f9630f1".into(),
                 status: ResponseTerminalStatus::Completed,
             }),
             body: "done".into(),
@@ -2127,6 +2150,7 @@ mod tests {
                 timestamp: Utc::now(),
                 source: InputOrigin::Peer {
                     peer_id: "p".into(),
+                    display_identity: None,
                     runtime_id: None,
                 },
                 durability: InputDurability::Durable,

--- a/meerkat-runtime/tests/control_plane_contract.rs
+++ b/meerkat-runtime/tests/control_plane_contract.rs
@@ -34,6 +34,7 @@ fn make_progress_input(label: &str) -> Input {
             timestamp: Utc::now(),
             source: InputOrigin::Peer {
                 peer_id: "peer-1".into(),
+                display_identity: None,
                 runtime_id: None,
             },
             durability: InputDurability::Ephemeral,

--- a/meerkat-runtime/tests/driver_ephemeral.rs
+++ b/meerkat-runtime/tests/driver_ephemeral.rs
@@ -37,6 +37,7 @@ fn make_peer_terminal(body: &str) -> Input {
             timestamp: Utc::now(),
             source: InputOrigin::Peer {
                 peer_id: "peer-1".into(),
+                display_identity: Some("Peer 1".into()),
                 runtime_id: None,
             },
             durability: InputDurability::Durable,
@@ -46,7 +47,7 @@ fn make_peer_terminal(body: &str) -> Input {
             correlation_id: None,
         },
         convention: Some(PeerConvention::ResponseTerminal {
-            request_id: "req-1".into(),
+            request_id: "018f6f79-7a82-7c4e-a552-a3b86f9630f1".into(),
             status: ResponseTerminalStatus::Completed,
         }),
         body: body.into(),
@@ -63,6 +64,7 @@ fn make_peer_progress() -> Input {
             timestamp: Utc::now(),
             source: InputOrigin::Peer {
                 peer_id: "peer-1".into(),
+                display_identity: Some("Peer 1".into()),
                 runtime_id: None,
             },
             durability: InputDurability::Ephemeral,
@@ -786,6 +788,7 @@ async fn accept_peer_response_progress_with_handling_mode_returns_rejected() {
             timestamp: Utc::now(),
             source: InputOrigin::Peer {
                 peer_id: "peer-1".into(),
+                display_identity: Some("Peer 1".into()),
                 runtime_id: None,
             },
             durability: InputDurability::Durable,
@@ -811,7 +814,7 @@ async fn accept_peer_response_progress_with_handling_mode_returns_rejected() {
 }
 
 #[tokio::test]
-async fn accept_peer_response_terminal_with_handling_mode_returns_rejected() {
+async fn accept_peer_response_terminal_with_handling_mode_returns_accepted() {
     let mut driver = EphemeralRuntimeDriver::new(LogicalRuntimeId::new("test"));
     let input = Input::Peer(PeerInput {
         header: InputHeader {
@@ -819,6 +822,7 @@ async fn accept_peer_response_terminal_with_handling_mode_returns_rejected() {
             timestamp: Utc::now(),
             source: InputOrigin::Peer {
                 peer_id: "peer-1".into(),
+                display_identity: Some("Peer 1".into()),
                 runtime_id: None,
             },
             durability: InputDurability::Durable,
@@ -828,7 +832,7 @@ async fn accept_peer_response_terminal_with_handling_mode_returns_rejected() {
             correlation_id: None,
         },
         convention: Some(PeerConvention::ResponseTerminal {
-            request_id: "req-1".into(),
+            request_id: "018f6f79-7a82-7c4e-a552-a3b86f9630f1".into(),
             status: ResponseTerminalStatus::Completed,
         }),
         body: "done".into(),
@@ -838,8 +842,8 @@ async fn accept_peer_response_terminal_with_handling_mode_returns_rejected() {
     });
     let outcome = driver.accept_input(input).await.unwrap();
     assert!(
-        outcome.is_rejected(),
-        "ResponseTerminal with handling_mode=Steer must be rejected"
+        outcome.is_accepted(),
+        "ResponseTerminal with handling_mode=Steer must be accepted"
     );
 }
 
@@ -852,6 +856,7 @@ async fn accept_peer_response_terminal_with_empty_request_id_returns_rejected() 
             timestamp: Utc::now(),
             source: InputOrigin::Peer {
                 peer_id: "peer-1".into(),
+                display_identity: Some("Peer 1".into()),
                 runtime_id: None,
             },
             durability: InputDurability::Durable,
@@ -885,6 +890,7 @@ async fn accept_peer_message_with_steer_handling_mode_returns_accepted() {
             timestamp: Utc::now(),
             source: InputOrigin::Peer {
                 peer_id: "peer-1".into(),
+                display_identity: None,
                 runtime_id: None,
             },
             durability: InputDurability::Durable,
@@ -979,6 +985,7 @@ async fn post_admission_signal_steer_is_request_immediate() {
             timestamp: Utc::now(),
             source: InputOrigin::Peer {
                 peer_id: "p".into(),
+                display_identity: None,
                 runtime_id: None,
             },
             durability: InputDurability::Durable,
@@ -1024,6 +1031,7 @@ async fn post_admission_signal_queue_peer_message_while_running_interrupts_yield
             timestamp: Utc::now(),
             source: InputOrigin::Peer {
                 peer_id: "p".into(),
+                display_identity: None,
                 runtime_id: None,
             },
             durability: InputDurability::Durable,

--- a/meerkat-runtime/tests/driver_ephemeral.rs
+++ b/meerkat-runtime/tests/driver_ephemeral.rs
@@ -811,7 +811,7 @@ async fn accept_peer_response_progress_with_handling_mode_returns_rejected() {
 }
 
 #[tokio::test]
-async fn accept_peer_response_terminal_with_handling_mode_returns_accepted() {
+async fn accept_peer_response_terminal_with_handling_mode_returns_rejected() {
     let mut driver = EphemeralRuntimeDriver::new(LogicalRuntimeId::new("test"));
     let input = Input::Peer(PeerInput {
         header: InputHeader {
@@ -838,8 +838,41 @@ async fn accept_peer_response_terminal_with_handling_mode_returns_accepted() {
     });
     let outcome = driver.accept_input(input).await.unwrap();
     assert!(
-        outcome.is_accepted(),
-        "ResponseTerminal with handling_mode=Steer must be accepted"
+        outcome.is_rejected(),
+        "ResponseTerminal with handling_mode=Steer must be rejected"
+    );
+}
+
+#[tokio::test]
+async fn accept_peer_response_terminal_with_empty_request_id_returns_rejected() {
+    let mut driver = EphemeralRuntimeDriver::new(LogicalRuntimeId::new("test"));
+    let input = Input::Peer(PeerInput {
+        header: InputHeader {
+            id: InputId::new(),
+            timestamp: Utc::now(),
+            source: InputOrigin::Peer {
+                peer_id: "peer-1".into(),
+                runtime_id: None,
+            },
+            durability: InputDurability::Durable,
+            visibility: InputVisibility::default(),
+            idempotency_key: None,
+            supersession_key: None,
+            correlation_id: None,
+        },
+        convention: Some(PeerConvention::ResponseTerminal {
+            request_id: " ".into(),
+            status: ResponseTerminalStatus::Completed,
+        }),
+        body: "done".into(),
+        payload: Some(serde_json::json!({"ok": true})),
+        blocks: None,
+        handling_mode: None,
+    });
+    let outcome = driver.accept_input(input).await.unwrap();
+    assert!(
+        outcome.is_rejected(),
+        "ResponseTerminal with empty request_id must fail closed at admission"
     );
 }
 

--- a/meerkat-runtime/tests/meerkat_machine.rs
+++ b/meerkat-runtime/tests/meerkat_machine.rs
@@ -659,6 +659,7 @@ async fn recycle_attached_runtime_wakes_preserved_queued_work() {
                 timestamp: Utc::now(),
                 source: InputOrigin::Peer {
                     peer_id: "peer-1".into(),
+                    display_identity: None,
                     runtime_id: None,
                 },
                 durability: InputDurability::Ephemeral,
@@ -1055,9 +1056,12 @@ async fn runtime_comms_terminal_response_wake_drains_requester_queue() {
         .lock()
         .expect("terminal_context_keys mutex")
         .clone();
+    let responder_route_id = responder_comms.public_key().to_peer_id();
     assert_eq!(
         keys,
-        vec![format!("peer_response_terminal:{name_b}:{request_id}")],
+        vec![format!(
+            "peer_response_terminal:{responder_route_id}:{request_id}"
+        )],
         "terminal response should render through typed context append"
     );
     let active_ids = adapter

--- a/meerkat-runtime/tests/meerkat_machine.rs
+++ b/meerkat-runtime/tests/meerkat_machine.rs
@@ -828,6 +828,265 @@ async fn accept_with_executor_triggers_loop() {
     assert!(active.is_empty(), "All inputs should be consumed");
 }
 
+#[tokio::test]
+async fn runtime_comms_terminal_response_wake_drains_requester_queue() {
+    use meerkat_comms::runtime::comms_runtime::CommsRuntime as InprocCommsRuntime;
+    use meerkat_core::agent::CommsRuntime as CoreCommsRuntime;
+    use meerkat_core::comms::{CommsCommand, InputStreamMode, PeerName, PeerRoute, SendReceipt};
+    use meerkat_core::lifecycle::core_executor::{
+        CoreApplyOutput, CoreExecutor, CoreExecutorError,
+    };
+    use meerkat_core::lifecycle::run_control::RunControlCommand;
+    use meerkat_core::lifecycle::run_primitive::{RunApplyBoundary, RunPrimitive};
+    use meerkat_core::lifecycle::run_receipt::RunBoundaryReceipt;
+    use meerkat_core::{HandlingMode, InteractionContent, InteractionId, ResponseStatus};
+    use meerkat_runtime::PeerConvention;
+    use tokio::sync::Notify;
+    use uuid::Uuid;
+
+    struct BlockingRecordingExecutor {
+        calls: Arc<AtomicUsize>,
+        first_apply_started: Arc<Notify>,
+        release_first_apply: Arc<Notify>,
+        terminal_applied: Arc<Notify>,
+        terminal_context_keys: Arc<std::sync::Mutex<Vec<String>>>,
+    }
+
+    #[async_trait::async_trait]
+    impl CoreExecutor for BlockingRecordingExecutor {
+        async fn apply(
+            &mut self,
+            run_id: RunId,
+            primitive: RunPrimitive,
+        ) -> Result<CoreApplyOutput, CoreExecutorError> {
+            let call = self.calls.fetch_add(1, Ordering::SeqCst) + 1;
+            if call == 1 {
+                self.first_apply_started.notify_waiters();
+                self.release_first_apply.notified().await;
+            }
+
+            let boundary = match &primitive {
+                RunPrimitive::StagedInput(staged) => {
+                    for append in &staged.context_appends {
+                        if append.key.starts_with("peer_response_terminal:") {
+                            self.terminal_context_keys
+                                .lock()
+                                .expect("terminal_context_keys mutex")
+                                .push(append.key.clone());
+                            self.terminal_applied.notify_waiters();
+                        }
+                    }
+                    staged.boundary
+                }
+                RunPrimitive::ImmediateAppend(_) => RunApplyBoundary::Immediate,
+                _ => RunApplyBoundary::RunStart,
+            };
+
+            Ok(CoreApplyOutput {
+                receipt: RunBoundaryReceipt {
+                    run_id,
+                    boundary,
+                    contributing_input_ids: primitive.contributing_input_ids().to_vec(),
+                    conversation_digest: None,
+                    message_count: 0,
+                    sequence: call as u64,
+                },
+                session_snapshot: None,
+                terminal: None,
+                run_result: None,
+            })
+        }
+
+        async fn control(&mut self, _cmd: RunControlCommand) -> Result<(), CoreExecutorError> {
+            Ok(())
+        }
+    }
+
+    async fn drain_until_nonempty(
+        runtime: &InprocCommsRuntime,
+    ) -> Vec<meerkat_core::ClassifiedInboxInteraction> {
+        tokio::time::timeout(Duration::from_secs(2), async {
+            loop {
+                let batch = CoreCommsRuntime::drain_classified_inbox_interactions(runtime)
+                    .await
+                    .unwrap_or_default();
+                if !batch.is_empty() {
+                    return batch;
+                }
+                tokio::time::sleep(Duration::from_millis(5)).await;
+            }
+        })
+        .await
+        .expect("classified inbox should receive request")
+    }
+
+    let suffix = Uuid::new_v4().simple().to_string();
+    let name_a = format!("runtime-requester-{suffix}");
+    let name_b = format!("runtime-responder-{suffix}");
+    let (requester_comms, responder_comms) =
+        InprocCommsRuntime::inproc_pair_with_mutual_trust(&name_a, &name_b)
+            .await
+            .expect("inproc comms pair");
+
+    let adapter = Arc::new(MeerkatMachine::ephemeral());
+    let sid = SessionId::new();
+    let bindings = adapter
+        .prepare_bindings(sid.clone())
+        .await
+        .expect("prepare runtime bindings");
+    requester_comms.install_peer_comms_handle(Arc::clone(&bindings.peer_comms));
+    requester_comms.install_peer_interaction_handle(
+        bindings
+            .peer_interaction
+            .clone()
+            .expect("runtime bindings include peer interaction handle"),
+    );
+
+    let calls = Arc::new(AtomicUsize::new(0));
+    let first_apply_started = Arc::new(Notify::new());
+    let release_first_apply = Arc::new(Notify::new());
+    let terminal_applied = Arc::new(Notify::new());
+    let terminal_context_keys = Arc::new(std::sync::Mutex::new(Vec::new()));
+    adapter
+        .register_session_with_executor(
+            sid.clone(),
+            Box::new(BlockingRecordingExecutor {
+                calls: Arc::clone(&calls),
+                first_apply_started: Arc::clone(&first_apply_started),
+                release_first_apply: Arc::clone(&release_first_apply),
+                terminal_applied: Arc::clone(&terminal_applied),
+                terminal_context_keys: Arc::clone(&terminal_context_keys),
+            }),
+        )
+        .await;
+
+    let requester_for_drain: Arc<dyn CoreCommsRuntime> = requester_comms.clone();
+    assert!(
+        adapter
+            .update_peer_ingress_context(&sid, true, Some(requester_for_drain))
+            .await,
+        "host-mode requester should spawn comms drain"
+    );
+
+    adapter
+        .accept_input(&sid, make_prompt("keep requester busy"))
+        .await
+        .expect("accept blocking prompt");
+    tokio::time::timeout(Duration::from_secs(2), first_apply_started.notified())
+        .await
+        .expect("first apply should start");
+
+    let receipt = CoreCommsRuntime::send(
+        requester_comms.as_ref(),
+        CommsCommand::PeerRequest {
+            to: PeerRoute::with_display_name(
+                responder_comms.public_key().to_peer_id(),
+                PeerName::new(name_b.clone()).expect("responder peer name"),
+            ),
+            intent: "terminal-wake-probe".to_string(),
+            params: serde_json::json!({"probe": true}),
+            handling_mode: HandlingMode::Queue,
+            stream: InputStreamMode::ReserveInteraction,
+        },
+    )
+    .await
+    .expect("send request");
+    let request_id = match receipt {
+        SendReceipt::PeerRequestSent { envelope_id, .. } => envelope_id,
+        other => panic!("expected PeerRequestSent, got {other:?}"),
+    };
+
+    let request_at_responder = drain_until_nonempty(responder_comms.as_ref()).await;
+    assert!(matches!(
+        request_at_responder[0].interaction.content,
+        InteractionContent::Request { .. }
+    ));
+
+    CoreCommsRuntime::send(
+        responder_comms.as_ref(),
+        CommsCommand::PeerResponse {
+            to: PeerRoute::with_display_name(
+                requester_comms.public_key().to_peer_id(),
+                PeerName::new(name_a.clone()).expect("requester peer name"),
+            ),
+            in_reply_to: InteractionId(request_id),
+            status: ResponseStatus::Completed,
+            result: serde_json::json!({"probe_reply": true}),
+            handling_mode: Some(HandlingMode::Steer),
+        },
+    )
+    .await
+    .expect("send terminal response");
+
+    tokio::time::timeout(Duration::from_secs(2), async {
+        loop {
+            let active_ids = adapter
+                .list_active_inputs(&sid)
+                .await
+                .expect("active inputs");
+            for input_id in active_ids {
+                if let Some(state) = adapter
+                    .input_state(&sid, &input_id)
+                    .await
+                    .expect("input state")
+                    && matches!(
+                        state.state.persisted_input.as_ref(),
+                        Some(Input::Peer(meerkat_runtime::PeerInput {
+                            convention: Some(PeerConvention::ResponseTerminal { .. }),
+                            ..
+                        }))
+                    )
+                {
+                    return;
+                }
+            }
+            tokio::time::sleep(Duration::from_millis(5)).await;
+        }
+    })
+    .await
+    .expect("terminal response should queue while requester is running");
+
+    release_first_apply.notify_waiters();
+    tokio::time::timeout(Duration::from_secs(2), terminal_applied.notified())
+        .await
+        .expect("WakeLoop should drain queued peer_response_terminal");
+
+    let keys = terminal_context_keys
+        .lock()
+        .expect("terminal_context_keys mutex")
+        .clone();
+    assert_eq!(
+        keys,
+        vec![format!("peer_response_terminal:{name_b}:{request_id}")],
+        "terminal response should render through typed context append"
+    );
+    let active_ids = adapter
+        .list_active_inputs(&sid)
+        .await
+        .expect("active inputs after drain");
+    for input_id in active_ids {
+        let state = adapter
+            .input_state(&sid, &input_id)
+            .await
+            .expect("input state")
+            .expect("active input state");
+        assert!(
+            !matches!(
+                state.state.persisted_input.as_ref(),
+                Some(Input::Peer(meerkat_runtime::PeerInput {
+                    convention: Some(PeerConvention::ResponseTerminal { .. }),
+                    ..
+                }))
+            ),
+            "queued peer_response_terminal must not remain stuck after WakeLoop: {state:?}"
+        );
+    }
+    assert!(
+        calls.load(Ordering::SeqCst) >= 2,
+        "requester executor should run once for prompt and once for terminal response"
+    );
+}
+
 /// Test that a failed executor never strands the input in APC.
 #[tokio::test]
 async fn failed_executor_does_not_strand_input_in_apc() {

--- a/meerkat-runtime/tests/peer_handling_mode_contract.rs
+++ b/meerkat-runtime/tests/peer_handling_mode_contract.rs
@@ -33,6 +33,7 @@ fn peer_message_input(handling_mode: Option<HandlingMode>) -> Input {
             timestamp: Utc::now(),
             source: InputOrigin::Peer {
                 peer_id: "peer-1".into(),
+                display_identity: None,
                 runtime_id: None,
             },
             durability: InputDurability::Durable,

--- a/meerkat-runtime/tests/regression_comms_runtime.rs
+++ b/meerkat-runtime/tests/regression_comms_runtime.rs
@@ -623,7 +623,7 @@ async fn drain_terminal_response_produces_exactly_one_peer_input() {
 // §14: Terminal response + Steer handling_mode while running
 // ---------------------------------------------------------------------------
 #[tokio::test]
-async fn terminal_response_with_steer_policy_while_running() {
+async fn terminal_response_drops_steer_handling_mode_while_running() {
     // Build a terminal response with Steer handling_mode.
     let in_reply_to = iid();
     let interaction = InboxInteraction {
@@ -639,18 +639,20 @@ async fn terminal_response_with_steer_policy_while_running() {
         render_metadata: None,
     };
     let input = interaction_to_peer_input(&interaction, &rid());
+    if let Input::Peer(peer) = &input {
+        assert_eq!(
+            peer.handling_mode, None,
+            "peer response terminal handling policy must be machine-owned"
+        );
+    }
 
-    // While running: explicit steer uses cooperative interrupt semantics at the
-    // policy layer, and ingress still requests immediate processing via the
-    // typed steer signal.
+    // While running: terminal responses ignore shell-supplied handling mode
+    // and keep the machine-owned WakeIfIdle terminal policy.
     let policy = DefaultPolicyTable::resolve(&input, false);
-    assert_eq!(
-        policy.wake_mode,
-        meerkat_runtime::WakeMode::InterruptYielding
-    );
+    assert_eq!(policy.wake_mode, meerkat_runtime::WakeMode::WakeIfIdle);
     assert_eq!(
         policy.routing_disposition,
-        meerkat_runtime::RoutingDisposition::Steer
+        meerkat_runtime::RoutingDisposition::Queue
     );
 
     // Verify driver behavior while running.
@@ -658,14 +660,10 @@ async fn terminal_response_with_steer_policy_while_running() {
     bind_running(&mut driver);
     let outcome = driver.accept_input(input).await.unwrap();
     assert!(outcome.is_accepted());
-    assert_machine_owned_admission_signal(
-        &outcome,
-        true,
-        PostAdmissionSignal::RequestImmediateProcessing,
-    );
+    assert_machine_owned_admission_signal(&outcome, false, PostAdmissionSignal::WakeLoop);
     assert_eq!(
         driver.take_post_admission_signal(),
-        PostAdmissionSignal::None
+        PostAdmissionSignal::WakeLoop
     );
 }
 
@@ -674,7 +672,7 @@ async fn terminal_response_with_steer_policy_while_running() {
 // ---------------------------------------------------------------------------
 
 #[tokio::test]
-async fn terminal_response_with_steer_policy_while_idle() {
+async fn terminal_response_drops_steer_handling_mode_while_idle() {
     // Build a terminal response with Steer handling_mode.
     let in_reply_to = iid();
     let interaction = InboxInteraction {
@@ -690,24 +688,26 @@ async fn terminal_response_with_steer_policy_while_idle() {
         render_metadata: None,
     };
     let input = interaction_to_peer_input(&interaction, &rid());
+    if let Input::Peer(peer) = &input {
+        assert_eq!(
+            peer.handling_mode, None,
+            "peer response terminal handling policy must be machine-owned"
+        );
+    }
 
-    // While idle: should get WakeIfIdle + Steer.
+    // While idle: should get machine-owned WakeIfIdle + Queue.
     let policy = DefaultPolicyTable::resolve(&input, true);
     assert_eq!(policy.wake_mode, meerkat_runtime::WakeMode::WakeIfIdle);
     assert_eq!(
         policy.routing_disposition,
-        meerkat_runtime::RoutingDisposition::Steer
+        meerkat_runtime::RoutingDisposition::Queue
     );
 
     // Verify driver behavior while idle.
     let mut driver = EphemeralRuntimeDriver::new(rid());
     let outcome = driver.accept_input(input).await.unwrap();
     assert!(outcome.is_accepted());
-    assert_machine_owned_admission_signal(
-        &outcome,
-        true,
-        PostAdmissionSignal::RequestImmediateProcessing,
-    );
+    assert_machine_owned_admission_signal(&outcome, false, PostAdmissionSignal::WakeLoop);
     assert_eq!(
         driver.take_post_admission_signal(),
         PostAdmissionSignal::None

--- a/meerkat-runtime/tests/regression_comms_runtime.rs
+++ b/meerkat-runtime/tests/regression_comms_runtime.rs
@@ -11,6 +11,7 @@
 //! - Correct wake/no-wake semantics
 //! - Correct InputState lifecycle transitions
 
+use meerkat_core::comms::PeerId;
 use meerkat_core::interaction::{
     InboxInteraction, InteractionContent, InteractionId, ResponseStatus,
 };
@@ -48,8 +49,13 @@ fn iid() -> InteractionId {
     InteractionId(Uuid::now_v7())
 }
 
+fn response_route_id() -> PeerId {
+    PeerId::from_uuid(Uuid::parse_str("018f6f79-7a82-7c4e-a552-a3b86f9630f4").unwrap())
+}
+
 fn make_message(from: &str, body: &str) -> InboxInteraction {
     InboxInteraction {
+        from_route: None,
         id: iid(),
         from: from.into(),
         content: InteractionContent::Message {
@@ -64,6 +70,7 @@ fn make_message(from: &str, body: &str) -> InboxInteraction {
 
 fn make_message_with_blocks(from: &str, body: &str) -> InboxInteraction {
     InboxInteraction {
+        from_route: None,
         id: iid(),
         from: from.into(),
         content: InteractionContent::Message {
@@ -85,6 +92,7 @@ fn make_message_with_blocks(from: &str, body: &str) -> InboxInteraction {
 fn make_response(from: &str, status: ResponseStatus) -> InboxInteraction {
     let in_reply_to = iid();
     InboxInteraction {
+        from_route: Some(response_route_id()),
         id: iid(),
         from: from.into(),
         content: InteractionContent::Response {
@@ -100,6 +108,7 @@ fn make_response(from: &str, status: ResponseStatus) -> InboxInteraction {
 
 fn make_request(from: &str, intent: &str) -> InboxInteraction {
     InboxInteraction {
+        from_route: None,
         id: iid(),
         from: from.into(),
         content: InteractionContent::Request {
@@ -623,10 +632,11 @@ async fn drain_terminal_response_produces_exactly_one_peer_input() {
 // §14: Terminal response + Steer handling_mode while running
 // ---------------------------------------------------------------------------
 #[tokio::test]
-async fn terminal_response_drops_steer_handling_mode_while_running() {
+async fn terminal_response_with_steer_policy_while_running() {
     // Build a terminal response with Steer handling_mode.
     let in_reply_to = iid();
     let interaction = InboxInteraction {
+        from_route: Some(response_route_id()),
         id: iid(),
         from: "peer-1".into(),
         content: InteractionContent::Response {
@@ -639,31 +649,34 @@ async fn terminal_response_drops_steer_handling_mode_while_running() {
         render_metadata: None,
     };
     let input = interaction_to_peer_input(&interaction, &rid());
-    if let Input::Peer(peer) = &input {
-        assert_eq!(
-            peer.handling_mode, None,
-            "peer response terminal handling policy must be machine-owned"
-        );
-    }
 
-    // While running: terminal responses ignore shell-supplied handling mode
-    // and keep the machine-owned WakeIfIdle terminal policy.
+    // While running: explicit steer uses cooperative interrupt semantics at the
+    // policy layer, and ingress still requests immediate processing via the
+    // typed steer signal. The terminal apply intent remains StageRunStart.
     let policy = DefaultPolicyTable::resolve(&input, false);
-    assert_eq!(policy.wake_mode, meerkat_runtime::WakeMode::WakeIfIdle);
+    assert_eq!(
+        policy.wake_mode,
+        meerkat_runtime::WakeMode::InterruptYielding
+    );
     assert_eq!(
         policy.routing_disposition,
-        meerkat_runtime::RoutingDisposition::Queue
+        meerkat_runtime::RoutingDisposition::Steer
     );
+    assert_eq!(policy.apply_mode, meerkat_runtime::ApplyMode::StageRunStart);
 
     // Verify driver behavior while running.
     let mut driver = EphemeralRuntimeDriver::new(rid());
     bind_running(&mut driver);
     let outcome = driver.accept_input(input).await.unwrap();
     assert!(outcome.is_accepted());
-    assert_machine_owned_admission_signal(&outcome, false, PostAdmissionSignal::WakeLoop);
+    assert_machine_owned_admission_signal(
+        &outcome,
+        true,
+        PostAdmissionSignal::RequestImmediateProcessing,
+    );
     assert_eq!(
         driver.take_post_admission_signal(),
-        PostAdmissionSignal::WakeLoop
+        PostAdmissionSignal::None
     );
 }
 
@@ -672,10 +685,11 @@ async fn terminal_response_drops_steer_handling_mode_while_running() {
 // ---------------------------------------------------------------------------
 
 #[tokio::test]
-async fn terminal_response_drops_steer_handling_mode_while_idle() {
+async fn terminal_response_with_steer_policy_while_idle() {
     // Build a terminal response with Steer handling_mode.
     let in_reply_to = iid();
     let interaction = InboxInteraction {
+        from_route: Some(response_route_id()),
         id: iid(),
         from: "peer-1".into(),
         content: InteractionContent::Response {
@@ -688,26 +702,26 @@ async fn terminal_response_drops_steer_handling_mode_while_idle() {
         render_metadata: None,
     };
     let input = interaction_to_peer_input(&interaction, &rid());
-    if let Input::Peer(peer) = &input {
-        assert_eq!(
-            peer.handling_mode, None,
-            "peer response terminal handling policy must be machine-owned"
-        );
-    }
 
-    // While idle: should get machine-owned WakeIfIdle + Queue.
+    // While idle: should get WakeIfIdle + Steer with the machine-owned
+    // terminal apply intent preserved as StageRunStart.
     let policy = DefaultPolicyTable::resolve(&input, true);
     assert_eq!(policy.wake_mode, meerkat_runtime::WakeMode::WakeIfIdle);
     assert_eq!(
         policy.routing_disposition,
-        meerkat_runtime::RoutingDisposition::Queue
+        meerkat_runtime::RoutingDisposition::Steer
     );
+    assert_eq!(policy.apply_mode, meerkat_runtime::ApplyMode::StageRunStart);
 
     // Verify driver behavior while idle.
     let mut driver = EphemeralRuntimeDriver::new(rid());
     let outcome = driver.accept_input(input).await.unwrap();
     assert!(outcome.is_accepted());
-    assert_machine_owned_admission_signal(&outcome, false, PostAdmissionSignal::WakeLoop);
+    assert_machine_owned_admission_signal(
+        &outcome,
+        true,
+        PostAdmissionSignal::RequestImmediateProcessing,
+    );
     assert_eq!(
         driver.take_post_admission_signal(),
         PostAdmissionSignal::None

--- a/scripts/generate-bazel-rust-builds.mjs
+++ b/scripts/generate-bazel-rust-builds.mjs
@@ -347,14 +347,14 @@ function workspaceDataLabels(target) {
   if (source.includes(".github/")) {
     labels.add("//:github_workflows");
   }
+  if (source.includes("scripts/")) {
+    labels.add("//:repo_governance_files");
+  }
   if (source.includes("test-fixtures")) {
     labels.add("//:test_fixtures");
     labels.add("//test-fixtures/machine-dsl-tests:package_runfiles");
     labels.add("//test-fixtures/mcp-test-server:package_runfiles");
     labels.add("//test-fixtures/surface-build-fixtures:package_runfiles");
-  }
-  if (target.name === "rmat_audit") {
-    labels.add("//:repo_governance_files");
   }
   if (target.name === "protocol_codegen_drift") {
     for (const label of packageRunfileLabels) labels.add(label);
@@ -537,6 +537,7 @@ function writeRootBuild(fastTestLabels, e2eSystemTestLabels, surfaceFeatureMatri
     `            ".git/**",`,
     `            "bazel-*",`,
     `            "bazel-*/**",`,
+    `            "**/node_modules/**",`,
     `            "target/**",`,
     `            "**/BUILD",`,
     `            "**/BUILD.bazel",`,

--- a/sdks/python/meerkat/client.py
+++ b/sdks/python/meerkat/client.py
@@ -771,19 +771,25 @@ class MeerkatClient:
     async def send_peer_response_terminal(
         self,
         session_id: str,
-        peer_name: str,
+        route_identity: str,
+        display_identity: str,
         request_id: str,
         status: Literal["completed", "failed", "cancelled"],
         result: Any,
+        *,
+        transport_identity: str | None = None,
     ) -> ExternalEventOutcome:
         """Admit a correlated terminal peer response through the typed ingress."""
         params: dict[str, Any] = {
             "session_id": session_id,
-            "peer_name": peer_name,
+            "route_identity": route_identity,
+            "display_identity": display_identity,
             "request_id": request_id,
             "status": status,
             "result": result,
         }
+        if transport_identity is not None:
+            params["transport_identity"] = transport_identity
         return await self._request("session/peer_response_terminal", params)
 
 

--- a/sdks/python/meerkat/session.py
+++ b/sdks/python/meerkat/session.py
@@ -236,18 +236,23 @@ class Session:
 
     async def send_peer_response_terminal(
         self,
-        peer_name: str,
+        route_identity: str,
+        display_identity: str,
         request_id: str,
         status: str,
         result: Any,
+        *,
+        transport_identity: str | None = None,
     ) -> dict[str, Any]:
         """Admit a correlated terminal peer response into this session runtime."""
         return await self._client.send_peer_response_terminal(
             self._id,
-            peer_name,
+            route_identity,
+            display_identity,
             request_id,
             status,
             result,
+            transport_identity=transport_identity,
         )
 
     async def history(
@@ -420,18 +425,23 @@ class DeferredSession:
 
     async def send_peer_response_terminal(
         self,
-        peer_name: str,
+        route_identity: str,
+        display_identity: str,
         request_id: str,
         status: str,
         result: Any,
+        *,
+        transport_identity: str | None = None,
     ) -> dict[str, Any]:
         """Admit a correlated terminal peer response into this deferred session."""
         return await self._client.send_peer_response_terminal(
             self._id,
-            peer_name,
+            route_identity,
+            display_identity,
             request_id,
             status,
             result,
+            transport_identity=transport_identity,
         )
 
     async def history(

--- a/sdks/typescript/src/client.ts
+++ b/sdks/typescript/src/client.ts
@@ -570,18 +570,25 @@ export class MeerkatClient {
 
   async sendPeerResponseTerminal(
     sessionId: string,
-    peerName: string,
+    routeIdentity: string,
+    displayIdentity: string,
     requestId: string,
     status: "completed" | "failed" | "cancelled",
     result: unknown,
+    options?: { transportIdentity?: string },
   ): Promise<Record<string, unknown>> {
-    return this.request("session/peer_response_terminal", {
+    const params: Record<string, unknown> = {
       session_id: sessionId,
-      peer_name: peerName,
+      route_identity: routeIdentity,
+      display_identity: displayIdentity,
       request_id: requestId,
       status,
       result,
-    });
+    };
+    if (options?.transportIdentity !== undefined) {
+      params.transport_identity = options.transportIdentity;
+    }
+    return this.request("session/peer_response_terminal", params);
   }
 
   async injectContext(

--- a/sdks/typescript/src/session.ts
+++ b/sdks/typescript/src/session.ts
@@ -128,17 +128,21 @@ export class Session {
   }
 
   async sendPeerResponseTerminal(
-    peerName: string,
+    routeIdentity: string,
+    displayIdentity: string,
     requestId: string,
     status: "completed" | "failed" | "cancelled",
     result: unknown,
+    options?: { transportIdentity?: string },
   ): Promise<Record<string, unknown>> {
     return this._client.sendPeerResponseTerminal(
       this._id,
-      peerName,
+      routeIdentity,
+      displayIdentity,
       requestId,
       status,
       result,
+      options,
     );
   }
 
@@ -269,17 +273,21 @@ export class DeferredSession {
   }
 
   async sendPeerResponseTerminal(
-    peerName: string,
+    routeIdentity: string,
+    displayIdentity: string,
     requestId: string,
     status: "completed" | "failed" | "cancelled",
     result: unknown,
+    options?: { transportIdentity?: string },
   ): Promise<Record<string, unknown>> {
     return this._client.sendPeerResponseTerminal(
       this._id,
-      peerName,
+      routeIdentity,
+      displayIdentity,
       requestId,
       status,
       result,
+      options,
     );
   }
 

--- a/tests/integration/BUILD.bazel
+++ b/tests/integration/BUILD.bazel
@@ -207,6 +207,7 @@ rust_test(
     ],
     data = [
         ":package_runfiles",
+        "//:repo_governance_files",
         "//:workspace_runfiles",
     ],
     env = {
@@ -476,6 +477,7 @@ rust_test(
     ],
     data = [
         ":package_runfiles",
+        "//:repo_governance_files",
         "//:workspace_runfiles",
     ],
     env = {

--- a/tests/integration/tests/reserve_interaction_subscriber_fires.rs
+++ b/tests/integration/tests/reserve_interaction_subscriber_fires.rs
@@ -23,6 +23,7 @@
 #![allow(clippy::unwrap_used, clippy::expect_used, clippy::panic)]
 
 use meerkat_comms::runtime::comms_runtime::CommsRuntime;
+use meerkat_core::PeerInputClass;
 use meerkat_core::agent::CommsRuntime as CoreCommsRuntime;
 use meerkat_core::comms::{CommsCommand, InputStreamMode, PeerName, PeerRoute, SendReceipt};
 use meerkat_core::{
@@ -115,6 +116,11 @@ async fn reserve_interaction_subscriber_fires_on_matching_response() {
         response_at_a.len(),
         1,
         "A should observe exactly one response",
+    );
+    assert_eq!(
+        response_at_a[0].class,
+        PeerInputClass::ResponseTerminal,
+        "terminal response class must be machine-owned at ingress"
     );
     let response = &response_at_a[0].interaction;
     match &response.content {

--- a/xtask/BUILD.bazel
+++ b/xtask/BUILD.bazel
@@ -178,6 +178,7 @@ rust_test(
     size = "small",
     data = [
         ":package_runfiles",
+        "//:repo_governance_files",
         "//meerkat-cli:cargo_manifest",
         "//meerkat-cli:package_runfiles",
         "//meerkat-comms:cargo_manifest",
@@ -259,6 +260,7 @@ rust_test(
     data = [
         ":package_runfiles",
         "//:github_workflows",
+        "//:repo_governance_files",
         "//meerkat-core:package_runfiles",
         "//meerkat-machine-schema:package_runfiles",
         "//meerkat-mob:package_runfiles",
@@ -318,9 +320,12 @@ rust_test(
     ],
     data = [
         ":package_runfiles",
+        "//meerkat-contracts:package_runfiles",
+        "//meerkat-core:package_runfiles",
         "//meerkat-machine-kernels:package_runfiles",
         "//meerkat-machine-schema:package_runfiles",
         "//meerkat-mob:package_runfiles",
+        "//meerkat-rpc:package_runfiles",
         "//meerkat-runtime:package_runfiles",
         "//:workspace_runfiles",
         "@@rules_rust++rust+rustfmt_nightly-2026-04-16__aarch64-apple-darwin_tools//:rustfmt_bin",

--- a/xtask/src/machines.rs
+++ b/xtask/src/machines.rs
@@ -280,6 +280,7 @@ pub fn machine_check_drift(args: SelectionArgs) -> Result<()> {
     mismatches.extend(collect_phase1_production_body_mismatches(&root)?);
     mismatches.extend(collect_authority_language_mismatches(&root)?);
     mismatches.extend(collect_stale_cfg_mismatches(&root)?);
+    mismatches.extend(collect_peer_response_terminal_projection_mismatches(&root)?);
     mismatches.extend(collect_direct_flow_reducer_transition_mismatches(&root)?);
     mismatches.extend(collect_mob_runtime_catalog_command_gate_mismatches(&root)?);
 
@@ -498,6 +499,7 @@ fn ensure_no_drift(root: &Path, selection: &Selection) -> Result<()> {
     mismatches.extend(collect_phase1_production_body_mismatches(root)?);
     mismatches.extend(collect_authority_language_mismatches(root)?);
     mismatches.extend(collect_stale_cfg_mismatches(root)?);
+    mismatches.extend(collect_peer_response_terminal_projection_mismatches(root)?);
     mismatches.extend(collect_direct_flow_reducer_transition_mismatches(root)?);
     mismatches.extend(collect_mob_runtime_catalog_command_gate_mismatches(root)?);
 
@@ -641,6 +643,59 @@ pub fn collect_authority_language_mismatches(root: &Path) -> Result<Vec<String>>
                     "stale authority language `{token}` present in {}",
                     path.display()
                 ));
+            }
+        }
+    }
+
+    Ok(mismatches)
+}
+
+pub fn collect_peer_response_terminal_projection_mismatches(root: &Path) -> Result<Vec<String>> {
+    let mut mismatches = Vec::new();
+    let boundary_files = [
+        "meerkat-runtime/src/accept.rs",
+        "meerkat-runtime/src/input.rs",
+        "meerkat-runtime/src/runtime_loop.rs",
+    ];
+    let banned = [
+        (
+            "PeerConversationProjection::ResponseTerminal",
+            "direct terminal projection construction",
+        ),
+        (
+            "[SYSTEM NOTICE][PEER_RESPONSE_TERMINAL]",
+            "handwritten terminal render text",
+        ),
+        (
+            "peer_response_terminal_context_key(",
+            "handwritten terminal context key projection",
+        ),
+    ];
+
+    for rel in boundary_files {
+        let path = root.join(rel);
+        if !path.exists() {
+            continue;
+        }
+        let contents = fs::read_to_string(&path).with_context(|| {
+            format!(
+                "read peer-response terminal boundary file {}",
+                path.display()
+            )
+        })?;
+        let production = contents
+            .split("\n#[cfg(test)]")
+            .next()
+            .unwrap_or(contents.as_str());
+
+        for (line_idx, line) in production.lines().enumerate() {
+            for (token, reason) in banned {
+                if line.contains(token) {
+                    mismatches.push(format!(
+                        "{rel}:{}: {reason} `{token}` must route through typed core peer-response terminal facts",
+                        line_idx + 1
+                    ));
+                }
             }
         }
     }

--- a/xtask/src/machines.rs
+++ b/xtask/src/machines.rs
@@ -700,6 +700,102 @@ pub fn collect_peer_response_terminal_projection_mismatches(root: &Path) -> Resu
         }
     }
 
+    let core_projection_owner = root.join("meerkat-core/src/handles.rs");
+    if core_projection_owner.exists() {
+        let rel = "meerkat-core/src/handles.rs";
+        let contents = fs::read_to_string(&core_projection_owner).with_context(|| {
+            format!(
+                "read peer-response terminal core projection owner {}",
+                core_projection_owner.display()
+            )
+        })?;
+        let production = contents
+            .split("\n#[cfg(test)]")
+            .next()
+            .unwrap_or(contents.as_str());
+        let core_banned = [
+            (
+                "transport_identity: Option<String>",
+                "transport identity string bus",
+            ),
+            ("route_identity: String", "route identity string bus"),
+            ("display_identity: String", "display identity string bus"),
+            ("correlation_id: String", "correlation id string bus"),
+            (
+                "peer_response_terminal_context_key(&self.source.route_identity, &self.correlation_id)",
+                "untyped terminal context key projection",
+            ),
+        ];
+
+        for (line_idx, line) in production.lines().enumerate() {
+            for (token, reason) in core_banned {
+                if line.contains(token) {
+                    mismatches.push(format!(
+                        "{rel}:{}: {reason} `{token}` must use distinct typed peer-response terminal facts",
+                        line_idx + 1
+                    ));
+                }
+            }
+        }
+    }
+
+    let shell_boundary_files = [
+        "meerkat-contracts/src/wire/runtime.rs",
+        "meerkat-rest/src/lib.rs",
+        "meerkat-rpc/src/handlers/event.rs",
+        "meerkat-rpc/src/session_runtime.rs",
+    ];
+    let shell_banned = [
+        (
+            "pub peer_name: PeerName",
+            "terminal shell peer_name identity bus",
+        ),
+        (
+            "peer_name: meerkat_core::comms::PeerName",
+            "terminal shell peer_name identity bus",
+        ),
+        (
+            "PeerResponseTerminalRouteIdentity::parse(peer_name",
+            "terminal route identity projected from peer_name",
+        ),
+        (
+            "PeerResponseTerminalDisplayIdentity::parse(peer_name",
+            "terminal display identity projected from peer_name",
+        ),
+        (
+            "peer_response_terminal_input(&peer_name",
+            "terminal input projected from peer_name",
+        ),
+    ];
+
+    for rel in shell_boundary_files {
+        let path = root.join(rel);
+        if !path.exists() {
+            continue;
+        }
+        let contents = fs::read_to_string(&path).with_context(|| {
+            format!(
+                "read peer-response terminal shell boundary file {}",
+                path.display()
+            )
+        })?;
+        let production = contents
+            .split("\n#[cfg(test)]")
+            .next()
+            .unwrap_or(contents.as_str());
+
+        for (line_idx, line) in production.lines().enumerate() {
+            for (token, reason) in shell_banned {
+                if line.contains(token) {
+                    mismatches.push(format!(
+                        "{rel}:{}: {reason} `{token}` must transport typed route/display/correlation facts",
+                        line_idx + 1
+                    ));
+                }
+            }
+        }
+    }
+
     Ok(mismatches)
 }
 

--- a/xtask/tests/machines_contracts.rs
+++ b/xtask/tests/machines_contracts.rs
@@ -174,6 +174,46 @@ fn authority_language_check_reports_live_docs_outside_retired_architecture_scope
 }
 
 #[test]
+fn peer_response_terminal_projection_ratchet_rejects_runtime_boundary_projection() {
+    let dir = tempdir().expect("tempdir");
+    let runtime = dir.path().join("meerkat-runtime/src");
+    fs::create_dir_all(&runtime).expect("create runtime dir");
+    fs::write(
+        runtime.join("input.rs"),
+        r#"
+fn bad() {
+    let _ = PeerConversationProjection::ResponseTerminal { fact };
+    let _ = "[SYSTEM NOTICE][PEER_RESPONSE_TERMINAL]";
+    let _ = peer_response_terminal_context_key("peer", "req");
+}
+
+#[cfg(test)]
+mod tests {
+    fn allowed_test_fixture() {
+        let _ = "[SYSTEM NOTICE][PEER_RESPONSE_TERMINAL]";
+    }
+}
+"#,
+    )
+    .expect("write boundary file");
+
+    let mismatches = collect_peer_response_terminal_projection_mismatches(dir.path())
+        .expect("peer response terminal projection mismatches");
+    assert_eq!(
+        mismatches.len(),
+        3,
+        "expected production boundary projection violations only, got {mismatches:#?}"
+    );
+    assert!(
+        mismatches.iter().all(|mismatch| {
+            mismatch.contains("meerkat-runtime/src/input.rs")
+                && !mismatch.contains("allowed_test_fixture")
+        }),
+        "expected mismatches to point at production boundary lines, got {mismatches:#?}"
+    );
+}
+
+#[test]
 fn canonical_machine_inventory_matches_docs_and_artifact_bundle() {
     require_live_workspace_runfiles();
     let root = repo_root().expect("repo root");

--- a/xtask/tests/machines_contracts.rs
+++ b/xtask/tests/machines_contracts.rs
@@ -214,6 +214,111 @@ mod tests {
 }
 
 #[test]
+fn peer_response_terminal_projection_ratchet_rejects_core_string_identity_bus() {
+    let dir = tempdir().expect("tempdir");
+    let core = dir.path().join("meerkat-core/src");
+    fs::create_dir_all(&core).expect("create core dir");
+    fs::write(
+        core.join("handles.rs"),
+        r#"
+pub struct PeerResponseTerminalSource {
+    pub transport_identity: Option<String>,
+    pub route_identity: String,
+    pub display_identity: String,
+}
+
+pub struct PeerResponseTerminalFact {
+    pub correlation_id: String,
+}
+
+impl PeerResponseTerminalFact {
+    pub fn context_key(&self) -> String {
+        peer_response_terminal_context_key(&self.source.route_identity, &self.correlation_id)
+    }
+}
+"#,
+    )
+    .expect("write core handles file");
+
+    let mismatches = collect_peer_response_terminal_projection_mismatches(dir.path())
+        .expect("peer response terminal projection mismatches");
+    assert!(
+        mismatches
+            .iter()
+            .any(|mismatch| mismatch.contains("transport_identity")),
+        "expected transport identity string bus to be rejected, got {mismatches:#?}"
+    );
+    assert!(
+        mismatches
+            .iter()
+            .any(|mismatch| mismatch.contains("route_identity")),
+        "expected route identity string bus to be rejected, got {mismatches:#?}"
+    );
+    assert!(
+        mismatches
+            .iter()
+            .any(|mismatch| mismatch.contains("display_identity")),
+        "expected display identity string bus to be rejected, got {mismatches:#?}"
+    );
+    assert!(
+        mismatches
+            .iter()
+            .any(|mismatch| mismatch.contains("correlation_id")),
+        "expected correlation id string bus to be rejected, got {mismatches:#?}"
+    );
+}
+
+#[test]
+fn peer_response_terminal_projection_ratchet_rejects_shell_peer_name_identity_bus() {
+    let dir = tempdir().expect("tempdir");
+    let contracts = dir.path().join("meerkat-contracts/src/wire");
+    let rpc = dir.path().join("meerkat-rpc/src");
+    fs::create_dir_all(&contracts).expect("create contracts dir");
+    fs::create_dir_all(rpc.join("handlers")).expect("create rpc handlers dir");
+    fs::write(
+        contracts.join("runtime.rs"),
+        r#"
+pub struct SessionPeerResponseTerminalParams {
+    pub peer_name: PeerName,
+}
+"#,
+    )
+    .expect("write contract boundary file");
+    fs::write(
+        rpc.join("session_runtime.rs"),
+        r#"
+fn bad(peer_name: PeerName) {
+    let route = PeerResponseTerminalRouteIdentity::parse(peer_name.as_str().to_string());
+    let display = PeerResponseTerminalDisplayIdentity::parse(peer_name.as_str().to_string());
+    let _ = peer_response_terminal_input(&peer_name, request_id, status, result);
+}
+"#,
+    )
+    .expect("write rpc boundary file");
+
+    let mismatches = collect_peer_response_terminal_projection_mismatches(dir.path())
+        .expect("peer response terminal projection mismatches");
+    assert!(
+        mismatches
+            .iter()
+            .any(|mismatch| mismatch.contains("pub peer_name: PeerName")),
+        "expected contract peer_name identity bus to be rejected, got {mismatches:#?}"
+    );
+    assert!(
+        mismatches
+            .iter()
+            .any(|mismatch| mismatch.contains("RouteIdentity")),
+        "expected route identity projection from peer_name to be rejected, got {mismatches:#?}"
+    );
+    assert!(
+        mismatches
+            .iter()
+            .any(|mismatch| mismatch.contains("DisplayIdentity")),
+        "expected display identity projection from peer_name to be rejected, got {mismatches:#?}"
+    );
+}
+
+#[test]
 fn canonical_machine_inventory_matches_docs_and_artifact_bundle() {
     require_live_workspace_runfiles();
     let root = repo_root().expect("repo root");


### PR DESCRIPTION
## Summary
- split peer response ingress into typed progress vs terminal classes
- introduce core-owned peer response terminal facts for render/context projection
- reject malformed terminal facts and shell-provided response handling modes at admission
- add requester WakeLoop drain coverage and boundary ratchet tests

Linear: LUC-158

## Validation
- ./scripts/repo-cargo test -p meerkat-core peer_ingress_policy_owns_response_terminal_classification
- ./scripts/repo-cargo test -p meerkat-comms classify_completed_response_as_terminal_response
- ./scripts/repo-cargo test -p meerkat-runtime peer_handling_mode
- ./scripts/repo-cargo test -p meerkat-runtime accept_peer_response_terminal_with_handling_mode_returns_rejected
- ./scripts/repo-cargo test -p meerkat-runtime response_terminal_with_
- ./scripts/repo-cargo test -p meerkat-runtime terminal_response_drops_steer_handling_mode
- ./scripts/repo-cargo test -p meerkat-runtime runtime_comms_terminal_response_wake_drains_requester_queue
- ./scripts/repo-cargo test -p xtask --features machine-authority peer_response_terminal_projection_ratchet_rejects_runtime_boundary_projection
- ./scripts/repo-cargo test -p meerkat-core peer_terminal_projection_owns_prompt_and_context_key
- ./scripts/repo-cargo test -p meerkat-integration-tests reserve_interaction_subscriber_fires_on_matching_response
- ./scripts/repo-cargo test -p meerkat-mob contract_mob_002_peer_request_response_round_trip
- ./scripts/repo-cargo fmt --all --check
- git diff --check
- MEERKAT_BUILDBUDDY=1 make check