### PR TITLE
LUC-353 Enforce AuthMachine freshness for cloud authorizers

### DIFF
--- a/meerkat-auth-core/src/authorizers/azure.rs
+++ b/meerkat-auth-core/src/authorizers/azure.rs
@@ -12,8 +12,9 @@
 //!   2. Environment variables `AZURE_TENANT_ID`, `AZURE_CLIENT_ID`, `AZURE_CLIENT_SECRET`
 //!   3. `AZURE_AUTHORITY_HOST` override (defaults to `login.microsoftonline.com`)
 //!
-//! Tokens are cached in memory until 60s before expiry; refresh is
-//! single-flight via an internal mutex.
+//! Tokens are cached as a private implementation detail; reuse requires
+//! AuthMachine lease freshness. Refresh is single-flight via an internal
+//! mutex.
 
 use std::sync::Arc;
 
@@ -23,7 +24,7 @@ use parking_lot::Mutex;
 use serde::Deserialize;
 use thiserror::Error;
 
-use super::{LeaseFreshnessObserver, oauth_endpoint_failure_is_permanent, token_is_fresh_at};
+use super::{LeaseFreshnessObserver, oauth_endpoint_failure_is_permanent};
 use meerkat_core::handles::{AuthLeaseHandle, LeaseKey};
 use meerkat_core::{AuthError, HttpAuthorizationRequest, HttpAuthorizer};
 
