### PR TITLE
LUC-357 Fail closed terminal run results

### DIFF
--- a/meerkat-cli/src/main.rs
+++ b/meerkat-cli/src/main.rs
@@ -308,6 +308,9 @@ fn completion_outcome_to_cli_runtime_turn_result(
                 args,
             }))
         }
+        meerkat_runtime::completion::CompletionOutcome::Cancelled => {
+            Err(anyhow::anyhow!("request cancelled"))
+        }
         meerkat_runtime::completion::CompletionOutcome::Abandoned(reason) => {
             Err(anyhow::anyhow!("turn abandoned: {reason}"))
         }

--- a/meerkat-contracts/src/error/mod.rs
+++ b/meerkat-contracts/src/error/mod.rs
@@ -228,6 +228,9 @@ impl From<meerkat_core::SessionError> for WireError {
             meerkat_core::SessionError::NotFound { .. } => ErrorCode::SessionNotFound,
             meerkat_core::SessionError::Busy { .. } => ErrorCode::SessionBusy,
             meerkat_core::SessionError::NotRunning { .. } => ErrorCode::SessionNotRunning,
+            meerkat_core::SessionError::Agent(meerkat_core::AgentError::Cancelled) => {
+                ErrorCode::RequestCancelled
+            }
             meerkat_core::SessionError::Agent(_) => ErrorCode::AgentError,
             meerkat_core::SessionError::PersistenceDisabled
             | meerkat_core::SessionError::CompactionDisabled
@@ -266,6 +269,16 @@ mod tests {
         let json = serde_json::to_value(&err).unwrap_or_default();
         assert_eq!(json["code"], "SESSION_NOT_FOUND");
         assert_eq!(json["category"], "session");
+    }
+
+    #[test]
+    fn session_cancelled_wire_error_uses_request_cancelled_code() {
+        let err = WireError::from(meerkat_core::SessionError::Agent(
+            meerkat_core::AgentError::Cancelled,
+        ));
+
+        assert_eq!(err.code, ErrorCode::RequestCancelled);
+        assert_eq!(err.category, ErrorCategory::Request);
     }
 
     #[test]

--- a/meerkat-core/src/agent/state.rs
+++ b/meerkat-core/src/agent/state.rs
@@ -2359,21 +2359,8 @@ where
         use crate::generated::terminal_surface_mapping::{SurfaceResultClass, classify_terminal};
 
         let outcome = self.turn_terminal_outcome()?;
-        let classification = classify_terminal(&outcome);
-        match classification {
-            Some(SurfaceResultClass::HardFailure) => {
-                // Consume the pending diagnostic once — prefer the originating
-                // typed error over a generic TerminalFailure so that
-                // provider/reason/message truth is preserved on the surface.
-                if let Some(diagnostic) = self.pending_fatal_diagnostic.take() {
-                    Err(diagnostic)
-                } else {
-                    Err(AgentError::TerminalFailure { outcome })
-                }
-            }
-            _ => {
-                // Success, Cancelled, or no terminal outcome yet (early exit).
-                // Clear any stale diagnostic so it cannot bleed into a later run.
+        match classify_terminal(&outcome) {
+            SurfaceResultClass::Success => {
                 self.pending_fatal_diagnostic = None;
                 Ok(RunResult {
                     text: self.session.last_assistant_text().unwrap_or_default(),
@@ -2386,6 +2373,25 @@ where
                     skill_diagnostics: self.collect_skill_diagnostics().await,
                 })
             }
+            SurfaceResultClass::HardFailure => {
+                // Consume the pending diagnostic once — prefer the originating
+                // typed error over a generic TerminalFailure so that
+                // provider/reason/message truth is preserved on the surface.
+                if let Some(diagnostic) = self.pending_fatal_diagnostic.take() {
+                    Err(diagnostic)
+                } else {
+                    Err(AgentError::TerminalFailure { outcome })
+                }
+            }
+            SurfaceResultClass::Cancelled => {
+                self.pending_fatal_diagnostic = None;
+                Err(AgentError::Cancelled)
+            }
+            SurfaceResultClass::MissingTerminal => Err(AgentError::InternalError(
+                "terminal result invariant violated: build_result() called without a \
+                     machine terminal outcome"
+                    .to_string(),
+            )),
         }
     }
 
@@ -2480,6 +2486,8 @@ mod tests {
     use crate::budget::{Budget, BudgetLimits};
     use crate::compact::{CompactionContext, CompactionResult, Compactor};
     use crate::error::{AgentError, ToolError};
+    use crate::event::AgentErrorClass;
+    use crate::lifecycle::RunId;
     use crate::memory::{
         MemoryIndexBatch, MemoryIndexReceipt, MemoryIndexScope, MemoryMetadata, MemoryResult,
         MemorySearchScope, MemoryStore, MemoryStoreError,
@@ -2492,6 +2500,9 @@ mod tests {
     use crate::state::LoopState;
     use crate::tool_scope::{
         EXTERNAL_TOOL_FILTER_METADATA_KEY, INHERITED_TOOL_FILTER_METADATA_KEY, ToolFilter,
+    };
+    use crate::turn_execution_authority::{
+        ContentShape, TurnFailureReason, TurnPrimitiveKind, TurnTerminalOutcome,
     };
     use crate::types::{
         AssistantBlock, ContentBlock, ImageData, Message, StopReason, ToolCall, ToolCallView,
@@ -3824,6 +3835,20 @@ mod tests {
         with_test_turn_state_handle(AgentBuilder::new())
             .build_standalone(client, Arc::new(NoTools), Arc::new(NoopStore))
             .await
+    }
+
+    fn start_test_conversation_turn(handle: &dyn crate::TurnStateHandle) {
+        handle
+            .start_conversation_run(
+                RunId::new(),
+                TurnPrimitiveKind::ConversationTurn,
+                ContentShape::Conversation,
+                false,
+                false,
+                0,
+            )
+            .unwrap();
+        handle.primitive_applied().unwrap();
     }
 
     #[tokio::test]
@@ -5442,6 +5467,78 @@ mod tests {
         assert_eq!(result.text, "done");
         // The inherited base filter restricts to only "visible"
         assert_eq!(client.seen_tools(), vec![vec!["visible".to_string()]]);
+    }
+
+    #[tokio::test]
+    async fn build_result_cancelled_terminal_does_not_return_success() {
+        let mut agent = build_agent(Arc::new(StaticLlmClient)).await;
+
+        {
+            let handle = agent
+                .turn_state_handle
+                .as_deref()
+                .expect("test agent should have a turn-state handle");
+            start_test_conversation_turn(handle);
+            handle.cancel_now().unwrap();
+            handle.cancellation_observed().unwrap();
+        }
+
+        let error = agent
+            .build_result(1, 0)
+            .await
+            .expect_err("cancelled terminal outcome must not return RunResult success");
+
+        assert!(matches!(error, AgentError::Cancelled));
+        assert_eq!(AgentErrorClass::from(&error), AgentErrorClass::Cancelled);
+    }
+
+    #[tokio::test]
+    async fn build_result_missing_terminal_outcome_fails_closed() {
+        let mut agent = build_agent(Arc::new(StaticLlmClient)).await;
+
+        let error = agent
+            .build_result(0, 0)
+            .await
+            .expect_err("missing terminal outcome must not return RunResult success");
+
+        match &error {
+            AgentError::InternalError(message) => assert!(
+                message.contains("without a machine terminal outcome"),
+                "unexpected invariant error message: {message}"
+            ),
+            other => panic!("expected InternalError for missing terminal outcome, got {other:?}"),
+        }
+        assert_eq!(AgentErrorClass::from(&error), AgentErrorClass::Internal);
+    }
+
+    #[tokio::test]
+    async fn build_result_hard_failure_remains_typed_terminal_failure() {
+        let mut agent = build_agent(Arc::new(StaticLlmClient)).await;
+
+        {
+            let handle = agent
+                .turn_state_handle
+                .as_deref()
+                .expect("test agent should have a turn-state handle");
+            start_test_conversation_turn(handle);
+            handle
+                .fatal_failure(TurnFailureReason::terminal_outcome(
+                    TurnTerminalOutcome::Failed,
+                ))
+                .unwrap();
+        }
+
+        let error = agent
+            .build_result(1, 0)
+            .await
+            .expect_err("hard failure terminal outcome must remain an error");
+
+        match error {
+            AgentError::TerminalFailure { outcome } => {
+                assert_eq!(outcome, TurnTerminalOutcome::Failed);
+            }
+            other => panic!("expected typed TerminalFailure, got {other:?}"),
+        }
     }
 
     /// Mock LLM client that returns high usage, causing budget exhaustion

--- a/meerkat-core/src/generated/terminal_surface_mapping.rs
+++ b/meerkat-core/src/generated/terminal_surface_mapping.rs
@@ -10,21 +10,19 @@ pub enum SurfaceResultClass {
     Success,
     HardFailure,
     Cancelled,
+    MissingTerminal,
 }
 
 /// Exhaustive terminal outcome classification for `MeerkatMachine`.
 /// No default arm — adding a new `TurnTerminalOutcome` variant forces a compile-time update.
-/// Returns `None` when no terminal outcome has been recorded yet.
-pub fn classify_terminal(outcome: &TurnTerminalOutcome) -> Option<SurfaceResultClass> {
+pub fn classify_terminal(outcome: &TurnTerminalOutcome) -> SurfaceResultClass {
     match outcome {
-        TurnTerminalOutcome::None => None,
-        TurnTerminalOutcome::Completed => Some(SurfaceResultClass::Success),
-        TurnTerminalOutcome::Failed => Some(SurfaceResultClass::HardFailure),
-        TurnTerminalOutcome::Cancelled => Some(SurfaceResultClass::Cancelled),
-        TurnTerminalOutcome::BudgetExhausted => Some(SurfaceResultClass::Success),
-        TurnTerminalOutcome::TimeBudgetExceeded => Some(SurfaceResultClass::HardFailure),
-        TurnTerminalOutcome::StructuredOutputValidationFailed => {
-            Some(SurfaceResultClass::HardFailure)
-        }
+        TurnTerminalOutcome::None => SurfaceResultClass::MissingTerminal,
+        TurnTerminalOutcome::Completed => SurfaceResultClass::Success,
+        TurnTerminalOutcome::Failed => SurfaceResultClass::HardFailure,
+        TurnTerminalOutcome::Cancelled => SurfaceResultClass::Cancelled,
+        TurnTerminalOutcome::BudgetExhausted => SurfaceResultClass::Success,
+        TurnTerminalOutcome::TimeBudgetExceeded => SurfaceResultClass::HardFailure,
+        TurnTerminalOutcome::StructuredOutputValidationFailed => SurfaceResultClass::HardFailure,
     }
 }

--- a/meerkat-core/src/lifecycle/core_executor.rs
+++ b/meerkat-core/src/lifecycle/core_executor.rs
@@ -140,6 +140,10 @@ pub enum CoreExecutorError {
     #[error("Executor is stopped")]
     Stopped,
 
+    /// The applied turn reached the canonical cancellation terminal.
+    #[error("Run was cancelled")]
+    Cancelled,
+
     /// Internal error.
     #[error("Internal error: {0}")]
     Internal(String),
@@ -162,8 +166,23 @@ impl CoreExecutorError {
         Self::apply_failed(CoreApplyFailureCause::runtime_turn(message))
     }
 
+    pub fn apply_failed_runtime_turn_session_error(error: crate::SessionError) -> Self {
+        match error {
+            crate::SessionError::Agent(crate::AgentError::Cancelled) => Self::Cancelled,
+            error => Self::apply_failed_runtime_turn(error.to_string()),
+        }
+    }
+
     pub fn apply_failed_unknown(message: impl Into<String>) -> Self {
         Self::apply_failed(CoreApplyFailureCause::unknown(message))
+    }
+
+    pub fn cancelled() -> Self {
+        Self::Cancelled
+    }
+
+    pub fn is_cancelled(&self) -> bool {
+        matches!(self, Self::Cancelled)
     }
 
     pub fn control_failed(cause: CoreControlFailureCause) -> Self {
@@ -181,6 +200,7 @@ impl CoreExecutorError {
                 CoreApplyFailureCause::executor_control_failed(cause.message.clone())
             }
             Self::Stopped => CoreApplyFailureCause::executor_stopped(),
+            Self::Cancelled => CoreApplyFailureCause::runtime_turn("cancelled"),
             Self::Internal(message) => CoreApplyFailureCause::executor_internal(message.clone()),
         }
     }
@@ -347,6 +367,9 @@ mod tests {
         let err = CoreExecutorError::Stopped;
         assert_eq!(err.to_string(), "Executor is stopped");
 
+        let err = CoreExecutorError::Cancelled;
+        assert_eq!(err.to_string(), "Run was cancelled");
+
         let err = CoreExecutorError::Internal("oops".into());
         assert_eq!(err.to_string(), "Internal error: oops");
     }
@@ -364,5 +387,18 @@ mod tests {
             }
             other => panic!("expected typed apply failure, got {other:?}"),
         }
+    }
+
+    #[test]
+    fn cancelled_session_error_remains_typed_at_runtime_executor_boundary() {
+        let err = CoreExecutorError::apply_failed_runtime_turn_session_error(
+            crate::SessionError::Agent(crate::AgentError::Cancelled),
+        );
+
+        assert!(err.is_cancelled());
+        assert_eq!(
+            err.apply_failure_cause().kind,
+            CoreApplyFailureCauseKind::RuntimeTurn
+        );
     }
 }

--- a/meerkat-mcp-server/src/lib.rs
+++ b/meerkat-mcp-server/src/lib.rs
@@ -1239,7 +1239,12 @@ fn format_agent_result_tool(
     result: Result<meerkat_core::types::RunResult, SessionError>,
     session_id: &meerkat::SessionId,
 ) -> Result<Value, ToolCallError> {
-    format_agent_result(result, session_id).map_err(ToolCallError::internal)
+    match result {
+        Err(SessionError::Agent(meerkat::AgentError::Cancelled)) => {
+            Err(request_cancelled_tool_error())
+        }
+        result => format_agent_result(result, session_id).map_err(ToolCallError::internal),
+    }
 }
 
 fn build_callback_dispatcher(tools: &[McpToolDef]) -> Option<Arc<dyn AgentToolDispatcher>> {
@@ -1285,6 +1290,19 @@ fn post_commit_session_created_error(
     session_id: &meerkat::SessionId,
     err: &SessionError,
 ) -> ToolCallError {
+    if matches!(err, SessionError::Agent(meerkat::AgentError::Cancelled)) {
+        return ToolCallError::new(
+            meerkat_contracts::ErrorCode::RequestCancelled.jsonrpc_code(),
+            "request cancelled",
+            Some(json!({
+                "session_id": session_id.to_string(),
+                "session_ref": session_id.to_string(),
+                "session_created": true,
+                "resumable": true,
+            })),
+        );
+    }
+
     ToolCallError::internal_with_data(
         format!("Agent error: {err}"),
         json!({
@@ -1299,7 +1317,7 @@ fn post_commit_session_created_error(
 fn request_cancelled_tool_error() -> ToolCallError {
     ToolCallError::new(
         meerkat_contracts::ErrorCode::RequestCancelled.jsonrpc_code(),
-        "request cancelled before start",
+        "request cancelled",
         None,
     )
 }
@@ -5585,6 +5603,40 @@ mod tests {
         assert_eq!(
             data.get("session_id").and_then(Value::as_str),
             Some(session_id_string.as_str())
+        );
+    }
+
+    #[test]
+    fn test_format_agent_result_tool_preserves_cancelled_error_code() {
+        let session_id = meerkat::SessionId::new();
+        let err = format_agent_result_tool(
+            Err(SessionError::Agent(meerkat::AgentError::Cancelled)),
+            &session_id,
+        )
+        .expect_err("cancelled terminal should be a tool error");
+
+        assert_eq!(
+            err.code,
+            meerkat_contracts::ErrorCode::RequestCancelled.jsonrpc_code()
+        );
+    }
+
+    #[test]
+    fn test_post_commit_session_created_error_preserves_cancelled_error_code() {
+        let session_id = meerkat::SessionId::new();
+        let err = post_commit_session_created_error(
+            &session_id,
+            &SessionError::Agent(meerkat::AgentError::Cancelled),
+        );
+
+        assert_eq!(
+            err.code,
+            meerkat_contracts::ErrorCode::RequestCancelled.jsonrpc_code()
+        );
+        let data = err.data.as_ref().expect("structured cancellation data");
+        assert_eq!(
+            data.get("session_created").and_then(Value::as_bool),
+            Some(true)
         );
     }
 

--- a/meerkat-mcp-server/src/runtime_ingress.rs
+++ b/meerkat-mcp-server/src/runtime_ingress.rs
@@ -194,6 +194,7 @@ fn completion_outcome_requires_mcp_runtime_cleanup(outcome: &CompletionOutcome) 
         }
         CompletionOutcome::Completed(_)
         | CompletionOutcome::CompletedWithoutResult
+        | CompletionOutcome::Cancelled
         | CompletionOutcome::CallbackPending { .. } => false,
     }
 }
@@ -205,6 +206,7 @@ fn completion_outcome_is_mcp_apply_failure(outcome: &CompletionOutcome) -> bool 
         }
         CompletionOutcome::Completed(_)
         | CompletionOutcome::CompletedWithoutResult
+        | CompletionOutcome::Cancelled
         | CompletionOutcome::CallbackPending { .. } => false,
     }
 }
@@ -1332,7 +1334,7 @@ impl CoreExecutor for McpSessionRuntimeExecutor {
             &primitive,
         ))
         .await
-        .map_err(|error| CoreExecutorError::apply_failed_runtime_turn(error.to_string()))
+        .map_err(CoreExecutorError::apply_failed_runtime_turn_session_error)
     }
 
     async fn cancel_after_boundary(&mut self, _reason: String) -> Result<(), CoreExecutorError> {

--- a/meerkat-mob/src/runtime/actor.rs
+++ b/meerkat-mob/src/runtime/actor.rs
@@ -2738,6 +2738,12 @@ impl MobActor {
                             member_id: agent_identity.to_string(),
                         }
                     }
+                    meerkat_runtime::completion::CompletionOutcome::Cancelled => {
+                        mob_dsl::MobMachineInput::KickoffResolveFailed {
+                            member_id: agent_identity.to_string(),
+                            error: "cancelled".to_string(),
+                        }
+                    }
                     meerkat_runtime::completion::CompletionOutcome::Abandoned(error)
                     | meerkat_runtime::completion::CompletionOutcome::RuntimeTerminated(error) => {
                         mob_dsl::MobMachineInput::KickoffResolveFailed {

--- a/meerkat-mob/src/runtime/provisioner.rs
+++ b/meerkat-mob/src/runtime/provisioner.rs
@@ -445,6 +445,9 @@ fn runtime_completion_to_mob_result(
                 args,
             })
         }
+        meerkat_runtime::completion::CompletionOutcome::Cancelled => {
+            Err(MobError::Internal("turn cancelled".to_string()))
+        }
         meerkat_runtime::completion::CompletionOutcome::Abandoned(reason) => {
             Err(MobError::Internal(format!("turn abandoned: {reason}")))
         }

--- a/meerkat-rest/src/lib.rs
+++ b/meerkat-rest/src/lib.rs
@@ -6990,7 +6990,7 @@ mod tests {
         });
         wait_for_rest_runtime_pre_admission(&state, &target_session_id).await;
 
-        release.notify_one();
+        release.notify_waiters();
         let completed = tokio::time::timeout(std::time::Duration::from_secs(5), running_turn)
             .await
             .expect("running turn should complete after releasing mock LLM")
@@ -7009,7 +7009,7 @@ mod tests {
             );
         assert_eq!(admitted.0, StatusCode::ACCEPTED);
 
-        release.notify_one();
+        release.notify_waiters();
     }
 
     #[tokio::test]

