### PR TITLE
LUC-200 Require complete peer request authority

### DIFF
--- a/meerkat-comms/src/runtime/comms_runtime.rs
+++ b/meerkat-comms/src/runtime/comms_runtime.rs
@@ -81,6 +81,10 @@ impl StreamRegistryEntry {
 }
 
 type InteractionStreamRegistry = Arc<Mutex<HashMap<Uuid, StreamRegistryEntry>>>;
+type PeerRequestResponseAuthorityHandles = (
+    Arc<dyn meerkat_core::handles::PeerInteractionHandle>,
+    Arc<dyn meerkat_core::handles::InteractionStreamHandle>,
+);
 
 #[derive(Clone)]
 pub struct PeerRequestResponseAuthority {
@@ -558,11 +562,10 @@ impl CoreCommsRuntime for CommsRuntime {
                 let interaction_id = Uuid::new_v4();
                 let corr_id = meerkat_core::PeerCorrelationId::from_uuid(interaction_id);
                 let stream_reserved = stream == InputStreamMode::ReserveInteraction;
-                let peer_handle = self.require_peer_interaction_authority("PeerRequest")?;
+                let (peer_handle, stream_authority) =
+                    self.require_peer_request_response_authority("PeerRequest")?;
                 let stream_handle = if stream_reserved {
-                    Some(self.require_interaction_stream_authority(
-                        "PeerRequest with ReserveInteraction",
-                    )?)
+                    Some(stream_authority)
                 } else {
                     None
                 };
@@ -627,7 +630,8 @@ impl CoreCommsRuntime for CommsRuntime {
                 result,
                 handling_mode,
             } => {
-                let peer_handle = self.require_peer_interaction_authority("PeerResponse")?;
+                let (peer_handle, _stream_authority) =
+                    self.require_peer_request_response_authority("PeerResponse")?;
                 let corr_id = meerkat_core::PeerCorrelationId::from_uuid(in_reply_to.0);
                 let core_status = status;
                 let status = match status {
@@ -731,9 +735,8 @@ impl CoreCommsRuntime for CommsRuntime {
                 // id can be used for stream attachment and reply correlation.
                 let interaction_id = Uuid::new_v4();
                 let corr_id = meerkat_core::PeerCorrelationId::from_uuid(interaction_id);
-                let peer_handle = self.require_peer_interaction_authority("PeerRequest")?;
-                let stream_handle = self
-                    .require_interaction_stream_authority("PeerRequest with ReserveInteraction")?;
+                let (peer_handle, stream_handle) =
+                    self.require_peer_request_response_authority("PeerRequest")?;
 
                 if let Err(err) = peer_handle.request_sent(corr_id, to.peer_id.to_string()) {
                     tracing::warn!(
@@ -865,6 +868,17 @@ impl CoreCommsRuntime for CommsRuntime {
         &self,
     ) -> Option<Arc<dyn meerkat_core::handles::PeerInteractionHandle>> {
         self.peer_interaction_handle()
+    }
+
+    fn peer_request_response_authority_handle(
+        &self,
+    ) -> Option<Arc<dyn meerkat_core::handles::PeerInteractionHandle>> {
+        let peer_handle = self.peer_interaction_handle();
+        if peer_handle.is_some() && self.interaction_stream_handle().is_some() {
+            peer_handle
+        } else {
+            None
+        }
     }
 
     async fn drain_classified_inbox_interactions(
@@ -1718,9 +1732,18 @@ impl CommsRuntime {
         })
     }
 
+    fn require_peer_request_response_authority(
+        &self,
+        command: &'static str,
+    ) -> Result<PeerRequestResponseAuthorityHandles, SendError> {
+        let peer_handle = self.require_peer_interaction_authority(command)?;
+        let stream_handle = self.require_interaction_stream_authority(command)?;
+        Ok((peer_handle, stream_handle))
+    }
+
     fn peer_request_response_sendable_kinds(&self) -> Vec<PeerSendability> {
         let mut kinds = vec![PeerSendability::PeerMessage];
-        if self.peer_interaction_handle().is_some() {
+        if self.peer_interaction_handle().is_some() && self.interaction_stream_handle().is_some() {
             kinds.push(PeerSendability::PeerRequest);
             kinds.push(PeerSendability::PeerResponse);
         }
@@ -3669,6 +3692,148 @@ mod tests {
             .expect("trusted peer should be listed");
 
         assert_eq!(entry.sendable_kinds, vec![PeerSendability::PeerMessage]);
+    }
+
+    #[tokio::test]
+    async fn partial_peer_authority_does_not_advertise_semantic_request_response() {
+        let suffix = Uuid::new_v4().simple().to_string();
+        let peer_name = format!("directory-partial-peer-{suffix}");
+        let runtime_name = format!("directory-partial-runtime-{suffix}");
+
+        let peer = CommsRuntime::inproc_only(&peer_name).unwrap();
+        let runtime = Arc::new(CommsRuntime::inproc_only(&runtime_name).unwrap());
+        runtime.install_peer_interaction_handle(Arc::new(TestPeerInteractionHandle::default()));
+        CoreCommsRuntime::add_trusted_peer(
+            runtime.as_ref(),
+            trusted_descriptor(
+                &peer_name,
+                peer.public_key(),
+                &format!("inproc://{peer_name}"),
+            ),
+        )
+        .await
+        .expect("runtime should trust peer");
+
+        let peers = CoreCommsRuntime::peers(runtime.as_ref()).await;
+        let entry = peers
+            .iter()
+            .find(|entry| entry.name.as_str() == peer_name)
+            .expect("trusted peer should be listed");
+
+        assert_eq!(entry.sendable_kinds, vec![PeerSendability::PeerMessage]);
+    }
+
+    #[tokio::test]
+    async fn partial_peer_authority_rejects_peer_request_receipts_without_stream_authority() {
+        let suffix = Uuid::new_v4().simple().to_string();
+        let peer_name = format!("partial-authority-peer-{suffix}");
+        let runtime_name = format!("partial-authority-runtime-{suffix}");
+
+        let peer = CommsRuntime::inproc_only(&peer_name).unwrap();
+        let runtime = Arc::new(CommsRuntime::inproc_only(&runtime_name).unwrap());
+        runtime.install_peer_interaction_handle(Arc::new(TestPeerInteractionHandle::default()));
+        CoreCommsRuntime::add_trusted_peer(
+            runtime.as_ref(),
+            trusted_descriptor(
+                &peer_name,
+                peer.public_key(),
+                &format!("inproc://{peer_name}"),
+            ),
+        )
+        .await
+        .expect("runtime should trust peer");
+        CoreCommsRuntime::add_trusted_peer(
+            &peer,
+            trusted_descriptor(
+                &runtime_name,
+                runtime.public_key(),
+                &format!("inproc://{runtime_name}"),
+            ),
+        )
+        .await
+        .expect("peer should trust runtime");
+
+        let result = CoreCommsRuntime::send(
+            runtime.as_ref(),
+            CommsCommand::PeerRequest {
+                to: peer_route(&peer_name, peer.public_key()),
+                intent: "must-have-complete-authority".to_string(),
+                params: serde_json::json!({}),
+                handling_mode: meerkat_core::types::HandlingMode::Queue,
+                stream: InputStreamMode::None,
+            },
+        )
+        .await;
+
+        assert!(
+            matches!(result, Err(SendError::Validation(ref message)) if message.contains("machine interaction stream authority")),
+            "partial peer authority must fail before emitting PeerRequestSent, got {result:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn partial_peer_authority_rejects_peer_response_receipts_without_stream_authority() {
+        let suffix = Uuid::new_v4().simple().to_string();
+        let peer_name = format!("partial-response-peer-{suffix}");
+        let runtime_name = format!("partial-response-runtime-{suffix}");
+
+        let peer = CommsRuntime::inproc_only(&peer_name).unwrap();
+        let runtime = Arc::new(CommsRuntime::inproc_only(&runtime_name).unwrap());
+        let peer_handle = Arc::new(TestPeerInteractionHandle::default());
+        runtime.install_peer_interaction_handle(peer_handle.clone());
+        CoreCommsRuntime::add_trusted_peer(
+            runtime.as_ref(),
+            trusted_descriptor(
+                &peer_name,
+                peer.public_key(),
+                &format!("inproc://{peer_name}"),
+            ),
+        )
+        .await
+        .expect("runtime should trust peer");
+        CoreCommsRuntime::add_trusted_peer(
+            &peer,
+            trusted_descriptor(
+                &runtime_name,
+                runtime.public_key(),
+                &format!("inproc://{runtime_name}"),
+            ),
+        )
+        .await
+        .expect("peer should trust runtime");
+
+        let interaction_id = Uuid::new_v4();
+        let corr_id = meerkat_core::PeerCorrelationId::from_uuid(interaction_id);
+        meerkat_core::handles::PeerInteractionHandle::request_received(
+            peer_handle.as_ref(),
+            corr_id,
+        )
+        .expect("seed inbound request state");
+
+        let result = CoreCommsRuntime::send(
+            runtime.as_ref(),
+            CommsCommand::PeerResponse {
+                to: peer_route(&peer_name, peer.public_key()),
+                in_reply_to: InteractionId(interaction_id),
+                status: meerkat_core::ResponseStatus::Completed,
+                result: serde_json::json!({"ok": true}),
+                handling_mode: Some(meerkat_core::types::HandlingMode::Queue),
+            },
+        )
+        .await;
+
+        assert!(
+            matches!(result, Err(SendError::Validation(ref message)) if message.contains("machine interaction stream authority")),
+            "partial peer authority must fail before emitting PeerResponseSent, got {result:?}"
+        );
+        assert_eq!(
+            meerkat_core::handles::PeerInteractionHandle::inbound_state(
+                peer_handle.as_ref(),
+                corr_id
+            ),
+            Some(meerkat_core::InboundPeerRequestState::Received),
+            "failed PeerResponse must leave inbound request state retryable"
+        );
     }
 
     #[tokio::test]

--- a/meerkat-core/src/agent.rs
+++ b/meerkat-core/src/agent.rs
@@ -823,6 +823,20 @@ pub trait CommsRuntime: Send + Sync {
         None
     }
 
+    /// Access peer request/response authority only when the runtime has the
+    /// complete machine-owned lifecycle pair.
+    ///
+    /// Semantic peer request/response ingress requires both the peer
+    /// interaction handle and the paired interaction-stream handle. The stream
+    /// handle itself stays hidden behind runtime ownership; this witness lets
+    /// authority boundaries fail closed instead of treating a lone peer handle
+    /// as sufficient.
+    fn peer_request_response_authority_handle(
+        &self,
+    ) -> Option<std::sync::Arc<dyn crate::handles::PeerInteractionHandle>> {
+        None
+    }
+
     /// Drain classified inbox interactions.
     ///
     /// Returns interactions with pre-computed classification from ingress.

--- a/meerkat-runtime/src/comms_drain.rs
+++ b/meerkat-runtime/src/comms_drain.rs
@@ -328,17 +328,30 @@ pub fn spawn_comms_drain(
                             candidate_class,
                             PeerInputClass::SilentRequest | PeerInputClass::ActionableRequest
                         );
-                        if is_inbound_peer_request
-                            && let Some(handle) = comms_runtime.peer_interaction_handle()
-                        {
+                        if is_inbound_peer_request {
+                            let Some(handle) =
+                                comms_runtime.peer_request_response_authority_handle()
+                            else {
+                                tracing::warn!(
+                                    interaction_id = %interaction_id,
+                                    class = ?candidate_class,
+                                    "comms_drain: rejected inbound peer request without complete peer request authority"
+                                );
+                                comms_runtime.mark_interaction_complete(&interaction_id);
+                                continue;
+                            };
                             let corr_id =
                                 meerkat_core::PeerCorrelationId::from_uuid(interaction_id.0);
-                            if let Err(err) = handle.request_received(corr_id) {
+                            if handle.inbound_state(corr_id).is_none()
+                                && let Err(err) = handle.request_received(corr_id)
+                            {
                                 tracing::warn!(
                                     error = %err,
                                     corr_id = %corr_id,
                                     "PeerInteractionHandle::request_received rejected"
                                 );
+                                comms_runtime.mark_interaction_complete(&interaction_id);
+                                continue;
                             }
                         }
 
@@ -922,13 +935,18 @@ async fn resolve_peer_route(
 fn record_bridge_inbound_peer_request(
     comms_runtime: &Arc<dyn CommsRuntime>,
     candidate: &PeerInputCandidate,
-) {
-    let Some(handle) = comms_runtime.peer_interaction_handle() else {
-        return;
+) -> bool {
+    let Some(handle) = comms_runtime.peer_request_response_authority_handle() else {
+        tracing::warn!(
+            interaction_id = %candidate.interaction.id,
+            "comms_drain: rejected supervisor bridge request without complete peer request authority"
+        );
+        comms_runtime.mark_interaction_complete(&candidate.interaction.id);
+        return false;
     };
     let corr_id = meerkat_core::PeerCorrelationId::from_uuid(candidate.interaction.id.0);
     if handle.inbound_state(corr_id).is_some() {
-        return;
+        return true;
     }
     if let Err(err) = handle.request_received(corr_id) {
         tracing::warn!(
@@ -936,7 +954,10 @@ fn record_bridge_inbound_peer_request(
             corr_id = %corr_id,
             "PeerInteractionHandle::request_received rejected for supervisor bridge command"
         );
+        comms_runtime.mark_interaction_complete(&candidate.interaction.id);
+        return false;
     }
+    true
 }
 
 async fn send_bridge_failure(
@@ -985,7 +1006,12 @@ async fn try_handle_supervisor_bridge_command(
 
     // Bridge commands are handled before the generic drain branch that records
     // inbound peer-request state, but their replies are semantic PeerResponses.
-    record_bridge_inbound_peer_request(comms_runtime, candidate);
+    // Treat the bridge pre-dispatch as the same authority boundary: if the
+    // inbound request cannot be recorded under complete peer request/response
+    // authority, do not decode or apply bridge side effects.
+    if !record_bridge_inbound_peer_request(comms_runtime, candidate) {
+        return true;
+    }
 
     let command: BridgeCommand = match decode_bridge_command(params.clone()) {
         Ok(cmd) => cmd,
@@ -1826,7 +1852,7 @@ mod tests {
     use meerkat_core::InteractionId;
     use meerkat_core::SendError;
     use meerkat_core::interaction::InboxInteraction;
-    use meerkat_core::interaction::PeerIngressIdentity;
+    use meerkat_core::interaction::{PeerIngressConvention, PeerIngressIdentity};
     use meerkat_core::types::HandlingMode;
     use serde_json::json;
     use std::collections::{HashMap, HashSet};
@@ -1852,9 +1878,18 @@ mod tests {
         inbound: std::sync::Mutex<HashSet<meerkat_core::PeerCorrelationId>>,
         request_received_count: std::sync::atomic::AtomicUsize,
         response_replied_count: std::sync::atomic::AtomicUsize,
+        reject_request_received: std::sync::atomic::AtomicBool,
     }
 
     impl CountingPeerInteractionHandle {
+        fn rejecting_request_received() -> Self {
+            let handle = Self::default();
+            handle
+                .reject_request_received
+                .store(true, std::sync::atomic::Ordering::SeqCst);
+            handle
+        }
+
         fn rejected(
             context: &'static str,
             corr_id: meerkat_core::PeerCorrelationId,
@@ -1911,6 +1946,15 @@ mod tests {
             &self,
             corr_id: meerkat_core::PeerCorrelationId,
         ) -> Result<(), meerkat_core::handles::DslTransitionError> {
+            if self
+                .reject_request_received
+                .load(std::sync::atomic::Ordering::SeqCst)
+            {
+                return Err(Self::rejected(
+                    "PeerInteractionHandle::request_received",
+                    corr_id,
+                ));
+            }
             let mut inbound = self.inbound.lock().expect("inbound mutex");
             if !inbound.insert(corr_id) {
                 return Err(Self::rejected(
@@ -1961,6 +2005,267 @@ mod tests {
             &self,
             _observer: Arc<dyn meerkat_core::handles::PeerInteractionCleanupObserver>,
         ) {
+        }
+    }
+
+    struct OneShotPeerRequestRuntime {
+        notify: Arc<tokio::sync::Notify>,
+        candidate: std::sync::Mutex<Option<PeerInputCandidate>>,
+        peer_handle: Option<Arc<dyn meerkat_core::handles::PeerInteractionHandle>>,
+        peer_request_response_handle: Option<Arc<dyn meerkat_core::handles::PeerInteractionHandle>>,
+        completed_count: std::sync::atomic::AtomicUsize,
+    }
+
+    impl OneShotPeerRequestRuntime {
+        fn new(
+            candidate: PeerInputCandidate,
+            peer_handle: Option<Arc<dyn meerkat_core::handles::PeerInteractionHandle>>,
+        ) -> Self {
+            Self {
+                notify: Arc::new(tokio::sync::Notify::new()),
+                candidate: std::sync::Mutex::new(Some(candidate)),
+                peer_handle,
+                peer_request_response_handle: None,
+                completed_count: std::sync::atomic::AtomicUsize::new(0),
+            }
+        }
+
+        fn with_complete_authority(
+            candidate: PeerInputCandidate,
+            peer_handle: Arc<dyn meerkat_core::handles::PeerInteractionHandle>,
+        ) -> Self {
+            Self {
+                notify: Arc::new(tokio::sync::Notify::new()),
+                candidate: std::sync::Mutex::new(Some(candidate)),
+                peer_handle: Some(peer_handle.clone()),
+                peer_request_response_handle: Some(peer_handle),
+                completed_count: std::sync::atomic::AtomicUsize::new(0),
+            }
+        }
+
+        fn completed_count(&self) -> usize {
+            self.completed_count
+                .load(std::sync::atomic::Ordering::SeqCst)
+        }
+    }
+
+    #[async_trait::async_trait]
+    impl CommsRuntime for OneShotPeerRequestRuntime {
+        async fn drain_messages(&self) -> Vec<String> {
+            Vec::new()
+        }
+
+        fn inbox_notify(&self) -> Arc<tokio::sync::Notify> {
+            self.notify.clone()
+        }
+
+        fn dismiss_received(&self) -> bool {
+            self.candidate.lock().expect("candidate mutex").is_none()
+        }
+
+        fn peer_interaction_handle(
+            &self,
+        ) -> Option<Arc<dyn meerkat_core::handles::PeerInteractionHandle>> {
+            self.peer_handle.clone()
+        }
+
+        fn peer_request_response_authority_handle(
+            &self,
+        ) -> Option<Arc<dyn meerkat_core::handles::PeerInteractionHandle>> {
+            self.peer_request_response_handle.clone()
+        }
+
+        async fn drain_peer_input_candidates(&self) -> Vec<PeerInputCandidate> {
+            self.candidate
+                .lock()
+                .expect("candidate mutex")
+                .take()
+                .into_iter()
+                .collect()
+        }
+
+        fn mark_interaction_complete(&self, _id: &InteractionId) {
+            self.completed_count
+                .fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+        }
+    }
+
+    fn inbound_peer_request_candidate(class: PeerInputClass) -> PeerInputCandidate {
+        assert!(
+            matches!(
+                class,
+                PeerInputClass::SilentRequest | PeerInputClass::ActionableRequest
+            ),
+            "test helper only builds inbound peer requests"
+        );
+        let id = InteractionId(Uuid::new_v4());
+        let intent = format!("test.inbound.{class:?}");
+        let sender = "partial-authority-peer";
+        PeerInputCandidate {
+            interaction: InboxInteraction {
+                id,
+                from_route: None,
+                from: sender.to_string(),
+                content: InteractionContent::Request {
+                    intent: intent.clone(),
+                    params: json!({ "ok": true }),
+                },
+                rendered_text: String::new(),
+                handling_mode: HandlingMode::Queue,
+                render_metadata: None,
+            },
+            ingress: PeerIngressFact::peer(
+                id,
+                class,
+                meerkat_core::PeerIngressKind::Request,
+                Some(meerkat_core::PeerIngressAuthDecision::Required),
+                PeerIngressIdentity::new(
+                    PeerId::new(),
+                    sender,
+                    PeerIngressConvention::Request {
+                        request_id: id.to_string(),
+                        intent,
+                    },
+                ),
+            ),
+            lifecycle_peer: None,
+            response_terminality: None,
+        }
+    }
+
+    #[tokio::test]
+    async fn rejected_peer_request_recording_rejects_inbound_request_before_machine_admission() {
+        for class in [
+            PeerInputClass::SilentRequest,
+            PeerInputClass::ActionableRequest,
+        ] {
+            let adapter = Arc::new(MeerkatMachine::ephemeral());
+            let session_id = SessionId::new();
+            adapter.register_session(session_id.clone()).await;
+
+            let peer_handle = Arc::new(CountingPeerInteractionHandle::rejecting_request_received());
+            let peer_authority: Arc<dyn meerkat_core::handles::PeerInteractionHandle> = peer_handle;
+            let runtime = Arc::new(OneShotPeerRequestRuntime::with_complete_authority(
+                inbound_peer_request_candidate(class),
+                peer_authority,
+            ));
+            let drain = spawn_comms_drain(
+                adapter.clone(),
+                session_id.clone(),
+                runtime.clone(),
+                Some(Duration::from_millis(10)),
+            );
+
+            tokio::time::timeout(Duration::from_secs(1), drain)
+                .await
+                .expect("drain should exit after one candidate")
+                .expect("drain task should not panic");
+
+            let snapshot = adapter
+                .meerkat_machine_spine_snapshot(&session_id)
+                .await
+                .expect("registered session snapshot");
+            assert_eq!(
+                snapshot.ledger.input_count, 0,
+                "rejected PeerRequestReceived must not admit {class:?} into machine work"
+            );
+            assert_eq!(
+                runtime.completed_count(),
+                1,
+                "rejected {class:?} should be closed at the comms boundary"
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn incomplete_peer_request_authority_rejects_inbound_request_before_machine_admission() {
+        for class in [
+            PeerInputClass::SilentRequest,
+            PeerInputClass::ActionableRequest,
+        ] {
+            let adapter = Arc::new(MeerkatMachine::ephemeral());
+            let session_id = SessionId::new();
+            adapter.register_session(session_id.clone()).await;
+
+            let peer_handle = Arc::new(CountingPeerInteractionHandle::default());
+            let peer_authority: Arc<dyn meerkat_core::handles::PeerInteractionHandle> =
+                peer_handle.clone();
+            let runtime = Arc::new(OneShotPeerRequestRuntime::new(
+                inbound_peer_request_candidate(class),
+                Some(peer_authority),
+            ));
+            let drain = spawn_comms_drain(
+                adapter.clone(),
+                session_id.clone(),
+                runtime.clone(),
+                Some(Duration::from_millis(10)),
+            );
+
+            tokio::time::timeout(Duration::from_secs(1), drain)
+                .await
+                .expect("drain should exit after one candidate")
+                .expect("drain task should not panic");
+
+            let snapshot = adapter
+                .meerkat_machine_spine_snapshot(&session_id)
+                .await
+                .expect("registered session snapshot");
+            assert_eq!(
+                peer_handle.request_received_count(),
+                0,
+                "partial authority must not fire PeerRequestReceived for {class:?}"
+            );
+            assert_eq!(
+                snapshot.ledger.input_count, 0,
+                "partial authority must not admit {class:?} into machine work"
+            );
+            assert_eq!(
+                runtime.completed_count(),
+                1,
+                "rejected {class:?} should be closed at the comms boundary"
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn absent_peer_request_authority_rejects_inbound_request_before_machine_admission() {
+        for class in [
+            PeerInputClass::SilentRequest,
+            PeerInputClass::ActionableRequest,
+        ] {
+            let adapter = Arc::new(MeerkatMachine::ephemeral());
+            let session_id = SessionId::new();
+            adapter.register_session(session_id.clone()).await;
+
+            let runtime = Arc::new(OneShotPeerRequestRuntime::new(
+                inbound_peer_request_candidate(class),
+                None,
+            ));
+            let drain = spawn_comms_drain(
+                adapter.clone(),
+                session_id.clone(),
+                runtime.clone(),
+                Some(Duration::from_millis(10)),
+            );
+
+            tokio::time::timeout(Duration::from_secs(1), drain)
+                .await
+                .expect("drain should exit after one candidate")
+                .expect("drain task should not panic");
+
+            let snapshot = adapter
+                .meerkat_machine_spine_snapshot(&session_id)
+                .await
+                .expect("registered session snapshot");
+            assert_eq!(
+                snapshot.ledger.input_count, 0,
+                "missing authority must not admit {class:?} into machine work"
+            );
+            assert_eq!(
+                runtime.completed_count(),
+                1,
+                "rejected {class:?} should be closed at the comms boundary"
+            );
         }
     }
 
@@ -2442,6 +2747,9 @@ mod tests {
         add_trusted_peer_errors: HashMap<String, String>,
         remove_trusted_peer_errors: HashMap<String, String>,
         trusted_peer_ids: Arc<tokio::sync::Mutex<HashSet<String>>>,
+        peer_handle: Option<Arc<dyn meerkat_core::handles::PeerInteractionHandle>>,
+        peer_request_response_handle: Option<Arc<dyn meerkat_core::handles::PeerInteractionHandle>>,
+        completed_count: Arc<std::sync::atomic::AtomicUsize>,
     }
 
     #[async_trait::async_trait]
@@ -2466,6 +2774,23 @@ mod tests {
             self.inbox_notify.clone()
         }
 
+        fn peer_interaction_handle(
+            &self,
+        ) -> Option<Arc<dyn meerkat_core::handles::PeerInteractionHandle>> {
+            self.peer_handle.clone()
+        }
+
+        fn peer_request_response_authority_handle(
+            &self,
+        ) -> Option<Arc<dyn meerkat_core::handles::PeerInteractionHandle>> {
+            self.peer_request_response_handle.clone()
+        }
+
+        fn mark_interaction_complete(&self, _id: &InteractionId) {
+            self.completed_count
+                .fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+        }
+
         async fn add_trusted_peer(&self, peer: TrustedPeerDescriptor) -> Result<(), SendError> {
             let peer_id_str = peer.peer_id.as_str();
             if let Some(message) = self.add_trusted_peer_errors.get(&peer_id_str) {
@@ -2488,6 +2813,8 @@ mod tests {
         address: &str,
         bootstrap_token: Option<&str>,
     ) -> BootstrapRuntime {
+        let peer_handle = Arc::new(CountingPeerInteractionHandle::default());
+        let peer_handle: Arc<dyn meerkat_core::handles::PeerInteractionHandle> = peer_handle;
         BootstrapRuntime {
             peer_id: peer_id.to_string(),
             address: address.to_string(),
@@ -2496,6 +2823,9 @@ mod tests {
             add_trusted_peer_errors: HashMap::new(),
             remove_trusted_peer_errors: HashMap::new(),
             trusted_peer_ids: Arc::new(tokio::sync::Mutex::new(HashSet::new())),
+            peer_handle: Some(peer_handle.clone()),
+            peer_request_response_handle: Some(peer_handle),
+            completed_count: Arc::new(std::sync::atomic::AtomicUsize::new(0)),
         }
     }
 
@@ -3004,6 +3334,95 @@ mod tests {
         }
     }
 
+    #[tokio::test]
+    async fn bridge_request_without_complete_peer_authority_fails_before_dispatch() {
+        for install_peer_handle in [false, true] {
+            let payload = sample_bind_payload();
+            let sender = payload.supervisor.peer_id.clone();
+            let mut runtime_impl = bootstrap_runtime(
+                PEER_ID_RECEIVER,
+                "inproc://receiver",
+                Some("expected-token"),
+            );
+            let peer_handle = Arc::new(CountingPeerInteractionHandle::default());
+            if install_peer_handle {
+                let peer_handle: Arc<dyn meerkat_core::handles::PeerInteractionHandle> =
+                    peer_handle.clone();
+                runtime_impl.peer_handle = Some(peer_handle);
+            } else {
+                runtime_impl.peer_handle = None;
+            }
+            runtime_impl.peer_request_response_handle = None;
+            let completed_count = runtime_impl.completed_count.clone();
+            let runtime: Arc<dyn CommsRuntime> = Arc::new(runtime_impl);
+            let adapter = Arc::new(MeerkatMachine::ephemeral());
+            let session_id = SessionId::new();
+            adapter.register_session(session_id.clone()).await;
+            let candidate = bridge_candidate(&sender, &BridgeCommand::BindMember(payload));
+
+            assert!(
+                try_handle_supervisor_bridge_command(&adapter, &session_id, &runtime, &candidate)
+                    .await,
+                "bridge handler must own bridge requests even when rejecting authority"
+            );
+            assert!(
+                matches!(
+                    adapter.supervisor_binding(&session_id).await,
+                    SupervisorBinding::Unbound
+                ),
+                "bridge request must not mutate supervisor binding without complete authority"
+            );
+            assert_eq!(
+                peer_handle.request_received_count(),
+                0,
+                "peer-only authority must not record PeerRequestReceived through bridge dispatch"
+            );
+            assert_eq!(
+                completed_count.load(std::sync::atomic::Ordering::SeqCst),
+                1,
+                "bridge request rejected at the authority boundary should be marked complete"
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn bridge_request_rejected_by_peer_authority_fails_before_dispatch() {
+        let payload = sample_bind_payload();
+        let sender = payload.supervisor.peer_id.clone();
+        let mut runtime_impl = bootstrap_runtime(
+            PEER_ID_RECEIVER,
+            "inproc://receiver",
+            Some("expected-token"),
+        );
+        let peer_handle = Arc::new(CountingPeerInteractionHandle::rejecting_request_received());
+        let peer_handle: Arc<dyn meerkat_core::handles::PeerInteractionHandle> = peer_handle;
+        runtime_impl.peer_handle = Some(peer_handle.clone());
+        runtime_impl.peer_request_response_handle = Some(peer_handle);
+        let completed_count = runtime_impl.completed_count.clone();
+        let runtime: Arc<dyn CommsRuntime> = Arc::new(runtime_impl);
+        let adapter = Arc::new(MeerkatMachine::ephemeral());
+        let session_id = SessionId::new();
+        adapter.register_session(session_id.clone()).await;
+        let candidate = bridge_candidate(&sender, &BridgeCommand::BindMember(payload));
+
+        assert!(
+            try_handle_supervisor_bridge_command(&adapter, &session_id, &runtime, &candidate).await,
+            "bridge handler must own bridge requests even when rejecting authority"
+        );
+        assert!(
+            matches!(
+                adapter.supervisor_binding(&session_id).await,
+                SupervisorBinding::Unbound
+            ),
+            "bridge request must not mutate supervisor binding when PeerRequestReceived is rejected"
+        );
+        assert_eq!(
+            completed_count.load(std::sync::atomic::Ordering::SeqCst),
+            1,
+            "bridge request rejected by peer authority should be marked complete"
+        );
+    }
+
     fn authorized_state_for(
         payload: &meerkat_contracts::wire::supervisor_bridge::BridgeBindPayload,
     ) -> SupervisorBinding {
@@ -3374,6 +3793,12 @@ mod tests {
 
         fn inbox_notify(&self) -> Arc<tokio::sync::Notify> {
             self.inbox_notify.clone()
+        }
+
+        fn peer_request_response_authority_handle(
+            &self,
+        ) -> Option<Arc<dyn meerkat_core::handles::PeerInteractionHandle>> {
+            Some(Arc::new(CountingPeerInteractionHandle::default()))
         }
 
         async fn add_trusted_peer(&self, _peer: TrustedPeerDescriptor) -> Result<(), SendError> {

--- a/meerkat-runtime/tests/meerkat_machine.rs
+++ b/meerkat-runtime/tests/meerkat_machine.rs
@@ -840,7 +840,9 @@ async fn runtime_comms_terminal_response_wake_drains_requester_queue() {
     use meerkat_core::lifecycle::run_control::RunControlCommand;
     use meerkat_core::lifecycle::run_primitive::{RunApplyBoundary, RunPrimitive};
     use meerkat_core::lifecycle::run_receipt::RunBoundaryReceipt;
-    use meerkat_core::{HandlingMode, InteractionContent, InteractionId, ResponseStatus};
+    use meerkat_core::{
+        HandlingMode, InteractionContent, InteractionId, PeerCorrelationId, ResponseStatus,
+    };
     use meerkat_runtime::PeerConvention;
     use tokio::sync::Notify;
     use uuid::Uuid;
@@ -936,7 +938,24 @@ async fn runtime_comms_terminal_response_wake_drains_requester_queue() {
         .await
         .expect("prepare runtime bindings");
     requester_comms.install_peer_comms_handle(Arc::clone(&bindings.peer_comms));
-    requester_comms.install_peer_interaction_handle(Arc::clone(&bindings.peer_interaction));
+    requester_comms.install_peer_request_response_authority(
+        meerkat_comms::PeerRequestResponseAuthority::new(
+            Arc::clone(&bindings.peer_interaction),
+            Arc::clone(&bindings.interaction_stream),
+        ),
+    );
+    let responder_adapter = Arc::new(MeerkatMachine::ephemeral());
+    let responder_sid = SessionId::new();
+    let responder_bindings = responder_adapter
+        .prepare_bindings(responder_sid)
+        .await
+        .expect("prepare responder runtime bindings");
+    responder_comms.install_peer_request_response_authority(
+        meerkat_comms::PeerRequestResponseAuthority::new(
+            Arc::clone(&responder_bindings.peer_interaction),
+            Arc::clone(&responder_bindings.interaction_stream),
+        ),
+    );
 
     let calls = Arc::new(AtomicUsize::new(0));
     let first_apply_started = Arc::new(Notify::new());
@@ -997,6 +1016,10 @@ async fn runtime_comms_terminal_response_wake_drains_requester_queue() {
         request_at_responder[0].interaction.content,
         InteractionContent::Request { .. }
     ));
+    responder_bindings
+        .peer_interaction
+        .request_received(PeerCorrelationId::from_uuid(request_id))
+        .expect("seed responder inbound request state");
 
     CoreCommsRuntime::send(
         responder_comms.as_ref(),


### PR DESCRIPTION
## Summary
- require both peer-interaction and interaction-stream handles before advertising or sending semantic peer request/response commands
- add partial-authority regression coverage for peer directory, PeerRequest, and PeerResponse fail-closed behavior
- update the runtime terminal-response fixture to install full peer request/response authority on both sides

## Validation
- ./scripts/repo-cargo test -p meerkat-comms partial_peer_authority
- ./scripts/repo-cargo test -p meerkat-comms authority
- ./scripts/repo-cargo test -p meerkat-runtime --test meerkat_machine runtime_comms_terminal_response_wake_drains_requester_queue
- ./scripts/repo-cargo test -p meerkat-mob peer_response
- ./scripts/repo-cargo test -p meerkat-mob test_rotate_supervisor_reauthorizes_live_remote_members_and_rejects_stale_epoch
- ./scripts/repo-cargo fmt --check
- git diff --check
- make check

Linear: LUC-200