### PR TITLE
LUC-297 Collapse runtime turn metadata carrier boundary

### DIFF
--- a/meerkat-session/src/ephemeral.rs
+++ b/meerkat-session/src/ephemeral.rs
@@ -1738,25 +1738,22 @@ impl<B: SessionAgentBuilder + 'static> EphemeralSessionService<B> {
             }
 
             let metadata = req.turn_metadata;
-            let render_metadata = req.render_metadata.or_else(|| {
-                metadata
-                    .as_ref()
-                    .and_then(|metadata| metadata.render_metadata.clone())
-            });
+            let render_metadata = metadata
+                .as_ref()
+                .and_then(|metadata| metadata.render_metadata.clone())
+                .or(req.render_metadata);
             let handling_mode = metadata
                 .as_ref()
                 .and_then(|metadata| metadata.handling_mode)
                 .unwrap_or(req.handling_mode);
-            let skill_references = req.skill_references.or_else(|| {
-                metadata
-                    .as_ref()
-                    .and_then(|metadata| metadata.skill_references.clone())
-            });
-            let flow_tool_overlay = req.flow_tool_overlay.or_else(|| {
-                metadata
-                    .as_ref()
-                    .and_then(|metadata| metadata.flow_tool_overlay.clone())
-            });
+            let skill_references = metadata
+                .as_ref()
+                .and_then(|metadata| metadata.skill_references.clone())
+                .or(req.skill_references);
+            let flow_tool_overlay = metadata
+                .as_ref()
+                .and_then(|metadata| metadata.flow_tool_overlay.clone())
+                .or(req.flow_tool_overlay);
             let pre_turn_context_appends = req.pre_turn_context_appends;
             let execution_kind = metadata
                 .as_ref()
@@ -2257,20 +2254,18 @@ impl<B: SessionAgentBuilder + 'static> SessionService for EphemeralSessionServic
             .as_ref()
             .and_then(|build| build.initial_turn_metadata.as_ref())
             .cloned();
-        let initial_render_metadata = req.render_metadata.or_else(|| {
-            initial_turn_metadata
-                .as_ref()
-                .and_then(|metadata| metadata.render_metadata.clone())
-        });
+        let initial_render_metadata = initial_turn_metadata
+            .as_ref()
+            .and_then(|metadata| metadata.render_metadata.clone())
+            .or(req.render_metadata);
         let initial_handling_mode = initial_turn_metadata
             .as_ref()
             .and_then(|metadata| metadata.handling_mode)
             .unwrap_or(meerkat_core::types::HandlingMode::Queue);
-        let initial_skill_references = req.skill_references.or_else(|| {
-            initial_turn_metadata
-                .as_ref()
-                .and_then(|metadata| metadata.skill_references.clone())
-        });
+        let initial_skill_references = initial_turn_metadata
+            .as_ref()
+            .and_then(|metadata| metadata.skill_references.clone())
+            .or(req.skill_references);
         let initial_flow_tool_overlay = initial_turn_metadata
             .as_ref()
             .and_then(|metadata| metadata.flow_tool_overlay.clone());
@@ -3852,6 +3847,73 @@ mod runtime_turn_metadata_tests {
                 .expect("observed skill references lock poisoned"),
             vec![Some(vec![skill])],
             "eager first turn must forward the full runtime metadata carrier"
+        );
+    }
+
+    #[tokio::test]
+    async fn start_turn_runtime_metadata_prevents_stale_split_skill_replay() {
+        let observed_skill_references = Arc::new(Mutex::new(Vec::new()));
+        let observed_context_texts = Arc::new(Mutex::new(Vec::new()));
+        let run_context_counts = Arc::new(Mutex::new(Vec::new()));
+        let service = EphemeralSessionService::new(
+            MetadataProbeBuilder {
+                observed_skill_references: Arc::clone(&observed_skill_references),
+                observed_context_texts,
+                run_context_counts,
+                fail_flow_overlay_set: false,
+            },
+            1,
+        );
+        let stale_split =
+            SkillKey::builtin(SkillName::parse("stale-split-skill").expect("valid skill"));
+        let canonical =
+            SkillKey::builtin(SkillName::parse("runtime-canonical-skill").expect("valid skill"));
+
+        let result = service
+            .create_session(CreateSessionRequest {
+                model: "metadata-probe-model".to_string(),
+                prompt: ContentInput::Text("defer".to_string()),
+                render_metadata: None,
+                system_prompt: None,
+                max_tokens: None,
+                event_tx: None,
+                skill_references: None,
+                initial_turn: InitialTurnPolicy::Defer,
+                deferred_prompt_policy: DeferredPromptPolicy::Discard,
+                build: Some(SessionBuildOptions::default()),
+                labels: None,
+            })
+            .await
+            .expect("deferred session should create");
+
+        service
+            .start_turn(
+                &result.session_id,
+                StartTurnRequest {
+                    prompt: ContentInput::Text("go".to_string()),
+                    system_prompt: None,
+                    render_metadata: None,
+                    handling_mode: meerkat_core::types::HandlingMode::Queue,
+                    event_tx: None,
+                    skill_references: Some(vec![stale_split]),
+                    flow_tool_overlay: None,
+                    pre_turn_context_appends: Vec::new(),
+                    turn_metadata: Some(RuntimeTurnMetadata {
+                        execution_kind: Some(RuntimeExecutionKind::ContentTurn),
+                        skill_references: Some(vec![canonical.clone()]),
+                        ..Default::default()
+                    }),
+                },
+            )
+            .await
+            .expect("turn should run with canonical runtime metadata");
+
+        assert_eq!(
+            *observed_skill_references
+                .lock()
+                .expect("observed skill references lock poisoned"),
+            vec![Some(vec![canonical])],
+            "canonical RuntimeTurnMetadata must be the only skill carrier once present"
         );
     }
 

