### PR TITLE
LUC-190 Centralize request lifecycle classification

### DIFF
--- a/meerkat-contracts/src/lib.rs
+++ b/meerkat-contracts/src/lib.rs
@@ -9,6 +9,7 @@ pub mod capability;
 pub mod error;
 pub mod event_catalog;
 pub mod protocol;
+pub mod request_lifecycle;
 pub mod rest_catalog;
 pub mod rpc_catalog;
 pub mod session_locator;
@@ -27,6 +28,11 @@ pub use error::{CapabilityHint, ErrorCategory, ErrorCode, WireError};
 pub use event_catalog::KNOWN_AGENT_EVENT_TYPES;
 pub use meerkat_core::{ExecutionPlacement, ExecutionPlacementIdentity};
 pub use protocol::Protocol;
+pub use request_lifecycle::{
+    MCP_TOOL_REQUEST_LIFECYCLE_CATALOG, McpToolRequestLifecycleCatalog,
+    McpToolRequestLifecycleDescriptor, RequestLifecycle, RpcRequestLifecycleRule,
+    mcp_tool_request_lifecycle, rpc_request_lifecycle,
+};
 pub use rest_catalog::{
     RestOperationDescriptor, RestPathDescriptor, rest_documented_paths, rest_path_catalog,
 };

