### PR TITLE
Fail closed on stale session projections

### DIFF
--- a/meerkat-runtime/src/driver/persistent.rs
+++ b/meerkat-runtime/src/driver/persistent.rs
@@ -171,6 +171,35 @@ impl PersistentRuntimeDriver {
         self.inner.sync_control_projection_from_dsl_authority();
     }
 
+    fn apply_destroy_dsl_authority(&mut self) -> Result<(), RuntimeDriverError> {
+        let fallback_session_id =
+            crate::meerkat_machine::dsl::SessionId::from(self.runtime_id.to_string());
+        let authority = self.inner.shared_dsl_authority();
+        let transition = {
+            let mut authority = authority
+                .lock()
+                .unwrap_or_else(std::sync::PoisonError::into_inner);
+            let session_id = authority
+                .state
+                .session_id
+                .clone()
+                .unwrap_or(fallback_session_id);
+            crate::meerkat_machine::dsl::MeerkatMachineMutator::apply(
+                &mut *authority,
+                crate::meerkat_machine::dsl::MeerkatMachineInput::Destroy { session_id },
+            )
+        };
+        transition
+            .map(|_| {
+                self.inner.sync_control_projection_from_dsl_authority();
+            })
+            .map_err(|err| {
+                RuntimeDriverError::Internal(format!(
+                    "DSL authority (Destroy) rejected runtime destroy: {err:?}"
+                ))
+            })
+    }
+
     /// Get pending events (delegates to inner).
     pub fn drain_events(&mut self) -> Vec<RuntimeEventEnvelope> {
         self.inner.drain_events()
@@ -475,8 +504,11 @@ impl PersistentRuntimeDriver {
 
     pub async fn destroy(&mut self) -> Result<DestroyReport, RuntimeDriverError> {
         let (checkpoint, report) = self.prepare_destroy_lifecycle();
-        self.inner
-            .force_runtime_authority(RuntimeState::Destroyed, None, None);
+        if let Err(err) = self.apply_destroy_dsl_authority() {
+            self.inner.restore_rollback_snapshot(checkpoint);
+            self.inner.sync_control_projection_from_dsl_authority();
+            return Err(err);
+        }
         self.commit_prepared_destroy_lifecycle(checkpoint).await?;
         Ok(report)
     }

--- a/meerkat-runtime/tests/driver_persistent.rs
+++ b/meerkat-runtime/tests/driver_persistent.rs
@@ -1004,6 +1004,37 @@ async fn direct_destroy_persists_destroyed_runtime_state() {
 }
 
 #[tokio::test]
+async fn direct_destroy_rejects_before_persisting_when_dsl_guard_rejects() {
+    let store = Arc::new(InMemoryRuntimeStore::new());
+    let rid = LogicalRuntimeId::new("test");
+    let mut driver = PersistentRuntimeDriver::new(
+        rid.clone(),
+        store.clone() as Arc<dyn RuntimeStore>,
+        memory_blob_store(),
+    );
+    driver.contract_force_runtime_authority(RuntimeState::Initializing, None, None);
+
+    let error = driver
+        .destroy()
+        .await
+        .expect_err("destroy without bound runtime identity must surface the DSL rejection");
+    assert!(
+        error.to_string().contains("DSL authority (Destroy)"),
+        "unexpected error: {error}",
+    );
+    assert_eq!(
+        driver.runtime_state(),
+        RuntimeState::Initializing,
+        "failed destroy must not override DSL lifecycle authority",
+    );
+    assert_ne!(
+        store.load_runtime_state(&rid).await.unwrap(),
+        Some(RuntimeState::Destroyed),
+        "failed destroy must not persist shell-projected destroyed state",
+    );
+}
+
+#[tokio::test]
 async fn recovery_lifecycle_commit_failure_restores_recovered_projection() {
     let inner = Arc::new(InMemoryRuntimeStore::new());
     let rid = LogicalRuntimeId::new("test");

--- a/meerkat-session/src/persistent.rs
+++ b/meerkat-session/src/persistent.rs
@@ -1393,13 +1393,14 @@ impl<B: SessionAgentBuilder + 'static> PersistentSessionService<B> {
                         "runtime snapshot persistence failed: {err}"
                     )))
                 })?;
