### PR TITLE
LUC-343 Amputate peer ingress compatibility authority

### DIFF
--- a/meerkat-comms/src/classify.rs
+++ b/meerkat-comms/src/classify.rs
@@ -1112,6 +1112,170 @@ mod tests {
     }
 
     #[test]
+    fn runtime_backed_missing_machine_rejects_auth_lifecycle_response_and_plain_cases() {
+        let sender = make_keypair();
+        let trusted = make_trusted_peers("sender-agent", &sender.public_key());
+        let ctx = make_context(true, trusted, vec!["review"]);
+        ctx.require_machine_authority.store(true, Ordering::SeqCst);
+        let response_id = Uuid::new_v4();
+
+        let external_cases = [
+            MessageKind::Request {
+                intent: meerkat_core::SUPERVISOR_BRIDGE_INTENT.to_string(),
+                params: serde_json::json!({}),
+                handling_mode: None,
+            },
+            MessageKind::Request {
+                intent: "mob.peer_added".to_string(),
+                params: serde_json::json!({"peer": "new-agent"}),
+                handling_mode: None,
+            },
+            MessageKind::Response {
+                in_reply_to: response_id,
+                status: crate::types::Status::Completed,
+                result: serde_json::json!({"ok": true}),
+                handling_mode: None,
+            },
+        ];
+
+        for kind in external_cases {
+            let result = ctx.classify(&InboxItem::External {
+                envelope: make_envelope(&sender, kind),
+            });
+            assert!(
+                result.is_none(),
+                "runtime-backed ingress must fail closed instead of letting the compatibility classifier decide"
+            );
+        }
+
+        let plain_result = ctx.classify(&InboxItem::PlainEvent {
+            blocks: None,
+            body: "event body".to_string(),
+            source: meerkat_core::PlainEventSource::Tcp,
+            handling_mode: meerkat_core::types::HandlingMode::Queue,
+            interaction_id: None,
+            render_metadata: None,
+        });
+        assert!(
+            plain_result.is_none(),
+            "plain event projection must also require machine authority on runtime-backed ingress"
+        );
+    }
+
+    #[test]
+    fn machine_result_overrides_local_auth_lifecycle_and_terminality_conventions() {
+        let sender = make_keypair();
+
+        let auth_override = PeerIngressAdmission {
+            classification: meerkat_core::PeerIngressClassification::required(
+                PeerInputClass::ActionableRequest,
+                PeerIngressKind::Request,
+            ),
+            lifecycle_peer: None,
+            request_id: None,
+            rendered_text: "machine-required-supervisor-bridge".to_string(),
+        };
+        let auth_machine =
+            RecordingPeerCommsHandle::accepting_with_external_override(auth_override);
+        let auth_ctx = make_context_with_machine(
+            true,
+            TrustedPeers::new(),
+            vec![],
+            Some(auth_machine.clone() as Arc<dyn meerkat_core::handles::PeerCommsHandle>),
+        );
+        let auth_result = auth_ctx.classify(&InboxItem::External {
+            envelope: make_envelope(
+                &sender,
+                MessageKind::Request {
+                    intent: meerkat_core::SUPERVISOR_BRIDGE_INTENT.to_string(),
+                    params: serde_json::json!({}),
+                    handling_mode: None,
+                },
+            ),
+        });
+        assert!(
+            auth_result.is_none(),
+            "local supervisor-bridge exemption must not admit when machine returned auth-required"
+        );
+        assert_eq!(auth_machine.external_calls(), 1);
+
+        let lifecycle_override = PeerIngressAdmission {
+            classification: meerkat_core::PeerIngressClassification::required(
+                PeerInputClass::ActionableRequest,
+                PeerIngressKind::Request,
+            ),
+            lifecycle_peer: None,
+            request_id: None,
+            rendered_text: "machine-actionable-peer-added".to_string(),
+        };
+        let lifecycle_machine =
+            RecordingPeerCommsHandle::accepting_with_external_override(lifecycle_override);
+        let trusted = make_trusted_peers("orchestrator", &sender.public_key());
+        let lifecycle_ctx = make_context_with_machine(
+            true,
+            trusted,
+            vec![],
+            Some(lifecycle_machine.clone() as Arc<dyn meerkat_core::handles::PeerCommsHandle>),
+        );
+        let lifecycle = lifecycle_ctx
+            .classify(&InboxItem::External {
+                envelope: make_envelope(
+                    &sender,
+                    MessageKind::Request {
+                        intent: "mob.peer_added".to_string(),
+                        params: serde_json::json!({"peer": "new-agent"}),
+                        handling_mode: None,
+                    },
+                ),
+            })
+            .expect("machine-accepted request should classify");
+        assert_eq!(lifecycle.class, PeerInputClass::ActionableRequest);
+        assert_eq!(lifecycle.lifecycle_peer, None);
+        assert_eq!(lifecycle_machine.external_calls(), 1);
+
+        let response_override = PeerIngressAdmission {
+            classification: meerkat_core::PeerIngressClassification {
+                class: PeerInputClass::ResponseProgress,
+                kind: PeerIngressKind::Response,
+                auth: PeerIngressAuthDecision::Required,
+                lifecycle_kind: None,
+                response_terminality: Some(TerminalityClass::Progress),
+            },
+            lifecycle_peer: None,
+            request_id: Some(Uuid::new_v4().to_string()),
+            rendered_text: "machine-progress-response".to_string(),
+        };
+        let response_machine =
+            RecordingPeerCommsHandle::accepting_with_external_override(response_override);
+        let trusted = make_trusted_peers("sender-agent", &sender.public_key());
+        let response_ctx = make_context_with_machine(
+            true,
+            trusted,
+            vec![],
+            Some(response_machine.clone() as Arc<dyn meerkat_core::handles::PeerCommsHandle>),
+        );
+        let response = response_ctx
+            .classify(&InboxItem::External {
+                envelope: make_envelope(
+                    &sender,
+                    MessageKind::Response {
+                        in_reply_to: Uuid::new_v4(),
+                        status: crate::types::Status::Completed,
+                        result: serde_json::json!({"ok": true}),
+                        handling_mode: None,
+                    },
+                ),
+            })
+            .expect("machine-accepted response should classify");
+        assert_eq!(response.class, PeerInputClass::ResponseProgress);
+        assert_eq!(
+            response.response_terminality,
+            Some(TerminalityClass::Progress)
+        );
+        assert_eq!(response_machine.external_calls(), 1);
+    }
+
+    #[test]
     fn classify_untrusted_legacy_bridge_intent_drops_at_ingress() {
         let sender = make_keypair();
         let trusted = TrustedPeers::new(); // sender NOT trusted yet

--- a/meerkat-comms/src/inbox.rs
+++ b/meerkat-comms/src/inbox.rs
@@ -17,11 +17,10 @@ use crate::classify::IngressClassificationContext;
 use crate::classify::PreparedIngressItem;
 use crate::peer_types::PeerIngressState;
 use crate::trust::TrustedPeers;
-use crate::types::{Envelope, InboxItem, MessageKind};
+use crate::types::{Envelope, InboxItem};
 use meerkat_core::{
     InteractionId, PeerIngressAdmissionDiagnostic, PeerIngressAuthDecision,
-    PeerIngressDiagnosticDisplay, PeerIngressEntrySnapshot, PeerIngressEnvelopeFacts,
-    PeerIngressEnvelopeKind, PeerIngressFact, PeerIngressKind, PeerIngressMachinePolicy,
+    PeerIngressDiagnosticDisplay, PeerIngressEntrySnapshot, PeerIngressFact, PeerIngressKind,
     PeerIngressQueueSnapshot, PeerInputClass, TerminalityClass,
 };
 
@@ -595,7 +594,11 @@ impl InboxSender {
             return self.send_classified(InboxItem::External { envelope });
         }
 
-        let auth = ingress_auth_decision(&envelope.kind);
+        // Raw inbox ingress is transport mechanics only. It must not reconstruct
+        // auth exemptions, lifecycle intent, or response terminality from the
+        // compatibility classifier; those facts exist only on the classified
+        // runtime/machine path.
+        let auth = PeerIngressAuthDecision::Required;
         if require_peer_auth
             && !auth.is_exempt()
             && !trusted_peers.read().is_trusted(&envelope.from)
@@ -793,44 +796,6 @@ impl Drop for Inbox {
             queue.lock().close();
         }
     }
