### PR TITLE
Require runtime-stamped execution kind

### DIFF
--- a/examples/024-host-mode-event-mesh-rs/main.rs
+++ b/examples/024-host-mode-event-mesh-rs/main.rs
@@ -153,6 +153,7 @@ Production surfaces (CLI, REST, RPC, MCP) use the runtime-backed path.
                 event_tx: Some(event_tx),
                 skill_references: None,
                 flow_tool_overlay: None,
+                pre_turn_context_appends: Vec::new(),
                 turn_metadata: None,
             },
         )
@@ -190,6 +191,7 @@ Production surfaces (CLI, REST, RPC, MCP) use the runtime-backed path.
                 event_tx: Some(event_tx),
                 skill_references: None,
                 flow_tool_overlay: None,
+                pre_turn_context_appends: Vec::new(),
                 turn_metadata: None,
             },
         )

--- a/examples/034-codemob-mcp/src/tools/consult.rs
+++ b/examples/034-codemob-mcp/src/tools/consult.rs
@@ -132,6 +132,7 @@ pub async fn handle(
         override_shell: meerkat_core::ToolCategoryOverride::from_override(input.shell),
         additional_instructions,
         runtime_build_mode: meerkat_core::RuntimeBuildMode::StandaloneEphemeral,
+        initial_turn_metadata: None,
         ..SessionBuildOptions::default()
     };
     build.provider_params = input.provider_params;

--- a/examples/034-codemob-mcp/src/tools/consult.rs
+++ b/examples/034-codemob-mcp/src/tools/consult.rs
@@ -77,6 +77,7 @@ pub async fn handle(
             event_tx: None,
             skill_references: None,
             flow_tool_overlay: None,
+            pre_turn_context_appends: Vec::new(),
             turn_metadata: None,
         };
 

--- a/examples/035-mdm-tux-rs/src/bin/target.rs
+++ b/examples/035-mdm-tux-rs/src/bin/target.rs
@@ -41,7 +41,10 @@ use meerkat_comms::{CommsRuntime, PeerMeta, ResolvedCommsConfig, TrustedPeer};
 use meerkat_core::lifecycle::RunId;
 use meerkat_core::lifecycle::core_executor::{CoreApplyOutput, CoreExecutor, CoreExecutorError};
 use meerkat_core::lifecycle::run_control::RunControlCommand;
-use meerkat_core::lifecycle::run_primitive::{CoreRenderable, RunApplyBoundary, RunPrimitive};
+use meerkat_core::PendingSystemContextAppend;
+use meerkat_core::lifecycle::run_primitive::{
+    ConversationContextAppend, CoreRenderable, RunApplyBoundary, RunPrimitive,
+};
 use meerkat_core::mcp_config::McpConfig;
 use meerkat_core::service::{
     CreateSessionRequest, InitialTurnPolicy, SessionBuildOptions, SessionError, SessionService,
@@ -352,6 +355,7 @@ impl SurfaceScheduleSessionHost for TargetScheduleSessionHost {
                 provider_params: None,
                 render_metadata: dispatch.render_metadata.clone(),
                 execution_kind: None,
+                peer_response_terminal_apply_intent: None,
                 connection_ref: None,
             },
         );
@@ -1073,47 +1077,64 @@ impl TargetCoreExecutor {
     }
 }
 
