### PR TITLE
Shrink OAuth flow payload authority

### DIFF
--- a/meerkat-auth-core/src/oauth_flow.rs
+++ b/meerkat-auth-core/src/oauth_flow.rs
@@ -383,10 +383,6 @@ pub struct OAuthFlowRegistrySnapshot {
     pub browser: Vec<PersistedOAuthBrowserFlow>,
     #[serde(default)]
     pub device: Vec<PersistedOAuthDeviceFlow>,
-    #[serde(default)]
-    pub browser_removed: Vec<PersistedOAuthBrowserFlowRemoval>,
-    #[serde(default)]
-    pub device_removed: Vec<PersistedOAuthDeviceFlowRemoval>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -406,20 +402,6 @@ pub struct PersistedOAuthDeviceFlow {
     pub provider: String,
     pub device_code: String,
     pub created_at_millis: u64,
-    pub expires_at_millis: u64,
-}
-
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
-pub struct PersistedOAuthBrowserFlowRemoval {
-    pub target: ConnectionRef,
-    pub state: String,
-    pub expires_at_millis: u64,
-}
-
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
-pub struct PersistedOAuthDeviceFlowRemoval {
-    pub target: ConnectionRef,
-    pub device_code: String,
     pub expires_at_millis: u64,
 }
 
@@ -984,12 +966,7 @@ impl OAuthFlowRegistry {
             })
             .collect();
 
