### PR TITLE
LUC-332 provider-aware model capability boundary

### DIFF
--- a/meerkat-anthropic/src/client.rs
+++ b/meerkat-anthropic/src/client.rs
@@ -9,7 +9,7 @@ use meerkat_core::lifecycle::run_primitive::{
     AnthropicProviderTag, AnthropicThinkingConfig, ProviderTag,
 };
 use meerkat_core::schema::{CompiledSchema, SchemaError};
-use meerkat_core::{ContentBlock, ImageData, Message, OutputSchema, StopReason, Usage};
+use meerkat_core::{ContentBlock, ImageData, Message, OutputSchema, Provider, StopReason, Usage};
 use meerkat_llm_core::LlmError;
 use meerkat_llm_core::{LlmClient, LlmDoneOutcome, LlmEvent, LlmRequest, LlmStream};
 use meerkat_llm_core::{http, streaming};
@@ -139,18 +139,23 @@ fn anthropic_tag(request: &LlmRequest) -> Option<&AnthropicProviderTag> {
 }
 
 fn catalog_beta_value(request: &LlmRequest, feature: &str) -> Option<&'static str> {
-    meerkat_core::model_profile::capabilities::capabilities_for("anthropic", &request.model)?
-        .beta_headers
-        .iter()
-        .find(|header| header.feature == feature)
-        .map(|header| header.header_value)
+    meerkat_core::model_profile::capabilities::capabilities_for(
+        Provider::Anthropic,
+        &request.model,
+    )?
+    .beta_headers
+    .iter()
+    .find(|header| header.feature == feature)
+    .map(|header| header.header_value)
 }
 
 fn catalog_context_beta_value(request: &LlmRequest) -> Option<&'static str> {
-    let header =
-        meerkat_core::model_profile::capabilities::capabilities_for("anthropic", &request.model)?
-            .context_window_beta?
-            .header;
+    let header = meerkat_core::model_profile::capabilities::capabilities_for(
+        Provider::Anthropic,
+        &request.model,
+    )?
+    .context_window_beta?
+    .header;
     header.strip_prefix("anthropic-beta: ")
 }
 

--- a/meerkat-core/src/model_profile/anthropic.rs
+++ b/meerkat-core/src/model_profile/anthropic.rs
@@ -1,10 +1,11 @@
 //! Anthropic catalog-backed request helpers.
 //!
-//! Capability facts for Anthropic models live in
-//! [`crate::model_profile::capabilities::anthropic`]. This module only exposes
+//! Capability facts for Anthropic models live in the typed
+//! [`crate::model_profile::capabilities`] catalog. This module only exposes
 //! request-shaping helpers for provider clients; uncatalogued model IDs do not
 //! synthesize semantic capabilities from name prefixes.
 
+use crate::Provider;
 use crate::model_profile::capabilities::capabilities_for;
 
 /// Whether the model accepts a non-default `temperature`.
@@ -12,7 +13,7 @@ use crate::model_profile::capabilities::capabilities_for;
 /// Catalog rows are authoritative. Unknown model IDs return `false` so callers
 /// do not send optional provider parameters based on model-name folklore.
 pub fn supports_temperature(model: &str) -> bool {
-    capabilities_for("anthropic", model).is_some_and(|caps| caps.supports_temperature)
+    capabilities_for(Provider::Anthropic, model).is_some_and(|caps| caps.supports_temperature)
 }
 
 #[cfg(test)]

--- a/meerkat-core/src/model_profile/capabilities.rs
+++ b/meerkat-core/src/model_profile/capabilities.rs
@@ -10,11 +10,23 @@
 //! broad model groups (e.g. "opus 4.6 bucket" served both Opus 4.6 and 4.7;
 //! "standard" served everything else), flattening real differences such as
 //! Opus 4.7's `xhigh` effort tier or Sonnet 4.5's 1M context beta.
+//!
+//! Public callers must cross the typed [`crate::Provider`] boundary before
+//! reading capability truth; raw row iteration is intentionally crate-private:
+//!
+//! ```compile_fail
+//! let _ = meerkat_core::model_profile::capabilities::all_capabilities();
+//! ```
+//!
+//! ```compile_fail
+//! let _ = meerkat_core::model_profile::capabilities::gemini::CAPABILITIES;
+//! ```
 
-pub mod anthropic;
-pub mod gemini;
-pub mod openai;
+mod anthropic;
+mod gemini;
+mod openai;
 
+use crate::Provider;
 use crate::model_profile::catalog::ModelTier;
 
 /// Full per-model capability record.
@@ -34,8 +46,8 @@ pub struct ModelCapabilities {
     // ── Identity ──────────────────────────────────────────────────────
     /// Model identifier (e.g. `"claude-opus-4-7"`).
     pub id: &'static str,
-    /// Canonical provider string (`"anthropic"`, `"openai"`, `"gemini"`).
-    pub provider: &'static str,
+    /// Typed provider that owns this capability row.
+    pub provider: Provider,
     /// Human-readable display name.
     pub display_name: &'static str,
     /// Recommendation tier.
@@ -146,23 +158,35 @@ pub enum ThinkingSupport {
     GeminiThinkingLevel,
 }
 
-/// Lookup a model's capabilities by provider + id.
+/// Lookup a model's capabilities by typed provider + id.
 ///
 /// Returns `None` when the provider/model pair has no capability row.
 /// Callers must treat `None` as unknown capability truth; uncatalogued model
 /// IDs must not synthesize semantic facts from model-name folklore.
-pub fn capabilities_for(provider: &str, model_id: &str) -> Option<&'static ModelCapabilities> {
+///
+/// Provider/display strings are intentionally rejected at compile time:
+///
+/// ```compile_fail
+/// let _ = meerkat_core::model_profile::capabilities::capabilities_for(
+///     "gemini",
+///     "gemini-3-flash-preview",
+/// );
+/// ```
+pub fn capabilities_for(provider: Provider, model_id: &str) -> Option<&'static ModelCapabilities> {
     let table: &'static [ModelCapabilities] = match provider {
-        "anthropic" => anthropic::CAPABILITIES,
-        "openai" => openai::CAPABILITIES,
-        "gemini" => gemini::CAPABILITIES,
+        Provider::Anthropic => anthropic::CAPABILITIES,
+        Provider::OpenAI => openai::CAPABILITIES,
+        Provider::Gemini => gemini::CAPABILITIES,
         _ => return None,
     };
     table.iter().find(|c| c.id == model_id)
 }
 
 /// Iterate every known capability record across all providers.
-pub fn all_capabilities() -> impl Iterator<Item = &'static ModelCapabilities> {
+///
+/// This is crate-internal so public callers cannot obtain semantic capability
+/// rows through provider/model string filtering or model-only row scans.
+pub(crate) fn all_capabilities() -> impl Iterator<Item = &'static ModelCapabilities> {
     anthropic::CAPABILITIES
         .iter()
         .chain(openai::CAPABILITIES.iter())