--- a/meerkat/src/surface/runtime_backed.rs
+++ b/meerkat/src/surface/runtime_backed.rs
@@ -414,13 +414,11 @@ fn start_turn_request_from_primitive(
     Ok(meerkat_core::service::StartTurnRequest {
         prompt: primitive.extract_content_input(),
         system_prompt: None,
-        render_metadata: metadata.and_then(|metadata| metadata.render_metadata.clone()),
-        handling_mode: metadata
-            .and_then(|metadata| metadata.handling_mode)
-            .unwrap_or(HandlingMode::Queue),
+        render_metadata: None,
+        handling_mode: HandlingMode::Queue,
         event_tx: None,
-        skill_references: metadata.and_then(|metadata| metadata.skill_references.clone()),
-        flow_tool_overlay: metadata.and_then(|metadata| metadata.flow_tool_overlay.clone()),
+        skill_references: None,
+        flow_tool_overlay: None,
         pre_turn_context_appends,
         turn_metadata: metadata.cloned(),
     })
@@ -668,11 +666,24 @@ mod tests {
 
     #[test]
     fn run_primitive_carries_runtime_metadata_into_start_turn_request() {
+        let skill = meerkat_core::skills::SkillKey::builtin(
+            meerkat_core::skills::SkillName::parse("runtime-metadata").expect("valid skill"),
+        );
         let metadata = RuntimeTurnMetadata {
             execution_kind: Some(meerkat_core::lifecycle::RuntimeExecutionKind::ResumePending),
             model: Some(meerkat_core::lifecycle::run_primitive::ModelId::new(
                 "model-from-runtime",
             )),
+            handling_mode: Some(meerkat_core::types::HandlingMode::Steer),
+            render_metadata: Some(meerkat_core::types::RenderMetadata {
+                class: meerkat_core::types::RenderClass::FlowStep,
+                salience: meerkat_core::types::RenderSalience::Important,
+            }),
+            skill_references: Some(vec![skill]),
+            flow_tool_overlay: Some(meerkat_core::service::TurnToolOverlay {
+                allowed_tools: Some(vec!["runtime_tool".to_string()]),
+                blocked_tools: None,
+            }),
             ..Default::default()
         };
         let primitive =
@@ -692,6 +703,10 @@ mod tests {
         let req = start_turn_request_from_primitive(&primitive)
             .expect("metadata should be carried, not rejected");
 
+        assert_eq!(req.render_metadata, None);
+        assert_eq!(req.handling_mode, meerkat_core::types::HandlingMode::Queue);
+        assert_eq!(req.skill_references, None);
+        assert_eq!(req.flow_tool_overlay, None);
         assert_eq!(req.turn_metadata, Some(metadata));
         assert_eq!(
             req.turn_metadata


### PR DESCRIPTION
## Summary
- Make `RuntimeTurnMetadata` authoritative at the session start-turn boundary when present; split `StartTurnRequest` fields are fallback-only for direct/non-runtime callers.
- Stop the runtime-backed executor from mirroring canonical runtime metadata into split `StartTurnRequest` fields.
- Add a stale split `skill_references` regression and strengthen the runtime-backed conversion test.

## Review Readiness Packet
Packet freshness: current for exact PR head `a83e1cc05f6b61c751471871b0ceb4ff8bc0c52a` (`Collapse runtime turn metadata carrier boundary`). Rework on 2026-05-02 only refreshed this packet/workpad after the admission gate; code, branch head, and validation evidence are unchanged.

Canonical carrier: `RuntimeTurnMetadata` carried on `RunPrimitive::StagedInput` and forwarded via `StartTurnRequest.turn_metadata`.

Boundary collapsed: runtime-backed turn execution into `EphemeralSessionService`/persistent wrapper. The runtime-backed surface now leaves split request fields empty/default and the session boundary derives semantics from `turn_metadata` first.

Complexity Delta: 2 non-generated Rust files, +108/-31. No schema, SDK, generated, REST, RPC, MCP, or public wire churn. Net additions are focused tests plus a mechanical precedence collapse; the design is simpler because old split request fields no longer have authority once the canonical carrier is present.

Regression covered: stale split `skill_references` cannot replay over canonical runtime metadata, preventing the prior split-carrier skill injection failure mode.

## Validation
- Exact head validated: `a83e1cc05f6b61c751471871b0ceb4ff8bc0c52a`
- `./scripts/repo-cargo fmt`
- `git diff --check`
- `./scripts/repo-cargo test -p meerkat-session runtime_turn_metadata_tests --features session-store`
- `./scripts/repo-cargo test -p meerkat run_primitive_carries_runtime_metadata_into_start_turn_request --features session-store,jsonl-store`
- `make check` via BuildBuddy invocation `c46863e8-ac08-4591-a7a8-c1b1b5875d26`
- GitHub CI for PR head `a83e1cc05f6b61c751471871b0ceb4ff8bc0c52a`: green; merge state clean; no PR reviews/comments at packet refresh time.

Linear: LUC-297