### PR TITLE
LUC-193 Make auth status surfaces lease-owned

### DIFF
--- a/artifacts/schemas/rest-openapi.json
+++ b/artifacts/schemas/rest-openapi.json
@@ -55,6 +55,18 @@
         ],
         "type": "object"
       },
+      "AuthStatusPhase": {
+        "description": "Public auth status phase shared by REST, RPC, CLI, and generated SDK wire\npayloads.\n\nThis is the compatibility projection of typed auth lease truth. Surfaces\nshould map to this enum first and only then emit [`Self::as_public_str`].",
+        "enum": [
+          "valid",
+          "expiring",
+          "expired",
+          "reauth_required",
+          "refresh_failed",
+          "unknown"
+        ],
+        "type": "string"
+      },
       "BindingId": {
         "description": "Opaque slug identifying a binding inside a realm.",
         "type": "string"
@@ -12152,8 +12164,8 @@
             "type": "string"
           },
           "state": {
-            "description": "High-level health: \"valid\" / \"expiring\" / \"expired\" /\n\"reauth_required\" / \"refresh_failed\" / \"unknown\".",
-            "type": "string"
+            "$ref": "#/components/schemas/AuthStatusPhase",
+            "description": "High-level health projected from typed auth-lease lifecycle truth."
           }
         },
         "required": [
@@ -12208,7 +12220,7 @@
             "type": "string"
           },
           "state": {
-            "type": "string"
+            "$ref": "#/components/schemas/AuthStatusPhase"
           }
         },
         "required": [

--- a/artifacts/schemas/wire-types.json
+++ b/artifacts/schemas/wire-types.json
@@ -14458,6 +14458,18 @@
   },
   "WireAuthStatus": {
     "$defs": {
+      "AuthStatusPhase": {
+        "description": "Public auth status phase shared by REST, RPC, CLI, and generated SDK wire\npayloads.\n\nThis is the compatibility projection of typed auth lease truth. Surfaces\nshould map to this enum first and only then emit [`Self::as_public_str`].",
+        "enum": [
+          "valid",
+          "expiring",
+          "expired",
+          "reauth_required",
+          "refresh_failed",
+          "unknown"
+        ],
+        "type": "string"
+      },
       "WireAuthError": {
         "description": "Stable wire kind for auth errors. Mirrors `meerkat_core::AuthErrorKind`\non the wire as a normalized string.",
         "oneOf": [
@@ -14650,8 +14662,8 @@
         "type": "string"
       },
       "state": {
-        "description": "High-level health: \"valid\" / \"expiring\" / \"expired\" /\n\"reauth_required\" / \"refresh_failed\" / \"unknown\".",
-        "type": "string"
+        "$ref": "#/$defs/AuthStatusPhase",
+        "description": "High-level health projected from typed auth-lease lifecycle truth."
       }
     },
     "required": [
@@ -14665,6 +14677,18 @@
   },
   "WireAuthStatusDetail": {
     "$defs": {
+      "AuthStatusPhase": {
+        "description": "Public auth status phase shared by REST, RPC, CLI, and generated SDK wire\npayloads.\n\nThis is the compatibility projection of typed auth lease truth. Surfaces\nshould map to this enum first and only then emit [`Self::as_public_str`].",
+        "enum": [
+          "valid",
+          "expiring",
+          "expired",
+          "reauth_required",
+          "refresh_failed",
+          "unknown"
+        ],
+        "type": "string"
+      },
       "BindingId": {
         "description": "Opaque slug identifying a binding inside a realm.",
         "type": "string"
@@ -14747,7 +14771,7 @@
         "type": "string"
       },
       "state": {
-        "type": "string"
+        "$ref": "#/$defs/AuthStatusPhase"
       }
     },
     "required": [

--- a/meerkat-cli/src/main.rs
+++ b/meerkat-cli/src/main.rs
@@ -1386,8 +1386,7 @@ enum AuthCommands {
     },
 
     /// Print auth profile status — reports realm config shape and the
-    /// state of the persisted TokenStore entry (auth_mode, expiry,
-    /// refresh attempt count).
+    /// observed AuthMachine lease lifecycle state.
     Status {
         /// Realm id.
         #[arg(long, default_value = "dev")]
@@ -2933,92 +2932,23 @@ async fn handle_auth_command(command: AuthCommands, scope: &RuntimeScope) -> any
             println!("provider:    {}", profile.provider.as_str());
             println!("auth_method: {}", profile.auth_method);
             println!("source_kind: {}", source_kind_label(&profile.source));
-            // TokenStore lookup: `<realm>:<profile_id>` is the canonical key.
-            #[cfg(all(feature = "anthropic", feature = "openai", feature = "gemini"))]
-            {
-                use meerkat_core::handles::{AuthLeaseHandle, LeaseKey};
-                use meerkat_providers::auth_store::{TokenKey, TokenStoreBackend};
-                let store = TokenStoreBackend::default_auto()
-                    .map_err(|e| anyhow::anyhow!("Cannot open TokenStore: {e}"))?
-                    .open()
-                    .map_err(|e| anyhow::anyhow!("Cannot open TokenStore: {e}"))?;
-                let key = TokenKey::parse(&realm, &profile_id)
-                    .map_err(|e| anyhow::anyhow!("invalid token-key realm/profile: {e}"))?;
-                let stored = store
-                    .load(&key)
-                    .await
-                    .map_err(|e| anyhow::anyhow!("TokenStore load failed: {e}"))?;
-                let connection_ref = meerkat_core::ConnectionRef {
-                    realm: key.realm.clone(),
-                    binding: key.binding.clone(),
-                    profile: key.profile.clone(),
-                };
-                let auth_lease = meerkat_runtime::RuntimeAuthLeaseHandle::new();
-                let snapshot = auth_lease.snapshot(&LeaseKey::from_connection_ref(&connection_ref));
-                let projection = meerkat_core::project_published_auth_status(
-                    chrono::Utc::now(),
-                    stored.as_ref(),
-                    &snapshot,
-                );
-                match projection.tokens {
-                    Some(tokens) => {
-                        println!("state:       {}", projection.phase.as_public_str());
-                        println!("auth_mode:   {:?}", tokens.auth_mode);
-                        println!(
-                            "has_secret:  {}",
-                            tokens
-                                .primary_secret
-                                .as_ref()
-                                .map(|s| !s.is_empty())
-                                .unwrap_or(false)
-                        );
-                        println!(
-                            "has_refresh: {}",
-                            tokens
-                                .refresh_token
-                                .as_ref()
-                                .map(|s| !s.is_empty())
-                                .unwrap_or(false)
-                        );
-                        if let Some(expires_at) = tokens.expires_at {
-                            println!("expires_at:  {}", expires_at.to_rfc3339());
-                        }
-                        if let Some(last_refresh) = tokens.last_refresh {
-                            println!("last_refresh:{}", last_refresh.to_rfc3339());
-                        }
-                        if let Some(account_id) = tokens.account_id.as_ref() {
-                            println!("account_id:  {account_id}");
-                        }
-                        if !tokens.scopes.is_empty() {
-                            println!("scopes:      {}", tokens.scopes.join(", "));
-                        }
-                        println!("backend:     {}", store.backend_name());
-                    }
-                    None => {
-                        println!("state:       {}", projection.phase.as_public_str());
-                        println!("backend:     {}", store.backend_name());
-                        if stored.is_none() {
-                            println!(
-                                "note:        no persisted credential for '{realm}:{profile_id}';"
-                            );
-                            println!(
-                                "             run `rkat auth login {}` or rely on env-var fallback.",
-                                profile.provider.as_str(),
-                            );
-                        } else {
-                            println!(
-                                "note:        persisted credential metadata hidden until AuthMachine lifecycle is live."
-                            );
-                        }
-                    }
-                }
+            use meerkat_core::handles::{AuthLeaseHandle, LeaseKey};
+            let connection_ref = ConnectionRef {
+                realm: meerkat_core::RealmId::parse(realm.clone())
+                    .map_err(|e| anyhow::anyhow!("invalid realm id '{realm}': {e}"))?,
+                binding: meerkat_core::BindingId::parse(profile_id.clone())
+                    .map_err(|e| anyhow::anyhow!("invalid binding id '{profile_id}': {e}"))?,
+                profile: None,
+            };
+            let auth_lease = meerkat_runtime::RuntimeAuthLeaseHandle::new();
+            let snapshot = auth_lease.snapshot(&LeaseKey::from_connection_ref(&connection_ref));
+            let phase = AuthStatusPhase::from_lease_snapshot(chrono::Utc::now(), &snapshot);
+            println!("state:       {}", phase.as_public_str());
+            if let Some(expires_at) = meerkat_core::lease_snapshot_expires_at_datetime(&snapshot) {
+                println!("expires_at:  {}", expires_at.to_rfc3339());
             }
-            #[cfg(not(all(feature = "anthropic", feature = "openai", feature = "gemini")))]
-            {
-                println!(
-                    "state:       {} (TokenStore disabled at build time)",
-                    AuthStatusPhase::Unknown.as_public_str()
-                );
+            if phase == AuthStatusPhase::Unknown {
+                println!("note:        no live AuthMachine lease for '{realm}:{profile_id}'.");
             }
         }
         AuthCommands::ProfileDelete {

--- a/meerkat-cli/src/main.rs
+++ b/meerkat-cli/src/main.rs
@@ -2894,7 +2894,7 @@ async fn handle_auth_command(command: AuthCommands, scope: &RuntimeScope) -> any
                 .ok_or_else(|| anyhow::anyhow!("Unknown realm '{realm}'"))?;
             let realm_set = meerkat_core::RealmConnectionSet::from_config(&realm, section)
                 .map_err(|e| anyhow::anyhow!("Realm config invalid: {e}"))?;
-            let registry = meerkat_providers::ProviderRuntimeRegistry::empty();
+            let registry = cli_provider_registry();
             let env = meerkat_providers::ResolverEnvironment::with_process_env()
                 .with_auth_lease_handle(Arc::clone(&scope.auth_lease));
             let connection_ref = meerkat_core::ConnectionRef {
@@ -2994,8 +2994,9 @@ async fn handle_auth_command(command: AuthCommands, scope: &RuntimeScope) -> any
                     .map_err(|e| anyhow::anyhow!("Cannot open TokenStore: {e}"))?
                     .open()
                     .map_err(|e| anyhow::anyhow!("Cannot open TokenStore: {e}"))?;
-                let key = TokenKey::parse(&realm, &profile_id)
-                    .map_err(|e| anyhow::anyhow!("invalid token-key realm/profile: {e}"))?;
+                let binding_id = auth_status_binding_id(&realm, &profile_id, &realm_set)?;
+                let key = TokenKey::parse(&realm, binding_id)
+                    .map_err(|e| anyhow::anyhow!("invalid token-key realm/binding: {e}"))?;
                 let should_clear = match store.load(&key).await {
                     Ok(present) => present.is_some(),
                     Err(e) if token_store_load_error_allows_clear(&e) => true,
@@ -3017,7 +3018,7 @@ async fn handle_auth_command(command: AuthCommands, scope: &RuntimeScope) -> any
                     println!("deleted: {}:{}", key.realm.as_str(), key.binding.as_str());
                 } else {
                     println!(
-                        "nothing to delete: no persisted credential for '{realm}:{profile_id}'"
+                        "nothing to delete: no persisted credential for '{realm}:{binding_id}'"
                     );
                 }
             }
@@ -3192,18 +3193,7 @@ async fn refresh_auth_profile(
         return Ok(());
     }
 
-    // Find a binding that references this auth profile.
-    let binding_id = realm_set
-        .bindings
-        .iter()
-        .find(|(_, b)| b.auth_profile == profile_id)
-        .map(|(id, _)| id.clone())
-        .ok_or_else(|| {
-            anyhow::anyhow!(
-                "No binding in realm '{realm}' references auth profile '{profile_id}'; \
-                 refresh requires a binding to drive the resolver."
-            )
-        })?;
+    let binding_id = auth_status_binding_id(realm, profile_id, &realm_set)?.to_string();
 
     // Wire the TokenStore + RefreshCoordinator into the environment so
     // the refresh write-back reaches persistent storage.
@@ -3214,8 +3204,8 @@ async fn refresh_auth_profile(
     let coord: StdArc<dyn RefreshCoordinator> = StdArc::new(InMemoryCoordinator::default());
 
     // Pre-state for the reported diff.
-    let key = TokenKey::parse(&realm, &profile_id)
-        .map_err(|e| anyhow::anyhow!("invalid token-key realm/profile: {e}"))?;
+    let key = TokenKey::parse(realm, &binding_id)
+        .map_err(|e| anyhow::anyhow!("invalid token-key realm/binding: {e}"))?;
     let before = store
         .load(&key)
         .await
@@ -3223,6 +3213,7 @@ async fn refresh_auth_profile(
     if before.is_none() {
         println!(
             "profile:       {realm}:{profile_id}\n\
+             binding:       {realm}:{binding_id}\n\
              refresh:       skipped\n\
              reason:        no persisted credential; run `rkat auth login {}` first",
             profile.provider.as_str(),
@@ -3234,7 +3225,7 @@ async fn refresh_auth_profile(
         .with_token_store(store.clone())
         .with_refresh_coordinator(coord)
         .with_auth_lease_handle(Arc::clone(&scope.auth_lease));
-    let registry = meerkat_providers::ProviderRuntimeRegistry::empty();
+    let registry = cli_provider_registry();
     let connection_ref = meerkat_core::ConnectionRef {
         realm: meerkat_core::RealmId::parse(realm)
             .map_err(|e| anyhow::anyhow!("invalid realm id '{realm}': {e}"))?,
@@ -3259,8 +3250,18 @@ async fn refresh_auth_profile(
         .load(&key)
         .await
         .map_err(|e| anyhow::anyhow!("TokenStore reload failed: {e}"))?;
+    let Some(after_tokens) = after.as_ref() else {
+        anyhow::bail!("Refresh completed but TokenStore no longer has '{realm}:{binding_id}'");
+    };
+    meerkat_core::publish_token_lifecycle_acquired(
+        scope.auth_lease.as_ref(),
+        &connection_ref,
+        after_tokens,
+    )
+    .map_err(|e| anyhow::anyhow!("AuthMachine lifecycle acquire failed: {e}"))?;
 
     println!("profile:       {realm}:{profile_id}");
+    println!("binding:       {realm}:{binding_id}");
     println!("auth_method:   {}", profile.auth_method);
     println!("refresh:       ok");
     if let Some(before) = before.as_ref()
@@ -3492,6 +3493,58 @@ fn resolve_login_provider(hint: Option<&str>) -> anyhow::Result<LoginProvider> {
 }
 
 #[cfg(all(feature = "anthropic", feature = "openai", feature = "gemini"))]
+fn connection_ref_from_token_key(key: &meerkat_providers::auth_store::TokenKey) -> ConnectionRef {
+    ConnectionRef {
+        realm: key.realm.clone(),
+        binding: key.binding.clone(),
+        profile: key.profile.clone(),
+    }
+}
+
+#[cfg(all(feature = "anthropic", feature = "openai", feature = "gemini"))]
+async fn save_cli_tokens_and_publish_lifecycle(
+    store: &dyn meerkat_providers::auth_store::TokenStore,
+    auth_lease: &dyn meerkat_core::handles::AuthLeaseHandle,
+    connection_ref: &ConnectionRef,
+    tokens: &meerkat_providers::auth_store::PersistedTokens,
+) -> anyhow::Result<()> {
+    let key = meerkat_providers::auth_store::TokenKey::from_connection_ref(connection_ref);
+    let previous = store
+        .load(&key)
+        .await
+        .map_err(|e| anyhow::anyhow!("TokenStore load failed: {e}"))?;
+    store
+        .save(&key, tokens)
+        .await
+        .map_err(|e| anyhow::anyhow!("Failed to persist tokens: {e}"))?;
+    if let Err(e) =
+        meerkat_core::publish_token_lifecycle_acquired(auth_lease, connection_ref, tokens)
+    {
+        if let Err(rollback_error) =
+            restore_cli_tokens_after_lifecycle_failure(store, &key, previous.as_ref()).await
+        {
+            anyhow::bail!(
+                "AuthMachine lifecycle acquire failed: {e}; TokenStore rollback failed: {rollback_error}"
+            );
+        }
+        anyhow::bail!("AuthMachine lifecycle acquire failed: {e}");
+    }
+    Ok(())
+}
+
+#[cfg(all(feature = "anthropic", feature = "openai", feature = "gemini"))]
+async fn restore_cli_tokens_after_lifecycle_failure(
+    store: &dyn meerkat_providers::auth_store::TokenStore,
+    key: &meerkat_providers::auth_store::TokenKey,
+    previous: Option<&meerkat_providers::auth_store::PersistedTokens>,
+) -> Result<(), meerkat_providers::auth_store::TokenStoreError> {
+    match previous {
+        Some(tokens) => store.save(key, tokens).await,
+        None => store.clear(key).await,
+    }
+}
+
+#[cfg(all(feature = "anthropic", feature = "openai", feature = "gemini"))]
 /// Plan §4d.cli.1: non-interactive login path. Resolves the secret
 /// (from `--secret` or stdin), validates against the requested
 /// (backend, method) shape, and writes an api_key-style entry into
@@ -3503,7 +3556,7 @@ async fn noninteractive_login(
     backend_hint: Option<&str>,
     method_hint: Option<&str>,
     secret: Option<&str>,
-    _scope: &RuntimeScope,
+    scope: &RuntimeScope,
 ) -> anyhow::Result<()> {
     use meerkat_providers::auth_store::{
         PersistedAuthMode, PersistedTokens, TokenKey, TokenStoreBackend,
@@ -3577,7 +3630,14 @@ async fn noninteractive_login(
             "source": "rkat auth login --non-interactive",
         }),
     };
-    store.save(&key, &persisted).await?;
+    let connection_ref = connection_ref_from_token_key(&key);
+    save_cli_tokens_and_publish_lifecycle(
+        store.as_ref(),
+        scope.auth_lease.as_ref(),
+        &connection_ref,
+        &persisted,
+    )
+    .await?;
     println!("ok: wrote api_key for {provider_lc} into TokenStore under dev:default_{provider_lc}");
     Ok(())
 }
@@ -3585,7 +3645,7 @@ async fn noninteractive_login(
 #[cfg(all(feature = "anthropic", feature = "openai", feature = "gemini"))]
 async fn interactive_login(
     provider_hint: Option<&str>,
-    _scope: &RuntimeScope,
+    scope: &RuntimeScope,
 ) -> anyhow::Result<()> {
     use std::sync::Arc as StdArc;
     use std::time::Duration;
@@ -3772,10 +3832,14 @@ async fn interactive_login(
         .map_err(|e| anyhow::anyhow!("Cannot open TokenStore: {e}"))?
         .open()
         .map_err(|e| anyhow::anyhow!("Cannot open TokenStore: {e}"))?;
-    store
-        .save(&key, &tokens)
-        .await
-        .map_err(|e| anyhow::anyhow!("Failed to persist tokens: {e}"))?;
+    let connection_ref = connection_ref_from_token_key(&key);
+    save_cli_tokens_and_publish_lifecycle(
+        store.as_ref(),
+        scope.auth_lease.as_ref(),
+        &connection_ref,
+        &tokens,
+    )
+    .await?;
     print_ok("Tokens persisted securely (keyring if available, file 0o600 otherwise).");
 
     // --- Success summary + next steps -----------------------------
@@ -3959,6 +4023,25 @@ fn auth_status_binding_id<'a>(
             matches.join(", ")
         ),
     }
+}
+
+fn cli_provider_registry() -> meerkat_providers::ProviderRuntimeRegistry {
+    #[allow(unused_mut)]
+    let mut registry = meerkat_providers::ProviderRuntimeRegistry::empty();
+    #[cfg(feature = "anthropic")]
+    {
+        registry = registry.with_runtime(Arc::new(meerkat_anthropic::AnthropicProviderRuntime));
+    }
+    #[cfg(feature = "openai")]
+    {
+        registry = registry.with_runtime(Arc::new(meerkat_openai::OpenAiProviderRuntime));
+        registry = registry.with_runtime(Arc::new(meerkat_providers::SelfHostedProviderRuntime));
+    }
+    #[cfg(feature = "gemini")]
+    {
+        registry = registry.with_runtime(Arc::new(meerkat_gemini::GoogleProviderRuntime));
+    }
+    registry
 }
 
 const SELF_HOSTED_LEGACY_REALM_ID: &str = "self_hosted_legacy";
@@ -9901,6 +9984,53 @@ mod tests {
             user_config_root: None,
             auth_lease: Arc::new(meerkat_runtime::RuntimeAuthLeaseHandle::new()),
         }
+    }
+
+    #[cfg(all(feature = "anthropic", feature = "openai", feature = "gemini"))]
+    #[tokio::test]
+    async fn test_cli_login_save_boundary_publishes_binding_scoped_auth_lease() {
+        use meerkat_core::handles::{AuthLeaseHandle, AuthLeasePhase, LeaseKey};
+        use meerkat_providers::auth_store::{
+            EphemeralTokenStore, PersistedAuthMode, PersistedTokens, TokenKey, TokenStore,
+        };
+
+        let store = EphemeralTokenStore::new();
+        let auth_lease = meerkat_runtime::RuntimeAuthLeaseHandle::new();
+        let connection_ref = meerkat_core::ConnectionRef {
+            realm: meerkat_core::RealmId::parse("dev").expect("realm id parses"),
+            binding: meerkat_core::BindingId::parse("default_openai").expect("binding id parses"),
+            profile: None,
+        };
+        let tokens = PersistedTokens {
+            auth_mode: PersistedAuthMode::ApiKey,
+            primary_secret: Some("sk-test".into()),
+            refresh_token: None,
+            id_token: None,
+            expires_at: None,
+            last_refresh: Some(chrono::Utc::now()),
+            scopes: Vec::new(),
+            account_id: None,
+            metadata: serde_json::Value::Null,
+        };
+
+        save_cli_tokens_and_publish_lifecycle(&store, &auth_lease, &connection_ref, &tokens)
+            .await
+            .expect("login save boundary should publish lease lifecycle");
+
+        let lease_key = LeaseKey::from_connection_ref(&connection_ref);
+        assert_eq!(
+            auth_lease.snapshot(&lease_key).phase,
+            Some(AuthLeasePhase::Valid),
+            "CLI login must acquire the binding-scoped AuthMachine lease that status reads"
+        );
+        assert!(
+            store
+                .load(&TokenKey::from_connection_ref(&connection_ref))
+                .await
+                .expect("token load succeeds")
+                .is_some(),
+            "login save boundary should still persist token material"
+        );
     }
 
     async fn serve_one_models_request_requiring_bearer_token(

--- a/meerkat-cli/src/main.rs
+++ b/meerkat-cli/src/main.rs
@@ -2594,6 +2594,7 @@ struct RuntimeScope {
     origin_hint: RealmOrigin,
     context_root: Option<PathBuf>,
     user_config_root: Option<PathBuf>,
+    auth_lease: Arc<dyn meerkat_core::handles::AuthLeaseHandle>,
 }
 
 impl RuntimeScope {
@@ -2644,6 +2645,7 @@ fn resolve_runtime_scope(cli: &Cli) -> anyhow::Result<RuntimeScope> {
         origin_hint,
         context_root,
         user_config_root,
+        auth_lease: Arc::new(meerkat_runtime::RuntimeAuthLeaseHandle::new()),
     })
 }
 
@@ -2893,7 +2895,8 @@ async fn handle_auth_command(command: AuthCommands, scope: &RuntimeScope) -> any
             let realm_set = meerkat_core::RealmConnectionSet::from_config(&realm, section)
                 .map_err(|e| anyhow::anyhow!("Realm config invalid: {e}"))?;
             let registry = meerkat_providers::ProviderRuntimeRegistry::empty();
-            let env = meerkat_providers::ResolverEnvironment::with_process_env();
+            let env = meerkat_providers::ResolverEnvironment::with_process_env()
+                .with_auth_lease_handle(Arc::clone(&scope.auth_lease));
             let connection_ref = meerkat_core::ConnectionRef {
                 realm: meerkat_core::RealmId::parse(realm.clone())
                     .map_err(|e| anyhow::anyhow!("invalid realm id '{realm}': {e}"))?,
@@ -2932,23 +2935,27 @@ async fn handle_auth_command(command: AuthCommands, scope: &RuntimeScope) -> any
             println!("provider:    {}", profile.provider.as_str());
             println!("auth_method: {}", profile.auth_method);
             println!("source_kind: {}", source_kind_label(&profile.source));
-            use meerkat_core::handles::{AuthLeaseHandle, LeaseKey};
+            let binding_id = auth_status_binding_id(&realm, &profile_id, &realm_set)?;
+            println!("binding_id:  {binding_id}");
+            use meerkat_core::handles::LeaseKey;
             let connection_ref = ConnectionRef {
                 realm: meerkat_core::RealmId::parse(realm.clone())
                     .map_err(|e| anyhow::anyhow!("invalid realm id '{realm}': {e}"))?,
-                binding: meerkat_core::BindingId::parse(profile_id.clone())
-                    .map_err(|e| anyhow::anyhow!("invalid binding id '{profile_id}': {e}"))?,
+                binding: meerkat_core::BindingId::parse(binding_id)
+                    .map_err(|e| anyhow::anyhow!("invalid binding id '{binding_id}': {e}"))?,
                 profile: None,
             };
-            let auth_lease = meerkat_runtime::RuntimeAuthLeaseHandle::new();
-            let snapshot = auth_lease.snapshot(&LeaseKey::from_connection_ref(&connection_ref));
-            let phase = AuthStatusPhase::from_lease_snapshot(chrono::Utc::now(), &snapshot);
-            println!("state:       {}", phase.as_public_str());
-            if let Some(expires_at) = meerkat_core::lease_snapshot_expires_at_datetime(&snapshot) {
+            let snapshot = scope
+                .auth_lease
+                .snapshot(&LeaseKey::from_connection_ref(&connection_ref));
+            let projection =
+                meerkat_core::project_published_auth_status(chrono::Utc::now(), None, &snapshot);
+            println!("state:       {}", projection.phase.as_public_str());
+            if let Some(expires_at) = projection.expires_at {
                 println!("expires_at:  {}", expires_at.to_rfc3339());
             }
-            if phase == AuthStatusPhase::Unknown {
-                println!("note:        no live AuthMachine lease for '{realm}:{profile_id}'.");
+            if projection.phase == AuthStatusPhase::Unknown {
+                println!("note:        no live AuthMachine lease for '{realm}:{binding_id}'.");
             }
         }
         AuthCommands::ProfileDelete {
@@ -3000,10 +3007,9 @@ async fn handle_auth_command(command: AuthCommands, scope: &RuntimeScope) -> any
                         binding: key.binding.clone(),
                         profile: key.profile.clone(),
                     };
-                    let auth_lease = meerkat_runtime::RuntimeAuthLeaseHandle::new();
                     meerkat_core::clear_tokens_and_publish_lifecycle_released(
                         store.as_ref(),
-                        &auth_lease,
+                        scope.auth_lease.as_ref(),
                         &connection_ref,
                     )
                     .await
@@ -3111,7 +3117,7 @@ async fn handle_auth_command(command: AuthCommands, scope: &RuntimeScope) -> any
         AuthCommands::Refresh { realm, profile_id } => {
             #[cfg(all(feature = "anthropic", feature = "openai", feature = "gemini"))]
             {
-                refresh_auth_profile(&realm, &profile_id, &config).await?;
+                refresh_auth_profile(&realm, &profile_id, &config, scope).await?;
             }
             #[cfg(not(all(feature = "anthropic", feature = "openai", feature = "gemini")))]
             {
@@ -3145,6 +3151,7 @@ async fn refresh_auth_profile(
     realm: &str,
     profile_id: &str,
     config: &meerkat_core::Config,
+    scope: &RuntimeScope,
 ) -> anyhow::Result<()> {
     use meerkat_core::auth::AuthRefreshReason;
     use meerkat_providers::ResolverEnvironment;
@@ -3225,7 +3232,8 @@ async fn refresh_auth_profile(
 
     let env = ResolverEnvironment::with_process_env()
         .with_token_store(store.clone())
-        .with_refresh_coordinator(coord);
+        .with_refresh_coordinator(coord)
+        .with_auth_lease_handle(Arc::clone(&scope.auth_lease));
     let registry = meerkat_providers::ProviderRuntimeRegistry::empty();
     let connection_ref = meerkat_core::ConnectionRef {
         realm: meerkat_core::RealmId::parse(realm)
@@ -3846,7 +3854,7 @@ fn token_store_load_error_allows_clear(e: &meerkat_providers::auth_store::TokenS
 }
 
 #[cfg(all(feature = "anthropic", feature = "openai", feature = "gemini"))]
-async fn interactive_logout(profile_id: &str, _scope: &RuntimeScope) -> anyhow::Result<()> {
+async fn interactive_logout(profile_id: &str, scope: &RuntimeScope) -> anyhow::Result<()> {
     use meerkat_providers::auth_store::{TokenKey, TokenStoreBackend};
 
     let store = TokenStoreBackend::default_auto()
@@ -3869,7 +3877,6 @@ async fn interactive_logout(profile_id: &str, _scope: &RuntimeScope) -> anyhow::
         ],
     };
     let mut cleared = 0;
-    let auth_lease = meerkat_runtime::RuntimeAuthLeaseHandle::new();
     for key in keys {
         let should_clear = match store.load(&key).await {
             Ok(present) => present.is_some(),
@@ -3884,7 +3891,7 @@ async fn interactive_logout(profile_id: &str, _scope: &RuntimeScope) -> anyhow::
             };
             meerkat_core::clear_tokens_and_publish_lifecycle_released(
                 store.as_ref(),
-                &auth_lease,
+                scope.auth_lease.as_ref(),
                 &connection_ref,
             )
             .await
@@ -3920,6 +3927,37 @@ fn source_kind_label(source: &meerkat_core::CredentialSourceSpec) -> &'static st
         meerkat_core::CredentialSourceSpec::PlatformDefault => "platform_default",
         meerkat_core::CredentialSourceSpec::Command { .. } => "command",
         meerkat_core::CredentialSourceSpec::FileDescriptor { .. } => "file_descriptor",
+    }
+}
+
+fn auth_status_binding_id<'a>(
+    realm: &str,
+    profile_id: &str,
+    realm_set: &'a meerkat_core::RealmConnectionSet,
+) -> anyhow::Result<&'a str> {
+    let matches = realm_set
+        .bindings
+        .iter()
+        .filter_map(|(id, binding)| (binding.auth_profile == profile_id).then_some(id.as_str()))
+        .collect::<Vec<_>>();
+
+    if let Some(default_binding) = realm_set.default_binding.as_deref()
+        && matches.contains(&default_binding)
+    {
+        return Ok(default_binding);
+    }
+
+    match matches.as_slice() {
+        [binding_id] => Ok(*binding_id),
+        [] => anyhow::bail!(
+            "No binding in realm '{realm}' references auth profile '{profile_id}'; \
+             auth status is binding-scoped because AuthMachine leases are binding-scoped."
+        ),
+        _ => anyhow::bail!(
+            "Multiple bindings in realm '{realm}' reference auth profile '{profile_id}' ({}); \
+             set a default binding for this profile or query a binding-specific status surface.",
+            matches.join(", ")
+        ),
     }
 }
 
@@ -5229,6 +5267,7 @@ fn build_cli_runtime_backed_service_with_defaults(
     factory: AgentFactory,
     config: Config,
     persistence: PersistenceBundle,
+    auth_lease: Arc<dyn meerkat_core::handles::AuthLeaseHandle>,
     default_schedule_tools: Option<Arc<dyn AgentToolDispatcher>>,
 ) -> (
     meerkat::PersistentSessionService<FactoryAgentBuilder>,
@@ -5236,7 +5275,10 @@ fn build_cli_runtime_backed_service_with_defaults(
 ) {
     let builder = FactoryAgentBuilder::new(factory, config);
     meerkat::surface::set_default_schedule_tools(&builder, default_schedule_tools);
-    meerkat::surface::build_runtime_backed_service(builder, 64, persistence)
+    let (service, runtime_adapter) =
+        meerkat::surface::build_runtime_backed_service(builder, 64, persistence);
+    runtime_adapter.set_auth_lease_handle(auth_lease);
+    (service, runtime_adapter)
 }
 
 #[cfg(test)]
@@ -5587,6 +5629,7 @@ async fn run_agent(
             factory,
             config.clone(),
             persistence.clone(),
+            Arc::clone(&scope.auth_lease),
             default_schedule_tools,
         );
 
@@ -6649,6 +6692,7 @@ async fn get_or_create_cli_persistent_surface_from_bundle(
         factory,
         config,
         persistence,
+        Arc::clone(&scope.auth_lease),
         default_schedule_tools,
     );
     let service = Arc::new(service);
@@ -9855,6 +9899,7 @@ mod tests {
             origin_hint: RealmOrigin::Explicit,
             context_root: None,
             user_config_root: None,
+            auth_lease: Arc::new(meerkat_runtime::RuntimeAuthLeaseHandle::new()),
         }
     }
 
@@ -13444,10 +13489,13 @@ capabilities = ["definitely_missing_capability"]
             .session_store(session_store)
             .builtins(false)
             .shell(false);
+        let auth_lease: Arc<dyn meerkat_core::handles::AuthLeaseHandle> =
+            Arc::new(meerkat_runtime::RuntimeAuthLeaseHandle::new());
         let (service, runtime_adapter) = build_cli_runtime_backed_service_with_defaults(
             factory,
             Config::default(),
             persistence,
+            Arc::clone(&auth_lease),
             None,
         );
 
@@ -13457,6 +13505,22 @@ capabilities = ["definitely_missing_capability"]
             .prepare_bindings(session_id.clone())
             .await
             .expect("runtime bindings should be prepared");
+        let connection_ref = meerkat_core::ConnectionRef {
+            realm: meerkat_core::RealmId::parse("dev").expect("realm id parses"),
+            binding: meerkat_core::BindingId::parse("default_openai").expect("binding id parses"),
+            profile: None,
+        };
+        let lease_key = meerkat_core::handles::LeaseKey::from_connection_ref(&connection_ref);
+        bindings
+            .auth_lease
+            .acquire_lease(&lease_key, u64::MAX)
+            .expect("runtime bindings should publish into the CLI scope auth lease");
+        let snapshot = auth_lease.snapshot(&lease_key);
+        assert_eq!(
+            snapshot.phase,
+            Some(meerkat_core::handles::AuthLeasePhase::Valid),
+            "CLI runtime-backed surfaces must share the same auth lease authority that status reads"
+        );
         let llm_override: Arc<dyn LlmClient> = Arc::new(CapturingLlmClient::new(
             Arc::new(Mutex::new(Vec::new())),
             Arc::new(Mutex::new(None)),
@@ -14195,6 +14259,7 @@ supports_reasoning = true
             origin_hint: RealmOrigin::Explicit,
             context_root: Some(root),
             user_config_root: None,
+            auth_lease: Arc::new(meerkat_runtime::RuntimeAuthLeaseHandle::new()),
         }
     }
 

--- a/meerkat-cli/src/main.rs
+++ b/meerkat-cli/src/main.rs
@@ -1353,7 +1353,7 @@ enum AuthCommands {
 
     /// Delete an auth profile's persisted credentials from the TokenStore.
     /// The realm config entry itself is declarative — this removes the
-    /// secret/token material bound to `<realm>:<profile_id>`.
+    /// secret/token material bound to the profile's owning `<realm>:<binding_id>`.
     ProfileDelete {
         /// Realm id.
         #[arg(long, default_value = "dev")]

--- a/meerkat-cli/tests/cli_auth_flow.rs
+++ b/meerkat-cli/tests/cli_auth_flow.rs
@@ -269,6 +269,54 @@ fn rkat_auth_status_hides_token_metadata_without_lifecycle() {
     }
 }
 
+#[test]
+fn rkat_auth_status_ignores_malformed_token_storage_without_lifecycle() {
+    let Some(rkat) = rkat_binary() else {
+        eprintln!("SKIP: rkat binary unavailable");
+        return;
+    };
+
+    let tmp = tempfile::TempDir::new().expect("tempdir");
+    seed_managed_openai_realm_config(tmp.path());
+    seed_token_file(tmp.path(), "{ malformed token json");
+
+    let status = Command::new(&rkat)
+        .args([
+            "--state-root",
+            tmp.path().join("realms").to_str().expect("utf8 path"),
+            "--realm",
+            "dev",
+            "auth",
+            "status",
+            "--realm",
+            "dev",
+            "default_openai",
+        ])
+        .env("HOME", tmp.path())
+        .env("XDG_CONFIG_HOME", tmp.path().join("config"))
+        .stdin(Stdio::null())
+        .output()
+        .expect("rkat auth status must spawn");
+    if !status.status.success() {
+        let stderr = String::from_utf8_lossy(&status.stderr);
+        if stderr.contains("requires the `anthropic`, `openai`, and `gemini`") {
+            eprintln!("SKIP: auth provider features unavailable");
+            return;
+        }
+        panic!("status must not be owned by malformed token storage; stderr={stderr}");
+    }
+
+    let stdout = String::from_utf8_lossy(&status.stdout);
+    assert!(
+        stdout.contains("state:       unknown"),
+        "status should report lease-unknown without token-store truth; stdout:\n{stdout}"
+    );
+    assert!(
+        !stdout.contains("auth_mode:"),
+        "status must not expose token-derived metadata without lifecycle; stdout:\n{stdout}"
+    );
+}
+
 /// `rkat auth profile list --realm <empty>` returns either 0 (empty
 /// list) or a typed error; it must not panic or spew an unstructured
 /// stack trace.

--- a/meerkat-cli/tests/cli_auth_flow.rs
+++ b/meerkat-cli/tests/cli_auth_flow.rs
@@ -24,6 +24,22 @@ fn seed_managed_openai_realm_config_with_ids(
     auth_profile_id: &str,
     binding_id: &str,
 ) {
+    seed_openai_realm_config_with_ids_and_method(
+        root,
+        auth_profile_id,
+        binding_id,
+        "openai_api",
+        "api_key",
+    );
+}
+
+fn seed_openai_realm_config_with_ids_and_method(
+    root: &std::path::Path,
+    auth_profile_id: &str,
+    binding_id: &str,
+    backend_kind: &str,
+    auth_method: &str,
+) {
     let realm_dir = root.join("realms").join("dev");
     std::fs::create_dir_all(&realm_dir).expect("mkdir realm config dir");
     std::fs::write(
@@ -35,11 +51,11 @@ default_binding = "{binding_id}"
 
 [realm.dev.backend.openai_backend]
 provider = "openai"
-backend_kind = "openai_api"
+backend_kind = "{backend_kind}"
 
 [realm.dev.auth.{auth_profile_id}]
 provider = "openai"
-auth_method = "api_key"
+auth_method = "{auth_method}"
 source = {{ kind = "managed_store" }}
 
 [realm.dev.binding.{binding_id}]
@@ -52,6 +68,10 @@ auth_profile = "{auth_profile_id}"
 }
 
 fn token_file_path(root: &std::path::Path) -> PathBuf {
+    token_file_path_for_binding(root, "default_openai")
+}
+
+fn token_file_path_for_binding(root: &std::path::Path, binding_id: &str) -> PathBuf {
     #[cfg(target_os = "macos")]
     let config_root = root.join("Library").join("Application Support");
     #[cfg(not(target_os = "macos"))]
@@ -61,11 +81,15 @@ fn token_file_path(root: &std::path::Path) -> PathBuf {
         .join("meerkat")
         .join("credentials")
         .join("dev")
-        .join("default_openai.json")
+        .join(format!("{binding_id}.json"))
 }
 
 fn seed_token_file(root: &std::path::Path, body: &str) {
-    let token_file = token_file_path(root);
+    seed_token_file_for_binding(root, "default_openai", body);
+}
+
+fn seed_token_file_for_binding(root: &std::path::Path, binding_id: &str, body: &str) {
+    let token_file = token_file_path_for_binding(root, binding_id);
     let token_dir = token_file.parent().expect("token file has parent");
     std::fs::create_dir_all(token_dir).expect("mkdir token dir");
     std::fs::write(token_file, body).expect("write token file");
@@ -209,6 +233,55 @@ fn rkat_auth_profile_delete_clears_malformed_token_file() {
 }
 
 #[test]
+fn rkat_auth_profile_delete_clears_binding_scoped_token_when_profile_id_differs() {
+    let Some(rkat) = rkat_binary() else {
+        eprintln!("SKIP: rkat binary unavailable");
+        return;
+    };
+
+    let tmp = tempfile::TempDir::new().expect("tempdir");
+    seed_managed_openai_realm_config_with_ids(tmp.path(), "openai_managed", "default_openai");
+    seed_token_file_for_binding(tmp.path(), "default_openai", "{ malformed token json");
+
+    let delete = Command::new(&rkat)
+        .args([
+            "--state-root",
+            tmp.path().join("realms").to_str().expect("utf8 path"),
+            "--realm",
+            "dev",
+            "auth",
+            "profile-delete",
+            "--realm",
+            "dev",
+            "openai_managed",
+            "--yes",
+        ])
+        .env("HOME", tmp.path())
+        .env("XDG_CONFIG_HOME", tmp.path().join("config"))
+        .stdin(Stdio::null())
+        .output()
+        .expect("rkat auth profile-delete must spawn");
+    if !delete.status.success() {
+        let stderr = String::from_utf8_lossy(&delete.stderr);
+        if stderr.contains("requires the `anthropic`, `openai`, and `gemini`") {
+            eprintln!("SKIP: auth provider features unavailable");
+            return;
+        }
+        panic!("profile delete must clear binding-scoped token file; stderr={stderr}");
+    }
+
+    let stdout = String::from_utf8_lossy(&delete.stdout);
+    assert!(
+        stdout.contains("deleted: dev:default_openai"),
+        "profile delete should report the binding-scoped token key; stdout:\n{stdout}"
+    );
+    assert!(
+        !token_file_path_for_binding(tmp.path(), "default_openai").exists(),
+        "profile delete must remove the token file keyed by the owning binding"
+    );
+}
+
+#[test]
 fn rkat_auth_status_hides_token_metadata_without_lifecycle() {
     let Some(rkat) = rkat_binary() else {
         eprintln!("SKIP: rkat binary unavailable");
@@ -324,6 +397,75 @@ fn rkat_auth_status_ignores_malformed_token_storage_without_lifecycle() {
     assert!(
         !stdout.contains("auth_mode:"),
         "status must not expose token-derived metadata without lifecycle; stdout:\n{stdout}"
+    );
+}
+
+#[test]
+fn rkat_auth_refresh_uses_binding_scoped_token_when_profile_id_differs() {
+    let Some(rkat) = rkat_binary() else {
+        eprintln!("SKIP: rkat binary unavailable");
+        return;
+    };
+
+    let tmp = tempfile::TempDir::new().expect("tempdir");
+    seed_openai_realm_config_with_ids_and_method(
+        tmp.path(),
+        "openai_managed",
+        "default_openai",
+        "chatgpt_backend",
+        "managed_chatgpt_oauth",
+    );
+    seed_token_file(
+        tmp.path(),
+        r#"{
+  "auth_mode": "chatgpt_oauth",
+  "primary_secret": "fresh-chatgpt-access",
+  "refresh_token": "refresh-token",
+  "expires_at": 1893456000,
+  "last_refresh": 1700000000,
+  "scopes": ["openid", "email"],
+  "account_id": "acct-fresh"
+}"#,
+    );
+
+    let refresh = Command::new(&rkat)
+        .args([
+            "--state-root",
+            tmp.path().join("realms").to_str().expect("utf8 path"),
+            "--realm",
+            "dev",
+            "auth",
+            "refresh",
+            "--realm",
+            "dev",
+            "openai_managed",
+        ])
+        .env("HOME", tmp.path())
+        .env("XDG_CONFIG_HOME", tmp.path().join("config"))
+        .stdin(Stdio::null())
+        .output()
+        .expect("rkat auth refresh must spawn");
+    if !refresh.status.success() {
+        let stderr = String::from_utf8_lossy(&refresh.stderr);
+        if stderr.contains("requires the `anthropic`, `openai`, and `gemini`") {
+            eprintln!("SKIP: auth provider features unavailable");
+            return;
+        }
+        panic!("refresh must use the binding-scoped token key; stderr={stderr}");
+    }
+
+    let stdout = String::from_utf8_lossy(&refresh.stdout);
+    assert!(
+        stdout.contains("profile:       dev:openai_managed"),
+        "refresh should still report the requested auth profile; stdout:\n{stdout}"
+    );
+    assert!(
+        stdout.contains("refresh:       ok"),
+        "refresh must not skip when credentials exist under the owning binding; stdout:\n{stdout}"
+    );
+    assert!(
+        !stdout.contains("reason:        no persisted credential"),
+        "refresh must not preflight token storage by auth profile id; stdout:\n{stdout}"
     );
 }
 

--- a/meerkat-cli/tests/cli_auth_flow.rs
+++ b/meerkat-cli/tests/cli_auth_flow.rs
@@ -16,27 +16,37 @@ use std::path::PathBuf;
 use std::process::{Command, Stdio};
 
 fn seed_managed_openai_realm_config(root: &std::path::Path) {
+    seed_managed_openai_realm_config_with_ids(root, "default_openai", "default_openai");
+}
+
+fn seed_managed_openai_realm_config_with_ids(
+    root: &std::path::Path,
+    auth_profile_id: &str,
+    binding_id: &str,
+) {
     let realm_dir = root.join("realms").join("dev");
     std::fs::create_dir_all(&realm_dir).expect("mkdir realm config dir");
     std::fs::write(
         realm_dir.join("config.toml"),
-        r#"
+        format!(
+            r#"
 [realm.dev]
-default_binding = "default_openai"
+default_binding = "{binding_id}"
 
 [realm.dev.backend.openai_backend]
 provider = "openai"
 backend_kind = "openai_api"
 
-[realm.dev.auth.default_openai]
+[realm.dev.auth.{auth_profile_id}]
 provider = "openai"
 auth_method = "api_key"
-source = { kind = "managed_store" }
+source = {{ kind = "managed_store" }}
 
-[realm.dev.binding.default_openai]
+[realm.dev.binding.{binding_id}]
 backend_profile = "openai_backend"
-auth_profile = "default_openai"
-"#,
+auth_profile = "{auth_profile_id}"
+"#
+        ),
     )
     .expect("write realm config");
 }
@@ -314,6 +324,50 @@ fn rkat_auth_status_ignores_malformed_token_storage_without_lifecycle() {
     assert!(
         !stdout.contains("auth_mode:"),
         "status must not expose token-derived metadata without lifecycle; stdout:\n{stdout}"
+    );
+}
+
+#[test]
+fn rkat_auth_status_resolves_binding_that_references_auth_profile() {
+    let Some(rkat) = rkat_binary() else {
+        eprintln!("SKIP: rkat binary unavailable");
+        return;
+    };
+
+    let tmp = tempfile::TempDir::new().expect("tempdir");
+    seed_managed_openai_realm_config_with_ids(tmp.path(), "openai_managed", "default_openai");
+
+    let status = Command::new(&rkat)
+        .args([
+            "--state-root",
+            tmp.path().join("realms").to_str().expect("utf8 path"),
+            "--realm",
+            "dev",
+            "auth",
+            "status",
+            "--realm",
+            "dev",
+            "openai_managed",
+        ])
+        .env("HOME", tmp.path())
+        .env("XDG_CONFIG_HOME", tmp.path().join("config"))
+        .stdin(Stdio::null())
+        .output()
+        .expect("rkat auth status must spawn");
+    assert!(
+        status.status.success(),
+        "status must resolve binding-scoped lease identity from auth profile; stderr={}",
+        String::from_utf8_lossy(&status.stderr)
+    );
+
+    let stdout = String::from_utf8_lossy(&status.stdout);
+    assert!(
+        stdout.contains("binding_id:  default_openai"),
+        "status must report the binding that owns the auth lease key; stdout:\n{stdout}"
+    );
+    assert!(
+        stdout.contains("state:       unknown"),
+        "status should still be lease-unknown without a live AuthMachine lifecycle; stdout:\n{stdout}"
     );
 }
 

--- a/meerkat-contracts/src/wire/connection.rs
+++ b/meerkat-contracts/src/wire/connection.rs
@@ -320,9 +320,8 @@ pub struct WireAuthStatus {
     pub profile_id: String,
     pub provider: String,
     pub auth_method: String,
-    /// High-level health: "valid" / "expiring" / "expired" /
-    /// "reauth_required" / "refresh_failed" / "unknown".
-    pub state: String,
+    /// High-level health projected from typed auth-lease lifecycle truth.
+    pub state: meerkat_core::AuthStatusPhase,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     #[cfg_attr(feature = "schema", schemars(with = "Option<String>"))]
     pub expires_at: Option<DateTime<Utc>>,
@@ -515,7 +514,7 @@ pub struct WireAuthStatusDetail {
     pub profile_id: String,
     pub provider: String,
     pub auth_method: String,
-    pub state: String,
+    pub state: meerkat_core::AuthStatusPhase,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub expires_at: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -642,7 +641,7 @@ mod tests {
             profile_id: "p".into(),
             provider: "openai".into(),
             auth_method: "managed_chatgpt_oauth".into(),
-            state: "valid".into(),
+            state: meerkat_core::AuthStatusPhase::Valid,
             expires_at: Some(chrono::Utc::now()),
             last_refresh_at: None,
             account_id: Some("acct_x".into()),

--- a/meerkat-contracts/tests/connection_ref_wire.rs
+++ b/meerkat-contracts/tests/connection_ref_wire.rs
@@ -166,7 +166,7 @@ fn auth_status_wire_with_error_roundtrips() {
         profile_id: "p1".to_string(),
         provider: "openai".to_string(),
         auth_method: "managed_chatgpt_oauth".to_string(),
-        state: "reauth_required".to_string(),
+        state: meerkat_core::AuthStatusPhase::ReauthRequired,
         expires_at: None,
         last_refresh_at: None,
         account_id: Some("acct_42".to_string()),
@@ -187,7 +187,7 @@ fn auth_status_detail_wire_flattens_binding_identity() {
         profile_id: "prod_env_key".to_string(),
         provider: "openai".to_string(),
         auth_method: "api_key".to_string(),
-        state: "valid".to_string(),
+        state: meerkat_core::AuthStatusPhase::Valid,
         expires_at: None,
         last_refresh_at: Some("2026-04-28T00:00:00Z".to_string()),
         account_id: Some("acct_42".to_string()),
@@ -205,6 +205,38 @@ fn auth_status_detail_wire_flattens_binding_identity() {
     assert_eq!(back.identity.connection_ref, status.identity.connection_ref);
     assert_eq!(back.profile_id, status.profile_id);
     assert_eq!(back.has_refresh_token, status.has_refresh_token);
+}
+
+#[test]
+fn auth_status_wire_rejects_unknown_lifecycle_state() {
+    let status = serde_json::json!({
+        "profile_id": "p1",
+        "provider": "openai",
+        "auth_method": "managed_chatgpt_oauth",
+        "state": "credential_present"
+    });
+    assert!(
+        serde_json::from_value::<WireAuthStatus>(status).is_err(),
+        "WireAuthStatus state must be typed lifecycle truth, not an arbitrary string"
+    );
+
+    let detail = serde_json::json!({
+        "realm_id": "dev",
+        "binding_id": "default_openai",
+        "connection_ref": {
+            "realm": "dev",
+            "binding": "default_openai"
+        },
+        "profile_id": "p1",
+        "provider": "openai",
+        "auth_method": "managed_chatgpt_oauth",
+        "state": "credential_present",
+        "has_refresh_token": false
+    });
+    assert!(
+        serde_json::from_value::<WireAuthStatusDetail>(detail).is_err(),
+        "WireAuthStatusDetail state must reject string defaults outside AuthStatusPhase"
+    );
 }
 
 #[cfg(feature = "schema")]

--- a/meerkat-core/src/auth/lifecycle.rs
+++ b/meerkat-core/src/auth/lifecycle.rs
@@ -507,6 +507,7 @@ mod tests {
         let snapshot = AuthLeaseSnapshot {
             phase: Some(AuthLeasePhase::Valid),
             expires_at: Some((now + chrono::Duration::hours(1)).timestamp() as u64),
+            generation: 1,
         };
 
         let status = project_published_auth_status(now, None, &snapshot);

--- a/meerkat-core/src/auth/lifecycle.rs
+++ b/meerkat-core/src/auth/lifecycle.rs
@@ -157,13 +157,6 @@ pub fn project_published_auth_status<'a>(
     stored: Option<&'a PersistedTokens>,
     snapshot: &AuthLeaseSnapshot,
 ) -> PublishedAuthStatus<'a> {
-    let Some(tokens) = stored else {
-        return PublishedAuthStatus {
-            phase: AuthStatusPhase::Unknown,
-            expires_at: None,
-            tokens: None,
-        };
-    };
     let phase = AuthStatusPhase::from_lease_snapshot(now, snapshot);
     if phase == AuthStatusPhase::Unknown {
         return PublishedAuthStatus {
@@ -174,8 +167,9 @@ pub fn project_published_auth_status<'a>(
     }
     PublishedAuthStatus {
         phase,
-        expires_at: lease_snapshot_expires_at_datetime(snapshot).or(tokens.expires_at),
-        tokens: Some(tokens),
+        expires_at: lease_snapshot_expires_at_datetime(snapshot)
+            .or_else(|| stored.and_then(|tokens| tokens.expires_at)),
+        tokens: stored,
     }
 }
 
@@ -505,5 +499,20 @@ mod tests {
             "lifecycle must remain untouched when unreadable token material cannot be cleared"
         );
         assert!(handle.acquired().is_empty());
+    }
+
+    #[test]
+    fn published_status_projects_lease_phase_without_token_material() {
+        let now = Utc::now();
+        let snapshot = AuthLeaseSnapshot {
+            phase: Some(AuthLeasePhase::Valid),
+            expires_at: Some((now + chrono::Duration::hours(1)).timestamp() as u64),
+        };
+
+        let status = project_published_auth_status(now, None, &snapshot);
+
+        assert_eq!(status.phase, AuthStatusPhase::Valid);
+        assert!(status.expires_at.is_some());
+        assert!(status.tokens.is_none());
     }
 }

--- a/meerkat-rest/src/auth_endpoints.rs
+++ b/meerkat-rest/src/auth_endpoints.rs
@@ -1096,7 +1096,7 @@ pub async fn get_auth_status(
             profile_id: auth_profile.id.clone(),
             provider: auth_profile.provider.as_str().to_string(),
             auth_method: auth_profile.auth_method.clone(),
-            state: projection.phase.as_public_str().to_string(),
+            state: projection.phase,
             expires_at: projection.expires_at.map(|e| e.to_rfc3339()),
             last_refresh_at: tokens.and_then(|t| t.last_refresh.map(|e| e.to_rfc3339())),
             account_id: tokens.and_then(|t| t.account_id.clone()),
@@ -1468,7 +1468,7 @@ mod tests {
         )
         .await;
 
-        assert_eq!(detail.state, "unknown");
+        assert_eq!(detail.state, meerkat_core::AuthStatusPhase::Unknown);
         assert_eq!(detail.expires_at, None);
         assert_eq!(detail.last_refresh_at, None);
         assert_eq!(detail.account_id, None);
@@ -1517,7 +1517,7 @@ mod tests {
         )
         .await;
 
-        assert_eq!(detail.state, "unknown");
+        assert_eq!(detail.state, meerkat_core::AuthStatusPhase::Unknown);
         assert_eq!(detail.expires_at, None);
         assert!(!detail.has_refresh_token);
     }
@@ -1568,7 +1568,7 @@ mod tests {
             get_auth_status(State(state.clone()), Path(binding_id()), Query(query())).await,
         )
         .await;
-        assert_eq!(detail.state, "valid");
+        assert_eq!(detail.state, meerkat_core::AuthStatusPhase::Valid);
 
         let bindings = state
             .runtime_adapter
@@ -1580,7 +1580,7 @@ mod tests {
             get_auth_status(State(state.clone()), Path(binding_id()), Query(query())).await,
         )
         .await;
-        assert_eq!(detail.state, "expiring");
+        assert_eq!(detail.state, meerkat_core::AuthStatusPhase::Expiring);
 
         bindings
             .auth_lease
@@ -1594,7 +1594,7 @@ mod tests {
             get_auth_status(State(state), Path(binding_id()), Query(query())).await,
         )
         .await;
-        assert_eq!(detail.state, "reauth_required");
+        assert_eq!(detail.state, meerkat_core::AuthStatusPhase::ReauthRequired);
     }
 
     #[test]

--- a/meerkat-rest/src/auth_endpoints.rs
+++ b/meerkat-rest/src/auth_endpoints.rs
@@ -1072,22 +1072,22 @@ pub async fn get_auth_status(
             return (status, Json(serde_json::json!({ "error": msg }))).into_response();
         }
     };
-    let key = TokenKey::from_connection_ref(&connection_ref);
-    let stored = match state.token_store.load(&key).await {
-        Ok(v) => v,
-        Err(e) => {
-            return (
-                StatusCode::INTERNAL_SERVER_ERROR,
-                Json(serde_json::json!({ "error": format!("TokenStore load failed: {e}") })),
-            )
-                .into_response();
-        }
-    };
     let snapshot = state
         .auth_lease
         .snapshot(&LeaseKey::from_connection_ref(&connection_ref));
-    let projection =
-        meerkat_core::project_published_auth_status(chrono::Utc::now(), stored.as_ref(), &snapshot);
+    let now = chrono::Utc::now();
+    let phase = meerkat_core::AuthStatusPhase::from_lease_snapshot(now, &snapshot);
+    let stored = if phase == meerkat_core::AuthStatusPhase::Unknown {
+        None
+    } else {
+        state
+            .token_store
+            .load(&TokenKey::from_connection_ref(&connection_ref))
+            .await
+            .ok()
+            .flatten()
+    };
+    let projection = meerkat_core::project_published_auth_status(now, stored.as_ref(), &snapshot);
     let tokens = projection.tokens;
     (
         StatusCode::OK,
@@ -1300,6 +1300,46 @@ mod tests {
         }
     }
 
+    struct LoadFailingTokenStore;
+
+    #[async_trait::async_trait]
+    impl TokenStore for LoadFailingTokenStore {
+        async fn load(
+            &self,
+            _key: &TokenKey,
+        ) -> Result<Option<PersistedTokens>, meerkat_providers::auth_store::TokenStoreError>
+        {
+            Err(meerkat_providers::auth_store::TokenStoreError::Serde(
+                "malformed token fixture".into(),
+            ))
+        }
+
+        async fn save(
+            &self,
+            _key: &TokenKey,
+            _tokens: &PersistedTokens,
+        ) -> Result<(), meerkat_providers::auth_store::TokenStoreError> {
+            Ok(())
+        }
+
+        async fn clear(
+            &self,
+            _key: &TokenKey,
+        ) -> Result<(), meerkat_providers::auth_store::TokenStoreError> {
+            Ok(())
+        }
+
+        async fn list(
+            &self,
+        ) -> Result<Vec<TokenKey>, meerkat_providers::auth_store::TokenStoreError> {
+            Ok(Vec::new())
+        }
+
+        fn backend_name(&self) -> &'static str {
+            "load_failing"
+        }
+    }
+
     fn config_with_openai_managed_store_binding() -> meerkat_core::Config {
         let mut config = meerkat_core::Config::default();
         let mut section = meerkat_core::RealmConfigSection::default();
@@ -1476,7 +1516,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn rest_auth_status_does_not_report_valid_when_token_is_missing() {
+    async fn rest_auth_status_reports_lease_phase_when_token_is_missing() {
         let temp = tempfile::tempdir().unwrap();
         let mut state = AppState::load_from(temp.path().to_path_buf())
             .await
@@ -1517,8 +1557,57 @@ mod tests {
         )
         .await;
 
-        assert_eq!(detail.state, meerkat_core::AuthStatusPhase::Unknown);
-        assert_eq!(detail.expires_at, None);
+        assert_eq!(detail.state, meerkat_core::AuthStatusPhase::Valid);
+        assert!(detail.expires_at.is_some());
+        assert!(!detail.has_refresh_token);
+    }
+
+    #[tokio::test]
+    async fn rest_auth_status_reports_lease_phase_when_token_load_fails() {
+        let temp = tempfile::tempdir().unwrap();
+        let mut state = AppState::load_from(temp.path().to_path_buf())
+            .await
+            .unwrap();
+        install_ephemeral_auth_state(&mut state);
+        state.token_store = Arc::new(LoadFailingTokenStore);
+        state
+            .config_runtime
+            .set(config_with_openai_managed_store_binding(), None)
+            .await
+            .unwrap();
+        let connection_ref = ConnectionRef {
+            realm: RealmId::parse("dev").unwrap(),
+            binding: BindingId::parse("default_openai").unwrap(),
+            profile: None,
+        };
+        let lease_key = LeaseKey::from_connection_ref(&connection_ref);
+        let now = chrono::Utc::now().timestamp() as u64;
+        let bindings = state
+            .runtime_adapter
+            .prepare_bindings(meerkat_core::SessionId::new())
+            .await
+            .unwrap();
+        bindings
+            .auth_lease
+            .acquire_lease(&lease_key, now + 3600)
+            .unwrap();
+
+        let detail = auth_status_detail(
+            get_auth_status(
+                State(state),
+                Path(BindingId::parse("default_openai").unwrap()),
+                Query(RealmQuery {
+                    realm_id: RealmId::parse("dev").unwrap(),
+                    profile_id: None,
+                }),
+            )
+            .await,
+        )
+        .await;
+
+        assert_eq!(detail.state, meerkat_core::AuthStatusPhase::Valid);
+        assert!(detail.expires_at.is_some());
+        assert_eq!(detail.account_id, None);
         assert!(!detail.has_refresh_token);
     }
 

--- a/meerkat-rpc/src/handlers/auth.rs
+++ b/meerkat-rpc/src/handlers/auth.rs
@@ -1103,27 +1103,22 @@ pub async fn handle_auth_status_get(
         Ok(v) => v,
         Err(r) => return r.with_id(id),
     };
-    let stored = if let Some(store) = runtime.token_store() {
-        match store
+    let auth_lease = runtime.auth_lease_handle();
+    let snapshot = auth_lease.snapshot(&LeaseKey::from_connection_ref(&connection_ref));
+    let now = chrono::Utc::now();
+    let phase = meerkat_core::AuthStatusPhase::from_lease_snapshot(now, &snapshot);
+    let stored = if phase == meerkat_core::AuthStatusPhase::Unknown {
+        None
+    } else if let Some(store) = runtime.token_store() {
+        store
             .load(&TokenKey::from_connection_ref(&connection_ref))
             .await
-        {
-            Ok(stored) => stored,
-            Err(e) => {
-                return RpcResponse::error(
-                    id,
-                    error::INTERNAL_ERROR,
-                    format!("TokenStore load failed: {e}"),
-                );
-            }
-        }
+            .ok()
+            .flatten()
     } else {
         None
     };
-    let auth_lease = runtime.auth_lease_handle();
-    let snapshot = auth_lease.snapshot(&LeaseKey::from_connection_ref(&connection_ref));
-    let projection =
-        meerkat_core::project_published_auth_status(chrono::Utc::now(), stored.as_ref(), &snapshot);
+    let projection = meerkat_core::project_published_auth_status(now, stored.as_ref(), &snapshot);
     let tokens = projection.tokens;
     RpcResponse::success(
         id,
@@ -1205,9 +1200,16 @@ mod tests {
     }
 
     fn test_runtime_with_config(config: meerkat_core::Config) -> SessionRuntime {
-        let temp = tempfile::tempdir().unwrap();
-        let token_store: Arc<dyn meerkat_providers::auth_store::TokenStore> =
+        let token_store: Arc<dyn TokenStore> =
             Arc::new(meerkat_providers::auth_store::EphemeralTokenStore::new());
+        test_runtime_with_config_and_token_store(config, token_store)
+    }
+
+    fn test_runtime_with_config_and_token_store(
+        config: meerkat_core::Config,
+        token_store: Arc<dyn TokenStore>,
+    ) -> SessionRuntime {
+        let temp = tempfile::tempdir().unwrap();
         let factory =
             meerkat::AgentFactory::new(temp.path().join("sessions")).with_token_store(token_store);
         let store: Arc<dyn meerkat::SessionStore> = Arc::new(meerkat::MemoryStore::new());
@@ -1419,6 +1421,46 @@ mod tests {
         }
     }
 
+    struct LoadFailingTokenStore;
+
+    #[async_trait::async_trait]
+    impl TokenStore for LoadFailingTokenStore {
+        async fn load(
+            &self,
+            _key: &TokenKey,
+        ) -> Result<Option<PersistedTokens>, meerkat_providers::auth_store::TokenStoreError>
+        {
+            Err(meerkat_providers::auth_store::TokenStoreError::Serde(
+                "malformed token fixture".into(),
+            ))
+        }
+
+        async fn save(
+            &self,
+            _key: &TokenKey,
+            _tokens: &PersistedTokens,
+        ) -> Result<(), meerkat_providers::auth_store::TokenStoreError> {
+            Ok(())
+        }
+
+        async fn clear(
+            &self,
+            _key: &TokenKey,
+        ) -> Result<(), meerkat_providers::auth_store::TokenStoreError> {
+            Ok(())
+        }
+
+        async fn list(
+            &self,
+        ) -> Result<Vec<TokenKey>, meerkat_providers::auth_store::TokenStoreError> {
+            Ok(Vec::new())
+        }
+
+        fn backend_name(&self) -> &'static str {
+            "load_failing"
+        }
+    }
+
     #[test]
     fn oauth_completion_params_keep_missing_identity_unowned_by_surface() {
         let login: LoginCompleteParams = serde_json::from_value(serde_json::json!({
@@ -1554,7 +1596,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn auth_status_does_not_report_valid_when_token_is_missing() {
+    async fn auth_status_reports_lease_phase_when_token_is_missing() {
         let runtime = test_runtime_with_config(config_with_openai_managed_store_binding());
         let connection_ref = ConnectionRef {
             realm: meerkat_core::RealmId::parse("dev").unwrap(),
@@ -1581,8 +1623,45 @@ mod tests {
             handle_auth_status_get(Some(RpcId::Num(1)), Some(params.as_ref()), &runtime).await;
 
         let status = auth_status_value(resp);
-        assert_eq!(status["state"], "unknown");
-        assert!(status.get("expires_at").is_none());
+        assert_eq!(status["state"], "valid");
+        assert!(status.get("expires_at").is_some());
+        assert_eq!(status["has_refresh_token"], false);
+    }
+
+    #[tokio::test]
+    async fn auth_status_reports_lease_phase_when_token_load_fails() {
+        let runtime = test_runtime_with_config_and_token_store(
+            config_with_openai_managed_store_binding(),
+            Arc::new(LoadFailingTokenStore),
+        );
+        let connection_ref = ConnectionRef {
+            realm: meerkat_core::RealmId::parse("dev").unwrap(),
+            binding: meerkat_core::BindingId::parse("default_openai").unwrap(),
+            profile: None,
+        };
+        let lease_key = LeaseKey::from_connection_ref(&connection_ref);
+        let now = chrono::Utc::now().timestamp() as u64;
+        let bindings = runtime
+            .runtime_adapter()
+            .prepare_bindings(meerkat_core::SessionId::new())
+            .await
+            .unwrap();
+        bindings
+            .auth_lease
+            .acquire_lease(&lease_key, now + 3600)
+            .unwrap();
+        let params = raw_params(serde_json::json!({
+            "realm_id": "dev",
+            "binding_id": "default_openai"
+        }));
+
+        let resp =
+            handle_auth_status_get(Some(RpcId::Num(1)), Some(params.as_ref()), &runtime).await;
+
+        let status = auth_status_value(resp);
+        assert_eq!(status["state"], "valid");
+        assert!(status.get("expires_at").is_some());
+        assert!(status.get("account_id").is_none());
         assert_eq!(status["has_refresh_token"], false);
     }
 

--- a/meerkat-rpc/src/handlers/auth.rs
+++ b/meerkat-rpc/src/handlers/auth.rs
@@ -1132,7 +1132,7 @@ pub async fn handle_auth_status_get(
             profile_id: auth_profile.id,
             provider: auth_profile.provider.as_str().to_string(),
             auth_method: auth_profile.auth_method,
-            state: projection.phase.as_public_str().to_string(),
+            state: projection.phase,
             expires_at: projection.expires_at.map(|e| e.to_rfc3339()),
             last_refresh_at: tokens.and_then(|t| t.last_refresh.map(|e| e.to_rfc3339())),
             account_id: tokens.and_then(|t| t.account_id.clone()),

--- a/sdks/python/meerkat/generated/types.py
+++ b/sdks/python/meerkat/generated/types.py
@@ -1788,7 +1788,7 @@ class WireAuthStatus:
     auth_method: str
     profile_id: str
     provider: str
-    state: str
+    state: Literal['valid', 'expiring', 'expired', 'reauth_required', 'refresh_failed', 'unknown']
     account_id: Optional[str] = None
     expires_at: Optional[str] = None
     last_error: Optional[dict[str, Any]] = None
@@ -1808,7 +1808,7 @@ binding directly."""
     profile_id: str
     provider: str
     realm_id: str
-    state: str
+    state: Literal['valid', 'expiring', 'expired', 'reauth_required', 'refresh_failed', 'unknown']
     account_id: Optional[str] = None
     expires_at: Optional[str] = None
     last_refresh_at: Optional[str] = None

--- a/sdks/typescript/src/generated/types.ts
+++ b/sdks/typescript/src/generated/types.ts
@@ -1938,7 +1938,7 @@ export interface WireAuthStatus {
   last_refresh_at?: string;
   profile_id: string;
   provider: string;
-  state: string;
+  state: "valid" | "expiring" | "expired" | "reauth_required" | "refresh_failed" | "unknown";
 }
 
 export interface WireAuthStatusDetail {
@@ -1952,7 +1952,7 @@ export interface WireAuthStatusDetail {
   profile_id: string;
   provider: string;
   realm_id: string;
-  state: string;
+  state: "valid" | "expiring" | "expired" | "reauth_required" | "refresh_failed" | "unknown";
 }
 
 export interface WireAuthErrorMissingSecret {


### PR DESCRIPTION
## Summary
- Make CLI auth status render from typed AuthLease snapshot state instead of opening/loading TokenStore.
- Type WireAuthStatus and WireAuthStatusDetail state as AuthStatusPhase, then regenerate schemas and SDK types.
- Add regressions for malformed token storage being irrelevant to CLI status and wire status rejecting arbitrary lifecycle strings.

## Validation
- TDD red: ./scripts/repo-cargo test -p meerkat-contracts --test connection_ref_wire auth_status_wire_rejects_unknown_lifecycle_state
- TDD red: ./scripts/repo-cargo test -p rkat --test cli_auth_flow rkat_auth_status_ignores_malformed_token_storage_without_lifecycle
- ./scripts/repo-cargo test -p meerkat-contracts --test connection_ref_wire auth_status
- ./scripts/repo-cargo test -p rkat --test cli_auth_flow rkat_auth_status
- ./scripts/repo-cargo test -p meerkat-rest rest_auth_status
- ./scripts/repo-cargo test -p meerkat-rpc auth_status
- make regen-schemas
- make fmt
- make check (BuildBuddy invocation 63773769-179f-4a97-9a77-7c1b90d27b70)
- make verify-schema-freshness

Linear: LUC-193