### PR TITLE
Update skills documentation

### DIFF
--- a/.claude/skills/meerkat-platform/SKILL.md
+++ b/.claude/skills/meerkat-platform/SKILL.md
@@ -637,7 +637,7 @@ Canonical skill identity is `SkillKey { source_uuid, skill_name }`. `preload_ski
 - CLI: `rkat skill list [--json]`, `rkat skill inspect <skill-name> --source-uuid <uuid> [--json]`
 - RPC: `skills/list`
 - REST: `GET /skills`
-- MCP: `meerkat_skills` tool (`action: "list"`)
+- MCP: `meerkat_skills` tool (`action: "list"` or `"inspect"` with typed `skill_key` and optional `source` UUID)
 - Rust SDK: `SkillRuntime::list_all_with_provenance()`, `SkillRuntime::load_from_source()`
 
 Introspection returns typed keys plus source provenance. Shadowing is by full `SkillKey`, not by `skill_name` alone. Agent-facing skill tools (`browse_skills`, `load_skill`, resource tools, function invocation) also use `source_uuid` + `skill_name`.

--- a/.claude/skills/meerkat-platform/SKILL.md
+++ b/.claude/skills/meerkat-platform/SKILL.md
@@ -628,17 +628,19 @@ Key types: `PersistedOpsSnapshot`, `EpochCursorState`, `EpochCursorSnapshot`. Re
 
 ### Skills
 
-Skill loading is runtime-root aware. Workspace realms use project `.rkat/skills`; non-workspace realms use realm runtime roots.
+Skill loading is runtime-root aware. Workspace realms can discover project `.rkat/skills`; non-workspace realms use realm runtime roots and configured repositories.
 
-**Skill introspection** surfaces are available on all surfaces:
+Canonical skill identity is `SkillKey { source_uuid, skill_name }`. `preload_skills` carries plain `SkillKey` objects; API `skill_refs` carries tagged `SkillRef` objects (`kind: "structured"`, `source_uuid`, `skill_name`). Do not describe slash-delimited skill IDs as a public wire format.
 
-- CLI: `rkat skill list [--json]`, `rkat skill inspect <id> [--source <name>] [--json]`
-- RPC: `skills/list`, `skills/inspect`
-- REST: `GET /skills`, `GET /skills/{id}`
-- MCP: `meerkat_skills` tool (`action: "list"` / `"inspect"`)
+**Skill introspection** surfaces:
+
+- CLI: `rkat skill list [--json]`, `rkat skill inspect <skill-name> --source-uuid <uuid> [--json]`
+- RPC: `skills/list`
+- REST: `GET /skills`
+- MCP: `meerkat_skills` tool (`action: "list"`)
 - Rust SDK: `SkillRuntime::list_all_with_provenance()`, `SkillRuntime::load_from_source()`
 
-Introspection returns both active and shadowed skills with their source provenance, enabling debugging of skill resolution order.
+Introspection returns typed keys plus source provenance. Shadowing is by full `SkillKey`, not by `skill_name` alone. Agent-facing skill tools (`browse_skills`, `load_skill`, resource tools, function invocation) also use `source_uuid` + `skill_name`.
 
 ### Hooks
 

--- a/.claude/skills/meerkat-platform/references/api_reference.md
+++ b/.claude/skills/meerkat-platform/references/api_reference.md
@@ -250,7 +250,7 @@ Core tools:
 - `meerkat_config` — get/set/patch config
 - `meerkat_capabilities` — list runtime capabilities
 - `meerkat_models_catalog` — curated model catalog with provider profiles
-- `meerkat_skills` — list skills (`action: "list"`)
+- `meerkat_skills` — list skills (`action: "list"`) or inspect one skill (`action: "inspect"`, typed `skill_key`, optional `source` UUID)
 - `meerkat_mcp_add` — stage live MCP server add
 - `meerkat_mcp_remove` — stage live MCP server remove
 - `meerkat_mcp_reload` — stage live MCP server reload
@@ -305,7 +305,7 @@ Client methods:
 - `list_mobs()` → `list[MobSummary]`
 - `get_config()` / `set_config(...)` / `patch_config(...)`
 - `mcp_add(params)` / `mcp_remove(params)` / `mcp_reload(params)`
-- `list_skills()` / `inspect_skill(id, source?)`
+- `list_skills()`
 - `capabilities` (property, populated during `connect()`)
 
 Session methods:
@@ -371,7 +371,7 @@ Client methods:
 - `listMobs()` → `MobSummary[]`
 - `getConfig()` / `setConfig(...)` / `patchConfig(...)`
 - `mcpAdd(params)` / `mcpRemove(params)` / `mcpReload(params)`
-- `listSkills()` / `inspectSkill(id, options?)`
+- `listSkills()`
 - `capabilities` (property, populated during `connect()`)
 
 Session methods:

--- a/.claude/skills/meerkat-platform/references/api_reference.md
+++ b/.claude/skills/meerkat-platform/references/api_reference.md
@@ -61,7 +61,7 @@ rkat comms send <SESSION-ID> --json <JSON>        # (comms feature)
 rkat comms peers <SESSION-ID>                     # (comms feature)
 rkat realm current|list|show
 rkat skill list [--json]
-rkat skill inspect <ID> [--source <SOURCE>] [--json]
+rkat skill inspect <skill-name> --source-uuid <uuid> [--json]
 rkat models [--json]
 rkat mob create|list|status|spawn|retire|respawn|wire|unwire|turn|stop|resume|complete|flows|run-flow|flow-status|events|destroy|pack|inspect|validate|deploy|web
 rkat config get|set|patch ...
@@ -136,7 +136,6 @@ Core endpoints:
 - `POST /sessions/{id}/event` — (legacy) push external event
 - `POST /requests/{request_id}/cancel` — cancel uncommitted in-flight work when `X-Meerkat-Request-Id` is supplied
 - `GET /skills` — list skills with provenance
-- `GET /skills/{id}` — inspect a skill's full body
 - `GET /health`
 - `GET /models/catalog` — curated model catalog with provider profiles
 - `GET /capabilities`
@@ -201,7 +200,6 @@ Core methods:
 - `config/set`
 - `config/patch`
 - `skills/list` — list skills with provenance (active + shadowed)
-- `skills/inspect` — inspect a skill's full body by ID
 - `models/catalog` — curated model catalog with provider profiles
 - `capabilities/get`
 - `mcp/add` — stage live MCP server add for a session
@@ -252,7 +250,7 @@ Core tools:
 - `meerkat_config` — get/set/patch config
 - `meerkat_capabilities` — list runtime capabilities
 - `meerkat_models_catalog` — curated model catalog with provider profiles
-- `meerkat_skills` — list (`action: "list"`) or inspect (`action: "inspect"`, `skill_id: "..."`) skills
+- `meerkat_skills` — list skills (`action: "list"`)
 - `meerkat_mcp_add` — stage live MCP server add
 - `meerkat_mcp_remove` — stage live MCP server remove
 - `meerkat_mcp_reload` — stage live MCP server reload
@@ -439,7 +437,7 @@ let mut agent = factory.build_agent(build, &config).await?;
 
 `AgentBuildConfig` also carries:
 - `silent_comms_intents: Vec<String>` — intents injected silently (no LLM turn)
-- `preload_skills: Option<Vec<SkillId>>` — skills to inject at session creation
+- `preload_skills: Option<Vec<SkillKey>>` — skills to inject at session creation
 - `runtime_build_mode: RuntimeBuildMode` — required, determines ops lifecycle ownership
 
 ### Runtime build mode

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -226,7 +226,6 @@ The RPC server speaks JSON-RPC 2.0 over newline-delimited JSON (JSONL) on stdin/
 | `comms/send` | Push external event into session (comms feature) |
 | `comms/peers` | List discoverable peers (comms feature) |
 | `skills/list` | List skills with provenance |
-| `skills/inspect` | Inspect a skill's full content |
 | `mcp/add` | Stage live MCP server addition |
 | `mcp/remove` | Stage live MCP server removal |
 | `mcp/reload` | Reload one or all MCP servers |

--- a/docs/api/mcp.mdx
+++ b/docs/api/mcp.mdx
@@ -47,7 +47,7 @@ second surface-local execution loop.
 | `meerkat_config` | Get or update server config |
 | `meerkat_capabilities` | Query runtime capabilities |
 | `meerkat_models_catalog` | List available models with provider profiles and capabilities |
-| `meerkat_skills` | List available skills |
+| `meerkat_skills` | List or inspect available skills |
 | `meerkat_schedule_*` tools | Agent-facing schedule create/get/list/update/pause/resume/delete/occurrences tools |
 | `meerkat_mcp_add` | Stage a live MCP server addition on an active session |
 | `meerkat_mcp_remove` | Stage a live MCP server removal on an active session |
@@ -694,11 +694,33 @@ No parameters required. The catalog is resolved from built-in model metadata plu
 
 ### meerkat_skills
 
-List available skills with provenance information.
+List available skills with provenance information, or inspect one skill's full
+body by typed `SkillKey`.
 
 <CodeGroup>
 ```json List all skills
 { "action": "list" }
