### PR TITLE
LUC-162: Fix peer response terminal apply intent

### DIFF
--- a/meerkat-cli/src/main.rs
+++ b/meerkat-cli/src/main.rs
@@ -7173,6 +7173,7 @@ impl SurfaceScheduleSessionHost for CliScheduleSessionHost {
                     clear_provider_params: false,
                     render_metadata: dispatch.render_metadata.clone(),
                     execution_kind: None,
+                    peer_response_terminal_apply_intent: None,
                     connection_ref: None,
                     clear_connection_ref: false,
                 },

--- a/meerkat-contracts/src/wire/runtime.rs
+++ b/meerkat-contracts/src/wire/runtime.rs
@@ -778,6 +778,8 @@ pub struct WireRuntimeTurnMetadata {
     pub render_metadata: Option<crate::wire::mob::WireRenderMetadata>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub execution_kind: Option<WireRuntimeExecutionKind>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub peer_response_terminal_apply_intent: Option<WirePeerResponseTerminalApplyIntent>,
 }
 
 /// Typed wire projection of [`meerkat_core::lifecycle::run_primitive::RuntimeExecutionKind`].
@@ -787,6 +789,15 @@ pub struct WireRuntimeTurnMetadata {
 pub enum WireRuntimeExecutionKind {
     ContentTurn,
     ResumePending,
+}
+
+/// Typed wire projection of
+/// [`meerkat_core::lifecycle::run_primitive::PeerResponseTerminalApplyIntent`].
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
+#[serde(rename_all = "snake_case")]
+pub enum WirePeerResponseTerminalApplyIntent {
+    AppendContextAndRun,
 }
 
 impl From<meerkat_core::lifecycle::run_primitive::RuntimeExecutionKind>
@@ -812,6 +823,30 @@ impl From<WireRuntimeExecutionKind>
     }
 }
 
+impl From<meerkat_core::lifecycle::run_primitive::PeerResponseTerminalApplyIntent>
+    for WirePeerResponseTerminalApplyIntent
+{
+    fn from(
+        value: meerkat_core::lifecycle::run_primitive::PeerResponseTerminalApplyIntent,
+    ) -> Self {
+        match value {
+            meerkat_core::lifecycle::run_primitive::PeerResponseTerminalApplyIntent::AppendContextAndRun => {
+                Self::AppendContextAndRun
+            }
+        }
+    }
+}
+
+impl From<WirePeerResponseTerminalApplyIntent>
+    for meerkat_core::lifecycle::run_primitive::PeerResponseTerminalApplyIntent
+{
+    fn from(value: WirePeerResponseTerminalApplyIntent) -> Self {
+        match value {
+            WirePeerResponseTerminalApplyIntent::AppendContextAndRun => Self::AppendContextAndRun,
+        }
+    }
+}
+
 impl From<meerkat_core::lifecycle::run_primitive::RuntimeTurnMetadata> for WireRuntimeTurnMetadata {
     fn from(value: meerkat_core::lifecycle::run_primitive::RuntimeTurnMetadata) -> Self {
         Self {
@@ -830,6 +865,9 @@ impl From<meerkat_core::lifecycle::run_primitive::RuntimeTurnMetadata> for WireR
             keep_alive: value.keep_alive.map(Into::into),
             render_metadata: value.render_metadata.map(Into::into),
             execution_kind: value.execution_kind.map(Into::into),
+            peer_response_terminal_apply_intent: value
+                .peer_response_terminal_apply_intent
+                .map(Into::into),
         }
     }
 }
@@ -853,6 +891,9 @@ impl From<WireRuntimeTurnMetadata> for meerkat_core::lifecycle::run_primitive::R
             keep_alive: value.keep_alive.map(Into::into),
             render_metadata: value.render_metadata.map(Into::into),
             execution_kind: value.execution_kind.map(Into::into),
+            peer_response_terminal_apply_intent: value
+                .peer_response_terminal_apply_intent
+                .map(Into::into),
         }
     }
 }

--- a/meerkat-core/src/lifecycle/run_primitive.rs
+++ b/meerkat-core/src/lifecycle/run_primitive.rs
@@ -92,6 +92,19 @@ pub enum RuntimeExecutionKind {
     ResumePending,
 }
 
+/// Machine-owned apply intent for terminal peer responses.
+///
+/// Terminal peer responses are context facts and requester wake/reaction work.
+/// This closed intent prevents context-only executor shortcuts from inferring a
+/// different meaning from the primitive's append shape.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum PeerResponseTerminalApplyIntent {
+    /// Append the durable system-context fact, then run the requester reaction
+    /// turn using the appended context.
+    AppendContextAndRun,
+}
+
 /// Opaque model identifier carried by a per-turn override.
 ///
 /// A bare string here is a failure of the typed-metadata invariant: validation
@@ -1052,6 +1065,10 @@ pub struct RuntimeTurnMetadata {
     /// `Some(ResumePending)` forces `run_pending`.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub execution_kind: Option<RuntimeExecutionKind>,
+    /// Typed terminal peer-response apply intent classified by the runtime
+    /// machine at admission.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub peer_response_terminal_apply_intent: Option<PeerResponseTerminalApplyIntent>,
 }
 
 impl RuntimeTurnMetadata {
@@ -1071,6 +1088,7 @@ impl RuntimeTurnMetadata {
             && self.keep_alive.is_none()
             && self.render_metadata.is_none()
             && self.execution_kind.is_none()
+            && self.peer_response_terminal_apply_intent.is_none()
     }
 
     /// Merge another metadata carrier into this one. Scalar conflicts (two
@@ -1127,6 +1145,11 @@ impl RuntimeTurnMetadata {
             &mut self.execution_kind,
             other.execution_kind,
             "execution_kind",
+        )?;
+        merge_scalar(
+            &mut self.peer_response_terminal_apply_intent,
+            other.peer_response_terminal_apply_intent,
+            "peer_response_terminal_apply_intent",
         )?;
 
         // Collections: accumulate.
@@ -1314,6 +1337,57 @@ impl RunPrimitive {
         }
     }
 
+    pub fn peer_response_terminal_apply_intent(&self) -> Option<PeerResponseTerminalApplyIntent> {
+        self.turn_metadata()
+            .and_then(|metadata| metadata.peer_response_terminal_apply_intent)
+    }
+
+    pub fn is_peer_response_terminal_context_and_run(&self) -> bool {
+        matches!(
+            self.peer_response_terminal_apply_intent(),
+            Some(PeerResponseTerminalApplyIntent::AppendContextAndRun)
+        )
+    }
+
+    pub fn peer_response_terminal_apply_intent_violation(&self) -> Option<&'static str> {
+        if !self.is_peer_response_terminal_context_and_run() {
+            return None;
+        }
+
+        let RunPrimitive::StagedInput(staged) = self else {
+            return Some("terminal peer-response apply intent requires a staged primitive");
+        };
+        if staged.boundary != RunApplyBoundary::RunStart {
+            return Some("terminal peer-response apply intent requires RunStart boundary");
+        }
+        if !staged.appends.is_empty() || staged.context_appends.is_empty() {
+            return Some(
+                "terminal peer-response apply intent requires context-only staged appends",
+            );
+        }
+        if staged
+            .turn_metadata
+            .as_ref()
+            .and_then(|metadata| metadata.execution_kind)
+            != Some(RuntimeExecutionKind::ContentTurn)
+        {
+            return Some("terminal peer-response apply intent requires ContentTurn execution kind");
+        }
+        None
+    }
+
+    /// Whether this primitive's context appends should be applied without
+    /// running a requester reaction turn.
+    pub fn is_context_only_apply_without_turn(&self) -> bool {
+        matches!(
+            self,
+            RunPrimitive::StagedInput(staged)
+            if staged.appends.is_empty()
+                && !staged.context_appends.is_empty()
+                && !self.is_peer_response_terminal_context_and_run()
+        )
+    }
+
     /// Whether this primitive is a context-only staged input that should be
     /// routed to `apply_runtime_context_appends` rather than a full turn.
     pub fn is_context_only_immediate(&self) -> bool {
@@ -1485,6 +1559,51 @@ mod tests {
             turn_metadata: None,
         });
         assert!(!p.is_context_only_immediate());
