### PR TITLE
LUC-301: Route surface request terminals through lifecycle owner

### DIFF
--- a/meerkat-mcp-server/src/main.rs
+++ b/meerkat-mcp-server/src/main.rs
@@ -2,8 +2,8 @@
 
 use clap::{Parser, ValueEnum};
 use meerkat::surface::{
-    RequestTerminal, RequestTerminalResolution, StdioJsonWriter, SurfaceRequestExecutor,
-    SurfaceRequestSemantics, noop_request_action, spawn_stdio_json_writer,
+    RequestTerminalResolution, StdioJsonWriter, SurfaceRequestExecutor, SurfaceRequestSemantics,
+    noop_request_action, spawn_stdio_json_writer,
 };
 use meerkat_contracts::{ErrorCode, mcp_tool_request_lifecycle};
 use meerkat_core::{RealmConfig, RealmSelection, RuntimeBootstrap};
@@ -63,7 +63,8 @@ impl From<RealmBackendArg> for RealmBackend {
 
 struct ToolCompletion {
     request_key: String,
-    terminal: RequestTerminal<Value>,
+    success: bool,
+    response: Value,
 }
 
 #[tokio::main]
@@ -196,9 +197,12 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                             .cloned()
                             .unwrap_or_else(|| json!({}));
 
-                        let context = request_executor.begin_request(
+                        let semantics =
+                            SurfaceRequestSemantics::from(mcp_tool_request_lifecycle(&name));
+                        let context = request_executor.begin_request_with_semantics(
                             request_key.clone(),
                             noop_request_action(),
+                            semantics,
                         );
 
                         let notifier_writer = writer.clone();
@@ -231,12 +235,10 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                         let state = Arc::clone(&state);
                         let completion_tx = completion_tx.clone();
                         let tool_name = name.clone();
-                        let semantics =
-                            SurfaceRequestSemantics::from(mcp_tool_request_lifecycle(&tool_name));
                         let request_id_for_task = request_id.clone();
                         let request_key_for_task = request_key.clone();
                         let handle = tokio::spawn(async move {
-                            let terminal = match meerkat_mcp_server::handle_tools_call_with_notifier(
+                            let (success, response) = match meerkat_mcp_server::handle_tools_call_with_notifier(
                                 &state,
                                 &tool_name,
                                 &arguments,
@@ -249,7 +251,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                                         "id": request_id_for_task,
                                         "result": result
                                     });
-                                    semantics.classify_terminal(true, response)
+                                    (true, response)
                                 }
                                 Err(err) => {
                                     let mut error = json!({
@@ -259,7 +261,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                                     if let Some(data) = err.data {
                                         error["data"] = data;
                                     }
-                                    RequestTerminal::RespondWithoutPublish(json!({
+                                    (false, json!({
                                         "jsonrpc": "2.0",
                                         "id": request_id_for_task,
                                         "error": error
@@ -267,7 +269,11 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                                 }
                             };
                             let _ = completion_tx
-                                .send(ToolCompletion { request_key: request_key_for_task, terminal })
+                                .send(ToolCompletion {
+                                    request_key: request_key_for_task,
+                                    success,
+                                    response,
+                                })
                                 .await;
                         });
                         request_executor.attach_task(&request_key, handle);
@@ -321,9 +327,13 @@ async fn write_tool_completion(
     request_executor: &SurfaceRequestExecutor,
     completion: ToolCompletion,
 ) -> bool {
-    let cancel_id = completion.terminal.payload().get("id").cloned();
+    let cancel_id = completion.response.get("id").cloned();
     let to_write = match request_executor
-        .resolve_terminal(Some(&completion.request_key), completion.terminal)
+        .resolve_admitted_terminal(
+            Some(&completion.request_key),
+            completion.success,
+            completion.response,
+        )
         .await
     {
         RequestTerminalResolution::Emit(response) => response,
@@ -370,23 +380,46 @@ fn request_lifecycle_error_response(
 mod tests {
     use super::*;
 
-    #[test]
-    fn meerkat_run_and_resume_publish_on_success() {
-        assert!(matches!(
-            SurfaceRequestSemantics::from(mcp_tool_request_lifecycle("meerkat_run"))
-                .classify_terminal(true, ()),
-            RequestTerminal::Publish(())
-        ));
-        assert!(matches!(
-            SurfaceRequestSemantics::from(mcp_tool_request_lifecycle("meerkat_resume"))
-                .classify_terminal(true, ()),
-            RequestTerminal::Publish(())
-        ));
-        assert!(matches!(
-            SurfaceRequestSemantics::from(mcp_tool_request_lifecycle("meerkat_sessions"))
-                .classify_terminal(true, ()),
-            RequestTerminal::RespondWithoutPublish(())
-        ));
+    #[tokio::test]
+    async fn meerkat_run_and_resume_publish_on_success() {
+        use std::sync::atomic::{AtomicUsize, Ordering};
+
+        for (tool_name, expected_cleanup_count) in [
+            ("meerkat_run", 0),
+            ("meerkat_resume", 0),
+            ("meerkat_sessions", 1),
+        ] {
+            let executor = SurfaceRequestExecutor::new(tokio::time::Duration::from_millis(1));
+            let cleanup_count = Arc::new(AtomicUsize::new(0));
+            let request_key = format!("{tool_name}-request");
+            let context = executor.begin_request_with_semantics(
+                request_key.clone(),
+                noop_request_action(),
+                SurfaceRequestSemantics::from(mcp_tool_request_lifecycle(tool_name)),
+            );
+            context.set_unpublished_cleanup(meerkat::surface::request_action({
+                let cleanup_count = Arc::clone(&cleanup_count);
+                move || {
+                    let cleanup_count = Arc::clone(&cleanup_count);
+                    async move {
+                        cleanup_count.fetch_add(1, Ordering::SeqCst);
+                    }
+                }
+            }));
+
+            assert!(matches!(
+                executor
+                    .resolve_admitted_terminal(Some(context.key()), true, ())
+                    .await,
+                RequestTerminalResolution::Emit(())
+            ));
+            assert_eq!(
+                cleanup_count.load(Ordering::SeqCst),
+                expected_cleanup_count,
+                "{tool_name} should let the executor choose publish vs observation"
+            );
+            assert_eq!(executor.phase(&request_key), None);
+        }
     }
 
     #[tokio::test]
@@ -398,7 +431,11 @@ mod tests {
         let request_executor = SurfaceRequestExecutor::new(tokio::time::Duration::from_millis(1));
         let request_id = json!(42);
         let request_key = request_key(&request_id);
-        let _ctx = request_executor.begin_request(request_key.clone(), noop_request_action());
+        let _ctx = request_executor.begin_request_with_semantics(
+            request_key.clone(),
+            noop_request_action(),
+            SurfaceRequestSemantics::long_running_publish_on_success(),
+        );
 
         assert_eq!(
             request_executor.cancel_request(&request_key).await,
@@ -411,11 +448,12 @@ mod tests {
                 &request_executor,
                 ToolCompletion {
                     request_key: request_key.clone(),
-                    terminal: RequestTerminal::Publish(json!({
+                    success: true,
+                    response: json!({
                         "jsonrpc": "2.0",
                         "id": request_id,
                         "result": {"ok": true}
-                    })),
+                    }),
                 },
             )
             .await

--- a/meerkat-rpc/src/server.rs
+++ b/meerkat-rpc/src/server.rs
@@ -9,8 +9,7 @@ use std::sync::Arc;
 use std::sync::atomic::AtomicU64;
 
 use meerkat::surface::{
-    RequestTerminal, RequestTerminalResolution, SurfaceRequestExecutor, SurfaceRequestSemantics,
-    noop_request_action,
+    RequestTerminalResolution, SurfaceRequestExecutor, SurfaceRequestSemantics, noop_request_action,
 };
 use meerkat_contracts::rpc_request_lifecycle;
 use tokio::io::{AsyncBufRead, BufReader};
@@ -27,7 +26,8 @@ use crate::transport::{BlockingWriter, JsonlTransport, TransportError, Transport
 
 struct LongRunningResponse {
     request_key: String,
-    terminal: RequestTerminal<RpcResponse>,
+    success: bool,
+    response: RpcResponse,
 }
 
 /// Errors from the RPC server.
@@ -340,9 +340,11 @@ impl<R: AsyncBufRead + Unpin, W: TransportWriter> RpcServer<R, W> {
         }
         let id = request.id.clone()?;
         let request_key = request_key(&id);
-        let context = self
-            .request_executor
-            .begin_request(request_key.clone(), noop_request_action());
+        let context = self.request_executor.begin_request_with_semantics(
+            request_key.clone(),
+            noop_request_action(),
+            semantics,
+        );
         let router = self.router.clone();
         let long_running_tx = self.long_running_tx.clone();
         let request = request.clone();
@@ -351,11 +353,12 @@ impl<R: AsyncBufRead + Unpin, W: TransportWriter> RpcServer<R, W> {
             if let Some(response) =
                 Box::pin(router.dispatch_with_request_context(request, Some(context))).await
             {
-                let terminal = classify_long_running_response(&response, semantics);
+                let success = response.error.is_none();
                 let _ = long_running_tx
                     .send(LongRunningResponse {
                         request_key: request_key_for_task,
-                        terminal,
+                        success,
+                        response,
                     })
                     .await;
             }
@@ -364,10 +367,14 @@ impl<R: AsyncBufRead + Unpin, W: TransportWriter> RpcServer<R, W> {
     }
 
     async fn write_long_running_response(&mut self, response: LongRunningResponse) -> bool {
-        let cancel_id = response.terminal.payload().id.clone();
+        let cancel_id = response.response.id.clone();
         let to_write = match self
             .request_executor
-            .resolve_terminal(Some(&response.request_key), response.terminal)
+            .resolve_admitted_terminal(
+                Some(&response.request_key),
+                response.success,
+                response.response,
+            )
             .await
         {
             RequestTerminalResolution::Emit(rpc_response) => rpc_response,
@@ -429,13 +436,6 @@ impl<R: AsyncBufRead + Unpin, W: TransportWriter> RpcServer<R, W> {
             ),
         }
     }
-}
-
-fn classify_long_running_response(
-    response: &RpcResponse,
-    semantics: SurfaceRequestSemantics,
-) -> RequestTerminal<RpcResponse> {
-    semantics.classify_terminal(response.error.is_none(), response.clone())
 }
 
 fn request_key(id: &RpcId) -> String {
@@ -639,8 +639,8 @@ mod tests {
         assert!(request_semantics(&request).requires_long_running_executor());
     }
 
-    #[test]
-    fn turn_start_is_publish_on_success() {
+    #[tokio::test]
+    async fn turn_start_is_publish_on_success() {
         let request = RpcRequest {
             jsonrpc: "2.0".to_string(),
             id: Some(RpcId::Num(1)),
@@ -653,11 +653,26 @@ mod tests {
 
         let semantics = request_semantics(&request);
         assert!(semantics.requires_long_running_executor());
+        let executor = SurfaceRequestExecutor::new(tokio::time::Duration::from_millis(1));
+        let request_key = request_key(request.id.as_ref().expect("request id"));
+        let context = executor.begin_request_with_semantics(
+            request_key.clone(),
+            noop_request_action(),
+            semantics,
+        );
         let response = RpcResponse::success(request.id, serde_json::json!({"ok": true}));
+
         assert!(matches!(
-            classify_long_running_response(&response, semantics),
-            RequestTerminal::Publish(_)
+            executor
+                .resolve_admitted_terminal(Some(context.key()), response.error.is_none(), response)
+                .await,
+            RequestTerminalResolution::Emit(_)
         ));
+        assert_eq!(executor.phase(&request_key), None);
+        assert_eq!(
+            executor.cancel_request(&request_key).await,
+            meerkat::surface::CancelOutcome::NotFound
+        );
     }
 
     #[derive(Clone)]
@@ -685,9 +700,11 @@ mod tests {
         let mut server = RpcServer::new(reader, writer, runtime, config_store);
         let request_id = RpcId::Num(42);
         let request_key = request_key(&request_id);
-        let _ctx = server
-            .request_executor
-            .begin_request(request_key.clone(), noop_request_action());
+        let _ctx = server.request_executor.begin_request_with_semantics(
+            request_key.clone(),
+            noop_request_action(),
+            SurfaceRequestSemantics::long_running_publish_on_success(),
+        );
 
         assert_eq!(
             server.request_executor.cancel_request(&request_key).await,
@@ -700,7 +717,8 @@ mod tests {
             server
                 .write_long_running_response(LongRunningResponse {
                     request_key: request_key.clone(),
-                    terminal: RequestTerminal::Publish(publish_response),
+                    success: publish_response.error.is_none(),
+                    response: publish_response,
                 })
                 .await
         );

--- a/meerkat/src/surface/request_execution.rs
+++ b/meerkat/src/surface/request_execution.rs
@@ -59,14 +59,6 @@ pub enum RequestTerminal<T> {
 }
 
 impl<T> RequestTerminal<T> {
-    /// Borrow the terminal payload without exposing whether it was classified as
-    /// committed or observational.
-    pub fn payload(&self) -> &T {
-        match self {
-            Self::Publish(payload) | Self::RespondWithoutPublish(payload) => payload,
-        }
-    }
-
     fn into_payload(self) -> T {
         match self {
             Self::Publish(payload) | Self::RespondWithoutPublish(payload) => payload,
@@ -135,19 +127,6 @@ impl SurfaceRequestSemantics {
 
     pub const fn requires_long_running_executor(self) -> bool {
         matches!(self.execution, SurfaceRequestExecution::LongRunning)
-    }
-
-    pub fn classify_terminal<T>(self, success: bool, response: T) -> RequestTerminal<T> {
-        if success
-            && matches!(
-                self.terminal_policy,
-                SurfaceRequestTerminalPolicy::PublishOnSuccess
-            )
-        {
-            RequestTerminal::Publish(response)
-        } else {
-            RequestTerminal::RespondWithoutPublish(response)
-        }
     }
 }
 
@@ -268,15 +247,20 @@ pub enum PublishOutcome {
 
 struct RequestEntry {
     phase: Mutex<SurfaceRequestPhase>,
+    terminal_policy: SurfaceRequestTerminalPolicy,
     cancel_action: Mutex<RequestAsyncAction>,
     unpublished_cleanup: Mutex<Option<RequestAsyncAction>>,
     task_handle: Mutex<Option<JoinHandle<()>>>,
 }
 
 impl RequestEntry {
-    fn new(initial_cancel: RequestAsyncAction) -> Self {
+    fn new(
+        initial_cancel: RequestAsyncAction,
+        terminal_policy: SurfaceRequestTerminalPolicy,
+    ) -> Self {
         Self {
             phase: Mutex::new(SurfaceRequestPhase::Pending),
+            terminal_policy,
             cancel_action: Mutex::new(initial_cancel),
             unpublished_cleanup: Mutex::new(None),
             task_handle: Mutex::new(None),
@@ -374,8 +358,21 @@ impl SurfaceRequestLifecycleMachine {
         key: impl Into<String>,
         initial_cancel: RequestAsyncAction,
     ) -> RequestContext {
+        self.begin_request_with_semantics(
+            key,
+            initial_cancel,
+            SurfaceRequestSemantics::long_running_observation(),
+        )
+    }
+
+    fn begin_request_with_semantics(
+        &self,
+        key: impl Into<String>,
+        initial_cancel: RequestAsyncAction,
+        semantics: SurfaceRequestSemantics,
+    ) -> RequestContext {
         let key = key.into();
-        let entry = Arc::new(RequestEntry::new(initial_cancel));
+        let entry = Arc::new(RequestEntry::new(initial_cancel, semantics.terminal_policy));
         let mut entries = lock_or_recover(&self.entries);
         entries.insert(key.clone(), Arc::clone(&entry));
         RequestContext { key, entry }
@@ -386,14 +383,50 @@ impl SurfaceRequestLifecycleMachine {
         key: impl Into<String>,
         initial_cancel: RequestAsyncAction,
     ) -> Result<RequestContext, RequestAlreadyExists> {
+        self.try_begin_request_with_semantics(
+            key,
+            initial_cancel,
+            SurfaceRequestSemantics::long_running_observation(),
+        )
+    }
+
+    fn try_begin_request_with_semantics(
+        &self,
+        key: impl Into<String>,
+        initial_cancel: RequestAsyncAction,
+        semantics: SurfaceRequestSemantics,
+    ) -> Result<RequestContext, RequestAlreadyExists> {
         let key = key.into();
         let mut entries = lock_or_recover(&self.entries);
         if entries.contains_key(&key) {
             return Err(RequestAlreadyExists);
         }
-        let entry = Arc::new(RequestEntry::new(initial_cancel));
+        let entry = Arc::new(RequestEntry::new(initial_cancel, semantics.terminal_policy));
         entries.insert(key.clone(), Arc::clone(&entry));
         Ok(RequestContext { key, entry })
+    }
+
+    fn classify_terminal<T>(
+        &self,
+        key: &str,
+        success: bool,
+        response: T,
+    ) -> Result<RequestTerminal<T>, RequestTransitionError> {
+        let terminal_policy = lock_or_recover(&self.entries)
+            .get(key)
+            .map(|entry| entry.terminal_policy)
+            .ok_or(RequestTransitionError::NotFound)?;
+
+        if success
+            && matches!(
+                terminal_policy,
+                SurfaceRequestTerminalPolicy::PublishOnSuccess
+            )
+        {
+            Ok(RequestTerminal::Publish(response))
+        } else {
+            Ok(RequestTerminal::RespondWithoutPublish(response))
+        }
     }
 
     fn attach_task(&self, key: &str, handle: JoinHandle<()>) {
@@ -537,6 +570,20 @@ impl SurfaceRequestExecutor {
         self.lifecycle.begin_request(key, initial_cancel)
     }
 
+    /// Register a request together with its terminal publication semantics.
+    ///
+    /// This is the admission path for surfaces whose terminal response should
+    /// be classified by the lifecycle owner instead of by the transport task.
+    pub fn begin_request_with_semantics(
+        &self,
+        key: impl Into<String>,
+        initial_cancel: RequestAsyncAction,
+        semantics: SurfaceRequestSemantics,
+    ) -> RequestContext {
+        self.lifecycle
+            .begin_request_with_semantics(key, initial_cancel, semantics)
+    }
+
     /// Fallible variant of `begin_request` that rejects duplicate in-flight keys.
     ///
     /// Returns `Err(RequestAlreadyExists)` if a request with the same key is
@@ -548,6 +595,17 @@ impl SurfaceRequestExecutor {
         initial_cancel: RequestAsyncAction,
     ) -> Result<RequestContext, RequestAlreadyExists> {
         self.lifecycle.try_begin_request(key, initial_cancel)
+    }
+
+    /// Fallible admission variant that stores terminal publication semantics.
+    pub fn try_begin_request_with_semantics(
+        &self,
+        key: impl Into<String>,
+        initial_cancel: RequestAsyncAction,
+        semantics: SurfaceRequestSemantics,
+    ) -> Result<RequestContext, RequestAlreadyExists> {
+        self.lifecycle
+            .try_begin_request_with_semantics(key, initial_cancel, semantics)
     }
 
     /// Attach the task handle for later forced abort during shutdown.
@@ -642,6 +700,27 @@ impl SurfaceRequestExecutor {
                 }
             }
         }
+    }
+
+    /// Resolve a raw surface completion through the admitted request semantics.
+    ///
+    /// The committed-publish vs cancellable-observation split is read from the
+    /// lifecycle entry created at admission, then resolved through the same
+    /// publish/cancel/complete transitions as [`Self::resolve_terminal`].
+    pub async fn resolve_admitted_terminal<T>(
+        &self,
+        key: Option<&str>,
+        success: bool,
+        response: T,
+    ) -> RequestTerminalResolution<T> {
+        let Some(key) = key else {
+            return RequestTerminalResolution::Emit(response);
+        };
+        let terminal = match self.lifecycle.classify_terminal(key, success, response) {
+            Ok(terminal) => terminal,
+            Err(err) => return RequestTerminalResolution::LifecycleError(err),
+        };
+        self.resolve_terminal(Some(key), terminal).await
     }
 
     /// Cancel every tracked request. Honours the same typed transitions as
@@ -743,23 +822,76 @@ mod tests {
         );
     }
 
-    #[test]
-    fn terminal_policy_publishes_only_successful_commits() {
-        assert!(matches!(
-            SurfaceRequestSemantics::long_running_publish_on_success()
-                .classify_terminal(true, "committed"),
-            RequestTerminal::Publish("committed")
-        ));
-        assert!(matches!(
-            SurfaceRequestSemantics::long_running_publish_on_success()
-                .classify_terminal(false, "failed"),
-            RequestTerminal::RespondWithoutPublish("failed")
-        ));
-        assert!(matches!(
-            SurfaceRequestSemantics::long_running_observation()
-                .classify_terminal(true, "observation"),
-            RequestTerminal::RespondWithoutPublish("observation")
-        ));
+    #[tokio::test]
+    async fn terminal_policy_publishes_only_successful_commits() {
+        let executor = SurfaceRequestExecutor::new(Duration::from_millis(1));
+        let cleanup_count = Arc::new(AtomicUsize::new(0));
+
+        let publish_context = executor.begin_request_with_semantics(
+            "publish-success",
+            noop_request_action(),
+            SurfaceRequestSemantics::long_running_publish_on_success(),
+        );
+        publish_context.set_unpublished_cleanup(request_action({
+            let cleanup_count = Arc::clone(&cleanup_count);
+            move || {
+                let cleanup_count = Arc::clone(&cleanup_count);
+                async move {
+                    cleanup_count.fetch_add(1, Ordering::SeqCst);
+                }
+            }
+        }));
+        assert_eq!(
+            executor
+                .resolve_admitted_terminal(Some(publish_context.key()), true, "committed")
+                .await,
+            RequestTerminalResolution::Emit("committed")
+        );
+        assert_eq!(cleanup_count.load(Ordering::SeqCst), 0);
+
+        let failed_context = executor.begin_request_with_semantics(
+            "publish-failed",
+            noop_request_action(),
+            SurfaceRequestSemantics::long_running_publish_on_success(),
+        );
+        failed_context.set_unpublished_cleanup(request_action({
+            let cleanup_count = Arc::clone(&cleanup_count);
+            move || {
+                let cleanup_count = Arc::clone(&cleanup_count);
+                async move {
+                    cleanup_count.fetch_add(1, Ordering::SeqCst);
+                }
+            }
+        }));
+        assert_eq!(
+            executor
+                .resolve_admitted_terminal(Some(failed_context.key()), false, "failed")
+                .await,
+            RequestTerminalResolution::Emit("failed")
+        );
+        assert_eq!(cleanup_count.load(Ordering::SeqCst), 1);
+
+        let observation_context = executor.begin_request_with_semantics(
+            "observation-success",
+            noop_request_action(),
+            SurfaceRequestSemantics::long_running_observation(),
+        );
+        observation_context.set_unpublished_cleanup(request_action({
+            let cleanup_count = Arc::clone(&cleanup_count);
+            move || {
+                let cleanup_count = Arc::clone(&cleanup_count);
+                async move {
+                    cleanup_count.fetch_add(1, Ordering::SeqCst);
+                }
+            }
+        }));
+        assert_eq!(
+            executor
+                .resolve_admitted_terminal(Some(observation_context.key()), true, "observation")
+                .await,
+            RequestTerminalResolution::Emit("observation")
+        );
+        assert_eq!(cleanup_count.load(Ordering::SeqCst), 2);
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary
- Remove the public surface-side terminal classifier `SurfaceRequestSemantics::classify_terminal`.
- Store terminal publication policy on the tracked request lifecycle entry at admission.
- Route RPC/MCP long-running completions as raw `(success, response)` outcomes through `SurfaceRequestExecutor::resolve_admitted_terminal`, so publish-vs-observation classification and cancel/cleanup resolution happen inside the existing `SurfaceRequestLifecycleMachine`.

## Review Readiness Packet

### Complexity Delta
- Files changed: 3.
- Diff size: +286 / -98, no generated/formal/spec artifacts.
- Scope is limited to shared surface request execution plus the RPC and MCP long-running adapters.
- Authority complexity decreases on this path: RPC/MCP no longer construct `RequestTerminal::Publish` vs `RespondWithoutPublish`; that decision is read from the admitted lifecycle entry and resolved by the existing lifecycle owner.

### Prior LUC-289 Blocker Mapping
- Broad generated/spec churn: avoided; no TLA/spec/codegen files touched.
- All-surface rewrite: avoided; the concrete path is RPC/MCP long-running admission and terminal completion.
- Side authority/per-surface lifecycle map: avoided; terminal policy is stored on the existing tracked request entry owned by `SurfaceRequestLifecycleMachine`.
- Cleanup/terminal race risk: terminal classification now feeds the same existing publish/cancel/finish transitions, and focused cancel-before-publish tests cover RPC and MCP.

## Validation
- `./scripts/repo-cargo fmt --all`
- `git diff --check`
- `./scripts/repo-cargo test -p meerkat --lib request_execution`
- `./scripts/repo-cargo test -p meerkat-rpc --lib turn_start_is_publish_on_success`
- `./scripts/repo-cargo test -p meerkat-rpc --lib publish_completion_after_cancel_writes_cancel_response`
- `./scripts/repo-cargo test -p meerkat-mcp-server --bin rkat-mcp meerkat_run_and_resume_publish_on_success`
- `./scripts/repo-cargo test -p meerkat-mcp-server --bin rkat-mcp publish_completion_after_cancel_writes_cancel_response`
- `MEERKAT_BUILDBUDDY=1 make check` (BuildBuddy invocation: https://app.buildbuddy.io/invocation/867d951c-222a-4dfb-be2d-30ffe95442d8)

Linear: LUC-301
