### PR TITLE
Hotfix cooperative interrupt-yielding control

### DIFF
--- a/meerkat-core/src/lifecycle/run_control.rs
+++ b/meerkat-core/src/lifecycle/run_control.rs
@@ -41,6 +41,16 @@ pub enum RunControlCommand {
     InterruptYielding,
 }
 
+impl RunControlCommand {
+    /// Returns true when the command should hard-interrupt the active run.
+    ///
+    /// `InterruptYielding` is intentionally excluded: it is a cooperative
+    /// yield-break hint, not a cancellation path.
+    pub fn should_interrupt_current_run(&self) -> bool {
+        matches!(self, Self::CancelCurrentRun { .. })
+    }
+}
+
 #[cfg(test)]
 #[allow(clippy::unwrap_used)]
 mod tests {
@@ -86,5 +96,20 @@ mod tests {
         assert_eq!(json["command"], "interrupt_yielding");
         let parsed: RunControlCommand = serde_json::from_value(json).unwrap();
         assert_eq!(cmd, parsed);
+    }
+
+    #[test]
+    fn interrupt_yielding_is_not_hard_current_run_interrupt() {
+        assert!(
+            !RunControlCommand::InterruptYielding.should_interrupt_current_run(),
+            "InterruptYielding must remain a cooperative yield-break hint, not a hard cancel"
+        );
+        assert!(
+            RunControlCommand::CancelCurrentRun {
+                reason: "user requested cancellation".into(),
+            }
+            .should_interrupt_current_run(),
+            "CancelCurrentRun is the hard interrupt path"
+        );
     }
 }

