### PR TITLE
Route inproc sends by canonical peer identity

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -158,6 +158,7 @@ test_suite(
         "//meerkat-client:meerkat_client_unit_test",
         "//meerkat-client:rct_contracts_test",
         "//meerkat-comms:inbox_admission_toctou_test",
+        "//meerkat-comms:inproc_canonical_peer_routing_test",
         "//meerkat-comms:meerkat_comms_unit_test",
         "//meerkat-comms:router_ambiguous_name_typed_error_test",
         "//meerkat-comms:trust_duplicate_name_ok_duplicate_id_rejected_test",

--- a/meerkat-comms/BUILD.bazel
+++ b/meerkat-comms/BUILD.bazel
@@ -214,6 +214,58 @@ rust_test(
 )
 
 rust_test(
+    name = "inproc_canonical_peer_routing_test",
+    aliases = aliases(
+        package_name = "meerkat-comms",
+        normal = True,
+        normal_dev = True,
+        proc_macro = True,
+        proc_macro_dev = True,
+    ),
+    crate_name = "inproc_canonical_peer_routing",
+    crate_root = "tests/inproc_canonical_peer_routing.rs",
+    crate_features = [
+        "integration-real-tests",
+    ],
+    edition = "2024",
+    compile_data = [
+        "Cargo.toml",
+        "skills/multi-agent-comms/SKILL.md",
+    ],
+    srcs = [
+        "tests/inproc_canonical_peer_routing.rs",
+    ],
+    visibility = ["//visibility:public"],
+    rustc_env = {
+        "CARGO_BIN_NAME": "inproc_canonical_peer_routing",
+        "CARGO_MANIFEST_DIR": "./meerkat-comms",
+    },
+    tags = [
+        "fast",
+    ],
+    size = "small",
+    data = [],
+    env = {
+        "RUST_MIN_STACK": "16777216",
+    },
+    proc_macro_deps = all_crate_deps(
+        package_name = "meerkat-comms",
+        proc_macro = True,
+        proc_macro_dev = True,
+    ),
+    deps = [
+        "//meerkat-comms:meerkat_comms",
+        "//meerkat-contracts:meerkat_contracts",
+        "//meerkat-core:meerkat_core",
+        "//meerkat-skills:meerkat_skills",
+    ] + all_crate_deps(
+        package_name = "meerkat-comms",
+        normal = True,
+        normal_dev = True,
+    ),
+)
+
+rust_test(
     name = "router_ambiguous_name_typed_error_test",
     aliases = aliases(
         package_name = "meerkat-comms",
@@ -373,6 +425,7 @@ test_suite(
     name = "fast_tests",
     tests = [
         ":inbox_admission_toctou_test",
+        ":inproc_canonical_peer_routing_test",
         ":meerkat_comms_unit_test",
         ":router_ambiguous_name_typed_error_test",
         ":trust_duplicate_name_ok_duplicate_id_rejected_test",

--- a/meerkat-comms/src/inproc.rs
+++ b/meerkat-comms/src/inproc.rs
@@ -156,6 +156,14 @@ impl InprocRegistry {
         meta: PeerMeta,
     ) {
         let name = name.into();
+        if pubkey.is_zero() {
+            tracing::warn!(
+                inproc_namespace = %namespace,
+                peer_name = %name,
+                "rejecting zero-pubkey inproc registration"
+            );
+            return;
+        }
         let peer = InprocPeer {
             name: name.clone(),
             pubkey,
@@ -672,6 +680,44 @@ mod tests {
 
         // Lookup by pubkey
         assert!(registry.get_by_pubkey(&pubkey).is_some());
+    }
+
+    #[test]
+    fn test_registry_rejects_zero_pubkey_registration() {
+        let registry = InprocRegistry::new();
+        let (_, sender) = Inbox::new();
+        let zero_pubkey = PubKey::new([0u8; 32]);
+
+        registry.register("zero-agent", zero_pubkey, sender);
+
+        assert!(registry.is_empty());
+        assert!(!registry.contains_name("zero-agent"));
+        assert!(registry.get_by_name("zero-agent").is_none());
+        assert!(registry.get_by_pubkey(&zero_pubkey).is_none());
+    }
+
+    #[test]
+    fn test_registry_zero_pubkey_registration_does_not_shadow_valid_name() {
+        let registry = InprocRegistry::new();
+        let valid_keypair = make_keypair();
+        let valid_pubkey = valid_keypair.public_key();
+        let (_, valid_sender) = Inbox::new();
+        let (_, zero_sender) = Inbox::new();
+        let zero_pubkey = PubKey::new([0u8; 32]);
+
+        registry.register("stable-agent", valid_pubkey, valid_sender);
+        registry.register("stable-agent", zero_pubkey, zero_sender);
+
+        assert_eq!(registry.len(), 1);
+        assert!(registry.contains(&valid_pubkey));
+        assert!(registry.contains_name("stable-agent"));
+        assert!(registry.get_by_pubkey(&valid_pubkey).is_some());
+        assert!(registry.get_by_pubkey(&zero_pubkey).is_none());
+
+        let (found_pubkey, _) = registry
+            .get_by_name("stable-agent")
+            .expect("valid name mapping should remain");
+        assert_eq!(found_pubkey, valid_pubkey);
     }
 
     #[test]

--- a/meerkat-comms/src/inproc.rs
+++ b/meerkat-comms/src/inproc.rs
@@ -275,6 +275,9 @@ impl InprocRegistry {
         namespace: &str,
         pubkey: &PubKey,
     ) -> Option<InboxSender> {
+        if pubkey.is_zero() {
+            return None;
+        }
         self.state
             .read()
             .namespace(namespace)?
@@ -289,6 +292,9 @@ impl InprocRegistry {
     /// canonical identity is live in more than one namespace, fail closed
     /// rather than choosing whichever namespace the map happens to yield first.
     pub(crate) fn get_by_pubkey_any_namespace(&self, pubkey: &PubKey) -> Option<InboxSender> {
+        if pubkey.is_zero() {
+            return None;
+        }
         let state = self.state.read();
         let mut found = None;
         for namespace_state in state.namespaces.values() {
@@ -313,6 +319,9 @@ impl InprocRegistry {
         namespace: &str,
         pubkey: &PubKey,
     ) -> Option<String> {
+        if pubkey.is_zero() {
+            return None;
+        }
         self.state
             .read()
             .namespace(namespace)?
@@ -496,6 +505,9 @@ impl InprocRegistry {
         let (to_pubkey, sender) = self
             .get_by_name_in_namespace(namespace, to_name)
             .ok_or_else(|| InprocSendError::PeerNotFound(to_name.to_string()))?;
+        if to_pubkey.is_zero() {
+            return Err(InprocSendError::PeerNotFound(to_name.to_string()));
+        }
 
         Self::deliver_to_sender(
             from_keypair,
@@ -1312,8 +1324,7 @@ mod tests {
     }
 
     #[test]
-    fn test_send_cross_namespace_with_id_rejects_duplicate_pubkey_with_different_names_across_namespaces()
-    {
+    fn test_send_cross_namespace_with_id_rejects_duplicate_pubkey_different_names() {
         let registry = InprocRegistry::new();
         let sender_kp = make_keypair();
         let target_key = make_keypair();

--- a/meerkat-comms/src/inproc.rs
+++ b/meerkat-comms/src/inproc.rs
@@ -316,6 +316,19 @@ impl InprocRegistry {
         found
     }
 
+    /// Count live registrations for a canonical pubkey across all namespaces.
+    pub(crate) fn pubkey_registration_count_any_namespace(&self, pubkey: &PubKey) -> usize {
+        if pubkey.is_zero() {
+            return 0;
+        }
+        self.state
+            .read()
+            .namespaces
+            .values()
+            .filter(|namespace_state| namespace_state.peers.contains_key(pubkey))
+            .count()
+    }
+
     /// Look up an inproc peer name by public key.
     pub fn get_name_by_pubkey(&self, pubkey: &PubKey) -> Option<String> {
         self.get_name_by_pubkey_in_namespace(DEFAULT_NAMESPACE, pubkey)
@@ -528,7 +541,8 @@ impl InprocRegistry {
     }
 
     /// Send a message directly to an inproc peer within a namespace by pubkey.
-    pub(crate) fn send_to_pubkey_in_namespace_with_id(
+    #[cfg(test)]
+    fn send_to_pubkey_in_namespace_with_id(
         &self,
         namespace: &str,
         from_keypair: &Keypair,

--- a/meerkat-comms/src/inproc.rs
+++ b/meerkat-comms/src/inproc.rs
@@ -269,13 +269,22 @@ impl InprocRegistry {
     }
 
     /// Look up an inproc peer by pubkey across all namespaces.
+    ///
+    /// Cross-namespace delivery has no typed target namespace. If the same
+    /// canonical identity is live in more than one namespace, fail closed
+    /// rather than choosing whichever namespace the map happens to yield first.
     pub(crate) fn get_by_pubkey_any_namespace(&self, pubkey: &PubKey) -> Option<InboxSender> {
         let state = self.state.read();
-        state
-            .namespaces
-            .values()
-            .find_map(|namespace_state| namespace_state.peers.get(pubkey))
-            .map(|peer| peer.sender.clone())
+        let mut found = None;
+        for namespace_state in state.namespaces.values() {
+            if let Some(peer) = namespace_state.peers.get(pubkey) {
+                if found.is_some() {
+                    return None;
+                }
+                found = Some(peer.sender.clone());
+            }
+        }
+        found
     }
 
     /// Look up an inproc peer name by public key.
@@ -993,6 +1002,47 @@ mod tests {
             panic!("expected external envelope");
         };
         assert_eq!(envelope.to, target_pubkey);
+    }
+
+    #[test]
+    fn test_send_to_pubkey_any_namespace_rejects_ambiguous_identity() {
+        let registry = InprocRegistry::new();
+        let sender_keypair = make_keypair();
+        let target_keypair = make_keypair();
+        let target_pubkey = target_keypair.public_key();
+        let (mut alpha_inbox, alpha_sender) = Inbox::new();
+        let (mut beta_inbox, beta_sender) = Inbox::new();
+
+        registry.register_with_meta_in_namespace(
+            "realm-alpha",
+            "alpha-target",
+            target_pubkey,
+            alpha_sender,
+            PeerMeta::default(),
+        );
+        registry.register_with_meta_in_namespace(
+            "realm-beta",
+            "beta-target",
+            target_pubkey,
+            beta_sender,
+            PeerMeta::default(),
+        );
+
+        let result = registry.send_to_pubkey_any_namespace_with_id(
+            &sender_keypair,
+            &target_pubkey,
+            Uuid::new_v4(),
+            MessageKind::Message {
+                blocks: None,
+                body: "ambiguous identity".to_string(),
+                handling_mode: None,
+            },
+            true,
+        );
+
+        assert!(matches!(result, Err(InprocSendError::PeerNotFound(_))));
+        assert!(alpha_inbox.try_drain().is_empty());
+        assert!(beta_inbox.try_drain().is_empty());
     }
 
     #[test]

--- a/meerkat-comms/src/inproc.rs
+++ b/meerkat-comms/src/inproc.rs
@@ -237,16 +237,31 @@ impl InprocRegistry {
         name: &str,
         expected_pubkey: &PubKey,
     ) -> Option<(PubKey, InboxSender)> {
+        if expected_pubkey.is_zero() {
+            return None;
+        }
         let state = self.state.read();
+        let mut found = None;
+        let mut pubkey_registrations = 0;
         for namespace_state in state.namespaces.values() {
+            if namespace_state.peers.contains_key(expected_pubkey) {
+                pubkey_registrations += 1;
+            }
             if let Some(&pubkey) = namespace_state.names.get(name)
                 && pubkey == *expected_pubkey
                 && let Some(peer) = namespace_state.peers.get(&pubkey)
             {
-                return Some((peer.pubkey, peer.sender.clone()));
+                if found.is_some() {
+                    return None;
+                }
+                found = Some((peer.pubkey, peer.sender.clone()));
             }
         }
-        None
+        if pubkey_registrations == 1 {
+            found
+        } else {
+            None
+        }
     }
 
     /// Look up an inproc peer by pubkey.
@@ -1193,6 +1208,159 @@ mod tests {
         assert!(
             matches!(result_mismatch, Err(InprocSendError::PeerNotFound(_))),
             "must reject when resolved pubkey doesn't match expected: {result_mismatch:?}"
+        );
+    }
+
+    #[test]
+    fn test_send_cross_namespace_rejects_duplicate_name_pubkey_across_namespaces() {
+        let registry = InprocRegistry::new();
+        let sender_kp = make_keypair();
+        let target_key = make_keypair();
+        let target_pubkey = target_key.public_key();
+        let (mut inbox_a, sender_a) = Inbox::new();
+        let (mut inbox_b, sender_b) = Inbox::new();
+
+        registry.register_with_meta_in_namespace(
+            "mob:alpha",
+            "ambassador",
+            target_pubkey,
+            sender_a,
+            PeerMeta::default(),
+        );
+        registry.register_with_meta_in_namespace(
+            "mob:beta",
+            "ambassador",
+            target_pubkey,
+            sender_b,
+            PeerMeta::default(),
+        );
+
+        let result = registry.send_cross_namespace(
+            &sender_kp,
+            "ambassador",
+            &target_pubkey,
+            MessageKind::Request {
+                intent: "test".into(),
+                params: serde_json::json!({}),
+                handling_mode: None,
+            },
+            false,
+        );
+
+        assert!(
+            matches!(result, Err(InprocSendError::PeerNotFound(_))),
+            "same name/pubkey across namespaces must fail closed instead of picking a namespace: {result:?}"
+        );
+        assert!(
+            inbox_a.try_drain().is_empty(),
+            "must not deliver to the first duplicate namespace"
+        );
+        assert!(
+            inbox_b.try_drain().is_empty(),
+            "must not deliver to the second duplicate namespace"
+        );
+    }
+
+    #[test]
+    fn test_send_cross_namespace_rejects_duplicate_pubkey_with_different_names_across_namespaces() {
+        let registry = InprocRegistry::new();
+        let sender_kp = make_keypair();
+        let target_key = make_keypair();
+        let target_pubkey = target_key.public_key();
+        let (mut alpha_inbox, alpha_sender) = Inbox::new();
+        let (mut beta_inbox, beta_sender) = Inbox::new();
+
+        registry.register_with_meta_in_namespace(
+            "mob:alpha",
+            "ambassador",
+            target_pubkey,
+            alpha_sender,
+            PeerMeta::default(),
+        );
+        registry.register_with_meta_in_namespace(
+            "mob:beta",
+            "observer",
+            target_pubkey,
+            beta_sender,
+            PeerMeta::default(),
+        );
+
+        let result = registry.send_cross_namespace(
+            &sender_kp,
+            "ambassador",
+            &target_pubkey,
+            MessageKind::Request {
+                intent: "test".into(),
+                params: serde_json::json!({}),
+                handling_mode: None,
+            },
+            false,
+        );
+
+        assert!(
+            matches!(result, Err(InprocSendError::PeerNotFound(_))),
+            "duplicate pubkey across namespaces must fail closed even when display names differ: {result:?}"
+        );
+        assert!(
+            alpha_inbox.try_drain().is_empty(),
+            "must not deliver to the named namespace when canonical pubkey is ambiguous"
+        );
+        assert!(
+            beta_inbox.try_drain().is_empty(),
+            "must not deliver to the differently named duplicate namespace"
+        );
+    }
+
+    #[test]
+    fn test_send_cross_namespace_with_id_rejects_duplicate_pubkey_with_different_names_across_namespaces()
+    {
+        let registry = InprocRegistry::new();
+        let sender_kp = make_keypair();
+        let target_key = make_keypair();
+        let target_pubkey = target_key.public_key();
+        let (mut alpha_inbox, alpha_sender) = Inbox::new();
+        let (mut beta_inbox, beta_sender) = Inbox::new();
+        let envelope_id = Uuid::new_v4();
+
+        registry.register_with_meta_in_namespace(
+            "mob:alpha",
+            "ambassador",
+            target_pubkey,
+            alpha_sender,
+            PeerMeta::default(),
+        );
+        registry.register_with_meta_in_namespace(
+            "mob:beta",
+            "observer",
+            target_pubkey,
+            beta_sender,
+            PeerMeta::default(),
+        );
+
+        let result = registry.send_cross_namespace_with_id(
+            &sender_kp,
+            "ambassador",
+            &target_pubkey,
+            envelope_id,
+            MessageKind::Request {
+                intent: "test".into(),
+                params: serde_json::json!({}),
+                handling_mode: None,
+            },
+            false,
+        );
+
+        assert!(
+            matches!(result, Err(InprocSendError::PeerNotFound(_))),
+            "duplicate pubkey across namespaces must fail closed on send_cross_namespace_with_id: {result:?}"
+        );
+        assert!(
+            alpha_inbox.try_drain().is_empty(),
+            "must not deliver the caller-chosen envelope id to the named namespace"
+        );
+        assert!(
+            beta_inbox.try_drain().is_empty(),
+            "must not deliver the caller-chosen envelope id to the differently named duplicate namespace"
         );
     }
 }

--- a/meerkat-comms/src/inproc.rs
+++ b/meerkat-comms/src/inproc.rs
@@ -268,6 +268,16 @@ impl InprocRegistry {
             .map(|p| p.sender.clone())
     }
 
+    /// Look up an inproc peer by pubkey across all namespaces.
+    pub(crate) fn get_by_pubkey_any_namespace(&self, pubkey: &PubKey) -> Option<InboxSender> {
+        let state = self.state.read();
+        state
+            .namespaces
+            .values()
+            .find_map(|namespace_state| namespace_state.peers.get(pubkey))
+            .map(|peer| peer.sender.clone())
+    }
+
     /// Look up an inproc peer name by public key.
     pub fn get_name_by_pubkey(&self, pubkey: &PubKey) -> Option<String> {
         self.get_name_by_pubkey_in_namespace(DEFAULT_NAMESPACE, pubkey)
@@ -393,32 +403,40 @@ impl InprocRegistry {
             .get_by_name_and_pubkey_any_namespace(to_name, expected_pubkey)
             .ok_or_else(|| InprocSendError::PeerNotFound(to_name.to_string()))?;
 
-        let mut envelope = Envelope {
-            id: envelope_id,
-            from: from_keypair.public_key(),
-            to: to_pubkey,
+        Self::deliver_to_sender(
+            from_keypair,
+            to_pubkey,
+            sender,
+            envelope_id,
             kind,
-            sig: Signature::new([0u8; 64]),
-        };
-        if sign_envelope {
-            envelope.sign(from_keypair);
-        }
+            sign_envelope,
+        )
+    }
 
-        let envelope_id = envelope.id;
-        match sender.send_classified(InboxItem::External { envelope }) {
-            AdmissionOutcome::Admitted => {}
-            AdmissionOutcome::Dropped {
-                reason: DropReason::SessionClosed,
-            } => return Err(InprocSendError::InboxClosed),
-            AdmissionOutcome::Dropped {
-                reason: DropReason::InboxFull,
-            } => return Err(InprocSendError::InboxFull),
-            AdmissionOutcome::Dropped { reason } => {
-                return Err(InprocSendError::IngressDropped(reason));
-            }
-        }
+    /// Send a message to an inproc peer by pubkey, searching ALL namespaces.
+    ///
+    /// Router call sites already resolved the destination from canonical trust
+    /// state, so delivery must use that identity rather than a display name.
+    pub(crate) fn send_to_pubkey_any_namespace_with_id(
+        &self,
+        from_keypair: &Keypair,
+        to_pubkey: &PubKey,
+        envelope_id: Uuid,
+        kind: MessageKind,
+        sign_envelope: bool,
+    ) -> Result<uuid::Uuid, InprocSendError> {
+        let sender = self
+            .get_by_pubkey_any_namespace(to_pubkey)
+            .ok_or_else(|| InprocSendError::PeerNotFound(to_pubkey.to_peer_id().to_string()))?;
 
-        Ok(envelope_id)
+        Self::deliver_to_sender(
+            from_keypair,
+            *to_pubkey,
+            sender,
+            envelope_id,
+            kind,
+            sign_envelope,
+        )
     }
 
     /// Send a message directly to an inproc peer within a namespace.
@@ -455,7 +473,48 @@ impl InprocRegistry {
             .get_by_name_in_namespace(namespace, to_name)
             .ok_or_else(|| InprocSendError::PeerNotFound(to_name.to_string()))?;
 
-        // Create and sign the envelope
+        Self::deliver_to_sender(
+            from_keypair,
+            to_pubkey,
+            sender,
+            envelope_id,
+            kind,
+            sign_envelope,
+        )
+    }
+
+    /// Send a message directly to an inproc peer within a namespace by pubkey.
+    pub(crate) fn send_to_pubkey_in_namespace_with_id(
+        &self,
+        namespace: &str,
+        from_keypair: &Keypair,
+        to_pubkey: &PubKey,
+        envelope_id: Uuid,
+        kind: MessageKind,
+        sign_envelope: bool,
+    ) -> Result<uuid::Uuid, InprocSendError> {
+        let sender = self
+            .get_by_pubkey_in_namespace(namespace, to_pubkey)
+            .ok_or_else(|| InprocSendError::PeerNotFound(to_pubkey.to_peer_id().to_string()))?;
+
+        Self::deliver_to_sender(
+            from_keypair,
+            *to_pubkey,
+            sender,
+            envelope_id,
+            kind,
+            sign_envelope,
+        )
+    }
+
+    fn deliver_to_sender(
+        from_keypair: &Keypair,
+        to_pubkey: PubKey,
+        sender: InboxSender,
+        envelope_id: Uuid,
+        kind: MessageKind,
+        sign_envelope: bool,
+    ) -> Result<uuid::Uuid, InprocSendError> {
         let mut envelope = Envelope {
             id: envelope_id,
             from: from_keypair.public_key(),
@@ -885,6 +944,55 @@ mod tests {
 
         let items = inbox.try_drain();
         assert_eq!(items.len(), 1);
+    }
+
+    #[test]
+    fn test_send_to_pubkey_in_namespace_ignores_display_name_collision() {
+        let registry = InprocRegistry::new();
+        let target_keypair = make_keypair();
+        let target_pubkey = target_keypair.public_key();
+        let shadow_keypair = make_keypair();
+        let shadow_pubkey = shadow_keypair.public_key();
+        let (mut target_inbox, target_sender) = Inbox::new();
+        let (mut shadow_inbox, shadow_sender) = Inbox::new();
+
+        registry.register_with_meta_in_namespace(
+            "",
+            "canonical-target",
+            target_pubkey,
+            target_sender,
+            PeerMeta::default(),
+        );
+        registry.register_with_meta_in_namespace(
+            "",
+            "shared-display-name",
+            shadow_pubkey,
+            shadow_sender,
+            PeerMeta::default(),
+        );
+
+        let sender_keypair = make_keypair();
+        let result = registry.send_to_pubkey_in_namespace_with_id(
+            "",
+            &sender_keypair,
+            &target_pubkey,
+            Uuid::new_v4(),
+            MessageKind::Message {
+                blocks: None,
+                body: "hello canonical".to_string(),
+                handling_mode: None,
+            },
+            true,
+        );
+        assert!(result.is_ok());
+
+        assert_eq!(shadow_inbox.try_drain().len(), 0);
+        let items = target_inbox.try_drain();
+        assert_eq!(items.len(), 1);
+        let InboxItem::External { envelope } = &items[0] else {
+            panic!("expected external envelope");
+        };
+        assert_eq!(envelope.to, target_pubkey);
     }
 
     #[test]

--- a/meerkat-comms/src/mcp/tools.rs
+++ b/meerkat-comms/src/mcp/tools.rs
@@ -14,6 +14,7 @@ use parking_lot::RwLock;
 use schemars::JsonSchema;
 use serde::Deserialize;
 use serde_json::{Map, Value, json};
+use std::collections::HashMap;
 use std::sync::Arc;
 
 #[cfg(test)]
@@ -470,6 +471,14 @@ fn runtime_less_peer_directory(ctx: &ToolContext) -> Vec<PeerDirectoryEntry> {
     let self_pubkey = ctx.router.keypair_arc().public_key();
     let peers = ctx.trusted_peers.read();
     let sendable_kinds = peer_sendability_authorized_by_tools(ctx);
+    let peer_id_counts: HashMap<PeerId, usize> = peers
+        .peers
+        .iter()
+        .filter(|p| !p.pubkey.is_zero() && p.pubkey != self_pubkey)
+        .fold(HashMap::new(), |mut counts, peer| {
+            *counts.entry(peer.pubkey.to_peer_id()).or_default() += 1;
+            counts
+        });
     peers
         .peers
         .iter()
@@ -483,6 +492,14 @@ fn runtime_less_peer_directory(ctx: &ToolContext) -> Vec<PeerDirectoryEntry> {
                 return None;
             }
             let peer_id = p.pubkey.to_peer_id();
+            if peer_id_counts.get(&peer_id).copied().unwrap_or(0) != 1 {
+                tracing::warn!(
+                    peer_name = %p.name,
+                    peer_id = %peer_id,
+                    "skipping duplicate trusted peer id in MCP peer directory"
+                );
+                return None;
+            }
             let name = match PeerName::new(p.name.clone()) {
                 Ok(name) => name,
                 Err(err) => {
@@ -985,6 +1002,53 @@ mod tests {
         assert_eq!(peer["reachability"], "unknown");
         assert_eq!(peer["last_unreachable_reason"], Value::Null);
         assert!(peer["meta"].is_object());
+    }
+
+    #[test]
+    fn test_runtime_less_peer_directory_skips_duplicate_canonical_peer_ids() {
+        let sender_keypair = Keypair::generate();
+        let peer_keypair = Keypair::generate();
+        let peer_pubkey = peer_keypair.public_key();
+        let peer_id = peer_pubkey.to_peer_id();
+        let trusted_peers = Arc::new(RwLock::new(TrustedPeers::new()));
+        let (_, inbox_sender) = crate::Inbox::new();
+        let router = Arc::new(Router::with_shared_peers(
+            sender_keypair,
+            trusted_peers.clone(),
+            CommsConfig::default(),
+            inbox_sender,
+            true,
+        ));
+        trusted_peers.write().peers.extend([
+            TrustedPeer {
+                name: "runtime-less-primary".to_string(),
+                pubkey: peer_pubkey,
+                addr: "inproc://runtime-less-primary".to_string(),
+                meta: crate::PeerMeta::default(),
+            },
+            TrustedPeer {
+                name: "runtime-less-shadow".to_string(),
+                pubkey: peer_pubkey,
+                addr: "inproc://runtime-less-shadow".to_string(),
+                meta: crate::PeerMeta::default(),
+            },
+        ]);
+        let ctx = ToolContext {
+            router,
+            trusted_peers,
+            runtime: None,
+        };
+
+        assert!(
+            ensure_peer_id_is_trusted(&ctx, &peer_id).is_err(),
+            "duplicate canonical trust is not send-resolvable"
+        );
+
+        let peers = runtime_less_peer_directory(&ctx);
+        assert!(
+            peers.iter().all(|peer| peer.peer_id != peer_id),
+            "runtime-less peer directory must not advertise duplicate canonical ids: {peers:?}"
+        );
     }
 
     #[tokio::test]

--- a/meerkat-comms/src/router.rs
+++ b/meerkat-comms/src/router.rs
@@ -117,6 +117,12 @@ pub struct Router {
     inproc_namespace: Option<String>,
 }
 
+enum TrustedPeerLookup {
+    Resolved(TrustedPeer),
+    Ambiguous,
+    Missing,
+}
+
 impl Router {
     pub fn new(
         keypair: Keypair,
@@ -261,7 +267,7 @@ impl Router {
         true
     }
 
-    fn trusted_peer_by_peer_id(&self, peer_id: &PeerId) -> Option<TrustedPeer> {
+    fn trusted_peer_by_peer_id(&self, peer_id: &PeerId) -> TrustedPeerLookup {
         let peer_ids = self.trusted_peer_ids.read().clone();
         let trusted = self.trusted_peers.read();
         let mut matches = trusted.peers.iter().filter(|peer| {
@@ -272,11 +278,13 @@ impl Router {
                     .unwrap_or_else(|| peer_id_from_pubkey(&peer.pubkey))
                     == *peer_id
         });
-        let peer = matches.next()?;
+        let Some(peer) = matches.next() else {
+            return TrustedPeerLookup::Missing;
+        };
         if matches.next().is_some() {
-            None
+            TrustedPeerLookup::Ambiguous
         } else {
-            Some(peer.clone())
+            TrustedPeerLookup::Resolved(peer.clone())
         }
     }
 
@@ -367,28 +375,29 @@ impl Router {
         kind: MessageKind,
     ) -> Result<Uuid, SendError> {
         let inproc_namespace = self.inproc_namespace.as_deref().unwrap_or("");
-        let peer = self
-            .trusted_peer_by_peer_id(&dest)
-            .or_else(|| {
-                if self.require_peer_auth {
-                    None
-                } else {
-                    // Auth-disabled fallback: scan the inproc registry for an
-                    // entry whose derived PeerId matches. Display names remain
-                    // the inproc lookup key, but the routing match is PeerId.
-                    InprocRegistry::global()
-                        .peers_in_namespace(inproc_namespace)
-                        .into_iter()
-                        .find(|p| !p.pubkey.is_zero() && peer_id_from_pubkey(&p.pubkey) == dest)
-                        .map(|p| TrustedPeer {
-                            name: p.name.clone(),
-                            pubkey: p.pubkey,
-                            addr: format!("inproc://{}", p.name),
-                            meta: p.meta,
-                        })
-                }
-            })
-            .ok_or(SendError::PeerNotFound(dest))?;
+        let peer = match self.trusted_peer_by_peer_id(&dest) {
+            TrustedPeerLookup::Resolved(peer) => peer,
+            TrustedPeerLookup::Ambiguous => return Err(SendError::PeerNotFound(dest)),
+            TrustedPeerLookup::Missing if self.require_peer_auth => {
+                return Err(SendError::PeerNotFound(dest));
+            }
+            TrustedPeerLookup::Missing => {
+                // Auth-disabled fallback: scan the inproc registry for an
+                // entry whose derived PeerId matches. Display names remain
+                // the inproc lookup key, but the routing match is PeerId.
+                InprocRegistry::global()
+                    .peers_in_namespace(inproc_namespace)
+                    .into_iter()
+                    .find(|p| !p.pubkey.is_zero() && peer_id_from_pubkey(&p.pubkey) == dest)
+                    .map(|p| TrustedPeer {
+                        name: p.name.clone(),
+                        pubkey: p.pubkey,
+                        addr: format!("inproc://{}", p.name),
+                        meta: p.meta,
+                    })
+                    .ok_or(SendError::PeerNotFound(dest))?
+            }
+        };
         let addr = PeerAddr::parse(&peer.addr)?;
         let mut envelope = Envelope {
             id: envelope_id,

--- a/meerkat-comms/src/router.rs
+++ b/meerkat-comms/src/router.rs
@@ -365,7 +365,7 @@ impl Router {
                     InprocRegistry::global()
                         .peers_in_namespace(inproc_namespace)
                         .into_iter()
-                        .find(|p| peer_id_from_pubkey(&p.pubkey) == dest)
+                        .find(|p| !p.pubkey.is_zero() && peer_id_from_pubkey(&p.pubkey) == dest)
                         .map(|p| TrustedPeer {
                             name: p.name.clone(),
                             pubkey: p.pubkey,

--- a/meerkat-comms/src/router.rs
+++ b/meerkat-comms/src/router.rs
@@ -408,23 +408,20 @@ impl Router {
                 }
                 PeerAddr::Inproc(_) => {
                     let registry = InprocRegistry::global();
-                    // Inproc delivery is constrained by the resolved peer's
-                    // pubkey: the trust store already pinned it to `dest`,
-                    // so the registry lookup must agree or we refuse the
-                    // send rather than fall through to a name collision.
-                    match registry.send_with_signature_in_namespace_with_id(
+                    // Inproc delivery uses the trusted peer identity resolved
+                    // from `dest`; display names are not routing authority.
+                    match registry.send_to_pubkey_in_namespace_with_id(
                         inproc_namespace,
                         &self.keypair,
-                        &peer.name,
+                        &peer.pubkey,
                         envelope.id,
                         envelope.kind.clone(),
                         self.require_peer_auth,
                     ) {
                         Ok(uuid) => Ok(uuid),
                         Err(InprocSendError::PeerNotFound(_)) => registry
-                            .send_cross_namespace_with_id(
+                            .send_to_pubkey_any_namespace_with_id(
                                 &self.keypair,
-                                &peer.name,
                                 &peer.pubkey,
                                 envelope.id,
                                 envelope.kind,
@@ -445,19 +442,20 @@ impl Router {
                 ))),
                 PeerAddr::Inproc(_) => {
                     let registry = InprocRegistry::global();
-                    match registry.send_with_signature_in_namespace(
+                    match registry.send_to_pubkey_in_namespace_with_id(
                         inproc_namespace,
                         &self.keypair,
-                        &peer.name,
+                        &peer.pubkey,
+                        envelope.id,
                         envelope.kind.clone(),
                         self.require_peer_auth,
                     ) {
                         Ok(uuid) => Ok(uuid),
                         Err(InprocSendError::PeerNotFound(_)) => registry
-                            .send_cross_namespace(
+                            .send_to_pubkey_any_namespace_with_id(
                                 &self.keypair,
-                                &peer.name,
                                 &peer.pubkey,
+                                envelope.id,
                                 envelope.kind,
                                 self.require_peer_auth,
                             )

--- a/meerkat-comms/src/router.rs
+++ b/meerkat-comms/src/router.rs
@@ -231,39 +231,53 @@ impl Router {
 
     pub fn remove_trusted_peer(&self, peer_id: &PeerId) -> bool {
         let peer_ids = self.trusted_peer_ids.read().clone();
-        let removed = {
+        let removed_pubkeys = {
             let mut trusted = self.trusted_peers.write();
-            let Some(index) = trusted.peers.iter().position(|peer| {
-                peer_ids
+            let mut removed_pubkeys = Vec::new();
+            trusted.peers.retain(|peer| {
+                let matches = peer_ids
                     .get(&peer.pubkey)
                     .copied()
                     .unwrap_or_else(|| peer_id_from_pubkey(&peer.pubkey))
-                    == *peer_id
-            }) else {
-                return false;
-            };
-            trusted.peers.remove(index)
+                    == *peer_id;
+                if matches {
+                    removed_pubkeys.push(peer.pubkey);
+                    false
+                } else {
+                    true
+                }
+            });
+            removed_pubkeys
         };
-        self.trusted_peer_ids.write().remove(&removed.pubkey);
+        if removed_pubkeys.is_empty() {
+            return false;
+        }
+        let mut trusted_peer_ids = self.trusted_peer_ids.write();
+        for pubkey in removed_pubkeys {
+            trusted_peer_ids.remove(&pubkey);
+        }
+        drop(trusted_peer_ids);
         self.private_peer_ids.write().remove(peer_id);
         true
     }
 
     fn trusted_peer_by_peer_id(&self, peer_id: &PeerId) -> Option<TrustedPeer> {
         let peer_ids = self.trusted_peer_ids.read().clone();
-        self.trusted_peers
-            .read()
-            .peers
-            .iter()
-            .find(|peer| {
-                !peer.pubkey.is_zero()
-                    && peer_ids
-                        .get(&peer.pubkey)
-                        .copied()
-                        .unwrap_or_else(|| peer_id_from_pubkey(&peer.pubkey))
-                        == *peer_id
-            })
-            .cloned()
+        let trusted = self.trusted_peers.read();
+        let mut matches = trusted.peers.iter().filter(|peer| {
+            !peer.pubkey.is_zero()
+                && peer_ids
+                    .get(&peer.pubkey)
+                    .copied()
+                    .unwrap_or_else(|| peer_id_from_pubkey(&peer.pubkey))
+                    == *peer_id
+        });
+        let peer = matches.next()?;
+        if matches.next().is_some() {
+            None
+        } else {
+            Some(peer.clone())
+        }
     }
 
     /// Get the trusted peers Arc.

--- a/meerkat-comms/src/router.rs
+++ b/meerkat-comms/src/router.rs
@@ -120,11 +120,12 @@ pub struct Router {
 impl Router {
     pub fn new(
         keypair: Keypair,
-        trusted_peers: TrustedPeers,
+        mut trusted_peers: TrustedPeers,
         config: CommsConfig,
         inbox_sender: InboxSender,
         require_peer_auth: bool,
     ) -> Self {
+        trusted_peers.retain_raw_sendable_identities();
         Self {
             keypair: Arc::new(keypair),
             trusted_peers: Arc::new(RwLock::new(trusted_peers)),
@@ -144,6 +145,7 @@ impl Router {
         inbox_sender: InboxSender,
         require_peer_auth: bool,
     ) -> Self {
+        trusted_peers.write().retain_raw_sendable_identities();
         Self {
             keypair: Arc::new(keypair),
             trusted_peers,

--- a/meerkat-comms/src/router.rs
+++ b/meerkat-comms/src/router.rs
@@ -433,28 +433,18 @@ impl Router {
                 }
                 PeerAddr::Inproc(_) => {
                     let registry = InprocRegistry::global();
-                    // Inproc delivery uses the trusted peer identity resolved
-                    // from `dest`; display names are not routing authority.
-                    match registry.send_to_pubkey_in_namespace_with_id(
-                        inproc_namespace,
-                        &self.keypair,
-                        &peer.pubkey,
-                        envelope.id,
-                        envelope.kind.clone(),
-                        self.require_peer_auth,
-                    ) {
-                        Ok(uuid) => Ok(uuid),
-                        Err(InprocSendError::PeerNotFound(_)) => registry
-                            .send_to_pubkey_any_namespace_with_id(
-                                &self.keypair,
-                                &peer.pubkey,
-                                envelope.id,
-                                envelope.kind,
-                                self.require_peer_auth,
-                            )
-                            .map_err(|err| map_inproc_send_error(err, dest)),
-                        Err(other) => Err(map_inproc_send_error(other, dest)),
-                    }
+                    // Router sends have a typed peer identity, but not a
+                    // typed target namespace. Require the canonical pubkey to
+                    // have exactly one live inproc owner before delivery.
+                    registry
+                        .send_to_pubkey_any_namespace_with_id(
+                            &self.keypair,
+                            &peer.pubkey,
+                            envelope.id,
+                            envelope.kind,
+                            self.require_peer_auth,
+                        )
+                        .map_err(|err| map_inproc_send_error(err, dest))
                 }
             }
         }
@@ -467,26 +457,15 @@ impl Router {
                 ))),
                 PeerAddr::Inproc(_) => {
                     let registry = InprocRegistry::global();
-                    match registry.send_to_pubkey_in_namespace_with_id(
-                        inproc_namespace,
-                        &self.keypair,
-                        &peer.pubkey,
-                        envelope.id,
-                        envelope.kind.clone(),
-                        self.require_peer_auth,
-                    ) {
-                        Ok(uuid) => Ok(uuid),
-                        Err(InprocSendError::PeerNotFound(_)) => registry
-                            .send_to_pubkey_any_namespace_with_id(
-                                &self.keypair,
-                                &peer.pubkey,
-                                envelope.id,
-                                envelope.kind,
-                                self.require_peer_auth,
-                            )
-                            .map_err(|err| map_inproc_send_error(err, dest)),
-                        Err(other) => Err(map_inproc_send_error(other, dest)),
-                    }
+                    registry
+                        .send_to_pubkey_any_namespace_with_id(
+                            &self.keypair,
+                            &peer.pubkey,
+                            envelope.id,
+                            envelope.kind,
+                            self.require_peer_auth,
+                        )
+                        .map_err(|err| map_inproc_send_error(err, dest))
                 }
             }
         }

--- a/meerkat-comms/src/runtime/comms_runtime.rs
+++ b/meerkat-comms/src/runtime/comms_runtime.rs
@@ -2155,6 +2155,8 @@ impl CommsRuntime {
                     continue;
                 }
                 let peer_id = self.router.peer_id_for_pubkey(&peer.pubkey);
+                trusted_names.insert(peer.name.clone());
+                trusted_pubkeys.insert(peer.pubkey);
                 if trusted_peer_id_counts.get(&peer_id).copied().unwrap_or(0) != 1 {
                     tracing::warn!(
                         peer_name = %peer.name,
@@ -2163,8 +2165,6 @@ impl CommsRuntime {
                     );
                     continue;
                 }
-                trusted_names.insert(peer.name.clone());
-                trusted_pubkeys.insert(peer.pubkey);
                 if private_peer_ids.contains(&peer_id) {
                     continue;
                 }

--- a/meerkat-comms/src/runtime/comms_runtime.rs
+++ b/meerkat-comms/src/runtime/comms_runtime.rs
@@ -2134,7 +2134,7 @@ impl CommsRuntime {
         {
             let trusted = self.trusted_peers.read();
             for peer in &trusted.peers {
-                if peer.pubkey.is_zero() {
+                if !peer.has_raw_sendable_identity() {
                     tracing::warn!(
                         peer_name = %peer.name,
                         "skipping zero-pubkey trusted peer in peer directory"
@@ -2198,6 +2198,9 @@ impl CommsRuntime {
         }
 
         for inproc in &inproc_peers {
+            if inproc.pubkey.is_zero() {
+                continue;
+            }
             if private_peer_ids.contains(&peer_id_from_pubkey(&inproc.pubkey)) {
                 continue;
             }

--- a/meerkat-comms/src/runtime/comms_runtime.rs
+++ b/meerkat-comms/src/runtime/comms_runtime.rs
@@ -2118,8 +2118,8 @@ impl CommsRuntime {
     where
         F: FnMut(ResolvedPeer),
     {
-        let inproc_peers =
-            InprocRegistry::global().peers_in_namespace(self.inproc_namespace().unwrap_or(""));
+        let registry = InprocRegistry::global();
+        let inproc_peers = registry.peers_in_namespace(self.inproc_namespace().unwrap_or(""));
         let inproc_by_name: std::collections::HashMap<String, crate::identity::PubKey> =
             inproc_peers
                 .iter()
@@ -2219,7 +2219,16 @@ impl CommsRuntime {
             if inproc.pubkey.is_zero() {
                 continue;
             }
-            if private_peer_ids.contains(&peer_id_from_pubkey(&inproc.pubkey)) {
+            let peer_id = peer_id_from_pubkey(&inproc.pubkey);
+            if registry.pubkey_registration_count_any_namespace(&inproc.pubkey) != 1 {
+                tracing::warn!(
+                    peer_name = %inproc.name,
+                    peer_id = %peer_id,
+                    "skipping duplicate inproc peer id in auth-disabled peer directory"
+                );
+                continue;
+            }
+            if private_peer_ids.contains(&peer_id) {
                 continue;
             }
             let name = match PeerName::new(inproc.name.clone()) {
@@ -2242,7 +2251,7 @@ impl CommsRuntime {
             }
             on_peer(ResolvedPeer {
                 name,
-                peer_id: peer_id_from_pubkey(&inproc.pubkey),
+                peer_id,
                 address: meerkat_core::comms::PeerAddress::new(
                     meerkat_core::comms::PeerTransport::Inproc,
                     peer_name_str.clone(),

--- a/meerkat-comms/src/runtime/comms_runtime.rs
+++ b/meerkat-comms/src/runtime/comms_runtime.rs
@@ -2133,6 +2133,16 @@ impl CommsRuntime {
 
         {
             let trusted = self.trusted_peers.read();
+            let trusted_peer_id_counts: HashMap<PeerId, usize> = trusted
+                .peers
+                .iter()
+                .filter(|peer| peer.has_raw_sendable_identity())
+                .fold(HashMap::new(), |mut counts, peer| {
+                    *counts
+                        .entry(self.router.peer_id_for_pubkey(&peer.pubkey))
+                        .or_default() += 1;
+                    counts
+                });
             for peer in &trusted.peers {
                 if !peer.has_raw_sendable_identity() {
                     tracing::warn!(
@@ -2144,9 +2154,17 @@ impl CommsRuntime {
                 if peer.name == participant_name || peer.pubkey == self.public_key {
                     continue;
                 }
+                let peer_id = self.router.peer_id_for_pubkey(&peer.pubkey);
+                if trusted_peer_id_counts.get(&peer_id).copied().unwrap_or(0) != 1 {
+                    tracing::warn!(
+                        peer_name = %peer.name,
+                        peer_id = %peer_id,
+                        "skipping duplicate trusted peer id in peer directory"
+                    );
+                    continue;
+                }
                 trusted_names.insert(peer.name.clone());
                 trusted_pubkeys.insert(peer.pubkey);
-                let peer_id = self.router.peer_id_for_pubkey(&peer.pubkey);
                 if private_peer_ids.contains(&peer_id) {
                     continue;
                 }

--- a/meerkat-comms/src/trust.rs
+++ b/meerkat-comms/src/trust.rs
@@ -274,6 +274,10 @@ impl<'de> Deserialize<'de> for TrustedPeer {
         peer.validate().map_err(serde::de::Error::custom)?;
         Ok(peer)
     }
+
+    pub(crate) fn has_raw_sendable_identity(&self) -> bool {
+        self.validate().is_ok()
+    }
 }
 
 /// Collection of trusted peers.
@@ -302,6 +306,10 @@ impl TrustedPeers {
     /// Returns the number of trusted peers.
     pub fn len(&self) -> usize {
         self.peers.len()
+    }
+
+    pub(crate) fn retain_raw_sendable_identities(&mut self) {
+        self.peers.retain(|peer| peer.validate().is_ok());
     }
 
     /// Load trusted peers from a JSON file, or return empty if not found.

--- a/meerkat-comms/src/trust.rs
+++ b/meerkat-comms/src/trust.rs
@@ -1,6 +1,6 @@
 //! Trust management for Meerkat comms.
 
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, BTreeSet};
 use std::io;
 #[cfg(not(target_arch = "wasm32"))]
 use std::path::Path;
@@ -404,11 +404,11 @@ impl TrustedPeers {
     }
 
     pub fn validate(&self) -> Result<(), TrustError> {
-        let mut peer_ids = BTreeMap::new();
+        let mut peer_ids = BTreeSet::new();
         for peer in &self.peers {
             peer.validate()?;
             let peer_id = peer.pubkey.to_peer_id();
-            if peer_ids.insert(peer_id, ()).is_some() {
+            if !peer_ids.insert(peer_id) {
                 return Err(TrustError::DuplicatePeerId { peer_id });
             }
         }

--- a/meerkat-comms/src/trust.rs
+++ b/meerkat-comms/src/trust.rs
@@ -309,7 +309,18 @@ impl TrustedPeers {
     }
 
     pub(crate) fn retain_raw_sendable_identities(&mut self) {
-        self.peers.retain(|peer| peer.validate().is_ok());
+        let mut peer_id_counts: BTreeMap<PeerId, usize> = BTreeMap::new();
+        for peer in self.peers.iter().filter(|peer| peer.validate().is_ok()) {
+            *peer_id_counts.entry(peer.pubkey.to_peer_id()).or_default() += 1;
+        }
+        self.peers.retain(|peer| {
+            peer.validate().is_ok()
+                && peer_id_counts
+                    .get(&peer.pubkey.to_peer_id())
+                    .copied()
+                    .unwrap_or(0)
+                    == 1
+        });
     }
 
     /// Load trusted peers from a JSON file, or return empty if not found.
@@ -393,8 +404,13 @@ impl TrustedPeers {
     }
 
     pub fn validate(&self) -> Result<(), TrustError> {
+        let mut peer_ids = BTreeMap::new();
         for peer in &self.peers {
             peer.validate()?;
+            let peer_id = peer.pubkey.to_peer_id();
+            if peer_ids.insert(peer_id, ()).is_some() {
+                return Err(TrustError::DuplicatePeerId { peer_id });
+            }
         }
         Ok(())
     }
@@ -419,9 +435,15 @@ impl TrustedPeers {
     /// unambiguous even when multiple entries share a [`crate::peer_meta::PeerMeta`]
     /// display name.
     pub fn find_by_peer_id(&self, peer_id: &PeerId) -> Option<&TrustedPeer> {
-        self.peers.iter().find(|p| {
+        let mut matches = self.peers.iter().filter(|p| {
             !p.pubkey.is_zero() && crate::router::peer_id_from_pubkey(&p.pubkey) == *peer_id
-        })
+        });
+        let peer = matches.next()?;
+        if matches.next().is_some() {
+            None
+        } else {
+            Some(peer)
+        }
     }
 }
 
@@ -600,6 +622,36 @@ mod tests {
         assert!(
             peers.get_peer(&zero).is_none(),
             "zero pubkey must not resolve through raw trust lookup"
+        );
+    }
+
+    #[test]
+    fn test_trusted_peers_validate_rejects_duplicate_peer_id() {
+        let pubkey = PubKey::new([42u8; 32]);
+        let peer_id = pubkey.to_peer_id();
+        let peers = TrustedPeers {
+            peers: vec![
+                TrustedPeer {
+                    name: "primary".to_string(),
+                    pubkey,
+                    addr: "inproc://primary".to_string(),
+                    meta: crate::PeerMeta::default(),
+                },
+                TrustedPeer {
+                    name: "stale-shadow".to_string(),
+                    pubkey,
+                    addr: "inproc://stale-shadow".to_string(),
+                    meta: crate::PeerMeta::default(),
+                },
+            ],
+        };
+
+        let err = peers
+            .validate()
+            .expect_err("legacy TrustedPeers must reject duplicate canonical identities");
+        assert!(
+            matches!(err, TrustError::DuplicatePeerId { peer_id: id } if id == peer_id),
+            "expected duplicate PeerId error for raw TrustedPeers, got {err:?}"
         );
     }
 

--- a/meerkat-comms/src/trust.rs
+++ b/meerkat-comms/src/trust.rs
@@ -309,18 +309,11 @@ impl TrustedPeers {
     }
 
     pub(crate) fn retain_raw_sendable_identities(&mut self) {
-        let mut peer_id_counts: BTreeMap<PeerId, usize> = BTreeMap::new();
-        for peer in self.peers.iter().filter(|peer| peer.validate().is_ok()) {
-            *peer_id_counts.entry(peer.pubkey.to_peer_id()).or_default() += 1;
-        }
-        self.peers.retain(|peer| {
-            peer.validate().is_ok()
-                && peer_id_counts
-                    .get(&peer.pubkey.to_peer_id())
-                    .copied()
-                    .unwrap_or(0)
-                    == 1
-        });
+        // Keep duplicate non-zero identities visible to the canonical router
+        // resolver so it can fail closed as ambiguous. Dropping them here would
+        // make ambiguous trust indistinguishable from missing trust and can
+        // enable auth-disabled discovery fallback.
+        self.peers.retain(|peer| peer.validate().is_ok());
     }
 
     /// Load trusted peers from a JSON file, or return empty if not found.

--- a/meerkat-comms/src/trust.rs
+++ b/meerkat-comms/src/trust.rs
@@ -228,6 +228,10 @@ impl TrustedPeer {
         }
         Ok(())
     }
+
+    pub(crate) fn has_raw_sendable_identity(&self) -> bool {
+        self.validate().is_ok()
+    }
 }
 
 // Custom serde to serialize pubkey as "ed25519:..." string per spec
@@ -273,10 +277,6 @@ impl<'de> Deserialize<'de> for TrustedPeer {
         };
         peer.validate().map_err(serde::de::Error::custom)?;
         Ok(peer)
-    }
-
-    pub(crate) fn has_raw_sendable_identity(&self) -> bool {
-        self.validate().is_ok()
     }
 }
 
@@ -579,6 +579,28 @@ mod tests {
 
         let unknown = PubKey::new([99u8; 32]);
         assert!(peers.get_peer(&unknown).is_none());
+    }
+
+    #[test]
+    fn test_zero_pubkey_is_never_trusted_or_resolved() {
+        let zero = PubKey::new([0u8; 32]);
+        let peers = TrustedPeers {
+            peers: vec![TrustedPeer {
+                name: "zero".to_string(),
+                pubkey: zero,
+                addr: "inproc://zero".to_string(),
+                meta: crate::PeerMeta::default(),
+            }],
+        };
+
+        assert!(
+            !peers.is_trusted(&zero),
+            "zero pubkey must not be trusted even if a raw peer is present"
+        );
+        assert!(
+            peers.get_peer(&zero).is_none(),
+            "zero pubkey must not resolve through raw trust lookup"
+        );
     }
 
     #[test]

--- a/meerkat-comms/tests/inproc_canonical_peer_routing.rs
+++ b/meerkat-comms/tests/inproc_canonical_peer_routing.rs
@@ -316,6 +316,175 @@ async fn ingress_rejects_late_shared_zero_pubkey_trust_mutation() {
 }
 
 #[tokio::test]
+async fn router_rejects_duplicate_trusted_canonical_peer_identity() {
+    let _lock = INPROC_REGISTRY_LOCK.lock().await;
+    let registry = InprocRegistry::global();
+    registry.clear();
+
+    let suffix = uuid::Uuid::new_v4().simple().to_string();
+    let target_keypair = Keypair::generate();
+    let target_pubkey = target_keypair.public_key();
+    let target_name = format!("duplicate-canonical-target-{suffix}");
+    let stale_name = format!("duplicate-canonical-stale-{suffix}");
+    let (mut target_inbox, target_sender) = Inbox::new();
+
+    registry.register_with_meta_in_namespace(
+        "",
+        &target_name,
+        target_pubkey,
+        target_sender,
+        PeerMeta::default(),
+    );
+
+    let (_, router_inbox_sender) = Inbox::new();
+    let router = Router::new(
+        Keypair::generate(),
+        TrustedPeers {
+            peers: vec![
+                TrustedPeer {
+                    name: stale_name.clone(),
+                    pubkey: target_pubkey,
+                    addr: format!("inproc://{stale_name}"),
+                    meta: PeerMeta::default(),
+                },
+                TrustedPeer {
+                    name: target_name.clone(),
+                    pubkey: target_pubkey,
+                    addr: format!("inproc://{target_name}"),
+                    meta: PeerMeta::default(),
+                },
+            ],
+        },
+        CommsConfig::default(),
+        router_inbox_sender,
+        true,
+    );
+
+    let dest = target_pubkey.to_peer_id();
+    let result = router
+        .send(dest, message("duplicate canonical trust must not route"))
+        .await;
+
+    assert!(
+        matches!(result, Err(SendError::PeerNotFound(peer_id)) if peer_id == dest),
+        "duplicate trusted canonical identity must fail closed: {result:?}"
+    );
+    assert!(
+        target_inbox.try_drain().is_empty(),
+        "duplicate trusted canonical identity must not deliver by whichever entry wins"
+    );
+
+    registry.clear();
+}
+
+#[tokio::test]
+async fn router_remove_trusted_peer_removes_all_duplicate_canonical_matches() {
+    let _lock = INPROC_REGISTRY_LOCK.lock().await;
+    let registry = InprocRegistry::global();
+    registry.clear();
+
+    let suffix = uuid::Uuid::new_v4().simple().to_string();
+    let target_keypair = Keypair::generate();
+    let target_pubkey = target_keypair.public_key();
+    let target_name = format!("remove-duplicate-target-{suffix}");
+    let shadow_name = format!("remove-duplicate-shadow-{suffix}");
+    let (mut target_inbox, target_sender) = Inbox::new();
+
+    registry.register_with_meta_in_namespace(
+        "",
+        &target_name,
+        target_pubkey,
+        target_sender,
+        PeerMeta::default(),
+    );
+
+    let trusted_peers = Arc::new(parking_lot::RwLock::new(TrustedPeers::new()));
+    let (_, router_inbox_sender) = Inbox::new();
+    let router = Router::with_shared_peers(
+        Keypair::generate(),
+        trusted_peers.clone(),
+        CommsConfig::default(),
+        router_inbox_sender,
+        true,
+    );
+    trusted_peers.write().peers.extend([
+        TrustedPeer {
+            name: shadow_name.clone(),
+            pubkey: target_pubkey,
+            addr: format!("inproc://{shadow_name}"),
+            meta: PeerMeta::default(),
+        },
+        TrustedPeer {
+            name: target_name.clone(),
+            pubkey: target_pubkey,
+            addr: format!("inproc://{target_name}"),
+            meta: PeerMeta::default(),
+        },
+    ]);
+
+    let dest = target_pubkey.to_peer_id();
+    assert!(
+        router.remove_trusted_peer(&dest),
+        "remove should report that duplicate canonical trust entries were removed"
+    );
+    assert!(
+        trusted_peers
+            .read()
+            .peers
+            .iter()
+            .all(|peer| peer.pubkey != target_pubkey),
+        "remove must clear every raw entry for the canonical peer id"
+    );
+
+    let result = router
+        .send(dest, message("removed duplicate trust must not route"))
+        .await;
+
+    assert!(
+        matches!(result, Err(SendError::PeerNotFound(peer_id)) if peer_id == dest),
+        "removing duplicate trust must not leave one duplicate sendable: {result:?}"
+    );
+    assert!(
+        target_inbox.try_drain().is_empty(),
+        "removed duplicate canonical identity must not deliver through the remaining entry"
+    );
+
+    registry.clear();
+}
+
+#[tokio::test]
+async fn runtime_peer_directory_skips_duplicate_trusted_canonical_peer_identity() {
+    let suffix = uuid::Uuid::new_v4().simple().to_string();
+    let runtime = CommsRuntime::inproc_only(&format!("duplicate-directory-runtime-{suffix}"))
+        .expect("runtime");
+    let target_keypair = Keypair::generate();
+    let target_pubkey = target_keypair.public_key();
+    let peer_id = target_pubkey.to_peer_id();
+
+    runtime.trusted_peers_shared().write().peers.extend([
+        TrustedPeer {
+            name: format!("duplicate-directory-primary-{suffix}"),
+            pubkey: target_pubkey,
+            addr: format!("inproc://duplicate-directory-primary-{suffix}"),
+            meta: PeerMeta::default(),
+        },
+        TrustedPeer {
+            name: format!("duplicate-directory-shadow-{suffix}"),
+            pubkey: target_pubkey,
+            addr: format!("inproc://duplicate-directory-shadow-{suffix}"),
+            meta: PeerMeta::default(),
+        },
+    ]);
+
+    let peers = CoreCommsRuntime::peers(&runtime).await;
+
+    assert!(
+        peers.iter().all(|peer| peer.peer_id != peer_id),
+        "duplicate trusted canonical identities must not be advertised: {peers:?}"
+    );
+}
+
+#[tokio::test]
 async fn router_inproc_same_namespace_delivers_to_resolved_peer_identity_not_display_name() {
     let _lock = INPROC_REGISTRY_LOCK.lock().await;
     let registry = InprocRegistry::global();

--- a/meerkat-comms/tests/inproc_canonical_peer_routing.rs
+++ b/meerkat-comms/tests/inproc_canonical_peer_routing.rs
@@ -378,6 +378,136 @@ async fn router_rejects_duplicate_trusted_canonical_peer_identity() {
 }
 
 #[tokio::test]
+async fn router_auth_disabled_fallback_rejects_duplicate_trusted_canonical_peer_identity() {
+    let _lock = INPROC_REGISTRY_LOCK.lock().await;
+    let registry = InprocRegistry::global();
+    registry.clear();
+
+    let suffix = uuid::Uuid::new_v4().simple().to_string();
+    let target_keypair = Keypair::generate();
+    let target_pubkey = target_keypair.public_key();
+    let target_name = format!("auth-disabled-duplicate-target-{suffix}");
+    let stale_name = format!("auth-disabled-duplicate-stale-{suffix}");
+    let (mut target_inbox, target_sender) = Inbox::new();
+
+    registry.register_with_meta_in_namespace(
+        "",
+        &target_name,
+        target_pubkey,
+        target_sender,
+        PeerMeta::default(),
+    );
+
+    let (_, router_inbox_sender) = Inbox::new();
+    let router = Router::new(
+        Keypair::generate(),
+        TrustedPeers {
+            peers: vec![
+                TrustedPeer {
+                    name: stale_name.clone(),
+                    pubkey: target_pubkey,
+                    addr: format!("inproc://{stale_name}"),
+                    meta: PeerMeta::default(),
+                },
+                TrustedPeer {
+                    name: target_name.clone(),
+                    pubkey: target_pubkey,
+                    addr: format!("inproc://{target_name}"),
+                    meta: PeerMeta::default(),
+                },
+            ],
+        },
+        CommsConfig::default(),
+        router_inbox_sender,
+        false,
+    );
+
+    let dest = target_pubkey.to_peer_id();
+    let result = router
+        .send(
+            dest,
+            message("auth-disabled duplicate canonical trust must not fallback"),
+        )
+        .await;
+
+    assert!(
+        matches!(result, Err(SendError::PeerNotFound(peer_id)) if peer_id == dest),
+        "auth-disabled duplicate trusted canonical identity must fail closed before fallback: {result:?}"
+    );
+    assert!(
+        target_inbox.try_drain().is_empty(),
+        "auth-disabled fallback must not deliver to an ambiguous trusted canonical identity"
+    );
+
+    registry.clear();
+}
+
+#[tokio::test]
+async fn router_auth_disabled_fallback_rejects_late_shared_duplicate_trust() {
+    let _lock = INPROC_REGISTRY_LOCK.lock().await;
+    let registry = InprocRegistry::global();
+    registry.clear();
+
+    let suffix = uuid::Uuid::new_v4().simple().to_string();
+    let target_keypair = Keypair::generate();
+    let target_pubkey = target_keypair.public_key();
+    let target_name = format!("late-auth-disabled-duplicate-target-{suffix}");
+    let stale_name = format!("late-auth-disabled-duplicate-stale-{suffix}");
+    let (mut target_inbox, target_sender) = Inbox::new();
+
+    registry.register_with_meta_in_namespace(
+        "",
+        &target_name,
+        target_pubkey,
+        target_sender,
+        PeerMeta::default(),
+    );
+
+    let trusted_peers = Arc::new(parking_lot::RwLock::new(TrustedPeers::new()));
+    let (_, router_inbox_sender) = Inbox::new();
+    let router = Router::with_shared_peers(
+        Keypair::generate(),
+        trusted_peers.clone(),
+        CommsConfig::default(),
+        router_inbox_sender,
+        false,
+    );
+    trusted_peers.write().peers.extend([
+        TrustedPeer {
+            name: stale_name.clone(),
+            pubkey: target_pubkey,
+            addr: format!("inproc://{stale_name}"),
+            meta: PeerMeta::default(),
+        },
+        TrustedPeer {
+            name: target_name.clone(),
+            pubkey: target_pubkey,
+            addr: format!("inproc://{target_name}"),
+            meta: PeerMeta::default(),
+        },
+    ]);
+
+    let dest = target_pubkey.to_peer_id();
+    let result = router
+        .send(
+            dest,
+            message("late shared duplicate canonical trust must not fallback"),
+        )
+        .await;
+
+    assert!(
+        matches!(result, Err(SendError::PeerNotFound(peer_id)) if peer_id == dest),
+        "late shared duplicate trusted canonical identity must fail closed before fallback: {result:?}"
+    );
+    assert!(
+        target_inbox.try_drain().is_empty(),
+        "auth-disabled fallback must not deliver after late shared duplicate trust mutation"
+    );
+
+    registry.clear();
+}
+
+#[tokio::test]
 async fn router_remove_trusted_peer_removes_all_duplicate_canonical_matches() {
     let _lock = INPROC_REGISTRY_LOCK.lock().await;
     let registry = InprocRegistry::global();
@@ -482,6 +612,73 @@ async fn runtime_peer_directory_skips_duplicate_trusted_canonical_peer_identity(
         peers.iter().all(|peer| peer.peer_id != peer_id),
         "duplicate trusted canonical identities must not be advertised: {peers:?}"
     );
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+#[tokio::test]
+async fn runtime_auth_disabled_directory_suppresses_inproc_for_duplicate_trust() {
+    let _lock = INPROC_REGISTRY_LOCK.lock().await;
+    let registry = InprocRegistry::global();
+    registry.clear();
+
+    let suffix = uuid::Uuid::new_v4().simple().to_string();
+    let runtime_name = format!("auth-disabled-duplicate-directory-runtime-{suffix}");
+    let target_name = format!("auth-disabled-duplicate-directory-target-{suffix}");
+    let stale_name = format!("auth-disabled-duplicate-directory-stale-{suffix}");
+    let tmp = tempfile::TempDir::new().expect("tempdir");
+    let runtime = CommsRuntime::new(meerkat_comms::ResolvedCommsConfig {
+        enabled: true,
+        name: runtime_name,
+        inproc_namespace: None,
+        identity_dir: tmp.path().join("identity"),
+        trusted_peers_path: tmp.path().join("trusted_peers.json"),
+        listen_uds: None,
+        listen_tcp: None,
+        event_listen_tcp: None,
+        #[cfg(unix)]
+        event_listen_uds: None,
+        comms_config: CommsConfig::default(),
+        auth: meerkat_core::CommsAuthMode::Open,
+        require_peer_auth: false,
+        allow_external_unauthenticated: false,
+    })
+    .await
+    .expect("auth-disabled runtime");
+    let target_keypair = Keypair::generate();
+    let target_pubkey = target_keypair.public_key();
+    let peer_id = target_pubkey.to_peer_id();
+    let (_target_inbox, target_sender) = Inbox::new();
+
+    runtime.trusted_peers_shared().write().peers.extend([
+        TrustedPeer {
+            name: stale_name.clone(),
+            pubkey: target_pubkey,
+            addr: format!("inproc://{stale_name}"),
+            meta: PeerMeta::default(),
+        },
+        TrustedPeer {
+            name: target_name.clone(),
+            pubkey: target_pubkey,
+            addr: format!("inproc://{target_name}"),
+            meta: PeerMeta::default(),
+        },
+    ]);
+    registry.register_with_meta_in_namespace(
+        "",
+        &target_name,
+        target_pubkey,
+        target_sender,
+        PeerMeta::default(),
+    );
+
+    let peers = CoreCommsRuntime::peers(&runtime).await;
+
+    assert!(
+        peers.iter().all(|peer| peer.peer_id != peer_id),
+        "auth-disabled peer directory must not re-advertise ambiguous trusted identities as inproc: {peers:?}"
+    );
+
+    registry.clear();
 }
 
 #[tokio::test]

--- a/meerkat-comms/tests/inproc_canonical_peer_routing.rs
+++ b/meerkat-comms/tests/inproc_canonical_peer_routing.rs
@@ -1,0 +1,93 @@
+use std::sync::LazyLock;
+
+use meerkat_comms::{
+    CommsConfig, Inbox, InboxItem, InprocRegistry, Keypair, MessageKind, PeerMeta, Router,
+    TrustedPeer, TrustedPeers,
+};
+
+static INPROC_REGISTRY_LOCK: LazyLock<tokio::sync::Mutex<()>> =
+    LazyLock::new(|| tokio::sync::Mutex::new(()));
+
+fn message(body: &str) -> MessageKind {
+    MessageKind::Message {
+        body: body.to_string(),
+        blocks: None,
+        handling_mode: None,
+    }
+}
+
+#[tokio::test]
+async fn router_inproc_same_namespace_delivers_to_resolved_peer_identity_not_display_name() {
+    let _lock = INPROC_REGISTRY_LOCK.lock().await;
+    let registry = InprocRegistry::global();
+    registry.clear();
+
+    let target_keypair = Keypair::generate();
+    let target_pubkey = target_keypair.public_key();
+    let shadow_keypair = Keypair::generate();
+    let shadow_pubkey = shadow_keypair.public_key();
+
+    let (mut target_inbox, target_sender) = Inbox::new();
+    let (mut shadow_inbox, shadow_sender) = Inbox::new();
+
+    registry.register_with_meta_in_namespace(
+        "",
+        "canonical-target",
+        target_pubkey,
+        target_sender,
+        PeerMeta::default(),
+    );
+    registry.register_with_meta_in_namespace(
+        "",
+        "shared-display-name",
+        shadow_pubkey,
+        shadow_sender,
+        PeerMeta::default(),
+    );
+
+    let sender_keypair = Keypair::generate();
+    let sender_pubkey = sender_keypair.public_key();
+    let trusted_peers = TrustedPeers {
+        peers: vec![TrustedPeer {
+            name: "shared-display-name".to_string(),
+            pubkey: target_pubkey,
+            addr: "inproc://shared-display-name".to_string(),
+            meta: PeerMeta::default(),
+        }],
+    };
+    let (_, router_inbox_sender) = Inbox::new();
+    let router = Router::new(
+        sender_keypair,
+        trusted_peers,
+        CommsConfig::default(),
+        router_inbox_sender,
+        true,
+    );
+
+    router
+        .send(
+            meerkat_comms::router::peer_id_from_pubkey(&target_pubkey),
+            message("canonical route"),
+        )
+        .await
+        .expect("send should route to the trusted peer identity");
+
+    let target_items = target_inbox.try_drain();
+    let shadow_items = shadow_inbox.try_drain();
+
+    assert_eq!(
+        shadow_items.len(),
+        0,
+        "display-name shadow must not receive"
+    );
+    assert_eq!(target_items.len(), 1, "canonical target should receive");
+
+    let InboxItem::External { envelope } = &target_items[0] else {
+        panic!("expected external envelope");
+    };
+    assert_eq!(envelope.from, sender_pubkey);
+    assert_eq!(envelope.to, target_pubkey);
+    assert!(envelope.verify(), "signed envelope should verify");
+
+    registry.clear();
+}

--- a/meerkat-comms/tests/inproc_canonical_peer_routing.rs
+++ b/meerkat-comms/tests/inproc_canonical_peer_routing.rs
@@ -1,9 +1,11 @@
 use std::sync::{Arc, LazyLock};
 
 use meerkat_comms::{
-    CommsConfig, Inbox, InboxItem, InprocRegistry, Keypair, MessageKind, PeerMeta, Router,
-    PubKey, SendError, TrustedPeer, TrustedPeers,
+    AdmissionOutcome, CommsConfig, CommsRuntime, DropReason, Envelope, Inbox, InboxItem,
+    InprocRegistry, Keypair, MessageKind, PeerMeta, PubKey, Router, SendError, Signature,
+    TrustedPeer, TrustedPeers,
 };
+use meerkat_core::agent::CommsRuntime as CoreCommsRuntime;
 
 static INPROC_REGISTRY_LOCK: LazyLock<tokio::sync::Mutex<()>> =
     LazyLock::new(|| tokio::sync::Mutex::new(()));
@@ -183,6 +185,134 @@ async fn router_add_trusted_peer_raw_zero_pubkey_trust_is_not_sendable() {
     );
 
     registry.clear();
+}
+
+#[tokio::test]
+async fn router_auth_disabled_inproc_fallback_rejects_zero_pubkey_registry_identity() {
+    let _lock = INPROC_REGISTRY_LOCK.lock().await;
+    let registry = InprocRegistry::global();
+    registry.clear();
+
+    let suffix = uuid::Uuid::new_v4().simple().to_string();
+    let target_name = format!("auth-disabled-zero-fallback-{suffix}");
+    let mut target_inbox = register_zero_pubkey_inproc_target(registry, &target_name);
+    let (_, router_inbox_sender) = Inbox::new();
+    let router = Router::new(
+        Keypair::generate(),
+        TrustedPeers::new(),
+        CommsConfig::default(),
+        router_inbox_sender,
+        false,
+    );
+
+    let dest = zero_pubkey().to_peer_id();
+    let result = router
+        .send(
+            dest,
+            message("auth-disabled fallback must not trust zero pubkeys"),
+        )
+        .await;
+
+    assert!(
+        matches!(result, Err(SendError::PeerNotFound(peer_id)) if peer_id == dest),
+        "auth-disabled inproc fallback must not synthesize a zero-pubkey sendable peer: {result:?}"
+    );
+    assert!(
+        target_inbox.try_drain().is_empty(),
+        "zero-pubkey registry target must not receive through auth-disabled fallback"
+    );
+
+    registry.clear();
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+#[tokio::test]
+async fn runtime_auth_disabled_directory_skips_zero_pubkey_inproc_identity() {
+    let _lock = INPROC_REGISTRY_LOCK.lock().await;
+    let registry = InprocRegistry::global();
+    registry.clear();
+
+    let suffix = uuid::Uuid::new_v4().simple().to_string();
+    let runtime_name = format!("auth-disabled-directory-sender-{suffix}");
+    let zero_name = format!("auth-disabled-directory-zero-{suffix}");
+    let tmp = tempfile::TempDir::new().expect("tempdir");
+    let runtime = CommsRuntime::new(meerkat_comms::ResolvedCommsConfig {
+        enabled: true,
+        name: runtime_name,
+        inproc_namespace: None,
+        identity_dir: tmp.path().join("identity"),
+        trusted_peers_path: tmp.path().join("trusted_peers.json"),
+        listen_uds: None,
+        listen_tcp: None,
+        event_listen_tcp: None,
+        #[cfg(unix)]
+        event_listen_uds: None,
+        comms_config: CommsConfig::default(),
+        auth: meerkat_core::CommsAuthMode::Open,
+        require_peer_auth: false,
+        allow_external_unauthenticated: false,
+    })
+    .await
+    .expect("auth-disabled runtime");
+
+    let (_zero_inbox, zero_sender) = Inbox::new();
+    registry.register_with_meta_in_namespace(
+        "",
+        &zero_name,
+        zero_pubkey(),
+        zero_sender,
+        PeerMeta::default(),
+    );
+
+    let peers = CoreCommsRuntime::peers(&runtime).await;
+    assert!(
+        peers
+            .iter()
+            .all(|peer| peer.peer_id != zero_pubkey().to_peer_id()),
+        "auth-disabled peer directory must not advertise zero-pubkey inproc identities: {peers:?}"
+    );
+
+    registry.clear();
+}
+
+#[tokio::test]
+async fn ingress_rejects_late_shared_zero_pubkey_trust_mutation() {
+    let suffix = uuid::Uuid::new_v4().simple().to_string();
+    let receiver =
+        CommsRuntime::inproc_only(&format!("zero-ingress-receiver-{suffix}")).expect("runtime");
+    let trusted_peers = receiver.router_arc().shared_trusted_peers();
+    trusted_peers
+        .write()
+        .peers
+        .push(raw_zero_trusted_peer(&format!(
+            "zero-ingress-sender-{suffix}"
+        )));
+
+    let envelope = Envelope {
+        id: uuid::Uuid::new_v4(),
+        from: zero_pubkey(),
+        to: receiver.public_key(),
+        kind: message("zero pubkey ingress must not admit"),
+        sig: Signature::new([0u8; 64]),
+    };
+
+    let outcome = receiver
+        .router_arc()
+        .inbox_sender()
+        .send_connection_ingress(envelope, true, &trusted_peers);
+    assert_eq!(
+        outcome,
+        AdmissionOutcome::Dropped {
+            reason: DropReason::UntrustedSender
+        },
+        "late shared zero-pubkey trust mutation must not admit ingress"
+    );
+
+    let drained = CoreCommsRuntime::drain_messages(&receiver).await;
+    assert!(
+        drained.is_empty(),
+        "zero-pubkey ingress must not reach runtime messages: {drained:?}"
+    );
 }
 
 #[tokio::test]

--- a/meerkat-comms/tests/inproc_canonical_peer_routing.rs
+++ b/meerkat-comms/tests/inproc_canonical_peer_routing.rs
@@ -1,8 +1,8 @@
-use std::sync::LazyLock;
+use std::sync::{Arc, LazyLock};
 
 use meerkat_comms::{
     CommsConfig, Inbox, InboxItem, InprocRegistry, Keypair, MessageKind, PeerMeta, Router,
-    SendError, TrustedPeer, TrustedPeers,
+    PubKey, SendError, TrustedPeer, TrustedPeers,
 };
 
 static INPROC_REGISTRY_LOCK: LazyLock<tokio::sync::Mutex<()>> =
@@ -14,6 +14,175 @@ fn message(body: &str) -> MessageKind {
         blocks: None,
         handling_mode: None,
     }
+}
+
+fn zero_pubkey() -> PubKey {
+    PubKey::new([0u8; 32])
+}
+
+fn raw_zero_trusted_peer(name: &str) -> TrustedPeer {
+    TrustedPeer {
+        name: name.to_string(),
+        pubkey: zero_pubkey(),
+        addr: format!("inproc://{name}"),
+        meta: PeerMeta::default(),
+    }
+}
+
+fn register_zero_pubkey_inproc_target(registry: &InprocRegistry, name: &str) -> Inbox {
+    let (inbox, sender) = Inbox::new();
+    registry.register_with_meta_in_namespace("", name, zero_pubkey(), sender, PeerMeta::default());
+    inbox
+}
+
+#[tokio::test]
+async fn router_new_raw_zero_pubkey_trust_is_not_sendable() {
+    let _lock = INPROC_REGISTRY_LOCK.lock().await;
+    let registry = InprocRegistry::global();
+    registry.clear();
+
+    let suffix = uuid::Uuid::new_v4().simple().to_string();
+    let target_name = format!("raw-zero-router-new-{suffix}");
+    let mut target_inbox = register_zero_pubkey_inproc_target(registry, &target_name);
+    let (_, router_inbox_sender) = Inbox::new();
+    let router = Router::new(
+        Keypair::generate(),
+        TrustedPeers {
+            peers: vec![raw_zero_trusted_peer(&target_name)],
+        },
+        CommsConfig::default(),
+        router_inbox_sender,
+        true,
+    );
+
+    let dest = zero_pubkey().to_peer_id();
+    let result = router.send(dest, message("raw zero should not send")).await;
+
+    assert!(
+        matches!(result, Err(SendError::PeerNotFound(peer_id)) if peer_id == dest),
+        "raw Router::new zero-pubkey trust must not be sendable: {result:?}"
+    );
+    assert!(
+        target_inbox.try_drain().is_empty(),
+        "zero-pubkey registry target must not receive from raw Router::new trust"
+    );
+
+    registry.clear();
+}
+
+#[tokio::test]
+async fn router_with_shared_peers_raw_zero_pubkey_trust_is_not_sendable() {
+    let _lock = INPROC_REGISTRY_LOCK.lock().await;
+    let registry = InprocRegistry::global();
+    registry.clear();
+
+    let suffix = uuid::Uuid::new_v4().simple().to_string();
+    let target_name = format!("raw-zero-router-shared-{suffix}");
+    let mut target_inbox = register_zero_pubkey_inproc_target(registry, &target_name);
+    let trusted_peers = Arc::new(parking_lot::RwLock::new(TrustedPeers {
+        peers: vec![raw_zero_trusted_peer(&target_name)],
+    }));
+    let (_, router_inbox_sender) = Inbox::new();
+    let router = Router::with_shared_peers(
+        Keypair::generate(),
+        trusted_peers,
+        CommsConfig::default(),
+        router_inbox_sender,
+        true,
+    );
+
+    let dest = zero_pubkey().to_peer_id();
+    let result = router.send(dest, message("raw zero should not send")).await;
+
+    assert!(
+        matches!(result, Err(SendError::PeerNotFound(peer_id)) if peer_id == dest),
+        "raw Router::with_shared_peers zero-pubkey trust must not be sendable: {result:?}"
+    );
+    assert!(
+        target_inbox.try_drain().is_empty(),
+        "zero-pubkey registry target must not receive from raw shared trust"
+    );
+
+    registry.clear();
+}
+
+#[tokio::test]
+async fn router_send_filters_late_shared_raw_zero_pubkey_trust_mutation() {
+    let _lock = INPROC_REGISTRY_LOCK.lock().await;
+    let registry = InprocRegistry::global();
+    registry.clear();
+
+    let suffix = uuid::Uuid::new_v4().simple().to_string();
+    let target_name = format!("raw-zero-router-late-shared-{suffix}");
+    let mut target_inbox = register_zero_pubkey_inproc_target(registry, &target_name);
+    let trusted_peers = Arc::new(parking_lot::RwLock::new(TrustedPeers::new()));
+    let (_, router_inbox_sender) = Inbox::new();
+    let router = Router::with_shared_peers(
+        Keypair::generate(),
+        trusted_peers.clone(),
+        CommsConfig::default(),
+        router_inbox_sender,
+        true,
+    );
+    trusted_peers
+        .write()
+        .peers
+        .push(raw_zero_trusted_peer(&target_name));
+
+    let dest = zero_pubkey().to_peer_id();
+    let result = router
+        .send(dest, message("late raw zero should not send"))
+        .await;
+
+    assert!(
+        matches!(result, Err(SendError::PeerNotFound(peer_id)) if peer_id == dest),
+        "late shared zero-pubkey trust mutation must not become sendable: {result:?}"
+    );
+    assert!(
+        target_inbox.try_drain().is_empty(),
+        "zero-pubkey registry target must not receive from late shared trust mutation"
+    );
+
+    registry.clear();
+}
+
+#[tokio::test]
+async fn router_add_trusted_peer_raw_zero_pubkey_trust_is_not_sendable() {
+    let _lock = INPROC_REGISTRY_LOCK.lock().await;
+    let registry = InprocRegistry::global();
+    registry.clear();
+
+    let suffix = uuid::Uuid::new_v4().simple().to_string();
+    let target_name = format!("raw-zero-router-add-{suffix}");
+    let mut target_inbox = register_zero_pubkey_inproc_target(registry, &target_name);
+    let (_, router_inbox_sender) = Inbox::new();
+    let router = Router::new(
+        Keypair::generate(),
+        TrustedPeers::new(),
+        CommsConfig::default(),
+        router_inbox_sender,
+        true,
+    );
+    assert!(
+        router
+            .add_trusted_peer(raw_zero_trusted_peer(&target_name))
+            .is_err(),
+        "raw Router::add_trusted_peer zero-pubkey trust must be rejected"
+    );
+
+    let dest = zero_pubkey().to_peer_id();
+    let result = router.send(dest, message("raw zero should not send")).await;
+
+    assert!(
+        matches!(result, Err(SendError::PeerNotFound(peer_id)) if peer_id == dest),
+        "raw Router::add_trusted_peer zero-pubkey trust must not be sendable: {result:?}"
+    );
+    assert!(
+        target_inbox.try_drain().is_empty(),
+        "zero-pubkey registry target must not receive from raw add_trusted_peer trust"
+    );
+
+    registry.clear();
 }
 
 #[tokio::test]

--- a/meerkat-comms/tests/inproc_canonical_peer_routing.rs
+++ b/meerkat-comms/tests/inproc_canonical_peer_routing.rs
@@ -2,7 +2,7 @@ use std::sync::LazyLock;
 
 use meerkat_comms::{
     CommsConfig, Inbox, InboxItem, InprocRegistry, Keypair, MessageKind, PeerMeta, Router,
-    TrustedPeer, TrustedPeers,
+    SendError, TrustedPeer, TrustedPeers,
 };
 
 static INPROC_REGISTRY_LOCK: LazyLock<tokio::sync::Mutex<()>> =
@@ -88,6 +88,72 @@ async fn router_inproc_same_namespace_delivers_to_resolved_peer_identity_not_dis
     assert_eq!(envelope.from, sender_pubkey);
     assert_eq!(envelope.to, target_pubkey);
     assert!(envelope.verify(), "signed envelope should verify");
+
+    registry.clear();
+}
+
+#[tokio::test]
+async fn router_inproc_cross_namespace_rejects_ambiguous_peer_identity() {
+    let _lock = INPROC_REGISTRY_LOCK.lock().await;
+    let registry = InprocRegistry::global();
+    registry.clear();
+
+    let target_keypair = Keypair::generate();
+    let target_pubkey = target_keypair.public_key();
+    let (mut alpha_inbox, alpha_sender) = Inbox::new();
+    let (mut beta_inbox, beta_sender) = Inbox::new();
+
+    registry.register_with_meta_in_namespace(
+        "realm-alpha",
+        "alpha-target",
+        target_pubkey,
+        alpha_sender,
+        PeerMeta::default(),
+    );
+    registry.register_with_meta_in_namespace(
+        "realm-beta",
+        "beta-target",
+        target_pubkey,
+        beta_sender,
+        PeerMeta::default(),
+    );
+
+    let sender_keypair = Keypair::generate();
+    let trusted_peers = TrustedPeers {
+        peers: vec![TrustedPeer {
+            name: "alpha-target".to_string(),
+            pubkey: target_pubkey,
+            addr: "inproc://alpha-target".to_string(),
+            meta: PeerMeta::default(),
+        }],
+    };
+    let (_, router_inbox_sender) = Inbox::new();
+    let router = Router::new(
+        sender_keypair,
+        trusted_peers,
+        CommsConfig::default(),
+        router_inbox_sender,
+        true,
+    )
+    .with_inproc_namespace(Some("realm-sender".to_string()));
+
+    let dest = meerkat_comms::router::peer_id_from_pubkey(&target_pubkey);
+    let result = router
+        .send(dest, message("ambiguous cross-namespace route"))
+        .await;
+
+    assert!(
+        matches!(result, Err(SendError::PeerNotFound(peer_id)) if peer_id == dest),
+        "ambiguous cross-namespace pubkey registrations must fail closed: {result:?}"
+    );
+    assert!(
+        alpha_inbox.try_drain().is_empty(),
+        "must not fall back to display-name scoped delivery"
+    );
+    assert!(
+        beta_inbox.try_drain().is_empty(),
+        "must not pick an arbitrary namespace for a reused identity"
+    );
 
     registry.clear();
 }

--- a/meerkat-comms/tests/inproc_canonical_peer_routing.rs
+++ b/meerkat-comms/tests/inproc_canonical_peer_routing.rs
@@ -681,6 +681,67 @@ async fn runtime_auth_disabled_directory_suppresses_inproc_for_duplicate_trust()
     registry.clear();
 }
 
+#[cfg(not(target_arch = "wasm32"))]
+#[tokio::test]
+async fn runtime_auth_disabled_directory_suppresses_inproc_for_duplicate_live_canonical_identity() {
+    let _lock = INPROC_REGISTRY_LOCK.lock().await;
+    let registry = InprocRegistry::global();
+    registry.clear();
+
+    let suffix = uuid::Uuid::new_v4().simple().to_string();
+    let runtime_name = format!("auth-disabled-live-duplicate-directory-runtime-{suffix}");
+    let local_name = format!("auth-disabled-live-duplicate-local-{suffix}");
+    let remote_name = format!("auth-disabled-live-duplicate-remote-{suffix}");
+    let tmp = tempfile::TempDir::new().expect("tempdir");
+    let runtime = CommsRuntime::new(meerkat_comms::ResolvedCommsConfig {
+        enabled: true,
+        name: runtime_name,
+        inproc_namespace: Some("realm-local".to_string()),
+        identity_dir: tmp.path().join("identity"),
+        trusted_peers_path: tmp.path().join("trusted_peers.json"),
+        listen_uds: None,
+        listen_tcp: None,
+        event_listen_tcp: None,
+        #[cfg(unix)]
+        event_listen_uds: None,
+        comms_config: CommsConfig::default(),
+        auth: meerkat_core::CommsAuthMode::Open,
+        require_peer_auth: false,
+        allow_external_unauthenticated: false,
+    })
+    .await
+    .expect("auth-disabled runtime");
+    let target_keypair = Keypair::generate();
+    let target_pubkey = target_keypair.public_key();
+    let peer_id = target_pubkey.to_peer_id();
+    let (_local_inbox, local_sender) = Inbox::new();
+    let (_remote_inbox, remote_sender) = Inbox::new();
+
+    registry.register_with_meta_in_namespace(
+        "realm-local",
+        &local_name,
+        target_pubkey,
+        local_sender,
+        PeerMeta::default(),
+    );
+    registry.register_with_meta_in_namespace(
+        "realm-remote",
+        &remote_name,
+        target_pubkey,
+        remote_sender,
+        PeerMeta::default(),
+    );
+
+    let peers = CoreCommsRuntime::peers(&runtime).await;
+
+    assert!(
+        peers.iter().all(|peer| peer.peer_id != peer_id),
+        "auth-disabled peer directory must not advertise duplicate live canonical inproc identities: {peers:?}"
+    );
+
+    registry.clear();
+}
+
 #[tokio::test]
 async fn router_inproc_same_namespace_delivers_to_resolved_peer_identity_not_display_name() {
     let _lock = INPROC_REGISTRY_LOCK.lock().await;
@@ -753,6 +814,72 @@ async fn router_inproc_same_namespace_delivers_to_resolved_peer_identity_not_dis
     assert_eq!(envelope.from, sender_pubkey);
     assert_eq!(envelope.to, target_pubkey);
     assert!(envelope.verify(), "signed envelope should verify");
+
+    registry.clear();
+}
+
+#[tokio::test]
+async fn router_inproc_same_namespace_rejects_duplicate_live_canonical_peer_identity() {
+    let _lock = INPROC_REGISTRY_LOCK.lock().await;
+    let registry = InprocRegistry::global();
+    registry.clear();
+
+    let target_keypair = Keypair::generate();
+    let target_pubkey = target_keypair.public_key();
+    let (mut local_inbox, local_sender) = Inbox::new();
+    let (mut remote_inbox, remote_sender) = Inbox::new();
+
+    registry.register_with_meta_in_namespace(
+        "realm-local",
+        "local-target",
+        target_pubkey,
+        local_sender,
+        PeerMeta::default(),
+    );
+    registry.register_with_meta_in_namespace(
+        "realm-remote",
+        "remote-target",
+        target_pubkey,
+        remote_sender,
+        PeerMeta::default(),
+    );
+
+    let sender_keypair = Keypair::generate();
+    let trusted_peers = TrustedPeers {
+        peers: vec![TrustedPeer {
+            name: "local-target".to_string(),
+            pubkey: target_pubkey,
+            addr: "inproc://local-target".to_string(),
+            meta: PeerMeta::default(),
+        }],
+    };
+    let (_, router_inbox_sender) = Inbox::new();
+    let router = Router::new(
+        sender_keypair,
+        trusted_peers,
+        CommsConfig::default(),
+        router_inbox_sender,
+        true,
+    )
+    .with_inproc_namespace(Some("realm-local".to_string()));
+
+    let dest = meerkat_comms::router::peer_id_from_pubkey(&target_pubkey);
+    let result = router
+        .send(dest, message("same-namespace duplicate canonical route"))
+        .await;
+
+    assert!(
+        matches!(result, Err(SendError::PeerNotFound(peer_id)) if peer_id == dest),
+        "same-namespace inproc delivery must fail closed when the canonical identity is live in another namespace: {result:?}"
+    );
+    assert!(
+        local_inbox.try_drain().is_empty(),
+        "must not deliver to the namespace-local registration before checking canonical ambiguity"
+    );
+    assert!(
+        remote_inbox.try_drain().is_empty(),
+        "must not choose the duplicate registration in another namespace"
+    );
 
     registry.clear();
 }

--- a/meerkat-mob/src/runtime/tests.rs
+++ b/meerkat-mob/src/runtime/tests.rs
@@ -3200,8 +3200,11 @@ async fn spawn_live_external_peer(peer_name: &str) -> LiveExternalPeerHarness {
                                 candidate.interaction.id.0,
                             ))
                             .expect("record inbound peer request before response");
-                        let reply_name = candidate.interaction.from.clone();
-                        let to = test_trusted_peer_route(responder_runtime.as_ref(), &reply_name);
+                        let to = trust_candidate_sender_for_reply(
+                            responder_runtime.as_ref(),
+                            &candidate,
+                        )
+                        .await;
                         let bridge_parse: Result<super::bridge_protocol::BridgeCommand, _> =
                             serde_json::from_value(params.clone());
                         let mut remove_supervisors_after_response = Vec::new();
@@ -3880,6 +3883,47 @@ fn test_trusted_peer_route(comms: &meerkat_comms::CommsRuntime, name: &str) -> P
     let trusted = comms.trusted_peers_shared();
     let trusted = trusted.read();
     panic!("trusted or inproc peer route not found for {name}; trusted={trusted:?}");
+}
+
+async fn trust_candidate_sender_for_reply(
+    comms: &meerkat_comms::CommsRuntime,
+    candidate: &meerkat_core::interaction::PeerInputCandidate,
+) -> PeerRoute {
+    let route = candidate
+        .ingress
+        .route
+        .clone()
+        .or_else(|| {
+            candidate.interaction.from_route.map(|peer_id| {
+                PeerRoute::with_display_name(
+                    peer_id,
+                    PeerName::new(candidate.interaction.from.clone())
+                        .expect("candidate sender display name should be valid"),
+                )
+            })
+        })
+        .expect("peer request candidate must carry a typed reply route");
+    let display_name = route
+        .display_name
+        .clone()
+        .or_else(|| candidate.ingress.display_name.clone())
+        .expect("inproc reply route must carry the sender display name");
+    let signing_pubkey = candidate
+        .ingress
+        .signing_pubkey
+        .expect("peer request candidate must carry the sender signing pubkey");
+    let descriptor = TrustedPeerDescriptor::unsigned_with_pubkey(
+        display_name.as_str(),
+        route.peer_id.to_string(),
+        signing_pubkey,
+        format!("inproc://{}", display_name.as_str()),
+    )
+    .expect("typed ingress sender should convert to a reply trusted peer");
+    comms
+        .add_trusted_peer(descriptor)
+        .await
+        .expect("trust typed ingress sender for bridge reply");
+    route
 }
 
 fn with_unique_mob_id(mut definition: MobDefinition, label: &str) -> MobDefinition {


### PR DESCRIPTION
## Summary
- route same-namespace and fallback inproc sends by the resolved trusted peer pubkey instead of display name
- add a router-level regression proving a display-name shadow cannot receive a canonical PeerId send
- adjust the mob live-external test harness to reply via typed ingress route + signing pubkey instead of re-resolving by display name
- add the new comms regression to generated Bazel fast test targets

Linear: LUC-287

## Validation
- `./scripts/repo-cargo fmt --check`
- `./scripts/repo-cargo test -p meerkat-comms --test inproc_canonical_peer_routing`
- `./scripts/repo-cargo test -p meerkat-comms --lib inproc::tests::test_send_to_pubkey_in_namespace_ignores_display_name_collision -- --exact`
- `./scripts/repo-cargo test -p meerkat-mob --lib runtime::tests::test_rotate_supervisor_advances_local_authority_when_rollback_fails -- --exact --nocapture`
- `./scripts/repo-cargo test -p meerkat-mob --lib runtime::tests::test_rotate_supervisor -- --nocapture`
- `make buildbuddy-generate-check`
- `MEERKAT_BUILDBUDDY=1 make test`

## Review
- Spawned review pass 1: no blockers
- Spawned review pass 2: no blockers