### PR TITLE
LUC-371 typed machine drift schema check

### DIFF
--- a/docs/architecture/catalog-authoritative-machine-generation-rct.md
+++ b/docs/architecture/catalog-authoritative-machine-generation-rct.md
@@ -104,7 +104,7 @@ forward and must not mark `REQ-101` complete.
 | Task | Owner | Requirement | Done When |
 | --- | --- | --- | --- |
 | P1-T1 | impl | CONTRACT-001, INV-002 | A schema parity gate compares catalog and production schema shape for every Phase 0 production body; the full-convergence assertion is unignored and the inventory test pins zero drift. |
-| P1-T2 | impl | INV-001, REQ-101 | A production-body audit rejects new handwritten canonical `machine!` bodies outside the catalog unless the file is generated kernel output or explicitly listed as a Phase 1 carry-forward production body; fixtures cover bare, spaced, and qualified macro paths. |
+| P1-T2 | impl | INV-001, REQ-101 | A production-owner schema relation audit proves every canonical generated kernel has typed production owner metadata; source-only `machine!` token matches do not certify ownership. |
 | P1-T3 | impl | REQ-102 | Generated kernel output drift is checked through existing `machine-check-drift` / generated-header mechanisms, preferably via BuildBuddy-backed lanes where available. |
 | P1-T4 | orchestrator | INV-001, INV-002 | A negative control proves the schema parity gate fails when a production-only state/effect/transition shape change is introduced in the test fixture. |
 | P1-T5 | orchestrator | INV-001 | The trace names zero carry-forward handwritten production bodies; any future body drift must be rejected or newly classified before landing. |
@@ -112,12 +112,13 @@ forward and must not mark `REQ-101` complete.
 
 ### Phase 1 Carry-Forward Dogma Debt
 
-There is no Phase 1 carry-forward dogma debt. `PHASE1_CARRY_FORWARD_PRODUCTION_BODIES`
-is empty, and the schema drift inventory expects no MeerkatMachine,
-MobMachine, AuthMachine, ScheduleLifecycleMachine, or OccurrenceLifecycleMachine
-rows. Reopening any production-only body drift requires a parity-ledger row,
-typed transition rule, invariant review, and TLC/runtime evidence before the
-schema parity gate may be updated.
+There is no Phase 1 carry-forward dogma debt. The old
+`collect_phase1_production_body_mismatches` source-string scanner has been
+removed from the authoritative drift gate; production ownership is now certified
+by `canonical_machine_production_owner_relations` and generated-kernel drift.
+Reopening any production-only body drift requires a parity-ledger row, typed
+transition rule, invariant review, and TLC/runtime evidence before the schema
+parity gate may be updated.
 
 Closed Phase 1 batches:
 

--- a/meerkat-machine-schema/src/catalog/dsl/mod.rs
+++ b/meerkat-machine-schema/src/catalog/dsl/mod.rs
@@ -70,6 +70,10 @@ pub const MEERKAT_MACHINE_PRODUCTION_RUST_CRATE: &str = "meerkat-runtime";
 pub const MEERKAT_MACHINE_PRODUCTION_RUST_MODULE: &str = "meerkat_machine::dsl";
 pub const MOB_MACHINE_PRODUCTION_RUST_CRATE: &str = "meerkat-mob";
 pub const MOB_MACHINE_PRODUCTION_RUST_MODULE: &str = "machines::mob_machine";