+```
+
+```json Inspect a skill
+{
+  "action": "inspect",
+  "skill_key": {
+    "source_uuid": "00000000-0000-4b11-8111-000000000001",
+    "skill_name": "task-workflow"
+  }
+}
+```
+
+```json Inspect a specific source
+{
+  "action": "inspect",
+  "skill_key": {
+    "source_uuid": "00000000-0000-4b11-8111-000000000001",
+    "skill_name": "task-workflow"
+  },
+  "source": "00000000-0000-4b11-8111-000000000001"
+}
 ```
 
 ```json List response
@@ -724,10 +746,43 @@ List available skills with provenance information.
   ]
 }
 ```
+
+```json Inspect response
+{
+  "key": {
+    "source_uuid": "00000000-0000-4b11-8111-000000000001",
+    "skill_name": "task-workflow"
+  },
+  "name": "Task Workflow",
+  "description": "How to use task tools",
+  "scope": "builtin",
+  "source": {
+    "source_uuid": "00000000-0000-4b11-8111-000000000001",
+    "display_name": "embedded",
+    "transport_kind": "embedded",
+    "fingerprint": "embedded:inventory",
+    "status": "active"
+  },
+  "body": "# Task Workflow\n\n..."
+}
+```
 </CodeGroup>
 
 <ParamField body="action" type="string" required>
-  `"list"` to list all skills.
+  `"list"` to list all skills, or `"inspect"` to load one skill's full body.
 </ParamField>
 
-The list response includes both active and shadowed skills. Shadowed skills have `is_active: false` and a `shadowed_by` field indicating which source has precedence.
+<ParamField body="skill_key" type="object">
+  Required for `inspect`. The typed skill identity with `source_uuid` and
+  `skill_name` fields.
+</ParamField>
+
+<ParamField body="source" type="string">
+  Optional source UUID selector for `inspect`; omit it to load the canonical
+  source for `skill_key`.
+</ParamField>
+
+The list response includes both active and shadowed skills. Shadowed skills have
+`is_active: false` and a `shadowed_by` field indicating which source has
+precedence. Inspect canonicalizes `skill_key` through the identity registry
+before loading the body.

--- a/docs/api/mcp.mdx
+++ b/docs/api/mcp.mdx
@@ -47,7 +47,7 @@ second surface-local execution loop.
 | `meerkat_config` | Get or update server config |
 | `meerkat_capabilities` | Query runtime capabilities |
 | `meerkat_models_catalog` | List available models with provider profiles and capabilities |
-| `meerkat_skills` | List or inspect available skills |
+| `meerkat_skills` | List available skills |
 | `meerkat_schedule_*` tools | Agent-facing schedule create/get/list/update/pause/resume/delete/occurrences tools |
 | `meerkat_mcp_add` | Stage a live MCP server addition on an active session |
 | `meerkat_mcp_remove` | Stage a live MCP server removal on an active session |
@@ -694,53 +694,40 @@ No parameters required. The catalog is resolved from built-in model metadata plu
 
 ### meerkat_skills
 
-List or inspect available skills with provenance information.
+List available skills with provenance information.
 
 <CodeGroup>
 ```json List all skills
 { "action": "list" }
 ```
 
-```json Inspect a specific skill
-{
-  "action": "inspect",
-  "skill_id": "task-workflow"
-}
-```
-
 ```json List response
 {
   "skills": [
     {
-      "id": "task-workflow",
+      "key": {
+        "source_uuid": "00000000-0000-4b11-8111-000000000001",
+        "skill_name": "task-workflow"
+      },
       "name": "Task Workflow",
       "description": "How to use task tools",
       "scope": "builtin",
-      "source": "embedded",
+      "source": {
+        "source_uuid": "00000000-0000-4b11-8111-000000000001",
+        "display_name": "embedded",
+        "transport_kind": "embedded",
+        "fingerprint": "embedded:inventory",
+        "status": "active"
+      },
       "is_active": true
     }
   ]
 }
 ```
-
-```json Inspect response
-{
-  "id": "task-workflow",
-  "name": "Task Workflow",
-  "description": "How to use task tools",
-  "scope": "builtin",
-  "source": "embedded",
-  "body": "# Task Workflow\n\nUse task_create to..."
-}
-```
 </CodeGroup>
 
 <ParamField body="action" type="string" required>
-  `"list"` to list all skills, `"inspect"` to inspect a specific skill.
-</ParamField>
-
-<ParamField body="skill_id" type="string">
-  Skill ID to inspect (required when `action` is `"inspect"`).
+  `"list"` to list all skills.
 </ParamField>
 
 The list response includes both active and shadowed skills. Shadowed skills have `is_active: false` and a `shadowed_by` field indicating which source has precedence.

--- a/docs/api/rest.mdx
+++ b/docs/api/rest.mdx
@@ -683,21 +683,38 @@ List all skills with provenance information. Returns active and shadowed entries
 {
   "skills": [
     {
-      "id": "task-workflow",
+      "key": {
+        "source_uuid": "00000000-0000-4b11-8111-000000000001",
+        "skill_name": "task-workflow"
+      },
       "name": "Task Workflow",
       "description": "How to use task tools",
       "scope": "builtin",
-      "source": "embedded",
+      "source": {
+        "source_uuid": "00000000-0000-4b11-8111-000000000001",
+        "display_name": "embedded",
+        "transport_kind": "embedded",
+        "fingerprint": "embedded:inventory",
+        "status": "active"
+      },
       "is_active": true
     },
     {
-      "id": "task-workflow",
+      "key": {
+        "source_uuid": "dc256086-0d2f-4f61-a307-320d4148107f",
+        "skill_name": "task-workflow"
+      },
       "name": "Custom Task Workflow",
       "description": "Override tasks",
       "scope": "project",
-      "source": "company",
-      "is_active": false,
-      "shadowed_by": "embedded"
+      "source": {
+        "source_uuid": "dc256086-0d2f-4f61-a307-320d4148107f",
+        "display_name": "company",
+        "transport_kind": "git",
+        "fingerprint": "repo-7cc66f36fd9db1a1",
+        "status": "active"
+      },
+      "is_active": true
     }
   ]
 }

--- a/docs/api/rpc.mdx
+++ b/docs/api/rpc.mdx
@@ -620,7 +620,7 @@ Returns the same result shape as `session/create`. Fails with error code `-32001
 </ParamField>
 
 <ParamField body="skill_refs" type="object[] | null">
