### PR TITLE
LUC-163: Require runtime authority for semantic comms tools

### DIFF
--- a/meerkat-cli/src/main.rs
+++ b/meerkat-cli/src/main.rs
@@ -14088,7 +14088,7 @@ supports_reasoning = true
         // Create CommsToolDispatcher with no inner dispatcher
         let dispatcher = CommsToolDispatcher::new(router, trusted_peers);
 
-        // Verify comms tools are available
+        // Runtime-less dispatchers expose transport-only comms tools.
         let tools = dispatcher.tools();
         let tool_names: Vec<_> = tools.iter().map(|t| t.name.as_ref()).collect();
 
@@ -14097,12 +14097,12 @@ supports_reasoning = true
             "expected send_message tool, got: {tool_names:?}"
         );
         assert!(
-            tool_names.contains(&"send_request"),
-            "expected send_request tool, got: {tool_names:?}"
+            !tool_names.contains(&"send_request"),
+            "send_request requires runtime command authority, got: {tool_names:?}"
         );
         assert!(
-            tool_names.contains(&"send_response"),
-            "expected send_response tool, got: {tool_names:?}"
+            !tool_names.contains(&"send_response"),
+            "send_response requires runtime command authority, got: {tool_names:?}"
         );
         assert!(tool_names.contains(&"peers"));
     }

--- a/meerkat-comms/src/agent/dispatcher.rs
+++ b/meerkat-comms/src/agent/dispatcher.rs
@@ -1,10 +1,14 @@
 //! CommsToolDispatcher - Implements AgentToolDispatcher for comms tools.
 
-use crate::mcp::tools::{ToolContext, handle_tools_call, tools_list};
+use crate::mcp::tools::{
+    RuntimeCommsCommandHandle, ToolContext, comms_tool_unavailable_reason, handle_tools_call,
+    tools_list,
+};
 use crate::runtime::CommsRuntime;
 use crate::{Router, TrustedPeers};
 use async_trait::async_trait;
 use meerkat_core::AgentToolDispatcher;
+use meerkat_core::ToolCallability;
 use meerkat_core::ToolCatalogCapabilities;
 use meerkat_core::ToolCatalogEntry;
 use meerkat_core::ToolDispatchOutcome;
