### PR TITLE
Fail closed on tool visibility restore failures

### DIFF
--- a/meerkat-core/src/agent/builder.rs
+++ b/meerkat-core/src/agent/builder.rs
@@ -74,7 +74,7 @@ pub struct AgentBuilder {
 
 /// Error returned when the canonical factory has not composed the policy state
 /// required before crossing into core agent construction.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, thiserror::Error)]
+#[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
 pub enum AgentBuildPolicyError {
     #[error("factory policy build requires an explicit session")]
     MissingSession,
@@ -86,6 +86,10 @@ pub enum AgentBuildPolicyError {
     MissingTurnStateHandle,
     #[error("factory policy build requires the canonical factory bridge token")]
     InvalidFactoryBridgeToken,
+    #[error("failed to restore canonical tool visibility state: {message}")]
+    ToolVisibilityRestore { message: String },
+    #[error("failed to persist canonical tool visibility state during restore: {message}")]
+    ToolVisibilityPersist { message: String },
 }
 
 #[cfg(not(target_arch = "wasm32"))]
@@ -142,7 +146,7 @@ pub(crate) unsafe extern "Rust" fn exported_agent_factory_policy_build(
     Box::pin(async move {
         validate_factory_bridge_token(factory_bridge_token)?;
         builder.validate_factory_policy()?;
-        Ok(builder.build_inner(client, tools, store).await)
+        builder.build_inner(client, tools, store).await
     })
 }
 
@@ -316,12 +320,32 @@ impl AgentBuilder {
     /// primitive themselves. Production-facing Meerkat surfaces route through
     /// `AgentFactory::build_agent`.
     #[cfg(test)]
+    #[allow(clippy::panic)]
     pub async fn build_standalone<C, T, S>(
         self,
         client: Arc<C>,
         tools: Arc<T>,
         store: Arc<S>,
     ) -> Agent<C, T, S>
+    where
+        C: AgentLlmClient + ?Sized,
+        T: AgentToolDispatcher + ?Sized,
+        S: AgentSessionStore + ?Sized,
+    {
+        match self.try_build_standalone(client, tools, store).await {
+            Ok(agent) => agent,
+            Err(err) => panic!("standalone agent build failed: {err}"),
+        }
+    }
+
+    /// Build a standalone low-level agent and surface core build failures.
+    #[cfg(test)]
+    pub async fn try_build_standalone<C, T, S>(
+        self,
+        client: Arc<C>,
+        tools: Arc<T>,
+        store: Arc<S>,
+    ) -> Result<Agent<C, T, S>, AgentBuildPolicyError>
     where
         C: AgentLlmClient + ?Sized,
         T: AgentToolDispatcher + ?Sized,
@@ -354,7 +378,7 @@ impl AgentBuilder {
         client: Arc<C>,
         tools: Arc<T>,
         store: Arc<S>,
-    ) -> Agent<C, T, S>
+    ) -> Result<Agent<C, T, S>, AgentBuildPolicyError>
     where
         C: AgentLlmClient + ?Sized,
         T: AgentToolDispatcher + ?Sized,
@@ -484,11 +508,21 @@ impl AgentBuilder {
             last_pending_catalog_sources: Default::default(),
         };
 
-        let mut visibility_state = agent.session.tool_visibility_state().unwrap_or_default();
         let has_canonical_visibility_state = agent
             .session
             .metadata()
             .contains_key(SESSION_TOOL_VISIBILITY_STATE_KEY);
+        let mut visibility_state = match agent.session.tool_visibility_state() {
+            Ok(Some(state)) => state,
+            Ok(None) => SessionToolVisibilityState::default(),
+            Err(err) => {
+                return Err(AgentBuildPolicyError::ToolVisibilityRestore {
+                    message: format!(
+                        "failed to decode canonical session metadata `{SESSION_TOOL_VISIBILITY_STATE_KEY}`: {err}"
+                    ),
+                });
+            }
+        };
 
         if !has_canonical_visibility_state {
             if let Some(raw_filter) = agent
@@ -503,10 +537,11 @@ impl AgentBuilder {
                         visibility_state.staged_filter = filter;
                     }
                     Err(err) => {
-                        tracing::warn!(
-                            error = %err,
-                            "failed to parse persisted tool scope filter; ignoring"
-                        );
+                        return Err(AgentBuildPolicyError::ToolVisibilityRestore {
+                            message: format!(
+                                "failed to decode legacy session metadata `{EXTERNAL_TOOL_FILTER_METADATA_KEY}`: {err}"
+                            ),
+                        });
                     }
                 }
             }
@@ -522,10 +557,11 @@ impl AgentBuilder {
                         visibility_state.inherited_base_filter = filter;
                     }
                     Err(err) => {
-                        tracing::warn!(
-                            error = %err,
-                            "failed to parse inherited tool scope filter; ignoring"
-                        );
+                        return Err(AgentBuildPolicyError::ToolVisibilityRestore {
+                            message: format!(
+                                "failed to decode legacy session metadata `{INHERITED_TOOL_FILTER_METADATA_KEY}`: {err}"
+                            ),
+                        });
                     }
                 }
             }