@@ -94,6 +95,8 @@ struct TokenResponse {
 struct CachedToken {
     access_token: String,
     expires_at: DateTime<Utc>,
+    // Private cache provenance only; freshness is decided by the
+    // AuthMachine lease snapshot when an observer is installed.
     lease_generation: Option<u64>,
 }
 
@@ -190,27 +193,25 @@ impl AzureAdAuthorizer {
     }
 
     fn cached_expires_at(&self) -> Option<DateTime<Utc>> {
-        if let Some(observer) = &self.lease_observer {
-            return observer.expires_at();
-        }
-        self.cache.lock().as_ref().map(|token| token.expires_at)
+        self.lease_observer
+            .as_ref()
+            .and_then(LeaseFreshnessObserver::expires_at)
     }
 
     fn fresh_cached_token(&self, now: DateTime<Utc>) -> Result<Option<String>, AuthError> {
-        if let Some((access_token, expires_at, lease_generation)) = {
+        let Some(observer) = &self.lease_observer else {
+            return Ok(None);
+        };
+        let Some((access_token, expires_at, lease_generation)) = ({
             let guard = self.cache.lock();
             guard
                 .as_ref()
                 .map(|t| (t.access_token.clone(), t.expires_at, t.lease_generation))
-        } {
-            let fresh = if let Some(observer) = &self.lease_observer {
-                observer.cached_token_is_fresh(&self.label, expires_at, lease_generation, now)?
-            } else {
-                token_is_fresh_at(expires_at, now)
-            };
-            if fresh {
-                return Ok(Some(access_token));
-            }
+        }) else {
+            return Ok(None);
+        };
+        if observer.cached_token_is_fresh(&self.label, expires_at, lease_generation, now)? {
+            return Ok(Some(access_token));
         }
         Ok(None)
     }

--- a/meerkat-auth-core/src/authorizers/azure.rs
+++ b/meerkat-auth-core/src/authorizers/azure.rs
@@ -12,7 +12,8 @@
 //!   2. Environment variables `AZURE_TENANT_ID`, `AZURE_CLIENT_ID`, `AZURE_CLIENT_SECRET`
 //!   3. `AZURE_AUTHORITY_HOST` override (defaults to `login.microsoftonline.com`)
 //!
-//! Tokens are cached as a private implementation detail; reuse requires
+//! Tokens are cached as a private implementation detail; every authorize
+//! path requires AuthMachine lease observation, and cache reuse requires
 //! AuthMachine lease freshness. Refresh is single-flight via an internal
 //! mutex.
 
@@ -96,7 +97,7 @@ struct CachedToken {
     access_token: String,
     expires_at: DateTime<Utc>,
     // Private cache provenance only; freshness is decided by the
-    // AuthMachine lease snapshot when an observer is installed.
+    // required AuthMachine lease snapshot.
     lease_generation: Option<u64>,
 }
 
@@ -198,10 +199,11 @@ impl AzureAdAuthorizer {
             .and_then(LeaseFreshnessObserver::expires_at)
     }
 
-    fn fresh_cached_token(&self, now: DateTime<Utc>) -> Result<Option<String>, AuthError> {
-        let Some(observer) = &self.lease_observer else {
-            return Ok(None);
-        };
+    fn fresh_cached_token(
+        &self,
+        observer: &LeaseFreshnessObserver,
+        now: DateTime<Utc>,
+    ) -> Result<Option<String>, AuthError> {
         let Some((access_token, expires_at, lease_generation)) = ({
             let guard = self.cache.lock();
             guard
@@ -217,42 +219,38 @@ impl AzureAdAuthorizer {
     }
 
     async fn get_token(&self) -> Result<String, AuthError> {
+        let Some(observer) = &self.lease_observer else {
+            return Err(AuthError::HostOwnedUnavailable);
+        };
+
         // Check cache without taking the refresh path.
-        if let Some(access_token) = self.fresh_cached_token(Utc::now())? {
+        if let Some(access_token) = self.fresh_cached_token(observer, Utc::now())? {
             return Ok(access_token);
         }
 
         let _refresh_guard = self.refresh_lock.lock().await;
-        if let Some(access_token) = self.fresh_cached_token(Utc::now())? {
+        if let Some(access_token) = self.fresh_cached_token(observer, Utc::now())? {
             return Ok(access_token);
         }
 
-        let lifecycle = if let Some(observer) = &self.lease_observer {
-            Some(observer.begin_refresh(&self.label).await?)
-        } else {
-            None
-        };
+        let lifecycle = observer.begin_refresh(&self.label).await?;
 
         // Miss — fetch a fresh token.
         let mut new_token = match self.fetch_token().await {
             Ok(token) => token,
             Err(err) => {
-                if let (Some(observer), Some(lifecycle)) = (&self.lease_observer, lifecycle) {
-                    observer.refresh_failed(
-                        &self.label,
-                        lifecycle,
-                        azure_refresh_failure_is_permanent(&err),
-                    )?;
-                }
+                observer.refresh_failed(
+                    &self.label,
+                    lifecycle,
+                    azure_refresh_failure_is_permanent(&err),
+                )?;
                 return Err(err.into());
             }
         };
         let access = new_token.access_token.clone();
         let expires_at = new_token.expires_at;
-        if let (Some(observer), Some(lifecycle)) = (&self.lease_observer, lifecycle) {
-            new_token.lease_generation =
-                Some(observer.complete_refresh(&self.label, lifecycle, expires_at, Utc::now())?);
-        }
+        new_token.lease_generation =
+            Some(observer.complete_refresh(&self.label, lifecycle, expires_at, Utc::now())?);
         *self.cache.lock() = Some(new_token);
         Ok(access)
     }

--- a/meerkat-auth-core/src/authorizers/google.rs
+++ b/meerkat-auth-core/src/authorizers/google.rs
@@ -26,7 +26,7 @@ use thiserror::Error;
 
 use super::{
     EnvLookup, LeaseFreshnessObserver, endpoint_failure_is_transient,
-    oauth_endpoint_failure_is_permanent, token_is_fresh_at,
+    oauth_endpoint_failure_is_permanent,
 };
 use meerkat_core::handles::{AuthLeaseHandle, LeaseKey};
 use meerkat_core::{AuthError, HttpAuthorizationRequest, HttpAuthorizer};
@@ -118,6 +118,8 @@ fn default_expires_in() -> u64 {
 struct CachedToken {
     access_token: String,
     expires_at: DateTime<Utc>,
+    // Private cache provenance only; freshness is decided by the
+    // AuthMachine lease snapshot when an observer is installed.
     lease_generation: Option<u64>,
 }
 
@@ -219,27 +221,25 @@ impl GoogleAuthAuthorizer {
     }
 
     fn cached_expires_at(&self) -> Option<DateTime<Utc>> {
-        if let Some(observer) = &self.lease_observer {
-            return observer.expires_at();
-        }
-        self.cache.lock().as_ref().map(|token| token.expires_at)
+        self.lease_observer
+            .as_ref()
+            .and_then(LeaseFreshnessObserver::expires_at)
     }
 
     fn fresh_cached_token(&self, now: DateTime<Utc>) -> Result<Option<String>, AuthError> {
-        if let Some((access_token, expires_at, lease_generation)) = {
+        let Some(observer) = &self.lease_observer else {
+            return Ok(None);
+        };
+        let Some((access_token, expires_at, lease_generation)) = ({
             let guard = self.cache.lock();
             guard
                 .as_ref()
                 .map(|t| (t.access_token.clone(), t.expires_at, t.lease_generation))
-        } {
-            let fresh = if let Some(observer) = &self.lease_observer {
-                observer.cached_token_is_fresh(&self.label, expires_at, lease_generation, now)?
-            } else {
-                token_is_fresh_at(expires_at, now)
-            };
-            if fresh {
-                return Ok(Some(access_token));
-            }
+        }) else {
+            return Ok(None);
+        };
+        if observer.cached_token_is_fresh(&self.label, expires_at, lease_generation, now)? {
+            return Ok(Some(access_token));
         }
         Ok(None)
     }

--- a/meerkat-auth-core/src/authorizers/google.rs
+++ b/meerkat-auth-core/src/authorizers/google.rs
@@ -119,7 +119,7 @@ struct CachedToken {
     access_token: String,
     expires_at: DateTime<Utc>,
     // Private cache provenance only; freshness is decided by the
-    // AuthMachine lease snapshot when an observer is installed.
+    // required AuthMachine lease snapshot.
     lease_generation: Option<u64>,
 }
 
@@ -226,10 +226,11 @@ impl GoogleAuthAuthorizer {
             .and_then(LeaseFreshnessObserver::expires_at)
     }
 
-    fn fresh_cached_token(&self, now: DateTime<Utc>) -> Result<Option<String>, AuthError> {
-        let Some(observer) = &self.lease_observer else {
-            return Ok(None);
-        };
+    fn fresh_cached_token(
+        &self,
+        observer: &LeaseFreshnessObserver,
+        now: DateTime<Utc>,
+    ) -> Result<Option<String>, AuthError> {
         let Some((access_token, expires_at, lease_generation)) = ({
             let guard = self.cache.lock();
             guard
@@ -245,55 +246,49 @@ impl GoogleAuthAuthorizer {
     }
 
     async fn get_token(&self) -> Result<String, AuthError> {
-        if let Some(access_token) = self.fresh_cached_token(Utc::now())? {
+        let Some(observer) = &self.lease_observer else {
+            return Err(AuthError::HostOwnedUnavailable);
+        };
+
+        if let Some(access_token) = self.fresh_cached_token(observer, Utc::now())? {
             return Ok(access_token);
         }
 
         let _refresh_guard = self.refresh_lock.lock().await;
-        if let Some(access_token) = self.fresh_cached_token(Utc::now())? {
+        if let Some(access_token) = self.fresh_cached_token(observer, Utc::now())? {
             return Ok(access_token);
         }
 
-        let lifecycle = if let Some(observer) = &self.lease_observer {
-            Some(observer.begin_refresh(&self.label).await?)
-        } else {
-            None
-        };
+        let lifecycle = observer.begin_refresh(&self.label).await?;
 
         let mut token = match self.chain {
             GoogleAuthChain::ComputeOnly => match self.fetch_from_metadata().await {
                 Ok(token) => token,
                 Err(err) => {
-                    if let (Some(observer), Some(lifecycle)) = (&self.lease_observer, lifecycle) {
-                        observer.refresh_failed(
-                            &self.label,
-                            lifecycle,
-                            google_refresh_failure_is_permanent(&err),
-                        )?;
-                    }
+                    observer.refresh_failed(
+                        &self.label,
+                        lifecycle,
+                        google_refresh_failure_is_permanent(&err),
+                    )?;
                     return Err(err.into());
                 }
             },
             GoogleAuthChain::Default => match self.fetch_full_chain().await {
                 Ok(token) => token,
                 Err(err) => {
-                    if let (Some(observer), Some(lifecycle)) = (&self.lease_observer, lifecycle) {
-                        observer.refresh_failed(
-                            &self.label,
-                            lifecycle,
-                            google_refresh_failure_is_permanent(&err),
-                        )?;
-                    }
+                    observer.refresh_failed(
+                        &self.label,
+                        lifecycle,
+                        google_refresh_failure_is_permanent(&err),
+                    )?;
                     return Err(err.into());
                 }
             },
         };
         let access = token.access_token.clone();
         let expires_at = token.expires_at;
-        if let (Some(observer), Some(lifecycle)) = (&self.lease_observer, lifecycle) {
-            token.lease_generation =
-                Some(observer.complete_refresh(&self.label, lifecycle, expires_at, Utc::now())?);
-        }
+        token.lease_generation =
+            Some(observer.complete_refresh(&self.label, lifecycle, expires_at, Utc::now())?);
         *self.cache.lock() = Some(token);
         Ok(access)
     }

--- a/meerkat-auth-core/src/authorizers/mod.rs
+++ b/meerkat-auth-core/src/authorizers/mod.rs
@@ -9,7 +9,7 @@
 use std::sync::Arc;
 
 #[cfg(any(feature = "azure-ad", feature = "gcp-auth"))]
-use chrono::{DateTime, Duration, Utc};
+use chrono::{DateTime, Utc};
 #[cfg(any(feature = "azure-ad", feature = "gcp-auth"))]
 use meerkat_core::AuthError;
 #[cfg(any(feature = "azure-ad", feature = "gcp-auth"))]
@@ -217,11 +217,6 @@ pub(crate) enum LeaseRefreshLifecycle {
 enum LeaseRefreshStart {
     Started(LeaseRefreshLifecycle),
     WaitForInFlight,
-}
-
-#[cfg(any(feature = "azure-ad", feature = "gcp-auth"))]
-pub(crate) fn token_is_fresh_at(expires_at: DateTime<Utc>, now: DateTime<Utc>) -> bool {
-    expires_at - now > Duration::seconds(AUTH_LEASE_TTL_REFRESH_WINDOW_SECS as i64)
 }
 
 #[cfg(any(feature = "azure-ad", feature = "gcp-auth"))]

--- a/meerkat-auth-core/tests/azure_ad_authorizer.rs
+++ b/meerkat-auth-core/tests/azure_ad_authorizer.rs
@@ -356,14 +356,33 @@ fn creds(token_url_host: &str) -> AzureClientCredentials {
     }
 }
 
+fn with_recording_auth_lease(
+    authorizer: AzureAdAuthorizer,
+) -> (AzureAdAuthorizer, Arc<RecordingAuthLeaseHandle>, LeaseKey) {
+    let handle = Arc::new(RecordingAuthLeaseHandle::default());
+    let lease_key = LeaseKey::new(
+        RealmId::parse("dev").unwrap(),
+        BindingId::parse("azure_foundry").unwrap(),
+        Some(ProfileId::parse("foundry_azure_ad").unwrap()),
+    );
+    let lease_handle: Arc<dyn AuthLeaseHandle> = handle.clone();
+    (
+        authorizer.with_auth_lease_observer(lease_handle, lease_key.clone()),
+        handle,
+        lease_key,
+    )
+}
+
 #[tokio::test]
 async fn authorize_adds_bearer_header_from_token_endpoint() {
     let mock = start_mock("azure-access-token-xyz", 3600).await;
-    let authorizer = AzureAdAuthorizer::new(
-        "https://cognitiveservices.azure.com/.default",
-        creds(&mock.base_url),
-    )
-    .with_token_url_override(format!("{}/tenant-id/oauth2/v2.0/token", mock.base_url));
+    let (authorizer, _, _) = with_recording_auth_lease(
+        AzureAdAuthorizer::new(
+            "https://cognitiveservices.azure.com/.default",
+            creds(&mock.base_url),
+        )
+        .with_token_url_override(format!("{}/tenant-id/oauth2/v2.0/token", mock.base_url)),
+    );
 
     let mut headers = Vec::new();
     let mut req = HttpAuthorizationRequest {
@@ -379,8 +398,8 @@ async fn authorize_adds_bearer_header_from_token_endpoint() {
         .unwrap();
     assert_eq!(auth.1, "Bearer azure-access-token-xyz");
     assert!(
-        authorizer.expires_at().is_none(),
-        "Azure AD expiry is only projected from AuthMachine lease truth"
+        authorizer.expires_at().is_some(),
+        "Azure AD expiry must be projected from AuthMachine lease truth"
     );
 
     let captured = mock.captured.lock().unwrap();
@@ -395,47 +414,13 @@ async fn authorize_adds_bearer_header_from_token_endpoint() {
 }
 
 #[tokio::test]
-async fn provider_local_cache_without_auth_lease_is_not_reused_as_fresh() {
+async fn authorize_without_auth_lease_observer_fails_closed_before_token_fetch() {
     let mock = start_mock("cached-token", 3600).await;
     let authorizer = AzureAdAuthorizer::new(
         "https://cognitiveservices.azure.com/.default",
         creds(&mock.base_url),
     )
     .with_token_url_override(format!("{}/tenant-id/oauth2/v2.0/token", mock.base_url));
-
-    for _ in 0..5 {
-        let mut headers = Vec::new();
-        let mut req = HttpAuthorizationRequest {
-            method: "POST",
-            url: "https://example.foundry.azure.com/v1/messages",
-            headers: &mut headers,
-        };
-        authorizer.authorize(&mut req).await.unwrap();
-    }
-    assert_eq!(
-        mock.counter.load(Ordering::SeqCst),
-        5,
-        "provider-local cache must not decide freshness without AuthMachine lease truth; got {} token fetches",
-        mock.counter.load(Ordering::SeqCst),
-    );
-}
-
-#[tokio::test]
-async fn provider_local_cache_without_auth_lease_fails_closed_instead_of_reuse() {
-    let mock = start_mock_with_failure("cached-without-lease", 3600, Some(2)).await;
-    let authorizer = AzureAdAuthorizer::new(
-        "https://cognitiveservices.azure.com/.default",
-        creds(&mock.base_url),
-    )
-    .with_token_url_override(format!("{}/tenant-id/oauth2/v2.0/token", mock.base_url));
-
-    let mut headers = Vec::new();
-    let mut req = HttpAuthorizationRequest {
-        method: "POST",
-        url: "https://example.foundry.azure.com/v1/messages",
-        headers: &mut headers,
-    };
-    authorizer.authorize(&mut req).await.unwrap();
 
     let mut headers = Vec::new();
     let mut req = HttpAuthorizationRequest {
@@ -446,49 +431,19 @@ async fn provider_local_cache_without_auth_lease_fails_closed_instead_of_reuse()
     let err = authorizer.authorize(&mut req).await.unwrap_err();
 
     assert!(
-        matches!(err, meerkat_core::AuthError::RefreshFailed(_)),
-        "second authorize must refetch and fail without lease freshness, got {err:?}"
+        matches!(err, meerkat_core::AuthError::HostOwnedUnavailable),
+        "cloud authorizer must fail closed without AuthMachine ownership, got {err:?}"
     );
     assert!(
         headers
             .iter()
             .all(|(name, _)| !name.eq_ignore_ascii_case("authorization")),
-        "stale provider-local cache must not attach an authorization header without AuthMachine lease truth"
+        "observer-absent cloud authorizer must not attach an authorization header"
     );
     assert_eq!(
         mock.counter.load(Ordering::SeqCst),
-        2,
-        "second authorize must reach the token endpoint instead of treating the private cache as fresh"
-    );
-}
-
-#[tokio::test]
-async fn short_lived_token_without_auth_lease_refetches_without_expiry_projection() {
-    let mock = start_mock("short-lived-token", 30).await;
-    let authorizer = AzureAdAuthorizer::new(
-        "https://cognitiveservices.azure.com/.default",
-        creds(&mock.base_url),
-    )
-    .with_token_url_override(format!("{}/tenant-id/oauth2/v2.0/token", mock.base_url));
-
-    for _ in 0..2 {
-        let mut headers = Vec::new();
-        let mut req = HttpAuthorizationRequest {
-            method: "POST",
-            url: "https://example.foundry.azure.com/v1/messages",
-            headers: &mut headers,
-        };
-        authorizer.authorize(&mut req).await.unwrap();
-    }
-
-    assert!(
-        authorizer.expires_at().is_none(),
-        "provider-local expiry must not be projected without AuthMachine lease truth"
-    );
-    assert_eq!(
-        mock.counter.load(Ordering::SeqCst),
-        2,
-        "token without AuthMachine lease truth must be refetched"
+        0,
+        "observer-absent cloud authorizer must not fetch a provider-local token"
     );
 }
 
@@ -1002,11 +957,13 @@ async fn token_endpoint_error_propagates_as_refresh_failed() {
     });
 
     let base_url = format!("http://{addr}");
-    let authorizer = AzureAdAuthorizer::new(
-        "https://cognitiveservices.azure.com/.default",
-        creds(&base_url),
-    )
-    .with_token_url_override(format!("{base_url}/tenant-id/oauth2/v2.0/token"));
+    let (authorizer, _, _) = with_recording_auth_lease(
+        AzureAdAuthorizer::new(
+            "https://cognitiveservices.azure.com/.default",
+            creds(&base_url),
+        )
+        .with_token_url_override(format!("{base_url}/tenant-id/oauth2/v2.0/token")),
+    );
 
     let mut headers = Vec::new();
     let mut req = HttpAuthorizationRequest {

--- a/meerkat-auth-core/tests/azure_ad_authorizer.rs
+++ b/meerkat-auth-core/tests/azure_ad_authorizer.rs
@@ -183,6 +183,7 @@ impl AuthLeaseHandle for RecordingAuthLeaseHandle {
             expires_at: Some(expires_at),
             credential_present: true,
             generation,
+            credential_published_at_millis: None,
         };
         Ok(AuthLeaseTransition {
             generation,
@@ -234,6 +235,7 @@ impl AuthLeaseHandle for RecordingAuthLeaseHandle {
             expires_at: Some(new_expires_at),
             credential_present: true,
             generation,
+            credential_published_at_millis: None,
         };
         Ok(AuthLeaseTransition {
             generation,
@@ -377,8 +379,8 @@ async fn authorize_adds_bearer_header_from_token_endpoint() {
         .unwrap();
     assert_eq!(auth.1, "Bearer azure-access-token-xyz");
     assert!(
-        authorizer.expires_at().is_some(),
-        "Azure AD token expiry must be observable through HttpAuthorizer"
+        authorizer.expires_at().is_none(),
+        "Azure AD expiry is only projected from AuthMachine lease truth"
     );
 
     let captured = mock.captured.lock().unwrap();
@@ -393,7 +395,7 @@ async fn authorize_adds_bearer_header_from_token_endpoint() {
 }
 
 #[tokio::test]
-async fn token_is_cached_between_authorize_calls() {
+async fn provider_local_cache_without_auth_lease_is_not_reused_as_fresh() {
     let mock = start_mock("cached-token", 3600).await;
     let authorizer = AzureAdAuthorizer::new(
         "https://cognitiveservices.azure.com/.default",
@@ -412,14 +414,56 @@ async fn token_is_cached_between_authorize_calls() {
     }
     assert_eq!(
         mock.counter.load(Ordering::SeqCst),
-        1,
-        "expected 1 token fetch, got {}",
+        5,
+        "provider-local cache must not decide freshness without AuthMachine lease truth; got {} token fetches",
         mock.counter.load(Ordering::SeqCst),
     );
 }
 
 #[tokio::test]
-async fn short_lived_token_expiry_is_observable_and_refetched() {
+async fn provider_local_cache_without_auth_lease_fails_closed_instead_of_reuse() {
+    let mock = start_mock_with_failure("cached-without-lease", 3600, Some(2)).await;
+    let authorizer = AzureAdAuthorizer::new(
+        "https://cognitiveservices.azure.com/.default",
+        creds(&mock.base_url),
+    )
+    .with_token_url_override(format!("{}/tenant-id/oauth2/v2.0/token", mock.base_url));
+
+    let mut headers = Vec::new();
+    let mut req = HttpAuthorizationRequest {
+        method: "POST",
+        url: "https://example.foundry.azure.com/v1/messages",
+        headers: &mut headers,
+    };
+    authorizer.authorize(&mut req).await.unwrap();
+
+    let mut headers = Vec::new();
+    let mut req = HttpAuthorizationRequest {
+        method: "POST",
+        url: "https://example.foundry.azure.com/v1/messages",
+        headers: &mut headers,
+    };
+    let err = authorizer.authorize(&mut req).await.unwrap_err();
+
+    assert!(
+        matches!(err, meerkat_core::AuthError::RefreshFailed(_)),
+        "second authorize must refetch and fail without lease freshness, got {err:?}"
+    );
+    assert!(
+        headers
+            .iter()
+            .all(|(name, _)| !name.eq_ignore_ascii_case("authorization")),
+        "stale provider-local cache must not attach an authorization header without AuthMachine lease truth"
+    );
+    assert_eq!(
+        mock.counter.load(Ordering::SeqCst),
+        2,
+        "second authorize must reach the token endpoint instead of treating the private cache as fresh"
+    );
+}
+
+#[tokio::test]
+async fn short_lived_token_without_auth_lease_refetches_without_expiry_projection() {
     let mock = start_mock("short-lived-token", 30).await;
     let authorizer = AzureAdAuthorizer::new(
         "https://cognitiveservices.azure.com/.default",
@@ -437,17 +481,14 @@ async fn short_lived_token_expiry_is_observable_and_refetched() {
         authorizer.authorize(&mut req).await.unwrap();
     }
 
-    let expires_at = authorizer
-        .expires_at()
-        .expect("short-lived token expiry should be projected");
     assert!(
-        expires_at > Utc::now(),
-        "cached expiry should carry the token endpoint's expires_in"
+        authorizer.expires_at().is_none(),
+        "provider-local expiry must not be projected without AuthMachine lease truth"
     );
     assert_eq!(
         mock.counter.load(Ordering::SeqCst),
         2,
-        "token inside the canonical refresh window must be refetched"
+        "token without AuthMachine lease truth must be refetched"
     );
 }
 
@@ -666,6 +707,12 @@ async fn refresh_failure_is_visible_on_auth_lease_snapshot() {
     assert!(
         matches!(err, meerkat_core::AuthError::RefreshFailed(_)),
         "token endpoint failure should still surface as refresh failure, got {err:?}"
+    );
+    assert!(
+        headers
+            .iter()
+            .all(|(name, _)| !name.eq_ignore_ascii_case("authorization")),
+        "refresh failure must not fall back to the stale provider-local token"
     );
 
     let snapshot = handle.snapshot(&lease_key);

--- a/meerkat-auth-core/tests/google_auth_authorizer.rs
+++ b/meerkat-auth-core/tests/google_auth_authorizer.rs
@@ -215,6 +215,7 @@ impl AuthLeaseHandle for RecordingAuthLeaseHandle {
             expires_at: Some(expires_at),
             credential_present: true,
             generation,
+            credential_published_at_millis: None,
         };
         Ok(AuthLeaseTransition {
             generation,
@@ -266,6 +267,7 @@ impl AuthLeaseHandle for RecordingAuthLeaseHandle {
             expires_at: Some(new_expires_at),
             credential_present: true,
             generation,
+            credential_published_at_millis: None,
         };
         Ok(AuthLeaseTransition {
             generation,
@@ -434,8 +436,8 @@ async fn service_account_path_signs_jwt_and_gets_token() {
         .unwrap();
     assert_eq!(auth.1, "Bearer sa-access-token");
     assert!(
-        authorizer.expires_at().is_some(),
-        "service-account token expiry must be observable through HttpAuthorizer"
+        authorizer.expires_at().is_none(),
+        "Google token expiry is only projected from AuthMachine lease truth"
     );
     assert_eq!(mock.counter.load(Ordering::SeqCst), 1);
     let captured = mock.captured.lock().unwrap();
@@ -550,7 +552,7 @@ async fn default_chain_falls_through_to_metadata_when_no_sa_and_no_user_adc() {
 }
 
 #[tokio::test]
-async fn token_is_cached_between_calls() {
+async fn provider_local_cache_without_auth_lease_is_not_reused_as_fresh() {
     let mock = start_mock("cached-sa-token").await;
     let tempdir = tempfile::tempdir().unwrap();
     let sa_path = write_sa_key(tempdir.path(), &format!("{}/token", mock.base_url));
@@ -579,8 +581,69 @@ async fn token_is_cached_between_calls() {
     }
     assert_eq!(
         mock.counter.load(Ordering::SeqCst),
-        1,
-        "expected single fetch with caching"
+        4,
+        "provider-local cache must not decide freshness without AuthMachine lease truth"
+    );
+}
+
+#[tokio::test]
+async fn provider_local_cache_without_auth_lease_fails_closed_instead_of_reuse() {
+    let mock = start_mock_with_config(
+        "cached-without-lease",
+        vec![3600],
+        Some(MockFailure {
+            from_call: 2,
+            status: axum::http::StatusCode::UNAUTHORIZED,
+            body: serde_json::json!({"error": "invalid_client"}),
+        }),
+    )
+    .await;
+    let tempdir = tempfile::tempdir().unwrap();
+    let sa_path = write_sa_key(tempdir.path(), &format!("{}/token", mock.base_url));
+    let env_lookup = {
+        let sa_path = sa_path.clone();
+        Arc::new(move |k: &str| {
+            if k == "GOOGLE_APPLICATION_CREDENTIALS" {
+                Some(sa_path.to_string_lossy().to_string())
+            } else {
+                None
+            }
+        }) as Arc<dyn Fn(&str) -> Option<String> + Send + Sync>
+    };
+    let authorizer = GoogleAuthAuthorizer::with_env_lookup(GoogleAuthChain::Default, env_lookup)
+        .with_home_dir(tempdir.path())
+        .with_token_url_override(format!("{}/token", mock.base_url));
+
+    let mut headers = Vec::new();
+    let mut req = HttpAuthorizationRequest {
+        method: "POST",
+        url: "https://x.googleapis.com/",
+        headers: &mut headers,
+    };
+    authorizer.authorize(&mut req).await.unwrap();
+
+    let mut headers = Vec::new();
+    let mut req = HttpAuthorizationRequest {
+        method: "POST",
+        url: "https://x.googleapis.com/",
+        headers: &mut headers,
+    };
+    let err = authorizer.authorize(&mut req).await.unwrap_err();
+
+    assert!(
+        matches!(err, meerkat_core::AuthError::RefreshFailed(_)),
+        "second authorize must refetch and fail without lease freshness, got {err:?}"
+    );
+    assert!(
+        headers
+            .iter()
+            .all(|(name, _)| !name.eq_ignore_ascii_case("authorization")),
+        "stale provider-local cache must not attach an authorization header without AuthMachine lease truth"
+    );
+    assert_eq!(
+        mock.counter.load(Ordering::SeqCst),
+        2,
+        "second authorize must reach the token endpoint instead of treating the private cache as fresh"
     );
 }
 
@@ -748,7 +811,7 @@ async fn observer_failure_fails_closed_without_authorization_header() {
 }
 
 #[tokio::test]
-async fn short_lived_token_expiry_is_observable_and_refetched() {
+async fn short_lived_token_without_auth_lease_refetches_without_expiry_projection() {
     let mock = start_mock_with_expiry("short-lived-sa-token", 30).await;
     let tempdir = tempfile::tempdir().unwrap();
     let sa_path = write_sa_key(tempdir.path(), &format!("{}/token", mock.base_url));
@@ -776,17 +839,14 @@ async fn short_lived_token_expiry_is_observable_and_refetched() {
         authorizer.authorize(&mut req).await.unwrap();
     }
 
-    let expires_at = authorizer
-        .expires_at()
-        .expect("short-lived token expiry should be projected");
     assert!(
-        expires_at > Utc::now(),
-        "cached expiry should carry the token endpoint's expires_in"
+        authorizer.expires_at().is_none(),
+        "provider-local expiry must not be projected without AuthMachine lease truth"
     );
     assert_eq!(
         mock.counter.load(Ordering::SeqCst),
         2,
-        "token inside the canonical refresh window must be refetched"
+        "token without AuthMachine lease truth must be refetched"
     );
 }
 
@@ -844,6 +904,12 @@ async fn token_endpoint_transient_failure_keeps_auth_lease_retryable() {
     assert!(
         matches!(err, meerkat_core::AuthError::RefreshFailed(_)),
         "token endpoint outage should still fail the caller visibly, got {err:?}"
+    );
+    assert!(
+        headers
+            .iter()
+            .all(|(name, _)| !name.eq_ignore_ascii_case("authorization")),
+        "refresh failure must not fall back to the stale provider-local token"
     );
 
     let snapshot = handle.snapshot(&lease_key);

--- a/meerkat-auth-core/tests/google_auth_authorizer.rs
+++ b/meerkat-auth-core/tests/google_auth_authorizer.rs
@@ -399,6 +399,28 @@ fn write_user_adc(dir: &std::path::Path, token_url: &str) -> std::path::PathBuf 
     path
 }
 
+fn with_recording_auth_lease(
+    authorizer: GoogleAuthAuthorizer,
+    profile_id: &str,
+) -> (
+    GoogleAuthAuthorizer,
+    Arc<RecordingAuthLeaseHandle>,
+    LeaseKey,
+) {
+    let handle = Arc::new(RecordingAuthLeaseHandle::default());
+    let lease_key = LeaseKey::new(
+        RealmId::parse("dev").unwrap(),
+        BindingId::parse("gemini").unwrap(),
+        Some(ProfileId::parse(profile_id).unwrap()),
+    );
+    let lease_handle: Arc<dyn AuthLeaseHandle> = handle.clone();
+    (
+        authorizer.with_auth_lease_observer(lease_handle, lease_key.clone()),
+        handle,
+        lease_key,
+    )
+}
+
 // --- Service account path ---------------------------------------------
 
 #[tokio::test]
@@ -418,9 +440,12 @@ async fn service_account_path_signs_jwt_and_gets_token() {
         }) as Arc<dyn Fn(&str) -> Option<String> + Send + Sync>
     };
 
-    let authorizer = GoogleAuthAuthorizer::with_env_lookup(GoogleAuthChain::Default, env_lookup)
-        .with_home_dir(tempdir.path()) // empty home, no user ADC
-        .with_token_url_override(format!("{}/token", mock.base_url));
+    let (authorizer, _, _) = with_recording_auth_lease(
+        GoogleAuthAuthorizer::with_env_lookup(GoogleAuthChain::Default, env_lookup)
+            .with_home_dir(tempdir.path()) // empty home, no user ADC
+            .with_token_url_override(format!("{}/token", mock.base_url)),
+        "google_adc",
+    );
 
     let mut headers = Vec::new();
     let mut req = HttpAuthorizationRequest {
@@ -436,8 +461,8 @@ async fn service_account_path_signs_jwt_and_gets_token() {
         .unwrap();
     assert_eq!(auth.1, "Bearer sa-access-token");
     assert!(
-        authorizer.expires_at().is_none(),
-        "Google token expiry is only projected from AuthMachine lease truth"
+        authorizer.expires_at().is_some(),
+        "Google token expiry must be projected from AuthMachine lease truth"
     );
     assert_eq!(mock.counter.load(Ordering::SeqCst), 1);
     let captured = mock.captured.lock().unwrap();
@@ -462,9 +487,12 @@ async fn user_adc_path_uses_refresh_token_flow() {
     let env_lookup =
         Arc::new(|_: &str| None::<String>) as Arc<dyn Fn(&str) -> Option<String> + Send + Sync>;
 
-    let authorizer = GoogleAuthAuthorizer::with_env_lookup(GoogleAuthChain::Default, env_lookup)
-        .with_home_dir(tempdir.path())
-        .with_token_url_override(format!("{}/token", mock.base_url));
+    let (authorizer, _, _) = with_recording_auth_lease(
+        GoogleAuthAuthorizer::with_env_lookup(GoogleAuthChain::Default, env_lookup)
+            .with_home_dir(tempdir.path())
+            .with_token_url_override(format!("{}/token", mock.base_url)),
+        "google_user_adc",
+    );
 
     let mut headers = Vec::new();
     let mut req = HttpAuthorizationRequest {
@@ -499,12 +527,14 @@ async fn compute_only_chain_uses_metadata_server() {
     let env_lookup =
         Arc::new(|_: &str| None::<String>) as Arc<dyn Fn(&str) -> Option<String> + Send + Sync>;
 
-    let authorizer =
+    let (authorizer, _, _) = with_recording_auth_lease(
         GoogleAuthAuthorizer::with_env_lookup(GoogleAuthChain::ComputeOnly, env_lookup)
             .with_metadata_url_override(format!(
                 "{}/computeMetadata/v1/instance/service-accounts/default/token",
                 mock.base_url
-            ));
+            )),
+        "google_metadata",
+    );
 
     let mut headers = Vec::new();
     let mut req = HttpAuthorizationRequest {
@@ -530,12 +560,15 @@ async fn default_chain_falls_through_to_metadata_when_no_sa_and_no_user_adc() {
     let env_lookup =
         Arc::new(|_: &str| None::<String>) as Arc<dyn Fn(&str) -> Option<String> + Send + Sync>;
 
-    let authorizer = GoogleAuthAuthorizer::with_env_lookup(GoogleAuthChain::Default, env_lookup)
-        .with_home_dir(tempdir.path())
-        .with_metadata_url_override(format!(
-            "{}/computeMetadata/v1/instance/service-accounts/default/token",
-            mock.base_url
-        ));
+    let (authorizer, _, _) = with_recording_auth_lease(
+        GoogleAuthAuthorizer::with_env_lookup(GoogleAuthChain::Default, env_lookup)
+            .with_home_dir(tempdir.path())
+            .with_metadata_url_override(format!(
+                "{}/computeMetadata/v1/instance/service-accounts/default/token",
+                mock.base_url
+            )),
+        "google_default_metadata",
+    );
 
     let mut headers = Vec::new();
     let mut req = HttpAuthorizationRequest {
@@ -552,7 +585,7 @@ async fn default_chain_falls_through_to_metadata_when_no_sa_and_no_user_adc() {
 }
 
 #[tokio::test]
-async fn provider_local_cache_without_auth_lease_is_not_reused_as_fresh() {
+async fn authorize_without_auth_lease_observer_fails_closed_before_token_fetch() {
     let mock = start_mock("cached-sa-token").await;
     let tempdir = tempfile::tempdir().unwrap();
     let sa_path = write_sa_key(tempdir.path(), &format!("{}/token", mock.base_url));
@@ -570,58 +603,6 @@ async fn provider_local_cache_without_auth_lease_is_not_reused_as_fresh() {
         .with_home_dir(tempdir.path())
         .with_token_url_override(format!("{}/token", mock.base_url));
 
-    for _ in 0..4 {
-        let mut headers = Vec::new();
-        let mut req = HttpAuthorizationRequest {
-            method: "POST",
-            url: "https://x.googleapis.com/",
-            headers: &mut headers,
-        };
-        authorizer.authorize(&mut req).await.unwrap();
-    }
-    assert_eq!(
-        mock.counter.load(Ordering::SeqCst),
-        4,
-        "provider-local cache must not decide freshness without AuthMachine lease truth"
-    );
-}
-
-#[tokio::test]
-async fn provider_local_cache_without_auth_lease_fails_closed_instead_of_reuse() {
-    let mock = start_mock_with_config(
-        "cached-without-lease",
-        vec![3600],
-        Some(MockFailure {
-            from_call: 2,
-            status: axum::http::StatusCode::UNAUTHORIZED,
-            body: serde_json::json!({"error": "invalid_client"}),
-        }),
-    )
-    .await;
-    let tempdir = tempfile::tempdir().unwrap();
-    let sa_path = write_sa_key(tempdir.path(), &format!("{}/token", mock.base_url));
-    let env_lookup = {
-        let sa_path = sa_path.clone();
-        Arc::new(move |k: &str| {
-            if k == "GOOGLE_APPLICATION_CREDENTIALS" {
-                Some(sa_path.to_string_lossy().to_string())
-            } else {
-                None
-            }
-        }) as Arc<dyn Fn(&str) -> Option<String> + Send + Sync>
-    };
-    let authorizer = GoogleAuthAuthorizer::with_env_lookup(GoogleAuthChain::Default, env_lookup)
-        .with_home_dir(tempdir.path())
-        .with_token_url_override(format!("{}/token", mock.base_url));
-
-    let mut headers = Vec::new();
-    let mut req = HttpAuthorizationRequest {
-        method: "POST",
-        url: "https://x.googleapis.com/",
-        headers: &mut headers,
-    };
-    authorizer.authorize(&mut req).await.unwrap();
-
     let mut headers = Vec::new();
     let mut req = HttpAuthorizationRequest {
         method: "POST",
@@ -631,19 +612,19 @@ async fn provider_local_cache_without_auth_lease_fails_closed_instead_of_reuse()
     let err = authorizer.authorize(&mut req).await.unwrap_err();
 
     assert!(
-        matches!(err, meerkat_core::AuthError::RefreshFailed(_)),
-        "second authorize must refetch and fail without lease freshness, got {err:?}"
+        matches!(err, meerkat_core::AuthError::HostOwnedUnavailable),
+        "cloud authorizer must fail closed without AuthMachine ownership, got {err:?}"
     );
     assert!(
         headers
             .iter()
             .all(|(name, _)| !name.eq_ignore_ascii_case("authorization")),
-        "stale provider-local cache must not attach an authorization header without AuthMachine lease truth"
+        "observer-absent cloud authorizer must not attach an authorization header"
     );
     assert_eq!(
         mock.counter.load(Ordering::SeqCst),
-        2,
-        "second authorize must reach the token endpoint instead of treating the private cache as fresh"
+        0,
+        "observer-absent cloud authorizer must not fetch a provider-local token"
     );
 }
 
@@ -807,46 +788,6 @@ async fn observer_failure_fails_closed_without_authorization_header() {
             .iter()
             .all(|(name, _)| !name.eq_ignore_ascii_case("authorization")),
         "authorizer must not attach a bearer token when lease truth rejected publication"
-    );
-}
-
-#[tokio::test]
-async fn short_lived_token_without_auth_lease_refetches_without_expiry_projection() {
-    let mock = start_mock_with_expiry("short-lived-sa-token", 30).await;
-    let tempdir = tempfile::tempdir().unwrap();
-    let sa_path = write_sa_key(tempdir.path(), &format!("{}/token", mock.base_url));
-    let env_lookup = {
-        let sa_path = sa_path.clone();
-        Arc::new(move |k: &str| {
-            if k == "GOOGLE_APPLICATION_CREDENTIALS" {
-                Some(sa_path.to_string_lossy().to_string())
-            } else {
-                None
-            }
-        }) as Arc<dyn Fn(&str) -> Option<String> + Send + Sync>
-    };
-    let authorizer = GoogleAuthAuthorizer::with_env_lookup(GoogleAuthChain::Default, env_lookup)
-        .with_home_dir(tempdir.path())
-        .with_token_url_override(format!("{}/token", mock.base_url));
-
-    for _ in 0..2 {
-        let mut headers = Vec::new();
-        let mut req = HttpAuthorizationRequest {
-            method: "POST",
-            url: "https://x.googleapis.com/",
-            headers: &mut headers,
-        };
-        authorizer.authorize(&mut req).await.unwrap();
-    }
-
-    assert!(
-        authorizer.expires_at().is_none(),
-        "provider-local expiry must not be projected without AuthMachine lease truth"
-    );
-    assert_eq!(
-        mock.counter.load(Ordering::SeqCst),
-        2,
-        "token without AuthMachine lease truth must be refetched"
     );
 }
 
@@ -1069,11 +1010,14 @@ async fn missing_credentials_surface_missing_secret() {
     let tempdir = tempfile::tempdir().unwrap();
     let env_lookup =
         Arc::new(|_: &str| None::<String>) as Arc<dyn Fn(&str) -> Option<String> + Send + Sync>;
-    let authorizer = GoogleAuthAuthorizer::with_env_lookup(GoogleAuthChain::Default, env_lookup)
-        .with_home_dir(tempdir.path())
-        .with_metadata_url_override(format!(
-            "http://{addr}/computeMetadata/v1/instance/service-accounts/default/token"
-        ));
+    let (authorizer, _, _) = with_recording_auth_lease(
+        GoogleAuthAuthorizer::with_env_lookup(GoogleAuthChain::Default, env_lookup)
+            .with_home_dir(tempdir.path())
+            .with_metadata_url_override(format!(
+                "http://{addr}/computeMetadata/v1/instance/service-accounts/default/token"
+            )),
+        "google_missing",
+    );
 
     let mut headers = Vec::new();
     let mut req = HttpAuthorizationRequest {


### PR DESCRIPTION
## Summary
- require an AuthMachine observer before Google/Azure authorizers can inspect cache, fetch provider tokens, record refresh results, or attach bearer headers
- keep provider-local token caches as private storage only; cache reuse remains a read-only projection of AuthMachine lease generation and expiry
- update Google/Azure fixtures so success paths install an observer and observer-absent paths fail closed without hitting token endpoints
- merge latest `origin/main` and delete orphan `.claude/worktrees/piped-orbiting-oasis` gitlink so the base-owned checkout/gate cleanup can run

## Validation
- Baseline before rework: Azure no-observer bearer-header test passed on old head, proving the reviewed escape hatch existed.
- Baseline before rework: Google no-observer service-account bearer-header test passed on old head, proving the reviewed escape hatch existed.
- `make fmt`
- `./scripts/repo-cargo test -p meerkat-auth-core --features gcp-auth,azure-ad --lib authorizers::tests`
- `make lint` (BuildBuddy invocation `c7b57774-5278-47c0-a449-0315cebe33f4`)
- `make check` (BuildBuddy invocation `51dad898-084c-4e39-a059-8389fe18e33f`)
- `./scripts/repo-cargo test -p meerkat-auth-core --features gcp-auth,azure-ad --test google_auth_authorizer --test azure_ad_authorizer`
- after merging latest `origin/main`: `./scripts/repo-cargo test -p meerkat-auth-core --features gcp-auth,azure-ad --test google_auth_authorizer --test azure_ad_authorizer`
- after deleting orphan gitlink: `git submodule foreach --recursive true`

## Review Readiness Packet

Current head SHA: `bd952edb61f64070d5b4b4c663c05318d2ab73ae`

Command output:

```text
$ ./scripts/repo-cargo test -p meerkat-auth-core --features gcp-auth,azure-ad --test google_auth_authorizer --test azure_ad_authorizer
Azure authorizer tests: 12 passed; Google authorizer tests: 12 passed.

$ make lint
Build completed successfully (BuildBuddy invocation c7b57774-5278-47c0-a449-0315cebe33f4).

$ make check
Build completed successfully (BuildBuddy invocation 51dad898-084c-4e39-a059-8389fe18e33f).

$ git submodule foreach --recursive true
(no output; exit 0)

 scripts/dogma_cleanup_gate.py --packet <(gh pr view 575 --json body -q .body) --repo . --base origin/main --head-sha bd952edb61f64070d5b4b4c663c05318d2ab73ae
Dogma cleanup gate passed for /dev/fd/63
```

## Complexity Delta

- Docs/scripts/tests: Google/Azure authorizer fixtures updated; orphan `.claude/worktrees/piped-orbiting-oasis` gitlink deleted to unblock base-owned checkout cleanup.
- Non-test implementation: Google/Azure authorizer `get_token` and cache lookup paths now require AuthMachine observer ownership.
- Generated/schema churn: none.

## Old Path Amputation Proof

| Old path | Classification | Search literal | Mechanical proof | Follow-up |
| --- | --- | --- | --- | --- |
| `token_is_fresh_at provider-local cache freshness` | deleted | `token_is_fresh_at` | Symbol removed; `rg -n "token_is_fresh_at" meerkat-auth-core/src/authorizers` returns no production references. | none |
| `observer optional lifecycle get_token provider fetch` | made uncallable at boundary | `lifecycle = if let Some(observer)` | Production `GoogleAuthAuthorizer::get_token` and `AzureAdAuthorizer::get_token` reject access with `AuthError::HostOwnedUnavailable` before provider token fetch or header attachment when AuthMachine observer ownership is absent. | none |

## Sample Passing Old Path Amputation Proof

| Old path | Classification | Search literal | Mechanical proof | Follow-up |
| --- | --- | --- | --- | --- |
| `old/session-route` | deleted | `old/session-route` | No production references remain. | none |

## Sample Failing Old Path Amputation Proof

| Old path | Classification | Search literal | Mechanical proof | Follow-up |
| --- | --- | --- | --- | --- |
| `old/session-route` | wrapped | `old/session-route` | A preferred path exists beside the old route. | none |
| `surface_request_lifecycle_helper` | made uncallable at boundary | `surface_request_lifecycle_helper` | Boundary test exercises the replacement wrapper while the old helper remains callable for compatibility. | none |
| `wasm_contract_string_mirror` | retained with linked follow-up | `wasm_contract_string_mirror` | Retained for an active SDK cutover. | LUC-999 |

Linear: LUC-353


<!-- ci-refresh: 2026-05-03T15:03:33Z
 -->
