### PR TITLE
LUC-350 Route store-only session control through authority

### DIFF
--- a/meerkat-mcp-server/src/lib.rs
+++ b/meerkat-mcp-server/src/lib.rs
@@ -2110,11 +2110,22 @@ impl McpArchiveCleanup {
     }
 }
 
+async fn archive_with_mcp_machine_authority(
+    service: &PersistentSessionService<FactoryAgentBuilder>,
+    runtime_adapter: &meerkat_runtime::MeerkatMachine,
+    session_id: &meerkat::SessionId,
+) -> Result<(), SessionError> {
+    service
+        .archive_with_machine_authority(session_id, runtime_adapter.session_control_authority())
+        .await
+}
+
 async fn archive_session_with_runtime_cleanup(
     state: &MeerkatMcpState,
     session_id: meerkat::SessionId,
 ) -> Result<(), SessionError> {
     let service = Arc::clone(&state.service);
+    let runtime_adapter = Arc::clone(&state.runtime_adapter);
     let cleanup = McpArchiveCleanup {
         ingress: state.runtime_ingress_context(),
         #[cfg(feature = "mob")]
@@ -2123,7 +2134,12 @@ async fn archive_session_with_runtime_cleanup(
     let result_session_id = session_id.clone();
     let (result_tx, result_rx) = tokio::sync::oneshot::channel();
     tokio::spawn(async move {
-        let result = service.archive(&session_id).await;
+        let result = archive_with_mcp_machine_authority(
+            service.as_ref(),
+            runtime_adapter.as_ref(),
+            &session_id,
+        )
+        .await;
         if matches!(result, Ok(()) | Err(SessionError::NotFound { .. })) {
             cleanup.run(&session_id).await;
         }
@@ -2856,19 +2872,31 @@ async fn handle_meerkat_run(
             }))
             .await;
         let service = state.service.clone();
+        let archive_runtime_adapter = state.runtime_adapter.clone();
         let session_id_for_cleanup = session_id.clone();
         let ingress_for_cleanup = ingress.clone();
         context.set_unpublished_cleanup(request_action(move || {
             let service = service.clone();
+            let archive_runtime_adapter = archive_runtime_adapter.clone();
             let ingress = ingress_for_cleanup.clone();
             let session_id = session_id_for_cleanup.clone();
             async move {
-                let _ = service.archive(&session_id).await;
+                let _ = archive_with_mcp_machine_authority(
+                    service.as_ref(),
+                    archive_runtime_adapter.as_ref(),
+                    &session_id,
+                )
+                .await;
                 ingress.clear_session(&session_id).await;
             }
         }));
         if install == meerkat::surface::CancelActionInstallOutcome::AlreadyCancelled {
-            let _ = state.service.archive(&session_id).await;
+            let _ = archive_with_mcp_machine_authority(
+                state.service.as_ref(),
+                state.runtime_adapter.as_ref(),
+                &session_id,
+            )
+            .await;
             ingress.clear_session(&session_id).await;
             return Err(request_cancelled_tool_error());
         }
@@ -2955,7 +2983,12 @@ async fn handle_meerkat_run(
     ));
 
     reject_if_cancelled_before_mcp_service_admission(request_context.as_ref(), async {
-        let _ = state.service.archive(&session_id).await;
+        let _ = archive_with_mcp_machine_authority(
+            state.service.as_ref(),
+            state.runtime_adapter.as_ref(),
+            &session_id,
+        )
+        .await;
         state.runtime_adapter.unregister_session(&session_id).await;
         ingress.clear_session(&session_id).await;
     })
@@ -5878,11 +5911,13 @@ mod tests {
         assert_eq!(history_payload["has_more"], true);
         assert_eq!(history_payload["messages"].as_array().unwrap().len(), 2);
 
-        state
-            .service
-            .archive(session.id())
-            .await
-            .expect("archive should succeed");
+        Box::pin(handle_tools_call(
+            &state,
+            "meerkat_archive",
+            &json!({ "session_id": session_id }),
+        ))
+        .await
+        .expect("archive should succeed");
 
         let archived_history = Box::pin(handle_tools_call(
             &state,

--- a/meerkat-rpc/src/session_runtime.rs
+++ b/meerkat-rpc/src/session_runtime.rs
@@ -150,6 +150,19 @@ struct ArchiveRuntimeCleanup {
 }
 
 impl ArchiveRuntimeCleanup {
+    async fn archive_service(
+        &self,
+        service: &PersistentSessionService<FactoryAgentBuilder>,
+        session_id: &SessionId,
+    ) -> Result<(), SessionError> {
+        service
+            .archive_with_machine_authority(
+                session_id,
+                self.runtime_adapter.session_control_authority(),
+            )
+            .await
+    }
+
     async fn run(&self, session_id: &SessionId) {
         self.runtime_adapter.unregister_session(session_id).await;
         if let Some(streams) = self.pending_session_event_streams.as_ref() {
@@ -449,7 +462,10 @@ async fn await_guarded_session_cleanup(
     let (result_tx, result_rx) = tokio::sync::oneshot::channel();
     tokio::spawn(async move {
         let result = match operation {
-            GuardedSessionCleanupOperation::Archive => service.archive(&session_id).await,
+            GuardedSessionCleanupOperation::Archive => match runtime_cleanup.as_ref() {
+                Some(cleanup) => cleanup.archive_service(&service, &session_id).await,
+                None => service.archive(&session_id).await,
+            },
             GuardedSessionCleanupOperation::DiscardLive => {
                 service.discard_live_session(&session_id).await
             }
@@ -484,7 +500,7 @@ async fn await_guarded_staged_archive(
     let result_session_id = session_id.clone();
     let (result_tx, result_rx) = tokio::sync::oneshot::channel();
     tokio::spawn(async move {
-        let result = match service.archive(&session_id).await {
+        let result = match runtime_cleanup.archive_service(&service, &session_id).await {
             Ok(()) | Err(SessionError::NotFound { .. }) => {
                 runtime_cleanup.run(&session_id).await;
                 #[cfg(test)]
@@ -531,7 +547,7 @@ async fn await_session_archive_with_runtime_cleanup(
     let result_session_id = session_id.clone();
     let (result_tx, result_rx) = tokio::sync::oneshot::channel();
     tokio::spawn(async move {
-        let result = service.archive(&session_id).await;
+        let result = runtime_cleanup.archive_service(&service, &session_id).await;
         if matches!(result, Ok(()) | Err(SessionError::NotFound { .. })) {
             runtime_cleanup.run(&session_id).await;
         }
@@ -654,6 +670,7 @@ impl PendingPromotionCleanup {
     async fn restore_after_materialized_failure(
         &mut self,
         service: &PersistentSessionService<FactoryAgentBuilder>,
+        authority: meerkat_runtime::MachineSessionControlAuthority,
     ) -> Result<(), SessionError> {
         if let Err(error) = self
             .recover_materialized_staged_capacity_admission(service)
@@ -663,7 +680,10 @@ impl PendingPromotionCleanup {
             return Err(error);
         }
 
-        if let Err(error) = service.archive(&self.session_id).await {
+        if let Err(error) = service
+            .archive_with_machine_authority(&self.session_id, authority)
+            .await
+        {
             let _ = service.discard_live_session(&self.session_id).await;
             self.restore_now().await;
             return Err(error);
@@ -1262,7 +1282,10 @@ impl SessionService for RpcMobSessionService {
         if self.staged_sessions.contains(id).await {
             return Err(SessionError::Busy { id: id.clone() });
         }
-        let result = self.service.archive(id).await;
+        let result = self
+            .service
+            .archive_with_machine_authority(id, self.runtime_adapter.session_control_authority())
+            .await;
         if matches!(result, Ok(()) | Err(SessionError::NotFound { .. })) {
             self.archive_runtime_cleanup().run(id).await;
         }
@@ -3098,7 +3121,10 @@ impl SessionRuntime {
             let result = service.start_turn(&session_id, start_req).await;
             if Self::should_restore_pending_after_start_turn(&service, &session_id, &result).await {
                 let restore_result = promotion_cleanup
-                    .restore_after_materialized_failure(&service)
+                    .restore_after_materialized_failure(
+                        &service,
+                        runtime_adapter.session_control_authority(),
+                    )
                     .await;
                 promotion_cleanup.disarm();
                 let _ = result_tx.send(match restore_result {
@@ -3299,7 +3325,10 @@ impl SessionRuntime {
                 .await
             {
                 let restore_result = promotion_cleanup
-                    .restore_after_materialized_failure(&service)
+                    .restore_after_materialized_failure(
+                        &service,
+                        runtime_adapter.session_control_authority(),
+                    )
                     .await;
                 promotion_cleanup.disarm();
                 let _ = result_tx.send(match restore_result {
@@ -15153,7 +15182,10 @@ mod tests {
             .expect("reserve recovery admission");
         runtime
             .service
-            .archive(&session_id)
+            .archive_with_machine_authority(
+                &session_id,
+                runtime.runtime_adapter.session_control_authority(),
+            )
             .await
             .expect("archive should win before recovered create");
         let result_rx = runtime.spawn_recovered_create_and_apply_runtime_turn_with_admission_guard(

--- a/meerkat-runtime/src/lib.rs
+++ b/meerkat-runtime/src/lib.rs
@@ -137,8 +137,8 @@ pub use input_state::{
 };
 pub use meerkat_core::types::HandlingMode;
 pub use meerkat_machine::{
-    CommsDrainMode, CommsDrainPhase, DrainExitReason, MeerkatConsumerSurface, MeerkatMachine,
-    PeerIngressOwner, RuntimeBindingsError,
+    CommsDrainMode, CommsDrainPhase, DrainExitReason, MachineSessionControlAuthority,
+    MeerkatConsumerSurface, MeerkatMachine, PeerIngressOwner, RuntimeBindingsError,
 };
 pub use meerkat_machine_types::{
     HydratedSessionLlmState, ImageOperationRoutingRequest, ImageOperationRoutingResult,

--- a/meerkat-runtime/src/meerkat_machine/mod.rs
+++ b/meerkat-runtime/src/meerkat_machine/mod.rs
@@ -727,7 +727,13 @@ impl MeerkatMachine {
     }
 }
 
-/// Per-session comms drain slot, driven by direct in-kernel state.
+/// Capability token proving a session-control mutation is routed through
+/// `MeerkatMachine` authority instead of a public store-only service path.
+#[derive(Debug, Clone, Copy)]
+pub struct MachineSessionControlAuthority {
+    _private: (),
+}
+
 /// Session-scoped execution kernel for the Meerkat runtime.
 ///
 /// Owns per-session runtime state (driver, ops registry, completion waiters,
@@ -767,6 +773,13 @@ pub struct MeerkatMachine {
 }
 
 impl MeerkatMachine {
+    /// Capability token for store-only session-control mutations routed
+    /// through this machine authority.
+    #[must_use]
+    pub fn session_control_authority(&self) -> MachineSessionControlAuthority {
+        MachineSessionControlAuthority { _private: () }
+    }
+
     fn normalize_destroyed_error(err: RuntimeDriverError) -> RuntimeDriverError {
         match err {
             RuntimeDriverError::NotReady {

--- a/meerkat-session/src/persistent.rs
+++ b/meerkat-session/src/persistent.rs
@@ -781,7 +781,7 @@ impl<B: SessionAgentBuilder + 'static> PersistentSessionService<B> {
 
     fn store_only_control_mutation_error(id: &SessionId, operation: &str) -> SessionError {
         SessionError::Unsupported(format!(
-            "{operation} cannot mutate store-only compatibility projection for session {id}; runtime-backed control mutations require an authoritative runtime snapshot"
+            "{operation} cannot mutate store-only compatibility projection for session {id}; session control mutations require an authoritative runtime/session machine snapshot"
         ))
     }
 
@@ -823,30 +823,16 @@ impl<B: SessionAgentBuilder + 'static> PersistentSessionService<B> {
                 .await;
         }
 
-        // Runtime-less services are a legacy compatibility lane. They have no
-        // runtime authority to update, so this path must stay unreachable when a
-        // runtime store is configured.
-        self.store
-            .load(id)
+        if self
+            .store
+            .exists(id)
             .await
-            .map_err(|e| SessionError::Store(Box::new(e)))
-    }
-
-    async fn save_persisted_control_session(
-        &self,
-        session: Session,
-    ) -> Result<Session, SessionError> {
-        if self.runtime_store.is_none() {
-            // Legacy runtime-less compatibility only. This is not a runtime
-            // authority path; runtime-backed callers commit through
-            // `RuntimeStore::commit_session_snapshot` inside
-            // `save_normalized_session`.
-            tracing::debug!(
-                session_id = %session.id(),
-                "saving runtime-less legacy control mutation to session store"
-            );
+            .map_err(|e| SessionError::Store(Box::new(e)))?
+        {
+            return Err(Self::store_only_control_mutation_error(id, operation));
         }
-        self.save_normalized_session(session).await
+
+        Ok(None)
     }
 
     async fn discard_stale_live_session_if_needed(
@@ -2325,7 +2311,10 @@ impl<B: SessionAgentBuilder + 'static> SessionService for PersistentSessionServi
 
         let archived_snapshot = match self.export_session_with_labels(id).await {
             Ok(session) => Some(session),
-            Err(SessionError::NotFound { .. }) => self.load_authoritative_session_base(id).await?,
+            Err(SessionError::NotFound { .. }) => {
+                self.load_persisted_session_for_control(id, "archive")
+                    .await?
+            }
             Err(err) => return Err(err),
         };
         if let Some(ref session) = archived_snapshot
@@ -2356,11 +2345,6 @@ impl<B: SessionAgentBuilder + 'static> SessionService for PersistentSessionServi
         };
 
         let had_durable_snapshot = archived_snapshot.is_some();
-        let in_store = self
-            .store
-            .exists(id)
-            .await
-            .map_err(|e| SessionError::Store(Box::new(e)))?;
         let mut saved_archived_snapshot = false;
         if let Some(mut session) = archived_snapshot.clone() {
             session.set_metadata(SESSION_ARCHIVED_KEY, serde_json::Value::Bool(true));
@@ -2386,7 +2370,7 @@ impl<B: SessionAgentBuilder + 'static> SessionService for PersistentSessionServi
         drop(gate_guard.take());
         self.checkpointer_gates.lock().await.remove(id);
 
-        match (&live_result, in_store || saved_archived_snapshot) {
+        match (&live_result, saved_archived_snapshot) {
             // At least one side had the session — success.
             (Ok(()), _) | (_, true) => Ok(()),
             (_, false) if had_durable_snapshot => Ok(()),
@@ -2708,7 +2692,7 @@ impl<B: SessionAgentBuilder + 'static> SessionServiceControlExt for PersistentSe
             .stage_append(&req, meerkat_core::time_compat::SystemTime::now())
             .map_err(|err| err.into_control_error(id))?;
         write_system_context_state(&mut session, state)?;
-        self.save_persisted_control_session(session)
+        self.save_normalized_session(session)
             .await
             .map_err(SessionControlError::Session)?;
         Ok(AppendSystemContextResult { status })
@@ -2865,7 +2849,7 @@ impl<B: SessionAgentBuilder + 'static> SessionServiceControlExt for PersistentSe
         let accepted =
             state.stage_tool_results(req.results, meerkat_core::time_compat::SystemTime::now());
         write_deferred_turn_state(&mut session, state).map_err(control_error_into_session_error)?;
-        self.save_persisted_control_session(session).await?;
+        self.save_normalized_session(session).await?;
         Ok(StageToolResultsResult {
             accepted_result_count: accepted,
         })
@@ -5385,20 +5369,13 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_persistent_archive_store_only_session_succeeds() {
-        // After restart, sessions exist only in the persistent store —
-        // not in the live (inner) ephemeral service. archive() must still
-        // succeed by deleting from the store even when inner returns NotFound.
+    async fn test_raw_store_delete_removes_seeded_session() {
         let store: Arc<dyn SessionStore> = Arc::new(MemoryStore::new());
         let session = Session::new();
         let id = session.id().clone();
         store.save(&session).await.unwrap();
 
-        // Verify the session exists in the store
         assert!(store.load(&id).await.unwrap().is_some());
-
-        // Simulate the archive path: inner.archive() would return NotFound,
-        // but store.delete() should still succeed.
         store.delete(&id).await.unwrap();
         assert!(store.load(&id).await.unwrap().is_none());
     }
@@ -5413,9 +5390,11 @@ mod tests {
             None,
             memory_blob_store(),
         );
-        let session = Session::new();
-        let id = session.id().clone();
-        store.save(&session).await.unwrap();
+        let created = service
+            .create_session(create_request("archived", InitialTurnPolicy::Defer))
+            .await
+            .expect("create_session should succeed");
+        let id = created.session_id.clone();
         service.archive(&id).await.unwrap();
         let archived = store
             .load(&id)
@@ -8571,144 +8550,120 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_runtime_backed_control_mutations_reject_store_only_projection() {
-        let store: Arc<dyn SessionStore> = Arc::new(MemoryStore::new());
-        let runtime_store = Arc::new(InMemoryRuntimeStore::new());
-        let service = PersistentSessionService::new(
-            DummyBuilder,
-            4,
-            Arc::clone(&store),
-            Some(runtime_store.clone()),
-            memory_blob_store(),
-        );
-        let session = Session::new();
-        let id = session.id().clone();
-        store
-            .save(&session)
-            .await
-            .expect("test should seed a store-only compatibility projection");
+    async fn test_store_only_control_mutations_fail_closed_without_runtime_divergence() {
+        for runtime_backed in [true, false] {
+            let mode = if runtime_backed {
+                "runtime-backed"
+            } else {
+                "runtime-less"
+            };
+            let store: Arc<dyn SessionStore> = Arc::new(MemoryStore::new());
+            let runtime_store = runtime_backed.then(|| Arc::new(InMemoryRuntimeStore::new()));
+            let service_runtime_store = runtime_store
+                .as_ref()
+                .map(|store| Arc::clone(store) as Arc<dyn RuntimeStore>);
+            let service = PersistentSessionService::new(
+                DummyBuilder,
+                4,
+                Arc::clone(&store),
+                service_runtime_store,
+                memory_blob_store(),
+            );
+            let session = Session::new();
+            let id = session.id().clone();
+            store
+                .save(&session)
+                .await
+                .expect("test should seed a store-only compatibility projection");
 
-        let append_err = service
-            .append_system_context(
-                &id,
-                AppendSystemContextRequest {
-                    text: "must not become authority".to_string(),
-                    source: Some("api".to_string()),
-                    idempotency_key: Some("store-only-runtime-append".to_string()),
-                },
-            )
-            .await
-            .expect_err("store-only projection must not be promoted by append");
-        assert!(matches!(
-            append_err,
-            SessionControlError::Session(SessionError::Unsupported(ref message))
-                if message.contains("store-only compatibility projection")
-        ));
-
-        let stage_err = service
-            .stage_tool_results(
-                &id,
-                StageToolResultsRequest {
-                    results: vec![ToolResult::new(
-                        "tool-call-1".to_string(),
-                        "callback result".to_string(),
-                        false,
-                    )],
-                },
-            )
-            .await
-            .expect_err("store-only projection must not be promoted by staged tool results");
-        assert!(matches!(
-            stage_err,
-            SessionError::Unsupported(ref message)
-                if message.contains("store-only compatibility projection")
-        ));
-
-        let raw = store
-            .load(&id)
-            .await
-            .expect("raw store load should succeed")
-            .expect("store-only projection should remain present");
-        assert!(
-            raw.system_context_state().is_none(),
-            "append rejection must not mutate the store-only projection"
-        );
-        assert!(
-            raw.deferred_turn_state().is_none(),
-            "stage rejection must not mutate the store-only projection"
-        );
-        assert!(
-            runtime_store
-                .load_session_snapshot(
-                    &PersistentSessionService::<DummyBuilder>::runtime_id_for_session(&id)
+            let append_err = service
+                .append_system_context(
+                    &id,
+                    AppendSystemContextRequest {
+                        text: format!("{mode} store-only append must fail closed"),
+                        source: Some("api".to_string()),
+                        idempotency_key: Some(format!("store-only-{mode}-append")),
+                    },
                 )
                 .await
-                .expect("runtime snapshot load should succeed")
-                .is_none(),
-            "store-only control mutations must not create runtime authority"
-        );
-    }
+                .expect_err("store-only projection must not be promoted by append");
+            assert!(
+                matches!(
+                    append_err,
+                    SessionControlError::Session(SessionError::Unsupported(ref message))
+                        if message.contains("store-only compatibility projection")
+                            && message.contains("machine snapshot")
+                ),
+                "{mode} append error should require machine authority: {append_err:?}"
+            );
 
-    #[tokio::test]
-    async fn test_legacy_runtime_less_store_only_control_mutations_are_compatibility_only() {
-        let store: Arc<dyn SessionStore> = Arc::new(MemoryStore::new());
-        let service = PersistentSessionService::new(
-            DummyBuilder,
-            4,
-            Arc::clone(&store),
-            None,
-            memory_blob_store(),
-        );
-        let session = Session::new();
-        let id = session.id().clone();
-        store
-            .save(&session)
-            .await
-            .expect("test should seed a legacy store-only session");
+            let stage_err = service
+                .stage_tool_results(
+                    &id,
+                    StageToolResultsRequest {
+                        results: vec![ToolResult::new(
+                            "tool-call-1".to_string(),
+                            "callback result".to_string(),
+                            false,
+                        )],
+                    },
+                )
+                .await
+                .expect_err("store-only projection must not be promoted by staged tool results");
+            assert!(
+                matches!(
+                    stage_err,
+                    SessionError::Unsupported(ref message)
+                        if message.contains("store-only compatibility projection")
+                            && message.contains("machine snapshot")
+                ),
+                "{mode} stage error should require machine authority: {stage_err:?}"
+            );
 
-        let append = service
-            .append_system_context(
-                &id,
-                AppendSystemContextRequest {
-                    text: "legacy compatibility append".to_string(),
-                    source: Some("legacy".to_string()),
-                    idempotency_key: Some("legacy-store-only-append".to_string()),
-                },
-            )
-            .await
-            .expect("runtime-less compatibility append should still be available");
-        assert_eq!(
-            append.status,
-            meerkat_core::AppendSystemContextStatus::Staged
-        );
-        let staged = service
-            .stage_tool_results(
-                &id,
-                StageToolResultsRequest {
-                    results: vec![ToolResult::new(
-                        "tool-call-1".to_string(),
-                        "legacy callback result".to_string(),
-                        false,
-                    )],
-                },
-            )
-            .await
-            .expect("runtime-less compatibility staging should still be available");
-        assert_eq!(staged.accepted_result_count, 1);
+            let archive_err = service
+                .archive(&id)
+                .await
+                .expect_err("store-only projection must not own lifecycle archive");
+            assert!(
+                matches!(
+                    archive_err,
+                    SessionError::Unsupported(ref message)
+                        if message.contains("store-only compatibility projection")
+                            && message.contains("machine snapshot")
+                ),
+                "{mode} archive error should require machine authority: {archive_err:?}"
+            );
 
-        let raw = store
-            .load(&id)
-            .await
-            .expect("raw store load should succeed")
-            .expect("legacy store-only session should remain present");
-        let state = raw
-            .system_context_state()
-            .expect("legacy compatibility append writes only the store row");
-        assert_eq!(state.pending[0].text, "legacy compatibility append");
-        let deferred = raw
-            .deferred_turn_state()
-            .expect("legacy compatibility stage writes only the store row");
-        assert_eq!(deferred.pending_tool_results.len(), 1);
+            let raw = store
+                .load(&id)
+                .await
+                .expect("raw store load should succeed")
+                .expect("store-only projection should remain present");
+            assert!(
+                raw.system_context_state().is_none(),
+                "{mode} append rejection must not mutate the store-only projection"
+            );
+            assert!(
+                raw.deferred_turn_state().is_none(),
+                "{mode} stage rejection must not mutate the store-only projection"
+            );
+            assert!(
+                !metadata_marks_archived(raw.metadata()),
+                "{mode} archive rejection must not mutate lifecycle metadata"
+            );
+            if let Some(runtime_store) = runtime_store {
+                assert!(
+                    runtime_store
+                        .load_session_snapshot(
+                            &PersistentSessionService::<DummyBuilder>::runtime_id_for_session(&id)
+                        )
+                        .await
+                        .expect("runtime snapshot load should succeed")
+                        .is_none(),
+                    "store-only control mutations must not create runtime authority"
+                );
+            }
+        }
     }
 
     #[tokio::test]

--- a/meerkat-session/src/persistent.rs
+++ b/meerkat-session/src/persistent.rs
@@ -34,7 +34,7 @@ use meerkat_core::{InputId, RunId};
 use meerkat_runtime::identifiers::LogicalRuntimeId;
 use meerkat_runtime::input_state::{InputLifecycleState, InputTerminalOutcome, StoredInputState};
 use meerkat_runtime::store::SessionDelta;
-use meerkat_runtime::{RuntimeMode, RuntimeState, RuntimeStore};
+use meerkat_runtime::{MachineSessionControlAuthority, RuntimeMode, RuntimeState, RuntimeStore};
 use meerkat_store::{SessionFilter, SessionStore};
 use sha2::{Digest, Sha256};
 use std::collections::{BTreeMap, HashMap, HashSet};
@@ -241,6 +241,12 @@ fn validate_tool_result_video(results: &[ToolResult]) -> Result<(), SessionError
 /// and `archive()` sets `cancelled = true` under the lock before deleting.
 struct CheckpointerGate {
     cancelled: Mutex<bool>,
+}
+
+#[derive(Clone, Copy)]
+enum StoreOnlyArchiveMode {
+    Reject,
+    MachineAuthority,
 }
 
 /// Checkpointer that saves sessions to a [`SessionStore`].
@@ -833,6 +839,23 @@ impl<B: SessionAgentBuilder + 'static> PersistentSessionService<B> {
         }
 
         Ok(None)
+    }
+
+    async fn load_machine_authority_session_for_control(
+        &self,
+        id: &SessionId,
+    ) -> Result<Option<Session>, SessionError> {
+        if let Some(runtime_store) = self.runtime_store.as_ref()
+            && let Some(runtime) =
+                Self::load_runtime_session_snapshot_for_session(runtime_store, id).await?
+        {
+            return Ok(Some(runtime));
+        }
+
+        self.store
+            .load(id)
+            .await
+            .map_err(|e| SessionError::Store(Box::new(e)))
     }
 
     async fn discard_stale_live_session_if_needed(
@@ -2149,6 +2172,101 @@ impl<B: SessionAgentBuilder + 'static> PersistentSessionService<B> {
 
         Ok(result)
     }
+
+    async fn archive_with_store_only_mode(
+        &self,
+        id: &SessionId,
+        store_only_mode: StoreOnlyArchiveMode,
+    ) -> Result<(), SessionError> {
+        let recovery_gate = self.recovery_gate_for_session(id).await;
+        let _recovery_guard = recovery_gate.lock().await;
+
+        let archived_snapshot = match self.export_session_with_labels(id).await {
+            Ok(session) => Some(session),
+            Err(SessionError::NotFound { .. }) => match store_only_mode {
+                StoreOnlyArchiveMode::Reject => {
+                    self.load_persisted_session_for_control(id, "archive")
+                        .await?
+                }
+                StoreOnlyArchiveMode::MachineAuthority => {
+                    self.load_machine_authority_session_for_control(id).await?
+                }
+            },
+            Err(err) => return Err(err),
+        };
+        if let Some(ref session) = archived_snapshot
+            && metadata_marks_archived(session.metadata())
+        {
+            if metadata_marks_transient_pending_archive(session.metadata()) {
+                let mut session = session.clone();
+                clear_transient_pending_archive_marker(&mut session);
+                let session = self.save_normalized_session(session).await?;
+                self.remember_archived_session(session).await;
+            } else {
+                self.remember_archived_session(session.clone()).await;
+            }
+            return Err(SessionError::NotFound { id: id.clone() });
+        }
+
+        // Acquire the checkpointer gate (if any) and hold it across the
+        // archival save. This prevents a concurrent checkpoint() from saving
+        // a live snapshot over the archived one. Setting cancelled under the
+        // lock ensures all future checkpoints are no-ops.
+        let gate = self.existing_gate_for_session(id).await;
+        let mut gate_guard = if let Some(ref gate) = gate {
+            let mut guard = gate.cancelled.lock().await;
+            *guard = true;
+            Some(guard)
+        } else {
+            None
+        };
+
+        let had_durable_snapshot = archived_snapshot.is_some();
+        let mut saved_archived_snapshot = false;
+        if let Some(mut session) = archived_snapshot.clone() {
+            session.set_metadata(SESSION_ARCHIVED_KEY, serde_json::Value::Bool(true));
+            clear_transient_pending_archive_marker(&mut session);
+            match self.save_normalized_session(session).await {
+                Ok(session) => {
+                    saved_archived_snapshot = true;
+                    self.remember_archived_session(session).await;
+                }
+                Err(err) => {
+                    if let Some(ref mut guard) = gate_guard {
+                        **guard = false;
+                    }
+                    return Err(err);
+                }
+            }
+        }
+
+        let live_result = self.inner.archive(id).await;
+
+        // Gate guard is dropped here - any in-flight checkpoint that was
+        // blocked on the lock will now see cancelled == true and bail out.
+        drop(gate_guard.take());
+        self.checkpointer_gates.lock().await.remove(id);
+
+        match (&live_result, saved_archived_snapshot) {
+            // At least one side had the session - success.
+            (Ok(()), _) | (_, true) => Ok(()),
+            (_, false) if had_durable_snapshot => Ok(()),
+            // Neither side had it - propagate NotFound from the live service.
+            _ => live_result,
+        }
+    }
+
+    /// Archive through runtime/session machine authority when the service has
+    /// no live runtime snapshot yet, such as staged sessions owned by
+    /// `MeerkatMachine`.
+    pub async fn archive_with_machine_authority(
+        &self,
+        id: &SessionId,
+        _authority: MachineSessionControlAuthority,
+    ) -> Result<(), SessionError> {
+        self.archive_with_store_only_mode(id, StoreOnlyArchiveMode::MachineAuthority)
+            .await
+    }
 }
 
 #[async_trait]
@@ -2306,77 +2424,8 @@ impl<B: SessionAgentBuilder + 'static> SessionService for PersistentSessionServi
     }
 
     async fn archive(&self, id: &SessionId) -> Result<(), SessionError> {
-        let recovery_gate = self.recovery_gate_for_session(id).await;
-        let _recovery_guard = recovery_gate.lock().await;
-
-        let archived_snapshot = match self.export_session_with_labels(id).await {
-            Ok(session) => Some(session),
-            Err(SessionError::NotFound { .. }) => {
-                self.load_persisted_session_for_control(id, "archive")
-                    .await?
-            }
-            Err(err) => return Err(err),
-        };
-        if let Some(ref session) = archived_snapshot
-            && metadata_marks_archived(session.metadata())
-        {
-            if metadata_marks_transient_pending_archive(session.metadata()) {
-                let mut session = session.clone();
-                clear_transient_pending_archive_marker(&mut session);
-                let session = self.save_normalized_session(session).await?;
-                self.remember_archived_session(session).await;
-            } else {
-                self.remember_archived_session(session.clone()).await;
-            }
-            return Err(SessionError::NotFound { id: id.clone() });
-        }
-
-        // Acquire the checkpointer gate (if any) and hold it across the
-        // archival save. This prevents a concurrent checkpoint() from saving
-        // a live snapshot over the archived one. Setting cancelled under the
-        // lock ensures all future checkpoints are no-ops.
-        let gate = self.existing_gate_for_session(id).await;
-        let mut gate_guard = if let Some(ref gate) = gate {
-            let mut guard = gate.cancelled.lock().await;
-            *guard = true;
-            Some(guard)
-        } else {
-            None
-        };
-
-        let had_durable_snapshot = archived_snapshot.is_some();
-        let mut saved_archived_snapshot = false;
-        if let Some(mut session) = archived_snapshot.clone() {
-            session.set_metadata(SESSION_ARCHIVED_KEY, serde_json::Value::Bool(true));
-            clear_transient_pending_archive_marker(&mut session);
-            match self.save_normalized_session(session).await {
-                Ok(session) => {
-                    saved_archived_snapshot = true;
-                    self.remember_archived_session(session).await;
-                }
-                Err(err) => {
-                    if let Some(ref mut guard) = gate_guard {
-                        **guard = false;
-                    }
-                    return Err(err);
-                }
-            }
-        }
-
-        let live_result = self.inner.archive(id).await;
-
-        // Gate guard is dropped here — any in-flight checkpoint that was
-        // blocked on the lock will now see cancelled == true and bail out.
-        drop(gate_guard.take());
-        self.checkpointer_gates.lock().await.remove(id);
-
-        match (&live_result, saved_archived_snapshot) {
-            // At least one side had the session — success.
-            (Ok(()), _) | (_, true) => Ok(()),
-            (_, false) if had_durable_snapshot => Ok(()),
-            // Neither side had it — propagate NotFound from the live service.
-            _ => live_result,
-        }
+        self.archive_with_store_only_mode(id, StoreOnlyArchiveMode::Reject)
+            .await
     }
 
     async fn update_session_keep_alive(
@@ -8661,6 +8710,68 @@ mod tests {
                         .expect("runtime snapshot load should succeed")
                         .is_none(),
                     "store-only control mutations must not create runtime authority"
+                );
+            }
+        }
+    }
+
+    #[tokio::test]
+    async fn test_machine_authorized_archive_routes_store_only_projection() {
+        for runtime_backed in [true, false] {
+            let store: Arc<dyn SessionStore> = Arc::new(MemoryStore::new());
+            let runtime_store = runtime_backed.then(|| Arc::new(InMemoryRuntimeStore::new()));
+            let service_runtime_store = runtime_store
+                .as_ref()
+                .map(|store| Arc::clone(store) as Arc<dyn RuntimeStore>);
+            let service = PersistentSessionService::new(
+                DummyBuilder,
+                4,
+                Arc::clone(&store),
+                service_runtime_store,
+                memory_blob_store(),
+            );
+            let session = Session::new();
+            let id = session.id().clone();
+            store
+                .save(&session)
+                .await
+                .expect("test should seed a store-only compatibility projection");
+
+            let machine = meerkat_runtime::MeerkatMachine::ephemeral();
+            service
+                .archive_with_machine_authority(&id, machine.session_control_authority())
+                .await
+                .expect("machine-routed archive should own the store-only transition");
+
+            let raw = store
+                .load(&id)
+                .await
+                .expect("raw store load should succeed")
+                .expect("archived projection should remain present");
+            assert!(
+                metadata_marks_archived(raw.metadata()),
+                "machine-routed archive should persist archived lifecycle metadata"
+            );
+            assert!(
+                raw.system_context_state().is_none(),
+                "archive must not add control append state"
+            );
+            assert!(
+                raw.deferred_turn_state().is_none(),
+                "archive must not add deferred-turn control state"
+            );
+            if let Some(runtime_store) = runtime_store {
+                let archived = runtime_store
+                    .load_session_snapshot(
+                        &PersistentSessionService::<DummyBuilder>::runtime_id_for_session(&id),
+                    )
+                    .await
+                    .expect("runtime snapshot load should succeed")
+                    .and_then(|bytes| serde_json::from_slice::<Session>(&bytes).ok())
+                    .expect("machine-routed archive should write runtime authority");
+                assert!(
+                    metadata_marks_archived(archived.metadata()),
+                    "runtime-backed machine archive should persist archived runtime authority"
                 );
             }
         }


### PR DESCRIPTION
## Summary
- Fail closed public persistent store-only session-control mutations for append_system_context, stage_tool_results, and archive.
- Add MachineSessionControlAuthority from MeerkatMachine and route RPC/MCP archive cleanup surfaces through archive_with_machine_authority.
- Add regression fixtures for runtime-backed/runtime-less legality parity and machine-authorized archive of store-only projections.
- Remove the tracked invalid `.claude/worktrees/piped-orbiting-oasis` gitlink from this PR head so checkout-based gates can run.

## Validation
- ./scripts/repo-cargo test -p meerkat-session --features session-store test_store_only_control_mutations_fail_closed_without_runtime_divergence
- ./scripts/repo-cargo test -p meerkat-session --features session-store test_machine_authorized_archive_routes_store_only_projection
- ./scripts/repo-cargo test -p meerkat-session --features session-store
- ./scripts/repo-cargo test -p meerkat-rpc archive
- ./scripts/repo-cargo test -p meerkat-rpc pending_runtime_apply_pre_run_terminal_restores_staged_admission
- ./scripts/repo-cargo test -p meerkat-rpc recovered_create_archived_recheck_unregisters_prepared_bindings
- ./scripts/repo-cargo test -p meerkat-mcp-server
- make check
- make lint
- make test
- git submodule foreach --recursive 'true'
- git diff --check
- make dogma-cleanup-gate DOGMA_PACKET=/tmp/luc350-review-readiness.md

## Review Readiness Packet

Current head SHA: cdf948b209bbd306c23294595b67fd75fd6b53ed

Command output:

```text
$ make dogma-cleanup-gate DOGMA_PACKET=/tmp/luc350-review-readiness.md
Dogma cleanup gate passed for /tmp/luc350-review-readiness.md
```

## Old Path Amputation Proof

Exact amputated route: public/session-service `append_system_context`, `stage_tool_results`, or `archive` -> `load_persisted_session_for_control` -> raw `SessionStore` row -> `save_persisted_control_session` -> serialized control-state write.

| Old path | Classification | Search literal | Mechanical proof | Follow-up |
| --- | --- | --- | --- | --- |
| `save_persisted_control_session` | deleted | `save_persisted_control_session` | `rg -F "save_persisted_control_session" --glob '!target' --glob '!bazel-*'` returns no production matches; the control save symbol was deleted, and public `SessionService` archive/append/stage access is rejected before raw `SessionStore` control-state writes. | none |

## Complexity Delta

- Docs/scripts/tests: 0 files.
- Non-test implementation: 5 files (`meerkat-session/src/persistent.rs`, `meerkat-runtime/src/lib.rs`, `meerkat-runtime/src/meerkat_machine/mod.rs`, `meerkat-rpc/src/session_runtime.rs`, `meerkat-mcp-server/src/lib.rs`).
- Generated/schema churn: 0 files.

## Sample Passing Old Path Amputation Proof

| Old path | Classification | Search literal | Mechanical proof | Follow-up |
| --- | --- | --- | --- | --- |
| `old/session-route` | deleted | `old/session-route` | No production references remain. | none |

## Sample Failing Old Path Amputation Proof

| Old path | Classification | Search literal | Mechanical proof | Follow-up |
| --- | --- | --- | --- | --- |
| `old/session-route` | wrapped | `old/session-route` | A preferred path exists beside the old route. | none |

Fixes LUC-350.