-}
-
-fn ingress_auth_decision(kind: &MessageKind) -> PeerIngressAuthDecision {
-    let facts = PeerIngressEnvelopeFacts {
-        item_id: String::new(),
-        from_peer: String::new(),
-        from_peer_id: meerkat_core::comms::PeerId::from_uuid(uuid::Uuid::nil()),
-        kind: match kind {
-            MessageKind::Message { body, .. } => {
-                PeerIngressEnvelopeKind::Message { body: body.clone() }
-            }
-            MessageKind::Request { intent, params, .. } => PeerIngressEnvelopeKind::Request {
-                intent: intent.clone(),
-                params: params.clone(),
-            },
-            MessageKind::Lifecycle { kind, params } => PeerIngressEnvelopeKind::Lifecycle {
-                kind: *kind,
-                params: params.clone(),
-            },
-            MessageKind::Response {
-                in_reply_to,
-                status,
-                result,
-                ..
-            } => PeerIngressEnvelopeKind::Response {
-                in_reply_to: in_reply_to.to_string(),
-                status: (*status).into(),
-                result: result.clone(),
-            },
-            MessageKind::Ack { in_reply_to } => PeerIngressEnvelopeKind::Ack {
-                in_reply_to: in_reply_to.to_string(),
-            },
-        },
-    };
-    PeerIngressMachinePolicy::default()
-        .classify_external_envelope(&facts)
-        .classification
-        .auth
 }
 
 fn snapshot_entry(entry: &ClassifiedInboxEntry) -> PeerIngressEntrySnapshot {
@@ -1123,6 +1088,7 @@ mod tests {
 
     use crate::classify::IngressClassificationContext;
     use crate::trust::{TrustedPeer, TrustedPeers};
+    use meerkat_core::PeerIngressMachinePolicy;
     use std::sync::atomic::AtomicUsize;
 
     fn make_classification_context(
@@ -1708,6 +1674,28 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn test_runtime_required_response_without_machine_authority_fails_closed() {
+        let sender_pubkey = PubKey::new([1u8; 32]);
+        let ctx = make_classification_context(make_trusted("peer", &sender_pubkey), true);
+        ctx.require_machine_authority.store(true, Ordering::SeqCst);
+        let (mut inbox, sender) = Inbox::new_classified(ctx);
+
+        let outcome = sender.send_classified(InboxItem::External {
+            envelope: make_response_envelope(Uuid::new_v4()),
+        });
+
+        assert_eq!(
+            outcome,
+            AdmissionOutcome::Dropped {
+                reason: DropReason::ClassificationRejected
+            },
+            "runtime-backed peer response must not be accepted or terminalized by the compatibility classifier"
+        );
+        assert_eq!(inbox.dropped_count(), Some(1));
+        assert_eq!(inbox.try_drain_classified().len(), 0);
+    }
+
+    #[tokio::test]
     async fn test_classified_full_queue_returns_typed_drop_reason() {
         // InboxFull drops surface as typed `Dropped { InboxFull }` with the
         // counter bumped. We build a classified queue at capacity 1 by using
@@ -1752,10 +1740,10 @@ mod tests {
     }
 
     #[test]
-    fn test_raw_connection_ingress_allows_auth_exempt_bridge_request() {
-        // DOGMA-12 defensive scan: raw transport ingress must not invent its
-        // own "drop bridge bootstrap traffic" rule. Auth-exempt bridge
-        // requests still flow through the canonical inbox admission seam.
+    fn test_raw_connection_ingress_rejects_untrusted_bridge_without_machine_authority() {
+        // Raw transport ingress is not a classification authority. Without the
+        // classified runtime/machine path, it cannot infer supervisor-bridge
+        // auth exemption from a local compatibility policy.
         let receiver = crate::identity::Keypair::generate();
         let sender = crate::identity::Keypair::generate();
         let trusted = Arc::new(parking_lot::RwLock::new(TrustedPeers::new()));
@@ -1773,23 +1761,16 @@ mod tests {
             sig: crate::identity::Signature::new([0u8; 64]),
         };
         envelope.sign(&sender);
-        let envelope_id = envelope.id;
 
         let outcome = inbox_sender.send_connection_ingress(envelope, true, &trusted);
-        assert_eq!(outcome, AdmissionOutcome::Admitted);
+        assert_eq!(
+            outcome,
+            AdmissionOutcome::Dropped {
+                reason: DropReason::UntrustedSender
+            }
+        );
 
         let items = inbox.try_drain();
-        assert_eq!(items.len(), 1, "auth-exempt ingress must reach the inbox");
-        match &items[0] {
-            InboxItem::External { envelope } => {
-                assert_eq!(envelope.id, envelope_id);
-                assert!(matches!(
-                    envelope.kind,
-                    MessageKind::Request { ref intent, .. }
-                        if intent == meerkat_core::SUPERVISOR_BRIDGE_INTENT
-                ));
-            }
-            _ => panic!("expected External ingress item"),
-        }
+        assert!(items.is_empty(), "raw ingress must fail closed");
     }
 }

--- a/meerkat-comms/src/runtime/comms_runtime.rs
+++ b/meerkat-comms/src/runtime/comms_runtime.rs
@@ -1331,6 +1331,33 @@ impl CommsRuntime {
         config: ResolvedCommsConfig,
         silent_intents: Arc<HashSet<String>>,
     ) -> Result<Self, CommsRuntimeError> {
+        Self::new_with_silent_intents_and_machine_authority_requirement(
+            config,
+            silent_intents,
+            false,
+        )
+        .await
+    }
+
+    #[cfg(not(target_arch = "wasm32"))]
+    pub async fn new_machine_authority_required_with_silent_intents(
+        config: ResolvedCommsConfig,
+        silent_intents: Arc<HashSet<String>>,
+    ) -> Result<Self, CommsRuntimeError> {
+        Self::new_with_silent_intents_and_machine_authority_requirement(
+            config,
+            silent_intents,
+            true,
+        )
+        .await
+    }
+
+    #[cfg(not(target_arch = "wasm32"))]
+    async fn new_with_silent_intents_and_machine_authority_requirement(
+        config: ResolvedCommsConfig,
+        silent_intents: Arc<HashSet<String>>,
+        require_machine_authority: bool,
+    ) -> Result<Self, CommsRuntimeError> {
         // Always load keypair and trusted peers — outbound routing needs them
         // regardless of auth mode. The auth mode only affects the external
         // event listener, not the signed agent-to-agent path.
@@ -1347,7 +1374,8 @@ impl CommsRuntime {
 
         // Build classified inbox using the same trusted_peers Arc
         let peer_comms_handle = Arc::new(parking_lot::RwLock::new(None));
-        let require_peer_comms_machine_authority = Arc::new(AtomicBool::new(false));
+        let require_peer_comms_machine_authority =
+            Arc::new(AtomicBool::new(require_machine_authority));
         let classification_context = Arc::new(crate::classify::IngressClassificationContext {
             require_peer_auth: config.require_peer_auth,
             trusted_peers: trusted_peers.clone(),
@@ -1691,6 +1719,11 @@ impl CommsRuntime {
     pub fn require_peer_comms_machine_authority(&self) {
         self.require_peer_comms_machine_authority
             .store(true, Ordering::SeqCst);
+    }
+
+    pub fn peer_comms_machine_authority_required(&self) -> bool {
+        self.require_peer_comms_machine_authority
+            .load(Ordering::SeqCst)
     }
 
     pub fn peer_comms_handle(&self) -> Option<Arc<dyn meerkat_core::handles::PeerCommsHandle>> {
@@ -3223,6 +3256,70 @@ mod tests {
             require_peer_auth: true,
             allow_external_unauthenticated: false,
         }
+    }
+
+    #[tokio::test]
+    async fn machine_required_tcp_runtime_rejects_ingress_before_handle_or_listener_start() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let suffix = Uuid::new_v4().simple().to_string();
+        let sender_name = format!("pre-authority-sender-{suffix}");
+        let receiver_name = format!("pre-authority-receiver-{suffix}");
+        let sender = CommsRuntime::inproc_only(&sender_name).unwrap();
+        let mut config = test_runtime_config(&receiver_name, &tmp);
+        config.listen_tcp = Some("127.0.0.1:0".parse().unwrap());
+        let receiver = CommsRuntime::new_machine_authority_required_with_silent_intents(
+            config,
+            Arc::new(HashSet::new()),
+        )
+        .await
+        .unwrap();
+
+        assert!(receiver.peer_comms_machine_authority_required());
+        assert!(receiver.peer_comms_handle().is_none());
+
+        CoreCommsRuntime::add_trusted_peer(
+            &sender,
+            trusted_descriptor(
+                &receiver_name,
+                receiver.public_key(),
+                &format!("inproc://{receiver_name}"),
+            ),
+        )
+        .await
+        .unwrap();
+        CoreCommsRuntime::add_trusted_peer(
+            &receiver,
+            trusted_descriptor(
+                &sender_name,
+                sender.public_key(),
+                &format!("inproc://{sender_name}"),
+            ),
+        )
+        .await
+        .unwrap();
+
+        let result = CoreCommsRuntime::send(
+            &sender,
+            CommsCommand::PeerMessage {
+                blocks: None,
+                to: peer_route(&receiver_name, receiver.public_key()),
+                body: "must not pass local classifier".to_string(),
+                handling_mode: meerkat_core::types::HandlingMode::Queue,
+            },
+        )
+        .await;
+
+        assert!(matches!(
+            result,
+            Err(SendError::AdmissionDropped {
+                reason: meerkat_core::comms::AdmissionDropReason::ClassificationRejected
+            })
+        ));
+        let interactions = CoreCommsRuntime::drain_inbox_interactions(&receiver).await;
+        assert!(
+            interactions.is_empty(),
+            "runtime-required ingress without a machine handle must not reach the inbox"
+        );
     }
 
     fn signed_envelope(from: &Keypair, to: PubKey, kind: MessageKind) -> Envelope {

--- a/meerkat-core/src/interaction.rs
+++ b/meerkat-core/src/interaction.rs
@@ -37,12 +37,12 @@ pub enum ResponseStatus {
     Failed,
 }
 
-/// Canonical terminality classification of a `ResponseStatus`.
+/// Terminality projection for a typed `ResponseStatus`.
 ///
-/// Consumers that care about progress-vs-terminal (and, within terminal,
-/// whether the response completed or failed) must read this typed class
-/// rather than re-`match` on `ResponseStatus` — that duplication is how
-/// "terminal" drifts from one call site to another.
+/// Runtime-backed peer ingress receives this as part of the typed
+/// `PeerIngressClassification` emitted by the machine authority. Downstream
+/// runtime/public projections must consume that carried terminality instead of
+/// re-matching raw response status after admission.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 #[non_exhaustive]
 pub enum TerminalityClass {
@@ -640,8 +640,10 @@ pub struct PeerIngressAdmission {
 ///
 /// Runtime-backed comms must use the MeerkatMachine
 /// `PeerIngressClassified` effect as authority. This adapter exists only for
-/// standalone comms runtimes without a session DSL and is ratcheted by comms
-/// tests so session-backed ingress cannot silently fall back to it.
+/// standalone comms runtimes without a session DSL and for tests that need a
+/// wire-compatible projection of machine behavior. Raw inbox ingress and
+/// runtime-required classified ingress must not use it as a second authority
+/// for auth exemptions, lifecycle intent, or response terminality.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct PeerIngressMachinePolicy {
     silent_request_intents: BTreeSet<String>,

--- a/meerkat-runtime/src/comms_bridge.rs
+++ b/meerkat-runtime/src/comms_bridge.rs
@@ -33,6 +33,10 @@ pub enum PeerIngressProjectionError {
     MissingCanonicalPeerId {
         interaction_id: meerkat_core::InteractionId,
     },
+    #[error("classified peer response {interaction_id} missing machine response terminality")]
+    MissingResponseTerminality {
+        interaction_id: meerkat_core::InteractionId,
+    },
 }
 
 /// Convert a classified comms interaction into the appropriate runtime-owned
@@ -102,12 +106,7 @@ fn peer_input_from_ingress_fact(
     ingress: &PeerIngressFact,
     response_terminality: Option<meerkat_core::interaction::TerminalityClass>,
 ) -> Result<Input, PeerIngressProjectionError> {
-    let convention = map_ingress_convention(ingress, response_terminality).ok_or(
-        PeerIngressProjectionError::UnsupportedPeerConvention {
-            interaction_id: interaction.id,
-            kind: ingress.kind,
-        },
-    )?;
+    let convention = map_ingress_convention(interaction.id, ingress, response_terminality)?;
     let durability = map_durability(&convention);
     let peer_id = ingress.canonical_peer_id_string().ok_or(
         PeerIngressProjectionError::MissingCanonicalPeerId {
@@ -150,64 +149,42 @@ fn peer_input_from_ingress_fact(
 }
 
 fn map_ingress_convention(
+    interaction_id: meerkat_core::InteractionId,
     ingress: &PeerIngressFact,
     response_terminality: Option<meerkat_core::interaction::TerminalityClass>,
-) -> Option<PeerConvention> {
+) -> Result<PeerConvention, PeerIngressProjectionError> {
     match &ingress.convention {
-        PeerIngressConvention::Message => Some(PeerConvention::Message),
-        PeerIngressConvention::Request { request_id, intent } => Some(PeerConvention::Request {
+        PeerIngressConvention::Message => Ok(PeerConvention::Message),
+        PeerIngressConvention::Request { request_id, intent } => Ok(PeerConvention::Request {
             request_id: request_id.clone(),
             intent: intent.clone(),
         }),
         PeerIngressConvention::Response {
             in_reply_to,
-            status,
-        } => Some(map_response_convention(
-            *in_reply_to,
-            *status,
-            Some(ingress.class),
-            response_terminality,
-        )),
-        PeerIngressConvention::Lifecycle { kind, .. } => Some(PeerConvention::Request {
+            status: _,
+        } => {
+            let terminality = response_terminality
+                .ok_or(PeerIngressProjectionError::MissingResponseTerminality { interaction_id })?;
+            Ok(map_response_convention(*in_reply_to, terminality))
+        }
+        PeerIngressConvention::Lifecycle { kind, .. } => Ok(PeerConvention::Request {
             request_id: ingress.interaction_id.to_string(),
             intent: kind.to_string(),
         }),
-        PeerIngressConvention::Ack { .. } | PeerIngressConvention::PlainEvent { .. } => None,
+        PeerIngressConvention::Ack { .. } | PeerIngressConvention::PlainEvent { .. } => {
+            Err(PeerIngressProjectionError::UnsupportedPeerConvention {
+                interaction_id,
+                kind: ingress.kind,
+            })
+        }
     }
 }
 
 fn map_response_convention(
     in_reply_to: meerkat_core::InteractionId,
-    status: meerkat_core::ResponseStatus,
-    ingress_class: Option<PeerInputClass>,
-    response_terminality: Option<meerkat_core::interaction::TerminalityClass>,
+    terminality: meerkat_core::interaction::TerminalityClass,
 ) -> PeerConvention {
     let request_id = in_reply_to.to_string();
-    let terminality = match response_terminality {
-        Some(terminality) => terminality,
-        None => match ingress_class {
-            Some(PeerInputClass::ResponseProgress) => {
-                meerkat_core::interaction::TerminalityClass::Progress
-            }
-            Some(PeerInputClass::ResponseTerminal) => {
-                match meerkat_core::interaction::classify_response_terminality(status) {
-                    terminal @ meerkat_core::interaction::TerminalityClass::Terminal { .. } => {
-                        terminal
-                    }
-                    other => {
-                        tracing::warn!(
-                            class = ?other,
-                            "terminal ingress class conflicted with response status; failing closed as terminal failure"
-                        );
-                        meerkat_core::interaction::TerminalityClass::Terminal {
-                            disposition: meerkat_core::interaction::TerminalDisposition::Failed,
-                        }
-                    }
-                }
-            }
-            _ => meerkat_core::interaction::classify_response_terminality(status),
-        },
-    };
     match terminality {
         meerkat_core::interaction::TerminalityClass::Progress => PeerConvention::ResponseProgress {
             request_id,
@@ -377,10 +354,11 @@ mod tests {
         let id = interaction.id;
         let label = interaction.from.clone();
         let peer_id = interaction.from_route.unwrap_or_else(test_peer_id);
-        let (class, convention) = match &interaction.content {
+        let (class, convention, response_terminality) = match &interaction.content {
             InteractionContent::Message { .. } => (
                 PeerInputClass::ActionableMessage,
                 PeerIngressConvention::Message,
+                None,
             ),
             InteractionContent::Request { intent, .. } => (
                 PeerInputClass::ActionableRequest,
@@ -388,23 +366,38 @@ mod tests {
                     request_id: id.to_string(),
                     intent: intent.clone(),
                 },
+                None,
             ),
             InteractionContent::Response {
                 in_reply_to,
                 status,
                 ..
-            } => (
-                meerkat_core::PeerIngressMachinePolicy::default()
-                    .classify_response(*status)
-                    .class,
-                PeerIngressConvention::Response {
-                    in_reply_to: *in_reply_to,
-                    status: *status,
-                },
-            ),
+            } => {
+                let terminality = meerkat_core::interaction::classify_response_terminality(*status);
+                let class = match terminality {
+                    meerkat_core::TerminalityClass::Progress => PeerInputClass::ResponseProgress,
+                    meerkat_core::TerminalityClass::Terminal { .. } => {
+                        PeerInputClass::ResponseTerminal
+                    }
+                    _ => PeerInputClass::ResponseTerminal,
+                };
+                (
+                    class,
+                    PeerIngressConvention::Response {
+                        in_reply_to: *in_reply_to,
+                        status: *status,
+                    },
+                    Some(terminality),
+                )
+            }
         };
         let ingress = peer_ingress(id, peer_id, &label, class, convention);
-        PeerInputCandidate::new(interaction, ingress, None)
+        PeerInputCandidate {
+            interaction,
+            ingress,
+            lifecycle_peer: None,
+            response_terminality,
+        }
     }
 
     fn peer_input_for_test(interaction: &InboxInteraction, runtime_id: &LogicalRuntimeId) -> Input {
@@ -1000,6 +993,54 @@ mod tests {
         } else {
             panic!("Expected PeerInput");
         }
+    }
+
+    #[test]
+    fn classified_response_missing_machine_terminality_fails_closed() {
+        let in_reply_to = make_interaction_id();
+        let id = make_interaction_id();
+        let classified = PeerInputCandidate {
+            interaction: InboxInteraction {
+                from_route: None,
+                from: "peer-1".into(),
+                content: InteractionContent::Response {
+                    status: ResponseStatus::Completed,
+                    result: serde_json::json!({"ok": true}),
+                    in_reply_to,
+                },
+                id,
+                rendered_text: String::new(),
+                handling_mode: meerkat_core::types::HandlingMode::Queue,
+                render_metadata: None,
+            },
+            ingress: PeerIngressFact::peer(
+                id,
+                PeerInputClass::ResponseTerminal,
+                meerkat_core::PeerIngressKind::Response,
+                Some(meerkat_core::PeerIngressAuthDecision::Required),
+                PeerIngressIdentity::new(
+                    test_peer_id(),
+                    "peer-1",
+                    PeerIngressConvention::Response {
+                        in_reply_to,
+                        status: ResponseStatus::Completed,
+                    },
+                ),
+            ),
+            lifecycle_peer: None,
+            response_terminality: None,
+        };
+
+        let result =
+            classified_interaction_to_runtime_input(&classified, &LogicalRuntimeId::new("test"));
+        assert!(
+            matches!(
+                result,
+                Err(PeerIngressProjectionError::MissingResponseTerminality { interaction_id })
+                    if interaction_id == id
+            ),
+            "runtime projection must not infer public terminality from raw status: {result:?}"
+        );
     }
 
     #[test]

--- a/meerkat/src/factory.rs
+++ b/meerkat/src/factory.rs
@@ -1594,6 +1594,10 @@ impl AgentFactory {
     /// peer-to-peer addressing.
     #[cfg(feature = "comms")]
     pub fn with_comms_runtime(mut self, runtime: Arc<meerkat_comms::CommsRuntime>) -> Self {
+        // A factory-owned runtime can later be wired into `SessionOwned`
+        // builds, so local compatibility classification must be inert as soon
+        // as the runtime enters this surface.
+        runtime.require_peer_comms_machine_authority();
         self.comms_runtime = Some(runtime);
         self
     }
@@ -3080,6 +3084,27 @@ impl AgentFactory {
             session.set_metadata(key, value.clone());
         }
         let _session_id = session.id().to_string();
+        use meerkat_core::runtime_epoch::RuntimeBuildMode;
+
+        let resolved_mode = &build_config.runtime_build_mode;
+        if let RuntimeBuildMode::SessionOwned(bindings) = resolved_mode {
+            if !meerkat_runtime::session_runtime_bindings_have_machine_authority(bindings) {
+                return Err(BuildAgentError::Config(
+                    "SessionRuntimeBindings were not prepared by MeerkatMachine; \
+                     session-owned runtime builds must use MeerkatMachine::prepare_bindings"
+                        .to_string(),
+                ));
+            }
+            if bindings.session_id() != session.id() {
+                return Err(BuildAgentError::Config(format!(
+                    "SessionRuntimeBindings.session_id ({}) does not match session ({}); \
+                     bindings may have been prepared for a different session",
+                    bindings.session_id(),
+                    session.id(),
+                )));
+            }
+        }
+
         // 6b. Create comms runtime before tool wiring.
         // If the factory has a pre-built runtime (surface with stable identity),
         // use it directly. Otherwise create a per-session runtime from config.
@@ -3179,6 +3204,16 @@ impl AgentFactory {
         #[allow(clippy::no_effect_underscore_binding)]
         let _comms_runtime: Option<()> = None;
 
+        #[cfg(feature = "comms")]
+        if let RuntimeBuildMode::SessionOwned(bindings) = resolved_mode
+            && let Some(runtime) = &comms_runtime
+        {
+            // Close the runtime-backed ingress window before any later build
+            // work can interleave with already-started shared listeners.
+            runtime.require_peer_comms_machine_authority();
+            runtime.install_peer_comms_handle(Arc::clone(bindings.peer_comms()));
+        }
+
         // Resolve model profile for capability gating and runtime defaults.
         let _image_tool_results = model_profile.as_ref().is_none_or(|p| p.image_tool_results);
 
@@ -3201,31 +3236,12 @@ impl AgentFactory {
             }
         }
         // Resolve ops lifecycle registry via RuntimeBuildMode.
-        use meerkat_core::runtime_epoch::RuntimeBuildMode;
-
-        let resolved_mode = &build_config.runtime_build_mode;
-
         #[allow(unused_variables)]
         let (ops_lifecycle, concrete_ops_lifecycle): (
             Arc<dyn OpsLifecycleRegistry>,
             Option<Arc<RuntimeOpsLifecycleRegistry>>,
-        ) = match &resolved_mode {
+        ) = match resolved_mode {
             RuntimeBuildMode::SessionOwned(bindings) => {
-                if !meerkat_runtime::session_runtime_bindings_have_machine_authority(bindings) {
-                    return Err(BuildAgentError::Config(
-                        "SessionRuntimeBindings were not prepared by MeerkatMachine; \
-                         session-owned runtime builds must use MeerkatMachine::prepare_bindings"
-                            .to_string(),
-                    ));
-                }
-                if bindings.session_id() != session.id() {
-                    return Err(BuildAgentError::Config(format!(
-                        "SessionRuntimeBindings.session_id ({}) does not match session ({}); \
-                         bindings may have been prepared for a different session",
-                        bindings.session_id(),
-                        session.id(),
-                    )));
-                }
                 (Arc::clone(bindings.ops_lifecycle()), None)
             }
             RuntimeBuildMode::StandaloneEphemeral => {
@@ -3301,13 +3317,6 @@ impl AgentFactory {
         if let RuntimeBuildMode::SessionOwned(bindings) = resolved_mode {
             tools.bind_external_tool_surface_handle(Arc::clone(bindings.external_tool_surface()));
             tools.bind_mcp_server_lifecycle_handle(Arc::clone(bindings.mcp_server_lifecycle()));
-            // LUC-104: classified comms ingress must hand raw external/plain
-            // ingress through the session's MeerkatMachine before the comms
-            // shell computes compatibility auth/routing projections.
-            #[cfg(feature = "comms")]
-            if let Some(runtime) = &comms_runtime {
-                runtime.install_peer_comms_handle(Arc::clone(bindings.peer_comms()));
-            }
             // W1-A/U6: install the typed machine authority required before
             // comms can emit semantic peer request/response receipts.
             #[cfg(feature = "comms")]
@@ -6622,6 +6631,51 @@ mod tests {
         assert!(
             caps.iter().any(|cap| cap.as_str() == "comms"),
             "per-session comms identity should expose comms capability to skills"
+        );
+    }
+
+    #[cfg(all(feature = "comms", not(target_arch = "wasm32")))]
+    #[tokio::test]
+    async fn session_owned_shared_comms_runtime_is_marked_machine_required() {
+        let temp = tempfile::tempdir().unwrap();
+        let shared_name = format!("shared-session-owned-{}", meerkat_core::SessionId::new());
+        let shared_runtime =
+            Arc::new(meerkat_comms::CommsRuntime::inproc_only(&shared_name).unwrap());
+        assert!(!shared_runtime.peer_comms_machine_authority_required());
+        assert!(shared_runtime.peer_comms_handle().is_none());
+
+        let session = Session::new();
+        let runtime = meerkat_runtime::MeerkatMachine::ephemeral();
+        let bindings = runtime
+            .prepare_bindings(session.id().clone())
+            .await
+            .expect("session runtime bindings");
+        let mut build = AgentBuildConfig::new("gpt-5.4");
+        build.llm_client_override = Some(Arc::new(meerkat_client::TestClient::default()));
+        build.resume_session = Some(session);
+        build.runtime_build_mode = meerkat_core::RuntimeBuildMode::SessionOwned(bindings);
+        build.override_builtins = ToolCategoryOverride::Disable;
+
+        let factory = AgentFactory::new(temp.path().join("sessions"))
+            .builtins(false)
+            .with_comms_runtime(Arc::clone(&shared_runtime));
+        assert!(
+            shared_runtime.peer_comms_machine_authority_required(),
+            "factory attachment must fail closed before a session-owned build can install machine authority"
+        );
+
+        let _agent = factory
+            .build_agent(build, &Config::default())
+            .await
+            .expect("session-owned build should succeed");
+
+        assert!(
+            shared_runtime.peer_comms_machine_authority_required(),
+            "shared runtime must fail closed before any session-owned ingress can use local classifier authority"
+        );
+        assert!(
+            shared_runtime.peer_comms_handle().is_some(),
+            "session-owned shared runtime should install the PeerComms machine handle"
         );
     }
 

--- a/meerkat/src/sdk.rs
+++ b/meerkat/src/sdk.rs
@@ -454,65 +454,72 @@ pub async fn build_comms_runtime_from_config_scoped_with_silent_intents(
         })
         .transpose()?;
 
-    let runtime = match config.comms.mode {
-        CommsRuntimeMode::Inproc => CommsRuntime::inproc_only_with_silent_intents(
-            comms_name,
-            inproc_namespace.clone(),
-            silent_intents.clone(),
-        )
-        .map_err(|e| format!("Failed to create inproc comms runtime: {e}"))?,
-        CommsRuntimeMode::Tcp => {
-            let address = config
-                .comms
-                .address
-                .as_ref()
-                .ok_or_else(|| "comms.address is required when comms.mode = tcp".to_string())?;
-            let listen_tcp = address
-                .parse()
-                .map_err(|e| format!("Invalid comms TCP address '{address}': {e}"))?;
-            let comms = CoreCommsConfig {
-                enabled: true,
-                name: comms_name.to_string(),
-                inproc_namespace: inproc_namespace.clone(),
-                listen_tcp: Some(listen_tcp),
-                auth: config.comms.auth,
-                event_listen_tcp,
-                ..Default::default()
-            };
-            let resolved = comms.resolve_paths(base_dir.as_ref());
-            let mut rt = CommsRuntime::new_with_silent_intents(resolved, silent_intents.clone())
+    let runtime =
+        match config.comms.mode {
+            CommsRuntimeMode::Inproc => CommsRuntime::inproc_only_with_silent_intents(
+                comms_name,
+                inproc_namespace.clone(),
+                silent_intents.clone(),
+            )
+            .map_err(|e| format!("Failed to create inproc comms runtime: {e}"))?,
+            CommsRuntimeMode::Tcp => {
+                let address =
+                    config.comms.address.as_ref().ok_or_else(|| {
+                        "comms.address is required when comms.mode = tcp".to_string()
+                    })?;
+                let listen_tcp = address
+                    .parse()
+                    .map_err(|e| format!("Invalid comms TCP address '{address}': {e}"))?;
+                let comms = CoreCommsConfig {
+                    enabled: true,
+                    name: comms_name.to_string(),
+                    inproc_namespace: inproc_namespace.clone(),
+                    listen_tcp: Some(listen_tcp),
+                    auth: config.comms.auth,
+                    event_listen_tcp,
+                    ..Default::default()
+                };
+                let resolved = comms.resolve_paths(base_dir.as_ref());
+                let mut rt = CommsRuntime::new_machine_authority_required_with_silent_intents(
+                    resolved,
+                    silent_intents.clone(),
+                )
                 .await
                 .map_err(|e| format!("Failed to create comms runtime: {e}"))?;
-            rt.start_listeners()
-                .await
-                .map_err(|e| format!("Failed to start comms listeners: {e}"))?;
-            rt
-        }
-        CommsRuntimeMode::Uds => {
-            let address = config
-                .comms
-                .address
-                .as_ref()
-                .ok_or_else(|| "comms.address is required when comms.mode = uds".to_string())?;
-            let comms = CoreCommsConfig {
-                enabled: true,
-                name: comms_name.to_string(),
-                inproc_namespace: inproc_namespace.clone(),
-                listen_uds: Some(std::path::PathBuf::from(address)),
-                auth: config.comms.auth,
-                event_listen_tcp,
-                ..Default::default()
-            };
-            let resolved = comms.resolve_paths(base_dir.as_ref());
-            let mut rt = CommsRuntime::new_with_silent_intents(resolved, silent_intents.clone())
+                rt.start_listeners()
+                    .await
+                    .map_err(|e| format!("Failed to start comms listeners: {e}"))?;
+                rt
+            }
+            CommsRuntimeMode::Uds => {
+                let address =
+                    config.comms.address.as_ref().ok_or_else(|| {
+                        "comms.address is required when comms.mode = uds".to_string()
+                    })?;
+                let comms = CoreCommsConfig {
+                    enabled: true,
+                    name: comms_name.to_string(),
+                    inproc_namespace: inproc_namespace.clone(),
+                    listen_uds: Some(std::path::PathBuf::from(address)),
+                    auth: config.comms.auth,
+                    event_listen_tcp,
+                    ..Default::default()
+                };
+                let resolved = comms.resolve_paths(base_dir.as_ref());
+                let mut rt = CommsRuntime::new_machine_authority_required_with_silent_intents(
+                    resolved,
+                    silent_intents.clone(),
+                )
                 .await
                 .map_err(|e| format!("Failed to create comms runtime: {e}"))?;
-            rt.start_listeners()
-                .await
-                .map_err(|e| format!("Failed to start comms listeners: {e}"))?;
-            rt
-        }
-    };
+                rt.start_listeners()
+                    .await
+                    .map_err(|e| format!("Failed to start comms listeners: {e}"))?;
+                rt
+            }
+        };
+
+    runtime.require_peer_comms_machine_authority();
 
     if let Some(meta) = peer_meta {
         runtime.set_peer_meta(meta);
@@ -574,9 +581,12 @@ pub async fn build_session_scoped_comms_runtime_from_config_scoped_with_silent_i
                 ..Default::default()
             };
             let resolved = comms.resolve_paths(base_dir.as_ref());
-            let mut rt = CommsRuntime::new_with_silent_intents(resolved, silent_intents.clone())
-                .await
-                .map_err(|e| format!("Failed to create comms runtime: {e}"))?;
+            let mut rt = CommsRuntime::new_machine_authority_required_with_silent_intents(
+                resolved,
+                silent_intents.clone(),
+            )
+            .await
+            .map_err(|e| format!("Failed to create comms runtime: {e}"))?;
             rt.start_listeners()
                 .await
                 .map_err(|e| format!("Failed to start comms listeners: {e}"))?;
@@ -598,9 +608,12 @@ pub async fn build_session_scoped_comms_runtime_from_config_scoped_with_silent_i
                 ..Default::default()
             };
             let resolved = comms.resolve_paths(base_dir.as_ref());
-            let mut rt = CommsRuntime::new_with_silent_intents(resolved, silent_intents.clone())
-                .await
-                .map_err(|e| format!("Failed to create comms runtime: {e}"))?;
+            let mut rt = CommsRuntime::new_machine_authority_required_with_silent_intents(
+                resolved,
+                silent_intents.clone(),
+            )
+            .await
+            .map_err(|e| format!("Failed to create comms runtime: {e}"))?;
             rt.start_listeners()
                 .await
                 .map_err(|e| format!("Failed to start comms listeners: {e}"))?;
@@ -665,6 +678,111 @@ mod tests {
         HookRuntimeKind,
     };
     use std::path::Path;
+
+    #[cfg(all(feature = "comms", not(target_arch = "wasm32")))]
+    fn trusted_descriptor(
+        name: &str,
+        pubkey: meerkat_comms::identity::PubKey,
+        address: meerkat_core::comms::PeerAddress,
+    ) -> meerkat_core::comms::TrustedPeerDescriptor {
+        meerkat_core::comms::TrustedPeerDescriptor {
+            peer_id: pubkey.to_peer_id(),
+            name: meerkat_core::comms::PeerName::new(name.to_string()).expect("valid peer name"),
+            address,
+            pubkey: *pubkey.as_bytes(),
+        }
+    }
+
+    #[cfg(all(feature = "comms", not(target_arch = "wasm32")))]
+    fn peer_route(
+        name: &str,
+        pubkey: meerkat_comms::identity::PubKey,
+    ) -> meerkat_core::comms::PeerRoute {
+        meerkat_core::comms::PeerRoute::with_display_name(
+            pubkey.to_peer_id(),
+            meerkat_core::comms::PeerName::new(name.to_string()).expect("valid peer name"),
+        )
+    }
+
+    #[cfg(all(feature = "comms", not(target_arch = "wasm32")))]
+    #[tokio::test]
+    async fn sdk_tcp_runtime_fails_closed_before_session_machine_handle() {
+        use meerkat_core::agent::CommsRuntime as CoreCommsRuntime;
+        use meerkat_core::comms::CommsCommand;
+
+        let temp = tempfile::tempdir().expect("tempdir");
+        let suffix = meerkat_core::SessionId::new().to_string();
+        let sender_name = format!("sdk-pre-authority-sender-{suffix}");
+        let receiver_name = format!("sdk-pre-authority-receiver-{suffix}");
+        let sender = CommsRuntime::inproc_only(&sender_name).expect("sender runtime");
+        let mut config = Config::default();
+        config.comms.mode = CommsRuntimeMode::Tcp;
+        config.comms.address = Some("127.0.0.1:0".to_string());
+
+        let receiver = build_comms_runtime_from_config(&config, temp.path(), &receiver_name, None)
+            .await
+            .expect("sdk tcp runtime");
+
+        assert!(
+            receiver.peer_comms_machine_authority_required(),
+            "public SDK listener runtimes must fail closed before a session-owned build installs machine authority"
+        );
+        assert!(
+            receiver.peer_comms_handle().is_none(),
+            "fixture must prove the pre-handle ingress path is closed"
+        );
+
+        CoreCommsRuntime::add_trusted_peer(
+            &sender,
+            trusted_descriptor(
+                &receiver_name,
+                receiver.public_key(),
+                meerkat_core::comms::PeerAddress::new(
+                    meerkat_core::comms::PeerTransport::Inproc,
+                    receiver_name.clone(),
+                ),
+            ),
+        )
+        .await
+        .expect("sender trusts receiver");
+        CoreCommsRuntime::add_trusted_peer(
+            &receiver,
+            trusted_descriptor(
+                &sender_name,
+                sender.public_key(),
+                meerkat_core::comms::PeerAddress::new(
+                    meerkat_core::comms::PeerTransport::Inproc,
+                    sender_name.clone(),
+                ),
+            ),
+        )
+        .await
+        .expect("receiver trusts sender");
+
+        let result = CoreCommsRuntime::send(
+            &sender,
+            CommsCommand::PeerMessage {
+                blocks: None,
+                to: peer_route(&receiver_name, receiver.public_key()),
+                body: "must not pass sdk compatibility classifier".to_string(),
+                handling_mode: meerkat_core::types::HandlingMode::Queue,
+            },
+        )
+        .await;
+
+        assert!(matches!(
+            result,
+            Err(meerkat_core::comms::SendError::AdmissionDropped {
+                reason: meerkat_core::comms::AdmissionDropReason::ClassificationRejected
+            })
+        ));
+        assert!(
+            CoreCommsRuntime::drain_inbox_interactions(&receiver)
+                .await
+                .is_empty(),
+            "pre-handle SDK-built runtime must not enqueue peer ingress"
+        );
+    }
 
     async fn dispatch_json(
         dispatcher: &dyn AgentToolDispatcher,


### PR DESCRIPTION
## Summary
- Deletes the raw inbox auth-exemption classifier path by removing `ingress_auth_decision`; raw external ingress now stays auth-required unless routed through classified machine authority.
- Requires public SDK-built comms runtimes to fail closed before reuse by runtime-backed agents: TCP/UDS use the machine-required constructor before listeners start, inproc SDK runtimes are marked required before return, and `AgentFactory::with_comms_runtime` marks direct shared runtimes required at attachment.
- Adds runtime-required fail-closed fixtures for auth-exempt, lifecycle, response terminality, plain-event ingress, listener-before-authority, shared-runtime-before-handle, and the public SDK shared-runtime pre-handle gap.
- Requires runtime peer response projection to consume carried `response_terminality`; missing typed terminality now fails closed instead of re-inferring from raw status.
- Branch is current with `origin/main`; landed persistent destroy DSL-authority guard code stays present and the PR diff has no persistent-driver rollback.

## Validation
- `./scripts/repo-cargo test -p meerkat-runtime direct_destroy_rejects_before_persisting_when_dsl_guard_rejects --test driver_persistent`
- `./scripts/repo-cargo test -p meerkat-comms classify --lib`
- `./scripts/repo-cargo test -p meerkat-comms inbox --lib`
- `./scripts/repo-cargo test -p meerkat-comms machine_required_tcp_runtime_rejects_ingress_before_handle_or_listener_start --lib`
- `./scripts/repo-cargo test -p meerkat-runtime comms_bridge --lib`
- `./scripts/repo-cargo test -p meerkat --features comms sdk_tcp_runtime_fails_closed_before_session_machine_handle --lib`
- `./scripts/repo-cargo test -p meerkat --features comms session_owned_shared_comms_runtime_is_marked_machine_required --lib`
- `./scripts/repo-cargo test -p meerkat --features comms sdk::tests --lib`
- `git diff --check origin/main...HEAD`
- `python3 scripts/dogma_cleanup_gate.py --repo . --base origin/main --packet <packet>`
- `MEERKAT_BUILDBUDDY=1 make check` via BuildBuddy invocation `011756a3-b80f-42ac-b2e1-5e6603df93fc`

## Review Readiness Packet
Linear: LUC-343
Current head SHA: `f97ad7508974e7865fcaf3ecb4c66511327c0082`
Canonical owner after this PR: runtime/machine peer-ingress authority owns touched peer ingress classification, lifecycle intent, auth exemption, and response terminality.
Current base: `origin/main` at `bbfe4171d` when this packet was prepared.
Persistent destroy note: branch diff has no persistent-driver files; production `destroy()` still calls `apply_destroy_dsl_authority()` from current `main`.
Command output:
```text
git diff --stat origin/main...HEAD
meerkat-comms/src/classify.rs              | 164 ++++++++++++++++++++
meerkat-comms/src/inbox.rs                 | 101 +++++-------
meerkat-comms/src/runtime/comms_runtime.rs |  99 +++++++++++-
meerkat-core/src/interaction.rs            |  16 +-
meerkat-runtime/src/comms_bridge.rs        | 155 ++++++++++++-------
meerkat/src/factory.rs                     | 108 +++++++++----
meerkat/src/sdk.rs                         | 240 +++++++++++++++++++++--------
7 files changed, 670 insertions(+), 213 deletions(-)
```

## Old Path Amputation Proof
| Old path | Classification | Search literal | Mechanical proof | Follow-up |
| --- | --- | --- | --- | --- |
| `meerkat-comms/src/inbox.rs::ingress_auth_decision` | Deleted | `ingress_auth_decision` | Symbol deleted from production source; raw `send_connection_ingress` no longer calls `PeerIngressMachinePolicy`, so auth-exemption access through that helper is not callable. | None |
| `meerkat/src/sdk.rs` listener/public old constructor call `CommsRuntime::new_with_silent_intents(resolved, silent_intents.clone())` | Deleted | `CommsRuntime::new_with_silent_intents(resolved, silent_intents.clone())` | Old listener construction line deleted from production SDK source; TCP/UDS listener runtimes now use machine-required construction before listener start, so pre-handle access is rejected. | None |
| `meerkat/src/factory.rs` late install block marker `LUC-104: classified comms ingress must hand raw external/plain` | Deleted | `LUC-104: classified comms ingress must hand raw external/plain` | Late install block marker deleted from production factory source; direct shared runtime attachment now requires machine authority before storage, so pre-handle access is rejected. | None |

## Complexity Delta
- Docs/scripts/tests: 0 standalone docs/scripts/test files in the PR diff; regression coverage is in crate-local Rust unit tests inside touched source files.
- Non-test implementation: 7 Rust source files, +670/-213 in the PR diff at current head.
- Generated/schema churn: 0 generated/schema files.

## Sample Passing Old Path Amputation Proof
- Example passing row: old path names the removed helper, classification is `Deleted`, search literal names the helper, and proof cites deleted symbol plus production call-boundary removal.

## Sample Failing Old Path Amputation Proof
- Example failing row: classification claims cleanup while proof says old calls stay callable for a later migration.