-  Structured skill references to resolve and inject for this turn.
+  Tagged structured skill references to resolve and inject for this turn. Each entry uses `{"kind":"structured","source_uuid":"...","skill_name":"..."}`.
 </ParamField>
 
 ### turn/interrupt
@@ -832,14 +832,7 @@ List all skills with provenance information, including active and shadowed entri
           "fingerprint": "repo-7cc66f36fd9db1a1",
           "status": "active"
         },
-        "is_active": false,
-        "shadowed_by": {
-          "source_uuid": "00000000-0000-4b11-8111-000000000001",
-          "display_name": "embedded",
-          "transport_kind": "embedded",
-          "fingerprint": "embedded:inventory",
-          "status": "active"
-        }
+        "is_active": true
       }
     ]
   }

--- a/docs/cli/commands.mdx
+++ b/docs/cli/commands.mdx
@@ -339,7 +339,7 @@ rkat skill add <PATH_OR_ID> [--name <NAME>]
 rkat skill remove <NAME_OR_ID_OR_PATH>
 rkat skill get <NAME_OR_ID_OR_PATH> [--json]
 rkat skill list [--json]
-rkat skill inspect <ID> [--source <SOURCE>] [--json]
+rkat skill inspect <skill-name> --source-uuid <uuid> [--json]
 ```
 
 ## models

--- a/docs/examples/skills.mdx
+++ b/docs/examples/skills.mdx
@@ -97,6 +97,21 @@ View the full body and metadata of a specific skill by canonical key.
       --json
     ```
   </Tab>
+  <Tab title="MCP">
+    ```json
+    {
+      "name": "meerkat_skills",
+      "arguments": {
+        "action": "inspect",
+        "skill_key": {
+          "source_uuid": "00000000-0000-4b11-8111-000000000001",
+          "skill_name": "task-workflow"
+        },
+        "source": "00000000-0000-4b11-8111-000000000001"
+      }
+    }
+    ```
+  </Tab>
   <Tab title="Rust">
     ```rust
     let key = SkillKey::new(

--- a/docs/examples/skills.mdx
+++ b/docs/examples/skills.mdx
@@ -11,7 +11,7 @@ Recommended progression on this page:
 1. discover skills
 2. inspect a skill
 3. preload skills for a session
-4. inject typed skills at session start if you need explicit canonical references
+4. inject typed skills for the first turn if you do not want a session-level preload
 5. inject skills for one specific turn
 </Note>
 
@@ -55,14 +55,16 @@ Discover all skills from every source (project, user, filesystem, git, HTTP, std
     ```python
     skills = await client.list_skills()
     for s in skills:
-        print(f"{s.id}: {s.name} (source={s.source})")
+        key = s["key"]
+        print(f"{key['source_uuid']}/{key['skill_name']}: {s['name']}")
     ```
   </Tab>
   <Tab title="TypeScript">
     ```typescript
     const skills = await client.listSkills();
     for (const s of skills) {
-      console.log(`${s.id}: ${s.name} (source=${s.source})`);
+      const key = s.key as { source_uuid: string; skill_name: string };
+      console.log(`${key.source_uuid}/${key.skill_name}: ${s.name}`);
     }
     ```
   </Tab>
@@ -72,7 +74,7 @@ Discover all skills from every source (project, user, filesystem, git, HTTP, std
         .list_all_with_provenance(&SkillFilter::default())
         .await?;
     for entry in &entries {
-        println!("{}: active={}", entry.descriptor.id, entry.is_active);
+        println!("{}: active={}", entry.descriptor.key, entry.is_active);
     }
     ```
   </Tab>