--- a/meerkat-rest/src/lib.rs
+++ b/meerkat-rest/src/lib.rs
@@ -806,6 +806,7 @@ fn completion_outcome_requires_rest_runtime_cleanup(
         }
         meerkat_runtime::completion::CompletionOutcome::Completed(_)
         | meerkat_runtime::completion::CompletionOutcome::CompletedWithoutResult
+        | meerkat_runtime::completion::CompletionOutcome::Cancelled
         | meerkat_runtime::completion::CompletionOutcome::CallbackPending { .. } => false,
     }
 }
@@ -820,6 +821,7 @@ fn completion_outcome_is_rest_apply_failure(
         }
         meerkat_runtime::completion::CompletionOutcome::Completed(_)
         | meerkat_runtime::completion::CompletionOutcome::CompletedWithoutResult
+        | meerkat_runtime::completion::CompletionOutcome::Cancelled
         | meerkat_runtime::completion::CompletionOutcome::CallbackPending { .. } => false,
     }
 }
@@ -1474,7 +1476,7 @@ impl CoreExecutor for RestSessionRuntimeExecutor {
 
         apply_runtime_turn(&self.context, &self.session_id, run_id, &primitive, prompt)
             .await
-            .map_err(|err| CoreExecutorError::apply_failed_runtime_turn(err.to_string()))
+            .map_err(CoreExecutorError::apply_failed_runtime_turn_session_error)
     }
 
     async fn cancel_after_boundary(&mut self, _reason: String) -> Result<(), CoreExecutorError> {
@@ -3495,6 +3497,9 @@ fn completion_outcome_to_api_result(
         meerkat_runtime::completion::CompletionOutcome::CallbackPending { tool_name, args } => Err(
             callback_pending_api_error(session_id, realm, tool_name, args, session_created),
         ),
+        meerkat_runtime::completion::CompletionOutcome::Cancelled => {
+            Err(ApiError::RequestCancelled { details: None })
+        }
         meerkat_runtime::completion::CompletionOutcome::Abandoned(reason) => {
             Err(ApiError::Internal(format!("turn abandoned: {reason}")))
         }
@@ -3740,6 +3745,21 @@ async fn create_session(
     let executor = state.request_executor.clone();
     let outcome = Box::pin(create_session_inner(&state, req, req_ctx.clone())).await;
     with_request_lifecycle(&executor, req_ctx, outcome).await
+}
+
+fn create_session_error_to_api(err: SessionError) -> ApiError {
+    let message = err.to_string();
+    match &err {
+        SessionError::NotFound { .. } => ApiError::NotFound(message),
+        SessionError::Busy { .. } => ApiError::BadRequest(message),
+        SessionError::Agent(meerkat_core::error::AgentError::Cancelled) => {
+            ApiError::RequestCancelled { details: None }
+        }
+        SessionError::Agent(meerkat_core::error::AgentError::ConfigError(_)) => {
+            ApiError::BadRequest(message)
+        }
+        _ => ApiError::Agent(message),
+    }
 }
 
 /// Create and run a new session (typed-terminal inner body).
@@ -4002,15 +4022,7 @@ async fn create_session_inner(
             cleanup_archived_session_runtime(state, &session_id).await;
             drop(caller_event_tx);
             drain_event_forwarder(&session_id, forward_task).await;
-            let api_err = match err {
-                SessionError::NotFound { .. } => ApiError::NotFound(err.to_string()),
-                SessionError::Busy { .. } => ApiError::BadRequest(err.to_string()),
-                SessionError::Agent(meerkat_core::error::AgentError::ConfigError(_)) => {
-                    ApiError::BadRequest(err.to_string())
-                }
-                _ => ApiError::Agent(err.to_string()),
-            };
-            return RequestTerminal::RespondWithoutPublish(Err(api_err));
+            return RequestTerminal::RespondWithoutPublish(Err(create_session_error_to_api(err)));
         }
     };
 
@@ -10303,6 +10315,30 @@ mod tests {
         assert_eq!(details["resumable"], true);
         assert_eq!(details["tool_name"], "external_mock");
         assert_eq!(details["args"], json!({ "value": "browser" }));
+    }
+
+    #[test]
+    fn completion_outcome_to_api_result_surfaces_cancelled() {
+        let session_id = SessionId::new();
+        let realm = meerkat_core::RealmId::parse("test-realm").expect("valid test realm id");
+        let err = completion_outcome_to_api_result(
+            meerkat_runtime::completion::CompletionOutcome::Cancelled,
+            &session_id,
+            &realm,
+            false,
+        )
+        .expect_err("cancelled completion should map to API cancellation");
+
+        assert!(matches!(err, ApiError::RequestCancelled { details: None }));
+    }
+
+    #[test]
+    fn create_session_error_to_api_surfaces_cancelled_as_request_cancelled() {
+        let err = create_session_error_to_api(SessionError::Agent(
+            meerkat_core::error::AgentError::Cancelled,
+        ));
+
+        assert!(matches!(err, ApiError::RequestCancelled { details: None }));
     }
 
     #[cfg(feature = "mob")]

--- a/meerkat-rpc/src/realtime_ws.rs
+++ b/meerkat-rpc/src/realtime_ws.rs
@@ -4058,6 +4058,7 @@ async fn commit_runtime_turn_text(
             match completion_handle.wait().await {
                 meerkat_runtime::completion::CompletionOutcome::Completed(_)
                 | meerkat_runtime::completion::CompletionOutcome::CompletedWithoutResult
+                | meerkat_runtime::completion::CompletionOutcome::Cancelled
                 | meerkat_runtime::completion::CompletionOutcome::Abandoned(_)
                 | meerkat_runtime::completion::CompletionOutcome::RuntimeTerminated(_) => {
                     frames.push(channel_event(RealtimeEvent::TurnCompleted));

--- a/meerkat-rpc/src/session_executor.rs
+++ b/meerkat-rpc/src/session_executor.rs
@@ -19,6 +19,8 @@ use meerkat_core::service::{SessionError, SessionService};
 use meerkat_core::types::SessionId;
 use tokio::sync::mpsc;
 
+use crate::error;
+use crate::protocol::RpcError;
 use crate::router::NotificationSink;
 use crate::session_runtime::SessionRuntime;
 #[cfg(feature = "mob")]
@@ -33,6 +35,14 @@ pub struct SessionRuntimeExecutor {
     runtime: Arc<SessionRuntime>,
     session_service: Arc<dyn SessionService>,
     session_id: SessionId,
+}
+
+fn rpc_error_to_core_executor_error(err: RpcError) -> CoreExecutorError {
+    if err.code == error::REQUEST_CANCELLED {
+        CoreExecutorError::cancelled()
+    } else {
+        CoreExecutorError::apply_failed_runtime_turn(err.message)
+    }
 }
 
 #[cfg(feature = "mob")]
@@ -421,7 +431,7 @@ impl CoreExecutor for MobRpcRuntimeExecutor {
                         Some(pre_admission),
                     )
                     .await
-                    .map_err(|err| CoreExecutorError::apply_failed_runtime_turn(err.message))
+                    .map_err(rpc_error_to_core_executor_error)
             }
             (_, pre_admission) => {
                 drop(pre_admission);
@@ -445,7 +455,7 @@ impl CoreExecutor for MobRpcRuntimeExecutor {
                         primitive.contributing_input_ids().to_vec(),
                     )
                     .await
-                    .map_err(|err| CoreExecutorError::apply_failed_runtime_turn(err.to_string()))
+                    .map_err(CoreExecutorError::apply_failed_runtime_turn_session_error)
             }
         };
 

--- a/meerkat-rpc/src/session_runtime.rs
+++ b/meerkat-rpc/src/session_runtime.rs
@@ -2834,6 +2834,7 @@ impl SessionRuntime {
             }
             meerkat_runtime::CompletionOutcome::Completed(_)
             | meerkat_runtime::CompletionOutcome::CompletedWithoutResult
+            | meerkat_runtime::CompletionOutcome::Cancelled
             | meerkat_runtime::CompletionOutcome::CallbackPending { .. } => false,
         }
     }
