### PR TITLE
LUC-339 fail closed Web mob decoders

### DIFF
--- a/docs/architecture/luc-339-review-readiness.md
+++ b/docs/architecture/luc-339-review-readiness.md
@@ -9,32 +9,48 @@ changes, this packet must be re-read against that exact head before review.
 
 Generated:
 - `sdks/web/src/generated/mob.ts` adds browser-local mob wire result types from
-  `artifacts/schemas/wire-types.json`, including the generated `MobListResult`
-  envelope for Web mob listing.
+  `artifacts/schemas/wire-types.json`, including generated `MobListResult`,
+  `MobMemberSendResult`, `MobFlowStatusResult`, `MobHelperResult`,
+  `MobMemberStatusResult`, and supporting `WireMemberRef` contracts.
 
 Non-test implementation:
 - `sdks/web/src/mob.ts` replaces mob status/result/event casts and fabricated
   fallback projections with strict generated-envelope parsers. The mob status
   parser is shared with runtime mob listing.
+- `sdks/web/src/mob.ts` routes `Member.send()`, `spawnHelper()`,
+  `forkHelper()`, and `flowStatus()` through generated/fail-closed result
+  parsers instead of raw casts or caller/default projections.
+- `sdks/web/src/mob.ts` requires canonical event envelope metadata
+  (`event_id`, `source_id`, `seq`, `timestamp_ms`) before exposing member or
+  mob-wide subscription events.
 - `sdks/web/src/runtime.ts` decodes `MeerkatRuntime.listMobs()` as a generated
   `MobListResult` envelope and validates every mob row with the generated mob
   status parser.
 - `sdks/web/src/types.ts` moves public mob status/event shapes to generated
-  `status` and `payload` truth, keeping only `state: status` as an inert
-  compatibility projection.
+  `status`, event metadata, and `payload` truth, keeping only `state: status`
+  as an inert compatibility projection. `MobMemberSnapshot` now preserves the
+  generated member-status fields `current_session_id`,
+  `realtime_attachment_status`, and `external_member`.
 - `meerkat-web-runtime/src/lib.rs` emits generated `status` and respawn
   `receipt.member_ref` fields, and `mob_list()` now emits the generated
-  `MobListResult` envelope, so the real browser WASM path supplies the wire
-  truth now required by the SDK.
+  `MobListResult` envelope. It also emits generated `mob_id` on
+  `mob_member_send()` and wraps `mob_flow_status()` as generated
+  `{ "run": ... }`, so the real browser WASM path supplies the wire truth now
+  required by the SDK.
 - `tools/sdk-codegen/generate.py` emits the Web mob generated type slice.
+- The branch is rebased onto current `origin/main`; the exact-head two-dot diff
+  no longer contains the stale `meerkat-runtime/src/driver/persistent.rs` or
+  `meerkat-session/src/persistent.rs` regressions called out in rework.
 
 Tests:
 - `sdks/web/tests/mob_payload.unit.mjs` adds negative fixtures for missing mob
   status/result fields, `MeerkatRuntime.listMobs()` state-only/malformed rows,
   legacy respawn receipt carriers, malformed member and mob-wide event
-  envelopes, and malformed mob event log entries.
+  envelopes, metadata-light `{ payload: { type } }` envelopes, malformed
+  helper/send/flow result envelopes, and malformed mob event log entries.
 - `sdks/web/tests/e2e_wasm_runtime.test.mjs` updates the fake WASM fixture to
-  the generated mob list, member status, and respawn receipt shape.
+  the generated mob list, member status, member-send, flow-status, and respawn
+  receipt shape.
 
 Docs:
 - This packet.
@@ -54,7 +70,25 @@ The following exact Web SDK default/fabrication paths became impossible:
   now throws `Invalid mob/list response: malformed envelope`.
 - `Mob.memberStatus()` no longer fabricates `status: "unknown"`,
   `tokens_used: 0`, or `is_final: false`. The generated member status,
-  token count, and finality flag are all required and type checked.
+  token count, and finality flag are all required and type checked. The
+  generated `current_session_id`, `realtime_attachment_status`, and
+  `external_member` fields are preserved after validation instead of being
+  dropped.
+- `Member.send()` no longer raw-casts a partial receipt or projects missing
+  returned `handling_mode` from the caller request. It requires generated
+  `mob_id`, `agent_identity`, `member_ref`, and `handling_mode`; missing
+  `handling_mode` now throws
+  `Invalid mob member delivery response: missing handling_mode`.
+- `Mob.spawnHelper()` and `Mob.forkHelper()` no longer fabricate
+  `tokens_used: 0`. They require generated `tokens_used`, `agent_identity`, and
+  `member_ref`; missing token truth now throws
+  `Invalid mob spawn_helper response: tokens_used must be number` or the
+  matching fork-helper error.
+- `Mob.flowStatus()` no longer returns `JSON.parse(json) as FlowStatus`. It
+  requires the generated `MobFlowStatusResult.run` envelope, returns `null` only
+  for explicit `run: null`, and validates `run_id` and `status` before exposing
+  a run object. A malformed legacy payload such as `{ state: "running" }` now
+  throws `Invalid mob flow_status response: missing run`.
 - `Mob.respawn()` no longer maps missing or unknown result status to
   `completed`, and no longer accepts the legacy `receipt.agent_identity`
   carrier. It requires generated `status`, `receipt.identity`, and
@@ -64,7 +98,10 @@ The following exact Web SDK default/fabrication paths became impossible:
 - Member and mob-wide subscription decoders no longer synthesize
   `{ type: "unknown" }`, empty `source`, or empty `role` from malformed event
   envelopes. They require generated `payload.type`, a validated mob-wide
-  runtime-id `source` object, and mob-wide `role`.
+  runtime-id `source` object, mob-wide `role`, and canonical envelope
+  metadata (`event_id`, `source_id`, `seq`, `timestamp_ms`). A metadata-light
+  `{ payload: { type } }` envelope now throws
+  `Invalid mob member subscription event[0]: missing event_id`.
 - `Mob.events()` no longer returns a raw cast of malformed event log rows; it
   requires `cursor`, `timestamp`, `mob_id`, and `kind`.
 
@@ -93,3 +130,22 @@ an inert projection of the already-required generated `status` field.
 - Rework focused validation: `npm test` in `sdks/web` passed after routing
   `MeerkatRuntime.listMobs()` through the generated mob list/status parsers and
   fixing the stale e2e member-status fixture.
+- Second rework baseline at
+  `36e3c85f763e5325677cb57fe9ce1ca0f7a306c7`: `npm test` in `sdks/web`
+  passed, and one-off probes confirmed the old paths still projected missing
+  `handling_mode`, fabricated helper `tokens_used: 0`, raw-cast malformed
+  flow-status payloads, and accepted metadata-light member events.
+- Second rework focused validation: `npm test` in `sdks/web` passed after
+  adding generated parsers for member-send, helper, and flow-status results;
+  requiring canonical event envelope metadata; preserving generated
+  member-status fields; and rebasing away the stale non-Web exact-head diff.
+- Second rework one-off probes now fail closed with
+  `Invalid mob member delivery response: missing handling_mode`,
+  `Invalid mob spawn_helper response: tokens_used must be number`,
+  `Invalid mob fork_helper response: tokens_used must be number`,
+  `Invalid mob flow_status response: missing run`, and
+  `Invalid mob member subscription event[0]: missing event_id`.
+- Second rework targeted Rust compile:
+  `./scripts/repo-cargo test -p meerkat-web-runtime --no-run` passed.
+- Local Web e2e attempt: `npm run test:e2e` could not start because
+  `wasm-pack` is not installed in this workspace (`spawn wasm-pack ENOENT`).

--- a/docs/architecture/luc-339-review-readiness.md
+++ b/docs/architecture/luc-339-review-readiness.md
@@ -50,8 +50,8 @@ The following exact Web SDK default/fabrication paths became impossible:
   `staged`.
 - Member and mob-wide subscription decoders no longer synthesize
   `{ type: "unknown" }`, empty `source`, or empty `role` from malformed event
-  envelopes. They require generated `payload.type`, mob-wide `source`, and
-  mob-wide `role`.
+  envelopes. They require generated `payload.type`, a validated mob-wide
+  runtime-id `source` object, and mob-wide `role`.
 - `Mob.events()` no longer returns a raw cast of malformed event log rows; it
   requires `cursor`, `timestamp`, `mob_id`, and `kind`.
 
@@ -67,3 +67,7 @@ an inert projection of the already-required generated `status` field.
 - Formatting: `make fmt-check` passed.
 - Broad check: `MEERKAT_BUILDBUDDY=1 make check` passed via BuildBuddy
   invocation `46c526e1-9a54-4d2b-aa19-e22f94ab1b8d`.
+- AI review follow-up: mob-wide `source` now requires the real runtime-id object
+  shape and rejects the legacy string source instead of projecting
+  `agent_identity`.
+  Revalidated with `npm test` in `sdks/web` and `make agent-gate`.

--- a/docs/architecture/luc-339-review-readiness.md
+++ b/docs/architecture/luc-339-review-readiness.md
@@ -9,25 +9,32 @@ changes, this packet must be re-read against that exact head before review.
 
 Generated:
 - `sdks/web/src/generated/mob.ts` adds browser-local mob wire result types from
-  `artifacts/schemas/wire-types.json`.
+  `artifacts/schemas/wire-types.json`, including the generated `MobListResult`
+  envelope for Web mob listing.
 
 Non-test implementation:
 - `sdks/web/src/mob.ts` replaces mob status/result/event casts and fabricated
-  fallback projections with strict generated-envelope parsers.
+  fallback projections with strict generated-envelope parsers. The mob status
+  parser is shared with runtime mob listing.
+- `sdks/web/src/runtime.ts` decodes `MeerkatRuntime.listMobs()` as a generated
+  `MobListResult` envelope and validates every mob row with the generated mob
+  status parser.
 - `sdks/web/src/types.ts` moves public mob status/event shapes to generated
   `status` and `payload` truth, keeping only `state: status` as an inert
   compatibility projection.
 - `meerkat-web-runtime/src/lib.rs` emits generated `status` and respawn
-  `receipt.member_ref` fields so the real browser WASM path supplies the wire
+  `receipt.member_ref` fields, and `mob_list()` now emits the generated
+  `MobListResult` envelope, so the real browser WASM path supplies the wire
   truth now required by the SDK.
 - `tools/sdk-codegen/generate.py` emits the Web mob generated type slice.
 
 Tests:
 - `sdks/web/tests/mob_payload.unit.mjs` adds negative fixtures for missing mob
-  status/result fields, legacy respawn receipt carriers, malformed member and
-  mob-wide event envelopes, and malformed mob event log entries.
+  status/result fields, `MeerkatRuntime.listMobs()` state-only/malformed rows,
+  legacy respawn receipt carriers, malformed member and mob-wide event
+  envelopes, and malformed mob event log entries.
 - `sdks/web/tests/e2e_wasm_runtime.test.mjs` updates the fake WASM fixture to
-  the generated mob status and respawn receipt shape.
+  the generated mob list, member status, and respawn receipt shape.
 
 Docs:
 - This packet.
@@ -39,6 +46,12 @@ The following exact Web SDK default/fabrication paths became impossible:
 - `Mob.status()` no longer returns a raw cast and can no longer accept a
   state-only payload. Missing `status` now throws
   `Invalid mob/status response: missing status`.