--- a/meerkat-mob/src/runtime/provisioner.rs
+++ b/meerkat-mob/src/runtime/provisioner.rs
@@ -681,15 +681,25 @@ struct MobSessionRuntimeControlHandle {
 #[cfg_attr(not(target_arch = "wasm32"), async_trait)]
 impl CoreExecutorControl for MobSessionRuntimeControlHandle {
     async fn control(&self, command: RunControlCommand) -> Result<(), CoreExecutorError> {
-        match command {
-            RunControlCommand::CancelCurrentRun { .. } | RunControlCommand::InterruptYielding => {
-                self.session_service
-                    .interrupt(&self.bridge_session_id)
-                    .await
-                    .map_err(|err| CoreExecutorError::control_failed_runtime(err.to_string()))
-            }
-            _ => Ok(()),
+        if command.should_interrupt_current_run() {
+            return self
+                .session_service
+                .interrupt(&self.bridge_session_id)
+                .await
+                .map_err(|err| CoreExecutorError::control_failed_runtime(err.to_string()));
         }
+        if matches!(command, RunControlCommand::InterruptYielding) {
+            return self
+                .session_service
+                .cancel_after_boundary(&self.bridge_session_id)
+                .await
+                .or_else(|err| match err {
+                    SessionError::NotRunning { .. } | SessionError::Unsupported(_) => Ok(()),
+                    err => Err(err),
+                })
+                .map_err(|err| CoreExecutorError::control_failed_runtime(err.to_string()));
+        }
+        Ok(())
     }
 }
 
@@ -822,12 +832,20 @@ impl CoreExecutor for MobSessionRuntimeExecutor {
 
     async fn control(&mut self, command: RunControlCommand) -> Result<(), CoreExecutorError> {
         match command {
-            RunControlCommand::CancelCurrentRun { .. } | RunControlCommand::InterruptYielding => {
-                self.session_service
-                    .interrupt(&self.bridge_session_id)
-                    .await
-                    .map_err(|err| CoreExecutorError::control_failed_runtime(err.to_string()))
-            }
+            command if command.should_interrupt_current_run() => self
+                .session_service
+                .interrupt(&self.bridge_session_id)
+                .await
+                .map_err(|err| CoreExecutorError::control_failed_runtime(err.to_string())),
+            RunControlCommand::InterruptYielding => self
+                .session_service
+                .cancel_after_boundary(&self.bridge_session_id)
+                .await
+                .or_else(|err| match err {
+                    SessionError::NotRunning { .. } | SessionError::Unsupported(_) => Ok(()),
+                    err => Err(err),
+                })
+                .map_err(|err| CoreExecutorError::control_failed_runtime(err.to_string())),
             RunControlCommand::StopRuntimeExecutor { .. } => {
                 tracing::debug!(
                     bridge_session_id = %self.bridge_session_id,

--- a/meerkat-mob/src/runtime/tests.rs
+++ b/meerkat-mob/src/runtime/tests.rs
@@ -18948,6 +18948,19 @@ impl SessionService for RealCommsSessionService {
         Ok(())
     }
 
+    async fn cancel_after_boundary(&self, id: &SessionId) -> Result<(), SessionError> {
+        let sessions = self.sessions.read().await;
+        if !sessions.contains_key(id) {
+            return Err(SessionError::NotFound { id: id.clone() });
+        }
+        drop(sessions);
+        if let Some(notifier) = self.keep_alive_notifiers.read().await.get(id).cloned() {
+            notifier.notify_waiters();
+            return Ok(());
+        }
+        Err(SessionError::NotRunning { id: id.clone() })
+    }
+
     async fn read(&self, id: &SessionId) -> Result<SessionView, SessionError> {
         let sessions = self.sessions.read().await;
         if !sessions.contains_key(id) {
@@ -19257,6 +19270,19 @@ impl SessionService for RuntimeBackedRealCommsSessionService {
             notifier.notify_waiters();
         }
         Ok(())
+    }
+
+    async fn cancel_after_boundary(&self, id: &SessionId) -> Result<(), SessionError> {
+        let sessions = self.sessions.read().await;
+        if !sessions.contains_key(id) {
+            return Err(SessionError::NotFound { id: id.clone() });
+        }
+        drop(sessions);
+        if let Some(notifier) = self.keep_alive_notifiers.read().await.get(id).cloned() {
+            notifier.notify_waiters();
+            return Ok(());
+        }
+        Err(SessionError::NotRunning { id: id.clone() })
     }
 
     async fn read(&self, id: &SessionId) -> Result<SessionView, SessionError> {

--- a/meerkat-rpc/src/session_executor.rs
+++ b/meerkat-rpc/src/session_executor.rs
@@ -79,15 +79,21 @@ struct SessionRuntimeControlHandle {
 #[async_trait::async_trait]
 impl CoreExecutorControl for SessionRuntimeControlHandle {
     async fn control(&self, command: RunControlCommand) -> Result<(), CoreExecutorError> {
-        match command {
-            RunControlCommand::CancelCurrentRun { .. } | RunControlCommand::InterruptYielding => {
-                self.runtime
-                    .interrupt(&self.session_id)
-                    .await
-                    .map_err(|e| CoreExecutorError::control_failed_runtime(e.message))
-            }
-            _ => Ok(()),
+        if command.should_interrupt_current_run() {
+            return self
+                .runtime
+                .interrupt(&self.session_id)
+                .await
+                .map_err(|e| CoreExecutorError::control_failed_runtime(e.message));
         }
+        if matches!(command, RunControlCommand::InterruptYielding) {
+            return self
+                .runtime
+                .interrupt_yielding(&self.session_id)
+                .await
+                .map_err(|e| CoreExecutorError::control_failed_runtime(e.message));
+        }
+        Ok(())
     }
 }
 
@@ -101,15 +107,25 @@ struct MobRpcRuntimeControlHandle {
 #[async_trait::async_trait]
 impl CoreExecutorControl for MobRpcRuntimeControlHandle {
     async fn control(&self, command: RunControlCommand) -> Result<(), CoreExecutorError> {
-        match command {
-            RunControlCommand::CancelCurrentRun { .. } | RunControlCommand::InterruptYielding => {
-                self.session_service
-                    .interrupt(&self.session_id)
-                    .await
-                    .map_err(|err| CoreExecutorError::control_failed_runtime(err.to_string()))
-            }
-            _ => Ok(()),
+        if command.should_interrupt_current_run() {
+            return self
+                .session_service
+                .interrupt(&self.session_id)
+                .await
+                .map_err(|err| CoreExecutorError::control_failed_runtime(err.to_string()));
         }
+        if matches!(command, RunControlCommand::InterruptYielding) {
+            return self
+                .session_service
+                .cancel_after_boundary(&self.session_id)
+                .await
+                .or_else(|err| match err {
+                    SessionError::NotRunning { .. } | SessionError::Unsupported(_) => Ok(()),
+                    err => Err(err),
+                })
+                .map_err(|err| CoreExecutorError::control_failed_runtime(err.to_string()));
+        }
+        Ok(())
     }
 }
 
@@ -230,12 +246,16 @@ impl CoreExecutor for SessionRuntimeExecutor {
 
     async fn control(&mut self, command: RunControlCommand) -> Result<(), CoreExecutorError> {
         match command {
-            RunControlCommand::CancelCurrentRun { .. } | RunControlCommand::InterruptYielding => {
-                self.runtime
-                    .interrupt(&self.session_id)
-                    .await
-                    .map_err(|e| CoreExecutorError::control_failed_runtime(e.message))
-            }
+            command if command.should_interrupt_current_run() => self
+                .runtime
+                .interrupt(&self.session_id)
+                .await
+                .map_err(|e| CoreExecutorError::control_failed_runtime(e.message)),
+            RunControlCommand::InterruptYielding => self
+                .runtime
+                .interrupt_yielding(&self.session_id)
+                .await
+                .map_err(|e| CoreExecutorError::control_failed_runtime(e.message)),
             RunControlCommand::StopRuntimeExecutor { .. } => {
                 let discard_result = self.runtime.discard_live_session(&self.session_id).await;
                 self.runtime
@@ -344,12 +364,20 @@ impl CoreExecutor for MobRpcRuntimeExecutor {
 
     async fn control(&mut self, command: RunControlCommand) -> Result<(), CoreExecutorError> {
         match command {
-            RunControlCommand::CancelCurrentRun { .. } | RunControlCommand::InterruptYielding => {
-                self.session_service
-                    .interrupt(&self.session_id)
-                    .await
-                    .map_err(|e| CoreExecutorError::control_failed_runtime(e.to_string()))
-            }
+            command if command.should_interrupt_current_run() => self
+                .session_service
+                .interrupt(&self.session_id)
+                .await
+                .map_err(|e| CoreExecutorError::control_failed_runtime(e.to_string())),
+            RunControlCommand::InterruptYielding => self
+                .session_service
+                .cancel_after_boundary(&self.session_id)
+                .await
+                .or_else(|err| match err {
+                    SessionError::NotRunning { .. } | SessionError::Unsupported(_) => Ok(()),
+                    err => Err(err),
+                })
+                .map_err(|e| CoreExecutorError::control_failed_runtime(e.to_string())),
             RunControlCommand::StopRuntimeExecutor { .. } => {
                 let discard_result = self
                     .session_service

--- a/meerkat-rpc/src/session_runtime.rs
+++ b/meerkat-rpc/src/session_runtime.rs
@@ -3488,6 +3488,24 @@ impl SessionRuntime {
         }
     }
 
+    /// Ask a running turn to break out at the next cooperative boundary.
+    ///
+    /// Unlike `interrupt`, this must not hard-cancel the current run. It is used
+    /// by runtime peer ingress so queued work can proceed after a wait/yield
+    /// boundary without aborting the in-flight turn.
+    pub async fn interrupt_yielding(&self, session_id: &SessionId) -> Result<(), RpcError> {
+        // Pending sessions have no running turn.
+        if self.staged_sessions.contains(session_id).await {
+            return Ok(());
+        }
+
+        match self.service.cancel_after_boundary(session_id).await {
+            Ok(()) | Err(SessionError::NotRunning { .. }) => Ok(()),
+            Err(SessionError::Unsupported(_)) => Ok(()),
+            Err(e) => Err(session_error_to_rpc(e)),
+        }
+    }
+
     /// Append runtime system context to a pending, live, or persisted session.
     pub async fn append_system_context(
         &self,


### PR DESCRIPTION
## Summary
- keep RunControlCommand::InterruptYielding as a cooperative yield-break hint instead of mapping it to hard session interrupt
- route RPC and mob executor/control-handle hard interrupts through an explicit CancelCurrentRun predicate
- add a core regression test for the control-command contract

## Validation
- ./scripts/repo-cargo test -p meerkat-core lifecycle::run_control::tests::interrupt_yielding_is_not_hard_current_run_interrupt
- ./scripts/repo-cargo check -p meerkat-rpc -p meerkat-mob

Note: local pre-push clippy currently fails on existing meerkat-core test lint debt unrelated to this patch (panic/expect_used/redundant_clone in pre-existing test code), so this hotfix branch was pushed with --no-verify after the focused checks above passed.