### PR TITLE
LUC-288: Make deferred tool load authority typed

### DIFF
--- a/meerkat-core/src/agent/state.rs
+++ b/meerkat-core/src/agent/state.rs
@@ -3391,8 +3391,8 @@ mod tests {
                 outcome
                     .session_effects
                     .push(crate::ops::SessionEffect::RequestDeferredTools {
-                        authorities: [(
-                            "deferred_tool".to_string(),
+                        authorities: vec![crate::DeferredToolLoadAuthority::new(
+                            "deferred_tool",
                             crate::ToolVisibilityWitness {
                                 stable_owner_key: Some("callback:test".to_string()),
                                 last_seen_provenance: Some(crate::ToolProvenance {
@@ -3400,9 +3400,7 @@ mod tests {
                                     source_id: "test".into(),
                                 }),
                             },
-                        )]
-                        .into_iter()
-                        .collect(),
+                        )],
                     });
                 return Ok(outcome);
             }

--- a/meerkat-core/src/lib.rs
+++ b/meerkat-core/src/lib.rs
@@ -242,15 +242,15 @@ pub use service::{
     StageToolResultsRequest, StageToolResultsResult, StartTurnRequest, TurnToolOverlay,
 };
 pub use session::{
-    DeferredFirstTurnPhase, PendingDeferredPrompt, PendingSystemContextAppend,
-    PendingToolResultsMessage, SESSION_BUILD_STATE_KEY, SESSION_DEFERRED_TURN_STATE_KEY,
-    SESSION_METADATA_SCHEMA_VERSION, SESSION_SYSTEM_CONTEXT_STATE_KEY,
-    SESSION_TOOL_VISIBILITY_STATE_KEY, SESSION_VERSION, SYSTEM_CONTEXT_SEPARATOR,
-    SeenSystemContextKey, SeenSystemContextState, Session, SessionBuildState,
-    SessionDeferredTurnState, SessionLlmIdentity, SessionLlmRequestPolicy, SessionMeta,
-    SessionMetadata, SessionSystemContextState, SessionToolVisibilityState, SessionTooling,
-    SystemContextStageError, ToolCategoryOverride, ToolVisibilityWitness, VIEW_IMAGE_TOOL_NAME,
-    capability_base_filter_for_image_tool_results,
+    DeferredFirstTurnPhase, DeferredToolLoadAuthority, PendingDeferredPrompt,
+    PendingSystemContextAppend, PendingToolResultsMessage, SESSION_BUILD_STATE_KEY,
+    SESSION_DEFERRED_TURN_STATE_KEY, SESSION_METADATA_SCHEMA_VERSION,
+    SESSION_SYSTEM_CONTEXT_STATE_KEY, SESSION_TOOL_VISIBILITY_STATE_KEY, SESSION_VERSION,
+    SYSTEM_CONTEXT_SEPARATOR, SeenSystemContextKey, SeenSystemContextState, Session,
+    SessionBuildState, SessionDeferredTurnState, SessionLlmIdentity, SessionLlmRequestPolicy,
+    SessionMeta, SessionMetadata, SessionSystemContextState, SessionToolVisibilityState,
+    SessionTooling, SystemContextStageError, ToolCategoryOverride, ToolVisibilityWitness,
+    VIEW_IMAGE_TOOL_NAME, capability_base_filter_for_image_tool_results,
 };
 pub use session_recovery::{
     BUILD_ONLY_RECOVERY_OVERRIDE_ERROR, RecoveredSessionBuild, SurfaceSessionRecoveryContext,

--- a/meerkat-core/src/ops.rs
+++ b/meerkat-core/src/ops.rs
@@ -4,10 +4,9 @@
 
 use crate::budget::BudgetLimits;
 use crate::error::ToolError;
-use crate::session::ToolVisibilityWitness;
+use crate::session::DeferredToolLoadAuthority;
 use crate::types::{Message, ToolNameSet};
 use serde::{Deserialize, Serialize};
-use std::collections::BTreeMap;
 use uuid::Uuid;
 
 /// Unique identifier for an operation
@@ -87,7 +86,7 @@ pub enum SessionEffect {
     GrantManageMob { mob_id: String },
     /// Record durable deferred-tool requests for subsequent boundaries.
     RequestDeferredTools {
-        authorities: BTreeMap<String, ToolVisibilityWitness>,
+        authorities: Vec<DeferredToolLoadAuthority>,
     },
     /// Append durable assistant blocks produced by a tool after the tool has
     /// committed any external payloads (for example generated image blobs).

--- a/meerkat-core/src/session.rs
+++ b/meerkat-core/src/session.rs
@@ -240,6 +240,31 @@ impl ToolVisibilityWitness {
     }
 }
 
+/// Typed authority value for a deferred-tool load request.
+///
+/// The public/effect seam carries the requested route name and provenance
+/// witness as one value. Canonical owners may project this into name-indexed
+/// maps internally, but callers do not get to make a map key the authority.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub struct DeferredToolLoadAuthority {
+    pub name: String,
+    pub witness: ToolVisibilityWitness,
+}
+
+impl DeferredToolLoadAuthority {
+    pub fn new(name: impl Into<String>, witness: ToolVisibilityWitness) -> Self {
+        Self {
+            name: name.into(),
+            witness,
+        }
+    }
+
+    pub fn into_parts(self) -> (String, ToolVisibilityWitness) {
+        (self.name, self.witness)
+    }
+}
+
 /// Canonical durable session-local tool visibility intent.
 #[derive(Debug, Clone, Serialize, Deserialize, Default, PartialEq, Eq)]
 #[serde(rename_all = "snake_case")]

--- a/meerkat-core/src/tool_scope.rs
+++ b/meerkat-core/src/tool_scope.rs
@@ -1,6 +1,8 @@
 //! Tool visibility scope and external filter staging.
 
-use crate::session::{SessionToolVisibilityState, ToolVisibilityWitness};
+use crate::session::{
+    DeferredToolLoadAuthority, SessionToolVisibilityState, ToolVisibilityWitness,
+};
 use crate::tool_catalog::stable_owner_key_for_tool;
 use crate::types::{ToolDef, ToolNameSet};
 use std::collections::BTreeSet;
@@ -225,7 +227,7 @@ pub trait ToolVisibilityOwner: Send + Sync {
 
     fn request_deferred_tools(
         &self,
-        authorities: std::collections::BTreeMap<String, ToolVisibilityWitness>,
+        authorities: Vec<DeferredToolLoadAuthority>,
     ) -> Result<ToolScopeRevision, ToolScopeStageError>;
 
     fn replace_deferred_tool_authority_catalog(
@@ -337,12 +339,13 @@ impl ToolVisibilityOwner for LocalToolVisibilityOwner {
 
     fn request_deferred_tools(
         &self,
-        authorities: std::collections::BTreeMap<String, ToolVisibilityWitness>,
+        authorities: Vec<DeferredToolLoadAuthority>,
     ) -> Result<ToolScopeRevision, ToolScopeStageError> {
         let mut state = self
             .state
             .write()
             .map_err(|_| ToolScopeStageError::LockPoisoned)?;
+        let authorities = deferred_load_authority_map(&authorities)?;
         let names = authorities.keys().cloned().collect::<BTreeSet<_>>();
         let extended = state
             .staged_requested_deferred_names
@@ -1038,7 +1041,7 @@ impl ToolScope {
     /// Add durable requested deferred authorities for the next boundary.
     pub fn add_requested_deferred_authorities(
         &self,
-        authorities: &std::collections::BTreeMap<String, ToolVisibilityWitness>,
+        authorities: &[DeferredToolLoadAuthority],
     ) -> Result<ToolScopeRevision, ToolScopeStageError> {
         let state = self
             .state
@@ -1050,14 +1053,15 @@ impl ToolScope {
                 .map_err(|err| ToolScopeStageError::Owner {
                     message: err.to_string(),
                 })?;
-        let names = authorities.keys().cloned().collect::<BTreeSet<_>>();
+        let authorities_by_name = deferred_load_authority_map(authorities)?;
+        let names = authorities_by_name.keys().cloned().collect::<BTreeSet<_>>();
         let staged_requested_deferred_names = visibility_state.staged_requested_deferred_names;
         let mut combined_witnesses = visibility_state.requested_witnesses;
         let extended = staged_requested_deferred_names
             .union(&names)
             .cloned()
             .collect::<BTreeSet<_>>();
-        combined_witnesses.extend(authorities.clone());
+        combined_witnesses.extend(authorities_by_name);
         let catalog = deferred_authority_catalog_for_base_tools(
             &state.base_tools,
             &state.deferred_tool_names,
@@ -1067,6 +1071,7 @@ impl ToolScope {
         let requested_canonical_authorities = canonical_authorities
             .into_iter()
             .filter(|(name, _)| names.contains(name.as_str()))
+            .map(|(name, witness)| DeferredToolLoadAuthority::new(name, witness))
             .collect();
         drop(state);
 
@@ -1232,6 +1237,28 @@ fn deferred_authority_names_for_visibility_state(
         .union(&visibility_state.staged_requested_deferred_names)
         .cloned()
         .collect()
+}
+
+fn deferred_load_authority_map(
+    authorities: &[DeferredToolLoadAuthority],
+) -> Result<std::collections::BTreeMap<String, ToolVisibilityWitness>, ToolScopeStageError> {
+    let mut by_name = std::collections::BTreeMap::new();
+    let mut invalid = Vec::new();
+
+    for authority in authorities {
+        match by_name.insert(authority.name.clone(), authority.witness.clone()) {
+            Some(existing) if existing != authority.witness => invalid.push(authority.name.clone()),
+            _ => {}
+        }
+    }
+
+    if invalid.is_empty() {
+        return Ok(by_name);
+    }
+
+    invalid.sort_unstable();
+    invalid.dedup();
+    Err(ToolScopeStageError::InvalidWitnesses { names: invalid })
 }
 
 pub(crate) fn validate_deferred_authorities_for_names(
@@ -1503,17 +1530,13 @@ mod tests {
         );
 
         scope
-            .add_requested_deferred_authorities(
-                &[(
-                    "deferred".to_string(),
-                    crate::ToolVisibilityWitness {
-                        stable_owner_key: Some("callback:owner-a".to_string()),
-                        last_seen_provenance: deferred.provenance.clone(),
-                    },
-                )]
-                .into_iter()
-                .collect(),
-            )
+            .add_requested_deferred_authorities(&[crate::DeferredToolLoadAuthority::new(
+                "deferred",
+                crate::ToolVisibilityWitness {
+                    stable_owner_key: Some("callback:owner-a".to_string()),
+                    last_seen_provenance: deferred.provenance.clone(),
+                },
+            )])
             .unwrap();
 
         assert_eq!(
@@ -1748,17 +1771,13 @@ mod tests {
         );
 
         scope
-            .add_requested_deferred_authorities(
-                &[(
-                    "deferred".to_string(),
-                    crate::ToolVisibilityWitness {
-                        stable_owner_key: Some("callback:owner-a".to_string()),
-                        last_seen_provenance: requested.provenance.clone(),
-                    },
-                )]
-                .into_iter()
-                .collect(),
-            )
+            .add_requested_deferred_authorities(&[crate::DeferredToolLoadAuthority::new(
+                "deferred",
+                crate::ToolVisibilityWitness {
+                    stable_owner_key: Some("callback:owner-a".to_string()),
+                    last_seen_provenance: requested.provenance.clone(),
+                },
+            )])
             .unwrap();
         let promoted = scope.promote_staged_visibility().unwrap();
         scope
@@ -1880,17 +1899,13 @@ mod tests {
         );
 
         let err = scope
-            .add_requested_deferred_authorities(
-                &[(
-                    "deferred".to_string(),
-                    crate::ToolVisibilityWitness {
-                        stable_owner_key: Some("callback:owner-a".to_string()),
-                        last_seen_provenance: None,
-                    },
-                )]
-                .into_iter()
-                .collect(),
-            )
+            .add_requested_deferred_authorities(&[crate::DeferredToolLoadAuthority::new(
+                "deferred",
+                crate::ToolVisibilityWitness {
+                    stable_owner_key: Some("callback:owner-a".to_string()),
+                    last_seen_provenance: None,
+                },
+            )])
             .expect_err("requesting a deferred tool without provenance authority must fail");
 
         assert!(
@@ -1917,14 +1932,10 @@ mod tests {
         );
 
         let err = scope
-            .add_requested_deferred_authorities(
-                &[(
-                    "deferred".to_string(),
-                    crate::ToolVisibilityWitness::default(),
-                )]
-                .into_iter()
-                .collect(),
-            )
+            .add_requested_deferred_authorities(&[crate::DeferredToolLoadAuthority::new(
+                "deferred",
+                crate::ToolVisibilityWitness::default(),
+            )])
             .expect_err("empty deferred-tool witnesses should fail");
 
         assert!(
@@ -1942,6 +1953,51 @@ mod tests {
     }
 
     #[test]
+    fn requested_deferred_authorities_reject_conflicting_duplicate_authority_values() {
+        let requested = tool_with_provenance("deferred", "owner-a");
+        let scope = ToolScope::new_with_projection_names(
+            vec![Arc::clone(&requested)].into(),
+            HashSet::new(),
+            raw_set(&["deferred"]),
+        );
+
+        let err = scope
+            .add_requested_deferred_authorities(&[
+                crate::DeferredToolLoadAuthority::new(
+                    "deferred",
+                    crate::ToolVisibilityWitness {
+                        stable_owner_key: Some("callback:owner-a".to_string()),
+                        last_seen_provenance: requested.provenance.clone(),
+                    },
+                ),
+                crate::DeferredToolLoadAuthority::new(
+                    "deferred",
+                    crate::ToolVisibilityWitness {
+                        stable_owner_key: Some("callback:forged".to_string()),
+                        last_seen_provenance: Some(ToolProvenance {
+                            kind: ToolSourceKind::Callback,
+                            source_id: "forged".into(),
+                        }),
+                    },
+                ),
+            ])
+            .expect_err("conflicting authority values for one deferred route must fail");
+
+        assert!(
+            err.to_string().contains("deferred"),
+            "duplicate authority rejection should name the conflicted tool: {err}"
+        );
+        assert!(
+            scope
+                .visibility_state()
+                .unwrap()
+                .staged_requested_deferred_names
+                .is_empty(),
+            "failed duplicate-authority validation must not stage deferred names"
+        );
+    }
+
+    #[test]
     fn requested_deferred_names_reuse_existing_witnesses_for_extended_sets() {
         let requested_a = tool_with_provenance("deferred_a", "owner-a");
         let requested_b = tool_with_provenance("deferred_b", "owner-b");
@@ -1952,31 +2008,23 @@ mod tests {
         );
 
         scope
-            .add_requested_deferred_authorities(
-                &[(
-                    "deferred_a".to_string(),
-                    crate::ToolVisibilityWitness {
-                        stable_owner_key: Some("callback:owner-a".to_string()),
-                        last_seen_provenance: requested_a.provenance.clone(),
-                    },
-                )]
-                .into_iter()
-                .collect(),
-            )
+            .add_requested_deferred_authorities(&[crate::DeferredToolLoadAuthority::new(
+                "deferred_a",
+                crate::ToolVisibilityWitness {
+                    stable_owner_key: Some("callback:owner-a".to_string()),
+                    last_seen_provenance: requested_a.provenance.clone(),
+                },
+            )])
             .expect("initial deferred request should stage witness");
 
         scope
-            .add_requested_deferred_authorities(
-                &[(
-                    "deferred_b".to_string(),
-                    crate::ToolVisibilityWitness {
-                        stable_owner_key: Some("callback:owner-b".to_string()),
-                        last_seen_provenance: requested_b.provenance.clone(),
-                    },
-                )]
-                .into_iter()
-                .collect(),
-            )
+            .add_requested_deferred_authorities(&[crate::DeferredToolLoadAuthority::new(
+                "deferred_b",
+                crate::ToolVisibilityWitness {
+                    stable_owner_key: Some("callback:owner-b".to_string()),
+                    last_seen_provenance: requested_b.provenance.clone(),
+                },
+            )])
             .expect("extended deferred request should reuse already staged witnesses");
 
         let state = scope.visibility_state().unwrap();

--- a/meerkat-runtime/src/meerkat_machine/mod.rs
+++ b/meerkat-runtime/src/meerkat_machine/mod.rs
@@ -28,8 +28,8 @@ use meerkat_core::lifecycle::{InputId, RunId};
 use meerkat_core::types::SessionId;
 use meerkat_core::{BlobId, BlobPayload, BlobRef, BlobStore, BlobStoreError};
 use meerkat_core::{
-    SessionToolVisibilityState, ToolFilter, ToolScopeApplyError, ToolScopeRevision,
-    ToolScopeStageError, ToolVisibilityOwner, ToolVisibilityWitness,
+    DeferredToolLoadAuthority, SessionToolVisibilityState, ToolFilter, ToolScopeApplyError,
+    ToolScopeRevision, ToolScopeStageError, ToolVisibilityOwner, ToolVisibilityWitness,
 };
 
 use crate::accept::AcceptOutcome;

--- a/meerkat-runtime/src/meerkat_machine/session_management.rs
+++ b/meerkat-runtime/src/meerkat_machine/session_management.rs
@@ -738,7 +738,7 @@ impl MeerkatMachine {
     pub async fn request_deferred_tools(
         &self,
         session_id: &SessionId,
-        authorities: std::collections::BTreeMap<String, meerkat_core::ToolVisibilityWitness>,
+        authorities: Vec<meerkat_core::DeferredToolLoadAuthority>,
     ) -> Result<meerkat_core::ToolScopeRevision, RuntimeDriverError> {
         match self
             .execute_meerkat_machine_command(

--- a/meerkat-runtime/src/meerkat_machine/visibility.rs
+++ b/meerkat-runtime/src/meerkat_machine/visibility.rs
@@ -201,6 +201,28 @@ fn deferred_authority_names_for_visibility_state(
         .collect()
 }
 
+fn deferred_load_authority_map(
+    authorities: &[DeferredToolLoadAuthority],
+) -> Result<std::collections::BTreeMap<String, ToolVisibilityWitness>, ToolScopeStageError> {
+    let mut by_name = std::collections::BTreeMap::new();
+    let mut invalid = Vec::new();
+
+    for authority in authorities {
+        match by_name.insert(authority.name.clone(), authority.witness.clone()) {
+            Some(existing) if existing != authority.witness => invalid.push(authority.name.clone()),
+            _ => {}
+        }
+    }
+
+    if invalid.is_empty() {
+        return Ok(by_name);
+    }
+
+    invalid.sort_unstable();
+    invalid.dedup();
+    Err(ToolScopeStageError::InvalidWitnesses { names: invalid })
+}
+
 fn invalid_deferred_authority_names(
     names: &std::collections::BTreeSet<String>,
     witnesses: &std::collections::BTreeMap<String, ToolVisibilityWitness>,
@@ -422,11 +444,12 @@ impl ToolVisibilityOwner for MachineToolVisibilityOwner {
 
     fn request_deferred_tools(
         &self,
-        authorities: std::collections::BTreeMap<String, ToolVisibilityWitness>,
+        authorities: Vec<DeferredToolLoadAuthority>,
     ) -> Result<ToolScopeRevision, ToolScopeStageError> {
-        // `request_deferred_tools` extends the staged set and carries the
-        // authority map through the DSL input so deferred admission is
-        // authority-visible, not a shell-only name projection.
+        // `request_deferred_tools` receives typed load authorities, then
+        // canonicalizes them against this owner before projecting the accepted
+        // witness map into the DSL input.
+        let authorities = deferred_load_authority_map(&authorities)?;
         let (extended, mut combined_witnesses): (
             std::collections::BTreeSet<String>,
             std::collections::BTreeMap<String, ToolVisibilityWitness>,

--- a/meerkat-runtime/src/meerkat_machine_tests.rs
+++ b/meerkat-runtime/src/meerkat_machine_tests.rs
@@ -12682,6 +12682,13 @@ fn runtime_deferred_tool(name: &str, owner: &str) -> Arc<meerkat_core::ToolDef> 
     )
 }
 
+fn deferred_load_authority(
+    name: &str,
+    witness: meerkat_core::ToolVisibilityWitness,
+) -> meerkat_core::DeferredToolLoadAuthority {
+    meerkat_core::DeferredToolLoadAuthority::new(name, witness)
+}
+
 fn seed_deferred_tool_authority_catalog(
     bindings: &meerkat_core::SessionRuntimeBindings,
     tools: Vec<Arc<meerkat_core::ToolDef>>,
@@ -12712,15 +12719,13 @@ async fn request_deferred_tools_updates_machine_owned_visibility_state() {
         vec![Arc::clone(&deferred_tool)],
         &["deferred_tool"],
     );
-    let authorities = [(
-        "deferred_tool".to_string(),
+    let authorities = vec![deferred_load_authority(
+        "deferred_tool",
         meerkat_core::ToolVisibilityWitness {
             stable_owner_key: Some("callback:test".to_string()),
             last_seen_provenance: deferred_tool.provenance.clone(),
         },
-    )]
-    .into_iter()
-    .collect();
+    )];
 
     let revision = adapter
         .request_deferred_tools(&session_id, authorities)
@@ -12761,9 +12766,7 @@ async fn request_deferred_tools_records_typed_authority_in_dsl_state() {
     adapter
         .request_deferred_tools(
             &session_id,
-            [("deferred_tool".to_string(), witness.clone())]
-                .into_iter()
-                .collect(),
+            vec![deferred_load_authority("deferred_tool", witness.clone())],
         )
         .await
         .expect("request should succeed");
@@ -12813,9 +12816,7 @@ async fn request_deferred_tools_scopes_dsl_authority_to_requested_names() {
     adapter
         .request_deferred_tools(
             &session_id,
-            [("first_tool".to_string(), first_witness)]
-                .into_iter()
-                .collect(),
+            vec![deferred_load_authority("first_tool", first_witness)],
         )
         .await
         .expect("first request should succeed");
@@ -12831,9 +12832,10 @@ async fn request_deferred_tools_scopes_dsl_authority_to_requested_names() {
     adapter
         .request_deferred_tools(
             &session_id,
-            [("second_tool".to_string(), second_witness.clone())]
-                .into_iter()
-                .collect(),
+            vec![deferred_load_authority(
+                "second_tool",
+                second_witness.clone(),
+            )],
         )
         .await
         .expect("stale witnesses outside staged names must not poison DSL authority");
@@ -12869,15 +12871,13 @@ async fn request_deferred_tools_requires_machine_visible_provenance_authority() 
     let err = adapter
         .request_deferred_tools(
             &session_id,
-            [(
-                "deferred_tool".to_string(),
+            vec![deferred_load_authority(
+                "deferred_tool",
                 meerkat_core::ToolVisibilityWitness {
                     stable_owner_key: Some("callback:test".to_string()),
                     last_seen_provenance: None,
                 },
-            )]
-            .into_iter()
-            .collect(),
+            )],
         )
         .await
         .expect_err("missing deferred-tool provenance authority should fail");
@@ -12898,12 +12898,10 @@ async fn request_deferred_tools_requires_machine_visible_provenance_authority() 
     let err = adapter
         .request_deferred_tools(
             &session_id,
-            [(
-                "deferred_tool".to_string(),
+            vec![deferred_load_authority(
+                "deferred_tool",
                 meerkat_core::ToolVisibilityWitness::default(),
-            )]
-            .into_iter()
-            .collect(),
+            )],
         )
         .await
         .expect_err("empty deferred-tool witnesses should fail");
@@ -12937,15 +12935,13 @@ async fn request_deferred_tools_rejects_public_authority_mismatched_with_visible
     let unknown_err = adapter
         .request_deferred_tools(
             &session_id,
-            [(
-                "unknown_deferred_tool".to_string(),
+            vec![deferred_load_authority(
+                "unknown_deferred_tool",
                 meerkat_core::ToolVisibilityWitness {
                     stable_owner_key: Some("callback:catalog".to_string()),
                     last_seen_provenance: Some(catalog_provenance.clone()),
                 },
-            )]
-            .into_iter()
-            .collect(),
+            )],
         )
         .await
         .expect_err("unknown deferred authority must not stage through public request path");
@@ -12957,8 +12953,8 @@ async fn request_deferred_tools_rejects_public_authority_mismatched_with_visible
     let forged_err = adapter
         .request_deferred_tools(
             &session_id,
-            [(
-                "deferred_tool".to_string(),
+            vec![deferred_load_authority(
+                "deferred_tool",
                 meerkat_core::ToolVisibilityWitness {
                     stable_owner_key: Some("callback:forged".to_string()),
                     last_seen_provenance: Some(meerkat_core::ToolProvenance {
@@ -12966,9 +12962,7 @@ async fn request_deferred_tools_rejects_public_authority_mismatched_with_visible
                         source_id: "forged".into(),
                     }),
                 },
-            )]
-            .into_iter()
-            .collect(),
+            )],
         )
         .await
         .expect_err("mismatched deferred authority must not stage through public request path");
@@ -13109,9 +13103,7 @@ async fn machine_owned_visibility_owner_promotes_deferred_authority_at_boundary(
     adapter
         .request_deferred_tools(
             &session_id,
-            [("deferred_tool".to_string(), witness.clone())]
-                .into_iter()
-                .collect(),
+            vec![deferred_load_authority("deferred_tool", witness.clone())],
         )
         .await
         .expect("request should succeed");
@@ -13565,7 +13557,7 @@ async fn modeled_request_deferred_tools_matches_runtime_after_active_ahead_recon
 
     let revision = fixture
         .adapter
-        .request_deferred_tools(&fixture.session_id, runtime_parity_witnesses())
+        .request_deferred_tools(&fixture.session_id, runtime_parity_load_authorities())
         .await
         .expect("request should succeed after active-ahead reconfigure");
     assert_eq!(
@@ -16244,6 +16236,13 @@ fn runtime_parity_witnesses() -> BTreeMap<String, meerkat_core::ToolVisibilityWi
     .collect()
 }
 
+fn runtime_parity_load_authorities() -> Vec<meerkat_core::DeferredToolLoadAuthority> {
+    runtime_parity_witnesses()
+        .into_iter()
+        .map(|(name, witness)| deferred_load_authority(&name, witness))
+        .collect()
+}
+
 fn runtime_parity_steered_prompt(text: &str) -> Input {
     Input::Prompt(crate::input::PromptInput::new(
         text,
@@ -17189,7 +17188,7 @@ fn runtime_parity_probe_command(
         RuntimeParityProbeInput::RequestDeferredTools => {
             MeerkatMachineCommand::RequestDeferredTools {
                 session_id: fixture.session_id.clone(),
-                authorities: runtime_parity_witnesses(),
+                authorities: runtime_parity_load_authorities(),
             }
         }
         RuntimeParityProbeInput::PublishCommittedVisibleSet => {

--- a/meerkat-runtime/src/meerkat_machine_types.rs
+++ b/meerkat-runtime/src/meerkat_machine_types.rs
@@ -408,7 +408,7 @@ pub(crate) enum MeerkatMachineCommand {
     },
     RequestDeferredTools {
         session_id: SessionId,
-        authorities: std::collections::BTreeMap<String, meerkat_core::ToolVisibilityWitness>,
+        authorities: Vec<meerkat_core::DeferredToolLoadAuthority>,
     },
     /// Publish the committed visible tool set through the machine dispatch.
     ///

--- a/meerkat-session/src/persistent.rs
+++ b/meerkat-session/src/persistent.rs
@@ -3422,6 +3422,16 @@ mod tests {
         system_context_state: Arc<std::sync::Mutex<meerkat_core::SessionSystemContextState>>,
     }
 
+    fn expected_tool_dispatch_witness(tool_name: &str) -> meerkat_core::ToolVisibilityWitness {
+        meerkat_core::ToolVisibilityWitness {
+            stable_owner_key: Some(format!("callback:{tool_name}")),
+            last_seen_provenance: Some(meerkat_core::ToolProvenance {
+                kind: meerkat_core::ToolSourceKind::Callback,
+                source_id: tool_name.to_string().into(),
+            }),
+        }
+    }
+
     #[async_trait::async_trait]
     impl SessionAgent for ToolDispatchAgent {
         async fn run_with_events(
@@ -3476,9 +3486,28 @@ mod tests {
                 Err(poisoned) => poisoned.into_inner(),
             };
             let mut state = session.tool_visibility_state().unwrap_or_default();
+            if let Some(recovered_name) = call.name.strip_prefix("assert_recovered:") {
+                let requested_name = format!("requested:{recovered_name}");
+                let expected_witness = expected_tool_dispatch_witness(recovered_name);
+                if state.requested_witnesses.get(&requested_name) != Some(&expected_witness) {
+                    return Err(meerkat_core::error::AgentError::InternalError(format!(
+                        "missing recovered provenance witness for {requested_name}"
+                    )));
+                }
+                return Ok(ToolDispatchOutcome::sync_result(ToolResult::new(
+                    call.id,
+                    format!("recovered {recovered_name}"),
+                    false,
+                )));
+            }
+
+            let requested_name = format!("requested:{}", call.name);
             state
                 .staged_requested_deferred_names
-                .insert(format!("requested:{}", call.name));
+                .insert(requested_name.clone());
+            state
+                .requested_witnesses
+                .insert(requested_name, expected_tool_dispatch_witness(&call.name));
             session.set_tool_visibility_state(state).map_err(|err| {
                 meerkat_core::error::AgentError::InternalError(format!(
                     "failed to persist tool dispatch state: {err}"
@@ -7149,6 +7178,101 @@ mod tests {
                 .contains("requested:tool_catalog_load"),
             "expected persisted tool-dispatch state to include the requested tool"
         );
+    }
+
+    #[tokio::test]
+    async fn test_dispatch_external_tool_call_recovers_deferred_witness_provenance_after_restart() {
+        let store: Arc<dyn SessionStore> = Arc::new(MemoryStore::new());
+        let service = PersistentSessionService::new(
+            ToolDispatchBuilder,
+            4,
+            Arc::clone(&store),
+            None,
+            memory_blob_store(),
+        );
+
+        let created = service
+            .create_session(create_request("hello", InitialTurnPolicy::Defer))
+            .await
+            .expect("create session");
+        let id = created.session_id;
+
+        service
+            .dispatch_external_tool_call(
+                &id,
+                ToolCall::new(
+                    "call-1".to_string(),
+                    "tool_catalog_load".to_string(),
+                    serde_json::json!({}),
+                ),
+            )
+            .await
+            .expect("dispatch external tool call");
+
+        let persisted = store
+            .load(&id)
+            .await
+            .expect("load persisted session")
+            .expect("persisted session should exist");
+        let persisted_state = persisted
+            .tool_visibility_state()
+            .expect("persistent dispatch should save session mutations");
+        let requested_name = "requested:tool_catalog_load";
+        assert!(
+            persisted_state
+                .staged_requested_deferred_names
+                .contains(requested_name),
+            "store projection should retain the requested deferred name"
+        );
+        assert_eq!(
+            persisted_state.requested_witnesses.get(requested_name),
+            Some(&expected_tool_dispatch_witness("tool_catalog_load")),
+            "store projection must persist the provenance witness alongside the name"
+        );
+
+        let restarted = PersistentSessionService::new(
+            ToolDispatchBuilder,
+            4,
+            Arc::clone(&store),
+            None,
+            memory_blob_store(),
+        );
+        let resume_source = restarted
+            .load_authoritative_session(&id)
+            .await
+            .expect("authoritative load should succeed")
+            .expect("authoritative session should exist after restart");
+        let resumed = restarted
+            .create_session(resume_request(resume_source))
+            .await
+            .expect("resume should materialize persisted visibility state");
+        assert_eq!(resumed.session_id, id);
+
+        let resumed_live = restarted
+            .export_live_session(&id)
+            .await
+            .expect("resumed live session should export");
+        let resumed_state = resumed_live
+            .tool_visibility_state()
+            .expect("resumed session should carry visibility state");
+        assert_eq!(
+            resumed_state.requested_witnesses.get(requested_name),
+            Some(&expected_tool_dispatch_witness("tool_catalog_load")),
+            "resumed live session must reactivate the persisted provenance witness"
+        );
+
+        let outcome = restarted
+            .dispatch_external_tool_call(
+                &id,
+                ToolCall::new(
+                    "call-2".to_string(),
+                    "assert_recovered:tool_catalog_load".to_string(),
+                    serde_json::json!({}),
+                ),
+            )
+            .await
+            .expect("reactivated live session should prove recovered provenance authority");
+        assert_eq!(outcome.result.text_content(), "recovered tool_catalog_load");
     }
 
     #[tokio::test]

--- a/meerkat-session/src/persistent.rs
+++ b/meerkat-session/src/persistent.rs
@@ -3486,21 +3486,6 @@ mod tests {
                 Err(poisoned) => poisoned.into_inner(),
             };
             let mut state = session.tool_visibility_state().unwrap_or_default();
-            if let Some(recovered_name) = call.name.strip_prefix("assert_recovered:") {
-                let requested_name = format!("requested:{recovered_name}");
-                let expected_witness = expected_tool_dispatch_witness(recovered_name);
-                if state.requested_witnesses.get(&requested_name) != Some(&expected_witness) {
-                    return Err(meerkat_core::error::AgentError::InternalError(format!(
-                        "missing recovered provenance witness for {requested_name}"
-                    )));
-                }
-                return Ok(ToolDispatchOutcome::sync_result(ToolResult::new(
-                    call.id,
-                    format!("recovered {recovered_name}"),
-                    false,
-                )));
-            }
-
             let requested_name = format!("requested:{}", call.name);
             state
                 .staged_requested_deferred_names
@@ -7155,14 +7140,14 @@ mod tests {
                 &id,
                 ToolCall::new(
                     "call-1".to_string(),
-                    "tool_catalog_load".to_string(),
+                    "callback_probe_tool".to_string(),
                     serde_json::json!({}),
                 ),
             )
             .await
             .expect("dispatch external tool call");
 
-        assert_eq!(outcome.result.text_content(), "handled tool_catalog_load");
+        assert_eq!(outcome.result.text_content(), "handled callback_probe_tool");
 
         let persisted = store
             .load(&id)
@@ -7175,104 +7160,9 @@ mod tests {
         assert!(
             visibility_state
                 .staged_requested_deferred_names
-                .contains("requested:tool_catalog_load"),
+                .contains("requested:callback_probe_tool"),
             "expected persisted tool-dispatch state to include the requested tool"
         );
-    }
-
-    #[tokio::test]
-    async fn test_dispatch_external_tool_call_recovers_deferred_witness_provenance_after_restart() {
-        let store: Arc<dyn SessionStore> = Arc::new(MemoryStore::new());
-        let service = PersistentSessionService::new(
-            ToolDispatchBuilder,
-            4,
-            Arc::clone(&store),
-            None,
-            memory_blob_store(),
-        );
-
-        let created = service
-            .create_session(create_request("hello", InitialTurnPolicy::Defer))
-            .await
-            .expect("create session");
-        let id = created.session_id;
-
-        service
-            .dispatch_external_tool_call(
-                &id,
-                ToolCall::new(
-                    "call-1".to_string(),
-                    "tool_catalog_load".to_string(),
-                    serde_json::json!({}),
-                ),
-            )
-            .await
-            .expect("dispatch external tool call");
-
-        let persisted = store
-            .load(&id)
-            .await
-            .expect("load persisted session")
-            .expect("persisted session should exist");
-        let persisted_state = persisted
-            .tool_visibility_state()
-            .expect("persistent dispatch should save session mutations");
-        let requested_name = "requested:tool_catalog_load";
-        assert!(
-            persisted_state
-                .staged_requested_deferred_names
-                .contains(requested_name),
-            "store projection should retain the requested deferred name"
-        );
-        assert_eq!(
-            persisted_state.requested_witnesses.get(requested_name),
-            Some(&expected_tool_dispatch_witness("tool_catalog_load")),
-            "store projection must persist the provenance witness alongside the name"
-        );
-
-        let restarted = PersistentSessionService::new(
-            ToolDispatchBuilder,
-            4,
-            Arc::clone(&store),
-            None,
-            memory_blob_store(),
-        );
-        let resume_source = restarted
-            .load_authoritative_session(&id)
-            .await
-            .expect("authoritative load should succeed")
-            .expect("authoritative session should exist after restart");
-        let resumed = restarted
-            .create_session(resume_request(resume_source))
-            .await
-            .expect("resume should materialize persisted visibility state");
-        assert_eq!(resumed.session_id, id);
-
-        let resumed_live = restarted
-            .export_live_session(&id)
-            .await
-            .expect("resumed live session should export");
-        let resumed_state = resumed_live
-            .tool_visibility_state()
-            .expect("resumed session should carry visibility state");
-        assert_eq!(
-            resumed_state.requested_witnesses.get(requested_name),
-            Some(&expected_tool_dispatch_witness("tool_catalog_load")),
-            "resumed live session must reactivate the persisted provenance witness"
-        );
-
-        let outcome = restarted
-            .dispatch_external_tool_call(
-                &id,
-                ToolCall::new(
-                    "call-2".to_string(),
-                    "assert_recovered:tool_catalog_load".to_string(),
-                    serde_json::json!({}),
-                ),
-            )
-            .await
-            .expect("reactivated live session should prove recovered provenance authority");
-        assert_eq!(outcome.result.text_content(), "recovered tool_catalog_load");
     }
 
     #[tokio::test]
@@ -7298,7 +7188,7 @@ mod tests {
                 &id,
                 ToolCall::new(
                     "call-2".to_string(),
-                    "tool_catalog_load".to_string(),
+                    "callback_probe_tool".to_string(),
                     serde_json::json!({}),
                 ),
             )

--- a/meerkat-tools/src/control_plane.rs
+++ b/meerkat-tools/src/control_plane.rs
@@ -530,10 +530,18 @@ fn load_tool_def() -> ToolDef {
 mod tests {
     use super::*;
     use meerkat_core::ToolFilter;
+    use meerkat_core::agent::test_turn_state_handle::TestTurnStateHandle;
+    use meerkat_core::error::AgentError;
     use meerkat_core::types::ToolProvenance;
+    use meerkat_core::types::{AssistantBlock, StopReason, Usage};
+    use meerkat_core::{
+        AgentBuilder, AgentLlmClient, AgentSessionStore, DynamicToolComposite, LlmStreamResult,
+        Session,
+    };
     use serde_json::json;
     use serde_json::value::RawValue;
     use std::collections::{BTreeMap, BTreeSet};
+    use std::sync::Mutex;
 
     struct ExactCatalogDispatcher {
         tools: Arc<[Arc<ToolDef>]>,
@@ -568,6 +576,95 @@ mod tests {
             Err(ToolError::NotFound {
                 name: call.name.into(),
             })
+        }
+    }
+
+    struct NoopAgentStore;
+
+    #[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
+    #[cfg_attr(not(target_arch = "wasm32"), async_trait)]
+    impl AgentSessionStore for NoopAgentStore {
+        async fn save(&self, _session: &Session) -> Result<(), AgentError> {
+            Ok(())
+        }
+
+        async fn load(&self, _id: &str) -> Result<Option<Session>, AgentError> {
+            Ok(None)
+        }
+    }
+
+    struct CatalogLoadRouteClient {
+        calls: Mutex<u32>,
+        seen_tools: Mutex<Vec<Vec<String>>>,
+    }
+
+    impl CatalogLoadRouteClient {
+        fn new() -> Self {
+            Self {
+                calls: Mutex::new(0),
+                seen_tools: Mutex::new(Vec::new()),
+            }
+        }
+
+        fn seen_tools(&self) -> Vec<Vec<String>> {
+            self.seen_tools.lock().unwrap().clone()
+        }
+    }
+
+    #[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
+    #[cfg_attr(not(target_arch = "wasm32"), async_trait)]
+    impl AgentLlmClient for CatalogLoadRouteClient {
+        async fn stream_response(
+            &self,
+            _messages: &[meerkat_core::Message],
+            tools: &[Arc<ToolDef>],
+            _max_tokens: u32,
+            _temperature: Option<f32>,
+            _provider_params: Option<
+                &meerkat_core::lifecycle::run_primitive::ProviderParamsOverride,
+            >,
+        ) -> Result<LlmStreamResult, AgentError> {
+            self.seen_tools.lock().unwrap().push(
+                tools
+                    .iter()
+                    .map(|tool| tool.name.to_string())
+                    .collect::<Vec<_>>(),
+            );
+            let mut calls = self.calls.lock().unwrap();
+            let response = if *calls == 0 {
+                LlmStreamResult::new(
+                    vec![AssistantBlock::ToolUse {
+                        id: "load-deferred".to_string(),
+                        name: LOAD_TOOL_NAME.into(),
+                        args: RawValue::from_string(
+                            json!({ "names": ["deferred_mcp_tool"] }).to_string(),
+                        )
+                        .unwrap(),
+                        meta: None,
+                    }],
+                    StopReason::ToolUse,
+                    Usage::default(),
+                )
+            } else {
+                LlmStreamResult::new(
+                    vec![AssistantBlock::Text {
+                        text: "done".to_string(),
+                        meta: None,
+                    }],
+                    StopReason::EndTurn,
+                    Usage::default(),
+                )
+            };
+            *calls += 1;
+            Ok(response)
+        }
+
+        fn provider(&self) -> &'static str {
+            "mock"
+        }
+
+        fn model(&self) -> &str {
+            "mock-model"
         }
     }
 
@@ -989,6 +1086,88 @@ mod tests {
         assert_eq!(
             effect["authorities"][0]["witness"]["stable_owner_key"],
             "callback:test"
+        );
+    }
+
+    #[tokio::test]
+    async fn agent_boundary_routes_tool_catalog_load_authority_from_control_plane() {
+        let deferred = session_tool("deferred_mcp_tool", "Deferred MCP tool");
+        let deferred_two = session_tool("deferred_mcp_tool_two", "Second deferred MCP tool");
+        let session_dispatcher: Arc<dyn AgentToolDispatcher> = Arc::new(ExactCatalogDispatcher {
+            tools: vec![Arc::clone(&deferred), Arc::clone(&deferred_two)].into(),
+            catalog: vec![
+                ToolCatalogEntry::session_deferred(
+                    Arc::clone(&deferred),
+                    true,
+                    "callback:test".to_string(),
+                ),
+                ToolCatalogEntry::session_deferred(
+                    Arc::clone(&deferred_two),
+                    true,
+                    "callback:test".to_string(),
+                ),
+            ]
+            .into(),
+            pending_sources: Arc::from([]),
+            may_require_control_plane: false,
+        });
+        let visibility_provider = Arc::new(CatalogControlVisibilityProvider::new());
+        let control_dispatcher: Arc<dyn AgentToolDispatcher> =
+            Arc::new(CatalogControlDispatcher::new(
+                Arc::clone(&session_dispatcher),
+                Arc::clone(&visibility_provider),
+            ));
+        let tools = Arc::new(DynamicToolComposite::new(vec![
+            session_dispatcher,
+            control_dispatcher,
+        ]));
+        let client = Arc::new(CatalogLoadRouteClient::new());
+        let mut agent = AgentBuilder::new()
+            .with_turn_state_handle(Arc::new(TestTurnStateHandle::new()))
+            .build(client.clone(), tools, Arc::new(NoopAgentStore))
+            .await;
+        visibility_provider.set_scope(agent.tool_scope().clone());
+
+        let result = agent.run("prompt".to_string().into()).await.unwrap();
+        assert_eq!(result.text, "done");
+
+        let seen_tools = client.seen_tools();
+        assert!(
+            seen_tools.len() >= 2,
+            "expected load route to continue into a post-boundary LLM request, saw {seen_tools:?}"
+        );
+        assert!(
+            seen_tools[0].iter().any(|name| name == LOAD_TOOL_NAME),
+            "control load tool must be visible before deferred tools are loaded: {seen_tools:?}"
+        );
+        assert!(
+            !seen_tools[0].iter().any(|name| name == "deferred_mcp_tool"),
+            "deferred tool must stay hidden until the real catalog-load route is accepted"
+        );
+        assert!(
+            seen_tools[1].iter().any(|name| name == "deferred_mcp_tool"),
+            "real catalog-load route should reveal the requested deferred tool on the next boundary"
+        );
+
+        let visibility_state = agent
+            .session()
+            .tool_visibility_state()
+            .expect("agent boundary should persist canonical visibility state");
+        assert!(
+            visibility_state
+                .active_requested_deferred_names
+                .contains("deferred_mcp_tool"),
+            "catalog-load route should commit the requested deferred name at the boundary"
+        );
+        let witness = visibility_state
+            .requested_witnesses
+            .get("deferred_mcp_tool")
+            .expect("catalog-load route should persist the provenance witness");
+        assert_eq!(witness.stable_owner_key.as_deref(), Some("callback:test"));
+        assert_eq!(
+            witness.last_seen_provenance.as_ref(),
+            deferred.provenance.as_ref(),
+            "authority must come from the catalog entry provenance, not only the requested name"
         );
     }
 

--- a/meerkat-tools/src/control_plane.rs
+++ b/meerkat-tools/src/control_plane.rs
@@ -1,7 +1,9 @@
 use async_trait::async_trait;
 use meerkat_core::error::ToolError;
 use meerkat_core::ops::{SessionEffect, ToolDispatchOutcome};
-use meerkat_core::session::{SessionToolVisibilityState, ToolVisibilityWitness};
+use meerkat_core::session::{
+    DeferredToolLoadAuthority, SessionToolVisibilityState, ToolVisibilityWitness,
+};
 use meerkat_core::tool_catalog::stable_owner_key_from_provenance;
 use meerkat_core::types::{ToolCallView, ToolDef, ToolProvenance, ToolResult, ToolSourceKind};
 use meerkat_core::{
@@ -345,6 +347,10 @@ impl CatalogControlDispatcher {
         }
 
         let accepted_names_vec = accepted_authorities.keys().cloned().collect::<Vec<_>>();
+        let accepted_authorities = accepted_authorities
+            .into_iter()
+            .map(|(name, witness)| DeferredToolLoadAuthority::new(name, witness))
+            .collect::<Vec<_>>();
         let effect =
             (!accepted_authorities.is_empty()).then_some(SessionEffect::RequestDeferredTools {
                 authorities: accepted_authorities,
@@ -605,7 +611,7 @@ mod tests {
 
         fn request_deferred_tools(
             &self,
-            _authorities: BTreeMap<String, ToolVisibilityWitness>,
+            _authorities: Vec<DeferredToolLoadAuthority>,
         ) -> Result<meerkat_core::ToolScopeRevision, meerkat_core::ToolScopeStageError> {
             Err(meerkat_core::ToolScopeStageError::Owner {
                 message: "legacy visibility fixture is read-only".to_string(),
@@ -931,11 +937,58 @@ mod tests {
             panic!("expected RequestDeferredTools session effect");
         };
         assert_eq!(
-            authorities.get("deferred_mcp_tool"),
-            Some(&ToolVisibilityWitness {
-                stable_owner_key: Some("callback:test".to_string()),
-                last_seen_provenance: deferred.provenance.clone(),
-            })
+            authorities.as_slice(),
+            &[DeferredToolLoadAuthority::new(
+                "deferred_mcp_tool",
+                ToolVisibilityWitness {
+                    stable_owner_key: Some("callback:test".to_string()),
+                    last_seen_provenance: deferred.provenance.clone(),
+                }
+            )]
+        );
+    }
+
+    #[tokio::test]
+    async fn load_effect_carries_deferred_authority_values_not_name_keyed_witnesses() {
+        let deferred = session_tool("deferred_mcp_tool", "Deferred MCP tool");
+        let dispatcher = Arc::new(ExactCatalogDispatcher {
+            tools: vec![Arc::clone(&deferred)].into(),
+            catalog: vec![ToolCatalogEntry::session_deferred(
+                Arc::clone(&deferred),
+                true,
+                "callback:test".to_string(),
+            )]
+            .into(),
+            pending_sources: Arc::from([]),
+            may_require_control_plane: false,
+        });
+        let visibility_provider = Arc::new(CatalogControlVisibilityProvider::new());
+        visibility_provider.set_scope(ToolScope::new_with_projection_names(
+            vec![Arc::clone(&deferred)].into(),
+            std::collections::HashSet::new(),
+            ["deferred_mcp_tool".to_string()].into_iter().collect(),
+        ));
+
+        let control = CatalogControlDispatcher::new(dispatcher, visibility_provider);
+        let outcome = control
+            .dispatch(search_call(
+                LOAD_TOOL_NAME,
+                json!({ "names": ["deferred_mcp_tool"] }),
+            ))
+            .await
+            .unwrap();
+
+        assert_eq!(outcome.session_effects.len(), 1);
+        let effect = serde_json::to_value(&outcome.session_effects[0]).unwrap();
+        assert_eq!(effect["effect_type"], "request_deferred_tools");
+        assert!(
+            effect["authorities"].is_array(),
+            "deferred load authority should serialize as typed authority values, not a name-keyed witness map: {effect}"
+        );
+        assert_eq!(effect["authorities"][0]["name"], "deferred_mcp_tool");
+        assert_eq!(
+            effect["authorities"][0]["witness"]["stable_owner_key"],
+            "callback:test"
         );
     }
 
@@ -998,11 +1051,14 @@ mod tests {
             panic!("expected RequestDeferredTools session effect");
         };
         assert_eq!(
-            authorities.get("deferred_mcp_tool"),
-            Some(&ToolVisibilityWitness {
-                stable_owner_key: Some("callback:test".to_string()),
-                last_seen_provenance: deferred.provenance.clone(),
-            })
+            authorities.as_slice(),
+            &[DeferredToolLoadAuthority::new(
+                "deferred_mcp_tool",
+                ToolVisibilityWitness {
+                    stable_owner_key: Some("callback:test".to_string()),
+                    last_seen_provenance: deferred.provenance.clone(),
+                }
+            )]
         );
     }
 

--- a/meerkat/tests/persistence_contract.rs
+++ b/meerkat/tests/persistence_contract.rs
@@ -2,17 +2,24 @@
 
 #[cfg(all(feature = "session-store", feature = "memory-store"))]
 mod tests {
+    use std::pin::Pin;
     use std::sync::Arc;
+    use std::sync::Mutex;
 
     use meerkat::{
-        AgentFactory, Config, CreateSessionRequest, PersistenceBundle, SessionQuery,
-        SessionService, build_persistent_service, build_persistent_service_with_runtime_adapter,
+        AgentFactory, Config, CreateSessionRequest, FactoryAgentBuilder, PersistenceBundle,
+        PersistentSessionService, SessionQuery, SessionService, ToolCall, build_persistent_service,
+        build_persistent_service_with_runtime_adapter,
     };
+    use meerkat_client::{LlmClient, LlmDoneOutcome, LlmError, LlmEvent, LlmRequest};
     use meerkat_core::service::InitialTurnPolicy;
     use meerkat_core::{
-        BindingId, ConnectionRef, DeferredPromptPolicy, RealmId, service::SessionBuildOptions,
+        AgentToolDispatcher, BindingId, ConnectionRef, DeferredPromptPolicy, RealmId, ToolCallView,
+        ToolCatalogCapabilities, ToolCatalogEntry, ToolDef, ToolProvenance, ToolResult,
+        ToolSourceKind, service::SessionBuildOptions,
     };
     use meerkat_store::MemoryBlobStore;
+    use serde_json::json;
 
     fn test_connection_ref() -> ConnectionRef {
         ConnectionRef {
@@ -39,6 +46,207 @@ mod tests {
             }),
             labels: None,
         }
+    }
+
+    #[derive(Default)]
+    struct CatalogLoadClient {
+        calls: Mutex<usize>,
+        seen_tools: Mutex<Vec<Vec<String>>>,
+    }
+
+    impl CatalogLoadClient {
+        fn seen_tools(&self) -> Vec<Vec<String>> {
+            self.seen_tools.lock().expect("seen tools lock").clone()
+        }
+    }
+
+    #[async_trait::async_trait]
+    impl LlmClient for CatalogLoadClient {
+        fn stream<'a>(
+            &'a self,
+            request: &'a LlmRequest,
+        ) -> Pin<Box<dyn futures::Stream<Item = Result<LlmEvent, LlmError>> + Send + 'a>> {
+            self.seen_tools.lock().expect("seen tools lock").push(
+                request
+                    .tools
+                    .iter()
+                    .map(|tool| tool.name.to_string())
+                    .collect(),
+            );
+
+            let call_index = {
+                let mut calls = self.calls.lock().expect("calls lock");
+                let call_index = *calls;
+                *calls += 1;
+                call_index
+            };
+
+            let events = if call_index == 0 {
+                vec![
+                    Ok(LlmEvent::ToolCallComplete {
+                        id: "load-deferred".to_string(),
+                        name: "tool_catalog_load".to_string(),
+                        args: json!({ "names": ["deferred_mcp_tool"] }),
+                        meta: None,
+                    }),
+                    Ok(LlmEvent::Done {
+                        outcome: LlmDoneOutcome::Success {
+                            stop_reason: meerkat_core::StopReason::ToolUse,
+                        },
+                    }),
+                ]
+            } else {
+                vec![
+                    Ok(LlmEvent::TextDelta {
+                        delta: "done".to_string(),
+                        meta: None,
+                    }),
+                    Ok(LlmEvent::Done {
+                        outcome: LlmDoneOutcome::Success {
+                            stop_reason: meerkat_core::StopReason::EndTurn,
+                        },
+                    }),
+                ]
+            };
+            Box::pin(futures::stream::iter(events))
+        }
+
+        fn provider(&self) -> &'static str {
+            "mock"
+        }
+
+        async fn health_check(&self) -> Result<(), LlmError> {
+            Ok(())
+        }
+    }
+
+    struct DeferredCatalogDispatcher {
+        tools: Arc<[Arc<ToolDef>]>,
+        catalog: Arc<[ToolCatalogEntry]>,
+        dispatched_names: Mutex<Vec<String>>,
+    }
+
+    impl DeferredCatalogDispatcher {
+        fn new() -> Self {
+            let deferred = deferred_tool("deferred_mcp_tool");
+            let deferred_two = deferred_tool("deferred_mcp_tool_two");
+            Self {
+                tools: vec![Arc::clone(&deferred), Arc::clone(&deferred_two)].into(),
+                catalog: vec![
+                    ToolCatalogEntry::session_deferred(
+                        deferred,
+                        true,
+                        "callback:deferred-catalog".to_string(),
+                    ),
+                    ToolCatalogEntry::session_deferred(
+                        deferred_two,
+                        true,
+                        "callback:deferred-catalog".to_string(),
+                    ),
+                ]
+                .into(),
+                dispatched_names: Mutex::new(Vec::new()),
+            }
+        }
+
+        fn dispatched_names(&self) -> Vec<String> {
+            self.dispatched_names
+                .lock()
+                .expect("dispatched names lock")
+                .clone()
+        }
+    }
+
+    #[async_trait::async_trait]
+    impl AgentToolDispatcher for DeferredCatalogDispatcher {
+        fn tools(&self) -> Arc<[Arc<ToolDef>]> {
+            Arc::clone(&self.tools)
+        }
+
+        fn tool_catalog_capabilities(&self) -> ToolCatalogCapabilities {
+            ToolCatalogCapabilities {
+                exact_catalog: true,
+                may_require_catalog_control_plane: false,
+            }
+        }
+
+        fn tool_catalog(&self) -> Arc<[ToolCatalogEntry]> {
+            Arc::clone(&self.catalog)
+        }
+
+        async fn dispatch(
+            &self,
+            call: ToolCallView<'_>,
+        ) -> Result<meerkat_core::ops::ToolDispatchOutcome, meerkat_core::ToolError> {
+            self.dispatched_names
+                .lock()
+                .expect("dispatched names lock")
+                .push(call.name.to_string());
+            Ok(ToolResult::new(call.id.to_string(), format!("ran {}", call.name), false).into())
+        }
+    }
+
+    fn deferred_tool(name: &str) -> Arc<ToolDef> {
+        Arc::new(ToolDef {
+            name: name.into(),
+            description: format!("Deferred test tool {name}"),
+            input_schema: json!({ "type": "object" }),
+            provenance: Some(deferred_catalog_provenance()),
+        })
+    }
+
+    fn deferred_catalog_provenance() -> ToolProvenance {
+        ToolProvenance {
+            kind: ToolSourceKind::Callback,
+            source_id: "deferred-catalog".into(),
+        }
+    }
+
+    fn catalog_route_request(
+        prompt: &str,
+        initial_turn: InitialTurnPolicy,
+    ) -> CreateSessionRequest {
+        CreateSessionRequest {
+            model: "mock-model".to_string(),
+            prompt: prompt.to_string().into(),
+            render_metadata: None,
+            system_prompt: None,
+            max_tokens: None,
+            event_tx: None,
+            skill_references: None,
+            initial_turn,
+            deferred_prompt_policy: DeferredPromptPolicy::Discard,
+            build: None,
+            labels: None,
+        }
+    }
+
+    fn catalog_route_resume_request(session: meerkat::Session) -> CreateSessionRequest {
+        let mut request = catalog_route_request("", InitialTurnPolicy::Defer);
+        request.build = Some(SessionBuildOptions {
+            resume_session: Some(session),
+            ..Default::default()
+        });
+        request
+    }
+
+    fn catalog_route_service(
+        store_path: impl Into<std::path::PathBuf>,
+        store: Arc<dyn meerkat::SessionStore>,
+        dispatcher: Arc<DeferredCatalogDispatcher>,
+        client: Arc<CatalogLoadClient>,
+    ) -> PersistentSessionService<FactoryAgentBuilder> {
+        let factory = AgentFactory::new(store_path)
+            .builtins(false)
+            .shell(false)
+            .memory(false)
+            .schedule(false);
+        let mut builder = FactoryAgentBuilder::new(factory, Config::default());
+        let llm_client: Arc<dyn LlmClient> = client;
+        let tool_dispatcher: Arc<dyn AgentToolDispatcher> = dispatcher;
+        builder.default_llm_client = Some(llm_client);
+        builder.default_tool_dispatcher = Some(tool_dispatcher);
+        PersistentSessionService::new(builder, 4, store, None, Arc::new(MemoryBlobStore::new()))
     }
 
     #[tokio::test]
@@ -129,5 +337,128 @@ mod tests {
             .expect("authoritative load should succeed through the second service")
             .expect("services built from the same PersistenceBundle should share persisted state");
         assert_eq!(loaded.id(), &created.session_id);
+    }
+
+    #[tokio::test]
+    async fn deferred_catalog_load_authority_survives_persistent_restart() {
+        let temp = tempfile::tempdir().expect("tempdir should succeed");
+        let session_store: Arc<dyn meerkat::SessionStore> = Arc::new(meerkat::MemoryStore::new());
+        let dispatcher = Arc::new(DeferredCatalogDispatcher::new());
+        let client = Arc::new(CatalogLoadClient::default());
+        let service = catalog_route_service(
+            temp.path().join("sessions"),
+            Arc::clone(&session_store),
+            Arc::clone(&dispatcher),
+            Arc::clone(&client),
+        );
+
+        let created = service
+            .create_session(catalog_route_request(
+                "load the deferred catalog tool",
+                InitialTurnPolicy::RunImmediately,
+            ))
+            .await
+            .expect("real catalog-load route should complete");
+        let id = created.session_id;
+
+        let seen_tools = client.seen_tools();
+        assert!(
+            seen_tools.len() >= 2,
+            "catalog-load route should continue into a post-boundary LLM request: {seen_tools:?}"
+        );
+        assert!(
+            seen_tools[0].iter().any(|name| name == "tool_catalog_load"),
+            "control load tool must be visible before deferred tools are loaded: {seen_tools:?}"
+        );
+        assert!(
+            !seen_tools[0].iter().any(|name| name == "deferred_mcp_tool"),
+            "deferred tool must stay hidden before the catalog-load authority is accepted"
+        );
+        assert!(
+            seen_tools[1].iter().any(|name| name == "deferred_mcp_tool"),
+            "real catalog-load authority should reveal the requested deferred tool at the next boundary"
+        );
+
+        let persisted = session_store
+            .load(&id)
+            .await
+            .expect("load persisted session")
+            .expect("persisted session should exist");
+        let persisted_state = persisted
+            .tool_visibility_state()
+            .expect("catalog-load run should persist visibility state");
+        assert!(
+            persisted_state
+                .active_requested_deferred_names
+                .contains("deferred_mcp_tool"),
+            "store projection should retain the real catalog-load requested name"
+        );
+        let persisted_witness = persisted_state
+            .requested_witnesses
+            .get("deferred_mcp_tool")
+            .expect("store projection must persist the catalog-derived witness");
+        assert_eq!(
+            persisted_witness.stable_owner_key.as_deref(),
+            Some("callback:deferred-catalog")
+        );
+        assert_eq!(
+            persisted_witness.last_seen_provenance.as_ref(),
+            Some(&deferred_catalog_provenance()),
+            "authority must come from the catalog entry provenance"
+        );
+
+        let restarted_client = Arc::new(CatalogLoadClient::default());
+        let restarted = catalog_route_service(
+            temp.path().join("sessions-restarted"),
+            Arc::clone(&session_store),
+            Arc::clone(&dispatcher),
+            restarted_client,
+        );
+        let resume_source = restarted
+            .load_authoritative_session(&id)
+            .await
+            .expect("authoritative load should succeed")
+            .expect("authoritative session should exist after restart");
+        let resumed = restarted
+            .create_session(catalog_route_resume_request(resume_source))
+            .await
+            .expect("resume should materialize persisted visibility state");
+        assert_eq!(resumed.session_id, id);
+
+        let resumed_live = restarted
+            .export_live_session(&id)
+            .await
+            .expect("resumed live session should export");
+        let resumed_state = resumed_live
+            .tool_visibility_state()
+            .expect("resumed session should carry visibility state");
+        assert_eq!(
+            resumed_state
+                .requested_witnesses
+                .get("deferred_mcp_tool")
+                .and_then(|witness| witness.last_seen_provenance.as_ref()),
+            Some(&deferred_catalog_provenance()),
+            "resumed live session must reactivate the persisted provenance witness"
+        );
+
+        let outcome = restarted
+            .dispatch_external_tool_call(
+                &id,
+                ToolCall::new(
+                    "call-deferred".to_string(),
+                    "deferred_mcp_tool".to_string(),
+                    json!({}),
+                ),
+            )
+            .await
+            .expect("restarted session should dispatch the recovered deferred tool");
+        assert_eq!(outcome.result.text_content(), "ran deferred_mcp_tool");
+        assert!(
+            dispatcher
+                .dispatched_names()
+                .iter()
+                .any(|name| name == "deferred_mcp_tool"),
+            "recovered visibility authority should route the actual deferred tool"
+        );
     }
 }


### PR DESCRIPTION
## Summary
- add a typed DeferredToolLoadAuthority value for deferred-tool load requests
- carry typed authorities through SessionEffect, ToolVisibilityOwner, and runtime commands
- canonicalize load authorities at owner boundaries before projecting into machine DSL state
- add regression coverage for the old name-keyed effect shape and conflicting duplicate authorities

## Validation
- ./scripts/repo-cargo test -p meerkat-tools load_effect_carries_deferred_authority_values_not_name_keyed_witnesses -- --nocapture
- ./scripts/repo-cargo test -p meerkat-core requested_deferred -- --nocapture
- ./scripts/repo-cargo test -p meerkat-runtime request_deferred_tools -- --nocapture
- ./scripts/repo-cargo test -p meerkat-tools control_plane::tests:: -- --nocapture
- ./scripts/repo-cargo test -p meerkat-core requested_deferred_authorities_reject_conflicting_duplicate_authority_values -- --nocapture
- ./scripts/repo-cargo test -p meerkat-core deferred_tools_stay_hidden_until_requested_boundary_applies -- --nocapture
- ./scripts/repo-cargo test -p meerkat-core requested_witness_mismatch_prevents_rebinding_a_dormant_deferred_name -- --nocapture
- ./scripts/repo-cargo test -p meerkat-integration-tests --test session_tool_visibility_kernel -- --nocapture
- make fmt
- git diff --check
- MEERKAT_BUILDBUDDY=1 make check

Linear: LUC-288