--- a/meerkat-contracts/src/request_lifecycle.rs
+++ b/meerkat-contracts/src/request_lifecycle.rs
@@ -1,0 +1,89 @@
+/// Catalog-owned lifecycle classification for surface requests.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RequestLifecycle {
+    InlineObservation,
+    LongRunningPublishOnSuccess,
+    LongRunningObservation,
+}
+
+/// How an RPC catalog entry derives lifecycle semantics from request params.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RpcRequestLifecycleRule {
+    Static(RequestLifecycle),
+    SessionCreateInitialTurn,
+}
+
+impl RpcRequestLifecycleRule {
+    pub const INLINE_OBSERVATION: Self = Self::Static(RequestLifecycle::InlineObservation);
+    pub const LONG_RUNNING_PUBLISH_ON_SUCCESS: Self =
+        Self::Static(RequestLifecycle::LongRunningPublishOnSuccess);
+
+    pub fn resolve(self, params_json: Option<&str>) -> RequestLifecycle {
+        match self {
+            Self::Static(lifecycle) => lifecycle,
+            Self::SessionCreateInitialTurn if session_create_runs_immediately(params_json) => {
+                RequestLifecycle::LongRunningPublishOnSuccess
+            }
+            Self::SessionCreateInitialTurn => RequestLifecycle::InlineObservation,
+        }
+    }
+}
+
+pub fn rpc_request_lifecycle(method: &str, params_json: Option<&str>) -> RequestLifecycle {
+    crate::rpc_method_catalog(crate::RpcMethodCatalogOptions::documented_surface())
+        .into_iter()
+        .find(|descriptor| descriptor.name == method)
+        .map(|descriptor| descriptor.request_lifecycle.resolve(params_json))
+        .unwrap_or(RequestLifecycle::InlineObservation)
+}
+
+fn session_create_runs_immediately(params_json: Option<&str>) -> bool {
+    let Some(params_json) = params_json else {
+        return true;
+    };
+    let Ok(value) = serde_json::from_str::<serde_json::Value>(params_json) else {
+        return true;
+    };
+    !matches!(
+        value
+            .get("initial_turn")
+            .and_then(serde_json::Value::as_str),
+        Some("deferred")
+    )
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct McpToolRequestLifecycleDescriptor {
+    pub name: &'static str,
+    pub request_lifecycle: RequestLifecycle,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct McpToolRequestLifecycleCatalog {
+    pub default_lifecycle: RequestLifecycle,
+    pub tools: &'static [McpToolRequestLifecycleDescriptor],
+}
+
+pub const MCP_TOOL_REQUEST_LIFECYCLE_CATALOG: McpToolRequestLifecycleCatalog =
+    McpToolRequestLifecycleCatalog {
+        default_lifecycle: RequestLifecycle::LongRunningObservation,
+        tools: &[
+            McpToolRequestLifecycleDescriptor {
+                name: "meerkat_run",
+                request_lifecycle: RequestLifecycle::LongRunningPublishOnSuccess,
+            },
+            McpToolRequestLifecycleDescriptor {
+                name: "meerkat_resume",
+                request_lifecycle: RequestLifecycle::LongRunningPublishOnSuccess,
+            },
+        ],
+    };
+
+pub fn mcp_tool_request_lifecycle(tool_name: &str) -> RequestLifecycle {
+    MCP_TOOL_REQUEST_LIFECYCLE_CATALOG
+        .tools
+        .iter()
+        .find(|descriptor| descriptor.name == tool_name)
+        .map(|descriptor| descriptor.request_lifecycle)
+        .unwrap_or(MCP_TOOL_REQUEST_LIFECYCLE_CATALOG.default_lifecycle)
+}

--- a/meerkat-contracts/src/rpc_catalog.rs
+++ b/meerkat-contracts/src/rpc_catalog.rs
@@ -1,5 +1,7 @@
 use serde::Serialize;
 
+use crate::RpcRequestLifecycleRule;
+
 #[derive(Debug, Clone, Copy)]
 pub struct RpcMethodCatalogOptions {
     pub runtime_available: bool,
@@ -51,6 +53,8 @@ pub struct RpcMethodDescriptor {
     pub params_type: Option<&'static str>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub result_type: Option<&'static str>,
+    #[serde(skip_serializing)]
+    pub request_lifecycle: RpcRequestLifecycleRule,
 }
 
 impl RpcMethodDescriptor {
@@ -60,6 +64,7 @@ impl RpcMethodDescriptor {
             description,
             params_type: None,
             result_type: None,
+            request_lifecycle: RpcRequestLifecycleRule::INLINE_OBSERVATION,
         }
     }
 
@@ -74,7 +79,13 @@ impl RpcMethodDescriptor {
             description,
             params_type: Some(params_type),
             result_type: Some(result_type),
+            request_lifecycle: RpcRequestLifecycleRule::INLINE_OBSERVATION,
         }
+    }
+
+    const fn with_request_lifecycle(mut self, request_lifecycle: RpcRequestLifecycleRule) -> Self {
+        self.request_lifecycle = request_lifecycle;
+        self
     }
 
     const fn result_only(
@@ -87,6 +98,7 @@ impl RpcMethodDescriptor {
             description,
             params_type: None,
             result_type: Some(result_type),
+            request_lifecycle: RpcRequestLifecycleRule::INLINE_OBSERVATION,
         }
     }
 }
@@ -99,7 +111,8 @@ pub fn rpc_method_catalog(options: RpcMethodCatalogOptions) -> Vec<RpcMethodDesc
             "Create session + run first turn",
             "CreateSessionParams",
             "WireRunResult | DeferredCreateResult",
-        ),
+        )
+        .with_request_lifecycle(RpcRequestLifecycleRule::SessionCreateInitialTurn),
         RpcMethodDescriptor::typed(
             "session/list",
             "List active sessions",
@@ -129,7 +142,8 @@ pub fn rpc_method_catalog(options: RpcMethodCatalogOptions) -> Vec<RpcMethodDesc
             "Start a new turn on existing session",
             "StartTurnParams",
             "WireRunResult",
-        ),
+        )
+        .with_request_lifecycle(RpcRequestLifecycleRule::LONG_RUNNING_PUBLISH_ON_SUCCESS),
         RpcMethodDescriptor::typed(
             "turn/interrupt",
             "Cancel in-flight turn",
@@ -603,7 +617,8 @@ pub fn rpc_method_catalog(options: RpcMethodCatalogOptions) -> Vec<RpcMethodDesc
                 "Start a turn on a mob member by identity",
                 "MobTurnStartParams",
                 "WireRunResult",
-            ),
+            )
+            .with_request_lifecycle(RpcRequestLifecycleRule::LONG_RUNNING_PUBLISH_ON_SUCCESS),
             RpcMethodDescriptor::typed(
                 "mob/member_status",
                 "Get live status for a mob member",
@@ -813,6 +828,7 @@ pub fn rpc_notification_names(options: RpcMethodCatalogOptions) -> Vec<String> {
 #[allow(clippy::panic)]
 mod tests {
     use super::*;
+    use crate::{RequestLifecycle, mcp_tool_request_lifecycle, rpc_request_lifecycle};
 
     #[test]
     fn documented_surface_keeps_live_runtime_and_mob_methods() {
@@ -850,6 +866,59 @@ mod tests {
         assert!(notifications.iter().any(|n| n == "session/stream_end"));
         assert!(notifications.iter().any(|n| n == "mob/stream_event"));
         assert!(notifications.iter().any(|n| n == "mob/stream_end"));
+    }
+
+    #[test]
+    fn rpc_catalog_owns_request_lifecycle_rules() {
+        let methods = rpc_method_catalog(RpcMethodCatalogOptions::documented_surface());
+        let descriptor = |name: &str| {
+            methods
+                .iter()
+                .find(|method| method.name == name)
+                .unwrap_or_else(|| panic!("missing descriptor for {name}"))
+        };
+
+        assert_eq!(
+            descriptor("turn/start").request_lifecycle.resolve(None),
+            RequestLifecycle::LongRunningPublishOnSuccess
+        );
+        assert_eq!(
+            descriptor("mob/turn_start").request_lifecycle.resolve(None),
+            RequestLifecycle::LongRunningPublishOnSuccess
+        );
+        assert_eq!(
+            descriptor("session/create")
+                .request_lifecycle
+                .resolve(Some(r#"{"initial_turn":"deferred"}"#)),
+            RequestLifecycle::InlineObservation
+        );
+        assert_eq!(
+            rpc_request_lifecycle(
+                "session/create",
+                Some(r#"{"initial_turn":"run_immediately"}"#),
+            ),
+            RequestLifecycle::LongRunningPublishOnSuccess
+        );
+        assert_eq!(
+            rpc_request_lifecycle("session/list", None),
+            RequestLifecycle::InlineObservation
+        );
+    }
+
+    #[test]
+    fn mcp_tool_catalog_owns_request_lifecycle_rules() {
+        assert_eq!(
+            mcp_tool_request_lifecycle("meerkat_run"),
+            RequestLifecycle::LongRunningPublishOnSuccess
+        );
+        assert_eq!(
+            mcp_tool_request_lifecycle("meerkat_resume"),
+            RequestLifecycle::LongRunningPublishOnSuccess
+        );
+        assert_eq!(
+            mcp_tool_request_lifecycle("meerkat_sessions"),
+            RequestLifecycle::LongRunningObservation
+        );
     }
 
     #[test]

--- a/meerkat-mcp-server/src/main.rs
+++ b/meerkat-mcp-server/src/main.rs
@@ -5,7 +5,7 @@ use meerkat::surface::{
     RequestTerminal, RequestTerminalResolution, StdioJsonWriter, SurfaceRequestExecutor,
     SurfaceRequestSemantics, noop_request_action, spawn_stdio_json_writer,
 };
-use meerkat_contracts::ErrorCode;
+use meerkat_contracts::{ErrorCode, mcp_tool_request_lifecycle};
 use meerkat_core::{RealmConfig, RealmSelection, RuntimeBootstrap};
 use meerkat_store::RealmBackend;
 use serde_json::{Value, json};
@@ -231,7 +231,8 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                         let state = Arc::clone(&state);
                         let completion_tx = completion_tx.clone();
                         let tool_name = name.clone();
-                        let semantics = SurfaceRequestSemantics::for_mcp_tool_call(&tool_name);
+                        let semantics =
+                            SurfaceRequestSemantics::from(mcp_tool_request_lifecycle(&tool_name));
                         let request_id_for_task = request_id.clone();
                         let request_key_for_task = request_key.clone();
                         let handle = tokio::spawn(async move {
@@ -372,16 +373,17 @@ mod tests {
     #[test]
     fn meerkat_run_and_resume_publish_on_success() {
         assert!(matches!(
-            SurfaceRequestSemantics::for_mcp_tool_call("meerkat_run").classify_terminal(true, ()),
-            RequestTerminal::Publish(())
-        ));
-        assert!(matches!(
-            SurfaceRequestSemantics::for_mcp_tool_call("meerkat_resume")
+            SurfaceRequestSemantics::from(mcp_tool_request_lifecycle("meerkat_run"))
                 .classify_terminal(true, ()),
             RequestTerminal::Publish(())
         ));
         assert!(matches!(
-            SurfaceRequestSemantics::for_mcp_tool_call("meerkat_sessions")
+            SurfaceRequestSemantics::from(mcp_tool_request_lifecycle("meerkat_resume"))
+                .classify_terminal(true, ()),
+            RequestTerminal::Publish(())
+        ));
+        assert!(matches!(
+            SurfaceRequestSemantics::from(mcp_tool_request_lifecycle("meerkat_sessions"))
                 .classify_terminal(true, ()),
             RequestTerminal::RespondWithoutPublish(())
         ));

--- a/meerkat-rpc/src/server.rs
+++ b/meerkat-rpc/src/server.rs
@@ -12,6 +12,7 @@ use meerkat::surface::{
     RequestTerminal, RequestTerminalResolution, SurfaceRequestExecutor, SurfaceRequestSemantics,
     noop_request_action,
 };
+use meerkat_contracts::rpc_request_lifecycle;
 use tokio::io::{AsyncBufRead, BufReader};
 use tokio::sync::{mpsc, oneshot};
 
@@ -468,10 +469,10 @@ fn request_lifecycle_error_response(
 }
 
 fn request_semantics(request: &RpcRequest) -> SurfaceRequestSemantics {
-    SurfaceRequestSemantics::for_rpc_request(
+    SurfaceRequestSemantics::from(rpc_request_lifecycle(
         request.method.as_str(),
         request.params.as_deref().map(|params| params.get()),
-    )
+    ))
 }
 
 /// Start the RPC server on stdin/stdout.

--- a/meerkat/BUILD.bazel
+++ b/meerkat/BUILD.bazel
@@ -52,6 +52,7 @@ rust_library(
     compile_data = [
         "Cargo.toml",
         "skills/mob-communication/SKILL.md",
+        "src/surface/request_execution.rs",
     ],
     srcs = glob(["src/**/*.rs"]),
     visibility = ["//visibility:public"],
@@ -115,6 +116,7 @@ rust_test(
     compile_data = [
         "Cargo.toml",
         "skills/mob-communication/SKILL.md",
+        "src/surface/request_execution.rs",
     ],
     srcs = glob(["src/**/*.rs"]),
     visibility = ["//visibility:public"],
@@ -194,6 +196,7 @@ rust_test(
     compile_data = [
         "Cargo.toml",
         "skills/mob-communication/SKILL.md",
+        "src/surface/request_execution.rs",
     ],
     srcs = [
         "tests/agent_factory_connection_ref.rs",
@@ -274,6 +277,7 @@ rust_test(
     compile_data = [
         "Cargo.toml",
         "skills/mob-communication/SKILL.md",
+        "src/surface/request_execution.rs",
     ],
     srcs = [
         "tests/e2e_shell.rs",
@@ -358,6 +362,7 @@ rust_test(
     compile_data = [
         "Cargo.toml",
         "skills/mob-communication/SKILL.md",
+        "src/surface/request_execution.rs",
     ],
     srcs = [
         "tests/embedded_skill_registration.rs",
@@ -438,6 +443,7 @@ rust_test(
     compile_data = [
         "Cargo.toml",
         "skills/mob-communication/SKILL.md",
+        "src/surface/request_execution.rs",
     ],
     srcs = [
         "tests/factory_build_agent.rs",
@@ -521,6 +527,7 @@ rust_test(
     compile_data = [
         "Cargo.toml",
         "skills/mob-communication/SKILL.md",
+        "src/surface/request_execution.rs",
     ],
     srcs = [
         "tests/integration.rs",
@@ -604,6 +611,7 @@ rust_test(
     compile_data = [
         "Cargo.toml",
         "skills/mob-communication/SKILL.md",
+        "src/surface/request_execution.rs",
     ],
     srcs = [
         "tests/live_meerkat_comms.rs",
@@ -685,6 +693,7 @@ rust_test(
     compile_data = [
         "Cargo.toml",
         "skills/mob-communication/SKILL.md",
+        "src/surface/request_execution.rs",
     ],
     srcs = [
         "tests/live_meerkat_regression.rs",
@@ -766,6 +775,7 @@ rust_test(
     compile_data = [
         "Cargo.toml",
         "skills/mob-communication/SKILL.md",
+        "src/surface/request_execution.rs",
     ],
     srcs = [
         "tests/live_meerkat_user_flows.rs",
@@ -851,6 +861,7 @@ rust_test(
     compile_data = [
         "Cargo.toml",
         "skills/mob-communication/SKILL.md",
+        "src/surface/request_execution.rs",
     ],
     srcs = [
         "tests/persistence_contract.rs",
@@ -931,6 +942,7 @@ rust_test(
     compile_data = [
         "Cargo.toml",
         "skills/mob-communication/SKILL.md",
+        "src/surface/request_execution.rs",
     ],
     srcs = [
         "tests/realtime_channel_builder.rs",
@@ -1011,6 +1023,7 @@ rust_test(
     compile_data = [
         "Cargo.toml",
         "skills/mob-communication/SKILL.md",
+        "src/surface/request_execution.rs",
     ],
     srcs = [
         "tests/schedule_host_typed_mapping.rs",
@@ -1093,6 +1106,7 @@ rust_test(
     compile_data = [
         "Cargo.toml",
         "skills/mob-communication/SKILL.md",
+        "src/surface/request_execution.rs",
     ],
     srcs = [
         "tests/sdk_agentfactory.rs",
@@ -1174,6 +1188,7 @@ rust_test(
     compile_data = [
         "Cargo.toml",
         "skills/mob-communication/SKILL.md",
+        "src/surface/request_execution.rs",
     ],
     srcs = [
         "tests/sdk_config_ephemeral.rs",
@@ -1254,6 +1269,7 @@ rust_test(
     compile_data = [
         "Cargo.toml",
         "skills/mob-communication/SKILL.md",
+        "src/surface/request_execution.rs",
     ],
     srcs = [
         "tests/sdk_structured_output.rs",
@@ -1335,6 +1351,7 @@ rust_test(
     compile_data = [
         "Cargo.toml",
         "skills/mob-communication/SKILL.md",
+        "src/surface/request_execution.rs",
     ],
     srcs = [
         "tests/smoke_meerkat_sdk.rs",

--- a/meerkat/src/surface/request_execution.rs
+++ b/meerkat/src/surface/request_execution.rs
@@ -5,6 +5,7 @@ use std::sync::{Arc, Mutex, MutexGuard};
 use std::time::Duration;
 
 use futures::future::BoxFuture;
+use meerkat_contracts::RequestLifecycle;
 use meerkat_core::{Session, SessionId, SessionRuntimeBindings};
 
 #[cfg(target_arch = "wasm32")]
@@ -132,34 +133,6 @@ impl SurfaceRequestSemantics {
         }
     }
 
-    /// Canonical RPC request semantics for an already-parsed `session/create`
-    /// initial-turn policy. Prefer [`Self::for_rpc_request`] at protocol
-    /// boundaries so request lifecycle classification stays machine-owned.
-    pub fn for_rpc_method(method: &str, session_create_runs_immediately: bool) -> Self {
-        match method {
-            "turn/start" | "mob/turn_start" => Self::long_running_publish_on_success(),
-            "session/create" if session_create_runs_immediately => {
-                Self::long_running_publish_on_success()
-            }
-            _ => Self::inline_observation(),
-        }
-    }
-
-    /// Canonical RPC request semantics, including wire-parameter classification.
-    pub fn for_rpc_request(method: &str, params_json: Option<&str>) -> Self {
-        let session_create_runs_immediately =
-            rpc_session_create_runs_immediately(method, params_json);
-        Self::for_rpc_method(method, session_create_runs_immediately)
-    }
-
-    /// Canonical MCP tool-call request semantics.
-    pub fn for_mcp_tool_call(tool_name: &str) -> Self {
-        match tool_name {
-            "meerkat_run" | "meerkat_resume" => Self::long_running_publish_on_success(),
-            _ => Self::long_running_observation(),
-        }
-    }
-
     pub const fn requires_long_running_executor(self) -> bool {
         matches!(self.execution, SurfaceRequestExecution::LongRunning)
     }
@@ -178,22 +151,16 @@ impl SurfaceRequestSemantics {
     }
 }
 
-fn rpc_session_create_runs_immediately(method: &str, params_json: Option<&str>) -> bool {
-    if method != "session/create" {
-        return false;
+impl From<RequestLifecycle> for SurfaceRequestSemantics {
+    fn from(lifecycle: RequestLifecycle) -> Self {
+        match lifecycle {
+            RequestLifecycle::InlineObservation => Self::inline_observation(),
+            RequestLifecycle::LongRunningPublishOnSuccess => {
+                Self::long_running_publish_on_success()
+            }
+            RequestLifecycle::LongRunningObservation => Self::long_running_observation(),
+        }
     }
-    let Some(params_json) = params_json else {
-        return true;
-    };
-    let Ok(value) = serde_json::from_str::<serde_json::Value>(params_json) else {
-        return true;
-    };
-    !matches!(
-        value
-            .get("initial_turn")
-            .and_then(serde_json::Value::as_str),
-        Some("deferred")
-    )
 }
 
 /// Canonical lifecycle phase of a tracked request.
@@ -743,52 +710,35 @@ mod tests {
     use std::sync::atomic::{AtomicUsize, Ordering};
 
     #[test]
-    fn canonical_request_classifiers_cover_rpc_and_mcp_names() {
-        assert_eq!(
-            SurfaceRequestSemantics::for_rpc_request("turn/start", None),
-            SurfaceRequestSemantics::long_running_publish_on_success()
-        );
-        assert_eq!(
-            SurfaceRequestSemantics::for_rpc_request("mob/turn_start", Some("{}")),
-            SurfaceRequestSemantics::long_running_publish_on_success()
-        );
-        assert_eq!(
-            SurfaceRequestSemantics::for_rpc_request("session/create", None),
-            SurfaceRequestSemantics::long_running_publish_on_success()
-        );
-        assert_eq!(
-            SurfaceRequestSemantics::for_rpc_request(
-                "session/create",
-                Some(r#"{"initial_turn":"immediate"}"#),
-            ),
-            SurfaceRequestSemantics::long_running_publish_on_success()
-        );
-        assert_eq!(
-            SurfaceRequestSemantics::for_rpc_request(
-                "session/create",
-                Some(r#"{"initial_turn":"deferred"}"#),
-            ),
-            SurfaceRequestSemantics::inline_observation()
-        );
-        assert_eq!(
-            SurfaceRequestSemantics::for_rpc_request("session/create", Some("{not json")),
-            SurfaceRequestSemantics::long_running_publish_on_success()
-        );
-        assert_eq!(
-            SurfaceRequestSemantics::for_rpc_request("session/list", None),
-            SurfaceRequestSemantics::inline_observation()
-        );
+    fn surface_semantics_do_not_own_raw_request_lifecycle_tables() {
+        let source = include_str!("request_execution.rs");
+        for forbidden in [
+            concat!("for_", "rpc_method"),
+            concat!("for_", "mcp_tool_call"),
+            concat!("\"", "turn", "/start", "\""),
+            concat!("\"", "mob", "/turn_start", "\""),
+            concat!("\"", "meerkat", "_run", "\""),
+            concat!("\"", "meerkat", "_resume", "\""),
+        ] {
+            assert!(
+                !source.contains(forbidden),
+                "surface request execution must adapt catalog-owned lifecycle semantics, not classify `{forbidden}` locally"
+            );
+        }
+    }
 
+    #[test]
+    fn catalog_request_lifecycle_adapter_preserves_surface_semantics() {
         assert_eq!(
-            SurfaceRequestSemantics::for_mcp_tool_call("meerkat_run"),
+            SurfaceRequestSemantics::from(RequestLifecycle::InlineObservation),
+            SurfaceRequestSemantics::inline_observation()
+        );
+        assert_eq!(
+            SurfaceRequestSemantics::from(RequestLifecycle::LongRunningPublishOnSuccess),
             SurfaceRequestSemantics::long_running_publish_on_success()
         );
         assert_eq!(
-            SurfaceRequestSemantics::for_mcp_tool_call("meerkat_resume"),
-            SurfaceRequestSemantics::long_running_publish_on_success()
-        );
-        assert_eq!(
-            SurfaceRequestSemantics::for_mcp_tool_call("meerkat_sessions"),
+            SurfaceRequestSemantics::from(RequestLifecycle::LongRunningObservation),
             SurfaceRequestSemantics::long_running_observation()
         );
     }


### PR DESCRIPTION
## Summary
- add contract/catalog-owned request lifecycle classification for RPC methods and MCP tool calls
- make shared surface execution adapt typed lifecycle semantics instead of matching raw method/tool names
- wire RPC and MCP entry points through the catalog-owned authority while preserving terminal behavior

## Validation
- Red before implementation: `./scripts/repo-cargo test -p meerkat-contracts rpc_catalog_owns_request_lifecycle_rules --lib`
- `./scripts/repo-cargo test -p meerkat-contracts request_lifecycle --lib`
- `./scripts/repo-cargo test -p meerkat surface_semantics_do_not_own_raw_request_lifecycle_tables --lib`
- `./scripts/repo-cargo test -p meerkat catalog_request_lifecycle_adapter_preserves_surface_semantics --lib`
- `./scripts/repo-cargo test -p meerkat-rpc session_create_uses --lib`
- `./scripts/repo-cargo test -p meerkat-rpc turn_start_is_publish_on_success --lib`
- `./scripts/repo-cargo test -p meerkat-mcp-server --bin rkat-mcp meerkat_run_and_resume_publish_on_success`
- `make fmt-check`
- `MEERKAT_BUILDBUDDY=1 make check` (BuildBuddy invocation `8aa5821d-f993-4cf8-900d-d2009dc8aca7`)

Linear: LUC-190