+    }
+
+    #[test]
+    fn context_only_apply_without_turn_true_for_plain_context() {
+        let p = RunPrimitive::StagedInput(StagedRunInput {
+            boundary: RunApplyBoundary::RunCheckpoint,
+            appends: vec![],
+            context_appends: vec![ConversationContextAppend {
+                key: "k".into(),
+                content: CoreRenderable::Text { text: "ctx".into() },
+            }],
+            contributing_input_ids: vec![],
+            turn_metadata: Some(RuntimeTurnMetadata {
+                execution_kind: Some(RuntimeExecutionKind::ContentTurn),
+                ..Default::default()
+            }),
+        });
+
+        assert!(p.is_context_only_apply_without_turn());
+    }
+
+    #[test]
+    fn terminal_peer_response_context_and_run_bypasses_context_only_shortcut() {
+        let p = RunPrimitive::StagedInput(StagedRunInput {
+            boundary: RunApplyBoundary::RunStart,
+            appends: vec![],
+            context_appends: vec![ConversationContextAppend {
+                key: "peer_response_terminal:analyst-rt:req-123".into(),
+                content: CoreRenderable::Text {
+                    text: "[SYSTEM NOTICE][PEER_RESPONSE_TERMINAL] done".into(),
+                },
+            }],
+            contributing_input_ids: vec![InputId::new()],
+            turn_metadata: Some(RuntimeTurnMetadata {
+                execution_kind: Some(RuntimeExecutionKind::ContentTurn),
+                peer_response_terminal_apply_intent: Some(
+                    PeerResponseTerminalApplyIntent::AppendContextAndRun,
+                ),
+                ..Default::default()
+            }),
+        });
+
+        assert!(p.is_peer_response_terminal_context_and_run());
+        assert_eq!(p.peer_response_terminal_apply_intent_violation(), None);
+        assert!(!p.is_context_only_apply_without_turn());
     }
 
     #[test]

--- a/meerkat-core/tests/runtime_turn_metadata_typed_round_trip.rs
+++ b/meerkat-core/tests/runtime_turn_metadata_typed_round_trip.rs
@@ -10,9 +10,9 @@ use std::time::Duration;
 use meerkat_core::connection::ConnectionRef;
 use meerkat_core::lifecycle::run_primitive::{
     AnthropicProviderTag, GeminiProviderTag, KeepAliveMode, KeepAlivePolicy, ModelId,
-    OpenAiProviderTag, ProviderParamsOverride, ProviderTag, ReasoningEffort, ReasoningMode,
-    RuntimeExecutionKind, RuntimeTurnMetadata, TurnInstruction, TurnInstructionKind,
-    TurnMetadataMergeConflict,
+    OpenAiProviderTag, PeerResponseTerminalApplyIntent, ProviderParamsOverride, ProviderTag,
+    ReasoningEffort, ReasoningMode, RuntimeExecutionKind, RuntimeTurnMetadata, TurnInstruction,
+    TurnInstructionKind, TurnMetadataMergeConflict,
 };
 use meerkat_core::provider::Provider;
 use meerkat_core::service::TurnToolOverlay;
@@ -68,6 +68,9 @@ fn sample_metadata() -> RuntimeTurnMetadata {
             salience: RenderSalience::Urgent,
         }),
         execution_kind: Some(RuntimeExecutionKind::ContentTurn),
+        peer_response_terminal_apply_intent: Some(
+            PeerResponseTerminalApplyIntent::AppendContextAndRun,
+        ),
     }
 }
 

--- a/meerkat-mob/src/runtime/provisioner.rs
+++ b/meerkat-mob/src/runtime/provisioner.rs
@@ -737,6 +737,21 @@ impl CoreExecutor for MobSessionRuntimeExecutor {
                 });
         }
 
+        if primitive.is_peer_response_terminal_context_and_run() {
+            let RunPrimitive::StagedInput(staged) = &primitive else {
+                unreachable!("terminal peer-response apply intent only matches staged primitives");
+            };
+            self.session_service
+                .apply_runtime_system_context_for_turn(
+                    &self.bridge_session_id,
+                    pending_system_context_appends_for_runtime_executor(&staged.context_appends),
+                )
+                .await
+                .map_err(|err| CoreExecutorError::ApplyFailed {
+                    reason: err.to_string(),
+                })?;
+        }
+
         let contributing_input_ids = primitive.contributing_input_ids().to_vec();
         let queued_context = self
             .state

--- a/meerkat-mob/src/runtime/provisioner.rs
+++ b/meerkat-mob/src/runtime/provisioner.rs
@@ -709,14 +709,19 @@ impl CoreExecutor for MobSessionRuntimeExecutor {
         run_id: CoreRunId,
         primitive: RunPrimitive,
     ) -> Result<CoreApplyOutput, CoreExecutorError> {
-        // Context-only staged primitive — no conversation appends, just
-        // context (e.g. peer_response_terminal with Steer→RunCheckpoint
-        // boundary). Must not trigger a turn. See SessionRuntimeExecutor
-        // for the rationale on relaxing the boundary==Immediate gate.
-        if let RunPrimitive::StagedInput(staged) = &primitive
-            && staged.appends.is_empty()
-            && !staged.context_appends.is_empty()
-        {
+        if let Some(reason) = primitive.peer_response_terminal_apply_intent_violation() {
+            return Err(CoreExecutorError::ApplyFailed {
+                reason: reason.to_string(),
+            });
+        }
+
+        // Context-only staged primitives may land directly as runtime
+        // system-context appends, but terminal peer responses carry a typed
+        // apply intent that requires a requester reaction turn.
+        if primitive.is_context_only_apply_without_turn() {
+            let RunPrimitive::StagedInput(staged) = &primitive else {
+                unreachable!("context-only apply without turn only matches staged primitives");
+            };
             return self
                 .session_service
                 .apply_runtime_context_appends_with_boundary(

--- a/meerkat-mob/src/runtime/session_service.rs
+++ b/meerkat-mob/src/runtime/session_service.rs
@@ -238,6 +238,18 @@ pub trait MobSessionService:
         ))
     }
 
+    async fn apply_runtime_system_context_for_turn(
+        &self,
+        _session_id: &SessionId,
+        _appends: Vec<PendingSystemContextAppend>,
+    ) -> Result<(), SessionError> {
+        Err(SessionError::Agent(
+            meerkat_core::error::AgentError::InternalError(
+                "runtime-backed context staging is unavailable for this session service".into(),
+            ),
+        ))
+    }
+
     async fn discard_live_session(&self, _session_id: &SessionId) -> Result<(), SessionError> {
         Ok(())
     }
@@ -386,6 +398,17 @@ where
         )
         .await
     }