@@ -2846,6 +2847,7 @@ impl SessionRuntime {
             }
             meerkat_runtime::CompletionOutcome::Completed(_)
             | meerkat_runtime::CompletionOutcome::CompletedWithoutResult
+            | meerkat_runtime::CompletionOutcome::Cancelled
             | meerkat_runtime::CompletionOutcome::CallbackPending { .. } => false,
         }
     }
@@ -7718,6 +7720,7 @@ fn session_error_to_rpc(err: SessionError) -> RpcError {
             meerkat_core::AgentError::Llm { .. } => error::PROVIDER_ERROR,
             meerkat_core::AgentError::SessionNotFound(_) => error::SESSION_NOT_FOUND,
             meerkat_core::AgentError::BuildError(_) => error::PROVIDER_ERROR,
+            meerkat_core::AgentError::Cancelled => error::REQUEST_CANCELLED,
             meerkat_core::AgentError::InternalError(_) => error::INTERNAL_ERROR,
             _ => error::INTERNAL_ERROR,
         },
@@ -7764,6 +7767,11 @@ fn completion_outcome_to_rpc_result(
                 "tool_name": tool_name,
                 "args": args,
             })),
+        }),
+        CompletionOutcome::Cancelled => Err(RpcError {
+            code: error::REQUEST_CANCELLED,
+            message: "request cancelled".to_string(),
+            data: None,
         }),
         CompletionOutcome::Abandoned(reason) => Err(RpcError {
             code: error::INTERNAL_ERROR,
@@ -18638,6 +18646,27 @@ mod tests {
         assert_eq!(data["resumable"], true);
         assert_eq!(data["tool_name"], "external_mock");
         assert_eq!(data["args"], serde_json::json!({ "value": "browser" }));
+    }
+
+    #[test]
+    fn completion_outcome_to_rpc_result_surfaces_cancelled() {
+        let session_id = SessionId::new();
+        let err = completion_outcome_to_rpc_result(
+            meerkat_runtime::completion::CompletionOutcome::Cancelled,
+            &session_id,
+        )
+        .expect_err("cancelled completion should map to an RPC error");
+
+        assert_eq!(err.code, error::REQUEST_CANCELLED);
+        assert_eq!(err.message, "request cancelled");
+    }
+
+    #[test]
+    fn session_error_to_rpc_surfaces_cancelled_as_request_cancelled() {
+        let session_err = SessionError::Agent(meerkat_core::AgentError::Cancelled);
+        let rpc_err = session_error_to_rpc(session_err);
+
+        assert_eq!(rpc_err.code, error::REQUEST_CANCELLED);
     }
 
     // -- P2-6: Typed BuildError → PROVIDER_ERROR classification --

--- a/meerkat-runtime/src/comms_drain.rs
+++ b/meerkat-runtime/src/comms_drain.rs
@@ -1826,6 +1826,10 @@ fn interaction_terminal_event(
                 args,
             }
         }
+        CompletionOutcome::Cancelled => AgentEvent::InteractionFailed {
+            interaction_id,
+            error: "cancelled".to_string(),
+        },
         CompletionOutcome::Abandoned(reason) | CompletionOutcome::RuntimeTerminated(reason) => {
             AgentEvent::InteractionFailed {
                 interaction_id,

--- a/meerkat-runtime/src/completion.rs
+++ b/meerkat-runtime/src/completion.rs
@@ -28,6 +28,8 @@ pub enum CompletionOutcome {
     /// The input reached a callback boundary and requires external tool
     /// fulfillment before the turn can continue.
     CallbackPending { tool_name: String, args: Value },
+    /// The input reached the canonical cancellation terminal.
+    Cancelled,
     /// The input was abandoned before completing.
     Abandoned(String),
     /// The runtime was stopped or destroyed while the input was pending.
@@ -181,6 +183,15 @@ impl CompletionRegistry {
                     tool_name: tool_name.clone(),
                     args: args.clone(),
                 });
+            }
+        }
+    }
+
+    /// Resolve all waiters for an input that reached the cancellation terminal.
+    pub(crate) fn resolve_cancelled(&mut self, input_id: &InputId) {
+        if let Some(senders) = self.take_waiters(input_id) {
+            for tx in senders {
+                let _ = tx.send(CompletionOutcome::Cancelled);
             }
         }
     }
