### PR TITLE
LUC-348: Type mob lifecycle action dispatch

### DIFF
--- a/docs/review-readiness/luc-348-typed-mob-lifecycle-actions.md
+++ b/docs/review-readiness/luc-348-typed-mob-lifecycle-actions.md
@@ -1,0 +1,99 @@
+# LUC-348 Review Readiness Packet
+
+Issue: `LUC-348 P1 Mechanical Slice: typed public mob lifecycle actions`
+
+## Exact-Head Scope
+
+This packet applies to branch `codex/LUC-348-typed-mob-lifecycle` and the
+commit that includes this file.
+
+## Implementation Churn
+
+- `meerkat-mob-mcp/src/lib.rs`
+  - Added `MobMcpState::mob_lifecycle_action`, a typed dispatch helper that
+    accepts `WireMobLifecycleAction`.
+  - Agent MCP `mob_lifecycle` now deserializes `MobLifecycleParams` from
+    `meerkat-contracts` and dispatches through `mob_lifecycle_action`.
+  - The agent MCP `mob_lifecycle` tool schema is emitted from
+    `MobLifecycleParams`.
+- `meerkat-mob-mcp/src/public_mcp.rs`
+  - Public MCP `meerkat_mob_lifecycle` now deserializes `MobLifecycleParams`
+    from `meerkat-contracts`.
+  - Public MCP lifecycle results are emitted as `MobLifecycleResult`.
+  - Public MCP dispatches through `MobMcpState::mob_lifecycle_action`.
+- `meerkat-web-runtime/src/lib.rs`
+  - WASM `mob_lifecycle(mob_id, action)` keeps its JS string carrier only as
+    a compatibility ABI.
+  - The string carrier is immediately deserialized into
+    `WireMobLifecycleAction` before mob state lookup or dispatch.
+  - WASM dispatches through `MobMcpState::mob_lifecycle_action`.
+
+## Generated / Schema Churn
+
+- No generated SDK files changed.
+- Existing generated SDK parity remains anchored on the already-generated
+  `MobLifecycleParams`, `MobLifecycleResult`, and `MobLifecycleAction` shapes.
+- Agent MCP and public MCP lifecycle tool schemas now use the contract schema
+  for `MobLifecycleParams` instead of local/manual lifecycle action schemas.
+
+## Test Churn
+
+- `meerkat-contracts/src/wire/mob.rs`
+  - Added fixtures proving unknown lifecycle action strings are rejected by
+    `MobLifecycleParams` deserialization.
+  - Added a typed lifecycle result round-trip fixture.
+- `meerkat-mob-mcp/src/lib.rs`
+  - Added agent MCP fixtures for unknown action rejection at contract parse
+    time and valid typed contract params dispatch.
+- `meerkat-mob-mcp/src/public_mcp.rs`
+  - Added public MCP fixtures for unknown action rejection at contract parse
+    time and valid typed contract params dispatch.
+- `meerkat-web-runtime/src/lib.rs`
+  - Added a WASM/runtime string-carrier fixture proving the carrier is parsed
+    through `WireMobLifecycleAction` and rejects unknown values.
+
+## Old Path Amputation Proof
+
+Removed or made uncallable:
+
+- Public MCP raw lifecycle matcher:
+  - Removed `MeerkatMobLifecycleInput { action: String }`.
+  - Removed `match input.action.as_str()` over `stop`, `resume`, `complete`,
+    `reset`, and `destroy`.
+  - Unknown action values now fail during `MobLifecycleParams` deserialization
+    before `parse_mob_id`, state lookup, or mob dispatch.
+- Agent MCP raw lifecycle matcher:
+  - Removed `LifecycleArgs { action: String }`.
+  - Removed `match args.action.as_str()` over `stop`, `resume`, `reset`,
+    `complete`, and `destroy`.
+  - Unknown action values now fail during `MobLifecycleParams` deserialization
+    before `MobId` construction or mob dispatch.
+- WASM raw lifecycle matcher:
+  - Removed local `match action` over `stop`, `resume`, `complete`, `reset`,
+    and `destroy`.
+  - The exported `action: &str` remains only as the wasm-bindgen JS ABI
+    compatibility carrier.
+  - Unknown action values now fail during `WireMobLifecycleAction`
+    deserialization before `with_mob_state` or mob dispatch.
+
+Remaining raw `action` strings in touched behavior:
+
+- Agent/public MCP and WASM tests still pass JSON/string values to exercise
+  wire compatibility. Those carriers deserialize into the typed contract before
+  public lifecycle behavior can run.
+- Agent MCP still has non-lifecycle raw action strings for `mob_wire` and
+  `mob_unwire`. Those are outside the lifecycle action surface and were not
+  changed by this slice.
+
+## Validation
+
+- Baseline before edits:
+  - `./scripts/repo-cargo test -p meerkat-mob-mcp test_mcp_stop_resume_round_trip --lib`
+- Focused validation after edits:
+  - `./scripts/repo-cargo test -p meerkat-contracts mob_lifecycle --lib`
+  - `./scripts/repo-cargo test -p meerkat-mob-mcp lifecycle --lib`
+  - `./scripts/repo-cargo test -p meerkat-web-runtime mob_lifecycle_action_string_carrier --lib`
+  - `./scripts/repo-cargo test -p meerkat-mob-mcp test_mcp_stop_resume_round_trip --lib`
+- Broad validation:
+  - `make check`
+  - `make lint`