@@ -45,7 +49,7 @@ impl CommsToolDispatcher<NoOpDispatcher> {
         let tool_context = ToolContext {
             router,
             trusted_peers,
-            runtime: Some(runtime),
+            runtime: Some(RuntimeCommsCommandHandle::new(runtime)),
         };
         let tool_defs: Arc<[Arc<ToolDef>]> = comms_tool_defs().into();
         Self {
@@ -98,6 +102,11 @@ fn is_comms_tool(name: &str) -> bool {
     )
 }
 
+fn callability_for_context(ctx: &ToolContext, name: &str) -> ToolCallability {
+    comms_tool_unavailable_reason(ctx, name)
+        .map_or_else(ToolCallability::callable, ToolCallability::unavailable)
+}
+
 /// Canonical JSON-to-ToolDef conversion for comms tools.
 pub fn comms_tool_defs() -> Vec<Arc<ToolDef>> {
     tools_list()
@@ -121,11 +130,25 @@ pub fn comms_tool_defs() -> Vec<Arc<ToolDef>> {
 impl<T: AgentToolDispatcher + 'static> AgentToolDispatcher for CommsToolDispatcher<T> {
     fn tools(&self) -> Arc<[Arc<ToolDef>]> {
         if let Some(inner) = &self.inner {
-            let mut tools = self.tool_defs.iter().cloned().collect::<Vec<_>>();
+            let mut tools = self
+                .tool_defs
+                .iter()
+                .filter(|tool| {
+                    callability_for_context(&self.tool_context, &tool.name).is_callable()
+                })
+                .cloned()
+                .collect::<Vec<_>>();
             tools.extend(inner.tools().iter().map(Arc::clone));
             tools.into()
         } else {
-            Arc::clone(&self.tool_defs)
+            self.tool_defs
+                .iter()
+                .filter(|tool| {
+                    callability_for_context(&self.tool_context, &tool.name).is_callable()
+                })
+                .cloned()
+                .collect::<Vec<_>>()
+                .into()
         }
     }
 
@@ -133,6 +156,11 @@ impl<T: AgentToolDispatcher + 'static> AgentToolDispatcher for CommsToolDispatch
         let args: Value = serde_json::from_str(call.args.get())
             .unwrap_or_else(|_| Value::String(call.args.get().to_string()));
         if is_comms_tool(call.name) {
+            if let Some(reason) =
+                callability_for_context(&self.tool_context, call.name).unavailable_reason()
+            {
+                return Err(ToolError::unavailable(call.name, reason));
+            }
             let result = handle_tools_call(&self.tool_context, call.name, &args)
                 .await
                 .map_err(|e| ToolError::ExecutionFailed { message: e })?;
@@ -177,7 +205,12 @@ impl<T: AgentToolDispatcher + 'static> AgentToolDispatcher for CommsToolDispatch
         let mut catalog = self
             .tool_defs
             .iter()
-            .map(|tool| ToolCatalogEntry::session_inline(Arc::clone(tool), true))
+            .map(|tool| {
+                ToolCatalogEntry::session_inline_with_callability(
+                    Arc::clone(tool),
+                    callability_for_context(&self.tool_context, &tool.name),
+                )
+            })
             .collect::<Vec<_>>();
         if let Some(inner) = &self.inner {
             if inner.tool_catalog_capabilities().exact_catalog {
@@ -229,7 +262,7 @@ impl DynCommsToolDispatcher {
         let tool_context = ToolContext {
             router,
             trusted_peers,
-            runtime: Some(runtime),
+            runtime: Some(RuntimeCommsCommandHandle::new(runtime)),
         };
         let tool_defs: Arc<[Arc<ToolDef>]> = comms_tool_defs().into();
         Self {
@@ -244,7 +277,12 @@ impl DynCommsToolDispatcher {
 #[cfg_attr(not(target_arch = "wasm32"), async_trait)]
 impl AgentToolDispatcher for DynCommsToolDispatcher {
     fn tools(&self) -> Arc<[Arc<ToolDef>]> {
-        let mut tools = self.tool_defs.iter().cloned().collect::<Vec<_>>();
+        let mut tools = self
+            .tool_defs
+            .iter()
+            .filter(|tool| callability_for_context(&self.tool_context, &tool.name).is_callable())
+            .cloned()
+            .collect::<Vec<_>>();
         tools.extend(self.inner.tools().iter().map(Arc::clone));
         tools.into()
     }
@@ -253,6 +291,11 @@ impl AgentToolDispatcher for DynCommsToolDispatcher {
         let args: Value = serde_json::from_str(call.args.get())
             .unwrap_or_else(|_| Value::String(call.args.get().to_string()));
         if is_comms_tool(call.name) {
+            if let Some(reason) =
+                callability_for_context(&self.tool_context, call.name).unavailable_reason()
+            {
+                return Err(ToolError::unavailable(call.name, reason));
+            }
             let result = handle_tools_call(&self.tool_context, call.name, &args)
                 .await
                 .map_err(|e| ToolError::ExecutionFailed { message: e })?;
@@ -282,7 +325,12 @@ impl AgentToolDispatcher for DynCommsToolDispatcher {
         let mut catalog = self
             .tool_defs
             .iter()
-            .map(|tool| ToolCatalogEntry::session_inline(Arc::clone(tool), true))
+            .map(|tool| {
+                ToolCatalogEntry::session_inline_with_callability(
+                    Arc::clone(tool),
+                    callability_for_context(&self.tool_context, &tool.name),
+                )
+            })
             .collect::<Vec<_>>();
         if self.inner.tool_catalog_capabilities().exact_catalog {
             catalog.extend(self.inner.tool_catalog().iter().cloned());
@@ -427,5 +475,51 @@ mod tests {
 
         dispatcher.poll_external_updates().await;
         assert!(inner.polled.load(Ordering::SeqCst));
+    }
+
+    #[tokio::test]
+    async fn runtime_less_semantic_send_request_returns_typed_unavailable() {
+        let (router, trusted_peers) = test_router();
+        let dispatcher = CommsToolDispatcher::new(router, trusted_peers);
+        let args_raw = serde_json::value::RawValue::from_string(
+            serde_json::json!({
+                "peer_id": meerkat_core::comms::PeerId::new(),
+                "intent": "review",
+                "params": {"file": "main.rs"},
+                "handling_mode": "steer"
+            })
+            .to_string(),
+        )
+        .expect("valid args");
+        let call = ToolCallView {
+            id: "test-1",
+            name: "send_request",
+            args: &args_raw,
+        };
+
+        let result = dispatcher.dispatch(call).await;
+        assert!(matches!(
+            result,
+            Err(ToolError::Unavailable {
+                reason: meerkat_core::ToolUnavailableReason::RuntimeCommandAuthorityUnavailable,
+                ..
+            })
+        ));
+    }
+
+    #[test]
+    fn runtime_less_tools_hide_semantic_request_response_tools() {
+        let (router, trusted_peers) = test_router();
+        let dispatcher = CommsToolDispatcher::new(router, trusted_peers);
+        let tools = dispatcher.tools();
+        let names = tools
+            .iter()
+            .map(|tool| tool.name.as_str())
+            .collect::<Vec<_>>();
+
+        assert!(names.contains(&"send_message"));
+        assert!(names.contains(&"peers"));
+        assert!(!names.contains(&"send_request"));
+        assert!(!names.contains(&"send_response"));
     }
 }

--- a/meerkat-comms/src/lib.rs
+++ b/meerkat-comms/src/lib.rs
@@ -60,7 +60,10 @@ pub use agent::CommsAgent;
 pub use agent::dispatcher::{
     CommsToolDispatcher, DynCommsToolDispatcher, NoOpDispatcher, comms_tool_defs, wrap_with_comms,
 };
-pub use mcp::tools::{ToolContext, handle_tools_call, tools_list};
+pub use mcp::tools::{
+    RuntimeCommsCommandHandle, ToolContext, comms_tool_unavailable_reason, handle_tools_call,
+    tools_list,
+};
 
 // Capability registration
 inventory::submit! {

--- a/meerkat-comms/src/mcp/mod.rs
+++ b/meerkat-comms/src/mcp/mod.rs
@@ -2,4 +2,6 @@
 
 pub mod tools;
 
-pub use tools::{PeersInput, ToolContext, handle_tools_call, tools_list};
+pub use tools::{
+    PeersInput, RuntimeCommsCommandHandle, ToolContext, handle_tools_call, tools_list,
+};

--- a/meerkat-comms/src/mcp/tools.rs
+++ b/meerkat-comms/src/mcp/tools.rs
@@ -18,11 +18,17 @@ use std::sync::Arc;
 
 #[cfg(test)]
 use crate::{CommsConfig, Keypair};
-use crate::{Router, Status, TrustedPeers};
+use crate::{Router, TrustedPeers};
 use meerkat_core::agent::CommsRuntime as CoreCommsRuntime;
-use meerkat_core::comms::{CommsCommand, InputStreamMode, PeerId, PeerName, PeerRoute};
+use meerkat_core::comms::{
+    CommsCommand, InputStreamMode, PeerDirectoryEntry, PeerId, PeerName, PeerRoute, SendError,
+    SendReceipt,
+};
 use meerkat_core::interaction::{InteractionId, ResponseStatus};
+use meerkat_core::tool_catalog::ToolUnavailableReason;
 use meerkat_core::types::HandlingMode;
+
+const RUNTIME_COMMAND_AUTHORITY_UNAVAILABLE_CODE: &str = "runtime_command_authority_unavailable";
 
 fn schema_for<T: JsonSchema>() -> Value {
     let schema = schemars::schema_for!(T);
@@ -110,7 +116,39 @@ pub struct PeersInput {}
 pub struct ToolContext {
     pub router: Arc<Router>,
     pub trusted_peers: Arc<RwLock<TrustedPeers>>,
-    pub runtime: Option<Arc<dyn CoreCommsRuntime>>,
+    pub runtime: Option<RuntimeCommsCommandHandle>,
+}
+
+/// Runtime-bound authority for semantic comms command execution.
+#[derive(Clone)]
+pub struct RuntimeCommsCommandHandle {
+    runtime: Arc<dyn CoreCommsRuntime>,
+}
+
+impl RuntimeCommsCommandHandle {
+    pub fn new(runtime: Arc<dyn CoreCommsRuntime>) -> Self {
+        Self { runtime }
+    }
+
+    pub async fn send(&self, command: CommsCommand) -> Result<SendReceipt, SendError> {
+        self.runtime.send(command).await
+    }
+
+    pub async fn peers(&self) -> Vec<PeerDirectoryEntry> {
+        self.runtime.peers().await
+    }
+}
+
+pub fn requires_runtime_command_authority(name: &str) -> bool {
+    matches!(name, "send_request" | "send_response")
+}
+
+pub fn comms_tool_unavailable_reason(
+    ctx: &ToolContext,
+    name: &str,
+) -> Option<ToolUnavailableReason> {
+    (requires_runtime_command_authority(name) && ctx.runtime.is_none())
+        .then_some(ToolUnavailableReason::RuntimeCommandAuthorityUnavailable)
 }
 
 /// Returns the list of comms tools.
@@ -145,6 +183,10 @@ pub async fn handle_tools_call(
     name: &str,
     args: &Value,
 ) -> Result<Value, String> {
+    if comms_tool_unavailable_reason(ctx, name).is_some() {
+        return Err(runtime_command_authority_unavailable_message());
+    }
+
     match name {
         "send_message" => {
             let input: SendMessageInput = serde_json::from_value(args.clone())
@@ -232,15 +274,15 @@ async fn dispatch(ctx: &ToolContext, command: CommsCommand) -> Result<Value, Str
     let cmd_kind = command.command_kind().to_string();
 
     if let Some(runtime) = &ctx.runtime {
-        runtime.send(command).await.map_err(|error| match error {
-            meerkat_core::comms::SendError::PeerNotFound(p) => {
+        let receipt = runtime.send(command).await.map_err(|error| match error {
+            SendError::PeerNotFound(p) => {
                 format!("peer_not_found_or_not_trusted: peer '{p}' is not found or not trusted")
             }
-            meerkat_core::comms::SendError::PeerOffline => format!(
+            SendError::PeerOffline => format!(
                 "peer_unreachable: peer '{}' is unreachable: offline_or_no_ack",
                 peer_for_errors.as_deref().unwrap_or("<unknown>")
             ),
-            meerkat_core::comms::SendError::Internal(inner) if is_transport_internal(&inner) => {
+            SendError::Internal(inner) if is_transport_internal(&inner) => {
                 format!(
                     "peer_unreachable: peer '{}' is unreachable: transport_error ({inner})",
                     peer_for_errors.as_deref().unwrap_or("<unknown>")
@@ -248,12 +290,20 @@ async fn dispatch(ctx: &ToolContext, command: CommsCommand) -> Result<Value, Str
             }
             other => other.to_string(),
         })?;
-        return Ok(json!({ "status": "sent", "kind": cmd_kind }));
+        return Ok(sent_result(&cmd_kind, receipt));
+    }
+
+    if matches!(
+        command,
+        CommsCommand::PeerRequest { .. } | CommsCommand::PeerResponse { .. }
+    ) {
+        return Err(runtime_command_authority_unavailable_message());
     }
 
     // Fallback path (no runtime): dispatch directly through the router.
-    // This is used by unit tests and minimal host configurations. The
-    // destination was resolved to `PeerId` at the tool boundary.
+    // This is transport-only and intentionally excludes semantic
+    // request/response traffic, which must be owned by a runtime command
+    // authority.
     let dest_display = peer_for_errors
         .as_deref()
         .unwrap_or("<unknown>")
@@ -299,51 +349,60 @@ async fn dispatch(ctx: &ToolContext, command: CommsCommand) -> Result<Value, Str
                 .map_err(|e| format_router_send_error(&dest_display, e))?;
             Ok(json!({ "status": "sent", "kind": cmd_kind }))
         }
-        CommsCommand::PeerRequest {
-            intent,
-            params,
-            handling_mode,
-            ..
-        } => {
-            ctx.router
-                .send(
-                    dest_peer_id,
-                    crate::types::MessageKind::Request {
-                        intent,
-                        params,
-                        handling_mode: Some(handling_mode),
-                    },
-                )
-                .await
-                .map_err(|e| format_router_send_error(&dest_display, e))?;
-            Ok(json!({ "status": "sent", "kind": cmd_kind }))
-        }
-        CommsCommand::PeerResponse {
+        CommsCommand::PeerRequest { .. } => Err(runtime_command_authority_unavailable_message()),
+        CommsCommand::PeerResponse { .. } => Err(runtime_command_authority_unavailable_message()),
+    }
+}
+
+fn runtime_command_authority_unavailable_message() -> String {
+    format!("tool_unavailable: {RUNTIME_COMMAND_AUTHORITY_UNAVAILABLE_CODE}")
+}
+
+fn sent_result(kind: &str, receipt: SendReceipt) -> Value {
+    json!({
+        "status": "sent",
+        "kind": kind,
+        "receipt": receipt_to_json(receipt),
+    })
+}
+
+fn receipt_to_json(receipt: SendReceipt) -> Value {
+    match receipt {
+        SendReceipt::InputAccepted {
+            interaction_id,
+            stream_reserved,
+        } => json!({
+            "type": "input_accepted",
+            "interaction_id": interaction_id.0,
+            "stream_reserved": stream_reserved,
+        }),
+        SendReceipt::PeerMessageSent { envelope_id, acked } => json!({
+            "type": "peer_message_sent",
+            "envelope_id": envelope_id,
+            "acked": acked,
+        }),
+        SendReceipt::PeerLifecycleSent { envelope_id } => json!({
+            "type": "peer_lifecycle_sent",
+            "envelope_id": envelope_id,
+        }),
+        SendReceipt::PeerRequestSent {
+            envelope_id,
+            interaction_id,
+            stream_reserved,
+        } => json!({
+            "type": "peer_request_sent",
+            "envelope_id": envelope_id,
+            "interaction_id": interaction_id.0,
+            "stream_reserved": stream_reserved,
+        }),
+        SendReceipt::PeerResponseSent {
+            envelope_id,
             in_reply_to,
-            status,
-            result,
-            handling_mode,
-            ..
-        } => {
-            let status = match status {
-                ResponseStatus::Accepted => Status::Accepted,
-                ResponseStatus::Completed => Status::Completed,
-                ResponseStatus::Failed => Status::Failed,
-            };
-            ctx.router
-                .send(
-                    dest_peer_id,
-                    crate::types::MessageKind::Response {
-                        in_reply_to: in_reply_to.0,
-                        status,
-                        result,
-                        handling_mode,
-                    },
-                )
-                .await
-                .map_err(|e| format_router_send_error(&dest_display, e))?;
-            Ok(json!({ "status": "sent", "kind": cmd_kind }))
-        }
+        } => json!({
+            "type": "peer_response_sent",
+            "envelope_id": envelope_id,
+            "in_reply_to": in_reply_to.0,
+        }),
     }
 }
 
@@ -448,6 +507,118 @@ async fn handle_peers(ctx: &ToolContext) -> Result<Value, String> {
 mod tests {
     use super::*;
     use crate::{PubKey, TrustedPeer};
+    use parking_lot::Mutex;
+    use std::sync::LazyLock;
+    use tokio::sync::Notify;
+
+    static INPROC_REGISTRY_LOCK: LazyLock<tokio::sync::Mutex<()>> =
+        LazyLock::new(|| tokio::sync::Mutex::new(()));
+
+    struct RecordingRuntime {
+        sent: Mutex<Vec<CommsCommand>>,
+        notify: Arc<Notify>,
+    }
+
+    impl RecordingRuntime {
+        fn new() -> Self {
+            Self {
+                sent: Mutex::new(Vec::new()),
+                notify: Arc::new(Notify::new()),
+            }
+        }
+
+        fn sent_len(&self) -> usize {
+            self.sent.lock().len()
+        }
+    }
+
+    #[async_trait::async_trait]
+    impl CoreCommsRuntime for RecordingRuntime {
+        async fn send(
+            &self,
+            cmd: CommsCommand,
+        ) -> Result<meerkat_core::comms::SendReceipt, meerkat_core::comms::SendError> {
+            let receipt = match &cmd {
+                CommsCommand::PeerRequest { .. } => {
+                    meerkat_core::comms::SendReceipt::PeerRequestSent {
+                        envelope_id: uuid::Uuid::from_u128(1),
+                        interaction_id: InteractionId(uuid::Uuid::from_u128(2)),
+                        stream_reserved: false,
+                    }
+                }
+                CommsCommand::PeerResponse { in_reply_to, .. } => {
+                    meerkat_core::comms::SendReceipt::PeerResponseSent {
+                        envelope_id: uuid::Uuid::from_u128(3),
+                        in_reply_to: *in_reply_to,
+                    }
+                }
+                other => {
+                    return Err(meerkat_core::comms::SendError::Unsupported(format!(
+                        "unexpected command in test: {}",
+                        other.command_kind()
+                    )));
+                }
+            };
+            self.sent.lock().push(cmd);
+            Ok(receipt)
+        }
+
+        async fn drain_messages(&self) -> Vec<String> {
+            Vec::new()
+        }
+
+        fn inbox_notify(&self) -> Arc<Notify> {
+            Arc::clone(&self.notify)
+        }
+    }
+
+    fn make_trusted_runtime_less_context(
+        peer_keypair: &Keypair,
+    ) -> (ToolContext, meerkat_core::comms::PeerId) {
+        let sender_keypair = Keypair::generate();
+        let peer_id = peer_keypair.public_key().to_peer_id();
+        let trusted_peers = TrustedPeers {
+            peers: vec![TrustedPeer {
+                name: "test-peer".to_string(),
+                pubkey: peer_keypair.public_key(),
+                addr: "inproc://test-peer".to_string(),
+                meta: crate::PeerMeta::default(),
+            }],
+        };
+        let trusted_peers = Arc::new(RwLock::new(trusted_peers));
+        let (_, inbox_sender) = crate::Inbox::new();
+        let router = Arc::new(Router::with_shared_peers(
+            sender_keypair,
+            trusted_peers.clone(),
+            CommsConfig::default(),
+            inbox_sender,
+            true,
+        ));
+
+        (
+            ToolContext {
+                router,
+                trusted_peers,
+                runtime: None,
+            },
+            peer_id,
+        )
+    }
+
+    async fn make_runtime_less_inproc_context() -> (ToolContext, meerkat_core::comms::PeerId) {
+        let _lock = INPROC_REGISTRY_LOCK.lock().await;
+        crate::InprocRegistry::global().clear();
+
+        let peer_keypair = Keypair::generate();
+        let (_receiver_inbox, receiver_sender) = crate::Inbox::new();
+        crate::InprocRegistry::global().register(
+            "test-peer",
+            peer_keypair.public_key(),
+            receiver_sender,
+        );
+
+        make_trusted_runtime_less_context(&peer_keypair)
+    }
 
     #[test]
     fn test_tools_list_has_four_tools() {
@@ -655,5 +826,123 @@ mod tests {
                 .await
                 .is_err()
         );
+    }
+
+    #[tokio::test]
+    async fn test_send_request_without_runtime_command_authority_fails_closed() {
+        let (ctx, peer_id) = make_runtime_less_inproc_context().await;
+
+        let error = handle_tools_call(
+            &ctx,
+            "send_request",
+            &json!({
+                "peer_id": peer_id,
+                "intent": "review",
+                "params": {"file": "main.rs"},
+                "handling_mode": "steer"
+            }),
+        )
+        .await
+        .expect_err("runtime-less send_request must not fall back to router send");
+
+        assert!(
+            error.contains("runtime_command_authority_unavailable"),
+            "expected runtime command authority error, got: {error}"
+        );
+
+        crate::InprocRegistry::global().clear();
+    }
+
+    #[tokio::test]
+    async fn test_send_response_without_runtime_command_authority_fails_closed() {
+        let (ctx, peer_id) = make_runtime_less_inproc_context().await;
+        let request_id = uuid::Uuid::new_v4();
+
+        let error = handle_tools_call(
+            &ctx,
+            "send_response",
+            &json!({
+                "peer_id": peer_id,
+                "in_reply_to": request_id.to_string(),
+                "status": "completed",
+                "result": {"ok": true}
+            }),
+        )
+        .await
+        .expect_err("runtime-less send_response must not fall back to router send");
+
+        assert!(
+            error.contains("runtime_command_authority_unavailable"),
+            "expected runtime command authority error, got: {error}"
+        );
+
+        crate::InprocRegistry::global().clear();
+    }
+
+    #[tokio::test]
+    async fn test_runtime_bound_send_request_returns_typed_receipt() {
+        let peer_keypair = Keypair::generate();
+        let (mut ctx, peer_id) = make_trusted_runtime_less_context(&peer_keypair);
+        let runtime = Arc::new(RecordingRuntime::new());
+        ctx.runtime = Some(RuntimeCommsCommandHandle::new(runtime.clone()));
+
+        let result = handle_tools_call(
+            &ctx,
+            "send_request",
+            &json!({
+                "peer_id": peer_id,
+                "intent": "review",
+                "params": {"file": "main.rs"},
+                "handling_mode": "queue"
+            }),
+        )
+        .await
+        .expect("runtime-backed send_request should succeed");
+
+        assert_eq!(runtime.sent_len(), 1);
+        assert_eq!(result["status"], "sent");
+        assert_eq!(result["kind"], "peer_request");
+        assert_eq!(result["receipt"]["type"], "peer_request_sent");
+        assert_eq!(
+            result["receipt"]["envelope_id"],
+            uuid::Uuid::from_u128(1).to_string()
+        );
+        assert_eq!(
+            result["receipt"]["interaction_id"],
+            uuid::Uuid::from_u128(2).to_string()
+        );
+        assert_eq!(result["receipt"]["stream_reserved"], false);
+    }
+
+    #[tokio::test]
+    async fn test_runtime_bound_send_response_returns_typed_receipt() {
+        let peer_keypair = Keypair::generate();
+        let (mut ctx, peer_id) = make_trusted_runtime_less_context(&peer_keypair);
+        let runtime = Arc::new(RecordingRuntime::new());
+        ctx.runtime = Some(RuntimeCommsCommandHandle::new(runtime.clone()));
+        let request_id = uuid::Uuid::from_u128(4);
+
+        let result = handle_tools_call(
+            &ctx,
+            "send_response",
+            &json!({
+                "peer_id": peer_id,
+                "in_reply_to": request_id.to_string(),
+                "status": "completed",
+                "result": {"ok": true}
+            }),
+        )
+        .await
+        .expect("runtime-backed send_response should succeed");
+
+        assert_eq!(runtime.sent_len(), 1);
+        assert_eq!(result["status"], "sent");
+        assert_eq!(result["kind"], "peer_response");
+        assert_eq!(result["receipt"]["type"], "peer_response_sent");
+        assert_eq!(
+            result["receipt"]["envelope_id"],
+            uuid::Uuid::from_u128(3).to_string()
+        );
+        assert_eq!(result["receipt"]["in_reply_to"], request_id.to_string());
     }
 }

--- a/meerkat-comms/tests/router_integration.rs
+++ b/meerkat-comms/tests/router_integration.rs
@@ -462,7 +462,9 @@ async fn integration_real_send() {
 
 #[tokio::test]
 #[ignore = "integration-real: socket integration + timing behavior"]
-async fn integration_real_send_request() {
+async fn integration_real_router_transport_only_send_request_frame() {
+    // Transport-only: verifies the router can frame a Request on the wire.
+    // Agent-facing semantic request dispatch is owned by the runtime tool path.
     let tmp = TempDir::new().unwrap();
     let sock_path = tmp.path().join("peer.sock");
 
@@ -531,7 +533,9 @@ async fn integration_real_send_request() {
 
 #[tokio::test]
 #[ignore = "integration-real: socket integration + timing behavior"]
-async fn integration_real_send_response() {
+async fn integration_real_router_transport_only_send_response_frame() {
+    // Transport-only: verifies the router can frame a Response on the wire.
+    // It must not be used as proof that agent-facing send_response semantics ran.
     let tmp = TempDir::new().unwrap();
     let sock_path = tmp.path().join("peer.sock");
 
@@ -595,7 +599,8 @@ async fn integration_real_send_response() {
 
 #[tokio::test]
 #[ignore = "integration-real: socket integration + timing behavior"]
-async fn integration_real_send_response_no_ack_wait() {
+async fn integration_real_router_transport_only_send_response_frame_no_ack_wait() {
+    // Transport-only: response frames do not wait for ACKs at the router layer.
     let tmp = TempDir::new().unwrap();
     let sock_path = tmp.path().join("peer.sock");
 
@@ -769,7 +774,9 @@ async fn integration_real_router_inproc_peer_not_found() {
 
 #[tokio::test]
 #[ignore = "integration-real: socket integration + timing behavior"]
-async fn integration_real_router_inproc_request_response() {
+async fn integration_real_router_inproc_transport_only_request_frame() {
+    // Transport-only: verifies inproc Request framing, not semantic peer
+    // request/response lifecycle ownership.
     use meerkat_comms::{Inbox, InprocRegistry};
 
     let _lock = INPROC_REGISTRY_LOCK.lock().await;

--- a/meerkat-core/src/tool_catalog.rs
+++ b/meerkat-core/src/tool_catalog.rs
@@ -111,6 +111,7 @@ impl ToolCatalogEntry {
 pub enum ToolUnavailableReason {
     NotCurrentlyCallable,
     NoPeersConfigured,
+    RuntimeCommandAuthorityUnavailable,
     TemporarilyUnavailable,
 }
 
@@ -121,6 +122,9 @@ impl std::fmt::Display for ToolUnavailableReason {
                 f.write_str("tool is not currently callable")
             }
             ToolUnavailableReason::NoPeersConfigured => f.write_str("no peers configured"),
+            ToolUnavailableReason::RuntimeCommandAuthorityUnavailable => {
+                f.write_str("runtime command authority unavailable")
+            }
             ToolUnavailableReason::TemporarilyUnavailable => {
                 f.write_str("tool is temporarily unavailable")
             }

--- a/meerkat-tools/src/builtin/comms/surface.rs
+++ b/meerkat-tools/src/builtin/comms/surface.rs
@@ -1,7 +1,10 @@
 //! Comms tool surface - provides comms tools as a ToolDispatcher
 
 use async_trait::async_trait;
-use meerkat_comms::{Router, ToolContext, TrustedPeers, comms_tool_defs, handle_tools_call};
+use meerkat_comms::{
+    Router, RuntimeCommsCommandHandle, ToolContext, TrustedPeers, comms_tool_defs,
+    comms_tool_unavailable_reason, handle_tools_call,
+};
 use meerkat_core::AgentToolDispatcher;
 use meerkat_core::error::ToolError;
 use meerkat_core::types::{ToolCallView, ToolDef, ToolResult};
@@ -41,7 +44,7 @@ impl CommsToolSurface {
         let tool_context = ToolContext {
             router,
             trusted_peers,
-            runtime: Some(runtime),
+            runtime: Some(RuntimeCommsCommandHandle::new(runtime)),
         };
         let tool_defs: Arc<[Arc<ToolDef>]> = comms_tool_defs().into();
         Self {
@@ -58,9 +61,10 @@ impl CommsToolSurface {
             .unwrap_or(false)
     }
 
-    fn callability(&self) -> ToolCallability {
+    fn callability_for_tool(&self, name: &str) -> ToolCallability {
         if self.has_peers() {
-            ToolCallability::callable()
+            comms_tool_unavailable_reason(&self.tool_context, name)
+                .map_or_else(ToolCallability::callable, ToolCallability::unavailable)
         } else {
             ToolCallability::unavailable(ToolUnavailableReason::NoPeersConfigured)
         }
@@ -101,11 +105,13 @@ impl AgentToolDispatcher for CommsToolSurface {
     }
 
     fn tool_catalog(&self) -> Arc<[ToolCatalogEntry]> {
-        let callability = self.callability();
         self.tool_defs
             .iter()
             .map(|tool| {
-                ToolCatalogEntry::session_inline_with_callability(Arc::clone(tool), callability)
+                ToolCatalogEntry::session_inline_with_callability(
+                    Arc::clone(tool),
+                    self.callability_for_tool(&tool.name),
+                )
             })
             .collect::<Vec<_>>()
             .into()
@@ -121,7 +127,7 @@ impl AgentToolDispatcher for CommsToolSurface {
                 name: call.name.to_string(),
             });
         }
-        if let Some(reason) = self.callability().unavailable_reason() {
+        if let Some(reason) = self.callability_for_tool(call.name).unavailable_reason() {
             return Err(ToolError::unavailable(call.name, reason));
         }
 
@@ -173,7 +179,10 @@ mod tests {
         let surface = CommsToolSurface::new(router, trusted_peers);
         assert!(surface.tool_catalog_capabilities().exact_catalog);
         let catalog = surface.tool_catalog();
-        assert_eq!(catalog.len(), surface.tools().len());
+        assert_eq!(catalog.len(), surface.tool_defs.len());
+        assert!(catalog.iter().any(|entry| entry.tool.name == "send_request"
+            && entry.callability.unavailable_reason()
+                == Some(ToolUnavailableReason::RuntimeCommandAuthorityUnavailable)));
     }
 
     #[test]
@@ -210,13 +219,12 @@ mod tests {
         }));
         let router = make_tool_context().0;
         let surface = CommsToolSurface::new(router, trusted_peers);
-        assert_eq!(surface.tools().len(), surface.tool_defs.len());
-        assert!(
-            surface
-                .tool_catalog()
-                .iter()
-                .all(meerkat_core::ToolCatalogEntry::currently_callable)
-        );
+        let tools = surface.tools();
+        let tool_names: Vec<&str> = tools.iter().map(|tool| tool.name.as_str()).collect();
+        assert!(tool_names.contains(&"send_message"));
+        assert!(tool_names.contains(&"peers"));
+        assert!(!tool_names.contains(&"send_request"));
+        assert!(!tool_names.contains(&"send_response"));
     }
 
     #[tokio::test]
@@ -240,5 +248,38 @@ mod tests {
         };
         let result = surface.dispatch(call).await;
         assert!(matches!(result, Err(ToolError::Unavailable { .. })));
+    }
+
+    #[tokio::test]
+    async fn send_request_without_runtime_returns_typed_unavailable_reason() {
+        let (router, trusted_peers) = make_tool_context();
+        let surface = CommsToolSurface::new(router, trusted_peers);
+        let peer_id = surface.tool_context.trusted_peers.read().peers[0]
+            .pubkey
+            .to_peer_id();
+        let args_raw = serde_json::value::RawValue::from_string(
+            serde_json::json!({
+                "peer_id": peer_id,
+                "intent": "review",
+                "params": {"file": "main.rs"},
+                "handling_mode": "steer"
+            })
+            .to_string(),
+        )
+        .unwrap();
+        let call = ToolCallView {
+            id: "test-1",
+            name: "send_request",
+            args: &args_raw,
+        };
+
+        let result = surface.dispatch(call).await;
+        assert!(matches!(
+            result,
+            Err(ToolError::Unavailable {
+                reason: ToolUnavailableReason::RuntimeCommandAuthorityUnavailable,
+                ..
+            })
+        ));
     }
 }


### PR DESCRIPTION
## Summary
- add a runtime-bound comms command handle and require it for agent-facing send_request/send_response
- return typed ToolUnavailableReason::RuntimeCommandAuthorityUnavailable from dispatcher surfaces when semantic comms authority is absent
- include runtime-owned send receipts in successful comms tool output and scope router request/response tests as transport-only

## Validation
- ./scripts/repo-cargo test -p meerkat-comms mcp::tools
- ./scripts/repo-cargo test -p meerkat-comms agent::dispatcher
- ./scripts/repo-cargo test -p meerkat-tools builtin::comms
- make check
- make test

Linear: LUC-163