### PR TITLE
LUC-367 provider-owned inline video capability

### DIFF
--- a/meerkat-core/src/lib.rs
+++ b/meerkat-core/src/lib.rs
@@ -116,7 +116,10 @@ pub use memory::{
     MemoryIndexBatch, MemoryIndexReceipt, MemoryIndexRequest, MemoryIndexScope, MemoryMetadata,
     MemoryOwner, MemoryResult, MemorySearchScope, MemoryStore, MemoryStoreError,
 };
-pub use model_registry::{ModelRegistry, ModelRegistryEntry, SelfHostedServerRef};
+pub use model_registry::{
+    ModelCapability, ModelRegistry, ModelRegistryEntry, SelfHostedServerRef,
+    UnsupportedModelCapabilityEvidence, UnsupportedModelCapabilityReason,
+};
 pub use peer_correlation::{
     InboundPeerRequestState, InteractionStreamState, OutboundPeerRequestState, PeerCorrelationId,
 };

--- a/meerkat-core/src/model_registry.rs
+++ b/meerkat-core/src/model_registry.rs
@@ -5,7 +5,9 @@ use crate::config::{
     Config, ConfigError, SelfHostedApiStyle, SelfHostedConfig, SelfHostedTransport,
 };
 use crate::model_profile::{ModelProfile, catalog::ModelTier};
+use serde::{Deserialize, Serialize};
 use std::collections::BTreeMap;
