### PR TITLE
LUC-291: Replace machine drift ratchets with typed governance

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6111,6 +6111,7 @@ dependencies = [
  "clap",
  "meerkat-machine-codegen",
  "meerkat-machine-schema",
+ "meerkat-mob",
  "proc-macro2",
  "quote",
  "serde",

--- a/MODULE.bazel.lock
+++ b/MODULE.bazel.lock
@@ -501,7 +501,7 @@
           "REPO_MAPPING:rules_rust+,bazel_tools bazel_tools",
           "REPO_MAPPING:rules_rust+,rules_cc rules_cc+",
           "REPO_MAPPING:rules_rust+,rules_rust rules_rust+",
-          "FILE:@@//Cargo.lock d22f1e801649345cd7554f7fd9661f8a2637d9ca46402b0374165ddd7c0f90aa",
+          "FILE:@@//Cargo.lock 6d04cafccd66c79921303f2507cbd12c3fdad7a1cc114791f46d1e7409381101",
           "FILE:@@//Cargo.toml e5d6d35d507c9bc2a5e2b83e17b12b659f92a78addd0a7ae2a24b1cdcc1d6c5e",
           "FILE:@@//meerkat-machine-derive/Cargo.toml f91da732cdc018477e0db4a1e89ea66cbbf1659bc4eae29782f9b6ba2ac487a6",
           "FILE:@@//meerkat-models/Cargo.toml d2c34db2fbe0ef549bec09bb87d7d048cd4af937ae50fe77a74ddecd92308379",
@@ -542,7 +542,7 @@
           "FILE:@@//meerkat-machine-codegen/Cargo.toml 8ad230c353e921fba809d6b32dad21c91481877674e6e6028d1f1a3d6d01b669",
           "FILE:@@//test-fixtures/surface-build-fixtures/Cargo.toml 0ca9e0746e4c7f80b43591ec7a83c6fa0261f7730d719168a5eb624e31b826bc",
           "FILE:@@//test-fixtures/machine-dsl-tests/Cargo.toml bc9c8bd79e3d4529e12b6495c1ddf79d02020782b06e265539f7dca351438ccd",
-          "FILE:@@//xtask/Cargo.toml e3212c96185cd3e09f10115934760c0f29cfd6a1b61fa28ceb55c10092b2bc65",
+          "FILE:@@//xtask/Cargo.toml 9517b11f56e7334133377e776987a7be1a761ee1e43c3d956c70e2bc391cecf6",
           "FILE:@@//vendor/oai-rt-rs/Cargo.toml 5325298146e1f43afb519170283663b96ddafe2b43c65d64be3ab6b92516bc42"
         ],
         "generatedRepoSpecs": {

--- a/meerkat-machine-codegen/tests/runtime_alphabet_parity.rs
+++ b/meerkat-machine-codegen/tests/runtime_alphabet_parity.rs
@@ -293,7 +293,8 @@ fn assert_mob_command_records_are_identity_checked(
         );
 
         match record.classification {
-            MobMachineCommandClassification::CatalogInput(input) => {
+            MobMachineCommandClassification::CatalogInput(input)
+            | MobMachineCommandClassification::GatedCatalogInput(input) => {
                 if let Some(command_input) = command_input {
                     assert_eq!(
                         input.input_variant(),
@@ -306,7 +307,8 @@ fn assert_mob_command_records_are_identity_checked(
                     "MobMachine command `{command_name}` classifies to an input absent from the generated input alphabet"
                 );
             }
-            MobMachineCommandClassification::CatalogInputs(inputs) => {
+            MobMachineCommandClassification::CatalogInputs(inputs)
+            | MobMachineCommandClassification::GatedCatalogInputs(inputs) => {
                 assert!(
                     !inputs.is_empty(),
                     "MobMachine command `{command_name}` must not use an empty typed catalog classification"

--- a/meerkat-machine-schema/tests/schema_contracts.rs
+++ b/meerkat-machine-schema/tests/schema_contracts.rs
@@ -167,15 +167,15 @@ fn peer_ingress_lifecycle_subject_signal_carries_candidate_not_selected_subject(
         .collect::<Vec<_>>();
 
     assert!(
-        fields.iter().any(|name| *name == "from_peer"),
+        fields.contains(&"from_peer"),
         "fallback peer identity should remain a typed input fact"
     );
     assert!(
-        fields.iter().any(|name| *name == "lifecycle_peer_param"),
+        fields.contains(&"lifecycle_peer_param"),
         "machine should receive the parsed lifecycle peer parameter candidate"
     );
     assert!(
-        !fields.iter().any(|name| *name == "lifecycle_peer"),
+        !fields.contains(&"lifecycle_peer"),
         "preselected lifecycle subjects must not cross the machine signal seam"
     );
 }

--- a/meerkat-mob/src/lib.rs
+++ b/meerkat-mob/src/lib.rs
@@ -89,9 +89,10 @@ pub use launch::{BudgetSplitPolicy, ForkContext, MemberLaunchMode};
 #[doc(hidden)]
 pub use mob_machine::{
     MobMachineCatalogInput, MobMachineCommandClassification, MobMachineCommandClassificationRecord,
-    MobMachineCommandVariant, MobMachineRuntimeInternalClassificationRecord,
-    MobMachineRuntimeInternalReason, MobMachineShellMechanicReason,
-    canonical_mob_machine_command_classifications, canonical_mob_machine_command_manifest,
+    MobMachineCommandGateRequirement, MobMachineCommandVariant,
+    MobMachineRuntimeInternalClassificationRecord, MobMachineRuntimeInternalReason,
+    MobMachineShellMechanicReason, canonical_mob_machine_command_classifications,
+    canonical_mob_machine_command_gate_requirements, canonical_mob_machine_command_manifest,
     canonical_mob_machine_runtime_internal_classifications,
     canonical_mob_machine_runtime_internal_manifest,
 };

--- a/meerkat-mob/src/mob_machine.rs
+++ b/meerkat-mob/src/mob_machine.rs
@@ -243,6 +243,8 @@ pub fn canonical_mob_machine_runtime_internal_manifest() -> IndexSet<&'static st
 pub enum MobMachineCommandClassification {
     CatalogInput(MobMachineCatalogInput),
     CatalogInputs(&'static [MobMachineCatalogInput]),
+    GatedCatalogInput(MobMachineCatalogInput),
+    GatedCatalogInputs(&'static [MobMachineCatalogInput]),
     ShellMechanic(MobMachineShellMechanicReason),
 }
 
@@ -250,8 +252,8 @@ impl MobMachineCommandClassification {
     #[must_use]
     pub fn catalog_inputs(self) -> Vec<MobMachineCatalogInput> {
         match self {
-            Self::CatalogInput(input) => vec![input],
-            Self::CatalogInputs(inputs) => inputs.to_vec(),
+            Self::CatalogInput(input) | Self::GatedCatalogInput(input) => vec![input],
+            Self::CatalogInputs(inputs) | Self::GatedCatalogInputs(inputs) => inputs.to_vec(),
             Self::ShellMechanic(_) => Vec::new(),
         }
     }
@@ -262,6 +264,15 @@ impl MobMachineCommandClassification {
             .into_iter()
             .map(MobMachineCatalogInput::input_variant)
             .collect()
+    }
+
+    #[must_use]
+    pub fn gate_inputs(self) -> Vec<MobMachineCatalogInput> {
+        match self {
+            Self::GatedCatalogInput(input) => vec![input],
+            Self::GatedCatalogInputs(inputs) => inputs.to_vec(),
+            Self::CatalogInput(_) | Self::CatalogInputs(_) | Self::ShellMechanic(_) => Vec::new(),
+        }
     }
 }
 
@@ -585,6 +596,12 @@ pub struct MobMachineCommandClassificationRecord {
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct MobMachineCommandGateRequirement {
+    pub command: MobMachineCommandVariant,
+    pub input: MobMachineCatalogInput,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct MobMachineRuntimeInternalClassificationRecord {
     pub input: MobMachineCatalogInput,
     pub reason: MobMachineRuntimeInternalReason,
@@ -686,6 +703,24 @@ pub fn canonical_mob_machine_command_classifications() -> Vec<MobMachineCommandC
 
 #[doc(hidden)]
 #[must_use]
+pub fn canonical_mob_machine_command_gate_requirements() -> Vec<MobMachineCommandGateRequirement> {
+    canonical_mob_machine_command_classifications()
+        .into_iter()
+        .flat_map(|record| {
+            record
+                .classification
+                .gate_inputs()
+                .into_iter()
+                .map(move |input| MobMachineCommandGateRequirement {
+                    command: record.command,
+                    input,
+                })
+        })
+        .collect()
+}
+
+#[doc(hidden)]
+#[must_use]
 pub const fn canonical_mob_machine_runtime_internal_classifications()
 -> &'static [MobMachineRuntimeInternalClassificationRecord] {
     MOB_MACHINE_RUNTIME_INTERNAL_CLASSIFICATIONS
@@ -718,10 +753,10 @@ const fn mob_machine_command_classification(
             MobMachineCatalogInput::UnwireExternalPeer,
         ]),
         MobMachineCommandVariant::RunFlow => {
-            MobMachineCommandClassification::CatalogInput(MobMachineCatalogInput::RunFlow)
+            MobMachineCommandClassification::GatedCatalogInput(MobMachineCatalogInput::RunFlow)
         }
         MobMachineCommandVariant::CancelFlow => {
-            MobMachineCommandClassification::CatalogInput(MobMachineCatalogInput::CancelFlow)
+            MobMachineCommandClassification::GatedCatalogInput(MobMachineCatalogInput::CancelFlow)
         }
         MobMachineCommandVariant::FlowStatus => {
             MobMachineCommandClassification::CatalogInput(MobMachineCatalogInput::FlowStatus)
@@ -769,7 +804,7 @@ const fn mob_machine_command_classification(
             MobMachineCommandClassification::CatalogInput(MobMachineCatalogInput::Destroy)
         }
         MobMachineCommandVariant::TaskCreate => {
-            MobMachineCommandClassification::CatalogInput(MobMachineCatalogInput::TaskCreate)
+            MobMachineCommandClassification::GatedCatalogInput(MobMachineCatalogInput::TaskCreate)
         }
         MobMachineCommandVariant::TaskUpdate => {
             MobMachineCommandClassification::CatalogInput(MobMachineCatalogInput::TaskUpdate)
@@ -830,13 +865,42 @@ const fn mob_machine_command_classification(
             MobMachineCommandClassification::CatalogInput(MobMachineCatalogInput::GetMember)
         }
         MobMachineCommandVariant::SetSpawnPolicy => {
-            MobMachineCommandClassification::CatalogInput(MobMachineCatalogInput::SetSpawnPolicy)
+            MobMachineCommandClassification::GatedCatalogInput(
+                MobMachineCatalogInput::SetSpawnPolicy,
+            )
         }
         MobMachineCommandVariant::Shutdown => {
             MobMachineCommandClassification::CatalogInput(MobMachineCatalogInput::Shutdown)
         }
         MobMachineCommandVariant::ForceCancel => {
-            MobMachineCommandClassification::CatalogInput(MobMachineCatalogInput::ForceCancel)
+            MobMachineCommandClassification::GatedCatalogInput(MobMachineCatalogInput::ForceCancel)
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn command_gate_requirements_are_owned_by_canonical_classification() {
+        let requirements = canonical_mob_machine_command_gate_requirements();
+        for record in canonical_mob_machine_command_classifications() {
+            let classified_inputs = record.classification.gate_inputs();
+            let required_inputs = requirements
+                .iter()
+                .filter(|requirement| requirement.command == record.command)
+                .map(|requirement| requirement.input)
+                .collect::<Vec<_>>();
+            assert_eq!(
+                required_inputs, classified_inputs,
+                "gate requirements for {:?} must come from its canonical classification",
+                record.command
+            );
+        }
+        assert!(requirements.iter().any(|requirement| {
+            requirement.command == MobMachineCommandVariant::SetSpawnPolicy
+                && requirement.input == MobMachineCatalogInput::SetSpawnPolicy
+        }));
     }
 }

--- a/meerkat-mob/src/runtime/flow_frame_engine.rs
+++ b/meerkat-mob/src/runtime/flow_frame_engine.rs
@@ -20,7 +20,7 @@ use crate::run::{
 use crate::run::{flow_frame, flow_run, loop_iteration};
 use crate::runtime::MobHandle;
 use crate::runtime::conditions::evaluate_condition;
-use crate::store::MobRunStore;
+use crate::store::{FrameAtomicOperation, MobRunStore};
 #[cfg(target_arch = "wasm32")]
 use crate::tokio::time as tokio_time;
 use async_trait::async_trait;
@@ -198,7 +198,201 @@ pub enum FlowFrameLoopStorePlan {
     },
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+pub enum FlowFrameLoopStorePlanVariant {
+    InsertFrame,
+    FrameState,
+    CompleteStepAndRecordOutput,
+    GrantNodeSlot,
+    StartLoop,
+    GrantBodyFrameStart,
+    RunStateOnly,
+    SealFrame,
+    CompleteBodyFrame,
+    LoopRequestBodyFrame,
+    CompleteLoop,
+}
+
+impl FlowFrameLoopStorePlanVariant {
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::InsertFrame => "InsertFrame",
+            Self::FrameState => "FrameState",
+            Self::CompleteStepAndRecordOutput => "CompleteStepAndRecordOutput",
+            Self::GrantNodeSlot => "GrantNodeSlot",
+            Self::StartLoop => "StartLoop",
+            Self::GrantBodyFrameStart => "GrantBodyFrameStart",
+            Self::RunStateOnly => "RunStateOnly",
+            Self::SealFrame => "SealFrame",
+            Self::CompleteBodyFrame => "CompleteBodyFrame",
+            Self::LoopRequestBodyFrame => "LoopRequestBodyFrame",
+            Self::CompleteLoop => "CompleteLoop",
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum FlowFrameLoopStorePlanCommitOperation {
+    FlowState,
+    FrameAtomic(FrameAtomicOperation),
+}
+
+impl FlowFrameLoopStorePlanCommitOperation {
+    pub fn store_method_base(self) -> &'static str {
+        match self {
+            Self::FlowState => "cas_flow_state",
+            Self::FrameAtomic(operation) => match operation {
+                FrameAtomicOperation::CasFrameState => "cas_frame_state",
+                FrameAtomicOperation::CasGrantNodeSlot => "cas_grant_node_slot",
+                FrameAtomicOperation::CasCompleteStepAndRecordOutput => {
+                    "cas_complete_step_and_record_output"
+                }
+                FrameAtomicOperation::CasStartLoop => "cas_start_loop",
+                FrameAtomicOperation::CasLoopRequestBodyFrame => "cas_loop_request_body_frame",
+                FrameAtomicOperation::CasGrantBodyFrameStart => "cas_grant_body_frame_start",
+                FrameAtomicOperation::CasCompleteBodyFrame => "cas_complete_body_frame",
+                FrameAtomicOperation::CasCompleteLoop => "cas_complete_loop",
+            },
+        }
+    }
+
+    pub fn store_methods(self) -> [&'static str; 1] {
+        match self {
+            Self::FlowState => ["cas_flow_state_with_authority"],
+            Self::FrameAtomic(FrameAtomicOperation::CasFrameState) => {
+                ["cas_frame_state_with_authority"]
+            }
+            Self::FrameAtomic(FrameAtomicOperation::CasGrantNodeSlot) => {
+                ["cas_grant_node_slot_with_authority"]
+            }
+            Self::FrameAtomic(FrameAtomicOperation::CasCompleteStepAndRecordOutput) => {
+                ["cas_complete_step_and_record_output_with_authority"]
+            }
+            Self::FrameAtomic(FrameAtomicOperation::CasStartLoop) => {
+                ["cas_start_loop_with_authority"]
+            }
+            Self::FrameAtomic(FrameAtomicOperation::CasLoopRequestBodyFrame) => {
+                ["cas_loop_request_body_frame_with_authority"]
+            }
+            Self::FrameAtomic(FrameAtomicOperation::CasGrantBodyFrameStart) => {
+                ["cas_grant_body_frame_start_with_authority"]
+            }
+            Self::FrameAtomic(FrameAtomicOperation::CasCompleteBodyFrame) => {
+                ["cas_complete_body_frame_with_authority"]
+            }
+            Self::FrameAtomic(FrameAtomicOperation::CasCompleteLoop) => {
+                ["cas_complete_loop_with_authority"]
+            }
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct FlowFrameLoopStorePlanCommitRequirement {
+    pub variant: FlowFrameLoopStorePlanVariant,
+    pub operation: FlowFrameLoopStorePlanCommitOperation,
+}
+
+pub const fn canonical_flow_frame_loop_store_plan_commit_requirements()
+-> &'static [FlowFrameLoopStorePlanCommitRequirement] {
+    &[
+        FlowFrameLoopStorePlanCommitRequirement {
+            variant: FlowFrameLoopStorePlanVariant::InsertFrame,
+            operation: FlowFrameLoopStorePlanCommitOperation::FrameAtomic(
+                FrameAtomicOperation::CasFrameState,
+            ),
+        },
+        FlowFrameLoopStorePlanCommitRequirement {
+            variant: FlowFrameLoopStorePlanVariant::FrameState,
+            operation: FlowFrameLoopStorePlanCommitOperation::FrameAtomic(
+                FrameAtomicOperation::CasFrameState,
+            ),
+        },
+        FlowFrameLoopStorePlanCommitRequirement {
+            variant: FlowFrameLoopStorePlanVariant::CompleteStepAndRecordOutput,
+            operation: FlowFrameLoopStorePlanCommitOperation::FrameAtomic(
+                FrameAtomicOperation::CasCompleteStepAndRecordOutput,
+            ),
+        },
+        FlowFrameLoopStorePlanCommitRequirement {
+            variant: FlowFrameLoopStorePlanVariant::GrantNodeSlot,
+            operation: FlowFrameLoopStorePlanCommitOperation::FrameAtomic(
+                FrameAtomicOperation::CasGrantNodeSlot,
+            ),
+        },
+        FlowFrameLoopStorePlanCommitRequirement {
+            variant: FlowFrameLoopStorePlanVariant::StartLoop,
+            operation: FlowFrameLoopStorePlanCommitOperation::FrameAtomic(
+                FrameAtomicOperation::CasStartLoop,
+            ),
+        },
+        FlowFrameLoopStorePlanCommitRequirement {
+            variant: FlowFrameLoopStorePlanVariant::GrantBodyFrameStart,
+            operation: FlowFrameLoopStorePlanCommitOperation::FrameAtomic(
+                FrameAtomicOperation::CasGrantBodyFrameStart,
+            ),
+        },
+        FlowFrameLoopStorePlanCommitRequirement {
+            variant: FlowFrameLoopStorePlanVariant::RunStateOnly,
+            operation: FlowFrameLoopStorePlanCommitOperation::FlowState,
+        },
+        FlowFrameLoopStorePlanCommitRequirement {
+            variant: FlowFrameLoopStorePlanVariant::SealFrame,
+            operation: FlowFrameLoopStorePlanCommitOperation::FrameAtomic(
+                FrameAtomicOperation::CasFrameState,
+            ),
+        },
+        FlowFrameLoopStorePlanCommitRequirement {
+            variant: FlowFrameLoopStorePlanVariant::CompleteBodyFrame,
+            operation: FlowFrameLoopStorePlanCommitOperation::FrameAtomic(
+                FrameAtomicOperation::CasCompleteBodyFrame,
+            ),
+        },
+        FlowFrameLoopStorePlanCommitRequirement {
+            variant: FlowFrameLoopStorePlanVariant::LoopRequestBodyFrame,
+            operation: FlowFrameLoopStorePlanCommitOperation::FrameAtomic(
+                FrameAtomicOperation::CasLoopRequestBodyFrame,
+            ),
+        },
+        FlowFrameLoopStorePlanCommitRequirement {
+            variant: FlowFrameLoopStorePlanVariant::CompleteLoop,
+            operation: FlowFrameLoopStorePlanCommitOperation::FrameAtomic(
+                FrameAtomicOperation::CasCompleteLoop,
+            ),
+        },
+    ]
+}
+
 impl FlowFrameLoopStorePlan {
+    pub fn canonical_variant(&self) -> FlowFrameLoopStorePlanVariant {
+        match self {
+            Self::InsertFrame { .. } => FlowFrameLoopStorePlanVariant::InsertFrame,
+            Self::FrameState { .. } => FlowFrameLoopStorePlanVariant::FrameState,
+            Self::CompleteStepAndRecordOutput { .. } => {
+                FlowFrameLoopStorePlanVariant::CompleteStepAndRecordOutput
+            }
+            Self::GrantNodeSlot { .. } => FlowFrameLoopStorePlanVariant::GrantNodeSlot,
+            Self::StartLoop { .. } => FlowFrameLoopStorePlanVariant::StartLoop,
+            Self::GrantBodyFrameStart { .. } => FlowFrameLoopStorePlanVariant::GrantBodyFrameStart,
+            Self::RunStateOnly { .. } => FlowFrameLoopStorePlanVariant::RunStateOnly,
+            Self::SealFrame { .. } => FlowFrameLoopStorePlanVariant::SealFrame,
+            Self::CompleteBodyFrame { .. } => FlowFrameLoopStorePlanVariant::CompleteBodyFrame,
+            Self::LoopRequestBodyFrame { .. } => {
+                FlowFrameLoopStorePlanVariant::LoopRequestBodyFrame
+            }
+            Self::CompleteLoop { .. } => FlowFrameLoopStorePlanVariant::CompleteLoop,
+        }
+    }
+
+    pub fn canonical_commit_operation(&self) -> FlowFrameLoopStorePlanCommitOperation {
+        canonical_flow_frame_loop_store_plan_commit_requirements()
+            .iter()
+            .find_map(|requirement| {
+                (requirement.variant == self.canonical_variant()).then_some(requirement.operation)
+            })
+            .expect("every FlowFrameLoopStorePlan variant has a canonical commit operation")
+    }
+
     pub(super) fn machine_inputs(&self) -> &[mob_dsl::MobMachineInput] {
         match self {
             Self::InsertFrame { machine_inputs, .. }

--- a/meerkat-runtime/src/comms_bridge.rs
+++ b/meerkat-runtime/src/comms_bridge.rs
@@ -602,7 +602,7 @@ mod tests {
                 assert_eq!(peer.body, "[COMMS MESSAGE from event:webhook]\nhello");
                 match peer.header.source {
                     InputOrigin::Peer { peer_id, .. } => {
-                        assert_eq!(peer_id, test_peer_id().as_str())
+                        assert_eq!(peer_id, test_peer_id().as_str());
                     }
                     other => panic!("Expected peer source, got {other:?}"),
                 }
@@ -946,8 +946,7 @@ mod tests {
         };
         assert!(
             text.contains("from Peer One"),
-            "terminal prompt should use display identity: {}",
-            text
+            "terminal prompt should use display identity: {text}"
         );
     }
 

--- a/meerkat-runtime/src/comms_drain.rs
+++ b/meerkat-runtime/src/comms_drain.rs
@@ -2629,7 +2629,7 @@ mod tests {
             &supervisor_name,
             supervisor_pubkey.to_peer_id().as_str(),
             *supervisor_pubkey.as_bytes(),
-            &format!("inproc://{supervisor_name}"),
+            format!("inproc://{supervisor_name}"),
         )
         .expect("valid supervisor spec");
         member_runtime
@@ -2642,7 +2642,7 @@ mod tests {
             &member_name,
             member_pubkey.to_peer_id().as_str(),
             *member_pubkey.as_bytes(),
-            &format!("inproc://{member_name}"),
+            format!("inproc://{member_name}"),
         )
         .expect("valid member spec");
         supervisor_runtime

--- a/meerkat-runtime/src/meerkat_machine/dispatch_control.rs
+++ b/meerkat-runtime/src/meerkat_machine/dispatch_control.rs
@@ -434,7 +434,12 @@ impl MeerkatMachine {
                 };
                 drv.sync_control_projection_from_dsl_authority();
                 let report = prepared_destroy.report;
-                match machine_commit_prepared_destroy(&mut drv, prepared_destroy.lifecycle).await {
+                match Box::pin(machine_commit_prepared_destroy(
+                    &mut drv,
+                    prepared_destroy.lifecycle,
+                ))
+                .await
+                {
                     Ok(()) => {}
                     Err(err) => {
                         drv.sync_control_projection_from_dsl_authority();

--- a/meerkat-runtime/src/meerkat_machine_tests.rs
+++ b/meerkat-runtime/src/meerkat_machine_tests.rs
@@ -2905,26 +2905,28 @@ async fn persistent_destroy_durable_commit_observes_canonical_destroy_truth() {
         "test probe should observe the store after durable destroyed commit",
     );
 
-    let sessions = adapter.sessions.read().await;
-    let entry = sessions
-        .get(&session_id)
-        .expect("destroy keeps the session entry available for terminal snapshots");
-    assert_eq!(
-        entry.control_snapshot().phase,
-        RuntimeState::Destroyed,
-        "durable destroyed state must not become visible while the shared driver projection still trails canonical destroy",
-    );
-    let authority = entry
-        .dsl_authority
-        .lock()
-        .unwrap_or_else(std::sync::PoisonError::into_inner);
-    assert_eq!(
-        crate::meerkat_machine::dsl_authority::runtime_phase_from_authority(&authority),
-        RuntimeState::Destroyed,
-        "durable destroyed state must not race ahead of canonical DSL destroy truth",
-    );
-    drop(authority);
-    drop(sessions);
+    {
+        let sessions = adapter.sessions.read().await;
+        let entry = sessions
+            .get(&session_id)
+            .expect("destroy keeps the session entry available for terminal snapshots");
+        assert_eq!(
+            entry.control_snapshot().phase,
+            RuntimeState::Destroyed,
+            "durable destroyed state must not become visible while the shared driver projection still trails canonical destroy",
+        );
+        {
+            let authority = entry
+                .dsl_authority
+                .lock()
+                .unwrap_or_else(std::sync::PoisonError::into_inner);
+            assert_eq!(
+                crate::meerkat_machine::dsl_authority::runtime_phase_from_authority(&authority),
+                RuntimeState::Destroyed,
+                "durable destroyed state must not race ahead of canonical DSL destroy truth",
+            );
+        }
+    }
 
     store.release_destroy_commit.notify_waiters();
     let report = tokio::time::timeout(Duration::from_secs(2), destroy_task)

--- a/meerkat-runtime/tests/meerkat_machine.rs
+++ b/meerkat-runtime/tests/meerkat_machine.rs
@@ -1512,10 +1512,16 @@ async fn failed_executor_continues_processing_backlog() {
     )
     .await;
     assert_eq!(second_state.seed.phase, InputLifecycleState::Consumed);
-    assert_eq!(
-        adapter.runtime_state(&sid).await.unwrap(),
-        RuntimeState::Attached
-    );
+    tokio::time::timeout(Duration::from_secs(1), async {
+        loop {
+            if adapter.runtime_state(&sid).await.unwrap() == RuntimeState::Attached {
+                break;
+            }
+            tokio::time::sleep(Duration::from_millis(5)).await;
+        }
+    })
+    .await
+    .expect("runtime loop should settle back to Attached after draining the backlog");
     assert!(
         calls.load(Ordering::SeqCst) >= 2,
         "the runtime loop should keep draining queued backlog after a failed run"

--- a/xtask/BUILD.bazel
+++ b/xtask/BUILD.bazel
@@ -51,6 +51,7 @@ rust_library(
     deps = [
         "//meerkat-machine-codegen:meerkat_machine_codegen",
         "//meerkat-machine-schema:meerkat_machine_schema",
+        "//meerkat-mob:meerkat_mob",
         "@crates//:which-7.0.3",
     ] + all_crate_deps(
         package_name = "xtask",
@@ -105,6 +106,7 @@ rust_test(
     deps = [
         "//meerkat-machine-codegen:meerkat_machine_codegen",
         "//meerkat-machine-schema:meerkat_machine_schema",
+        "//meerkat-mob:meerkat_mob",
         "@crates//:which-7.0.3",
     ] + all_crate_deps(
         package_name = "xtask",
@@ -138,6 +140,7 @@ rust_binary(
     deps = [
         "//meerkat-machine-codegen:meerkat_machine_codegen",
         "//meerkat-machine-schema:meerkat_machine_schema",
+        "//meerkat-mob:meerkat_mob",
         "//xtask:xtask",
         "@crates//:which-7.0.3",
     ] + all_crate_deps(
@@ -220,6 +223,7 @@ rust_test(
     deps = [
         "//meerkat-machine-codegen:meerkat_machine_codegen",
         "//meerkat-machine-schema:meerkat_machine_schema",
+        "//meerkat-mob:meerkat_mob",
         "//xtask:xtask",
         "@crates//:which-7.0.3",
     ] + all_crate_deps(
@@ -282,6 +286,7 @@ rust_test(
     deps = [
         "//meerkat-machine-codegen:meerkat_machine_codegen",
         "//meerkat-machine-schema:meerkat_machine_schema",
+        "//meerkat-mob:meerkat_mob",
         "//xtask:xtask",
         "@crates//:which-7.0.3",
     ] + all_crate_deps(
@@ -346,6 +351,7 @@ rust_test(
     deps = [
         "//meerkat-machine-codegen:meerkat_machine_codegen",
         "//meerkat-machine-schema:meerkat_machine_schema",
+        "//meerkat-mob:meerkat_mob",
         "//xtask:xtask",
         "@crates//:which-7.0.3",
     ] + all_crate_deps(
@@ -446,6 +452,7 @@ rust_test(
     deps = [
         "//meerkat-machine-codegen:meerkat_machine_codegen",
         "//meerkat-machine-schema:meerkat_machine_schema",
+        "//meerkat-mob:meerkat_mob",
         "//xtask:xtask",
         "@crates//:which-7.0.3",
     ] + all_crate_deps(
@@ -512,6 +519,7 @@ rust_test(
     deps = [
         "//meerkat-machine-codegen:meerkat_machine_codegen",
         "//meerkat-machine-schema:meerkat_machine_schema",
+        "//meerkat-mob:meerkat_mob",
         "//xtask:xtask",
         "@crates//:which-7.0.3",
     ] + all_crate_deps(
@@ -569,6 +577,7 @@ rust_test(
     deps = [
         "//meerkat-machine-codegen:meerkat_machine_codegen",
         "//meerkat-machine-schema:meerkat_machine_schema",
+        "//meerkat-mob:meerkat_mob",
         "//xtask:xtask",
         "@crates//:which-7.0.3",
     ] + all_crate_deps(
@@ -626,6 +635,7 @@ rust_test(
     deps = [
         "//meerkat-machine-codegen:meerkat_machine_codegen",
         "//meerkat-machine-schema:meerkat_machine_schema",
+        "//meerkat-mob:meerkat_mob",
         "//xtask:xtask",
         "@crates//:which-7.0.3",
     ] + all_crate_deps(

--- a/xtask/Cargo.toml
+++ b/xtask/Cargo.toml
@@ -19,7 +19,7 @@ path = "src/main.rs"
 
 [features]
 default = []
-machine-authority = ["dep:meerkat-machine-codegen", "dep:which"]
+machine-authority = ["dep:meerkat-machine-codegen", "dep:meerkat-mob", "dep:which"]
 
 [dependencies]
 anyhow.workspace = true
@@ -33,6 +33,7 @@ toml.workspace = true
 which = { workspace = true, optional = true }
 meerkat-machine-codegen = { path = "../meerkat-machine-codegen", optional = true }
 meerkat-machine-schema = { path = "../meerkat-machine-schema" }
+meerkat-mob = { workspace = true, optional = true }
 
 [dev-dependencies]
 serde_yaml.workspace = true

--- a/xtask/src/machines.rs
+++ b/xtask/src/machines.rs
@@ -18,13 +18,18 @@ use meerkat_machine_codegen::{
     render_machine_contract_markdown, render_machine_kernel_module,
     render_machine_mapping_coverage, render_machine_semantic_model,
 };
+use meerkat_machine_schema::catalog::dsl::mob_machine::{MobMachineInput, MobMachineInputVariant};
 use meerkat_machine_schema::{
     CompositionCoverageManifest, CompositionSchema, MachineCoverageManifest, MachineSchema,
     SchedulerRule, SemanticCoverageEntry, TriggerKind, canonical_composition_coverage_manifests,
     canonical_composition_schemas, canonical_machine_coverage_manifests, canonical_machine_schemas,
 };
+use meerkat_mob::canonical_mob_machine_command_gate_requirements;
+use meerkat_mob::runtime::flow_frame_engine::canonical_flow_frame_loop_store_plan_commit_requirements;
 use proc_macro2::TokenTree;
 use serde::Serialize;
+use syn::parse::Parser;
+use syn::visit::{self, Visit};
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct Phase1CarryForwardProductionBody {
@@ -801,165 +806,23 @@ pub fn collect_peer_response_terminal_projection_mismatches(root: &Path) -> Resu
 
 pub fn collect_direct_flow_reducer_transition_mismatches(root: &Path) -> Result<Vec<String>> {
     let mut mismatches = Vec::new();
-    let forbidden_modules = ["flow_run", "flow_frame", "loop_iteration"];
-    let forbidden_flow_projection_fields = [
-        "phase",
-        "step_status",
-        "output_recorded",
-        "step_condition_results",
-        "target_counts",
-        "target_success_counts",
-        "target_terminal_failure_counts",
-        "target_retry_counts",
-        "failure_count",
-        "consecutive_failure_count",
-        "ready_frames",
-        "ready_frame_membership",
-        "pending_body_frame_loops",
-        "pending_body_frame_loop_membership",
-        "active_node_count",
-        "active_frame_count",
-        "last_granted_frame",
-        "last_granted_loop",
-        "max_active_nodes",
-        "max_active_frames",
-        "max_frame_depth",
-    ];
-    let forbidden_frame_projection_fields = [
-        "phase",
-        "last_admitted_node",
-        "node_status",
-        "ready_queue",
-        "output_recorded",
-        "node_condition_results",
-    ];
-    let forbidden_projection_cas_writes = [
-        ".cas_flow_state(",
-        ".cas_run_snapshot(",
-        ".cas_frame_state(",
-        ".cas_complete_step_and_record_output(",
-        ".cas_loop_state(",
-        ".cas_grant_node_slot(",
-        ".cas_start_loop(",
-        ".cas_grant_body_frame_start(",
-        ".cas_complete_body_frame(",
-        ".cas_loop_request_body_frame(",
-        ".cas_complete_loop(",
-    ];
+    let facts = FlowProjectionGovernanceFacts::load(root)?;
 
     for path in production_rust_source_paths(root)? {
         let rel = relative_slash_path(root, &path)?;
+        if rel.ends_with("/tests.rs") {
+            continue;
+        }
         let contents = fs::read_to_string(&path).with_context(|| {
             format!("read flow reducer transition candidate {}", path.display())
         })?;
-        let lines = contents.lines().collect::<Vec<_>>();
-        let test_only_lines = flow_reducer_test_only_lines(&rel, &lines);
-        let mut module_aliases = BTreeMap::new();
-        let mut bare_transition_aliases = BTreeMap::new();
-        let mut bare_input_aliases = BTreeMap::new();
-
-        for module in forbidden_modules {
-            module_aliases.insert(module.to_string(), module.to_string());
-        }
-
-        for line in contents.lines() {
-            let compact = line.split_whitespace().collect::<Vec<_>>().join(" ");
-            for module in forbidden_modules {
-                if let Some(alias) = reducer_module_alias(&compact, module) {
-                    module_aliases.insert(alias, module.to_string());
-                }
-                if compact.contains(&format!("{module}::transition"))
-                    || compact.contains(&format!("{module}::Input"))
-                    || compact.contains(&format!("{module}::{{"))
-                {
-                    collect_reducer_bare_aliases(
-                        &compact,
-                        module,
-                        &mut bare_transition_aliases,
-                        &mut bare_input_aliases,
-                    );
-                }
-            }
-        }
-
-        for (line_index, line) in lines.iter().enumerate() {
-            if test_only_lines[line_index] {
-                continue;
-            }
-            for alias in module_aliases.keys() {
-                let module = module_aliases
-                    .get(alias)
-                    .map(String::as_str)
-                    .unwrap_or(alias);
-                for token in [format!("{alias}::transition("), format!("{alias}::Input::")] {
-                    if line.contains(&token)
-                        && !flow_reducer_direct_use_is_structurally_allowed(
-                            &rel, &lines, line_index, module, &token,
-                        )
-                    {
-                        mismatches.push(format!(
-                            "direct live-flow reducer transition `{token}` is not MobMachine-command gated: {rel}:{}",
-                            line_index + 1
-                        ));
-                    }
-                }
-            }
-            for (alias, module) in &bare_transition_aliases {
-                if line.contains(&format!("{alias}("))
-                    && !flow_reducer_direct_use_is_structurally_allowed(
-                        &rel, &lines, line_index, module, alias,
-                    )
-                {
-                    mismatches.push(format!(
-                        "direct live-flow reducer transition alias `{alias}` is not MobMachine-command gated: {rel}:{}",
-                        line_index + 1
-                    ));
-                }
-            }
-            for (alias, module) in &bare_input_aliases {
-                let token = format!("{alias}::");
-                if line.contains(&token)
-                    && !flow_reducer_direct_use_is_structurally_allowed(
-                        &rel, &lines, line_index, module, &token,
-                    )
-                {
-                    mismatches.push(format!(
-                        "direct live-flow reducer input alias `{alias}` is not MobMachine-command gated: {rel}:{}",
-                        line_index + 1
-                    ));
-                }
-            }
-            for field in forbidden_flow_projection_fields {
-                let token = format!(".flow_state.{field}");
-                if projection_field_is_directly_written(line, &token) {
-                    mismatches.push(format!(
-                        "direct live-flow projection mutation `{token}` is not MobMachine-command gated: {rel}:{}",
-                        line_index + 1
-                    ));
-                }
-            }
-            for field in forbidden_frame_projection_fields {
-                let token = format!(".kernel_state.{field}");
-                if projection_field_is_directly_written(line, &token) {
-                    mismatches.push(format!(
-                        "direct live-flow projection mutation `{token}` is not MobMachine-command gated: {rel}:{}",
-                        line_index + 1
-                    ));
-                }
-            }
-            for token in forbidden_projection_cas_writes {
-                if line.contains(token)
-                    && !flow_reducer_projection_commit_is_structurally_allowed(
-                        &rel, &lines, line_index,
-                    )
-                {
-                    mismatches.push(format!(
-                        "direct live-flow projection mutation `{token}` is not MobMachine-command gated: {rel}:{}",
-                        line_index + 1
-                    ));
-                }
-            }
-        }
+        let parsed = syn::parse_file(&contents).with_context(|| {
+            format!("parse flow reducer transition candidate {}", path.display())
+        })?;
+        let aliases = RustUseAliases::from_file(&parsed);
+        let mut visitor = FlowGovernanceVisitor::new(&rel, &aliases, &facts);
+        visitor.visit_file(&parsed);
+        mismatches.extend(visitor.mismatches);
     }
 
     Ok(mismatches)
@@ -973,41 +836,19 @@ pub fn collect_mob_runtime_catalog_command_gate_mismatches(root: &Path) -> Resul
 
     let contents = fs::read_to_string(&actor_path)
         .with_context(|| format!("read Mob runtime actor {}", actor_path.display()))?;
-    let lines = contents.lines().collect::<Vec<_>>();
+    let parsed = syn::parse_file(&contents)
+        .with_context(|| format!("parse Mob runtime actor {}", actor_path.display()))?;
     let rel = relative_slash_path(root, &actor_path)?;
-    let critical_inputs = [
-        MobCatalogCommandGateSpec {
-            input: "RunFlow",
-            scope: MobCatalogCommandGateScope::Function("handle_run_flow"),
-        },
-        MobCatalogCommandGateSpec {
-            input: "CancelFlow",
-            scope: MobCatalogCommandGateScope::Function("handle_cancel_flow"),
-        },
-        MobCatalogCommandGateSpec {
-            input: "TaskCreate",
-            scope: MobCatalogCommandGateScope::Function("handle_task_create"),
-        },
-        MobCatalogCommandGateSpec {
-            input: "SetSpawnPolicy",
-            scope: MobCatalogCommandGateScope::CommandArm("SetSpawnPolicy"),
-        },
-        MobCatalogCommandGateSpec {
-            input: "ForceCancel",
-            scope: MobCatalogCommandGateScope::Function("handle_force_cancel"),
-        },
-    ];
+    let actor = MobRuntimeActorAst::from_file(&parsed);
     let mut mismatches = Vec::new();
 
-    for spec in critical_inputs {
-        let scope = spec.scope.resolve(&lines);
-        let gated = scope.is_some_and(|(start, end)| {
-            mob_catalog_input_has_fail_closed_gate(&lines[start..=end], spec.input)
-        });
-        if !gated {
+    for requirement in canonical_mob_machine_command_gate_requirements() {
+        let command = requirement.command.as_str();
+        let input = requirement.input.input_variant();
+        if !actor.command_fail_closes_on(command, input) {
+            let input = requirement.input.as_str();
             mismatches.push(format!(
-                "MobCommand::{} is catalog-classified but does not fail-close on MobMachineInput::{} in {}",
-                spec.input, spec.input, rel
+                "MobCommand::{command} is catalog-classified but does not fail-close on MobMachineInput::{input} in {rel}",
             ));
         }
     }
@@ -1015,201 +856,208 @@ pub fn collect_mob_runtime_catalog_command_gate_mismatches(root: &Path) -> Resul
     Ok(mismatches)
 }
 
-#[derive(Debug, Clone, Copy)]
-struct MobCatalogCommandGateSpec {
-    input: &'static str,
-    scope: MobCatalogCommandGateScope,
+#[derive(Debug, Clone, Default)]
+struct RustUseAliases {
+    aliases: BTreeMap<String, Vec<Vec<String>>>,
+    shadowed_roots: BTreeSet<String>,
+    ambiguous_glob_import: bool,
 }
 
-#[derive(Debug, Clone, Copy)]
-enum MobCatalogCommandGateScope {
-    Function(&'static str),
-    CommandArm(&'static str),
-}
+impl RustUseAliases {
+    fn from_file(file: &syn::File) -> Self {
+        let mut aliases = Self::default();
+        aliases.collect_from_items(&file.items);
+        aliases
+    }
 
-impl MobCatalogCommandGateScope {
-    fn resolve(self, lines: &[&str]) -> Option<(usize, usize)> {
-        match self {
-            Self::Function(name) => function_scope_bounds(lines, name),
-            Self::CommandArm(variant) => command_arm_scope_bounds(lines, variant),
-        }
-    }
-}
-
-fn reducer_module_alias(line: &str, module: &str) -> Option<String> {
-    let marker = format!("{module} as ");
-    let index = line.find(&marker)?;
-    Some(
-        line[index + marker.len()..]
-            .chars()
-            .take_while(|ch| ch.is_ascii_alphanumeric() || *ch == '_')
-            .collect(),
-    )
-    .filter(|alias: &String| !alias.is_empty())
-}
-
-fn collect_reducer_bare_aliases(
-    line: &str,
-    module: &str,
-    transition_aliases: &mut BTreeMap<String, String>,
-    input_aliases: &mut BTreeMap<String, String>,
-) {
-    if let Some((_, after)) = line.split_once(&format!("{module}::transition")) {
-        if let Some(alias) = after
-            .trim_start()
-            .strip_prefix("as ")
-            .map(|value| {
-                value
-                    .chars()
-                    .take_while(|ch| ch.is_ascii_alphanumeric() || *ch == '_')
-                    .collect::<String>()
-            })
-            .filter(|alias| !alias.is_empty())
-        {
-            transition_aliases.insert(alias, module.to_string());
-        } else {
-            transition_aliases.insert("transition".to_string(), module.to_string());
-        }
-    }
-    if let Some((_, after)) = line.split_once(&format!("{module}::Input")) {
-        if let Some(alias) = after
-            .trim_start()
-            .strip_prefix("as ")
-            .map(|value| {
-                value
-                    .chars()
-                    .take_while(|ch| ch.is_ascii_alphanumeric() || *ch == '_')
-                    .collect::<String>()
-            })
-            .filter(|alias| !alias.is_empty())
-        {
-            input_aliases.insert(alias, module.to_string());
-        } else {
-            input_aliases.insert("Input".to_string(), module.to_string());
-        }
-    }
-    if line.contains(&format!("{module}::*")) {
-        transition_aliases.insert("transition".to_string(), module.to_string());
-        input_aliases.insert("Input".to_string(), module.to_string());
-    }
-    if let Some((_, imports)) = line.split_once(&format!("{module}::{{"))
-        && let Some((imports, _)) = imports.split_once('}')
-    {
-        for item in imports.split(',').map(str::trim) {
-            if let Some(alias) = item.strip_prefix("transition as ") {
-                let alias = alias.trim();
-                if !alias.is_empty() {
-                    transition_aliases.insert(alias.to_string(), module.to_string());
-                }
-            } else if item == "transition" {
-                transition_aliases.insert("transition".to_string(), module.to_string());
-            } else if let Some(alias) = item.strip_prefix("Input as ") {
-                let alias = alias.trim();
-                if !alias.is_empty() {
-                    input_aliases.insert(alias.to_string(), module.to_string());
-                }
-            } else if item == "Input" {
-                input_aliases.insert("Input".to_string(), module.to_string());
+    fn collect_from_items(&mut self, items: &[syn::Item]) {
+        for item in items {
+            match item {
+                syn::Item::Use(item_use) => self.collect_use_tree(Vec::new(), &item_use.tree),
+                _ => self.collect_item_shadow(item),
             }
         }
     }
-}
 
-fn projection_field_is_directly_written(line: &str, token: &str) -> bool {
-    let Some(index) = line.find(token) else {
-        return false;
-    };
-    let tail = &line[index + token.len()..];
-    let tail = tail.trim_start();
-    (tail.starts_with('=') && !tail.starts_with("==") && !tail.starts_with("=>"))
-        || tail.starts_with("+=")
-        || tail.starts_with("-=")
-        || tail.starts_with(".insert(")
-        || tail.starts_with(".remove(")
-        || tail.starts_with(".clear(")
-        || tail.starts_with(".push(")
-        || tail.starts_with(".retain(")
-}
-
-fn mob_catalog_input_has_fail_closed_gate(lines: &[&str], input: &str) -> bool {
-    let token = format!("MobMachineInput::{input}");
-    lines
-        .iter()
-        .enumerate()
-        .filter(|(_, line)| line.contains(&token))
-        .any(|(line_index, _)| mob_catalog_input_occurrence_is_fail_closed(lines, line_index))
-}
-
-fn mob_catalog_input_occurrence_is_fail_closed(lines: &[&str], line_index: usize) -> bool {
-    let start = line_index.saturating_sub(4);
-    let end = (line_index + 18).min(lines.len());
-    let window = lines[start..end].join("\n");
-    let compact = window.split_whitespace().collect::<Vec<_>>().join(" ");
-
-    if compact.contains("let _ = self.apply_dsl_input") || compact.contains("may diverge") {
-        return false;
+    fn with_item_aliases(&self, items: &[syn::Item]) -> Self {
+        let mut aliases = self.clone();
+        aliases.collect_from_items(items);
+        aliases
     }
 
-    compact.contains("probe_mob_machine_input(")
-        || (compact.contains("apply_dsl_input(")
-            && (compact.contains('?')
-                || compact.contains("return Err")
-                || compact.contains("continue;")
-                || compact.contains(".map_err(")))
-        || (compact.contains("prepare_dsl_input(")
-            && (compact.contains('?')
-                || compact.contains("return Err")
-                || compact.contains("continue;")
-                || compact.contains(".map_err(")))
-        || (compact.contains("apply_command_admission(")
-            && (compact.contains('?')
-                || compact.contains("return Err")
-                || compact.contains("continue;")
-                || compact.contains(".map_err(")))
-        || (compact.contains("prepare_command_admission(")
-            && (compact.contains('?')
-                || compact.contains("return Err")
-                || compact.contains("continue;")
-                || compact.contains(".map_err(")))
-}
+    fn with_block_aliases(&self, block: &syn::Block) -> Self {
+        let mut aliases = self.clone();
+        let mut collector = BlockUseAliasCollector {
+            aliases: &mut aliases,
+        };
+        collector.visit_block(block);
+        aliases
+    }
 
-fn function_scope_bounds(lines: &[&str], function_name: &str) -> Option<(usize, usize)> {
-    let needle = format!("fn{function_name}(");
-    let start = lines.iter().position(|line| {
-        let compact = line.split_whitespace().collect::<String>();
-        compact.contains(&needle)
-    })?;
-    brace_scope_bounds(lines, start)
-}
-
-fn command_arm_scope_bounds(lines: &[&str], variant: &str) -> Option<(usize, usize)> {
-    let needle = format!("MobCommand::{variant}");
-    let start = lines.iter().position(|line| line.contains(&needle))?;
-    brace_scope_bounds(lines, start)
-}
-
-fn brace_scope_bounds(lines: &[&str], start: usize) -> Option<(usize, usize)> {
-    let mut depth = 0usize;
-    let mut opened = false;
-    for (index, line) in lines.iter().enumerate().skip(start) {
-        for ch in line.chars() {
-            match ch {
-                '{' => {
-                    depth += 1;
-                    opened = true;
+    fn collect_use_tree(&mut self, mut prefix: Vec<String>, tree: &syn::UseTree) {
+        match tree {
+            syn::UseTree::Path(path) => {
+                prefix.push(path.ident.to_string());
+                self.collect_use_tree(prefix, &path.tree);
+            }
+            syn::UseTree::Name(name) => {
+                let mut full_path = prefix;
+                full_path.push(name.ident.to_string());
+                self.aliases.insert(name.ident.to_string(), vec![full_path]);
+            }
+            syn::UseTree::Rename(rename) => {
+                let mut full_path = prefix;
+                full_path.push(rename.ident.to_string());
+                self.aliases
+                    .insert(rename.rename.to_string(), vec![full_path]);
+            }
+            syn::UseTree::Glob(_) => {
+                if let Some(family) = FlowReducerFamily::from_canonical_module_path(&prefix) {
+                    self.aliases.insert(
+                        "transition".to_string(),
+                        vec![vec![family.module().to_string(), "transition".to_string()]],
+                    );
+                    self.aliases.insert(
+                        "Input".to_string(),
+                        vec![vec![family.module().to_string(), "Input".to_string()]],
+                    );
+                } else if !glob_prefix_is_known_canonical_import_surface(&prefix) {
+                    self.ambiguous_glob_import = true;
                 }
-                '}' if depth > 0 => depth -= 1,
-                _ => {}
+            }
+            syn::UseTree::Group(group) => {
+                for tree in &group.items {
+                    self.collect_use_tree(prefix.clone(), tree);
+                }
             }
         }
-        if opened && depth == 0 {
-            return Some((start, index));
+    }
+
+    fn collect_item_shadow(&mut self, item: &syn::Item) {
+        let ident = match item {
+            syn::Item::Const(item) => Some(&item.ident),
+            syn::Item::Enum(item) => Some(&item.ident),
+            syn::Item::Mod(item)
+                if item.content.is_some()
+                    || FlowReducerFamily::from_module(&item.ident.to_string()).is_none() =>
+            {
+                Some(&item.ident)
+            }
+            syn::Item::Mod(_) => None,
+            syn::Item::Static(item) => Some(&item.ident),
+            syn::Item::Struct(item) => Some(&item.ident),
+            syn::Item::Trait(item) => Some(&item.ident),
+            syn::Item::TraitAlias(item) => Some(&item.ident),
+            syn::Item::Type(item) => Some(&item.ident),
+            syn::Item::Union(item) => Some(&item.ident),
+            _ => None,
+        };
+        if let Some(ident) = ident {
+            self.shadowed_roots.insert(ident.to_string());
         }
     }
-    None
+
+    fn path_has_shadowed_bare_root(&self, path: &syn::Path) -> bool {
+        path.leading_colon.is_none()
+            && path
+                .segments
+                .first()
+                .is_some_and(|segment| self.shadowed_roots.contains(&segment.ident.to_string()))
+    }
+
+    fn path_has_unresolved_bare_root(&self, path: &syn::Path, root: &str) -> bool {
+        path.leading_colon.is_none()
+            && path
+                .segments
+                .first()
+                .is_some_and(|segment| segment.ident == root)
+            && !self.aliases.contains_key(root)
+    }
+
+    fn path_is_unresolved_bare_ident(&self, path: &syn::Path, ident: &str) -> bool {
+        path.leading_colon.is_none()
+            && path.segments.len() == 1
+            && path
+                .segments
+                .first()
+                .is_some_and(|segment| segment.ident == ident)
+            && !self.aliases.contains_key(ident)
+    }
+
+    fn resolve_path(&self, path: &syn::Path) -> Vec<Vec<String>> {
+        self.resolve_segments(path_segments(path), &mut BTreeSet::new())
+    }
+
+    fn resolve_segments(
+        &self,
+        segments: Vec<String>,
+        seen: &mut BTreeSet<String>,
+    ) -> Vec<Vec<String>> {
+        if let Some(first) = segments.first()
+            && let Some(alias_paths) = self.aliases.get(first)
+            && seen.insert(first.clone())
+        {
+            let resolved_paths = alias_paths
+                .iter()
+                .flat_map(|alias_path| {
+                    let mut resolved = alias_path.clone();
+                    resolved.extend(segments.iter().skip(1).cloned());
+                    self.resolve_segments(resolved, seen)
+                })
+                .collect::<Vec<_>>();
+            seen.remove(first);
+            if !resolved_paths.is_empty() {
+                return resolved_paths;
+            }
+        }
+        vec![segments]
+    }
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+fn glob_prefix_is_known_canonical_import_surface(prefix: &[String]) -> bool {
+    prefix.iter().map(String::as_str).eq(["super"])
+        || prefix.iter().map(String::as_str).eq(["crate", "run"])
+        || prefix.iter().map(String::as_str).eq(["crate", "runtime"])
+        || prefix
+            .iter()
+            .map(String::as_str)
+            .eq(["crate", "machines", "mob_machine", "MobCommand"])
+        || prefix.iter().map(String::as_str).eq([
+            "crate",
+            "machines",
+            "mob_machine",
+            "MobMachineInput",
+        ])
+        || prefix
+            .iter()
+            .map(String::as_str)
+            .eq(["super", "state", "MobCommand"])
+}
+
+struct BlockUseAliasCollector<'a> {
+    aliases: &'a mut RustUseAliases,
+}
+
+impl<'ast> Visit<'ast> for BlockUseAliasCollector<'_> {
+    fn visit_block(&mut self, node: &'ast syn::Block) {
+        for stmt in &node.stmts {
+            if let syn::Stmt::Item(item) = stmt {
+                match item {
+                    syn::Item::Use(item_use) => self.visit_item_use(item_use),
+                    _ => self.aliases.collect_item_shadow(item),
+                }
+            }
+        }
+    }
+
+    fn visit_item_use(&mut self, node: &'ast syn::ItemUse) {
+        self.aliases.collect_use_tree(Vec::new(), &node.tree);
+    }
+
+    fn visit_item_mod(&mut self, _node: &'ast syn::ItemMod) {}
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
 enum FlowReducerFamily {
     FlowRun,
     FlowFrame,
@@ -1224,6 +1072,57 @@ impl FlowReducerFamily {
             "loop_iteration" => Some(Self::LoopIteration),
             _ => None,
         }
+    }
+
+    fn from_any_path_segments(segments: &[String]) -> Option<Self> {
+        segments
+            .iter()
+            .rev()
+            .find_map(|segment| Self::from_module(segment))
+    }
+
+    fn from_canonical_module_path(segments: &[String]) -> Option<Self> {
+        if segments.len() == 1 {
+            return segments
+                .first()
+                .and_then(|segment| Self::from_module(segment));
+        }
+        if segments.len() == 3
+            && segments.first().is_some_and(|segment| segment == "crate")
+            && segments.get(1).is_some_and(|segment| segment == "run")
+        {
+            return segments
+                .get(2)
+                .and_then(|segment| Self::from_module(segment));
+        }
+        None
+    }
+
+    fn from_transition_path(segments: &[String]) -> Option<(Self, bool)> {
+        if segments
+            .last()
+            .is_none_or(|segment| segment != "transition")
+        {
+            return None;
+        }
+        let family = Self::from_any_path_segments(segments)?;
+        let canonical =
+            Self::from_canonical_module_path(&segments[..segments.len().saturating_sub(1)])
+                .is_some_and(|canonical_family| canonical_family == family);
+        Some((family, canonical))
+    }
+
+    fn from_input_path(segments: &[String]) -> Option<(Self, bool)> {
+        for input_index in 1..segments.len() {
+            if segments[input_index] == "Input"
+                && let Some(family) = Self::from_module(&segments[input_index - 1])
+            {
+                let canonical = Self::from_canonical_module_path(&segments[..input_index])
+                    .is_some_and(|canonical_family| canonical_family == family);
+                return Some((family, canonical));
+            }
+        }
+        None
     }
 
     fn module(self) -> &'static str {
@@ -1249,223 +1148,7042 @@ impl FlowReducerFamily {
             Self::LoopIteration => "MobMachineLoopIterationCommand",
         }
     }
+}
 
-    fn authority_kind(self) -> &'static str {
-        match self {
-            Self::FlowRun => "MobMachineFlowAuthorityKind::FlowRun",
-            Self::FlowFrame => "MobMachineFlowAuthorityKind::FlowFrame",
-            Self::LoopIteration => "MobMachineFlowAuthorityKind::LoopIteration",
+#[derive(Debug, Clone)]
+struct FlowProjectionGovernanceFacts {
+    flow_state_fields: BTreeSet<String>,
+    frame_state_fields: BTreeSet<String>,
+    cas_methods: BTreeMap<String, ProjectionCasMethodFacts>,
+    store_plan_variant_fields: BTreeMap<String, BTreeSet<String>>,
+    store_plan_variant_commit_methods: BTreeMap<String, BTreeSet<String>>,
+}
+
+#[derive(Debug, Clone, Default)]
+struct ProjectionCasMethodFacts {
+    next_flow_state_arg_indices: BTreeSet<usize>,
+    plan_state_arg_indices: BTreeSet<usize>,
+    authority_input_arg_indices: BTreeSet<usize>,
+    authority_identity_arg_indices: BTreeSet<usize>,
+    plan_owned_arg_indices: BTreeSet<usize>,
+    arg_names: BTreeMap<usize, String>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+struct SourcePosition {
+    line: usize,
+    column: usize,
+}
+
+#[derive(Debug, Clone)]
+struct PreparedCommitFact {
+    position: SourcePosition,
+    guard_var: Option<String>,
+}
+
+#[derive(Debug, Clone, Default)]
+struct ActorPlanArmFacts {
+    variants: BTreeSet<String>,
+    bindings: BTreeSet<String>,
+    field_bindings: BTreeMap<String, BTreeSet<String>>,
+}
+
+#[derive(Debug, Clone, Copy, Default)]
+struct ActorPlanResultProof {
+    authorized_commit_seen: bool,
+    unauthorized_true_possible: bool,
+}
+
+impl ActorPlanResultProof {
+    fn authorized() -> Self {
+        Self {
+            authorized_commit_seen: true,
+            unauthorized_true_possible: false,
+        }
+    }
+
+    fn static_false() -> Self {
+        Self {
+            authorized_commit_seen: false,
+            unauthorized_true_possible: false,
+        }
+    }
+
+    fn unauthorized() -> Self {
+        Self {
+            authorized_commit_seen: false,
+            unauthorized_true_possible: true,
+        }
+    }
+
+    fn combine(self, other: Self) -> Self {
+        Self {
+            authorized_commit_seen: self.authorized_commit_seen || other.authorized_commit_seen,
+            unauthorized_true_possible: self.unauthorized_true_possible
+                || other.unauthorized_true_possible,
+        }
+    }
+
+    fn proves_authorized_commit(self) -> bool {
+        self.authorized_commit_seen && !self.unauthorized_true_possible
+    }
+}
+
+impl FlowProjectionGovernanceFacts {
+    fn load(root: &Path) -> Result<Self> {
+        let owner_root = if root.join("meerkat-mob/src/run/flow_run.rs").exists() {
+            root.to_path_buf()
+        } else {
+            repo_root()?
+        };
+
+        let flow_state_fields =
+            state_struct_fields(&owner_root.join("meerkat-mob/src/run/flow_run.rs"))?;
+        let frame_state_fields =
+            state_struct_fields(&owner_root.join("meerkat-mob/src/run/flow_frame.rs"))?;
+        let cas_methods =
+            mob_run_store_cas_methods(&owner_root.join("meerkat-mob/src/store/mod.rs"))?;
+        let store_plan_variant_fields = flow_frame_loop_store_plan_variant_fields(
+            &owner_root.join("meerkat-mob/src/runtime/flow_frame_engine.rs"),
+        )?;
+        let store_plan_variant_commit_methods =
+            canonical_flow_frame_loop_store_plan_commit_requirements()
+                .iter()
+                .map(|requirement| {
+                    (
+                        requirement.variant.as_str().to_string(),
+                        requirement
+                            .operation
+                            .store_methods()
+                            .into_iter()
+                            .map(ToOwned::to_owned)
+                            .collect::<BTreeSet<_>>(),
+                    )
+                })
+                .collect();
+
+        Ok(Self {
+            flow_state_fields,
+            frame_state_fields,
+            cas_methods,
+            store_plan_variant_fields,
+            store_plan_variant_commit_methods,
+        })
+    }
+}
+
+#[derive(Debug, Clone, Default)]
+struct FlowFunctionContext {
+    name: String,
+    impl_type: Option<String>,
+    impl_type_path: Option<Vec<String>>,
+    module_depth: usize,
+    return_path: Option<Vec<String>>,
+    parameter_type_idents: BTreeSet<String>,
+    parameter_names_by_type: BTreeMap<String, BTreeSet<String>>,
+    authority_requirements: BTreeMap<FlowReducerFamily, BTreeMap<String, SourcePosition>>,
+    calls: BTreeSet<String>,
+    plan_freshness_check_position: Option<SourcePosition>,
+    prepared_plan_input_vars: BTreeMap<String, SourcePosition>,
+    committed_prepared_input_vars: BTreeMap<String, PreparedCommitFact>,
+}
+
+impl FlowFunctionContext {
+    fn from_signature(
+        sig: &syn::Signature,
+        block: &syn::Block,
+        impl_type_path: Option<Vec<String>>,
+        module_depth: usize,
+        rel: &str,
+        aliases: &RustUseAliases,
+    ) -> Self {
+        let impl_type = impl_type_path
+            .as_ref()
+            .and_then(|path| path.last())
+            .cloned();
+        let mut context = Self {
+            name: sig.ident.to_string(),
+            impl_type,
+            impl_type_path,
+            module_depth,
+            return_path: signature_return_path(sig),
+            ..Self::default()
+        };
+        for input in &sig.inputs {
+            if let syn::FnArg::Typed(pat_type) = input {
+                if type_is_exact_canonical_mob_run_store_receiver(&pat_type.ty, aliases)
+                    && let Some(name) = pat_ident_name(&pat_type.pat)
+                {
+                    context
+                        .parameter_type_idents
+                        .insert("MobRunStore".to_string());
+                    context
+                        .parameter_names_by_type
+                        .entry("MobRunStore".to_string())
+                        .or_default()
+                        .insert(name);
+                }
+                if let Some(type_ident) =
+                    parameter_type_key(&pat_type.ty, aliases, rel, module_depth)
+                {
+                    context.parameter_type_idents.insert(type_ident.clone());
+                    if let Some(name) = pat_ident_name(&pat_type.pat) {
+                        context
+                            .parameter_names_by_type
+                            .entry(type_ident)
+                            .or_default()
+                            .insert(name);
+                    }
+                }
+            }
+        }
+        let authority_parameter_names = context
+            .parameter_names_by_type
+            .get("MobMachineFlowAuthorityToken")
+            .cloned()
+            .unwrap_or_default();
+        let plan_parameter_names = context
+            .parameter_names_by_type
+            .get("FlowFrameLoopStorePlan")
+            .cloned()
+            .unwrap_or_default();
+        let run_id_parameter_names = context
+            .parameter_names_by_type
+            .get("RunId")
+            .cloned()
+            .unwrap_or_default();
+        let mut command_parameter_names = BTreeMap::new();
+        for family in [
+            FlowReducerFamily::FlowRun,
+            FlowReducerFamily::FlowFrame,
+            FlowReducerFamily::LoopIteration,
+        ] {
+            if let Some(names) = context.parameter_names_by_type.get(family.command_type()) {
+                command_parameter_names.insert(family, names.clone());
+            }
+        }
+        let mut facts = FlowBodyFactCollector::new(
+            aliases,
+            authority_parameter_names,
+            command_parameter_names,
+            run_id_parameter_names,
+            plan_parameter_names,
+        );
+        facts.visit_block(block);
+        context.authority_requirements = facts.authority_requirements;
+        context.calls = facts.calls;
+        context.plan_freshness_check_position = facts.plan_freshness_check_position;
+        context.prepared_plan_input_vars = facts.prepared_plan_input_vars;
+        context.committed_prepared_input_vars = facts.committed_prepared_input_vars;
+        context
+    }
+}
+
+struct FlowBodyFactCollector<'a> {
+    aliases: &'a RustUseAliases,
+    authority_parameter_names: BTreeSet<String>,
+    command_parameter_names: BTreeMap<FlowReducerFamily, BTreeSet<String>>,
+    run_id_parameter_names: BTreeSet<String>,
+    plan_parameter_names: BTreeSet<String>,
+    tracked_parameter_names: BTreeSet<String>,
+    shadowed_name_scope_stack: Vec<BTreeSet<String>>,
+    commit_guard_stack: Vec<Option<String>>,
+    invalidated_plan_parameter_names: BTreeSet<String>,
+    plan_match_result_vars: BTreeMap<String, SourcePosition>,
+    fail_closed_depth: usize,
+    conditional_depth: usize,
+    authority_requirements: BTreeMap<FlowReducerFamily, BTreeMap<String, SourcePosition>>,
+    calls: BTreeSet<String>,
+    plan_freshness_check_position: Option<SourcePosition>,
+    prepared_plan_input_vars: BTreeMap<String, SourcePosition>,
+    committed_prepared_input_vars: BTreeMap<String, PreparedCommitFact>,
+}
+
+fn restore_shadowed_block_facts<T: Clone>(
+    facts: &mut BTreeMap<String, T>,
+    before: &BTreeMap<String, T>,
+    block_bound_names: &BTreeSet<String>,
+) {
+    for name in block_bound_names {
+        if let Some(previous) = before.get(name) {
+            facts.insert(name.clone(), previous.clone());
+        } else {
+            facts.remove(name);
         }
     }
 }
 
-fn flow_reducer_test_only_lines(path: &str, lines: &[&str]) -> Vec<bool> {
-    if path.ends_with("/tests.rs") {
-        return vec![true; lines.len()];
-    }
-
-    let mut test_only = Vec::with_capacity(lines.len());
-    let mut in_test_module = false;
-    for (index, line) in lines.iter().enumerate() {
-        if index > 0 && lines[index - 1].trim() == "#[cfg(test)]" && line.contains("mod tests") {
-            in_test_module = true;
-        }
-        test_only.push(in_test_module);
-    }
-    test_only
-}
-
-fn flow_reducer_direct_use_is_structurally_allowed(
-    path: &str,
-    lines: &[&str],
-    line_index: usize,
-    module: &str,
-    token: &str,
-) -> bool {
-    if path != "meerkat-mob/src/run.rs" {
-        return false;
-    }
-    let Some(family) = FlowReducerFamily::from_module(module) else {
-        return false;
-    };
-
-    let Some(function_start) = nearest_function_start(lines, line_index) else {
-        return false;
-    };
-    let function_name = function_name_from_signature(lines[function_start]);
-
-    if function_name.as_deref() == Some(family.apply_function())
-        && token.contains("transition")
-        && lines[function_start..=line_index]
+fn restore_shadowed_commit_facts(
+    facts: &mut BTreeMap<String, PreparedCommitFact>,
+    before: &BTreeMap<String, PreparedCommitFact>,
+    block_bound_names: &BTreeSet<String>,
+) {
+    let mut affected = block_bound_names.clone();
+    affected.extend(
+        facts
             .iter()
-            .any(|line| line.contains(&format!("authority.require({}", family.authority_kind())))
+            .filter(|(_, fact)| {
+                fact.guard_var
+                    .as_ref()
+                    .is_some_and(|guard| block_bound_names.contains(guard))
+            })
+            .map(|(name, _)| name.clone()),
+    );
+    for name in affected {
+        if let Some(previous) = before.get(&name) {
+            facts.insert(name, previous.clone());
+        } else {
+            facts.remove(&name);
+        }
+    }
+}
+
+impl<'a> FlowBodyFactCollector<'a> {
+    fn new(
+        aliases: &'a RustUseAliases,
+        authority_parameter_names: BTreeSet<String>,
+        command_parameter_names: BTreeMap<FlowReducerFamily, BTreeSet<String>>,
+        run_id_parameter_names: BTreeSet<String>,
+        plan_parameter_names: BTreeSet<String>,
+    ) -> Self {
+        let tracked_parameter_names = authority_parameter_names
+            .iter()
+            .chain(command_parameter_names.values().flatten())
+            .chain(&run_id_parameter_names)
+            .chain(&plan_parameter_names)
+            .cloned()
+            .collect();
+        Self {
+            aliases,
+            authority_parameter_names,
+            command_parameter_names,
+            run_id_parameter_names,
+            plan_parameter_names,
+            tracked_parameter_names,
+            shadowed_name_scope_stack: Vec::new(),
+            commit_guard_stack: Vec::new(),
+            invalidated_plan_parameter_names: BTreeSet::new(),
+            plan_match_result_vars: BTreeMap::new(),
+            fail_closed_depth: 0,
+            conditional_depth: 0,
+            authority_requirements: BTreeMap::new(),
+            calls: BTreeSet::new(),
+            plan_freshness_check_position: None,
+            prepared_plan_input_vars: BTreeMap::new(),
+            committed_prepared_input_vars: BTreeMap::new(),
+        }
+    }
+
+    fn with_fail_closed<R>(&mut self, f: impl FnOnce(&mut Self) -> R) -> R {
+        self.fail_closed_depth += 1;
+        let result = f(self);
+        self.fail_closed_depth -= 1;
+        result
+    }
+
+    fn with_conditional<R>(&mut self, f: impl FnOnce(&mut Self) -> R) -> R {
+        self.conditional_depth += 1;
+        let result = f(self);
+        self.conditional_depth -= 1;
+        result
+    }
+
+    fn name_is_shadowed(&self, name: &str) -> bool {
+        self.shadowed_name_scope_stack
+            .iter()
+            .rev()
+            .any(|scope| scope.contains(name))
+    }
+
+    fn visible_parameter_name(&self, name: &str) -> bool {
+        self.tracked_parameter_names.contains(name) && !self.name_is_shadowed(name)
+    }
+
+    fn visible_command_parameter_names(&self, family: FlowReducerFamily) -> BTreeSet<String> {
+        self.command_parameter_names
+            .get(&family)
+            .into_iter()
+            .flat_map(|names| names.iter())
+            .filter(|name| self.visible_parameter_name(name))
+            .cloned()
+            .collect()
+    }
+
+    fn visible_plan_parameter_names(&self) -> BTreeSet<String> {
+        let names = self
+            .plan_parameter_names
+            .iter()
+            .filter(|name| {
+                self.visible_parameter_name(name)
+                    && !self.invalidated_plan_parameter_names.contains(*name)
+            })
+            .cloned()
+            .collect::<BTreeSet<_>>();
+        if names.len() == 1 {
+            names
+        } else {
+            BTreeSet::new()
+        }
+    }
+
+    fn visible_run_id_parameter_names(&self) -> BTreeSet<String> {
+        let names = self
+            .run_id_parameter_names
+            .iter()
+            .filter(|name| self.visible_parameter_name(name))
+            .cloned()
+            .collect::<BTreeSet<_>>();
+        if names.len() == 1 {
+            names
+        } else {
+            BTreeSet::new()
+        }
+    }
+
+    fn expr_is_authority_parameter(&self, expr: &syn::Expr) -> bool {
+        expr_path_single_ident(expr).as_ref().is_some_and(|ident| {
+            self.authority_parameter_names.contains(ident) && self.visible_parameter_name(ident)
+        })
+    }
+
+    fn expr_is_plan_scrutinee(&self, expr: &syn::Expr) -> bool {
+        expr_is_plan_scrutinee(expr, &self.visible_plan_parameter_names())
+    }
+
+    fn expr_is_plan_machine_inputs_prepare_call(&self, expr: &syn::Expr) -> bool {
+        expr_is_plan_machine_inputs_prepare_call(expr, &self.visible_plan_parameter_names())
+    }
+
+    fn expr_is_plan_freshness_failure_guard(&self, expr: &syn::Expr) -> bool {
+        expr_is_plan_freshness_failure_guard(
+            expr,
+            &self.visible_run_id_parameter_names(),
+            &self.visible_plan_parameter_names(),
+        )
+    }
+
+    fn authority_kind_command_parameter(
+        &self,
+        family: FlowReducerFamily,
+        expr: &syn::Expr,
+    ) -> Option<String> {
+        let command_vars = self.visible_command_parameter_names(family);
+        flow_authority_kind_command_parameter(expr, family, &command_vars, self.aliases)
+    }
+
+    fn bind_local_names(&mut self, pat: &syn::Pat) {
+        let Some(scope) = self.shadowed_name_scope_stack.last_mut() else {
+            return;
+        };
+        scope.extend(pat_bound_idents(pat));
+    }
+
+    fn invalidate_plan_proof_var(&mut self, name: &str) {
+        if self.plan_parameter_names.contains(name) && self.visible_parameter_name(name) {
+            self.invalidated_plan_parameter_names
+                .insert(name.to_string());
+            self.prepared_plan_input_vars.clear();
+            self.plan_match_result_vars.clear();
+            self.committed_prepared_input_vars.clear();
+            return;
+        }
+        self.prepared_plan_input_vars.remove(name);
+        self.plan_match_result_vars.remove(name);
+        self.committed_prepared_input_vars
+            .retain(|prepared, commit| {
+                prepared != name && commit.guard_var.as_deref() != Some(name)
+            });
+    }
+}
+
+impl<'ast> Visit<'ast> for FlowBodyFactCollector<'_> {
+    fn visit_block(&mut self, node: &'ast syn::Block) {
+        let invalidated_plan_parameter_names_before = self.invalidated_plan_parameter_names.clone();
+        let plan_match_result_vars_before = self.plan_match_result_vars.clone();
+        let prepared_plan_input_vars_before = self.prepared_plan_input_vars.clone();
+        let committed_prepared_input_vars_before = self.committed_prepared_input_vars.clone();
+        let nested_block = !self.shadowed_name_scope_stack.is_empty();
+        let mut scope = block_item_function_names(node);
+        scope.retain(|name| self.tracked_parameter_names.contains(name));
+        self.shadowed_name_scope_stack.push(scope);
+        for stmt in &node.stmts {
+            self.visit_stmt(stmt);
+            if stmt_unconditionally_exits_block(stmt) {
+                break;
+            }
+        }
+        let block_bound_names = self.shadowed_name_scope_stack.pop().unwrap_or_default();
+        if nested_block {
+            restore_shadowed_block_facts(
+                &mut self.plan_match_result_vars,
+                &plan_match_result_vars_before,
+                &block_bound_names,
+            );
+            restore_shadowed_block_facts(
+                &mut self.prepared_plan_input_vars,
+                &prepared_plan_input_vars_before,
+                &block_bound_names,
+            );
+            restore_shadowed_commit_facts(
+                &mut self.committed_prepared_input_vars,
+                &committed_prepared_input_vars_before,
+                &block_bound_names,
+            );
+            for name in &block_bound_names {
+                if invalidated_plan_parameter_names_before.contains(name) {
+                    self.invalidated_plan_parameter_names.insert(name.clone());
+                } else {
+                    self.invalidated_plan_parameter_names.remove(name);
+                }
+            }
+        } else {
+            self.plan_match_result_vars = plan_match_result_vars_before;
+        }
+    }
+
+    fn visit_local(&mut self, node: &'ast syn::Local) {
+        if let Some(init) = &node.init {
+            self.visit_expr(&init.expr);
+            if let Some((_, diverge)) = &init.diverge {
+                self.visit_expr(diverge);
+            }
+        }
+        let bound_names = pat_bound_idents(&node.pat);
+        for name in &bound_names {
+            self.invalidate_plan_proof_var(name);
+        }
+        if let syn::Pat::Ident(ident) = &node.pat
+            && let Some(init) = &node.init
+        {
+            let name = ident.ident.to_string();
+            if self.expr_is_plan_machine_inputs_prepare_call(&init.expr) {
+                self.prepared_plan_input_vars
+                    .insert(name.clone(), source_position(node));
+            }
+            if matches!(&*init.expr, syn::Expr::Match(expr_match) if self.expr_is_plan_scrutinee(&expr_match.expr))
+            {
+                self.plan_match_result_vars
+                    .insert(name, source_position(node));
+            }
+        }
+        self.bind_local_names(&node.pat);
+    }
+
+    fn visit_item_fn(&mut self, _node: &'ast syn::ItemFn) {}
+
+    fn visit_item_impl(&mut self, _node: &'ast syn::ItemImpl) {}
+
+    fn visit_expr_try(&mut self, node: &'ast syn::ExprTry) {
+        if expr_is_ok_constructor_call(&node.expr)
+            || expr_contains_fail_open_result_method(&node.expr)
+        {
+            self.visit_expr(&node.expr);
+        } else {
+            self.with_fail_closed(|this| this.visit_expr(&node.expr));
+        }
+    }
+
+    fn visit_expr_closure(&mut self, node: &'ast syn::ExprClosure) {
+        self.with_conditional(|this| visit::visit_expr_closure(this, node));
+    }
+
+    fn visit_expr_async(&mut self, node: &'ast syn::ExprAsync) {
+        self.with_conditional(|this| visit::visit_expr_async(this, node));
+    }
+
+    fn visit_expr_loop(&mut self, node: &'ast syn::ExprLoop) {
+        self.with_conditional(|this| visit::visit_expr_loop(this, node));
+    }
+
+    fn visit_expr_while(&mut self, node: &'ast syn::ExprWhile) {
+        self.with_conditional(|this| visit::visit_expr_while(this, node));
+    }
+
+    fn visit_expr_for_loop(&mut self, node: &'ast syn::ExprForLoop) {
+        self.with_conditional(|this| visit::visit_expr_for_loop(this, node));
+    }
+
+    fn visit_expr_if(&mut self, node: &'ast syn::ExprIf) {
+        if self.conditional_depth == 0
+            && node.else_branch.is_none()
+            && self.expr_is_plan_freshness_failure_guard(&node.cond)
+            && block_returns_ok_false(&node.then_branch)
+        {
+            self.plan_freshness_check_position
+                .get_or_insert_with(|| source_position(node));
+        }
+        self.visit_expr(&node.cond);
+        let commit_guard = expr_path_single_ident(&node.cond)
+            .filter(|name| self.plan_match_result_vars.contains_key(name));
+        self.commit_guard_stack.push(commit_guard);
+        self.with_conditional(|this| this.visit_block(&node.then_branch));
+        let _ = self.commit_guard_stack.pop();
+        if let Some((_, else_branch)) = &node.else_branch {
+            self.commit_guard_stack.push(None);
+            self.with_conditional(|this| this.visit_expr(else_branch));
+            let _ = self.commit_guard_stack.pop();
+        }
+    }
+
+    fn visit_expr_match(&mut self, node: &'ast syn::ExprMatch) {
+        self.visit_expr(&node.expr);
+        for arm in &node.arms {
+            if let Some((_, guard)) = &arm.guard {
+                self.visit_expr(guard);
+            }
+            self.with_conditional(|this| this.visit_expr(&arm.body));
+        }
+    }
+
+    fn visit_expr_assign(&mut self, node: &'ast syn::ExprAssign) {
+        self.visit_expr(&node.right);
+        if let Some(name) = expr_path_single_ident(&node.left) {
+            self.invalidate_plan_proof_var(&name);
+            if self.expr_is_plan_machine_inputs_prepare_call(&node.right) {
+                self.prepared_plan_input_vars
+                    .insert(name.clone(), source_position(node));
+            }
+            if matches!(&*node.right, syn::Expr::Match(expr_match) if self.expr_is_plan_scrutinee(&expr_match.expr))
+            {
+                self.plan_match_result_vars
+                    .insert(name, source_position(node));
+            }
+        } else {
+            if let Some(name) = expr_root_ident(&node.left) {
+                self.invalidate_plan_proof_var(&name);
+            }
+            self.visit_expr(&node.left);
+        }
+    }
+
+    fn visit_expr_reference(&mut self, node: &'ast syn::ExprReference) {
+        if node.mutability.is_some()
+            && let Some(name) = expr_root_ident(&node.expr)
+        {
+            self.invalidate_plan_proof_var(&name);
+        }
+        visit::visit_expr_reference(self, node);
+    }
+
+    fn visit_expr_binary(&mut self, node: &'ast syn::ExprBinary) {
+        if bin_op_is_assign(&node.op)
+            && let Some(name) = expr_root_ident(&node.left)
+        {
+            self.invalidate_plan_proof_var(&name);
+        }
+        if matches!(node.op, syn::BinOp::And(_) | syn::BinOp::Or(_)) {
+            self.with_conditional(|this| {
+                this.visit_expr(&node.left);
+                this.visit_expr(&node.right);
+            });
+        } else {
+            visit::visit_expr_binary(self, node);
+        }
+    }
+
+    fn visit_expr_call(&mut self, node: &'ast syn::ExprCall) {
+        if let syn::Expr::Path(func) = &*node.func
+            && let Some(name) = func.path.segments.last()
+        {
+            self.calls.insert(name.ident.to_string());
+        }
+        visit::visit_expr_call(self, node);
+    }
+
+    fn visit_expr_method_call(&mut self, node: &'ast syn::ExprMethodCall) {
+        let method = node.method.to_string();
+        if flow_provenance_mutator_method(&method)
+            && let Some(name) = expr_root_ident(&node.receiver)
+        {
+            self.invalidate_plan_proof_var(&name);
+        }
+        if method == "require"
+            && self.fail_closed_depth > 0
+            && self.conditional_depth == 0
+            && self.expr_is_authority_parameter(&node.receiver)
+            && let Some(arg) = node.args.first()
+            && let Some(family) = flow_authority_kind_argument(arg, self.aliases)
+            && let Some(command_var) = self.authority_kind_command_parameter(family, arg)
+        {
+            self.authority_requirements
+                .entry(family)
+                .or_default()
+                .entry(command_var)
+                .or_insert_with(|| source_position(node));
+        }
+        if method == "commit_prepared_dsl_input"
+            && expr_is_self_receiver(&node.receiver)
+            && self.conditional_depth == 1
+            && let Some(prepared_var) = node.args.first().and_then(expr_path_single_ident)
+            && self.prepared_plan_input_vars.contains_key(&prepared_var)
+        {
+            self.committed_prepared_input_vars
+                .entry(prepared_var)
+                .or_insert_with(|| PreparedCommitFact {
+                    position: source_position(node),
+                    guard_var: self.commit_guard_stack.last().cloned().flatten(),
+                });
+        }
+        self.calls.insert(method);
+        visit::visit_expr_method_call(self, node);
+    }
+}
+
+struct FlowGovernanceVisitor<'a> {
+    rel: &'a str,
+    aliases: &'a RustUseAliases,
+    facts: &'a FlowProjectionGovernanceFacts,
+    impl_stack: Vec<Option<Vec<String>>>,
+    module_depth: usize,
+    function_stack: Vec<FlowFunctionContext>,
+    alias_stack: Vec<RustUseAliases>,
+    projection_state_alias_stack: Vec<BTreeMap<String, Option<String>>>,
+    typed_flow_outcome_scope_stack: Vec<BTreeMap<String, bool>>,
+    typed_flow_outcome_command_scope_stack: Vec<BTreeMap<String, Option<String>>>,
+    typed_flow_outcome_identity_scope_stack: Vec<BTreeMap<String, Option<String>>>,
+    typed_flow_next_state_scope_stack: Vec<BTreeMap<String, bool>>,
+    typed_flow_next_state_command_scope_stack: Vec<BTreeMap<String, Option<String>>>,
+    typed_flow_next_state_identity_scope_stack: Vec<BTreeMap<String, Option<String>>>,
+    flow_run_command_scope_stack: Vec<BTreeMap<String, bool>>,
+    flow_authority_token_scope_stack: Vec<BTreeMap<String, bool>>,
+    flow_authority_input_scope_stack: Vec<BTreeMap<String, Option<String>>>,
+    flow_authority_input_identity_scope_stack: Vec<BTreeMap<String, Option<String>>>,
+    actor_plan_authority_input_scope_stack: Vec<BTreeMap<String, bool>>,
+    shadowed_name_scope_stack: Vec<BTreeSet<String>>,
+    deferred_expr_depth: usize,
+    actor_plan_binding_scope_stack: Vec<ActorPlanArmFacts>,
+    actor_plan_match_result_stack: Vec<Option<String>>,
+    actor_plan_result_expr_depth: usize,
+    actor_plan_authorized_commit_stack: Vec<bool>,
+    mismatches: Vec<String>,
+}
+
+impl<'a> FlowGovernanceVisitor<'a> {
+    fn new(
+        rel: &'a str,
+        aliases: &'a RustUseAliases,
+        facts: &'a FlowProjectionGovernanceFacts,
+    ) -> Self {
+        Self {
+            rel,
+            aliases,
+            facts,
+            impl_stack: Vec::new(),
+            module_depth: 0,
+            function_stack: Vec::new(),
+            alias_stack: Vec::new(),
+            projection_state_alias_stack: Vec::new(),
+            typed_flow_outcome_scope_stack: Vec::new(),
+            typed_flow_outcome_command_scope_stack: Vec::new(),
+            typed_flow_outcome_identity_scope_stack: Vec::new(),
+            typed_flow_next_state_scope_stack: Vec::new(),
+            typed_flow_next_state_command_scope_stack: Vec::new(),
+            typed_flow_next_state_identity_scope_stack: Vec::new(),
+            flow_run_command_scope_stack: Vec::new(),
+            flow_authority_token_scope_stack: Vec::new(),
+            flow_authority_input_scope_stack: Vec::new(),
+            flow_authority_input_identity_scope_stack: Vec::new(),
+            actor_plan_authority_input_scope_stack: Vec::new(),
+            shadowed_name_scope_stack: Vec::new(),
+            deferred_expr_depth: 0,
+            actor_plan_binding_scope_stack: Vec::new(),
+            actor_plan_match_result_stack: Vec::new(),
+            actor_plan_result_expr_depth: 0,
+            actor_plan_authorized_commit_stack: Vec::new(),
+            mismatches: Vec::new(),
+        }
+    }
+
+    fn current_function(&self) -> Option<&FlowFunctionContext> {
+        self.function_stack.last()
+    }
+
+    fn current_aliases(&self) -> &RustUseAliases {
+        self.alias_stack.last().unwrap_or(self.aliases)
+    }
+
+    fn name_is_shadowed(&self, name: &str) -> bool {
+        self.shadowed_name_scope_stack
+            .iter()
+            .rev()
+            .any(|scope| scope.contains(name))
+    }
+
+    fn visible_parameter_names(&self, type_ident: &str) -> BTreeSet<String> {
+        self.current_function()
+            .and_then(|function| function.parameter_names_by_type.get(type_ident))
+            .into_iter()
+            .flat_map(|names| names.iter())
+            .filter(|name| !self.name_is_shadowed(name))
+            .cloned()
+            .collect()
+    }
+
+    fn has_visible_parameter_type(&self, type_ident: &str) -> bool {
+        !self.visible_parameter_names(type_ident).is_empty()
+    }
+
+    fn visible_projection_state_alias(&self, alias: &str) -> Option<&str> {
+        for scope in self.projection_state_alias_stack.iter().rev() {
+            if let Some(value) = scope.get(alias) {
+                return value.as_deref();
+            }
+        }
+        None
+    }
+
+    fn visible_typed_flow_outcome_vars(&self) -> BTreeSet<String> {
+        let mut resolved = BTreeMap::new();
+        for scope in self.typed_flow_outcome_scope_stack.iter().rev() {
+            for (name, is_typed) in scope {
+                resolved.entry(name.clone()).or_insert(*is_typed);
+            }
+        }
+        resolved
+            .into_iter()
+            .filter_map(|(name, is_typed)| is_typed.then_some(name))
+            .collect()
+    }
+
+    fn visible_typed_flow_outcome_command_vars(&self) -> BTreeMap<String, String> {
+        let mut resolved: BTreeMap<String, Option<String>> = BTreeMap::new();
+        for scope in self.typed_flow_outcome_command_scope_stack.iter().rev() {
+            for (name, command) in scope {
+                resolved
+                    .entry(name.clone())
+                    .or_insert_with(|| command.clone());
+            }
+        }
+        resolved
+            .into_iter()
+            .filter_map(|(name, command)| command.map(|command| (name, command)))
+            .collect()
+    }
+
+    fn visible_typed_flow_outcome_identity_vars(&self) -> BTreeMap<String, String> {
+        let mut resolved: BTreeMap<String, Option<String>> = BTreeMap::new();
+        for scope in self.typed_flow_outcome_identity_scope_stack.iter().rev() {
+            for (name, identity) in scope {
+                resolved
+                    .entry(name.clone())
+                    .or_insert_with(|| identity.clone());
+            }
+        }
+        resolved
+            .into_iter()
+            .filter_map(|(name, identity)| identity.map(|identity| (name, identity)))
+            .collect()
+    }
+
+    fn visible_typed_flow_next_state_vars(&self) -> BTreeSet<String> {
+        let mut resolved = BTreeMap::new();
+        for scope in self.typed_flow_next_state_scope_stack.iter().rev() {
+            for (name, is_typed) in scope {
+                resolved.entry(name.clone()).or_insert(*is_typed);
+            }
+        }
+        resolved
+            .into_iter()
+            .filter_map(|(name, is_typed)| is_typed.then_some(name))
+            .collect()
+    }
+
+    fn visible_typed_flow_next_state_command_vars(&self) -> BTreeMap<String, String> {
+        let mut resolved: BTreeMap<String, Option<String>> = BTreeMap::new();
+        for scope in self.typed_flow_next_state_command_scope_stack.iter().rev() {
+            for (name, command) in scope {
+                resolved
+                    .entry(name.clone())
+                    .or_insert_with(|| command.clone());
+            }
+        }
+        resolved
+            .into_iter()
+            .filter_map(|(name, command)| command.map(|command| (name, command)))
+            .collect()
+    }
+
+    fn visible_typed_flow_next_state_identity_vars(&self) -> BTreeMap<String, String> {
+        let mut resolved: BTreeMap<String, Option<String>> = BTreeMap::new();
+        for scope in self.typed_flow_next_state_identity_scope_stack.iter().rev() {
+            for (name, identity) in scope {
+                resolved
+                    .entry(name.clone())
+                    .or_insert_with(|| identity.clone());
+            }
+        }
+        resolved
+            .into_iter()
+            .filter_map(|(name, identity)| identity.map(|identity| (name, identity)))
+            .collect()
+    }
+
+    fn visible_flow_run_command_vars(&self) -> BTreeSet<String> {
+        let mut vars = self.visible_parameter_names("MobMachineFlowRunCommand");
+        let mut resolved = BTreeMap::new();
+        for scope in self.flow_run_command_scope_stack.iter().rev() {
+            for (name, is_typed) in scope {
+                resolved.entry(name.clone()).or_insert(*is_typed);
+            }
+        }
+        for (name, is_typed) in resolved {
+            if is_typed {
+                vars.insert(name);
+            } else {
+                vars.remove(&name);
+            }
+        }
+        vars
+    }
+
+    fn visible_flow_authority_token_vars(&self) -> BTreeSet<String> {
+        let mut vars = self.visible_parameter_names("MobMachineFlowAuthorityToken");
+        let mut resolved = BTreeMap::new();
+        for scope in self.flow_authority_token_scope_stack.iter().rev() {
+            for (name, is_typed) in scope {
+                resolved.entry(name.clone()).or_insert(*is_typed);
+            }
+        }
+        for (name, is_typed) in resolved {
+            if is_typed {
+                vars.insert(name);
+            } else {
+                vars.remove(&name);
+            }
+        }
+        vars
+    }
+
+    fn visible_flow_authority_input_command_vars(&self) -> BTreeMap<String, String> {
+        let mut resolved: BTreeMap<String, Option<String>> = BTreeMap::new();
+        for scope in self.flow_authority_input_scope_stack.iter().rev() {
+            for (name, command) in scope {
+                resolved
+                    .entry(name.clone())
+                    .or_insert_with(|| command.clone());
+            }
+        }
+        resolved
+            .into_iter()
+            .filter_map(|(name, command)| command.map(|command| (name, command)))
+            .collect()
+    }
+
+    fn visible_flow_authority_input_identity_vars(&self) -> BTreeMap<String, String> {
+        let mut resolved: BTreeMap<String, Option<String>> = BTreeMap::new();
+        for scope in self.flow_authority_input_identity_scope_stack.iter().rev() {
+            for (name, identity) in scope {
+                resolved
+                    .entry(name.clone())
+                    .or_insert_with(|| identity.clone());
+            }
+        }
+        resolved
+            .into_iter()
+            .filter_map(|(name, identity)| identity.map(|identity| (name, identity)))
+            .collect()
+    }
+
+    fn visible_actor_plan_authority_input_vars(&self) -> BTreeSet<String> {
+        let mut resolved = BTreeMap::new();
+        for scope in self.actor_plan_authority_input_scope_stack.iter().rev() {
+            for (name, is_plan_authority) in scope {
+                resolved.entry(name.clone()).or_insert(*is_plan_authority);
+            }
+        }
+        resolved
+            .into_iter()
+            .filter_map(|(name, is_plan_authority)| is_plan_authority.then_some(name))
+            .collect()
+    }
+
+    fn visible_actor_plan_parameter_vars(&self) -> BTreeSet<String> {
+        let names = self.visible_parameter_names("FlowFrameLoopStorePlan");
+        if names.len() == 1 {
+            names
+        } else {
+            BTreeSet::new()
+        }
+    }
+
+    fn expr_is_actor_plan_scrutinee(&self, expr: &syn::Expr) -> bool {
+        expr_is_plan_scrutinee(expr, &self.visible_actor_plan_parameter_vars())
+    }
+
+    fn expr_is_actor_plan_machine_inputs_value(
+        &self,
+        expr: &syn::Expr,
+        plan_authority_input_vars: &BTreeSet<String>,
+    ) -> bool {
+        expr_is_plan_machine_inputs_value(
+            expr,
+            plan_authority_input_vars,
+            &self.visible_actor_plan_parameter_vars(),
+        )
+    }
+
+    fn set_typed_flow_outcome_var(&mut self, name: &str, is_typed: bool) {
+        for scope in self.typed_flow_outcome_scope_stack.iter_mut().rev() {
+            if scope.contains_key(name) {
+                scope.insert(name.to_string(), is_typed);
+                return;
+            }
+        }
+        if let Some(scope) = self.typed_flow_outcome_scope_stack.last_mut() {
+            scope.insert(name.to_string(), is_typed);
+        }
+    }
+
+    fn set_typed_flow_outcome_command_var(&mut self, name: &str, command: Option<String>) {
+        for scope in self.typed_flow_outcome_command_scope_stack.iter_mut().rev() {
+            if scope.contains_key(name) {
+                scope.insert(name.to_string(), command);
+                return;
+            }
+        }
+        if let Some(scope) = self.typed_flow_outcome_command_scope_stack.last_mut() {
+            scope.insert(name.to_string(), command);
+        }
+    }
+
+    fn set_typed_flow_outcome_identity_var(&mut self, name: &str, identity: Option<String>) {
+        for scope in self
+            .typed_flow_outcome_identity_scope_stack
+            .iter_mut()
+            .rev()
+        {
+            if scope.contains_key(name) {
+                scope.insert(name.to_string(), identity);
+                return;
+            }
+        }
+        if let Some(scope) = self.typed_flow_outcome_identity_scope_stack.last_mut() {
+            scope.insert(name.to_string(), identity);
+        }
+    }
+
+    fn set_typed_flow_next_state_var(&mut self, name: &str, is_typed: bool) {
+        for scope in self.typed_flow_next_state_scope_stack.iter_mut().rev() {
+            if scope.contains_key(name) {
+                scope.insert(name.to_string(), is_typed);
+                return;
+            }
+        }
+        if let Some(scope) = self.typed_flow_next_state_scope_stack.last_mut() {
+            scope.insert(name.to_string(), is_typed);
+        }
+    }
+
+    fn set_typed_flow_next_state_command_var(&mut self, name: &str, command: Option<String>) {
+        for scope in self
+            .typed_flow_next_state_command_scope_stack
+            .iter_mut()
+            .rev()
+        {
+            if scope.contains_key(name) {
+                scope.insert(name.to_string(), command);
+                return;
+            }
+        }
+        if let Some(scope) = self.typed_flow_next_state_command_scope_stack.last_mut() {
+            scope.insert(name.to_string(), command);
+        }
+    }
+
+    fn set_typed_flow_next_state_identity_var(&mut self, name: &str, identity: Option<String>) {
+        for scope in self
+            .typed_flow_next_state_identity_scope_stack
+            .iter_mut()
+            .rev()
+        {
+            if scope.contains_key(name) {
+                scope.insert(name.to_string(), identity);
+                return;
+            }
+        }
+        if let Some(scope) = self.typed_flow_next_state_identity_scope_stack.last_mut() {
+            scope.insert(name.to_string(), identity);
+        }
+    }
+
+    fn set_flow_run_command_var(&mut self, name: &str, is_typed: bool) {
+        for scope in self.flow_run_command_scope_stack.iter_mut().rev() {
+            if scope.contains_key(name) {
+                scope.insert(name.to_string(), is_typed);
+                return;
+            }
+        }
+        if let Some(scope) = self.flow_run_command_scope_stack.last_mut() {
+            scope.insert(name.to_string(), is_typed);
+        }
+    }
+
+    fn set_flow_authority_token_var(&mut self, name: &str, is_typed: bool) {
+        for scope in self.flow_authority_token_scope_stack.iter_mut().rev() {
+            if scope.contains_key(name) {
+                scope.insert(name.to_string(), is_typed);
+                return;
+            }
+        }
+        if let Some(scope) = self.flow_authority_token_scope_stack.last_mut() {
+            scope.insert(name.to_string(), is_typed);
+        }
+    }
+
+    fn set_flow_authority_input_var(&mut self, name: &str, command: Option<String>) {
+        for scope in self.flow_authority_input_scope_stack.iter_mut().rev() {
+            if scope.contains_key(name) {
+                scope.insert(name.to_string(), command);
+                return;
+            }
+        }
+        if let Some(scope) = self.flow_authority_input_scope_stack.last_mut() {
+            scope.insert(name.to_string(), command);
+        }
+    }
+
+    fn set_flow_authority_input_identity_var(&mut self, name: &str, identity: Option<String>) {
+        for scope in self
+            .flow_authority_input_identity_scope_stack
+            .iter_mut()
+            .rev()
+        {
+            if scope.contains_key(name) {
+                scope.insert(name.to_string(), identity);
+                return;
+            }
+        }
+        if let Some(scope) = self.flow_authority_input_identity_scope_stack.last_mut() {
+            scope.insert(name.to_string(), identity);
+        }
+    }
+
+    fn set_actor_plan_authority_input_var(&mut self, name: &str, is_plan_authority: bool) {
+        for scope in self.actor_plan_authority_input_scope_stack.iter_mut().rev() {
+            if scope.contains_key(name) {
+                scope.insert(name.to_string(), is_plan_authority);
+                return;
+            }
+        }
+        if let Some(scope) = self.actor_plan_authority_input_scope_stack.last_mut() {
+            scope.insert(name.to_string(), is_plan_authority);
+        }
+    }
+
+    fn invalidate_typed_flow_outcome_path(&mut self, expr: &syn::Expr) {
+        if let Some(name) = expr_field_chain(expr).first().cloned()
+            && self.visible_typed_flow_outcome_vars().contains(&name)
+        {
+            self.set_typed_flow_outcome_var(&name, false);
+            self.set_typed_flow_outcome_command_var(&name, None);
+            self.set_typed_flow_outcome_identity_var(&name, None);
+        }
+    }
+
+    fn invalidate_typed_flow_next_state_path(&mut self, expr: &syn::Expr) {
+        if let Some(name) = expr_field_chain(expr).first().cloned()
+            && self.visible_typed_flow_next_state_vars().contains(&name)
+        {
+            self.set_typed_flow_next_state_var(&name, false);
+            self.set_typed_flow_next_state_command_var(&name, None);
+            self.set_typed_flow_next_state_identity_var(&name, None);
+        }
+    }
+
+    fn invalidate_flow_provenance_var(&mut self, name: &str) {
+        self.set_typed_flow_outcome_var(name, false);
+        self.set_typed_flow_outcome_command_var(name, None);
+        self.set_typed_flow_outcome_identity_var(name, None);
+        self.set_typed_flow_next_state_var(name, false);
+        self.set_typed_flow_next_state_command_var(name, None);
+        self.set_typed_flow_next_state_identity_var(name, None);
+        self.set_flow_run_command_var(name, false);
+        self.set_flow_authority_token_var(name, false);
+        self.set_flow_authority_input_var(name, None);
+        self.set_flow_authority_input_identity_var(name, None);
+        self.set_actor_plan_authority_input_var(name, false);
+        self.set_projection_state_alias_var(name, None);
+    }
+
+    fn set_projection_state_alias_var(&mut self, name: &str, alias: Option<String>) {
+        for scope in self.projection_state_alias_stack.iter_mut().rev() {
+            if scope.contains_key(name) {
+                scope.insert(name.to_string(), alias);
+                return;
+            }
+        }
+        if let Some(scope) = self.projection_state_alias_stack.last_mut() {
+            scope.insert(name.to_string(), alias);
+        }
+    }
+
+    fn current_actor_plan_arm(&self) -> Option<&ActorPlanArmFacts> {
+        self.actor_plan_binding_scope_stack.last()
+    }
+
+    fn current_actor_plan_match_result_var(&self) -> Option<&str> {
+        self.actor_plan_match_result_stack
+            .last()
+            .and_then(|name| name.as_deref())
+    }
+
+    fn mark_actor_plan_authorized_commit(&mut self) {
+        if let Some(seen) = self.actor_plan_authorized_commit_stack.last_mut() {
+            *seen = true;
+        }
+    }
+
+    fn with_actor_plan_commit_marker<R>(&mut self, f: impl FnOnce(&mut Self) -> R) -> (R, bool) {
+        self.actor_plan_authorized_commit_stack.push(false);
+        let result = f(self);
+        let seen = self
+            .actor_plan_authorized_commit_stack
+            .pop()
+            .unwrap_or(false);
+        (result, seen)
+    }
+
+    fn with_actor_plan_result_expr<R>(&mut self, f: impl FnOnce(&mut Self) -> R) -> R {
+        self.actor_plan_result_expr_depth += 1;
+        let result = f(self);
+        self.actor_plan_result_expr_depth -= 1;
+        result
+    }
+
+    fn visit_actor_plan_result_stmt(&mut self, stmt: &syn::Stmt) -> ActorPlanResultProof {
+        match stmt {
+            syn::Stmt::Expr(expr, None) => self.visit_actor_plan_result_expr(expr),
+            _ => {
+                self.visit_stmt(stmt);
+                ActorPlanResultProof::unauthorized()
+            }
+        }
+    }
+
+    fn visit_actor_plan_result_expr(&mut self, expr: &syn::Expr) -> ActorPlanResultProof {
+        match expr {
+            syn::Expr::Block(block) => {
+                let local_aliases = self.current_aliases().with_block_aliases(&block.block);
+                self.alias_stack.push(local_aliases);
+                self.typed_flow_outcome_scope_stack.push(BTreeMap::new());
+                self.typed_flow_outcome_command_scope_stack
+                    .push(BTreeMap::new());
+                self.typed_flow_outcome_identity_scope_stack
+                    .push(BTreeMap::new());
+                self.typed_flow_next_state_scope_stack.push(BTreeMap::new());
+                self.typed_flow_next_state_command_scope_stack
+                    .push(BTreeMap::new());
+                self.typed_flow_next_state_identity_scope_stack
+                    .push(BTreeMap::new());
+                self.flow_run_command_scope_stack.push(BTreeMap::new());
+                self.flow_authority_token_scope_stack.push(BTreeMap::new());
+                self.flow_authority_input_scope_stack.push(BTreeMap::new());
+                self.flow_authority_input_identity_scope_stack
+                    .push(BTreeMap::new());
+                self.actor_plan_authority_input_scope_stack
+                    .push(BTreeMap::new());
+                self.projection_state_alias_stack.push(BTreeMap::new());
+                self.shadowed_name_scope_stack
+                    .push(block_item_function_names(&block.block));
+                let mut proof = ActorPlanResultProof::unauthorized();
+                for (index, stmt) in block.block.stmts.iter().enumerate() {
+                    if index + 1 == block.block.stmts.len() {
+                        proof = self.visit_actor_plan_result_stmt(stmt);
+                    } else {
+                        self.visit_stmt(stmt);
+                    }
+                }
+                let _ = self.shadowed_name_scope_stack.pop();
+                let _ = self.projection_state_alias_stack.pop();
+                let _ = self.actor_plan_authority_input_scope_stack.pop();
+                let _ = self.flow_authority_input_identity_scope_stack.pop();
+                let _ = self.flow_authority_input_scope_stack.pop();
+                let _ = self.flow_authority_token_scope_stack.pop();
+                let _ = self.flow_run_command_scope_stack.pop();
+                let _ = self.typed_flow_next_state_identity_scope_stack.pop();
+                let _ = self.typed_flow_next_state_command_scope_stack.pop();
+                let _ = self.typed_flow_next_state_scope_stack.pop();
+                let _ = self.typed_flow_outcome_identity_scope_stack.pop();
+                let _ = self.typed_flow_outcome_command_scope_stack.pop();
+                let _ = self.typed_flow_outcome_scope_stack.pop();
+                let _ = self.alias_stack.pop();
+                proof
+            }
+            syn::Expr::If(expr_if) => {
+                self.visit_expr(&expr_if.cond);
+                let then_expr = syn::Expr::Block(syn::ExprBlock {
+                    attrs: Vec::new(),
+                    label: None,
+                    block: expr_if.then_branch.clone(),
+                });
+                let then_proof = if let syn::Expr::Let(expr_let) = &*expr_if.cond {
+                    self.with_pattern_bindings(&expr_let.pat, &expr_let.expr, |this| {
+                        this.visit_actor_plan_result_expr(&then_expr)
+                    })
+                } else {
+                    self.visit_actor_plan_result_expr(&then_expr)
+                };
+                let else_proof = if let Some((_, else_branch)) = &expr_if.else_branch {
+                    self.visit_actor_plan_result_expr(else_branch)
+                } else {
+                    ActorPlanResultProof::unauthorized()
+                };
+                then_proof.combine(else_proof)
+            }
+            syn::Expr::Match(expr_match) => {
+                self.visit_expr(&expr_match.expr);
+                let mut proof = ActorPlanResultProof::static_false();
+                for arm in &expr_match.arms {
+                    let arm_proof =
+                        self.with_pattern_bindings(&arm.pat, &expr_match.expr, |this| {
+                            if let Some((_, guard)) = &arm.guard {
+                                this.visit_expr(guard);
+                            }
+                            this.visit_actor_plan_result_expr(&arm.body)
+                        });
+                    proof = proof.combine(arm_proof);
+                }
+                proof
+            }
+            syn::Expr::Try(try_expr) => self.visit_actor_plan_result_expr(&try_expr.expr),
+            syn::Expr::Await(await_expr) => self.visit_actor_plan_result_expr(&await_expr.base),
+            syn::Expr::Reference(reference) => self.visit_actor_plan_result_expr(&reference.expr),
+            syn::Expr::Paren(paren) => self.visit_actor_plan_result_expr(&paren.expr),
+            syn::Expr::Group(group) => self.visit_actor_plan_result_expr(&group.expr),
+            syn::Expr::MethodCall(call) if call.method == "map_err" => {
+                let proof = self.visit_actor_plan_result_expr(&call.receiver);
+                for arg in &call.args {
+                    self.visit_expr(arg);
+                }
+                proof
+            }
+            syn::Expr::MethodCall(call)
+                if self
+                    .facts
+                    .cas_methods
+                    .contains_key(&call.method.to_string()) =>
+            {
+                let ((), seen) = self.with_actor_plan_commit_marker(|this| {
+                    this.with_actor_plan_result_expr(|this| {
+                        this.visit_expr(expr);
+                    });
+                });
+                if seen {
+                    ActorPlanResultProof::authorized()
+                } else {
+                    ActorPlanResultProof::unauthorized()
+                }
+            }
+            syn::Expr::Call(call)
+                if expr_as_path(&call.func)
+                    .and_then(|path| path.segments.last())
+                    .is_some_and(|segment| {
+                        self.facts
+                            .cas_methods
+                            .contains_key(&segment.ident.to_string())
+                    }) =>
+            {
+                let ((), seen) = self.with_actor_plan_commit_marker(|this| {
+                    this.with_actor_plan_result_expr(|this| {
+                        this.visit_expr(expr);
+                    });
+                });
+                if seen {
+                    ActorPlanResultProof::authorized()
+                } else {
+                    ActorPlanResultProof::unauthorized()
+                }
+            }
+            _ if expr_static_bool_value(expr) == Some(false) => {
+                ActorPlanResultProof::static_false()
+            }
+            _ if expr_static_bool_value(expr) == Some(true) => {
+                self.visit_expr(expr);
+                ActorPlanResultProof::unauthorized()
+            }
+            _ => {
+                self.visit_expr(expr);
+                ActorPlanResultProof::unauthorized()
+            }
+        }
+    }
+
+    fn bind_local_names(&mut self, pat: &syn::Pat) {
+        let names = pat_bound_idents(pat);
+        if let Some(scope) = self.shadowed_name_scope_stack.last_mut() {
+            scope.extend(names.iter().cloned());
+        }
+        if let Some(scope) = self.typed_flow_outcome_scope_stack.last_mut() {
+            for name in &names {
+                scope.entry(name.clone()).or_insert(false);
+            }
+        }
+        if let Some(scope) = self.typed_flow_outcome_command_scope_stack.last_mut() {
+            for name in &names {
+                scope.entry(name.clone()).or_insert(None);
+            }
+        }
+        if let Some(scope) = self.typed_flow_outcome_identity_scope_stack.last_mut() {
+            for name in &names {
+                scope.entry(name.clone()).or_insert(None);
+            }
+        }
+        if let Some(scope) = self.typed_flow_next_state_scope_stack.last_mut() {
+            for name in &names {
+                scope.entry(name.clone()).or_insert(false);
+            }
+        }
+        if let Some(scope) = self.typed_flow_next_state_command_scope_stack.last_mut() {
+            for name in &names {
+                scope.entry(name.clone()).or_insert(None);
+            }
+        }
+        if let Some(scope) = self.typed_flow_next_state_identity_scope_stack.last_mut() {
+            for name in &names {
+                scope.entry(name.clone()).or_insert(None);
+            }
+        }
+        if let Some(scope) = self.flow_run_command_scope_stack.last_mut() {
+            for name in &names {
+                scope.entry(name.clone()).or_insert(false);
+            }
+        }
+        if let Some(scope) = self.flow_authority_token_scope_stack.last_mut() {
+            for name in &names {
+                scope.entry(name.clone()).or_insert(false);
+            }
+        }
+        if let Some(scope) = self.flow_authority_input_scope_stack.last_mut() {
+            for name in &names {
+                scope.entry(name.clone()).or_insert(None);
+            }
+        }
+        if let Some(scope) = self.flow_authority_input_identity_scope_stack.last_mut() {
+            for name in &names {
+                scope.entry(name.clone()).or_insert(None);
+            }
+        }
+        if let Some(scope) = self.actor_plan_authority_input_scope_stack.last_mut() {
+            for name in &names {
+                scope.entry(name.clone()).or_insert(false);
+            }
+        }
+        if let Some(scope) = self.projection_state_alias_stack.last_mut() {
+            for name in names {
+                scope.entry(name).or_insert(None);
+            }
+        }
+    }
+
+    fn with_deferred_expr<R>(&mut self, f: impl FnOnce(&mut Self) -> R) -> R {
+        self.deferred_expr_depth += 1;
+        let result = f(self);
+        self.deferred_expr_depth -= 1;
+        result
+    }
+
+    fn record_direct_use(
+        &mut self,
+        kind: FlowDirectUse,
+        line: usize,
+        position: SourcePosition,
+        source_path: &syn::Path,
+        call: Option<&syn::ExprCall>,
+    ) {
+        if self.direct_use_allowed(kind, position, call) {
+            return;
+        }
+        let source_segments = path_segments(source_path);
+        let source_label = source_segments.join("::");
+        match kind {
+            FlowDirectUse::Transition { .. } if source_segments.len() == 1 => {
+                self.mismatches.push(format!(
+                    "direct live-flow reducer transition alias `{source_label}` is not MobMachine-command gated: {}:{line}",
+                    self.rel
+                ));
+            }
+            FlowDirectUse::Transition { .. } => {
+                self.mismatches.push(format!(
+                    "direct live-flow reducer transition `{source_label}(` is not MobMachine-command gated: {}:{line}",
+                    self.rel
+                ));
+            }
+            FlowDirectUse::Input { .. }
+                if source_segments
+                    .first()
+                    .is_some_and(|segment| FlowReducerFamily::from_module(segment).is_none()) =>
+            {
+                let alias = source_segments
+                    .first()
+                    .map(String::as_str)
+                    .unwrap_or(source_label.as_str());
+                self.mismatches.push(format!(
+                    "direct live-flow reducer input alias `{alias}` is not MobMachine-command gated: {}:{line}",
+                    self.rel
+                ));
+            }
+            FlowDirectUse::Input { .. } => {
+                self.mismatches.push(format!(
+                    "direct live-flow reducer input `{source_label}` is not MobMachine-command gated: {}:{line}",
+                    self.rel
+                ));
+            }
+        }
+    }
+
+    fn direct_use_allowed(
+        &self,
+        kind: FlowDirectUse,
+        position: SourcePosition,
+        call: Option<&syn::ExprCall>,
+    ) -> bool {
+        if self.rel != "meerkat-mob/src/run.rs" {
+            return false;
+        }
+        let Some(function) = self.current_function() else {
+            return false;
+        };
+        if self.deferred_expr_depth > 0 {
+            return false;
+        }
+        match kind {
+            FlowDirectUse::Transition { canonical, .. }
+            | FlowDirectUse::Input { canonical, .. }
+                if !canonical =>
+            {
+                return false;
+            }
+            _ => {}
+        }
+        if function.module_depth != 0 {
+            return false;
+        }
+        match kind {
+            FlowDirectUse::Transition { family, .. } => {
+                let command_vars = if family == FlowReducerFamily::FlowRun {
+                    self.visible_flow_run_command_vars()
+                } else {
+                    self.visible_parameter_names(family.command_type())
+                };
+                let Some(command_var) =
+                    call.and_then(|call| transition_call_command_input_var(call, &command_vars))
+                else {
+                    return false;
+                };
+                function.name == family.apply_function()
+                    && self.has_visible_parameter_type(family.command_type())
+                    && self.has_visible_parameter_type("MobMachineFlowAuthorityToken")
+                    && function
+                        .authority_requirements
+                        .get(&family)
+                        .and_then(|requirements| requirements.get(&command_var))
+                        .is_some_and(|required_position| *required_position < position)
+            }
+            FlowDirectUse::Input { family, .. } => {
+                function.name == "into_input"
+                    && function.impl_type.as_deref() == Some(family.command_type())
+                    && function
+                        .return_path
+                        .as_ref()
+                        .is_some_and(|path| path_has_tail(path, &[family.module(), "Input"]))
+            }
+        }
+    }
+
+    fn actor_store_plan_commit_allowed(
+        &self,
+        node: &syn::ExprMethodCall,
+        cas_facts: &ProjectionCasMethodFacts,
+    ) -> bool {
+        if self.deferred_expr_depth > 0 {
+            return false;
+        }
+        if self.actor_plan_result_expr_depth == 0 {
+            return false;
+        }
+        let Some(function) = self.current_function() else {
+            return false;
+        };
+        if function.name != "commit_flow_frame_store_plan_in_actor" {
+            return false;
+        }
+        if function.module_depth != 0 {
+            return false;
+        }
+        if !function
+            .impl_type_path
+            .as_deref()
+            .is_some_and(path_is_root_mob_actor_impl)
+        {
+            return false;
+        }
+        if !expr_is_self_run_store_receiver(&node.receiver) {
+            return false;
+        }
+        let Some(plan_arm) = self.current_actor_plan_arm() else {
+            return false;
+        };
+        let plan_bindings = &plan_arm.bindings;
+        if !cas_facts.authority_identity_arg_indices.is_empty() {
+            let run_id_parameters = self.visible_parameter_names("RunId");
+            let Some(authority_run_id) = run_id_parameters.iter().next() else {
+                return false;
+            };
+            if plan_arm.bindings.contains(authority_run_id)
+                || run_id_parameters.len() != 1
+                || !cas_facts
+                    .authority_identity_arg_indices
+                    .iter()
+                    .all(|index| {
+                        node.args.iter().nth(*index).is_some_and(|arg| {
+                            expr_identity_argument_name(arg)
+                                .as_ref()
+                                .is_some_and(|name| name == authority_run_id)
+                        })
+                    })
+            {
+                return false;
+            }
+        }
+        if cas_facts.plan_state_arg_indices.is_empty()
+            || !cas_facts.plan_state_arg_indices.iter().all(|index| {
+                node.args.iter().nth(*index).is_some_and(|arg| {
+                    expr_variable_name(arg, plan_bindings)
+                        .as_ref()
+                        .is_some_and(|name| !self.name_is_shadowed(name))
+                })
+            })
+        {
+            return false;
+        }
+        let plan_authority_inputs = self.visible_actor_plan_authority_input_vars();
+        if !cas_facts.plan_owned_arg_indices.iter().all(|index| {
+            node.args.iter().nth(*index).is_some_and(|arg| {
+                self.expr_is_actor_plan_owned_arg(arg, plan_bindings, &plan_authority_inputs)
+            })
+        }) {
+            return false;
+        }
+        if !self.actor_plan_variant_commit_method_allowed(node, plan_arm) {
+            return false;
+        }
+        if !self.actor_plan_cas_args_match_variant_fields(node, cas_facts, plan_arm) {
+            return false;
+        }
+        if !self.actor_plan_variant_fields_are_consumed(node, cas_facts, plan_arm) {
+            return false;
+        }
+        let Some(match_result_var) = self.current_actor_plan_match_result_var() else {
+            return false;
+        };
+        let position = source_position(node);
+        let Some(freshness_position) = function.plan_freshness_check_position else {
+            return false;
+        };
+        function
+            .prepared_plan_input_vars
+            .iter()
+            .any(|(var, prepared_position)| {
+                freshness_position < *prepared_position
+                    && *prepared_position < position
+                    && function
+                        .committed_prepared_input_vars
+                        .get(var)
+                        .is_some_and(|commit| {
+                            commit.position > position
+                                && commit.guard_var.as_deref() == Some(match_result_var)
+                        })
+            })
+    }
+
+    fn expr_is_actor_plan_owned_arg(
+        &self,
+        expr: &syn::Expr,
+        plan_bindings: &BTreeSet<String>,
+        plan_authority_inputs: &BTreeSet<String>,
+    ) -> bool {
+        if expr_is_none_constructor(expr, self.current_aliases()) {
+            return true;
+        }
+        if expr_variable_name(expr, plan_bindings)
+            .as_ref()
+            .is_some_and(|name| !self.name_is_shadowed(name))
+        {
+            return true;
+        }
+        if expr_variable_name(expr, plan_authority_inputs).is_some() {
+            return true;
+        }
+        if self.expr_is_actor_plan_machine_inputs_value(expr, plan_authority_inputs) {
+            return true;
+        }
+        match expr {
+            syn::Expr::Call(call) => {
+                expr_as_path(&call.func).is_some_and(|path| {
+                    path.segments
+                        .last()
+                        .is_some_and(|segment| segment.ident == "Some")
+                }) && call.args.iter().all(|arg| {
+                    self.expr_is_actor_plan_owned_arg(arg, plan_bindings, plan_authority_inputs)
+                })
+            }
+            syn::Expr::Tuple(tuple) => tuple.elems.iter().all(|elem| {
+                self.expr_is_actor_plan_owned_arg(elem, plan_bindings, plan_authority_inputs)
+            }),
+            syn::Expr::MethodCall(call) if call.method == "map" => {
+                if !self.expr_is_actor_plan_owned_arg(
+                    &call.receiver,
+                    plan_bindings,
+                    plan_authority_inputs,
+                ) {
+                    return false;
+                }
+                let Some(syn::Expr::Closure(closure)) = call.args.first() else {
+                    return false;
+                };
+                let mut closure_plan_bindings = plan_bindings.clone();
+                for input in &closure.inputs {
+                    closure_plan_bindings.extend(pat_bound_idents(input));
+                }
+                self.expr_is_actor_plan_owned_arg(
+                    &closure.body,
+                    &closure_plan_bindings,
+                    plan_authority_inputs,
+                )
+            }
+            syn::Expr::MethodCall(call)
+                if matches!(
+                    call.method.to_string().as_str(),
+                    "clone" | "as_ref" | "to_vec" | "cloned" | "copied"
+                ) =>
+            {
+                self.expr_is_actor_plan_owned_arg(
+                    &call.receiver,
+                    plan_bindings,
+                    plan_authority_inputs,
+                )
+            }
+            syn::Expr::Unary(unary) if matches!(unary.op, syn::UnOp::Deref(_)) => {
+                self.expr_is_actor_plan_owned_arg(&unary.expr, plan_bindings, plan_authority_inputs)
+            }
+            syn::Expr::Reference(reference) => self.expr_is_actor_plan_owned_arg(
+                &reference.expr,
+                plan_bindings,
+                plan_authority_inputs,
+            ),
+            syn::Expr::Paren(paren) => {
+                self.expr_is_actor_plan_owned_arg(&paren.expr, plan_bindings, plan_authority_inputs)
+            }
+            syn::Expr::Group(group) => {
+                self.expr_is_actor_plan_owned_arg(&group.expr, plan_bindings, plan_authority_inputs)
+            }
+            syn::Expr::Try(try_expr) => self.expr_is_actor_plan_owned_arg(
+                &try_expr.expr,
+                plan_bindings,
+                plan_authority_inputs,
+            ),
+            syn::Expr::Await(await_expr) => self.expr_is_actor_plan_owned_arg(
+                &await_expr.base,
+                plan_bindings,
+                plan_authority_inputs,
+            ),
+            _ => false,
+        }
+    }
+
+    fn actor_plan_variant_fields_are_consumed(
+        &self,
+        node: &syn::ExprMethodCall,
+        cas_facts: &ProjectionCasMethodFacts,
+        plan_arm: &ActorPlanArmFacts,
+    ) -> bool {
+        let Some(variant) = actor_plan_single_variant(plan_arm) else {
+            return false;
+        };
+        let Some(required_fields) = self.facts.store_plan_variant_fields.get(&variant) else {
+            return false;
+        };
+        let consumed = cas_facts
+            .plan_owned_arg_indices
+            .iter()
+            .filter_map(|index| node.args.iter().nth(*index))
+            .flat_map(expr_root_idents_through_calls)
+            .filter(|name| !self.name_is_shadowed(name))
+            .collect::<BTreeSet<_>>();
+
+        required_fields.iter().all(|field| {
+            plan_arm
+                .field_bindings
+                .get(field)
+                .is_some_and(|bindings| bindings.iter().any(|binding| consumed.contains(binding)))
+        })
+    }
+
+    fn actor_plan_variant_commit_method_allowed(
+        &self,
+        node: &syn::ExprMethodCall,
+        plan_arm: &ActorPlanArmFacts,
+    ) -> bool {
+        let Some(variant) = actor_plan_single_variant(plan_arm) else {
+            return false;
+        };
+        self.facts
+            .store_plan_variant_commit_methods
+            .get(&variant)
+            .is_some_and(|methods| methods.contains(&node.method.to_string()))
+    }
+
+    fn actor_plan_cas_args_match_variant_fields(
+        &self,
+        node: &syn::ExprMethodCall,
+        cas_facts: &ProjectionCasMethodFacts,
+        plan_arm: &ActorPlanArmFacts,
+    ) -> bool {
+        let Some(variant) = actor_plan_single_variant(plan_arm) else {
+            return false;
+        };
+        let Some(required_fields) = self.facts.store_plan_variant_fields.get(&variant) else {
+            return false;
+        };
+        if variant == "InsertFrame"
+            && let Some((expected_index, _)) = cas_facts
+                .arg_names
+                .iter()
+                .find(|(_, arg_name)| arg_name.as_str() == "expected")
+            && !node
+                .args
+                .iter()
+                .nth(*expected_index)
+                .is_some_and(|arg| expr_is_none_constructor(arg, self.current_aliases()))
+        {
+            return false;
+        }
+        cas_facts
+            .arg_names
+            .iter()
+            .filter(|(_, arg_name)| {
+                arg_name.as_str() != "run_id" && arg_name.as_str() != "authority_inputs"
+            })
+            .all(|(index, arg_name)| {
+                let Some(field) = actor_plan_field_for_cas_arg(arg_name.as_str(), required_fields)
+                else {
+                    return true;
+                };
+                let Some(arg) = node.args.iter().nth(*index) else {
+                    return false;
+                };
+                let consumed = expr_root_idents_through_calls(arg)
+                    .into_iter()
+                    .filter(|name| !self.name_is_shadowed(name))
+                    .collect::<BTreeSet<_>>();
+                plan_arm.field_bindings.get(&field).is_some_and(|bindings| {
+                    bindings.iter().any(|binding| consumed.contains(binding))
+                })
+            })
+    }
+
+    fn path_resolves_to_canonical_flow_run_apply(&self, path: &syn::Path) -> bool {
+        let segments = path_segments(path);
+        if segments.len() == 1
+            && segments
+                .first()
+                .is_some_and(|name| self.name_is_shadowed(name))
+        {
+            return false;
+        }
+        self.current_aliases()
+            .resolve_path(path)
+            .into_iter()
+            .any(|resolved| resolved_path_is_canonical_flow_run_apply(&resolved))
+    }
+
+    fn block_shadows_flow_apply_command_provenance(&self, block: &syn::Block) -> bool {
+        let mut protected = self.visible_flow_run_command_vars();
+        protected.extend(self.visible_flow_authority_token_vars());
+        block_shadows_names(block, &protected)
+    }
+
+    fn block_shadows_flow_apply_identity_provenance(&self, block: &syn::Block) -> bool {
+        block_shadows_names(block, &self.visible_parameter_names("RunId"))
+    }
+
+    fn expr_canonical_flow_run_apply_command_var(&self, expr: &syn::Expr) -> Option<String> {
+        match expr {
+            syn::Expr::Call(call) => {
+                let path = expr_as_path(&call.func)?;
+                if !self.path_resolves_to_canonical_flow_run_apply(path) {
+                    return None;
+                }
+                let command_vars = self.visible_flow_run_command_vars();
+                let authority_vars = self.visible_flow_authority_token_vars();
+                if authority_vars.is_empty()
+                    || !call
+                        .args
+                        .iter()
+                        .any(|arg| expr_variable_name(arg, &authority_vars).is_some())
+                {
+                    return None;
+                }
+                call.args
+                    .iter()
+                    .find_map(|arg| expr_variable_name(arg, &command_vars))
+            }
+            syn::Expr::MethodCall(call) if call.method == "map_err" => {
+                self.expr_canonical_flow_run_apply_command_var(&call.receiver)
+            }
+            syn::Expr::Try(try_expr) => {
+                self.expr_canonical_flow_run_apply_command_var(&try_expr.expr)
+            }
+            syn::Expr::Await(await_expr) => {
+                self.expr_canonical_flow_run_apply_command_var(&await_expr.base)
+            }
+            syn::Expr::Reference(reference) => {
+                self.expr_canonical_flow_run_apply_command_var(&reference.expr)
+            }
+            syn::Expr::Paren(paren) => self.expr_canonical_flow_run_apply_command_var(&paren.expr),
+            syn::Expr::Group(group) => self.expr_canonical_flow_run_apply_command_var(&group.expr),
+            syn::Expr::Block(block) => {
+                if self.block_shadows_flow_apply_command_provenance(&block.block) {
+                    return None;
+                }
+                block
+                    .block
+                    .stmts
+                    .last()
+                    .and_then(|stmt| self.stmt_canonical_flow_run_apply_command_var(stmt))
+            }
+            _ => None,
+        }
+    }
+
+    fn expr_canonical_flow_run_apply_identity_var(&self, expr: &syn::Expr) -> Option<String> {
+        match expr {
+            syn::Expr::Call(call) => {
+                let path = expr_as_path(&call.func)?;
+                if !self.path_resolves_to_canonical_flow_run_apply(path) {
+                    return None;
+                }
+                let run_id_vars = self.visible_parameter_names("RunId");
+                call.args.iter().find_map(|arg| {
+                    expr_identity_argument_name(arg).filter(|name| run_id_vars.contains(name))
+                })
+            }
+            syn::Expr::MethodCall(call) if call.method == "map_err" => {
+                self.expr_canonical_flow_run_apply_identity_var(&call.receiver)
+            }
+            syn::Expr::Try(try_expr) => {
+                self.expr_canonical_flow_run_apply_identity_var(&try_expr.expr)
+            }
+            syn::Expr::Await(await_expr) => {
+                self.expr_canonical_flow_run_apply_identity_var(&await_expr.base)
+            }
+            syn::Expr::Reference(reference) => {
+                self.expr_canonical_flow_run_apply_identity_var(&reference.expr)
+            }
+            syn::Expr::Paren(paren) => self.expr_canonical_flow_run_apply_identity_var(&paren.expr),
+            syn::Expr::Group(group) => self.expr_canonical_flow_run_apply_identity_var(&group.expr),
+            syn::Expr::Block(block) => {
+                if self.block_shadows_flow_apply_identity_provenance(&block.block) {
+                    return None;
+                }
+                block
+                    .block
+                    .stmts
+                    .last()
+                    .and_then(|stmt| self.stmt_canonical_flow_run_apply_identity_var(stmt))
+            }
+            _ => None,
+        }
+    }
+
+    fn expr_canonical_flow_run_apply_next_state_command_var(
+        &self,
+        expr: &syn::Expr,
+    ) -> Option<String> {
+        match expr {
+            syn::Expr::Field(field) => {
+                if matches!(&field.member, syn::Member::Named(ident) if ident == "next_state") {
+                    self.expr_canonical_flow_run_apply_command_var(&field.base)
+                } else {
+                    None
+                }
+            }
+            syn::Expr::MethodCall(call) if call.method == "clone" => {
+                self.expr_canonical_flow_run_apply_next_state_command_var(&call.receiver)
+            }
+            syn::Expr::Try(try_expr) => {
+                self.expr_canonical_flow_run_apply_next_state_command_var(&try_expr.expr)
+            }
+            syn::Expr::Await(await_expr) => {
+                self.expr_canonical_flow_run_apply_next_state_command_var(&await_expr.base)
+            }
+            syn::Expr::Reference(reference) => {
+                self.expr_canonical_flow_run_apply_next_state_command_var(&reference.expr)
+            }
+            syn::Expr::Paren(paren) => {
+                self.expr_canonical_flow_run_apply_next_state_command_var(&paren.expr)
+            }
+            syn::Expr::Group(group) => {
+                self.expr_canonical_flow_run_apply_next_state_command_var(&group.expr)
+            }
+            _ => None,
+        }
+    }
+
+    fn expr_canonical_flow_run_apply_next_state_identity_var(
+        &self,
+        expr: &syn::Expr,
+    ) -> Option<String> {
+        match expr {
+            syn::Expr::Field(field) => {
+                if matches!(&field.member, syn::Member::Named(ident) if ident == "next_state") {
+                    self.expr_canonical_flow_run_apply_identity_var(&field.base)
+                } else {
+                    None
+                }
+            }
+            syn::Expr::MethodCall(call) if call.method == "clone" => {
+                self.expr_canonical_flow_run_apply_next_state_identity_var(&call.receiver)
+            }
+            syn::Expr::Try(try_expr) => {
+                self.expr_canonical_flow_run_apply_next_state_identity_var(&try_expr.expr)
+            }
+            syn::Expr::Await(await_expr) => {
+                self.expr_canonical_flow_run_apply_next_state_identity_var(&await_expr.base)
+            }
+            syn::Expr::Reference(reference) => {
+                self.expr_canonical_flow_run_apply_next_state_identity_var(&reference.expr)
+            }
+            syn::Expr::Paren(paren) => {
+                self.expr_canonical_flow_run_apply_next_state_identity_var(&paren.expr)
+            }
+            syn::Expr::Group(group) => {
+                self.expr_canonical_flow_run_apply_next_state_identity_var(&group.expr)
+            }
+            _ => None,
+        }
+    }
+
+    fn stmt_canonical_flow_run_apply_command_var(&self, stmt: &syn::Stmt) -> Option<String> {
+        match stmt {
+            syn::Stmt::Expr(expr, None) => self.expr_canonical_flow_run_apply_command_var(expr),
+            syn::Stmt::Local(_) | syn::Stmt::Expr(_, Some(_)) => None,
+            syn::Stmt::Item(_) | syn::Stmt::Macro(_) => None,
+        }
+    }
+
+    fn stmt_canonical_flow_run_apply_identity_var(&self, stmt: &syn::Stmt) -> Option<String> {
+        match stmt {
+            syn::Stmt::Expr(expr, None) => self.expr_canonical_flow_run_apply_identity_var(expr),
+            syn::Stmt::Local(_) | syn::Stmt::Expr(_, Some(_)) => None,
+            syn::Stmt::Item(_) | syn::Stmt::Macro(_) => None,
+        }
+    }
+
+    fn flow_runtime_cas_receiver_allowed(&self, receiver: &syn::Expr) -> bool {
+        match self.rel {
+            "meerkat-mob/src/runtime/flow.rs" | "meerkat-mob/src/runtime/builder.rs" => {
+                expr_is_self_run_store_receiver(receiver)
+                    || self.expr_is_visible_mob_run_store_parameter_receiver(receiver)
+            }
+            _ => false,
+        }
+    }
+
+    fn expr_is_visible_mob_run_store_parameter_receiver(&self, receiver: &syn::Expr) -> bool {
+        match receiver {
+            syn::Expr::Path(_) | syn::Expr::Paren(_) | syn::Expr::Group(_) => {
+                expr_path_single_ident(receiver)
+                    .as_ref()
+                    .is_some_and(|name| self.visible_parameter_names("MobRunStore").contains(name))
+            }
+            syn::Expr::Reference(reference) => {
+                self.expr_is_visible_mob_run_store_parameter_receiver(&reference.expr)
+            }
+            syn::Expr::Unary(unary) if matches!(unary.op, syn::UnOp::Deref(_)) => {
+                self.expr_is_visible_mob_run_store_parameter_receiver(&unary.expr)
+            }
+            _ => false,
+        }
+    }
+
+    fn projection_commit_allowed(&self, node: &syn::ExprMethodCall) -> bool {
+        if self.current_function().is_none() {
+            return false;
+        }
+        if self.deferred_expr_depth > 0 {
+            return false;
+        }
+        let method = node.method.to_string();
+        let Some(cas_facts) = self.facts.cas_methods.get(&method) else {
+            return false;
+        };
+        match self.rel {
+            "meerkat-mob/src/runtime/flow.rs" | "meerkat-mob/src/runtime/builder.rs" => {
+                if cas_facts.authority_input_arg_indices.is_empty()
+                    || !self.flow_runtime_cas_receiver_allowed(&node.receiver)
+                {
+                    return false;
+                }
+                let typed_identity_var = method_call_typed_next_state_identity_var(
+                    node,
+                    cas_facts,
+                    &self.visible_typed_flow_outcome_identity_vars(),
+                    &self.visible_typed_flow_next_state_identity_vars(),
+                );
+                method_call_typed_next_state_command_var(
+                    node,
+                    cas_facts,
+                    &self.visible_typed_flow_outcome_command_vars(),
+                    &self.visible_typed_flow_next_state_command_vars(),
+                )
+                .as_ref()
+                .is_some_and(|command| {
+                    method_call_uses_matching_typed_flow_identity(
+                        node,
+                        cas_facts,
+                        typed_identity_var.as_deref(),
+                    ) && method_call_uses_matching_flow_authority_input(
+                        node,
+                        cas_facts,
+                        command,
+                        &self.visible_flow_authority_input_command_vars(),
+                        &self.visible_flow_authority_input_identity_vars(),
+                        &self.visible_flow_run_command_vars(),
+                    )
+                })
+            }
+            "meerkat-mob/src/runtime/actor.rs" => {
+                if cas_facts.authority_input_arg_indices.is_empty() {
+                    return false;
+                }
+                self.actor_store_plan_commit_allowed(node, cas_facts)
+            }
+            _ => false,
+        }
+    }
+
+    fn projection_call_allowed(&self, node: &syn::ExprCall) -> bool {
+        if self.current_function().is_none() {
+            return false;
+        }
+        if self.deferred_expr_depth > 0 {
+            return false;
+        }
+        let Some(path) = expr_as_path(&node.func) else {
+            return false;
+        };
+        let Some(method) = path
+            .segments
+            .last()
+            .map(|segment| segment.ident.to_string())
+        else {
+            return false;
+        };
+        let Some(cas_facts) = self.facts.cas_methods.get(&method) else {
+            return false;
+        };
+        if !path_is_canonical_mob_run_store_cas_call(path, self.current_aliases(), &method) {
+            return false;
+        }
+        if cas_facts.authority_input_arg_indices.is_empty() {
+            return false;
+        }
+        if path.segments.len() > 1
+            && !node
+                .args
+                .first()
+                .is_some_and(|receiver| self.flow_runtime_cas_receiver_allowed(receiver))
+        {
+            return false;
+        }
+        matches!(self.rel, "meerkat-mob/src/runtime/flow.rs")
+            && self.has_visible_parameter_type("MobMachineFlowRunCommand")
+            && self.has_visible_parameter_type("MobMachineFlowAuthorityToken")
+            && {
+                let typed_identity_var = call_typed_next_state_identity_var(
+                    node,
+                    path,
+                    cas_facts,
+                    &self.visible_typed_flow_outcome_identity_vars(),
+                    &self.visible_typed_flow_next_state_identity_vars(),
+                );
+                call_typed_next_state_command_var(
+                    node,
+                    path,
+                    cas_facts,
+                    &self.visible_typed_flow_outcome_command_vars(),
+                    &self.visible_typed_flow_next_state_command_vars(),
+                )
+                .as_ref()
+                .is_some_and(|command| {
+                    call_uses_matching_typed_flow_identity(
+                        node,
+                        path,
+                        cas_facts,
+                        typed_identity_var.as_deref(),
+                    ) && call_uses_matching_flow_authority_input(
+                        node,
+                        path,
+                        cas_facts,
+                        command,
+                        &self.visible_flow_authority_input_command_vars(),
+                        &self.visible_flow_authority_input_identity_vars(),
+                        &self.visible_flow_run_command_vars(),
+                    )
+                })
+            }
+    }
+
+    fn direct_use_from_path(&self, path: &syn::Path) -> Option<FlowDirectUse> {
+        let shadowed_root = self.current_aliases().path_has_shadowed_bare_root(path);
+        self.current_aliases()
+            .resolve_path(path)
+            .into_iter()
+            .find_map(|segments| {
+                FlowReducerFamily::from_transition_path(&segments)
+                    .map(|(family, canonical)| FlowDirectUse::Transition {
+                        family,
+                        canonical: canonical && !shadowed_root,
+                    })
+                    .or_else(|| {
+                        FlowReducerFamily::from_input_path(&segments).map(|(family, canonical)| {
+                            FlowDirectUse::Input {
+                                family,
+                                canonical: canonical && !shadowed_root,
+                            }
+                        })
+                    })
+            })
+    }
+
+    fn projection_field_token(&self, expr: &syn::Expr) -> Option<String> {
+        let chain = expr_field_chain(expr);
+        projection_field_token_from_chain(&chain, "flow_state", &self.facts.flow_state_fields)
+            .or_else(|| {
+                projection_field_token_from_chain(
+                    &chain,
+                    "kernel_state",
+                    &self.facts.frame_state_fields,
+                )
+            })
+            .or_else(|| {
+                let alias = chain.first()?;
+                let field = chain.get(1)?;
+                match self.visible_projection_state_alias(alias) {
+                    Some("flow_state") if self.facts.flow_state_fields.contains(field) => {
+                        Some(format!(".flow_state.{field}"))
+                    }
+                    Some("kernel_state") if self.facts.frame_state_fields.contains(field) => {
+                        Some(format!(".kernel_state.{field}"))
+                    }
+                    _ => None,
+                }
+            })
+    }
+
+    fn projection_state_token(&self, expr: &syn::Expr) -> Option<String> {
+        let chain = expr_field_chain(expr);
+        projection_state_token_from_chain(&chain)
+            .map(ToOwned::to_owned)
+            .or_else(|| {
+                if chain.len() == 1 {
+                    chain
+                        .first()
+                        .and_then(|alias| self.visible_projection_state_alias(alias))
+                        .map(|state| format!(".{state}"))
+                } else {
+                    None
+                }
+            })
+    }
+
+    fn projection_write_token(&self, expr: &syn::Expr) -> Option<String> {
+        self.projection_field_token(expr).or_else(|| {
+            self.whole_projection_state_write_forbidden()
+                .then(|| self.projection_state_token(expr))
+                .flatten()
+        })
+    }
+
+    fn whole_projection_state_write_forbidden(&self) -> bool {
+        self.rel.starts_with("meerkat-mob/src/runtime/")
+    }
+
+    fn projection_state_field_from_struct_pattern(
+        &self,
+        pat_struct: &syn::PatStruct,
+        field: &str,
+    ) -> Option<&'static str> {
+        let resolved_paths = self.current_aliases().resolve_path(&pat_struct.path);
+        match field {
+            "flow_state"
+                if resolved_paths
+                    .iter()
+                    .any(|path| path_is_canonical_mob_run_projection_owner(path)) =>
+            {
+                Some("flow_state")
+            }
+            "kernel_state"
+                if resolved_paths
+                    .iter()
+                    .any(|path| path_is_canonical_kernel_snapshot_projection_owner(path)) =>
+            {
+                Some("kernel_state")
+            }
+            _ => None,
+        }
+    }
+
+    fn projection_state_alias_from_expr(&self, expr: &syn::Expr) -> Option<String> {
+        if let Some(field) = projection_state_alias_from_expr(expr) {
+            return Some(field.to_string());
+        }
+        let chain = expr_field_chain(expr);
+        if chain.len() == 1 {
+            chain
+                .first()
+                .and_then(|alias| self.visible_projection_state_alias(alias))
+                .map(ToOwned::to_owned)
+        } else {
+            None
+        }
+    }
+
+    fn collect_projection_alias_bindings(
+        &self,
+        pat: &syn::Pat,
+        expr: &syn::Expr,
+        bindings: &mut BTreeMap<String, Option<String>>,
+    ) {
+        match (pat, expr) {
+            (syn::Pat::Ident(ident), expr) => {
+                bindings.insert(
+                    ident.ident.to_string(),
+                    self.projection_state_alias_from_expr(expr),
+                );
+            }
+            (syn::Pat::Tuple(pat_tuple), syn::Expr::Tuple(expr_tuple)) => {
+                for (pat, expr) in pat_tuple.elems.iter().zip(&expr_tuple.elems) {
+                    self.collect_projection_alias_bindings(pat, expr, bindings);
+                }
+            }
+            (syn::Pat::TupleStruct(pat_tuple), syn::Expr::Tuple(expr_tuple)) => {
+                for (pat, expr) in pat_tuple.elems.iter().zip(&expr_tuple.elems) {
+                    self.collect_projection_alias_bindings(pat, expr, bindings);
+                }
+            }
+            (syn::Pat::Struct(pat_struct), syn::Expr::Struct(expr_struct)) => {
+                let expr_fields = expr_struct
+                    .fields
+                    .iter()
+                    .map(|field| (member_key(&field.member), &field.expr))
+                    .collect::<BTreeMap<_, _>>();
+                for field in &pat_struct.fields {
+                    let key = member_key(&field.member);
+                    if let Some(expr) = expr_fields.get(&key) {
+                        self.collect_projection_alias_bindings(&field.pat, expr, bindings);
+                    }
+                }
+            }
+            (syn::Pat::Struct(pat_struct), _) => {
+                for field in &pat_struct.fields {
+                    let key = member_key(&field.member);
+                    let Some(state_field) =
+                        self.projection_state_field_from_struct_pattern(pat_struct, &key)
+                    else {
+                        continue;
+                    };
+                    for name in pat_bound_idents(&field.pat) {
+                        bindings.insert(name, Some(state_field.to_string()));
+                    }
+                }
+            }
+            (syn::Pat::Slice(pat_slice), syn::Expr::Array(expr_array)) => {
+                for (pat, expr) in pat_slice.elems.iter().zip(&expr_array.elems) {
+                    self.collect_projection_alias_bindings(pat, expr, bindings);
+                }
+            }
+            (syn::Pat::Paren(paren), expr) => {
+                self.collect_projection_alias_bindings(&paren.pat, expr, bindings);
+            }
+            (syn::Pat::Reference(reference), expr) => {
+                self.collect_projection_alias_bindings(&reference.pat, expr, bindings);
+            }
+            (syn::Pat::Type(ty), expr) => {
+                self.collect_projection_alias_bindings(&ty.pat, expr, bindings);
+            }
+            (pat, syn::Expr::Reference(reference)) => {
+                self.collect_projection_alias_bindings(pat, &reference.expr, bindings);
+            }
+            (pat, syn::Expr::Paren(paren)) => {
+                self.collect_projection_alias_bindings(pat, &paren.expr, bindings);
+            }
+            (pat, syn::Expr::Group(group)) => {
+                self.collect_projection_alias_bindings(pat, &group.expr, bindings);
+            }
+            _ => {}
+        }
+    }
+
+    fn push_pattern_scope(&mut self) {
+        self.typed_flow_outcome_scope_stack.push(BTreeMap::new());
+        self.typed_flow_outcome_command_scope_stack
+            .push(BTreeMap::new());
+        self.typed_flow_outcome_identity_scope_stack
+            .push(BTreeMap::new());
+        self.typed_flow_next_state_scope_stack.push(BTreeMap::new());
+        self.typed_flow_next_state_command_scope_stack
+            .push(BTreeMap::new());
+        self.typed_flow_next_state_identity_scope_stack
+            .push(BTreeMap::new());
+        self.flow_run_command_scope_stack.push(BTreeMap::new());
+        self.flow_authority_token_scope_stack.push(BTreeMap::new());
+        self.flow_authority_input_scope_stack.push(BTreeMap::new());
+        self.flow_authority_input_identity_scope_stack
+            .push(BTreeMap::new());
+        self.actor_plan_authority_input_scope_stack
+            .push(BTreeMap::new());
+        self.projection_state_alias_stack.push(BTreeMap::new());
+        self.shadowed_name_scope_stack.push(BTreeSet::new());
+    }
+
+    fn pop_pattern_scope(&mut self) {
+        let _ = self.shadowed_name_scope_stack.pop();
+        let _ = self.projection_state_alias_stack.pop();
+        let _ = self.actor_plan_authority_input_scope_stack.pop();
+        let _ = self.flow_authority_input_identity_scope_stack.pop();
+        let _ = self.flow_authority_input_scope_stack.pop();
+        let _ = self.flow_authority_token_scope_stack.pop();
+        let _ = self.flow_run_command_scope_stack.pop();
+        let _ = self.typed_flow_next_state_identity_scope_stack.pop();
+        let _ = self.typed_flow_next_state_command_scope_stack.pop();
+        let _ = self.typed_flow_next_state_scope_stack.pop();
+        let _ = self.typed_flow_outcome_identity_scope_stack.pop();
+        let _ = self.typed_flow_outcome_command_scope_stack.pop();
+        let _ = self.typed_flow_outcome_scope_stack.pop();
+    }
+
+    fn with_pattern_bindings<R>(
+        &mut self,
+        pat: &syn::Pat,
+        expr: &syn::Expr,
+        f: impl FnOnce(&mut Self) -> R,
+    ) -> R {
+        self.push_pattern_scope();
+        self.bind_local_names(pat);
+        let mut alias_bindings = BTreeMap::new();
+        self.collect_projection_alias_bindings(pat, expr, &mut alias_bindings);
+        if let Some(aliases) = self.projection_state_alias_stack.last_mut() {
+            aliases.extend(alias_bindings);
+        }
+        let result = f(self);
+        self.pop_pattern_scope();
+        result
+    }
+}
+
+impl<'ast> Visit<'ast> for FlowGovernanceVisitor<'_> {
+    fn visit_block(&mut self, node: &'ast syn::Block) {
+        let local_aliases = self.current_aliases().with_block_aliases(node);
+        self.alias_stack.push(local_aliases);
+        self.typed_flow_outcome_scope_stack.push(BTreeMap::new());
+        self.typed_flow_outcome_command_scope_stack
+            .push(BTreeMap::new());
+        self.typed_flow_outcome_identity_scope_stack
+            .push(BTreeMap::new());
+        self.typed_flow_next_state_scope_stack.push(BTreeMap::new());
+        self.typed_flow_next_state_command_scope_stack
+            .push(BTreeMap::new());
+        self.typed_flow_next_state_identity_scope_stack
+            .push(BTreeMap::new());
+        self.flow_run_command_scope_stack.push(BTreeMap::new());
+        self.flow_authority_token_scope_stack.push(BTreeMap::new());
+        self.flow_authority_input_scope_stack.push(BTreeMap::new());
+        self.flow_authority_input_identity_scope_stack
+            .push(BTreeMap::new());
+        self.actor_plan_authority_input_scope_stack
+            .push(BTreeMap::new());
+        self.projection_state_alias_stack.push(BTreeMap::new());
+        self.shadowed_name_scope_stack
+            .push(block_item_function_names(node));
+        for stmt in &node.stmts {
+            self.visit_stmt(stmt);
+        }
+        let _ = self.shadowed_name_scope_stack.pop();
+        let _ = self.projection_state_alias_stack.pop();
+        let _ = self.actor_plan_authority_input_scope_stack.pop();
+        let _ = self.flow_authority_input_identity_scope_stack.pop();
+        let _ = self.flow_authority_input_scope_stack.pop();
+        let _ = self.flow_authority_token_scope_stack.pop();
+        let _ = self.flow_run_command_scope_stack.pop();
+        let _ = self.typed_flow_next_state_identity_scope_stack.pop();
+        let _ = self.typed_flow_next_state_command_scope_stack.pop();
+        let _ = self.typed_flow_next_state_scope_stack.pop();
+        let _ = self.typed_flow_outcome_identity_scope_stack.pop();
+        let _ = self.typed_flow_outcome_command_scope_stack.pop();
+        let _ = self.typed_flow_outcome_scope_stack.pop();
+        let _ = self.alias_stack.pop();
+    }
+
+    fn visit_item_mod(&mut self, node: &'ast syn::ItemMod) {
+        if attrs_cfg_test(&node.attrs) {
+            return;
+        }
+        if let Some((_, items)) = &node.content {
+            let local_aliases = RustUseAliases::default().with_item_aliases(items);
+            self.alias_stack.push(local_aliases);
+            self.module_depth += 1;
+            visit::visit_item_mod(self, node);
+            self.module_depth -= 1;
+            let _ = self.alias_stack.pop();
+        } else {
+            visit::visit_item_mod(self, node);
+        }
+    }
+
+    fn visit_item_impl(&mut self, node: &'ast syn::ItemImpl) {
+        self.impl_stack.push(type_path_segments(&node.self_ty));
+        visit::visit_item_impl(self, node);
+        let _ = self.impl_stack.pop();
+    }
+
+    fn visit_item_fn(&mut self, node: &'ast syn::ItemFn) {
+        if attrs_cfg_test(&node.attrs) {
+            return;
+        }
+        let local_aliases = self.current_aliases().with_block_aliases(&node.block);
+        let context = FlowFunctionContext::from_signature(
+            &node.sig,
+            &node.block,
+            None,
+            self.module_depth,
+            self.rel,
+            &local_aliases,
+        );
+        self.alias_stack.push(local_aliases);
+        self.function_stack.push(context);
+        visit::visit_item_fn(self, node);
+        let _ = self.function_stack.pop();
+        let _ = self.alias_stack.pop();
+    }
+
+    fn visit_impl_item_fn(&mut self, node: &'ast syn::ImplItemFn) {
+        if attrs_cfg_test(&node.attrs) {
+            return;
+        }
+        let local_aliases = self.current_aliases().with_block_aliases(&node.block);
+        let context = FlowFunctionContext::from_signature(
+            &node.sig,
+            &node.block,
+            self.impl_stack.last().cloned().flatten(),
+            self.module_depth,
+            self.rel,
+            &local_aliases,
+        );
+        self.alias_stack.push(local_aliases);
+        self.function_stack.push(context);
+        visit::visit_impl_item_fn(self, node);
+        let _ = self.function_stack.pop();
+        let _ = self.alias_stack.pop();
+    }
+
+    fn visit_local(&mut self, node: &'ast syn::Local) {
+        if let Some(init) = &node.init {
+            let plan_match_result_var = match (&node.pat, &*init.expr) {
+                (syn::Pat::Ident(ident), syn::Expr::Match(expr_match))
+                    if self.rel == "meerkat-mob/src/runtime/actor.rs"
+                        && self.current_function().is_some_and(|function| {
+                            function.name == "commit_flow_frame_store_plan_in_actor"
+                        })
+                        && self.expr_is_actor_plan_scrutinee(&expr_match.expr) =>
+                {
+                    Some(ident.ident.to_string())
+                }
+                _ => None,
+            };
+            self.actor_plan_match_result_stack
+                .push(plan_match_result_var);
+            self.visit_expr(&init.expr);
+            if let Some((_, diverge)) = &init.diverge {
+                self.visit_expr(diverge);
+            }
+            let _ = self.actor_plan_match_result_stack.pop();
+        }
+        let bound_names = pat_bound_idents(&node.pat);
+        let simple_initialized_ident =
+            matches!(&node.pat, syn::Pat::Ident(_)) && node.init.is_some();
+        if !simple_initialized_ident {
+            for name in &bound_names {
+                self.invalidate_flow_provenance_var(name);
+            }
+        }
+        let mut alias_bindings = BTreeMap::new();
+        if let Some(init) = &node.init {
+            self.collect_projection_alias_bindings(&node.pat, &init.expr, &mut alias_bindings);
+        }
+        if let Some(aliases) = self.projection_state_alias_stack.last_mut() {
+            aliases.extend(alias_bindings);
+        }
+        if let syn::Pat::Ident(ident) = &node.pat
+            && let Some(init) = &node.init
+        {
+            let typed_outcome_command_var =
+                self.expr_canonical_flow_run_apply_command_var(&init.expr);
+            let typed_outcome_identity_var =
+                self.expr_canonical_flow_run_apply_identity_var(&init.expr);
+            let name = ident.ident.to_string();
+            let typed_next_state_command_var =
+                self.expr_canonical_flow_run_apply_next_state_command_var(&init.expr);
+            let typed_next_state_identity_var =
+                self.expr_canonical_flow_run_apply_next_state_identity_var(&init.expr);
+            let is_flow_run_command =
+                expr_returns_mob_machine_flow_run_command(&init.expr, self.current_aliases());
+            let is_flow_authority_token =
+                expr_returns_mob_machine_flow_authority_token(&init.expr, self.current_aliases());
+            let visible_flow_authority_input_command_vars =
+                self.visible_flow_authority_input_command_vars();
+            let visible_flow_authority_input_identity_vars =
+                self.visible_flow_authority_input_identity_vars();
+            let flow_authority_input_command_var = expr_flow_authority_input_command_var(
+                &init.expr,
+                &self.visible_flow_run_command_vars(),
+                &visible_flow_authority_input_command_vars,
+            );
+            let flow_authority_input_identity_var = expr_flow_authority_input_identity_var(
+                &init.expr,
+                &visible_flow_authority_input_identity_vars,
+            );
+            let is_actor_plan_authority_input =
+                self.expr_is_actor_plan_machine_inputs_value(&init.expr, &BTreeSet::new());
+            if let Some(scope) = self.typed_flow_outcome_scope_stack.last_mut() {
+                scope.insert(name.clone(), typed_outcome_command_var.is_some());
+            }
+            if let Some(scope) = self.typed_flow_outcome_command_scope_stack.last_mut() {
+                scope.insert(name.clone(), typed_outcome_command_var);
+            }
+            if let Some(scope) = self.typed_flow_outcome_identity_scope_stack.last_mut() {
+                scope.insert(name.clone(), typed_outcome_identity_var);
+            }
+            if let Some(scope) = self.typed_flow_next_state_scope_stack.last_mut() {
+                scope.insert(name.clone(), typed_next_state_command_var.is_some());
+            }
+            if let Some(scope) = self.typed_flow_next_state_command_scope_stack.last_mut() {
+                scope.insert(name.clone(), typed_next_state_command_var);
+            }
+            if let Some(scope) = self.typed_flow_next_state_identity_scope_stack.last_mut() {
+                scope.insert(name.clone(), typed_next_state_identity_var);
+            }
+            if let Some(scope) = self.flow_run_command_scope_stack.last_mut() {
+                scope.insert(name.clone(), is_flow_run_command);
+            }
+            if let Some(scope) = self.flow_authority_token_scope_stack.last_mut() {
+                scope.insert(name.clone(), is_flow_authority_token);
+            }
+            if let Some(scope) = self.flow_authority_input_scope_stack.last_mut() {
+                scope.insert(name.clone(), flow_authority_input_command_var);
+            }
+            if let Some(scope) = self.flow_authority_input_identity_scope_stack.last_mut() {
+                scope.insert(name.clone(), flow_authority_input_identity_var);
+            }
+            if let Some(scope) = self.actor_plan_authority_input_scope_stack.last_mut() {
+                scope.insert(name, is_actor_plan_authority_input);
+            }
+        }
+        self.bind_local_names(&node.pat);
+    }
+
+    fn visit_expr_closure(&mut self, node: &'ast syn::ExprClosure) {
+        self.with_deferred_expr(|this| visit::visit_expr_closure(this, node));
+    }
+
+    fn visit_expr_async(&mut self, node: &'ast syn::ExprAsync) {
+        self.with_deferred_expr(|this| visit::visit_expr_async(this, node));
+    }
+
+    fn visit_expr_match(&mut self, node: &'ast syn::ExprMatch) {
+        let is_actor_plan_match = self.rel == "meerkat-mob/src/runtime/actor.rs"
+            && self
+                .current_function()
+                .is_some_and(|function| function.name == "commit_flow_frame_store_plan_in_actor")
+            && self.expr_is_actor_plan_scrutinee(&node.expr);
+        if is_actor_plan_match {
+            self.visit_expr(&node.expr);
+            for arm in &node.arms {
+                if let Some((_, guard)) = &arm.guard {
+                    self.visit_expr(guard);
+                }
+                let plan_arm = actor_plan_arm_facts_from_pat(&arm.pat, self.current_aliases());
+                let plan_variant = actor_plan_single_variant(&plan_arm);
+                self.actor_plan_binding_scope_stack.push(plan_arm);
+                let result_proof = self.visit_actor_plan_result_expr(&arm.body);
+                let _ = self.actor_plan_binding_scope_stack.pop();
+                if let Some(variant) = plan_variant
+                    && !result_proof.proves_authorized_commit()
+                {
+                    self.mismatches.push(format!(
+                        "FlowFrameLoopStorePlan::{variant} arm does not use canonical MobRunStore CAS: {}:{}",
+                        self.rel,
+                        line_number(&arm.pat)
+                    ));
+                }
+            }
+        } else {
+            self.visit_expr(&node.expr);
+            for arm in &node.arms {
+                self.with_pattern_bindings(&arm.pat, &node.expr, |this| {
+                    if let Some((_, guard)) = &arm.guard {
+                        this.visit_expr(guard);
+                    }
+                    this.visit_expr(&arm.body);
+                });
+            }
+        }
+    }
+
+    fn visit_expr_if(&mut self, node: &'ast syn::ExprIf) {
+        self.visit_expr(&node.cond);
+        if let syn::Expr::Let(expr_let) = &*node.cond {
+            self.with_pattern_bindings(&expr_let.pat, &expr_let.expr, |this| {
+                this.visit_block(&node.then_branch);
+            });
+        } else {
+            self.visit_block(&node.then_branch);
+        }
+        if let Some((_, else_branch)) = &node.else_branch {
+            self.visit_expr(else_branch);
+        }
+    }
+
+    fn visit_expr_call(&mut self, node: &'ast syn::ExprCall) {
+        if let Some(path) = expr_as_path(&node.func) {
+            if let Some(kind) = self.direct_use_from_path(path) {
+                self.record_direct_use(
+                    kind,
+                    line_number(node),
+                    source_position(node),
+                    path,
+                    Some(node),
+                );
+            }
+            if let Some(method) = path
+                .segments
+                .last()
+                .map(|segment| segment.ident.to_string())
+                && self.facts.cas_methods.contains_key(&method)
+                && !self.projection_call_allowed(node)
+            {
+                self.mismatches.push(format!(
+                    "direct live-flow projection mutation `.{method}(` is not MobMachine-command gated: {}:{}",
+                    self.rel,
+                    line_number(node)
+                ));
+            }
+        } else {
+            self.visit_expr(&node.func);
+        }
+        for arg in &node.args {
+            self.visit_expr(arg);
+        }
+    }
+
+    fn visit_expr_struct(&mut self, node: &'ast syn::ExprStruct) {
+        if let Some(kind) = self.direct_use_from_path(&node.path) {
+            self.record_direct_use(
+                kind,
+                line_number(node),
+                source_position(node),
+                &node.path,
+                None,
+            );
+        }
+        visit::visit_expr_struct(self, node);
+    }
+
+    fn visit_expr_path(&mut self, node: &'ast syn::ExprPath) {
+        if let Some(kind) = self.direct_use_from_path(&node.path) {
+            self.record_direct_use(
+                kind,
+                line_number(node),
+                source_position(node),
+                &node.path,
+                None,
+            );
+        }
+    }
+
+    fn visit_expr_assign(&mut self, node: &'ast syn::ExprAssign) {
+        if let Some(token) = self.projection_write_token(&node.left) {
+            self.mismatches.push(format!(
+                "direct live-flow projection mutation `{token}` is not MobMachine-command gated: {}:{}",
+                self.rel,
+                line_number(node)
+            ));
+        }
+        if let Some(name) = expr_path_single_ident(&node.left) {
+            let typed_outcome_command_var =
+                self.expr_canonical_flow_run_apply_command_var(&node.right);
+            let typed_outcome_identity_var =
+                self.expr_canonical_flow_run_apply_identity_var(&node.right);
+            self.set_typed_flow_outcome_var(&name, typed_outcome_command_var.is_some());
+            self.set_typed_flow_outcome_command_var(&name, typed_outcome_command_var);
+            self.set_typed_flow_outcome_identity_var(&name, typed_outcome_identity_var);
+            let typed_next_state_command_var =
+                self.expr_canonical_flow_run_apply_next_state_command_var(&node.right);
+            let typed_next_state_identity_var =
+                self.expr_canonical_flow_run_apply_next_state_identity_var(&node.right);
+            self.set_typed_flow_next_state_var(&name, typed_next_state_command_var.is_some());
+            self.set_typed_flow_next_state_command_var(&name, typed_next_state_command_var);
+            self.set_typed_flow_next_state_identity_var(&name, typed_next_state_identity_var);
+            let visible_flow_authority_input_command_vars =
+                self.visible_flow_authority_input_command_vars();
+            let visible_flow_authority_input_identity_vars =
+                self.visible_flow_authority_input_identity_vars();
+            let flow_authority_input_command_var = expr_flow_authority_input_command_var(
+                &node.right,
+                &self.visible_flow_run_command_vars(),
+                &visible_flow_authority_input_command_vars,
+            );
+            let flow_authority_input_identity_var = expr_flow_authority_input_identity_var(
+                &node.right,
+                &visible_flow_authority_input_identity_vars,
+            );
+            self.set_flow_run_command_var(
+                &name,
+                expr_returns_mob_machine_flow_run_command(&node.right, self.current_aliases()),
+            );
+            self.set_flow_authority_token_var(
+                &name,
+                expr_returns_mob_machine_flow_authority_token(&node.right, self.current_aliases()),
+            );
+            self.set_flow_authority_input_var(&name, flow_authority_input_command_var);
+            self.set_flow_authority_input_identity_var(&name, flow_authority_input_identity_var);
+            self.set_actor_plan_authority_input_var(
+                &name,
+                self.expr_is_actor_plan_machine_inputs_value(
+                    &node.right,
+                    &self.visible_actor_plan_authority_input_vars(),
+                ),
+            );
+            let alias = self.projection_state_alias_from_expr(&node.right);
+            self.set_projection_state_alias_var(&name, alias);
+        } else {
+            if let Some(name) = expr_root_ident(&node.left) {
+                self.invalidate_flow_provenance_var(&name);
+            }
+            self.invalidate_typed_flow_outcome_path(&node.left);
+            self.invalidate_typed_flow_next_state_path(&node.left);
+        }
+        visit::visit_expr_assign(self, node);
+    }
+
+    fn visit_expr_binary(&mut self, node: &'ast syn::ExprBinary) {
+        if bin_op_is_assign(&node.op)
+            && let Some(token) = self.projection_write_token(&node.left)
+        {
+            self.mismatches.push(format!(
+                "direct live-flow projection mutation `{token}` is not MobMachine-command gated: {}:{}",
+                self.rel,
+                line_number(node)
+            ));
+        }
+        if bin_op_is_assign(&node.op)
+            && let Some(name) = expr_path_single_ident(&node.left)
+        {
+            self.invalidate_flow_provenance_var(&name);
+        }
+        if bin_op_is_assign(&node.op) {
+            if let Some(name) = expr_root_ident(&node.left) {
+                self.invalidate_flow_provenance_var(&name);
+            }
+            self.invalidate_typed_flow_outcome_path(&node.left);
+            self.invalidate_typed_flow_next_state_path(&node.left);
+        }
+        visit::visit_expr_binary(self, node);
+    }
+
+    fn visit_expr_reference(&mut self, node: &'ast syn::ExprReference) {
+        if node.mutability.is_some() {
+            if let Some(token) = self.projection_write_token(&node.expr) {
+                self.mismatches.push(format!(
+                    "direct live-flow projection mutation `{token}` is not MobMachine-command gated: {}:{}",
+                    self.rel,
+                    line_number(node)
+                ));
+            }
+            if let Some(name) = expr_root_ident(&node.expr) {
+                self.invalidate_flow_provenance_var(&name);
+            }
+        }
+        visit::visit_expr_reference(self, node);
+    }
+
+    fn visit_expr_method_call(&mut self, node: &'ast syn::ExprMethodCall) {
+        let method = node.method.to_string();
+        if projection_mutator_method(&method)
+            && let Some(token) = self.projection_write_token(&node.receiver)
+        {
+            self.mismatches.push(format!(
+                "direct live-flow projection mutation `{token}` is not MobMachine-command gated: {}:{}",
+                self.rel,
+                line_number(node)
+            ));
+        }
+        if !projection_method_preserves_typed_flow_state(&method) {
+            self.invalidate_typed_flow_outcome_path(&node.receiver);
+            self.invalidate_typed_flow_next_state_path(&node.receiver);
+        }
+        if flow_provenance_mutator_method(&method)
+            && let Some(name) = expr_root_ident(&node.receiver)
+        {
+            self.invalidate_flow_provenance_var(&name);
+        }
+        if self.facts.cas_methods.contains_key(&method) {
+            if self.projection_commit_allowed(node) {
+                self.mark_actor_plan_authorized_commit();
+            } else {
+                self.mismatches.push(format!(
+                    "direct live-flow projection mutation `.{method}(` is not MobMachine-command gated: {}:{}",
+                    self.rel,
+                    line_number(node)
+                ));
+            }
+        }
+        visit::visit_expr_method_call(self, node);
+    }
+}
+
+#[derive(Debug, Clone, Copy)]
+enum FlowDirectUse {
+    Transition {
+        family: FlowReducerFamily,
+        canonical: bool,
+    },
+    Input {
+        family: FlowReducerFamily,
+        canonical: bool,
+    },
+}
+
+#[derive(Debug, Clone, Default)]
+struct MobRuntimeActorAst {
+    functions: BTreeMap<String, Vec<MobGateSummary>>,
+    command_arms: BTreeMap<String, Vec<MobGateSummary>>,
+    catch_all_arms: Vec<MobGateSummary>,
+    dispatch_contexts: Vec<MobGateSummary>,
+}
+
+impl MobRuntimeActorAst {
+    fn from_file(file: &syn::File) -> Self {
+        let aliases = RustUseAliases::from_file(file);
+        let mut visitor = MobRuntimeActorVisitor::new(&aliases);
+        visitor.visit_file(file);
+        Self {
+            functions: visitor.functions,
+            command_arms: visitor.command_arms,
+            catch_all_arms: visitor.catch_all_arms,
+            dispatch_contexts: visitor.dispatch_contexts,
+        }
+    }
+
+    fn command_fail_closes_on(&self, command: &str, input: MobMachineInputVariant) -> bool {
+        let visited = BTreeSet::new();
+        let handler = format!("handle_{}", camel_to_snake(command));
+        if self
+            .dispatch_contexts
+            .iter()
+            .filter(|summary| summary.has_command_effect())
+            .any(|summary| {
+                let mut visited = BTreeSet::new();
+                !self.summary_fail_closes_on(summary, input, &mut visited, true)
+            })
+        {
+            return false;
+        }
+        if let Some(summaries) = self.command_arms.get(command) {
+            return summaries.iter().all(|summary| {
+                let mut visited = BTreeSet::new();
+                self.summary_fail_closes_on(summary, input, &mut visited, true)
+            });
+        }
+        let catch_all_summaries = self
+            .catch_all_arms
+            .iter()
+            .filter(|summary| summary.has_command_effect())
+            .collect::<Vec<_>>();
+        if !catch_all_summaries.is_empty() {
+            return catch_all_summaries.iter().all(|summary| {
+                let mut visited = BTreeSet::new();
+                self.summary_fail_closes_on(summary, input, &mut visited, true)
+            });
+        }
+        self.functions.get(&handler).is_some_and(|summaries| {
+            summaries.iter().all(|summary| {
+                let mut branch_visited = visited.clone();
+                self.summary_fail_closes_on(summary, input, &mut branch_visited, false)
+            })
+        })
+    }
+
+    fn summary_fail_closes_on(
+        &self,
+        summary: &MobGateSummary,
+        input: MobMachineInputVariant,
+        visited: &mut BTreeSet<String>,
+        command_arm: bool,
+    ) -> bool {
+        if self
+            .summary_gate_eval(summary, input, visited, false)
+            .is_some_and(|eval| eval.fail_closes)
+        {
+            return true;
+        }
+        summary_direct_fail_closes_on(summary, input, command_arm)
+    }
+
+    fn summary_gate_eval(
+        &self,
+        summary: &MobGateSummary,
+        input: MobMachineInputVariant,
+        visited: &mut BTreeSet<String>,
+        inherited_gate: bool,
+    ) -> Option<MobGateEval> {
+        let mut eval = MobGateEval {
+            gated: inherited_gate,
+            ..MobGateEval::default()
+        };
+        for event in &summary.events {
+            match event {
+                MobGateEvent::Gate(gated_input) if *gated_input == input => {
+                    eval.gated = true;
+                }
+                MobGateEvent::SideEffect => {
+                    eval.has_side_effect = true;
+                    if !eval.gated {
+                        eval.has_ungated_side_effect = true;
+                    }
+                }
+                MobGateEvent::FailClosedCall(call) | MobGateEvent::PropagatedCall(call) => {
+                    if !visited.insert(call.clone()) {
+                        continue;
+                    }
+                    let Some(called) = self.functions.get(call) else {
+                        continue;
+                    };
+                    let mut called_fail_closes = true;
+                    let mut called_has_side_effect = false;
+                    for summary in called {
+                        let mut branch_visited = visited.clone();
+                        let called_eval = self.summary_gate_eval(
+                            summary,
+                            input,
+                            &mut branch_visited,
+                            eval.gated,
+                        )?;
+                        if called_eval.has_ungated_side_effect {
+                            return Some(MobGateEval {
+                                has_side_effect: true,
+                                has_ungated_side_effect: true,
+                                ..eval
+                            });
+                        }
+                        called_fail_closes &= called_eval.fail_closes;
+                        called_has_side_effect |= called_eval.has_side_effect;
+                    }
+                    if called_has_side_effect {
+                        eval.has_side_effect = true;
+                    }
+                    if called_fail_closes {
+                        eval.gated = true;
+                    }
+                }
+                MobGateEvent::HelperCall { call, gated_inputs } => {
+                    let mut helper_visited = visited.clone();
+                    if !helper_visited.insert(call.clone()) {
+                        continue;
+                    }
+                    let Some(called) = self.functions.get(call) else {
+                        continue;
+                    };
+                    for summary in called {
+                        let mut branch_visited = helper_visited.clone();
+                        let called_eval = self.summary_gate_eval(
+                            summary,
+                            input,
+                            &mut branch_visited,
+                            eval.gated || gated_inputs.contains(&input),
+                        )?;
+                        if called_eval.has_ungated_side_effect {
+                            return Some(MobGateEval {
+                                has_side_effect: true,
+                                has_ungated_side_effect: true,
+                                ..eval
+                            });
+                        }
+                        if called_eval.has_side_effect {
+                            eval.has_side_effect = true;
+                        }
+                    }
+                }
+                _ => {}
+            }
+        }
+        if summary.has_ungated_side_effect && !inherited_gate {
+            eval.has_side_effect = true;
+            eval.has_ungated_side_effect = true;
+        }
+        eval.fail_closes = (eval.gated
+            || (eval.has_side_effect && summary.reply_gated_inputs.contains(&input)))
+            && !eval.has_ungated_side_effect;
+        Some(eval)
+    }
+}
+
+fn summary_direct_fail_closes_on(
+    summary: &MobGateSummary,
+    input: MobMachineInputVariant,
+    command_arm: bool,
+) -> bool {
+    if summary.has_ungated_side_effect {
+        return false;
+    }
+    if !summary.has_side_effect
+        && summary.gated_inputs.contains(&input)
+        && summary.fail_closed_calls.is_empty()
+        && summary.propagated_calls.is_empty()
     {
         return true;
     }
-
-    let function_signature = lines[function_start].split_whitespace().collect::<String>();
-    let expected_input_return = format!("->{}::Input", family.module());
-    function_name.as_deref() == Some("into_input")
-        && nearest_impl_start(lines, function_start)
-            .is_some_and(|impl_start| lines[impl_start].contains(family.command_type()))
-        && function_signature.contains(expected_input_return.as_str())
-        && token.contains("Input::")
+    if summary.has_side_effect && command_arm {
+        summary.side_effect_gated_inputs.contains(&input)
+            && (summary.reply_gated_inputs.contains(&input)
+                || summary.gated_inputs.contains(&input))
+    } else {
+        summary.has_side_effect && summary.side_effect_gated_inputs.contains(&input)
+    }
 }
 
-fn flow_reducer_projection_commit_is_structurally_allowed(
-    path: &str,
-    lines: &[&str],
-    line_index: usize,
-) -> bool {
-    let Some(function_start) = nearest_function_start(lines, line_index) else {
-        return false;
-    };
-    let function_name = function_name_from_signature(lines[function_start]);
-    let scope = &lines[function_start..=line_index];
+#[derive(Debug, Clone, Default)]
+struct MobGateEval {
+    gated: bool,
+    has_side_effect: bool,
+    has_ungated_side_effect: bool,
+    fail_closes: bool,
+}
 
-    match path {
-        "meerkat-mob/src/runtime/flow.rs" => {
-            let signature = compact_function_signature(lines, function_start);
-            let call_window = lines[line_index..(line_index + 8).min(lines.len())].join(" ");
-            let has_authority_setup = scope
+#[derive(Debug, Clone, Default)]
+struct MobGateSummary {
+    gated_inputs: BTreeSet<MobMachineInputVariant>,
+    side_effect_gated_inputs: BTreeSet<MobMachineInputVariant>,
+    reply_gated_inputs: BTreeSet<MobMachineInputVariant>,
+    has_side_effect: bool,
+    has_ungated_side_effect: bool,
+    fail_closed_calls: BTreeSet<String>,
+    propagated_calls: BTreeSet<String>,
+    events: Vec<MobGateEvent>,
+}
+
+impl MobGateSummary {
+    fn has_command_effect(&self) -> bool {
+        self.has_side_effect
+            || self.has_ungated_side_effect
+            || !self.side_effect_gated_inputs.is_empty()
+            || !self.fail_closed_calls.is_empty()
+            || !self.propagated_calls.is_empty()
+            || self
+                .events
                 .iter()
-                .any(|line| line.contains("project_machine_input("))
-                && scope
-                    .iter()
-                    .any(|line| line.contains("from_accepted_mob_machine_input("));
-            let has_typed_authority_args = signature.contains("MobMachineFlowRunCommand")
-                && signature.contains("MobMachineFlowAuthorityToken");
-            let has_typed_authority_token_and_command_source = signature
-                .contains("MobMachineFlowAuthorityToken")
-                && (signature.contains("MobMachineFlowRunCommand")
-                    || scope
-                        .iter()
-                        .any(|line| line.contains("MobMachineFlowRunCommand::")));
-            scope
-                .iter()
-                .any(|line| line.contains("apply_mob_machine_flow_run_command("))
-                && (has_authority_setup
-                    || has_typed_authority_args
-                    || has_typed_authority_token_and_command_source)
-                && (call_window.contains("outcome.next_state")
-                    || call_window.contains("next_state"))
+                .any(|event| matches!(event, MobGateEvent::HelperCall { .. }))
+    }
+}
+
+#[derive(Debug, Clone)]
+enum MobGateEvent {
+    Gate(MobMachineInputVariant),
+    SideEffect,
+    FailClosedCall(String),
+    HelperCall {
+        call: String,
+        gated_inputs: BTreeSet<MobMachineInputVariant>,
+    },
+    PropagatedCall(String),
+}
+
+fn retain_loop_preserved_gate_map<T: Clone + Eq>(
+    facts: &mut BTreeMap<String, T>,
+    before: &BTreeMap<String, T>,
+) {
+    let after = facts.clone();
+    facts.clear();
+    for (name, value) in before {
+        if after
+            .get(name)
+            .is_some_and(|after_value| after_value == value)
+        {
+            facts.insert(name.clone(), value.clone());
         }
-        "meerkat-mob/src/runtime/actor.rs" => {
-            if function_name.as_deref() != Some("commit_flow_frame_store_plan_in_actor") {
-                return false;
-            }
-            let function_commits_prepared_inputs = lines
-                .iter()
-                .skip(function_start)
-                .take(420)
-                .any(|line| line.contains("commit_prepared_dsl_input(prepared)"));
-            let function_prepares_machine_inputs = lines
-                .iter()
-                .skip(function_start)
-                .take(420)
-                .any(|line| line.contains("prepare_dsl_inputs(plan.machine_inputs()"));
-            if !function_prepares_machine_inputs || !function_commits_prepared_inputs {
-                return false;
-            }
-            let window_start = line_index.saturating_sub(32);
-            let local_scope = &lines[window_start..=line_index];
-            let call_window = lines[line_index..(line_index + 12).min(lines.len())].join(" ");
-            (call_window.contains(".cas_flow_state(")
-                && call_window.contains("next_run_state")
-                && local_scope
-                    .iter()
-                    .any(|line| line.contains("FlowFrameLoopStorePlan::RunStateOnly")))
-                || (call_window.contains(".cas_frame_state(")
-                    && call_window.contains("next_frame")
-                    && local_scope
-                        .iter()
-                        .any(|line| line.contains("FlowFrameLoopStorePlan::FrameState")))
-                || (call_window.contains(".cas_frame_state(")
-                    && call_window.contains("initial_frame")
-                    && local_scope
-                        .iter()
-                        .any(|line| line.contains("FlowFrameLoopStorePlan::InsertFrame")))
-                || (call_window.contains(".cas_frame_state(")
-                    && call_window.contains("next_frame")
-                    && local_scope
-                        .iter()
-                        .any(|line| line.contains("FlowFrameLoopStorePlan::SealFrame")))
-                || (call_window.contains(".cas_complete_step_and_record_output(")
-                    && local_scope.iter().any(|line| {
-                        line.contains("FlowFrameLoopStorePlan::CompleteStepAndRecordOutput")
-                    }))
-                || (call_window.contains(".cas_grant_node_slot(")
-                    && local_scope
-                        .iter()
-                        .any(|line| line.contains("FlowFrameLoopStorePlan::GrantNodeSlot")))
-                || (call_window.contains(".cas_start_loop(")
-                    && local_scope
-                        .iter()
-                        .any(|line| line.contains("FlowFrameLoopStorePlan::StartLoop")))
-                || (call_window.contains(".cas_grant_body_frame_start(")
-                    && local_scope
-                        .iter()
-                        .any(|line| line.contains("FlowFrameLoopStorePlan::GrantBodyFrameStart")))
-                || (call_window.contains(".cas_complete_body_frame(")
-                    && local_scope
-                        .iter()
-                        .any(|line| line.contains("FlowFrameLoopStorePlan::CompleteBodyFrame")))
-                || (call_window.contains(".cas_loop_request_body_frame(")
-                    && local_scope
-                        .iter()
-                        .any(|line| line.contains("FlowFrameLoopStorePlan::LoopRequestBodyFrame")))
-                || (call_window.contains(".cas_complete_loop(")
-                    && local_scope
-                        .iter()
-                        .any(|line| line.contains("FlowFrameLoopStorePlan::CompleteLoop")))
+    }
+}
+
+fn retain_loop_preserved_gate_set(facts: &mut BTreeSet<String>, before: &BTreeSet<String>) {
+    facts.retain(|name| before.contains(name));
+}
+
+struct MobRuntimeActorVisitor<'a> {
+    aliases: &'a RustUseAliases,
+    alias_stack: Vec<RustUseAliases>,
+    functions: BTreeMap<String, Vec<MobGateSummary>>,
+    command_arms: BTreeMap<String, Vec<MobGateSummary>>,
+    catch_all_arms: Vec<MobGateSummary>,
+    dispatch_contexts: Vec<MobGateSummary>,
+    mob_command_value_scope_stack: Vec<BTreeMap<String, bool>>,
+    mob_command_source_scope_stack: Vec<BTreeMap<String, bool>>,
+    mob_command_buffer_scope_stack: Vec<BTreeMap<String, bool>>,
+    mob_command_dispatch_scope_stack: Vec<bool>,
+    impl_self_type_stack: Vec<Option<Vec<String>>>,
+}
+
+impl<'a> MobRuntimeActorVisitor<'a> {
+    fn new(aliases: &'a RustUseAliases) -> Self {
+        Self {
+            aliases,
+            alias_stack: Vec::new(),
+            functions: BTreeMap::new(),
+            command_arms: BTreeMap::new(),
+            catch_all_arms: Vec::new(),
+            dispatch_contexts: Vec::new(),
+            mob_command_value_scope_stack: Vec::new(),
+            mob_command_source_scope_stack: Vec::new(),
+            mob_command_buffer_scope_stack: Vec::new(),
+            mob_command_dispatch_scope_stack: Vec::new(),
+            impl_self_type_stack: Vec::new(),
         }
-        "meerkat-mob/src/runtime/flow_frame_engine.rs" => false,
+    }
+
+    fn current_aliases(&self) -> &RustUseAliases {
+        self.alias_stack.last().unwrap_or(self.aliases)
+    }
+
+    fn visible_scope_names(stack: &[BTreeMap<String, bool>]) -> BTreeSet<String> {
+        let mut resolved = BTreeMap::new();
+        for scope in stack.iter().rev() {
+            for (name, visible) in scope {
+                resolved.entry(name.clone()).or_insert(*visible);
+            }
+        }
+        resolved
+            .into_iter()
+            .filter_map(|(name, visible)| visible.then_some(name))
+            .collect()
+    }
+
+    fn visible_mob_command_values(&self) -> BTreeSet<String> {
+        Self::visible_scope_names(&self.mob_command_value_scope_stack)
+    }
+
+    fn visible_mob_command_sources(&self) -> BTreeSet<String> {
+        Self::visible_scope_names(&self.mob_command_source_scope_stack)
+    }
+
+    fn visible_mob_command_buffers(&self) -> BTreeSet<String> {
+        Self::visible_scope_names(&self.mob_command_buffer_scope_stack)
+    }
+
+    fn expr_is_visible_mob_command_value(&self, expr: &syn::Expr) -> bool {
+        expr_path_single_ident(expr)
+            .as_ref()
+            .is_some_and(|ident| self.visible_mob_command_values().contains(ident))
+    }
+
+    fn set_mob_command_value_var(&mut self, name: &str, visible: bool) {
+        for scope in self.mob_command_value_scope_stack.iter_mut().rev() {
+            if scope.contains_key(name) {
+                scope.insert(name.to_string(), visible);
+                return;
+            }
+        }
+        if let Some(scope) = self.mob_command_value_scope_stack.last_mut() {
+            scope.insert(name.to_string(), visible);
+        }
+    }
+
+    fn set_mob_command_source_var(&mut self, name: &str, visible: bool) {
+        for scope in self.mob_command_source_scope_stack.iter_mut().rev() {
+            if scope.contains_key(name) {
+                scope.insert(name.to_string(), visible);
+                return;
+            }
+        }
+        if let Some(scope) = self.mob_command_source_scope_stack.last_mut() {
+            scope.insert(name.to_string(), visible);
+        }
+    }
+
+    fn set_mob_command_buffer_var(&mut self, name: &str, visible: bool) {
+        for scope in self.mob_command_buffer_scope_stack.iter_mut().rev() {
+            if scope.contains_key(name) {
+                scope.insert(name.to_string(), visible);
+                return;
+            }
+        }
+        if let Some(scope) = self.mob_command_buffer_scope_stack.last_mut() {
+            scope.insert(name.to_string(), visible);
+        }
+    }
+
+    fn invalidate_mob_command_provenance_var(&mut self, name: &str) {
+        self.set_mob_command_value_var(name, false);
+        self.set_mob_command_source_var(name, false);
+        self.set_mob_command_buffer_var(name, false);
+    }
+
+    fn expr_is_mob_command_scrutinee(&self, expr: &syn::Expr) -> bool {
+        if !self
+            .mob_command_dispatch_scope_stack
+            .last()
+            .copied()
+            .unwrap_or(false)
+        {
+            return false;
+        }
+        expr_path_single_ident(expr)
+            .as_ref()
+            .is_some_and(|ident| self.visible_mob_command_values().contains(ident))
+    }
+
+    fn expr_uses_mob_command_source(&self, expr: &syn::Expr) -> bool {
+        match expr {
+            syn::Expr::MethodCall(call) => {
+                let receiver = expr_path_single_ident(&call.receiver);
+                (call.method == "recv"
+                    && receiver
+                        .as_ref()
+                        .is_some_and(|ident| self.visible_mob_command_sources().contains(ident)))
+                    || (call.method == "pop_front"
+                        && receiver.as_ref().is_some_and(|ident| {
+                            self.visible_mob_command_buffers().contains(ident)
+                        }))
+                    || self.expr_uses_mob_command_source(&call.receiver)
+                    || call
+                        .args
+                        .iter()
+                        .any(|arg| self.expr_uses_mob_command_source(arg))
+            }
+            syn::Expr::Call(call) => call
+                .args
+                .iter()
+                .any(|arg| self.expr_uses_mob_command_source(arg)),
+            syn::Expr::If(expr_if) => {
+                self.expr_uses_mob_command_source(&expr_if.cond)
+                    || expr_if
+                        .then_branch
+                        .stmts
+                        .iter()
+                        .any(|stmt| self.stmt_uses_mob_command_source(stmt))
+                    || expr_if
+                        .else_branch
+                        .as_ref()
+                        .is_some_and(|(_, expr)| self.expr_uses_mob_command_source(expr))
+            }
+            syn::Expr::Let(expr_let) => self.expr_uses_mob_command_source(&expr_let.expr),
+            syn::Expr::Block(block) => block
+                .block
+                .stmts
+                .iter()
+                .any(|stmt| self.stmt_uses_mob_command_source(stmt)),
+            syn::Expr::Try(try_expr) => self.expr_uses_mob_command_source(&try_expr.expr),
+            syn::Expr::Await(await_expr) => self.expr_uses_mob_command_source(&await_expr.base),
+            syn::Expr::Reference(reference) => self.expr_uses_mob_command_source(&reference.expr),
+            syn::Expr::Paren(paren) => self.expr_uses_mob_command_source(&paren.expr),
+            syn::Expr::Group(group) => self.expr_uses_mob_command_source(&group.expr),
+            _ => false,
+        }
+    }
+
+    fn stmt_uses_mob_command_source(&self, stmt: &syn::Stmt) -> bool {
+        match stmt {
+            syn::Stmt::Local(local) => local
+                .init
+                .as_ref()
+                .is_some_and(|init| self.expr_uses_mob_command_source(&init.expr)),
+            syn::Stmt::Expr(expr, _) => self.expr_uses_mob_command_source(expr),
+            syn::Stmt::Item(_) | syn::Stmt::Macro(_) => false,
+        }
+    }
+
+    fn push_mob_command_signature_scope(&mut self, sig: &syn::Signature) {
+        let mut values = BTreeMap::new();
+        let mut sources = BTreeMap::new();
+        let function_name = sig.ident.to_string();
+        for input in &sig.inputs {
+            let syn::FnArg::Typed(pat_type) = input else {
+                continue;
+            };
+            let Some(name) = pat_ident_name(&pat_type.pat) else {
+                continue;
+            };
+            if type_is_canonical_mob_command(&pat_type.ty, self.current_aliases()) {
+                let is_dispatch_command = function_name == "dispatch" && name == "command";
+                values.insert(name, is_dispatch_command);
+            } else if type_contains_canonical_mob_command(&pat_type.ty, self.current_aliases()) {
+                sources.insert(name, true);
+            }
+        }
+        let command_values = values.values().any(|visible| *visible);
+        let command_sources = sources.values().any(|visible| *visible);
+        self.mob_command_value_scope_stack.push(values);
+        self.mob_command_source_scope_stack.push(sources);
+        self.mob_command_buffer_scope_stack.push(BTreeMap::new());
+        self.mob_command_dispatch_scope_stack
+            .push(command_sources || (command_values && function_name == "dispatch"));
+    }
+
+    fn pop_mob_command_signature_scope(&mut self) {
+        let _ = self.mob_command_dispatch_scope_stack.pop();
+        let _ = self.mob_command_buffer_scope_stack.pop();
+        let _ = self.mob_command_source_scope_stack.pop();
+        let _ = self.mob_command_value_scope_stack.pop();
+    }
+
+    fn dispatch_command_parameter_names(&self, sig: &syn::Signature) -> BTreeSet<String> {
+        sig.inputs
+            .iter()
+            .filter_map(|input| match input {
+                syn::FnArg::Typed(pat_type) => {
+                    let name = pat_ident_name(&pat_type.pat)?;
+                    (sig.ident == "dispatch"
+                        && name == "command"
+                        && type_is_canonical_mob_command(&pat_type.ty, self.current_aliases()))
+                    .then_some(name)
+                }
+                syn::FnArg::Receiver(_) => None,
+            })
+            .collect()
+    }
+
+    fn dispatch_command_source_parameter_names(&self, sig: &syn::Signature) -> BTreeSet<String> {
+        sig.inputs
+            .iter()
+            .filter_map(|input| match input {
+                syn::FnArg::Typed(pat_type) => {
+                    let name = pat_ident_name(&pat_type.pat)?;
+                    type_contains_canonical_mob_command(&pat_type.ty, self.current_aliases())
+                        .then_some(name)
+                }
+                syn::FnArg::Receiver(_) => None,
+            })
+            .collect()
+    }
+}
+
+impl<'ast> Visit<'ast> for MobRuntimeActorVisitor<'_> {
+    fn visit_item_mod(&mut self, _node: &'ast syn::ItemMod) {}
+
+    fn visit_item_impl(&mut self, node: &'ast syn::ItemImpl) {
+        if attrs_cfg_test(&node.attrs) {
+            return;
+        }
+        self.impl_self_type_stack
+            .push(type_path_segments(&node.self_ty));
+        visit::visit_item_impl(self, node);
+        let _ = self.impl_self_type_stack.pop();
+    }
+
+    fn visit_block(&mut self, node: &'ast syn::Block) {
+        let local_aliases = self.current_aliases().with_block_aliases(node);
+        self.alias_stack.push(local_aliases);
+        self.mob_command_value_scope_stack.push(BTreeMap::new());
+        self.mob_command_source_scope_stack.push(BTreeMap::new());
+        self.mob_command_buffer_scope_stack.push(BTreeMap::new());
+        visit::visit_block(self, node);
+        let _ = self.mob_command_buffer_scope_stack.pop();
+        let _ = self.mob_command_source_scope_stack.pop();
+        let _ = self.mob_command_value_scope_stack.pop();
+        let _ = self.alias_stack.pop();
+    }
+
+    fn visit_item_fn(&mut self, node: &'ast syn::ItemFn) {
+        if attrs_cfg_test(&node.attrs) {
+            return;
+        }
+        let summary = MobGateAnalyzer::analyze(&node.block, self.current_aliases());
+        self.functions
+            .entry(node.sig.ident.to_string())
+            .or_default()
+            .push(summary);
+        let dispatch_command_vars = self.dispatch_command_parameter_names(&node.sig);
+        let dispatch_command_source_vars = self.dispatch_command_source_parameter_names(&node.sig);
+        if !dispatch_command_vars.is_empty() || !dispatch_command_source_vars.is_empty() {
+            self.dispatch_contexts
+                .push(MobGateAnalyzer::analyze_dispatch_context(
+                    &node.block,
+                    self.current_aliases(),
+                    dispatch_command_vars,
+                    dispatch_command_source_vars,
+                ));
+        }
+        self.push_mob_command_signature_scope(&node.sig);
+        visit::visit_item_fn(self, node);
+        self.pop_mob_command_signature_scope();
+    }
+
+    fn visit_impl_item_fn(&mut self, node: &'ast syn::ImplItemFn) {
+        if attrs_cfg_test(&node.attrs) {
+            return;
+        }
+        let is_mob_actor_impl = self
+            .impl_self_type_stack
+            .last()
+            .and_then(|path| path.as_deref())
+            .is_some_and(path_is_root_mob_actor_impl);
+        if !is_mob_actor_impl {
+            return;
+        }
+        let summary = MobGateAnalyzer::analyze(&node.block, self.current_aliases());
+        self.functions
+            .entry(node.sig.ident.to_string())
+            .or_default()
+            .push(summary);
+        let dispatch_command_vars = self.dispatch_command_parameter_names(&node.sig);
+        let dispatch_command_source_vars = self.dispatch_command_source_parameter_names(&node.sig);
+        if !dispatch_command_vars.is_empty() || !dispatch_command_source_vars.is_empty() {
+            self.dispatch_contexts
+                .push(MobGateAnalyzer::analyze_dispatch_context(
+                    &node.block,
+                    self.current_aliases(),
+                    dispatch_command_vars,
+                    dispatch_command_source_vars,
+                ));
+        }
+        self.push_mob_command_signature_scope(&node.sig);
+        visit::visit_impl_item_fn(self, node);
+        self.pop_mob_command_signature_scope();
+    }
+
+    fn visit_local(&mut self, node: &'ast syn::Local) {
+        if let Some(init) = &node.init
+            && let Some((_, diverge)) = &init.diverge
+        {
+            self.visit_expr(diverge);
+        }
+        let bound_names = pat_bound_idents(&node.pat);
+        if let syn::Pat::Ident(ident) = &node.pat
+            && let Some(init) = &node.init
+        {
+            let name = ident.ident.to_string();
+            let is_command_value = self.expr_uses_mob_command_source(&init.expr)
+                || self.expr_is_visible_mob_command_value(&init.expr);
+            if let Some(scope) = self.mob_command_value_scope_stack.last_mut() {
+                scope.insert(name.clone(), is_command_value);
+            }
+            if let Some(scope) = self.mob_command_source_scope_stack.last_mut() {
+                scope.insert(name.clone(), false);
+            }
+            let is_command_buffer = expr_initializes_mob_command_buffer(&init.expr)
+                && !self.visible_mob_command_sources().is_empty();
+            if let Some(scope) = self.mob_command_buffer_scope_stack.last_mut() {
+                scope.insert(name, is_command_buffer);
+            }
+        } else {
+            for name in &bound_names {
+                if let Some(scope) = self.mob_command_value_scope_stack.last_mut() {
+                    scope.insert(name.clone(), false);
+                }
+                if let Some(scope) = self.mob_command_source_scope_stack.last_mut() {
+                    scope.insert(name.clone(), false);
+                }
+                if let Some(scope) = self.mob_command_buffer_scope_stack.last_mut() {
+                    scope.insert(name.clone(), false);
+                }
+            }
+        }
+        visit::visit_local(self, node);
+    }
+
+    fn visit_expr_match(&mut self, node: &'ast syn::ExprMatch) {
+        if self.expr_is_mob_command_scrutinee(&node.expr) {
+            let command_variants = canonical_gated_mob_command_variants();
+            for arm in &node.arms {
+                let variants = mob_command_variants_from_pat(
+                    &arm.pat,
+                    self.current_aliases(),
+                    &command_variants,
+                );
+                if !variants.is_empty() {
+                    let summary = if arm.guard.is_some() {
+                        MobGateSummary {
+                            has_ungated_side_effect: true,
+                            ..MobGateSummary::default()
+                        }
+                    } else {
+                        MobGateAnalyzer::analyze_command_arm_expr(
+                            &arm.body,
+                            self.current_aliases(),
+                            reply_tx_vars_from_pat(&arm.pat),
+                        )
+                    };
+                    for variant in variants {
+                        self.command_arms
+                            .entry(variant)
+                            .or_default()
+                            .push(summary.clone());
+                    }
+                } else if pat_is_catch_all_command_arm(&arm.pat) {
+                    let summary = if arm.guard.is_some() {
+                        MobGateSummary {
+                            has_ungated_side_effect: true,
+                            ..MobGateSummary::default()
+                        }
+                    } else {
+                        MobGateAnalyzer::analyze_command_arm_expr(
+                            &arm.body,
+                            self.current_aliases(),
+                            reply_tx_vars_from_pat(&arm.pat),
+                        )
+                    };
+                    self.catch_all_arms.push(summary);
+                }
+            }
+        }
+        visit::visit_expr_match(self, node);
+    }
+
+    fn visit_expr_assign(&mut self, node: &'ast syn::ExprAssign) {
+        self.visit_expr(&node.right);
+        if let Some(name) = expr_path_single_ident(&node.left) {
+            self.set_mob_command_value_var(
+                &name,
+                self.expr_uses_mob_command_source(&node.right)
+                    || self.expr_is_visible_mob_command_value(&node.right),
+            );
+            self.set_mob_command_source_var(&name, false);
+            self.set_mob_command_buffer_var(
+                &name,
+                expr_initializes_mob_command_buffer(&node.right)
+                    && !self.visible_mob_command_sources().is_empty(),
+            );
+        } else if let Some(name) = expr_root_ident(&node.left) {
+            self.invalidate_mob_command_provenance_var(&name);
+            self.visit_expr(&node.left);
+        } else {
+            self.visit_expr(&node.left);
+        }
+    }
+
+    fn visit_expr_binary(&mut self, node: &'ast syn::ExprBinary) {
+        if bin_op_is_assign(&node.op)
+            && let Some(name) = expr_root_ident(&node.left)
+        {
+            self.invalidate_mob_command_provenance_var(&name);
+        }
+        visit::visit_expr_binary(self, node);
+    }
+
+    fn visit_expr_reference(&mut self, node: &'ast syn::ExprReference) {
+        if node.mutability.is_some()
+            && let Some(name) = expr_root_ident(&node.expr)
+        {
+            self.invalidate_mob_command_provenance_var(&name);
+        }
+        visit::visit_expr_reference(self, node);
+    }
+
+    fn visit_expr_method_call(&mut self, node: &'ast syn::ExprMethodCall) {
+        let method = node.method.to_string();
+        if gate_provenance_mutator_method(&method)
+            && let Some(name) = expr_root_ident(&node.receiver)
+        {
+            self.invalidate_mob_command_provenance_var(&name);
+        }
+        visit::visit_expr_method_call(self, node);
+    }
+}
+
+struct MobGateAnalyzer {
+    aliases: RustUseAliases,
+    input_vars: BTreeMap<String, MobMachineInputVariant>,
+    pending_gate_result_vars: BTreeMap<String, MobMachineInputVariant>,
+    self_call_result_vars: BTreeMap<String, String>,
+    reply_tx_vars: BTreeSet<String>,
+    skipped_command_match_vars: BTreeSet<String>,
+    skipped_command_source_vars: BTreeSet<String>,
+    skipped_command_buffer_vars: BTreeSet<String>,
+    command_effects_require_skipped_source: bool,
+    skipped_command_effects_armed: bool,
+    side_effect_receiver_vars: BTreeSet<String>,
+    active_gated_inputs: BTreeSet<MobMachineInputVariant>,
+    statement_gated_inputs: BTreeSet<MobMachineInputVariant>,
+    fail_closed_depth: usize,
+    summary: MobGateSummary,
+}
+
+impl MobGateAnalyzer {
+    fn analyze(block: &syn::Block, aliases: &RustUseAliases) -> MobGateSummary {
+        let local_aliases = aliases.with_block_aliases(block);
+        let mut analyzer = Self::new(local_aliases);
+        analyzer.visit_block(block);
+        analyzer.summary
+    }
+
+    fn analyze_dispatch_context(
+        block: &syn::Block,
+        aliases: &RustUseAliases,
+        command_vars: BTreeSet<String>,
+        command_source_vars: BTreeSet<String>,
+    ) -> MobGateSummary {
+        let local_aliases = aliases.with_block_aliases(block);
+        let mut analyzer = Self::new(local_aliases);
+        analyzer.command_effects_require_skipped_source =
+            command_vars.is_empty() && !command_source_vars.is_empty();
+        analyzer.skipped_command_effects_armed = !command_vars.is_empty();
+        analyzer.skipped_command_match_vars = command_vars;
+        analyzer.skipped_command_source_vars = command_source_vars;
+        analyzer.visit_block(block);
+        analyzer.summary
+    }
+
+    fn analyze_command_arm_expr(
+        expr: &syn::Expr,
+        aliases: &RustUseAliases,
+        reply_tx_vars: BTreeSet<String>,
+    ) -> MobGateSummary {
+        Self::analyze_expr_with_reply_vars(expr, aliases, reply_tx_vars)
+    }
+
+    fn analyze_expr_with_reply_vars(
+        expr: &syn::Expr,
+        aliases: &RustUseAliases,
+        reply_tx_vars: BTreeSet<String>,
+    ) -> MobGateSummary {
+        let local_aliases = match expr {
+            syn::Expr::Block(block) => aliases.with_block_aliases(&block.block),
+            _ => aliases.clone(),
+        };
+        let mut analyzer = Self::new(local_aliases);
+        analyzer.reply_tx_vars = reply_tx_vars;
+        analyzer.visit_expr(expr);
+        analyzer.summary
+    }
+
+    fn new(aliases: RustUseAliases) -> Self {
+        Self {
+            aliases,
+            input_vars: BTreeMap::new(),
+            pending_gate_result_vars: BTreeMap::new(),
+            self_call_result_vars: BTreeMap::new(),
+            reply_tx_vars: BTreeSet::new(),
+            skipped_command_match_vars: BTreeSet::new(),
+            skipped_command_source_vars: BTreeSet::new(),
+            skipped_command_buffer_vars: BTreeSet::new(),
+            command_effects_require_skipped_source: false,
+            skipped_command_effects_armed: true,
+            side_effect_receiver_vars: BTreeSet::new(),
+            active_gated_inputs: BTreeSet::new(),
+            statement_gated_inputs: BTreeSet::new(),
+            fail_closed_depth: 0,
+            summary: MobGateSummary::default(),
+        }
+    }
+
+    fn with_fail_closed<R>(&mut self, f: impl FnOnce(&mut Self) -> R) -> R {
+        self.fail_closed_depth += 1;
+        let result = f(self);
+        self.fail_closed_depth -= 1;
+        result
+    }
+
+    fn command_effects_enabled(&self) -> bool {
+        !self.command_effects_require_skipped_source || self.skipped_command_effects_armed
+    }
+
+    fn record_gate_call(&mut self, input: MobMachineInputVariant) {
+        if !self.command_effects_enabled() {
+            return;
+        }
+        if self.fail_closed_depth > 0 {
+            self.summary.gated_inputs.insert(input);
+            self.statement_gated_inputs.insert(input);
+            self.summary.events.push(MobGateEvent::Gate(input));
+        }
+    }
+
+    fn record_mob_side_effect(&mut self) {
+        if !self.command_effects_enabled() {
+            return;
+        }
+        self.summary.has_side_effect = true;
+        self.summary.events.push(MobGateEvent::SideEffect);
+        if self.active_gated_inputs.is_empty() {
+            self.summary.has_ungated_side_effect = true;
+        } else {
+            self.summary
+                .side_effect_gated_inputs
+                .extend(self.active_gated_inputs.iter().copied());
+        }
+    }
+
+    fn pending_gate_input_from_condition(
+        &self,
+        expr: &syn::Expr,
+    ) -> Option<MobMachineInputVariant> {
+        match expr {
+            syn::Expr::MethodCall(call) if call.method == "is_ok" => {
+                expr_path_single_ident(&call.receiver)
+                    .and_then(|var| self.pending_gate_result_vars.get(&var).copied())
+            }
+            syn::Expr::Paren(paren) => self.pending_gate_input_from_condition(&paren.expr),
+            syn::Expr::Group(group) => self.pending_gate_input_from_condition(&group.expr),
+            syn::Expr::Reference(reference) => {
+                self.pending_gate_input_from_condition(&reference.expr)
+            }
+            _ => None,
+        }
+    }
+
+    fn with_isolated_statement_gates<R>(&mut self, f: impl FnOnce(&mut Self) -> R) -> R {
+        let statement_before = self.statement_gated_inputs.clone();
+        let summary_gated_before = self.summary.gated_inputs.clone();
+        let fail_closed_before = self.summary.fail_closed_calls.clone();
+        let propagated_before = self.summary.propagated_calls.clone();
+        let reply_gated_before = self.summary.reply_gated_inputs.clone();
+        let events_before = self.summary.events.clone();
+        self.statement_gated_inputs.clear();
+        let result = f(self);
+        let retained_helper_events = self
+            .summary
+            .events
+            .iter()
+            .skip(events_before.len())
+            .filter(|event| matches!(event, MobGateEvent::HelperCall { .. }))
+            .cloned()
+            .collect::<Vec<_>>();
+        self.summary.gated_inputs = summary_gated_before;
+        self.summary.fail_closed_calls = fail_closed_before;
+        self.summary.propagated_calls = propagated_before;
+        self.summary.reply_gated_inputs = reply_gated_before;
+        self.summary.events = events_before;
+        self.summary.events.extend(retained_helper_events);
+        self.statement_gated_inputs = statement_before;
+        result
+    }
+
+    fn with_isolated_gate_state<R>(&mut self, f: impl FnOnce(&mut Self) -> R) -> R {
+        let input_vars_before = self.input_vars.clone();
+        let pending_gate_result_vars_before = self.pending_gate_result_vars.clone();
+        let self_call_result_vars_before = self.self_call_result_vars.clone();
+        let reply_tx_vars_before = self.reply_tx_vars.clone();
+        let skipped_command_match_vars_before = self.skipped_command_match_vars.clone();
+        let skipped_command_source_vars_before = self.skipped_command_source_vars.clone();
+        let skipped_command_buffer_vars_before = self.skipped_command_buffer_vars.clone();
+        let skipped_command_effects_armed_before = self.skipped_command_effects_armed;
+        let side_effect_receiver_vars_before = self.side_effect_receiver_vars.clone();
+        let active_before = self.active_gated_inputs.clone();
+        let statement_before = self.statement_gated_inputs.clone();
+        let summary_gated_before = self.summary.gated_inputs.clone();
+        let side_effect_gated_before = self.summary.side_effect_gated_inputs.clone();
+        let has_side_effect_before = self.summary.has_side_effect;
+        let has_ungated_side_effect_before = self.summary.has_ungated_side_effect;
+        let fail_closed_before = self.summary.fail_closed_calls.clone();
+        let propagated_before = self.summary.propagated_calls.clone();
+        let reply_gated_before = self.summary.reply_gated_inputs.clone();
+        let events_before = self.summary.events.clone();
+        self.statement_gated_inputs.clear();
+        let result = f(self);
+        self.summary.gated_inputs = summary_gated_before;
+        self.summary.side_effect_gated_inputs = side_effect_gated_before;
+        self.summary.has_side_effect = has_side_effect_before;
+        self.summary.has_ungated_side_effect = has_ungated_side_effect_before;
+        self.summary.fail_closed_calls = fail_closed_before;
+        self.summary.propagated_calls = propagated_before;
+        self.summary.reply_gated_inputs = reply_gated_before;
+        self.summary.events = events_before;
+        self.active_gated_inputs = active_before;
+        self.statement_gated_inputs = statement_before;
+        self.input_vars = input_vars_before;
+        self.pending_gate_result_vars = pending_gate_result_vars_before;
+        self.self_call_result_vars = self_call_result_vars_before;
+        self.reply_tx_vars = reply_tx_vars_before;
+        self.skipped_command_match_vars = skipped_command_match_vars_before;
+        self.skipped_command_source_vars = skipped_command_source_vars_before;
+        self.skipped_command_buffer_vars = skipped_command_buffer_vars_before;
+        self.skipped_command_effects_armed = skipped_command_effects_armed_before;
+        self.side_effect_receiver_vars = side_effect_receiver_vars_before;
+        result
+    }
+
+    fn with_isolated_loop_gate_state<R>(&mut self, f: impl FnOnce(&mut Self) -> R) -> R {
+        let input_vars_before = self.input_vars.clone();
+        let pending_gate_result_vars_before = self.pending_gate_result_vars.clone();
+        let self_call_result_vars_before = self.self_call_result_vars.clone();
+        let reply_tx_vars_before = self.reply_tx_vars.clone();
+        let skipped_command_match_vars_before = self.skipped_command_match_vars.clone();
+        let skipped_command_source_vars_before = self.skipped_command_source_vars.clone();
+        let skipped_command_buffer_vars_before = self.skipped_command_buffer_vars.clone();
+        let skipped_command_effects_armed_before = self.skipped_command_effects_armed;
+        let side_effect_receiver_vars_before = self.side_effect_receiver_vars.clone();
+        let active_before = self.active_gated_inputs.clone();
+        let statement_before = self.statement_gated_inputs.clone();
+        let summary_gated_before = self.summary.gated_inputs.clone();
+        let fail_closed_before = self.summary.fail_closed_calls.clone();
+        let propagated_before = self.summary.propagated_calls.clone();
+        let reply_gated_before = self.summary.reply_gated_inputs.clone();
+        let events_before = self.summary.events.clone();
+        self.statement_gated_inputs.clear();
+        let result = f(self);
+        self.summary.gated_inputs = summary_gated_before;
+        self.summary.fail_closed_calls = fail_closed_before;
+        self.summary.propagated_calls = propagated_before;
+        self.summary.reply_gated_inputs = reply_gated_before;
+        self.summary.events = events_before;
+        self.active_gated_inputs = active_before;
+        self.statement_gated_inputs = statement_before;
+        retain_loop_preserved_gate_map(&mut self.input_vars, &input_vars_before);
+        retain_loop_preserved_gate_map(
+            &mut self.pending_gate_result_vars,
+            &pending_gate_result_vars_before,
+        );
+        retain_loop_preserved_gate_map(
+            &mut self.self_call_result_vars,
+            &self_call_result_vars_before,
+        );
+        retain_loop_preserved_gate_set(&mut self.reply_tx_vars, &reply_tx_vars_before);
+        retain_loop_preserved_gate_set(
+            &mut self.skipped_command_match_vars,
+            &skipped_command_match_vars_before,
+        );
+        retain_loop_preserved_gate_set(
+            &mut self.skipped_command_source_vars,
+            &skipped_command_source_vars_before,
+        );
+        retain_loop_preserved_gate_set(
+            &mut self.skipped_command_buffer_vars,
+            &skipped_command_buffer_vars_before,
+        );
+        self.skipped_command_effects_armed = skipped_command_effects_armed_before;
+        retain_loop_preserved_gate_set(
+            &mut self.side_effect_receiver_vars,
+            &side_effect_receiver_vars_before,
+        );
+        result
+    }
+
+    fn with_shadowed_gate_vars<R>(
+        &mut self,
+        names: &BTreeSet<String>,
+        f: impl FnOnce(&mut Self) -> R,
+    ) -> R {
+        if names.is_empty() {
+            return f(self);
+        }
+        let input_vars_before = self.input_vars.clone();
+        let pending_gate_result_vars_before = self.pending_gate_result_vars.clone();
+        let self_call_result_vars_before = self.self_call_result_vars.clone();
+        let reply_tx_vars_before = self.reply_tx_vars.clone();
+        let skipped_command_match_vars_before = self.skipped_command_match_vars.clone();
+        let skipped_command_source_vars_before = self.skipped_command_source_vars.clone();
+        let skipped_command_buffer_vars_before = self.skipped_command_buffer_vars.clone();
+        let side_effect_receiver_vars_before = self.side_effect_receiver_vars.clone();
+        for name in names {
+            self.input_vars.remove(name);
+            self.pending_gate_result_vars.remove(name);
+            self.self_call_result_vars.remove(name);
+            self.reply_tx_vars.remove(name);
+            self.skipped_command_match_vars.remove(name);
+            self.skipped_command_source_vars.remove(name);
+            self.skipped_command_buffer_vars.remove(name);
+            self.side_effect_receiver_vars.remove(name);
+        }
+        let result = f(self);
+        self.input_vars = input_vars_before;
+        self.pending_gate_result_vars = pending_gate_result_vars_before;
+        self.self_call_result_vars = self_call_result_vars_before;
+        self.reply_tx_vars = reply_tx_vars_before;
+        self.skipped_command_match_vars = skipped_command_match_vars_before;
+        self.skipped_command_source_vars = skipped_command_source_vars_before;
+        self.skipped_command_buffer_vars = skipped_command_buffer_vars_before;
+        self.side_effect_receiver_vars = side_effect_receiver_vars_before;
+        result
+    }
+
+    fn invalidate_gate_var(&mut self, name: &str) {
+        self.input_vars.remove(name);
+        self.pending_gate_result_vars.remove(name);
+        self.self_call_result_vars.remove(name);
+        self.reply_tx_vars.remove(name);
+        self.skipped_command_match_vars.remove(name);
+        self.skipped_command_source_vars.remove(name);
+        self.skipped_command_buffer_vars.remove(name);
+        self.side_effect_receiver_vars.remove(name);
+    }
+
+    fn expr_is_mob_side_effect_receiver_source(&self, expr: &syn::Expr) -> bool {
+        expr_root_ident_through_method_calls(expr)
+            .as_ref()
+            .is_some_and(|root| self.side_effect_receiver_vars.contains(root))
+            || expr_is_self_mob_side_effect_field(expr)
+            || self.expr_contains_mob_side_effect_receiver_source(expr)
+    }
+
+    fn expr_contains_mob_side_effect_receiver_source(&self, expr: &syn::Expr) -> bool {
+        match expr {
+            syn::Expr::Call(call) => call
+                .args
+                .iter()
+                .any(|arg| self.expr_is_mob_side_effect_receiver_source(arg)),
+            syn::Expr::MethodCall(call) => {
+                self.expr_is_mob_side_effect_receiver_source(&call.receiver)
+                    || call
+                        .args
+                        .iter()
+                        .any(|arg| self.expr_is_mob_side_effect_receiver_source(arg))
+            }
+            syn::Expr::Try(try_expr) => {
+                self.expr_is_mob_side_effect_receiver_source(&try_expr.expr)
+            }
+            syn::Expr::Await(await_expr) => {
+                self.expr_is_mob_side_effect_receiver_source(&await_expr.base)
+            }
+            syn::Expr::Reference(reference) => {
+                self.expr_is_mob_side_effect_receiver_source(&reference.expr)
+            }
+            syn::Expr::Paren(paren) => self.expr_is_mob_side_effect_receiver_source(&paren.expr),
+            syn::Expr::Group(group) => self.expr_is_mob_side_effect_receiver_source(&group.expr),
+            _ => false,
+        }
+    }
+
+    fn expr_uses_skipped_command_source(&self, expr: &syn::Expr) -> bool {
+        match expr {
+            syn::Expr::MethodCall(call) => {
+                let receiver = expr_path_single_ident(&call.receiver);
+                (call.method == "recv"
+                    && receiver
+                        .as_ref()
+                        .is_some_and(|ident| self.skipped_command_source_vars.contains(ident)))
+                    || (call.method == "pop_front"
+                        && receiver
+                            .as_ref()
+                            .is_some_and(|ident| self.skipped_command_buffer_vars.contains(ident)))
+                    || self.expr_uses_skipped_command_source(&call.receiver)
+                    || call
+                        .args
+                        .iter()
+                        .any(|arg| self.expr_uses_skipped_command_source(arg))
+            }
+            syn::Expr::Call(call) => call
+                .args
+                .iter()
+                .any(|arg| self.expr_uses_skipped_command_source(arg)),
+            syn::Expr::If(expr_if) => {
+                self.expr_uses_skipped_command_source(&expr_if.cond)
+                    || expr_if
+                        .then_branch
+                        .stmts
+                        .iter()
+                        .any(|stmt| self.stmt_uses_skipped_command_source(stmt))
+                    || expr_if
+                        .else_branch
+                        .as_ref()
+                        .is_some_and(|(_, expr)| self.expr_uses_skipped_command_source(expr))
+            }
+            syn::Expr::Let(expr_let) => self.expr_uses_skipped_command_source(&expr_let.expr),
+            syn::Expr::Block(block) => block
+                .block
+                .stmts
+                .iter()
+                .any(|stmt| self.stmt_uses_skipped_command_source(stmt)),
+            syn::Expr::Try(try_expr) => self.expr_uses_skipped_command_source(&try_expr.expr),
+            syn::Expr::Await(await_expr) => self.expr_uses_skipped_command_source(&await_expr.base),
+            syn::Expr::Reference(reference) => {
+                self.expr_uses_skipped_command_source(&reference.expr)
+            }
+            syn::Expr::Paren(paren) => self.expr_uses_skipped_command_source(&paren.expr),
+            syn::Expr::Group(group) => self.expr_uses_skipped_command_source(&group.expr),
+            _ => false,
+        }
+    }
+
+    fn stmt_uses_skipped_command_source(&self, stmt: &syn::Stmt) -> bool {
+        match stmt {
+            syn::Stmt::Local(local) => local
+                .init
+                .as_ref()
+                .is_some_and(|init| self.expr_uses_skipped_command_source(&init.expr)),
+            syn::Stmt::Expr(expr, _) => self.expr_uses_skipped_command_source(expr),
+            syn::Stmt::Item(_) | syn::Stmt::Macro(_) => false,
+        }
+    }
+}
+
+impl<'ast> Visit<'ast> for MobGateAnalyzer {
+    fn visit_block(&mut self, node: &'ast syn::Block) {
+        let aliases_before = self.aliases.clone();
+        self.aliases = self.aliases.with_block_aliases(node);
+        let local_names = block_local_bound_names(node);
+        let input_vars_before = self.input_vars.clone();
+        let pending_gate_result_vars_before = self.pending_gate_result_vars.clone();
+        let self_call_result_vars_before = self.self_call_result_vars.clone();
+        let reply_tx_vars_before = self.reply_tx_vars.clone();
+        let skipped_command_match_vars_before = self.skipped_command_match_vars.clone();
+        let skipped_command_source_vars_before = self.skipped_command_source_vars.clone();
+        let skipped_command_buffer_vars_before = self.skipped_command_buffer_vars.clone();
+        let side_effect_receiver_vars_before = self.side_effect_receiver_vars.clone();
+        for stmt in &node.stmts {
+            self.statement_gated_inputs.clear();
+            self.visit_stmt(stmt);
+            self.active_gated_inputs
+                .extend(self.statement_gated_inputs.iter().copied());
+        }
+        self.statement_gated_inputs.clear();
+        for name in &local_names {
+            if let Some(input) = input_vars_before.get(name) {
+                self.input_vars.insert(name.clone(), *input);
+            } else {
+                self.input_vars.remove(name);
+            }
+            if let Some(input) = pending_gate_result_vars_before.get(name) {
+                self.pending_gate_result_vars.insert(name.clone(), *input);
+            } else {
+                self.pending_gate_result_vars.remove(name);
+            }
+            if let Some(method) = self_call_result_vars_before.get(name) {
+                self.self_call_result_vars
+                    .insert(name.clone(), method.clone());
+            } else {
+                self.self_call_result_vars.remove(name);
+            }
+            if reply_tx_vars_before.contains(name) {
+                self.reply_tx_vars.insert(name.clone());
+            } else {
+                self.reply_tx_vars.remove(name);
+            }
+            if skipped_command_match_vars_before.contains(name) {
+                self.skipped_command_match_vars.insert(name.clone());
+            } else {
+                self.skipped_command_match_vars.remove(name);
+            }
+            if skipped_command_source_vars_before.contains(name) {
+                self.skipped_command_source_vars.insert(name.clone());
+            } else {
+                self.skipped_command_source_vars.remove(name);
+            }
+            if skipped_command_buffer_vars_before.contains(name) {
+                self.skipped_command_buffer_vars.insert(name.clone());
+            } else {
+                self.skipped_command_buffer_vars.remove(name);
+            }
+            if side_effect_receiver_vars_before.contains(name) {
+                self.side_effect_receiver_vars.insert(name.clone());
+            } else {
+                self.side_effect_receiver_vars.remove(name);
+            }
+        }
+        self.aliases = aliases_before;
+    }
+
+    fn visit_local(&mut self, node: &'ast syn::Local) {
+        if let Some(init) = &node.init {
+            self.visit_expr(&init.expr);
+            if let Some((_, diverge)) = &init.diverge {
+                self.visit_expr(diverge);
+            }
+        }
+        let bound_names = pat_bound_idents(&node.pat);
+        if let syn::Pat::Ident(ident) = &node.pat
+            && let Some(init) = &node.init
+        {
+            let name = ident.ident.to_string();
+            let is_reply_tx_alias = expr_path_single_ident(&init.expr)
+                .as_ref()
+                .is_some_and(|source| self.reply_tx_vars.contains(source));
+            if is_reply_tx_alias {
+                self.reply_tx_vars.insert(name.clone());
+            } else {
+                self.reply_tx_vars.remove(&name);
+            }
+            if let Some(input) =
+                mob_input_variant_from_expr(&init.expr, &self.input_vars, &self.aliases)
+            {
+                self.input_vars.insert(name.clone(), input);
+            } else {
+                self.input_vars.remove(&name);
+            }
+            if let Some(input) =
+                mob_gate_input_from_expr(&init.expr, &self.input_vars, &self.aliases)
+            {
+                self.pending_gate_result_vars.insert(name.clone(), input);
+            } else {
+                self.pending_gate_result_vars.remove(&name);
+            }
+            if let Some(method) = self_method_call_name_from_expr(&init.expr) {
+                self.self_call_result_vars.insert(name.clone(), method);
+            } else {
+                self.self_call_result_vars.remove(&name);
+            }
+            let uses_skipped_command_source = self.expr_uses_skipped_command_source(&init.expr);
+            if uses_skipped_command_source {
+                self.skipped_command_effects_armed = true;
+            }
+            let is_skipped_command_source_alias = expr_path_single_ident(&init.expr)
+                .as_ref()
+                .is_some_and(|source| self.skipped_command_source_vars.contains(source));
+            if is_skipped_command_source_alias {
+                self.skipped_command_source_vars.insert(name.clone());
+            } else {
+                self.skipped_command_source_vars.remove(&name);
+            }
+            let is_skipped_command_buffer = expr_initializes_mob_command_buffer(&init.expr)
+                && !self.skipped_command_source_vars.is_empty();
+            if is_skipped_command_buffer {
+                self.skipped_command_buffer_vars.insert(name.clone());
+            } else {
+                self.skipped_command_buffer_vars.remove(&name);
+            }
+            if uses_skipped_command_source
+                || expr_path_single_ident(&init.expr)
+                    .as_ref()
+                    .is_some_and(|source| self.skipped_command_match_vars.contains(source))
+            {
+                self.skipped_command_match_vars.insert(name.clone());
+            } else {
+                self.skipped_command_match_vars.remove(&name);
+            }
+            if self.expr_is_mob_side_effect_receiver_source(&init.expr) {
+                self.side_effect_receiver_vars.insert(name);
+            } else {
+                self.side_effect_receiver_vars.remove(&name);
+            }
+            return;
+        }
+        for name in bound_names {
+            self.input_vars.remove(&name);
+            self.pending_gate_result_vars.remove(&name);
+            self.self_call_result_vars.remove(&name);
+            self.reply_tx_vars.remove(&name);
+            self.skipped_command_match_vars.remove(&name);
+            self.skipped_command_source_vars.remove(&name);
+            self.skipped_command_buffer_vars.remove(&name);
+            self.side_effect_receiver_vars.remove(&name);
+        }
+    }
+
+    fn visit_expr_try(&mut self, node: &'ast syn::ExprTry) {
+        if expr_is_ok_constructor_call(&node.expr)
+            || expr_contains_fail_open_result_method(&node.expr)
+        {
+            self.visit_expr(&node.expr);
+        } else {
+            self.with_fail_closed(|this| this.visit_expr(&node.expr));
+        }
+    }
+
+    fn visit_expr_if(&mut self, node: &'ast syn::ExprIf) {
+        self.visit_expr(&node.cond);
+        let shadowed_cond_names = match &*node.cond {
+            syn::Expr::Let(expr_let) => pat_bound_idents(&expr_let.pat),
+            _ => BTreeSet::new(),
+        };
+        let active_before = self.active_gated_inputs.clone();
+        if let Some(input) = self.pending_gate_input_from_condition(&node.cond) {
+            self.active_gated_inputs.insert(input);
+            self.with_isolated_statement_gates(|this| {
+                this.with_shadowed_gate_vars(&shadowed_cond_names, |this| {
+                    this.with_fail_closed(|this| this.visit_block(&node.then_branch));
+                });
+            });
+        } else {
+            self.with_isolated_statement_gates(|this| {
+                this.with_shadowed_gate_vars(&shadowed_cond_names, |this| {
+                    this.visit_block(&node.then_branch);
+                });
+            });
+        }
+        self.active_gated_inputs = active_before.clone();
+        if let Some((_, else_branch)) = &node.else_branch {
+            self.with_isolated_statement_gates(|this| this.visit_expr(else_branch));
+            self.active_gated_inputs = active_before;
+        }
+    }
+
+    fn visit_expr_assign(&mut self, node: &'ast syn::ExprAssign) {
+        self.visit_expr(&node.right);
+        if let Some(name) = expr_path_single_ident(&node.left) {
+            let is_reply_tx_alias = expr_path_single_ident(&node.right)
+                .as_ref()
+                .is_some_and(|source| self.reply_tx_vars.contains(source));
+            if is_reply_tx_alias {
+                self.reply_tx_vars.insert(name.clone());
+            } else {
+                self.reply_tx_vars.remove(&name);
+            }
+            if let Some(input) =
+                mob_input_variant_from_expr(&node.right, &self.input_vars, &self.aliases)
+            {
+                self.input_vars.insert(name.clone(), input);
+            } else {
+                self.input_vars.remove(&name);
+            }
+            if let Some(input) =
+                mob_gate_input_from_expr(&node.right, &self.input_vars, &self.aliases)
+            {
+                self.pending_gate_result_vars.insert(name.clone(), input);
+            } else {
+                self.pending_gate_result_vars.remove(&name);
+            }
+            if let Some(method) = self_method_call_name_from_expr(&node.right) {
+                self.self_call_result_vars.insert(name.clone(), method);
+            } else {
+                self.self_call_result_vars.remove(&name);
+            }
+            let uses_skipped_command_source = self.expr_uses_skipped_command_source(&node.right);
+            if uses_skipped_command_source {
+                self.skipped_command_effects_armed = true;
+            }
+            let is_skipped_command_source_alias = expr_path_single_ident(&node.right)
+                .as_ref()
+                .is_some_and(|source| self.skipped_command_source_vars.contains(source));
+            if is_skipped_command_source_alias {
+                self.skipped_command_source_vars.insert(name.clone());
+            } else {
+                self.skipped_command_source_vars.remove(&name);
+            }
+            let is_skipped_command_buffer = expr_initializes_mob_command_buffer(&node.right)
+                && !self.skipped_command_source_vars.is_empty();
+            if is_skipped_command_buffer {
+                self.skipped_command_buffer_vars.insert(name.clone());
+            } else {
+                self.skipped_command_buffer_vars.remove(&name);
+            }
+            if uses_skipped_command_source
+                || expr_path_single_ident(&node.right)
+                    .as_ref()
+                    .is_some_and(|source| self.skipped_command_match_vars.contains(source))
+            {
+                self.skipped_command_match_vars.insert(name.clone());
+            } else {
+                self.skipped_command_match_vars.remove(&name);
+            }
+            if self.expr_is_mob_side_effect_receiver_source(&node.right) {
+                self.side_effect_receiver_vars.insert(name);
+            } else {
+                self.side_effect_receiver_vars.remove(&name);
+            }
+        } else {
+            self.visit_expr(&node.left);
+        }
+    }
+
+    fn visit_expr_binary(&mut self, node: &'ast syn::ExprBinary) {
+        if bin_op_is_assign(&node.op)
+            && let Some(name) = expr_root_ident(&node.left)
+        {
+            self.invalidate_gate_var(&name);
+        }
+        visit::visit_expr_binary(self, node);
+    }
+
+    fn visit_expr_reference(&mut self, node: &'ast syn::ExprReference) {
+        if node.mutability.is_some()
+            && let Some(name) = expr_path_single_ident(&node.expr)
+        {
+            self.invalidate_gate_var(&name);
+        }
+        visit::visit_expr_reference(self, node);
+    }
+
+    fn visit_expr_match(&mut self, node: &'ast syn::ExprMatch) {
+        self.visit_expr(&node.expr);
+        let uses_skipped_command_source = self.expr_uses_skipped_command_source(&node.expr);
+        if uses_skipped_command_source {
+            self.skipped_command_effects_armed = true;
+        }
+        if uses_skipped_command_source
+            || expr_path_single_ident(&node.expr)
+                .as_ref()
+                .is_some_and(|ident| self.skipped_command_match_vars.contains(ident))
+        {
+            return;
+        }
+        let active_before = self.active_gated_inputs.clone();
+        for arm in &node.arms {
+            self.active_gated_inputs = active_before.clone();
+            let shadowed_names = pat_bound_idents(&arm.pat);
+            self.with_shadowed_gate_vars(&shadowed_names, |this| {
+                if let Some((_, guard)) = &arm.guard {
+                    this.visit_expr(guard);
+                }
+                this.with_isolated_statement_gates(|this| this.visit_expr(&arm.body));
+            });
+        }
+        self.active_gated_inputs = active_before;
+    }
+
+    fn visit_expr_closure(&mut self, node: &'ast syn::ExprClosure) {
+        self.with_isolated_gate_state(|this| visit::visit_expr_closure(this, node));
+    }
+
+    fn visit_expr_async(&mut self, node: &'ast syn::ExprAsync) {
+        self.with_isolated_gate_state(|this| visit::visit_expr_async(this, node));
+    }
+
+    fn visit_expr_loop(&mut self, node: &'ast syn::ExprLoop) {
+        self.with_isolated_loop_gate_state(|this| visit::visit_expr_loop(this, node));
+    }
+
+    fn visit_expr_while(&mut self, node: &'ast syn::ExprWhile) {
+        self.with_isolated_loop_gate_state(|this| visit::visit_expr_while(this, node));
+    }
+
+    fn visit_expr_for_loop(&mut self, node: &'ast syn::ExprForLoop) {
+        self.with_isolated_loop_gate_state(|this| visit::visit_expr_for_loop(this, node));
+    }
+
+    fn visit_expr_call(&mut self, node: &'ast syn::ExprCall) {
+        if let syn::Expr::Path(func) = &*node.func
+            && let Some(name) = func
+                .path
+                .segments
+                .last()
+                .map(|segment| segment.ident.to_string())
+            && self.fail_closed_depth > 0
+            && self.command_effects_enabled()
+        {
+            self.summary.fail_closed_calls.insert(name.clone());
+            self.summary.events.push(MobGateEvent::FailClosedCall(name));
+        }
+        if mob_side_effect_path_call(node, &self.side_effect_receiver_vars) {
+            self.record_mob_side_effect();
+        }
+        visit::visit_expr_call(self, node);
+    }
+
+    fn visit_expr_method_call(&mut self, node: &'ast syn::ExprMethodCall) {
+        let method = node.method.to_string();
+        if gate_provenance_mutator_method(&method)
+            && let Some(name) = expr_root_ident(&node.receiver)
+        {
+            self.invalidate_gate_var(&name);
+        }
+        if method == "map_err" {
+            if self.fail_closed_depth > 0 {
+                self.with_fail_closed(|this| this.visit_expr(&node.receiver));
+            } else {
+                self.visit_expr(&node.receiver);
+            }
+            for arg in &node.args {
+                self.visit_expr(arg);
+            }
+            return;
+        }
+        if expr_is_self_receiver(&node.receiver) {
+            if self.fail_closed_depth > 0 && self.command_effects_enabled() {
+                self.summary.fail_closed_calls.insert(method.clone());
+                self.summary
+                    .events
+                    .push(MobGateEvent::FailClosedCall(method.clone()));
+            }
+            if self.command_effects_enabled() {
+                self.summary.events.push(MobGateEvent::HelperCall {
+                    call: method.clone(),
+                    gated_inputs: self.active_gated_inputs.clone(),
+                });
+            }
+        }
+        if method == "send"
+            && expr_path_single_ident(&node.receiver)
+                .as_ref()
+                .is_some_and(|receiver| self.reply_tx_vars.contains(receiver))
+            && let Some(result_var) = node.args.first().and_then(expr_path_single_ident)
+            && let Some(input) = self.pending_gate_result_vars.get(&result_var).copied()
+            && self.command_effects_enabled()
+        {
+            self.summary.reply_gated_inputs.insert(input);
+        }
+        if method == "send"
+            && expr_path_single_ident(&node.receiver)
+                .as_ref()
+                .is_some_and(|receiver| self.reply_tx_vars.contains(receiver))
+            && let Some(result_var) = node.args.first().and_then(expr_path_single_ident)
+            && let Some(call) = self.self_call_result_vars.get(&result_var)
+            && self.command_effects_enabled()
+        {
+            self.summary.propagated_calls.insert(call.clone());
+            self.summary
+                .events
+                .push(MobGateEvent::PropagatedCall(call.clone()));
+        }
+        if mob_side_effect_call(node, &self.side_effect_receiver_vars) {
+            self.record_mob_side_effect();
+        }
+        if let Some(input) = mob_gate_method_input(node, &self.input_vars, &self.aliases) {
+            self.record_gate_call(input);
+        }
+        visit::visit_expr_method_call(self, node);
+    }
+}
+
+fn attrs_cfg_test(attrs: &[syn::Attribute]) -> bool {
+    attrs.iter().any(|attr| {
+        if !attr.path().is_ident("cfg") {
+            return false;
+        }
+        let mut found = false;
+        let _ = attr.parse_nested_meta(|meta| {
+            if meta.path.is_ident("test") {
+                found = true;
+            }
+            Ok(())
+        });
+        found
+    })
+}
+
+fn path_segments(path: &syn::Path) -> Vec<String> {
+    path.segments
+        .iter()
+        .map(|segment| segment.ident.to_string())
+        .collect()
+}
+
+fn path_has_tail(path: &[String], tail: &[&str]) -> bool {
+    path.len() >= tail.len()
+        && path[path.len() - tail.len()..]
+            .iter()
+            .map(String::as_str)
+            .eq(tail.iter().copied())
+}
+
+fn path_is_canonical_mob_machine_type(path: &[String], owner: &str) -> bool {
+    path.iter().map(String::as_str).eq([owner])
+        || path
+            .iter()
+            .map(String::as_str)
+            .eq(["crate", "machines", "mob_machine", owner])
+}
+
+fn path_is_canonical_mob_command_type(path: &[String]) -> bool {
+    path_is_canonical_mob_machine_type(path, "MobCommand")
+        || path
+            .iter()
+            .map(String::as_str)
+            .eq(["super", "state", "MobCommand"])
+        || path
+            .iter()
+            .map(String::as_str)
+            .eq(["crate", "runtime", "state", "MobCommand"])
+}
+
+fn path_is_canonical_mob_machine_variant(path: &[String], owner: &str, variant: &str) -> bool {
+    (path.len() == 2
+        && path.first().is_some_and(|segment| segment == owner)
+        && path.get(1).is_some_and(|segment| segment == variant))
+        || path
+            .iter()
+            .map(String::as_str)
+            .eq(["crate", "machines", "mob_machine", owner, variant])
+}
+
+fn path_is_canonical_mob_command_variant(path: &[String], variant: &str) -> bool {
+    path_is_canonical_mob_machine_variant(path, "MobCommand", variant)
+        || path
+            .iter()
+            .map(String::as_str)
+            .eq(["super", "state", "MobCommand", variant])
+        || path
+            .iter()
+            .map(String::as_str)
+            .eq(["crate", "runtime", "state", "MobCommand", variant])
+}
+
+fn path_is_root_mob_actor_impl(path: &[String]) -> bool {
+    path.iter().map(String::as_str).eq(["MobActor"])
+}
+
+fn expr_is_self_run_store_receiver(expr: &syn::Expr) -> bool {
+    expr_field_chain(expr)
+        .iter()
+        .map(String::as_str)
+        .eq(["self", "run_store"])
+}
+
+fn expr_static_bool_value(expr: &syn::Expr) -> Option<bool> {
+    match expr {
+        syn::Expr::Lit(lit) => {
+            if let syn::Lit::Bool(value) = &lit.lit {
+                Some(value.value)
+            } else {
+                None
+            }
+        }
+        syn::Expr::Paren(paren) => expr_static_bool_value(&paren.expr),
+        syn::Expr::Group(group) => expr_static_bool_value(&group.expr),
+        _ => None,
+    }
+}
+
+fn resolved_path_is_canonical_flow_run_apply(path: &[String]) -> bool {
+    path.iter()
+        .map(String::as_str)
+        .eq(["crate", "run", "apply_mob_machine_flow_run_command"])
+}
+
+fn path_is_canonical_mob_run_store_cas_call(
+    path: &syn::Path,
+    aliases: &RustUseAliases,
+    method: &str,
+) -> bool {
+    if aliases.path_has_shadowed_bare_root(path)
+        || (aliases.ambiguous_glob_import
+            && aliases.path_has_unresolved_bare_root(path, "MobRunStore"))
+    {
+        return false;
+    }
+    aliases.resolve_path(path).into_iter().any(|segments| {
+        segments
+            .iter()
+            .map(String::as_str)
+            .eq(["MobRunStore", method])
+            || segments
+                .iter()
+                .map(String::as_str)
+                .eq(["crate", "store", "MobRunStore", method])
+    })
+}
+
+fn member_key(member: &syn::Member) -> String {
+    match member {
+        syn::Member::Named(ident) => ident.to_string(),
+        syn::Member::Unnamed(index) => index.index.to_string(),
+    }
+}
+
+fn line_number(node: &impl syn::spanned::Spanned) -> usize {
+    node.span().start().line
+}
+
+fn source_position(node: &impl syn::spanned::Spanned) -> SourcePosition {
+    let start = node.span().start();
+    SourcePosition {
+        line: start.line,
+        column: start.column,
+    }
+}
+
+fn expr_as_path(expr: &syn::Expr) -> Option<&syn::Path> {
+    match expr {
+        syn::Expr::Path(path) => Some(&path.path),
+        syn::Expr::Paren(paren) => expr_as_path(&paren.expr),
+        syn::Expr::Group(group) => expr_as_path(&group.expr),
+        _ => None,
+    }
+}
+
+fn expr_path_single_ident(expr: &syn::Expr) -> Option<String> {
+    let path = expr_as_path(expr)?;
+    if path.segments.len() == 1 {
+        path.segments
+            .first()
+            .map(|segment| segment.ident.to_string())
+    } else {
+        None
+    }
+}
+
+fn expr_root_ident(expr: &syn::Expr) -> Option<String> {
+    match expr {
+        syn::Expr::Path(_) => expr_path_single_ident(expr),
+        syn::Expr::Field(field) => expr_root_ident(&field.base),
+        syn::Expr::Index(index) => expr_root_ident(&index.expr),
+        syn::Expr::Reference(reference) => expr_root_ident(&reference.expr),
+        syn::Expr::Unary(unary) if matches!(unary.op, syn::UnOp::Deref(_)) => {
+            expr_root_ident(&unary.expr)
+        }
+        syn::Expr::Paren(paren) => expr_root_ident(&paren.expr),
+        syn::Expr::Group(group) => expr_root_ident(&group.expr),
+        syn::Expr::Await(await_expr) => expr_root_ident(&await_expr.base),
+        _ => None,
+    }
+}
+
+fn expr_identity_argument_name(expr: &syn::Expr) -> Option<String> {
+    match expr {
+        syn::Expr::Path(_) => expr_path_single_ident(expr),
+        syn::Expr::MethodCall(call)
+            if matches!(call.method.to_string().as_str(), "clone" | "as_ref") =>
+        {
+            expr_identity_argument_name(&call.receiver)
+        }
+        syn::Expr::Reference(reference) => expr_identity_argument_name(&reference.expr),
+        syn::Expr::Paren(paren) => expr_identity_argument_name(&paren.expr),
+        syn::Expr::Group(group) => expr_identity_argument_name(&group.expr),
+        _ => None,
+    }
+}
+
+fn expr_is_plan_scrutinee(expr: &syn::Expr, plan_vars: &BTreeSet<String>) -> bool {
+    expr_variable_name(expr, plan_vars).is_some()
+}
+
+fn expr_initializes_mob_command_buffer(expr: &syn::Expr) -> bool {
+    match expr {
+        syn::Expr::Call(call) => expr_as_path(&call.func)
+            .is_some_and(|path| path_has_tail(&path_segments(path), &["VecDeque", "new"])),
+        syn::Expr::Paren(paren) => expr_initializes_mob_command_buffer(&paren.expr),
+        syn::Expr::Group(group) => expr_initializes_mob_command_buffer(&group.expr),
         _ => false,
     }
 }
 
-fn nearest_function_start(lines: &[&str], line_index: usize) -> Option<usize> {
-    (0..=line_index).rev().find(|index| {
-        let compact = lines[*index].split_whitespace().collect::<String>();
-        compact.starts_with("fn")
-            || compact.starts_with("pubfn")
-            || compact.starts_with("pub(crate)fn")
-            || compact.starts_with("pub(super)fn")
-            || compact.starts_with("asyncfn")
-            || compact.starts_with("pubasyncfn")
-            || compact.starts_with("pub(crate)asyncfn")
-            || compact.starts_with("pub(super)asyncfn")
-    })
+fn state_struct_fields(path: &Path) -> Result<BTreeSet<String>> {
+    if !path.exists() {
+        return Ok(BTreeSet::new());
+    }
+    let source = fs::read_to_string(path).with_context(|| format!("read {}", path.display()))?;
+    let parsed = syn::parse_file(&source).with_context(|| format!("parse {}", path.display()))?;
+    Ok(parsed
+        .items
+        .iter()
+        .find_map(|item| match item {
+            syn::Item::Struct(item_struct) if item_struct.ident == "State" => {
+                Some(named_field_idents(&item_struct.fields))
+            }
+            _ => None,
+        })
+        .unwrap_or_default())
 }
 
-fn nearest_impl_start(lines: &[&str], line_index: usize) -> Option<usize> {
-    (0..=line_index).rev().find(|index| {
-        let compact = lines[*index].split_whitespace().collect::<String>();
-        compact.starts_with("impl")
-    })
+fn named_field_idents(fields: &syn::Fields) -> BTreeSet<String> {
+    match fields {
+        syn::Fields::Named(fields) => fields
+            .named
+            .iter()
+            .filter_map(|field| field.ident.as_ref().map(ToString::to_string))
+            .collect(),
+        syn::Fields::Unnamed(_) | syn::Fields::Unit => BTreeSet::new(),
+    }
 }
 
-fn compact_function_signature(lines: &[&str], function_start: usize) -> String {
-    let mut signature = String::new();
-    for line in &lines[function_start..] {
-        for part in line.split_whitespace() {
-            signature.push_str(part);
-        }
-        if line.contains('{') {
-            break;
+fn flow_frame_loop_store_plan_variant_fields(
+    path: &Path,
+) -> Result<BTreeMap<String, BTreeSet<String>>> {
+    if !path.exists() {
+        return Ok(BTreeMap::new());
+    }
+    let source = fs::read_to_string(path).with_context(|| format!("read {}", path.display()))?;
+    let parsed = syn::parse_file(&source).with_context(|| format!("parse {}", path.display()))?;
+    let mut variants = BTreeMap::new();
+    for item in parsed.items {
+        if let syn::Item::Enum(item_enum) = item
+            && item_enum.ident == "FlowFrameLoopStorePlan"
+        {
+            for variant in item_enum.variants {
+                let mut fields = named_field_idents(&variant.fields);
+                fields.remove("machine_inputs");
+                variants.insert(variant.ident.to_string(), fields);
+            }
         }
     }
-    signature
+    Ok(variants)
 }
 
-fn function_name_from_signature(line: &str) -> Option<String> {
-    let compact = line.split_whitespace().collect::<String>();
-    let after_fn = compact.split_once("fn")?.1;
-    let name = after_fn
-        .chars()
-        .take_while(|ch| ch.is_ascii_alphanumeric() || *ch == '_')
-        .collect::<String>();
-    (!name.is_empty()).then_some(name)
+fn mob_run_store_cas_methods(path: &Path) -> Result<BTreeMap<String, ProjectionCasMethodFacts>> {
+    if !path.exists() {
+        return Ok(BTreeMap::new());
+    }
+    let source = fs::read_to_string(path).with_context(|| format!("read {}", path.display()))?;
+    let parsed = syn::parse_file(&source).with_context(|| format!("parse {}", path.display()))?;
+    let mut methods = BTreeMap::new();
+    for item in parsed.items {
+        if let syn::Item::Trait(item_trait) = item
+            && item_trait.ident == "MobRunStore"
+        {
+            for trait_item in item_trait.items {
+                if let syn::TraitItem::Fn(method) = trait_item {
+                    let method_name = method.sig.ident.to_string();
+                    if method_name.starts_with("cas_") {
+                        methods.insert(method_name, projection_cas_method_facts(&method.sig));
+                    }
+                }
+            }
+        }
+    }
+    Ok(methods)
+}
+
+fn projection_cas_method_facts(sig: &syn::Signature) -> ProjectionCasMethodFacts {
+    let mut facts = ProjectionCasMethodFacts::default();
+    let mut method_arg_index = 0;
+    for input in &sig.inputs {
+        match input {
+            syn::FnArg::Receiver(_) => {}
+            syn::FnArg::Typed(pat_type) => {
+                let arg_name = pat_ident_name(&pat_type.pat);
+                if let Some(arg_name) = &arg_name {
+                    facts.arg_names.insert(method_arg_index, arg_name.clone());
+                }
+                if projection_cas_arg_is_next_flow_state(pat_type) {
+                    facts.next_flow_state_arg_indices.insert(method_arg_index);
+                }
+                if projection_cas_arg_is_plan_state(pat_type) {
+                    facts.plan_state_arg_indices.insert(method_arg_index);
+                }
+                if projection_cas_arg_is_authority_input(pat_type) {
+                    facts.authority_input_arg_indices.insert(method_arg_index);
+                }
+                if arg_name.as_deref() == Some("run_id") {
+                    facts
+                        .authority_identity_arg_indices
+                        .insert(method_arg_index);
+                }
+                if arg_name.as_deref() != Some("run_id") {
+                    facts.plan_owned_arg_indices.insert(method_arg_index);
+                }
+                method_arg_index += 1;
+            }
+        }
+    }
+    facts
+}
+
+fn projection_cas_arg_is_next_flow_state(pat_type: &syn::PatType) -> bool {
+    pat_ident_name(&pat_type.pat)
+        .is_some_and(|name| name == "next" || name == "next_flow_state" || name == "next_run_state")
+        && type_path_segments(&pat_type.ty)
+            .is_some_and(|segments| path_has_tail(&segments, &["flow_run", "State"]))
+}
+
+fn projection_cas_arg_is_plan_state(pat_type: &syn::PatType) -> bool {
+    pat_ident_name(&pat_type.pat).is_some_and(|name| {
+        name == "next"
+            || name.starts_with("next_")
+            || name.starts_with("initial_")
+            || name == "next_flow_state"
+            || name == "next_run_state"
+    })
+}
+
+fn projection_cas_arg_is_authority_input(pat_type: &syn::PatType) -> bool {
+    pat_ident_name(&pat_type.pat).is_some_and(|name| name == "authority_inputs")
+        && type_contains_canonical_mob_machine_input(&pat_type.ty)
+}
+
+fn signature_return_path(sig: &syn::Signature) -> Option<Vec<String>> {
+    match &sig.output {
+        syn::ReturnType::Default => None,
+        syn::ReturnType::Type(_, ty) => type_path_segments(ty),
+    }
+}
+
+fn type_path_segments(ty: &syn::Type) -> Option<Vec<String>> {
+    match ty {
+        syn::Type::Path(path) => Some(path_segments(&path.path)),
+        syn::Type::Reference(reference) => type_path_segments(&reference.elem),
+        syn::Type::Paren(paren) => type_path_segments(&paren.elem),
+        syn::Type::Group(group) => type_path_segments(&group.elem),
+        _ => None,
+    }
+}
+
+fn type_tail_ident(ty: &syn::Type) -> Option<String> {
+    type_path_segments(ty).and_then(|segments| segments.last().cloned())
+}
+
+fn parameter_type_key(
+    ty: &syn::Type,
+    aliases: &RustUseAliases,
+    rel: &str,
+    module_depth: usize,
+) -> Option<String> {
+    let tail = type_tail_ident(ty)?;
+    match tail.as_str() {
+        "MobMachineFlowRunCommand"
+        | "MobMachineFlowFrameCommand"
+        | "MobMachineLoopIterationCommand"
+        | "MobMachineFlowAuthorityToken" => {
+            type_is_canonical_mob_run_owner_type(ty, aliases, rel, module_depth, tail.as_str())
+                .then_some(tail)
+        }
+        "FlowFrameLoopStorePlan" => {
+            type_is_canonical_flow_frame_loop_store_plan(ty, aliases).then_some(tail)
+        }
+        "RunId" => type_is_canonical_mob_run_id(ty, aliases).then_some(tail),
+        _ => Some(tail),
+    }
+}
+
+fn type_is_canonical_mob_run_owner_type(
+    ty: &syn::Type,
+    aliases: &RustUseAliases,
+    rel: &str,
+    module_depth: usize,
+    owner: &str,
+) -> bool {
+    match ty {
+        syn::Type::Path(path) => {
+            let segments = path_segments(&path.path);
+            if path.path.leading_colon.is_none()
+                && segments.len() == 1
+                && segments.first().is_some_and(|segment| segment == owner)
+                && rel == "meerkat-mob/src/run.rs"
+                && module_depth == 0
+            {
+                return true;
+            }
+            if aliases.path_has_shadowed_bare_root(&path.path) {
+                return false;
+            }
+            if aliases.ambiguous_glob_import
+                && aliases.path_has_unresolved_bare_root(&path.path, owner)
+            {
+                return false;
+            }
+            aliases
+                .resolve_path(&path.path)
+                .into_iter()
+                .any(|segments| path_is_canonical_mob_run_owner_type(&segments, owner))
+        }
+        syn::Type::Reference(reference) => {
+            type_is_canonical_mob_run_owner_type(&reference.elem, aliases, rel, module_depth, owner)
+        }
+        syn::Type::Paren(paren) => {
+            type_is_canonical_mob_run_owner_type(&paren.elem, aliases, rel, module_depth, owner)
+        }
+        syn::Type::Group(group) => {
+            type_is_canonical_mob_run_owner_type(&group.elem, aliases, rel, module_depth, owner)
+        }
+        _ => false,
+    }
+}
+
+fn path_is_canonical_mob_run_owner_type(path: &[String], owner: &str) -> bool {
+    path.iter().map(String::as_str).eq([owner])
+        || path.iter().map(String::as_str).eq(["crate", "run", owner])
+}
+
+fn type_resolved_paths_for_owner(
+    ty: &syn::Type,
+    aliases: &RustUseAliases,
+    owner: Option<&str>,
+) -> Vec<Vec<String>> {
+    match ty {
+        syn::Type::Path(path) => {
+            if aliases.path_has_shadowed_bare_root(&path.path)
+                || owner.is_some_and(|owner| {
+                    aliases.ambiguous_glob_import
+                        && aliases.path_has_unresolved_bare_root(&path.path, owner)
+                })
+            {
+                Vec::new()
+            } else {
+                aliases.resolve_path(&path.path)
+            }
+        }
+        syn::Type::Reference(reference) => {
+            type_resolved_paths_for_owner(&reference.elem, aliases, owner)
+        }
+        syn::Type::Paren(paren) => type_resolved_paths_for_owner(&paren.elem, aliases, owner),
+        syn::Type::Group(group) => type_resolved_paths_for_owner(&group.elem, aliases, owner),
+        _ => Vec::new(),
+    }
+}
+
+fn type_is_canonical_flow_frame_loop_store_plan(ty: &syn::Type, aliases: &RustUseAliases) -> bool {
+    type_resolved_paths_for_owner(ty, aliases, Some("FlowFrameLoopStorePlan"))
+        .into_iter()
+        .any(|segments| path_is_canonical_flow_frame_loop_store_plan_type(&segments))
+}
+
+fn path_is_canonical_flow_frame_loop_store_plan_type(path: &[String]) -> bool {
+    path.iter()
+        .map(String::as_str)
+        .eq(["FlowFrameLoopStorePlan"])
+        || path.iter().map(String::as_str).eq([
+            "super",
+            "flow_frame_engine",
+            "FlowFrameLoopStorePlan",
+        ])
+        || path.iter().map(String::as_str).eq([
+            "crate",
+            "runtime",
+            "flow_frame_engine",
+            "FlowFrameLoopStorePlan",
+        ])
+}
+
+fn path_is_canonical_flow_frame_loop_store_plan_variant(path: &[String], variant: &str) -> bool {
+    (path.len() == 2
+        && path
+            .first()
+            .is_some_and(|segment| segment == "FlowFrameLoopStorePlan")
+        && path.get(1).is_some_and(|segment| segment == variant))
+        || path.iter().map(String::as_str).eq([
+            "super",
+            "flow_frame_engine",
+            "FlowFrameLoopStorePlan",
+            variant,
+        ])
+        || path.iter().map(String::as_str).eq([
+            "crate",
+            "runtime",
+            "flow_frame_engine",
+            "FlowFrameLoopStorePlan",
+            variant,
+        ])
+}
+
+fn type_is_exact_canonical_mob_run_store_receiver(
+    ty: &syn::Type,
+    aliases: &RustUseAliases,
+) -> bool {
+    match ty {
+        syn::Type::Path(path) => {
+            type_path_is_canonical_mob_run_store_type(path, aliases)
+                || type_path_is_arc_canonical_mob_run_store_trait_object(path, aliases)
+        }
+        syn::Type::TraitObject(trait_object) => {
+            trait_object_is_canonical_mob_run_store(trait_object, aliases)
+        }
+        syn::Type::Reference(reference) => {
+            type_is_exact_canonical_mob_run_store_receiver(&reference.elem, aliases)
+        }
+        syn::Type::Paren(paren) => {
+            type_is_exact_canonical_mob_run_store_receiver(&paren.elem, aliases)
+        }
+        syn::Type::Group(group) => {
+            type_is_exact_canonical_mob_run_store_receiver(&group.elem, aliases)
+        }
+        _ => false,
+    }
+}
+
+fn type_path_is_canonical_mob_run_store_type(
+    path: &syn::TypePath,
+    aliases: &RustUseAliases,
+) -> bool {
+    !(type_path_has_generic_arguments(path)
+        || aliases.path_has_shadowed_bare_root(&path.path)
+        || (aliases.ambiguous_glob_import
+            && aliases.path_has_unresolved_bare_root(&path.path, "MobRunStore")))
+        && aliases
+            .resolve_path(&path.path)
+            .into_iter()
+            .any(|segments| path_is_canonical_mob_run_store_type(&segments))
+}
+
+fn type_path_is_arc_canonical_mob_run_store_trait_object(
+    path: &syn::TypePath,
+    aliases: &RustUseAliases,
+) -> bool {
+    if !type_path_is_allowed_arc(&path.path, aliases) {
+        return false;
+    }
+    let Some(segment) = path.path.segments.last() else {
+        return false;
+    };
+    let syn::PathArguments::AngleBracketed(arguments) = &segment.arguments else {
+        return false;
+    };
+    let mut type_args = arguments.args.iter().filter_map(|arg| {
+        if let syn::GenericArgument::Type(ty) = arg {
+            Some(ty)
+        } else {
+            None
+        }
+    });
+    let Some(syn::Type::TraitObject(trait_object)) = type_args.next() else {
+        return false;
+    };
+    type_args.next().is_none() && trait_object_is_canonical_mob_run_store(trait_object, aliases)
+}
+
+fn type_path_has_generic_arguments(path: &syn::TypePath) -> bool {
+    path.path
+        .segments
+        .iter()
+        .any(|segment| !matches!(segment.arguments, syn::PathArguments::None))
+}
+
+fn type_path_is_allowed_arc(path: &syn::Path, aliases: &RustUseAliases) -> bool {
+    if aliases.path_has_shadowed_bare_root(path) {
+        return false;
+    }
+    aliases.resolve_path(path).into_iter().any(|segments| {
+        segments.iter().map(String::as_str).eq(["Arc"])
+            || segments
+                .iter()
+                .map(String::as_str)
+                .eq(["std", "sync", "Arc"])
+    })
+}
+
+fn trait_object_is_canonical_mob_run_store(
+    trait_object: &syn::TypeTraitObject,
+    aliases: &RustUseAliases,
+) -> bool {
+    trait_object.bounds.iter().any(|bound| {
+        if let syn::TypeParamBound::Trait(trait_bound) = bound {
+            !(aliases.path_has_shadowed_bare_root(&trait_bound.path)
+                || (aliases.ambiguous_glob_import
+                    && aliases.path_has_unresolved_bare_root(&trait_bound.path, "MobRunStore")))
+                && aliases
+                    .resolve_path(&trait_bound.path)
+                    .into_iter()
+                    .any(|segments| path_is_canonical_mob_run_store_type(&segments))
+        } else {
+            false
+        }
+    })
+}
+
+fn path_is_canonical_mob_run_store_type(path: &[String]) -> bool {
+    path.iter().map(String::as_str).eq(["MobRunStore"])
+        || path
+            .iter()
+            .map(String::as_str)
+            .eq(["crate", "store", "MobRunStore"])
+        || path
+            .iter()
+            .map(String::as_str)
+            .eq(["super", "store", "MobRunStore"])
+}
+
+fn actor_plan_arm_facts_from_pat(pat: &syn::Pat, aliases: &RustUseAliases) -> ActorPlanArmFacts {
+    let mut facts = ActorPlanArmFacts {
+        bindings: pat_bound_idents(pat),
+        ..ActorPlanArmFacts::default()
+    };
+    collect_actor_plan_arm_facts(pat, aliases, &mut facts);
+    facts
+}
+
+fn actor_plan_single_variant(plan_arm: &ActorPlanArmFacts) -> Option<String> {
+    (plan_arm.variants.len() == 1)
+        .then(|| plan_arm.variants.iter().next().cloned())
+        .flatten()
+}
+
+fn actor_plan_field_for_cas_arg(
+    arg_name: &str,
+    variant_fields: &BTreeSet<String>,
+) -> Option<String> {
+    match arg_name {
+        "expected" if variant_fields.contains("expected_frame") => Some("expected_frame"),
+        "expected" if variant_fields.contains("expected_run_state") => Some("expected_run_state"),
+        "next" if variant_fields.contains("next_frame") => Some("next_frame"),
+        "next" if variant_fields.contains("next_run_state") => Some("next_run_state"),
+        "next" if variant_fields.contains("initial_frame") => Some("initial_frame"),
+        field if variant_fields.contains(field) => Some(field),
+        _ => None,
+    }
+    .map(ToOwned::to_owned)
+}
+
+fn collect_actor_plan_arm_facts(
+    pat: &syn::Pat,
+    aliases: &RustUseAliases,
+    facts: &mut ActorPlanArmFacts,
+) {
+    match pat {
+        syn::Pat::Struct(pat_struct) => {
+            let variant = aliases
+                .resolve_path(&pat_struct.path)
+                .into_iter()
+                .find_map(|path| {
+                    path.last().and_then(|variant| {
+                        path_is_canonical_flow_frame_loop_store_plan_variant(&path, variant)
+                            .then(|| variant.clone())
+                    })
+                });
+            if let Some(variant) = variant {
+                facts.variants.insert(variant);
+            }
+            for field in &pat_struct.fields {
+                if let syn::Member::Named(ident) = &field.member {
+                    let field_name = ident.to_string();
+                    if field_name != "machine_inputs" {
+                        let bindings = pat_bound_idents(&field.pat);
+                        if !bindings.is_empty() {
+                            facts
+                                .field_bindings
+                                .entry(field_name)
+                                .or_default()
+                                .extend(bindings);
+                        }
+                    }
+                }
+            }
+        }
+        syn::Pat::Reference(reference) => {
+            collect_actor_plan_arm_facts(&reference.pat, aliases, facts);
+        }
+        syn::Pat::Paren(paren) => {
+            collect_actor_plan_arm_facts(&paren.pat, aliases, facts);
+        }
+        syn::Pat::Or(or_pat) => {
+            for case in &or_pat.cases {
+                collect_actor_plan_arm_facts(case, aliases, facts);
+            }
+        }
+        syn::Pat::Type(ty) => {
+            collect_actor_plan_arm_facts(&ty.pat, aliases, facts);
+        }
+        _ => {}
+    }
+}
+
+fn type_is_canonical_mob_run_id(ty: &syn::Type, aliases: &RustUseAliases) -> bool {
+    type_resolved_paths_for_owner(ty, aliases, Some("RunId"))
+        .into_iter()
+        .any(|segments| path_is_canonical_mob_run_id_type(&segments))
+}
+
+fn path_is_canonical_mob_run_id_type(path: &[String]) -> bool {
+    path.iter().map(String::as_str).eq(["RunId"])
+        || path.iter().map(String::as_str).eq(["crate", "RunId"])
+        || path
+            .iter()
+            .map(String::as_str)
+            .eq(["crate", "ids", "RunId"])
+        || path.iter().map(String::as_str).eq(["super", "RunId"])
+        || path
+            .iter()
+            .map(String::as_str)
+            .eq(["super", "ids", "RunId"])
+}
+
+fn type_is_canonical_mob_command(ty: &syn::Type, aliases: &RustUseAliases) -> bool {
+    match ty {
+        syn::Type::Path(path) => {
+            !(aliases.path_has_shadowed_bare_root(&path.path)
+                || (aliases.ambiguous_glob_import
+                    && aliases.path_has_unresolved_bare_root(&path.path, "MobCommand")))
+                && aliases
+                    .resolve_path(&path.path)
+                    .into_iter()
+                    .any(|segments| path_is_canonical_mob_command_type(&segments))
+        }
+        syn::Type::Reference(reference) => type_is_canonical_mob_command(&reference.elem, aliases),
+        syn::Type::Paren(paren) => type_is_canonical_mob_command(&paren.elem, aliases),
+        syn::Type::Group(group) => type_is_canonical_mob_command(&group.elem, aliases),
+        _ => false,
+    }
+}
+
+fn type_contains_canonical_mob_command(ty: &syn::Type, aliases: &RustUseAliases) -> bool {
+    match ty {
+        syn::Type::Path(path) => {
+            (!(aliases.path_has_shadowed_bare_root(&path.path)
+                || (aliases.ambiguous_glob_import
+                    && aliases.path_has_unresolved_bare_root(&path.path, "MobCommand")))
+                && aliases
+                    .resolve_path(&path.path)
+                    .into_iter()
+                    .any(|segments| path_is_canonical_mob_command_type(&segments)))
+                || path.path.segments.iter().any(|segment| {
+                    if let syn::PathArguments::AngleBracketed(arguments) = &segment.arguments {
+                        arguments.args.iter().any(|arg| match arg {
+                            syn::GenericArgument::Type(ty) => {
+                                type_contains_canonical_mob_command(ty, aliases)
+                            }
+                            _ => false,
+                        })
+                    } else {
+                        false
+                    }
+                })
+        }
+        syn::Type::Reference(reference) => {
+            type_contains_canonical_mob_command(&reference.elem, aliases)
+        }
+        syn::Type::Paren(paren) => type_contains_canonical_mob_command(&paren.elem, aliases),
+        syn::Type::Group(group) => type_contains_canonical_mob_command(&group.elem, aliases),
+        _ => false,
+    }
+}
+
+fn type_contains_canonical_mob_machine_input(ty: &syn::Type) -> bool {
+    match ty {
+        syn::Type::Path(path) => {
+            let segments = path_segments(&path.path);
+            path_is_canonical_mob_machine_type(&segments, "MobMachineInput")
+                || segments
+                    .iter()
+                    .map(String::as_str)
+                    .eq(["mob_dsl", "MobMachineInput"])
+                || path.path.segments.iter().any(|segment| {
+                    if let syn::PathArguments::AngleBracketed(arguments) = &segment.arguments {
+                        arguments.args.iter().any(|arg| match arg {
+                            syn::GenericArgument::Type(ty) => {
+                                type_contains_canonical_mob_machine_input(ty)
+                            }
+                            _ => false,
+                        })
+                    } else {
+                        false
+                    }
+                })
+        }
+        syn::Type::Reference(reference) => {
+            type_contains_canonical_mob_machine_input(&reference.elem)
+        }
+        syn::Type::Paren(paren) => type_contains_canonical_mob_machine_input(&paren.elem),
+        syn::Type::Group(group) => type_contains_canonical_mob_machine_input(&group.elem),
+        _ => false,
+    }
+}
+
+fn pat_ident_name(pat: &syn::Pat) -> Option<String> {
+    match pat {
+        syn::Pat::Ident(ident) => Some(ident.ident.to_string()),
+        syn::Pat::Reference(reference) => pat_ident_name(&reference.pat),
+        syn::Pat::Paren(paren) => pat_ident_name(&paren.pat),
+        _ => None,
+    }
+}
+
+fn pat_bound_idents(pat: &syn::Pat) -> BTreeSet<String> {
+    let mut idents = BTreeSet::new();
+    collect_pat_bound_idents(pat, &mut idents);
+    idents
+}
+
+fn collect_pat_bound_idents(pat: &syn::Pat, idents: &mut BTreeSet<String>) {
+    match pat {
+        syn::Pat::Ident(ident) => {
+            idents.insert(ident.ident.to_string());
+            if let Some((_, subpat)) = &ident.subpat {
+                collect_pat_bound_idents(subpat, idents);
+            }
+        }
+        syn::Pat::Or(or) => {
+            for case in &or.cases {
+                collect_pat_bound_idents(case, idents);
+            }
+        }
+        syn::Pat::Paren(paren) => collect_pat_bound_idents(&paren.pat, idents),
+        syn::Pat::Reference(reference) => collect_pat_bound_idents(&reference.pat, idents),
+        syn::Pat::Slice(slice) => {
+            for elem in &slice.elems {
+                collect_pat_bound_idents(elem, idents);
+            }
+        }
+        syn::Pat::Struct(strukt) => {
+            for field in &strukt.fields {
+                collect_pat_bound_idents(&field.pat, idents);
+            }
+        }
+        syn::Pat::Tuple(tuple) => {
+            for elem in &tuple.elems {
+                collect_pat_bound_idents(elem, idents);
+            }
+        }
+        syn::Pat::TupleStruct(tuple) => {
+            for elem in &tuple.elems {
+                collect_pat_bound_idents(elem, idents);
+            }
+        }
+        syn::Pat::Type(ty) => collect_pat_bound_idents(&ty.pat, idents),
+        syn::Pat::Const(_)
+        | syn::Pat::Lit(_)
+        | syn::Pat::Macro(_)
+        | syn::Pat::Path(_)
+        | syn::Pat::Range(_)
+        | syn::Pat::Rest(_)
+        | syn::Pat::Verbatim(_)
+        | syn::Pat::Wild(_) => {}
+        _ => {}
+    }
+}
+
+fn block_item_function_names(block: &syn::Block) -> BTreeSet<String> {
+    block
+        .stmts
+        .iter()
+        .filter_map(|stmt| match stmt {
+            syn::Stmt::Item(syn::Item::Fn(item_fn)) => Some(item_fn.sig.ident.to_string()),
+            _ => None,
+        })
+        .collect()
+}
+
+fn block_local_bound_names(block: &syn::Block) -> BTreeSet<String> {
+    let mut names = block_item_function_names(block);
+    for stmt in &block.stmts {
+        if let syn::Stmt::Local(local) = stmt {
+            names.extend(pat_bound_idents(&local.pat));
+        }
+    }
+    names
+}
+
+fn block_shadows_names(block: &syn::Block, names: &BTreeSet<String>) -> bool {
+    block_local_bound_names(block)
+        .iter()
+        .any(|name| names.contains(name))
+}
+
+fn flow_authority_kind_argument(
+    expr: &syn::Expr,
+    aliases: &RustUseAliases,
+) -> Option<FlowReducerFamily> {
+    match expr {
+        syn::Expr::Call(call) => {
+            let syn::Expr::Path(func) = &*call.func else {
+                return None;
+            };
+            if aliases.path_has_shadowed_bare_root(&func.path)
+                || (aliases.ambiguous_glob_import
+                    && aliases
+                        .path_has_unresolved_bare_root(&func.path, "MobMachineFlowAuthorityKind"))
+            {
+                return None;
+            }
+            aliases
+                .resolve_path(&func.path)
+                .into_iter()
+                .find_map(|path| flow_authority_kind_family_from_path(&path))
+        }
+        syn::Expr::Paren(paren) => flow_authority_kind_argument(&paren.expr, aliases),
+        syn::Expr::Group(group) => flow_authority_kind_argument(&group.expr, aliases),
+        _ => None,
+    }
+}
+
+fn flow_authority_kind_family_from_path(path: &[String]) -> Option<FlowReducerFamily> {
+    let (variant, owner_path) = path.split_last()?;
+    let canonical_owner = owner_path
+        .iter()
+        .map(String::as_str)
+        .eq(["MobMachineFlowAuthorityKind"])
+        || owner_path.iter().map(String::as_str).eq([
+            "crate",
+            "run",
+            "MobMachineFlowAuthorityKind",
+        ])
+        || owner_path
+            .iter()
+            .map(String::as_str)
+            .eq(["super", "MobMachineFlowAuthorityKind"]);
+    if !canonical_owner {
+        return None;
+    }
+    FlowReducerFamily::from_module(match variant.as_str() {
+        "FlowRun" => "flow_run",
+        "FlowFrame" => "flow_frame",
+        "LoopIteration" => "loop_iteration",
+        _ => return None,
+    })
+}
+
+fn flow_authority_kind_command_parameter(
+    expr: &syn::Expr,
+    family: FlowReducerFamily,
+    command_vars: &BTreeSet<String>,
+    aliases: &RustUseAliases,
+) -> Option<String> {
+    match expr {
+        syn::Expr::Call(call) => {
+            if flow_authority_kind_argument(expr, aliases) == Some(family) && call.args.len() == 1 {
+                call.args
+                    .first()
+                    .and_then(|arg| expr_command_kind_call_var(arg, command_vars))
+            } else {
+                None
+            }
+        }
+        syn::Expr::Try(try_expr) => {
+            flow_authority_kind_command_parameter(&try_expr.expr, family, command_vars, aliases)
+        }
+        syn::Expr::Reference(reference) => {
+            flow_authority_kind_command_parameter(&reference.expr, family, command_vars, aliases)
+        }
+        syn::Expr::Paren(paren) => {
+            flow_authority_kind_command_parameter(&paren.expr, family, command_vars, aliases)
+        }
+        syn::Expr::Group(group) => {
+            flow_authority_kind_command_parameter(&group.expr, family, command_vars, aliases)
+        }
+        _ => None,
+    }
+}
+
+fn expr_command_kind_call_var(expr: &syn::Expr, command_vars: &BTreeSet<String>) -> Option<String> {
+    match expr {
+        syn::Expr::MethodCall(call) if call.method == "kind" && call.args.is_empty() => {
+            expr_variable_name(&call.receiver, command_vars)
+        }
+        syn::Expr::Reference(reference) => {
+            expr_command_kind_call_var(&reference.expr, command_vars)
+        }
+        syn::Expr::Paren(paren) => expr_command_kind_call_var(&paren.expr, command_vars),
+        syn::Expr::Group(group) => expr_command_kind_call_var(&group.expr, command_vars),
+        _ => None,
+    }
+}
+
+fn expr_variable_name(expr: &syn::Expr, names: &BTreeSet<String>) -> Option<String> {
+    match expr {
+        syn::Expr::Path(_) => expr_path_single_ident(expr).filter(|ident| names.contains(ident)),
+        syn::Expr::MethodCall(call) if call.method == "clone" && call.args.is_empty() => {
+            expr_variable_name(&call.receiver, names)
+        }
+        syn::Expr::Reference(reference) => expr_variable_name(&reference.expr, names),
+        syn::Expr::Paren(paren) => expr_variable_name(&paren.expr, names),
+        syn::Expr::Group(group) => expr_variable_name(&group.expr, names),
+        _ => None,
+    }
+}
+
+fn transition_call_command_input_var(
+    call: &syn::ExprCall,
+    command_vars: &BTreeSet<String>,
+) -> Option<String> {
+    call.args
+        .iter()
+        .find_map(|arg| expr_command_input_var(arg, command_vars))
+}
+
+fn expr_command_input_var(expr: &syn::Expr, command_vars: &BTreeSet<String>) -> Option<String> {
+    match expr {
+        syn::Expr::MethodCall(call) if call.method == "into_input" => {
+            expr_variable_name(&call.receiver, command_vars)
+        }
+        syn::Expr::MethodCall(call) if call.method == "clone" => {
+            expr_command_input_var(&call.receiver, command_vars)
+        }
+        syn::Expr::Try(try_expr) => expr_command_input_var(&try_expr.expr, command_vars),
+        syn::Expr::Reference(reference) => expr_command_input_var(&reference.expr, command_vars),
+        syn::Expr::Paren(paren) => expr_command_input_var(&paren.expr, command_vars),
+        syn::Expr::Group(group) => expr_command_input_var(&group.expr, command_vars),
+        _ => None,
+    }
+}
+
+fn expr_is_ok_constructor_call(expr: &syn::Expr) -> bool {
+    match expr {
+        syn::Expr::Call(call) => expr_as_path(&call.func).is_some_and(|path| {
+            path.segments
+                .last()
+                .is_some_and(|segment| segment.ident == "Ok")
+        }),
+        syn::Expr::Paren(paren) => expr_is_ok_constructor_call(&paren.expr),
+        syn::Expr::Group(group) => expr_is_ok_constructor_call(&group.expr),
+        _ => false,
+    }
+}
+
+fn result_method_can_swallow_error(method: &str) -> bool {
+    matches!(
+        method,
+        "or" | "or_else"
+            | "unwrap_or"
+            | "unwrap_or_else"
+            | "unwrap_or_default"
+            | "ok"
+            | "err"
+            | "map_or"
+            | "map_or_else"
+    )
+}
+
+fn expr_contains_fail_open_result_method(expr: &syn::Expr) -> bool {
+    match expr {
+        syn::Expr::MethodCall(call) => {
+            result_method_can_swallow_error(&call.method.to_string())
+                || expr_contains_fail_open_result_method(&call.receiver)
+                || call.args.iter().any(expr_contains_fail_open_result_method)
+        }
+        syn::Expr::Call(call) => {
+            expr_as_path(&call.func)
+                .and_then(|path| path.segments.last())
+                .is_some_and(|segment| result_method_can_swallow_error(&segment.ident.to_string()))
+                || call.args.iter().any(expr_contains_fail_open_result_method)
+        }
+        syn::Expr::Closure(closure) => expr_contains_fail_open_result_method(&closure.body),
+        syn::Expr::Try(try_expr) => expr_contains_fail_open_result_method(&try_expr.expr),
+        syn::Expr::Await(await_expr) => expr_contains_fail_open_result_method(&await_expr.base),
+        syn::Expr::Reference(reference) => expr_contains_fail_open_result_method(&reference.expr),
+        syn::Expr::Paren(paren) => expr_contains_fail_open_result_method(&paren.expr),
+        syn::Expr::Group(group) => expr_contains_fail_open_result_method(&group.expr),
+        syn::Expr::Block(block) => block
+            .block
+            .stmts
+            .iter()
+            .any(stmt_contains_fail_open_result_method),
+        syn::Expr::If(expr_if) => {
+            expr_contains_fail_open_result_method(&expr_if.cond)
+                || expr_if
+                    .then_branch
+                    .stmts
+                    .iter()
+                    .any(stmt_contains_fail_open_result_method)
+                || expr_if
+                    .else_branch
+                    .as_ref()
+                    .is_some_and(|(_, expr)| expr_contains_fail_open_result_method(expr))
+        }
+        syn::Expr::Match(expr_match) => {
+            expr_contains_fail_open_result_method(&expr_match.expr)
+                || expr_match.arms.iter().any(|arm| {
+                    arm.guard
+                        .as_ref()
+                        .is_some_and(|(_, guard)| expr_contains_fail_open_result_method(guard))
+                        || expr_contains_fail_open_result_method(&arm.body)
+                })
+        }
+        _ => false,
+    }
+}
+
+fn stmt_contains_fail_open_result_method(stmt: &syn::Stmt) -> bool {
+    match stmt {
+        syn::Stmt::Local(local) => local
+            .init
+            .as_ref()
+            .is_some_and(|init| expr_contains_fail_open_result_method(&init.expr)),
+        syn::Stmt::Expr(expr, _) => expr_contains_fail_open_result_method(expr),
+        syn::Stmt::Item(_) | syn::Stmt::Macro(_) => false,
+    }
+}
+
+fn stmt_unconditionally_exits_block(stmt: &syn::Stmt) -> bool {
+    match stmt {
+        syn::Stmt::Expr(expr, _) => expr_unconditionally_exits_block(expr),
+        syn::Stmt::Local(_) | syn::Stmt::Item(_) | syn::Stmt::Macro(_) => false,
+    }
+}
+
+fn expr_unconditionally_exits_block(expr: &syn::Expr) -> bool {
+    match expr {
+        syn::Expr::Return(_) | syn::Expr::Break(_) | syn::Expr::Continue(_) => true,
+        syn::Expr::Group(group) => expr_unconditionally_exits_block(&group.expr),
+        syn::Expr::Paren(paren) => expr_unconditionally_exits_block(&paren.expr),
+        _ => false,
+    }
+}
+
+fn path_is_canonical_mob_run_owner_constructor(
+    path: &syn::Path,
+    aliases: &RustUseAliases,
+    owner: &str,
+    constructor: impl Fn(&str) -> bool,
+) -> bool {
+    if aliases.path_has_shadowed_bare_root(path)
+        || (aliases.ambiguous_glob_import && aliases.path_has_unresolved_bare_root(path, owner))
+    {
+        return false;
+    }
+    aliases.resolve_path(path).into_iter().any(|segments| {
+        let Some(last) = segments.last() else {
+            return false;
+        };
+        constructor(last)
+            && path_is_canonical_mob_run_owner_type(
+                &segments[..segments.len().saturating_sub(1)],
+                owner,
+            )
+    })
+}
+
+fn expr_returns_mob_machine_flow_run_command(expr: &syn::Expr, aliases: &RustUseAliases) -> bool {
+    match expr {
+        syn::Expr::Call(call) => expr_as_path(&call.func).is_some_and(|path| {
+            path_is_canonical_mob_run_owner_constructor(
+                path,
+                aliases,
+                "MobMachineFlowRunCommand",
+                |constructor| constructor != "from",
+            )
+        }),
+        syn::Expr::MethodCall(call) if call.method == "clone" => {
+            expr_returns_mob_machine_flow_run_command(&call.receiver, aliases)
+        }
+        syn::Expr::Try(try_expr) => {
+            expr_returns_mob_machine_flow_run_command(&try_expr.expr, aliases)
+        }
+        syn::Expr::Await(await_expr) => {
+            expr_returns_mob_machine_flow_run_command(&await_expr.base, aliases)
+        }
+        syn::Expr::Reference(reference) => {
+            expr_returns_mob_machine_flow_run_command(&reference.expr, aliases)
+        }
+        syn::Expr::Paren(paren) => expr_returns_mob_machine_flow_run_command(&paren.expr, aliases),
+        syn::Expr::Group(group) => expr_returns_mob_machine_flow_run_command(&group.expr, aliases),
+        _ => false,
+    }
+}
+
+fn expr_returns_mob_machine_flow_authority_token(
+    expr: &syn::Expr,
+    aliases: &RustUseAliases,
+) -> bool {
+    match expr {
+        syn::Expr::Call(call) => expr_as_path(&call.func).is_some_and(|path| {
+            path_is_canonical_mob_run_owner_constructor(
+                path,
+                aliases,
+                "MobMachineFlowAuthorityToken",
+                |constructor| constructor == "from_accepted_mob_machine_input",
+            )
+        }),
+        syn::Expr::MethodCall(call) if call.method == "clone" => {
+            expr_returns_mob_machine_flow_authority_token(&call.receiver, aliases)
+        }
+        syn::Expr::Try(try_expr) => {
+            expr_returns_mob_machine_flow_authority_token(&try_expr.expr, aliases)
+        }
+        syn::Expr::Await(await_expr) => {
+            expr_returns_mob_machine_flow_authority_token(&await_expr.base, aliases)
+        }
+        syn::Expr::Reference(reference) => {
+            expr_returns_mob_machine_flow_authority_token(&reference.expr, aliases)
+        }
+        syn::Expr::Paren(paren) => {
+            expr_returns_mob_machine_flow_authority_token(&paren.expr, aliases)
+        }
+        syn::Expr::Group(group) => {
+            expr_returns_mob_machine_flow_authority_token(&group.expr, aliases)
+        }
+        _ => false,
+    }
+}
+
+fn expr_flow_authority_input_command_var(
+    expr: &syn::Expr,
+    command_vars: &BTreeSet<String>,
+    authority_input_command_vars: &BTreeMap<String, String>,
+) -> Option<String> {
+    match expr {
+        syn::Expr::Path(_) => expr_path_single_ident(expr)
+            .and_then(|name| authority_input_command_vars.get(&name).cloned()),
+        syn::Expr::MethodCall(call) if call.method == "authority_input" => {
+            expr_variable_name(&call.receiver, command_vars)
+        }
+        syn::Expr::MethodCall(call) if call.method == "clone" => {
+            expr_flow_authority_input_command_var(
+                &call.receiver,
+                command_vars,
+                authority_input_command_vars,
+            )
+        }
+        syn::Expr::Try(try_expr) => expr_flow_authority_input_command_var(
+            &try_expr.expr,
+            command_vars,
+            authority_input_command_vars,
+        ),
+        syn::Expr::Await(await_expr) => expr_flow_authority_input_command_var(
+            &await_expr.base,
+            command_vars,
+            authority_input_command_vars,
+        ),
+        syn::Expr::Reference(reference) => expr_flow_authority_input_command_var(
+            &reference.expr,
+            command_vars,
+            authority_input_command_vars,
+        ),
+        syn::Expr::Paren(paren) => expr_flow_authority_input_command_var(
+            &paren.expr,
+            command_vars,
+            authority_input_command_vars,
+        ),
+        syn::Expr::Group(group) => expr_flow_authority_input_command_var(
+            &group.expr,
+            command_vars,
+            authority_input_command_vars,
+        ),
+        _ => None,
+    }
+}
+
+fn expr_flow_authority_input_identity_var(
+    expr: &syn::Expr,
+    authority_input_identity_vars: &BTreeMap<String, String>,
+) -> Option<String> {
+    match expr {
+        syn::Expr::Path(_) => expr_path_single_ident(expr)
+            .and_then(|name| authority_input_identity_vars.get(&name).cloned()),
+        syn::Expr::MethodCall(call) if call.method == "authority_input" => {
+            call.args.first().and_then(expr_identity_argument_name)
+        }
+        syn::Expr::MethodCall(call) if call.method == "clone" => {
+            expr_flow_authority_input_identity_var(&call.receiver, authority_input_identity_vars)
+        }
+        syn::Expr::Try(try_expr) => {
+            expr_flow_authority_input_identity_var(&try_expr.expr, authority_input_identity_vars)
+        }
+        syn::Expr::Await(await_expr) => {
+            expr_flow_authority_input_identity_var(&await_expr.base, authority_input_identity_vars)
+        }
+        syn::Expr::Reference(reference) => {
+            expr_flow_authority_input_identity_var(&reference.expr, authority_input_identity_vars)
+        }
+        syn::Expr::Paren(paren) => {
+            expr_flow_authority_input_identity_var(&paren.expr, authority_input_identity_vars)
+        }
+        syn::Expr::Group(group) => {
+            expr_flow_authority_input_identity_var(&group.expr, authority_input_identity_vars)
+        }
+        _ => None,
+    }
+}
+
+fn expr_is_plan_machine_inputs_prepare_call(
+    expr: &syn::Expr,
+    plan_vars: &BTreeSet<String>,
+) -> bool {
+    match expr {
+        syn::Expr::MethodCall(call) => {
+            call.method == "prepare_dsl_inputs"
+                && expr_is_self_receiver(&call.receiver)
+                && call
+                    .args
+                    .first()
+                    .is_some_and(|arg| expr_is_plan_machine_inputs_call(arg, plan_vars))
+        }
+        syn::Expr::Try(try_expr) => {
+            expr_is_plan_machine_inputs_prepare_call(&try_expr.expr, plan_vars)
+        }
+        syn::Expr::Await(await_expr) => {
+            expr_is_plan_machine_inputs_prepare_call(&await_expr.base, plan_vars)
+        }
+        syn::Expr::Reference(reference) => {
+            expr_is_plan_machine_inputs_prepare_call(&reference.expr, plan_vars)
+        }
+        syn::Expr::Paren(paren) => expr_is_plan_machine_inputs_prepare_call(&paren.expr, plan_vars),
+        syn::Expr::Group(group) => expr_is_plan_machine_inputs_prepare_call(&group.expr, plan_vars),
+        _ => false,
+    }
+}
+
+fn expr_is_plan_machine_inputs_value(
+    expr: &syn::Expr,
+    plan_authority_input_vars: &BTreeSet<String>,
+    plan_vars: &BTreeSet<String>,
+) -> bool {
+    if expr_variable_name(expr, plan_authority_input_vars).is_some() {
+        return true;
+    }
+    match expr {
+        syn::Expr::MethodCall(call)
+            if matches!(call.method.to_string().as_str(), "to_vec" | "clone") =>
+        {
+            expr_is_plan_machine_inputs_value(&call.receiver, plan_authority_input_vars, plan_vars)
+        }
+        syn::Expr::MethodCall(call) => {
+            call.method == "machine_inputs" && expr_is_plan_scrutinee(&call.receiver, plan_vars)
+        }
+        syn::Expr::Try(try_expr) => {
+            expr_is_plan_machine_inputs_value(&try_expr.expr, plan_authority_input_vars, plan_vars)
+        }
+        syn::Expr::Await(await_expr) => expr_is_plan_machine_inputs_value(
+            &await_expr.base,
+            plan_authority_input_vars,
+            plan_vars,
+        ),
+        syn::Expr::Reference(reference) => {
+            expr_is_plan_machine_inputs_value(&reference.expr, plan_authority_input_vars, plan_vars)
+        }
+        syn::Expr::Paren(paren) => {
+            expr_is_plan_machine_inputs_value(&paren.expr, plan_authority_input_vars, plan_vars)
+        }
+        syn::Expr::Group(group) => {
+            expr_is_plan_machine_inputs_value(&group.expr, plan_authority_input_vars, plan_vars)
+        }
+        _ => false,
+    }
+}
+
+fn expr_is_none_constructor(expr: &syn::Expr, aliases: &RustUseAliases) -> bool {
+    match expr {
+        syn::Expr::Path(path) => {
+            !(aliases.path_has_shadowed_bare_root(&path.path)
+                || (aliases.ambiguous_glob_import
+                    && aliases.path_has_unresolved_bare_root(&path.path, "None")))
+                && aliases
+                    .resolve_path(&path.path)
+                    .into_iter()
+                    .any(|segments| path_is_canonical_none_constructor(&segments))
+        }
+        syn::Expr::Paren(paren) => expr_is_none_constructor(&paren.expr, aliases),
+        syn::Expr::Group(group) => expr_is_none_constructor(&group.expr, aliases),
+        _ => false,
+    }
+}
+
+fn path_is_canonical_none_constructor(path: &[String]) -> bool {
+    path.iter().map(String::as_str).eq(["None"])
+        || path.iter().map(String::as_str).eq(["Option", "None"])
+        || path
+            .iter()
+            .map(String::as_str)
+            .eq(["std", "option", "Option", "None"])
+        || path
+            .iter()
+            .map(String::as_str)
+            .eq(["core", "option", "Option", "None"])
+}
+
+fn expr_is_plan_freshness_failure_guard(
+    expr: &syn::Expr,
+    run_id_vars: &BTreeSet<String>,
+    plan_vars: &BTreeSet<String>,
+) -> bool {
+    match expr {
+        syn::Expr::Unary(unary) if matches!(unary.op, syn::UnOp::Not(_)) => {
+            expr_is_plan_freshness_check(&unary.expr, run_id_vars, plan_vars)
+        }
+        syn::Expr::Paren(paren) => {
+            expr_is_plan_freshness_failure_guard(&paren.expr, run_id_vars, plan_vars)
+        }
+        syn::Expr::Group(group) => {
+            expr_is_plan_freshness_failure_guard(&group.expr, run_id_vars, plan_vars)
+        }
+        _ => false,
+    }
+}
+
+fn expr_is_plan_freshness_check(
+    expr: &syn::Expr,
+    run_id_vars: &BTreeSet<String>,
+    plan_vars: &BTreeSet<String>,
+) -> bool {
+    match expr {
+        syn::Expr::MethodCall(call) => {
+            call.method == "flow_frame_store_plan_expected_matches"
+                && expr_is_self_receiver(&call.receiver)
+                && call.args.len() == 2
+                && call
+                    .args
+                    .first()
+                    .is_some_and(|arg| expr_variable_name(arg, run_id_vars).is_some())
+                && call
+                    .args
+                    .iter()
+                    .nth(1)
+                    .is_some_and(|arg| expr_variable_name(arg, plan_vars).is_some())
+        }
+        syn::Expr::Try(try_expr) => {
+            expr_is_plan_freshness_check(&try_expr.expr, run_id_vars, plan_vars)
+        }
+        syn::Expr::Await(await_expr) => {
+            expr_is_plan_freshness_check(&await_expr.base, run_id_vars, plan_vars)
+        }
+        syn::Expr::Reference(reference) => {
+            expr_is_plan_freshness_check(&reference.expr, run_id_vars, plan_vars)
+        }
+        syn::Expr::Paren(paren) => {
+            expr_is_plan_freshness_check(&paren.expr, run_id_vars, plan_vars)
+        }
+        syn::Expr::Group(group) => {
+            expr_is_plan_freshness_check(&group.expr, run_id_vars, plan_vars)
+        }
+        _ => false,
+    }
+}
+
+fn block_returns_ok_false(block: &syn::Block) -> bool {
+    block.stmts.iter().any(stmt_returns_ok_false)
+}
+
+fn stmt_returns_ok_false(stmt: &syn::Stmt) -> bool {
+    match stmt {
+        syn::Stmt::Expr(expr, _) => expr_returns_ok_false(expr),
+        syn::Stmt::Local(_) | syn::Stmt::Item(_) | syn::Stmt::Macro(_) => false,
+    }
+}
+
+fn expr_returns_ok_false(expr: &syn::Expr) -> bool {
+    match expr {
+        syn::Expr::Return(ret) => ret.expr.as_deref().is_some_and(expr_is_ok_false),
+        syn::Expr::Paren(paren) => expr_returns_ok_false(&paren.expr),
+        syn::Expr::Group(group) => expr_returns_ok_false(&group.expr),
+        _ => false,
+    }
+}
+
+fn expr_is_ok_false(expr: &syn::Expr) -> bool {
+    match expr {
+        syn::Expr::Call(call) => {
+            expr_as_path(&call.func)
+                .and_then(|path| path.segments.last())
+                .is_some_and(|segment| segment.ident == "Ok")
+                && call
+                    .args
+                    .first()
+                    .is_some_and(|arg| expr_static_bool_value(arg) == Some(false))
+                && call.args.len() == 1
+        }
+        syn::Expr::Paren(paren) => expr_is_ok_false(&paren.expr),
+        syn::Expr::Group(group) => expr_is_ok_false(&group.expr),
+        _ => false,
+    }
+}
+
+fn expr_is_plan_machine_inputs_call(expr: &syn::Expr, plan_vars: &BTreeSet<String>) -> bool {
+    match expr {
+        syn::Expr::MethodCall(call) => {
+            call.method == "machine_inputs" && expr_is_plan_scrutinee(&call.receiver, plan_vars)
+        }
+        syn::Expr::Reference(reference) => {
+            expr_is_plan_machine_inputs_call(&reference.expr, plan_vars)
+        }
+        syn::Expr::Paren(paren) => expr_is_plan_machine_inputs_call(&paren.expr, plan_vars),
+        syn::Expr::Group(group) => expr_is_plan_machine_inputs_call(&group.expr, plan_vars),
+        _ => false,
+    }
+}
+
+fn expr_field_chain(expr: &syn::Expr) -> Vec<String> {
+    match expr {
+        syn::Expr::Field(field) => {
+            let mut chain = expr_field_chain(&field.base);
+            if let syn::Member::Named(ident) = &field.member {
+                chain.push(ident.to_string());
+            }
+            chain
+        }
+        syn::Expr::Path(path) => path
+            .path
+            .segments
+            .last()
+            .map(|segment| vec![segment.ident.to_string()])
+            .unwrap_or_default(),
+        syn::Expr::Index(index) => expr_field_chain(&index.expr),
+        syn::Expr::Reference(reference) => expr_field_chain(&reference.expr),
+        syn::Expr::Unary(unary) if matches!(unary.op, syn::UnOp::Deref(_)) => {
+            expr_field_chain(&unary.expr)
+        }
+        syn::Expr::Paren(paren) => expr_field_chain(&paren.expr),
+        syn::Expr::Group(group) => expr_field_chain(&group.expr),
+        syn::Expr::Await(await_expr) => expr_field_chain(&await_expr.base),
+        _ => Vec::new(),
+    }
+}
+
+fn projection_state_alias_from_expr(expr: &syn::Expr) -> Option<&'static str> {
+    let chain = expr_field_chain(expr);
+    if chain.iter().any(|segment| segment == "flow_state") {
+        Some("flow_state")
+    } else if chain.iter().any(|segment| segment == "kernel_state") {
+        Some("kernel_state")
+    } else {
+        None
+    }
+}
+
+fn projection_state_token_from_chain(chain: &[String]) -> Option<&'static str> {
+    if chain.iter().any(|segment| segment == "flow_state") {
+        Some(".flow_state")
+    } else if chain.iter().any(|segment| segment == "kernel_state") {
+        Some(".kernel_state")
+    } else {
+        None
+    }
+}
+
+fn path_is_canonical_mob_run_projection_owner(path: &[String]) -> bool {
+    path.iter().map(String::as_str).eq(["MobRun"])
+        || path
+            .iter()
+            .map(String::as_str)
+            .eq(["crate", "run", "MobRun"])
+}
+
+fn path_is_canonical_kernel_snapshot_projection_owner(path: &[String]) -> bool {
+    path.iter().map(String::as_str).eq(["FrameSnapshot"])
+        || path.iter().map(String::as_str).eq(["LoopSnapshot"])
+        || path
+            .iter()
+            .map(String::as_str)
+            .eq(["crate", "run", "FrameSnapshot"])
+        || path
+            .iter()
+            .map(String::as_str)
+            .eq(["crate", "run", "LoopSnapshot"])
+}
+
+fn projection_field_token_from_chain(
+    chain: &[String],
+    state_field: &str,
+    governed_fields: &BTreeSet<String>,
+) -> Option<String> {
+    chain.windows(2).find_map(|window| {
+        if window[0] == state_field && governed_fields.contains(&window[1]) {
+            Some(format!(".{state_field}.{}", window[1]))
+        } else {
+            None
+        }
+    })
+}
+
+fn method_call_typed_next_state_command_var(
+    call: &syn::ExprMethodCall,
+    facts: &ProjectionCasMethodFacts,
+    typed_outcome_command_vars: &BTreeMap<String, String>,
+    typed_next_state_command_vars: &BTreeMap<String, String>,
+) -> Option<String> {
+    facts.next_flow_state_arg_indices.iter().find_map(|index| {
+        call.args.iter().nth(*index).and_then(|arg| {
+            expr_typed_outcome_next_state_command_var(
+                arg,
+                typed_outcome_command_vars,
+                typed_next_state_command_vars,
+            )
+        })
+    })
+}
+
+fn method_call_typed_next_state_identity_var(
+    call: &syn::ExprMethodCall,
+    facts: &ProjectionCasMethodFacts,
+    typed_outcome_identity_vars: &BTreeMap<String, String>,
+    typed_next_state_identity_vars: &BTreeMap<String, String>,
+) -> Option<String> {
+    facts.next_flow_state_arg_indices.iter().find_map(|index| {
+        call.args.iter().nth(*index).and_then(|arg| {
+            expr_typed_outcome_next_state_identity_var(
+                arg,
+                typed_outcome_identity_vars,
+                typed_next_state_identity_vars,
+            )
+        })
+    })
+}
+
+fn call_typed_next_state_command_var(
+    call: &syn::ExprCall,
+    path: &syn::Path,
+    facts: &ProjectionCasMethodFacts,
+    typed_outcome_command_vars: &BTreeMap<String, String>,
+    typed_next_state_command_vars: &BTreeMap<String, String>,
+) -> Option<String> {
+    let receiver_offset = usize::from(path.segments.len() > 1);
+    facts.next_flow_state_arg_indices.iter().find_map(|index| {
+        call.args
+            .iter()
+            .nth(index + receiver_offset)
+            .and_then(|arg| {
+                expr_typed_outcome_next_state_command_var(
+                    arg,
+                    typed_outcome_command_vars,
+                    typed_next_state_command_vars,
+                )
+            })
+    })
+}
+
+fn call_typed_next_state_identity_var(
+    call: &syn::ExprCall,
+    path: &syn::Path,
+    facts: &ProjectionCasMethodFacts,
+    typed_outcome_identity_vars: &BTreeMap<String, String>,
+    typed_next_state_identity_vars: &BTreeMap<String, String>,
+) -> Option<String> {
+    let receiver_offset = usize::from(path.segments.len() > 1);
+    facts.next_flow_state_arg_indices.iter().find_map(|index| {
+        call.args
+            .iter()
+            .nth(index + receiver_offset)
+            .and_then(|arg| {
+                expr_typed_outcome_next_state_identity_var(
+                    arg,
+                    typed_outcome_identity_vars,
+                    typed_next_state_identity_vars,
+                )
+            })
+    })
+}
+
+fn expr_typed_outcome_next_state_command_var(
+    expr: &syn::Expr,
+    typed_outcome_command_vars: &BTreeMap<String, String>,
+    typed_next_state_command_vars: &BTreeMap<String, String>,
+) -> Option<String> {
+    match expr {
+        syn::Expr::Path(_) => expr_path_single_ident(expr)
+            .and_then(|name| typed_next_state_command_vars.get(&name).cloned()),
+        syn::Expr::Field(_) => {
+            let chain = expr_field_chain(expr);
+            chain
+                .first()
+                .and_then(|name| typed_outcome_command_vars.get(name))
+                .filter(|_| chain.last().is_some_and(|field| field == "next_state"))
+                .cloned()
+        }
+        syn::Expr::MethodCall(call) if call.method == "clone" => {
+            expr_typed_outcome_next_state_command_var(
+                &call.receiver,
+                typed_outcome_command_vars,
+                typed_next_state_command_vars,
+            )
+        }
+        syn::Expr::Try(try_expr) => expr_typed_outcome_next_state_command_var(
+            &try_expr.expr,
+            typed_outcome_command_vars,
+            typed_next_state_command_vars,
+        ),
+        syn::Expr::Await(await_expr) => expr_typed_outcome_next_state_command_var(
+            &await_expr.base,
+            typed_outcome_command_vars,
+            typed_next_state_command_vars,
+        ),
+        syn::Expr::Reference(reference) => expr_typed_outcome_next_state_command_var(
+            &reference.expr,
+            typed_outcome_command_vars,
+            typed_next_state_command_vars,
+        ),
+        syn::Expr::Paren(paren) => expr_typed_outcome_next_state_command_var(
+            &paren.expr,
+            typed_outcome_command_vars,
+            typed_next_state_command_vars,
+        ),
+        syn::Expr::Group(group) => expr_typed_outcome_next_state_command_var(
+            &group.expr,
+            typed_outcome_command_vars,
+            typed_next_state_command_vars,
+        ),
+        _ => None,
+    }
+}
+
+fn expr_typed_outcome_next_state_identity_var(
+    expr: &syn::Expr,
+    typed_outcome_identity_vars: &BTreeMap<String, String>,
+    typed_next_state_identity_vars: &BTreeMap<String, String>,
+) -> Option<String> {
+    match expr {
+        syn::Expr::Path(_) => expr_path_single_ident(expr)
+            .and_then(|name| typed_next_state_identity_vars.get(&name).cloned()),
+        syn::Expr::Field(_) => {
+            let chain = expr_field_chain(expr);
+            chain
+                .first()
+                .and_then(|name| typed_outcome_identity_vars.get(name))
+                .filter(|_| chain.last().is_some_and(|field| field == "next_state"))
+                .cloned()
+        }
+        syn::Expr::MethodCall(call) if call.method == "clone" => {
+            expr_typed_outcome_next_state_identity_var(
+                &call.receiver,
+                typed_outcome_identity_vars,
+                typed_next_state_identity_vars,
+            )
+        }
+        syn::Expr::Try(try_expr) => expr_typed_outcome_next_state_identity_var(
+            &try_expr.expr,
+            typed_outcome_identity_vars,
+            typed_next_state_identity_vars,
+        ),
+        syn::Expr::Await(await_expr) => expr_typed_outcome_next_state_identity_var(
+            &await_expr.base,
+            typed_outcome_identity_vars,
+            typed_next_state_identity_vars,
+        ),
+        syn::Expr::Reference(reference) => expr_typed_outcome_next_state_identity_var(
+            &reference.expr,
+            typed_outcome_identity_vars,
+            typed_next_state_identity_vars,
+        ),
+        syn::Expr::Paren(paren) => expr_typed_outcome_next_state_identity_var(
+            &paren.expr,
+            typed_outcome_identity_vars,
+            typed_next_state_identity_vars,
+        ),
+        syn::Expr::Group(group) => expr_typed_outcome_next_state_identity_var(
+            &group.expr,
+            typed_outcome_identity_vars,
+            typed_next_state_identity_vars,
+        ),
+        _ => None,
+    }
+}
+
+fn method_call_uses_matching_flow_authority_input(
+    call: &syn::ExprMethodCall,
+    facts: &ProjectionCasMethodFacts,
+    command_var: &str,
+    authority_input_command_vars: &BTreeMap<String, String>,
+    authority_input_identity_vars: &BTreeMap<String, String>,
+    command_vars: &BTreeSet<String>,
+) -> bool {
+    let Some(required_identity_vars) =
+        method_call_authority_identity_vars(call, &facts.authority_identity_arg_indices)
+    else {
+        return false;
+    };
+    !facts.authority_input_arg_indices.is_empty()
+        && facts.authority_input_arg_indices.iter().any(|index| {
+            call.args.iter().nth(*index).is_some_and(|arg| {
+                expr_contains_flow_authority_input_for_command(
+                    arg,
+                    command_var,
+                    authority_input_command_vars,
+                    authority_input_identity_vars,
+                    &required_identity_vars,
+                    command_vars,
+                )
+            })
+        })
+}
+
+fn method_call_uses_matching_typed_flow_identity(
+    call: &syn::ExprMethodCall,
+    facts: &ProjectionCasMethodFacts,
+    typed_identity_var: Option<&str>,
+) -> bool {
+    let Some(typed_identity_var) = typed_identity_var else {
+        return false;
+    };
+    let Some(required_identity_vars) =
+        method_call_authority_identity_vars(call, &facts.authority_identity_arg_indices)
+    else {
+        return false;
+    };
+    required_identity_vars.contains(typed_identity_var)
+}
+
+fn call_uses_matching_flow_authority_input(
+    call: &syn::ExprCall,
+    path: &syn::Path,
+    facts: &ProjectionCasMethodFacts,
+    command_var: &str,
+    authority_input_command_vars: &BTreeMap<String, String>,
+    authority_input_identity_vars: &BTreeMap<String, String>,
+    command_vars: &BTreeSet<String>,
+) -> bool {
+    let receiver_offset = usize::from(path.segments.len() > 1);
+    let Some(required_identity_vars) =
+        call_authority_identity_vars(call, receiver_offset, &facts.authority_identity_arg_indices)
+    else {
+        return false;
+    };
+    !facts.authority_input_arg_indices.is_empty()
+        && facts.authority_input_arg_indices.iter().any(|index| {
+            call.args
+                .iter()
+                .nth(index + receiver_offset)
+                .is_some_and(|arg| {
+                    expr_contains_flow_authority_input_for_command(
+                        arg,
+                        command_var,
+                        authority_input_command_vars,
+                        authority_input_identity_vars,
+                        &required_identity_vars,
+                        command_vars,
+                    )
+                })
+        })
+}
+
+fn call_uses_matching_typed_flow_identity(
+    call: &syn::ExprCall,
+    path: &syn::Path,
+    facts: &ProjectionCasMethodFacts,
+    typed_identity_var: Option<&str>,
+) -> bool {
+    let Some(typed_identity_var) = typed_identity_var else {
+        return false;
+    };
+    let receiver_offset = usize::from(path.segments.len() > 1);
+    let Some(required_identity_vars) =
+        call_authority_identity_vars(call, receiver_offset, &facts.authority_identity_arg_indices)
+    else {
+        return false;
+    };
+    required_identity_vars.contains(typed_identity_var)
+}
+
+fn method_call_authority_identity_vars(
+    call: &syn::ExprMethodCall,
+    indices: &BTreeSet<usize>,
+) -> Option<BTreeSet<String>> {
+    let identities = indices
+        .iter()
+        .filter_map(|index| {
+            call.args
+                .iter()
+                .nth(*index)
+                .and_then(expr_identity_argument_name)
+        })
+        .collect::<BTreeSet<_>>();
+    (!identities.is_empty() || indices.is_empty()).then_some(identities)
+}
+
+fn call_authority_identity_vars(
+    call: &syn::ExprCall,
+    receiver_offset: usize,
+    indices: &BTreeSet<usize>,
+) -> Option<BTreeSet<String>> {
+    let identities = indices
+        .iter()
+        .filter_map(|index| {
+            call.args
+                .iter()
+                .nth(index + receiver_offset)
+                .and_then(expr_identity_argument_name)
+        })
+        .collect::<BTreeSet<_>>();
+    (!identities.is_empty() || indices.is_empty()).then_some(identities)
+}
+
+fn expr_contains_flow_authority_input_for_command(
+    expr: &syn::Expr,
+    command_var: &str,
+    authority_input_command_vars: &BTreeMap<String, String>,
+    authority_input_identity_vars: &BTreeMap<String, String>,
+    required_identity_vars: &BTreeSet<String>,
+    command_vars: &BTreeSet<String>,
+) -> bool {
+    match expr {
+        syn::Expr::Path(_) => expr_path_single_ident(expr).is_some_and(|name| {
+            authority_input_command_vars
+                .get(&name)
+                .is_some_and(|command| command == command_var)
+                && authority_input_identity_matches(
+                    authority_input_identity_vars.get(&name),
+                    required_identity_vars,
+                )
+        }),
+        syn::Expr::MethodCall(call) if call.method == "authority_input" => {
+            expr_variable_name(&call.receiver, command_vars).as_deref() == Some(command_var)
+                && authority_input_identity_matches(
+                    call.args
+                        .first()
+                        .and_then(expr_identity_argument_name)
+                        .as_ref(),
+                    required_identity_vars,
+                )
+        }
+        syn::Expr::MethodCall(call) if call.method == "clone" => {
+            expr_contains_flow_authority_input_for_command(
+                &call.receiver,
+                command_var,
+                authority_input_command_vars,
+                authority_input_identity_vars,
+                required_identity_vars,
+                command_vars,
+            )
+        }
+        syn::Expr::Array(array) => {
+            !array.elems.is_empty()
+                && array.elems.iter().all(|elem| {
+                    expr_contains_flow_authority_input_for_command(
+                        elem,
+                        command_var,
+                        authority_input_command_vars,
+                        authority_input_identity_vars,
+                        required_identity_vars,
+                        command_vars,
+                    )
+                })
+        }
+        syn::Expr::Macro(mac) if mac.mac.path.is_ident("vec") => {
+            let parser = syn::punctuated::Punctuated::<syn::Expr, syn::Token![,]>::parse_terminated;
+            parser
+                .parse2(mac.mac.tokens.clone())
+                .ok()
+                .is_some_and(|exprs| {
+                    !exprs.is_empty()
+                        && exprs.iter().all(|expr| {
+                            expr_contains_flow_authority_input_for_command(
+                                expr,
+                                command_var,
+                                authority_input_command_vars,
+                                authority_input_identity_vars,
+                                required_identity_vars,
+                                command_vars,
+                            )
+                        })
+                })
+        }
+        syn::Expr::Reference(reference) => expr_contains_flow_authority_input_for_command(
+            &reference.expr,
+            command_var,
+            authority_input_command_vars,
+            authority_input_identity_vars,
+            required_identity_vars,
+            command_vars,
+        ),
+        syn::Expr::Paren(paren) => expr_contains_flow_authority_input_for_command(
+            &paren.expr,
+            command_var,
+            authority_input_command_vars,
+            authority_input_identity_vars,
+            required_identity_vars,
+            command_vars,
+        ),
+        syn::Expr::Group(group) => expr_contains_flow_authority_input_for_command(
+            &group.expr,
+            command_var,
+            authority_input_command_vars,
+            authority_input_identity_vars,
+            required_identity_vars,
+            command_vars,
+        ),
+        _ => false,
+    }
+}
+
+fn authority_input_identity_matches(
+    identity: Option<&String>,
+    required_identity_vars: &BTreeSet<String>,
+) -> bool {
+    required_identity_vars.is_empty()
+        || identity.is_some_and(|identity| required_identity_vars.contains(identity))
+}
+
+fn projection_mutator_method(method: &str) -> bool {
+    matches!(
+        method,
+        "append"
+            | "clear"
+            | "clone_from"
+            | "as_mut"
+            | "as_mut_slice"
+            | "back_mut"
+            | "chunks_exact_mut"
+            | "chunks_mut"
+            | "dedup"
+            | "dedup_by"
+            | "dedup_by_key"
+            | "drain"
+            | "entry"
+            | "extend"
+            | "first_entry"
+            | "first_mut"
+            | "front_mut"
+            | "get_mut"
+            | "insert"
+            | "iter_mut"
+            | "last_entry"
+            | "last_mut"
+            | "pop"
+            | "pop_first"
+            | "pop_last"
+            | "push"
+            | "range_mut"
+            | "rchunks_exact_mut"
+            | "rchunks_mut"
+            | "replace"
+            | "remove"
+            | "retain"
+            | "retain_mut"
+            | "resize"
+            | "resize_with"
+            | "reverse"
+            | "rotate_left"
+            | "rotate_right"
+            | "sort"
+            | "sort_by"
+            | "sort_by_cached_key"
+            | "sort_by_key"
+            | "splice"
+            | "split_at_mut"
+            | "split_first_mut"
+            | "split_last_mut"
+            | "split_off"
+            | "swap"
+            | "swap_remove"
+            | "take"
+            | "truncate"
+            | "values_mut"
+    )
+}
+
+fn flow_provenance_mutator_method(method: &str) -> bool {
+    projection_mutator_method(method) || matches!(method, "clone_from")
+}
+
+fn gate_provenance_mutator_method(method: &str) -> bool {
+    flow_provenance_mutator_method(method)
+}
+
+fn projection_method_preserves_typed_flow_state(method: &str) -> bool {
+    matches!(method, "clone")
+}
+
+fn bin_op_is_assign(op: &syn::BinOp) -> bool {
+    matches!(
+        op,
+        syn::BinOp::AddAssign(_)
+            | syn::BinOp::SubAssign(_)
+            | syn::BinOp::MulAssign(_)
+            | syn::BinOp::DivAssign(_)
+            | syn::BinOp::RemAssign(_)
+            | syn::BinOp::BitXorAssign(_)
+            | syn::BinOp::BitAndAssign(_)
+            | syn::BinOp::BitOrAssign(_)
+            | syn::BinOp::ShlAssign(_)
+            | syn::BinOp::ShrAssign(_)
+    )
+}
+
+fn canonical_gated_mob_command_variants() -> BTreeSet<String> {
+    canonical_mob_machine_command_gate_requirements()
+        .into_iter()
+        .map(|requirement| requirement.command.as_str().to_string())
+        .collect()
+}
+
+fn reply_tx_vars_from_pat(pat: &syn::Pat) -> BTreeSet<String> {
+    match pat {
+        syn::Pat::Struct(strukt) => strukt
+            .fields
+            .iter()
+            .filter(|field| member_key(&field.member) == "reply_tx")
+            .flat_map(|field| pat_bound_idents(&field.pat))
+            .collect(),
+        syn::Pat::Or(or) => or.cases.iter().flat_map(reply_tx_vars_from_pat).collect(),
+        syn::Pat::Reference(reference) => reply_tx_vars_from_pat(&reference.pat),
+        syn::Pat::Paren(paren) => reply_tx_vars_from_pat(&paren.pat),
+        syn::Pat::Ident(ident) if ident.ident == "reply_tx" => {
+            BTreeSet::from([ident.ident.to_string()])
+        }
+        _ => BTreeSet::new(),
+    }
+}
+
+fn pat_is_catch_all_command_arm(pat: &syn::Pat) -> bool {
+    match pat {
+        syn::Pat::Wild(_) => true,
+        syn::Pat::Ident(ident) => ident.subpat.is_none(),
+        syn::Pat::Reference(reference) => pat_is_catch_all_command_arm(&reference.pat),
+        syn::Pat::Paren(paren) => pat_is_catch_all_command_arm(&paren.pat),
+        syn::Pat::Type(ty) => pat_is_catch_all_command_arm(&ty.pat),
+        _ => false,
+    }
+}
+
+fn mob_command_variants_from_pat(
+    pat: &syn::Pat,
+    aliases: &RustUseAliases,
+    command_variants: &BTreeSet<String>,
+) -> BTreeSet<String> {
+    match pat {
+        syn::Pat::Struct(pat) => {
+            mob_command_variant_from_path(&pat.path, aliases, command_variants)
+                .into_iter()
+                .collect()
+        }
+        syn::Pat::TupleStruct(pat) => {
+            mob_command_variant_from_path(&pat.path, aliases, command_variants)
+                .into_iter()
+                .collect()
+        }
+        syn::Pat::Path(pat) => mob_command_variant_from_path(&pat.path, aliases, command_variants)
+            .into_iter()
+            .collect(),
+        syn::Pat::Or(or) => or
+            .cases
+            .iter()
+            .flat_map(|pat| mob_command_variants_from_pat(pat, aliases, command_variants))
+            .collect(),
+        syn::Pat::Ident(ident) => ident
+            .subpat
+            .as_ref()
+            .map(|(_, pat)| mob_command_variants_from_pat(pat, aliases, command_variants))
+            .unwrap_or_default(),
+        syn::Pat::Reference(reference) => {
+            mob_command_variants_from_pat(&reference.pat, aliases, command_variants)
+        }
+        syn::Pat::Paren(paren) => {
+            mob_command_variants_from_pat(&paren.pat, aliases, command_variants)
+        }
+        syn::Pat::Type(ty) => mob_command_variants_from_pat(&ty.pat, aliases, command_variants),
+        _ => BTreeSet::new(),
+    }
+}
+
+fn mob_command_variant_from_path(
+    path: &syn::Path,
+    aliases: &RustUseAliases,
+    command_variants: &BTreeSet<String>,
+) -> Option<String> {
+    if aliases.path_has_shadowed_bare_root(path) {
+        return None;
+    }
+    let segments = path_segments(path);
+    if aliases.ambiguous_glob_import && aliases.path_has_unresolved_bare_root(path, "MobCommand") {
+        return None;
+    }
+    if segments.len() == 1
+        && let Some(variant) = segments.first()
+        && command_variants.contains(variant)
+    {
+        if aliases.ambiguous_glob_import && aliases.path_is_unresolved_bare_ident(path, variant) {
+            return None;
+        }
+        return Some(variant.clone());
+    }
+    aliases.resolve_path(path).into_iter().find_map(|segments| {
+        canonical_mob_command_variant_from_segments(&segments, command_variants)
+    })
+}
+
+fn canonical_mob_command_variant_from_segments(
+    segments: &[String],
+    command_variants: &BTreeSet<String>,
+) -> Option<String> {
+    command_variants.iter().find_map(|variant| {
+        path_is_canonical_mob_command_variant(segments, variant.as_str()).then(|| variant.clone())
+    })
+}
+
+fn mob_gate_call_function(name: &str) -> bool {
+    matches!(
+        name,
+        "apply_dsl_input"
+            | "prepare_dsl_input"
+            | "preview_dsl_input"
+            | "apply_command_admission"
+            | "prepare_command_admission"
+            | "probe_mob_machine_input"
+    )
+}
+
+fn mob_side_effect_call(call: &syn::ExprMethodCall, receiver_aliases: &BTreeSet<String>) -> bool {
+    let method = call.method.to_string();
+    let receiver_root = expr_root_ident_through_method_calls(&call.receiver);
+    let receiver_is_actor_owned = receiver_root
+        .as_deref()
+        .is_some_and(|root| root == "self" || receiver_aliases.contains(root));
+    match method.as_str() {
+        "cancel" | "abort" => true,
+        "insert" | "set" | "remove" => receiver_is_actor_owned,
+        "cancel_unfinished_steps" | "terminalize_canceled" | "terminalize_failed" => true,
+        "create_pending_run"
+        | "create_task"
+        | "create_task_with_id"
+        | "interrupt_member"
+        | "terminalize_canceled_in_actor"
+        | "apply_dsl_signal" => receiver_is_actor_owned,
+        _ => false,
+    }
+}
+
+fn mob_side_effect_path_call(call: &syn::ExprCall, receiver_aliases: &BTreeSet<String>) -> bool {
+    let Some(path) = expr_as_path(&call.func) else {
+        return false;
+    };
+    let Some(function) = path
+        .segments
+        .last()
+        .map(|segment| segment.ident.to_string())
+    else {
+        return false;
+    };
+    match function.as_str() {
+        "cancel" | "abort" => true,
+        "spawn" => path_is_tokio_spawn(path),
+        "set" | "remove" => call
+            .args
+            .first()
+            .and_then(expr_root_ident_through_method_calls)
+            .as_deref()
+            .is_some_and(|root| root == "self" || receiver_aliases.contains(root)),
+        "cancel_unfinished_steps" | "terminalize_canceled" | "terminalize_failed" => true,
+        "create_pending_run"
+        | "create_task"
+        | "create_task_with_id"
+        | "interrupt_member"
+        | "terminalize_canceled_in_actor"
+        | "apply_dsl_signal" => call
+            .args
+            .first()
+            .and_then(expr_root_ident_through_method_calls)
+            .as_deref()
+            .is_some_and(|root| root == "self" || receiver_aliases.contains(root)),
+        _ => false,
+    }
+}
+
+fn path_is_tokio_spawn(path: &syn::Path) -> bool {
+    let segments = path_segments(path);
+    segments.iter().map(String::as_str).eq(["tokio", "spawn"])
+        || segments
+            .iter()
+            .map(String::as_str)
+            .eq(["crate", "tokio", "spawn"])
+}
+
+fn expr_root_ident_through_method_calls(expr: &syn::Expr) -> Option<String> {
+    match expr {
+        syn::Expr::Path(_) => expr_path_single_ident(expr),
+        syn::Expr::Field(field) => expr_root_ident_through_method_calls(&field.base),
+        syn::Expr::Index(index) => expr_root_ident_through_method_calls(&index.expr),
+        syn::Expr::MethodCall(call) => expr_root_ident_through_method_calls(&call.receiver),
+        syn::Expr::Reference(reference) => expr_root_ident_through_method_calls(&reference.expr),
+        syn::Expr::Unary(unary) if matches!(unary.op, syn::UnOp::Deref(_)) => {
+            expr_root_ident_through_method_calls(&unary.expr)
+        }
+        syn::Expr::Paren(paren) => expr_root_ident_through_method_calls(&paren.expr),
+        syn::Expr::Group(group) => expr_root_ident_through_method_calls(&group.expr),
+        syn::Expr::Await(await_expr) => expr_root_ident_through_method_calls(&await_expr.base),
+        _ => None,
+    }
+}
+
+fn expr_field_chain_through_method_calls(expr: &syn::Expr) -> Vec<String> {
+    match expr {
+        syn::Expr::Field(field) => {
+            let mut chain = expr_field_chain_through_method_calls(&field.base);
+            if let syn::Member::Named(ident) = &field.member {
+                chain.push(ident.to_string());
+            }
+            chain
+        }
+        syn::Expr::Path(_) => expr_field_chain(expr),
+        syn::Expr::Index(index) => expr_field_chain_through_method_calls(&index.expr),
+        syn::Expr::MethodCall(call) => expr_field_chain_through_method_calls(&call.receiver),
+        syn::Expr::Reference(reference) => expr_field_chain_through_method_calls(&reference.expr),
+        syn::Expr::Unary(unary) if matches!(unary.op, syn::UnOp::Deref(_)) => {
+            expr_field_chain_through_method_calls(&unary.expr)
+        }
+        syn::Expr::Paren(paren) => expr_field_chain_through_method_calls(&paren.expr),
+        syn::Expr::Group(group) => expr_field_chain_through_method_calls(&group.expr),
+        syn::Expr::Await(await_expr) => expr_field_chain_through_method_calls(&await_expr.base),
+        _ => Vec::new(),
+    }
+}
+
+fn expr_is_self_mob_side_effect_field(expr: &syn::Expr) -> bool {
+    let chain = expr_field_chain_through_method_calls(expr);
+    chain.first().is_some_and(|segment| segment == "self")
+        && chain.get(1).is_some_and(|segment| {
+            matches!(
+                segment.as_str(),
+                "spawn_policy" | "task_board_service" | "provisioner"
+            )
+        })
+}
+
+fn expr_root_idents_through_calls(expr: &syn::Expr) -> BTreeSet<String> {
+    let mut roots = BTreeSet::new();
+    collect_expr_root_idents_through_calls(expr, &mut roots);
+    roots
+}
+
+fn collect_expr_root_idents_through_calls(expr: &syn::Expr, roots: &mut BTreeSet<String>) {
+    if let Some(root) = expr_root_ident_through_method_calls(expr) {
+        roots.insert(root);
+    }
+    match expr {
+        syn::Expr::Array(array) => {
+            for elem in &array.elems {
+                collect_expr_root_idents_through_calls(elem, roots);
+            }
+        }
+        syn::Expr::Call(call) => {
+            for arg in &call.args {
+                collect_expr_root_idents_through_calls(arg, roots);
+            }
+        }
+        syn::Expr::MethodCall(call) => {
+            collect_expr_root_idents_through_calls(&call.receiver, roots);
+            for arg in &call.args {
+                collect_expr_root_idents_through_calls(arg, roots);
+            }
+        }
+        syn::Expr::Tuple(tuple) => {
+            for elem in &tuple.elems {
+                collect_expr_root_idents_through_calls(elem, roots);
+            }
+        }
+        syn::Expr::Reference(reference) => {
+            collect_expr_root_idents_through_calls(&reference.expr, roots);
+        }
+        syn::Expr::Paren(paren) => collect_expr_root_idents_through_calls(&paren.expr, roots),
+        syn::Expr::Group(group) => collect_expr_root_idents_through_calls(&group.expr, roots),
+        syn::Expr::Try(try_expr) => collect_expr_root_idents_through_calls(&try_expr.expr, roots),
+        syn::Expr::Await(await_expr) => {
+            collect_expr_root_idents_through_calls(&await_expr.base, roots);
+        }
+        syn::Expr::Unary(unary) if matches!(unary.op, syn::UnOp::Deref(_)) => {
+            collect_expr_root_idents_through_calls(&unary.expr, roots);
+        }
+        _ => {}
+    }
+}
+
+fn self_method_call_name_from_expr(expr: &syn::Expr) -> Option<String> {
+    match expr {
+        syn::Expr::MethodCall(call) if expr_is_self_receiver(&call.receiver) => {
+            Some(call.method.to_string())
+        }
+        syn::Expr::MethodCall(call) if call.method == "map_err" => {
+            self_method_call_name_from_expr(&call.receiver)
+        }
+        syn::Expr::Try(try_expr) => self_method_call_name_from_expr(&try_expr.expr),
+        syn::Expr::Await(await_expr) => self_method_call_name_from_expr(&await_expr.base),
+        syn::Expr::Reference(reference) => self_method_call_name_from_expr(&reference.expr),
+        syn::Expr::Paren(paren) => self_method_call_name_from_expr(&paren.expr),
+        syn::Expr::Group(group) => self_method_call_name_from_expr(&group.expr),
+        syn::Expr::Match(expr_match) => {
+            let calls = expr_match
+                .arms
+                .iter()
+                .filter_map(|arm| self_method_call_name_from_expr(&arm.body))
+                .collect::<BTreeSet<_>>();
+            if calls.len() == 1 {
+                calls.into_iter().next()
+            } else {
+                None
+            }
+        }
+        _ => None,
+    }
+}
+
+fn mob_gate_method_input(
+    call: &syn::ExprMethodCall,
+    input_vars: &BTreeMap<String, MobMachineInputVariant>,
+    aliases: &RustUseAliases,
+) -> Option<MobMachineInputVariant> {
+    if !mob_gate_call_function(&call.method.to_string()) || !expr_is_self_receiver(&call.receiver) {
+        return None;
+    }
+    call.args
+        .first()
+        .and_then(|arg| mob_input_variant_from_expr(arg, input_vars, aliases))
+}
+
+fn expr_is_self_receiver(expr: &syn::Expr) -> bool {
+    expr_path_single_ident(expr).is_some_and(|ident| ident == "self")
+}
+
+fn mob_gate_input_from_expr(
+    expr: &syn::Expr,
+    input_vars: &BTreeMap<String, MobMachineInputVariant>,
+    aliases: &RustUseAliases,
+) -> Option<MobMachineInputVariant> {
+    match expr {
+        syn::Expr::MethodCall(call) => {
+            let method = call.method.to_string();
+            if method == "map_err" {
+                return mob_gate_input_from_expr(&call.receiver, input_vars, aliases);
+            }
+            if let Some(input) = mob_gate_method_input(call, input_vars, aliases) {
+                return Some(input);
+            }
+            None
+        }
+        syn::Expr::Call(_) => None,
+        syn::Expr::Try(try_expr) => mob_gate_input_from_expr(&try_expr.expr, input_vars, aliases),
+        syn::Expr::Await(await_expr) => {
+            mob_gate_input_from_expr(&await_expr.base, input_vars, aliases)
+        }
+        syn::Expr::Reference(reference) => {
+            mob_gate_input_from_expr(&reference.expr, input_vars, aliases)
+        }
+        syn::Expr::Paren(paren) => mob_gate_input_from_expr(&paren.expr, input_vars, aliases),
+        syn::Expr::Group(group) => mob_gate_input_from_expr(&group.expr, input_vars, aliases),
+        _ => None,
+    }
+}
+
+fn mob_input_variant_from_expr(
+    expr: &syn::Expr,
+    input_vars: &BTreeMap<String, MobMachineInputVariant>,
+    aliases: &RustUseAliases,
+) -> Option<MobMachineInputVariant> {
+    match expr {
+        syn::Expr::Struct(expr) => mob_input_variant_from_path(&expr.path, aliases),
+        syn::Expr::Path(expr) => {
+            let segments = path_segments(&expr.path);
+            if segments.len() == 1
+                && let Some(input) = input_vars.get(&segments[0])
+            {
+                return Some(*input);
+            }
+            mob_input_variant_from_path(&expr.path, aliases)
+        }
+        syn::Expr::Call(call) => {
+            let syn::Expr::Path(func) = &*call.func else {
+                return None;
+            };
+            if path_is_canonical_mob_run_flow_input_constructor(&func.path, aliases) {
+                return Some(MobMachineInputVariant::RunFlow);
+            }
+            mob_input_variant_from_path(&func.path, aliases)
+        }
+        syn::Expr::MethodCall(call) if call.method == "clone" => {
+            mob_input_variant_from_expr(&call.receiver, input_vars, aliases)
+        }
+        syn::Expr::Try(try_expr) => {
+            mob_input_variant_from_expr(&try_expr.expr, input_vars, aliases)
+        }
+        syn::Expr::Reference(reference) => {
+            mob_input_variant_from_expr(&reference.expr, input_vars, aliases)
+        }
+        syn::Expr::Paren(paren) => mob_input_variant_from_expr(&paren.expr, input_vars, aliases),
+        syn::Expr::Group(group) => mob_input_variant_from_expr(&group.expr, input_vars, aliases),
+        _ => None,
+    }
+}
+
+fn path_is_canonical_mob_run_flow_input_constructor(
+    path: &syn::Path,
+    aliases: &RustUseAliases,
+) -> bool {
+    if aliases.path_has_shadowed_bare_root(path) {
+        return false;
+    }
+    if aliases.ambiguous_glob_import && aliases.path_has_unresolved_bare_root(path, "MobRun") {
+        return false;
+    }
+    aliases.resolve_path(path).into_iter().any(|segments| {
+        segments
+            .last()
+            .is_some_and(|method| method == "run_flow_input")
+            && path_is_canonical_mob_run_projection_owner(
+                &segments[..segments.len().saturating_sub(1)],
+            )
+    })
+}
+
+fn mob_input_variant_from_path(
+    path: &syn::Path,
+    aliases: &RustUseAliases,
+) -> Option<MobMachineInputVariant> {
+    if aliases.path_has_shadowed_bare_root(path) {
+        return None;
+    }
+    if aliases.ambiguous_glob_import
+        && aliases.path_has_unresolved_bare_root(path, "MobMachineInput")
+    {
+        return None;
+    }
+    aliases
+        .resolve_path(path)
+        .into_iter()
+        .find_map(|segments| canonical_mob_input_variant_from_segments(&segments))
+}
+
+fn canonical_mob_input_variant_from_segments(
+    segments: &[String],
+) -> Option<MobMachineInputVariant> {
+    MobMachineInput::variant_manifest()
+        .iter()
+        .copied()
+        .find(|variant| {
+            let variant = format!("{variant:?}");
+            path_is_canonical_mob_machine_variant(segments, "MobMachineInput", variant.as_str())
+        })
+}
+
+fn camel_to_snake(input: &str) -> String {
+    let mut out = String::with_capacity(input.len());
+    for (index, ch) in input.chars().enumerate() {
+        if ch.is_ascii_uppercase() {
+            if index > 0 {
+                out.push('_');
+            }
+            out.push(ch.to_ascii_lowercase());
+        } else {
+            out.push(ch);
+        }
+    }
+    out
 }
 
 pub fn collect_generated_kernel_boundary_mismatches(root: &Path) -> Result<Vec<String>> {

--- a/xtask/tests/machines_contracts.rs
+++ b/xtask/tests/machines_contracts.rs
@@ -1,7 +1,10 @@
 #![allow(clippy::expect_used, clippy::panic)]
 
-use std::fs;
+use std::{collections::BTreeMap, fs};
 
+use meerkat_mob::runtime::flow_frame_engine::{
+    FlowFrameLoopStorePlanVariant, canonical_flow_frame_loop_store_plan_commit_requirements,
+};
 use tempfile::tempdir;
 use xtask::machines::*;
 
@@ -73,6 +76,93 @@ fn registry_selection_rejects_absorbed_machine_slugs() {
 fn registry_validation_covers_canonical_machine_and_composition_sets() {
     let registry = CanonicalRegistry::load();
     assert!(registry.validate().is_ok());
+}
+
+#[test]
+fn flow_frame_loop_store_plan_commit_requirements_cover_all_variants_with_authority_cas() {
+    let requirements = canonical_flow_frame_loop_store_plan_commit_requirements();
+    let mut by_variant = BTreeMap::new();
+    for requirement in requirements {
+        let previous = by_variant.insert(
+            requirement.variant.as_str(),
+            requirement.operation.store_methods(),
+        );
+        assert!(
+            previous.is_none(),
+            "duplicate commit requirement for {}",
+            requirement.variant.as_str()
+        );
+        let methods = requirement.operation.store_methods();
+        assert_eq!(
+            methods.len(),
+            1,
+            "expected exactly one authority CAS method for {}",
+            requirement.variant.as_str()
+        );
+        assert!(
+            methods[0].starts_with("cas_") && methods[0].ends_with("_with_authority"),
+            "expected authority MobRunStore CAS method for {}, got {}",
+            requirement.variant.as_str(),
+            methods[0]
+        );
+    }
+
+    let expected = [
+        (
+            FlowFrameLoopStorePlanVariant::InsertFrame,
+            "cas_frame_state_with_authority",
+        ),
+        (
+            FlowFrameLoopStorePlanVariant::FrameState,
+            "cas_frame_state_with_authority",
+        ),
+        (
+            FlowFrameLoopStorePlanVariant::CompleteStepAndRecordOutput,
+            "cas_complete_step_and_record_output_with_authority",
+        ),
+        (
+            FlowFrameLoopStorePlanVariant::GrantNodeSlot,
+            "cas_grant_node_slot_with_authority",
+        ),
+        (
+            FlowFrameLoopStorePlanVariant::StartLoop,
+            "cas_start_loop_with_authority",
+        ),
+        (
+            FlowFrameLoopStorePlanVariant::GrantBodyFrameStart,
+            "cas_grant_body_frame_start_with_authority",
+        ),
+        (
+            FlowFrameLoopStorePlanVariant::RunStateOnly,
+            "cas_flow_state_with_authority",
+        ),
+        (
+            FlowFrameLoopStorePlanVariant::SealFrame,
+            "cas_frame_state_with_authority",
+        ),
+        (
+            FlowFrameLoopStorePlanVariant::CompleteBodyFrame,
+            "cas_complete_body_frame_with_authority",
+        ),
+        (
+            FlowFrameLoopStorePlanVariant::LoopRequestBodyFrame,
+            "cas_loop_request_body_frame_with_authority",
+        ),
+        (
+            FlowFrameLoopStorePlanVariant::CompleteLoop,
+            "cas_complete_loop_with_authority",
+        ),
+    ];
+
+    assert_eq!(by_variant.len(), expected.len());
+    for (variant, method) in expected {
+        assert_eq!(
+            by_variant.get(variant.as_str()).copied(),
+            Some([method]),
+            "unexpected commit method for {}",
+            variant.as_str()
+        );
+    }
 }
 
 #[test]
@@ -220,7 +310,7 @@ fn peer_response_terminal_projection_ratchet_rejects_core_string_identity_bus() 
     fs::create_dir_all(&core).expect("create core dir");
     fs::write(
         core.join("handles.rs"),
-        r#"
+        r"
 pub struct PeerResponseTerminalSource {
     pub transport_identity: Option<String>,
     pub route_identity: String,
@@ -236,7 +326,7 @@ impl PeerResponseTerminalFact {
         peer_response_terminal_context_key(&self.source.route_identity, &self.correlation_id)
     }
 }
-"#,
+",
     )
     .expect("write core handles file");
 
@@ -277,22 +367,22 @@ fn peer_response_terminal_projection_ratchet_rejects_shell_peer_name_identity_bu
     fs::create_dir_all(rpc.join("handlers")).expect("create rpc handlers dir");
     fs::write(
         contracts.join("runtime.rs"),
-        r#"
+        r"
 pub struct SessionPeerResponseTerminalParams {
     pub peer_name: PeerName,
 }
-"#,
+",
     )
     .expect("write contract boundary file");
     fs::write(
         rpc.join("session_runtime.rs"),
-        r#"
+        r"
 fn bad(peer_name: PeerName) {
     let route = PeerResponseTerminalRouteIdentity::parse(peer_name.as_str().to_string());
     let display = PeerResponseTerminalDisplayIdentity::parse(peer_name.as_str().to_string());
     let _ = peer_response_terminal_input(&peer_name, request_id, status, result);
 }
-"#,
+",
     )
     .expect("write rpc boundary file");
 
@@ -857,6 +947,40 @@ fn live_flow_runtime_reducer_transition_ratchet_rejects_aliases_and_projection_w
 }
 
 #[test]
+fn live_flow_runtime_projection_ratchet_rejects_indexed_projection_field_writes() {
+    let dir = tempdir().expect("tempdir");
+    let runtime = dir.path().join("meerkat-mob/src/runtime");
+    fs::create_dir_all(&runtime).expect("create runtime dir");
+    fs::write(
+        runtime.join("flow.rs"),
+        r"
+fn bad(run: &mut MobRun, frame: &mut FrameSnapshot, frame_id: FrameId, node_id: NodeId) {
+    run.flow_state.ready_frames[0] = frame_id;
+    frame.kernel_state.ready_queue[0] = node_id;
+}
+",
+    )
+    .expect("write indexed projection field writes");
+
+    let mismatches = collect_direct_flow_reducer_transition_mismatches(dir.path())
+        .expect("flow projection mutation mismatches");
+    assert!(
+        mismatches.iter().any(|mismatch| {
+            mismatch.contains("meerkat-mob/src/runtime/flow.rs")
+                && mismatch.contains(".flow_state.ready_frames")
+        }),
+        "expected indexed flow_state ready_frames write to be rejected, got {mismatches:#?}"
+    );
+    assert!(
+        mismatches.iter().any(|mismatch| {
+            mismatch.contains("meerkat-mob/src/runtime/flow.rs")
+                && mismatch.contains(".kernel_state.ready_queue")
+        }),
+        "expected indexed kernel_state ready_queue write to be rejected, got {mismatches:#?}"
+    );
+}
+
+#[test]
 fn mob_runtime_catalog_command_gate_ratchet_rejects_missing_and_warning_only_gates() {
     let dir = tempdir().expect("tempdir");
     let runtime = dir.path().join("meerkat-mob/src/runtime");
@@ -978,6 +1102,4906 @@ async fn dispatch(&mut self, command: MobCommand) -> Result<(), MobError> {
 }
 
 #[test]
+fn mob_runtime_catalog_command_gate_ratchet_rejects_comment_spoofed_gates() {
+    let dir = tempdir().expect("tempdir");
+    let runtime = dir.path().join("meerkat-mob/src/runtime");
+    fs::create_dir_all(&runtime).expect("create runtime dir");
+    fs::write(
+        runtime.join("actor.rs"),
+        r#"
+async fn handle_run_flow(&mut self) -> Result<RunId, MobError> {
+    // self.apply_dsl_input(MobMachineInput::RunFlow, "run_flow")?;
+    Ok(RunId::new())
+}
+
+async fn handle_cancel_flow(&mut self) -> Result<(), MobError> {
+    // self.apply_command_admission(MobMachineInput::CancelFlow, MobState::Running, "cancel_flow")?;
+    Ok(())
+}
+
+async fn handle_task_create(&mut self) -> Result<TaskId, MobError> {
+    // self.prepare_command_admission(MobMachineInput::TaskCreate { task_id }, MobState::Running, "task_create")?;
+    Ok(TaskId::new())
+}
+
+async fn handle_force_cancel(&mut self) -> Result<(), MobError> {
+    // self.apply_dsl_input(MobMachineInput::ForceCancel, "force_cancel")?;
+    Ok(())
+}
+
+async fn dispatch(&mut self, command: MobCommand) {
+    match command {
+        MobCommand::SetSpawnPolicy { policy, reply_tx } => {
+            // self.apply_dsl_input(MobMachineInput::SetSpawnPolicy, "set_spawn_policy")?;
+            self.spawn_policy.set(policy).await;
+            let _ = reply_tx.send(());
+        }
+        _ => {}
+    }
+}
+"#,
+    )
+    .expect("write comment-spoofed actor gates");
+
+    let mismatches = collect_mob_runtime_catalog_command_gate_mismatches(dir.path())
+        .expect("catalog command gate mismatches");
+    for input in [
+        "RunFlow",
+        "CancelFlow",
+        "TaskCreate",
+        "SetSpawnPolicy",
+        "ForceCancel",
+    ] {
+        assert!(
+            mismatches.iter().any(|mismatch| {
+                mismatch.contains(&format!("MobCommand::{input}"))
+                    && mismatch.contains(&format!("MobMachineInput::{input}"))
+            }),
+            "expected comment-spoofed {input} command gate to be rejected, got {mismatches:#?}"
+        );
+    }
+}
+
+#[test]
+fn mob_runtime_catalog_command_gate_ratchet_rejects_ignored_map_err_gates() {
+    let dir = tempdir().expect("tempdir");
+    let runtime = dir.path().join("meerkat-mob/src/runtime");
+    fs::create_dir_all(&runtime).expect("create runtime dir");
+    fs::write(
+        runtime.join("actor.rs"),
+        r#"
+async fn handle_run_flow(&mut self) -> Result<RunId, MobError> {
+    self.apply_dsl_input(MobMachineInput::RunFlow, "run_flow")?;
+    Ok(RunId::new())
+}
+
+async fn handle_cancel_flow(&mut self) -> Result<(), MobError> {
+    self.apply_command_admission(MobMachineInput::CancelFlow, MobState::Running, "cancel_flow")?;
+    Ok(())
+}
+
+async fn handle_task_create(&mut self) -> Result<TaskId, MobError> {
+    self.prepare_command_admission(MobMachineInput::TaskCreate { task_id }, MobState::Running, "task_create")?;
+    Ok(TaskId::new())
+}
+
+async fn handle_force_cancel(&mut self) -> Result<(), MobError> {
+    self.preview_dsl_input(MobMachineInput::ForceCancel, "force_cancel")?;
+    self.apply_dsl_input(MobMachineInput::ForceCancel, "force_cancel")?;
+    Ok(())
+}
+
+async fn handle_set_spawn_policy(&mut self) -> Result<(), MobError> {
+    Ok(())
+}
+
+async fn dispatch(&mut self, command: MobCommand) {
+    match command {
+        MobCommand::SetSpawnPolicy { policy, reply_tx } => {
+            let result = self
+                .apply_dsl_input(MobMachineInput::SetSpawnPolicy, "set_spawn_policy")
+                .map_err(|error| MobError::Internal(format!("{error}")));
+            self.spawn_policy.set(policy).await;
+            let _ = reply_tx.send(result);
+        }
+        _ => {}
+    }
+}
+"#,
+    )
+    .expect("write ignored map_err actor gate");
+
+    let mismatches = collect_mob_runtime_catalog_command_gate_mismatches(dir.path())
+        .expect("catalog command gate mismatches");
+    assert!(
+        mismatches.iter().any(|mismatch| {
+            mismatch.contains("MobCommand::SetSpawnPolicy")
+                && mismatch.contains("MobMachineInput::SetSpawnPolicy")
+        }),
+        "expected ignored SetSpawnPolicy map_err gate to be rejected, got {mismatches:#?}"
+    );
+}
+
+#[test]
+fn mob_runtime_catalog_command_gate_ratchet_rejects_uncontrolled_is_ok_checks() {
+    let dir = tempdir().expect("tempdir");
+    let runtime = dir.path().join("meerkat-mob/src/runtime");
+    fs::create_dir_all(&runtime).expect("create runtime dir");
+    fs::write(
+        runtime.join("actor.rs"),
+        r#"
+async fn handle_run_flow(&mut self) -> Result<RunId, MobError> {
+    self.apply_dsl_input(MobMachineInput::RunFlow, "run_flow")?;
+    Ok(RunId::new())
+}
+
+async fn handle_cancel_flow(&mut self) -> Result<(), MobError> {
+    self.apply_command_admission(MobMachineInput::CancelFlow, MobState::Running, "cancel_flow")?;
+    Ok(())
+}
+
+async fn handle_task_create(&mut self) -> Result<TaskId, MobError> {
+    self.prepare_command_admission(MobMachineInput::TaskCreate { task_id }, MobState::Running, "task_create")?;
+    Ok(TaskId::new())
+}
+
+async fn handle_force_cancel(&mut self) -> Result<(), MobError> {
+    self.preview_dsl_input(MobMachineInput::ForceCancel, "force_cancel")?;
+    self.apply_dsl_input(MobMachineInput::ForceCancel, "force_cancel")?;
+    Ok(())
+}
+
+async fn handle_set_spawn_policy(&mut self) -> Result<(), MobError> {
+    Ok(())
+}
+
+async fn dispatch(&mut self, command: MobCommand) {
+    match command {
+        MobCommand::SetSpawnPolicy { policy, reply_tx } => {
+            let result = self
+                .apply_dsl_input(MobMachineInput::SetSpawnPolicy, "set_spawn_policy")
+                .map_err(|error| MobError::Internal(format!("{error}")));
+            let _ = result.is_ok();
+            self.spawn_policy.set(policy).await;
+            let _ = reply_tx.send(result);
+        }
+        _ => {}
+    }
+}
+"#,
+    )
+    .expect("write uncontrolled is_ok actor gate");
+
+    let mismatches = collect_mob_runtime_catalog_command_gate_mismatches(dir.path())
+        .expect("catalog command gate mismatches");
+    assert!(
+        mismatches.iter().any(|mismatch| {
+            mismatch.contains("MobCommand::SetSpawnPolicy")
+                && mismatch.contains("MobMachineInput::SetSpawnPolicy")
+        }),
+        "expected uncontrolled SetSpawnPolicy is_ok check to be rejected, got {mismatches:#?}"
+    );
+}
+
+#[test]
+fn mob_runtime_catalog_command_gate_ratchet_rejects_branch_local_is_ok_bypass() {
+    let dir = tempdir().expect("tempdir");
+    let runtime = dir.path().join("meerkat-mob/src/runtime");
+    fs::create_dir_all(&runtime).expect("create runtime dir");
+    fs::write(
+        runtime.join("actor.rs"),
+        r#"
+async fn handle_run_flow(&mut self) -> Result<RunId, MobError> {
+    self.apply_dsl_input(MobMachineInput::RunFlow, "run_flow")?;
+    Ok(RunId::new())
+}
+
+async fn handle_cancel_flow(&mut self) -> Result<(), MobError> {
+    self.apply_command_admission(MobMachineInput::CancelFlow, MobState::Running, "cancel_flow")?;
+    Ok(())
+}
+
+async fn handle_task_create(&mut self) -> Result<TaskId, MobError> {
+    self.prepare_command_admission(MobMachineInput::TaskCreate { task_id }, MobState::Running, "task_create")?;
+    Ok(TaskId::new())
+}
+
+async fn handle_force_cancel(&mut self) -> Result<(), MobError> {
+    self.preview_dsl_input(MobMachineInput::ForceCancel, "force_cancel")?;
+    self.apply_dsl_input(MobMachineInput::ForceCancel, "force_cancel")?;
+    Ok(())
+}
+
+async fn dispatch(&mut self, command: MobCommand) {
+    match command {
+        MobCommand::SetSpawnPolicy { policy, reply_tx } => {
+            let result = self
+                .apply_dsl_input(MobMachineInput::SetSpawnPolicy, "set_spawn_policy")
+                .map_err(|error| MobError::Internal(format!("{error}")));
+            if result.is_ok() {
+                self.unrelated.set(policy.clone()).await;
+            }
+            self.spawn_policy.set(policy).await;
+            let _ = reply_tx.send(result);
+        }
+        _ => {}
+    }
+}
+"#,
+    )
+    .expect("write branch-local is_ok actor gate");
+
+    let mismatches = collect_mob_runtime_catalog_command_gate_mismatches(dir.path())
+        .expect("catalog command gate mismatches");
+    assert!(
+        mismatches.iter().any(|mismatch| {
+            mismatch.contains("MobCommand::SetSpawnPolicy")
+                && mismatch.contains("MobMachineInput::SetSpawnPolicy")
+        }),
+        "expected side effect outside SetSpawnPolicy is_ok branch to be rejected, got {mismatches:#?}"
+    );
+}
+
+#[test]
+fn mob_runtime_catalog_command_gate_ratchet_accepts_helper_side_effect_inside_is_ok_branch() {
+    let dir = tempdir().expect("tempdir");
+    let runtime = dir.path().join("meerkat-mob/src/runtime");
+    fs::create_dir_all(&runtime).expect("create runtime dir");
+    fs::write(
+        runtime.join("actor.rs"),
+        r#"
+async fn apply_spawn_policy(&mut self, policy: SpawnPolicy) -> Result<(), MobError> {
+    self.spawn_policy.set(policy).await;
+    Ok(())
+}
+
+async fn handle_run_flow(&mut self) -> Result<RunId, MobError> {
+    self.apply_dsl_input(MobMachineInput::RunFlow, "run_flow")?;
+    Ok(RunId::new())
+}
+
+async fn handle_cancel_flow(&mut self) -> Result<(), MobError> {
+    self.apply_command_admission(MobMachineInput::CancelFlow, MobState::Running, "cancel_flow")?;
+    Ok(())
+}
+
+async fn handle_task_create(&mut self) -> Result<TaskId, MobError> {
+    self.apply_dsl_input(MobMachineInput::TaskCreate { task_id }, "task_create")?;
+    Ok(TaskId::new())
+}
+
+async fn handle_force_cancel(&mut self) -> Result<(), MobError> {
+    self.apply_dsl_input(MobMachineInput::ForceCancel, "force_cancel")?;
+    Ok(())
+}
+
+async fn dispatch(&mut self, command: MobCommand) {
+    match command {
+        MobCommand::SetSpawnPolicy { policy, reply_tx } => {
+            let result =
+                self.apply_dsl_input(MobMachineInput::SetSpawnPolicy, "set_spawn_policy");
+            if result.is_ok() {
+                self.apply_spawn_policy(policy.clone()).await?;
+            }
+            let _ = reply_tx.send(result);
+        }
+        _ => {}
+    }
+}
+"#,
+    )
+    .expect("write helper side effect inside is_ok branch actor");
+
+    let mismatches = collect_mob_runtime_catalog_command_gate_mismatches(dir.path())
+        .expect("catalog command gate mismatches");
+    assert!(
+        mismatches.is_empty(),
+        "expected helper side effect inside SetSpawnPolicy is_ok branch to be accepted, got {mismatches:#?}"
+    );
+}
+
+#[test]
+fn mob_runtime_catalog_command_gate_ratchet_rejects_ufcs_set_before_gate() {
+    let dir = tempdir().expect("tempdir");
+    let runtime = dir.path().join("meerkat-mob/src/runtime");
+    fs::create_dir_all(&runtime).expect("create runtime dir");
+    fs::write(
+        runtime.join("actor.rs"),
+        r#"
+async fn handle_run_flow(&mut self) -> Result<RunId, MobError> {
+    self.apply_dsl_input(MobMachineInput::RunFlow, "run_flow")?;
+    Ok(RunId::new())
+}
+
+async fn handle_cancel_flow(&mut self) -> Result<(), MobError> {
+    self.apply_command_admission(MobMachineInput::CancelFlow, MobState::Running, "cancel_flow")?;
+    Ok(())
+}
+
+async fn handle_task_create(&mut self) -> Result<TaskId, MobError> {
+    self.apply_dsl_input(MobMachineInput::TaskCreate { task_id }, "task_create")?;
+    Ok(TaskId::new())
+}
+
+async fn handle_force_cancel(&mut self) -> Result<(), MobError> {
+    self.apply_dsl_input(MobMachineInput::ForceCancel, "force_cancel")?;
+    Ok(())
+}
+
+async fn dispatch(&mut self, command: MobCommand) {
+    match command {
+        MobCommand::SetSpawnPolicy { policy, reply_tx } => {
+            SpawnPolicyService::set(self.spawn_policy.as_ref(), policy.clone()).await?;
+            let result =
+                self.apply_dsl_input(MobMachineInput::SetSpawnPolicy, "set_spawn_policy");
+            let _ = reply_tx.send(result);
+        }
+        _ => {}
+    }
+}
+"#,
+    )
+    .expect("write UFCS set before gate actor");
+
+    let mismatches = collect_mob_runtime_catalog_command_gate_mismatches(dir.path())
+        .expect("catalog command gate mismatches");
+    assert!(
+        mismatches.iter().any(|mismatch| {
+            mismatch.contains("MobCommand::SetSpawnPolicy")
+                && mismatch.contains("MobMachineInput::SetSpawnPolicy")
+        }),
+        "expected UFCS set side effect before SetSpawnPolicy gate to be rejected, got {mismatches:#?}"
+    );
+}
+
+#[test]
+fn mob_runtime_catalog_command_gate_ratchet_rejects_ufcs_set_on_associated_cloned_service_alias_before_gate()
+ {
+    let dir = tempdir().expect("tempdir");
+    let runtime = dir.path().join("meerkat-mob/src/runtime");
+    fs::create_dir_all(&runtime).expect("create runtime dir");
+    fs::write(
+        runtime.join("actor.rs"),
+        r#"
+async fn handle_run_flow(&mut self) -> Result<RunId, MobError> {
+    self.apply_dsl_input(MobMachineInput::RunFlow, "run_flow")?;
+    Ok(RunId::new())
+}
+
+async fn handle_cancel_flow(&mut self) -> Result<(), MobError> {
+    self.apply_command_admission(MobMachineInput::CancelFlow, MobState::Running, "cancel_flow")?;
+    Ok(())
+}
+
+async fn handle_task_create(&mut self) -> Result<TaskId, MobError> {
+    self.apply_dsl_input(MobMachineInput::TaskCreate { task_id }, "task_create")?;
+    Ok(TaskId::new())
+}
+
+async fn handle_force_cancel(&mut self) -> Result<(), MobError> {
+    self.apply_dsl_input(MobMachineInput::ForceCancel, "force_cancel")?;
+    Ok(())
+}
+
+async fn dispatch(&mut self, command: MobCommand) {
+    match command {
+        MobCommand::SetSpawnPolicy { policy, reply_tx } => {
+            let service = Arc::clone(&self.spawn_policy);
+            SpawnPolicyService::set(service.as_ref(), policy.clone()).await?;
+            let result =
+                self.apply_dsl_input(MobMachineInput::SetSpawnPolicy, "set_spawn_policy");
+            let _ = reply_tx.send(result);
+        }
+        _ => {}
+    }
+}
+"#,
+    )
+    .expect("write UFCS set on cloned service alias before gate actor");
+
+    let mismatches = collect_mob_runtime_catalog_command_gate_mismatches(dir.path())
+        .expect("catalog command gate mismatches");
+    assert!(
+        mismatches.iter().any(|mismatch| {
+            mismatch.contains("MobCommand::SetSpawnPolicy")
+                && mismatch.contains("MobMachineInput::SetSpawnPolicy")
+        }),
+        "expected UFCS set on associated cloned service alias before SetSpawnPolicy gate to be rejected, got {mismatches:#?}"
+    );
+}
+
+#[test]
+fn mob_runtime_catalog_command_gate_ratchet_rejects_method_set_on_associated_cloned_service_alias_before_gate()
+ {
+    let dir = tempdir().expect("tempdir");
+    let runtime = dir.path().join("meerkat-mob/src/runtime");
+    fs::create_dir_all(&runtime).expect("create runtime dir");
+    fs::write(
+        runtime.join("actor.rs"),
+        r#"
+async fn handle_run_flow(&mut self) -> Result<RunId, MobError> {
+    self.apply_dsl_input(MobMachineInput::RunFlow, "run_flow")?;
+    Ok(RunId::new())
+}
+
+async fn handle_cancel_flow(&mut self) -> Result<(), MobError> {
+    self.apply_command_admission(MobMachineInput::CancelFlow, MobState::Running, "cancel_flow")?;
+    Ok(())
+}
+
+async fn handle_task_create(&mut self) -> Result<TaskId, MobError> {
+    self.apply_dsl_input(MobMachineInput::TaskCreate { task_id }, "task_create")?;
+    Ok(TaskId::new())
+}
+
+async fn handle_force_cancel(&mut self) -> Result<(), MobError> {
+    self.apply_dsl_input(MobMachineInput::ForceCancel, "force_cancel")?;
+    Ok(())
+}
+
+async fn dispatch(&mut self, command: MobCommand) {
+    match command {
+        MobCommand::SetSpawnPolicy { policy, reply_tx } => {
+            let service = Arc::clone(&self.spawn_policy);
+            service.set(policy.clone()).await?;
+            let result =
+                self.apply_dsl_input(MobMachineInput::SetSpawnPolicy, "set_spawn_policy");
+            let _ = reply_tx.send(result);
+        }
+        _ => {}
+    }
+}
+"#,
+    )
+    .expect("write method set on cloned service alias before gate actor");
+
+    let mismatches = collect_mob_runtime_catalog_command_gate_mismatches(dir.path())
+        .expect("catalog command gate mismatches");
+    assert!(
+        mismatches.iter().any(|mismatch| {
+            mismatch.contains("MobCommand::SetSpawnPolicy")
+                && mismatch.contains("MobMachineInput::SetSpawnPolicy")
+        }),
+        "expected method set on associated cloned service alias before SetSpawnPolicy gate to be rejected, got {mismatches:#?}"
+    );
+}
+
+#[test]
+fn mob_runtime_catalog_command_gate_ratchet_rejects_fake_gate_receivers() {
+    let dir = tempdir().expect("tempdir");
+    let runtime = dir.path().join("meerkat-mob/src/runtime");
+    fs::create_dir_all(&runtime).expect("create runtime dir");
+    fs::write(
+        runtime.join("actor.rs"),
+        r#"
+async fn handle_run_flow(&mut self) -> Result<RunId, MobError> {
+    self.apply_dsl_input(MobMachineInput::RunFlow, "run_flow")?;
+    Ok(RunId::new())
+}
+
+async fn handle_cancel_flow(&mut self) -> Result<(), MobError> {
+    self.apply_command_admission(MobMachineInput::CancelFlow, MobState::Running, "cancel_flow")?;
+    Ok(())
+}
+
+async fn handle_task_create(&mut self) -> Result<TaskId, MobError> {
+    self.prepare_command_admission(MobMachineInput::TaskCreate { task_id }, MobState::Running, "task_create")?;
+    Ok(TaskId::new())
+}
+
+async fn handle_force_cancel(&mut self) -> Result<(), MobError> {
+    self.preview_dsl_input(MobMachineInput::ForceCancel, "force_cancel")?;
+    self.apply_dsl_input(MobMachineInput::ForceCancel, "force_cancel")?;
+    Ok(())
+}
+
+async fn dispatch(&mut self, command: MobCommand) {
+    match command {
+        MobCommand::SetSpawnPolicy { policy, reply_tx } => {
+            fake.apply_dsl_input(MobMachineInput::SetSpawnPolicy, "set_spawn_policy")?;
+            self.spawn_policy.set(policy).await;
+            let _ = reply_tx.send(Ok(()));
+        }
+        _ => {}
+    }
+}
+"#,
+    )
+    .expect("write fake receiver actor gate");
+
+    let mismatches = collect_mob_runtime_catalog_command_gate_mismatches(dir.path())
+        .expect("catalog command gate mismatches");
+    assert!(
+        mismatches.iter().any(|mismatch| {
+            mismatch.contains("MobCommand::SetSpawnPolicy")
+                && mismatch.contains("MobMachineInput::SetSpawnPolicy")
+        }),
+        "expected fake SetSpawnPolicy gate receiver to be rejected, got {mismatches:#?}"
+    );
+}
+
+#[test]
+fn mob_runtime_catalog_command_gate_ratchet_rejects_conditional_gate_leaks() {
+    let dir = tempdir().expect("tempdir");
+    let runtime = dir.path().join("meerkat-mob/src/runtime");
+    fs::create_dir_all(&runtime).expect("create runtime dir");
+    fs::write(
+        runtime.join("actor.rs"),
+        r#"
+async fn handle_run_flow(&mut self) -> Result<RunId, MobError> {
+    self.apply_dsl_input(MobMachineInput::RunFlow, "run_flow")?;
+    Ok(RunId::new())
+}
+
+async fn handle_cancel_flow(&mut self) -> Result<(), MobError> {
+    self.apply_command_admission(MobMachineInput::CancelFlow, MobState::Running, "cancel_flow")?;
+    Ok(())
+}
+
+async fn handle_task_create(&mut self) -> Result<TaskId, MobError> {
+    self.prepare_command_admission(MobMachineInput::TaskCreate { task_id }, MobState::Running, "task_create")?;
+    Ok(TaskId::new())
+}
+
+async fn handle_force_cancel(&mut self) -> Result<(), MobError> {
+    self.preview_dsl_input(MobMachineInput::ForceCancel, "force_cancel")?;
+    self.apply_dsl_input(MobMachineInput::ForceCancel, "force_cancel")?;
+    Ok(())
+}
+
+async fn dispatch(&mut self, command: MobCommand, should_gate: bool) {
+    match command {
+        MobCommand::SetSpawnPolicy { policy, reply_tx } => {
+            if should_gate {
+                self.apply_dsl_input(MobMachineInput::SetSpawnPolicy, "set_spawn_policy")?;
+            }
+            self.spawn_policy.set(policy).await;
+            let _ = reply_tx.send(Ok(()));
+        }
+        _ => {}
+    }
+}
+"#,
+    )
+    .expect("write conditional gate actor");
+
+    let mismatches = collect_mob_runtime_catalog_command_gate_mismatches(dir.path())
+        .expect("catalog command gate mismatches");
+    assert!(
+        mismatches.iter().any(|mismatch| {
+            mismatch.contains("MobCommand::SetSpawnPolicy")
+                && mismatch.contains("MobMachineInput::SetSpawnPolicy")
+        }),
+        "expected conditionally gated SetSpawnPolicy side effect to be rejected, got {mismatches:#?}"
+    );
+}
+
+#[test]
+fn mob_runtime_catalog_command_gate_ratchet_rejects_shadowed_pending_gate_results() {
+    let dir = tempdir().expect("tempdir");
+    let runtime = dir.path().join("meerkat-mob/src/runtime");
+    fs::create_dir_all(&runtime).expect("create runtime dir");
+    fs::write(
+        runtime.join("actor.rs"),
+        r#"
+async fn handle_run_flow(&mut self) -> Result<RunId, MobError> {
+    self.apply_dsl_input(MobMachineInput::RunFlow, "run_flow")?;
+    Ok(RunId::new())
+}
+
+async fn handle_cancel_flow(&mut self) -> Result<(), MobError> {
+    self.apply_command_admission(MobMachineInput::CancelFlow, MobState::Running, "cancel_flow")?;
+    Ok(())
+}
+
+async fn handle_task_create(&mut self) -> Result<TaskId, MobError> {
+    self.prepare_command_admission(MobMachineInput::TaskCreate { task_id }, MobState::Running, "task_create")?;
+    Ok(TaskId::new())
+}
+
+async fn handle_force_cancel(&mut self) -> Result<(), MobError> {
+    self.preview_dsl_input(MobMachineInput::ForceCancel, "force_cancel")?;
+    self.apply_dsl_input(MobMachineInput::ForceCancel, "force_cancel")?;
+    Ok(())
+}
+
+async fn dispatch(&mut self, command: MobCommand) {
+    match command {
+        MobCommand::SetSpawnPolicy { policy, reply_tx } => {
+            let result = self
+                .apply_dsl_input(MobMachineInput::SetSpawnPolicy, "set_spawn_policy")
+                .map_err(|error| MobError::Internal(format!("{error}")));
+            let result = Ok(());
+            if result.is_ok() {
+                self.spawn_policy.set(policy).await;
+            }
+            let _ = reply_tx.send(result);
+        }
+        _ => {}
+    }
+}
+"#,
+    )
+    .expect("write shadowed pending gate actor");
+
+    let mismatches = collect_mob_runtime_catalog_command_gate_mismatches(dir.path())
+        .expect("catalog command gate mismatches");
+    assert!(
+        mismatches.iter().any(|mismatch| {
+            mismatch.contains("MobCommand::SetSpawnPolicy")
+                && mismatch.contains("MobMachineInput::SetSpawnPolicy")
+        }),
+        "expected shadowed pending SetSpawnPolicy gate result to be rejected, got {mismatches:#?}"
+    );
+}
+
+#[test]
+fn mob_runtime_catalog_command_gate_ratchet_rejects_reassigned_pending_gate_results() {
+    let dir = tempdir().expect("tempdir");
+    let runtime = dir.path().join("meerkat-mob/src/runtime");
+    fs::create_dir_all(&runtime).expect("create runtime dir");
+    fs::write(
+        runtime.join("actor.rs"),
+        r#"
+async fn handle_run_flow(&mut self) -> Result<RunId, MobError> {
+    self.apply_dsl_input(MobMachineInput::RunFlow, "run_flow")?;
+    Ok(RunId::new())
+}
+
+async fn handle_cancel_flow(&mut self) -> Result<(), MobError> {
+    self.apply_command_admission(MobMachineInput::CancelFlow, MobState::Running, "cancel_flow")?;
+    Ok(())
+}
+
+async fn handle_task_create(&mut self) -> Result<TaskId, MobError> {
+    self.prepare_command_admission(MobMachineInput::TaskCreate { task_id }, MobState::Running, "task_create")?;
+    Ok(TaskId::new())
+}
+
+async fn handle_force_cancel(&mut self) -> Result<(), MobError> {
+    self.preview_dsl_input(MobMachineInput::ForceCancel, "force_cancel")?;
+    self.apply_dsl_input(MobMachineInput::ForceCancel, "force_cancel")?;
+    Ok(())
+}
+
+async fn dispatch(&mut self, command: MobCommand) {
+    match command {
+        MobCommand::SetSpawnPolicy { policy, reply_tx } => {
+            let mut result = self
+                .apply_dsl_input(MobMachineInput::SetSpawnPolicy, "set_spawn_policy")
+                .map_err(|error| MobError::Internal(format!("{error}")));
+            result = Ok(());
+            if result.is_ok() {
+                self.spawn_policy.set(policy).await;
+            }
+            let _ = reply_tx.send(result);
+        }
+        _ => {}
+    }
+}
+"#,
+    )
+    .expect("write reassigned pending gate actor");
+
+    let mismatches = collect_mob_runtime_catalog_command_gate_mismatches(dir.path())
+        .expect("catalog command gate mismatches");
+    assert!(
+        mismatches.iter().any(|mismatch| {
+            mismatch.contains("MobCommand::SetSpawnPolicy")
+                && mismatch.contains("MobMachineInput::SetSpawnPolicy")
+        }),
+        "expected reassigned pending SetSpawnPolicy gate result to be rejected, got {mismatches:#?}"
+    );
+}
+
+#[test]
+fn mob_runtime_catalog_command_gate_ratchet_rejects_reassigned_gate_inputs() {
+    let dir = tempdir().expect("tempdir");
+    let runtime = dir.path().join("meerkat-mob/src/runtime");
+    fs::create_dir_all(&runtime).expect("create runtime dir");
+    fs::write(
+        runtime.join("actor.rs"),
+        r#"
+async fn handle_run_flow(&mut self) -> Result<RunId, MobError> {
+    self.apply_dsl_input(MobMachineInput::RunFlow, "run_flow")?;
+    Ok(RunId::new())
+}
+
+async fn handle_cancel_flow(&mut self) -> Result<(), MobError> {
+    self.apply_command_admission(MobMachineInput::CancelFlow, MobState::Running, "cancel_flow")?;
+    Ok(())
+}
+
+async fn handle_task_create(&mut self) -> Result<TaskId, MobError> {
+    self.prepare_command_admission(MobMachineInput::TaskCreate { task_id }, MobState::Running, "task_create")?;
+    Ok(TaskId::new())
+}
+
+async fn handle_force_cancel(&mut self) -> Result<(), MobError> {
+    self.preview_dsl_input(MobMachineInput::ForceCancel, "force_cancel")?;
+    self.apply_dsl_input(MobMachineInput::ForceCancel, "force_cancel")?;
+    Ok(())
+}
+
+async fn dispatch(&mut self, command: MobCommand) {
+    match command {
+        MobCommand::SetSpawnPolicy { policy, reply_tx } => {
+            let mut input = MobMachineInput::SetSpawnPolicy;
+            input = MobMachineInput::RunFlow;
+            let result = self
+                .apply_dsl_input(input, "set_spawn_policy")
+                .map_err(|error| MobError::Internal(format!("{error}")));
+            if result.is_ok() {
+                self.spawn_policy.set(policy).await;
+            }
+            let _ = reply_tx.send(result);
+        }
+        _ => {}
+    }
+}
+"#,
+    )
+    .expect("write reassigned gate input actor");
+
+    let mismatches = collect_mob_runtime_catalog_command_gate_mismatches(dir.path())
+        .expect("catalog command gate mismatches");
+    assert!(
+        mismatches.iter().any(|mismatch| {
+            mismatch.contains("MobCommand::SetSpawnPolicy")
+                && mismatch.contains("MobMachineInput::SetSpawnPolicy")
+        }),
+        "expected reassigned SetSpawnPolicy gate input to be rejected, got {mismatches:#?}"
+    );
+}
+
+#[test]
+fn mob_runtime_catalog_command_gate_ratchet_rejects_if_let_shadowed_pending_gate_results() {
+    let dir = tempdir().expect("tempdir");
+    let runtime = dir.path().join("meerkat-mob/src/runtime");
+    fs::create_dir_all(&runtime).expect("create runtime dir");
+    fs::write(
+        runtime.join("actor.rs"),
+        r#"
+async fn handle_run_flow(&mut self) -> Result<RunId, MobError> {
+    self.apply_dsl_input(MobMachineInput::RunFlow, "run_flow")?;
+    Ok(RunId::new())
+}
+
+async fn handle_cancel_flow(&mut self) -> Result<(), MobError> {
+    self.apply_command_admission(MobMachineInput::CancelFlow, MobState::Running, "cancel_flow")?;
+    Ok(())
+}
+
+async fn handle_task_create(&mut self) -> Result<TaskId, MobError> {
+    self.prepare_command_admission(MobMachineInput::TaskCreate { task_id }, MobState::Running, "task_create")?;
+    Ok(TaskId::new())
+}
+
+async fn handle_force_cancel(&mut self) -> Result<(), MobError> {
+    self.preview_dsl_input(MobMachineInput::ForceCancel, "force_cancel")?;
+    self.apply_dsl_input(MobMachineInput::ForceCancel, "force_cancel")?;
+    Ok(())
+}
+
+async fn dispatch(&mut self, command: MobCommand, maybe_result: Option<Result<(), MobError>>) {
+    match command {
+        MobCommand::SetSpawnPolicy { policy, reply_tx } => {
+            let result = self
+                .apply_dsl_input(MobMachineInput::SetSpawnPolicy, "set_spawn_policy")
+                .map_err(|error| MobError::Internal(format!("{error}")));
+            if let Some(result) = maybe_result {
+                if result.is_ok() {
+                    self.spawn_policy.set(policy).await;
+                }
+                let _ = reply_tx.send(result);
+            }
+        }
+        _ => {}
+    }
+}
+"#,
+    )
+    .expect("write if-let shadowed pending gate actor");
+
+    let mismatches = collect_mob_runtime_catalog_command_gate_mismatches(dir.path())
+        .expect("catalog command gate mismatches");
+    assert!(
+        mismatches.iter().any(|mismatch| {
+            mismatch.contains("MobCommand::SetSpawnPolicy")
+                && mismatch.contains("MobMachineInput::SetSpawnPolicy")
+        }),
+        "expected if-let shadowed pending SetSpawnPolicy gate result to be rejected, got {mismatches:#?}"
+    );
+}
+
+#[test]
+fn mob_runtime_catalog_command_gate_ratchet_rejects_unpropagated_gate_result_success_reply() {
+    let dir = tempdir().expect("tempdir");
+    let runtime = dir.path().join("meerkat-mob/src/runtime");
+    fs::create_dir_all(&runtime).expect("create runtime dir");
+    fs::write(
+        runtime.join("actor.rs"),
+        r#"
+async fn handle_run_flow(&mut self) -> Result<RunId, MobError> {
+    self.apply_dsl_input(MobMachineInput::RunFlow, "run_flow")?;
+    Ok(RunId::new())
+}
+
+async fn handle_cancel_flow(&mut self) -> Result<(), MobError> {
+    self.apply_command_admission(MobMachineInput::CancelFlow, MobState::Running, "cancel_flow")?;
+    Ok(())
+}
+
+async fn handle_task_create(&mut self) -> Result<TaskId, MobError> {
+    self.prepare_command_admission(MobMachineInput::TaskCreate { task_id }, MobState::Running, "task_create")?;
+    Ok(TaskId::new())
+}
+
+async fn handle_force_cancel(&mut self) -> Result<(), MobError> {
+    self.preview_dsl_input(MobMachineInput::ForceCancel, "force_cancel")?;
+    self.apply_dsl_input(MobMachineInput::ForceCancel, "force_cancel")?;
+    Ok(())
+}
+
+async fn dispatch(&mut self, command: MobCommand) {
+    match command {
+        MobCommand::SetSpawnPolicy { policy, reply_tx } => {
+            let result = self
+                .apply_dsl_input(MobMachineInput::SetSpawnPolicy, "set_spawn_policy")
+                .map_err(|error| MobError::Internal(format!("{error}")));
+            if result.is_ok() {
+                self.spawn_policy.set(policy).await;
+            }
+            let _ = reply_tx.send(Ok(()));
+        }
+        _ => {}
+    }
+}
+"#,
+    )
+    .expect("write unpropagated gate result success reply actor");
+
+    let mismatches = collect_mob_runtime_catalog_command_gate_mismatches(dir.path())
+        .expect("catalog command gate mismatches");
+    assert!(
+        mismatches.iter().any(|mismatch| {
+            mismatch.contains("MobCommand::SetSpawnPolicy")
+                && mismatch.contains("MobMachineInput::SetSpawnPolicy")
+        }),
+        "expected SetSpawnPolicy gate result not propagated to reply to be rejected, got {mismatches:#?}"
+    );
+}
+
+#[test]
+fn mob_runtime_catalog_command_gate_ratchet_rejects_gate_result_sent_to_unrelated_channel() {
+    let dir = tempdir().expect("tempdir");
+    let runtime = dir.path().join("meerkat-mob/src/runtime");
+    fs::create_dir_all(&runtime).expect("create runtime dir");
+    fs::write(
+        runtime.join("actor.rs"),
+        r#"
+async fn handle_run_flow(&mut self) -> Result<RunId, MobError> {
+    self.apply_dsl_input(MobMachineInput::RunFlow, "run_flow")?;
+    Ok(RunId::new())
+}
+
+async fn handle_cancel_flow(&mut self) -> Result<(), MobError> {
+    self.apply_command_admission(MobMachineInput::CancelFlow, MobState::Running, "cancel_flow")?;
+    Ok(())
+}
+
+async fn handle_task_create(&mut self) -> Result<TaskId, MobError> {
+    self.prepare_command_admission(MobMachineInput::TaskCreate { task_id }, MobState::Running, "task_create")?;
+    Ok(TaskId::new())
+}
+
+async fn handle_force_cancel(&mut self) -> Result<(), MobError> {
+    self.preview_dsl_input(MobMachineInput::ForceCancel, "force_cancel")?;
+    self.apply_dsl_input(MobMachineInput::ForceCancel, "force_cancel")?;
+    Ok(())
+}
+
+async fn dispatch(&mut self, command: MobCommand, audit_tx: ReplyTx<Result<(), MobError>>) {
+    match command {
+        MobCommand::SetSpawnPolicy { policy, reply_tx } => {
+            let result = self
+                .apply_dsl_input(MobMachineInput::SetSpawnPolicy, "set_spawn_policy")
+                .map_err(|error| MobError::Internal(format!("{error}")));
+            if result.is_ok() {
+                self.spawn_policy.set(policy).await;
+            }
+            let _ = audit_tx.send(result);
+            let _ = reply_tx.send(Ok(()));
+        }
+        _ => {}
+    }
+}
+"#,
+    )
+    .expect("write unrelated reply channel actor");
+
+    let mismatches = collect_mob_runtime_catalog_command_gate_mismatches(dir.path())
+        .expect("catalog command gate mismatches");
+    assert!(
+        mismatches.iter().any(|mismatch| {
+            mismatch.contains("MobCommand::SetSpawnPolicy")
+                && mismatch.contains("MobMachineInput::SetSpawnPolicy")
+        }),
+        "expected SetSpawnPolicy gate result sent to unrelated channel to be rejected, got {mismatches:#?}"
+    );
+}
+
+#[test]
+fn mob_runtime_catalog_command_gate_ratchet_rejects_shadowed_reply_tx_propagation() {
+    let dir = tempdir().expect("tempdir");
+    let runtime = dir.path().join("meerkat-mob/src/runtime");
+    fs::create_dir_all(&runtime).expect("create runtime dir");
+    fs::write(
+        runtime.join("actor.rs"),
+        r#"
+async fn handle_run_flow(&mut self) -> Result<RunId, MobError> {
+    self.apply_dsl_input(MobMachineInput::RunFlow, "run_flow")?;
+    Ok(RunId::new())
+}
+
+async fn handle_cancel_flow(&mut self) -> Result<(), MobError> {
+    self.apply_command_admission(MobMachineInput::CancelFlow, MobState::Running, "cancel_flow")?;
+    Ok(())
+}
+
+async fn handle_task_create(&mut self) -> Result<TaskId, MobError> {
+    self.prepare_command_admission(MobMachineInput::TaskCreate { task_id }, MobState::Running, "task_create")?;
+    Ok(TaskId::new())
+}
+
+async fn handle_force_cancel(&mut self) -> Result<(), MobError> {
+    self.preview_dsl_input(MobMachineInput::ForceCancel, "force_cancel")?;
+    self.apply_dsl_input(MobMachineInput::ForceCancel, "force_cancel")?;
+    Ok(())
+}
+
+async fn dispatch(&mut self, command: MobCommand, audit_tx: ReplyTx<Result<(), MobError>>) {
+    match command {
+        MobCommand::SetSpawnPolicy { policy, reply_tx } => {
+            let result = self
+                .apply_dsl_input(MobMachineInput::SetSpawnPolicy, "set_spawn_policy")
+                .map_err(|error| MobError::Internal(format!("{error}")));
+            if result.is_ok() {
+                self.spawn_policy.set(policy).await;
+            }
+            let reply_tx = audit_tx;
+            let _ = reply_tx.send(result);
+        }
+        _ => {}
+    }
+}
+"#,
+    )
+    .expect("write shadowed reply channel actor");
+
+    let mismatches = collect_mob_runtime_catalog_command_gate_mismatches(dir.path())
+        .expect("catalog command gate mismatches");
+    assert!(
+        mismatches.iter().any(|mismatch| {
+            mismatch.contains("MobCommand::SetSpawnPolicy")
+                && mismatch.contains("MobMachineInput::SetSpawnPolicy")
+        }),
+        "expected SetSpawnPolicy gate result sent through shadowed reply_tx to be rejected, got {mismatches:#?}"
+    );
+}
+
+#[test]
+fn mob_runtime_catalog_command_gate_ratchet_accepts_reply_tx_alias_propagation() {
+    let dir = tempdir().expect("tempdir");
+    let runtime = dir.path().join("meerkat-mob/src/runtime");
+    fs::create_dir_all(&runtime).expect("create runtime dir");
+    fs::write(
+        runtime.join("actor.rs"),
+        r#"
+async fn handle_run_flow(&mut self) -> Result<RunId, MobError> {
+    self.apply_dsl_input(MobMachineInput::RunFlow, "run_flow")?;
+    Ok(RunId::new())
+}
+
+async fn handle_cancel_flow(&mut self) -> Result<(), MobError> {
+    self.apply_command_admission(MobMachineInput::CancelFlow, MobState::Running, "cancel_flow")?;
+    Ok(())
+}
+
+async fn handle_task_create(&mut self) -> Result<TaskId, MobError> {
+    self.apply_dsl_input(MobMachineInput::TaskCreate { task_id }, "task_create")?;
+    Ok(TaskId::new())
+}
+
+async fn handle_force_cancel(&mut self) -> Result<(), MobError> {
+    self.apply_dsl_input(MobMachineInput::ForceCancel, "force_cancel")?;
+    Ok(())
+}
+
+async fn dispatch(&mut self, command: MobCommand) {
+    match command {
+        MobCommand::SetSpawnPolicy { policy, reply_tx } => {
+            let result = self
+                .apply_dsl_input(MobMachineInput::SetSpawnPolicy, "set_spawn_policy")
+                .map_err(MobError::from);
+            if result.is_ok() {
+                self.spawn_policy.set(policy).await;
+            }
+            let tx = reply_tx;
+            let _ = tx.send(result);
+        }
+        _ => {}
+    }
+}
+"#,
+    )
+    .expect("write reply_tx alias propagation actor");
+
+    let mismatches = collect_mob_runtime_catalog_command_gate_mismatches(dir.path())
+        .expect("catalog command gate mismatches");
+    assert!(
+        mismatches.is_empty(),
+        "expected SetSpawnPolicy reply sender alias propagation to be accepted, got {mismatches:#?}"
+    );
+}
+
+#[test]
+fn mob_runtime_catalog_command_gate_ratchet_rejects_deferred_side_effect_proofs() {
+    let dir = tempdir().expect("tempdir");
+    let runtime = dir.path().join("meerkat-mob/src/runtime");
+    fs::create_dir_all(&runtime).expect("create runtime dir");
+    fs::write(
+        runtime.join("actor.rs"),
+        r#"
+async fn handle_run_flow(&mut self) -> Result<RunId, MobError> {
+    self.apply_dsl_input(MobMachineInput::RunFlow, "run_flow")?;
+    Ok(RunId::new())
+}
+
+async fn handle_cancel_flow(&mut self) -> Result<(), MobError> {
+    self.apply_command_admission(MobMachineInput::CancelFlow, MobState::Running, "cancel_flow")?;
+    Ok(())
+}
+
+async fn handle_task_create(&mut self) -> Result<TaskId, MobError> {
+    self.prepare_command_admission(MobMachineInput::TaskCreate { task_id }, MobState::Running, "task_create")?;
+    Ok(TaskId::new())
+}
+
+async fn handle_force_cancel(&mut self) -> Result<(), MobError> {
+    self.preview_dsl_input(MobMachineInput::ForceCancel, "force_cancel")?;
+    self.apply_dsl_input(MobMachineInput::ForceCancel, "force_cancel")?;
+    Ok(())
+}
+
+async fn dispatch(&mut self, command: MobCommand) {
+    match command {
+        MobCommand::SetSpawnPolicy { policy, reply_tx } => {
+            let result = self
+                .apply_dsl_input(MobMachineInput::SetSpawnPolicy, "set_spawn_policy")
+                .map_err(|error| MobError::Internal(format!("{error}")));
+            let _deferred = async {
+                if result.is_ok() {
+                    self.spawn_policy.set(policy.clone()).await;
+                }
+            };
+            let _ = reply_tx.send(result);
+        }
+        _ => {}
+    }
+}
+"#,
+    )
+    .expect("write deferred side-effect proof actor");
+
+    let mismatches = collect_mob_runtime_catalog_command_gate_mismatches(dir.path())
+        .expect("catalog command gate mismatches");
+    assert!(
+        mismatches.iter().any(|mismatch| {
+            mismatch.contains("MobCommand::SetSpawnPolicy")
+                && mismatch.contains("MobMachineInput::SetSpawnPolicy")
+        }),
+        "expected SetSpawnPolicy side effect hidden in deferred async block to be rejected, got {mismatches:#?}"
+    );
+}
+
+#[test]
+fn mob_runtime_catalog_command_gate_ratchet_rejects_ungated_command_arm_side_effects() {
+    let dir = tempdir().expect("tempdir");
+    let runtime = dir.path().join("meerkat-mob/src/runtime");
+    fs::create_dir_all(&runtime).expect("create runtime dir");
+    fs::write(
+        runtime.join("actor.rs"),
+        r#"
+async fn handle_run_flow(&mut self) -> Result<RunId, MobError> {
+    self.apply_dsl_input(MobMachineInput::RunFlow, "run_flow")?;
+    Ok(RunId::new())
+}
+
+async fn handle_cancel_flow(&mut self) -> Result<(), MobError> {
+    self.apply_command_admission(MobMachineInput::CancelFlow, MobState::Running, "cancel_flow")?;
+    Ok(())
+}
+
+async fn handle_task_create(&mut self) -> Result<TaskId, MobError> {
+    self.prepare_command_admission(MobMachineInput::TaskCreate { task_id }, MobState::Running, "task_create")?;
+    Ok(TaskId::new())
+}
+
+async fn handle_force_cancel(&mut self) -> Result<(), MobError> {
+    self.preview_dsl_input(MobMachineInput::ForceCancel, "force_cancel")?;
+    self.apply_dsl_input(MobMachineInput::ForceCancel, "force_cancel")?;
+    Ok(())
+}
+
+async fn dispatch(&mut self, command: MobCommand) {
+    match command {
+        MobCommand::RunFlow { reply_tx, .. } => {
+            self.create_pending_run().await?;
+            let _ = reply_tx.send(Ok(RunId::new()));
+        }
+        MobCommand::SetSpawnPolicy { policy, reply_tx } => {
+            self.apply_dsl_input(MobMachineInput::SetSpawnPolicy, "set_spawn_policy")?;
+            self.spawn_policy.set(policy).await;
+            let _ = reply_tx.send(Ok(()));
+        }
+        _ => {}
+    }
+}
+"#,
+    )
+    .expect("write ungated command arm actor");
+
+    let mismatches = collect_mob_runtime_catalog_command_gate_mismatches(dir.path())
+        .expect("catalog command gate mismatches");
+    assert!(
+        mismatches.iter().any(|mismatch| {
+            mismatch.contains("MobCommand::RunFlow")
+                && mismatch.contains("MobMachineInput::RunFlow")
+        }),
+        "expected ungated RunFlow command-arm side effect to be rejected even when the handler gates, got {mismatches:#?}"
+    );
+}
+
+#[test]
+fn mob_runtime_catalog_command_gate_ratchet_rejects_secondary_dispatch_arm_masking_real_arm() {
+    let dir = tempdir().expect("tempdir");
+    let runtime = dir.path().join("meerkat-mob/src/runtime");
+    fs::create_dir_all(&runtime).expect("create runtime dir");
+    fs::write(
+        runtime.join("actor.rs"),
+        r#"
+async fn handle_run_flow(&mut self) -> Result<RunId, MobError> {
+    Ok(RunId::new())
+}
+
+async fn handle_cancel_flow(&mut self) -> Result<(), MobError> {
+    self.apply_command_admission(MobMachineInput::CancelFlow, MobState::Running, "cancel_flow")?;
+    Ok(())
+}
+
+async fn handle_task_create(&mut self) -> Result<TaskId, MobError> {
+    self.prepare_command_admission(MobMachineInput::TaskCreate { task_id }, MobState::Running, "task_create")?;
+    Ok(TaskId::new())
+}
+
+async fn handle_force_cancel(&mut self) -> Result<(), MobError> {
+    self.preview_dsl_input(MobMachineInput::ForceCancel, "force_cancel")?;
+    self.apply_dsl_input(MobMachineInput::ForceCancel, "force_cancel")?;
+    Ok(())
+}
+
+async fn run(&mut self, command: MobCommand) {
+    match command {
+        MobCommand::RunFlow { .. } => {
+            self.apply_dsl_input(MobMachineInput::RunFlow, "run_flow")?;
+        }
+        _ => {}
+    }
+}
+
+async fn dispatch(&mut self, command: MobCommand) {
+    match command {
+        MobCommand::RunFlow { reply_tx, .. } => {
+            let result = self.handle_run_flow().await;
+            let _ = reply_tx.send(result);
+        }
+        MobCommand::SetSpawnPolicy { policy, reply_tx } => {
+            self.apply_dsl_input(MobMachineInput::SetSpawnPolicy, "set_spawn_policy")?;
+            self.spawn_policy.set(policy).await;
+            let _ = reply_tx.send(Ok(()));
+        }
+        _ => {}
+    }
+}
+"#,
+    )
+    .expect("write secondary dispatch masking actor");
+
+    let mismatches = collect_mob_runtime_catalog_command_gate_mismatches(dir.path())
+        .expect("catalog command gate mismatches");
+    assert!(
+        mismatches.iter().any(|mismatch| {
+            mismatch.contains("MobCommand::RunFlow")
+                && mismatch.contains("MobMachineInput::RunFlow")
+        }),
+        "expected gated secondary RunFlow arm not to mask ungated real dispatch arm, got {mismatches:#?}"
+    );
+}
+
+#[test]
+fn mob_runtime_catalog_command_gate_ratchet_rejects_imported_variant_ungated_arms() {
+    let dir = tempdir().expect("tempdir");
+    let runtime = dir.path().join("meerkat-mob/src/runtime");
+    fs::create_dir_all(&runtime).expect("create runtime dir");
+    fs::write(
+        runtime.join("actor.rs"),
+        r#"
+use crate::mob_machine::MobCommand::*;
+
+async fn handle_run_flow(&mut self) -> Result<RunId, MobError> {
+    self.apply_dsl_input(MobMachineInput::RunFlow, "run_flow")?;
+    Ok(RunId::new())
+}
+
+async fn handle_cancel_flow(&mut self) -> Result<(), MobError> {
+    self.apply_command_admission(MobMachineInput::CancelFlow, MobState::Running, "cancel_flow")?;
+    Ok(())
+}
+
+async fn handle_task_create(&mut self) -> Result<TaskId, MobError> {
+    self.prepare_command_admission(MobMachineInput::TaskCreate { task_id }, MobState::Running, "task_create")?;
+    Ok(TaskId::new())
+}
+
+async fn handle_force_cancel(&mut self) -> Result<(), MobError> {
+    self.preview_dsl_input(MobMachineInput::ForceCancel, "force_cancel")?;
+    self.apply_dsl_input(MobMachineInput::ForceCancel, "force_cancel")?;
+    Ok(())
+}
+
+async fn dispatch(&mut self, command: MobCommand) {
+    match command {
+        RunFlow { reply_tx, .. } => {
+            self.create_pending_run().await?;
+            let _ = reply_tx.send(Ok(RunId::new()));
+        }
+        SetSpawnPolicy { policy, reply_tx } => {
+            self.apply_dsl_input(MobMachineInput::SetSpawnPolicy, "set_spawn_policy")?;
+            self.spawn_policy.set(policy).await;
+            let _ = reply_tx.send(Ok(()));
+        }
+        _ => {}
+    }
+}
+"#,
+    )
+    .expect("write imported variant actor");
+
+    let mismatches = collect_mob_runtime_catalog_command_gate_mismatches(dir.path())
+        .expect("catalog command gate mismatches");
+    assert!(
+        mismatches.iter().any(|mismatch| {
+            mismatch.contains("MobCommand::RunFlow")
+                && mismatch.contains("MobMachineInput::RunFlow")
+        }),
+        "expected imported RunFlow command arm to be checked independently, got {mismatches:#?}"
+    );
+}
+
+#[test]
+fn mob_runtime_catalog_command_gate_ratchet_rejects_or_pattern_variant_gate_aliasing() {
+    let dir = tempdir().expect("tempdir");
+    let runtime = dir.path().join("meerkat-mob/src/runtime");
+    fs::create_dir_all(&runtime).expect("create runtime dir");
+    fs::write(
+        runtime.join("actor.rs"),
+        r#"
+async fn handle_run_flow(&mut self) -> Result<RunId, MobError> {
+    self.apply_dsl_input(MobMachineInput::RunFlow, "run_flow")?;
+    Ok(RunId::new())
+}
+
+async fn handle_cancel_flow(&mut self) -> Result<(), MobError> {
+    self.apply_command_admission(MobMachineInput::CancelFlow, MobState::Running, "cancel_flow")?;
+    Ok(())
+}
+
+async fn handle_task_create(&mut self) -> Result<TaskId, MobError> {
+    self.prepare_command_admission(MobMachineInput::TaskCreate { task_id }, MobState::Running, "task_create")?;
+    Ok(TaskId::new())
+}
+
+async fn handle_force_cancel(&mut self) -> Result<(), MobError> {
+    self.preview_dsl_input(MobMachineInput::ForceCancel, "force_cancel")?;
+    self.apply_dsl_input(MobMachineInput::ForceCancel, "force_cancel")?;
+    Ok(())
+}
+
+async fn dispatch(&mut self, command: MobCommand) {
+    match command {
+        MobCommand::CancelFlow { .. } | MobCommand::ForceCancel { .. } => {
+            self.apply_dsl_input(MobMachineInput::CancelFlow, "cancel_flow")?;
+        }
+        MobCommand::SetSpawnPolicy { policy, reply_tx } => {
+            self.apply_dsl_input(MobMachineInput::SetSpawnPolicy, "set_spawn_policy")?;
+            self.spawn_policy.set(policy).await;
+            let _ = reply_tx.send(Ok(()));
+        }
+        _ => {}
+    }
+}
+"#,
+    )
+    .expect("write or-pattern command arm actor");
+
+    let mismatches = collect_mob_runtime_catalog_command_gate_mismatches(dir.path())
+        .expect("catalog command gate mismatches");
+    assert!(
+        mismatches.iter().any(|mismatch| {
+            mismatch.contains("MobCommand::ForceCancel")
+                && mismatch.contains("MobMachineInput::ForceCancel")
+        }),
+        "expected shared CancelFlow | ForceCancel arm not to borrow CancelFlow gate proof for ForceCancel, got {mismatches:#?}"
+    );
+}
+
+#[test]
+fn mob_runtime_catalog_command_gate_ratchet_rejects_block_local_variant_alias_arms() {
+    let dir = tempdir().expect("tempdir");
+    let runtime = dir.path().join("meerkat-mob/src/runtime");
+    fs::create_dir_all(&runtime).expect("create runtime dir");
+    fs::write(
+        runtime.join("actor.rs"),
+        r#"
+async fn handle_run_flow(&mut self) -> Result<RunId, MobError> {
+    self.apply_dsl_input(MobMachineInput::RunFlow, "run_flow")?;
+    Ok(RunId::new())
+}
+
+async fn handle_cancel_flow(&mut self) -> Result<(), MobError> {
+    self.apply_command_admission(MobMachineInput::CancelFlow, MobState::Running, "cancel_flow")?;
+    Ok(())
+}
+
+async fn handle_task_create(&mut self) -> Result<TaskId, MobError> {
+    self.prepare_command_admission(MobMachineInput::TaskCreate { task_id }, MobState::Running, "task_create")?;
+    Ok(TaskId::new())
+}
+
+async fn handle_force_cancel(&mut self) -> Result<(), MobError> {
+    self.preview_dsl_input(MobMachineInput::ForceCancel, "force_cancel")?;
+    self.apply_dsl_input(MobMachineInput::ForceCancel, "force_cancel")?;
+    Ok(())
+}
+
+async fn dispatch(&mut self, command: MobCommand) {
+    use crate::machines::mob_machine::MobCommand::RunFlow as Run;
+
+    match command {
+        Run { reply_tx, .. } => {
+            self.create_pending_run().await?;
+            let _ = reply_tx.send(Ok(RunId::new()));
+        }
+        MobCommand::SetSpawnPolicy { policy, reply_tx } => {
+            self.apply_dsl_input(MobMachineInput::SetSpawnPolicy, "set_spawn_policy")?;
+            self.spawn_policy.set(policy).await;
+            let _ = reply_tx.send(Ok(()));
+        }
+        _ => {}
+    }
+}
+"#,
+    )
+    .expect("write block-local variant alias actor");
+
+    let mismatches = collect_mob_runtime_catalog_command_gate_mismatches(dir.path())
+        .expect("catalog command gate mismatches");
+    assert!(
+        mismatches.iter().any(|mismatch| {
+            mismatch.contains("MobCommand::RunFlow")
+                && mismatch.contains("MobMachineInput::RunFlow")
+        }),
+        "expected block-local RunFlow variant alias arm to be checked independently, got {mismatches:#?}"
+    );
+}
+
+#[test]
+fn mob_runtime_catalog_command_gate_ratchet_rejects_variant_alias_chain_arms() {
+    let dir = tempdir().expect("tempdir");
+    let runtime = dir.path().join("meerkat-mob/src/runtime");
+    fs::create_dir_all(&runtime).expect("create runtime dir");
+    fs::write(
+        runtime.join("actor.rs"),
+        r#"
+use crate::machines::mob_machine::MobCommand::RunFlow as CanonicalRun;
+use CanonicalRun as Run;
+
+async fn handle_run_flow(&mut self) -> Result<RunId, MobError> {
+    self.apply_dsl_input(MobMachineInput::RunFlow, "run_flow")?;
+    Ok(RunId::new())
+}
+
+async fn handle_cancel_flow(&mut self) -> Result<(), MobError> {
+    self.apply_command_admission(MobMachineInput::CancelFlow, MobState::Running, "cancel_flow")?;
+    Ok(())
+}
+
+async fn handle_task_create(&mut self) -> Result<TaskId, MobError> {
+    self.prepare_command_admission(MobMachineInput::TaskCreate { task_id }, MobState::Running, "task_create")?;
+    Ok(TaskId::new())
+}
+
+async fn handle_force_cancel(&mut self) -> Result<(), MobError> {
+    self.preview_dsl_input(MobMachineInput::ForceCancel, "force_cancel")?;
+    self.apply_dsl_input(MobMachineInput::ForceCancel, "force_cancel")?;
+    Ok(())
+}
+
+async fn dispatch(&mut self, command: MobCommand) {
+    match command {
+        Run { reply_tx, .. } => {
+            self.create_pending_run().await?;
+            let _ = reply_tx.send(Ok(RunId::new()));
+        }
+        MobCommand::SetSpawnPolicy { policy, reply_tx } => {
+            self.apply_dsl_input(MobMachineInput::SetSpawnPolicy, "set_spawn_policy")?;
+            self.spawn_policy.set(policy).await;
+            let _ = reply_tx.send(Ok(()));
+        }
+        _ => {}
+    }
+}
+"#,
+    )
+    .expect("write variant alias chain actor");
+
+    let mismatches = collect_mob_runtime_catalog_command_gate_mismatches(dir.path())
+        .expect("catalog command gate mismatches");
+    assert!(
+        mismatches.iter().any(|mismatch| {
+            mismatch.contains("MobCommand::RunFlow")
+                && mismatch.contains("MobMachineInput::RunFlow")
+        }),
+        "expected RunFlow variant alias chain arm to be checked independently, got {mismatches:#?}"
+    );
+}
+
+#[test]
+fn mob_runtime_catalog_command_gate_ratchet_rejects_at_pattern_command_arms() {
+    let dir = tempdir().expect("tempdir");
+    let runtime = dir.path().join("meerkat-mob/src/runtime");
+    fs::create_dir_all(&runtime).expect("create runtime dir");
+    fs::write(
+        runtime.join("actor.rs"),
+        r#"
+async fn handle_run_flow(&mut self) -> Result<RunId, MobError> {
+    self.apply_dsl_input(MobMachineInput::RunFlow, "run_flow")?;
+    Ok(RunId::new())
+}
+
+async fn handle_cancel_flow(&mut self) -> Result<(), MobError> {
+    self.apply_command_admission(MobMachineInput::CancelFlow, MobState::Running, "cancel_flow")?;
+    Ok(())
+}
+
+async fn handle_task_create(&mut self) -> Result<TaskId, MobError> {
+    self.prepare_command_admission(MobMachineInput::TaskCreate { task_id }, MobState::Running, "task_create")?;
+    Ok(TaskId::new())
+}
+
+async fn handle_force_cancel(&mut self) -> Result<(), MobError> {
+    self.preview_dsl_input(MobMachineInput::ForceCancel, "force_cancel")?;
+    self.apply_dsl_input(MobMachineInput::ForceCancel, "force_cancel")?;
+    Ok(())
+}
+
+async fn dispatch(&mut self, command: MobCommand) {
+    match command {
+        run @ MobCommand::RunFlow { reply_tx, .. } => {
+            self.create_pending_run().await?;
+            let _ = reply_tx.send(Ok(RunId::new()));
+            let _ = run;
+        }
+        MobCommand::SetSpawnPolicy { policy, reply_tx } => {
+            self.apply_dsl_input(MobMachineInput::SetSpawnPolicy, "set_spawn_policy")?;
+            self.spawn_policy.set(policy).await;
+            let _ = reply_tx.send(Ok(()));
+        }
+        _ => {}
+    }
+}
+"#,
+    )
+    .expect("write at-pattern command arm actor");
+
+    let mismatches = collect_mob_runtime_catalog_command_gate_mismatches(dir.path())
+        .expect("catalog command gate mismatches");
+    assert!(
+        mismatches.iter().any(|mismatch| {
+            mismatch.contains("MobCommand::RunFlow")
+                && mismatch.contains("MobMachineInput::RunFlow")
+        }),
+        "expected RunFlow @ pattern arm to be checked independently, got {mismatches:#?}"
+    );
+}
+
+#[test]
+fn mob_runtime_catalog_command_gate_ratchet_rejects_guarded_command_arm_spoofing() {
+    let dir = tempdir().expect("tempdir");
+    let runtime = dir.path().join("meerkat-mob/src/runtime");
+    fs::create_dir_all(&runtime).expect("create runtime dir");
+    fs::write(
+        runtime.join("actor.rs"),
+        r#"
+async fn handle_run_flow(&mut self) -> Result<RunId, MobError> {
+    Ok(RunId::new())
+}
+
+async fn handle_cancel_flow(&mut self) -> Result<(), MobError> {
+    self.apply_command_admission(MobMachineInput::CancelFlow, MobState::Running, "cancel_flow")?;
+    Ok(())
+}
+
+async fn handle_task_create(&mut self) -> Result<TaskId, MobError> {
+    self.prepare_command_admission(MobMachineInput::TaskCreate { task_id }, MobState::Running, "task_create")?;
+    Ok(TaskId::new())
+}
+
+async fn handle_force_cancel(&mut self) -> Result<(), MobError> {
+    self.preview_dsl_input(MobMachineInput::ForceCancel, "force_cancel")?;
+    self.apply_dsl_input(MobMachineInput::ForceCancel, "force_cancel")?;
+    Ok(())
+}
+
+async fn dispatch(&mut self, command: MobCommand) {
+    match command {
+        MobCommand::RunFlow { .. } if false => {
+            self.apply_dsl_input(MobMachineInput::RunFlow, "run_flow")?;
+        }
+        MobCommand::SetSpawnPolicy { policy, reply_tx } => {
+            self.apply_dsl_input(MobMachineInput::SetSpawnPolicy, "set_spawn_policy")?;
+            self.spawn_policy.set(policy).await;
+            let _ = reply_tx.send(Ok(()));
+        }
+        _ => {}
+    }
+}
+"#,
+    )
+    .expect("write guarded command arm actor");
+
+    let mismatches = collect_mob_runtime_catalog_command_gate_mismatches(dir.path())
+        .expect("catalog command gate mismatches");
+    assert!(
+        mismatches.iter().any(|mismatch| {
+            mismatch.contains("MobCommand::RunFlow")
+                && mismatch.contains("MobMachineInput::RunFlow")
+        }),
+        "expected guarded/dead RunFlow arm not to mask ungated RunFlow handler, got {mismatches:#?}"
+    );
+}
+
+#[test]
+fn mob_runtime_catalog_command_gate_ratchet_rejects_shadowed_gate_input_alias() {
+    let dir = tempdir().expect("tempdir");
+    let runtime = dir.path().join("meerkat-mob/src/runtime");
+    fs::create_dir_all(&runtime).expect("create runtime dir");
+    fs::write(
+        runtime.join("actor.rs"),
+        r#"
+use crate::mob_machine::MobMachineInput::SetSpawnPolicy as Gate;
+
+async fn handle_run_flow(&mut self) -> Result<RunId, MobError> {
+    self.apply_dsl_input(MobMachineInput::RunFlow, "run_flow")?;
+    Ok(RunId::new())
+}
+
+async fn handle_cancel_flow(&mut self) -> Result<(), MobError> {
+    self.apply_command_admission(MobMachineInput::CancelFlow, MobState::Running, "cancel_flow")?;
+    Ok(())
+}
+
+async fn handle_task_create(&mut self) -> Result<TaskId, MobError> {
+    self.prepare_command_admission(MobMachineInput::TaskCreate { task_id }, MobState::Running, "task_create")?;
+    Ok(TaskId::new())
+}
+
+async fn handle_force_cancel(&mut self) -> Result<(), MobError> {
+    self.preview_dsl_input(MobMachineInput::ForceCancel, "force_cancel")?;
+    self.apply_dsl_input(MobMachineInput::ForceCancel, "force_cancel")?;
+    Ok(())
+}
+
+async fn dispatch(&mut self, command: MobCommand) {
+    match command {
+        MobCommand::SetSpawnPolicy { policy, reply_tx } => {
+            use crate::mob_machine::MobMachineInput::RunFlow as Gate;
+
+            let result = self.apply_dsl_input(Gate, "set_spawn_policy").map_err(Into::into);
+            if result.is_ok() {
+                self.spawn_policy.set(policy).await;
+            }
+            let _ = reply_tx.send(result);
+        }
+        _ => {}
+    }
+}
+"#,
+    )
+    .expect("write shadowed gate input alias actor");
+
+    let mismatches = collect_mob_runtime_catalog_command_gate_mismatches(dir.path())
+        .expect("catalog command gate mismatches");
+    assert!(
+        mismatches.iter().any(|mismatch| {
+            mismatch.contains("MobCommand::SetSpawnPolicy")
+                && mismatch.contains("MobMachineInput::SetSpawnPolicy")
+        }),
+        "expected block-local Gate alias shadowing to require SetSpawnPolicy authority, got {mismatches:#?}"
+    );
+}
+
+#[test]
+fn mob_runtime_catalog_command_gate_ratchet_rejects_nested_shadowed_gate_input_alias() {
+    let dir = tempdir().expect("tempdir");
+    let runtime = dir.path().join("meerkat-mob/src/runtime");
+    fs::create_dir_all(&runtime).expect("create runtime dir");
+    fs::write(
+        runtime.join("actor.rs"),
+        r#"
+use crate::mob_machine::MobMachineInput::SetSpawnPolicy as Gate;
+
+async fn handle_run_flow(&mut self) -> Result<RunId, MobError> {
+    self.apply_dsl_input(MobMachineInput::RunFlow, "run_flow")?;
+    Ok(RunId::new())
+}
+
+async fn handle_cancel_flow(&mut self) -> Result<(), MobError> {
+    self.apply_command_admission(MobMachineInput::CancelFlow, MobState::Running, "cancel_flow")?;
+    Ok(())
+}
+
+async fn handle_task_create(&mut self) -> Result<TaskId, MobError> {
+    self.prepare_command_admission(MobMachineInput::TaskCreate { task_id }, MobState::Running, "task_create")?;
+    Ok(TaskId::new())
+}
+
+async fn handle_force_cancel(&mut self) -> Result<(), MobError> {
+    self.preview_dsl_input(MobMachineInput::ForceCancel, "force_cancel")?;
+    self.apply_dsl_input(MobMachineInput::ForceCancel, "force_cancel")?;
+    Ok(())
+}
+
+async fn dispatch(&mut self, command: MobCommand) {
+    match command {
+        MobCommand::SetSpawnPolicy { policy, reply_tx } => {
+            let result = {
+                use crate::mob_machine::MobMachineInput::RunFlow as Gate;
+                self.apply_dsl_input(Gate, "set_spawn_policy").map_err(Into::into)
+            };
+            if result.is_ok() {
+                self.spawn_policy.set(policy).await;
+            }
+            let _ = reply_tx.send(result);
+        }
+        _ => {}
+    }
+}
+"#,
+    )
+    .expect("write nested shadowed gate input alias actor");
+
+    let mismatches = collect_mob_runtime_catalog_command_gate_mismatches(dir.path())
+        .expect("catalog command gate mismatches");
+    assert!(
+        mismatches.iter().any(|mismatch| {
+            mismatch.contains("MobCommand::SetSpawnPolicy")
+                && mismatch.contains("MobMachineInput::SetSpawnPolicy")
+        }),
+        "expected nested block-local Gate alias shadowing to require SetSpawnPolicy authority, got {mismatches:#?}"
+    );
+}
+
+#[test]
+fn mob_runtime_catalog_command_gate_ratchet_rejects_mutably_replaced_gate_input() {
+    let dir = tempdir().expect("tempdir");
+    let runtime = dir.path().join("meerkat-mob/src/runtime");
+    fs::create_dir_all(&runtime).expect("create runtime dir");
+    fs::write(
+        runtime.join("actor.rs"),
+        r#"
+async fn handle_run_flow(&mut self) -> Result<RunId, MobError> {
+    self.apply_dsl_input(MobMachineInput::RunFlow, "run_flow")?;
+    Ok(RunId::new())
+}
+
+async fn handle_cancel_flow(&mut self) -> Result<(), MobError> {
+    self.apply_command_admission(MobMachineInput::CancelFlow, MobState::Running, "cancel_flow")?;
+    Ok(())
+}
+
+async fn handle_task_create(&mut self) -> Result<TaskId, MobError> {
+    self.prepare_command_admission(MobMachineInput::TaskCreate { task_id }, MobState::Running, "task_create")?;
+    Ok(TaskId::new())
+}
+
+async fn handle_force_cancel(&mut self) -> Result<(), MobError> {
+    self.preview_dsl_input(MobMachineInput::ForceCancel, "force_cancel")?;
+    self.apply_dsl_input(MobMachineInput::ForceCancel, "force_cancel")?;
+    Ok(())
+}
+
+async fn dispatch(&mut self, command: MobCommand) {
+    match command {
+        MobCommand::SetSpawnPolicy { policy, reply_tx } => {
+            let mut input = MobMachineInput::SetSpawnPolicy;
+            std::mem::replace(&mut input, MobMachineInput::RunFlow);
+            let result = self.apply_dsl_input(input, "set_spawn_policy").map_err(Into::into);
+            if result.is_ok() {
+                self.spawn_policy.set(policy).await;
+            }
+            let _ = reply_tx.send(result);
+        }
+        _ => {}
+    }
+}
+"#,
+    )
+    .expect("write mutably replaced gate input actor");
+
+    let mismatches = collect_mob_runtime_catalog_command_gate_mismatches(dir.path())
+        .expect("catalog command gate mismatches");
+    assert!(
+        mismatches.iter().any(|mismatch| {
+            mismatch.contains("MobCommand::SetSpawnPolicy")
+                && mismatch.contains("MobMachineInput::SetSpawnPolicy")
+        }),
+        "expected mutable input replacement to invalidate SetSpawnPolicy gate proof, got {mismatches:#?}"
+    );
+}
+
+#[test]
+fn mob_runtime_catalog_command_gate_ratchet_rejects_autoref_mutated_gate_input() {
+    let dir = tempdir().expect("tempdir");
+    let runtime = dir.path().join("meerkat-mob/src/runtime");
+    fs::create_dir_all(&runtime).expect("create runtime dir");
+    fs::write(
+        runtime.join("actor.rs"),
+        r#"
+async fn handle_run_flow(&mut self) -> Result<RunId, MobError> {
+    self.apply_dsl_input(MobMachineInput::RunFlow, "run_flow")?;
+    Ok(RunId::new())
+}
+
+async fn handle_cancel_flow(&mut self) -> Result<(), MobError> {
+    self.apply_command_admission(MobMachineInput::CancelFlow, MobState::Running, "cancel_flow")?;
+    Ok(())
+}
+
+async fn handle_task_create(&mut self) -> Result<TaskId, MobError> {
+    self.prepare_command_admission(MobMachineInput::TaskCreate { task_id }, MobState::Running, "task_create")?;
+    Ok(TaskId::new())
+}
+
+async fn handle_force_cancel(&mut self) -> Result<(), MobError> {
+    self.preview_dsl_input(MobMachineInput::ForceCancel, "force_cancel")?;
+    self.apply_dsl_input(MobMachineInput::ForceCancel, "force_cancel")?;
+    Ok(())
+}
+
+async fn dispatch(&mut self, command: MobCommand) {
+    match command {
+        MobCommand::SetSpawnPolicy { policy, reply_tx } => {
+            let mut input = MobMachineInput::SetSpawnPolicy;
+            input.clone_from(&MobMachineInput::RunFlow);
+            let result = self.apply_dsl_input(input, "set_spawn_policy").map_err(Into::into);
+            if result.is_ok() {
+                self.spawn_policy.set(policy).await;
+            }
+            let _ = reply_tx.send(result);
+        }
+        _ => {}
+    }
+}
+"#,
+    )
+    .expect("write autoref-mutated gate input actor");
+
+    let mismatches = collect_mob_runtime_catalog_command_gate_mismatches(dir.path())
+        .expect("catalog command gate mismatches");
+    assert!(
+        mismatches.iter().any(|mismatch| {
+            mismatch.contains("MobCommand::SetSpawnPolicy")
+                && mismatch.contains("MobMachineInput::SetSpawnPolicy")
+        }),
+        "expected autoref input mutation to invalidate SetSpawnPolicy gate proof, got {mismatches:#?}"
+    );
+}
+
+#[test]
+fn mob_runtime_catalog_command_gate_ratchet_rejects_nested_block_autoref_mutated_gate_input() {
+    let dir = tempdir().expect("tempdir");
+    let runtime = dir.path().join("meerkat-mob/src/runtime");
+    fs::create_dir_all(&runtime).expect("create runtime dir");
+    fs::write(
+        runtime.join("actor.rs"),
+        r#"
+async fn handle_run_flow(&mut self) -> Result<RunId, MobError> {
+    self.apply_dsl_input(MobMachineInput::RunFlow, "run_flow")?;
+    Ok(RunId::new())
+}
+
+async fn handle_cancel_flow(&mut self) -> Result<(), MobError> {
+    self.apply_command_admission(MobMachineInput::CancelFlow, MobState::Running, "cancel_flow")?;
+    Ok(())
+}
+
+async fn handle_task_create(&mut self) -> Result<TaskId, MobError> {
+    self.prepare_command_admission(MobMachineInput::TaskCreate { task_id }, MobState::Running, "task_create")?;
+    Ok(TaskId::new())
+}
+
+async fn handle_force_cancel(&mut self) -> Result<(), MobError> {
+    self.preview_dsl_input(MobMachineInput::ForceCancel, "force_cancel")?;
+    self.apply_dsl_input(MobMachineInput::ForceCancel, "force_cancel")?;
+    Ok(())
+}
+
+async fn dispatch(&mut self, command: MobCommand) {
+    match command {
+        MobCommand::SetSpawnPolicy { policy, reply_tx } => {
+            let mut input = MobMachineInput::SetSpawnPolicy;
+            {
+                input.clone_from(&MobMachineInput::RunFlow);
+            }
+            let result = self.apply_dsl_input(input, "set_spawn_policy").map_err(Into::into);
+            if result.is_ok() {
+                self.spawn_policy.set(policy).await;
+            }
+            let _ = reply_tx.send(result);
+        }
+        _ => {}
+    }
+}
+"#,
+    )
+    .expect("write nested-block autoref-mutated gate input actor");
+
+    let mismatches = collect_mob_runtime_catalog_command_gate_mismatches(dir.path())
+        .expect("catalog command gate mismatches");
+    assert!(
+        mismatches.iter().any(|mismatch| {
+            mismatch.contains("MobCommand::SetSpawnPolicy")
+                && mismatch.contains("MobMachineInput::SetSpawnPolicy")
+        }),
+        "expected nested block autoref input mutation to invalidate SetSpawnPolicy gate proof, got {mismatches:#?}"
+    );
+}
+
+#[test]
+fn mob_runtime_catalog_command_gate_ratchet_rejects_loop_autoref_mutated_gate_input() {
+    let dir = tempdir().expect("tempdir");
+    let runtime = dir.path().join("meerkat-mob/src/runtime");
+    fs::create_dir_all(&runtime).expect("create runtime dir");
+    fs::write(
+        runtime.join("actor.rs"),
+        r#"
+async fn handle_run_flow(&mut self) -> Result<RunId, MobError> {
+    self.apply_dsl_input(MobMachineInput::RunFlow, "run_flow")?;
+    Ok(RunId::new())
+}
+
+async fn handle_cancel_flow(&mut self) -> Result<(), MobError> {
+    self.apply_command_admission(MobMachineInput::CancelFlow, MobState::Running, "cancel_flow")?;
+    Ok(())
+}
+
+async fn handle_task_create(&mut self) -> Result<TaskId, MobError> {
+    self.prepare_command_admission(MobMachineInput::TaskCreate { task_id }, MobState::Running, "task_create")?;
+    Ok(TaskId::new())
+}
+
+async fn handle_force_cancel(&mut self) -> Result<(), MobError> {
+    self.preview_dsl_input(MobMachineInput::ForceCancel, "force_cancel")?;
+    self.apply_dsl_input(MobMachineInput::ForceCancel, "force_cancel")?;
+    Ok(())
+}
+
+async fn dispatch(&mut self, command: MobCommand, should_replace: bool) {
+    match command {
+        MobCommand::SetSpawnPolicy { policy, reply_tx } => {
+            let mut input = MobMachineInput::SetSpawnPolicy;
+            while should_replace {
+                input.clone_from(&MobMachineInput::RunFlow);
+                break;
+            }
+            let result = self.apply_dsl_input(input, "set_spawn_policy").map_err(Into::into);
+            if result.is_ok() {
+                self.spawn_policy.set(policy).await;
+            }
+            let _ = reply_tx.send(result);
+        }
+        _ => {}
+    }
+}
+"#,
+    )
+    .expect("write loop autoref-mutated gate input actor");
+
+    let mismatches = collect_mob_runtime_catalog_command_gate_mismatches(dir.path())
+        .expect("catalog command gate mismatches");
+    assert!(
+        mismatches.iter().any(|mismatch| {
+            mismatch.contains("MobCommand::SetSpawnPolicy")
+                && mismatch.contains("MobMachineInput::SetSpawnPolicy")
+        }),
+        "expected loop autoref input mutation to invalidate SetSpawnPolicy gate proof, got {mismatches:#?}"
+    );
+}
+
+#[test]
+fn mob_runtime_catalog_command_gate_ratchet_rejects_mutably_replaced_gate_result() {
+    let dir = tempdir().expect("tempdir");
+    let runtime = dir.path().join("meerkat-mob/src/runtime");
+    fs::create_dir_all(&runtime).expect("create runtime dir");
+    fs::write(
+        runtime.join("actor.rs"),
+        r#"
+async fn handle_run_flow(&mut self) -> Result<RunId, MobError> {
+    self.apply_dsl_input(MobMachineInput::RunFlow, "run_flow")?;
+    Ok(RunId::new())
+}
+
+async fn handle_cancel_flow(&mut self) -> Result<(), MobError> {
+    self.apply_command_admission(MobMachineInput::CancelFlow, MobState::Running, "cancel_flow")?;
+    Ok(())
+}
+
+async fn handle_task_create(&mut self) -> Result<TaskId, MobError> {
+    self.prepare_command_admission(MobMachineInput::TaskCreate { task_id }, MobState::Running, "task_create")?;
+    Ok(TaskId::new())
+}
+
+async fn handle_force_cancel(&mut self) -> Result<(), MobError> {
+    self.preview_dsl_input(MobMachineInput::ForceCancel, "force_cancel")?;
+    self.apply_dsl_input(MobMachineInput::ForceCancel, "force_cancel")?;
+    Ok(())
+}
+
+async fn dispatch(&mut self, command: MobCommand) {
+    match command {
+        MobCommand::SetSpawnPolicy { policy, reply_tx } => {
+            let mut result = self
+                .apply_dsl_input(MobMachineInput::SetSpawnPolicy, "set_spawn_policy")
+                .map_err(Into::into);
+            std::mem::replace(&mut result, Ok(()));
+            if result.is_ok() {
+                self.spawn_policy.set(policy).await;
+            }
+            let _ = reply_tx.send(result);
+        }
+        _ => {}
+    }
+}
+"#,
+    )
+    .expect("write mutably replaced gate result actor");
+
+    let mismatches = collect_mob_runtime_catalog_command_gate_mismatches(dir.path())
+        .expect("catalog command gate mismatches");
+    assert!(
+        mismatches.iter().any(|mismatch| {
+            mismatch.contains("MobCommand::SetSpawnPolicy")
+                && mismatch.contains("MobMachineInput::SetSpawnPolicy")
+        }),
+        "expected mutable result replacement to invalidate SetSpawnPolicy gate proof, got {mismatches:#?}"
+    );
+}
+
+#[test]
+fn mob_runtime_catalog_command_gate_ratchet_rejects_mutably_replaced_reply_tx() {
+    let dir = tempdir().expect("tempdir");
+    let runtime = dir.path().join("meerkat-mob/src/runtime");
+    fs::create_dir_all(&runtime).expect("create runtime dir");
+    fs::write(
+        runtime.join("actor.rs"),
+        r#"
+async fn handle_run_flow(&mut self) -> Result<RunId, MobError> {
+    self.apply_dsl_input(MobMachineInput::RunFlow, "run_flow")?;
+    Ok(RunId::new())
+}
+
+async fn handle_cancel_flow(&mut self) -> Result<(), MobError> {
+    self.apply_command_admission(MobMachineInput::CancelFlow, MobState::Running, "cancel_flow")?;
+    Ok(())
+}
+
+async fn handle_task_create(&mut self) -> Result<TaskId, MobError> {
+    self.prepare_command_admission(MobMachineInput::TaskCreate { task_id }, MobState::Running, "task_create")?;
+    Ok(TaskId::new())
+}
+
+async fn handle_force_cancel(&mut self) -> Result<(), MobError> {
+    self.preview_dsl_input(MobMachineInput::ForceCancel, "force_cancel")?;
+    self.apply_dsl_input(MobMachineInput::ForceCancel, "force_cancel")?;
+    Ok(())
+}
+
+async fn dispatch(
+    &mut self,
+    command: MobCommand,
+    audit_tx: ReplyTx<Result<(), MobError>>,
+) {
+    match command {
+        MobCommand::SetSpawnPolicy { policy, reply_tx } => {
+            let result = self
+                .apply_dsl_input(MobMachineInput::SetSpawnPolicy, "set_spawn_policy")
+                .map_err(Into::into);
+            if result.is_ok() {
+                self.spawn_policy.set(policy).await;
+            }
+            std::mem::replace(&mut reply_tx, audit_tx);
+            let _ = reply_tx.send(result);
+        }
+        _ => {}
+    }
+}
+"#,
+    )
+    .expect("write mutably replaced reply_tx actor");
+
+    let mismatches = collect_mob_runtime_catalog_command_gate_mismatches(dir.path())
+        .expect("catalog command gate mismatches");
+    assert!(
+        mismatches.iter().any(|mismatch| {
+            mismatch.contains("MobCommand::SetSpawnPolicy")
+                && mismatch.contains("MobMachineInput::SetSpawnPolicy")
+        }),
+        "expected mutable reply_tx replacement to invalidate propagated reply proof, got {mismatches:#?}"
+    );
+}
+
+#[test]
+fn mob_runtime_catalog_command_gate_ratchet_rejects_fail_open_gate_result_wrappers() {
+    let dir = tempdir().expect("tempdir");
+    let runtime = dir.path().join("meerkat-mob/src/runtime");
+    fs::create_dir_all(&runtime).expect("create runtime dir");
+    fs::write(
+        runtime.join("actor.rs"),
+        r#"
+async fn handle_run_flow(&mut self) -> Result<RunId, MobError> {
+    self.apply_dsl_input(MobMachineInput::RunFlow, "run_flow")?;
+    Ok(RunId::new())
+}
+
+async fn handle_cancel_flow(&mut self) -> Result<(), MobError> {
+    self.apply_command_admission(MobMachineInput::CancelFlow, MobState::Running, "cancel_flow")?;
+    Ok(())
+}
+
+async fn handle_task_create(&mut self) -> Result<TaskId, MobError> {
+    self.prepare_command_admission(MobMachineInput::TaskCreate { task_id }, MobState::Running, "task_create")?;
+    Ok(TaskId::new())
+}
+
+async fn handle_force_cancel(&mut self) -> Result<(), MobError> {
+    self.preview_dsl_input(MobMachineInput::ForceCancel, "force_cancel")?;
+    self.apply_dsl_input(MobMachineInput::ForceCancel, "force_cancel")?;
+    Ok(())
+}
+
+async fn dispatch(&mut self, command: MobCommand) {
+    match command {
+        MobCommand::SetSpawnPolicy { policy, reply_tx } => {
+            let result = self
+                .apply_dsl_input(MobMachineInput::SetSpawnPolicy, "set_spawn_policy")
+                .or_else(|_| Ok(()));
+            if result.is_ok() {
+                self.spawn_policy.set(policy).await;
+            }
+            let _ = reply_tx.send(result);
+        }
+        _ => {}
+    }
+}
+"#,
+    )
+    .expect("write fail-open gate result wrapper actor");
+
+    let mismatches = collect_mob_runtime_catalog_command_gate_mismatches(dir.path())
+        .expect("catalog command gate mismatches");
+    assert!(
+        mismatches.iter().any(|mismatch| {
+            mismatch.contains("MobCommand::SetSpawnPolicy")
+                && mismatch.contains("MobMachineInput::SetSpawnPolicy")
+        }),
+        "expected fail-open result wrapper not to count as a fail-closed gate, got {mismatches:#?}"
+    );
+}
+
+#[test]
+fn mob_runtime_catalog_command_gate_ratchet_rejects_fail_open_try_gate_wrappers() {
+    let dir = tempdir().expect("tempdir");
+    let runtime = dir.path().join("meerkat-mob/src/runtime");
+    fs::create_dir_all(&runtime).expect("create runtime dir");
+    fs::write(
+        runtime.join("actor.rs"),
+        r#"
+async fn handle_run_flow(&mut self) -> Result<RunId, MobError> {
+    self.apply_dsl_input(MobMachineInput::RunFlow, "run_flow")?;
+    Ok(RunId::new())
+}
+
+async fn handle_cancel_flow(&mut self) -> Result<(), MobError> {
+    self.apply_command_admission(MobMachineInput::CancelFlow, MobState::Running, "cancel_flow")?;
+    Ok(())
+}
+
+async fn handle_task_create(&mut self) -> Result<TaskId, MobError> {
+    self.prepare_command_admission(MobMachineInput::TaskCreate { task_id }, MobState::Running, "task_create")?;
+    Ok(TaskId::new())
+}
+
+async fn handle_force_cancel(&mut self) -> Result<(), MobError> {
+    self.preview_dsl_input(MobMachineInput::ForceCancel, "force_cancel")?;
+    self.apply_dsl_input(MobMachineInput::ForceCancel, "force_cancel")?;
+    Ok(())
+}
+
+async fn dispatch(&mut self, command: MobCommand) -> Result<(), MobError> {
+    match command {
+        MobCommand::SetSpawnPolicy { policy, reply_tx } => {
+            self.apply_dsl_input(MobMachineInput::SetSpawnPolicy, "set_spawn_policy")
+                .or_else(|_| Ok(()))?;
+            self.spawn_policy.set(policy).await;
+            let _ = reply_tx.send(Ok(()));
+        }
+        _ => {}
+    }
+    Ok(())
+}
+"#,
+    )
+    .expect("write fail-open try gate wrapper actor");
+
+    let mismatches = collect_mob_runtime_catalog_command_gate_mismatches(dir.path())
+        .expect("catalog command gate mismatches");
+    assert!(
+        mismatches.iter().any(|mismatch| {
+            mismatch.contains("MobCommand::SetSpawnPolicy")
+                && mismatch.contains("MobMachineInput::SetSpawnPolicy")
+        }),
+        "expected fail-open try wrapper not to count as a fail-closed gate, got {mismatches:#?}"
+    );
+}
+
+#[test]
+fn mob_runtime_catalog_command_gate_ratchet_rejects_ufcs_fail_open_try_gate_wrappers() {
+    let dir = tempdir().expect("tempdir");
+    let runtime = dir.path().join("meerkat-mob/src/runtime");
+    fs::create_dir_all(&runtime).expect("create runtime dir");
+    fs::write(
+        runtime.join("actor.rs"),
+        r#"
+async fn handle_run_flow(&mut self) -> Result<RunId, MobError> {
+    self.apply_dsl_input(MobMachineInput::RunFlow, "run_flow")?;
+    Ok(RunId::new())
+}
+
+async fn handle_cancel_flow(&mut self) -> Result<(), MobError> {
+    self.apply_command_admission(MobMachineInput::CancelFlow, MobState::Running, "cancel_flow")?;
+    Ok(())
+}
+
+async fn handle_task_create(&mut self) -> Result<TaskId, MobError> {
+    self.prepare_command_admission(MobMachineInput::TaskCreate { task_id }, MobState::Running, "task_create")?;
+    Ok(TaskId::new())
+}
+
+async fn handle_force_cancel(&mut self) -> Result<(), MobError> {
+    self.preview_dsl_input(MobMachineInput::ForceCancel, "force_cancel")?;
+    self.apply_dsl_input(MobMachineInput::ForceCancel, "force_cancel")?;
+    Ok(())
+}
+
+async fn dispatch(&mut self, command: MobCommand) -> Result<(), MobError> {
+    match command {
+        MobCommand::SetSpawnPolicy { policy, reply_tx } => {
+            Result::or_else(
+                self.apply_dsl_input(MobMachineInput::SetSpawnPolicy, "set_spawn_policy"),
+                |_| Ok(()),
+            )?;
+            self.spawn_policy.set(policy).await;
+            let _ = reply_tx.send(Ok(()));
+        }
+        _ => {}
+    }
+    Ok(())
+}
+"#,
+    )
+    .expect("write UFCS fail-open try gate wrapper actor");
+
+    let mismatches = collect_mob_runtime_catalog_command_gate_mismatches(dir.path())
+        .expect("catalog command gate mismatches");
+    assert!(
+        mismatches.iter().any(|mismatch| {
+            mismatch.contains("MobCommand::SetSpawnPolicy")
+                && mismatch.contains("MobMachineInput::SetSpawnPolicy")
+        }),
+        "expected UFCS fail-open try wrapper not to count as a fail-closed gate, got {mismatches:#?}"
+    );
+}
+
+#[test]
+fn mob_runtime_catalog_command_gate_ratchet_rejects_catch_all_side_effect_arms() {
+    let dir = tempdir().expect("tempdir");
+    let runtime = dir.path().join("meerkat-mob/src/runtime");
+    fs::create_dir_all(&runtime).expect("create runtime dir");
+    fs::write(
+        runtime.join("actor.rs"),
+        r#"
+async fn handle_run_flow(&mut self) -> Result<RunId, MobError> {
+    self.apply_dsl_input(MobMachineInput::RunFlow, "run_flow")?;
+    Ok(RunId::new())
+}
+
+async fn handle_cancel_flow(&mut self) -> Result<(), MobError> {
+    self.apply_command_admission(MobMachineInput::CancelFlow, MobState::Running, "cancel_flow")?;
+    Ok(())
+}
+
+async fn handle_task_create(&mut self) -> Result<TaskId, MobError> {
+    self.prepare_command_admission(MobMachineInput::TaskCreate { task_id }, MobState::Running, "task_create")?;
+    Ok(TaskId::new())
+}
+
+async fn handle_force_cancel(&mut self) -> Result<(), MobError> {
+    self.preview_dsl_input(MobMachineInput::ForceCancel, "force_cancel")?;
+    self.apply_dsl_input(MobMachineInput::ForceCancel, "force_cancel")?;
+    Ok(())
+}
+
+async fn handle_set_spawn_policy(&mut self) -> Result<(), MobError> {
+    self.apply_dsl_input(MobMachineInput::SetSpawnPolicy, "set_spawn_policy")?;
+    Ok(())
+}
+
+async fn dispatch(&mut self, command: MobCommand) {
+    match command {
+        other => {
+            self.create_pending_run().await?;
+            let _ = other;
+        }
+    }
+}
+"#,
+    )
+    .expect("write catch-all side-effect actor");
+
+    let mismatches = collect_mob_runtime_catalog_command_gate_mismatches(dir.path())
+        .expect("catalog command gate mismatches");
+    assert!(
+        mismatches.iter().any(|mismatch| {
+            mismatch.contains("MobCommand::RunFlow")
+                && mismatch.contains("MobMachineInput::RunFlow")
+        }),
+        "expected catch-all command side effect not to be hidden by handler fallback, got {mismatches:#?}"
+    );
+}
+
+#[test]
+fn mob_runtime_catalog_command_gate_ratchet_rejects_fake_command_and_input_owners() {
+    let dir = tempdir().expect("tempdir");
+    let runtime = dir.path().join("meerkat-mob/src/runtime");
+    fs::create_dir_all(&runtime).expect("create runtime dir");
+    fs::write(
+        runtime.join("actor.rs"),
+        r#"
+mod fake {
+    enum MobCommand {
+        SetSpawnPolicy { policy: SpawnPolicy, reply_tx: ReplyTx<Result<(), MobError>> },
+    }
+
+    enum MobMachineInput {
+        SetSpawnPolicy,
+    }
+}
+
+async fn handle_run_flow(&mut self) -> Result<RunId, MobError> {
+    self.apply_dsl_input(MobMachineInput::RunFlow, "run_flow")?;
+    Ok(RunId::new())
+}
+
+async fn handle_cancel_flow(&mut self) -> Result<(), MobError> {
+    self.apply_command_admission(MobMachineInput::CancelFlow, MobState::Running, "cancel_flow")?;
+    Ok(())
+}
+
+async fn handle_task_create(&mut self) -> Result<TaskId, MobError> {
+    self.prepare_command_admission(MobMachineInput::TaskCreate { task_id }, MobState::Running, "task_create")?;
+    Ok(TaskId::new())
+}
+
+async fn handle_force_cancel(&mut self) -> Result<(), MobError> {
+    self.preview_dsl_input(MobMachineInput::ForceCancel, "force_cancel")?;
+    self.apply_dsl_input(MobMachineInput::ForceCancel, "force_cancel")?;
+    Ok(())
+}
+
+async fn dispatch(&mut self, command: fake::MobCommand) {
+    match command {
+        fake::MobCommand::SetSpawnPolicy { policy, reply_tx } => {
+            let result = self
+                .apply_dsl_input(fake::MobMachineInput::SetSpawnPolicy, "set_spawn_policy")
+                .map_err(Into::into);
+            if result.is_ok() {
+                self.spawn_policy.set(policy).await;
+            }
+            let _ = reply_tx.send(result);
+        }
+    }
+}
+"#,
+    )
+    .expect("write fake command and input owners actor");
+
+    let mismatches = collect_mob_runtime_catalog_command_gate_mismatches(dir.path())
+        .expect("catalog command gate mismatches");
+    assert!(
+        mismatches.iter().any(|mismatch| {
+            mismatch.contains("MobCommand::SetSpawnPolicy")
+                && mismatch.contains("MobMachineInput::SetSpawnPolicy")
+        }),
+        "expected fake MobCommand/MobMachineInput owners not to satisfy canonical command gate, got {mismatches:#?}"
+    );
+}
+
+#[test]
+fn mob_runtime_catalog_command_gate_ratchet_rejects_fake_mob_machine_path_owners() {
+    let dir = tempdir().expect("tempdir");
+    let runtime = dir.path().join("meerkat-mob/src/runtime");
+    fs::create_dir_all(&runtime).expect("create runtime dir");
+    fs::write(
+        runtime.join("actor.rs"),
+        r#"
+mod fake {
+    pub mod mob_machine {
+        pub enum MobCommand {
+            SetSpawnPolicy { policy: SpawnPolicy, reply_tx: ReplyTx<Result<(), MobError>> },
+        }
+
+        pub enum MobMachineInput {
+            SetSpawnPolicy,
+        }
+    }
+}
+
+async fn handle_run_flow(&mut self) -> Result<RunId, MobError> {
+    self.apply_dsl_input(MobMachineInput::RunFlow, "run_flow")?;
+    Ok(RunId::new())
+}
+
+async fn handle_cancel_flow(&mut self) -> Result<(), MobError> {
+    self.apply_command_admission(MobMachineInput::CancelFlow, MobState::Running, "cancel_flow")?;
+    Ok(())
+}
+
+async fn handle_task_create(&mut self) -> Result<TaskId, MobError> {
+    self.prepare_command_admission(MobMachineInput::TaskCreate { task_id }, MobState::Running, "task_create")?;
+    Ok(TaskId::new())
+}
+
+async fn handle_force_cancel(&mut self) -> Result<(), MobError> {
+    self.preview_dsl_input(MobMachineInput::ForceCancel, "force_cancel")?;
+    self.apply_dsl_input(MobMachineInput::ForceCancel, "force_cancel")?;
+    Ok(())
+}
+
+async fn dispatch(&mut self, command: fake::mob_machine::MobCommand) {
+    match command {
+        fake::mob_machine::MobCommand::SetSpawnPolicy { policy, reply_tx } => {
+            let result = self
+                .apply_dsl_input(fake::mob_machine::MobMachineInput::SetSpawnPolicy, "set_spawn_policy")
+                .map_err(Into::into);
+            if result.is_ok() {
+                self.spawn_policy.set(policy).await;
+            }
+            let _ = reply_tx.send(result);
+        }
+    }
+}
+"#,
+    )
+    .expect("write fake mob_machine command and input owners actor");
+
+    let mismatches = collect_mob_runtime_catalog_command_gate_mismatches(dir.path())
+        .expect("catalog command gate mismatches");
+    assert!(
+        mismatches.iter().any(|mismatch| {
+            mismatch.contains("MobCommand::SetSpawnPolicy")
+                && mismatch.contains("MobMachineInput::SetSpawnPolicy")
+        }),
+        "expected fake mob_machine owner path not to satisfy canonical command gate, got {mismatches:#?}"
+    );
+}
+
+#[test]
+fn mob_runtime_catalog_command_gate_ratchet_rejects_crate_qualified_fake_mob_machine_path_owners() {
+    let dir = tempdir().expect("tempdir");
+    let runtime = dir.path().join("meerkat-mob/src/runtime");
+    fs::create_dir_all(&runtime).expect("create runtime dir");
+    fs::write(
+        runtime.join("actor.rs"),
+        r#"
+mod fake {
+    pub mod mob_machine {
+        pub enum MobCommand {
+            SetSpawnPolicy { policy: SpawnPolicy, reply_tx: ReplyTx<Result<(), MobError>> },
+        }
+
+        pub enum MobMachineInput {
+            SetSpawnPolicy,
+        }
+    }
+}
+
+async fn handle_run_flow(&mut self) -> Result<RunId, MobError> {
+    self.apply_dsl_input(MobMachineInput::RunFlow, "run_flow")?;
+    Ok(RunId::new())
+}
+
+async fn handle_cancel_flow(&mut self) -> Result<(), MobError> {
+    self.apply_command_admission(MobMachineInput::CancelFlow, MobState::Running, "cancel_flow")?;
+    Ok(())
+}
+
+async fn handle_task_create(&mut self) -> Result<TaskId, MobError> {
+    self.prepare_command_admission(MobMachineInput::TaskCreate { task_id }, MobState::Running, "task_create")?;
+    Ok(TaskId::new())
+}
+
+async fn handle_force_cancel(&mut self) -> Result<(), MobError> {
+    self.preview_dsl_input(MobMachineInput::ForceCancel, "force_cancel")?;
+    self.apply_dsl_input(MobMachineInput::ForceCancel, "force_cancel")?;
+    Ok(())
+}
+
+async fn dispatch(&mut self, command: crate::fake::mob_machine::MobCommand) {
+    match command {
+        crate::fake::mob_machine::MobCommand::SetSpawnPolicy { policy, reply_tx } => {
+            let result = self
+                .apply_dsl_input(crate::fake::mob_machine::MobMachineInput::SetSpawnPolicy, "set_spawn_policy")
+                .map_err(Into::into);
+            if result.is_ok() {
+                self.spawn_policy.set(policy).await;
+            }
+            let _ = reply_tx.send(result);
+        }
+    }
+}
+"#,
+    )
+    .expect("write crate-qualified fake mob_machine command and input owners actor");
+
+    let mismatches = collect_mob_runtime_catalog_command_gate_mismatches(dir.path())
+        .expect("catalog command gate mismatches");
+    assert!(
+        mismatches.iter().any(|mismatch| {
+            mismatch.contains("MobCommand::SetSpawnPolicy")
+                && mismatch.contains("MobMachineInput::SetSpawnPolicy")
+        }),
+        "expected crate-qualified fake mob_machine owner path not to satisfy canonical command gate, got {mismatches:#?}"
+    );
+}
+
+#[test]
+fn mob_runtime_catalog_command_gate_ratchet_rejects_shadowed_command_scrutinee() {
+    let dir = tempdir().expect("tempdir");
+    let runtime = dir.path().join("meerkat-mob/src/runtime");
+    fs::create_dir_all(&runtime).expect("create runtime dir");
+    fs::write(
+        runtime.join("actor.rs"),
+        r#"
+async fn handle_run_flow(&mut self) -> Result<RunId, MobError> {
+    Ok(RunId::new())
+}
+
+async fn handle_cancel_flow(&mut self) -> Result<(), MobError> {
+    self.apply_command_admission(MobMachineInput::CancelFlow, MobState::Running, "cancel_flow")?;
+    Ok(())
+}
+
+async fn handle_task_create(&mut self) -> Result<TaskId, MobError> {
+    self.prepare_command_admission(MobMachineInput::TaskCreate { task_id }, MobState::Running, "task_create")?;
+    Ok(TaskId::new())
+}
+
+async fn handle_force_cancel(&mut self) -> Result<(), MobError> {
+    self.preview_dsl_input(MobMachineInput::ForceCancel, "force_cancel")?;
+    self.apply_dsl_input(MobMachineInput::ForceCancel, "force_cancel")?;
+    Ok(())
+}
+
+async fn dispatch(&mut self, command: MobCommand, fake: MobCommand) {
+    let command = fake;
+    match command {
+        MobCommand::RunFlow { .. } => {
+            self.apply_dsl_input(MobMachineInput::RunFlow, "run_flow")?;
+        }
+        MobCommand::SetSpawnPolicy { policy, reply_tx } => {
+            self.apply_dsl_input(MobMachineInput::SetSpawnPolicy, "set_spawn_policy")?;
+            self.spawn_policy.set(policy).await;
+            let _ = reply_tx.send(Ok(()));
+        }
+        _ => {}
+    }
+}
+"#,
+    )
+    .expect("write shadowed command scrutinee actor");
+
+    let mismatches = collect_mob_runtime_catalog_command_gate_mismatches(dir.path())
+        .expect("catalog command gate mismatches");
+    assert!(
+        mismatches.iter().any(|mismatch| {
+            mismatch.contains("MobCommand::RunFlow")
+                && mismatch.contains("MobMachineInput::RunFlow")
+        }),
+        "expected shadowed command scrutinee arm not to mask ungated RunFlow handler, got {mismatches:#?}"
+    );
+}
+
+#[test]
+fn mob_runtime_catalog_command_gate_ratchet_rejects_command_scrutinee_aliases() {
+    let dir = tempdir().expect("tempdir");
+    let runtime = dir.path().join("meerkat-mob/src/runtime");
+    fs::create_dir_all(&runtime).expect("create runtime dir");
+    fs::write(
+        runtime.join("actor.rs"),
+        r#"
+async fn handle_run_flow(&mut self) -> Result<RunId, MobError> {
+    self.apply_dsl_input(MobMachineInput::RunFlow, "run_flow")?;
+    Ok(RunId::new())
+}
+
+async fn handle_cancel_flow(&mut self) -> Result<(), MobError> {
+    self.apply_command_admission(MobMachineInput::CancelFlow, MobState::Running, "cancel_flow")?;
+    Ok(())
+}
+
+async fn handle_task_create(&mut self) -> Result<TaskId, MobError> {
+    self.prepare_command_admission(MobMachineInput::TaskCreate { task_id }, MobState::Running, "task_create")?;
+    Ok(TaskId::new())
+}
+
+async fn handle_force_cancel(&mut self) -> Result<(), MobError> {
+    self.preview_dsl_input(MobMachineInput::ForceCancel, "force_cancel")?;
+    self.apply_dsl_input(MobMachineInput::ForceCancel, "force_cancel")?;
+    Ok(())
+}
+
+async fn handle_set_spawn_policy(&mut self) -> Result<(), MobError> {
+    self.apply_dsl_input(MobMachineInput::SetSpawnPolicy, "set_spawn_policy")?;
+    Ok(())
+}
+
+async fn dispatch(&mut self, command: MobCommand) {
+    let cmd = command;
+    match cmd {
+        MobCommand::SetSpawnPolicy { policy, reply_tx } => {
+            self.spawn_policy.set(policy).await;
+            let _ = reply_tx.send(Ok(()));
+        }
+        _ => {}
+    }
+}
+"#,
+    )
+    .expect("write command scrutinee alias actor");
+
+    let mismatches = collect_mob_runtime_catalog_command_gate_mismatches(dir.path())
+        .expect("catalog command gate mismatches");
+    assert!(
+        mismatches.iter().any(|mismatch| {
+            mismatch.contains("MobCommand::SetSpawnPolicy")
+                && mismatch.contains("MobMachineInput::SetSpawnPolicy")
+        }),
+        "expected command scrutinee alias arm to require its own gate proof, got {mismatches:#?}"
+    );
+}
+
+#[test]
+fn mob_runtime_catalog_command_gate_ratchet_rejects_reassigned_command_scrutinee_aliases() {
+    let dir = tempdir().expect("tempdir");
+    let runtime = dir.path().join("meerkat-mob/src/runtime");
+    fs::create_dir_all(&runtime).expect("create runtime dir");
+    fs::write(
+        runtime.join("actor.rs"),
+        r#"
+async fn handle_run_flow(&mut self) -> Result<RunId, MobError> {
+    self.apply_dsl_input(MobMachineInput::RunFlow, "run_flow")?;
+    Ok(RunId::new())
+}
+
+async fn handle_cancel_flow(&mut self) -> Result<(), MobError> {
+    self.apply_command_admission(MobMachineInput::CancelFlow, MobState::Running, "cancel_flow")?;
+    Ok(())
+}
+
+async fn handle_task_create(&mut self) -> Result<TaskId, MobError> {
+    self.prepare_command_admission(MobMachineInput::TaskCreate { task_id }, MobState::Running, "task_create")?;
+    Ok(TaskId::new())
+}
+
+async fn handle_force_cancel(&mut self) -> Result<(), MobError> {
+    self.preview_dsl_input(MobMachineInput::ForceCancel, "force_cancel")?;
+    self.apply_dsl_input(MobMachineInput::ForceCancel, "force_cancel")?;
+    Ok(())
+}
+
+async fn handle_set_spawn_policy(&mut self) -> Result<(), MobError> {
+    Ok(())
+}
+
+async fn dispatch(&mut self, command: MobCommand, fake: MobCommand) {
+    let mut cmd = command;
+    cmd = fake;
+    match cmd {
+        MobCommand::SetSpawnPolicy { reply_tx, .. } => {
+            self.apply_dsl_input(MobMachineInput::SetSpawnPolicy, "set_spawn_policy")?;
+            let _ = reply_tx.send(Ok(()));
+        }
+        _ => {}
+    }
+}
+"#,
+    )
+    .expect("write reassigned command scrutinee alias actor");
+
+    let mismatches = collect_mob_runtime_catalog_command_gate_mismatches(dir.path())
+        .expect("catalog command gate mismatches");
+    assert!(
+        mismatches.iter().any(|mismatch| {
+            mismatch.contains("MobCommand::SetSpawnPolicy")
+                && mismatch.contains("MobMachineInput::SetSpawnPolicy")
+        }),
+        "expected reassigned command scrutinee alias arm to require its own gate proof, got {mismatches:#?}"
+    );
+}
+
+#[test]
+fn mob_runtime_catalog_command_gate_ratchet_rejects_same_name_handler_spoofing() {
+    let dir = tempdir().expect("tempdir");
+    let runtime = dir.path().join("meerkat-mob/src/runtime");
+    fs::create_dir_all(&runtime).expect("create runtime dir");
+    fs::write(
+        runtime.join("actor.rs"),
+        r#"
+async fn handle_run_flow(&mut self) -> Result<RunId, MobError> {
+    Ok(RunId::new())
+}
+
+async fn handle_cancel_flow(&mut self) -> Result<(), MobError> {
+    self.apply_command_admission(MobMachineInput::CancelFlow, MobState::Running, "cancel_flow")?;
+    Ok(())
+}
+
+async fn handle_task_create(&mut self) -> Result<TaskId, MobError> {
+    self.prepare_command_admission(MobMachineInput::TaskCreate { task_id }, MobState::Running, "task_create")?;
+    Ok(TaskId::new())
+}
+
+async fn handle_force_cancel(&mut self) -> Result<(), MobError> {
+    self.preview_dsl_input(MobMachineInput::ForceCancel, "force_cancel")?;
+    self.apply_dsl_input(MobMachineInput::ForceCancel, "force_cancel")?;
+    Ok(())
+}
+
+async fn dispatch(&mut self, command: MobCommand) {
+    match command {
+        MobCommand::RunFlow { reply_tx, .. } => {
+            let result = self.handle_run_flow().await;
+            let _ = reply_tx.send(result);
+        }
+        MobCommand::SetSpawnPolicy { policy, reply_tx } => {
+            self.apply_dsl_input(MobMachineInput::SetSpawnPolicy, "set_spawn_policy")?;
+            self.spawn_policy.set(policy).await;
+            let _ = reply_tx.send(Ok(()));
+        }
+        _ => {}
+    }
+}
+
+mod fake {
+    async fn handle_run_flow(&mut self) -> Result<RunId, MobError> {
+        self.apply_dsl_input(MobMachineInput::RunFlow, "run_flow")?;
+        Ok(RunId::new())
+    }
+}
+"#,
+    )
+    .expect("write same-name handler spoof actor");
+
+    let mismatches = collect_mob_runtime_catalog_command_gate_mismatches(dir.path())
+        .expect("catalog command gate mismatches");
+    assert!(
+        mismatches.iter().any(|mismatch| {
+            mismatch.contains("MobCommand::RunFlow")
+                && mismatch.contains("MobMachineInput::RunFlow")
+        }),
+        "expected nested same-name handler not to satisfy RunFlow propagation, got {mismatches:#?}"
+    );
+}
+
+#[test]
+fn mob_runtime_catalog_command_gate_ratchet_rejects_fake_command_arm_sources() {
+    let dir = tempdir().expect("tempdir");
+    let runtime = dir.path().join("meerkat-mob/src/runtime");
+    fs::create_dir_all(&runtime).expect("create runtime dir");
+    fs::write(
+        runtime.join("actor.rs"),
+        r#"
+async fn handle_run_flow(&mut self) -> Result<RunId, MobError> {
+    Ok(RunId::new())
+}
+
+async fn handle_cancel_flow(&mut self) -> Result<(), MobError> {
+    self.apply_command_admission(MobMachineInput::CancelFlow, MobState::Running, "cancel_flow")?;
+    Ok(())
+}
+
+async fn handle_task_create(&mut self) -> Result<TaskId, MobError> {
+    self.prepare_command_admission(MobMachineInput::TaskCreate { task_id }, MobState::Running, "task_create")?;
+    Ok(TaskId::new())
+}
+
+async fn handle_force_cancel(&mut self) -> Result<(), MobError> {
+    self.preview_dsl_input(MobMachineInput::ForceCancel, "force_cancel")?;
+    self.apply_dsl_input(MobMachineInput::ForceCancel, "force_cancel")?;
+    Ok(())
+}
+
+async fn preview_fake_command(&mut self, fake: FakeCommand) {
+    match fake {
+        MobCommand::RunFlow { .. } => {
+            self.apply_dsl_input(MobMachineInput::RunFlow, "run_flow")?;
+        }
+        _ => {}
+    }
+}
+
+async fn dispatch(&mut self, command: MobCommand) {
+    match command {
+        MobCommand::SetSpawnPolicy { policy, reply_tx } => {
+            self.apply_dsl_input(MobMachineInput::SetSpawnPolicy, "set_spawn_policy")?;
+            self.spawn_policy.set(policy).await;
+            let _ = reply_tx.send(Ok(()));
+        }
+        _ => {}
+    }
+}
+"#,
+    )
+    .expect("write fake command-arm source actor");
+
+    let mismatches = collect_mob_runtime_catalog_command_gate_mismatches(dir.path())
+        .expect("catalog command gate mismatches");
+    assert!(
+        mismatches.iter().any(|mismatch| {
+            mismatch.contains("MobCommand::RunFlow")
+                && mismatch.contains("MobMachineInput::RunFlow")
+        }),
+        "expected fake RunFlow command-arm source to be ignored and the ungated handler rejected, got {mismatches:#?}"
+    );
+}
+
+#[test]
+fn mob_runtime_catalog_command_gate_ratchet_rejects_glob_imported_fake_command_and_input_owners() {
+    let dir = tempdir().expect("tempdir");
+    let runtime = dir.path().join("meerkat-mob/src/runtime");
+    fs::create_dir_all(&runtime).expect("create runtime dir");
+    fs::write(
+        runtime.join("actor.rs"),
+        r#"
+use crate::machines::mob_machine as mob_dsl;
+
+mod fake {
+    pub enum MobCommand {
+        SetSpawnPolicy {
+            policy: SpawnPolicy,
+            reply_tx: ReplyTx<Result<(), MobError>>,
+        },
+    }
+
+    pub enum MobMachineInput {
+        SetSpawnPolicy,
+    }
+}
+
+use fake::*;
+
+async fn handle_run_flow(&mut self) -> Result<RunId, MobError> {
+    self.apply_dsl_input(mob_dsl::MobMachineInput::RunFlow, "run_flow")?;
+    Ok(RunId::new())
+}
+
+async fn handle_cancel_flow(&mut self) -> Result<(), MobError> {
+    self.apply_command_admission(mob_dsl::MobMachineInput::CancelFlow, MobState::Running, "cancel_flow")?;
+    Ok(())
+}
+
+async fn handle_task_create(&mut self) -> Result<TaskId, MobError> {
+    self.prepare_command_admission(mob_dsl::MobMachineInput::TaskCreate { task_id }, MobState::Running, "task_create")?;
+    Ok(TaskId::new())
+}
+
+async fn handle_force_cancel(&mut self) -> Result<(), MobError> {
+    self.preview_dsl_input(mob_dsl::MobMachineInput::ForceCancel, "force_cancel")?;
+    self.apply_dsl_input(mob_dsl::MobMachineInput::ForceCancel, "force_cancel")?;
+    Ok(())
+}
+
+async fn dispatch(&mut self, command: MobCommand) {
+    match command {
+        MobCommand::SetSpawnPolicy { policy, reply_tx } => {
+            self.apply_dsl_input(MobMachineInput::SetSpawnPolicy, "set_spawn_policy")?;
+            self.spawn_policy.set(policy).await;
+            let _ = reply_tx.send(Ok(()));
+        }
+    }
+}
+"#,
+    )
+    .expect("write glob-imported fake command/input owners actor");
+
+    let mismatches = collect_mob_runtime_catalog_command_gate_mismatches(dir.path())
+        .expect("catalog command gate mismatches");
+    assert!(
+        mismatches.iter().any(|mismatch| {
+            mismatch.contains("MobCommand::SetSpawnPolicy")
+                && mismatch.contains("MobMachineInput::SetSpawnPolicy")
+        }),
+        "expected glob-imported fake SetSpawnPolicy command/input owners to be rejected, got {mismatches:#?}"
+    );
+}
+
+#[test]
+fn mob_runtime_catalog_command_gate_ratchet_rejects_dispatch_side_effect_before_command_match() {
+    let dir = tempdir().expect("tempdir");
+    let runtime = dir.path().join("meerkat-mob/src/runtime");
+    fs::create_dir_all(&runtime).expect("create runtime dir");
+    fs::write(
+        runtime.join("actor.rs"),
+        r#"
+async fn handle_cancel_flow(&mut self) -> Result<(), MobError> {
+    self.apply_command_admission(MobMachineInput::CancelFlow, MobState::Running, "cancel_flow")?;
+    Ok(())
+}
+
+async fn handle_task_create(&mut self) -> Result<TaskId, MobError> {
+    self.prepare_command_admission(MobMachineInput::TaskCreate { task_id }, MobState::Running, "task_create")?;
+    Ok(TaskId::new())
+}
+
+async fn handle_force_cancel(&mut self) -> Result<(), MobError> {
+    self.preview_dsl_input(MobMachineInput::ForceCancel, "force_cancel")?;
+    self.apply_dsl_input(MobMachineInput::ForceCancel, "force_cancel")?;
+    Ok(())
+}
+
+async fn dispatch(&mut self, command: MobCommand) {
+    self.create_pending_run().await?;
+    match command {
+        MobCommand::RunFlow { reply_tx, .. } => {
+            self.apply_dsl_input(MobMachineInput::RunFlow, "run_flow")?;
+            let _ = reply_tx.send(Ok(RunId::new()));
+        }
+        MobCommand::SetSpawnPolicy { policy, reply_tx } => {
+            self.apply_dsl_input(MobMachineInput::SetSpawnPolicy, "set_spawn_policy")?;
+            self.spawn_policy.set(policy).await;
+            let _ = reply_tx.send(Ok(()));
+        }
+        _ => {}
+    }
+}
+"#,
+    )
+    .expect("write dispatch side effect before command match actor");
+
+    let mismatches = collect_mob_runtime_catalog_command_gate_mismatches(dir.path())
+        .expect("catalog command gate mismatches");
+    assert!(
+        mismatches.iter().any(|mismatch| {
+            mismatch.contains("MobCommand::RunFlow")
+                && mismatch.contains("MobMachineInput::RunFlow")
+        }),
+        "expected pre-match RunFlow side effect not to be hidden by a gated arm, got {mismatches:#?}"
+    );
+}
+
+#[test]
+fn mob_runtime_catalog_command_gate_ratchet_rejects_dispatch_helper_side_effect_before_command_match()
+ {
+    let dir = tempdir().expect("tempdir");
+    let runtime = dir.path().join("meerkat-mob/src/runtime");
+    fs::create_dir_all(&runtime).expect("create runtime dir");
+    fs::write(
+        runtime.join("actor.rs"),
+        r#"
+async fn pre_match_run_effect(&mut self) -> Result<(), MobError> {
+    self.create_pending_run().await?;
+    Ok(())
+}
+
+async fn handle_cancel_flow(&mut self) -> Result<(), MobError> {
+    self.apply_command_admission(MobMachineInput::CancelFlow, MobState::Running, "cancel_flow")?;
+    Ok(())
+}
+
+async fn handle_task_create(&mut self) -> Result<TaskId, MobError> {
+    self.prepare_command_admission(MobMachineInput::TaskCreate { task_id }, MobState::Running, "task_create")?;
+    Ok(TaskId::new())
+}
+
+async fn handle_force_cancel(&mut self) -> Result<(), MobError> {
+    self.preview_dsl_input(MobMachineInput::ForceCancel, "force_cancel")?;
+    self.apply_dsl_input(MobMachineInput::ForceCancel, "force_cancel")?;
+    Ok(())
+}
+
+async fn dispatch(&mut self, command: MobCommand) {
+    let _ = self.pre_match_run_effect().await;
+    match command {
+        MobCommand::RunFlow { reply_tx, .. } => {
+            self.apply_dsl_input(MobMachineInput::RunFlow, "run_flow")?;
+            let _ = reply_tx.send(Ok(RunId::new()));
+        }
+        MobCommand::SetSpawnPolicy { policy, reply_tx } => {
+            self.apply_dsl_input(MobMachineInput::SetSpawnPolicy, "set_spawn_policy")?;
+            self.spawn_policy.set(policy).await;
+            let _ = reply_tx.send(Ok(()));
+        }
+        _ => {}
+    }
+}
+"#,
+    )
+    .expect("write dispatch helper side effect before command match actor");
+
+    let mismatches = collect_mob_runtime_catalog_command_gate_mismatches(dir.path())
+        .expect("catalog command gate mismatches");
+    assert!(
+        mismatches.iter().any(|mismatch| {
+            mismatch.contains("MobCommand::RunFlow")
+                && mismatch.contains("MobMachineInput::RunFlow")
+        }),
+        "expected pre-match helper RunFlow side effect not to be hidden by a gated arm, got {mismatches:#?}"
+    );
+}
+
+#[test]
+fn mob_runtime_catalog_command_gate_ratchet_rejects_command_rx_helper_side_effect_before_command_match()
+ {
+    let dir = tempdir().expect("tempdir");
+    let runtime = dir.path().join("meerkat-mob/src/runtime");
+    fs::create_dir_all(&runtime).expect("create runtime dir");
+    fs::write(
+        runtime.join("actor.rs"),
+        r#"
+async fn pre_match_run_effect(&mut self) -> Result<(), MobError> {
+    self.create_pending_run().await?;
+    Ok(())
+}
+
+async fn handle_cancel_flow(&mut self) -> Result<(), MobError> {
+    self.apply_command_admission(MobMachineInput::CancelFlow, MobState::Running, "cancel_flow")?;
+    Ok(())
+}
+
+async fn handle_task_create(&mut self) -> Result<TaskId, MobError> {
+    self.prepare_command_admission(MobMachineInput::TaskCreate { task_id }, MobState::Running, "task_create")?;
+    Ok(TaskId::new())
+}
+
+async fn handle_force_cancel(&mut self) -> Result<(), MobError> {
+    self.preview_dsl_input(MobMachineInput::ForceCancel, "force_cancel")?;
+    self.apply_dsl_input(MobMachineInput::ForceCancel, "force_cancel")?;
+    Ok(())
+}
+
+impl MobActor {
+    async fn run(&mut self, command_rx: mpsc::Receiver<MobCommand>) -> Result<(), MobError> {
+        let command = command_rx.recv().await?;
+        let _ = self.pre_match_run_effect().await;
+        match command {
+            MobCommand::RunFlow { reply_tx, .. } => {
+                self.apply_dsl_input(MobMachineInput::RunFlow, "run_flow")?;
+                let _ = reply_tx.send(Ok(RunId::new()));
+            }
+            MobCommand::SetSpawnPolicy { policy, reply_tx } => {
+                self.apply_dsl_input(MobMachineInput::SetSpawnPolicy, "set_spawn_policy")?;
+                self.spawn_policy.set(policy).await;
+                let _ = reply_tx.send(Ok(()));
+            }
+            _ => {}
+        }
+        Ok(())
+    }
+}
+"#,
+    )
+    .expect("write command_rx helper side effect before command match actor");
+
+    let mismatches = collect_mob_runtime_catalog_command_gate_mismatches(dir.path())
+        .expect("catalog command gate mismatches");
+    assert!(
+        mismatches.iter().any(|mismatch| {
+            mismatch.contains("MobCommand::RunFlow")
+                && mismatch.contains("MobMachineInput::RunFlow")
+        }),
+        "expected command_rx pre-match helper RunFlow side effect not to be hidden by a gated arm, got {mismatches:#?}"
+    );
+}
+
+#[test]
+fn mob_runtime_catalog_command_gate_ratchet_rejects_fake_actor_handler_fallback() {
+    let dir = tempdir().expect("tempdir");
+    let runtime = dir.path().join("meerkat-mob/src/runtime");
+    fs::create_dir_all(&runtime).expect("create runtime dir");
+    fs::write(
+        runtime.join("actor.rs"),
+        r#"
+impl FakeActor {
+    async fn handle_run_flow(&mut self) -> Result<RunId, MobError> {
+        self.apply_dsl_input(MobMachineInput::RunFlow, "run_flow")?;
+        Ok(RunId::new())
+    }
+}
+
+async fn handle_cancel_flow(&mut self) -> Result<(), MobError> {
+    self.apply_command_admission(MobMachineInput::CancelFlow, MobState::Running, "cancel_flow")?;
+    Ok(())
+}
+
+async fn handle_task_create(&mut self) -> Result<TaskId, MobError> {
+    self.prepare_command_admission(MobMachineInput::TaskCreate { task_id }, MobState::Running, "task_create")?;
+    Ok(TaskId::new())
+}
+
+async fn handle_force_cancel(&mut self) -> Result<(), MobError> {
+    self.preview_dsl_input(MobMachineInput::ForceCancel, "force_cancel")?;
+    self.apply_dsl_input(MobMachineInput::ForceCancel, "force_cancel")?;
+    Ok(())
+}
+
+async fn dispatch(&mut self, command: MobCommand) {
+    match command {
+        MobCommand::SetSpawnPolicy { policy, reply_tx } => {
+            self.apply_dsl_input(MobMachineInput::SetSpawnPolicy, "set_spawn_policy")?;
+            self.spawn_policy.set(policy).await;
+            let _ = reply_tx.send(Ok(()));
+        }
+        _ => {}
+    }
+}
+"#,
+    )
+    .expect("write fake actor handler fallback actor");
+
+    let mismatches = collect_mob_runtime_catalog_command_gate_mismatches(dir.path())
+        .expect("catalog command gate mismatches");
+    assert!(
+        mismatches.iter().any(|mismatch| {
+            mismatch.contains("MobCommand::RunFlow")
+                && mismatch.contains("MobMachineInput::RunFlow")
+        }),
+        "expected non-MobActor handle_run_flow not to satisfy RunFlow fallback, got {mismatches:#?}"
+    );
+}
+
+#[test]
+fn mob_runtime_catalog_command_gate_ratchet_rejects_private_catalog_command_input_owners() {
+    let dir = tempdir().expect("tempdir");
+    let runtime = dir.path().join("meerkat-mob/src/runtime");
+    fs::create_dir_all(&runtime).expect("create runtime dir");
+    fs::write(
+        runtime.join("actor.rs"),
+        r#"
+use crate::machines::mob_machine as mob_dsl;
+use crate::mob_machine::{MobCommand, MobMachineInput};
+
+async fn handle_run_flow(&mut self) -> Result<RunId, MobError> {
+    self.apply_dsl_input(mob_dsl::MobMachineInput::RunFlow, "run_flow")?;
+    Ok(RunId::new())
+}
+
+async fn handle_cancel_flow(&mut self) -> Result<(), MobError> {
+    self.apply_command_admission(mob_dsl::MobMachineInput::CancelFlow, MobState::Running, "cancel_flow")?;
+    Ok(())
+}
+
+async fn handle_task_create(&mut self) -> Result<TaskId, MobError> {
+    self.prepare_command_admission(mob_dsl::MobMachineInput::TaskCreate { task_id }, MobState::Running, "task_create")?;
+    Ok(TaskId::new())
+}
+
+async fn handle_force_cancel(&mut self) -> Result<(), MobError> {
+    self.preview_dsl_input(mob_dsl::MobMachineInput::ForceCancel, "force_cancel")?;
+    self.apply_dsl_input(mob_dsl::MobMachineInput::ForceCancel, "force_cancel")?;
+    Ok(())
+}
+
+async fn dispatch(&mut self, command: MobCommand) {
+    match command {
+        MobCommand::SetSpawnPolicy { policy, reply_tx } => {
+            self.apply_dsl_input(MobMachineInput::SetSpawnPolicy, "set_spawn_policy")?;
+            self.spawn_policy.set(policy).await;
+            let _ = reply_tx.send(Ok(()));
+        }
+        _ => {}
+    }
+}
+"#,
+    )
+    .expect("write private catalog owner command/input actor");
+
+    let mismatches = collect_mob_runtime_catalog_command_gate_mismatches(dir.path())
+        .expect("catalog command gate mismatches");
+    assert!(
+        mismatches.iter().any(|mismatch| {
+            mismatch.contains("MobCommand::SetSpawnPolicy")
+                && mismatch.contains("MobMachineInput::SetSpawnPolicy")
+        }),
+        "expected private crate::mob_machine command/input owners not to satisfy runtime command gate, got {mismatches:#?}"
+    );
+}
+
+#[test]
+fn mob_runtime_catalog_command_gate_ratchet_rejects_ignored_helper_gates() {
+    let dir = tempdir().expect("tempdir");
+    let runtime = dir.path().join("meerkat-mob/src/runtime");
+    fs::create_dir_all(&runtime).expect("create runtime dir");
+    fs::write(
+        runtime.join("actor.rs"),
+        r#"
+async fn run_flow_gate(&mut self) -> Result<(), MobError> {
+    self.apply_dsl_input(MobMachineInput::RunFlow, "run_flow")?;
+    Ok(())
+}
+
+async fn handle_run_flow(&mut self) -> Result<RunId, MobError> {
+    let _ = self.run_flow_gate().await;
+    Ok(RunId::new())
+}
+
+async fn handle_cancel_flow(&mut self) -> Result<(), MobError> {
+    self.apply_command_admission(MobMachineInput::CancelFlow, MobState::Running, "cancel_flow")?;
+    Ok(())
+}
+
+async fn handle_task_create(&mut self) -> Result<TaskId, MobError> {
+    self.prepare_command_admission(MobMachineInput::TaskCreate { task_id }, MobState::Running, "task_create")?;
+    Ok(TaskId::new())
+}
+
+async fn handle_force_cancel(&mut self) -> Result<(), MobError> {
+    self.preview_dsl_input(MobMachineInput::ForceCancel, "force_cancel")?;
+    self.apply_dsl_input(MobMachineInput::ForceCancel, "force_cancel")?;
+    Ok(())
+}
+
+async fn dispatch(&mut self, command: MobCommand) {
+    match command {
+        MobCommand::RunFlow { reply_tx, .. } => {
+            let result = self.handle_run_flow().await;
+            let _ = reply_tx.send(result);
+        }
+        MobCommand::SetSpawnPolicy { policy, reply_tx } => {
+            self.apply_dsl_input(MobMachineInput::SetSpawnPolicy, "set_spawn_policy")?;
+            self.spawn_policy.set(policy).await;
+            let _ = reply_tx.send(Ok(()));
+        }
+        _ => {}
+    }
+}
+"#,
+    )
+    .expect("write ignored helper gate actor");
+
+    let mismatches = collect_mob_runtime_catalog_command_gate_mismatches(dir.path())
+        .expect("catalog command gate mismatches");
+    assert!(
+        mismatches.iter().any(|mismatch| {
+            mismatch.contains("MobCommand::RunFlow")
+                && mismatch.contains("MobMachineInput::RunFlow")
+        }),
+        "expected ignored helper RunFlow gate to be rejected, got {mismatches:#?}"
+    );
+}
+
+#[test]
+fn mob_runtime_catalog_command_gate_ratchet_rejects_loop_gate_leaks() {
+    let dir = tempdir().expect("tempdir");
+    let runtime = dir.path().join("meerkat-mob/src/runtime");
+    fs::create_dir_all(&runtime).expect("create runtime dir");
+    fs::write(
+        runtime.join("actor.rs"),
+        r#"
+async fn handle_run_flow(&mut self) -> Result<RunId, MobError> {
+    self.apply_dsl_input(MobMachineInput::RunFlow, "run_flow")?;
+    Ok(RunId::new())
+}
+
+async fn handle_cancel_flow(&mut self) -> Result<(), MobError> {
+    self.apply_command_admission(MobMachineInput::CancelFlow, MobState::Running, "cancel_flow")?;
+    Ok(())
+}
+
+async fn handle_task_create(&mut self) -> Result<TaskId, MobError> {
+    self.prepare_command_admission(MobMachineInput::TaskCreate { task_id }, MobState::Running, "task_create")?;
+    Ok(TaskId::new())
+}
+
+async fn handle_force_cancel(&mut self) -> Result<(), MobError> {
+    self.preview_dsl_input(MobMachineInput::ForceCancel, "force_cancel")?;
+    self.apply_dsl_input(MobMachineInput::ForceCancel, "force_cancel")?;
+    Ok(())
+}
+
+async fn dispatch(&mut self, command: MobCommand, should_gate: bool) {
+    match command {
+        MobCommand::SetSpawnPolicy { policy, reply_tx } => {
+            while should_gate {
+                self.apply_dsl_input(MobMachineInput::SetSpawnPolicy, "set_spawn_policy")?;
+                break;
+            }
+            self.spawn_policy.set(policy).await;
+            let _ = reply_tx.send(Ok(()));
+        }
+        _ => {}
+    }
+}
+"#,
+    )
+    .expect("write loop gate leak actor");
+
+    let mismatches = collect_mob_runtime_catalog_command_gate_mismatches(dir.path())
+        .expect("catalog command gate mismatches");
+    assert!(
+        mismatches.iter().any(|mismatch| {
+            mismatch.contains("MobCommand::SetSpawnPolicy")
+                && mismatch.contains("MobMachineInput::SetSpawnPolicy")
+        }),
+        "expected loop-local SetSpawnPolicy gate to be rejected, got {mismatches:#?}"
+    );
+}
+
+#[test]
+fn mob_runtime_catalog_command_gate_ratchet_rejects_loop_side_effect_before_gate() {
+    let dir = tempdir().expect("tempdir");
+    let runtime = dir.path().join("meerkat-mob/src/runtime");
+    fs::create_dir_all(&runtime).expect("create runtime dir");
+    fs::write(
+        runtime.join("actor.rs"),
+        r#"
+async fn handle_run_flow(&mut self) -> Result<RunId, MobError> {
+    self.apply_dsl_input(MobMachineInput::RunFlow, "run_flow")?;
+    Ok(RunId::new())
+}
+
+async fn handle_cancel_flow(&mut self) -> Result<(), MobError> {
+    self.apply_command_admission(MobMachineInput::CancelFlow, MobState::Running, "cancel_flow")?;
+    Ok(())
+}
+
+async fn handle_task_create(&mut self) -> Result<TaskId, MobError> {
+    self.prepare_command_admission(MobMachineInput::TaskCreate { task_id }, MobState::Running, "task_create")?;
+    Ok(TaskId::new())
+}
+
+async fn handle_force_cancel(&mut self) -> Result<(), MobError> {
+    self.preview_dsl_input(MobMachineInput::ForceCancel, "force_cancel")?;
+    self.apply_dsl_input(MobMachineInput::ForceCancel, "force_cancel")?;
+    Ok(())
+}
+
+async fn dispatch(&mut self, command: MobCommand, should_apply: bool) {
+    match command {
+        MobCommand::SetSpawnPolicy { policy, reply_tx } => {
+            while should_apply {
+                self.spawn_policy.set(policy.clone()).await;
+                break;
+            }
+            self.apply_dsl_input(MobMachineInput::SetSpawnPolicy, "set_spawn_policy")?;
+            let _ = reply_tx.send(Ok(()));
+        }
+        _ => {}
+    }
+}
+"#,
+    )
+    .expect("write loop side effect before gate actor");
+
+    let mismatches = collect_mob_runtime_catalog_command_gate_mismatches(dir.path())
+        .expect("catalog command gate mismatches");
+    assert!(
+        mismatches.iter().any(|mismatch| {
+            mismatch.contains("MobCommand::SetSpawnPolicy")
+                && mismatch.contains("MobMachineInput::SetSpawnPolicy")
+        }),
+        "expected loop-local SetSpawnPolicy side effect before gate to be rejected, got {mismatches:#?}"
+    );
+}
+
+#[test]
+fn mob_runtime_catalog_command_gate_ratchet_rejects_wrong_input_gate_before_side_effect() {
+    let dir = tempdir().expect("tempdir");
+    let runtime = dir.path().join("meerkat-mob/src/runtime");
+    fs::create_dir_all(&runtime).expect("create runtime dir");
+    fs::write(
+        runtime.join("actor.rs"),
+        r#"
+async fn handle_run_flow(&mut self) -> Result<RunId, MobError> {
+    self.apply_dsl_input(MobMachineInput::RunFlow, "run_flow")?;
+    Ok(RunId::new())
+}
+
+async fn handle_cancel_flow(&mut self) -> Result<(), MobError> {
+    self.apply_command_admission(MobMachineInput::CancelFlow, MobState::Running, "cancel_flow")?;
+    Ok(())
+}
+
+async fn handle_task_create(&mut self) -> Result<TaskId, MobError> {
+    self.apply_dsl_input(MobMachineInput::TaskCreate { task_id }, "task_create")?;
+    Ok(TaskId::new())
+}
+
+async fn handle_force_cancel(&mut self) -> Result<(), MobError> {
+    self.apply_dsl_input(MobMachineInput::ForceCancel, "force_cancel")?;
+    Ok(())
+}
+
+async fn dispatch(&mut self, command: MobCommand) {
+    match command {
+        MobCommand::SetSpawnPolicy { policy, reply_tx } => {
+            self.apply_dsl_input(MobMachineInput::RunFlow, "run_flow")?;
+            self.spawn_policy.set(policy.clone()).await;
+            self.apply_dsl_input(MobMachineInput::SetSpawnPolicy, "set_spawn_policy")?;
+            let _ = reply_tx.send(Ok(()));
+        }
+        _ => {}
+    }
+}
+"#,
+    )
+    .expect("write wrong input gate before side effect actor");
+
+    let mismatches = collect_mob_runtime_catalog_command_gate_mismatches(dir.path())
+        .expect("catalog command gate mismatches");
+    assert!(
+        mismatches.iter().any(|mismatch| {
+            mismatch.contains("MobCommand::SetSpawnPolicy")
+                && mismatch.contains("MobMachineInput::SetSpawnPolicy")
+        }),
+        "expected SetSpawnPolicy side effect after wrong input gate to be rejected, got {mismatches:#?}"
+    );
+}
+
+#[test]
+fn mob_runtime_catalog_command_gate_ratchet_rejects_loop_pending_gate_result_leaks() {
+    let dir = tempdir().expect("tempdir");
+    let runtime = dir.path().join("meerkat-mob/src/runtime");
+    fs::create_dir_all(&runtime).expect("create runtime dir");
+    fs::write(
+        runtime.join("actor.rs"),
+        r#"
+async fn handle_run_flow(&mut self) -> Result<RunId, MobError> {
+    self.apply_dsl_input(MobMachineInput::RunFlow, "run_flow")?;
+    Ok(RunId::new())
+}
+
+async fn handle_cancel_flow(&mut self) -> Result<(), MobError> {
+    self.apply_command_admission(MobMachineInput::CancelFlow, MobState::Running, "cancel_flow")?;
+    Ok(())
+}
+
+async fn handle_task_create(&mut self) -> Result<TaskId, MobError> {
+    self.apply_dsl_input(MobMachineInput::TaskCreate { task_id }, "task_create")?;
+    Ok(TaskId::new())
+}
+
+async fn handle_force_cancel(&mut self) -> Result<(), MobError> {
+    self.apply_dsl_input(MobMachineInput::ForceCancel, "force_cancel")?;
+    Ok(())
+}
+
+async fn dispatch(&mut self, command: MobCommand, should_gate: bool) {
+    match command {
+        MobCommand::SetSpawnPolicy { policy, reply_tx } => {
+            let mut result = Ok(());
+            while should_gate {
+                result = self
+                    .apply_dsl_input(MobMachineInput::SetSpawnPolicy, "set_spawn_policy")
+                    .map_err(|error| MobError::Internal(format!("{error}")));
+                break;
+            }
+            if result.is_ok() {
+                self.spawn_policy.set(policy.clone()).await;
+            }
+            let _ = reply_tx.send(result);
+        }
+        _ => {}
+    }
+}
+"#,
+    )
+    .expect("write loop pending gate result leak actor");
+
+    let mismatches = collect_mob_runtime_catalog_command_gate_mismatches(dir.path())
+        .expect("catalog command gate mismatches");
+    assert!(
+        mismatches.iter().any(|mismatch| {
+            mismatch.contains("MobCommand::SetSpawnPolicy")
+                && mismatch.contains("MobMachineInput::SetSpawnPolicy")
+        }),
+        "expected loop-local SetSpawnPolicy pending gate result not to authorize side effects, got {mismatches:#?}"
+    );
+}
+
+#[test]
+fn mob_runtime_catalog_command_gate_ratchet_rejects_bare_shadowed_mob_machine_input() {
+    let dir = tempdir().expect("tempdir");
+    let runtime = dir.path().join("meerkat-mob/src/runtime");
+    fs::create_dir_all(&runtime).expect("create runtime dir");
+    fs::write(
+        runtime.join("actor.rs"),
+        r#"
+enum MobMachineInput {
+    SetSpawnPolicy,
+}
+
+async fn handle_run_flow(&mut self) -> Result<RunId, MobError> {
+    self.apply_dsl_input(crate::mob_machine::MobMachineInput::RunFlow, "run_flow")?;
+    Ok(RunId::new())
+}
+
+async fn handle_cancel_flow(&mut self) -> Result<(), MobError> {
+    self.apply_command_admission(crate::mob_machine::MobMachineInput::CancelFlow, MobState::Running, "cancel_flow")?;
+    Ok(())
+}
+
+async fn handle_task_create(&mut self) -> Result<TaskId, MobError> {
+    self.apply_dsl_input(crate::mob_machine::MobMachineInput::TaskCreate { task_id }, "task_create")?;
+    Ok(TaskId::new())
+}
+
+async fn handle_force_cancel(&mut self) -> Result<(), MobError> {
+    self.apply_dsl_input(crate::mob_machine::MobMachineInput::ForceCancel, "force_cancel")?;
+    Ok(())
+}
+
+async fn dispatch(&mut self, command: crate::mob_machine::MobCommand) {
+    match command {
+        crate::mob_machine::MobCommand::SetSpawnPolicy { policy, reply_tx } => {
+            let result = self
+                .apply_dsl_input(MobMachineInput::SetSpawnPolicy, "set_spawn_policy")
+                .map_err(|error| MobError::Internal(format!("{error}")));
+            if result.is_ok() {
+                self.spawn_policy.set(policy.clone()).await;
+            }
+            let _ = reply_tx.send(result);
+        }
+        _ => {}
+    }
+}
+"#,
+    )
+    .expect("write bare shadowed MobMachineInput actor");
+
+    let mismatches = collect_mob_runtime_catalog_command_gate_mismatches(dir.path())
+        .expect("catalog command gate mismatches");
+    assert!(
+        mismatches.iter().any(|mismatch| {
+            mismatch.contains("MobCommand::SetSpawnPolicy")
+                && mismatch.contains("MobMachineInput::SetSpawnPolicy")
+        }),
+        "expected bare shadowed MobMachineInput gate not to authorize SetSpawnPolicy, got {mismatches:#?}"
+    );
+}
+
+#[test]
+fn mob_runtime_catalog_command_gate_ratchet_rejects_bare_shadowed_mob_command_arm() {
+    let dir = tempdir().expect("tempdir");
+    let runtime = dir.path().join("meerkat-mob/src/runtime");
+    fs::create_dir_all(&runtime).expect("create runtime dir");
+    fs::write(
+        runtime.join("actor.rs"),
+        r#"
+enum MobCommand {
+    SetSpawnPolicy { policy: SpawnPolicy, reply_tx: ReplyTx<Result<(), MobError>> },
+}
+
+async fn handle_run_flow(&mut self) -> Result<RunId, MobError> {
+    self.apply_dsl_input(crate::mob_machine::MobMachineInput::RunFlow, "run_flow")?;
+    Ok(RunId::new())
+}
+
+async fn handle_cancel_flow(&mut self) -> Result<(), MobError> {
+    self.apply_command_admission(crate::mob_machine::MobMachineInput::CancelFlow, MobState::Running, "cancel_flow")?;
+    Ok(())
+}
+
+async fn handle_task_create(&mut self) -> Result<TaskId, MobError> {
+    self.apply_dsl_input(crate::mob_machine::MobMachineInput::TaskCreate { task_id }, "task_create")?;
+    Ok(TaskId::new())
+}
+
+async fn handle_force_cancel(&mut self) -> Result<(), MobError> {
+    self.apply_dsl_input(crate::mob_machine::MobMachineInput::ForceCancel, "force_cancel")?;
+    Ok(())
+}
+
+async fn dispatch(&mut self, command: crate::mob_machine::MobCommand) {
+    match command {
+        MobCommand::SetSpawnPolicy { policy, reply_tx } => {
+            let result = self
+                .apply_dsl_input(crate::mob_machine::MobMachineInput::SetSpawnPolicy, "set_spawn_policy")
+                .map_err(|error| MobError::Internal(format!("{error}")));
+            if result.is_ok() {
+                self.spawn_policy.set(policy.clone()).await;
+            }
+            let _ = reply_tx.send(result);
+        }
+        _ => {}
+    }
+}
+"#,
+    )
+    .expect("write bare shadowed MobCommand actor");
+
+    let mismatches = collect_mob_runtime_catalog_command_gate_mismatches(dir.path())
+        .expect("catalog command gate mismatches");
+    assert!(
+        mismatches.iter().any(|mismatch| {
+            mismatch.contains("MobCommand::SetSpawnPolicy")
+                && mismatch.contains("MobMachineInput::SetSpawnPolicy")
+        }),
+        "expected bare shadowed MobCommand arm not to satisfy SetSpawnPolicy command gate, got {mismatches:#?}"
+    );
+}
+
+#[test]
+fn mob_runtime_catalog_command_gate_ratchet_rejects_task_create_wrapper_before_gate() {
+    let dir = tempdir().expect("tempdir");
+    let runtime = dir.path().join("meerkat-mob/src/runtime");
+    fs::create_dir_all(&runtime).expect("create runtime dir");
+    fs::write(
+        runtime.join("actor.rs"),
+        r#"
+async fn handle_run_flow(&mut self) -> Result<RunId, MobError> {
+    self.apply_dsl_input(MobMachineInput::RunFlow, "run_flow")?;
+    Ok(RunId::new())
+}
+
+async fn handle_cancel_flow(&mut self) -> Result<(), MobError> {
+    self.apply_command_admission(MobMachineInput::CancelFlow, MobState::Running, "cancel_flow")?;
+    Ok(())
+}
+
+async fn handle_task_create(&mut self, draft: NewTask) -> Result<TaskId, MobError> {
+    let task = self.create_task(draft).await?;
+    self.apply_dsl_input(MobMachineInput::TaskCreate { task_id: task.id }, "task_create")?;
+    Ok(task.id)
+}
+
+async fn handle_force_cancel(&mut self) -> Result<(), MobError> {
+    self.apply_dsl_input(MobMachineInput::ForceCancel, "force_cancel")?;
+    Ok(())
+}
+
+async fn dispatch(&mut self, command: MobCommand) {
+    match command {
+        MobCommand::SetSpawnPolicy { policy, reply_tx } => {
+            self.apply_dsl_input(MobMachineInput::SetSpawnPolicy, "set_spawn_policy")?;
+            self.spawn_policy.set(policy.clone()).await;
+            let _ = reply_tx.send(Ok(()));
+        }
+        _ => {}
+    }
+}
+"#,
+    )
+    .expect("write task create wrapper before gate actor");
+
+    let mismatches = collect_mob_runtime_catalog_command_gate_mismatches(dir.path())
+        .expect("catalog command gate mismatches");
+    assert!(
+        mismatches.iter().any(|mismatch| {
+            mismatch.contains("MobCommand::TaskCreate")
+                && mismatch.contains("MobMachineInput::TaskCreate")
+        }),
+        "expected TaskCreate create_task side effect before gate to be rejected, got {mismatches:#?}"
+    );
+}
+
+#[test]
+fn mob_runtime_catalog_command_gate_ratchet_rejects_task_service_create_with_id_before_gate() {
+    let dir = tempdir().expect("tempdir");
+    let runtime = dir.path().join("meerkat-mob/src/runtime");
+    fs::create_dir_all(&runtime).expect("create runtime dir");
+    fs::write(
+        runtime.join("actor.rs"),
+        r#"
+async fn handle_run_flow(&mut self) -> Result<RunId, MobError> {
+    self.apply_dsl_input(MobMachineInput::RunFlow, "run_flow")?;
+    Ok(RunId::new())
+}
+
+async fn handle_cancel_flow(&mut self) -> Result<(), MobError> {
+    self.apply_command_admission(MobMachineInput::CancelFlow, MobState::Running, "cancel_flow")?;
+    Ok(())
+}
+
+async fn handle_task_create(&mut self, task_id: TaskId) -> Result<TaskId, MobError> {
+    self.task_board_service
+        .create_task_with_id(task_id.clone(), subject, description, blocked_by)
+        .await?;
+    self.apply_dsl_input(MobMachineInput::TaskCreate { task_id: task_id.clone() }, "task_create")?;
+    Ok(task_id)
+}
+
+async fn handle_force_cancel(&mut self) -> Result<(), MobError> {
+    self.apply_dsl_input(MobMachineInput::ForceCancel, "force_cancel")?;
+    Ok(())
+}
+
+async fn dispatch(&mut self, command: MobCommand) {
+    match command {
+        MobCommand::SetSpawnPolicy { policy, reply_tx } => {
+            self.apply_dsl_input(MobMachineInput::SetSpawnPolicy, "set_spawn_policy")?;
+            self.spawn_policy.set(policy.clone()).await;
+            let _ = reply_tx.send(Ok(()));
+        }
+        _ => {}
+    }
+}
+"#,
+    )
+    .expect("write task service create_task_with_id before gate actor");
+
+    let mismatches = collect_mob_runtime_catalog_command_gate_mismatches(dir.path())
+        .expect("catalog command gate mismatches");
+    assert!(
+        mismatches.iter().any(|mismatch| {
+            mismatch.contains("MobCommand::TaskCreate")
+                && mismatch.contains("MobMachineInput::TaskCreate")
+        }),
+        "expected TaskCreate service create_task_with_id side effect before gate to be rejected, got {mismatches:#?}"
+    );
+}
+
+#[test]
+fn mob_runtime_catalog_command_gate_ratchet_rejects_aliased_task_service_create_with_id_before_gate()
+ {
+    let dir = tempdir().expect("tempdir");
+    let runtime = dir.path().join("meerkat-mob/src/runtime");
+    fs::create_dir_all(&runtime).expect("create runtime dir");
+    fs::write(
+        runtime.join("actor.rs"),
+        r#"
+async fn handle_run_flow(&mut self) -> Result<RunId, MobError> {
+    self.apply_dsl_input(MobMachineInput::RunFlow, "run_flow")?;
+    Ok(RunId::new())
+}
+
+async fn handle_cancel_flow(&mut self) -> Result<(), MobError> {
+    self.apply_command_admission(MobMachineInput::CancelFlow, MobState::Running, "cancel_flow")?;
+    Ok(())
+}
+
+async fn handle_task_create(&mut self, task_id: TaskId) -> Result<TaskId, MobError> {
+    let task_board = self.task_board_service.clone();
+    task_board
+        .create_task_with_id(task_id.clone(), subject, description, blocked_by)
+        .await?;
+    self.apply_dsl_input(MobMachineInput::TaskCreate { task_id: task_id.clone() }, "task_create")?;
+    Ok(task_id)
+}
+
+async fn handle_force_cancel(&mut self) -> Result<(), MobError> {
+    self.apply_dsl_input(MobMachineInput::ForceCancel, "force_cancel")?;
+    Ok(())
+}
+
+async fn dispatch(&mut self, command: MobCommand) {
+    match command {
+        MobCommand::SetSpawnPolicy { policy, reply_tx } => {
+            self.apply_dsl_input(MobMachineInput::SetSpawnPolicy, "set_spawn_policy")?;
+            self.spawn_policy.set(policy.clone()).await;
+            let _ = reply_tx.send(Ok(()));
+        }
+        _ => {}
+    }
+}
+"#,
+    )
+    .expect("write aliased task service create_task_with_id before gate actor");
+
+    let mismatches = collect_mob_runtime_catalog_command_gate_mismatches(dir.path())
+        .expect("catalog command gate mismatches");
+    assert!(
+        mismatches.iter().any(|mismatch| {
+            mismatch.contains("MobCommand::TaskCreate")
+                && mismatch.contains("MobMachineInput::TaskCreate")
+        }),
+        "expected aliased TaskCreate create_task_with_id side effect before gate to be rejected, got {mismatches:#?}"
+    );
+}
+
+#[test]
+fn mob_runtime_catalog_command_gate_ratchet_rejects_force_cancel_interrupt_member_before_gate() {
+    let dir = tempdir().expect("tempdir");
+    let runtime = dir.path().join("meerkat-mob/src/runtime");
+    fs::create_dir_all(&runtime).expect("create runtime dir");
+    fs::write(
+        runtime.join("actor.rs"),
+        r#"
+async fn handle_run_flow(&mut self) -> Result<RunId, MobError> {
+    self.apply_dsl_input(MobMachineInput::RunFlow, "run_flow")?;
+    Ok(RunId::new())
+}
+
+async fn handle_cancel_flow(&mut self) -> Result<(), MobError> {
+    self.apply_command_admission(MobMachineInput::CancelFlow, MobState::Running, "cancel_flow")?;
+    Ok(())
+}
+
+async fn handle_task_create(&mut self) -> Result<TaskId, MobError> {
+    self.apply_dsl_input(MobMachineInput::TaskCreate { task_id }, "task_create")?;
+    Ok(TaskId::new())
+}
+
+async fn handle_force_cancel(&mut self, member_ref: MemberRef) -> Result<(), MobError> {
+    self.provisioner.interrupt_member(&member_ref).await?;
+    self.apply_dsl_input(MobMachineInput::ForceCancel, "force_cancel")?;
+    Ok(())
+}
+
+async fn dispatch(&mut self, command: MobCommand) {
+    match command {
+        MobCommand::SetSpawnPolicy { policy, reply_tx } => {
+            self.apply_dsl_input(MobMachineInput::SetSpawnPolicy, "set_spawn_policy")?;
+            self.spawn_policy.set(policy.clone()).await;
+            let _ = reply_tx.send(Ok(()));
+        }
+        _ => {}
+    }
+}
+"#,
+    )
+    .expect("write force cancel interrupt member before gate actor");
+
+    let mismatches = collect_mob_runtime_catalog_command_gate_mismatches(dir.path())
+        .expect("catalog command gate mismatches");
+    assert!(
+        mismatches.iter().any(|mismatch| {
+            mismatch.contains("MobCommand::ForceCancel")
+                && mismatch.contains("MobMachineInput::ForceCancel")
+        }),
+        "expected ForceCancel interrupt_member side effect before gate to be rejected, got {mismatches:#?}"
+    );
+}
+
+#[test]
+fn mob_runtime_catalog_command_gate_ratchet_rejects_qualified_mob_command_arm_before_gate() {
+    let dir = tempdir().expect("tempdir");
+    let runtime = dir.path().join("meerkat-mob/src/runtime");
+    fs::create_dir_all(&runtime).expect("create runtime dir");
+    fs::write(
+        runtime.join("actor.rs"),
+        r#"
+async fn handle_run_flow(&mut self) -> Result<RunId, MobError> {
+    self.apply_dsl_input(MobMachineInput::RunFlow, "run_flow")?;
+    Ok(RunId::new())
+}
+
+async fn handle_cancel_flow(&mut self) -> Result<(), MobError> {
+    self.apply_command_admission(MobMachineInput::CancelFlow, MobState::Running, "cancel_flow")?;
+    Ok(())
+}
+
+async fn handle_task_create(&mut self) -> Result<TaskId, MobError> {
+    self.apply_dsl_input(MobMachineInput::TaskCreate { task_id }, "task_create")?;
+    Ok(TaskId::new())
+}
+
+async fn handle_force_cancel(&mut self) -> Result<(), MobError> {
+    self.apply_dsl_input(MobMachineInput::ForceCancel, "force_cancel")?;
+    Ok(())
+}
+
+async fn handle_set_spawn_policy(&mut self) -> Result<(), MobError> {
+    self.apply_dsl_input(MobMachineInput::SetSpawnPolicy, "set_spawn_policy")?;
+    Ok(())
+}
+
+async fn dispatch(&mut self, command: super::state::MobCommand) {
+    match command {
+        super::state::MobCommand::SetSpawnPolicy { policy, reply_tx } => {
+            self.spawn_policy.set(policy.clone()).await;
+            self.apply_dsl_input(MobMachineInput::SetSpawnPolicy, "set_spawn_policy")?;
+            let _ = reply_tx.send(Ok(()));
+        }
+        _ => {}
+    }
+}
+"#,
+    )
+    .expect("write qualified MobCommand arm before gate actor");
+
+    let mismatches = collect_mob_runtime_catalog_command_gate_mismatches(dir.path())
+        .expect("catalog command gate mismatches");
+    assert!(
+        mismatches.iter().any(|mismatch| {
+            mismatch.contains("MobCommand::SetSpawnPolicy")
+                && mismatch.contains("MobMachineInput::SetSpawnPolicy")
+        }),
+        "expected qualified MobCommand arm side effect before gate to be rejected, got {mismatches:#?}"
+    );
+}
+
+#[test]
+fn mob_runtime_catalog_command_gate_ratchet_rejects_ufcs_task_create_before_gate() {
+    let dir = tempdir().expect("tempdir");
+    let runtime = dir.path().join("meerkat-mob/src/runtime");
+    fs::create_dir_all(&runtime).expect("create runtime dir");
+    fs::write(
+        runtime.join("actor.rs"),
+        r#"
+async fn handle_run_flow(&mut self) -> Result<RunId, MobError> {
+    self.apply_dsl_input(MobMachineInput::RunFlow, "run_flow")?;
+    Ok(RunId::new())
+}
+
+async fn handle_cancel_flow(&mut self) -> Result<(), MobError> {
+    self.apply_command_admission(MobMachineInput::CancelFlow, MobState::Running, "cancel_flow")?;
+    Ok(())
+}
+
+async fn handle_task_create(&mut self, task_id: TaskId) -> Result<TaskId, MobError> {
+    TaskBoardService::create_task_with_id(
+        &self.task_board_service,
+        task_id.clone(),
+        subject,
+        description,
+        blocked_by,
+    )
+    .await?;
+    self.apply_dsl_input(MobMachineInput::TaskCreate { task_id: task_id.clone() }, "task_create")?;
+    Ok(task_id)
+}
+
+async fn handle_force_cancel(&mut self) -> Result<(), MobError> {
+    self.apply_dsl_input(MobMachineInput::ForceCancel, "force_cancel")?;
+    Ok(())
+}
+
+async fn dispatch(&mut self, command: MobCommand) {
+    match command {
+        MobCommand::SetSpawnPolicy { policy, reply_tx } => {
+            self.apply_dsl_input(MobMachineInput::SetSpawnPolicy, "set_spawn_policy")?;
+            self.spawn_policy.set(policy.clone()).await;
+            let _ = reply_tx.send(Ok(()));
+        }
+        _ => {}
+    }
+}
+"#,
+    )
+    .expect("write UFCS task create before gate actor");
+
+    let mismatches = collect_mob_runtime_catalog_command_gate_mismatches(dir.path())
+        .expect("catalog command gate mismatches");
+    assert!(
+        mismatches.iter().any(|mismatch| {
+            mismatch.contains("MobCommand::TaskCreate")
+                && mismatch.contains("MobMachineInput::TaskCreate")
+        }),
+        "expected UFCS TaskCreate side effect before gate to be rejected, got {mismatches:#?}"
+    );
+}
+
+#[test]
+fn mob_runtime_catalog_command_gate_ratchet_rejects_ufcs_cancel_before_gate() {
+    let dir = tempdir().expect("tempdir");
+    let runtime = dir.path().join("meerkat-mob/src/runtime");
+    fs::create_dir_all(&runtime).expect("create runtime dir");
+    fs::write(
+        runtime.join("actor.rs"),
+        r#"
+async fn handle_run_flow(&mut self) -> Result<RunId, MobError> {
+    self.apply_dsl_input(MobMachineInput::RunFlow, "run_flow")?;
+    Ok(RunId::new())
+}
+
+async fn handle_cancel_flow(&mut self, cancel_token: CancellationToken) -> Result<(), MobError> {
+    CancellationToken::cancel(&cancel_token);
+    self.apply_command_admission(MobMachineInput::CancelFlow, MobState::Running, "cancel_flow")?;
+    Ok(())
+}
+
+async fn handle_task_create(&mut self) -> Result<TaskId, MobError> {
+    self.apply_dsl_input(MobMachineInput::TaskCreate { task_id }, "task_create")?;
+    Ok(TaskId::new())
+}
+
+async fn handle_force_cancel(&mut self) -> Result<(), MobError> {
+    self.apply_dsl_input(MobMachineInput::ForceCancel, "force_cancel")?;
+    Ok(())
+}
+
+async fn dispatch(&mut self, command: MobCommand) {
+    match command {
+        MobCommand::SetSpawnPolicy { policy, reply_tx } => {
+            self.apply_dsl_input(MobMachineInput::SetSpawnPolicy, "set_spawn_policy")?;
+            self.spawn_policy.set(policy.clone()).await;
+            let _ = reply_tx.send(Ok(()));
+        }
+        _ => {}
+    }
+}
+"#,
+    )
+    .expect("write UFCS cancel before gate actor");
+
+    let mismatches = collect_mob_runtime_catalog_command_gate_mismatches(dir.path())
+        .expect("catalog command gate mismatches");
+    assert!(
+        mismatches.iter().any(|mismatch| {
+            mismatch.contains("MobCommand::CancelFlow")
+                && mismatch.contains("MobMachineInput::CancelFlow")
+        }),
+        "expected UFCS CancelFlow side effect before gate to be rejected, got {mismatches:#?}"
+    );
+}
+
+#[test]
+fn mob_runtime_catalog_command_gate_ratchet_rejects_ordered_helper_side_effect_before_gate() {
+    let dir = tempdir().expect("tempdir");
+    let runtime = dir.path().join("meerkat-mob/src/runtime");
+    fs::create_dir_all(&runtime).expect("create runtime dir");
+    fs::write(
+        runtime.join("actor.rs"),
+        r#"
+async fn handle_run_flow(&mut self) -> Result<RunId, MobError> {
+    self.apply_dsl_input(MobMachineInput::RunFlow, "run_flow")?;
+    Ok(RunId::new())
+}
+
+async fn handle_cancel_flow(&mut self) -> Result<(), MobError> {
+    self.apply_command_admission(MobMachineInput::CancelFlow, MobState::Running, "cancel_flow")?;
+    Ok(())
+}
+
+async fn a_task_create_gate(&mut self, task_id: TaskId) -> Result<(), MobError> {
+    self.apply_dsl_input(MobMachineInput::TaskCreate { task_id }, "task_create")?;
+    Ok(())
+}
+
+async fn z_task_create_side_effect(&mut self, task_id: TaskId) -> Result<(), MobError> {
+    self.task_board_service
+        .create_task_with_id(task_id.clone(), subject, description, blocked_by)
+        .await?;
+    Ok(())
+}
+
+async fn handle_task_create(&mut self, task_id: TaskId) -> Result<TaskId, MobError> {
+    self.z_task_create_side_effect(task_id.clone()).await?;
+    self.a_task_create_gate(task_id.clone()).await?;
+    Ok(task_id)
+}
+
+async fn handle_force_cancel(&mut self) -> Result<(), MobError> {
+    self.apply_dsl_input(MobMachineInput::ForceCancel, "force_cancel")?;
+    Ok(())
+}
+
+async fn dispatch(&mut self, command: MobCommand) {
+    match command {
+        MobCommand::SetSpawnPolicy { policy, reply_tx } => {
+            self.apply_dsl_input(MobMachineInput::SetSpawnPolicy, "set_spawn_policy")?;
+            self.spawn_policy.set(policy.clone()).await;
+            let _ = reply_tx.send(Ok(()));
+        }
+        _ => {}
+    }
+}
+"#,
+    )
+    .expect("write ordered helper side effect before gate actor");
+
+    let mismatches = collect_mob_runtime_catalog_command_gate_mismatches(dir.path())
+        .expect("catalog command gate mismatches");
+    assert!(
+        mismatches.iter().any(|mismatch| {
+            mismatch.contains("MobCommand::TaskCreate")
+                && mismatch.contains("MobMachineInput::TaskCreate")
+        }),
+        "expected helper side effect before later gate helper to be rejected, got {mismatches:#?}"
+    );
+}
+
+#[test]
+fn mob_runtime_catalog_command_gate_ratchet_rejects_ignored_helper_side_effect_before_gate() {
+    let dir = tempdir().expect("tempdir");
+    let runtime = dir.path().join("meerkat-mob/src/runtime");
+    fs::create_dir_all(&runtime).expect("create runtime dir");
+    fs::write(
+        runtime.join("actor.rs"),
+        r#"
+async fn handle_run_flow(&mut self) -> Result<RunId, MobError> {
+    self.apply_dsl_input(MobMachineInput::RunFlow, "run_flow")?;
+    Ok(RunId::new())
+}
+
+async fn handle_cancel_flow(&mut self) -> Result<(), MobError> {
+    self.apply_command_admission(MobMachineInput::CancelFlow, MobState::Running, "cancel_flow")?;
+    Ok(())
+}
+
+async fn a_task_create_gate(&mut self, task_id: TaskId) -> Result<(), MobError> {
+    self.apply_dsl_input(MobMachineInput::TaskCreate { task_id }, "task_create")?;
+    Ok(())
+}
+
+async fn z_task_create_side_effect(&mut self, task_id: TaskId) -> Result<(), MobError> {
+    self.task_board_service
+        .create_task_with_id(task_id.clone(), subject, description, blocked_by)
+        .await?;
+    Ok(())
+}
+
+async fn handle_task_create(&mut self, task_id: TaskId) -> Result<TaskId, MobError> {
+    let _ = self.z_task_create_side_effect(task_id.clone()).await;
+    self.a_task_create_gate(task_id.clone()).await?;
+    Ok(task_id)
+}
+
+async fn handle_force_cancel(&mut self) -> Result<(), MobError> {
+    self.apply_dsl_input(MobMachineInput::ForceCancel, "force_cancel")?;
+    Ok(())
+}
+
+async fn dispatch(&mut self, command: MobCommand) {
+    match command {
+        MobCommand::SetSpawnPolicy { policy, reply_tx } => {
+            self.apply_dsl_input(MobMachineInput::SetSpawnPolicy, "set_spawn_policy")?;
+            self.spawn_policy.set(policy.clone()).await;
+            let _ = reply_tx.send(Ok(()));
+        }
+        _ => {}
+    }
+}
+"#,
+    )
+    .expect("write ignored helper side effect before gate actor");
+
+    let mismatches = collect_mob_runtime_catalog_command_gate_mismatches(dir.path())
+        .expect("catalog command gate mismatches");
+    assert!(
+        mismatches.iter().any(|mismatch| {
+            mismatch.contains("MobCommand::TaskCreate")
+                && mismatch.contains("MobMachineInput::TaskCreate")
+        }),
+        "expected ignored helper side effect before later gate helper to be rejected, got {mismatches:#?}"
+    );
+}
+
+#[test]
+fn mob_runtime_catalog_command_gate_ratchet_rejects_fake_mob_run_run_flow_input() {
+    let dir = tempdir().expect("tempdir");
+    let runtime = dir.path().join("meerkat-mob/src/runtime");
+    fs::create_dir_all(&runtime).expect("create runtime dir");
+    fs::write(
+        runtime.join("actor.rs"),
+        r#"
+mod fake {
+    pub struct MobRun;
+
+    impl MobRun {
+        pub fn run_flow_input(_run_id: &RunId, _config: &FlowRunConfig) -> Result<MobMachineInput, MobError> {
+            Ok(MobMachineInput::CancelFlow)
+        }
+    }
+}
+
+async fn handle_run_flow(
+    &mut self,
+    flow_id: FlowId,
+    activation_params: serde_json::Value,
+) -> Result<RunId, MobError> {
+    let run_id = RunId::new();
+    let config = FlowRunConfig::from_definition(flow_id, &self.definition)?;
+    let run_flow = fake::MobRun::run_flow_input(&run_id, &config)?;
+    let prepared_run_flow = self.prepare_dsl_input(run_flow.clone(), "run_flow")?;
+    self.create_pending_run(
+        run_id.clone(),
+        &config,
+        &prepared_run_flow.authority.state,
+        activation_params.clone(),
+        vec![run_flow],
+    )
+    .await?;
+    self.commit_prepared_dsl_input(prepared_run_flow);
+    Ok(run_id)
+}
+
+async fn handle_cancel_flow(&mut self) -> Result<(), MobError> {
+    self.apply_command_admission(MobMachineInput::CancelFlow, MobState::Running, "cancel_flow")?;
+    Ok(())
+}
+
+async fn handle_task_create(&mut self) -> Result<TaskId, MobError> {
+    self.apply_dsl_input(MobMachineInput::TaskCreate { task_id }, "task_create")?;
+    Ok(TaskId::new())
+}
+
+async fn handle_force_cancel(&mut self) -> Result<(), MobError> {
+    self.apply_dsl_input(MobMachineInput::ForceCancel, "force_cancel")?;
+    Ok(())
+}
+
+async fn dispatch(&mut self, command: MobCommand) {
+    match command {
+        MobCommand::SetSpawnPolicy { policy, reply_tx } => {
+            self.apply_dsl_input(MobMachineInput::SetSpawnPolicy, "set_spawn_policy")?;
+            self.spawn_policy.set(policy.clone()).await;
+            let _ = reply_tx.send(Ok(()));
+        }
+        _ => {}
+    }
+}
+"#,
+    )
+    .expect("write fake MobRun run_flow_input actor");
+
+    let mismatches = collect_mob_runtime_catalog_command_gate_mismatches(dir.path())
+        .expect("catalog command gate mismatches");
+    assert!(
+        mismatches.iter().any(|mismatch| {
+            mismatch.contains("MobCommand::RunFlow")
+                && mismatch.contains("MobMachineInput::RunFlow")
+        }),
+        "expected fake MobRun::run_flow_input provenance to be rejected, got {mismatches:#?}"
+    );
+}
+
+#[test]
+fn mob_runtime_catalog_command_gate_ratchet_rejects_glob_imported_fake_mob_run_run_flow_input() {
+    let dir = tempdir().expect("tempdir");
+    let runtime = dir.path().join("meerkat-mob/src/runtime");
+    fs::create_dir_all(&runtime).expect("create runtime dir");
+    fs::write(
+        runtime.join("actor.rs"),
+        r#"
+mod fake {
+    pub struct MobRun;
+
+    impl MobRun {
+        pub fn run_flow_input(_run_id: &RunId, _config: &FlowRunConfig) -> Result<MobMachineInput, MobError> {
+            Ok(MobMachineInput::CancelFlow)
+        }
+    }
+}
+
+use fake::*;
+
+async fn handle_run_flow(
+    &mut self,
+    flow_id: FlowId,
+    activation_params: serde_json::Value,
+) -> Result<RunId, MobError> {
+    let run_id = RunId::new();
+    let config = FlowRunConfig::from_definition(flow_id, &self.definition)?;
+    let run_flow = MobRun::run_flow_input(&run_id, &config)?;
+    let prepared_run_flow = self.prepare_dsl_input(run_flow.clone(), "run_flow")?;
+    self.create_pending_run(
+        run_id.clone(),
+        &config,
+        &prepared_run_flow.authority.state,
+        activation_params.clone(),
+        vec![run_flow],
+    )
+    .await?;
+    self.commit_prepared_dsl_input(prepared_run_flow);
+    Ok(run_id)
+}
+
+async fn handle_cancel_flow(&mut self) -> Result<(), MobError> {
+    self.apply_command_admission(MobMachineInput::CancelFlow, MobState::Running, "cancel_flow")?;
+    Ok(())
+}
+
+async fn handle_task_create(&mut self) -> Result<TaskId, MobError> {
+    self.apply_dsl_input(MobMachineInput::TaskCreate { task_id }, "task_create")?;
+    Ok(TaskId::new())
+}
+
+async fn handle_force_cancel(&mut self) -> Result<(), MobError> {
+    self.apply_dsl_input(MobMachineInput::ForceCancel, "force_cancel")?;
+    Ok(())
+}
+
+async fn dispatch(&mut self, command: MobCommand) {
+    match command {
+        MobCommand::SetSpawnPolicy { policy, reply_tx } => {
+            self.apply_dsl_input(MobMachineInput::SetSpawnPolicy, "set_spawn_policy")?;
+            self.spawn_policy.set(policy.clone()).await;
+            let _ = reply_tx.send(Ok(()));
+        }
+        _ => {}
+    }
+}
+"#,
+    )
+    .expect("write glob imported fake MobRun run_flow_input actor");
+
+    let mismatches = collect_mob_runtime_catalog_command_gate_mismatches(dir.path())
+        .expect("catalog command gate mismatches");
+    assert!(
+        mismatches.iter().any(|mismatch| {
+            mismatch.contains("MobCommand::RunFlow")
+                && mismatch.contains("MobMachineInput::RunFlow")
+        }),
+        "expected glob-imported fake MobRun::run_flow_input provenance to be rejected, got {mismatches:#?}"
+    );
+}
+
+#[test]
+fn mob_runtime_catalog_command_gate_ratchet_rejects_run_flow_tracker_insert_before_gate() {
+    let dir = tempdir().expect("tempdir");
+    let runtime = dir.path().join("meerkat-mob/src/runtime");
+    fs::create_dir_all(&runtime).expect("create runtime dir");
+    fs::write(
+        runtime.join("actor.rs"),
+        r#"
+async fn handle_run_flow(&mut self) -> Result<RunId, MobError> {
+    let run_id = RunId::new();
+    let cancel_token = tokio_util::sync::CancellationToken::new();
+    self.run_cancel_tokens.insert(run_id.clone(), (cancel_token.clone(), flow_id.clone()));
+    self.flow_streams.lock().await.insert(run_id.clone(), scoped_event_tx);
+    self.apply_dsl_input(MobMachineInput::RunFlow, "run_flow")?;
+    Ok(run_id)
+}
+
+async fn handle_cancel_flow(&mut self) -> Result<(), MobError> {
+    self.apply_command_admission(MobMachineInput::CancelFlow, MobState::Running, "cancel_flow")?;
+    Ok(())
+}
+
+async fn handle_task_create(&mut self) -> Result<TaskId, MobError> {
+    self.apply_dsl_input(MobMachineInput::TaskCreate { task_id }, "task_create")?;
+    Ok(TaskId::new())
+}
+
+async fn handle_force_cancel(&mut self) -> Result<(), MobError> {
+    self.apply_dsl_input(MobMachineInput::ForceCancel, "force_cancel")?;
+    Ok(())
+}
+
+async fn dispatch(&mut self, command: MobCommand) {
+    match command {
+        MobCommand::SetSpawnPolicy { policy, reply_tx } => {
+            self.apply_dsl_input(MobMachineInput::SetSpawnPolicy, "set_spawn_policy")?;
+            self.spawn_policy.set(policy.clone()).await;
+            let _ = reply_tx.send(Ok(()));
+        }
+        _ => {}
+    }
+}
+"#,
+    )
+    .expect("write run flow tracker inserts before gate actor");
+
+    let mismatches = collect_mob_runtime_catalog_command_gate_mismatches(dir.path())
+        .expect("catalog command gate mismatches");
+    assert!(
+        mismatches.iter().any(|mismatch| {
+            mismatch.contains("MobCommand::RunFlow")
+                && mismatch.contains("MobMachineInput::RunFlow")
+        }),
+        "expected RunFlow tracker inserts before gate to be rejected, got {mismatches:#?}"
+    );
+}
+
+#[test]
+fn mob_runtime_catalog_command_gate_ratchet_rejects_run_flow_task_spawn_before_gate() {
+    let dir = tempdir().expect("tempdir");
+    let runtime = dir.path().join("meerkat-mob/src/runtime");
+    fs::create_dir_all(&runtime).expect("create runtime dir");
+    fs::write(
+        runtime.join("actor.rs"),
+        r#"
+async fn handle_run_flow(&mut self) -> Result<RunId, MobError> {
+    let run_id = RunId::new();
+    let handle = tokio::spawn(async move {
+        let _ = run_id.clone();
+    });
+    self.run_tasks.insert(run_id.clone(), handle);
+    self.apply_dsl_input(MobMachineInput::RunFlow, "run_flow")?;
+    Ok(run_id)
+}
+
+async fn handle_cancel_flow(&mut self) -> Result<(), MobError> {
+    self.apply_command_admission(MobMachineInput::CancelFlow, MobState::Running, "cancel_flow")?;
+    Ok(())
+}
+
+async fn handle_task_create(&mut self) -> Result<TaskId, MobError> {
+    self.apply_dsl_input(MobMachineInput::TaskCreate { task_id }, "task_create")?;
+    Ok(TaskId::new())
+}
+
+async fn handle_force_cancel(&mut self) -> Result<(), MobError> {
+    self.apply_dsl_input(MobMachineInput::ForceCancel, "force_cancel")?;
+    Ok(())
+}
+
+async fn dispatch(&mut self, command: MobCommand) {
+    match command {
+        MobCommand::SetSpawnPolicy { policy, reply_tx } => {
+            self.apply_dsl_input(MobMachineInput::SetSpawnPolicy, "set_spawn_policy")?;
+            self.spawn_policy.set(policy.clone()).await;
+            let _ = reply_tx.send(Ok(()));
+        }
+        _ => {}
+    }
+}
+"#,
+    )
+    .expect("write run flow task spawn before gate actor");
+
+    let mismatches = collect_mob_runtime_catalog_command_gate_mismatches(dir.path())
+        .expect("catalog command gate mismatches");
+    assert!(
+        mismatches.iter().any(|mismatch| {
+            mismatch.contains("MobCommand::RunFlow")
+                && mismatch.contains("MobMachineInput::RunFlow")
+        }),
+        "expected RunFlow task spawn before gate to be rejected, got {mismatches:#?}"
+    );
+}
+
+#[test]
+fn mob_runtime_catalog_command_gate_ratchet_rejects_cancel_flow_cleanup_before_gate() {
+    let dir = tempdir().expect("tempdir");
+    let runtime = dir.path().join("meerkat-mob/src/runtime");
+    fs::create_dir_all(&runtime).expect("create runtime dir");
+    fs::write(
+        runtime.join("actor.rs"),
+        r#"
+async fn handle_run_flow(&mut self) -> Result<RunId, MobError> {
+    self.apply_dsl_input(MobMachineInput::RunFlow, "run_flow")?;
+    Ok(RunId::new())
+}
+
+async fn handle_cancel_flow(&mut self, run_id: RunId) -> Result<(), MobError> {
+    self.flow_streams.lock().await.remove(&run_id);
+    self.apply_command_admission(MobMachineInput::CancelFlow, MobState::Running, "cancel_flow")?;
+    Ok(())
+}
+
+async fn handle_task_create(&mut self) -> Result<TaskId, MobError> {
+    self.apply_dsl_input(MobMachineInput::TaskCreate { task_id }, "task_create")?;
+    Ok(TaskId::new())
+}
+
+async fn handle_force_cancel(&mut self) -> Result<(), MobError> {
+    self.apply_dsl_input(MobMachineInput::ForceCancel, "force_cancel")?;
+    Ok(())
+}
+
+async fn dispatch(&mut self, command: MobCommand) {
+    match command {
+        MobCommand::SetSpawnPolicy { policy, reply_tx } => {
+            self.apply_dsl_input(MobMachineInput::SetSpawnPolicy, "set_spawn_policy")?;
+            self.spawn_policy.set(policy.clone()).await;
+            let _ = reply_tx.send(Ok(()));
+        }
+        _ => {}
+    }
+}
+"#,
+    )
+    .expect("write cancel flow cleanup before gate actor");
+
+    let mismatches = collect_mob_runtime_catalog_command_gate_mismatches(dir.path())
+        .expect("catalog command gate mismatches");
+    assert!(
+        mismatches.iter().any(|mismatch| {
+            mismatch.contains("MobCommand::CancelFlow")
+                && mismatch.contains("MobMachineInput::CancelFlow")
+        }),
+        "expected CancelFlow cleanup before gate to be rejected, got {mismatches:#?}"
+    );
+}
+
+#[test]
+fn mob_runtime_catalog_command_gate_ratchet_rejects_cancel_flow_token_cancel_before_gate() {
+    let dir = tempdir().expect("tempdir");
+    let runtime = dir.path().join("meerkat-mob/src/runtime");
+    fs::create_dir_all(&runtime).expect("create runtime dir");
+    fs::write(
+        runtime.join("actor.rs"),
+        r#"
+async fn handle_run_flow(&mut self) -> Result<RunId, MobError> {
+    self.apply_dsl_input(MobMachineInput::RunFlow, "run_flow")?;
+    Ok(RunId::new())
+}
+
+async fn handle_cancel_flow(&mut self, run_id: RunId) -> Result<(), MobError> {
+    let Some((cancel_token, _flow_id)) = self
+        .run_cancel_tokens
+        .get(&run_id)
+        .map(|(token, flow_id)| (token.clone(), flow_id.clone()))
+    else {
+        return Ok(());
+    };
+    cancel_token.cancel();
+    self.apply_command_admission(MobMachineInput::CancelFlow, MobState::Running, "cancel_flow")?;
+    Ok(())
+}
+
+async fn handle_task_create(&mut self) -> Result<TaskId, MobError> {
+    self.apply_dsl_input(MobMachineInput::TaskCreate { task_id }, "task_create")?;
+    Ok(TaskId::new())
+}
+
+async fn handle_force_cancel(&mut self) -> Result<(), MobError> {
+    self.apply_dsl_input(MobMachineInput::ForceCancel, "force_cancel")?;
+    Ok(())
+}
+
+async fn dispatch(&mut self, command: MobCommand) {
+    match command {
+        MobCommand::SetSpawnPolicy { policy, reply_tx } => {
+            self.apply_dsl_input(MobMachineInput::SetSpawnPolicy, "set_spawn_policy")?;
+            self.spawn_policy.set(policy.clone()).await;
+            let _ = reply_tx.send(Ok(()));
+        }
+        _ => {}
+    }
+}
+"#,
+    )
+    .expect("write cancel flow token cancel before gate actor");
+
+    let mismatches = collect_mob_runtime_catalog_command_gate_mismatches(dir.path())
+        .expect("catalog command gate mismatches");
+    assert!(
+        mismatches.iter().any(|mismatch| {
+            mismatch.contains("MobCommand::CancelFlow")
+                && mismatch.contains("MobMachineInput::CancelFlow")
+        }),
+        "expected CancelFlow token cancel before gate to be rejected, got {mismatches:#?}"
+    );
+}
+
+#[test]
+fn mob_runtime_catalog_command_gate_ratchet_rejects_cancel_flow_engine_cancel_before_gate() {
+    let dir = tempdir().expect("tempdir");
+    let runtime = dir.path().join("meerkat-mob/src/runtime");
+    fs::create_dir_all(&runtime).expect("create runtime dir");
+    fs::write(
+        runtime.join("actor.rs"),
+        r#"
+async fn handle_run_flow(&mut self) -> Result<RunId, MobError> {
+    self.apply_dsl_input(MobMachineInput::RunFlow, "run_flow")?;
+    Ok(RunId::new())
+}
+
+async fn handle_cancel_flow(&mut self, run_id: RunId) -> Result<(), MobError> {
+    let flow_engine = self.flow_engine.clone();
+    flow_engine.cancel_unfinished_steps(&run_id).await?;
+    self.apply_command_admission(MobMachineInput::CancelFlow, MobState::Running, "cancel_flow")?;
+    Ok(())
+}
+
+async fn handle_task_create(&mut self) -> Result<TaskId, MobError> {
+    self.apply_dsl_input(MobMachineInput::TaskCreate { task_id }, "task_create")?;
+    Ok(TaskId::new())
+}
+
+async fn handle_force_cancel(&mut self) -> Result<(), MobError> {
+    self.apply_dsl_input(MobMachineInput::ForceCancel, "force_cancel")?;
+    Ok(())
+}
+
+async fn dispatch(&mut self, command: MobCommand) {
+    match command {
+        MobCommand::SetSpawnPolicy { policy, reply_tx } => {
+            self.apply_dsl_input(MobMachineInput::SetSpawnPolicy, "set_spawn_policy")?;
+            self.spawn_policy.set(policy.clone()).await;
+            let _ = reply_tx.send(Ok(()));
+        }
+        _ => {}
+    }
+}
+"#,
+    )
+    .expect("write cancel flow engine cancel before gate actor");
+
+    let mismatches = collect_mob_runtime_catalog_command_gate_mismatches(dir.path())
+        .expect("catalog command gate mismatches");
+    assert!(
+        mismatches.iter().any(|mismatch| {
+            mismatch.contains("MobCommand::CancelFlow")
+                && mismatch.contains("MobMachineInput::CancelFlow")
+        }),
+        "expected CancelFlow engine cancel before gate to be rejected, got {mismatches:#?}"
+    );
+}
+
+#[test]
+fn mob_runtime_catalog_command_gate_ratchet_rejects_uncalled_mob_command_helpers() {
+    let dir = tempdir().expect("tempdir");
+    let runtime = dir.path().join("meerkat-mob/src/runtime");
+    fs::create_dir_all(&runtime).expect("create runtime dir");
+    fs::write(
+        runtime.join("actor.rs"),
+        r#"
+async fn handle_run_flow(&mut self) -> Result<RunId, MobError> {
+    Ok(RunId::new())
+}
+
+async fn handle_cancel_flow(&mut self) -> Result<(), MobError> {
+    self.apply_command_admission(MobMachineInput::CancelFlow, MobState::Running, "cancel_flow")?;
+    Ok(())
+}
+
+async fn handle_task_create(&mut self) -> Result<TaskId, MobError> {
+    self.prepare_command_admission(MobMachineInput::TaskCreate { task_id }, MobState::Running, "task_create")?;
+    Ok(TaskId::new())
+}
+
+async fn handle_force_cancel(&mut self) -> Result<(), MobError> {
+    self.preview_dsl_input(MobMachineInput::ForceCancel, "force_cancel")?;
+    self.apply_dsl_input(MobMachineInput::ForceCancel, "force_cancel")?;
+    Ok(())
+}
+
+async fn preview_command(&mut self, command: MobCommand) {
+    match command {
+        MobCommand::RunFlow { .. } => {
+            self.apply_dsl_input(MobMachineInput::RunFlow, "run_flow")?;
+        }
+        _ => {}
+    }
+}
+
+async fn dispatch(&mut self, command: MobCommand) {
+    match command {
+        MobCommand::SetSpawnPolicy { policy, reply_tx } => {
+            self.apply_dsl_input(MobMachineInput::SetSpawnPolicy, "set_spawn_policy")?;
+            self.spawn_policy.set(policy).await;
+            let _ = reply_tx.send(Ok(()));
+        }
+        _ => {}
+    }
+}
+"#,
+    )
+    .expect("write uncalled MobCommand helper actor");
+
+    let mismatches = collect_mob_runtime_catalog_command_gate_mismatches(dir.path())
+        .expect("catalog command gate mismatches");
+    assert!(
+        mismatches.iter().any(|mismatch| {
+            mismatch.contains("MobCommand::RunFlow")
+                && mismatch.contains("MobMachineInput::RunFlow")
+        }),
+        "expected uncalled MobCommand helper arm to be ignored and the ungated RunFlow handler rejected, got {mismatches:#?}"
+    );
+}
+
+#[test]
+fn mob_runtime_catalog_command_gate_ratchet_rejects_uncalled_run_command_helpers() {
+    let dir = tempdir().expect("tempdir");
+    let runtime = dir.path().join("meerkat-mob/src/runtime");
+    fs::create_dir_all(&runtime).expect("create runtime dir");
+    fs::write(
+        runtime.join("actor.rs"),
+        r#"
+async fn handle_run_flow(&mut self) -> Result<RunId, MobError> {
+    Ok(RunId::new())
+}
+
+async fn handle_cancel_flow(&mut self) -> Result<(), MobError> {
+    self.apply_command_admission(MobMachineInput::CancelFlow, MobState::Running, "cancel_flow")?;
+    Ok(())
+}
+
+async fn handle_task_create(&mut self) -> Result<TaskId, MobError> {
+    self.prepare_command_admission(MobMachineInput::TaskCreate { task_id }, MobState::Running, "task_create")?;
+    Ok(TaskId::new())
+}
+
+async fn handle_force_cancel(&mut self) -> Result<(), MobError> {
+    self.preview_dsl_input(MobMachineInput::ForceCancel, "force_cancel")?;
+    self.apply_dsl_input(MobMachineInput::ForceCancel, "force_cancel")?;
+    Ok(())
+}
+
+async fn run(&mut self, command: MobCommand) {
+    match command {
+        MobCommand::RunFlow { .. } => {
+            self.apply_dsl_input(MobMachineInput::RunFlow, "run_flow")?;
+        }
+        _ => {}
+    }
+}
+
+async fn dispatch(&mut self, command: MobCommand) {
+    match command {
+        MobCommand::SetSpawnPolicy { policy, reply_tx } => {
+            self.apply_dsl_input(MobMachineInput::SetSpawnPolicy, "set_spawn_policy")?;
+            self.spawn_policy.set(policy).await;
+            let _ = reply_tx.send(Ok(()));
+        }
+        _ => {}
+    }
+}
+"#,
+    )
+    .expect("write uncalled run MobCommand helper actor");
+
+    let mismatches = collect_mob_runtime_catalog_command_gate_mismatches(dir.path())
+        .expect("catalog command gate mismatches");
+    assert!(
+        mismatches.iter().any(|mismatch| {
+            mismatch.contains("MobCommand::RunFlow")
+                && mismatch.contains("MobMachineInput::RunFlow")
+        }),
+        "expected uncalled run(command: MobCommand) helper arm to be ignored and the ungated RunFlow handler rejected, got {mismatches:#?}"
+    );
+}
+
+#[test]
+fn mob_runtime_catalog_command_gate_ratchet_rejects_command_arm_ignored_handler_results() {
+    let dir = tempdir().expect("tempdir");
+    let runtime = dir.path().join("meerkat-mob/src/runtime");
+    fs::create_dir_all(&runtime).expect("create runtime dir");
+    fs::write(
+        runtime.join("actor.rs"),
+        r#"
+async fn handle_run_flow(&mut self) -> Result<RunId, MobError> {
+    self.apply_dsl_input(MobMachineInput::RunFlow, "run_flow")?;
+    Ok(RunId::new())
+}
+
+async fn handle_cancel_flow(&mut self) -> Result<(), MobError> {
+    self.apply_command_admission(MobMachineInput::CancelFlow, MobState::Running, "cancel_flow")?;
+    Ok(())
+}
+
+async fn handle_task_create(&mut self) -> Result<TaskId, MobError> {
+    self.prepare_command_admission(MobMachineInput::TaskCreate { task_id }, MobState::Running, "task_create")?;
+    Ok(TaskId::new())
+}
+
+async fn handle_force_cancel(&mut self) -> Result<(), MobError> {
+    self.preview_dsl_input(MobMachineInput::ForceCancel, "force_cancel")?;
+    self.apply_dsl_input(MobMachineInput::ForceCancel, "force_cancel")?;
+    Ok(())
+}
+
+async fn dispatch(&mut self, command: MobCommand) {
+    match command {
+        MobCommand::RunFlow { reply_tx, .. } => {
+            let _ = self.handle_run_flow().await;
+            let _ = reply_tx.send(Ok(RunId::new()));
+        }
+        MobCommand::SetSpawnPolicy { policy, reply_tx } => {
+            self.apply_dsl_input(MobMachineInput::SetSpawnPolicy, "set_spawn_policy")?;
+            self.spawn_policy.set(policy).await;
+            let _ = reply_tx.send(Ok(()));
+        }
+        _ => {}
+    }
+}
+"#,
+    )
+    .expect("write ignored handler result command arm actor");
+
+    let mismatches = collect_mob_runtime_catalog_command_gate_mismatches(dir.path())
+        .expect("catalog command gate mismatches");
+    assert!(
+        mismatches.iter().any(|mismatch| {
+            mismatch.contains("MobCommand::RunFlow")
+                && mismatch.contains("MobMachineInput::RunFlow")
+        }),
+        "expected command arm that ignores the gated handler result to be rejected, got {mismatches:#?}"
+    );
+}
+
+#[test]
+fn mob_runtime_catalog_command_gate_ratchet_rejects_conditional_handler_result_propagation() {
+    let dir = tempdir().expect("tempdir");
+    let runtime = dir.path().join("meerkat-mob/src/runtime");
+    fs::create_dir_all(&runtime).expect("create runtime dir");
+    fs::write(
+        runtime.join("actor.rs"),
+        r#"
+async fn handle_run_flow(&mut self) -> Result<RunId, MobError> {
+    self.apply_dsl_input(MobMachineInput::RunFlow, "run_flow")?;
+    Ok(RunId::new())
+}
+
+async fn handle_cancel_flow(&mut self) -> Result<(), MobError> {
+    self.apply_command_admission(MobMachineInput::CancelFlow, MobState::Running, "cancel_flow")?;
+    Ok(())
+}
+
+async fn handle_task_create(&mut self) -> Result<TaskId, MobError> {
+    self.prepare_command_admission(MobMachineInput::TaskCreate { task_id }, MobState::Running, "task_create")?;
+    Ok(TaskId::new())
+}
+
+async fn handle_force_cancel(&mut self) -> Result<(), MobError> {
+    self.preview_dsl_input(MobMachineInput::ForceCancel, "force_cancel")?;
+    self.apply_dsl_input(MobMachineInput::ForceCancel, "force_cancel")?;
+    Ok(())
+}
+
+async fn dispatch(&mut self, command: MobCommand, should_propagate: bool) {
+    match command {
+        MobCommand::RunFlow { reply_tx, .. } => {
+            if should_propagate {
+                let result = self.handle_run_flow().await;
+                let _ = reply_tx.send(result);
+            }
+            let _ = reply_tx.send(Ok(RunId::new()));
+        }
+        MobCommand::SetSpawnPolicy { policy, reply_tx } => {
+            self.apply_dsl_input(MobMachineInput::SetSpawnPolicy, "set_spawn_policy")?;
+            self.spawn_policy.set(policy).await;
+            let _ = reply_tx.send(Ok(()));
+        }
+        _ => {}
+    }
+}
+"#,
+    )
+    .expect("write conditional handler result propagation actor");
+
+    let mismatches = collect_mob_runtime_catalog_command_gate_mismatches(dir.path())
+        .expect("catalog command gate mismatches");
+    assert!(
+        mismatches.iter().any(|mismatch| {
+            mismatch.contains("MobCommand::RunFlow")
+                && mismatch.contains("MobMachineInput::RunFlow")
+        }),
+        "expected conditional RunFlow handler-result propagation to be rejected, got {mismatches:#?}"
+    );
+}
+
+#[test]
+fn mob_runtime_catalog_command_gate_ratchet_rejects_conditional_gate_only_handlers() {
+    let dir = tempdir().expect("tempdir");
+    let runtime = dir.path().join("meerkat-mob/src/runtime");
+    fs::create_dir_all(&runtime).expect("create runtime dir");
+    fs::write(
+        runtime.join("actor.rs"),
+        r#"
+async fn handle_run_flow(&mut self, should_gate: bool) -> Result<RunId, MobError> {
+    if should_gate {
+        self.apply_dsl_input(MobMachineInput::RunFlow, "run_flow")?;
+    }
+    Ok(RunId::new())
+}
+
+async fn handle_cancel_flow(&mut self) -> Result<(), MobError> {
+    self.apply_command_admission(MobMachineInput::CancelFlow, MobState::Running, "cancel_flow")?;
+    Ok(())
+}
+
+async fn handle_task_create(&mut self) -> Result<TaskId, MobError> {
+    self.prepare_command_admission(MobMachineInput::TaskCreate { task_id }, MobState::Running, "task_create")?;
+    Ok(TaskId::new())
+}
+
+async fn handle_force_cancel(&mut self) -> Result<(), MobError> {
+    self.preview_dsl_input(MobMachineInput::ForceCancel, "force_cancel")?;
+    self.apply_dsl_input(MobMachineInput::ForceCancel, "force_cancel")?;
+    Ok(())
+}
+
+async fn dispatch(&mut self, command: MobCommand) {
+    match command {
+        MobCommand::SetSpawnPolicy { policy, reply_tx } => {
+            self.apply_dsl_input(MobMachineInput::SetSpawnPolicy, "set_spawn_policy")?;
+            self.spawn_policy.set(policy).await;
+            let _ = reply_tx.send(Ok(()));
+        }
+        _ => {}
+    }
+}
+"#,
+    )
+    .expect("write conditional gate-only handler actor");
+
+    let mismatches = collect_mob_runtime_catalog_command_gate_mismatches(dir.path())
+        .expect("catalog command gate mismatches");
+    assert!(
+        mismatches.iter().any(|mismatch| {
+            mismatch.contains("MobCommand::RunFlow")
+                && mismatch.contains("MobMachineInput::RunFlow")
+        }),
+        "expected conditional-only RunFlow gate to be rejected, got {mismatches:#?}"
+    );
+}
+
+#[test]
+fn mob_runtime_catalog_command_gate_ratchet_rejects_deferred_gate_only_handlers() {
+    let dir = tempdir().expect("tempdir");
+    let runtime = dir.path().join("meerkat-mob/src/runtime");
+    fs::create_dir_all(&runtime).expect("create runtime dir");
+    fs::write(
+        runtime.join("actor.rs"),
+        r#"
+async fn handle_run_flow(&mut self) -> Result<RunId, MobError> {
+    let gate = || -> Result<(), MobError> {
+        self.apply_dsl_input(MobMachineInput::RunFlow, "run_flow")?;
+        Ok(())
+    };
+    let _ = gate;
+    Ok(RunId::new())
+}
+
+async fn handle_cancel_flow(&mut self) -> Result<(), MobError> {
+    self.apply_command_admission(MobMachineInput::CancelFlow, MobState::Running, "cancel_flow")?;
+    Ok(())
+}
+
+async fn handle_task_create(&mut self) -> Result<TaskId, MobError> {
+    self.prepare_command_admission(MobMachineInput::TaskCreate { task_id }, MobState::Running, "task_create")?;
+    Ok(TaskId::new())
+}
+
+async fn handle_force_cancel(&mut self) -> Result<(), MobError> {
+    self.preview_dsl_input(MobMachineInput::ForceCancel, "force_cancel")?;
+    self.apply_dsl_input(MobMachineInput::ForceCancel, "force_cancel")?;
+    Ok(())
+}
+
+async fn dispatch(&mut self, command: MobCommand) {
+    match command {
+        MobCommand::SetSpawnPolicy { policy, reply_tx } => {
+            self.apply_dsl_input(MobMachineInput::SetSpawnPolicy, "set_spawn_policy")?;
+            self.spawn_policy.set(policy).await;
+            let _ = reply_tx.send(Ok(()));
+        }
+        _ => {}
+    }
+}
+"#,
+    )
+    .expect("write deferred gate-only handler actor");
+
+    let mismatches = collect_mob_runtime_catalog_command_gate_mismatches(dir.path())
+        .expect("catalog command gate mismatches");
+    assert!(
+        mismatches.iter().any(|mismatch| {
+            mismatch.contains("MobCommand::RunFlow")
+                && mismatch.contains("MobMachineInput::RunFlow")
+        }),
+        "expected deferred-only RunFlow gate to be rejected, got {mismatches:#?}"
+    );
+}
+
+#[test]
 fn live_flow_runtime_reducer_transition_ratchet_accepts_typed_authority_wrappers() {
     let dir = tempdir().expect("tempdir");
     let run = dir.path().join("meerkat-mob/src/run.rs");
@@ -1014,6 +6038,856 @@ impl MobMachineFlowRunCommand {
 }
 
 #[test]
+fn live_flow_runtime_reducer_transition_ratchet_accepts_typed_authority_wrappers_with_module_declarations()
+ {
+    let dir = tempdir().expect("tempdir");
+    let run = dir.path().join("meerkat-mob/src/run.rs");
+    fs::create_dir_all(run.parent().expect("run parent")).expect("create run dir");
+    fs::write(
+        &run,
+        r"
+pub mod flow_frame;
+pub mod flow_run;
+pub mod loop_iteration;
+
+pub(crate) fn apply_mob_machine_flow_run_command(
+    state: &flow_run::State,
+    command: MobMachineFlowRunCommand,
+    authority: MobMachineFlowAuthorityToken,
+) -> Result<flow_run::Outcome, MobError> {
+    authority.require(MobMachineFlowAuthorityKind::FlowRun(command.kind()))?;
+    flow_run::transition(state, command.into_input(), &flow_run::EmptyContext)
+}
+
+impl MobMachineFlowRunCommand {
+    fn into_input(self) -> flow_run::Input {
+        match self {
+            Self::StartRun(payload) => flow_run::Input::StartRun(payload),
+        }
+    }
+}
+",
+    )
+    .expect("write typed wrapper with module declarations");
+
+    let mismatches = collect_direct_flow_reducer_transition_mismatches(dir.path())
+        .expect("flow reducer transition mismatches");
+    assert!(
+        mismatches.is_empty(),
+        "expected typed MobMachine authority wrapper with reducer module declarations to be accepted, got {mismatches:#?}"
+    );
+}
+
+#[test]
+fn live_flow_runtime_reducer_transition_ratchet_rejects_comment_spoofed_authority_wrapper() {
+    let dir = tempdir().expect("tempdir");
+    let run = dir.path().join("meerkat-mob/src/run.rs");
+    fs::create_dir_all(run.parent().expect("run parent")).expect("create run dir");
+    fs::write(
+        &run,
+        r"
+pub(crate) fn apply_mob_machine_flow_run_command(
+    state: &flow_run::State,
+    command: MobMachineFlowRunCommand,
+    authority: MobMachineFlowAuthorityToken,
+) -> Result<flow_run::Outcome, MobError> {
+    let _ = authority;
+    // authority.require(MobMachineFlowAuthorityKind::FlowRun(command.kind()))?;
+    flow_run::transition(state, command.into_input(), &flow_run::EmptyContext)
+}
+
+impl MobMachineFlowRunCommand {
+    fn into_input(self) -> flow_run::Input {
+        match self {
+            Self::StartRun(payload) => flow_run::Input::StartRun(payload),
+        }
+    }
+}
+",
+    )
+    .expect("write comment-spoofed authority wrapper");
+
+    let mismatches = collect_direct_flow_reducer_transition_mismatches(dir.path())
+        .expect("flow reducer transition mismatches");
+    assert!(
+        mismatches.iter().any(|mismatch| {
+            mismatch.contains("meerkat-mob/src/run.rs")
+                && mismatch.contains("flow_run::transition(")
+        }),
+        "expected comment-spoofed authority wrapper to be rejected, got {mismatches:#?}"
+    );
+}
+
+#[test]
+fn live_flow_runtime_reducer_transition_ratchet_rejects_nested_fake_authority_wrapper() {
+    let dir = tempdir().expect("tempdir");
+    let run = dir.path().join("meerkat-mob/src/run.rs");
+    fs::create_dir_all(run.parent().expect("run parent")).expect("create run dir");
+    fs::write(
+        &run,
+        r"
+mod spoof {
+    struct MobMachineFlowAuthorityToken;
+    struct MobMachineFlowRunCommand;
+
+    impl MobMachineFlowAuthorityToken {
+        fn require(&self, _kind: MobMachineFlowAuthorityKind) -> Result<(), MobError> {
+            Ok(())
+        }
+    }
+
+    impl MobMachineFlowRunCommand {
+        fn kind(&self) -> FlowRunReducerCommandKind {
+            FlowRunReducerCommandKind::StartRun
+        }
+
+        fn into_input(self) -> flow_run::Input {
+            flow_run::Input::StartRun(flow_run::inputs::StartRun {})
+        }
+    }
+
+    pub(crate) fn apply_mob_machine_flow_run_command(
+        state: &flow_run::State,
+        command: MobMachineFlowRunCommand,
+        authority: MobMachineFlowAuthorityToken,
+    ) -> Result<flow_run::Outcome, MobError> {
+        authority.require(MobMachineFlowAuthorityKind::FlowRun(command.kind()))?;
+        flow_run::transition(state, command.into_input(), &flow_run::EmptyContext)
+    }
+}
+",
+    )
+    .expect("write nested fake authority wrapper");
+
+    let mismatches = collect_direct_flow_reducer_transition_mismatches(dir.path())
+        .expect("flow reducer transition mismatches");
+    assert!(
+        mismatches.iter().any(|mismatch| {
+            mismatch.contains("meerkat-mob/src/run.rs")
+                && mismatch.contains("flow_run::transition(")
+        }),
+        "expected nested fake reducer authority wrapper to be rejected, got {mismatches:#?}"
+    );
+}
+
+#[test]
+fn live_flow_runtime_reducer_transition_ratchet_rejects_fake_reducer_module_inside_authority_wrapper()
+ {
+    let dir = tempdir().expect("tempdir");
+    let run = dir.path().join("meerkat-mob/src/run.rs");
+    fs::create_dir_all(run.parent().expect("run parent")).expect("create run dir");
+    fs::write(
+        &run,
+        r"
+mod fake {
+    pub mod flow_run {
+        pub struct State;
+        pub struct EmptyContext;
+        pub enum Input {
+            StartRun,
+        }
+        pub fn transition(
+            _state: &State,
+            _input: Input,
+            _ctx: &EmptyContext,
+        ) -> Result<Outcome, MobError> {
+            Ok(Outcome)
+        }
+        pub struct Outcome;
+    }
+}
+
+pub(crate) fn apply_mob_machine_flow_run_command(
+    state: &fake::flow_run::State,
+    command: MobMachineFlowRunCommand,
+    authority: MobMachineFlowAuthorityToken,
+) -> Result<fake::flow_run::Outcome, MobError> {
+    authority.require(MobMachineFlowAuthorityKind::FlowRun(command.kind()))?;
+    fake::flow_run::transition(state, command.into_input(), &fake::flow_run::EmptyContext)
+}
+
+impl MobMachineFlowRunCommand {
+    fn into_input(self) -> fake::flow_run::Input {
+        fake::flow_run::Input::StartRun
+    }
+}
+",
+    )
+    .expect("write fake reducer module inside authority wrapper");
+
+    let mismatches = collect_direct_flow_reducer_transition_mismatches(dir.path())
+        .expect("flow reducer transition mismatches");
+    assert!(
+        mismatches.iter().any(|mismatch| {
+            mismatch.contains("meerkat-mob/src/run.rs")
+                && mismatch.contains("fake::flow_run::transition(")
+        }),
+        "expected fake reducer module inside typed wrapper to be rejected, got {mismatches:#?}"
+    );
+}
+
+#[test]
+fn live_flow_runtime_reducer_transition_ratchet_rejects_block_local_aliases() {
+    let dir = tempdir().expect("tempdir");
+    let runtime = dir.path().join("meerkat-mob/src/runtime");
+    fs::create_dir_all(&runtime).expect("create runtime dir");
+    fs::write(
+        runtime.join("block_alias.rs"),
+        r"
+fn bad(state: &flow_run::State, input: flow_run::Input) -> Result<flow_run::Outcome, MobError> {
+    use crate::run::flow_run as fr;
+    fr::transition(state, input, &flow_run::EmptyContext)
+}
+",
+    )
+    .expect("write block-local alias reducer use");
+
+    let mismatches = collect_direct_flow_reducer_transition_mismatches(dir.path())
+        .expect("flow reducer transition mismatches");
+    assert!(
+        mismatches.iter().any(|mismatch| {
+            mismatch.contains("meerkat-mob/src/runtime/block_alias.rs")
+                && mismatch.contains("fr::transition(")
+        }),
+        "expected block-local reducer alias to be rejected, got {mismatches:#?}"
+    );
+}
+
+#[test]
+fn live_flow_runtime_reducer_transition_ratchet_rejects_parenthesized_transition_callees() {
+    let dir = tempdir().expect("tempdir");
+    let runtime = dir.path().join("meerkat-mob/src/runtime");
+    fs::create_dir_all(&runtime).expect("create runtime dir");
+    fs::write(
+        runtime.join("paren_callee.rs"),
+        r"
+fn bad(state: &flow_run::State, input: flow_run::Input) -> Result<flow_run::Outcome, MobError> {
+    (flow_run::transition)(state, input, &flow_run::EmptyContext)
+}
+",
+    )
+    .expect("write parenthesized reducer callee");
+
+    let mismatches = collect_direct_flow_reducer_transition_mismatches(dir.path())
+        .expect("flow reducer transition mismatches");
+    assert!(
+        mismatches.iter().any(|mismatch| {
+            mismatch.contains("meerkat-mob/src/runtime/paren_callee.rs")
+                && mismatch.contains("flow_run::transition(")
+        }),
+        "expected parenthesized reducer callee to be rejected, got {mismatches:#?}"
+    );
+}
+
+#[test]
+fn live_flow_runtime_reducer_transition_ratchet_rejects_wrapped_authority_parameters() {
+    let dir = tempdir().expect("tempdir");
+    let run = dir.path().join("meerkat-mob/src/run.rs");
+    fs::create_dir_all(run.parent().expect("run parent")).expect("create run dir");
+    fs::write(
+        &run,
+        r"
+pub(crate) fn apply_mob_machine_flow_run_command(
+    state: &flow_run::State,
+    command: Wrapper<MobMachineFlowRunCommand>,
+    authority: Wrapper<MobMachineFlowAuthorityToken>,
+) -> Result<flow_run::Outcome, MobError> {
+    authority.require(MobMachineFlowAuthorityKind::FlowRun(command.kind()))?;
+    flow_run::transition(state, command.into_input(), &flow_run::EmptyContext)
+}
+",
+    )
+    .expect("write wrapped authority parameters");
+
+    let mismatches = collect_direct_flow_reducer_transition_mismatches(dir.path())
+        .expect("flow reducer transition mismatches");
+    assert!(
+        mismatches.iter().any(|mismatch| {
+            mismatch.contains("meerkat-mob/src/run.rs")
+                && mismatch.contains("flow_run::transition(")
+        }),
+        "expected wrapped reducer authority/command parameters to be rejected, got {mismatches:#?}"
+    );
+}
+
+#[test]
+fn live_flow_runtime_reducer_transition_ratchet_rejects_fake_authority_kind_constructors() {
+    let dir = tempdir().expect("tempdir");
+    let run = dir.path().join("meerkat-mob/src/run.rs");
+    fs::create_dir_all(run.parent().expect("run parent")).expect("create run dir");
+    fs::write(
+        &run,
+        r"
+pub(crate) fn apply_mob_machine_flow_run_command(
+    state: &flow_run::State,
+    command: MobMachineFlowRunCommand,
+    authority: MobMachineFlowAuthorityToken,
+    hardcoded_kind: FlowRunReducerCommandKind,
+) -> Result<flow_run::Outcome, MobError> {
+    authority.require(MobMachineFlowAuthorityKind::FlowRun(fake_kind(command.kind(), hardcoded_kind)))?;
+    flow_run::transition(state, command.into_input(), &flow_run::EmptyContext)
+}
+
+impl MobMachineFlowRunCommand {
+    fn into_input(self) -> flow_run::Input {
+        match self {
+            Self::StartRun(payload) => flow_run::Input::StartRun(payload),
+        }
+    }
+}
+",
+    )
+    .expect("write fake authority kind constructor");
+
+    let mismatches = collect_direct_flow_reducer_transition_mismatches(dir.path())
+        .expect("flow reducer transition mismatches");
+    assert!(
+        mismatches.iter().any(|mismatch| {
+            mismatch.contains("meerkat-mob/src/run.rs")
+                && mismatch.contains("flow_run::transition(")
+        }),
+        "expected fake reducer authority kind constructor to be rejected, got {mismatches:#?}"
+    );
+}
+
+#[test]
+fn live_flow_runtime_reducer_transition_ratchet_rejects_fake_authority_kind_owner_path() {
+    let dir = tempdir().expect("tempdir");
+    let run = dir.path().join("meerkat-mob/src/run.rs");
+    fs::create_dir_all(run.parent().expect("run parent")).expect("create run dir");
+    fs::write(
+        &run,
+        r"
+mod fake {
+    pub(crate) enum MobMachineFlowAuthorityKind {
+        FlowRun(FlowRunReducerCommandKind),
+    }
+}
+
+pub(crate) fn apply_mob_machine_flow_run_command(
+    state: &flow_run::State,
+    command: MobMachineFlowRunCommand,
+    authority: MobMachineFlowAuthorityToken,
+) -> Result<flow_run::Outcome, MobError> {
+    authority.require(fake::MobMachineFlowAuthorityKind::FlowRun(command.kind()))?;
+    flow_run::transition(state, command.into_input(), &flow_run::EmptyContext)
+}
+
+impl MobMachineFlowRunCommand {
+    fn into_input(self) -> flow_run::Input {
+        match self {
+            Self::StartRun(payload) => flow_run::Input::StartRun(payload),
+        }
+    }
+}
+",
+    )
+    .expect("write fake authority kind owner path");
+
+    let mismatches = collect_direct_flow_reducer_transition_mismatches(dir.path())
+        .expect("flow reducer transition mismatches");
+    assert!(
+        mismatches.iter().any(|mismatch| {
+            mismatch.contains("meerkat-mob/src/run.rs")
+                && mismatch.contains("flow_run::transition(")
+        }),
+        "expected fake reducer authority kind owner path to be rejected, got {mismatches:#?}"
+    );
+}
+
+#[test]
+fn live_flow_runtime_reducer_transition_ratchet_rejects_ambiguous_glob_authority_kind_owner() {
+    let dir = tempdir().expect("tempdir");
+    let run = dir.path().join("meerkat-mob/src/run.rs");
+    fs::create_dir_all(run.parent().expect("run parent")).expect("create run dir");
+    fs::write(
+        &run,
+        r"
+mod fake {
+    pub(crate) enum MobMachineFlowAuthorityKind {
+        FlowRun(FlowRunReducerCommandKind),
+    }
+}
+use fake::*;
+
+pub(crate) fn apply_mob_machine_flow_run_command(
+    state: &flow_run::State,
+    command: MobMachineFlowRunCommand,
+    authority: MobMachineFlowAuthorityToken,
+) -> Result<flow_run::Outcome, MobError> {
+    authority.require(MobMachineFlowAuthorityKind::FlowRun(command.kind()))?;
+    flow_run::transition(state, command.into_input(), &flow_run::EmptyContext)
+}
+
+impl MobMachineFlowRunCommand {
+    fn into_input(self) -> flow_run::Input {
+        match self {
+            Self::StartRun(payload) => flow_run::Input::StartRun(payload),
+        }
+    }
+}
+",
+    )
+    .expect("write ambiguous glob authority kind owner");
+
+    let mismatches = collect_direct_flow_reducer_transition_mismatches(dir.path())
+        .expect("flow reducer transition mismatches");
+    assert!(
+        mismatches.iter().any(|mismatch| {
+            mismatch.contains("meerkat-mob/src/run.rs")
+                && mismatch.contains("flow_run::transition(")
+        }),
+        "expected ambiguous glob reducer authority kind owner to be rejected, got {mismatches:#?}"
+    );
+}
+
+#[test]
+fn live_flow_runtime_reducer_transition_ratchet_rejects_ignored_authority_require() {
+    let dir = tempdir().expect("tempdir");
+    let run = dir.path().join("meerkat-mob/src/run.rs");
+    fs::create_dir_all(run.parent().expect("run parent")).expect("create run dir");
+    fs::write(
+        &run,
+        r"
+pub(crate) fn apply_mob_machine_flow_run_command(
+    state: &flow_run::State,
+    command: MobMachineFlowRunCommand,
+    authority: MobMachineFlowAuthorityToken,
+) -> Result<flow_run::Outcome, MobError> {
+    let _ = authority.require(MobMachineFlowAuthorityKind::FlowRun(command.kind()));
+    flow_run::transition(state, command.into_input(), &flow_run::EmptyContext)
+}
+
+impl MobMachineFlowRunCommand {
+    fn into_input(self) -> flow_run::Input {
+        match self {
+            Self::StartRun(payload) => flow_run::Input::StartRun(payload),
+        }
+    }
+}
+",
+    )
+    .expect("write ignored authority wrapper");
+
+    let mismatches = collect_direct_flow_reducer_transition_mismatches(dir.path())
+        .expect("flow reducer transition mismatches");
+    assert!(
+        mismatches.iter().any(|mismatch| {
+            mismatch.contains("meerkat-mob/src/run.rs")
+                && mismatch.contains("flow_run::transition(")
+        }),
+        "expected ignored authority requirement to be rejected, got {mismatches:#?}"
+    );
+}
+
+#[test]
+fn live_flow_runtime_reducer_transition_ratchet_rejects_nested_result_authority_require() {
+    let dir = tempdir().expect("tempdir");
+    let run = dir.path().join("meerkat-mob/src/run.rs");
+    fs::create_dir_all(run.parent().expect("run parent")).expect("create run dir");
+    fs::write(
+        &run,
+        r"
+pub(crate) fn apply_mob_machine_flow_run_command(
+    state: &flow_run::State,
+    command: MobMachineFlowRunCommand,
+    authority: MobMachineFlowAuthorityToken,
+) -> Result<flow_run::Outcome, MobError> {
+    Ok(authority.require(MobMachineFlowAuthorityKind::FlowRun(command.kind())))?;
+    flow_run::transition(state, command.into_input(), &flow_run::EmptyContext)
+}
+
+impl MobMachineFlowRunCommand {
+    fn into_input(self) -> flow_run::Input {
+        match self {
+            Self::StartRun(payload) => flow_run::Input::StartRun(payload),
+        }
+    }
+}
+",
+    )
+    .expect("write nested result authority wrapper");
+
+    let mismatches = collect_direct_flow_reducer_transition_mismatches(dir.path())
+        .expect("flow reducer transition mismatches");
+    assert!(
+        mismatches.iter().any(|mismatch| {
+            mismatch.contains("meerkat-mob/src/run.rs")
+                && mismatch.contains("flow_run::transition(")
+        }),
+        "expected nested Result authority requirement not propagated by ? to be rejected, got {mismatches:#?}"
+    );
+}
+
+#[test]
+fn live_flow_runtime_reducer_transition_ratchet_rejects_fake_authority_receiver() {
+    let dir = tempdir().expect("tempdir");
+    let run = dir.path().join("meerkat-mob/src/run.rs");
+    fs::create_dir_all(run.parent().expect("run parent")).expect("create run dir");
+    fs::write(
+        &run,
+        r"
+pub(crate) fn apply_mob_machine_flow_run_command(
+    state: &flow_run::State,
+    command: MobMachineFlowRunCommand,
+    authority: MobMachineFlowAuthorityToken,
+    fake: FakeAuthority,
+) -> Result<flow_run::Outcome, MobError> {
+    let _ = authority;
+    fake.require(MobMachineFlowAuthorityKind::FlowRun(command.kind()))?;
+    flow_run::transition(state, command.into_input(), &flow_run::EmptyContext)
+}
+
+impl MobMachineFlowRunCommand {
+    fn into_input(self) -> flow_run::Input {
+        match self {
+            Self::StartRun(payload) => flow_run::Input::StartRun(payload),
+        }
+    }
+}
+",
+    )
+    .expect("write fake authority receiver wrapper");
+
+    let mismatches = collect_direct_flow_reducer_transition_mismatches(dir.path())
+        .expect("flow reducer transition mismatches");
+    assert!(
+        mismatches.iter().any(|mismatch| {
+            mismatch.contains("meerkat-mob/src/run.rs")
+                && mismatch.contains("flow_run::transition(")
+        }),
+        "expected fake authority receiver to be rejected, got {mismatches:#?}"
+    );
+}
+
+#[test]
+fn live_flow_runtime_reducer_transition_ratchet_rejects_conditional_authority_require() {
+    let dir = tempdir().expect("tempdir");
+    let run = dir.path().join("meerkat-mob/src/run.rs");
+    fs::create_dir_all(run.parent().expect("run parent")).expect("create run dir");
+    fs::write(
+        &run,
+        r"
+pub(crate) fn apply_mob_machine_flow_run_command(
+    state: &flow_run::State,
+    command: MobMachineFlowRunCommand,
+    authority: MobMachineFlowAuthorityToken,
+    should_require: bool,
+) -> Result<flow_run::Outcome, MobError> {
+    if should_require {
+        authority.require(MobMachineFlowAuthorityKind::FlowRun(command.kind()))?;
+    }
+    flow_run::transition(state, command.into_input(), &flow_run::EmptyContext)
+}
+
+impl MobMachineFlowRunCommand {
+    fn into_input(self) -> flow_run::Input {
+        match self {
+            Self::StartRun(payload) => flow_run::Input::StartRun(payload),
+        }
+    }
+}
+",
+    )
+    .expect("write conditional authority wrapper");
+
+    let mismatches = collect_direct_flow_reducer_transition_mismatches(dir.path())
+        .expect("flow reducer transition mismatches");
+    assert!(
+        mismatches.iter().any(|mismatch| {
+            mismatch.contains("meerkat-mob/src/run.rs")
+                && mismatch.contains("flow_run::transition(")
+        }),
+        "expected conditional authority requirement to be rejected, got {mismatches:#?}"
+    );
+}
+
+#[test]
+fn live_flow_runtime_reducer_transition_ratchet_rejects_shadowed_authority_bindings() {
+    let dir = tempdir().expect("tempdir");
+    let run = dir.path().join("meerkat-mob/src/run.rs");
+    fs::create_dir_all(run.parent().expect("run parent")).expect("create run dir");
+    fs::write(
+        &run,
+        r"
+pub(crate) fn apply_mob_machine_flow_run_command(
+    state: &flow_run::State,
+    command: MobMachineFlowRunCommand,
+    authority: MobMachineFlowAuthorityToken,
+    fake_command: FakeCommand,
+    fake_authority: FakeAuthority,
+) -> Result<flow_run::Outcome, MobError> {
+    let authority = fake_authority;
+    let command = fake_command;
+    authority.require(MobMachineFlowAuthorityKind::FlowRun(command.kind()))?;
+    flow_run::transition(state, command.into_input(), &flow_run::EmptyContext)
+}
+
+impl MobMachineFlowRunCommand {
+    fn into_input(self) -> flow_run::Input {
+        match self {
+            Self::StartRun(payload) => flow_run::Input::StartRun(payload),
+        }
+    }
+}
+",
+    )
+    .expect("write shadowed authority bindings");
+
+    let mismatches = collect_direct_flow_reducer_transition_mismatches(dir.path())
+        .expect("flow reducer transition mismatches");
+    assert!(
+        mismatches.iter().any(|mismatch| {
+            mismatch.contains("meerkat-mob/src/run.rs")
+                && mismatch.contains("flow_run::transition(")
+        }),
+        "expected shadowed reducer authority/command bindings to be rejected, got {mismatches:#?}"
+    );
+}
+
+#[test]
+fn live_flow_runtime_reducer_transition_ratchet_rejects_split_command_authority() {
+    let dir = tempdir().expect("tempdir");
+    let run = dir.path().join("meerkat-mob/src/run.rs");
+    fs::create_dir_all(run.parent().expect("run parent")).expect("create run dir");
+    fs::write(
+        &run,
+        r"
+pub(crate) fn apply_mob_machine_flow_run_command(
+    state: &flow_run::State,
+    required_command: MobMachineFlowRunCommand,
+    transitioned_command: MobMachineFlowRunCommand,
+    authority: MobMachineFlowAuthorityToken,
+) -> Result<flow_run::Outcome, MobError> {
+    authority.require(MobMachineFlowAuthorityKind::FlowRun(required_command.kind()))?;
+    flow_run::transition(state, transitioned_command.into_input(), &flow_run::EmptyContext)
+}
+
+impl MobMachineFlowRunCommand {
+    fn into_input(self) -> flow_run::Input {
+        match self {
+            Self::StartRun(payload) => flow_run::Input::StartRun(payload),
+        }
+    }
+}
+",
+    )
+    .expect("write split command authority");
+
+    let mismatches = collect_direct_flow_reducer_transition_mismatches(dir.path())
+        .expect("flow reducer transition mismatches");
+    assert!(
+        mismatches.iter().any(|mismatch| {
+            mismatch.contains("meerkat-mob/src/run.rs")
+                && mismatch.contains("flow_run::transition(")
+        }),
+        "expected transition input from a different command than the required command to be rejected, got {mismatches:#?}"
+    );
+}
+
+#[test]
+fn live_flow_runtime_reducer_transition_ratchet_rejects_deferred_authority_require() {
+    let dir = tempdir().expect("tempdir");
+    let run = dir.path().join("meerkat-mob/src/run.rs");
+    fs::create_dir_all(run.parent().expect("run parent")).expect("create run dir");
+    fs::write(
+        &run,
+        r"
+pub(crate) fn apply_mob_machine_flow_run_command(
+    state: &flow_run::State,
+    command: MobMachineFlowRunCommand,
+    authority: MobMachineFlowAuthorityToken,
+) -> Result<flow_run::Outcome, MobError> {
+    let require = || -> Result<(), MobError> {
+        authority.require(MobMachineFlowAuthorityKind::FlowRun(command.kind()))?;
+        Ok(())
+    };
+    let _ = require;
+    flow_run::transition(state, command.into_input(), &flow_run::EmptyContext)
+}
+
+impl MobMachineFlowRunCommand {
+    fn into_input(self) -> flow_run::Input {
+        match self {
+            Self::StartRun(payload) => flow_run::Input::StartRun(payload),
+        }
+    }
+}
+",
+    )
+    .expect("write deferred authority requirement");
+
+    let mismatches = collect_direct_flow_reducer_transition_mismatches(dir.path())
+        .expect("flow reducer transition mismatches");
+    assert!(
+        mismatches.iter().any(|mismatch| {
+            mismatch.contains("meerkat-mob/src/run.rs")
+                && mismatch.contains("flow_run::transition(")
+        }),
+        "expected deferred reducer authority requirement to be rejected, got {mismatches:#?}"
+    );
+}
+
+#[test]
+fn live_flow_runtime_reducer_transition_ratchet_rejects_nested_helper_authority_require() {
+    let dir = tempdir().expect("tempdir");
+    let run = dir.path().join("meerkat-mob/src/run.rs");
+    fs::create_dir_all(run.parent().expect("run parent")).expect("create run dir");
+    fs::write(
+        &run,
+        r"
+pub(crate) fn apply_mob_machine_flow_run_command(
+    state: &flow_run::State,
+    command: MobMachineFlowRunCommand,
+    authority: MobMachineFlowAuthorityToken,
+) -> Result<flow_run::Outcome, MobError> {
+    fn never_called(
+        command: MobMachineFlowRunCommand,
+        authority: MobMachineFlowAuthorityToken,
+    ) -> Result<(), MobError> {
+        authority.require(MobMachineFlowAuthorityKind::FlowRun(command.kind()))?;
+        Ok(())
+    }
+    let _ = never_called;
+    flow_run::transition(state, command.into_input(), &flow_run::EmptyContext)
+}
+
+impl MobMachineFlowRunCommand {
+    fn into_input(self) -> flow_run::Input {
+        match self {
+            Self::StartRun(payload) => flow_run::Input::StartRun(payload),
+        }
+    }
+}
+",
+    )
+    .expect("write nested helper authority requirement");
+
+    let mismatches = collect_direct_flow_reducer_transition_mismatches(dir.path())
+        .expect("flow reducer transition mismatches");
+    assert!(
+        mismatches.iter().any(|mismatch| {
+            mismatch.contains("meerkat-mob/src/run.rs")
+                && mismatch.contains("flow_run::transition(")
+        }),
+        "expected nested uncalled reducer authority helper to be rejected, got {mismatches:#?}"
+    );
+}
+
+#[test]
+fn live_flow_runtime_reducer_transition_ratchet_rejects_short_circuit_authority_require() {
+    let dir = tempdir().expect("tempdir");
+    let run = dir.path().join("meerkat-mob/src/run.rs");
+    fs::create_dir_all(run.parent().expect("run parent")).expect("create run dir");
+    fs::write(
+        &run,
+        r"
+pub(crate) fn apply_mob_machine_flow_run_command(
+    state: &flow_run::State,
+    command: MobMachineFlowRunCommand,
+    authority: MobMachineFlowAuthorityToken,
+    should_require: bool,
+) -> Result<flow_run::Outcome, MobError> {
+    let _ = should_require && {
+        authority.require(MobMachineFlowAuthorityKind::FlowRun(command.kind()))?;
+        true
+    };
+    flow_run::transition(state, command.into_input(), &flow_run::EmptyContext)
+}
+
+impl MobMachineFlowRunCommand {
+    fn into_input(self) -> flow_run::Input {
+        match self {
+            Self::StartRun(payload) => flow_run::Input::StartRun(payload),
+        }
+    }
+}
+",
+    )
+    .expect("write short-circuit authority requirement");
+
+    let mismatches = collect_direct_flow_reducer_transition_mismatches(dir.path())
+        .expect("flow reducer transition mismatches");
+    assert!(
+        mismatches.iter().any(|mismatch| {
+            mismatch.contains("meerkat-mob/src/run.rs")
+                && mismatch.contains("flow_run::transition(")
+        }),
+        "expected short-circuit reducer authority requirement to be rejected, got {mismatches:#?}"
+    );
+}
+
+#[test]
+fn live_flow_runtime_reducer_transition_ratchet_rejects_same_line_late_authority_require() {
+    let dir = tempdir().expect("tempdir");
+    let run = dir.path().join("meerkat-mob/src/run.rs");
+    fs::create_dir_all(run.parent().expect("run parent")).expect("create run dir");
+    fs::write(
+        &run,
+        r"
+pub(crate) fn apply_mob_machine_flow_run_command(
+    state: &flow_run::State,
+    command: MobMachineFlowRunCommand,
+    authority: MobMachineFlowAuthorityToken,
+) -> Result<flow_run::Outcome, MobError> {
+    let outcome = flow_run::transition(state, command.clone().into_input(), &flow_run::EmptyContext); authority.require(MobMachineFlowAuthorityKind::FlowRun(command.kind()))?; outcome
+}
+
+impl MobMachineFlowRunCommand {
+    fn into_input(self) -> flow_run::Input {
+        match self {
+            Self::StartRun(payload) => flow_run::Input::StartRun(payload),
+        }
+    }
+}
+",
+    )
+    .expect("write same-line late authority requirement");
+
+    let mismatches = collect_direct_flow_reducer_transition_mismatches(dir.path())
+        .expect("flow reducer transition mismatches");
+    assert!(
+        mismatches.iter().any(|mismatch| {
+            mismatch.contains("meerkat-mob/src/run.rs")
+                && mismatch.contains("flow_run::transition(")
+        }),
+        "expected same-line authority requirement after transition to be rejected, got {mismatches:#?}"
+    );
+}
+
+#[test]
+fn live_flow_runtime_reducer_transition_ratchet_rejects_untyped_transition_input() {
+    let dir = tempdir().expect("tempdir");
+    let run = dir.path().join("meerkat-mob/src/run.rs");
+    fs::create_dir_all(run.parent().expect("run parent")).expect("create run dir");
+    fs::write(
+        &run,
+        r"
+pub(crate) fn apply_mob_machine_flow_run_command(
+    state: &flow_run::State,
+    command: MobMachineFlowRunCommand,
+    authority: MobMachineFlowAuthorityToken,
+    input: flow_run::Input,
+) -> Result<flow_run::Outcome, MobError> {
+    authority.require(MobMachineFlowAuthorityKind::FlowRun(command.kind()))?;
+    flow_run::transition(state, input, &flow_run::EmptyContext)
+}
+",
+    )
+    .expect("write untyped transition input wrapper");
+
+    let mismatches = collect_direct_flow_reducer_transition_mismatches(dir.path())
+        .expect("flow reducer transition mismatches");
+    assert!(
+        mismatches.iter().any(|mismatch| {
+            mismatch.contains("meerkat-mob/src/run.rs")
+                && mismatch.contains("flow_run::transition(")
+        }),
+        "expected untyped transition input to be rejected, got {mismatches:#?}"
+    );
+}
+
+#[test]
 fn live_flow_runtime_projection_ratchet_accepts_typed_outcome_commits() {
     let dir = tempdir().expect("tempdir");
     let runtime = dir.path().join("meerkat-mob/src/runtime");
@@ -1021,10 +6895,19 @@ fn live_flow_runtime_projection_ratchet_accepts_typed_outcome_commits() {
     fs::write(
         runtime.join("flow.rs"),
         r"
-async fn good(run_store: Store, run_id: &RunId, run: MobRun, command: MobMachineFlowRunCommand, authority: MobMachineFlowAuthorityToken) -> Result<(), MobError> {
-    let outcome = apply_mob_machine_flow_run_command(&run.flow_state, command, authority)?;
+use crate::run::apply_mob_machine_flow_run_command;
+
+async fn good(run_store: Arc<dyn crate::store::MobRunStore>, run_id: &RunId, machine_state: &MobMachineState, run: MobRun, command: MobMachineFlowRunCommand, authority: MobMachineFlowAuthorityToken) -> Result<(), MobError> {
+    let authority_input = command.authority_input(run_id);
+    let outcome = apply_mob_machine_flow_run_command(
+        &run.flow_state,
+        &machine_state,
+        run_id,
+        command,
+        authority,
+    )?;
     run_store
-        .cas_flow_state(run_id, &run.flow_state, &outcome.next_state)
+        .cas_flow_state_with_authority(run_id, &run.flow_state, &outcome.next_state, vec![authority_input])
         .await?;
     Ok(())
 }
@@ -1041,7 +6924,4262 @@ async fn good(run_store: Store, run_id: &RunId, run: MobRun, command: MobMachine
 }
 
 #[test]
+fn live_flow_runtime_projection_ratchet_rejects_raw_cas_after_typed_outcome() {
+    let dir = tempdir().expect("tempdir");
+    let runtime = dir.path().join("meerkat-mob/src/runtime");
+    fs::create_dir_all(&runtime).expect("create runtime dir");
+    fs::write(
+        runtime.join("flow.rs"),
+        r"
+use crate::run::apply_mob_machine_flow_run_command;
+
+async fn bad(run_store: Arc<dyn crate::store::MobRunStore>, run_id: &RunId, machine_state: &MobMachineState, run: MobRun, command: MobMachineFlowRunCommand, authority: MobMachineFlowAuthorityToken) -> Result<(), MobError> {
+    let outcome = apply_mob_machine_flow_run_command(
+        &run.flow_state,
+        &machine_state,
+        run_id,
+        command,
+        authority,
+    )?;
+    run_store
+        .cas_flow_state(run_id, &run.flow_state, &outcome.next_state)
+        .await?;
+    Ok(())
+}
+",
+    )
+    .expect("write raw typed outcome commit");
+
+    let mismatches = collect_direct_flow_reducer_transition_mismatches(dir.path())
+        .expect("flow projection mutation mismatches");
+    assert!(
+        mismatches.iter().any(|mismatch| {
+            mismatch.contains("meerkat-mob/src/runtime/flow.rs")
+                && mismatch.contains(".cas_flow_state(")
+        }),
+        "expected raw CAS of a typed MobMachine flow outcome to be rejected, got {mismatches:#?}"
+    );
+}
+
+#[test]
+fn live_flow_runtime_projection_ratchet_rejects_fake_receiver_with_typed_authority_cas() {
+    let dir = tempdir().expect("tempdir");
+    let runtime = dir.path().join("meerkat-mob/src/runtime");
+    fs::create_dir_all(&runtime).expect("create runtime dir");
+    fs::write(
+        runtime.join("flow.rs"),
+        r"
+use crate::run::apply_mob_machine_flow_run_command;
+
+async fn bad(fake_store: FakeRunStore, run_id: &RunId, machine_state: &MobMachineState, run: MobRun, command: MobMachineFlowRunCommand, authority: MobMachineFlowAuthorityToken) -> Result<(), MobError> {
+    let authority_input = command.authority_input(run_id);
+    let outcome = apply_mob_machine_flow_run_command(
+        &run.flow_state,
+        &machine_state,
+        run_id,
+        command,
+        authority,
+    )?;
+    fake_store
+        .cas_flow_state_with_authority(run_id, &run.flow_state, &outcome.next_state, vec![authority_input])
+        .await?;
+    Ok(())
+}
+",
+    )
+    .expect("write fake receiver typed authority commit");
+
+    let mismatches = collect_direct_flow_reducer_transition_mismatches(dir.path())
+        .expect("flow projection mutation mismatches");
+    assert!(
+        mismatches.iter().any(|mismatch| {
+            mismatch.contains("meerkat-mob/src/runtime/flow.rs")
+                && mismatch.contains(".cas_flow_state_with_authority(")
+        }),
+        "expected typed authority CAS on a fake receiver to be rejected, got {mismatches:#?}"
+    );
+}
+
+#[test]
+fn live_flow_runtime_projection_ratchet_rejects_chained_fake_receiver_from_typed_run_store() {
+    let dir = tempdir().expect("tempdir");
+    let runtime = dir.path().join("meerkat-mob/src/runtime");
+    fs::create_dir_all(&runtime).expect("create runtime dir");
+    fs::write(
+        runtime.join("flow.rs"),
+        r"
+use crate::run::apply_mob_machine_flow_run_command;
+
+async fn bad(run_store: Arc<dyn crate::store::MobRunStore>, run_id: &RunId, machine_state: &MobMachineState, run: MobRun, command: MobMachineFlowRunCommand, authority: MobMachineFlowAuthorityToken) -> Result<(), MobError> {
+    let authority_input = command.authority_input(run_id);
+    let outcome = apply_mob_machine_flow_run_command(
+        &run.flow_state,
+        &machine_state,
+        run_id,
+        command,
+        authority,
+    )?;
+    run_store
+        .fake()
+        .cas_flow_state_with_authority(run_id, &run.flow_state, &outcome.next_state, vec![authority_input])
+        .await?;
+    Ok(())
+}
+",
+    )
+    .expect("write chained fake receiver typed authority commit");
+
+    let mismatches = collect_direct_flow_reducer_transition_mismatches(dir.path())
+        .expect("flow projection mutation mismatches");
+    assert!(
+        mismatches.iter().any(|mismatch| {
+            mismatch.contains("meerkat-mob/src/runtime/flow.rs")
+                && mismatch.contains(".cas_flow_state_with_authority(")
+        }),
+        "expected typed authority CAS through a chained fake receiver to be rejected, got {mismatches:#?}"
+    );
+}
+
+#[test]
+fn live_flow_runtime_projection_ratchet_rejects_fake_wrapper_parameter_containing_mob_run_store() {
+    let dir = tempdir().expect("tempdir");
+    let runtime = dir.path().join("meerkat-mob/src/runtime");
+    fs::create_dir_all(&runtime).expect("create runtime dir");
+    fs::write(
+        runtime.join("flow.rs"),
+        r"
+use crate::run::apply_mob_machine_flow_run_command;
+
+struct FakeStore<T>(T);
+
+async fn bad(run_store: FakeStore<Arc<dyn crate::store::MobRunStore>>, run_id: &RunId, machine_state: &MobMachineState, run: MobRun, command: MobMachineFlowRunCommand, authority: MobMachineFlowAuthorityToken) -> Result<(), MobError> {
+    let authority_input = command.authority_input(run_id);
+    let outcome = apply_mob_machine_flow_run_command(
+        &run.flow_state,
+        &machine_state,
+        run_id,
+        command,
+        authority,
+    )?;
+    run_store
+        .cas_flow_state_with_authority(run_id, &run.flow_state, &outcome.next_state, vec![authority_input])
+        .await?;
+    Ok(())
+}
+",
+    )
+    .expect("write fake wrapper parameter typed authority commit");
+
+    let mismatches = collect_direct_flow_reducer_transition_mismatches(dir.path())
+        .expect("flow projection mutation mismatches");
+    assert!(
+        mismatches.iter().any(|mismatch| {
+            mismatch.contains("meerkat-mob/src/runtime/flow.rs")
+                && mismatch.contains(".cas_flow_state_with_authority(")
+        }),
+        "expected typed authority CAS on a fake wrapper receiver to be rejected, got {mismatches:#?}"
+    );
+}
+
+#[test]
+fn live_flow_runtime_projection_ratchet_rejects_top_level_fake_apply_outcomes() {
+    let dir = tempdir().expect("tempdir");
+    let runtime = dir.path().join("meerkat-mob/src/runtime");
+    fs::create_dir_all(&runtime).expect("create runtime dir");
+    fs::write(
+        runtime.join("flow.rs"),
+        r"
+fn apply_mob_machine_flow_run_command(
+    _state: &flow_run::State,
+    _command: MobMachineFlowRunCommand,
+    _authority: MobMachineFlowAuthorityToken,
+) -> Result<FakeOutcome, MobError> {
+    Ok(FakeOutcome {
+        next_state: flow_run::State::default(),
+    })
+}
+
+async fn bad(run_store: Store, run_id: &RunId, run: MobRun, command: MobMachineFlowRunCommand, authority: MobMachineFlowAuthorityToken) -> Result<(), MobError> {
+    let outcome = apply_mob_machine_flow_run_command(&run.flow_state, command, authority)?;
+    run_store
+        .cas_flow_state(run_id, &run.flow_state, &outcome.next_state)
+        .await?;
+    Ok(())
+}
+",
+    )
+    .expect("write top-level fake apply outcome");
+
+    let mismatches = collect_direct_flow_reducer_transition_mismatches(dir.path())
+        .expect("flow projection mutation mismatches");
+    assert!(
+        mismatches.iter().any(|mismatch| {
+            mismatch.contains("meerkat-mob/src/runtime/flow.rs")
+                && mismatch.contains(".cas_flow_state(")
+        }),
+        "expected top-level fake flow-apply outcome to be rejected, got {mismatches:#?}"
+    );
+}
+
+#[test]
+fn live_flow_runtime_projection_ratchet_rejects_fake_run_module_apply_outcomes() {
+    let dir = tempdir().expect("tempdir");
+    let runtime = dir.path().join("meerkat-mob/src/runtime");
+    fs::create_dir_all(&runtime).expect("create runtime dir");
+    fs::write(
+        runtime.join("flow.rs"),
+        r"
+async fn bad(run_store: Store, run_id: &RunId, run: MobRun, command: MobMachineFlowRunCommand, authority: MobMachineFlowAuthorityToken) -> Result<(), MobError> {
+    let outcome = crate::fake::run::apply_mob_machine_flow_run_command(&run.flow_state, command, authority)?;
+    run_store
+        .cas_flow_state(run_id, &run.flow_state, &outcome.next_state)
+        .await?;
+    Ok(())
+}
+",
+    )
+    .expect("write fake run module apply outcome");
+
+    let mismatches = collect_direct_flow_reducer_transition_mismatches(dir.path())
+        .expect("flow projection mutation mismatches");
+    assert!(
+        mismatches.iter().any(|mismatch| {
+            mismatch.contains("meerkat-mob/src/runtime/flow.rs")
+                && mismatch.contains(".cas_flow_state(")
+        }),
+        "expected fake crate::fake::run flow-apply outcome to be rejected, got {mismatches:#?}"
+    );
+}
+
+#[test]
+fn live_flow_runtime_projection_ratchet_rejects_bare_run_module_fake_apply_outcomes() {
+    let dir = tempdir().expect("tempdir");
+    let runtime = dir.path().join("meerkat-mob/src/runtime");
+    fs::create_dir_all(&runtime).expect("create runtime dir");
+    fs::write(
+        runtime.join("flow.rs"),
+        r"
+mod run {
+    pub fn apply_mob_machine_flow_run_command(
+        _state: &flow_run::State,
+        _command: MobMachineFlowRunCommand,
+        _authority: MobMachineFlowAuthorityToken,
+    ) -> Result<FakeOutcome, MobError> {
+        Ok(FakeOutcome {
+            next_state: flow_run::State::default(),
+        })
+    }
+}
+
+async fn bad(run_store: Store, run_id: &RunId, run: MobRun, command: MobMachineFlowRunCommand, authority: MobMachineFlowAuthorityToken) -> Result<(), MobError> {
+    let outcome = run::apply_mob_machine_flow_run_command(&run.flow_state, command, authority)?;
+    run_store
+        .cas_flow_state(run_id, &run.flow_state, &outcome.next_state)
+        .await?;
+    Ok(())
+}
+",
+    )
+    .expect("write bare run:: fake apply outcome");
+
+    let mismatches = collect_direct_flow_reducer_transition_mismatches(dir.path())
+        .expect("flow projection mutation mismatches");
+    assert!(
+        mismatches.iter().any(|mismatch| {
+            mismatch.contains("meerkat-mob/src/runtime/flow.rs")
+                && mismatch.contains(".cas_flow_state(")
+        }),
+        "expected fake bare run:: flow-apply outcome to be rejected, got {mismatches:#?}"
+    );
+}
+
+#[test]
+fn live_flow_runtime_projection_ratchet_rejects_inner_scope_canonical_apply_alias_leak() {
+    let dir = tempdir().expect("tempdir");
+    let runtime = dir.path().join("meerkat-mob/src/runtime");
+    fs::create_dir_all(&runtime).expect("create runtime dir");
+    fs::write(
+        runtime.join("flow.rs"),
+        r"
+async fn bad(run_store: Store, run_id: &RunId, run: MobRun, command: MobMachineFlowRunCommand, authority: MobMachineFlowAuthorityToken) -> Result<(), MobError> {
+    {
+        use crate::run::apply_mob_machine_flow_run_command as apply;
+        let _ = ();
+    }
+    let outcome = apply(&run.flow_state, command, authority)?;
+    run_store
+        .cas_flow_state(run_id, &run.flow_state, &outcome.next_state)
+        .await?;
+    Ok(())
+}
+",
+    )
+    .expect("write inner-scope canonical apply alias leak");
+
+    let mismatches = collect_direct_flow_reducer_transition_mismatches(dir.path())
+        .expect("flow projection mutation mismatches");
+    assert!(
+        mismatches.iter().any(|mismatch| {
+            mismatch.contains("meerkat-mob/src/runtime/flow.rs")
+                && mismatch.contains(".cas_flow_state(")
+        }),
+        "expected inner-scope canonical flow-apply alias leak to be rejected, got {mismatches:#?}"
+    );
+}
+
+#[test]
+fn live_flow_runtime_projection_ratchet_rejects_nested_module_canonical_apply_alias_leak() {
+    let dir = tempdir().expect("tempdir");
+    let runtime = dir.path().join("meerkat-mob/src/runtime");
+    fs::create_dir_all(&runtime).expect("create runtime dir");
+    fs::write(
+        runtime.join("flow.rs"),
+        r"
+mod leak {
+    use crate::run::apply_mob_machine_flow_run_command;
+}
+
+fn apply_mob_machine_flow_run_command(
+    _state: &flow_run::State,
+    _command: MobMachineFlowRunCommand,
+    _authority: MobMachineFlowAuthorityToken,
+) -> Result<FakeOutcome, MobError> {
+    Ok(FakeOutcome {
+        next_state: flow_run::State::default(),
+    })
+}
+
+async fn bad(run_store: Store, run_id: &RunId, run: MobRun, command: MobMachineFlowRunCommand, authority: MobMachineFlowAuthorityToken) -> Result<(), MobError> {
+    let outcome = apply_mob_machine_flow_run_command(&run.flow_state, command, authority)?;
+    run_store
+        .cas_flow_state(run_id, &run.flow_state, &outcome.next_state)
+        .await?;
+    Ok(())
+}
+",
+    )
+    .expect("write nested module canonical apply alias leak");
+
+    let mismatches = collect_direct_flow_reducer_transition_mismatches(dir.path())
+        .expect("flow projection mutation mismatches");
+    assert!(
+        mismatches.iter().any(|mismatch| {
+            mismatch.contains("meerkat-mob/src/runtime/flow.rs")
+                && mismatch.contains(".cas_flow_state(")
+        }),
+        "expected nested module canonical flow-apply alias not to authorize sibling fake apply, got {mismatches:#?}"
+    );
+}
+
+#[test]
+fn live_flow_runtime_projection_ratchet_rejects_parent_alias_leaking_into_child_module() {
+    let dir = tempdir().expect("tempdir");
+    let runtime = dir.path().join("meerkat-mob/src/runtime");
+    fs::create_dir_all(&runtime).expect("create runtime dir");
+    fs::write(
+        runtime.join("flow.rs"),
+        r"
+use crate::run::apply_mob_machine_flow_run_command as apply;
+
+mod inner {
+    fn apply(
+        _state: &flow_run::State,
+        _command: MobMachineFlowRunCommand,
+        _authority: MobMachineFlowAuthorityToken,
+    ) -> Result<FakeOutcome, MobError> {
+        Ok(FakeOutcome {
+            next_state: flow_run::State::default(),
+        })
+    }
+
+    async fn bad(run_store: Store, run_id: &RunId, run: MobRun, command: MobMachineFlowRunCommand, authority: MobMachineFlowAuthorityToken) -> Result<(), MobError> {
+        let outcome = apply(&run.flow_state, command, authority)?;
+        run_store
+            .cas_flow_state(run_id, &run.flow_state, &outcome.next_state)
+            .await?;
+        Ok(())
+    }
+}
+",
+    )
+    .expect("write parent alias leaking into child module");
+
+    let mismatches = collect_direct_flow_reducer_transition_mismatches(dir.path())
+        .expect("flow projection mutation mismatches");
+    assert!(
+        mismatches.iter().any(|mismatch| {
+            mismatch.contains("meerkat-mob/src/runtime/flow.rs")
+                && mismatch.contains(".cas_flow_state(")
+        }),
+        "expected parent canonical apply alias not to authorize child-module fake apply, got {mismatches:#?}"
+    );
+}
+
+#[test]
+fn live_flow_runtime_projection_ratchet_rejects_self_run_module_fake_apply_outcomes() {
+    let dir = tempdir().expect("tempdir");
+    let runtime = dir.path().join("meerkat-mob/src/runtime");
+    fs::create_dir_all(&runtime).expect("create runtime dir");
+    fs::write(
+        runtime.join("flow.rs"),
+        r"
+mod run {
+    pub fn apply_mob_machine_flow_run_command(
+        _state: &flow_run::State,
+        _command: MobMachineFlowRunCommand,
+        _authority: MobMachineFlowAuthorityToken,
+    ) -> Result<FakeOutcome, MobError> {
+        Ok(FakeOutcome {
+            next_state: flow_run::State::default(),
+        })
+    }
+}
+
+async fn bad(run_store: Store, run_id: &RunId, run: MobRun, command: MobMachineFlowRunCommand, authority: MobMachineFlowAuthorityToken) -> Result<(), MobError> {
+    let outcome = self::run::apply_mob_machine_flow_run_command(&run.flow_state, command, authority)?;
+    run_store
+        .cas_flow_state(run_id, &run.flow_state, &outcome.next_state)
+        .await?;
+    Ok(())
+}
+",
+    )
+    .expect("write self::run fake apply outcome");
+
+    let mismatches = collect_direct_flow_reducer_transition_mismatches(dir.path())
+        .expect("flow projection mutation mismatches");
+    assert!(
+        mismatches.iter().any(|mismatch| {
+            mismatch.contains("meerkat-mob/src/runtime/flow.rs")
+                && mismatch.contains(".cas_flow_state(")
+        }),
+        "expected fake self::run flow-apply outcome to be rejected, got {mismatches:#?}"
+    );
+}
+
+#[test]
+fn live_flow_runtime_projection_ratchet_rejects_reassigned_typed_outcomes() {
+    let dir = tempdir().expect("tempdir");
+    let runtime = dir.path().join("meerkat-mob/src/runtime");
+    fs::create_dir_all(&runtime).expect("create runtime dir");
+    fs::write(
+        runtime.join("flow.rs"),
+        r"
+use crate::run::apply_mob_machine_flow_run_command;
+
+async fn bad(run_store: Store, run_id: &RunId, run: MobRun, command: MobMachineFlowRunCommand, authority: MobMachineFlowAuthorityToken) -> Result<(), MobError> {
+    let mut outcome = apply_mob_machine_flow_run_command(&run.flow_state, command, authority)?;
+    outcome = FakeOutcome {
+        next_state: flow_run::State::default(),
+    };
+    run_store
+        .cas_flow_state(run_id, &run.flow_state, &outcome.next_state)
+        .await?;
+    Ok(())
+}
+",
+    )
+    .expect("write reassigned typed outcome");
+
+    let mismatches = collect_direct_flow_reducer_transition_mismatches(dir.path())
+        .expect("flow projection mutation mismatches");
+    assert!(
+        mismatches.iter().any(|mismatch| {
+            mismatch.contains("meerkat-mob/src/runtime/flow.rs")
+                && mismatch.contains(".cas_flow_state(")
+        }),
+        "expected reassigned typed flow outcome to be rejected, got {mismatches:#?}"
+    );
+}
+
+#[test]
+fn live_flow_runtime_projection_ratchet_rejects_mutated_typed_outcome_next_state() {
+    let dir = tempdir().expect("tempdir");
+    let runtime = dir.path().join("meerkat-mob/src/runtime");
+    fs::create_dir_all(&runtime).expect("create runtime dir");
+    fs::write(
+        runtime.join("flow.rs"),
+        r"
+use crate::run::apply_mob_machine_flow_run_command;
+
+async fn bad(run_store: Store, run_id: &RunId, run: MobRun, command: MobMachineFlowRunCommand, authority: MobMachineFlowAuthorityToken) -> Result<(), MobError> {
+    let mut outcome = apply_mob_machine_flow_run_command(&run.flow_state, command, authority)?;
+    outcome.next_state = flow_run::State::default();
+    run_store
+        .cas_flow_state(run_id, &run.flow_state, &outcome.next_state)
+        .await?;
+    Ok(())
+}
+",
+    )
+    .expect("write mutated typed outcome next_state");
+
+    let mismatches = collect_direct_flow_reducer_transition_mismatches(dir.path())
+        .expect("flow projection mutation mismatches");
+    assert!(
+        mismatches.iter().any(|mismatch| {
+            mismatch.contains("meerkat-mob/src/runtime/flow.rs")
+                && mismatch.contains(".cas_flow_state(")
+        }),
+        "expected typed flow outcome with mutated next_state to be rejected, got {mismatches:#?}"
+    );
+}
+
+#[test]
+fn live_flow_runtime_projection_ratchet_rejects_method_mutated_typed_outcome_next_state() {
+    let dir = tempdir().expect("tempdir");
+    let runtime = dir.path().join("meerkat-mob/src/runtime");
+    fs::create_dir_all(&runtime).expect("create runtime dir");
+    fs::write(
+        runtime.join("flow.rs"),
+        r"
+use crate::run::apply_mob_machine_flow_run_command;
+
+async fn bad(run_store: Store, run_id: &RunId, run: MobRun, command: MobMachineFlowRunCommand, authority: MobMachineFlowAuthorityToken, frame_id: FrameId) -> Result<(), MobError> {
+    let mut outcome = apply_mob_machine_flow_run_command(&run.flow_state, command, authority)?;
+    outcome.next_state.ready_frames.push(frame_id);
+    run_store
+        .cas_flow_state(run_id, &run.flow_state, &outcome.next_state)
+        .await?;
+    Ok(())
+}
+",
+    )
+    .expect("write method-mutated typed outcome next_state");
+
+    let mismatches = collect_direct_flow_reducer_transition_mismatches(dir.path())
+        .expect("flow projection mutation mismatches");
+    assert!(
+        mismatches.iter().any(|mismatch| {
+            mismatch.contains("meerkat-mob/src/runtime/flow.rs")
+                && mismatch.contains(".cas_flow_state(")
+        }),
+        "expected typed flow outcome with method-mutated next_state to be rejected, got {mismatches:#?}"
+    );
+}
+
+#[test]
+fn live_flow_runtime_projection_ratchet_rejects_method_mutated_typed_next_state_alias() {
+    let dir = tempdir().expect("tempdir");
+    let runtime = dir.path().join("meerkat-mob/src/runtime");
+    fs::create_dir_all(&runtime).expect("create runtime dir");
+    fs::write(
+        runtime.join("flow.rs"),
+        r"
+use crate::run::apply_mob_machine_flow_run_command;
+
+async fn bad(run_store: Store, run_id: &RunId, run: MobRun, command: MobMachineFlowRunCommand, authority: MobMachineFlowAuthorityToken, frame_id: FrameId) -> Result<(), MobError> {
+    let mut next_state = apply_mob_machine_flow_run_command(&run.flow_state, command, authority)?.next_state;
+    next_state.ready_frames.push(frame_id);
+    run_store
+        .cas_flow_state(run_id, &run.flow_state, &next_state)
+        .await?;
+    Ok(())
+}
+",
+    )
+    .expect("write method-mutated typed next_state alias");
+
+    let mismatches = collect_direct_flow_reducer_transition_mismatches(dir.path())
+        .expect("flow projection mutation mismatches");
+    assert!(
+        mismatches.iter().any(|mismatch| {
+            mismatch.contains("meerkat-mob/src/runtime/flow.rs")
+                && mismatch.contains(".cas_flow_state(")
+        }),
+        "expected method-mutated typed next_state alias to be rejected, got {mismatches:#?}"
+    );
+}
+
+#[test]
+fn live_flow_runtime_projection_ratchet_rejects_unlisted_method_mutated_typed_next_state() {
+    let dir = tempdir().expect("tempdir");
+    let runtime = dir.path().join("meerkat-mob/src/runtime");
+    fs::create_dir_all(&runtime).expect("create runtime dir");
+    fs::write(
+        runtime.join("flow.rs"),
+        r"
+use crate::run::apply_mob_machine_flow_run_command;
+
+async fn bad(run_store: Store, run_id: &RunId, run: MobRun, command: MobMachineFlowRunCommand, authority: MobMachineFlowAuthorityToken) -> Result<(), MobError> {
+    let mut next_state = apply_mob_machine_flow_run_command(&run.flow_state, command, authority)?.next_state;
+    next_state.ready_frames.truncate(0);
+    run_store
+        .cas_flow_state(run_id, &run.flow_state, &next_state)
+        .await?;
+    Ok(())
+}
+",
+    )
+    .expect("write unlisted method-mutated typed next_state");
+
+    let mismatches = collect_direct_flow_reducer_transition_mismatches(dir.path())
+        .expect("flow projection mutation mismatches");
+    assert!(
+        mismatches.iter().any(|mismatch| {
+            mismatch.contains("meerkat-mob/src/runtime/flow.rs")
+                && mismatch.contains(".cas_flow_state(")
+        }),
+        "expected unlisted method-mutated typed next_state to be rejected, got {mismatches:#?}"
+    );
+}
+
+#[test]
+fn live_flow_runtime_projection_ratchet_rejects_inner_shadowed_next_state_alias() {
+    let dir = tempdir().expect("tempdir");
+    let runtime = dir.path().join("meerkat-mob/src/runtime");
+    fs::create_dir_all(&runtime).expect("create runtime dir");
+    fs::write(
+        runtime.join("flow.rs"),
+        r"
+use crate::run::apply_mob_machine_flow_run_command;
+
+async fn bad(run_store: Store, run_id: &RunId, run: MobRun, command: MobMachineFlowRunCommand, authority: MobMachineFlowAuthorityToken) -> Result<(), MobError> {
+    let next_state = flow_run::State::default();
+    {
+        let next_state = apply_mob_machine_flow_run_command(&run.flow_state, command, authority)?.next_state;
+        let _ = next_state;
+    }
+    run_store
+        .cas_flow_state(run_id, &run.flow_state, &next_state)
+        .await?;
+    Ok(())
+}
+",
+    )
+    .expect("write inner shadowed next-state alias");
+
+    let mismatches = collect_direct_flow_reducer_transition_mismatches(dir.path())
+        .expect("flow projection mutation mismatches");
+    assert!(
+        mismatches.iter().any(|mismatch| {
+            mismatch.contains("meerkat-mob/src/runtime/flow.rs")
+                && mismatch.contains(".cas_flow_state(")
+        }),
+        "expected inner shadowed typed next_state alias not to authorize outer CAS, got {mismatches:#?}"
+    );
+}
+
+#[test]
+fn live_flow_runtime_projection_ratchet_rejects_with_authority_cas_without_authority_inputs() {
+    let dir = tempdir().expect("tempdir");
+    let runtime = dir.path().join("meerkat-mob/src/runtime");
+    fs::create_dir_all(&runtime).expect("create runtime dir");
+    fs::write(
+        runtime.join("flow.rs"),
+        r"
+use crate::run::apply_mob_machine_flow_run_command;
+
+async fn bad(run_store: Store, run_id: &RunId, run: MobRun, command: MobMachineFlowRunCommand, authority: MobMachineFlowAuthorityToken) -> Result<(), MobError> {
+    let outcome = apply_mob_machine_flow_run_command(&run.flow_state, command.clone(), authority)?;
+    run_store
+        .cas_flow_state_with_authority(run_id, &run.flow_state, &outcome.next_state, vec![])
+        .await?;
+    Ok(())
+}
+",
+    )
+    .expect("write empty with-authority CAS commit");
+
+    let mismatches = collect_direct_flow_reducer_transition_mismatches(dir.path())
+        .expect("flow projection mutation mismatches");
+    assert!(
+        mismatches.iter().any(|mismatch| {
+            mismatch.contains("meerkat-mob/src/runtime/flow.rs")
+                && mismatch.contains(".cas_flow_state_with_authority(")
+        }),
+        "expected with-authority CAS without matching authority inputs to be rejected, got {mismatches:#?}"
+    );
+}
+
+#[test]
+fn live_flow_runtime_projection_ratchet_rejects_with_authority_cas_with_mismatched_authority_input()
+{
+    let dir = tempdir().expect("tempdir");
+    let runtime = dir.path().join("meerkat-mob/src/runtime");
+    fs::create_dir_all(&runtime).expect("create runtime dir");
+    fs::write(
+        runtime.join("flow.rs"),
+        r"
+use crate::run::apply_mob_machine_flow_run_command;
+
+async fn bad(run_store: Store, run_id: &RunId, run: MobRun, command: MobMachineFlowRunCommand, other_command: MobMachineFlowRunCommand, authority: MobMachineFlowAuthorityToken) -> Result<(), MobError> {
+    let outcome = apply_mob_machine_flow_run_command(&run.flow_state, command.clone(), authority)?;
+    let authority_input = other_command.authority_input(run_id);
+    run_store
+        .cas_flow_state_with_authority(
+            run_id,
+            &run.flow_state,
+            &outcome.next_state,
+            vec![authority_input],
+        )
+        .await?;
+    Ok(())
+}
+",
+    )
+    .expect("write mismatched with-authority CAS commit");
+
+    let mismatches = collect_direct_flow_reducer_transition_mismatches(dir.path())
+        .expect("flow projection mutation mismatches");
+    assert!(
+        mismatches.iter().any(|mismatch| {
+            mismatch.contains("meerkat-mob/src/runtime/flow.rs")
+                && mismatch.contains(".cas_flow_state_with_authority(")
+        }),
+        "expected with-authority CAS with mismatched authority input to be rejected, got {mismatches:#?}"
+    );
+}
+
+#[test]
+fn live_flow_runtime_projection_ratchet_rejects_with_authority_cas_with_wrong_run_id_input() {
+    let dir = tempdir().expect("tempdir");
+    let runtime = dir.path().join("meerkat-mob/src/runtime");
+    fs::create_dir_all(&runtime).expect("create runtime dir");
+    fs::write(
+        runtime.join("flow.rs"),
+        r"
+use crate::run::apply_mob_machine_flow_run_command;
+
+async fn bad(run_store: Store, run_id: &RunId, other_run_id: &RunId, run: MobRun, command: MobMachineFlowRunCommand, authority: MobMachineFlowAuthorityToken) -> Result<(), MobError> {
+    let outcome = apply_mob_machine_flow_run_command(&run.flow_state, command.clone(), authority)?;
+    let authority_input = command.authority_input(other_run_id);
+    run_store
+        .cas_flow_state_with_authority(
+            run_id,
+            &run.flow_state,
+            &outcome.next_state,
+            vec![authority_input],
+        )
+        .await?;
+    Ok(())
+}
+",
+    )
+    .expect("write wrong-run-id with-authority CAS commit");
+
+    let mismatches = collect_direct_flow_reducer_transition_mismatches(dir.path())
+        .expect("flow projection mutation mismatches");
+    assert!(
+        mismatches.iter().any(|mismatch| {
+            mismatch.contains("meerkat-mob/src/runtime/flow.rs")
+                && mismatch.contains(".cas_flow_state_with_authority(")
+        }),
+        "expected authority input identity to match the CAS run_id, got {mismatches:#?}"
+    );
+}
+
+#[test]
+fn live_flow_runtime_projection_ratchet_rejects_apply_run_id_mismatched_with_cas_identity() {
+    let dir = tempdir().expect("tempdir");
+    let runtime = dir.path().join("meerkat-mob/src/runtime");
+    fs::create_dir_all(&runtime).expect("create runtime dir");
+    fs::write(
+        runtime.join("flow.rs"),
+        r"
+use crate::run::apply_mob_machine_flow_run_command;
+
+async fn bad(
+    run_store: Store,
+    run_id: &RunId,
+    other_run_id: &RunId,
+    machine_state: &MobMachineState,
+    run: MobRun,
+    command: MobMachineFlowRunCommand,
+    authority: MobMachineFlowAuthorityToken,
+) -> Result<(), MobError> {
+    let outcome = apply_mob_machine_flow_run_command(
+        &run.flow_state,
+        machine_state,
+        other_run_id,
+        command,
+        authority,
+    )?;
+    run_store
+        .cas_flow_state(run_id, &run.flow_state, &outcome.next_state)
+        .await?;
+    Ok(())
+}
+",
+    )
+    .expect("write apply-run-id mismatched CAS identity");
+
+    let mismatches = collect_direct_flow_reducer_transition_mismatches(dir.path())
+        .expect("flow projection mutation mismatches");
+    assert!(
+        mismatches.iter().any(|mismatch| {
+            mismatch.contains("meerkat-mob/src/runtime/flow.rs")
+                && mismatch.contains(".cas_flow_state(")
+        }),
+        "expected typed flow outcome computed with another RunId to be rejected, got {mismatches:#?}"
+    );
+}
+
+#[test]
+fn live_flow_runtime_projection_ratchet_rejects_apply_run_id_from_local_identity() {
+    let dir = tempdir().expect("tempdir");
+    let runtime = dir.path().join("meerkat-mob/src/runtime");
+    fs::create_dir_all(&runtime).expect("create runtime dir");
+    fs::write(
+        runtime.join("flow.rs"),
+        r"
+use crate::run::apply_mob_machine_flow_run_command;
+
+async fn bad(
+    run_store: Store,
+    run_id: &RunId,
+    machine_state: &MobMachineState,
+    run: MobRun,
+    command: MobMachineFlowRunCommand,
+    authority: MobMachineFlowAuthorityToken,
+) -> Result<(), MobError> {
+    let forged_run_id = RunId::new();
+    let outcome = apply_mob_machine_flow_run_command(
+        &run.flow_state,
+        machine_state,
+        &forged_run_id,
+        command,
+        authority,
+    )?;
+    run_store
+        .cas_flow_state(run_id, &run.flow_state, &outcome.next_state)
+        .await?;
+    Ok(())
+}
+",
+    )
+    .expect("write local apply-run-id CAS identity");
+
+    let mismatches = collect_direct_flow_reducer_transition_mismatches(dir.path())
+        .expect("flow projection mutation mismatches");
+    assert!(
+        mismatches.iter().any(|mismatch| {
+            mismatch.contains("meerkat-mob/src/runtime/flow.rs")
+                && mismatch.contains(".cas_flow_state(")
+        }),
+        "expected typed flow outcome computed with local RunId to be rejected, got {mismatches:#?}"
+    );
+}
+
+#[test]
+fn live_flow_runtime_projection_ratchet_rejects_block_local_run_id_shadowed_apply() {
+    let dir = tempdir().expect("tempdir");
+    let runtime = dir.path().join("meerkat-mob/src/runtime");
+    fs::create_dir_all(&runtime).expect("create runtime dir");
+    fs::write(
+        runtime.join("flow.rs"),
+        r"
+use crate::run::apply_mob_machine_flow_run_command;
+
+async fn bad(
+    run_store: Store,
+    run_id: &RunId,
+    machine_state: &MobMachineState,
+    run: MobRun,
+    command: MobMachineFlowRunCommand,
+    authority: MobMachineFlowAuthorityToken,
+) -> Result<(), MobError> {
+    let outcome = {
+        let run_id = RunId::new();
+        apply_mob_machine_flow_run_command(
+            &run.flow_state,
+            machine_state,
+            &run_id,
+            command,
+            authority,
+        )?
+    };
+    run_store
+        .cas_flow_state(run_id, &run.flow_state, &outcome.next_state)
+        .await?;
+    Ok(())
+}
+",
+    )
+    .expect("write block-local run_id shadowed apply");
+
+    let mismatches = collect_direct_flow_reducer_transition_mismatches(dir.path())
+        .expect("flow projection mutation mismatches");
+    assert!(
+        mismatches.iter().any(|mismatch| {
+            mismatch.contains("meerkat-mob/src/runtime/flow.rs")
+                && mismatch.contains(".cas_flow_state(")
+        }),
+        "expected block-local RunId shadowed flow outcome to be rejected, got {mismatches:#?}"
+    );
+}
+
+#[test]
+fn live_flow_runtime_projection_ratchet_rejects_block_local_command_shadowed_apply() {
+    let dir = tempdir().expect("tempdir");
+    let runtime = dir.path().join("meerkat-mob/src/runtime");
+    fs::create_dir_all(&runtime).expect("create runtime dir");
+    fs::write(
+        runtime.join("flow.rs"),
+        r"
+use crate::run::apply_mob_machine_flow_run_command;
+
+async fn bad(
+    run_store: Store,
+    run_id: &RunId,
+    machine_state: &MobMachineState,
+    run: MobRun,
+    command: MobMachineFlowRunCommand,
+    other_command: MobMachineFlowRunCommand,
+    authority: MobMachineFlowAuthorityToken,
+) -> Result<(), MobError> {
+    let outcome = {
+        let command = other_command;
+        apply_mob_machine_flow_run_command(
+            &run.flow_state,
+            machine_state,
+            run_id,
+            command,
+            authority,
+        )?
+    };
+    let authority_input = command.authority_input(run_id);
+    run_store
+        .cas_flow_state_with_authority(
+            run_id,
+            &run.flow_state,
+            &outcome.next_state,
+            vec![authority_input],
+        )
+        .await?;
+    Ok(())
+}
+",
+    )
+    .expect("write block-local command shadowed apply");
+
+    let mismatches = collect_direct_flow_reducer_transition_mismatches(dir.path())
+        .expect("flow projection mutation mismatches");
+    assert!(
+        mismatches.iter().any(|mismatch| {
+            mismatch.contains("meerkat-mob/src/runtime/flow.rs")
+                && mismatch.contains(".cas_flow_state_with_authority(")
+        }),
+        "expected block-local command shadowed flow outcome to be rejected, got {mismatches:#?}"
+    );
+}
+
+#[test]
+fn live_flow_runtime_projection_ratchet_rejects_match_shadowed_typed_outcome() {
+    let dir = tempdir().expect("tempdir");
+    let runtime = dir.path().join("meerkat-mob/src/runtime");
+    fs::create_dir_all(&runtime).expect("create runtime dir");
+    fs::write(
+        runtime.join("flow.rs"),
+        r"
+use crate::run::apply_mob_machine_flow_run_command;
+
+async fn bad(
+    run_store: Store,
+    run_id: &RunId,
+    machine_state: &MobMachineState,
+    run: MobRun,
+    command: MobMachineFlowRunCommand,
+    authority: MobMachineFlowAuthorityToken,
+    fake: FakeOutcomeHolder,
+) -> Result<(), MobError> {
+    let outcome = apply_mob_machine_flow_run_command(
+        &run.flow_state,
+        machine_state,
+        run_id,
+        command,
+        authority,
+    )?;
+    match fake {
+        FakeOutcomeHolder { outcome } => {
+            run_store
+                .cas_flow_state(run_id, &run.flow_state, &outcome.next_state)
+                .await?;
+        }
+    }
+    Ok(())
+}
+",
+    )
+    .expect("write match-shadowed typed outcome");
+
+    let mismatches = collect_direct_flow_reducer_transition_mismatches(dir.path())
+        .expect("flow projection mutation mismatches");
+    assert!(
+        mismatches.iter().any(|mismatch| {
+            mismatch.contains("meerkat-mob/src/runtime/flow.rs")
+                && mismatch.contains(".cas_flow_state(")
+        }),
+        "expected match-shadowed typed outcome to be rejected, got {mismatches:#?}"
+    );
+}
+
+#[test]
+fn live_flow_runtime_projection_ratchet_rejects_fake_local_command_token_constructors() {
+    let dir = tempdir().expect("tempdir");
+    let runtime = dir.path().join("meerkat-mob/src/runtime");
+    fs::create_dir_all(&runtime).expect("create runtime dir");
+    fs::write(
+        runtime.join("flow.rs"),
+        r"
+use crate::run::apply_mob_machine_flow_run_command;
+
+mod fake {
+    pub enum MobMachineFlowRunCommand {
+        StartRun(flow_run::inputs::StartRun),
+    }
+
+    impl MobMachineFlowRunCommand {
+        fn authority_input(&self, _run_id: &RunId) -> MobMachineInput {
+            MobMachineInput::RunFlow
+        }
+    }
+
+    pub struct MobMachineFlowAuthorityToken;
+
+    impl MobMachineFlowAuthorityToken {
+        fn from_accepted_mob_machine_input(
+            _input: &MobMachineInput,
+        ) -> Result<Self, MobError> {
+            Ok(Self)
+        }
+    }
+}
+
+async fn bad(
+    run_store: Store,
+    run_id: &RunId,
+    machine_state: &MobMachineState,
+    run: MobRun,
+    accepted_input: MobMachineInput,
+) -> Result<(), MobError> {
+    let command = fake::MobMachineFlowRunCommand::StartRun(flow_run::inputs::StartRun {});
+    let authority = fake::MobMachineFlowAuthorityToken::from_accepted_mob_machine_input(
+        &accepted_input,
+    )?;
+    let outcome = apply_mob_machine_flow_run_command(
+        &run.flow_state,
+        machine_state,
+        run_id,
+        command,
+        authority,
+    )?;
+    let authority_input = command.authority_input(run_id);
+    run_store
+        .cas_flow_state_with_authority(
+            run_id,
+            &run.flow_state,
+            &outcome.next_state,
+            vec![authority_input],
+        )
+        .await?;
+    Ok(())
+}
+",
+    )
+    .expect("write fake local command/token constructors");
+
+    let mismatches = collect_direct_flow_reducer_transition_mismatches(dir.path())
+        .expect("flow projection mutation mismatches");
+    assert!(
+        mismatches.iter().any(|mismatch| {
+            mismatch.contains("meerkat-mob/src/runtime/flow.rs")
+                && mismatch.contains(".cas_flow_state_with_authority(")
+        }),
+        "expected fake local command/token constructors not to authorize flow CAS, got {mismatches:#?}"
+    );
+}
+
+#[test]
+fn live_flow_runtime_projection_ratchet_rejects_if_let_shadowed_authority_input() {
+    let dir = tempdir().expect("tempdir");
+    let runtime = dir.path().join("meerkat-mob/src/runtime");
+    fs::create_dir_all(&runtime).expect("create runtime dir");
+    fs::write(
+        runtime.join("flow.rs"),
+        r"
+use crate::run::apply_mob_machine_flow_run_command;
+
+async fn bad(
+    run_store: Store,
+    run_id: &RunId,
+    machine_state: &MobMachineState,
+    run: MobRun,
+    command: MobMachineFlowRunCommand,
+    authority: MobMachineFlowAuthorityToken,
+    fake_input: Option<MobMachineInput>,
+) -> Result<(), MobError> {
+    let outcome = apply_mob_machine_flow_run_command(
+        &run.flow_state,
+        machine_state,
+        run_id,
+        command.clone(),
+        authority,
+    )?;
+    let authority_input = command.authority_input(run_id);
+    if let Some(authority_input) = fake_input {
+        run_store
+            .cas_flow_state_with_authority(
+                run_id,
+                &run.flow_state,
+                &outcome.next_state,
+                vec![authority_input],
+            )
+            .await?;
+    }
+    Ok(())
+}
+",
+    )
+    .expect("write if-let-shadowed authority input");
+
+    let mismatches = collect_direct_flow_reducer_transition_mismatches(dir.path())
+        .expect("flow projection mutation mismatches");
+    assert!(
+        mismatches.iter().any(|mismatch| {
+            mismatch.contains("meerkat-mob/src/runtime/flow.rs")
+                && mismatch.contains(".cas_flow_state_with_authority(")
+        }),
+        "expected if-let-shadowed authority input to be rejected, got {mismatches:#?}"
+    );
+}
+
+#[test]
+fn live_flow_runtime_projection_ratchet_rejects_mutably_replaced_authority_input() {
+    let dir = tempdir().expect("tempdir");
+    let runtime = dir.path().join("meerkat-mob/src/runtime");
+    fs::create_dir_all(&runtime).expect("create runtime dir");
+    fs::write(
+        runtime.join("flow.rs"),
+        r"
+use crate::run::apply_mob_machine_flow_run_command;
+
+async fn bad(run_store: Store, run_id: &RunId, run: MobRun, command: MobMachineFlowRunCommand, other_command: MobMachineFlowRunCommand, authority: MobMachineFlowAuthorityToken) -> Result<(), MobError> {
+    let outcome = apply_mob_machine_flow_run_command(&run.flow_state, command.clone(), authority)?;
+    let mut authority_input = command.authority_input(run_id);
+    std::mem::replace(&mut authority_input, other_command.authority_input(run_id));
+    run_store
+        .cas_flow_state_with_authority(
+            run_id,
+            &run.flow_state,
+            &outcome.next_state,
+            vec![authority_input],
+        )
+        .await?;
+    Ok(())
+}
+",
+    )
+    .expect("write mutably replaced authority input CAS commit");
+
+    let mismatches = collect_direct_flow_reducer_transition_mismatches(dir.path())
+        .expect("flow projection mutation mismatches");
+    assert!(
+        mismatches.iter().any(|mismatch| {
+            mismatch.contains("meerkat-mob/src/runtime/flow.rs")
+                && mismatch.contains(".cas_flow_state_with_authority(")
+        }),
+        "expected mutable authority input replacement to invalidate CAS authority proof, got {mismatches:#?}"
+    );
+}
+
+#[test]
+fn live_flow_runtime_projection_ratchet_rejects_mutably_replaced_next_state_alias() {
+    let dir = tempdir().expect("tempdir");
+    let runtime = dir.path().join("meerkat-mob/src/runtime");
+    fs::create_dir_all(&runtime).expect("create runtime dir");
+    fs::write(
+        runtime.join("flow.rs"),
+        r"
+use crate::run::apply_mob_machine_flow_run_command;
+
+async fn bad(run_store: Store, run_id: &RunId, run: MobRun, command: MobMachineFlowRunCommand, authority: MobMachineFlowAuthorityToken) -> Result<(), MobError> {
+    let outcome = apply_mob_machine_flow_run_command(&run.flow_state, command.clone(), authority)?;
+    let authority_input = command.authority_input(run_id);
+    let mut next_state = outcome.next_state.clone();
+    std::mem::replace(&mut next_state, flow_run::State::default());
+    run_store
+        .cas_flow_state_with_authority(
+            run_id,
+            &run.flow_state,
+            &next_state,
+            vec![authority_input],
+        )
+        .await?;
+    Ok(())
+}
+",
+    )
+    .expect("write mutably replaced next-state alias CAS commit");
+
+    let mismatches = collect_direct_flow_reducer_transition_mismatches(dir.path())
+        .expect("flow projection mutation mismatches");
+    assert!(
+        mismatches.iter().any(|mismatch| {
+            mismatch.contains("meerkat-mob/src/runtime/flow.rs")
+                && mismatch.contains(".cas_flow_state_with_authority(")
+        }),
+        "expected mutable next-state alias replacement to invalidate CAS state proof, got {mismatches:#?}"
+    );
+}
+
+#[test]
+fn live_flow_runtime_projection_ratchet_rejects_rebound_command_authority_input() {
+    let dir = tempdir().expect("tempdir");
+    let runtime = dir.path().join("meerkat-mob/src/runtime");
+    fs::create_dir_all(&runtime).expect("create runtime dir");
+    fs::write(
+        runtime.join("flow.rs"),
+        r"
+use crate::run::apply_mob_machine_flow_run_command;
+
+async fn bad(run_store: Store, run_id: &RunId, run: MobRun, command: MobMachineFlowRunCommand, replacement: MobMachineFlowRunCommand, authority: MobMachineFlowAuthorityToken) -> Result<(), MobError> {
+    let outcome = apply_mob_machine_flow_run_command(&run.flow_state, command.clone(), authority)?;
+    let command = replacement;
+    let authority_input = command.authority_input(run_id);
+    run_store
+        .cas_flow_state_with_authority(
+            run_id,
+            &run.flow_state,
+            &outcome.next_state,
+            vec![authority_input],
+        )
+        .await?;
+    Ok(())
+}
+",
+    )
+    .expect("write rebound command authority input CAS commit");
+
+    let mismatches = collect_direct_flow_reducer_transition_mismatches(dir.path())
+        .expect("flow projection mutation mismatches");
+    assert!(
+        mismatches.iter().any(|mismatch| {
+            mismatch.contains("meerkat-mob/src/runtime/flow.rs")
+                && mismatch.contains(".cas_flow_state_with_authority(")
+        }),
+        "expected authority input derived from rebound command name to be rejected, got {mismatches:#?}"
+    );
+}
+
+#[test]
+fn live_flow_runtime_projection_ratchet_rejects_reassigned_command_parameter_authority_input() {
+    let dir = tempdir().expect("tempdir");
+    let runtime = dir.path().join("meerkat-mob/src/runtime");
+    fs::create_dir_all(&runtime).expect("create runtime dir");
+    fs::write(
+        runtime.join("flow.rs"),
+        r"
+use crate::run::apply_mob_machine_flow_run_command;
+
+async fn bad(run_store: Store, run_id: &RunId, run: MobRun, mut command: MobMachineFlowRunCommand, replacement: MobMachineFlowRunCommand, authority: MobMachineFlowAuthorityToken) -> Result<(), MobError> {
+    let outcome = apply_mob_machine_flow_run_command(&run.flow_state, command.clone(), authority)?;
+    command = replacement;
+    let authority_input = command.authority_input(run_id);
+    run_store
+        .cas_flow_state_with_authority(
+            run_id,
+            &run.flow_state,
+            &outcome.next_state,
+            vec![authority_input],
+        )
+        .await?;
+    Ok(())
+}
+",
+    )
+    .expect("write reassigned command parameter authority input CAS commit");
+
+    let mismatches = collect_direct_flow_reducer_transition_mismatches(dir.path())
+        .expect("flow projection mutation mismatches");
+    assert!(
+        mismatches.iter().any(|mismatch| {
+            mismatch.contains("meerkat-mob/src/runtime/flow.rs")
+                && mismatch.contains(".cas_flow_state_with_authority(")
+        }),
+        "expected authority input derived from reassigned command parameter to be rejected, got {mismatches:#?}"
+    );
+}
+
+#[test]
+fn live_flow_runtime_projection_ratchet_rejects_mixed_authority_input_vector() {
+    let dir = tempdir().expect("tempdir");
+    let runtime = dir.path().join("meerkat-mob/src/runtime");
+    fs::create_dir_all(&runtime).expect("create runtime dir");
+    fs::write(
+        runtime.join("flow.rs"),
+        r"
+use crate::run::apply_mob_machine_flow_run_command;
+
+async fn bad(run_store: Store, run_id: &RunId, run: MobRun, command: MobMachineFlowRunCommand, other_command: MobMachineFlowRunCommand, authority: MobMachineFlowAuthorityToken) -> Result<(), MobError> {
+    let outcome = apply_mob_machine_flow_run_command(&run.flow_state, command.clone(), authority)?;
+    let authority_input = command.authority_input(run_id);
+    let unrelated_input = other_command.authority_input(run_id);
+    run_store
+        .cas_flow_state_with_authority(
+            run_id,
+            &run.flow_state,
+            &outcome.next_state,
+            vec![authority_input, unrelated_input],
+        )
+        .await?;
+    Ok(())
+}
+",
+    )
+    .expect("write mixed authority input CAS commit");
+
+    let mismatches = collect_direct_flow_reducer_transition_mismatches(dir.path())
+        .expect("flow projection mutation mismatches");
+    assert!(
+        mismatches.iter().any(|mismatch| {
+            mismatch.contains("meerkat-mob/src/runtime/flow.rs")
+                && mismatch.contains(".cas_flow_state_with_authority(")
+        }),
+        "expected with-authority CAS containing unrelated authority input to be rejected, got {mismatches:#?}"
+    );
+}
+
+#[test]
+fn live_flow_runtime_projection_ratchet_rejects_unrelated_with_authority_cas_next_state() {
+    let dir = tempdir().expect("tempdir");
+    let runtime = dir.path().join("meerkat-mob/src/runtime");
+    fs::create_dir_all(&runtime).expect("create runtime dir");
+    fs::write(
+        runtime.join("flow.rs"),
+        r"
+async fn bad(run_store: Store, run_id: &RunId, run: MobRun) -> Result<(), MobError> {
+    let unrelated_next_state = flow_run::State::default();
+    run_store
+        .cas_flow_state_with_authority(run_id, &run.flow_state, &unrelated_next_state, vec![])
+        .await?;
+    Ok(())
+}
+",
+    )
+    .expect("write unrelated with-authority CAS commit");
+
+    let mismatches = collect_direct_flow_reducer_transition_mismatches(dir.path())
+        .expect("flow projection mutation mismatches");
+    assert!(
+        mismatches.iter().any(|mismatch| {
+            mismatch.contains("meerkat-mob/src/runtime/flow.rs")
+                && mismatch.contains(".cas_flow_state_with_authority(")
+        }),
+        "expected with-authority CAS not tied to typed outcome.next_state to be rejected, got {mismatches:#?}"
+    );
+}
+
+#[test]
+fn live_flow_runtime_projection_ratchet_rejects_unrelated_cas_next_state() {
+    let dir = tempdir().expect("tempdir");
+    let runtime = dir.path().join("meerkat-mob/src/runtime");
+    fs::create_dir_all(&runtime).expect("create runtime dir");
+    fs::write(
+        runtime.join("flow.rs"),
+        r"
+async fn bad(run_store: Store, run_id: &RunId, run: MobRun, command: MobMachineFlowRunCommand, authority: MobMachineFlowAuthorityToken) -> Result<(), MobError> {
+    let outcome = apply_mob_machine_flow_run_command(&run.flow_state, command, authority)?;
+    let unrelated_next_state = flow_run::State::default();
+    run_store
+        .cas_flow_state(run_id, &run.flow_state, &unrelated_next_state)
+        .await?;
+    let _ = outcome;
+    Ok(())
+}
+",
+    )
+    .expect("write unrelated CAS commit");
+
+    let mismatches = collect_direct_flow_reducer_transition_mismatches(dir.path())
+        .expect("flow projection mutation mismatches");
+    assert!(
+        mismatches.iter().any(|mismatch| {
+            mismatch.contains("meerkat-mob/src/runtime/flow.rs")
+                && mismatch.contains(".cas_flow_state(")
+        }),
+        "expected CAS not tied to typed outcome.next_state to be rejected, got {mismatches:#?}"
+    );
+}
+
+#[test]
+fn live_flow_runtime_projection_ratchet_rejects_typed_outcome_in_wrong_cas_argument() {
+    let dir = tempdir().expect("tempdir");
+    let runtime = dir.path().join("meerkat-mob/src/runtime");
+    fs::create_dir_all(&runtime).expect("create runtime dir");
+    fs::write(
+        runtime.join("flow.rs"),
+        r"
+async fn bad(run_store: Store, run_id: &RunId, run: MobRun, command: MobMachineFlowRunCommand, authority: MobMachineFlowAuthorityToken) -> Result<(), MobError> {
+    let outcome = apply_mob_machine_flow_run_command(&run.flow_state, command, authority)?;
+    let unrelated_next_state = flow_run::State::default();
+    run_store
+        .cas_flow_state(run_id, &outcome.next_state, &unrelated_next_state)
+        .await?;
+    Ok(())
+}
+",
+    )
+    .expect("write wrong-position CAS commit");
+
+    let mismatches = collect_direct_flow_reducer_transition_mismatches(dir.path())
+        .expect("flow projection mutation mismatches");
+    assert!(
+        mismatches.iter().any(|mismatch| {
+            mismatch.contains("meerkat-mob/src/runtime/flow.rs")
+                && mismatch.contains(".cas_flow_state(")
+        }),
+        "expected CAS with typed outcome in expected-state slot to be rejected, got {mismatches:#?}"
+    );
+}
+
+#[test]
+fn live_flow_runtime_projection_ratchet_rejects_fake_outcome_wrappers() {
+    let dir = tempdir().expect("tempdir");
+    let runtime = dir.path().join("meerkat-mob/src/runtime");
+    fs::create_dir_all(&runtime).expect("create runtime dir");
+    fs::write(
+        runtime.join("flow.rs"),
+        r"
+async fn bad(run_store: Store, run_id: &RunId, run: MobRun, command: MobMachineFlowRunCommand, authority: MobMachineFlowAuthorityToken) -> Result<(), MobError> {
+    let fake = {
+        let _ = apply_mob_machine_flow_run_command(&run.flow_state, command, authority)?;
+        FakeOutcome {
+            next_state: flow_run::State::default(),
+        }
+    };
+    run_store
+        .cas_flow_state(run_id, &run.flow_state, &fake.next_state)
+        .await?;
+    Ok(())
+}
+",
+    )
+    .expect("write fake outcome commit");
+
+    let mismatches = collect_direct_flow_reducer_transition_mismatches(dir.path())
+        .expect("flow projection mutation mismatches");
+    assert!(
+        mismatches.iter().any(|mismatch| {
+            mismatch.contains("meerkat-mob/src/runtime/flow.rs")
+                && mismatch.contains(".cas_flow_state(")
+        }),
+        "expected fake outcome wrapper to be rejected, got {mismatches:#?}"
+    );
+}
+
+#[test]
+fn live_flow_runtime_projection_ratchet_rejects_shadowed_outcome_names() {
+    let dir = tempdir().expect("tempdir");
+    let runtime = dir.path().join("meerkat-mob/src/runtime");
+    fs::create_dir_all(&runtime).expect("create runtime dir");
+    fs::write(
+        runtime.join("flow.rs"),
+        r"
+async fn bad(run_store: Store, run_id: &RunId, run: MobRun, command: MobMachineFlowRunCommand, authority: MobMachineFlowAuthorityToken) -> Result<(), MobError> {
+    let outcome = FakeOutcome {
+        next_state: flow_run::State::default(),
+    };
+    {
+        let outcome = apply_mob_machine_flow_run_command(&run.flow_state, command, authority)?;
+        let _ = outcome;
+    }
+    run_store
+        .cas_flow_state(run_id, &run.flow_state, &outcome.next_state)
+        .await?;
+    Ok(())
+}
+",
+    )
+    .expect("write shadowed outcome commit");
+
+    let mismatches = collect_direct_flow_reducer_transition_mismatches(dir.path())
+        .expect("flow projection mutation mismatches");
+    assert!(
+        mismatches.iter().any(|mismatch| {
+            mismatch.contains("meerkat-mob/src/runtime/flow.rs")
+                && mismatch.contains(".cas_flow_state(")
+        }),
+        "expected shadowed outcome name to be rejected, got {mismatches:#?}"
+    );
+}
+
+#[test]
+fn live_flow_runtime_projection_ratchet_rejects_local_fake_apply_outcomes() {
+    let dir = tempdir().expect("tempdir");
+    let runtime = dir.path().join("meerkat-mob/src/runtime");
+    fs::create_dir_all(&runtime).expect("create runtime dir");
+    fs::write(
+        runtime.join("flow.rs"),
+        r"
+async fn bad(run_store: Store, run_id: &RunId, run: MobRun, command: MobMachineFlowRunCommand, authority: MobMachineFlowAuthorityToken) -> Result<(), MobError> {
+    fn apply_mob_machine_flow_run_command(
+        _state: &flow_run::State,
+        _command: MobMachineFlowRunCommand,
+        _authority: MobMachineFlowAuthorityToken,
+    ) -> Result<FakeOutcome, MobError> {
+        Ok(FakeOutcome {
+            next_state: flow_run::State::default(),
+        })
+    }
+
+    let outcome = apply_mob_machine_flow_run_command(&run.flow_state, command, authority)?;
+    run_store
+        .cas_flow_state(run_id, &run.flow_state, &outcome.next_state)
+        .await?;
+    Ok(())
+}
+",
+    )
+    .expect("write local fake apply outcome");
+
+    let mismatches = collect_direct_flow_reducer_transition_mismatches(dir.path())
+        .expect("flow projection mutation mismatches");
+    assert!(
+        mismatches.iter().any(|mismatch| {
+            mismatch.contains("meerkat-mob/src/runtime/flow.rs")
+                && mismatch.contains(".cas_flow_state(")
+        }),
+        "expected local fake flow-apply outcome to be rejected, got {mismatches:#?}"
+    );
+}
+
+#[test]
+fn live_flow_runtime_projection_ratchet_rejects_ufcs_cas_writes() {
+    let dir = tempdir().expect("tempdir");
+    let runtime = dir.path().join("meerkat-mob/src/runtime");
+    fs::create_dir_all(&runtime).expect("create runtime dir");
+    fs::write(
+        runtime.join("flow.rs"),
+        r"
+async fn bad(run_store: Store, run_id: &RunId, run: MobRun) -> Result<(), MobError> {
+    let unrelated_next_state = flow_run::State::default();
+    MobRunStore::cas_flow_state(&run_store, run_id, &run.flow_state, &unrelated_next_state).await?;
+    Ok(())
+}
+",
+    )
+    .expect("write UFCS CAS commit");
+
+    let mismatches = collect_direct_flow_reducer_transition_mismatches(dir.path())
+        .expect("flow projection mutation mismatches");
+    assert!(
+        mismatches.iter().any(|mismatch| {
+            mismatch.contains("meerkat-mob/src/runtime/flow.rs")
+                && mismatch.contains(".cas_flow_state(")
+        }),
+        "expected UFCS CAS write to be rejected, got {mismatches:#?}"
+    );
+}
+
+#[test]
+fn live_flow_runtime_projection_ratchet_rejects_local_same_name_cas_function() {
+    let dir = tempdir().expect("tempdir");
+    let runtime = dir.path().join("meerkat-mob/src/runtime");
+    fs::create_dir_all(&runtime).expect("create runtime dir");
+    fs::write(
+        runtime.join("flow.rs"),
+        r"
+use crate::run::apply_mob_machine_flow_run_command;
+
+async fn cas_flow_state_with_authority(
+    _run_id: &RunId,
+    _expected: &flow_run::State,
+    _next: &flow_run::State,
+    _authority_inputs: Vec<MobMachineInput>,
+) -> Result<bool, MobError> {
+    Ok(true)
+}
+
+async fn bad(
+    run_id: &RunId,
+    run: MobRun,
+    command: MobMachineFlowRunCommand,
+    authority: MobMachineFlowAuthorityToken,
+) -> Result<(), MobError> {
+    let outcome = apply_mob_machine_flow_run_command(&run.flow_state, command.clone(), authority)?;
+    let authority_inputs = command.authority_input(run_id);
+    cas_flow_state_with_authority(
+        run_id,
+        &run.flow_state,
+        &outcome.next_state,
+        authority_inputs,
+    )
+    .await?;
+    Ok(())
+}
+",
+    )
+    .expect("write local same-name CAS function");
+
+    let mismatches = collect_direct_flow_reducer_transition_mismatches(dir.path())
+        .expect("flow projection mutation mismatches");
+    assert!(
+        mismatches.iter().any(|mismatch| {
+            mismatch.contains("meerkat-mob/src/runtime/flow.rs")
+                && mismatch.contains(".cas_flow_state_with_authority(")
+        }),
+        "expected local same-name CAS function not to authorize projection commit, got {mismatches:#?}"
+    );
+}
+
+#[test]
+fn live_flow_runtime_projection_ratchet_rejects_transitive_state_alias_mutation() {
+    let dir = tempdir().expect("tempdir");
+    let runtime = dir.path().join("meerkat-mob/src/runtime");
+    fs::create_dir_all(&runtime).expect("create runtime dir");
+    fs::write(
+        runtime.join("flow.rs"),
+        r"
+fn bad(run: &mut MobRun) {
+    let state = &mut run.flow_state;
+    let alias = state;
+    alias.phase = flow_run::Phase::Running;
+}
+",
+    )
+    .expect("write transitive state alias mutation");
+
+    let mismatches = collect_direct_flow_reducer_transition_mismatches(dir.path())
+        .expect("flow projection mutation mismatches");
+    assert!(
+        mismatches.iter().any(|mismatch| {
+            mismatch.contains("meerkat-mob/src/runtime/flow.rs")
+                && mismatch.contains(".flow_state.phase")
+        }),
+        "expected transitive flow-state alias mutation to be rejected, got {mismatches:#?}"
+    );
+}
+
+#[test]
+fn live_flow_runtime_projection_ratchet_rejects_assigned_state_alias_mutation() {
+    let dir = tempdir().expect("tempdir");
+    let runtime = dir.path().join("meerkat-mob/src/runtime");
+    fs::create_dir_all(&runtime).expect("create runtime dir");
+    fs::write(
+        runtime.join("flow.rs"),
+        r"
+fn bad(run: &mut MobRun) {
+    let state;
+    state = &mut run.flow_state;
+    state.phase = flow_run::Phase::Running;
+}
+",
+    )
+    .expect("write assigned state alias mutation");
+
+    let mismatches = collect_direct_flow_reducer_transition_mismatches(dir.path())
+        .expect("flow projection mutation mismatches");
+    assert!(
+        mismatches.iter().any(|mismatch| {
+            mismatch.contains("meerkat-mob/src/runtime/flow.rs")
+                && mismatch.contains(".flow_state.phase")
+        }),
+        "expected assigned flow-state alias mutation to be rejected, got {mismatches:#?}"
+    );
+}
+
+#[test]
+fn live_flow_runtime_projection_ratchet_rejects_destructured_state_alias_mutation() {
+    let dir = tempdir().expect("tempdir");
+    let runtime = dir.path().join("meerkat-mob/src/runtime");
+    fs::create_dir_all(&runtime).expect("create runtime dir");
+    fs::write(
+        runtime.join("flow.rs"),
+        r"
+fn bad(run: &mut MobRun) {
+    let state = &mut run.flow_state;
+    let (alias,) = (state,);
+    alias.phase = flow_run::Phase::Running;
+}
+",
+    )
+    .expect("write destructured state alias mutation");
+
+    let mismatches = collect_direct_flow_reducer_transition_mismatches(dir.path())
+        .expect("flow projection mutation mismatches");
+    assert!(
+        mismatches.iter().any(|mismatch| {
+            mismatch.contains("meerkat-mob/src/runtime/flow.rs")
+                && mismatch.contains(".flow_state.phase")
+        }),
+        "expected destructured flow-state alias mutation to be rejected, got {mismatches:#?}"
+    );
+}
+
+#[test]
+fn live_flow_runtime_projection_ratchet_rejects_struct_destructured_state_alias_mutation() {
+    let dir = tempdir().expect("tempdir");
+    let runtime = dir.path().join("meerkat-mob/src/runtime");
+    fs::create_dir_all(&runtime).expect("create runtime dir");
+    fs::write(
+        runtime.join("flow.rs"),
+        r"
+fn bad(run: &mut MobRun) {
+    let Wrapper { alias } = Wrapper {
+        alias: &mut run.flow_state,
+    };
+    alias.phase = flow_run::Phase::Running;
+}
+",
+    )
+    .expect("write struct-destructured state alias mutation");
+
+    let mismatches = collect_direct_flow_reducer_transition_mismatches(dir.path())
+        .expect("flow projection mutation mismatches");
+    assert!(
+        mismatches.iter().any(|mismatch| {
+            mismatch.contains("meerkat-mob/src/runtime/flow.rs")
+                && mismatch.contains(".flow_state.phase")
+        }),
+        "expected struct-destructured flow-state alias mutation to be rejected, got {mismatches:#?}"
+    );
+}
+
+#[test]
+fn live_flow_runtime_projection_ratchet_rejects_slice_destructured_state_alias_mutation() {
+    let dir = tempdir().expect("tempdir");
+    let runtime = dir.path().join("meerkat-mob/src/runtime");
+    fs::create_dir_all(&runtime).expect("create runtime dir");
+    fs::write(
+        runtime.join("flow.rs"),
+        r"
+fn bad(run: &mut MobRun) {
+    let [alias] = [&mut run.flow_state];
+    alias.phase = flow_run::Phase::Running;
+}
+",
+    )
+    .expect("write slice-destructured state alias mutation");
+
+    let mismatches = collect_direct_flow_reducer_transition_mismatches(dir.path())
+        .expect("flow projection mutation mismatches");
+    assert!(
+        mismatches.iter().any(|mismatch| {
+            mismatch.contains("meerkat-mob/src/runtime/flow.rs")
+                && mismatch.contains(".flow_state.phase")
+        }),
+        "expected slice-destructured flow-state alias mutation to be rejected, got {mismatches:#?}"
+    );
+}
+
+#[test]
+fn live_flow_runtime_projection_ratchet_rejects_state_alias_mutation() {
+    let dir = tempdir().expect("tempdir");
+    let runtime = dir.path().join("meerkat-mob/src/runtime");
+    fs::create_dir_all(&runtime).expect("create runtime dir");
+    fs::write(
+        runtime.join("flow.rs"),
+        r"
+fn bad(run: &mut MobRun) {
+    let state = &mut run.flow_state;
+    state.phase = flow_run::Phase::Running;
+}
+",
+    )
+    .expect("write state alias mutation");
+
+    let mismatches = collect_direct_flow_reducer_transition_mismatches(dir.path())
+        .expect("flow projection mutation mismatches");
+    assert!(
+        mismatches.iter().any(|mismatch| {
+            mismatch.contains("meerkat-mob/src/runtime/flow.rs")
+                && mismatch.contains(".flow_state.phase")
+        }),
+        "expected aliased flow-state mutation to be rejected, got {mismatches:#?}"
+    );
+}
+
+#[test]
+fn live_flow_runtime_projection_ratchet_rejects_deref_state_alias_mutation() {
+    let dir = tempdir().expect("tempdir");
+    let runtime = dir.path().join("meerkat-mob/src/runtime");
+    fs::create_dir_all(&runtime).expect("create runtime dir");
+    fs::write(
+        runtime.join("flow.rs"),
+        r"
+fn bad(mut run: MobRun) {
+    let state = &mut run.flow_state;
+    (*state).phase = flow_run::Phase::Running;
+}
+",
+    )
+    .expect("write deref state alias mutation");
+
+    let mismatches = collect_direct_flow_reducer_transition_mismatches(dir.path())
+        .expect("flow projection mutation mismatches");
+    assert!(
+        mismatches.iter().any(|mismatch| {
+            mismatch.contains("meerkat-mob/src/runtime/flow.rs")
+                && mismatch.contains(".flow_state.phase")
+        }),
+        "expected dereferenced flow_state alias mutation to be rejected, got {mismatches:#?}"
+    );
+}
+
+#[test]
+fn live_flow_runtime_projection_ratchet_rejects_mutable_reference_to_flow_state() {
+    let dir = tempdir().expect("tempdir");
+    let runtime = dir.path().join("meerkat-mob/src/runtime");
+    fs::create_dir_all(&runtime).expect("create runtime dir");
+    fs::write(
+        runtime.join("flow.rs"),
+        r"
+fn bad(run: &mut MobRun) {
+    let _old = std::mem::replace(&mut run.flow_state, flow_run::State::default());
+}
+",
+    )
+    .expect("write mutable reference to flow state");
+
+    let mismatches = collect_direct_flow_reducer_transition_mismatches(dir.path())
+        .expect("flow projection mutation mismatches");
+    assert!(
+        mismatches.iter().any(|mismatch| {
+            mismatch.contains("meerkat-mob/src/runtime/flow.rs") && mismatch.contains(".flow_state")
+        }),
+        "expected mutable reference to flow_state to be rejected, got {mismatches:#?}"
+    );
+}
+
+#[test]
+fn live_flow_runtime_projection_ratchet_rejects_whole_flow_state_assignment() {
+    let dir = tempdir().expect("tempdir");
+    let runtime = dir.path().join("meerkat-mob/src/runtime");
+    fs::create_dir_all(&runtime).expect("create runtime dir");
+    fs::write(
+        runtime.join("flow.rs"),
+        r"
+fn bad(run: &mut MobRun) {
+    run.flow_state = flow_run::State::default();
+}
+",
+    )
+    .expect("write whole flow state assignment");
+
+    let mismatches = collect_direct_flow_reducer_transition_mismatches(dir.path())
+        .expect("flow projection mutation mismatches");
+    assert!(
+        mismatches.iter().any(|mismatch| {
+            mismatch.contains("meerkat-mob/src/runtime/flow.rs") && mismatch.contains(".flow_state")
+        }),
+        "expected whole flow_state assignment to be rejected, got {mismatches:#?}"
+    );
+}
+
+#[test]
+fn live_flow_runtime_projection_ratchet_rejects_whole_flow_state_mutator() {
+    let dir = tempdir().expect("tempdir");
+    let runtime = dir.path().join("meerkat-mob/src/runtime");
+    fs::create_dir_all(&runtime).expect("create runtime dir");
+    fs::write(
+        runtime.join("flow.rs"),
+        r"
+fn bad(run: &mut MobRun) {
+    run.flow_state.clone_from(&flow_run::State::default());
+}
+",
+    )
+    .expect("write whole flow state mutator");
+
+    let mismatches = collect_direct_flow_reducer_transition_mismatches(dir.path())
+        .expect("flow projection mutation mismatches");
+    assert!(
+        mismatches.iter().any(|mismatch| {
+            mismatch.contains("meerkat-mob/src/runtime/flow.rs") && mismatch.contains(".flow_state")
+        }),
+        "expected whole flow_state mutator to be rejected, got {mismatches:#?}"
+    );
+}
+
+#[test]
+fn live_flow_runtime_projection_ratchet_rejects_flow_state_entry_mutator() {
+    let dir = tempdir().expect("tempdir");
+    let runtime = dir.path().join("meerkat-mob/src/runtime");
+    fs::create_dir_all(&runtime).expect("create runtime dir");
+    fs::write(
+        runtime.join("flow.rs"),
+        r"
+fn bad(run: &mut MobRun, step_id: StepId) {
+    run.flow_state
+        .step_status
+        .entry(step_id)
+        .or_insert(Some(StepRunStatus::Running));
+}
+",
+    )
+    .expect("write flow state entry mutator");
+
+    let mismatches = collect_direct_flow_reducer_transition_mismatches(dir.path())
+        .expect("flow projection mutation mismatches");
+    assert!(
+        mismatches.iter().any(|mismatch| {
+            mismatch.contains("meerkat-mob/src/runtime/flow.rs")
+                && mismatch.contains(".flow_state.step_status")
+        }),
+        "expected flow_state entry mutator to be rejected, got {mismatches:#?}"
+    );
+}
+
+#[test]
+fn live_flow_runtime_projection_ratchet_rejects_flow_state_get_mut_write_access() {
+    let dir = tempdir().expect("tempdir");
+    let runtime = dir.path().join("meerkat-mob/src/runtime");
+    fs::create_dir_all(&runtime).expect("create runtime dir");
+    fs::write(
+        runtime.join("flow.rs"),
+        r"
+fn bad(run: &mut MobRun, step_id: &StepId) {
+    if let Some(status) = run.flow_state.step_status.get_mut(step_id) {
+        *status = Some(StepRunStatus::Running);
+    }
+}
+",
+    )
+    .expect("write flow state get_mut write access");
+
+    let mismatches = collect_direct_flow_reducer_transition_mismatches(dir.path())
+        .expect("flow projection mutation mismatches");
+    assert!(
+        mismatches.iter().any(|mismatch| {
+            mismatch.contains("meerkat-mob/src/runtime/flow.rs")
+                && mismatch.contains(".flow_state.step_status")
+        }),
+        "expected flow_state get_mut write access to be rejected, got {mismatches:#?}"
+    );
+}
+
+#[test]
+fn live_flow_runtime_projection_ratchet_rejects_flow_state_values_mut_write_access() {
+    let dir = tempdir().expect("tempdir");
+    let runtime = dir.path().join("meerkat-mob/src/runtime");
+    fs::create_dir_all(&runtime).expect("create runtime dir");
+    fs::write(
+        runtime.join("flow.rs"),
+        r"
+fn bad(run: &mut MobRun) {
+    for status in run.flow_state.step_status.values_mut() {
+        *status = StepRunStatus::Running;
+    }
+}
+",
+    )
+    .expect("write flow state values_mut write access");
+
+    let mismatches = collect_direct_flow_reducer_transition_mismatches(dir.path())
+        .expect("flow projection mutation mismatches");
+    assert!(
+        mismatches.iter().any(|mismatch| {
+            mismatch.contains("meerkat-mob/src/runtime/flow.rs")
+                && mismatch.contains(".flow_state.step_status")
+        }),
+        "expected flow_state values_mut write access to be rejected, got {mismatches:#?}"
+    );
+}
+
+#[test]
+fn live_flow_runtime_projection_ratchet_rejects_flow_state_range_mut_write_access() {
+    let dir = tempdir().expect("tempdir");
+    let runtime = dir.path().join("meerkat-mob/src/runtime");
+    fs::create_dir_all(&runtime).expect("create runtime dir");
+    fs::write(
+        runtime.join("flow.rs"),
+        r"
+fn bad(run: &mut MobRun) {
+    for (_, status) in run.flow_state.step_status.range_mut(..) {
+        *status = StepRunStatus::Running;
+    }
+}
+",
+    )
+    .expect("write flow state range_mut write access");
+
+    let mismatches = collect_direct_flow_reducer_transition_mismatches(dir.path())
+        .expect("flow projection mutation mismatches");
+    assert!(
+        mismatches.iter().any(|mismatch| {
+            mismatch.contains("meerkat-mob/src/runtime/flow.rs")
+                && mismatch.contains(".flow_state.step_status")
+        }),
+        "expected flow_state range_mut write access to be rejected, got {mismatches:#?}"
+    );
+}
+
+#[test]
+fn live_flow_runtime_projection_ratchet_rejects_flow_state_first_entry_write_access() {
+    let dir = tempdir().expect("tempdir");
+    let runtime = dir.path().join("meerkat-mob/src/runtime");
+    fs::create_dir_all(&runtime).expect("create runtime dir");
+    fs::write(
+        runtime.join("flow.rs"),
+        r"
+fn bad(run: &mut MobRun) {
+    if let Some(mut entry) = run.flow_state.step_status.first_entry() {
+        entry.insert(StepRunStatus::Running);
+    }
+}
+",
+    )
+    .expect("write flow state first_entry write access");
+
+    let mismatches = collect_direct_flow_reducer_transition_mismatches(dir.path())
+        .expect("flow projection mutation mismatches");
+    assert!(
+        mismatches.iter().any(|mismatch| {
+            mismatch.contains("meerkat-mob/src/runtime/flow.rs")
+                && mismatch.contains(".flow_state.step_status")
+        }),
+        "expected flow_state first_entry write access to be rejected, got {mismatches:#?}"
+    );
+}
+
+#[test]
+fn live_flow_runtime_projection_ratchet_rejects_flow_state_take_write_access() {
+    let dir = tempdir().expect("tempdir");
+    let runtime = dir.path().join("meerkat-mob/src/runtime");
+    fs::create_dir_all(&runtime).expect("create runtime dir");
+    fs::write(
+        runtime.join("flow.rs"),
+        r"
+fn bad(run: &mut MobRun, step_id: &StepId) {
+    let _ = run.flow_state.ready_frame_membership.take(step_id);
+}
+",
+    )
+    .expect("write flow state take write access");
+
+    let mismatches = collect_direct_flow_reducer_transition_mismatches(dir.path())
+        .expect("flow projection mutation mismatches");
+    assert!(
+        mismatches.iter().any(|mismatch| {
+            mismatch.contains("meerkat-mob/src/runtime/flow.rs")
+                && mismatch.contains(".flow_state.ready_frame_membership")
+        }),
+        "expected flow_state take write access to be rejected, got {mismatches:#?}"
+    );
+}
+
+#[test]
+fn live_flow_runtime_projection_ratchet_rejects_flow_state_replace_write_access() {
+    let dir = tempdir().expect("tempdir");
+    let runtime = dir.path().join("meerkat-mob/src/runtime");
+    fs::create_dir_all(&runtime).expect("create runtime dir");
+    fs::write(
+        runtime.join("flow.rs"),
+        r"
+fn bad(run: &mut MobRun, step_id: StepId) {
+    let _ = run.flow_state.ready_queue.replace(step_id);
+}
+",
+    )
+    .expect("write flow state replace write access");
+
+    let mismatches = collect_direct_flow_reducer_transition_mismatches(dir.path())
+        .expect("flow projection mutation mismatches");
+    assert!(
+        mismatches.iter().any(|mismatch| {
+            mismatch.contains("meerkat-mob/src/runtime/flow.rs") && mismatch.contains(".flow_state")
+        }),
+        "expected flow_state replace write access to be rejected, got {mismatches:#?}"
+    );
+}
+
+#[test]
+fn live_flow_runtime_projection_ratchet_rejects_flow_state_pop_entry_write_access() {
+    let dir = tempdir().expect("tempdir");
+    let runtime = dir.path().join("meerkat-mob/src/runtime");
+    fs::create_dir_all(&runtime).expect("create runtime dir");
+    fs::write(
+        runtime.join("flow.rs"),
+        r"
+fn bad(run: &mut MobRun) {
+    let _ = run.flow_state.step_status.pop_first();
+}
+",
+    )
+    .expect("write flow state pop_first write access");
+
+    let mismatches = collect_direct_flow_reducer_transition_mismatches(dir.path())
+        .expect("flow projection mutation mismatches");
+    assert!(
+        mismatches.iter().any(|mismatch| {
+            mismatch.contains("meerkat-mob/src/runtime/flow.rs")
+                && mismatch.contains(".flow_state.step_status")
+        }),
+        "expected flow_state pop_first write access to be rejected, got {mismatches:#?}"
+    );
+}
+
+#[test]
+fn live_flow_runtime_projection_ratchet_rejects_match_destructured_state_alias_mutation() {
+    let dir = tempdir().expect("tempdir");
+    let runtime = dir.path().join("meerkat-mob/src/runtime");
+    fs::create_dir_all(&runtime).expect("create runtime dir");
+    fs::write(
+        runtime.join("flow.rs"),
+        r"
+fn bad(run: &mut MobRun) {
+    match run {
+        MobRun { flow_state: state, .. } => {
+            state.phase = flow_run::Phase::Running;
+        }
+    }
+}
+",
+    )
+    .expect("write match owner struct destructured state alias mutation");
+
+    let mismatches = collect_direct_flow_reducer_transition_mismatches(dir.path())
+        .expect("flow projection mutation mismatches");
+    assert!(
+        mismatches.iter().any(|mismatch| {
+            mismatch.contains("meerkat-mob/src/runtime/flow.rs")
+                && mismatch.contains(".flow_state.phase")
+        }),
+        "expected match-destructured flow_state alias mutation to be rejected, got {mismatches:#?}"
+    );
+}
+
+#[test]
+fn live_flow_runtime_projection_ratchet_rejects_let_else_diverge_projection_mutation() {
+    let dir = tempdir().expect("tempdir");
+    let runtime = dir.path().join("meerkat-mob/src/runtime");
+    fs::create_dir_all(&runtime).expect("create runtime dir");
+    fs::write(
+        runtime.join("flow.rs"),
+        r"
+fn bad(run: &mut MobRun, maybe: Option<StepId>) {
+    let Some(step_id) = maybe else {
+        run.flow_state.phase = flow_run::Phase::Running;
+        return;
+    };
+    let _ = step_id;
+}
+",
+    )
+    .expect("write let-else diverge projection mutation");
+
+    let mismatches = collect_direct_flow_reducer_transition_mismatches(dir.path())
+        .expect("flow projection mutation mismatches");
+    assert!(
+        mismatches.iter().any(|mismatch| {
+            mismatch.contains("meerkat-mob/src/runtime/flow.rs")
+                && mismatch.contains(".flow_state.phase")
+        }),
+        "expected let-else diverge projection mutation to be rejected, got {mismatches:#?}"
+    );
+}
+
+#[test]
+fn live_flow_runtime_projection_ratchet_rejects_owner_struct_destructured_state_alias_mutation() {
+    let dir = tempdir().expect("tempdir");
+    let runtime = dir.path().join("meerkat-mob/src/runtime");
+    fs::create_dir_all(&runtime).expect("create runtime dir");
+    fs::write(
+        runtime.join("flow.rs"),
+        r"
+fn bad(run: &mut MobRun) {
+    let MobRun { flow_state: state, .. } = run;
+    state.phase = flow_run::Phase::Running;
+}
+",
+    )
+    .expect("write owner struct destructured state alias mutation");
+
+    let mismatches = collect_direct_flow_reducer_transition_mismatches(dir.path())
+        .expect("flow projection mutation mismatches");
+    assert!(
+        mismatches.iter().any(|mismatch| {
+            mismatch.contains("meerkat-mob/src/runtime/flow.rs")
+                && mismatch.contains(".flow_state.phase")
+        }),
+        "expected owner-struct destructured flow_state alias mutation to be rejected, got {mismatches:#?}"
+    );
+}
+
+#[test]
+fn live_flow_runtime_projection_ratchet_rejects_aliased_owner_struct_destructured_state_alias_mutation()
+ {
+    let dir = tempdir().expect("tempdir");
+    let runtime = dir.path().join("meerkat-mob/src/runtime");
+    fs::create_dir_all(&runtime).expect("create runtime dir");
+    fs::write(
+        runtime.join("flow.rs"),
+        r"
+use crate::run::MobRun as Run;
+
+fn bad(run: &mut Run) {
+    let Run { flow_state: state, .. } = run;
+    state.phase = flow_run::Phase::Running;
+}
+",
+    )
+    .expect("write aliased owner struct destructured state alias mutation");
+
+    let mismatches = collect_direct_flow_reducer_transition_mismatches(dir.path())
+        .expect("flow projection mutation mismatches");
+    assert!(
+        mismatches.iter().any(|mismatch| {
+            mismatch.contains("meerkat-mob/src/runtime/flow.rs")
+                && mismatch.contains(".flow_state.phase")
+        }),
+        "expected aliased owner-struct destructured flow_state alias mutation to be rejected, got {mismatches:#?}"
+    );
+}
+
+#[test]
 fn live_flow_runtime_projection_ratchet_accepts_actor_store_plan_commit() {
+    let dir = tempdir().expect("tempdir");
+    let runtime = dir.path().join("meerkat-mob/src/runtime");
+    fs::create_dir_all(&runtime).expect("create runtime dir");
+    fs::write(
+        runtime.join("actor.rs"),
+        r#"
+impl MobActor {
+    async fn commit_flow_frame_store_plan_in_actor(
+        &mut self,
+        run_id: &RunId,
+        plan: FlowFrameLoopStorePlan,
+    ) -> Result<bool, MobError> {
+        if !self
+            .flow_frame_store_plan_expected_matches(run_id, &plan)
+            .await?
+        {
+            return Ok(false);
+        }
+        let prepared =
+            self.prepare_dsl_inputs(plan.machine_inputs(), "flow_frame_loop_store_plan")?;
+        let authority_inputs = plan.machine_inputs().to_vec();
+        let won = match &plan {
+            FlowFrameLoopStorePlan::InsertFrame {
+                frame_id,
+                initial_frame,
+                ..
+            } => self
+                .run_store
+                .cas_frame_state_with_authority(
+                    run_id,
+                    frame_id,
+                    None,
+                    initial_frame.clone(),
+                    authority_inputs.clone(),
+                )
+                .await?,
+            FlowFrameLoopStorePlan::FrameState {
+                frame_id,
+                expected_frame,
+                next_frame,
+                ..
+            } => self
+                .run_store
+                .cas_frame_state_with_authority(
+                    run_id,
+                    frame_id,
+                    Some(expected_frame),
+                    next_frame.clone(),
+                    authority_inputs.clone(),
+                )
+                .await?,
+            FlowFrameLoopStorePlan::CompleteStepAndRecordOutput {
+                frame_id,
+                expected_frame,
+                next_frame,
+                step_output_key,
+                step_output,
+                loop_context,
+                ..
+            } => self
+                .run_store
+                .cas_complete_step_and_record_output_with_authority(
+                    run_id,
+                    frame_id,
+                    expected_frame,
+                    next_frame.clone(),
+                    step_output_key.clone(),
+                    step_output.clone(),
+                    loop_context
+                        .as_ref()
+                        .map(|(loop_id, iteration)| (loop_id, *iteration)),
+                    authority_inputs.clone(),
+                )
+                .await?,
+            FlowFrameLoopStorePlan::GrantNodeSlot {
+                expected_run_state,
+                next_run_state,
+                frame_id,
+                expected_frame,
+                next_frame,
+                ..
+            } => self
+                .run_store
+                .cas_grant_node_slot_with_authority(
+                    run_id,
+                    expected_run_state,
+                    next_run_state.clone(),
+                    frame_id,
+                    expected_frame,
+                    next_frame.clone(),
+                    authority_inputs.clone(),
+                )
+                .await?,
+            FlowFrameLoopStorePlan::StartLoop {
+                loop_instance_id,
+                expected_run_state,
+                next_run_state,
+                frame_id,
+                expected_frame,
+                next_frame,
+                initial_loop,
+                ..
+            } => self
+                .run_store
+                .cas_start_loop_with_authority(
+                    run_id,
+                    loop_instance_id,
+                    expected_run_state,
+                    next_run_state.clone(),
+                    frame_id,
+                    expected_frame,
+                    next_frame.clone(),
+                    initial_loop.clone(),
+                    authority_inputs.clone(),
+                )
+                .await?,
+            FlowFrameLoopStorePlan::GrantBodyFrameStart {
+                loop_instance_id,
+                expected_loop,
+                next_loop,
+                frame_id,
+                initial_frame,
+                ledger_entry,
+                expected_run_state,
+                next_run_state,
+                ..
+            } => self
+                .run_store
+                .cas_grant_body_frame_start_with_authority(
+                    run_id,
+                    loop_instance_id,
+                    expected_loop,
+                    next_loop.clone(),
+                    frame_id,
+                    initial_frame.clone(),
+                    ledger_entry.clone(),
+                    expected_run_state,
+                    next_run_state.clone(),
+                    authority_inputs.clone(),
+                )
+                .await?,
+            FlowFrameLoopStorePlan::RunStateOnly {
+                expected_run_state,
+                next_run_state,
+                ..
+            } => self
+                .run_store
+                .cas_flow_state_with_authority(
+                    run_id,
+                    expected_run_state,
+                    next_run_state,
+                    authority_inputs.clone(),
+                )
+                .await?,
+            FlowFrameLoopStorePlan::SealFrame {
+                frame_id,
+                expected_frame,
+                next_frame,
+                ..
+            } => self
+                .run_store
+                .cas_frame_state_with_authority(
+                    run_id,
+                    frame_id,
+                    Some(expected_frame),
+                    next_frame.clone(),
+                    authority_inputs.clone(),
+                )
+                .await?,
+            FlowFrameLoopStorePlan::CompleteBodyFrame {
+                loop_instance_id,
+                expected_loop,
+                next_loop,
+                frame_id,
+                expected_frame,
+                next_frame,
+                expected_run_state,
+                next_run_state,
+                ..
+            } => self
+                .run_store
+                .cas_complete_body_frame_with_authority(
+                    run_id,
+                    loop_instance_id,
+                    expected_loop,
+                    next_loop.clone(),
+                    frame_id,
+                    expected_frame,
+                    next_frame.clone(),
+                    expected_run_state,
+                    next_run_state.clone(),
+                    authority_inputs.clone(),
+                )
+                .await?,
+            FlowFrameLoopStorePlan::LoopRequestBodyFrame {
+                loop_instance_id,
+                expected_loop,
+                next_loop,
+                expected_run_state,
+                next_run_state,
+                ..
+            } => self
+                .run_store
+                .cas_loop_request_body_frame_with_authority(
+                    run_id,
+                    loop_instance_id,
+                    expected_loop,
+                    next_loop.clone(),
+                    expected_run_state,
+                    next_run_state.clone(),
+                    authority_inputs.clone(),
+                )
+                .await?,
+            FlowFrameLoopStorePlan::CompleteLoop {
+                loop_instance_id,
+                expected_loop,
+                next_loop,
+                frame_id,
+                expected_frame,
+                next_frame,
+                expected_run_state,
+                next_run_state,
+                ..
+            } => self
+                .run_store
+                .cas_complete_loop_with_authority(
+                    run_id,
+                    loop_instance_id,
+                    expected_loop,
+                    next_loop.clone(),
+                    frame_id,
+                    expected_frame,
+                    next_frame.clone(),
+                    expected_run_state,
+                    next_run_state.clone(),
+                    authority_inputs.clone(),
+                )
+                .await?,
+            _ => false,
+        };
+        if won {
+            self.commit_prepared_dsl_input(prepared);
+        }
+        Ok(won)
+    }
+}
+"#,
+    )
+    .expect("write actor store plan commit");
+
+    let mismatches = collect_direct_flow_reducer_transition_mismatches(dir.path())
+        .expect("flow projection mutation mismatches");
+    assert!(
+        mismatches.is_empty(),
+        "expected actor-gated store plan commits to be accepted, got {mismatches:#?}"
+    );
+}
+
+#[test]
+fn live_flow_runtime_projection_ratchet_rejects_actor_store_plan_wrong_run_id_arg() {
+    let dir = tempdir().expect("tempdir");
+    let runtime = dir.path().join("meerkat-mob/src/runtime");
+    fs::create_dir_all(&runtime).expect("create runtime dir");
+    fs::write(
+        runtime.join("actor.rs"),
+        r#"
+impl MobActor {
+    async fn commit_flow_frame_store_plan_in_actor(
+        &mut self,
+        run_id: &RunId,
+        other_run_id: &RunId,
+        plan: FlowFrameLoopStorePlan,
+    ) -> Result<bool, MobError> {
+        let prepared =
+            self.prepare_dsl_inputs(plan.machine_inputs(), "flow_frame_loop_store_plan")?;
+        let won = match &plan {
+            FlowFrameLoopStorePlan::RunStateOnly {
+                expected_run_state,
+                next_run_state,
+                ..
+            } => self
+                .run_store
+                .cas_flow_state(other_run_id, expected_run_state, next_run_state)
+                .await?,
+            _ => false,
+        };
+        if won {
+            self.commit_prepared_dsl_input(prepared);
+        }
+        Ok(won)
+    }
+}
+"#,
+    )
+    .expect("write actor store plan wrong run_id arg");
+
+    let mismatches = collect_direct_flow_reducer_transition_mismatches(dir.path())
+        .expect("flow projection mutation mismatches");
+    assert!(
+        mismatches.iter().any(|mismatch| {
+            mismatch.contains("meerkat-mob/src/runtime/actor.rs")
+                && mismatch.contains(".cas_flow_state(")
+        }),
+        "expected actor store-plan CAS with wrong run_id arg to be rejected, got {mismatches:#?}"
+    );
+}
+
+#[test]
+fn live_flow_runtime_projection_ratchet_rejects_actor_store_plan_swapped_run_state_args() {
+    let dir = tempdir().expect("tempdir");
+    let runtime = dir.path().join("meerkat-mob/src/runtime");
+    fs::create_dir_all(&runtime).expect("create runtime dir");
+    fs::write(
+        runtime.join("actor.rs"),
+        r#"
+impl MobActor {
+    async fn commit_flow_frame_store_plan_in_actor(
+        &mut self,
+        run_id: &RunId,
+        plan: FlowFrameLoopStorePlan,
+    ) -> Result<bool, MobError> {
+        let prepared =
+            self.prepare_dsl_inputs(plan.machine_inputs(), "flow_frame_loop_store_plan")?;
+        let won = match &plan {
+            FlowFrameLoopStorePlan::RunStateOnly {
+                expected_run_state,
+                next_run_state,
+                ..
+            } => self
+                .run_store
+                .cas_flow_state(run_id, next_run_state, expected_run_state)
+                .await?,
+            _ => false,
+        };
+        if won {
+            self.commit_prepared_dsl_input(prepared);
+        }
+        Ok(won)
+    }
+}
+"#,
+    )
+    .expect("write actor store plan swapped run state args");
+
+    let mismatches = collect_direct_flow_reducer_transition_mismatches(dir.path())
+        .expect("flow projection mutation mismatches");
+    assert!(
+        mismatches.iter().any(|mismatch| {
+            mismatch.contains("meerkat-mob/src/runtime/actor.rs")
+                && mismatch.contains(".cas_flow_state(")
+        }),
+        "expected actor store-plan CAS with swapped expected/next run states to be rejected, got {mismatches:#?}"
+    );
+}
+
+#[test]
+fn live_flow_runtime_projection_ratchet_rejects_actor_store_plan_wrong_cas_for_variant() {
+    let dir = tempdir().expect("tempdir");
+    let runtime = dir.path().join("meerkat-mob/src/runtime");
+    fs::create_dir_all(&runtime).expect("create runtime dir");
+    fs::write(
+        runtime.join("actor.rs"),
+        r#"
+impl MobActor {
+    async fn commit_flow_frame_store_plan_in_actor(
+        &mut self,
+        run_id: &RunId,
+        plan: FlowFrameLoopStorePlan,
+    ) -> Result<bool, MobError> {
+        let prepared =
+            self.prepare_dsl_inputs(plan.machine_inputs(), "flow_frame_loop_store_plan")?;
+        let won = match &plan {
+            FlowFrameLoopStorePlan::GrantNodeSlot {
+                expected_run_state,
+                next_run_state,
+                frame_id,
+                expected_frame,
+                next_frame,
+                ..
+            } => self
+                .run_store
+                .cas_flow_state(run_id, expected_run_state, next_run_state)
+                .await?,
+            _ => false,
+        };
+        if won {
+            self.commit_prepared_dsl_input(prepared);
+        }
+        Ok(won)
+    }
+}
+"#,
+    )
+    .expect("write actor store plan wrong CAS for variant");
+
+    let mismatches = collect_direct_flow_reducer_transition_mismatches(dir.path())
+        .expect("flow projection mutation mismatches");
+    assert!(
+        mismatches.iter().any(|mismatch| {
+            mismatch.contains("meerkat-mob/src/runtime/actor.rs")
+                && mismatch.contains(".cas_flow_state(")
+        }),
+        "expected actor store-plan CAS that drops GrantNodeSlot frame fields to be rejected, got {mismatches:#?}"
+    );
+}
+
+#[test]
+fn live_flow_runtime_projection_ratchet_rejects_actor_store_plan_discarded_loop_context() {
+    let dir = tempdir().expect("tempdir");
+    let runtime = dir.path().join("meerkat-mob/src/runtime");
+    fs::create_dir_all(&runtime).expect("create runtime dir");
+    fs::write(
+        runtime.join("actor.rs"),
+        r#"
+impl MobActor {
+    async fn commit_flow_frame_store_plan_in_actor(
+        &mut self,
+        run_id: &RunId,
+        plan: FlowFrameLoopStorePlan,
+    ) -> Result<bool, MobError> {
+        let prepared =
+            self.prepare_dsl_inputs(plan.machine_inputs(), "flow_frame_loop_store_plan")?;
+        let authority_inputs = plan.machine_inputs().to_vec();
+        let won = match &plan {
+            FlowFrameLoopStorePlan::CompleteStepAndRecordOutput {
+                frame_id,
+                expected_frame,
+                next_frame,
+                step_output_key,
+                step_output,
+                loop_context,
+                ..
+            } => self
+                .run_store
+                .cas_complete_step_and_record_output_with_authority(
+                    run_id,
+                    frame_id,
+                    expected_frame,
+                    next_frame.clone(),
+                    step_output_key.clone(),
+                    step_output.clone(),
+                    None,
+                    authority_inputs,
+                )
+                .await?,
+            _ => false,
+        };
+        if won {
+            self.commit_prepared_dsl_input(prepared);
+        }
+        Ok(won)
+    }
+}
+"#,
+    )
+    .expect("write actor store plan discarded loop context");
+
+    let mismatches = collect_direct_flow_reducer_transition_mismatches(dir.path())
+        .expect("flow projection mutation mismatches");
+    assert!(
+        mismatches.iter().any(|mismatch| {
+            mismatch.contains("meerkat-mob/src/runtime/actor.rs")
+                && mismatch.contains(".cas_complete_step_and_record_output_with_authority(")
+        }),
+        "expected actor store-plan CAS that discards loop_context to be rejected, got {mismatches:#?}"
+    );
+}
+
+#[test]
+fn live_flow_runtime_projection_ratchet_rejects_actor_store_plan_same_shape_wrong_cas_variant() {
+    let dir = tempdir().expect("tempdir");
+    let runtime = dir.path().join("meerkat-mob/src/runtime");
+    fs::create_dir_all(&runtime).expect("create runtime dir");
+    fs::write(
+        runtime.join("actor.rs"),
+        r#"
+impl MobActor {
+    async fn commit_flow_frame_store_plan_in_actor(
+        &mut self,
+        run_id: &RunId,
+        plan: FlowFrameLoopStorePlan,
+    ) -> Result<bool, MobError> {
+        let prepared =
+            self.prepare_dsl_inputs(plan.machine_inputs(), "flow_frame_loop_store_plan")?;
+        let authority_inputs = plan.machine_inputs().to_vec();
+        let won = match &plan {
+            FlowFrameLoopStorePlan::CompleteBodyFrame {
+                loop_instance_id,
+                expected_loop,
+                next_loop,
+                frame_id,
+                expected_frame,
+                next_frame,
+                expected_run_state,
+                next_run_state,
+                ..
+            } => self
+                .run_store
+                .cas_complete_loop_with_authority(
+                    run_id,
+                    loop_instance_id,
+                    expected_loop,
+                    next_loop.clone(),
+                    frame_id,
+                    expected_frame,
+                    next_frame.clone(),
+                    expected_run_state,
+                    next_run_state.clone(),
+                    authority_inputs,
+                )
+                .await?,
+            _ => false,
+        };
+        if won {
+            self.commit_prepared_dsl_input(prepared);
+        }
+        Ok(won)
+    }
+}
+"#,
+    )
+    .expect("write actor store plan same-shape wrong CAS variant");
+
+    let mismatches = collect_direct_flow_reducer_transition_mismatches(dir.path())
+        .expect("flow projection mutation mismatches");
+    assert!(
+        mismatches.iter().any(|mismatch| {
+            mismatch.contains("meerkat-mob/src/runtime/actor.rs")
+                && mismatch.contains(".cas_complete_loop_with_authority(")
+        }),
+        "expected same-shape store-plan variant to require its canonical CAS method, got {mismatches:#?}"
+    );
+}
+
+#[test]
+fn live_flow_runtime_projection_ratchet_rejects_actor_store_plan_or_pattern_variant_union() {
+    let dir = tempdir().expect("tempdir");
+    let runtime = dir.path().join("meerkat-mob/src/runtime");
+    fs::create_dir_all(&runtime).expect("create runtime dir");
+    fs::write(
+        runtime.join("actor.rs"),
+        r#"
+impl MobActor {
+    async fn commit_flow_frame_store_plan_in_actor(
+        &mut self,
+        run_id: &RunId,
+        plan: FlowFrameLoopStorePlan,
+    ) -> Result<bool, MobError> {
+        let prepared =
+            self.prepare_dsl_inputs(plan.machine_inputs(), "flow_frame_loop_store_plan")?;
+        let won = match &plan {
+            FlowFrameLoopStorePlan::GrantNodeSlot {
+                expected_run_state,
+                next_run_state,
+                frame_id,
+                expected_frame,
+                next_frame,
+                ..
+            }
+            | FlowFrameLoopStorePlan::StartLoop {
+                expected_run_state,
+                next_run_state,
+                frame_id,
+                expected_frame,
+                next_frame,
+                ..
+            } => self
+                .run_store
+                .cas_grant_node_slot(
+                    run_id,
+                    expected_run_state,
+                    next_run_state.clone(),
+                    frame_id,
+                    expected_frame,
+                    next_frame.clone(),
+                )
+                .await?,
+            _ => false,
+        };
+        if won {
+            self.commit_prepared_dsl_input(prepared);
+        }
+        Ok(won)
+    }
+}
+"#,
+    )
+    .expect("write actor store plan or-pattern variant union");
+
+    let mismatches = collect_direct_flow_reducer_transition_mismatches(dir.path())
+        .expect("flow projection mutation mismatches");
+    assert!(
+        mismatches.iter().any(|mismatch| {
+            mismatch.contains("meerkat-mob/src/runtime/actor.rs")
+                && mismatch.contains(".cas_grant_node_slot(")
+        }),
+        "expected store-plan or-pattern variant union to be rejected, got {mismatches:#?}"
+    );
+}
+
+#[test]
+fn live_flow_runtime_projection_ratchet_rejects_actor_store_plan_reassigned_plan_parameter() {
+    let dir = tempdir().expect("tempdir");
+    let runtime = dir.path().join("meerkat-mob/src/runtime");
+    fs::create_dir_all(&runtime).expect("create runtime dir");
+    fs::write(
+        runtime.join("actor.rs"),
+        r#"
+impl MobActor {
+    async fn commit_flow_frame_store_plan_in_actor(
+        &mut self,
+        run_id: &RunId,
+        mut plan: FlowFrameLoopStorePlan,
+    ) -> Result<bool, MobError> {
+        let prepared =
+            self.prepare_dsl_inputs(plan.machine_inputs(), "flow_frame_loop_store_plan")?;
+        plan = replacement_plan();
+        let won = match &plan {
+            FlowFrameLoopStorePlan::RunStateOnly {
+                expected_run_state,
+                next_run_state,
+                ..
+            } => self
+                .run_store
+                .cas_flow_state(run_id, expected_run_state, next_run_state)
+                .await?,
+            _ => false,
+        };
+        if won {
+            self.commit_prepared_dsl_input(prepared);
+        }
+        Ok(won)
+    }
+}
+"#,
+    )
+    .expect("write actor store plan reassigned plan parameter");
+
+    let mismatches = collect_direct_flow_reducer_transition_mismatches(dir.path())
+        .expect("flow projection mutation mismatches");
+    assert!(
+        mismatches.iter().any(|mismatch| {
+            mismatch.contains("meerkat-mob/src/runtime/actor.rs")
+                && mismatch.contains(".cas_flow_state(")
+        }),
+        "expected actor store-plan CAS with reassigned plan parameter to be rejected, got {mismatches:#?}"
+    );
+}
+
+#[test]
+fn live_flow_runtime_projection_ratchet_rejects_actor_store_plan_previously_mutated_plan_parameter()
+{
+    let dir = tempdir().expect("tempdir");
+    let runtime = dir.path().join("meerkat-mob/src/runtime");
+    fs::create_dir_all(&runtime).expect("create runtime dir");
+    fs::write(
+        runtime.join("actor.rs"),
+        r#"
+impl MobActor {
+    async fn commit_flow_frame_store_plan_in_actor(
+        &mut self,
+        run_id: &RunId,
+        mut plan: FlowFrameLoopStorePlan,
+    ) -> Result<bool, MobError> {
+        std::mem::replace(&mut plan, replacement_plan());
+        let prepared =
+            self.prepare_dsl_inputs(plan.machine_inputs(), "flow_frame_loop_store_plan")?;
+        let won = match &plan {
+            FlowFrameLoopStorePlan::RunStateOnly {
+                expected_run_state,
+                next_run_state,
+                ..
+            } => self
+                .run_store
+                .cas_flow_state(run_id, expected_run_state, next_run_state)
+                .await?,
+            _ => false,
+        };
+        if won {
+            self.commit_prepared_dsl_input(prepared);
+        }
+        Ok(won)
+    }
+}
+"#,
+    )
+    .expect("write actor store plan mutated plan parameter before prepare");
+
+    let mismatches = collect_direct_flow_reducer_transition_mismatches(dir.path())
+        .expect("flow projection mutation mismatches");
+    assert!(
+        mismatches.iter().any(|mismatch| {
+            mismatch.contains("meerkat-mob/src/runtime/actor.rs")
+                && mismatch.contains(".cas_flow_state(")
+        }),
+        "expected actor store-plan CAS with previously mutated plan parameter to be rejected, got {mismatches:#?}"
+    );
+}
+
+#[test]
+fn live_flow_runtime_projection_ratchet_rejects_actor_store_plan_shadowed_plan_parameter() {
+    let dir = tempdir().expect("tempdir");
+    let runtime = dir.path().join("meerkat-mob/src/runtime");
+    fs::create_dir_all(&runtime).expect("create runtime dir");
+    fs::write(
+        runtime.join("actor.rs"),
+        r#"
+impl MobActor {
+    async fn commit_flow_frame_store_plan_in_actor(
+        &mut self,
+        run_id: &RunId,
+        plan: FlowFrameLoopStorePlan,
+        fake_plan: FlowFrameLoopStorePlan,
+    ) -> Result<bool, MobError> {
+        let plan = fake_plan;
+        let prepared =
+            self.prepare_dsl_inputs(plan.machine_inputs(), "flow_frame_loop_store_plan")?;
+        let won = match &plan {
+            FlowFrameLoopStorePlan::RunStateOnly {
+                expected_run_state,
+                next_run_state,
+                ..
+            } => self
+                .run_store
+                .cas_flow_state(run_id, expected_run_state, next_run_state)
+                .await?,
+            _ => false,
+        };
+        if won {
+            self.commit_prepared_dsl_input(prepared);
+        }
+        Ok(won)
+    }
+}
+"#,
+    )
+    .expect("write actor store plan shadowed plan parameter");
+
+    let mismatches = collect_direct_flow_reducer_transition_mismatches(dir.path())
+        .expect("flow projection mutation mismatches");
+    assert!(
+        mismatches.iter().any(|mismatch| {
+            mismatch.contains("meerkat-mob/src/runtime/actor.rs")
+                && mismatch.contains(".cas_flow_state(")
+        }),
+        "expected actor store-plan CAS using a shadowed plan parameter to be rejected, got {mismatches:#?}"
+    );
+}
+
+#[test]
+fn live_flow_runtime_projection_ratchet_rejects_actor_store_plan_fake_plan_parameter() {
+    let dir = tempdir().expect("tempdir");
+    let runtime = dir.path().join("meerkat-mob/src/runtime");
+    fs::create_dir_all(&runtime).expect("create runtime dir");
+    fs::write(
+        runtime.join("actor.rs"),
+        r#"
+impl MobActor {
+    async fn commit_flow_frame_store_plan_in_actor(
+        &mut self,
+        run_id: &RunId,
+        plan: FlowFrameLoopStorePlan,
+        fake_plan: FlowFrameLoopStorePlan,
+    ) -> Result<bool, MobError> {
+        let prepared =
+            self.prepare_dsl_inputs(fake_plan.machine_inputs(), "flow_frame_loop_store_plan")?;
+        let won = match &fake_plan {
+            FlowFrameLoopStorePlan::RunStateOnly {
+                expected_run_state,
+                next_run_state,
+                ..
+            } => self
+                .run_store
+                .cas_flow_state(run_id, expected_run_state, next_run_state)
+                .await?,
+            _ => false,
+        };
+        if won {
+            self.commit_prepared_dsl_input(prepared);
+        }
+        Ok(won)
+    }
+}
+"#,
+    )
+    .expect("write actor store plan fake plan parameter");
+
+    let mismatches = collect_direct_flow_reducer_transition_mismatches(dir.path())
+        .expect("flow projection mutation mismatches");
+    assert!(
+        mismatches.iter().any(|mismatch| {
+            mismatch.contains("meerkat-mob/src/runtime/actor.rs")
+                && mismatch.contains(".cas_flow_state(")
+        }),
+        "expected actor store-plan CAS using a fake plan parameter to be rejected, got {mismatches:#?}"
+    );
+}
+
+#[test]
+fn live_flow_runtime_projection_ratchet_rejects_actor_store_plan_nested_prepared_reassignment() {
+    let dir = tempdir().expect("tempdir");
+    let runtime = dir.path().join("meerkat-mob/src/runtime");
+    fs::create_dir_all(&runtime).expect("create runtime dir");
+    fs::write(
+        runtime.join("actor.rs"),
+        r#"
+impl MobActor {
+    async fn commit_flow_frame_store_plan_in_actor(
+        &mut self,
+        run_id: &RunId,
+        plan: FlowFrameLoopStorePlan,
+    ) -> Result<bool, MobError> {
+        let mut prepared =
+            self.prepare_dsl_inputs(plan.machine_inputs(), "flow_frame_loop_store_plan")?;
+        {
+            let fake_prepared =
+                self.prepare_dsl_inputs(Vec::new(), "flow_frame_loop_store_plan")?;
+            prepared = fake_prepared;
+        }
+        let won = match &plan {
+            FlowFrameLoopStorePlan::RunStateOnly {
+                expected_run_state,
+                next_run_state,
+                ..
+            } => self
+                .run_store
+                .cas_flow_state(run_id, expected_run_state, next_run_state)
+                .await?,
+            _ => false,
+        };
+        if won {
+            self.commit_prepared_dsl_input(prepared);
+        }
+        Ok(won)
+    }
+}
+"#,
+    )
+    .expect("write actor store plan nested prepared reassignment");
+
+    let mismatches = collect_direct_flow_reducer_transition_mismatches(dir.path())
+        .expect("flow projection mutation mismatches");
+    assert!(
+        mismatches.iter().any(|mismatch| {
+            mismatch.contains("meerkat-mob/src/runtime/actor.rs")
+                && mismatch.contains(".cas_flow_state(")
+        }),
+        "expected actor store-plan CAS after nested prepared reassignment to be rejected, got {mismatches:#?}"
+    );
+}
+
+#[test]
+fn live_flow_runtime_projection_ratchet_rejects_actor_store_plan_nested_match_result_reassignment()
+{
+    let dir = tempdir().expect("tempdir");
+    let runtime = dir.path().join("meerkat-mob/src/runtime");
+    fs::create_dir_all(&runtime).expect("create runtime dir");
+    fs::write(
+        runtime.join("actor.rs"),
+        r#"
+impl MobActor {
+    async fn commit_flow_frame_store_plan_in_actor(
+        &mut self,
+        run_id: &RunId,
+        plan: FlowFrameLoopStorePlan,
+        should_commit: bool,
+    ) -> Result<bool, MobError> {
+        let prepared =
+            self.prepare_dsl_inputs(plan.machine_inputs(), "flow_frame_loop_store_plan")?;
+        let mut won = match &plan {
+            FlowFrameLoopStorePlan::RunStateOnly {
+                expected_run_state,
+                next_run_state,
+                ..
+            } => self
+                .run_store
+                .cas_flow_state(run_id, expected_run_state, next_run_state)
+                .await?,
+            _ => false,
+        };
+        {
+            won = should_commit;
+        }
+        if won {
+            self.commit_prepared_dsl_input(prepared);
+        }
+        Ok(won)
+    }
+}
+"#,
+    )
+    .expect("write actor store plan nested match result reassignment");
+
+    let mismatches = collect_direct_flow_reducer_transition_mismatches(dir.path())
+        .expect("flow projection mutation mismatches");
+    assert!(
+        mismatches.iter().any(|mismatch| {
+            mismatch.contains("meerkat-mob/src/runtime/actor.rs")
+                && mismatch.contains(".cas_flow_state(")
+        }),
+        "expected actor store-plan CAS after nested match-result reassignment to be rejected, got {mismatches:#?}"
+    );
+}
+
+#[test]
+fn live_flow_runtime_projection_ratchet_rejects_actor_store_plan_fake_cas_receiver() {
+    let dir = tempdir().expect("tempdir");
+    let runtime = dir.path().join("meerkat-mob/src/runtime");
+    fs::create_dir_all(&runtime).expect("create runtime dir");
+    fs::write(
+        runtime.join("actor.rs"),
+        r#"
+impl MobActor {
+    async fn commit_flow_frame_store_plan_in_actor(
+        &mut self,
+        run_id: &RunId,
+        plan: FlowFrameLoopStorePlan,
+    ) -> Result<bool, MobError> {
+        let prepared =
+            self.prepare_dsl_inputs(plan.machine_inputs(), "flow_frame_loop_store_plan")?;
+        let fake_store = FakeRunStore::default();
+        let won = match &plan {
+            FlowFrameLoopStorePlan::RunStateOnly {
+                expected_run_state,
+                next_run_state,
+                ..
+            } => fake_store
+                .cas_flow_state(run_id, expected_run_state, next_run_state)
+                .await?,
+            _ => false,
+        };
+        if won {
+            self.commit_prepared_dsl_input(prepared);
+        }
+        Ok(won)
+    }
+}
+"#,
+    )
+    .expect("write actor store plan fake cas receiver");
+
+    let mismatches = collect_direct_flow_reducer_transition_mismatches(dir.path())
+        .expect("flow projection mutation mismatches");
+    assert!(
+        mismatches.iter().any(|mismatch| {
+            mismatch.contains("meerkat-mob/src/runtime/actor.rs")
+                && mismatch.contains(".cas_flow_state(")
+        }),
+        "expected actor store-plan CAS on fake receiver to be rejected, got {mismatches:#?}"
+    );
+}
+
+#[test]
+fn live_flow_runtime_projection_ratchet_rejects_actor_store_plan_shadowed_prepared_commit_after_cas()
+ {
+    let dir = tempdir().expect("tempdir");
+    let runtime = dir.path().join("meerkat-mob/src/runtime");
+    fs::create_dir_all(&runtime).expect("create runtime dir");
+    fs::write(
+        runtime.join("actor.rs"),
+        r#"
+impl MobActor {
+    async fn commit_flow_frame_store_plan_in_actor(
+        &mut self,
+        run_id: &RunId,
+        plan: FlowFrameLoopStorePlan,
+    ) -> Result<bool, MobError> {
+        let prepared =
+            self.prepare_dsl_inputs(plan.machine_inputs(), "flow_frame_loop_store_plan")?;
+        let won = match &plan {
+            FlowFrameLoopStorePlan::RunStateOnly {
+                expected_run_state,
+                next_run_state,
+                ..
+            } => self
+                .run_store
+                .cas_flow_state(run_id, expected_run_state, next_run_state)
+                .await?,
+            _ => false,
+        };
+        if won {
+            let prepared =
+                self.prepare_dsl_inputs(plan.machine_inputs(), "flow_frame_loop_store_plan")?;
+            self.commit_prepared_dsl_input(prepared);
+        }
+        Ok(won)
+    }
+}
+"#,
+    )
+    .expect("write actor store plan shadowed prepared commit after cas");
+
+    let mismatches = collect_direct_flow_reducer_transition_mismatches(dir.path())
+        .expect("flow projection mutation mismatches");
+    assert!(
+        mismatches.iter().any(|mismatch| {
+            mismatch.contains("meerkat-mob/src/runtime/actor.rs")
+                && mismatch.contains(".cas_flow_state(")
+        }),
+        "expected actor store-plan CAS committed with a post-CAS shadowed prepared input to be rejected, got {mismatches:#?}"
+    );
+}
+
+#[test]
+fn live_flow_runtime_projection_ratchet_rejects_actor_store_plan_mutated_prepared_field() {
+    let dir = tempdir().expect("tempdir");
+    let runtime = dir.path().join("meerkat-mob/src/runtime");
+    fs::create_dir_all(&runtime).expect("create runtime dir");
+    fs::write(
+        runtime.join("actor.rs"),
+        r#"
+impl MobActor {
+    async fn commit_flow_frame_store_plan_in_actor(
+        &mut self,
+        run_id: &RunId,
+        plan: FlowFrameLoopStorePlan,
+    ) -> Result<bool, MobError> {
+        let mut prepared =
+            self.prepare_dsl_inputs(plan.machine_inputs(), "flow_frame_loop_store_plan")?;
+        prepared.effects.clear();
+        let won = match &plan {
+            FlowFrameLoopStorePlan::RunStateOnly {
+                expected_run_state,
+                next_run_state,
+                ..
+            } => self
+                .run_store
+                .cas_flow_state(run_id, expected_run_state, next_run_state)
+                .await?,
+            _ => false,
+        };
+        if won {
+            self.commit_prepared_dsl_input(prepared);
+        }
+        Ok(won)
+    }
+}
+"#,
+    )
+    .expect("write actor store plan mutated prepared field");
+
+    let mismatches = collect_direct_flow_reducer_transition_mismatches(dir.path())
+        .expect("flow projection mutation mismatches");
+    assert!(
+        mismatches.iter().any(|mismatch| {
+            mismatch.contains("meerkat-mob/src/runtime/actor.rs")
+                && mismatch.contains(".cas_flow_state(")
+        }),
+        "expected actor store-plan CAS committed with mutated prepared field to be rejected, got {mismatches:#?}"
+    );
+}
+
+#[test]
+fn live_flow_runtime_projection_ratchet_rejects_actor_store_plan_mutable_prepared_field_reference()
+{
+    let dir = tempdir().expect("tempdir");
+    let runtime = dir.path().join("meerkat-mob/src/runtime");
+    fs::create_dir_all(&runtime).expect("create runtime dir");
+    fs::write(
+        runtime.join("actor.rs"),
+        r#"
+impl MobActor {
+    async fn commit_flow_frame_store_plan_in_actor(
+        &mut self,
+        run_id: &RunId,
+        plan: FlowFrameLoopStorePlan,
+        fake_authority: MobMachineAuthority,
+    ) -> Result<bool, MobError> {
+        let mut prepared =
+            self.prepare_dsl_inputs(plan.machine_inputs(), "flow_frame_loop_store_plan")?;
+        let _old = std::mem::replace(&mut prepared.authority, fake_authority);
+        let won = match &plan {
+            FlowFrameLoopStorePlan::RunStateOnly {
+                expected_run_state,
+                next_run_state,
+                ..
+            } => self
+                .run_store
+                .cas_flow_state(run_id, expected_run_state, next_run_state)
+                .await?,
+            _ => false,
+        };
+        if won {
+            self.commit_prepared_dsl_input(prepared);
+        }
+        Ok(won)
+    }
+}
+"#,
+    )
+    .expect("write actor store plan mutable prepared field reference");
+
+    let mismatches = collect_direct_flow_reducer_transition_mismatches(dir.path())
+        .expect("flow projection mutation mismatches");
+    assert!(
+        mismatches.iter().any(|mismatch| {
+            mismatch.contains("meerkat-mob/src/runtime/actor.rs")
+                && mismatch.contains(".cas_flow_state(")
+        }),
+        "expected actor store-plan CAS committed with mutable prepared field reference to be rejected, got {mismatches:#?}"
+    );
+}
+
+#[test]
+fn live_flow_runtime_projection_ratchet_rejects_actor_store_plan_prepared_as_mut_slice() {
+    let dir = tempdir().expect("tempdir");
+    let runtime = dir.path().join("meerkat-mob/src/runtime");
+    fs::create_dir_all(&runtime).expect("create runtime dir");
+    fs::write(
+        runtime.join("actor.rs"),
+        r#"
+impl MobActor {
+    async fn commit_flow_frame_store_plan_in_actor(
+        &mut self,
+        run_id: &RunId,
+        plan: FlowFrameLoopStorePlan,
+        replacement_effect: PreparedDslEffect,
+    ) -> Result<bool, MobError> {
+        let mut prepared =
+            self.prepare_dsl_inputs(plan.machine_inputs(), "flow_frame_loop_store_plan")?;
+        prepared.effects.as_mut_slice()[0] = replacement_effect;
+        let won = match &plan {
+            FlowFrameLoopStorePlan::RunStateOnly {
+                expected_run_state,
+                next_run_state,
+                ..
+            } => self
+                .run_store
+                .cas_flow_state(run_id, expected_run_state, next_run_state)
+                .await?,
+            _ => false,
+        };
+        if won {
+            self.commit_prepared_dsl_input(prepared);
+        }
+        Ok(won)
+    }
+}
+"#,
+    )
+    .expect("write actor store plan prepared as_mut_slice mutation");
+
+    let mismatches = collect_direct_flow_reducer_transition_mismatches(dir.path())
+        .expect("flow projection mutation mismatches");
+    assert!(
+        mismatches.iter().any(|mismatch| {
+            mismatch.contains("meerkat-mob/src/runtime/actor.rs")
+                && mismatch.contains(".cas_flow_state(")
+        }),
+        "expected actor store-plan CAS with as_mut_slice-mutated prepared input to be rejected, got {mismatches:#?}"
+    );
+}
+
+#[test]
+fn live_flow_runtime_projection_ratchet_rejects_actor_store_plan_shadowed_won_guard_after_cas() {
+    let dir = tempdir().expect("tempdir");
+    let runtime = dir.path().join("meerkat-mob/src/runtime");
+    fs::create_dir_all(&runtime).expect("create runtime dir");
+    fs::write(
+        runtime.join("actor.rs"),
+        r#"
+impl MobActor {
+    async fn commit_flow_frame_store_plan_in_actor(
+        &mut self,
+        run_id: &RunId,
+        plan: FlowFrameLoopStorePlan,
+    ) -> Result<bool, MobError> {
+        let prepared =
+            self.prepare_dsl_inputs(plan.machine_inputs(), "flow_frame_loop_store_plan")?;
+        let won = match &plan {
+            FlowFrameLoopStorePlan::RunStateOnly {
+                expected_run_state,
+                next_run_state,
+                ..
+            } => self
+                .run_store
+                .cas_flow_state(run_id, expected_run_state, next_run_state)
+                .await?,
+            _ => false,
+        };
+        {
+            let won = match &plan {
+                FlowFrameLoopStorePlan::RunStateOnly { .. } => true,
+                _ => false,
+            };
+            if won {
+                self.commit_prepared_dsl_input(prepared);
+            }
+        }
+        Ok(won)
+    }
+}
+"#,
+    )
+    .expect("write actor store plan shadowed won guard after cas");
+
+    let mismatches = collect_direct_flow_reducer_transition_mismatches(dir.path())
+        .expect("flow projection mutation mismatches");
+    assert!(
+        mismatches.iter().any(|mismatch| {
+            mismatch.contains("meerkat-mob/src/runtime/actor.rs")
+                && mismatch.contains(".cas_flow_state(")
+        }),
+        "expected actor store-plan CAS committed under a post-CAS shadowed won guard to be rejected, got {mismatches:#?}"
+    );
+}
+
+#[test]
+fn live_flow_runtime_projection_ratchet_rejects_actor_store_plan_fake_plan_type_owner() {
+    let dir = tempdir().expect("tempdir");
+    let runtime = dir.path().join("meerkat-mob/src/runtime");
+    fs::create_dir_all(&runtime).expect("create runtime dir");
+    fs::write(
+        runtime.join("actor.rs"),
+        r#"
+mod fake {
+    pub enum FlowFrameLoopStorePlan {
+        RunStateOnly {
+            expected_run_state: flow_run::State,
+            next_run_state: flow_run::State,
+        },
+    }
+}
+
+impl MobActor {
+    async fn commit_flow_frame_store_plan_in_actor(
+        &mut self,
+        run_id: &RunId,
+        plan: fake::FlowFrameLoopStorePlan,
+    ) -> Result<bool, MobError> {
+        let prepared =
+            self.prepare_dsl_inputs(plan.machine_inputs(), "flow_frame_loop_store_plan")?;
+        let won = match &plan {
+            fake::FlowFrameLoopStorePlan::RunStateOnly {
+                expected_run_state,
+                next_run_state,
+            } => self
+                .run_store
+                .cas_flow_state(run_id, expected_run_state, next_run_state)
+                .await?,
+        };
+        if won {
+            self.commit_prepared_dsl_input(prepared);
+        }
+        Ok(won)
+    }
+}
+"#,
+    )
+    .expect("write actor store plan fake plan type owner");
+
+    let mismatches = collect_direct_flow_reducer_transition_mismatches(dir.path())
+        .expect("flow projection mutation mismatches");
+    assert!(
+        mismatches.iter().any(|mismatch| {
+            mismatch.contains("meerkat-mob/src/runtime/actor.rs")
+                && mismatch.contains(".cas_flow_state(")
+        }),
+        "expected actor store-plan CAS with fake FlowFrameLoopStorePlan owner to be rejected, got {mismatches:#?}"
+    );
+}
+
+#[test]
+fn live_flow_runtime_projection_ratchet_rejects_actor_store_plan_bare_shadowed_plan_type_owner() {
+    let dir = tempdir().expect("tempdir");
+    let runtime = dir.path().join("meerkat-mob/src/runtime");
+    fs::create_dir_all(&runtime).expect("create runtime dir");
+    fs::write(
+        runtime.join("actor.rs"),
+        r#"
+pub enum FlowFrameLoopStorePlan {
+    RunStateOnly {
+        expected_run_state: flow_run::State,
+        next_run_state: flow_run::State,
+    },
+}
+
+impl FlowFrameLoopStorePlan {
+    fn machine_inputs(&self) -> Vec<MobMachineInput> {
+        Vec::new()
+    }
+}
+
+impl MobActor {
+    async fn commit_flow_frame_store_plan_in_actor(
+        &mut self,
+        run_id: &RunId,
+        plan: FlowFrameLoopStorePlan,
+    ) -> Result<bool, MobError> {
+        let prepared =
+            self.prepare_dsl_inputs(plan.machine_inputs(), "flow_frame_loop_store_plan")?;
+        let won = match &plan {
+            FlowFrameLoopStorePlan::RunStateOnly {
+                expected_run_state,
+                next_run_state,
+            } => self
+                .run_store
+                .cas_flow_state(run_id, expected_run_state, next_run_state)
+                .await?,
+        };
+        if won {
+            self.commit_prepared_dsl_input(prepared);
+        }
+        Ok(won)
+    }
+}
+"#,
+    )
+    .expect("write actor store plan bare shadowed plan type owner");
+
+    let mismatches = collect_direct_flow_reducer_transition_mismatches(dir.path())
+        .expect("flow projection mutation mismatches");
+    assert!(
+        mismatches.iter().any(|mismatch| {
+            mismatch.contains("meerkat-mob/src/runtime/actor.rs")
+                && mismatch.contains(".cas_flow_state(")
+        }),
+        "expected actor store-plan CAS with bare shadowed FlowFrameLoopStorePlan owner to be rejected, got {mismatches:#?}"
+    );
+}
+
+#[test]
+fn live_flow_runtime_projection_ratchet_rejects_actor_store_plan_ambiguous_glob_plan_type_owner() {
+    let dir = tempdir().expect("tempdir");
+    let runtime = dir.path().join("meerkat-mob/src/runtime");
+    fs::create_dir_all(&runtime).expect("create runtime dir");
+    fs::write(
+        runtime.join("actor.rs"),
+        r#"
+mod fake {
+    pub enum FlowFrameLoopStorePlan {
+        RunStateOnly {
+            expected_run_state: flow_run::State,
+            next_run_state: flow_run::State,
+        },
+    }
+
+    impl FlowFrameLoopStorePlan {
+        pub fn machine_inputs(&self) -> Vec<MobMachineInput> {
+            Vec::new()
+        }
+    }
+}
+
+use fake::*;
+
+impl MobActor {
+    async fn commit_flow_frame_store_plan_in_actor(
+        &mut self,
+        run_id: &RunId,
+        plan: FlowFrameLoopStorePlan,
+    ) -> Result<bool, MobError> {
+        let prepared =
+            self.prepare_dsl_inputs(plan.machine_inputs(), "flow_frame_loop_store_plan")?;
+        let won = match &plan {
+            FlowFrameLoopStorePlan::RunStateOnly {
+                expected_run_state,
+                next_run_state,
+            } => self
+                .run_store
+                .cas_flow_state(run_id, expected_run_state, next_run_state)
+                .await?,
+        };
+        if won {
+            self.commit_prepared_dsl_input(prepared);
+        }
+        Ok(won)
+    }
+}
+"#,
+    )
+    .expect("write actor store plan ambiguous-glob plan type owner");
+
+    let mismatches = collect_direct_flow_reducer_transition_mismatches(dir.path())
+        .expect("flow projection mutation mismatches");
+    assert!(
+        mismatches.iter().any(|mismatch| {
+            mismatch.contains("meerkat-mob/src/runtime/actor.rs")
+                && mismatch.contains(".cas_flow_state(")
+        }),
+        "expected actor store-plan CAS with ambiguous-glob FlowFrameLoopStorePlan owner to be rejected, got {mismatches:#?}"
+    );
+}
+
+#[test]
+fn live_flow_runtime_projection_ratchet_rejects_actor_store_plan_fake_run_id_type_owner() {
+    let dir = tempdir().expect("tempdir");
+    let runtime = dir.path().join("meerkat-mob/src/runtime");
+    fs::create_dir_all(&runtime).expect("create runtime dir");
+    fs::write(
+        runtime.join("actor.rs"),
+        r#"
+mod fake {
+    pub struct RunId;
+}
+
+impl MobActor {
+    async fn commit_flow_frame_store_plan_in_actor(
+        &mut self,
+        run_id: &fake::RunId,
+        plan: FlowFrameLoopStorePlan,
+    ) -> Result<bool, MobError> {
+        let prepared =
+            self.prepare_dsl_inputs(plan.machine_inputs(), "flow_frame_loop_store_plan")?;
+        let won = match &plan {
+            FlowFrameLoopStorePlan::RunStateOnly {
+                expected_run_state,
+                next_run_state,
+                ..
+            } => self
+                .run_store
+                .cas_flow_state(run_id, expected_run_state, next_run_state)
+                .await?,
+            _ => false,
+        };
+        if won {
+            self.commit_prepared_dsl_input(prepared);
+        }
+        Ok(won)
+    }
+}
+"#,
+    )
+    .expect("write actor store plan fake run id type owner");
+
+    let mismatches = collect_direct_flow_reducer_transition_mismatches(dir.path())
+        .expect("flow projection mutation mismatches");
+    assert!(
+        mismatches.iter().any(|mismatch| {
+            mismatch.contains("meerkat-mob/src/runtime/actor.rs")
+                && mismatch.contains(".cas_flow_state(")
+        }),
+        "expected actor store-plan CAS with fake RunId owner to be rejected, got {mismatches:#?}"
+    );
+}
+
+#[test]
+fn live_flow_runtime_projection_ratchet_rejects_actor_store_plan_ambiguous_glob_run_id_type_owner()
+{
+    let dir = tempdir().expect("tempdir");
+    let runtime = dir.path().join("meerkat-mob/src/runtime");
+    fs::create_dir_all(&runtime).expect("create runtime dir");
+    fs::write(
+        runtime.join("actor.rs"),
+        r#"
+mod fake {
+    pub struct RunId;
+}
+
+use fake::*;
+
+impl MobActor {
+    async fn commit_flow_frame_store_plan_in_actor(
+        &mut self,
+        run_id: &RunId,
+        plan: FlowFrameLoopStorePlan,
+    ) -> Result<bool, MobError> {
+        let prepared =
+            self.prepare_dsl_inputs(plan.machine_inputs(), "flow_frame_loop_store_plan")?;
+        let won = match &plan {
+            FlowFrameLoopStorePlan::RunStateOnly {
+                expected_run_state,
+                next_run_state,
+                ..
+            } => self
+                .run_store
+                .cas_flow_state(run_id, expected_run_state, next_run_state)
+                .await?,
+            _ => false,
+        };
+        if won {
+            self.commit_prepared_dsl_input(prepared);
+        }
+        Ok(won)
+    }
+}
+"#,
+    )
+    .expect("write actor store plan ambiguous-glob RunId type owner");
+
+    let mismatches = collect_direct_flow_reducer_transition_mismatches(dir.path())
+        .expect("flow projection mutation mismatches");
+    assert!(
+        mismatches.iter().any(|mismatch| {
+            mismatch.contains("meerkat-mob/src/runtime/actor.rs")
+                && mismatch.contains(".cas_flow_state(")
+        }),
+        "expected actor store-plan CAS with ambiguous-glob RunId owner to be rejected, got {mismatches:#?}"
+    );
+}
+
+#[test]
+fn live_flow_runtime_projection_ratchet_rejects_actor_store_plan_bare_shadowed_run_id_type_owner() {
+    let dir = tempdir().expect("tempdir");
+    let runtime = dir.path().join("meerkat-mob/src/runtime");
+    fs::create_dir_all(&runtime).expect("create runtime dir");
+    fs::write(
+        runtime.join("actor.rs"),
+        r#"
+pub struct RunId;
+
+impl MobActor {
+    async fn commit_flow_frame_store_plan_in_actor(
+        &mut self,
+        run_id: &RunId,
+        plan: FlowFrameLoopStorePlan,
+    ) -> Result<bool, MobError> {
+        let prepared =
+            self.prepare_dsl_inputs(plan.machine_inputs(), "flow_frame_loop_store_plan")?;
+        let won = match &plan {
+            FlowFrameLoopStorePlan::RunStateOnly {
+                expected_run_state,
+                next_run_state,
+                ..
+            } => self
+                .run_store
+                .cas_flow_state(run_id, expected_run_state, next_run_state)
+                .await?,
+            _ => false,
+        };
+        if won {
+            self.commit_prepared_dsl_input(prepared);
+        }
+        Ok(won)
+    }
+}
+"#,
+    )
+    .expect("write actor store plan bare shadowed run id type owner");
+
+    let mismatches = collect_direct_flow_reducer_transition_mismatches(dir.path())
+        .expect("flow projection mutation mismatches");
+    assert!(
+        mismatches.iter().any(|mismatch| {
+            mismatch.contains("meerkat-mob/src/runtime/actor.rs")
+                && mismatch.contains(".cas_flow_state(")
+        }),
+        "expected actor store-plan CAS with bare shadowed RunId owner to be rejected, got {mismatches:#?}"
+    );
+}
+
+#[test]
+fn live_flow_runtime_projection_ratchet_rejects_actor_store_plan_root_free_function_spoof() {
+    let dir = tempdir().expect("tempdir");
+    let runtime = dir.path().join("meerkat-mob/src/runtime");
+    fs::create_dir_all(&runtime).expect("create runtime dir");
+    fs::write(
+        runtime.join("actor.rs"),
+        r#"
+async fn commit_flow_frame_store_plan_in_actor(
+    &mut self,
+    run_id: &RunId,
+    plan: FlowFrameLoopStorePlan,
+) -> Result<bool, MobError> {
+    let prepared =
+        self.prepare_dsl_inputs(plan.machine_inputs(), "flow_frame_loop_store_plan")?;
+    let won = match &plan {
+        FlowFrameLoopStorePlan::RunStateOnly {
+            expected_run_state,
+            next_run_state,
+            ..
+        } => self
+            .run_store
+            .cas_flow_state(run_id, expected_run_state, next_run_state)
+            .await?,
+        _ => false,
+    };
+    if won {
+        self.commit_prepared_dsl_input(prepared);
+    }
+    Ok(won)
+}
+"#,
+    )
+    .expect("write root free actor store plan spoof");
+
+    let mismatches = collect_direct_flow_reducer_transition_mismatches(dir.path())
+        .expect("flow projection mutation mismatches");
+    assert!(
+        mismatches.iter().any(|mismatch| {
+            mismatch.contains("meerkat-mob/src/runtime/actor.rs")
+                && mismatch.contains(".cas_flow_state(")
+        }),
+        "expected root free function not to authorize actor store-plan CAS, got {mismatches:#?}"
+    );
+}
+
+#[test]
+fn live_flow_runtime_projection_ratchet_rejects_actor_store_plan_commit_without_freshness_check() {
+    let dir = tempdir().expect("tempdir");
+    let runtime = dir.path().join("meerkat-mob/src/runtime");
+    fs::create_dir_all(&runtime).expect("create runtime dir");
+    fs::write(
+        runtime.join("actor.rs"),
+        r#"
+impl MobActor {
+    async fn commit_flow_frame_store_plan_in_actor(
+        &mut self,
+        run_id: &RunId,
+        plan: FlowFrameLoopStorePlan,
+    ) -> Result<bool, MobError> {
+        let prepared =
+            self.prepare_dsl_inputs(plan.machine_inputs(), "flow_frame_loop_store_plan")?;
+        let authority_inputs = plan.machine_inputs().to_vec();
+        let won = match &plan {
+            FlowFrameLoopStorePlan::RunStateOnly {
+                expected_run_state,
+                next_run_state,
+                ..
+            } => self
+                .run_store
+                .cas_flow_state_with_authority(
+                    run_id,
+                    expected_run_state,
+                    next_run_state,
+                    authority_inputs,
+                )
+                .await?,
+            _ => false,
+        };
+        if won {
+            self.commit_prepared_dsl_input(prepared);
+        }
+        Ok(won)
+    }
+}
+"#,
+    )
+    .expect("write actor store plan commit without freshness check");
+
+    let mismatches = collect_direct_flow_reducer_transition_mismatches(dir.path())
+        .expect("flow projection mutation mismatches");
+    assert!(
+        mismatches.iter().any(|mismatch| {
+            mismatch.contains("meerkat-mob/src/runtime/actor.rs")
+                && mismatch.contains("FlowFrameLoopStorePlan::RunStateOnly")
+        }),
+        "expected actor store-plan commit without freshness check to be rejected, got {mismatches:#?}"
+    );
+}
+
+#[test]
+fn live_flow_runtime_projection_ratchet_rejects_actor_store_plan_arm_true_without_cas() {
+    let dir = tempdir().expect("tempdir");
+    let runtime = dir.path().join("meerkat-mob/src/runtime");
+    fs::create_dir_all(&runtime).expect("create runtime dir");
+    fs::write(
+        runtime.join("actor.rs"),
+        r#"
+impl MobActor {
+    async fn commit_flow_frame_store_plan_in_actor(
+        &mut self,
+        run_id: &RunId,
+        plan: FlowFrameLoopStorePlan,
+    ) -> Result<bool, MobError> {
+        let prepared =
+            self.prepare_dsl_inputs(plan.machine_inputs(), "flow_frame_loop_store_plan")?;
+        let won = match &plan {
+            FlowFrameLoopStorePlan::RunStateOnly {
+                expected_run_state: _,
+                next_run_state: _,
+                ..
+            } => true,
+            _ => false,
+        };
+        if won {
+            self.commit_prepared_dsl_input(prepared);
+        }
+        Ok(won)
+    }
+}
+"#,
+    )
+    .expect("write actor store plan true without CAS");
+
+    let mismatches = collect_direct_flow_reducer_transition_mismatches(dir.path())
+        .expect("flow projection mutation mismatches");
+    assert!(
+        mismatches.iter().any(|mismatch| {
+            mismatch.contains("meerkat-mob/src/runtime/actor.rs")
+                && mismatch.contains("FlowFrameLoopStorePlan::RunStateOnly")
+        }),
+        "expected actor store-plan arm returning true without CAS to be rejected, got {mismatches:#?}"
+    );
+}
+
+#[test]
+fn live_flow_runtime_projection_ratchet_rejects_actor_store_plan_branch_true_without_cas() {
+    let dir = tempdir().expect("tempdir");
+    let runtime = dir.path().join("meerkat-mob/src/runtime");
+    fs::create_dir_all(&runtime).expect("create runtime dir");
+    fs::write(
+        runtime.join("actor.rs"),
+        r#"
+impl MobActor {
+    async fn commit_flow_frame_store_plan_in_actor(
+        &mut self,
+        run_id: &RunId,
+        plan: FlowFrameLoopStorePlan,
+    ) -> Result<bool, MobError> {
+        let prepared =
+            self.prepare_dsl_inputs(plan.machine_inputs(), "flow_frame_loop_store_plan")?;
+        let authority_inputs = plan.machine_inputs().to_vec();
+        let won = match &plan {
+            FlowFrameLoopStorePlan::RunStateOnly {
+                expected_run_state,
+                next_run_state,
+                ..
+            } => {
+                if bypass() {
+                    true
+                } else {
+                    self
+                        .run_store
+                        .cas_flow_state_with_authority(
+                            run_id,
+                            expected_run_state,
+                            next_run_state,
+                            authority_inputs.clone(),
+                        )
+                        .await?
+                }
+            }
+            _ => false,
+        };
+        if won {
+            self.commit_prepared_dsl_input(prepared);
+        }
+        Ok(won)
+    }
+}
+"#,
+    )
+    .expect("write actor store plan branch true without CAS");
+
+    let mismatches = collect_direct_flow_reducer_transition_mismatches(dir.path())
+        .expect("flow projection mutation mismatches");
+    assert!(
+        mismatches.iter().any(|mismatch| {
+            mismatch.contains("meerkat-mob/src/runtime/actor.rs")
+                && mismatch.contains("FlowFrameLoopStorePlan::RunStateOnly")
+        }),
+        "expected actor store-plan branch returning true without CAS to be rejected, got {mismatches:#?}"
+    );
+}
+
+#[test]
+fn live_flow_runtime_projection_ratchet_rejects_actor_store_plan_insert_frame_non_none_expected() {
+    let dir = tempdir().expect("tempdir");
+    let runtime = dir.path().join("meerkat-mob/src/runtime");
+    fs::create_dir_all(&runtime).expect("create runtime dir");
+    fs::write(
+        runtime.join("actor.rs"),
+        r#"
+impl MobActor {
+    async fn commit_flow_frame_store_plan_in_actor(
+        &mut self,
+        run_id: &RunId,
+        plan: FlowFrameLoopStorePlan,
+    ) -> Result<bool, MobError> {
+        let prepared =
+            self.prepare_dsl_inputs(plan.machine_inputs(), "flow_frame_loop_store_plan")?;
+        let authority_inputs = plan.machine_inputs().to_vec();
+        let won = match &plan {
+            FlowFrameLoopStorePlan::InsertFrame {
+                frame_id,
+                initial_frame,
+                ..
+            } => self
+                .run_store
+                .cas_frame_state_with_authority(
+                    run_id,
+                    frame_id,
+                    Some(initial_frame),
+                    initial_frame.clone(),
+                    authority_inputs.clone(),
+                )
+                .await?,
+            _ => false,
+        };
+        if won {
+            self.commit_prepared_dsl_input(prepared);
+        }
+        Ok(won)
+    }
+}
+"#,
+    )
+    .expect("write actor store plan InsertFrame non-None expected");
+
+    let mismatches = collect_direct_flow_reducer_transition_mismatches(dir.path())
+        .expect("flow projection mutation mismatches");
+    assert!(
+        mismatches.iter().any(|mismatch| {
+            mismatch.contains("meerkat-mob/src/runtime/actor.rs")
+                && mismatch.contains(".cas_frame_state_with_authority(")
+        }),
+        "expected actor store-plan InsertFrame CAS with non-None expected frame to be rejected, got {mismatches:#?}"
+    );
+}
+
+#[test]
+fn live_flow_runtime_projection_ratchet_rejects_actor_store_plan_insert_frame_fake_none_expected() {
+    let dir = tempdir().expect("tempdir");
+    let runtime = dir.path().join("meerkat-mob/src/runtime");
+    fs::create_dir_all(&runtime).expect("create runtime dir");
+    fs::write(
+        runtime.join("actor.rs"),
+        r#"
+impl MobActor {
+    async fn commit_flow_frame_store_plan_in_actor(
+        &mut self,
+        run_id: &RunId,
+        plan: FlowFrameLoopStorePlan,
+    ) -> Result<bool, MobError> {
+        if !self
+            .flow_frame_store_plan_expected_matches(run_id, &plan)
+            .await?
+        {
+            return Ok(false);
+        }
+        let prepared =
+            self.prepare_dsl_inputs(plan.machine_inputs(), "flow_frame_loop_store_plan")?;
+        let authority_inputs = plan.machine_inputs().to_vec();
+        let won = match &plan {
+            FlowFrameLoopStorePlan::InsertFrame {
+                frame_id,
+                initial_frame,
+                ..
+            } => self
+                .run_store
+                .cas_frame_state_with_authority(
+                    run_id,
+                    frame_id,
+                    fake::None,
+                    initial_frame.clone(),
+                    authority_inputs,
+                )
+                .await?,
+            _ => false,
+        };
+        if won {
+            self.commit_prepared_dsl_input(prepared);
+        }
+        Ok(won)
+    }
+}
+"#,
+    )
+    .expect("write actor store plan insert frame fake None expected");
+
+    let mismatches = collect_direct_flow_reducer_transition_mismatches(dir.path())
+        .expect("flow projection mutation mismatches");
+    assert!(
+        mismatches.iter().any(|mismatch| {
+            mismatch.contains("meerkat-mob/src/runtime/actor.rs")
+                && mismatch.contains("FlowFrameLoopStorePlan::InsertFrame")
+        }),
+        "expected actor store-plan InsertFrame CAS with fake None expected arg to be rejected, got {mismatches:#?}"
+    );
+}
+
+#[test]
+fn live_flow_runtime_projection_ratchet_rejects_actor_store_plan_cas_before_prepare() {
+    let dir = tempdir().expect("tempdir");
+    let runtime = dir.path().join("meerkat-mob/src/runtime");
+    fs::create_dir_all(&runtime).expect("create runtime dir");
+    fs::write(
+        runtime.join("actor.rs"),
+        r#"
+impl MobActor {
+async fn commit_flow_frame_store_plan_in_actor(
+    &mut self,
+    run_id: &RunId,
+    plan: FlowFrameLoopStorePlan,
+) -> Result<bool, MobError> {
+    let won = match &plan {
+        FlowFrameLoopStorePlan::RunStateOnly {
+            expected_run_state,
+            next_run_state,
+            ..
+        } => self
+            .run_store
+            .cas_flow_state(run_id, expected_run_state, next_run_state)
+            .await?,
+        _ => false,
+    };
+    let prepared =
+        self.prepare_dsl_inputs(plan.machine_inputs(), "flow_frame_loop_store_plan")?;
+    if won {
+        self.commit_prepared_dsl_input(prepared);
+    }
+    Ok(won)
+}
+}
+"#,
+    )
+    .expect("write actor store plan commit before prepare");
+
+    let mismatches = collect_direct_flow_reducer_transition_mismatches(dir.path())
+        .expect("flow projection mutation mismatches");
+    assert!(
+        mismatches.iter().any(|mismatch| {
+            mismatch.contains("meerkat-mob/src/runtime/actor.rs")
+                && mismatch.contains(".cas_flow_state(")
+        }),
+        "expected actor store-plan CAS before prepared MobMachine input authority to be rejected, got {mismatches:#?}"
+    );
+}
+
+#[test]
+fn live_flow_runtime_projection_ratchet_rejects_actor_store_plan_commit_before_cas() {
+    let dir = tempdir().expect("tempdir");
+    let runtime = dir.path().join("meerkat-mob/src/runtime");
+    fs::create_dir_all(&runtime).expect("create runtime dir");
+    fs::write(
+        runtime.join("actor.rs"),
+        r#"
+impl MobActor {
+async fn commit_flow_frame_store_plan_in_actor(
+    &mut self,
+    run_id: &RunId,
+    plan: FlowFrameLoopStorePlan,
+) -> Result<bool, MobError> {
+    let prepared =
+        self.prepare_dsl_inputs(plan.machine_inputs(), "flow_frame_loop_store_plan")?;
+    self.commit_prepared_dsl_input(prepared);
+    let won = match &plan {
+        FlowFrameLoopStorePlan::RunStateOnly {
+            expected_run_state,
+            next_run_state,
+            ..
+        } => self
+            .run_store
+            .cas_flow_state(run_id, expected_run_state, next_run_state)
+            .await?,
+        _ => false,
+    };
+    Ok(won)
+}
+}
+"#,
+    )
+    .expect("write actor store plan commit before cas");
+
+    let mismatches = collect_direct_flow_reducer_transition_mismatches(dir.path())
+        .expect("flow projection mutation mismatches");
+    assert!(
+        mismatches.iter().any(|mismatch| {
+            mismatch.contains("meerkat-mob/src/runtime/actor.rs")
+                && mismatch.contains(".cas_flow_state(")
+        }),
+        "expected actor store-plan CAS after an already-committed prepared input to be rejected, got {mismatches:#?}"
+    );
+}
+
+#[test]
+fn live_flow_runtime_projection_ratchet_rejects_actor_store_plan_unrelated_raw_cas() {
+    let dir = tempdir().expect("tempdir");
+    let runtime = dir.path().join("meerkat-mob/src/runtime");
+    fs::create_dir_all(&runtime).expect("create runtime dir");
+    fs::write(
+        runtime.join("actor.rs"),
+        r#"
+impl MobActor {
+async fn commit_flow_frame_store_plan_in_actor(
+    &mut self,
+    run_id: &RunId,
+    plan: FlowFrameLoopStorePlan,
+    expected_run_state: &flow_run::State,
+    next_run_state: &flow_run::State,
+) -> Result<bool, MobError> {
+    let prepared =
+        self.prepare_dsl_inputs(plan.machine_inputs(), "flow_frame_loop_store_plan")?;
+    let won = self
+        .run_store
+        .cas_flow_state(run_id, expected_run_state, next_run_state)
+        .await?;
+    if won {
+        self.commit_prepared_dsl_input(prepared);
+    }
+    Ok(won)
+}
+}
+"#,
+    )
+    .expect("write actor store plan unrelated raw cas");
+
+    let mismatches = collect_direct_flow_reducer_transition_mismatches(dir.path())
+        .expect("flow projection mutation mismatches");
+    assert!(
+        mismatches.iter().any(|mismatch| {
+            mismatch.contains("meerkat-mob/src/runtime/actor.rs")
+                && mismatch.contains(".cas_flow_state(")
+        }),
+        "expected actor store-plan raw CAS unrelated to the plan match to be rejected, got {mismatches:#?}"
+    );
+}
+
+#[test]
+fn live_flow_runtime_projection_ratchet_rejects_actor_store_plan_unrelated_raw_cas_inside_match() {
+    let dir = tempdir().expect("tempdir");
+    let runtime = dir.path().join("meerkat-mob/src/runtime");
+    fs::create_dir_all(&runtime).expect("create runtime dir");
+    fs::write(
+        runtime.join("actor.rs"),
+        r#"
+impl MobActor {
+async fn commit_flow_frame_store_plan_in_actor(
+    &mut self,
+    run_id: &RunId,
+    plan: FlowFrameLoopStorePlan,
+    expected_run_state: &flow_run::State,
+    next_run_state: &flow_run::State,
+) -> Result<bool, MobError> {
+    let prepared =
+        self.prepare_dsl_inputs(plan.machine_inputs(), "flow_frame_loop_store_plan")?;
+    let won = match &plan {
+        FlowFrameLoopStorePlan::RunStateOnly {
+            expected_run_state: _plan_expected_run_state,
+            next_run_state: _plan_next_run_state,
+            ..
+        } => self
+            .run_store
+            .cas_flow_state(run_id, expected_run_state, next_run_state)
+            .await?,
+        _ => false,
+    };
+    if won {
+        self.commit_prepared_dsl_input(prepared);
+    }
+    Ok(won)
+}
+}
+"#,
+    )
+    .expect("write actor store plan unrelated raw cas inside match");
+
+    let mismatches = collect_direct_flow_reducer_transition_mismatches(dir.path())
+        .expect("flow projection mutation mismatches");
+    assert!(
+        mismatches.iter().any(|mismatch| {
+            mismatch.contains("meerkat-mob/src/runtime/actor.rs")
+                && mismatch.contains(".cas_flow_state(")
+        }),
+        "expected actor store-plan raw CAS unrelated to the matched plan arm to be rejected, got {mismatches:#?}"
+    );
+}
+
+#[test]
+fn live_flow_runtime_projection_ratchet_rejects_actor_store_plan_shadowed_compound_cas_args() {
     let dir = tempdir().expect("tempdir");
     let runtime = dir.path().join("meerkat-mob/src/runtime");
     fs::create_dir_all(&runtime).expect("create runtime dir");
@@ -1063,17 +11201,713 @@ async fn commit_flow_frame_store_plan_in_actor(
             expected_frame,
             next_frame,
             ..
+        } => {
+            let next_run_state = flow_run::State::default();
+            self
+                .run_store
+                .cas_grant_node_slot(
+                    run_id,
+                    expected_run_state,
+                    next_run_state,
+                    frame_id,
+                    expected_frame,
+                    next_frame.clone(),
+                )
+                .await?
+        }
+        _ => false,
+    };
+    if won {
+        self.commit_prepared_dsl_input(prepared);
+    }
+    Ok(won)
+}
+"#,
+    )
+    .expect("write actor store plan shadowed compound cas args");
+
+    let mismatches = collect_direct_flow_reducer_transition_mismatches(dir.path())
+        .expect("flow projection mutation mismatches");
+    assert!(
+        mismatches.iter().any(|mismatch| {
+            mismatch.contains("meerkat-mob/src/runtime/actor.rs")
+                && mismatch.contains(".cas_grant_node_slot(")
+        }),
+        "expected actor store-plan compound CAS with shadowed plan state arg to be rejected, got {mismatches:#?}"
+    );
+}
+
+#[test]
+fn live_flow_runtime_projection_ratchet_rejects_actor_store_plan_unrelated_compound_cas_id_arg() {
+    let dir = tempdir().expect("tempdir");
+    let runtime = dir.path().join("meerkat-mob/src/runtime");
+    fs::create_dir_all(&runtime).expect("create runtime dir");
+    fs::write(
+        runtime.join("actor.rs"),
+        r#"
+async fn commit_flow_frame_store_plan_in_actor(
+    &mut self,
+    run_id: &RunId,
+    plan: FlowFrameLoopStorePlan,
+    unrelated_frame_id: &FrameId,
+) -> Result<bool, MobError> {
+    let prepared =
+        self.prepare_dsl_inputs(plan.machine_inputs(), "flow_frame_loop_store_plan")?;
+    let authority_inputs = plan.machine_inputs().to_vec();
+    let won = match &plan {
+        FlowFrameLoopStorePlan::GrantNodeSlot {
+            expected_run_state,
+            next_run_state,
+            frame_id: _frame_id,
+            expected_frame,
+            next_frame,
+            ..
         } => self
             .run_store
-            .cas_grant_node_slot(
+            .cas_grant_node_slot_with_authority(
                 run_id,
                 expected_run_state,
                 next_run_state.clone(),
+                unrelated_frame_id,
+                expected_frame,
+                next_frame.clone(),
+                authority_inputs,
+            )
+            .await?,
+        _ => false,
+    };
+    if won {
+        self.commit_prepared_dsl_input(prepared);
+    }
+    Ok(won)
+}
+"#,
+    )
+    .expect("write actor store plan unrelated compound CAS id arg");
+
+    let mismatches = collect_direct_flow_reducer_transition_mismatches(dir.path())
+        .expect("flow projection mutation mismatches");
+    assert!(
+        mismatches.iter().any(|mismatch| {
+            mismatch.contains("meerkat-mob/src/runtime/actor.rs")
+                && mismatch.contains(".cas_grant_node_slot_with_authority(")
+        }),
+        "expected actor store-plan compound CAS with unrelated frame id arg to be rejected, got {mismatches:#?}"
+    );
+}
+
+#[test]
+fn live_flow_runtime_projection_ratchet_rejects_actor_store_plan_unrelated_map_cas_arg() {
+    let dir = tempdir().expect("tempdir");
+    let runtime = dir.path().join("meerkat-mob/src/runtime");
+    fs::create_dir_all(&runtime).expect("create runtime dir");
+    fs::write(
+        runtime.join("actor.rs"),
+        r#"
+async fn commit_flow_frame_store_plan_in_actor(
+    &mut self,
+    run_id: &RunId,
+    plan: FlowFrameLoopStorePlan,
+    unrelated_loop_id: &LoopId,
+) -> Result<bool, MobError> {
+    let prepared =
+        self.prepare_dsl_inputs(plan.machine_inputs(), "flow_frame_loop_store_plan")?;
+    let authority_inputs = plan.machine_inputs().to_vec();
+    let won = match &plan {
+        FlowFrameLoopStorePlan::CompleteStepAndRecordOutput {
+            frame_id,
+            expected_frame,
+            next_frame,
+            step_output_key,
+            step_output,
+            loop_context,
+            ..
+        } => self
+            .run_store
+            .cas_complete_step_and_record_output_with_authority(
+                run_id,
                 frame_id,
                 expected_frame,
                 next_frame.clone(),
+                step_output_key.clone(),
+                step_output.clone(),
+                loop_context.as_ref().map(|_| (unrelated_loop_id, 0)),
+                authority_inputs,
             )
             .await?,
+        _ => false,
+    };
+    if won {
+        self.commit_prepared_dsl_input(prepared);
+    }
+    Ok(won)
+}
+"#,
+    )
+    .expect("write actor store plan unrelated map CAS arg");
+
+    let mismatches = collect_direct_flow_reducer_transition_mismatches(dir.path())
+        .expect("flow projection mutation mismatches");
+    assert!(
+        mismatches.iter().any(|mismatch| {
+            mismatch.contains("meerkat-mob/src/runtime/actor.rs")
+                && mismatch.contains(".cas_complete_step_and_record_output_with_authority(")
+        }),
+        "expected actor store-plan CAS with unrelated map output to be rejected, got {mismatches:#?}"
+    );
+}
+
+#[test]
+fn live_flow_runtime_projection_ratchet_rejects_actor_store_plan_deferred_cas() {
+    let dir = tempdir().expect("tempdir");
+    let runtime = dir.path().join("meerkat-mob/src/runtime");
+    fs::create_dir_all(&runtime).expect("create runtime dir");
+    fs::write(
+        runtime.join("actor.rs"),
+        r#"
+async fn commit_flow_frame_store_plan_in_actor(
+    &mut self,
+    run_id: &RunId,
+    plan: FlowFrameLoopStorePlan,
+) -> Result<bool, MobError> {
+    let prepared =
+        self.prepare_dsl_inputs(plan.machine_inputs(), "flow_frame_loop_store_plan")?;
+    let won = match &plan {
+        FlowFrameLoopStorePlan::RunStateOnly {
+            expected_run_state,
+            next_run_state,
+            ..
+        } => {
+            let _deferred = || {
+                self.run_store.cas_flow_state(run_id, expected_run_state, next_run_state)
+            };
+            false
+        }
+        _ => false,
+    };
+    if won {
+        self.commit_prepared_dsl_input(prepared);
+    }
+    Ok(won)
+}
+"#,
+    )
+    .expect("write actor store plan deferred CAS");
+
+    let mismatches = collect_direct_flow_reducer_transition_mismatches(dir.path())
+        .expect("flow projection mutation mismatches");
+    assert!(
+        mismatches.iter().any(|mismatch| {
+            mismatch.contains("meerkat-mob/src/runtime/actor.rs")
+                && mismatch.contains(".cas_flow_state(")
+        }),
+        "expected actor store-plan CAS hidden in deferred closure to be rejected, got {mismatches:#?}"
+    );
+}
+
+#[test]
+fn live_flow_runtime_projection_ratchet_rejects_actor_store_plan_deferred_commit_proof() {
+    let dir = tempdir().expect("tempdir");
+    let runtime = dir.path().join("meerkat-mob/src/runtime");
+    fs::create_dir_all(&runtime).expect("create runtime dir");
+    fs::write(
+        runtime.join("actor.rs"),
+        r#"
+impl MobActor {
+    async fn commit_flow_frame_store_plan_in_actor(
+        &mut self,
+        run_id: &RunId,
+        plan: FlowFrameLoopStorePlan,
+    ) -> Result<bool, MobError> {
+        let prepared =
+            self.prepare_dsl_inputs(plan.machine_inputs(), "flow_frame_loop_store_plan")?;
+        let won = match &plan {
+            FlowFrameLoopStorePlan::RunStateOnly {
+                expected_run_state,
+                next_run_state,
+                ..
+            } => self
+                .run_store
+                .cas_flow_state(run_id, expected_run_state, next_run_state)
+                .await?,
+            _ => false,
+        };
+        if won {
+            let _deferred = || {
+                self.commit_prepared_dsl_input(prepared);
+            };
+        }
+        Ok(won)
+    }
+}
+"#,
+    )
+    .expect("write actor store plan deferred commit proof");
+
+    let mismatches = collect_direct_flow_reducer_transition_mismatches(dir.path())
+        .expect("flow projection mutation mismatches");
+    assert!(
+        mismatches.iter().any(|mismatch| {
+            mismatch.contains("meerkat-mob/src/runtime/actor.rs")
+                && mismatch.contains(".cas_flow_state(")
+        }),
+        "expected actor store-plan commit hidden in a deferred closure not to authorize the CAS, got {mismatches:#?}"
+    );
+}
+
+#[test]
+fn live_flow_runtime_projection_ratchet_rejects_actor_store_plan_unreachable_commit_proof() {
+    let dir = tempdir().expect("tempdir");
+    let runtime = dir.path().join("meerkat-mob/src/runtime");
+    fs::create_dir_all(&runtime).expect("create runtime dir");
+    fs::write(
+        runtime.join("actor.rs"),
+        r#"
+impl MobActor {
+    async fn commit_flow_frame_store_plan_in_actor(
+        &mut self,
+        run_id: &RunId,
+        plan: FlowFrameLoopStorePlan,
+    ) -> Result<bool, MobError> {
+        let prepared =
+            self.prepare_dsl_inputs(plan.machine_inputs(), "flow_frame_loop_store_plan")?;
+        let won = match &plan {
+            FlowFrameLoopStorePlan::RunStateOnly {
+                expected_run_state,
+                next_run_state,
+                ..
+            } => self
+                .run_store
+                .cas_flow_state(run_id, expected_run_state, next_run_state)
+                .await?,
+            _ => false,
+        };
+        if won {
+            return Ok(won);
+            self.commit_prepared_dsl_input(prepared);
+        }
+        Ok(won)
+    }
+}
+"#,
+    )
+    .expect("write actor store plan unreachable commit proof");
+
+    let mismatches = collect_direct_flow_reducer_transition_mismatches(dir.path())
+        .expect("flow projection mutation mismatches");
+    assert!(
+        mismatches.iter().any(|mismatch| {
+            mismatch.contains("meerkat-mob/src/runtime/actor.rs")
+                && mismatch.contains(".cas_flow_state(")
+        }),
+        "expected unreachable actor store-plan commit not to authorize the CAS, got {mismatches:#?}"
+    );
+}
+
+#[test]
+fn live_flow_runtime_projection_ratchet_rejects_actor_store_plan_commit_without_won_guard() {
+    let dir = tempdir().expect("tempdir");
+    let runtime = dir.path().join("meerkat-mob/src/runtime");
+    fs::create_dir_all(&runtime).expect("create runtime dir");
+    fs::write(
+        runtime.join("actor.rs"),
+        r#"
+async fn commit_flow_frame_store_plan_in_actor(
+    &mut self,
+    run_id: &RunId,
+    plan: FlowFrameLoopStorePlan,
+    should_commit: bool,
+) -> Result<bool, MobError> {
+    let prepared =
+        self.prepare_dsl_inputs(plan.machine_inputs(), "flow_frame_loop_store_plan")?;
+    let won = match &plan {
+        FlowFrameLoopStorePlan::RunStateOnly {
+            expected_run_state,
+            next_run_state,
+            ..
+        } => self
+            .run_store
+            .cas_flow_state(run_id, expected_run_state, next_run_state)
+            .await?,
+        _ => false,
+    };
+    if should_commit {
+        self.commit_prepared_dsl_input(prepared);
+    }
+    Ok(won)
+}
+"#,
+    )
+    .expect("write actor store plan commit without won guard");
+
+    let mismatches = collect_direct_flow_reducer_transition_mismatches(dir.path())
+        .expect("flow projection mutation mismatches");
+    assert!(
+        mismatches.iter().any(|mismatch| {
+            mismatch.contains("meerkat-mob/src/runtime/actor.rs")
+                && mismatch.contains(".cas_flow_state(")
+        }),
+        "expected actor store-plan commit not guarded by CAS result to reject the CAS authorization, got {mismatches:#?}"
+    );
+}
+
+#[test]
+fn live_flow_runtime_projection_ratchet_rejects_actor_store_plan_cas_not_feeding_won() {
+    let dir = tempdir().expect("tempdir");
+    let runtime = dir.path().join("meerkat-mob/src/runtime");
+    fs::create_dir_all(&runtime).expect("create runtime dir");
+    fs::write(
+        runtime.join("actor.rs"),
+        r#"
+async fn commit_flow_frame_store_plan_in_actor(
+    &mut self,
+    run_id: &RunId,
+    plan: FlowFrameLoopStorePlan,
+) -> Result<bool, MobError> {
+    let prepared =
+        self.prepare_dsl_inputs(plan.machine_inputs(), "flow_frame_loop_store_plan")?;
+    let won = match &plan {
+        FlowFrameLoopStorePlan::RunStateOnly {
+            expected_run_state,
+            next_run_state,
+            ..
+        } => {
+            self
+                .run_store
+                .cas_flow_state(run_id, expected_run_state, next_run_state)
+                .await?;
+            false
+        }
+        _ => false,
+    };
+    if won {
+        self.commit_prepared_dsl_input(prepared);
+    }
+    Ok(won)
+}
+"#,
+    )
+    .expect("write actor store plan cas not feeding won");
+
+    let mismatches = collect_direct_flow_reducer_transition_mismatches(dir.path())
+        .expect("flow projection mutation mismatches");
+    assert!(
+        mismatches.iter().any(|mismatch| {
+            mismatch.contains("meerkat-mob/src/runtime/actor.rs")
+                && mismatch.contains(".cas_flow_state(")
+        }),
+        "expected actor store-plan CAS whose result does not feed won to be rejected, got {mismatches:#?}"
+    );
+}
+
+#[test]
+fn live_flow_runtime_projection_ratchet_rejects_actor_store_plan_tuple_tail_discards_cas_result() {
+    let dir = tempdir().expect("tempdir");
+    let runtime = dir.path().join("meerkat-mob/src/runtime");
+    fs::create_dir_all(&runtime).expect("create runtime dir");
+    fs::write(
+        runtime.join("actor.rs"),
+        r#"
+async fn commit_flow_frame_store_plan_in_actor(
+    &mut self,
+    run_id: &RunId,
+    plan: FlowFrameLoopStorePlan,
+) -> Result<bool, MobError> {
+    let prepared =
+        self.prepare_dsl_inputs(plan.machine_inputs(), "flow_frame_loop_store_plan")?;
+    let won = match &plan {
+        FlowFrameLoopStorePlan::RunStateOnly {
+            expected_run_state,
+            next_run_state,
+            ..
+        } => (self
+            .run_store
+            .cas_flow_state(run_id, expected_run_state, next_run_state)
+            .await?, false).1,
+        _ => false,
+    };
+    if won {
+        self.commit_prepared_dsl_input(prepared);
+    }
+    Ok(won)
+}
+"#,
+    )
+    .expect("write actor store plan tuple tail discarding cas result");
+
+    let mismatches = collect_direct_flow_reducer_transition_mismatches(dir.path())
+        .expect("flow projection mutation mismatches");
+    assert!(
+        mismatches.iter().any(|mismatch| {
+            mismatch.contains("meerkat-mob/src/runtime/actor.rs")
+                && mismatch.contains(".cas_flow_state(")
+        }),
+        "expected actor store-plan CAS discarded by tuple-field tail expression to be rejected, got {mismatches:#?}"
+    );
+}
+
+#[test]
+fn live_flow_runtime_projection_ratchet_rejects_actor_store_plan_shadowed_won_commit_guard() {
+    let dir = tempdir().expect("tempdir");
+    let runtime = dir.path().join("meerkat-mob/src/runtime");
+    fs::create_dir_all(&runtime).expect("create runtime dir");
+    fs::write(
+        runtime.join("actor.rs"),
+        r#"
+async fn commit_flow_frame_store_plan_in_actor(
+    &mut self,
+    run_id: &RunId,
+    plan: FlowFrameLoopStorePlan,
+    should_commit: bool,
+) -> Result<bool, MobError> {
+    let prepared =
+        self.prepare_dsl_inputs(plan.machine_inputs(), "flow_frame_loop_store_plan")?;
+    let won = match &plan {
+        FlowFrameLoopStorePlan::RunStateOnly {
+            expected_run_state,
+            next_run_state,
+            ..
+        } => self
+            .run_store
+            .cas_flow_state(run_id, expected_run_state, next_run_state)
+            .await?,
+        _ => false,
+    };
+    let won = should_commit;
+    if won {
+        self.commit_prepared_dsl_input(prepared);
+    }
+    Ok(won)
+}
+"#,
+    )
+    .expect("write actor store plan shadowed won commit guard");
+
+    let mismatches = collect_direct_flow_reducer_transition_mismatches(dir.path())
+        .expect("flow projection mutation mismatches");
+    assert!(
+        mismatches.iter().any(|mismatch| {
+            mismatch.contains("meerkat-mob/src/runtime/actor.rs")
+                && mismatch.contains(".cas_flow_state(")
+        }),
+        "expected actor store-plan commit guarded by a shadowed CAS result name to reject the CAS authorization, got {mismatches:#?}"
+    );
+}
+
+#[test]
+fn live_flow_runtime_projection_ratchet_rejects_actor_store_plan_reassigned_won_commit_guard() {
+    let dir = tempdir().expect("tempdir");
+    let runtime = dir.path().join("meerkat-mob/src/runtime");
+    fs::create_dir_all(&runtime).expect("create runtime dir");
+    fs::write(
+        runtime.join("actor.rs"),
+        r#"
+async fn commit_flow_frame_store_plan_in_actor(
+    &mut self,
+    run_id: &RunId,
+    plan: FlowFrameLoopStorePlan,
+    should_commit: bool,
+) -> Result<bool, MobError> {
+    let prepared =
+        self.prepare_dsl_inputs(plan.machine_inputs(), "flow_frame_loop_store_plan")?;
+    let mut won = match &plan {
+        FlowFrameLoopStorePlan::RunStateOnly {
+            expected_run_state,
+            next_run_state,
+            ..
+        } => self
+            .run_store
+            .cas_flow_state(run_id, expected_run_state, next_run_state)
+            .await?,
+        _ => false,
+    };
+    won = should_commit;
+    if won {
+        self.commit_prepared_dsl_input(prepared);
+    }
+    Ok(won)
+}
+"#,
+    )
+    .expect("write actor store plan reassigned won commit guard");
+
+    let mismatches = collect_direct_flow_reducer_transition_mismatches(dir.path())
+        .expect("flow projection mutation mismatches");
+    assert!(
+        mismatches.iter().any(|mismatch| {
+            mismatch.contains("meerkat-mob/src/runtime/actor.rs")
+                && mismatch.contains(".cas_flow_state(")
+        }),
+        "expected actor store-plan commit guarded by reassigned CAS result name to reject the CAS authorization, got {mismatches:#?}"
+    );
+}
+
+#[test]
+fn live_flow_runtime_projection_ratchet_rejects_actor_store_plan_destructured_won_commit_guard() {
+    let dir = tempdir().expect("tempdir");
+    let runtime = dir.path().join("meerkat-mob/src/runtime");
+    fs::create_dir_all(&runtime).expect("create runtime dir");
+    fs::write(
+        runtime.join("actor.rs"),
+        r#"
+impl MobActor {
+    async fn commit_flow_frame_store_plan_in_actor(
+        &mut self,
+        run_id: &RunId,
+        plan: FlowFrameLoopStorePlan,
+        should_commit: bool,
+    ) -> Result<bool, MobError> {
+        let prepared =
+            self.prepare_dsl_inputs(plan.machine_inputs(), "flow_frame_loop_store_plan")?;
+        let won = match &plan {
+            FlowFrameLoopStorePlan::RunStateOnly {
+                expected_run_state,
+                next_run_state,
+                ..
+            } => self
+                .run_store
+                .cas_flow_state(run_id, expected_run_state, next_run_state)
+                .await?,
+            _ => false,
+        };
+        let (won,) = (should_commit,);
+        if won {
+            self.commit_prepared_dsl_input(prepared);
+        }
+        Ok(won)
+    }
+}
+"#,
+    )
+    .expect("write actor store plan destructured won commit guard");
+
+    let mismatches = collect_direct_flow_reducer_transition_mismatches(dir.path())
+        .expect("flow projection mutation mismatches");
+    assert!(
+        mismatches.iter().any(|mismatch| {
+            mismatch.contains("meerkat-mob/src/runtime/actor.rs")
+                && mismatch.contains(".cas_flow_state(")
+        }),
+        "expected actor store-plan commit guarded by destructured CAS result name to reject the CAS authorization, got {mismatches:#?}"
+    );
+}
+
+#[test]
+fn live_flow_runtime_projection_ratchet_rejects_actor_store_plan_autoref_mutated_won_guard() {
+    let dir = tempdir().expect("tempdir");
+    let runtime = dir.path().join("meerkat-mob/src/runtime");
+    fs::create_dir_all(&runtime).expect("create runtime dir");
+    fs::write(
+        runtime.join("actor.rs"),
+        r#"
+impl MobActor {
+    async fn commit_flow_frame_store_plan_in_actor(
+        &mut self,
+        run_id: &RunId,
+        plan: FlowFrameLoopStorePlan,
+        should_commit: bool,
+    ) -> Result<bool, MobError> {
+        let prepared =
+            self.prepare_dsl_inputs(plan.machine_inputs(), "flow_frame_loop_store_plan")?;
+        let mut won = match &plan {
+            FlowFrameLoopStorePlan::RunStateOnly {
+                expected_run_state,
+                next_run_state,
+                ..
+            } => self
+                .run_store
+                .cas_flow_state(run_id, expected_run_state, next_run_state)
+                .await?,
+            _ => false,
+        };
+        won.clone_from(&should_commit);
+        if won {
+            self.commit_prepared_dsl_input(prepared);
+        }
+        Ok(won)
+    }
+}
+"#,
+    )
+    .expect("write actor store plan autoref-mutated won guard");
+
+    let mismatches = collect_direct_flow_reducer_transition_mismatches(dir.path())
+        .expect("flow projection mutation mismatches");
+    assert!(
+        mismatches.iter().any(|mismatch| {
+            mismatch.contains("meerkat-mob/src/runtime/actor.rs")
+                && mismatch.contains(".cas_flow_state(")
+        }),
+        "expected actor store-plan commit guarded by autoref-mutated CAS result name to reject the CAS authorization, got {mismatches:#?}"
+    );
+}
+
+#[test]
+fn live_flow_runtime_projection_ratchet_rejects_actor_store_plan_shadowed_prepared_commit() {
+    let dir = tempdir().expect("tempdir");
+    let runtime = dir.path().join("meerkat-mob/src/runtime");
+    fs::create_dir_all(&runtime).expect("create runtime dir");
+    fs::write(
+        runtime.join("actor.rs"),
+        r#"
+async fn commit_flow_frame_store_plan_in_actor(
+    &mut self,
+    run_id: &RunId,
+    plan: FlowFrameLoopStorePlan,
+    fake_prepared: PreparedDslInput,
+) -> Result<bool, MobError> {
+    let prepared =
+        self.prepare_dsl_inputs(plan.machine_inputs(), "flow_frame_loop_store_plan")?;
+    let won = match &plan {
+        FlowFrameLoopStorePlan::RunStateOnly {
+            expected_run_state,
+            next_run_state,
+            ..
+        } => self
+            .run_store
+            .cas_flow_state(run_id, expected_run_state, next_run_state)
+            .await?,
+        _ => false,
+    };
+    if won {
+        let prepared = fake_prepared;
+        self.commit_prepared_dsl_input(prepared);
+    }
+    Ok(won)
+}
+"#,
+    )
+    .expect("write actor store plan shadowed prepared commit");
+
+    let mismatches = collect_direct_flow_reducer_transition_mismatches(dir.path())
+        .expect("flow projection mutation mismatches");
+    assert!(
+        mismatches.iter().any(|mismatch| {
+            mismatch.contains("meerkat-mob/src/runtime/actor.rs")
+                && mismatch.contains(".cas_flow_state(")
+        }),
+        "expected actor store-plan commit using shadowed prepared input to reject the CAS authorization, got {mismatches:#?}"
+    );
+}
+
+#[test]
+fn live_flow_runtime_projection_ratchet_rejects_actor_store_plan_reassigned_prepared_commit() {
+    let dir = tempdir().expect("tempdir");
+    let runtime = dir.path().join("meerkat-mob/src/runtime");
+    fs::create_dir_all(&runtime).expect("create runtime dir");
+    fs::write(
+        runtime.join("actor.rs"),
+        r#"
+async fn commit_flow_frame_store_plan_in_actor(
+    &mut self,
+    run_id: &RunId,
+    plan: FlowFrameLoopStorePlan,
+    fake_prepared: PreparedDslInput,
+) -> Result<bool, MobError> {
+    let mut prepared =
+        self.prepare_dsl_inputs(plan.machine_inputs(), "flow_frame_loop_store_plan")?;
+    prepared = fake_prepared;
+    let won = match &plan {
         FlowFrameLoopStorePlan::RunStateOnly {
             expected_run_state,
             next_run_state,
@@ -1091,12 +11925,492 @@ async fn commit_flow_frame_store_plan_in_actor(
 }
 "#,
     )
-    .expect("write actor store plan commit");
+    .expect("write actor store plan reassigned prepared commit");
 
     let mismatches = collect_direct_flow_reducer_transition_mismatches(dir.path())
         .expect("flow projection mutation mismatches");
     assert!(
-        mismatches.is_empty(),
-        "expected actor-gated store plan commits to be accepted, got {mismatches:#?}"
+        mismatches.iter().any(|mismatch| {
+            mismatch.contains("meerkat-mob/src/runtime/actor.rs")
+                && mismatch.contains(".cas_flow_state(")
+        }),
+        "expected actor store-plan commit using reassigned prepared input to reject the CAS authorization, got {mismatches:#?}"
+    );
+}
+
+#[test]
+fn live_flow_runtime_projection_ratchet_rejects_actor_store_plan_destructured_prepared_commit() {
+    let dir = tempdir().expect("tempdir");
+    let runtime = dir.path().join("meerkat-mob/src/runtime");
+    fs::create_dir_all(&runtime).expect("create runtime dir");
+    fs::write(
+        runtime.join("actor.rs"),
+        r#"
+impl MobActor {
+    async fn commit_flow_frame_store_plan_in_actor(
+        &mut self,
+        run_id: &RunId,
+        plan: FlowFrameLoopStorePlan,
+        fake_prepared: PreparedDslInput,
+    ) -> Result<bool, MobError> {
+        let prepared =
+            self.prepare_dsl_inputs(plan.machine_inputs(), "flow_frame_loop_store_plan")?;
+        let (prepared,) = (fake_prepared,);
+        let won = match &plan {
+            FlowFrameLoopStorePlan::RunStateOnly {
+                expected_run_state,
+                next_run_state,
+                ..
+            } => self
+                .run_store
+                .cas_flow_state(run_id, expected_run_state, next_run_state)
+                .await?,
+            _ => false,
+        };
+        if won {
+            self.commit_prepared_dsl_input(prepared);
+        }
+        Ok(won)
+    }
+}
+"#,
+    )
+    .expect("write actor store plan destructured prepared commit");
+
+    let mismatches = collect_direct_flow_reducer_transition_mismatches(dir.path())
+        .expect("flow projection mutation mismatches");
+    assert!(
+        mismatches.iter().any(|mismatch| {
+            mismatch.contains("meerkat-mob/src/runtime/actor.rs")
+                && mismatch.contains(".cas_flow_state(")
+        }),
+        "expected actor store-plan commit using destructured prepared input to reject the CAS authorization, got {mismatches:#?}"
+    );
+}
+
+#[test]
+fn live_flow_runtime_projection_ratchet_rejects_actor_store_plan_fake_receiver_commit() {
+    let dir = tempdir().expect("tempdir");
+    let runtime = dir.path().join("meerkat-mob/src/runtime");
+    fs::create_dir_all(&runtime).expect("create runtime dir");
+    fs::write(
+        runtime.join("actor.rs"),
+        r#"
+async fn commit_flow_frame_store_plan_in_actor(
+    &mut self,
+    run_id: &RunId,
+    plan: FlowFrameLoopStorePlan,
+    fake: FakeActor,
+) -> Result<bool, MobError> {
+    let prepared =
+        self.prepare_dsl_inputs(plan.machine_inputs(), "flow_frame_loop_store_plan")?;
+    let won = match &plan {
+        FlowFrameLoopStorePlan::RunStateOnly {
+            expected_run_state,
+            next_run_state,
+            ..
+        } => self
+            .run_store
+            .cas_flow_state(run_id, expected_run_state, next_run_state)
+            .await?,
+        _ => false,
+    };
+    if won {
+        fake.commit_prepared_dsl_input(prepared);
+    }
+    Ok(won)
+}
+"#,
+    )
+    .expect("write actor store plan fake receiver commit");
+
+    let mismatches = collect_direct_flow_reducer_transition_mismatches(dir.path())
+        .expect("flow projection mutation mismatches");
+    assert!(
+        mismatches.iter().any(|mismatch| {
+            mismatch.contains("meerkat-mob/src/runtime/actor.rs")
+                && mismatch.contains(".cas_flow_state(")
+        }),
+        "expected actor store-plan commit on fake receiver to reject the CAS authorization, got {mismatches:#?}"
+    );
+}
+
+#[test]
+fn live_flow_runtime_projection_ratchet_rejects_actor_store_plan_non_actor_impl_spoof() {
+    let dir = tempdir().expect("tempdir");
+    let runtime = dir.path().join("meerkat-mob/src/runtime");
+    fs::create_dir_all(&runtime).expect("create runtime dir");
+    fs::write(
+        runtime.join("actor.rs"),
+        r#"
+struct FakeActor {
+    run_store: Store,
+}
+
+impl FakeActor {
+    async fn commit_flow_frame_store_plan_in_actor(
+        &mut self,
+        run_id: &RunId,
+        plan: FlowFrameLoopStorePlan,
+    ) -> Result<bool, MobError> {
+        let prepared =
+            self.prepare_dsl_inputs(plan.machine_inputs(), "flow_frame_loop_store_plan")?;
+        let won = match &plan {
+            FlowFrameLoopStorePlan::RunStateOnly {
+                expected_run_state,
+                next_run_state,
+                ..
+            } => self
+                .run_store
+                .cas_flow_state(run_id, expected_run_state, next_run_state)
+                .await?,
+            _ => false,
+        };
+        if won {
+            self.commit_prepared_dsl_input(prepared);
+        }
+        Ok(won)
+    }
+}
+"#,
+    )
+    .expect("write fake actor store plan impl spoof");
+
+    let mismatches = collect_direct_flow_reducer_transition_mismatches(dir.path())
+        .expect("flow projection mutation mismatches");
+    assert!(
+        mismatches.iter().any(|mismatch| {
+            mismatch.contains("meerkat-mob/src/runtime/actor.rs")
+                && mismatch.contains(".cas_flow_state(")
+        }),
+        "expected non-MobActor impl not to authorize actor store-plan CAS, got {mismatches:#?}"
+    );
+}
+
+#[test]
+fn live_flow_runtime_projection_ratchet_rejects_actor_store_plan_root_qualified_mob_actor_spoof() {
+    let dir = tempdir().expect("tempdir");
+    let runtime = dir.path().join("meerkat-mob/src/runtime");
+    fs::create_dir_all(&runtime).expect("create runtime dir");
+    fs::write(
+        runtime.join("actor.rs"),
+        r#"
+mod fake {
+    pub struct MobActor {
+        run_store: Store,
+    }
+}
+
+impl fake::MobActor {
+    async fn commit_flow_frame_store_plan_in_actor(
+        &mut self,
+        run_id: &RunId,
+        plan: FlowFrameLoopStorePlan,
+    ) -> Result<bool, MobError> {
+        let prepared =
+            self.prepare_dsl_inputs(plan.machine_inputs(), "flow_frame_loop_store_plan")?;
+        let won = match &plan {
+            FlowFrameLoopStorePlan::RunStateOnly {
+                expected_run_state,
+                next_run_state,
+                ..
+            } => self
+                .run_store
+                .cas_flow_state(run_id, expected_run_state, next_run_state)
+                .await?,
+            _ => false,
+        };
+        if won {
+            self.commit_prepared_dsl_input(prepared);
+        }
+        Ok(won)
+    }
+}
+"#,
+    )
+    .expect("write root-qualified fake MobActor store plan impl spoof");
+
+    let mismatches = collect_direct_flow_reducer_transition_mismatches(dir.path())
+        .expect("flow projection mutation mismatches");
+    assert!(
+        mismatches.iter().any(|mismatch| {
+            mismatch.contains("meerkat-mob/src/runtime/actor.rs")
+                && mismatch.contains(".cas_flow_state(")
+        }),
+        "expected root-qualified fake MobActor impl not to authorize actor store-plan CAS, got {mismatches:#?}"
+    );
+}
+
+#[test]
+fn live_flow_runtime_projection_ratchet_rejects_actor_store_plan_mutated_authority_inputs() {
+    let dir = tempdir().expect("tempdir");
+    let runtime = dir.path().join("meerkat-mob/src/runtime");
+    fs::create_dir_all(&runtime).expect("create runtime dir");
+    fs::write(
+        runtime.join("actor.rs"),
+        r#"
+async fn commit_flow_frame_store_plan_in_actor(
+    &mut self,
+    run_id: &RunId,
+    plan: FlowFrameLoopStorePlan,
+) -> Result<bool, MobError> {
+    let prepared =
+        self.prepare_dsl_inputs(plan.machine_inputs(), "flow_frame_loop_store_plan")?;
+    let mut authority_inputs = plan.machine_inputs().to_vec();
+    authority_inputs.clear();
+    let won = match &plan {
+        FlowFrameLoopStorePlan::RunStateOnly {
+            expected_run_state,
+            next_run_state,
+            ..
+        } => self
+            .run_store
+            .cas_flow_state_with_authority(
+                run_id,
+                expected_run_state,
+                next_run_state,
+                authority_inputs,
+            )
+            .await?,
+        _ => false,
+    };
+    if won {
+        self.commit_prepared_dsl_input(prepared);
+    }
+    Ok(won)
+}
+"#,
+    )
+    .expect("write actor store plan mutated authority inputs");
+
+    let mismatches = collect_direct_flow_reducer_transition_mismatches(dir.path())
+        .expect("flow projection mutation mismatches");
+    assert!(
+        mismatches.iter().any(|mismatch| {
+            mismatch.contains("meerkat-mob/src/runtime/actor.rs")
+                && mismatch.contains(".cas_flow_state_with_authority(")
+        }),
+        "expected mutated actor store-plan authority inputs to reject the CAS authorization, got {mismatches:#?}"
+    );
+}
+
+#[test]
+fn live_flow_runtime_projection_ratchet_rejects_actor_store_plan_split_off_authority_inputs() {
+    let dir = tempdir().expect("tempdir");
+    let runtime = dir.path().join("meerkat-mob/src/runtime");
+    fs::create_dir_all(&runtime).expect("create runtime dir");
+    fs::write(
+        runtime.join("actor.rs"),
+        r#"
+impl MobActor {
+    async fn commit_flow_frame_store_plan_in_actor(
+        &mut self,
+        run_id: &RunId,
+        plan: FlowFrameLoopStorePlan,
+    ) -> Result<bool, MobError> {
+        let prepared =
+            self.prepare_dsl_inputs(plan.machine_inputs(), "flow_frame_loop_store_plan")?;
+        let mut authority_inputs = plan.machine_inputs().to_vec();
+        let _removed = authority_inputs.split_off(0);
+        let won = match &plan {
+            FlowFrameLoopStorePlan::RunStateOnly {
+                expected_run_state,
+                next_run_state,
+                ..
+            } => self
+                .run_store
+                .cas_flow_state_with_authority(
+                    run_id,
+                    expected_run_state,
+                    next_run_state,
+                    authority_inputs,
+                )
+                .await?,
+            _ => false,
+        };
+        if won {
+            self.commit_prepared_dsl_input(prepared);
+        }
+        Ok(won)
+    }
+}
+"#,
+    )
+    .expect("write actor store plan split_off-mutated authority inputs");
+
+    let mismatches = collect_direct_flow_reducer_transition_mismatches(dir.path())
+        .expect("flow projection mutation mismatches");
+    assert!(
+        mismatches.iter().any(|mismatch| {
+            mismatch.contains("meerkat-mob/src/runtime/actor.rs")
+                && mismatch.contains(".cas_flow_state_with_authority(")
+        }),
+        "expected split_off actor store-plan authority input mutation to reject the CAS authorization, got {mismatches:#?}"
+    );
+}
+
+#[test]
+fn live_flow_runtime_projection_ratchet_rejects_actor_store_plan_destructured_authority_inputs() {
+    let dir = tempdir().expect("tempdir");
+    let runtime = dir.path().join("meerkat-mob/src/runtime");
+    fs::create_dir_all(&runtime).expect("create runtime dir");
+    fs::write(
+        runtime.join("actor.rs"),
+        r#"
+impl MobActor {
+    async fn commit_flow_frame_store_plan_in_actor(
+        &mut self,
+        run_id: &RunId,
+        plan: FlowFrameLoopStorePlan,
+        fake_authority_inputs: Vec<MobMachineInput>,
+    ) -> Result<bool, MobError> {
+        let prepared =
+            self.prepare_dsl_inputs(plan.machine_inputs(), "flow_frame_loop_store_plan")?;
+        let authority_inputs = plan.machine_inputs().to_vec();
+        let (authority_inputs,) = (fake_authority_inputs,);
+        let won = match &plan {
+            FlowFrameLoopStorePlan::RunStateOnly {
+                expected_run_state,
+                next_run_state,
+                ..
+            } => self
+                .run_store
+                .cas_flow_state_with_authority(
+                    run_id,
+                    expected_run_state,
+                    next_run_state,
+                    authority_inputs,
+                )
+                .await?,
+            _ => false,
+        };
+        if won {
+            self.commit_prepared_dsl_input(prepared);
+        }
+        Ok(won)
+    }
+}
+"#,
+    )
+    .expect("write actor store plan destructured authority inputs");
+
+    let mismatches = collect_direct_flow_reducer_transition_mismatches(dir.path())
+        .expect("flow projection mutation mismatches");
+    assert!(
+        mismatches.iter().any(|mismatch| {
+            mismatch.contains("meerkat-mob/src/runtime/actor.rs")
+                && mismatch.contains(".cas_flow_state_with_authority(")
+        }),
+        "expected destructured actor store-plan authority input shadow to reject the CAS authorization, got {mismatches:#?}"
+    );
+}
+
+#[test]
+fn live_flow_runtime_projection_ratchet_rejects_actor_store_plan_index_mutated_authority_inputs() {
+    let dir = tempdir().expect("tempdir");
+    let runtime = dir.path().join("meerkat-mob/src/runtime");
+    fs::create_dir_all(&runtime).expect("create runtime dir");
+    fs::write(
+        runtime.join("actor.rs"),
+        r#"
+impl MobActor {
+    async fn commit_flow_frame_store_plan_in_actor(
+        &mut self,
+        run_id: &RunId,
+        plan: FlowFrameLoopStorePlan,
+        unrelated_input: MobMachineInput,
+    ) -> Result<bool, MobError> {
+        let prepared =
+            self.prepare_dsl_inputs(plan.machine_inputs(), "flow_frame_loop_store_plan")?;
+        let mut authority_inputs = plan.machine_inputs().to_vec();
+        authority_inputs[0] = unrelated_input;
+        let won = match &plan {
+            FlowFrameLoopStorePlan::RunStateOnly {
+                expected_run_state,
+                next_run_state,
+                ..
+            } => self
+                .run_store
+                .cas_flow_state_with_authority(
+                    run_id,
+                    expected_run_state,
+                    next_run_state,
+                    authority_inputs,
+                )
+                .await?,
+            _ => false,
+        };
+        if won {
+            self.commit_prepared_dsl_input(prepared);
+        }
+        Ok(won)
+    }
+}
+"#,
+    )
+    .expect("write actor store plan index-mutated authority inputs");
+
+    let mismatches = collect_direct_flow_reducer_transition_mismatches(dir.path())
+        .expect("flow projection mutation mismatches");
+    assert!(
+        mismatches.iter().any(|mismatch| {
+            mismatch.contains("meerkat-mob/src/runtime/actor.rs")
+                && mismatch.contains(".cas_flow_state_with_authority(")
+        }),
+        "expected indexed actor store-plan authority input mutation to reject the CAS authorization, got {mismatches:#?}"
+    );
+}
+
+#[test]
+fn live_flow_runtime_projection_ratchet_rejects_actor_store_plan_nested_mob_actor_spoof() {
+    let dir = tempdir().expect("tempdir");
+    let runtime = dir.path().join("meerkat-mob/src/runtime");
+    fs::create_dir_all(&runtime).expect("create runtime dir");
+    fs::write(
+        runtime.join("actor.rs"),
+        r#"
+mod fake {
+    struct MobActor {
+        run_store: Store,
+    }
+
+    impl MobActor {
+        async fn commit_flow_frame_store_plan_in_actor(
+            &mut self,
+            run_id: &RunId,
+            plan: FlowFrameLoopStorePlan,
+        ) -> Result<bool, MobError> {
+            let prepared =
+                self.prepare_dsl_inputs(plan.machine_inputs(), "flow_frame_loop_store_plan")?;
+            let won = match &plan {
+                FlowFrameLoopStorePlan::RunStateOnly {
+                    expected_run_state,
+                    next_run_state,
+                    ..
+                } => self
+                    .run_store
+                    .cas_flow_state(run_id, expected_run_state, next_run_state)
+                    .await?,
+                _ => false,
+            };
+            if won {
+                self.commit_prepared_dsl_input(prepared);
+            }
+            Ok(won)
+        }
+    }
+}
+"#,
+    )
+    .expect("write nested fake MobActor store plan impl spoof");
+
+    let mismatches = collect_direct_flow_reducer_transition_mismatches(dir.path())
+        .expect("flow projection mutation mismatches");
+    assert!(
+        mismatches.iter().any(|mismatch| {
+            mismatch.contains("meerkat-mob/src/runtime/actor.rs")
+                && mismatch.contains(".cas_flow_state(")
+        }),
+        "expected nested fake MobActor impl not to authorize actor store-plan CAS, got {mismatches:#?}"
     );
 }


### PR DESCRIPTION
## Summary
- Replace machine drift source-string ratchets with typed AST/canonical-owner governance for live-flow reducers, flow projection commits, and Mob command gates.
- Add canonical Mob command gate requirements and FlowFrameLoopStorePlan commit requirements as the authority source.
- Add regression coverage for fake owners, shadowing, fake receivers, raw CAS, path-sensitive store-plan commits, stale-plan freshness, and canonical InsertFrame None handling.

## Validation
- make fmt
- ./scripts/repo-cargo test -p xtask --features machine-authority --test machines_contracts -- --nocapture (257 passed)
- ./scripts/repo-cargo clippy -p xtask --features machine-authority --all-targets -- -D warnings
- make machine-check-drift
- git diff --check
- python3 -m json.tool MODULE.bazel.lock >/dev/null
- MEERKAT_BUILDBUDDY=1 make agent-gate (workspace-fast-clippy-rbe 169 tests passed; workspace-build-clippy-rbe passed; e2e-system-rbe 10 tests passed)

Linear: LUC-291