+pub const SCHEDULE_LIFECYCLE_PRODUCTION_RUST_CRATE: &str = "meerkat-schedule";
+pub const SCHEDULE_LIFECYCLE_PRODUCTION_RUST_MODULE: &str = "machines::schedule_lifecycle";
+pub const OCCURRENCE_LIFECYCLE_PRODUCTION_RUST_CRATE: &str = "meerkat-schedule";
+pub const OCCURRENCE_LIFECYCLE_PRODUCTION_RUST_MODULE: &str = "machines::occurrence_lifecycle";
 
 fn with_production_rust_binding(
     mut schema: MachineSchema,

--- a/meerkat-machine-schema/src/catalog/mod.rs
+++ b/meerkat-machine-schema/src/catalog/mod.rs
@@ -3,6 +3,7 @@ mod coverage;
 pub mod dsl;
 
 use crate::{CompositionSchema, MachineSchema};
+use crate::{RustBinding, identity::MachineId};
 
 // Canonical exposures for the two-kernel cutover
 pub use compositions::{
@@ -15,6 +16,25 @@ pub use coverage::{
     SemanticCoverageEntry, canonical_composition_coverage_manifests,
     canonical_machine_coverage_manifests,
 };
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct MachineProductionOwnerRelation {
+    pub machine: MachineId,
+    pub rust: RustBinding,
+}
+
+impl MachineProductionOwnerRelation {
+    pub fn new(machine: &str, crate_name: &str, module: &str) -> Self {
+        Self {
+            #[allow(clippy::expect_used)]
+            machine: MachineId::parse(machine).expect("valid machine id"),
+            rust: RustBinding {
+                crate_name: crate_name.to_owned(),
+                module: module.to_owned(),
+            },
+        }
+    }
+}
 
 pub fn canonical_machine_schemas() -> Vec<MachineSchema> {
     vec![
@@ -33,5 +53,35 @@ pub fn canonical_composition_schemas() -> Vec<CompositionSchema> {
         schedule_runtime_bundle_composition(),
         schedule_mob_bundle_composition(),
         auth_lease_bundle_composition(),
+    ]
+}
+
+pub fn canonical_machine_production_owner_relations() -> Vec<MachineProductionOwnerRelation> {
+    vec![
+        MachineProductionOwnerRelation::new(
+            "MeerkatMachine",
+            dsl::MEERKAT_MACHINE_PRODUCTION_RUST_CRATE,
+            dsl::MEERKAT_MACHINE_PRODUCTION_RUST_MODULE,
+        ),
+        MachineProductionOwnerRelation::new(
+            "AuthMachine",
+            dsl::AUTH_MACHINE_PRODUCTION_RUST_CRATE,
+            dsl::AUTH_MACHINE_PRODUCTION_RUST_MODULE,
+        ),
+        MachineProductionOwnerRelation::new(
+            "MobMachine",
+            dsl::MOB_MACHINE_PRODUCTION_RUST_CRATE,
+            dsl::MOB_MACHINE_PRODUCTION_RUST_MODULE,
+        ),
+        MachineProductionOwnerRelation::new(
+            "ScheduleLifecycleMachine",
+            dsl::SCHEDULE_LIFECYCLE_PRODUCTION_RUST_CRATE,
+            dsl::SCHEDULE_LIFECYCLE_PRODUCTION_RUST_MODULE,
+        ),
+        MachineProductionOwnerRelation::new(
+            "OccurrenceLifecycleMachine",
+            dsl::OCCURRENCE_LIFECYCLE_PRODUCTION_RUST_CRATE,
+            dsl::OCCURRENCE_LIFECYCLE_PRODUCTION_RUST_MODULE,
+        ),
     ]
 }

--- a/meerkat-machine-schema/src/lib.rs
+++ b/meerkat-machine-schema/src/lib.rs
@@ -11,10 +11,11 @@ pub use identity::{
 pub use types::{CommsRuntimeId, McpServerId, MobId, PeerCorrelationId};
 
 pub use catalog::{
-    CodeAnchor, CompositionCoverageManifest, MachineCoverageManifest, ScenarioCoverage,
-    SemanticCoverageEntry, canonical_composition_coverage_manifests, canonical_composition_schemas,
-    canonical_machine_coverage_manifests, canonical_machine_schemas, compat_composition_schemas,
-    meerkat_mob_seam_composition,
+    CodeAnchor, CompositionCoverageManifest, MachineCoverageManifest,
+    MachineProductionOwnerRelation, ScenarioCoverage, SemanticCoverageEntry,
+    canonical_composition_coverage_manifests, canonical_composition_schemas,
+    canonical_machine_coverage_manifests, canonical_machine_production_owner_relations,
+    canonical_machine_schemas, compat_composition_schemas, meerkat_mob_seam_composition,
 };
 pub use composition::{
     ActorKind, ActorPriority, ActorSchema, ClosurePolicy, CompositionDriver,

--- a/xtask/src/machines.rs
+++ b/xtask/src/machines.rs
@@ -19,51 +19,15 @@ use meerkat_machine_codegen::{
     render_machine_mapping_coverage, render_machine_semantic_model,
 };
 use meerkat_machine_schema::{
-    CompositionCoverageManifest, CompositionSchema, MachineCoverageManifest, MachineSchema,
-    SchedulerRule, SemanticCoverageEntry, TriggerKind, canonical_composition_coverage_manifests,
-    canonical_composition_schemas, canonical_machine_coverage_manifests, canonical_machine_schemas,
+    CompositionCoverageManifest, CompositionSchema, MachineCoverageManifest,
+    MachineProductionOwnerRelation, MachineSchema, SchedulerRule, SemanticCoverageEntry,
+    TriggerKind, canonical_composition_coverage_manifests, canonical_composition_schemas,
+    canonical_machine_coverage_manifests, canonical_machine_production_owner_relations,
+    canonical_machine_schemas,
 };
-use proc_macro2::TokenTree;
 use quote::ToTokens;
 use serde::Serialize;
 use syn::spanned::Spanned;
-
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub struct Phase1CarryForwardProductionBody {
-    pub machine: &'static str,
-    pub path: &'static str,
-}
-
-pub const PHASE1_CARRY_FORWARD_PRODUCTION_BODIES: &[Phase1CarryForwardProductionBody] = &[];
-
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub struct ProductionMachineOwnerPath {
-    pub machine: &'static str,
-    pub path: &'static str,
-}
-
-pub const PRODUCTION_MACHINE_OWNER_PATHS: &[ProductionMachineOwnerPath] = &[
-    ProductionMachineOwnerPath {
-        machine: "MeerkatMachine",
-        path: "meerkat-runtime/src/meerkat_machine/dsl.rs",
-    },
-    ProductionMachineOwnerPath {
-        machine: "AuthMachine",
-        path: "meerkat-runtime/src/auth_machine/dsl.rs",
-    },
-    ProductionMachineOwnerPath {
-        machine: "MobMachine",
-        path: "meerkat-mob/src/machines/mob_machine.rs",
-    },
-    ProductionMachineOwnerPath {
-        machine: "ScheduleLifecycleMachine",
-        path: "meerkat-schedule/src/machines/schedule_lifecycle.rs",
-    },
-    ProductionMachineOwnerPath {
-        machine: "OccurrenceLifecycleMachine",
-        path: "meerkat-schedule/src/machines/occurrence_lifecycle.rs",
-    },
-];
 
 #[derive(Debug, Clone, Args)]
 pub struct SelectionArgs {
@@ -278,8 +242,8 @@ pub fn machine_check_drift(args: SelectionArgs) -> Result<()> {
     let mut mismatches = collect_drift_mismatches(&root, &selection)?;
     mismatches.extend(collect_coverage_anchor_mismatches(&root, &selection));
     mismatches.extend(collect_machine_inventory_mismatches(&root)?);
+    mismatches.extend(collect_production_machine_owner_relation_mismatches(&root)?);
     mismatches.extend(collect_generated_kernel_boundary_mismatches(&root)?);
-    mismatches.extend(collect_phase1_production_body_mismatches(&root)?);
     mismatches.extend(collect_authority_language_mismatches(&root)?);
     mismatches.extend(collect_stale_cfg_mismatches(&root)?);
     mismatches.extend(collect_peer_response_terminal_projection_mismatches(&root)?);
@@ -497,8 +461,8 @@ fn ensure_no_drift(root: &Path, selection: &Selection) -> Result<()> {
     let mut mismatches = collect_drift_mismatches(root, selection)?;
     mismatches.extend(collect_coverage_anchor_mismatches(root, selection));
     mismatches.extend(collect_machine_inventory_mismatches(root)?);
+    mismatches.extend(collect_production_machine_owner_relation_mismatches(root)?);
     mismatches.extend(collect_generated_kernel_boundary_mismatches(root)?);
-    mismatches.extend(collect_phase1_production_body_mismatches(root)?);
     mismatches.extend(collect_authority_language_mismatches(root)?);
     mismatches.extend(collect_stale_cfg_mismatches(root)?);
     mismatches.extend(collect_peer_response_terminal_projection_mismatches(root)?);
@@ -1671,55 +1635,6 @@ pub fn collect_generated_kernel_boundary_mismatches(root: &Path) -> Result<Vec<S
         }
     }
 
-    for machine in &registry.machines {
-        let slug = generated_kernel_module_slug(&machine.machine);
-        let generated_kernel = generated_kernel_module_path(root, &slug);
-        if !generated_kernel.exists() {
-            continue;
-        }
-
-        let owner_paths = PRODUCTION_MACHINE_OWNER_PATHS
-            .iter()
-            .filter(|owner| owner.machine == machine.machine.as_str())
-            .collect::<Vec<_>>();
-        if owner_paths.is_empty() {
-            mismatches.push(format!(
-                "missing production owner audit path for {} while generated kernel {} exists",
-                machine.machine,
-                generated_kernel.display()
-            ));
-            continue;
-        }
-
-        for owner in owner_paths {
-            let owner_path = root.join(owner.path);
-            if !owner_path.exists() {
-                mismatches.push(format!(
-                    "production owner audit path for {} is missing: {}",
-                    machine.machine,
-                    owner_path.display()
-                ));
-                continue;
-            }
-            let source = fs::read_to_string(&owner_path)
-                .with_context(|| format!("read production owner {}", owner_path.display()))?;
-            if !source.contains("machine") {
-                continue;
-            }
-            let parsed = syn::parse_file(&source)
-                .with_context(|| format!("parse production owner {}", owner_path.display()))?;
-            for declared_machine in machine_macro_names(&parsed) {
-                if declared_machine == machine.machine.as_str() {
-                    mismatches.push(format!(
-                        "production owner module must not define canonical machine! body after generated-kernel cutover: {} in {}",
-                        machine.machine,
-                        owner.path
-                    ));
-                }
-            }
-        }
-    }
-
     let generated_mod = generated_kernel_mod_path(root);
     let generated_dir = generated_mod
         .parent()
@@ -1756,6 +1671,103 @@ pub fn collect_generated_kernel_boundary_mismatches(root: &Path) -> Result<Vec<S
     Ok(mismatches)
 }
 
+pub fn collect_production_machine_owner_relation_mismatches(root: &Path) -> Result<Vec<String>> {
+    let registry = CanonicalRegistry::load();
+    let relations = canonical_machine_production_owner_relations();
+    collect_production_machine_owner_relation_mismatches_for_schemas(
+        root,
+        &registry.machines,
+        &relations,
+    )
+}
+
+pub fn collect_production_machine_owner_relation_mismatches_for_schemas(
+    root: &Path,
+    schemas: &[MachineSchema],
+    relations: &[MachineProductionOwnerRelation],
+) -> Result<Vec<String>> {
+    let mut mismatches = Vec::new();
+    let schemas_by_machine = schemas
+        .iter()
+        .map(|schema| (schema.machine.as_str(), schema))
+        .collect::<BTreeMap<_, _>>();
+    let mut relations_by_machine: BTreeMap<&str, Vec<&MachineProductionOwnerRelation>> =
+        BTreeMap::new();
+
+    for relation in relations {
+        relations_by_machine
+            .entry(relation.machine.as_str())
+            .or_default()
+            .push(relation);
+
+        if !schemas_by_machine.contains_key(relation.machine.as_str()) {
+            mismatches.push(format!(
+                "production owner schema relation references untracked machine {}",
+                relation.machine
+            ));
+            continue;
+        }
+
+        if relation.rust.crate_name == "self" || relation.rust.crate_name.trim().is_empty() {
+            mismatches.push(format!(
+                "production owner schema relation for {} must name a production crate, found `{}`",
+                relation.machine, relation.rust.crate_name
+            ));
+        }
+        if relation.rust.module.trim().is_empty() {
+            mismatches.push(format!(
+                "production owner schema relation for {} must name a Rust module",
+                relation.machine
+            ));
+        }
+
+        let owner_path = owner_module_file(root, &relation.rust.crate_name, &relation.rust.module)?;
+        let rel_owner_path = relative_slash_path(root, &owner_path)?;
+        if is_catalog_dsl_path(&rel_owner_path) {
+            mismatches.push(format!(
+                "production owner schema relation for {} points at catalog DSL instead of production owner: {}",
+                relation.machine, rel_owner_path
+            ));
+        }
+        if !owner_path.exists() {
+            mismatches.push(format!(
+                "production owner schema relation for {} points at missing owner module {}",
+                relation.machine,
+                owner_path.display()
+            ));
+        }
+
+        let generated_slug = generated_kernel_module_slug(&relation.machine);
+        let generated_kernel = generated_kernel_module_path(root, &generated_slug);
+        if !generated_kernel.exists() {
+            mismatches.push(format!(
+                "production owner schema relation for {} has no generated kernel module {}",
+                relation.machine,
+                generated_kernel.display()
+            ));
+        }
+    }
+
+    for schema in schemas {
+        let relation_count = relations_by_machine
+            .get(schema.machine.as_str())
+            .map_or(0, Vec::len);
+        match relation_count {
+            0 => mismatches.push(format!(
+                "missing production owner schema relation for {}",
+                schema.machine
+            )),
+            1 => {}
+            count => mismatches.push(format!(
+                "duplicate production owner schema relations for {} ({count} entries)",
+                schema.machine
+            )),
+        }
+    }
+
+    Ok(mismatches)
+}
+
 fn retired_generated_source_paths() -> &'static [&'static str] {
     &[
         "meerkat-machine-kernels/src/compat_generated.rs",
@@ -1770,63 +1782,6 @@ fn retired_generated_source_paths() -> &'static [&'static str] {
         "meerkat-mob/src/runtime/flow_frame_kernel.rs",
         "meerkat-mob/src/runtime/loop_iteration_authority.rs",
     ]
-}
-
-pub fn collect_phase1_production_body_mismatches(root: &Path) -> Result<Vec<String>> {
-    let registry = CanonicalRegistry::load();
-    let canonical_machines: BTreeSet<String> = registry
-        .machines
-        .iter()
-        .map(|machine| machine.machine.as_str().to_owned())
-        .collect();
-    let carry_forward: BTreeSet<(&'static str, &'static str)> =
-        PHASE1_CARRY_FORWARD_PRODUCTION_BODIES
-            .iter()
-            .map(|body| (body.path, body.machine))
-            .collect();
-    let mut seen_carry_forward = BTreeSet::new();
-    let mut mismatches = Vec::new();
-
-    for path in production_rust_source_paths(root)? {
-        let rel = relative_slash_path(root, &path)?;
-        let source = fs::read_to_string(&path)
-            .with_context(|| format!("read machine body candidate {}", path.display()))?;
-        if !source.contains("machine") {
-            continue;
-        }
-        let parsed = syn::parse_file(&source)
-            .with_context(|| format!("parse machine body candidate {}", path.display()))?;
-
-        for machine in machine_macro_names(&parsed) {
-            if !canonical_machines.contains(&machine) {
-                continue;
-            }
-            if is_catalog_dsl_path(&rel) {
-                continue;
-            }
-            if is_expected_generated_kernel_body(&rel, &machine) {
-                continue;
-            }
-            if carry_forward.contains(&(rel.as_str(), machine.as_str())) {
-                seen_carry_forward.insert((rel.clone(), machine));
-                continue;
-            }
-            mismatches.push(format!(
-                "canonical machine! body outside catalog is not Phase 1 carry-forward debt: {machine} in {rel}"
-            ));
-        }
-    }
-
-    for body in PHASE1_CARRY_FORWARD_PRODUCTION_BODIES {
-        if !seen_carry_forward.contains(&(body.path.to_owned(), body.machine.to_owned())) {
-            mismatches.push(format!(
-                "Phase 1 carry-forward production body is not present as declared: {} in {}",
-                body.machine, body.path
-            ));
-        }
-    }
-
-    Ok(mismatches)
 }
 
 pub fn collect_coverage_anchor_mismatches(root: &Path, selection: &Selection) -> Vec<String> {
@@ -2264,152 +2219,6 @@ fn relative_slash_path(root: &Path, path: &Path) -> Result<String> {
 
 fn is_catalog_dsl_path(path: &str) -> bool {
     path.starts_with("meerkat-machine-schema/src/catalog/dsl/")
-}
-
-fn is_expected_generated_kernel_body(path: &str, machine: &str) -> bool {
-    path == format!(
-        "meerkat-machine-kernels/src/generated/{}.rs",
-        generated_kernel_module_slug(machine)
-    )
-}
-
-fn machine_macro_names(parsed: &syn::File) -> Vec<String> {
-    let mut names = Vec::new();
-    let mut aliases = BTreeSet::new();
-    collect_machine_macro_aliases_from_items(&parsed.items, &mut aliases);
-    collect_machine_macro_names_from_items(&parsed.items, &aliases, &mut names);
-    names
-}
-
-fn collect_machine_macro_names_from_items(
-    items: &[syn::Item],
-    aliases: &BTreeSet<String>,
-    names: &mut Vec<String>,
-) {
-    for item in items {
-        match item {
-            syn::Item::Macro(item_macro)
-                if macro_path_ends_with_machine(&item_macro.mac.path)
-                    || macro_path_ends_with_machine_alias(&item_macro.mac.path, aliases) =>
-            {
-                if let Some(name) = machine_name_from_tokens(item_macro.mac.tokens.clone()) {
-                    names.push(name);
-                }
-            }
-            syn::Item::Macro(item_macro)
-                if macro_path_ends_with_macro_rules(&item_macro.mac.path) =>
-            {
-                for name in machine_names_from_wrapper_macro_tokens(item_macro.mac.tokens.clone()) {
-                    names.push(name);
-                }
-            }
-            syn::Item::Mod(item_mod) => {
-                if let Some((_, nested_items)) = &item_mod.content {
-                    collect_machine_macro_names_from_items(nested_items, aliases, names);
-                }
-            }
-            _ => {}
-        }
-    }
-}
-
-fn collect_machine_macro_aliases_from_items(items: &[syn::Item], aliases: &mut BTreeSet<String>) {
-    for item in items {
-        match item {
-            syn::Item::Use(item_use) => {
-                collect_machine_macro_aliases_from_use_tree(&item_use.tree, &[], aliases);
-            }
-            syn::Item::Mod(item_mod) => {
-                if let Some((_, nested_items)) = &item_mod.content {
-                    collect_machine_macro_aliases_from_items(nested_items, aliases);
-                }
-            }
-            _ => {}
-        }
-    }
-}
-
-fn collect_machine_macro_aliases_from_use_tree(
-    tree: &syn::UseTree,
-    prefix: &[String],
-    aliases: &mut BTreeSet<String>,
-) {
-    match tree {
-        syn::UseTree::Path(path) => {
-            let mut next_prefix = prefix.to_vec();
-            next_prefix.push(path.ident.to_string());
-            collect_machine_macro_aliases_from_use_tree(&path.tree, &next_prefix, aliases);
-        }
-        syn::UseTree::Name(name)
-            if is_meerkat_machine_dsl_prefix(prefix) && name.ident == "machine" =>
-        {
-            aliases.insert(name.ident.to_string());
-        }
-        syn::UseTree::Rename(rename)
-            if is_meerkat_machine_dsl_prefix(prefix) && rename.ident == "machine" =>
-        {
-            aliases.insert(rename.rename.to_string());
-        }
-        syn::UseTree::Group(group) => {
-            for item in &group.items {
-                collect_machine_macro_aliases_from_use_tree(item, prefix, aliases);
-            }
-        }
-        _ => {}
-    }
-}
-
-fn is_meerkat_machine_dsl_prefix(prefix: &[String]) -> bool {
-    prefix.len() == 1 && prefix[0] == "meerkat_machine_dsl"
-}
-
-fn macro_path_ends_with_machine(path: &syn::Path) -> bool {
-    path.segments
-        .last()
-        .is_some_and(|segment| segment.ident == "machine")
-}
-
-fn macro_path_ends_with_machine_alias(path: &syn::Path, aliases: &BTreeSet<String>) -> bool {
-    path.segments
-        .last()
-        .is_some_and(|segment| aliases.contains(&segment.ident.to_string()))
-}
-
-fn macro_path_ends_with_macro_rules(path: &syn::Path) -> bool {
-    path.segments
-        .last()
-        .is_some_and(|segment| segment.ident == "macro_rules")
-}
-
-fn machine_names_from_wrapper_macro_tokens(tokens: proc_macro2::TokenStream) -> Vec<String> {
-    let mut names = Vec::new();
-    let mut iter = tokens.into_iter().peekable();
-    while let Some(token) = iter.next() {
-        match token {
-            TokenTree::Ident(ident) if ident == "machine" => {
-                if let Some(TokenTree::Ident(machine_name)) = iter.next() {
-                    names.push(machine_name.to_string());
-                }
-            }
-            TokenTree::Group(group) => {
-                names.extend(machine_names_from_wrapper_macro_tokens(group.stream()));
-            }
-            _ => {}
-        }
-    }
-    names
-}
-
-fn machine_name_from_tokens(tokens: proc_macro2::TokenStream) -> Option<String> {
-    let mut after_machine_keyword = false;
-    for token in tokens {
-        match token {
-            TokenTree::Ident(ident) if after_machine_keyword => return Some(ident.to_string()),
-            TokenTree::Ident(ident) if ident == "machine" => after_machine_keyword = true,
-            _ => {}
-        }
-    }
-    None
 }
 
 pub struct CanonicalRegistry {

--- a/xtask/tests/machines_contracts.rs
+++ b/xtask/tests/machines_contracts.rs
@@ -2,6 +2,7 @@
 
 use std::fs;
 
+use meerkat_machine_schema::{MachineProductionOwnerRelation, canonical_machine_schemas};
 use tempfile::tempdir;
 use xtask::machines::*;
 
@@ -385,36 +386,6 @@ fn kernel_generated_inventory_is_canonical_five_only() {
 }
 
 #[test]
-fn generated_kernel_boundary_rejects_production_owner_machine_body() {
-    let dir = tempdir().expect("tempdir");
-    let generated = dir
-        .path()
-        .join("meerkat-machine-kernels/src/generated/meerkat.rs");
-    fs::create_dir_all(generated.parent().expect("generated parent")).expect("create generated");
-    fs::write(&generated, "// generated kernel exists").expect("write generated kernel");
-
-    let owner = dir
-        .path()
-        .join("meerkat-runtime/src/meerkat_machine/dsl.rs");
-    fs::create_dir_all(owner.parent().expect("owner parent")).expect("create owner");
-    fs::write(
-        &owner,
-        "meerkat_machine_dsl::machine! { machine MeerkatMachine {} }",
-    )
-    .expect("write production owner body");
-
-    let mismatches =
-        collect_generated_kernel_boundary_mismatches(dir.path()).expect("boundary mismatches");
-    assert!(
-        mismatches.iter().any(|mismatch| {
-            mismatch.contains("MeerkatMachine")
-                && mismatch.contains("meerkat-runtime/src/meerkat_machine/dsl.rs")
-        }),
-        "expected production owner machine! body to be rejected, got {mismatches:#?}"
-    );
-}
-
-#[test]
 fn generated_kernel_boundary_rejects_retired_generated_source_and_bridge_paths() {
     let dir = tempdir().expect("tempdir");
     for retired in [
@@ -471,132 +442,86 @@ fn generated_kernel_boundary_accepts_canonical_generated_module_without_owner_bo
 }
 
 #[test]
-fn phase1_production_body_audit_accepts_only_declared_carry_forward_bodies() {
-    require_live_workspace_runfiles();
-    let root = repo_root().expect("repo root");
+fn production_owner_relation_rejects_source_only_token_without_schema_relation() {
+    let dir = tempdir().expect("tempdir");
+    let schemas = canonical_machine_schemas()
+        .into_iter()
+        .filter(|schema| schema.machine.as_str() == "MeerkatMachine")
+        .collect::<Vec<_>>();
+
+    let generated = dir
+        .path()
+        .join("meerkat-machine-kernels/src/generated/meerkat.rs");
+    fs::create_dir_all(generated.parent().expect("generated parent")).expect("create generated");
+    fs::write(&generated, "// generated MeerkatMachine kernel").expect("write generated kernel");
+
+    let source_only = dir
+        .path()
+        .join("meerkat-runtime/src/meerkat_machine/dsl.rs");
+    fs::create_dir_all(source_only.parent().expect("source parent")).expect("create parent");
+    fs::write(&source_only, "machine! { machine MeerkatMachine {} }").expect("write source");
+
     let mismatches =
-        collect_phase1_production_body_mismatches(&root).expect("production body mismatches");
+        collect_production_machine_owner_relation_mismatches_for_schemas(dir.path(), &schemas, &[])
+            .expect("production owner relation mismatches");
+    assert!(
+        mismatches.iter().any(|mismatch| mismatch
+            .contains("missing production owner schema relation for MeerkatMachine")),
+        "expected source-only machine token to fail without schema owner relation, got {mismatches:#?}"
+    );
+}
+
+#[test]
+fn production_owner_relation_accepts_generated_relation_without_machine_token_shape() {
+    let dir = tempdir().expect("tempdir");
+    let schemas = canonical_machine_schemas()
+        .into_iter()
+        .filter(|schema| schema.machine.as_str() == "MeerkatMachine")
+        .collect::<Vec<_>>();
+    let relations = [MachineProductionOwnerRelation::new(
+        "MeerkatMachine",
+        "meerkat-runtime",
+        "meerkat_machine::dsl",
+    )];
+
+    let generated = dir
+        .path()
+        .join("meerkat-machine-kernels/src/generated/meerkat.rs");
+    fs::create_dir_all(generated.parent().expect("generated parent")).expect("create generated");
+    fs::write(&generated, "// generated MeerkatMachine kernel").expect("write generated kernel");
+
+    let owner = dir
+        .path()
+        .join("meerkat-runtime/src/meerkat_machine/dsl.rs");
+    fs::create_dir_all(owner.parent().expect("owner parent")).expect("create owner");
+    fs::write(&owner, "pub fn schema_adapter() {}").expect("write owner");
+
+    let mismatches = collect_production_machine_owner_relation_mismatches_for_schemas(
+        dir.path(),
+        &schemas,
+        &relations,
+    )
+    .expect("production owner relation mismatches");
     assert!(
         mismatches.is_empty(),
-        "expected live canonical machine! bodies outside the catalog to be explicit Phase 1 carry-forward debt, got {mismatches:#?}"
+        "expected typed owner relation plus generated kernel to pass without source token shape, got {mismatches:#?}"
     );
 }
 
 #[test]
-fn phase1_production_body_audit_rejects_new_canonical_body_outside_catalog() {
-    let dir = tempdir().expect("tempdir");
-
-    for body in PHASE1_CARRY_FORWARD_PRODUCTION_BODIES {
-        let path = dir.path().join(body.path);
-        fs::create_dir_all(path.parent().expect("carry-forward parent")).expect("create parent");
-        fs::write(
-            &path,
-            format!("machine! {{ machine {} {{}} }}", body.machine),
-        )
-        .expect("write carry-forward body");
-    }
-
-    let new_body = dir.path().join("meerkat-runtime/src/new_machine.rs");
-    fs::create_dir_all(new_body.parent().expect("new body parent")).expect("create parent");
-    fs::write(&new_body, "machine! { machine MeerkatMachine {} }").expect("write new body");
-
-    let mismatches =
-        collect_phase1_production_body_mismatches(dir.path()).expect("production body mismatches");
-    assert!(
-        mismatches.iter().any(|mismatch| {
-            mismatch.contains("MeerkatMachine")
-                && mismatch.contains("meerkat-runtime/src/new_machine.rs")
-        }),
-        "expected new canonical body to be rejected, got {mismatches:#?}"
-    );
-}
-
-#[test]
-fn phase1_production_body_audit_rejects_spaced_and_qualified_machine_macros() {
-    let dir = tempdir().expect("tempdir");
-
-    for body in PHASE1_CARRY_FORWARD_PRODUCTION_BODIES {
-        let path = dir.path().join(body.path);
-        fs::create_dir_all(path.parent().expect("carry-forward parent")).expect("create parent");
-        fs::write(
-            &path,
-            format!("machine! {{ machine {} {{}} }}", body.machine),
-        )
-        .expect("write carry-forward body");
-    }
-
-    let spaced_body = dir.path().join("meerkat-runtime/src/spaced_machine.rs");
-    fs::create_dir_all(spaced_body.parent().expect("spaced body parent")).expect("create parent");
-    fs::write(&spaced_body, "machine ! { machine MeerkatMachine {} }").expect("write spaced body");
-
-    let qualified_body = dir.path().join("meerkat-mob/src/qualified_machine.rs");
-    fs::create_dir_all(qualified_body.parent().expect("qualified body parent"))
-        .expect("create parent");
-    fs::write(
-        &qualified_body,
-        "meerkat_machine_dsl::machine! { machine MobMachine {} }",
+fn phase1_source_string_scanner_is_removed_from_xtask_surface() {
+    require_live_workspace_runfiles();
+    let source = fs::read_to_string(
+        repo_root()
+            .expect("repo root")
+            .join("xtask/src/machines.rs"),
     )
-    .expect("write qualified body");
+    .expect("read machines xtask source");
 
-    let alias_body = dir.path().join("meerkat-runtime/src/aliased_machine.rs");
-    fs::create_dir_all(alias_body.parent().expect("aliased body parent")).expect("create parent");
-    fs::write(
-        &alias_body,
-        "use meerkat_machine_dsl::machine as local_machine;\nlocal_machine! { machine MeerkatMachine {} }",
-    )
-    .expect("write aliased body");
-
-    let mismatches =
-        collect_phase1_production_body_mismatches(dir.path()).expect("production body mismatches");
     assert!(
-        mismatches.iter().any(|mismatch| {
-            mismatch.contains("MeerkatMachine")
-                && mismatch.contains("meerkat-runtime/src/spaced_machine.rs")
-        }),
-        "expected spaced canonical body to be rejected, got {mismatches:#?}"
-    );
-    assert!(
-        mismatches.iter().any(|mismatch| {
-            mismatch.contains("MobMachine")
-                && mismatch.contains("meerkat-mob/src/qualified_machine.rs")
-        }),
-        "expected qualified canonical body to be rejected, got {mismatches:#?}"
-    );
-    assert!(
-        mismatches.iter().any(|mismatch| {
-            mismatch.contains("MeerkatMachine")
-                && mismatch.contains("meerkat-runtime/src/aliased_machine.rs")
-        }),
-        "expected aliased canonical body to be rejected, got {mismatches:#?}"
-    );
-}
-
-#[test]
-fn phase1_production_body_audit_rejects_machine_body_hidden_in_wrapper_macro() {
-    let dir = tempdir().expect("tempdir");
-    let wrapped_body = dir.path().join("meerkat-runtime/src/wrapped_machine.rs");
-    fs::create_dir_all(wrapped_body.parent().expect("wrapped body parent")).expect("create parent");
-    fs::write(
-        &wrapped_body,
-        r"
-macro_rules! prod_body {
-    () => {
-        meerkat_machine_dsl::machine! { machine MeerkatMachine {} }
-    };
-}
-prod_body!();
-",
-    )
-    .expect("write wrapped body");
-
-    let mismatches =
-        collect_phase1_production_body_mismatches(dir.path()).expect("production body mismatches");
-    assert!(
-        mismatches.iter().any(|mismatch| {
-            mismatch.contains("MeerkatMachine")
-                && mismatch.contains("meerkat-runtime/src/wrapped_machine.rs")
-        }),
-        "expected wrapper macro canonical body to be rejected, got {mismatches:#?}"
+        !source.contains("collect_phase1_production_body_mismatches")
+            && !source.contains("PHASE1_CARRY_FORWARD_PRODUCTION_BODIES"),
+        "old Phase 1 source-string machine scanner must not remain invokable as the authoritative gate"
     );
 }
 


### PR DESCRIPTION
## Summary

- Add typed schema-catalog production owner relations via `canonical_machine_production_owner_relations`.
- Wire `machine-check-drift` / `ensure_no_drift` to validate production owner relations and generated kernel ownership from schema metadata.
- Remove the authoritative source-string scanner path `xtask::machines::collect_phase1_production_body_mismatches` and the hard-coded xtask `PRODUCTION_MACHINE_OWNER_PATHS` table.
- Add negative fixtures proving source-only `machine!` token matches do not satisfy ownership, schema relations pass without token shape, and the old scanner surface is gone.

## Review Readiness Packet

Current head SHA: 783d259e106fe422fa30a9ec26285ba79c0f784f

Command output:

```text
$ make dogma-cleanup-gate DOGMA_PACKET=/tmp/luc-371-review-readiness.md
Dogma cleanup gate passed for /tmp/luc-371-review-readiness.md
```

## Old Path Amputation Proof

| Old path | Classification | Search literal | Mechanical proof | Follow-up |
| --- | --- | --- | --- | --- |
| `xtask::machines::collect_phase1_production_body_mismatches` | deleted | `collect_phase1_production_body_mismatches` | `rg -n "collect_phase1_production_body_mismatches" xtask/src meerkat-machine-schema/src` returns no production matches; focused test `phase1_source_string_scanner_is_removed_from_xtask_surface` also asserts the xtask source no longer contains that scanner. | none |
| `xtask::machines::PRODUCTION_MACHINE_OWNER_PATHS` | deleted | `PRODUCTION_MACHINE_OWNER_PATHS` | `rg -n "PRODUCTION_MACHINE_OWNER_PATHS" xtask/src meerkat-machine-schema/src` returns no production matches; owner coverage now comes from schema catalog metadata. | none |

## Complexity Delta

- Docs/scripts/tests: 2 files.
- Non-test implementation: 4 files.
- Generated/schema churn: 3 schema-catalog metadata files.

## Sample Passing Old Path Amputation Proof

| Old path | Classification | Search literal | Mechanical proof | Follow-up |
| --- | --- | --- | --- | --- |
| `old/session-route` | deleted | `old/session-route` | No production references remain. | none |

## Sample Failing Old Path Amputation Proof

| Old path | Classification | Search literal | Mechanical proof | Follow-up |
| --- | --- | --- | --- | --- |
| `old/session-route` | wrapped | `old/session-route` | A preferred path exists beside the old route. | none |

## Validation

- `make fmt`
- `git diff --check`
- `./scripts/repo-cargo test -p xtask --features machine-authority --test machines_contracts production_owner_relation -- --nocapture`
- `./scripts/repo-cargo test -p xtask --features machine-authority --test machines_contracts phase1_source_string_scanner_is_removed_from_xtask_surface -- --nocapture`
- `./scripts/repo-cargo test -p xtask --features machine-authority --test machines_contracts`
- `make machine-check-drift`
- `make check` (BuildBuddy invocation `afb83c2c-45fd-4c5c-ac2f-900148196ab2`)
- `make lint` (BuildBuddy invocation `5d3b3c52-6c71-4786-a239-c3ee8ed49117`)
- Rework: `./scripts/repo-cargo test -p meerkat-rest rest_peer_terminal_webhook_allows_running_target_when_capacity_full -- --nocapture`

Linear: LUC-371