-        OAuthFlowRegistrySnapshot {
-            browser,
-            device,
-            browser_removed: Vec::new(),
-            device_removed: Vec::new(),
-        }
+        OAuthFlowRegistrySnapshot { browser, device }
     }
 
     pub fn insert_restored_browser_flow(

--- a/meerkat-runtime/src/handles/oauth_flow.rs
+++ b/meerkat-runtime/src/handles/oauth_flow.rs
@@ -540,6 +540,8 @@ impl RuntimeOAuthFlowHandle {
         operation: &'static str,
         removed_browser: &[BrowserSnapshotKey],
         removed_device: &[DeviceSnapshotKey],
+        admitted_browser: &[BrowserSnapshotKey],
+        admitted_device: &[DeviceSnapshotKey],
     ) -> Result<(), OAuthFlowError> {
         persist_registry_payloads_claiming_admission(
             &self.registry,
@@ -547,6 +549,8 @@ impl RuntimeOAuthFlowHandle {
             operation,
             removed_browser,
             removed_device,
+            admitted_browser,
+            admitted_device,
         )
     }
 
@@ -881,6 +885,8 @@ fn persist_registry_payloads_claiming_admission(
     operation: &'static str,
     removed_browser: &[BrowserSnapshotKey],
     removed_device: &[DeviceSnapshotKey],
+    admitted_browser: &[BrowserSnapshotKey],
+    admitted_device: &[DeviceSnapshotKey],
 ) -> Result<(), OAuthFlowError> {
     let now_millis = current_time_millis();
     let snapshot = registry.snapshot_for_persistence(now_millis);
@@ -891,7 +897,11 @@ fn persist_registry_payloads_claiming_admission(
         removed_browser,
         removed_device,
         now_millis,
-        SnapshotPersistPolicy::claim_admission(registry.max_outstanding()),
+        SnapshotPersistPolicy::claim_admission(
+            registry.max_outstanding(),
+            admitted_browser,
+            admitted_device,
+        ),
     )
 }
 
@@ -902,42 +912,46 @@ enum SnapshotRemovalMode {
 }
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
-struct SnapshotPersistPolicy {
+struct SnapshotPersistPolicy<'a> {
     removal_mode: SnapshotRemovalMode,
     admission_capacity: Option<usize>,
-    admit_local_payloads: bool,
+    admitted_browser: &'a [BrowserSnapshotKey],
+    admitted_device: &'a [DeviceSnapshotKey],
 }
 
-impl SnapshotPersistPolicy {
+impl<'a> SnapshotPersistPolicy<'a> {
     fn merge() -> Self {
         Self {
             removal_mode: SnapshotRemovalMode::Merge,
             admission_capacity: None,
-            admit_local_payloads: true,
+            admitted_browser: &[],
+            admitted_device: &[],
         }
     }
 
     fn merge_existing() -> Self {
-        Self {
-            removal_mode: SnapshotRemovalMode::Merge,
-            admission_capacity: None,
-            admit_local_payloads: false,
-        }
+        Self::merge()
     }
 
     fn claim_removal() -> Self {
         Self {
             removal_mode: SnapshotRemovalMode::Claim,
             admission_capacity: None,
-            admit_local_payloads: true,
+            admitted_browser: &[],
+            admitted_device: &[],
         }
     }
 
-    fn claim_admission(max_outstanding: usize) -> Self {
+    fn claim_admission(
+        max_outstanding: usize,
+        admitted_browser: &'a [BrowserSnapshotKey],
+        admitted_device: &'a [DeviceSnapshotKey],
+    ) -> Self {
         Self {
             removal_mode: SnapshotRemovalMode::Merge,
             admission_capacity: Some(max_outstanding),
-            admit_local_payloads: true,
+            admitted_browser,
+            admitted_device,
         }
     }
 }
@@ -949,7 +963,7 @@ fn persist_registry_snapshot(
     removed_browser: &[BrowserSnapshotKey],
     removed_device: &[DeviceSnapshotKey],
     now_millis: u64,
-    policy: SnapshotPersistPolicy,
+    policy: SnapshotPersistPolicy<'_>,
 ) -> Result<(), OAuthFlowError> {
     let store = store
         .lock()
@@ -1081,7 +1095,7 @@ fn merge_oauth_registry_snapshot(
     removed_browser: &[BrowserSnapshotKey],
     removed_device: &[DeviceSnapshotKey],
     now_millis: u64,
-    policy: SnapshotPersistPolicy,
+    policy: SnapshotPersistPolicy<'_>,
 ) -> Result<OAuthFlowRegistrySnapshot, crate::store::RuntimeStoreError> {
     let mut merged = match current {
         Some(bytes) => serde_json::from_slice::<OAuthFlowRegistrySnapshot>(bytes)
@@ -1090,6 +1104,16 @@ fn merge_oauth_registry_snapshot(
     };
     let removed_browser = removed_browser.iter().cloned().collect::<BTreeSet<_>>();
     let removed_device = removed_device.iter().cloned().collect::<BTreeSet<_>>();
+    let admitted_browser = policy
+        .admitted_browser
+        .iter()
+        .cloned()
+        .collect::<BTreeSet<_>>();
+    let admitted_device = policy
+        .admitted_device
+        .iter()
+        .cloned()
+        .collect::<BTreeSet<_>>();
     if policy.removal_mode == SnapshotRemovalMode::Claim {
         ensure_removed_flows_are_active(&merged, &removed_browser, &removed_device, now_millis)?;
     }
@@ -1134,7 +1158,7 @@ fn merge_oauth_registry_snapshot(
                 let key = persisted_browser_snapshot_key(flow);
                 flow.expires_at_millis > now_millis
                     && !removed_browser.contains(&key)
-                    && (policy.admit_local_payloads || current_browser.contains(&key))
+                    && (current_browser.contains(&key) || admitted_browser.contains(&key))
             })
             .cloned(),
     );
@@ -1146,7 +1170,7 @@ fn merge_oauth_registry_snapshot(
                 let key = persisted_device_snapshot_key(flow);
                 flow.expires_at_millis > now_millis
                     && !removed_device.contains(&key)
-                    && (policy.admit_local_payloads || current_device.contains(&key))
+                    && (current_device.contains(&key) || admitted_device.contains(&key))
             })
             .cloned(),
     );
@@ -1381,10 +1405,13 @@ impl OAuthFlowAuthority for RuntimeOAuthFlowHandle {
                 (Vec::new(), Vec::new())
             };
         self.expire_collected_flows(pruned);
+        let admitted_browser = [browser_snapshot_key(&target, &state)];
         if let Err(err) = self.persist_registry_payloads_claiming_admission(
             "admit_oauth_browser_flow",
             &removed_browser,
             &removed_device,
+            &admitted_browser,
+            &[],
         ) {
             let _ = self
                 .registry
@@ -1549,10 +1576,13 @@ impl OAuthFlowAuthority for RuntimeOAuthFlowHandle {
                 (Vec::new(), Vec::new())
             };
         self.expire_collected_flows(pruned);
+        let admitted_device = [device_snapshot_key(&target, &device_code)];
         if let Err(err) = self.persist_registry_payloads_claiming_admission(
             "admit_oauth_device_flow",
             &removed_browser,
             &removed_device,
+            &[],
+            &admitted_device,
         ) {
             let _ = self
                 .registry
@@ -2186,27 +2216,20 @@ mod tests {
             .expect("second independent flow rehydrates after first consume");
     }
 
-    #[cfg(feature = "sqlite-store")]
     #[test]
-    fn persistent_oauth_browser_payload_sync_blocks_stale_authority_resurrection() {
-        let temp_dir = tempfile::tempdir().expect("tempdir");
-        let store_path = temp_dir.path().join("runtime.sqlite");
-        let creator_store: Arc<dyn RuntimeStore> =
-            Arc::new(crate::store::sqlite::SqliteRuntimeStore::new(&store_path).unwrap());
-        let stale_store: Arc<dyn RuntimeStore> =
-            Arc::new(crate::store::sqlite::SqliteRuntimeStore::new(&store_path).unwrap());
-        let consumer_store: Arc<dyn RuntimeStore> =
-            Arc::new(crate::store::sqlite::SqliteRuntimeStore::new(&store_path).unwrap());
+    fn persistent_oauth_browser_admit_does_not_resurrect_consumed_between_sync_and_persist() {
+        let store = Arc::new(FailingOAuthSnapshotStore::default());
+        let store_dyn = Arc::clone(&store) as Arc<dyn RuntimeStore>;
         let creator = RuntimeOAuthFlowHandle::new_with_persistent_store_and_auth_lease(
             Duration::from_secs(60),
             Arc::new(RuntimeAuthLeaseHandle::new()),
-            &creator_store,
+            &store_dyn,
         );
         let target = target();
-        let stale_target = alternate_target();
+        let replacement_target = alternate_target();
         let provider = OAuthProviderIdentity::OpenAiChatGpt;
         let redirect_uri = "http://127.0.0.1/callback";
-        let stale_redirect_uri = "http://127.0.0.1/stale-callback";
+        let replacement_redirect_uri = "http://127.0.0.1/replacement-callback";
         let consumed_state = creator
             .start(
                 target.clone(),
@@ -2216,33 +2239,43 @@ mod tests {
             )
             .expect("creator admits browser flow");
 
-        let stale_authority = RuntimeOAuthFlowHandle::new_with_persistent_store_and_auth_lease(
-            Duration::from_secs(60),
-            Arc::new(RuntimeAuthLeaseHandle::new()),
-            &stale_store,
+        let stale_authority = Arc::new(
+            RuntimeOAuthFlowHandle::new_with_persistent_store_and_auth_lease(
+                Duration::from_secs(60),
+                Arc::new(RuntimeAuthLeaseHandle::new()),
+                &store_dyn,
+            ),
         );
         let consumer = RuntimeOAuthFlowHandle::new_with_persistent_store_and_auth_lease(
             Duration::from_secs(60),
             Arc::new(RuntimeAuthLeaseHandle::new()),
-            &consumer_store,
+            &store_dyn,
         );
+
+        store.block_next_oauth_persist();
+        let stale_admit = std::thread::spawn({
+            let stale_authority = Arc::clone(&stale_authority);
+            let replacement_target = replacement_target.clone();
+            move || {
+                stale_authority.start(
+                    replacement_target,
+                    provider,
+                    replacement_redirect_uri.to_string(),
+                    "replacement-verifier".to_string(),
+                )
+            }
+        });
+        store.wait_for_blocked_oauth_persist();
         consumer
             .consume(&consumed_state, &target, provider, redirect_uri)
-            .expect("independent authority consumes browser flow");
-        assert!(matches!(
-            stale_authority.consume(&consumed_state, &target, provider, redirect_uri),
-            Err(OAuthFlowError::Missing)
-        ));
+            .expect("independent authority consumes browser flow between sync and persist");
+        store.release_blocked_oauth_persist();
+        let replacement_state = stale_admit
+            .join()
+            .expect("stale browser admit thread should not panic")
+            .expect("stale authority admits replacement browser flow");
 
-        let stale_new_state = stale_authority
-            .start(
-                stale_target.clone(),
-                provider,
-                stale_redirect_uri.to_string(),
-                "stale-new-verifier".to_string(),
-            )
-            .expect("stale authority admits another flow");
-        let snapshot_json = stale_store
+        let snapshot_json = store
             .load_auth_oauth_flow_snapshot()
             .expect("durable OAuth snapshot loads")
             .expect("durable OAuth snapshot exists");
@@ -2253,22 +2286,20 @@ mod tests {
                 .browser
                 .iter()
                 .any(|flow| flow.state == consumed_state),
-            "a stale authority must not resurrect a consumed browser flow"
+            "a stale admission must not resurrect a browser flow consumed after pre-sync"
         );
         assert!(
             snapshot
                 .browser
                 .iter()
-                .any(|flow| flow.state == stale_new_state),
-            "the stale authority's new browser flow should still persist"
+                .any(|flow| flow.state == replacement_state),
+            "the stale authority's newly admitted browser flow should still persist"
         );
 
-        let restarted_store: Arc<dyn RuntimeStore> =
-            Arc::new(crate::store::sqlite::SqliteRuntimeStore::new(&store_path).unwrap());
         let restarted = RuntimeOAuthFlowHandle::new_with_persistent_store_and_auth_lease(
             Duration::from_secs(60),
             Arc::new(RuntimeAuthLeaseHandle::new()),
-            &restarted_store,
+            &store_dyn,
         );
         assert!(matches!(
             restarted.consume(&consumed_state, &target, provider, redirect_uri),
@@ -2276,35 +2307,28 @@ mod tests {
         ));
         restarted
             .consume(
-                &stale_new_state,
-                &stale_target,
+                &replacement_state,
+                &replacement_target,
                 provider,
-                stale_redirect_uri,
+                replacement_redirect_uri,
             )
             .expect("new stale-authority flow survives restart");
     }
 
-    #[cfg(feature = "sqlite-store")]
     #[test]
-    fn persistent_oauth_device_payload_sync_blocks_stale_authority_resurrection() {
-        let temp_dir = tempfile::tempdir().expect("tempdir");
-        let store_path = temp_dir.path().join("runtime.sqlite");
-        let creator_store: Arc<dyn RuntimeStore> =
-            Arc::new(crate::store::sqlite::SqliteRuntimeStore::new(&store_path).unwrap());
-        let stale_store: Arc<dyn RuntimeStore> =
-            Arc::new(crate::store::sqlite::SqliteRuntimeStore::new(&store_path).unwrap());
-        let consumer_store: Arc<dyn RuntimeStore> =
-            Arc::new(crate::store::sqlite::SqliteRuntimeStore::new(&store_path).unwrap());
+    fn persistent_oauth_device_admit_does_not_resurrect_consumed_between_sync_and_persist() {
+        let store = Arc::new(FailingOAuthSnapshotStore::default());
+        let store_dyn = Arc::clone(&store) as Arc<dyn RuntimeStore>;
         let creator = RuntimeOAuthFlowHandle::new_with_persistent_store_and_auth_lease(
             Duration::from_secs(60),
             Arc::new(RuntimeAuthLeaseHandle::new()),
-            &creator_store,
+            &store_dyn,
         );
         let target = target();
-        let stale_target = alternate_target();
+        let replacement_target = alternate_target();
         let provider = OAuthProviderIdentity::GoogleCodeAssist;
         let consumed_device_code = "consumed-device-code";
-        let stale_device_code = "stale-new-device-code";
+        let replacement_device_code = "replacement-device-code";
         creator
             .admit_device_code(
                 target.clone(),
@@ -2314,35 +2338,45 @@ mod tests {
             )
             .expect("creator admits device flow");
 
-        let stale_authority = RuntimeOAuthFlowHandle::new_with_persistent_store_and_auth_lease(
-            Duration::from_secs(60),
-            Arc::new(RuntimeAuthLeaseHandle::new()),
-            &stale_store,
+        let stale_authority = Arc::new(
+            RuntimeOAuthFlowHandle::new_with_persistent_store_and_auth_lease(
+                Duration::from_secs(60),
+                Arc::new(RuntimeAuthLeaseHandle::new()),
+                &store_dyn,
+            ),
         );
         let consumer = RuntimeOAuthFlowHandle::new_with_persistent_store_and_auth_lease(
             Duration::from_secs(60),
             Arc::new(RuntimeAuthLeaseHandle::new()),
-            &consumer_store,
+            &store_dyn,
         );
+
+        store.block_next_oauth_persist();
+        let stale_admit = std::thread::spawn({
+            let stale_authority = Arc::clone(&stale_authority);
+            let replacement_target = replacement_target.clone();
+            move || {
+                stale_authority.admit_device_code(
+                    replacement_target,
+                    provider,
+                    replacement_device_code.to_string(),
+                    Duration::from_secs(60),
+                )
+            }
+        });
+        store.wait_for_blocked_oauth_persist();
         consumer
             .begin_device_code_poll(consumed_device_code, &target, provider)
             .expect("independent authority begins device poll")
             .consume()
-            .expect("independent authority consumes device flow");
-        assert!(matches!(
-            stale_authority.begin_device_code_poll(consumed_device_code, &target, provider),
-            Err(OAuthFlowError::Missing)
-        ));
+            .expect("independent authority consumes device flow between sync and persist");
+        store.release_blocked_oauth_persist();
+        stale_admit
+            .join()
+            .expect("stale device admit thread should not panic")
+            .expect("stale authority admits replacement device flow");
 
-        stale_authority
-            .admit_device_code(
-                stale_target.clone(),
-                provider,
-                stale_device_code.to_string(),
-                Duration::from_secs(60),
-            )
-            .expect("stale authority admits another device flow");
-        let snapshot_json = stale_store
+        let snapshot_json = store
             .load_auth_oauth_flow_snapshot()
             .expect("durable OAuth snapshot loads")
             .expect("durable OAuth snapshot exists");
@@ -2353,29 +2387,27 @@ mod tests {
                 .device
                 .iter()
                 .any(|flow| flow.device_code == consumed_device_code),
-            "a stale authority must not resurrect a consumed device flow"
+            "a stale admission must not resurrect a device flow consumed after pre-sync"
         );
         assert!(
             snapshot
                 .device
                 .iter()
-                .any(|flow| flow.device_code == stale_device_code),
-            "the stale authority's new device flow should still persist"
+                .any(|flow| flow.device_code == replacement_device_code),
+            "the stale authority's newly admitted device flow should still persist"
         );
 
-        let restarted_store: Arc<dyn RuntimeStore> =
-            Arc::new(crate::store::sqlite::SqliteRuntimeStore::new(&store_path).unwrap());
         let restarted = RuntimeOAuthFlowHandle::new_with_persistent_store_and_auth_lease(
             Duration::from_secs(60),
             Arc::new(RuntimeAuthLeaseHandle::new()),
-            &restarted_store,
+            &store_dyn,
         );
         assert!(matches!(
             restarted.verify_device_code(consumed_device_code, &target, provider),
             Err(OAuthFlowError::Missing)
         ));
         restarted
-            .verify_device_code(stale_device_code, &stale_target, provider)
+            .verify_device_code(replacement_device_code, &replacement_target, provider)
             .expect("new stale-authority device flow survives restart");
     }
 

--- a/meerkat-runtime/src/handles/oauth_flow.rs
+++ b/meerkat-runtime/src/handles/oauth_flow.rs
@@ -6,15 +6,14 @@
 //! membership and terminal transitions are routed through generated
 //! AuthMachine inputs keyed by the target binding.
 
-use std::collections::{BTreeMap, BTreeSet};
+use std::collections::BTreeSet;
 use std::sync::{Arc, Mutex, Weak};
 use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 
 use meerkat_auth_core::oauth_flow::{
     OAuthDeviceFlowRecord, OAuthDevicePollLease, OAuthDevicePollLifecycle, OAuthFlowAuthority,
     OAuthFlowError, OAuthFlowRecord, OAuthFlowRegistry, OAuthFlowRegistrySnapshot,
-    OAuthProviderIdentity, OAuthPrunedFlows, PersistedOAuthBrowserFlow,
-    PersistedOAuthBrowserFlowRemoval, PersistedOAuthDeviceFlow, PersistedOAuthDeviceFlowRemoval,
+    OAuthProviderIdentity, OAuthPrunedFlows, PersistedOAuthBrowserFlow, PersistedOAuthDeviceFlow,
 };
 use meerkat_core::ConnectionRef;
 use meerkat_core::handles::{DslTransitionError, LeaseKey};
@@ -27,8 +26,8 @@ use super::auth_lease::{AuthLeaseReleaseObserver, ReleasedOAuthFlows};
 
 type StoreSlot = Arc<Mutex<Option<Weak<dyn RuntimeStore>>>>;
 type PayloadLock = Arc<Mutex<()>>;
-type RemovedBrowserSnapshotKeys = Vec<PersistedOAuthBrowserFlowRemoval>;
-type RemovedDeviceSnapshotKeys = Vec<PersistedOAuthDeviceFlowRemoval>;
+type RemovedBrowserSnapshotKeys = Vec<BrowserSnapshotKey>;
+type RemovedDeviceSnapshotKeys = Vec<DeviceSnapshotKey>;
 
 fn current_time_millis() -> u64 {
     SystemTime::now()
@@ -110,38 +109,18 @@ impl AuthLeaseReleaseObserver for OAuthPayloadReleaseObserver {
             });
         };
         let now_millis = current_time_millis();
-        let removed_browser = snapshot
-            .browser_removed
-            .iter()
-            .filter(|removal| removal.expires_at_millis > now_millis)
-            .map(persisted_browser_removal_key)
-            .collect::<BTreeSet<_>>();
-        let removed_device = snapshot
-            .device_removed
-            .iter()
-            .filter(|removal| removal.expires_at_millis > now_millis)
-            .map(persisted_device_removal_key)
-            .collect::<BTreeSet<_>>();
         Ok(ReleasedOAuthFlows {
             lease_key: lease_key.clone(),
             browser_flow_ids: snapshot
                 .browser
                 .iter()
-                .filter(|flow| {
-                    flow.target == target
-                        && flow.expires_at_millis > now_millis
-                        && !removed_browser.contains(&persisted_browser_snapshot_key(flow))
-                })
+                .filter(|flow| flow.target == target && flow.expires_at_millis > now_millis)
                 .map(|flow| flow.state.clone())
                 .collect(),
             device_flow_ids: snapshot
                 .device
                 .iter()
-                .filter(|flow| {
-                    flow.target == target
-                        && flow.expires_at_millis > now_millis
-                        && !removed_device.contains(&persisted_device_snapshot_key(flow))
-                })
+                .filter(|flow| flow.target == target && flow.expires_at_millis > now_millis)
                 .map(|flow| flow.device_code.clone())
                 .collect(),
         })
@@ -169,56 +148,48 @@ impl AuthLeaseReleaseObserver for OAuthPayloadReleaseObserver {
             .collect::<BTreeSet<_>>();
         let now_millis = current_time_millis();
         let mut snapshot = self.registry.snapshot_for_persistence(now_millis);
-        let mut removed_browser = BTreeMap::new();
-        for removal in snapshot
+        let mut removed_browser = snapshot
             .browser
             .iter()
             .filter(|flow| flow.target == target && browser_flow_ids.contains(flow.state.as_str()))
-            .map(browser_removal_from_flow)
-        {
-            merge_browser_removal(&mut removed_browser, removal, now_millis);
-        }
-        let mut removed_device = BTreeMap::new();
-        for removal in snapshot
+            .map(persisted_browser_snapshot_key)
+            .collect::<BTreeSet<_>>();
+        let mut removed_device = snapshot
             .device
             .iter()
             .filter(|flow| {
                 flow.target == target && device_flow_ids.contains(flow.device_code.as_str())
             })
-            .map(device_removal_from_flow)
-        {
-            merge_device_removal(&mut removed_device, removal, now_millis);
-        }
+            .map(persisted_device_snapshot_key)
+            .collect::<BTreeSet<_>>();
         if let Some(durable) =
             load_oauth_snapshot_for_release(&self.store, "release_oauth_flow_payloads")?
         {
-            for removal in durable
-                .browser
-                .iter()
-                .filter(|flow| {
-                    flow.target == target
-                        && browser_flow_ids.contains(flow.state.as_str())
-                        && flow.expires_at_millis > now_millis
-                })
-                .map(browser_removal_from_flow)
-            {
-                merge_browser_removal(&mut removed_browser, removal, now_millis);
-            }
-            for removal in durable
-                .device
-                .iter()
-                .filter(|flow| {
-                    flow.target == target
-                        && device_flow_ids.contains(flow.device_code.as_str())
-                        && flow.expires_at_millis > now_millis
-                })
-                .map(device_removal_from_flow)
-            {
-                merge_device_removal(&mut removed_device, removal, now_millis);
-            }
+            removed_browser.extend(
+                durable
+                    .browser
+                    .iter()
+                    .filter(|flow| {
+                        flow.target == target
+                            && browser_flow_ids.contains(flow.state.as_str())
+                            && flow.expires_at_millis > now_millis
+                    })
+                    .map(persisted_browser_snapshot_key),
+            );
+            removed_device.extend(
+                durable
+                    .device
+                    .iter()
+                    .filter(|flow| {
+                        flow.target == target
+                            && device_flow_ids.contains(flow.device_code.as_str())
+                            && flow.expires_at_millis > now_millis
+                    })
+                    .map(persisted_device_snapshot_key),
+            );
         }
-        let removed_browser = removed_browser.into_values().collect::<Vec<_>>();
-        let removed_device = removed_device.into_values().collect::<Vec<_>>();
+        let removed_browser = removed_browser.into_iter().collect::<Vec<_>>();
+        let removed_device = removed_device.into_iter().collect::<Vec<_>>();
         snapshot.browser.retain(|flow| {
             !(flow.target == target && browser_flow_ids.contains(flow.state.as_str()))
         });
@@ -515,13 +486,13 @@ impl RuntimeOAuthFlowHandle {
             .browser
             .iter()
             .filter(|flow| pruned_browser.contains(&persisted_browser_snapshot_key(flow)))
-            .map(browser_removal_from_flow)
+            .map(persisted_browser_snapshot_key)
             .collect();
         let device = snapshot
             .device
             .iter()
             .filter(|flow| pruned_device.contains(&persisted_device_snapshot_key(flow)))
-            .map(device_removal_from_flow)
+            .map(persisted_device_snapshot_key)
             .collect();
         (browser, device)
     }
@@ -537,8 +508,8 @@ impl RuntimeOAuthFlowHandle {
     fn persist_registry_payloads_removing(
         &self,
         operation: &'static str,
-        removed_browser: &[PersistedOAuthBrowserFlowRemoval],
-        removed_device: &[PersistedOAuthDeviceFlowRemoval],
+        removed_browser: &[BrowserSnapshotKey],
+        removed_device: &[DeviceSnapshotKey],
     ) -> Result<(), OAuthFlowError> {
         persist_registry_payloads(
             &self.registry,
@@ -552,8 +523,8 @@ impl RuntimeOAuthFlowHandle {
     fn persist_registry_payloads_claiming_removal(
         &self,
         operation: &'static str,
-        removed_browser: &[PersistedOAuthBrowserFlowRemoval],
-        removed_device: &[PersistedOAuthDeviceFlowRemoval],
+        removed_browser: &[BrowserSnapshotKey],
+        removed_device: &[DeviceSnapshotKey],
     ) -> Result<(), OAuthFlowError> {
         persist_registry_payloads_claiming_removal(
             &self.registry,
@@ -567,8 +538,8 @@ impl RuntimeOAuthFlowHandle {
     fn persist_registry_payloads_claiming_admission(
         &self,
         operation: &'static str,
-        removed_browser: &[PersistedOAuthBrowserFlowRemoval],
-        removed_device: &[PersistedOAuthDeviceFlowRemoval],
+        removed_browser: &[BrowserSnapshotKey],
+        removed_device: &[DeviceSnapshotKey],
     ) -> Result<(), OAuthFlowError> {
         persist_registry_payloads_claiming_admission(
             &self.registry,
@@ -648,13 +619,13 @@ impl RuntimeOAuthFlowHandle {
             .browser
             .iter()
             .filter(|flow| !current_browser.contains(&persisted_browser_snapshot_key(flow)))
-            .map(browser_removal_from_flow)
+            .map(persisted_browser_snapshot_key)
             .collect::<Vec<_>>();
         let removed_device = snapshot
             .device
             .iter()
             .filter(|flow| !current_device.contains(&persisted_device_snapshot_key(flow)))
-            .map(device_removal_from_flow)
+            .map(persisted_device_snapshot_key)
             .collect::<Vec<_>>();
         let _ = self.persist_registry_payloads_removing(
             "rehydrate_oauth_flows",
@@ -683,41 +654,24 @@ impl RuntimeOAuthFlowHandle {
             };
         let now_millis = current_time_millis();
         let now_instant = Instant::now();
-        let removed_browser = snapshot
-            .browser_removed
-            .iter()
-            .filter(|removal| removal.expires_at_millis > now_millis)
-            .map(persisted_browser_removal_key)
-            .collect::<BTreeSet<_>>();
-        let removed_device = snapshot
-            .device_removed
-            .iter()
-            .filter(|removal| removal.expires_at_millis > now_millis)
-            .map(persisted_device_removal_key)
-            .collect::<BTreeSet<_>>();
         let durable_browser = snapshot
             .browser
             .iter()
-            .filter(|flow| {
-                flow.expires_at_millis > now_millis
-                    && !removed_browser.contains(&persisted_browser_snapshot_key(flow))
-            })
+            .filter(|flow| flow.expires_at_millis > now_millis)
             .map(persisted_browser_snapshot_key)
             .collect::<BTreeSet<_>>();
         let durable_device = snapshot
             .device
             .iter()
-            .filter(|flow| {
-                flow.expires_at_millis > now_millis
-                    && !removed_device.contains(&persisted_device_snapshot_key(flow))
-            })
+            .filter(|flow| flow.expires_at_millis > now_millis)
             .map(persisted_device_snapshot_key)
             .collect::<BTreeSet<_>>();
         let current = self.registry.snapshot_for_persistence(now_millis);
-        for flow in current.browser.iter().filter(|flow| {
-            !durable_browser.contains(&persisted_browser_snapshot_key(flow))
-                || removed_browser.contains(&persisted_browser_snapshot_key(flow))
-        }) {
+        for flow in current
+            .browser
+            .iter()
+            .filter(|flow| !durable_browser.contains(&persisted_browser_snapshot_key(flow)))
+        {
             if let Some(provider) = OAuthProviderIdentity::from_alias(&flow.provider) {
                 let _ =
                     self.registry
@@ -725,10 +679,11 @@ impl RuntimeOAuthFlowHandle {
             }
             let _ = self.expire_browser(&flow.target, &flow.state);
         }
-        for flow in current.device.iter().filter(|flow| {
-            !durable_device.contains(&persisted_device_snapshot_key(flow))
-                || removed_device.contains(&persisted_device_snapshot_key(flow))
-        }) {
+        for flow in current
+            .device
+            .iter()
+            .filter(|flow| !durable_device.contains(&persisted_device_snapshot_key(flow)))
+        {
             if let Some(provider) = OAuthProviderIdentity::from_alias(&flow.provider) {
                 let _ = self
                     .registry
@@ -754,7 +709,6 @@ impl RuntimeOAuthFlowHandle {
             .iter()
             .filter(|flow| {
                 flow.expires_at_millis > now_millis
-                    && !removed_browser.contains(&persisted_browser_snapshot_key(flow))
                     && !current_browser.contains(&persisted_browser_snapshot_key(flow))
             })
             .cloned()
@@ -766,7 +720,6 @@ impl RuntimeOAuthFlowHandle {
             .iter()
             .filter(|flow| {
                 flow.expires_at_millis > now_millis
-                    && !removed_device.contains(&persisted_device_snapshot_key(flow))
                     && !current_device.contains(&persisted_device_snapshot_key(flow))
             })
             .cloned()
@@ -868,8 +821,8 @@ fn persist_registry_payloads(
     registry: &OAuthFlowRegistry,
     store: &StoreSlot,
     operation: &'static str,
-    removed_browser: &[PersistedOAuthBrowserFlowRemoval],
-    removed_device: &[PersistedOAuthDeviceFlowRemoval],
+    removed_browser: &[BrowserSnapshotKey],
+    removed_device: &[DeviceSnapshotKey],
 ) -> Result<(), OAuthFlowError> {
     let now_millis = current_time_millis();
     let snapshot = registry.snapshot_for_persistence(now_millis);
@@ -888,8 +841,8 @@ fn persist_registry_payloads_claiming_removal(
     registry: &OAuthFlowRegistry,
     store: &StoreSlot,
     operation: &'static str,
-    removed_browser: &[PersistedOAuthBrowserFlowRemoval],
-    removed_device: &[PersistedOAuthDeviceFlowRemoval],
+    removed_browser: &[BrowserSnapshotKey],
+    removed_device: &[DeviceSnapshotKey],
 ) -> Result<(), OAuthFlowError> {
     let now_millis = current_time_millis();
     let snapshot = registry.snapshot_for_persistence(now_millis);
@@ -908,8 +861,8 @@ fn persist_registry_payloads_claiming_admission(
     registry: &OAuthFlowRegistry,
     store: &StoreSlot,
     operation: &'static str,
-    removed_browser: &[PersistedOAuthBrowserFlowRemoval],
-    removed_device: &[PersistedOAuthDeviceFlowRemoval],
+    removed_browser: &[BrowserSnapshotKey],
+    removed_device: &[DeviceSnapshotKey],
 ) -> Result<(), OAuthFlowError> {
     let now_millis = current_time_millis();
     let snapshot = registry.snapshot_for_persistence(now_millis);
@@ -963,8 +916,8 @@ fn persist_registry_snapshot(
     snapshot: &OAuthFlowRegistrySnapshot,
     store: &StoreSlot,
     operation: &'static str,
-    removed_browser: &[PersistedOAuthBrowserFlowRemoval],
-    removed_device: &[PersistedOAuthDeviceFlowRemoval],
+    removed_browser: &[BrowserSnapshotKey],
+    removed_device: &[DeviceSnapshotKey],
     now_millis: u64,
     policy: SnapshotPersistPolicy,
 ) -> Result<(), OAuthFlowError> {
@@ -1045,72 +998,10 @@ fn persisted_device_snapshot_key(flow: &PersistedOAuthDeviceFlow) -> DeviceSnaps
     device_snapshot_key(&flow.target, &flow.device_code)
 }
 
-fn persisted_browser_removal_key(removal: &PersistedOAuthBrowserFlowRemoval) -> BrowserSnapshotKey {
-    browser_snapshot_key(&removal.target, &removal.state)
-}
-
-fn persisted_device_removal_key(removal: &PersistedOAuthDeviceFlowRemoval) -> DeviceSnapshotKey {
-    device_snapshot_key(&removal.target, &removal.device_code)
-}
-
-fn browser_removal_from_flow(flow: &PersistedOAuthBrowserFlow) -> PersistedOAuthBrowserFlowRemoval {
-    PersistedOAuthBrowserFlowRemoval {
-        target: flow.target.clone(),
-        state: flow.state.clone(),
-        expires_at_millis: flow.expires_at_millis,
-    }
-}
-
-fn device_removal_from_flow(flow: &PersistedOAuthDeviceFlow) -> PersistedOAuthDeviceFlowRemoval {
-    PersistedOAuthDeviceFlowRemoval {
-        target: flow.target.clone(),
-        device_code: flow.device_code.clone(),
-        expires_at_millis: flow.expires_at_millis,
-    }
-}
-
-fn merge_browser_removal(
-    removals: &mut BTreeMap<BrowserSnapshotKey, PersistedOAuthBrowserFlowRemoval>,
-    removal: PersistedOAuthBrowserFlowRemoval,
-    now_millis: u64,
-) {
-    if removal.expires_at_millis <= now_millis {
-        return;
-    }
-    let key = persisted_browser_removal_key(&removal);
-    if let Some(existing) = removals.get_mut(&key) {
-        if removal.expires_at_millis > existing.expires_at_millis {
-            *existing = removal;
-        }
-    } else {
-        removals.insert(key, removal);
-    }
-}
-
-fn merge_device_removal(
-    removals: &mut BTreeMap<DeviceSnapshotKey, PersistedOAuthDeviceFlowRemoval>,
-    removal: PersistedOAuthDeviceFlowRemoval,
-    now_millis: u64,
-) {
-    if removal.expires_at_millis <= now_millis {
-        return;
-    }
-    let key = persisted_device_removal_key(&removal);
-    if let Some(existing) = removals.get_mut(&key) {
-        if removal.expires_at_millis > existing.expires_at_millis {
-            *existing = removal;
-        }
-    } else {
-        removals.insert(key, removal);
-    }
-}
-
 fn ensure_removed_flows_are_active(
     current: &OAuthFlowRegistrySnapshot,
-    browser_removed: &BTreeMap<BrowserSnapshotKey, PersistedOAuthBrowserFlowRemoval>,
-    device_removed: &BTreeMap<DeviceSnapshotKey, PersistedOAuthDeviceFlowRemoval>,
-    removed_browser: &[PersistedOAuthBrowserFlowRemoval],
-    removed_device: &[PersistedOAuthDeviceFlowRemoval],
+    removed_browser: &BTreeSet<BrowserSnapshotKey>,
+    removed_device: &BTreeSet<DeviceSnapshotKey>,
     now_millis: u64,
 ) -> Result<(), crate::store::RuntimeStoreError> {
     let active_browser = current
@@ -1119,12 +1010,8 @@ fn ensure_removed_flows_are_active(
         .filter(|flow| flow.expires_at_millis > now_millis)
         .map(persisted_browser_snapshot_key)
         .collect::<BTreeSet<_>>();
-    for removal in removed_browser {
-        let key = persisted_browser_removal_key(removal);
-        if removal.expires_at_millis <= now_millis
-            || browser_removed.contains_key(&key)
-            || !active_browser.contains(&key)
-        {
+    for key in removed_browser {
+        if !active_browser.contains(key) {
             return Err(crate::store::RuntimeStoreError::NotFound(
                 "oauth browser flow was already consumed".to_string(),
             ));
@@ -1137,12 +1024,8 @@ fn ensure_removed_flows_are_active(
         .filter(|flow| flow.expires_at_millis > now_millis)
         .map(persisted_device_snapshot_key)
         .collect::<BTreeSet<_>>();
-    for removal in removed_device {
-        let key = persisted_device_removal_key(removal);
-        if removal.expires_at_millis <= now_millis
-            || device_removed.contains_key(&key)
-            || !active_device.contains(&key)
-        {
+    for key in removed_device {
+        if !active_device.contains(key) {
             return Err(crate::store::RuntimeStoreError::NotFound(
                 "oauth device flow was already consumed".to_string(),
             ));
@@ -1166,8 +1049,8 @@ fn ensure_merged_snapshot_within_capacity(
 fn merge_oauth_registry_snapshot(
     current: Option<&[u8]>,
     local: &OAuthFlowRegistrySnapshot,
-    removed_browser: &[PersistedOAuthBrowserFlowRemoval],
-    removed_device: &[PersistedOAuthDeviceFlowRemoval],
+    removed_browser: &[BrowserSnapshotKey],
+    removed_device: &[DeviceSnapshotKey],
     now_millis: u64,
     removal_mode: SnapshotRemovalMode,
     admission_capacity: Option<usize>,
@@ -1177,32 +1060,11 @@ fn merge_oauth_registry_snapshot(
             .map_err(|err| crate::store::RuntimeStoreError::WriteFailed(err.to_string()))?,
         None => OAuthFlowRegistrySnapshot::default(),
     };
-    let mut browser_removed = BTreeMap::new();
-    for removal in merged.browser_removed.iter().cloned() {
-        merge_browser_removal(&mut browser_removed, removal, now_millis);
-    }
-    let mut device_removed = BTreeMap::new();
-    for removal in merged.device_removed.iter().cloned() {
-        merge_device_removal(&mut device_removed, removal, now_millis);
-    }
+    let removed_browser = removed_browser.iter().cloned().collect::<BTreeSet<_>>();
+    let removed_device = removed_device.iter().cloned().collect::<BTreeSet<_>>();
     if removal_mode == SnapshotRemovalMode::Claim {
-        ensure_removed_flows_are_active(
-            &merged,
-            &browser_removed,
-            &device_removed,
-            removed_browser,
-            removed_device,
-            now_millis,
-        )?;
+        ensure_removed_flows_are_active(&merged, &removed_browser, &removed_device, now_millis)?;
     }
-    for removal in removed_browser.iter().cloned() {
-        merge_browser_removal(&mut browser_removed, removal, now_millis);
-    }
-    for removal in removed_device.iter().cloned() {
-        merge_device_removal(&mut device_removed, removal, now_millis);
-    }
-    let removed_browser = browser_removed.keys().cloned().collect::<BTreeSet<_>>();
-    let removed_device = device_removed.keys().cloned().collect::<BTreeSet<_>>();
     let local_browser = local
         .browser
         .iter()
@@ -1244,16 +1106,8 @@ fn merge_oauth_registry_snapshot(
             })
             .cloned(),
     );
-    merged.browser_removed = browser_removed.into_values().collect();
-    merged.device_removed = device_removed.into_values().collect();
     merged.browser.sort_by_key(persisted_browser_snapshot_key);
     merged.device.sort_by_key(persisted_device_snapshot_key);
-    merged
-        .browser_removed
-        .sort_by_key(persisted_browser_removal_key);
-    merged
-        .device_removed
-        .sort_by_key(persisted_device_removal_key);
     if let Some(max_outstanding) = admission_capacity {
         ensure_merged_snapshot_within_capacity(&merged, max_outstanding)?;
     }
@@ -1422,15 +1276,7 @@ impl OAuthDevicePollLifecycle for RuntimeOAuthDevicePollLifecycle {
         &self,
         record: &OAuthDeviceFlowRecord,
     ) -> Result<(), OAuthFlowError> {
-        let remaining = record
-            .expires_at
-            .checked_duration_since(Instant::now())
-            .ok_or(OAuthFlowError::Missing)?;
-        let removed = [PersistedOAuthDeviceFlowRemoval {
-            target: record.target.clone(),
-            device_code: record.device_code.clone(),
-            expires_at_millis: expires_at_millis(remaining)?,
-        }];
+        let removed = [device_snapshot_key(&record.target, &record.device_code)];
         persist_registry_payloads_claiming_removal(
             &self.registry,
             &self.store,
@@ -1575,11 +1421,7 @@ impl OAuthFlowAuthority for RuntimeOAuthFlowHandle {
             let _ = self.restore_browser_flow(state, &record);
             return Err(err);
         }
-        let removed_browser = [PersistedOAuthBrowserFlowRemoval {
-            target: target.clone(),
-            state: state.to_string(),
-            expires_at_millis: self.browser_record_expires_at_millis(&record)?,
-        }];
+        let removed_browser = [browser_snapshot_key(target, state)];
         if let Err(err) = self.persist_registry_payloads_claiming_removal(
             "consume_oauth_browser_flow",
             &removed_browser,
@@ -2304,7 +2146,7 @@ mod tests {
 
     #[cfg(feature = "sqlite-store")]
     #[test]
-    fn persistent_oauth_browser_tombstone_blocks_stale_authority_resurrection() {
+    fn persistent_oauth_browser_payload_sync_blocks_stale_authority_resurrection() {
         let temp_dir = tempfile::tempdir().expect("tempdir");
         let store_path = temp_dir.path().join("runtime.sqlite");
         let creator_store: Arc<dyn RuntimeStore> =
@@ -2402,7 +2244,7 @@ mod tests {
 
     #[cfg(feature = "sqlite-store")]
     #[test]
-    fn persistent_oauth_device_tombstone_blocks_stale_authority_resurrection() {
+    fn persistent_oauth_device_payload_sync_blocks_stale_authority_resurrection() {
         let temp_dir = tempfile::tempdir().expect("tempdir");
         let store_path = temp_dir.path().join("runtime.sqlite");
         let creator_store: Arc<dyn RuntimeStore> =

--- a/meerkat-runtime/src/handles/oauth_flow.rs
+++ b/meerkat-runtime/src/handles/oauth_flow.rs
@@ -971,9 +971,7 @@ fn persist_registry_snapshot(
             removed_browser,
             removed_device,
             now_millis,
-            policy.removal_mode,
-            policy.admission_capacity,
-            policy.admit_local_payloads,
+            policy,
         )?;
         serde_json::to_vec(&merged)
             .map_err(|err| crate::store::RuntimeStoreError::WriteFailed(err.to_string()))
@@ -1083,9 +1081,7 @@ fn merge_oauth_registry_snapshot(
     removed_browser: &[BrowserSnapshotKey],
     removed_device: &[DeviceSnapshotKey],
     now_millis: u64,
-    removal_mode: SnapshotRemovalMode,
-    admission_capacity: Option<usize>,
-    admit_local_payloads: bool,
+    policy: SnapshotPersistPolicy,
 ) -> Result<OAuthFlowRegistrySnapshot, crate::store::RuntimeStoreError> {
     let mut merged = match current {
         Some(bytes) => serde_json::from_slice::<OAuthFlowRegistrySnapshot>(bytes)
@@ -1094,7 +1090,7 @@ fn merge_oauth_registry_snapshot(
     };
     let removed_browser = removed_browser.iter().cloned().collect::<BTreeSet<_>>();
     let removed_device = removed_device.iter().cloned().collect::<BTreeSet<_>>();
-    if removal_mode == SnapshotRemovalMode::Claim {
+    if policy.removal_mode == SnapshotRemovalMode::Claim {
         ensure_removed_flows_are_active(&merged, &removed_browser, &removed_device, now_millis)?;
     }
     let current_browser = merged
@@ -1138,7 +1134,7 @@ fn merge_oauth_registry_snapshot(
                 let key = persisted_browser_snapshot_key(flow);
                 flow.expires_at_millis > now_millis
                     && !removed_browser.contains(&key)
-                    && (admit_local_payloads || current_browser.contains(&key))
+                    && (policy.admit_local_payloads || current_browser.contains(&key))
             })
             .cloned(),
     );
@@ -1150,13 +1146,13 @@ fn merge_oauth_registry_snapshot(
                 let key = persisted_device_snapshot_key(flow);
                 flow.expires_at_millis > now_millis
                     && !removed_device.contains(&key)
-                    && (admit_local_payloads || current_device.contains(&key))
+                    && (policy.admit_local_payloads || current_device.contains(&key))
             })
             .cloned(),
     );
     merged.browser.sort_by_key(persisted_browser_snapshot_key);
     merged.device.sort_by_key(persisted_device_snapshot_key);
-    if let Some(max_outstanding) = admission_capacity {
+    if let Some(max_outstanding) = policy.admission_capacity {
         ensure_merged_snapshot_within_capacity(&merged, max_outstanding)?;
     }
     Ok(merged)

--- a/meerkat-runtime/src/handles/oauth_flow.rs
+++ b/meerkat-runtime/src/handles/oauth_flow.rs
@@ -837,6 +837,24 @@ fn persist_registry_payloads(
     )
 }
 
+fn persist_existing_registry_payloads(
+    registry: &OAuthFlowRegistry,
+    store: &StoreSlot,
+    operation: &'static str,
+) -> Result<(), OAuthFlowError> {
+    let now_millis = current_time_millis();
+    let snapshot = registry.snapshot_for_persistence(now_millis);
+    persist_registry_snapshot(
+        &snapshot,
+        store,
+        operation,
+        &[],
+        &[],
+        now_millis,
+        SnapshotPersistPolicy::merge_existing(),
+    )
+}
+
 fn persist_registry_payloads_claiming_removal(
     registry: &OAuthFlowRegistry,
     store: &StoreSlot,
@@ -887,6 +905,7 @@ enum SnapshotRemovalMode {
 struct SnapshotPersistPolicy {
     removal_mode: SnapshotRemovalMode,
     admission_capacity: Option<usize>,
+    admit_local_payloads: bool,
 }
 
 impl SnapshotPersistPolicy {
@@ -894,6 +913,15 @@ impl SnapshotPersistPolicy {
         Self {
             removal_mode: SnapshotRemovalMode::Merge,
             admission_capacity: None,
+            admit_local_payloads: true,
+        }
+    }
+
+    fn merge_existing() -> Self {
+        Self {
+            removal_mode: SnapshotRemovalMode::Merge,
+            admission_capacity: None,
+            admit_local_payloads: false,
         }
     }
 
@@ -901,6 +929,7 @@ impl SnapshotPersistPolicy {
         Self {
             removal_mode: SnapshotRemovalMode::Claim,
             admission_capacity: None,
+            admit_local_payloads: true,
         }
     }
 
@@ -908,6 +937,7 @@ impl SnapshotPersistPolicy {
         Self {
             removal_mode: SnapshotRemovalMode::Merge,
             admission_capacity: Some(max_outstanding),
+            admit_local_payloads: true,
         }
     }
 }
@@ -943,6 +973,7 @@ fn persist_registry_snapshot(
             now_millis,
             policy.removal_mode,
             policy.admission_capacity,
+            policy.admit_local_payloads,
         )?;
         serde_json::to_vec(&merged)
             .map_err(|err| crate::store::RuntimeStoreError::WriteFailed(err.to_string()))
@@ -1054,6 +1085,7 @@ fn merge_oauth_registry_snapshot(
     now_millis: u64,
     removal_mode: SnapshotRemovalMode,
     admission_capacity: Option<usize>,
+    admit_local_payloads: bool,
 ) -> Result<OAuthFlowRegistrySnapshot, crate::store::RuntimeStoreError> {
     let mut merged = match current {
         Some(bytes) => serde_json::from_slice::<OAuthFlowRegistrySnapshot>(bytes)
@@ -1065,6 +1097,18 @@ fn merge_oauth_registry_snapshot(
     if removal_mode == SnapshotRemovalMode::Claim {
         ensure_removed_flows_are_active(&merged, &removed_browser, &removed_device, now_millis)?;
     }
+    let current_browser = merged
+        .browser
+        .iter()
+        .filter(|flow| flow.expires_at_millis > now_millis)
+        .map(persisted_browser_snapshot_key)
+        .collect::<BTreeSet<_>>();
+    let current_device = merged
+        .device
+        .iter()
+        .filter(|flow| flow.expires_at_millis > now_millis)
+        .map(persisted_device_snapshot_key)
+        .collect::<BTreeSet<_>>();
     let local_browser = local
         .browser
         .iter()
@@ -1091,8 +1135,10 @@ fn merge_oauth_registry_snapshot(
             .browser
             .iter()
             .filter(|flow| {
+                let key = persisted_browser_snapshot_key(flow);
                 flow.expires_at_millis > now_millis
-                    && !removed_browser.contains(&persisted_browser_snapshot_key(flow))
+                    && !removed_browser.contains(&key)
+                    && (admit_local_payloads || current_browser.contains(&key))
             })
             .cloned(),
     );
@@ -1101,8 +1147,10 @@ fn merge_oauth_registry_snapshot(
             .device
             .iter()
             .filter(|flow| {
+                let key = persisted_device_snapshot_key(flow);
                 flow.expires_at_millis > now_millis
-                    && !removed_device.contains(&persisted_device_snapshot_key(flow))
+                    && !removed_device.contains(&key)
+                    && (admit_local_payloads || current_device.contains(&key))
             })
             .cloned(),
     );
@@ -1263,12 +1311,10 @@ impl OAuthDevicePollLifecycle for RuntimeOAuthDevicePollLifecycle {
     }
 
     fn device_flow_payloads_changed(&self) -> Result<(), OAuthFlowError> {
-        persist_registry_payloads(
+        persist_existing_registry_payloads(
             &self.registry,
             &self.store,
             "persist_oauth_device_flow_payloads",
-            &[],
-            &[],
         )
     }
 
@@ -2335,6 +2381,84 @@ mod tests {
         restarted
             .verify_device_code(stale_device_code, &stale_target, provider)
             .expect("new stale-authority device flow survives restart");
+    }
+
+    #[cfg(feature = "sqlite-store")]
+    #[test]
+    fn persistent_oauth_device_poll_finish_does_not_resurrect_consumed_payload() {
+        let temp_dir = tempfile::tempdir().expect("tempdir");
+        let store_path = temp_dir.path().join("runtime.sqlite");
+        let creator_store: Arc<dyn RuntimeStore> =
+            Arc::new(crate::store::sqlite::SqliteRuntimeStore::new(&store_path).unwrap());
+        let stale_store: Arc<dyn RuntimeStore> =
+            Arc::new(crate::store::sqlite::SqliteRuntimeStore::new(&store_path).unwrap());
+        let consumer_store: Arc<dyn RuntimeStore> =
+            Arc::new(crate::store::sqlite::SqliteRuntimeStore::new(&store_path).unwrap());
+        let creator = RuntimeOAuthFlowHandle::new_with_persistent_store_and_auth_lease(
+            Duration::from_secs(60),
+            Arc::new(RuntimeAuthLeaseHandle::new()),
+            &creator_store,
+        );
+        let target = target();
+        let provider = OAuthProviderIdentity::GoogleCodeAssist;
+        let device_code = "pending-finish-device-code";
+        creator
+            .admit_device_code(
+                target.clone(),
+                provider,
+                device_code.to_string(),
+                Duration::from_secs(60),
+            )
+            .expect("creator admits device flow");
+
+        let stale_authority = RuntimeOAuthFlowHandle::new_with_persistent_store_and_auth_lease(
+            Duration::from_secs(60),
+            Arc::new(RuntimeAuthLeaseHandle::new()),
+            &stale_store,
+        );
+        let stale_poll = stale_authority
+            .begin_device_code_poll(device_code, &target, provider)
+            .expect("stale authority begins pending poll");
+        let consumer = RuntimeOAuthFlowHandle::new_with_persistent_store_and_auth_lease(
+            Duration::from_secs(60),
+            Arc::new(RuntimeAuthLeaseHandle::new()),
+            &consumer_store,
+        );
+        consumer
+            .begin_device_code_poll(device_code, &target, provider)
+            .expect("consumer begins independent poll")
+            .consume()
+            .expect("consumer consumes durable payload");
+
+        stale_poll
+            .finish()
+            .expect("stale pending poll finish is local cleanup only");
+
+        let snapshot_json = stale_store
+            .load_auth_oauth_flow_snapshot()
+            .expect("durable OAuth snapshot loads")
+            .expect("durable OAuth snapshot exists");
+        let snapshot = serde_json::from_slice::<OAuthFlowRegistrySnapshot>(&snapshot_json)
+            .expect("durable OAuth snapshot decodes");
+        assert!(
+            !snapshot
+                .device
+                .iter()
+                .any(|flow| flow.device_code == device_code),
+            "a stale pending poll finish must not resurrect a consumed device flow"
+        );
+
+        let restarted_store: Arc<dyn RuntimeStore> =
+            Arc::new(crate::store::sqlite::SqliteRuntimeStore::new(&store_path).unwrap());
+        let restarted = RuntimeOAuthFlowHandle::new_with_persistent_store_and_auth_lease(
+            Duration::from_secs(60),
+            Arc::new(RuntimeAuthLeaseHandle::new()),
+            &restarted_store,
+        );
+        assert!(matches!(
+            restarted.verify_device_code(device_code, &target, provider),
+            Err(OAuthFlowError::Missing)
+        ));
     }
 
     #[cfg(feature = "sqlite-store")]


### PR DESCRIPTION
## Summary
- remove the durable OAuth removed-flow tombstone projection from the auth-core payload snapshot
- keep `RuntimeOAuthFlowHandle` persistence payload-only while retaining atomic consume/admission claims against the current snapshot
- constrain device poll-finish persistence to existing durable payloads so stale local pending polls cannot re-admit consumed flows
- keep REST/RPC/CLI boundaries unchanged and retain stale-authority validation through payload sync tests

## Review Readiness Packet
Complexity Delta: 2 files changed, 213 insertions / 274 deletions, net -61 non-generated lines. No generated/spec churn.

#521 code paths removed:
- `OAuthFlowRegistrySnapshot.browser_removed` / `device_removed`
- `PersistedOAuthBrowserFlowRemoval` and `PersistedOAuthDeviceFlowRemoval`
- runtime tombstone merge/removal helpers and tombstone filtering in payload sync/release collection
- durable removed-flow marker writes from browser/device consume and release paths

#521 code paths retained:
- canonical OAuth membership transitions through `RuntimeAuthLeaseHandle` / AuthMachine per `LeaseKey`
- auth-core `OAuthFlowRegistry` as active PKCE/device payload storage only
- runtime active payload snapshot merge, atomic consume/admission claim checks, capacity enforcement, release observer pruning, and existing-only poll-finish payload updates
- REST/RPC/CLI endpoint behavior and boundaries

AI review rework:
- added `persistent_oauth_device_poll_finish_does_not_resurrect_consumed_payload`
- changed poll-finish payload persistence to merge only durable-existing payloads rather than allowing local stale payloads to act as admission

CI rework:
- folded merge knobs into `SnapshotPersistPolicy` to satisfy clippy `too_many_arguments` without changing behavior

## Validation
- Baseline before edits: `./scripts/repo-cargo test -p meerkat-runtime oauth_flow -- --nocapture` passed 24 focused runtime OAuth tests
- First pass: `./scripts/repo-cargo fmt --all -- --check`
- First pass: `git diff --check`
- First pass: `./scripts/repo-cargo test -p meerkat-runtime oauth_flow -- --nocapture`
- First pass: `./scripts/repo-cargo test -p meerkat-runtime --features sqlite-store persistent_oauth -- --nocapture`
- First pass: `./scripts/repo-cargo test -p meerkat-auth-core oauth_flow -- --nocapture`
- First pass: `make check` via BuildBuddy invocation `b38f466b-5475-40ea-b9a8-c4d0216485c5`
- Rework: `./scripts/repo-cargo test -p meerkat-runtime --features sqlite-store persistent_oauth_device_poll_finish_does_not_resurrect_consumed_payload -- --nocapture`
- Rework: `./scripts/repo-cargo test -p meerkat-runtime --features sqlite-store persistent_oauth -- --nocapture`
- Rework: `./scripts/repo-cargo test -p meerkat-runtime oauth_flow -- --nocapture`
- Rework: `./scripts/repo-cargo fmt --all -- --check`
- Rework: `git diff --check`
- Rework: `make check` via BuildBuddy invocation `37f351d0-6826-4323-af02-cf52020e7af4`
- CI lint fix: `./scripts/repo-cargo fmt --all -- --check`
- CI lint fix: `git diff --check`
- CI lint fix: `make lint` via BuildBuddy invocation `2fb0d7f6-eddd-47e4-8f17-3bda3ab900ef`
- CI lint fix: `make lint-feature-matrix`
- CI lint fix: `./scripts/repo-cargo test -p meerkat-runtime --features sqlite-store persistent_oauth_device_poll_finish_does_not_resurrect_consumed_payload -- --nocapture`
- CI lint fix: `make check` via BuildBuddy invocation `035c77d6-11e9-4836-bb84-214fc565edc7`

Linear: LUC-299