-            if let Err(error) = self.store.save(&session).await {
+            self.store.save(&session).await.map_err(|error| {
                 tracing::warn!(
                     session_id = %session.id(),
                     error = %error,
                     "failed to update session-store projection after runtime authority commit"
                 );
-            }
+                SessionError::Store(Box::new(error))
+            })?;
         } else {
             self.store
                 .save(&session)
@@ -6850,6 +6851,90 @@ mod tests {
                 .iter()
                 .any(|summary| summary.session_id == result.session_id),
             "runtime-backed sessions should remain listable through the session-store projection after the live handle is gone"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_runtime_backed_projection_save_failure_fails_closed_and_list_uses_authority() {
+        let fail_store = Arc::new(FailSaveStore::new());
+        let store = Arc::clone(&fail_store) as Arc<dyn SessionStore>;
+        let runtime_store = Arc::new(InMemoryRuntimeStore::new());
+        let service = PersistentSessionService::new(
+            DummyBuilder,
+            4,
+            Arc::clone(&store),
+            Some(runtime_store),
+            memory_blob_store(),
+        );
+
+        let result = service
+            .create_session(create_request(
+                "hello",
+                meerkat_core::service::InitialTurnPolicy::Defer,
+            ))
+            .await
+            .expect("create_session should succeed before projection failures");
+        let raw_before = store
+            .load(&result.session_id)
+            .await
+            .expect("raw projection load should succeed")
+            .expect("initial projection should exist");
+        let raw_message_count = raw_before.messages().len();
+
+        fail_store.set_fail_save(true);
+        let error = service
+            .start_turn(
+                &result.session_id,
+                start_turn_request("runtime authority commits before projection failure"),
+            )
+            .await
+            .expect_err("projection save failure after runtime authority commit must fail closed");
+        assert!(
+            matches!(error, SessionError::Store(_)),
+            "projection failure should surface as a store error, got {error:?}"
+        );
+
+        let authoritative = service
+            .load_authoritative_session(&result.session_id)
+            .await
+            .expect("authoritative load should succeed")
+            .expect("runtime authority should still contain the committed turn");
+        assert!(
+            authoritative.messages().len() > raw_message_count,
+            "runtime authority should be ahead of the stale session-store projection"
+        );
+        let raw_after = store
+            .load(&result.session_id)
+            .await
+            .expect("raw projection load should succeed after failure")
+            .expect("stale projection should remain present");
+        assert_eq!(
+            raw_after.messages().len(),
+            raw_message_count,
+            "failed projection update must not be silently refreshed"
+        );
+
+        service
+            .discard_live_session(&result.session_id)
+            .await
+            .expect("test should be able to force list through the durable projection");
+        let listed = service
+            .list(SessionQuery::default())
+            .await
+            .expect("list should not fail while authoritative runtime snapshot exists");
+        let summary = listed
+            .iter()
+            .find(|summary| summary.session_id == result.session_id)
+            .expect("stale projection row should only identify the authoritative session");
+        assert_eq!(
+            summary.message_count,
+            authoritative.messages().len(),
+            "list() must report runtime authority, not stale SessionStore projection metadata"
+        );
+        assert_ne!(
+            summary.message_count,
+            raw_after.messages().len(),
+            "list() must not present stale projection state as fresh canonical state"
         );
     }
 

--- a/meerkat-session/src/persistent.rs
+++ b/meerkat-session/src/persistent.rs
@@ -1393,14 +1393,24 @@ impl<B: SessionAgentBuilder + 'static> PersistentSessionService<B> {
                         "runtime snapshot persistence failed: {err}"
                     )))
                 })?;