@@ -538,26 +574,24 @@ impl AgentBuilder {
                 .tool_scope
                 .set_visibility_state(visibility_state.clone())
             {
-                tracing::warn!(
-                    error = %err,
-                    "failed to apply canonical tool visibility state; ignoring"
-                );
-            } else if let Err(err) = agent.session.set_tool_visibility_state(visibility_state) {
-                tracing::warn!(
-                    error = %err,
-                    "failed to persist canonical tool visibility state during restore"
-                );
-            } else {
-                agent
-                    .session
-                    .remove_metadata(EXTERNAL_TOOL_FILTER_METADATA_KEY);
-                agent
-                    .session
-                    .remove_metadata(INHERITED_TOOL_FILTER_METADATA_KEY);
+                return Err(AgentBuildPolicyError::ToolVisibilityRestore {
+                    message: err.to_string(),
+                });
             }
+            if let Err(err) = agent.session.set_tool_visibility_state(visibility_state) {
+                return Err(AgentBuildPolicyError::ToolVisibilityPersist {
+                    message: err.to_string(),
+                });
+            }
+            agent
+                .session
+                .remove_metadata(EXTERNAL_TOOL_FILTER_METADATA_KEY);
+            agent
+                .session
+                .remove_metadata(INHERITED_TOOL_FILTER_METADATA_KEY);
         }
 
-        agent
+        Ok(agent)
     }
 
     /// Set the session checkpointer for keep-alive persistence.