+- `MeerkatRuntime.listMobs()` no longer returns
+  `JSON.parse(json) as MobStatus[]`. It now requires the generated
+  `MobListResult.mobs` envelope and validates each row as a generated
+  `MobStatusResult`. A state-only row such as `{ mob_id, state }` now throws
+  `Invalid mob/list response.mobs[0]: missing status`, and a legacy bare array
+  now throws `Invalid mob/list response: malformed envelope`.
 - `Mob.memberStatus()` no longer fabricates `status: "unknown"`,
   `tokens_used: 0`, or `is_final: false`. The generated member status,
   token count, and finality flag are all required and type checked.
@@ -55,7 +68,8 @@ The following exact Web SDK default/fabrication paths became impossible:
 - `Mob.events()` no longer returns a raw cast of malformed event log rows; it
   requires `cursor`, `timestamp`, `mob_id`, and `kind`.
 
-The only retained status compatibility helper is `Mob.status().state`, which is
+The only retained status compatibility helper is `state` on public mob status
+objects from `Mob.status()` and `MeerkatRuntime.listMobs()`. In both cases it is
 an inert projection of the already-required generated `status` field.
 
 ## Validation Evidence
@@ -71,3 +85,11 @@ an inert projection of the already-required generated `status` field.
   shape and rejects the legacy string source instead of projecting
   `agent_identity`.
   Revalidated with `npm test` in `sdks/web` and `make agent-gate`.
+- Human Review rework baseline at
+  `962ad4fdae385ed228d2a324aaf38b0d2edc2677`: `npm test` in `sdks/web` passed,
+  and a one-off `MeerkatRuntime.listMobs()` probe showed the old raw-cast path
+  returned `[{"mob_id":"mob-web-unit","state":"Running"}]` from a state-only
+  `mob_list()` row.
+- Rework focused validation: `npm test` in `sdks/web` passed after routing
+  `MeerkatRuntime.listMobs()` through the generated mob list/status parsers and
+  fixing the stale e2e member-status fixture.

--- a/docs/architecture/luc-339-review-readiness.md
+++ b/docs/architecture/luc-339-review-readiness.md
@@ -1,0 +1,69 @@
+# LUC-339 Review Readiness Packet
+
+Issue: `LUC-339` fail closed Web SDK mob decoder defaults.
+
+This packet applies to the PR head that contains this file. If the PR head
+changes, this packet must be re-read against that exact head before review.
+
+## Scope Separation
+
+Generated:
+- `sdks/web/src/generated/mob.ts` adds browser-local mob wire result types from
+  `artifacts/schemas/wire-types.json`.
+
+Non-test implementation:
+- `sdks/web/src/mob.ts` replaces mob status/result/event casts and fabricated
+  fallback projections with strict generated-envelope parsers.
+- `sdks/web/src/types.ts` moves public mob status/event shapes to generated
+  `status` and `payload` truth, keeping only `state: status` as an inert
+  compatibility projection.
+- `meerkat-web-runtime/src/lib.rs` emits generated `status` and respawn
+  `receipt.member_ref` fields so the real browser WASM path supplies the wire
+  truth now required by the SDK.
+- `tools/sdk-codegen/generate.py` emits the Web mob generated type slice.
+
+Tests:
+- `sdks/web/tests/mob_payload.unit.mjs` adds negative fixtures for missing mob
+  status/result fields, legacy respawn receipt carriers, malformed member and
+  mob-wide event envelopes, and malformed mob event log entries.
+- `sdks/web/tests/e2e_wasm_runtime.test.mjs` updates the fake WASM fixture to
+  the generated mob status and respawn receipt shape.
+
+Docs:
+- This packet.
+
+## Old Path Amputation Proof
+
+The following exact Web SDK default/fabrication paths became impossible:
+
+- `Mob.status()` no longer returns a raw cast and can no longer accept a
+  state-only payload. Missing `status` now throws
+  `Invalid mob/status response: missing status`.
+- `Mob.memberStatus()` no longer fabricates `status: "unknown"`,
+  `tokens_used: 0`, or `is_final: false`. The generated member status,
+  token count, and finality flag are all required and type checked.
+- `Mob.respawn()` no longer maps missing or unknown result status to
+  `completed`, and no longer accepts the legacy `receipt.agent_identity`
+  carrier. It requires generated `status`, `receipt.identity`, and
+  `receipt.member_ref`.
+- `Mob.appendSystemContext()` no longer maps a missing result status to
+  `staged`.
+- Member and mob-wide subscription decoders no longer synthesize
+  `{ type: "unknown" }`, empty `source`, or empty `role` from malformed event
+  envelopes. They require generated `payload.type`, mob-wide `source`, and
+  mob-wide `role`.
+- `Mob.events()` no longer returns a raw cast of malformed event log rows; it
+  requires `cursor`, `timestamp`, `mob_id`, and `kind`.
+
+The only retained status compatibility helper is `Mob.status().state`, which is
+an inert projection of the already-required generated `status` field.
+
+## Validation Evidence
+
+- Baseline before edits: `npm test` in `sdks/web` passed, and a one-off decoder
+  probe showed the old path fabricating `unknown`, `completed`, and
+  `{ type: "unknown" }`.
+- Focused after edits: `npm test` in `sdks/web` passed.
+- Formatting: `make fmt-check` passed.
+- Broad check: `MEERKAT_BUILDBUDDY=1 make check` passed via BuildBuddy
+  invocation `46c526e1-9a54-4d2b-aa19-e22f94ab1b8d`.

