### PR TITLE
LUC-340 fail closed WASM subscription serialization

### DIFF
--- a/meerkat-web-runtime/src/lib.rs
+++ b/meerkat-web-runtime/src/lib.rs
@@ -2278,6 +2278,8 @@ enum SubscriptionInner {
     /// Mob-wide attributed event receiver from the event router.
     /// The entire handle is stored to keep the router task alive (Drop cancels it).
     MobWide(std::cell::RefCell<meerkat_mob::MobEventRouterHandle>),
+    #[cfg(all(test, target_arch = "wasm32"))]
+    InjectedProjectionFailure,
 }
 
 /// Per-subscription state wrapping the inner receiver.
@@ -2395,6 +2397,8 @@ pub async fn mob_subscribe_events(mob_id: &str) -> Result<u32, JsValue> {
 ///
 /// Returns a JSON array of event objects. Drains all buffered events
 /// since the last poll. Non-blocking: returns `[]` if no new events.
+/// If any buffered event cannot be projected to JSON, returns a typed
+/// `serialize_error` instead of silently omitting the event.
 ///
 /// For per-member subscriptions (`mob_member_subscribe`), returns
 /// `EventEnvelope<AgentEvent>` objects. For mob-wide subscriptions
@@ -2418,10 +2422,10 @@ pub fn poll_subscription(handle: u32) -> Result<String, JsValue> {
                 let mut rx = rx_cell.borrow_mut();
                 loop {
                     match rx.try_recv() {
-                        Ok(event) => match serde_json::to_value(&event) {
-                            Ok(val) => events.push(val),
-                            Err(e) => tracing::warn!(error = %e, "failed to serialize agent event"),
-                        },
+                        Ok(event) => events.push(
+                            serialize_subscription_item(&event, "subscription agent event")
+                                .map_err(|message| err_js("serialize_error", &message))?,
+                        ),
                         Err(TryRecvError::Lagged(n)) => {
                             tracing::warn!(skipped = n, "subscription lagged");
                             events.push(serde_json::json!({
@@ -2437,17 +2441,43 @@ pub fn poll_subscription(handle: u32) -> Result<String, JsValue> {
             SubscriptionInner::MobWide(handle_cell) => {
                 let mut router_handle = handle_cell.borrow_mut();
                 while let Ok(attributed) = router_handle.event_rx.try_recv() {
-                    match serde_json::to_value(&attributed) {
-                        Ok(val) => events.push(val),
-                        Err(e) => {
-                            tracing::warn!(error = %e, "failed to serialize attributed event");
-                        }
+                    events.push(
+                        serialize_subscription_item(&attributed, "subscription attributed event")
+                            .map_err(|message| err_js("serialize_error", &message))?,
+                    );
+                }
+            }
+            #[cfg(all(test, target_arch = "wasm32"))]
+            SubscriptionInner::InjectedProjectionFailure => {
+                struct FailingProjection;
+
+                impl Serialize for FailingProjection {
+                    fn serialize<S>(&self, _serializer: S) -> Result<S::Ok, S::Error>
+                    where
+                        S: serde::Serializer,
+                    {
+                        Err(serde::ser::Error::custom("injected projection failure"))
                     }
                 }
+
+                events.push(
+                    serialize_subscription_item(
+                        &FailingProjection,
+                        "subscription injected test event",
+                    )
+                    .map_err(|message| err_js("serialize_error", &message))?,
+                );
             }
         }
         serde_json::to_string(&events).map_err(|e| err_str("serialize_error", e))
     })
+}
+
+fn serialize_subscription_item<T: Serialize + ?Sized>(
+    item: &T,
+    projection: &str,
+) -> Result<serde_json::Value, String> {
+    serde_json::to_value(item).map_err(|e| format!("failed to serialize {projection}: {e}"))
 }
 
 /// Close a subscription and free resources.
@@ -2470,7 +2500,7 @@ mod tests {
     use super::{
         EventSubscription, SUBSCRIPTIONS, SubscriptionInner, close_subscription,
         merge_runtime_system_context_state, parse_mob_lifecycle_action_arg, parse_mobpack,
-        poll_subscription,
+        poll_subscription, serialize_subscription_item,
     };
     #[cfg(target_arch = "wasm32")]
     use super::{
@@ -2994,6 +3024,98 @@ capabilities = [{capability_values}]
 
         destroy_session(handle).expect("destroy session");
         assert!(get_session_state(handle).is_err());
+    }
+
+    #[test]
+    fn poll_subscription_empty_success_is_clean_empty_array() {
+        let (_tx, rx) = crate::tokio::sync::broadcast::channel(1);
+
+        let handle = SUBSCRIPTIONS.with(|cell| {
+            let mut registry = cell.borrow_mut();
+            let handle = registry.next_handle;
+            registry.next_handle = registry.next_handle.wrapping_add(1);
+            registry.subscriptions.insert(
+                handle,
+                EventSubscription {
+                    inner: SubscriptionInner::Member(std::cell::RefCell::new(rx)),
+                },
+            );
+            handle
+        });
+
+        let payload = poll_subscription(handle).expect("empty poll should succeed");
+        let parsed: serde_json::Value =
+            serde_json::from_str(&payload).expect("empty poll should be json");
+        assert_eq!(
+            parsed.as_array().map(Vec::len),
+            Some(0),
+            "clean empty poll must remain a successful empty array"
+        );
+
+        let close_result = close_subscription(handle);
+        assert!(close_result.is_ok());
+    }
+
+    #[test]
+    fn serialize_subscription_item_reports_projection_failure() {
+        struct FailingProjection;
+
+        impl serde::Serialize for FailingProjection {
+            fn serialize<S>(&self, _serializer: S) -> Result<S::Ok, S::Error>
+            where
+                S: serde::Serializer,
+            {
+                Err(serde::ser::Error::custom("injected projection failure"))
+            }
+        }
+
+        let error =
+            serialize_subscription_item(&FailingProjection, "subscription injected test event")
+                .expect_err("projection failure should be reported");
+
+        assert!(
+            error.contains("failed to serialize subscription injected test event"),
+            "projection failure should name the failed subscription projection"
+        );
+        assert!(
+            error.contains("injected projection failure"),
+            "projection failure should preserve the serialization cause"
+        );
+    }
+
+    #[cfg(target_arch = "wasm32")]
+    #[wasm_bindgen_test::wasm_bindgen_test]
+    #[allow(clippy::expect_used)]
+    fn poll_subscription_fails_closed_when_projection_serialization_fails() {
+        let handle = SUBSCRIPTIONS.with(|cell| {
+            let mut registry = cell.borrow_mut();
+            let handle = registry.next_handle;
+            registry.next_handle = registry.next_handle.wrapping_add(1);
+            registry.subscriptions.insert(
+                handle,
+                EventSubscription {
+                    inner: SubscriptionInner::InjectedProjectionFailure,
+                },
+            );
+            handle
+        });
+
+        let error =
+            poll_subscription(handle).expect_err("projection failure must fail public poll");
+        let error_json = error.as_string().expect("typed error json");
+        let parsed: serde_json::Value =
+            serde_json::from_str(&error_json).expect("typed error should be json");
+        assert_eq!(parsed["code"], "serialize_error");
+        assert!(
+            parsed["message"]
+                .as_str()
+                .unwrap_or_default()
+                .contains("injected projection failure"),
+            "projection failure should surface the serialization cause"
+        );
+
+        let close_result = close_subscription(handle);
+        assert!(close_result.is_ok());
     }
 
     #[test]

--- a/meerkat-web-runtime/src/lib.rs
+++ b/meerkat-web-runtime/src/lib.rs
@@ -3083,6 +3083,42 @@ capabilities = [{capability_values}]
         );
     }
 
+    #[allow(clippy::expect_used)]
+    #[test]
+    fn attributed_subscription_item_serializes_runtime_id_source_shape() {
+        let source = meerkat_mob::AgentRuntimeId::new(
+            meerkat_mob::AgentIdentity::from("worker-runtime"),
+            meerkat_mob::Generation::new(3),
+        );
+        let attributed = meerkat_mob::AttributedEvent {
+            source,
+            source_fence_token: meerkat_mob::FenceToken::new(9),
+            role: meerkat_mob::ProfileName::from("worker"),
+            envelope: meerkat_core::EventEnvelope::new(
+                "worker-runtime",
+                7,
+                Some("mob-web-unit".to_string()),
+                meerkat_core::AgentEvent::TextDelta {
+                    delta: "hello".to_string(),
+                },
+            ),
+        };
+
+        let parsed = serialize_subscription_item(&attributed, "subscription attributed event")
+            .expect("canonical attributed subscription event should serialize");
+
+        assert!(
+            parsed["source"].as_str().is_none(),
+            "AgentRuntimeId source must not be projected as a lossy string"
+        );
+        assert_eq!(parsed["source"]["identity"], "worker-runtime");
+        assert_eq!(parsed["source"]["generation"], 3);
+        assert_eq!(parsed["source_fence_token"], 9);
+        assert_eq!(parsed["role"], "worker");
+        assert_eq!(parsed["envelope"]["payload"]["type"], "text_delta");
+        assert_eq!(parsed["envelope"]["payload"]["delta"], "hello");
+    }
+
     #[cfg(target_arch = "wasm32")]
     #[wasm_bindgen_test::wasm_bindgen_test]
     #[allow(clippy::expect_used)]

--- a/sdks/web/src/events.ts
+++ b/sdks/web/src/events.ts
@@ -3,12 +3,12 @@ export class EventSubscription<T> {
   private closed = false;
   private readonly pollSource: () => string;
   private readonly closeSource: () => void;
-  private readonly parseEvents: (raw: unknown) => T[];
+  private readonly parseEvents: (raw: unknown[]) => T[];
 
   /** @internal — use Session.subscribe(), Member.subscribe(), Mob.subscribeMemberEvents(), or Mob.subscribeEvents(). */
   constructor(
     pollSource: () => string,
-    parseEvents: (raw: unknown) => T[],
+    parseEvents: (raw: unknown[]) => T[],
     closeSource: () => void = () => {},
   ) {
     this.pollSource = pollSource;
@@ -21,6 +21,9 @@ export class EventSubscription<T> {
     if (this.closed) return [];
     const json = this.pollSource();
     const parsed: unknown = JSON.parse(json);
+    if (!Array.isArray(parsed)) {
+      throw new Error('Invalid subscription poll response: expected event array');
+    }
     return this.parseEvents(parsed);
   }
 

--- a/sdks/web/src/mob.ts
+++ b/sdks/web/src/mob.ts
@@ -242,10 +242,7 @@ export class Member {
     const handle = await this.bindings.mob_member_subscribe(this.mobId, this.agentIdentity);
     return new EventSubscription<MemberEventItem>(
       () => this.bindings.poll_subscription(handle),
-      (raw) =>
-        Array.isArray(raw)
-          ? raw.map((item) => normalizeEventEnvelope(item, this.mobId))
-          : [],
+      (raw) => raw.map((item) => normalizeEventEnvelope(item, this.mobId)),
       () => this.bindings.close_subscription(handle),
     );
   }
@@ -586,10 +583,7 @@ export class Mob {
     const handle = await this.bindings.mob_member_subscribe(this.mobId, agentIdentity);
     return new EventSubscription<MemberEventItem>(
       () => this.bindings.poll_subscription(handle),
-      (raw) =>
-        Array.isArray(raw)
-          ? raw.map((item) => normalizeEventEnvelope(item, this.mobId))
-          : [],
+      (raw) => raw.map((item) => normalizeEventEnvelope(item, this.mobId)),
       () => this.bindings.close_subscription(handle),
     );
   }
@@ -599,10 +593,7 @@ export class Mob {
     const handle = await this.bindings.mob_subscribe_events(this.mobId);
     return new EventSubscription<AttributedEventItem>(
       () => this.bindings.poll_subscription(handle),
-      (raw) =>
-        Array.isArray(raw)
-          ? raw.map((item) => normalizeAttributedEvent(item, this.mobId))
-          : [],
+      (raw) => raw.map((item) => normalizeAttributedEvent(item, this.mobId)),
       () => this.bindings.close_subscription(handle),
     );
   }

--- a/sdks/web/src/mob.ts
+++ b/sdks/web/src/mob.ts
@@ -23,6 +23,7 @@ import type {
   MobMemberSnapshot,
   MobHelperResult,
   EventEnvelope,
+  AgentRuntimeId,
   SubscriptionLaggedEvent,
 } from './types.js';
 
@@ -177,6 +178,31 @@ function requireNumberField(
   return value;
 }
 
+function normalizeAgentRuntimeId(raw: unknown): AgentRuntimeId {
+  if (!isRecord(raw)) {
+    throw new Error('Invalid mob subscription event: missing source');
+  }
+  requireOnlyKeys(
+    raw,
+    ['identity', 'generation'],
+    'Invalid mob subscription event: malformed source',
+  );
+  const identity = requireStringField(
+    raw,
+    'identity',
+    'Invalid mob subscription event: source missing identity',
+  );
+  const generation = requireNumberField(
+    raw,
+    'generation',
+    'Invalid mob subscription event: source missing generation',
+  );
+  if (!Number.isInteger(generation) || generation < 0) {
+    throw new Error('Invalid mob subscription event: source generation must be a non-negative integer');
+  }
+  return { identity, generation };
+}
+
 function normalizeLaggedEvent(record: Record<string, unknown>): SubscriptionLaggedEvent {
   const skipped = record.skipped;
   if (typeof skipped !== 'number' || !Number.isFinite(skipped)) {
@@ -246,11 +272,7 @@ function normalizeAttributedEvent(raw: unknown): AttributedEventItem {
   }
 
   const attributed = {
-    source: requireStringField(
-      record,
-      'source',
-      'Invalid mob subscription event: missing source',
-    ),
+    source: normalizeAgentRuntimeId(record.source),
     role: requireStringField(
       record,
       'role',

--- a/sdks/web/src/mob.ts
+++ b/sdks/web/src/mob.ts
@@ -23,6 +23,7 @@ import type {
   MobMemberSnapshot,
   MobHelperResult,
   EventEnvelope,
+  SubscriptionLaggedEvent,
 } from './types.js';
 
 // WASM function signatures (bound at construction)
@@ -152,46 +153,123 @@ function normalizeSpawnManyEntry(raw: unknown, mobId: string): SpawnResult {
   };
 }
 
-function normalizeEventEnvelope(raw: unknown, mobId: string): MemberEventItem {
-  if (!raw || typeof raw !== 'object') {
-    return raw as MemberEventItem;
+function requireStringField(
+  record: Record<string, unknown>,
+  field: string,
+  message: string,
+): string {
+  const value = record[field];
+  if (typeof value !== 'string' || value.length === 0) {
+    throw new Error(message);
   }
-  const record = raw as Record<string, unknown>;
-  if (record.type === 'lagged') {
-    return raw as MemberEventItem;
+  return value;
+}
+
+function requireNumberField(
+  record: Record<string, unknown>,
+  field: string,
+  message: string,
+): number {
+  const value = record[field];
+  if (typeof value !== 'number' || !Number.isFinite(value)) {
+    throw new Error(message);
   }
-  const agentIdentity =
-    typeof record.agent_identity === 'string' && record.agent_identity.length > 0
-      ? record.agent_identity
-      : undefined;
+  return value;
+}
+
+function normalizeLaggedEvent(record: Record<string, unknown>): SubscriptionLaggedEvent {
+  const skipped = record.skipped;
+  if (typeof skipped !== 'number' || !Number.isFinite(skipped)) {
+    throw new Error('Invalid subscription lagged event: missing skipped count');
+  }
   return {
-    agent_identity: agentIdentity,
-    member_ref: agentIdentity ? encodeMemberRef(mobId, agentIdentity) : undefined,
-    cursor:
-      typeof record.cursor === 'string' || typeof record.cursor === 'number'
-        ? record.cursor
-        : undefined,
-    event:
-      record.event && typeof record.event === 'object'
-        ? (record.event as EventEnvelope['event'])
-        : { type: 'unknown' },
+    type: 'lagged',
+    skipped,
   };
 }
 
-function normalizeAttributedEvent(raw: unknown, mobId: string): AttributedEventItem {
-  if (!raw || typeof raw !== 'object') {
-    return raw as AttributedEventItem;
+function normalizeEventEnvelope(raw: unknown): MemberEventItem {
+  if (!isRecord(raw)) {
+    throw new Error('Invalid subscription event envelope: expected object');
   }
-  const record = raw as Record<string, unknown>;
+  const record = raw;
   if (record.type === 'lagged') {
-    return raw as AttributedEventItem;
+    return normalizeLaggedEvent(record);
   }
-  const envelope = normalizeEventEnvelope(record.envelope, mobId);
-  return {
-    source: typeof record.source === 'string' ? record.source : '',
-    role: typeof record.role === 'string' ? record.role : '',
-    envelope: envelope && 'event' in envelope ? envelope : { event: { type: 'unknown' } },
+  const payload = record.payload;
+  if (!isRecord(payload) || typeof payload.type !== 'string' || payload.type.length === 0) {
+    throw new Error('Invalid subscription event envelope: missing payload');
+  }
+
+  const envelope: EventEnvelope = {
+    event_id: requireStringField(
+      record,
+      'event_id',
+      'Invalid subscription event envelope: missing event_id',
+    ),
+    source_id: requireStringField(
+      record,
+      'source_id',
+      'Invalid subscription event envelope: missing source_id',
+    ),
+    seq: requireNumberField(
+      record,
+      'seq',
+      'Invalid subscription event envelope: missing seq',
+    ),
+    timestamp_ms: requireNumberField(
+      record,
+      'timestamp_ms',
+      'Invalid subscription event envelope: missing timestamp_ms',
+    ),
+    payload: payload as EventEnvelope['payload'],
   };
+
+  if (typeof record.mob_id === 'string' && record.mob_id.length > 0) {
+    envelope.mob_id = record.mob_id;
+  }
+
+  return envelope;
+}
+
+function normalizeAttributedEvent(raw: unknown): AttributedEventItem {
+  if (!isRecord(raw)) {
+    throw new Error('Invalid mob subscription event: expected object');
+  }
+  const record = raw;
+  if (record.type === 'lagged') {
+    return normalizeLaggedEvent(record);
+  }
+  const envelope = normalizeEventEnvelope(record.envelope);
+  if ('type' in envelope) {
+    throw new Error('Invalid mob subscription event: lagged envelope is not attributed event data');
+  }
+
+  const attributed = {
+    source: requireStringField(
+      record,
+      'source',
+      'Invalid mob subscription event: missing source',
+    ),
+    role: requireStringField(
+      record,
+      'role',
+      'Invalid mob subscription event: missing role',
+    ),
+    envelope,
+  };
+
+  if (
+    typeof record.source_fence_token === 'number'
+    && Number.isFinite(record.source_fence_token)
+  ) {
+    return {
+      ...attributed,
+      source_fence_token: record.source_fence_token,
+    };
+  }
+
+  return attributed;
 }
 
 /** Capability-bearing handle for one mob member. */
@@ -242,7 +320,7 @@ export class Member {
     const handle = await this.bindings.mob_member_subscribe(this.mobId, this.agentIdentity);
     return new EventSubscription<MemberEventItem>(
       () => this.bindings.poll_subscription(handle),
-      (raw) => raw.map((item) => normalizeEventEnvelope(item, this.mobId)),
+      (raw) => raw.map((item) => normalizeEventEnvelope(item)),
       () => this.bindings.close_subscription(handle),
     );
   }
@@ -583,7 +661,7 @@ export class Mob {
     const handle = await this.bindings.mob_member_subscribe(this.mobId, agentIdentity);
     return new EventSubscription<MemberEventItem>(
       () => this.bindings.poll_subscription(handle),
-      (raw) => raw.map((item) => normalizeEventEnvelope(item, this.mobId)),
+      (raw) => raw.map((item) => normalizeEventEnvelope(item)),
       () => this.bindings.close_subscription(handle),
     );
   }
@@ -593,7 +671,7 @@ export class Mob {
     const handle = await this.bindings.mob_subscribe_events(this.mobId);
     return new EventSubscription<AttributedEventItem>(
       () => this.bindings.poll_subscription(handle),
-      (raw) => raw.map((item) => normalizeAttributedEvent(item, this.mobId)),
+      (raw) => raw.map((item) => normalizeAttributedEvent(item)),
       () => this.bindings.close_subscription(handle),
     );
   }

--- a/sdks/web/src/session.ts
+++ b/sdks/web/src/session.ts
@@ -6,6 +6,7 @@ import type {
   SessionState,
   AppendSystemContextOptions,
   AppendSystemContextResult,
+  SubscriptionLaggedEvent,
 } from './types.js';
 
 // WASM function signatures (bound at construction)
@@ -17,6 +18,41 @@ type AppendSystemContextFn = (
   handle: number,
   request_json: string,
 ) => Promise<string>;
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function normalizeSessionLaggedEvent(record: Record<string, unknown>): SubscriptionLaggedEvent {
+  const skipped = record.skipped;
+  if (typeof skipped !== 'number' || !Number.isFinite(skipped)) {
+    throw new Error('Invalid session event: lagged event missing skipped count');
+  }
+  return {
+    type: 'lagged',
+    skipped,
+  };
+}
+
+function normalizeSessionEvent(raw: unknown): SessionEvent {
+  if (!isRecord(raw)) {
+    throw new Error('Invalid session event: expected object');
+  }
+  if (raw.type === 'lagged') {
+    return normalizeSessionLaggedEvent(raw);
+  }
+  if (typeof raw.type !== 'string' || raw.type.length === 0) {
+    throw new Error('Invalid session event: missing type');
+  }
+  return raw as unknown as SessionEvent;
+}
+
+function normalizeSessionEvents(raw: unknown): SessionEvent[] {
+  if (!Array.isArray(raw)) {
+    throw new Error('Invalid session poll response: expected event array');
+  }
+  return raw.map((item) => normalizeSessionEvent(item));
+}
 
 /** A direct (non-mob) agent session. */
 export class Session {
@@ -89,7 +125,7 @@ export class Session {
     if (this.destroyed) return [];
     const json = this.pollFn(this.handle);
     const parsed: unknown = JSON.parse(json);
-    return Array.isArray(parsed) ? (parsed as SessionEvent[]) : [];
+    return normalizeSessionEvents(parsed);
   }
 
   /**
@@ -103,7 +139,7 @@ export class Session {
     if (this.destroyed) throw new Error('Session has been destroyed');
     return new EventSubscription<SessionEvent>(
       () => (this.destroyed ? '[]' : this.pollFn(this.handle)),
-      (raw) => raw as SessionEvent[],
+      (raw) => raw.map((item) => normalizeSessionEvent(item)),
     );
   }
 

--- a/sdks/web/src/session.ts
+++ b/sdks/web/src/session.ts
@@ -103,7 +103,7 @@ export class Session {
     if (this.destroyed) throw new Error('Session has been destroyed');
     return new EventSubscription<SessionEvent>(
       () => (this.destroyed ? '[]' : this.pollFn(this.handle)),
-      (raw) => (Array.isArray(raw) ? (raw as SessionEvent[]) : []),
+      (raw) => raw as SessionEvent[],
     );
   }
 

--- a/sdks/web/src/types.ts
+++ b/sdks/web/src/types.ts
@@ -417,10 +417,12 @@ export interface MobHelperResult {
 
 /** Envelope wrapping an agent event with metadata. */
 export interface EventEnvelope {
-  agent_identity?: string;
-  member_ref?: MobMemberRef;
-  cursor?: string | number;
-  event: AgentEvent | { type: string; [key: string]: unknown };
+  event_id: string;
+  source_id: string;
+  seq: number;
+  mob_id?: string;
+  timestamp_ms: number;
+  payload: AgentEvent | { type: string; [key: string]: unknown };
 }
 
 /** Poll/subscribe lag sentinel emitted by the browser runtime. */
@@ -438,6 +440,7 @@ export type MemberEventItem = EventEnvelope | SubscriptionLaggedEvent;
 /** Attributed mob-wide event from mob subscriptions. */
 export interface AttributedEvent {
   source: string;
+  source_fence_token?: number;
   role: string;
   envelope: EventEnvelope;
 }

--- a/sdks/web/src/types.ts
+++ b/sdks/web/src/types.ts
@@ -437,9 +437,15 @@ export type SessionEvent = AgentEvent | SubscriptionLaggedEvent;
 /** Member subscription item from the browser runtime. */
 export type MemberEventItem = EventEnvelope | SubscriptionLaggedEvent;
 
+/** Runtime identity for one mob member incarnation. */
+export interface AgentRuntimeId {
+  identity: string;
+  generation: number;
+}
+
 /** Attributed mob-wide event from mob subscriptions. */
 export interface AttributedEvent {
-  source: string;
+  source: AgentRuntimeId;
   source_fence_token?: number;
   role: string;
   envelope: EventEnvelope;

--- a/sdks/web/tests/mob_payload.unit.mjs
+++ b/sdks/web/tests/mob_payload.unit.mjs
@@ -3,6 +3,7 @@ import test from 'node:test';
 
 import { Mob } from '../dist/mob.js';
 import { MeerkatRuntime } from '../dist/runtime.js';
+import { Session } from '../dist/session.js';
 
 function makeSubscriptionRuntime(overrides = {}) {
   return {
@@ -65,6 +66,17 @@ function makeSubscriptionMob(pollSubscription) {
     poll_subscription: pollSubscription,
     close_subscription: () => undefined,
   });
+}
+
+function makeDirectSession(pollEvents) {
+  return new Session(
+    7,
+    async () => '{}',
+    () => JSON.stringify({ session_id: 'session-web-unit', phase: 'idle' }),
+    () => undefined,
+    pollEvents,
+    async () => '{}',
+  );
 }
 
 test('Mob.spawn strips legacy generation and projects typed wasm spawn rows', async () => {
@@ -221,7 +233,10 @@ test('Mob.subscribeEvents projects canonical attributed WASM EventEnvelope paylo
     mob_id: 'mob-web-unit',
   });
   const attributed = {
-    source: 'worker-runtime',
+    source: {
+      identity: 'worker-runtime',
+      generation: 0,
+    },
     source_fence_token: 3,
     role: 'worker',
     envelope,
@@ -235,6 +250,7 @@ test('Mob.subscribeEvents projects canonical attributed WASM EventEnvelope paylo
   const items = subscription.poll();
 
   assert.deepEqual(items, [attributed]);
+  assert.deepEqual(items[0].source, { identity: 'worker-runtime', generation: 0 });
   assert.equal(items[0].envelope.payload.type, 'text_delta');
   assert.equal('event' in items[0].envelope, false);
 });
@@ -256,7 +272,10 @@ test('Mob subscriptions reject unrecognized event envelopes instead of fabricati
     }
     return JSON.stringify([
       {
-        source: 'worker-runtime',
+        source: {
+          identity: 'worker-runtime',
+          generation: 0,
+        },
         role: 'worker',
         envelope: legacyMemberEnvelope,
       },
@@ -268,6 +287,46 @@ test('Mob subscriptions reject unrecognized event envelopes instead of fabricati
 
   const mobSubscription = await mob.subscribeEvents();
   assert.throws(() => mobSubscription.poll(), /missing payload/);
+});
+
+test('Mob.subscribeEvents rejects legacy string sources instead of hiding runtime generation', async () => {
+  const mob = makeSubscriptionMob((handle) => {
+    assert.equal(handle, 2);
+    return JSON.stringify([
+      {
+        source: 'worker-runtime',
+        role: 'worker',
+        envelope: canonicalEnvelope({ mob_id: 'mob-web-unit' }),
+      },
+    ]);
+  });
+
+  const subscription = await mob.subscribeEvents();
+  assert.throws(() => subscription.poll(), /missing source/);
+});
+
+test('Session direct polling projects valid agent events', () => {
+  const event = {
+    type: 'text_delta',
+    delta: 'hello',
+  };
+  const session = makeDirectSession(() => JSON.stringify([event]));
+
+  assert.deepEqual(session.pollEvents(), [event]);
+  assert.deepEqual(session.subscribe().poll(), [event]);
+});
+
+test('Session direct polling rejects malformed output instead of clean empty success', () => {
+  const session = makeDirectSession(() => JSON.stringify({ events: [] }));
+
+  assert.throws(() => session.pollEvents(), /expected event array/);
+});
+
+test('Session direct polling rejects malformed event items', () => {
+  const session = makeDirectSession(() => JSON.stringify([{}]));
+
+  assert.throws(() => session.pollEvents(), /missing type/);
+  assert.throws(() => session.subscribe().poll(), /missing type/);
 });
 
 test('MeerkatRuntime keeps a clean empty subscription poll as empty success', async () => {

--- a/sdks/web/tests/mob_payload.unit.mjs
+++ b/sdks/web/tests/mob_payload.unit.mjs
@@ -2,6 +2,43 @@ import assert from 'node:assert/strict';
 import test from 'node:test';
 
 import { Mob } from '../dist/mob.js';
+import { MeerkatRuntime } from '../dist/runtime.js';
+
+function makeSubscriptionRuntime(overrides = {}) {
+  return {
+    default: async () => undefined,
+    runtime_version: () => '0.6.0',
+    init_runtime_from_config: () => JSON.stringify({ status: 'initialized' }),
+    destroy_runtime: () => undefined,
+    async mob_create(definitionJson) {
+      return JSON.parse(definitionJson).id;
+    },
+    async mob_subscribe_events() {
+      return 1;
+    },
+    poll_subscription() {
+      return '[]';
+    },
+    close_subscription: () => undefined,
+    ...overrides,
+  };
+}
+
+async function makeRuntimeMob(wasm) {
+  const runtime = await MeerkatRuntime.init(wasm, {
+    anthropicApiKey: 'sk-test',
+    model: 'claude-sonnet-4-5',
+  });
+  const mob = await runtime.createMob({
+    id: 'mob-web-unit',
+    profiles: {
+      worker: {
+        model: 'claude-sonnet-4-5',
+      },
+    },
+  });
+  return { runtime, mob };
+}
 
 test('Mob.spawn strips legacy generation and projects typed wasm spawn rows', async () => {
   let captured;
@@ -135,4 +172,45 @@ test('Mob.spawn rejects typed failed rows instead of projecting success', async 
     () => mob.spawn([{ profile: 'worker', agent_identity: 'worker-1' }]),
     /Mob spawn failed: profile missing/,
   );
+});
+
+test('MeerkatRuntime keeps a clean empty subscription poll as empty success', async () => {
+  const wasm = makeSubscriptionRuntime();
+  const { runtime, mob } = await makeRuntimeMob(wasm);
+  try {
+    const subscription = await mob.subscribeEvents();
+    assert.deepEqual(subscription.poll(), []);
+  } finally {
+    runtime.destroy();
+  }
+});
+
+test('MeerkatRuntime propagates subscription serialization failures', async () => {
+  const wasm = makeSubscriptionRuntime({
+    poll_subscription() {
+      throw new Error('serialize_error: failed to serialize subscription attributed event');
+    },
+  });
+  const { runtime, mob } = await makeRuntimeMob(wasm);
+  try {
+    const subscription = await mob.subscribeEvents();
+    assert.throws(() => subscription.poll(), /serialize_error/);
+  } finally {
+    runtime.destroy();
+  }
+});
+
+test('MeerkatRuntime rejects malformed subscription poll output', async () => {
+  const wasm = makeSubscriptionRuntime({
+    poll_subscription() {
+      return JSON.stringify({ events: [] });
+    },
+  });
+  const { runtime, mob } = await makeRuntimeMob(wasm);
+  try {
+    const subscription = await mob.subscribeEvents();
+    assert.throws(() => subscription.poll(), /expected event array/);
+  } finally {
+    runtime.destroy();
+  }
 });

--- a/sdks/web/tests/mob_payload.unit.mjs
+++ b/sdks/web/tests/mob_payload.unit.mjs
@@ -40,6 +40,33 @@ async function makeRuntimeMob(wasm) {
   return { runtime, mob };
 }
 
+function canonicalEnvelope(overrides = {}) {
+  return {
+    event_id: '00000000-0000-0000-0000-000000000001',
+    source_id: 'worker-runtime',
+    seq: 7,
+    timestamp_ms: 1710000000000,
+    payload: {
+      type: 'text_delta',
+      delta: 'hello',
+    },
+    ...overrides,
+  };
+}
+
+function makeSubscriptionMob(pollSubscription) {
+  return new Mob('mob-web-unit', {
+    async mob_member_subscribe() {
+      return 1;
+    },
+    async mob_subscribe_events() {
+      return 2;
+    },
+    poll_subscription: pollSubscription,
+    close_subscription: () => undefined,
+  });
+}
+
 test('Mob.spawn strips legacy generation and projects typed wasm spawn rows', async () => {
   let captured;
   const mob = new Mob('mob-web-unit', {
@@ -172,6 +199,75 @@ test('Mob.spawn rejects typed failed rows instead of projecting success', async 
     () => mob.spawn([{ profile: 'worker', agent_identity: 'worker-1' }]),
     /Mob spawn failed: profile missing/,
   );
+});
+
+test('Mob.subscribeMemberEvents projects canonical WASM EventEnvelope payloads', async () => {
+  const envelope = canonicalEnvelope();
+  const mob = makeSubscriptionMob((handle) => {
+    assert.equal(handle, 1);
+    return JSON.stringify([envelope]);
+  });
+
+  const subscription = await mob.subscribeMemberEvents('worker-1');
+  const items = subscription.poll();
+
+  assert.deepEqual(items, [envelope]);
+  assert.equal(items[0].payload.type, 'text_delta');
+  assert.equal('event' in items[0], false);
+});
+
+test('Mob.subscribeEvents projects canonical attributed WASM EventEnvelope payloads', async () => {
+  const envelope = canonicalEnvelope({
+    mob_id: 'mob-web-unit',
+  });
+  const attributed = {
+    source: 'worker-runtime',
+    source_fence_token: 3,
+    role: 'worker',
+    envelope,
+  };
+  const mob = makeSubscriptionMob((handle) => {
+    assert.equal(handle, 2);
+    return JSON.stringify([attributed]);
+  });
+
+  const subscription = await mob.subscribeEvents();
+  const items = subscription.poll();
+
+  assert.deepEqual(items, [attributed]);
+  assert.equal(items[0].envelope.payload.type, 'text_delta');
+  assert.equal('event' in items[0].envelope, false);
+});
+
+test('Mob subscriptions reject unrecognized event envelopes instead of fabricating unknown events', async () => {
+  const legacyMemberEnvelope = {
+    event_id: '00000000-0000-0000-0000-000000000001',
+    source_id: 'worker-runtime',
+    seq: 7,
+    timestamp_ms: 1710000000000,
+    event: {
+      type: 'text_delta',
+      delta: 'legacy',
+    },
+  };
+  const mob = makeSubscriptionMob((handle) => {
+    if (handle === 1) {
+      return JSON.stringify([legacyMemberEnvelope]);
+    }
+    return JSON.stringify([
+      {
+        source: 'worker-runtime',
+        role: 'worker',
+        envelope: legacyMemberEnvelope,
+      },
+    ]);
+  });
+
+  const memberSubscription = await mob.subscribeMemberEvents('worker-1');
+  assert.throws(() => memberSubscription.poll(), /missing payload/);
+
+  const mobSubscription = await mob.subscribeEvents();
+  assert.throws(() => mobSubscription.poll(), /missing payload/);
 });
 
 test('MeerkatRuntime keeps a clean empty subscription poll as empty success', async () => {


### PR DESCRIPTION
## Summary

- Make `meerkat-web-runtime::poll_subscription` fail closed with typed `serialize_error` when member or mob-wide subscription event projection cannot serialize.
- Keep clean empty subscription polls as `[]`, while removing the prior warn-and-omit success path.
- Tighten Web SDK projection so canonical WASM subscription envelopes expose `payload` truth, mob-wide `source` preserves Rust `AgentRuntimeId` `{ identity, generation }`, and malformed direct-session output fails closed.

Linear: https://linear.app/lucrfr/issue/LUC-340/p1-mechanical-slice-fail-closed-wasm-subscription-serialization

## Review Readiness Packet

Exact head: `f2f2fa82fa461163754805b36be1f74c396aac46` on `codex/LUC-340-fail-closed-wasm-subscription`, rebased onto `origin/main` `26d83aee459b9f2bb5cb24ee36a9fbb51a39ed51`.

Implementation:
- `meerkat-web-runtime/src/lib.rs`: added `serialize_subscription_item`; both member and mob-wide subscription polling branches now map projection serialization failure to typed `serialize_error` and return immediately. Added a Rust serialization-shape fixture proving `meerkat_mob::AttributedEvent.source` serializes as the canonical `AgentRuntimeId` object.
- `sdks/web/src/events.ts`, `sdks/web/src/session.ts`: subscription polling requires an array payload; direct `Session.pollEvents()` now rejects non-array output and both direct polling APIs reject malformed event items missing `type`.
- `sdks/web/src/mob.ts`, `sdks/web/src/types.ts`: member and mob-wide subscription projection now requires canonical `{ event_id, source_id, seq, timestamp_ms, payload }` envelopes; mob-wide `source` now requires `{ identity, generation }`; unrecognized shapes fail closed.

Tests:
- `meerkat-web-runtime/src/lib.rs`: clean empty poll coverage, projection failure coverage, Rust canonical attributed source serialization coverage, and wasm-only public poll fail-closed coverage for injected serialization failure.
- `sdks/web/tests/mob_payload.unit.mjs`: runtime subscription fixtures for clean empty success, propagated serialization failure, malformed poll rejection, canonical member/mob-wide `EventEnvelope` payload projection, canonical `AgentRuntimeId` mob source projection, legacy string-source rejection, and direct session malformed-output rejection.

Generated/docs:
- None. No generated files or docs were changed.

## Old Path Amputation Proof

Old paths made impossible:
- The member branch in `poll_subscription` previously logged `failed to serialize agent event` and continued, returning a successful event array with the failed event omitted.
- The mob-wide branch previously logged `failed to serialize attributed event` and continued, returning a successful event array with the failed event omitted.
- The Web SDK mob subscription normalizer previously converted canonical WASM envelopes with `payload` into successful `{ event: { type: "unknown" } }` output.
- Direct `Session.pollEvents()` previously converted non-array poll JSON into clean `[]`, and direct subscription parsing trusted malformed array items.

Amputation evidence:
- The Rust warn-only strings are removed from `meerkat-web-runtime/src/lib.rs`.
- Both Rust projection sites now call `serialize_subscription_item(...).map_err(|message| err_js("serialize_error", &message))?`, so a failed projection cannot masquerade as an empty or partial successful array.
- `sdks/web/src/mob.ts` no longer synthesizes `{ type: "unknown" }`; member projection requires a canonical event envelope with `payload`, and mob-wide projection requires `{ source: { identity, generation }, role, envelope: <canonical EventEnvelope> }`.
- Direct session projection now fails closed on non-array output and malformed event items instead of returning clean empty or unchecked item success.
- Clean empty success remains distinct: an empty receiver still serializes as `[]` and is covered by Rust and SDK empty poll tests.
- Rebased onto current `origin/main`; the exact diff no longer includes the stale `force_runtime_authority(RuntimeState::Destroyed, ...)` destroy regression or related stale projection changes.

## Validation

- Reproduced rework signal before edits: canonical mob-wide `{ source: { identity, generation }, role, envelope }` rejected as `Invalid mob subscription event: missing source`; direct `Session.pollEvents()` returned clean `[]` for non-array `{ events: [] }` output.
- Final exact-head rebase conflict was limited to keeping both `parse_mob_lifecycle_action_arg` and `serialize_subscription_item` test imports after `origin/main` advanced to `26d83aee459b9f2bb5cb24ee36a9fbb51a39ed51`.
- `npm --prefix sdks/web test`
- `./scripts/repo-cargo test -p meerkat-web-runtime subscription`
- `make fmt-check`
- `git diff --check`
- `make check` (BuildBuddy invocation `ddc6b2f6-89c6-4bf6-9c3f-6bf782efb007`)