@@ -747,7 +781,7 @@ mod tests {
     use async_trait::async_trait;
     use std::collections::BTreeMap;
     use std::sync::Mutex;
-    use std::sync::atomic::AtomicBool;
+    use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
     use tokio::sync::mpsc;
 
     struct MockClient;
@@ -811,6 +845,179 @@ mod tests {
         }
         async fn load(&self, _id: &str) -> Result<Option<Session>, AgentError> {
             Ok(None)
+        }
+    }
+
+    struct RestoreFailingVisibilityOwner {
+        fallback_state: LocalToolVisibilityOwner,
+        replace_calls: AtomicUsize,
+    }
+
+    impl RestoreFailingVisibilityOwner {
+        fn new() -> Self {
+            Self {
+                fallback_state: LocalToolVisibilityOwner::new(),
+                replace_calls: AtomicUsize::new(0),
+            }
+        }
+
+        fn replace_calls(&self) -> usize {
+            self.replace_calls.load(Ordering::SeqCst)
+        }
+    }
+
+    impl ToolVisibilityOwner for RestoreFailingVisibilityOwner {
+        fn visibility_state(
+            &self,
+        ) -> Result<SessionToolVisibilityState, crate::ToolScopeApplyError> {
+            self.fallback_state.visibility_state()
+        }
+
+        fn replace_visibility_state(
+            &self,
+            _visibility_state: SessionToolVisibilityState,
+        ) -> Result<(), crate::ToolScopeApplyError> {
+            self.replace_calls.fetch_add(1, Ordering::SeqCst);
+            Err(crate::ToolScopeApplyError::Owner {
+                message: "restore fixture rejected canonical visibility state".to_string(),
+            })
+        }
+
+        fn stage_persistent_filter(
+            &self,
+            filter: ToolFilter,
+            witnesses: BTreeMap<String, crate::ToolVisibilityWitness>,
+        ) -> Result<crate::ToolScopeRevision, crate::ToolScopeStageError> {
+            self.fallback_state
+                .stage_persistent_filter(filter, witnesses)
+        }
+
+        fn stage_requested_deferred_names(
+            &self,
+            names: std::collections::BTreeSet<String>,
+        ) -> Result<crate::ToolScopeRevision, crate::ToolScopeStageError> {
+            self.fallback_state.stage_requested_deferred_names(names)
+        }
+
+        fn request_deferred_tools(
+            &self,
+            authorities: Vec<crate::DeferredToolLoadAuthority>,
+        ) -> Result<crate::ToolScopeRevision, crate::ToolScopeStageError> {
+            self.fallback_state.request_deferred_tools(authorities)
+        }
+
+        fn replace_deferred_tool_authority_catalog(
+            &self,
+            catalog: BTreeMap<String, crate::ToolVisibilityWitness>,
+        ) {
+            self.fallback_state
+                .replace_deferred_tool_authority_catalog(catalog);
+        }
+
+        fn boundary_applied(
+            &self,
+        ) -> Result<SessionToolVisibilityState, crate::ToolScopeApplyError> {
+            self.fallback_state.boundary_applied()
+        }
+    }
+
+    struct RestoreFailureCatalogDispatcher {
+        tools: Arc<[Arc<ToolDef>]>,
+        catalog: Arc<[crate::ToolCatalogEntry]>,
+    }
+
+    impl RestoreFailureCatalogDispatcher {
+        fn new() -> Self {
+            let visible = Arc::new(ToolDef::new(
+                "visible",
+                "visible session tool",
+                serde_json::json!({ "type": "object" }),
+            ));
+            let secret = Arc::new(ToolDef::new(
+                "secret",
+                "policy-hidden session tool",
+                serde_json::json!({ "type": "object" }),
+            ));
+            let deferred_a = Arc::new(
+                ToolDef::new(
+                    "deferred_a",
+                    "deferred session tool",
+                    serde_json::json!({ "type": "object" }),
+                )
+                .with_provenance(crate::ToolProvenance {
+                    kind: crate::ToolSourceKind::Callback,
+                    source_id: "restore-fixture".into(),
+                }),
+            );
+            let deferred_b = Arc::new(
+                ToolDef::new(
+                    "deferred_b",
+                    "second deferred session tool",
+                    serde_json::json!({ "type": "object" }),
+                )
+                .with_provenance(crate::ToolProvenance {
+                    kind: crate::ToolSourceKind::Callback,
+                    source_id: "restore-fixture".into(),
+                }),
+            );
+            let control = Arc::new(ToolDef::new(
+                "tool_catalog_load",
+                "deferred catalog control tool",
+                serde_json::json!({ "type": "object" }),
+            ));
+
+            Self {
+                tools: vec![
+                    Arc::clone(&visible),
+                    Arc::clone(&secret),
+                    Arc::clone(&deferred_a),
+                    Arc::clone(&deferred_b),
+                    Arc::clone(&control),
+                ]
+                .into(),
+                catalog: vec![
+                    crate::ToolCatalogEntry::session_inline(visible, true),
+                    crate::ToolCatalogEntry::session_inline(secret, true),
+                    crate::ToolCatalogEntry::session_deferred(
+                        deferred_a,
+                        true,
+                        "callback:restore-fixture".to_string(),
+                    ),
+                    crate::ToolCatalogEntry::session_deferred(
+                        deferred_b,
+                        true,
+                        "callback:restore-fixture".to_string(),
+                    ),
+                    crate::ToolCatalogEntry::control_inline(control, true),
+                ]
+                .into(),
+            }
+        }
+    }
+
+    #[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
+    #[cfg_attr(not(target_arch = "wasm32"), async_trait)]
+    impl AgentToolDispatcher for RestoreFailureCatalogDispatcher {
+        fn tools(&self) -> Arc<[Arc<ToolDef>]> {
+            Arc::clone(&self.tools)
+        }
+
+        fn tool_catalog_capabilities(&self) -> crate::ToolCatalogCapabilities {
+            crate::ToolCatalogCapabilities {
+                exact_catalog: true,
+                may_require_catalog_control_plane: false,
+            }
+        }
+
+        fn tool_catalog(&self) -> Arc<[crate::ToolCatalogEntry]> {
+            Arc::clone(&self.catalog)
+        }
+
+        async fn dispatch(
+            &self,
+            call: ToolCallView<'_>,
+        ) -> Result<crate::ops::ToolDispatchOutcome, ToolError> {
+            Err(ToolError::access_denied(call.name))
         }
     }
 
