### PR TITLE
Add dogma cleanup review gate

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,70 @@
+## Summary
+
+Dogma cleanup PR: no
+
+
+## Validation
+
+
+## Review Readiness Packet
+
+Current head SHA:
+
+Command output:
+
+```text
+
+```
+
+## Complexity Delta
+
+- Docs/scripts/tests:
+- Non-test implementation:
+- Generated/schema churn:
+
+## Old Path Amputation Proof
+
+Required for dogma cleanup PRs. Run:
+
+```bash
+make dogma-cleanup-gate DOGMA_PACKET=<packet>
+```
+
+The required `Dogma cleanup review gate` CI check runs this gate against the PR
+body when the PR title, labels, body marker, or stable changed-file/diff signal
+indicates dogma cleanup work, including dogma-shaped ordinary source changes and
+structural source deletions in known campaign surfaces, and gate-owning file
+changes that could disable this check. In GitHub CI the checker is invoked
+directly from the base branch gate source when available, so PR-head Makefile
+rewrites cannot skip the gate before the detector runs.
+
+| Old path | Classification | Search literal | Mechanical proof | Follow-up |
+| --- | --- | --- | --- | --- |
+|  | `deleted` or `made uncallable at boundary` |  |  | none |
+
+## Sample Passing Old Path Amputation Proof
+
+| Old path | Classification | Search literal | Mechanical proof | Follow-up |
+| --- | --- | --- | --- | --- |
+| `old/session-route` | deleted | `old/session-route` | No production references remain. | none |
+
+## Sample Failing Old Path Amputation Proof
+
+| Old path | Classification | Search literal | Mechanical proof | Follow-up |
+| --- | --- | --- | --- | --- |
+| `old/session-route` | wrapped | `old/session-route` | A preferred path exists beside the old route. | none |
+| `surface_request_lifecycle_helper` | made uncallable at boundary | `surface_request_lifecycle_helper` | Boundary test exercises the replacement wrapper while the old helper remains callable for compatibility. | none |
+| `wasm_contract_string_mirror` | retained with linked follow-up | `wasm_contract_string_mirror` | Retained for an active SDK cutover. | LUC-999 |
+
+## Reviewer Dogma Gate
+
+For dogma cleanup PRs, answer before normal bug review: What exact old path
+became impossible after this PR?
+
+Move to Rework unless the PR deletes the old path or makes it uncallable at the
+boundary. If a dogma cleanup PR reaches review without this gate running, move
+it to Rework; the gate is expected to run from explicit PR signal, stable
+dogma-shaped diff signal, and gate-owning file changes. Gate-owning files cannot
+skip the gate. Wrapper/adapter/mirror proof text, retained rows, or proof that
+says the old path remains supported/exported/available/routed/working/callable
+for compatibility, or usable by old callers during migration, is Rework.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,6 +8,14 @@ on:
       - feat/**
       - feature/**
   pull_request:
+    types:
+      - opened
+      - synchronize
+      - reopened
+      - edited
+      - labeled
+      - unlabeled
+      - ready_for_review
   workflow_dispatch:
 
 permissions:
@@ -35,10 +43,67 @@ jobs:
       machine_authority_head_sha: ${{ github.sha }}
     secrets: inherit
 
+  dogma-cleanup-gate:
+    name: Dogma cleanup review gate
+    runs-on: ubuntu-latest
+    env:
+      DOGMA_CLEANUP_BASE: ${{ github.event_name == 'pull_request' && github.event.pull_request.base.sha || 'origin/main' }}
+    steps:
+      - name: Checkout pull request
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+          path: pr
+
+      - name: Checkout immutable gate source
+        if: ${{ github.event_name == 'pull_request' }}
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ github.event.pull_request.base.sha }}
+          fetch-depth: 1
+          path: dogma-gate-source
+
+      - name: Enforce dogma cleanup review packet
+        shell: bash
+        run: |
+          pr_repo="$GITHUB_WORKSPACE/pr"
+          gate_script="$GITHUB_WORKSPACE/dogma-gate-source/scripts/dogma_cleanup_gate.py"
+          if [[ ! -f "$gate_script" ]]; then
+            gate_script="$pr_repo/scripts/dogma_cleanup_gate.py"
+            echo "Base dogma cleanup gate is not available; using PR checkout for bootstrap."
+          fi
+          python3 "$gate_script" --repo "$pr_repo" --base "$DOGMA_CLEANUP_BASE" --github-event "$GITHUB_EVENT_PATH"
+
+      - name: Validate PR-head dogma gate fixtures
+        shell: bash
+        run: |
+          pr_repo="$GITHUB_WORKSPACE/pr"
+          pr_gate_script="$pr_repo/scripts/dogma_cleanup_gate.py"
+          pr_fixture_dir="$pr_repo/scripts/fixtures/dogma_cleanup_gate"
+          pr_test_script="$pr_repo/scripts/tests/dogma_cleanup_gate_test.py"
+          base_test_script="$GITHUB_WORKSPACE/dogma-gate-source/scripts/tests/dogma_cleanup_gate_test.py"
+          if [[ ! -f "$pr_test_script" ]]; then
+            echo "::error::PR-head dogma gate fixture suite is missing: scripts/tests/dogma_cleanup_gate_test.py"
+            exit 1
+          fi
+          if [[ ! -f "$pr_gate_script" ]]; then
+            echo "::error::PR-head dogma gate script is missing: scripts/dogma_cleanup_gate.py"
+            exit 1
+          fi
+          if [[ -f "$base_test_script" ]]; then
+            DOGMA_GATE_REPO_ROOT="$pr_repo" \
+            DOGMA_GATE_SCRIPT="$pr_gate_script" \
+            DOGMA_GATE_FIXTURE_DIR="$pr_fixture_dir" \
+              python3 "$base_test_script" -v
+          else
+            echo "Base dogma cleanup fixture oracle is not available; using PR checkout for bootstrap."
+            python3 "$pr_test_script" -v
+          fi
+
   gate:
     name: CI gate
     if: always()
-    needs: [cargo, buildbuddy]
+    needs: [cargo, buildbuddy, dogma-cleanup-gate]
     runs-on: ubuntu-latest
     steps:
       - name: Check selected backend
@@ -46,6 +111,12 @@ jobs:
           bb_enabled="${{ (vars.MEERKAT_BUILDBUDDY == 'true' || vars.MEERKAT_BUILDBUDDY == '1') && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) }}"
           cargo_result="${{ needs.cargo.result }}"
           buildbuddy_result="${{ needs.buildbuddy.result }}"
+          dogma_result="${{ needs.dogma-cleanup-gate.result }}"
+
+          echo "Dogma cleanup gate: $dogma_result"
+          if [[ "$dogma_result" != "success" ]]; then
+            exit 1
+          fi
 
           if [[ "$bb_enabled" == "true" ]]; then
             echo "BuildBuddy selected: $buildbuddy_result"

--- a/.github/workflows/dogma-cleanup-immutable-gate.yml
+++ b/.github/workflows/dogma-cleanup-immutable-gate.yml
@@ -1,0 +1,63 @@
+name: Dogma cleanup immutable gate
+run-name: Dogma cleanup immutable review gate
+
+on:
+  pull_request_target:
+    types:
+      - opened
+      - synchronize
+      - reopened
+      - edited
+      - labeled
+      - unlabeled
+      - ready_for_review
+
+permissions:
+  contents: read
+  pull-requests: read
+
+jobs:
+  dogma-cleanup-immutable-gate:
+    name: CI gate
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout pull request content
+        uses: actions/checkout@v6
+        with:
+          repository: ${{ github.event.pull_request.head.repo.full_name || github.repository }}
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
+          fetch-depth: 0
+          persist-credentials: false
+          path: pr
+
+      - name: Checkout immutable gate source
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ github.event.pull_request.base.sha || github.sha }}
+          fetch-depth: 1
+          persist-credentials: false
+          path: dogma-gate-source
+
+      - name: Fetch base commit for diff
+        if: ${{ github.event_name == 'pull_request_target' }}
+        shell: bash
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          BASE_REPOSITORY: ${{ github.repository }}
+        run: |
+          pr_repo="$GITHUB_WORKSPACE/pr"
+          git -C "$pr_repo" remote add dogma-base "https://github.com/$BASE_REPOSITORY.git"
+          git -C "$pr_repo" fetch --no-tags dogma-base "$BASE_SHA:refs/remotes/dogma-base/dogma-cleanup-base"
+
+      - name: Enforce immutable dogma cleanup review packet
+        shell: bash
+        env:
+          DOGMA_CLEANUP_BASE: refs/remotes/dogma-base/dogma-cleanup-base
+        run: |
+          pr_repo="$GITHUB_WORKSPACE/pr"
+          gate_script="$GITHUB_WORKSPACE/dogma-gate-source/scripts/dogma_cleanup_gate.py"
+          if [[ ! -f "$gate_script" ]]; then
+            echo "::error::Base dogma cleanup gate is missing: scripts/dogma_cleanup_gate.py"
+            exit 1
+          fi
+          python3 "$gate_script" --repo "$pr_repo" --base "$DOGMA_CLEANUP_BASE" --github-event "$GITHUB_EVENT_PATH"

--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ YELLOW := \033[0;33m
 RED := \033[0;31m
 NC := \033[0m
 
-.PHONY: all install-build-deps build test test-unit test-int e2e-fast e2e-build e2e-system e2e-live e2e-smoke test-int-real test-e2e test-all test-minimal test-feature-matrix-lib test-feature-matrix-surface test-feature-matrix test-surface-modularity test-sdk-python test-sdk-typescript test-sdk-suites lint lint-feature-matrix fmt fmt-check audit rust-lane-doctor agent-gate cargo-agent-gate buildbuddy-install buildbuddy-generate buildbuddy-generate-check buildbuddy-doctor buildbuddy-build buildbuddy-check buildbuddy-clippy buildbuddy-lint buildbuddy-test buildbuddy-test-all buildbuddy-test-unit buildbuddy-test-int buildbuddy-e2e-fast buildbuddy-e2e-system buildbuddy-e2e-live buildbuddy-e2e-smoke buildbuddy-agent-gate buildbuddy-ci-dispatch buildbuddy-fast buildbuddy-benchmark buildbuddy-ci buildbuddy-ci-warm buildbuddy-ci-full buildbuddy-ci-full-warm ci ci-smoke release-preflight release-preflight-smoke publish-dry-run publish-dry-run-python publish-dry-run-typescript release-dry-run release-dry-run-smoke clean doc release install-hooks coverage check help legacy-surface-gate legacy-surface-inventory session-control-gate deprecated-backend-gate deprecated-backend-inventory verify-version-parity verify-schema-freshness verify-rpc-surface-alignment verify-sdk-wrapper-freshness check-rust-release-packaging check-mini-skill-size bump-sdk-versions smoke-sdk-python-artifact smoke-sdk-typescript-artifact xtask-build machine-codegen machine-verify machine-check-drift seam-inventory rmat-audit audit-generated-headers
+.PHONY: all install-build-deps build test test-unit test-int e2e-fast e2e-build e2e-system e2e-live e2e-smoke test-int-real test-e2e test-all test-minimal test-feature-matrix-lib test-feature-matrix-surface test-feature-matrix test-surface-modularity test-sdk-python test-sdk-typescript test-sdk-suites lint lint-feature-matrix fmt fmt-check audit rust-lane-doctor agent-gate cargo-agent-gate buildbuddy-install buildbuddy-generate buildbuddy-generate-check buildbuddy-doctor buildbuddy-build buildbuddy-check buildbuddy-clippy buildbuddy-lint buildbuddy-test buildbuddy-test-all buildbuddy-test-unit buildbuddy-test-int buildbuddy-e2e-fast buildbuddy-e2e-system buildbuddy-e2e-live buildbuddy-e2e-smoke buildbuddy-agent-gate buildbuddy-ci-dispatch buildbuddy-fast buildbuddy-benchmark buildbuddy-ci buildbuddy-ci-warm buildbuddy-ci-full buildbuddy-ci-full-warm ci ci-smoke release-preflight release-preflight-smoke publish-dry-run publish-dry-run-python publish-dry-run-typescript release-dry-run release-dry-run-smoke clean doc release install-hooks coverage check help legacy-surface-gate legacy-surface-inventory session-control-gate deprecated-backend-gate deprecated-backend-inventory dogma-cleanup-gate dogma-cleanup-gate-fixtures dogma-cleanup-ci-gate verify-version-parity verify-schema-freshness verify-rpc-surface-alignment verify-sdk-wrapper-freshness check-rust-release-packaging check-mini-skill-size bump-sdk-versions smoke-sdk-python-artifact smoke-sdk-typescript-artifact xtask-build machine-codegen machine-verify machine-check-drift seam-inventory rmat-audit audit-generated-headers
 
 # Default target
 all: ci
@@ -207,7 +207,7 @@ cargo-agent-gate: rust-lane-doctor
 	@echo "$(GREEN)Running Cargo agent changed-path gate...$(NC)"
 	@scripts/cargo-agent-gate $(AGENT_GATE_ARGS)
 
-agent-gate:
+agent-gate: dogma-cleanup-local-gate
 	@. ./scripts/build-backend-env; \
 	if meerkat_buildbuddy_enabled; then \
 		$(MAKE) buildbuddy-doctor; \
@@ -311,12 +311,12 @@ buildbuddy-ci-full-warm: buildbuddy-doctor
 	@scripts/buildbuddy-ci-full --warm
 
 # Full CI pipeline - runs the required deterministic lanes plus build policy checks
-ci: fmt-check legacy-surface-gate session-control-gate deprecated-backend-gate bridge-no-responsestatus-gate verify-version-parity verify-rpc-surface-alignment verify-sdk-wrapper-freshness check-rust-release-packaging lint lint-feature-matrix test-unit test-int e2e-fast e2e-system test-minimal test-feature-matrix test-surface-modularity seam-inventory rmat-audit audit-generated-headers audit
+ci: dogma-cleanup-local-gate fmt-check legacy-surface-gate session-control-gate deprecated-backend-gate bridge-no-responsestatus-gate verify-version-parity verify-rpc-surface-alignment verify-sdk-wrapper-freshness check-rust-release-packaging lint lint-feature-matrix test-unit test-int e2e-fast e2e-system test-minimal test-feature-matrix test-surface-modularity seam-inventory rmat-audit audit-generated-headers audit
 	@echo "$(GREEN)CI pipeline complete!$(NC)"
 
 # Developer smoke CI pipeline for faster pre-release iteration.
 # Keeps core validation, skips full feature matrix clippy/test expansion.
-ci-smoke: fmt-check legacy-surface-gate session-control-gate deprecated-backend-gate bridge-no-responsestatus-gate verify-version-parity verify-rpc-surface-alignment verify-sdk-wrapper-freshness check-rust-release-packaging lint test-unit test-int e2e-fast e2e-system test-minimal seam-inventory rmat-audit audit-generated-headers audit
+ci-smoke: dogma-cleanup-local-gate fmt-check legacy-surface-gate session-control-gate deprecated-backend-gate bridge-no-responsestatus-gate verify-version-parity verify-rpc-surface-alignment verify-sdk-wrapper-freshness check-rust-release-packaging lint test-unit test-int e2e-fast e2e-system test-minimal seam-inventory rmat-audit audit-generated-headers audit
 	@echo "$(GREEN)CI smoke pipeline complete!$(NC)"
 
 # Milestone 0 gate: ensure legacy public surface names are either removed
@@ -337,6 +337,35 @@ session-control-gate:
 deprecated-backend-gate:
 	@echo "$(GREEN)Checking for deprecated backend references...$(NC)"
 	@scripts/deprecated_backend_scan.sh
+
+dogma-cleanup-gate:
+	@if [ -z "$${DOGMA_PACKET:-}" ]; then \
+		echo "$(RED)DOGMA_PACKET=<review-readiness-packet.md> is required$(NC)" >&2; \
+		exit 2; \
+	fi
+	@$(PYTHON) scripts/dogma_cleanup_gate.py --packet "$$DOGMA_PACKET" $(DOGMA_CLEANUP_GATE_ARGS)
+
+dogma-cleanup-gate-fixtures:
+	@$(PYTHON) scripts/tests/dogma_cleanup_gate_test.py
+
+dogma-cleanup-local-gate: dogma-cleanup-gate-fixtures
+	@if [ -n "$${GITHUB_EVENT_PATH:-}" ]; then \
+		$(PYTHON) scripts/dogma_cleanup_gate.py --github-event "$$GITHUB_EVENT_PATH" $(DOGMA_CLEANUP_GATE_ARGS); \
+	elif [ -n "$${DOGMA_PACKET:-}" ]; then \
+		$(PYTHON) scripts/dogma_cleanup_gate.py --packet "$$DOGMA_PACKET" $(DOGMA_CLEANUP_GATE_ARGS); \
+	else \
+		echo "$(YELLOW)Dogma cleanup gate skipped for local broad lane: set DOGMA_PACKET or GITHUB_EVENT_PATH to enforce.$(NC)"; \
+	fi
+
+dogma-cleanup-ci-gate: dogma-cleanup-gate-fixtures
+	@if [ -n "$${GITHUB_EVENT_PATH:-}" ]; then \
+		$(PYTHON) scripts/dogma_cleanup_gate.py --github-event "$$GITHUB_EVENT_PATH" $(DOGMA_CLEANUP_GATE_ARGS); \
+	elif [ -n "$${DOGMA_PACKET:-}" ]; then \
+		$(PYTHON) scripts/dogma_cleanup_gate.py --packet "$$DOGMA_PACKET" $(DOGMA_CLEANUP_GATE_ARGS); \
+	else \
+		echo "DOGMA_PACKET or GITHUB_EVENT_PATH is required for dogma cleanup CI enforcement." >&2; \
+		exit 2; \
+	fi
 
 # W2-F bridge-classifier gate: supervisor_bridge / local_bridge / bridge
 # wire types must not re-interpret `ResponseStatus`. All terminal-vs-progress
@@ -648,6 +677,9 @@ help:
 	@echo "  $(GREEN)rust-lane-doctor$(NC)- Check Rust lane isolation and filtered test lanes"
 	@echo "  $(GREEN)agent-gate$(NC)    - Run Cargo or MEERKAT_BUILDBUDDY=1 BuildBuddy changed gate (AGENT_GATE_ARGS=...)"
 	@echo "  $(GREEN)cargo-agent-gate$(NC)- Run Cargo gate for changed agent files"
+	@echo "  $(GREEN)dogma-cleanup-gate$(NC)- Validate dogma cleanup Review Readiness Packet (DOGMA_PACKET=...)"
+	@echo "  $(GREEN)dogma-cleanup-gate-fixtures$(NC)- Run dogma cleanup gate fixture tests"
+	@echo "  $(GREEN)dogma-cleanup-ci-gate$(NC)- Enforce dogma cleanup packet for signaled PRs"
 	@echo "  $(GREEN)buildbuddy-install$(NC)- Install pinned optional BuildBuddy CLI"
 	@echo "  $(GREEN)buildbuddy-generate$(NC)- Regenerate optional Bazel BUILD files"
 	@echo "  $(GREEN)buildbuddy-generate-check$(NC)- Check optional Bazel BUILD freshness"

--- a/docs/process/dogma-cleanup-gate.md
+++ b/docs/process/dogma-cleanup-gate.md
@@ -1,0 +1,126 @@
+# Dogma Cleanup Review Gate
+
+Dogma cleanup PRs are review-inadmissible until the Review Readiness Packet
+contains an `Old Path Amputation Proof` and `make dogma-cleanup-gate` passes
+against that packet.
+
+The required GitHub `Dogma cleanup review gate` check enforces this at PR
+admission. For pull requests whose title, labels, or body marker signal dogma
+cleanup work, whose changed files/diff match the provisional dogma-cleanup
+shape in ordinary source paths, whose diff structurally deletes a source symbol
+from known campaign surfaces, or whose diff changes the gate-owning files that
+could disable this check, CI treats the PR body as the Review Readiness Packet
+and runs the gate before the top-level `CI gate` can pass. In GitHub CI, the
+workflow invokes the checker directly from the base branch gate source when that
+source exists, with the PR checkout passed as data. PR-head rewrites of
+`Makefile`, the checker, fixtures, or docs therefore cannot make the gate skip
+before the old-path detector runs. The immutable `pull_request_target` workflow
+also reports the required `CI gate` status context from base-owned workflow
+source after this workflow exists on `main`, so PR-head workflow rewrites cannot
+be the only path satisfying the active required status. The normal `make ci`,
+`make ci-smoke`, and `make agent-gate` command surfaces invoke the local wrapper:
+they always run the dogma gate fixture oracle, enforce the packet whenever
+`GITHUB_EVENT_PATH` or `DOGMA_PACKET` is set, and otherwise skip dogma admission
+for ordinary local non-dogma work. The explicit `dogma-cleanup-ci-gate` target
+remains fail-closed without `GITHUB_EVENT_PATH` or `DOGMA_PACKET` so fixture-only
+output cannot be cited as CI enforcement evidence. The GitHub workflow also
+reruns on pull request edits and label changes so a previous skipped result
+cannot remain green after dogma cleanup signal is added or removed.
+
+The gate exists to stop canonicalization beside the old path. A cleanup is not
+ready because a typed owner, preferred route, wrapper, mirror, adapter, cache, or
+JSON carrier exists. It is ready only when the old authority became impossible to
+call. A retained old path with a linked follow-up is a named residual, not a
+passing review-admission state.
+
+## Required Packet Shape
+
+The Review Readiness Packet for a dogma cleanup PR must include:
+
+- Current head SHA.
+- Command output for `make dogma-cleanup-gate DOGMA_PACKET=<packet>`.
+- `Old Path Amputation Proof`.
+- `Complexity Delta`.
+- A sample passing and sample failing Old Path Amputation Proof.
+
+Use this table for the live proof:
+
+| Old path | Classification | Search literal | Mechanical proof | Follow-up |
+| --- | --- | --- | --- | --- |
+| `<symbol/route/API/carrier>` | `deleted` or `made uncallable at boundary` | `<literal used by the provisional scanner>` | `<command/test/boundary evidence>` | `none` |
+
+Every old authority, carrier, surface, cache, string mirror, JSON bag, SDK/WASM
+contract path, compatibility fallback, and machine governance scanner path being
+attacked must appear as its own row. `Wrapped`, `mirrored`, `adapter added`,
+`preferred path exists`, `preferred-path-only`, replacement-wrapper proof,
+retained rows, and proof that admits the old path remains supported, exported,
+available, routed, working, usable by old callers, or callable for compatibility
+fail the gate.
+
+## Mechanical Check
+
+Run:
+
+```bash
+make dogma-cleanup-gate DOGMA_PACKET=artifacts/review-readiness.md
+```
+
+For CI parity, run:
+
+```bash
+make dogma-cleanup-ci-gate DOGMA_PACKET=artifacts/review-readiness.md
+```
+
+The script verifies the packet structure, rejects wrapper-only proof language,
+checks `deleted` rows for remaining production references to the search literal,
+requires mechanical uncallable proof such as compile failure, rejected calls, or
+removed route/export evidence, rejects broad new compatibility-shim phrases in
+added implementation lines, rejects suspicious new public carrier names, and
+verifies generated/schema churn is separated in `Complexity Delta`. Its fixture
+tests also prove dogma-shaped source changes and structural symbol deletions in
+representative runtime/core, provider/model ownership, and RPC/comms surface
+paths require the Review Readiness Packet even when the PR title, labels, and
+body do not opt in. Gate-owning paths (`Makefile`,
+`.github/workflows/ci.yml`, the PR template, the checker, and its fixtures/tests)
+also require the packet when changed, so a Makefile-only no-op rewrite of
+`dogma-cleanup-ci-gate` cannot skip the gate.
+
+This scanner is provisional. It uses literal references and stable changed-diff
+signals only where the repository does not yet expose typed old-path metadata.
+If a proof claim depends on typed metadata, reviewers must require typed
+evidence in the packet or a linked typed metadata follow-up before review
+proceeds. Typed metadata replacement is tracked in LUC-321.
+
+## Reviewer Rule
+
+Spawned reviewers must answer this before normal bug review:
+
+> What exact old path became impossible after this PR?
+
+If the answer is "none", "a wrapper was added", "a mirror was added", "the
+preferred path exists", "the proof is preferred-path-only", or "the adapter
+redirects it", or "the old path remains callable for compatibility", move the
+PR to Rework. If a dogma cleanup PR reaches review without the required gate
+running, move it to Rework; the gate is expected to run from explicit PR signal,
+stable dogma-shaped diff signal, and gate-owning file changes. Exceptions that
+retain callable old paths are not review-admissible through this front door:
+move the PR to Rework and require the retained row to be split to a linked
+follow-up before normal review resumes.
+
+## Required Coverage Areas
+
+Apply the same standard to each recurring mistake family:
+
+- Runtime metadata: old string mirrors, JSON bags, caches, and helper carriers
+  must be deleted or made boundary-uncallable.
+- AuthMachine/OAuth: token freshness caches and authorizer fallbacks must not
+  remain callable beside lease-owned truth.
+- Surface request lifecycle: route/method/tool classifiers must not keep local
+  authority once machine-owned semantics exist.
+- SDK/WASM contract mirrors: generated or hand-written compatibility carriers
+  must be counted separately and cannot hide as implementation work.
+- Machine governance scanners: scanner allowlists and local authority rules must
+  be deleted or made uncallable, not shadowed by newer checks.
+
+Do not claim the campaign is healthier because this gate lands. It prevents new
+process debt; it does not recover existing implementation churn.

--- a/meerkat-auth-core/tests/google_auth_authorizer.rs
+++ b/meerkat-auth-core/tests/google_auth_authorizer.rs
@@ -215,6 +215,7 @@ impl AuthLeaseHandle for RecordingAuthLeaseHandle {
             expires_at: Some(expires_at),
             credential_present: true,
             generation,
+            credential_published_at_millis: None,
         };
         Ok(AuthLeaseTransition {
             generation,
@@ -266,6 +267,7 @@ impl AuthLeaseHandle for RecordingAuthLeaseHandle {
             expires_at: Some(new_expires_at),
             credential_present: true,
             generation,
+            credential_published_at_millis: None,
         };
         Ok(AuthLeaseTransition {
             generation,

--- a/meerkat-cli/tests/cli_auth_flow.rs
+++ b/meerkat-cli/tests/cli_auth_flow.rs
@@ -424,7 +424,14 @@ fn rkat_auth_refresh_uses_binding_scoped_token_when_profile_id_differs() {
   "expires_at": 1893456000,
   "last_refresh": 1700000000,
   "scopes": ["openid", "email"],
-  "account_id": "acct-fresh"
+  "account_id": "acct-fresh",
+  "metadata": {
+    "meerkat_auth_lifecycle": {
+      "published": true,
+      "version": 2,
+      "expires_at": 1893456000
+    }
+  }
 }"#,
     );
 
@@ -449,6 +456,14 @@ fn rkat_auth_refresh_uses_binding_scoped_token_when_profile_id_differs() {
         let stderr = String::from_utf8_lossy(&refresh.stderr);
         if stderr.contains("requires the `anthropic`, `openai`, and `gemini`") {
             eprintln!("SKIP: auth provider features unavailable");
+            return;
+        }
+        if stderr.contains("token endpoint error") {
+            assert!(
+                !stderr.contains("missing secret for auth resolution"),
+                "refresh must resolve the binding-scoped token before reaching the provider; stderr={stderr}"
+            );
+            eprintln!("SKIP: fake refresh token was rejected by the provider endpoint");
             return;
         }
         panic!("refresh must use the binding-scoped token key; stderr={stderr}");

--- a/meerkat-rest/src/auth_endpoints.rs
+++ b/meerkat-rest/src/auth_endpoints.rs
@@ -423,7 +423,7 @@ async fn rollback_token_commit(
                 token_store
                     .save(&commit.key, previous)
                     .await
-                    .map_err(|e| format!("TokenStore rollback save failed: {e}"))?
+                    .map_err(|e| format!("TokenStore rollback save failed: {e}"))?;
             }
         },
         None => {
@@ -2392,7 +2392,7 @@ mod tests {
                     auth_lease: Arc::new(StaticLease::inline_secret(
                         "sk-rest-test".to_string(),
                         meerkat_core::AuthMetadata::default(),
-                        Some(self.expires_at.clone()),
+                        Some(self.expires_at),
                         "test",
                     )),
                 })

--- a/meerkat-rest/src/lib.rs
+++ b/meerkat-rest/src/lib.rs
@@ -7083,7 +7083,7 @@ mod tests {
             result = &mut webhook_task => {
                 panic!("wakeful webhook completed before registration lock release: {result:?}");
             }
-            _ = tokio::time::sleep(std::time::Duration::from_millis(50)) => {}
+            () = tokio::time::sleep(std::time::Duration::from_millis(50)) => {}
         }
         wait_for_rest_runtime_pre_admission(&state, &target_session_id).await;
 
@@ -7414,7 +7414,7 @@ mod tests {
                 release.notify_waiters();
                 tokio::select! {
                     result = &mut continue_task => break result,
-                    _ = tokio::time::sleep(std::time::Duration::from_millis(10)) => {}
+                    () = tokio::time::sleep(std::time::Duration::from_millis(10)) => {}
                 }
             }
         })
@@ -9914,7 +9914,7 @@ mod tests {
             result = &mut continue_task => {
                 panic!("rebuild continue completed before taking the runtime registration lock: {result:?}");
             }
-            _ = tokio::time::sleep(std::time::Duration::from_millis(50)) => {}
+            () = tokio::time::sleep(std::time::Duration::from_millis(50)) => {}
         }
         assert!(
             !state.runtime_adapter.contains_session(&session_id).await,

--- a/meerkat-rpc/src/handlers/auth.rs
+++ b/meerkat-rpc/src/handlers/auth.rs
@@ -505,7 +505,7 @@ async fn rollback_token_commit(
                 store
                     .save(&commit.key, previous)
                     .await
-                    .map_err(|e| format!("TokenStore rollback save failed: {e}"))?
+                    .map_err(|e| format!("TokenStore rollback save failed: {e}"))?;
             }
         },
         None => {
@@ -2898,7 +2898,8 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn provision_api_key_requires_runtime_oauth_flow_admission_before_token_store() {
+    async fn provision_api_key_requires_runtime_oauth_flow_admission_before_token_store()
+    -> Result<(), String> {
         let runtime = test_runtime_with_config_without_token_store(
             config_with_anthropic_oauth_to_api_key_binding(),
         );
@@ -2923,7 +2924,7 @@ mod tests {
                     operation: "admit_oauth_browser_flow",
                     ..
                 }) => break,
-                Err(err) => panic!("unexpected OAuth flow admission error: {err}"),
+                Err(err) => return Err(format!("unexpected OAuth flow admission error: {err}")),
             }
         }
         let params = raw_params(serde_json::json!({
@@ -2953,6 +2954,7 @@ mod tests {
             "expected runtime OAuth authority failure before TokenStore access, got `{}`",
             error.message
         );
+        Ok(())
     }
 
     #[tokio::test]

--- a/meerkat-rpc/src/session_runtime.rs
+++ b/meerkat-rpc/src/session_runtime.rs
@@ -471,6 +471,7 @@ async fn await_guarded_session_cleanup(
         })?
 }
 
+#[allow(clippy::too_many_arguments)]
 async fn await_guarded_staged_archive(
     service: Arc<PersistentSessionService<FactoryAgentBuilder>>,
     staged_sessions: Arc<StagedSessionRegistry>,
@@ -3000,11 +3001,11 @@ impl SessionRuntime {
 
     #[cfg(test)]
     pub(crate) async fn wait_runtime_routed_pre_promotion_hook(&self, session_id: &SessionId) {
-        if !self
+        if self
             .staged_sessions
             .info(session_id)
             .await
-            .is_some_and(|info| !info.is_promoting)
+            .is_none_or(|info| info.is_promoting)
         {
             return;
         }

--- a/meerkat-runtime/src/meerkat_machine/mod.rs
+++ b/meerkat-runtime/src/meerkat_machine/mod.rs
@@ -106,7 +106,7 @@ fn runtime_store_identity(store: &Arc<dyn RuntimeStore>) -> PersistentAuthAuthor
         .auth_authority_key()
         .map(PersistentAuthAuthorityKey::Durable)
         .unwrap_or_else(|| {
-            PersistentAuthAuthorityKey::Process(Arc::as_ptr(store) as *const () as usize)
+            PersistentAuthAuthorityKey::Process(Arc::as_ptr(store).cast::<()>() as usize)
         })
 }
 

--- a/meerkat/src/factory.rs
+++ b/meerkat/src/factory.rs
@@ -6287,7 +6287,7 @@ mod tests {
                     auth_lease: Arc::new(StaticLease::inline_secret(
                         "sk-image-test".to_string(),
                         meerkat_core::AuthMetadata::default(),
-                        Some(self.expires_at.clone()),
+                        Some(self.expires_at),
                         "test",
                     )),
                 })

--- a/scripts/buildbuddy-doctor
+++ b/scripts/buildbuddy-doctor
@@ -427,7 +427,7 @@ if ! grep -Fq 'rust-release-packaging:' .github/workflows/cargo.yml &&
   ! grep -Fq 'e2e-smoke:' .github/workflows/cargo.yml &&
   grep -Fq 'Cargo E2E live lane' .github/workflows/live-e2e.yml &&
   grep -Fq 'Cargo E2E smoke lane' .github/workflows/live-e2e.yml &&
-  grep -Fq 'needs: [cargo, buildbuddy]' .github/workflows/ci.yml &&
+  grep -Fq 'needs: [cargo, buildbuddy, dogma-cleanup-gate]' .github/workflows/ci.yml &&
   grep -Fq 'needs: [fmt-lint, sdk-suites, machine-authority, test-unit, integration-fast, e2e-fast, e2e-system, test-minimal' .github/workflows/cargo.yml &&
   ! grep -Fq 'needs: [fmt-lint, sdk-suites, rust-release-packaging' .github/workflows/cargo.yml; then
   pass "CI gate selects one backend and Cargo gate depends on every standard Cargo CI lane"

--- a/scripts/dogma_cleanup_gate.py
+++ b/scripts/dogma_cleanup_gate.py
@@ -1,0 +1,1297 @@
+#!/usr/bin/env python3
+"""Provisional dogma cleanup review-readiness gate.
+
+The gate is intentionally small: it validates the Review Readiness Packet and
+checks changed files for the mechanical failure modes this campaign keeps
+admitting. It is not a semantic proof. Typed old-path metadata should replace
+the literal reference checks once the follow-up exists.
+"""
+
+from __future__ import annotations
+
+import argparse
+from dataclasses import dataclass
+import json
+import os
+from pathlib import Path
+from pathlib import PurePosixPath
+import re
+import subprocess
+import sys
+from typing import Iterable
+
+try:
+    import tomllib
+except ModuleNotFoundError:  # pragma: no cover - Python <3.11 fallback.
+    tomllib = None
+
+
+FORBIDDEN_PROOF_PATTERNS: tuple[tuple[str, str], ...] = (
+    (
+        r"\b(?:test|fixture|harness|mock)[-_ ]only\b",
+        "test-only proof does not prove production boundary uncallability",
+    ),
+    (r"\bwrapped\b", "wrapped is not an amputation classification"),
+    (r"\bwrapper[-_ ]only\b", "wrapper-only cleanup leaves the old path callable"),
+    (
+        r"\b(?:replacement|compat(?:ibility)?|temporary|thin|new)\s+wrapper\b|"
+        r"\bwrapper\s+(?:around|beside|while|over)\b",
+        "wrapper cleanup leaves the old path callable",
+    ),
+    (r"\bmirrored\b", "mirrored is not an amputation classification"),
+    (r"\bmirror[-_ ]only\b", "mirror-only cleanup leaves the old path callable"),
+    (
+        r"\b(?:replacement|compat(?:ibility)?|temporary|thin|new)\s+mirror\b|"
+        r"\bmirror\s+(?:around|beside|while|over)\b",
+        "mirror cleanup leaves the old path callable",
+    ),
+    (r"\badapter added\b", "adapter-added cleanup leaves the old path callable"),
+    (
+        r"\b(?:replacement|compat(?:ibility)?|temporary|thin|new)\s+adapter\b|"
+        r"\badapter\s+(?:around|beside|while|over|redirects?)\b",
+        "adapter cleanup leaves the old path callable",
+    ),
+    (r"\bpreferred path exists\b", "preferred-path cleanup leaves the old path callable"),
+    (r"\bpreferred[-_ ]path[-_ ]only\b", "preferred-path-only cleanup leaves the old path callable"),
+    (
+        r"\b(?:remains?|still|kept|left|leaves)\s+callable\b",
+        "proof admits the old path remains callable",
+    ),
+    (
+        r"\b(?:callable|retained)\s+for\s+(?:backwards?\s+)?compatibility\b|"
+        r"\b(?:backwards?\s+)?compatibility\s+(?:wrapper|adapter|mirror|fallback)\b|"
+        r"\b(?:wrapper|adapter|mirror|fallback)\s+for\s+(?:backwards?\s+)?compatibility\b",
+        "compatibility-retained proof leaves the old path callable",
+    ),
+    (
+        r"\b(?:remains?|still|kept|left|leaves|stays?|is|are)?\s*"
+        r"(?:supported|exported|available|routed|working)\s+for\s+"
+        r"(?:backwards?\s+)?compatibility\b",
+        "compatibility-retained proof leaves the old path callable",
+    ),
+    (
+        r"\b(?:alias(?:es)?|facades?|shadow[-_ ]routes?|shadow[-_ ]surfaces?)\b"
+        r"[^|\n.]*\b(?:rollout|migration|compat(?:ibility)?|legacy|old|previous|retained|"
+        r"kept|continues?|routes?|serves?|handles?)\b|"
+        r"\b(?:old|legacy|previous|existing|former|deprecated)\s+"
+        r"(?:alias(?:es)?|facades?|shadow[-_ ]routes?|shadow[-_ ]surfaces?)\b",
+        "alias/facade proof leaves the old path callable",
+    ),
+    (
+        r"\b(?:old|legacy|previous|existing|former|deprecated)\s+"
+        r"(?:helpers?|paths?|routes?|endpoints?|apis?|services?|surfaces?|exports?|actions?)\s+"
+        r"(?:remains?|remained|still|stays?|is|are|was|were|continues?|continued|"
+        r"keeps?|kept|left)\s+"
+        r"(?:as|behind|on|via|through|using|with|under)\s+"
+        r"(?:(?:an?|the)\s+)?(?:alias(?:es)?|facades?|shadow[-_ ]routes?|shadow[-_ ]surfaces?)\b",
+        "alias/facade proof leaves the old path callable",
+    ),
+    (
+        r"\bcompatibility\s+(?:traffic|requests?|calls?|callers?|clients?|consumers?|"
+        r"integrations?)\s+"
+        r"(?:is|are|was|were|remains?|remained|still|continues?|continued|can|may)?\s*"
+        r"(?:handled|routed|served|accepted|supported|processed|sent|flowing|flows?)\s+"
+        r"(?:by|through|via|to|on|against)\s+"
+        r"(?:(?:the|a|an)\s+)?(?:old|legacy|previous|existing|former|deprecated)\s+"
+        r"(?:helpers?|paths?|routes?|endpoints?|apis?|services?|surfaces?|exports?|"
+        r"actions?|aliases?|facades?)\b",
+        "compatibility-retained proof leaves the old path callable",
+    ),
+    (
+        r"\b(?:old|legacy|previous|existing|former|deprecated)\s+"
+        r"(?:helpers?|paths?|routes?|endpoints?|apis?|services?|surfaces?|exports?|actions?|"
+        r"clients?|users?|callers?|sdks?|apps?|tools?|deployments?|access)\s+"
+        r"(?:remains?|remained|still|stays?|is|are|was|were|can|may|should|might|must|"
+        r"continue(?:s)?(?:\s+to)?|will|would|shall|could|keeps?|kept|left)\s+"
+        r"(?:(?:fully|still)\s+)?(?:be\s+)?(?:usable|available|reachable|callable|supported|working|routable|operable|accessible|"
+        r"operational|open|in\s+service|exposed|published|grandfathered|"
+        r"use|used|using|call|called|calling|reach|reached|reaching|operate|operated|operating|"
+        r"access|accessed|accessing|invoke|invokes|invoked|invoking|hit|hits|hitting|"
+        r"submit|submits|submitted|submitting|import|imports|imported|importing|"
+        r"respond|responds|responded|responding|"
+        r"serve|serves|served|serving|accept|accepts|accepted|accepting|"
+        r"function|functions|functioned|functioning|handle|handles|handled|handling|"
+        r"preserved|enabled|maintained|allowed|retained|kept|importable|invokable|active|live|online)\b",
+        "proof admits old callers can still use the old path",
+    ),
+    (
+        r"\b(?:old|legacy|previous|existing|former|deprecated)\s+"
+        r"(?:helpers?|paths?|routes?|endpoints?|apis?|services?|surfaces?|exports?|actions?|"
+        r"clients?|users?|callers?|sdks?|apps?|tools?|deployments?|access)\s+"
+        r"(?:(?:will|would|shall|could|should|might|must)(?:\s+still)?|"
+        r"(?:need|needs|needed)\s+to|"
+        r"(?:(?:is|are|was|were)\s+)?(?:expected|intended)\s+to|"
+        r"ought\s+to)\s+"
+        r"(?:remain|stay|continue(?:s)?(?:\s+to)?(?:\s+be)?|be)\s+"
+        r"(?:(?:fully|still)\s+)?(?:usable|available|reachable|callable|supported|working|routable|operable|accessible|"
+        r"operational|open|in\s+service|invocable|invokable|importable|active|live|online)\b",
+        "proof admits old callers can still use the old path",
+    ),
+    (
+        r"\b(?:old|legacy|previous|existing|former|deprecated|older)\s+"
+        r"(?:clients?|users?|callers?|sdks?|apps?|tools?|deployments?)\s+"
+        r"(?:(?:should|might|must)(?:\s+still)?(?:\s+(?:keep|continue(?:s)?)(?:\s+to)?)?|"
+        r"(?:need|needs|needed)\s+to(?:\s+(?:keep|continue(?:s)?)(?:\s+to)?)?|"
+        r"(?:(?:is|are|was|were)\s+)?(?:expected|intended)\s+to"
+        r"(?:\s+(?:keep|continue(?:s)?)(?:\s+to)?)?|"
+        r"ought\s+to(?:\s+(?:keep|continue(?:s)?)(?:\s+to)?)?|"
+        r"(?:can|may|will|would|shall|could)(?:\s+still)?(?:\s+(?:keep|continue(?:s)?)(?:\s+to)?)?|"
+        r"still\s+(?:can|may|will|would|shall|could)?(?:\s+(?:keep|continue(?:s)?)(?:\s+to)?)?|"
+        r"(?:keep|continue)(?:s)?(?:\s+to)?|remain able to)\s+"
+        r"(?:use|using|call|calling|reach|reaching|operate|operating|access|accessing|"
+        r"invoke|invoking|hit|hitting|submit|submitting|import|importing)\b",
+        "proof admits old callers can still use the old path",
+    ),
+    (
+        r"\b(?:old|legacy|previous|existing|former|deprecated|older)\s+"
+        r"(?:clients?|users?|callers?|consumers?|integrations?|sdks?|apps?|tools?|deployments?)\s+"
+        r"(?:(?:should|might|must)(?:\s+still)?(?:\s+(?:keep|continue(?:s)?)(?:\s+to)?)?|"
+        r"(?:need|needs|needed)\s+to(?:\s+(?:keep|continue(?:s)?)(?:\s+to)?)?|"
+        r"(?:(?:is|are|was|were)\s+)?(?:expected|intended)\s+to"
+        r"(?:\s+(?:keep|continue(?:s)?)(?:\s+to)?)?|"
+        r"ought\s+to(?:\s+(?:keep|continue(?:s)?)(?:\s+to)?)?|"
+        r"(?:can|may|will|would|shall|could)(?:\s+still)?(?:\s+(?:keep|continue(?:s)?)(?:\s+to)?)?|"
+        r"still\s+(?:can|may|will|would|shall|could)?(?:\s+(?:keep|continue(?:s)?)(?:\s+to)?)?|"
+        r"(?:keep|continue)(?:s)?(?:\s+to)?|remain able to)\s+"
+        r"(?:(?:use|using|call|calling|reach|reaching|operate|operating|access|accessing|"
+        r"invoke|invoking|hit|hitting|submit|submitting|import|importing)\s+)?"
+        r"(?:through|via|against|on|it|them|that|this|the\s+old\s+path)\b",
+        "proof admits old callers can still use the old path",
+    ),
+    (
+        r"\b(?:callers?|clients?|users?|consumers?|integrations?|sdks?|apps?|tools?|deployments?)\s+"
+        r"(?:(?:should|might|must)(?:\s+still)?(?:\s+(?:keep|continue(?:s)?)(?:\s+to)?)?|"
+        r"(?:need|needs|needed)\s+to(?:\s+(?:keep|continue(?:s)?)(?:\s+to)?)?|"
+        r"(?:(?:is|are|was|were)\s+)?(?:expected|intended)\s+to"
+        r"(?:\s+(?:keep|continue(?:s)?)(?:\s+to)?)?|"
+        r"ought\s+to(?:\s+(?:keep|continue(?:s)?)(?:\s+to)?)?|"
+        r"(?:can|may|will|would|shall|could)(?:\s+still)?(?:\s+(?:keep|continue(?:s)?)(?:\s+to)?)?|"
+        r"still\s+(?:can|may|will|would|shall|could)?(?:\s+(?:keep|continue(?:s)?)(?:\s+to)?)?|"
+        r"(?:keep|continue)(?:s)?(?:\s+to)?|remain able to|(?:keeps?|kept)\s+)\s*"
+        r"(?:use|using|call|calling|reach|reaching|operate|operating|access|accessing|"
+        r"invoke|invoking|hit|hitting|submit|submitting|import|importing)\s+"
+        r"(?:(?:requests?|calls?)\s+)?(?:to\s+)?"
+        r"(?:(?:the|a|an)\s+)?(?:old|legacy|previous|existing|former|deprecated)\s+"
+        r"(?:helpers?|paths?|routes?|endpoints?|apis?|services?|surfaces?|exports?|actions?)\b",
+        "proof admits old callers can still use the old path",
+    ),
+    (
+        r"\b(?:old|legacy|previous|existing|former|deprecated)\s+(?:clients?|users?|callers?|"
+        r"consumers?|integrations?)\s+"
+        r"(?:are|were|remain|remains|remained|stay|stays|stayed|still)\s+"
+        r"(?:served|handled|accepted|routed|supported)\s+by\s+"
+        r"(?:(?:the|a|an)\s+)?(?:old|legacy|previous|existing|former|deprecated)\s+"
+        r"(?:helpers?|paths?|routes?|endpoints?|apis?|services?|surfaces?|exports?|actions?)\b",
+        "proof admits old callers can still use the old path",
+    ),
+    (
+        r"\b(?:old|legacy|previous|existing|former|deprecated)\s+(?:clients?|users?|callers?|"
+        r"consumers?|integrations?)\s+"
+        r"(?:remain|remains|remained|stay|stays|stayed|continue(?:s)?|continued)\s+"
+        r"(?:on|at|against|with|behind)\s+"
+        r"(?:(?:the|a|an)\s+)?(?:old|legacy|previous|existing|former|deprecated)\s+"
+        r"(?:helpers?|paths?|routes?|endpoints?|apis?|services?|surfaces?|exports?|actions?)\b",
+        "proof admits old callers can still use the old path",
+    ),
+    (
+        r"\b(?:(?:the|that|this)\s+)?"
+        r"(?:(?:old|legacy|previous|existing|former|deprecated)\s+)?"
+        r"(?:helpers?|paths?|routes?|endpoints?|apis?|services?|surfaces?|exports?|actions?|"
+        r"clients?|users?|callers?|consumers?|integrations?|access)\s+"
+        r"(?:remains?|still|stays?|is|are|was|were|kept|left|continue(?:s)?(?:\s+to)?)\s+"
+        r"(?:(?:fully|still)\s+)?(?:usable|available|reachable|callable|supported|working|routable|operable|accessible|"
+        r"operational|open|in\s+service|"
+        r"respond|responding|serve|serving|accept|accepting|function|functioning|handle|handled|"
+        r"work|preserved|enabled|maintained|allowed|exposed|published|grandfathered|"
+        r"retained|kept|left|"
+        r"active|live|online)\b",
+        "proof admits old callers can still use the old path",
+    ),
+    (
+        r"\b(?:keeps?|keeping|kept|leaves?|leaving|left|retains?|retaining|retained|"
+        r"preserves?|preserving|preserved|enables?|enabling|enabled|maintains?|maintaining|"
+        r"maintained|allows?|allowing|allowed)\s+"
+        r"(?:(?:the|that|this)\s+)?(?:(?:old|legacy|previous|existing|former|deprecated)\s+)?"
+        r"(?:helpers?|paths?|routes?|endpoints?|apis?|services?|surfaces?|exports?|actions?|"
+        r"clients?|users?|callers?|consumers?|integrations?|access)\b",
+        "proof admits old callers can still use the old path",
+    ),
+    (
+        r"\b(?:keeps?|kept|leaves?|left|retains?|retained|preserves?|preserved|enables?|enabled|"
+        r"maintains?|maintained|allows?|allowed)\s+"
+        r"(?:(?:the|that|this)\s+)?(?:(?:old|legacy|previous|existing|former|deprecated)\s+)?"
+        r"(?:helpers?|paths?|routes?|endpoints?|apis?|services?|surfaces?|exports?|actions?|access)\s+"
+        r"(?:(?:fully|still)\s+)?(?:usable|available|reachable|callable|supported|working|routable|operable|accessible|"
+        r"operational|open|in\s+service|"
+        r"responds|responding|serves|serving|accepts|accepting|functions|functioning|"
+        r"handles|handling|preserved|enabled|maintained|allowed|exposed|published|"
+        r"grandfathered|active|live|online)\b",
+        "proof admits old callers can still use the old path",
+    ),
+    (
+        r"\b(?:old|legacy|previous|existing|former|deprecated)\s+"
+        r"(?:helpers?|paths?|routes?|endpoints?|apis?|services?|surfaces?|exports?|actions?|"
+        r"clients?|users?|callers?|consumers?|integrations?|access)\b"
+        r"[^|\n.]{0,120}\b(?:semver|abi|api|compat(?:ibility)?)\s+stability\b",
+        "compatibility-retained proof leaves the old path callable",
+    ),
+)
+
+UNCALLABLE_PROOF_PATTERNS: tuple[re.Pattern[str], ...] = (
+    re.compile(
+        r"\b(?:compile(?:[- ]fail(?:ure|s)?|s? fails?)|does not compile|compiler rejects)\b",
+        re.IGNORECASE,
+    ),
+    re.compile(
+        r"\b(?:deny|denies|denied|reject|rejects|rejected|block|blocks|blocked)\s+"
+        r"(?:calls?|requests?|routes?|exports?|access)\b",
+        re.IGNORECASE,
+    ),
+    re.compile(
+        r"\b(?:calls?|requests?|routes?|exports?|access)\s+"
+        r"(?:are|is)\s+(?:denied|rejected|blocked)\b",
+        re.IGNORECASE,
+    ),
+    re.compile(
+        r"\b(?:not|no longer)\s+(?:exported|routed|registered|callable|reachable|available)\b",
+        re.IGNORECASE,
+    ),
+    re.compile(
+        r"\b(?:route|export|api|symbol|handler)\s+(?:removed|deleted|unregistered)\b",
+        re.IGNORECASE,
+    ),
+    re.compile(r"\b(?:not routable|not callable|boundary[- ]uncallable)\b", re.IGNORECASE),
+)
+
+NON_PRODUCTION_PROOF_CONTEXT = re.compile(
+    r"\b(?:unit\s+tests?|test\s+fixtures?|fixtures?|harness(?:es)?|mocks?|mocked|synthetic)\b",
+    re.IGNORECASE,
+)
+
+PRODUCTION_BOUNDARY_CONTEXT = re.compile(
+    r"\b(?:type\s+system|compiler|route\s+registry|router|handler|"
+    r"export|symbol|api|public\s+(?:route|api|export|handler|symbol)|"
+    r"production\s+(?:router|handler|route|api|binary)|"
+    r"runtime\s+(?:rejects?|denies|denied|blocks?|blocked|removed|removes|"
+    r"unregistered|unregisters|no\s+longer\s+(?:routes?|exports?|calls?|accepts?)))\b",
+    re.IGNORECASE,
+)
+
+PUBLIC_CARRIER_NAME = re.compile(
+    r"""
+    ^\+\s*
+    (?:
+      (?:pub\s+)?(?:struct|enum|type|trait|fn|const)\s+
+      [A-Za-z0-9_]*(?:Legacy|Compat|Compatibility|Fallback|Mirror|Carrier|Bag|Cache|Shadow|RawJson|Json)[A-Za-z0-9_]*
+      |
+      export\s+(?:interface|type|class|function|const)\s+
+      [A-Za-z0-9_]*(?:Legacy|Compat|Compatibility|Fallback|Mirror|Carrier|Bag|Cache|Shadow|RawJson|Json)[A-Za-z0-9_]*
+      |
+      pub\s+[A-Za-z0-9_]*(?:legacy|compat|fallback|mirror|carrier|bag|cache|shadow|raw_json|json)[A-Za-z0-9_]*\s*:
+    )
+    """,
+    re.VERBOSE,
+)
+
+COMPAT_SHIM_LINE = re.compile(
+    r"\b(?:compat(?:ibility)? shim|legacy fallback|fallback compatibility|"
+    r"wrapper[- ]only|mirror[- ]only|adapter added|preferred path exists|"
+    r"preferred[- ]path[- ]only|"
+    r"temporary (?:adapter|wrapper|mirror)|backwards? compatibility)\b",
+    re.IGNORECASE,
+)
+
+DOGMA_CLEANUP_SIGNAL = re.compile(
+    r"\b(?:dogma cleanup|dogma-cleanup|dogma violations?|dogma ledger|"
+    r"canonicalization beside the old path)\b",
+    re.IGNORECASE,
+)
+
+DOGMA_CLEANUP_BODY_MARKER = re.compile(
+    r"(?im)^\s*(?:[-*]\s*)?(?:dogma cleanup|dogma-cleanup)(?:\s+pr)?\s*:\s*(?:yes|true|required)\b"
+)
+
+DOGMA_CLEANUP_DIRECT_PATH = re.compile(
+    r"(^|/)(?:dogma|dogma[-_]cleanup)(?:[-_/]|$)",
+    re.IGNORECASE,
+)
+
+DOGMA_CLEANUP_REVIEW_PATHS: tuple[tuple[re.Pattern[str], str], ...] = (
+    (
+        re.compile(
+            r"^(?:docs/(?:process/)?dogma|docs/.*dogma|scripts/.*dogma|"
+            r"\.github/PULL_REQUEST_TEMPLATE\.md|\.github/workflows/ci\.yml)",
+            re.IGNORECASE,
+        ),
+        "dogma review process path",
+    ),
+    (
+        re.compile(
+            r"^(?:meerkat-runtime/|meerkat-rpc/src/(?:session_runtime\.rs|handlers/auth\.rs)|"
+            r"meerkat-rest/src/(?:auth|lib\.rs)|meerkat-auth-core/|"
+            r"meerkat-machine-schema/src/catalog/dsl/auth_machine\.rs|specs/machines/auth|"
+            r"meerkat-core/src/generated/|meerkat-wasm/|sdks/|xtask/|scripts/)",
+            re.IGNORECASE,
+        ),
+        "known dogma cleanup surface",
+    ),
+)
+
+NON_CARGO_DOGMA_CAMPAIGN_SURFACE_PATHS: tuple[tuple[re.Pattern[str], str], ...] = (
+    (
+        re.compile(r"^(?:sdks/[^/]+/src/|xtask/src/)", re.IGNORECASE),
+        "known dogma campaign source deletion",
+    ),
+    (
+        re.compile(r"^specs/(?:machines|compositions)/", re.IGNORECASE),
+        "known dogma campaign source deletion",
+    ),
+)
+
+NON_PRODUCTION_WORKSPACE_MEMBER_PREFIXES = (
+    "test-fixtures/",
+    "tests/",
+    "vendor/",
+)
+
+NON_PRODUCTION_WORKSPACE_MEMBERS = {
+    "xtask",
+}
+
+DOGMA_GATE_OWNING_PATHS: tuple[tuple[re.Pattern[str], str], ...] = (
+    (re.compile(r"^Makefile$"), "dogma gate-owning path"),
+    (
+        re.compile(r"^\.github/(?:PULL_REQUEST_TEMPLATE\.md|workflows/ci\.yml)$"),
+        "dogma gate-owning path",
+    ),
+    (
+        re.compile(
+            r"^scripts/(?:dogma_cleanup_gate\.py|tests/dogma_cleanup_gate_test\.py|"
+            r"fixtures/dogma_cleanup_gate/)"
+        ),
+        "dogma gate-owning path",
+    ),
+    (re.compile(r"^docs/process/dogma-cleanup-gate\.md$"), "dogma gate-owning path"),
+)
+
+DOGMA_CLEANUP_DIFF_SIGNAL = re.compile(
+    r"(?<![A-Za-z0-9])(?:dogma|old[-_ ]path|old authority|local authority|public carrier|"
+    r"canonicali[sz]ation beside the old path|runtime metadata|surface request lifecycle|"
+    r"machine governance|legacy|compat(?:ibility)?|fallback|mirror(?:ed)?|"
+    r"carrier|cache|json bag|raw[_ -]?json|string mirror|surface|"
+    r"wrapper[-_ ]only|adapter|preferred[-_ ]path|route removed|not exported|"
+    r"AuthMachine|OAuth|SDK|WASM|scanner|allowlist)(?![A-Za-z0-9])",
+    re.IGNORECASE,
+)
+
+STRUCTURAL_SOURCE_DELETION = re.compile(
+    r"""
+    ^-\s*
+    (?:
+      (?:pub(?:\([^)]*\))?\s+)?
+      (?:(?:async|unsafe|extern)\s+)*
+      (?:fn|struct|enum|trait|type|const|static|mod)\s+[A-Za-z_][A-Za-z0-9_]*
+      |
+      (?:pub(?:\([^)]*\))?\s+)?[A-Za-z_][A-Za-z0-9_]*\s*:\s*
+      |
+      export\s+(?:interface|type|class|function|const)\s+[A-Za-z_][A-Za-z0-9_]*
+      |
+      (?:unsafe\s+)?
+      impl(?:\s*<[^>{}]+>)?\s+
+      (?:
+        [A-Za-z_][A-Za-z0-9_:]*(?:\s*<[^>{}]+>)?\s+for\s+
+      )?
+      [A-Za-z_][A-Za-z0-9_:]*(?:\s*<[^>{}]+>)?\s*(?:where\b[^{}]*)?\{?
+      |
+      (?:router|route|routes|endpoint|handler)\s*[.(]
+      |
+      [A-Z][A-Za-z0-9_]*(?:\s*\([^)]*\)|\s*\{[^}]*\})?\s*,?\s*(?://.*)?
+    )
+    """,
+    re.VERBOSE,
+)
+
+GENERATED_OR_SCHEMA_PATH = re.compile(
+    r"(^schemas/|^schema/|/schemas?/|^artifacts/.*(?:schema|generated|sdk)|"
+    r"(?:^|/)src/generated/|"
+    r"^sdks/[^/]+/(?:dist|generated|src/generated)/|"
+    r"(?:^|/)(?:openapi|schema|schemas)[^/]*\.(?:json|yaml|yml)$|"
+    r"\.(?:schema|schemas)\.(?:json|yaml|yml)$)",
+    re.IGNORECASE,
+)
+
+IMPLEMENTATION_SUFFIXES = {
+    ".rs",
+    ".py",
+    ".ts",
+    ".tsx",
+    ".js",
+    ".mjs",
+    ".cjs",
+    ".sh",
+    ".toml",
+    ".json",
+    ".yaml",
+    ".yml",
+}
+
+
+@dataclass(frozen=True)
+class ProofEntry:
+    old_path: str
+    classification: str
+    search_literal: str
+    proof: str
+    follow_up: str
+
+
+@dataclass(frozen=True)
+class AddedLine:
+    path: str
+    line: str
+
+
+@dataclass(frozen=True)
+class ChangedLine:
+    path: str
+    line: str
+
+
+@dataclass(frozen=True)
+class GitHubPullRequest:
+    title: str
+    body: str
+    labels: tuple[str, ...]
+    head_sha: str
+
+
+def fail(message: str) -> None:
+    print(f"dogma cleanup gate failed: {message}", file=sys.stderr)
+    raise SystemExit(1)
+
+
+def run(cmd: list[str], cwd: Path, check: bool = True) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(cmd, cwd=cwd, text=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE, check=check)
+
+
+def git_output(args: list[str], cwd: Path) -> str:
+    try:
+        return run(["git", *args], cwd=cwd).stdout.strip()
+    except subprocess.CalledProcessError as exc:
+        detail = exc.stderr.strip() or exc.stdout.strip()
+        fail(f"git {' '.join(args)} failed: {detail}")
+
+
+def git_ref_exists(ref: str, cwd: Path) -> bool:
+    result = run(["git", "rev-parse", "--verify", "--quiet", ref], cwd=cwd, check=False)
+    return result.returncode == 0
+
+
+def resolve_base_ref(repo: Path, requested: str) -> str:
+    if git_ref_exists(requested, repo):
+        return requested
+    if requested == "origin/main":
+        for fallback in ("main", "master"):
+            if git_ref_exists(fallback, repo):
+                return fallback
+    fail(f"base ref `{requested}` was not found; set DOGMA_CLEANUP_BASE or pass --base")
+
+
+def normalize_heading(value: str) -> str:
+    value = re.sub(r"[`*_]", "", value).strip().lower()
+    return re.sub(r"[^a-z0-9]+", " ", value).strip()
+
+
+def markdown_headings(markdown: str) -> list[tuple[int, str, int, int]]:
+    headings: list[tuple[int, str, int, int]] = []
+    in_fence = False
+    fence_marker = ""
+    offset = 0
+    for line in markdown.splitlines(keepends=True):
+        fence = re.match(r"^\s*(```+|~~~+)", line)
+        if fence:
+            marker = fence.group(1)
+            if in_fence and marker[0] == fence_marker[0] and len(marker) >= len(fence_marker):
+                in_fence = False
+                fence_marker = ""
+            elif not in_fence:
+                in_fence = True
+                fence_marker = marker
+            offset += len(line)
+            continue
+        if not in_fence:
+            heading = re.match(r"^(#{1,6})\s+(.+?)\s*$", line.rstrip("\r\n"))
+            if heading:
+                headings.append((len(heading.group(1)), heading.group(2), offset, offset + len(line)))
+        offset += len(line)
+    return headings
+
+
+def find_section(markdown: str, heading: str) -> str | None:
+    wanted = normalize_heading(heading)
+    headings = markdown_headings(markdown)
+    for index, (level, title, start_offset, end_offset) in enumerate(headings):
+        if normalize_heading(title) != wanted:
+            continue
+        start = end_offset
+        end = len(markdown)
+        for later_level, _later_title, later_start, _later_end in headings[index + 1 :]:
+            if later_level <= level:
+                end = later_start
+                break
+        return markdown[start:end]
+    return None
+
+
+def require_heading(markdown: str, heading: str) -> str:
+    section = find_section(markdown, heading)
+    if section is None:
+        fail(f"Review Readiness Packet is missing required heading: {heading}")
+    return section
+
+
+def split_table_row(line: str) -> list[str]:
+    return [cell.strip() for cell in line.strip().strip("|").split("|")]
+
+
+def is_separator_row(line: str) -> bool:
+    cells = split_table_row(line)
+    return bool(cells) and all(re.fullmatch(r":?-{3,}:?", cell.strip()) for cell in cells)
+
+
+def strip_cell(value: str) -> str:
+    value = value.replace("<br>", " ").replace("<br/>", " ").replace("<br />", " ")
+    value = value.strip()
+    if value.startswith("`") and value.endswith("`") and len(value) >= 2:
+        value = value[1:-1]
+    return value.strip()
+
+
+def header_key(value: str) -> str:
+    value = strip_cell(value).lower()
+    return re.sub(r"[^a-z0-9]+", "_", value).strip("_")
+
+
+def parse_proof_entries(section: str) -> list[ProofEntry]:
+    lines = section.splitlines()
+    for index, line in enumerate(lines):
+        if not line.lstrip().startswith("|"):
+            continue
+        if index + 1 >= len(lines) or not is_separator_row(lines[index + 1]):
+            continue
+        headers = [header_key(cell) for cell in split_table_row(line)]
+        if "old_path" not in headers or "classification" not in headers:
+            continue
+        rows: list[ProofEntry] = []
+        for row_line in lines[index + 2 :]:
+            if not row_line.lstrip().startswith("|"):
+                break
+            cells = split_table_row(row_line)
+            if len(cells) < len(headers):
+                cells.extend([""] * (len(headers) - len(cells)))
+            row = {headers[cell_index]: strip_cell(cells[cell_index]) for cell_index in range(len(headers))}
+            old_path = row.get("old_path", "")
+            classification = row.get("classification", "")
+            search_literal = row.get("search_literal") or old_path
+            proof = row.get("mechanical_proof", "") or row.get("proof", "")
+            follow_up = row.get("follow_up", "") or row.get("followup", "")
+            rows.append(
+                ProofEntry(
+                    old_path=old_path,
+                    classification=classification,
+                    search_literal=search_literal,
+                    proof=proof,
+                    follow_up=follow_up,
+                )
+            )
+        return rows
+    return []
+
+
+def canonical_classification(value: str) -> str | None:
+    normalized = re.sub(r"[^a-z0-9]+", " ", strip_cell(value).lower()).strip()
+    if normalized == "deleted":
+        return "deleted"
+    if normalized in {
+        "uncallable",
+        "made uncallable",
+        "made uncallable at boundary",
+        "uncallable at boundary",
+        "boundary uncallable",
+    }:
+        return "uncallable"
+    if normalized in {
+        "retained follow up",
+        "retained with linked follow up",
+        "intentionally retained with linked follow up",
+        "intentionally retained",
+    }:
+        return "retained"
+    return None
+
+
+def proof_has_forbidden_language(section: str) -> list[str]:
+    messages: list[str] = []
+    for pattern, message in FORBIDDEN_PROOF_PATTERNS:
+        if re.search(pattern, section, flags=re.IGNORECASE):
+            messages.append(message)
+    return messages
+
+
+def has_uncallable_boundary_proof(proof: str) -> bool:
+    return any(pattern.search(proof) is not None for pattern in UNCALLABLE_PROOF_PATTERNS)
+
+
+def uses_non_production_only_boundary_proof(proof: str) -> bool:
+    return (
+        NON_PRODUCTION_PROOF_CONTEXT.search(proof) is not None
+        and has_uncallable_boundary_proof(proof)
+        and PRODUCTION_BOUNDARY_CONTEXT.search(proof) is None
+    )
+
+
+def validate_packet(markdown: str, head_sha: str) -> list[ProofEntry]:
+    readiness_section = require_heading(markdown, "Review Readiness Packet")
+    proof_section = require_heading(markdown, "Old Path Amputation Proof")
+    require_heading(markdown, "Complexity Delta")
+    require_heading(markdown, "Sample Passing Old Path Amputation Proof")
+    require_heading(markdown, "Sample Failing Old Path Amputation Proof")
+
+    head_match = re.search(
+        r"(?im)^\s*Current head SHA\s*:\s*`?([0-9a-f]{40})`?\s*$",
+        readiness_section,
+    )
+    if not head_match:
+        fail("Review Readiness Packet must include a `Current head SHA: <sha>` line")
+    packet_head = head_match.group(1)
+    if packet_head != head_sha:
+        fail(f"Review Readiness Packet Current head SHA must be {head_sha}")
+    if not re.search(r"\bcommand output\b", markdown, flags=re.IGNORECASE):
+        fail("Review Readiness Packet must include command output")
+
+    entries = parse_proof_entries(proof_section)
+    if not entries:
+        fail("Old Path Amputation Proof must contain a markdown table with Old path and Classification columns")
+
+    section_forbidden = proof_has_forbidden_language(proof_section)
+    if section_forbidden:
+        fail("Old Path Amputation Proof uses non-amputating proof language: " + "; ".join(section_forbidden))
+
+    for entry in entries:
+        forbidden = proof_has_forbidden_language(
+            "\n".join([entry.classification, entry.proof, entry.follow_up])
+        )
+        if forbidden:
+            fail(
+                f"Old Path Amputation Proof row `{entry.old_path}` uses non-amputating proof language: "
+                + "; ".join(forbidden)
+            )
+        if not entry.old_path or entry.old_path.lower() in {"n/a", "none", "not applicable"}:
+            fail("each Old Path Amputation Proof row must name an old path")
+        classification = canonical_classification(entry.classification)
+        if classification is None:
+            fail(
+                "Old Path Amputation Proof classifications must be deleted, "
+                "made uncallable at boundary, or retained with linked follow-up"
+            )
+        if classification in {"deleted", "uncallable"}:
+            literal = entry.search_literal.strip()
+            if len(literal) < 3:
+                fail(
+                    f"{classification} old path `{entry.old_path}` needs a search literal "
+                    "of at least 3 characters"
+                )
+            if not literal_names_old_path(entry):
+                fail(
+                    f"{classification} old path `{entry.old_path}` search literal `{literal}` "
+                    "must name or overlap the old path"
+                )
+        if classification == "retained":
+            if not re.search(r"\bLUC-\d+\b|https?://", entry.follow_up):
+                fail(f"retained old path `{entry.old_path}` must link a follow-up")
+            fail(
+                f"retained old path `{entry.old_path}` is non-clean residual work; "
+                "split it out or move the PR to Rework until the old path is deleted "
+                "or made uncallable"
+            )
+        if classification == "uncallable":
+            if uses_non_production_only_boundary_proof(entry.proof):
+                fail(
+                    f"uncallable old path `{entry.old_path}` cites only non-production fixture, "
+                    "harness, mock, or unit-test evidence; cite production-boundary evidence"
+                )
+            if not has_uncallable_boundary_proof(entry.proof):
+                fail(
+                    f"uncallable old path `{entry.old_path}` must cite mechanical boundary proof "
+                    "such as compile failure, rejected calls, removed route/export, or not-callable evidence"
+                )
+    return entries
+
+
+def changed_files(repo: Path, base: str) -> list[str]:
+    merge_base = git_output(["merge-base", base, "HEAD"], repo)
+    outputs = [
+        git_output(["diff", "--name-only", "--diff-filter=ACDMR", f"{merge_base}..HEAD", "--"], repo),
+        git_output(["diff", "--cached", "--name-only", "--diff-filter=ACDMR", "--"], repo),
+        git_output(["diff", "--name-only", "--diff-filter=ACDMR", "--"], repo),
+        git_output(["ls-files", "--others", "--exclude-standard"], repo),
+    ]
+    seen: set[str] = set()
+    files: list[str] = []
+    for output in outputs:
+        for line in output.splitlines():
+            if line and line not in seen:
+                seen.add(line)
+                files.append(line)
+    return files
+
+
+def added_lines(repo: Path, base: str) -> list[AddedLine]:
+    merge_base = git_output(["merge-base", base, "HEAD"], repo)
+    diffs = [
+        git_output(["diff", "--unified=0", "--no-ext-diff", f"{merge_base}..HEAD", "--"], repo),
+        git_output(["diff", "--cached", "--unified=0", "--no-ext-diff", "--"], repo),
+        git_output(["diff", "--unified=0", "--no-ext-diff", "--"], repo),
+    ]
+    current_path = ""
+    lines: list[AddedLine] = []
+    for diff in diffs:
+        for line in diff.splitlines():
+            if line.startswith("+++ b/"):
+                current_path = line[6:]
+                continue
+            if line.startswith("+") and not line.startswith("+++"):
+                lines.append(AddedLine(current_path, line))
+    untracked = git_output(["ls-files", "--others", "--exclude-standard"], repo)
+    for rel_path in untracked.splitlines():
+        path = repo / rel_path
+        try:
+            for line in path.read_text(encoding="utf-8").splitlines():
+                lines.append(AddedLine(rel_path, f"+{line}"))
+        except (FileNotFoundError, UnicodeDecodeError):
+            continue
+    return lines
+
+
+def changed_diff_lines(repo: Path, base: str) -> list[ChangedLine]:
+    merge_base = git_output(["merge-base", base, "HEAD"], repo)
+    diffs = [
+        git_output(["diff", "--unified=0", "--no-ext-diff", f"{merge_base}..HEAD", "--"], repo),
+        git_output(["diff", "--cached", "--unified=0", "--no-ext-diff", "--"], repo),
+        git_output(["diff", "--unified=0", "--no-ext-diff", "--"], repo),
+    ]
+    lines: list[ChangedLine] = []
+    for diff in diffs:
+        current_path = ""
+        old_path = ""
+        for line in diff.splitlines():
+            if line.startswith("--- a/"):
+                old_path = line[6:]
+                if not current_path:
+                    current_path = old_path
+                continue
+            if line.startswith("+++ b/"):
+                current_path = line[6:]
+                continue
+            if line == "+++ /dev/null":
+                current_path = old_path
+                continue
+            if line.startswith(("+", "-")) and not line.startswith(("+++", "---")):
+                lines.append(ChangedLine(current_path, line))
+    untracked = git_output(["ls-files", "--others", "--exclude-standard"], repo)
+    for rel_path in untracked.splitlines():
+        path = repo / rel_path
+        try:
+            for line in path.read_text(encoding="utf-8").splitlines():
+                lines.append(ChangedLine(rel_path, f"+{line}"))
+        except (FileNotFoundError, UnicodeDecodeError):
+            continue
+    return lines
+
+
+def is_generated_or_schema(path: str) -> bool:
+    return GENERATED_OR_SCHEMA_PATH.search(path) is not None
+
+
+def is_docs_scripts_or_tests(path: str) -> bool:
+    if path == "Makefile":
+        return True
+    if path.startswith(("docs/", "scripts/", ".github/", "tests/")):
+        return True
+    if "/tests/" in path or "/fixtures/" in path or path.endswith(("_test.rs", ".md", ".mdx")):
+        return True
+    return False
+
+
+def is_impl_scan_path(path: str) -> bool:
+    if is_docs_scripts_or_tests(path):
+        return False
+    return Path(path).suffix in IMPLEMENTATION_SUFFIXES
+
+
+def is_reference_scan_path(path: str) -> bool:
+    if path.startswith(("docs/", ".github/", "tests/")):
+        return False
+    if "/tests/" in path or "/fixtures/" in path or path.endswith((".md", ".mdx")):
+        return False
+    return Path(path).suffix in IMPLEMENTATION_SUFFIXES
+
+
+def validate_complexity_delta(markdown: str, files: list[str]) -> None:
+    section = require_heading(markdown, "Complexity Delta")
+    required = {
+        "Docs/scripts/tests": r"^\s*[-*]?\s*Docs/scripts/tests\s*:\s*(.+)$",
+        "Non-test implementation": r"^\s*[-*]?\s*Non-test implementation\s*:\s*(.+)$",
+        "Generated/schema churn": r"^\s*[-*]?\s*Generated/schema churn\s*:\s*(.+)$",
+    }
+    found: dict[str, str] = {}
+    for label, pattern in required.items():
+        match = re.search(pattern, section, flags=re.IGNORECASE | re.MULTILINE)
+        if not match:
+            fail(f"Complexity Delta must separate `{label}`")
+        found[label] = match.group(1).strip()
+
+    generated = [path for path in files if is_generated_or_schema(path)]
+    generated_line = found["Generated/schema churn"]
+    if generated:
+        if re.search(r"\b(?:0|none|no)\b", generated_line, flags=re.IGNORECASE):
+            fail(
+                "Complexity Delta says generated/schema churn is absent, "
+                f"but changed generated/schema paths exist: {', '.join(generated)}"
+            )
+        if str(len(generated)) not in generated_line:
+            fail(
+                "Complexity Delta must include the generated/schema changed-file count "
+                f"({len(generated)}) when generated/schema paths changed"
+            )
+
+
+def validate_diff_hygiene(lines: Iterable[AddedLine]) -> None:
+    public_carrier_hits: list[str] = []
+    shim_hits: list[str] = []
+    for added in lines:
+        if not is_impl_scan_path(added.path):
+            continue
+        if PUBLIC_CARRIER_NAME.search(added.line):
+            public_carrier_hits.append(f"{added.path}: {added.line[1:].strip()}")
+        if COMPAT_SHIM_LINE.search(added.line):
+            shim_hits.append(f"{added.path}: {added.line[1:].strip()}")
+    if public_carrier_hits:
+        fail("new public carrier-like names found:\n  " + "\n  ".join(public_carrier_hits))
+    if shim_hits:
+        fail("broad compatibility shim language found in added implementation lines:\n  " + "\n  ".join(shim_hits))
+
+
+def tracked_files(repo: Path) -> list[str]:
+    outputs = [
+        git_output(["ls-files"], repo),
+        git_output(["ls-files", "--others", "--exclude-standard"], repo),
+    ]
+    seen: set[str] = set()
+    files: list[str] = []
+    for output in outputs:
+        for line in output.splitlines():
+            if line and line not in seen:
+                seen.add(line)
+                files.append(line)
+    return files
+
+
+def production_ref_paths(paths: Iterable[str]) -> list[str]:
+    selected: list[str] = []
+    for path in paths:
+        if is_reference_scan_path(path):
+            selected.append(path)
+    return selected
+
+
+def normalize_reference_fragment(value: str) -> str:
+    normalized = re.sub(r"[^a-z0-9]+", " ", value.lower()).strip()
+    return re.sub(r"\s+", " ", normalized)
+
+
+def workspace_members_from_manifest_text(text: str) -> tuple[str, ...]:
+    if tomllib is not None:
+        try:
+            data = tomllib.loads(text)
+        except tomllib.TOMLDecodeError:
+            return ()
+        workspace = data.get("workspace", {})
+        members = workspace.get("members", []) if isinstance(workspace, dict) else []
+        return tuple(member for member in members if isinstance(member, str))
+
+    members_match = re.search(r"(?ms)^\s*members\s*=\s*\[(.*?)\]", text)
+    if members_match is None:
+        return ()
+    return tuple(re.findall(r'"([^"]+)"', members_match.group(1)))
+
+
+def workspace_members_from_manifest(repo: Path) -> tuple[str, ...]:
+    manifest = repo / "Cargo.toml"
+    try:
+        text = manifest.read_text(encoding="utf-8")
+    except FileNotFoundError:
+        return ()
+    return workspace_members_from_manifest_text(text)
+
+
+def git_file_text(repo: Path, ref: str, path: str) -> str | None:
+    result = run(["git", "show", f"{ref}:{path}"], cwd=repo, check=False)
+    if result.returncode != 0:
+        return None
+    return result.stdout
+
+
+def workspace_members_from_git_ref(repo: Path, ref: str) -> tuple[str, ...]:
+    text = git_file_text(repo, ref, "Cargo.toml")
+    if text is None:
+        return ()
+    return workspace_members_from_manifest_text(text)
+
+
+def expand_workspace_member(repo: Path, member: str) -> list[str]:
+    normalized = member.strip().strip("/")
+    if not normalized:
+        return []
+    if "*" not in normalized:
+        return [PurePosixPath(normalized).as_posix()]
+    expanded: list[str] = []
+    for path in sorted(repo.glob(normalized)):
+        if path.is_dir():
+            expanded.append(path.relative_to(repo).as_posix())
+    return expanded
+
+
+def expand_workspace_member_at_ref(repo: Path, ref: str, member: str) -> list[str]:
+    normalized = member.strip().strip("/")
+    if not normalized:
+        return []
+    if "*" not in normalized:
+        return [PurePosixPath(normalized).as_posix()]
+    result = run(["git", "ls-tree", "-r", "--name-only", ref, "--"], cwd=repo, check=False)
+    if result.returncode != 0:
+        return []
+    expanded: list[str] = []
+    for file_path in result.stdout.splitlines():
+        if not file_path.endswith("/Cargo.toml"):
+            continue
+        candidate = file_path.removesuffix("/Cargo.toml")
+        if PurePosixPath(candidate).match(normalized):
+            expanded.append(PurePosixPath(candidate).as_posix())
+    return sorted(set(expanded))
+
+
+def is_production_workspace_member(member: str) -> bool:
+    normalized = PurePosixPath(member.strip().strip("/")).as_posix()
+    if normalized in NON_PRODUCTION_WORKSPACE_MEMBERS:
+        return False
+    return not any(normalized.startswith(prefix) for prefix in NON_PRODUCTION_WORKSPACE_MEMBER_PREFIXES)
+
+
+def production_workspace_src_roots(repo: Path, base: str | None = None) -> tuple[str, ...]:
+    roots: list[str] = []
+    seen: set[str] = set()
+
+    def add_root(member_path: str) -> None:
+        if not is_production_workspace_member(member_path):
+            return
+        root = f"{member_path}/src/"
+        if root not in seen:
+            seen.add(root)
+            roots.append(root)
+
+    for member in workspace_members_from_manifest(repo):
+        for expanded in expand_workspace_member(repo, member):
+            add_root(expanded)
+    if base is not None:
+        merge_base = git_output(["merge-base", base, "HEAD"], repo)
+        for member in workspace_members_from_git_ref(repo, merge_base):
+            for expanded in expand_workspace_member_at_ref(repo, merge_base, member):
+                add_root(expanded)
+    return tuple(roots)
+
+
+def production_workspace_source_path_reason(repo: Path, path: str, base: str | None = None) -> str | None:
+    if not is_reference_scan_path(path) or is_generated_or_schema(path):
+        return None
+    normalized = PurePosixPath(path).as_posix()
+    for src_root in production_workspace_src_roots(repo, base):
+        if normalized.startswith(src_root):
+            return "production workspace crate source deletion"
+    return None
+
+
+def literal_matches(repo: Path, literal: str, paths: Iterable[str]) -> list[str]:
+    matches: list[str] = []
+    if not literal or literal.lower() in {"none", "n/a", "not applicable"}:
+        return matches
+    normalized_literal = normalize_reference_fragment(literal)
+    for rel_path in paths:
+        path = repo / rel_path
+        try:
+            text = path.read_text(encoding="utf-8")
+        except UnicodeDecodeError:
+            continue
+        except FileNotFoundError:
+            continue
+        for index, line in enumerate(text.splitlines(), start=1):
+            normalized_line = normalize_reference_fragment(line)
+            if literal in line or (
+                normalized_literal and normalized_literal in normalized_line
+            ):
+                matches.append(f"{rel_path}:{index}:{line.strip()}")
+    return matches
+
+
+GENERIC_OLD_PATH_TOKENS = {
+    "old",
+    "legacy",
+    "previous",
+    "existing",
+    "former",
+    "deprecated",
+    "path",
+    "paths",
+    "route",
+    "routes",
+    "endpoint",
+    "endpoints",
+    "api",
+    "apis",
+    "helper",
+    "helpers",
+    "service",
+    "services",
+    "surface",
+    "surfaces",
+    "export",
+    "exports",
+    "action",
+    "actions",
+}
+
+
+def literal_names_old_path(entry: ProofEntry) -> bool:
+    old_path = strip_cell(entry.old_path)
+    literal = strip_cell(entry.search_literal)
+    old_norm = normalize_reference_fragment(old_path)
+    literal_norm = normalize_reference_fragment(literal)
+    if not old_norm or not literal_norm:
+        return False
+    if old_norm in literal_norm or literal_norm in old_norm:
+        return True
+    old_tokens = {
+        token
+        for token in re.findall(r"[a-z0-9_]{3,}", old_path.lower())
+        if token not in GENERIC_OLD_PATH_TOKENS
+    }
+    literal_tokens = {
+        token
+        for token in re.findall(r"[a-z0-9_]{3,}", literal.lower())
+        if token not in GENERIC_OLD_PATH_TOKENS
+    }
+    return bool(old_tokens & literal_tokens)
+
+
+def validate_old_path_references(repo: Path, entries: Iterable[ProofEntry]) -> None:
+    paths = production_ref_paths(tracked_files(repo))
+    for entry in entries:
+        classification = canonical_classification(entry.classification)
+        if classification not in {"deleted", "uncallable"}:
+            continue
+        literal = entry.search_literal.strip()
+        matches = literal_matches(repo, literal, paths)
+        if not matches:
+            continue
+        if classification == "deleted":
+            fail(
+                f"deleted old path `{entry.old_path}` still has production references for `{literal}`:\n  "
+                + "\n  ".join(matches[:20])
+            )
+        fail(
+            f"uncallable old path `{entry.old_path}` still has production references for `{literal}`; "
+            "remove the callable production carrier, prove it as inert/fail-closed code, or classify "
+            "remaining work as retained with linked follow-up:\n  "
+            + "\n  ".join(matches[:20])
+        )
+
+
+def dogma_review_path_reason(path: str) -> str | None:
+    for pattern, reason in DOGMA_CLEANUP_REVIEW_PATHS:
+        if pattern.search(path):
+            return reason
+    return None
+
+
+def dogma_campaign_surface_path_reason(repo: Path, path: str, base: str | None = None) -> str | None:
+    reason = production_workspace_source_path_reason(repo, path, base)
+    if reason is not None:
+        return reason
+    if not is_reference_scan_path(path) or is_generated_or_schema(path):
+        return None
+    for pattern, reason in NON_CARGO_DOGMA_CAMPAIGN_SURFACE_PATHS:
+        if pattern.search(path):
+            return reason
+    return None
+
+
+def dogma_gate_owning_path_reason(path: str) -> str | None:
+    for pattern, reason in DOGMA_GATE_OWNING_PATHS:
+        if pattern.search(path):
+            return reason
+    return None
+
+
+def stable_diff_path_reason(path: str) -> str | None:
+    reason = dogma_gate_owning_path_reason(path)
+    if reason is not None:
+        return reason
+    reason = dogma_review_path_reason(path)
+    if reason is not None:
+        return reason
+    if is_reference_scan_path(path):
+        return "ordinary source path"
+    return None
+
+
+def is_structural_source_deletion(line: str) -> bool:
+    return STRUCTURAL_SOURCE_DELETION.search(line) is not None
+
+
+def stable_dogma_cleanup_signals(repo: Path, base: str) -> list[str]:
+    signals: list[str] = []
+    files = changed_files(repo, base)
+    for path in files:
+        reason = dogma_gate_owning_path_reason(path)
+        if reason is not None:
+            signals.append(f"{path}: {reason}")
+            continue
+        if DOGMA_CLEANUP_DIRECT_PATH.search(path):
+            signals.append(f"{path}: dogma path")
+
+    for changed in changed_diff_lines(repo, base):
+        reason = stable_diff_path_reason(changed.path)
+        if reason is not None and DOGMA_CLEANUP_DIFF_SIGNAL.search(changed.line):
+            signals.append(f"{changed.path}: {reason}: {changed.line[1:].strip()}")
+            continue
+        campaign_reason = dogma_campaign_surface_path_reason(repo, changed.path, base)
+        if campaign_reason is not None and is_structural_source_deletion(changed.line):
+            signals.append(f"{changed.path}: {campaign_reason}: {changed.line[1:].strip()}")
+
+    seen: set[str] = set()
+    deduped: list[str] = []
+    for signal in signals:
+        if signal in seen:
+            continue
+        seen.add(signal)
+        deduped.append(signal)
+        if len(deduped) >= 5:
+            break
+    return deduped
+
+
+def read_github_pull_request(event_path: Path) -> GitHubPullRequest | None:
+    try:
+        event = json.loads(event_path.read_text(encoding="utf-8"))
+    except FileNotFoundError:
+        fail(f"GitHub event payload not found: {event_path}")
+    except json.JSONDecodeError as exc:
+        fail(f"GitHub event payload is not valid JSON: {exc}")
+    pull_request = event.get("pull_request")
+    if not isinstance(pull_request, dict):
+        return None
+    labels = []
+    for label in pull_request.get("labels") or []:
+        if isinstance(label, dict) and isinstance(label.get("name"), str):
+            labels.append(label["name"])
+    head = pull_request.get("head")
+    head_sha = head.get("sha", "") if isinstance(head, dict) else ""
+    return GitHubPullRequest(
+        title=str(pull_request.get("title") or ""),
+        body=str(pull_request.get("body") or ""),
+        labels=tuple(labels),
+        head_sha=head_sha,
+    )
+
+
+def dogma_cleanup_required(pr: GitHubPullRequest, repo: Path, base: str) -> tuple[bool, str]:
+    title_and_labels = "\n".join([pr.title, *pr.labels])
+    if DOGMA_CLEANUP_SIGNAL.search(title_and_labels) is not None:
+        return True, "title or labels"
+    if DOGMA_CLEANUP_BODY_MARKER.search(pr.body) is not None:
+        return True, "PR body marker"
+    signals = stable_dogma_cleanup_signals(repo, base)
+    if signals:
+        return True, "stable diff signal: " + "; ".join(signals)
+    return False, "no dogma cleanup PR signal or stable diff signal"
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Validate a dogma cleanup Review Readiness Packet.")
+    parser.add_argument("--packet", help="Markdown file containing the Review Readiness Packet.")
+    parser.add_argument("--repo", default=".", help="Repository root. Defaults to current directory.")
+    parser.add_argument("--base", default=os.environ.get("DOGMA_CLEANUP_BASE", "origin/main"))
+    parser.add_argument("--head-sha", help="Override the current head SHA. Useful for fixtures.")
+    parser.add_argument(
+        "--github-event",
+        help=(
+            "GitHub event JSON. For pull_request events with dogma cleanup signals, "
+            "or stable dogma-shaped diff signals, the PR body is treated as the packet "
+            "when --packet is omitted."
+        ),
+    )
+    parser.add_argument(
+        "--packet-only",
+        action="store_true",
+        help="Validate packet structure/proof language only; skip git diff and reference checks.",
+    )
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    repo = Path(args.repo).resolve()
+    base = resolve_base_ref(repo, args.base)
+    packet_label = "GitHub PR body"
+    github_pr = None
+    if args.github_event:
+        github_pr = read_github_pull_request(Path(args.github_event))
+        if github_pr is None:
+            print("Dogma cleanup gate skipped: not a pull_request event.")
+            return 0
+        required, reason = dogma_cleanup_required(github_pr, repo, base)
+        if not required:
+            print(f"Dogma cleanup gate skipped: {reason}.", flush=True)
+            return 0
+        print(f"Dogma cleanup gate required by {reason}.", flush=True)
+
+    if args.packet:
+        packet_path = Path(args.packet)
+        if not packet_path.is_absolute():
+            packet_path = repo / packet_path
+        markdown = packet_path.read_text(encoding="utf-8")
+        packet_label = str(packet_path)
+    elif github_pr is not None:
+        markdown = github_pr.body
+    else:
+        fail("--packet is required unless --github-event supplies a dogma cleanup pull_request body")
+
+    head_sha = args.head_sha or (
+        github_pr.head_sha if github_pr is not None and github_pr.head_sha else ""
+    )
+    if not head_sha:
+        head_sha = git_output(["rev-parse", "HEAD"], repo)
+
+    entries = validate_packet(markdown, head_sha)
+    if not args.packet_only:
+        files = changed_files(repo, base)
+        validate_complexity_delta(markdown, files)
+        validate_diff_hygiene(added_lines(repo, base))
+        validate_old_path_references(repo, entries)
+
+    print(f"Dogma cleanup gate passed for {packet_label}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/fixtures/dogma_cleanup_gate/bare_make_boundary_packet.md
+++ b/scripts/fixtures/dogma_cleanup_gate/bare_make_boundary_packet.md
@@ -1,0 +1,34 @@
+## Review Readiness Packet
+
+Current head SHA: 0000000000000000000000000000000000000000
+
+Command output:
+
+```text
+$ make dogma-cleanup-gate DOGMA_PACKET=artifacts/review-readiness.md
+dogma cleanup gate failed: fixture proof must cite production-boundary evidence
+```
+
+## Old Path Amputation Proof
+
+| Old path | Classification | Search literal | Mechanical proof | Follow-up |
+| --- | --- | --- | --- | --- |
+| `legacy_endpoint` | made uncallable at boundary | `legacy_endpoint` | A unit test fixture rejects calls and says the old route is not callable; make test passed. | none |
+
+## Complexity Delta
+
+- Docs/scripts/tests: 1 file.
+- Non-test implementation: 0 files.
+- Generated/schema churn: 0 files.
+
+## Sample Passing Old Path Amputation Proof
+
+| Old path | Classification | Search literal | Mechanical proof | Follow-up |
+| --- | --- | --- | --- | --- |
+| `old/session-route` | deleted | `old/session-route` | No production references remain. | none |
+
+## Sample Failing Old Path Amputation Proof
+
+| Old path | Classification | Search literal | Mechanical proof | Follow-up |
+| --- | --- | --- | --- | --- |
+| `old/session-route` | wrapped | `old/session-route` | A preferred path exists beside the old route. | none |

--- a/scripts/fixtures/dogma_cleanup_gate/boundary_keyword_only_packet.md
+++ b/scripts/fixtures/dogma_cleanup_gate/boundary_keyword_only_packet.md
@@ -1,0 +1,34 @@
+## Review Readiness Packet
+
+Current head SHA: 0000000000000000000000000000000000000000
+
+Command output:
+
+```text
+$ make dogma-cleanup-gate DOGMA_PACKET=artifacts/review-readiness.md
+dogma cleanup gate failed: uncallable old path must cite mechanical boundary proof
+```
+
+## Old Path Amputation Proof
+
+| Old path | Classification | Search literal | Mechanical proof | Follow-up |
+| --- | --- | --- | --- | --- |
+| `surface_request_lifecycle_helper` | made uncallable at boundary | `surface_request_lifecycle_helper` | Boundary test covers the new route. | none |
+
+## Complexity Delta
+
+- Docs/scripts/tests: 1 file.
+- Non-test implementation: 0 files.
+- Generated/schema churn: 0 files.
+
+## Sample Passing Old Path Amputation Proof
+
+| Old path | Classification | Search literal | Mechanical proof | Follow-up |
+| --- | --- | --- | --- | --- |
+| `old/session-route` | deleted | `old/session-route` | No production references remain. | none |
+
+## Sample Failing Old Path Amputation Proof
+
+| Old path | Classification | Search literal | Mechanical proof | Follow-up |
+| --- | --- | --- | --- | --- |
+| `old/session-route` | wrapped | `old/session-route` | A preferred path exists beside the old route. | none |

--- a/scripts/fixtures/dogma_cleanup_gate/callable_wrapper_packet.md
+++ b/scripts/fixtures/dogma_cleanup_gate/callable_wrapper_packet.md
@@ -1,0 +1,34 @@
+## Review Readiness Packet
+
+Current head SHA: 0000000000000000000000000000000000000000
+
+Command output:
+
+```text
+$ make dogma-cleanup-gate DOGMA_PACKET=artifacts/review-readiness.md
+Dogma cleanup gate passed for artifacts/review-readiness.md
+```
+
+## Old Path Amputation Proof
+
+| Old path | Classification | Search literal | Mechanical proof | Follow-up |
+| --- | --- | --- | --- | --- |
+| `surface_request_lifecycle_helper` | made uncallable at boundary | `surface_request_lifecycle_helper` | Boundary test exercises the replacement wrapper while the old helper remains callable for compatibility. | none |
+
+## Complexity Delta
+
+- Docs/scripts/tests: 1 file.
+- Non-test implementation: 0 files.
+- Generated/schema churn: 0 files.
+
+## Sample Passing Old Path Amputation Proof
+
+| Old path | Classification | Search literal | Mechanical proof | Follow-up |
+| --- | --- | --- | --- | --- |
+| `old/session-route` | deleted | `old/session-route` | No production references remain. | none |
+
+## Sample Failing Old Path Amputation Proof
+
+| Old path | Classification | Search literal | Mechanical proof | Follow-up |
+| --- | --- | --- | --- | --- |
+| `old/session-route` | wrapped | `old/session-route` | A preferred path exists beside the old route. | none |

--- a/scripts/fixtures/dogma_cleanup_gate/caller_legacy_endpoint_packet.md
+++ b/scripts/fixtures/dogma_cleanup_gate/caller_legacy_endpoint_packet.md
@@ -1,0 +1,34 @@
+## Review Readiness Packet
+
+Current head SHA: 0000000000000000000000000000000000000000
+
+Command output:
+
+```text
+$ make dogma-cleanup-gate DOGMA_PACKET=artifacts/review-readiness.md
+dogma cleanup gate failed: proof admits old callers can still use the old path
+```
+
+## Old Path Amputation Proof
+
+| Old path | Classification | Search literal | Mechanical proof | Follow-up |
+| --- | --- | --- | --- | --- |
+| `legacy_endpoint` | made uncallable at boundary | `legacy_endpoint` | Rejected calls prove the boundary while callers may continue using a legacy endpoint during migration. | none |
+
+## Complexity Delta
+
+- Docs/scripts/tests: 1 file.
+- Non-test implementation: 0 files.
+- Generated/schema churn: 0 files.
+
+## Sample Passing Old Path Amputation Proof
+
+| Old path | Classification | Search literal | Mechanical proof | Follow-up |
+| --- | --- | --- | --- | --- |
+| `old/session-route` | deleted | `old/session-route` | No production references remain. | none |
+
+## Sample Failing Old Path Amputation Proof
+
+| Old path | Classification | Search literal | Mechanical proof | Follow-up |
+| --- | --- | --- | --- | --- |
+| `old/session-route` | wrapped | `old/session-route` | A preferred path exists beside the old route. | none |

--- a/scripts/fixtures/dogma_cleanup_gate/compatibility_supported_packet.md
+++ b/scripts/fixtures/dogma_cleanup_gate/compatibility_supported_packet.md
@@ -1,0 +1,34 @@
+## Review Readiness Packet
+
+Current head SHA: 0000000000000000000000000000000000000000
+
+Command output:
+
+```text
+$ make dogma-cleanup-gate DOGMA_PACKET=artifacts/review-readiness.md
+dogma cleanup gate failed: compatibility-retained proof leaves the old path callable
+```
+
+## Old Path Amputation Proof
+
+| Old path | Classification | Search literal | Mechanical proof | Follow-up |
+| --- | --- | --- | --- | --- |
+| `surface_request_lifecycle_helper` | made uncallable at boundary | `surface_request_lifecycle_helper` | Boundary test verifies the old helper remains supported for compatibility. | none |
+
+## Complexity Delta
+
+- Docs/scripts/tests: 1 file.
+- Non-test implementation: 0 files.
+- Generated/schema churn: 0 files.
+
+## Sample Passing Old Path Amputation Proof
+
+| Old path | Classification | Search literal | Mechanical proof | Follow-up |
+| --- | --- | --- | --- | --- |
+| `old/session-route` | deleted | `old/session-route` | No production references remain. | none |
+
+## Sample Failing Old Path Amputation Proof
+
+| Old path | Classification | Search literal | Mechanical proof | Follow-up |
+| --- | --- | --- | --- | --- |
+| `old/session-route` | wrapped | `old/session-route` | A preferred path exists beside the old route. | none |

--- a/scripts/fixtures/dogma_cleanup_gate/github_labeled_missing_packet_event.json
+++ b/scripts/fixtures/dogma_cleanup_gate/github_labeled_missing_packet_event.json
@@ -1,0 +1,14 @@
+{
+  "pull_request": {
+    "title": "Runtime cleanup",
+    "body": "## Summary\n\nDogma cleanup PR: no\n\n- Cleanup only.",
+    "labels": [
+      {
+        "name": "dogma cleanup"
+      }
+    ],
+    "head": {
+      "sha": "0000000000000000000000000000000000000000"
+    }
+  }
+}

--- a/scripts/fixtures/dogma_cleanup_gate/github_unsignaled_dogma_shape_event.json
+++ b/scripts/fixtures/dogma_cleanup_gate/github_unsignaled_dogma_shape_event.json
@@ -1,0 +1,10 @@
+{
+  "pull_request": {
+    "title": "Shrink runtime metadata carrier",
+    "body": "## Summary\n\nDogma cleanup PR: no\n\n- Deletes a legacy metadata carrier and moves callers to the canonical runtime owner.",
+    "labels": [],
+    "head": {
+      "sha": "0000000000000000000000000000000000000000"
+    }
+  }
+}

--- a/scripts/fixtures/dogma_cleanup_gate/migration_usable_packet.md
+++ b/scripts/fixtures/dogma_cleanup_gate/migration_usable_packet.md
@@ -1,0 +1,34 @@
+## Review Readiness Packet
+
+Current head SHA: 0000000000000000000000000000000000000000
+
+Command output:
+
+```text
+$ make dogma-cleanup-gate DOGMA_PACKET=artifacts/review-readiness.md
+dogma cleanup gate failed: proof admits old callers can still use the old path
+```
+
+## Old Path Amputation Proof
+
+| Old path | Classification | Search literal | Mechanical proof | Follow-up |
+| --- | --- | --- | --- | --- |
+| `surface_request_lifecycle_helper` | made uncallable at boundary | `surface_request_lifecycle_helper` | Rejected calls prove the boundary while old clients can still use the legacy helper during migration. | none |
+
+## Complexity Delta
+
+- Docs/scripts/tests: 1 file.
+- Non-test implementation: 0 files.
+- Generated/schema churn: 0 files.
+
+## Sample Passing Old Path Amputation Proof
+
+| Old path | Classification | Search literal | Mechanical proof | Follow-up |
+| --- | --- | --- | --- | --- |
+| `old/session-route` | deleted | `old/session-route` | No production references remain. | none |
+
+## Sample Failing Old Path Amputation Proof
+
+| Old path | Classification | Search literal | Mechanical proof | Follow-up |
+| --- | --- | --- | --- | --- |
+| `old/session-route` | wrapped | `old/session-route` | A preferred path exists beside the old route. | none |

--- a/scripts/fixtures/dogma_cleanup_gate/modal_intent_retained_packet.md
+++ b/scripts/fixtures/dogma_cleanup_gate/modal_intent_retained_packet.md
@@ -1,0 +1,34 @@
+## Review Readiness Packet
+
+Current head SHA: 0000000000000000000000000000000000000000
+
+Command output:
+
+```text
+$ make dogma-cleanup-gate DOGMA_PACKET=artifacts/review-readiness.md
+dogma cleanup gate failed: proof admits old callers can still use the old path
+```
+
+## Old Path Amputation Proof
+
+| Old path | Classification | Search literal | Mechanical proof | Follow-up |
+| --- | --- | --- | --- | --- |
+| `legacy_endpoint` | made uncallable at boundary | `legacy_endpoint` | Rejected calls prove the boundary while old clients should continue using the legacy endpoint. | none |
+
+## Complexity Delta
+
+- Docs/scripts/tests: 1 file.
+- Non-test implementation: 0 files.
+- Generated/schema churn: 0 files.
+
+## Sample Passing Old Path Amputation Proof
+
+| Old path | Classification | Search literal | Mechanical proof | Follow-up |
+| --- | --- | --- | --- | --- |
+| `old/session-route` | deleted | `old/session-route` | No production references remain. | none |
+
+## Sample Failing Old Path Amputation Proof
+
+| Old path | Classification | Search literal | Mechanical proof | Follow-up |
+| --- | --- | --- | --- | --- |
+| `old/session-route` | wrapped | `old/session-route` | A preferred path exists beside the old route. | none |

--- a/scripts/fixtures/dogma_cleanup_gate/passing_packet.md
+++ b/scripts/fixtures/dogma_cleanup_gate/passing_packet.md
@@ -1,0 +1,35 @@
+## Review Readiness Packet
+
+Current head SHA: 0000000000000000000000000000000000000000
+
+Command output:
+
+```text
+$ make dogma-cleanup-gate DOGMA_PACKET=artifacts/review-readiness.md
+Dogma cleanup gate passed for artifacts/review-readiness.md
+```
+
+## Old Path Amputation Proof
+
+| Old path | Classification | Search literal | Mechanical proof | Follow-up |
+| --- | --- | --- | --- | --- |
+| `legacy/runtime-status` | deleted | `legacy/runtime-status` | `rg -F "legacy/runtime-status"` returns no production matches. | none |
+| `oauth_token_cache_fallback` | made uncallable at boundary | `oauth_token_cache_fallback` | Boundary test rejects calls before the AuthMachine lease owner. | none |
+
+## Complexity Delta
+
+- Docs/scripts/tests: 2 files.
+- Non-test implementation: 0 files.
+- Generated/schema churn: 0 files.
+
+## Sample Passing Old Path Amputation Proof
+
+| Old path | Classification | Search literal | Mechanical proof | Follow-up |
+| --- | --- | --- | --- | --- |
+| `old/session-route` | deleted | `old/session-route` | No production references remain. | none |
+
+## Sample Failing Old Path Amputation Proof
+
+| Old path | Classification | Search literal | Mechanical proof | Follow-up |
+| --- | --- | --- | --- | --- |
+| `old/session-route` | wrapped | `old/session-route` | A preferred path exists beside the old route. | none |

--- a/scripts/fixtures/dogma_cleanup_gate/preferred_path_only_packet.md
+++ b/scripts/fixtures/dogma_cleanup_gate/preferred_path_only_packet.md
@@ -1,0 +1,34 @@
+## Review Readiness Packet
+
+Current head SHA: 0000000000000000000000000000000000000000
+
+Command output:
+
+```text
+$ make dogma-cleanup-gate DOGMA_PACKET=artifacts/review-readiness.md
+dogma cleanup gate failed: preferred-path-only cleanup leaves the old path callable
+```
+
+## Old Path Amputation Proof
+
+| Old path | Classification | Search literal | Mechanical proof | Follow-up |
+| --- | --- | --- | --- | --- |
+| `surface_request_lifecycle_helper` | made uncallable at boundary | `surface_request_lifecycle_helper` | preferred-path-only test covers the new route while the old helper remains callable. | none |
+
+## Complexity Delta
+
+- Docs/scripts/tests: 1 file.
+- Non-test implementation: 0 files.
+- Generated/schema churn: 0 files.
+
+## Sample Passing Old Path Amputation Proof
+
+| Old path | Classification | Search literal | Mechanical proof | Follow-up |
+| --- | --- | --- | --- | --- |
+| `old/session-route` | deleted | `old/session-route` | No production references remain. | none |
+
+## Sample Failing Old Path Amputation Proof
+
+| Old path | Classification | Search literal | Mechanical proof | Follow-up |
+| --- | --- | --- | --- | --- |
+| `old/session-route` | wrapped | `old/session-route` | A preferred path exists beside the old route. | none |

--- a/scripts/fixtures/dogma_cleanup_gate/retained_packet.md
+++ b/scripts/fixtures/dogma_cleanup_gate/retained_packet.md
@@ -1,0 +1,34 @@
+## Review Readiness Packet
+
+Current head SHA: 0000000000000000000000000000000000000000
+
+Command output:
+
+```text
+$ make dogma-cleanup-gate DOGMA_PACKET=artifacts/review-readiness.md
+dogma cleanup gate failed: retained old path is non-clean residual work
+```
+
+## Old Path Amputation Proof
+
+| Old path | Classification | Search literal | Mechanical proof | Follow-up |
+| --- | --- | --- | --- | --- |
+| `wasm_contract_string_mirror` | retained with linked follow-up | `wasm_contract_string_mirror` | Retained only for an active SDK cutover. | LUC-999 |
+
+## Complexity Delta
+
+- Docs/scripts/tests: 1 file.
+- Non-test implementation: 0 files.
+- Generated/schema churn: 0 files.
+
+## Sample Passing Old Path Amputation Proof
+
+| Old path | Classification | Search literal | Mechanical proof | Follow-up |
+| --- | --- | --- | --- | --- |
+| `old/session-route` | deleted | `old/session-route` | No production references remain. | none |
+
+## Sample Failing Old Path Amputation Proof
+
+| Old path | Classification | Search literal | Mechanical proof | Follow-up |
+| --- | --- | --- | --- | --- |
+| `old/session-route` | wrapped | `old/session-route` | A preferred path exists beside the old route. | none |

--- a/scripts/fixtures/dogma_cleanup_gate/wrapper_only_packet.md
+++ b/scripts/fixtures/dogma_cleanup_gate/wrapper_only_packet.md
@@ -1,0 +1,34 @@
+## Review Readiness Packet
+
+Current head SHA: 0000000000000000000000000000000000000000
+
+Command output:
+
+```text
+$ make dogma-cleanup-gate DOGMA_PACKET=artifacts/review-readiness.md
+dogma cleanup gate failed: wrapped is not an amputation classification
+```
+
+## Old Path Amputation Proof
+
+| Old path | Classification | Search literal | Mechanical proof | Follow-up |
+| --- | --- | --- | --- | --- |
+| `surface_request_lifecycle_helper` | wrapped | `surface_request_lifecycle_helper` | Preferred path exists, old helper remains for compatibility. | none |
+
+## Complexity Delta
+
+- Docs/scripts/tests: 1 file.
+- Non-test implementation: 0 files.
+- Generated/schema churn: 0 files.
+
+## Sample Passing Old Path Amputation Proof
+
+| Old path | Classification | Search literal | Mechanical proof | Follow-up |
+| --- | --- | --- | --- | --- |
+| `old/session-route` | deleted | `old/session-route` | No production references remain. | none |
+
+## Sample Failing Old Path Amputation Proof
+
+| Old path | Classification | Search literal | Mechanical proof | Follow-up |
+| --- | --- | --- | --- | --- |
+| `old/session-route` | wrapped | `old/session-route` | A preferred path exists beside the old route. | none |

--- a/scripts/tests/dogma_cleanup_gate_test.py
+++ b/scripts/tests/dogma_cleanup_gate_test.py
@@ -1,0 +1,1516 @@
+#!/usr/bin/env python3
+
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+import subprocess
+import sys
+import tempfile
+import textwrap
+import unittest
+
+
+REPO_ROOT = Path(
+    os.environ.get("DOGMA_GATE_REPO_ROOT", Path(__file__).resolve().parents[2])
+).resolve()
+SCRIPT = Path(
+    os.environ.get("DOGMA_GATE_SCRIPT", REPO_ROOT / "scripts" / "dogma_cleanup_gate.py")
+).resolve()
+FIXTURE_DIR = Path(
+    os.environ.get(
+        "DOGMA_GATE_FIXTURE_DIR",
+        REPO_ROOT / "scripts" / "fixtures" / "dogma_cleanup_gate",
+    )
+).resolve()
+
+
+def run_command(args: list[str], cwd: Path) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(args, cwd=cwd, text=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+
+
+def require_success(args: list[str], cwd: Path) -> str:
+    result = run_command(args, cwd)
+    if result.returncode != 0:
+        raise AssertionError(
+            f"{args} failed with {result.returncode}\nstdout:\n{result.stdout}\nstderr:\n{result.stderr}"
+        )
+    return result.stdout.strip()
+
+
+def run_gate(args: list[str]) -> subprocess.CompletedProcess[str]:
+    env = os.environ.copy()
+    env.pop("DOGMA_CLEANUP_BASE", None)
+    return subprocess.run(
+        [sys.executable, str(SCRIPT), *args],
+        cwd=REPO_ROOT,
+        env=env,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+
+
+class DogmaCleanupGateTest(unittest.TestCase):
+    maxDiff = None
+
+    def test_packet_fixture_passes(self) -> None:
+        result = run_gate(
+            [
+                "--packet",
+                str(FIXTURE_DIR / "passing_packet.md"),
+                "--head-sha",
+                "0000000000000000000000000000000000000000",
+                "--packet-only",
+            ]
+        )
+        self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
+        self.assertIn("Dogma cleanup gate passed", result.stdout)
+
+    def test_wrapper_only_packet_fails(self) -> None:
+        result = run_gate(
+            [
+                "--packet",
+                str(FIXTURE_DIR / "wrapper_only_packet.md"),
+                "--head-sha",
+                "0000000000000000000000000000000000000000",
+                "--packet-only",
+            ]
+        )
+        self.assertNotEqual(result.returncode, 0, result.stdout + result.stderr)
+        self.assertIn("wrapped is not an amputation classification", result.stderr)
+
+    def test_preferred_path_only_packet_fails(self) -> None:
+        result = run_gate(
+            [
+                "--packet",
+                str(FIXTURE_DIR / "preferred_path_only_packet.md"),
+                "--head-sha",
+                "0000000000000000000000000000000000000000",
+                "--packet-only",
+            ]
+        )
+        self.assertNotEqual(result.returncode, 0, result.stdout + result.stderr)
+        self.assertIn("preferred-path-only cleanup leaves the old path callable", result.stderr)
+
+    def test_callable_wrapper_packet_fails(self) -> None:
+        result = run_gate(
+            [
+                "--packet",
+                str(FIXTURE_DIR / "callable_wrapper_packet.md"),
+                "--head-sha",
+                "0000000000000000000000000000000000000000",
+                "--packet-only",
+            ]
+        )
+        self.assertNotEqual(result.returncode, 0, result.stdout + result.stderr)
+        self.assertIn("proof admits the old path remains callable", result.stderr)
+
+    def test_compatibility_supported_packet_fails(self) -> None:
+        result = run_gate(
+            [
+                "--packet",
+                str(FIXTURE_DIR / "compatibility_supported_packet.md"),
+                "--head-sha",
+                "0000000000000000000000000000000000000000",
+                "--packet-only",
+            ]
+        )
+        self.assertNotEqual(result.returncode, 0, result.stdout + result.stderr)
+        self.assertIn("compatibility-retained proof leaves the old path callable", result.stderr)
+
+    def test_migration_usable_packet_fails(self) -> None:
+        result = run_gate(
+            [
+                "--packet",
+                str(FIXTURE_DIR / "migration_usable_packet.md"),
+                "--head-sha",
+                "0000000000000000000000000000000000000000",
+                "--packet-only",
+            ]
+        )
+        self.assertNotEqual(result.returncode, 0, result.stdout + result.stderr)
+        self.assertIn("proof admits old callers can still use the old path", result.stderr)
+
+    def test_caller_legacy_endpoint_packet_fails(self) -> None:
+        result = run_gate(
+            [
+                "--packet",
+                str(FIXTURE_DIR / "caller_legacy_endpoint_packet.md"),
+                "--head-sha",
+                "0000000000000000000000000000000000000000",
+                "--packet-only",
+            ]
+        )
+        self.assertNotEqual(result.returncode, 0, result.stdout + result.stderr)
+        self.assertIn("proof admits old callers can still use the old path", result.stderr)
+
+    def test_modal_intent_retained_packet_fails(self) -> None:
+        result = run_gate(
+            [
+                "--packet",
+                str(FIXTURE_DIR / "modal_intent_retained_packet.md"),
+                "--head-sha",
+                "0000000000000000000000000000000000000000",
+                "--packet-only",
+            ]
+        )
+        self.assertNotEqual(result.returncode, 0, result.stdout + result.stderr)
+        self.assertIn("proof admits old callers can still use the old path", result.stderr)
+
+    def test_retained_endpoint_synonym_packets_fail(self) -> None:
+        for proof in [
+            "Rejected calls prove the boundary while the legacy endpoint is preserved for migration.",
+            "Rejected calls prove the boundary while the previous route stays enabled during rollout.",
+            "Rejected calls prove the boundary while the legacy endpoint was preserved for migration.",
+            "Rejected calls prove the boundary while the previous route was enabled during rollout.",
+            "Rejected calls prove the boundary while the endpoint was preserved for migration.",
+            "Rejected calls prove the boundary while the endpoint was enabled during rollout.",
+            "Rejected calls prove the boundary while that route was preserved.",
+            "Rejected calls prove the boundary while that route was enabled.",
+            "Rejected calls prove the boundary while retained the endpoint for migration.",
+            "Rejected calls prove the boundary while the endpoint was maintained for migration.",
+            "Rejected calls prove the boundary while the endpoint was allowed during rollout.",
+            "Rejected calls prove the boundary while maintained the endpoint for migration.",
+            "Rejected calls prove the boundary while legacy access remained allowed during migration.",
+            "Rejected calls prove the boundary while the legacy endpoint continues responding during migration.",
+            "Rejected calls prove the boundary while the legacy endpoint continues to serve old clients.",
+            "Rejected calls prove the boundary while old clients are served by the legacy endpoint during migration.",
+            "Rejected calls prove the boundary while the old route keeps accepting requests for compatibility.",
+            "Rejected calls prove the boundary while the legacy API still accepts requests during rollout.",
+            "Rejected calls prove the boundary while old clients can still invoke the legacy endpoint during migration.",
+            "Rejected calls prove the boundary while callers keep hitting the old route.",
+            "Rejected calls prove the boundary while callers keep hitting the old action.",
+            "Rejected calls prove the boundary while users may still submit to the deprecated API.",
+            "Rejected calls prove the boundary while the legacy export remains importable.",
+            "Rejected calls prove the boundary while the legacy endpoint remains fully operational.",
+            "Rejected calls prove the boundary while the legacy endpoint stays open.",
+            "Rejected calls prove the boundary while the legacy endpoint remains in service.",
+            "Rejected calls prove the boundary while older integrations can continue through it.",
+            "Rejected calls prove the boundary while previous exports keep functioning for old integrations.",
+            "Rejected calls prove the boundary while existing callers remain on the legacy surface until LUC-999.",
+            "Rejected calls prove the boundary while the former endpoint remains reachable during migration.",
+            "Rejected calls prove the boundary while deprecated access remains available during rollout.",
+            "Rejected calls prove the boundary while the legacy service remains available during migration.",
+            "Rejected calls prove the boundary while retained the service for migration.",
+            "Rejected calls prove the boundary while retaining the service for migration.",
+            "Rejected calls prove the boundary while the PR retains the service for migration.",
+            "Rejected calls prove the boundary while keeping the legacy service available during migration.",
+            "Rejected calls prove the boundary while the legacy service is retained for migration.",
+            "Rejected calls prove the boundary while the service is retained for migration.",
+            "Rejected calls prove the boundary while legacy access is retained during migration.",
+            "Rejected calls prove the boundary while the route is kept during migration.",
+            "Rejected calls prove the boundary while route is kept.",
+            "Rejected calls prove the boundary while access is kept.",
+            "Rejected calls prove the boundary while helper is left.",
+            "Rejected calls prove the boundary while path continues working.",
+            "Rejected calls prove the boundary while route continues to respond.",
+            "Rejected calls prove the boundary while the old route continues to be callable.",
+            "Rejected calls prove the boundary while endpoint continues responding for compatibility.",
+            "Rejected calls prove the boundary while caller is kept until LUC-999.",
+            "Rejected calls prove the boundary while clients keep using the legacy endpoint during migration.",
+            "Rejected calls prove the boundary while legacy SDKs continue using it during migration.",
+            "Rejected calls prove the boundary while older clients will keep using the legacy endpoint.",
+            "Rejected calls prove the boundary while callers kept calling the old route.",
+            "Rejected calls prove the boundary while keeping the client during migration.",
+            "Rejected calls prove the boundary while maintains the integration during migration.",
+            "Rejected calls prove the boundary while keeps the access during migration.",
+            "Rejected calls prove the boundary while the previous endpoint will stay accessible during migration.",
+            "Rejected calls prove the boundary while the legacy endpoint will remain reachable.",
+            "Rejected calls prove the boundary while the legacy endpoint remains exposed for semver stability.",
+            "Rejected calls prove the boundary while the old route stays published for ABI stability.",
+            "Rejected calls prove the boundary while the legacy API is grandfathered for existing integrations.",
+        ]:
+            with self.subTest(proof=proof):
+                result = run_gate(
+                    [
+                        "--packet",
+                        str(self.packet_with_proof(proof)),
+                        "--head-sha",
+                        "0000000000000000000000000000000000000000",
+                        "--packet-only",
+                    ]
+                )
+                self.assertNotEqual(result.returncode, 0, result.stdout + result.stderr)
+                self.assertIn("proof admits old callers can still use the old path", result.stderr)
+
+    def test_modal_intent_retained_variants_fail(self) -> None:
+        for proof in [
+            "Rejected calls prove the boundary while old clients should continue using the legacy endpoint.",
+            "Rejected calls prove the boundary while old clients might still invoke the legacy endpoint.",
+            "Rejected calls prove the boundary while callers need to continue hitting the old route.",
+            "Rejected calls prove the boundary while the legacy route is intended to stay reachable.",
+            "Rejected calls prove the boundary while old clients must continue using the legacy endpoint.",
+            "Rejected calls prove the boundary while old clients are expected to keep using the legacy endpoint.",
+            "Rejected calls prove the boundary while old clients ought to continue invoking the legacy endpoint.",
+            "Rejected calls prove the boundary while the old helper should remain invocable.",
+            "Rejected calls prove the boundary while the legacy endpoint might still be callable.",
+            "Rejected calls prove the boundary while SDKs are expected to keep using the legacy API.",
+        ]:
+            with self.subTest(proof=proof):
+                result = run_gate(
+                    [
+                        "--packet",
+                        str(self.packet_with_proof(proof)),
+                        "--head-sha",
+                        "0000000000000000000000000000000000000000",
+                        "--packet-only",
+                    ]
+                )
+                self.assertNotEqual(result.returncode, 0, result.stdout + result.stderr)
+                self.assertIn("proof admits old callers can still use the old path", result.stderr)
+
+    def test_test_only_boundary_proof_fails(self) -> None:
+        result = run_gate(
+            [
+                "--packet",
+                str(
+                    self.packet_with_proof(
+                        "A test-only harness rejects calls; the old route is not callable in that fixture."
+                    )
+                ),
+                "--head-sha",
+                "0000000000000000000000000000000000000000",
+                "--packet-only",
+            ]
+        )
+        self.assertNotEqual(result.returncode, 0, result.stdout + result.stderr)
+        self.assertIn("test-only proof does not prove production boundary uncallability", result.stderr)
+
+    def test_unit_test_fixture_rejected_calls_need_production_boundary_evidence(self) -> None:
+        result = run_gate(
+            [
+                "--packet",
+                str(
+                    self.packet_with_proof(
+                        "A unit test fixture rejects calls and says the old route is not callable."
+                    )
+                ),
+                "--head-sha",
+                "0000000000000000000000000000000000000000",
+                "--packet-only",
+            ]
+        )
+        self.assertNotEqual(result.returncode, 0, result.stdout + result.stderr)
+        self.assertIn("cites only non-production fixture", result.stderr)
+
+    def test_bare_make_boundary_packet_fails(self) -> None:
+        result = run_gate(
+            [
+                "--packet",
+                str(FIXTURE_DIR / "bare_make_boundary_packet.md"),
+                "--head-sha",
+                "0000000000000000000000000000000000000000",
+                "--packet-only",
+            ]
+        )
+        self.assertNotEqual(result.returncode, 0, result.stdout + result.stderr)
+        self.assertIn("cites only non-production fixture", result.stderr)
+
+    def test_bare_make_or_cargo_does_not_make_fixture_proof_production_boundary(self) -> None:
+        for proof in [
+            "A unit test fixture rejects calls and says the old route is not callable; make test passed.",
+            "A unit test fixture rejects calls and says the old route is not callable; cargo test passed.",
+        ]:
+            with self.subTest(proof=proof):
+                result = run_gate(
+                    [
+                        "--packet",
+                        str(self.packet_with_proof(proof)),
+                        "--head-sha",
+                        "0000000000000000000000000000000000000000",
+                        "--packet-only",
+                    ]
+                )
+                self.assertNotEqual(result.returncode, 0, result.stdout + result.stderr)
+                self.assertIn("cites only non-production fixture", result.stderr)
+
+    def test_fixture_proof_can_pass_with_production_boundary_evidence(self) -> None:
+        result = run_gate(
+            [
+                "--packet",
+                str(
+                    self.packet_with_proof(
+                        "A unit test fixture rejects calls, and the production router removed "
+                        "the old route from the public route registry."
+                    )
+                ),
+                "--head-sha",
+                "0000000000000000000000000000000000000000",
+                "--packet-only",
+            ]
+        )
+        self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
+
+    def test_unit_test_fixture_with_unrelated_production_noun_fails(self) -> None:
+        result = run_gate(
+            [
+                "--packet",
+                str(
+                    self.packet_with_proof(
+                        "A unit test fixture rejects calls; production docs mention the boundary."
+                    )
+                ),
+                "--head-sha",
+                "0000000000000000000000000000000000000000",
+                "--packet-only",
+            ]
+        )
+        self.assertNotEqual(result.returncode, 0, result.stdout + result.stderr)
+        self.assertIn("cites only non-production fixture", result.stderr)
+
+    def test_alias_facade_and_shadow_route_retention_packets_fail(self) -> None:
+        proofs = [
+            "Rejected calls prove the boundary; the legacy route is an alias during rollout.",
+            "Rejected calls prove the boundary; legacy consumers are migrated through the old facade until LUC-999.",
+            "Rejected calls prove the boundary; the previous shadow route handles compatibility traffic.",
+            "Rejected calls prove the boundary; the old route remains as an alias.",
+            "Rejected calls prove the boundary; the old endpoint remains behind a facade.",
+            "Rejected calls prove the boundary; the previous endpoint remains as a shadow route.",
+            "Rejected calls prove the boundary; the previous endpoint remains on a shadow surface.",
+        ]
+        for proof in proofs:
+            with self.subTest(proof=proof):
+                result = run_gate(
+                    [
+                        "--packet",
+                        str(self.packet_with_proof(proof)),
+                        "--head-sha",
+                        "0000000000000000000000000000000000000000",
+                        "--packet-only",
+                    ]
+                )
+                self.assertNotEqual(result.returncode, 0, result.stdout + result.stderr)
+                self.assertIn("old path callable", result.stderr)
+
+    def test_compatibility_traffic_on_previous_endpoint_fails(self) -> None:
+        result = run_gate(
+            [
+                "--packet",
+                str(
+                    self.packet_with_proof(
+                        "Rejected calls prove the boundary. Compatibility traffic is handled by the previous endpoint."
+                    )
+                ),
+                "--head-sha",
+                "0000000000000000000000000000000000000000",
+                "--packet-only",
+            ]
+        )
+        self.assertNotEqual(result.returncode, 0, result.stdout + result.stderr)
+        self.assertIn("compatibility-retained proof leaves the old path callable", result.stderr)
+
+    def test_retention_language_outside_parsed_cells_fails(self) -> None:
+        packet = self.packet_with_proof(
+            "Rejected calls prove the boundary and the old route is not callable."
+        )
+        text = packet.read_text(encoding="utf-8")
+        text = text.replace(
+            "## Complexity Delta",
+            "Note: the legacy endpoint remains callable for compatibility until LUC-999.\n\n"
+            "## Complexity Delta",
+        )
+        packet.write_text(text, encoding="utf-8")
+
+        result = run_gate(
+            [
+                "--packet",
+                str(packet),
+                "--head-sha",
+                "0000000000000000000000000000000000000000",
+                "--packet-only",
+            ]
+        )
+        self.assertNotEqual(result.returncode, 0, result.stdout + result.stderr)
+        self.assertIn("proof admits the old path remains callable", result.stderr)
+
+    def test_retention_language_in_extra_table_cell_fails(self) -> None:
+        packet = self.packet_with_proof(
+            "Rejected calls prove the boundary and the old route is not callable."
+        )
+        text = packet.read_text(encoding="utf-8")
+        text = text.replace(
+            "| `legacy_endpoint` | made uncallable at boundary | `legacy_endpoint` | "
+            "Rejected calls prove the boundary and the old route is not callable. | none |",
+            "| `legacy_endpoint` | made uncallable at boundary | `legacy_endpoint` | "
+            "Rejected calls prove the boundary and the old route is not callable. | none | "
+            "the legacy endpoint remains callable for compatibility until LUC-999 |",
+        )
+        packet.write_text(text, encoding="utf-8")
+
+        result = run_gate(
+            [
+                "--packet",
+                str(packet),
+                "--head-sha",
+                "0000000000000000000000000000000000000000",
+                "--packet-only",
+            ]
+        )
+        self.assertNotEqual(result.returncode, 0, result.stdout + result.stderr)
+        self.assertIn("proof admits the old path remains callable", result.stderr)
+
+    def test_retained_follow_up_language_fails(self) -> None:
+        proof = "Rejected calls prove the boundary and the old route is not callable."
+        for follow_up in [
+            "LUC-999 keeps the endpoint preserved for migration.",
+            "LUC-999 leaves legacy access allowed during migration.",
+            "LUC-999 keeps the legacy endpoint responding during migration.",
+            "LUC-999 keeps the legacy service available during migration.",
+            "LUC-999 retained the service for migration.",
+            "LUC-999 keeps the service for migration.",
+            "LUC-999 keeping the legacy service available during migration.",
+        ]:
+            with self.subTest(follow_up=follow_up):
+                result = run_gate(
+                    [
+                        "--packet",
+                        str(self.packet_with_proof(proof, follow_up=follow_up)),
+                        "--head-sha",
+                        "0000000000000000000000000000000000000000",
+                        "--packet-only",
+                    ]
+                )
+                self.assertNotEqual(result.returncode, 0, result.stdout + result.stderr)
+                self.assertIn("proof admits old callers can still use the old path", result.stderr)
+
+    def test_current_head_sha_must_match_current_head_line(self) -> None:
+        expected_head = "1111111111111111111111111111111111111111"
+        stale_head = "2222222222222222222222222222222222222222"
+        proof = (
+            "Rejected calls prove the boundary and the old route is not callable. "
+            f"Validation command used {expected_head}."
+        )
+        result = run_gate(
+            [
+                "--packet",
+                str(self.packet_with_proof(proof, head_sha=stale_head)),
+                "--head-sha",
+                expected_head,
+                "--packet-only",
+            ]
+        )
+        self.assertNotEqual(result.returncode, 0, result.stdout + result.stderr)
+        self.assertIn("Current head SHA must be", result.stderr)
+
+        prefix_result = run_gate(
+            [
+                "--packet",
+                str(self.packet_with_proof(proof, head_sha=expected_head[:12])),
+                "--head-sha",
+                expected_head,
+                "--packet-only",
+            ]
+        )
+        self.assertNotEqual(prefix_result.returncode, 0, prefix_result.stdout + prefix_result.stderr)
+        self.assertIn("Current head SHA", prefix_result.stderr)
+
+        masked_result = run_gate(
+            [
+                "--packet",
+                str(
+                    self.packet_with_proof(
+                        proof,
+                        head_sha=stale_head,
+                        preamble=f"## Validation\n\nCurrent head SHA: {expected_head}\n\n",
+                    )
+                ),
+                "--head-sha",
+                expected_head,
+                "--packet-only",
+            ]
+        )
+        self.assertNotEqual(masked_result.returncode, 0, masked_result.stdout + masked_result.stderr)
+        self.assertIn("Current head SHA must be", masked_result.stderr)
+
+    def test_fenced_headings_cannot_spoof_packet_sections(self) -> None:
+        head_sha = "0000000000000000000000000000000000000000"
+        packet = tempfile.NamedTemporaryFile("w", delete=False, encoding="utf-8")
+        self.addCleanup(lambda: Path(packet.name).unlink(missing_ok=True))
+        with packet:
+            packet.write(
+                textwrap.dedent(
+                    f"""\
+                    ## Review Readiness Packet
+
+                    Current head SHA: {head_sha}
+                    Command output: fake local gate output.
+
+                    ```markdown
+                    ## Old Path Amputation Proof
+
+                    | Old path | Classification | Search literal | Mechanical proof | Follow-up |
+                    | --- | --- | --- | --- | --- |
+                    | `legacy_endpoint` | made uncallable at boundary | `legacy_endpoint` | Rejected calls prove the boundary and the old route is not callable. | none |
+                    ```
+
+                    ## Old Path Amputation Proof
+
+                    | Old path | Classification | Search literal | Mechanical proof | Follow-up |
+                    | --- | --- | --- | --- | --- |
+                    | `legacy_endpoint` | made uncallable at boundary | `legacy_endpoint` | Rejected calls prove the boundary while old clients can still invoke the legacy endpoint during migration. | none |
+
+                    ## Complexity Delta
+
+                    - Docs/scripts/tests: 1 file.
+                    - Non-test implementation: 0 files.
+                    - Generated/schema churn: 0 files.
+
+                    ## Sample Passing Old Path Amputation Proof
+
+                    | Old path | Classification | Search literal | Mechanical proof | Follow-up |
+                    | --- | --- | --- | --- | --- |
+                    | `old/session-route` | deleted | `old/session-route` | No production references remain. | none |
+
+                    ## Sample Failing Old Path Amputation Proof
+
+                    | Old path | Classification | Search literal | Mechanical proof | Follow-up |
+                    | --- | --- | --- | --- | --- |
+                    | `old/session-route` | wrapped | `old/session-route` | A preferred path exists beside the old route. | none |
+                    """
+                )
+            )
+        result = run_gate(
+            [
+                "--packet",
+                packet.name,
+                "--head-sha",
+                head_sha,
+                "--packet-only",
+            ]
+        )
+        self.assertNotEqual(result.returncode, 0, result.stdout + result.stderr)
+        self.assertIn("proof admits old callers can still use the old path", result.stderr)
+
+    def test_long_fenced_headings_cannot_spoof_packet_sections(self) -> None:
+        head_sha = "0000000000000000000000000000000000000000"
+        packet = tempfile.NamedTemporaryFile("w", delete=False, encoding="utf-8")
+        self.addCleanup(lambda: Path(packet.name).unlink(missing_ok=True))
+        with packet:
+            packet.write(
+                textwrap.dedent(
+                    f"""\
+                    ## Review Readiness Packet
+
+                    Current head SHA: {head_sha}
+                    Command output: fake local gate output.
+
+                    ````markdown
+                    ## Old Path Amputation Proof
+
+                    | Old path | Classification | Search literal | Mechanical proof | Follow-up |
+                    | --- | --- | --- | --- | --- |
+                    | `legacy_endpoint` | made uncallable at boundary | `legacy_endpoint` | Rejected calls prove the boundary and the old route is not callable. | none |
+                    ```
+
+                    ## Complexity Delta
+
+                    - Docs/scripts/tests: 1 file.
+                    - Non-test implementation: 0 files.
+                    - Generated/schema churn: 0 files.
+
+                    ## Sample Passing Old Path Amputation Proof
+
+                    | Old path | Classification | Search literal | Mechanical proof | Follow-up |
+                    | --- | --- | --- | --- | --- |
+                    | `old/session-route` | deleted | `old/session-route` | No production references remain. | none |
+
+                    ## Sample Failing Old Path Amputation Proof
+
+                    | Old path | Classification | Search literal | Mechanical proof | Follow-up |
+                    | --- | --- | --- | --- | --- |
+                    | `old/session-route` | wrapped | `old/session-route` | A preferred path exists beside the old route. | none |
+                    ````
+                    """
+                )
+            )
+        result = run_gate(
+            [
+                "--packet",
+                packet.name,
+                "--head-sha",
+                head_sha,
+                "--packet-only",
+            ]
+        )
+        self.assertNotEqual(result.returncode, 0, result.stdout + result.stderr)
+        self.assertIn("missing required heading: Old Path Amputation Proof", result.stderr)
+
+    def test_retained_packet_fails_front_door_gate(self) -> None:
+        result = run_gate(
+            [
+                "--packet",
+                str(FIXTURE_DIR / "retained_packet.md"),
+                "--head-sha",
+                "0000000000000000000000000000000000000000",
+                "--packet-only",
+            ]
+        )
+        self.assertNotEqual(result.returncode, 0, result.stdout + result.stderr)
+        self.assertIn("retained old path `wasm_contract_string_mirror` is non-clean residual", result.stderr)
+
+    def test_boundary_keyword_only_packet_fails(self) -> None:
+        result = run_gate(
+            [
+                "--packet",
+                str(FIXTURE_DIR / "boundary_keyword_only_packet.md"),
+                "--head-sha",
+                "0000000000000000000000000000000000000000",
+                "--packet-only",
+            ]
+        )
+        self.assertNotEqual(result.returncode, 0, result.stdout + result.stderr)
+        self.assertIn("must cite mechanical boundary proof", result.stderr)
+
+    def test_default_base_falls_back_to_local_main(self) -> None:
+        repo = self.create_repo()
+        readme = repo / "README.md"
+        readme.write_text("base\n", encoding="utf-8")
+        require_success(["git", "add", "README.md"], repo)
+        require_success(["git", "commit", "-q", "-m", "base"], repo)
+
+        result = run_gate(
+            [
+                "--repo",
+                str(repo),
+                "--packet",
+                str(FIXTURE_DIR / "passing_packet.md"),
+                "--head-sha",
+                "0000000000000000000000000000000000000000",
+            ]
+        )
+        self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
+        self.assertIn("Dogma cleanup gate passed", result.stdout)
+
+    def test_deleted_old_path_requires_related_search_literal(self) -> None:
+        repo = self.create_repo()
+        source_path = repo / "src" / "lib.rs"
+        source_path.parent.mkdir(parents=True, exist_ok=True)
+        source_path.write_text("pub fn legacy_endpoint() {}\n", encoding="utf-8")
+        require_success(["git", "add", "src/lib.rs"], repo)
+        require_success(["git", "commit", "-q", "-m", "base"], repo)
+        require_success(["git", "checkout", "-q", "-b", "pr"], repo)
+        readme = repo / "README.md"
+        readme.write_text("metadata refresh\n", encoding="utf-8")
+        require_success(["git", "add", "README.md"], repo)
+        require_success(["git", "commit", "-q", "-m", "metadata"], repo)
+
+        packet = tempfile.NamedTemporaryFile("w", delete=False, encoding="utf-8")
+        self.addCleanup(lambda: Path(packet.name).unlink(missing_ok=True))
+        with packet:
+            packet.write(
+                textwrap.dedent(
+                    """\
+                    ## Review Readiness Packet
+
+                    Current head SHA: 0000000000000000000000000000000000000000
+                    Command output: fake local gate output.
+
+                    ## Old Path Amputation Proof
+
+                    | Old path | Classification | Search literal | Mechanical proof | Follow-up |
+                    | --- | --- | --- | --- | --- |
+                    | `legacy_endpoint` | deleted | `definitely_not_in_repo` | No production references remain. | none |
+
+                    ## Complexity Delta
+
+                    - Docs/scripts/tests: 1 file.
+                    - Non-test implementation: 0 files.
+                    - Generated/schema churn: 0 files.
+
+                    ## Sample Passing Old Path Amputation Proof
+
+                    | Old path | Classification | Search literal | Mechanical proof | Follow-up |
+                    | --- | --- | --- | --- | --- |
+                    | `old/session-route` | deleted | `old/session-route` | No production references remain. | none |
+
+                    ## Sample Failing Old Path Amputation Proof
+
+                    | Old path | Classification | Search literal | Mechanical proof | Follow-up |
+                    | --- | --- | --- | --- | --- |
+                    | `old/session-route` | wrapped | `old/session-route` | A preferred path exists beside the old route. | none |
+                    """
+                )
+            )
+        result = run_gate(
+            [
+                "--repo",
+                str(repo),
+                "--base",
+                "main",
+                "--packet",
+                packet.name,
+                "--head-sha",
+                "0000000000000000000000000000000000000000",
+            ]
+        )
+        self.assertNotEqual(result.returncode, 0, result.stdout + result.stderr)
+        self.assertIn("search literal `definitely_not_in_repo` must name or overlap", result.stderr)
+
+    def test_uncallable_old_path_requires_related_search_literal(self) -> None:
+        result = run_gate(
+            [
+                "--packet",
+                str(
+                    self.packet_with_proof(
+                        "Rejected calls prove the production router boundary and the old route is not callable.",
+                        search_literal="definitely_not_in_repo",
+                    )
+                ),
+                "--head-sha",
+                "0000000000000000000000000000000000000000",
+                "--packet-only",
+            ]
+        )
+        self.assertNotEqual(result.returncode, 0, result.stdout + result.stderr)
+        self.assertIn("uncallable old path `legacy_endpoint` search literal", result.stderr)
+        self.assertIn("must name or overlap the old path", result.stderr)
+
+    def test_uncallable_old_path_fails_when_search_literal_still_in_production(self) -> None:
+        repo = self.create_repo()
+        (repo / "Cargo.toml").write_text(
+            textwrap.dedent(
+                """\
+                [workspace]
+                members = ["app"]
+                """
+            ),
+            encoding="utf-8",
+        )
+        source_path = repo / "app/src/lib.rs"
+        source_path.parent.mkdir(parents=True, exist_ok=True)
+        source_path.write_text(
+            "pub fn legacy_endpoint() -> bool { true }\n"
+            'pub fn canonical_owner() -> &\'static str { "new" }\n',
+            encoding="utf-8",
+        )
+        require_success(["git", "add", "Cargo.toml", "app/src/lib.rs"], repo)
+        require_success(["git", "commit", "-q", "-m", "base"], repo)
+        require_success(["git", "checkout", "-q", "-b", "pr"], repo)
+
+        result = run_gate(
+            [
+                "--repo",
+                str(repo),
+                "--base",
+                "main",
+                "--packet",
+                str(
+                    self.packet_with_proof(
+                        "Rejected calls prove the production router boundary and the old route is not callable."
+                    )
+                ),
+                "--head-sha",
+                "0000000000000000000000000000000000000000",
+            ]
+        )
+        self.assertNotEqual(result.returncode, 0, result.stdout + result.stderr)
+        self.assertIn(
+            "uncallable old path `legacy_endpoint` still has production references",
+            result.stderr,
+        )
+        self.assertIn("app/src/lib.rs", result.stderr)
+
+    def test_deleted_old_path_fails_when_normalized_literal_still_in_production(self) -> None:
+        repo = self.create_repo()
+        (repo / "Cargo.toml").write_text(
+            textwrap.dedent(
+                """\
+                [workspace]
+                members = ["app"]
+                """
+            ),
+            encoding="utf-8",
+        )
+        source_path = repo / "app/src/lib.rs"
+        source_path.parent.mkdir(parents=True, exist_ok=True)
+        source_path.write_text("pub fn legacy_endpoint() -> bool { true }\n", encoding="utf-8")
+        require_success(["git", "add", "Cargo.toml", "app/src/lib.rs"], repo)
+        require_success(["git", "commit", "-q", "-m", "base"], repo)
+        require_success(["git", "checkout", "-q", "-b", "pr"], repo)
+        (repo / "README.md").write_text("metadata refresh\n", encoding="utf-8")
+        require_success(["git", "add", "README.md"], repo)
+        require_success(["git", "commit", "-q", "-m", "metadata"], repo)
+
+        packet = tempfile.NamedTemporaryFile("w", delete=False, encoding="utf-8")
+        self.addCleanup(lambda: Path(packet.name).unlink(missing_ok=True))
+        with packet:
+            packet.write(
+                textwrap.dedent(
+                    """\
+                    ## Review Readiness Packet
+
+                    Current head SHA: 0000000000000000000000000000000000000000
+                    Command output: fake local gate output.
+
+                    ## Old Path Amputation Proof
+
+                    | Old path | Classification | Search literal | Mechanical proof | Follow-up |
+                    | --- | --- | --- | --- | --- |
+                    | `legacy_endpoint` | deleted | `legacy endpoint` | No production references remain. | none |
+
+                    ## Complexity Delta
+
+                    - Docs/scripts/tests: 1 file.
+                    - Non-test implementation: 0 files.
+                    - Generated/schema churn: 0 files.
+
+                    ## Sample Passing Old Path Amputation Proof
+
+                    | Old path | Classification | Search literal | Mechanical proof | Follow-up |
+                    | --- | --- | --- | --- | --- |
+                    | `old/session-route` | deleted | `old/session-route` | No production references remain. | none |
+
+                    ## Sample Failing Old Path Amputation Proof
+
+                    | Old path | Classification | Search literal | Mechanical proof | Follow-up |
+                    | --- | --- | --- | --- | --- |
+                    | `old/session-route` | wrapped | `old/session-route` | A preferred path exists beside the old route. | none |
+                    """
+                )
+            )
+
+        result = run_gate(
+            [
+                "--repo",
+                str(repo),
+                "--base",
+                "main",
+                "--packet",
+                packet.name,
+                "--head-sha",
+                "0000000000000000000000000000000000000000",
+            ]
+        )
+        self.assertNotEqual(result.returncode, 0, result.stdout + result.stderr)
+        self.assertIn(
+            "deleted old path `legacy_endpoint` still has production references",
+            result.stderr,
+        )
+        self.assertIn("app/src/lib.rs", result.stderr)
+
+    def test_deleted_schema_file_counts_as_generated_churn(self) -> None:
+        repo = self.create_repo()
+        schema_path = repo / "schemas" / "runtime.schema.json"
+        schema_path.parent.mkdir(parents=True, exist_ok=True)
+        schema_path.write_text('{"type":"object"}\n', encoding="utf-8")
+        require_success(["git", "add", "schemas/runtime.schema.json"], repo)
+        require_success(["git", "commit", "-q", "-m", "base"], repo)
+        require_success(["git", "checkout", "-q", "-b", "pr"], repo)
+        schema_path.unlink()
+        require_success(["git", "add", "schemas/runtime.schema.json"], repo)
+        require_success(["git", "commit", "-q", "-m", "delete schema"], repo)
+
+        result = run_gate(
+            [
+                "--repo",
+                str(repo),
+                "--base",
+                "main",
+                "--packet",
+                str(FIXTURE_DIR / "passing_packet.md"),
+                "--head-sha",
+                "0000000000000000000000000000000000000000",
+            ]
+        )
+        self.assertNotEqual(result.returncode, 0, result.stdout + result.stderr)
+        self.assertIn("changed generated/schema paths exist", result.stderr)
+        self.assertIn("schemas/runtime.schema.json", result.stderr)
+
+    def test_deleted_repo_native_generated_rust_counts_as_generated_churn(self) -> None:
+        repo = self.create_repo()
+        generated_path = repo / "meerkat-runtime" / "src" / "generated" / "protocol.rs"
+        generated_path.parent.mkdir(parents=True, exist_ok=True)
+        generated_path.write_text("pub const GENERATED: &str = \"old\";\n", encoding="utf-8")
+        require_success(["git", "add", "meerkat-runtime/src/generated/protocol.rs"], repo)
+        require_success(["git", "commit", "-q", "-m", "base"], repo)
+        require_success(["git", "checkout", "-q", "-b", "pr"], repo)
+        generated_path.unlink()
+        require_success(["git", "add", "meerkat-runtime/src/generated/protocol.rs"], repo)
+        require_success(["git", "commit", "-q", "-m", "delete generated rust"], repo)
+
+        result = run_gate(
+            [
+                "--repo",
+                str(repo),
+                "--base",
+                "main",
+                "--packet",
+                str(FIXTURE_DIR / "passing_packet.md"),
+                "--head-sha",
+                "0000000000000000000000000000000000000000",
+            ]
+        )
+        self.assertNotEqual(result.returncode, 0, result.stdout + result.stderr)
+        self.assertIn("changed generated/schema paths exist", result.stderr)
+        self.assertIn("meerkat-runtime/src/generated/protocol.rs", result.stderr)
+
+    def test_unsignaled_runtime_core_source_cleanup_requires_packet(self) -> None:
+        result = self.run_unsignaled_source_cleanup(
+            "meerkat-core/src/turn_execution_authority.rs",
+            'pub fn legacy_runtime_metadata_cache() -> &\'static str { "old" }\n',
+        )
+        self.assert_stable_signal_required(result, "meerkat-core/src/turn_execution_authority.rs")
+
+    def test_unsignaled_provider_model_owner_cleanup_requires_packet_without_legacy_keywords(self) -> None:
+        result = self.run_unsignaled_source_cleanup(
+            "meerkat-core/src/provider_model.rs",
+            'pub fn provider_model_owner_source() -> &\'static str { "old" }\n',
+        )
+        self.assert_stable_signal_required(
+            result,
+            "meerkat-core/src/provider_model.rs",
+            "production workspace crate source deletion",
+        )
+
+    def test_unsignaled_comms_source_cleanup_requires_packet_without_legacy_keywords(self) -> None:
+        result = self.run_unsignaled_source_cleanup(
+            "meerkat-comms/src/peer_model.rs",
+            'pub struct PeerModelOwnerSource;\n',
+        )
+        self.assert_stable_signal_required(
+            result,
+            "meerkat-comms/src/peer_model.rs",
+            "production workspace crate source deletion",
+        )
+
+    def test_unsignaled_cli_source_cleanup_requires_packet_from_workspace_manifest(self) -> None:
+        result = self.run_unsignaled_source_cleanup(
+            "meerkat-cli/src/auth.rs",
+            'pub fn cli_owner_source() -> bool { true }\n',
+        )
+        self.assert_stable_signal_required(
+            result,
+            "meerkat-cli/src/auth.rs",
+            "production workspace crate source deletion",
+        )
+
+    def test_removed_workspace_member_source_deletion_requires_packet(self) -> None:
+        repo = self.create_repo()
+        (repo / "Cargo.toml").write_text(
+            textwrap.dedent(
+                """\
+                [workspace]
+                members = ["old-crate"]
+                """
+            ),
+            encoding="utf-8",
+        )
+        source_path = repo / "old-crate/src/lib.rs"
+        source_path.parent.mkdir(parents=True, exist_ok=True)
+        source_path.write_text(
+            "pub fn removed_workspace_owner_source() -> bool { true }\n"
+            'pub fn canonical_owner() -> &\'static str { "new" }\n',
+            encoding="utf-8",
+        )
+        require_success(["git", "add", "Cargo.toml", "old-crate/src/lib.rs"], repo)
+        require_success(["git", "commit", "-q", "-m", "base"], repo)
+        require_success(["git", "checkout", "-q", "-b", "pr"], repo)
+
+        (repo / "Cargo.toml").write_text(
+            textwrap.dedent(
+                """\
+                [workspace]
+                members = []
+                """
+            ),
+            encoding="utf-8",
+        )
+        source_path.unlink()
+        require_success(["git", "add", "Cargo.toml", "old-crate/src/lib.rs"], repo)
+        require_success(["git", "commit", "-q", "-m", "remove workspace member source"], repo)
+        head_sha = require_success(["git", "rev-parse", "HEAD"], repo)
+
+        result = run_gate(
+            [
+                "--repo",
+                str(repo),
+                "--base",
+                "main",
+                "--github-event",
+                str(self.github_event_path(head_sha)),
+            ]
+        )
+        self.assert_stable_signal_required(
+            result,
+            "old-crate/src/lib.rs",
+            "production workspace crate source deletion",
+        )
+
+    def test_unsignaled_rpc_surface_source_cleanup_requires_packet(self) -> None:
+        result = self.run_unsignaled_source_cleanup(
+            "meerkat-rpc/src/handlers/session.rs",
+            'pub fn surface_request_lifecycle_fallback_cache() -> &\'static str { "old" }\n',
+        )
+        self.assert_stable_signal_required(result, "meerkat-rpc/src/handlers/session.rs")
+
+    def test_unsignaled_enum_variant_authority_cleanup_requires_packet(self) -> None:
+        result = self.run_unsignaled_source_cleanup(
+            "meerkat-runtime/src/meerkat_machine/visibility.rs",
+            "    ShellOwned,\n",
+        )
+        self.assert_stable_signal_required(
+            result,
+            "meerkat-runtime/src/meerkat_machine/visibility.rs",
+            "production workspace crate source deletion",
+        )
+
+    def test_unsignaled_impl_only_authority_cleanup_requires_packet(self) -> None:
+        result = self.run_unsignaled_source_cleanup(
+            "meerkat-runtime/src/meerkat_machine/owner.rs",
+            "impl BoundaryOwner for RuntimeOwner {}\n",
+        )
+        self.assert_stable_signal_required(
+            result,
+            "meerkat-runtime/src/meerkat_machine/owner.rs",
+            "production workspace crate source deletion",
+        )
+
+    def test_unsignaled_source_cleanup_requires_packet_in_session_tools_and_mcp_server(self) -> None:
+        cases = [
+            ("meerkat-session/src/persistent.rs", 'pub fn session_owner_source() -> bool { true }\n'),
+            ("meerkat-tools/src/registry.rs", 'pub struct ToolRegistryOwnerSource;\n'),
+            ("meerkat-mcp-server/src/router.rs", 'pub fn mcp_router_owner_source() -> bool { true }\n'),
+        ]
+        for rel_path, deleted_line in cases:
+            with self.subTest(rel_path=rel_path):
+                result = self.run_unsignaled_source_cleanup(rel_path, deleted_line)
+                self.assert_stable_signal_required(
+                    result,
+                    rel_path,
+                    "production workspace crate source deletion",
+                )
+
+    def test_unsignaled_gate_owning_paths_require_packet(self) -> None:
+        cases = [
+            (
+                "Makefile",
+                "dogma-cleanup-ci-gate:\n\tpython3 scripts/dogma_cleanup_gate.py\n",
+                "dogma-cleanup-ci-gate:\n\t@true\n",
+            ),
+            (".github/workflows/ci.yml", "name: CI\n", "name: build\n"),
+            ("scripts/dogma_cleanup_gate.py", "print('enforce')\n", "print('skip')\n"),
+            (
+                "scripts/tests/dogma_cleanup_gate_test.py",
+                "assert True\n",
+                "assert True\n# changed\n",
+            ),
+            ("scripts/fixtures/dogma_cleanup_gate/passing_packet.md", "old\n", "new\n"),
+        ]
+        for rel_path, base_text, pr_text in cases:
+            with self.subTest(rel_path=rel_path):
+                result = self.run_unsignaled_path_change(rel_path, base_text, pr_text)
+                self.assert_stable_signal_required(result, rel_path, "dogma gate-owning path")
+
+    def test_make_ci_gate_fails_closed_without_event_or_packet(self) -> None:
+        override = tempfile.NamedTemporaryFile("w", delete=False, encoding="utf-8")
+        self.addCleanup(lambda: Path(override.name).unlink(missing_ok=True))
+        with override:
+            override.write(
+                ".PHONY: dogma-cleanup-gate-fixtures\n"
+                "dogma-cleanup-gate-fixtures:\n"
+                "\t@:\n"
+            )
+        env = os.environ.copy()
+        env.pop("DOGMA_PACKET", None)
+        env.pop("GITHUB_EVENT_PATH", None)
+        result = subprocess.run(
+            [
+                "make",
+                "--no-print-directory",
+                "-f",
+                "Makefile",
+                "-f",
+                override.name,
+                "dogma-cleanup-ci-gate",
+            ],
+            cwd=REPO_ROOT,
+            env=env,
+            text=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+        )
+        self.assertEqual(result.returncode, 2, result.stdout + result.stderr)
+        self.assertIn(
+            "DOGMA_PACKET or GITHUB_EVENT_PATH is required for dogma cleanup CI enforcement",
+            result.stderr,
+        )
+        self.assertNotIn("Dogma cleanup gate skipped", result.stdout + result.stderr)
+
+    def test_local_broad_lane_gate_skips_without_event_or_packet(self) -> None:
+        override = tempfile.NamedTemporaryFile("w", delete=False, encoding="utf-8")
+        self.addCleanup(lambda: Path(override.name).unlink(missing_ok=True))
+        with override:
+            override.write(
+                ".PHONY: dogma-cleanup-gate-fixtures\n"
+                "dogma-cleanup-gate-fixtures:\n"
+                "\t@:\n"
+            )
+        env = os.environ.copy()
+        env.pop("DOGMA_PACKET", None)
+        env.pop("GITHUB_EVENT_PATH", None)
+        result = subprocess.run(
+            [
+                "make",
+                "--no-print-directory",
+                "-f",
+                "Makefile",
+                "-f",
+                override.name,
+                "dogma-cleanup-local-gate",
+            ],
+            cwd=REPO_ROOT,
+            env=env,
+            text=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+        )
+        self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
+        self.assertIn("Dogma cleanup gate skipped for local broad lane", result.stdout)
+
+    def test_broad_make_lanes_use_local_dogma_gate(self) -> None:
+        makefile = (REPO_ROOT / "Makefile").read_text(encoding="utf-8")
+
+        self.assertIn("agent-gate: dogma-cleanup-local-gate", makefile)
+        self.assertIn("ci: dogma-cleanup-local-gate", makefile)
+        self.assertIn("ci-smoke: dogma-cleanup-local-gate", makefile)
+        self.assertIn("dogma-cleanup-ci-gate: dogma-cleanup-gate-fixtures", makefile)
+
+    def test_github_gate_invokes_immutable_checker_without_pr_head_make(self) -> None:
+        workflow = (REPO_ROOT / ".github" / "workflows" / "ci.yml").read_text(encoding="utf-8")
+
+        self.assertIn("Checkout immutable gate source", workflow)
+        self.assertIn("dogma-gate-source/scripts/dogma_cleanup_gate.py", workflow)
+        self.assertIn('python3 "$gate_script" --repo "$pr_repo"', workflow)
+        self.assertIn("Validate PR-head dogma gate fixtures", workflow)
+        self.assertIn('pr_test_script="$pr_repo/scripts/tests/dogma_cleanup_gate_test.py"', workflow)
+        self.assertIn('base_test_script="$GITHUB_WORKSPACE/dogma-gate-source/scripts/tests/dogma_cleanup_gate_test.py"', workflow)
+        self.assertIn('DOGMA_GATE_SCRIPT="$pr_gate_script"', workflow)
+        self.assertIn('[[ ! -f "$pr_test_script" ]]', workflow)
+        self.assertIn("PR-head dogma gate fixture suite is missing", workflow)
+        self.assertIn('python3 "$base_test_script" -v', workflow)
+        self.assertIn('python3 "$pr_test_script" -v', workflow)
+        self.assertNotIn("make dogma-cleanup-ci-gate", workflow)
+
+    def test_pull_request_target_gate_uses_base_checker_without_pr_code_execution(self) -> None:
+        workflow = (
+            REPO_ROOT / ".github" / "workflows" / "dogma-cleanup-immutable-gate.yml"
+        ).read_text(encoding="utf-8")
+
+        self.assertIn("pull_request_target:", workflow)
+        self.assertIn("Dogma cleanup immutable review gate", workflow)
+        self.assertIn("name: CI gate", workflow)
+        self.assertIn("github.event.pull_request.head.repo.full_name", workflow)
+        self.assertIn("github.event.pull_request.head.sha", workflow)
+        self.assertIn("github.event.pull_request.base.sha", workflow)
+        self.assertIn("persist-credentials: false", workflow)
+        self.assertIn("dogma-gate-source/scripts/dogma_cleanup_gate.py", workflow)
+        self.assertIn("refs/remotes/dogma-base/dogma-cleanup-base", workflow)
+        self.assertIn('python3 "$gate_script" --repo "$pr_repo"', workflow)
+        self.assertNotIn("make dogma-cleanup-ci-gate", workflow)
+        self.assertNotIn("python3 \"$pr_test_script\"", workflow)
+        self.assertNotIn("DOGMA_GATE_SCRIPT=\"$pr_gate_script\"", workflow)
+
+    def test_pr_head_fixture_step_fails_closed_when_suite_is_missing_or_renamed(self) -> None:
+        body = self.workflow_step_body("Validate PR-head dogma gate fixtures")
+        temp_dir = tempfile.TemporaryDirectory()
+        self.addCleanup(temp_dir.cleanup)
+        workspace = Path(temp_dir.name)
+        renamed = workspace / "pr" / "scripts" / "tests" / "dogma_cleanup_gate_tests.py"
+        renamed.parent.mkdir(parents=True, exist_ok=True)
+        renamed.write_text("print('renamed suite should not count')\n", encoding="utf-8")
+
+        result = self.run_workflow_step_body(body, workspace)
+
+        self.assertNotEqual(result.returncode, 0, result.stdout + result.stderr)
+        self.assertIn("PR-head dogma gate fixture suite is missing", result.stdout + result.stderr)
+
+    def test_pr_head_fixture_step_bootstraps_pr_suite_when_base_oracle_is_absent(self) -> None:
+        body = self.workflow_step_body("Validate PR-head dogma gate fixtures")
+        temp_dir = tempfile.TemporaryDirectory()
+        self.addCleanup(temp_dir.cleanup)
+        workspace = Path(temp_dir.name)
+        script = workspace / "pr" / "scripts" / "tests" / "dogma_cleanup_gate_test.py"
+        script.parent.mkdir(parents=True, exist_ok=True)
+        gate = workspace / "pr" / "scripts" / "dogma_cleanup_gate.py"
+        gate.write_text("raise SystemExit(0)\n", encoding="utf-8")
+        script.write_text(
+            "from pathlib import Path\n"
+            "import sys\n"
+            "Path(__file__).with_name('ran.txt').write_text(' '.join(sys.argv[1:]), encoding='utf-8')\n",
+            encoding="utf-8",
+        )
+
+        result = self.run_workflow_step_body(body, workspace)
+
+        self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
+        self.assertEqual((script.parent / "ran.txt").read_text(encoding="utf-8"), "-v")
+
+    def test_pr_head_fixture_step_uses_base_oracle_against_pr_gate_script(self) -> None:
+        body = self.workflow_step_body("Validate PR-head dogma gate fixtures")
+        temp_dir = tempfile.TemporaryDirectory()
+        self.addCleanup(temp_dir.cleanup)
+        workspace = Path(temp_dir.name)
+        pr_test = workspace / "pr" / "scripts" / "tests" / "dogma_cleanup_gate_test.py"
+        pr_test.parent.mkdir(parents=True, exist_ok=True)
+        pr_test.write_text(
+            "from pathlib import Path\n"
+            "Path(__file__).with_name('pr-ran.txt').write_text('bad', encoding='utf-8')\n"
+            "raise SystemExit(0)\n",
+            encoding="utf-8",
+        )
+        pr_gate = workspace / "pr" / "scripts" / "dogma_cleanup_gate.py"
+        pr_gate.write_text("raise SystemExit(0)\n", encoding="utf-8")
+        pr_fixture_dir = workspace / "pr" / "scripts" / "fixtures" / "dogma_cleanup_gate"
+        pr_fixture_dir.mkdir(parents=True, exist_ok=True)
+        base_test = (
+            workspace
+            / "dogma-gate-source"
+            / "scripts"
+            / "tests"
+            / "dogma_cleanup_gate_test.py"
+        )
+        base_test.parent.mkdir(parents=True, exist_ok=True)
+        base_test.write_text(
+            "from pathlib import Path\n"
+            "import os\n"
+            "Path(__file__).with_name('base-ran.txt').write_text(\n"
+            "    os.environ['DOGMA_GATE_SCRIPT'] + '\\n' + os.environ['DOGMA_GATE_FIXTURE_DIR'],\n"
+            "    encoding='utf-8',\n"
+            ")\n",
+            encoding="utf-8",
+        )
+
+        result = self.run_workflow_step_body(body, workspace)
+
+        self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
+        self.assertFalse((pr_test.parent / "pr-ran.txt").exists())
+        marker = (base_test.parent / "base-ran.txt").read_text(encoding="utf-8")
+        self.assertIn(str(pr_gate), marker)
+        self.assertIn(str(pr_fixture_dir), marker)
+
+    def run_unsignaled_source_cleanup(
+        self, rel_path: str, deleted_line: str
+    ) -> subprocess.CompletedProcess[str]:
+        repo = self.create_repo()
+        manifest_paths = self.write_workspace_manifest(repo, rel_path)
+
+        source_path = repo / rel_path
+        source_path.parent.mkdir(parents=True, exist_ok=True)
+        source_path.write_text(
+            deleted_line + 'pub fn canonical_owner() -> &\'static str { "new" }\n',
+            encoding="utf-8",
+        )
+        require_success(["git", "add", *manifest_paths, rel_path], repo)
+        require_success(["git", "commit", "-q", "-m", "base"], repo)
+        require_success(["git", "checkout", "-q", "-b", "pr"], repo)
+
+        source_path.write_text(
+            'pub fn canonical_owner() -> &\'static str { "new" }\n',
+            encoding="utf-8",
+        )
+        require_success(["git", "add", rel_path], repo)
+        require_success(["git", "commit", "-q", "-m", "delete old path"], repo)
+        head_sha = require_success(["git", "rev-parse", "HEAD"], repo)
+
+        event_path = self.github_event_path(head_sha)
+        return run_gate(
+            [
+                "--repo",
+                str(repo),
+                "--base",
+                "main",
+                "--github-event",
+                str(event_path),
+            ]
+        )
+
+    def run_unsignaled_path_change(
+        self, rel_path: str, base_text: str, pr_text: str
+    ) -> subprocess.CompletedProcess[str]:
+        repo = self.create_repo()
+
+        changed_path = repo / rel_path
+        changed_path.parent.mkdir(parents=True, exist_ok=True)
+        changed_path.write_text(base_text, encoding="utf-8")
+        require_success(["git", "add", rel_path], repo)
+        require_success(["git", "commit", "-q", "-m", "base"], repo)
+        require_success(["git", "checkout", "-q", "-b", "pr"], repo)
+
+        changed_path.write_text(pr_text, encoding="utf-8")
+        require_success(["git", "add", rel_path], repo)
+        require_success(["git", "commit", "-q", "-m", "rewrite gate path"], repo)
+        head_sha = require_success(["git", "rev-parse", "HEAD"], repo)
+
+        event_path = self.github_event_path(head_sha)
+        return run_gate(
+            [
+                "--repo",
+                str(repo),
+                "--base",
+                "main",
+                "--github-event",
+                str(event_path),
+            ]
+        )
+
+    def create_repo(self) -> Path:
+        temp_dir = tempfile.TemporaryDirectory()
+        self.addCleanup(temp_dir.cleanup)
+        repo = Path(temp_dir.name)
+        require_success(["git", "init", "-q"], repo)
+        require_success(["git", "config", "user.email", "dogma@example.invalid"], repo)
+        require_success(["git", "config", "user.name", "Dogma Gate Test"], repo)
+        require_success(["git", "branch", "-M", "main"], repo)
+        return repo
+
+    def packet_with_proof(
+        self,
+        proof: str,
+        head_sha: str = "0000000000000000000000000000000000000000",
+        search_literal: str = "legacy_endpoint",
+        follow_up: str = "none",
+        preamble: str = "",
+    ) -> Path:
+        packet = tempfile.NamedTemporaryFile("w", delete=False, encoding="utf-8")
+        self.addCleanup(lambda: Path(packet.name).unlink(missing_ok=True))
+        with packet:
+            packet.write(
+                preamble
+                +
+                textwrap.dedent(
+                    f"""\
+                    ## Review Readiness Packet
+
+                    Current head SHA: {head_sha}
+
+                    Command output:
+
+                    ```text
+                    $ make dogma-cleanup-gate
+                    expected failure
+                    ```
+
+                    ## Old Path Amputation Proof
+
+                    | Old path | Classification | Search literal | Mechanical proof | Follow-up |
+                    | --- | --- | --- | --- | --- |
+                    | `legacy_endpoint` | made uncallable at boundary | `{search_literal}` | {proof} | {follow_up} |
+
+                    ## Complexity Delta
+
+                    - Docs/scripts/tests: 1 file.
+                    - Non-test implementation: 0 files.
+                    - Generated/schema churn: 0 files.
+
+                    ## Sample Passing Old Path Amputation Proof
+
+                    | Old path | Classification | Search literal | Mechanical proof | Follow-up |
+                    | --- | --- | --- | --- | --- |
+                    | `old/session-route` | deleted | `old/session-route` | No production references remain. | none |
+
+                    ## Sample Failing Old Path Amputation Proof
+
+                    | Old path | Classification | Search literal | Mechanical proof | Follow-up |
+                    | --- | --- | --- | --- | --- |
+                    | `old/session-route` | wrapped | `old/session-route` | A preferred path exists beside the old route. | none |
+                    """
+                )
+            )
+        return Path(packet.name)
+
+    def github_event_path(self, head_sha: str) -> Path:
+        event_file = tempfile.NamedTemporaryFile("w", delete=False, encoding="utf-8")
+        self.addCleanup(lambda: Path(event_file.name).unlink(missing_ok=True))
+        event_path = Path(event_file.name)
+        with event_file:
+            json.dump(
+                {
+                    "pull_request": {
+                        "title": "Cleanup runtime path",
+                        "body": textwrap.dedent(
+                            """\
+                            ## Summary
+
+                            Dogma cleanup PR: no
+
+                            - Moves callers to the typed owner without using a dogma label.
+                            """
+                        ),
+                        "labels": [],
+                        "head": {"sha": head_sha},
+                    }
+                },
+                event_file,
+            )
+        return event_path
+
+    def assert_stable_signal_required(
+        self,
+        result: subprocess.CompletedProcess[str],
+        rel_path: str,
+        reason: str = "ordinary source path",
+    ) -> None:
+        self.assertNotEqual(result.returncode, 0, result.stdout + result.stderr)
+        self.assertIn("Dogma cleanup gate required by stable diff signal", result.stdout)
+        self.assertIn(rel_path, result.stdout)
+        self.assertIn(reason, result.stdout)
+        self.assertIn("Review Readiness Packet is missing required heading", result.stderr)
+
+    def write_workspace_manifest(self, repo: Path, rel_path: str) -> list[str]:
+        if "/src/" not in rel_path:
+            return []
+        member = rel_path.split("/src/", 1)[0]
+        if member.startswith(("sdks/", "specs/")):
+            return []
+        (repo / "Cargo.toml").write_text(
+            textwrap.dedent(
+                f"""\
+                [workspace]
+                members = ["{member}"]
+                """
+            ),
+            encoding="utf-8",
+        )
+        return ["Cargo.toml"]
+
+    def workflow_step_body(self, step_name: str) -> str:
+        workflow = (REPO_ROOT / ".github" / "workflows" / "ci.yml").read_text(encoding="utf-8")
+        lines = workflow.splitlines()
+        for index, line in enumerate(lines):
+            if line.strip() != f"- name: {step_name}":
+                continue
+            for run_index in range(index + 1, len(lines)):
+                if lines[run_index].strip() != "run: |":
+                    continue
+                run_indent = len(lines[run_index]) - len(lines[run_index].lstrip())
+                block_prefix = " " * (run_indent + 2)
+                body_lines: list[str] = []
+                for body_line in lines[run_index + 1 :]:
+                    if not body_line.strip():
+                        body_lines.append("")
+                    elif body_line.startswith(block_prefix):
+                        body_lines.append(body_line[len(block_prefix) :])
+                    else:
+                        break
+                return "\n".join(body_lines)
+        raise AssertionError(f"workflow step not found: {step_name}")
+
+    def run_workflow_step_body(
+        self, body: str, workspace: Path
+    ) -> subprocess.CompletedProcess[str]:
+        env = os.environ.copy()
+        env["GITHUB_WORKSPACE"] = str(workspace)
+        return subprocess.run(
+            ["bash", "-e", "-u", "-o", "pipefail", "-c", body],
+            cwd=REPO_ROOT,
+            env=env,
+            text=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/xtask/tests/ci_gate_requires_rmat.rs
+++ b/xtask/tests/ci_gate_requires_rmat.rs
@@ -116,8 +116,12 @@ fn gate_job_requires_every_governance_lane() {
     let wrapper_needs = gate_needs(&ci_doc, &ci_yml);
     assert_eq!(
         wrapper_needs,
-        vec!["cargo".to_string(), "buildbuddy".to_string()],
-        "{} jobs.gate.needs must gate both reusable backend workflows",
+        vec![
+            "cargo".to_string(),
+            "buildbuddy".to_string(),
+            "dogma-cleanup-gate".to_string()
+        ],
+        "{} jobs.gate.needs must gate both reusable backend workflows and the dogma cleanup review boundary",
         ci_yml.display(),
     );
 
@@ -136,6 +140,28 @@ fn gate_job_requires_every_governance_lane() {
             missing.is_empty(),
             "jobs.gate.needs in {} is missing required governance lane(s): {missing:?}. Declared: {declared:?}. Add them to the gate.needs array in the reusable workflow.",
             workflow_path.display(),
+        );
+    }
+}
+
+#[test]
+fn dogma_gate_reruns_when_pr_signal_changes() {
+    let ci_yml = ci_yml_path();
+    let text = std::fs::read_to_string(&ci_yml)
+        .unwrap_or_else(|e| panic!("read {}: {e}", ci_yml.display()));
+    for action in [
+        "opened",
+        "synchronize",
+        "reopened",
+        "edited",
+        "labeled",
+        "unlabeled",
+        "ready_for_review",
+    ] {
+        assert!(
+            text.contains(&format!("- {action}")),
+            "{} pull_request trigger must include `{action}` so dogma cleanup gate decisions are recomputed when mutable PR signal changes",
+            ci_yml.display(),
         );
     }
 }


### PR DESCRIPTION
## Summary

Dogma cleanup PR: yes

- Add the dogma cleanup review gate, packet template, Make targets, provisional checker, fixtures, and CI wiring.
- Add a base-owned `pull_request_target` workflow for future PRs so PR-head workflow rewrites cannot remove the dogma admission job that schedules from `main`; the immutable job now reports the active required `CI gate` status context.
- Reject wrapper-only, mirror-only, adapter-only, preferred-path-only, retained rows, compatibility-retained proof, modal/intent retained-callability wording, retained SDK/app/tool/deployment paths, exposed/published/grandfathered/stability retention synonyms, unit-fixture proof laundered by bare `make`/`cargo` tokens, and deleted/uncallable rows whose named old production path still has production references under normalized literal forms.
- Treat impl-only Rust authority deletions as stable dogma cleanup signals, preserve ordinary local broad Make lane usability for non-dogma work, and keep explicit CI/packet dogma enforcement fail-closed.
- Keep the literal/diff scanner provisional; typed metadata replacement remains tracked by LUC-321.

Linear: LUC-316

## Validation

Latest exact-head validation for `0848d68ae9a029848fe559a69eff5d2b34053bb9`:

```text
$ python3 -m py_compile scripts/dogma_cleanup_gate.py scripts/tests/dogma_cleanup_gate_test.py
passed

$ python3 scripts/tests/dogma_cleanup_gate_test.py -v
Ran 51 tests in 14.598s
OK

$ make dogma-cleanup-gate-fixtures
Ran 51 tests in 14.727s
OK

$ env -u GITHUB_EVENT_PATH -u DOGMA_PACKET make dogma-cleanup-local-gate
Ran 51 tests in 14.779s
OK
Dogma cleanup gate skipped for local broad lane: set DOGMA_PACKET or GITHUB_EVENT_PATH to enforce.

$ env -u GITHUB_EVENT_PATH -u DOGMA_PACKET make dogma-cleanup-ci-gate
Ran 51 tests in 14.652s
OK
DOGMA_PACKET or GITHUB_EVENT_PATH is required for dogma cleanup CI enforcement.
make: *** [Makefile:361: dogma-cleanup-ci-gate] Error 2
(expected fail-closed negative validation with no PR event or DOGMA_PACKET)

$ make fmt-check
passed

$ ./scripts/repo-cargo test -p xtask --test ci_gate_requires_rmat
7 passed; 0 failed

$ git diff --check origin/main...HEAD && git diff --check
passed

$ make agent-gate
BuildBuddy doctor: 35 pass, 1 warn, 0 fail
BuildBuddy workspace CI (warm) wall: 339s
PASS workspace-fast-clippy-rbe; Executed 117 out of 175 tests: 175 tests pass.
PASS workspace-build-clippy-rbe
PASS e2e-system-rbe; Executed 10 out of 10 tests: 10 tests pass.
```

## Review Readiness Packet

Current head SHA: 0848d68ae9a029848fe559a69eff5d2b34053bb9
Command output: see Validation above. Branch is based on current `origin/main` `042879d752911a73fb39c8072b01f48b0d292334`. Required GitHub CI for this exact head is pending until this packet is pushed and checks complete.

Prior blocker resolution:

- Latest Human Review blocker for `c605834e4e5309cc52b9bb92b1e4e9a500f15360`: exact-literal/normalized-reference bypass is closed. Production reference scanning now normalizes both the packet search literal and candidate production lines, so search literal `legacy endpoint` matches production token `legacy_endpoint`. Negative coverage: `test_deleted_old_path_fails_when_normalized_literal_still_in_production` keeps `pub fn legacy_endpoint()` in `app/src/lib.rs` and verifies a `deleted` row with search literal `legacy endpoint` fails.
- Latest Human Review blocker for `c605834e4e5309cc52b9bb92b1e4e9a500f15360`: Rust impl-only authority deletions are stable dogma cleanup signals. `STRUCTURAL_SOURCE_DELETION` now catches removed `impl ... for ... {}` lines. Negative coverage: `test_unsignaled_impl_only_authority_cleanup_requires_packet` deletes only `impl BoundaryOwner for RuntimeOwner {}` from production workspace source and verifies the unsignaled PR requires a packet.
- Latest Human Review blocker for `c605834e4e5309cc52b9bb92b1e4e9a500f15360`: retained-compatibility synonyms now fail. Negative coverage in `test_retained_endpoint_synonym_packets_fail` includes `legacy endpoint remains exposed for semver stability`, `old route stays published for ABI stability`, and `legacy API is grandfathered for existing integrations`.
- Latest Human Review blocker for `c605834e4e5309cc52b9bb92b1e4e9a500f15360`: ordinary local `make agent-gate`, `make ci`, and `make ci-smoke` usability is restored for non-dogma work. Those broad lanes now depend on `dogma-cleanup-local-gate`, which runs the fixture oracle and enforces only when `GITHUB_EVENT_PATH` or `DOGMA_PACKET` is set; explicit `dogma-cleanup-ci-gate` remains fail-closed without event/packet. Negative/positive coverage: `test_make_ci_gate_fails_closed_without_event_or_packet`, `test_local_broad_lane_gate_skips_without_event_or_packet`, and `test_broad_make_lanes_use_local_dogma_gate`.
- Latest Human Review blocker for `c605834e4e5309cc52b9bb92b1e4e9a500f15360`: active required-check evidence is tied to the immutable gate. GitHub API evidence before this update showed active ruleset `Protect MAIN` requires status context `CI gate` only. This head changes `.github/workflows/dogma-cleanup-immutable-gate.yml` so the base-owned `pull_request_target` job reports `name: CI gate`, while `run-name: Dogma cleanup immutable review gate` preserves the audit label. After this workflow exists on `main`, a PR-head rewrite of `.github/workflows/ci.yml` cannot be the only producer satisfying the active required context while the base-owned immutable gate fails. Coverage: `test_pull_request_target_gate_uses_base_checker_without_pr_code_execution` asserts the immutable workflow uses `pull_request_target`, checks out the PR only as data, checks out base gate source, fetches the base commit for diff, invokes `python3 "$gate_script" --repo "$pr_repo"`, avoids PR-head tests/checker execution, and reports `name: CI gate`.
- Prior Human Review blocker for `5da6ff5fa2bf57aaae086aca50da5b5e07f3f38f`: `made uncallable at boundary` rows use the same production reference scan as `deleted` rows. If the row's search literal still appears in production reference paths, the gate fails instead of accepting proof wording alone. Negative coverage: `test_uncallable_old_path_fails_when_search_literal_still_in_production`.
- Prior Human Review blocker for `5da6ff5fa2bf57aaae086aca50da5b5e07f3f38f`: `uncallable` rows must provide a search literal that names or overlaps the old path, so a packet cannot dodge the production reference scan with an unrelated literal. Negative coverage: `test_uncallable_old_path_requires_related_search_literal`.
- Bootstrap limitation for this exact PR: the immutable `pull_request_target` workflow cannot protect PR #558 until the workflow exists on `main`. This PR is protected by the bootstrap PR-head `Dogma cleanup review gate`, direct base-checker invocation when available, local gate validation, the active required `CI gate`, and Human Review admission. After merge, future dogma cleanup PRs get the base-owned immutable admission job from `main` under the same required status context.
- Prior Human Review blocker for `0d4daf30d2ae8b36a9e142a471f3e197af105daf`: modal/intent retained-callability wording now fails, including `should`, `might`, `must`, `need to`, `expected to`, `intended to`, and `ought to` variants around old clients/routes/helpers/endpoints remaining usable, reachable, callable, or invocable.
- Prior Human Review blocker for `0d4daf30d2ae8b36a9e142a471f3e197af105daf`: bare `make` and `cargo` tokens no longer count as production-boundary evidence for unit-fixture/harness/mock proof. Negative fixtures cover `make test passed` and `cargo test passed` laundering attempts.
- Existing blocker coverage retained: PR-head Makefile no-op rewrites, gate-owning file changes, retained rows, wrapper/adapter/mirror/preferred-path proof, non-production-only proof, source deletions hidden by workspace-member removal, ordinary structural source deletions, and exact-head packet enforcement still require or fail the gate as before.

## Complexity Delta

- Docs/scripts/tests: 24 files, +3626/-9, covering PR template, CI workflows, Make gate wiring, process docs, checker script, fixtures, Python gate tests, BuildBuddy doctor expectation, Rust test fixtures, and CI-gate self-test.
- Non-test implementation: 6 Rust source files, +15/-12, with no product behavior change beyond the existing clippy/test-harness cleanup surface required by the broad gate.
- Generated/schema churn: 0 files.
- Commit shape: 1 non-merge commit on top of `origin/main`; total PR delta is 30 files, +3641/-21.

## Old Path Amputation Proof

| Old path | Classification | Search literal | Mechanical proof | Follow-up |
| --- | --- | --- | --- | --- |
| Dogma cleanup PR review without an exact-head packet | made uncallable at boundary | Dogma cleanup review without exact-head packet | Required CI and Make boundaries block access to review unless the PR body or packet validates for the exact current head. | none |
| PR-head Makefile or checker rewrite that turns the gate into a no-op | made uncallable at boundary | PR-head Makefile checker no-op rewrite | Gate-owning path changes trigger stable admission, and the CI job invokes the checker directly from base source when available, so CI gate blocks access before review for local no-op rewrites. | none |
| PR-head workflow rewrite that removes or masks the normal CI dogma job | made uncallable at boundary | PR-head workflow rewrite removes CI dogma job | After this PR lands, the base-owned immutable workflow schedules from `main`, treats the PR checkout only as data, reports the active required `CI gate` status context, and blocks access before review when immutable packet validation fails. | none |
| Compatibility proof admission path for legacy caller surface | made uncallable at boundary | compatibility caller surface admission | The checker blocks access before review for retained-use proof language across modal and intent caller surfaces, path states, SDK/app/tool/deployment subjects, and exposed/published/grandfathered/stability retention synonyms. | none |
| Non-production fixture proof laundered by bare `make` or `cargo` tokens | made uncallable at boundary | non-production fixture proof laundering | The checker rejects fixture proof that says calls are rejected when the claimed production boundary is bare `make` or `cargo`; it requires typed, route registry, export, symbol, API, or runtime boundary evidence. | none |
| Impl-only authority deletion hidden by no dogma PR signal | made uncallable at boundary | impl authority deletion signal | Stable diff detection treats removed Rust `impl ... for ... {}` production source lines as structural authority deletion and blocks access before review unless the unsignaled impl-only cleanup has the exact-head packet. | none |
| Residual old authority presented as clean closure | made uncallable at boundary | residual old authority clean closure | Residual rows block access before review as non-clean residual work; they must split to unresolved debt or become deleted or boundary-uncallable. | none |

## Sample Passing Old Path Amputation Proof

| Old path | Classification | Search literal | Mechanical proof | Follow-up |
| --- | --- | --- | --- | --- |
| `old/session-route` | deleted | `old/session-route` | No production references remain. | none |

## Sample Failing Old Path Amputation Proof

| Old path | Classification | Search literal | Mechanical proof | Follow-up |
| --- | --- | --- | --- | --- |
| `old/session-route` | wrapped | `old/session-route` | A preferred path exists beside the old route. | none |
| `wasm_contract_string_mirror` | retained with linked follow-up | `wasm_contract_string_mirror` | Retained for an active SDK cutover. | LUC-999 |

## Reviewer Dogma Gate

Before normal review, answer: which root authority leak collapsed, and what exact old path became impossible? If the answer is a wrapper, mirror, adapter, preferred path, retained follow-up row, PR-head-only check, or compatibility surface, move the PR to Rework.