-            self.store.save(&session).await.map_err(|error| {
+            if let Err(error) = self.store.save(&session).await {
                 tracing::warn!(
                     session_id = %session.id(),
                     error = %error,
                     "failed to update session-store projection after runtime authority commit"
                 );
-                SessionError::Store(Box::new(error))
-            })?;
+                match self.discard_live_session(session.id()).await {
+                    Ok(()) | Err(SessionError::NotFound { .. }) => {}
+                    Err(discard_error) => {
+                        tracing::warn!(
+                            session_id = %session.id(),
+                            error = %discard_error,
+                            "failed to discard live session after runtime-backed projection update failure"
+                        );
+                    }
+                }
+                return Err(SessionError::Store(Box::new(error)));
+            }
         } else {
             self.store
                 .save(&session)
@@ -6913,11 +6923,13 @@ mod tests {
             raw_message_count,
             "failed projection update must not be silently refreshed"
         );
-
-        service
-            .discard_live_session(&result.session_id)
-            .await
-            .expect("test should be able to force list through the durable projection");
+        assert!(
+            !service
+                .has_live_session(&result.session_id)
+                .await
+                .expect("status should succeed after projection failure"),
+            "post-commit projection failure must evict stale live state"
+        );
         let listed = service
             .list(SessionQuery::default())
             .await
@@ -6935,6 +6947,136 @@ mod tests {
             summary.message_count,
             raw_after.messages().len(),
             "list() must not present stale projection state as fresh canonical state"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_runtime_backed_control_projection_save_failure_discards_live_state() {
+        let fail_store = Arc::new(FailSaveStore::new());
+        let store = Arc::clone(&fail_store) as Arc<dyn SessionStore>;
+        let runtime_store = Arc::new(InMemoryRuntimeStore::new());
+        let service = PersistentSessionService::new(
+            DummyBuilder,
+            4,
+            Arc::clone(&store),
+            Some(runtime_store),
+            memory_blob_store(),
+        );
+
+        let append_result = service
+            .create_session(create_request(
+                "hello",
+                meerkat_core::service::InitialTurnPolicy::Defer,
+            ))
+            .await
+            .expect("create_session should succeed before projection failures");
+
+        fail_store.set_fail_save(true);
+        let append_error = service
+            .append_system_context(
+                &append_result.session_id,
+                AppendSystemContextRequest {
+                    text: "runtime-backed control context".to_string(),
+                    source: Some("test".to_string()),
+                    idempotency_key: Some("control-projection-failure".to_string()),
+                },
+            )
+            .await
+            .expect_err("control projection save failure must fail closed");
+        assert!(
+            matches!(
+                append_error,
+                SessionControlError::Session(SessionError::Store(_))
+            ),
+            "projection failure should surface as a store error, got {append_error:?}"
+        );
+        assert!(
+            !service
+                .has_live_session(&append_result.session_id)
+                .await
+                .expect("status should succeed after append projection failure"),
+            "append projection failure after runtime commit must evict stale live state"
+        );
+        let append_authoritative = service
+            .load_authoritative_session(&append_result.session_id)
+            .await
+            .expect("authoritative load should succeed after append failure")
+            .expect("runtime authority should retain the committed append");
+        let append_state = append_authoritative
+            .system_context_state()
+            .expect("runtime authority should carry the committed append");
+        assert_eq!(append_state.pending.len(), 1);
+        assert_eq!(
+            append_state.pending[0].text,
+            "runtime-backed control context"
+        );
+        let append_raw = store
+            .load(&append_result.session_id)
+            .await
+            .expect("raw projection load should succeed after append failure")
+            .expect("stale append projection should remain present");
+        let raw_pending_context_count = append_raw
+            .system_context_state()
+            .map_or(0, |state| state.pending.len());
+        assert_eq!(
+            raw_pending_context_count, 0,
+            "failed append projection update must not silently refresh raw store state"
+        );
+
+        fail_store.set_fail_save(false);
+        let stage_result = service
+            .create_session(create_request(
+                "hello",
+                meerkat_core::service::InitialTurnPolicy::Defer,
+            ))
+            .await
+            .expect("second create_session should succeed before projection failures");
+
+        fail_store.set_fail_save(true);
+        let stage_error = service
+            .stage_tool_results(
+                &stage_result.session_id,
+                StageToolResultsRequest {
+                    results: vec![ToolResult::new(
+                        "tool-call-1".to_string(),
+                        "callback result".to_string(),
+                        false,
+                    )],
+                },
+            )
+            .await
+            .expect_err("staged tool-result projection save failure must fail closed");
+        assert!(
+            matches!(stage_error, SessionError::Store(_)),
+            "projection failure should surface as a store error, got {stage_error:?}"
+        );
+        assert!(
+            !service
+                .has_live_session(&stage_result.session_id)
+                .await
+                .expect("status should succeed after stage projection failure"),
+            "stage projection failure after runtime commit must evict stale live state"
+        );
+        let stage_authoritative = service
+            .load_authoritative_session(&stage_result.session_id)
+            .await
+            .expect("authoritative load should succeed after stage failure")
+            .expect("runtime authority should retain the staged tool results");
+        let stage_deferred = stage_authoritative
+            .deferred_turn_state()
+            .expect("runtime authority should carry staged tool results");
+        assert_eq!(stage_deferred.pending_tool_results.len(), 1);
+        let stage_raw = store
+            .load(&stage_result.session_id)
+            .await
+            .expect("raw projection load should succeed after stage failure")
+            .expect("stale stage projection should remain present");
+        let raw_tool_result_count = stage_raw
+            .deferred_turn_state()
+            .map_or(0, |state| state.pending_tool_results.len());
+        assert_eq!(
+            raw_tool_result_count, 0,
+            "failed stage projection update must not silently refresh raw store state"
         );
     }
 

--- a/meerkat-session/src/persistent.rs
+++ b/meerkat-session/src/persistent.rs
@@ -8040,7 +8040,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_live_runtime_list_status_and_resume_ignore_stale_raw_store_metadata() {
+    async fn test_live_runtime_list_status_and_resume_fail_closed_on_stale_raw_store_metadata() {
         let store: Arc<dyn SessionStore> = Arc::new(MemoryStore::new());
         let runtime_store = Arc::new(GatedSnapshotRuntimeStore::new());
         let service = PersistentSessionService::new(
@@ -8133,19 +8133,42 @@ mod tests {
             !resume_source.metadata().contains_key(SESSION_LABELS_KEY),
             "resume source must not inherit raw store metadata"
         );
-        let resumed = restarted
+        let resume_error = restarted
             .create_session(resume_request(resume_source))
             .await
-            .expect("resume should materialize runtime truth");
-        assert_eq!(resumed.session_id, result.session_id);
-        let resumed_live = restarted
-            .export_live_session(&result.session_id)
+            .expect_err(
+                "resume must fail closed when projection refresh would shrink stale raw state",
+            );
+        assert!(
+            matches!(resume_error, SessionError::Store(_)),
+            "stale projection refresh failure should surface as a store error, got {resume_error:?}"
+        );
+        assert!(
+            !restarted
+                .has_live_session(&result.session_id)
+                .await
+                .expect("status should succeed after failed resume"),
+            "failed projection refresh must discard the materialized live session"
+        );
+        let authoritative_after_failure = restarted
+            .load_authoritative_session(&result.session_id)
             .await
-            .expect("resumed live session should export");
+            .expect("authoritative load should still succeed after failed resume")
+            .expect("runtime authority should remain present after failed resume");
         assert_eq!(
-            resumed_live.messages().len(),
+            authoritative_after_failure.messages().len(),
             live.messages().len(),
-            "resumed live session must preserve runtime-authoritative metadata"
+            "failed projection refresh must not replace runtime-authoritative metadata"
+        );
+        let raw_after_failure = store
+            .load(&result.session_id)
+            .await
+            .expect("raw projection load should still succeed")
+            .expect("stale projection should remain present after failed resume");
+        assert_eq!(
+            raw_after_failure.messages().len(),
+            live.messages().len() + 1,
+            "failed projection refresh must not silently rewrite stale raw projection state"
         );
     }
 


### PR DESCRIPTION
## Summary
- fail closed when runtime-backed `SessionStore` projection saves fail after runtime authority commits
- add regression fixtures proving public listing/resume paths do not present stale projection rows as fresh canonical state
- stage persistent driver destroy through the DSL before any destroyed shell state can be persisted

## Validation
- `./scripts/repo-cargo test -p meerkat-session --features session-store --lib test_runtime_backed_projection_save_failure_fails_closed_and_list_uses_authority`
- `./scripts/repo-cargo test -p meerkat-session --features session-store --lib test_runtime_backed_control_projection_save_failure_discards_live_state`
- `./scripts/repo-cargo test -p meerkat-session --features session-store --lib test_live_runtime_list_status_and_resume_fail_closed_on_stale_raw_store_metadata`
- `./scripts/repo-cargo test -p meerkat-session --features session-store --lib runtime_backed`
- `./scripts/repo-cargo test -p meerkat-session --features session-store --lib`
- `./scripts/repo-cargo test -p meerkat-runtime --test driver_persistent direct_destroy`
- `./scripts/repo-cargo test -p meerkat-runtime --test driver_persistent`
- `make check` (BuildBuddy invocation `b437d30c-46db-4e13-98ce-02fda04ce732`)
- `make lint` (BuildBuddy invocation `eb9bf704-c886-449b-984f-f48237ab058a`)
- `make buildbuddy-test-unit` (BuildBuddy invocations `0af01d74-68c2-404f-8d0d-b3f1461c1aea`, `e6784322-e4f0-45bd-91d1-0d9ed45e3644`)
- `git diff --check origin/main..HEAD`

## Review Readiness Packet

Current head SHA: a98047978742d04608022e18b7b134f8811c97c6
Base: `main` at `777d5c33ffb1d318b5d85e69629731bb0c75f626`
Linear: LUC-335
Dogma cleanup PR: yes
Admission note: this PR carries the local Old Path Amputation Proof required while the LUC-316 gate is not yet the source of admission for this slice.

Command output:

```text
$ python3 /home/luka_crnkovicfriis_king_com/symphony/workspaces/LUC-316/scripts/dogma_cleanup_gate.py --repo . --base origin/main --head-sha a98047978742d04608022e18b7b134f8811c97c6 --packet <(gh pr view 560 --json body --jq .body)
Dogma cleanup gate passed for /dev/fd/63
```

## Old Path Amputation Proof

| Old path | Classification | Search literal | Mechanical proof | Follow-up |
| --- | --- | --- | --- | --- |
| stale `SessionStore` projection warn-only authority path after runtime commit | made uncallable at boundary | `save_normalized_session` | `test_runtime_backed_projection_save_failure_fails_closed_and_list_uses_authority` injects post-commit `SessionStore::save` failure; the public mutation returns `SessionError::Store`, evicts the live handle, and rejects calls from observing a success result on stale projection metadata. | none |
| raw `SessionStore::list`/status projection treated as runtime-backed canonical state | made uncallable at boundary | `list_runtime_session_summaries` | `test_live_runtime_list_status_and_resume_fail_closed_on_stale_raw_store_metadata` rejects calls that would publish stale raw store metadata as canonical state; listing and status read runtime authority, and resume returns `SessionError::Store` when projection refresh is rejected. | none |
| shell-first destroy projection before DSL authority acceptance | made uncallable at boundary | `PersistentRuntimeDriver::destroy` | `direct_destroy_rejects_before_persisting_when_dsl_guard_rejects` rejects calls before the shell lifecycle commit persists `Destroyed`; durable state is not written when DSL authority rejects `Destroy`. | none |
| post-commit live handle after projection save failure | made uncallable at boundary | `discard_live_session_after_projection_failure` | `test_runtime_backed_control_projection_save_failure_discards_live_state` rejects calls from using the post-failure live handle; the handle is evicted after the store error so later saves cannot mask the projection failure. | none |

## Complexity Delta

- Docs/scripts/tests: 1 file (`meerkat-runtime/tests/driver_persistent.rs`).
- Non-test implementation: 2 files (`meerkat-session/src/persistent.rs`, `meerkat-runtime/src/driver/persistent.rs`).
- Generated/schema churn: 0 files.

## Negative Fixtures
- `test_runtime_backed_projection_save_failure_fails_closed_and_list_uses_authority` injects projection save failure after runtime authority commit and asserts the public mutation fails closed while `list()` reports runtime authority rather than the stale projection.
- `test_runtime_backed_control_projection_save_failure_discards_live_state` covers runtime-backed control mutations and asserts projection failure returns an error, evicts live state, preserves runtime authority, and leaves the raw projection stale.
- `test_live_runtime_list_status_and_resume_fail_closed_on_stale_raw_store_metadata` proves listing/status do not consume stale raw metadata and resume fails closed when projection refresh would rewrite stale raw state.
- `direct_destroy_rejects_before_persisting_when_dsl_guard_rejects` proves shell destroy projection cannot persist semantic destroyed state after DSL rejection.

## Sample Passing Old Path Amputation Proof

| Old path | Classification | Search literal | Mechanical proof | Follow-up |
| --- | --- | --- | --- | --- |
| `old/session-route` | deleted | `old/session-route` | No production references remain after removal. | none |
| `legacy/control-projection` | made uncallable at boundary | `legacy/control-projection` | Boundary test rejects calls before semantic authority accepts the transition. | none |

## Sample Failing Old Path Amputation Proof

| Old path | Classification | Search literal | Mechanical proof | Follow-up |
| --- | --- | --- | --- | --- |
| `old/session-route` | wrapped | `old/session-route` | A preferred path exists beside the old route. | none |
| `legacy/control-projection` | retained with linked follow-up | `legacy/control-projection` | Rejected calls prove a boundary, but a compatibility surface is preserved for migration. | LUC-999 |

## CI / Review Gate
- Current PR head is mergeable (`CLEAN`) and all GitHub checks were green on run `25273475318` before this metadata-only rework.
- The only Codex AI review is a `COMMENTED` suggestion on older commit `b1268f4953`; current head `a980479787` addresses it by discarding live state after post-commit projection save failures.
- No blocking or requested-changes AI review is present for the exact head.

Linear: LUC-335