@@ -80,43 +82,29 @@ Discover all skills from every source (project, user, filesystem, git, HTTP, std
 
 ## Inspect a skill
 
-View the full body and metadata of a specific skill. Use `--source` to inspect a shadowed version.
+View the full body and metadata of a specific skill by canonical key.
 
 <Tabs>
   <Tab title="CLI">
     ```bash
     # Inspect the active version
-    rkat skill inspect task-workflow
+    rkat skill inspect task-workflow \
+      --source-uuid 00000000-0000-4b11-8111-000000000001
 
-    # Inspect a shadowed version from a specific source
-    rkat skill inspect task-workflow --source company --json
-    ```
-  </Tab>
-  <Tab title="REST">
-    ```bash
-    # Active version
-    curl http://127.0.0.1:8080/skills/task-workflow
-
-    # From a specific source
-    curl http://127.0.0.1:8080/skills/task-workflow?source=company
-    ```
-  </Tab>
-  <Tab title="MCP">
-    ```json
-    {
-      "name": "meerkat_skills",
-      "arguments": {
-        "action": "inspect",
-        "skill_id": "task-workflow",
-        "source": "company"
-      }
-    }
+    # JSON output
+    rkat skill inspect task-workflow \
+      --source-uuid 00000000-0000-4b11-8111-000000000001 \
+      --json
     ```
   </Tab>
   <Tab title="Rust">
     ```rust
+    let key = SkillKey::new(
+        SourceUuid::parse("00000000-0000-4b11-8111-000000000001")?,
+        SkillName::parse("task-workflow")?,
+    );
     let doc = skill_runtime
-        .load_from_source(&"task-workflow".into(), Some("company"))
+        .load_from_source(&key, Some("00000000-0000-4b11-8111-000000000001"))
         .await?;
     println!("{}", doc.body);
     ```
@@ -144,7 +132,16 @@ Use this when the skill should shape the whole session from the start.
       "method": "session/create",
       "params": {
         "prompt": "Extract emails",
-        "preload_skills": ["email-extractor", "markdown-formatter"]
+        "preload_skills": [
+          {
+            "source_uuid": "dc256086-0d2f-4f61-a307-320d4148107f",
+            "skill_name": "email-extractor"
+          },
+          {
+            "source_uuid": "dc256086-0d2f-4f61-a307-320d4148107f",
+            "skill_name": "markdown-formatter"
+          }
+        ]
       }
     }
     ```
@@ -155,7 +152,16 @@ Use this when the skill should shape the whole session from the start.
       -H "Content-Type: application/json" \
       -d '{
         "prompt": "Extract emails",
-        "preload_skills": ["email-extractor", "markdown-formatter"]
+        "preload_skills": [
+          {
+            "source_uuid": "dc256086-0d2f-4f61-a307-320d4148107f",
+            "skill_name": "email-extractor"
+          },
+          {
+            "source_uuid": "dc256086-0d2f-4f61-a307-320d4148107f",
+            "skill_name": "markdown-formatter"
+          }
+        ]
       }'
     ```
   </Tab>
@@ -165,23 +171,52 @@ Use this when the skill should shape the whole session from the start.
       "name": "meerkat_run",
       "arguments": {
         "prompt": "Extract emails",
-        "preload_skills": ["email-extractor", "markdown-formatter"]
+        "preload_skills": [
+          {
+            "source_uuid": "dc256086-0d2f-4f61-a307-320d4148107f",
+            "skill_name": "email-extractor"
+          },
+          {
+            "source_uuid": "dc256086-0d2f-4f61-a307-320d4148107f",
+            "skill_name": "markdown-formatter"
+          }
+        ]
       }
     }
     ```
   </Tab>
   <Tab title="Python">
     ```python
+    from meerkat import SkillKey
+
     result = await client.create_session(
         "Extract emails",
-        preload_skills=["email-extractor", "markdown-formatter"],
+        preload_skills=[
+            SkillKey(
+                source_uuid="dc256086-0d2f-4f61-a307-320d4148107f",
+                skill_name="email-extractor",
+            ),
+            SkillKey(
+                source_uuid="dc256086-0d2f-4f61-a307-320d4148107f",
+                skill_name="markdown-formatter",
+            ),
+        ],
     )
     ```
   </Tab>
   <Tab title="TypeScript">
     ```typescript
     const result = await client.createSession("Extract emails", {
-      preloadSkills: ["email-extractor", "markdown-formatter"],
+      preloadSkills: [
+        {
+          sourceUuid: "dc256086-0d2f-4f61-a307-320d4148107f",
+          skillName: "email-extractor",
+        },
+        {
+          sourceUuid: "dc256086-0d2f-4f61-a307-320d4148107f",
+          skillName: "markdown-formatter",
+        },
+      ],
     });
     ```
   </Tab>
@@ -189,8 +224,14 @@ Use this when the skill should shape the whole session from the start.
     ```rust
     let build_opts = SessionBuildOptions {
         preload_skills: Some(vec![
-            "email-extractor".into(),
-            "markdown-formatter".into(),
+            SkillKey::new(
+                SourceUuid::parse("dc256086-0d2f-4f61-a307-320d4148107f")?,
+                SkillName::parse("email-extractor")?,
+            ),
+            SkillKey::new(
+                SourceUuid::parse("dc256086-0d2f-4f61-a307-320d4148107f")?,
+                SkillName::parse("markdown-formatter")?,
+            ),
         ]),
         ..Default::default()
     };
@@ -198,9 +239,9 @@ Use this when the skill should shape the whole session from the start.
   </Tab>
 </Tabs>
 
-## Typed session-start injection
+## First-turn skill injection
 
-Use this when you want explicit canonical `SkillKey` references at session start rather than preload-by-id behavior.
+Use `skill_refs` when the skill should be injected for the first turn rather than preloaded into the session system prompt.
 
 <Tabs>
   <Tab title="JSON-RPC">
