### PR TITLE
Fix RuntimeStore test wrapper snapshot commit

### DIFF
--- a/meerkat-runtime/src/meerkat_machine_tests.rs
+++ b/meerkat-runtime/src/meerkat_machine_tests.rs
@@ -2635,6 +2635,16 @@ async fn persistent_destroy_durable_commit_observes_canonical_destroy_truth() {
                 .await
         }
 
+        async fn commit_session_snapshot(
+            &self,
+            runtime_id: &LogicalRuntimeId,
+            session_delta: crate::store::SessionDelta,
+        ) -> Result<(), crate::store::RuntimeStoreError> {
+            self.inner
+                .commit_session_snapshot(runtime_id, session_delta)
+                .await
+        }
+
         async fn atomic_apply(
             &self,
             runtime_id: &LogicalRuntimeId,


### PR DESCRIPTION
## Summary
- forward commit_session_snapshot through the BlockingDestroyCommitStore test wrapper
- fixes main CI after RuntimeStore gained the snapshot-only commit method

## Verification
- ./scripts/repo-cargo check -p meerkat-runtime
- ./scripts/repo-cargo test -p meerkat-runtime persistent_destroy_durable_commit_observes_canonical_destroy_truth -- --nocapture