### PR TITLE
LUC-209 Split runtime identity from session aliases

### DIFF
--- a/meerkat-cli/src/main.rs
+++ b/meerkat-cli/src/main.rs
@@ -13681,7 +13681,7 @@ capabilities = ["definitely_missing_capability"]
             .expect("runtime-backed CLI service should create deferred session");
 
         assert_eq!(created.session_id, session_id);
-        let runtime_id = meerkat_runtime::LogicalRuntimeId::new(session_id.to_string());
+        let runtime_id = meerkat_runtime::LogicalRuntimeId::for_session(&session_id);
         assert!(
             runtime_store
                 .load_session_snapshot(&runtime_id)

--- a/meerkat-mob/src/runtime/local_bridge.rs
+++ b/meerkat-mob/src/runtime/local_bridge.rs
@@ -121,7 +121,7 @@ impl MobBoundMemberRuntimeBridge for LocalMobRuntimeBridge {
                 source: InputOrigin::Peer {
                     peer_id: format!("local-bridge:{}", self.session_id),
                     display_identity: Some(format!("local-bridge:{}", self.session_id)),
-                    runtime_id: Some(LogicalRuntimeId::new(self.session_id.to_string())),
+                    runtime_id: Some(LogicalRuntimeId::for_session(&self.session_id)),
                 },
                 durability: InputDurability::Durable,
                 visibility: InputVisibility::default(),
@@ -248,10 +248,9 @@ impl MobBoundMemberRuntimeBridge for LocalMobRuntimeBridge {
     }
 
     async fn destroy_member(&self) -> Result<BridgeDestroyResponse, MobError> {
-        use meerkat_runtime::identifiers::LogicalRuntimeId;
         use meerkat_runtime::traits::RuntimeControlPlane;
 
-        let runtime_id = LogicalRuntimeId::new(self.session_id.to_string());
+        let runtime_id = LogicalRuntimeId::for_session(&self.session_id);
         let report = RuntimeControlPlane::destroy(self.machine.as_ref(), &runtime_id)
             .await
             .map_err(|error| MobError::Internal(format!("local destroy_member failed: {error}")))?;

--- a/meerkat-runtime/src/comms_drain.rs
+++ b/meerkat-runtime/src/comms_drain.rs
@@ -36,6 +36,7 @@ use meerkat_contracts::wire::supervisor_bridge::{
 use crate::comms_bridge::classified_interaction_to_runtime_input;
 use crate::completion::CompletionOutcome;
 use crate::identifiers::IdempotencyKey;
+#[cfg(test)]
 use crate::identifiers::LogicalRuntimeId;
 use crate::input::{
     Input, InputDurability, InputHeader, InputOrigin, InputVisibility, PeerConvention, PeerInput,
@@ -62,7 +63,7 @@ pub fn spawn_comms_drain(
     idle_timeout: Option<Duration>,
 ) -> crate::tokio::task::JoinHandle<()> {
     let timeout_dur = idle_timeout.unwrap_or(DEFAULT_IDLE_TIMEOUT);
-    let runtime_id = LogicalRuntimeId::new(session_id.to_string());
+    let runtime_id = MeerkatMachine::logical_runtime_id(&session_id);
 
     crate::tokio::spawn(async move {
         if std::env::var_os("RKAT_TRACE_COMMS_DRAIN_BIND").is_some() {
@@ -542,7 +543,7 @@ fn peer_input_from_delivery_payload(
             source: InputOrigin::Peer {
                 peer_id: sender_peer_id.as_str(),
                 display_identity: Some(sender_peer_id.as_str()),
-                runtime_id: Some(LogicalRuntimeId::new(session_id.to_string())),
+                runtime_id: Some(MeerkatMachine::logical_runtime_id(session_id)),
             },
             durability: InputDurability::Durable,
             visibility: InputVisibility {
@@ -1593,7 +1594,7 @@ async fn try_handle_supervisor_bridge_command(
                 send_bridge_failure(comms_runtime, candidate, cause, reason).await;
                 return true;
             }
-            let runtime_id = LogicalRuntimeId::new(session_id.to_string());
+            let runtime_id = MeerkatMachine::logical_runtime_id(session_id);
             match RuntimeControlPlane::destroy(adapter.as_ref(), &runtime_id).await {
                 Ok(report) => {
                     send_bridge_response(

--- a/meerkat-runtime/src/identifiers.rs
+++ b/meerkat-runtime/src/identifiers.rs
@@ -6,6 +6,8 @@
 use serde::{Deserialize, Serialize};
 use uuid::Uuid;
 
+use meerkat_core::types::SessionId;
+
 /// Unique identifier for a runtime event.
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub struct RuntimeEventId(pub Uuid);
@@ -33,8 +35,35 @@ impl std::fmt::Display for RuntimeEventId {
 pub struct LogicalRuntimeId(pub String);
 
 impl LogicalRuntimeId {
+    const SESSION_RUNTIME_PREFIX: &'static str = "rt:session:";
+
     pub fn new(id: impl Into<String>) -> Self {
         Self(id.into())
+    }
+
+    pub fn for_session(session_id: &SessionId) -> Self {
+        Self(format!("{}{session_id}", Self::SESSION_RUNTIME_PREFIX))
+    }
+
+    pub fn legacy_session_uuid_alias(session_id: &SessionId) -> Self {
+        Self(session_id.to_string())
+    }
+
+    pub fn legacy_session_uuid_storage_alias(&self) -> Option<Self> {
+        self.0
+            .strip_prefix(Self::SESSION_RUNTIME_PREFIX)
+            .map(Self::new)
+    }
+
+    pub fn storage_alias_candidates(&self) -> Vec<Self> {
+        let Some(legacy) = self.legacy_session_uuid_storage_alias() else {
+            return vec![self.clone()];
+        };
+        if legacy == *self {
+            vec![self.clone()]
+        } else {
+            vec![self.clone(), legacy]
+        }
     }
 }
 

--- a/meerkat-runtime/src/meerkat_machine/dispatch_control.rs
+++ b/meerkat-runtime/src/meerkat_machine/dispatch_control.rs
@@ -514,7 +514,7 @@ impl MeerkatMachine {
                 Ok(MeerkatMachineCommandResult::DestroyReport(report))
             }
             MeerkatMachineCommand::RuntimeState { runtime_id } => {
-                let session_id = Self::resolve_session_id(&runtime_id)?;
+                let session_id = self.resolve_session_id(&runtime_id).await?;
                 let state = self
                     .existing_session_visible_runtime_state(&session_id)
                     .await
@@ -524,9 +524,7 @@ impl MeerkatMachine {
             MeerkatMachineCommand::RuntimeRealtimeAttachmentStatus { session_id } => {
                 let sessions = self.sessions.read().await;
                 let entry = sessions.get(&session_id).ok_or_else(|| {
-                    RuntimeControlPlaneError::NotFound(LogicalRuntimeId::new(
-                        session_id.to_string(),
-                    ))
+                    RuntimeControlPlaneError::NotFound(Self::logical_runtime_id(&session_id))
                 })?;
                 let authority = entry
                     .dsl_authority
@@ -540,9 +538,7 @@ impl MeerkatMachine {
             MeerkatMachineCommand::RuntimeRealtimeChannelStatus { session_id } => {
                 let sessions = self.sessions.read().await;
                 let entry = sessions.get(&session_id).ok_or_else(|| {
-                    RuntimeControlPlaneError::NotFound(LogicalRuntimeId::new(
-                        session_id.to_string(),
-                    ))
+                    RuntimeControlPlaneError::NotFound(Self::logical_runtime_id(&session_id))
                 })?;
                 let authority = entry
                     .dsl_authority
@@ -573,9 +569,7 @@ impl MeerkatMachine {
             MeerkatMachineCommand::SessionModelRoutingStatus { session_id } => {
                 let sessions = self.sessions.read().await;
                 let entry = sessions.get(&session_id).ok_or_else(|| {
-                    RuntimeControlPlaneError::NotFound(LogicalRuntimeId::new(
-                        session_id.to_string(),
-                    ))
+                    RuntimeControlPlaneError::NotFound(Self::logical_runtime_id(&session_id))
                 })?;
                 let authority = entry
                     .dsl_authority

--- a/meerkat-runtime/src/meerkat_machine/dispatch_control.rs
+++ b/meerkat-runtime/src/meerkat_machine/dispatch_control.rs
@@ -898,11 +898,16 @@ impl MeerkatMachine {
                 run_id,
                 sequence,
             } => {
+                let _session_id = self.resolve_session_id(&runtime_id).await?;
                 let receipt = match &self.store {
-                    Some(store) => store
-                        .load_boundary_receipt(&runtime_id, &run_id, sequence)
-                        .await
-                        .map_err(|e| RuntimeControlPlaneError::StoreError(e.to_string()))?,
+                    Some(store) => super::driver::load_boundary_receipt_for_storage_aliases(
+                        store.as_ref(),
+                        &runtime_id,
+                        &run_id,
+                        sequence,
+                    )
+                    .await
+                    .map_err(|e| RuntimeControlPlaneError::StoreError(e.to_string()))?,
                     None => None,
                 };
                 Ok(MeerkatMachineCommandResult::BoundaryReceipt(receipt))

--- a/meerkat-runtime/src/meerkat_machine/dispatch_control.rs
+++ b/meerkat-runtime/src/meerkat_machine/dispatch_control.rs
@@ -903,7 +903,7 @@ impl MeerkatMachine {
                     Some(store) => super::driver::load_boundary_receipt_for_storage_aliases(
                         store.as_ref(),
                         &runtime_id,
-                        &runtime_id,
+                        false,
                         &run_id,
                         sequence,
                     )

--- a/meerkat-runtime/src/meerkat_machine/dispatch_control.rs
+++ b/meerkat-runtime/src/meerkat_machine/dispatch_control.rs
@@ -903,6 +903,7 @@ impl MeerkatMachine {
                     Some(store) => super::driver::load_boundary_receipt_for_storage_aliases(
                         store.as_ref(),
                         &runtime_id,
+                        &runtime_id,
                         &run_id,
                         sequence,
                     )

--- a/meerkat-runtime/src/meerkat_machine/driver.rs
+++ b/meerkat-runtime/src/meerkat_machine/driver.rs
@@ -2,7 +2,7 @@
 
 use std::sync::Arc;
 
-use meerkat_core::lifecycle::{CoreApplyFailureCause, InputId, RunId};
+use meerkat_core::lifecycle::{CoreApplyFailureCause, InputId, RunBoundaryReceipt, RunId};
 
 use crate::accept::{AcceptOutcome, ResolvedAdmission};
 use crate::driver::ephemeral::{EphemeralDriverRollbackSnapshot, EphemeralRuntimeDriver};
@@ -1117,11 +1117,12 @@ pub(crate) async fn machine_normalize_recovered_input_state(
                 bundle.seed.last_run_id.clone(),
                 bundle.seed.last_boundary_sequence,
             ) {
-                (Some(run_id), Some(sequence)) => store
-                    .load_boundary_receipt(runtime_id, &run_id, sequence)
-                    .await
-                    .map_err(|e| RuntimeDriverError::Internal(e.to_string()))?
-                    .is_some(),
+                (Some(run_id), Some(sequence)) => {
+                    load_boundary_receipt_for_storage_aliases(store, runtime_id, &run_id, sequence)
+                        .await
+                        .map_err(|e| RuntimeDriverError::Internal(e.to_string()))?
+                        .is_some()
+                }
                 _ => false,
             },
         )
@@ -1132,6 +1133,74 @@ pub(crate) async fn machine_normalize_recovered_input_state(
     let _ = machine_apply_recovered_input_normalization(&mut bundle, applied_boundary_committed);
 
     Ok(bundle)
+}
+
+pub(super) async fn load_boundary_receipt_for_storage_aliases(
+    store: &dyn crate::store::RuntimeStore,
+    runtime_id: &LogicalRuntimeId,
+    run_id: &RunId,
+    sequence: u64,
+) -> Result<Option<RunBoundaryReceipt>, crate::store::RuntimeStoreError> {
+    for candidate in runtime_id.storage_alias_candidates() {
+        if let Some(receipt) = store
+            .load_boundary_receipt(&candidate, run_id, sequence)
+            .await?
+        {
+            return Ok(Some(receipt));
+        }
+    }
+    Ok(None)
+}
+
+async fn load_input_states_for_storage_aliases(
+    store: &dyn crate::store::RuntimeStore,
+    runtime_id: &LogicalRuntimeId,
+) -> Result<Vec<(LogicalRuntimeId, StoredInputState)>, crate::store::RuntimeStoreError> {
+    let mut merged: Vec<(usize, LogicalRuntimeId, StoredInputState)> = Vec::new();
+
+    for (candidate_index, candidate) in runtime_id
+        .storage_alias_candidates()
+        .into_iter()
+        .enumerate()
+    {
+        for state in store.load_input_states(&candidate).await? {
+            let input_id = state.state.input_id.clone();
+            if let Some((existing_index, existing_runtime_id, existing_state)) = merged
+                .iter_mut()
+                .find(|(_, _, existing)| existing.state.input_id == input_id)
+            {
+                let candidate_updated_at = state.state.updated_at();
+                let existing_updated_at = existing_state.state.updated_at();
+                if candidate_updated_at > existing_updated_at
+                    || (candidate_updated_at == existing_updated_at
+                        && candidate_index < *existing_index)
+                {
+                    *existing_index = candidate_index;
+                    *existing_runtime_id = candidate.clone();
+                    *existing_state = state;
+                }
+            } else {
+                merged.push((candidate_index, candidate.clone(), state));
+            }
+        }
+    }
+
+    Ok(merged
+        .into_iter()
+        .map(|(_, runtime_id, state)| (runtime_id, state))
+        .collect())
+}
+
+fn runtime_state_resume_rank(state: RuntimeState) -> u8 {
+    match state {
+        RuntimeState::Initializing => 0,
+        RuntimeState::Idle => 1,
+        RuntimeState::Attached => 2,
+        RuntimeState::Running => 3,
+        RuntimeState::Retired => 4,
+        RuntimeState::Stopped => 5,
+        RuntimeState::Destroyed => 6,
+    }
 }
 
 #[derive(Debug, Default, Clone, Copy)]
@@ -1450,24 +1519,14 @@ pub(crate) async fn machine_recover_persistent_driver(
     runtime_id: &LogicalRuntimeId,
     driver: &mut crate::driver::ephemeral::EphemeralRuntimeDriver,
 ) -> Result<RecoveryReport, RuntimeDriverError> {
-    let mut recovered_runtime_id = runtime_id.clone();
-    let mut stored_states = Vec::new();
-    for candidate in runtime_id.storage_alias_candidates() {
-        stored_states = store
-            .load_input_states(&candidate)
-            .await
-            .map_err(|e| RuntimeDriverError::Internal(e.to_string()))?;
-        recovered_runtime_id = candidate;
-        if !stored_states.is_empty() {
-            break;
-        }
-    }
-
     let mut recovered_payloads = Vec::new();
 
-    for bundle in stored_states {
+    for (stored_runtime_id, bundle) in load_input_states_for_storage_aliases(store, runtime_id)
+        .await
+        .map_err(|e| RuntimeDriverError::Internal(e.to_string()))?
+    {
         let bundle =
-            machine_normalize_recovered_input_state(store, &recovered_runtime_id, bundle).await?;
+            machine_normalize_recovered_input_state(store, &stored_runtime_id, bundle).await?;
 
         if driver.input_state(&bundle.state.input_id).is_none() {
             let Some(entry) = machine_build_recovered_ingress_entry(&bundle.state) else {
@@ -1514,12 +1573,21 @@ pub(crate) async fn machine_recover_persistent_driver(
 
     let mut recovered_runtime_state = None;
     for candidate in runtime_id.storage_alias_candidates() {
-        recovered_runtime_state = store
+        let candidate_state = store
             .load_runtime_state(&candidate)
             .await
             .map_err(|e| RuntimeDriverError::Internal(e.to_string()))?;
-        if recovered_runtime_state.is_some() {
-            break;
+        if let Some(candidate_state) = candidate_state {
+            recovered_runtime_state =
+                Some(recovered_runtime_state.map_or(candidate_state, |existing| {
+                    if runtime_state_resume_rank(candidate_state)
+                        > runtime_state_resume_rank(existing)
+                    {
+                        candidate_state
+                    } else {
+                        existing
+                    }
+                }));
         }
     }
     if let Some(runtime_state) = recovered_runtime_state {

--- a/meerkat-runtime/src/meerkat_machine/driver.rs
+++ b/meerkat-runtime/src/meerkat_machine/driver.rs
@@ -1121,7 +1121,7 @@ pub(crate) async fn machine_normalize_recovered_input_state(
                 (Some(run_id), Some(sequence)) => load_boundary_receipt_for_storage_aliases(
                     store,
                     runtime_id,
-                    stored_runtime_id,
+                    stored_runtime_id == runtime_id,
                     &run_id,
                     sequence,
                 )
@@ -1143,11 +1143,10 @@ pub(crate) async fn machine_normalize_recovered_input_state(
 pub(super) async fn load_boundary_receipt_for_storage_aliases(
     store: &dyn crate::store::RuntimeStore,
     runtime_id: &LogicalRuntimeId,
-    stored_runtime_id: &LogicalRuntimeId,
+    canonical_miss_authoritative: bool,
     run_id: &RunId,
     sequence: u64,
 ) -> Result<Option<RunBoundaryReceipt>, crate::store::RuntimeStoreError> {
-    let selected_primary_alias = stored_runtime_id == runtime_id;
     let mut primary_alias_loaded = false;
     for (candidate_index, candidate) in runtime_id
         .storage_alias_candidates()
@@ -1160,14 +1159,16 @@ pub(super) async fn load_boundary_receipt_for_storage_aliases(
         {
             Ok(Some(receipt)) => return Ok(Some(receipt)),
             Ok(None) => {
-                if candidate_index == 0 && selected_primary_alias {
+                if candidate_index == 0 && canonical_miss_authoritative {
                     return Ok(None);
                 }
                 if candidate_index == 0 {
                     primary_alias_loaded = true;
                 }
             }
-            Err(_err) if candidate_index > 0 && primary_alias_loaded && selected_primary_alias => {
+            Err(_err)
+                if candidate_index > 0 && primary_alias_loaded && canonical_miss_authoritative =>
+            {
                 continue;
             }
             Err(err) => return Err(err),

--- a/meerkat-runtime/src/meerkat_machine/driver.rs
+++ b/meerkat-runtime/src/meerkat_machine/driver.rs
@@ -1450,15 +1450,24 @@ pub(crate) async fn machine_recover_persistent_driver(
     runtime_id: &LogicalRuntimeId,
     driver: &mut crate::driver::ephemeral::EphemeralRuntimeDriver,
 ) -> Result<RecoveryReport, RuntimeDriverError> {
-    let stored_states = store
-        .load_input_states(runtime_id)
-        .await
-        .map_err(|e| RuntimeDriverError::Internal(e.to_string()))?;
+    let mut recovered_runtime_id = runtime_id.clone();
+    let mut stored_states = Vec::new();
+    for candidate in runtime_id.storage_alias_candidates() {
+        stored_states = store
+            .load_input_states(&candidate)
+            .await
+            .map_err(|e| RuntimeDriverError::Internal(e.to_string()))?;
+        recovered_runtime_id = candidate;
+        if !stored_states.is_empty() {
+            break;
+        }
+    }
 
     let mut recovered_payloads = Vec::new();
 
     for bundle in stored_states {
-        let bundle = machine_normalize_recovered_input_state(store, runtime_id, bundle).await?;
+        let bundle =
+            machine_normalize_recovered_input_state(store, &recovered_runtime_id, bundle).await?;
 
         if driver.input_state(&bundle.state.input_id).is_none() {
             let Some(entry) = machine_build_recovered_ingress_entry(&bundle.state) else {
@@ -1503,11 +1512,17 @@ pub(crate) async fn machine_recover_persistent_driver(
         }
     }
 
-    if let Some(runtime_state) = store
-        .load_runtime_state(runtime_id)
-        .await
-        .map_err(|e| RuntimeDriverError::Internal(e.to_string()))?
-    {
+    let mut recovered_runtime_state = None;
+    for candidate in runtime_id.storage_alias_candidates() {
+        recovered_runtime_state = store
+            .load_runtime_state(&candidate)
+            .await
+            .map_err(|e| RuntimeDriverError::Internal(e.to_string()))?;
+        if recovered_runtime_state.is_some() {
+            break;
+        }
+    }
+    if let Some(runtime_state) = recovered_runtime_state {
         machine_realize_recovered_runtime_state(driver, runtime_state);
 
         if runtime_state.is_terminal() {

--- a/meerkat-runtime/src/meerkat_machine/driver.rs
+++ b/meerkat-runtime/src/meerkat_machine/driver.rs
@@ -1160,6 +1160,9 @@ pub(super) async fn load_boundary_receipt_for_storage_aliases(
         {
             Ok(Some(receipt)) => return Ok(Some(receipt)),
             Ok(None) => {
+                if candidate_index == 0 && selected_primary_alias {
+                    return Ok(None);
+                }
                 if candidate_index == 0 {
                     primary_alias_loaded = true;
                 }

--- a/meerkat-runtime/src/meerkat_machine/driver.rs
+++ b/meerkat-runtime/src/meerkat_machine/driver.rs
@@ -1191,18 +1191,6 @@ async fn load_input_states_for_storage_aliases(
         .collect())
 }
 
-fn runtime_state_resume_rank(state: RuntimeState) -> u8 {
-    match state {
-        RuntimeState::Initializing => 0,
-        RuntimeState::Idle => 1,
-        RuntimeState::Attached => 2,
-        RuntimeState::Running => 3,
-        RuntimeState::Retired => 4,
-        RuntimeState::Stopped => 5,
-        RuntimeState::Destroyed => 6,
-    }
-}
-
 #[derive(Debug, Default, Clone, Copy)]
 pub(crate) struct MachineRecoveryDelta {
     pub recovered: usize,
@@ -1573,21 +1561,12 @@ pub(crate) async fn machine_recover_persistent_driver(
 
     let mut recovered_runtime_state = None;
     for candidate in runtime_id.storage_alias_candidates() {
-        let candidate_state = store
+        recovered_runtime_state = store
             .load_runtime_state(&candidate)
             .await
             .map_err(|e| RuntimeDriverError::Internal(e.to_string()))?;
-        if let Some(candidate_state) = candidate_state {
-            recovered_runtime_state =
-                Some(recovered_runtime_state.map_or(candidate_state, |existing| {
-                    if runtime_state_resume_rank(candidate_state)
-                        > runtime_state_resume_rank(existing)
-                    {
-                        candidate_state
-                    } else {
-                        existing
-                    }
-                }));
+        if recovered_runtime_state.is_some() {
+            break;
         }
     }
     if let Some(runtime_state) = recovered_runtime_state {

--- a/meerkat-runtime/src/meerkat_machine/driver.rs
+++ b/meerkat-runtime/src/meerkat_machine/driver.rs
@@ -1106,6 +1106,7 @@ pub(crate) fn machine_validate_run_failed(
 pub(crate) async fn machine_normalize_recovered_input_state(
     store: &dyn crate::store::RuntimeStore,
     runtime_id: &LogicalRuntimeId,
+    stored_runtime_id: &LogicalRuntimeId,
     mut bundle: StoredInputState,
 ) -> Result<StoredInputState, RuntimeDriverError> {
     let applied_boundary_committed = if matches!(
@@ -1117,12 +1118,16 @@ pub(crate) async fn machine_normalize_recovered_input_state(
                 bundle.seed.last_run_id.clone(),
                 bundle.seed.last_boundary_sequence,
             ) {
-                (Some(run_id), Some(sequence)) => {
-                    load_boundary_receipt_for_storage_aliases(store, runtime_id, &run_id, sequence)
-                        .await
-                        .map_err(|e| RuntimeDriverError::Internal(e.to_string()))?
-                        .is_some()
-                }
+                (Some(run_id), Some(sequence)) => load_boundary_receipt_for_storage_aliases(
+                    store,
+                    runtime_id,
+                    stored_runtime_id,
+                    &run_id,
+                    sequence,
+                )
+                .await
+                .map_err(|e| RuntimeDriverError::Internal(e.to_string()))?
+                .is_some(),
                 _ => false,
             },
         )
@@ -1138,15 +1143,31 @@ pub(crate) async fn machine_normalize_recovered_input_state(
 pub(super) async fn load_boundary_receipt_for_storage_aliases(
     store: &dyn crate::store::RuntimeStore,
     runtime_id: &LogicalRuntimeId,
+    stored_runtime_id: &LogicalRuntimeId,
     run_id: &RunId,
     sequence: u64,
 ) -> Result<Option<RunBoundaryReceipt>, crate::store::RuntimeStoreError> {
-    for candidate in runtime_id.storage_alias_candidates() {
-        if let Some(receipt) = store
+    let selected_primary_alias = stored_runtime_id == runtime_id;
+    let mut primary_alias_loaded = false;
+    for (candidate_index, candidate) in runtime_id
+        .storage_alias_candidates()
+        .into_iter()
+        .enumerate()
+    {
+        match store
             .load_boundary_receipt(&candidate, run_id, sequence)
-            .await?
+            .await
         {
-            return Ok(Some(receipt));
+            Ok(Some(receipt)) => return Ok(Some(receipt)),
+            Ok(None) => {
+                if candidate_index == 0 {
+                    primary_alias_loaded = true;
+                }
+            }
+            Err(_err) if candidate_index > 0 && primary_alias_loaded && selected_primary_alias => {
+                continue;
+            }
+            Err(err) => return Err(err),
         }
     }
     Ok(None)
@@ -1182,10 +1203,12 @@ async fn load_input_states_for_storage_aliases(
             {
                 let candidate_updated_at = state.state.updated_at();
                 let existing_updated_at = existing_state.state.updated_at();
-                if candidate_updated_at > existing_updated_at
-                    || (candidate_updated_at == existing_updated_at
-                        && candidate_index < *existing_index)
-                {
+                let should_replace = if candidate_index == *existing_index {
+                    candidate_updated_at > existing_updated_at
+                } else {
+                    candidate_index < *existing_index
+                };
+                if should_replace {
                     *existing_index = candidate_index;
                     *existing_runtime_id = candidate.clone();
                     *existing_state = state;
@@ -1520,11 +1543,13 @@ pub(crate) async fn machine_recover_persistent_driver(
 ) -> Result<RecoveryReport, RuntimeDriverError> {
     let mut recovered_payloads = Vec::new();
 
-    for (_stored_runtime_id, bundle) in load_input_states_for_storage_aliases(store, runtime_id)
+    for (stored_runtime_id, bundle) in load_input_states_for_storage_aliases(store, runtime_id)
         .await
         .map_err(|e| RuntimeDriverError::Internal(e.to_string()))?
     {
-        let bundle = machine_normalize_recovered_input_state(store, runtime_id, bundle).await?;
+        let bundle =
+            machine_normalize_recovered_input_state(store, runtime_id, &stored_runtime_id, bundle)
+                .await?;
 
         if driver.input_state(&bundle.state.input_id).is_none() {
             let Some(entry) = machine_build_recovered_ingress_entry(&bundle.state) else {

--- a/meerkat-runtime/src/meerkat_machine/driver.rs
+++ b/meerkat-runtime/src/meerkat_machine/driver.rs
@@ -1157,6 +1157,7 @@ async fn load_input_states_for_storage_aliases(
     runtime_id: &LogicalRuntimeId,
 ) -> Result<Vec<(LogicalRuntimeId, StoredInputState)>, crate::store::RuntimeStoreError> {
     let mut merged: Vec<(usize, LogicalRuntimeId, StoredInputState)> = Vec::new();
+    let mut primary_alias_loaded = false;
 
     for (candidate_index, candidate) in runtime_id
         .storage_alias_candidates()
@@ -1164,8 +1165,13 @@ async fn load_input_states_for_storage_aliases(
         .enumerate()
     {
         let states = match store.load_input_states(&candidate).await {
-            Ok(states) => states,
-            Err(_err) if candidate_index > 0 && !merged.is_empty() => continue,
+            Ok(states) => {
+                if candidate_index == 0 {
+                    primary_alias_loaded = true;
+                }
+                states
+            }
+            Err(_err) if candidate_index > 0 && primary_alias_loaded => continue,
             Err(err) => return Err(err),
         };
         for state in states {
@@ -1564,11 +1570,22 @@ pub(crate) async fn machine_recover_persistent_driver(
     }
 
     let mut recovered_runtime_state = None;
-    for candidate in runtime_id.storage_alias_candidates() {
-        recovered_runtime_state = store
-            .load_runtime_state(&candidate)
-            .await
-            .map_err(|e| RuntimeDriverError::Internal(e.to_string()))?;
+    let mut primary_runtime_state_loaded = false;
+    for (candidate_index, candidate) in runtime_id
+        .storage_alias_candidates()
+        .into_iter()
+        .enumerate()
+    {
+        match store.load_runtime_state(&candidate).await {
+            Ok(state) => {
+                if candidate_index == 0 {
+                    primary_runtime_state_loaded = true;
+                }
+                recovered_runtime_state = state;
+            }
+            Err(_err) if candidate_index > 0 && primary_runtime_state_loaded => continue,
+            Err(err) => return Err(RuntimeDriverError::Internal(err.to_string())),
+        }
         if recovered_runtime_state.is_some() {
             break;
         }

--- a/meerkat-runtime/src/meerkat_machine/driver.rs
+++ b/meerkat-runtime/src/meerkat_machine/driver.rs
@@ -1163,7 +1163,12 @@ async fn load_input_states_for_storage_aliases(
         .into_iter()
         .enumerate()
     {
-        for state in store.load_input_states(&candidate).await? {
+        let states = match store.load_input_states(&candidate).await {
+            Ok(states) => states,
+            Err(_err) if candidate_index > 0 && !merged.is_empty() => continue,
+            Err(err) => return Err(err),
+        };
+        for state in states {
             let input_id = state.state.input_id.clone();
             if let Some((existing_index, existing_runtime_id, existing_state)) = merged
                 .iter_mut()

--- a/meerkat-runtime/src/meerkat_machine/driver.rs
+++ b/meerkat-runtime/src/meerkat_machine/driver.rs
@@ -1509,12 +1509,11 @@ pub(crate) async fn machine_recover_persistent_driver(
 ) -> Result<RecoveryReport, RuntimeDriverError> {
     let mut recovered_payloads = Vec::new();
 
-    for (stored_runtime_id, bundle) in load_input_states_for_storage_aliases(store, runtime_id)
+    for (_stored_runtime_id, bundle) in load_input_states_for_storage_aliases(store, runtime_id)
         .await
         .map_err(|e| RuntimeDriverError::Internal(e.to_string()))?
     {
-        let bundle =
-            machine_normalize_recovered_input_state(store, &stored_runtime_id, bundle).await?;
+        let bundle = machine_normalize_recovered_input_state(store, runtime_id, bundle).await?;
 
         if driver.input_state(&bundle.state.input_id).is_none() {
             let Some(entry) = machine_build_recovered_ingress_entry(&bundle.state) else {

--- a/meerkat-runtime/src/meerkat_machine/mod.rs
+++ b/meerkat-runtime/src/meerkat_machine/mod.rs
@@ -171,6 +171,8 @@ enum CommittedEffectDispatchFailure {
 
 /// Per-session state: driver + registration phase.
 struct RuntimeSessionEntry {
+    /// Canonical runtime control-plane identity for this registered session.
+    runtime_id: LogicalRuntimeId,
     /// Per-session mutation gate.
     ///
     /// Serializes same-session mutating commands across the full
@@ -820,10 +822,9 @@ impl MeerkatMachine {
     /// Create a driver entry for a session.
     fn make_driver(
         &self,
-        session_id: &SessionId,
+        runtime_id: LogicalRuntimeId,
         dsl_authority: crate::driver::ephemeral::SharedIngressDslAuthority,
     ) -> DriverEntry {
-        let runtime_id = LogicalRuntimeId::new(session_id.to_string());
         let control_projection = Arc::new(StdRwLock::new(
             crate::driver::ephemeral::RuntimeControlProjection::default(),
         ));
@@ -854,57 +855,68 @@ impl MeerkatMachine {
     async fn recover_or_create_ops_state(
         &self,
         session_id: &SessionId,
+        runtime_id: &LogicalRuntimeId,
     ) -> (
         Arc<crate::ops_lifecycle::RuntimeOpsLifecycleRegistry>,
         meerkat_core::RuntimeEpochId,
         Arc<meerkat_core::EpochCursorState>,
     ) {
         if let Some(ref store) = self.store {
-            let runtime_id = crate::identifiers::LogicalRuntimeId::new(session_id.to_string());
-            match store.load_ops_lifecycle(&runtime_id).await {
-                Ok(Some(snapshot)) => {
-                    let recovered_epoch = snapshot.epoch_id.clone();
-                    let recovered_cursors = meerkat_core::EpochCursorState::from_recovered(
-                        snapshot.cursors.agent_applied_cursor,
-                        snapshot.cursors.runtime_observed_seq,
-                        snapshot.cursors.runtime_last_injected_seq,
-                    );
-                    let recovered_ops_count = snapshot.completion_entries.len();
-                    let registry =
-                        crate::ops_lifecycle::RuntimeOpsLifecycleRegistry::from_recovered(snapshot);
-                    tracing::info!(
-                        %session_id,
-                        epoch_id = %recovered_epoch,
-                        recovered_ops = recovered_ops_count,
-                        "ops lifecycle recovered from durable store (same epoch)"
-                    );
-                    (
-                        Arc::new(registry),
-                        recovered_epoch,
-                        Arc::new(recovered_cursors),
-                    )
-                }
-                Ok(None) => {
-                    tracing::debug!(%session_id, "no persisted ops lifecycle; fresh epoch");
-                    (
-                        Arc::new(crate::ops_lifecycle::RuntimeOpsLifecycleRegistry::new()),
-                        meerkat_core::RuntimeEpochId::new(),
-                        Arc::new(meerkat_core::EpochCursorState::new()),
-                    )
-                }
-                Err(err) => {
-                    tracing::warn!(
-                        %session_id,
-                        error = %err,
-                        "failed to load ops lifecycle; epoch rotated"
-                    );
-                    (
-                        Arc::new(crate::ops_lifecycle::RuntimeOpsLifecycleRegistry::new()),
-                        meerkat_core::RuntimeEpochId::new(),
-                        Arc::new(meerkat_core::EpochCursorState::new()),
-                    )
+            let legacy_alias = LogicalRuntimeId::legacy_session_uuid_alias(session_id);
+            let candidates = if &legacy_alias == runtime_id {
+                vec![runtime_id.clone()]
+            } else {
+                vec![runtime_id.clone(), legacy_alias]
+            };
+            for candidate in candidates {
+                match store.load_ops_lifecycle(&candidate).await {
+                    Ok(Some(snapshot)) => {
+                        let recovered_epoch = snapshot.epoch_id.clone();
+                        let recovered_cursors = meerkat_core::EpochCursorState::from_recovered(
+                            snapshot.cursors.agent_applied_cursor,
+                            snapshot.cursors.runtime_observed_seq,
+                            snapshot.cursors.runtime_last_injected_seq,
+                        );
+                        let recovered_ops_count = snapshot.completion_entries.len();
+                        let registry =
+                            crate::ops_lifecycle::RuntimeOpsLifecycleRegistry::from_recovered(
+                                snapshot,
+                            );
+                        tracing::info!(
+                            %session_id,
+                            %candidate,
+                            epoch_id = %recovered_epoch,
+                            recovered_ops = recovered_ops_count,
+                            "ops lifecycle recovered from durable store (same epoch)"
+                        );
+                        return (
+                            Arc::new(registry),
+                            recovered_epoch,
+                            Arc::new(recovered_cursors),
+                        );
+                    }
+                    Ok(None) => {}
+                    Err(err) => {
+                        tracing::warn!(
+                            %session_id,
+                            %candidate,
+                            error = %err,
+                            "failed to load ops lifecycle; epoch rotated"
+                        );
+                        return (
+                            Arc::new(crate::ops_lifecycle::RuntimeOpsLifecycleRegistry::new()),
+                            meerkat_core::RuntimeEpochId::new(),
+                            Arc::new(meerkat_core::EpochCursorState::new()),
+                        );
+                    }
                 }
             }
+            tracing::debug!(%session_id, "no persisted ops lifecycle; fresh epoch");
+            (
+                Arc::new(crate::ops_lifecycle::RuntimeOpsLifecycleRegistry::new()),
+                meerkat_core::RuntimeEpochId::new(),
+                Arc::new(meerkat_core::EpochCursorState::new()),
+            )
         } else {
             (
                 Arc::new(crate::ops_lifecycle::RuntimeOpsLifecycleRegistry::new()),

--- a/meerkat-runtime/src/meerkat_machine/mod.rs
+++ b/meerkat-runtime/src/meerkat_machine/mod.rs
@@ -118,6 +118,25 @@ type MeerkatMachineCommandFuture<'a> = Pin<
     Box<dyn Future<Output = Result<MeerkatMachineCommandResult, MeerkatMachineCommandError>> + 'a>,
 >;
 
+fn ops_snapshot_resume_rank(
+    snapshot: &crate::ops_lifecycle::PersistedOpsSnapshot,
+) -> (u64, u64, u64, u64, usize, usize) {
+    let completion_watermark = snapshot
+        .completion_entries
+        .iter()
+        .map(|entry| entry.seq)
+        .max()
+        .unwrap_or(0);
+    (
+        completion_watermark,
+        snapshot.cursors.agent_applied_cursor,
+        snapshot.cursors.runtime_observed_seq,
+        snapshot.cursors.runtime_last_injected_seq,
+        snapshot.completion_entries.len(),
+        snapshot.authority_state.operation_count(),
+    )
+}
+
 pub(crate) use driver::{
     DriverEntry, SharedCompletionRegistry, SharedDriver, commit_runtime_loop_run,
     fail_machine_run_without_runtime_apply_cause, fail_runtime_loop_run,
@@ -868,32 +887,19 @@ impl MeerkatMachine {
             } else {
                 vec![runtime_id.clone(), legacy_alias]
             };
+            let mut recovered: Option<(
+                LogicalRuntimeId,
+                crate::ops_lifecycle::PersistedOpsSnapshot,
+            )> = None;
             for candidate in candidates {
                 match store.load_ops_lifecycle(&candidate).await {
                     Ok(Some(snapshot)) => {
-                        let recovered_epoch = snapshot.epoch_id.clone();
-                        let recovered_cursors = meerkat_core::EpochCursorState::from_recovered(
-                            snapshot.cursors.agent_applied_cursor,
-                            snapshot.cursors.runtime_observed_seq,
-                            snapshot.cursors.runtime_last_injected_seq,
-                        );
-                        let recovered_ops_count = snapshot.completion_entries.len();
-                        let registry =
-                            crate::ops_lifecycle::RuntimeOpsLifecycleRegistry::from_recovered(
-                                snapshot,
-                            );
-                        tracing::info!(
-                            %session_id,
-                            %candidate,
-                            epoch_id = %recovered_epoch,
-                            recovered_ops = recovered_ops_count,
-                            "ops lifecycle recovered from durable store (same epoch)"
-                        );
-                        return (
-                            Arc::new(registry),
-                            recovered_epoch,
-                            Arc::new(recovered_cursors),
-                        );
+                        let replace = recovered.as_ref().is_none_or(|(_, existing)| {
+                            ops_snapshot_resume_rank(&snapshot) > ops_snapshot_resume_rank(existing)
+                        });
+                        if replace {
+                            recovered = Some((candidate, snapshot));
+                        }
                     }
                     Ok(None) => {}
                     Err(err) => {
@@ -910,6 +916,29 @@ impl MeerkatMachine {
                         );
                     }
                 }
+            }
+            if let Some((candidate, snapshot)) = recovered {
+                let recovered_epoch = snapshot.epoch_id.clone();
+                let recovered_cursors = meerkat_core::EpochCursorState::from_recovered(
+                    snapshot.cursors.agent_applied_cursor,
+                    snapshot.cursors.runtime_observed_seq,
+                    snapshot.cursors.runtime_last_injected_seq,
+                );
+                let recovered_ops_count = snapshot.completion_entries.len();
+                let registry =
+                    crate::ops_lifecycle::RuntimeOpsLifecycleRegistry::from_recovered(snapshot);
+                tracing::info!(
+                    %session_id,
+                    %candidate,
+                    epoch_id = %recovered_epoch,
+                    recovered_ops = recovered_ops_count,
+                    "ops lifecycle recovered from durable store (same epoch)"
+                );
+                return (
+                    Arc::new(registry),
+                    recovered_epoch,
+                    Arc::new(recovered_cursors),
+                );
             }
             tracing::debug!(%session_id, "no persisted ops lifecycle; fresh epoch");
             (

--- a/meerkat-runtime/src/meerkat_machine/mod.rs
+++ b/meerkat-runtime/src/meerkat_machine/mod.rs
@@ -118,25 +118,6 @@ type MeerkatMachineCommandFuture<'a> = Pin<
     Box<dyn Future<Output = Result<MeerkatMachineCommandResult, MeerkatMachineCommandError>> + 'a>,
 >;
 
-fn ops_snapshot_resume_rank(
-    snapshot: &crate::ops_lifecycle::PersistedOpsSnapshot,
-) -> (u64, u64, u64, u64, usize, usize) {
-    let completion_watermark = snapshot
-        .completion_entries
-        .iter()
-        .map(|entry| entry.seq)
-        .max()
-        .unwrap_or(0);
-    (
-        completion_watermark,
-        snapshot.cursors.agent_applied_cursor,
-        snapshot.cursors.runtime_observed_seq,
-        snapshot.cursors.runtime_last_injected_seq,
-        snapshot.completion_entries.len(),
-        snapshot.authority_state.operation_count(),
-    )
-}
-
 pub(crate) use driver::{
     DriverEntry, SharedCompletionRegistry, SharedDriver, commit_runtime_loop_run,
     fail_machine_run_without_runtime_apply_cause, fail_runtime_loop_run,
@@ -894,12 +875,11 @@ impl MeerkatMachine {
             for candidate in candidates {
                 match store.load_ops_lifecycle(&candidate).await {
                     Ok(Some(snapshot)) => {
-                        let replace = recovered.as_ref().is_none_or(|(_, existing)| {
-                            ops_snapshot_resume_rank(&snapshot) > ops_snapshot_resume_rank(existing)
-                        });
-                        if replace {
+                        if candidate == *runtime_id {
                             recovered = Some((candidate, snapshot));
+                            break;
                         }
+                        recovered = Some((candidate, snapshot));
                     }
                     Ok(None) => {}
                     Err(err) if recovered.is_some() => {

--- a/meerkat-runtime/src/meerkat_machine/mod.rs
+++ b/meerkat-runtime/src/meerkat_machine/mod.rs
@@ -902,6 +902,14 @@ impl MeerkatMachine {
                         }
                     }
                     Ok(None) => {}
+                    Err(err) if recovered.is_some() => {
+                        tracing::warn!(
+                            %session_id,
+                            %candidate,
+                            error = %err,
+                            "ignoring legacy ops lifecycle fallback error because canonical snapshot was already recovered"
+                        );
+                    }
                     Err(err) => {
                         tracing::warn!(
                             %session_id,

--- a/meerkat-runtime/src/meerkat_machine/session_management.rs
+++ b/meerkat-runtime/src/meerkat_machine/session_management.rs
@@ -149,7 +149,8 @@ impl MeerkatMachine {
                 None,
             )),
         ));
-        let mut entry = self.make_driver(&session_id, Arc::clone(&dsl_authority));
+        let runtime_id = Self::logical_runtime_id(&session_id);
+        let mut entry = self.make_driver(runtime_id.clone(), Arc::clone(&dsl_authority));
         if let Err(err) = entry.as_driver_mut().recover().await {
             tracing::error!(%session_id, error = %err, "failed to recover runtime driver during registration");
             return;
@@ -161,8 +162,9 @@ impl MeerkatMachine {
         );
         let control_projection = entry.control_projection_handle();
 
-        let (ops_lifecycle, epoch_id, cursor_state) =
-            self.recover_or_create_ops_state(&session_id).await;
+        let (ops_lifecycle, epoch_id, cursor_state) = self
+            .recover_or_create_ops_state(&session_id, &runtime_id)
+            .await;
 
         let tool_visibility_owner = Arc::new(MachineToolVisibilityOwner::new());
         // Bind the DSL authority into the visibility owner so its staging
@@ -170,6 +172,7 @@ impl MeerkatMachine {
         // `next_staged_visibility_revision` (dogma round 4, wave 2b #12).
         tool_visibility_owner.bind_dsl_authority(Arc::clone(&dsl_authority));
         let session_entry = RuntimeSessionEntry {
+            runtime_id,
             mutation_gate: Arc::new(Mutex::new(())),
             control_projection,
             driver: Arc::new(Mutex::new(entry)),
@@ -307,7 +310,9 @@ impl MeerkatMachine {
                         ),
                     ),
                 ));
-                let mut recovered_entry = self.make_driver(&session_id, Arc::clone(&dsl_authority));
+                let runtime_id = Self::logical_runtime_id(&session_id);
+                let mut recovered_entry =
+                    self.make_driver(runtime_id.clone(), Arc::clone(&dsl_authority));
                 if let Err(err) = recovered_entry.as_driver_mut().recover().await {
                     tracing::error!(
                         %session_id,
@@ -324,8 +329,9 @@ impl MeerkatMachine {
 
                 // Recover ops state OUTSIDE the sessions lock to avoid blocking
                 // other adapter operations behind potentially slow disk I/O.
-                let (recovered_ops, recovered_epoch, recovered_cursors) =
-                    self.recover_or_create_ops_state(&session_id).await;
+                let (recovered_ops, recovered_epoch, recovered_cursors) = self
+                    .recover_or_create_ops_state(&session_id, &runtime_id)
+                    .await;
 
                 // Double-check under the lock — another task may have inserted
                 // the entry while we were rebuilding runtime state.
@@ -353,6 +359,7 @@ impl MeerkatMachine {
                     sessions.insert(
                         session_id.clone(),
                         RuntimeSessionEntry {
+                            runtime_id,
                             mutation_gate: Arc::new(Mutex::new(())),
                             control_projection,
                             driver: driver.clone(),
@@ -424,21 +431,25 @@ impl MeerkatMachine {
             let (persist_tx, persist_rx) = crate::tokio::sync::mpsc::unbounded_channel::<
                 crate::ops_lifecycle::OpsLifecyclePersistenceRequest,
             >();
-            let entry_epoch_id = {
+            let (entry_epoch_id, entry_cursor, runtime_id) = {
                 let sessions = self.sessions.read().await;
-                sessions
-                    .get(&session_id)
-                    .map(|e| e.epoch_id.clone())
-                    .unwrap_or_else(meerkat_core::RuntimeEpochId::new)
+                sessions.get(&session_id).map_or_else(
+                    || {
+                        (
+                            meerkat_core::RuntimeEpochId::new(),
+                            Arc::new(meerkat_core::EpochCursorState::new()),
+                            Self::logical_runtime_id(&session_id),
+                        )
+                    },
+                    |entry| {
+                        (
+                            entry.epoch_id.clone(),
+                            Arc::clone(&entry.cursor_state),
+                            entry.runtime_id.clone(),
+                        )
+                    },
+                )
             };
-            let entry_cursor = {
-                let sessions = self.sessions.read().await;
-                sessions
-                    .get(&session_id)
-                    .map(|e| Arc::clone(&e.cursor_state))
-                    .unwrap_or_else(|| Arc::new(meerkat_core::EpochCursorState::new()))
-            };
-            let runtime_id = crate::identifiers::LogicalRuntimeId::new(session_id.to_string());
             spawn_ops_lifecycle_persistence_worker(Arc::clone(store), runtime_id, persist_rx);
             ops_lifecycle.set_persistence_channel(persist_tx, entry_epoch_id, entry_cursor);
         }

--- a/meerkat-runtime/src/meerkat_machine/traits.rs
+++ b/meerkat-runtime/src/meerkat_machine/traits.rs
@@ -394,8 +394,8 @@ impl SessionServiceRuntimeExt for MeerkatMachine {
 // ---------------------------------------------------------------------------
 
 impl MeerkatMachine {
-    pub(super) fn logical_runtime_id(session_id: &SessionId) -> LogicalRuntimeId {
-        LogicalRuntimeId::new(session_id.to_string())
+    pub(crate) fn logical_runtime_id(session_id: &SessionId) -> LogicalRuntimeId {
+        LogicalRuntimeId::for_session(session_id)
     }
 
     pub(super) fn post_admission_signal_from_effects(
@@ -459,19 +459,18 @@ impl MeerkatMachine {
         }
     }
 
-    /// Resolve a LogicalRuntimeId to a SessionId for internal lookup.
-    ///
-    /// The adapter uses `LogicalRuntimeId::new(session_id.to_string())` when
-    /// creating drivers, so runtime IDs are UUID strings that parse back to
-    /// SessionId.
-    pub(super) fn resolve_session_id(
+    /// Resolve a LogicalRuntimeId to a registered SessionId for internal lookup.
+    pub(super) async fn resolve_session_id(
+        &self,
         runtime_id: &LogicalRuntimeId,
     ) -> Result<SessionId, RuntimeControlPlaneError> {
-        runtime_id
-            .0
-            .parse::<uuid::Uuid>()
-            .map(SessionId)
-            .map_err(|_| RuntimeControlPlaneError::NotFound(runtime_id.clone()))
+        let sessions = self.sessions.read().await;
+        sessions
+            .iter()
+            .find_map(|(session_id, entry)| {
+                (&entry.runtime_id == runtime_id).then(|| session_id.clone())
+            })
+            .ok_or_else(|| RuntimeControlPlaneError::NotFound(runtime_id.clone()))
     }
 
     pub(super) async fn existing_session_runtime_state(
@@ -519,13 +518,13 @@ impl MeerkatMachine {
         ),
         RuntimeControlPlaneError,
     > {
-        let session_id = Self::resolve_session_id(runtime_id)?;
         let sessions = self.sessions.read().await;
-        let entry = sessions
-            .get(&session_id)
+        let (session_id, entry) = sessions
+            .iter()
+            .find(|(_, entry)| &entry.runtime_id == runtime_id)
             .ok_or_else(|| RuntimeControlPlaneError::NotFound(runtime_id.clone()))?;
         Ok((
-            session_id,
+            session_id.clone(),
             entry.driver.clone(),
             entry.completions.clone(),
             entry.wake_sender(),

--- a/meerkat-runtime/src/meerkat_machine_tests.rs
+++ b/meerkat-runtime/src/meerkat_machine_tests.rs
@@ -54,6 +54,10 @@ fn memory_blob_store() -> Arc<dyn meerkat_core::BlobStore> {
     Arc::new(meerkat_store::MemoryBlobStore::new())
 }
 
+fn runtime_id_for_session(session_id: &SessionId) -> LogicalRuntimeId {
+    MeerkatMachine::logical_runtime_id(session_id)
+}
+
 #[derive(Default)]
 struct RecordingMeerkatSignalSurface {
     log: tokio::sync::Mutex<
@@ -316,6 +320,33 @@ async fn authoritative_dsl_apply_rolls_back_state_when_effect_dispatch_fails() {
 }
 
 #[tokio::test]
+async fn control_plane_runtime_id_is_not_raw_session_uuid_alias() {
+    let machine = MeerkatMachine::ephemeral();
+    let session_id = SessionId::new();
+    machine.register_session(session_id.clone()).await;
+
+    let runtime_id = runtime_id_for_session(&session_id);
+    let raw_session_alias = LogicalRuntimeId::legacy_session_uuid_alias(&session_id);
+    assert_ne!(
+        runtime_id, raw_session_alias,
+        "runtime control-plane identity must not be the raw session UUID alias"
+    );
+
+    let state = crate::traits::RuntimeControlPlane::runtime_state(&machine, &runtime_id)
+        .await
+        .expect("canonical runtime id should resolve registered session");
+    assert_eq!(state, RuntimeState::Idle);
+
+    let err = crate::traits::RuntimeControlPlane::runtime_state(&machine, &raw_session_alias)
+        .await
+        .expect_err("raw session UUID alias must not resolve as a runtime id");
+    assert!(matches!(
+        err,
+        crate::traits::RuntimeControlPlaneError::NotFound(_)
+    ));
+}
+
+#[tokio::test]
 async fn destroy_keeps_committed_dsl_state_when_runtime_destroyed_signal_dispatch_fails() {
     let machine = MeerkatMachine::ephemeral();
     let session_id = SessionId::new();
@@ -325,7 +356,7 @@ async fn destroy_keeps_committed_dsl_state_when_runtime_destroyed_signal_dispatc
         .expect("prepare bindings before destroy");
     install_rejecting_meerkat_signal_dispatcher(&machine);
 
-    let runtime_id = LogicalRuntimeId::new(session_id.to_string());
+    let runtime_id = runtime_id_for_session(&session_id);
     let err = crate::traits::RuntimeControlPlane::destroy(&machine, &runtime_id)
         .await
         .expect_err("signal dispatch failure should surface");
@@ -351,7 +382,7 @@ async fn persistent_retire_keeps_committed_dsl_state_when_runtime_retired_signal
     machine.register_session(session_id.clone()).await;
     install_rejecting_meerkat_signal_dispatcher(&machine);
 
-    let runtime_id = LogicalRuntimeId::new(session_id.to_string());
+    let runtime_id = runtime_id_for_session(&session_id);
     let err = crate::traits::RuntimeControlPlane::retire(&machine, &runtime_id)
         .await
         .expect_err("signal dispatch failure should surface");
@@ -402,7 +433,7 @@ async fn prepare_bindings_dispatches_runtime_bound_after_shell_commit() {
     assert_eq!(log[0].1[0].0.as_str(), "agent_runtime_id");
     assert!(matches!(
         &log[0].1[0].1,
-        crate::composition::OwnedFieldValue::Str(value) if value == &session_id.to_string()
+        crate::composition::OwnedFieldValue::Str(value) if value == &runtime_id_for_session(&session_id).to_string()
     ));
 }
 
@@ -2199,7 +2230,7 @@ async fn meerkat_machine_spine_snapshot_preserves_completion_waiters_after_recyc
         input_id
     );
 
-    let runtime_id = LogicalRuntimeId::new(session_id.to_string());
+    let runtime_id = runtime_id_for_session(&session_id);
     let report = crate::traits::RuntimeControlPlane::recycle(&*adapter, &runtime_id)
         .await
         .expect("recycle should preserve queued work");
@@ -2287,7 +2318,7 @@ async fn meerkat_machine_spine_snapshot_recycle_reconciles_stale_completion_wait
         "stale waiter should be visible before recycle reconciliation"
     );
 
-    let runtime_id = LogicalRuntimeId::new(session_id.to_string());
+    let runtime_id = runtime_id_for_session(&session_id);
     let report = crate::traits::RuntimeControlPlane::recycle(&*adapter, &runtime_id)
         .await
         .expect("recycle should reconcile waiters against active input truth");
@@ -2342,7 +2373,7 @@ async fn shared_ingress_authority_is_identical_after_register_recover_and_recycl
         "fresh registration should share one ingress authority between session and driver",
     );
 
-    let runtime_id = LogicalRuntimeId::new(session_id.to_string());
+    let runtime_id = runtime_id_for_session(&session_id);
     crate::traits::RuntimeControlPlane::recover(&*adapter, &runtime_id)
         .await
         .expect("recover should succeed");
@@ -2396,7 +2427,7 @@ async fn meerkat_machine_spine_snapshot_preserves_completion_waiters_after_recov
         input_id
     );
 
-    let runtime_id = LogicalRuntimeId::new(session_id.to_string());
+    let runtime_id = runtime_id_for_session(&session_id);
     let report = crate::traits::RuntimeControlPlane::recover(&*adapter, &runtime_id)
         .await
         .expect("recover should preserve queued work");
@@ -2559,7 +2590,7 @@ async fn meerkat_machine_spine_snapshot_recover_reconciles_stale_completion_wait
         "stale waiter should be visible before recover reconciliation"
     );
 
-    let runtime_id = LogicalRuntimeId::new(session_id.to_string());
+    let runtime_id = runtime_id_for_session(&session_id);
     let report = crate::traits::RuntimeControlPlane::recover(&*adapter, &runtime_id)
         .await
         .expect("recover should reconcile waiters against active input truth");
@@ -2631,7 +2662,7 @@ async fn meerkat_machine_spine_snapshot_clears_completion_waiters_after_destroy(
         1
     );
 
-    let runtime_id = LogicalRuntimeId::new(session_id.to_string());
+    let runtime_id = runtime_id_for_session(&session_id);
     let report = crate::traits::RuntimeControlPlane::destroy(&*adapter, &runtime_id)
         .await
         .expect("destroy should terminate active completion waiters");
@@ -2676,7 +2707,7 @@ async fn persistent_destroy_synchronizes_driver_control_projection_shadow() {
 
     adapter.register_session(session_id.clone()).await;
 
-    let runtime_id = crate::identifiers::LogicalRuntimeId::new(session_id.to_string());
+    let runtime_id = runtime_id_for_session(&session_id);
     let report = crate::traits::RuntimeControlPlane::destroy(&*adapter, &runtime_id)
         .await
         .expect("persistent destroy should succeed");
@@ -2984,7 +3015,7 @@ async fn meerkat_machine_spine_snapshot_destroy_clears_steered_waiter_and_queue_
         "wait_all should track the active operation before destroy"
     );
 
-    let runtime_id = LogicalRuntimeId::new(session_id.to_string());
+    let runtime_id = runtime_id_for_session(&session_id);
     let report = crate::traits::RuntimeControlPlane::destroy(&*adapter, &runtime_id)
         .await
         .expect("destroy should clear the steered completion waiter while preserving wait_all");
@@ -3162,7 +3193,7 @@ async fn meerkat_machine_spine_snapshot_clears_completion_waiters_after_destroy_
         "destroy has not yet attempted any executor control"
     );
 
-    let runtime_id = LogicalRuntimeId::new(session_id.to_string());
+    let runtime_id = runtime_id_for_session(&session_id);
     let report = crate::traits::RuntimeControlPlane::destroy(&*adapter, &runtime_id)
         .await
         .expect("destroy should synchronously clear queued waiters even with a live loop");
@@ -4022,7 +4053,7 @@ async fn meerkat_machine_spine_snapshot_attached_steered_prompt_destroy_splits_c
     assert_eq!(apply_calls.load(Ordering::SeqCst), 1);
     assert_eq!(control_calls.load(Ordering::SeqCst), 1);
 
-    let runtime_id = LogicalRuntimeId::new(session_id.to_string());
+    let runtime_id = runtime_id_for_session(&session_id);
     crate::traits::RuntimeControlPlane::destroy(&*adapter, &runtime_id)
         .await
         .expect("destroy should split attached steered completion and wait_all lifetimes");
@@ -5612,7 +5643,7 @@ async fn meerkat_machine_spine_snapshot_clears_completion_waiters_after_retire_w
         input_id
     );
 
-    let runtime_id = LogicalRuntimeId::new(session_id.to_string());
+    let runtime_id = runtime_id_for_session(&session_id);
     let report = crate::traits::RuntimeControlPlane::retire(&*adapter, &runtime_id)
         .await
         .expect("retire should clear queued waiters when no runtime loop can drain");
@@ -5723,7 +5754,7 @@ async fn meerkat_machine_spine_snapshot_preserves_completion_waiters_after_retir
         "queued progress input should remain pending until retire wakes the attached loop"
     );
 
-    let runtime_id = LogicalRuntimeId::new(session_id.to_string());
+    let runtime_id = runtime_id_for_session(&session_id);
     let report = crate::traits::RuntimeControlPlane::retire(&*adapter, &runtime_id)
         .await
         .expect("retire should preserve queued work for the live runtime loop to drain");
@@ -5877,7 +5908,7 @@ async fn meerkat_machine_spine_snapshot_preserves_completion_waiters_after_recov
         "recover should not yet have attempted executor control"
     );
 
-    let runtime_id = LogicalRuntimeId::new(session_id.to_string());
+    let runtime_id = runtime_id_for_session(&session_id);
     let report = crate::traits::RuntimeControlPlane::recover(&*adapter, &runtime_id)
         .await
         .expect(
@@ -6058,7 +6089,7 @@ async fn meerkat_machine_spine_snapshot_preserves_completion_waiters_after_recyc
         "recycle should not yet have attempted executor control"
     );
 
-    let runtime_id = LogicalRuntimeId::new(session_id.to_string());
+    let runtime_id = runtime_id_for_session(&session_id);
     let report = crate::traits::RuntimeControlPlane::recycle(&*adapter, &runtime_id)
         .await
         .expect(
@@ -6352,7 +6383,7 @@ async fn meerkat_machine_spine_snapshot_preserves_wait_all_after_recover() {
         "wait_all should track the active operation before recover"
     );
 
-    let runtime_id = LogicalRuntimeId::new(session_id.to_string());
+    let runtime_id = runtime_id_for_session(&session_id);
     let report = crate::traits::RuntimeControlPlane::recover(&*adapter, &runtime_id)
         .await
         .expect("recover should preserve the active wait_all carrier");
@@ -6487,7 +6518,7 @@ async fn meerkat_machine_spine_snapshot_recover_splits_completion_and_wait_all_l
         "wait_all should track the active operation before recover"
     );
 
-    let runtime_id = LogicalRuntimeId::new(session_id.to_string());
+    let runtime_id = runtime_id_for_session(&session_id);
     let report = crate::traits::RuntimeControlPlane::recover(&*adapter, &runtime_id)
         .await
         .expect("recover should preserve both queued input and active wait_all");
@@ -6655,7 +6686,7 @@ async fn meerkat_machine_spine_snapshot_recover_preserves_steered_input_and_wait
         "wait_all should track the active operation before recover"
     );
 
-    let runtime_id = LogicalRuntimeId::new(session_id.to_string());
+    let runtime_id = runtime_id_for_session(&session_id);
     let report = crate::traits::RuntimeControlPlane::recover(&*adapter, &runtime_id)
         .await
         .expect("recover should preserve steered input and active wait_all");
@@ -6819,7 +6850,7 @@ async fn meerkat_machine_spine_snapshot_recycle_preserves_steered_input_and_wait
         "wait_all should track the active operation before recycle"
     );
 
-    let runtime_id = LogicalRuntimeId::new(session_id.to_string());
+    let runtime_id = runtime_id_for_session(&session_id);
     let report = crate::traits::RuntimeControlPlane::recycle(&*adapter, &runtime_id)
         .await
         .expect("recycle should preserve steered input and active wait_all");
@@ -6957,7 +6988,7 @@ async fn meerkat_machine_spine_snapshot_preserves_wait_all_after_recycle() {
         "wait_all should track the active operation before recycle"
     );
 
-    let runtime_id = LogicalRuntimeId::new(session_id.to_string());
+    let runtime_id = runtime_id_for_session(&session_id);
     let report = crate::traits::RuntimeControlPlane::recycle(&*adapter, &runtime_id)
         .await
         .expect("recycle should preserve the active wait_all carrier");
@@ -7084,7 +7115,7 @@ async fn meerkat_machine_spine_snapshot_recycle_splits_completion_and_wait_all_l
         "wait_all should track the active operation before recycle"
     );
 
-    let runtime_id = LogicalRuntimeId::new(session_id.to_string());
+    let runtime_id = runtime_id_for_session(&session_id);
     let report = crate::traits::RuntimeControlPlane::recycle(&*adapter, &runtime_id)
         .await
         .expect("recycle should preserve both queued input and active wait_all");
@@ -7296,7 +7327,7 @@ async fn meerkat_machine_spine_snapshot_preserves_wait_all_after_recover_with_ru
         "recover should not yet have attempted executor control"
     );
 
-    let runtime_id = LogicalRuntimeId::new(session_id.to_string());
+    let runtime_id = runtime_id_for_session(&session_id);
     let report = crate::traits::RuntimeControlPlane::recover(&*adapter, &runtime_id)
         .await
         .expect("recover should preserve wait_all while replaying attached-loop work");
@@ -7574,7 +7605,7 @@ async fn meerkat_machine_spine_snapshot_recover_with_runtime_loop_splits_complet
         "recover should not yet have attempted executor control"
     );
 
-    let runtime_id = LogicalRuntimeId::new(session_id.to_string());
+    let runtime_id = runtime_id_for_session(&session_id);
     let report = crate::traits::RuntimeControlPlane::recover(&*adapter, &runtime_id)
         .await
         .expect("recover should split completion and wait_all lifetimes on attached runtimes");
@@ -7845,7 +7876,7 @@ async fn meerkat_machine_spine_snapshot_preserves_wait_all_after_recycle_with_ru
         "recycle should not yet have attempted executor control"
     );
 
-    let runtime_id = LogicalRuntimeId::new(session_id.to_string());
+    let runtime_id = runtime_id_for_session(&session_id);
     let report = crate::traits::RuntimeControlPlane::recycle(&*adapter, &runtime_id)
         .await
         .expect("recycle should preserve wait_all while requeueing attached-loop work");
@@ -8094,7 +8125,7 @@ async fn meerkat_machine_spine_snapshot_recycle_with_runtime_loop_splits_complet
         "recycle should not yet have attempted executor control"
     );
 
-    let runtime_id = LogicalRuntimeId::new(session_id.to_string());
+    let runtime_id = runtime_id_for_session(&session_id);
     let report = crate::traits::RuntimeControlPlane::recycle(&*adapter, &runtime_id)
         .await
         .expect("recycle should split completion and wait_all lifetimes on attached runtimes");
@@ -9132,7 +9163,7 @@ async fn meerkat_machine_spine_snapshot_preserves_wait_all_after_destroy() {
         "wait_all should track the active operation before destroy"
     );
 
-    let runtime_id = LogicalRuntimeId::new(session_id.to_string());
+    let runtime_id = runtime_id_for_session(&session_id);
     let report = crate::traits::RuntimeControlPlane::destroy(&*adapter, &runtime_id)
         .await
         .expect("destroy should succeed for an idle runtime");
@@ -9269,7 +9300,7 @@ async fn meerkat_machine_spine_snapshot_destroy_splits_completion_and_wait_all_l
         "wait_all should track the active operation before destroy"
     );
 
-    let runtime_id = LogicalRuntimeId::new(session_id.to_string());
+    let runtime_id = runtime_id_for_session(&session_id);
     let report = crate::traits::RuntimeControlPlane::destroy(&*adapter, &runtime_id)
         .await
         .expect("destroy should split completion and wait_all lifetimes");
@@ -9463,7 +9494,7 @@ async fn meerkat_machine_spine_snapshot_preserves_wait_all_after_destroy_with_ru
         "destroy has not yet attempted any executor control"
     );
 
-    let runtime_id = LogicalRuntimeId::new(session_id.to_string());
+    let runtime_id = runtime_id_for_session(&session_id);
     let report = crate::traits::RuntimeControlPlane::destroy(&*adapter, &runtime_id)
         .await
         .expect("destroy should preserve wait_all while abandoning queued attached-loop work");
@@ -9659,7 +9690,7 @@ async fn meerkat_machine_spine_snapshot_destroy_with_runtime_loop_splits_complet
         "wait_all should track the active operation before destroy"
     );
 
-    let runtime_id = LogicalRuntimeId::new(session_id.to_string());
+    let runtime_id = runtime_id_for_session(&session_id);
     let report = crate::traits::RuntimeControlPlane::destroy(&*adapter, &runtime_id)
         .await
         .expect("destroy should split completion and wait_all lifetimes on attached runtimes");
@@ -10685,7 +10716,7 @@ async fn meerkat_machine_spine_snapshot_preserves_wait_all_after_retire() {
         "wait_all should track the active operation before retire"
     );
 
-    let runtime_id = LogicalRuntimeId::new(session_id.to_string());
+    let runtime_id = runtime_id_for_session(&session_id);
     let report = crate::traits::RuntimeControlPlane::retire(&*adapter, &runtime_id)
         .await
         .expect("retire should preserve the active wait_all carrier");
@@ -10815,7 +10846,7 @@ async fn meerkat_machine_spine_snapshot_retire_splits_completion_and_wait_all_li
         "wait_all should track the active operation before retire"
     );
 
-    let runtime_id = LogicalRuntimeId::new(session_id.to_string());
+    let runtime_id = runtime_id_for_session(&session_id);
     let report = crate::traits::RuntimeControlPlane::retire(&*adapter, &runtime_id)
         .await
         .expect("retire should split completion and wait_all lifetimes");
@@ -10973,7 +11004,7 @@ async fn meerkat_machine_spine_snapshot_retire_clears_steered_waiter_and_steer_q
         "wait_all should track the active operation before retire"
     );
 
-    let runtime_id = LogicalRuntimeId::new(session_id.to_string());
+    let runtime_id = runtime_id_for_session(&session_id);
     let report = crate::traits::RuntimeControlPlane::retire(&*adapter, &runtime_id)
         .await
         .expect("retire should terminate the steered completion waiter while preserving wait_all");
@@ -11169,7 +11200,7 @@ async fn meerkat_machine_spine_snapshot_preserves_wait_all_after_retire_with_run
         "queued attached-loop work should remain pending until retire wakes the loop"
     );
 
-    let runtime_id = LogicalRuntimeId::new(session_id.to_string());
+    let runtime_id = runtime_id_for_session(&session_id);
     let report = crate::traits::RuntimeControlPlane::retire(&*adapter, &runtime_id)
         .await
         .expect("retire should preserve wait_all while the live loop drains queued work");
@@ -11438,7 +11469,7 @@ async fn meerkat_machine_spine_snapshot_retire_with_runtime_loop_splits_completi
         "retire should not yet have attempted executor control"
     );
 
-    let runtime_id = LogicalRuntimeId::new(session_id.to_string());
+    let runtime_id = runtime_id_for_session(&session_id);
     let report = crate::traits::RuntimeControlPlane::retire(&*adapter, &runtime_id)
         .await
         .expect("retire should preserve queued work and wait_all while the live loop drains");
@@ -11656,7 +11687,7 @@ async fn register_session_rejects_destroyed_session() {
     adapter.register_session(session_id.clone()).await;
 
     // Transition to Destroyed via the control-plane destroy path.
-    let runtime_id = LogicalRuntimeId::new(session_id.to_string());
+    let runtime_id = runtime_id_for_session(&session_id);
     crate::traits::RuntimeControlPlane::destroy(&*adapter, &runtime_id)
         .await
         .expect("destroy should succeed");
@@ -11712,7 +11743,7 @@ async fn interrupt_current_run_rejects_destroyed_session() {
 
     adapter.register_session(session_id.clone()).await;
 
-    let runtime_id = LogicalRuntimeId::new(session_id.to_string());
+    let runtime_id = runtime_id_for_session(&session_id);
     crate::traits::RuntimeControlPlane::destroy(&*adapter, &runtime_id)
         .await
         .expect("destroy should succeed");
@@ -11734,7 +11765,7 @@ async fn cancel_after_boundary_rejects_destroyed_session() {
 
     adapter.register_session(session_id.clone()).await;
 
-    let runtime_id = LogicalRuntimeId::new(session_id.to_string());
+    let runtime_id = runtime_id_for_session(&session_id);
     crate::traits::RuntimeControlPlane::destroy(&*adapter, &runtime_id)
         .await
         .expect("destroy should succeed");
@@ -11756,7 +11787,7 @@ async fn stop_runtime_executor_rejects_destroyed_session() {
 
     adapter.register_session(session_id.clone()).await;
 
-    let runtime_id = LogicalRuntimeId::new(session_id.to_string());
+    let runtime_id = runtime_id_for_session(&session_id);
     crate::traits::RuntimeControlPlane::destroy(&*adapter, &runtime_id)
         .await
         .expect("destroy should succeed");
@@ -11802,7 +11833,7 @@ async fn set_peer_ingress_context_rejects_destroyed_session() {
 
     adapter.register_session(session_id.clone()).await;
 
-    let runtime_id = LogicalRuntimeId::new(session_id.to_string());
+    let runtime_id = runtime_id_for_session(&session_id);
     crate::traits::RuntimeControlPlane::destroy(adapter.as_ref(), &runtime_id)
         .await
         .expect("destroy should succeed");
@@ -11834,7 +11865,7 @@ async fn notify_drain_exited_rejects_destroyed_session() {
 
     adapter.register_session(session_id.clone()).await;
 
-    let runtime_id = LogicalRuntimeId::new(session_id.to_string());
+    let runtime_id = runtime_id_for_session(&session_id);
     crate::traits::RuntimeControlPlane::destroy(adapter.as_ref(), &runtime_id)
         .await
         .expect("destroy should succeed");
@@ -11875,7 +11906,7 @@ async fn ingest_rejects_retired_session() {
 
     adapter.register_session(session_id.clone()).await;
 
-    let runtime_id = LogicalRuntimeId::new(session_id.to_string());
+    let runtime_id = runtime_id_for_session(&session_id);
     crate::traits::RuntimeControlPlane::retire(&*adapter, &runtime_id)
         .await
         .expect("retire should succeed");
@@ -11903,7 +11934,7 @@ async fn ingest_rejects_stopped_session() {
     adapter.register_session(session_id.clone()).await;
 
     // Stop the session by driving it through retire → stop.
-    let runtime_id = LogicalRuntimeId::new(session_id.to_string());
+    let runtime_id = runtime_id_for_session(&session_id);
     adapter
         .stop_runtime_executor(
             &session_id,
@@ -11953,7 +11984,7 @@ async fn retire_rejects_initializing_session() {
         .await
         .expect("stop should succeed");
 
-    let runtime_id = LogicalRuntimeId::new(session_id.to_string());
+    let runtime_id = runtime_id_for_session(&session_id);
     let err = crate::traits::RuntimeControlPlane::retire(&*adapter, &runtime_id)
         .await
         .expect_err("retire should reject a stopped session");
@@ -11979,7 +12010,7 @@ async fn accept_input_with_completion_rejects_retired_session() {
 
     adapter.register_session(session_id.clone()).await;
 
-    let runtime_id = LogicalRuntimeId::new(session_id.to_string());
+    let runtime_id = runtime_id_for_session(&session_id);
     crate::traits::RuntimeControlPlane::retire(&*adapter, &runtime_id)
         .await
         .expect("retire should succeed");
@@ -12004,7 +12035,7 @@ async fn accept_input_with_completion_rejects_destroyed_session() {
 
     adapter.register_session(session_id.clone()).await;
 
-    let runtime_id = LogicalRuntimeId::new(session_id.to_string());
+    let runtime_id = runtime_id_for_session(&session_id);
     crate::traits::RuntimeControlPlane::destroy(&*adapter, &runtime_id)
         .await
         .expect("destroy should succeed");
@@ -12068,7 +12099,7 @@ async fn legacy_run_prepare_rejects_retired_session() {
 
     adapter.register_session(session_id.clone()).await;
 
-    let runtime_id = LogicalRuntimeId::new(session_id.to_string());
+    let runtime_id = runtime_id_for_session(&session_id);
     crate::traits::RuntimeControlPlane::retire(&*adapter, &runtime_id)
         .await
         .expect("retire should succeed");
@@ -12098,7 +12129,7 @@ async fn legacy_run_prepare_rejects_destroyed_session() {
 
     adapter.register_session(session_id.clone()).await;
 
-    let runtime_id = LogicalRuntimeId::new(session_id.to_string());
+    let runtime_id = runtime_id_for_session(&session_id);
     crate::traits::RuntimeControlPlane::destroy(&*adapter, &runtime_id)
         .await
         .expect("destroy should succeed");
@@ -12475,7 +12506,7 @@ async fn spine_invariants_hold_after_destroy() {
         .await
         .expect("prompt should be accepted");
 
-    let runtime_id = LogicalRuntimeId::new(session_id.to_string());
+    let runtime_id = runtime_id_for_session(&session_id);
     crate::traits::RuntimeControlPlane::destroy(&*adapter, &runtime_id)
         .await
         .expect("destroy should succeed");
@@ -12501,7 +12532,7 @@ async fn spine_invariants_hold_after_retire() {
         .await
         .expect("prompt should be accepted");
 
-    let runtime_id = LogicalRuntimeId::new(session_id.to_string());
+    let runtime_id = runtime_id_for_session(&session_id);
     crate::traits::RuntimeControlPlane::retire(&*adapter, &runtime_id)
         .await
         .expect("retire should succeed");
@@ -12527,7 +12558,7 @@ async fn spine_invariants_hold_after_reset() {
         .await
         .expect("prompt should be accepted");
 
-    let runtime_id = LogicalRuntimeId::new(session_id.to_string());
+    let runtime_id = runtime_id_for_session(&session_id);
     crate::traits::RuntimeControlPlane::reset(&*adapter, &runtime_id)
         .await
         .expect("reset should succeed");
@@ -12553,7 +12584,7 @@ async fn spine_invariants_hold_after_recycle() {
         .await
         .expect("prompt should be accepted");
 
-    let runtime_id = LogicalRuntimeId::new(session_id.to_string());
+    let runtime_id = runtime_id_for_session(&session_id);
     crate::traits::RuntimeControlPlane::recycle(&*adapter, &runtime_id)
         .await
         .expect("recycle should succeed");
@@ -13126,7 +13157,7 @@ async fn publish_committed_visible_set_rejects_destroyed_session() {
     let session_id = SessionId::new();
     adapter.register_session(session_id.clone()).await;
 
-    let runtime_id = LogicalRuntimeId::new(session_id.to_string());
+    let runtime_id = runtime_id_for_session(&session_id);
     crate::traits::RuntimeControlPlane::destroy(&*adapter, &runtime_id)
         .await
         .expect("destroy should succeed");
@@ -16173,7 +16204,7 @@ async fn modeled_meerkat_accept_with_completion_idle_queue_signal_matches_runtim
 
     crate::traits::RuntimeControlPlane::destroy(
         adapter.as_ref(),
-        &LogicalRuntimeId::new(session_id.to_string()),
+        &runtime_id_for_session(&session_id),
     )
     .await
     .expect("idle queue test should destroy runtime cleanly");
@@ -16225,7 +16256,7 @@ async fn meerkat_reset_clears_silent_intent_overrides() {
         .set_session_silent_intents(&fixture.session_id, runtime_parity_silent_intents())
         .await;
 
-    let runtime_id = LogicalRuntimeId::new(fixture.session_id.to_string());
+    let runtime_id = runtime_id_for_session(&fixture.session_id);
     let result = fixture
         .adapter
         .execute_meerkat_machine_command(
@@ -16262,7 +16293,7 @@ async fn meerkat_destroy_clears_silent_intent_overrides() {
         .set_session_silent_intents(&fixture.session_id, runtime_parity_silent_intents())
         .await;
 
-    let runtime_id = LogicalRuntimeId::new(fixture.session_id.to_string());
+    let runtime_id = runtime_id_for_session(&fixture.session_id);
     let result = fixture
         .adapter
         .execute_meerkat_machine_command(
@@ -16595,7 +16626,7 @@ async fn wait_for_runtime_parity_phase(
 async fn build_runtime_parity_fixture(phase: RuntimeParityPhase) -> RuntimeParityFixture {
     let adapter = Arc::new(MeerkatMachine::ephemeral());
     let session_id = SessionId::new();
-    let runtime_id = LogicalRuntimeId::new(session_id.to_string());
+    let runtime_id = runtime_id_for_session(&session_id);
 
     match phase {
         RuntimeParityPhase::Idle => {

--- a/meerkat-runtime/src/meerkat_machine_tests.rs
+++ b/meerkat-runtime/src/meerkat_machine_tests.rs
@@ -2886,7 +2886,7 @@ async fn persistent_destroy_durable_commit_observes_canonical_destroy_truth() {
     let session_id = SessionId::new();
     adapter.register_session(session_id.clone()).await;
 
-    let runtime_id = LogicalRuntimeId::new(session_id.to_string());
+    let runtime_id = LogicalRuntimeId::for_session(&session_id);
     let destroy_task = tokio::spawn({
         let adapter = Arc::clone(&adapter);
         let runtime_id = runtime_id.clone();

--- a/meerkat-runtime/src/store/memory.rs
+++ b/meerkat-runtime/src/store/memory.rs
@@ -444,7 +444,7 @@ mod tests {
 
         assert_eq!(
             store
-                .load_session_snapshot(&LogicalRuntimeId::new(session_id.to_string()))
+                .load_session_snapshot(&LogicalRuntimeId::legacy_session_uuid_alias(&session_id))
                 .await
                 .unwrap(),
             Some(snapshot)

--- a/meerkat-runtime/tests/control_plane_contract.rs
+++ b/meerkat-runtime/tests/control_plane_contract.rs
@@ -322,7 +322,7 @@ async fn control_plane_contract_stop_runtime_executor_persists_stopped_state_wit
         RuntimeState::Stopped
     );
 
-    let runtime_id = LogicalRuntimeId::new(sid.to_string());
+    let runtime_id = LogicalRuntimeId::for_session(&sid);
     assert_eq!(
         store.load_runtime_state(&runtime_id).await.unwrap(),
         Some(RuntimeState::Stopped),

--- a/meerkat-runtime/tests/driver_persistent.rs
+++ b/meerkat-runtime/tests/driver_persistent.rs
@@ -1345,6 +1345,78 @@ async fn recover_ignores_legacy_boundary_receipt_load_error_after_canonical_miss
 }
 
 #[tokio::test]
+async fn recover_treats_canonical_boundary_receipt_miss_as_authoritative() {
+    use meerkat_core::lifecycle::RunId;
+    use meerkat_core::lifecycle::run_primitive::RunApplyBoundary;
+    use meerkat_core::lifecycle::run_receipt::RunBoundaryReceipt;
+    use meerkat_runtime::input_state::InputLifecycleState;
+
+    let store = Arc::new(InMemoryRuntimeStore::new());
+    let session_id = SessionId::new();
+    let canonical_rid = LogicalRuntimeId::for_session(&session_id);
+    let legacy_rid = LogicalRuntimeId::legacy_session_uuid_alias(&session_id);
+    let input = make_prompt("canonical missing receipt must not consume from legacy receipt");
+    let input_id = input.id().clone();
+    let run_id = RunId::new();
+
+    let mut state = InputState::new_accepted(input_id.clone());
+    state.persisted_input = Some(input);
+    state.durability = Some(InputDurability::Durable);
+    state.attempt_count = 1;
+    store
+        .persist_input_state(
+            &canonical_rid,
+            &StoredInputState {
+                state,
+                seed: InputStateSeed {
+                    phase: InputLifecycleState::AppliedPendingConsumption,
+                    last_run_id: Some(run_id.clone()),
+                    last_boundary_sequence: Some(0),
+                    terminal_outcome: None,
+                    attempt_count: 1,
+                },
+            },
+        )
+        .await
+        .unwrap();
+    store
+        .atomic_apply(
+            &legacy_rid,
+            None,
+            RunBoundaryReceipt {
+                run_id,
+                boundary: RunApplyBoundary::RunStart,
+                contributing_input_ids: vec![input_id.clone()],
+                conversation_digest: None,
+                message_count: 1,
+                sequence: 0,
+            },
+            vec![],
+            None,
+        )
+        .await
+        .unwrap();
+
+    let mut driver = PersistentRuntimeDriver::new(canonical_rid, store, memory_blob_store());
+    let report = driver
+        .recover()
+        .await
+        .expect("canonical receipt miss should not be poisoned by legacy receipt presence");
+
+    assert_eq!(report.inputs_recovered, 1);
+    assert_eq!(
+        driver.inner_ref().input_phase(&input_id),
+        Some(InputLifecycleState::Queued),
+        "canonical receipt miss should requeue instead of consuming from stale legacy receipt"
+    );
+    assert_eq!(
+        driver.dequeue_next().map(|(queued_id, _)| queued_id),
+        Some(input_id),
+        "canonical missing-receipt input should remain queued for replay"
+    );
+}
+
+#[tokio::test]
 async fn recover_ignores_legacy_input_state_load_error_after_canonical_states() {
     let inner = Arc::new(InMemoryRuntimeStore::new());
     let session_id = SessionId::new();

--- a/meerkat-runtime/tests/driver_persistent.rs
+++ b/meerkat-runtime/tests/driver_persistent.rs
@@ -9,7 +9,7 @@ use meerkat_core::BlobStore;
 use meerkat_core::lifecycle::{
     InputId, RunId, run_primitive::RunApplyBoundary, run_receipt::RunBoundaryReceipt,
 };
-use meerkat_core::types::{ContentBlock, ImageData};
+use meerkat_core::types::{ContentBlock, ImageData, SessionId};
 use meerkat_runtime::input_state::{InputStateSeed, StoredInputState};
 use meerkat_runtime::store::RuntimeStoreError;
 use meerkat_runtime::{
@@ -362,6 +362,41 @@ async fn recover_from_store() {
     let (queued_id, queued_input) = dequeued.unwrap();
     assert_eq!(queued_id, input_id);
     assert_eq!(queued_input.id(), &input_id);
+}
+
+#[tokio::test]
+async fn recover_merges_canonical_and_legacy_session_alias_input_states() {
+    let store = Arc::new(InMemoryRuntimeStore::new());
+    let session_id = SessionId::new();
+    let canonical_rid = LogicalRuntimeId::for_session(&session_id);
+    let legacy_rid = LogicalRuntimeId::legacy_session_uuid_alias(&session_id);
+
+    let canonical_input = make_prompt("canonical input");
+    let canonical_input_id = canonical_input.id().clone();
+    let mut canonical_state = InputState::new_accepted(canonical_input_id.clone());
+    canonical_state.persisted_input = Some(canonical_input);
+    canonical_state.durability = Some(InputDurability::Durable);
+    store
+        .persist_input_state(&canonical_rid, &stored_accepted(canonical_state))
+        .await
+        .unwrap();
+
+    let legacy_input = make_prompt("legacy input");
+    let legacy_input_id = legacy_input.id().clone();
+    let mut legacy_state = InputState::new_accepted(legacy_input_id.clone());
+    legacy_state.persisted_input = Some(legacy_input);
+    legacy_state.durability = Some(InputDurability::Durable);
+    store
+        .persist_input_state(&legacy_rid, &stored_accepted(legacy_state))
+        .await
+        .unwrap();
+
+    let mut driver = PersistentRuntimeDriver::new(canonical_rid, store, memory_blob_store());
+    let report = driver.recover().await.unwrap();
+
+    assert_eq!(report.inputs_recovered, 2);
+    assert!(driver.input_state(&canonical_input_id).is_some());
+    assert!(driver.input_state(&legacy_input_id).is_some());
 }
 
 #[tokio::test]

--- a/meerkat-runtime/tests/driver_persistent.rs
+++ b/meerkat-runtime/tests/driver_persistent.rs
@@ -36,6 +36,7 @@ struct FailPersistInputStore {
     fail_atomic_apply: AtomicBool,
     fail_atomic_lifecycle_commit: AtomicBool,
     fail_load_input_states_for: Option<LogicalRuntimeId>,
+    fail_load_runtime_state_for: Option<LogicalRuntimeId>,
 }
 
 impl FailPersistInputStore {
@@ -46,6 +47,7 @@ impl FailPersistInputStore {
             fail_atomic_apply: AtomicBool::new(false),
             fail_atomic_lifecycle_commit: AtomicBool::new(false),
             fail_load_input_states_for: None,
+            fail_load_runtime_state_for: None,
         }
     }
 
@@ -56,6 +58,7 @@ impl FailPersistInputStore {
             fail_atomic_apply: AtomicBool::new(true),
             fail_atomic_lifecycle_commit: AtomicBool::new(false),
             fail_load_input_states_for: None,
+            fail_load_runtime_state_for: None,
         }
     }
 
@@ -66,6 +69,7 @@ impl FailPersistInputStore {
             fail_atomic_apply: AtomicBool::new(false),
             fail_atomic_lifecycle_commit: AtomicBool::new(true),
             fail_load_input_states_for: None,
+            fail_load_runtime_state_for: None,
         }
     }
 
@@ -79,6 +83,21 @@ impl FailPersistInputStore {
             fail_atomic_apply: AtomicBool::new(false),
             fail_atomic_lifecycle_commit: AtomicBool::new(false),
             fail_load_input_states_for: Some(runtime_id),
+            fail_load_runtime_state_for: None,
+        }
+    }
+
+    fn fail_load_runtime_state_for(
+        inner: Arc<InMemoryRuntimeStore>,
+        runtime_id: LogicalRuntimeId,
+    ) -> Self {
+        Self {
+            inner,
+            fail_persist_input_state: AtomicBool::new(false),
+            fail_atomic_apply: AtomicBool::new(false),
+            fail_atomic_lifecycle_commit: AtomicBool::new(false),
+            fail_load_input_states_for: None,
+            fail_load_runtime_state_for: Some(runtime_id),
         }
     }
 }
@@ -203,6 +222,11 @@ impl RuntimeStore for FailPersistInputStore {
         &self,
         runtime_id: &LogicalRuntimeId,
     ) -> Result<Option<RuntimeState>, RuntimeStoreError> {
+        if self.fail_load_runtime_state_for.as_ref() == Some(runtime_id) {
+            return Err(RuntimeStoreError::ReadFailed(
+                "synthetic legacy runtime-state load failure".into(),
+            ));
+        }
         self.inner.load_runtime_state(runtime_id).await
     }
 
@@ -1200,5 +1224,52 @@ async fn recover_ignores_legacy_input_state_load_error_after_canonical_states() 
     assert!(
         driver.input_state(&input_id).is_some(),
         "canonical input state should recover even when legacy alias load fails"
+    );
+}
+
+#[tokio::test]
+async fn recover_ignores_legacy_input_state_load_error_after_empty_canonical_read() {
+    let inner = Arc::new(InMemoryRuntimeStore::new());
+    let session_id = SessionId::new();
+    let canonical_rid = LogicalRuntimeId::for_session(&session_id);
+    let legacy_rid = LogicalRuntimeId::legacy_session_uuid_alias(&session_id);
+    let store = Arc::new(FailPersistInputStore::fail_load_input_states_for(
+        inner, legacy_rid,
+    ));
+    let mut driver = PersistentRuntimeDriver::new(canonical_rid, store, memory_blob_store());
+
+    let report = driver
+        .recover()
+        .await
+        .expect("legacy input-state read failure must not poison empty canonical recovery");
+
+    assert_eq!(report.inputs_recovered, 0);
+    assert!(
+        driver.active_input_ids().is_empty(),
+        "empty canonical recovery should stay empty when legacy alias load fails"
+    );
+}
+
+#[tokio::test]
+async fn recover_ignores_legacy_runtime_state_load_error_after_canonical_miss() {
+    let inner = Arc::new(InMemoryRuntimeStore::new());
+    let session_id = SessionId::new();
+    let canonical_rid = LogicalRuntimeId::for_session(&session_id);
+    let legacy_rid = LogicalRuntimeId::legacy_session_uuid_alias(&session_id);
+    let store = Arc::new(FailPersistInputStore::fail_load_runtime_state_for(
+        inner, legacy_rid,
+    ));
+    let mut driver = PersistentRuntimeDriver::new(canonical_rid, store, memory_blob_store());
+
+    let report = driver
+        .recover()
+        .await
+        .expect("legacy runtime-state read failure must not poison a canonical miss");
+
+    assert_eq!(report.inputs_recovered, 0);
+    assert_eq!(
+        driver.runtime_state(),
+        RuntimeState::Idle,
+        "canonical runtime-state miss should retain the fresh idle runtime state"
     );
 }

--- a/meerkat-runtime/tests/driver_persistent.rs
+++ b/meerkat-runtime/tests/driver_persistent.rs
@@ -36,6 +36,7 @@ struct FailPersistInputStore {
     fail_atomic_apply: AtomicBool,
     fail_atomic_lifecycle_commit: AtomicBool,
     fail_load_input_states_for: Option<LogicalRuntimeId>,
+    fail_load_boundary_receipt_for: Option<LogicalRuntimeId>,
     fail_load_runtime_state_for: Option<LogicalRuntimeId>,
 }
 
@@ -47,6 +48,7 @@ impl FailPersistInputStore {
             fail_atomic_apply: AtomicBool::new(false),
             fail_atomic_lifecycle_commit: AtomicBool::new(false),
             fail_load_input_states_for: None,
+            fail_load_boundary_receipt_for: None,
             fail_load_runtime_state_for: None,
         }
     }
@@ -58,6 +60,7 @@ impl FailPersistInputStore {
             fail_atomic_apply: AtomicBool::new(true),
             fail_atomic_lifecycle_commit: AtomicBool::new(false),
             fail_load_input_states_for: None,
+            fail_load_boundary_receipt_for: None,
             fail_load_runtime_state_for: None,
         }
     }
@@ -69,6 +72,7 @@ impl FailPersistInputStore {
             fail_atomic_apply: AtomicBool::new(false),
             fail_atomic_lifecycle_commit: AtomicBool::new(true),
             fail_load_input_states_for: None,
+            fail_load_boundary_receipt_for: None,
             fail_load_runtime_state_for: None,
         }
     }
@@ -83,6 +87,22 @@ impl FailPersistInputStore {
             fail_atomic_apply: AtomicBool::new(false),
             fail_atomic_lifecycle_commit: AtomicBool::new(false),
             fail_load_input_states_for: Some(runtime_id),
+            fail_load_boundary_receipt_for: None,
+            fail_load_runtime_state_for: None,
+        }
+    }
+
+    fn fail_load_boundary_receipt_for(
+        inner: Arc<InMemoryRuntimeStore>,
+        runtime_id: LogicalRuntimeId,
+    ) -> Self {
+        Self {
+            inner,
+            fail_persist_input_state: AtomicBool::new(false),
+            fail_atomic_apply: AtomicBool::new(false),
+            fail_atomic_lifecycle_commit: AtomicBool::new(false),
+            fail_load_input_states_for: None,
+            fail_load_boundary_receipt_for: Some(runtime_id),
             fail_load_runtime_state_for: None,
         }
     }
@@ -97,6 +117,7 @@ impl FailPersistInputStore {
             fail_atomic_apply: AtomicBool::new(false),
             fail_atomic_lifecycle_commit: AtomicBool::new(false),
             fail_load_input_states_for: None,
+            fail_load_boundary_receipt_for: None,
             fail_load_runtime_state_for: Some(runtime_id),
         }
     }
@@ -177,6 +198,11 @@ impl RuntimeStore for FailPersistInputStore {
         run_id: &RunId,
         sequence: u64,
     ) -> Result<Option<RunBoundaryReceipt>, RuntimeStoreError> {
+        if self.fail_load_boundary_receipt_for.as_ref() == Some(runtime_id) {
+            return Err(RuntimeStoreError::ReadFailed(
+                "synthetic legacy boundary-receipt load failure".into(),
+            ));
+        }
         self.inner
             .load_boundary_receipt(runtime_id, run_id, sequence)
             .await
@@ -1190,6 +1216,131 @@ async fn recover_duplicate_legacy_input_row_keeps_canonical_boundary_receipt() {
     assert!(
         driver.dequeue_next().is_none(),
         "canonical committed input must not be replayed because the newer duplicate row came from the legacy alias"
+    );
+}
+
+#[tokio::test]
+async fn recover_prefers_canonical_duplicate_over_newer_stale_legacy_row() {
+    use meerkat_core::lifecycle::RunId;
+    use meerkat_core::lifecycle::run_primitive::RunApplyBoundary;
+    use meerkat_core::lifecycle::run_receipt::RunBoundaryReceipt;
+    use meerkat_runtime::input_state::InputLifecycleState;
+
+    let store = Arc::new(InMemoryRuntimeStore::new());
+    let session_id = SessionId::new();
+    let canonical_rid = LogicalRuntimeId::for_session(&session_id);
+    let legacy_rid = LogicalRuntimeId::legacy_session_uuid_alias(&session_id);
+    let input = make_prompt("canonical applied row beats stale legacy accepted row");
+    let input_id = input.id().clone();
+    let run_id = RunId::new();
+
+    let mut canonical_state = InputState::new_accepted(input_id.clone());
+    canonical_state.persisted_input = Some(input.clone());
+    canonical_state.durability = Some(InputDurability::Durable);
+    canonical_state.attempt_count = 1;
+    let canonical_stored = StoredInputState {
+        state: canonical_state.clone(),
+        seed: InputStateSeed {
+            phase: InputLifecycleState::AppliedPendingConsumption,
+            last_run_id: Some(run_id.clone()),
+            last_boundary_sequence: Some(0),
+            terminal_outcome: None,
+            attempt_count: 1,
+        },
+    };
+    store
+        .atomic_apply(
+            &canonical_rid,
+            None,
+            RunBoundaryReceipt {
+                run_id: run_id.clone(),
+                boundary: RunApplyBoundary::RunStart,
+                contributing_input_ids: vec![input_id.clone()],
+                conversation_digest: None,
+                message_count: 1,
+                sequence: 0,
+            },
+            vec![canonical_stored.clone()],
+            None,
+        )
+        .await
+        .unwrap();
+
+    let mut legacy_state = canonical_state;
+    legacy_state.updated_at = canonical_stored.state.updated_at + chrono::Duration::milliseconds(1);
+    store
+        .persist_input_state(&legacy_rid, &stored_accepted(legacy_state))
+        .await
+        .unwrap();
+
+    let mut driver = PersistentRuntimeDriver::new(canonical_rid, store, memory_blob_store());
+    driver.recover().await.unwrap();
+
+    assert_eq!(
+        driver.inner_ref().input_phase(&input_id),
+        Some(InputLifecycleState::Consumed),
+        "canonical applied row must not be replaced by a newer stale legacy row"
+    );
+    assert!(
+        driver.dequeue_next().is_none(),
+        "newer stale legacy row must not replay a canonically committed input"
+    );
+}
+
+#[tokio::test]
+async fn recover_ignores_legacy_boundary_receipt_load_error_after_canonical_miss() {
+    use meerkat_core::lifecycle::RunId;
+    use meerkat_runtime::input_state::InputLifecycleState;
+
+    let inner = Arc::new(InMemoryRuntimeStore::new());
+    let session_id = SessionId::new();
+    let canonical_rid = LogicalRuntimeId::for_session(&session_id);
+    let legacy_rid = LogicalRuntimeId::legacy_session_uuid_alias(&session_id);
+    let input = make_prompt("canonical applied row with missing receipt");
+    let input_id = input.id().clone();
+    let run_id = RunId::new();
+
+    let mut state = InputState::new_accepted(input_id.clone());
+    state.persisted_input = Some(input);
+    state.durability = Some(InputDurability::Durable);
+    state.attempt_count = 1;
+    inner
+        .persist_input_state(
+            &canonical_rid,
+            &StoredInputState {
+                state,
+                seed: InputStateSeed {
+                    phase: InputLifecycleState::AppliedPendingConsumption,
+                    last_run_id: Some(run_id),
+                    last_boundary_sequence: Some(0),
+                    terminal_outcome: None,
+                    attempt_count: 1,
+                },
+            },
+        )
+        .await
+        .unwrap();
+
+    let store = Arc::new(FailPersistInputStore::fail_load_boundary_receipt_for(
+        inner, legacy_rid,
+    ));
+    let mut driver = PersistentRuntimeDriver::new(canonical_rid, store, memory_blob_store());
+
+    let report = driver
+        .recover()
+        .await
+        .expect("legacy receipt read failure must not poison canonical missing-receipt recovery");
+
+    assert_eq!(report.inputs_recovered, 1);
+    assert_eq!(
+        driver.inner_ref().input_phase(&input_id),
+        Some(InputLifecycleState::Queued),
+        "canonical missing receipt should recover by requeueing the input"
+    );
+    assert_eq!(
+        driver.dequeue_next().map(|(queued_id, _)| queued_id),
+        Some(input_id),
+        "requeued canonical input should remain available for replay"
     );
 }
 

--- a/meerkat-runtime/tests/driver_persistent.rs
+++ b/meerkat-runtime/tests/driver_persistent.rs
@@ -1074,3 +1074,75 @@ async fn recover_consumes_committed_applied_pending_inputs() {
         "committed applied inputs should not be replayed after recovery"
     );
 }
+
+#[tokio::test]
+async fn recover_duplicate_legacy_input_row_keeps_canonical_boundary_receipt() {
+    use meerkat_core::lifecycle::RunId;
+    use meerkat_core::lifecycle::run_primitive::RunApplyBoundary;
+    use meerkat_core::lifecycle::run_receipt::RunBoundaryReceipt;
+    use meerkat_runtime::input_state::InputLifecycleState;
+
+    let store = Arc::new(InMemoryRuntimeStore::new());
+    let session_id = SessionId::new();
+    let canonical_rid = LogicalRuntimeId::for_session(&session_id);
+    let legacy_rid = LogicalRuntimeId::legacy_session_uuid_alias(&session_id);
+    let input = make_prompt("already committed under canonical alias");
+    let input_id = input.id().clone();
+    let run_id = RunId::new();
+
+    let mut canonical_state = InputState::new_accepted(input_id.clone());
+    canonical_state.persisted_input = Some(input.clone());
+    canonical_state.durability = Some(InputDurability::Durable);
+    canonical_state.attempt_count = 1;
+    let canonical_stored = StoredInputState {
+        state: canonical_state.clone(),
+        seed: InputStateSeed {
+            phase: InputLifecycleState::AppliedPendingConsumption,
+            last_run_id: Some(run_id.clone()),
+            last_boundary_sequence: Some(0),
+            terminal_outcome: None,
+            attempt_count: 1,
+        },
+    };
+    store
+        .atomic_apply(
+            &canonical_rid,
+            None,
+            RunBoundaryReceipt {
+                run_id: run_id.clone(),
+                boundary: RunApplyBoundary::RunStart,
+                contributing_input_ids: vec![input_id.clone()],
+                conversation_digest: None,
+                message_count: 1,
+                sequence: 0,
+            },
+            vec![canonical_stored.clone()],
+            None,
+        )
+        .await
+        .unwrap();
+
+    let mut legacy_state = canonical_state;
+    legacy_state.updated_at = canonical_stored.state.updated_at + chrono::Duration::milliseconds(1);
+    let legacy_stored = StoredInputState {
+        state: legacy_state,
+        seed: canonical_stored.seed.clone(),
+    };
+    store
+        .persist_input_state(&legacy_rid, &legacy_stored)
+        .await
+        .unwrap();
+
+    let mut driver = PersistentRuntimeDriver::new(canonical_rid, store, memory_blob_store());
+    driver.recover().await.unwrap();
+
+    assert_eq!(
+        driver.inner_ref().input_phase(&input_id),
+        Some(InputLifecycleState::Consumed),
+        "duplicate legacy row must still consult the canonical boundary receipt"
+    );
+    assert!(
+        driver.dequeue_next().is_none(),
+        "canonical committed input must not be replayed because the newer duplicate row came from the legacy alias"
+    );
+}

--- a/meerkat-runtime/tests/driver_persistent.rs
+++ b/meerkat-runtime/tests/driver_persistent.rs
@@ -35,6 +35,7 @@ struct FailPersistInputStore {
     fail_persist_input_state: AtomicBool,
     fail_atomic_apply: AtomicBool,
     fail_atomic_lifecycle_commit: AtomicBool,
+    fail_load_input_states_for: Option<LogicalRuntimeId>,
 }
 
 impl FailPersistInputStore {
@@ -44,6 +45,7 @@ impl FailPersistInputStore {
             fail_persist_input_state: AtomicBool::new(true),
             fail_atomic_apply: AtomicBool::new(false),
             fail_atomic_lifecycle_commit: AtomicBool::new(false),
+            fail_load_input_states_for: None,
         }
     }
 
@@ -53,6 +55,7 @@ impl FailPersistInputStore {
             fail_persist_input_state: AtomicBool::new(false),
             fail_atomic_apply: AtomicBool::new(true),
             fail_atomic_lifecycle_commit: AtomicBool::new(false),
+            fail_load_input_states_for: None,
         }
     }
 
@@ -62,6 +65,20 @@ impl FailPersistInputStore {
             fail_persist_input_state: AtomicBool::new(false),
             fail_atomic_apply: AtomicBool::new(false),
             fail_atomic_lifecycle_commit: AtomicBool::new(true),
+            fail_load_input_states_for: None,
+        }
+    }
+
+    fn fail_load_input_states_for(
+        inner: Arc<InMemoryRuntimeStore>,
+        runtime_id: LogicalRuntimeId,
+    ) -> Self {
+        Self {
+            inner,
+            fail_persist_input_state: AtomicBool::new(false),
+            fail_atomic_apply: AtomicBool::new(false),
+            fail_atomic_lifecycle_commit: AtomicBool::new(false),
+            fail_load_input_states_for: Some(runtime_id),
         }
     }
 }
@@ -127,6 +144,11 @@ impl RuntimeStore for FailPersistInputStore {
         &self,
         runtime_id: &LogicalRuntimeId,
     ) -> Result<Vec<StoredInputState>, RuntimeStoreError> {
+        if self.fail_load_input_states_for.as_ref() == Some(runtime_id) {
+            return Err(RuntimeStoreError::ReadFailed(
+                "synthetic legacy input-state load failure".into(),
+            ));
+        }
         self.inner.load_input_states(runtime_id).await
     }
 
@@ -1144,5 +1166,39 @@ async fn recover_duplicate_legacy_input_row_keeps_canonical_boundary_receipt() {
     assert!(
         driver.dequeue_next().is_none(),
         "canonical committed input must not be replayed because the newer duplicate row came from the legacy alias"
+    );
+}
+
+#[tokio::test]
+async fn recover_ignores_legacy_input_state_load_error_after_canonical_states() {
+    let inner = Arc::new(InMemoryRuntimeStore::new());
+    let session_id = SessionId::new();
+    let canonical_rid = LogicalRuntimeId::for_session(&session_id);
+    let legacy_rid = LogicalRuntimeId::legacy_session_uuid_alias(&session_id);
+    let input = make_prompt("canonical survives unreadable legacy alias");
+    let input_id = input.id().clone();
+
+    let mut state = InputState::new_accepted(input_id.clone());
+    state.persisted_input = Some(input);
+    state.durability = Some(InputDurability::Durable);
+    inner
+        .persist_input_state(&canonical_rid, &stored_accepted(state))
+        .await
+        .unwrap();
+
+    let store = Arc::new(FailPersistInputStore::fail_load_input_states_for(
+        inner, legacy_rid,
+    ));
+    let mut driver = PersistentRuntimeDriver::new(canonical_rid, store, memory_blob_store());
+
+    let report = driver
+        .recover()
+        .await
+        .expect("legacy input-state read failure must not poison canonical recovery");
+
+    assert_eq!(report.inputs_recovered, 1);
+    assert!(
+        driver.input_state(&input_id).is_some(),
+        "canonical input state should recover even when legacy alias load fails"
     );
 }

--- a/meerkat-runtime/tests/meerkat_machine.rs
+++ b/meerkat-runtime/tests/meerkat_machine.rs
@@ -523,7 +523,7 @@ async fn cold_reregister_recovers_legacy_session_uuid_runtime_state_alias() {
 }
 
 #[tokio::test]
-async fn cold_reregister_prefers_terminal_legacy_runtime_state_over_canonical_idle_alias() {
+async fn cold_reregister_prefers_canonical_runtime_state_over_stale_legacy_alias() {
     let store = Arc::new(meerkat_runtime::store::InMemoryRuntimeStore::new());
     let sid = SessionId::new();
     let canonical_runtime_id = LogicalRuntimeId::for_session(&sid);
@@ -533,7 +533,7 @@ async fn cold_reregister_prefers_terminal_legacy_runtime_state_over_canonical_id
         .await
         .expect("seed canonical runtime state alias");
     store
-        .atomic_lifecycle_commit(&legacy_runtime_alias, RuntimeState::Destroyed, &[])
+        .atomic_lifecycle_commit(&legacy_runtime_alias, RuntimeState::Retired, &[])
         .await
         .expect("seed legacy runtime state alias");
 
@@ -544,8 +544,8 @@ async fn cold_reregister_prefers_terminal_legacy_runtime_state_over_canonical_id
     adapter.register_session(sid.clone()).await;
     assert_eq!(
         adapter.runtime_state(&sid).await.unwrap(),
-        RuntimeState::Destroyed,
-        "cold re-registration must not hide terminal legacy runtime state when both aliases exist",
+        RuntimeState::Idle,
+        "cold re-registration must not let stale legacy runtime state override canonical state when both aliases exist",
     );
 }
 

--- a/meerkat-runtime/tests/meerkat_machine.rs
+++ b/meerkat-runtime/tests/meerkat_machine.rs
@@ -13,7 +13,9 @@ use std::time::Duration;
 
 use chrono::Utc;
 use meerkat_core::BlobStore;
-use meerkat_core::lifecycle::{InputId, RunId};
+use meerkat_core::lifecycle::{
+    InputId, RunBoundaryReceipt, RunId, run_primitive::RunApplyBoundary,
+};
 use meerkat_core::types::SessionId;
 use meerkat_runtime::input_state::StoredInputState;
 use meerkat_runtime::{
@@ -518,6 +520,93 @@ async fn cold_reregister_recovers_legacy_session_uuid_runtime_state_alias() {
         RuntimeState::Destroyed,
         "cold re-registration must recover terminal state stored under the legacy raw session UUID alias",
     );
+}
+
+#[tokio::test]
+async fn cold_reregister_prefers_terminal_legacy_runtime_state_over_canonical_idle_alias() {
+    let store = Arc::new(meerkat_runtime::store::InMemoryRuntimeStore::new());
+    let sid = SessionId::new();
+    let canonical_runtime_id = LogicalRuntimeId::for_session(&sid);
+    let legacy_runtime_alias = LogicalRuntimeId::legacy_session_uuid_alias(&sid);
+    store
+        .atomic_lifecycle_commit(&canonical_runtime_id, RuntimeState::Idle, &[])
+        .await
+        .expect("seed canonical runtime state alias");
+    store
+        .atomic_lifecycle_commit(&legacy_runtime_alias, RuntimeState::Destroyed, &[])
+        .await
+        .expect("seed legacy runtime state alias");
+
+    let adapter = Arc::new(MeerkatMachine::persistent(
+        Arc::clone(&store) as Arc<dyn RuntimeStore>,
+        memory_blob_store(),
+    ));
+    adapter.register_session(sid.clone()).await;
+    assert_eq!(
+        adapter.runtime_state(&sid).await.unwrap(),
+        RuntimeState::Destroyed,
+        "cold re-registration must not hide terminal legacy runtime state when both aliases exist",
+    );
+}
+
+#[tokio::test]
+async fn control_plane_receipt_lookup_uses_canonical_runtime_id_with_legacy_storage_fallback() {
+    let store = Arc::new(meerkat_runtime::store::InMemoryRuntimeStore::new());
+    let sid = SessionId::new();
+    let canonical_runtime_id = LogicalRuntimeId::for_session(&sid);
+    let legacy_runtime_alias = LogicalRuntimeId::legacy_session_uuid_alias(&sid);
+    let run_id = RunId::new();
+    let receipt = RunBoundaryReceipt {
+        run_id: run_id.clone(),
+        boundary: RunApplyBoundary::RunStart,
+        contributing_input_ids: Vec::new(),
+        conversation_digest: None,
+        message_count: 0,
+        sequence: 0,
+    };
+    store
+        .atomic_apply(
+            &legacy_runtime_alias,
+            None,
+            receipt.clone(),
+            Vec::new(),
+            None,
+        )
+        .await
+        .expect("seed legacy boundary receipt alias");
+
+    let adapter = Arc::new(MeerkatMachine::persistent(
+        Arc::clone(&store) as Arc<dyn RuntimeStore>,
+        memory_blob_store(),
+    ));
+    adapter.register_session(sid.clone()).await;
+
+    let loaded = meerkat_runtime::traits::RuntimeControlPlane::load_boundary_receipt(
+        adapter.as_ref(),
+        &canonical_runtime_id,
+        &run_id,
+        0,
+    )
+    .await
+    .expect("canonical runtime id should be accepted");
+    assert_eq!(
+        loaded.map(|loaded| loaded.run_id),
+        Some(run_id.clone()),
+        "canonical control-plane lookup should read legacy receipt storage"
+    );
+
+    let raw_alias_err = meerkat_runtime::traits::RuntimeControlPlane::load_boundary_receipt(
+        adapter.as_ref(),
+        &legacy_runtime_alias,
+        &run_id,
+        0,
+    )
+    .await
+    .expect_err("raw session UUID alias must not resolve as a runtime control-plane id");
+    assert!(matches!(
+        raw_alias_err,
+        meerkat_runtime::traits::RuntimeControlPlaneError::NotFound(_)
+    ));
 }
 
 #[tokio::test]

--- a/meerkat-runtime/tests/meerkat_machine.rs
+++ b/meerkat-runtime/tests/meerkat_machine.rs
@@ -390,7 +390,7 @@ async fn lifecycle_commit_failure_restores_staged_session_dsl_state() {
     let adapter = Arc::new(MeerkatMachine::persistent(store, memory_blob_store()));
     let sid = SessionId::new();
     adapter.register_session(sid.clone()).await;
-    let runtime_id = LogicalRuntimeId::new(sid.to_string());
+    let runtime_id = LogicalRuntimeId::for_session(&sid);
 
     let input = make_prompt("retire rollback");
     let input_id = input.id().clone();
@@ -480,7 +480,7 @@ async fn cold_reregister_preserves_destroyed_runtime_state() {
         memory_blob_store(),
     ));
     adapter.register_session(sid.clone()).await;
-    let runtime_id = LogicalRuntimeId::new(sid.to_string());
+    let runtime_id = LogicalRuntimeId::for_session(&sid);
     meerkat_runtime::traits::RuntimeControlPlane::destroy(&*adapter, &runtime_id)
         .await
         .expect("destroy should succeed before adapter restart");
@@ -495,6 +495,28 @@ async fn cold_reregister_preserves_destroyed_runtime_state() {
         restarted.runtime_state(&sid).await.unwrap(),
         RuntimeState::Destroyed,
         "cold re-registration must preserve the stored destroyed phase",
+    );
+}
+
+#[tokio::test]
+async fn cold_reregister_recovers_legacy_session_uuid_runtime_state_alias() {
+    let store = Arc::new(meerkat_runtime::store::InMemoryRuntimeStore::new());
+    let sid = SessionId::new();
+    let legacy_runtime_alias = LogicalRuntimeId::legacy_session_uuid_alias(&sid);
+    store
+        .atomic_lifecycle_commit(&legacy_runtime_alias, RuntimeState::Destroyed, &[])
+        .await
+        .expect("seed legacy runtime state alias");
+
+    let adapter = Arc::new(MeerkatMachine::persistent(
+        Arc::clone(&store) as Arc<dyn RuntimeStore>,
+        memory_blob_store(),
+    ));
+    adapter.register_session(sid.clone()).await;
+    assert_eq!(
+        adapter.runtime_state(&sid).await.unwrap(),
+        RuntimeState::Destroyed,
+        "cold re-registration must recover terminal state stored under the legacy raw session UUID alias",
     );
 }
 
@@ -530,7 +552,7 @@ async fn recycle_preserves_ephemeral_queued_work() {
     adapter.accept_input(&sid, first).await.unwrap();
     adapter.accept_input(&sid, second).await.unwrap();
 
-    let runtime_id = LogicalRuntimeId::new(sid.to_string());
+    let runtime_id = LogicalRuntimeId::for_session(&sid);
     let report = meerkat_runtime::RuntimeControlPlane::recycle(&*adapter, &runtime_id)
         .await
         .unwrap();
@@ -573,7 +595,7 @@ async fn recycle_preserves_persistent_queued_work() {
     adapter.accept_input(&sid, first).await.unwrap();
     adapter.accept_input(&sid, second).await.unwrap();
 
-    let runtime_id = LogicalRuntimeId::new(sid.to_string());
+    let runtime_id = LogicalRuntimeId::for_session(&sid);
     let report = meerkat_runtime::RuntimeControlPlane::recycle(&*adapter, &runtime_id)
         .await
         .unwrap();
@@ -649,7 +671,7 @@ async fn recycle_keeps_waiters_for_preserved_pending_input() {
     assert!(outcome.is_accepted());
     let handle = handle.expect("accepted input should produce a completion handle");
 
-    let runtime_id = LogicalRuntimeId::new(sid.to_string());
+    let runtime_id = LogicalRuntimeId::for_session(&sid);
     let report = meerkat_runtime::RuntimeControlPlane::recycle(&*adapter, &runtime_id)
         .await
         .unwrap();
@@ -759,7 +781,7 @@ async fn recycle_attached_runtime_wakes_preserved_queued_work() {
     assert!(outcome.is_accepted());
     let handle = handle.expect("queued progress input should expose a completion handle");
 
-    let runtime_id = LogicalRuntimeId::new(sid.to_string());
+    let runtime_id = LogicalRuntimeId::for_session(&sid);
     let report = meerkat_runtime::RuntimeControlPlane::recycle(&*adapter, &runtime_id)
         .await
         .unwrap();

--- a/meerkat-runtime/tests/meerkat_machine.rs
+++ b/meerkat-runtime/tests/meerkat_machine.rs
@@ -430,7 +430,7 @@ async fn destroy_lifecycle_commit_failure_restores_staged_session_dsl_state() {
     ));
     let sid = SessionId::new();
     adapter.register_session(sid.clone()).await;
-    let runtime_id = LogicalRuntimeId::new(sid.to_string());
+    let runtime_id = LogicalRuntimeId::for_session(&sid);
 
     let input = make_prompt("destroy rollback");
     let input_id = input.id().clone();

--- a/meerkat-runtime/tests/ops_lifecycle_persistence.rs
+++ b/meerkat-runtime/tests/ops_lifecycle_persistence.rs
@@ -16,7 +16,8 @@ use meerkat_core::runtime_epoch::{EpochCursorState, RuntimeEpochId};
 use meerkat_core::types::SessionId;
 use meerkat_runtime::RuntimeStore; // needed for trait method calls
 use meerkat_runtime::{
-    OpsLifecyclePersistenceRequest, PersistedOpsSnapshot, RuntimeOpsLifecycleRegistry,
+    LogicalRuntimeId, OpsLifecyclePersistenceRequest, PersistedOpsSnapshot,
+    RuntimeOpsLifecycleRegistry,
 };
 
 fn bg_spec(name: &str) -> OperationSpec {
@@ -709,6 +710,58 @@ async fn cold_persistent_adapter_recovers_persisted_epoch() {
         1,
         "register_session must recover persisted completion entries"
     );
+    assert_eq!(batch.entries[0].operation_id, op_id);
+}
+
+#[tokio::test]
+async fn cold_persistent_adapter_prefers_more_advanced_legacy_ops_alias_snapshot() {
+    let store = Arc::new(meerkat_runtime::InMemoryRuntimeStore::new());
+    let session_id = SessionId::new();
+    let canonical_epoch = RuntimeEpochId::new();
+    let canonical_registry = meerkat_runtime::RuntimeOpsLifecycleRegistry::new();
+    let canonical_snapshot =
+        canonical_registry.capture_persistence_snapshot(canonical_epoch, &EpochCursorState::new());
+    store
+        .persist_ops_lifecycle(
+            &LogicalRuntimeId::for_session(&session_id),
+            &canonical_snapshot,
+        )
+        .await
+        .unwrap();
+
+    let legacy_registry = meerkat_runtime::RuntimeOpsLifecycleRegistry::new();
+    let legacy_cursor_state = Arc::new(EpochCursorState::new());
+    let legacy_epoch = RuntimeEpochId::new();
+    let spec = bg_spec("legacy-advanced-recovery");
+    let op_id = spec.id.clone();
+    legacy_registry.register_operation(spec).unwrap();
+    legacy_registry.provisioning_succeeded(&op_id).unwrap();
+    legacy_registry
+        .complete_operation(&op_id, op_result(&op_id))
+        .unwrap();
+    let legacy_snapshot =
+        legacy_registry.capture_persistence_snapshot(legacy_epoch.clone(), &legacy_cursor_state);
+    store
+        .persist_ops_lifecycle(
+            &LogicalRuntimeId::legacy_session_uuid_alias(&session_id),
+            &legacy_snapshot,
+        )
+        .await
+        .unwrap();
+
+    let adapter = meerkat_runtime::MeerkatMachine::persistent_without_blobs(
+        Arc::clone(&store) as Arc<dyn RuntimeStore>
+    );
+    adapter.register_session(session_id.clone()).await;
+
+    let bindings = adapter.prepare_bindings(session_id.clone()).await.unwrap();
+    assert_eq!(
+        bindings.epoch_id, legacy_epoch,
+        "register_session must not hide a more advanced legacy ops lifecycle alias snapshot"
+    );
+    let feed = bindings.ops_lifecycle.completion_feed().unwrap();
+    let batch = feed.list_since(0);
+    assert_eq!(batch.entries.len(), 1);
     assert_eq!(batch.entries[0].operation_id, op_id);
 }
 

--- a/meerkat-runtime/tests/ops_lifecycle_persistence.rs
+++ b/meerkat-runtime/tests/ops_lifecycle_persistence.rs
@@ -735,7 +735,7 @@ async fn cold_persistent_adapter_recovers_persisted_epoch() {
 }
 
 #[tokio::test]
-async fn cold_persistent_adapter_prefers_more_advanced_legacy_ops_alias_snapshot() {
+async fn cold_persistent_adapter_keeps_canonical_ops_snapshot_over_more_advanced_legacy_alias() {
     let store = Arc::new(meerkat_runtime::InMemoryRuntimeStore::new());
     let session_id = SessionId::new();
     let canonical_epoch = RuntimeEpochId::new();
@@ -777,13 +777,15 @@ async fn cold_persistent_adapter_prefers_more_advanced_legacy_ops_alias_snapshot
 
     let bindings = adapter.prepare_bindings(session_id.clone()).await.unwrap();
     assert_eq!(
-        bindings.epoch_id, legacy_epoch,
-        "register_session must not hide a more advanced legacy ops lifecycle alias snapshot"
+        bindings.epoch_id, canonical_snapshot.epoch_id,
+        "register_session must keep canonical ops lifecycle authority over legacy alias snapshots"
     );
     let feed = bindings.ops_lifecycle.completion_feed().unwrap();
     let batch = feed.list_since(0);
-    assert_eq!(batch.entries.len(), 1);
-    assert_eq!(batch.entries[0].operation_id, op_id);
+    assert!(
+        batch.entries.is_empty(),
+        "legacy completion entries must not be resurrected over canonical ops authority"
+    );
 }
 
 #[tokio::test]

--- a/meerkat-runtime/tests/ops_lifecycle_persistence.rs
+++ b/meerkat-runtime/tests/ops_lifecycle_persistence.rs
@@ -669,7 +669,7 @@ async fn cold_persistent_adapter_recovers_persisted_epoch() {
 
     let session_id = SessionId::new();
 
-    // Phase 1: Persist a snapshot manually.
+    // Phase 1: Persist a snapshot manually under the legacy raw UUID alias.
     let registry = meerkat_runtime::RuntimeOpsLifecycleRegistry::new();
     let cursor_state = Arc::new(EpochCursorState::new());
     let epoch_id = RuntimeEpochId::new();
@@ -683,7 +683,8 @@ async fn cold_persistent_adapter_recovers_persisted_epoch() {
         .unwrap();
 
     let snapshot = registry.capture_persistence_snapshot(epoch_id.clone(), &cursor_state);
-    let runtime_id = meerkat_runtime::identifiers::LogicalRuntimeId::new(session_id.to_string());
+    let runtime_id =
+        meerkat_runtime::identifiers::LogicalRuntimeId::legacy_session_uuid_alias(&session_id);
     store
         .persist_ops_lifecycle(&runtime_id, &snapshot)
         .await
@@ -718,7 +719,7 @@ async fn cold_ensure_session_with_executor_recovers_persisted_epoch() {
 
     let session_id = SessionId::new();
 
-    // Persist a snapshot
+    // Persist a snapshot under the legacy raw UUID alias.
     let registry = meerkat_runtime::RuntimeOpsLifecycleRegistry::new();
     let cursor_state = Arc::new(EpochCursorState::new());
     let epoch_id = RuntimeEpochId::new();
@@ -732,7 +733,8 @@ async fn cold_ensure_session_with_executor_recovers_persisted_epoch() {
         .unwrap();
 
     let snapshot = registry.capture_persistence_snapshot(epoch_id.clone(), &cursor_state);
-    let runtime_id = meerkat_runtime::identifiers::LogicalRuntimeId::new(session_id.to_string());
+    let runtime_id =
+        meerkat_runtime::identifiers::LogicalRuntimeId::legacy_session_uuid_alias(&session_id);
     store
         .persist_ops_lifecycle(&runtime_id, &snapshot)
         .await

--- a/meerkat-runtime/tests/ops_lifecycle_persistence.rs
+++ b/meerkat-runtime/tests/ops_lifecycle_persistence.rs
@@ -392,6 +392,8 @@ fn terminal_persistence_channel_closed_fails_terminal_transition() {
 struct FailingOpsLifecycleStore {
     inner: meerkat_runtime::InMemoryRuntimeStore,
     persist_calls: AtomicUsize,
+    fail_persist_ops: bool,
+    fail_ops_load_for: Option<LogicalRuntimeId>,
 }
 
 impl FailingOpsLifecycleStore {
@@ -399,6 +401,17 @@ impl FailingOpsLifecycleStore {
         Self {
             inner: meerkat_runtime::InMemoryRuntimeStore::new(),
             persist_calls: AtomicUsize::new(0),
+            fail_persist_ops: true,
+            fail_ops_load_for: None,
+        }
+    }
+
+    fn fail_ops_load_for(runtime_id: LogicalRuntimeId) -> Self {
+        Self {
+            inner: meerkat_runtime::InMemoryRuntimeStore::new(),
+            persist_calls: AtomicUsize::new(0),
+            fail_persist_ops: false,
+            fail_ops_load_for: Some(runtime_id),
         }
     }
 
@@ -538,19 +551,27 @@ impl RuntimeStore for FailingOpsLifecycleStore {
 
     async fn persist_ops_lifecycle(
         &self,
-        _runtime_id: &meerkat_runtime::identifiers::LogicalRuntimeId,
-        _snapshot: &PersistedOpsSnapshot,
+        runtime_id: &meerkat_runtime::identifiers::LogicalRuntimeId,
+        snapshot: &PersistedOpsSnapshot,
     ) -> Result<(), meerkat_runtime::RuntimeStoreError> {
-        self.persist_calls.fetch_add(1, Ordering::SeqCst);
-        Err(meerkat_runtime::RuntimeStoreError::WriteFailed(
-            "synthetic ops lifecycle persist failure".to_string(),
-        ))
+        if self.fail_persist_ops {
+            self.persist_calls.fetch_add(1, Ordering::SeqCst);
+            return Err(meerkat_runtime::RuntimeStoreError::WriteFailed(
+                "synthetic ops lifecycle persist failure".to_string(),
+            ));
+        }
+        self.inner.persist_ops_lifecycle(runtime_id, snapshot).await
     }
 
     async fn load_ops_lifecycle(
         &self,
         runtime_id: &meerkat_runtime::identifiers::LogicalRuntimeId,
     ) -> Result<Option<PersistedOpsSnapshot>, meerkat_runtime::RuntimeStoreError> {
+        if self.fail_ops_load_for.as_ref() == Some(runtime_id) {
+            return Err(meerkat_runtime::RuntimeStoreError::ReadFailed(
+                "synthetic legacy ops lifecycle load failure".to_string(),
+            ));
+        }
         self.inner.load_ops_lifecycle(runtime_id).await
     }
 }
@@ -758,6 +779,48 @@ async fn cold_persistent_adapter_prefers_more_advanced_legacy_ops_alias_snapshot
     assert_eq!(
         bindings.epoch_id, legacy_epoch,
         "register_session must not hide a more advanced legacy ops lifecycle alias snapshot"
+    );
+    let feed = bindings.ops_lifecycle.completion_feed().unwrap();
+    let batch = feed.list_since(0);
+    assert_eq!(batch.entries.len(), 1);
+    assert_eq!(batch.entries[0].operation_id, op_id);
+}
+
+#[tokio::test]
+async fn cold_persistent_adapter_keeps_canonical_ops_snapshot_when_legacy_alias_load_fails() {
+    let session_id = SessionId::new();
+    let canonical_runtime_id = LogicalRuntimeId::for_session(&session_id);
+    let legacy_runtime_id = LogicalRuntimeId::legacy_session_uuid_alias(&session_id);
+    let store = Arc::new(FailingOpsLifecycleStore::fail_ops_load_for(
+        legacy_runtime_id,
+    ));
+
+    let registry = meerkat_runtime::RuntimeOpsLifecycleRegistry::new();
+    let cursor_state = Arc::new(EpochCursorState::new());
+    let canonical_epoch = RuntimeEpochId::new();
+    let spec = bg_spec("canonical-recovery-survives-legacy-error");
+    let op_id = spec.id.clone();
+    registry.register_operation(spec).unwrap();
+    registry.provisioning_succeeded(&op_id).unwrap();
+    registry
+        .complete_operation(&op_id, op_result(&op_id))
+        .unwrap();
+    let snapshot = registry.capture_persistence_snapshot(canonical_epoch.clone(), &cursor_state);
+    store
+        .inner
+        .persist_ops_lifecycle(&canonical_runtime_id, &snapshot)
+        .await
+        .unwrap();
+
+    let adapter = meerkat_runtime::MeerkatMachine::persistent_without_blobs(
+        Arc::clone(&store) as Arc<dyn RuntimeStore>
+    );
+    adapter.register_session(session_id.clone()).await;
+
+    let bindings = adapter.prepare_bindings(session_id.clone()).await.unwrap();
+    assert_eq!(
+        bindings.epoch_id, canonical_epoch,
+        "legacy ops alias load failure must not rotate away from a valid canonical snapshot"
     );
     let feed = bindings.ops_lifecycle.completion_feed().unwrap();
     let batch = feed.list_since(0);

--- a/meerkat-session/src/persistent.rs
+++ b/meerkat-session/src/persistent.rs
@@ -448,7 +448,7 @@ impl<B: SessionAgentBuilder + 'static> PersistentSessionService<B> {
         let Some(runtime_store) = self.runtime_store.as_ref() else {
             return Ok(Vec::new());
         };
-        let mut stored_states: Vec<StoredInputState> = Vec::new();
+        let mut stored_states: Vec<(usize, StoredInputState)> = Vec::new();
         let mut primary_alias_loaded = false;
         for (candidate_index, runtime_id) in Self::runtime_id_candidates_for_session(id)
             .into_iter()
@@ -461,7 +461,15 @@ impl<B: SessionAgentBuilder + 'static> PersistentSessionService<B> {
                     }
                     states
                 }
-                Err(err) if candidate_index > 0 && primary_alias_loaded => {
+                Err(err)
+                    if candidate_index > 0
+                        && primary_alias_loaded
+                        && contributing_input_ids.iter().all(|input_id| {
+                            stored_states
+                                .iter()
+                                .any(|(_, state)| &state.state.input_id == input_id)
+                        }) =>
+                {
                     tracing::warn!(
                         session_id = %id,
                         runtime_id = %runtime_id,
@@ -480,15 +488,23 @@ impl<B: SessionAgentBuilder + 'static> PersistentSessionService<B> {
             };
             for state in candidate_states {
                 let input_id = state.state.input_id.clone();
-                if let Some(existing) = stored_states
+                if let Some((existing_index, existing_state)) = stored_states
                     .iter_mut()
-                    .find(|existing| existing.state.input_id == input_id)
+                    .find(|(_, existing)| existing.state.input_id == input_id)
                 {
-                    if state.state.updated_at() > existing.state.updated_at() {
-                        *existing = state;
+                    let candidate_updated_at = state.state.updated_at();
+                    let existing_updated_at = existing_state.state.updated_at();
+                    let should_replace = if candidate_index == *existing_index {
+                        candidate_updated_at > existing_updated_at
+                    } else {
+                        candidate_index < *existing_index
+                    };
+                    if should_replace {
+                        *existing_index = candidate_index;
+                        *existing_state = state;
                     }
                 } else {
-                    stored_states.push(state);
+                    stored_states.push((candidate_index, state));
                 }
             }
         }
@@ -498,7 +514,8 @@ impl<B: SessionAgentBuilder + 'static> PersistentSessionService<B> {
             .filter_map(|input_id| {
                 let mut bundle = stored_states
                     .iter()
-                    .find(|candidate| &candidate.state.input_id == input_id)?
+                    .find(|(_, candidate)| &candidate.state.input_id == input_id)?
+                    .1
                     .clone();
                 // Stamp receipt metadata and mirror the Consumed terminal on
                 // the persisted snapshot. The authoritative DSL transition
@@ -5224,6 +5241,98 @@ mod tests {
             updates.is_empty(),
             "no-contributor boundary should not need legacy input-state data"
         );
+    }
+
+    #[tokio::test]
+    async fn test_runtime_input_updates_require_legacy_alias_when_contributor_missing_from_canonical()
+     {
+        let store: Arc<dyn SessionStore> = Arc::new(MemoryStore::new());
+        let runtime_store = Arc::new(GatedSnapshotRuntimeStore::new());
+        let service = PersistentSessionService::new(
+            DummyBuilder,
+            4,
+            Arc::clone(&store),
+            Some(runtime_store.clone()),
+            memory_blob_store(),
+        );
+
+        let id = SessionId::new();
+        let input_id = InputId::new();
+        runtime_store
+            .fail_input_state_load_for(LogicalRuntimeId::legacy_session_uuid_alias(&id))
+            .await;
+
+        let err = service
+            .runtime_input_updates(&id, &RunId::new(), 0, std::slice::from_ref(&input_id))
+            .await
+            .expect_err(
+                "missing canonical contributor must not be silently dropped when legacy is unreadable",
+            );
+
+        assert!(
+            err.to_string()
+                .contains("synthetic legacy input-state load failure"),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_runtime_input_updates_prefer_canonical_duplicate_over_newer_stale_legacy_row() {
+        let store: Arc<dyn SessionStore> = Arc::new(MemoryStore::new());
+        let runtime_store = Arc::new(GatedSnapshotRuntimeStore::new());
+        let service = PersistentSessionService::new(
+            DummyBuilder,
+            4,
+            Arc::clone(&store),
+            Some(runtime_store.clone()),
+            memory_blob_store(),
+        );
+
+        let id = SessionId::new();
+        let input_id = InputId::new();
+        let canonical_runtime_id =
+            PersistentSessionService::<DummyBuilder>::runtime_id_for_session(&id);
+        let legacy_runtime_id = LogicalRuntimeId::legacy_session_uuid_alias(&id);
+
+        let mut canonical_state = meerkat_runtime::InputState::new_accepted(input_id.clone());
+        canonical_state.durability = Some(meerkat_runtime::InputDurability::Durable);
+        canonical_state.recovery_count = 7;
+        let canonical_stored = StoredInputState {
+            state: canonical_state.clone(),
+            seed: meerkat_runtime::input_state::InputStateSeed::new_accepted(),
+        };
+        runtime_store
+            .persist_input_state(&canonical_runtime_id, &canonical_stored)
+            .await
+            .expect("test should seed canonical input state");
+
+        tokio::time::sleep(std::time::Duration::from_millis(1)).await;
+        let mut legacy_state = meerkat_runtime::InputState::new_accepted(input_id.clone());
+        legacy_state.durability = Some(meerkat_runtime::InputDurability::Durable);
+        legacy_state.recovery_count = 99;
+        runtime_store
+            .persist_input_state(
+                &legacy_runtime_id,
+                &StoredInputState {
+                    state: legacy_state,
+                    seed: meerkat_runtime::input_state::InputStateSeed::new_accepted(),
+                },
+            )
+            .await
+            .expect("test should seed newer stale legacy input state");
+
+        let updates = service
+            .runtime_input_updates(&id, &RunId::new(), 3, std::slice::from_ref(&input_id))
+            .await
+            .expect("runtime input updates should merge duplicate aliases");
+
+        assert_eq!(updates.len(), 1);
+        assert_eq!(
+            updates[0].state.recovery_count, 7,
+            "canonical contributor state must win over newer stale legacy duplicate"
+        );
+        assert_eq!(updates[0].seed.phase, InputLifecycleState::Consumed);
+        assert_eq!(updates[0].seed.last_boundary_sequence, Some(3));
     }
 
     #[tokio::test]

--- a/meerkat-session/src/persistent.rs
+++ b/meerkat-session/src/persistent.rs
@@ -421,7 +421,21 @@ impl<B: SessionAgentBuilder + 'static> PersistentSessionService<B> {
     }
 
     fn runtime_id_for_session(id: &SessionId) -> LogicalRuntimeId {
-        LogicalRuntimeId::new(id.to_string())
+        LogicalRuntimeId::for_session(id)
+    }
+
+    fn legacy_runtime_id_for_session(id: &SessionId) -> LogicalRuntimeId {
+        LogicalRuntimeId::legacy_session_uuid_alias(id)
+    }
+
+    fn runtime_id_candidates_for_session(id: &SessionId) -> Vec<LogicalRuntimeId> {
+        let canonical = Self::runtime_id_for_session(id);
+        let legacy = Self::legacy_runtime_id_for_session(id);
+        if canonical == legacy {
+            vec![canonical]
+        } else {
+            vec![canonical, legacy]
+        }
     }
 
     async fn runtime_input_updates(
@@ -434,15 +448,20 @@ impl<B: SessionAgentBuilder + 'static> PersistentSessionService<B> {
         let Some(runtime_store) = self.runtime_store.as_ref() else {
             return Ok(Vec::new());
         };
-        let runtime_id = Self::runtime_id_for_session(id);
-        let stored_states = runtime_store
-            .load_input_states(&runtime_id)
-            .await
-            .map_err(|err| {
-                SessionError::Agent(meerkat_core::error::AgentError::InternalError(format!(
-                    "failed to load runtime input states: {err}"
-                )))
-            })?;
+        let mut stored_states = Vec::new();
+        for runtime_id in Self::runtime_id_candidates_for_session(id) {
+            stored_states = runtime_store
+                .load_input_states(&runtime_id)
+                .await
+                .map_err(|err| {
+                    SessionError::Agent(meerkat_core::error::AgentError::InternalError(format!(
+                        "failed to load runtime input states: {err}"
+                    )))
+                })?;
+            if !stored_states.is_empty() {
+                break;
+            }
+        }
 
         Ok(contributing_input_ids
             .iter()
@@ -577,8 +596,7 @@ impl<B: SessionAgentBuilder + 'static> PersistentSessionService<B> {
         id: &SessionId,
     ) -> Result<Option<Session>, SessionError> {
         if let Some(runtime_store) = self.runtime_store.as_ref() {
-            let runtime_id = Self::runtime_id_for_session(id);
-            Self::load_runtime_session_snapshot(runtime_store, &runtime_id).await
+            Self::load_runtime_session_snapshot_for_session(runtime_store, id).await
         } else {
             self.store
                 .load(id)
@@ -611,6 +629,20 @@ impl<B: SessionAgentBuilder + 'static> PersistentSessionService<B> {
             .transpose()
     }
 
+    async fn load_runtime_session_snapshot_for_session(
+        runtime_store: &Arc<dyn RuntimeStore>,
+        id: &SessionId,
+    ) -> Result<Option<Session>, SessionError> {
+        for runtime_id in Self::runtime_id_candidates_for_session(id) {
+            if let Some(session) =
+                Self::load_runtime_session_snapshot(runtime_store, &runtime_id).await?
+            {
+                return Ok(Some(session));
+            }
+        }
+        Ok(None)
+    }
+
     fn store_only_control_mutation_error(id: &SessionId, operation: &str) -> SessionError {
         SessionError::Unsupported(format!(
             "{operation} cannot mutate store-only compatibility projection for session {id}; runtime-backed control mutations require an authoritative runtime snapshot"
@@ -626,25 +658,8 @@ impl<B: SessionAgentBuilder + 'static> PersistentSessionService<B> {
             return Ok(None);
         };
 
-        let runtime_id = Self::runtime_id_for_session(id);
-        if let Some(runtime) = runtime_store
-            .load_session_snapshot(&runtime_id)
-            .await
-            .map_err(|err| {
-                SessionError::Agent(meerkat_core::error::AgentError::InternalError(format!(
-                    "failed to load runtime session snapshot: {err}"
-                )))
-            })?
-            .map(|bytes| {
-                meerkat_core::session_migrations::deserialize_session_migrating(&bytes).map_err(
-                    |err| {
-                        SessionError::Agent(meerkat_core::error::AgentError::InternalError(
-                            format!("failed to deserialize runtime session snapshot: {err}"),
-                        ))
-                    },
-                )
-            })
-            .transpose()?
+        if let Some(runtime) =
+            Self::load_runtime_session_snapshot_for_session(runtime_store, id).await?
         {
             return Ok(Some(runtime));
         }
@@ -709,9 +724,8 @@ impl<B: SessionAgentBuilder + 'static> PersistentSessionService<B> {
         };
 
         let stored = if let Some(runtime_store) = self.runtime_store.as_ref() {
-            let runtime_id = Self::runtime_id_for_session(id);
             let Some(runtime) =
-                Self::load_runtime_session_snapshot(runtime_store, &runtime_id).await?
+                Self::load_runtime_session_snapshot_for_session(runtime_store, id).await?
             else {
                 return Ok(false);
             };
@@ -4882,6 +4896,59 @@ mod tests {
             raw_store_row.messages().len(),
             raw_projection.messages().len(),
             "compatibility projection should remain inert in the raw store"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_runtime_backed_authoritative_load_accepts_legacy_session_uuid_runtime_alias() {
+        let store: Arc<dyn SessionStore> = Arc::new(MemoryStore::new());
+        let runtime_store = Arc::new(InMemoryRuntimeStore::new());
+        let service = PersistentSessionService::new(
+            DummyBuilder,
+            4,
+            Arc::clone(&store),
+            Some(runtime_store.clone()),
+            memory_blob_store(),
+        );
+
+        let mut legacy_runtime_session = Session::new();
+        legacy_runtime_session.push(Message::User(UserMessage::text(
+            "legacy runtime alias row".to_string(),
+        )));
+        let id = legacy_runtime_session.id().clone();
+        let snapshot =
+            serde_json::to_vec(&legacy_runtime_session).expect("legacy session should serialize");
+        let legacy_runtime_alias = LogicalRuntimeId::legacy_session_uuid_alias(&id);
+        let canonical_runtime_id =
+            PersistentSessionService::<DummyBuilder>::runtime_id_for_session(&id);
+        assert_ne!(
+            canonical_runtime_id, legacy_runtime_alias,
+            "canonical runtime id must be distinct from the legacy raw session UUID alias"
+        );
+
+        runtime_store
+            .commit_session_boundary(
+                &legacy_runtime_alias,
+                meerkat_runtime::store::SessionDelta {
+                    session_snapshot: snapshot,
+                },
+                RunId::new(),
+                RunApplyBoundary::Immediate,
+                vec![],
+                vec![],
+            )
+            .await
+            .expect("test should seed a legacy runtime alias snapshot");
+
+        let authoritative = service
+            .load_authoritative_session(&id)
+            .await
+            .expect("authoritative load should succeed")
+            .expect("legacy runtime alias should remain readable");
+        assert_eq!(
+            authoritative.messages().len(),
+            legacy_runtime_session.messages().len(),
+            "runtime-backed resume must preserve legacy raw alias snapshots"
         );
     }
 

--- a/meerkat-session/src/persistent.rs
+++ b/meerkat-session/src/persistent.rs
@@ -448,18 +448,29 @@ impl<B: SessionAgentBuilder + 'static> PersistentSessionService<B> {
         let Some(runtime_store) = self.runtime_store.as_ref() else {
             return Ok(Vec::new());
         };
-        let mut stored_states = Vec::new();
+        let mut stored_states: Vec<StoredInputState> = Vec::new();
         for runtime_id in Self::runtime_id_candidates_for_session(id) {
-            stored_states = runtime_store
-                .load_input_states(&runtime_id)
-                .await
-                .map_err(|err| {
-                    SessionError::Agent(meerkat_core::error::AgentError::InternalError(format!(
-                        "failed to load runtime input states: {err}"
-                    )))
-                })?;
-            if !stored_states.is_empty() {
-                break;
+            let candidate_states =
+                runtime_store
+                    .load_input_states(&runtime_id)
+                    .await
+                    .map_err(|err| {
+                        SessionError::Agent(meerkat_core::error::AgentError::InternalError(
+                            format!("failed to load runtime input states: {err}"),
+                        ))
+                    })?;
+            for state in candidate_states {
+                let input_id = state.state.input_id.clone();
+                if let Some(existing) = stored_states
+                    .iter_mut()
+                    .find(|existing| existing.state.input_id == input_id)
+                {
+                    if state.state.updated_at() > existing.state.updated_at() {
+                        *existing = state;
+                    }
+                } else {
+                    stored_states.push(state);
+                }
             }
         }
 
@@ -633,14 +644,20 @@ impl<B: SessionAgentBuilder + 'static> PersistentSessionService<B> {
         runtime_store: &Arc<dyn RuntimeStore>,
         id: &SessionId,
     ) -> Result<Option<Session>, SessionError> {
+        let mut selected = None;
         for runtime_id in Self::runtime_id_candidates_for_session(id) {
             if let Some(session) =
                 Self::load_runtime_session_snapshot(runtime_store, &runtime_id).await?
             {
-                return Ok(Some(session));
+                let replace = selected
+                    .as_ref()
+                    .is_none_or(|existing: &Session| session.updated_at() > existing.updated_at());
+                if replace {
+                    selected = Some(session);
+                }
             }
         }
-        Ok(None)
+        Ok(selected)
     }
 
     fn store_only_control_mutation_error(id: &SessionId, operation: &str) -> SessionError {
@@ -4949,6 +4966,72 @@ mod tests {
             authoritative.messages().len(),
             legacy_runtime_session.messages().len(),
             "runtime-backed resume must preserve legacy raw alias snapshots"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_runtime_backed_authoritative_load_prefers_newer_legacy_runtime_alias_snapshot() {
+        let store: Arc<dyn SessionStore> = Arc::new(MemoryStore::new());
+        let runtime_store = Arc::new(InMemoryRuntimeStore::new());
+        let service = PersistentSessionService::new(
+            DummyBuilder,
+            4,
+            Arc::clone(&store),
+            Some(runtime_store.clone()),
+            memory_blob_store(),
+        );
+
+        let mut canonical_session = Session::new();
+        canonical_session.push(Message::User(UserMessage::text(
+            "canonical runtime alias row".to_string(),
+        )));
+        let id = canonical_session.id().clone();
+        let canonical_runtime_id =
+            PersistentSessionService::<DummyBuilder>::runtime_id_for_session(&id);
+        runtime_store
+            .commit_session_boundary(
+                &canonical_runtime_id,
+                meerkat_runtime::store::SessionDelta {
+                    session_snapshot: serde_json::to_vec(&canonical_session)
+                        .expect("canonical session should serialize"),
+                },
+                RunId::new(),
+                RunApplyBoundary::Immediate,
+                vec![],
+                vec![],
+            )
+            .await
+            .expect("test should seed a canonical runtime alias snapshot");
+
+        tokio::time::sleep(std::time::Duration::from_millis(1)).await;
+        let mut legacy_session = canonical_session.clone();
+        legacy_session.push(Message::User(UserMessage::text(
+            "newer legacy runtime alias row".to_string(),
+        )));
+        runtime_store
+            .commit_session_boundary(
+                &LogicalRuntimeId::legacy_session_uuid_alias(&id),
+                meerkat_runtime::store::SessionDelta {
+                    session_snapshot: serde_json::to_vec(&legacy_session)
+                        .expect("legacy session should serialize"),
+                },
+                RunId::new(),
+                RunApplyBoundary::Immediate,
+                vec![],
+                vec![],
+            )
+            .await
+            .expect("test should seed a newer legacy runtime alias snapshot");
+
+        let authoritative = service
+            .load_authoritative_session(&id)
+            .await
+            .expect("authoritative load should succeed")
+            .expect("runtime alias snapshot should exist");
+        assert_eq!(
+            authoritative.messages().len(),
+            legacy_session.messages().len(),
+            "runtime-backed resume must not hide a newer legacy raw alias snapshot when both aliases exist"
         );
     }
 

--- a/meerkat-session/src/persistent.rs
+++ b/meerkat-session/src/persistent.rs
@@ -687,12 +687,10 @@ impl<B: SessionAgentBuilder + 'static> PersistentSessionService<B> {
         {
             match Self::load_runtime_session_snapshot(runtime_store, &runtime_id).await {
                 Ok(Some(session)) => {
-                    let replace = selected.as_ref().is_none_or(|existing: &Session| {
-                        session.updated_at() > existing.updated_at()
-                    });
-                    if replace {
-                        selected = Some(session);
+                    if candidate_index == 0 {
+                        return Ok(Some(session));
                     }
+                    selected = Some(session);
                 }
                 Ok(None) => {}
                 Err(err) if candidate_index > 0 && selected.is_some() => {
@@ -5053,7 +5051,8 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_runtime_backed_authoritative_load_prefers_newer_legacy_runtime_alias_snapshot() {
+    async fn test_runtime_backed_authoritative_load_keeps_canonical_over_newer_legacy_runtime_alias_snapshot()
+     {
         let store: Arc<dyn SessionStore> = Arc::new(MemoryStore::new());
         let runtime_store = Arc::new(InMemoryRuntimeStore::new());
         let service = PersistentSessionService::new(
@@ -5113,8 +5112,8 @@ mod tests {
             .expect("runtime alias snapshot should exist");
         assert_eq!(
             authoritative.messages().len(),
-            legacy_session.messages().len(),
-            "runtime-backed resume must not hide a newer legacy raw alias snapshot when both aliases exist"
+            canonical_session.messages().len(),
+            "canonical runtime authority must not be overwritten by a newer legacy raw alias snapshot"
         );
     }
 

--- a/meerkat-session/src/persistent.rs
+++ b/meerkat-session/src/persistent.rs
@@ -449,16 +449,29 @@ impl<B: SessionAgentBuilder + 'static> PersistentSessionService<B> {
             return Ok(Vec::new());
         };
         let mut stored_states: Vec<StoredInputState> = Vec::new();
-        for runtime_id in Self::runtime_id_candidates_for_session(id) {
-            let candidate_states =
-                runtime_store
-                    .load_input_states(&runtime_id)
-                    .await
-                    .map_err(|err| {
-                        SessionError::Agent(meerkat_core::error::AgentError::InternalError(
-                            format!("failed to load runtime input states: {err}"),
-                        ))
-                    })?;
+        for (candidate_index, runtime_id) in Self::runtime_id_candidates_for_session(id)
+            .into_iter()
+            .enumerate()
+        {
+            let candidate_states = match runtime_store.load_input_states(&runtime_id).await {
+                Ok(states) => states,
+                Err(err) if candidate_index > 0 && !stored_states.is_empty() => {
+                    tracing::warn!(
+                        session_id = %id,
+                        runtime_id = %runtime_id,
+                        error = %err,
+                        "ignoring legacy runtime input-state fallback error because canonical input states were already loaded"
+                    );
+                    continue;
+                }
+                Err(err) => {
+                    return Err(SessionError::Agent(
+                        meerkat_core::error::AgentError::InternalError(format!(
+                            "failed to load runtime input states: {err}"
+                        )),
+                    ));
+                }
+            };
             for state in candidate_states {
                 let input_id = state.state.input_id.clone();
                 if let Some(existing) = stored_states
@@ -2425,6 +2438,7 @@ mod tests {
         inner: InMemoryRuntimeStore,
         hidden_snapshot_loads: AtomicUsize,
         session_snapshot_overrides: Mutex<HashMap<LogicalRuntimeId, Vec<u8>>>,
+        input_state_load_errors: Mutex<HashSet<LogicalRuntimeId>>,
         boundary_commits: Mutex<Vec<meerkat_core::lifecycle::RunBoundaryReceipt>>,
     }
 
@@ -2434,6 +2448,7 @@ mod tests {
                 inner: InMemoryRuntimeStore::new(),
                 hidden_snapshot_loads: AtomicUsize::new(0),
                 session_snapshot_overrides: Mutex::new(HashMap::new()),
+                input_state_load_errors: Mutex::new(HashSet::new()),
                 boundary_commits: Mutex::new(Vec::new()),
             }
         }
@@ -2471,6 +2486,10 @@ mod tests {
                 .lock()
                 .await
                 .insert(runtime_id, snapshot);
+        }
+
+        async fn fail_input_state_load_for(&self, runtime_id: LogicalRuntimeId) {
+            self.input_state_load_errors.lock().await.insert(runtime_id);
         }
     }
 
@@ -2536,6 +2555,16 @@ mod tests {
             &self,
             runtime_id: &LogicalRuntimeId,
         ) -> Result<Vec<StoredInputState>, meerkat_runtime::store::RuntimeStoreError> {
+            if self
+                .input_state_load_errors
+                .lock()
+                .await
+                .contains(runtime_id)
+            {
+                return Err(meerkat_runtime::store::RuntimeStoreError::ReadFailed(
+                    "synthetic legacy input-state load failure".to_string(),
+                ));
+            }
             self.inner.load_input_states(runtime_id).await
         }
 
@@ -5117,6 +5146,49 @@ mod tests {
             canonical_session.messages().len(),
             "canonical runtime authority must win over corrupt legacy fallback data"
         );
+    }
+
+    #[tokio::test]
+    async fn test_runtime_input_updates_ignore_legacy_alias_load_error_after_canonical_states() {
+        let store: Arc<dyn SessionStore> = Arc::new(MemoryStore::new());
+        let runtime_store = Arc::new(GatedSnapshotRuntimeStore::new());
+        let service = PersistentSessionService::new(
+            DummyBuilder,
+            4,
+            Arc::clone(&store),
+            Some(runtime_store.clone()),
+            memory_blob_store(),
+        );
+
+        let id = SessionId::new();
+        let input_id = InputId::new();
+        let canonical_runtime_id =
+            PersistentSessionService::<DummyBuilder>::runtime_id_for_session(&id);
+        let mut input_state = meerkat_runtime::InputState::new_accepted(input_id.clone());
+        input_state.durability = Some(meerkat_runtime::InputDurability::Durable);
+        let stored = StoredInputState {
+            state: input_state,
+            seed: meerkat_runtime::input_state::InputStateSeed::new_accepted(),
+        };
+        runtime_store
+            .persist_input_state(&canonical_runtime_id, &stored)
+            .await
+            .expect("test should seed canonical input state");
+        runtime_store
+            .fail_input_state_load_for(LogicalRuntimeId::legacy_session_uuid_alias(&id))
+            .await;
+
+        let run_id = RunId::new();
+        let updates = service
+            .runtime_input_updates(&id, &run_id, 7, std::slice::from_ref(&input_id))
+            .await
+            .expect("legacy input-state load failure must not poison canonical updates");
+
+        assert_eq!(updates.len(), 1);
+        assert_eq!(updates[0].state.input_id, input_id);
+        assert_eq!(updates[0].seed.phase, InputLifecycleState::Consumed);
+        assert_eq!(updates[0].seed.last_run_id, Some(run_id));
+        assert_eq!(updates[0].seed.last_boundary_sequence, Some(7));
     }
 
     #[tokio::test]

--- a/meerkat-session/src/persistent.rs
+++ b/meerkat-session/src/persistent.rs
@@ -449,13 +449,19 @@ impl<B: SessionAgentBuilder + 'static> PersistentSessionService<B> {
             return Ok(Vec::new());
         };
         let mut stored_states: Vec<StoredInputState> = Vec::new();
+        let mut primary_alias_loaded = false;
         for (candidate_index, runtime_id) in Self::runtime_id_candidates_for_session(id)
             .into_iter()
             .enumerate()
         {
             let candidate_states = match runtime_store.load_input_states(&runtime_id).await {
-                Ok(states) => states,
-                Err(err) if candidate_index > 0 && !stored_states.is_empty() => {
+                Ok(states) => {
+                    if candidate_index == 0 {
+                        primary_alias_loaded = true;
+                    }
+                    states
+                }
+                Err(err) if candidate_index > 0 && primary_alias_loaded => {
                     tracing::warn!(
                         session_id = %id,
                         runtime_id = %runtime_id,
@@ -5189,6 +5195,35 @@ mod tests {
         assert_eq!(updates[0].seed.phase, InputLifecycleState::Consumed);
         assert_eq!(updates[0].seed.last_run_id, Some(run_id));
         assert_eq!(updates[0].seed.last_boundary_sequence, Some(7));
+    }
+
+    #[tokio::test]
+    async fn test_runtime_input_updates_ignore_legacy_alias_load_error_after_empty_canonical_read()
+    {
+        let store: Arc<dyn SessionStore> = Arc::new(MemoryStore::new());
+        let runtime_store = Arc::new(GatedSnapshotRuntimeStore::new());
+        let service = PersistentSessionService::new(
+            DummyBuilder,
+            4,
+            Arc::clone(&store),
+            Some(runtime_store.clone()),
+            memory_blob_store(),
+        );
+
+        let id = SessionId::new();
+        runtime_store
+            .fail_input_state_load_for(LogicalRuntimeId::legacy_session_uuid_alias(&id))
+            .await;
+
+        let updates = service
+            .runtime_input_updates(&id, &RunId::new(), 0, &[])
+            .await
+            .expect("legacy input-state load failure must not poison empty canonical updates");
+
+        assert!(
+            updates.is_empty(),
+            "no-contributor boundary should not need legacy input-state data"
+        );
     }
 
     #[tokio::test]

--- a/meerkat-session/src/persistent.rs
+++ b/meerkat-session/src/persistent.rs
@@ -645,16 +645,29 @@ impl<B: SessionAgentBuilder + 'static> PersistentSessionService<B> {
         id: &SessionId,
     ) -> Result<Option<Session>, SessionError> {
         let mut selected = None;
-        for runtime_id in Self::runtime_id_candidates_for_session(id) {
-            if let Some(session) =
-                Self::load_runtime_session_snapshot(runtime_store, &runtime_id).await?
-            {
-                let replace = selected
-                    .as_ref()
-                    .is_none_or(|existing: &Session| session.updated_at() > existing.updated_at());
-                if replace {
-                    selected = Some(session);
+        for (candidate_index, runtime_id) in Self::runtime_id_candidates_for_session(id)
+            .into_iter()
+            .enumerate()
+        {
+            match Self::load_runtime_session_snapshot(runtime_store, &runtime_id).await {
+                Ok(Some(session)) => {
+                    let replace = selected.as_ref().is_none_or(|existing: &Session| {
+                        session.updated_at() > existing.updated_at()
+                    });
+                    if replace {
+                        selected = Some(session);
+                    }
                 }
+                Ok(None) => {}
+                Err(err) if candidate_index > 0 && selected.is_some() => {
+                    tracing::warn!(
+                        session_id = %id,
+                        runtime_id = %runtime_id,
+                        error = ?err,
+                        "ignoring legacy runtime session snapshot fallback error because canonical authority was already loaded"
+                    );
+                }
+                Err(err) => return Err(err),
             }
         }
         Ok(selected)
@@ -2411,6 +2424,7 @@ mod tests {
     struct GatedSnapshotRuntimeStore {
         inner: InMemoryRuntimeStore,
         hidden_snapshot_loads: AtomicUsize,
+        session_snapshot_overrides: Mutex<HashMap<LogicalRuntimeId, Vec<u8>>>,
         boundary_commits: Mutex<Vec<meerkat_core::lifecycle::RunBoundaryReceipt>>,
     }
 
@@ -2419,6 +2433,7 @@ mod tests {
             Self {
                 inner: InMemoryRuntimeStore::new(),
                 hidden_snapshot_loads: AtomicUsize::new(0),
+                session_snapshot_overrides: Mutex::new(HashMap::new()),
                 boundary_commits: Mutex::new(Vec::new()),
             }
         }
@@ -2449,6 +2464,13 @@ mod tests {
 
         async fn reset_boundary_commits(&self) {
             self.boundary_commits.lock().await.clear();
+        }
+
+        async fn override_session_snapshot(&self, runtime_id: LogicalRuntimeId, snapshot: Vec<u8>) {
+            self.session_snapshot_overrides
+                .lock()
+                .await
+                .insert(runtime_id, snapshot);
         }
     }
 
@@ -2537,6 +2559,15 @@ mod tests {
         ) -> Result<Option<Vec<u8>>, meerkat_runtime::store::RuntimeStoreError> {
             if self.should_hide_session_snapshot_load() {
                 return Ok(None);
+            }
+            if let Some(snapshot) = self
+                .session_snapshot_overrides
+                .lock()
+                .await
+                .get(runtime_id)
+                .cloned()
+            {
+                return Ok(Some(snapshot));
             }
             self.inner.load_session_snapshot(runtime_id).await
         }
@@ -5032,6 +5063,59 @@ mod tests {
             authoritative.messages().len(),
             legacy_session.messages().len(),
             "runtime-backed resume must not hide a newer legacy raw alias snapshot when both aliases exist"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_runtime_authority_ignores_corrupt_legacy_alias_after_canonical_snapshot() {
+        let store: Arc<dyn SessionStore> = Arc::new(MemoryStore::new());
+        let runtime_store = Arc::new(GatedSnapshotRuntimeStore::new());
+        let service = PersistentSessionService::new(
+            DummyBuilder,
+            4,
+            Arc::clone(&store),
+            Some(runtime_store.clone()),
+            memory_blob_store(),
+        );
+
+        let mut canonical_session = Session::new();
+        canonical_session.push(Message::User(UserMessage::text(
+            "canonical runtime alias row".to_string(),
+        )));
+        let id = canonical_session.id().clone();
+        let canonical_runtime_id =
+            PersistentSessionService::<DummyBuilder>::runtime_id_for_session(&id);
+        runtime_store
+            .commit_session_boundary(
+                &canonical_runtime_id,
+                meerkat_runtime::store::SessionDelta {
+                    session_snapshot: serde_json::to_vec(&canonical_session)
+                        .expect("canonical session should serialize"),
+                },
+                RunId::new(),
+                RunApplyBoundary::Immediate,
+                vec![],
+                vec![],
+            )
+            .await
+            .expect("test should seed a canonical runtime snapshot");
+
+        runtime_store
+            .override_session_snapshot(
+                LogicalRuntimeId::legacy_session_uuid_alias(&id),
+                b"{not valid json".to_vec(),
+            )
+            .await;
+
+        let authoritative = service
+            .load_authoritative_session(&id)
+            .await
+            .expect("valid canonical authority must not be poisoned by corrupt legacy fallback")
+            .expect("canonical runtime snapshot should exist");
+        assert_eq!(
+            authoritative.messages().len(),
+            canonical_session.messages().len(),
+            "canonical runtime authority must win over corrupt legacy fallback data"
         );
     }
 


### PR DESCRIPTION
## Summary
- Introduce canonical session-backed runtime IDs as `rt:session:<session-uuid>` instead of raw session UUID control-plane aliases.
- Store canonical runtime IDs on registered runtime entries and resolve control-plane operations through registered runtime identity.
- Preserve durable resume by reading legacy raw session UUID aliases as storage fallback candidates for runtime state, input state, ops lifecycle, and session snapshots.

## Validation
- `./scripts/repo-cargo test -p meerkat-runtime control_plane_runtime_id_is_not_raw_session_uuid_alias`
- `./scripts/repo-cargo test -p meerkat-session --features session-store test_runtime_backed_authoritative_load_accepts_legacy_session_uuid_runtime_alias`
- `./scripts/repo-cargo test -p meerkat-runtime --test meerkat_machine`
- `./scripts/repo-cargo test -p meerkat-runtime --test meerkat_machine cold_reregister_recovers_legacy_session_uuid_runtime_state_alias`
- `./scripts/repo-cargo test -p meerkat-runtime --test ops_lifecycle_persistence recovers_persisted_epoch`
- `./scripts/repo-cargo test -p meerkat-runtime --test control_plane_contract control_plane_contract_stop_runtime_executor_persists_stopped_state_without_loop`
- `./scripts/repo-cargo test -p meerkat-runtime --lib`
- `./scripts/repo-cargo test -p meerkat-session --features session-store --lib`
- `git diff --check`
- `make check` via BuildBuddy: b31c3e7d-0416-4a16-82e9-0ddac2de3a70

Linear: LUC-209