--- a/meerkat-web-runtime/src/lib.rs
+++ b/meerkat-web-runtime/src/lib.rs
@@ -2071,6 +2071,7 @@ pub async fn mob_member_send(
         .map_err(err_mob)?;
     let identity_str = receipt.identity.to_string();
     let payload = serde_json::json!({
+        "mob_id": id.as_str(),
         "agent_identity": receipt.identity,
         "member_ref": meerkat_contracts::WireMemberRef::encode(id.as_str(), &identity_str),
         "handling_mode": match receipt.handling_mode {
@@ -2254,7 +2255,8 @@ pub async fn mob_run_flow(
 
 /// Read flow run status.
 ///
-/// Returns JSON with run state and ledgers, or null if not found.
+/// Returns a generated `MobFlowStatusResult` JSON envelope whose `run` field
+/// carries run state and ledgers, or null when not found.
 #[wasm_bindgen]
 pub async fn mob_flow_status(mob_id: &str, run_id: &str) -> Result<JsValue, JsValue> {
     let mob_state = with_mob_state(Ok)?;
@@ -2263,13 +2265,9 @@ pub async fn mob_flow_status(mob_id: &str, run_id: &str) -> Result<JsValue, JsVa
         .parse()
         .map_err(|e| err_str("invalid_run_id", format!("{e}")))?;
     let status = mob_state.mob_flow_status(&id, rid).await.map_err(err_mob)?;
-    match status {
-        Some(run) => {
-            let json = serde_json::to_string(&run).map_err(|e| err_str("serialize_error", e))?;
-            Ok(JsValue::from_str(&json))
-        }
-        None => Ok(JsValue::from_str("null")),
-    }
+    let json = serde_json::to_string(&serde_json::json!({ "run": status }))
+        .map_err(|e| err_str("serialize_error", e))?;
+    Ok(JsValue::from_str(&json))
 }
 
 /// Cancel an in-flight flow run.

--- a/meerkat-web-runtime/src/lib.rs
+++ b/meerkat-web-runtime/src/lib.rs
@@ -1576,7 +1576,7 @@ pub async fn mob_create(definition_json: &str) -> Result<JsValue, JsValue> {
 
 /// Get the status of a mob.
 ///
-/// Returns JSON with the mob state.
+/// Returns JSON with the generated mob status plus the legacy state projection.
 #[wasm_bindgen]
 pub async fn mob_status(mob_id: &str) -> Result<JsValue, JsValue> {
     let mob_state = with_mob_state(Ok)?;
@@ -1584,6 +1584,7 @@ pub async fn mob_status(mob_id: &str) -> Result<JsValue, JsValue> {
     let state = mob_state.mob_status(&id).await.map_err(err_mob)?;
     let result = serde_json::json!({
         "mob_id": mob_id,
+        "status": state.as_str(),
         "state": state.as_str(),
     });
     Ok(JsValue::from_str(&result.to_string()))
@@ -1591,7 +1592,7 @@ pub async fn mob_status(mob_id: &str) -> Result<JsValue, JsValue> {
 
 /// List all mobs.
 ///
-/// Returns JSON array of `{ mob_id, state }`.
+/// Returns JSON array of `{ mob_id, status, state }`.
 #[wasm_bindgen]
 pub async fn mob_list() -> Result<JsValue, JsValue> {
     let mob_state = with_mob_state(Ok)?;
@@ -1601,6 +1602,7 @@ pub async fn mob_list() -> Result<JsValue, JsValue> {
         .map(|(id, state)| {
             serde_json::json!({
                 "mob_id": id.to_string(),
+                "status": state.as_str(),
                 "state": state.as_str(),
             })
         })
@@ -2111,9 +2113,16 @@ pub async fn mob_respawn(
     });
     match mob_state.mob_respawn(&id, mid, initial_message).await {
         Ok(receipt) => {
+            let identity_str = receipt.identity.to_string();
             let result = serde_json::json!({
                 "status": "completed",
-                "receipt": receipt,
+                "receipt": {
+                    "identity": identity_str,
+                    "member_ref": meerkat_contracts::WireMemberRef::encode(
+                        id.as_str(),
+                        &identity_str,
+                    ),
+                },
             });
             Ok(JsValue::from_str(&result.to_string()))
         }
@@ -2121,9 +2130,16 @@ pub async fn mob_respawn(
             receipt,
             failed_peer_ids,
         }) => {
+            let identity_str = receipt.identity.to_string();
             let result = serde_json::json!({
                 "status": "topology_restore_failed",
-                "receipt": receipt,
+                "receipt": {
+                    "identity": identity_str,
+                    "member_ref": meerkat_contracts::WireMemberRef::encode(
+                        id.as_str(),
+                        &identity_str,
+                    ),
+                },
                 "failed_peer_ids": failed_peer_ids.iter().map(std::string::ToString::to_string).collect::<Vec<_>>(),
             });
             Ok(JsValue::from_str(&result.to_string()))

--- a/meerkat-web-runtime/src/lib.rs
+++ b/meerkat-web-runtime/src/lib.rs
@@ -1592,21 +1592,21 @@ pub async fn mob_status(mob_id: &str) -> Result<JsValue, JsValue> {
 
 /// List all mobs.
 ///
-/// Returns JSON array of `{ mob_id, status, state }`.
+/// Returns a generated `MobListResult` JSON envelope.
 #[wasm_bindgen]
 pub async fn mob_list() -> Result<JsValue, JsValue> {
     let mob_state = with_mob_state(Ok)?;
     let mobs = mob_state.mob_list().await;
-    let result: Vec<serde_json::Value> = mobs
+    let rows: Vec<serde_json::Value> = mobs
         .into_iter()
         .map(|(id, state)| {
             serde_json::json!({
                 "mob_id": id.to_string(),
                 "status": state.as_str(),
-                "state": state.as_str(),
             })
         })
         .collect();
+    let result = serde_json::json!({ "mobs": rows });
     let json = serde_json::to_string(&result).map_err(|e| err_str("serialize_error", e))?;
     Ok(JsValue::from_str(&json))
 }

--- a/sdks/web/src/generated/mob.ts
+++ b/sdks/web/src/generated/mob.ts
@@ -1,0 +1,38 @@
+// Generated mob wire types for @rkat/web
+// Source: artifacts/schemas/wire-types.json
+
+export type WireMobMemberStatus = "active" | "retiring" | "broken" | "completed" | "unknown";
+
+export interface MobStatusResult {
+  mob_id: string;
+  status: string;
+}
+
+export interface MobRespawnResult {
+  failed_peer_ids?: string[];
+  receipt: Record<string, unknown>;
+  status: string;
+}
+
+export interface MobEventsResult {
+  events: unknown[];
+}
+
+export interface MobMemberStatusResult {
+  current_session_id?: string;
+  error?: string;
+  external_member?: unknown;
+  is_final: boolean;
+  kickoff?: unknown;
+  output_preview?: string;
+  peer_connectivity?: unknown;
+  realtime_attachment_status?: string;
+  status: WireMobMemberStatus;
+  tokens_used: number;
+}
+
+export interface MobAppendSystemContextResult {
+  agent_identity: string;
+  mob_id: string;
+  status: string;
+}

--- a/sdks/web/src/generated/mob.ts
+++ b/sdks/web/src/generated/mob.ts
@@ -3,6 +3,8 @@
 
 export type WireMobMemberStatus = "active" | "retiring" | "broken" | "completed" | "unknown";
 
+export type WireMemberRef = string;
+
 export interface MobStatusResult {
   mob_id: string;
   status: string;
@@ -20,6 +22,24 @@ export interface MobRespawnResult {
 
 export interface MobEventsResult {
   events: unknown[];
+}
+
+export interface MobMemberSendResult {
+  agent_identity: string;
+  handling_mode: "queue" | "steer";
+  member_ref: WireMemberRef;
+  mob_id: string;
+}
+
+export interface MobFlowStatusResult {
+  run: unknown;
+}
+
+export interface MobHelperResult {
+  agent_identity: string;
+  member_ref: WireMemberRef;
+  output?: string;
+  tokens_used: number;
 }
 
 export interface MobMemberStatusResult {

--- a/sdks/web/src/generated/mob.ts
+++ b/sdks/web/src/generated/mob.ts
@@ -8,6 +8,10 @@ export interface MobStatusResult {
   status: string;
 }
 
+export interface MobListResult {
+  mobs: MobStatusResult[];
+}
+
 export interface MobRespawnResult {
   failed_peer_ids?: string[];
   receipt: Record<string, unknown>;

--- a/sdks/web/src/mob.ts
+++ b/sdks/web/src/mob.ts
@@ -18,7 +18,6 @@ import type {
   RenderMetadata,
   ContentBlock,
   MemberDeliveryReceipt,
-  MemberRespawnReceipt,
   MobRespawnResult,
   MobMemberSnapshot,
   MobHelperResult,
@@ -26,6 +25,16 @@ import type {
   AgentRuntimeId,
   SubscriptionLaggedEvent,
 } from './types.js';
+import type {
+  MobAppendSystemContextResult as WireMobAppendSystemContextResult,
+  MobFlowStatusResult as WireMobFlowStatusResult,
+  MobHelperResult as WireMobHelperResult,
+  MobMemberSendResult as WireMobMemberSendResult,
+  MobMemberStatusResult as WireMobMemberStatusResult,
+  MobRespawnResult as WireMobRespawnResult,
+  MobStatusResult as WireMobStatusResult,
+  WireMobMemberStatus,
+} from './generated/mob.js';
 
 // WASM function signatures (bound at construction)
 interface MobWasmBindings {
@@ -104,6 +113,221 @@ function requireOnlyKeys(
   }
 }
 
+function parseJsonPayload(json: string, context: string): unknown {
+  try {
+    return JSON.parse(json) as unknown;
+  } catch (error) {
+    throw new Error(`${context}: invalid JSON`);
+  }
+}
+
+function requireRecord(value: unknown, message: string): Record<string, unknown> {
+  if (!isRecord(value)) {
+    throw new Error(message);
+  }
+  return value;
+}
+
+function requireStringField(
+  value: Record<string, unknown>,
+  field: string,
+  message: string,
+): string {
+  const raw = value[field];
+  if (typeof raw !== 'string' || raw.length === 0) {
+    throw new Error(message);
+  }
+  return raw;
+}
+
+function optionalStringField(
+  value: Record<string, unknown>,
+  field: string,
+  message: string,
+): string | undefined {
+  const raw = value[field];
+  if (raw == null) {
+    return undefined;
+  }
+  if (typeof raw !== 'string') {
+    throw new Error(message);
+  }
+  return raw;
+}
+
+function optionalNonEmptyStringField(
+  value: Record<string, unknown>,
+  field: string,
+  message: string,
+): string | undefined {
+  const raw = optionalStringField(value, field, message);
+  if (raw === undefined) {
+    return undefined;
+  }
+  if (raw.length === 0) {
+    throw new Error(message);
+  }
+  return raw;
+}
+
+function requireNumberField(
+  value: Record<string, unknown>,
+  field: string,
+  message: string,
+): number {
+  const raw = value[field];
+  if (typeof raw !== 'number' || !Number.isFinite(raw)) {
+    throw new Error(message);
+  }
+  return raw;
+}
+
+function requireNonNegativeIntegerField(
+  value: Record<string, unknown>,
+  field: string,
+  message: string,
+): number {
+  const raw = requireNumberField(value, field, message);
+  if (!Number.isInteger(raw) || raw < 0) {
+    throw new Error(message);
+  }
+  return raw;
+}
+
+function optionalNumberField(
+  value: Record<string, unknown>,
+  field: string,
+  message: string,
+): number | undefined {
+  const raw = value[field];
+  if (raw == null) {
+    return undefined;
+  }
+  if (typeof raw !== 'number' || !Number.isFinite(raw)) {
+    throw new Error(message);
+  }
+  return raw;
+}
+
+function requireBooleanField(
+  value: Record<string, unknown>,
+  field: string,
+  message: string,
+): boolean {
+  const raw = value[field];
+  if (typeof raw !== 'boolean') {
+    throw new Error(message);
+  }
+  return raw;
+}
+
+function optionalRecordField(
+  value: Record<string, unknown>,
+  field: string,
+  message: string,
+): Record<string, unknown> | undefined {
+  const raw = value[field];
+  if (raw == null) {
+    return undefined;
+  }
+  return requireRecord(raw, message);
+}
+
+function optionalStringArrayField(
+  value: Record<string, unknown>,
+  field: string,
+  message: string,
+): string[] | undefined {
+  const raw = value[field];
+  if (raw == null) {
+    return undefined;
+  }
+  if (!Array.isArray(raw) || raw.some((entry) => typeof entry !== 'string')) {
+    throw new Error(message);
+  }
+  return [...raw];
+}
+
+const WIRE_MOB_MEMBER_STATUSES: readonly WireMobMemberStatus[] = [
+  'active',
+  'retiring',
+  'broken',
+  'completed',
+  'unknown',
+];
+
+function parseWireMobMemberStatus(raw: unknown, message: string): WireMobMemberStatus {
+  if (
+    typeof raw === 'string' &&
+    WIRE_MOB_MEMBER_STATUSES.includes(raw as WireMobMemberStatus)
+  ) {
+    return raw as WireMobMemberStatus;
+  }
+  throw new Error(message);
+}
+
+const WIRE_HANDLING_MODES: readonly HandlingMode[] = ['queue', 'steer'];
+
+function parseWireHandlingMode(raw: unknown, message: string): HandlingMode {
+  if (typeof raw === 'string' && WIRE_HANDLING_MODES.includes(raw as HandlingMode)) {
+    return raw as HandlingMode;
+  }
+  throw new Error(message);
+}
+
+export function parseMobStatusResult(
+  raw: unknown,
+  context = 'Invalid mob/status response',
+): MobStatus {
+  const record = requireRecord(raw, `${context}: malformed envelope`) as Partial<
+    WireMobStatusResult
+  > &
+    Record<string, unknown>;
+  const mobId = requireStringField(
+    record,
+    'mob_id',
+    `${context}: missing mob_id`,
+  );
+  const status = requireStringField(
+    record,
+    'status',
+    `${context}: missing status`,
+  );
+  return {
+    mob_id: mobId,
+    status,
+    state: status,
+  };
+}
+
+function parseMobAppendSystemContextResult(raw: unknown): MobAppendSystemContextResult {
+  const record = requireRecord(
+    raw,
+    'Invalid mob append_system_context response: malformed envelope',
+  ) as Partial<WireMobAppendSystemContextResult> & Record<string, unknown>;
+  const status = requireStringField(
+    record,
+    'status',
+    'Invalid mob append_system_context response: missing status',
+  );
+  if (status !== 'staged' && status !== 'duplicate') {
+    throw new Error('Invalid mob append_system_context response: invalid status');
+  }
+  return {
+    mob_id: requireStringField(
+      record,
+      'mob_id',
+      'Invalid mob append_system_context response: missing mob_id',
+    ),
+    agent_identity: requireStringField(
+      record,
+      'agent_identity',
+      'Invalid mob append_system_context response: missing agent_identity',
+    ),
+    status,
+  };
+}
+
 function normalizeSpawnManyEntry(raw: unknown, mobId: string): SpawnResult {
   if (!isRecord(raw)) {
     throw new Error('Invalid mob spawn response: malformed result entry');
@@ -154,144 +378,314 @@ function normalizeSpawnManyEntry(raw: unknown, mobId: string): SpawnResult {
   };
 }
 
-function requireStringField(
+function parseSubscriptionLaggedEvent(
   record: Record<string, unknown>,
-  field: string,
-  message: string,
-): string {
-  const value = record[field];
-  if (typeof value !== 'string' || value.length === 0) {
-    throw new Error(message);
-  }
-  return value;
-}
-
-function requireNumberField(
-  record: Record<string, unknown>,
-  field: string,
-  message: string,
-): number {
-  const value = record[field];
-  if (typeof value !== 'number' || !Number.isFinite(value)) {
-    throw new Error(message);
-  }
-  return value;
-}
-
-function normalizeAgentRuntimeId(raw: unknown): AgentRuntimeId {
-  if (!isRecord(raw)) {
-    throw new Error('Invalid mob subscription event: missing source');
-  }
-  requireOnlyKeys(
-    raw,
-    ['identity', 'generation'],
-    'Invalid mob subscription event: malformed source',
-  );
-  const identity = requireStringField(
-    raw,
-    'identity',
-    'Invalid mob subscription event: source missing identity',
-  );
-  const generation = requireNumberField(
-    raw,
-    'generation',
-    'Invalid mob subscription event: source missing generation',
-  );
-  if (!Number.isInteger(generation) || generation < 0) {
-    throw new Error('Invalid mob subscription event: source generation must be a non-negative integer');
-  }
-  return { identity, generation };
-}
-
-function normalizeLaggedEvent(record: Record<string, unknown>): SubscriptionLaggedEvent {
-  const skipped = record.skipped;
-  if (typeof skipped !== 'number' || !Number.isFinite(skipped)) {
-    throw new Error('Invalid subscription lagged event: missing skipped count');
-  }
+  context: string,
+): SubscriptionLaggedEvent {
   return {
     type: 'lagged',
-    skipped,
+    skipped: requireNumberField(record, 'skipped', `${context}: lagged skipped must be number`),
   };
 }
 
-function normalizeEventEnvelope(raw: unknown): MemberEventItem {
-  if (!isRecord(raw)) {
-    throw new Error('Invalid subscription event envelope: expected object');
-  }
-  const record = raw;
-  if (record.type === 'lagged') {
-    return normalizeLaggedEvent(record);
-  }
-  const payload = record.payload;
-  if (!isRecord(payload) || typeof payload.type !== 'string' || payload.type.length === 0) {
-    throw new Error('Invalid subscription event envelope: missing payload');
-  }
+function parseEventPayload(raw: unknown, context: string): EventEnvelope['payload'] {
+  const payload = requireRecord(raw, `${context}: missing payload`);
+  requireStringField(payload, 'type', `${context}: payload missing type`);
+  return payload as EventEnvelope['payload'];
+}
 
+function parseEventEnvelope(raw: unknown, context: string): EventEnvelope {
+  const record = requireRecord(raw, `${context}: malformed envelope`);
+  const payload = parseEventPayload(record.payload, context);
   const envelope: EventEnvelope = {
     event_id: requireStringField(
       record,
       'event_id',
-      'Invalid subscription event envelope: missing event_id',
+      `${context}: missing event_id`,
     ),
     source_id: requireStringField(
       record,
       'source_id',
-      'Invalid subscription event envelope: missing source_id',
+      `${context}: missing source_id`,
     ),
-    seq: requireNumberField(
-      record,
-      'seq',
-      'Invalid subscription event envelope: missing seq',
-    ),
+    seq: requireNumberField(record, 'seq', `${context}: missing seq`),
     timestamp_ms: requireNumberField(
       record,
       'timestamp_ms',
-      'Invalid subscription event envelope: missing timestamp_ms',
+      `${context}: missing timestamp_ms`,
     ),
-    payload: payload as EventEnvelope['payload'],
+    payload,
   };
-
-  if (typeof record.mob_id === 'string' && record.mob_id.length > 0) {
-    envelope.mob_id = record.mob_id;
+  const mobId = optionalNonEmptyStringField(record, 'mob_id', `${context}: mob_id must be string`);
+  if (mobId !== undefined) envelope.mob_id = mobId;
+  const agentIdentity = optionalNonEmptyStringField(
+    record,
+    'agent_identity',
+    `${context}: agent_identity must be string`,
+  );
+  if (agentIdentity !== undefined) envelope.agent_identity = agentIdentity;
+  const memberRef = optionalNonEmptyStringField(
+    record,
+    'member_ref',
+    `${context}: member_ref must be string`,
+  );
+  if (memberRef !== undefined) envelope.member_ref = memberRef;
+  const cursor = record.cursor;
+  if (cursor != null) {
+    if (typeof cursor !== 'string' && typeof cursor !== 'number') {
+      throw new Error(`${context}: cursor must be string or number`);
+    }
+    envelope.cursor = cursor;
   }
-
   return envelope;
 }
 
-function normalizeAttributedEvent(raw: unknown): AttributedEventItem {
-  if (!isRecord(raw)) {
-    throw new Error('Invalid mob subscription event: expected object');
-  }
-  const record = raw;
+function parseMemberEventItem(raw: unknown, context: string): MemberEventItem {
+  const record = requireRecord(raw, `${context}: malformed event item`);
   if (record.type === 'lagged') {
-    return normalizeLaggedEvent(record);
+    return parseSubscriptionLaggedEvent(record, context);
   }
-  const envelope = normalizeEventEnvelope(record.envelope);
-  if ('type' in envelope) {
-    throw new Error('Invalid mob subscription event: lagged envelope is not attributed event data');
-  }
+  return parseEventEnvelope(record, context);
+}
 
+function parseAttributedSource(raw: unknown, context: string): AgentRuntimeId {
+  const source = requireRecord(raw, `${context}: missing source`);
+  const identity = requireStringField(source, 'identity', `${context}: source missing identity`);
+  const generation = requireNonNegativeIntegerField(
+    source,
+    'generation',
+    `${context}: source generation must be a non-negative integer`,
+  );
+  return { identity, generation };
+}
+
+function parseAttributedEventItem(raw: unknown, context: string): AttributedEventItem {
+  const record = requireRecord(raw, `${context}: malformed attributed event`);
+  if (record.type === 'lagged') {
+    return parseSubscriptionLaggedEvent(record, context);
+  }
+  const source = parseAttributedSource(record.source, context);
+  const role = requireStringField(record, 'role', `${context}: missing role`);
   const attributed = {
-    source: normalizeAgentRuntimeId(record.source),
-    role: requireStringField(
-      record,
-      'role',
-      'Invalid mob subscription event: missing role',
-    ),
-    envelope,
+    source,
+    role,
+    envelope: parseEventEnvelope(record.envelope, `${context}: envelope`),
   };
+  const sourceFenceToken = optionalNumberField(
+    record,
+    'source_fence_token',
+    `${context}: source_fence_token must be number`,
+  );
+  return sourceFenceToken === undefined
+    ? attributed
+    : { ...attributed, source_fence_token: sourceFenceToken };
+}
 
-  if (
-    typeof record.source_fence_token === 'number'
-    && Number.isFinite(record.source_fence_token)
-  ) {
-    return {
-      ...attributed,
-      source_fence_token: record.source_fence_token,
-    };
+function parseEventItems<T>(
+  raw: unknown,
+  context: string,
+  parseItem: (item: unknown, itemContext: string) => T,
+): T[] {
+  if (!Array.isArray(raw)) {
+    throw new Error(`${context}: events must be a list`);
   }
+  return raw.map((item, index) => parseItem(item, `${context}[${index}]`));
+}
 
-  return attributed;
+function parseMobEvent(raw: unknown, context: string): MobEvent {
+  const record = requireRecord(raw, `${context}: malformed mob event`);
+  return {
+    cursor: requireNumberField(record, 'cursor', `${context}: cursor must be number`),
+    timestamp: requireStringField(record, 'timestamp', `${context}: missing timestamp`),
+    mob_id: requireStringField(record, 'mob_id', `${context}: missing mob_id`),
+    kind: requireRecord(record.kind, `${context}: missing kind`),
+  };
+}
+
+function parseMobEvents(raw: unknown): MobEvent[] {
+  return parseEventItems(raw, 'Invalid mob/events response', parseMobEvent);
+}
+
+function parseMobMemberSnapshot(raw: unknown, mobId: string, agentIdentity: string): MobMemberSnapshot {
+  const snapshot = requireRecord(
+    raw,
+    'Invalid mob member_status response: malformed envelope',
+  ) as Partial<WireMobMemberStatusResult> & Record<string, unknown>;
+  const currentSessionId = optionalStringField(
+    snapshot,
+    'current_session_id',
+    'Invalid mob member_status response: current_session_id must be string',
+  );
+  const realtimeAttachmentStatus = optionalStringField(
+    snapshot,
+    'realtime_attachment_status',
+    'Invalid mob member_status response: realtime_attachment_status must be string',
+  );
+  const result: MobMemberSnapshot = {
+    status: parseWireMobMemberStatus(
+      snapshot.status,
+      'Invalid mob member_status response: missing status',
+    ),
+    member_ref: encodeMemberRef(mobId, agentIdentity),
+    output_preview: optionalStringField(
+      snapshot,
+      'output_preview',
+      'Invalid mob member_status response: output_preview must be string',
+    ),
+    error: optionalStringField(
+      snapshot,
+      'error',
+      'Invalid mob member_status response: error must be string',
+    ),
+    tokens_used: requireNonNegativeIntegerField(
+      snapshot,
+      'tokens_used',
+      'Invalid mob member_status response: tokens_used must be number',
+    ),
+    is_final: requireBooleanField(
+      snapshot,
+      'is_final',
+      'Invalid mob member_status response: is_final must be boolean',
+    ),
+    kickoff: optionalRecordField(
+      snapshot,
+      'kickoff',
+      'Invalid mob member_status response: kickoff must be object',
+    ),
+    peer_connectivity: optionalRecordField(
+      snapshot,
+      'peer_connectivity',
+      'Invalid mob member_status response: peer_connectivity must be object',
+    ) as MobMemberSnapshot['peer_connectivity'],
+  };
+  if (currentSessionId !== undefined) {
+    result.current_session_id = currentSessionId;
+  }
+  if (realtimeAttachmentStatus !== undefined) {
+    result.realtime_attachment_status = realtimeAttachmentStatus;
+  }
+  if (Object.prototype.hasOwnProperty.call(snapshot, 'external_member')) {
+    result.external_member = snapshot.external_member;
+  }
+  return result;
+}
+
+function parseMobRespawnResult(raw: unknown): MobRespawnResult {
+  const result = requireRecord(raw, 'Invalid mob respawn response: malformed envelope') as Partial<
+    WireMobRespawnResult
+  > &
+    Record<string, unknown>;
+  const status = requireStringField(
+    result,
+    'status',
+    'Invalid mob respawn response: missing status',
+  );
+  if (status !== 'completed' && status !== 'topology_restore_failed') {
+    throw new Error('Invalid mob respawn response: invalid status');
+  }
+  const receipt = requireRecord(result.receipt, 'Invalid mob respawn response: missing receipt');
+  const memberRef = requireStringField(
+    receipt,
+    'member_ref',
+    'Invalid mob respawn response: receipt missing member_ref',
+  );
+  const identity = requireStringField(
+    receipt,
+    'identity',
+    'Invalid mob respawn response: receipt missing identity',
+  );
+  return {
+    status,
+    receipt: {
+      agent_identity: identity,
+      member_ref: memberRef,
+    },
+    failed_peer_ids: optionalStringArrayField(
+      result,
+      'failed_peer_ids',
+      'Invalid mob respawn response: failed_peer_ids must be string list',
+    ),
+  };
+}
+
+function parseMemberDeliveryReceipt(
+  raw: unknown,
+  expectedMobId: string,
+  expectedAgentIdentity: string,
+): MemberDeliveryReceipt {
+  const receipt = requireRecord(
+    raw,
+    'Invalid mob member delivery response: malformed envelope',
+  ) as Partial<WireMobMemberSendResult> & Record<string, unknown>;
+  const mobId = requireStringField(
+    receipt,
+    'mob_id',
+    'Invalid mob member delivery response: missing mob_id',
+  );
+  if (mobId !== expectedMobId) {
+    throw new Error('Invalid mob member delivery response: mob_id mismatch');
+  }
+  const agentIdentity = requireStringField(
+    receipt,
+    'agent_identity',
+    'Invalid mob member delivery response: missing agent_identity',
+  );
+  if (agentIdentity !== expectedAgentIdentity) {
+    throw new Error('Invalid mob member delivery response: agent_identity mismatch');
+  }
+  return {
+    agent_identity: agentIdentity,
+    member_ref: requireStringField(
+      receipt,
+      'member_ref',
+      'Invalid mob member delivery response: missing member_ref',
+    ),
+    handling_mode: parseWireHandlingMode(
+      receipt.handling_mode,
+      'Invalid mob member delivery response: missing handling_mode',
+    ),
+  };
+}
+
+function parseMobHelperResult(raw: unknown, context: string): MobHelperResult {
+  const result = requireRecord(raw, `${context}: malformed envelope`) as Partial<
+    WireMobHelperResult
+  > &
+    Record<string, unknown>;
+  return {
+    output: optionalStringField(result, 'output', `${context}: output must be string`),
+    tokens_used: requireNonNegativeIntegerField(
+      result,
+      'tokens_used',
+      `${context}: tokens_used must be number`,
+    ),
+    agent_identity: requireStringField(
+      result,
+      'agent_identity',
+      `${context}: missing agent_identity`,
+    ),
+    member_ref: requireStringField(result, 'member_ref', `${context}: missing member_ref`),
+  };
+}
+
+function parseMobFlowStatusResult(raw: unknown): FlowStatus | null {
+  const context = 'Invalid mob flow_status response';
+  const record = requireRecord(raw, `${context}: malformed envelope`) as Partial<
+    WireMobFlowStatusResult
+  > &
+    Record<string, unknown>;
+  if (!Object.prototype.hasOwnProperty.call(record, 'run')) {
+    throw new Error(`${context}: missing run`);
+  }
+  if (record.run == null) {
+    return null;
+  }
+  const run = requireRecord(record.run, `${context}: run must be object`);
+  return {
+    ...run,
+    run_id: requireStringField(run, 'run_id', `${context}: run missing run_id`),
+    status: requireStringField(run, 'status', `${context}: run missing status`),
+  };
 }
 
 /** Capability-bearing handle for one mob member. */
@@ -320,29 +714,19 @@ export class Member {
         render_metadata: renderMetadata,
       }),
     );
-    const receipt = JSON.parse(json) as Partial<MemberDeliveryReceipt>;
-    const memberRef =
-      typeof receipt.member_ref === 'string' && receipt.member_ref.length > 0
-        ? receipt.member_ref
-        : undefined;
-    if (!memberRef) {
-      throw new Error('Invalid mob member delivery response: missing member_ref');
-    }
-    if (typeof receipt.agent_identity !== 'string' || receipt.agent_identity.length === 0) {
-      throw new Error('Invalid mob member delivery response: missing agent_identity');
-    }
-    return {
-      agent_identity: receipt.agent_identity,
-      member_ref: memberRef,
-      handling_mode: receipt.handling_mode ?? handlingMode,
-    };
+    return parseMemberDeliveryReceipt(
+      parseJsonPayload(json, 'Invalid mob member delivery response'),
+      this.mobId,
+      this.agentIdentity,
+    );
   }
 
   async subscribe(): Promise<EventSubscription<MemberEventItem>> {
     const handle = await this.bindings.mob_member_subscribe(this.mobId, this.agentIdentity);
     return new EventSubscription<MemberEventItem>(
       () => this.bindings.poll_subscription(handle),
-      (raw) => raw.map((item) => normalizeEventEnvelope(item)),
+      (raw) =>
+        parseEventItems(raw, 'Invalid mob member subscription event', parseMemberEventItem),
       () => this.bindings.close_subscription(handle),
     );
   }
@@ -367,7 +751,7 @@ export class Mob {
       this.mobId,
       JSON.stringify(specs.map(spawnSpecPayload)),
     );
-    const parsed = JSON.parse(json) as unknown;
+    const parsed = parseJsonPayload(json, 'Invalid mob spawn response');
     if (!Array.isArray(parsed)) {
       throw new Error('Invalid mob spawn response: results must be a list');
     }
@@ -408,7 +792,15 @@ export class Mob {
   /** List all members in the mob. */
   async listMembers(): Promise<MobMember[]> {
     const json = await this.bindings.mob_list_members(this.mobId);
-    return (JSON.parse(json) as Array<Record<string, unknown>>).map((member) => {
+    const parsed = parseJsonPayload(json, 'Invalid mob list_members response');
+    if (!Array.isArray(parsed)) {
+      throw new Error('Invalid mob list_members response: members must be a list');
+    }
+    return parsed.map((rawMember, index) => {
+      const member = requireRecord(
+        rawMember,
+        `Invalid mob list_members entry ${index}: malformed member`,
+      );
       if (typeof member.agent_identity !== 'string' || member.agent_identity.length === 0) {
         throw new Error('Invalid mob list_members entry: missing agent_identity');
       }
@@ -420,10 +812,21 @@ export class Mob {
       if (!memberRef) {
         throw new Error('Invalid mob list_members entry: missing member_ref');
       }
+      const profile =
+        typeof member.role === 'string' && member.role.length > 0
+          ? member.role
+          : typeof member.profile === 'string' && member.profile.length > 0
+            ? member.profile
+            : typeof member.profile_name === 'string' && member.profile_name.length > 0
+              ? member.profile_name
+              : undefined;
+      if (!profile) {
+        throw new Error('Invalid mob list_members entry: missing profile');
+      }
       return {
         agent_identity: agentIdentity,
         member_ref: memberRef,
-        profile: String(member.profile_name ?? member.profile ?? member.role ?? ''),
+        profile,
         peer_id: member.peer_id != null ? String(member.peer_id) : undefined,
         external_peer_specs:
           member.external_peer_specs && typeof member.external_peer_specs === 'object'
@@ -469,13 +872,9 @@ export class Mob {
         idempotency_key: options.idempotencyKey,
       }),
     );
-    const result = JSON.parse(json) as Partial<MobAppendSystemContextResult>;
-    return {
-      mob_id: typeof result.mob_id === 'string' ? result.mob_id : this.mobId,
-      agent_identity:
-        typeof result.agent_identity === 'string' ? result.agent_identity : agentIdentity,
-      status: result.status === 'duplicate' ? 'duplicate' : 'staged',
-    };
+    return parseMobAppendSystemContextResult(
+      parseJsonPayload(json, 'Invalid mob append_system_context response'),
+    );
   }
 
   /** Get a capability-bearing handle for one member. */
@@ -495,35 +894,7 @@ export class Mob {
           : JSON.stringify(initialMessage)
         : undefined;
     const json = await this.bindings.mob_respawn(this.mobId, agentIdentity, payload);
-    const result = JSON.parse(json) as Partial<MobRespawnResult> & {
-      receipt?: Partial<MemberRespawnReceipt>;
-      failed_peer_ids?: unknown;
-    };
-    if (!result.receipt || typeof result.receipt !== 'object') {
-      throw new Error('Invalid mob respawn response: missing receipt');
-    }
-    const receipt = result.receipt as unknown as Partial<MemberRespawnReceipt> &
-      Record<string, unknown>;
-    const memberRef =
-      typeof receipt.member_ref === 'string' && receipt.member_ref.length > 0
-        ? receipt.member_ref
-        : undefined;
-    if (!memberRef) {
-      throw new Error('Invalid mob respawn response: receipt missing member_ref');
-    }
-    if (typeof receipt.agent_identity !== 'string' || receipt.agent_identity.length === 0) {
-      throw new Error('Invalid mob respawn response: receipt missing agent_identity');
-    }
-    return {
-      status: result.status === 'topology_restore_failed' ? 'topology_restore_failed' : 'completed',
-      receipt: {
-        agent_identity: receipt.agent_identity,
-        member_ref: memberRef,
-      },
-      failed_peer_ids: Array.isArray(result.failed_peer_ids)
-        ? result.failed_peer_ids.map((peerId) => String(peerId))
-        : undefined,
-    };
+    return parseMobRespawnResult(parseJsonPayload(json, 'Invalid mob respawn response'));
   }
 
   /** Force-cancel an active member turn. */
@@ -534,24 +905,11 @@ export class Mob {
   /** Read the current execution snapshot for a member. */
   async memberStatus(agentIdentity: string): Promise<MobMemberSnapshot> {
     const json = await this.bindings.mob_member_status(this.mobId, agentIdentity);
-    const snapshot = JSON.parse(json) as Record<string, unknown>;
-    return {
-      status: typeof snapshot.status === 'string' ? snapshot.status : 'unknown',
-      member_ref: encodeMemberRef(this.mobId, agentIdentity),
-      output_preview:
-        typeof snapshot.output_preview === 'string' ? snapshot.output_preview : undefined,
-      error: typeof snapshot.error === 'string' ? snapshot.error : undefined,
-      tokens_used: typeof snapshot.tokens_used === 'number' ? snapshot.tokens_used : 0,
-      is_final: Boolean(snapshot.is_final),
-      kickoff:
-        snapshot.kickoff && typeof snapshot.kickoff === 'object'
-          ? (snapshot.kickoff as Record<string, unknown>)
-          : undefined,
-      peer_connectivity:
-        snapshot.peer_connectivity && typeof snapshot.peer_connectivity === 'object'
-          ? (snapshot.peer_connectivity as MobMemberSnapshot['peer_connectivity'])
-          : undefined,
-    };
+    return parseMobMemberSnapshot(
+      parseJsonPayload(json, 'Invalid mob member_status response'),
+      this.mobId,
+      agentIdentity,
+    );
   }
 
   /** Spawn a short-lived helper and return its terminal result. */
@@ -576,23 +934,10 @@ export class Mob {
           backend: options?.backend,
         }),
     );
-    const result = JSON.parse(json) as Partial<MobHelperResult>;
-    const memberRef =
-      typeof result.member_ref === 'string' && result.member_ref.length > 0
-        ? result.member_ref
-        : undefined;
-    if (!memberRef) {
-      throw new Error('Invalid mob spawn_helper response: missing member_ref');
-    }
-    if (typeof result.agent_identity !== 'string' || result.agent_identity.length === 0) {
-      throw new Error('Invalid mob spawn_helper response: missing agent_identity');
-    }
-    return {
-      output: typeof result.output === 'string' ? result.output : undefined,
-      tokens_used: typeof result.tokens_used === 'number' ? result.tokens_used : 0,
-      agent_identity: result.agent_identity,
-      member_ref: memberRef,
-    };
+    return parseMobHelperResult(
+      parseJsonPayload(json, 'Invalid mob spawn_helper response'),
+      'Invalid mob spawn_helper response',
+    );
   }
 
   /** Fork a helper from an existing member and return its terminal result. */
@@ -621,29 +966,16 @@ export class Mob {
           backend: options?.backend,
         }),
     );
-    const result = JSON.parse(json) as Partial<MobHelperResult>;
-    const memberRef =
-      typeof result.member_ref === 'string' && result.member_ref.length > 0
-        ? result.member_ref
-        : undefined;
-    if (!memberRef) {
-      throw new Error('Invalid mob fork_helper response: missing member_ref');
-    }
-    if (typeof result.agent_identity !== 'string' || result.agent_identity.length === 0) {
-      throw new Error('Invalid mob fork_helper response: missing agent_identity');
-    }
-    return {
-      output: typeof result.output === 'string' ? result.output : undefined,
-      tokens_used: typeof result.tokens_used === 'number' ? result.tokens_used : 0,
-      agent_identity: result.agent_identity,
-      member_ref: memberRef,
-    };
+    return parseMobHelperResult(
+      parseJsonPayload(json, 'Invalid mob fork_helper response'),
+      'Invalid mob fork_helper response',
+    );
   }
 
   /** Get mob status. */
   async status(): Promise<MobStatus> {
     const json = await this.bindings.mob_status(this.mobId);
-    return JSON.parse(json) as MobStatus;
+    return parseMobStatusResult(parseJsonPayload(json, 'Invalid mob/status response'));
   }
 
   /** Perform a lifecycle action (stop, resume, complete, destroy). */
@@ -655,7 +987,7 @@ export class Mob {
   async events(afterCursor = '', limit = 100): Promise<MobEvent[]> {
     const numericCursor = afterCursor === '' ? 0 : Number(afterCursor);
     const json = await this.bindings.mob_events(this.mobId, Number.isFinite(numericCursor) ? numericCursor : 0, limit);
-    return JSON.parse(json) as MobEvent[];
+    return parseMobEvents(parseJsonPayload(json, 'Invalid mob/events response'));
   }
 
   /** Run a flow. Returns the run ID. */
@@ -668,9 +1000,9 @@ export class Mob {
   }
 
   /** Get flow status. */
-  async flowStatus(runId: string): Promise<FlowStatus> {
+  async flowStatus(runId: string): Promise<FlowStatus | null> {
     const json = await this.bindings.mob_flow_status(this.mobId, runId);
-    return JSON.parse(json) as FlowStatus;
+    return parseMobFlowStatusResult(parseJsonPayload(json, 'Invalid mob flow_status response'));
   }
 
   /** Cancel a running flow. */
@@ -683,7 +1015,8 @@ export class Mob {
     const handle = await this.bindings.mob_member_subscribe(this.mobId, agentIdentity);
     return new EventSubscription<MemberEventItem>(
       () => this.bindings.poll_subscription(handle),
-      (raw) => raw.map((item) => normalizeEventEnvelope(item)),
+      (raw) =>
+        parseEventItems(raw, 'Invalid mob member subscription event', parseMemberEventItem),
       () => this.bindings.close_subscription(handle),
     );
   }
@@ -693,7 +1026,8 @@ export class Mob {
     const handle = await this.bindings.mob_subscribe_events(this.mobId);
     return new EventSubscription<AttributedEventItem>(
       () => this.bindings.poll_subscription(handle),
-      (raw) => raw.map((item) => normalizeAttributedEvent(item)),
+      (raw) =>
+        parseEventItems(raw, 'Invalid mob attributed subscription event', parseAttributedEventItem),
       () => this.bindings.close_subscription(handle),
     );
   }

--- a/sdks/web/src/runtime.ts
+++ b/sdks/web/src/runtime.ts
@@ -1,4 +1,4 @@
-import { Mob } from './mob.js';
+import { Mob, parseMobStatusResult } from './mob.js';
 import { Session } from './session.js';
 import type {
   RuntimeConfig,
@@ -9,6 +9,7 @@ import type {
   ToolCallback,
   MobStatus,
 } from './types.js';
+import type { MobListResult as WireMobListResult } from './generated/mob.js';
 
 /** Expected WASM runtime version — must match the compiled binary. */
 const EXPECTED_VERSION = '0.6.0';
@@ -48,6 +49,34 @@ function sessionToWasm(config: SessionConfig): Record<string, unknown> {
     additional_instructions: config.additionalInstructions,
     app_context: config.appContext,
   };
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function parseJsonPayload(json: string, context: string): unknown {
+  try {
+    return JSON.parse(json) as unknown;
+  } catch (error) {
+    throw new Error(`${context}: invalid JSON`);
+  }
+}
+
+function parseMobListResult(raw: unknown): MobStatus[] {
+  const context = 'Invalid mob/list response';
+  if (!isRecord(raw)) {
+    throw new Error(`${context}: malformed envelope`);
+  }
+
+  const record = raw as Partial<WireMobListResult> & Record<string, unknown>;
+  if (!Array.isArray(record.mobs)) {
+    throw new Error(`${context}: missing mobs`);
+  }
+
+  return record.mobs.map((mob, index) =>
+    parseMobStatusResult(mob, `${context}.mobs[${index}]`),
+  );
 }
 
 /**
@@ -340,7 +369,7 @@ export class MeerkatRuntime {
   /** List all active mobs. */
   async listMobs(): Promise<MobStatus[]> {
     const json = await this.wasm.mob_list();
-    return JSON.parse(json) as MobStatus[];
+    return parseMobListResult(parseJsonPayload(json, 'Invalid mob/list response'));
   }
 
   /** Wire two agents across different mobs for cross-mob comms. */

--- a/sdks/web/src/types.ts
+++ b/sdks/web/src/types.ts
@@ -1,5 +1,6 @@
 import { KNOWN_AGENT_EVENT_TYPES } from './generated/events.js';
 import type { AgentEvent, SkillKey, Usage } from './generated/events.js';
+import type { WireMobMemberStatus } from './generated/mob.js';
 
 // ─── Bootstrap config ───────────────────────────────────────────
 
@@ -377,6 +378,8 @@ export type MobPeerTarget = string | ExternalPeerTarget;
 /** Mob status. */
 export interface MobStatus {
   mob_id: string;
+  status: string;
+  /** @deprecated Use `status`. Kept as an inert projection of generated status. */
   state: string;
 }
 
@@ -395,12 +398,15 @@ export interface MobPeerConnectivitySnapshot {
 
 /** Point-in-time execution snapshot for a mob member. */
 export interface MobMemberSnapshot {
-  status: string;
+  status: WireMobMemberStatus;
   member_ref: MobMemberRef;
   output_preview?: string;
   error?: string;
   tokens_used: number;
   is_final: boolean;
+  current_session_id?: string;
+  realtime_attachment_status?: string;
+  external_member?: unknown;
   kickoff?: Record<string, unknown>;
   peer_connectivity?: MobPeerConnectivitySnapshot;
 }
@@ -422,6 +428,9 @@ export interface EventEnvelope {
   seq: number;
   mob_id?: string;
   timestamp_ms: number;
+  agent_identity?: string;
+  member_ref?: MobMemberRef;
+  cursor?: string | number;
   payload: AgentEvent | { type: string; [key: string]: unknown };
 }
 

--- a/sdks/web/tests/e2e_wasm_runtime.test.mjs
+++ b/sdks/web/tests/e2e_wasm_runtime.test.mjs
@@ -439,7 +439,7 @@ test("MeerkatRuntime forwards canonical mob status/helper methods through the wa
       return JSON.stringify({ mob_id: mobId, status: "running" });
     },
     async mob_list() {
-      return JSON.stringify([]);
+      return JSON.stringify({ mobs: [] });
     },
     async mob_lifecycle(mobId, action) {
       calls.push(["lifecycle", mobId, action]);
@@ -500,7 +500,7 @@ test("MeerkatRuntime forwards canonical mob status/helper methods through the wa
     },
     async mob_member_status(_mobId, agentIdentity) {
       return JSON.stringify({
-        status: "running",
+        status: "active",
         agent_runtime_id: { identity: agentIdentity, generation: 1 },
         fence_token: 1,
         tokens_used: 7,

--- a/sdks/web/tests/e2e_wasm_runtime.test.mjs
+++ b/sdks/web/tests/e2e_wasm_runtime.test.mjs
@@ -436,7 +436,7 @@ test("MeerkatRuntime forwards canonical mob status/helper methods through the wa
       return "mob-web-parity";
     },
     async mob_status(mobId) {
-      return JSON.stringify({ mob_id: mobId, state: "running" });
+      return JSON.stringify({ mob_id: mobId, status: "running" });
     },
     async mob_list() {
       return JSON.stringify([]);
@@ -511,7 +511,7 @@ test("MeerkatRuntime forwards canonical mob status/helper methods through the wa
       return JSON.stringify({
         status: "completed",
         receipt: {
-          agent_identity: agentIdentity,
+          identity: agentIdentity,
           member_ref: `ref-${agentIdentity}`,
         },
       });
@@ -633,7 +633,7 @@ test("MeerkatRuntime forwards canonical mob status/helper methods through the wa
       JSON.stringify({
         status: "topology_restore_failed",
         receipt: {
-          agent_identity: agentIdentity,
+          identity: agentIdentity,
           member_ref: `ref-${agentIdentity}`,
         },
         failed_peer_ids: ["peer-a", "peer-b"],

--- a/sdks/web/tests/e2e_wasm_runtime.test.mjs
+++ b/sdks/web/tests/e2e_wasm_runtime.test.mjs
@@ -493,6 +493,7 @@ test("MeerkatRuntime forwards canonical mob status/helper methods through the wa
     async mob_member_send(_mobId, agentIdentity, requestJson) {
       calls.push(["member_send", agentIdentity, JSON.parse(requestJson)]);
       return JSON.stringify({
+        mob_id: _mobId,
         agent_identity: agentIdentity,
         member_ref: `ref-${agentIdentity}`,
         handling_mode: "queue",
@@ -541,7 +542,7 @@ test("MeerkatRuntime forwards canonical mob status/helper methods through the wa
       return "run-1";
     },
     async mob_flow_status() {
-      return JSON.stringify({ run_id: "run-1", status: "running" });
+      return JSON.stringify({ run: { run_id: "run-1", status: "running" } });
     },
     async mob_cancel_flow(mobId, runId) {
       calls.push(["cancel_flow", mobId, runId]);

--- a/sdks/web/tests/mob_payload.unit.mjs
+++ b/sdks/web/tests/mob_payload.unit.mjs
@@ -79,6 +79,24 @@ function makeDirectSession(pollEvents) {
   );
 }
 
+async function runtimeWithMobList(payload) {
+  return MeerkatRuntime.init(
+    {
+      async default() {},
+      runtime_version() {
+        return '0.6.0';
+      },
+      init_runtime_from_config() {
+        return JSON.stringify({ status: 'initialized' });
+      },
+      async mob_list() {
+        return JSON.stringify(payload);
+      },
+    },
+    {},
+  );
+}
+
 test('Mob.spawn strips legacy generation and projects typed wasm spawn rows', async () => {
   let captured;
   const mob = new Mob('mob-web-unit', {
@@ -368,4 +386,390 @@ test('MeerkatRuntime rejects malformed subscription poll output', async () => {
   } finally {
     runtime.destroy();
   }
+});
+
+test('Mob.status projects only generated status truth', async () => {
+  const mob = new Mob('mob-web-unit', {
+    async mob_status(mobId) {
+      return JSON.stringify({ mob_id: mobId, status: 'Running' });
+    },
+  });
+
+  const status = await mob.status();
+
+  assert.equal(status.mob_id, 'mob-web-unit');
+  assert.equal(status.status, 'Running');
+  assert.equal(status.state, 'Running');
+});
+
+test('MeerkatRuntime.listMobs projects only generated mob list status truth', async () => {
+  const runtime = await runtimeWithMobList({
+    mobs: [{ mob_id: 'mob-web-unit', status: 'Running', state: 'Stale' }],
+  });
+
+  const statuses = await runtime.listMobs();
+
+  assert.deepEqual(statuses, [
+    {
+      mob_id: 'mob-web-unit',
+      status: 'Running',
+      state: 'Running',
+    },
+  ]);
+});
+
+test('MeerkatRuntime.listMobs rejects malformed typed status rows instead of projecting state', async () => {
+  const malformedPayloads = [
+    [{ mob_id: 'mob-web-unit', state: 'Running' }],
+    { mobs: [{ mob_id: 'mob-web-unit', state: 'Running' }] },
+    { mobs: [{ mob_id: 'mob-web-unit', status: '' }] },
+    { mobs: [{ status: 'Running' }] },
+    { mobs: 'not-an-array' },
+    {},
+  ];
+
+  for (const payload of malformedPayloads) {
+    const runtime = await runtimeWithMobList(payload);
+    await assert.rejects(() => runtime.listMobs(), /Invalid mob\/list response/);
+  }
+});
+
+test('Mob decoders reject missing typed status instead of fabricating defaults', async () => {
+  const missingMobStatus = new Mob('mob-web-unit', {
+    async mob_status() {
+      return JSON.stringify({ mob_id: 'mob-web-unit', state: 'Running' });
+    },
+  });
+  await assert.rejects(
+    () => missingMobStatus.status(),
+    /Invalid mob\/status response: missing status/,
+  );
+
+  const missingMemberStatus = new Mob('mob-web-unit', {
+    async mob_member_status() {
+      return JSON.stringify({ tokens_used: 0, is_final: false });
+    },
+  });
+  await assert.rejects(
+    () => missingMemberStatus.memberStatus('worker-1'),
+    /Invalid mob member_status response: missing status/,
+  );
+
+  const missingRespawnStatus = new Mob('mob-web-unit', {
+    async mob_respawn() {
+      return JSON.stringify({
+        receipt: {
+          identity: 'worker-1',
+          member_ref: 'ref-worker-1',
+        },
+      });
+    },
+  });
+  await assert.rejects(
+    () => missingRespawnStatus.respawn('worker-1'),
+    /Invalid mob respawn response: missing status/,
+  );
+
+  const missingAppendStatus = new Mob('mob-web-unit', {
+    async mob_append_system_context() {
+      return JSON.stringify({
+        mob_id: 'mob-web-unit',
+        agent_identity: 'worker-1',
+      });
+    },
+  });
+  await assert.rejects(
+    () =>
+      missingAppendStatus.appendSystemContext('worker-1', {
+        text: 'remember this',
+      }),
+    /Invalid mob append_system_context response: missing status/,
+  );
+});
+
+test('Mob result decoders reject missing generated truth instead of fabricating success', async () => {
+  const missingHandlingMode = new Mob('mob-web-unit', {
+    async mob_member_send() {
+      return JSON.stringify({
+        mob_id: 'mob-web-unit',
+        agent_identity: 'worker-1',
+        member_ref: 'ref-worker-1',
+      });
+    },
+  });
+  await assert.rejects(
+    () => missingHandlingMode.member('worker-1').send('hello', 'steer'),
+    /Invalid mob member delivery response: missing handling_mode/,
+  );
+
+  const missingDeliveryMobId = new Mob('mob-web-unit', {
+    async mob_member_send() {
+      return JSON.stringify({
+        agent_identity: 'worker-1',
+        member_ref: 'ref-worker-1',
+        handling_mode: 'queue',
+      });
+    },
+  });
+  await assert.rejects(
+    () => missingDeliveryMobId.member('worker-1').send('hello'),
+    /Invalid mob member delivery response: missing mob_id/,
+  );
+
+  const malformedHelperResults = [
+    {
+      method: 'spawnHelper',
+      call: (mob) => mob.spawnHelper('summarize'),
+      binding: 'mob_spawn_helper',
+      response: { agent_identity: 'helper-1', member_ref: 'ref-helper-1' },
+      pattern: /Invalid mob spawn_helper response: tokens_used must be number/,
+    },
+    {
+      method: 'forkHelper',
+      call: (mob) => mob.forkHelper('worker-1', 'review'),
+      binding: 'mob_fork_helper',
+      response: { agent_identity: 'fork-1', member_ref: 'ref-fork-1' },
+      pattern: /Invalid mob fork_helper response: tokens_used must be number/,
+    },
+  ];
+
+  for (const fixture of malformedHelperResults) {
+    const mob = new Mob('mob-web-unit', {
+      async [fixture.binding]() {
+        return JSON.stringify(fixture.response);
+      },
+    });
+    await assert.rejects(
+      () => fixture.call(mob),
+      fixture.pattern,
+      `${fixture.method} must not fabricate tokens_used`,
+    );
+  }
+
+  const malformedFlowStatus = new Mob('mob-web-unit', {
+    async mob_flow_status() {
+      return JSON.stringify({ state: 'legacy-success' });
+    },
+  });
+  await assert.rejects(
+    () => malformedFlowStatus.flowStatus('run-1'),
+    /Invalid mob flow_status response: missing run/,
+  );
+});
+
+test('Mob result decoders preserve generated result truth after validation', async () => {
+  const deliveryMob = new Mob('mob-web-unit', {
+    async mob_member_send() {
+      return JSON.stringify({
+        mob_id: 'mob-web-unit',
+        agent_identity: 'worker-1',
+        member_ref: 'ref-worker-1',
+        handling_mode: 'steer',
+      });
+    },
+    async mob_member_status() {
+      return JSON.stringify({
+        status: 'active',
+        tokens_used: 3,
+        is_final: false,
+        current_session_id: 'session-1',
+        realtime_attachment_status: 'attached',
+        external_member: { provider: 'external' },
+      });
+    },
+    async mob_flow_status() {
+      return JSON.stringify({
+        run: {
+          run_id: 'run-1',
+          status: 'running',
+          step_ledger: [],
+        },
+      });
+    },
+  });
+
+  const receipt = await deliveryMob.member('worker-1').send('hello', 'steer');
+  assert.deepEqual(receipt, {
+    agent_identity: 'worker-1',
+    member_ref: 'ref-worker-1',
+    handling_mode: 'steer',
+  });
+
+  const snapshot = await deliveryMob.memberStatus('worker-1');
+  assert.equal(snapshot.current_session_id, 'session-1');
+  assert.equal(snapshot.realtime_attachment_status, 'attached');
+  assert.deepEqual(snapshot.external_member, { provider: 'external' });
+
+  const flowStatus = await deliveryMob.flowStatus('run-1');
+  assert.equal(flowStatus.run_id, 'run-1');
+  assert.equal(flowStatus.status, 'running');
+  assert.deepEqual(flowStatus.step_ledger, []);
+});
+
+test('Mob.respawn rejects legacy receipt carriers instead of projecting success', async () => {
+  const mob = new Mob('mob-web-unit', {
+    async mob_respawn() {
+      return JSON.stringify({
+        status: 'completed',
+        receipt: {
+          agent_identity: 'worker-1',
+          member_ref: 'ref-worker-1',
+        },
+      });
+    },
+  });
+
+  await assert.rejects(
+    () => mob.respawn('worker-1'),
+    /Invalid mob respawn response: receipt missing identity/,
+  );
+});
+
+test('Mob event decoders reject malformed envelopes instead of synthesizing unknown events', async () => {
+  const memberMob = new Mob('mob-web-unit', {
+    async mob_member_subscribe() {
+      return 1;
+    },
+    poll_subscription() {
+      return JSON.stringify([{ event: { type: 'text_delta', delta: 'legacy' } }]);
+    },
+    close_subscription() {},
+  });
+  const memberSubscription = await memberMob.member('worker-1').subscribe();
+  assert.throws(
+    () => memberSubscription.poll(),
+    /Invalid mob member subscription event\[0\]: missing payload/,
+  );
+
+  const metadataLightMember = new Mob('mob-web-unit', {
+    async mob_member_subscribe() {
+      return 3;
+    },
+    poll_subscription() {
+      return JSON.stringify([{ payload: { type: 'turn_completed' } }]);
+    },
+    close_subscription() {},
+  });
+  const metadataLightMemberSubscription = await metadataLightMember
+    .member('worker-1')
+    .subscribe();
+  assert.throws(
+    () => metadataLightMemberSubscription.poll(),
+    /Invalid mob member subscription event\[0\]: missing event_id/,
+  );
+
+  const mobWide = new Mob('mob-web-unit', {
+    async mob_subscribe_events() {
+      return 2;
+    },
+    poll_subscription() {
+      return JSON.stringify([
+        {
+          source: { identity: 'worker-runtime', generation: 1 },
+          role: 'worker',
+          envelope: {},
+        },
+      ]);
+    },
+    close_subscription() {},
+  });
+  const mobSubscription = await mobWide.subscribeEvents();
+  assert.throws(
+    () => mobSubscription.poll(),
+    /Invalid mob attributed subscription event\[0\]: envelope: missing payload/,
+  );
+
+  const metadataLightMobWide = new Mob('mob-web-unit', {
+    async mob_subscribe_events() {
+      return 4;
+    },
+    poll_subscription() {
+      return JSON.stringify([
+        {
+          source: { identity: 'worker-runtime', generation: 1 },
+          role: 'worker',
+          envelope: { payload: { type: 'turn_completed' } },
+        },
+      ]);
+    },
+    close_subscription() {},
+  });
+  const metadataLightMobSubscription = await metadataLightMobWide.subscribeEvents();
+  assert.throws(
+    () => metadataLightMobSubscription.poll(),
+    /Invalid mob attributed subscription event\[0\]: envelope: missing event_id/,
+  );
+
+  const eventLogMob = new Mob('mob-web-unit', {
+    async mob_events() {
+      return JSON.stringify([
+        {
+          cursor: 1,
+          timestamp: '2026-05-03T00:00:00Z',
+          mob_id: 'mob-web-unit',
+        },
+      ]);
+    },
+  });
+  await assert.rejects(
+    () => eventLogMob.events('', 10),
+    /Invalid mob\/events response\[0\]: missing kind/,
+  );
+});
+
+test('Mob event decoders preserve generated payload envelopes', async () => {
+  const memberMob = new Mob('mob-web-unit', {
+    async mob_member_subscribe() {
+      return 1;
+    },
+    poll_subscription() {
+      return JSON.stringify([
+        {
+          event_id: 'evt-1',
+          source_id: 'session-1',
+          seq: 1,
+          timestamp_ms: 123,
+          payload: { type: 'text_delta', delta: 'hello' },
+        },
+      ]);
+    },
+    close_subscription() {},
+  });
+
+  const memberSubscription = await memberMob.member('worker-1').subscribe();
+  const [memberEvent] = memberSubscription.poll();
+
+  assert.equal(memberEvent.payload.type, 'text_delta');
+  assert.equal(memberEvent.seq, 1);
+
+  const mobWide = new Mob('mob-web-unit', {
+    async mob_subscribe_events() {
+      return 2;
+    },
+    poll_subscription() {
+      return JSON.stringify([
+        {
+          source: { identity: 'worker-1', generation: 7 },
+          source_fence_token: 7,
+          role: 'worker',
+          envelope: {
+            event_id: 'evt-2',
+            source_id: 'session-2',
+            seq: 2,
+            timestamp_ms: 456,
+            payload: { type: 'turn_completed' },
+          },
+        },
+      ]);
+    },
+    close_subscription() {},
+  });
+
+  const mobSubscription = await mobWide.subscribeEvents();
+  const [mobEvent] = mobSubscription.poll();
+
+  assert.deepEqual(mobEvent.source, { identity: 'worker-1', generation: 7 });
+  assert.equal('agent_identity' in mobEvent, false);
+  assert.equal(mobEvent.source_fence_token, 7);
+  assert.equal(mobEvent.envelope.payload.type, 'turn_completed');
 });

--- a/sdks/web/tests/mob_payload.unit.mjs
+++ b/sdks/web/tests/mob_payload.unit.mjs
@@ -1,6 +1,7 @@
 import assert from 'node:assert/strict';
 import test from 'node:test';
 
+import { MeerkatRuntime } from '../dist/index.js';
 import { Mob } from '../dist/mob.js';
 import { MeerkatRuntime } from '../dist/runtime.js';
 import { Session } from '../dist/session.js';
@@ -76,6 +77,24 @@ function makeDirectSession(pollEvents) {
     () => undefined,
     pollEvents,
     async () => '{}',
+  );
+}
+
+async function runtimeWithMobList(payload) {
+  return MeerkatRuntime.init(
+    {
+      async default() {},
+      runtime_version() {
+        return '0.6.0';
+      },
+      init_runtime_from_config() {
+        return JSON.stringify({ status: 'initialized' });
+      },
+      async mob_list() {
+        return JSON.stringify(payload);
+      },
+    },
+    {},
   );
 }
 

--- a/sdks/web/tests/mob_payload.unit.mjs
+++ b/sdks/web/tests/mob_payload.unit.mjs
@@ -1,7 +1,6 @@
 import assert from 'node:assert/strict';
 import test from 'node:test';
 
-import { MeerkatRuntime } from '../dist/index.js';
 import { Mob } from '../dist/mob.js';
 import { MeerkatRuntime } from '../dist/runtime.js';
 import { Session } from '../dist/session.js';
@@ -77,24 +76,6 @@ function makeDirectSession(pollEvents) {
     () => undefined,
     pollEvents,
     async () => '{}',
-  );
-}
-
-async function runtimeWithMobList(payload) {
-  return MeerkatRuntime.init(
-    {
-      async default() {},
-      runtime_version() {
-        return '0.6.0';
-      },
-      init_runtime_from_config() {
-        return JSON.stringify({ status: 'initialized' });
-      },
-      async mob_list() {
-        return JSON.stringify(payload);
-      },
-    },
-    {},
   );
 }
 

--- a/sdks/web/tests/types.test.ts
+++ b/sdks/web/tests/types.test.ts
@@ -33,6 +33,7 @@ import type {
   MemberDeliveryReceipt,
   MobMemberSnapshot,
   MobHelperResult,
+  FlowStatus,
 } from '../src/index.js';
 import { Auth } from '../src/index.js';
 
@@ -319,6 +320,7 @@ const forkedHelperResult: Promise<MobHelperResult> = mob.forkHelper(
   'Review the draft and suggest one improvement.',
   { connectionRef: { realm: 'default', binding: 'anthropic' } },
 );
+const flowStatusResult: Promise<FlowStatus | null> = mob.flowStatus('run-1');
 const memberSubscription = mob.member('worker-1').subscribe();
 const mobSubscription = mob.subscribeEvents();
 
@@ -357,5 +359,6 @@ void memberStatusResult;
 void helperResult;
 void helperWithConnectionResult;
 void forkedHelperResult;
+void flowStatusResult;
 void memberSubscription;
 void mobSubscription;

--- a/tools/sdk-codegen/generate.py
+++ b/tools/sdk-codegen/generate.py
@@ -1429,6 +1429,62 @@ def generate_web_event_types(schemas: dict, output_dir: Path) -> None:
     (output_dir / "events.ts").write_text("\n".join(lines))
 
 
+def generate_web_mob_types(schemas: dict, output_dir: Path) -> None:
+    output_dir.mkdir(parents=True, exist_ok=True)
+    wire_schema = _schema_root_with_nested_defs(schemas.get("wire-types", {}))
+    emitted: set[str] = set()
+    lines: list[str] = [
+        "// Generated mob wire types for @rkat/web",
+        "// Source: artifacts/schemas/wire-types.json",
+        "",
+    ]
+
+    def append_interface(name: str) -> None:
+        if name in emitted:
+            return
+        schema = _lookup_named_schema(wire_schema, name)
+        if not schema:
+            raise KeyError(f"schema for generated web mob type {name} not found")
+        properties = schema.get("properties", {}) if isinstance(schema, dict) else {}
+        required = set(schema.get("required", [])) if isinstance(schema, dict) else set()
+        local_defs = set(schema.get("$defs", {}).keys()) if isinstance(schema, dict) else set()
+        schema_root = _schema_root_with_local_defs(wire_schema, schema)
+        lines.append(f"export interface {name} {{")
+        for field_name, field_schema in properties.items():
+            field_type, optional_by_type = _typescript_type_from_schema(
+                schema_root,
+                field_schema,
+                local_defs,
+            )
+            optional = "?" if (field_name not in required or optional_by_type) else ""
+            lines.append(f"  {field_name}{optional}: {field_type};")
+        lines.append("}")
+        lines.append("")
+        emitted.add(name)
+
+    def append_alias(name: str) -> None:
+        if name in emitted:
+            return
+        schema = _lookup_named_schema(wire_schema, name)
+        if not schema:
+            raise KeyError(f"schema for generated web mob alias {name} not found")
+        local_defs = set(schema.get("$defs", {}).keys()) if isinstance(schema, dict) else set()
+        schema_root = _schema_root_with_local_defs(wire_schema, schema)
+        alias_type, _ = _typescript_type_from_schema(schema_root, schema, local_defs)
+        lines.append(f"export type {name} = {alias_type};")
+        lines.append("")
+        emitted.add(name)
+
+    append_alias("WireMobMemberStatus")
+    append_interface("MobStatusResult")
+    append_interface("MobRespawnResult")
+    append_interface("MobEventsResult")
+    append_interface("MobMemberStatusResult")
+    append_interface("MobAppendSystemContextResult")
+
+    (output_dir / "mob.ts").write_text("\n".join(lines))
+
+
 def load_available_capabilities(artifacts_dir: Path) -> set[str]:
     """Load available capability IDs from capabilities.json."""
     caps_file = artifacts_dir / "capabilities.json"
@@ -1500,6 +1556,8 @@ def main():
     web_events_output = output_root / "sdks" / "web" / "src" / "generated"
     generate_web_event_types(schemas, web_events_output)
     print(f"Generated web event types in {web_events_output}")
+    generate_web_mob_types(schemas, web_events_output)
+    print(f"Generated web mob types in {web_events_output}")
 
 
 if __name__ == "__main__":

--- a/tools/sdk-codegen/generate.py
+++ b/tools/sdk-codegen/generate.py
@@ -1477,6 +1477,11 @@ def generate_web_mob_types(schemas: dict, output_dir: Path) -> None:
 
     append_alias("WireMobMemberStatus")
     append_interface("MobStatusResult")
+    lines.append("export interface MobListResult {")
+    lines.append("  mobs: MobStatusResult[];")
+    lines.append("}")
+    lines.append("")
+    emitted.add("MobListResult")
     append_interface("MobRespawnResult")
     append_interface("MobEventsResult")
     append_interface("MobMemberStatusResult")

--- a/tools/sdk-codegen/generate.py
+++ b/tools/sdk-codegen/generate.py
@@ -1476,6 +1476,7 @@ def generate_web_mob_types(schemas: dict, output_dir: Path) -> None:
         emitted.add(name)
 
     append_alias("WireMobMemberStatus")
+    append_alias("WireMemberRef")
     append_interface("MobStatusResult")
     lines.append("export interface MobListResult {")
     lines.append("  mobs: MobStatusResult[];")
@@ -1484,6 +1485,9 @@ def generate_web_mob_types(schemas: dict, output_dir: Path) -> None:
     emitted.add("MobListResult")
     append_interface("MobRespawnResult")
     append_interface("MobEventsResult")
+    append_interface("MobMemberSendResult")
+    append_interface("MobFlowStatusResult")
+    append_interface("MobHelperResult")
     append_interface("MobMemberStatusResult")
     append_interface("MobAppendSystemContextResult")
 


### PR DESCRIPTION
## Summary

Dogma cleanup PR: yes

Fail closed the Web SDK mob decoders against generated mob wire truth:
- Generated typed mob wire contracts now cover mob status/list/member-send/helper/flow/member-status result envelopes.
- `sdks/web/src/mob.ts` and `sdks/web/src/runtime.ts` parse those envelopes before exposing SDK objects.
- Compatibility output is limited to `state: status`; it is an inert projection of already-required generated `status`.

Rework/rebase note: this branch is rebased on current `origin/main` after the base branch removed the orphan Claude worktree gitlink. The exact two-dot diff now has 4 non-merge commits:

```text
7cff67eea Fail closed adjacent web mob decoders
c03e8fd1c Fail closed mob list decoder
f80ca0123 Handle mob attributed runtime sources
f5ad5345b Fail closed web mob decoders
```

## Validation

```text
$ npm test
1..22
# tests 22
# suites 0
# pass 22
# fail 0
```

```text
$ ./scripts/repo-cargo test -p meerkat-web-runtime --no-run
Finished `test` profile [unoptimized] target(s) in 4.28s
```

```text
$ MEERKAT_BUILDBUDDY=1 DOGMA_PACKET=.tmp-luc-339-pr-body.md make agent-gate
Dogma cleanup gate passed for /home/luka_crnkovicfriis_king_com/symphony/workspaces/LUC-339/.tmp-luc-339-pr-body.md
PASS owned-fast-test
PASS owned-clippy-rbe
```

## Review Readiness Packet

Current head SHA: 7cff67eea7847c64dc094405fd30c41a64b89d12

Command output:

```text
$ make dogma-cleanup-gate DOGMA_PACKET=.tmp-luc-339-pr-body.md
Dogma cleanup gate passed for /home/luka_crnkovicfriis_king_com/symphony/workspaces/LUC-339/.tmp-luc-339-pr-body.md
```

## Complexity Delta

- Docs/scripts/tests: 4 files. `docs/architecture/luc-339-review-readiness.md`, `sdks/web/tests/mob_payload.unit.mjs`, `sdks/web/tests/e2e_wasm_runtime.test.mjs`, `sdks/web/tests/types.test.ts`.
- Non-test implementation: 5 files. `sdks/web/src/mob.ts`, `sdks/web/src/runtime.ts`, `sdks/web/src/types.ts`, `meerkat-web-runtime/src/lib.rs`, `tools/sdk-codegen/generate.py`.
- Generated/schema churn: 1 file. `sdks/web/src/generated/mob.ts`.

## Old Path Amputation Proof

What exact Web SDK default/fabrication path became impossible: the Web SDK mob surface can no longer convert absent or malformed generated mob status/result/event truth into `unknown`, empty strings, default success, or legacy string lifecycle/event state. These old paths now throw before an SDK object is exposed.

| Old path | Classification | Search literal | Mechanical proof | Follow-up |
| --- | --- | --- | --- | --- |
| State-only mob status payload accepted by `Mob.status()` | made uncallable at boundary | `state-only mob status payload` | Public API rejects calls before exposing an SDK object: `parseMobStatusResult` requires generated `mob_id` and `status` and throws `Invalid mob/status response: missing status`. | none |
| Raw mob list status row accepted by `MeerkatRuntime.listMobs()` | made uncallable at boundary | `raw mob list status row` | Runtime public API rejects calls with state-only rows: `runtime.ts` requires generated `MobListResult.mobs` and validates each row with `parseMobStatusResult`, throwing `Invalid mob/list response.mobs[0]: missing status`. | none |
| `memberStatus` unknown status default | made uncallable at boundary | `memberStatus unknown status default` | Public API rejects calls before snapshot exposure: `parseMobMemberSnapshot` requires generated member status, token count, and finality and throws on missing status. | none |
| `Member.send` caller handling-mode fallback | made uncallable at boundary | `Member.send caller handling-mode fallback` | Public API rejects calls before receipt exposure: `parseMemberDeliveryReceipt` requires generated `mob_id`, `agent_identity`, `member_ref`, and `handling_mode` and throws `Invalid mob member delivery response: missing handling_mode`. | none |
| `spawnHelper` helper token-zero fallback | made uncallable at boundary | `spawnHelper helper token-zero fallback` | Public API rejects calls before helper result exposure: `parseMobHelperResult` requires generated `tokens_used`, `agent_identity`, and `member_ref` and throws `tokens_used must be number`. | none |
| `flowStatus` raw malformed flow cast | made uncallable at boundary | `flowStatus raw malformed flow cast` | Public API rejects calls before flow exposure: `parseMobFlowStatusResult` requires generated `{ run }`, returns `null` only for explicit `run: null`, and throws `Invalid mob flow_status response: missing run`. | none |
| `respawn` default completed result | made uncallable at boundary | `respawn default completed result` | Public API rejects calls before respawn exposure: `parseMobRespawnResult` requires generated `status`, `receipt.identity`, and `receipt.member_ref` and throws on missing status. | none |
| `subscribeEvents` unknown event or string source synthesis | made uncallable at boundary | `subscribeEvents unknown event or string source synthesis` | Public API rejects calls while polling subscriptions: event decoders require canonical `payload.type`, `event_id`, `source_id`, `seq`, `timestamp_ms`, `role`, and runtime-id `source`, throwing `Invalid mob attributed subscription event[0]: missing source`. | none |
| `Mob.events` raw malformed event-log cast | made uncallable at boundary | `Mob.events raw malformed event-log cast` | Public API rejects calls before event-log exposure: `parseMobEvent` requires `cursor`, `timestamp`, `mob_id`, and `kind` and throws `Invalid mob/events response[0]: missing kind`. | none |

## Sample Passing Old Path Amputation Proof

| Old path | Classification | Search literal | Mechanical proof | Follow-up |
| --- | --- | --- | --- | --- |
| `old/session-route` | deleted | `old/session-route` | No production references remain. | none |

## Sample Failing Old Path Amputation Proof

| Old path | Classification | Search literal | Mechanical proof | Follow-up |
| --- | --- | --- | --- | --- |
| `old/session-route` | wrapped | `old/session-route` | A preferred path exists beside the old route. | none |
| `surface_request_lifecycle_helper` | made uncallable at boundary | `surface_request_lifecycle_helper` | Boundary test exercises the replacement wrapper while the old helper remains callable for compatibility. | none |