@@ -177,34 +201,38 @@ mod tests {
     #[test]
     fn every_capability_matches_a_catalog_entry() {
         for caps in all_capabilities() {
-            let entry = crate::model_profile::catalog::entry_for(caps.provider, caps.id);
+            let entry = crate::model_profile::catalog::entry_for(caps.provider.as_str(), caps.id);
             assert!(
                 entry.is_some(),
                 "capability row '{}' (provider '{}') has no catalog entry",
                 caps.id,
-                caps.provider,
+                caps.provider.as_str(),
             );
         }
     }
 
     #[test]
     fn no_duplicate_capability_ids_within_provider() {
-        for provider in crate::model_profile::catalog::provider_names() {
+        for provider_name in crate::model_profile::catalog::provider_names() {
+            let provider = Provider::parse_strict(provider_name)
+                .unwrap_or_else(|| panic!("catalog provider '{provider_name}' must parse"));
             let ids: Vec<&str> = all_capabilities()
-                .filter(|c| c.provider == *provider)
+                .filter(|c| c.provider == provider)
                 .map(|c| c.id)
                 .collect();
             let mut unique: Vec<&str> = ids.clone();
             unique.sort_unstable();
             unique.dedup();
-            assert_eq!(ids.len(), unique.len(), "duplicate ids in {provider}");
+            assert_eq!(ids.len(), unique.len(), "duplicate ids in {provider_name}");
         }
     }
 
     #[test]
     fn every_catalog_entry_has_capabilities() {
         for entry in crate::model_profile::catalog::catalog() {
-            let caps = capabilities_for(entry.provider, entry.id);
+            let provider = Provider::parse_strict(entry.provider)
+                .unwrap_or_else(|| panic!("catalog provider '{}' must parse", entry.provider));
+            let caps = capabilities_for(provider, entry.id);
             assert!(
                 caps.is_some(),
                 "catalog model '{}' (provider '{}') has no capability row",
@@ -217,7 +245,7 @@ mod tests {
     #[test]
     fn tier_matches_catalog_entry() {
         for caps in all_capabilities() {
-            let entry = crate::model_profile::catalog::entry_for(caps.provider, caps.id)
+            let entry = crate::model_profile::catalog::entry_for(caps.provider.as_str(), caps.id)
                 .unwrap_or_else(|| panic!("missing catalog entry for {}", caps.id));
             assert_eq!(caps.tier, entry.tier, "tier mismatch for {}", caps.id);
         }
@@ -226,7 +254,7 @@ mod tests {
     #[test]
     fn claude_haiku_45_is_cataloged_with_official_limits() {
         for model in ["claude-haiku-4-5-20251001", "claude-haiku-4-5"] {
-            let caps = capabilities_for("anthropic", model)
+            let caps = capabilities_for(Provider::Anthropic, model)
                 .unwrap_or_else(|| panic!("{model} must be in the Anthropic catalog"));
             assert_eq!(caps.model_family, "claude-haiku-4");
             assert_eq!(caps.context_window, 200_000);
@@ -234,5 +262,22 @@ mod tests {
             assert_eq!(caps.thinking, ThinkingSupport::AnthropicEnabledOnly);
             assert!(!caps.supports_compaction);
         }
+    }
+
+    #[test]
+    fn typed_provider_mismatch_fails_closed() {
+        assert!(capabilities_for(Provider::Anthropic, "gpt-5.4").is_none());
+        assert!(capabilities_for(Provider::OpenAI, "gemini-3-flash-preview").is_none());
+        assert!(capabilities_for(Provider::Other, "gpt-5.4").is_none());
+    }
+
+    #[test]
+    fn display_provider_string_cannot_be_promoted_to_capability_owner() {
+        let display_provider = Provider::parse_strict("Gemini").unwrap_or(Provider::Other);
+        assert_eq!(display_provider, Provider::Other);
+        assert!(
+            capabilities_for(display_provider, "gemini-3-flash-preview").is_none(),
+            "display provider strings must fail closed at the typed capability boundary"
+        );
     }
 }

--- a/meerkat-core/src/model_profile/capabilities/anthropic.rs
+++ b/meerkat-core/src/model_profile/capabilities/anthropic.rs
@@ -6,6 +6,7 @@
 //! `context-windows`, `compaction`, `structured-outputs`).
 
 use super::{BetaHeader, BetaValue, ModelCapabilities, ThinkingSupport};
+use crate::Provider;
 use crate::model_profile::catalog::ModelTier;
 
 // ── Beta headers ──────────────────────────────────────────────────────────
@@ -85,7 +86,7 @@ pub const CAPABILITIES: &[ModelCapabilities] = &[
     //     (supported; compact-2026-01-12 beta header)
     ModelCapabilities {
         id: "claude-opus-4-7",
-        provider: "anthropic",
+        provider: Provider::Anthropic,
         display_name: "Claude Opus 4.7",
         tier: ModelTier::Recommended,
         model_family: "claude-opus-4",
@@ -126,7 +127,7 @@ pub const CAPABILITIES: &[ModelCapabilities] = &[
     //     (supported, low/medium/high/max; no xhigh)
     ModelCapabilities {
         id: "claude-opus-4-6",
-        provider: "anthropic",
+        provider: Provider::Anthropic,
         display_name: "Claude Opus 4.6",
         tier: ModelTier::Supported,
         model_family: "claude-opus-4",
@@ -170,7 +171,7 @@ pub const CAPABILITIES: &[ModelCapabilities] = &[
     //     (supported via compact-2026-01-12)
     ModelCapabilities {
         id: "claude-sonnet-4-6",
-        provider: "anthropic",
+        provider: Provider::Anthropic,
         display_name: "Claude Sonnet 4.6",
         tier: ModelTier::Recommended,
         model_family: "claude-sonnet-4",
@@ -218,7 +219,7 @@ pub const CAPABILITIES: &[ModelCapabilities] = &[
     //     (explicitly lists claude-sonnet-4-5)
     ModelCapabilities {
         id: "claude-sonnet-4-5",
-        provider: "anthropic",
+        provider: Provider::Anthropic,
         display_name: "Claude Sonnet 4.5",
         tier: ModelTier::Supported,
         model_family: "claude-sonnet-4",
@@ -257,7 +258,7 @@ pub const CAPABILITIES: &[ModelCapabilities] = &[
     //     (manual thinking supported; Claude Haiku 4.5 supports up to 64k output)
     ModelCapabilities {
         id: "claude-haiku-4-5-20251001",
-        provider: "anthropic",
+        provider: Provider::Anthropic,
         display_name: "Claude Haiku 4.5",
         tier: ModelTier::Recommended,
         model_family: "claude-haiku-4",
@@ -290,7 +291,7 @@ pub const CAPABILITIES: &[ModelCapabilities] = &[
     // resolution stays registry-owned instead of falling back to prefix folklore.
     ModelCapabilities {
         id: "claude-haiku-4-5",
-        provider: "anthropic",
+        provider: Provider::Anthropic,
         display_name: "Claude Haiku 4.5",
         tier: ModelTier::Recommended,
         model_family: "claude-haiku-4",
@@ -335,7 +336,7 @@ pub const CAPABILITIES: &[ModelCapabilities] = &[
     //     (NOT supported — Opus 4.5 is not in the supported-models list)
     ModelCapabilities {
         id: "claude-opus-4-5",
-        provider: "anthropic",
+        provider: Provider::Anthropic,
         display_name: "Claude Opus 4.5",
         tier: ModelTier::Supported,
         model_family: "claude-opus-4",

--- a/meerkat-core/src/model_profile/capabilities/gemini.rs
+++ b/meerkat-core/src/model_profile/capabilities/gemini.rs
@@ -5,6 +5,7 @@
 //! and `ai.google.dev/gemini-api/docs/gemini-3`.
 
 use super::{ModelCapabilities, ThinkingSupport};
+use crate::Provider;
 use crate::model_profile::catalog::ModelTier;
 
 /// Capability rows for Gemini catalog models.
@@ -23,7 +24,7 @@ pub const CAPABILITIES: &[ModelCapabilities] = &[
     //     (thinking_budget accepted for backward compatibility)
     ModelCapabilities {
         id: "gemini-3-flash-preview",
-        provider: "gemini",
+        provider: Provider::Gemini,
         display_name: "Gemini 3 Flash Preview",
         tier: ModelTier::Recommended,
         model_family: "gemini-3",
@@ -65,7 +66,7 @@ pub const CAPABILITIES: &[ModelCapabilities] = &[
     //     migrate to 3.1 Pro
     ModelCapabilities {
         id: "gemini-3.1-pro-preview",
-        provider: "gemini",
+        provider: Provider::Gemini,
         display_name: "Gemini 3.1 Pro Preview",
         tier: ModelTier::Supported,
         model_family: "gemini-3",
@@ -103,7 +104,7 @@ pub const CAPABILITIES: &[ModelCapabilities] = &[
     //     (thinking_level default "minimal")
     ModelCapabilities {
         id: "gemini-3.1-flash-lite-preview",
-        provider: "gemini",
+        provider: Provider::Gemini,
         display_name: "Gemini 3.1 Flash Lite Preview",
         tier: ModelTier::Supported,
         model_family: "gemini-3",

--- a/meerkat-core/src/model_profile/capabilities/openai.rs
+++ b/meerkat-core/src/model_profile/capabilities/openai.rs
@@ -5,6 +5,7 @@
 //! `openai.com/index/*`, and the Codex model index.
 
 use super::{ModelCapabilities, ThinkingSupport};
+use crate::Provider;
 use crate::model_profile::catalog::ModelTier;
 
 /// Reasoning-effort levels accepted by recent GPT-5.x models (5.4, 5.5, 5.5-pro).
@@ -33,7 +34,7 @@ pub const CAPABILITIES: &[ModelCapabilities] = &[
     // request policy does not infer facts from the model name.
     ModelCapabilities {
         id: "gpt-5.5",
-        provider: "openai",
+        provider: Provider::OpenAI,
         display_name: "GPT-5.5",
         tier: ModelTier::Recommended,
         model_family: "gpt-5",
@@ -66,7 +67,7 @@ pub const CAPABILITIES: &[ModelCapabilities] = &[
     // not derived from the `-pro` suffix.
     ModelCapabilities {
         id: "gpt-5.5-pro",
-        provider: "openai",
+        provider: Provider::OpenAI,
         display_name: "GPT-5.5 Pro",
         tier: ModelTier::Recommended,
         model_family: "gpt-5",
@@ -106,7 +107,7 @@ pub const CAPABILITIES: &[ModelCapabilities] = &[
     // supported choice but the catalog default points at 5.5.
     ModelCapabilities {
         id: "gpt-5.4",
-        provider: "openai",
+        provider: Provider::OpenAI,
         display_name: "GPT-5.4",
         tier: ModelTier::Supported,
         model_family: "gpt-5",
@@ -148,7 +149,7 @@ pub const CAPABILITIES: &[ModelCapabilities] = &[
     //      built-in computer use, and compaction)
     ModelCapabilities {
         id: "gpt-5.4-mini",
-        provider: "openai",
+        provider: Provider::OpenAI,
         display_name: "GPT-5.4 Mini",
         tier: ModelTier::Supported,
         model_family: "gpt-5",
@@ -186,7 +187,7 @@ pub const CAPABILITIES: &[ModelCapabilities] = &[
     //   - Web search: not listed among Codex-supported tools on the model page
     ModelCapabilities {
         id: "gpt-5.3-codex",
-        provider: "openai",
+        provider: Provider::OpenAI,
         display_name: "GPT-5.3 Codex",
         tier: ModelTier::Supported,
         model_family: "codex",
@@ -229,7 +230,7 @@ pub const CAPABILITIES: &[ModelCapabilities] = &[
     // to a realtime-capable model before opening a realtime channel.
     ModelCapabilities {
         id: "gpt-realtime-1.5",
-        provider: "openai",
+        provider: Provider::OpenAI,
         display_name: "GPT Realtime 1.5",
         tier: ModelTier::Recommended,
         model_family: "gpt-realtime",
@@ -267,7 +268,7 @@ pub const CAPABILITIES: &[ModelCapabilities] = &[
     // 1.5 rollout window.
     ModelCapabilities {
         id: "gpt-realtime",
-        provider: "openai",
+        provider: Provider::OpenAI,
         display_name: "GPT Realtime (legacy alias)",
         tier: ModelTier::Supported,
         model_family: "gpt-realtime",

--- a/meerkat-core/src/model_profile/catalog.rs
+++ b/meerkat-core/src/model_profile/catalog.rs
@@ -76,7 +76,7 @@ pub fn catalog() -> &'static [CatalogEntry] {
             .map(|c| CatalogEntry {
                 id: c.id,
                 display_name: c.display_name,
-                provider: c.provider,
+                provider: c.provider.as_str(),
                 tier: c.tier,
                 context_window: Some(c.context_window),
                 max_output_tokens: Some(c.max_output_tokens),
@@ -252,10 +252,12 @@ mod tests {
     #[test]
     fn catalog_matches_capability_table() {
         for entry in catalog() {
-            let caps = capabilities::capabilities_for(entry.provider, entry.id)
+            let provider = crate::Provider::parse_strict(entry.provider)
+                .unwrap_or_else(|| panic!("catalog provider '{}' must parse", entry.provider));
+            let caps = capabilities::capabilities_for(provider, entry.id)
                 .expect("catalog entry must have a capability row");
             assert_eq!(entry.id, caps.id);
-            assert_eq!(entry.provider, caps.provider);
+            assert_eq!(entry.provider, caps.provider.as_str());
             assert_eq!(entry.display_name, caps.display_name);
             assert_eq!(entry.tier, caps.tier);
             assert_eq!(entry.context_window, Some(caps.context_window));

--- a/meerkat-core/src/model_profile/gemini.rs
+++ b/meerkat-core/src/model_profile/gemini.rs
@@ -1,5 +1,5 @@
 //! Gemini catalog module.
 //!
-//! Capability facts for Gemini models live in
-//! [`crate::model_profile::capabilities::gemini`]. This module intentionally
+//! Capability facts for Gemini models live in the typed
+//! [`crate::model_profile::capabilities`] catalog. This module intentionally
 //! has no fallback capability synthesis for uncatalogued model IDs.

--- a/meerkat-core/src/model_profile/mod.rs
+++ b/meerkat-core/src/model_profile/mod.rs
@@ -22,6 +22,7 @@ pub mod gemini;
 pub mod openai;
 pub mod schema_builder;
 
+use crate::Provider;
 use crate::model_profile::capabilities::{
     BetaHeader, ModelCapabilities, ThinkingSupport, capabilities_for,
 };
@@ -90,29 +91,28 @@ impl From<&BetaHeader> for ModelBetaHeader {
     }
 }
 
-/// Look up the profile for a model by provider string and model ID.
+/// Look up the profile for a model by typed provider and model ID.
 ///
 /// Catalog models project directly from their capability row. Uncatalogued
 /// model IDs return `None`; semantic capability facts must come from the
 /// capability catalog, not model-name prefixes.
 ///
-/// Returns `None` if the provider is unknown or the model doesn't match any
-/// recognized family.
-pub fn profile_for(provider: &str, model: &str) -> Option<ModelProfile> {
+/// Returns `None` if the provider/model pair has no catalog capability row.
+pub fn profile_for(provider: Provider, model: &str) -> Option<ModelProfile> {
     capabilities_for(provider, model).map(project_to_profile)
 }
 
-/// Look up whether a model accepts inline video by provider string and model ID.
+/// Look up whether a model accepts inline video by typed provider and model ID.
 ///
 /// Returns `None` when the provider/model pair has no capability row.
-pub fn inline_video_support_for(provider: &str, model: &str) -> Option<bool> {
+pub fn inline_video_support_for(provider: Provider, model: &str) -> Option<bool> {
     capabilities_for(provider, model).map(|caps| caps.inline_video)
 }
 
 /// Project a capability record into the [`ModelProfile`] surface.
 pub(crate) fn project_to_profile(caps: &ModelCapabilities) -> ModelProfile {
     ModelProfile {
-        provider: caps.provider.to_string(),
+        provider: caps.provider.as_str().to_string(),
         model_family: caps.model_family.to_string(),
         supports_temperature: caps.supports_temperature,
         supports_thinking: caps.thinking != ThinkingSupport::None,
@@ -137,10 +137,15 @@ pub(crate) fn project_to_profile(caps: &ModelCapabilities) -> ModelProfile {
 mod tests {
     use super::*;
 
+    fn provider_from_catalog(provider: &str) -> Provider {
+        Provider::parse_strict(provider)
+            .unwrap_or_else(|| panic!("catalog provider '{provider}' must parse"))
+    }
+
     #[test]
     fn profile_for_all_catalog_models() {
         for entry in crate::model_profile::catalog::catalog() {
-            let profile = profile_for(entry.provider, entry.id);
+            let profile = profile_for(provider_from_catalog(entry.provider), entry.id);
             assert!(
                 profile.is_some(),
                 "catalog model '{}' (provider '{}') must have a profile",
@@ -152,19 +157,42 @@ mod tests {
 
     #[test]
     fn unknown_provider_returns_none() {
-        assert!(profile_for("unknown", "some-model").is_none());
+        assert!(profile_for(Provider::Other, "some-model").is_none());
     }
 
     #[test]
     fn uncatalogued_model_returns_none_for_known_provider() {
-        assert!(profile_for("openai", "gpt-5.9-future").is_none());
-        assert!(profile_for("anthropic", "claude-opus-4-7-20260501-preview").is_none());
-        assert!(profile_for("gemini", "gemini-4-future").is_none());
+        assert!(profile_for(Provider::OpenAI, "gpt-5.9-future").is_none());
+        assert!(profile_for(Provider::Anthropic, "claude-opus-4-7-20260501-preview").is_none());
+        assert!(profile_for(Provider::Gemini, "gemini-4-future").is_none());
+    }
+
+    #[test]
+    fn wrong_typed_provider_for_known_model_returns_none() {
+        assert!(profile_for(Provider::Anthropic, "gpt-5.4").is_none());
+        assert!(profile_for(Provider::OpenAI, "gemini-3-flash-preview").is_none());
+    }
+
+    #[test]
+    fn unknown_provider_model_pairs_fail_closed_without_defaults() {
+        assert!(profile_for(Provider::Other, "gpt-5.4").is_none());
+        assert!(profile_for(Provider::Other, "uncatalogued-gpt-compatible").is_none());
+        assert!(inline_video_support_for(Provider::Other, "gemini-3-flash-preview").is_none());
+    }
+
+    #[test]
+    fn display_provider_strings_cannot_select_capability_without_typed_provider() {
+        let display_provider = Provider::parse_strict("Gemini").unwrap_or(Provider::Other);
+        assert_eq!(display_provider, Provider::Other);
+        assert_eq!(
+            inline_video_support_for(display_provider, "gemini-3-flash-preview"),
+            None
+        );
     }
 
     #[test]
     fn claude_profile_vision_and_image_tool_results_true() {
-        let profile = profile_for("anthropic", "claude-opus-4-6")
+        let profile = profile_for(Provider::Anthropic, "claude-opus-4-6")
             .expect("claude-opus-4-6 must have a profile");
         assert!(profile.vision, "Anthropic models must support vision");
         assert!(
@@ -176,7 +204,7 @@ mod tests {
             "Anthropic models must NOT support inline video"
         );
 
-        let profile = profile_for("anthropic", "claude-sonnet-4-5")
+        let profile = profile_for(Provider::Anthropic, "claude-sonnet-4-5")
             .expect("claude-sonnet-4-5 must have a profile");
         assert!(profile.vision);
         assert!(profile.image_tool_results);
@@ -184,7 +212,8 @@ mod tests {
 
     #[test]
     fn gpt_profile_vision_true_image_tool_results_false() {
-        let profile = profile_for("openai", "gpt-5.4").expect("gpt-5.4 must have a profile");
+        let profile =
+            profile_for(Provider::OpenAI, "gpt-5.4").expect("gpt-5.4 must have a profile");
         assert!(profile.vision, "OpenAI models must support vision");
         assert!(
             !profile.image_tool_results,
@@ -198,7 +227,7 @@ mod tests {
 
     #[test]
     fn gemini_profile_vision_and_image_tool_results_true() {
-        let profile = profile_for("gemini", "gemini-3-flash-preview")
+        let profile = profile_for(Provider::Gemini, "gemini-3-flash-preview")
             .expect("gemini-3-flash-preview must have a profile");
         assert!(profile.vision, "Gemini models must support vision");
         assert!(
@@ -218,7 +247,7 @@ mod tests {
             .filter(|entry| entry.provider == "gemini")
         {
             assert!(
-                profile_for(entry.provider, entry.id)
+                profile_for(provider_from_catalog(entry.provider), entry.id)
                     .as_ref()
                     .is_some_and(|profile| profile.inline_video),
                 "Gemini model '{}' must support inline video",
@@ -230,17 +259,23 @@ mod tests {
     #[test]
     fn inline_video_support_for_reads_capability_truth() {
         assert_eq!(
-            inline_video_support_for("gemini", "gemini-3-flash-preview"),
+            inline_video_support_for(Provider::Gemini, "gemini-3-flash-preview"),
             Some(true)
         );
-        assert_eq!(inline_video_support_for("openai", "gpt-5.4"), Some(false));
-        assert_eq!(inline_video_support_for("gemini", "gemini-4-future"), None);
+        assert_eq!(
+            inline_video_support_for(Provider::OpenAI, "gpt-5.4"),
+            Some(false)
+        );
+        assert_eq!(
+            inline_video_support_for(Provider::Gemini, "gemini-4-future"),
+            None
+        );
     }
 
     #[test]
     fn params_schema_non_empty_for_all_profiles() {
         for entry in crate::model_profile::catalog::catalog() {
-            let profile = profile_for(entry.provider, entry.id);
+            let profile = profile_for(provider_from_catalog(entry.provider), entry.id);
             if let Some(p) = profile {
                 assert!(
                     p.params_schema.is_object(),
@@ -255,7 +290,7 @@ mod tests {
     #[test]
     fn call_timeout_secs_populated_for_known_models() {
         for entry in crate::model_profile::catalog::catalog() {
-            let profile = profile_for(entry.provider, entry.id);
+            let profile = profile_for(provider_from_catalog(entry.provider), entry.id);
             if let Some(p) = profile {
                 assert!(
                     p.call_timeout_secs.is_some(),
@@ -270,8 +305,8 @@ mod tests {
 
     #[test]
     fn anthropic_opus_has_longer_timeout_than_haiku() {
-        let opus = profile_for("anthropic", "claude-opus-4-6").unwrap();
-        let haiku = profile_for("anthropic", "claude-haiku-4-5-20251001").unwrap();
+        let opus = profile_for(Provider::Anthropic, "claude-opus-4-6").unwrap();
+        let haiku = profile_for(Provider::Anthropic, "claude-haiku-4-5-20251001").unwrap();
         assert!(
             opus.call_timeout_secs.unwrap() > haiku.call_timeout_secs.unwrap(),
             "Opus should have a longer default timeout than Haiku"
@@ -280,8 +315,8 @@ mod tests {
 
     #[test]
     fn openai_pro_has_longer_timeout_than_standard_gpt5() {
-        let pro = profile_for("openai", "gpt-5.5-pro").unwrap();
-        let standard = profile_for("openai", "gpt-5.5").unwrap();
+        let pro = profile_for(Provider::OpenAI, "gpt-5.5-pro").unwrap();
+        let standard = profile_for(Provider::OpenAI, "gpt-5.5").unwrap();
         assert!(
             pro.call_timeout_secs.unwrap() > standard.call_timeout_secs.unwrap(),
             "gpt-5.5-pro ({}) should have a much longer timeout than gpt-5.5 ({})",
@@ -292,8 +327,8 @@ mod tests {
 
     #[test]
     fn gemini_flash_has_shorter_timeout_than_pro() {
-        let flash = profile_for("gemini", "gemini-3.1-flash-lite-preview").unwrap();
-        let pro = profile_for("gemini", "gemini-3.1-pro-preview").unwrap();
+        let flash = profile_for(Provider::Gemini, "gemini-3.1-flash-lite-preview").unwrap();
+        let pro = profile_for(Provider::Gemini, "gemini-3.1-pro-preview").unwrap();
         assert!(
             flash.call_timeout_secs.unwrap() < pro.call_timeout_secs.unwrap(),
             "gemini flash ({}) should have shorter timeout than gemini pro ({})",
@@ -304,13 +339,13 @@ mod tests {
 
     #[test]
     fn unknown_provider_call_timeout_is_none() {
-        assert!(profile_for("unknown", "model").is_none());
+        assert!(profile_for(Provider::Other, "model").is_none());
     }
 
     #[test]
     fn web_search_flag_populated_for_all_catalog_models() {
         for entry in crate::model_profile::catalog::catalog() {
-            let profile = profile_for(entry.provider, entry.id);
+            let profile = profile_for(provider_from_catalog(entry.provider), entry.id);
             assert!(
                 profile.is_some(),
                 "catalog model '{}' (provider '{}') must have a profile",
@@ -322,19 +357,19 @@ mod tests {
 
     #[test]
     fn anthropic_supports_web_search() {
-        let profile = profile_for("anthropic", "claude-opus-4-6").unwrap();
+        let profile = profile_for(Provider::Anthropic, "claude-opus-4-6").unwrap();
         assert!(profile.supports_web_search);
     }
 
     #[test]
     fn openai_supports_web_search() {
-        let profile = profile_for("openai", "gpt-5.4").unwrap();
+        let profile = profile_for(Provider::OpenAI, "gpt-5.4").unwrap();
         assert!(profile.supports_web_search);
     }
 
     #[test]
     fn gemini_supports_web_search() {
-        let profile = profile_for("gemini", "gemini-3-flash-preview").unwrap();
+        let profile = profile_for(Provider::Gemini, "gemini-3-flash-preview").unwrap();
         assert!(profile.supports_web_search);
     }
 }

--- a/meerkat-core/src/model_profile/openai.rs
+++ b/meerkat-core/src/model_profile/openai.rs
@@ -1,10 +1,11 @@
 //! OpenAI catalog-backed request helpers.
 //!
-//! Capability facts for OpenAI models live in
-//! [`crate::model_profile::capabilities::openai`]. This module only exposes
+//! Capability facts for OpenAI models live in the typed
+//! [`crate::model_profile::capabilities`] catalog. This module only exposes
 //! request-shaping helpers for provider clients; uncatalogued model IDs do not
 //! synthesize semantic capabilities from name prefixes or substrings.
 
+use crate::Provider;
 use crate::model_profile::capabilities::capabilities_for;
 
 /// Whether the model accepts a non-default `temperature`.
@@ -12,7 +13,7 @@ use crate::model_profile::capabilities::capabilities_for;
 /// Catalog rows are authoritative. Unknown model IDs return `false` so callers
 /// do not send optional provider parameters based on model-name folklore.
 pub fn supports_temperature(model: &str) -> bool {
-    capabilities_for("openai", model).is_some_and(|caps| caps.supports_temperature)
+    capabilities_for(Provider::OpenAI, model).is_some_and(|caps| caps.supports_temperature)
 }
 
 /// Whether the model supports explicit reasoning effort control.
@@ -20,7 +21,7 @@ pub fn supports_temperature(model: &str) -> bool {
 /// Catalog rows are authoritative. Unknown model IDs return `false` so callers
 /// do not send reasoning controls based on model-name folklore.
 pub fn supports_reasoning(model: &str) -> bool {
-    capabilities_for("openai", model).is_some_and(|caps| caps.supports_reasoning)
+    capabilities_for(Provider::OpenAI, model).is_some_and(|caps| caps.supports_reasoning)
 }
 
 #[cfg(test)]

--- a/meerkat-core/src/model_profile/schema_builder.rs
+++ b/meerkat-core/src/model_profile/schema_builder.rs
@@ -6,15 +6,16 @@
 //! hand-written struct buckets (`AnthropicOpus46Params`, `OpenAiGpt5Params`,
 //! etc.), which conflated unrelated models into the same bucket.
 
+use crate::Provider;
 use crate::model_profile::capabilities::{ModelCapabilities, ThinkingSupport};
 use serde_json::{Value, json};
 
 /// Build the JSON Schema for a model's `provider_params`.
 pub fn build_params_schema(caps: &ModelCapabilities) -> Value {
     match caps.provider {
-        "anthropic" => build_anthropic_schema(caps),
-        "openai" => build_openai_schema(caps),
-        "gemini" => build_gemini_schema(caps),
+        Provider::Anthropic => build_anthropic_schema(caps),
+        Provider::OpenAI => build_openai_schema(caps),
+        Provider::Gemini => build_gemini_schema(caps),
         _ => json!({
             "type": "object",
             "additionalProperties": false,
@@ -382,7 +383,8 @@ mod tests {
 
     #[test]
     fn opus_47_effort_includes_xhigh() {
-        let caps = capabilities_for("anthropic", "claude-opus-4-7").expect("opus 4.7 row");
+        let caps =
+            capabilities_for(crate::Provider::Anthropic, "claude-opus-4-7").expect("opus 4.7 row");
         let schema = build_params_schema(caps);
         let values = enum_values_for(&schema, "effort").expect("effort enum");
         assert!(values.contains("xhigh"), "opus 4.7 must advertise xhigh");
@@ -392,7 +394,8 @@ mod tests {
 
     #[test]
     fn sonnet_45_has_no_effort_property() {
-        let caps = capabilities_for("anthropic", "claude-sonnet-4-5").expect("sonnet 4.5 row");
+        let caps = capabilities_for(crate::Provider::Anthropic, "claude-sonnet-4-5")
+            .expect("sonnet 4.5 row");
         let schema = build_params_schema(caps);
         let keys = property_keys(&schema);
         assert!(
@@ -403,8 +406,8 @@ mod tests {
 
     #[test]
     fn gemini_3_schema_exposes_thinking_level() {
-        let caps =
-            capabilities_for("gemini", "gemini-3-flash-preview").expect("gemini 3 flash row");
+        let caps = capabilities_for(crate::Provider::Gemini, "gemini-3-flash-preview")
+            .expect("gemini 3 flash row");
         let schema = build_params_schema(caps);
         let keys = property_keys(&schema);
         assert!(
@@ -422,7 +425,7 @@ mod tests {
 
     #[test]
     fn gemini_schema_has_no_include_thoughts() {
-        for caps in all_capabilities().filter(|c| c.provider == "gemini") {
+        for caps in all_capabilities().filter(|c| c.provider == crate::Provider::Gemini) {
             let schema = build_params_schema(caps);
             let keys = property_keys(&schema);
             assert!(

--- a/meerkat-core/src/model_registry.rs
+++ b/meerkat-core/src/model_registry.rs
@@ -24,19 +24,20 @@ pub struct ModelRegistryEntry {
     pub tier: ModelTier,
     pub context_window: Option<u32>,
     pub max_output_tokens: Option<u32>,
-    pub profile: ModelProfile,
     pub self_hosted: Option<SelfHostedServerRef>,
 }
 
 #[derive(Debug, Clone)]
 pub struct ModelRegistry {
     entries: BTreeMap<String, ModelRegistryEntry>,
+    profiles: BTreeMap<(Provider, String), ModelProfile>,
     defaults: BTreeMap<Provider, String>,
 }
 
 impl ModelRegistry {
     pub fn from_config(config: &Config) -> Result<Self, ConfigError> {
         let mut entries = BTreeMap::new();
+        let mut profiles = BTreeMap::new();
         let mut defaults = BTreeMap::new();
 
         for provider_name in crate::model_profile::catalog::provider_names() {
@@ -55,8 +56,8 @@ impl ModelRegistry {
                 .iter()
                 .filter(|entry| entry.provider == *provider_name)
             {
-                let profile = crate::model_profile::profile_for(entry.provider, entry.id)
-                    .ok_or_else(|| {
+                let profile =
+                    crate::model_profile::profile_for(provider, entry.id).ok_or_else(|| {
                         ConfigError::InternalError(format!(
                             "missing built-in profile for {}:{}",
                             entry.provider, entry.id
@@ -64,6 +65,7 @@ impl ModelRegistry {
                     })?;
                 insert_unique(
                     &mut entries,
+                    &mut profiles,
                     ModelRegistryEntry {
                         id: entry.id.to_string(),
                         display_name: entry.display_name.to_string(),
@@ -71,18 +73,46 @@ impl ModelRegistry {
                         tier: entry.tier,
                         context_window: entry.context_window,
                         max_output_tokens: entry.max_output_tokens,
-                        profile,
                         self_hosted: None,
                     },
+                    profile,
                 )?;
             }
         }
 
-        append_self_hosted(&mut entries, &mut defaults, &config.self_hosted)?;
+        append_self_hosted(
+            &mut entries,
+            &mut profiles,
+            &mut defaults,
+            &config.self_hosted,
+        )?;
 
-        Ok(Self { entries, defaults })
+        Ok(Self {
+            entries,
+            profiles,
+            defaults,
+        })
     }
 
+    /// Returns model projection metadata by id.
+    ///
+    /// This model-only lookup intentionally does not expose `ModelProfile` or
+    /// capability fields. Capability decisions must use typed provider-aware
+    /// lookup through [`ModelRegistry::profile_for_provider`].
+    ///
+    /// ```compile_fail
+    /// let registry = meerkat_core::Config::default().model_registry().unwrap();
+    /// let entry = registry.entry("gemini-3-flash-preview").unwrap();
+    /// let _inline_video = entry.profile.inline_video;
+    /// ```
+    ///
+    /// ```
+    /// let registry = meerkat_core::Config::default().model_registry().unwrap();
+    /// let profile = registry
+    ///     .profile_for_provider(meerkat_core::Provider::Gemini, "gemini-3-flash-preview")
+    ///     .unwrap();
+    /// assert!(profile.inline_video);
+    /// ```
     pub fn entry(&self, model_id: &str) -> Option<&ModelRegistryEntry> {
         self.entries.get(model_id)
     }
@@ -113,13 +143,11 @@ impl ModelRegistry {
         ))
     }
 
-    pub fn profile_for(&self, model_id: &str) -> Option<ModelProfile> {
-        self.entry(model_id).map(|entry| entry.profile.clone())
-    }
-
     pub fn profile_for_provider(&self, provider: Provider, model_id: &str) -> Option<ModelProfile> {
-        self.entry_for_provider(provider, model_id)
-            .map(|entry| entry.profile.clone())
+        self.entry_for_provider(provider, model_id)?;
+        self.profiles
+            .get(&(provider, model_id.to_string()))
+            .cloned()
     }
 
     pub fn default_model(&self, provider: Provider) -> Option<&str> {
@@ -144,6 +172,7 @@ impl ModelRegistry {
 
 fn append_self_hosted(
     entries: &mut BTreeMap<String, ModelRegistryEntry>,
+    profiles: &mut BTreeMap<(Provider, String), ModelProfile>,
     defaults: &mut BTreeMap<Provider, String>,
     config: &SelfHostedConfig,
 ) -> Result<(), ConfigError> {
@@ -195,6 +224,7 @@ fn append_self_hosted(
 
         insert_unique(
             entries,
+            profiles,
             ModelRegistryEntry {
                 id: model_id.clone(),
                 display_name: model.display_name.clone(),
@@ -202,9 +232,9 @@ fn append_self_hosted(
                 tier: model.tier,
                 context_window: model.context_window,
                 max_output_tokens: model.max_output_tokens,
-                profile,
                 self_hosted: Some(self_hosted),
             },
+            profile,
         )?;
     }
 
@@ -213,13 +243,18 @@ fn append_self_hosted(
 
 fn insert_unique(
     entries: &mut BTreeMap<String, ModelRegistryEntry>,
+    profiles: &mut BTreeMap<(Provider, String), ModelProfile>,
     entry: ModelRegistryEntry,
+    profile: ModelProfile,
 ) -> Result<(), ConfigError> {
-    if entries.insert(entry.id.clone(), entry).is_some() {
+    let model_id = entry.id.clone();
+    let provider = entry.provider;
+    if entries.insert(model_id.clone(), entry).is_some() {
         return Err(ConfigError::Validation(
             "model id must be unique across built-in and self-hosted entries".to_string(),
         ));
     }
+    profiles.insert((provider, model_id), profile);
     Ok(())
 }
 
@@ -392,9 +427,21 @@ mod tests {
             Ok(registry) => registry,
             Err(err) => panic!("registry construction failed: {err}"),
         };
-        assert!(registry.profile_for("gpt-unknown-preview").is_none());
-        assert!(registry.profile_for("claude-unknown-preview").is_none());
-        assert!(registry.profile_for("gemini-unknown-preview").is_none());
+        assert!(
+            registry
+                .profile_for_provider(Provider::OpenAI, "gpt-unknown-preview")
+                .is_none()
+        );
+        assert!(
+            registry
+                .profile_for_provider(Provider::Anthropic, "claude-unknown-preview")
+                .is_none()
+        );
+        assert!(
+            registry
+                .profile_for_provider(Provider::Gemini, "gemini-unknown-preview")
+                .is_none()
+        );
     }
 
     #[test]
@@ -416,8 +463,67 @@ mod tests {
             "provider-aware lookup must not share OpenAI defaults with Anthropic"
         );
         assert!(
-            registry.profile_for("gpt-5.4").is_some(),
-            "legacy unambiguous model-id lookup remains available"
+            registry
+                .profile_for_provider(Provider::OpenAI, "gemini-3-flash-preview")
+                .is_none(),
+            "provider-aware lookup must not let provider strings select another provider's capabilities"
+        );
+    }
+
+    #[test]
+    fn model_only_entries_are_projection_metadata_not_capability_authority() {
+        let registry = match ModelRegistry::from_config(&Config::default()) {
+            Ok(registry) => registry,
+            Err(err) => panic!("registry construction failed: {err}"),
+        };
+
+        let entry = registry
+            .entry("gemini-3-flash-preview")
+            .expect("catalog entry must exist");
+        assert_eq!(entry.provider, Provider::Gemini);
+        assert_eq!(entry.id, "gemini-3-flash-preview");
+        let rendered = format!("{entry:?}");
+        assert!(
+            !rendered.contains("inline_video") && !rendered.contains("supports_temperature"),
+            "model-only projection entry must not expose capability fields: {rendered}"
+        );
+
+        let profile = registry
+            .profile_for_provider(Provider::Gemini, "gemini-3-flash-preview")
+            .expect("typed provider-aware capability lookup should resolve");
+        assert!(profile.inline_video);
+        assert!(
+            registry
+                .profile_for_provider(Provider::OpenAI, "gemini-3-flash-preview")
+                .is_none(),
+            "display/catalog lookup must not let another typed provider read capability truth"
+        );
+    }
+
+    #[test]
+    fn provider_aware_profile_lookup_fails_closed_for_unknown_pairs() {
+        let registry = match ModelRegistry::from_config(&Config::default()) {
+            Ok(registry) => registry,
+            Err(err) => panic!("registry construction failed: {err}"),
+        };
+
+        assert!(
+            registry
+                .profile_for_provider(Provider::Other, "gpt-5.4")
+                .is_none(),
+            "unknown typed provider must not receive known model defaults"
+        );
+        assert!(
+            registry
+                .profile_for_provider(Provider::Other, "uncatalogued-gpt-compatible")
+                .is_none(),
+            "unknown provider/model pairs must fail closed"
+        );
+        assert!(
+            registry
+                .profile_for_provider(Provider::OpenAI, "uncatalogued-gpt-compatible")
+                .is_none(),
+            "known provider plus uncatalogued model must fail closed"
         );
     }
 

--- a/meerkat-models/src/lib.rs
+++ b/meerkat-models/src/lib.rs
@@ -10,7 +10,7 @@ pub use meerkat_core::model_profile::capabilities;
 pub use meerkat_core::model_profile::catalog;
 
 pub use meerkat_core::model_profile::capabilities::{
-    BetaHeader, BetaValue, ModelCapabilities, ThinkingSupport, all_capabilities, capabilities_for,
+    BetaHeader, BetaValue, ModelCapabilities, ThinkingSupport, capabilities_for,
 };
 pub use meerkat_core::model_profile::catalog::{
     CatalogEntry, ModelTier, ProviderDefaults, allowed_models, catalog, default_model, entry_for,

--- a/meerkat-rest/src/lib.rs
+++ b/meerkat-rest/src/lib.rs
@@ -978,7 +978,7 @@ async fn validate_prompt_video_input(
         .and_then(|state| state.config.model_registry().ok())
         .and_then(|registry| {
             registry
-                .profile_for(&identity.model)
+                .profile_for_provider(identity.provider, &identity.model)
                 .map(|profile| profile.inline_video)
         })
         .unwrap_or(false);
@@ -6323,6 +6323,16 @@ mod tests {
         }])
     }
 
+    fn validation_identity(provider: Provider, model: &str) -> SessionLlmIdentity {
+        SessionLlmIdentity {
+            model: model.to_string(),
+            provider,
+            self_hosted_server_id: None,
+            provider_params: None,
+            connection_ref: None,
+        }
+    }
+
     #[tokio::test]
     async fn rest_context_only_runtime_apply_preserves_run_checkpoint_boundary() {
         let temp = TempDir::new().unwrap();
@@ -7898,6 +7908,62 @@ mod tests {
         validate_prompt_video_input(&config_runtime, &inline_video_prompt(), &identity)
             .await
             .expect("self-hosted aliases should validate inline video against the active registry");
+    }
+
+    #[tokio::test]
+    async fn validate_prompt_video_input_rejects_inline_video_for_wrong_provider_known_model() {
+        let temp = TempDir::new().unwrap();
+        let store: Arc<dyn meerkat_core::ConfigStore> =
+            Arc::new(MemoryConfigStore::new(Config::default()));
+        let config_runtime =
+            meerkat_core::ConfigRuntime::new(store, temp.path().join("config_state.json"));
+        let identity = validation_identity(Provider::Anthropic, "gemini-3-flash-preview");
+
+        let err = validate_prompt_video_input(&config_runtime, &inline_video_prompt(), &identity)
+            .await
+            .expect_err("wrong typed provider must not inherit Gemini inline-video support");
+
+        assert!(err.contains("inline video"));
+        assert!(err.contains("gemini-3-flash-preview"));
+        assert!(err.contains("anthropic"));
+    }
+
+    #[tokio::test]
+    async fn validate_prompt_video_input_rejects_inline_video_for_unknown_provider_model_pair() {
+        let temp = TempDir::new().unwrap();
+        let store: Arc<dyn meerkat_core::ConfigStore> =
+            Arc::new(MemoryConfigStore::new(Config::default()));
+        let config_runtime =
+            meerkat_core::ConfigRuntime::new(store, temp.path().join("config_state.json"));
+        let identity = validation_identity(Provider::Other, "uncatalogued-video-model");
+
+        let err = validate_prompt_video_input(&config_runtime, &inline_video_prompt(), &identity)
+            .await
+            .expect_err("unknown provider/model pair must fail closed without defaults");
+
+        assert!(err.contains("inline video"));
+        assert!(err.contains("uncatalogued-video-model"));
+        assert!(err.contains("other"));
+    }
+
+    #[tokio::test]
+    async fn validate_prompt_video_input_rejects_inline_video_without_typed_provider_authority() {
+        let temp = TempDir::new().unwrap();
+        let store: Arc<dyn meerkat_core::ConfigStore> =
+            Arc::new(MemoryConfigStore::new(Config::default()));
+        let config_runtime =
+            meerkat_core::ConfigRuntime::new(store, temp.path().join("config_state.json"));
+        let identity = validation_identity(Provider::Other, "gemini-3-flash-preview");
+
+        let err = validate_prompt_video_input(&config_runtime, &inline_video_prompt(), &identity)
+            .await
+            .expect_err(
+                "known model/display strings must not select capability without typed provider",
+            );
+
+        assert!(err.contains("inline video"));
+        assert!(err.contains("gemini-3-flash-preview"));
+        assert!(err.contains("other"));
     }
 
     #[tokio::test]

--- a/meerkat-session/src/ephemeral.rs
+++ b/meerkat-session/src/ephemeral.rs
@@ -366,10 +366,7 @@ pub trait SessionAgentBuilder: Send + Sync {
     /// Implementations with a richer configured model registry can override
     /// this; the default uses the built-in model capability catalog.
     async fn model_supports_inline_video(&self, identity: &SessionLlmIdentity) -> Option<bool> {
-        meerkat_core::model_profile::inline_video_support_for(
-            identity.provider.as_str(),
-            &identity.model,
-        )
+        meerkat_core::model_profile::inline_video_support_for(identity.provider, &identity.model)
     }
 
     /// Build an agent for a new session.

--- a/meerkat/src/factory.rs
+++ b/meerkat/src/factory.rs
@@ -932,15 +932,14 @@ impl meerkat_core::ImageGenerationPlanner for CompositeImageGenerationPlanner {
         )?;
         let requires_scoped_override = resolution.execution_plan.requires_scoped_override();
         let machine_routing_realtime_capable = if requires_scoped_override {
-            model_realtime_capable(
-                resolution.execution_plan.provider.0.as_str(),
-                resolution.provider_call_model.as_str(),
-            )
+            meerkat_core::Provider::parse_strict(resolution.execution_plan.provider.0.as_str())
+                .map(|provider| {
+                    model_realtime_capable(provider, resolution.provider_call_model.as_str())
+                })
+                .unwrap_or(false)
         } else {
             effective_provider
-                .map(|provider| {
-                    model_realtime_capable(provider.as_str(), status.effective_model.as_str())
-                })
+                .map(|provider| model_realtime_capable(provider, status.effective_model.as_str()))
                 .unwrap_or(false)
         };
         let machine_routing_model = if resolution.execution_plan.requires_scoped_override() {
@@ -989,7 +988,7 @@ fn image_projection_messages(
 }
 
 #[cfg(not(target_arch = "wasm32"))]
-fn model_realtime_capable(provider: &str, model: &str) -> bool {
+fn model_realtime_capable(provider: meerkat_core::Provider, model: &str) -> bool {
     meerkat_core::model_profile::capabilities::capabilities_for(provider, model)
         .map(|caps| caps.realtime)
         .unwrap_or(false)
@@ -1004,9 +1003,12 @@ fn model_realtime_capable(provider: &str, model: &str) -> bool {
 /// `model_not_found`, so any session whose resolved model is
 /// realtime-capable must use the WebSocket text adapter.
 fn is_openai_realtime_capable(model: &str) -> bool {
-    meerkat_core::model_profile::capabilities::capabilities_for("openai", model)
-        .map(|caps| caps.realtime)
-        .unwrap_or(false)
+    meerkat_core::model_profile::capabilities::capabilities_for(
+        meerkat_core::Provider::OpenAI,
+        model,
+    )
+    .map(|caps| caps.realtime)
+    .unwrap_or(false)
 }
 
 /// Deferred snapshot provider that captures visible tools from a composed tool dispatcher.
@@ -2068,15 +2070,23 @@ impl AgentFactory {
                 OpenAiCompatibleMode::ChatCompletions
             }
         };
+        let profile = registry
+            .profile_for_provider(Provider::SelfHosted, &identity.model)
+            .ok_or_else(|| {
+                FactoryError::ClientCreationFailed(format!(
+                    "missing provider-aware profile for self-hosted model '{}'",
+                    identity.model
+                ))
+            })?;
 
         Ok(SelfHostedClientSpec {
             server_id: self_hosted.server_id.clone(),
             mode,
             remote_model: self_hosted.remote_model.clone(),
             base_url: self_hosted.base_url.clone(),
-            supports_temperature: entry.profile.supports_temperature,
-            supports_thinking: entry.profile.supports_thinking,
-            supports_reasoning: entry.profile.supports_reasoning,
+            supports_temperature: profile.supports_temperature,
+            supports_thinking: profile.supports_thinking,
+            supports_reasoning: profile.supports_reasoning,
         })
     }
 

--- a/meerkat/src/service_factory.rs
+++ b/meerkat/src/service_factory.rs
@@ -518,7 +518,7 @@ impl SessionAgentBuilder for FactoryAgentBuilder {
             .map(|profile| profile.inline_video)
             .or_else(|| {
                 meerkat_core::model_profile::inline_video_support_for(
-                    identity.provider.as_str(),
+                    identity.provider,
                     &identity.model,
                 )
             })

--- a/meerkat/src/surface.rs
+++ b/meerkat/src/surface.rs
@@ -302,16 +302,24 @@ pub fn build_models_catalog_response(
             let models = registry
                 .entries_for_provider(provider)
                 .map(|entry| {
+                    let model_profile = registry
+                        .profile_for_provider(provider, &entry.id)
+                        .ok_or_else(|| {
+                            meerkat_core::ConfigError::InternalError(format!(
+                                "missing provider-aware profile for {}:{}",
+                                provider.as_str(),
+                                entry.id
+                            ))
+                        })?;
                     let profile = Some(meerkat_contracts::WireModelProfile {
-                        model_family: entry.profile.model_family.clone(),
-                        supports_temperature: entry.profile.supports_temperature,
-                        supports_thinking: entry.profile.supports_thinking,
-                        supports_reasoning: entry.profile.supports_reasoning,
-                        supports_web_search: entry.profile.supports_web_search,
-                        inline_video: entry.profile.inline_video,
-                        params_schema: entry.profile.params_schema.clone(),
-                        beta_headers: entry
-                            .profile
+                        model_family: model_profile.model_family.clone(),
+                        supports_temperature: model_profile.supports_temperature,
+                        supports_thinking: model_profile.supports_thinking,
+                        supports_reasoning: model_profile.supports_reasoning,
+                        supports_web_search: model_profile.supports_web_search,
+                        inline_video: model_profile.inline_video,
+                        params_schema: model_profile.params_schema.clone(),
+                        beta_headers: model_profile
                             .beta_headers
                             .iter()
                             .map(|header| meerkat_contracts::WireModelBetaHeader {
@@ -321,7 +329,7 @@ pub fn build_models_catalog_response(
                             })
                             .collect(),
                     });
-                    meerkat_contracts::CatalogModelEntry {
+                    Ok(meerkat_contracts::CatalogModelEntry {
                         id: entry.id.clone(),
                         display_name: entry.display_name.clone(),
                         tier: match entry.tier {
@@ -339,16 +347,16 @@ pub fn build_models_catalog_response(
                             .as_ref()
                             .map(|server| server.server_id.clone()),
                         profile,
-                    }
+                    })
                 })
-                .collect();
-            meerkat_contracts::ProviderCatalog {
+                .collect::<Result<Vec<_>, meerkat_core::ConfigError>>()?;
+            Ok(meerkat_contracts::ProviderCatalog {
                 provider: provider.as_str().to_string(),
                 default_model_id: default_model_id.to_string(),
                 models,
-            }
+            })
         })
-        .collect();
+        .collect::<Result<Vec<_>, meerkat_core::ConfigError>>()?;
 
     Ok(meerkat_contracts::ModelsCatalogResponse {
         contract_version: ContractVersion::CURRENT,

--- a/tests/integration/tests/e2e_models_lane.rs
+++ b/tests/integration/tests/e2e_models_lane.rs
@@ -24,10 +24,8 @@ use meerkat_client::{
     AnthropicClient, GeminiClient, LlmDoneOutcome, LlmEvent, LlmRequest, OpenAiClient,
     types::LlmClient,
 };
-use meerkat_core::{Message, UserMessage};
-use meerkat_models::{
-    CatalogEntry, ModelCapabilities, ThinkingSupport, all_capabilities, capabilities_for, catalog,
-};
+use meerkat_core::{Message, Provider, UserMessage};
+use meerkat_models::{CatalogEntry, ModelCapabilities, ThinkingSupport, capabilities_for, catalog};
 
 // ---------------------------------------------------------------------------
 // API key resolution
@@ -96,7 +94,9 @@ fn for_each_catalog_model_with_key() -> impl Iterator<Item = (&'static CatalogEn
 }
 
 fn caps_for(entry: &CatalogEntry) -> &'static ModelCapabilities {
-    capabilities_for(entry.provider, entry.id)
+    let provider = Provider::parse_strict(entry.provider)
+        .unwrap_or_else(|| panic!("catalog provider '{}' must parse", entry.provider));
+    capabilities_for(provider, entry.id)
         .unwrap_or_else(|| panic!("no capability row for {}", entry.id))
 }
 
@@ -380,22 +380,13 @@ async fn thinking_modes_per_capability() {
 #[ignore = "lane:e2e-models"]
 fn every_catalog_model_has_capability_row() {
     for entry in catalog() {
-        let caps = capabilities_for(entry.provider, entry.id);
+        let provider = Provider::parse_strict(entry.provider)
+            .unwrap_or_else(|| panic!("catalog provider '{}' must parse", entry.provider));
+        let caps = capabilities_for(provider, entry.id);
         assert!(
             caps.is_some(),
             "catalog model {} has no capability row",
             entry.id
-        );
-    }
-    // Every capability row also maps back to a catalog entry.
-    for caps in all_capabilities() {
-        let entry = catalog()
-            .iter()
-            .find(|e| e.provider == caps.provider && e.id == caps.id);
-        assert!(
-            entry.is_some(),
-            "capability row {} has no catalog entry",
-            caps.id
         );
     }
 }


### PR DESCRIPTION
## Summary
- make model capability lookup require typed `Provider` inputs and keep provider/model mismatches fail-closed
- remove capability `ModelProfile` from public model-only registry entries; `entry(model)` is projection metadata only
- close the lower-level public capability bypass by typing `capabilities_for`, hiding raw capability row iteration, and making provider-specific row modules private
- validate REST inline-video support and touched catalog/self-hosted capability reads through provider-aware registry lookup
- add negative fixtures for wrong provider/model, unknown provider/model, display/provider string non-authority, model-only registry profile compile failure, string capability lookup compile failure, and raw row scan/module privacy

## Validation
- `./scripts/repo-cargo test -p meerkat-core model_registry`
- `./scripts/repo-cargo test -p meerkat-core --doc model_registry`
- `./scripts/repo-cargo test -p meerkat-core model_profile::capabilities`
- `./scripts/repo-cargo test -p meerkat-core --doc model_profile::capabilities`
- `./scripts/repo-cargo check -p meerkat-core -p meerkat-models -p meerkat-anthropic -p meerkat -p meerkat-integration-tests`
- `./scripts/repo-cargo test -p meerkat-rest validate_prompt_video_input`
- `./scripts/repo-cargo test -p meerkat-rest rest_peer_terminal_webhook_allows_running_target_when_capacity_full`
- `make fmt-check`
- `git diff --check`
- `MEERKAT_BUILDBUDDY=1 make check`
- `MEERKAT_BUILDBUDDY=1 make buildbuddy-test-unit`

## Review Readiness Packet
Dogma cleanup PR: yes
Linear: LUC-332
Current head SHA: `b417ed7517414f4547703534cb42fcb5823fe0bf`
Base: `main` at `10f351b`

### Command Output
LUC-316 gate source is used from `origin/codex/LUC-316-dogma-cleanup-gate` because LUC-316 has not landed in this branch.

```text
$ ./scripts/repo-cargo test -p meerkat-core model_registry
8 passed; 0 failed

$ ./scripts/repo-cargo test -p meerkat-core --doc model_registry
1 passing doctest; 1 compile-fail doctest passed

$ ./scripts/repo-cargo test -p meerkat-core model_profile::capabilities
7 passed; 0 failed

$ ./scripts/repo-cargo test -p meerkat-core --doc model_profile::capabilities
3 compile-fail doctests passed

$ ./scripts/repo-cargo check -p meerkat-core -p meerkat-models -p meerkat-anthropic -p meerkat -p meerkat-integration-tests
Finished `dev` profile [unoptimized + debuginfo]

$ ./scripts/repo-cargo test -p meerkat-rest validate_prompt_video_input
4 passed; 0 failed

$ ./scripts/repo-cargo test -p meerkat-rest rest_peer_terminal_webhook_allows_running_target_when_capacity_full
1 passed; 0 failed

$ make fmt-check
passed

$ git diff --check
passed

$ rg -n 'pub fn capabilities_for\(provider: &str|pub fn all_capabilities|capabilities_for\("(anthropic|openai|gemini)' meerkat-core/src/model_profile/capabilities.rs meerkat-core/src/model_profile meerkat-anthropic/src meerkat/src meerkat-models/src tests/integration/tests/e2e_models_lane.rs
no matches

$ rg -n '^pub mod (anthropic|gemini|openai);' meerkat-core/src/model_profile/capabilities.rs
no matches

$ MEERKAT_BUILDBUDDY=1 make check
BuildBuddy invocation a11c7393-29ce-4df4-b2e8-43e298668265 completed successfully

$ MEERKAT_BUILDBUDDY=1 make buildbuddy-test-unit
BuildBuddy invocation c2bec593-b3ec-4daf-af85-10c1e56e3c49 completed successfully
```

### Scope
This is the LUC-332 mechanical slice for provider-aware model capability ownership. Capability truth is owned by typed provider-aware catalog lookup when typed provider identity is available; model-only registry entry access remains projection metadata, and the lower-level capability catalog no longer exposes public provider-string lookup or public raw row scans.

### Complexity Delta
- Docs/scripts/tests: 0 standalone changed files; focused tests live inside touched Rust modules and the existing e2e model lane was updated for the typed API.
- Non-test implementation: 14 changed files in the existing capability boundary surface (`meerkat-core/src/model_profile/*`, `meerkat-core/src/model_registry.rs`, `meerkat-rest/src/lib.rs`, `meerkat-session/src/ephemeral.rs`, `meerkat/src/factory.rs`, `meerkat/src/service_factory.rs`, `meerkat/src/surface.rs`, `meerkat-anthropic/src/client.rs`, `meerkat-models/src/lib.rs`, and `tests/integration/tests/e2e_models_lane.rs`).
- Generated/schema churn: 0 files; no generated or schema artifacts changed.

### Sample Passing Old Path Amputation Proof
- Typed owner: `ModelRegistry::profile_for_provider(Provider::Gemini, "gemini-3-flash-preview")` resolves the Gemini capability row and exposes inline-video support only through the typed provider-aware catalog boundary.
- Typed lower-level owner: `model_profile::capabilities::capabilities_for(Provider::Gemini, "gemini-3-flash-preview")` returns the row; wrong/unknown typed providers return `None`.
- REST pass sample: a session identity carrying `provider: Provider::Gemini` and model `gemini-3-flash-preview` is accepted for inline video because `validate_prompt_video_input` asks the registry with typed provider plus exact model ID.
- Projection sample: `ModelRegistry::entry("gemini-3-flash-preview")` can read inert catalog metadata such as id, display name, provider owner, tier, limits, and self-hosted routing metadata; it cannot read `ModelProfile` or capability fields.

### Sample Failing Old Path Amputation Proof
- Wrong provider plus known model ID: `Provider::OpenAI` with `gemini-3-flash-preview` returns `None` at `profile_for_provider(...)` and at lower-level `capabilities_for(...)`; REST rejects inline video.
- Unknown provider/model: `Provider::Other` with an unknown model returns `None`; no default profile or permissive fallback is produced.
- Display/provider strings cannot select capability: strict parsing of display strings yields no supported typed provider, and capability lookup rejects `Provider::Other` plus the Gemini model ID.
- Provider-string capability lookup is boundary-uncallable: the doctest `capabilities_for("gemini", "gemini-3-flash-preview")` is compile-fail.
- Public raw row scan is boundary-uncallable: the doctests `capabilities::all_capabilities()` and `capabilities::gemini::CAPABILITIES` are compile-fail from public code.
- Model-only entry capability access is boundary-uncallable: the doctest `entry.profile.inline_video` is compile-fail, and the runtime fixture asserts debug output for the entry projection omits capability field names.

### Old Path Amputation Proof
| Old path | Classification | Search literal | Mechanical proof | Follow-up |
| --- | --- | --- | --- | --- |
| `ModelRegistry::entry(model_id).profile` | made uncallable at boundary | `entry.profile` | `ModelRegistryEntry` no longer has a `profile` field. Compile failure evidence: the `ModelRegistry::entry` rustdoc includes a compile-fail fixture for `entry.profile.inline_video`, and `./scripts/repo-cargo test -p meerkat-core --doc model_registry` passes that fixture. | none |
| Model-only registry entry as capability carrier | made uncallable at boundary | `pub profile: ModelProfile` | `pub profile: ModelProfile` is no longer exported on `ModelRegistryEntry`; `ModelRegistry` stores profiles internally by `(Provider, model_id)`, and `profile_for_provider(provider, model)` first verifies `entry_for_provider(provider, model)`. | none |
| `ModelRegistry::profile_for(&self, model_id: &str)` | deleted | `pub fn profile_for(&self, model_id: &str)` | Symbol deleted from `meerkat-core/src/model_registry.rs`; `rg 'pub fn profile_for\(&self, model_id: &str\)' meerkat-core/src/model_registry.rs` returns no matches. | none |
| `model_profile::profile_for(provider: &str, model: &str)` | deleted | `pub fn profile_for(provider: &str` | String-provider helper signature deleted; the current function requires typed `Provider` and exact model ID. | none |
| `model_profile::inline_video_support_for(provider: &str, model: &str)` | deleted | `pub fn inline_video_support_for(provider: &str` | String-provider helper signature deleted; inline-video decisions use typed provider-aware profile lookup. | none |
| `model_profile::capabilities::capabilities_for(provider: &str, model: &str)` | made uncallable at boundary | `pub fn capabilities_for(provider: &str` | Public function now requires typed `Provider`; `./scripts/repo-cargo test -p meerkat-core --doc model_profile::capabilities` passes the compile-fail fixture for `capabilities_for("gemini", ...)`. Repository search for old string calls returns no matches. | none |
| Public raw capability row iteration | made uncallable at boundary | `pub fn all_capabilities` | `all_capabilities()` is now `pub(crate)`; the public compile-fail doctest proves external callers cannot scan rows and select capability truth by model/provider strings. `meerkat-models` no longer re-exports it. | none |
| Public provider-specific raw row modules | made uncallable at boundary | `pub mod gemini;` | `capabilities::{anthropic, gemini, openai}` are private modules; the public compile-fail doctest proves `capabilities::gemini::CAPABILITIES` is not reachable. | none |
| String provider ownership on capability rows | made uncallable at boundary | `provider: "gemini"` | Compile failure evidence: `ModelCapabilities.provider` is now `Provider`, so `provider: "gemini"` does not compile in capability rows. Row constants compile only with `Provider::{Anthropic, OpenAI, Gemini}`; catalog projection still exposes provider strings for display/config, but capability ownership stores typed provider identity. | none |
| REST inline-video `registry.profile_for(&identity.model)` | deleted | `profile_for(&identity.model)` | Call site deleted from `meerkat-rest/src/lib.rs`; REST now calls `profile_for_provider(identity.provider, &identity.model)`. | none |
| Entry-backed catalog/self-hosted capability reads | made uncallable at boundary | `entry.profile.supports_temperature` | Not callable because `ModelRegistryEntry` has no `profile` field. Surface catalog projection and self-hosted client spec call `profile_for_provider(provider, model)` before reading support flags or inline-video capability. | none |
| Display/provider string capability selection | made uncallable at boundary | `display_provider_strings_cannot_select_capability_without_typed_provider` | Negative fixtures prove display strings do not become supported typed provider identity, and capability calls are rejected for `Provider::Other` plus a known model ID. | none |

### Acceptance Evidence
- Wrong provider plus known model ID fails through typed profile/capability lookup and REST inline-video validation.
- Unknown provider/model fails closed without defaults through `Provider::Other` profile, registry, capability, and REST tests.
- Display/provider strings cannot select model capability without typed `Provider`; strict parsing of display form yields no supported typed provider and no capability row.
- Public model-only registry lookup cannot expose `ModelProfile` or capability fields; compile-fail doctest proves `entry.profile.inline_video` is rejected.
- Public lower-level provider-string capability lookup cannot expose `ModelCapabilities`; compile-fail doctests prove string lookup, public row scans, and public provider-specific row constants are rejected.
- PR checks are being rerun on exact head `b417ed7517414f4547703534cb42fcb5823fe0bf` after a no-op re-push. Previous CI run `25276426207` had one unrelated REST timeout in `rest_peer_terminal_webhook_allows_running_target_when_capacity_full`; the same test and the full local BuildBuddy unit lane passed on this code.