+use std::fmt;
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct SelfHostedServerRef {
@@ -32,6 +34,92 @@ pub struct ModelRegistry {
     entries: BTreeMap<String, ModelRegistryEntry>,
     profiles: BTreeMap<(Provider, String), ModelProfile>,
     defaults: BTreeMap<Provider, String>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ModelCapability {
+    InlineVideo,
+}
+
+impl ModelCapability {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::InlineVideo => "inline_video",
+        }
+    }
+
+    fn display_name(self) -> &'static str {
+        match self {
+            Self::InlineVideo => "inline video",
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum UnsupportedModelCapabilityReason {
+    CapabilityDisabled,
+    ProviderModelProfileMissing,
+    CapabilityRegistryUnavailable,
+}
+
+impl UnsupportedModelCapabilityReason {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::CapabilityDisabled => "capability_disabled",
+            Self::ProviderModelProfileMissing => "provider_model_profile_missing",
+            Self::CapabilityRegistryUnavailable => "capability_registry_unavailable",
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct UnsupportedModelCapabilityEvidence {
+    pub capability: ModelCapability,
+    pub provider: Provider,
+    pub model: String,
+    pub reason: UnsupportedModelCapabilityReason,
+}
+
+impl UnsupportedModelCapabilityEvidence {
+    pub fn inline_video(
+        provider: Provider,
+        model: impl Into<String>,
+        reason: UnsupportedModelCapabilityReason,
+    ) -> Self {
+        Self {
+            capability: ModelCapability::InlineVideo,
+            provider,
+            model: model.into(),
+            reason,
+        }
+    }
+
+    pub fn details(&self) -> serde_json::Value {
+        serde_json::json!({
+            "unsupported_capability": {
+                "capability": self.capability.as_str(),
+                "provider": self.provider.as_str(),
+                "model": self.model.as_str(),
+                "reason": self.reason.as_str(),
+            },
+        })
+    }
+}
+
+impl fmt::Display for UnsupportedModelCapabilityEvidence {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "{} input is not supported by model '{}' on provider '{}' (capability: {}, reason: {})",
+            self.capability.display_name(),
+            self.model,
+            self.provider.as_str(),
+            self.capability.as_str(),
+            self.reason.as_str()
+        )
+    }
 }
 
 impl ModelRegistry {
@@ -148,6 +236,30 @@ impl ModelRegistry {
         self.profiles
             .get(&(provider, model_id.to_string()))
             .cloned()
+    }
+
+    pub fn require_inline_video_for_provider(
+        &self,
+        provider: Provider,
+        model_id: &str,
+    ) -> Result<(), UnsupportedModelCapabilityEvidence> {
+        let Some(profile) = self.profile_for_provider(provider, model_id) else {
+            return Err(UnsupportedModelCapabilityEvidence::inline_video(
+                provider,
+                model_id,
+                UnsupportedModelCapabilityReason::ProviderModelProfileMissing,
+            ));
+        };
+
+        if profile.inline_video {
+            Ok(())
+        } else {
+            Err(UnsupportedModelCapabilityEvidence::inline_video(
+                provider,
+                model_id,
+                UnsupportedModelCapabilityReason::CapabilityDisabled,
+            ))
+        }
     }
 
     pub fn default_model(&self, provider: Provider) -> Option<&str> {
@@ -524,6 +636,62 @@ mod tests {
                 .profile_for_provider(Provider::OpenAI, "uncatalogued-gpt-compatible")
                 .is_none(),
             "known provider plus uncatalogued model must fail closed"
+        );
+    }
+
+    #[test]
+    fn inline_video_capability_requires_typed_provider_owner() {
+        let registry = match ModelRegistry::from_config(&Config::default()) {
+            Ok(registry) => registry,
+            Err(err) => panic!("registry construction failed: {err}"),
+        };
+
+        registry
+            .require_inline_video_for_provider(Provider::Gemini, "gemini-3-flash-preview")
+            .expect("Gemini catalog owner should authorize inline video");
+
+        let err = registry
+            .require_inline_video_for_provider(Provider::OpenAI, "gemini-3-flash-preview")
+            .expect_err("same model name under another provider must fail closed");
+        assert_eq!(err.capability, ModelCapability::InlineVideo);
+        assert_eq!(err.provider, Provider::OpenAI);
+        assert_eq!(err.model, "gemini-3-flash-preview");
+        assert_eq!(
+            err.reason,
+            UnsupportedModelCapabilityReason::ProviderModelProfileMissing
+        );
+    }
+
+    #[test]
+    fn inline_video_capability_evidence_distinguishes_disabled_and_unknown() {
+        let registry = match ModelRegistry::from_config(&Config::default()) {
+            Ok(registry) => registry,
+            Err(err) => panic!("registry construction failed: {err}"),
+        };
+
+        let disabled = registry
+            .require_inline_video_for_provider(Provider::OpenAI, "gpt-5.4")
+            .expect_err("known OpenAI model has catalog-owned inline video disabled");
+        assert_eq!(
+            disabled.reason,
+            UnsupportedModelCapabilityReason::CapabilityDisabled
+        );
+
+        let unknown = registry
+            .require_inline_video_for_provider(Provider::Other, "uncatalogued-video-model")
+            .expect_err("unknown provider/model pair must fail closed");
+        assert_eq!(
+            unknown.reason,
+            UnsupportedModelCapabilityReason::ProviderModelProfileMissing
+        );
+        let details = unknown.details();
+        assert_eq!(
+            details["unsupported_capability"]["capability"],
+            serde_json::json!("inline_video")
+        );
+        assert_eq!(
+            details["unsupported_capability"]["reason"],
+            serde_json::json!("provider_model_profile_missing")
         );
     }
 

--- a/meerkat-rest/src/lib.rs
+++ b/meerkat-rest/src/lib.rs
@@ -959,39 +959,88 @@ async fn resolve_validation_identity(
     })
 }
 
