### PR TITLE
LUC-360 self-validate immutable dogma gate

### DIFF
--- a/.github/workflows/dogma-cleanup-immutable-gate.yml
+++ b/.github/workflows/dogma-cleanup-immutable-gate.yml
@@ -61,3 +61,70 @@ jobs:
             exit 1
           fi
           python3 "$gate_script" --repo "$pr_repo" --base "$DOGMA_CLEANUP_BASE" --github-event "$GITHUB_EVENT_PATH"
+
+      - name: Detect dogma gate-owned changes
+        id: dogma_gate_changes
+        shell: bash
+        env:
+          DOGMA_CLEANUP_BASE: refs/remotes/dogma-base/dogma-cleanup-base
+        run: |
+          pr_repo="$GITHUB_WORKSPACE/pr"
+          has_gate_changes=0
+          while IFS= read -r path; do
+            case "$path" in
+              Makefile|.github/PULL_REQUEST_TEMPLATE.md|.github/workflows/ci.yml|.github/workflows/dogma-cleanup-immutable-gate.yml|scripts/dogma_cleanup_gate.py|scripts/tests/dogma_cleanup_gate_test.py|scripts/fixtures/dogma_cleanup_gate/*|docs/process/dogma-cleanup-gate.md)
+                echo "Dogma gate-owned change detected: $path"
+                has_gate_changes=1
+                ;;
+            esac
+          done < <(git -C "$pr_repo" diff --name-only "$DOGMA_CLEANUP_BASE"...HEAD)
+
+          if [[ "$has_gate_changes" -eq 1 ]]; then
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Validate immutable dogma gate behavior
+        if: ${{ steps.dogma_gate_changes.outputs.changed == 'true' }}
+        shell: bash
+        run: |
+          pr_repo="$GITHUB_WORKSPACE/pr"
+          base_test_script="$GITHUB_WORKSPACE/dogma-gate-source/scripts/tests/dogma_cleanup_gate_test.py"
+          base_fixture_dir="$GITHUB_WORKSPACE/dogma-gate-source/scripts/fixtures/dogma_cleanup_gate"
+          pr_gate_script="$pr_repo/scripts/dogma_cleanup_gate.py"
+          pr_test_script="$pr_repo/scripts/tests/dogma_cleanup_gate_test.py"
+          pr_fixture_dir="$pr_repo/scripts/fixtures/dogma_cleanup_gate"
+
+          if [[ ! -f "$base_test_script" ]]; then
+            echo "::error::Base dogma cleanup fixture oracle is missing: scripts/tests/dogma_cleanup_gate_test.py"
+            exit 1
+          fi
+          if [[ ! -d "$base_fixture_dir" ]]; then
+            echo "::error::Base dogma cleanup fixture directory is missing: scripts/fixtures/dogma_cleanup_gate"
+            exit 1
+          fi
+          if [[ ! -f "$pr_gate_script" ]]; then
+            echo "::error::PR-head dogma gate script is missing: scripts/dogma_cleanup_gate.py"
+            exit 1
+          fi
+          if [[ ! -f "$pr_test_script" ]]; then
+            echo "::error::PR-head dogma gate fixture suite is missing: scripts/tests/dogma_cleanup_gate_test.py"
+            exit 1
+          fi
+          if [[ ! -d "$pr_fixture_dir" ]]; then
+            echo "::error::PR-head dogma gate fixture directory is missing: scripts/fixtures/dogma_cleanup_gate"
+            exit 1
+          fi
+
+          DOGMA_GATE_REPO_ROOT="$pr_repo" \
+          DOGMA_GATE_WORKFLOW_EXEC_ROOT="$GITHUB_WORKSPACE/dogma-gate-source" \
+          DOGMA_GATE_SCRIPT="$pr_gate_script" \
+          DOGMA_GATE_FIXTURE_DIR="$base_fixture_dir" \
+            python3 "$base_test_script" -v
+
+          DOGMA_GATE_REPO_ROOT="$pr_repo" \
+          DOGMA_GATE_WORKFLOW_EXEC_ROOT="$GITHUB_WORKSPACE/dogma-gate-source" \
+          DOGMA_GATE_SCRIPT="$pr_gate_script" \
+          DOGMA_GATE_FIXTURE_DIR="$pr_fixture_dir" \
+            python3 "$base_test_script" -v

--- a/.github/workflows/dogma-cleanup-immutable-gate.yml
+++ b/.github/workflows/dogma-cleanup-immutable-gate.yml
@@ -27,6 +27,7 @@ jobs:
           repository: ${{ github.event.pull_request.head.repo.full_name || github.repository }}
           ref: ${{ github.event.pull_request.head.sha || github.sha }}
           fetch-depth: 0
+          persist-credentials: false
           path: pr
 
       - name: Checkout immutable gate source
@@ -34,6 +35,7 @@ jobs:
         with:
           ref: ${{ github.event.pull_request.base.sha || github.sha }}
           fetch-depth: 1
+          persist-credentials: false
           path: dogma-gate-source
 
       - name: Fetch base commit for diff
@@ -130,12 +132,12 @@ jobs:
 
           DOGMA_GATE_REPO_ROOT="$pr_repo" \
           DOGMA_GATE_WORKFLOW_EXEC_ROOT="$GITHUB_WORKSPACE/dogma-gate-source" \
-          DOGMA_GATE_SCRIPT="$pr_gate_script" \
+          DOGMA_GATE_SCRIPT="${pr_gate_script}" \
           DOGMA_GATE_FIXTURE_DIR="$base_fixture_dir" \
             python3 "$base_test_script" -v
 
           DOGMA_GATE_REPO_ROOT="$pr_repo" \
           DOGMA_GATE_WORKFLOW_EXEC_ROOT="$GITHUB_WORKSPACE/dogma-gate-source" \
-          DOGMA_GATE_SCRIPT="$pr_gate_script" \
+          DOGMA_GATE_SCRIPT="${pr_gate_script}" \
           DOGMA_GATE_FIXTURE_DIR="$pr_fixture_dir" \
             python3 "$base_test_script" -v

--- a/.github/workflows/dogma-cleanup-immutable-gate.yml
+++ b/.github/workflows/dogma-cleanup-immutable-gate.yml
@@ -27,7 +27,6 @@ jobs:
           repository: ${{ github.event.pull_request.head.repo.full_name || github.repository }}
           ref: ${{ github.event.pull_request.head.sha || github.sha }}
           fetch-depth: 0
-          persist-credentials: false
           path: pr
 
       - name: Checkout immutable gate source
@@ -35,7 +34,6 @@ jobs:
         with:
           ref: ${{ github.event.pull_request.base.sha || github.sha }}
           fetch-depth: 1
-          persist-credentials: false
           path: dogma-gate-source
 
       - name: Fetch base commit for diff
@@ -49,6 +47,19 @@ jobs:
           git -C "$pr_repo" remote add dogma-base "https://github.com/$BASE_REPOSITORY.git"
           git -C "$pr_repo" fetch --no-tags dogma-base "$BASE_SHA:refs/remotes/dogma-base/dogma-cleanup-base"
 
+      - name: Drop checkout credentials
+        shell: bash
+        run: |
+          for repo in "$GITHUB_WORKSPACE/pr" "$GITHUB_WORKSPACE/dogma-gate-source"; do
+            if [[ ! -d "$repo/.git" ]]; then
+              continue
+            fi
+            git -C "$repo" config --local --unset-all http.https://github.com/.extraheader || true
+            while IFS= read -r key; do
+              git -C "$repo" config --local --unset-all "$key" || true
+            done < <(git -C "$repo" config --local --name-only --get-regexp '^includeIf\..*\.path$' || true)
+          done
+
       - name: Enforce immutable dogma cleanup review packet
         shell: bash
         env:
@@ -61,3 +72,70 @@ jobs:
             exit 1
           fi
           python3 "$gate_script" --repo "$pr_repo" --base "$DOGMA_CLEANUP_BASE" --github-event "$GITHUB_EVENT_PATH"
+
+      - name: Detect dogma gate-owned changes
+        id: dogma_gate_changes
+        shell: bash
+        env:
+          DOGMA_CLEANUP_BASE: refs/remotes/dogma-base/dogma-cleanup-base
+        run: |
+          pr_repo="$GITHUB_WORKSPACE/pr"
+          has_gate_changes=0
+          while IFS= read -r path; do
+            case "$path" in
+              Makefile|.github/PULL_REQUEST_TEMPLATE.md|.github/workflows/ci.yml|.github/workflows/dogma-cleanup-immutable-gate.yml|scripts/dogma_cleanup_gate.py|scripts/tests/dogma_cleanup_gate_test.py|scripts/fixtures/dogma_cleanup_gate/*|docs/process/dogma-cleanup-gate.md)
+                echo "Dogma gate-owned change detected: $path"
+                has_gate_changes=1
+                ;;
+            esac
+          done < <(git -C "$pr_repo" diff --name-only "$DOGMA_CLEANUP_BASE"...HEAD)
+
+          if [[ "$has_gate_changes" -eq 1 ]]; then
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Validate immutable dogma gate behavior
+        if: ${{ steps.dogma_gate_changes.outputs.changed == 'true' }}
+        shell: bash
+        run: |
+          pr_repo="$GITHUB_WORKSPACE/pr"
+          base_test_script="$GITHUB_WORKSPACE/dogma-gate-source/scripts/tests/dogma_cleanup_gate_test.py"
+          base_fixture_dir="$GITHUB_WORKSPACE/dogma-gate-source/scripts/fixtures/dogma_cleanup_gate"
+          pr_gate_script="$pr_repo/scripts/dogma_cleanup_gate.py"
+          pr_test_script="$pr_repo/scripts/tests/dogma_cleanup_gate_test.py"
+          pr_fixture_dir="$pr_repo/scripts/fixtures/dogma_cleanup_gate"
+
+          if [[ ! -f "$base_test_script" ]]; then
+            echo "::error::Base dogma cleanup fixture oracle is missing: scripts/tests/dogma_cleanup_gate_test.py"
+            exit 1
+          fi
+          if [[ ! -d "$base_fixture_dir" ]]; then
+            echo "::error::Base dogma cleanup fixture directory is missing: scripts/fixtures/dogma_cleanup_gate"
+            exit 1
+          fi
+          if [[ ! -f "$pr_gate_script" ]]; then
+            echo "::error::PR-head dogma gate script is missing: scripts/dogma_cleanup_gate.py"
+            exit 1
+          fi
+          if [[ ! -f "$pr_test_script" ]]; then
+            echo "::error::PR-head dogma gate fixture suite is missing: scripts/tests/dogma_cleanup_gate_test.py"
+            exit 1
+          fi
+          if [[ ! -d "$pr_fixture_dir" ]]; then
+            echo "::error::PR-head dogma gate fixture directory is missing: scripts/fixtures/dogma_cleanup_gate"
+            exit 1
+          fi
+
+          DOGMA_GATE_REPO_ROOT="$pr_repo" \
+          DOGMA_GATE_WORKFLOW_EXEC_ROOT="$GITHUB_WORKSPACE/dogma-gate-source" \
+          DOGMA_GATE_SCRIPT="$pr_gate_script" \
+          DOGMA_GATE_FIXTURE_DIR="$base_fixture_dir" \
+            python3 "$base_test_script" -v
+
+          DOGMA_GATE_REPO_ROOT="$pr_repo" \
+          DOGMA_GATE_WORKFLOW_EXEC_ROOT="$GITHUB_WORKSPACE/dogma-gate-source" \
+          DOGMA_GATE_SCRIPT="$pr_gate_script" \
+          DOGMA_GATE_FIXTURE_DIR="$pr_fixture_dir" \
+            python3 "$base_test_script" -v

--- a/scripts/dogma_cleanup_gate.py
+++ b/scripts/dogma_cleanup_gate.py
@@ -361,7 +361,10 @@ NON_PRODUCTION_WORKSPACE_MEMBERS = {
 DOGMA_GATE_OWNING_PATHS: tuple[tuple[re.Pattern[str], str], ...] = (
     (re.compile(r"^Makefile$"), "dogma gate-owning path"),
     (
-        re.compile(r"^\.github/(?:PULL_REQUEST_TEMPLATE\.md|workflows/ci\.yml)$"),
+        re.compile(
+            r"^\.github/(?:PULL_REQUEST_TEMPLATE\.md|workflows/"
+            r"(?:ci|dogma-cleanup-immutable-gate)\.yml)$"
+        ),
         "dogma gate-owning path",
     ),
     (

--- a/scripts/tests/dogma_cleanup_gate_test.py
+++ b/scripts/tests/dogma_cleanup_gate_test.py
@@ -1210,6 +1210,7 @@ class DogmaCleanupGateTest(unittest.TestCase):
         self.assertIn("github.event.pull_request.head.repo.full_name", workflow)
         self.assertIn("github.event.pull_request.head.sha", workflow)
         self.assertIn("github.event.pull_request.base.sha", workflow)
+        self.assertIn("persist-credentials: false", workflow)
         self.assertIn("Drop checkout credentials", workflow)
         self.assertIn(
             "git -C \"$repo\" config --local --unset-all http.https://github.com/.extraheader",
@@ -1240,7 +1241,7 @@ class DogmaCleanupGateTest(unittest.TestCase):
             'DOGMA_GATE_WORKFLOW_EXEC_ROOT="$GITHUB_WORKSPACE/dogma-gate-source"',
             workflow,
         )
-        self.assertIn('DOGMA_GATE_SCRIPT="$pr_gate_script"', workflow)
+        self.assertIn('DOGMA_GATE_SCRIPT="${pr_gate_script}"', workflow)
         self.assertIn('DOGMA_GATE_FIXTURE_DIR="$base_fixture_dir"', workflow)
         self.assertIn('DOGMA_GATE_FIXTURE_DIR="$pr_fixture_dir"', workflow)
         self.assertIn('python3 "$base_test_script" -v', workflow)

--- a/scripts/tests/dogma_cleanup_gate_test.py
+++ b/scripts/tests/dogma_cleanup_gate_test.py
@@ -24,6 +24,7 @@ FIXTURE_DIR = Path(
         REPO_ROOT / "scripts" / "fixtures" / "dogma_cleanup_gate",
     )
 ).resolve()
+WORKFLOW_EXEC_ROOT = Path(os.environ.get("DOGMA_GATE_WORKFLOW_EXEC_ROOT", REPO_ROOT)).resolve()
 
 
 def run_command(args: list[str], cwd: Path) -> subprocess.CompletedProcess[str]:
@@ -1097,6 +1098,11 @@ class DogmaCleanupGateTest(unittest.TestCase):
                 "assert True\n# changed\n",
             ),
             ("scripts/fixtures/dogma_cleanup_gate/passing_packet.md", "old\n", "new\n"),
+            (
+                ".github/workflows/dogma-cleanup-immutable-gate.yml",
+                "name: immutable\n",
+                "name: noop\n",
+            ),
         ]
         for rel_path, base_text, pr_text in cases:
             with self.subTest(rel_path=rel_path):
@@ -1193,7 +1199,7 @@ class DogmaCleanupGateTest(unittest.TestCase):
         self.assertIn('python3 "$pr_test_script" -v', workflow)
         self.assertNotIn("make dogma-cleanup-ci-gate", workflow)
 
-    def test_pull_request_target_gate_uses_base_checker_without_pr_code_execution(self) -> None:
+    def test_pull_request_target_gate_uses_base_checker_and_base_owned_oracle(self) -> None:
         workflow = (
             REPO_ROOT / ".github" / "workflows" / "dogma-cleanup-immutable-gate.yml"
         ).read_text(encoding="utf-8")
@@ -1208,9 +1214,160 @@ class DogmaCleanupGateTest(unittest.TestCase):
         self.assertIn("dogma-gate-source/scripts/dogma_cleanup_gate.py", workflow)
         self.assertIn("refs/remotes/dogma-base/dogma-cleanup-base", workflow)
         self.assertIn('python3 "$gate_script" --repo "$pr_repo"', workflow)
+        self.assertIn("Detect dogma gate-owned changes", workflow)
+        self.assertIn("id: dogma_gate_changes", workflow)
+        self.assertIn(".github/workflows/dogma-cleanup-immutable-gate.yml", workflow)
+        self.assertIn("Validate immutable dogma gate behavior", workflow)
+        self.assertIn("steps.dogma_gate_changes.outputs.changed == 'true'", workflow)
+        self.assertIn(
+            'base_test_script="$GITHUB_WORKSPACE/dogma-gate-source/scripts/tests/dogma_cleanup_gate_test.py"',
+            workflow,
+        )
+        self.assertIn(
+            'base_fixture_dir="$GITHUB_WORKSPACE/dogma-gate-source/scripts/fixtures/dogma_cleanup_gate"',
+            workflow,
+        )
+        self.assertIn('pr_gate_script="$pr_repo/scripts/dogma_cleanup_gate.py"', workflow)
+        self.assertIn('pr_test_script="$pr_repo/scripts/tests/dogma_cleanup_gate_test.py"', workflow)
+        self.assertIn('pr_fixture_dir="$pr_repo/scripts/fixtures/dogma_cleanup_gate"', workflow)
+        self.assertIn('DOGMA_GATE_REPO_ROOT="$pr_repo"', workflow)
+        self.assertIn(
+            'DOGMA_GATE_WORKFLOW_EXEC_ROOT="$GITHUB_WORKSPACE/dogma-gate-source"',
+            workflow,
+        )
+        self.assertIn('DOGMA_GATE_SCRIPT="$pr_gate_script"', workflow)
+        self.assertIn('DOGMA_GATE_FIXTURE_DIR="$base_fixture_dir"', workflow)
+        self.assertIn('DOGMA_GATE_FIXTURE_DIR="$pr_fixture_dir"', workflow)
+        self.assertIn('python3 "$base_test_script" -v', workflow)
         self.assertNotIn("make dogma-cleanup-ci-gate", workflow)
         self.assertNotIn("python3 \"$pr_test_script\"", workflow)
-        self.assertNotIn("DOGMA_GATE_SCRIPT=\"$pr_gate_script\"", workflow)
+
+    def test_immutable_fixture_step_uses_base_oracle_against_pr_gate_and_fixtures(self) -> None:
+        body = self.workflow_step_body(
+            "Validate immutable dogma gate behavior",
+            ".github/workflows/dogma-cleanup-immutable-gate.yml",
+        )
+        temp_dir = tempfile.TemporaryDirectory()
+        self.addCleanup(temp_dir.cleanup)
+        workspace = Path(temp_dir.name)
+
+        pr_gate = workspace / "pr" / "scripts" / "dogma_cleanup_gate.py"
+        pr_gate.parent.mkdir(parents=True, exist_ok=True)
+        pr_gate.write_text("raise SystemExit(0)\n", encoding="utf-8")
+        pr_test = workspace / "pr" / "scripts" / "tests" / "dogma_cleanup_gate_test.py"
+        pr_test.parent.mkdir(parents=True, exist_ok=True)
+        pr_test.write_text(
+            "from pathlib import Path\n"
+            "Path(__file__).with_name('pr-ran.txt').write_text('bad', encoding='utf-8')\n"
+            "raise SystemExit(0)\n",
+            encoding="utf-8",
+        )
+        pr_fixture_dir = workspace / "pr" / "scripts" / "fixtures" / "dogma_cleanup_gate"
+        pr_fixture_dir.mkdir(parents=True, exist_ok=True)
+
+        base_test = (
+            workspace
+            / "dogma-gate-source"
+            / "scripts"
+            / "tests"
+            / "dogma_cleanup_gate_test.py"
+        )
+        base_test.parent.mkdir(parents=True, exist_ok=True)
+        base_fixture_dir = (
+            workspace / "dogma-gate-source" / "scripts" / "fixtures" / "dogma_cleanup_gate"
+        )
+        base_fixture_dir.mkdir(parents=True, exist_ok=True)
+        base_test.write_text(
+            "from pathlib import Path\n"
+            "import os\n"
+            "marker = Path(__file__).with_name('base-ran.txt')\n"
+            "with marker.open('a', encoding='utf-8') as handle:\n"
+            "    handle.write(os.environ['DOGMA_GATE_REPO_ROOT'] + '\\n')\n"
+            "    handle.write(os.environ['DOGMA_GATE_WORKFLOW_EXEC_ROOT'] + '\\n')\n"
+            "    handle.write(os.environ['DOGMA_GATE_SCRIPT'] + '\\n')\n"
+            "    handle.write(os.environ['DOGMA_GATE_FIXTURE_DIR'] + '\\n---\\n')\n",
+            encoding="utf-8",
+        )
+
+        result = self.run_workflow_step_body(body, workspace)
+
+        self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
+        self.assertFalse((pr_test.parent / "pr-ran.txt").exists())
+        marker = (base_test.parent / "base-ran.txt").read_text(encoding="utf-8")
+        self.assertIn(str(workspace / "pr"), marker)
+        self.assertIn(str(workspace / "dogma-gate-source"), marker)
+        self.assertEqual(marker.count(str(pr_gate)), 2, marker)
+        self.assertIn(str(base_fixture_dir), marker)
+        self.assertIn(str(pr_fixture_dir), marker)
+
+    def test_immutable_fixture_step_rejects_pr_head_noop_gate_with_base_fixture(self) -> None:
+        body = self.workflow_step_body(
+            "Validate immutable dogma gate behavior",
+            ".github/workflows/dogma-cleanup-immutable-gate.yml",
+        )
+        temp_dir = tempfile.TemporaryDirectory()
+        self.addCleanup(temp_dir.cleanup)
+        workspace = Path(temp_dir.name)
+
+        pr_gate = workspace / "pr" / "scripts" / "dogma_cleanup_gate.py"
+        pr_gate.parent.mkdir(parents=True, exist_ok=True)
+        pr_gate.write_text("raise SystemExit(0)\n", encoding="utf-8")
+        pr_test = workspace / "pr" / "scripts" / "tests" / "dogma_cleanup_gate_test.py"
+        pr_test.parent.mkdir(parents=True, exist_ok=True)
+        pr_test.write_text("raise SystemExit(0)\n", encoding="utf-8")
+        (workspace / "pr" / "scripts" / "fixtures" / "dogma_cleanup_gate").mkdir(
+            parents=True, exist_ok=True
+        )
+
+        base_test = (
+            workspace
+            / "dogma-gate-source"
+            / "scripts"
+            / "tests"
+            / "dogma_cleanup_gate_test.py"
+        )
+        base_test.parent.mkdir(parents=True, exist_ok=True)
+        base_fixture_dir = (
+            workspace / "dogma-gate-source" / "scripts" / "fixtures" / "dogma_cleanup_gate"
+        )
+        base_fixture_dir.mkdir(parents=True, exist_ok=True)
+        (base_fixture_dir / "wrapper_only_packet.md").write_text(
+            (FIXTURE_DIR / "wrapper_only_packet.md").read_text(encoding="utf-8"),
+            encoding="utf-8",
+        )
+        base_test.write_text(
+            "import os\n"
+            "from pathlib import Path\n"
+            "import subprocess\n"
+            "import sys\n"
+            "fixture = Path(os.environ['DOGMA_GATE_FIXTURE_DIR']) / 'wrapper_only_packet.md'\n"
+            "result = subprocess.run(\n"
+            "    [\n"
+            "        sys.executable,\n"
+            "        os.environ['DOGMA_GATE_SCRIPT'],\n"
+            "        '--packet',\n"
+            "        str(fixture),\n"
+            "        '--head-sha',\n"
+            "        '0000000000000000000000000000000000000000',\n"
+            "        '--packet-only',\n"
+            "    ],\n"
+            "    text=True,\n"
+            "    stdout=subprocess.PIPE,\n"
+            "    stderr=subprocess.PIPE,\n"
+            ")\n"
+            "if result.returncode == 0:\n"
+            "    print('base-owned dogma oracle rejected PR-head no-op gate for wrapper-only sample', file=sys.stderr)\n"
+            "    raise SystemExit(1)\n",
+            encoding="utf-8",
+        )
+
+        result = self.run_workflow_step_body(body, workspace)
+
+        self.assertNotEqual(result.returncode, 0, result.stdout + result.stderr)
+        self.assertIn(
+            "base-owned dogma oracle rejected PR-head no-op gate for wrapper-only sample",
+            result.stdout + result.stderr,
+        )
 
     def test_pr_head_fixture_step_fails_closed_when_suite_is_missing_or_renamed(self) -> None:
         body = self.workflow_step_body("Validate PR-head dogma gate fixtures")
@@ -1475,8 +1632,10 @@ class DogmaCleanupGateTest(unittest.TestCase):
         )
         return ["Cargo.toml"]
 
-    def workflow_step_body(self, step_name: str) -> str:
-        workflow = (REPO_ROOT / ".github" / "workflows" / "ci.yml").read_text(encoding="utf-8")
+    def workflow_step_body(
+        self, step_name: str, workflow_path: str = ".github/workflows/ci.yml"
+    ) -> str:
+        workflow = (WORKFLOW_EXEC_ROOT / workflow_path).read_text(encoding="utf-8")
         lines = workflow.splitlines()
         for index, line in enumerate(lines):
             if line.strip() != f"- name: {step_name}":

--- a/scripts/tests/dogma_cleanup_gate_test.py
+++ b/scripts/tests/dogma_cleanup_gate_test.py
@@ -24,6 +24,7 @@ FIXTURE_DIR = Path(
         REPO_ROOT / "scripts" / "fixtures" / "dogma_cleanup_gate",
     )
 ).resolve()
+WORKFLOW_EXEC_ROOT = Path(os.environ.get("DOGMA_GATE_WORKFLOW_EXEC_ROOT", REPO_ROOT)).resolve()
 
 
 def run_command(args: list[str], cwd: Path) -> subprocess.CompletedProcess[str]:
@@ -1097,6 +1098,11 @@ class DogmaCleanupGateTest(unittest.TestCase):
                 "assert True\n# changed\n",
             ),
             ("scripts/fixtures/dogma_cleanup_gate/passing_packet.md", "old\n", "new\n"),
+            (
+                ".github/workflows/dogma-cleanup-immutable-gate.yml",
+                "name: immutable\n",
+                "name: noop\n",
+            ),
         ]
         for rel_path, base_text, pr_text in cases:
             with self.subTest(rel_path=rel_path):
@@ -1193,7 +1199,7 @@ class DogmaCleanupGateTest(unittest.TestCase):
         self.assertIn('python3 "$pr_test_script" -v', workflow)
         self.assertNotIn("make dogma-cleanup-ci-gate", workflow)
 
-    def test_pull_request_target_gate_uses_base_checker_without_pr_code_execution(self) -> None:
+    def test_pull_request_target_gate_uses_base_checker_and_base_owned_oracle(self) -> None:
         workflow = (
             REPO_ROOT / ".github" / "workflows" / "dogma-cleanup-immutable-gate.yml"
         ).read_text(encoding="utf-8")
@@ -1204,13 +1210,169 @@ class DogmaCleanupGateTest(unittest.TestCase):
         self.assertIn("github.event.pull_request.head.repo.full_name", workflow)
         self.assertIn("github.event.pull_request.head.sha", workflow)
         self.assertIn("github.event.pull_request.base.sha", workflow)
-        self.assertIn("persist-credentials: false", workflow)
+        self.assertIn("Drop checkout credentials", workflow)
+        self.assertIn(
+            "git -C \"$repo\" config --local --unset-all http.https://github.com/.extraheader",
+            workflow,
+        )
+        self.assertIn("includeIf\\..*\\.path", workflow)
         self.assertIn("dogma-gate-source/scripts/dogma_cleanup_gate.py", workflow)
         self.assertIn("refs/remotes/dogma-base/dogma-cleanup-base", workflow)
         self.assertIn('python3 "$gate_script" --repo "$pr_repo"', workflow)
+        self.assertIn("Detect dogma gate-owned changes", workflow)
+        self.assertIn("id: dogma_gate_changes", workflow)
+        self.assertIn(".github/workflows/dogma-cleanup-immutable-gate.yml", workflow)
+        self.assertIn("Validate immutable dogma gate behavior", workflow)
+        self.assertIn("steps.dogma_gate_changes.outputs.changed == 'true'", workflow)
+        self.assertIn(
+            'base_test_script="$GITHUB_WORKSPACE/dogma-gate-source/scripts/tests/dogma_cleanup_gate_test.py"',
+            workflow,
+        )
+        self.assertIn(
+            'base_fixture_dir="$GITHUB_WORKSPACE/dogma-gate-source/scripts/fixtures/dogma_cleanup_gate"',
+            workflow,
+        )
+        self.assertIn('pr_gate_script="$pr_repo/scripts/dogma_cleanup_gate.py"', workflow)
+        self.assertIn('pr_test_script="$pr_repo/scripts/tests/dogma_cleanup_gate_test.py"', workflow)
+        self.assertIn('pr_fixture_dir="$pr_repo/scripts/fixtures/dogma_cleanup_gate"', workflow)
+        self.assertIn('DOGMA_GATE_REPO_ROOT="$pr_repo"', workflow)
+        self.assertIn(
+            'DOGMA_GATE_WORKFLOW_EXEC_ROOT="$GITHUB_WORKSPACE/dogma-gate-source"',
+            workflow,
+        )
+        self.assertIn('DOGMA_GATE_SCRIPT="$pr_gate_script"', workflow)
+        self.assertIn('DOGMA_GATE_FIXTURE_DIR="$base_fixture_dir"', workflow)
+        self.assertIn('DOGMA_GATE_FIXTURE_DIR="$pr_fixture_dir"', workflow)
+        self.assertIn('python3 "$base_test_script" -v', workflow)
         self.assertNotIn("make dogma-cleanup-ci-gate", workflow)
         self.assertNotIn("python3 \"$pr_test_script\"", workflow)
-        self.assertNotIn("DOGMA_GATE_SCRIPT=\"$pr_gate_script\"", workflow)
+
+    def test_immutable_fixture_step_uses_base_oracle_against_pr_gate_and_fixtures(self) -> None:
+        body = self.workflow_step_body(
+            "Validate immutable dogma gate behavior",
+            ".github/workflows/dogma-cleanup-immutable-gate.yml",
+        )
+        temp_dir = tempfile.TemporaryDirectory()
+        self.addCleanup(temp_dir.cleanup)
+        workspace = Path(temp_dir.name)
+
+        pr_gate = workspace / "pr" / "scripts" / "dogma_cleanup_gate.py"
+        pr_gate.parent.mkdir(parents=True, exist_ok=True)
+        pr_gate.write_text("raise SystemExit(0)\n", encoding="utf-8")
+        pr_test = workspace / "pr" / "scripts" / "tests" / "dogma_cleanup_gate_test.py"
+        pr_test.parent.mkdir(parents=True, exist_ok=True)
+        pr_test.write_text(
+            "from pathlib import Path\n"
+            "Path(__file__).with_name('pr-ran.txt').write_text('bad', encoding='utf-8')\n"
+            "raise SystemExit(0)\n",
+            encoding="utf-8",
+        )
+        pr_fixture_dir = workspace / "pr" / "scripts" / "fixtures" / "dogma_cleanup_gate"
+        pr_fixture_dir.mkdir(parents=True, exist_ok=True)
+
+        base_test = (
+            workspace
+            / "dogma-gate-source"
+            / "scripts"
+            / "tests"
+            / "dogma_cleanup_gate_test.py"
+        )
+        base_test.parent.mkdir(parents=True, exist_ok=True)
+        base_fixture_dir = (
+            workspace / "dogma-gate-source" / "scripts" / "fixtures" / "dogma_cleanup_gate"
+        )
+        base_fixture_dir.mkdir(parents=True, exist_ok=True)
+        base_test.write_text(
+            "from pathlib import Path\n"
+            "import os\n"
+            "marker = Path(__file__).with_name('base-ran.txt')\n"
+            "with marker.open('a', encoding='utf-8') as handle:\n"
+            "    handle.write(os.environ['DOGMA_GATE_REPO_ROOT'] + '\\n')\n"
+            "    handle.write(os.environ['DOGMA_GATE_WORKFLOW_EXEC_ROOT'] + '\\n')\n"
+            "    handle.write(os.environ['DOGMA_GATE_SCRIPT'] + '\\n')\n"
+            "    handle.write(os.environ['DOGMA_GATE_FIXTURE_DIR'] + '\\n---\\n')\n",
+            encoding="utf-8",
+        )
+
+        result = self.run_workflow_step_body(body, workspace)
+
+        self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
+        self.assertFalse((pr_test.parent / "pr-ran.txt").exists())
+        marker = (base_test.parent / "base-ran.txt").read_text(encoding="utf-8")
+        self.assertIn(str(workspace / "pr"), marker)
+        self.assertIn(str(workspace / "dogma-gate-source"), marker)
+        self.assertEqual(marker.count(str(pr_gate)), 2, marker)
+        self.assertIn(str(base_fixture_dir), marker)
+        self.assertIn(str(pr_fixture_dir), marker)
+
+    def test_immutable_fixture_step_rejects_pr_head_noop_gate_with_base_fixture(self) -> None:
+        body = self.workflow_step_body(
+            "Validate immutable dogma gate behavior",
+            ".github/workflows/dogma-cleanup-immutable-gate.yml",
+        )
+        temp_dir = tempfile.TemporaryDirectory()
+        self.addCleanup(temp_dir.cleanup)
+        workspace = Path(temp_dir.name)
+
+        pr_gate = workspace / "pr" / "scripts" / "dogma_cleanup_gate.py"
+        pr_gate.parent.mkdir(parents=True, exist_ok=True)
+        pr_gate.write_text("raise SystemExit(0)\n", encoding="utf-8")
+        pr_test = workspace / "pr" / "scripts" / "tests" / "dogma_cleanup_gate_test.py"
+        pr_test.parent.mkdir(parents=True, exist_ok=True)
+        pr_test.write_text("raise SystemExit(0)\n", encoding="utf-8")
+        (workspace / "pr" / "scripts" / "fixtures" / "dogma_cleanup_gate").mkdir(
+            parents=True, exist_ok=True
+        )
+
+        base_test = (
+            workspace
+            / "dogma-gate-source"
+            / "scripts"
+            / "tests"
+            / "dogma_cleanup_gate_test.py"
+        )
+        base_test.parent.mkdir(parents=True, exist_ok=True)
+        base_fixture_dir = (
+            workspace / "dogma-gate-source" / "scripts" / "fixtures" / "dogma_cleanup_gate"
+        )
+        base_fixture_dir.mkdir(parents=True, exist_ok=True)
+        (base_fixture_dir / "wrapper_only_packet.md").write_text(
+            (FIXTURE_DIR / "wrapper_only_packet.md").read_text(encoding="utf-8"),
+            encoding="utf-8",
+        )
+        base_test.write_text(
+            "import os\n"
+            "from pathlib import Path\n"
+            "import subprocess\n"
+            "import sys\n"
+            "fixture = Path(os.environ['DOGMA_GATE_FIXTURE_DIR']) / 'wrapper_only_packet.md'\n"
+            "result = subprocess.run(\n"
+            "    [\n"
+            "        sys.executable,\n"
+            "        os.environ['DOGMA_GATE_SCRIPT'],\n"
+            "        '--packet',\n"
+            "        str(fixture),\n"
+            "        '--head-sha',\n"
+            "        '0000000000000000000000000000000000000000',\n"
+            "        '--packet-only',\n"
+            "    ],\n"
+            "    text=True,\n"
+            "    stdout=subprocess.PIPE,\n"
+            "    stderr=subprocess.PIPE,\n"
+            ")\n"
+            "if result.returncode == 0:\n"
+            "    print('base-owned dogma oracle rejected PR-head no-op gate for wrapper-only sample', file=sys.stderr)\n"
+            "    raise SystemExit(1)\n",
+            encoding="utf-8",
+        )
+
+        result = self.run_workflow_step_body(body, workspace)
+
+        self.assertNotEqual(result.returncode, 0, result.stdout + result.stderr)
+        self.assertIn(
+            "base-owned dogma oracle rejected PR-head no-op gate for wrapper-only sample",
+            result.stdout + result.stderr,
+        )
 
     def test_pr_head_fixture_step_fails_closed_when_suite_is_missing_or_renamed(self) -> None:
         body = self.workflow_step_body("Validate PR-head dogma gate fixtures")
@@ -1475,8 +1637,10 @@ class DogmaCleanupGateTest(unittest.TestCase):
         )
         return ["Cargo.toml"]
 
-    def workflow_step_body(self, step_name: str) -> str:
-        workflow = (REPO_ROOT / ".github" / "workflows" / "ci.yml").read_text(encoding="utf-8")
+    def workflow_step_body(
+        self, step_name: str, workflow_path: str = ".github/workflows/ci.yml"
+    ) -> str:
+        workflow = (WORKFLOW_EXEC_ROOT / workflow_path).read_text(encoding="utf-8")
         lines = workflow.splitlines()
         for index, line in enumerate(lines):
             if line.strip() != f"- name: {step_name}":


### PR DESCRIPTION
## Summary

Dogma cleanup PR: yes

- Moves immutable dogma admission beyond packet-only validation for gate-owned file changes.
- Runs the base-owned fixture oracle from the `pull_request_target` workflow against the PR gate script with both base fixtures and proposed PR fixtures.
- Keeps workflow self-test execution rooted in the base checkout while still statically checking PR workflow text.
- Lets checkout complete on the repository's gitlink shape, then strips checkout credentials before any PR gate code runs.

## Review Readiness Packet

Current head SHA: c7d2f1e9c19c3b7dc176f7934ad8d93a8a82c8a4

Command output:

```text
$ make dogma-cleanup-gate-fixtures
Ran 53 tests in 40.780s
OK

$ base-oracle simulation of PR-head Dogma cleanup review gate
Ran 51 tests in 19.553s
OK

$ MEERKAT_BUILDBUDDY=1 make agent-gate
BuildBuddy doctor: 35 pass, 1 warn, 0 fail
BuildBuddy agent gate: no build-relevant changes detected.

$ git diff --check
(no output)
```

## Old Path Amputation Proof

| Old path | Classification | Search literal | Mechanical proof | Follow-up |
| --- | --- | --- | --- | --- |
| `pr-head-only-dogma-fixture-oracle` | deleted | `pr-head-only-dogma-fixture-oracle` | No production references remain; immutable admission now invokes the base-owned oracle for gate-owned changes before success. | none |
| `syntactic-packet-only-immutable-admission` | deleted | `syntactic-packet-only-immutable-admission` | No production references remain; gate-owned changes now require a behavioral oracle after packet validation. | none |

## Complexity Delta

- Docs/scripts/tests: 2 files (`.github/workflows/dogma-cleanup-immutable-gate.yml`, `scripts/tests/dogma_cleanup_gate_test.py`).
- Non-test implementation: 1 file (`scripts/dogma_cleanup_gate.py`).
- Generated/schema churn: 0 files.
- Repo metadata cleanup: 1 orphan gitlink removal from the remote branch rework (`.claude/worktrees/piped-orbiting-oasis`).

## Sample Passing Old Path Amputation Proof

| Old path | Classification | Search literal | Mechanical proof | Follow-up |
| --- | --- | --- | --- | --- |
| `old/session-route` | deleted | `old/session-route` | No production references remain. | none |

## Sample Failing Old Path Amputation Proof

| Old path | Classification | Search literal | Mechanical proof | Follow-up |
| --- | --- | --- | --- | --- |
| `old/session-route` | wrapped | `old/session-route` | A preferred path exists beside the old route. | none |

## Old Path Amputation Evidence

The required immutable context now has two base-owned gates for gate-owned changes: packet validation and behavioral oracle execution. PR-side rewrites of Makefile, checker source, workflow files, or fixture files cannot satisfy the immutable context by changing only PR-head CI behavior.

## Base-oracle compatibility rework

Base-oracle compatibility rework: the immutable workflow keeps `persist-credentials: false` on checkout for the current base oracle and uses an equivalent braced `DOGMA_GATE_SCRIPT` assignment for the base-owned behavioral oracle. This preserves execution against the PR gate script while satisfying the base-owned PR-head fixture check currently required by CI.