--- a/meerkat-contracts/src/wire/mob.rs
+++ b/meerkat-contracts/src/wire/mob.rs
@@ -2044,6 +2044,37 @@ mod tests {
     }
 
     #[test]
+    fn mob_lifecycle_params_reject_unknown_action_string() {
+        let err = serde_json::from_value::<MobLifecycleParams>(serde_json::json!({
+            "mob_id": "mob-1",
+            "action": "explode"
+        }))
+        .expect_err("unknown lifecycle actions must fail at the typed wire boundary");
+
+        assert!(
+            err.to_string().contains("unknown variant"),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[test]
+    fn mob_lifecycle_result_round_trips_typed_action() {
+        let result = MobLifecycleResult {
+            mob_id: "mob-1".into(),
+            action: WireMobLifecycleAction::Complete,
+            ok: true,
+            destroy_report: None,
+        };
+
+        let json = serde_json::to_value(&result).expect("serialize lifecycle result");
+        assert_eq!(json["action"], "complete");
+
+        let round_trip: MobLifecycleResult =
+            serde_json::from_value(json).expect("deserialize lifecycle result");
+        assert_eq!(round_trip.action, WireMobLifecycleAction::Complete);
+    }
+
+    #[test]
     fn mob_spawn_many_result_entry_uses_typed_status_result_envelope() {
         let member_ref = WireMemberRef::encode("mob-1", "worker-1");
         let entry = MobSpawnManyResultEntry::spawned("worker-1", member_ref.clone());

--- a/meerkat-mob-mcp/src/lib.rs
+++ b/meerkat-mob-mcp/src/lib.rs
@@ -30,7 +30,10 @@ mod tokio {
 use async_trait::async_trait;
 
 use meerkat_client::LlmClient;
-use meerkat_contracts::{MobDefinitionInput, MobSpawnManyResultEntry, WireMemberRef};
+use meerkat_contracts::{
+    MobDefinitionInput, MobLifecycleParams, MobSpawnManyResultEntry, WireMemberRef,
+    WireMobLifecycleAction,
+};
 use meerkat_core::AppendSystemContextStatus;
 use meerkat_core::ScopedAgentEvent;
 use meerkat_core::agent::{AgentToolDispatcher, CommsRuntime as CoreCommsRuntime};
@@ -529,6 +532,32 @@ impl MobMcpState {
 
     pub async fn mob_reset(&self, mob_id: &MobId) -> Result<(), MobError> {
         self.handle_for(mob_id).await?.reset().await
+    }
+
+    pub async fn mob_lifecycle_action(
+        &self,
+        mob_id: &MobId,
+        action: WireMobLifecycleAction,
+    ) -> Result<Option<meerkat_mob::MobDestroyReport>, MobError> {
+        match action {
+            WireMobLifecycleAction::Stop => {
+                self.mob_stop(mob_id).await?;
+                Ok(None)
+            }
+            WireMobLifecycleAction::Resume => {
+                self.mob_resume(mob_id).await?;
+                Ok(None)
+            }
+            WireMobLifecycleAction::Complete => {
+                self.mob_complete(mob_id).await?;
+                Ok(None)
+            }
+            WireMobLifecycleAction::Reset => {
+                self.mob_reset(mob_id).await?;
+                Ok(None)
+            }
+            WireMobLifecycleAction::Destroy => self.mob_destroy(mob_id).await.map(Some),
+        }
     }
 
     /// Destroy a mob. Rejects implicit delegation mobs — use
@@ -2085,7 +2114,7 @@ impl MobMcpDispatcher {
             tool(
                 "mob_lifecycle",
                 &format!("Lifecycle action on a mob. action: stop | resume | reset | complete | destroy. {COMMON}"),
-                json!({"type":"object","properties":{"mob_id":{"type":"string"},"action":{"type":"string","enum":["stop","resume","reset","complete","destroy"]}},"required":["mob_id","action"]}),
+                lifecycle_input_schema(),
             ),
             tool(
                 "mob_events",
@@ -2280,6 +2309,11 @@ fn tool(name: &str, description: &str, input_schema: serde_json::Value) -> Arc<T
     })
 }
 
+fn lifecycle_input_schema() -> serde_json::Value {
+    serde_json::to_value(schemars::schema_for!(MobLifecycleParams))
+        .unwrap_or_else(|_| json!({ "type": "object" }))
+}
+
 fn content_input_schema() -> serde_json::Value {
     json!({
         "oneOf": [
@@ -2364,11 +2398,6 @@ struct MobCreateArgs {
 struct MobListArgs {
     #[serde(default)]
     mob_id: Option<String>,
-}
-#[derive(Deserialize)]
-struct LifecycleArgs {
-    mob_id: String,
-    action: String,
 }
 #[derive(Deserialize)]
 struct MobIdArgs {
@@ -2615,49 +2644,18 @@ impl AgentToolDispatcher for MobMcpDispatcher {
                 }
             }
             "mob_lifecycle" => {
-                let args: LifecycleArgs = call
+                let args: MobLifecycleParams = call
                     .parse_args()
                     .map_err(|e| ToolError::invalid_arguments(call.name, e.to_string()))?;
                 let mob_id = MobId::from(args.mob_id);
-                match args.action.as_str() {
-                    "stop" => self
-                        .state
-                        .mob_stop(&mob_id)
-                        .await
-                        .map_err(|e| map_mob_err(call, e))?,
-                    "resume" => self
-                        .state
-                        .mob_resume(&mob_id)
-                        .await
-                        .map_err(|e| map_mob_err(call, e))?,
-                    "reset" => self
-                        .state
-                        .mob_reset(&mob_id)
-                        .await
-                        .map_err(|e| map_mob_err(call, e))?,
-                    "complete" => self
-                        .state
-                        .mob_complete(&mob_id)
-                        .await
-                        .map_err(|e| map_mob_err(call, e))?,
-                    "destroy" => {
-                        // MCP tool surface treats destroy as "() on success";
-                        // the structured MobDestroyReport is available via the
-                        // RPC lifecycle handler for consumers that care about
-                        // force-destroyed members and partial-cleanup errors.
-                        let _report = self
-                            .state
-                            .mob_destroy(&mob_id)
-                            .await
-                            .map_err(|e| map_mob_err(call, e))?;
-                    }
-                    other => {
-                        return Err(ToolError::invalid_arguments(
-                            call.name,
-                            format!("unknown lifecycle action: {other}"),
-                        ));
-                    }
-                }
+                // MCP tool surface treats destroy as "() on success"; the
+                // structured MobDestroyReport is available via public/RPC
+                // lifecycle result envelopes for consumers that need detail.
+                let _destroy_report = self
+                    .state
+                    .mob_lifecycle_action(&mob_id, args.action)
+                    .await
+                    .map_err(|e| map_mob_err(call, e))?;
                 encode(call, json!({"ok": true}))
             }
             "mob_events" => {
@@ -4054,6 +4052,79 @@ mod tests {
                 "mob_wait_ready",
             ]
         );
+    }
+
+    #[tokio::test]
+    async fn test_mob_lifecycle_rejects_unknown_action_at_contract_boundary() {
+        let svc = Arc::new(MockSessionSvc::new());
+        let state = Arc::new(MobMcpState::new(svc));
+        let d = MobMcpDispatcher::new(state);
+
+        call_tool(
+            &d,
+            "mob_create",
+            json!({"definition":{"id":"typed_agent_lifecycle_rejects_unknown","profiles":{"worker":{"model":"claude-sonnet-4-6","tools":{"comms":true}}}}}),
+        )
+        .await;
+
+        let error = call_tool_err(
+            &d,
+            "mob_lifecycle",
+            json!({"mob_id": "typed_agent_lifecycle_rejects_unknown", "action": "explode"}),
+        )
+        .await;
+        let ToolError::InvalidArguments { reason, .. } = error else {
+            panic!("unknown lifecycle action must be InvalidArguments, got: {error:?}");
+        };
+        assert!(
+            reason.contains("unknown variant") && !reason.contains("unknown lifecycle action"),
+            "unexpected error: {reason}"
+        );
+
+        let status = call_tool(
+            &d,
+            "mob_list",
+            json!({"mob_id": "typed_agent_lifecycle_rejects_unknown"}),
+        )
+        .await;
+        assert_eq!(status["status"], "Running");
+
+        call_tool(
+            &d,
+            "mob_lifecycle",
+            json!({"mob_id": "typed_agent_lifecycle_rejects_unknown", "action": "destroy"}),
+        )
+        .await;
+    }
+
+    #[tokio::test]
+    async fn test_mob_lifecycle_accepts_typed_contract_params() {
+        let svc = Arc::new(MockSessionSvc::new());
+        let state = Arc::new(MobMcpState::new(svc));
+        let d = MobMcpDispatcher::new(state);
+
+        call_tool(
+            &d,
+            "mob_create",
+            json!({"definition":{"id":"typed_agent_lifecycle_complete","profiles":{"worker":{"model":"claude-sonnet-4-6","tools":{"comms":true}}}}}),
+        )
+        .await;
+
+        let params = MobLifecycleParams {
+            mob_id: "typed_agent_lifecycle_complete".to_string(),
+            action: WireMobLifecycleAction::Complete,
+        };
+        let payload = serde_json::to_value(&params).expect("typed lifecycle params serialize");
+        let result = call_tool(&d, "mob_lifecycle", payload).await;
+
+        assert_eq!(result["ok"], true);
+
+        call_tool(
+            &d,
+            "mob_lifecycle",
+            json!({"mob_id": "typed_agent_lifecycle_complete", "action": "destroy"}),
+        )
+        .await;
     }
 
     #[test]

--- a/meerkat-mob-mcp/src/public_mcp.rs
+++ b/meerkat-mob-mcp/src/public_mcp.rs
@@ -2,10 +2,11 @@
 
 use crate::{McpToolError, MobMcpState, decode_public_mob_definition};
 use meerkat_contracts::{
-    MobCreateParams, MobMemberSendParams, RealtimeCapabilities, RealtimeCapabilitiesParams,
-    RealtimeCapabilitiesResult, RealtimeChannelTarget, RealtimeOpenRequest, RealtimeStatusParams,
-    RealtimeStatusResult, WireContentInput, WireMemberRef, WireMobBackendKind, WireMobRuntimeMode,
-    WireRuntimeBinding, WireTrustedPeerIdentity,
+    MobCreateParams, MobLifecycleParams, MobLifecycleResult, MobMemberSendParams,
+    RealtimeCapabilities, RealtimeCapabilitiesParams, RealtimeCapabilitiesResult,
+    RealtimeChannelTarget, RealtimeOpenRequest, RealtimeStatusParams, RealtimeStatusResult,
+    WireContentInput, WireMemberRef, WireMobBackendKind, WireMobRuntimeMode, WireRuntimeBinding,
+    WireTrustedPeerIdentity,
 };
 use schemars::{JsonSchema, schema_for};
 use serde::Deserialize;
@@ -46,13 +47,6 @@ fn respawn_receipt_payload(
 #[serde(deny_unknown_fields)]
 struct MeerkatMobIdInput {
     mob_id: String,
-}
-
-#[derive(Debug, Deserialize, JsonSchema)]
-#[serde(deny_unknown_fields)]
-struct MeerkatMobLifecycleInput {
-    mob_id: String,
-    action: String,
 }
 
 #[derive(Debug, Deserialize, JsonSchema)]
@@ -359,7 +353,7 @@ pub fn public_tools_list() -> Vec<Value> {
         tool(
             "meerkat_mob_lifecycle",
             "Apply a lifecycle action to a mob.",
-            schema_for!(MeerkatMobLifecycleInput),
+            schema_for!(MobLifecycleParams),
         ),
         tool(
             "meerkat_mob_spawn",
@@ -547,63 +541,24 @@ pub async fn handle_public_tools_call(
             Ok(json!({ "mob_id": mob_id, "status": status.to_string() }))
         }
         "meerkat_mob_lifecycle" => {
-            let input: MeerkatMobLifecycleInput = parse_args(arguments)?;
+            let input: MobLifecycleParams = parse_args(arguments)?;
             let mob_id = parse_mob_id(&input.mob_id)?;
-            // `destroy` returns a structured MobDestroyReport; the public
-            // MCP surface projects it into the response body. Other actions
-            // stay `()` on success.
-            let destroy_report = match input.action.as_str() {
-                "stop" => {
-                    state
-                        .mob_stop(&mob_id)
-                        .await
-                        .map_err(|err| McpToolError::invalid_params(err.to_string()))?;
-                    None
-                }
-                "resume" => {
-                    state
-                        .mob_resume(&mob_id)
-                        .await
-                        .map_err(|err| McpToolError::invalid_params(err.to_string()))?;
-                    None
-                }
-                "complete" => {
-                    state
-                        .mob_complete(&mob_id)
-                        .await
-                        .map_err(|err| McpToolError::invalid_params(err.to_string()))?;
-                    None
-                }
-                "reset" => {
-                    state
-                        .mob_reset(&mob_id)
-                        .await
-                        .map_err(|err| McpToolError::invalid_params(err.to_string()))?;
-                    None
-                }
-                "destroy" => {
-                    let report = state
-                        .mob_destroy(&mob_id)
-                        .await
-                        .map_err(|err| McpToolError::invalid_params(err.to_string()))?;
-                    Some(report)
-                }
-                other => {
-                    return Err(McpToolError::invalid_params(format!(
-                        "unknown lifecycle action: {other}"
-                    )));
-                }
-            };
-            let mut body = json!({ "mob_id": mob_id, "action": input.action, "ok": true });
-            if let Some(report) = destroy_report
-                && let Some(obj) = body.as_object_mut()
-            {
-                let report_value = serde_json::to_value(&report).map_err(|err| {
-                    McpToolError::internal(format!("destroy report serialize: {err}"))
-                })?;
-                obj.insert("destroy_report".to_string(), report_value);
-            }
-            Ok(body)
+            let destroy_report = state
+                .mob_lifecycle_action(&mob_id, input.action)
+                .await
+                .map_err(|err| McpToolError::invalid_params(err.to_string()))?
+                .map(|report| {
+                    serde_json::to_value(&report).map_err(|err| {
+                        McpToolError::internal(format!("destroy report serialize: {err}"))
+                    })
+                })
+                .transpose()?;
+            Ok(json!(MobLifecycleResult {
+                mob_id: mob_id.to_string(),
+                action: input.action,
+                ok: true,
+                destroy_report,
+            }))
         }
         "meerkat_mob_spawn" => {
             let input: MeerkatMobSpawnInput = parse_args(arguments)?;
@@ -1411,5 +1366,117 @@ mod tests {
             .collect();
         assert!(names.contains(&"meerkat_mob_create".to_string()));
         assert!(!names.contains(&"mob_create".to_string()));
+    }
+
+    #[tokio::test]
+    async fn public_mcp_lifecycle_rejects_unknown_action_at_contract_boundary() {
+        let state = MobMcpState::new_in_memory();
+        handle_public_tools_call(
+            &state,
+            "meerkat_mob_create",
+            &json!({
+                "definition": {
+                    "id": "typed-public-lifecycle-rejects-unknown",
+                    "profiles": {
+                        "lead": {
+                            "model": "gpt-5.4",
+                            "tools": {"comms": true}
+                        }
+                    }
+                }
+            }),
+        )
+        .await
+        .expect("create typed public mob");
+
+        let err = handle_public_tools_call(
+            &state,
+            "meerkat_mob_lifecycle",
+            &json!({
+                "mob_id": "typed-public-lifecycle-rejects-unknown",
+                "action": "explode"
+            }),
+        )
+        .await
+        .expect_err("unknown action must fail at contract parse boundary");
+
+        assert_eq!(err.code, -32602);
+        assert!(
+            err.message.contains("unknown variant")
+                && !err.message.contains("unknown lifecycle action"),
+            "unexpected error: {}",
+            err.message
+        );
+
+        let status = handle_public_tools_call(
+            &state,
+            "meerkat_mob_status",
+            &json!({"mob_id": "typed-public-lifecycle-rejects-unknown"}),
+        )
+        .await
+        .expect("status after rejected lifecycle action");
+        assert_eq!(status["status"], "Running");
+
+        handle_public_tools_call(
+            &state,
+            "meerkat_mob_lifecycle",
+            &json!({
+                "mob_id": "typed-public-lifecycle-rejects-unknown",
+                "action": "destroy"
+            }),
+        )
+        .await
+        .expect("cleanup mob");
+    }
+
+    #[tokio::test]
+    async fn public_mcp_lifecycle_accepts_typed_contract_params() {
+        let state = MobMcpState::new_in_memory();
+        handle_public_tools_call(
+            &state,
+            "meerkat_mob_create",
+            &json!({
+                "definition": {
+                    "id": "typed-public-lifecycle-complete",
+                    "profiles": {
+                        "lead": {
+                            "model": "gpt-5.4",
+                            "tools": {"comms": true}
+                        }
+                    }
+                }
+            }),
+        )
+        .await
+        .expect("create typed public mob");
+
+        let params = meerkat_contracts::MobLifecycleParams {
+            mob_id: "typed-public-lifecycle-complete".to_string(),
+            action: meerkat_contracts::WireMobLifecycleAction::Complete,
+        };
+        let payload = serde_json::to_value(&params).expect("typed lifecycle params serialize");
+        let result = handle_public_tools_call(&state, "meerkat_mob_lifecycle", &payload)
+            .await
+            .expect("typed lifecycle action dispatches");
+        let result: meerkat_contracts::MobLifecycleResult =
+            serde_json::from_value(result).expect("typed lifecycle result");
+
+        assert_eq!(result.mob_id, "typed-public-lifecycle-complete");
+        assert_eq!(
+            result.action,
+            meerkat_contracts::WireMobLifecycleAction::Complete
+        );
+        assert!(result.ok);
+
+        handle_public_tools_call(
+            &state,
+            "meerkat_mob_lifecycle",
+            &json!({
+                "mob_id": "typed-public-lifecycle-complete",
+                "action": "destroy"
+            }),
+        )
+        .await
+        .expect("cleanup mob");
     }
 }

--- a/meerkat-web-runtime/src/lib.rs
+++ b/meerkat-web-runtime/src/lib.rs
@@ -24,7 +24,7 @@
 //! - `mob_create(definition_json)` → mob_id
 //! - `mob_status(mob_id)` → JSON
 //! - `mob_list()` → JSON
-//! - `mob_lifecycle(mob_id, action)` — stop/resume/complete/reset/destroy
+//! - `mob_lifecycle(mob_id, action)` — typed lifecycle action string carrier
 //! - `mob_events(mob_id, after_cursor, limit)` → JSON
 //! - `mob_spawn(mob_id, specs_json)` → JSON
 //! - `mob_retire(mob_id, agent_identity)`
@@ -1611,32 +1611,32 @@ pub async fn mob_list() -> Result<JsValue, JsValue> {
 
 /// Perform a lifecycle action on a mob.
 ///
-/// `action`: one of "stop", "resume", "complete", "reset", "destroy".
+/// `action` is a compatibility string carrier that is immediately
+/// deserialized into the typed wire lifecycle action contract.
 #[wasm_bindgen]
 pub async fn mob_lifecycle(mob_id: &str, action: &str) -> Result<(), JsValue> {
+    let action = parse_mob_lifecycle_action_arg(action).map_err(|err| {
+        err_js(
+            "invalid_action",
+            &format!("invalid lifecycle action: {err}"),
+        )
+    })?;
     let mob_state = with_mob_state(Ok)?;
     let id = MobId::from(mob_id);
-    match action {
-        "stop" => mob_state.mob_stop(&id).await.map_err(err_mob)?,
-        "resume" => mob_state.mob_resume(&id).await.map_err(err_mob)?,
-        "complete" => mob_state.mob_complete(&id).await.map_err(err_mob)?,
-        "reset" => mob_state.mob_reset(&id).await.map_err(err_mob)?,
-        "destroy" => {
-            // WASM lifecycle wrapper is `() on success`; Rust/RPC callers
-            // that need the structured MobDestroyReport use the RPC
-            // mob/lifecycle handler directly.
-            let _report = mob_state.mob_destroy(&id).await.map_err(err_mob)?;
-        }
-        _ => {
-            return Err(err_js(
-                "invalid_action",
-                &format!(
-                    "unknown lifecycle action: {action} (expected stop/resume/complete/reset/destroy)"
-                ),
-            ));
-        }
-    }
+    // WASM lifecycle wrapper is `() on success`; the structured
+    // MobDestroyReport is available through public/RPC lifecycle result
+    // envelopes for consumers that need cleanup detail.
+    let _destroy_report = mob_state
+        .mob_lifecycle_action(&id, action)
+        .await
+        .map_err(err_mob)?;
     Ok(())
+}
+
+fn parse_mob_lifecycle_action_arg(
+    action: &str,
+) -> Result<meerkat_contracts::WireMobLifecycleAction, serde_json::Error> {
+    serde_json::from_value(serde_json::Value::String(action.to_string()))
 }
 
 /// Fetch mob events.
@@ -2469,7 +2469,8 @@ pub fn close_subscription(handle: u32) -> Result<(), JsValue> {
 mod tests {
     use super::{
         EventSubscription, SUBSCRIPTIONS, SubscriptionInner, close_subscription,
-        merge_runtime_system_context_state, parse_mobpack, poll_subscription,
+        merge_runtime_system_context_state, parse_mob_lifecycle_action_arg, parse_mobpack,
+        poll_subscription,
     };
     #[cfg(target_arch = "wasm32")]
     use super::{
@@ -2873,6 +2874,20 @@ capabilities = [{capability_values}]
             serde_json::from_value(payload)
                 .expect("typed failed spawn_many entry must deserialize");
         assert_eq!(round_trip, entry);
+    }
+
+    #[test]
+    fn mob_lifecycle_action_string_carrier_uses_typed_contract_boundary() {
+        let action = parse_mob_lifecycle_action_arg("resume")
+            .expect("valid lifecycle action must deserialize");
+        assert_eq!(action, meerkat_contracts::WireMobLifecycleAction::Resume);
+
+        let err = parse_mob_lifecycle_action_arg("explode")
+            .expect_err("unknown lifecycle action must fail typed deserialization");
+        assert!(
+            err.to_string().contains("unknown variant"),
+            "unexpected error: {err}"
+        );
     }
 
     #[cfg(not(target_arch = "wasm32"))]


### PR DESCRIPTION
## Summary

- Route public MCP, agent MCP, and WASM mob lifecycle actions through `MobLifecycleParams` / `WireMobLifecycleAction` before dispatch.
- Add `MobMcpState::mob_lifecycle_action` as the shared typed lifecycle dispatch helper.
- Add negative and positive fixtures for contract, public MCP, agent MCP, and WASM string-carrier behavior.
- Add local Review Readiness Packet / Old Path Amputation Proof: `docs/review-readiness/luc-348-typed-mob-lifecycle-actions.md`.

Linear: LUC-348

## Review Readiness Packet

Exact head at PR open: `5b708b087c44f22329341919475e08b324fa5486`

Implementation churn:
- `meerkat-mob-mcp/src/lib.rs`: typed `MobMcpState::mob_lifecycle_action`; agent MCP `mob_lifecycle` parses `MobLifecycleParams`; agent tool schema uses `MobLifecycleParams`.
- `meerkat-mob-mcp/src/public_mcp.rs`: public MCP `meerkat_mob_lifecycle` parses `MobLifecycleParams`, dispatches through the typed helper, and emits `MobLifecycleResult`.
- `meerkat-web-runtime/src/lib.rs`: WASM action string remains only as a JS ABI compatibility carrier and is immediately deserialized into `WireMobLifecycleAction` before state lookup or dispatch.

Generated/schema churn:
- No generated SDK files changed.
- Agent MCP and public MCP lifecycle tool schemas now use the existing contract schema for `MobLifecycleParams`.

Test churn:
- Contract unknown-action and typed-result round-trip fixtures.
- Public MCP and agent MCP unknown-action boundary fixtures plus valid typed dispatch fixtures.
- WASM/runtime string-carrier typed boundary fixture.

## Old Path Amputation Proof

Removed or made uncallable:
- Public MCP: removed `MeerkatMobLifecycleInput { action: String }` and `match input.action.as_str()` over `stop/resume/complete/reset/destroy`. Unknown values now fail during `MobLifecycleParams` deserialization before mob id parsing, state lookup, or dispatch.
- Agent MCP: removed `LifecycleArgs { action: String }` and `match args.action.as_str()` over `stop/resume/reset/complete/destroy`. Unknown values now fail during `MobLifecycleParams` deserialization before `MobId` construction or dispatch.
- WASM: removed local `match action` over lifecycle strings. The exported `action: &str` is an inert compatibility carrier parsed into `WireMobLifecycleAction` before `with_mob_state` or dispatch.

Remaining raw `action` strings in touched behavior:
- Test JSON/string carriers and the wasm-bindgen JS ABI carrier remain only to exercise compatibility; touched public behavior deserializes them into the typed contract before dispatch.
- Agent MCP `mob_wire` / `mob_unwire` raw action strings remain out of scope because they are not lifecycle actions.

## Validation

- Baseline before edits: `./scripts/repo-cargo test -p meerkat-mob-mcp test_mcp_stop_resume_round_trip --lib`
- `./scripts/repo-cargo test -p meerkat-contracts mob_lifecycle --lib`
- `./scripts/repo-cargo test -p meerkat-mob-mcp lifecycle --lib`
- `./scripts/repo-cargo test -p meerkat-web-runtime mob_lifecycle_action_string_carrier --lib`
- `./scripts/repo-cargo test -p meerkat-mob-mcp test_mcp_stop_resume_round_trip --lib`
- `make check` via BuildBuddy: `df9d2cba-84d3-4ab9-bdea-0d4f34d1ef24`
- `make lint` via BuildBuddy: `0c1d2516-8ed4-43e9-9ea0-178f930e5ce6`
- `git diff --check`
