### PR TITLE
Retire runtime session control compatibility routes

### DIFF
--- a/meerkat-rpc/src/router.rs
+++ b/meerkat-rpc/src/router.rs
@@ -1331,84 +1331,6 @@ impl MethodRouter {
                 .await
             }
             #[cfg(not(feature = "mini-surface"))]
-            "runtime/session_status" => {
-                let session_id = match self.session_id_from_runtime_params(id.clone(), params) {
-                    Ok(session_id) => session_id,
-                    Err(response) => return Some(response),
-                };
-                if let Err(response) = self.ensure_runtime_session_registered(&session_id).await {
-                    return Some(response.with_id(id));
-                }
-                handlers::runtime::handle_runtime_status(id, params, self.runtime_adapter.as_ref())
-                    .await
-            }
-            #[cfg(not(feature = "mini-surface"))]
-            "runtime/session_submit" => {
-                handlers::runtime::handle_runtime_submit(
-                    id,
-                    params,
-                    &self.runtime,
-                    &self.runtime_adapter,
-                )
-                .await
-            }
-            #[cfg(not(feature = "mini-surface"))]
-            "runtime/session_submission" => {
-                let session_id = match self.session_id_from_runtime_params(id.clone(), params) {
-                    Ok(session_id) => session_id,
-                    Err(response) => return Some(response),
-                };
-                if let Err(response) = self.ensure_runtime_session_registered(&session_id).await {
-                    return Some(response.with_id(id));
-                }
-                handlers::runtime::handle_runtime_submission(
-                    id,
-                    params,
-                    self.runtime_adapter.as_ref(),
-                )
-                .await
-            }
-            #[cfg(not(feature = "mini-surface"))]
-            "runtime/session_submissions" => {
-                let session_id = match self.session_id_from_runtime_params(id.clone(), params) {
-                    Ok(session_id) => session_id,
-                    Err(response) => return Some(response),
-                };
-                if let Err(response) = self.ensure_runtime_session_registered(&session_id).await {
-                    return Some(response.with_id(id));
-                }
-                handlers::runtime::handle_runtime_submissions(
-                    id,
-                    params,
-                    self.runtime_adapter.as_ref(),
-                )
-                .await
-            }
-            #[cfg(not(feature = "mini-surface"))]
-            "runtime/session_retire" => {
-                let session_id = match self.session_id_from_runtime_params(id.clone(), params) {
-                    Ok(session_id) => session_id,
-                    Err(response) => return Some(response),
-                };
-                if let Err(response) = self.ensure_runtime_session_registered(&session_id).await {
-                    return Some(response.with_id(id));
-                }
-                handlers::runtime::handle_runtime_retire(id, params, self.runtime_adapter.as_ref())
-                    .await
-            }
-            #[cfg(not(feature = "mini-surface"))]
-            "runtime/session_reset" => {
-                let session_id = match self.session_id_from_runtime_params(id.clone(), params) {
-                    Ok(session_id) => session_id,
-                    Err(response) => return Some(response),
-                };
-                if let Err(response) = self.ensure_runtime_session_registered(&session_id).await {
-                    return Some(response.with_id(id));
-                }
-                handlers::runtime::handle_runtime_reset(id, params, self.runtime_adapter.as_ref())
-                    .await
-            }
-            #[cfg(not(feature = "mini-surface"))]
             "realtime/open_info" => {
                 let maybe_session_id = match self
                     .resolve_realtime_target_session_id(id.clone(), params)
@@ -2486,13 +2408,11 @@ mod tests {
     use meerkat::AgentFactory;
     use meerkat::surface::{RequestContext, SurfaceRequestExecutor, noop_request_action};
     use meerkat_client::{LlmClient, LlmError};
-    use meerkat_core::lifecycle::run_primitive::RunPrimitive;
     use meerkat_core::skills::{
         SkillKey, SkillKeyRemap, SkillName, SourceIdentityLineage, SourceIdentityLineageEvent,
         SourceIdentityRecord, SourceIdentityRegistry, SourceIdentityStatus, SourceTransportKind,
         SourceUuid,
     };
-    use meerkat_core::types::ContentInput;
     use meerkat_core::{Config, ConfigRuntime, MemoryConfigStore, Message, StopReason};
     use serde::Serialize;
 
@@ -5705,55 +5625,83 @@ mod tests {
         assert_eq!(error_code(&resp), error::METHOD_NOT_FOUND);
     }
 
-    /// Dispatch contract (dogma rule 1, 17): METHOD_NOT_FOUND is reserved for
-    /// "the server doesn't know this method name." Methods whose handlers may
-    /// reject for runtime-state reasons must still route to their handler so
-    /// the handler can return a typed application error — they must never
-    /// surface as METHOD_NOT_FOUND from the dispatch table.
-    ///
-    /// Regression test for the bug where state-gated dispatch arms returned
-    /// METHOD_NOT_FOUND, decoupling method existence from the dispatch table
-    /// and creating drift against the advertised method catalog.
     #[cfg(not(feature = "mini-surface"))]
     #[tokio::test]
-    async fn previously_state_gated_methods_dispatch_to_handlers() {
+    async fn retired_runtime_session_control_methods_fail_closed_and_leave_state_unchanged() {
         let (router, _notif_rx) = test_router_with_v9_runtime().await;
-        let unknown_session_id = meerkat_core::SessionId::new().to_string();
+        let create_resp = router
+            .dispatch(make_request(
+                "session/create",
+                serde_json::json!({
+                    "prompt": "deferred retired-route fixture",
+                    "initial_turn": "deferred"
+                }),
+            ))
+            .await
+            .expect("create response");
+        let session_id = result_value(&create_resp)["session_id"]
+            .as_str()
+            .expect("session_id")
+            .to_string();
+        let parsed_session_id =
+            SessionId::parse(&session_id).expect("created session id should parse");
+        let before_registered = router
+            .runtime_adapter()
+            .contains_session(&parsed_session_id)
+            .await;
+        let before_read = router
+            .dispatch(make_request(
+                "session/read",
+                serde_json::json!({ "session_id": &session_id }),
+            ))
+            .await
+            .expect("read response");
+        let before_session = result_value(&before_read).clone();
 
-        // Each of these dispatch arms used to short-circuit with
-        // METHOD_NOT_FOUND when `runtime_mode != V9Compliant`. The handler
-        // may reject for state reasons (e.g. unknown session), but the
-        // dispatcher must always recognize the method name.
-        let cases = [
+        let input_id = meerkat_core::InputId::new().to_string();
+        let cases = vec![
             (
                 "runtime/session_status",
-                serde_json::json!({ "session_id": unknown_session_id }),
+                serde_json::json!({ "session_id": &session_id }),
             ),
             (
                 "runtime/session_submit",
-                serde_json::json!({ "session_id": unknown_session_id }),
-            ),
-            (
-                "session/realtime_attachment_status",
-                serde_json::json!({ "session_id": unknown_session_id }),
-            ),
-            (
-                "realtime/open_info",
                 serde_json::json!({
-                    "target": { "type": "session_target", "session_id": unknown_session_id }
+                    "session_id": &session_id,
+                    "input": {
+                        "input_type": "prompt",
+                        "header": {
+                            "id": meerkat_core::InputId::new(),
+                            "timestamp": "2026-03-12T00:00:00Z",
+                            "source": { "type": "operator" },
+                            "durability": "durable",
+                            "visibility": {
+                                "transcript_eligible": true,
+                                "operator_eligible": true
+                            }
+                        },
+                        "text": "must not enter runtime queue"
+                    }
                 }),
             ),
             (
-                "realtime/capabilities",
+                "runtime/session_submission",
                 serde_json::json!({
-                    "target": { "type": "session_target", "session_id": unknown_session_id }
+                    "session_id": &session_id,
+                    "input_id": input_id,
                 }),
             ),
             (
-                "realtime/status",
-                serde_json::json!({
-                    "target": { "type": "session_target", "session_id": unknown_session_id }
-                }),
+                "runtime/session_submissions",
+                serde_json::json!({ "session_id": &session_id }),
+            ),
+            (
+                "runtime/session_retire",
+                serde_json::json!({ "session_id": &session_id }),
+            ),
+            (
+                "runtime/session_reset",
+                serde_json::json!({ "session_id": &session_id }),
             ),
         ];
 
@@ -5762,12 +5710,38 @@ mod tests {
                 .dispatch(make_request(method, params))
                 .await
                 .expect("response");
-            assert_ne!(
+            assert_eq!(
                 error_code(&resp),
                 error::METHOD_NOT_FOUND,
-                "{method} must dispatch to its handler — METHOD_NOT_FOUND is reserved for unknown method names"
+                "{method} must fail closed after retirement"
             );
         }
+
+        let after_registered = router
+            .runtime_adapter()
+            .contains_session(&parsed_session_id)
+            .await;
+        assert_eq!(
+            after_registered, before_registered,
+            "retired runtime/session_* methods must not register or unregister runtime state"
+        );
+        let after_read = router
+            .dispatch(make_request(
+                "session/read",
+                serde_json::json!({ "session_id": &session_id }),
+            ))
+            .await
+            .expect("read response");
+        let after_session = result_value(&after_read);
+        assert_eq!(after_session["session_id"], before_session["session_id"]);
+        assert_eq!(
+            after_session["message_count"],
+            before_session["message_count"]
+        );
+        assert_eq!(
+            after_session["last_assistant_text"],
+            before_session["last_assistant_text"]
+        );
     }
 
     /// 3. `session/create` happy path - creates session, runs first turn, returns result.
@@ -5925,232 +5899,6 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn deferred_session_runtime_endpoints_register_pending_session() {
-        let (router, _notif_rx) = test_router_with_v9_runtime().await;
-        let create_resp = router
-            .dispatch(make_request(
-                "session/create",
-                serde_json::json!({
-                    "prompt": "deferred",
-                    "initial_turn": "deferred"
-                }),
-            ))
-            .await
-            .unwrap();
-        let created = result_value(&create_resp);
-        let session_id = created["session_id"]
-            .as_str()
-            .expect("session_id")
-            .to_string();
-
-        let state_resp = router
-            .dispatch(make_request(
-                "runtime/session_status",
-                serde_json::json!({ "session_id": session_id }),
-            ))
-            .await
-            .unwrap();
-        let state = result_value(&state_resp);
-        // RPC surface eagerly attaches an executor for all sessions (including
-        // deferred ones), so the runtime state is Attached, not Idle.
-        assert_eq!(
-            state["state"].as_str(),
-            Some("attached"),
-            "deferred sessions should be routable through runtime/session_status before their first turn"
-        );
-
-        let accept_resp = router
-            .dispatch(make_request(
-                "runtime/session_submit",
-                serde_json::json!({
-                    "session_id": session_id,
-                    "input": {
-                        "input_type": "prompt",
-                        "header": {
-                            "id": meerkat_core::InputId::new(),
-                            "timestamp": "2026-03-12T00:00:00Z",
-                            "source": { "type": "operator" },
-                            "durability": "durable",
-                            "visibility": {
-                                "transcript_eligible": true,
-                                "operator_eligible": true
-                            }
-                        },
-                        "text": "drive via runtime"
-                    }
-                }),
-            ))
-            .await
-            .unwrap();
-        let accepted = result_value(&accept_resp);
-        assert_eq!(
-            accepted["outcome_type"].as_str(),
-            Some("accepted"),
-            "deferred sessions should also be routable through runtime/session_submit before their first turn"
-        );
-    }
-
-    #[tokio::test]
-    async fn runtime_submit_capacity_full_rejects_before_input_accept() {
-        let (router, _notif_rx) = test_router_with_v9_runtime_and_max_sessions(1).await;
-        let first_resp = router
-            .dispatch(make_request(
-                "session/create",
-                serde_json::json!({ "prompt": "completed session" }),
-            ))
-            .await
-            .unwrap();
-        let first_session_id = SessionId::parse(
-            result_value(&first_resp)["session_id"]
-                .as_str()
-                .expect("first session id"),
-        )
-        .expect("valid first session id");
-        let first_active = router
-            .runtime_adapter()
-            .list_active_inputs(&first_session_id)
-            .await
-            .expect("list active inputs before rejection");
-        assert!(
-            first_active.is_empty(),
-            "completed first session should have no active runtime inputs"
-        );
-
-        let filler_resp = router
-            .dispatch(make_request(
-                "session/create",
-                serde_json::json!({
-                    "prompt": "capacity filler",
-                    "initial_turn": "deferred"
-                }),
-            ))
-            .await
-            .unwrap();
-        assert!(
-            result_value(&filler_resp)["session_id"].is_string(),
-            "deferred filler should reserve active capacity"
-        );
-
-        let rejected = router
-            .dispatch(make_request(
-                "runtime/session_submit",
-                serde_json::json!({
-                    "session_id": first_session_id.to_string(),
-                    "input": {
-                        "input_type": "prompt",
-                        "header": {
-                            "id": meerkat_core::InputId::new(),
-                            "timestamp": "2026-03-12T00:00:00Z",
-                            "source": { "type": "operator" },
-                            "durability": "durable",
-                            "visibility": {
-                                "transcript_eligible": true,
-                                "operator_eligible": true
-                            }
-                        },
-                        "text": "must not enter runtime queue"
-                    }
-                }),
-            ))
-            .await
-            .unwrap();
-        assert!(
-            error_message(&rejected).contains("Max sessions"),
-            "capacity-full runtime submit should reject before runtime input accept: {}",
-            error_message(&rejected)
-        );
-
-        let first_active = router
-            .runtime_adapter()
-            .list_active_inputs(&first_session_id)
-            .await
-            .expect("list active inputs after rejection");
-        assert!(
-            first_active.is_empty(),
-            "capacity-full runtime submit must not enqueue active runtime input"
-        );
-    }
-
-    #[tokio::test]
-    async fn runtime_submit_external_event_capacity_full_rejects_before_input_accept() {
-        let (router, _notif_rx) = test_router_with_v9_runtime_and_max_sessions(1).await;
-        let first_resp = router
-            .dispatch(make_request(
-                "session/create",
-                serde_json::json!({ "prompt": "completed session" }),
-            ))
-            .await
-            .unwrap();
-        let first_session_id = SessionId::parse(
-            result_value(&first_resp)["session_id"]
-                .as_str()
-                .expect("first session id"),
-        )
-        .expect("valid first session id");
-
-        let filler_resp = router
-            .dispatch(make_request(
-                "session/create",
-                serde_json::json!({
-                    "prompt": "capacity filler",
-                    "initial_turn": "deferred"
-                }),
-            ))
-            .await
-            .unwrap();
-        assert!(
-            result_value(&filler_resp)["session_id"].is_string(),
-            "deferred filler should reserve active capacity"
-        );
-
-        let rejected = router
-            .dispatch(make_request(
-                "runtime/session_submit",
-                serde_json::json!({
-                    "session_id": first_session_id.to_string(),
-                    "input": {
-                        "input_type": "external_event",
-                        "header": {
-                            "id": meerkat_core::InputId::new(),
-                            "timestamp": "2026-03-12T00:00:00Z",
-                            "source": {
-                                "type": "external",
-                                "source_name": "calendar"
-                            },
-                            "durability": "durable",
-                            "visibility": {
-                                "transcript_eligible": true,
-                                "operator_eligible": true
-                            }
-                        },
-                        "event_type": "calendar.reminder",
-                        "payload": {
-                            "body": "must not enter runtime queue"
-                        },
-                        "handling_mode": "queue"
-                    }
-                }),
-            ))
-            .await
-            .unwrap();
-        assert!(
-            error_message(&rejected).contains("Max sessions"),
-            "capacity-full external event submit should reject before runtime input accept: {}",
-            error_message(&rejected)
-        );
-
-        let first_active = router
-            .runtime_adapter()
-            .list_active_inputs(&first_session_id)
-            .await
-            .expect("list active inputs after rejection");
-        assert!(
-            first_active.is_empty(),
-            "capacity-full external event submit must not enqueue active runtime input"
-        );
-    }
-
-    #[tokio::test]
     async fn turn_start_capacity_full_rejects_before_executor_registration() {
         let (router, _notif_rx) = test_router_with_v9_runtime_and_max_sessions(1).await;
         let target_resp = router
@@ -6218,94 +5966,6 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn runtime_submit_routes_restored_staged_transient_archive_session() {
-        let (router, _notif_rx) = test_router_with_v9_runtime().await;
-        let create_resp = router
-            .dispatch(make_request(
-                "session/create",
-                serde_json::json!({
-                    "prompt": "deferred",
-                    "initial_turn": "deferred"
-                }),
-            ))
-            .await
-            .unwrap();
-        let created = result_value(&create_resp);
-        let session_id = SessionId::parse(created["session_id"].as_str().expect("session_id"))
-            .expect("valid session id");
-
-        let primitive = RunPrimitive::StagedInput(
-            meerkat_core::lifecycle::run_primitive::StagedRunInput {
-                boundary: meerkat_core::lifecycle::run_primitive::RunApplyBoundary::Immediate,
-                appends: Vec::new(),
-                context_appends: Vec::new(),
-                contributing_input_ids: vec![meerkat_core::InputId::new()],
-                turn_metadata: Some(
-                    meerkat_core::lifecycle::run_primitive::RuntimeTurnMetadata {
-                        execution_kind: Some(
-                            meerkat_core::lifecycle::run_primitive::RuntimeExecutionKind::ResumePending,
-                        ),
-                        ..Default::default()
-                    },
-                ),
-            },
-        );
-        let (event_tx, _event_rx) = mpsc::channel(100);
-        router
-            .runtime
-            .apply_runtime_turn(
-                &session_id,
-                meerkat_core::RunId::new(),
-                &primitive,
-                ContentInput::Text(String::new()),
-                event_tx,
-                None,
-                None,
-                None,
-                None,
-            )
-            .await
-            .expect("resume-pending pre-run terminal should restore staged session");
-        let stored = router
-            .runtime
-            .load_persisted_session(&session_id)
-            .await
-            .expect("load transient archived session")
-            .expect("transient archived session should exist");
-        assert!(MethodRouter::session_metadata_marks_archived(&stored));
-
-        let accept_resp = router
-            .dispatch(make_request(
-                "runtime/session_submit",
-                serde_json::json!({
-                    "session_id": session_id,
-                    "input": {
-                        "input_type": "prompt",
-                        "header": {
-                            "id": meerkat_core::InputId::new(),
-                            "timestamp": "2026-03-12T00:00:00Z",
-                            "source": { "type": "operator" },
-                            "durability": "durable",
-                            "visibility": {
-                                "transcript_eligible": true,
-                                "operator_eligible": true
-                            }
-                        },
-                        "text": "retry restored staged session"
-                    }
-                }),
-            ))
-            .await
-            .unwrap();
-        let accepted = result_value(&accept_resp);
-        assert_eq!(
-            accepted["outcome_type"].as_str(),
-            Some("accepted"),
-            "runtime predispatch should allow restored staged sessions despite transient archived snapshots"
-        );
-    }
-
-    #[tokio::test]
     async fn realtime_status_projects_runtime_realtime_attachment_truth_for_session_targets() {
         let (router, _notif_rx) = test_router_with_v9_runtime().await;
         let create_resp = router
@@ -6325,15 +5985,10 @@ mod tests {
             .to_string();
         let parsed_session_id =
             meerkat_core::SessionId::parse(&session_id).expect("session id should parse");
-        let session_status = router
-            .dispatch(make_request(
-                "runtime/session_status",
-                serde_json::json!({ "session_id": session_id }),
-            ))
+        router
+            .ensure_runtime_session_registered(&parsed_session_id)
             .await
-            .unwrap();
-        let status = result_value(&session_status);
-        assert_eq!(status["state"].as_str(), Some("attached"));
+            .expect("session should register for realtime status setup");
         router
             .runtime_adapter()
             .project_realtime_attachment_intent(&parsed_session_id, true)
@@ -6378,15 +6033,10 @@ mod tests {
             .to_string();
         let parsed_session_id =
             meerkat_core::SessionId::parse(&session_id).expect("session id should parse");
-        let session_status = router
-            .dispatch(make_request(
-                "runtime/session_status",
-                serde_json::json!({ "session_id": session_id }),
-            ))
+        router
+            .ensure_runtime_session_registered(&parsed_session_id)
             .await
-            .unwrap();
-        let status = result_value(&session_status);
-        assert_eq!(status["state"].as_str(), Some("attached"));
+            .expect("session should register for realtime status setup");
 
         // Drive the session into a reconnecting state. `intent=true`
         // plus `RequireRealtimeReattach` puts the DSL into
@@ -7454,50 +7104,6 @@ mod tests {
         let interrupt_resp = router.dispatch(interrupt_req).await.unwrap();
 
         assert_eq!(error_code(&interrupt_resp), error::SESSION_NOT_FOUND);
-    }
-
-    #[tokio::test]
-    async fn turn_interrupt_retired_runtime_returns_invalid_request() {
-        let (router, _notif_rx) = test_router().await;
-        let create_resp = router
-            .dispatch(make_request(
-                "session/create",
-                serde_json::json!({"prompt": "Hello"}),
-            ))
-            .await
-            .unwrap();
-        let session_id = result_value(&create_resp)["session_id"]
-            .as_str()
-            .unwrap()
-            .to_string();
-
-        let retire_resp = router
-            .dispatch(make_request(
-                "runtime/session_retire",
-                serde_json::json!({ "session_id": session_id }),
-            ))
-            .await
-            .unwrap();
-        assert!(
-            retire_resp.error.is_none(),
-            "runtime/session_retire should succeed: {:?}",
-            retire_resp.error
-        );
-
-        let interrupt_resp = router
-            .dispatch(make_request(
-                "turn/interrupt",
-                serde_json::json!({ "session_id": session_id }),
-            ))
-            .await
-            .unwrap();
-
-        assert_eq!(error_code(&interrupt_resp), error::INVALID_REQUEST);
-        assert!(
-            error_message(&interrupt_resp).contains("runtime is retired"),
-            "unexpected error: {:?}",
-            interrupt_resp.error
-        );
     }
 
     #[tokio::test]

--- a/meerkat-rpc/tests/live_smoke_rpc.rs
+++ b/meerkat-rpc/tests/live_smoke_rpc.rs
@@ -534,7 +534,7 @@ async fn e2e_scenario_16_kitchen_sink() {
         resp["result"]["contract_version"]
     );
 
-    // --- 2. Create a deferred session and drive it through runtime/* before any turn/start ---
+    // --- 2. Create a deferred session and drive it through turn/start ---
     let id = next_id();
     send_request(
         &mut writer,
@@ -559,41 +559,10 @@ async fn e2e_scenario_16_kitchen_sink() {
     send_request(
         &mut writer,
         &serde_json::json!({
-            "jsonrpc":"2.0","id":id,"method":"runtime/session_status",
-            "params":{"session_id": deferred_session}
-        }),
-    )
-    .await;
-    let resp = timeout(t, read_response(&mut reader)).await.unwrap();
-    assert!(
-        resp["error"].is_null(),
-        "runtime/session_status failed for deferred session: {resp}"
-    );
-    // RPC surface eagerly attaches an executor for all sessions (including
-    // deferred ones), so the runtime state is Attached, not Idle.
-    assert_eq!(resp["result"]["state"].as_str(), Some("attached"));
-
-    let id = next_id();
-    send_request(
-        &mut writer,
-        &serde_json::json!({
-            "jsonrpc":"2.0","id":id,"method":"runtime/session_submit",
+            "jsonrpc":"2.0","id":id,"method":"turn/start",
             "params":{
                 "session_id": deferred_session,
-                "input": {
-                    "input_type": "prompt",
-                    "header": {
-                        "id": meerkat_core::InputId::new(),
-                        "timestamp": "2026-03-12T00:00:00Z",
-                        "source": { "type": "operator" },
-                        "durability": "durable",
-                        "visibility": {
-                            "transcript_eligible": true,
-                            "operator_eligible": true
-                        }
-                    },
-                    "text": "Reply with RPC_RUNTIME_DEFERRED_16 and confirm the saved marker."
-                }
+                "prompt": "Reply with RPC_RUNTIME_DEFERRED_16 and confirm the saved marker."
             }
         }),
     )
@@ -601,36 +570,7 @@ async fn e2e_scenario_16_kitchen_sink() {
     let resp = timeout(t, read_response(&mut reader)).await.unwrap();
     assert!(
         resp["error"].is_null(),
-        "runtime/session_submit failed for deferred session: {resp}"
-    );
-    assert_eq!(resp["result"]["outcome_type"].as_str(), Some("accepted"));
-    let deferred_input_id = resp["result"]["input_id"].as_str().unwrap().to_string();
-
-    let mut consumed = false;
-    for _ in 0..120 {
-        let id = next_id();
-        send_request(
-            &mut writer,
-            &serde_json::json!({
-                "jsonrpc":"2.0","id":id,"method":"runtime/session_submission",
-                "params":{"session_id": deferred_session, "input_id": deferred_input_id}
-            }),
-        )
-        .await;
-        let resp = timeout(t, read_response(&mut reader)).await.unwrap();
-        assert!(
-            resp["error"].is_null(),
-            "runtime/session_submission failed for deferred session: {resp}"
-        );
-        if resp["result"]["current_state"].as_str() == Some("consumed") {
-            consumed = true;
-            break;
-        }
-        tokio::time::sleep(std::time::Duration::from_millis(250)).await;
-    }
-    assert!(
-        consumed,
-        "runtime/session_submit should fully consume the deferred-session input before continuing"
+        "turn/start failed for deferred session: {resp}"
     );
 
     let mut deferred_runtime_text = String::new();
@@ -663,7 +603,7 @@ async fn e2e_scenario_16_kitchen_sink() {
     assert!(
         deferred_runtime_text.contains("rpc_runtime_deferred_16")
             || deferred_runtime_text.contains("rpc runtime deferred 16"),
-        "deferred runtime turn should materialize an assistant reply via raw runtime/* methods, got: {deferred_runtime_text}"
+        "deferred turn/start should materialize an assistant reply, got: {deferred_runtime_text}"
     );
 
     // --- 3. Create session A: shell + builtins enabled ---

--- a/scripts/verify_rpc_surface_alignment.py
+++ b/scripts/verify_rpc_surface_alignment.py
@@ -39,16 +39,9 @@ def main() -> int:
     router_methods.discard("initialized")
 
     # Router-only compatibility shims intentionally remain absent from the
-    # public catalog and docs. The runtime/session_* handlers are v9-internal
-    # control paths, and skills/inspect is a retired method that returns
-    # method-not-found from the router for clearer legacy-client errors.
+    # public catalog and docs. Retired runtime/session_* control paths must not
+    # be added here: the public catalog owns the callable RPC surface.
     router_only_compat = {
-        "runtime/session_status",
-        "runtime/session_submit",
-        "runtime/session_retire",
-        "runtime/session_reset",
-        "runtime/session_submission",
-        "runtime/session_submissions",
         "skills/inspect",
     }
     router_methods -= router_only_compat

--- a/sdks/python/meerkat/client.py
+++ b/sdks/python/meerkat/client.py
@@ -45,16 +45,10 @@ from .generated.types import (
     RealtimeOpenInfo,
     RealtimeOpenRequest,
     RealtimeStatusResult,
-    RuntimeAcceptResult,
     RuntimeRealtimeAttachmentStatusResult,
-    RuntimeResetResult,
-    RuntimeRetireResult,
-    RuntimeStateResult,
     WireBudgetSplitPolicy,
     WireConnectionRef,
     WireContentInput,
-    WireInputState,
-    WireInputStateHistoryEntry,
     WireMemberLaunchMode,
     WireMobBackendKind,
     WireMobProfile,
@@ -2194,55 +2188,32 @@ class MeerkatClient:
     async def peers(self, session_id: str) -> dict[str, Any]:
         return await self._request("comms/peers", {"session_id": session_id})
 
-    async def runtime_status(self, session_id: str) -> RuntimeStateResult:
-        raw = await self._request("runtime/session_status", {"session_id": session_id})
-        result = RuntimeStateResult()
-        for key, value in raw.items():
-            setattr(result, key, value)
-        return result
+    @staticmethod
+    def _retired_runtime_session_control_error() -> MeerkatError:
+        return MeerkatError(
+            "METHOD_NOT_FOUND",
+            "Retired runtime session control methods are no longer supported by the public RPC surface.",
+        )
+
+    async def runtime_status(self, session_id: str) -> None:
+        raise self._retired_runtime_session_control_error()
 
     async def runtime_submit(
         self, session_id: str, input: dict[str, Any] | ContentInput
-    ) -> RuntimeAcceptResult:
-        raw = await self._request(
-            "runtime/session_submit",
-            {"session_id": session_id, "input": input},
-        )
-        return RuntimeAcceptResult(**raw)
+    ) -> None:
+        raise self._retired_runtime_session_control_error()
 
-    async def runtime_submission(self, session_id: str, input_id: str) -> WireInputState:
-        raw = await self._request(
-            "runtime/session_submission",
-            {"session_id": session_id, "input_id": input_id},
-        )
-        return self._parse_wire_input_state(raw)
+    async def runtime_submission(self, session_id: str, input_id: str) -> None:
+        raise self._retired_runtime_session_control_error()
 
-    async def runtime_submissions(self, session_id: str) -> dict[str, list[WireInputState]]:
-        raw = await self._request("runtime/session_submissions", {"session_id": session_id})
-        inputs = raw.get("inputs", [])
-        if not isinstance(inputs, list):
-            raise MeerkatError("INVALID_RESPONSE", "Invalid runtime/session_submissions response")
-        return {
-            "inputs": [
-                self._parse_wire_input_state(item)
-                for item in inputs
-                if isinstance(item, dict)
-            ]
-        }
+    async def runtime_submissions(self, session_id: str) -> None:
+        raise self._retired_runtime_session_control_error()
 
-    async def runtime_retire(self, session_id: str) -> RuntimeRetireResult:
-        raw = await self._request("runtime/session_retire", {"session_id": session_id})
-        result = RuntimeRetireResult()
-        for key, value in raw.items():
-            setattr(result, key, value)
-        return result
+    async def runtime_retire(self, session_id: str) -> None:
+        raise self._retired_runtime_session_control_error()
 
-    async def runtime_reset(self, session_id: str) -> RuntimeResetResult:
-        raw = await self._request("runtime/session_reset", {"session_id": session_id})
-        result = RuntimeResetResult()
-        for key, value in raw.items():
-            setattr(result, key, value)
-        return result
+    async def runtime_reset(self, session_id: str) -> None:
+        raise self._retired_runtime_session_control_error()
 
     async def runtime_realtime_attachment_status(
         self, session_id: str
@@ -2289,33 +2260,6 @@ class MeerkatClient:
             {"mob_id": mob_id, "filter": filter},
         )
 
-    async def runtime_status(self, session_id: str) -> RuntimeStateResult:
-        """Return the runtime state for a session via `runtime/session_status`."""
-        raw = await self._request("runtime/session_status", {"session_id": session_id})
-        return RuntimeStateResult(**raw)
-
-    async def runtime_submit(
-        self, session_id: str, input: dict[str, Any]
-    ) -> RuntimeAcceptResult:
-        """Submit a runtime input via `runtime/session_submit`."""
-        raw = await self._request(
-            "runtime/session_submit",
-            {"session_id": session_id, "input": input},
-        )
-        return RuntimeAcceptResult(**raw)
-
-    async def runtime_submission(
-        self, session_id: str, input_id: str
-    ) -> WireInputState | None:
-        """Read one runtime input state via `runtime/session_submission`."""
-        raw = await self._request(
-            "runtime/session_submission",
-            {"session_id": session_id, "input_id": input_id},
-        )
-        if raw is None:
-            return None
-        return self._parse_wire_input_state(raw)
-
     async def realtime_open_info(
         self, request: RealtimeOpenRequest | dict[str, Any]
     ) -> RealtimeOpenInfo:
@@ -2344,31 +2288,6 @@ class MeerkatClient:
         self._process.stdin.write((json.dumps(request) + "\n").encode())
         await self._process.stdin.drain()
         return await response_future
-
-    @staticmethod
-    def _parse_wire_input_state(raw: dict[str, Any]) -> WireInputState:
-        history_raw = raw.get("history", [])
-        history: list[WireInputStateHistoryEntry] = []
-        if isinstance(history_raw, list):
-            for entry in history_raw:
-                if not isinstance(entry, dict):
-                    continue
-                history.append(
-                    WireInputStateHistoryEntry(
-                        from_=str(entry.get("from", "")),
-                        reason=(
-                            str(entry["reason"])
-                            if entry.get("reason") is not None
-                            else None
-                        ),
-                        timestamp=str(entry.get("timestamp", "")),
-                        to=str(entry.get("to", "")),
-                    )
-                )
-
-        payload = dict(raw)
-        payload["history"] = history
-        return WireInputState(**payload)
 
     # -- Binary resolution (unchanged from original) -----------------------
 

--- a/sdks/python/tests/test_audit_parity.py
+++ b/sdks/python/tests/test_audit_parity.py
@@ -7,6 +7,7 @@ from unittest.mock import AsyncMock, MagicMock
 import pytest
 
 from meerkat.client import MeerkatClient
+from meerkat.errors import MeerkatError
 from meerkat.mob import Mob
 from meerkat.session import DeferredSession, Session
 
@@ -40,13 +41,7 @@ CANONICAL_APP_RPC_METHODS = {
     "realtime/open_info",
     "realtime/status",
     "realtime/capabilities",
-    "runtime/session_status",
     "session/realtime_attachment_status",
-    "runtime/session_submission",
-    "runtime/session_submissions",
-    "runtime/session_submit",
-    "runtime/session_retire",
-    "runtime/session_reset",
     "mob/create",
     "mob/list",
     "mob/status",
@@ -110,13 +105,7 @@ RPC_PUBLIC_WRAPPERS: dict[str, tuple[type, str]] = {
     "realtime/open_info": (MeerkatClient, "realtime_open_info"),
     "realtime/status": (MeerkatClient, "realtime_status"),
     "realtime/capabilities": (MeerkatClient, "realtime_capabilities"),
-    "runtime/session_status": (MeerkatClient, "runtime_status"),
     "session/realtime_attachment_status": (MeerkatClient, "runtime_realtime_attachment_status"),
-    "runtime/session_submission": (MeerkatClient, "runtime_submission"),
-    "runtime/session_submissions": (MeerkatClient, "runtime_submissions"),
-    "runtime/session_submit": (MeerkatClient, "runtime_submit"),
-    "runtime/session_retire": (MeerkatClient, "runtime_retire"),
-    "runtime/session_reset": (MeerkatClient, "runtime_reset"),
     "mob/create": (MeerkatClient, "create_mob"),
     "mob/list": (MeerkatClient, "list_mobs"),
     "mob/status": (Mob, "status"),
@@ -186,6 +175,30 @@ def test_parity_exclusion_set_is_small_and_justified():
         "mob/stream_open",
         "mob/stream_close",
     }
+
+
+@pytest.mark.asyncio
+async def test_python_retired_runtime_session_wrappers_fail_before_transport():
+    client = MeerkatClient()
+    client._process = MagicMock()
+    client._dispatcher = MagicMock()
+    client._request = AsyncMock(side_effect=AssertionError("retired wrapper reached transport"))
+
+    calls = [
+        lambda: client.runtime_status("session-1"),
+        lambda: client.runtime_submit("session-1", {"input_type": "prompt"}),
+        lambda: client.runtime_submission("session-1", "input-1"),
+        lambda: client.runtime_submissions("session-1"),
+        lambda: client.runtime_retire("session-1"),
+        lambda: client.runtime_reset("session-1"),
+    ]
+    for call in calls:
+        with pytest.raises(MeerkatError) as exc_info:
+            await call()
+        assert exc_info.value.code == "METHOD_NOT_FOUND"
+        assert "Retired runtime session control methods" in exc_info.value.message
+
+    client._request.assert_not_called()
 
 
 @pytest.mark.asyncio
@@ -497,6 +510,12 @@ def test_sdk_never_uses_retired_public_method_strings():
 
     retired_methods = [
         '"auth/profile/test"',
+        '"runtime/session_status"',
+        '"runtime/session_submission"',
+        '"runtime/session_submissions"',
+        '"runtime/session_submit"',
+        '"runtime/session_retire"',
+        '"runtime/session_reset"',
         '"session/realtime_attachment_statuses"',
         '"skills/inspect"',
     ]
@@ -507,6 +526,8 @@ def test_sdk_never_uses_retired_public_method_strings():
     for root in sdk_roots:
         for path in root.rglob("*"):
             if path.suffix not in {".py", ".ts"}:
+                continue
+            if "generated" in path.parts:
                 continue
             text = path.read_text()
             for needle in retired_methods:

--- a/sdks/python/tests/test_e2e_smoke.py
+++ b/sdks/python/tests/test_e2e_smoke.py
@@ -19,7 +19,6 @@ from .live_smoke_support import (
     has_gemini_api_key,
     has_openai_api_key,
     live_client,
-    make_prompt_input,
     openai_model,
     raw_request,
     resolve_rkat_rpc_path,
@@ -307,14 +306,14 @@ if include_scenario(38):
 
 
 # ---------------------------------------------------------------------------
-# Scenario 39: Persistent reconnect + session submit
+# Scenario 39: Persistent reconnect + turn/start
 # ---------------------------------------------------------------------------
 
 
 if include_scenario(39):
     @pytest.mark.asyncio
     @requires_live_llm
-    async def test_smoke_scenario_39_persistent_reconnect_and_session_submit(tmp_path: Path):
+    async def test_smoke_scenario_39_persistent_reconnect_and_turn_start(tmp_path: Path):
         realm = persistent_realm_kwargs(tmp_path)
         marker = f"python-runtime-{uuid4().hex[:8]}"
 
@@ -331,40 +330,17 @@ if include_scenario(39):
             assert read_back.session_id == session_id
             assert read_back.message_count >= 2
 
-            runtime_state = await client_b.runtime_status(session_id)
-            assert runtime_state.state in {
-                "attached",
-                "idle",
-                "running",
-                "initializing",
-            }
-
-            accepted = await client_b.runtime_submit(
+            result = await client_b._start_turn(  # noqa: SLF001
                 session_id,
-                make_prompt_input(
-                    f"Reply with PY-RUNTIME-39, PY-RUNTIME-OK, and the marker {marker}.",
-                    turn_metadata={
-                        "additional_instructions": [
-                            "Keep the response brief and include only the requested markers.",
-                        ],
-                    },
-                ),
+                f"Reply with PY-RUNTIME-39, PY-RUNTIME-OK, and the marker {marker}.",
+                additional_instructions=[
+                    "Keep the response brief and include only the requested markers.",
+                ],
             )
-            assert accepted.outcome_type == "accepted"
-            assert accepted.input_id is not None
-            input_id = accepted.input_id
-
-            input_state = await wait_for(
-                "runtime input to be consumed",
-                lambda: client_b.runtime_submission(session_id, input_id),
-                lambda state: state is not None and state.current_state == "consumed",
-                timeout_secs=120.0,
-            )
-            assert input_state is not None
-            assert input_state.current_state == "consumed"
+            assert result.session_id == session_id
 
             after_runtime = await wait_for(
-                "runtime-authored assistant reply",
+                "turn/start-authored assistant reply",
                 lambda: client_b.read_session(session_id),
                 lambda state: "py-runtime-39" in (state.last_assistant_text or "").lower()
                 and "py-runtime-ok" in (state.last_assistant_text or "").lower(),

--- a/sdks/typescript/src/client.ts
+++ b/sdks/typescript/src/client.ts
@@ -48,13 +48,8 @@ import {
   type RealtimeOpenInfo,
   type RealtimeOpenRequest,
   type RealtimeStatusResult,
-  type RuntimeAcceptResult,
   type MobTurnStartParams,
   type RuntimeRealtimeAttachmentStatusResult,
-  type RuntimeResetResult,
-  type RuntimeRetireResult,
-  type RuntimeStateResult,
-  type WireInputState,
   type McpAddParams,
   type McpLiveOpResponse,
   type McpReloadParams,
@@ -1913,45 +1908,41 @@ export class MeerkatClient {
     await this.request("session/archive", { session_id: sessionId });
   }
 
-  /**
-   * Runtime-control surface wrappers.
-   *
-   * Thin pass-throughs to the canonical runtime RPC methods. Typed
-   * request/response shapes live on the Rust wire contracts
-   * (`meerkat-contracts/src/wire/runtime.rs`); callers that need typed
-   * parameter shapes consume the generated types from
-   * `sdks/typescript/src/generated/`. Exposed here so the
-   * rpc-surface-alignment + sdk-wrapper-freshness gates see the method
-   * names in the TS source tree.
-   * @internal
-   */
-  async _runtimeStatus(params: Record<string, unknown>): Promise<unknown> {
-    return this.request("runtime/session_status", params);
+  private static retiredRuntimeSessionControlError(): MeerkatError {
+    return new MeerkatError(
+      "METHOD_NOT_FOUND",
+      "Retired runtime session control methods are no longer supported by the public RPC surface.",
+    );
   }
 
   /** @internal */
-  async _runtimeSubmit(params: Record<string, unknown>): Promise<unknown> {
-    return this.request("runtime/session_submit", params);
+  async _runtimeStatus(_params: Record<string, unknown>): Promise<never> {
+    throw MeerkatClient.retiredRuntimeSessionControlError();
   }
 
   /** @internal */
-  async _runtimeSubmission(params: Record<string, unknown>): Promise<unknown> {
-    return this.request("runtime/session_submission", params);
+  async _runtimeSubmit(_params: Record<string, unknown>): Promise<never> {
+    throw MeerkatClient.retiredRuntimeSessionControlError();
   }
 
   /** @internal */
-  async _runtimeSubmissions(params: Record<string, unknown>): Promise<unknown> {
-    return this.request("runtime/session_submissions", params);
+  async _runtimeSubmission(_params: Record<string, unknown>): Promise<never> {
+    throw MeerkatClient.retiredRuntimeSessionControlError();
   }
 
   /** @internal */
-  async _runtimeRetire(params: Record<string, unknown>): Promise<unknown> {
-    return this.request("runtime/session_retire", params);
+  async _runtimeSubmissions(_params: Record<string, unknown>): Promise<never> {
+    throw MeerkatClient.retiredRuntimeSessionControlError();
   }
 
   /** @internal */
-  async _runtimeReset(params: Record<string, unknown>): Promise<unknown> {
-    return this.request("runtime/session_reset", params);
+  async _runtimeRetire(_params: Record<string, unknown>): Promise<never> {
+    throw MeerkatClient.retiredRuntimeSessionControlError();
+  }
+
+  /** @internal */
+  async _runtimeReset(_params: Record<string, unknown>): Promise<never> {
+    throw MeerkatClient.retiredRuntimeSessionControlError();
   }
 
   /** @internal */

--- a/sdks/typescript/tests/types.test.js
+++ b/sdks/typescript/tests/types.test.js
@@ -1341,6 +1341,38 @@ describe("Auth wrappers", () => {
 });
 
 describe("Parity wrappers", () => {
+  it("retired runtime session wrappers fail before transport", async () => {
+    const client = new MeerkatClient();
+    const calls = [];
+    client.request = async (method, params) => {
+      calls.push({ method, params });
+      throw new Error("retired wrapper reached transport");
+    };
+
+    for (const methodName of [
+      "_runtimeStatus",
+      "_runtimeSubmit",
+      "_runtimeSubmission",
+      "_runtimeSubmissions",
+      "_runtimeRetire",
+      "_runtimeReset",
+    ]) {
+      await assert.rejects(
+        async () => {
+          await client[methodName]({ session_id: "session-1" });
+        },
+        (err) => {
+          assert.ok(err instanceof MeerkatError);
+          assert.equal(err.code, "METHOD_NOT_FOUND");
+          assert.match(err.message, /Retired runtime session control methods/);
+          return true;
+        },
+      );
+    }
+
+    assert.deepEqual(calls, []);
+  });
+
   it("adds wrappers for session external events and model catalog", async () => {
     const client = new MeerkatClient();
     const calls = [];

--- a/xtask/tests/buildbuddy_static_lanes.rs
+++ b/xtask/tests/buildbuddy_static_lanes.rs
@@ -285,17 +285,7 @@ fn rpc_catalog_router_docs_and_sdk_wrappers_are_aligned() {
 
     // Router-only compatibility shims intentionally remain absent from the public
     // catalog and docs. Keep this in sync with scripts/verify-rpc-surface-alignment.sh.
-    for method in [
-        "runtime/session_status",
-        "runtime/session_submit",
-        "runtime/session_retire",
-        "runtime/session_reset",
-        "runtime/session_submission",
-        "runtime/session_submissions",
-        "skills/inspect",
-    ] {
-        router_methods.remove(method);
-    }
+    router_methods.remove("skills/inspect");
 
     let mut catalog_methods = BTreeSet::new();
     for needle in [


### PR DESCRIPTION
## Summary
- remove retired `runtime/session_*` dispatch arms from the RPC router so catalog-absent methods fail closed
- remove `runtime/session_*` from router/catalog audit allowlists and xtask parity checks
- turn TS/Python SDK old runtime session wrappers into local `METHOD_NOT_FOUND` stubs and update smoke/parity tests to use canonical `turn/start` paths

Dogma cleanup PR: yes

## Review Readiness Packet

Current head SHA: 73d53ad8b16311c08b815582fba120dfde289d1b
Base: `main`
Linear: LUC-333
Canonical owner after PR: public RPC catalog/generator owns callable runtime/session control method truth.

Command output:

```text
$ python3 /tmp/luc-316-dogma_cleanup_gate.py --repo . --base origin/main --packet /tmp/luc-333-rrp.md --head-sha 73d53ad8b16311c08b815582fba120dfde289d1b --packet-only
Dogma cleanup gate passed for /tmp/luc-333-rrp.md
$ python3 /tmp/luc-316-dogma_cleanup_gate.py --repo . --base origin/main --packet /tmp/luc-333-rrp.md --head-sha 73d53ad8b16311c08b815582fba120dfde289d1b
Dogma cleanup gate passed for /tmp/luc-333-rrp.md
```

## Old Path Amputation Proof

| Old path | Classification | Search literal | Mechanical proof | Follow-up |
| --- | --- | --- | --- | --- |
| `runtime/session_status` | made uncallable at boundary | `runtime/session_status` | Router requests are rejected through the unknown-method path with `METHOD_NOT_FOUND`; `retired_runtime_session_control_methods_fail_closed_and_leave_state_unchanged` proves runtime/session state is unchanged. | none |
| `runtime/session_submit` | made uncallable at boundary | `runtime/session_submit` | Router requests are rejected through the unknown-method path with `METHOD_NOT_FOUND`; `retired_runtime_session_control_methods_fail_closed_and_leave_state_unchanged` proves runtime/session state is unchanged. | none |
| `runtime/session_submission` | made uncallable at boundary | `runtime/session_submission` | Router requests are rejected through the unknown-method path with `METHOD_NOT_FOUND`; `retired_runtime_session_control_methods_fail_closed_and_leave_state_unchanged` proves runtime/session state is unchanged. | none |
| `runtime/session_submissions` | made uncallable at boundary | `runtime/session_submissions` | Router requests are rejected through the unknown-method path with `METHOD_NOT_FOUND`; `retired_runtime_session_control_methods_fail_closed_and_leave_state_unchanged` proves runtime/session state is unchanged. | none |
| `runtime/session_retire` | made uncallable at boundary | `runtime/session_retire` | Router requests are rejected through the unknown-method path with `METHOD_NOT_FOUND`; `retired_runtime_session_control_methods_fail_closed_and_leave_state_unchanged` proves runtime/session state is unchanged. | none |
| `runtime/session_reset` | made uncallable at boundary | `runtime/session_reset` | Router requests are rejected through the unknown-method path with `METHOD_NOT_FOUND`; `retired_runtime_session_control_methods_fail_closed_and_leave_state_unchanged` proves runtime/session state is unchanged. | none |
| TypeScript SDK `_runtimeStatus` | made uncallable at boundary | `_runtimeStatus` | SDK calls are rejected locally with `METHOD_NOT_FOUND` before transport; `node --test tests/types.test.js` asserts no request reaches transport. | none |
| TypeScript SDK `_runtimeSubmit` | made uncallable at boundary | `_runtimeSubmit` | SDK calls are rejected locally with `METHOD_NOT_FOUND` before transport; `node --test tests/types.test.js` asserts no request reaches transport. | none |
| TypeScript SDK `_runtimeSubmission` | made uncallable at boundary | `_runtimeSubmission` | SDK calls are rejected locally with `METHOD_NOT_FOUND` before transport; `node --test tests/types.test.js` asserts no request reaches transport. | none |
| TypeScript SDK `_runtimeSubmissions` | made uncallable at boundary | `_runtimeSubmissions` | SDK calls are rejected locally with `METHOD_NOT_FOUND` before transport; `node --test tests/types.test.js` asserts no request reaches transport. | none |
| TypeScript SDK `_runtimeRetire` | made uncallable at boundary | `_runtimeRetire` | SDK calls are rejected locally with `METHOD_NOT_FOUND` before transport; `node --test tests/types.test.js` asserts no request reaches transport. | none |
| TypeScript SDK `_runtimeReset` | made uncallable at boundary | `_runtimeReset` | SDK calls are rejected locally with `METHOD_NOT_FOUND` before transport; `node --test tests/types.test.js` asserts no request reaches transport. | none |
| Python SDK `runtime_status` | made uncallable at boundary | `runtime_status` | SDK calls are rejected locally with `METHOD_NOT_FOUND` before transport; `python3 -m pytest sdks/python/tests/test_audit_parity.py -q` asserts `_request` is not called. | none |
| Python SDK `runtime_submit` | made uncallable at boundary | `runtime_submit` | SDK calls are rejected locally with `METHOD_NOT_FOUND` before transport; `python3 -m pytest sdks/python/tests/test_audit_parity.py -q` asserts `_request` is not called. | none |
| Python SDK `runtime_submission` | made uncallable at boundary | `runtime_submission` | SDK calls are rejected locally with `METHOD_NOT_FOUND` before transport; `python3 -m pytest sdks/python/tests/test_audit_parity.py -q` asserts `_request` is not called. | none |
| Python SDK `runtime_submissions` | made uncallable at boundary | `runtime_submissions` | SDK calls are rejected locally with `METHOD_NOT_FOUND` before transport; `python3 -m pytest sdks/python/tests/test_audit_parity.py -q` asserts `_request` is not called. | none |
| Python SDK `runtime_retire` | made uncallable at boundary | `runtime_retire` | SDK calls are rejected locally with `METHOD_NOT_FOUND` before transport; `python3 -m pytest sdks/python/tests/test_audit_parity.py -q` asserts `_request` is not called. | none |
| Python SDK `runtime_reset` | made uncallable at boundary | `runtime_reset` | SDK calls are rejected locally with `METHOD_NOT_FOUND` before transport; `python3 -m pytest sdks/python/tests/test_audit_parity.py -q` asserts `_request` is not called. | none |
| Router/catalog audit allowlist for `runtime/session_*` | made uncallable at boundary | `runtime/session_*` | `make verify-rpc-surface-alignment` rejects routes served by the router but absent from the public catalog after the allowlist removal. | none |

## Complexity Delta

- Docs/scripts/tests: 6 files (`meerkat-rpc/tests/live_smoke_rpc.rs`, `scripts/verify_rpc_surface_alignment.py`, `sdks/python/tests/test_audit_parity.py`, `sdks/python/tests/test_e2e_smoke.py`, `sdks/typescript/tests/types.test.js`, `xtask/tests/buildbuddy_static_lanes.rs`).
- Non-test implementation: 3 files (`meerkat-rpc/src/router.rs`, `sdks/python/meerkat/client.py`, `sdks/typescript/src/client.ts`).
- Generated/schema churn: 0 files.

## Sample Passing Old Path Amputation Proof

| Old path | Classification | Search literal | Mechanical proof | Follow-up |
| --- | --- | --- | --- | --- |
| `runtime/session_status` | made uncallable at boundary | `runtime/session_status` | Requests are rejected with `METHOD_NOT_FOUND` and the negative RPC fixture proves state is unchanged. | none |

## Sample Failing Old Path Amputation Proof

| Old path | Classification | Search literal | Mechanical proof | Follow-up |
| --- | --- | --- | --- | --- |
| `runtime/session_status` | wrapped | `runtime/session_status` | A preferred path exists beside the old route. | none |

## Validation
- `make verify-rpc-surface-alignment`
- `make verify-sdk-wrapper-freshness`
- `./scripts/repo-cargo test -p meerkat-rpc retired_runtime_session_control_methods_fail_closed_and_leave_state_unchanged`
- `PYTHONPATH=sdks/python python3 -m pytest sdks/python/tests/test_audit_parity.py -q`
- `npm run build && node --test tests/types.test.js` (in `sdks/typescript`)
- `./scripts/repo-cargo clippy -p xtask --test buildbuddy_static_lanes -- -D warnings`
- `make fmt-check`
- `make agent-gate`

## CI / Review Gate
- GitHub checks are green for exact head `73d53ad8b16311c08b815582fba120dfde289d1b`; `CI gate` and BuildBuddy matrix checks passed.
- No PR comments or reviews were present when the current rework pass began, and no blocking AI review feedback was recorded.
