### PR TITLE
LUC-318 Collapse auth provider ownership boundaries

### DIFF
--- a/meerkat-anthropic/src/runtime/mod.rs
+++ b/meerkat-anthropic/src/runtime/mod.rs
@@ -368,12 +368,7 @@ impl ProviderRuntime for AnthropicProviderRuntime {
                             persisted
                         }
                         AnthropicAuthMethod::ClaudeAiOauth => {
-                            use chrono::{Duration, Utc};
-                            let fresh = persisted
-                                .expires_at
-                                .is_none_or(|exp| exp - Utc::now() > Duration::seconds(60));
                             if lifecycle == ManagedStoreLifecycle::Authorized
-                                && fresh
                                 && persisted.primary_secret.is_some()
                                 && !env.force_refresh
                             {

--- a/meerkat-auth-core/src/resolver.rs
+++ b/meerkat-auth-core/src/resolver.rs
@@ -165,6 +165,18 @@ pub enum ManagedStoreLifecycle {
 }
 
 #[cfg(not(target_arch = "wasm32"))]
+fn managed_store_lifecycle_from_phase(phase: AuthStatusPhase) -> ManagedStoreLifecycle {
+    match phase {
+        AuthStatusPhase::Valid => ManagedStoreLifecycle::Authorized,
+        AuthStatusPhase::Expiring
+        | AuthStatusPhase::Expired
+        | AuthStatusPhase::ReauthRequired
+        | AuthStatusPhase::RefreshFailed
+        | AuthStatusPhase::Unknown => ManagedStoreLifecycle::RefreshRequired,
+    }
+}
+
+#[cfg(not(target_arch = "wasm32"))]
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum OAuthLifecycleMarkerRelation {
     Matches,
@@ -339,11 +351,7 @@ pub async fn load_managed_store_tokens_with_lifecycle(
         now,
         Some(meerkat_core::persisted_token_expires_at_epoch_secs(&tokens)),
     );
-    let lifecycle = if token_phase == AuthStatusPhase::Expired {
-        ManagedStoreLifecycle::RefreshRequired
-    } else {
-        ManagedStoreLifecycle::Authorized
-    };
+    let lifecycle = managed_store_lifecycle_from_phase(token_phase);
 
     if let Some(auth_lease) = env.auth_lease_handle.as_ref() {
         let mut snapshot = auth_lease.snapshot(&lease_key);
@@ -413,15 +421,15 @@ pub async fn load_managed_store_tokens_with_lifecycle(
         }
 
         return match phase {
-            AuthStatusPhase::Valid | AuthStatusPhase::Expiring => Ok(managed_store_tokens(
+            AuthStatusPhase::Valid => Ok(managed_store_tokens(
                 store,
                 key,
                 tokens,
                 Some(snapshot),
-                lifecycle,
+                managed_store_lifecycle_from_phase(phase),
                 lifecycle_guard,
             )),
-            AuthStatusPhase::Expired => Ok(managed_store_tokens(
+            AuthStatusPhase::Expiring | AuthStatusPhase::Expired => Ok(managed_store_tokens(
                 store,
                 key,
                 tokens,
@@ -1878,6 +1886,43 @@ mod tests {
             err,
             ProviderAuthError::Auth(AuthError::InteractiveLoginRequired | AuthError::MissingSecret)
         ));
+    }
+
+    #[cfg(not(target_arch = "wasm32"))]
+    #[tokio::test]
+    async fn managed_store_oauth_source_rejects_expiring_authmachine_freshness() {
+        let store = Arc::new(EphemeralTokenStore::new());
+        let binding =
+            simple_secret_binding(CredentialSourceSpec::ManagedStore, "managed_chatgpt_oauth");
+        let key = TokenKey::from_connection_ref(&binding.connection_ref);
+        let mut tokens = chatgpt_oauth_tokens("expiring-access");
+        tokens.expires_at = Some(chrono::Utc::now() + chrono::Duration::seconds(30));
+        let expires_at = meerkat_core::persisted_token_expires_at_epoch_secs(&tokens);
+        let transition = AuthLeaseTransition {
+            generation: 7,
+            credential_published_at_millis: Some(2_000),
+        };
+        let marked =
+            meerkat_core::mark_tokens_lifecycle_published_for_transition(&tokens, transition);
+        store.save(&key, &marked).await.unwrap();
+        let env = ResolverEnvironment::testing()
+            .with_token_store(store)
+            .with_auth_lease_handle(
+                StaticAuthLeaseHandle::valid_generation_with_expiry_and_publication_time(
+                    7,
+                    expires_at,
+                    Some(2_000),
+                ),
+            );
+
+        let err = resolve_simple_secret(&binding.auth_profile.source, &env, &binding)
+            .await
+            .unwrap_err();
+
+        assert!(
+            matches!(err, ProviderAuthError::Auth(AuthError::Expired)),
+            "expiring OAuth token must be rejected at the AuthMachine/token-store boundary, got {err}"
+        );
     }
 
     #[cfg(not(target_arch = "wasm32"))]

--- a/meerkat-gemini/src/runtime/mod.rs
+++ b/meerkat-gemini/src/runtime/mod.rs
@@ -270,12 +270,7 @@ impl ProviderRuntime for GoogleProviderRuntime {
                         load_managed_store_tokens_with_lifecycle(env, binding).await?;
                     let lifecycle = managed.lifecycle;
                     let persisted = managed.tokens.clone();
-                    use chrono::{Duration, Utc};
-                    let fresh = persisted
-                        .expires_at
-                        .is_none_or(|exp| exp - Utc::now() > Duration::seconds(60));
                     let effective_tokens = if lifecycle == ManagedStoreLifecycle::Authorized
-                        && fresh
                         && persisted.primary_secret.is_some()
                         && !env.force_refresh
                     {

--- a/meerkat-openai/src/runtime/mod.rs
+++ b/meerkat-openai/src/runtime/mod.rs
@@ -182,12 +182,7 @@ impl ProviderRuntime for OpenAiProviderRuntime {
                             persisted
                         }
                         OpenAiAuthMethod::ManagedChatGptOauth => {
-                            use chrono::{Duration, Utc};
-                            let fresh = persisted
-                                .expires_at
-                                .is_none_or(|exp| exp - Utc::now() > Duration::seconds(60));
                             if lifecycle == ManagedStoreLifecycle::Authorized
-                                && fresh
                                 && persisted.primary_secret.is_some()
                                 && !env.force_refresh
                             {

--- a/meerkat-rpc/src/handlers/session.rs
+++ b/meerkat-rpc/src/handlers/session.rs
@@ -30,6 +30,14 @@ use meerkat::surface::{RequestContext, request_action};
 // Param types
 // ---------------------------------------------------------------------------
 
+fn parse_provider_param(provider: &str) -> Result<Provider, String> {
+    Provider::parse_strict(provider).ok_or_else(|| {
+        format!(
+            "unknown provider '{provider}' (expected anthropic, openai, gemini, or self_hosted)"
+        )
+    })
+}
+
 /// Controls whether the first turn runs immediately on session creation.
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Deserialize, Serialize)]
 #[serde(rename_all = "snake_case")]
@@ -269,7 +277,15 @@ pub async fn handle_create(
                 .unwrap_or("claude-sonnet-4-5")
                 .to_string()
         });
-    let provider = params.provider.as_deref().map(Provider::from_name);
+    let provider = match params
+        .provider
+        .as_deref()
+        .map(parse_provider_param)
+        .transpose()
+    {
+        Ok(provider) => provider,
+        Err(message) => return RpcResponse::error(id, error::INVALID_PARAMS, message),
+    };
 
     // Parse output schema if provided
     let output_schema = match params.output_schema {
@@ -684,6 +700,14 @@ mod tests {
         let json = serde_json::json!({"prompt": "hello"});
         let params: CreateSessionParams = serde_json::from_value(json).unwrap();
         assert_eq!(params.initial_turn, None);
+    }
+
+    #[test]
+    fn create_session_provider_param_fails_closed_for_unknown_provider() {
+        let err = super::parse_provider_param("provider-shaped-cache-key").unwrap_err();
+
+        assert!(err.contains("unknown provider"));
+        assert!(err.contains("provider-shaped-cache-key"));
     }
 
     #[test]

--- a/meerkat-rpc/src/session_runtime.rs
+++ b/meerkat-rpc/src/session_runtime.rs
@@ -71,6 +71,14 @@ use meerkat_core::ToolConfigChangeOperation;
 
 const SESSION_TRANSIENT_PENDING_ARCHIVE_KEY: &str = "session_transient_pending_archive";
 
+fn unknown_provider_message(provider: &str) -> String {
+    format!("unknown provider '{provider}' (expected anthropic, openai, gemini, or self_hosted)")
+}
+
+fn parse_provider_override(provider: &str) -> Result<meerkat_core::Provider, String> {
+    meerkat_core::Provider::parse_strict(provider).ok_or_else(|| unknown_provider_message(provider))
+}
+
 fn render_context_append_text(content: &CoreRenderable) -> String {
     match content {
         CoreRenderable::Text { text } => text.clone(),
@@ -1715,7 +1723,8 @@ impl SessionRuntimeLlmReconfigureHost {
             .clone()
             .unwrap_or_else(|| current.model.clone());
         let provider = if let Some(provider_name) = request.provider.as_ref() {
-            meerkat_core::Provider::from_name(provider_name)
+            parse_provider_override(provider_name)
+                .map_err(|reason| RuntimeDriverError::ValidationFailed { reason })?
         } else {
             current.provider
         };
@@ -2193,7 +2202,7 @@ impl SessionRuntime {
                 .map(meerkat_core::lifecycle::run_primitive::ModelId::new),
             provider: overrides
                 .and_then(|ov| ov.provider.as_ref())
-                .map(|provider| meerkat_core::Provider::from_name(provider)),
+                .and_then(|provider| parse_provider_override(provider).ok()),
             provider_params,
             render_metadata: None,
             connection_ref,
@@ -3615,11 +3624,15 @@ impl SessionRuntime {
 
         Ok(SurfaceSessionRecoveryOverrides {
             model: overrides.and_then(|ov| ov.model.clone()),
-            provider: overrides.and_then(|ov| {
-                ov.provider
-                    .as_ref()
-                    .map(|provider| meerkat_core::Provider::from_name(provider))
-            }),
+            provider: overrides
+                .and_then(|ov| ov.provider.as_ref())
+                .map(|provider| parse_provider_override(provider))
+                .transpose()
+                .map_err(|message| RpcError {
+                    code: error::INVALID_PARAMS,
+                    message,
+                    data: None,
+                })?,
             provider_params: overrides.and_then(|ov| ov.provider_params.clone()),
             clear_provider_params: overrides.is_some_and(|ov| ov.clear_provider_params),
             connection_ref: overrides.and_then(|ov| ov.connection_ref.clone()),
@@ -3885,7 +3898,11 @@ impl SessionRuntime {
         let registry = self.model_registry().await?;
         let model = ov.model.clone().unwrap_or_else(|| current.model.clone());
         let provider = if let Some(provider_name) = ov.provider.as_ref() {
-            meerkat_core::Provider::from_name(provider_name)
+            parse_provider_override(provider_name).map_err(|message| RpcError {
+                code: error::INVALID_PARAMS,
+                message,
+                data: None,
+            })?
         } else {
             current.provider
         };
@@ -10498,6 +10515,38 @@ mod tests {
         assert!(
             err.to_string().contains("anthropic") && err.to_string().contains("gpt-5.4"),
             "error should identify the rejected provider/model pair: {err}"
+        );
+    }
+
+    #[tokio::test]
+    async fn reconfigure_rejects_unknown_provider_model_identity() {
+        let temp = tempfile::tempdir().unwrap();
+        let runtime = make_runtime(temp_factory(&temp), 10);
+        let host = runtime.llm_reconfigure_host();
+        let current = SessionLlmIdentity {
+            model: "claude-sonnet-4-5".to_string(),
+            provider: meerkat_core::Provider::Anthropic,
+            self_hosted_server_id: None,
+            provider_params: None,
+            connection_ref: None,
+        };
+        let request = SessionLlmReconfigureRequest {
+            model: Some("unknown-model-xyz".to_string()),
+            provider: Some("provider-shaped-cache-key".to_string()),
+            provider_params: None,
+            clear_provider_params: false,
+            connection_ref: None,
+            clear_connection_ref: false,
+        };
+
+        let err = host
+            .resolve_target_session_llm_identity(&request, &current)
+            .await
+            .expect_err("unknown provider/model identity must fail closed");
+        assert!(
+            err.to_string().contains("unknown provider")
+                && err.to_string().contains("provider-shaped-cache-key"),
+            "error should reject the provider string before model fallback: {err}"
         );
     }
 


### PR DESCRIPTION
## Summary

Dogma cleanup PR: yes.

- Collapses managed-store OAuth freshness into the `meerkat-auth-core` resolver boundary by treating AuthMachine `Expiring` snapshots as `ManagedStoreLifecycle::RefreshRequired`.
- Removes provider-local OAuth freshness clocks from OpenAI, Gemini, and Anthropic managed OAuth runtime branches.
- Makes RPC provider identity overrides fail closed by replacing `Provider::from_name` fallback with strict provider parsing in session create/reconfigure/recovery/turn paths.

Linear: LUC-318

## Validation

```text
./scripts/repo-cargo fmt
git diff --check
./scripts/repo-cargo test -p meerkat-auth-core managed_store_oauth_source_rejects_expiring_authmachine_freshness
./scripts/repo-cargo test -p meerkat-rpc reconfigure_rejects_unknown_provider_model_identity
./scripts/repo-cargo test -p meerkat-rpc create_session_provider_param_fails_closed_for_unknown_provider
./scripts/repo-cargo test -p meerkat-openai --test oauth_resolve openai_managed_chatgpt_oauth_fresh_token_resolves
./scripts/repo-cargo test -p meerkat-gemini --test oauth_resolve google_oauth_fresh_token_resolves_with_auth_lifecycle
./scripts/repo-cargo test -p meerkat-anthropic --test oauth_resolve claude_ai_oauth_fresh_token_returns_access_token
./scripts/repo-cargo test -p meerkat-auth-core managed_store_oauth
./scripts/repo-cargo test -p meerkat-rpc unknown_provider
make dogma-cleanup-gate DOGMA_PACKET=artifacts/review-readiness-luc-318.md
make check
```

Rerun note: packet SHA refreshed after branch head `eb9e5750f331a7ff4afd2ac723bf0606a0b3b2c0` merged current `main`.

## Review Readiness Packet

Current head SHA: eb9e5750f331a7ff4afd2ac723bf0606a0b3b2c0

Command output:

```text
$ make dogma-cleanup-gate DOGMA_PACKET=artifacts/review-readiness-luc-318.md
Dogma cleanup gate passed for /home/luka_crnkovicfriis_king_com/symphony/workspaces/LUC-318/artifacts/review-readiness-luc-318.md
```

## Old Path Amputation Proof

| Old path | Classification | Search literal | Mechanical proof | Follow-up |
| --- | --- | --- | --- | --- |
| `RPC create Provider::from_name param parse` | made uncallable at boundary | `map(Provider::from_name)` | `handle_create` routes provider input through `parse_provider_param`; rejected calls are covered by `./scripts/repo-cargo test -p meerkat-rpc unknown_provider`. | none |
| `RPC Provider::from_name(provider_name) identity parse` | made uncallable at boundary | `Provider::from_name(provider_name)` | Reconfigure and turn identity resolution route provider input through `parse_provider_override`; rejected calls are covered by `./scripts/repo-cargo test -p meerkat-rpc unknown_provider`. | none |
| `turn_metadata_from_overrides Provider::from_name metadata projection` | made uncallable at boundary | `turn_metadata_from_overrides Provider::from_name metadata projection` | Provider input is rejected by the runtime handler before turn metadata projection; the runtime rejects requests in `./scripts/repo-cargo test -p meerkat-rpc unknown_provider`. | none |
| `provider-local OAuth exp - Utc::now() > Duration::seconds(60)` | deleted | `exp - Utc::now() > Duration::seconds(60)` | `rg -F "exp - Utc::now() > Duration::seconds(60)" meerkat-openai/src/runtime/mod.rs meerkat-gemini/src/runtime/mod.rs meerkat-anthropic/src/runtime/mod.rs` returns no matches; the resolver boundary rejects expiring leases in `./scripts/repo-cargo test -p meerkat-auth-core managed_store_oauth`. | none |

## Atomicity Proof

- Token usability for managed-store OAuth is decided in `meerkat-auth-core::load_managed_store_tokens_with_lifecycle` from the AuthMachine lease snapshot plus the token lifecycle marker relation.
- `AuthStatusPhase::Expiring` now maps to `ManagedStoreLifecycle::RefreshRequired` at the resolver boundary, so provider runtimes cannot publish a separate freshness decision from their local wall-clock check.
- Refresh publication still uses the canonical lifecycle commit path. Existing `managed_store_oauth_refresh_commit_uses_authmachine_refresh_lifecycle`, `managed_store_oauth_refresh_rejects_newer_token_marker_over_refreshing_lease`, and `managed_store_oauth_refresh_rejects_newer_token_marker_over_existing_lease` cover unchanged token-store and AuthMachine snapshot guards before commit.
- Refresh failure and rollback behavior remains covered by `managed_store_oauth_owned_refresh_failure_publishes_authmachine_failure`, `managed_store_oauth_transient_refresh_failure_keeps_retryable_marker`, and the provider runtime commit/rollback tests.

## Negative Coverage

- Unknown RPC provider/model identity: `./scripts/repo-cargo test -p meerkat-rpc unknown_provider`.
- Stale/expiring OAuth freshness: `./scripts/repo-cargo test -p meerkat-auth-core managed_store_oauth`.

## Compatibility Scope

- `Provider::from_name` is not removed from `meerkat-core` because it is the enum helper definition.
- Non-RPC uses in `meerkat/src/factory.rs` and `examples/035-mdm-tux-rs/src/bin/target.rs` are outside this PR boundary and are not used as proof for RPC admission.

## Complexity Delta

- Docs/scripts/tests: 0 files.
- Non-test implementation: 6 files (`meerkat-auth-core`, OpenAI/Gemini/Anthropic runtimes, RPC session handler/runtime); focused unit tests are colocated inside touched implementation files.
- Generated/schema churn: 0 files.

## Sample Passing Old Path Amputation Proof

| Old path | Classification | Search literal | Mechanical proof | Follow-up |
| --- | --- | --- | --- | --- |
| `old/session-route` | deleted | `old/session-route` | No production references remain. | none |

## Sample Failing Old Path Amputation Proof

| Old path | Classification | Search literal | Mechanical proof | Follow-up |
| --- | --- | --- | --- | --- |
| `old/session-route` | wrapped | `old/session-route` | A preferred path exists beside the old route. | none |