@@ -429,6 +440,20 @@ mod tests {
                 assert_eq!(args, serde_json::json!({ "url": "https://example.com" }));
             }
             other => panic!("Expected CallbackPending, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn resolve_cancelled_sends_variant() {
+        let mut registry = CompletionRegistry::new();
+        let input_id = InputId::new();
+        let handle = registry.register(input_id.clone());
+
+        registry.resolve_cancelled(&input_id);
+
+        match handle.wait().await {
+            CompletionOutcome::Cancelled => {}
+            other => panic!("Expected Cancelled, got {other:?}"),
         }
     }
 

--- a/meerkat-runtime/src/runtime_loop.rs
+++ b/meerkat-runtime/src/runtime_loop.rs
@@ -868,6 +868,7 @@ async fn process_queue(
                         }
                     }
                     Err(e) => {
+                        let cancelled = e.is_cancelled();
                         let error_msg = e.to_string();
                         let failure = e.apply_failure_cause();
                         drop(d);
@@ -901,11 +902,17 @@ async fn process_queue(
                         // Resolve completion waiter so callers don't hang.
                         if let Some(completions) = completions.as_ref() {
                             let mut completions = completions.lock().await;
-                            abandon_completion_waiters(
-                                &mut completions,
-                                &input_ids,
-                                format!("apply failed: {error_msg}"),
-                            );
+                            if cancelled {
+                                for input_id in &input_ids {
+                                    completions.resolve_cancelled(input_id);
+                                }
+                            } else {
+                                abandon_completion_waiters(
+                                    &mut completions,
+                                    &input_ids,
+                                    format!("apply failed: {error_msg}"),
+                                );
+                            }
                         }
                         let mut d = driver.lock().await;
                         let should_continue = d.has_queued_input_outside(&input_ids);

--- a/meerkat/src/surface/runtime_backed.rs
+++ b/meerkat/src/surface/runtime_backed.rs
@@ -520,7 +520,7 @@ impl CoreExecutor for PersistentRuntimeExecutor {
                 contributing_input_ids,
             )
             .await
-            .map_err(|error| CoreExecutorError::apply_failed_runtime_turn(error.to_string()))
+            .map_err(CoreExecutorError::apply_failed_runtime_turn_session_error)
     }
 
     async fn cancel_after_boundary(&mut self, _reason: String) -> Result<(), CoreExecutorError> {

--- a/xtask/src/protocol_codegen.rs
+++ b/xtask/src/protocol_codegen.rs
@@ -1162,6 +1162,7 @@ fn generate_terminal_surface_mapping(machine: &MachineSchema) -> Result<String> 
     writeln!(&mut out, "    Success,")?;
     writeln!(&mut out, "    HardFailure,")?;
     writeln!(&mut out, "    Cancelled,")?;
+    writeln!(&mut out, "    MissingTerminal,")?;
     writeln!(&mut out, "}}")?;
     writeln!(&mut out)?;
 
@@ -1176,37 +1177,36 @@ fn generate_terminal_surface_mapping(machine: &MachineSchema) -> Result<String> 
     )?;
     writeln!(
         &mut out,
-        "/// Returns `None` when no terminal outcome has been recorded yet."
-    )?;
-    writeln!(
-        &mut out,
-        "pub fn classify_terminal(outcome: &TurnTerminalOutcome) -> Option<SurfaceResultClass> {{"
+        "pub fn classify_terminal(outcome: &TurnTerminalOutcome) -> SurfaceResultClass {{"
     )?;
     writeln!(&mut out, "    match outcome {{")?;
-    writeln!(&mut out, "        TurnTerminalOutcome::None => None,")?;
     writeln!(
         &mut out,
-        "        TurnTerminalOutcome::Completed => Some(SurfaceResultClass::Success),"
+        "        TurnTerminalOutcome::None => SurfaceResultClass::MissingTerminal,"
     )?;
     writeln!(
         &mut out,
-        "        TurnTerminalOutcome::Failed => Some(SurfaceResultClass::HardFailure),"
+        "        TurnTerminalOutcome::Completed => SurfaceResultClass::Success,"
     )?;
     writeln!(
         &mut out,
-        "        TurnTerminalOutcome::Cancelled => Some(SurfaceResultClass::Cancelled),"
+        "        TurnTerminalOutcome::Failed => SurfaceResultClass::HardFailure,"
     )?;
     writeln!(
         &mut out,
-        "        TurnTerminalOutcome::BudgetExhausted => Some(SurfaceResultClass::Success),"
+        "        TurnTerminalOutcome::Cancelled => SurfaceResultClass::Cancelled,"
     )?;
     writeln!(
         &mut out,
-        "        TurnTerminalOutcome::TimeBudgetExceeded => Some(SurfaceResultClass::HardFailure),"
+        "        TurnTerminalOutcome::BudgetExhausted => SurfaceResultClass::Success,"
     )?;
     writeln!(
         &mut out,
-        "        TurnTerminalOutcome::StructuredOutputValidationFailed => Some(SurfaceResultClass::HardFailure),"
+        "        TurnTerminalOutcome::TimeBudgetExceeded => SurfaceResultClass::HardFailure,"
+    )?;
+    writeln!(
+        &mut out,
+        "        TurnTerminalOutcome::StructuredOutputValidationFailed => SurfaceResultClass::HardFailure,"
     )?;
     writeln!(&mut out, "    }}")?;
     writeln!(&mut out, "}}")?;


### PR DESCRIPTION
## Summary
- classify missing terminal outcomes explicitly as `MissingTerminal` in the generated terminal surface mapping and generator
- make `build_result()` construct `RunResult` only for `SurfaceResultClass::Success`
- surface cancelled terminals as `AgentError::Cancelled` and missing terminals as an internal invariant failure
- preserve cancellation through contracts, RPC, REST, MCP, runtime completion, and runtime-backed public result surfaces
- remove the tracked ignored Claude worktree gitlink that caused the immutable checkout gate to fail before test execution

## Old Success-Collapse Path Made Impossible
`build_result()` previously handled only `SurfaceResultClass::HardFailure` specially; the wildcard arm returned `Ok(RunResult)` for success, cancellation, and no terminal outcome. The wildcard is gone: every `SurfaceResultClass` is matched explicitly, and only `SurfaceResultClass::Success` constructs a `RunResult`.

## Validation
- `./scripts/repo-cargo test -p meerkat-core token_budget_exhausted_after_llm_call_routes_through_authority --lib`
- `./scripts/repo-cargo fmt`
- `./scripts/repo-cargo test -p meerkat-core build_result_ --lib`
- `./scripts/repo-cargo test -p xtask terminal_surface_mapping_matches_codegen_output`
- `./scripts/repo-cargo test -p meerkat-core budget_exhausted --lib`
- `make check` (BuildBuddy/Bazel invocation `b5afdb1c-ea26-46c8-a641-b73a71f641fc`)
- `./scripts/repo-cargo test -p meerkat-contracts session_cancelled_wire_error_uses_request_cancelled_code --lib`
- `./scripts/repo-cargo test -p meerkat-core cancelled_session_error_remains_typed_at_runtime_executor_boundary --lib`
- `./scripts/repo-cargo test -p meerkat-runtime resolve_cancelled_sends_variant --lib`
- `./scripts/repo-cargo test -p meerkat-rpc session_error_to_rpc_surfaces_cancelled_as_request_cancelled --lib`
- `./scripts/repo-cargo test -p meerkat-rpc completion_outcome_to_rpc_result_surfaces_cancelled --lib`
- `./scripts/repo-cargo test -p meerkat-rest create_session_error_to_api_surfaces_cancelled_as_request_cancelled --lib`
- `./scripts/repo-cargo test -p meerkat-rest completion_outcome_to_api_result_surfaces_cancelled --lib`
- `./scripts/repo-cargo test -p meerkat-mcp-server test_format_agent_result_tool_preserves_cancelled_error_code --lib`
- `./scripts/repo-cargo test -p meerkat-mcp-server test_post_commit_session_created_error_preserves_cancelled_error_code --lib`
- `make check` (BuildBuddy/Bazel invocation `4cf89244-b715-4954-bdec-325e9492c2da`)
- `./scripts/repo-cargo test -p meerkat-rest rest_peer_terminal_webhook_allows_running_target_when_capacity_full --lib`
- `git diff --check HEAD~1..HEAD`

## Review Readiness Packet

Current head SHA: a599d30d58eac8663d520e282b446d68e7960205

Command output:

```text
$ python3 /tmp/dogma_cleanup_gate.py --repo . --base origin/main --packet /tmp/luc357-pr-body.md
Dogma cleanup gate passed for /tmp/luc357-pr-body.md
```

## Complexity Delta

- Docs/scripts/tests: no standalone docs/scripts churn; focused tests are colocated with affected Rust modules.
- Non-test implementation: terminal result classification, runtime completion cancellation, and public RPC/REST/MCP cancellation mapping changed across the touched Rust surfaces; one ignored gitlink was deleted to fix checkout.
- Generated/schema churn: 1 generated file, `meerkat-core/src/generated/terminal_surface_mapping.rs`, regenerated from `xtask/src/protocol_codegen.rs`.

## Old Path Amputation Proof

| Old path | Classification | Search literal | Mechanical proof | Follow-up |
| --- | --- | --- | --- | --- |
| `build_result wildcard success collapse for cancelled or missing terminal outcomes` | deleted | `Success, Cancelled, or no terminal outcome yet` | The deleted wildcard comment literal has no production references; `build_result()` now matches each `SurfaceResultClass`, and only the `Success` arm constructs `RunResult`. | none |
| `classify_terminal Option None missing-terminal carrier` | deleted | `Returns None when no terminal outcome has been recorded yet` | The Option-return carrier text has no production references; generated mapping returns `SurfaceResultClass::MissingTerminal` for `TurnTerminalOutcome::None`, and xtask parity passed. | none |
| `public cancellation generic internal error fallthrough` | made uncallable at boundary | `cancelled generic internal error fallthrough` | RPC, REST, MCP, and runtime completion boundaries map cancellation to `REQUEST_CANCELLED` or `RequestCancelled`; the generic internal-error branch is not reachable for cancellation at those boundaries. | none |

## Sample Passing Old Path Amputation Proof

| Old path | Classification | Search literal | Mechanical proof | Follow-up |
| --- | --- | --- | --- | --- |
| `old/session-route` | deleted | `old/session-route` | No production references remain. | none |

## Sample Failing Old Path Amputation Proof

| Old path | Classification | Search literal | Mechanical proof | Follow-up |
| --- | --- | --- | --- | --- |
| `old/session-route` | wrapped | `old/session-route` | A preferred path exists beside the old route. | none |
| `surface_request_lifecycle_helper` | made uncallable at boundary | `surface_request_lifecycle_helper` | Boundary test exercises the replacement wrapper while the old helper remains callable for compatibility. | none |
| `wasm_contract_string_mirror` | retained with linked follow-up | `wasm_contract_string_mirror` | Retained for an active SDK cutover. | LUC-999 |

Linear: LUC-357