+#[derive(Debug, Clone)]
+enum PromptVideoInputValidationError {
+    InvalidBlock(String),
+    UnsupportedCapability(meerkat_core::UnsupportedModelCapabilityEvidence),
+}
+
+impl PromptVideoInputValidationError {
+    #[cfg(test)]
+    fn unsupported_evidence(&self) -> Option<&meerkat_core::UnsupportedModelCapabilityEvidence> {
+        match self {
+            Self::UnsupportedCapability(evidence) => Some(evidence),
+            Self::InvalidBlock(_) => None,
+        }
+    }
+}
+
+impl std::fmt::Display for PromptVideoInputValidationError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::InvalidBlock(message) => f.write_str(message),
+            Self::UnsupportedCapability(evidence) => evidence.fmt(f),
+        }
+    }
+}
+
+fn inline_video_registry_unavailable_evidence(
+    identity: &SessionLlmIdentity,
+) -> meerkat_core::UnsupportedModelCapabilityEvidence {
+    meerkat_core::UnsupportedModelCapabilityEvidence::inline_video(
+        identity.provider,
+        identity.model.clone(),
+        meerkat_core::UnsupportedModelCapabilityReason::CapabilityRegistryUnavailable,
+    )
+}
+
+async fn require_inline_video_support(
+    config_runtime: &meerkat_core::ConfigRuntime,
+    identity: &SessionLlmIdentity,
+) -> Result<(), meerkat_core::UnsupportedModelCapabilityEvidence> {
+    let Ok(snapshot) = config_runtime.get().await else {
+        return Err(inline_video_registry_unavailable_evidence(identity));
+    };
+    let Ok(registry) = snapshot.config.model_registry() else {
+        return Err(inline_video_registry_unavailable_evidence(identity));
+    };
+
+    registry.require_inline_video_for_provider(identity.provider, &identity.model)
+}
+
 async fn validate_prompt_video_input(
     config_runtime: &meerkat_core::ConfigRuntime,
     prompt: &ContentInput,
     identity: &SessionLlmIdentity,
-) -> Result<(), String> {
+) -> Result<(), PromptVideoInputValidationError> {
     let blocks = match prompt {
         ContentInput::Text(_) => return Ok(()),
         ContentInput::Blocks(blocks) => blocks,
     };
 
-    meerkat_core::validate_inline_video_blocks(blocks)?;
+    meerkat_core::validate_inline_video_blocks(blocks)
+        .map_err(PromptVideoInputValidationError::InvalidBlock)?;
 
-    let supports_inline_video = config_runtime
-        .get()
-        .await
-        .ok()
-        .and_then(|state| state.config.model_registry().ok())
-        .and_then(|registry| {
-            registry
-                .profile_for_provider(identity.provider, &identity.model)
-                .map(|profile| profile.inline_video)
-        })
-        .unwrap_or(false);
-
-    if meerkat_core::has_video(blocks) && !supports_inline_video {
-        return Err(format!(
-            "inline video input is not supported by model '{}' on provider '{}'",
-            identity.model,
-            identity.provider.as_str()
-        ));
+    if meerkat_core::has_video(blocks) {
+        require_inline_video_support(config_runtime, identity)
+            .await
+            .map_err(PromptVideoInputValidationError::UnsupportedCapability)?;
     }
 
     Ok(())
+}
+
+fn prompt_video_input_error_to_api(error: PromptVideoInputValidationError) -> ApiError {
+    match error {
+        PromptVideoInputValidationError::InvalidBlock(message) => ApiError::BadRequest(message),
+        PromptVideoInputValidationError::UnsupportedCapability(evidence) => {
+            ApiError::BadRequestWithData {
+                message: evidence.to_string(),
+                code: "UNSUPPORTED_MODEL_CAPABILITY".to_string(),
+                details: evidence.details(),
+            }
+        }
+    }
 }
 
 async fn apply_runtime_turn(
@@ -1252,11 +1301,11 @@ async fn apply_runtime_turn(
                 .map(|metadata| metadata.llm_identity())
         });
     if let Some(identity) = session_identity
-        && let Err(message) =
+        && let Err(error) =
             validate_prompt_video_input(&context.config_runtime, &prompt, &identity).await
     {
         return Err(SessionError::Agent(meerkat_core::AgentError::ConfigError(
-            message,
+            error.to_string(),
         )));
     }
 
@@ -3986,7 +4035,7 @@ async fn create_session_inner(
         cleanup_archived_session_runtime(state, &session_id).await;
         drop(caller_event_tx);
         drain_event_forwarder(&session_id, forward_task).await;
-        return RequestTerminal::RespondWithoutPublish(Err(ApiError::BadRequest(err)));
+        return RequestTerminal::RespondWithoutPublish(Err(prompt_video_input_error_to_api(err)));
     }
 
     let adapter = state.runtime_adapter.clone();
@@ -4804,7 +4853,9 @@ async fn continue_session_inner(
                 .await;
             drop(caller_event_tx);
             drain_event_forwarder(&session_id, forward_task).await;
-            return RequestTerminal::RespondWithoutPublish(Err(ApiError::BadRequest(err)));
+            return RequestTerminal::RespondWithoutPublish(Err(prompt_video_input_error_to_api(
+                err,
+            )));
         }
         let create_result = match state
             .session_service
@@ -5034,7 +5085,9 @@ async fn continue_session_inner(
                 .await;
             drop(caller_event_tx);
             drain_event_forwarder(&session_id, forward_task).await;
-            return RequestTerminal::RespondWithoutPublish(Err(ApiError::BadRequest(err)));
+            return RequestTerminal::RespondWithoutPublish(Err(prompt_video_input_error_to_api(
+                err,
+            )));
         }
 
         // Install cancel action: interrupt the session.
@@ -5875,6 +5928,11 @@ pub async fn shutdown_all_mcp_sessions(state: &AppState) {
 #[derive(Debug)]
 pub enum ApiError {
     BadRequest(String),
+    BadRequestWithData {
+        message: String,
+        code: String,
+        details: Value,
+    },
     Unauthorized(String),
     NotFound(String),
     Conflict(String),
@@ -5908,6 +5966,11 @@ impl IntoResponse for ApiError {
                 msg,
                 None,
             ),
+            ApiError::BadRequestWithData {
+                message,
+                code,
+                details,
+            } => (StatusCode::BAD_REQUEST, code, message, Some(details)),
             ApiError::Unauthorized(msg) => (
                 StatusCode::UNAUTHORIZED,
                 "UNAUTHORIZED".to_string(),
@@ -7923,9 +7986,19 @@ mod tests {
             .await
             .expect_err("wrong typed provider must not inherit Gemini inline-video support");
 
-        assert!(err.contains("inline video"));
-        assert!(err.contains("gemini-3-flash-preview"));
-        assert!(err.contains("anthropic"));
+        let evidence = err
+            .unsupported_evidence()
+            .expect("unsupported inline-video error should carry typed evidence");
+        assert_eq!(
+            evidence.capability,
+            meerkat_core::ModelCapability::InlineVideo
+        );
+        assert_eq!(
+            evidence.reason,
+            meerkat_core::UnsupportedModelCapabilityReason::ProviderModelProfileMissing
+        );
+        assert_eq!(evidence.provider, Provider::Anthropic);
+        assert_eq!(evidence.model, "gemini-3-flash-preview");
     }
 
     #[tokio::test]
@@ -7941,9 +8014,15 @@ mod tests {
             .await
             .expect_err("unknown provider/model pair must fail closed without defaults");
 
-        assert!(err.contains("inline video"));
-        assert!(err.contains("uncatalogued-video-model"));
-        assert!(err.contains("other"));
+        let evidence = err
+            .unsupported_evidence()
+            .expect("unknown provider/model must carry typed unsupported evidence");
+        assert_eq!(
+            evidence.reason,
+            meerkat_core::UnsupportedModelCapabilityReason::ProviderModelProfileMissing
+        );
+        assert_eq!(evidence.provider, Provider::Other);
+        assert_eq!(evidence.model, "uncatalogued-video-model");
     }
 
     #[tokio::test]
@@ -7961,9 +8040,15 @@ mod tests {
                 "known model/display strings must not select capability without typed provider",
             );
 
-        assert!(err.contains("inline video"));
-        assert!(err.contains("gemini-3-flash-preview"));
-        assert!(err.contains("other"));
+        let evidence = err
+            .unsupported_evidence()
+            .expect("providerless display/model strings must carry typed unsupported evidence");
+        assert_eq!(
+            evidence.reason,
+            meerkat_core::UnsupportedModelCapabilityReason::ProviderModelProfileMissing
+        );
+        assert_eq!(evidence.provider, Provider::Other);
+        assert_eq!(evidence.model, "gemini-3-flash-preview");
     }
 
     #[tokio::test]
@@ -9678,10 +9763,19 @@ mod tests {
         .await;
 
         match outcome {
-            RequestTerminal::RespondWithoutPublish(Err(ApiError::BadRequest(message))) => {
+            RequestTerminal::RespondWithoutPublish(Err(ApiError::BadRequestWithData {
+                message,
+                code,
+                details,
+            })) => {
+                assert_eq!(code, "UNSUPPORTED_MODEL_CAPABILITY");
                 assert!(
                     message.contains("inline video"),
                     "expected inline video validation failure: {message}"
+                );
+                assert_eq!(
+                    details["unsupported_capability"]["capability"],
+                    serde_json::json!("inline_video")
                 );
             }
             other => panic!("expected bad request validation failure, got {other:?}"),
@@ -9755,10 +9849,19 @@ mod tests {
         .await;
 
         match outcome {
-            RequestTerminal::RespondWithoutPublish(Err(ApiError::BadRequest(message))) => {
+            RequestTerminal::RespondWithoutPublish(Err(ApiError::BadRequestWithData {
+                message,
+                code,
+                details,
+            })) => {
+                assert_eq!(code, "UNSUPPORTED_MODEL_CAPABILITY");
                 assert!(
                     message.contains("inline video"),
                     "expected inline video validation failure: {message}"
+                );
+                assert_eq!(
+                    details["unsupported_capability"]["capability"],
+                    serde_json::json!("inline_video")
                 );
             }
             other => panic!("expected bad request validation failure, got {other:?}"),

--- a/meerkat-rpc/src/session_runtime.rs
+++ b/meerkat-rpc/src/session_runtime.rs
@@ -1548,6 +1548,16 @@ fn registered_model_provider_mismatch_reason(
     registry.provider_override_mismatch_reason(provider, model)
 }
 
+fn unsupported_model_capability_rpc_error(
+    evidence: meerkat_core::UnsupportedModelCapabilityEvidence,
+) -> RpcError {
+    RpcError {
+        code: error::INVALID_PARAMS,
+        message: evidence.to_string(),
+        data: Some(evidence.details()),
+    }
+}
+
 fn profile_to_capability_surface(
     profile: &meerkat_models::profile::ModelProfile,
 ) -> SessionLlmCapabilitySurface {
@@ -3815,12 +3825,24 @@ impl SessionRuntime {
     }
 
     async fn provider_supports_inline_video(&self, identity: &SessionLlmIdentity) -> bool {
-        self.model_registry()
-            .await
-            .ok()
-            .and_then(|registry| registry.profile_for_provider(identity.provider, &identity.model))
-            .map(|profile| profile.inline_video)
-            .unwrap_or(false)
+        self.require_inline_video_support(identity).await.is_ok()
+    }
+
+    async fn require_inline_video_support(
+        &self,
+        identity: &SessionLlmIdentity,
+    ) -> Result<(), meerkat_core::UnsupportedModelCapabilityEvidence> {
+        let Ok(registry) = self.model_registry().await else {
+            return Err(
+                meerkat_core::UnsupportedModelCapabilityEvidence::inline_video(
+                    identity.provider,
+                    identity.model.clone(),
+                    meerkat_core::UnsupportedModelCapabilityReason::CapabilityRegistryUnavailable,
+                ),
+            );
+        };
+
+        registry.require_inline_video_for_provider(identity.provider, &identity.model)
     }
 
     async fn validate_prompt_video_input(
@@ -3839,16 +3861,10 @@ impl SessionRuntime {
             data: None,
         })?;
 
-        if meerkat_core::has_video(blocks) && !self.provider_supports_inline_video(identity).await {
-            return Err(RpcError {
-                code: error::INVALID_PARAMS,
-                message: format!(
-                    "inline video input is not supported by model '{}' on provider '{}'",
-                    identity.model,
-                    identity.provider.as_str()
-                ),
-                data: None,
-            });
+        if meerkat_core::has_video(blocks)
+            && let Err(evidence) = self.require_inline_video_support(identity).await
+        {
+            return Err(unsupported_model_capability_rpc_error(evidence));
         }
 
         Ok(())
@@ -10467,6 +10483,43 @@ mod tests {
                 .provider_supports_inline_video(&gemini_video_model_on_gemini)
                 .await,
             "owned Gemini inline-video capability should still resolve"
+        );
+    }
+
+    #[tokio::test]
+    async fn inline_video_validation_returns_typed_unsupported_capability_evidence() {
+        let temp = tempfile::tempdir().unwrap();
+        let runtime = make_runtime(temp_factory(&temp), 10);
+        let identity = SessionLlmIdentity {
+            model: "gemini-3-flash-preview".to_string(),
+            provider: meerkat_core::Provider::OpenAI,
+            self_hosted_server_id: None,
+            provider_params: None,
+            connection_ref: None,
+        };
+
+        let err = runtime
+            .validate_prompt_video_input(&inline_video_prompt(), &identity)
+            .await
+            .expect_err("same model name under incompatible provider must fail closed");
+
+        assert_eq!(err.code, error::INVALID_PARAMS);
+        let data = err.data.expect("unsupported capability evidence data");
+        assert_eq!(
+            data["unsupported_capability"]["capability"],
+            serde_json::json!("inline_video")
+        );
+        assert_eq!(
+            data["unsupported_capability"]["reason"],
+            serde_json::json!("provider_model_profile_missing")
+        );
+        assert_eq!(
+            data["unsupported_capability"]["provider"],
+            serde_json::json!("openai")
+        );
+        assert_eq!(
+            data["unsupported_capability"]["model"],
+            serde_json::json!("gemini-3-flash-preview")
         );
     }
 

--- a/meerkat-session/src/ephemeral.rs
+++ b/meerkat-session/src/ephemeral.rs
@@ -655,6 +655,7 @@ pub trait SessionAgent: Send {
     }
 }
 
+#[cfg(test)]
 fn validate_prompt_video_input_against_capability(
     prompt: &ContentInput,
     identity: &SessionLlmIdentity,
@@ -782,11 +783,27 @@ impl<B: SessionAgentBuilder + 'static> EphemeralSessionService<B> {
         })
     }
 
-    async fn model_supports_inline_video(&self, identity: &SessionLlmIdentity) -> bool {
-        self.builder
-            .model_supports_inline_video(identity)
-            .await
-            .unwrap_or(false)
+    async fn require_inline_video_support(
+        &self,
+        identity: &SessionLlmIdentity,
+    ) -> Result<(), meerkat_core::UnsupportedModelCapabilityEvidence> {
+        match self.builder.model_supports_inline_video(identity).await {
+            Some(true) => Ok(()),
+            Some(false) => Err(
+                meerkat_core::UnsupportedModelCapabilityEvidence::inline_video(
+                    identity.provider,
+                    identity.model.clone(),
+                    meerkat_core::UnsupportedModelCapabilityReason::CapabilityDisabled,
+                ),
+            ),
+            None => Err(
+                meerkat_core::UnsupportedModelCapabilityEvidence::inline_video(
+                    identity.provider,
+                    identity.model.clone(),
+                    meerkat_core::UnsupportedModelCapabilityReason::ProviderModelProfileMissing,
+                ),
+            ),
+        }
     }
 
     async fn validate_prompt_video_input(
@@ -794,11 +811,23 @@ impl<B: SessionAgentBuilder + 'static> EphemeralSessionService<B> {
         prompt: &ContentInput,
         identity: &SessionLlmIdentity,
     ) -> Result<(), SessionError> {
-        validate_prompt_video_input_against_capability(
-            prompt,
-            identity,
-            self.model_supports_inline_video(identity).await,
-        )
+        let blocks = match prompt {
+            ContentInput::Text(_) => return Ok(()),
+            ContentInput::Blocks(blocks) => blocks,
+        };
+
+        meerkat_core::validate_inline_video_blocks(blocks)
+            .map_err(|err| SessionError::Agent(AgentError::ConfigError(err)))?;
+
+        if meerkat_core::has_video(blocks)
+            && let Err(evidence) = self.require_inline_video_support(identity).await
+        {
+            return Err(SessionError::Agent(AgentError::ConfigError(
+                evidence.to_string(),
+            )));
+        }
+
+        Ok(())
     }
 
     fn validate_tool_result_video(results: &[ToolResult]) -> Result<(), SessionError> {

--- a/meerkat/src/service_factory.rs
+++ b/meerkat/src/service_factory.rs
@@ -516,12 +516,6 @@ impl SessionAgentBuilder for FactoryAgentBuilder {
             .ok()
             .and_then(|registry| registry.profile_for_provider(identity.provider, &identity.model))
             .map(|profile| profile.inline_video)
-            .or_else(|| {
-                meerkat_core::model_profile::inline_video_support_for(
-                    identity.provider,
-                    &identity.model,
-                )
-            })
     }
 
     async fn build_agent(


### PR DESCRIPTION
## Summary
- add typed `UnsupportedModelCapabilityEvidence` and `ModelRegistry::require_inline_video_for_provider` as the inline-video admission authority
- route REST/RPC/session inline-video validation through provider-aware registry evidence instead of bool fallbacks
- remove the factory fallback to `model_profile::inline_video_support_for` after registry lookup, so model-only entries cannot authorize inline video

## Old Path Made Impossible
`ModelRegistry::entry(model_id)` is projection-only and is not used for inline-video capability admission. REST/RPC/runtime validation requires `ModelRegistry::require_inline_video_for_provider(provider, model_id)`, and unknown/wrong-provider pairs return typed `unsupported_capability` evidence.

## Validation
- Baseline: `RUST_LANE_ID=LUC367 ./scripts/repo-cargo test -p meerkat-core provider_aware_profile_lookup -- --nocapture`
- Baseline: `RUST_LANE_ID=LUC367 ./scripts/repo-cargo test -p meerkat-core inline_video_support_for_reads_capability_truth -- --nocapture`
- Baseline: `RUST_LANE_ID=LUC367 ./scripts/repo-cargo test -p meerkat-rest validate_prompt_video_input -- --nocapture`
- `RUST_LANE_ID=LUC367 ./scripts/repo-cargo test -p meerkat-core inline_video_capability -- --nocapture`
- `RUST_LANE_ID=LUC367 ./scripts/repo-cargo test -p meerkat-rest validate_prompt_video_input -- --nocapture`
- `RUST_LANE_ID=LUC367 ./scripts/repo-cargo test -p meerkat-session inline_video_admission -- --nocapture`
- `RUST_LANE_ID=LUC367 ./scripts/repo-cargo test -p meerkat-rpc inline_video -- --nocapture`
- `RUST_LANE_ID=LUC367 ./scripts/repo-cargo test -p meerkat inline_video_capability_reads_current_config_store -- --nocapture`
- `RUST_LANE_ID=LUC367 ./scripts/repo-cargo test -p meerkat-rest test_continue_session_validation_failure -- --nocapture`
- `MEERKAT_BUILDBUDDY=1 RUST_LANE_ID=LUC367 make check`
- `MEERKAT_BUILDBUDDY=1 RUST_LANE_ID=LUC367 make lint`

Linear: LUC-367

## Review Readiness Packet

Current head SHA: 0cffdba385e46bb58d84611c0bed0f4d7c30fd55

Command output:

```text
$ DOGMA_PACKET=/tmp/luc367-review-readiness.md make dogma-cleanup-gate
Dogma cleanup gate passed for /tmp/luc367-review-readiness.md
```

## Old Path Amputation Proof

| Old path | Classification | Search literal | Mechanical proof | Follow-up |
| --- | --- | --- | --- | --- |
| `model-only inline-video admission` | made uncallable at boundary | `model-only inline-video admission` | `require_inline_video_for_provider(provider, model_id)` is the production API; REST/RPC/session runtime rejects requests for wrong-provider or uncatalogued pairs with typed unsupported capability evidence before model execution. | none |
| `service-factory registry-miss inline-video fallback` | deleted | `service-factory registry-miss inline-video fallback` | `FactoryAgentBuilder::model_supports_inline_video` has no registry-miss capability branch after the configured registry lookup. | none |

## Complexity Delta

- Docs/scripts/tests: 0 files.
- Non-test implementation: 6 files.
- Generated/schema churn: 0 files.

## Sample Passing Old Path Amputation Proof

| Old path | Classification | Search literal | Mechanical proof | Follow-up |
| --- | --- | --- | --- | --- |
| `old/session-route` | deleted | `old/session-route` | No production references remain. | none |

## Sample Failing Old Path Amputation Proof

| Old path | Classification | Search literal | Mechanical proof | Follow-up |
| --- | --- | --- | --- | --- |
| `old/session-route` | wrapped | `old/session-route` | A preferred path exists beside the old route. | none |
| `surface_request_lifecycle_helper` | made uncallable at boundary | `surface_request_lifecycle_helper` | Boundary test exercises the replacement wrapper while the old helper remains callable for compatibility. | none |
| `wasm_contract_string_mirror` | retained with linked follow-up | `wasm_contract_string_mirror` | Retained for an active SDK cutover. | LUC-999 |
