### PR TITLE
LUC-373 require AuthMachine-owned OAuth terminal state

### DIFF
--- a/meerkat-auth-core/src/oauth_flow.rs
+++ b/meerkat-auth-core/src/oauth_flow.rs
@@ -420,6 +420,8 @@ struct OAuthDevicePollLeaseState {
 pub enum OAuthFlowError {
     #[error("oauth state is missing or expired")]
     Missing,
+    #[error("oauth registry projection payload missing after AuthMachine accepted {operation}")]
+    RegistryProjectionMissing { operation: &'static str },
     #[error("oauth state provider mismatch: expected {expected}, got {actual}")]
     ProviderMismatch {
         expected: OAuthProviderIdentity,
@@ -455,6 +457,10 @@ pub enum OAuthFlowError {
 }
 
 pub trait OAuthDevicePollLifecycle: Send + Sync {
+    fn device_flow_state_is_authmachine_owned(&self) -> bool {
+        false
+    }
+
     fn finish_device_poll(
         &self,
         target: &ConnectionRef,
@@ -535,6 +541,21 @@ impl OAuthDevicePollLease {
         }
     }
 
+    pub fn terminal_flow_state_is_authmachine_owned(&self) -> bool {
+        self.lifecycle
+            .as_ref()
+            .map(|lifecycle| lifecycle.device_flow_state_is_authmachine_owned())
+            .unwrap_or(false)
+    }
+
+    fn local_missing_error(&self, operation: &'static str) -> OAuthFlowError {
+        if self.terminal_flow_state_is_authmachine_owned() {
+            OAuthFlowError::RegistryProjectionMissing { operation }
+        } else {
+            OAuthFlowError::Missing
+        }
+    }
+
     pub fn with_lifecycle(mut self, lifecycle: Arc<dyn OAuthDevicePollLifecycle>) -> Self {
         self.lifecycle = Some(lifecycle);
         self
@@ -561,10 +582,13 @@ impl OAuthDevicePollLease {
             )
             .map(|_| ())
         };
-        if matches!(verify_result, Err(OAuthFlowError::Missing))
-            && let Some(lifecycle) = &self.lifecycle
-        {
-            let _ = lifecycle.expire_device_flow(&self.target, &self.device_code);
+        if matches!(verify_result, Err(OAuthFlowError::Missing)) {
+            if self.terminal_flow_state_is_authmachine_owned()
+                && let Some(lifecycle) = &self.lifecycle
+            {
+                let _ = lifecycle.finish_device_poll(&self.target, &self.device_code);
+            }
+            return Err(self.local_missing_error("finish_oauth_device_poll"));
         }
         verify_result?;
 
@@ -583,17 +607,19 @@ impl OAuthDevicePollLease {
             prune_expired_device_locked(&mut flows);
             result
         };
-        if result.is_ok() {
-            self.active = false;
-            if let Some(lifecycle) = &self.lifecycle {
-                lifecycle.device_flow_payloads_changed()?;
+        match result {
+            Ok(()) => {
+                self.active = false;
+                if let Some(lifecycle) = &self.lifecycle {
+                    lifecycle.device_flow_payloads_changed()?;
+                }
+                Ok(())
             }
-        } else if matches!(result, Err(OAuthFlowError::Missing))
-            && let Some(lifecycle) = &self.lifecycle
-        {
-            let _ = lifecycle.expire_device_flow(&self.target, &self.device_code);
+            Err(OAuthFlowError::Missing) => {
+                Err(self.local_missing_error("finish_oauth_device_poll"))
+            }
+            Err(err) => Err(err),
         }
-        result
     }
 
     pub fn verify(&self) -> Result<OAuthDeviceFlowRecord, OAuthFlowError> {
@@ -606,10 +632,8 @@ impl OAuthDevicePollLease {
             self.lease_id,
         );
         prune_expired_device_locked(&mut flows);
-        if matches!(result, Err(OAuthFlowError::Missing))
-            && let Some(lifecycle) = &self.lifecycle
-        {
-            let _ = lifecycle.expire_device_flow(&self.target, &self.device_code);
+        if matches!(result, Err(OAuthFlowError::Missing)) {
+            return Err(self.local_missing_error("verify_oauth_device_poll"));
         }
         result
     }
@@ -629,12 +653,18 @@ impl OAuthDevicePollLease {
                 self.lease_id,
             )
         };
-        if matches!(verified, Err(OAuthFlowError::Missing))
-            && let Some(lifecycle) = &self.lifecycle
-        {
-            let _ = lifecycle.expire_device_flow(&self.target, &self.device_code);
-        }
-        let verified = verified?;
+        let verified = match verified {
+            Ok(verified) => verified,
+            Err(OAuthFlowError::Missing) => {
+                if self.terminal_flow_state_is_authmachine_owned()
+                    && let Some(lifecycle) = &self.lifecycle
+                {
+                    let _ = lifecycle.finish_device_poll(&self.target, &self.device_code);
+                }
+                return Err(self.local_missing_error("consume_oauth_device_flow"));
+            }
+            Err(err) => return Err(err),
+        };
 
         if let Some(lifecycle) = &self.lifecycle {
             lifecycle.consume_device_flow(&self.target, &self.device_code, self.provider)?;
@@ -657,7 +687,10 @@ impl OAuthDevicePollLease {
                 if let Some(lifecycle) = &self.lifecycle
                     && let Err(err) = lifecycle.device_flow_payload_removed(&record)
                 {
-                    if matches!(err, OAuthFlowError::Missing) {
+                    if matches!(
+                        err,
+                        OAuthFlowError::Missing | OAuthFlowError::RegistryProjectionMissing { .. }
+                    ) {
                         return Err(err);
                     }
                     let _ = lifecycle.restore_device_flow(&verified);
@@ -674,6 +707,11 @@ impl OAuthDevicePollLease {
                 Ok(record)
             }
             Err(err) => {
+                if matches!(err, OAuthFlowError::Missing)
+                    && self.terminal_flow_state_is_authmachine_owned()
+                {
+                    return Err(self.local_missing_error("consume_oauth_device_flow"));
+                }
                 if let Some(lifecycle) = &self.lifecycle {
                     let _ = lifecycle.restore_device_flow(&verified);
                     if matches!(err, OAuthFlowError::Missing) {
@@ -702,7 +740,11 @@ impl Drop for OAuthDevicePollLease {
         prune_expired_device_locked(&mut flows);
         if let Some(lifecycle) = &self.lifecycle {
             if matches!(result, Err(OAuthFlowError::Missing)) {
-                let _ = lifecycle.expire_device_flow(&self.target, &self.device_code);
+                if lifecycle.device_flow_state_is_authmachine_owned() {
+                    let _ = lifecycle.finish_device_poll(&self.target, &self.device_code);
+                } else {
+                    let _ = lifecycle.expire_device_flow(&self.target, &self.device_code);
+                }
             } else {
                 let _ = lifecycle.finish_device_poll(&self.target, &self.device_code);
             }
@@ -711,6 +753,10 @@ impl Drop for OAuthDevicePollLease {
 }
 
 pub trait OAuthFlowAuthority: Send + Sync {
+    fn terminal_flow_state_is_authmachine_owned(&self) -> bool {
+        false
+    }
+
     fn start(
         &self,
         target: ConnectionRef,

--- a/meerkat-rest/src/auth_endpoints.rs
+++ b/meerkat-rest/src/auth_endpoints.rs
@@ -165,6 +165,10 @@ fn oauth_device_state_error(err: OAuthFlowError) -> (StatusCode, String) {
             StatusCode::BAD_REQUEST,
             "oauth device code is missing or expired".to_string(),
         ),
+        OAuthFlowError::RegistryProjectionMissing { .. } => (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            format!("oauth device registry projection failed: {err}"),
+        ),
         other => (
             StatusCode::BAD_REQUEST,
             format!("oauth device state verification failed: {other}"),
@@ -491,6 +495,13 @@ async fn save_tokens_and_consume_device_flow_unlocked(
     tokens: &PersistedTokens,
     poll_lease: OAuthDevicePollLease,
 ) -> Result<(), (StatusCode, String)> {
+    if !poll_lease.terminal_flow_state_is_authmachine_owned() {
+        return Err((
+            StatusCode::INTERNAL_SERVER_ERROR,
+            "consume_oauth_device_flow requires an AuthMachine-owned OAuth device poll lease"
+                .to_string(),
+        ));
+    }
     verify_terminal_device_flow(&poll_lease)?;
     let prepared = prepare_token_commit_unlocked(token_store, connection_ref).await?;
     consume_terminal_device_flow(auth_lease, connection_ref, poll_lease)?;
@@ -538,6 +549,13 @@ async fn save_tokens_and_consume_browser_flow_unlocked(
     tokens: &PersistedTokens,
     flow: BrowserFlowConsume<'_>,
 ) -> Result<(), (StatusCode, String)> {
+    if !flow.authority.terminal_flow_state_is_authmachine_owned() {
+        return Err((
+            StatusCode::INTERNAL_SERVER_ERROR,
+            "consume_oauth_browser_flow requires an AuthMachine-owned OAuth flow authority"
+                .to_string(),
+        ));
+    }
     let prepared = prepare_token_commit_unlocked(token_store, connection_ref).await?;
     flow.authority
         .consume(flow.state, connection_ref, flow.provider, flow.redirect_uri)
@@ -1140,6 +1158,15 @@ pub async fn complete_login(
             return (
                 StatusCode::BAD_REQUEST,
                 Json(serde_json::json!({ "error": "oauth state is missing or expired" })),
+            )
+                .into_response();
+        }
+        Err(e @ OAuthFlowError::RegistryProjectionMissing { .. }) => {
+            return (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(
+                    serde_json::json!({ "error": format!("oauth registry projection failed: {e}") }),
+                ),
             )
                 .into_response();
         }
@@ -1956,6 +1983,10 @@ mod tests {
     struct RejectDeviceConsumeLifecycle;
 
     impl meerkat_providers::oauth_flow::OAuthDevicePollLifecycle for RejectDeviceConsumeLifecycle {
+        fn device_flow_state_is_authmachine_owned(&self) -> bool {
+            true
+        }
+
         fn finish_device_poll(
             &self,
             _target: &ConnectionRef,
@@ -1988,6 +2019,10 @@ mod tests {
     struct RejectBrowserConsumeAuthority;
 
     impl meerkat_providers::oauth_flow::OAuthFlowAuthority for RejectBrowserConsumeAuthority {
+        fn terminal_flow_state_is_authmachine_owned(&self) -> bool {
+            true
+        }
+
         fn start(
             &self,
             _target: ConnectionRef,
@@ -2506,7 +2541,10 @@ mod tests {
                 meerkat_providers::oauth_flow::OAuthProviderIdentity::OpenAiChatGpt,
                 redirect_uri,
             ),
-            Err(OAuthFlowError::Missing)
+            Err(OAuthFlowError::LifecycleRejected {
+                operation: "verify_oauth_browser_flow",
+                ..
+            })
         ));
         let flow = state
             .oauth_flow_authority()
@@ -2947,7 +2985,10 @@ mod tests {
                 &managed_connection_ref(),
                 meerkat_providers::oauth_flow::OAuthProviderIdentity::GoogleCodeAssist,
             ),
-            Err(OAuthFlowError::DevicePollInProgress)
+            Err(OAuthFlowError::LifecycleRejected {
+                operation: "begin_oauth_device_poll",
+                ..
+            })
         ));
 
         drop(poll);
@@ -2998,7 +3039,10 @@ mod tests {
                 &managed_connection_ref(),
                 meerkat_providers::oauth_flow::OAuthProviderIdentity::GoogleCodeAssist,
             ),
-            Err(OAuthFlowError::DevicePollInProgress)
+            Err(OAuthFlowError::LifecycleRejected {
+                operation: "begin_oauth_device_poll",
+                ..
+            })
         ));
 
         task.abort();
@@ -3129,7 +3173,12 @@ mod tests {
                 &managed_connection_ref(),
                 meerkat_providers::oauth_flow::OAuthProviderIdentity::GoogleCodeAssist,
             ),
-            Err(meerkat_providers::oauth_flow::OAuthFlowError::Missing)
+            Err(
+                meerkat_providers::oauth_flow::OAuthFlowError::LifecycleRejected {
+                    operation: "begin_oauth_device_poll",
+                    ..
+                }
+            )
         ));
     }
 
@@ -3237,6 +3286,112 @@ mod tests {
         );
         let snapshot = auth_lease.snapshot(&LeaseKey::from_connection_ref(&connection_ref));
         assert_eq!(snapshot.phase, None);
+    }
+
+    #[tokio::test]
+    async fn rest_raw_registry_browser_success_cannot_commit_tokens() {
+        let store = EphemeralTokenStore::new();
+        let auth_lease = RuntimeAuthLeaseHandle::new();
+        let connection_ref = managed_connection_ref();
+        let key = TokenKey::from_connection_ref(&connection_ref);
+        let redirect_uri = "http://127.0.0.1/callback";
+        let registry = meerkat_providers::oauth_flow::OAuthFlowRegistry::new(
+            std::time::Duration::from_secs(600),
+        );
+        let state = registry
+            .start(
+                connection_ref.clone(),
+                meerkat_providers::oauth_flow::OAuthProviderIdentity::OpenAiChatGpt,
+                redirect_uri.to_string(),
+                "registry-only-verifier".to_string(),
+            )
+            .expect("raw registry admits browser flow");
+
+        let err = save_tokens_and_consume_browser_flow(
+            &store,
+            &auth_lease,
+            &connection_ref,
+            &api_key_tokens(),
+            BrowserFlowConsume {
+                authority: &registry,
+                state: &state,
+                provider: meerkat_providers::oauth_flow::OAuthProviderIdentity::OpenAiChatGpt,
+                redirect_uri,
+            },
+        )
+        .await
+        .unwrap_err();
+
+        assert_eq!(err.0, StatusCode::INTERNAL_SERVER_ERROR);
+        assert!(err.1.contains("AuthMachine-owned OAuth flow authority"));
+        assert!(store.load(&key).await.unwrap().is_none());
+        assert_eq!(
+            auth_lease
+                .snapshot(&LeaseKey::from_connection_ref(&connection_ref))
+                .phase,
+            None
+        );
+        registry
+            .verify(
+                &state,
+                &connection_ref,
+                meerkat_providers::oauth_flow::OAuthProviderIdentity::OpenAiChatGpt,
+                redirect_uri,
+            )
+            .expect("raw registry success path is inert and remains unconsumed");
+    }
+
+    #[tokio::test]
+    async fn rest_raw_registry_device_success_cannot_commit_tokens() {
+        let store = EphemeralTokenStore::new();
+        let auth_lease = RuntimeAuthLeaseHandle::new();
+        let connection_ref = managed_connection_ref();
+        let key = TokenKey::from_connection_ref(&connection_ref);
+        let registry = meerkat_providers::oauth_flow::OAuthFlowRegistry::new(
+            std::time::Duration::from_secs(600),
+        );
+        registry
+            .admit_device_code(
+                connection_ref.clone(),
+                meerkat_providers::oauth_flow::OAuthProviderIdentity::GoogleCodeAssist,
+                "registry-only-device-code".to_string(),
+                std::time::Duration::from_secs(600),
+            )
+            .expect("raw registry admits device flow");
+        let poll_lease = registry
+            .begin_device_code_poll(
+                "registry-only-device-code",
+                &connection_ref,
+                meerkat_providers::oauth_flow::OAuthProviderIdentity::GoogleCodeAssist,
+            )
+            .expect("raw registry begins device poll");
+
+        let err = save_tokens_and_consume_device_flow(
+            &store,
+            &auth_lease,
+            &connection_ref,
+            &api_key_tokens(),
+            poll_lease,
+        )
+        .await
+        .unwrap_err();
+
+        assert_eq!(err.0, StatusCode::INTERNAL_SERVER_ERROR);
+        assert!(err.1.contains("AuthMachine-owned OAuth device poll lease"));
+        assert!(store.load(&key).await.unwrap().is_none());
+        assert_eq!(
+            auth_lease
+                .snapshot(&LeaseKey::from_connection_ref(&connection_ref))
+                .phase,
+            None
+        );
+        registry
+            .verify_device_code(
+                "registry-only-device-code",
+                &connection_ref,
+                meerkat_providers::oauth_flow::OAuthProviderIdentity::GoogleCodeAssist,
+            )
+            .expect("raw registry device success path is inert and remains unconsumed");
     }
 
     #[tokio::test]
@@ -3513,7 +3668,8 @@ mod tests {
         .unwrap_err();
 
         assert_eq!(err.0, StatusCode::INTERNAL_SERVER_ERROR);
-        assert!(err.1.contains("oauth state is missing or expired"));
+        assert!(err.1.contains("oauth state terminal consume failed"));
+        assert!(err.1.contains("verify_oauth_browser_flow"));
         assert!(store.load(&key).await.unwrap().is_none());
         let snapshot = auth_lease.snapshot(&LeaseKey::from_connection_ref(&connection_ref));
         assert_eq!(snapshot.phase, None);

--- a/meerkat-rpc/src/handlers/auth.rs
+++ b/meerkat-rpc/src/handlers/auth.rs
@@ -250,6 +250,11 @@ fn oauth_device_state_error(id: Option<RpcId>, err: OAuthFlowError) -> RpcRespon
             error::INVALID_PARAMS,
             "oauth device code is missing or expired",
         ),
+        OAuthFlowError::RegistryProjectionMissing { .. } => RpcResponse::error(
+            id,
+            error::INTERNAL_ERROR,
+            format!("oauth device registry projection failed: {err}"),
+        ),
         other => RpcResponse::error(
             id,
             error::INVALID_PARAMS,
@@ -582,6 +587,13 @@ async fn save_tokens_and_consume_device_flow_unlocked(
     tokens: &PersistedTokens,
     poll_lease: OAuthDevicePollLease,
 ) -> Option<RpcResponse> {
+    if !poll_lease.terminal_flow_state_is_authmachine_owned() {
+        return Some(RpcResponse::error(
+            id,
+            error::INTERNAL_ERROR,
+            "consume_oauth_device_flow requires an AuthMachine-owned OAuth device poll lease",
+        ));
+    }
     if let Some(resp) = verify_terminal_device_flow(id.clone(), &poll_lease) {
         return Some(resp);
     }
@@ -643,6 +655,13 @@ async fn save_tokens_and_consume_browser_flow_unlocked(
     tokens: &PersistedTokens,
     flow: BrowserFlowConsume<'_>,
 ) -> Result<(), RpcResponse> {
+    if !flow.authority.terminal_flow_state_is_authmachine_owned() {
+        return Err(RpcResponse::error(
+            id,
+            error::INTERNAL_ERROR,
+            "consume_oauth_browser_flow requires an AuthMachine-owned OAuth flow authority",
+        ));
+    }
     let prepared = prepare_token_commit_unlocked(id.clone(), store, connection_ref).await?;
     flow.authority
         .consume(flow.state, connection_ref, flow.provider, flow.redirect_uri)
@@ -1136,6 +1155,13 @@ pub async fn handle_auth_login_complete(
                 id,
                 error::INVALID_PARAMS,
                 "oauth state is missing or expired",
+            );
+        }
+        Err(e @ OAuthFlowError::RegistryProjectionMissing { .. }) => {
+            return RpcResponse::error(
+                id,
+                error::INTERNAL_ERROR,
+                format!("oauth registry projection failed: {e}"),
             );
         }
         Err(e) => {
@@ -2357,6 +2383,10 @@ mod tests {
     struct RejectDeviceConsumeLifecycle;
 
     impl meerkat_providers::oauth_flow::OAuthDevicePollLifecycle for RejectDeviceConsumeLifecycle {
+        fn device_flow_state_is_authmachine_owned(&self) -> bool {
+            true
+        }
+
         fn finish_device_poll(
             &self,
             _target: &ConnectionRef,
@@ -2389,6 +2419,10 @@ mod tests {
     struct RejectBrowserConsumeAuthority;
 
     impl meerkat_providers::oauth_flow::OAuthFlowAuthority for RejectBrowserConsumeAuthority {
+        fn terminal_flow_state_is_authmachine_owned(&self) -> bool {
+            true
+        }
+
         fn start(
             &self,
             _target: ConnectionRef,
@@ -2635,7 +2669,10 @@ mod tests {
                 meerkat_providers::oauth_flow::OAuthProviderIdentity::OpenAiChatGpt,
                 redirect_uri,
             ),
-            Err(OAuthFlowError::Missing)
+            Err(OAuthFlowError::LifecycleRejected {
+                operation: "verify_oauth_browser_flow",
+                ..
+            })
         ));
         let flow = runtime
             .oauth_flow_authority()
@@ -3026,7 +3063,10 @@ mod tests {
                 &openai_connection_ref(),
                 meerkat_providers::oauth_flow::OAuthProviderIdentity::GoogleCodeAssist,
             ),
-            Err(OAuthFlowError::DevicePollInProgress)
+            Err(OAuthFlowError::LifecycleRejected {
+                operation: "begin_oauth_device_poll",
+                ..
+            })
         ));
 
         drop(poll);
@@ -3074,7 +3114,10 @@ mod tests {
                 &openai_connection_ref(),
                 meerkat_providers::oauth_flow::OAuthProviderIdentity::GoogleCodeAssist,
             ),
-            Err(OAuthFlowError::DevicePollInProgress)
+            Err(OAuthFlowError::LifecycleRejected {
+                operation: "begin_oauth_device_poll",
+                ..
+            })
         ));
 
         task.abort();
@@ -3538,7 +3581,12 @@ mod tests {
                 &connection_ref,
                 meerkat_providers::oauth_flow::OAuthProviderIdentity::GoogleCodeAssist,
             ),
-            Err(meerkat_providers::oauth_flow::OAuthFlowError::Missing)
+            Err(
+                meerkat_providers::oauth_flow::OAuthFlowError::LifecycleRejected {
+                    operation: "begin_oauth_device_poll",
+                    ..
+                }
+            )
         ));
     }
 
@@ -3676,6 +3724,134 @@ mod tests {
         );
         let snapshot = auth_lease.snapshot(&LeaseKey::from_connection_ref(&connection_ref));
         assert_eq!(snapshot.phase, None);
+    }
+
+    #[tokio::test]
+    async fn raw_registry_browser_success_cannot_commit_tokens() {
+        let runtime = test_runtime_with_config(config_with_openai_managed_store_binding());
+        let store = runtime.token_store().expect("test token store");
+        let auth_lease = runtime.auth_lease_handle();
+        let connection_ref = ConnectionRef {
+            realm: meerkat_core::RealmId::parse("dev").unwrap(),
+            binding: meerkat_core::BindingId::parse("default_openai").unwrap(),
+            profile: None,
+        };
+        let key = TokenKey::from_connection_ref(&connection_ref);
+        let redirect_uri = "http://127.0.0.1/callback";
+        let registry = meerkat_providers::oauth_flow::OAuthFlowRegistry::new(
+            std::time::Duration::from_secs(600),
+        );
+        let state = registry
+            .start(
+                connection_ref.clone(),
+                meerkat_providers::oauth_flow::OAuthProviderIdentity::OpenAiChatGpt,
+                redirect_uri.to_string(),
+                "registry-only-verifier".to_string(),
+            )
+            .expect("raw registry admits browser flow");
+
+        let resp = save_tokens_and_consume_browser_flow(
+            Some(RpcId::Num(1)),
+            &store,
+            &runtime,
+            &connection_ref,
+            &PersistedTokens::api_key("sk-new"),
+            BrowserFlowConsume {
+                authority: &registry,
+                state: &state,
+                provider: meerkat_providers::oauth_flow::OAuthProviderIdentity::OpenAiChatGpt,
+                redirect_uri,
+            },
+        )
+        .await
+        .expect_err("raw registry must not commit tokens");
+
+        let error = resp.error.expect("consume should return RPC error");
+        assert_eq!(error.code, crate::error::INTERNAL_ERROR);
+        assert!(
+            error
+                .message
+                .contains("AuthMachine-owned OAuth flow authority")
+        );
+        assert!(store.load(&key).await.unwrap().is_none());
+        assert_eq!(
+            auth_lease
+                .snapshot(&LeaseKey::from_connection_ref(&connection_ref))
+                .phase,
+            None
+        );
+        registry
+            .verify(
+                &state,
+                &connection_ref,
+                meerkat_providers::oauth_flow::OAuthProviderIdentity::OpenAiChatGpt,
+                redirect_uri,
+            )
+            .expect("raw registry success path is inert and remains unconsumed");
+    }
+
+    #[tokio::test]
+    async fn raw_registry_device_success_cannot_commit_tokens() {
+        let runtime = test_runtime_with_config(config_with_openai_managed_store_binding());
+        let store = runtime.token_store().expect("test token store");
+        let auth_lease = runtime.auth_lease_handle();
+        let connection_ref = ConnectionRef {
+            realm: meerkat_core::RealmId::parse("dev").unwrap(),
+            binding: meerkat_core::BindingId::parse("default_openai").unwrap(),
+            profile: None,
+        };
+        let key = TokenKey::from_connection_ref(&connection_ref);
+        let registry = meerkat_providers::oauth_flow::OAuthFlowRegistry::new(
+            std::time::Duration::from_secs(600),
+        );
+        registry
+            .admit_device_code(
+                connection_ref.clone(),
+                meerkat_providers::oauth_flow::OAuthProviderIdentity::GoogleCodeAssist,
+                "registry-only-device-code".to_string(),
+                std::time::Duration::from_secs(600),
+            )
+            .expect("raw registry admits device flow");
+        let poll_lease = registry
+            .begin_device_code_poll(
+                "registry-only-device-code",
+                &connection_ref,
+                meerkat_providers::oauth_flow::OAuthProviderIdentity::GoogleCodeAssist,
+            )
+            .expect("raw registry begins device poll");
+
+        let resp = save_tokens_and_consume_device_flow(
+            Some(RpcId::Num(1)),
+            &store,
+            &runtime,
+            &connection_ref,
+            &PersistedTokens::api_key("sk-new"),
+            poll_lease,
+        )
+        .await
+        .expect("raw registry must not commit tokens");
+
+        let error = resp.error.expect("consume should return RPC error");
+        assert_eq!(error.code, crate::error::INTERNAL_ERROR);
+        assert!(
+            error
+                .message
+                .contains("AuthMachine-owned OAuth device poll lease")
+        );
+        assert!(store.load(&key).await.unwrap().is_none());
+        assert_eq!(
+            auth_lease
+                .snapshot(&LeaseKey::from_connection_ref(&connection_ref))
+                .phase,
+            None
+        );
+        registry
+            .verify_device_code(
+                "registry-only-device-code",
+                &connection_ref,
+                meerkat_providers::oauth_flow::OAuthProviderIdentity::GoogleCodeAssist,
+            )
+            .expect("raw registry device success path is inert and remains unconsumed");
     }
 
     #[tokio::test]
@@ -3981,7 +4157,12 @@ mod tests {
 
         let error = resp.error.expect("consume should return RPC error");
         assert_eq!(error.code, crate::error::INTERNAL_ERROR);
-        assert!(error.message.contains("oauth state is missing or expired"));
+        assert!(
+            error
+                .message
+                .contains("oauth state terminal consume failed")
+        );
+        assert!(error.message.contains("verify_oauth_browser_flow"));
         assert!(store.load(&key).await.unwrap().is_none());
         let snapshot = auth_lease.snapshot(&LeaseKey::from_connection_ref(&connection_ref));
         assert_eq!(snapshot.phase, None);

--- a/meerkat-runtime/src/handles/oauth_flow.rs
+++ b/meerkat-runtime/src/handles/oauth_flow.rs
@@ -995,7 +995,7 @@ fn persist_registry_snapshot(
         Err(crate::store::RuntimeStoreError::NotFound(_))
             if policy.removal_mode == SnapshotRemovalMode::Claim =>
         {
-            Err(OAuthFlowError::Missing)
+            Err(OAuthFlowError::RegistryProjectionMissing { operation })
         }
         Err(crate::store::RuntimeStoreError::Internal(detail))
             if policy.admission_capacity.is_some() && detail == DURABLE_OAUTH_CAPACITY_EXCEEDED =>
@@ -1195,6 +1195,10 @@ impl Default for RuntimeOAuthFlowHandle {
 }
 
 impl OAuthDevicePollLifecycle for RuntimeAuthLeaseHandle {
+    fn device_flow_state_is_authmachine_owned(&self) -> bool {
+        true
+    }
+
     fn finish_device_poll(
         &self,
         target: &ConnectionRef,
@@ -1280,6 +1284,10 @@ impl OAuthDevicePollLifecycle for RuntimeAuthLeaseHandle {
 }
 
 impl OAuthDevicePollLifecycle for RuntimeOAuthDevicePollLifecycle {
+    fn device_flow_state_is_authmachine_owned(&self) -> bool {
+        true
+    }
+
     fn finish_device_poll(
         &self,
         target: &ConnectionRef,
@@ -1346,7 +1354,7 @@ impl OAuthDevicePollLifecycle for RuntimeOAuthDevicePollLifecycle {
         persist_registry_payloads_claiming_removal(
             &self.registry,
             &self.store,
-            "persist_oauth_device_flow_payloads",
+            "consume_oauth_device_flow",
             &[],
             &removed,
         )
@@ -1354,6 +1362,10 @@ impl OAuthDevicePollLifecycle for RuntimeOAuthDevicePollLifecycle {
 }
 
 impl OAuthFlowAuthority for RuntimeOAuthFlowHandle {
+    fn terminal_flow_state_is_authmachine_owned(&self) -> bool {
+        true
+    }
+
     fn start(
         &self,
         target: ConnectionRef,
@@ -1435,21 +1447,12 @@ impl OAuthFlowAuthority for RuntimeOAuthFlowHandle {
             .unwrap_or_else(std::sync::PoisonError::into_inner);
         self.sync_persisted_payloads("verify_oauth_browser_flow")?;
         self.expire_pruned_flows();
-        if let Err(machine_err) = self.verify_browser(target, state, provider, redirect_uri) {
-            return match self.registry.verify(state, target, provider, redirect_uri) {
-                Err(OAuthFlowError::Missing) => {
-                    let _ = self.expire_browser(target, state);
-                    Err(OAuthFlowError::Missing)
-                }
-                _ => Err(machine_err),
-            };
-        }
+        self.verify_browser(target, state, provider, redirect_uri)?;
         match self.registry.verify(state, target, provider, redirect_uri) {
             Ok(record) => Ok(record),
-            Err(OAuthFlowError::Missing) => {
-                let _ = self.expire_browser(target, state);
-                Err(OAuthFlowError::Missing)
-            }
+            Err(OAuthFlowError::Missing) => Err(OAuthFlowError::RegistryProjectionMissing {
+                operation: "verify_oauth_browser_flow",
+            }),
             Err(err) => Err(err),
         }
     }
@@ -1467,28 +1470,25 @@ impl OAuthFlowAuthority for RuntimeOAuthFlowHandle {
             .unwrap_or_else(std::sync::PoisonError::into_inner);
         self.sync_persisted_payloads("consume_oauth_browser_flow")?;
         self.expire_pruned_flows();
-        if let Err(machine_err) = self.verify_browser(target, state, provider, redirect_uri) {
-            return match self.registry.verify(state, target, provider, redirect_uri) {
-                Err(OAuthFlowError::Missing) => {
-                    let _ = self.expire_browser(target, state);
-                    Err(OAuthFlowError::Missing)
-                }
-                _ => Err(machine_err),
-            };
-        }
+        self.verify_browser(target, state, provider, redirect_uri)?;
         let record = match self.registry.verify(state, target, provider, redirect_uri) {
             Ok(record) => record,
-            Err(err) => {
-                if matches!(err, OAuthFlowError::Missing) {
-                    let _ = self.expire_browser(target, state);
-                }
-                return Err(err);
+            Err(OAuthFlowError::Missing) => {
+                return Err(OAuthFlowError::RegistryProjectionMissing {
+                    operation: "consume_oauth_browser_flow",
+                });
             }
+            Err(err) => return Err(err),
         };
         self.consume_browser(target, state, provider, redirect_uri)?;
         if let Err(err) = self.registry.consume(state, target, provider, redirect_uri) {
             let _ = self.restore_browser_flow(state, &record);
-            return Err(err);
+            return Err(match err {
+                OAuthFlowError::Missing => OAuthFlowError::RegistryProjectionMissing {
+                    operation: "consume_oauth_browser_flow",
+                },
+                other => other,
+            });
         }
         let removed_browser = [browser_snapshot_key(target, state)];
         if let Err(err) = self.persist_registry_payloads_claiming_removal(
@@ -1496,7 +1496,10 @@ impl OAuthFlowAuthority for RuntimeOAuthFlowHandle {
             &removed_browser,
             &[],
         ) {
-            if matches!(err, OAuthFlowError::Missing) {
+            if matches!(
+                err,
+                OAuthFlowError::Missing | OAuthFlowError::RegistryProjectionMissing { .. }
+            ) {
                 return Err(err);
             }
             let _ = self.restore_browser_flow(state, &record);
@@ -1519,30 +1522,7 @@ impl OAuthFlowAuthority for RuntimeOAuthFlowHandle {
         self.sync_persisted_payloads("admit_oauth_device_flow")?;
         self.expire_pruned_flows();
         let machine_expires_at = expires_at_millis(expires_in)?;
-        if let Err(err) = self.admit_device(&target, &device_code, provider, machine_expires_at) {
-            match self
-                .registry
-                .verify_device_code(&device_code, &target, provider)
-            {
-                Err(OAuthFlowError::Missing) => {
-                    if self
-                        .lifecycle
-                        .expire_device_flow(&target, &device_code)
-                        .is_ok()
-                        && self
-                            .admit_device(&target, &device_code, provider, machine_expires_at)
-                            .is_ok()
-                    {
-                        // Recovered stale AuthMachine membership left behind after
-                        // registry-only cleanup; continue with payload insertion.
-                    } else {
-                        return Err(err);
-                    }
-                }
-                Ok(_) => return Err(OAuthFlowError::DeviceCodeAlreadyAdmitted),
-                Err(_) => return Err(err),
-            }
-        }
+        self.admit_device(&target, &device_code, provider, machine_expires_at)?;
         let mut inserted = self.registry.admit_device_code_with_pruned(
             target.clone(),
             provider,
@@ -1605,27 +1585,15 @@ impl OAuthFlowAuthority for RuntimeOAuthFlowHandle {
             .unwrap_or_else(std::sync::PoisonError::into_inner);
         self.sync_persisted_payloads("verify_oauth_device_flow")?;
         self.expire_pruned_flows();
-        if let Err(machine_err) = self.verify_device(target, device_code, provider) {
-            return match self
-                .registry
-                .verify_device_code(device_code, target, provider)
-            {
-                Err(OAuthFlowError::Missing) => {
-                    let _ = self.lifecycle.expire_device_flow(target, device_code);
-                    Err(OAuthFlowError::Missing)
-                }
-                _ => Err(machine_err),
-            };
-        }
+        self.verify_device(target, device_code, provider)?;
         match self
             .registry
             .verify_device_code(device_code, target, provider)
         {
             Ok(record) => Ok(record),
-            Err(OAuthFlowError::Missing) => {
-                let _ = self.lifecycle.expire_device_flow(target, device_code);
-                Err(OAuthFlowError::Missing)
-            }
+            Err(OAuthFlowError::Missing) => Err(OAuthFlowError::RegistryProjectionMissing {
+                operation: "verify_oauth_device_flow",
+            }),
             Err(err) => Err(err),
         }
     }
@@ -1642,33 +1610,17 @@ impl OAuthFlowAuthority for RuntimeOAuthFlowHandle {
             .unwrap_or_else(std::sync::PoisonError::into_inner);
         self.sync_persisted_payloads("begin_oauth_device_poll")?;
         self.expire_pruned_flows();
-        if let Err(machine_err) = self.begin_device_poll(target, device_code, provider) {
-            return match self
-                .registry
-                .begin_device_code_poll(device_code, target, provider)
-            {
-                Err(OAuthFlowError::DevicePollInProgress) => {
-                    Err(OAuthFlowError::DevicePollInProgress)
-                }
-                Err(OAuthFlowError::Missing) => {
-                    let _ = self.lifecycle.expire_device_flow(target, device_code);
-                    Err(OAuthFlowError::Missing)
-                }
-                Ok(poll) => {
-                    drop(poll);
-                    Err(machine_err)
-                }
-                Err(_) => Err(machine_err),
-            };
-        }
+        self.begin_device_poll(target, device_code, provider)?;
         let poll = match self
             .registry
             .begin_device_code_poll(device_code, target, provider)
         {
             Ok(poll) => poll,
             Err(OAuthFlowError::Missing) => {
-                let _ = self.lifecycle.expire_device_flow(target, device_code);
-                return Err(OAuthFlowError::Missing);
+                let _ = self.lifecycle.finish_device_poll(target, device_code);
+                return Err(OAuthFlowError::RegistryProjectionMissing {
+                    operation: "begin_oauth_device_poll",
+                });
             }
             Err(err) => {
                 let _ = self.lifecycle.finish_device_poll(target, device_code);
@@ -2012,6 +1964,92 @@ mod tests {
     }
 
     #[test]
+    fn missing_browser_projection_cannot_overwrite_authmachine_flow() {
+        let lifecycle = Arc::new(RuntimeAuthLeaseHandle::new());
+        let authority =
+            RuntimeOAuthFlowHandle::new_with_auth_lease(Duration::from_secs(60), lifecycle.clone());
+        let target = target();
+        let provider = OAuthProviderIdentity::OpenAiChatGpt;
+        let redirect_uri = "http://127.0.0.1/callback";
+        let state = authority
+            .start(
+                target.clone(),
+                provider,
+                redirect_uri.to_string(),
+                "verifier".to_string(),
+            )
+            .expect("browser flow admitted");
+
+        authority
+            .registry
+            .consume(&state, &target, provider, redirect_uri)
+            .expect("test removes only the local registry payload");
+
+        assert!(matches!(
+            authority.verify(&state, &target, provider, redirect_uri),
+            Err(OAuthFlowError::RegistryProjectionMissing {
+                operation: "verify_oauth_browser_flow"
+            })
+        ));
+        assert!(
+            lifecycle.has_oauth_browser_flow_for_test(&target, &state),
+            "missing process-local registry payload must not expire canonical AuthMachine membership"
+        );
+
+        assert!(matches!(
+            authority.consume(&state, &target, provider, redirect_uri),
+            Err(OAuthFlowError::RegistryProjectionMissing {
+                operation: "consume_oauth_browser_flow"
+            })
+        ));
+        assert!(
+            lifecycle.has_oauth_browser_flow_for_test(&target, &state),
+            "terminal consume must fail closed instead of converting payload loss to not-found"
+        );
+        assert_eq!(
+            snapshot_phase(&lifecycle, &target),
+            Some(AuthLeasePhase::ReauthRequired)
+        );
+    }
+
+    #[test]
+    fn missing_device_poll_projection_cannot_overwrite_authmachine_flow() {
+        let lifecycle = Arc::new(RuntimeAuthLeaseHandle::new());
+        let authority =
+            RuntimeOAuthFlowHandle::new_with_auth_lease(Duration::from_secs(60), lifecycle.clone());
+        let target = target();
+        let provider = OAuthProviderIdentity::GoogleCodeAssist;
+        let device_code = "provider-device-code";
+
+        authority
+            .admit_device_code(
+                target.clone(),
+                provider,
+                device_code.to_string(),
+                Duration::from_secs(60),
+            )
+            .expect("device flow admitted");
+        let poll = authority
+            .begin_device_code_poll(device_code, &target, provider)
+            .expect("device poll begins");
+        authority
+            .registry
+            .expire_device_code(device_code, &target, provider)
+            .expect("test removes only the local registry payload");
+
+        assert!(matches!(
+            poll.consume(),
+            Err(OAuthFlowError::RegistryProjectionMissing {
+                operation: "consume_oauth_device_flow"
+            })
+        ));
+        assert!(
+            lifecycle.has_oauth_device_flow_for_test(&target, device_code),
+            "missing process-local poll payload must not expire canonical AuthMachine membership"
+        );
+    }
+
+    #[test]
     fn browser_admit_persistence_failure_rolls_back_unreturned_flow() {
         let lifecycle = Arc::new(RuntimeAuthLeaseHandle::new());
         let store = Arc::new(FailingOAuthSnapshotStore::default());
@@ -2303,7 +2341,10 @@ mod tests {
         );
         assert!(matches!(
             restarted.consume(&consumed_state, &target, provider, redirect_uri),
-            Err(OAuthFlowError::Missing)
+            Err(OAuthFlowError::LifecycleRejected {
+                operation: "verify_oauth_browser_flow",
+                ..
+            })
         ));
         restarted
             .consume(
@@ -2404,7 +2445,10 @@ mod tests {
         );
         assert!(matches!(
             restarted.verify_device_code(consumed_device_code, &target, provider),
-            Err(OAuthFlowError::Missing)
+            Err(OAuthFlowError::LifecycleRejected {
+                operation: "verify_oauth_device_flow",
+                ..
+            })
         ));
         restarted
             .verify_device_code(replacement_device_code, &replacement_target, provider)
@@ -2485,7 +2529,10 @@ mod tests {
         );
         assert!(matches!(
             restarted.verify_device_code(device_code, &target, provider),
-            Err(OAuthFlowError::Missing)
+            Err(OAuthFlowError::LifecycleRejected {
+                operation: "verify_oauth_device_flow",
+                ..
+            })
         ));
     }
 
@@ -2666,7 +2713,9 @@ mod tests {
             first_consume
                 .join()
                 .expect("first consume thread should not panic"),
-            Err(OAuthFlowError::Missing)
+            Err(OAuthFlowError::RegistryProjectionMissing {
+                operation: "consume_oauth_browser_flow"
+            })
         ));
     }
 
@@ -2719,7 +2768,9 @@ mod tests {
             first_consume
                 .join()
                 .expect("first device consume thread should not panic"),
-            Err(OAuthFlowError::Missing)
+            Err(OAuthFlowError::RegistryProjectionMissing {
+                operation: "consume_oauth_device_flow"
+            })
         ));
     }
 
@@ -3150,11 +3201,23 @@ mod tests {
         let device_after_release =
             restarted.verify_device_code(device_code, &target, device_provider);
         assert!(
-            matches!(browser_after_release, Err(OAuthFlowError::Missing)),
+            matches!(
+                browser_after_release,
+                Err(OAuthFlowError::LifecycleRejected {
+                    operation: "verify_oauth_browser_flow",
+                    ..
+                })
+            ),
             "release from a stale authority must prune durable browser flow, got {browser_after_release:?}"
         );
         assert!(
-            matches!(device_after_release, Err(OAuthFlowError::Missing)),
+            matches!(
+                device_after_release,
+                Err(OAuthFlowError::LifecycleRejected {
+                    operation: "verify_oauth_device_flow",
+                    ..
+                })
+            ),
             "release from a stale authority must prune durable device flow, got {device_after_release:?}"
         );
         drop(releasing_authority);
@@ -3280,7 +3343,7 @@ mod tests {
     }
 
     #[test]
-    fn device_admit_recovers_registry_pruned_stale_lifecycle_membership() {
+    fn device_admit_rejects_registry_pruned_canonical_membership() {
         let lifecycle = Arc::new(RuntimeAuthLeaseHandle::new());
         let authority =
             RuntimeOAuthFlowHandle::new_with_auth_lease(Duration::from_secs(60), lifecycle.clone());
@@ -3303,16 +3366,39 @@ mod tests {
             .expect("test removes registry record without lifecycle cleanup");
         assert!(lifecycle.has_oauth_device_flow_for_test(&target, device_code));
 
-        authority
-            .admit_device_code(
+        assert!(matches!(
+            authority.admit_device_code(
                 target.clone(),
                 provider,
                 device_code.to_string(),
                 Duration::from_secs(60),
-            )
-            .expect("stale lifecycle membership is expired before readmit");
+            ),
+            Err(OAuthFlowError::LifecycleRejected {
+                operation: "admit_oauth_device_flow",
+                ..
+            })
+        ));
 
-        assert!(lifecycle.has_oauth_device_flow_for_test(&target, device_code));
+        assert!(
+            lifecycle.has_oauth_device_flow_for_test(&target, device_code),
+            "registry-only loss must not expire canonical AuthMachine device membership"
+        );
+        assert!(matches!(
+            authority.verify_device_code(device_code, &target, provider),
+            Err(OAuthFlowError::RegistryProjectionMissing {
+                operation: "verify_oauth_device_flow"
+            })
+        ));
+        assert!(matches!(
+            authority.begin_device_code_poll(device_code, &target, provider),
+            Err(OAuthFlowError::RegistryProjectionMissing {
+                operation: "begin_oauth_device_poll"
+            })
+        ));
+        assert!(
+            lifecycle.has_oauth_device_flow_for_test(&target, device_code),
+            "missing process-local device payload must fail closed without removing the flow"
+        );
     }
 
     #[test]
@@ -3339,7 +3425,13 @@ mod tests {
             Duration::from_secs(60),
         );
 
-        assert_eq!(duplicate, Err(OAuthFlowError::DeviceCodeAlreadyAdmitted));
+        assert!(matches!(
+            duplicate,
+            Err(OAuthFlowError::LifecycleRejected {
+                operation: "admit_oauth_device_flow",
+                ..
+            })
+        ));
         assert!(lifecycle.has_oauth_device_flow_for_test(&target, device_code));
         authority
             .begin_device_code_poll(device_code, &target, provider)
@@ -3437,7 +3529,10 @@ mod tests {
         assert_eq!(flow.pkce_verifier, "new-verifier");
         assert!(matches!(
             authority.consume(&old_state, &target, provider, redirect_uri),
-            Err(OAuthFlowError::Missing)
+            Err(OAuthFlowError::LifecycleRejected {
+                operation: "verify_oauth_browser_flow",
+                ..
+            })
         ));
     }
 

--- a/meerkat-runtime/src/meerkat_machine_tests.rs
+++ b/meerkat-runtime/src/meerkat_machine_tests.rs
@@ -480,7 +480,10 @@ fn persistent_oauth_device_consume_prunes_durable_snapshot_for_sqlite_store() {
         .expect_err("consumed device payload must not rehydrate from durable snapshot");
     assert!(matches!(
         err,
-        meerkat_auth_core::oauth_flow::OAuthFlowError::Missing
+        meerkat_auth_core::oauth_flow::OAuthFlowError::LifecycleRejected {
+            operation: "begin_oauth_device_poll",
+            ..
+        }
     ));
 }
 
@@ -534,7 +537,10 @@ fn persistent_oauth_authority_cache_rebinds_reopened_sqlite_store_after_drop() {
         .expect_err("consumed browser payload must not rehydrate after reopened-store consume");
     assert!(matches!(
         err,
-        meerkat_auth_core::oauth_flow::OAuthFlowError::Missing
+        meerkat_auth_core::oauth_flow::OAuthFlowError::LifecycleRejected {
+            operation: "verify_oauth_browser_flow",
+            ..
+        }
     ));
 }
 
@@ -588,7 +594,10 @@ fn persistent_oauth_authority_cache_rebinds_overlapping_reopened_sqlite_store() 
         .expect_err("consumed browser payload must not rehydrate after overlapping-store consume");
     assert!(matches!(
         err,
-        meerkat_auth_core::oauth_flow::OAuthFlowError::Missing
+        meerkat_auth_core::oauth_flow::OAuthFlowError::LifecycleRejected {
+            operation: "verify_oauth_browser_flow",
+            ..
+        }
     ));
 }
 
@@ -646,7 +655,10 @@ fn persistent_oauth_release_prunes_durable_payload_snapshot_for_sqlite_store() {
         .expect_err("released browser payload must not rehydrate from durable snapshot");
     assert!(matches!(
         browser_err,
-        meerkat_auth_core::oauth_flow::OAuthFlowError::Missing
+        meerkat_auth_core::oauth_flow::OAuthFlowError::LifecycleRejected {
+            operation: "verify_oauth_browser_flow",
+            ..
+        }
     ));
 
     let device_err = restarted
@@ -655,7 +667,10 @@ fn persistent_oauth_release_prunes_durable_payload_snapshot_for_sqlite_store() {
         .expect_err("released device payload must not rehydrate from durable snapshot");
     assert!(matches!(
         device_err,
-        meerkat_auth_core::oauth_flow::OAuthFlowError::Missing
+        meerkat_auth_core::oauth_flow::OAuthFlowError::LifecycleRejected {
+            operation: "begin_oauth_device_poll",
+            ..
+        }
     ));
 }
 
@@ -733,7 +748,12 @@ fn oauth_lifecycle_shares_auth_machine_release_authority() {
             meerkat_auth_core::oauth_flow::OAuthProviderIdentity::OpenAiChatGpt,
             redirect_uri,
         ),
-        Err(meerkat_auth_core::oauth_flow::OAuthFlowError::Missing)
+        Err(
+            meerkat_auth_core::oauth_flow::OAuthFlowError::LifecycleRejected {
+                operation: "verify_oauth_browser_flow",
+                ..
+            }
+        )
     ));
 }
 
@@ -770,7 +790,12 @@ fn oauth_lifecycle_release_stays_paired_after_custom_auth_handle_install() {
             meerkat_auth_core::oauth_flow::OAuthProviderIdentity::OpenAiChatGpt,
             redirect_uri,
         ),
-        Err(meerkat_auth_core::oauth_flow::OAuthFlowError::Missing)
+        Err(
+            meerkat_auth_core::oauth_flow::OAuthFlowError::LifecycleRejected {
+                operation: "verify_oauth_browser_flow",
+                ..
+            }
+        )
     ));
 }
 


### PR DESCRIPTION
## Summary
- make AuthMachine lifecycle evidence authoritative before OAuth browser/device terminal paths consult registry projections
- fail closed with typed registry projection errors instead of local Missing expiring canonical OAuth state
- require AuthMachine-owned browser authorities and device poll leases before REST/RPC token commit helpers save tokens

Dogma cleanup PR: yes

## Validation
- ./scripts/repo-cargo test -p meerkat-auth-core oauth_device
- ./scripts/repo-cargo test -p meerkat-runtime oauth_flow
- ./scripts/repo-cargo test -p meerkat-rest rest_raw_registry_device_success_cannot_commit_tokens
- ./scripts/repo-cargo test -p meerkat-rest rest_ready_device_consume_failure_does_not_commit_token
- ./scripts/repo-cargo test -p meerkat-rpc raw_registry_device_success_cannot_commit_tokens
- ./scripts/repo-cargo test -p meerkat-rpc ready_device_consume_failure_does_not_commit_token
- make check
- make test

Linear: LUC-373

## Review Readiness Packet

Current head SHA: 0b4ed4a94bdbf86ffde189b9288e475ead9f1c0d

Command output:

```text
$ make dogma-cleanup-gate DOGMA_PACKET=/tmp/luc-373-review-readiness.md
Dogma cleanup gate passed for /tmp/luc-373-review-readiness.md
```

## Old Path Amputation Proof

| Old path | Classification | Search literal | Mechanical proof | Follow-up |
| --- | --- | --- | --- | --- |
| `RuntimeOAuthFlowHandle registry-owned missing-fallback terminal path` | made uncallable at boundary | `registry-owned missing-fallback terminal path` | Production handler rejects requests by requiring AuthMachine verification before the registry projection; missing local payload returns `RegistryProjectionMissing` and does not call registry expiry. | none |
| `OAuthDevicePollLease local Missing expires canonical device flow path` | made uncallable at boundary | `local Missing expires canonical device flow path` | Production handler rejects calls through AuthMachine-owned poll leases by converting local `Missing` into `RegistryProjectionMissing` or `finish_oauth_device_poll` instead of `expire_oauth_device_flow`. | none |
| `REST/RPC raw OAuthFlowRegistry terminal token commit path` | made uncallable at boundary | `raw OAuthFlowRegistry terminal token commit path` | Production API rejects requests when `terminal_flow_state_is_authmachine_owned()` is false, so a raw registry browser success cannot enter token save. | none |
| `REST/RPC raw OAuthDevicePollLease terminal token commit path` | made uncallable at boundary | `raw OAuthDevicePollLease terminal token commit path` | Production API rejects requests when `terminal_flow_state_is_authmachine_owned()` is false, so a raw device poll lease cannot enter token save. | none |

## Complexity Delta

- Docs/scripts/tests: 0 files.
- Non-test implementation: 5 files.
- Generated/schema churn: 0 files.

## Sample Passing Old Path Amputation Proof

| Old path | Classification | Search literal | Mechanical proof | Follow-up |
| --- | --- | --- | --- | --- |
| `old/session-route` | deleted | `old/session-route` | No production references remain. | none |

## Sample Failing Old Path Amputation Proof

| Old path | Classification | Search literal | Mechanical proof | Follow-up |
| --- | --- | --- | --- | --- |
| `old/session-route` | wrapped | `old/session-route` | A preferred path exists beside the old route. | none |