-/// Extract prompt content from a `RunPrimitive`, preserving multimodal blocks.
-fn extract_prompt(primitive: &RunPrimitive) -> ContentInput {
-    match primitive {
-        RunPrimitive::StagedInput(staged) => {
-            let mut all_blocks = Vec::new();
-            for append in &staged.appends {
-                match &append.content {
-                    CoreRenderable::Text { text } => {
-                        all_blocks
-                            .push(meerkat_core::types::ContentBlock::Text { text: text.clone() });
-                    }
-                    CoreRenderable::Blocks { blocks } => {
-                        all_blocks.extend(blocks.iter().cloned());
-                    }
-                    _ => {}
-                }
-            }
-            if all_blocks.is_empty() {
-                ContentInput::Text(String::new())
-            } else if all_blocks.len() == 1 {
-                if let meerkat_core::types::ContentBlock::Text { text } = &all_blocks[0] {
-                    ContentInput::Text(text.clone())
-                } else {
-                    ContentInput::Blocks(all_blocks)
-                }
-            } else {
-                ContentInput::Blocks(all_blocks)
-            }
+fn render_runtime_context_append_text(content: &CoreRenderable) -> String {
+    match content {
+        CoreRenderable::Text { text } => text.clone(),
+        CoreRenderable::Blocks { blocks } => meerkat_core::types::text_content(blocks),
+        CoreRenderable::Json { value } => {
+            serde_json::to_string_pretty(value).unwrap_or_else(|_| value.to_string())
         }
-        RunPrimitive::ImmediateAppend(append) => match &append.content {
-            CoreRenderable::Text { text } => ContentInput::Text(text.clone()),
-            CoreRenderable::Blocks { blocks } => ContentInput::Blocks(blocks.clone()),
-            _ => ContentInput::Text(String::new()),
+        CoreRenderable::Reference { uri, label } => match label {
+            Some(label) if !label.trim().is_empty() => format!("[Reference] {label} ({uri})"),
+            _ => format!("[Reference] {uri}"),
         },
-        RunPrimitive::ImmediateContextAppend(ctx) => match &ctx.content {
-            CoreRenderable::Text { text } => ContentInput::Text(text.clone()),
-            CoreRenderable::Blocks { blocks } => ContentInput::Blocks(blocks.clone()),
-            _ => ContentInput::Text(String::new()),
-        },
-        _ => ContentInput::Text(String::new()),
+        _ => String::new(),
     }
+}
+
+fn pending_system_context_appends(
+    appends: &[ConversationContextAppend],
+) -> Vec<PendingSystemContextAppend> {
+    let accepted_at = meerkat_core::time_compat::SystemTime::now();
+    appends
+        .iter()
+        .map(|append| PendingSystemContextAppend {
+            text: render_runtime_context_append_text(&append.content),
+            source: Some(append.key.clone()),
+            idempotency_key: Some(append.key.clone()),
+            accepted_at,
+        })
+        .collect()
+}
+
+fn start_turn_request_from_primitive(
+    primitive: &RunPrimitive,
+) -> Result<StartTurnRequest, CoreExecutorError> {
+    if let Some(reason) = primitive.peer_response_terminal_apply_intent_violation() {
+        return Err(CoreExecutorError::apply_failed_primitive_rejected(
+            reason.to_string(),
+        ));
+    }
+    let metadata = primitive.turn_metadata();
+    let pre_turn_context_appends = match primitive {
+        RunPrimitive::StagedInput(staged) if primitive.is_peer_response_terminal_context_and_run() => {
+            pending_system_context_appends(&staged.context_appends)
+        }
+        _ => Vec::new(),
+    };
+    Ok(StartTurnRequest {
+        prompt: primitive.extract_content_input(),
+        system_prompt: None,
+        render_metadata: metadata.and_then(|meta| meta.render_metadata.clone()),
+        handling_mode: metadata
+            .and_then(|meta| meta.handling_mode)
+            .unwrap_or(HandlingMode::Queue),
+        event_tx: None,
+        skill_references: metadata.and_then(|meta| meta.skill_references.clone()),
+        flow_tool_overlay: metadata.and_then(|meta| meta.flow_tool_overlay.clone()),
+        pre_turn_context_appends,
+        turn_metadata: metadata.cloned(),
+    })
 }
 
 #[async_trait::async_trait]
@@ -1123,23 +1144,7 @@ impl CoreExecutor for TargetCoreExecutor {
         run_id: RunId,
         primitive: RunPrimitive,
     ) -> Result<CoreApplyOutput, CoreExecutorError> {
-        let prompt = extract_prompt(&primitive);
-
-        let req = StartTurnRequest {
-            prompt,
-            system_prompt: None,
-            render_metadata: None,
-            handling_mode: HandlingMode::Queue,
-            event_tx: None,
-            skill_references: primitive
-                .turn_metadata()
-                .and_then(|meta| meta.skill_references.clone()),
-            flow_tool_overlay: primitive
-                .turn_metadata()
-                .and_then(|meta| meta.flow_tool_overlay.clone()),
-            pre_turn_context_appends: Vec::new(),
-            turn_metadata: primitive.turn_metadata().cloned(),
-        };
+        let req = start_turn_request_from_primitive(&primitive)?;
 
         let boundary = match &primitive {
             RunPrimitive::StagedInput(staged) => staged.boundary,
@@ -2056,6 +2061,7 @@ mod tests {
     use meerkat_core::service::{
         CreateSessionRequest, InitialTurnPolicy, SessionBuildOptions, StartTurnRequest,
     };
+    use meerkat_core::lifecycle::run_primitive::{CoreRenderable, RunPrimitive};
     use meerkat_core::types::{ContentInput, HandlingMode};
     use meerkat_mob::MobSessionService;
     use meerkat_mob_mcp::{AgentMobToolSurfaceFactory, MobMcpState};
@@ -2234,6 +2240,50 @@ mod tests {
         ])
         .unwrap();
         assert_eq!(provider, Some(ProviderKind::Openai));
+    }
+
+    #[test]
+    fn target_executor_carries_terminal_peer_response_context_into_turn_request() {
+        let primitive = RunPrimitive::StagedInput(
+            meerkat_core::lifecycle::run_primitive::StagedRunInput {
+                boundary: meerkat_core::lifecycle::run_primitive::RunApplyBoundary::RunStart,
+                appends: Vec::new(),
+                context_appends: vec![
+                    meerkat_core::lifecycle::run_primitive::ConversationContextAppend {
+                        key: "peer_response_terminal:analyst:req-1".to_string(),
+                        content: CoreRenderable::Text {
+                            text: "terminal answer from analyst".to_string(),
+                        },
+                    },
+                ],
+                contributing_input_ids: vec![meerkat_core::lifecycle::InputId::new()],
+                turn_metadata: Some(
+                    meerkat_core::lifecycle::run_primitive::RuntimeTurnMetadata {
+                        execution_kind: Some(
+                            meerkat_core::lifecycle::RuntimeExecutionKind::ContentTurn,
+                        ),
+                        peer_response_terminal_apply_intent: Some(
+                            meerkat_core::lifecycle::run_primitive::PeerResponseTerminalApplyIntent::AppendContextAndRun,
+                        ),
+                        ..Default::default()
+                    },
+                ),
+            },
+        );
+
+        let request =
+            super::start_turn_request_from_primitive(&primitive).expect("primitive should convert");
+
+        assert_eq!(request.prompt.text_content(), "");
+        assert_eq!(request.pre_turn_context_appends.len(), 1);
+        assert_eq!(
+            request.pre_turn_context_appends[0].idempotency_key.as_deref(),
+            Some("peer_response_terminal:analyst:req-1")
+        );
+        assert_eq!(
+            request.pre_turn_context_appends[0].text,
+            "terminal answer from analyst"
+        );
     }
 
     #[tokio::test]

--- a/examples/035-mdm-tux-rs/src/bin/target.rs
+++ b/examples/035-mdm-tux-rs/src/bin/target.rs
@@ -1137,6 +1137,7 @@ impl CoreExecutor for TargetCoreExecutor {
             flow_tool_overlay: primitive
                 .turn_metadata()
                 .and_then(|meta| meta.flow_tool_overlay.clone()),
+            pre_turn_context_appends: Vec::new(),
             turn_metadata: primitive.turn_metadata().cloned(),
         };
 
@@ -2590,6 +2591,7 @@ mod tests {
                     event_tx: None,
                     skill_references: None,
                     flow_tool_overlay: None,
+                    pre_turn_context_appends: Vec::new(),
                     turn_metadata: None,
                 },
             )

--- a/meerkat-cli/src/main.rs
+++ b/meerkat-cli/src/main.rs
@@ -5817,6 +5817,7 @@ async fn run_agent(
             },
             shell_env: None,
             runtime_build_mode: meerkat_core::RuntimeBuildMode::SessionOwned(bindings),
+            initial_turn_metadata: None,
             resume_override_mask: Default::default(),
             call_timeout_override: Default::default(),
             blob_store_override: None,
@@ -13742,6 +13743,9 @@ capabilities = ["definitely_missing_capability"]
             build: Some(SessionBuildOptions {
                 resume_session: Some(session),
                 runtime_build_mode: meerkat_core::RuntimeBuildMode::SessionOwned(bindings),
+                initial_turn_metadata: Some(meerkat_runtime::runtime_stamped_prompt_turn_metadata(
+                    None,
+                )),
                 llm_client_override: Some(meerkat::encode_llm_client_override_for_service(
                     llm_override,
                 )),

--- a/meerkat-cli/src/main.rs
+++ b/meerkat-cli/src/main.rs
@@ -4882,6 +4882,49 @@ struct CliRuntimeExecutor {
     event_tx: Option<mpsc::Sender<EventEnvelope<AgentEvent>>>,
 }
 
+fn cli_render_context_append_text(
+    content: &meerkat_core::lifecycle::run_primitive::CoreRenderable,
+) -> String {
+    use meerkat_core::lifecycle::run_primitive::CoreRenderable;
+
+    match content {
+        CoreRenderable::Text { text } => text.clone(),
+        CoreRenderable::Blocks { blocks } => meerkat_core::types::text_content(blocks),
+        CoreRenderable::Json { value } => {
+            serde_json::to_string_pretty(value).unwrap_or_else(|_| value.to_string())
+        }
+        CoreRenderable::Reference { uri, label } => match label {
+            Some(label) if !label.trim().is_empty() => format!("[Reference] {label} ({uri})"),
+            _ => format!("[Reference] {uri}"),
+        },
+        _ => String::new(),
+    }
+}
+
+fn cli_terminal_pre_turn_context_appends(
+    primitive: &meerkat_core::lifecycle::run_primitive::RunPrimitive,
+) -> Vec<meerkat_core::PendingSystemContextAppend> {
+    use meerkat_core::lifecycle::run_primitive::RunPrimitive;
+
+    let RunPrimitive::StagedInput(staged) = primitive else {
+        return Vec::new();
+    };
+    if !primitive.is_peer_response_terminal_context_and_run() {
+        return Vec::new();
+    }
+    let accepted_at = meerkat_core::time_compat::SystemTime::now();
+    staged
+        .context_appends
+        .iter()
+        .map(|append| meerkat_core::PendingSystemContextAppend {
+            text: cli_render_context_append_text(&append.content),
+            source: Some(append.key.clone()),
+            idempotency_key: Some(append.key.clone()),
+            accepted_at,
+        })
+        .collect()
+}
+
 #[async_trait::async_trait]
 impl meerkat_core::lifecycle::CoreExecutor for CliRuntimeExecutor {
     async fn apply(
@@ -4894,6 +4937,7 @@ impl meerkat_core::lifecycle::CoreExecutor for CliRuntimeExecutor {
     > {
         // Forward the primitive metadata carrier as the single runtime-authored
         // source for per-turn policy.
+        let pre_turn_context_appends = cli_terminal_pre_turn_context_appends(&primitive);
         let turn_req = StartTurnRequest {
             prompt: primitive.extract_content_input(),
             system_prompt: None,
@@ -4906,6 +4950,7 @@ impl meerkat_core::lifecycle::CoreExecutor for CliRuntimeExecutor {
             flow_tool_overlay: primitive
                 .turn_metadata()
                 .and_then(|meta| meta.flow_tool_overlay.clone()),
+            pre_turn_context_appends,
             turn_metadata: primitive.turn_metadata().cloned(),
         };
 
@@ -10743,6 +10788,7 @@ default_model = "gemma"
     struct CapturingEventTurnService {
         session_id: SessionId,
         saw_event_tx: std::sync::atomic::AtomicBool,
+        pre_turn_context_appends: Mutex<Vec<meerkat_core::PendingSystemContextAppend>>,
     }
 
     impl CapturingEventTurnService {
@@ -10750,6 +10796,7 @@ default_model = "gemma"
             Self {
                 session_id,
                 saw_event_tx: std::sync::atomic::AtomicBool::new(false),
+                pre_turn_context_appends: Mutex::new(Vec::new()),
             }
         }
     }
@@ -10780,6 +10827,10 @@ default_model = "gemma"
             if id != &self.session_id {
                 return Err(SessionError::NotFound { id: id.clone() });
             }
+            *self
+                .pre_turn_context_appends
+                .lock()
+                .expect("pre-turn context appends lock poisoned") = req.pre_turn_context_appends;
             if let Some(tx) = req.event_tx {
                 self.saw_event_tx
                     .store(true, std::sync::atomic::Ordering::Release);
@@ -11091,6 +11142,66 @@ default_model = "gemma"
                 .saw_event_tx
                 .load(std::sync::atomic::Ordering::Acquire),
             "runtime-backed executor must forward the caller event sender"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_cli_runtime_executor_forwards_terminal_peer_response_context() {
+        use meerkat_core::lifecycle::InputId;
+        use meerkat_core::lifecycle::run_primitive::{
+            ConversationContextAppend, CoreRenderable, PeerResponseTerminalApplyIntent,
+            RunApplyBoundary, RuntimeExecutionKind, RuntimeTurnMetadata, StagedRunInput,
+        };
+
+        let session_id = SessionId::new();
+        let service = Arc::new(CapturingEventTurnService::new(session_id.clone()));
+        let runtime_adapter = Arc::new(meerkat_runtime::MeerkatMachine::ephemeral());
+        let mut executor = CliRuntimeExecutor {
+            service: service.clone(),
+            #[cfg(feature = "session-store")]
+            persistent_service: None,
+            session_id,
+            runtime_adapter,
+            event_tx: None,
+        };
+        let append_key = "peer_response_terminal:cli-peer:req-1";
+        let primitive =
+            meerkat_core::lifecycle::run_primitive::RunPrimitive::StagedInput(StagedRunInput {
+                boundary: RunApplyBoundary::RunStart,
+                appends: Vec::new(),
+                context_appends: vec![ConversationContextAppend {
+                    key: append_key.to_string(),
+                    content: CoreRenderable::Text {
+                        text: "terminal peer response token: ash twelve".to_string(),
+                    },
+                }],
+                contributing_input_ids: vec![InputId::new()],
+                turn_metadata: Some(RuntimeTurnMetadata {
+                    execution_kind: Some(RuntimeExecutionKind::ContentTurn),
+                    peer_response_terminal_apply_intent: Some(
+                        PeerResponseTerminalApplyIntent::AppendContextAndRun,
+                    ),
+                    ..Default::default()
+                }),
+            });
+
+        meerkat_core::lifecycle::CoreExecutor::apply(
+            &mut executor,
+            meerkat_core::lifecycle::RunId::new(),
+            primitive,
+        )
+        .await
+        .expect("terminal peer-response CLI turn should succeed");
+
+        let appends = service
+            .pre_turn_context_appends
+            .lock()
+            .expect("pre-turn context appends lock poisoned");
+        assert_eq!(appends.len(), 1);
+        assert_eq!(appends[0].source.as_deref(), Some(append_key));
+        assert!(
+            appends[0].text.contains("ash twelve"),
+            "terminal peer-response context must reach the CLI start_turn request"
         );
     }
 

--- a/meerkat-core/src/agent.rs
+++ b/meerkat-core/src/agent.rs
@@ -980,6 +980,8 @@ where
         Option<Arc<std::sync::RwLock<crate::service::MobToolAuthorityContext>>>,
     /// Runtime-backed turn-state handle, provided by the session runtime bindings.
     pub(crate) turn_state_handle: Option<Arc<dyn crate::TurnStateHandle>>,
+    /// True when the runtime control plane must stamp execution kind metadata.
+    pub(crate) runtime_execution_kind_required: bool,
     /// Typed execution intent for the current run, when this turn is owned by
     /// the runtime control plane rather than a direct surface call.
     pub(crate) runtime_execution_kind: Option<crate::lifecycle::RuntimeExecutionKind>,

--- a/meerkat-core/src/agent/builder.rs
+++ b/meerkat-core/src/agent/builder.rs
@@ -843,6 +843,37 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn runtime_backed_run_consumes_execution_kind_stamp() {
+        let client = Arc::new(MockClient);
+        let tools = Arc::new(MockTools);
+        let store = Arc::new(MockStore);
+
+        let mut agent = AgentBuilder::new()
+            .with_turn_state_handle(Arc::new(
+                crate::agent::test_turn_state_handle::TestTurnStateHandle::new(),
+            ))
+            .require_runtime_execution_kind_stamp()
+            .build(client, tools, store)
+            .await;
+        agent.set_runtime_execution_kind(Some(crate::lifecycle::RuntimeExecutionKind::ContentTurn));
+
+        agent
+            .run("hello".to_string().into())
+            .await
+            .expect("stamped runtime-backed run should succeed");
+
+        let err = agent
+            .run("raw follow-up".to_string().into())
+            .await
+            .expect_err("runtime-backed follow-up run must require a fresh stamp");
+
+        assert!(
+            err.to_string().contains("runtime_execution_kind not set"),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[tokio::test]
     async fn test_builder_event_tap_receives_turn_started_without_primary_event_tx() {
         let client = Arc::new(MockClient);
         let tools = Arc::new(MockTools);

--- a/meerkat-core/src/agent/builder.rs
+++ b/meerkat-core/src/agent/builder.rs
@@ -57,6 +57,7 @@ pub struct AgentBuilder {
     pub(super) epoch_cursor_state: Option<Arc<crate::runtime_epoch::EpochCursorState>>,
     pub(super) tool_visibility_owner: Option<Arc<dyn ToolVisibilityOwner>>,
     pub(super) turn_state_handle: Option<Arc<dyn crate::TurnStateHandle>>,
+    pub(super) runtime_execution_kind_required: bool,
     pub(super) runtime_execution_kind: Option<crate::lifecycle::RuntimeExecutionKind>,
     pub(super) external_tool_surface_handle: Option<Arc<dyn crate::ExternalToolSurfaceHandle>>,
     pub(super) auth_lease_handle: Option<Arc<dyn crate::handles::AuthLeaseHandle>>,
@@ -95,6 +96,7 @@ impl AgentBuilder {
             epoch_cursor_state: None,
             tool_visibility_owner: None,
             turn_state_handle: None,
+            runtime_execution_kind_required: false,
             runtime_execution_kind: None,
             external_tool_surface_handle: None,
             auth_lease_handle: None,
@@ -332,6 +334,7 @@ impl AgentBuilder {
             epoch_cursor_state: self.epoch_cursor_state,
             completion_enrichment: self.completion_enrichment,
             mob_authority_handle: None,
+            runtime_execution_kind_required: self.runtime_execution_kind_required,
             runtime_execution_kind: self.runtime_execution_kind,
             turn_state_handle: self.turn_state_handle,
             external_tool_surface_handle: self.external_tool_surface_handle,
@@ -529,6 +532,12 @@ impl AgentBuilder {
     /// Set the runtime-backed turn-state diagnostic handle for this build.
     pub fn with_turn_state_handle(mut self, handle: Arc<dyn crate::TurnStateHandle>) -> Self {
         self.turn_state_handle = Some(handle);
+        self
+    }
+
+    /// Require runtime-stamped execution kind metadata before executing turns.
+    pub fn require_runtime_execution_kind_stamp(mut self) -> Self {
+        self.runtime_execution_kind_required = true;
         self
     }
 
@@ -771,10 +780,12 @@ mod tests {
             .with_turn_state_handle(Arc::new(
                 crate::agent::test_turn_state_handle::TestTurnStateHandle::new(),
             ))
+            .require_runtime_execution_kind_stamp()
             .build(client, tools, store)
             .await;
 
         assert_eq!(agent.runtime_execution_kind, None);
+        assert!(agent.runtime_execution_kind_required);
     }
 
     #[tokio::test]
@@ -787,6 +798,7 @@ mod tests {
             .with_turn_state_handle(Arc::new(
                 crate::agent::test_turn_state_handle::TestTurnStateHandle::new(),
             ))
+            .require_runtime_execution_kind_stamp()
             .build(client, tools, store)
             .await;
 
@@ -815,6 +827,7 @@ mod tests {
             .with_turn_state_handle(Arc::new(
                 crate::agent::test_turn_state_handle::TestTurnStateHandle::new(),
             ))
+            .require_runtime_execution_kind_stamp()
             .build(client, tools, store)
             .await;
 

--- a/meerkat-core/src/agent/builder.rs
+++ b/meerkat-core/src/agent/builder.rs
@@ -57,6 +57,7 @@ pub struct AgentBuilder {
     pub(super) epoch_cursor_state: Option<Arc<crate::runtime_epoch::EpochCursorState>>,
     pub(super) tool_visibility_owner: Option<Arc<dyn ToolVisibilityOwner>>,
     pub(super) turn_state_handle: Option<Arc<dyn crate::TurnStateHandle>>,
+    pub(super) runtime_execution_kind: Option<crate::lifecycle::RuntimeExecutionKind>,
     pub(super) external_tool_surface_handle: Option<Arc<dyn crate::ExternalToolSurfaceHandle>>,
     pub(super) auth_lease_handle: Option<Arc<dyn crate::handles::AuthLeaseHandle>>,
     pub(super) mcp_server_lifecycle_handle:
@@ -94,6 +95,7 @@ impl AgentBuilder {
             epoch_cursor_state: None,
             tool_visibility_owner: None,
             turn_state_handle: None,
+            runtime_execution_kind: None,
             external_tool_surface_handle: None,
             auth_lease_handle: None,
             mcp_server_lifecycle_handle: None,
@@ -330,21 +332,7 @@ impl AgentBuilder {
             epoch_cursor_state: self.epoch_cursor_state,
             completion_enrichment: self.completion_enrichment,
             mob_authority_handle: None,
-            // Default classification: a runtime-backed agent constructed with
-            // an attached `turn_state_handle` is an ordinary external content
-            // turn unless the runtime surface explicitly restages a different
-            // kind via `set_runtime_execution_kind`. This prevents tests and
-            // direct-call paths (e.g. `agent.run_loop` without going through
-            // `run_inner`) from panicking at `runtime_turn_authority_snapshot`
-            // when the DSL-owned runtime kind has not been stamped yet. Agents
-            // built without a handle (legacy standalone paths, WASM) keep the
-            // field `None`; the snapshot accessor only panics when a handle
-            // *is* attached. See #32 Class W2.
-            runtime_execution_kind: if self.turn_state_handle.is_some() {
-                Some(crate::lifecycle::RuntimeExecutionKind::ContentTurn)
-            } else {
-                None
-            },
+            runtime_execution_kind: self.runtime_execution_kind,
             turn_state_handle: self.turn_state_handle,
             external_tool_surface_handle: self.external_tool_surface_handle,
             auth_lease_handle: self.auth_lease_handle,
@@ -541,6 +529,15 @@ impl AgentBuilder {
     /// Set the runtime-backed turn-state diagnostic handle for this build.
     pub fn with_turn_state_handle(mut self, handle: Arc<dyn crate::TurnStateHandle>) -> Self {
         self.turn_state_handle = Some(handle);
+        self
+    }
+
+    #[cfg(test)]
+    pub(crate) fn with_runtime_execution_kind_for_test(
+        mut self,
+        execution_kind: crate::lifecycle::RuntimeExecutionKind,
+    ) -> Self {
+        self.runtime_execution_kind = Some(execution_kind);
         self
     }
 
@@ -765,6 +762,74 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn runtime_backed_builder_does_not_seed_execution_kind() {
+        let client = Arc::new(MockClient);
+        let tools = Arc::new(MockTools);
+        let store = Arc::new(MockStore);
+
+        let agent = AgentBuilder::new()
+            .with_turn_state_handle(Arc::new(
+                crate::agent::test_turn_state_handle::TestTurnStateHandle::new(),
+            ))
+            .build(client, tools, store)
+            .await;
+
+        assert_eq!(agent.runtime_execution_kind, None);
+    }
+
+    #[tokio::test]
+    async fn runtime_backed_run_rejects_missing_execution_kind() {
+        let client = Arc::new(MockClient);
+        let tools = Arc::new(MockTools);
+        let store = Arc::new(MockStore);
+
+        let mut agent = AgentBuilder::new()
+            .with_turn_state_handle(Arc::new(
+                crate::agent::test_turn_state_handle::TestTurnStateHandle::new(),
+            ))
+            .build(client, tools, store)
+            .await;
+
+        let err = agent
+            .run("hello".to_string().into())
+            .await
+            .expect_err("runtime-backed runs must be stamped before execution");
+
+        assert!(
+            err.to_string().contains("runtime_execution_kind not set"),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[tokio::test]
+    async fn runtime_backed_run_pending_rejects_missing_execution_kind() {
+        let client = Arc::new(MockClient);
+        let tools = Arc::new(MockTools);
+        let store = Arc::new(MockStore);
+
+        let mut session = Session::new();
+        session.push(Message::User(UserMessage::text("resume me".to_string())));
+
+        let mut agent = AgentBuilder::new()
+            .resume_session(session)
+            .with_turn_state_handle(Arc::new(
+                crate::agent::test_turn_state_handle::TestTurnStateHandle::new(),
+            ))
+            .build(client, tools, store)
+            .await;
+
+        let err = agent
+            .run_pending()
+            .await
+            .expect_err("runtime-backed pending runs must be stamped before execution");
+
+        assert!(
+            err.to_string().contains("runtime_execution_kind not set"),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[tokio::test]
     async fn test_builder_event_tap_receives_turn_started_without_primary_event_tx() {
         let client = Arc::new(MockClient);
         let tools = Arc::new(MockTools);
@@ -787,6 +852,7 @@ mod tests {
             .with_event_tap(tap)
             .build(client, tools, store)
             .await;
+        agent.set_runtime_execution_kind(Some(crate::lifecycle::RuntimeExecutionKind::ContentTurn));
 
         let result = agent.run("hello".to_string().into()).await;
         assert!(result.is_ok());

--- a/meerkat-core/src/agent/builder.rs
+++ b/meerkat-core/src/agent/builder.rs
@@ -874,6 +874,34 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn runtime_backed_cancel_consumes_execution_kind_stamp() {
+        let client = Arc::new(MockClient);
+        let tools = Arc::new(MockTools);
+        let store = Arc::new(MockStore);
+
+        let mut agent = AgentBuilder::new()
+            .with_turn_state_handle(Arc::new(
+                crate::agent::test_turn_state_handle::TestTurnStateHandle::new(),
+            ))
+            .require_runtime_execution_kind_stamp()
+            .build(client, tools, store)
+            .await;
+        agent.set_runtime_execution_kind(Some(crate::lifecycle::RuntimeExecutionKind::ContentTurn));
+
+        agent.cancel();
+
+        let err = agent
+            .run("raw follow-up".to_string().into())
+            .await
+            .expect_err("runtime-backed follow-up run must require a fresh stamp after cancel");
+
+        assert!(
+            err.to_string().contains("runtime_execution_kind not set"),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[tokio::test]
     async fn test_builder_event_tap_receives_turn_started_without_primary_event_tx() {
         let client = Arc::new(MockClient);
         let tools = Arc::new(MockTools);

--- a/meerkat-core/src/agent/runner.rs
+++ b/meerkat-core/src/agent/runner.rs
@@ -227,7 +227,7 @@ where
     }
 
     fn require_runtime_execution_kind(&self) -> Result<(), AgentError> {
-        if self.turn_state_handle.is_some() && self.runtime_execution_kind.is_none() {
+        if self.runtime_execution_kind_required && self.runtime_execution_kind.is_none() {
             return Err(AgentError::InternalError(
                 "runtime_execution_kind not set: turn-state handle is attached but \
                  the runtime did not stamp RuntimeTurnMetadata.execution_kind"

--- a/meerkat-core/src/agent/runner.rs
+++ b/meerkat-core/src/agent/runner.rs
@@ -1039,6 +1039,7 @@ where
     pub fn cancel(&mut self) {
         use crate::turn_execution_authority::TurnExecutionInput;
 
+        self.clear_runtime_execution_kind();
         let snapshot = self
             .turn_state_handle
             .as_deref()

--- a/meerkat-core/src/agent/runner.rs
+++ b/meerkat-core/src/agent/runner.rs
@@ -226,6 +226,17 @@ where
         self.runtime_execution_kind = execution_kind;
     }
 
+    fn require_runtime_execution_kind(&self) -> Result<(), AgentError> {
+        if self.turn_state_handle.is_some() && self.runtime_execution_kind.is_none() {
+            return Err(AgentError::InternalError(
+                "runtime_execution_kind not set: turn-state handle is attached but \
+                 the runtime did not stamp RuntimeTurnMetadata.execution_kind"
+                    .to_string(),
+            ));
+        }
+        Ok(())
+    }
+
     /// Apply accumulated session effects from tool dispatch.
     ///
     /// Called by the agent loop after each parallel tool batch completes.
@@ -878,22 +889,9 @@ where
     ) -> Result<RunResult, AgentError> {
         let event_tx = event_tx.or_else(|| self.default_event_tx.clone());
 
+        self.require_runtime_execution_kind()?;
+
         // Reset state for new run (allows multi-turn on same agent).
-        //
-        // `run_inner` is the entry point for an ordinary content turn. Default
-        // the classification to `ContentTurn` unless the caller staged an
-        // explicit kind via `set_runtime_execution_kind` (e.g. a runtime-backed
-        // surface that propagates `RuntimeTurnMetadata.execution_kind` from a
-        // `StagedRunInput`). Preserving a previously-staged classification
-        // prevents the reset from silently wiping the caller's typed intent.
-        //
-        // `None` is no longer a valid post-reset state: `turn_state_handle`
-        // attaches pair `runtime_execution_kind` with every live-run path,
-        // and `runtime_turn_authority_snapshot` (state.rs) panics on an
-        // unclassified handle. See #32 W2 / PR #299 follow-up.
-        if self.runtime_execution_kind.is_none() {
-            self.runtime_execution_kind = Some(crate::lifecycle::RuntimeExecutionKind::ContentTurn);
-        }
         self.extraction_state.reset();
         self.run_completed_hooks_applied = false;
 
@@ -985,16 +983,9 @@ where
             ));
         };
 
+        self.require_runtime_execution_kind()?;
+
         // Reset state for new run (allows multi-turn on same agent).
-        //
-        // `run_pending_inner` is the entry point for an explicit continuation
-        // that resumes pending work at a boundary. Default the classification
-        // to `ResumePending` unless the caller staged an explicit kind via
-        // `set_runtime_execution_kind`. See #32 W2 / PR #299 follow-up.
-        if self.runtime_execution_kind.is_none() {
-            self.runtime_execution_kind =
-                Some(crate::lifecycle::RuntimeExecutionKind::ResumePending);
-        }
         self.extraction_state.reset();
         self.run_completed_hooks_applied = false;
 

--- a/meerkat-core/src/agent/runner.rs
+++ b/meerkat-core/src/agent/runner.rs
@@ -226,6 +226,10 @@ where
         self.runtime_execution_kind = execution_kind;
     }
 
+    fn clear_runtime_execution_kind(&mut self) {
+        self.runtime_execution_kind = None;
+    }
+
     fn require_runtime_execution_kind(&self) -> Result<(), AgentError> {
         if self.runtime_execution_kind_required && self.runtime_execution_kind.is_none() {
             return Err(AgentError::InternalError(
@@ -933,6 +937,7 @@ where
             .await
         {
             self.handle_run_failure(&err, event_tx.as_ref()).await;
+            self.clear_runtime_execution_kind();
             return Err(err);
         }
 
@@ -944,15 +949,18 @@ where
                         .await
                 {
                     self.handle_run_failure(&err, event_tx.as_ref()).await;
+                    self.clear_runtime_execution_kind();
                     return Err(err);
                 }
                 self.emit_run_completed_event(&result, event_tx.as_ref())
                     .await;
                 self.checkpoint_current_session().await;
+                self.clear_runtime_execution_kind();
                 Ok(result)
             }
             Err(err) => {
                 self.handle_run_failure(&err, event_tx.as_ref()).await;
+                self.clear_runtime_execution_kind();
                 Err(err)
             }
         }
@@ -978,6 +986,7 @@ where
         });
 
         let Some(prompt) = pending_prompt else {
+            self.clear_runtime_execution_kind();
             return Err(AgentError::ConfigError(
                 "run_pending requires a pending user or tool-results continuation boundary in the session".to_string(),
             ));
@@ -997,6 +1006,7 @@ where
             .await
         {
             self.handle_run_failure(&err, event_tx.as_ref()).await;
+            self.clear_runtime_execution_kind();
             return Err(err);
         }
 
@@ -1008,15 +1018,18 @@ where
                         .await
                 {
                     self.handle_run_failure(&err, event_tx.as_ref()).await;
+                    self.clear_runtime_execution_kind();
                     return Err(err);
                 }
                 self.emit_run_completed_event(&result, event_tx.as_ref())
                     .await;
                 self.checkpoint_current_session().await;
+                self.clear_runtime_execution_kind();
                 Ok(result)
             }
             Err(err) => {
                 self.handle_run_failure(&err, event_tx.as_ref()).await;
+                self.clear_runtime_execution_kind();
                 Err(err)
             }
         }

--- a/meerkat-core/src/agent/state.rs
+++ b/meerkat-core/src/agent/state.rs
@@ -2503,14 +2503,13 @@ mod tests {
     use tokio::sync::{Notify, mpsc};
 
     /// Attach an in-core phase-tracking `TurnStateHandle` to a raw
-    /// `AgentBuilder`.
+    /// `AgentBuilder` and explicitly stamp the test run as a content turn.
     ///
     /// Wave-A deleted the standalone in-core turn-state fallback
     /// (`LocalTurnExecutionState`); `Agent::runtime_turn_authority_snapshot`
     /// now requires a live handle on every run path. Tests that construct
-    /// a bare `AgentBuilder::new()` (wrapped here by this helper) must
-    /// thread a `TurnStateHandle` through the build or the agent loop
-    /// panics the first time it queries turn state.
+    /// a bare `AgentBuilder::new()` (wrapped here by this helper) must thread
+    /// both a `TurnStateHandle` and a runtime execution kind through the build.
     ///
     /// `meerkat-core` cannot borrow `RuntimeTurnStateHandle` from
     /// `meerkat-runtime` (circular dev-dep instantiates two copies of
@@ -2523,7 +2522,11 @@ mod tests {
     /// See #32 Class W1 — runtime_turn_authority missing handle.
     fn with_test_turn_state_handle(builder: AgentBuilder) -> AgentBuilder {
         use crate::agent::test_turn_state_handle::TestTurnStateHandle;
-        builder.with_turn_state_handle(Arc::new(TestTurnStateHandle::new()))
+        builder
+            .with_turn_state_handle(Arc::new(TestTurnStateHandle::new()))
+            .with_runtime_execution_kind_for_test(
+                crate::lifecycle::RuntimeExecutionKind::ContentTurn,
+            )
     }
 
     #[test]
@@ -4074,6 +4077,9 @@ mod tests {
             Arc::new(crate::agent::test_turn_state_handle::TestTurnStateHandle::new());
         let mut agent = AgentBuilder::new()
             .with_turn_state_handle(turn_handle.clone())
+            .with_runtime_execution_kind_for_test(
+                crate::lifecycle::RuntimeExecutionKind::ContentTurn,
+            )
             .with_hook_engine(Arc::new(DenyRunCompletedHook))
             .build(
                 Arc::new(StaticLlmClient),
@@ -4179,6 +4185,9 @@ mod tests {
             Arc::new(crate::agent::test_turn_state_handle::TestTurnStateHandle::new());
         let mut agent = AgentBuilder::new()
             .with_turn_state_handle(turn_handle.clone())
+            .with_runtime_execution_kind_for_test(
+                crate::lifecycle::RuntimeExecutionKind::ContentTurn,
+            )
             .with_hook_engine(Arc::new(DenyTurnBoundaryHook))
             .with_comms_runtime(comms)
             .build(
@@ -4926,6 +4935,9 @@ mod tests {
             Arc::new(crate::agent::test_turn_state_handle::TestTurnStateHandle::new());
         let mut agent = AgentBuilder::new()
             .with_turn_state_handle(turn_handle.clone())
+            .with_runtime_execution_kind_for_test(
+                crate::lifecycle::RuntimeExecutionKind::ContentTurn,
+            )
             .with_hook_engine(Arc::new(DenyPostToolHook))
             .build(client.clone(), tools, Arc::new(NoopStore))
             .await;

--- a/meerkat-core/src/agent/state.rs
+++ b/meerkat-core/src/agent/state.rs
@@ -251,7 +251,7 @@ where
                     .to_string(),
             )
         })?;
-        if self.runtime_execution_kind.is_none() {
+        if self.runtime_execution_kind_required && self.runtime_execution_kind.is_none() {
             return Err(AgentError::InternalError(
                 "runtime_execution_kind not set: turn-state handle is attached but \
                  the runtime build mode did not classify the execution kind"

--- a/meerkat-core/src/lifecycle/run_primitive.rs
+++ b/meerkat-core/src/lifecycle/run_primitive.rs
@@ -1352,8 +1352,9 @@ pub struct RuntimeTurnMetadata {
     pub render_metadata: Option<RenderMetadata>,
     /// Typed execution intent classified by the runtime layer.
     ///
-    /// `None` means the session layer should use its existing heuristic
-    /// (backward compat for non-runtime substrate-direct paths).
+    /// `None` is retained only for legacy/caller-owned metadata before runtime
+    /// admission. Runtime boundaries must stamp this field before applying a
+    /// turn; the session layer must not invent a runtime execution kind.
     /// `Some(ContentTurn)` forces `run_turn`.
     /// `Some(ResumePending)` forces `run_pending`.
     #[serde(default, skip_serializing_if = "Option::is_none")]

--- a/meerkat-core/src/service/mod.rs
+++ b/meerkat-core/src/service/mod.rs
@@ -288,6 +288,11 @@ pub struct SessionBuildOptions {
     /// - `StandaloneEphemeral`: factory creates local-only ephemeral bindings.
     ///   Suitable for WASM, tests, embedded, and standalone surfaces.
     pub runtime_build_mode: crate::runtime_epoch::RuntimeBuildMode,
+    /// Runtime-stamped metadata for an eager first turn.
+    ///
+    /// Session services only forward this carrier. They must not infer an
+    /// execution kind from runtime build mode.
+    pub initial_turn_metadata: Option<RuntimeTurnMetadata>,
     /// Runtime-injected mob operator authority context.
     ///
     /// This is the only source of mob operator tool authority. Tool visibility
@@ -666,6 +671,7 @@ impl Default for SessionBuildOptions {
             resume_override_mask: ResumeOverrideMask::default(),
             mob_tools: None,
             runtime_build_mode: crate::runtime_epoch::RuntimeBuildMode::StandaloneEphemeral,
+            initial_turn_metadata: None,
             mob_tool_authority_context: None,
         }
     }
@@ -711,6 +717,10 @@ impl std::fmt::Debug for SessionBuildOptions {
             .field("resume_override_mask", &self.resume_override_mask)
             .field("mob_tools", &self.mob_tools.is_some())
             .field("runtime_build_mode", &self.runtime_build_mode)
+            .field(
+                "initial_turn_metadata",
+                &self.initial_turn_metadata.is_some(),
+            )
             .field(
                 "mob_tool_authority_context",
                 &self.mob_tool_authority_context.is_some(),

--- a/meerkat-core/src/service/mod.rs
+++ b/meerkat-core/src/service/mod.rs
@@ -8,7 +8,7 @@ pub mod transport;
 use crate::event::AgentEvent;
 use crate::event::EventEnvelope;
 use crate::lifecycle::run_primitive::RuntimeTurnMetadata;
-use crate::session::SystemContextStageError;
+use crate::session::{PendingSystemContextAppend, SystemContextStageError};
 use crate::time_compat::SystemTime;
 #[cfg(target_arch = "wasm32")]
 use crate::tokio;
@@ -755,6 +755,9 @@ pub struct StartTurnRequest {
     pub skill_references: Option<Vec<crate::skills::SkillKey>>,
     /// Optional per-turn flow tool overlay (ephemeral, non-persistent).
     pub flow_tool_overlay: Option<TurnToolOverlay>,
+    /// Runtime-owned system-context appends that must be applied at this
+    /// turn boundary before the model run starts.
+    pub pre_turn_context_appends: Vec<PendingSystemContextAppend>,
     /// Canonical runtime-authored metadata for this turn.
     ///
     /// Runtime-backed callers populate this once at the machine boundary and

--- a/meerkat-core/src/session.rs
+++ b/meerkat-core/src/session.rs
@@ -507,6 +507,20 @@ fn render_system_context_block(append: &PendingSystemContextAppend) -> String {
     rendered
 }
 
+fn seen_system_context_matches(
+    seen: &SeenSystemContextKey,
+    append: &PendingSystemContextAppend,
+) -> bool {
+    seen.text == append.text && seen.source.as_deref() == append.source.as_deref()
+}
+
+fn pending_system_context_matches(
+    existing: &PendingSystemContextAppend,
+    append: &PendingSystemContextAppend,
+) -> bool {
+    existing.text == append.text && existing.source.as_deref() == append.source.as_deref()
+}
+
 impl Session {
     /// Create a new empty session
     pub fn new() -> Self {
@@ -701,16 +715,85 @@ impl Session {
             })
             .unwrap_or_default();
         let mut state = self.system_context_state().unwrap_or_default();
-        let new_appends = appends
-            .iter()
-            .filter(|append| {
-                append.idempotency_key.as_ref().is_none_or(|_| {
-                    !current_system_prompt.contains(&render_system_context_block(append))
-                })
-            })
-            .cloned()
-            .collect::<Vec<_>>();
+        let mut state_dirty = false;
+        let mut new_appends: Vec<PendingSystemContextAppend> = Vec::new();
+        for append in appends {
+            if append.text.trim().is_empty() {
+                continue;
+            }
+            let rendered = render_system_context_block(append);
+            if let Some(key) = append.idempotency_key.as_ref() {
+                if let Some(existing) = state.seen.get(key)
+                    && !seen_system_context_matches(existing, append)
+                {
+                    tracing::warn!(
+                        idempotency_key = %key,
+                        "skipping conflicting runtime system-context append"
+                    );
+                    continue;
+                }
+                if let Some(existing) = state
+                    .applied
+                    .iter()
+                    .find(|applied| applied.idempotency_key.as_ref() == Some(key))
+                    && !pending_system_context_matches(existing, append)
+                {
+                    tracing::warn!(
+                        idempotency_key = %key,
+                        "skipping conflicting runtime system-context append"
+                    );
+                    continue;
+                }
+                if let Some(existing) = new_appends
+                    .iter()
+                    .find(|pending| pending.idempotency_key.as_ref() == Some(key))
+                {
+                    if !pending_system_context_matches(existing, append) {
+                        tracing::warn!(
+                            idempotency_key = %key,
+                            "skipping conflicting runtime system-context append"
+                        );
+                    }
+                    continue;
+                }
+                if current_system_prompt.contains(&rendered) {
+                    if !state
+                        .applied
+                        .iter()
+                        .any(|applied| applied.idempotency_key.as_ref() == Some(key))
+                    {
+                        state.applied.push(append.clone());
+                        state_dirty = true;
+                    }
+                    if state
+                        .seen
+                        .get(key)
+                        .is_none_or(|seen| seen.state != SeenSystemContextState::Applied)
+                    {
+                        state.seen.insert(
+                            key.clone(),
+                            SeenSystemContextKey {
+                                text: append.text.clone(),
+                                source: append.source.clone(),
+                                state: SeenSystemContextState::Applied,
+                            },
+                        );
+                        state_dirty = true;
+                    }
+                    continue;
+                }
+            } else if state.applied.contains(append)
+                || new_appends.contains(append)
+                || current_system_prompt.contains(&rendered)
+            {
+                continue;
+            }
+            new_appends.push(append.clone());
+        }
         if new_appends.is_empty() {
+            if state_dirty && let Err(err) = self.set_system_context_state(state) {
+                tracing::warn!(error = %err, "failed to persist applied system-context state");
+            }
             return;
         }
 
@@ -730,6 +813,14 @@ impl Session {
 
         for append in new_appends {
             if let Some(key) = append.idempotency_key.as_ref() {
+                state.seen.insert(
+                    key.clone(),
+                    SeenSystemContextKey {
+                        text: append.text.clone(),
+                        source: append.source.clone(),
+                        state: SeenSystemContextState::Applied,
+                    },
+                );
                 if state
                     .applied
                     .iter()
@@ -1603,6 +1694,48 @@ mod tests {
     }
 
     #[test]
+    fn append_system_context_blocks_renders_pre_marked_pending_context() {
+        let accepted_at = SystemTime::UNIX_EPOCH;
+        let mut state = SessionSystemContextState::default();
+        state
+            .stage_append(
+                &AppendSystemContextRequest {
+                    text: "Apply this staged context at the request boundary.".to_string(),
+                    source: Some("rpc/session_inject_context".to_string()),
+                    idempotency_key: Some("ctx-boundary".to_string()),
+                },
+                accepted_at,
+            )
+            .expect("append should stage");
+        let pending = state.pending.clone();
+        state.mark_pending_applied();
+        let mut session = Session::new();
+        session
+            .set_system_context_state(state)
+            .expect("state should serialize");
+
+        session.append_system_context_blocks(&pending);
+
+        let system_prompt = session
+            .messages()
+            .first()
+            .and_then(|message| match message {
+                Message::System(system) => Some(system.content.as_str()),
+                _ => None,
+            })
+            .unwrap_or_default();
+        assert!(system_prompt.contains("Apply this staged context at the request boundary."));
+        let state = session
+            .system_context_state()
+            .expect("append should persist typed context state");
+        assert_eq!(state.applied.len(), 1);
+        assert_eq!(
+            state.seen["ctx-boundary"].state,
+            SeenSystemContextState::Applied
+        );
+    }
+
+    #[test]
     fn append_system_context_blocks_skips_duplicate_idempotency_key() {
         let first = PendingSystemContextAppend {
             text: "Authoritative peer token is birch seventeen.".to_string(),
@@ -1637,5 +1770,39 @@ mod tests {
                 .count(),
             1
         );
+    }
+
+    #[test]
+    fn append_system_context_blocks_skips_conflicting_duplicate_idempotency_key() {
+        let first = PendingSystemContextAppend {
+            text: "Authoritative peer token is birch seventeen.".to_string(),
+            source: Some("peer_response_terminal:analyst:req-1".to_string()),
+            idempotency_key: Some("req-1".to_string()),
+            accepted_at: SystemTime::UNIX_EPOCH,
+        };
+        let conflicting = PendingSystemContextAppend {
+            text: "Conflicting peer token should not reach the prompt.".to_string(),
+            accepted_at: SystemTime::UNIX_EPOCH + std::time::Duration::from_secs(1),
+            ..first.clone()
+        };
+        let mut session = Session::new();
+
+        session.append_system_context_blocks(std::slice::from_ref(&first));
+        session.append_system_context_blocks(std::slice::from_ref(&conflicting));
+
+        let state = session
+            .system_context_state()
+            .expect("append should persist typed context state");
+        assert_eq!(state.applied, vec![first]);
+        let system_prompt = session
+            .messages()
+            .first()
+            .and_then(|message| match message {
+                Message::System(system) => Some(system.content.as_str()),
+                _ => None,
+            })
+            .unwrap_or_default();
+        assert!(system_prompt.contains("Authoritative peer token is birch seventeen."));
+        assert!(!system_prompt.contains("Conflicting peer token should not reach the prompt."));
     }
 }

--- a/meerkat-core/src/session.rs
+++ b/meerkat-core/src/session.rs
@@ -692,7 +692,29 @@ impl Session {
             return;
         }
 
-        let rendered = appends
+        let current_system_prompt = self
+            .messages
+            .first()
+            .and_then(|message| match message {
+                Message::System(system) => Some(system.content.as_str()),
+                _ => None,
+            })
+            .unwrap_or_default();
+        let mut state = self.system_context_state().unwrap_or_default();
+        let new_appends = appends
+            .iter()
+            .filter(|append| {
+                append.idempotency_key.as_ref().is_none_or(|_| {
+                    !current_system_prompt.contains(&render_system_context_block(append))
+                })
+            })
+            .cloned()
+            .collect::<Vec<_>>();
+        if new_appends.is_empty() {
+            return;
+        }
+
+        let rendered = new_appends
             .iter()
             .map(render_system_context_block)
             .collect::<Vec<_>>()
@@ -706,11 +728,19 @@ impl Session {
         };
         self.set_system_prompt(next);
 
-        let mut state = self.system_context_state().unwrap_or_default();
-        for append in appends {
-            if !state.applied.contains(append) {
-                state.applied.push(append.clone());
+        for append in new_appends {
+            if let Some(key) = append.idempotency_key.as_ref() {
+                if state
+                    .applied
+                    .iter()
+                    .any(|applied| applied.idempotency_key.as_ref() == Some(key))
+                {
+                    continue;
+                }
+            } else if state.applied.contains(&append) {
+                continue;
             }
+            state.applied.push(append);
         }
         if let Err(err) = self.set_system_context_state(state) {
             tracing::warn!(error = %err, "failed to persist applied system-context state");
@@ -1570,5 +1600,42 @@ mod tests {
             .system_context_state()
             .expect("append should persist typed context state");
         assert_eq!(state.applied, vec![append]);
+    }
+
+    #[test]
+    fn append_system_context_blocks_skips_duplicate_idempotency_key() {
+        let first = PendingSystemContextAppend {
+            text: "Authoritative peer token is birch seventeen.".to_string(),
+            source: Some("peer_response_terminal:analyst:req-1".to_string()),
+            idempotency_key: Some("req-1".to_string()),
+            accepted_at: SystemTime::UNIX_EPOCH,
+        };
+        let duplicate = PendingSystemContextAppend {
+            accepted_at: SystemTime::UNIX_EPOCH + std::time::Duration::from_secs(1),
+            ..first.clone()
+        };
+        let mut session = Session::new();
+
+        session.append_system_context_blocks(std::slice::from_ref(&first));
+        session.append_system_context_blocks(std::slice::from_ref(&duplicate));
+
+        let state = session
+            .system_context_state()
+            .expect("append should persist typed context state");
+        assert_eq!(state.applied, vec![first]);
+        let system_prompt = session
+            .messages()
+            .first()
+            .and_then(|message| match message {
+                Message::System(system) => Some(system.content.as_str()),
+                _ => None,
+            })
+            .unwrap_or_default();
+        assert_eq!(
+            system_prompt
+                .matches("Authoritative peer token is birch seventeen.")
+                .count(),
+            1
+        );
     }
 }

--- a/meerkat-core/src/session_recovery.rs
+++ b/meerkat-core/src/session_recovery.rs
@@ -337,6 +337,7 @@ pub fn build_recovered_session(
         runtime_build_mode: context
             .runtime_build_mode
             .unwrap_or(RuntimeBuildMode::StandaloneEphemeral),
+        initial_turn_metadata: None,
     };
     build.apply_persisted_mob_operator_access(
         overrides

--- a/meerkat-mcp-server/src/lib.rs
+++ b/meerkat-mcp-server/src/lib.rs
@@ -3088,6 +3088,7 @@ async fn handle_meerkat_resume(
 
             skill_references: skill_references.clone(),
             flow_tool_overlay: input.flow_tool_overlay.clone().map(Into::into),
+            pre_turn_context_appends: Vec::new(),
             turn_metadata: Some(meerkat_runtime::runtime_stamped_prompt_turn_metadata(None)),
         };
         match state.service.start_turn(&session_id, turn_req).await {

--- a/meerkat-mcp-server/src/lib.rs
+++ b/meerkat-mcp-server/src/lib.rs
@@ -2700,6 +2700,7 @@ async fn handle_meerkat_run(
             .then(|| recoverable_callback_tool_defs(&input.tools)),
         llm_client_override: None,
         runtime_build_mode: meerkat_core::RuntimeBuildMode::SessionOwned(bindings),
+        initial_turn_metadata: Some(meerkat_runtime::runtime_stamped_prompt_turn_metadata(None)),
         override_builtins: ToolCategoryOverride::from_override(input.enable_builtins),
         override_shell: ToolCategoryOverride::from_override(enable_shell_override),
         override_memory: ToolCategoryOverride::from_override(input.enable_memory),
@@ -2989,6 +2990,7 @@ async fn handle_meerkat_resume(
             .then(|| recoverable_callback_tool_defs(&input.tools)),
         llm_client_override: None,
         runtime_build_mode: meerkat_core::RuntimeBuildMode::SessionOwned(resume_bindings),
+        initial_turn_metadata: Some(meerkat_runtime::runtime_stamped_prompt_turn_metadata(None)),
         override_builtins: ToolCategoryOverride::from_override(enable_builtins_override),
         override_shell: ToolCategoryOverride::from_override(enable_shell_override),
         override_memory: ToolCategoryOverride::from_override(input.enable_memory),
@@ -3086,7 +3088,7 @@ async fn handle_meerkat_resume(
 
             skill_references: skill_references.clone(),
             flow_tool_overlay: input.flow_tool_overlay.clone().map(Into::into),
-            turn_metadata: None,
+            turn_metadata: Some(meerkat_runtime::runtime_stamped_prompt_turn_metadata(None)),
         };
         match state.service.start_turn(&session_id, turn_req).await {
             Ok(run_result) => Ok(run_result),

--- a/meerkat-mcp-server/src/runtime_ingress.rs
+++ b/meerkat-mcp-server/src/runtime_ingress.rs
@@ -504,18 +504,17 @@ async fn apply_runtime_turn(
             .await;
     }
 
-    let terminal_context_appends = if primitive.is_peer_response_terminal_context_and_run() {
-        let RunPrimitive::StagedInput(staged) = primitive else {
-            unreachable!("terminal peer-response apply helper only matches staged inputs");
-        };
-        pending_system_context_appends(&staged.context_appends)
-    } else {
-        Vec::new()
-    };
-
     let prompt = primitive.extract_content_input();
     let boundary = primitive.apply_boundary();
     let contributing_input_ids = primitive.contributing_input_ids().to_vec();
+    let pre_turn_context_appends = match primitive {
+        RunPrimitive::StagedInput(staged)
+            if primitive.is_peer_response_terminal_context_and_run() =>
+        {
+            pending_system_context_appends(&staged.context_appends)
+        }
+        _ => Vec::new(),
+    };
     let queued_context = state
         .take_turn_context_for_inputs(&contributing_input_ids)
         .await;
@@ -535,38 +534,9 @@ async fn apply_runtime_turn(
         flow_tool_overlay: primitive
             .turn_metadata()
             .and_then(|meta| meta.flow_tool_overlay.clone()),
+        pre_turn_context_appends: pre_turn_context_appends.clone(),
         turn_metadata: primitive.turn_metadata().cloned(),
     };
-
-    if !terminal_context_appends.is_empty() {
-        match context
-            .service
-            .apply_runtime_system_context_for_turn(session_id, terminal_context_appends.clone())
-            .await
-        {
-            Ok(()) => {}
-            Err(SessionError::NotFound { .. }) => {
-                Box::pin(context.rematerialize_persisted_session(session_id, state.clone()))
-                    .await
-                    .map(|_| ())?;
-                context
-                    .service
-                    .apply_runtime_system_context_for_turn(session_id, terminal_context_appends)
-                    .await?;
-                return context
-                    .service
-                    .apply_runtime_turn_outcome(
-                        session_id,
-                        run_id,
-                        turn_request,
-                        boundary,
-                        contributing_input_ids,
-                    )
-                    .await;
-            }
-            Err(error) => return Err(error),
-        }
-    }
 
     match context
         .service
@@ -584,12 +554,6 @@ async fn apply_runtime_turn(
             Box::pin(context.rematerialize_persisted_session(session_id, state.clone()))
                 .await
                 .map(|_| ())?;
-            if !terminal_context_appends.is_empty() {
-                context
-                    .service
-                    .apply_runtime_system_context_for_turn(session_id, terminal_context_appends)
-                    .await?;
-            }
             context
                 .service
                 .apply_runtime_turn_outcome(
@@ -607,6 +571,7 @@ async fn apply_runtime_turn(
                         flow_tool_overlay: primitive
                             .turn_metadata()
                             .and_then(|meta| meta.flow_tool_overlay.clone()),
+                        pre_turn_context_appends,
                         turn_metadata: primitive.turn_metadata().cloned(),
                     },
                     boundary,

--- a/meerkat-mcp-server/src/runtime_ingress.rs
+++ b/meerkat-mcp-server/src/runtime_ingress.rs
@@ -471,6 +471,10 @@ fn pending_system_context_appends(
         .collect()
 }
 
+fn should_apply_context_without_turn(primitive: &RunPrimitive) -> bool {
+    primitive.is_context_only_apply_without_turn()
+}
+
 async fn apply_runtime_turn(
     context: &McpRuntimeIngressContext,
     state: &Arc<McpRuntimeSessionState>,
@@ -490,10 +494,11 @@ async fn apply_runtime_turn(
         };
         return context
             .service
-            .apply_runtime_context_appends(
+            .apply_runtime_context_appends_with_boundary(
                 session_id,
                 run_id,
                 pending_system_context_appends(&staged.context_appends),
+                primitive.apply_boundary(),
                 staged.contributing_input_ids.clone(),
             )
             .await;
@@ -698,6 +703,15 @@ mod tests {
         })
     }
 
+    fn context_append() -> ConversationContextAppend {
+        ConversationContextAppend {
+            key: "peer_response_terminal:analyst:req-1".to_string(),
+            content: CoreRenderable::Text {
+                text: "done".to_string(),
+            },
+        }
+    }
+
     #[tokio::test]
     async fn mcp_runtime_ingress_rejects_malformed_terminal_peer_response_intent() {
         let temp = tempfile::tempdir().expect("tempdir");
@@ -731,5 +745,43 @@ mod tests {
             error.to_string().contains("requires RunStart boundary"),
             "unexpected rejection reason: {error}"
         );
+    }
+
+    #[test]
+    fn mcp_context_only_shortcut_excludes_terminal_peer_response() {
+        let primitive = RunPrimitive::StagedInput(StagedRunInput {
+            boundary: RunApplyBoundary::RunStart,
+            appends: Vec::new(),
+            context_appends: vec![context_append()],
+            contributing_input_ids: vec![InputId::new()],
+            turn_metadata: Some(RuntimeTurnMetadata {
+                execution_kind: Some(RuntimeExecutionKind::ContentTurn),
+                peer_response_terminal_apply_intent: Some(
+                    PeerResponseTerminalApplyIntent::AppendContextAndRun,
+                ),
+                ..Default::default()
+            }),
+        });
+
+        assert!(
+            !should_apply_context_without_turn(&primitive),
+            "terminal peer responses must append context and run a requester reaction turn"
+        );
+    }
+
+    #[test]
+    fn mcp_context_only_shortcut_keeps_plain_context_append() {
+        let primitive = RunPrimitive::StagedInput(StagedRunInput {
+            boundary: RunApplyBoundary::RunCheckpoint,
+            appends: Vec::new(),
+            context_appends: vec![context_append()],
+            contributing_input_ids: vec![InputId::new()],
+            turn_metadata: Some(RuntimeTurnMetadata {
+                execution_kind: Some(RuntimeExecutionKind::ContentTurn),
+                ..Default::default()
+            }),
+        });
+
+        assert!(should_apply_context_without_turn(&primitive));
     }
 }

--- a/meerkat-mcp-server/src/schedule_host.rs
+++ b/meerkat-mcp-server/src/schedule_host.rs
@@ -200,6 +200,7 @@ impl McpScheduleContext {
             blob_store_override: None,
             mob_tools: None,
             runtime_build_mode: meerkat_core::RuntimeBuildMode::SessionOwned(runtime_bindings),
+            initial_turn_metadata: None,
         };
 
         let request = CreateSessionRequest {

--- a/meerkat-mob-mcp/src/lib.rs
+++ b/meerkat-mob-mcp/src/lib.rs
@@ -3720,6 +3720,7 @@ mod tests {
                     event_tx: None,
                     skill_references: None,
                     flow_tool_overlay: None,
+                    pre_turn_context_appends: Vec::new(),
                     turn_metadata: None,
                 },
             )
@@ -3906,6 +3907,7 @@ mod tests {
                     event_tx: None,
                     skill_references: None,
                     flow_tool_overlay: None,
+                    pre_turn_context_appends: Vec::new(),
                     turn_metadata: None,
                 },
             )
@@ -5377,6 +5379,7 @@ mod tests {
                 event_tx: None,
                 skill_references: None,
                 flow_tool_overlay: None,
+                pre_turn_context_appends: Vec::new(),
                 turn_metadata: None,
             },
             meerkat_core::lifecycle::run_primitive::RunApplyBoundary::RunStart,

--- a/meerkat-mob/src/runtime/actor.rs
+++ b/meerkat-mob/src/runtime/actor.rs
@@ -1964,6 +1964,7 @@ impl MobActor {
 
                                 skill_references: None,
                                 flow_tool_overlay: None,
+                                pre_turn_context_appends: Vec::new(),
                                 turn_metadata: None,
 
                             },
@@ -9156,6 +9157,7 @@ impl MobActor {
                     event_tx: None,
                     skill_references: None,
                     flow_tool_overlay: None,
+                    pre_turn_context_appends: Vec::new(),
                     turn_metadata: None,
                 };
                 self.provisioner.start_turn(&entry.member_ref, req).await?;

--- a/meerkat-mob/src/runtime/actor_turn_executor.rs
+++ b/meerkat-mob/src/runtime/actor_turn_executor.rs
@@ -367,6 +367,7 @@ impl FlowTurnExecutor for ActorFlowTurnExecutor {
                             event_tx: Some(event_tx),
                             skill_references: None,
                             flow_tool_overlay,
+                            pre_turn_context_appends: Vec::new(),
                             turn_metadata: None,
                         },
                     )

--- a/meerkat-mob/src/runtime/builder.rs
+++ b/meerkat-mob/src/runtime/builder.rs
@@ -1537,6 +1537,7 @@ impl MobBuilder {
                                 event_tx: None,
                                 skill_references: None,
                                 flow_tool_overlay: None,
+                                pre_turn_context_appends: Vec::new(),
                                 turn_metadata: None,
                             },
                         )

--- a/meerkat-mob/src/runtime/provisioner.rs
+++ b/meerkat-mob/src/runtime/provisioner.rs
@@ -777,20 +777,15 @@ impl CoreExecutor for MobSessionRuntimeExecutor {
                 .map_err(|err| CoreExecutorError::apply_failed_runtime_context(err.to_string()));
         }
 
-        if primitive.is_peer_response_terminal_context_and_run() {
-            let RunPrimitive::StagedInput(staged) = &primitive else {
-                unreachable!("terminal peer-response apply intent only matches staged primitives");
-            };
-            self.session_service
-                .apply_runtime_system_context_for_turn(
-                    &self.bridge_session_id,
-                    pending_system_context_appends_for_runtime_executor(&staged.context_appends),
-                )
-                .await
-                .map_err(|err| CoreExecutorError::apply_failed_runtime_context(err.to_string()))?;
-        }
-
         let contributing_input_ids = primitive.contributing_input_ids().to_vec();
+        let pre_turn_context_appends = match &primitive {
+            RunPrimitive::StagedInput(staged)
+                if primitive.is_peer_response_terminal_context_and_run() =>
+            {
+                pending_system_context_appends_for_runtime_executor(&staged.context_appends)
+            }
+            _ => Vec::new(),
+        };
         let queued_context = self
             .state
             .take_turn_context_for_inputs(&contributing_input_ids)
@@ -812,6 +807,7 @@ impl CoreExecutor for MobSessionRuntimeExecutor {
             flow_tool_overlay: primitive
                 .turn_metadata()
                 .and_then(|meta| meta.flow_tool_overlay.clone()),
+            pre_turn_context_appends,
             turn_metadata: primitive.turn_metadata().cloned(),
         };
 

--- a/meerkat-mob/src/runtime/provisioner.rs
+++ b/meerkat-mob/src/runtime/provisioner.rs
@@ -140,6 +140,19 @@ pub struct SessionBackend {
 }
 
 #[cfg(feature = "runtime-adapter")]
+fn stamp_eager_session_owned_initial_turn_metadata(req: &mut CreateSessionRequest) {
+    if req.initial_turn != meerkat_core::service::InitialTurnPolicy::RunImmediately {
+        return;
+    }
+    let build = req
+        .build
+        .get_or_insert_with(meerkat_core::service::SessionBuildOptions::default);
+    build.initial_turn_metadata = Some(meerkat_runtime::runtime_stamped_prompt_turn_metadata(
+        build.initial_turn_metadata.take(),
+    ));
+}
+
+#[cfg(feature = "runtime-adapter")]
 impl SessionBackend {
     pub fn new(
         session_service: Arc<dyn MobSessionService>,
@@ -640,6 +653,48 @@ mod tests {
         assert_eq!(spec.peer_id.to_string(), peer_id_str);
         assert_eq!(spec.address.to_string(), "tcp://example.invalid/member-1");
     }
+
+    #[cfg(feature = "runtime-adapter")]
+    #[test]
+    fn session_owned_eager_member_create_gets_runtime_execution_kind_stamp() {
+        let mut req = meerkat_core::service::CreateSessionRequest {
+            model: "gpt-5.4".to_string(),
+            prompt: "hello".to_string().into(),
+            render_metadata: None,
+            system_prompt: None,
+            max_tokens: None,
+            event_tx: None,
+            skill_references: None,
+            initial_turn: meerkat_core::service::InitialTurnPolicy::RunImmediately,
+            deferred_prompt_policy: meerkat_core::service::DeferredPromptPolicy::Discard,
+            build: Some(meerkat_core::service::SessionBuildOptions {
+                initial_turn_metadata: Some(
+                    meerkat_core::lifecycle::run_primitive::RuntimeTurnMetadata {
+                        handling_mode: Some(meerkat_core::types::HandlingMode::Queue),
+                        ..Default::default()
+                    },
+                ),
+                ..Default::default()
+            }),
+            labels: None,
+        };
+
+        super::stamp_eager_session_owned_initial_turn_metadata(&mut req);
+
+        let metadata = req
+            .build
+            .as_ref()
+            .and_then(|build| build.initial_turn_metadata.as_ref())
+            .expect("eager runtime-owned member create should be stamped");
+        assert_eq!(
+            metadata.execution_kind,
+            Some(meerkat_core::lifecycle::RuntimeExecutionKind::ContentTurn)
+        );
+        assert_eq!(
+            metadata.handling_mode,
+            Some(meerkat_core::types::HandlingMode::Queue)
+        );
+    }
 }
 
 #[cfg(feature = "runtime-adapter")]
@@ -930,6 +985,7 @@ impl MobProvisioner for SessionBackend {
                 build.runtime_build_mode =
                     meerkat_core::runtime_epoch::RuntimeBuildMode::SessionOwned(bindings);
             }
+            stamp_eager_session_owned_initial_turn_metadata(&mut req.create_session);
             Some(member_bridge_session_id)
         } else {
             None

--- a/meerkat-mob/src/runtime/tests.rs
+++ b/meerkat-mob/src/runtime/tests.rs
@@ -7643,6 +7643,7 @@ async fn test_flow_step_tool_overlay_is_step_scoped() {
                 event_tx: None,
                 skill_references: None,
                 flow_tool_overlay: None,
+                pre_turn_context_appends: Vec::new(),
                 turn_metadata: None,
             },
         )
@@ -19432,6 +19433,27 @@ impl MobSessionService for RuntimeBackedRealCommsSessionService {
         boundary: meerkat_core::lifecycle::run_primitive::RunApplyBoundary,
         contributing_input_ids: Vec<meerkat_core::InputId>,
     ) -> Result<meerkat_core::lifecycle::core_executor::CoreApplyOutput, SessionError> {
+        let pre_turn_context_appends = req.pre_turn_context_appends;
+        if !pre_turn_context_appends.is_empty() {
+            for append in pre_turn_context_appends {
+                self.append_system_context(
+                    session_id,
+                    AppendSystemContextRequest {
+                        text: append.text,
+                        source: append.source,
+                        idempotency_key: append.idempotency_key,
+                    },
+                )
+                .await
+                .map_err(|err| match err {
+                    SessionControlError::Session(err) => err,
+                    err => SessionError::Agent(meerkat_core::error::AgentError::InternalError(
+                        err.to_string(),
+                    )),
+                })?;
+            }
+        }
+
         self.applied_runtime_prompts
             .write()
             .await

--- a/meerkat-mob/src/tests/contracts.rs
+++ b/meerkat-mob/src/tests/contracts.rs
@@ -1124,6 +1124,7 @@ async fn contract_mob_001_keep_alive_session_stays_alive() {
                 event_tx: None,
                 skill_references: None,
                 flow_tool_overlay: None,
+                pre_turn_context_appends: Vec::new(),
                 turn_metadata: None,
             },
         )
@@ -1198,6 +1199,7 @@ async fn contract_mob_007_session_archive_removes_from_active_list() {
                 event_tx: None,
                 skill_references: None,
                 flow_tool_overlay: None,
+                pre_turn_context_appends: Vec::new(),
                 turn_metadata: None,
             },
         )

--- a/meerkat-rest/src/lib.rs
+++ b/meerkat-rest/src/lib.rs
@@ -586,10 +586,11 @@ async fn apply_runtime_turn(
         };
         return context
             .session_service
-            .apply_runtime_context_appends(
+            .apply_runtime_context_appends_with_boundary(
                 session_id,
                 run_id,
                 pending_system_context_appends(&staged.context_appends),
+                primitive.apply_boundary(),
                 staged.contributing_input_ids.clone(),
             )
             .await;
@@ -4755,6 +4756,81 @@ mod tests {
                 data: "AAAA".to_string(),
             },
         }])
+    }
+
+    #[tokio::test]
+    async fn rest_context_only_runtime_apply_preserves_run_checkpoint_boundary() {
+        let temp = TempDir::new().unwrap();
+        let mut state = AppState::load_from(temp.path().to_path_buf())
+            .await
+            .unwrap();
+        state.llm_client_override = Some(Arc::new(MockLlmClient));
+        let pre_session = Session::new();
+        let bindings = state
+            .runtime_adapter
+            .prepare_bindings(pre_session.id().clone())
+            .await
+            .expect("runtime bindings should prepare");
+        let create_result = state
+            .session_service
+            .create_session(SvcCreateSessionRequest {
+                model: state.default_model.to_string(),
+                prompt: "Hello".to_string().into(),
+                render_metadata: None,
+                system_prompt: None,
+                max_tokens: Some(state.max_tokens),
+                event_tx: None,
+                skill_references: None,
+                initial_turn: InitialTurnPolicy::Defer,
+                deferred_prompt_policy: DeferredPromptPolicy::Discard,
+                build: Some(SessionBuildOptions {
+                    resume_session: Some(pre_session),
+                    llm_client_override: state
+                        .llm_client_override
+                        .clone()
+                        .map(encode_llm_client_override_for_service),
+                    runtime_build_mode: meerkat_core::RuntimeBuildMode::SessionOwned(bindings),
+                    ..Default::default()
+                }),
+                labels: None,
+            })
+            .await
+            .expect("deferred session create should succeed");
+        let session_id = create_result.session_id;
+        let input_id = meerkat_core::lifecycle::InputId::new();
+        let primitive =
+            RunPrimitive::StagedInput(meerkat_core::lifecycle::run_primitive::StagedRunInput {
+                boundary: RunApplyBoundary::RunCheckpoint,
+                appends: Vec::new(),
+                context_appends: vec![ConversationContextAppend {
+                    key: "ctx-rest-checkpoint-boundary".to_string(),
+                    content: CoreRenderable::Text {
+                        text: "checkpoint-only runtime context".to_string(),
+                    },
+                }],
+                contributing_input_ids: vec![input_id.clone()],
+                turn_metadata: Some(
+                    meerkat_core::lifecycle::run_primitive::RuntimeTurnMetadata {
+                        execution_kind: Some(
+                            meerkat_core::lifecycle::RuntimeExecutionKind::ResumePending,
+                        ),
+                        ..Default::default()
+                    },
+                ),
+            });
+
+        let output = super::apply_runtime_turn(
+            &state.runtime_executor_context(),
+            &session_id,
+            meerkat_core::RunId::new(),
+            &primitive,
+            ContentInput::Text(String::new()),
+        )
+        .await
+        .expect("context-only apply should succeed");
+
+        assert_eq!(output.receipt.boundary, RunApplyBoundary::RunCheckpoint);
+        assert_eq!(output.receipt.contributing_input_ids, vec![input_id]);
     }
 
     #[tokio::test]

--- a/meerkat-rest/src/lib.rs
+++ b/meerkat-rest/src/lib.rs
@@ -595,19 +595,6 @@ async fn apply_runtime_turn(
             .await;
     }
 
-    if primitive.is_peer_response_terminal_context_and_run() {
-        let RunPrimitive::StagedInput(staged) = primitive else {
-            unreachable!("terminal peer-response apply intent only matches staged primitives");
-        };
-        context
-            .session_service
-            .apply_runtime_system_context_for_turn(
-                session_id,
-                pending_system_context_appends(&staged.context_appends),
-            )
-            .await?;
-    }
-
     let (event_tx, event_rx) = mpsc::channel::<EventEnvelope<AgentEvent>>(100);
     let forwarder = spawn_event_forwarder(
         event_rx,
@@ -615,6 +602,14 @@ async fn apply_runtime_turn(
         session_id.clone(),
         false,
     );
+    let pre_turn_context_appends = match primitive {
+        RunPrimitive::StagedInput(staged)
+            if primitive.is_peer_response_terminal_context_and_run() =>
+        {
+            pending_system_context_appends(&staged.context_appends)
+        }
+        _ => Vec::new(),
+    };
     // The turn-metadata keep_alive carrier is typed (`KeepAlivePolicy`); the
     // session recovery override and stored session metadata still track a
     // boolean. Collapse the typed per-turn policy into the boolean used by
@@ -652,6 +647,7 @@ async fn apply_runtime_turn(
         flow_tool_overlay: primitive
             .turn_metadata()
             .and_then(|meta| meta.flow_tool_overlay.clone()),
+        pre_turn_context_appends: pre_turn_context_appends.clone(),
         turn_metadata: primitive.turn_metadata().cloned(),
     };
 
@@ -766,6 +762,7 @@ async fn apply_runtime_turn(
                         flow_tool_overlay: primitive
                             .turn_metadata()
                             .and_then(|meta| meta.flow_tool_overlay.clone()),
+                        pre_turn_context_appends,
                         turn_metadata: primitive.turn_metadata().cloned(),
                     },
                     boundary,
@@ -6011,6 +6008,7 @@ mod tests {
 
                     skill_references: None,
                     flow_tool_overlay: None,
+                    pre_turn_context_appends: Vec::new(),
                     turn_metadata: None,
                 },
             )

--- a/meerkat-rest/src/lib.rs
+++ b/meerkat-rest/src/lib.rs
@@ -2892,6 +2892,7 @@ async fn create_session_inner(
         blob_store_override: None,
         mob_tools: None,
         runtime_build_mode: meerkat_core::RuntimeBuildMode::SessionOwned(bindings),
+        initial_turn_metadata: None,
     };
     build.apply_generated_create_only_mob_operator_access(ToolCategoryOverride::from_override(
         req.enable_mob,
@@ -3650,6 +3651,7 @@ async fn continue_session_inner(
             blob_store_override: None,
             mob_tools: None,
             runtime_build_mode: meerkat_core::RuntimeBuildMode::SessionOwned(bindings),
+            initial_turn_metadata: None,
         };
         build.apply_generated_create_only_mob_operator_access(ToolCategoryOverride::Inherit);
         let create_req = SvcCreateSessionRequest {

--- a/meerkat-rpc/src/session_executor.rs
+++ b/meerkat-rpc/src/session_executor.rs
@@ -309,20 +309,15 @@ impl CoreExecutor for MobRpcRuntimeExecutor {
                 .map_err(|err| CoreExecutorError::apply_failed_runtime_context(err.to_string()));
         }
 
-        if primitive.is_peer_response_terminal_context_and_run() {
-            let RunPrimitive::StagedInput(staged) = &primitive else {
-                unreachable!("terminal peer-response apply intent only matches staged primitives");
-            };
-            self.session_service
-                .apply_runtime_system_context_for_turn(
-                    &self.session_id,
-                    pending_system_context_appends_from_primitive(&staged.context_appends),
-                )
-                .await
-                .map_err(|err| CoreExecutorError::apply_failed_runtime_context(err.to_string()))?;
-        }
-
         let prompt = primitive.extract_content_input();
+        let pre_turn_context_appends = match &primitive {
+            RunPrimitive::StagedInput(staged)
+                if primitive.is_peer_response_terminal_context_and_run() =>
+            {
+                pending_system_context_appends_from_primitive(&staged.context_appends)
+            }
+            _ => Vec::new(),
+        };
         let (event_tx, mut event_rx) = mpsc::channel::<EventEnvelope<AgentEvent>>(128);
         let sink = self.notification_sink.clone();
         let sid = self.session_id.clone();
@@ -344,6 +339,7 @@ impl CoreExecutor for MobRpcRuntimeExecutor {
             flow_tool_overlay: primitive
                 .turn_metadata()
                 .and_then(|meta| meta.flow_tool_overlay.clone()),
+            pre_turn_context_appends,
             turn_metadata: primitive.turn_metadata().cloned(),
         };
 

--- a/meerkat-rpc/src/session_executor.rs
+++ b/meerkat-rpc/src/session_executor.rs
@@ -192,6 +192,7 @@ impl CoreExecutor for SessionRuntimeExecutor {
                     &self.session_id,
                     run_id,
                     pending_system_context_appends_from_primitive(&staged.context_appends),
+                    primitive.apply_boundary(),
                     staged.contributing_input_ids.clone(),
                 )
                 .await
@@ -299,10 +300,11 @@ impl CoreExecutor for MobRpcRuntimeExecutor {
             };
             return self
                 .session_service
-                .apply_runtime_context_appends(
+                .apply_runtime_context_appends_with_boundary(
                     &self.session_id,
                     run_id,
                     pending_system_context_appends_from_primitive(&staged.context_appends),
+                    primitive.apply_boundary(),
                     staged.contributing_input_ids.clone(),
                 )
                 .await

--- a/meerkat-rpc/src/session_runtime.rs
+++ b/meerkat-rpc/src/session_runtime.rs
@@ -836,7 +836,7 @@ impl SessionRuntime {
             provider_params,
             render_metadata: None,
             connection_ref,
-            execution_kind: None,
+            execution_kind: Some(meerkat_core::lifecycle::RuntimeExecutionKind::ContentTurn),
             peer_response_terminal_apply_intent: None,
         };
         (!metadata.is_empty()).then_some(metadata)
@@ -3217,6 +3217,12 @@ impl SessionRuntime {
                 .and_then(|session| session.session_metadata().map(|meta| meta.keep_alive))
                 .unwrap_or(false),
         };
+        let turn_metadata = Self::turn_metadata_from_overrides(
+            skill_references.clone(),
+            flow_tool_overlay.clone(),
+            additional_instructions.clone(),
+            overrides.as_ref(),
+        );
 
         let req = StartTurnRequest {
             prompt: turn_prompt.clone(),
@@ -3226,7 +3232,7 @@ impl SessionRuntime {
             event_tx: Some(event_tx.clone()),
             skill_references: skill_references.clone(),
             flow_tool_overlay: flow_tool_overlay.clone(),
-            turn_metadata: None,
+            turn_metadata,
         };
 
         if self.live_session_is_stale(session_id).await? {

--- a/meerkat-rpc/src/session_runtime.rs
+++ b/meerkat-rpc/src/session_runtime.rs
@@ -1829,13 +1829,20 @@ impl SessionRuntime {
         session_id: &SessionId,
         run_id: meerkat_core::lifecycle::RunId,
         appends: Vec<meerkat_core::PendingSystemContextAppend>,
+        boundary: RunApplyBoundary,
         contributing_input_ids: Vec<meerkat_core::lifecycle::InputId>,
     ) -> Result<
         meerkat_core::lifecycle::core_executor::CoreApplyOutput,
         meerkat_core::service::SessionError,
     > {
         self.service
-            .apply_runtime_context_appends(session_id, run_id, appends, contributing_input_ids)
+            .apply_runtime_context_appends_with_boundary(
+                session_id,
+                run_id,
+                appends,
+                boundary,
+                contributing_input_ids,
+            )
             .await
     }
 
@@ -2447,10 +2454,11 @@ impl SessionRuntime {
             };
             return self
                 .service
-                .apply_runtime_context_appends(
+                .apply_runtime_context_appends_with_boundary(
                     session_id,
                     run_id,
                     pending_system_context_appends(&staged.context_appends),
+                    primitive.apply_boundary(),
                     staged.contributing_input_ids.clone(),
                 )
                 .await
@@ -4899,6 +4907,71 @@ mod tests {
             llm_client_override: Some(Arc::new(SlowMockLlmClient::new(delay_ms))),
             ..AgentBuildConfig::new("claude-sonnet-4-5")
         }
+    }
+
+    #[tokio::test]
+    async fn context_only_runtime_apply_preserves_run_checkpoint_boundary() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let mut runtime = make_runtime(temp_factory(&temp), 10);
+        runtime.set_default_llm_client(Some(Arc::new(MockLlmClient)));
+
+        let session_id = runtime
+            .create_session(mock_build_config(), None, None)
+            .await
+            .expect("create_session");
+        let (initial_event_tx, _initial_event_rx) = mpsc::channel(100);
+        runtime
+            .start_turn(
+                &session_id,
+                "materialize runtime session".into(),
+                initial_event_tx,
+                None,
+                None,
+                None,
+                None,
+            )
+            .await
+            .expect("start_turn");
+        let input_id = meerkat_core::lifecycle::InputId::new();
+        let primitive =
+            RunPrimitive::StagedInput(meerkat_core::lifecycle::run_primitive::StagedRunInput {
+                boundary: RunApplyBoundary::RunCheckpoint,
+                appends: Vec::new(),
+                context_appends: vec![ConversationContextAppend {
+                    key: "ctx-rpc-checkpoint-boundary".to_string(),
+                    content: CoreRenderable::Text {
+                        text: "checkpoint-only runtime context".to_string(),
+                    },
+                }],
+                contributing_input_ids: vec![input_id.clone()],
+                turn_metadata: Some(
+                    meerkat_core::lifecycle::run_primitive::RuntimeTurnMetadata {
+                        execution_kind: Some(
+                            meerkat_core::lifecycle::RuntimeExecutionKind::ResumePending,
+                        ),
+                        ..Default::default()
+                    },
+                ),
+            });
+        let (event_tx, _event_rx) = mpsc::channel(100);
+
+        let output = runtime
+            .apply_runtime_turn(
+                &session_id,
+                RunId::new(),
+                &primitive,
+                ContentInput::Text(String::new()),
+                event_tx,
+                None,
+                None,
+                None,
+                None,
+            )
+            .await
+            .expect("context-only apply should succeed");
+
+        assert_eq!(output.receipt.boundary, RunApplyBoundary::RunCheckpoint);
+        assert_eq!(output.receipt.contributing_input_ids, vec![input_id]);
     }
 
     #[tokio::test]

--- a/meerkat-rpc/src/session_runtime.rs
+++ b/meerkat-rpc/src/session_runtime.rs
@@ -5692,45 +5692,42 @@ mod tests {
             let _ = handle.wait().await;
         }
 
-        let started = tokio::time::timeout(std::time::Duration::from_secs(3), events.next())
-            .await
-            .expect("run_started timeout")
-            .expect("run_started event should exist");
-        match started.payload {
-            AgentEvent::RunStarted { prompt, .. } => {
-                let normalized = prompt.text_content().to_lowercase();
-                assert!(
-                    normalized.contains(
-                        "peer_response_terminal:analyst-rt:018f6f79-7a82-7c4e-a552-a3b86f9630f1"
-                    ),
-                    "run_started prompt should expose runtime system-context source: {normalized}"
-                );
-                assert!(
-                    normalized.contains("birch seventeen"),
-                    "run_started prompt should expose authoritative terminal peer payload: {normalized}"
-                );
+        let (result, usage) = tokio::time::timeout(std::time::Duration::from_secs(3), async {
+            let mut saw_context_started = false;
+            while let Some(event) = events.next().await {
+                match event.payload {
+                    AgentEvent::RunStarted { prompt, .. } => {
+                        let normalized = prompt.text_content().to_lowercase();
+                        if normalized.contains(
+                            "peer_response_terminal:analyst-rt:018f6f79-7a82-7c4e-a552-a3b86f9630f1",
+                        ) {
+                            assert!(
+                                normalized.contains("birch seventeen"),
+                                "run_started prompt should expose authoritative terminal peer payload: {normalized}"
+                            );
+                            saw_context_started = true;
+                        }
+                    }
+                    AgentEvent::RunCompleted { result, usage, .. } if saw_context_started => {
+                        return (result, usage);
+                    }
+                    _ => {}
+                }
             }
-            other => panic!("expected run_started, got {other:?}"),
-        }
+            panic!("committed runtime context lifecycle events did not arrive");
+        })
+        .await
+        .expect("runtime context lifecycle timeout");
 
-        let completed = tokio::time::timeout(std::time::Duration::from_secs(3), events.next())
-            .await
-            .expect("run_completed timeout")
-            .expect("run_completed event should exist");
-        match completed.payload {
-            AgentEvent::RunCompleted { result, usage, .. } => {
-                assert!(
-                    result.is_empty(),
-                    "context-only runtime apply should not synthesize assistant output: {result:?}"
-                );
-                assert_eq!(
-                    usage,
-                    meerkat_core::types::Usage::default(),
-                    "context-only runtime apply should not report model usage"
-                );
-            }
-            other => panic!("expected run_completed, got {other:?}"),
-        }
+        assert!(
+            result.is_empty(),
+            "context-only runtime apply should not synthesize assistant output: {result:?}"
+        );
+        assert_eq!(
+            usage,
+            meerkat_core::types::Usage::default(),
+            "context-only runtime apply should not report model usage"
+        );
     }
 
     #[cfg(feature = "comms")]
@@ -5851,26 +5848,38 @@ mod tests {
         .await
         .expect("send terminal peer response");
 
-        let started = tokio::time::timeout(std::time::Duration::from_secs(5), events.next())
-            .await
-            .expect("run_started timeout")
-            .expect("run_started event should exist");
-        assert!(matches!(started.payload, AgentEvent::RunStarted { .. }));
-
-        let completed = tokio::time::timeout(std::time::Duration::from_secs(5), events.next())
-            .await
-            .expect("run_completed timeout")
-            .expect("run_completed event should exist");
-        match completed.payload {
-            AgentEvent::RunCompleted { result, usage, .. } => {
-                assert!(
-                    result.is_empty(),
-                    "context-only drain apply should not synthesize assistant output"
-                );
-                assert_eq!(usage, meerkat_core::types::Usage::default());
+        let (result, usage) = tokio::time::timeout(std::time::Duration::from_secs(5), async {
+            let mut saw_context_started = false;
+            while let Some(event) = events.next().await {
+                match event.payload {
+                    AgentEvent::RunStarted { prompt, .. } => {
+                        let normalized = prompt.text_content().to_lowercase();
+                        if normalized.contains("peer_response_terminal:")
+                            && normalized.contains("birch seventeen")
+                        {
+                            assert!(
+                                normalized.contains("checksum_token"),
+                                "run_started prompt should expose authoritative terminal peer payload: {normalized}"
+                            );
+                            saw_context_started = true;
+                        }
+                    }
+                    AgentEvent::RunCompleted { result, usage, .. } if saw_context_started => {
+                        return (result, usage);
+                    }
+                    _ => {}
+                }
             }
-            other => panic!("expected run_completed, got {other:?}"),
-        }
+            panic!("committed drain context lifecycle events did not arrive");
+        })
+        .await
+        .expect("runtime context lifecycle timeout");
+
+        assert!(
+            result.is_empty(),
+            "context-only drain apply should not synthesize assistant output"
+        );
+        assert_eq!(usage, meerkat_core::types::Usage::default());
     }
 
     #[tokio::test]

--- a/meerkat-rpc/src/session_runtime.rs
+++ b/meerkat-rpc/src/session_runtime.rs
@@ -842,6 +842,20 @@ impl SessionRuntime {
         (!metadata.is_empty()).then_some(metadata)
     }
 
+    fn runtime_stamped_prompt_turn_metadata_from_overrides(
+        skill_references: Option<Vec<meerkat_core::skills::SkillKey>>,
+        flow_tool_overlay: Option<meerkat_core::service::TurnToolOverlay>,
+        additional_instructions: Option<Vec<String>>,
+        overrides: Option<&crate::handlers::turn::TurnOverrides>,
+    ) -> meerkat_core::lifecycle::run_primitive::RuntimeTurnMetadata {
+        meerkat_runtime::runtime_stamped_prompt_turn_metadata(Self::turn_metadata_from_overrides(
+            skill_references,
+            flow_tool_overlay,
+            additional_instructions,
+            overrides,
+        ))
+    }
+
     pub(crate) fn turn_overrides_from_metadata(
         metadata: Option<&meerkat_core::lifecycle::run_primitive::RuntimeTurnMetadata>,
     ) -> Option<crate::handlers::turn::TurnOverrides> {
@@ -3111,6 +3125,13 @@ impl SessionRuntime {
             build.instance_id = build.instance_id.or_else(|| self.instance_id.clone());
             build.backend = build.backend.or_else(|| self.backend.clone());
             build.config_generation = build.config_generation.or(runtime_generation);
+            build.initial_turn_metadata =
+                Some(Self::runtime_stamped_prompt_turn_metadata_from_overrides(
+                    skill_references.clone(),
+                    flow_tool_overlay.clone(),
+                    additional_instructions.clone(),
+                    overrides.as_ref(),
+                ));
 
             let event_tx = self
                 .pending_session_event_fanout_tx(session_id, event_tx)
@@ -3217,12 +3238,12 @@ impl SessionRuntime {
                 .and_then(|session| session.session_metadata().map(|meta| meta.keep_alive))
                 .unwrap_or(false),
         };
-        let turn_metadata = Self::turn_metadata_from_overrides(
+        let turn_metadata = Some(Self::runtime_stamped_prompt_turn_metadata_from_overrides(
             skill_references.clone(),
             flow_tool_overlay.clone(),
             additional_instructions.clone(),
             overrides.as_ref(),
-        );
+        ));
 
         let req = StartTurnRequest {
             prompt: turn_prompt.clone(),
@@ -4692,6 +4713,34 @@ mod tests {
                 )),
                 Arc::new(meerkat_runtime::RuntimeInteractionStreamHandle::new(dsl)),
             ),
+        );
+    }
+
+    #[test]
+    fn turn_metadata_from_overrides_does_not_stamp_execution_kind() {
+        let metadata = SessionRuntime::turn_metadata_from_overrides(
+            None,
+            None,
+            Some(vec!["runtime note".to_string()]),
+            None,
+        )
+        .expect("additional instructions should produce metadata");
+
+        assert_eq!(metadata.execution_kind, None);
+    }
+
+    #[test]
+    fn runtime_prompt_metadata_helper_stamps_execution_kind() {
+        let metadata = SessionRuntime::runtime_stamped_prompt_turn_metadata_from_overrides(
+            None,
+            None,
+            Some(vec!["runtime note".to_string()]),
+            None,
+        );
+
+        assert_eq!(
+            metadata.execution_kind,
+            Some(meerkat_core::lifecycle::RuntimeExecutionKind::ContentTurn)
         );
     }
 

--- a/meerkat-rpc/src/session_runtime.rs
+++ b/meerkat-rpc/src/session_runtime.rs
@@ -836,7 +836,7 @@ impl SessionRuntime {
             provider_params,
             render_metadata: None,
             connection_ref,
-            execution_kind: Some(meerkat_core::lifecycle::RuntimeExecutionKind::ContentTurn),
+            execution_kind: None,
             peer_response_terminal_apply_intent: None,
         };
         (!metadata.is_empty()).then_some(metadata)
@@ -847,12 +847,14 @@ impl SessionRuntime {
         flow_tool_overlay: Option<meerkat_core::service::TurnToolOverlay>,
         additional_instructions: Option<Vec<String>>,
         overrides: Option<&crate::handlers::turn::TurnOverrides>,
+        provider_hint: Option<&str>,
     ) -> meerkat_core::lifecycle::run_primitive::RuntimeTurnMetadata {
         meerkat_runtime::runtime_stamped_prompt_turn_metadata(Self::turn_metadata_from_overrides(
             skill_references,
             flow_tool_overlay,
             additional_instructions,
             overrides,
+            provider_hint,
         ))
     }
 
@@ -2455,18 +2457,14 @@ impl SessionRuntime {
                 .map_err(session_error_to_rpc);
         }
 
-        if primitive.is_peer_response_terminal_context_and_run() {
-            let RunPrimitive::StagedInput(staged) = primitive else {
-                unreachable!("terminal peer-response apply intent only matches staged primitives");
-            };
-            self.service
-                .apply_runtime_system_context_for_turn(
-                    session_id,
-                    pending_system_context_appends(&staged.context_appends),
-                )
-                .await
-                .map_err(session_error_to_rpc)?;
-        }
+        let pre_turn_context_appends = match primitive {
+            RunPrimitive::StagedInput(staged)
+                if primitive.is_peer_response_terminal_context_and_run() =>
+            {
+                pending_system_context_appends(&staged.context_appends)
+            }
+            _ => Vec::new(),
+        };
 
         let effective_identity = self
             .effective_llm_identity_for_turn(session_id, overrides.as_ref())
@@ -2540,6 +2538,7 @@ impl SessionRuntime {
 
                 skill_references: skill_references.clone(),
                 flow_tool_overlay: flow_tool_overlay.clone(),
+                pre_turn_context_appends: pre_turn_context_appends.clone(),
                 turn_metadata: primitive.turn_metadata().cloned(),
             };
 
@@ -2768,6 +2767,7 @@ impl SessionRuntime {
 
                         skill_references,
                         flow_tool_overlay,
+                        pre_turn_context_appends: pre_turn_context_appends.clone(),
                         turn_metadata: primitive.turn_metadata().cloned(),
                     },
                     match primitive {
@@ -2828,6 +2828,7 @@ impl SessionRuntime {
 
                     skill_references,
                     flow_tool_overlay,
+                    pre_turn_context_appends,
                     turn_metadata: primitive.turn_metadata().cloned(),
                 },
                 match primitive {
@@ -3125,12 +3126,17 @@ impl SessionRuntime {
             build.instance_id = build.instance_id.or_else(|| self.instance_id.clone());
             build.backend = build.backend.or_else(|| self.backend.clone());
             build.config_generation = build.config_generation.or(runtime_generation);
+            let initial_turn_provider_hint = build_config
+                .provider
+                .or_else(|| meerkat_core::Provider::infer_from_model(&build_config.model))
+                .map(|provider| provider.as_str());
             build.initial_turn_metadata =
                 Some(Self::runtime_stamped_prompt_turn_metadata_from_overrides(
                     skill_references.clone(),
                     flow_tool_overlay.clone(),
                     additional_instructions.clone(),
                     overrides.as_ref(),
+                    initial_turn_provider_hint,
                 ));
 
             let event_tx = self
@@ -3243,6 +3249,7 @@ impl SessionRuntime {
             flow_tool_overlay.clone(),
             additional_instructions.clone(),
             overrides.as_ref(),
+            overrides.as_ref().and_then(|ov| ov.provider.as_deref()),
         ));
 
         let req = StartTurnRequest {
@@ -3253,6 +3260,7 @@ impl SessionRuntime {
             event_tx: Some(event_tx.clone()),
             skill_references: skill_references.clone(),
             flow_tool_overlay: flow_tool_overlay.clone(),
+            pre_turn_context_appends: Vec::new(),
             turn_metadata,
         };
 
@@ -4723,6 +4731,7 @@ mod tests {
             None,
             Some(vec!["runtime note".to_string()]),
             None,
+            None,
         )
         .expect("additional instructions should produce metadata");
 
@@ -4735,6 +4744,7 @@ mod tests {
             None,
             None,
             Some(vec!["runtime note".to_string()]),
+            None,
             None,
         );
 

--- a/meerkat-runtime/src/driver/ephemeral.rs
+++ b/meerkat-runtime/src/driver/ephemeral.rs
@@ -684,6 +684,18 @@ impl EphemeralRuntimeDriver {
         )
     }
 
+    pub(crate) fn recover_terminal_input_lifecycle(
+        &mut self,
+        work_id: &InputId,
+        recovered_seed: &InputStateSeed,
+    ) -> Result<(), RuntimeDriverError> {
+        debug_assert!(
+            recovered_seed.phase.is_terminal(),
+            "terminal recovery path must only be used for terminal input phases"
+        );
+        self.apply_recovered_lifecycle(work_id, recovered_seed, None)
+    }
+
     fn lifecycle_to_input_phase(lifecycle: InputLifecycleState) -> mm_dsl::InputPhase {
         match lifecycle {
             // The DSL never represents the pre-admission `Accepted` state —
@@ -722,8 +734,6 @@ impl EphemeralRuntimeDriver {
         request_id: Option<&RequestId>,
         reservation_key: Option<&ReservationKey>,
     ) -> Result<(), RuntimeDriverError> {
-        let key = Self::dsl_key(work_id);
-        let lifecycle_state = recovered_seed.phase;
         self.record_admission_metadata(
             work_id,
             content_shape,
@@ -735,6 +745,17 @@ impl EphemeralRuntimeDriver {
             request_id,
             reservation_key,
         );
+        self.apply_recovered_lifecycle(work_id, recovered_seed, Some(handling_mode))
+    }
+
+    fn apply_recovered_lifecycle(
+        &mut self,
+        work_id: &InputId,
+        recovered_seed: &InputStateSeed,
+        handling_mode: Option<HandlingMode>,
+    ) -> Result<(), RuntimeDriverError> {
+        let key = Self::dsl_key(work_id);
+        let lifecycle_state = recovered_seed.phase;
         let (terminal_kind, superseded_by, aggregate_id, abandon_reason, abandon_attempt_count) =
             match recovered_seed.terminal_outcome.clone() {
                 Some(InputTerminalOutcome::Consumed) => (
@@ -768,7 +789,8 @@ impl EphemeralRuntimeDriver {
                 None => (None, None, None, None, 0),
             };
         let lane = matches!(lifecycle_state, InputLifecycleState::Queued)
-            .then(|| mm_dsl::InputLane::from(handling_mode));
+            .then(|| handling_mode.map(mm_dsl::InputLane::from))
+            .flatten();
         self.dsl_apply(
             mm_dsl::MeerkatMachineInput::RecoverInputLifecycle {
                 input_id: key,

--- a/meerkat-runtime/src/driver/ephemeral.rs
+++ b/meerkat-runtime/src/driver/ephemeral.rs
@@ -810,6 +810,9 @@ impl EphemeralRuntimeDriver {
         self.handling_mode.insert(work_id.clone(), handling_mode);
         self.runtime_semantics
             .insert(work_id.clone(), runtime_semantics);
+        if let Some(state) = self.ledger.get_mut(work_id) {
+            state.runtime_semantics = Some(runtime_semantics);
+        }
         self.primitive_projection
             .insert(work_id.clone(), primitive_projection);
         if is_prompt {
@@ -1281,7 +1284,10 @@ impl EphemeralRuntimeDriver {
     /// ledger-side shell with the DSL-owned seed (phase / run association /
     /// boundary sequence). Used by persistence callsites and test helpers.
     pub fn stored_input_state(&self, input_id: &InputId) -> Option<StoredInputState> {
-        let state = self.ledger.get(input_id)?.clone();
+        let mut state = self.ledger.get(input_id)?.clone();
+        if state.runtime_semantics.is_none() {
+            state.runtime_semantics = self.admitted_runtime_semantics(input_id);
+        }
         let phase = self
             .input_phase(input_id)
             .unwrap_or(InputLifecycleState::Accepted);
@@ -1300,6 +1306,10 @@ impl EphemeralRuntimeDriver {
         self.ledger
             .iter()
             .map(|(input_id, state)| {
+                let mut state = state.clone();
+                if state.runtime_semantics.is_none() {
+                    state.runtime_semantics = self.admitted_runtime_semantics(input_id);
+                }
                 let phase = self
                     .input_phase(input_id)
                     .unwrap_or(InputLifecycleState::Accepted);
@@ -1310,10 +1320,7 @@ impl EphemeralRuntimeDriver {
                     terminal_outcome: self.input_terminal_outcome(input_id),
                     attempt_count: self.input_attempt_count(input_id),
                 };
-                StoredInputState {
-                    state: state.clone(),
-                    seed,
-                }
+                StoredInputState { state, seed }
             })
             .collect()
     }

--- a/meerkat-runtime/src/driver/ephemeral.rs
+++ b/meerkat-runtime/src/driver/ephemeral.rs
@@ -1238,6 +1238,14 @@ impl EphemeralRuntimeDriver {
         &mut self.steer_queue
     }
 
+    #[cfg(test)]
+    pub(crate) fn clear_admitted_runtime_semantics_for_test(&mut self, input_id: &InputId) {
+        self.runtime_semantics.remove(input_id);
+        if let Some(state) = self.ledger.get_mut(input_id) {
+            state.runtime_semantics = None;
+        }
+    }
+
     pub fn has_queued_input(&self, input_id: &InputId) -> bool {
         let key = Self::dsl_key(input_id);
         self.with_dsl_state(|state| state.input_lane.contains_key(&key))

--- a/meerkat-runtime/src/driver/ephemeral.rs
+++ b/meerkat-runtime/src/driver/ephemeral.rs
@@ -655,7 +655,7 @@ impl EphemeralRuntimeDriver {
     /// into the ledger before this call, so we must not rebuild physical queue
     /// projections until the full recovery batch has entered the DSL.
     #[allow(clippy::too_many_arguments)]
-    pub fn admit_recovered_to_ingress(
+    pub(crate) fn admit_recovered_to_ingress(
         &mut self,
         work_id: InputId,
         content_shape: ContentShape,
@@ -669,6 +669,18 @@ impl EphemeralRuntimeDriver {
         request_id: Option<RequestId>,
         reservation_key: Option<ReservationKey>,
     ) -> Result<(), RuntimeDriverError> {
+        let persisted_input =
+            recovered_state.persisted_input.as_ref().ok_or_else(|| {
+                RuntimeDriverError::Internal(format!(
+                    "store corruption: recovered input '{work_id}' has no persisted input; cannot validate recovered runtime semantics"
+                ))
+            })?;
+        let expected = RuntimeInputSemantics::from_policy_and_kind(&policy, persisted_input.kind());
+        if runtime_semantics != expected {
+            return Err(RuntimeDriverError::Internal(format!(
+                "store corruption: recovered input '{work_id}' has runtime execution semantics stamp that does not match persisted input kind and admission policy; cannot recover with contradictory runtime-stamped execution kind"
+            )));
+        }
         self.recover_input_lifecycle(
             &work_id,
             &content_shape,

--- a/meerkat-runtime/src/driver/persistent.rs
+++ b/meerkat-runtime/src/driver/persistent.rs
@@ -745,12 +745,19 @@ impl RuntimeDriver for PersistentRuntimeDriver {
 
     async fn recover(&mut self) -> Result<RecoveryReport, RuntimeDriverError> {
         let checkpoint = self.inner.rollback_snapshot();
-        let report = crate::meerkat_machine::machine_recover_persistent_driver(
+        let report = match crate::meerkat_machine::machine_recover_persistent_driver(
             self.store.as_ref(),
             &self.runtime_id,
             &mut self.inner,
         )
-        .await?;
+        .await
+        {
+            Ok(report) => report,
+            Err(err) => {
+                self.inner.restore_rollback_snapshot(checkpoint.clone());
+                return Err(err);
+            }
+        };
 
         // Persist recovered state atomically
         self.commit_lifecycle_with_rollback(

--- a/meerkat-runtime/src/ingress_types.rs
+++ b/meerkat-runtime/src/ingress_types.rs
@@ -93,12 +93,27 @@ pub struct RuntimeInputProjection {
 }
 
 impl RuntimeInputSemantics {
-    pub fn from_policy_and_kind(policy: &PolicyDecision, kind: InputKind) -> Self {
-        let boundary = match policy.apply_mode {
+    fn boundary_from_policy(policy: &PolicyDecision) -> RunApplyBoundary {
+        match policy.apply_mode {
             ApplyMode::StageRunBoundary => RunApplyBoundary::RunCheckpoint,
             ApplyMode::InjectNow => RunApplyBoundary::Immediate,
             ApplyMode::StageRunStart | ApplyMode::Ignore => RunApplyBoundary::RunStart,
-        };
+        }
+    }
+
+    pub fn from_policy_and_execution_kind(
+        policy: &PolicyDecision,
+        execution_kind: RuntimeExecutionKind,
+        peer_response_terminal_apply_intent: Option<PeerResponseTerminalApplyIntent>,
+    ) -> Self {
+        Self {
+            boundary: Self::boundary_from_policy(policy),
+            execution_kind,
+            peer_response_terminal_apply_intent,
+        }
+    }
+
+    pub fn from_policy_and_kind(policy: &PolicyDecision, kind: InputKind) -> Self {
         let execution_kind = match kind {
             InputKind::Continuation => RuntimeExecutionKind::ResumePending,
             InputKind::Prompt
@@ -123,11 +138,11 @@ impl RuntimeInputSemantics {
             | InputKind::Continuation
             | InputKind::Operation => None,
         };
-        Self {
-            boundary,
+        Self::from_policy_and_execution_kind(
+            policy,
             execution_kind,
             peer_response_terminal_apply_intent,
-        }
+        )
     }
 }
 

--- a/meerkat-runtime/src/ingress_types.rs
+++ b/meerkat-runtime/src/ingress_types.rs
@@ -11,6 +11,7 @@ use meerkat_core::lifecycle::run_primitive::{
     ConversationAppend, ConversationContextAppend, PeerResponseTerminalApplyIntent,
     RunApplyBoundary,
 };
+use serde::{Deserialize, Serialize};
 
 use crate::identifiers::{InputKind, KindId};
 use crate::policy::{ApplyMode, PolicyDecision};
@@ -72,7 +73,7 @@ pub struct RequestId(pub String);
 /// or handling-mode hints to decide how a dequeued input runs. Admission has
 /// already resolved the typed policy/kind tuple; this record is the canonical
 /// carrier from that decision point to `RunPrimitive` construction.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 pub struct RuntimeInputSemantics {
     pub boundary: RunApplyBoundary,
     pub execution_kind: RuntimeExecutionKind,

--- a/meerkat-runtime/src/input_state.rs
+++ b/meerkat-runtime/src/input_state.rs
@@ -17,6 +17,7 @@ use meerkat_core::lifecycle::{InputId, RunId};
 use serde::{Deserialize, Serialize};
 
 use crate::identifiers::PolicyVersion;
+use crate::ingress_types::RuntimeInputSemantics;
 use crate::input::Input;
 use crate::policy::PolicyDecision;
 
@@ -191,6 +192,9 @@ pub struct InputState {
     pub history: Vec<InputStateHistoryEntry>,
     pub updated_at: DateTime<Utc>,
     pub policy: Option<PolicySnapshot>,
+    /// Runtime-stamped run semantics captured at admission and persisted so
+    /// recovery does not reclassify execution kind from payload shape.
+    pub runtime_semantics: Option<RuntimeInputSemantics>,
     pub durability: Option<crate::input::InputDurability>,
     pub idempotency_key: Option<crate::identifiers::IdempotencyKey>,
     pub recovery_count: u32,
@@ -212,6 +216,7 @@ impl InputState {
             history: Vec::new(),
             updated_at: now,
             policy: None,
+            runtime_semantics: None,
             durability: None,
             idempotency_key: None,
             recovery_count: 0,
@@ -260,6 +265,8 @@ struct InputStateSerde {
     current_state: InputLifecycleState,
     #[serde(skip_serializing_if = "Option::is_none")]
     policy: Option<PolicySnapshot>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    runtime_semantics: Option<RuntimeInputSemantics>,
     #[serde(skip_serializing_if = "Option::is_none")]
     terminal_outcome: Option<InputTerminalOutcome>,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -290,6 +297,7 @@ impl Serialize for StoredInputState {
             input_id: self.state.input_id.clone(),
             current_state: self.seed.phase,
             policy: self.state.policy.clone(),
+            runtime_semantics: self.state.runtime_semantics,
             terminal_outcome: self.seed.terminal_outcome.clone(),
             durability: self.state.durability,
             idempotency_key: self.state.idempotency_key.clone(),
@@ -317,6 +325,7 @@ impl<'de> Deserialize<'de> for StoredInputState {
             history: helper.history,
             updated_at: helper.updated_at,
             policy: helper.policy,
+            runtime_semantics: helper.runtime_semantics,
             durability: helper.durability,
             idempotency_key: helper.idempotency_key,
             recovery_count: helper.recovery_count,
@@ -398,20 +407,25 @@ mod tests {
     #[test]
     fn stored_input_state_serde_roundtrip_preserves_fields() {
         let mut state = InputState::new_accepted(InputId::new());
+        let policy = PolicyDecision {
+            apply_mode: ApplyMode::StageRunStart,
+            wake_mode: WakeMode::WakeIfIdle,
+            queue_mode: QueueMode::Fifo,
+            consume_point: ConsumePoint::OnRunComplete,
+            drain_policy: DrainPolicy::QueueNextTurn,
+            routing_disposition: RoutingDisposition::Queue,
+            record_transcript: true,
+            emit_operator_content: true,
+            policy_version: PolicyVersion(1),
+        };
         state.policy = Some(PolicySnapshot {
             version: PolicyVersion(1),
-            decision: PolicyDecision {
-                apply_mode: ApplyMode::StageRunStart,
-                wake_mode: WakeMode::WakeIfIdle,
-                queue_mode: QueueMode::Fifo,
-                consume_point: ConsumePoint::OnRunComplete,
-                drain_policy: DrainPolicy::QueueNextTurn,
-                routing_disposition: RoutingDisposition::Queue,
-                record_transcript: true,
-                emit_operator_content: true,
-                policy_version: PolicyVersion(1),
-            },
+            decision: policy.clone(),
         });
+        state.runtime_semantics = Some(RuntimeInputSemantics::from_policy_and_kind(
+            &policy,
+            crate::identifiers::InputKind::Prompt,
+        ));
         state.history.push(InputStateHistoryEntry {
             timestamp: state.updated_at,
             from: InputLifecycleState::Accepted,
@@ -433,6 +447,10 @@ mod tests {
         let parsed: StoredInputState = serde_json::from_value(json).unwrap();
         assert_eq!(parsed.state.input_id, bundle.state.input_id);
         assert_eq!(parsed.seed.phase, bundle.seed.phase);
+        assert_eq!(
+            parsed.state.runtime_semantics,
+            bundle.state.runtime_semantics
+        );
         assert_eq!(parsed.state.history.len(), 1);
     }
 

--- a/meerkat-runtime/src/lib.rs
+++ b/meerkat-runtime/src/lib.rs
@@ -138,6 +138,24 @@ pub use ops_lifecycle::{
     RuntimeOpsLifecycleRegistry,
 };
 
+/// Stamp prompt turn metadata with the runtime-owned input semantics.
+///
+/// This helper exists for runtime-backed surfaces that must run an eager first
+/// turn through `SessionService::create_session` before the normal queued
+/// runtime loop can observe an `Input::Prompt`.
+pub fn runtime_stamped_prompt_turn_metadata(
+    metadata: Option<meerkat_core::lifecycle::run_primitive::RuntimeTurnMetadata>,
+) -> meerkat_core::lifecycle::run_primitive::RuntimeTurnMetadata {
+    let input = Input::Prompt(PromptInput::from_content_input(
+        meerkat_core::ContentInput::Text(String::new()),
+        metadata,
+    ));
+    let policy = policy_table::DefaultPolicyTable::resolve(&input, true);
+    let semantics =
+        ingress_types::RuntimeInputSemantics::from_policy_and_kind(&policy, input.kind());
+    runtime_loop::for_input(&input, semantics)
+}
+
 #[doc(hidden)]
 pub mod machine_schema_exports {
     pub fn meerkat_machine_schema() -> meerkat_machine_schema::MachineSchema {

--- a/meerkat-runtime/src/lib.rs
+++ b/meerkat-runtime/src/lib.rs
@@ -78,6 +78,8 @@ pub mod silent_intent;
 pub mod store;
 pub mod traits;
 
+use meerkat_core::lifecycle::run_primitive::RuntimeTurnMetadata as RuntimeStampedTurnMetadata;
+
 // Re-exports for convenience
 pub use accept::{AcceptOutcome, RejectReason, post_admission_signal_from_accept_outcome};
 pub use coalescing::{
@@ -144,8 +146,8 @@ pub use ops_lifecycle::{
 /// turn through `SessionService::create_session` before the normal queued
 /// runtime loop can observe an `Input::Prompt`.
 pub fn runtime_stamped_prompt_turn_metadata(
-    metadata: Option<meerkat_core::lifecycle::run_primitive::RuntimeTurnMetadata>,
-) -> meerkat_core::lifecycle::run_primitive::RuntimeTurnMetadata {
+    metadata: Option<RuntimeStampedTurnMetadata>,
+) -> RuntimeStampedTurnMetadata {
     let input = Input::Prompt(PromptInput::from_content_input(
         meerkat_core::ContentInput::Text(String::new()),
         metadata,

--- a/meerkat-runtime/src/meerkat_machine/dispatch_ingress.rs
+++ b/meerkat-runtime/src/meerkat_machine/dispatch_ingress.rs
@@ -457,10 +457,12 @@ impl MeerkatMachine {
                             std::slice::from_ref(&dequeued_id),
                         ) {
                             Some(mut semantics) if semantics.len() == 1 => {
+                                let projection_inputs =
+                                    [(dequeued_id.clone(), dequeued_input.clone())];
                                 let projections =
                                     crate::meerkat_machine::machine_batch_primitive_projections(
                                         &driver,
-                                        std::slice::from_ref(&dequeued_id),
+                                        &projection_inputs,
                                     );
                                 crate::runtime_loop::admitted_input_to_primitive(
                                     &dequeued_input,

--- a/meerkat-runtime/src/meerkat_machine/dispatch_ingress.rs
+++ b/meerkat-runtime/src/meerkat_machine/dispatch_ingress.rs
@@ -451,10 +451,33 @@ impl MeerkatMachine {
                         )));
                     }
 
-                    let primitive = match crate::runtime_loop::input_to_primitive(
-                        &dequeued_input,
-                        dequeued_id.clone(),
-                    ) {
+                    let primitive_result =
+                        match crate::meerkat_machine::machine_batch_runtime_semantics(
+                            &driver,
+                            std::slice::from_ref(&dequeued_id),
+                        ) {
+                            Some(mut semantics) if semantics.len() == 1 => {
+                                let projections =
+                                    crate::meerkat_machine::machine_batch_primitive_projections(
+                                        &driver,
+                                        std::slice::from_ref(&dequeued_id),
+                                    );
+                                crate::runtime_loop::admitted_input_to_primitive(
+                                    &dequeued_input,
+                                    dequeued_id.clone(),
+                                    projections.into_iter().next().unwrap_or_default(),
+                                    semantics.remove(0),
+                                )
+                            }
+                            _ => Err(
+                                meerkat_core::lifecycle::run_primitive::TurnMetadataMergeConflict {
+                                    field: "execution_kind",
+                                    reason: "runtime-stamped execution kind missing for one or more inputs",
+                                },
+                            ),
+                        };
+
+                    let primitive = match primitive_result {
                         Ok(primitive) => primitive,
                         Err(err) => {
                             let _ = driver.rollback_staged(std::slice::from_ref(&dequeued_id));

--- a/meerkat-runtime/src/meerkat_machine/driver.rs
+++ b/meerkat-runtime/src/meerkat_machine/driver.rs
@@ -1362,12 +1362,33 @@ pub(crate) struct RecoveredIngressEntry {
     pub policy: crate::policy::PolicyDecision,
 }
 
+fn expected_recovered_runtime_semantics(
+    state: &InputState,
+) -> Option<crate::ingress_types::RuntimeInputSemantics> {
+    let persisted_input = state.persisted_input.as_ref()?;
+    let policy = &state.policy.as_ref()?.decision;
+    Some(
+        crate::ingress_types::RuntimeInputSemantics::from_policy_and_kind(
+            policy,
+            persisted_input.kind(),
+        ),
+    )
+}
+
 pub(crate) fn machine_build_recovered_ingress_entry(
     state: &InputState,
 ) -> Option<RecoveredIngressEntry> {
     let persisted_input = state.persisted_input.as_ref()?;
     let runtime_semantics = state.runtime_semantics?;
     let policy = state.policy.as_ref()?.decision.clone();
+    if runtime_semantics
+        != crate::ingress_types::RuntimeInputSemantics::from_policy_and_kind(
+            &policy,
+            persisted_input.kind(),
+        )
+    {
+        return None;
+    }
     let handling_mode = crate::accept::handling_mode_from_policy(&policy);
     let content_shape = crate::ingress_types::ContentShape::from_kind(persisted_input.kind());
     let primitive_projection = crate::input::runtime_input_projection(persisted_input);
@@ -1398,6 +1419,14 @@ fn missing_recovered_ingress_entry_reason(state: &InputState) -> String {
     if state.policy.is_none() {
         return format!(
             "store corruption: recovered input '{}' missing runtime admission policy stamp; cannot recover without runtime-stamped policy and lane metadata",
+            state.input_id
+        );
+    }
+    if let Some(expected) = expected_recovered_runtime_semantics(state)
+        && state.runtime_semantics != Some(expected)
+    {
+        return format!(
+            "store corruption: recovered input '{}' has runtime execution semantics stamp that does not match persisted input kind and admission policy; cannot recover with contradictory runtime-stamped execution kind",
             state.input_id
         );
     }
@@ -2486,6 +2515,21 @@ mod recovery_tests {
         }
     }
 
+    fn state_with_runtime_semantics(
+        input: Input,
+        decision: crate::policy::PolicyDecision,
+        runtime_semantics: crate::ingress_types::RuntimeInputSemantics,
+    ) -> crate::input_state::InputState {
+        let mut state = crate::input_state::InputState::new_accepted(input.id().clone());
+        state.persisted_input = Some(input);
+        state.policy = Some(crate::input_state::PolicySnapshot {
+            version: crate::policy_table::DEFAULT_POLICY_VERSION,
+            decision,
+        });
+        state.runtime_semantics = Some(runtime_semantics);
+        state
+    }
+
     #[test]
     fn recovered_ingress_entry_requires_persisted_input_for_content_shape() {
         let mut state = crate::input_state::InputState::new_accepted(InputId::new());
@@ -2532,6 +2576,89 @@ mod recovery_tests {
         assert!(
             machine_build_recovered_ingress_entry(&state).is_none(),
             "recovery must not derive policy or handling mode when the durable policy stamp is missing"
+        );
+    }
+
+    #[test]
+    fn recovered_ingress_entry_rejects_prompt_stamped_as_resume_pending() {
+        let input = Input::Prompt(crate::input::PromptInput::new("queued prompt", None));
+        let decision = policy(ApplyMode::StageRunStart);
+        let mut runtime_semantics =
+            crate::ingress_types::RuntimeInputSemantics::from_policy_and_kind(
+                &decision,
+                input.kind(),
+            );
+        runtime_semantics.execution_kind =
+            meerkat_core::lifecycle::RuntimeExecutionKind::ResumePending;
+        let state = state_with_runtime_semantics(input, decision, runtime_semantics);
+
+        assert!(
+            machine_build_recovered_ingress_entry(&state).is_none(),
+            "recovery must reject a prompt row whose durable stamp says ResumePending"
+        );
+    }
+
+    #[test]
+    fn recovered_ingress_entry_rejects_continuation_stamped_as_content_turn() {
+        let input = Input::Continuation(
+            crate::input::ContinuationInput::detached_background_op_completed(),
+        );
+        let decision = policy(ApplyMode::StageRunBoundary);
+        let mut runtime_semantics =
+            crate::ingress_types::RuntimeInputSemantics::from_policy_and_kind(
+                &decision,
+                input.kind(),
+            );
+        runtime_semantics.execution_kind =
+            meerkat_core::lifecycle::RuntimeExecutionKind::ContentTurn;
+        let state = state_with_runtime_semantics(input, decision, runtime_semantics);
+
+        assert!(
+            machine_build_recovered_ingress_entry(&state).is_none(),
+            "recovery must reject a continuation row whose durable stamp says ContentTurn"
+        );
+    }
+
+    #[test]
+    fn recovered_ingress_entry_rejects_boundary_mismatch() {
+        let input = Input::Prompt(crate::input::PromptInput::new("queued prompt", None));
+        let decision = policy(ApplyMode::StageRunStart);
+        let mut runtime_semantics =
+            crate::ingress_types::RuntimeInputSemantics::from_policy_and_kind(
+                &decision,
+                input.kind(),
+            );
+        runtime_semantics.boundary =
+            meerkat_core::lifecycle::run_primitive::RunApplyBoundary::RunCheckpoint;
+        let state = state_with_runtime_semantics(input, decision, runtime_semantics);
+
+        assert!(
+            machine_build_recovered_ingress_entry(&state).is_none(),
+            "recovery must reject a durable stamp whose boundary disagrees with policy"
+        );
+    }
+
+    #[test]
+    fn recovered_ingress_entry_rejects_terminal_intent_mismatch() {
+        let input = crate::input::peer_response_terminal_input(
+            meerkat_core::comms::PeerId::new(),
+            Some(meerkat_core::comms::PeerName::new("reviewer").expect("peer name")),
+            meerkat_core::PeerCorrelationId::new(),
+            meerkat_contracts::PeerResponseTerminalStatusWire::Completed,
+            serde_json::json!({"status": "complete"}),
+        );
+        let decision = policy(ApplyMode::StageRunStart);
+        let mut runtime_semantics =
+            crate::ingress_types::RuntimeInputSemantics::from_policy_and_kind(
+                &decision,
+                input.kind(),
+            );
+        runtime_semantics.peer_response_terminal_apply_intent = None;
+        let state = state_with_runtime_semantics(input, decision, runtime_semantics);
+
+        assert!(
+            machine_build_recovered_ingress_entry(&state).is_none(),
+            "recovery must reject a terminal peer-response stamp with missing terminal apply intent"
         );
     }
 

--- a/meerkat-runtime/src/meerkat_machine/driver.rs
+++ b/meerkat-runtime/src/meerkat_machine/driver.rs
@@ -925,7 +925,7 @@ pub(crate) fn machine_select_runtime_loop_batch(driver: &DriverEntry) -> Vec<Inp
         }
         let target_boundary = machine_input_boundary(driver, first);
         let Some(target_execution_kind) = machine_input_execution_kind(driver, first) else {
-            return Vec::new();
+            return vec![first.clone()];
         };
         let target_peer_response_terminal_apply_intent =
             machine_input_peer_response_terminal_apply_intent(driver, first);
@@ -947,7 +947,7 @@ pub(crate) fn machine_select_runtime_loop_batch(driver: &DriverEntry) -> Vec<Inp
         let prefix = &queue[..=driver_index];
         if ingress.is_prompt(first) {
             let Some(target_execution_kind) = machine_input_execution_kind(driver, first) else {
-                return Vec::new();
+                return vec![first.clone()];
             };
             let target_peer_response_terminal_apply_intent =
                 machine_input_peer_response_terminal_apply_intent(driver, first);
@@ -962,7 +962,7 @@ pub(crate) fn machine_select_runtime_loop_batch(driver: &DriverEntry) -> Vec<Inp
             return prefix[first_compatible_index..].to_vec();
         }
         let Some(target_execution_kind) = machine_input_execution_kind(driver, first) else {
-            return Vec::new();
+            return vec![first.clone()];
         };
         let target_peer_response_terminal_apply_intent =
             machine_input_peer_response_terminal_apply_intent(driver, first);
@@ -1864,6 +1864,105 @@ mod tests {
             selected,
             vec![prompt_id],
             "prompt-driven batches must not stage older inputs with a different execution kind"
+        );
+    }
+
+    #[test]
+    fn batch_selection_surfaces_queued_input_missing_runtime_semantics() {
+        let mut driver = EphemeralRuntimeDriver::new(crate::identifiers::LogicalRuntimeId::new(
+            "missing-runtime-semantics-selection",
+        ));
+        let input = Input::Prompt(crate::input::PromptInput::new(
+            "unstamped queued prompt",
+            None,
+        ));
+        let input_id = input.id().clone();
+        let mut state = InputState::new_accepted(input_id.clone());
+        state.persisted_input = Some(input.clone());
+        let seed = queued_seed();
+        assert!(driver.ledger_mut().recover(state.clone()));
+        driver
+            .admit_recovered_to_ingress(
+                input_id.clone(),
+                ContentShape::from_kind(input.kind()),
+                meerkat_core::types::HandlingMode::Queue,
+                crate::ingress_types::RuntimeInputSemantics {
+                    boundary: meerkat_core::lifecycle::run_primitive::RunApplyBoundary::RunStart,
+                    execution_kind: meerkat_core::lifecycle::RuntimeExecutionKind::ContentTurn,
+                    peer_response_terminal_apply_intent: None,
+                },
+                crate::input::runtime_input_projection(&input),
+                true,
+                &state,
+                &seed,
+                queue_policy(
+                    crate::policy::WakeMode::WakeIfIdle,
+                    crate::policy::DrainPolicy::QueueNextTurn,
+                ),
+                None,
+                None,
+            )
+            .expect("recover queued prompt input");
+        driver.rebuild_queue_projections_after_recovery();
+        driver.clear_admitted_runtime_semantics_for_test(&input_id);
+
+        let selected = machine_select_runtime_loop_batch(&DriverEntry::Ephemeral(driver));
+
+        assert_eq!(
+            selected,
+            vec![input_id],
+            "missing runtime semantics must be selected so the runtime loop records a typed failure instead of treating the queue as empty"
+        );
+    }
+
+    #[test]
+    fn batch_selection_surfaces_steered_input_missing_runtime_semantics() {
+        let mut driver = EphemeralRuntimeDriver::new(crate::identifiers::LogicalRuntimeId::new(
+            "missing-steer-runtime-semantics-selection",
+        ));
+        let input = Input::Continuation(
+            crate::input::ContinuationInput::detached_background_op_completed(),
+        );
+        let input_id = input.id().clone();
+        let mut state = InputState::new_accepted(input_id.clone());
+        state.persisted_input = Some(input.clone());
+        let seed = queued_seed();
+        let mut policy = queue_policy(
+            crate::policy::WakeMode::WakeIfIdle,
+            crate::policy::DrainPolicy::SteerBatch,
+        );
+        policy.routing_disposition = crate::policy::RoutingDisposition::Steer;
+
+        assert!(driver.ledger_mut().recover(state.clone()));
+        driver
+            .admit_recovered_to_ingress(
+                input_id.clone(),
+                ContentShape::from_kind(input.kind()),
+                meerkat_core::types::HandlingMode::Steer,
+                crate::ingress_types::RuntimeInputSemantics {
+                    boundary:
+                        meerkat_core::lifecycle::run_primitive::RunApplyBoundary::RunCheckpoint,
+                    execution_kind: meerkat_core::lifecycle::RuntimeExecutionKind::ResumePending,
+                    peer_response_terminal_apply_intent: None,
+                },
+                crate::input::runtime_input_projection(&input),
+                false,
+                &state,
+                &seed,
+                policy,
+                None,
+                None,
+            )
+            .expect("recover steered continuation input");
+        driver.rebuild_queue_projections_after_recovery();
+        driver.clear_admitted_runtime_semantics_for_test(&input_id);
+
+        let selected = machine_select_runtime_loop_batch(&DriverEntry::Ephemeral(driver));
+
+        assert_eq!(
+            selected,
+            vec![input_id],
+            "missing runtime semantics in the steer lane must be selected so the runtime loop records a typed failure instead of treating the lane as empty"
         );
     }
 }

--- a/meerkat-runtime/src/meerkat_machine/driver.rs
+++ b/meerkat-runtime/src/meerkat_machine/driver.rs
@@ -943,39 +943,32 @@ pub(crate) fn machine_select_runtime_loop_batch(driver: &DriverEntry) -> Vec<Inp
 
     let queue = ingress.queue();
     if let Some(driver_index) = queue.iter().position(should_drive_loop) {
-        let first = &queue[driver_index];
-        let prefix = &queue[..=driver_index];
-        if ingress.is_prompt(first) {
-            let Some(target_execution_kind) = machine_input_execution_kind(driver, first) else {
-                return vec![first.clone()];
-            };
-            let target_peer_response_terminal_apply_intent =
-                machine_input_peer_response_terminal_apply_intent(driver, first);
-            let first_compatible_index = prefix
-                .iter()
-                .rposition(|id| {
-                    machine_input_execution_kind(driver, id) != Some(target_execution_kind)
-                        || machine_input_peer_response_terminal_apply_intent(driver, id)
-                            != target_peer_response_terminal_apply_intent
-                })
-                .map_or(0, |index| index + 1);
-            return prefix[first_compatible_index..].to_vec();
-        }
+        let Some(first) = queue.first() else {
+            return Vec::new();
+        };
         let Some(target_execution_kind) = machine_input_execution_kind(driver, first) else {
             return vec![first.clone()];
         };
         let target_peer_response_terminal_apply_intent =
             machine_input_peer_response_terminal_apply_intent(driver, first);
-        return queue[..]
-            .iter()
-            .take_while(|id| {
-                !ingress.is_prompt(id)
-                    && machine_input_execution_kind(driver, id) == Some(target_execution_kind)
-                    && machine_input_peer_response_terminal_apply_intent(driver, id)
-                        == target_peer_response_terminal_apply_intent
-            })
-            .cloned()
-            .collect();
+        let driver_is_prompt = ingress.is_prompt(&queue[driver_index]);
+        let mut selected = Vec::new();
+        for id in &queue {
+            if machine_input_execution_kind(driver, id) != Some(target_execution_kind)
+                || machine_input_peer_response_terminal_apply_intent(driver, id)
+                    != target_peer_response_terminal_apply_intent
+            {
+                break;
+            }
+            selected.push(id.clone());
+            if ingress.is_prompt(id) {
+                break;
+            }
+            if driver_is_prompt && selected.len() > driver_index {
+                break;
+            }
+        }
+        return selected;
     }
 
     Vec::new()
@@ -1779,7 +1772,7 @@ mod tests {
     }
 
     #[test]
-    fn prompt_batch_selection_excludes_mixed_execution_kind_prefix() {
+    fn prompt_batch_selection_drives_incompatible_prefix_before_prompt() {
         let mut driver = EphemeralRuntimeDriver::new(crate::identifiers::LogicalRuntimeId::new(
             "mixed-prefix-test",
         ));
@@ -1858,12 +1851,98 @@ mod tests {
             .expect("recover queued prompt input");
         driver.rebuild_queue_projections_after_recovery();
 
-        let selected = machine_select_runtime_loop_batch(&DriverEntry::Ephemeral(driver));
+        let entry = DriverEntry::Ephemeral(driver);
+        let selected = machine_select_runtime_loop_batch(&entry);
 
         assert_eq!(
             selected,
-            vec![prompt_id],
-            "prompt-driven batches must not stage older inputs with a different execution kind"
+            vec![resume_id],
+            "a later prompt may drive the queue, but selection must preserve the staged queue prefix when an older input has a different execution kind"
+        );
+        machine_validate_stage_drain_snapshot(&entry, &selected)
+            .expect("selected incompatible prefix must satisfy staging invariants");
+    }
+
+    #[test]
+    fn batch_selection_surfaces_unstamped_no_wake_prefix_before_prompt() {
+        let mut driver = EphemeralRuntimeDriver::new(crate::identifiers::LogicalRuntimeId::new(
+            "missing-prefix-before-prompt-selection",
+        ));
+        let prefix_input = Input::Continuation(
+            crate::input::ContinuationInput::detached_background_op_completed(),
+        );
+        let prompt_input = Input::Prompt(crate::input::PromptInput::new("drive the queue", None));
+        let prefix_id = prefix_input.id().clone();
+        let prompt_id = prompt_input.id().clone();
+        let mut prefix_state = InputState::new_accepted(prefix_id.clone());
+        prefix_state.persisted_input = Some(prefix_input.clone());
+        let mut prompt_state = InputState::new_accepted(prompt_id.clone());
+        prompt_state.persisted_input = Some(prompt_input.clone());
+        let seed = queued_seed();
+        assert!(driver.ledger_mut().recover(prefix_state.clone()));
+        assert!(driver.ledger_mut().recover(prompt_state.clone()));
+
+        driver
+            .admit_recovered_to_ingress(
+                prefix_id.clone(),
+                ContentShape::from_kind(prefix_input.kind()),
+                meerkat_core::types::HandlingMode::Queue,
+                crate::ingress_types::RuntimeInputSemantics {
+                    boundary:
+                        meerkat_core::lifecycle::run_primitive::RunApplyBoundary::RunCheckpoint,
+                    execution_kind: meerkat_core::lifecycle::RuntimeExecutionKind::ResumePending,
+                    peer_response_terminal_apply_intent: None,
+                },
+                crate::input::runtime_input_projection(&prefix_input),
+                false,
+                &prefix_state,
+                &seed,
+                queue_policy(
+                    crate::policy::WakeMode::None,
+                    crate::policy::DrainPolicy::QueueNextTurn,
+                ),
+                None,
+                None,
+            )
+            .expect("recover queued prefix input");
+        driver
+            .admit_recovered_to_ingress(
+                prompt_id,
+                ContentShape::from_kind(prompt_input.kind()),
+                meerkat_core::types::HandlingMode::Queue,
+                crate::ingress_types::RuntimeInputSemantics {
+                    boundary: meerkat_core::lifecycle::run_primitive::RunApplyBoundary::RunStart,
+                    execution_kind: meerkat_core::lifecycle::RuntimeExecutionKind::ContentTurn,
+                    peer_response_terminal_apply_intent: None,
+                },
+                crate::input::runtime_input_projection(&prompt_input),
+                true,
+                &prompt_state,
+                &seed,
+                queue_policy(
+                    crate::policy::WakeMode::WakeIfIdle,
+                    crate::policy::DrainPolicy::QueueNextTurn,
+                ),
+                None,
+                None,
+            )
+            .expect("recover queued prompt input");
+        driver.rebuild_queue_projections_after_recovery();
+        driver.clear_admitted_runtime_semantics_for_test(&prefix_id);
+
+        let entry = DriverEntry::Ephemeral(driver);
+        let selected = machine_select_runtime_loop_batch(&entry);
+
+        assert_eq!(
+            selected,
+            vec![prefix_id],
+            "an unstamped no-wake prefix entry must be selected before the later prompt so runtime-loop failure handling can consume the queue prefix"
+        );
+        machine_validate_stage_drain_snapshot(&entry, &selected)
+            .expect("selected unstamped prefix must satisfy staging invariants");
+        assert!(
+            machine_batch_runtime_semantics(&entry, &selected).is_none(),
+            "selected unstamped prefix must flow into the runtime-loop metadata conflict path"
         );
     }
 

--- a/meerkat-runtime/src/meerkat_machine/driver.rs
+++ b/meerkat-runtime/src/meerkat_machine/driver.rs
@@ -960,6 +960,9 @@ pub(crate) fn machine_select_runtime_loop_batch(driver: &DriverEntry) -> Vec<Inp
             {
                 break;
             }
+            if !driver_is_prompt && ingress.is_prompt(id) {
+                break;
+            }
             selected.push(id.clone());
             if ingress.is_prompt(id) {
                 break;
@@ -1944,6 +1947,102 @@ mod tests {
             machine_batch_runtime_semantics(&entry, &selected).is_none(),
             "selected unstamped prefix must flow into the runtime-loop metadata conflict path"
         );
+    }
+
+    #[test]
+    fn batch_selection_non_prompt_driver_stops_before_following_prompt() {
+        let mut driver = EphemeralRuntimeDriver::new(crate::identifiers::LogicalRuntimeId::new(
+            "non-prompt-driver-before-prompt-selection",
+        ));
+        let event_input = Input::ExternalEvent(crate::input::ExternalEventInput {
+            header: crate::input::InputHeader {
+                id: InputId::new(),
+                timestamp: chrono::Utc::now(),
+                source: crate::input::InputOrigin::External {
+                    source_name: "scheduler".into(),
+                },
+                durability: crate::input::InputDurability::Durable,
+                visibility: crate::input::InputVisibility::default(),
+                idempotency_key: None,
+                supersession_key: None,
+                correlation_id: None,
+            },
+            event_type: "scheduler_tick".into(),
+            payload: serde_json::json!({"body": "tick"}),
+            blocks: None,
+            handling_mode: meerkat_core::types::HandlingMode::Queue,
+            render_metadata: None,
+        });
+        let prompt_input = Input::Prompt(crate::input::PromptInput::new(
+            "operator prompt must wait",
+            None,
+        ));
+        let event_id = event_input.id().clone();
+        let prompt_id = prompt_input.id().clone();
+        let mut event_state = InputState::new_accepted(event_id.clone());
+        event_state.persisted_input = Some(event_input.clone());
+        let mut prompt_state = InputState::new_accepted(prompt_id.clone());
+        prompt_state.persisted_input = Some(prompt_input.clone());
+        let seed = queued_seed();
+        assert!(driver.ledger_mut().recover(event_state.clone()));
+        assert!(driver.ledger_mut().recover(prompt_state.clone()));
+
+        driver
+            .admit_recovered_to_ingress(
+                event_id.clone(),
+                ContentShape::from_kind(event_input.kind()),
+                meerkat_core::types::HandlingMode::Queue,
+                crate::ingress_types::RuntimeInputSemantics {
+                    boundary: meerkat_core::lifecycle::run_primitive::RunApplyBoundary::RunStart,
+                    execution_kind: meerkat_core::lifecycle::RuntimeExecutionKind::ContentTurn,
+                    peer_response_terminal_apply_intent: None,
+                },
+                crate::input::runtime_input_projection(&event_input),
+                false,
+                &event_state,
+                &seed,
+                queue_policy(
+                    crate::policy::WakeMode::WakeIfIdle,
+                    crate::policy::DrainPolicy::QueueNextTurn,
+                ),
+                None,
+                None,
+            )
+            .expect("recover queued event input");
+        driver
+            .admit_recovered_to_ingress(
+                prompt_id,
+                ContentShape::from_kind(prompt_input.kind()),
+                meerkat_core::types::HandlingMode::Queue,
+                crate::ingress_types::RuntimeInputSemantics {
+                    boundary: meerkat_core::lifecycle::run_primitive::RunApplyBoundary::RunStart,
+                    execution_kind: meerkat_core::lifecycle::RuntimeExecutionKind::ContentTurn,
+                    peer_response_terminal_apply_intent: None,
+                },
+                crate::input::runtime_input_projection(&prompt_input),
+                true,
+                &prompt_state,
+                &seed,
+                queue_policy(
+                    crate::policy::WakeMode::WakeIfIdle,
+                    crate::policy::DrainPolicy::QueueNextTurn,
+                ),
+                None,
+                None,
+            )
+            .expect("recover queued prompt input");
+        driver.rebuild_queue_projections_after_recovery();
+
+        let entry = DriverEntry::Ephemeral(driver);
+        let selected = machine_select_runtime_loop_batch(&entry);
+
+        assert_eq!(
+            selected,
+            vec![event_id],
+            "a non-prompt-driven batch must not absorb a following prompt into the same run"
+        );
+        machine_validate_stage_drain_snapshot(&entry, &selected)
+            .expect("selected non-prompt batch must satisfy staging invariants");
     }
 
     #[test]

--- a/meerkat-runtime/src/meerkat_machine/driver.rs
+++ b/meerkat-runtime/src/meerkat_machine/driver.rs
@@ -1803,6 +1803,56 @@ mod tests {
     }
 
     #[test]
+    fn recovered_ingress_admission_rejects_mismatched_runtime_semantics() {
+        let mut driver = EphemeralRuntimeDriver::new(crate::identifiers::LogicalRuntimeId::new(
+            "recovered-admission-mismatch",
+        ));
+        let input = Input::Prompt(crate::input::PromptInput::new("queued prompt", None));
+        let input_id = input.id().clone();
+        let policy = queue_policy(
+            crate::policy::WakeMode::WakeIfIdle,
+            crate::policy::DrainPolicy::QueueNextTurn,
+        );
+        let mut state = InputState::new_accepted(input_id.clone());
+        state.persisted_input = Some(input.clone());
+        let seed = queued_seed();
+        assert!(driver.ledger_mut().recover(state.clone()));
+        let mut runtime_semantics =
+            crate::ingress_types::RuntimeInputSemantics::from_policy_and_kind(
+                &policy,
+                input.kind(),
+            );
+        runtime_semantics.execution_kind =
+            meerkat_core::lifecycle::RuntimeExecutionKind::ResumePending;
+
+        let err = driver
+            .admit_recovered_to_ingress(
+                input_id.clone(),
+                ContentShape::from_kind(input.kind()),
+                meerkat_core::types::HandlingMode::Queue,
+                runtime_semantics,
+                crate::input::runtime_input_projection(&input),
+                true,
+                &state,
+                &seed,
+                policy,
+                None,
+                None,
+            )
+            .expect_err("lower-level recovered admission must reject contradictory stamps");
+
+        assert!(
+            err.to_string()
+                .contains("does not match persisted input kind and admission policy"),
+            "unexpected recovery error: {err}"
+        );
+        assert!(
+            driver.admitted_runtime_semantics(&input_id).is_none(),
+            "failed recovered admission must not record mismatched runtime semantics"
+        );
+    }
+
+    #[test]
     fn prompt_batch_selection_drives_incompatible_prefix_before_prompt() {
         let mut driver = EphemeralRuntimeDriver::new(crate::identifiers::LogicalRuntimeId::new(
             "mixed-prefix-test",
@@ -1834,6 +1884,11 @@ mod tests {
         let seed = queued_seed();
         assert!(driver.ledger_mut().recover(resume_state.clone()));
         assert!(driver.ledger_mut().recover(prompt_state.clone()));
+        let mut resume_policy = queue_policy(
+            crate::policy::WakeMode::None,
+            crate::policy::DrainPolicy::QueueNextTurn,
+        );
+        resume_policy.apply_mode = crate::policy::ApplyMode::StageRunBoundary;
 
         driver
             .admit_recovered_to_ingress(
@@ -1850,10 +1905,7 @@ mod tests {
                 false,
                 &resume_state,
                 &seed,
-                queue_policy(
-                    crate::policy::WakeMode::None,
-                    crate::policy::DrainPolicy::QueueNextTurn,
-                ),
+                resume_policy,
                 None,
                 None,
             )
@@ -1912,6 +1964,11 @@ mod tests {
         let seed = queued_seed();
         assert!(driver.ledger_mut().recover(prefix_state.clone()));
         assert!(driver.ledger_mut().recover(prompt_state.clone()));
+        let mut prefix_policy = queue_policy(
+            crate::policy::WakeMode::None,
+            crate::policy::DrainPolicy::QueueNextTurn,
+        );
+        prefix_policy.apply_mode = crate::policy::ApplyMode::StageRunBoundary;
 
         driver
             .admit_recovered_to_ingress(
@@ -1928,10 +1985,7 @@ mod tests {
                 false,
                 &prefix_state,
                 &seed,
-                queue_policy(
-                    crate::policy::WakeMode::None,
-                    crate::policy::DrainPolicy::QueueNextTurn,
-                ),
+                prefix_policy,
                 None,
                 None,
             )
@@ -2137,6 +2191,7 @@ mod tests {
             crate::policy::WakeMode::WakeIfIdle,
             crate::policy::DrainPolicy::SteerBatch,
         );
+        policy.apply_mode = crate::policy::ApplyMode::StageRunBoundary;
         policy.routing_disposition = crate::policy::RoutingDisposition::Steer;
 
         assert!(driver.ledger_mut().recover(state.clone()));

--- a/meerkat-runtime/src/meerkat_machine/driver.rs
+++ b/meerkat-runtime/src/meerkat_machine/driver.rs
@@ -946,16 +946,31 @@ pub(crate) fn machine_select_runtime_loop_batch(driver: &DriverEntry) -> Vec<Inp
         let first = &queue[driver_index];
         let prefix = &queue[..=driver_index];
         if ingress.is_prompt(first) {
-            return prefix.to_vec();
+            let Some(target_execution_kind) = machine_input_execution_kind(driver, first) else {
+                return Vec::new();
+            };
+            let target_peer_response_terminal_apply_intent =
+                machine_input_peer_response_terminal_apply_intent(driver, first);
+            let first_compatible_index = prefix
+                .iter()
+                .rposition(|id| {
+                    machine_input_execution_kind(driver, id) != Some(target_execution_kind)
+                        || machine_input_peer_response_terminal_apply_intent(driver, id)
+                            != target_peer_response_terminal_apply_intent
+                })
+                .map_or(0, |index| index + 1);
+            return prefix[first_compatible_index..].to_vec();
         }
+        let Some(target_execution_kind) = machine_input_execution_kind(driver, first) else {
+            return Vec::new();
+        };
         let target_peer_response_terminal_apply_intent =
             machine_input_peer_response_terminal_apply_intent(driver, first);
         return queue[..]
             .iter()
             .take_while(|id| {
                 !ingress.is_prompt(id)
-                    && machine_input_execution_kind(driver, id)
-                        == Some(meerkat_core::lifecycle::RuntimeExecutionKind::ContentTurn)
+                    && machine_input_execution_kind(driver, id) == Some(target_execution_kind)
                     && machine_input_peer_response_terminal_apply_intent(driver, id)
                         == target_peer_response_terminal_apply_intent
             })
@@ -1685,6 +1700,29 @@ pub(crate) async fn machine_stop_runtime(
 mod tests {
     use super::*;
 
+    fn queued_seed() -> InputStateSeed {
+        let mut seed = InputStateSeed::new_accepted();
+        seed.phase = InputLifecycleState::Queued;
+        seed
+    }
+
+    fn queue_policy(
+        wake_mode: crate::policy::WakeMode,
+        drain_policy: crate::policy::DrainPolicy,
+    ) -> crate::policy::PolicyDecision {
+        crate::policy::PolicyDecision {
+            apply_mode: crate::policy::ApplyMode::StageRunStart,
+            wake_mode,
+            queue_mode: crate::policy::QueueMode::Fifo,
+            consume_point: crate::policy::ConsumePoint::OnRunComplete,
+            drain_policy,
+            routing_disposition: crate::policy::RoutingDisposition::Queue,
+            record_transcript: true,
+            emit_operator_content: true,
+            policy_version: crate::policy_table::DEFAULT_POLICY_VERSION,
+        }
+    }
+
     #[test]
     fn machine_batch_execution_kind_requires_admitted_semantics() {
         let driver = DriverEntry::Ephemeral(EphemeralRuntimeDriver::new(
@@ -1696,6 +1734,95 @@ mod tests {
             machine_batch_execution_kind(&driver, &[unstamped_input]),
             None,
             "missing runtime semantics must not locally default to ContentTurn"
+        );
+    }
+
+    #[test]
+    fn prompt_batch_selection_excludes_mixed_execution_kind_prefix() {
+        let mut driver = EphemeralRuntimeDriver::new(crate::identifiers::LogicalRuntimeId::new(
+            "mixed-prefix-test",
+        ));
+        let resume_input = Input::Continuation(
+            crate::input::ContinuationInput::detached_background_op_completed(),
+        );
+        let prompt_input = Input::Prompt(crate::input::PromptInput {
+            header: crate::input::InputHeader {
+                id: InputId::new(),
+                timestamp: chrono::Utc::now(),
+                source: crate::input::InputOrigin::Operator,
+                durability: crate::input::InputDurability::Durable,
+                visibility: crate::input::InputVisibility::default(),
+                idempotency_key: None,
+                supersession_key: None,
+                correlation_id: None,
+            },
+            text: "drive the queue".into(),
+            blocks: None,
+            turn_metadata: None,
+        });
+        let resume_id = resume_input.id().clone();
+        let prompt_id = prompt_input.id().clone();
+        let mut resume_state = InputState::new_accepted(resume_id.clone());
+        resume_state.persisted_input = Some(resume_input.clone());
+        let mut prompt_state = InputState::new_accepted(prompt_id.clone());
+        prompt_state.persisted_input = Some(prompt_input.clone());
+        let seed = queued_seed();
+        assert!(driver.ledger_mut().recover(resume_state.clone()));
+        assert!(driver.ledger_mut().recover(prompt_state.clone()));
+
+        driver
+            .admit_recovered_to_ingress(
+                resume_id.clone(),
+                ContentShape(resume_input.kind_id().to_string()),
+                meerkat_core::types::HandlingMode::Queue,
+                crate::ingress_types::RuntimeInputSemantics {
+                    boundary:
+                        meerkat_core::lifecycle::run_primitive::RunApplyBoundary::RunCheckpoint,
+                    execution_kind: meerkat_core::lifecycle::RuntimeExecutionKind::ResumePending,
+                    peer_response_terminal_apply_intent: None,
+                },
+                crate::input::runtime_input_projection(&resume_input),
+                false,
+                &resume_state,
+                &seed,
+                queue_policy(
+                    crate::policy::WakeMode::None,
+                    crate::policy::DrainPolicy::QueueNextTurn,
+                ),
+                None,
+                None,
+            )
+            .expect("recover queued resume input");
+        driver
+            .admit_recovered_to_ingress(
+                prompt_id.clone(),
+                ContentShape(prompt_input.kind_id().to_string()),
+                meerkat_core::types::HandlingMode::Queue,
+                crate::ingress_types::RuntimeInputSemantics {
+                    boundary: meerkat_core::lifecycle::run_primitive::RunApplyBoundary::RunStart,
+                    execution_kind: meerkat_core::lifecycle::RuntimeExecutionKind::ContentTurn,
+                    peer_response_terminal_apply_intent: None,
+                },
+                crate::input::runtime_input_projection(&prompt_input),
+                true,
+                &prompt_state,
+                &seed,
+                queue_policy(
+                    crate::policy::WakeMode::WakeIfIdle,
+                    crate::policy::DrainPolicy::QueueNextTurn,
+                ),
+                None,
+                None,
+            )
+            .expect("recover queued prompt input");
+        driver.rebuild_queue_projections_after_recovery();
+
+        let selected = machine_select_runtime_loop_batch(&DriverEntry::Ephemeral(driver));
+
+        assert_eq!(
+            selected,
+            vec![prompt_id],
+            "prompt-driven batches must not stage older inputs with a different execution kind"
         );
     }
 }

--- a/meerkat-runtime/src/meerkat_machine/driver.rs
+++ b/meerkat-runtime/src/meerkat_machine/driver.rs
@@ -1366,16 +1366,9 @@ pub(crate) fn machine_build_recovered_ingress_entry(
     state: &InputState,
 ) -> Option<RecoveredIngressEntry> {
     let persisted_input = state.persisted_input.as_ref()?;
-    let policy = match state.policy.as_ref() {
-        Some(policy) => policy.decision.clone(),
-        None => crate::policy_table::DefaultPolicyTable::resolve(persisted_input, true),
-    };
     let runtime_semantics = state.runtime_semantics?;
-    let handling_mode = state
-        .policy
-        .as_ref()
-        .map(|policy| crate::accept::handling_mode_from_policy(&policy.decision))
-        .unwrap_or(meerkat_core::types::HandlingMode::Queue);
+    let policy = state.policy.as_ref()?.decision.clone();
+    let handling_mode = crate::accept::handling_mode_from_policy(&policy);
     let content_shape = crate::ingress_types::ContentShape::from_kind(persisted_input.kind());
     let primitive_projection = crate::input::runtime_input_projection(persisted_input);
 
@@ -1399,6 +1392,12 @@ fn missing_recovered_ingress_entry_reason(state: &InputState) -> String {
     if state.runtime_semantics.is_none() {
         return format!(
             "store corruption: recovered input '{}' missing runtime execution semantics stamp; cannot recover without runtime-stamped execution kind",
+            state.input_id
+        );
+    }
+    if state.policy.is_none() {
+        return format!(
+            "store corruption: recovered input '{}' missing runtime admission policy stamp; cannot recover without runtime-stamped policy and lane metadata",
             state.input_id
         );
     }
@@ -2517,6 +2516,25 @@ mod recovery_tests {
         );
     }
 
+    #[test]
+    fn recovered_ingress_entry_requires_policy_snapshot() {
+        let input = Input::Prompt(crate::input::PromptInput::new("queued prompt", None));
+        let decision = policy(ApplyMode::StageRunStart);
+        let mut state = crate::input_state::InputState::new_accepted(input.id().clone());
+        state.runtime_semantics = Some(
+            crate::ingress_types::RuntimeInputSemantics::from_policy_and_kind(
+                &decision,
+                input.kind(),
+            ),
+        );
+        state.persisted_input = Some(input);
+
+        assert!(
+            machine_build_recovered_ingress_entry(&state).is_none(),
+            "recovery must not derive policy or handling mode when the durable policy stamp is missing"
+        );
+    }
+
     #[tokio::test]
     async fn persistent_recovery_rejects_state_without_runtime_semantics_stamp() {
         use crate::store::RuntimeStore;
@@ -2547,6 +2565,49 @@ mod recovery_tests {
         assert!(
             err.to_string()
                 .contains("missing runtime execution semantics stamp"),
+            "unexpected recovery error: {err}"
+        );
+        assert!(
+            driver.input_state(&input_id).is_none(),
+            "failed recovery must not leave a ledger-only input row"
+        );
+    }
+
+    #[tokio::test]
+    async fn persistent_recovery_rejects_state_without_policy_snapshot() {
+        use crate::store::RuntimeStore;
+
+        let runtime_id = LogicalRuntimeId::new("missing-policy-snapshot");
+        let input = Input::Prompt(crate::input::PromptInput::new("queued prompt", None));
+        let input_id = input.id().clone();
+        let decision = policy(ApplyMode::StageRunStart);
+        let mut state = crate::input_state::InputState::new_accepted(input_id.clone());
+        state.runtime_semantics = Some(
+            crate::ingress_types::RuntimeInputSemantics::from_policy_and_kind(
+                &decision,
+                input.kind(),
+            ),
+        );
+        state.persisted_input = Some(input);
+        let mut seed = InputStateSeed::new_accepted();
+        seed.phase = InputLifecycleState::Queued;
+        let bundle = crate::input_state::StoredInputState { state, seed };
+        let store = crate::store::memory::InMemoryRuntimeStore::new();
+        store
+            .persist_input_state(&runtime_id, &bundle)
+            .await
+            .expect("persist corrupt recovered input state");
+
+        let mut driver = crate::driver::ephemeral::EphemeralRuntimeDriver::new(runtime_id.clone());
+        let err = machine_recover_persistent_driver(&store, &runtime_id, &mut driver)
+            .await
+            .expect_err(
+                "policy-less recovered input must not recover through local classification",
+            );
+
+        assert!(
+            err.to_string()
+                .contains("missing runtime admission policy stamp"),
             "unexpected recovery error: {err}"
         );
         assert!(

--- a/meerkat-runtime/src/meerkat_machine/driver.rs
+++ b/meerkat-runtime/src/meerkat_machine/driver.rs
@@ -1374,9 +1374,7 @@ pub(crate) fn machine_build_recovered_ingress_entry(
         Some(policy) => policy.decision.clone(),
         None => crate::policy_table::DefaultPolicyTable::resolve(persisted_input, true),
     };
-    let runtime_semantics = state
-        .runtime_semantics
-        .or_else(|| recovered_runtime_semantics_from_turn_metadata(persisted_input, &policy))?;
+    let runtime_semantics = state.runtime_semantics?;
     let handling_mode = state
         .policy
         .as_ref()
@@ -1393,27 +1391,6 @@ pub(crate) fn machine_build_recovered_ingress_entry(
         is_prompt: matches!(persisted_input, crate::input::Input::Prompt(_)),
         policy,
     })
-}
-
-fn recovered_runtime_semantics_from_turn_metadata(
-    input: &Input,
-    policy: &crate::policy::PolicyDecision,
-) -> Option<crate::ingress_types::RuntimeInputSemantics> {
-    let metadata = match input {
-        Input::Prompt(prompt) => prompt.turn_metadata.as_ref(),
-        Input::FlowStep(flow_step) => flow_step.turn_metadata.as_ref(),
-        Input::Peer(_) | Input::ExternalEvent(_) | Input::Continuation(_) | Input::Operation(_) => {
-            None
-        }
-    }?;
-    let execution_kind = metadata.execution_kind?;
-    Some(
-        crate::ingress_types::RuntimeInputSemantics::from_policy_and_execution_kind(
-            policy,
-            execution_kind,
-            metadata.peer_response_terminal_apply_intent,
-        ),
-    )
 }
 
 fn missing_recovered_ingress_entry_reason(state: &InputState) -> String {
@@ -2260,39 +2237,6 @@ mod recovery_tests {
         assert!(
             machine_build_recovered_ingress_entry(&state).is_none(),
             "recovery must not derive execution kind from payload/policy when the durable runtime semantics stamp is missing"
-        );
-    }
-
-    #[test]
-    fn recovered_ingress_entry_accepts_durable_turn_metadata_execution_stamp() {
-        let input = Input::Prompt(crate::input::PromptInput::new(
-            "queued prompt",
-            Some(
-                meerkat_core::lifecycle::run_primitive::RuntimeTurnMetadata {
-                    execution_kind: Some(
-                        meerkat_core::lifecycle::RuntimeExecutionKind::ContentTurn,
-                    ),
-                    ..Default::default()
-                },
-            ),
-        ));
-        let mut state = crate::input_state::InputState::new_accepted(input.id().clone());
-        state.persisted_input = Some(input);
-        state.policy = Some(crate::input_state::PolicySnapshot {
-            version: crate::policy_table::DEFAULT_POLICY_VERSION,
-            decision: policy(ApplyMode::StageRunBoundary),
-        });
-
-        let entry = machine_build_recovered_ingress_entry(&state)
-            .expect("durable turn metadata execution stamp should recover");
-
-        assert_eq!(
-            entry.runtime_semantics.execution_kind,
-            meerkat_core::lifecycle::RuntimeExecutionKind::ContentTurn
-        );
-        assert_eq!(
-            entry.runtime_semantics.boundary,
-            meerkat_core::lifecycle::run_primitive::RunApplyBoundary::RunCheckpoint
         );
     }
 

--- a/meerkat-runtime/src/meerkat_machine/driver.rs
+++ b/meerkat-runtime/src/meerkat_machine/driver.rs
@@ -1738,6 +1738,23 @@ mod tests {
     }
 
     #[test]
+    fn recovered_ingress_entry_requires_persisted_input_payload() {
+        let mut state = InputState::new_accepted(InputId::new());
+        state.policy = Some(crate::input_state::PolicySnapshot {
+            version: crate::identifiers::PolicyVersion(1),
+            decision: queue_policy(
+                crate::policy::WakeMode::WakeIfIdle,
+                crate::policy::DrainPolicy::QueueNextTurn,
+            ),
+        });
+
+        assert!(
+            machine_build_recovered_ingress_entry(&state).is_none(),
+            "recovery must not infer Prompt/ContentTurn when persisted input payload is missing"
+        );
+    }
+
+    #[test]
     fn prompt_batch_selection_excludes_mixed_execution_kind_prefix() {
         let mut driver = EphemeralRuntimeDriver::new(crate::identifiers::LogicalRuntimeId::new(
             "mixed-prefix-test",

--- a/meerkat-runtime/src/meerkat_machine/driver.rs
+++ b/meerkat-runtime/src/meerkat_machine/driver.rs
@@ -1370,6 +1370,7 @@ pub(crate) fn machine_build_recovered_ingress_entry(
     state: &InputState,
 ) -> Option<RecoveredIngressEntry> {
     let persisted_input = state.persisted_input.as_ref()?;
+    let runtime_semantics = state.runtime_semantics?;
     let handling_mode = state
         .policy
         .as_ref()
@@ -1380,9 +1381,6 @@ pub(crate) fn machine_build_recovered_ingress_entry(
         Some(policy) => policy.decision.clone(),
         None => crate::policy_table::DefaultPolicyTable::resolve(persisted_input, true),
     };
-    let recovered_kind = persisted_input.kind();
-    let runtime_semantics =
-        crate::ingress_types::RuntimeInputSemantics::from_policy_and_kind(&policy, recovered_kind);
     let primitive_projection = crate::input::runtime_input_projection(persisted_input);
 
     Some(RecoveredIngressEntry {
@@ -1393,6 +1391,25 @@ pub(crate) fn machine_build_recovered_ingress_entry(
         is_prompt: matches!(persisted_input, crate::input::Input::Prompt(_)),
         policy,
     })
+}
+
+fn missing_recovered_ingress_entry_reason(state: &InputState) -> String {
+    if state.persisted_input.is_none() {
+        return format!(
+            "store corruption: recovered input '{}' has no persisted input; cannot derive admitted-input content shape",
+            state.input_id
+        );
+    }
+    if state.runtime_semantics.is_none() {
+        return format!(
+            "store corruption: recovered input '{}' missing runtime execution semantics stamp; cannot recover without runtime-stamped execution kind",
+            state.input_id
+        );
+    }
+    format!(
+        "store corruption: recovered input '{}' is missing required admitted-input metadata",
+        state.input_id
+    )
 }
 
 pub(crate) fn machine_realize_recovered_runtime_state(
@@ -1501,10 +1518,9 @@ pub(crate) fn machine_recover_ephemeral_driver(
         Vec::with_capacity(normalized.len());
     for (input_id, bundle) in normalized {
         let Some(entry) = machine_build_recovered_ingress_entry(&bundle.state) else {
-            return Err(RuntimeDriverError::Internal(format!(
-                "store corruption: recovered input '{}' has no persisted input; cannot derive admitted-input content shape",
-                bundle.state.input_id
-            )));
+            return Err(RuntimeDriverError::Internal(
+                missing_recovered_ingress_entry_reason(&bundle.state),
+            ));
         };
         recovered_entries.push((input_id, entry, bundle.state, bundle.seed));
     }
@@ -1561,10 +1577,9 @@ pub(crate) async fn machine_recover_persistent_driver(
 
         if driver.input_state(&bundle.state.input_id).is_none() {
             let Some(entry) = machine_build_recovered_ingress_entry(&bundle.state) else {
-                return Err(RuntimeDriverError::Internal(format!(
-                    "store corruption: recovered input '{}' has no persisted input; cannot derive admitted-input content shape",
-                    bundle.state.input_id
-                )));
+                return Err(RuntimeDriverError::Internal(
+                    missing_recovered_ingress_entry_reason(&bundle.state),
+                ));
             };
 
             let inserted = driver.ledger_mut().recover(bundle.state.clone());
@@ -1790,7 +1805,7 @@ mod tests {
         driver
             .admit_recovered_to_ingress(
                 resume_id.clone(),
-                ContentShape(resume_input.kind_id().to_string()),
+                ContentShape::from_kind(resume_input.kind()),
                 meerkat_core::types::HandlingMode::Queue,
                 crate::ingress_types::RuntimeInputSemantics {
                     boundary:
@@ -1813,7 +1828,7 @@ mod tests {
         driver
             .admit_recovered_to_ingress(
                 prompt_id.clone(),
-                ContentShape(prompt_input.kind_id().to_string()),
+                ContentShape::from_kind(prompt_input.kind()),
                 meerkat_core::types::HandlingMode::Queue,
                 crate::ingress_types::RuntimeInputSemantics {
                     boundary: meerkat_core::lifecycle::run_primitive::RunApplyBoundary::RunStart,
@@ -2166,7 +2181,7 @@ async fn fail_runtime_loop_run_inner(
 }
 
 #[cfg(test)]
-mod tests {
+mod recovery_tests {
     use super::*;
     use crate::policy::{
         ApplyMode, ConsumePoint, DrainPolicy, QueueMode, RoutingDisposition, WakeMode,
@@ -2197,6 +2212,60 @@ mod tests {
         assert!(
             machine_build_recovered_ingress_entry(&state).is_none(),
             "recovery must not synthesize an unknown admitted-input content shape"
+        );
+    }
+
+    #[test]
+    fn recovered_ingress_entry_requires_runtime_semantics_stamp() {
+        let input = Input::Prompt(crate::input::PromptInput::new("queued prompt", None));
+        let mut state = crate::input_state::InputState::new_accepted(input.id().clone());
+        state.persisted_input = Some(input);
+        state.policy = Some(crate::input_state::PolicySnapshot {
+            version: crate::policy_table::DEFAULT_POLICY_VERSION,
+            decision: policy(ApplyMode::StageRunStart),
+        });
+
+        assert!(
+            machine_build_recovered_ingress_entry(&state).is_none(),
+            "recovery must not derive execution kind from payload/policy when the durable runtime semantics stamp is missing"
+        );
+    }
+
+    #[tokio::test]
+    async fn persistent_recovery_rejects_state_without_runtime_semantics_stamp() {
+        use crate::store::RuntimeStore;
+
+        let runtime_id = LogicalRuntimeId::new("missing-runtime-semantics-stamp");
+        let input = Input::Prompt(crate::input::PromptInput::new("queued prompt", None));
+        let input_id = input.id().clone();
+        let mut state = crate::input_state::InputState::new_accepted(input_id.clone());
+        state.persisted_input = Some(input);
+        state.policy = Some(crate::input_state::PolicySnapshot {
+            version: crate::policy_table::DEFAULT_POLICY_VERSION,
+            decision: policy(ApplyMode::StageRunStart),
+        });
+        let mut seed = InputStateSeed::new_accepted();
+        seed.phase = InputLifecycleState::Queued;
+        let bundle = crate::input_state::StoredInputState { state, seed };
+        let store = crate::store::memory::InMemoryRuntimeStore::new();
+        store
+            .persist_input_state(&runtime_id, &bundle)
+            .await
+            .expect("persist corrupt recovered input state");
+
+        let mut driver = crate::driver::ephemeral::EphemeralRuntimeDriver::new(runtime_id.clone());
+        let err = machine_recover_persistent_driver(&store, &runtime_id, &mut driver)
+            .await
+            .expect_err("unstamped recovered input must not recover through local classification");
+
+        assert!(
+            err.to_string()
+                .contains("missing runtime execution semantics stamp"),
+            "unexpected recovery error: {err}"
+        );
+        assert!(
+            driver.input_state(&input_id).is_none(),
+            "failed recovery must not leave a ledger-only input row"
         );
     }
 

--- a/meerkat-runtime/src/meerkat_machine/driver.rs
+++ b/meerkat-runtime/src/meerkat_machine/driver.rs
@@ -1370,17 +1370,19 @@ pub(crate) fn machine_build_recovered_ingress_entry(
     state: &InputState,
 ) -> Option<RecoveredIngressEntry> {
     let persisted_input = state.persisted_input.as_ref()?;
-    let runtime_semantics = state.runtime_semantics?;
+    let policy = match state.policy.as_ref() {
+        Some(policy) => policy.decision.clone(),
+        None => crate::policy_table::DefaultPolicyTable::resolve(persisted_input, true),
+    };
+    let runtime_semantics = state
+        .runtime_semantics
+        .or_else(|| recovered_runtime_semantics_from_turn_metadata(persisted_input, &policy))?;
     let handling_mode = state
         .policy
         .as_ref()
         .map(|policy| crate::accept::handling_mode_from_policy(&policy.decision))
         .unwrap_or(meerkat_core::types::HandlingMode::Queue);
     let content_shape = crate::ingress_types::ContentShape::from_kind(persisted_input.kind());
-    let policy = match state.policy.as_ref() {
-        Some(policy) => policy.decision.clone(),
-        None => crate::policy_table::DefaultPolicyTable::resolve(persisted_input, true),
-    };
     let primitive_projection = crate::input::runtime_input_projection(persisted_input);
 
     Some(RecoveredIngressEntry {
@@ -1391,6 +1393,27 @@ pub(crate) fn machine_build_recovered_ingress_entry(
         is_prompt: matches!(persisted_input, crate::input::Input::Prompt(_)),
         policy,
     })
+}
+
+fn recovered_runtime_semantics_from_turn_metadata(
+    input: &Input,
+    policy: &crate::policy::PolicyDecision,
+) -> Option<crate::ingress_types::RuntimeInputSemantics> {
+    let metadata = match input {
+        Input::Prompt(prompt) => prompt.turn_metadata.as_ref(),
+        Input::FlowStep(flow_step) => flow_step.turn_metadata.as_ref(),
+        Input::Peer(_) | Input::ExternalEvent(_) | Input::Continuation(_) | Input::Operation(_) => {
+            None
+        }
+    }?;
+    let execution_kind = metadata.execution_kind?;
+    Some(
+        crate::ingress_types::RuntimeInputSemantics::from_policy_and_execution_kind(
+            policy,
+            execution_kind,
+            metadata.peer_response_terminal_apply_intent,
+        ),
+    )
 }
 
 fn missing_recovered_ingress_entry_reason(state: &InputState) -> String {
@@ -2228,6 +2251,39 @@ mod recovery_tests {
         assert!(
             machine_build_recovered_ingress_entry(&state).is_none(),
             "recovery must not derive execution kind from payload/policy when the durable runtime semantics stamp is missing"
+        );
+    }
+
+    #[test]
+    fn recovered_ingress_entry_accepts_durable_turn_metadata_execution_stamp() {
+        let input = Input::Prompt(crate::input::PromptInput::new(
+            "queued prompt",
+            Some(
+                meerkat_core::lifecycle::run_primitive::RuntimeTurnMetadata {
+                    execution_kind: Some(
+                        meerkat_core::lifecycle::RuntimeExecutionKind::ContentTurn,
+                    ),
+                    ..Default::default()
+                },
+            ),
+        ));
+        let mut state = crate::input_state::InputState::new_accepted(input.id().clone());
+        state.persisted_input = Some(input);
+        state.policy = Some(crate::input_state::PolicySnapshot {
+            version: crate::policy_table::DEFAULT_POLICY_VERSION,
+            decision: policy(ApplyMode::StageRunBoundary),
+        });
+
+        let entry = machine_build_recovered_ingress_entry(&state)
+            .expect("durable turn metadata execution stamp should recover");
+
+        assert_eq!(
+            entry.runtime_semantics.execution_kind,
+            meerkat_core::lifecycle::RuntimeExecutionKind::ContentTurn
+        );
+        assert_eq!(
+            entry.runtime_semantics.boundary,
+            meerkat_core::lifecycle::run_primitive::RunApplyBoundary::RunCheckpoint
         );
     }
 

--- a/meerkat-runtime/src/meerkat_machine/driver.rs
+++ b/meerkat-runtime/src/meerkat_machine/driver.rs
@@ -1599,6 +1599,15 @@ pub(crate) async fn machine_recover_persistent_driver(
         }
 
         if driver.input_state(&bundle.state.input_id).is_none() {
+            if bundle.seed.phase.is_terminal() {
+                let inserted = driver.ledger_mut().recover(bundle.state.clone());
+                if !inserted {
+                    continue;
+                }
+                driver.recover_terminal_input_lifecycle(&bundle.state.input_id, &bundle.seed)?;
+                continue;
+            }
+
             let Some(entry) = machine_build_recovered_ingress_entry(&bundle.state) else {
                 return Err(RuntimeDriverError::Internal(
                     missing_recovered_ingress_entry_reason(&bundle.state),

--- a/meerkat-runtime/src/meerkat_machine/driver.rs
+++ b/meerkat-runtime/src/meerkat_machine/driver.rs
@@ -841,12 +841,11 @@ pub(crate) fn machine_input_boundary(
 pub(crate) fn machine_input_execution_kind(
     driver: &DriverEntry,
     work_id: &InputId,
-) -> meerkat_core::lifecycle::RuntimeExecutionKind {
+) -> Option<meerkat_core::lifecycle::RuntimeExecutionKind> {
     driver
         .driver_ingress()
         .runtime_semantics(work_id)
         .map(|semantics| semantics.execution_kind)
-        .unwrap_or(meerkat_core::lifecycle::RuntimeExecutionKind::ContentTurn)
 }
 
 pub(crate) fn machine_input_peer_response_terminal_apply_intent(
@@ -859,31 +858,29 @@ pub(crate) fn machine_input_peer_response_terminal_apply_intent(
         .and_then(|semantics| semantics.peer_response_terminal_apply_intent)
 }
 
+#[cfg(test)]
 pub(crate) fn machine_batch_execution_kind(
     driver: &DriverEntry,
     work_ids: &[InputId],
 ) -> Option<meerkat_core::lifecycle::RuntimeExecutionKind> {
-    if work_ids.is_empty() {
-        return None;
-    }
+    let mut semantics = machine_batch_runtime_semantics(driver, work_ids)?.into_iter();
+    let first = semantics.next()?.execution_kind;
 
-    if work_ids.iter().all(|id| {
-        machine_input_execution_kind(driver, id)
-            == meerkat_core::lifecycle::RuntimeExecutionKind::ResumePending
-    }) {
-        Some(meerkat_core::lifecycle::RuntimeExecutionKind::ResumePending)
+    if semantics.all(|semantics| semantics.execution_kind == first) {
+        Some(first)
     } else {
-        Some(meerkat_core::lifecycle::RuntimeExecutionKind::ContentTurn)
+        None
     }
 }
 
-pub(crate) fn machine_batch_peer_response_terminal_apply_intent(
+pub(crate) fn machine_batch_runtime_semantics(
     driver: &DriverEntry,
     work_ids: &[InputId],
-) -> Option<meerkat_core::lifecycle::run_primitive::PeerResponseTerminalApplyIntent> {
+) -> Option<Vec<crate::ingress_types::RuntimeInputSemantics>> {
     work_ids
         .iter()
-        .find_map(|id| machine_input_peer_response_terminal_apply_intent(driver, id))
+        .map(|id| driver.driver_ingress().runtime_semantics(id))
+        .collect()
 }
 
 pub(crate) fn machine_batch_primitive_projections(
@@ -927,14 +924,16 @@ pub(crate) fn machine_select_runtime_loop_batch(driver: &DriverEntry) -> Vec<Inp
             return Vec::new();
         }
         let target_boundary = machine_input_boundary(driver, first);
-        let target_execution_kind = machine_input_execution_kind(driver, first);
+        let Some(target_execution_kind) = machine_input_execution_kind(driver, first) else {
+            return Vec::new();
+        };
         let target_peer_response_terminal_apply_intent =
             machine_input_peer_response_terminal_apply_intent(driver, first);
         return steer
             .iter()
             .take_while(|id| {
                 machine_input_boundary(driver, id) == target_boundary
-                    && machine_input_execution_kind(driver, id) == target_execution_kind
+                    && machine_input_execution_kind(driver, id) == Some(target_execution_kind)
                     && machine_input_peer_response_terminal_apply_intent(driver, id)
                         == target_peer_response_terminal_apply_intent
             })
@@ -956,7 +955,7 @@ pub(crate) fn machine_select_runtime_loop_batch(driver: &DriverEntry) -> Vec<Inp
             .take_while(|id| {
                 !ingress.is_prompt(id)
                     && machine_input_execution_kind(driver, id)
-                        == meerkat_core::lifecycle::RuntimeExecutionKind::ContentTurn
+                        == Some(meerkat_core::lifecycle::RuntimeExecutionKind::ContentTurn)
                     && machine_input_peer_response_terminal_apply_intent(driver, id)
                         == target_peer_response_terminal_apply_intent
             })
@@ -1679,6 +1678,25 @@ pub(crate) async fn machine_stop_runtime(
             Ok(())
         }
         DriverEntry::Persistent(d) => d.finalize_runtime_executor_exit().await,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn machine_batch_execution_kind_requires_admitted_semantics() {
+        let driver = DriverEntry::Ephemeral(EphemeralRuntimeDriver::new(
+            crate::identifiers::LogicalRuntimeId::new("test"),
+        ));
+        let unstamped_input = InputId::new();
+
+        assert_eq!(
+            machine_batch_execution_kind(&driver, &[unstamped_input]),
+            None,
+            "missing runtime semantics must not locally default to ContentTurn"
+        );
     }
 }
 

--- a/meerkat-runtime/src/meerkat_machine/mod.rs
+++ b/meerkat-runtime/src/meerkat_machine/mod.rs
@@ -121,14 +121,13 @@ type MeerkatMachineCommandFuture<'a> = Pin<
 pub(crate) use driver::{
     DriverEntry, SharedCompletionRegistry, SharedDriver, commit_runtime_loop_run,
     fail_machine_run_without_runtime_apply_cause, fail_runtime_loop_run,
-    machine_apply_run_return_projection, machine_batch_execution_kind,
-    machine_batch_peer_response_terminal_apply_intent, machine_batch_primitive_projections,
-    machine_begin_run, machine_commit_prepared_destroy, machine_executor_attach_projection,
-    machine_input_boundary, machine_prepare_bindings_projection, machine_prepare_destroy,
-    machine_recover_ephemeral_driver, machine_recover_persistent_driver,
-    machine_recycle_preserving_work, machine_reset, machine_retire,
-    machine_select_runtime_loop_batch, machine_stop_runtime, machine_unregister_session_projection,
-    prepare_runtime_loop_batch_start,
+    machine_apply_run_return_projection, machine_batch_primitive_projections,
+    machine_batch_runtime_semantics, machine_begin_run, machine_commit_prepared_destroy,
+    machine_executor_attach_projection, machine_input_boundary,
+    machine_prepare_bindings_projection, machine_recover_ephemeral_driver,
+    machine_recover_persistent_driver, machine_recycle_preserving_work, machine_reset,
+    machine_prepare_destroy, machine_retire, machine_select_runtime_loop_batch,
+    machine_stop_runtime, machine_unregister_session_projection, prepare_runtime_loop_batch_start,
 };
 
 pub(crate) mod driver;

--- a/meerkat-runtime/src/meerkat_machine/mod.rs
+++ b/meerkat-runtime/src/meerkat_machine/mod.rs
@@ -124,10 +124,10 @@ pub(crate) use driver::{
     machine_apply_run_return_projection, machine_batch_primitive_projections,
     machine_batch_runtime_semantics, machine_begin_run, machine_commit_prepared_destroy,
     machine_executor_attach_projection, machine_input_boundary,
-    machine_prepare_bindings_projection, machine_recover_ephemeral_driver,
+    machine_prepare_bindings_projection, machine_prepare_destroy, machine_recover_ephemeral_driver,
     machine_recover_persistent_driver, machine_recycle_preserving_work, machine_reset,
-    machine_prepare_destroy, machine_retire, machine_select_runtime_loop_batch,
-    machine_stop_runtime, machine_unregister_session_projection, prepare_runtime_loop_batch_start,
+    machine_retire, machine_select_runtime_loop_batch, machine_stop_runtime,
+    machine_unregister_session_projection, prepare_runtime_loop_batch_start,
 };
 
 pub(crate) mod driver;

--- a/meerkat-runtime/src/runtime_loop.rs
+++ b/meerkat-runtime/src/runtime_loop.rs
@@ -7,15 +7,15 @@
 //! under the hood).
 
 use meerkat_core::lifecycle::core_executor::{CoreApplyFailureCause, CoreApplyTerminal};
-use meerkat_core::lifecycle::run_primitive::{
-    PeerResponseTerminalApplyIntent, RunApplyBoundary, RunPrimitive, StagedRunInput,
-};
+use meerkat_core::lifecycle::run_primitive::{RunApplyBoundary, RunPrimitive, StagedRunInput};
 use meerkat_core::lifecycle::{InputId, RunId};
 use meerkat_core::turn_execution_authority::ContentShape as TurnContentShape;
 
+use crate::input::Input;
 #[cfg(test)]
 use crate::input::input_prompt_text;
-use crate::input::{Input, runtime_input_projection_for_machine_batch};
+#[cfg(test)]
+use crate::input::runtime_input_projection_for_machine_batch;
 use crate::runtime_state::RuntimeState;
 use crate::tokio;
 

--- a/meerkat-runtime/src/runtime_loop.rs
+++ b/meerkat-runtime/src/runtime_loop.rs
@@ -235,6 +235,7 @@ async fn prepare_turn_state_for_primitive(
         })
 }
 
+#[cfg(test)]
 pub(crate) fn try_inputs_to_primitive_with_boundary(
     inputs: &[(InputId, Input)],
     boundary: RunApplyBoundary,
@@ -278,6 +279,7 @@ pub(crate) fn try_projected_inputs_to_primitive_with_boundary(
     }))
 }
 
+#[cfg(test)]
 pub(crate) fn inputs_to_primitive_with_boundary(
     inputs: &[(InputId, Input)],
     boundary: RunApplyBoundary,
@@ -286,6 +288,7 @@ pub(crate) fn inputs_to_primitive_with_boundary(
     try_inputs_to_primitive_with_boundary(inputs, boundary, &semantics)
 }
 
+#[cfg(test)]
 pub(crate) fn inputs_to_primitive(
     inputs: &[(InputId, Input)],
 ) -> Result<RunPrimitive, meerkat_core::lifecycle::run_primitive::TurnMetadataMergeConflict> {
@@ -296,11 +299,13 @@ pub(crate) fn inputs_to_primitive(
     inputs_to_primitive_with_boundary(inputs, boundary)
 }
 
+#[cfg(test)]
 fn fallback_unadmitted_semantics(input: &Input) -> crate::ingress_types::RuntimeInputSemantics {
     let policy = crate::policy_table::DefaultPolicyTable::resolve(input, true);
     crate::ingress_types::RuntimeInputSemantics::from_policy_and_kind(&policy, input.kind())
 }
 
+#[cfg(test)]
 fn fallback_batch_semantics(
     inputs: &[(InputId, Input)],
 ) -> Vec<crate::ingress_types::RuntimeInputSemantics> {
@@ -311,11 +316,26 @@ fn fallback_batch_semantics(
 }
 
 /// Convert an `Input` + its ID to a `RunPrimitive` for `CoreExecutor::apply()`.
+#[cfg(test)]
 pub(crate) fn input_to_primitive(
     input: &Input,
     input_id: InputId,
 ) -> Result<RunPrimitive, meerkat_core::lifecycle::run_primitive::TurnMetadataMergeConflict> {
     inputs_to_primitive(&[(input_id, input.clone())])
+}
+
+pub(crate) fn admitted_input_to_primitive(
+    input: &Input,
+    input_id: InputId,
+    projection: crate::ingress_types::RuntimeInputProjection,
+    semantics: crate::ingress_types::RuntimeInputSemantics,
+) -> Result<RunPrimitive, meerkat_core::lifecycle::run_primitive::TurnMetadataMergeConflict> {
+    try_projected_inputs_to_primitive_with_boundary(
+        &[(input_id, input.clone())],
+        &[projection],
+        semantics.boundary,
+        &[semantics],
+    )
 }
 
 /// Spawn the per-session runtime loop with optional completion registry.
@@ -2145,6 +2165,31 @@ mod tests {
         assert_eq!(
             meta.execution_kind,
             Some(meerkat_core::lifecycle::RuntimeExecutionKind::ResumePending)
+        );
+    }
+
+    #[test]
+    fn admitted_input_primitive_uses_runtime_stamped_execution_kind() {
+        let input = make_prompt("test prompt");
+        let id = input.id().clone();
+        let primitive = admitted_input_to_primitive(
+            &input,
+            id,
+            crate::input::runtime_input_projection(&input),
+            crate::ingress_types::RuntimeInputSemantics {
+                boundary: RunApplyBoundary::RunStart,
+                execution_kind: meerkat_core::lifecycle::RuntimeExecutionKind::ResumePending,
+                peer_response_terminal_apply_intent: None,
+            },
+        )
+        .expect("single input metadata cannot conflict");
+        let meta = primitive
+            .turn_metadata()
+            .expect("should have turn_metadata");
+        assert_eq!(
+            meta.execution_kind,
+            Some(meerkat_core::lifecycle::RuntimeExecutionKind::ResumePending),
+            "primitive construction must use the runtime-stamped execution kind, not the local input kind"
         );
     }
 

--- a/meerkat-runtime/src/runtime_loop.rs
+++ b/meerkat-runtime/src/runtime_loop.rs
@@ -33,22 +33,26 @@ pub(crate) fn input_to_prompt(input: &Input) -> String {
 /// integration test greps for that invariant at build time.
 pub(crate) fn for_input(
     input: &Input,
-) -> Option<meerkat_core::lifecycle::run_primitive::RuntimeTurnMetadata> {
+    semantics: crate::ingress_types::RuntimeInputSemantics,
+) -> meerkat_core::lifecycle::run_primitive::RuntimeTurnMetadata {
     use meerkat_core::lifecycle::run_primitive::RuntimeTurnMetadata;
-    match input {
-        Input::Prompt(prompt) => prompt.turn_metadata.clone(),
-        Input::FlowStep(flow_step) => flow_step.turn_metadata.clone(),
-        Input::ExternalEvent(event) => Some(RuntimeTurnMetadata {
+    let mut metadata = match input {
+        Input::Prompt(prompt) => prompt.turn_metadata.clone().unwrap_or_default(),
+        Input::FlowStep(flow_step) => flow_step.turn_metadata.clone().unwrap_or_default(),
+        Input::ExternalEvent(event) => RuntimeTurnMetadata {
             handling_mode: Some(event.handling_mode),
             render_metadata: event.render_metadata.clone(),
             ..Default::default()
-        }),
-        Input::Continuation(continuation) => Some(RuntimeTurnMetadata {
+        },
+        Input::Continuation(continuation) => RuntimeTurnMetadata {
             handling_mode: Some(continuation.handling_mode),
             ..Default::default()
-        }),
-        _ => None,
-    }
+        },
+        _ => RuntimeTurnMetadata::default(),
+    };
+    metadata.execution_kind = Some(semantics.execution_kind);
+    metadata.peer_response_terminal_apply_intent = semantics.peer_response_terminal_apply_intent;
+    metadata
 }
 
 /// Merge the per-input turn metadata carried by a staged batch into a single
@@ -57,16 +61,24 @@ pub(crate) fn for_input(
 /// shell defaults.
 pub(crate) fn merge_batch_turn_metadata(
     inputs: &[(meerkat_core::lifecycle::InputId, Input)],
+    semantics: &[crate::ingress_types::RuntimeInputSemantics],
 ) -> Result<
     Option<meerkat_core::lifecycle::run_primitive::RuntimeTurnMetadata>,
     meerkat_core::lifecycle::run_primitive::TurnMetadataMergeConflict,
 > {
     use meerkat_core::lifecycle::run_primitive::RuntimeTurnMetadata;
+    if inputs.len() != semantics.len() {
+        return Err(
+            meerkat_core::lifecycle::run_primitive::TurnMetadataMergeConflict {
+                field: "execution_kind",
+                reason: "runtime-stamped execution kind missing for one or more inputs",
+            },
+        );
+    }
+
     let mut acc: Option<RuntimeTurnMetadata> = None;
-    for (_, input) in inputs {
-        let Some(meta) = for_input(input) else {
-            continue;
-        };
+    for ((_, input), semantics) in inputs.iter().zip(semantics.iter()) {
+        let meta = for_input(input, *semantics);
         match acc.as_mut() {
             None => acc = Some(meta),
             Some(existing) => {
@@ -226,29 +238,20 @@ async fn prepare_turn_state_for_primitive(
 pub(crate) fn try_inputs_to_primitive_with_boundary(
     inputs: &[(InputId, Input)],
     boundary: RunApplyBoundary,
-    execution_kind: Option<meerkat_core::lifecycle::RuntimeExecutionKind>,
+    semantics: &[crate::ingress_types::RuntimeInputSemantics],
 ) -> Result<RunPrimitive, meerkat_core::lifecycle::run_primitive::TurnMetadataMergeConflict> {
     let projections = inputs
         .iter()
         .map(|(_, input)| runtime_input_projection_for_machine_batch(input))
         .collect::<Vec<_>>();
-    let peer_response_terminal_apply_intent =
-        fallback_batch_peer_response_terminal_apply_intent(inputs, boundary);
-    try_projected_inputs_to_primitive_with_boundary(
-        inputs,
-        &projections,
-        boundary,
-        execution_kind,
-        peer_response_terminal_apply_intent,
-    )
+    try_projected_inputs_to_primitive_with_boundary(inputs, &projections, boundary, semantics)
 }
 
 pub(crate) fn try_projected_inputs_to_primitive_with_boundary(
     inputs: &[(InputId, Input)],
     projections: &[crate::ingress_types::RuntimeInputProjection],
     boundary: RunApplyBoundary,
-    execution_kind: Option<meerkat_core::lifecycle::RuntimeExecutionKind>,
-    peer_response_terminal_apply_intent: Option<PeerResponseTerminalApplyIntent>,
+    semantics: &[crate::ingress_types::RuntimeInputSemantics],
 ) -> Result<RunPrimitive, meerkat_core::lifecycle::run_primitive::TurnMetadataMergeConflict> {
     let appends = projections
         .iter()
@@ -264,14 +267,7 @@ pub(crate) fn try_projected_inputs_to_primitive_with_boundary(
         .collect::<Vec<_>>();
     // Merge turn metadata from ALL inputs in the batch, not just the first.
     // Scalar conflicts are typed errors; collection fields accumulate.
-    let turn_metadata = merge_batch_turn_metadata(inputs)?;
-
-    let turn_metadata = {
-        let mut meta = turn_metadata.unwrap_or_default();
-        meta.execution_kind = execution_kind;
-        meta.peer_response_terminal_apply_intent = peer_response_terminal_apply_intent;
-        Some(meta)
-    };
+    let turn_metadata = merge_batch_turn_metadata(inputs, semantics)?;
 
     Ok(RunPrimitive::StagedInput(StagedRunInput {
         boundary,
@@ -286,8 +282,8 @@ pub(crate) fn inputs_to_primitive_with_boundary(
     inputs: &[(InputId, Input)],
     boundary: RunApplyBoundary,
 ) -> Result<RunPrimitive, meerkat_core::lifecycle::run_primitive::TurnMetadataMergeConflict> {
-    let execution_kind = fallback_batch_execution_kind(inputs);
-    try_inputs_to_primitive_with_boundary(inputs, boundary, execution_kind)
+    let semantics = fallback_batch_semantics(inputs);
+    try_inputs_to_primitive_with_boundary(inputs, boundary, &semantics)
 }
 
 pub(crate) fn inputs_to_primitive(
@@ -305,29 +301,13 @@ fn fallback_unadmitted_semantics(input: &Input) -> crate::ingress_types::Runtime
     crate::ingress_types::RuntimeInputSemantics::from_policy_and_kind(&policy, input.kind())
 }
 
-fn fallback_batch_execution_kind(
+fn fallback_batch_semantics(
     inputs: &[(InputId, Input)],
-) -> Option<meerkat_core::lifecycle::RuntimeExecutionKind> {
-    if inputs.is_empty() {
-        return None;
-    }
-    if inputs.iter().all(|(_, input)| {
-        fallback_unadmitted_semantics(input).execution_kind
-            == meerkat_core::lifecycle::RuntimeExecutionKind::ResumePending
-    }) {
-        Some(meerkat_core::lifecycle::RuntimeExecutionKind::ResumePending)
-    } else {
-        Some(meerkat_core::lifecycle::RuntimeExecutionKind::ContentTurn)
-    }
-}
-
-fn fallback_batch_peer_response_terminal_apply_intent(
-    inputs: &[(InputId, Input)],
-    _boundary: RunApplyBoundary,
-) -> Option<PeerResponseTerminalApplyIntent> {
-    inputs.iter().find_map(|(_, input)| {
-        fallback_unadmitted_semantics(input).peer_response_terminal_apply_intent
-    })
+) -> Vec<crate::ingress_types::RuntimeInputSemantics> {
+    inputs
+        .iter()
+        .map(|(_, input)| fallback_unadmitted_semantics(input))
+        .collect()
 }
 
 /// Convert an `Input` + its ID to a `RunPrimitive` for `CoreExecutor::apply()`.
@@ -662,22 +642,24 @@ async fn process_queue(
                 .iter()
                 .map(|(staged_input_id, _)| staged_input_id.clone())
                 .collect::<Vec<_>>();
-            let execution_kind =
-                crate::meerkat_machine::machine_batch_execution_kind(&d, &staged_ids);
-            let peer_response_terminal_apply_intent =
-                crate::meerkat_machine::machine_batch_peer_response_terminal_apply_intent(
-                    &d,
-                    &staged_ids,
-                );
+            let semantics =
+                crate::meerkat_machine::machine_batch_runtime_semantics(&d, &staged_ids);
             let projections =
                 crate::meerkat_machine::machine_batch_primitive_projections(&d, &staged_inputs);
-            let primitive = try_projected_inputs_to_primitive_with_boundary(
-                &staged_inputs,
-                &projections,
-                boundary,
-                execution_kind,
-                peer_response_terminal_apply_intent,
-            );
+            let primitive = match semantics {
+                Some(semantics) => try_projected_inputs_to_primitive_with_boundary(
+                    &staged_inputs,
+                    &projections,
+                    boundary,
+                    &semantics,
+                ),
+                None => Err(
+                    meerkat_core::lifecycle::run_primitive::TurnMetadataMergeConflict {
+                        field: "execution_kind",
+                        reason: "runtime-stamped execution kind missing for one or more inputs",
+                    },
+                ),
+            };
             Some((contributing_input_ids, staged_ids, run_id, primitive))
         };
 
@@ -828,7 +810,9 @@ mod tests {
     use super::*;
     use crate::input::*;
     use chrono::Utc;
-    use meerkat_core::lifecycle::run_primitive::{ConversationAppendRole, CoreRenderable};
+    use meerkat_core::lifecycle::run_primitive::{
+        ConversationAppendRole, CoreRenderable, PeerResponseTerminalApplyIntent,
+    };
     use std::sync::Arc;
 
     use meerkat_core::ops_lifecycle::{
@@ -1379,7 +1363,7 @@ mod tests {
         let primitive = try_inputs_to_primitive_with_boundary(
             &[(input.id().clone(), input)],
             semantics.boundary,
-            Some(semantics.execution_kind),
+            &[semantics],
         )
         .expect("single input metadata cannot conflict");
         let metadata = primitive
@@ -1492,8 +1476,12 @@ mod tests {
                 "terminal response batch must not absorb later normal peer messages"
             );
             assert_eq!(
-                crate::meerkat_machine::machine_batch_peer_response_terminal_apply_intent(
-                    &guard, &batch,
+                crate::meerkat_machine::machine_batch_runtime_semantics(&guard, &batch).and_then(
+                    |semantics| {
+                        semantics
+                            .into_iter()
+                            .find_map(|semantics| semantics.peer_response_terminal_apply_intent)
+                    }
                 ),
                 Some(PeerResponseTerminalApplyIntent::AppendContextAndRun)
             );
@@ -1519,8 +1507,12 @@ mod tests {
             "normal peer message batch must not absorb later terminal responses"
         );
         assert_eq!(
-            crate::meerkat_machine::machine_batch_peer_response_terminal_apply_intent(
-                &guard, &batch,
+            crate::meerkat_machine::machine_batch_runtime_semantics(&guard, &batch).and_then(
+                |semantics| {
+                    semantics
+                        .into_iter()
+                        .find_map(|semantics| semantics.peer_response_terminal_apply_intent)
+                }
             ),
             None
         );
@@ -2195,9 +2187,10 @@ mod tests {
     }
 
     #[test]
-    fn mixed_batch_defaults_to_content_turn() {
-        // If a batch contains both ContentTurn and ResumePending inputs,
-        // the whole batch must be ContentTurn (safe default).
+    fn mixed_batch_execution_kind_conflict_is_rejected() {
+        // Admission batches are already grouped by execution kind. A direct
+        // helper batch that mixes kinds must fail instead of inventing a local
+        // ContentTurn default.
         let peer = Input::Peer(PeerInput {
             header: InputHeader {
                 id: InputId::new(),
@@ -2225,16 +2218,10 @@ mod tests {
             (peer.id().clone(), peer),
             (continuation.id().clone(), continuation),
         ];
-        let primitive = inputs_to_primitive_with_boundary(&inputs, RunApplyBoundary::RunCheckpoint)
-            .expect("mixed test batch metadata should not conflict");
-        let meta = primitive
-            .turn_metadata()
-            .expect("should have turn_metadata");
-        assert_eq!(
-            meta.execution_kind,
-            Some(meerkat_core::lifecycle::RuntimeExecutionKind::ContentTurn),
-            "mixed batch must default to ContentTurn"
-        );
+        let err = inputs_to_primitive_with_boundary(&inputs, RunApplyBoundary::RunCheckpoint)
+            .expect_err("mixed execution kinds should be rejected");
+
+        assert_eq!(err.field, "execution_kind");
     }
 
     #[test]
@@ -2262,13 +2249,11 @@ mod tests {
             );
         }
         let inputs = vec![(first.id().clone(), first), (second.id().clone(), second)];
+        let semantics = fallback_batch_semantics(&inputs);
 
-        let err = try_inputs_to_primitive_with_boundary(
-            &inputs,
-            RunApplyBoundary::RunStart,
-            Some(meerkat_core::lifecycle::RuntimeExecutionKind::ContentTurn),
-        )
-        .expect_err("conflicting batch metadata should be rejected");
+        let err =
+            try_inputs_to_primitive_with_boundary(&inputs, RunApplyBoundary::RunStart, &semantics)
+                .expect_err("conflicting batch metadata should be rejected");
 
         assert_eq!(err.field, "model");
     }

--- a/meerkat-runtime/tests/core_apply_terminal_truth.rs
+++ b/meerkat-runtime/tests/core_apply_terminal_truth.rs
@@ -39,16 +39,13 @@ fn extract_braced_item<'a>(contents: &'a str, marker: &str) -> &'a str {
     panic!("unterminated braced item after `{marker}`");
 }
 
-fn assert_terminal_intent_validation_precedes_consumption(source: &str, owner: &str) {
+fn assert_terminal_intent_validation_precedes_markers(source: &str, owner: &str, markers: &[&str]) {
     let validation = source
         .find("primitive.peer_response_terminal_apply_intent_violation()")
         .unwrap_or_else(|| {
             panic!("{owner} must reject malformed terminal peer-response intent before applying it")
         });
-    for consumption in [
-        "primitive.is_context_only_apply_without_turn()",
-        "primitive.is_peer_response_terminal_context_and_run()",
-    ] {
+    for consumption in markers {
         let consumption = source
             .find(consumption)
             .unwrap_or_else(|| panic!("{owner} missing `{consumption}`"));
@@ -57,6 +54,15 @@ fn assert_terminal_intent_validation_precedes_consumption(source: &str, owner: &
             "{owner} must validate terminal peer-response intent before `{consumption}`"
         );
     }
+}
+
+fn assert_terminal_context_and_run_stages_pre_turn_appends(source: &str, owner: &str) {
+    assert!(
+        source.contains("primitive.is_peer_response_terminal_context_and_run()")
+            && source.contains("pending_system_context_appends(&staged.context_appends)")
+            && source.contains("pre_turn_context_appends"),
+        "{owner} must stage terminal context-and-run context into the admitted turn request"
+    );
 }
 
 #[test]
@@ -103,15 +109,25 @@ fn terminal_context_and_run_adapters_use_canonical_primitive_intent() {
         runtime_backed_apply.contains("primitive.is_context_only_apply_without_turn()"),
         "runtime-backed context shortcut must use the canonical primitive intent helper"
     );
-    assert_terminal_intent_validation_precedes_consumption(
+    assert_terminal_intent_validation_precedes_markers(
         runtime_backed_apply,
         "runtime-backed apply",
+        &[
+            "primitive.is_context_only_apply_without_turn()",
+            "start_turn_request_from_primitive(&primitive)",
+        ],
+    );
+    assert!(
+        runtime_backed_apply.contains("start_turn_request_from_primitive(&primitive)")
+            && runtime_backed_apply.contains(".apply_runtime_turn("),
+        "runtime-backed apply must build one admitted turn request before applying the reaction turn"
     );
 
-    assert!(
-        runtime_backed_apply.contains("primitive.is_peer_response_terminal_context_and_run()")
-            && runtime_backed_apply.contains("apply_runtime_system_context_for_turn"),
-        "runtime-backed terminal context-and-run apply must append context before the reaction turn"
+    let runtime_backed_request =
+        extract_braced_item(&runtime_backed, "fn start_turn_request_from_primitive");
+    assert_terminal_context_and_run_stages_pre_turn_appends(
+        runtime_backed_request,
+        "runtime-backed turn request builder",
     );
 
     let mcp_runtime_apply =
@@ -120,13 +136,16 @@ fn terminal_context_and_run_adapters_use_canonical_primitive_intent() {
         mcp_runtime_apply.contains("primitive.is_context_only_apply_without_turn()"),
         "MCP runtime ingress must not re-derive context-only terminal behavior from append shape"
     );
-    assert_terminal_intent_validation_precedes_consumption(
+    assert_terminal_intent_validation_precedes_markers(
         mcp_runtime_apply,
         "MCP runtime ingress apply",
+        &[
+            "primitive.is_context_only_apply_without_turn()",
+            "let pre_turn_context_appends = match primitive",
+        ],
     );
-    assert!(
-        mcp_runtime_apply.contains("primitive.is_peer_response_terminal_context_and_run()")
-            && mcp_runtime_apply.contains("apply_runtime_system_context_for_turn"),
-        "MCP runtime ingress must append terminal context-and-run context before the reaction turn"
+    assert_terminal_context_and_run_stages_pre_turn_appends(
+        mcp_runtime_apply,
+        "MCP runtime ingress apply",
     );
 }

--- a/meerkat-runtime/tests/driver_persistent.rs
+++ b/meerkat-runtime/tests/driver_persistent.rs
@@ -7,7 +7,9 @@ use async_trait::async_trait;
 use chrono::Utc;
 use meerkat_core::BlobStore;
 use meerkat_core::lifecycle::{
-    InputId, RunId, run_primitive::RunApplyBoundary, run_receipt::RunBoundaryReceipt,
+    InputId, RunId, RuntimeExecutionKind,
+    run_primitive::{RunApplyBoundary, RuntimeTurnMetadata},
+    run_receipt::RunBoundaryReceipt,
 };
 use meerkat_core::types::{ContentBlock, ImageData, SessionId};
 use meerkat_runtime::input_state::{InputStateSeed, StoredInputState};
@@ -321,6 +323,18 @@ fn make_prompt(text: &str) -> Input {
         blocks: None,
         turn_metadata: None,
     })
+}
+
+fn make_runtime_stamped_prompt(text: &str) -> Input {
+    let mut input = make_prompt(text);
+    let Input::Prompt(prompt) = &mut input else {
+        unreachable!("make_prompt must return prompt input");
+    };
+    prompt.turn_metadata = Some(RuntimeTurnMetadata {
+        execution_kind: Some(RuntimeExecutionKind::ContentTurn),
+        ..Default::default()
+    });
+    input
 }
 
 fn make_multimodal_prompt(text: &str, label: &str) -> Input {
@@ -1094,6 +1108,105 @@ async fn reset_persists_abandoned_inputs() {
         stored.seed.phase,
         meerkat_runtime::input_state::InputLifecycleState::Abandoned
     );
+}
+
+#[tokio::test]
+async fn recovery_rejecting_later_row_restores_partial_recovered_projection() {
+    let store = Arc::new(InMemoryRuntimeStore::new());
+    let rid = LogicalRuntimeId::new("test");
+
+    let valid_input = make_prompt("valid recovered row");
+    let valid_id = valid_input.id().clone();
+    let mut valid_state = InputState::new_accepted(valid_id.clone());
+    valid_state.persisted_input = Some(valid_input);
+    valid_state.durability = Some(InputDurability::Durable);
+    store
+        .persist_input_state(&rid, &stored_accepted(valid_state))
+        .await
+        .unwrap();
+
+    let invalid_input = make_prompt("unstamped recovered row");
+    let invalid_id = invalid_input.id().clone();
+    let mut invalid_state = InputState::new_accepted(invalid_id.clone());
+    invalid_state.persisted_input = Some(invalid_input);
+    invalid_state.durability = Some(InputDurability::Durable);
+    store
+        .persist_input_state(
+            &rid,
+            &StoredInputState {
+                state: invalid_state,
+                seed: InputStateSeed::new_accepted(),
+            },
+        )
+        .await
+        .unwrap();
+
+    let mut driver = PersistentRuntimeDriver::new(rid, store, memory_blob_store());
+    let err = driver
+        .recover()
+        .await
+        .expect_err("unstamped later row should fail recovery");
+
+    assert!(
+        err.to_string()
+            .contains("missing runtime execution semantics stamp"),
+        "unexpected error: {err}",
+    );
+    assert!(
+        driver.input_state(&valid_id).is_none(),
+        "failed recovery must roll back already admitted recovered rows",
+    );
+    assert!(
+        driver.input_state(&invalid_id).is_none(),
+        "failed recovery must not retain the rejected row",
+    );
+    assert!(
+        driver.dequeue_next().is_none(),
+        "failed recovery must not leave recovered queue projection",
+    );
+}
+
+#[tokio::test]
+async fn recover_migrates_legacy_turn_metadata_execution_stamp() {
+    let store = Arc::new(InMemoryRuntimeStore::new());
+    let rid = LogicalRuntimeId::new("test");
+
+    let input = make_runtime_stamped_prompt("legacy runtime-stamped row");
+    let input_id = input.id().clone();
+    let mut state = InputState::new_accepted(input_id.clone());
+    state.persisted_input = Some(input);
+    state.durability = Some(InputDurability::Durable);
+    store
+        .persist_input_state(
+            &rid,
+            &StoredInputState {
+                state,
+                seed: InputStateSeed::new_accepted(),
+            },
+        )
+        .await
+        .unwrap();
+
+    let mut driver = PersistentRuntimeDriver::new(rid.clone(), store.clone(), memory_blob_store());
+    driver
+        .recover()
+        .await
+        .expect("legacy runtime-stamped row should recover");
+
+    let recovered = driver
+        .input_state(&input_id)
+        .expect("recovered row should be present");
+    let semantics = recovered
+        .runtime_semantics
+        .expect("legacy turn metadata stamp should migrate to runtime semantics");
+    assert_eq!(semantics.execution_kind, RuntimeExecutionKind::ContentTurn);
+
+    let stored = store
+        .load_input_state(&rid, &input_id)
+        .await
+        .unwrap()
+        .expect("recovered row should be persisted");
+    assert_eq!(stored.state.runtime_semantics, Some(semantics));
 }
 
 #[tokio::test]

--- a/meerkat-runtime/tests/driver_persistent.rs
+++ b/meerkat-runtime/tests/driver_persistent.rs
@@ -28,12 +28,17 @@ fn stamp_runtime_semantics(state: &mut InputState) {
         return;
     };
     let policy = meerkat_runtime::DefaultPolicyTable::resolve(input, true);
+    let policy_version = policy.policy_version;
     state.runtime_semantics = Some(
         meerkat_runtime::ingress_types::RuntimeInputSemantics::from_policy_and_kind(
             &policy,
             input.kind(),
         ),
     );
+    state.policy = Some(meerkat_runtime::input_state::PolicySnapshot {
+        version: policy_version,
+        decision: policy,
+    });
 }
 
 fn stored_accepted(mut state: InputState) -> StoredInputState {

--- a/meerkat-runtime/tests/driver_persistent.rs
+++ b/meerkat-runtime/tests/driver_persistent.rs
@@ -12,7 +12,7 @@ use meerkat_core::lifecycle::{
     run_receipt::RunBoundaryReceipt,
 };
 use meerkat_core::types::{ContentBlock, ImageData, SessionId};
-use meerkat_runtime::input_state::{InputStateSeed, StoredInputState};
+use meerkat_runtime::input_state::{InputStateSeed, InputTerminalOutcome, StoredInputState};
 use meerkat_runtime::store::RuntimeStoreError;
 use meerkat_runtime::{
     InMemoryRuntimeStore, Input, InputDurability, InputHeader, InputOrigin, InputState,
@@ -1207,6 +1207,68 @@ async fn recover_migrates_legacy_turn_metadata_execution_stamp() {
         .unwrap()
         .expect("recovered row should be persisted");
     assert_eq!(stored.state.runtime_semantics, Some(semantics));
+}
+
+#[tokio::test]
+async fn recover_allows_legacy_unstamped_terminal_rows() {
+    use meerkat_runtime::input_state::InputLifecycleState;
+
+    let store = Arc::new(InMemoryRuntimeStore::new());
+    let rid = LogicalRuntimeId::new("test");
+
+    let input = make_prompt("legacy terminal row");
+    let input_id = input.id().clone();
+    let mut state = InputState::new_accepted(input_id.clone());
+    state.persisted_input = Some(input);
+    state.durability = Some(InputDurability::Durable);
+    state.terminal_outcome = Some(InputTerminalOutcome::Consumed);
+    store
+        .persist_input_state(
+            &rid,
+            &StoredInputState {
+                state,
+                seed: InputStateSeed {
+                    phase: InputLifecycleState::Consumed,
+                    last_run_id: None,
+                    last_boundary_sequence: None,
+                    terminal_outcome: Some(InputTerminalOutcome::Consumed),
+                    attempt_count: 0,
+                },
+            },
+        )
+        .await
+        .unwrap();
+
+    let mut driver = PersistentRuntimeDriver::new(rid.clone(), store.clone(), memory_blob_store());
+    driver
+        .recover()
+        .await
+        .expect("legacy unstamped terminal row should not block recovery");
+
+    assert!(
+        driver.input_state(&input_id).is_some(),
+        "terminal history should remain queryable after recovery"
+    );
+    assert_eq!(
+        driver.input_phase(&input_id),
+        Some(InputLifecycleState::Consumed)
+    );
+    assert!(
+        driver.active_input_ids().is_empty(),
+        "terminal rows must not become active"
+    );
+    assert!(
+        driver.dequeue_next().is_none(),
+        "terminal rows must not enter runtime queues"
+    );
+
+    let stored = store
+        .load_input_state(&rid, &input_id)
+        .await
+        .unwrap()
+        .expect("terminal row should remain persisted");
+    assert_eq!(stored.seed.phase, InputLifecycleState::Consumed);
+    assert_eq!(stored.state.runtime_semantics, None);
 }
 
 #[tokio::test]

--- a/meerkat-runtime/tests/driver_persistent.rs
+++ b/meerkat-runtime/tests/driver_persistent.rs
@@ -7,9 +7,7 @@ use async_trait::async_trait;
 use chrono::Utc;
 use meerkat_core::BlobStore;
 use meerkat_core::lifecycle::{
-    InputId, RunId, RuntimeExecutionKind,
-    run_primitive::{RunApplyBoundary, RuntimeTurnMetadata},
-    run_receipt::RunBoundaryReceipt,
+    InputId, RunId, run_primitive::RunApplyBoundary, run_receipt::RunBoundaryReceipt,
 };
 use meerkat_core::types::{ContentBlock, ImageData, SessionId};
 use meerkat_runtime::input_state::{InputStateSeed, InputTerminalOutcome, StoredInputState};
@@ -323,18 +321,6 @@ fn make_prompt(text: &str) -> Input {
         blocks: None,
         turn_metadata: None,
     })
-}
-
-fn make_runtime_stamped_prompt(text: &str) -> Input {
-    let mut input = make_prompt(text);
-    let Input::Prompt(prompt) = &mut input else {
-        unreachable!("make_prompt must return prompt input");
-    };
-    prompt.turn_metadata = Some(RuntimeTurnMetadata {
-        execution_kind: Some(RuntimeExecutionKind::ContentTurn),
-        ..Default::default()
-    });
-    input
 }
 
 fn make_multimodal_prompt(text: &str, label: &str) -> Input {
@@ -1164,49 +1150,6 @@ async fn recovery_rejecting_later_row_restores_partial_recovered_projection() {
         driver.dequeue_next().is_none(),
         "failed recovery must not leave recovered queue projection",
     );
-}
-
-#[tokio::test]
-async fn recover_migrates_legacy_turn_metadata_execution_stamp() {
-    let store = Arc::new(InMemoryRuntimeStore::new());
-    let rid = LogicalRuntimeId::new("test");
-
-    let input = make_runtime_stamped_prompt("legacy runtime-stamped row");
-    let input_id = input.id().clone();
-    let mut state = InputState::new_accepted(input_id.clone());
-    state.persisted_input = Some(input);
-    state.durability = Some(InputDurability::Durable);
-    store
-        .persist_input_state(
-            &rid,
-            &StoredInputState {
-                state,
-                seed: InputStateSeed::new_accepted(),
-            },
-        )
-        .await
-        .unwrap();
-
-    let mut driver = PersistentRuntimeDriver::new(rid.clone(), store.clone(), memory_blob_store());
-    driver
-        .recover()
-        .await
-        .expect("legacy runtime-stamped row should recover");
-
-    let recovered = driver
-        .input_state(&input_id)
-        .expect("recovered row should be present");
-    let semantics = recovered
-        .runtime_semantics
-        .expect("legacy turn metadata stamp should migrate to runtime semantics");
-    assert_eq!(semantics.execution_kind, RuntimeExecutionKind::ContentTurn);
-
-    let stored = store
-        .load_input_state(&rid, &input_id)
-        .await
-        .unwrap()
-        .expect("recovered row should be persisted");
-    assert_eq!(stored.state.runtime_semantics, Some(semantics));
 }
 
 #[tokio::test]

--- a/meerkat-runtime/tests/driver_persistent.rs
+++ b/meerkat-runtime/tests/driver_persistent.rs
@@ -23,7 +23,21 @@ fn memory_blob_store() -> Arc<dyn BlobStore> {
     Arc::new(MemoryBlobStore::new())
 }
 
-fn stored_accepted(state: InputState) -> StoredInputState {
+fn stamp_runtime_semantics(state: &mut InputState) {
+    let Some(input) = state.persisted_input.as_ref() else {
+        return;
+    };
+    let policy = meerkat_runtime::DefaultPolicyTable::resolve(input, true);
+    state.runtime_semantics = Some(
+        meerkat_runtime::ingress_types::RuntimeInputSemantics::from_policy_and_kind(
+            &policy,
+            input.kind(),
+        ),
+    );
+}
+
+fn stored_accepted(mut state: InputState) -> StoredInputState {
+    stamp_runtime_semantics(&mut state);
     StoredInputState {
         seed: InputStateSeed::new_accepted(),
         state,
@@ -1101,6 +1115,7 @@ async fn recover_consumes_committed_applied_pending_inputs() {
     // by seeding the DSL-owned phase + run association alongside the shell.
     use meerkat_runtime::input_state::InputLifecycleState;
     state.attempt_count = 1;
+    stamp_runtime_semantics(&mut state);
     let stored = StoredInputState {
         state,
         seed: InputStateSeed {
@@ -1171,6 +1186,7 @@ async fn recover_duplicate_legacy_input_row_keeps_canonical_boundary_receipt() {
     canonical_state.persisted_input = Some(input.clone());
     canonical_state.durability = Some(InputDurability::Durable);
     canonical_state.attempt_count = 1;
+    stamp_runtime_semantics(&mut canonical_state);
     let canonical_stored = StoredInputState {
         state: canonical_state.clone(),
         seed: InputStateSeed {
@@ -1243,6 +1259,7 @@ async fn recover_prefers_canonical_duplicate_over_newer_stale_legacy_row() {
     canonical_state.persisted_input = Some(input.clone());
     canonical_state.durability = Some(InputDurability::Durable);
     canonical_state.attempt_count = 1;
+    stamp_runtime_semantics(&mut canonical_state);
     let canonical_stored = StoredInputState {
         state: canonical_state.clone(),
         seed: InputStateSeed {
@@ -1309,6 +1326,7 @@ async fn recover_ignores_legacy_boundary_receipt_load_error_after_canonical_miss
     state.persisted_input = Some(input);
     state.durability = Some(InputDurability::Durable);
     state.attempt_count = 1;
+    stamp_runtime_semantics(&mut state);
     inner
         .persist_input_state(
             &canonical_rid,
@@ -1368,6 +1386,7 @@ async fn recover_treats_canonical_boundary_receipt_miss_as_authoritative() {
     state.persisted_input = Some(input);
     state.durability = Some(InputDurability::Durable);
     state.attempt_count = 1;
+    stamp_runtime_semantics(&mut state);
     store
         .persist_input_state(
             &canonical_rid,

--- a/meerkat-runtime/tests/recovery_contract.rs
+++ b/meerkat-runtime/tests/recovery_contract.rs
@@ -102,19 +102,26 @@ fn make_receipt(
     }
 }
 
-fn runtime_semantics_for(input: &Input) -> meerkat_runtime::ingress_types::RuntimeInputSemantics {
+fn stamp_runtime_metadata(state: &mut InputState, input: &Input) {
     let policy = meerkat_runtime::DefaultPolicyTable::resolve(input, true);
-    meerkat_runtime::ingress_types::RuntimeInputSemantics::from_policy_and_kind(
-        &policy,
-        input.kind(),
-    )
+    let policy_version = policy.policy_version;
+    state.runtime_semantics = Some(
+        meerkat_runtime::ingress_types::RuntimeInputSemantics::from_policy_and_kind(
+            &policy,
+            input.kind(),
+        ),
+    );
+    state.policy = Some(meerkat_runtime::input_state::PolicySnapshot {
+        version: policy_version,
+        decision: policy,
+    });
 }
 
 fn applied_pending_state(input: &Input, run_id: &RunId, sequence: u64) -> StoredInputState {
     let mut state = InputState::new_accepted(input.id().clone());
     state.persisted_input = Some(input.clone());
     state.durability = Some(InputDurability::Durable);
-    state.runtime_semantics = Some(runtime_semantics_for(input));
+    stamp_runtime_metadata(&mut state, input);
     // Simulate Accepted → Queued → Staged → Applied → AppliedPendingConsumption
     // by seeding the DSL-owned phase + run association alongside the shell.
     // The recovery path normalises these to a recovered phase based on the

--- a/meerkat-runtime/tests/recovery_contract.rs
+++ b/meerkat-runtime/tests/recovery_contract.rs
@@ -102,10 +102,19 @@ fn make_receipt(
     }
 }
 
+fn runtime_semantics_for(input: &Input) -> meerkat_runtime::ingress_types::RuntimeInputSemantics {
+    let policy = meerkat_runtime::DefaultPolicyTable::resolve(input, true);
+    meerkat_runtime::ingress_types::RuntimeInputSemantics::from_policy_and_kind(
+        &policy,
+        input.kind(),
+    )
+}
+
 fn applied_pending_state(input: &Input, run_id: &RunId, sequence: u64) -> StoredInputState {
     let mut state = InputState::new_accepted(input.id().clone());
     state.persisted_input = Some(input.clone());
     state.durability = Some(InputDurability::Durable);
+    state.runtime_semantics = Some(runtime_semantics_for(input));
     // Simulate Accepted → Queued → Staged → Applied → AppliedPendingConsumption
     // by seeding the DSL-owned phase + run association alongside the shell.
     // The recovery path normalises these to a recovered phase based on the

--- a/meerkat-runtime/tests/recovery_replay.rs
+++ b/meerkat-runtime/tests/recovery_replay.rs
@@ -46,19 +46,26 @@ fn make_prompt(text: &str) -> Input {
     })
 }
 
-fn runtime_semantics_for(input: &Input) -> meerkat_runtime::ingress_types::RuntimeInputSemantics {
+fn stamp_runtime_metadata(state: &mut InputState, input: &Input) {
     let policy = meerkat_runtime::DefaultPolicyTable::resolve(input, true);
-    meerkat_runtime::ingress_types::RuntimeInputSemantics::from_policy_and_kind(
-        &policy,
-        input.kind(),
-    )
+    let policy_version = policy.policy_version;
+    state.runtime_semantics = Some(
+        meerkat_runtime::ingress_types::RuntimeInputSemantics::from_policy_and_kind(
+            &policy,
+            input.kind(),
+        ),
+    );
+    state.policy = Some(meerkat_runtime::input_state::PolicySnapshot {
+        version: policy_version,
+        decision: policy,
+    });
 }
 
 fn applied_pending_state(input: &Input, run_id: &RunId, sequence: u64) -> StoredInputState {
     let mut state = InputState::new_accepted(input.id().clone());
     state.persisted_input = Some(input.clone());
     state.durability = Some(InputDurability::Durable);
-    state.runtime_semantics = Some(runtime_semantics_for(input));
+    stamp_runtime_metadata(&mut state, input);
     // Simulate Accepted → Queued → Staged → Applied → AppliedPendingConsumption
     // by seeding the DSL-owned phase + run association alongside the shell.
     state.attempt_count = 1;

--- a/meerkat-runtime/tests/recovery_replay.rs
+++ b/meerkat-runtime/tests/recovery_replay.rs
@@ -46,10 +46,19 @@ fn make_prompt(text: &str) -> Input {
     })
 }
 
+fn runtime_semantics_for(input: &Input) -> meerkat_runtime::ingress_types::RuntimeInputSemantics {
+    let policy = meerkat_runtime::DefaultPolicyTable::resolve(input, true);
+    meerkat_runtime::ingress_types::RuntimeInputSemantics::from_policy_and_kind(
+        &policy,
+        input.kind(),
+    )
+}
+
 fn applied_pending_state(input: &Input, run_id: &RunId, sequence: u64) -> StoredInputState {
     let mut state = InputState::new_accepted(input.id().clone());
     state.persisted_input = Some(input.clone());
     state.durability = Some(InputDurability::Durable);
+    state.runtime_semantics = Some(runtime_semantics_for(input));
     // Simulate Accepted → Queued → Staged → Applied → AppliedPendingConsumption
     // by seeding the DSL-owned phase + run association alongside the shell.
     state.attempt_count = 1;

--- a/meerkat-session/src/ephemeral.rs
+++ b/meerkat-session/src/ephemeral.rs
@@ -131,6 +131,10 @@ enum SessionCommand {
         appends: Vec<PendingSystemContextAppend>,
         reply_tx: oneshot::Sender<()>,
     },
+    PublishRuntimeSystemContextEvents {
+        appends: Vec<PendingSystemContextAppend>,
+        reply_tx: oneshot::Sender<()>,
+    },
     AppendExternalUserContent {
         content: ContentInput,
         reply_tx: oneshot::Sender<Result<(), meerkat_core::error::AgentError>>,
@@ -1062,6 +1066,32 @@ impl<B: SessionAgentBuilder + 'static> EphemeralSessionService<B> {
         handle
             .command_tx
             .send(SessionCommand::ApplyRuntimeSystemContext { appends, reply_tx })
+            .await
+            .map_err(|_| {
+                SessionError::Agent(meerkat_core::error::AgentError::InternalError(
+                    "Session task has exited".to_string(),
+                ))
+            })?;
+        reply_rx.await.map_err(|_| {
+            SessionError::Agent(meerkat_core::error::AgentError::InternalError(
+                "Session task dropped the reply channel".to_string(),
+            ))
+        })
+    }
+
+    pub async fn publish_runtime_system_context_events(
+        &self,
+        id: &SessionId,
+        appends: Vec<PendingSystemContextAppend>,
+    ) -> Result<(), SessionError> {
+        let sessions = self.sessions.read().await;
+        let handle = sessions
+            .get(id)
+            .ok_or_else(|| SessionError::NotFound { id: id.clone() })?;
+        let (reply_tx, reply_rx) = oneshot::channel();
+        handle
+            .command_tx
+            .send(SessionCommand::PublishRuntimeSystemContextEvents { appends, reply_tx })
             .await
             .map_err(|_| {
                 SessionError::Agent(meerkat_core::error::AgentError::InternalError(
@@ -2345,6 +2375,38 @@ fn apply_runtime_system_context_and_publish<A: SessionAgent>(
     }
 }
 
+fn publish_runtime_system_context_events<A: SessionAgent>(
+    agent: &A,
+    appends: &[PendingSystemContextAppend],
+    control: &SessionTaskControl,
+    next_seq: &mut u64,
+    source_id: &str,
+) {
+    if let Some(prompt) = render_runtime_system_context_event_prompt(appends) {
+        let session_id = agent.session_id();
+        let started = stamp_event_envelope(
+            next_seq,
+            source_id,
+            AgentEvent::RunStarted {
+                session_id: session_id.clone(),
+                prompt: ContentInput::Text(prompt),
+            },
+        );
+        let _ = control.session_event_tx.send(started);
+
+        let completed = stamp_event_envelope(
+            next_seq,
+            source_id,
+            AgentEvent::RunCompleted {
+                session_id,
+                result: String::new(),
+                usage: Usage::default(),
+            },
+        );
+        let _ = control.session_event_tx.send(completed);
+    }
+}
+
 fn lock_deferred_turn_state(
     state: &Arc<std::sync::Mutex<SessionDeferredTurnState>>,
 ) -> std::sync::MutexGuard<'_, SessionDeferredTurnState> {
@@ -2649,13 +2711,7 @@ async fn session_task<A: SessionAgent>(
                     }
                 }
                 if !pre_turn_context_appends.is_empty() {
-                    apply_runtime_system_context_and_publish(
-                        &mut agent,
-                        &pre_turn_context_appends,
-                        &control,
-                        &mut next_seq,
-                        &source_id,
-                    );
+                    agent.apply_runtime_system_context(&pre_turn_context_appends);
                 }
                 let mut event_stream_open = true;
 
@@ -2824,6 +2880,16 @@ async fn session_task<A: SessionAgent>(
             SessionCommand::ApplyRuntimeSystemContext { appends, reply_tx } => {
                 apply_runtime_system_context_and_publish(
                     &mut agent,
+                    &appends,
+                    &control,
+                    &mut next_seq,
+                    &source_id,
+                );
+                let _ = reply_tx.send(());
+            }
+            SessionCommand::PublishRuntimeSystemContextEvents { appends, reply_tx } => {
+                publish_runtime_system_context_events(
+                    &agent,
                     &appends,
                     &control,
                     &mut next_seq,

--- a/meerkat-session/src/ephemeral.rs
+++ b/meerkat-session/src/ephemeral.rs
@@ -1645,13 +1645,11 @@ impl<B: SessionAgentBuilder + 'static> SessionService for EphemeralSessionServic
             })?;
         }
 
-        let initial_execution_kind = req.build.as_ref().and_then(|build| {
-            matches!(
-                build.runtime_build_mode,
-                meerkat_core::runtime_epoch::RuntimeBuildMode::SessionOwned(_)
-            )
-            .then_some(meerkat_core::lifecycle::RuntimeExecutionKind::ContentTurn)
-        });
+        let initial_execution_kind = req
+            .build
+            .as_ref()
+            .and_then(|build| build.initial_turn_metadata.as_ref())
+            .and_then(|metadata| metadata.execution_kind);
 
         // Run the first turn
         let (result_tx, result_rx) = oneshot::channel();

--- a/meerkat-session/src/ephemeral.rs
+++ b/meerkat-session/src/ephemeral.rs
@@ -86,6 +86,7 @@ enum SessionCommand {
         result_tx: oneshot::Sender<Result<RunResult, meerkat_core::error::AgentError>>,
         skill_references: Option<Vec<meerkat_core::skills::SkillKey>>,
         flow_tool_overlay: Option<TurnToolOverlay>,
+        pre_turn_context_appends: Vec<PendingSystemContextAppend>,
         execution_kind: Option<meerkat_core::lifecycle::RuntimeExecutionKind>,
     },
     ReplaceClient {
@@ -1645,10 +1646,30 @@ impl<B: SessionAgentBuilder + 'static> SessionService for EphemeralSessionServic
             })?;
         }
 
-        let initial_execution_kind = req
+        let initial_turn_metadata = req
             .build
             .as_ref()
             .and_then(|build| build.initial_turn_metadata.as_ref())
+            .cloned();
+        let initial_render_metadata = req.render_metadata.or_else(|| {
+            initial_turn_metadata
+                .as_ref()
+                .and_then(|metadata| metadata.render_metadata.clone())
+        });
+        let initial_handling_mode = initial_turn_metadata
+            .as_ref()
+            .and_then(|metadata| metadata.handling_mode)
+            .unwrap_or(meerkat_core::types::HandlingMode::Queue);
+        let initial_skill_references = req.skill_references.or_else(|| {
+            initial_turn_metadata
+                .as_ref()
+                .and_then(|metadata| metadata.skill_references.clone())
+        });
+        let initial_flow_tool_overlay = initial_turn_metadata
+            .as_ref()
+            .and_then(|metadata| metadata.flow_tool_overlay.clone());
+        let initial_execution_kind = initial_turn_metadata
+            .as_ref()
             .and_then(|metadata| metadata.execution_kind);
 
         // Run the first turn
@@ -1656,12 +1677,13 @@ impl<B: SessionAgentBuilder + 'static> SessionService for EphemeralSessionServic
         if command_tx
             .send(SessionCommand::StartTurn {
                 prompt,
-                render_metadata: req.render_metadata,
-                handling_mode: meerkat_core::types::HandlingMode::Queue,
+                render_metadata: initial_render_metadata,
+                handling_mode: initial_handling_mode,
                 event_tx: caller_event_tx,
                 result_tx,
-                skill_references: req.skill_references,
-                flow_tool_overlay: None,
+                skill_references: initial_skill_references,
+                flow_tool_overlay: initial_flow_tool_overlay,
+                pre_turn_context_appends: Vec::new(),
                 execution_kind: initial_execution_kind,
             })
             .await
@@ -1776,6 +1798,7 @@ impl<B: SessionAgentBuilder + 'static> SessionService for EphemeralSessionServic
                     .as_ref()
                     .and_then(|metadata| metadata.flow_tool_overlay.clone())
             });
+            let pre_turn_context_appends = req.pre_turn_context_appends;
             let execution_kind = metadata
                 .as_ref()
                 .and_then(|metadata| metadata.execution_kind);
@@ -1790,6 +1813,7 @@ impl<B: SessionAgentBuilder + 'static> SessionService for EphemeralSessionServic
                     result_tx,
                     skill_references,
                     flow_tool_overlay,
+                    pre_turn_context_appends,
                     execution_kind,
                 })
                 .await
@@ -2280,6 +2304,47 @@ fn render_runtime_system_context_event_prompt(
     Some(rendered)
 }
 
+fn apply_runtime_system_context_and_publish<A: SessionAgent>(
+    agent: &mut A,
+    appends: &[PendingSystemContextAppend],
+    control: &SessionTaskControl,
+    next_seq: &mut u64,
+    source_id: &str,
+) {
+    agent.apply_runtime_system_context(appends);
+    let snap = agent.snapshot();
+    control.publish_summary(SessionSummaryCache {
+        updated_at: snap.updated_at,
+        message_count: snap.message_count,
+        total_tokens: snap.total_tokens,
+        usage: snap.usage,
+        last_assistant_text: snap.last_assistant_text,
+    });
+    if let Some(prompt) = render_runtime_system_context_event_prompt(appends) {
+        let session_id = agent.session_id();
+        let started = stamp_event_envelope(
+            next_seq,
+            source_id,
+            AgentEvent::RunStarted {
+                session_id: session_id.clone(),
+                prompt: ContentInput::Text(prompt),
+            },
+        );
+        let _ = control.session_event_tx.send(started);
+
+        let completed = stamp_event_envelope(
+            next_seq,
+            source_id,
+            AgentEvent::RunCompleted {
+                session_id,
+                result: String::new(),
+                usage: Usage::default(),
+            },
+        );
+        let _ = control.session_event_tx.send(completed);
+    }
+}
+
 fn lock_deferred_turn_state(
     state: &Arc<std::sync::Mutex<SessionDeferredTurnState>>,
 ) -> std::sync::MutexGuard<'_, SessionDeferredTurnState> {
@@ -2484,6 +2549,7 @@ async fn session_task<A: SessionAgent>(
                 result_tx,
                 skill_references,
                 flow_tool_overlay,
+                pre_turn_context_appends,
                 execution_kind,
             } => {
                 let current_phase = lock_turn_admission(&control.turn_admission).phase();
@@ -2531,6 +2597,16 @@ async fn session_task<A: SessionAgent>(
                     abort_admitted_turn(&control);
                     let _ = result_tx.send(Err(meerkat_core::error::AgentError::NoPendingBoundary));
                     continue;
+                }
+
+                if !pre_turn_context_appends.is_empty() {
+                    apply_runtime_system_context_and_publish(
+                        &mut agent,
+                        &pre_turn_context_appends,
+                        &control,
+                        &mut next_seq,
+                        &source_id,
+                    );
                 }
 
                 agent.set_skill_references(skill_references);
@@ -2747,38 +2823,13 @@ async fn session_task<A: SessionAgent>(
                 let _ = reply_tx.send(agent.external_tool_surface_snapshot());
             }
             SessionCommand::ApplyRuntimeSystemContext { appends, reply_tx } => {
-                agent.apply_runtime_system_context(&appends);
-                let snap = agent.snapshot();
-                control.publish_summary(SessionSummaryCache {
-                    updated_at: snap.updated_at,
-                    message_count: snap.message_count,
-                    total_tokens: snap.total_tokens,
-                    usage: snap.usage,
-                    last_assistant_text: snap.last_assistant_text,
-                });
-                if let Some(prompt) = render_runtime_system_context_event_prompt(&appends) {
-                    let session_id = agent.session_id();
-                    let started = stamp_event_envelope(
-                        &mut next_seq,
-                        &source_id,
-                        AgentEvent::RunStarted {
-                            session_id: session_id.clone(),
-                            prompt: ContentInput::Text(prompt),
-                        },
-                    );
-                    let _ = control.session_event_tx.send(started);
-
-                    let completed = stamp_event_envelope(
-                        &mut next_seq,
-                        &source_id,
-                        AgentEvent::RunCompleted {
-                            session_id,
-                            result: String::new(),
-                            usage: Usage::default(),
-                        },
-                    );
-                    let _ = control.session_event_tx.send(completed);
-                }
+                apply_runtime_system_context_and_publish(
+                    &mut agent,
+                    &appends,
+                    &control,
+                    &mut next_seq,
+                    &source_id,
+                );
                 let _ = reply_tx.send(());
             }
             SessionCommand::AppendExternalUserContent { content, reply_tx } => {
@@ -2893,6 +2944,261 @@ async fn session_task<A: SessionAgent>(
                 break;
             }
         }
+    }
+}
+
+#[cfg(test)]
+mod runtime_turn_metadata_tests {
+    use super::*;
+    use async_trait::async_trait;
+    use meerkat_core::lifecycle::RuntimeExecutionKind;
+    use meerkat_core::lifecycle::run_primitive::RuntimeTurnMetadata;
+    use meerkat_core::service::{
+        DeferredPromptPolicy, InitialTurnPolicy, SessionBuildOptions, SessionService,
+    };
+    use meerkat_core::skills::{SkillKey, SkillName};
+    use std::sync::{Arc, Mutex};
+
+    #[derive(Clone)]
+    struct MetadataProbeBuilder {
+        observed_skill_references: Arc<Mutex<Vec<Option<Vec<SkillKey>>>>>,
+        observed_context_texts: Arc<Mutex<Vec<String>>>,
+        run_context_counts: Arc<Mutex<Vec<usize>>>,
+    }
+
+    struct MetadataProbeAgent {
+        session_id: SessionId,
+        observed_skill_references: Arc<Mutex<Vec<Option<Vec<SkillKey>>>>>,
+        observed_context_texts: Arc<Mutex<Vec<String>>>,
+        run_context_counts: Arc<Mutex<Vec<usize>>>,
+        system_context_state: Arc<std::sync::Mutex<meerkat_core::SessionSystemContextState>>,
+    }
+
+    #[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
+    #[cfg_attr(not(target_arch = "wasm32"), async_trait)]
+    impl SessionAgentBuilder for MetadataProbeBuilder {
+        type Agent = MetadataProbeAgent;
+
+        async fn build_agent(
+            &self,
+            _req: &CreateSessionRequest,
+            _event_tx: mpsc::Sender<AgentEvent>,
+        ) -> Result<Self::Agent, SessionError> {
+            Ok(MetadataProbeAgent {
+                session_id: SessionId::new(),
+                observed_skill_references: Arc::clone(&self.observed_skill_references),
+                observed_context_texts: Arc::clone(&self.observed_context_texts),
+                run_context_counts: Arc::clone(&self.run_context_counts),
+                system_context_state: Arc::new(std::sync::Mutex::new(Default::default())),
+            })
+        }
+    }
+
+    #[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
+    #[cfg_attr(not(target_arch = "wasm32"), async_trait)]
+    impl SessionAgent for MetadataProbeAgent {
+        async fn run_with_events(
+            &mut self,
+            _prompt: ContentInput,
+            _event_tx: mpsc::Sender<AgentEvent>,
+        ) -> Result<RunResult, AgentError> {
+            self.run_context_counts
+                .lock()
+                .expect("run context counts lock poisoned")
+                .push(
+                    self.observed_context_texts
+                        .lock()
+                        .expect("observed context texts lock poisoned")
+                        .len(),
+                );
+            Ok(RunResult {
+                text: "ok".to_string(),
+                session_id: self.session_id.clone(),
+                usage: Usage::default(),
+                turns: 1,
+                tool_calls: 0,
+                structured_output: None,
+                schema_warnings: None,
+                skill_diagnostics: None,
+            })
+        }
+
+        fn set_skill_references(&mut self, refs: Option<Vec<SkillKey>>) {
+            self.observed_skill_references
+                .lock()
+                .expect("observed skill references lock poisoned")
+                .push(refs);
+        }
+
+        fn set_flow_tool_overlay(
+            &mut self,
+            _overlay: Option<TurnToolOverlay>,
+        ) -> Result<(), AgentError> {
+            Ok(())
+        }
+
+        fn hot_swap_llm_identity(
+            &mut self,
+            _client: Arc<dyn meerkat_core::AgentLlmClient>,
+            _identity: SessionLlmIdentity,
+            _request_policy: meerkat_core::SessionLlmRequestPolicy,
+        ) -> Result<(), AgentError> {
+            Ok(())
+        }
+
+        fn cancel(&mut self) {}
+
+        fn session_id(&self) -> SessionId {
+            self.session_id.clone()
+        }
+
+        fn snapshot(&self) -> SessionSnapshot {
+            SessionSnapshot {
+                created_at: SystemTime::now(),
+                updated_at: SystemTime::now(),
+                message_count: 0,
+                total_tokens: 0,
+                usage: Usage::default(),
+                last_assistant_text: None,
+            }
+        }
+
+        fn session_clone(&self) -> meerkat_core::Session {
+            meerkat_core::Session::new()
+        }
+
+        fn apply_runtime_system_context(&mut self, appends: &[PendingSystemContextAppend]) {
+            self.observed_context_texts
+                .lock()
+                .expect("observed context texts lock poisoned")
+                .extend(appends.iter().map(|append| append.text.clone()));
+        }
+
+        fn system_context_state(
+            &self,
+        ) -> Arc<std::sync::Mutex<meerkat_core::SessionSystemContextState>> {
+            Arc::clone(&self.system_context_state)
+        }
+    }
+
+    #[tokio::test]
+    async fn eager_initial_turn_forwards_full_runtime_metadata_carrier() {
+        let observed_skill_references = Arc::new(Mutex::new(Vec::new()));
+        let observed_context_texts = Arc::new(Mutex::new(Vec::new()));
+        let run_context_counts = Arc::new(Mutex::new(Vec::new()));
+        let service = EphemeralSessionService::new(
+            MetadataProbeBuilder {
+                observed_skill_references: Arc::clone(&observed_skill_references),
+                observed_context_texts,
+                run_context_counts,
+            },
+            1,
+        );
+        let skill = SkillKey::builtin(SkillName::parse("metadata-probe").expect("valid skill"));
+
+        service
+            .create_session(CreateSessionRequest {
+                model: "metadata-probe-model".to_string(),
+                prompt: ContentInput::Text("hello".to_string()),
+                render_metadata: None,
+                system_prompt: None,
+                max_tokens: None,
+                event_tx: None,
+                skill_references: None,
+                initial_turn: InitialTurnPolicy::RunImmediately,
+                deferred_prompt_policy: DeferredPromptPolicy::Discard,
+                build: Some(SessionBuildOptions {
+                    initial_turn_metadata: Some(RuntimeTurnMetadata {
+                        execution_kind: Some(RuntimeExecutionKind::ContentTurn),
+                        skill_references: Some(vec![skill.clone()]),
+                        ..Default::default()
+                    }),
+                    ..Default::default()
+                }),
+                labels: None,
+            })
+            .await
+            .expect("eager first turn should run");
+
+        assert_eq!(
+            *observed_skill_references
+                .lock()
+                .expect("observed skill references lock poisoned"),
+            vec![Some(vec![skill])],
+            "eager first turn must forward the full runtime metadata carrier"
+        );
+    }
+
+    #[tokio::test]
+    async fn start_turn_applies_pre_turn_context_before_run() {
+        let observed_skill_references = Arc::new(Mutex::new(Vec::new()));
+        let observed_context_texts = Arc::new(Mutex::new(Vec::new()));
+        let run_context_counts = Arc::new(Mutex::new(Vec::new()));
+        let service = EphemeralSessionService::new(
+            MetadataProbeBuilder {
+                observed_skill_references,
+                observed_context_texts: Arc::clone(&observed_context_texts),
+                run_context_counts: Arc::clone(&run_context_counts),
+            },
+            1,
+        );
+
+        let result = service
+            .create_session(CreateSessionRequest {
+                model: "metadata-probe-model".to_string(),
+                prompt: ContentInput::Text("defer".to_string()),
+                render_metadata: None,
+                system_prompt: None,
+                max_tokens: None,
+                event_tx: None,
+                skill_references: None,
+                initial_turn: InitialTurnPolicy::Defer,
+                deferred_prompt_policy: DeferredPromptPolicy::Discard,
+                build: Some(SessionBuildOptions::default()),
+                labels: None,
+            })
+            .await
+            .expect("deferred session should create");
+
+        service
+            .start_turn(
+                &result.session_id,
+                StartTurnRequest {
+                    prompt: ContentInput::Text("reaction".to_string()),
+                    system_prompt: None,
+                    render_metadata: None,
+                    handling_mode: meerkat_core::types::HandlingMode::Queue,
+                    event_tx: None,
+                    skill_references: None,
+                    flow_tool_overlay: None,
+                    pre_turn_context_appends: vec![PendingSystemContextAppend {
+                        text: "terminal peer context".to_string(),
+                        source: Some("peer_response_terminal:test:req".to_string()),
+                        idempotency_key: Some("peer_response_terminal:test:req".to_string()),
+                        accepted_at: meerkat_core::time_compat::SystemTime::now(),
+                    }],
+                    turn_metadata: Some(RuntimeTurnMetadata {
+                        execution_kind: Some(RuntimeExecutionKind::ContentTurn),
+                        ..Default::default()
+                    }),
+                },
+            )
+            .await
+            .expect("pre-turn context turn should run");
+
+        assert_eq!(
+            *observed_context_texts
+                .lock()
+                .expect("observed context texts lock poisoned"),
+            vec!["terminal peer context".to_string()]
+        );
+        assert_eq!(
+            *run_context_counts
+                .lock()
+                .expect("run context counts lock poisoned"),
+            vec![1],
+            "pre-turn context must be applied before the agent run starts"
+        );
     }
 }
 
@@ -3102,6 +3408,7 @@ mod inline_video_admission_tests {
             event_tx: None,
             skill_references: None,
             flow_tool_overlay: None,
+            pre_turn_context_appends: Vec::new(),
             turn_metadata: None,
         }
     }

--- a/meerkat-session/src/ephemeral.rs
+++ b/meerkat-session/src/ephemeral.rs
@@ -1645,6 +1645,14 @@ impl<B: SessionAgentBuilder + 'static> SessionService for EphemeralSessionServic
             })?;
         }
 
+        let initial_execution_kind = req.build.as_ref().and_then(|build| {
+            matches!(
+                build.runtime_build_mode,
+                meerkat_core::runtime_epoch::RuntimeBuildMode::SessionOwned(_)
+            )
+            .then_some(meerkat_core::lifecycle::RuntimeExecutionKind::ContentTurn)
+        });
+
         // Run the first turn
         let (result_tx, result_rx) = oneshot::channel();
         if command_tx
@@ -1656,7 +1664,7 @@ impl<B: SessionAgentBuilder + 'static> SessionService for EphemeralSessionServic
                 result_tx,
                 skill_references: req.skill_references,
                 flow_tool_overlay: None,
-                execution_kind: None, // non-runtime substrate-direct path
+                execution_kind: initial_execution_kind,
             })
             .await
             .is_err()

--- a/meerkat-session/src/ephemeral.rs
+++ b/meerkat-session/src/ephemeral.rs
@@ -2599,16 +2599,6 @@ async fn session_task<A: SessionAgent>(
                     continue;
                 }
 
-                if !pre_turn_context_appends.is_empty() {
-                    apply_runtime_system_context_and_publish(
-                        &mut agent,
-                        &pre_turn_context_appends,
-                        &control,
-                        &mut next_seq,
-                        &source_id,
-                    );
-                }
-
                 agent.set_skill_references(skill_references);
                 if let Err(error) = agent.set_flow_tool_overlay(flow_tool_overlay) {
                     restore_deferred_turn_inputs(
@@ -2657,6 +2647,15 @@ async fn session_task<A: SessionAgent>(
                             )));
                         continue;
                     }
+                }
+                if !pre_turn_context_appends.is_empty() {
+                    apply_runtime_system_context_and_publish(
+                        &mut agent,
+                        &pre_turn_context_appends,
+                        &control,
+                        &mut next_seq,
+                        &source_id,
+                    );
                 }
                 let mut event_stream_open = true;
 
@@ -2964,6 +2963,7 @@ mod runtime_turn_metadata_tests {
         observed_skill_references: Arc<Mutex<Vec<Option<Vec<SkillKey>>>>>,
         observed_context_texts: Arc<Mutex<Vec<String>>>,
         run_context_counts: Arc<Mutex<Vec<usize>>>,
+        fail_flow_overlay_set: bool,
     }
 
     struct MetadataProbeAgent {
@@ -2971,6 +2971,7 @@ mod runtime_turn_metadata_tests {
         observed_skill_references: Arc<Mutex<Vec<Option<Vec<SkillKey>>>>>,
         observed_context_texts: Arc<Mutex<Vec<String>>>,
         run_context_counts: Arc<Mutex<Vec<usize>>>,
+        fail_flow_overlay_set: bool,
         system_context_state: Arc<std::sync::Mutex<meerkat_core::SessionSystemContextState>>,
     }
 
@@ -2989,6 +2990,7 @@ mod runtime_turn_metadata_tests {
                 observed_skill_references: Arc::clone(&self.observed_skill_references),
                 observed_context_texts: Arc::clone(&self.observed_context_texts),
                 run_context_counts: Arc::clone(&self.run_context_counts),
+                fail_flow_overlay_set: self.fail_flow_overlay_set,
                 system_context_state: Arc::new(std::sync::Mutex::new(Default::default())),
             })
         }
@@ -3032,8 +3034,13 @@ mod runtime_turn_metadata_tests {
 
         fn set_flow_tool_overlay(
             &mut self,
-            _overlay: Option<TurnToolOverlay>,
+            overlay: Option<TurnToolOverlay>,
         ) -> Result<(), AgentError> {
+            if self.fail_flow_overlay_set && overlay.is_some() {
+                return Err(AgentError::ConfigError(
+                    "synthetic flow overlay failure".to_string(),
+                ));
+            }
             Ok(())
         }
 
@@ -3091,6 +3098,7 @@ mod runtime_turn_metadata_tests {
                 observed_skill_references: Arc::clone(&observed_skill_references),
                 observed_context_texts,
                 run_context_counts,
+                fail_flow_overlay_set: false,
             },
             1,
         );
@@ -3139,6 +3147,7 @@ mod runtime_turn_metadata_tests {
                 observed_skill_references,
                 observed_context_texts: Arc::clone(&observed_context_texts),
                 run_context_counts: Arc::clone(&run_context_counts),
+                fail_flow_overlay_set: false,
             },
             1,
         );
@@ -3198,6 +3207,87 @@ mod runtime_turn_metadata_tests {
                 .expect("run context counts lock poisoned"),
             vec![1],
             "pre-turn context must be applied before the agent run starts"
+        );
+    }
+
+    #[tokio::test]
+    async fn start_turn_does_not_apply_pre_turn_context_when_setup_fails() {
+        let observed_skill_references = Arc::new(Mutex::new(Vec::new()));
+        let observed_context_texts = Arc::new(Mutex::new(Vec::new()));
+        let run_context_counts = Arc::new(Mutex::new(Vec::new()));
+        let service = EphemeralSessionService::new(
+            MetadataProbeBuilder {
+                observed_skill_references,
+                observed_context_texts: Arc::clone(&observed_context_texts),
+                run_context_counts: Arc::clone(&run_context_counts),
+                fail_flow_overlay_set: true,
+            },
+            1,
+        );
+
+        let result = service
+            .create_session(CreateSessionRequest {
+                model: "metadata-probe-model".to_string(),
+                prompt: ContentInput::Text("defer".to_string()),
+                render_metadata: None,
+                system_prompt: None,
+                max_tokens: None,
+                event_tx: None,
+                skill_references: None,
+                initial_turn: InitialTurnPolicy::Defer,
+                deferred_prompt_policy: DeferredPromptPolicy::Discard,
+                build: Some(SessionBuildOptions::default()),
+                labels: None,
+            })
+            .await
+            .expect("deferred session should create");
+
+        let error = service
+            .start_turn(
+                &result.session_id,
+                StartTurnRequest {
+                    prompt: ContentInput::Text("reaction".to_string()),
+                    system_prompt: None,
+                    render_metadata: None,
+                    handling_mode: meerkat_core::types::HandlingMode::Queue,
+                    event_tx: None,
+                    skill_references: None,
+                    flow_tool_overlay: Some(TurnToolOverlay {
+                        allowed_tools: Some(vec!["flow_tool".to_string()]),
+                        blocked_tools: None,
+                    }),
+                    pre_turn_context_appends: vec![PendingSystemContextAppend {
+                        text: "must not leak before setup succeeds".to_string(),
+                        source: Some("peer_response_terminal:test:req".to_string()),
+                        idempotency_key: Some("peer_response_terminal:test:req".to_string()),
+                        accepted_at: meerkat_core::time_compat::SystemTime::now(),
+                    }],
+                    turn_metadata: Some(RuntimeTurnMetadata {
+                        execution_kind: Some(RuntimeExecutionKind::ContentTurn),
+                        ..Default::default()
+                    }),
+                },
+            )
+            .await
+            .expect_err("flow overlay setup should fail");
+
+        assert!(
+            error.to_string().contains("synthetic flow overlay failure"),
+            "unexpected error: {error}"
+        );
+        assert!(
+            observed_context_texts
+                .lock()
+                .expect("observed context texts lock poisoned")
+                .is_empty(),
+            "pre-turn context must not be visible when setup fails before run"
+        );
+        assert!(
+            run_context_counts
+                .lock()
+                .expect("run context counts lock poisoned")
+                .is_empty(),
+            "agent run must not start after setup failure"
         );
     }
 }

--- a/meerkat-session/src/ephemeral.rs
+++ b/meerkat-session/src/ephemeral.rs
@@ -1205,6 +1205,7 @@ impl<B: SessionAgentBuilder + 'static> EphemeralSessionService<B> {
         boundary: RunApplyBoundary,
         contributing_input_ids: Vec<InputId>,
     ) -> Result<CoreApplyOutput, SessionError> {
+        Self::require_runtime_execution_kind_stamp(&req)?;
         match self.start_turn(id, req).await {
             Ok(run_result) => {
                 self.build_runtime_output(
@@ -1241,6 +1242,24 @@ impl<B: SessionAgentBuilder + 'static> EphemeralSessionService<B> {
                 }
             }
         }
+    }
+
+    fn require_runtime_execution_kind_stamp(req: &StartTurnRequest) -> Result<(), SessionError> {
+        if req
+            .turn_metadata
+            .as_ref()
+            .and_then(|metadata| metadata.execution_kind)
+            .is_some()
+        {
+            return Ok(());
+        }
+
+        Err(SessionError::Agent(
+            meerkat_core::error::AgentError::InternalError(
+                "runtime_execution_kind not set: runtime-backed turn did not stamp RuntimeTurnMetadata.execution_kind"
+                    .to_string(),
+            ),
+        ))
     }
 
     pub async fn apply_runtime_context_appends(

--- a/meerkat-session/src/persistent.rs
+++ b/meerkat-session/src/persistent.rs
@@ -1229,6 +1229,7 @@ impl<B: SessionAgentBuilder + 'static> PersistentSessionService<B> {
         boundary: RunApplyBoundary,
         contributing_input_ids: Vec<InputId>,
         terminal: Option<CoreApplyTerminal>,
+        committed_context_events: Vec<PendingSystemContextAppend>,
     ) -> Result<CoreApplyOutput, SessionError> {
         let session = self.export_session_with_labels(id).await?;
         let persisted_session = self
@@ -1251,6 +1252,19 @@ impl<B: SessionAgentBuilder + 'static> PersistentSessionService<B> {
             )
             .await?;
 
+        if !committed_context_events.is_empty()
+            && let Err(error) = self
+                .inner
+                .publish_runtime_system_context_events(id, committed_context_events)
+                .await
+        {
+            tracing::warn!(
+                session_id = %id,
+                error = %error,
+                "failed to publish committed runtime system-context lifecycle events"
+            );
+        }
+
         let output = match terminal {
             Some(CoreApplyTerminal::RunResult(run_result)) => {
                 CoreApplyOutput::with_run_result(receipt, Some(session_snapshot), run_result)
@@ -1272,6 +1286,40 @@ impl<B: SessionAgentBuilder + 'static> PersistentSessionService<B> {
         };
 
         Ok(output)
+    }
+
+    async fn build_runtime_output_after_live_mutation(
+        &self,
+        id: &SessionId,
+        run_id: RunId,
+        boundary: RunApplyBoundary,
+        contributing_input_ids: Vec<InputId>,
+        terminal: Option<CoreApplyTerminal>,
+        committed_context_events: Vec<PendingSystemContextAppend>,
+    ) -> Result<CoreApplyOutput, SessionError> {
+        match self
+            .build_runtime_output(
+                id,
+                run_id,
+                boundary,
+                contributing_input_ids,
+                terminal,
+                committed_context_events,
+            )
+            .await
+        {
+            Ok(output) => Ok(output),
+            Err(error) => {
+                if let Err(discard_error) = self.discard_live_session(id).await {
+                    tracing::warn!(
+                        session_id = %id,
+                        error = %discard_error,
+                        "failed to discard live session after runtime output build failure"
+                    );
+                }
+                Err(error)
+            }
+        }
     }
 
     /// Apply a runtime-driven turn and return the authoritative boundary receipt.
@@ -1300,14 +1348,16 @@ impl<B: SessionAgentBuilder + 'static> PersistentSessionService<B> {
         contributing_input_ids: Vec<InputId>,
     ) -> Result<CoreApplyOutput, SessionError> {
         let _ = self.discard_stale_live_session_if_needed(id).await?;
+        let pre_turn_context_events = req.pre_turn_context_appends.clone();
         match self.inner.start_turn(id, req).await {
             Ok(run_result) => {
-                self.build_runtime_output(
+                self.build_runtime_output_after_live_mutation(
                     id,
                     run_id,
                     boundary,
                     contributing_input_ids,
                     Some(CoreApplyTerminal::RunResult(run_result)),
+                    pre_turn_context_events,
                 )
                 .await
             }
@@ -1318,17 +1368,19 @@ impl<B: SessionAgentBuilder + 'static> PersistentSessionService<B> {
                     boundary,
                     contributing_input_ids,
                     Some(CoreApplyTerminal::NoPendingBoundary),
+                    Vec::new(),
                 )
                 .await
             }
             Err(error) => {
                 if let Some(terminal) = Self::callback_pending_terminal(&error) {
-                    self.build_runtime_output(
+                    self.build_runtime_output_after_live_mutation(
                         id,
                         run_id,
                         boundary,
                         contributing_input_ids,
                         Some(terminal),
+                        pre_turn_context_events,
                     )
                     .await
                 } else {
@@ -3989,6 +4041,8 @@ mod tests {
 
     #[tokio::test]
     async fn test_failed_runtime_turn_discards_live_pre_turn_context() {
+        use futures::StreamExt;
+
         let store: Arc<dyn SessionStore> = Arc::new(MemoryStore::new());
         let runtime_store = Arc::new(InMemoryRuntimeStore::new());
         let service = PersistentSessionService::new(
@@ -4003,6 +4057,10 @@ mod tests {
             .create_session(create_request("seed", InitialTurnPolicy::Defer))
             .await
             .expect("create_session should succeed");
+        let mut events = service
+            .subscribe_session_events(&created.session_id)
+            .await
+            .expect("subscribe_session_events");
 
         let mut req = start_turn_request("runtime failed turn");
         req.pre_turn_context_appends = vec![PendingSystemContextAppend {
@@ -4033,6 +4091,12 @@ mod tests {
             error.to_string().contains("synthetic run failure"),
             "unexpected error: {error}"
         );
+        let event =
+            tokio::time::timeout(std::time::Duration::from_millis(100), events.next()).await;
+        assert!(
+            matches!(event, Err(_) | Ok(None)),
+            "failed runtime turn must not publish pre-turn context lifecycle events: {event:?}"
+        );
         assert!(
             !service
                 .has_live_session(&created.session_id)
@@ -4057,6 +4121,58 @@ mod tests {
                 !format!("{message:?}").contains("failed-turn context must not leak")
             }),
             "failed pre-turn context must not be committed into durable messages"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_failed_runtime_turn_output_commit_discards_live_session() {
+        let store = Arc::new(FailSaveStore::new());
+        let service = PersistentSessionService::new(
+            DummyBuilder,
+            4,
+            Arc::clone(&store) as Arc<dyn SessionStore>,
+            None,
+            memory_blob_store(),
+        );
+
+        let created = service
+            .create_session(create_request("seed", InitialTurnPolicy::Defer))
+            .await
+            .expect("create_session should succeed");
+
+        store.set_fail_save(true);
+        let error = service
+            .apply_runtime_turn(
+                &created.session_id,
+                RunId::new(),
+                start_turn_request("runtime turn with failed commit"),
+                RunApplyBoundary::RunStart,
+                vec![meerkat_core::lifecycle::InputId::new()],
+            )
+            .await
+            .expect_err("runtime output commit failure should propagate");
+
+        assert!(
+            matches!(error, SessionError::Store(_)),
+            "expected store error after runtime output commit failure, got {error:?}"
+        );
+        assert!(
+            !service
+                .has_live_session(&created.session_id)
+                .await
+                .expect("live-session status should succeed"),
+            "failed runtime output commit must discard the mutated live session"
+        );
+
+        store.set_fail_save(false);
+        let persisted = store
+            .load(&created.session_id)
+            .await
+            .expect("load should succeed")
+            .expect("deferred session row should remain durable");
+        assert!(
+            persisted.messages().is_empty(),
+            "failed runtime output commit must not persist the mutated turn"
         );
     }
 

--- a/meerkat-session/src/persistent.rs
+++ b/meerkat-session/src/persistent.rs
@@ -1332,6 +1332,13 @@ impl<B: SessionAgentBuilder + 'static> PersistentSessionService<B> {
                     )
                     .await
                 } else {
+                    if let Err(discard_error) = self.discard_live_session(id).await {
+                        tracing::warn!(
+                            session_id = %id,
+                            error = %discard_error,
+                            "failed to discard live session after failed runtime turn"
+                        );
+                    }
                     Err(error)
                 }
             }
@@ -2686,6 +2693,7 @@ mod tests {
     struct DummyAgent {
         session: Arc<std::sync::Mutex<Session>>,
         system_context_state: Arc<std::sync::Mutex<meerkat_core::SessionSystemContextState>>,
+        run_failure: Option<String>,
     }
 
     #[async_trait::async_trait]
@@ -2695,6 +2703,9 @@ mod tests {
             prompt: meerkat_core::types::ContentInput,
             _event_tx: tokio::sync::mpsc::Sender<meerkat_core::event::AgentEvent>,
         ) -> Result<RunResult, meerkat_core::error::AgentError> {
+            if let Some(message) = self.run_failure.clone() {
+                return Err(meerkat_core::error::AgentError::InternalError(message));
+            }
             let session_id = self.session_id();
             let result = {
                 let mut session = match self.session.lock() {
@@ -3037,6 +3048,7 @@ mod tests {
             Ok(DummyAgent {
                 session: Arc::new(std::sync::Mutex::new(session)),
                 system_context_state: Arc::new(std::sync::Mutex::new(system_context_state)),
+                run_failure: None,
             })
         }
     }
@@ -3062,7 +3074,33 @@ mod tests {
                 inner: DummyAgent {
                     session: Arc::new(std::sync::Mutex::new(session)),
                     system_context_state: Arc::new(std::sync::Mutex::new(system_context_state)),
+                    run_failure: None,
                 },
+            })
+        }
+    }
+
+    struct FailingRunBuilder;
+
+    #[async_trait::async_trait]
+    impl SessionAgentBuilder for FailingRunBuilder {
+        type Agent = DummyAgent;
+
+        async fn build_agent(
+            &self,
+            req: &CreateSessionRequest,
+            _event_tx: tokio::sync::mpsc::Sender<meerkat_core::event::AgentEvent>,
+        ) -> Result<Self::Agent, SessionError> {
+            let session = req
+                .build
+                .as_ref()
+                .and_then(|build| build.resume_session.clone())
+                .unwrap_or_default();
+            let system_context_state = session.system_context_state().unwrap_or_default();
+            Ok(DummyAgent {
+                session: Arc::new(std::sync::Mutex::new(session)),
+                system_context_state: Arc::new(std::sync::Mutex::new(system_context_state)),
+                run_failure: Some("synthetic run failure".to_string()),
             })
         }
     }
@@ -3100,6 +3138,7 @@ mod tests {
             Ok(DummyAgent {
                 session: Arc::new(std::sync::Mutex::new(session)),
                 system_context_state: Arc::new(std::sync::Mutex::new(system_context_state)),
+                run_failure: None,
             })
         }
     }
@@ -3302,6 +3341,7 @@ mod tests {
             Ok(DummyAgent {
                 session: Arc::new(std::sync::Mutex::new(session)),
                 system_context_state: Arc::new(std::sync::Mutex::new(system_context_state)),
+                run_failure: None,
             })
         }
     }
@@ -3945,6 +3985,79 @@ mod tests {
             output.terminal,
             Some(CoreApplyTerminal::NoPendingBoundary)
         ));
+    }
+
+    #[tokio::test]
+    async fn test_failed_runtime_turn_discards_live_pre_turn_context() {
+        let store: Arc<dyn SessionStore> = Arc::new(MemoryStore::new());
+        let runtime_store = Arc::new(InMemoryRuntimeStore::new());
+        let service = PersistentSessionService::new(
+            FailingRunBuilder,
+            4,
+            Arc::clone(&store),
+            Some(runtime_store),
+            memory_blob_store(),
+        );
+
+        let created = service
+            .create_session(create_request("seed", InitialTurnPolicy::Defer))
+            .await
+            .expect("create_session should succeed");
+
+        let mut req = start_turn_request("runtime failed turn");
+        req.pre_turn_context_appends = vec![PendingSystemContextAppend {
+            text: "failed-turn context must not leak".to_string(),
+            source: Some("peer_response_terminal:test:req".to_string()),
+            idempotency_key: Some("peer_response_terminal:test:req".to_string()),
+            accepted_at: meerkat_core::time_compat::SystemTime::now(),
+        }];
+        req.turn_metadata = Some(
+            meerkat_core::lifecycle::run_primitive::RuntimeTurnMetadata {
+                execution_kind: Some(meerkat_core::lifecycle::RuntimeExecutionKind::ContentTurn),
+                ..Default::default()
+            },
+        );
+
+        let error = service
+            .apply_runtime_turn(
+                &created.session_id,
+                RunId::new(),
+                req,
+                RunApplyBoundary::RunStart,
+                vec![meerkat_core::lifecycle::InputId::new()],
+            )
+            .await
+            .expect_err("synthetic run failure should propagate");
+
+        assert!(
+            error.to_string().contains("synthetic run failure"),
+            "unexpected error: {error}"
+        );
+        assert!(
+            !service
+                .has_live_session(&created.session_id)
+                .await
+                .expect("live-session status should succeed"),
+            "failed runtime turn must discard the live session carrying uncommitted pre-turn context"
+        );
+
+        let authoritative = service
+            .load_authoritative_session(&created.session_id)
+            .await
+            .expect("authoritative load should succeed")
+            .expect("created session should remain durable");
+        assert!(
+            authoritative
+                .system_context_state()
+                .is_none_or(|state| state.applied.is_empty()),
+            "failed pre-turn context must not be committed to durable session state"
+        );
+        assert!(
+            authoritative.messages().iter().all(|message| {
+                !format!("{message:?}").contains("failed-turn context must not leak")
+            }),
+            "failed pre-turn context must not be committed into durable messages"
+        );
     }
 
     #[tokio::test]

--- a/meerkat-session/src/persistent.rs
+++ b/meerkat-session/src/persistent.rs
@@ -1347,6 +1347,7 @@ impl<B: SessionAgentBuilder + 'static> PersistentSessionService<B> {
         boundary: RunApplyBoundary,
         contributing_input_ids: Vec<InputId>,
     ) -> Result<CoreApplyOutput, SessionError> {
+        Self::require_runtime_execution_kind_stamp(&req)?;
         let _ = self.discard_stale_live_session_if_needed(id).await?;
         let pre_turn_context_events = req.pre_turn_context_appends.clone();
         match self.inner.start_turn(id, req).await {
@@ -1395,6 +1396,24 @@ impl<B: SessionAgentBuilder + 'static> PersistentSessionService<B> {
                 }
             }
         }
+    }
+
+    fn require_runtime_execution_kind_stamp(req: &StartTurnRequest) -> Result<(), SessionError> {
+        if req
+            .turn_metadata
+            .as_ref()
+            .and_then(|metadata| metadata.execution_kind)
+            .is_some()
+        {
+            return Ok(());
+        }
+
+        Err(SessionError::Agent(
+            meerkat_core::error::AgentError::InternalError(
+                "runtime_execution_kind not set: runtime-backed turn did not stamp RuntimeTurnMetadata.execution_kind"
+                    .to_string(),
+            ),
+        ))
     }
 
     pub async fn apply_runtime_context_appends(
@@ -3681,6 +3700,17 @@ mod tests {
         }
     }
 
+    fn runtime_content_turn_request(prompt: &str) -> StartTurnRequest {
+        let mut req = start_turn_request(prompt);
+        req.turn_metadata = Some(
+            meerkat_core::lifecycle::run_primitive::RuntimeTurnMetadata {
+                execution_kind: Some(meerkat_core::lifecycle::RuntimeExecutionKind::ContentTurn),
+                ..Default::default()
+            },
+        );
+        req
+    }
+
     fn start_turn_request_with_system_prompt(
         prompt: &str,
         system_prompt: Option<&str>,
@@ -3963,14 +3993,13 @@ mod tests {
             .expect("create_session should succeed");
 
         let run_id = RunId::new();
+        let mut req = runtime_content_turn_request("ignored");
+        req.prompt = image_prompt("runtime");
         service
             .apply_runtime_turn(
                 &created.session_id,
                 run_id,
-                StartTurnRequest {
-                    prompt: image_prompt("runtime"),
-                    ..start_turn_request("ignored")
-                },
+                req,
                 RunApplyBoundary::RunStart,
                 vec![],
             )
@@ -4037,6 +4066,42 @@ mod tests {
             output.terminal,
             Some(CoreApplyTerminal::NoPendingBoundary)
         ));
+    }
+
+    #[tokio::test]
+    async fn test_apply_runtime_turn_rejects_missing_execution_kind_before_no_pending_terminal() {
+        let store: Arc<dyn SessionStore> = Arc::new(MemoryStore::new());
+        let runtime_store = Arc::new(InMemoryRuntimeStore::new());
+        let service = PersistentSessionService::new(
+            DummyBuilder,
+            4,
+            Arc::clone(&store),
+            Some(runtime_store),
+            memory_blob_store(),
+        );
+
+        let created = service
+            .create_session(create_request("seed", InitialTurnPolicy::Defer))
+            .await
+            .expect("create_session should succeed");
+
+        let error = service
+            .apply_runtime_turn(
+                &created.session_id,
+                RunId::new(),
+                start_turn_request(""),
+                RunApplyBoundary::RunStart,
+                vec![meerkat_core::lifecycle::InputId::new()],
+            )
+            .await
+            .expect_err(
+                "runtime apply must reject missing execution kind before no-pending commit",
+            );
+
+        assert!(
+            error.to_string().contains("runtime_execution_kind not set"),
+            "unexpected error: {error}"
+        );
     }
 
     #[tokio::test]
@@ -4145,7 +4210,7 @@ mod tests {
             .apply_runtime_turn(
                 &created.session_id,
                 RunId::new(),
-                start_turn_request("runtime turn with failed commit"),
+                runtime_content_turn_request("runtime turn with failed commit"),
                 RunApplyBoundary::RunStart,
                 vec![meerkat_core::lifecycle::InputId::new()],
             )
@@ -4913,7 +4978,7 @@ mod tests {
             .apply_runtime_turn(
                 &result.session_id,
                 RunId::new(),
-                start_turn_request("runtime committed turn"),
+                runtime_content_turn_request("runtime committed turn"),
                 RunApplyBoundary::Immediate,
                 vec![],
             )
@@ -4997,7 +5062,7 @@ mod tests {
             .apply_runtime_turn(
                 &result.session_id,
                 RunId::new(),
-                start_turn_request("runtime committed turn"),
+                runtime_content_turn_request("runtime committed turn"),
                 RunApplyBoundary::Immediate,
                 vec![],
             )
@@ -5954,7 +6019,7 @@ mod tests {
             .apply_runtime_turn(
                 &result.session_id,
                 RunId::new(),
-                start_turn_request("runtime committed turn"),
+                runtime_content_turn_request("runtime committed turn"),
                 RunApplyBoundary::Immediate,
                 vec![],
             )

--- a/meerkat-session/src/persistent.rs
+++ b/meerkat-session/src/persistent.rs
@@ -3584,6 +3584,7 @@ mod tests {
             event_tx: None,
             skill_references: None,
             flow_tool_overlay: None,
+            pre_turn_context_appends: Vec::new(),
             turn_metadata: None,
         }
     }
@@ -3600,6 +3601,7 @@ mod tests {
             event_tx: None,
             skill_references: None,
             flow_tool_overlay: None,
+            pre_turn_context_appends: Vec::new(),
             turn_metadata: None,
         }
     }

--- a/meerkat-session/tests/ephemeral_contract.rs
+++ b/meerkat-session/tests/ephemeral_contract.rs
@@ -816,6 +816,17 @@ fn turn_req(prompt: &str) -> StartTurnRequest {
     }
 }
 
+fn runtime_content_turn_req(prompt: &str) -> StartTurnRequest {
+    let mut req = turn_req(prompt);
+    req.turn_metadata = Some(
+        meerkat_core::lifecycle::run_primitive::RuntimeTurnMetadata {
+            execution_kind: Some(meerkat_core::lifecycle::RuntimeExecutionKind::ContentTurn),
+            ..Default::default()
+        },
+    );
+    req
+}
+
 // ---------------------------------------------------------------------------
 // Contract tests
 // ---------------------------------------------------------------------------
@@ -1427,7 +1438,7 @@ async fn test_apply_runtime_turn_returns_callback_pending_terminal() -> Result<(
         .apply_runtime_turn(
             &session_id,
             run_id.clone(),
-            turn_req("needs callback"),
+            runtime_content_turn_req("needs callback"),
             RunApplyBoundary::RunStart,
             contributing_input_ids.clone(),
         )
@@ -1446,6 +1457,40 @@ async fn test_apply_runtime_turn_returns_callback_pending_terminal() -> Result<(
     };
     assert_eq!(tool_name, "external_mock");
     assert_eq!(args, json!({ "value": "browser" }));
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_apply_runtime_turn_rejects_missing_execution_kind_before_no_pending_terminal()
+-> Result<(), String> {
+    let service = make_service(MockAgentBuilder::new());
+    let mut create = create_req_deferred("Hello");
+    create.deferred_prompt_policy = DeferredPromptPolicy::Discard;
+    let _ = service
+        .create_session(create)
+        .await
+        .expect("create deferred session");
+    let session_id = service
+        .list(SessionQuery::default())
+        .await
+        .expect("list sessions")[0]
+        .session_id
+        .clone();
+
+    let error = service
+        .apply_runtime_turn(
+            &session_id,
+            meerkat_core::lifecycle::RunId::new(),
+            turn_req(""),
+            RunApplyBoundary::RunStart,
+            vec![meerkat_core::lifecycle::InputId::new()],
+        )
+        .await
+        .expect_err("runtime apply must reject missing execution kind before no-pending commit");
+
+    if !error.to_string().contains("runtime_execution_kind not set") {
+        return Err(format!("unexpected error: {error}"));
+    }
     Ok(())
 }
 

--- a/meerkat-session/tests/ephemeral_contract.rs
+++ b/meerkat-session/tests/ephemeral_contract.rs
@@ -811,6 +811,7 @@ fn turn_req(prompt: &str) -> StartTurnRequest {
         event_tx: None,
         skill_references: None,
         flow_tool_overlay: None,
+        pre_turn_context_appends: Vec::new(),
         turn_metadata: None,
     }
 }

--- a/meerkat-session/tests/regression_lifecycle.rs
+++ b/meerkat-session/tests/regression_lifecycle.rs
@@ -602,6 +602,7 @@ fn turn_req(prompt: &str) -> StartTurnRequest {
         event_tx: None,
         skill_references: None,
         flow_tool_overlay: None,
+        pre_turn_context_appends: Vec::new(),
         turn_metadata: None,
     }
 }

--- a/meerkat-session/tests/regression_lifecycle.rs
+++ b/meerkat-session/tests/regression_lifecycle.rs
@@ -1181,6 +1181,7 @@ async fn start_turn_forwards_handling_mode_and_render_metadata() {
                 event_tx: None,
                 skill_references: None,
                 flow_tool_overlay: None,
+                pre_turn_context_appends: Vec::new(),
                 turn_metadata: None,
             },
         )

--- a/meerkat-web-runtime/src/lib.rs
+++ b/meerkat-web-runtime/src/lib.rs
@@ -1417,6 +1417,7 @@ pub async fn start_turn(handle: u32, prompt: &str) -> Result<JsValue, JsValue> {
                 event_tx: None,
                 skill_references: None,
                 flow_tool_overlay: None,
+                pre_turn_context_appends: Vec::new(),
                 turn_metadata: None,
             },
         )

--- a/meerkat/BUILD.bazel
+++ b/meerkat/BUILD.bazel
@@ -459,7 +459,6 @@ rust_test(
     size = "small",
     data = [
         ":package_runfiles",
-        "//meerkat-core:package_runfiles",
     ],
     env = {
         "RUST_MIN_STACK": "16777216",

--- a/meerkat/src/factory.rs
+++ b/meerkat/src/factory.rs
@@ -3759,6 +3759,7 @@ impl AgentFactory {
                 builder =
                     builder.with_tool_visibility_owner(Arc::clone(&bindings.tool_visibility_owner));
                 builder = builder.with_turn_state_handle(Arc::clone(&bindings.turn_state));
+                builder = builder.require_runtime_execution_kind_stamp();
                 builder = builder
                     .with_external_tool_surface_handle(Arc::clone(&bindings.external_tool_surface));
                 builder = builder.with_auth_lease_handle(Arc::clone(&bindings.auth_lease));

--- a/meerkat/src/factory.rs
+++ b/meerkat/src/factory.rs
@@ -624,6 +624,7 @@ impl AgentBuildConfig {
             call_timeout_override: self.call_timeout_override.clone(),
             resume_override_mask: self.resume_override_mask,
             runtime_build_mode: self.runtime_build_mode.clone(),
+            initial_turn_metadata: None,
         }
     }
 }

--- a/meerkat/src/service_factory.rs
+++ b/meerkat/src/service_factory.rs
@@ -1151,9 +1151,16 @@ mod tests {
             .await
             .map_err(|err| format!("{err}"))?;
         let (run_tx, _run_rx) = mpsc::channel(8);
-        SessionAgent::run_with_events(&mut agent, "inspect".to_string().into(), run_tx)
-            .await
-            .map_err(|err| format!("{err}"))?;
+        SessionAgent::run_turn_with_events(
+            &mut agent,
+            "inspect".to_string().into(),
+            HandlingMode::Queue,
+            None,
+            Some(meerkat_core::lifecycle::RuntimeExecutionKind::ContentTurn),
+            run_tx,
+        )
+        .await
+        .map_err(|err| format!("{err}"))?;
 
         let tool_names = capture.tool_names();
         assert!(
@@ -1212,9 +1219,16 @@ mod tests {
             .await
             .map_err(|err| format!("{err}"))?;
         let (run_tx, _run_rx) = mpsc::channel(8);
-        SessionAgent::run_with_events(&mut agent, "inspect".to_string().into(), run_tx)
-            .await
-            .map_err(|err| format!("{err}"))?;
+        SessionAgent::run_turn_with_events(
+            &mut agent,
+            "inspect".to_string().into(),
+            HandlingMode::Queue,
+            None,
+            Some(meerkat_core::lifecycle::RuntimeExecutionKind::ContentTurn),
+            run_tx,
+        )
+        .await
+        .map_err(|err| format!("{err}"))?;
 
         let tool_names = capture.tool_names();
         assert!(tool_names.iter().any(|name| name == "generate_image"));

--- a/meerkat/src/surface/runtime_backed.rs
+++ b/meerkat/src/surface/runtime_backed.rs
@@ -79,11 +79,10 @@ where
     let mut build = request.build.unwrap_or_default();
     build.resume_session = Some(session);
     build.runtime_build_mode = meerkat_core::RuntimeBuildMode::SessionOwned(bindings);
-    if request.initial_turn == meerkat_core::service::InitialTurnPolicy::RunImmediately
-        && build.initial_turn_metadata.is_none()
-    {
-        build.initial_turn_metadata =
-            Some(meerkat_runtime::runtime_stamped_prompt_turn_metadata(None));
+    if request.initial_turn == meerkat_core::service::InitialTurnPolicy::RunImmediately {
+        build.initial_turn_metadata = Some(meerkat_runtime::runtime_stamped_prompt_turn_metadata(
+            build.initial_turn_metadata.take(),
+        ));
     }
     request.build = Some(build);
 
@@ -617,6 +616,41 @@ mod tests {
         ))
         .await
         .expect("runtime-backed eager create should receive stamped metadata");
+
+        assert_eq!(result.text, "ok");
+        service
+            .discard_live_session(&result.session_id)
+            .await
+            .expect("discard live session");
+        adapter.unregister_session(&result.session_id).await;
+    }
+
+    #[tokio::test]
+    async fn materialize_session_stamps_existing_eager_initial_turn_metadata() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let (service, adapter) = build_test_service(&temp).await;
+
+        let mut request = make_request(SessionBuildOptions {
+            initial_turn_metadata: Some(RuntimeTurnMetadata {
+                handling_mode: Some(HandlingMode::Queue),
+                ..Default::default()
+            }),
+            ..Default::default()
+        });
+        request.initial_turn = meerkat_core::service::InitialTurnPolicy::RunImmediately;
+        let result = Box::pin(materialize_session(
+            &service,
+            &adapter,
+            Session::new(),
+            request,
+            {
+                let service = Arc::clone(&service);
+                let adapter = Arc::clone(&adapter);
+                move |session_id| default_persistent_executor(service, adapter, session_id)
+            },
+        ))
+        .await
+        .expect("runtime-backed eager create should stamp supplied metadata");
 
         assert_eq!(result.text, "ok");
         service

--- a/meerkat/src/surface/runtime_backed.rs
+++ b/meerkat/src/surface/runtime_backed.rs
@@ -79,6 +79,12 @@ where
     let mut build = request.build.unwrap_or_default();
     build.resume_session = Some(session);
     build.runtime_build_mode = meerkat_core::RuntimeBuildMode::SessionOwned(bindings);
+    if request.initial_turn == meerkat_core::service::InitialTurnPolicy::RunImmediately
+        && build.initial_turn_metadata.is_none()
+    {
+        build.initial_turn_metadata =
+            Some(meerkat_runtime::runtime_stamped_prompt_turn_metadata(None));
+    }
     request.build = Some(build);
 
     let result = match service.create_session(request).await {
@@ -589,6 +595,66 @@ mod tests {
             .await
             .expect("discard live session");
         adapter.unregister_session(&result.session_id).await;
+    }
+
+    #[tokio::test]
+    async fn materialize_session_stamps_eager_initial_turn_execution_kind() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let (service, adapter) = build_test_service(&temp).await;
+
+        let mut request = make_request(SessionBuildOptions::default());
+        request.initial_turn = meerkat_core::service::InitialTurnPolicy::RunImmediately;
+        let result = Box::pin(materialize_session(
+            &service,
+            &adapter,
+            Session::new(),
+            request,
+            {
+                let service = Arc::clone(&service);
+                let adapter = Arc::clone(&adapter);
+                move |session_id| default_persistent_executor(service, adapter, session_id)
+            },
+        ))
+        .await
+        .expect("runtime-backed eager create should receive stamped metadata");
+
+        assert_eq!(result.text, "ok");
+        service
+            .discard_live_session(&result.session_id)
+            .await
+            .expect("discard live session");
+        adapter.unregister_session(&result.session_id).await;
+    }
+
+    #[tokio::test]
+    async fn direct_runtime_owned_eager_create_rejects_missing_execution_kind_stamp() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let (service, adapter) = build_test_service(&temp).await;
+        let session = Session::new();
+        let session_id = session.id().clone();
+        let bindings = adapter
+            .prepare_bindings(session_id.clone())
+            .await
+            .expect("prepare runtime bindings");
+
+        let mut request = make_request(SessionBuildOptions {
+            resume_session: Some(session),
+            runtime_build_mode: meerkat_core::RuntimeBuildMode::SessionOwned(bindings),
+            ..Default::default()
+        });
+        request.initial_turn = meerkat_core::service::InitialTurnPolicy::RunImmediately;
+        request.prompt = "needs runtime stamp".to_string().into();
+
+        let error = service
+            .create_session(request)
+            .await
+            .expect_err("runtime-backed eager create must require stamped execution kind");
+
+        assert!(
+            error.to_string().contains("runtime_execution_kind not set"),
+            "unexpected error: {error}"
+        );
+        adapter.unregister_session(&session_id).await;
     }
 
     #[test]

--- a/meerkat/src/surface/runtime_backed.rs
+++ b/meerkat/src/surface/runtime_backed.rs
@@ -181,6 +181,14 @@ fn start_turn_request_from_primitive(
     primitive: &RunPrimitive,
 ) -> Result<meerkat_core::service::StartTurnRequest, CoreExecutorError> {
     let metadata = primitive.turn_metadata();
+    let pre_turn_context_appends = match primitive {
+        RunPrimitive::StagedInput(staged)
+            if primitive.is_peer_response_terminal_context_and_run() =>
+        {
+            pending_system_context_appends(&staged.context_appends)
+        }
+        _ => Vec::new(),
+    };
 
     Ok(meerkat_core::service::StartTurnRequest {
         prompt: primitive.extract_content_input(),
@@ -192,6 +200,7 @@ fn start_turn_request_from_primitive(
         event_tx: None,
         skill_references: metadata.and_then(|metadata| metadata.skill_references.clone()),
         flow_tool_overlay: metadata.and_then(|metadata| metadata.flow_tool_overlay.clone()),
+        pre_turn_context_appends,
         turn_metadata: metadata.cloned(),
     })
 }
@@ -226,21 +235,6 @@ impl CoreExecutor for PersistentRuntimeExecutor {
                 .map_err(|error| {
                     CoreExecutorError::apply_failed_runtime_context(error.to_string())
                 });
-        }
-
-        if primitive.is_peer_response_terminal_context_and_run() {
-            let RunPrimitive::StagedInput(staged) = &primitive else {
-                unreachable!("terminal peer-response apply intent only matches staged primitives");
-            };
-            self.service
-                .apply_runtime_system_context_for_turn(
-                    &self.session_id,
-                    pending_system_context_appends(&staged.context_appends),
-                )
-                .await
-                .map_err(|error| {
-                    CoreExecutorError::apply_failed_runtime_context(error.to_string())
-                })?;
         }
 
         let boundary = primitive.apply_boundary();

--- a/meerkat/tests/factory_build_agent.rs
+++ b/meerkat/tests/factory_build_agent.rs
@@ -109,41 +109,6 @@ fn temp_factory(temp: &tempfile::TempDir) -> AgentFactory {
     AgentFactory::new(temp.path().join("sessions"))
 }
 
-// Attach `RuntimeBuildMode::SessionOwned(bindings)` to a `build_config` so the
-// factory's `build_agent` path wires a runtime-backed `turn_state_handle`.
-// Returns the adapter so the caller keeps it alive for the duration of the
-// agent (the bindings hold handles that reference shared state owned by the
-// adapter).
-//
-// Wave-A deleted the standalone `turn_state_handle` fallback
-// (`meerkat-core/src/agent/state.rs:99-108`); the `AgentBuildConfig::new`
-// default is `StandaloneEphemeral`, which does NOT attach the handle (see
-// `meerkat/src/factory.rs:2741-2751`), and any `agent.run(...)` call then
-// panics with "runtime turn-state handle missing". Tests that exercise the
-// live-run path must switch to `SessionOwned` via this helper.
-//
-// The helper also seeds `build_config.resume_session` with a `Session` whose
-// id matches the bindings' session_id, so the factory's internal check at
-// build-commit time doesn't reject the bindings as "prepared for a different
-// session" (see `meerkat/src/factory.rs` resume-session handling).
-async fn with_runtime_bindings(
-    mut build_config: AgentBuildConfig,
-) -> (AgentBuildConfig, Arc<meerkat_runtime::MeerkatMachine>) {
-    let adapter = Arc::new(meerkat_runtime::MeerkatMachine::ephemeral());
-    let session = Session::new();
-    let session_id = session.id().clone();
-    adapter.register_session(session_id.clone()).await;
-    let bindings = adapter
-        .prepare_bindings(session_id)
-        .await
-        .expect("prepare_bindings");
-    build_config.runtime_build_mode = meerkat_core::RuntimeBuildMode::SessionOwned(bindings);
-    if build_config.resume_session.is_none() {
-        build_config.resume_session = Some(session);
-    }
-    (build_config, adapter)
-}
-
 struct EmptyDispatcher;
 
 #[async_trait]
@@ -231,7 +196,6 @@ async fn run_and_capture_tool_names(
 ) -> Vec<String> {
     let capture: Arc<CaptureClient> = Arc::new(CaptureClient::default());
     build_config.llm_client_override = Some(capture.clone());
-    let (build_config, _adapter) = with_runtime_bindings(build_config).await;
     let mut agent = factory
         .build_agent(build_config, &Config::default())
         .await
@@ -268,7 +232,6 @@ async fn build_agent_with_mock_client_produces_runnable_agent() {
         llm_client_override: Some(Arc::new(MockLlmClient)),
         ..AgentBuildConfig::new("claude-sonnet-4-5")
     };
-    let (build_config, _adapter) = with_runtime_bindings(build_config).await;
 
     let mut agent = factory.build_agent(build_config, &config).await.unwrap();
 
@@ -1518,7 +1481,6 @@ async fn build_agent_with_custom_session_store() {
         llm_client_override: Some(Arc::new(MockLlmClient)),
         ..AgentBuildConfig::new("claude-sonnet-4-5")
     };
-    let (build_config, _adapter) = with_runtime_bindings(build_config).await;
 
     let mut agent = factory.build_agent(build_config, &config).await.unwrap();
 
@@ -2114,7 +2076,6 @@ async fn web_search_default_injected_for_anthropic() {
         llm_client_override: Some(client.clone()),
         ..AgentBuildConfig::new("claude-sonnet-4-6")
     };
-    let (build_config, _adapter) = with_runtime_bindings(build_config).await;
     let mut agent = factory.build_agent(build_config, &config).await.unwrap();
     let _ = agent.run("test".to_string().into()).await.unwrap();
     let params = client
@@ -2137,7 +2098,6 @@ async fn web_search_not_injected_when_config_disabled() {
         llm_client_override: Some(client.clone()),
         ..AgentBuildConfig::new("claude-sonnet-4-6")
     };
-    let (build_config, _adapter) = with_runtime_bindings(build_config).await;
     let mut agent = factory.build_agent(build_config, &config).await.unwrap();
     let _ = agent.run("test".to_string().into()).await.unwrap();
     let params = client.captured_params();
@@ -2159,7 +2119,6 @@ async fn web_search_opt_out_via_null() {
         provider_params: Some(json!({"web_search": null})),
         ..AgentBuildConfig::new("claude-sonnet-4-6")
     };
-    let (build_config, _adapter) = with_runtime_bindings(build_config).await;
     let mut agent = factory.build_agent(build_config, &config).await.unwrap();
     let _ = agent.run("test".to_string().into()).await.unwrap();
     let params = client.captured_params();
@@ -2181,7 +2140,6 @@ async fn web_search_explicit_params_merged_with_defaults() {
         provider_params: Some(json!({"thinking_budget": 5000})),
         ..AgentBuildConfig::new("claude-sonnet-4-6")
     };
-    let (build_config, _adapter) = with_runtime_bindings(build_config).await;
     let mut agent = factory.build_agent(build_config, &config).await.unwrap();
     let _ = agent.run("test".to_string().into()).await.unwrap();
     let params = client
@@ -2208,7 +2166,6 @@ async fn explicit_meerkat_tool_policy_suppresses_ambient_provider_search_default
         override_builtins: ToolCategoryOverride::Disable,
         ..AgentBuildConfig::new("gpt-5.4")
     };
-    let (build_config, _adapter) = with_runtime_bindings(build_config).await;
     let mut agent = factory.build_agent(build_config, &config).await.unwrap();
     let _ = agent.run("test".to_string().into()).await.unwrap();
     let params = client.captured_params();
@@ -2231,7 +2188,6 @@ async fn explicit_provider_search_param_can_reenable_search_under_tool_policy() 
         provider_params: Some(json!({"web_search": {"type": "web_search"}})),
         ..AgentBuildConfig::new("gpt-5.4")
     };
-    let (build_config, _adapter) = with_runtime_bindings(build_config).await;
     let mut agent = factory.build_agent(build_config, &config).await.unwrap();
     let _ = agent.run("test".to_string().into()).await.unwrap();
     let params = client

--- a/meerkat/tests/live_meerkat_regression.rs
+++ b/meerkat/tests/live_meerkat_regression.rs
@@ -23,7 +23,7 @@ use meerkat_core::image_generation::{
     ImageOperationTerminalClass, ImageQualityPreference, ImageSizePreference, PromptSource,
     PromptText, SessionModelRoutingStatus, ToolCallId,
 };
-use meerkat_core::lifecycle::run_primitive::ModelId;
+use meerkat_core::lifecycle::run_primitive::{ModelId, RuntimeExecutionKind};
 use meerkat_core::service::{InitialTurnPolicy, SessionBuildOptions};
 use meerkat_core::{
     AgentToolDispatcher, AssistantBlock, BlobStore, ContentBlock, ProviderId, SessionEffect,
@@ -454,10 +454,16 @@ mod image_generation_substrate {
             .await
             .expect("factory should build runtime-backed image agent");
         let (run_tx, _run_rx) = mpsc::channel(32);
-        let result =
-            SessionAgent::run_with_events(&mut agent, "make an image".to_string().into(), run_tx)
-                .await
-                .expect("agent turn should complete after generate_image");
+        let result = SessionAgent::run_turn_with_events(
+            &mut agent,
+            "make an image".to_string().into(),
+            meerkat_core::types::HandlingMode::Queue,
+            None,
+            Some(RuntimeExecutionKind::ContentTurn),
+            run_tx,
+        )
+        .await
+        .expect("agent turn should complete after generate_image");
         assert_eq!(result.tool_calls, 1);
 
         let image_ref = agent

--- a/meerkat/tests/live_meerkat_regression.rs
+++ b/meerkat/tests/live_meerkat_regression.rs
@@ -563,6 +563,7 @@ mod scenario_22_session_service_lifecycle {
 
                     skill_references: None,
                     flow_tool_overlay: None,
+                    pre_turn_context_appends: Vec::new(),
                     turn_metadata: None,
                 },
             )

--- a/meerkat/tests/smoke_meerkat_sdk.rs
+++ b/meerkat/tests/smoke_meerkat_sdk.rs
@@ -1223,6 +1223,7 @@ mod scenario_09_session_service {
 
             skill_references: None,
             flow_tool_overlay: None,
+            pre_turn_context_appends: Vec::new(),
             turn_metadata: None,
         };
 
@@ -1695,6 +1696,7 @@ mod scenario_22_runtime_host_comms {
                 event_tx: None,
                 skill_references: None,
                 flow_tool_overlay: None,
+                pre_turn_context_appends: Vec::new(),
                 turn_metadata: None,
             };
 


### PR DESCRIPTION
## Summary
- stamp runtime execution kind into `RuntimeTurnMetadata` at runtime admission/queue boundaries
- reject missing or mixed execution-kind metadata instead of applying local `ContentTurn` / `ResumePending` defaults
- add runtime/core regression tests for unstamped runtime-backed runs and mixed batch metadata

## Validation
- `./scripts/repo-cargo fmt`
- `./scripts/repo-cargo test -p meerkat-core runtime_backed`
- `./scripts/repo-cargo test -p meerkat-runtime mixed_batch_execution_kind_conflict_is_rejected`
- `./scripts/repo-cargo test -p meerkat-runtime machine_batch_execution_kind_requires_admitted_semantics`
- `./scripts/repo-cargo test -p meerkat-core test_builder_event_tap_receives_turn_started_without_primary_event_tx`
- `./scripts/repo-cargo test -p meerkat-runtime primitive_from_prompt_has_content_turn`
- `./scripts/repo-cargo test -p meerkat-runtime primitive_from_continuation_has_resume_pending`
- `./scripts/repo-cargo test -p meerkat-runtime peer_response_terminal_apply_intent_is_policy_runtime_and_executor_consistent`
- `./scripts/repo-cargo test -p meerkat-runtime batch_metadata_conflict_surfaces_typed_error`
- `make check`
- `./scripts/repo-cargo test -p meerkat-core --lib`
- `./scripts/repo-cargo test -p meerkat-runtime --lib`
- `make lint`
- `git diff --check`

Linear: LUC-210