+
+    async fn apply_runtime_system_context_for_turn(
+        &self,
+        session_id: &SessionId,
+        appends: Vec<PendingSystemContextAppend>,
+    ) -> Result<(), SessionError> {
+        meerkat_session::EphemeralSessionService::<B>::apply_runtime_system_context(
+            self, session_id, appends,
+        )
+        .await
+    }
 }
 
 #[cfg(not(target_arch = "wasm32"))]
@@ -526,6 +549,17 @@ where
             appends,
             boundary,
             contributing_input_ids,
+        )
+        .await
+    }
+
+    async fn apply_runtime_system_context_for_turn(
+        &self,
+        session_id: &SessionId,
+        appends: Vec<PendingSystemContextAppend>,
+    ) -> Result<(), SessionError> {
+        meerkat_session::PersistentSessionService::<B>::apply_runtime_system_context_for_turn(
+            self, session_id, appends,
         )
         .await
     }

--- a/meerkat-mob/src/runtime/tests.rs
+++ b/meerkat-mob/src/runtime/tests.rs
@@ -19421,6 +19421,31 @@ impl MobSessionService for RuntimeBackedRealCommsSessionService {
         )
     }
 
+    async fn apply_runtime_system_context_for_turn(
+        &self,
+        session_id: &SessionId,
+        appends: Vec<meerkat_core::PendingSystemContextAppend>,
+    ) -> Result<(), SessionError> {
+        for append in appends {
+            self.append_system_context(
+                session_id,
+                AppendSystemContextRequest {
+                    text: append.text,
+                    source: append.source,
+                    idempotency_key: append.idempotency_key,
+                },
+            )
+            .await
+            .map_err(|err| match err {
+                SessionControlError::Session(err) => err,
+                err => SessionError::Agent(meerkat_core::error::AgentError::InternalError(
+                    err.to_string(),
+                )),
+            })?;
+        }
+        Ok(())
+    }
+
     async fn discard_live_session(&self, session_id: &SessionId) -> Result<(), SessionError> {
         self.sessions.write().await.remove(session_id);
         self.keep_alive_notifiers.write().await.remove(session_id);
@@ -20232,10 +20257,19 @@ async fn test_peer_response_reaches_requester_in_runtime_backed_real_comms() {
         Some(meerkat_runtime::InputLifecycleState::Consumed),
         "terminal peer response should be applied and consumed: {requester_snapshot:?}"
     );
+    let requester_prompts_after_response = service.applied_runtime_prompts(&sid_requester).await;
     assert_eq!(
-        service.applied_runtime_prompts(&sid_requester).await.len(),
-        requester_prompt_baseline,
-        "terminal peer response should apply as runtime system context without requiring a user prompt turn"
+        requester_prompts_after_response.len(),
+        requester_prompt_baseline + 1,
+        "terminal peer response should append runtime system context and kick a requester reaction turn"
+    );
+    assert_eq!(
+        requester_prompts_after_response
+            .last()
+            .map(ContentInput::text_content)
+            .unwrap_or_default(),
+        "",
+        "terminal peer response reaction should be system-triggered, not a new user prompt"
     );
 
     let duplicate = meerkat_runtime::peer_response_terminal_input(

--- a/meerkat-rest/src/lib.rs
+++ b/meerkat-rest/src/lib.rs
@@ -595,6 +595,19 @@ async fn apply_runtime_turn(
             .await;
     }
 
+    if primitive.is_peer_response_terminal_context_and_run() {
+        let RunPrimitive::StagedInput(staged) = primitive else {
+            unreachable!("terminal peer-response apply intent only matches staged primitives");
+        };
+        context
+            .session_service
+            .apply_runtime_system_context_for_turn(
+                session_id,
+                pending_system_context_appends(&staged.context_appends),
+            )
+            .await?;
+    }
+
     let (event_tx, event_rx) = mpsc::channel::<EventEnvelope<AgentEvent>>(100);
     let forwarder = spawn_event_forwarder(
         event_rx,

--- a/meerkat-rest/src/lib.rs
+++ b/meerkat-rest/src/lib.rs
@@ -571,14 +571,19 @@ async fn apply_runtime_turn(
     primitive: &RunPrimitive,
     prompt: ContentInput,
 ) -> Result<CoreApplyOutput, SessionError> {
-    // Context-only staged primitive (e.g. peer_response_terminal). Runtime
-    // boundary is Steer-derived (RunCheckpoint); the stricter
-    // `is_context_only_immediate` gate doesn't match, so use the
-    // appends-empty + context-appends-nonempty criterion directly.
-    if let RunPrimitive::StagedInput(staged) = primitive
-        && staged.appends.is_empty()
-        && !staged.context_appends.is_empty()
-    {
+    if let Some(reason) = primitive.peer_response_terminal_apply_intent_violation() {
+        return Err(SessionError::Agent(
+            meerkat_core::error::AgentError::InternalError(reason.to_string()),
+        ));
+    }
+
+    // Context-only staged primitives may land directly as runtime
+    // system-context appends, but terminal peer responses carry a typed apply
+    // intent that requires a requester reaction turn.
+    if primitive.is_context_only_apply_without_turn() {
+        let RunPrimitive::StagedInput(staged) = primitive else {
+            unreachable!("context-only apply without turn only matches staged primitives");
+        };
         return context
             .session_service
             .apply_runtime_context_appends(

--- a/meerkat-rpc/src/session_executor.rs
+++ b/meerkat-rpc/src/session_executor.rs
@@ -106,26 +106,19 @@ impl CoreExecutor for SessionRuntimeExecutor {
         run_id: meerkat_core::lifecycle::RunId,
         primitive: RunPrimitive,
     ) -> Result<CoreApplyOutput, CoreExecutorError> {
-        // Context-only-immediate primitives (e.g. peer_response_terminal
-        // with handling_mode=None) must land as runtime system-context
-        // appends on the session transcript, not trigger a turn. Without
-        // this gate, the authoritative peer terminal result is dropped
-        // and subsequent turns (including realtime recalls on the
-        // reconstructed session state) cannot see the peer-returned
-        // token/status.
-        // A context-only staged primitive — no conversation appends, only
-        // context appends (e.g. peer_response_terminal) — must not trigger a
-        // turn. Route it through `apply_runtime_context_appends` regardless
-        // of the apply boundary: the runtime boundary for peer terminal
-        // responses is Steer-derived (RunCheckpoint), so the core
-        // `is_context_only_immediate` gate (boundary == Immediate) does not
-        // match. Keep the stricter gate for explicit immediate short-circuits
-        // used elsewhere; here we only need to detect that no turn work is
-        // implied by this primitive.
-        if let RunPrimitive::StagedInput(staged) = &primitive
-            && staged.appends.is_empty()
-            && !staged.context_appends.is_empty()
-        {
+        if let Some(reason) = primitive.peer_response_terminal_apply_intent_violation() {
+            return Err(CoreExecutorError::ApplyFailed {
+                reason: reason.to_string(),
+            });
+        }
+
+        // Context-only staged primitives may land directly as runtime
+        // system-context appends, but terminal peer responses carry a typed
+        // apply intent that requires a requester reaction turn.
+        if primitive.is_context_only_apply_without_turn() {
+            let RunPrimitive::StagedInput(staged) = &primitive else {
+                unreachable!("context-only apply without turn only matches staged primitives");
+            };
             return self
                 .runtime
                 .apply_runtime_context_appends_via_service(
@@ -219,14 +212,16 @@ impl CoreExecutor for MobRpcRuntimeExecutor {
         run_id: meerkat_core::lifecycle::RunId,
         primitive: RunPrimitive,
     ) -> Result<CoreApplyOutput, CoreExecutorError> {
-        // A context-only staged primitive must not trigger a turn. See the
-        // corresponding short-circuit in SessionRuntimeExecutor::apply for
-        // why we check `appends.is_empty() && !context_appends.is_empty()`
-        // instead of the stricter `is_context_only_immediate` gate.
-        if let RunPrimitive::StagedInput(staged) = &primitive
-            && staged.appends.is_empty()
-            && !staged.context_appends.is_empty()
-        {
+        if let Some(reason) = primitive.peer_response_terminal_apply_intent_violation() {
+            return Err(CoreExecutorError::ApplyFailed {
+                reason: reason.to_string(),
+            });
+        }
+
+        if primitive.is_context_only_apply_without_turn() {
+            let RunPrimitive::StagedInput(staged) = &primitive else {
+                unreachable!("context-only apply without turn only matches staged primitives");
+            };
             return self
                 .session_service
                 .apply_runtime_context_appends(

--- a/meerkat-rpc/src/session_executor.rs
+++ b/meerkat-rpc/src/session_executor.rs
@@ -236,6 +236,21 @@ impl CoreExecutor for MobRpcRuntimeExecutor {
                 });
         }
 
+        if primitive.is_peer_response_terminal_context_and_run() {
+            let RunPrimitive::StagedInput(staged) = &primitive else {
+                unreachable!("terminal peer-response apply intent only matches staged primitives");
+            };
+            self.session_service
+                .apply_runtime_system_context_for_turn(
+                    &self.session_id,
+                    pending_system_context_appends_from_primitive(&staged.context_appends),
+                )
+                .await
+                .map_err(|err| CoreExecutorError::ApplyFailed {
+                    reason: err.to_string(),
+                })?;
+        }
+
         let prompt = primitive.extract_content_input();
         let (event_tx, mut event_rx) = mpsc::channel::<EventEnvelope<AgentEvent>>(128);
         let sink = self.notification_sink.clone();

--- a/meerkat-rpc/src/session_runtime.rs
+++ b/meerkat-rpc/src/session_runtime.rs
@@ -2399,6 +2399,19 @@ impl SessionRuntime {
                 .map_err(session_error_to_rpc);
         }
 
+        if primitive.is_peer_response_terminal_context_and_run() {
+            let RunPrimitive::StagedInput(staged) = primitive else {
+                unreachable!("terminal peer-response apply intent only matches staged primitives");
+            };
+            self.service
+                .apply_runtime_system_context_for_turn(
+                    session_id,
+                    pending_system_context_appends(&staged.context_appends),
+                )
+                .await
+                .map_err(session_error_to_rpc)?;
+        }
+
         let effective_identity = self
             .effective_llm_identity_for_turn(session_id, overrides.as_ref())
             .await?;

--- a/meerkat-rpc/src/session_runtime.rs
+++ b/meerkat-rpc/src/session_runtime.rs
@@ -808,9 +808,10 @@ impl SessionRuntime {
             provider_params: None,
             clear_provider_params: overrides.is_some_and(|ov| ov.clear_provider_params),
             render_metadata: None,
-            execution_kind: None,
             connection_ref: overrides.and_then(|ov| ov.connection_ref.clone()),
             clear_connection_ref: overrides.is_some_and(|ov| ov.clear_connection_ref),
+            execution_kind: None,
+            peer_response_terminal_apply_intent: None,
         };
         (!metadata.is_empty()).then_some(metadata)
     }
@@ -2371,15 +2372,21 @@ impl SessionRuntime {
         _additional_instructions: Option<Vec<String>>,
         overrides: Option<crate::handlers::turn::TurnOverrides>,
     ) -> Result<CoreApplyOutput, RpcError> {
-        // Context-only staged primitive (e.g. peer_response_terminal) must
-        // land as runtime system-context appends rather than trigger a turn.
-        // Runtime boundary is Steer-derived (RunCheckpoint), so the stricter
-        // `is_context_only_immediate` gate misses; use the
-        // appends-empty + context-appends-nonempty criterion directly.
-        if let RunPrimitive::StagedInput(staged) = primitive
-            && staged.appends.is_empty()
-            && !staged.context_appends.is_empty()
-        {
+        if let Some(reason) = primitive.peer_response_terminal_apply_intent_violation() {
+            return Err(RpcError {
+                code: error::INTERNAL_ERROR,
+                message: reason.to_string(),
+                data: None,
+            });
+        }
+
+        // Context-only staged primitives may land directly as runtime
+        // system-context appends, but terminal peer responses carry a typed
+        // apply intent that requires a requester reaction turn.
+        if primitive.is_context_only_apply_without_turn() {
+            let RunPrimitive::StagedInput(staged) = primitive else {
+                unreachable!("context-only apply without turn only matches staged primitives");
+            };
             return self
                 .service
                 .apply_runtime_context_appends(

--- a/meerkat-rpc/src/session_runtime/schedule_host.rs
+++ b/meerkat-rpc/src/session_runtime/schedule_host.rs
@@ -300,6 +300,7 @@ impl SessionRuntime {
                 clear_provider_params: false,
                 render_metadata: dispatch.render_metadata.clone(),
                 execution_kind: None,
+                peer_response_terminal_apply_intent: None,
                 connection_ref: None,
                 clear_connection_ref: false,
             },

--- a/meerkat-runtime/src/ingress_types.rs
+++ b/meerkat-runtime/src/ingress_types.rs
@@ -8,7 +8,8 @@
 
 use meerkat_core::lifecycle::RuntimeExecutionKind;
 use meerkat_core::lifecycle::run_primitive::{
-    ConversationAppend, ConversationContextAppend, RunApplyBoundary,
+    ConversationAppend, ConversationContextAppend, PeerResponseTerminalApplyIntent,
+    RunApplyBoundary,
 };
 
 use crate::identifiers::InputKind;
@@ -39,6 +40,7 @@ pub struct RequestId(pub String);
 pub struct RuntimeInputSemantics {
     pub boundary: RunApplyBoundary,
     pub execution_kind: RuntimeExecutionKind,
+    pub peer_response_terminal_apply_intent: Option<PeerResponseTerminalApplyIntent>,
 }
 
 /// Admitted conversation projection for one input.
@@ -71,9 +73,23 @@ impl RuntimeInputSemantics {
             | InputKind::ExternalEvent
             | InputKind::Operation => RuntimeExecutionKind::ContentTurn,
         };
+        let peer_response_terminal_apply_intent = match kind {
+            InputKind::PeerResponseTerminal => {
+                Some(PeerResponseTerminalApplyIntent::AppendContextAndRun)
+            }
+            InputKind::Prompt
+            | InputKind::PeerMessage
+            | InputKind::PeerRequest
+            | InputKind::PeerResponseProgress
+            | InputKind::FlowStep
+            | InputKind::ExternalEvent
+            | InputKind::Continuation
+            | InputKind::Operation => None,
+        };
         Self {
             boundary,
             execution_kind,
+            peer_response_terminal_apply_intent,
         }
     }
 }
@@ -106,6 +122,10 @@ mod tests {
 
         assert_eq!(semantics.boundary, RunApplyBoundary::RunCheckpoint);
         assert_eq!(semantics.execution_kind, RuntimeExecutionKind::ContentTurn);
+        assert_eq!(
+            semantics.peer_response_terminal_apply_intent,
+            Some(PeerResponseTerminalApplyIntent::AppendContextAndRun)
+        );
     }
 
     #[test]
@@ -120,5 +140,6 @@ mod tests {
             semantics.execution_kind,
             RuntimeExecutionKind::ResumePending
         );
+        assert_eq!(semantics.peer_response_terminal_apply_intent, None);
     }
 }

--- a/meerkat-runtime/src/meerkat_machine/driver.rs
+++ b/meerkat-runtime/src/meerkat_machine/driver.rs
@@ -792,6 +792,16 @@ pub(crate) fn machine_input_execution_kind(
         .unwrap_or(meerkat_core::lifecycle::RuntimeExecutionKind::ContentTurn)
 }
 
+pub(crate) fn machine_input_peer_response_terminal_apply_intent(
+    driver: &DriverEntry,
+    work_id: &InputId,
+) -> Option<meerkat_core::lifecycle::run_primitive::PeerResponseTerminalApplyIntent> {
+    driver
+        .driver_ingress()
+        .runtime_semantics(work_id)
+        .and_then(|semantics| semantics.peer_response_terminal_apply_intent)
+}
+
 pub(crate) fn machine_batch_execution_kind(
     driver: &DriverEntry,
     work_ids: &[InputId],
@@ -808,6 +818,16 @@ pub(crate) fn machine_batch_execution_kind(
     } else {
         Some(meerkat_core::lifecycle::RuntimeExecutionKind::ContentTurn)
     }
+}
+
+pub(crate) fn machine_batch_peer_response_terminal_apply_intent(
+    driver: &DriverEntry,
+    work_ids: &[InputId],
+) -> Option<meerkat_core::lifecycle::run_primitive::PeerResponseTerminalApplyIntent> {
+    work_ids
+        .iter()
+        .filter_map(|id| machine_input_peer_response_terminal_apply_intent(driver, id))
+        .next()
 }
 
 pub(crate) fn machine_batch_primitive_projections(

--- a/meerkat-runtime/src/meerkat_machine/driver.rs
+++ b/meerkat-runtime/src/meerkat_machine/driver.rs
@@ -826,8 +826,7 @@ pub(crate) fn machine_batch_peer_response_terminal_apply_intent(
 ) -> Option<meerkat_core::lifecycle::run_primitive::PeerResponseTerminalApplyIntent> {
     work_ids
         .iter()
-        .filter_map(|id| machine_input_peer_response_terminal_apply_intent(driver, id))
-        .next()
+        .find_map(|id| machine_input_peer_response_terminal_apply_intent(driver, id))
 }
 
 pub(crate) fn machine_batch_primitive_projections(

--- a/meerkat-runtime/src/meerkat_machine/driver.rs
+++ b/meerkat-runtime/src/meerkat_machine/driver.rs
@@ -858,11 +858,15 @@ pub(crate) fn machine_select_runtime_loop_batch(driver: &DriverEntry) -> Vec<Inp
         }
         let target_boundary = machine_input_boundary(driver, first);
         let target_execution_kind = machine_input_execution_kind(driver, first);
+        let target_peer_response_terminal_apply_intent =
+            machine_input_peer_response_terminal_apply_intent(driver, first);
         return steer
             .iter()
             .take_while(|id| {
                 machine_input_boundary(driver, id) == target_boundary
                     && machine_input_execution_kind(driver, id) == target_execution_kind
+                    && machine_input_peer_response_terminal_apply_intent(driver, id)
+                        == target_peer_response_terminal_apply_intent
             })
             .cloned()
             .collect();
@@ -875,12 +879,16 @@ pub(crate) fn machine_select_runtime_loop_batch(driver: &DriverEntry) -> Vec<Inp
         if ingress.is_prompt(first) {
             return prefix.to_vec();
         }
+        let target_peer_response_terminal_apply_intent =
+            machine_input_peer_response_terminal_apply_intent(driver, first);
         return queue[..]
             .iter()
             .take_while(|id| {
                 !ingress.is_prompt(id)
                     && machine_input_execution_kind(driver, id)
                         == meerkat_core::lifecycle::RuntimeExecutionKind::ContentTurn
+                    && machine_input_peer_response_terminal_apply_intent(driver, id)
+                        == target_peer_response_terminal_apply_intent
             })
             .cloned()
             .collect();

--- a/meerkat-runtime/src/meerkat_machine/mod.rs
+++ b/meerkat-runtime/src/meerkat_machine/mod.rs
@@ -121,8 +121,8 @@ type MeerkatMachineCommandFuture<'a> = Pin<
 pub(crate) use driver::{
     DriverEntry, SharedCompletionRegistry, SharedDriver, commit_runtime_loop_run,
     fail_runtime_loop_run, machine_apply_run_return_projection, machine_batch_execution_kind,
-    machine_batch_primitive_projections, machine_begin_run, machine_destroy,
-    machine_executor_attach_projection, machine_input_boundary,
+    machine_batch_peer_response_terminal_apply_intent, machine_batch_primitive_projections,
+    machine_begin_run, machine_destroy, machine_executor_attach_projection, machine_input_boundary,
     machine_prepare_bindings_projection, machine_recover_ephemeral_driver,
     machine_recover_persistent_driver, machine_recycle_preserving_work, machine_reset,
     machine_retire, machine_select_runtime_loop_batch, machine_stop_runtime,

--- a/meerkat-runtime/src/policy_table.rs
+++ b/meerkat-runtime/src/policy_table.rs
@@ -54,6 +54,39 @@ impl DefaultPolicyTable {
         // but the policy table also refuses to honor it so the contract
         // holds for any caller of resolve(), not just the driver path.
         let is_response_progress = matches!(kind, InputKind::PeerResponseProgress);
+        if matches!(kind, InputKind::PeerResponseTerminal)
+            && let Some(mode) = input.handling_mode()
+        {
+            let (wake_mode, drain_policy, routing_disposition) = match mode {
+                meerkat_core::types::HandlingMode::Queue => (
+                    if runtime_idle {
+                        WakeMode::WakeIfIdle
+                    } else {
+                        WakeMode::None
+                    },
+                    DrainPolicy::QueueNextTurn,
+                    RoutingDisposition::Queue,
+                ),
+                meerkat_core::types::HandlingMode::Steer => (
+                    if runtime_idle {
+                        WakeMode::WakeIfIdle
+                    } else {
+                        WakeMode::InterruptYielding
+                    },
+                    DrainPolicy::SteerBatch,
+                    RoutingDisposition::Steer,
+                ),
+            };
+            return pd(
+                ApplyMode::StageRunStart,
+                wake_mode,
+                QueueMode::Fifo,
+                ConsumePoint::OnRunComplete,
+                drain_policy,
+                routing_disposition,
+                true,
+            );
+        }
         if !is_response_progress && let Some(mode) = input.handling_mode() {
             return match mode {
                 meerkat_core::types::HandlingMode::Queue => pd(
@@ -744,7 +777,13 @@ mod tests {
         );
         let decision = DefaultPolicyTable::resolve(&input, true);
         assert_eq!(decision.routing_disposition, RoutingDisposition::Steer);
-        assert_eq!(decision.apply_mode, ApplyMode::StageRunBoundary);
+        assert_eq!(
+            decision.apply_mode,
+            ApplyMode::StageRunStart,
+            "terminal peer-response apply intent owns the context+reaction boundary; steer only changes urgency/lane"
+        );
+        assert_eq!(decision.drain_policy, DrainPolicy::SteerBatch);
+        assert_eq!(decision.wake_mode, WakeMode::WakeIfIdle);
         assert!(decision.record_transcript);
     }
 

--- a/meerkat-runtime/src/runtime_loop.rs
+++ b/meerkat-runtime/src/runtime_loop.rs
@@ -1369,6 +1369,125 @@ mod tests {
         Ok(())
     }
 
+    fn make_peer_message(peer_id: &str, body: &str) -> Input {
+        Input::Peer(PeerInput {
+            header: InputHeader {
+                id: InputId::new(),
+                timestamp: Utc::now(),
+                source: InputOrigin::Peer {
+                    peer_id: peer_id.into(),
+                    runtime_id: None,
+                },
+                durability: InputDurability::Durable,
+                visibility: InputVisibility::default(),
+                idempotency_key: None,
+                supersession_key: None,
+                correlation_id: None,
+            },
+            convention: Some(PeerConvention::Message),
+            body: body.into(),
+            payload: None,
+            blocks: None,
+            handling_mode: None,
+        })
+    }
+
+    fn make_terminal_peer_response(peer_id: &str, request_id: &str) -> Input {
+        Input::Peer(PeerInput {
+            header: InputHeader {
+                id: InputId::new(),
+                timestamp: Utc::now(),
+                source: InputOrigin::Peer {
+                    peer_id: peer_id.into(),
+                    runtime_id: None,
+                },
+                durability: InputDurability::Durable,
+                visibility: InputVisibility::default(),
+                idempotency_key: None,
+                supersession_key: None,
+                correlation_id: None,
+            },
+            convention: Some(PeerConvention::ResponseTerminal {
+                request_id: request_id.into(),
+                status: ResponseTerminalStatus::Completed,
+            }),
+            body: String::new(),
+            payload: Some(serde_json::json!({"ok": true})),
+            blocks: None,
+            handling_mode: None,
+        })
+    }
+
+    async fn accept_queued_input_id(
+        driver: &crate::meerkat_machine::SharedDriver,
+        input: Input,
+    ) -> InputId {
+        let mut guard = driver.lock().await;
+        match guard
+            .as_driver_mut()
+            .accept_input(input)
+            .await
+            .expect("input should be accepted")
+        {
+            crate::accept::AcceptOutcome::Accepted { input_id, .. } => input_id,
+            other => panic!("expected accepted queued input, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn terminal_peer_response_batches_do_not_mix_with_peer_messages() {
+        let terminal_first = make_shared_ephemeral_driver("terminal-first");
+        let terminal_id = accept_queued_input_id(
+            &terminal_first,
+            make_terminal_peer_response("analyst-rt", "req-terminal-first"),
+        )
+        .await;
+        let _message_id = accept_queued_input_id(
+            &terminal_first,
+            make_peer_message("analyst-rt", "follow-up"),
+        )
+        .await;
+
+        {
+            let guard = terminal_first.lock().await;
+            let batch = crate::meerkat_machine::machine_select_runtime_loop_batch(&guard);
+            assert_eq!(
+                batch,
+                vec![terminal_id],
+                "terminal response batch must not absorb later normal peer messages"
+            );
+            assert_eq!(
+                crate::meerkat_machine::machine_batch_peer_response_terminal_apply_intent(
+                    &guard, &batch,
+                ),
+                Some(PeerResponseTerminalApplyIntent::AppendContextAndRun)
+            );
+        }
+
+        let message_first = make_shared_ephemeral_driver("message-first");
+        let message_id =
+            accept_queued_input_id(&message_first, make_peer_message("analyst-rt", "first")).await;
+        let _terminal_id = accept_queued_input_id(
+            &message_first,
+            make_terminal_peer_response("analyst-rt", "req-message-first"),
+        )
+        .await;
+
+        let guard = message_first.lock().await;
+        let batch = crate::meerkat_machine::machine_select_runtime_loop_batch(&guard);
+        assert_eq!(
+            batch,
+            vec![message_id],
+            "normal peer message batch must not absorb later terminal responses"
+        );
+        assert_eq!(
+            crate::meerkat_machine::machine_batch_peer_response_terminal_apply_intent(
+                &guard, &batch,
+            ),
+            None
+        );
+    }
+
     #[test]
     fn peer_input_with_blocks_produces_blocks_renderable() -> Result<(), String> {
         let blocks = vec![

--- a/meerkat-runtime/src/runtime_loop.rs
+++ b/meerkat-runtime/src/runtime_loop.rs
@@ -7,7 +7,9 @@
 //! under the hood).
 
 use meerkat_core::lifecycle::core_executor::CoreApplyTerminal;
-use meerkat_core::lifecycle::run_primitive::{RunApplyBoundary, RunPrimitive, StagedRunInput};
+use meerkat_core::lifecycle::run_primitive::{
+    PeerResponseTerminalApplyIntent, RunApplyBoundary, RunPrimitive, StagedRunInput,
+};
 use meerkat_core::lifecycle::{InputId, RunId};
 
 #[cfg(test)]
@@ -139,16 +141,25 @@ fn primitive_turn_start_input(
                 admitted_content_shape,
             },
         ),
-        RunPrimitive::StagedInput(staged)
-            if staged.appends.is_empty() && !staged.context_appends.is_empty() =>
-        {
+        RunPrimitive::StagedInput(_) if primitive.is_peer_response_terminal_context_and_run() => {
             Some(
-                crate::meerkat_machine::dsl::MeerkatMachineInput::StartImmediateContext {
+                crate::meerkat_machine::dsl::MeerkatMachineInput::StartConversationRun {
                     run_id: crate::meerkat_machine::dsl::RunId::from_domain(run_id),
+                    primitive_kind:
+                        crate::meerkat_machine::dsl::TurnPrimitiveKind::ConversationTurn,
                     admitted_content_shape,
+                    vision_enabled: false,
+                    image_tool_results_enabled: false,
+                    max_extraction_retries: 0,
                 },
             )
         }
+        RunPrimitive::StagedInput(_) if primitive.is_context_only_apply_without_turn() => Some(
+            crate::meerkat_machine::dsl::MeerkatMachineInput::StartImmediateContext {
+                run_id: crate::meerkat_machine::dsl::RunId::from_domain(run_id),
+                admitted_content_shape,
+            },
+        ),
         RunPrimitive::StagedInput(staged) if staged.appends.is_empty() => None,
         RunPrimitive::StagedInput(_) => Some(
             crate::meerkat_machine::dsl::MeerkatMachineInput::StartConversationRun {
@@ -178,6 +189,9 @@ async fn prepare_turn_state_for_primitive(
     run_id: &RunId,
     primitive: &RunPrimitive,
 ) -> Result<(), crate::RuntimeDriverError> {
+    if let Some(reason) = primitive.peer_response_terminal_apply_intent_violation() {
+        return Err(crate::RuntimeDriverError::Internal(reason.to_string()));
+    }
     let Some(input) = primitive_turn_start_input(run_id, primitive) else {
         return Ok(());
     };
@@ -217,7 +231,15 @@ pub(crate) fn try_inputs_to_primitive_with_boundary(
         .iter()
         .map(|(_, input)| runtime_input_projection(input))
         .collect::<Vec<_>>();
-    try_projected_inputs_to_primitive_with_boundary(inputs, &projections, boundary, execution_kind)
+    let peer_response_terminal_apply_intent =
+        fallback_batch_peer_response_terminal_apply_intent(inputs, boundary);
+    try_projected_inputs_to_primitive_with_boundary(
+        inputs,
+        &projections,
+        boundary,
+        execution_kind,
+        peer_response_terminal_apply_intent,
+    )
 }
 
 pub(crate) fn try_projected_inputs_to_primitive_with_boundary(
@@ -225,6 +247,7 @@ pub(crate) fn try_projected_inputs_to_primitive_with_boundary(
     projections: &[crate::ingress_types::RuntimeInputProjection],
     boundary: RunApplyBoundary,
     execution_kind: Option<meerkat_core::lifecycle::RuntimeExecutionKind>,
+    peer_response_terminal_apply_intent: Option<PeerResponseTerminalApplyIntent>,
 ) -> Result<RunPrimitive, meerkat_core::lifecycle::run_primitive::TurnMetadataMergeConflict> {
     let appends = projections
         .iter()
@@ -245,6 +268,7 @@ pub(crate) fn try_projected_inputs_to_primitive_with_boundary(
     let turn_metadata = {
         let mut meta = turn_metadata.unwrap_or_default();
         meta.execution_kind = execution_kind;
+        meta.peer_response_terminal_apply_intent = peer_response_terminal_apply_intent;
         Some(meta)
     };
 
@@ -294,6 +318,18 @@ fn fallback_batch_execution_kind(
     } else {
         Some(meerkat_core::lifecycle::RuntimeExecutionKind::ContentTurn)
     }
+}
+
+fn fallback_batch_peer_response_terminal_apply_intent(
+    inputs: &[(InputId, Input)],
+    _boundary: RunApplyBoundary,
+) -> Option<PeerResponseTerminalApplyIntent> {
+    inputs
+        .iter()
+        .filter_map(|(_, input)| {
+            fallback_unadmitted_semantics(input).peer_response_terminal_apply_intent
+        })
+        .next()
 }
 
 /// Convert an `Input` + its ID to a `RunPrimitive` for `CoreExecutor::apply()`.
@@ -630,6 +666,11 @@ async fn process_queue(
                 .collect::<Vec<_>>();
             let execution_kind =
                 crate::meerkat_machine::machine_batch_execution_kind(&d, &staged_ids);
+            let peer_response_terminal_apply_intent =
+                crate::meerkat_machine::machine_batch_peer_response_terminal_apply_intent(
+                    &d,
+                    &staged_ids,
+                );
             let projections =
                 crate::meerkat_machine::machine_batch_primitive_projections(&d, &staged_ids);
             let primitive = try_projected_inputs_to_primitive_with_boundary(
@@ -637,6 +678,7 @@ async fn process_queue(
                 &projections,
                 boundary,
                 execution_kind,
+                peer_response_terminal_apply_intent,
             );
             Some((contributing_input_ids, staged_ids, run_id, primitive))
         };
@@ -1083,7 +1125,8 @@ mod tests {
     }
 
     #[test]
-    fn peer_response_terminal_creates_immediate_context_staged_input() -> Result<(), String> {
+    fn peer_response_terminal_forced_immediate_boundary_is_invalid_apply_intent()
+    -> Result<(), String> {
         let input = Input::Peer(PeerInput {
             header: InputHeader {
                 id: InputId::new(),
@@ -1117,6 +1160,13 @@ mod tests {
             RunApplyBoundary::Immediate,
         )
         .expect("single input metadata cannot conflict");
+        assert!(
+            primitive
+                .peer_response_terminal_apply_intent_violation()
+                .is_some(),
+            "terminal peer response with an immediate boundary must fail the typed apply invariant"
+        );
+        assert!(!primitive.is_context_only_apply_without_turn());
         let staged = match primitive {
             RunPrimitive::StagedInput(staged) => staged,
             other => return Err(format!("expected staged input, got {other:?}")),
@@ -1186,6 +1236,139 @@ mod tests {
         // None for the ResponseTerminal convention.
         assert!(staged.appends.is_empty());
         assert_eq!(staged.context_appends.len(), 1);
+        Ok(())
+    }
+
+    #[test]
+    fn queued_peer_response_terminal_starts_requester_reaction_turn() -> Result<(), String> {
+        let input = Input::Peer(PeerInput {
+            header: InputHeader {
+                id: InputId::new(),
+                timestamp: Utc::now(),
+                source: InputOrigin::Peer {
+                    peer_id: "analyst-rt".into(),
+                    runtime_id: None,
+                },
+                durability: InputDurability::Durable,
+                visibility: InputVisibility::default(),
+                idempotency_key: None,
+                supersession_key: None,
+                correlation_id: None,
+            },
+            convention: Some(crate::input::PeerConvention::ResponseTerminal {
+                request_id: "req-123".into(),
+                status: crate::input::ResponseTerminalStatus::Completed,
+            }),
+            body: String::new(),
+            payload: Some(serde_json::json!({
+                "request_intent": "checksum_token",
+                "token": "birch seventeen"
+            })),
+            blocks: None,
+            handling_mode: None,
+        });
+        let primitive = inputs_to_primitive(&[(input.id().clone(), input)])
+            .expect("single input metadata cannot conflict");
+        let run_id = RunId::new();
+
+        let start_input = primitive_turn_start_input(&run_id, &primitive).ok_or_else(|| {
+            "terminal response should start a requester reaction turn".to_string()
+        })?;
+
+        match start_input {
+            crate::meerkat_machine::dsl::MeerkatMachineInput::StartConversationRun {
+                run_id: got_run_id,
+                primitive_kind,
+                admitted_content_shape,
+                ..
+            } => {
+                assert_eq!(
+                    got_run_id,
+                    crate::meerkat_machine::dsl::RunId::from_domain(&run_id)
+                );
+                assert_eq!(
+                    primitive_kind,
+                    crate::meerkat_machine::dsl::TurnPrimitiveKind::ConversationTurn
+                );
+                assert_eq!(admitted_content_shape, "context");
+                Ok(())
+            }
+            other => Err(format!("expected StartConversationRun, got {other:?}")),
+        }
+    }
+
+    #[test]
+    fn peer_response_terminal_apply_intent_is_policy_runtime_and_executor_consistent()
+    -> Result<(), String> {
+        let input = Input::Peer(PeerInput {
+            header: InputHeader {
+                id: InputId::new(),
+                timestamp: Utc::now(),
+                source: InputOrigin::Peer {
+                    peer_id: "analyst-rt".into(),
+                    runtime_id: None,
+                },
+                durability: InputDurability::Durable,
+                visibility: InputVisibility::default(),
+                idempotency_key: None,
+                supersession_key: None,
+                correlation_id: None,
+            },
+            convention: Some(crate::input::PeerConvention::ResponseTerminal {
+                request_id: "req-123".into(),
+                status: crate::input::ResponseTerminalStatus::Completed,
+            }),
+            body: String::new(),
+            payload: Some(serde_json::json!({
+                "request_intent": "checksum_token",
+                "token": "birch seventeen"
+            })),
+            blocks: None,
+            handling_mode: None,
+        });
+
+        let policy = crate::policy_table::DefaultPolicyTable::resolve(&input, true);
+        assert_eq!(policy.apply_mode, crate::ApplyMode::StageRunStart);
+        assert_eq!(policy.wake_mode, crate::WakeMode::WakeIfIdle);
+        assert_eq!(policy.queue_mode, crate::QueueMode::Fifo);
+
+        let semantics = crate::ingress_types::RuntimeInputSemantics::from_policy_and_kind(
+            &policy,
+            input.kind(),
+        );
+        assert_eq!(semantics.boundary, RunApplyBoundary::RunStart);
+        assert_eq!(
+            semantics.execution_kind,
+            meerkat_core::lifecycle::RuntimeExecutionKind::ContentTurn
+        );
+        assert_eq!(
+            semantics.peer_response_terminal_apply_intent,
+            Some(PeerResponseTerminalApplyIntent::AppendContextAndRun)
+        );
+
+        let primitive = try_inputs_to_primitive_with_boundary(
+            &[(input.id().clone(), input)],
+            semantics.boundary,
+            Some(semantics.execution_kind),
+        )
+        .expect("single input metadata cannot conflict");
+        let metadata = primitive
+            .turn_metadata()
+            .ok_or_else(|| "terminal primitive should carry metadata".to_string())?;
+        assert_eq!(
+            metadata.peer_response_terminal_apply_intent,
+            Some(PeerResponseTerminalApplyIntent::AppendContextAndRun)
+        );
+        assert!(primitive.is_peer_response_terminal_context_and_run());
+        assert_eq!(
+            primitive.peer_response_terminal_apply_intent_violation(),
+            None
+        );
+        assert!(
+            !primitive.is_context_only_apply_without_turn(),
+            "executor context-only shortcut must not swallow terminal peer responses"
+        );
+
         Ok(())
     }
 

--- a/meerkat-runtime/src/runtime_loop.rs
+++ b/meerkat-runtime/src/runtime_loop.rs
@@ -324,12 +324,9 @@ fn fallback_batch_peer_response_terminal_apply_intent(
     inputs: &[(InputId, Input)],
     _boundary: RunApplyBoundary,
 ) -> Option<PeerResponseTerminalApplyIntent> {
-    inputs
-        .iter()
-        .filter_map(|(_, input)| {
-            fallback_unadmitted_semantics(input).peer_response_terminal_apply_intent
-        })
-        .next()
+    inputs.iter().find_map(|(_, input)| {
+        fallback_unadmitted_semantics(input).peer_response_terminal_apply_intent
+    })
 }
 
 /// Convert an `Input` + its ID to a `RunPrimitive` for `CoreExecutor::apply()`.

--- a/meerkat-runtime/tests/regression_comms_runtime.rs
+++ b/meerkat-runtime/tests/regression_comms_runtime.rs
@@ -152,6 +152,41 @@ async fn completed_response_idle_wakes() {
     );
 }
 
+#[tokio::test]
+async fn completed_response_admission_stamps_context_and_run_apply_intent() {
+    let mut driver = EphemeralRuntimeDriver::new(rid());
+    let interaction = make_response("peer-1", ResponseStatus::Completed);
+    let input = interaction_to_peer_input(&interaction, &rid());
+
+    let outcome = driver.accept_input(input).await.unwrap();
+    let meerkat_runtime::AcceptOutcome::Accepted { input_id, .. } = outcome else {
+        panic!("expected terminal peer response to be accepted");
+    };
+
+    let semantics = driver
+        .admitted_runtime_semantics(&input_id)
+        .expect("accepted input should have runtime semantics");
+    assert_eq!(
+        semantics.execution_kind,
+        meerkat_core::lifecycle::RuntimeExecutionKind::ContentTurn
+    );
+    assert_eq!(
+        semantics.peer_response_terminal_apply_intent,
+        Some(
+            meerkat_core::lifecycle::run_primitive::PeerResponseTerminalApplyIntent::AppendContextAndRun
+        )
+    );
+    assert_eq!(
+        driver.input_phase(&input_id),
+        Some(InputLifecycleState::Queued)
+    );
+    let projection = driver
+        .admitted_primitive_projection(&input_id)
+        .expect("accepted input should have primitive projection");
+    assert!(projection.append.is_none());
+    assert!(projection.context_append.is_some());
+}
+
 // ---------------------------------------------------------------------------
 // §2: Accepted response injects context, no continuation (no wake)
 // ---------------------------------------------------------------------------

--- a/meerkat-session/src/persistent.rs
+++ b/meerkat-session/src/persistent.rs
@@ -1326,6 +1326,17 @@ impl<B: SessionAgentBuilder + 'static> PersistentSessionService<B> {
         .await
     }
 
+    /// Apply runtime-owned system context to the live session before a
+    /// reaction turn. The subsequent runtime turn commit owns durability and
+    /// lifecycle for the combined context+run operation.
+    pub async fn apply_runtime_system_context_for_turn(
+        &self,
+        id: &SessionId,
+        appends: Vec<PendingSystemContextAppend>,
+    ) -> Result<(), SessionError> {
+        self.inner.apply_runtime_system_context(id, appends).await
+    }
+
     pub async fn apply_runtime_context_appends_with_boundary(
         &self,
         id: &SessionId,


### PR DESCRIPTION
Linear: https://linear.app/lucrfr/issue/LUC-162/p0-dogma-make-peer-response-wakeapply-semantics-a-single-machine-fact

## Summary
- add a typed PeerResponseTerminalApplyIntent carried through runtime semantics and RuntimeTurnMetadata
- route runtime loop, RPC/session executors, REST, and mob provisioner context-only gates through the typed helper/invariant
- add regression coverage for terminal response reaction, policy/executor consistency, context-only bypass, and metadata wire round trip

## Validation
- ./scripts/repo-cargo test -p meerkat-runtime peer_response_terminal --lib --tests
- ./scripts/repo-cargo test -p meerkat-runtime queued_peer_response_terminal_starts_requester_reaction_turn --lib
- ./scripts/repo-cargo check -p meerkat-runtime -p meerkat-rpc -p meerkat-mob -p meerkat-session
- ./scripts/repo-cargo test -p meerkat-core context_only --lib
- ./scripts/repo-cargo test -p meerkat-core --test runtime_turn_metadata_typed_round_trip
- ./scripts/repo-cargo test -p meerkat-runtime completed_response_admission_stamps_context_and_run_apply_intent --test regression_comms_runtime
- ./scripts/repo-cargo test -p meerkat-runtime peer_response_terminal --lib --test regression_comms_runtime
- ./scripts/repo-cargo test -p meerkat-rpc peer_response_terminal --lib --tests
- ./scripts/repo-cargo test -p meerkat-mob contract_mob_002_peer_request_response_round_trip --lib
- ./scripts/repo-cargo check -p meerkat-rest -p meerkat-mob
- make check