### PR TITLE
LUC-164 Require comms authority for peer semantics

### DIFF
--- a/meerkat-comms/src/lib.rs
+++ b/meerkat-comms/src/lib.rs
@@ -54,7 +54,9 @@ pub use runtime::comms_bootstrap::{
 pub use runtime::comms_config::CoreCommsConfig;
 #[cfg(not(target_arch = "wasm32"))]
 pub use runtime::comms_config::ResolvedCommsConfig;
-pub use runtime::comms_runtime::{CommsRuntime, CommsRuntimeError, CommsToolMaterial};
+pub use runtime::comms_runtime::{
+    CommsRuntime, CommsRuntimeError, CommsToolMaterial, PeerRequestResponseAuthority,
+};
 
 pub use agent::CommsAgent;
 pub use agent::dispatcher::{

--- a/meerkat-comms/src/runtime/comms_runtime.rs
+++ b/meerkat-comms/src/runtime/comms_runtime.rs
@@ -644,6 +644,21 @@ impl CoreCommsRuntime for CommsRuntime {
                     core_status,
                     meerkat_core::ResponseStatus::Completed | meerkat_core::ResponseStatus::Failed
                 );
+                let envelope_id = self
+                    .send_peer_command(
+                        &to,
+                        crate::types::MessageKind::Response {
+                            in_reply_to: in_reply_to.0,
+                            status,
+                            result,
+                            handling_mode,
+                        },
+                    )
+                    .await?;
+
+                // The terminal inbound transition is coupled to the actual
+                // response send outcome: route/transport failure leaves the
+                // request in `Received` so the responder can retry.
                 if is_terminal_reply && let Err(err) = peer_handle.response_replied(corr_id) {
                     tracing::warn!(
                         error = %err,
@@ -655,17 +670,7 @@ impl CoreCommsRuntime for CommsRuntime {
                     )));
                 }
 
-                self.send_peer_command(
-                    &to,
-                    crate::types::MessageKind::Response {
-                        in_reply_to: in_reply_to.0,
-                        status,
-                        result,
-                        handling_mode,
-                    },
-                )
-                .await
-                .map(|envelope_id| SendReceipt::PeerResponseSent {
+                Ok(SendReceipt::PeerResponseSent {
                     envelope_id,
                     in_reply_to,
                 })
@@ -3590,6 +3595,52 @@ mod tests {
         assert!(
             matches!(result, Err(SendError::Validation(ref message)) if message.contains("machine peer interaction authority")),
             "transport-only runtime must fail before emitting PeerResponseSent, got {result:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn terminal_peer_response_route_failure_keeps_inbound_request_retryable() {
+        let suffix = Uuid::new_v4().simple().to_string();
+        let runtime = Arc::new(
+            CommsRuntime::inproc_only(&format!("response-route-failure-{suffix}")).unwrap(),
+        );
+        let peer_handle = Arc::new(TestPeerInteractionHandle::default());
+        runtime.install_peer_request_response_authority(PeerRequestResponseAuthority::new(
+            peer_handle.clone(),
+            Arc::new(TestInteractionStreamHandle::default()),
+        ));
+
+        let interaction_id = Uuid::new_v4();
+        let corr_id = meerkat_core::PeerCorrelationId::from_uuid(interaction_id);
+        meerkat_core::handles::PeerInteractionHandle::request_received(
+            peer_handle.as_ref(),
+            corr_id,
+        )
+        .expect("test authority should seed inbound request state");
+
+        let result = CoreCommsRuntime::send(
+            runtime.as_ref(),
+            CommsCommand::PeerResponse {
+                to: missing_peer_route(&format!("missing-response-peer-{suffix}")),
+                in_reply_to: InteractionId(interaction_id),
+                status: meerkat_core::ResponseStatus::Completed,
+                result: serde_json::json!({"ok": true}),
+                handling_mode: Some(meerkat_core::types::HandlingMode::Queue),
+            },
+        )
+        .await;
+
+        assert!(
+            matches!(result, Err(SendError::PeerNotFound(_))),
+            "test must fail at transport routing, got {result:?}"
+        );
+        assert_eq!(
+            meerkat_core::handles::PeerInteractionHandle::inbound_state(
+                peer_handle.as_ref(),
+                corr_id
+            ),
+            Some(meerkat_core::InboundPeerRequestState::Received),
+            "failed terminal PeerResponse send must leave inbound request state retryable"
         );
     }
 

--- a/meerkat-comms/src/runtime/comms_runtime.rs
+++ b/meerkat-comms/src/runtime/comms_runtime.rs
@@ -52,45 +52,76 @@ const RESERVATION_TTL: meerkat_core::time_compat::Duration =
 
 /// Channels-only projection of an interaction stream.
 ///
-/// Lifecycle truth (Reserved/Attached/Completed/Expired/ClosedEarly) lives in
-/// the MeerkatMachine DSL `interaction_streams` map (U6 / dogma #5). This
-/// entry holds only the sender/receiver pair and the `created_at` timestamp
-/// the shell uses to decide *when* to fire the DSL-owned `expired`
-/// transition. All state-meaning decisions happen through the
-/// [`meerkat_core::handles::InteractionStreamHandle`].
+/// Semantic peer request streams store `Machine` and keep lifecycle truth
+/// (Reserved/Attached/Completed/Expired/ClosedEarly) in the MeerkatMachine DSL
+/// `interaction_streams` map (U6 / dogma #5). Local input streams store
+/// `LocalTransportOnly`, making their channel cleanup an explicit typed
+/// transport boundary with no semantic stream lifecycle twin.
 #[derive(Debug)]
 struct StreamRegistryEntry {
     _sender: mpsc::Sender<meerkat_core::AgentEvent>,
     receiver: Option<Receiver<meerkat_core::AgentEvent>>,
     created_at: Instant,
+    lifecycle_authority: InteractionStreamLifecycleAuthority,
 }
 
 impl StreamRegistryEntry {
     fn new(
         sender: mpsc::Sender<meerkat_core::AgentEvent>,
         receiver: Receiver<meerkat_core::AgentEvent>,
+        lifecycle_authority: InteractionStreamLifecycleAuthority,
     ) -> Self {
         Self {
             _sender: sender,
             receiver: Some(receiver),
             created_at: Instant::now(),
+            lifecycle_authority,
         }
     }
 }
 
 type InteractionStreamRegistry = Arc<Mutex<HashMap<Uuid, StreamRegistryEntry>>>;
 
+#[derive(Clone)]
+pub struct PeerRequestResponseAuthority {
+    peer_interaction: Arc<dyn meerkat_core::handles::PeerInteractionHandle>,
+    interaction_stream: Arc<dyn meerkat_core::handles::InteractionStreamHandle>,
+}
+
+impl PeerRequestResponseAuthority {
+    pub fn new(
+        peer_interaction: Arc<dyn meerkat_core::handles::PeerInteractionHandle>,
+        interaction_stream: Arc<dyn meerkat_core::handles::InteractionStreamHandle>,
+    ) -> Self {
+        Self {
+            peer_interaction,
+            interaction_stream,
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum InteractionStreamLifecycleAuthority {
+    Machine,
+    LocalTransportOnly,
+}
+
+enum InteractionStreamReservationAuthority {
+    Machine(Arc<dyn meerkat_core::handles::InteractionStreamHandle>),
+    LocalTransportOnly,
+}
+
 struct InteractionStream {
     id: Uuid,
     receiver: Option<Receiver<meerkat_core::AgentEvent>>,
-    /// Shared stream-lifecycle DSL handle (`Some` for runtime-backed
-    /// surfaces, `None` for standalone/WASM where the comms runtime owns the
-    /// channels directly via the local registry projection).
+    /// Shared stream-lifecycle DSL handle. `None` is valid only for
+    /// transport-only local input streams; semantic peer request/response
+    /// reservations require machine authority before they can be created.
     stream_handle: Option<Arc<dyn meerkat_core::handles::InteractionStreamHandle>>,
-    /// Channels-only projection registry — kept on the stream so that when no
-    /// DSL handle is installed (standalone fallback), the entry can still be
-    /// dropped on `finish`. With a handle installed, the cleanup observer
-    /// drops the entry under the same authority lock as the DSL transition.
+    /// Channels-only projection registry. With a handle installed, the cleanup
+    /// observer drops the entry under the same authority lock as the DSL
+    /// transition. Without a handle, the stream is a local transport-only
+    /// channel and owns direct cleanup.
     registry: InteractionStreamRegistry,
     source_id: String,
     seq: u64,
@@ -197,8 +228,8 @@ impl InteractionStream {
                 }
             }
             None => {
-                // Standalone fallback: no DSL handle installed (WASM /
-                // embedded). Drop the channel entry directly.
+                // Transport-only local stream: no semantic lifecycle exists,
+                // so the channel projection owns direct cleanup.
                 self.registry.lock().remove(&self.id);
             }
         }
@@ -330,31 +361,41 @@ impl CoreCommsRuntime for CommsRuntime {
             }
             StreamScope::Interaction(interaction_id) => {
                 let id = interaction_id.0;
-                let stream_handle = self.interaction_stream_handle();
                 let corr_id = meerkat_core::PeerCorrelationId::from_uuid(id);
 
                 // TTL check is shell-owned mechanics: the DSL holds the
-                // lifecycle state but `created_at` belongs with the channel
-                // (DSL state has no time). Inspect under the registry lock,
-                // expire if past TTL by firing the DSL transition.
-                let expired = {
+                // lifecycle state for machine-authoritative reservations, but
+                // `created_at` belongs with the channel (DSL state has no
+                // time). Inspect under the registry lock, then fire the typed
+                // cleanup path for the reservation authority that created it.
+                let (expired, lifecycle_authority) = {
                     let registry = self.interaction_stream_registry.lock();
                     match registry.get(&id) {
-                        Some(entry) => entry.created_at.elapsed() > RESERVATION_TTL,
+                        Some(entry) => (
+                            entry.created_at.elapsed() > RESERVATION_TTL,
+                            entry.lifecycle_authority,
+                        ),
                         None => return Err(StreamError::NotReserved(interaction_id)),
                     }
                 };
 
                 if expired {
-                    if let Some(handle) = stream_handle.as_ref() {
-                        // DSL fires expired → cleanup observer drops the
-                        // shell entry under the same authority lock. Ignore
-                        // guard rejections (state already terminal): the
-                        // shell still surfaces the timeout to the caller.
-                        let _ = handle.expired(corr_id);
-                    } else {
-                        // Standalone fallback: no DSL twin, drop directly.
-                        self.interaction_stream_registry.lock().remove(&id);
+                    match lifecycle_authority {
+                        InteractionStreamLifecycleAuthority::Machine => {
+                            if let Some(handle) = self.interaction_stream_handle() {
+                                // DSL fires expired → cleanup observer drops
+                                // the shell entry under the same authority
+                                // lock. Ignore guard rejections (state already
+                                // terminal): the shell still surfaces the
+                                // timeout to the caller.
+                                let _ = handle.expired(corr_id);
+                            }
+                        }
+                        InteractionStreamLifecycleAuthority::LocalTransportOnly => {
+                            // Transport-only local stream: no DSL twin exists,
+                            // so the channel projection owns timeout cleanup.
+                            self.interaction_stream_registry.lock().remove(&id);
+                        }
                     }
                     // W1-A: if the expired reservation corresponds to a
                     // live outbound peer-request DSL entry, fire the
@@ -371,8 +412,21 @@ impl CoreCommsRuntime for CommsRuntime {
                     )));
                 }
 
-                // Transition to Attached via the DSL handle (or direct CAS
-                // for standalone) and consume the receiver.
+                let stream_handle = match lifecycle_authority {
+                    InteractionStreamLifecycleAuthority::Machine => {
+                        Some(self.interaction_stream_handle().ok_or_else(|| {
+                            StreamError::Internal(
+                                "machine interaction stream authority missing for reserved stream"
+                                    .to_string(),
+                            )
+                        })?)
+                    }
+                    InteractionStreamLifecycleAuthority::LocalTransportOnly => None,
+                };
+
+                // Transition to Attached via the DSL handle only for
+                // machine-authoritative reservations; local input streams
+                // consume the receiver as transport-only channels.
                 if let Some(handle) = stream_handle.as_ref() {
                     handle.attached(corr_id).map_err(|err| {
                         // The DSL guard distinguishes "not Reserved": if
@@ -396,9 +450,9 @@ impl CoreCommsRuntime for CommsRuntime {
                     .get_mut(&id)
                     .ok_or(StreamError::NotReserved(interaction_id))?;
                 let receiver = entry.receiver.take().ok_or_else(|| {
-                    // Standalone fallback: no DSL guard ran, so
+                    // Transport-only local stream: no DSL guard ran, so
                     // double-attach surfaces here as a missing receiver.
-                    if stream_handle.is_some() {
+                    if lifecycle_authority == InteractionStreamLifecycleAuthority::Machine {
                         StreamError::Internal("interaction stream receiver missing".to_string())
                     } else {
                         StreamError::AlreadyAttached(interaction_id)
@@ -504,16 +558,16 @@ impl CoreCommsRuntime for CommsRuntime {
                 let interaction_id = Uuid::new_v4();
                 let corr_id = meerkat_core::PeerCorrelationId::from_uuid(interaction_id);
                 let stream_reserved = stream == InputStreamMode::ReserveInteraction;
+                let peer_handle = self.require_peer_interaction_authority("PeerRequest")?;
+                let stream_handle = if stream_reserved {
+                    Some(self.require_interaction_stream_authority(
+                        "PeerRequest with ReserveInteraction",
+                    )?)
+                } else {
+                    None
+                };
 
-                // W1-A: fire the DSL authority FIRST. If a handle is
-                // installed and the DSL rejects (duplicate corr_id, illegal
-                // phase), the shell refuses to reserve channels or send —
-                // DSL is authority, not observer. When no handle is
-                // installed (standalone / WASM), the shell retains the
-                // legacy inline behavior unchanged.
-                if let Some(handle) = self.peer_interaction_handle()
-                    && let Err(err) = handle.request_sent(corr_id, to.peer_id.to_string())
-                {
+                if let Err(err) = peer_handle.request_sent(corr_id, to.peer_id.to_string()) {
                     tracing::warn!(
                         error = %err,
                         corr_id = %corr_id,
@@ -524,12 +578,15 @@ impl CoreCommsRuntime for CommsRuntime {
                     )));
                 }
 
-                if stream_reserved {
-                    // Reserve under the canonical request envelope id so
-                    // replies can correlate via in_reply_to without an extra
-                    // local-id translation map. Stream lifecycle truth lives
-                    // in the DSL (U6); the shell registries are projections.
-                    self.reserve_interaction_stream_channels(corr_id, interaction_id)?;
+                if let Some(stream_handle) = stream_handle
+                    && let Err(err) = self.reserve_interaction_stream_channels(
+                        corr_id,
+                        interaction_id,
+                        InteractionStreamReservationAuthority::Machine(stream_handle),
+                    )
+                {
+                    let _ = peer_handle.request_timed_out(corr_id);
+                    return Err(err);
                 }
 
                 let envelope_id = match self
@@ -552,9 +609,7 @@ impl CoreCommsRuntime for CommsRuntime {
                         // Roll the peer-interaction DSL forward to
                         // `TimedOut` so the authoritative lifecycle matches
                         // reality (send failed, no response will come).
-                        if let Some(handle) = self.peer_interaction_handle() {
-                            let _ = handle.request_timed_out(corr_id);
-                        }
+                        let _ = peer_handle.request_timed_out(corr_id);
                         return Err(e);
                     }
                 };
@@ -572,35 +627,32 @@ impl CoreCommsRuntime for CommsRuntime {
                 result,
                 handling_mode,
             } => {
+                let peer_handle = self.require_peer_interaction_authority("PeerResponse")?;
+                let corr_id = meerkat_core::PeerCorrelationId::from_uuid(in_reply_to.0);
                 let core_status = status;
                 let status = match status {
                     meerkat_core::ResponseStatus::Accepted => crate::Status::Accepted,
                     meerkat_core::ResponseStatus::Completed => crate::Status::Completed,
                     meerkat_core::ResponseStatus::Failed => crate::Status::Failed,
                 };
-                // W1-A: fire the inbound `PeerResponseReplied` transition
-                // on terminal status only. Accepted is a progress signal
-                // that does not close the inbound lifecycle; only
-                // Completed/Failed terminate the inbound entry. Guard
-                // rejects a reply to an unknown corr_id, but we tolerate
-                // that because the receiver's ingress may not have
-                // installed an inbound DSL entry (plain-event-driven
-                // reply paths, bridge surfaces).
+                if peer_handle.inbound_state(corr_id).is_none() {
+                    return Err(SendError::Validation(format!(
+                        "PeerResponse requires machine inbound peer request state for corr_id {corr_id}"
+                    )));
+                }
                 let is_terminal_reply = matches!(
                     core_status,
                     meerkat_core::ResponseStatus::Completed | meerkat_core::ResponseStatus::Failed
                 );
-                if is_terminal_reply && let Some(handle) = self.peer_interaction_handle() {
-                    let corr_id = meerkat_core::PeerCorrelationId::from_uuid(in_reply_to.0);
-                    if handle.inbound_state(corr_id).is_some()
-                        && let Err(err) = handle.response_replied(corr_id)
-                    {
-                        tracing::warn!(
-                            error = %err,
-                            corr_id = %corr_id,
-                            "PeerInteractionHandle::response_replied rejected"
-                        );
-                    }
+                if is_terminal_reply && let Err(err) = peer_handle.response_replied(corr_id) {
+                    tracing::warn!(
+                        error = %err,
+                        corr_id = %corr_id,
+                        "PeerInteractionHandle::response_replied rejected"
+                    );
+                    return Err(SendError::Validation(format!(
+                        "DSL rejected PeerResponseReplied for corr_id {corr_id}: {err}"
+                    )));
                 }
 
                 self.send_peer_command(
@@ -674,12 +726,11 @@ impl CoreCommsRuntime for CommsRuntime {
                 // id can be used for stream attachment and reply correlation.
                 let interaction_id = Uuid::new_v4();
                 let corr_id = meerkat_core::PeerCorrelationId::from_uuid(interaction_id);
+                let peer_handle = self.require_peer_interaction_authority("PeerRequest")?;
+                let stream_handle = self
+                    .require_interaction_stream_authority("PeerRequest with ReserveInteraction")?;
 
-                // W1-A: DSL authority runs first — see the mirror comment
-                // in the `send` path's PeerRequest arm.
-                if let Some(handle) = self.peer_interaction_handle()
-                    && let Err(err) = handle.request_sent(corr_id, to.peer_id.to_string())
-                {
+                if let Err(err) = peer_handle.request_sent(corr_id, to.peer_id.to_string()) {
                     tracing::warn!(
                         error = %err,
                         corr_id = %corr_id,
@@ -690,8 +741,14 @@ impl CoreCommsRuntime for CommsRuntime {
                     ))));
                 }
 
-                self.reserve_interaction_stream_channels(corr_id, interaction_id)
-                    .map_err(SendAndStreamError::Send)?;
+                if let Err(err) = self.reserve_interaction_stream_channels(
+                    corr_id,
+                    interaction_id,
+                    InteractionStreamReservationAuthority::Machine(stream_handle),
+                ) {
+                    let _ = peer_handle.request_timed_out(corr_id);
+                    return Err(SendAndStreamError::Send(err));
+                }
 
                 let envelope_id = match self
                     .send_peer_command_with_id(
@@ -708,9 +765,7 @@ impl CoreCommsRuntime for CommsRuntime {
                     Ok(id) => id,
                     Err(e) => {
                         self.expire_interaction_stream_on_send_failure(corr_id, interaction_id);
-                        if let Some(handle) = self.peer_interaction_handle() {
-                            let _ = handle.request_timed_out(corr_id);
-                        }
+                        let _ = peer_handle.request_timed_out(corr_id);
                         return Err(SendAndStreamError::Send(e));
                     }
                 };
@@ -766,20 +821,25 @@ impl CoreCommsRuntime for CommsRuntime {
         let sender = self.subscriber_registry.lock().remove(&id.0);
         sender.as_ref()?;
 
-        // If still Reserved (consumer never attached), expire the
-        // reservation so the channel registry doesn't leak the entry. The
-        // DSL guard rejects when state has already advanced; the cleanup
-        // observer drops the registry entry under the same authority lock.
+        // If still Reserved (consumer never attached), expire the reservation
+        // through the same typed authority that created it.
         let corr_id = meerkat_core::PeerCorrelationId::from_uuid(id.0);
-        match self.interaction_stream_handle() {
-            Some(handle) => {
-                if handle.state(corr_id) == Some(meerkat_core::InteractionStreamState::Reserved) {
+        let lifecycle_authority = self
+            .interaction_stream_registry
+            .lock()
+            .get(&id.0)
+            .map(|entry| entry.lifecycle_authority);
+        match lifecycle_authority {
+            Some(InteractionStreamLifecycleAuthority::Machine) => {
+                if let Some(handle) = self.interaction_stream_handle()
+                    && handle.state(corr_id) == Some(meerkat_core::InteractionStreamState::Reserved)
+                {
                     let _ = handle.expired(corr_id);
                 }
             }
-            None => {
-                // Standalone fallback: drop the registry entry directly if
-                // no consumer ever took the receiver.
+            Some(InteractionStreamLifecycleAuthority::LocalTransportOnly) => {
+                // Transport-only local stream: expire the unclaimed channel
+                // directly because no semantic lifecycle was created.
                 let mut registry = self.interaction_stream_registry.lock();
                 if let Some(entry) = registry.get(&id.0)
                     && entry.receiver.is_some()
@@ -787,6 +847,7 @@ impl CoreCommsRuntime for CommsRuntime {
                     registry.remove(&id.0);
                 }
             }
+            None => {}
         }
         sender
     }
@@ -1147,15 +1208,10 @@ pub struct CommsRuntime {
     /// Set during construction when classified inbox is used.
     actionable_notify: Option<Arc<tokio::sync::Notify>>,
     blob_store: Option<Arc<dyn BlobStore>>,
-    /// Session-scoped peer-interaction DSL handle (W1-A). Populated by the
-    /// surface after `CommsRuntime` is constructed — comms runtime itself
-    /// does not know the session's DSL authority at new-time. When `Some`,
-    /// outbound `PeerRequestSent` events are recorded into the DSL and the
-    /// subscriber / stream registries become projection consumers of the
-    /// `PeerInteractionCleanup` effect. When `None` (standalone tests,
-    /// WASM) the legacy inline bookkeeping remains authoritative — this is
-    /// the documented projection fallback, not shadow truth, because the
-    /// DSL substate is simply absent for standalone runtimes.
+    /// Session-scoped peer-interaction DSL handle (W1-A). When this is absent,
+    /// the runtime is explicitly transport-only for semantic peer
+    /// request/response: it may carry one-way peer messages, but it must not
+    /// emit `PeerRequestSent` or `PeerResponseSent` receipts.
     peer_interaction_handle:
         parking_lot::RwLock<Option<Arc<dyn meerkat_core::handles::PeerInteractionHandle>>>,
     /// Session-scoped interaction-stream lifecycle DSL handle (U6 / dogma #5).
@@ -1165,10 +1221,9 @@ pub struct CommsRuntime {
     /// mark_interaction_complete, reap_expired_reservations, and the
     /// `InteractionStream::finish` close path all fire DSL inputs; the
     /// installed cleanup observer drops registry entries on terminal
-    /// transitions. When `None` (standalone tests, WASM) the registry holds
-    /// the channels directly without a DSL twin; this fallback exists to
-    /// keep `CommsRuntime::new` synchronously useful before the surface has
-    /// wired session bindings.
+    /// transitions. When `None`, only local transport-only input streams may
+    /// use the registry directly; peer request/response stream reservations
+    /// require this handle.
     interaction_stream_handle:
         parking_lot::RwLock<Option<Arc<dyn meerkat_core::handles::InteractionStreamHandle>>>,
 }
@@ -1562,6 +1617,20 @@ impl CommsRuntime {
         self.peer_comms_handle.read().clone()
     }
 
+    /// Install both machine handles required for semantic peer request/response.
+    ///
+    /// This is the typed boundary between transport-only comms and semantic
+    /// request/response. Without this authority, `PeerRequest` and
+    /// `PeerResponse` sends fail closed before transport send or receipt
+    /// emission.
+    pub fn install_peer_request_response_authority(
+        self: &Arc<Self>,
+        authority: PeerRequestResponseAuthority,
+    ) {
+        self.install_peer_interaction_handle(authority.peer_interaction);
+        self.install_interaction_stream_handle(authority.interaction_stream);
+    }
+
     /// Install the session's peer-interaction DSL handle (W1-A).
     ///
     /// Called by the surface after the session's `SessionRuntimeBindings`
@@ -1596,15 +1665,17 @@ impl CommsRuntime {
     ///
     /// Two things happen here:
     ///
-    /// 1. The runtime stores the handle so reservation, attach, completion,
-    ///    expiry, and consumer-drop transitions all flow through the DSL.
+    /// 1. The runtime stores the handle so machine-authoritative reservation,
+    ///    attach, completion, expiry, and consumer-drop transitions flow
+    ///    through the DSL.
     /// 2. The runtime registers itself as the handle's cleanup observer, so
     ///    every `InteractionStreamCleanup` effect drops the matching entry
     ///    in `interaction_stream_registry` (and the paired
     ///    `subscriber_registry` entry under the same lock).
     ///
-    /// After install, the registry holds channels only — the lifecycle truth
-    /// (Reserved/Attached/Completed/Expired/ClosedEarly) lives in the DSL.
+    /// For machine-authoritative entries, the registry holds channels only and
+    /// lifecycle truth (Reserved/Attached/Completed/Expired/ClosedEarly) lives
+    /// in the DSL. Local input streams stay transport-only.
     pub fn install_interaction_stream_handle(
         self: &Arc<Self>,
         handle: Arc<dyn meerkat_core::handles::InteractionStreamHandle>,
@@ -1620,6 +1691,37 @@ impl CommsRuntime {
         &self,
     ) -> Option<Arc<dyn meerkat_core::handles::InteractionStreamHandle>> {
         self.interaction_stream_handle.read().clone()
+    }
+
+    fn require_peer_interaction_authority(
+        &self,
+        command: &'static str,
+    ) -> Result<Arc<dyn meerkat_core::handles::PeerInteractionHandle>, SendError> {
+        self.peer_interaction_handle().ok_or_else(|| {
+            SendError::Validation(format!(
+                "{command} requires machine peer interaction authority; this CommsRuntime is transport-only for semantic peer request/response"
+            ))
+        })
+    }
+
+    fn require_interaction_stream_authority(
+        &self,
+        command: &'static str,
+    ) -> Result<Arc<dyn meerkat_core::handles::InteractionStreamHandle>, SendError> {
+        self.interaction_stream_handle().ok_or_else(|| {
+            SendError::Validation(format!(
+                "{command} requires machine interaction stream authority; this CommsRuntime is transport-only for semantic peer request/response streams"
+            ))
+        })
+    }
+
+    fn peer_request_response_sendable_kinds(&self) -> Vec<String> {
+        let mut kinds = vec!["peer_message".to_string()];
+        if self.peer_interaction_handle().is_some() {
+            kinds.push("peer_request".to_string());
+            kinds.push("peer_response".to_string());
+        }
+        kinds
     }
 
     async fn hydrate_message_kind_for_transport(
@@ -1877,11 +1979,7 @@ impl CommsRuntime {
     async fn resolve_peer_directory(&self) -> Vec<PeerDirectoryEntry> {
         let resolved = self.resolved_peers_snapshot().await;
         self.reconcile_peer_directory(&resolved);
-        let sendable_kinds = vec![
-            "peer_message".to_string(),
-            "peer_request".to_string(),
-            "peer_response".to_string(),
-        ];
+        let sendable_kinds = self.peer_request_response_sendable_kinds();
         let mut peers = Vec::new();
         let reachability = self.peer_directory_reachability.lock();
         for peer in resolved {
@@ -2143,16 +2241,22 @@ impl CommsRuntime {
 
     /// Mark an interaction stream as completed (terminal event received).
     ///
-    /// CAS semantics live in the DSL `is_attached` guard: if the consumer
-    /// already closed the stream (DSL has moved past `Attached`), the
-    /// transition is rejected and this call is a no-op. The cleanup observer
-    /// drops both the channel and subscriber entries under the same
-    /// authority lock as the DSL transition.
+    /// Machine-authoritative streams complete through the DSL `is_attached`
+    /// guard: if the consumer already closed the stream, the transition is
+    /// rejected and this call is a no-op. Local transport-only streams have no
+    /// semantic lifecycle twin, so completion drops their channel projection.
     pub fn mark_interaction_complete(&self, interaction_id: Uuid) {
         let corr_id = meerkat_core::PeerCorrelationId::from_uuid(interaction_id);
-        match self.interaction_stream_handle() {
-            Some(handle) => {
-                if let Err(err) = handle.completed(corr_id) {
+        let lifecycle_authority = self
+            .interaction_stream_registry
+            .lock()
+            .get(&interaction_id)
+            .map(|entry| entry.lifecycle_authority);
+        match lifecycle_authority {
+            Some(InteractionStreamLifecycleAuthority::Machine) => {
+                if let Some(handle) = self.interaction_stream_handle()
+                    && let Err(err) = handle.completed(corr_id)
+                {
                     tracing::trace!(
                         interaction_id = %interaction_id,
                         error = %err,
@@ -2160,10 +2264,10 @@ impl CommsRuntime {
                     );
                 }
             }
-            None => {
-                // Standalone fallback: drop the channel and subscriber
-                // entries directly. Without a DSL twin there's no CAS, so
-                // double-completion is a benign no-op against the maps.
+            Some(InteractionStreamLifecycleAuthority::LocalTransportOnly) | None => {
+                // Transport-only local stream: drop the channel and
+                // subscriber entries directly. Without a DSL twin there's no
+                // CAS, so double-completion is a benign no-op against the maps.
                 self.subscriber_registry.lock().remove(&interaction_id);
                 self.interaction_stream_registry
                     .lock()
@@ -2175,44 +2279,46 @@ impl CommsRuntime {
     /// Reap expired reservations that were never attached within the TTL.
     ///
     /// TTL is shell-owned mechanics (`created_at` lives with the channel
-    /// projection, not the DSL); the `Reserved → Expired` transition itself
-    /// is DSL truth. For each reservation past TTL, fires
-    /// `InteractionStreamHandle::expired` so the cleanup observer drops the
-    /// channel registry entry under the same authority lock. If the
-    /// reservation also corresponds to a live outbound peer-request DSL
-    /// entry, fires `PeerRequestTimedOut` so the peer-correlation lifecycle
-    /// matches reality.
+    /// projection, not the DSL). Machine-authoritative reservations fire
+    /// `InteractionStreamHandle::expired`; local transport-only reservations
+    /// remove the unclaimed channel projection directly. If the reservation
+    /// also corresponds to a live outbound peer-request DSL entry, fires
+    /// `PeerRequestTimedOut` so the peer-correlation lifecycle matches reality.
     pub fn reap_expired_reservations(&self) {
-        let candidate_ids: Vec<Uuid> = {
+        let candidates: Vec<(Uuid, InteractionStreamLifecycleAuthority)> = {
             let registry = self.interaction_stream_registry.lock();
             registry
                 .iter()
                 .filter_map(|(id, entry)| {
-                    (entry.created_at.elapsed() > RESERVATION_TTL).then_some(*id)
+                    (entry.created_at.elapsed() > RESERVATION_TTL)
+                        .then_some((*id, entry.lifecycle_authority))
                 })
                 .collect()
         };
-        if candidate_ids.is_empty() {
+        if candidates.is_empty() {
             return;
         }
         let stream_handle = self.interaction_stream_handle();
         let peer_handle = self.peer_interaction_handle();
-        for id in candidate_ids {
+        for (id, lifecycle_authority) in candidates {
             let corr_id = meerkat_core::PeerCorrelationId::from_uuid(id);
             // Stream lifecycle: only `Reserved` reservations expire. The
             // DSL guard rejects `Attached` (the stream is live and will
             // complete or close-early on its own).
-            match stream_handle.as_ref() {
-                Some(handle) => {
+            match lifecycle_authority {
+                InteractionStreamLifecycleAuthority::Machine => {
+                    let Some(handle) = stream_handle.as_ref() else {
+                        continue;
+                    };
                     if handle.state(corr_id) == Some(meerkat_core::InteractionStreamState::Reserved)
                     {
                         tracing::debug!(interaction_id = %id, "reservation expired (TTL)");
                         let _ = handle.expired(corr_id);
                     }
                 }
-                None => {
-                    // Standalone fallback: drop the entry if the receiver
-                    // is still present (consumer never attached).
+                InteractionStreamLifecycleAuthority::LocalTransportOnly => {
+                    // Transport-only local stream: drop the entry if the
+                    // receiver is still present (consumer never attached).
                     let mut registry = self.interaction_stream_registry.lock();
                     if let Some(entry) = registry.get(&id)
                         && entry.receiver.is_some()
@@ -2282,7 +2388,11 @@ impl CommsRuntime {
         handling_mode: meerkat_core::types::HandlingMode,
     ) -> Result<(), SendError> {
         let corr_id = meerkat_core::PeerCorrelationId::from_uuid(interaction_id);
-        self.reserve_interaction_stream_channels(corr_id, interaction_id)?;
+        self.reserve_interaction_stream_channels(
+            corr_id,
+            interaction_id,
+            InteractionStreamReservationAuthority::LocalTransportOnly,
+        )?;
 
         if let crate::inbox::AdmissionOutcome::Dropped { reason } = self
             .router
@@ -2312,52 +2422,72 @@ impl CommsRuntime {
         Ok(())
     }
 
-    /// Reserve channel slots for an interaction stream and record the
-    /// reservation in the DSL.
+    /// Reserve channel slots for an interaction stream.
     ///
-    /// Inserts the sender/receiver pair into the shell-side projection
-    /// (`subscriber_registry` / `interaction_stream_registry`) and fires
-    /// `InteractionStreamHandle::reserved` so the DSL records the lifecycle
-    /// entry. When no DSL handle is installed (standalone fallback), the
-    /// shell maps are the only source of truth.
+    /// Semantic peer request/response reservations pass `Machine` so the
+    /// DSL records lifecycle truth before the shell projection is inserted.
+    /// Local input streams pass `LocalTransportOnly`, making the direct
+    /// channel cleanup boundary explicit instead of acting as a semantic
+    /// lifecycle owner.
     fn reserve_interaction_stream_channels(
         &self,
         corr_id: meerkat_core::PeerCorrelationId,
         interaction_id: Uuid,
+        authority: InteractionStreamReservationAuthority,
     ) -> Result<(), SendError> {
-        if let Some(handle) = self.interaction_stream_handle()
-            && let Err(err) = handle.reserved(corr_id)
-        {
-            return Err(SendError::Validation(format!(
-                "DSL rejected InteractionStreamReserved for corr_id {corr_id}: {err}"
-            )));
+        let lifecycle_authority = match &authority {
+            InteractionStreamReservationAuthority::Machine(_) => {
+                InteractionStreamLifecycleAuthority::Machine
+            }
+            InteractionStreamReservationAuthority::LocalTransportOnly => {
+                InteractionStreamLifecycleAuthority::LocalTransportOnly
+            }
+        };
+        match authority {
+            InteractionStreamReservationAuthority::Machine(handle) => {
+                if let Err(err) = handle.reserved(corr_id) {
+                    return Err(SendError::Validation(format!(
+                        "DSL rejected InteractionStreamReserved for corr_id {corr_id}: {err}"
+                    )));
+                }
+            }
+            InteractionStreamReservationAuthority::LocalTransportOnly => {}
         }
         let (sender, receiver) = mpsc::channel::<meerkat_core::AgentEvent>(4096);
         self.subscriber_registry
             .lock()
             .insert(interaction_id, sender.clone());
-        self.interaction_stream_registry
-            .lock()
-            .insert(interaction_id, StreamRegistryEntry::new(sender, receiver));
+        self.interaction_stream_registry.lock().insert(
+            interaction_id,
+            StreamRegistryEntry::new(sender, receiver, lifecycle_authority),
+        );
         Ok(())
     }
 
     /// Tear down an interaction stream reservation when the inbound send /
     /// admission step fails.
     ///
-    /// Fires `InteractionStreamHandle::expired` so the DSL transitions
-    /// terminal and the cleanup observer drops the channel/subscriber
-    /// entries; falls back to direct removal when no handle is installed.
+    /// Machine-authoritative streams fire `InteractionStreamHandle::expired`
+    /// so the DSL transitions terminal and the cleanup observer drops the
+    /// channel/subscriber entries. Local transport-only streams remove the
+    /// projection directly.
     fn expire_interaction_stream_on_send_failure(
         &self,
         corr_id: meerkat_core::PeerCorrelationId,
         interaction_id: Uuid,
     ) {
-        match self.interaction_stream_handle() {
-            Some(handle) => {
-                let _ = handle.expired(corr_id);
+        let lifecycle_authority = self
+            .interaction_stream_registry
+            .lock()
+            .get(&interaction_id)
+            .map(|entry| entry.lifecycle_authority);
+        match lifecycle_authority {
+            Some(InteractionStreamLifecycleAuthority::Machine) => {
+                if let Some(handle) = self.interaction_stream_handle() {
+                    let _ = handle.expired(corr_id);
+                }
             }
-            None => {
+            Some(InteractionStreamLifecycleAuthority::LocalTransportOnly) | None => {
                 self.interaction_stream_registry
                     .lock()
                     .remove(&interaction_id);
@@ -2680,6 +2810,262 @@ mod tests {
         fn is_persistent(&self) -> bool {
             false
         }
+    }
+
+    #[derive(Default)]
+    struct TestPeerInteractionHandle {
+        outbound:
+            Mutex<HashMap<meerkat_core::PeerCorrelationId, meerkat_core::OutboundPeerRequestState>>,
+        inbound:
+            Mutex<HashMap<meerkat_core::PeerCorrelationId, meerkat_core::InboundPeerRequestState>>,
+        cleanup_observer:
+            Mutex<Option<Arc<dyn meerkat_core::handles::PeerInteractionCleanupObserver>>>,
+    }
+
+    impl TestPeerInteractionHandle {
+        fn notify_cleanup(&self, corr_id: meerkat_core::PeerCorrelationId) {
+            if let Some(observer) = self.cleanup_observer.lock().clone() {
+                observer.on_peer_interaction_cleanup(corr_id);
+            }
+        }
+
+        fn guard_rejected(
+            context: &'static str,
+            corr_id: meerkat_core::PeerCorrelationId,
+        ) -> meerkat_core::handles::DslTransitionError {
+            meerkat_core::handles::DslTransitionError::guard_rejected(
+                context,
+                format!("test authority rejected corr_id {corr_id}"),
+            )
+        }
+    }
+
+    impl meerkat_core::handles::PeerInteractionHandle for TestPeerInteractionHandle {
+        fn request_sent(
+            &self,
+            corr_id: meerkat_core::PeerCorrelationId,
+            _to: String,
+        ) -> Result<(), meerkat_core::handles::DslTransitionError> {
+            let mut outbound = self.outbound.lock();
+            if outbound.contains_key(&corr_id) {
+                return Err(Self::guard_rejected(
+                    "PeerInteractionHandle::request_sent",
+                    corr_id,
+                ));
+            }
+            outbound.insert(corr_id, meerkat_core::OutboundPeerRequestState::Sent);
+            Ok(())
+        }
+
+        fn response_progress(
+            &self,
+            corr_id: meerkat_core::PeerCorrelationId,
+        ) -> Result<(), meerkat_core::handles::DslTransitionError> {
+            let mut outbound = self.outbound.lock();
+            if !outbound.contains_key(&corr_id) {
+                return Err(Self::guard_rejected(
+                    "PeerInteractionHandle::response_progress",
+                    corr_id,
+                ));
+            }
+            outbound.insert(
+                corr_id,
+                meerkat_core::OutboundPeerRequestState::AcceptedProgress,
+            );
+            Ok(())
+        }
+
+        fn response_terminal(
+            &self,
+            corr_id: meerkat_core::PeerCorrelationId,
+            _disposition: meerkat_core::handles::PeerTerminalDisposition,
+        ) -> Result<(), meerkat_core::handles::DslTransitionError> {
+            if self.outbound.lock().remove(&corr_id).is_none() {
+                return Err(Self::guard_rejected(
+                    "PeerInteractionHandle::response_terminal",
+                    corr_id,
+                ));
+            }
+            self.notify_cleanup(corr_id);
+            Ok(())
+        }
+
+        fn request_timed_out(
+            &self,
+            corr_id: meerkat_core::PeerCorrelationId,
+        ) -> Result<(), meerkat_core::handles::DslTransitionError> {
+            if self.outbound.lock().remove(&corr_id).is_none() {
+                return Err(Self::guard_rejected(
+                    "PeerInteractionHandle::request_timed_out",
+                    corr_id,
+                ));
+            }
+            self.notify_cleanup(corr_id);
+            Ok(())
+        }
+
+        fn request_received(
+            &self,
+            corr_id: meerkat_core::PeerCorrelationId,
+        ) -> Result<(), meerkat_core::handles::DslTransitionError> {
+            let mut inbound = self.inbound.lock();
+            if inbound.contains_key(&corr_id) {
+                return Err(Self::guard_rejected(
+                    "PeerInteractionHandle::request_received",
+                    corr_id,
+                ));
+            }
+            inbound.insert(corr_id, meerkat_core::InboundPeerRequestState::Received);
+            Ok(())
+        }
+
+        fn response_replied(
+            &self,
+            corr_id: meerkat_core::PeerCorrelationId,
+        ) -> Result<(), meerkat_core::handles::DslTransitionError> {
+            if self.inbound.lock().remove(&corr_id).is_none() {
+                return Err(Self::guard_rejected(
+                    "PeerInteractionHandle::response_replied",
+                    corr_id,
+                ));
+            }
+            Ok(())
+        }
+
+        fn outbound_state(
+            &self,
+            corr_id: meerkat_core::PeerCorrelationId,
+        ) -> Option<meerkat_core::OutboundPeerRequestState> {
+            self.outbound.lock().get(&corr_id).copied()
+        }
+
+        fn inbound_state(
+            &self,
+            corr_id: meerkat_core::PeerCorrelationId,
+        ) -> Option<meerkat_core::InboundPeerRequestState> {
+            self.inbound.lock().get(&corr_id).copied()
+        }
+
+        fn install_cleanup_observer(
+            &self,
+            observer: Arc<dyn meerkat_core::handles::PeerInteractionCleanupObserver>,
+        ) {
+            *self.cleanup_observer.lock() = Some(observer);
+        }
+    }
+
+    #[derive(Default)]
+    struct TestInteractionStreamHandle {
+        states:
+            Mutex<HashMap<meerkat_core::PeerCorrelationId, meerkat_core::InteractionStreamState>>,
+        cleanup_observer:
+            Mutex<Option<Arc<dyn meerkat_core::handles::InteractionStreamCleanupObserver>>>,
+    }
+
+    impl TestInteractionStreamHandle {
+        fn notify_cleanup(&self, corr_id: meerkat_core::PeerCorrelationId) {
+            if let Some(observer) = self.cleanup_observer.lock().clone() {
+                observer.on_interaction_stream_cleanup(corr_id);
+            }
+        }
+
+        fn guard_rejected(
+            context: &'static str,
+            corr_id: meerkat_core::PeerCorrelationId,
+        ) -> meerkat_core::handles::DslTransitionError {
+            meerkat_core::handles::DslTransitionError::guard_rejected(
+                context,
+                format!("test stream authority rejected corr_id {corr_id}"),
+            )
+        }
+
+        fn terminal(
+            &self,
+            corr_id: meerkat_core::PeerCorrelationId,
+            context: &'static str,
+        ) -> Result<(), meerkat_core::handles::DslTransitionError> {
+            if self.states.lock().remove(&corr_id).is_none() {
+                return Err(Self::guard_rejected(context, corr_id));
+            }
+            self.notify_cleanup(corr_id);
+            Ok(())
+        }
+    }
+
+    impl meerkat_core::handles::InteractionStreamHandle for TestInteractionStreamHandle {
+        fn reserved(
+            &self,
+            corr_id: meerkat_core::PeerCorrelationId,
+        ) -> Result<(), meerkat_core::handles::DslTransitionError> {
+            let mut states = self.states.lock();
+            if states.contains_key(&corr_id) {
+                return Err(Self::guard_rejected(
+                    "InteractionStreamHandle::reserved",
+                    corr_id,
+                ));
+            }
+            states.insert(corr_id, meerkat_core::InteractionStreamState::Reserved);
+            Ok(())
+        }
+
+        fn attached(
+            &self,
+            corr_id: meerkat_core::PeerCorrelationId,
+        ) -> Result<(), meerkat_core::handles::DslTransitionError> {
+            let mut states = self.states.lock();
+            match states.get_mut(&corr_id) {
+                Some(state) if *state == meerkat_core::InteractionStreamState::Reserved => {
+                    *state = meerkat_core::InteractionStreamState::Attached;
+                    Ok(())
+                }
+                _ => Err(Self::guard_rejected(
+                    "InteractionStreamHandle::attached",
+                    corr_id,
+                )),
+            }
+        }
+
+        fn completed(
+            &self,
+            corr_id: meerkat_core::PeerCorrelationId,
+        ) -> Result<(), meerkat_core::handles::DslTransitionError> {
+            self.terminal(corr_id, "InteractionStreamHandle::completed")
+        }
+
+        fn expired(
+            &self,
+            corr_id: meerkat_core::PeerCorrelationId,
+        ) -> Result<(), meerkat_core::handles::DslTransitionError> {
+            self.terminal(corr_id, "InteractionStreamHandle::expired")
+        }
+
+        fn closed_early(
+            &self,
+            corr_id: meerkat_core::PeerCorrelationId,
+        ) -> Result<(), meerkat_core::handles::DslTransitionError> {
+            self.terminal(corr_id, "InteractionStreamHandle::closed_early")
+        }
+
+        fn state(
+            &self,
+            corr_id: meerkat_core::PeerCorrelationId,
+        ) -> Option<meerkat_core::InteractionStreamState> {
+            self.states.lock().get(&corr_id).copied()
+        }
+
+        fn install_cleanup_observer(
+            &self,
+            observer: Arc<dyn meerkat_core::handles::InteractionStreamCleanupObserver>,
+        ) {
+            *self.cleanup_observer.lock() = Some(observer);
+        }
+    }
+
+    fn install_test_peer_request_response_authority(runtime: &Arc<CommsRuntime>) {
+        runtime.install_peer_request_response_authority(PeerRequestResponseAuthority::new(
+            Arc::new(TestPeerInteractionHandle::default()),
+            Arc::new(TestInteractionStreamHandle::default()),
+        ));
     }
 
     fn test_runtime_config(name: &str, tmp: &tempfile::TempDir) -> ResolvedCommsConfig {
@@ -3009,7 +3395,8 @@ mod tests {
         let runtime_name = format!("corr-runtime-{suffix}");
 
         let peer = CommsRuntime::inproc_only(&peer_name).unwrap();
-        let runtime = CommsRuntime::inproc_only(&runtime_name).unwrap();
+        let runtime = Arc::new(CommsRuntime::inproc_only(&runtime_name).unwrap());
+        install_test_peer_request_response_authority(&runtime);
         {
             let mut trusted = runtime.trusted_peers.write();
             trusted.upsert(crate::TrustedPeer {
@@ -3036,7 +3423,7 @@ mod tests {
         .expect("peer should accept trust entry for runtime");
 
         let receipt = CoreCommsRuntime::send(
-            &runtime,
+            runtime.as_ref(),
             CommsCommand::PeerRequest {
                 to: peer_route(&peer_name, peer.public_key()),
                 intent: "checksum".to_string(),
@@ -3054,10 +3441,219 @@ mod tests {
         };
 
         let subscriber =
-            CoreCommsRuntime::interaction_subscriber(&runtime, &InteractionId(envelope_id));
+            CoreCommsRuntime::interaction_subscriber(runtime.as_ref(), &InteractionId(envelope_id));
         assert!(
             subscriber.is_some(),
             "reserved peer-request stream should correlate via the request envelope id carried in in_reply_to"
+        );
+    }
+
+    #[tokio::test]
+    async fn transport_only_runtime_rejects_peer_request_receipts_without_authority() {
+        let suffix = Uuid::new_v4().simple().to_string();
+        let peer_name = format!("transport-only-peer-{suffix}");
+        let runtime_name = format!("transport-only-runtime-{suffix}");
+
+        let peer = CommsRuntime::inproc_only(&peer_name).unwrap();
+        let runtime = CommsRuntime::inproc_only(&runtime_name).unwrap();
+        CoreCommsRuntime::add_trusted_peer(
+            &runtime,
+            trusted_descriptor(
+                &peer_name,
+                peer.public_key(),
+                &format!("inproc://{peer_name}"),
+            ),
+        )
+        .await
+        .expect("runtime should trust peer");
+        CoreCommsRuntime::add_trusted_peer(
+            &peer,
+            trusted_descriptor(
+                &runtime_name,
+                runtime.public_key(),
+                &format!("inproc://{runtime_name}"),
+            ),
+        )
+        .await
+        .expect("peer should trust runtime");
+
+        let result = CoreCommsRuntime::send(
+            &runtime,
+            CommsCommand::PeerRequest {
+                to: peer_route(&peer_name, peer.public_key()),
+                intent: "must-have-authority".to_string(),
+                params: serde_json::json!({}),
+                handling_mode: meerkat_core::types::HandlingMode::Queue,
+                stream: InputStreamMode::None,
+            },
+        )
+        .await;
+
+        assert!(
+            matches!(result, Err(SendError::Validation(ref message)) if message.contains("machine peer interaction authority")),
+            "transport-only runtime must fail before emitting PeerRequestSent, got {result:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn transport_only_runtime_rejects_peer_request_send_and_stream_without_authority() {
+        let suffix = Uuid::new_v4().simple().to_string();
+        let peer_name = format!("transport-only-stream-peer-{suffix}");
+        let runtime_name = format!("transport-only-stream-runtime-{suffix}");
+
+        let peer = CommsRuntime::inproc_only(&peer_name).unwrap();
+        let runtime = CommsRuntime::inproc_only(&runtime_name).unwrap();
+        CoreCommsRuntime::add_trusted_peer(
+            &runtime,
+            trusted_descriptor(
+                &peer_name,
+                peer.public_key(),
+                &format!("inproc://{peer_name}"),
+            ),
+        )
+        .await
+        .expect("runtime should trust peer");
+        CoreCommsRuntime::add_trusted_peer(
+            &peer,
+            trusted_descriptor(
+                &runtime_name,
+                runtime.public_key(),
+                &format!("inproc://{runtime_name}"),
+            ),
+        )
+        .await
+        .expect("peer should trust runtime");
+
+        let result = CoreCommsRuntime::send_and_stream(
+            &runtime,
+            CommsCommand::PeerRequest {
+                to: peer_route(&peer_name, peer.public_key()),
+                intent: "must-have-stream-authority".to_string(),
+                params: serde_json::json!({}),
+                handling_mode: meerkat_core::types::HandlingMode::Queue,
+                stream: InputStreamMode::ReserveInteraction,
+            },
+        )
+        .await;
+
+        assert!(
+            matches!(
+                result,
+                Err(SendAndStreamError::Send(SendError::Validation(ref message)))
+                    if message.contains("machine peer interaction authority")
+            ),
+            "transport-only runtime must fail before emitting streamed PeerRequestSent"
+        );
+    }
+
+    #[tokio::test]
+    async fn transport_only_runtime_rejects_peer_response_receipts_without_authority() {
+        let suffix = Uuid::new_v4().simple().to_string();
+        let peer_name = format!("transport-only-response-peer-{suffix}");
+        let runtime_name = format!("transport-only-response-runtime-{suffix}");
+
+        let peer = CommsRuntime::inproc_only(&peer_name).unwrap();
+        let runtime = CommsRuntime::inproc_only(&runtime_name).unwrap();
+        CoreCommsRuntime::add_trusted_peer(
+            &runtime,
+            trusted_descriptor(
+                &peer_name,
+                peer.public_key(),
+                &format!("inproc://{peer_name}"),
+            ),
+        )
+        .await
+        .expect("runtime should trust peer");
+        CoreCommsRuntime::add_trusted_peer(
+            &peer,
+            trusted_descriptor(
+                &runtime_name,
+                runtime.public_key(),
+                &format!("inproc://{runtime_name}"),
+            ),
+        )
+        .await
+        .expect("peer should trust runtime");
+
+        let result = CoreCommsRuntime::send(
+            &runtime,
+            CommsCommand::PeerResponse {
+                to: peer_route(&peer_name, peer.public_key()),
+                in_reply_to: meerkat_core::InteractionId(Uuid::new_v4()),
+                status: meerkat_core::ResponseStatus::Completed,
+                result: serde_json::json!({"ok": true}),
+                handling_mode: Some(meerkat_core::types::HandlingMode::Queue),
+            },
+        )
+        .await;
+
+        assert!(
+            matches!(result, Err(SendError::Validation(ref message)) if message.contains("machine peer interaction authority")),
+            "transport-only runtime must fail before emitting PeerResponseSent, got {result:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn transport_only_peer_directory_does_not_advertise_semantic_request_response() {
+        let suffix = Uuid::new_v4().simple().to_string();
+        let peer_name = format!("directory-transport-peer-{suffix}");
+        let runtime_name = format!("directory-transport-runtime-{suffix}");
+
+        let peer = CommsRuntime::inproc_only(&peer_name).unwrap();
+        let runtime = CommsRuntime::inproc_only(&runtime_name).unwrap();
+        CoreCommsRuntime::add_trusted_peer(
+            &runtime,
+            trusted_descriptor(
+                &peer_name,
+                peer.public_key(),
+                &format!("inproc://{peer_name}"),
+            ),
+        )
+        .await
+        .expect("runtime should trust peer");
+
+        let peers = CoreCommsRuntime::peers(&runtime).await;
+        let entry = peers
+            .iter()
+            .find(|entry| entry.name.as_str() == peer_name)
+            .expect("trusted peer should be listed");
+
+        assert_eq!(entry.sendable_kinds, vec!["peer_message".to_string()]);
+    }
+
+    #[tokio::test]
+    async fn peer_directory_advertises_semantic_request_response_with_authority() {
+        let suffix = Uuid::new_v4().simple().to_string();
+        let peer_name = format!("directory-semantic-peer-{suffix}");
+        let runtime_name = format!("directory-semantic-runtime-{suffix}");
+
+        let peer = CommsRuntime::inproc_only(&peer_name).unwrap();
+        let runtime = Arc::new(CommsRuntime::inproc_only(&runtime_name).unwrap());
+        install_test_peer_request_response_authority(&runtime);
+        CoreCommsRuntime::add_trusted_peer(
+            runtime.as_ref(),
+            trusted_descriptor(
+                &peer_name,
+                peer.public_key(),
+                &format!("inproc://{peer_name}"),
+            ),
+        )
+        .await
+        .expect("runtime should trust peer");
+
+        let peers = CoreCommsRuntime::peers(runtime.as_ref()).await;
+        let entry = peers
+            .iter()
+            .find(|entry| entry.name.as_str() == peer_name)
+            .expect("trusted peer should be listed");
+
+        assert_eq!(
+            entry.sendable_kinds,
+            vec![
+                "peer_message".to_string(),
+                "peer_request".to_string(),
+                "peer_response".to_string(),
+            ]
         );
     }
 
@@ -3211,6 +3807,54 @@ mod tests {
         assert!(
             matches!(duplicate, Err(StreamError::AlreadyAttached(_))),
             "reserved interaction streams should reject a second attachment"
+        );
+    }
+
+    #[tokio::test]
+    async fn local_input_stream_remains_transport_only_with_machine_stream_authority() {
+        let suffix = Uuid::new_v4().simple().to_string();
+        let runtime = Arc::new(
+            CommsRuntime::inproc_only(&format!("local-transport-authority-{suffix}")).unwrap(),
+        );
+        let stream_handle = Arc::new(TestInteractionStreamHandle::default());
+        runtime.install_interaction_stream_handle(stream_handle.clone());
+
+        let cmd = CommsCommand::Input {
+            blocks: None,
+            session_id: SessionId::new(),
+            body: "local input stream".to_string(),
+            handling_mode: meerkat_core::types::HandlingMode::Queue,
+            source: InputSource::Rpc,
+            stream: InputStreamMode::ReserveInteraction,
+            allow_self_session: true,
+        };
+
+        let (receipt, _stream) = CoreCommsRuntime::send_and_stream(runtime.as_ref(), cmd)
+            .await
+            .expect("local input send_and_stream should attach without semantic stream authority");
+
+        let interaction_id = match receipt {
+            SendReceipt::InputAccepted {
+                interaction_id,
+                stream_reserved,
+            } => {
+                assert!(stream_reserved);
+                interaction_id
+            }
+            other => panic!("expected InputAccepted, got {other:?}"),
+        };
+        let corr_id = meerkat_core::PeerCorrelationId::from_uuid(interaction_id.0);
+        assert_eq!(
+            meerkat_core::handles::InteractionStreamHandle::state(stream_handle.as_ref(), corr_id),
+            None,
+            "local input streams must not create semantic stream DSL state"
+        );
+
+        let duplicate =
+            CoreCommsRuntime::stream(runtime.as_ref(), StreamScope::Interaction(interaction_id));
+        assert!(
+            matches!(duplicate, Err(StreamError::AlreadyAttached(_))),
+            "local input streams should keep transport-only duplicate attach semantics"
         );
     }
 
@@ -4447,10 +5091,7 @@ mod tests {
             peer.source
         );
         assert_eq!(peer.address.to_string(), format!("inproc://{peer_name}"));
-        assert_eq!(peer.sendable_kinds.len(), 3);
-        assert!(peer.sendable_kinds.contains(&"peer_message".to_string()));
-        assert!(peer.sendable_kinds.contains(&"peer_request".to_string()));
-        assert!(peer.sendable_kinds.contains(&"peer_response".to_string()));
+        assert_eq!(peer.sendable_kinds, vec!["peer_message".to_string()]);
         assert_eq!(peer.reachability, PeerReachability::Unknown);
         assert_eq!(peer.last_unreachable_reason, None);
     }
@@ -4977,7 +5618,11 @@ mod tests {
         let id = Uuid::new_v4();
         let (sender, receiver) = mpsc::channel::<meerkat_core::AgentEvent>(16);
         {
-            let mut entry = StreamRegistryEntry::new(sender, receiver);
+            let mut entry = StreamRegistryEntry::new(
+                sender,
+                receiver,
+                InteractionStreamLifecycleAuthority::LocalTransportOnly,
+            );
             entry.created_at = Instant::now()
                 .checked_sub(meerkat_core::time_compat::Duration::from_secs(60))
                 .unwrap();

--- a/meerkat-comms/src/runtime/mod.rs
+++ b/meerkat-comms/src/runtime/mod.rs
@@ -11,4 +11,4 @@ pub use comms_bootstrap::{
 pub use comms_config::CoreCommsConfig;
 #[cfg(not(target_arch = "wasm32"))]
 pub use comms_config::ResolvedCommsConfig;
-pub use comms_runtime::{CommsRuntime, CommsRuntimeError};
+pub use comms_runtime::{CommsRuntime, CommsRuntimeError, PeerRequestResponseAuthority};

--- a/meerkat-core/src/agent.rs
+++ b/meerkat-core/src/agent.rs
@@ -814,9 +814,9 @@ pub trait CommsRuntime: Send + Sync {
 
     /// Access the session's peer-interaction DSL handle (W1-A).
     ///
-    /// Returns `None` for standalone / ephemeral comms runtimes that have no
-    /// attached session DSL. Returns `Some` once the surface has installed
-    /// the handle via [`meerkat_comms::CommsRuntime::install_peer_interaction_handle`].
+    /// Returns `None` for transport-only comms runtimes. A runtime that emits
+    /// semantic peer request/response receipts must return `Some` after the
+    /// surface installs machine authority.
     fn peer_interaction_handle(
         &self,
     ) -> Option<std::sync::Arc<dyn crate::handles::PeerInteractionHandle>> {

--- a/meerkat-core/src/runtime_epoch.rs
+++ b/meerkat-core/src/runtime_epoch.rs
@@ -184,12 +184,11 @@ pub struct SessionRuntimeBindings {
     pub mcp_server_lifecycle: Arc<dyn McpServerLifecycleHandle>,
     /// Peer interaction lifecycle DSL handle (W1-A / issue #264).
     ///
-    /// Optional: surfaces without a runtime-owned session DSL (WASM,
-    /// standalone ephemeral tests) leave this `None` and the comms runtime
-    /// falls back to inline channel bookkeeping. Surfaces with a real session
-    /// runtime populate this with [`RuntimePeerInteractionHandle`] sharing the
-    /// same `HandleDslAuthority` as the other five handles.
-    pub peer_interaction: Option<Arc<dyn PeerInteractionHandle>>,
+    /// Any session-owned runtime binding that can emit semantic peer
+    /// request/response receipts carries this handle. Standalone/embedded
+    /// builds without bindings are transport-only unless they explicitly
+    /// prepare an ephemeral machine authority and use `SessionOwned`.
+    pub peer_interaction: Arc<dyn PeerInteractionHandle>,
     /// Session-context advancement DSL handle (W2-E / issue #264).
     ///
     /// Fires `AdvanceSessionContext` at every canonical session-truth
@@ -208,10 +207,9 @@ pub struct SessionRuntimeBindings {
     pub session_claim_handle: Arc<dyn SessionClaimHandle>,
     /// Interaction stream lifecycle DSL handle (U6 / dogma #5).
     ///
-    /// Optional for the same reason as [`Self::peer_interaction`]; surfaces
-    /// without a session DSL leave this `None` and the comms runtime falls
-    /// back to standalone bookkeeping seeded by an ephemeral handle.
-    pub interaction_stream: Option<Arc<dyn InteractionStreamHandle>>,
+    /// Required with session-owned peer request/response semantics so stream
+    /// reservations remain a projection of machine state.
+    pub interaction_stream: Arc<dyn InteractionStreamHandle>,
     /// Realtime product-turn lifecycle DSL handle (U9 / dogma #4).
     ///
     /// Replaces the shell-local `product_turn_in_flight` /
@@ -238,10 +236,10 @@ impl Clone for SessionRuntimeBindings {
             model_routing: Arc::clone(&self.model_routing),
             auth_lease: Arc::clone(&self.auth_lease),
             mcp_server_lifecycle: Arc::clone(&self.mcp_server_lifecycle),
-            peer_interaction: self.peer_interaction.as_ref().map(Arc::clone),
+            peer_interaction: Arc::clone(&self.peer_interaction),
             session_context: Arc::clone(&self.session_context),
             session_claim_handle: Arc::clone(&self.session_claim_handle),
-            interaction_stream: self.interaction_stream.as_ref().map(Arc::clone),
+            interaction_stream: Arc::clone(&self.interaction_stream),
             realtime_product_turn: Arc::clone(&self.realtime_product_turn),
         }
     }
@@ -263,22 +261,10 @@ impl std::fmt::Debug for SessionRuntimeBindings {
             .field("model_routing", &"<dyn ModelRoutingHandle>")
             .field("auth_lease", &"<dyn AuthLeaseHandle>")
             .field("mcp_server_lifecycle", &"<dyn McpServerLifecycleHandle>")
-            .field(
-                "peer_interaction",
-                &self
-                    .peer_interaction
-                    .as_ref()
-                    .map(|_| "<dyn PeerInteractionHandle>"),
-            )
+            .field("peer_interaction", &"<dyn PeerInteractionHandle>")
             .field("session_context", &"<dyn SessionContextHandle>")
             .field("session_claim_handle", &"<dyn SessionClaimHandle>")
-            .field(
-                "interaction_stream",
-                &self
-                    .interaction_stream
-                    .as_ref()
-                    .map(|_| "<dyn InteractionStreamHandle>"),
-            )
+            .field("interaction_stream", &"<dyn InteractionStreamHandle>")
             .field("realtime_product_turn", &"<dyn RealtimeProductTurnHandle>")
             .finish()
     }
@@ -286,8 +272,9 @@ impl std::fmt::Debug for SessionRuntimeBindings {
 
 /// Discriminant for how the factory should resolve async-operation lifecycle resources.
 ///
-/// - `StandaloneEphemeral`: factory creates local-only ephemeral bindings.
-///   Suitable for WASM, tests, embedded, and doc examples.
+/// - `StandaloneEphemeral`: factory creates local-only ephemeral bindings for
+///   non-comms semantics. Comms peer request/response remains transport-only
+///   unless the host prepares explicit `SessionOwned` authority.
 /// - `SessionOwned`: factory consumes pre-created bindings from the runtime
 ///   epoch owner. Never creates a competing registry.
 ///
@@ -296,7 +283,8 @@ impl std::fmt::Debug for SessionRuntimeBindings {
 /// through the factory exactly once, never lands in a collection, so paying
 /// for an extra heap indirection on every construction would regress the hot
 /// path. The `StandaloneEphemeral` path only appears in WASM, tests, and
-/// standalone embedded runs.
+/// standalone embedded runs that do not need semantic peer request/response
+/// authority.
 #[allow(clippy::large_enum_variant)]
 pub enum RuntimeBuildMode {
     /// Standalone: factory creates local-only ephemeral bindings.

--- a/meerkat-mob/src/runtime/supervisor_bridge.rs
+++ b/meerkat-mob/src/runtime/supervisor_bridge.rs
@@ -60,7 +60,51 @@ impl MobSupervisorBridge {
                 "failed to construct mob supervisor comms runtime '{participant_name}': {error}"
             ))
         })?;
-        Ok(Arc::new(runtime))
+        let runtime = Arc::new(runtime);
+        Self::install_supervisor_peer_request_response_authority(&runtime, participant_name)?;
+        Ok(runtime)
+    }
+
+    /// Supervisor bridge runtimes intentionally issue semantic peer
+    /// request/response commands outside a session surface. Give them an
+    /// explicit ephemeral machine authority so comms never owns that lifecycle.
+    fn install_supervisor_peer_request_response_authority(
+        runtime: &Arc<meerkat_comms::CommsRuntime>,
+        participant_name: &str,
+    ) -> Result<(), MobError> {
+        let dsl = Arc::new(meerkat_runtime::HandleDslAuthority::ephemeral());
+        dsl.apply_signal(
+            meerkat_runtime::meerkat_machine::dsl::MeerkatMachineSignal::Initialize,
+            "mob_supervisor_bridge::initialize",
+        )
+        .map_err(|error| {
+            MobError::Internal(format!(
+                "failed to initialize supervisor bridge authority '{participant_name}': {error}"
+            ))
+        })?;
+        dsl.apply_input(
+            meerkat_runtime::meerkat_machine::dsl::MeerkatMachineInput::RegisterSession {
+                session_id: meerkat_runtime::meerkat_machine::dsl::SessionId::from(
+                    participant_name.to_string(),
+                ),
+            },
+            "mob_supervisor_bridge::register",
+        )
+        .map_err(|error| {
+            MobError::Internal(format!(
+                "failed to register supervisor bridge authority '{participant_name}': {error}"
+            ))
+        })?;
+
+        runtime.install_peer_request_response_authority(
+            meerkat_comms::PeerRequestResponseAuthority::new(
+                Arc::new(meerkat_runtime::RuntimePeerInteractionHandle::new(
+                    Arc::clone(&dsl),
+                )),
+                Arc::new(meerkat_runtime::RuntimeInteractionStreamHandle::new(dsl)),
+            ),
+        );
+        Ok(())
     }
 
     pub(crate) async fn rotate(

--- a/meerkat-mob/src/runtime/tests.rs
+++ b/meerkat-mob/src/runtime/tests.rs
@@ -41,7 +41,7 @@ use meerkat_core::types::{
 use meerkat_core::{
     Agent, AgentBuilder, AgentLlmClient, AgentSessionStore, AgentToolDispatcher,
     AppendSystemContextStatus, EventInjector, EventInjectorError, LlmStreamResult,
-    PendingSystemContextAppend, PlainEventSource,
+    PeerCorrelationId, PendingSystemContextAppend, PlainEventSource,
     event_injector::{InteractionSubscription, SubscribableInjector},
 };
 use meerkat_core::{
@@ -66,6 +66,56 @@ fn default_supervisor_authority_record() -> SupervisorAuthorityRecord {
     SupervisorAuthorityRecord::generate(
         super::bridge_protocol::supervisor_bridge_default_protocol_version(),
     )
+}
+
+fn install_ephemeral_peer_request_response_authority(
+    runtime: &Arc<meerkat_comms::CommsRuntime>,
+    session: &str,
+) {
+    let dsl = Arc::new(meerkat_runtime::HandleDslAuthority::ephemeral());
+    dsl.apply_signal(
+        meerkat_runtime::meerkat_machine::dsl::MeerkatMachineSignal::Initialize,
+        "test::initialize",
+    )
+    .expect("Initialize");
+    dsl.apply_input(
+        meerkat_runtime::meerkat_machine::dsl::MeerkatMachineInput::RegisterSession {
+            session_id: meerkat_runtime::meerkat_machine::dsl::SessionId::from(session.to_string()),
+        },
+        "test::register_session",
+    )
+    .expect("RegisterSession");
+
+    runtime.install_peer_request_response_authority(
+        meerkat_comms::PeerRequestResponseAuthority::new(
+            Arc::new(meerkat_runtime::RuntimePeerInteractionHandle::new(
+                Arc::clone(&dsl),
+            )),
+            Arc::new(meerkat_runtime::RuntimeInteractionStreamHandle::new(dsl)),
+        ),
+    );
+}
+
+async fn install_machine_peer_request_response_authority(
+    adapter: &meerkat_runtime::MeerkatMachine,
+    runtime: &Arc<meerkat_comms::CommsRuntime>,
+    session_id: &SessionId,
+) -> Result<(), SessionError> {
+    let bindings = adapter
+        .prepare_local_session_bindings(session_id.clone())
+        .await
+        .map_err(|err| {
+            SessionError::Agent(meerkat_core::error::AgentError::InternalError(format!(
+                "failed to prepare comms lifecycle authority: {err}"
+            )))
+        })?;
+    runtime.install_peer_request_response_authority(
+        meerkat_comms::PeerRequestResponseAuthority::new(
+            bindings.peer_interaction,
+            bindings.interaction_stream,
+        ),
+    );
+    Ok(())
 }
 
 // -----------------------------------------------------------------------
@@ -3005,6 +3055,10 @@ async fn spawn_live_external_peer(peer_name: &str) -> LiveExternalPeerHarness {
         meerkat_comms::CommsRuntime::inproc_only(&peer_name)
             .expect("create live external peer runtime"),
     );
+    install_ephemeral_peer_request_response_authority(
+        &runtime,
+        &format!("live-external-peer-{peer_name}"),
+    );
     let bootstrap_token = runtime.bridge_bootstrap_token().to_string();
     let peer_pubkey = *runtime.public_key().as_bytes();
     let binding = crate::RuntimeBinding::External {
@@ -3052,6 +3106,13 @@ async fn spawn_live_external_peer(peer_name: &str) -> LiveExternalPeerHarness {
                             .write()
                             .await
                             .push(intent.clone());
+                        responder_runtime
+                            .peer_interaction_handle()
+                            .expect("live external peer semantic authority")
+                            .request_received(PeerCorrelationId::from_uuid(
+                                candidate.interaction.id.0,
+                            ))
+                            .expect("record inbound peer request before response");
                         let reply_name = candidate.interaction.from.clone();
                         let to = test_trusted_peer_route(responder_runtime.as_ref(), &reply_name);
                         let bridge_parse: Result<super::bridge_protocol::BridgeCommand, _> =
@@ -18782,12 +18843,16 @@ impl SessionService for RealCommsSessionService {
             .and_then(|b| b.comms_name.clone())
             .unwrap_or_else(|| format!("real-comms-session-{n}"));
 
-        let comms = meerkat_comms::CommsRuntime::inproc_only(&comms_name)
-            .expect("create inproc CommsRuntime");
+        let comms = Arc::new(
+            meerkat_comms::CommsRuntime::inproc_only(&comms_name)
+                .expect("create inproc CommsRuntime"),
+        );
+        install_machine_peer_request_response_authority(&self.runtime_adapter, &comms, &session_id)
+            .await?;
         self.sessions
             .write()
             .await
-            .insert(session_id.clone(), Arc::new(comms));
+            .insert(session_id.clone(), Arc::clone(&comms));
         let is_keep_alive = req.build.as_ref().map(|b| b.keep_alive).unwrap_or(false);
         if is_keep_alive {
             self.keep_alive_notifiers
@@ -18799,10 +18864,6 @@ impl SessionService for RealCommsSessionService {
             .write()
             .await
             .insert(session_id.clone(), comms_name);
-        self.runtime_adapter
-            .register_session(session_id.clone())
-            .await;
-
         Ok(mock_run_result(session_id, "Session created".to_string()))
     }
 
@@ -19084,12 +19145,16 @@ impl SessionService for RuntimeBackedRealCommsSessionService {
             .and_then(|b| b.comms_name.clone())
             .unwrap_or_else(|| format!("real-runtime-comms-session-{n}"));
 
-        let comms = meerkat_comms::CommsRuntime::inproc_only(&comms_name)
-            .expect("create inproc CommsRuntime");
+        let comms = Arc::new(
+            meerkat_comms::CommsRuntime::inproc_only(&comms_name)
+                .expect("create inproc CommsRuntime"),
+        );
+        install_machine_peer_request_response_authority(&self.runtime_adapter, &comms, &session_id)
+            .await?;
         self.sessions
             .write()
             .await
-            .insert(session_id.clone(), Arc::new(comms));
+            .insert(session_id.clone(), Arc::clone(&comms));
         let is_keep_alive = req.build.as_ref().map(|b| b.keep_alive).unwrap_or(false);
         if is_keep_alive {
             self.keep_alive_notifiers

--- a/meerkat-mob/src/tests/contracts.rs
+++ b/meerkat-mob/src/tests/contracts.rs
@@ -11,7 +11,8 @@
 )]
 
 use async_trait::async_trait;
-use meerkat_comms::CommsRuntime;
+use meerkat_comms::{CommsRuntime, PeerRequestResponseAuthority};
+use meerkat_core::PeerCorrelationId;
 use meerkat_core::Provider;
 use meerkat_core::agent::CommsRuntime as CoreCommsRuntime;
 use meerkat_core::comms::{
@@ -47,6 +48,29 @@ fn inproc_peer_route(name: &str, runtime: &CommsRuntime) -> Result<PeerRoute, St
     ))
 }
 
+fn install_ephemeral_peer_request_response_authority(runtime: &Arc<CommsRuntime>, session: &str) {
+    let dsl = Arc::new(meerkat_runtime::HandleDslAuthority::ephemeral());
+    dsl.apply_signal(
+        meerkat_runtime::meerkat_machine::dsl::MeerkatMachineSignal::Initialize,
+        "test::initialize",
+    )
+    .expect("Initialize");
+    dsl.apply_input(
+        meerkat_runtime::meerkat_machine::dsl::MeerkatMachineInput::RegisterSession {
+            session_id: meerkat_runtime::meerkat_machine::dsl::SessionId::from(session.to_string()),
+        },
+        "test::register_session",
+    )
+    .expect("RegisterSession");
+
+    runtime.install_peer_request_response_authority(PeerRequestResponseAuthority::new(
+        Arc::new(meerkat_runtime::RuntimePeerInteractionHandle::new(
+            Arc::clone(&dsl),
+        )),
+        Arc::new(meerkat_runtime::RuntimeInteractionStreamHandle::new(dsl)),
+    ));
+}
+
 // ---------------------------------------------------------------------------
 // CONTRACT-MOB-002: PeerRequest/PeerResponse round-trip via CommsRuntime
 // ---------------------------------------------------------------------------
@@ -57,29 +81,36 @@ async fn contract_mob_002_peer_request_response_round_trip() {
     let sender_name = format!("c002-sender-{suffix}");
     let receiver_name = format!("c002-receiver-{suffix}");
 
-    let sender = CommsRuntime::inproc_only(&sender_name).unwrap();
-    let receiver = CommsRuntime::inproc_only(&receiver_name).unwrap();
+    let sender = Arc::new(CommsRuntime::inproc_only(&sender_name).unwrap());
+    let receiver = Arc::new(CommsRuntime::inproc_only(&receiver_name).unwrap());
+    install_ephemeral_peer_request_response_authority(&sender, &format!("c002-sender-{suffix}"));
+    install_ephemeral_peer_request_response_authority(
+        &receiver,
+        &format!("c002-receiver-{suffix}"),
+    );
 
     // Establish bidirectional trust
-    let peer_spec = inproc_peer_descriptor(&receiver_name, &receiver).expect("valid peer spec");
-    CoreCommsRuntime::add_trusted_peer(&sender, peer_spec)
+    let peer_spec =
+        inproc_peer_descriptor(&receiver_name, receiver.as_ref()).expect("valid peer spec");
+    CoreCommsRuntime::add_trusted_peer(sender.as_ref(), peer_spec)
         .await
         .expect("add sender->receiver trust");
 
-    let reverse_spec = inproc_peer_descriptor(&sender_name, &sender).expect("valid reverse spec");
-    CoreCommsRuntime::add_trusted_peer(&receiver, reverse_spec)
+    let reverse_spec =
+        inproc_peer_descriptor(&sender_name, sender.as_ref()).expect("valid reverse spec");
+    CoreCommsRuntime::add_trusted_peer(receiver.as_ref(), reverse_spec)
         .await
         .expect("add receiver->sender trust");
 
     // Send PeerRequest from sender to receiver
     let request_cmd = CommsCommand::PeerRequest {
-        to: inproc_peer_route(&receiver_name, &receiver).expect("valid peer route"),
+        to: inproc_peer_route(&receiver_name, receiver.as_ref()).expect("valid peer route"),
         intent: "mob.ping".to_string(),
         params: serde_json::json!({"seq": 1}),
         handling_mode: meerkat_core::types::HandlingMode::Queue,
         stream: meerkat_core::comms::InputStreamMode::None,
     };
-    let receipt = CoreCommsRuntime::send(&sender, request_cmd)
+    let receipt = CoreCommsRuntime::send(sender.as_ref(), request_cmd)
         .await
         .expect("PeerRequest send should succeed");
     let (request_envelope_id, request_interaction_id) = match receipt {
@@ -101,7 +132,7 @@ async fn contract_mob_002_peer_request_response_round_trip() {
     );
 
     // Receiver drains inbox and sees the request
-    let interactions = CoreCommsRuntime::drain_inbox_interactions(&receiver).await;
+    let interactions = CoreCommsRuntime::drain_inbox_interactions(receiver.as_ref()).await;
     assert_eq!(
         interactions.len(),
         1,
@@ -131,16 +162,21 @@ async fn contract_mob_002_peer_request_response_round_trip() {
         }
         other => panic!("expected Request interaction, got: {other:?}"),
     };
+    receiver
+        .peer_interaction_handle()
+        .expect("receiver should have peer interaction authority")
+        .request_received(PeerCorrelationId::from_uuid(request_id.0))
+        .expect("direct comms-drain bypass must seed inbound request state");
 
     // Receiver sends PeerResponse back
     let response_cmd = CommsCommand::PeerResponse {
-        to: inproc_peer_route(&sender_name, &sender).expect("valid peer route"),
+        to: inproc_peer_route(&sender_name, sender.as_ref()).expect("valid peer route"),
         in_reply_to: request_id,
         status: meerkat_core::ResponseStatus::Completed,
         result: serde_json::json!({"pong": true}),
         handling_mode: None,
     };
-    let resp_receipt = CoreCommsRuntime::send(&receiver, response_cmd)
+    let resp_receipt = CoreCommsRuntime::send(receiver.as_ref(), response_cmd)
         .await
         .expect("PeerResponse send should succeed");
     assert!(
@@ -149,7 +185,7 @@ async fn contract_mob_002_peer_request_response_round_trip() {
     );
 
     // Sender drains inbox and sees the response
-    let sender_interactions = CoreCommsRuntime::drain_inbox_interactions(&sender).await;
+    let sender_interactions = CoreCommsRuntime::drain_inbox_interactions(sender.as_ref()).await;
     assert_eq!(
         sender_interactions.len(),
         1,
@@ -186,7 +222,7 @@ async fn contract_mob_002_peer_request_response_round_trip() {
 async fn contract_mob_002b_terminal_transition_drives_registry_cleanup_via_effect() {
     use meerkat_core::comms::InputStreamMode;
     use meerkat_core::handles::{PeerInteractionHandle, PeerTerminalDisposition};
-    use meerkat_runtime::RuntimePeerInteractionHandle;
+    use meerkat_runtime::{RuntimeInteractionStreamHandle, RuntimePeerInteractionHandle};
 
     let suffix = Uuid::new_v4().simple().to_string();
     let sender_name = format!("c002b-sender-{suffix}");
@@ -216,7 +252,12 @@ async fn contract_mob_002b_terminal_transition_drives_registry_cleanup_via_effec
     .expect("RegisterSession");
     let handle: Arc<dyn PeerInteractionHandle> =
         Arc::new(RuntimePeerInteractionHandle::new(Arc::clone(&dsl)));
-    sender.install_peer_interaction_handle(Arc::clone(&handle));
+    sender.install_peer_request_response_authority(
+        meerkat_comms::PeerRequestResponseAuthority::new(
+            Arc::clone(&handle),
+            Arc::new(RuntimeInteractionStreamHandle::new(Arc::clone(&dsl))),
+        ),
+    );
 
     // Establish bidirectional trust.
     CoreCommsRuntime::add_trusted_peer(
@@ -278,8 +319,8 @@ async fn contract_mob_002b_terminal_transition_drives_registry_cleanup_via_effec
 
     // Drive the DSL terminal transition directly through the handle (the
     // exact thing comms_drain does when a Completed response arrives).
-    // This MUST fire `PeerInteractionCleanup`, and the observer installed
-    // on `install_peer_interaction_handle` MUST drop the registry entry.
+    // This MUST fire `PeerInteractionCleanup`, and the observer installed by
+    // `install_peer_request_response_authority` MUST drop the registry entry.
     handle
         .response_terminal(corr_id, PeerTerminalDisposition::Completed)
         .expect("terminal transition must succeed");
@@ -341,7 +382,12 @@ async fn contract_mob_002c_dsl_reject_refuses_shell_commit() {
     let handle: Arc<dyn PeerInteractionHandle> = Arc::new(
         meerkat_runtime::RuntimePeerInteractionHandle::new(Arc::clone(&dsl)),
     );
-    sender.install_peer_interaction_handle(Arc::clone(&handle));
+    sender.install_peer_request_response_authority(PeerRequestResponseAuthority::new(
+        Arc::clone(&handle),
+        Arc::new(meerkat_runtime::RuntimeInteractionStreamHandle::new(
+            Arc::clone(&dsl),
+        )),
+    ));
 
     CoreCommsRuntime::add_trusted_peer(
         sender.as_ref(),
@@ -446,7 +492,12 @@ async fn contract_mob_002d_inbound_terminal_reply_closes_lifecycle_via_send() {
     let handle: Arc<dyn PeerInteractionHandle> = Arc::new(
         meerkat_runtime::RuntimePeerInteractionHandle::new(Arc::clone(&dsl)),
     );
-    responder.install_peer_interaction_handle(Arc::clone(&handle));
+    responder.install_peer_request_response_authority(PeerRequestResponseAuthority::new(
+        Arc::clone(&handle),
+        Arc::new(meerkat_runtime::RuntimeInteractionStreamHandle::new(
+            Arc::clone(&dsl),
+        )),
+    ));
 
     CoreCommsRuntime::add_trusted_peer(
         responder.as_ref(),
@@ -896,16 +947,20 @@ impl SessionService for ContractSessionService {
             .and_then(|b| b.comms_name.clone())
             .unwrap_or_else(|| format!("contract-session-{}", Uuid::new_v4().simple()));
 
-        let comms = CommsRuntime::inproc_only(&comms_name).map_err(|e| {
+        let comms = Arc::new(CommsRuntime::inproc_only(&comms_name).map_err(|e| {
             SessionError::Agent(meerkat_core::error::AgentError::InternalError(format!(
                 "failed to create comms runtime: {e}"
             )))
-        })?;
+        })?);
+        install_ephemeral_peer_request_response_authority(
+            &comms,
+            &format!("contract-{session_id}"),
+        );
 
         self.sessions
             .write()
             .await
-            .insert(session_id.clone(), Arc::new(comms));
+            .insert(session_id.clone(), comms);
 
         Ok(run_result(session_id, "session created"))
     }

--- a/meerkat-rpc/src/router.rs
+++ b/meerkat-rpc/src/router.rs
@@ -2583,6 +2583,37 @@ mod tests {
         );
     }
 
+    #[cfg(feature = "comms")]
+    fn install_ephemeral_peer_request_response_authority(
+        runtime: &Arc<meerkat::CommsRuntime>,
+        session: &str,
+    ) {
+        let dsl = Arc::new(meerkat_runtime::HandleDslAuthority::ephemeral());
+        dsl.apply_signal(
+            meerkat_runtime::meerkat_machine::dsl::MeerkatMachineSignal::Initialize,
+            "test::initialize",
+        )
+        .expect("Initialize");
+        dsl.apply_input(
+            meerkat_runtime::meerkat_machine::dsl::MeerkatMachineInput::RegisterSession {
+                session_id: meerkat_runtime::meerkat_machine::dsl::SessionId::from(
+                    session.to_string(),
+                ),
+            },
+            "test::register_session",
+        )
+        .expect("RegisterSession");
+
+        runtime.install_peer_request_response_authority(
+            meerkat_comms::PeerRequestResponseAuthority::new(
+                Arc::new(meerkat_runtime::RuntimePeerInteractionHandle::new(
+                    Arc::clone(&dsl),
+                )),
+                Arc::new(meerkat_runtime::RuntimeInteractionStreamHandle::new(dsl)),
+            ),
+        );
+    }
+
     // -----------------------------------------------------------------------
     // Mock LLM client (same as session_runtime tests)
     // -----------------------------------------------------------------------
@@ -4551,6 +4582,7 @@ mod tests {
             meerkat::CommsRuntime::inproc_only("router-peer-response-sender")
                 .expect("sender comms runtime"),
         );
+        install_ephemeral_peer_request_response_authority(&sender, "router-peer-response-sender");
         let sender_peer_id = sender.public_key().to_peer_id().to_string();
         let sender_addr = sender.advertised_address();
         let operator_peer_id = operator_comms.public_key().expect("worker peer id");
@@ -4585,6 +4617,13 @@ mod tests {
         .await
         .expect("worker trusts sender");
 
+        let in_reply_to = InteractionId(uuid::Uuid::new_v4());
+        sender
+            .peer_interaction_handle()
+            .expect("sender peer response authority")
+            .request_received(meerkat_core::PeerCorrelationId::from_uuid(in_reply_to.0))
+            .expect("seed inbound request before terminal peer response");
+
         CoreCommsRuntime::send(
             &*sender,
             CommsCommand::PeerResponse {
@@ -4592,7 +4631,7 @@ mod tests {
                     operator_pubkey.to_peer_id(),
                     PeerName::new(format!("{mob_id}/worker/worker-1")).expect("valid peer name"),
                 ),
-                in_reply_to: InteractionId(uuid::Uuid::new_v4()),
+                in_reply_to,
                 status: meerkat_core::ResponseStatus::Completed,
                 result: serde_json::json!({
                     "request_intent": "checksum_token",

--- a/meerkat-rpc/src/session_runtime.rs
+++ b/meerkat-rpc/src/session_runtime.rs
@@ -4589,6 +4589,37 @@ mod tests {
     use std::pin::Pin;
     use std::sync::Arc;
 
+    #[cfg(feature = "comms")]
+    fn install_ephemeral_peer_request_response_authority(
+        runtime: &Arc<meerkat::CommsRuntime>,
+        session: &str,
+    ) {
+        let dsl = Arc::new(meerkat_runtime::HandleDslAuthority::ephemeral());
+        dsl.apply_signal(
+            meerkat_runtime::meerkat_machine::dsl::MeerkatMachineSignal::Initialize,
+            "test::initialize",
+        )
+        .expect("Initialize");
+        dsl.apply_input(
+            meerkat_runtime::meerkat_machine::dsl::MeerkatMachineInput::RegisterSession {
+                session_id: meerkat_runtime::meerkat_machine::dsl::SessionId::from(
+                    session.to_string(),
+                ),
+            },
+            "test::register_session",
+        )
+        .expect("RegisterSession");
+
+        runtime.install_peer_request_response_authority(
+            meerkat_comms::PeerRequestResponseAuthority::new(
+                Arc::new(meerkat_runtime::RuntimePeerInteractionHandle::new(
+                    Arc::clone(&dsl),
+                )),
+                Arc::new(meerkat_runtime::RuntimeInteractionStreamHandle::new(dsl)),
+            ),
+        );
+    }
+
     #[test]
     fn realtime_open_config_context_comes_from_typed_system_context_state() {
         let mut state = SessionSystemContextState::default();
@@ -5534,6 +5565,7 @@ mod tests {
         let sender = Arc::new(
             meerkat::CommsRuntime::inproc_only("analyst-drain-test").expect("sender comms runtime"),
         );
+        install_ephemeral_peer_request_response_authority(&sender, "analyst-drain-test");
         let sender_public_key = sender.public_key();
         let sender_peer_id = sender_public_key.to_peer_id().to_string();
         let sender_addr = sender.advertised_address();
@@ -5575,6 +5607,13 @@ mod tests {
             .await
             .expect("subscribe_session_events");
 
+        let in_reply_to = InteractionId(uuid::Uuid::new_v4());
+        sender
+            .peer_interaction_handle()
+            .expect("sender peer response authority")
+            .request_received(meerkat_core::PeerCorrelationId::from_uuid(in_reply_to.0))
+            .expect("seed inbound request before terminal peer response");
+
         CoreCommsRuntime::send(
             &*sender,
             CommsCommand::PeerResponse {
@@ -5582,7 +5621,7 @@ mod tests {
                     operator_pubkey.to_peer_id(),
                     PeerName::new(operator_name.to_string()).expect("valid operator peer name"),
                 ),
-                in_reply_to: InteractionId(uuid::Uuid::new_v4()),
+                in_reply_to,
                 status: meerkat_core::ResponseStatus::Completed,
                 result: serde_json::json!({
                     "request_intent": "checksum_token",

--- a/meerkat-runtime/src/comms_drain.rs
+++ b/meerkat-runtime/src/comms_drain.rs
@@ -2122,6 +2122,9 @@ mod tests {
         let supervisor_name = format!("bridge-response-supervisor-{suffix}");
         let member_runtime =
             Arc::new(meerkat_comms::CommsRuntime::inproc_only(&member_name).expect("member"));
+        let supervisor_runtime = Arc::new(
+            meerkat_comms::CommsRuntime::inproc_only(&supervisor_name).expect("supervisor"),
+        );
         let peer_handle = Arc::new(CountingPeerInteractionHandle::default());
         member_runtime.install_peer_request_response_authority(
             meerkat_comms::PeerRequestResponseAuthority::new(
@@ -2130,12 +2133,31 @@ mod tests {
             ),
         );
 
-        let supervisor_spec = TrustedPeerDescriptor::test_only_unsigned_typed(
+        let supervisor_pubkey = supervisor_runtime.public_key();
+        let supervisor_spec = TrustedPeerDescriptor::unsigned_with_pubkey(
             &supervisor_name,
-            PeerId::new(),
+            supervisor_pubkey.to_peer_id().as_str(),
+            *supervisor_pubkey.as_bytes(),
             &format!("inproc://{supervisor_name}"),
         )
         .expect("valid supervisor spec");
+        member_runtime
+            .add_trusted_peer(supervisor_spec.clone())
+            .await
+            .expect("member should trust supervisor");
+
+        let member_pubkey = member_runtime.public_key();
+        let member_spec = TrustedPeerDescriptor::unsigned_with_pubkey(
+            &member_name,
+            member_pubkey.to_peer_id().as_str(),
+            *member_pubkey.as_bytes(),
+            &format!("inproc://{member_name}"),
+        )
+        .expect("valid member spec");
+        supervisor_runtime
+            .add_trusted_peer(member_spec)
+            .await
+            .expect("supervisor should trust member");
 
         let adapter = Arc::new(MeerkatMachine::ephemeral());
         let session_id = SessionId::new();

--- a/meerkat-runtime/src/comms_drain.rs
+++ b/meerkat-runtime/src/comms_drain.rs
@@ -195,16 +195,14 @@ pub fn spawn_comms_drain(
                             // the terminal event to), THEN fire the DSL
                             // terminal transition. The transition emits
                             // `PeerInteractionCleanup`; the observer drops
-                            // the now-idle stream registry entry. If the
-                            // DSL is not installed (standalone / WASM),
-                            // `mark_interaction_complete` below handles
-                            // cleanup; when the DSL IS installed, the
-                            // effect drives cleanup and `mark_interaction_complete`
-                            // becomes a no-op.
+                            // the now-idle stream registry entry. Without a
+                            // peer-interaction handle, this drain path is
+                            // transport-only for lifecycle purposes and does
+                            // not synthesize semantic cleanup.
                             let subscriber = comms_runtime.interaction_subscriber(&interaction_id);
-                            let dsl_installed = comms_runtime.peer_interaction_handle().is_some();
+                            let peer_interaction_handle = comms_runtime.peer_interaction_handle();
                             if let (Some(handle), Some(disposition)) =
-                                (comms_runtime.peer_interaction_handle(), terminal_status)
+                                (peer_interaction_handle.as_ref(), terminal_status)
                             {
                                 let corr_id =
                                     meerkat_core::PeerCorrelationId::from_uuid(interaction_id.0);
@@ -231,8 +229,6 @@ pub fn spawn_comms_drain(
                                             subscriber,
                                             handle,
                                         );
-                                    } else if !dsl_installed {
-                                        comms_runtime.mark_interaction_complete(&interaction_id);
                                     }
                                 }
                                 Err(err) => {
@@ -240,9 +236,6 @@ pub fn spawn_comms_drain(
                                         error = %err,
                                         "comms_drain: failed to inject terminal response"
                                     );
-                                    if !dsl_installed {
-                                        comms_runtime.mark_interaction_complete(&interaction_id);
-                                    }
                                 }
                             }
                         } else {
@@ -865,6 +858,26 @@ async fn resolve_peer_route(
         .map(|entry| PeerRoute::with_display_name(entry.peer_id, entry.name.clone()))
 }
 
+fn record_bridge_inbound_peer_request(
+    comms_runtime: &Arc<dyn CommsRuntime>,
+    candidate: &PeerInputCandidate,
+) {
+    let Some(handle) = comms_runtime.peer_interaction_handle() else {
+        return;
+    };
+    let corr_id = meerkat_core::PeerCorrelationId::from_uuid(candidate.interaction.id.0);
+    if handle.inbound_state(corr_id).is_some() {
+        return;
+    }
+    if let Err(err) = handle.request_received(corr_id) {
+        tracing::warn!(
+            error = %err,
+            corr_id = %corr_id,
+            "PeerInteractionHandle::request_received rejected for supervisor bridge command"
+        );
+    }
+}
+
 async fn send_bridge_failure(
     comms_runtime: &Arc<dyn CommsRuntime>,
     candidate: &PeerInputCandidate,
@@ -908,6 +921,10 @@ async fn try_handle_supervisor_bridge_command(
     if intent != SUPERVISOR_BRIDGE_INTENT {
         return false;
     }
+
+    // Bridge commands are handled before the generic drain branch that records
+    // inbound peer-request state, but their replies are semantic PeerResponses.
+    record_bridge_inbound_peer_request(comms_runtime, candidate);
 
     let command: BridgeCommand = match decode_bridge_command(params.clone()) {
         Ok(cmd) => cmd,
@@ -1773,6 +1790,123 @@ mod tests {
     const PEER_ID_CURRENT_SUPERVISOR: &str = "00000000-0000-0000-0000-00000000cccc"; // "current-supervisor"
     const PEER_ID_OLD_SUPERVISOR: &str = "00000000-0000-0000-0000-00000000dddd"; // "old-supervisor"
 
+    #[derive(Default)]
+    struct CountingPeerInteractionHandle {
+        inbound: std::sync::Mutex<HashSet<meerkat_core::PeerCorrelationId>>,
+        request_received_count: std::sync::atomic::AtomicUsize,
+        response_replied_count: std::sync::atomic::AtomicUsize,
+    }
+
+    impl CountingPeerInteractionHandle {
+        fn rejected(
+            context: &'static str,
+            corr_id: meerkat_core::PeerCorrelationId,
+        ) -> meerkat_core::handles::DslTransitionError {
+            meerkat_core::handles::DslTransitionError::guard_rejected(
+                context,
+                format!("test authority rejected corr_id {corr_id}"),
+            )
+        }
+
+        fn request_received_count(&self) -> usize {
+            self.request_received_count
+                .load(std::sync::atomic::Ordering::SeqCst)
+        }
+
+        fn response_replied_count(&self) -> usize {
+            self.response_replied_count
+                .load(std::sync::atomic::Ordering::SeqCst)
+        }
+    }
+
+    impl meerkat_core::handles::PeerInteractionHandle for CountingPeerInteractionHandle {
+        fn request_sent(
+            &self,
+            _corr_id: meerkat_core::PeerCorrelationId,
+            _to: String,
+        ) -> Result<(), meerkat_core::handles::DslTransitionError> {
+            Ok(())
+        }
+
+        fn response_progress(
+            &self,
+            _corr_id: meerkat_core::PeerCorrelationId,
+        ) -> Result<(), meerkat_core::handles::DslTransitionError> {
+            Ok(())
+        }
+
+        fn response_terminal(
+            &self,
+            _corr_id: meerkat_core::PeerCorrelationId,
+            _disposition: meerkat_core::handles::PeerTerminalDisposition,
+        ) -> Result<(), meerkat_core::handles::DslTransitionError> {
+            Ok(())
+        }
+
+        fn request_timed_out(
+            &self,
+            _corr_id: meerkat_core::PeerCorrelationId,
+        ) -> Result<(), meerkat_core::handles::DslTransitionError> {
+            Ok(())
+        }
+
+        fn request_received(
+            &self,
+            corr_id: meerkat_core::PeerCorrelationId,
+        ) -> Result<(), meerkat_core::handles::DslTransitionError> {
+            let mut inbound = self.inbound.lock().expect("inbound mutex");
+            if !inbound.insert(corr_id) {
+                return Err(Self::rejected(
+                    "PeerInteractionHandle::request_received",
+                    corr_id,
+                ));
+            }
+            self.request_received_count
+                .fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+            Ok(())
+        }
+
+        fn response_replied(
+            &self,
+            corr_id: meerkat_core::PeerCorrelationId,
+        ) -> Result<(), meerkat_core::handles::DslTransitionError> {
+            let mut inbound = self.inbound.lock().expect("inbound mutex");
+            if !inbound.remove(&corr_id) {
+                return Err(Self::rejected(
+                    "PeerInteractionHandle::response_replied",
+                    corr_id,
+                ));
+            }
+            self.response_replied_count
+                .fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+            Ok(())
+        }
+
+        fn outbound_state(
+            &self,
+            _corr_id: meerkat_core::PeerCorrelationId,
+        ) -> Option<meerkat_core::OutboundPeerRequestState> {
+            None
+        }
+
+        fn inbound_state(
+            &self,
+            corr_id: meerkat_core::PeerCorrelationId,
+        ) -> Option<meerkat_core::InboundPeerRequestState> {
+            self.inbound
+                .lock()
+                .expect("inbound mutex")
+                .contains(&corr_id)
+                .then_some(meerkat_core::InboundPeerRequestState::Received)
+        }
+
+        fn install_cleanup_observer(
+            &self,
+            _observer: Arc<dyn meerkat_core::handles::PeerInteractionCleanupObserver>,
+        ) {
+        }
+    }
+
     fn typed_peer_id(raw: &str) -> PeerId {
         PeerId::parse(raw).expect("test peer id must be valid")
     }
@@ -1978,6 +2112,75 @@ mod tests {
         assert_eq!(
             route.display_name.as_ref().map(|name| name.as_str()),
             Some(peer_spec.name.as_str())
+        );
+    }
+
+    #[tokio::test]
+    async fn bridge_response_seeds_inbound_request_before_peer_response_send() {
+        let suffix = Uuid::new_v4().simple().to_string();
+        let member_name = format!("bridge-response-member-{suffix}");
+        let supervisor_name = format!("bridge-response-supervisor-{suffix}");
+        let member_runtime =
+            Arc::new(meerkat_comms::CommsRuntime::inproc_only(&member_name).expect("member"));
+        let peer_handle = Arc::new(CountingPeerInteractionHandle::default());
+        member_runtime.install_peer_request_response_authority(
+            meerkat_comms::PeerRequestResponseAuthority::new(
+                peer_handle.clone(),
+                Arc::new(crate::handles::RuntimeInteractionStreamHandle::ephemeral()),
+            ),
+        );
+
+        let supervisor_spec = TrustedPeerDescriptor::test_only_unsigned_typed(
+            &supervisor_name,
+            PeerId::new(),
+            &format!("inproc://{supervisor_name}"),
+        )
+        .expect("valid supervisor spec");
+
+        let adapter = Arc::new(MeerkatMachine::ephemeral());
+        let session_id = SessionId::new();
+        adapter.register_session(session_id.clone()).await;
+        adapter
+            .stage_supervisor_bind(
+                &session_id,
+                supervisor_spec.name.to_string(),
+                supervisor_spec.peer_id.as_str(),
+                supervisor_spec.address.to_string(),
+                1,
+            )
+            .await
+            .expect("pre-bind supervisor");
+        let command = BridgeCommand::ObserveMember(BridgeSupervisorPayload {
+            supervisor: BridgePeerSpec::from(supervisor_spec.clone()),
+            epoch: 1,
+            protocol_version: SUPERVISOR_BRIDGE_PROTOCOL_VERSION,
+        });
+        let candidate = bridge_candidate_with_typed_sender(
+            supervisor_spec.name.as_str(),
+            Some(supervisor_spec.peer_id),
+            &command,
+        );
+
+        assert!(
+            try_handle_supervisor_bridge_command(
+                &adapter,
+                &session_id,
+                &(member_runtime.clone() as Arc<dyn CommsRuntime>),
+                &candidate,
+            )
+            .await,
+            "bridge handler must own ObserveMember"
+        );
+
+        assert_eq!(
+            peer_handle.request_received_count(),
+            1,
+            "bridge handler must seed inbound peer request state before replying"
+        );
+        assert_eq!(
+            peer_handle.response_replied_count(),
+            1,
+            "real CommsRuntime::send(PeerResponse) should pass the inbound-state guard"
         );
     }
 

--- a/meerkat-runtime/src/handles/interaction_stream.rs
+++ b/meerkat-runtime/src/handles/interaction_stream.rs
@@ -63,8 +63,8 @@ impl RuntimeInteractionStreamHandle {
         }
     }
 
-    /// Construct a handle backed by an ephemeral DSL authority (tests / WASM /
-    /// standalone fallback).
+    /// Construct a handle backed by an ephemeral DSL authority for tests and
+    /// minimal hosts that explicitly opt into machine-owned semantics.
     pub fn ephemeral() -> Self {
         Self::new(Arc::new(HandleDslAuthority::ephemeral()))
     }

--- a/meerkat-runtime/src/handles/mod.rs
+++ b/meerkat-runtime/src/handles/mod.rs
@@ -80,8 +80,8 @@ pub use turn_state::RuntimeTurnStateHandle;
 /// authority.
 ///
 /// A standalone ephemeral constructor ([`HandleDslAuthority::ephemeral`]) is
-/// also provided for legacy code paths (recovery fallback, test sites) that
-/// do not yet have a session-owned DSL authority to share. Ephemeral
+/// also provided for tests and minimal hosts that explicitly need
+/// machine-owned semantics without a durable session authority. Ephemeral
 /// authorities do not synchronize with any other state; transitions land on a
 /// private initial DSL state only.
 pub struct HandleDslAuthority {

--- a/meerkat-runtime/src/meerkat_machine/dispatch_session.rs
+++ b/meerkat-runtime/src/meerkat_machine/dispatch_session.rs
@@ -143,19 +143,15 @@ impl MeerkatMachine {
                         &shared_handle_authority,
                     )),
                 ),
-                peer_interaction: Some(Arc::new(
-                    crate::handles::RuntimePeerInteractionHandle::new(Arc::clone(
-                        &shared_handle_authority,
-                    )),
+                peer_interaction: Arc::new(crate::handles::RuntimePeerInteractionHandle::new(
+                    Arc::clone(&shared_handle_authority),
                 )),
                 session_context: Arc::new(crate::handles::RuntimeSessionContextHandle::new(
                     Arc::clone(&shared_handle_authority),
                 )),
                 session_claim_handle: self.session_claim_handle(),
-                interaction_stream: Some(Arc::new(
-                    crate::handles::RuntimeInteractionStreamHandle::new(Arc::clone(
-                        &shared_handle_authority,
-                    )),
+                interaction_stream: Arc::new(crate::handles::RuntimeInteractionStreamHandle::new(
+                    Arc::clone(&shared_handle_authority),
                 )),
                 realtime_product_turn: Arc::new(
                     crate::handles::RuntimeRealtimeProductTurnHandle::new(Arc::clone(

--- a/meerkat-runtime/tests/meerkat_machine.rs
+++ b/meerkat-runtime/tests/meerkat_machine.rs
@@ -936,12 +936,7 @@ async fn runtime_comms_terminal_response_wake_drains_requester_queue() {
         .await
         .expect("prepare runtime bindings");
     requester_comms.install_peer_comms_handle(Arc::clone(&bindings.peer_comms));
-    requester_comms.install_peer_interaction_handle(
-        bindings
-            .peer_interaction
-            .clone()
-            .expect("runtime bindings include peer interaction handle"),
-    );
+    requester_comms.install_peer_interaction_handle(Arc::clone(&bindings.peer_interaction));
 
     let calls = Arc::new(AtomicUsize::new(0));
     let first_apply_started = Arc::new(Notify::new());

--- a/meerkat-session/src/persistent.rs
+++ b/meerkat-session/src/persistent.rs
@@ -2367,11 +2367,13 @@ mod tests {
             mcp_server_lifecycle: Arc::new(
                 meerkat_runtime::RuntimeMcpServerLifecycleHandle::ephemeral(),
             ),
-            peer_interaction: None,
+            peer_interaction: Arc::new(meerkat_runtime::RuntimePeerInteractionHandle::ephemeral()),
             session_context: Arc::new(meerkat_runtime::RuntimeSessionContextHandle::ephemeral()),
             session_claim_handle: meerkat_core::handles::DefaultSessionClaimRegistry::global()
                 as Arc<dyn meerkat_core::handles::SessionClaimHandle>,
-            interaction_stream: None,
+            interaction_stream: Arc::new(
+                meerkat_runtime::RuntimeInteractionStreamHandle::ephemeral(),
+            ),
             realtime_product_turn: Arc::new(
                 meerkat_runtime::RuntimeRealtimeProductTurnHandle::ephemeral(),
             ),

--- a/meerkat/src/factory.rs
+++ b/meerkat/src/factory.rs
@@ -3180,26 +3180,16 @@ impl AgentFactory {
             if let Some(runtime) = &comms_runtime {
                 runtime.install_peer_comms_handle(Arc::clone(&bindings.peer_comms));
             }
-            // W1-A: install the peer-interaction DSL handle on the session's
-            // comms runtime so outbound PeerRequest sends record into
-            // `pending_peer_requests` and `comms_drain` fires response
-            // progress / terminal transitions.
+            // W1-A/U6: install the typed machine authority required before
+            // comms can emit semantic peer request/response receipts.
             #[cfg(feature = "comms")]
-            if let (Some(runtime), Some(handle)) =
-                (&comms_runtime, bindings.peer_interaction.as_ref())
-            {
-                runtime.install_peer_interaction_handle(Arc::clone(handle));
-            }
-            // U6 (dogma #5): install the interaction-stream DSL handle so the
-            // shell-side `interaction_stream_registry` becomes a pure
-            // projection of DSL truth — `Reserved` / `Attached` / `Completed`
-            // / `Expired` / `ClosedEarly` lifecycle and the cleanup observer
-            // both flow through the DSL.
-            #[cfg(feature = "comms")]
-            if let (Some(runtime), Some(handle)) =
-                (&comms_runtime, bindings.interaction_stream.as_ref())
-            {
-                runtime.install_interaction_stream_handle(Arc::clone(handle));
+            if let Some(runtime) = &comms_runtime {
+                runtime.install_peer_request_response_authority(
+                    meerkat_comms::PeerRequestResponseAuthority::new(
+                        Arc::clone(&bindings.peer_interaction),
+                        Arc::clone(&bindings.interaction_stream),
+                    ),
+                );
             }
         }
 

--- a/tests/integration/tests/reserve_interaction_subscriber_fires.rs
+++ b/tests/integration/tests/reserve_interaction_subscriber_fires.rs
@@ -27,8 +27,14 @@ use meerkat_core::PeerInputClass;
 use meerkat_core::agent::CommsRuntime as CoreCommsRuntime;
 use meerkat_core::comms::{CommsCommand, InputStreamMode, PeerName, PeerRoute, SendReceipt};
 use meerkat_core::{
-    ClassifiedInboxInteraction, HandlingMode, InteractionContent, InteractionId, ResponseStatus,
+    ClassifiedInboxInteraction, HandlingMode, InteractionContent, InteractionId, PeerCorrelationId,
+    ResponseStatus,
 };
+use meerkat_runtime::handles::{
+    HandleDslAuthority, RuntimeInteractionStreamHandle, RuntimePeerInteractionHandle,
+};
+use meerkat_runtime::meerkat_machine::dsl as mm_dsl;
+use std::sync::Arc;
 use uuid::Uuid;
 
 #[tokio::test]
@@ -40,6 +46,8 @@ async fn reserve_interaction_subscriber_fires_on_matching_response() {
     let (a, b) = CommsRuntime::inproc_pair_with_mutual_trust(&name_a, &name_b)
         .await
         .expect("inproc pair with mutual trust");
+    install_ephemeral_peer_request_response_authority(&a, &format!("authority-a-{suffix}"));
+    install_ephemeral_peer_request_response_authority(&b, &format!("authority-b-{suffix}"));
 
     // 1. A sends a reserved-stream PeerRequest to B.
     let receipt = CoreCommsRuntime::send(
@@ -92,6 +100,10 @@ async fn reserve_interaction_subscriber_fires_on_matching_response() {
         InteractionId(envelope_id),
         "request envelope id at B must equal A's send receipt envelope id",
     );
+    b.peer_interaction_handle()
+        .expect("B should have explicit peer interaction authority")
+        .request_received(PeerCorrelationId::from_uuid(envelope_id))
+        .expect("direct comms-drain bypass must seed inbound request state");
 
     let _response_receipt = CoreCommsRuntime::send(
         b.as_ref(),
@@ -146,6 +158,26 @@ async fn reserve_interaction_subscriber_fires_on_matching_response() {
     );
     let second = CoreCommsRuntime::interaction_subscriber(a.as_ref(), &InteractionId(envelope_id));
     assert!(second.is_none(), "subscriber should be one-shot");
+}
+
+fn install_ephemeral_peer_request_response_authority(runtime: &Arc<CommsRuntime>, session: &str) {
+    let dsl = Arc::new(HandleDslAuthority::ephemeral());
+    dsl.apply_signal(mm_dsl::MeerkatMachineSignal::Initialize, "test::initialize")
+        .expect("Initialize signal");
+    dsl.apply_input(
+        mm_dsl::MeerkatMachineInput::RegisterSession {
+            session_id: mm_dsl::SessionId::from(session.to_string()),
+        },
+        "test::register_session",
+    )
+    .expect("RegisterSession input");
+
+    runtime.install_peer_request_response_authority(
+        meerkat_comms::PeerRequestResponseAuthority::new(
+            Arc::new(RuntimePeerInteractionHandle::new(Arc::clone(&dsl))),
+            Arc::new(RuntimeInteractionStreamHandle::new(dsl)),
+        ),
+    );
 }
 
 async fn drain_until_nonempty(


### PR DESCRIPTION
## Summary
- make comms peer request/response sends fail closed without machine authority
- separate transport-only local stream cleanup from semantic peer lifecycle ownership
- install explicit ephemeral/session authority in mob supervisor bridge, RPC, integration, and contract test hosts

## Testing
- ./scripts/repo-cargo test -p meerkat-comms transport_only_ -- --nocapture
- ./scripts/repo-cargo test -p meerkat-mob contract_mob_002 -- --nocapture
- make lint
- make test

Linear: LUC-164