### PR TITLE
LUC-369: Enforce typed skills resolved SDK events

### DIFF
--- a/docs/sdks/typescript/reference.mdx
+++ b/docs/sdks/typescript/reference.mdx
@@ -443,7 +443,7 @@ interface HookPatchPublishedEvent { type: "hook_patch_published";  hookId: strin
 ### Skill events
 
 ```typescript
-interface SkillsResolvedEvent       { type: "skills_resolved";         skills: readonly string[]; injectionBytes: number }
+interface SkillsResolvedEvent       { type: "skills_resolved";         skills: readonly SkillKey[]; injectionBytes: number }
 interface SkillResolutionFailedEvent { type: "skill_resolution_failed"; skillKey?: SkillKey; reason: SkillResolutionFailureReason; reference: string; error: string }
 ```
 

--- a/sdks/python/meerkat/events.py
+++ b/sdks/python/meerkat/events.py
@@ -307,7 +307,7 @@ class HookPatchPublished(Event):
 class SkillsResolved(Event):
     """Skills were resolved for this turn."""
 
-    skills: list[str] = field(default_factory=list)
+    skills: list[SkillKey] = field(default_factory=list)
     injection_bytes: int = 0
 
 
@@ -671,10 +671,29 @@ def _parse_skill_key(raw: Any) -> SkillKey | None:
 
     from .types import SkillKey
 
+    source_uuid = raw.get("source_uuid", raw.get("sourceUuid"))
+    skill_name = raw.get("skill_name", raw.get("skillName"))
+    if not isinstance(source_uuid, str) or source_uuid == "":
+        return None
+    if not isinstance(skill_name, str) or skill_name == "":
+        return None
+
     return SkillKey(
-        source_uuid=str(raw.get("source_uuid", raw.get("sourceUuid", ""))),
-        skill_name=str(raw.get("skill_name", raw.get("skillName", ""))),
+        source_uuid=source_uuid,
+        skill_name=skill_name,
     )
+
+
+def _parse_skill_key_list(raw: Any) -> list[SkillKey]:
+    if not isinstance(raw, list):
+        raise ValueError("skills must be SkillKey list")
+    skills: list[SkillKey] = []
+    for index, item in enumerate(raw):
+        skill_key = _parse_skill_key(item)
+        if skill_key is None:
+            raise ValueError(f"skills[{index}] must be SkillKey")
+        skills.append(skill_key)
+    return skills
 
 
 def _parse_optional_str(raw: Any) -> str | None:
@@ -721,11 +740,20 @@ def _parse_skill_resolution_failure_reason(
         "unknown",
     }
     normalized_reason_type = reason_type if reason_type in known_reason_types else "unknown"
+    key = _parse_skill_key(raw.get("key"))
+    if reason_type == "not_found" and key is None:
+        return None
+    if reason_type == "capability_unavailable":
+        capability = raw.get("capability")
+        if key is None or not isinstance(capability, str) or capability == "":
+            return None
+    else:
+        capability = raw.get("capability", "")
 
     return SkillResolutionFailureReason(
         reason_type=normalized_reason_type,
-        key=_parse_skill_key(raw.get("key")),
-        capability=str(raw.get("capability", "")),
+        key=key,
+        capability=capability if isinstance(capability, str) else "",
         message=str(raw.get("message", fallback_message)),
         source_uuid=str(raw.get("source_uuid", raw.get("sourceUuid", ""))),
         skill_name=str(raw.get("skill_name", raw.get("skillName", ""))),
@@ -893,9 +921,7 @@ def _validate_known_event(event_type: str, raw: dict[str, Any]) -> None:
             if "prompt" not in raw:
                 raise ValueError("prompt is required")
         elif field_name == "skills":
-            skills = raw.get("skills")
-            if not isinstance(skills, list) or not all(isinstance(skill, str) for skill in skills):
-                raise ValueError("skills must be string list")
+            _parse_skill_key_list(raw.get("skills"))
         elif field_name in {"patch", "envelope"}:
             if not isinstance(raw.get(field_name), dict):
                 raise ValueError(f"{field_name} must be object")
@@ -955,6 +981,8 @@ def parse_event(raw: dict[str, Any]) -> Event:
                 kwargs["is_error"] = _parse_optional_bool(raw.get("is_error"))
             elif f == "duration_ms" and cls is ToolExecutionCompleted:
                 kwargs["duration_ms"] = _parse_optional_int(raw.get("duration_ms"))
+            elif f == "skills" and cls is SkillsResolved:
+                kwargs["skills"] = _parse_skill_key_list(raw.get("skills"))
             elif f == "skill_key" and cls is SkillResolutionFailed:
                 kwargs["skill_key"] = _parse_skill_key(raw.get("skill_key"))
             elif f == "reason" and cls is SkillResolutionFailed:

--- a/sdks/python/tests/test_types.py
+++ b/sdks/python/tests/test_types.py
@@ -68,6 +68,7 @@ from meerkat.events import (
     RunCompleted,
     RunFailed,
     RunStarted,
+    SkillsResolved,
     SkillResolutionFailed,
     SkillResolutionFailureReason,
     ToolConfigChanged,
@@ -1424,6 +1425,43 @@ def test_parse_retrying():
     assert event.delay_ms == 2000
 
 
+def test_parse_skills_resolved_with_typed_skill_identities():
+    source_uuid = "00000000-0000-4b11-8111-000000000001"
+    raw = {
+        "type": "skills_resolved",
+        "skills": [{"source_uuid": source_uuid, "skill_name": "email-extractor"}],
+        "injection_bytes": 128,
+    }
+    event = parse_event(raw)
+    assert isinstance(event, SkillsResolved)
+    assert event.skills == [
+        SkillKey(source_uuid=source_uuid, skill_name="email-extractor"),
+    ]
+    assert event.injection_bytes == 128
+
+
+def test_parse_skills_resolved_rejects_legacy_string_only_payload():
+    raw = {
+        "type": "skills_resolved",
+        "skills": ["legacy/ref"],
+        "injection_bytes": 128,
+    }
+    event = parse_event(raw)
+    assert isinstance(event, UnknownEvent)
+    assert event.type == "malformed_event"
+
+
+def test_parse_skills_resolved_rejects_missing_typed_identity_fields():
+    raw = {
+        "type": "skills_resolved",
+        "skills": [{"source_uuid": "00000000-0000-4b11-8111-000000000001"}],
+        "injection_bytes": 128,
+    }
+    event = parse_event(raw)
+    assert isinstance(event, UnknownEvent)
+    assert event.type == "malformed_event"
+
+
 def test_parse_skill_resolution_failed_with_typed_reason():
     source_uuid = "00000000-0000-4b11-8111-000000000001"
     raw = {
@@ -1475,6 +1513,35 @@ def test_parse_skill_resolution_failed_does_not_fabricate_malformed_reason():
     }
     event = parse_event(raw)
     assert isinstance(event, SkillResolutionFailed)
+    assert event.reason is None
+
+
+def test_parse_skill_resolution_failed_preserves_unknown_status_as_typed_unknown():
+    raw = {
+        "type": "skill_resolution_failed",
+        "reason": {"reason_type": "future_status", "message": "future details"},
+        "reference": "legacy/ref",
+        "error": "missing",
+    }
+    event = parse_event(raw)
+    assert isinstance(event, SkillResolutionFailed)
+    assert event.skill_key is None
+    assert isinstance(event.reason, SkillResolutionFailureReason)
+    assert event.reason.reason_type == "unknown"
+    assert event.reason.message == "future details"
+    assert event.reason.raw_reason_type == "future_status"
+
+
+def test_parse_skill_resolution_failed_does_not_fabricate_empty_keyed_reason():
+    raw = {
+        "type": "skill_resolution_failed",
+        "reason": {"reason_type": "not_found"},
+        "reference": "legacy/ref",
+        "error": "missing",
+    }
+    event = parse_event(raw)
+    assert isinstance(event, SkillResolutionFailed)
+    assert event.skill_key is None
     assert event.reason is None
 
 

--- a/sdks/typescript/src/events.ts
+++ b/sdks/typescript/src/events.ts
@@ -296,7 +296,7 @@ export interface HookPatchPublishedEvent {
 
 export interface SkillsResolvedEvent {
   readonly type: "skills_resolved";
-  readonly skills: readonly string[];
+  readonly skills: readonly SkillKey[];
   readonly injectionBytes: number;
 }
 
@@ -688,18 +688,37 @@ function parseToolConfigChangeStatus(raw: unknown): ToolConfigChangeStatus | und
 }
 
 function parseSkillKey(raw: unknown): SkillKey | undefined {
-  if (raw == null || typeof raw !== "object") {
+  if (!isPlainRecord(raw)) {
     return undefined;
   }
-  const value = raw as Record<string, unknown>;
+  const value = raw;
+  const sourceUuid = value.source_uuid ?? value.sourceUuid;
+  const skillName = value.skill_name ?? value.skillName;
+  if (typeof sourceUuid !== "string" || sourceUuid.length === 0) {
+    return undefined;
+  }
+  if (typeof skillName !== "string" || skillName.length === 0) {
+    return undefined;
+  }
   return {
-    sourceUuid: String(value.source_uuid ?? value.sourceUuid ?? ""),
-    skillName: String(value.skill_name ?? value.skillName ?? ""),
+    sourceUuid,
+    skillName,
   };
 }
 
-function emptySkillKey(): SkillKey {
-  return { sourceUuid: "", skillName: "" };
+function requireSkillKey(raw: unknown, field: string): SkillKey {
+  const skillKey = parseSkillKey(raw);
+  if (!skillKey) {
+    throw new Error(`${field} must be SkillKey`);
+  }
+  return skillKey;
+}
+
+function requireSkillKeyArray(raw: unknown): readonly SkillKey[] {
+  if (!Array.isArray(raw)) {
+    throw new Error("skills must be SkillKey array");
+  }
+  return raw.map((skill, index) => requireSkillKey(skill, `skills[${index}]`));
 }
 
 const STOP_REASONS = new Set<StopReason>([
@@ -752,14 +771,21 @@ function parseSkillResolutionFailureReason(
   }
   const reasonType = reasonTypeRaw;
   switch (reasonType) {
-    case "not_found":
-      return { reasonType, key: parseSkillKey(value.key) ?? emptySkillKey() };
-    case "capability_unavailable":
+    case "not_found": {
+      const key = parseSkillKey(value.key);
+      return key ? { reasonType, key } : undefined;
+    }
+    case "capability_unavailable": {
+      const key = parseSkillKey(value.key);
+      if (!key || typeof value.capability !== "string" || value.capability.length === 0) {
+        return undefined;
+      }
       return {
         reasonType,
-        key: parseSkillKey(value.key) ?? emptySkillKey(),
-        capability: String(value.capability ?? ""),
+        key,
+        capability: value.capability,
       };
+    }
     case "load":
     case "parse":
       return { reasonType, message: String(value.message ?? "") };
@@ -958,10 +984,11 @@ export function parseCoreEvent(raw: Record<string, unknown>): AgentEvent {
 
     // Skills
     case "skills_resolved":
-      if (!Array.isArray(raw.skills) || !raw.skills.every((skill) => typeof skill === "string")) {
-        throw new Error("skills must be string array");
-      }
-      return { type, skills: raw.skills, injectionBytes: requireNumberField(raw, "injection_bytes") };
+      return {
+        type,
+        skills: requireSkillKeyArray(raw.skills),
+        injectionBytes: requireNumberField(raw, "injection_bytes"),
+      };
     case "skill_resolution_failed": {
       const reference = requireStringField(raw, "reference");
       const error = requireStringField(raw, "error");

--- a/sdks/typescript/tests/types.test.js
+++ b/sdks/typescript/tests/types.test.js
@@ -452,6 +452,51 @@ describe("Typed Events", () => {
     }
   });
 
+  it("should parse skills_resolved with typed skill identities", () => {
+    const sourceUuid = "00000000-0000-4b11-8111-000000000001";
+    const event = parseEvent({
+      type: "skills_resolved",
+      skills: [{ source_uuid: sourceUuid, skill_name: "email-extractor" }],
+      injection_bytes: 128,
+    });
+
+    assert.equal(event.type, "skills_resolved");
+    if (event.type === "skills_resolved") {
+      assert.deepEqual(event.skills, [
+        { sourceUuid, skillName: "email-extractor" },
+      ]);
+      assert.equal(event.injectionBytes, 128);
+    }
+  });
+
+  it("should reject legacy string-only skills_resolved payloads", () => {
+    const event = parseEvent({
+      type: "skills_resolved",
+      skills: ["legacy/ref"],
+      injection_bytes: 128,
+    });
+
+    assert.equal(event.type, "malformed_event");
+    if (event.type === "malformed_event") {
+      assert.equal(event.rawType, "skills_resolved");
+      assert.match(event.error, /SkillKey/);
+    }
+  });
+
+  it("should reject skills_resolved missing typed skill identity fields", () => {
+    const event = parseEvent({
+      type: "skills_resolved",
+      skills: [{ source_uuid: "00000000-0000-4b11-8111-000000000001" }],
+      injection_bytes: 128,
+    });
+
+    assert.equal(event.type, "malformed_event");
+    if (event.type === "malformed_event") {
+      assert.equal(event.rawType, "skills_resolved");
+      assert.match(event.error, /SkillKey/);
+    }
+  });
+
   it("should parse skill_resolution_failed with typed key and reason", () => {
     const sourceUuid = "00000000-0000-4b11-8111-000000000001";
     const event = parseEvent({
@@ -509,6 +554,40 @@ describe("Typed Events", () => {
 
     assert.equal(event.type, "skill_resolution_failed");
     if (event.type === "skill_resolution_failed") {
+      assert.equal(event.reason, undefined);
+    }
+  });
+
+  it("should preserve unknown skill resolution reason types as typed unknown", () => {
+    const event = parseEvent({
+      type: "skill_resolution_failed",
+      reason: { reason_type: "future_status", message: "future details" },
+      reference: "legacy/ref",
+      error: "missing",
+    });
+
+    assert.equal(event.type, "skill_resolution_failed");
+    if (event.type === "skill_resolution_failed") {
+      assert.equal(event.skillKey, undefined);
+      assert.deepEqual(event.reason, {
+        reasonType: "unknown",
+        message: "future details",
+        rawReasonType: "future_status",
+      });
+    }
+  });
+
+  it("should not fabricate empty skill keys for keyed failure reasons", () => {
+    const event = parseEvent({
+      type: "skill_resolution_failed",
+      reason: { reason_type: "not_found" },
+      reference: "legacy/ref",
+      error: "missing",
+    });
+
+    assert.equal(event.type, "skill_resolution_failed");
+    if (event.type === "skill_resolution_failed") {
+      assert.equal(event.skillKey, undefined);
       assert.equal(event.reason, undefined);
     }
   });

--- a/sdks/web/src/types.ts
+++ b/sdks/web/src/types.ts
@@ -473,9 +473,92 @@ export interface MobEvent {
 
 export { KNOWN_AGENT_EVENT_TYPES };
 
+function isNonEmptyString(value: unknown): value is string {
+  return typeof value === 'string' && value.length > 0;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function isWireSkillKey(value: unknown): value is SkillKey {
+  return (
+    isRecord(value) &&
+    isNonEmptyString(value.source_uuid) &&
+    isNonEmptyString(value.skill_name)
+  );
+}
+
+function hasStringFields(value: Record<string, unknown>, fields: readonly string[]): boolean {
+  return fields.every((field) => typeof value[field] === 'string');
+}
+
+function isSkillResolutionFailureReason(value: unknown): boolean {
+  if (!isRecord(value) || typeof value.reason_type !== 'string') {
+    return false;
+  }
+  switch (value.reason_type) {
+    case 'not_found':
+      return isWireSkillKey(value.key);
+    case 'capability_unavailable':
+      return isWireSkillKey(value.key) && isNonEmptyString(value.capability);
+    case 'load':
+    case 'parse':
+    case 'unknown':
+      return typeof value.message === 'string';
+    case 'source_uuid_collision':
+      return hasStringFields(value, ['source_uuid', 'existing_fingerprint', 'new_fingerprint']);
+    case 'source_uuid_mutation_without_lineage':
+      return hasStringFields(value, ['fingerprint', 'existing_source_uuid', 'mutated_source_uuid']);
+    case 'missing_skill_remaps':
+      return hasStringFields(value, ['event_id', 'event_kind']);
+    case 'remap_without_lineage':
+      return hasStringFields(value, [
+        'from_source_uuid',
+        'from_skill_name',
+        'to_source_uuid',
+        'to_skill_name',
+      ]);
+    case 'unknown_skill_alias':
+      return typeof value.alias === 'string';
+    case 'remap_cycle':
+      return hasStringFields(value, ['source_uuid', 'skill_name']);
+    default:
+      return false;
+  }
+}
+
+function isKnownSkillResolutionEvent(event: { type: string }): boolean {
+  const value = event as Record<string, unknown>;
+
+  if (event.type === 'skills_resolved') {
+    return (
+      Array.isArray(value.skills) &&
+      value.skills.every(isWireSkillKey) &&
+      typeof value.injection_bytes === 'number' &&
+      Number.isFinite(value.injection_bytes) &&
+      value.injection_bytes >= 0
+    );
+  }
+
+  if (event.type === 'skill_resolution_failed') {
+    return (
+      (value.skill_key == null || isWireSkillKey(value.skill_key)) &&
+      (value.reason == null || isSkillResolutionFailureReason(value.reason)) &&
+      (value.reference == null || typeof value.reference === 'string') &&
+      (value.error == null || typeof value.error === 'string')
+    );
+  }
+
+  return true;
+}
+
 /** Type guard for known event types. */
 export function isKnownEvent(event: { type: string }): event is AgentEvent {
-  return (KNOWN_AGENT_EVENT_TYPES as readonly string[]).includes(event.type);
+  return (
+    (KNOWN_AGENT_EVENT_TYPES as readonly string[]).includes(event.type) &&
+    isKnownSkillResolutionEvent(event)
+  );
 }
 
 // ─── Tool callback types ────────────────────────────────────────

--- a/sdks/web/tests/mob_payload.unit.mjs
+++ b/sdks/web/tests/mob_payload.unit.mjs
@@ -4,6 +4,7 @@ import test from 'node:test';
 import { Mob } from '../dist/mob.js';
 import { MeerkatRuntime } from '../dist/runtime.js';
 import { Session } from '../dist/session.js';
+import { isKnownEvent } from '../dist/types.js';
 
 function makeSubscriptionRuntime(overrides = {}) {
   return {
@@ -96,6 +97,59 @@ async function runtimeWithMobList(payload) {
     {},
   );
 }
+
+test('isKnownEvent requires typed skills_resolved identities', () => {
+  assert.equal(
+    isKnownEvent({
+      type: 'skills_resolved',
+      skills: [
+        {
+          source_uuid: '00000000-0000-4b11-8111-000000000001',
+          skill_name: 'email-extractor',
+        },
+      ],
+      injection_bytes: 128,
+    }),
+    true,
+  );
+  assert.equal(
+    isKnownEvent({
+      type: 'skills_resolved',
+      skills: ['legacy/ref'],
+      injection_bytes: 128,
+    }),
+    false,
+  );
+  assert.equal(
+    isKnownEvent({
+      type: 'skills_resolved',
+      skills: [{ source_uuid: '00000000-0000-4b11-8111-000000000001' }],
+      injection_bytes: 128,
+    }),
+    false,
+  );
+});
+
+test('isKnownEvent fails closed for unknown skill resolution statuses', () => {
+  assert.equal(
+    isKnownEvent({
+      type: 'skill_resolution_failed',
+      reason: { reason_type: 'future_status', message: 'future details' },
+      reference: 'legacy/ref',
+      error: 'missing',
+    }),
+    false,
+  );
+  assert.equal(
+    isKnownEvent({
+      type: 'skill_resolution_failed',
+      reason: { reason_type: 'unknown', message: 'future details' },
+      reference: 'legacy/ref',
+      error: 'missing',
+    }),
+    true,
+  );
+});
 
 test('Mob.spawn strips legacy generation and projects typed wasm spawn rows', async () => {
   let captured;

--- a/sdks/web/tests/types.test.ts
+++ b/sdks/web/tests/types.test.ts
@@ -296,6 +296,21 @@ function handleEvent(event: AgentEvent): string {
   }
 }
 
+const typedSkillsResolved: AgentEvent = {
+  type: 'skills_resolved',
+  skills: [
+    {
+      source_uuid: '00000000-0000-4b11-8111-000000000001',
+      skill_name: 'email-extractor',
+    },
+  ],
+  injection_bytes: 128,
+};
+handleEvent(typedSkillsResolved);
+
+// @ts-expect-error Legacy string-only skills_resolved payloads are not semantic AgentEvent data.
+const legacyStringSkillsResolved: AgentEvent = { type: 'skills_resolved', skills: ['legacy/ref'], injection_bytes: 128 };
+
 // ─── ToolCallback ───────────────────────────────────────────────
 
 const myTool: ToolCallback = async (args: string) => {
@@ -352,6 +367,8 @@ void mobAppendSystemContextResult;
 void mobDef;
 void spawnSpec;
 void handleEvent;
+void typedSkillsResolved;
+void legacyStringSkillsResolved;
 void myTool;
 void actions;
 void memberSendResult;


### PR DESCRIPTION
## Summary
- Align TypeScript/Python SDK skills_resolved decoders with the generated contract by decoding skills as structured SkillKey[] instead of strings.
- Tighten skill resolution failure parsing so keyed reasons no longer synthesize empty/default SkillKey identities, while unknown reason types become typed unknown in TS/Python.
- Add Web SDK isKnownEvent structural checks for skills resolution events so string-only success payloads and unknown statuses fail closed.
- Update the TypeScript SDK reference event shape from readonly string[] to readonly SkillKey[].

## Review Readiness Packet
Current head SHA: 0bbdaeee2a57d20f59958abe8554ffb86c945109

Command output recorded for this branch:

    $ python3 -m pytest sdks/python/tests/test_types.py -q
    89 passed

    $ cd sdks/typescript && npm run build && node --test tests/types.test.js
    # tests 80
    # pass 80
    # fail 0

    $ cd sdks/web && npm test
    # tests 24
    # pass 24
    # fail 0

    $ git diff --check origin/main..HEAD
    passed

    $ MEERKAT_BUILDBUDDY=1 make check
    Build completed successfully; BuildBuddy invocation ec16fec4-329c-40ae-8fb6-af7700d5eade

## Old Path Amputation Proof
| Old path | Classification | Search literal | Mechanical proof | Follow-up |
| --- | --- | --- | --- | --- |
| skills_resolved.skills: string[] | made uncallable at boundary | skills_resolved.skills: string[] | Production SDK parser boundary is boundary-uncallable for this string-array success carrier; TypeScript, Python, and Web decoders return malformed/fail-closed before exposing SkillsResolved. | None |
| skill_resolution_failed.reference SkillKey synthesis | made uncallable at boundary | skill_resolution_failed.reference SkillKey synthesis | Production SDK parser boundary rejects access to identity synthesis from display projection fields; keyed failures decode only from typed reason objects. | None |

## Complexity Delta
- Docs/scripts/tests: 5 files: one TypeScript SDK reference line plus Python/TypeScript/Web negative fixtures.
- Non-test implementation: 3 files: Python SDK event decoder, TypeScript SDK event decoder, and Web SDK event narrowing.
- Generated/schema churn: 0 changed files; generated contract artifacts already type skills_resolved.skills as SkillKey[].

## Generated vs SDK Churn
- Generated contract artifacts already model skills_resolved.skills as SkillKey[]; this PR does not regenerate schemas.
- Implementation churn is limited to handwritten TypeScript/Python SDK decoders, Web event narrowing, negative fixtures, and one SDK reference doc line.

## Old Carrier Made Impossible
- The previous semantic carrier was skills_resolved.skills: string[] in the handwritten SDK event decoders and Web event narrowing. It is now rejected as malformed/fail-closed instead of being accepted as successful skill resolution.
- skill_resolution_failed.reference and error remain display projections only; parsers do not use them to synthesize skill identity.

## Sample Passing Old Path Amputation Proof
A passing proof names the removed or boundary-uncallable carrier, gives a search literal that overlaps the carrier name, and cites production-boundary evidence such as parser rejection or unavailable typed access.

## Sample Failing Old Path Amputation Proof
A failing proof claims only that a preferred path exists, cites only fixtures, or says callers can still use the prior semantic carrier.

## Validation
- python3 -m pytest sdks/python/tests/test_types.py -q (89 passed)
- cd sdks/typescript && npm run build && node --test tests/types.test.js (80 passed)
- cd sdks/web && npm test (24 passed)
- git diff --check origin/main..HEAD (passed)
- MEERKAT_BUILDBUDDY=1 make check (passed; BuildBuddy invocation ec16fec4-329c-40ae-8fb6-af7700d5eade)

Linear: LUC-369