@@ -212,10 +253,12 @@ Use this when you want explicit canonical `SkillKey` references at session start
         "prompt": "Extract emails",
         "skill_refs": [
           {
+            "kind": "structured",
             "source_uuid": "dc256086-0d2f-4f61-a307-320d4148107f",
             "skill_name": "email-extractor"
           },
           {
+            "kind": "structured",
             "source_uuid": "dc256086-0d2f-4f61-a307-320d4148107f",
             "skill_name": "markdown-formatter"
           }
@@ -232,10 +275,12 @@ Use this when you want explicit canonical `SkillKey` references at session start
         "prompt": "Extract emails",
         "skill_refs": [
           {
+            "kind": "structured",
             "source_uuid": "dc256086-0d2f-4f61-a307-320d4148107f",
             "skill_name": "email-extractor"
           },
           {
+            "kind": "structured",
             "source_uuid": "dc256086-0d2f-4f61-a307-320d4148107f",
             "skill_name": "markdown-formatter"
           }
@@ -251,10 +296,12 @@ Use this when you want explicit canonical `SkillKey` references at session start
         "prompt": "Extract emails",
         "skill_refs": [
           {
+            "kind": "structured",
             "source_uuid": "dc256086-0d2f-4f61-a307-320d4148107f",
             "skill_name": "email-extractor"
           },
           {
+            "kind": "structured",
             "source_uuid": "dc256086-0d2f-4f61-a307-320d4148107f",
             "skill_name": "markdown-formatter"
           }
@@ -265,6 +312,8 @@ Use this when you want explicit canonical `SkillKey` references at session start
   </Tab>
   <Tab title="Python">
     ```python
+    from meerkat import SkillKey
+
     result = await client.create_session(
         "Extract emails",
         skill_refs=[
@@ -325,122 +374,6 @@ Use this when you want explicit canonical `SkillKey` references at session start
   </Tab>
 </Tabs>
 
-## Preload skills
-
-Preloaded skills are resolved and injected into the system prompt before the first turn runs. They use the same structured skill keys as per-turn skill injection.
-
-<Tabs>
-  <Tab title="CLI">
-    ```bash
-    rkat run "Help me deploy" --skill deployment-guide --skill shell-patterns
-    ```
-  </Tab>
-  <Tab title="JSON-RPC">
-    ```json
-    {
-      "jsonrpc": "2.0", "id": 1,
-      "method": "session/create",
-      "params": {
-        "prompt": "Help me deploy",
-        "preload_skills": [
-          {
-            "source_uuid": "dc256086-0d2f-4f61-a307-320d4148107f",
-            "skill_name": "deployment-guide"
-          },
-          {
-            "source_uuid": "dc256086-0d2f-4f61-a307-320d4148107f",
-            "skill_name": "shell-patterns"
-          }
-        ]
-      }
-    }
-    ```
-  </Tab>
-  <Tab title="REST">
-    ```bash
-    curl -X POST http://127.0.0.1:8080/sessions \
-      -H "Content-Type: application/json" \
-      -d '{
-        "prompt": "Help me deploy",
-        "preload_skills": [
-          {
-            "source_uuid": "dc256086-0d2f-4f61-a307-320d4148107f",
-            "skill_name": "deployment-guide"
-          },
-          {
-            "source_uuid": "dc256086-0d2f-4f61-a307-320d4148107f",
-            "skill_name": "shell-patterns"
-          }
-        ]
-      }'
-    ```
-  </Tab>
-  <Tab title="MCP">
-    ```json
-    {
-      "name": "meerkat_run",
-      "arguments": {
-        "prompt": "Help me deploy",
-        "preload_skills": [
-          {
-            "source_uuid": "dc256086-0d2f-4f61-a307-320d4148107f",
-            "skill_name": "deployment-guide"
-          },
-          {
-            "source_uuid": "dc256086-0d2f-4f61-a307-320d4148107f",
-            "skill_name": "shell-patterns"
-          }
-        ]
-      }
-    }
-    ```
-  </Tab>
-  <Tab title="Python">
-    ```python
-    result = await client.create_session(
-        "Help me deploy",
-        preload_skills=[
-            SkillKey(
-                source_uuid="dc256086-0d2f-4f61-a307-320d4148107f",
-                skill_name="deployment-guide",
-            ),
-            SkillKey(
-                source_uuid="dc256086-0d2f-4f61-a307-320d4148107f",
-                skill_name="shell-patterns",
-            ),
-        ],
-    )
-    ```
-  </Tab>
-  <Tab title="TypeScript">
-    ```typescript
-    const result = await client.createSession("Help me deploy", {
-      preloadSkills: [
-        {
-          sourceUuid: "dc256086-0d2f-4f61-a307-320d4148107f",
-          skillName: "deployment-guide",
-        },
-        {
-          sourceUuid: "dc256086-0d2f-4f61-a307-320d4148107f",
-          skillName: "shell-patterns",
-        },
-      ],
-    });
-    ```
-  </Tab>
-  <Tab title="Rust">
-    ```rust
-    let build_opts = SessionBuildOptions {
-        preload_skills: Some(vec![
-            "deployment-guide".into(),
-            "shell-patterns".into(),
-        ]),
-        ..Default::default()
-    };
-    ```
-  </Tab>
-</Tabs>
-
 ## Per-turn skill injection
 
 Inject skills into a specific turn on an existing session. The skill content is added to the context for that turn only. On the CLI, `--skill` remains the preload-style runtime-local path; the typed per-turn surface is `skill_refs`.
@@ -462,6 +395,7 @@ Inject skills into a specific turn on an existing session. The skill content is 
         "prompt": "Now format the output",
         "skill_refs": [
           {
+            "kind": "structured",
             "source_uuid": "dc256086-0d2f-4f61-a307-320d4148107f",
             "skill_name": "markdown-formatter"
           }
@@ -478,6 +412,7 @@ Inject skills into a specific turn on an existing session. The skill content is 
         "prompt": "Now format the output",
         "skill_refs": [
           {
+            "kind": "structured",
             "source_uuid": "dc256086-0d2f-4f61-a307-320d4148107f",
             "skill_name": "markdown-formatter"
           }
@@ -494,6 +429,7 @@ Inject skills into a specific turn on an existing session. The skill content is 
         "prompt": "Now format the output",
         "skill_refs": [
           {
+            "kind": "structured",
             "source_uuid": "dc256086-0d2f-4f61-a307-320d4148107f",
             "skill_name": "markdown-formatter"
           }
@@ -504,6 +440,8 @@ Inject skills into a specific turn on an existing session. The skill content is 
   </Tab>
   <Tab title="Python">
     ```python
+    from meerkat import SkillKey
+
     result = await session.turn(
         "Now format the output",
         skill_refs=[

--- a/docs/guides/skills.mdx
+++ b/docs/guides/skills.mdx
@@ -322,7 +322,7 @@ Skill introspection lets you see all skills — including shadowed ones — with
 | CLI | `rkat skill inspect <skill-name> --source-uuid <uuid> [--json]` | Inspect a skill's full body |
 | RPC | `skills/list` | List skills with provenance |
 | REST | `GET /skills` | List skills |
-| MCP | `meerkat_skills` tool (`action: "list"`) | List skills |
+| MCP | `meerkat_skills` tool (`action: "list"` or `"inspect"`) | List skills or inspect one by typed `skill_key` |
 | Rust SDK | `SkillRuntime::list_all_with_provenance()` | Programmatic access |
 | Rust SDK | `SkillRuntime::load_from_source()` | Load a typed key from a specific source UUID |
 

--- a/docs/guides/skills.mdx
+++ b/docs/guides/skills.mdx
@@ -4,7 +4,7 @@ description: "Domain-specific knowledge injection via markdown documents with YA
 icon: "graduation-cap"
 ---
 
-Skills inject domain-specific knowledge into the agent's context. A skill is a markdown document with YAML frontmatter that gets included in the system prompt or per-turn context when its required capabilities are available.
+Skills inject domain-specific knowledge into the agent's context. A skill is a `SKILL.md` document with YAML frontmatter, addressed at runtime by `SkillKey { source_uuid, skill_name }`, and included in the system prompt or per-turn context when its required capabilities are available.
 
 <Note>
 This page is the task-first guide. For the low-level runtime vocabulary and identity model, see [Skills reference](/reference/skills-reference).
@@ -16,22 +16,22 @@ Use this guide when you want to:
 
 - create or configure skill sources
 - preload or inject skills into sessions
+- understand `SkillKey` identity and source provenance
 - understand when to use `preload_skills` vs `skill_refs`
 
 ## Skill sources
 
-Skills are discovered from multiple sources, in precedence order:
+Skills are discovered from multiple source transports:
 
-1. **Project/runtime root** (`<runtime-root>/.rkat/skills/`) — highest precedence
-2. **User** (`~/.rkat/skills/`)
-3. **Configured filesystem sources**
-4. **Git repositories** — cloned to local cache, refreshed on TTL
-5. **HTTP endpoints** — fetched from remote skill servers
-6. **Stdio sources**
-7. **Embedded** (builtin skills from component crates)
+- **Embedded** builtin skills from component crates
+- **Project/runtime root** (`<context-root>/.rkat/skills/`) when a context root is active
+- **Configured filesystem sources**
+- **Git repositories** cloned to local cache and refreshed on TTL
+- **HTTP endpoints** fetched from remote skill servers
+- **Stdio sources**
 
 <Note>
-A project skill with the same ID as a builtin skill overrides the builtin (first-source-wins).
+The canonical identity is the pair of `source_uuid` and `skill_name`. Two sources can both provide `task-workflow` without colliding because their source UUIDs differ. First-source-wins shadowing applies only when the same full `SkillKey` appears more than once.
 </Note>
 
 ### Git sources
@@ -101,9 +101,9 @@ When running background jobs...
 
 | Field | Type | Required | Description |
 |-------|------|----------|-------------|
-| `name` | `String` | Yes | Canonical lowercase slug name for the skill |
+| `name` | `String` | Yes | Canonical lowercase slug name for the skill. For filesystem skills, this must match the containing directory. |
 | `description` | `String` | Yes | One-line description |
-| `requires_capabilities` | `Vec<String>` | No (default `[]`) | Capability IDs that must be available |
+| `requires_capabilities` | `Vec<String>` | No (default `[]`) | Lowercase capability IDs that must be available |
 
 The frontmatter is delimited by `---` markers. The body (everything after the closing `---`) is stored as the skill's `body` field.
 
@@ -114,17 +114,20 @@ Skills are filtered by their `requires_capabilities` field before being shown or
 - A skill is included only if **all** its required capabilities are available in the current build/config.
 - A skill with an empty `requires_capabilities` list is always available.
 
-## Skill resolution
+## Skill identity and resolution
 
-The resolver supports two reference formats:
+Every runtime skill reference resolves to:
 
-1. **Slash-prefix ID**: `/skill-id` -- current slash activation path.
+```json
+{
+  "source_uuid": "dc256086-0d2f-4f61-a307-320d4148107f",
+  "skill_name": "email-extractor"
+}
+```
 
-Resolution mode:
+The source identity registry applies source lifecycle gates and lineage/remap rules before load. Disabled or retired sources fail resolution; configured source rotations, renames, splits, and merges require explicit lineage and per-skill remap entries where needed.
 
-| Mode | Behavior |
-|------|----------|
-| `Explicit` | Only explicit `/skill-id` matches |
+Legacy slash-delimited strings are no longer accepted by wire `skill_refs`. Some local CLI paths still accept a bare skill slug as a convenience, but API and tool surfaces should use structured keys.
 
 ## Rendering
 
@@ -136,10 +139,10 @@ The renderer produces two output formats:
 
     ```xml
     <available_skills>
-      <skill id="task-workflow">
+      <skill id="00000000-0000-4b11-8111-000000000001/task-workflow">
         <description>How to use task_create/task_update/task_list for structured work tracking</description>
       </skill>
-      <skill id="shell-patterns">
+      <skill id="00000000-0000-4b11-8111-000000000001/shell-patterns">
         <description>Background job patterns with shell and job management tools</description>
       </skill>
     </available_skills>
@@ -149,11 +152,11 @@ The renderer produces two output formats:
 
     ```xml
     <available_skills mode="collections">
-      <collection path="extraction" count="8">Entity extraction skills</collection>
-      <collection path="formatting" count="3">Output formatting skills</collection>
+      <collection source="00000000-0000-4b11-8111-000000000001" count="8">Embedded skills</collection>
+      <collection source="dc256086-0d2f-4f61-a307-320d4148107f" count="3">Company skills</collection>
 
-      Use the browse_skills tool to list skills in a collection or search.
-      Use the load_skill tool or /collection/skill-name to activate a skill.
+      Use the browse_skills tool to list skills in a source or search.
+      Use the load_skill tool to activate a skill by SkillKey.
     </available_skills>
     ```
 
@@ -163,7 +166,7 @@ The renderer produces two output formats:
     Wraps the skill body in XML-style tags for per-turn injection:
 
     ```xml
-    <skill id="shell-patterns">
+    <skill id="00000000-0000-4b11-8111-000000000001/shell-patterns">
     # Shell Patterns
 
     When running background jobs...
@@ -249,19 +252,19 @@ In collection mode (when there are more than 12 skills), the system prompt shows
 
 Skills can be activated in three ways:
 
-### 1. Legacy slash reference compatibility
+### 1. CLI preload convenience
 
-Some host surfaces still accept legacy slash references as boundary compatibility input:
+The CLI `--skill` option accepts local skill slugs and materializes builtin-source `SkillKey` values for preload:
 
+```bash
+rkat run "Extract emails" --skill email-extractor
 ```
-/extraction/email Extract the sender from this email
-```
 
-Treat this as compatibility behavior rather than the primary model. The recommended current path is explicit `skill_refs`, because the canonical runtime identity for a skill is `SkillKey { source_uuid, skill_name }`.
+Use typed keys for API and tool surfaces.
 
 ### 2. Programmatic typed `skill_refs` (per-turn, recommended)
 
-Pass `skill_refs` in the API request to resolve and inject skills for a specific turn:
+Pass tagged `skill_refs` in API requests to resolve and inject skills for a specific turn:
 
 ```json
 {
@@ -271,6 +274,7 @@ Pass `skill_refs` in the API request to resolve and inject skills for a specific
     "prompt": "Extract emails from this text",
     "skill_refs": [
       {
+        "kind": "structured",
         "source_uuid": "dc256086-0d2f-4f61-a307-320d4148107f",
         "skill_name": "email-extractor"
       }
@@ -279,7 +283,7 @@ Pass `skill_refs` in the API request to resolve and inject skills for a specific
 }
 ```
 
-Legacy `skill_references` strings are retired; use structured `skill_refs`.
+Legacy `skill_references` strings are retired and rejected; use structured `skill_refs`.
 
 ### 3. Preloading at session creation
 
@@ -315,45 +319,47 @@ Skill introspection lets you see all skills — including shadowed ones — with
 | Surface | Method | Description |
 |---------|--------|-------------|
 | CLI | `rkat skill list [--json]` | List all skills with provenance |
-| CLI | `rkat skill inspect <id> [--source <name>] [--json]` | Inspect a skill's full body |
+| CLI | `rkat skill inspect <skill-name> --source-uuid <uuid> [--json]` | Inspect a skill's full body |
 | RPC | `skills/list` | List skills with provenance |
 | REST | `GET /skills` | List skills |
-| REST | `GET /skills/{id}` | Inspect a skill |
-| MCP | `meerkat_skills` tool (`action: "list"` / `"inspect"`) | List or inspect |
+| MCP | `meerkat_skills` tool (`action: "list"`) | List skills |
 | Rust SDK | `SkillRuntime::list_all_with_provenance()` | Programmatic access |
-| Rust SDK | `SkillRuntime::load_from_source()` | Load from specific source |
+| Rust SDK | `SkillRuntime::load_from_source()` | Load a typed key from a specific source UUID |
 
 ### Shadowing
 
-When multiple sources provide a skill with the same ID, the first source wins (project > user > git > http > embedded). Introspection shows both the active skill and the shadowed entries:
+When multiple sources provide the same full `SkillKey`, the first source in the runtime composite wins. Introspection shows both the active skill and the shadowed entries. The common case is that matching `skill_name` values from different sources remain separate active skills because their `source_uuid` values differ:
 
 ```json
 [
   {
-    "id": "task-workflow",
-    "name": "Custom Task Workflow",
-    "scope": "project",
-    "source": "company",
+    "key": {
+      "source_uuid": "00000000-0000-4b11-8111-000000000001",
+      "skill_name": "task-workflow"
+    },
+    "name": "Task Workflow",
+    "scope": "builtin",
     "is_active": true
   },
   {
-    "id": "task-workflow",
-    "name": "Task Workflow",
-    "scope": "builtin",
-    "source": "embedded",
-    "is_active": false,
-    "shadowed_by": "company"
+    "key": {
+      "source_uuid": "dc256086-0d2f-4f61-a307-320d4148107f",
+      "skill_name": "task-workflow"
+    },
+    "name": "Custom Task Workflow",
+    "scope": "project",
+    "is_active": true
   }
 ]
 ```
 
-Use `--source <name>` (CLI) or the `source` parameter (RPC/SDK) to load the body of a shadowed skill directly, bypassing first-wins resolution.
+Use a full `SkillKey` (`skill_name` plus `source_uuid`) when inspecting or loading a specific source.
 
 ### Rust SDK
 
 ```rust
 use meerkat::{AgentFactory, SkillRuntime, SkillFilter};
-use meerkat_core::Config;
+use meerkat_core::{Config, skills::{SkillKey, SkillName, SourceUuid}};
 
 let config = Config::load().await?;
 let factory = AgentFactory::new(store_path);
@@ -363,11 +369,20 @@ if let Some(runtime) = factory.build_skill_runtime(&config).await? {
     // List all skills with provenance
     let entries = runtime.list_all_with_provenance(&SkillFilter::default()).await?;
     for entry in &entries {
-        println!("{}: active={}, source={}", entry.descriptor.id, entry.is_active, entry.descriptor.source_name);
+        println!(
+            "{}: active={}, source={}",
+            entry.descriptor.key,
+            entry.is_active,
+            entry.descriptor.source_name,
+        );
     }
 
     // Load a specific skill's body (bypassing first-wins)
-    let doc = runtime.load_from_source(&"task-workflow".into(), Some("company")).await?;
+    let key = SkillKey::new(
+        SourceUuid::parse("dc256086-0d2f-4f61-a307-320d4148107f")?,
+        SkillName::parse("task-workflow")?,
+    );
+    let doc = runtime.load_from_source(&key, Some("dc256086-0d2f-4f61-a307-320d4148107f")).await?;
     println!("{}", doc.body);
 }
 ```

--- a/docs/reference/api-reference.mdx
+++ b/docs/reference/api-reference.mdx
@@ -249,11 +249,14 @@ See the [hooks guide](/guides/hooks) for usage details.
 
 | Type | Purpose |
 |------|---------|
-| `SkillId` | Newtype skill identifier |
+| `SourceUuid` | Stable source identity |
+| `SkillName` | Lowercase dash-separated skill slug |
+| `SkillKey` | Canonical skill identifier: `source_uuid` + `skill_name` |
+| `SkillRef` | Tagged per-turn skill reference (`kind: "structured"`) |
 | `SkillScope` | `Builtin`, `Project`, `User` |
-| `SkillDescriptor` | Skill metadata (id, name, description, required capabilities) |
+| `SkillDescriptor` | Skill metadata (key, name, description, required capabilities, source name) |
 | `SkillDocument` | Loaded skill with body content |
-| `SkillError` | `NotFound`, `CapabilityUnavailable`, `Ambiguous`, `Load`, `Parse`, `SourceUuidCollision`, `SourceUuidMutationWithoutLineage`, `MissingSkillRemaps`, `RemapWithoutLineage`, `InvalidLegacySkillRefFormat`, `UnknownSkillAlias`, `RemapCycle` |
+| `SkillError` | `NotFound`, `CapabilityUnavailable`, `Load`, `Parse`, `SourceUuidCollision`, `SourceUuidMutationWithoutLineage`, `MissingSkillRemaps`, `RemapWithoutLineage`, `UnknownSkillAlias`, `RemapCycle` |
 
 See the [skills guide](/guides/skills) for usage details.
 

--- a/docs/reference/skills-reference.mdx
+++ b/docs/reference/skills-reference.mdx
@@ -83,7 +83,7 @@ Collection mode groups by `source_uuid` and instructs the agent to use `browse_s
 
 ## Public Introspection
 
-Current public introspection list surfaces:
+Current public introspection surfaces:
 
 | Surface | Operation |
 |---------|-----------|
@@ -91,9 +91,11 @@ Current public introspection list surfaces:
 | CLI inspect | `rkat skill inspect <skill-name> --source-uuid <uuid> [--json]` |
 | RPC | `skills/list` |
 | REST | `GET /skills` |
-| MCP | `meerkat_skills` with `action: "list"` |
+| MCP list | `meerkat_skills` with `action: "list"` |
+| MCP inspect | `meerkat_skills` with `action: "inspect"`, typed `skill_key`, and optional `source` UUID |
 
 List responses include `key`, `source`, `is_active`, and optional `shadowed_by` provenance.
+Inspect responses include the same typed identity and provenance plus `body`.
 
 ## See also
 

--- a/docs/reference/skills-reference.mdx
+++ b/docs/reference/skills-reference.mdx
@@ -8,31 +8,92 @@ Use this page when you need exact skill-system vocabulary rather than a task wal
 
 ## Core identity model
 
-- `SkillKey { source_uuid, skill_name }`
-- `SkillRef`
-- source precedence and shadowing
+- `SourceUuid` is the stable source identity. Builtins use `00000000-0000-4b11-8111-000000000001`; conventional project-local `.rkat/skills` uses `00000000-0000-4b11-8111-000000000002`.
+- `SkillName` is a lowercase dash-separated slug (`[a-z0-9-]`, no leading/trailing dash, no `--`).
+- `SkillKey { source_uuid, skill_name }` is the canonical skill identity across runtime, RPC, REST, SDK, CLI, and tool surfaces.
+- `SkillRef` is the wire wrapper for per-turn refs. It currently has one tagged form:
 
-## Source transport families
+```json
+{
+  "kind": "structured",
+  "source_uuid": "dc256086-0d2f-4f61-a307-320d4148107f",
+  "skill_name": "email-extractor"
+}
+```
 
-- filesystem
-- git
-- HTTP
-- stdio
-- embedded
+`preload_skills` carries plain `SkillKey` objects; `skill_refs` carries tagged `SkillRef` objects. Legacy string refs are rejected.
+
+## Source Identity
+
+Each source has a `SourceIdentityRecord`:
+
+- `source_uuid`
+- `display_name`
+- `transport_kind`: `embedded`, `filesystem`, `git`, `http`, or `stdio`
+- `fingerprint`
+- `status`: `active`, `disabled`, or `retired`
+
+The source identity registry applies lifecycle checks before load. Disabled or retired sources fail resolution. Source UUID rotations, renames, splits, and merges are represented with lineage events plus `SkillKeyRemap` entries where the event needs per-skill coverage.
+
+Shadowing is keyed by the full `SkillKey`, not by `skill_name` alone. Two sources can both contain `email-extractor`; they are distinct skills unless their `source_uuid` is also the same.
+
+## Source Transports
+
+| Transport | Configuration shape | Notes |
+|-----------|---------------------|-------|
+| Embedded | component crate registration | Builtin skills registered through inventory. |
+| Filesystem | `type = "filesystem"`, `path = "..."` | Recursively discovers directories containing `SKILL.md`. |
+| Git | `type = "git"`, `url`, `git_ref`, `ref_type` | Uses local cache and refresh TTL for branch refs. |
+| HTTP | `type = "http"`, `url`, auth fields | Requires the HTTP skills feature. |
+| Stdio | `type = "stdio"`, `command`, `args` | External skill source process. |
 
 ## Activation paths
 
-- preload at session creation
-- per-turn `skill_refs`
-- legacy slash-reference compatibility
+- **Preload at session creation**: `preload_skills: SkillKey[]`; content is resolved into the system prompt before the first turn.
+- **First-turn or per-turn injection**: `skill_refs: SkillRef[]`; content is injected for that turn.
+- **CLI preload convenience**: `rkat run --skill <skill-name>` resolves a runtime-local slug to a builtin-source key.
+
+There is no slash-delimited public wire format. Use typed keys.
 
 ## Discovery tools
 
-- `browse_skills`
-- `load_skill`
-- `skill_list_resources`
-- `skill_read_resource`
-- `skill_invoke_function`
+Agent-facing discovery tools use typed key fields:
+
+| Tool | Key fields | Purpose |
+|------|------------|---------|
+| `browse_skills` | optional `source_uuid` filter | List active skills, optionally filtered by source UUID or search query. |
+| `load_skill` | `source_uuid`, `skill_name` | Load a skill's full instructions into the conversation. |
+| `skill_list_resources` | `source_uuid`, `skill_name` | List skill-owned resources/artifacts. |
+| `skill_read_resource` | `source_uuid`, `skill_name`, resource path | Read a specific skill-owned resource. |
+| `skill_invoke_function` | `source_uuid`, `skill_name`, function name, arguments | Invoke a skill-defined structured function. |
+
+## Rendering
+
+Flat inventory renders full key IDs:
+
+```xml
+<available_skills>
+  <skill id="00000000-0000-4b11-8111-000000000001/task-workflow">
+    <description>How to use task tools</description>
+  </skill>
+</available_skills>
+```
+
+Collection mode groups by `source_uuid` and instructs the agent to use `browse_skills` and `load_skill`. Injection blocks are size-limited to 32 KiB and rendered as `<skill id="source_uuid/skill_name">...</skill>`.
+
+## Public Introspection
+
+Current public introspection list surfaces:
+
+| Surface | Operation |
+|---------|-----------|
+| CLI | `rkat skill list [--json]` |
+| CLI inspect | `rkat skill inspect <skill-name> --source-uuid <uuid> [--json]` |
+| RPC | `skills/list` |
+| REST | `GET /skills` |
+| MCP | `meerkat_skills` with `action: "list"` |
+
+List responses include `key`, `source`, `is_active`, and optional `shadowed_by` provenance.
 
 ## See also
 

--- a/meerkat-mcp-server/src/lib.rs
+++ b/meerkat-mcp-server/src/lib.rs
@@ -1255,7 +1255,7 @@ fn base_tools_list() -> Vec<Value> {
         }),
         json!({
             "name": "meerkat_skills",
-            "description": "List or inspect available skills. Use action 'list' to see all skills, or 'inspect' with a skill_id to see its full content.",
+            "description": "List or inspect available skills. Use action 'list' to see all skills, or 'inspect' with a typed skill_key and optional source UUID selector to see full content.",
             "inputSchema": meerkat_tools::schema_for::<MeerkatSkillsInput>()
         }),
         json!({


### PR DESCRIPTION
## Summary\n- update skills docs to use canonical SkillKey and tagged SkillRef wire examples\n- align CLI/REST/RPC/MCP docs with current skill list/inspect surfaces\n- update the local meerkat-platform skill reference for the typed skills model\n\n## Validation\n- git diff --check\n- make verify-rpc-surface-alignment\n- ./scripts/repo-cargo test -p meerkat-core skills::tests --lib\n- ./scripts/repo-cargo test -p meerkat-tools --test browse_load_surface\n- make agent-gate\n\nLinear: LUC-184