@@ -916,6 +1123,130 @@ mod tests {
             realm: RealmId::parse("dev").expect("valid realm fixture"),
             binding: BindingId::parse(binding).expect("valid binding fixture"),
             profile: None,
+        }
+    }
+
+    #[tokio::test]
+    async fn builder_fails_closed_when_canonical_visibility_restore_fails() {
+        let client = Arc::new(MockClient);
+        let tools = Arc::new(RestoreFailureCatalogDispatcher::new());
+        let store = Arc::new(MockStore);
+        let visibility_owner = Arc::new(RestoreFailingVisibilityOwner::new());
+        let mut session = Session::new();
+        let hidden_filter = match serde_json::to_value(ToolFilter::Deny(
+            ["secret".to_string()].into_iter().collect(),
+        )) {
+            Ok(value) => value,
+            Err(err) => panic!("filter should serialize: {err}"),
+        };
+        session.set_metadata(EXTERNAL_TOOL_FILTER_METADATA_KEY, hidden_filter);
+
+        let result = AgentBuilder::new()
+            .resume_session(session)
+            .with_tool_visibility_owner(visibility_owner.clone())
+            .try_build_standalone(client, tools, store)
+            .await;
+
+        match result {
+            Err(AgentBuildPolicyError::ToolVisibilityRestore { message }) => {
+                assert!(
+                    message.contains("restore fixture rejected"),
+                    "restore error should preserve owner failure details: {message}"
+                );
+            }
+            Ok(agent) => {
+                let visible_names = agent
+                    .tool_scope()
+                    .visible_tool_names()
+                    .unwrap_or_else(|_| Default::default());
+                panic!(
+                    "builder must not complete after canonical restore failure; visible names from stale/default authority: {visible_names:?}"
+                );
+            }
+            Err(err) => panic!("unexpected build error: {err}"),
+        }
+        assert_eq!(
+            visibility_owner.replace_calls(),
+            1,
+            "builder should attempt the canonical restore once, then fail closed"
+        );
+    }
+
+    #[tokio::test]
+    async fn builder_fails_closed_when_canonical_visibility_metadata_is_malformed() {
+        let client = Arc::new(MockClient);
+        let tools = Arc::new(RestoreFailureCatalogDispatcher::new());
+        let store = Arc::new(MockStore);
+        let mut session = Session::new();
+        session.set_metadata(
+            SESSION_TOOL_VISIBILITY_STATE_KEY,
+            serde_json::json!({
+                "active_filter": {
+                    "unexpected_filter_kind": ["secret"]
+                }
+            }),
+        );
+
+        let result = AgentBuilder::new()
+            .resume_session(session)
+            .try_build_standalone(client, tools, store)
+            .await;
+
+        match result {
+            Err(AgentBuildPolicyError::ToolVisibilityRestore { message }) => {
+                assert!(
+                    message.contains("failed to decode canonical session metadata"),
+                    "restore error should identify malformed canonical metadata: {message}"
+                );
+            }
+            Ok(agent) => {
+                let visible_names = agent
+                    .tool_scope()
+                    .visible_tool_names()
+                    .unwrap_or_else(|_| Default::default());
+                panic!(
+                    "builder must not complete with default visibility after malformed canonical metadata; visible names: {visible_names:?}"
+                );
+            }
+            Err(err) => panic!("unexpected build error: {err}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn builder_fails_closed_when_legacy_visibility_filter_metadata_is_malformed() {
+        let client = Arc::new(MockClient);
+        let tools = Arc::new(RestoreFailureCatalogDispatcher::new());
+        let store = Arc::new(MockStore);
+        let mut session = Session::new();
+        session.set_metadata(
+            EXTERNAL_TOOL_FILTER_METADATA_KEY,
+            serde_json::json!({
+                "unexpected_filter_kind": ["secret"]
+            }),
+        );
+
+        let result = AgentBuilder::new()
+            .resume_session(session)
+            .try_build_standalone(client, tools, store)
+            .await;
+
+        match result {
+            Err(AgentBuildPolicyError::ToolVisibilityRestore { message }) => {
+                assert!(
+                    message.contains("failed to decode legacy session metadata"),
+                    "restore error should identify malformed legacy visibility metadata: {message}"
+                );
+            }
+            Ok(agent) => {
+                let visible_names = agent
+                    .tool_scope()
+                    .visible_tool_names()
+                    .unwrap_or_else(|_| Default::default());
+                panic!(
+                    "builder must not complete with default visibility after malformed legacy visibility metadata; visible names: {visible_names:?}"
+                );
+            }
+            Err(err) => panic!("unexpected build error: {err}"),
         }
     }
 

--- a/meerkat-core/src/agent/state.rs
+++ b/meerkat-core/src/agent/state.rs
@@ -4665,6 +4665,7 @@ mod tests {
         let visibility_state = agent
             .session()
             .tool_visibility_state()
+            .expect("session visibility state should decode")
             .expect("session effects should publish canonical visibility state");
         assert!(
             visibility_state
@@ -5280,6 +5281,7 @@ mod tests {
         let visibility_state = agent
             .session()
             .tool_visibility_state()
+            .expect("boundary visibility state should decode")
             .expect("boundary visibility apply should persist committed state");
         let expected_filter = crate::ToolFilter::Deny(["secret".to_string()].into_iter().collect());
         assert_eq!(visibility_state.active_filter, expected_filter);
@@ -5407,6 +5409,7 @@ mod tests {
         let visibility_state = agent
             .session()
             .tool_visibility_state()
+            .expect("canonical visibility state should decode")
             .expect("canonical visibility state should be present after restore");
         assert_eq!(
             visibility_state.active_filter,

--- a/meerkat-core/src/session.rs
+++ b/meerkat-core/src/session.rs
@@ -1004,10 +1004,13 @@ impl Session {
     }
 
     /// Load durable tool-visibility control state from the session metadata map.
-    pub fn tool_visibility_state(&self) -> Option<SessionToolVisibilityState> {
+    pub fn tool_visibility_state(
+        &self,
+    ) -> Result<Option<SessionToolVisibilityState>, serde_json::Error> {
         self.metadata
             .get(SESSION_TOOL_VISIBILITY_STATE_KEY)
-            .and_then(|value| serde_json::from_value(value.clone()).ok())
+            .map(|value| serde_json::from_value(value.clone()))
+            .transpose()
     }
 
     /// Store typed mob operator authority inside canonical build-state metadata.
@@ -1577,7 +1580,25 @@ mod tests {
         session
             .set_tool_visibility_state(state.clone())
             .expect("tool visibility state should serialize");
-        assert_eq!(session.tool_visibility_state(), Some(state));
+        assert_eq!(session.tool_visibility_state().unwrap(), Some(state));
+    }
+
+    #[test]
+    fn test_session_tool_visibility_state_malformed_returns_error() {
+        let mut session = Session::new();
+        session.set_metadata(
+            SESSION_TOOL_VISIBILITY_STATE_KEY,
+            serde_json::json!({
+                "active_filter": {
+                    "unexpected_filter_kind": ["secret"]
+                }
+            }),
+        );
+
+        assert!(
+            session.tool_visibility_state().is_err(),
+            "malformed canonical visibility metadata must not decode as absent/default"
+        );
     }
 
     #[test]

--- a/meerkat-core/src/tool_scope.rs
+++ b/meerkat-core/src/tool_scope.rs
@@ -1386,9 +1386,14 @@ fn sorted_names(names: &ToolNameSet) -> Vec<String> {
 #[allow(clippy::unwrap_used, clippy::expect_used)]
 mod tests {
     use super::ToolScopeRevision;
-    use super::{ToolFilter, ToolScope, ToolScopeStageError};
+    use super::{
+        ToolFilter, ToolScope, ToolScopeApplyError, ToolScopeStageError, ToolVisibilityOwner,
+    };
+    use crate::session::{
+        DeferredToolLoadAuthority, SessionToolVisibilityState, ToolVisibilityWitness,
+    };
     use crate::types::{ToolDef, ToolNameSet, ToolProvenance, ToolSourceKind};
-    use std::collections::HashSet;
+    use std::collections::{BTreeMap, BTreeSet, HashSet};
     use std::sync::Arc;
 
     fn set(names: &[&str]) -> ToolNameSet {
@@ -1424,6 +1429,57 @@ mod tests {
                 source_id: source_id.into(),
             }),
         })
+    }
+
+    struct VisibilityReadFailingOwner;
+
+    impl ToolVisibilityOwner for VisibilityReadFailingOwner {
+        fn visibility_state(&self) -> Result<SessionToolVisibilityState, ToolScopeApplyError> {
+            Err(ToolScopeApplyError::Owner {
+                message: "visibility read fixture failed".to_string(),
+            })
+        }
+
+        fn replace_visibility_state(
+            &self,
+            _visibility_state: SessionToolVisibilityState,
+        ) -> Result<(), ToolScopeApplyError> {
+            Ok(())
+        }
+
+        fn stage_persistent_filter(
+            &self,
+            _filter: ToolFilter,
+            _witnesses: BTreeMap<String, ToolVisibilityWitness>,
+        ) -> Result<ToolScopeRevision, ToolScopeStageError> {
+            Err(ToolScopeStageError::Owner {
+                message: "visibility read fixture failed".to_string(),
+            })
+        }
+
+        fn stage_requested_deferred_names(
+            &self,
+            _names: BTreeSet<String>,
+        ) -> Result<ToolScopeRevision, ToolScopeStageError> {
+            Err(ToolScopeStageError::Owner {
+                message: "visibility read fixture failed".to_string(),
+            })
+        }
+
+        fn request_deferred_tools(
+            &self,
+            _authorities: Vec<DeferredToolLoadAuthority>,
+        ) -> Result<ToolScopeRevision, ToolScopeStageError> {
+            Err(ToolScopeStageError::Owner {
+                message: "visibility read fixture failed".to_string(),
+            })
+        }
+
+        fn boundary_applied(&self) -> Result<SessionToolVisibilityState, ToolScopeApplyError> {
+            Err(ToolScopeApplyError::Owner {
+                message: "visibility read fixture failed".to_string(),
+            })
+        }
     }
 
     #[test]
@@ -1462,6 +1518,32 @@ mod tests {
 
         assert!(second > first);
         assert_eq!(handle.staged_revision().unwrap(), second);
+    }
+
+    #[test]
+    fn owner_visibility_read_failure_fails_closed_without_local_defaults() {
+        let scope = ToolScope::new_with_visibility_owner(
+            tools(&["visible", "deferred"]),
+            HashSet::new(),
+            raw_set(&["deferred"]),
+            Arc::new(VisibilityReadFailingOwner),
+        );
+
+        let err = scope
+            .visible_tools_result()
+            .expect_err("owner read failures must stay explicit");
+        assert!(
+            err.to_string().contains("visibility read fixture failed"),
+            "unexpected visibility error: {err}"
+        );
+        assert!(
+            scope.visible_tools().is_empty(),
+            "fallible visible_tools facade must close the projected tool set"
+        );
+        assert!(
+            scope.visible_tool_names().is_err(),
+            "dispatch prechecks must not synthesize names from local defaults"
+        );
     }
 
     #[test]

--- a/meerkat-rpc/src/session_runtime.rs
+++ b/meerkat-rpc/src/session_runtime.rs
@@ -242,7 +242,10 @@ fn realtime_projection_runtime_system_context(
 
 #[cfg(test)]
 fn exported_tool_visibility_state(session: &Session) -> meerkat_core::SessionToolVisibilityState {
-    session.tool_visibility_state().unwrap_or_default()
+    session
+        .tool_visibility_state()
+        .expect("exported visibility state should decode")
+        .unwrap_or_default()
 }
 
 struct RuntimePreAdmissionGuard {
@@ -1796,7 +1799,14 @@ impl SessionLlmReconfigureHost for SessionRuntimeLlmReconfigureHost {
             .export_live_session(session_id)
             .await
             .map_err(session_error_to_runtime_driver)?;
-        let current_visibility_state = session.tool_visibility_state().unwrap_or_default();
+        let current_visibility_state = session
+            .tool_visibility_state()
+            .map_err(|err| {
+                RuntimeDriverError::Internal(format!(
+                    "failed to decode live session tool visibility state: {err}"
+                ))
+            })?
+            .unwrap_or_default();
         let base_tool_names = self
             .service
             .tool_scope_snapshot(session_id)

--- a/meerkat-session/src/persistent.rs
+++ b/meerkat-session/src/persistent.rs
@@ -187,8 +187,10 @@ fn write_deferred_turn_state(
 fn rollback_tool_visibility_state_snapshot(
     session: &Session,
 ) -> Option<meerkat_core::SessionToolVisibilityState> {
-    if let Some(state) = session.tool_visibility_state() {
-        return Some(state);
+    match session.tool_visibility_state() {
+        Ok(Some(state)) => return Some(state),
+        Ok(None) => {}
+        Err(_) => return None,
     }
 
     let mut state = meerkat_core::SessionToolVisibilityState::default();
@@ -3559,7 +3561,14 @@ mod tests {
                 Ok(guard) => guard,
                 Err(poisoned) => poisoned.into_inner(),
             };
-            let mut state = session.tool_visibility_state().unwrap_or_default();
+            let mut state = session
+                .tool_visibility_state()
+                .map_err(|err| {
+                    meerkat_core::error::AgentError::InternalError(format!(
+                        "failed to decode dummy visibility state: {err}"
+                    ))
+                })?
+                .unwrap_or_default();
             state.staged_filter = filter;
             state.staged_revision = state.staged_revision.max(state.active_revision) + 1;
             session.set_tool_visibility_state(state).map_err(|err| {
@@ -4428,7 +4437,14 @@ mod tests {
                 Ok(guard) => guard,
                 Err(poisoned) => poisoned.into_inner(),
             };
-            let mut state = session.tool_visibility_state().unwrap_or_default();
+            let mut state = session
+                .tool_visibility_state()
+                .map_err(|err| {
+                    meerkat_core::error::AgentError::InternalError(format!(
+                        "failed to decode dummy visibility state: {err}"
+                    ))
+                })?
+                .unwrap_or_default();
             let requested_name = format!("requested:{}", call.name);
             state
                 .staged_requested_deferred_names
@@ -9267,6 +9283,7 @@ mod tests {
         let exported = service.export_session_with_labels(&id).await.unwrap();
         let exported_state = exported
             .tool_visibility_state()
+            .expect("live visibility state should decode")
             .expect("live session should carry visibility state after staging");
         assert_eq!(exported_state.staged_filter, filter);
         assert_eq!(exported_state.active_filter, meerkat_core::ToolFilter::All);
@@ -9276,6 +9293,7 @@ mod tests {
         let persisted = store.load(&id).await.unwrap().unwrap();
         let persisted_state = persisted
             .tool_visibility_state()
+            .expect("persisted visibility state should decode")
             .expect("persisted session should carry visibility state after staging");
         assert_eq!(persisted_state, exported_state);
     }
@@ -9298,7 +9316,10 @@ mod tests {
 
         let baseline = service.export_session_with_labels(&id).await.unwrap();
         assert!(
-            baseline.tool_visibility_state().is_none(),
+            baseline
+                .tool_visibility_state()
+                .expect("baseline visibility state should decode")
+                .is_none(),
             "new sessions should not materialize visibility metadata before updates"
         );
 
@@ -9314,16 +9335,23 @@ mod tests {
         fail_store.set_fail_save(false);
 
         let exported = service.export_session_with_labels(&id).await.unwrap();
+        let exported_visibility_state = exported
+            .tool_visibility_state()
+            .expect("exported visibility state should decode");
+        let baseline_visibility_state = baseline
+            .tool_visibility_state()
+            .expect("baseline visibility state should decode");
         assert_eq!(
-            exported.tool_visibility_state(),
-            baseline.tool_visibility_state(),
+            exported_visibility_state, baseline_visibility_state,
             "live session should roll back to the pre-mutation visibility state"
         );
 
         let persisted = fail_store.inner.load(&id).await.unwrap().unwrap();
+        let persisted_visibility_state = persisted
+            .tool_visibility_state()
+            .expect("persisted visibility state should decode");
         assert_eq!(
-            persisted.tool_visibility_state(),
-            baseline.tool_visibility_state(),
+            persisted_visibility_state, baseline_visibility_state,
             "store should retain the pre-mutation visibility state after rollback"
         );
     }
@@ -9547,6 +9575,7 @@ mod tests {
             .expect("persisted session should exist");
         let visibility_state = persisted
             .tool_visibility_state()
+            .expect("persisted visibility state should decode")
             .expect("persistent dispatch should save session mutations");
         assert!(
             visibility_state

--- a/meerkat/src/factory.rs
+++ b/meerkat/src/factory.rs
@@ -3190,7 +3190,14 @@ impl AgentFactory {
                 meerkat_core::capability_base_filter_for_image_tool_results(
                     profile.image_tool_results,
                 );
-            let mut visibility_state = session.tool_visibility_state().unwrap_or_default();
+            let mut visibility_state = session
+                .tool_visibility_state()
+                .map_err(|err| {
+                    BuildAgentError::Config(format!(
+                        "failed to decode canonical tool visibility state: {err}"
+                    ))
+                })?
+                .unwrap_or_default();
             if visibility_state.capability_base_filter != capability_base_filter
                 || has_canonical_visibility_state
             {

--- a/meerkat/tests/catalog_control_agent_boundary.rs
+++ b/meerkat/tests/catalog_control_agent_boundary.rs
@@ -212,6 +212,7 @@ async fn agent_boundary_routes_tool_catalog_load_authority_from_control_plane() 
     let visibility_state = agent
         .session()
         .tool_visibility_state()
+        .expect("agent visibility state should decode")
         .expect("agent boundary should persist canonical visibility state");
     assert!(
         visibility_state

--- a/meerkat/tests/persistence_contract.rs
+++ b/meerkat/tests/persistence_contract.rs
@@ -386,6 +386,7 @@ mod tests {
             .expect("persisted session should exist");
         let persisted_state = persisted
             .tool_visibility_state()
+            .expect("persisted visibility state should decode")
             .expect("catalog-load run should persist visibility state");
         assert!(
             persisted_state
@@ -431,6 +432,7 @@ mod tests {
             .expect("resumed live session should export");
         let resumed_state = resumed_live
             .tool_visibility_state()
+            .expect("resumed visibility state should decode")
             .expect("resumed session should carry visibility state");
         assert_eq!(
             resumed_state


### PR DESCRIPTION
## Summary
- Fail closed when canonical tool visibility restore/install or restore persistence fails, returning explicit builder policy errors instead of completing with local/default scope.
- Treat malformed canonical `session_tool_visibility_state_v1` and legacy visibility filter metadata as restore failures rather than decoding to default/ignored visibility.
- Add focused negative fixtures proving hidden/deferred tools do not become visible through stale or default authority after restore failure.
- Merge current `main`; the orphan `.claude/worktrees/piped-orbiting-oasis` gitlink deletion is now owned by the base branch.

## Review Readiness Packet

Current head SHA: 14c1b1a881e70abdd2f216a341940096b236c715

Command output:

```text
$ make dogma-cleanup-gate DOGMA_PACKET=/tmp/luc-354-pr-body-14c1b1a.md
Dogma cleanup gate passed for /tmp/luc-354-pr-body-14c1b1a.md
```

Branch: `codex/LUC-354-fail-closed-visibility-restore`
Base: `main` at `bbfe4171d91e16aa3a222f8288a0c3040223bd4a`
PR: #582
Linear: LUC-354

## Complexity Delta

- Docs/scripts/tests: 2 files (`meerkat/tests/catalog_control_agent_boundary.rs`, `meerkat/tests/persistence_contract.rs`); focused inline unit fixtures are colocated in implementation files.
- Non-test implementation: 7 files (`meerkat-core/src/agent/builder.rs`, `meerkat-core/src/agent/state.rs`, `meerkat-core/src/session.rs`, `meerkat-core/src/tool_scope.rs`, `meerkat-rpc/src/session_runtime.rs`, `meerkat-session/src/persistent.rs`, `meerkat/src/factory.rs`).
- Repo metadata: 0 files in the current PR diff; the earlier orphan worktree gitlink deletion is now present on `main` and no longer part of this PR's merge-base diff.
- Generated/schema churn: 0 files.
- Current diff: 9 files changed, 533 insertions(+), 47 deletions(-).

## Old Path Amputation Proof

| Old path | Classification | Search literal | Mechanical proof | Follow-up |
| --- | --- | --- | --- | --- |
| `failed to apply canonical tool visibility state; ignoring` warn branch | deleted | `failed to apply canonical tool visibility state; ignoring` | `rg -F "failed to apply canonical tool visibility state; ignoring" meerkat-core/src/agent/builder.rs` returns no matches; `builder_fails_closed_when_canonical_visibility_restore_fails` now observes `ToolVisibilityRestore`. | none |
| `else-if set_tool_visibility_state warn persist branch` | deleted | `else if let Err(err) = agent.session.set_tool_visibility_state` | `rg -F "else if let Err(err) = agent.session.set_tool_visibility_state" meerkat-core/src/agent/builder.rs` returns no matches; restore persistence errors now return `ToolVisibilityPersist`. | none |
| `failed to parse persisted tool scope filter; ignoring` migration branch | deleted | `failed to parse persisted tool scope filter; ignoring` | `rg -F "failed to parse persisted tool scope filter; ignoring" meerkat-core/src/agent/builder.rs` returns no matches; malformed legacy external filter metadata now returns `ToolVisibilityRestore`. | none |
| `failed to parse inherited tool scope filter; ignoring` migration branch | deleted | `failed to parse inherited tool scope filter; ignoring` | `rg -F "failed to parse inherited tool scope filter; ignoring" meerkat-core/src/agent/builder.rs` returns no matches; malformed legacy inherited filter metadata now returns `ToolVisibilityRestore`. | none |
| `tool_visibility_state Option decode-erasure path` | deleted | `pub fn tool_visibility_state(&self) -> Option<SessionToolVisibilityState>` | `rg -F "pub fn tool_visibility_state(&self) -> Option<SessionToolVisibilityState>" meerkat-core/src/session.rs` returns no matches; malformed canonical metadata now returns a decode error. | none |

## Sample Passing Old Path Amputation Proof

| Old path | Classification | Search literal | Mechanical proof | Follow-up |
| --- | --- | --- | --- | --- |
| `failed to apply canonical tool visibility state; ignoring` warn branch | deleted | `failed to apply canonical tool visibility state; ignoring` | No production references remain and focused negative coverage observes explicit restore failure. | none |
| `tool_visibility_state Option decode-erasure path` | deleted | `pub fn tool_visibility_state(&self) -> Option<SessionToolVisibilityState>` | No production signature remains; callers must handle canonical decode errors. | none |

## Sample Failing Old Path Amputation Proof

| Old path | Classification | Search literal | Mechanical proof | Follow-up |
| --- | --- | --- | --- | --- |
| `old/session-route` | wrapped | `old/session-route` | A preferred path exists beside the old route. | none |

## Validation
- `./scripts/repo-cargo test -p meerkat-core malformed -- --nocapture` passed after rebase.
- `./scripts/repo-cargo test -p meerkat-core fails_closed -- --nocapture` passed after rebase.
- `./scripts/repo-cargo test -p meerkat-core builder_restores -- --nocapture` passed after rebase.
- `git diff --check origin/main...HEAD` passed.
- `rg -n "warn!" meerkat-core/src/agent/builder.rs meerkat-core/src/tool_scope.rs` returned no matches.
- `make check` passed through BuildBuddy/Bazel RBE, invocation `00f301e1-4024-4bde-821c-47e897de8b95`.
- `make dogma-cleanup-gate DOGMA_PACKET=/tmp/luc-354-pr-body-14c1b1a.md` passed on exact head `14c1b1a881e70abdd2f216a341940096b236c715`.

## Review Gate Notes
- Prior immutable gate run `25282285929` reached policy evaluation and failed only because the PR body lacked `Sample Passing Old Path Amputation Proof`.
- Later admission failed after the PR head changed to `14c1b1a881e70abdd2f216a341940096b236c715` while the body still named the previous `0b43f954e10d8293c69e0004b54c6e49779c0ec1` head.
- This packet is refreshed for exact head `14c1b1a881e70abdd2f216a341940096b236c715` and current base `bbfe4171d91e16aa3a222f8288a0c3040223bd4a`.
