### PR TITLE
Remove recovered runtime force-authority fallback

### DIFF
--- a/meerkat-runtime/src/driver/ephemeral.rs
+++ b/meerkat-runtime/src/driver/ephemeral.rs
@@ -1105,6 +1105,176 @@ impl EphemeralRuntimeDriver {
         self.set_control_projection(next_phase, current_run_id, pre_run_phase);
     }
 
+    fn contract_session_authority_id(&self) -> mm_dsl::SessionId {
+        mm_dsl::SessionId::from(self.runtime_id.to_string())
+    }
+
+    fn ensure_contract_session_authority(
+        &mut self,
+    ) -> Result<mm_dsl::SessionId, RuntimeDriverError> {
+        let existing = {
+            let authority = self.shared_dsl_authority();
+            let authority = authority
+                .lock()
+                .unwrap_or_else(std::sync::PoisonError::into_inner);
+            authority.state.session_id.clone()
+        };
+        if let Some(session_id) = existing {
+            return Ok(session_id);
+        }
+
+        let session_id = self.contract_session_authority_id();
+        self.dsl_apply(
+            mm_dsl::MeerkatMachineInput::RegisterSession {
+                session_id: session_id.clone(),
+            },
+            "ContractRegisterSession",
+        )?;
+        self.sync_control_projection_from_dsl_authority();
+        Ok(session_id)
+    }
+
+    /// Contract helper for external tests that need a registered DSL session
+    /// before replaying lifecycle inputs through canonical authority.
+    #[doc(hidden)]
+    pub fn contract_register_session_authority(&mut self) -> Result<(), RuntimeDriverError> {
+        self.ensure_contract_session_authority().map(|_| ())
+    }
+
+    /// Contract helper for external tests that need to start a run through the
+    /// same DSL authority used by the runtime loop.
+    #[doc(hidden)]
+    pub fn contract_begin_run_authority(
+        &mut self,
+        run_id: RunId,
+    ) -> Result<(), RuntimeDriverError> {
+        let from = self.runtime_phase_snapshot();
+        if from == RuntimeState::Running && self.current_run_id().as_ref() == Some(&run_id) {
+            return Ok(());
+        }
+        if self.current_run_id().is_some() {
+            return Err(RuntimeDriverError::Internal(
+                crate::runtime_state::RuntimeStateTransitionError {
+                    from,
+                    to: RuntimeState::Running,
+                }
+                .to_string(),
+            ));
+        }
+        crate::runtime_state::run_start_pre_phase_from_phase(from)
+            .map_err(|err| RuntimeDriverError::Internal(err.to_string()))?;
+
+        let session_id = self.ensure_contract_session_authority()?;
+        if from == RuntimeState::Retired {
+            let authority = self.shared_dsl_authority();
+            let mut authority = authority
+                .lock()
+                .unwrap_or_else(std::sync::PoisonError::into_inner);
+            authority
+                .apply_signal(mm_dsl::MeerkatMachineSignal::DrainQueuedRun {
+                    run_id: mm_dsl::RunId::from_domain(&run_id),
+                })
+                .map(|_| ())
+                .map_err(|err| {
+                    RuntimeDriverError::Internal(crate::meerkat_machine::dsl_authority::map_error(
+                        err,
+                        "ContractDrainQueuedRun",
+                    ))
+                })?;
+        } else {
+            self.dsl_apply(
+                mm_dsl::MeerkatMachineInput::Prepare {
+                    session_id,
+                    run_id: mm_dsl::RunId::from_domain(&run_id),
+                },
+                "ContractPrepareRun",
+            )?;
+        }
+        self.sync_control_projection_from_dsl_authority();
+        Ok(())
+    }
+
+    /// Contract helper for external tests that complete a run through DSL
+    /// authority after shell-side input consumption has been realized.
+    #[doc(hidden)]
+    pub fn contract_commit_run_authority(
+        &mut self,
+        input_id: &InputId,
+        run_id: &RunId,
+    ) -> Result<(), RuntimeDriverError> {
+        self.dsl_apply(
+            mm_dsl::MeerkatMachineInput::Commit {
+                input_id: mm_dsl::InputId::from_domain(input_id),
+                run_id: mm_dsl::RunId::from_domain(run_id),
+            },
+            "ContractCommitRun",
+        )?;
+        self.sync_control_projection_from_dsl_authority();
+        Ok(())
+    }
+
+    /// Contract helper for external tests that roll back a run through DSL
+    /// authority after shell-side contributor replay has been realized.
+    #[doc(hidden)]
+    pub fn contract_rollback_run_authority(
+        &mut self,
+        run_id: &RunId,
+    ) -> Result<(), RuntimeDriverError> {
+        self.dsl_apply(
+            mm_dsl::MeerkatMachineInput::RollbackRun {
+                run_id: mm_dsl::RunId::from_domain(run_id),
+            },
+            "ContractRollbackRun",
+        )?;
+        self.sync_control_projection_from_dsl_authority();
+        Ok(())
+    }
+
+    /// Contract helper for external tests that need the runtime retired via
+    /// canonical DSL authority before invoking shell cleanup assertions.
+    #[doc(hidden)]
+    pub fn contract_retire_runtime_authority(&mut self) -> Result<(), RuntimeDriverError> {
+        let session_id = self.ensure_contract_session_authority()?;
+        self.dsl_apply(
+            mm_dsl::MeerkatMachineInput::Retire { session_id },
+            "ContractRetire",
+        )?;
+        self.sync_control_projection_from_dsl_authority();
+        Ok(())
+    }
+
+    /// Contract helper for external tests that need reset lifecycle authority
+    /// replayed through the DSL before invoking shell cleanup assertions.
+    #[doc(hidden)]
+    pub fn contract_reset_runtime_authority(&mut self) -> Result<(), RuntimeDriverError> {
+        self.dsl_apply(mm_dsl::MeerkatMachineInput::Reset, "ContractReset")?;
+        self.sync_control_projection_from_dsl_authority();
+        Ok(())
+    }
+
+    /// Contract helper for external tests that need destroyed lifecycle
+    /// authority replayed through the DSL after shell cleanup assertions.
+    #[doc(hidden)]
+    pub fn contract_destroy_runtime_authority(&mut self) -> Result<(), RuntimeDriverError> {
+        let session_id = self.ensure_contract_session_authority()?;
+        self.dsl_apply(
+            mm_dsl::MeerkatMachineInput::Destroy { session_id },
+            "ContractDestroy",
+        )?;
+        self.sync_control_projection_from_dsl_authority();
+        Ok(())
+    }
+
+    /// Contract helper for external tests that need stopped lifecycle authority
+    /// replayed through the DSL before invoking shell cleanup assertions.
+    #[doc(hidden)]
+    pub fn contract_stop_runtime_authority(&mut self) -> Result<(), RuntimeDriverError> {
+        self.apply_stop_runtime_executor_authority()?;
+        self.apply_runtime_executor_exited_authority()?;
+        self.sync_control_projection_from_dsl_authority();
+        Ok(())
+    }
+
     fn set_phase(&mut self, next_phase: RuntimeState) -> RuntimeState {
         let mut control = self.write_control_projection();
         let from_phase = control.phase;
@@ -1151,7 +1321,12 @@ impl EphemeralRuntimeDriver {
         self.set_control_projection(phase, current_run_id, pre_run_phase);
     }
 
-    pub(crate) fn force_runtime_authority(
+    /// Contract-only authority override for tests that need to seed impossible
+    /// or already-realized runtime phases. Production recovery must replay
+    /// durable lifecycle facts through DSL inputs instead of calling this.
+    #[cfg(test)]
+    #[doc(hidden)]
+    pub fn contract_force_runtime_authority(
         &mut self,
         next_phase: RuntimeState,
         current_run_id: Option<RunId>,
@@ -1171,16 +1346,6 @@ impl EphemeralRuntimeDriver {
                 .and_then(crate::meerkat_machine::dsl_authority::pre_run_phase_from_runtime_state);
         }
         self.set_control_projection(next_phase, current_run_id, pre_run_phase);
-    }
-
-    #[doc(hidden)]
-    pub fn contract_force_runtime_authority(
-        &mut self,
-        next_phase: RuntimeState,
-        current_run_id: Option<RunId>,
-        pre_run_phase: Option<RuntimeState>,
-    ) {
-        self.force_runtime_authority(next_phase, current_run_id, pre_run_phase);
     }
 
     pub(crate) fn apply_runtime_executor_exited_authority(

--- a/meerkat-runtime/src/driver/persistent.rs
+++ b/meerkat-runtime/src/driver/persistent.rs
@@ -164,6 +164,44 @@ impl PersistentRuntimeDriver {
         self.set_control_projection(next_phase, current_run_id, pre_run_phase);
     }
 
+    pub(crate) fn sync_control_projection_from_dsl_authority(&mut self) {
+        self.inner.sync_control_projection_from_dsl_authority();
+    }
+
+    /// Contract helper for external tests that need a registered DSL session
+    /// before replaying lifecycle inputs through canonical authority.
+    #[doc(hidden)]
+    pub fn contract_register_session_authority(&mut self) -> Result<(), RuntimeDriverError> {
+        self.inner.contract_register_session_authority()
+    }
+
+    /// Contract helper for external tests that need to start a run through the
+    /// same DSL authority used by the runtime loop.
+    #[doc(hidden)]
+    pub fn contract_begin_run_authority(
+        &mut self,
+        run_id: RunId,
+    ) -> Result<(), RuntimeDriverError> {
+        self.inner.contract_begin_run_authority(run_id)
+    }
+
+    /// Contract helper for external tests that need retired lifecycle
+    /// authority replayed through the DSL before invoking shell assertions.
+    #[doc(hidden)]
+    pub fn contract_retire_runtime_authority(&mut self) -> Result<(), RuntimeDriverError> {
+        self.inner.contract_retire_runtime_authority()
+    }
+
+    /// Contract helper for external tests that need reset lifecycle authority
+    /// replayed through the DSL before invoking shell assertions.
+    #[doc(hidden)]
+    pub fn contract_reset_runtime_authority(&mut self) -> Result<(), RuntimeDriverError> {
+        self.inner.contract_reset_runtime_authority()
+    }
+
+    /// Test-only authority override for crate-unit tests that need to seed
+    /// impossible or already-realized runtime phases.
+    #[cfg(test)]
     #[doc(hidden)]
     pub fn contract_force_runtime_authority(
         &mut self,
@@ -173,10 +211,6 @@ impl PersistentRuntimeDriver {
     ) {
         self.inner
             .contract_force_runtime_authority(next_phase, current_run_id, pre_run_phase);
-    }
-
-    pub(crate) fn sync_control_projection_from_dsl_authority(&mut self) {
-        self.inner.sync_control_projection_from_dsl_authority();
     }
 
     fn apply_destroy_dsl_authority(&mut self) -> Result<(), RuntimeDriverError> {

--- a/meerkat-runtime/src/meerkat_machine/driver.rs
+++ b/meerkat-runtime/src/meerkat_machine/driver.rs
@@ -1469,79 +1469,98 @@ fn missing_recovered_ingress_entry_reason(state: &InputState) -> String {
     )
 }
 
+fn recovered_runtime_state_corruption(
+    runtime_state: RuntimeState,
+    reason: impl Into<String>,
+) -> RuntimeDriverError {
+    RuntimeDriverError::RecoveryCorruption {
+        reason: format!(
+            "store corruption: recovered '{runtime_state}' runtime state cannot be replayed through DSL authority: {}",
+            reason.into()
+        ),
+    }
+}
+
+fn recovered_session_id(
+    driver: &crate::driver::ephemeral::EphemeralRuntimeDriver,
+    runtime_state: RuntimeState,
+) -> Result<crate::meerkat_machine::dsl::SessionId, RuntimeDriverError> {
+    let authority = driver.shared_dsl_authority();
+    let auth = authority
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner);
+    auth.state.session_id.clone().ok_or_else(|| {
+        recovered_runtime_state_corruption(
+            runtime_state,
+            "missing DSL session authority for session-scoped lifecycle input",
+        )
+    })
+}
+
+fn replay_recovered_runtime_input(
+    driver: &crate::driver::ephemeral::EphemeralRuntimeDriver,
+    runtime_state: RuntimeState,
+    input: crate::meerkat_machine::dsl::MeerkatMachineInput,
+    context: &'static str,
+) -> Result<(), RuntimeDriverError> {
+    let authority = driver.shared_dsl_authority();
+    let mut auth = authority
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner);
+    crate::meerkat_machine::dsl::MeerkatMachineMutator::apply(&mut *auth, input)
+        .map(|_| ())
+        .map_err(|err| {
+            recovered_runtime_state_corruption(
+                runtime_state,
+                crate::meerkat_machine::dsl_authority::map_error(err, context),
+            )
+        })
+}
+
 pub(crate) fn machine_realize_recovered_runtime_state(
     driver: &mut crate::driver::ephemeral::EphemeralRuntimeDriver,
     runtime_state: RuntimeState,
-) {
+) -> Result<(), RuntimeDriverError> {
     match runtime_state {
         RuntimeState::Retired if driver.runtime_state() != RuntimeState::Retired => {
-            let authority = driver.shared_dsl_authority();
-            let mut auth = authority
-                .lock()
-                .unwrap_or_else(std::sync::PoisonError::into_inner);
-            let applied = if let Some(session_id) = auth.state.session_id.clone() {
-                crate::meerkat_machine::dsl::MeerkatMachineMutator::apply(
-                    &mut *auth,
-                    crate::meerkat_machine::dsl::MeerkatMachineInput::Retire { session_id },
-                )
-                .is_ok()
-            } else {
-                false
-            };
-            drop(auth);
-            if applied {
-                driver.sync_control_projection_from_dsl_authority();
-            } else {
-                driver.force_runtime_authority(RuntimeState::Retired, None, None);
-            }
+            let session_id = recovered_session_id(driver, runtime_state)?;
+            replay_recovered_runtime_input(
+                driver,
+                runtime_state,
+                crate::meerkat_machine::dsl::MeerkatMachineInput::Retire { session_id },
+                "RecoverRuntimeState(Retired)",
+            )?;
+            driver.sync_control_projection_from_dsl_authority();
         }
         RuntimeState::Stopped
             if driver.runtime_state() != RuntimeState::Stopped
                 && driver.runtime_state() != RuntimeState::Destroyed =>
         {
-            let authority = driver.shared_dsl_authority();
-            let mut auth = authority
-                .lock()
-                .unwrap_or_else(std::sync::PoisonError::into_inner);
-            let applied = crate::meerkat_machine::dsl::MeerkatMachineMutator::apply(
-                &mut *auth,
+            replay_recovered_runtime_input(
+                driver,
+                runtime_state,
                 crate::meerkat_machine::dsl::MeerkatMachineInput::StopRuntimeExecutor {
-                    reason: "runtime state sync stopped executor".to_string(),
+                    reason: "recovered stopped runtime".to_string(),
                 },
-            )
-            .is_ok();
-            drop(auth);
-            if applied {
-                driver.sync_control_projection_from_dsl_authority();
-            } else {
-                driver.force_runtime_authority(RuntimeState::Stopped, None, None);
-            }
+                "RecoverRuntimeState(Stopped)",
+            )?;
+            driver.sync_control_projection_from_dsl_authority();
             driver.stop_runtime_cleanup();
         }
         RuntimeState::Destroyed if driver.runtime_state() != RuntimeState::Destroyed => {
-            let authority = driver.shared_dsl_authority();
-            let mut auth = authority
-                .lock()
-                .unwrap_or_else(std::sync::PoisonError::into_inner);
-            let applied = if let Some(session_id) = auth.state.session_id.clone() {
-                crate::meerkat_machine::dsl::MeerkatMachineMutator::apply(
-                    &mut *auth,
-                    crate::meerkat_machine::dsl::MeerkatMachineInput::Destroy { session_id },
-                )
-                .is_ok()
-            } else {
-                false
-            };
-            drop(auth);
-            if applied {
-                driver.sync_control_projection_from_dsl_authority();
-            } else {
-                driver.force_runtime_authority(RuntimeState::Destroyed, None, None);
-            }
+            let session_id = recovered_session_id(driver, runtime_state)?;
+            replay_recovered_runtime_input(
+                driver,
+                runtime_state,
+                crate::meerkat_machine::dsl::MeerkatMachineInput::Destroy { session_id },
+                "RecoverRuntimeState(Destroyed)",
+            )?;
+            driver.sync_control_projection_from_dsl_authority();
             driver.destroy_cleanup();
         }
         _ => {}
     }
+    Ok(())
 }
 
 pub(crate) fn machine_recover_ephemeral_driver(
@@ -1709,7 +1728,7 @@ pub(crate) async fn machine_recover_persistent_driver(
         }
     }
     if let Some(runtime_state) = recovered_runtime_state {
-        machine_realize_recovered_runtime_state(driver, runtime_state);
+        machine_realize_recovered_runtime_state(driver, runtime_state)?;
 
         if runtime_state.is_terminal() {
             let active = driver.active_input_ids();

--- a/meerkat-runtime/src/meerkat_machine/session_management.rs
+++ b/meerkat-runtime/src/meerkat_machine/session_management.rs
@@ -85,7 +85,7 @@ impl MeerkatMachine {
         session_id: &SessionId,
         dsl_authority: &Arc<std::sync::Mutex<super::dsl::MeerkatMachineAuthority>>,
         recovered_phase: RuntimeState,
-    ) {
+    ) -> Result<(), RuntimeDriverError> {
         // Cold-restart: when `recover()` realizes a stored terminal runtime
         // state on the driver, replay that fact through the DSL authority
         // before publishing or attaching the session entry. The shell
@@ -98,7 +98,7 @@ impl MeerkatMachine {
             super::dsl_authority::runtime_phase_from_authority(&authority)
         };
         if recovered_phase == RuntimeState::Idle || recovered_phase == authority_phase {
-            return;
+            return Ok(());
         }
 
         let input = match recovered_phase {
@@ -115,20 +115,21 @@ impl MeerkatMachine {
             RuntimeState::Idle => None,
         };
         let Some(input) = input else {
-            return;
+            return Ok(());
         };
 
         let mut authority = dsl_authority
             .lock()
             .unwrap_or_else(std::sync::PoisonError::into_inner);
         if let Err(err) = super::dsl::MeerkatMachineMutator::apply(&mut *authority, input) {
-            tracing::error!(
-                %session_id,
-                ?recovered_phase,
-                error = ?err,
-                "failed to replay recovered runtime phase through DSL authority"
-            );
+            return Err(RuntimeDriverError::RecoveryCorruption {
+                reason: format!(
+                    "store corruption: recovered '{recovered_phase}' runtime state for session '{session_id}' cannot be replayed through DSL authority: {}",
+                    super::dsl_authority::map_error(err, "RecoverRuntimeState(Session)")
+                ),
+            });
         }
+        Ok(())
     }
 
     pub(super) async fn register_session_inner(&self, session_id: SessionId) -> bool {
@@ -157,11 +158,14 @@ impl MeerkatMachine {
             tracing::error!(%session_id, error = %err, "failed to recover runtime driver during registration");
             return false;
         }
-        Self::replay_recovered_runtime_phase_through_dsl_authority(
+        if let Err(err) = Self::replay_recovered_runtime_phase_through_dsl_authority(
             &session_id,
             &dsl_authority,
             entry.as_driver().runtime_state(),
-        );
+        ) {
+            tracing::error!(%session_id, error = %err, "failed to replay recovered runtime phase through DSL authority");
+            return false;
+        }
         let control_projection = entry.control_projection_handle();
 
         let (ops_lifecycle, epoch_id, cursor_state) = self
@@ -343,97 +347,104 @@ impl MeerkatMachine {
             })
         };
 
-        let (driver, completions, ops_lifecycle) =
-            if let Some((has_attachment, driver, completions, ops_lifecycle)) = existing {
-                if has_attachment {
-                    return;
-                }
-                (driver, completions, ops_lifecycle)
-            } else {
-                let dsl_authority = Arc::new(std::sync::Mutex::new(
-                    super::dsl::MeerkatMachineAuthority::from_state(
-                        super::dsl_authority::project_state(
-                            &session_id,
-                            RuntimeState::Idle,
-                            None,
-                            None,
-                            None,
-                            std::collections::BTreeSet::new(),
-                            None,
-                        ),
+        let (driver, completions, ops_lifecycle) = if let Some((
+            has_attachment,
+            driver,
+            completions,
+            ops_lifecycle,
+        )) = existing
+        {
+            if has_attachment {
+                return;
+            }
+            (driver, completions, ops_lifecycle)
+        } else {
+            let dsl_authority = Arc::new(std::sync::Mutex::new(
+                super::dsl::MeerkatMachineAuthority::from_state(
+                    super::dsl_authority::project_state(
+                        &session_id,
+                        RuntimeState::Idle,
+                        None,
+                        None,
+                        None,
+                        std::collections::BTreeSet::new(),
+                        None,
                     ),
-                ));
-                let runtime_id = Self::logical_runtime_id(&session_id);
-                let mut recovered_entry =
-                    self.make_driver(runtime_id.clone(), Arc::clone(&dsl_authority));
-                if let Err(err) = recovered_entry.as_driver_mut().recover().await {
-                    tracing::error!(
-                        %session_id,
-                        error = %err,
-                        "failed to recover runtime driver during registration"
-                    );
+                ),
+            ));
+            let runtime_id = Self::logical_runtime_id(&session_id);
+            let mut recovered_entry =
+                self.make_driver(runtime_id.clone(), Arc::clone(&dsl_authority));
+            if let Err(err) = recovered_entry.as_driver_mut().recover().await {
+                tracing::error!(
+                    %session_id,
+                    error = %err,
+                    "failed to recover runtime driver during registration"
+                );
+                return;
+            }
+            if let Err(err) = Self::replay_recovered_runtime_phase_through_dsl_authority(
+                &session_id,
+                &dsl_authority,
+                recovered_entry.as_driver().runtime_state(),
+            ) {
+                tracing::error!(%session_id, error = %err, "failed to replay recovered runtime phase through DSL authority");
+                return;
+            }
+
+            // Recover ops state OUTSIDE the sessions lock to avoid blocking
+            // other adapter operations behind potentially slow disk I/O.
+            let (recovered_ops, recovered_epoch, recovered_cursors) = self
+                .recover_or_create_ops_state(&session_id, &runtime_id)
+                .await;
+
+            // Double-check under the lock — another task may have inserted
+            // the entry while we were rebuilding runtime state.
+            let mut sessions = self.sessions.write().await;
+            if let Some(entry) = sessions.get_mut(&session_id) {
+                entry.clear_dead_attachment();
+                if entry.has_attachment_or_attaching() {
                     return;
                 }
-                Self::replay_recovered_runtime_phase_through_dsl_authority(
-                    &session_id,
-                    &dsl_authority,
-                    recovered_entry.as_driver().runtime_state(),
+                entry.phase = RegistrationPhase::Attaching;
+                (
+                    entry.driver.clone(),
+                    entry.completions.clone(),
+                    entry.ops_lifecycle.clone(),
+                )
+            } else {
+                let control_projection = recovered_entry.control_projection_handle();
+                let driver = Arc::new(Mutex::new(recovered_entry));
+                let completions =
+                    Arc::new(Mutex::new(crate::completion::CompletionRegistry::new()));
+                let tool_visibility_owner = Arc::new(MachineToolVisibilityOwner::new());
+                // Bind the DSL authority before the entry is inserted — any
+                // subsequent staging trait call must see the bound authority.
+                tool_visibility_owner.bind_dsl_authority(Arc::clone(&dsl_authority));
+                sessions.insert(
+                    session_id.clone(),
+                    RuntimeSessionEntry {
+                        runtime_id,
+                        mutation_gate: Arc::new(Mutex::new(())),
+                        control_projection,
+                        driver: driver.clone(),
+                        ops_lifecycle: recovered_ops.clone(),
+                        epoch_id: recovered_epoch,
+                        cursor_state: recovered_cursors,
+                        completions: completions.clone(),
+                        tool_visibility_owner,
+                        current_llm_identity: None,
+                        current_capability_surface: None,
+                        capability_surface_status: SessionLlmCapabilitySurfaceStatus::Unresolved,
+                        phase: RegistrationPhase::Queuing,
+                        provisional_interrupt_handle: None,
+                        dsl_authority,
+                        drain_slot: CommsDrainSlot::new(),
+                    },
                 );
-
-                // Recover ops state OUTSIDE the sessions lock to avoid blocking
-                // other adapter operations behind potentially slow disk I/O.
-                let (recovered_ops, recovered_epoch, recovered_cursors) = self
-                    .recover_or_create_ops_state(&session_id, &runtime_id)
-                    .await;
-
-                // Double-check under the lock — another task may have inserted
-                // the entry while we were rebuilding runtime state.
-                let mut sessions = self.sessions.write().await;
-                if let Some(entry) = sessions.get_mut(&session_id) {
-                    entry.clear_dead_attachment();
-                    if entry.has_attachment_or_attaching() {
-                        return;
-                    }
-                    entry.phase = RegistrationPhase::Attaching;
-                    (
-                        entry.driver.clone(),
-                        entry.completions.clone(),
-                        entry.ops_lifecycle.clone(),
-                    )
-                } else {
-                    let control_projection = recovered_entry.control_projection_handle();
-                    let driver = Arc::new(Mutex::new(recovered_entry));
-                    let completions =
-                        Arc::new(Mutex::new(crate::completion::CompletionRegistry::new()));
-                    let tool_visibility_owner = Arc::new(MachineToolVisibilityOwner::new());
-                    // Bind the DSL authority before the entry is inserted — any
-                    // subsequent staging trait call must see the bound authority.
-                    tool_visibility_owner.bind_dsl_authority(Arc::clone(&dsl_authority));
-                    sessions.insert(
-                        session_id.clone(),
-                        RuntimeSessionEntry {
-                            runtime_id,
-                            mutation_gate: Arc::new(Mutex::new(())),
-                            control_projection,
-                            driver: driver.clone(),
-                            ops_lifecycle: recovered_ops.clone(),
-                            epoch_id: recovered_epoch,
-                            cursor_state: recovered_cursors,
-                            completions: completions.clone(),
-                            tool_visibility_owner,
-                            current_llm_identity: None,
-                            current_capability_surface: None,
-                            capability_surface_status:
-                                SessionLlmCapabilitySurfaceStatus::Unresolved,
-                            phase: RegistrationPhase::Queuing,
-                            provisional_interrupt_handle: None,
-                            dsl_authority,
-                            drain_slot: CommsDrainSlot::new(),
-                        },
-                    );
-                    (driver, completions, recovered_ops)
-                }
-            };
+                (driver, completions, recovered_ops)
+            }
+        };
 
         // Stage the DSL EnsureSessionWithExecutor transition BEFORE mutating
         // the driver, so a DSL rejection never leaves shell and DSL disagreeing.

--- a/meerkat-runtime/src/meerkat_machine_tests.rs
+++ b/meerkat-runtime/src/meerkat_machine_tests.rs
@@ -19928,6 +19928,9 @@ fn summarize_runtime_parity_driver_error(error: &RuntimeDriverError) -> String {
             format!("validation_failed:{reason}")
         }
         RuntimeDriverError::Destroyed => "destroyed".to_string(),
+        RuntimeDriverError::RecoveryCorruption { reason } => {
+            format!("recovery_corruption:{reason}")
+        }
         RuntimeDriverError::Internal(reason) => format!("internal:{reason}"),
     }
 }
@@ -20758,7 +20761,7 @@ async fn destroy_from_bound_initializing_is_backed_by_dsl_guard() {
         let DriverEntry::Ephemeral(driver) = &mut *entry else {
             panic!("test uses ephemeral driver");
         };
-        driver.force_runtime_authority(RuntimeState::Initializing, None, None);
+        driver.contract_force_runtime_authority(RuntimeState::Initializing, None, None);
         driver.sync_control_projection_from_dsl_authority();
     }
 

--- a/meerkat-runtime/src/traits.rs
+++ b/meerkat-runtime/src/traits.rs
@@ -28,6 +28,10 @@ pub enum RuntimeDriverError {
     #[error("Runtime destroyed")]
     Destroyed,
 
+    /// Durable recovery state could not be replayed through canonical runtime authority.
+    #[error("Recovery corruption: {reason}")]
+    RecoveryCorruption { reason: String },
+
     /// Internal error.
     #[error("Internal error: {0}")]
     Internal(String),

--- a/meerkat-runtime/tests/driver_ephemeral.rs
+++ b/meerkat-runtime/tests/driver_ephemeral.rs
@@ -108,35 +108,30 @@ fn assert_machine_owned_admission_signal(
 }
 
 fn bind_running(driver: &mut EphemeralRuntimeDriver, run_id: RunId, pre_run_phase: RuntimeState) {
-    driver.contract_force_runtime_authority(
-        RuntimeState::Running,
-        Some(run_id),
-        Some(pre_run_phase),
-    );
-}
-
-fn complete_run_projection(driver: &mut EphemeralRuntimeDriver, next_phase: RuntimeState) {
-    driver.contract_force_runtime_authority(next_phase, None, None);
+    assert_eq!(driver.runtime_state(), pre_run_phase);
+    driver.contract_begin_run_authority(run_id).unwrap();
+    assert_eq!(driver.runtime_state(), RuntimeState::Running);
+    assert_eq!(driver.pre_run_phase(), Some(pre_run_phase));
 }
 
 fn retire_runtime(driver: &mut EphemeralRuntimeDriver) -> meerkat_runtime::RetireReport {
-    driver.contract_force_runtime_authority(RuntimeState::Retired, None, None);
+    driver.contract_retire_runtime_authority().unwrap();
     driver.contract_finalize_retire()
 }
 
 fn reset_runtime(driver: &mut EphemeralRuntimeDriver) -> meerkat_runtime::ResetReport {
-    driver.contract_force_runtime_authority(RuntimeState::Idle, None, None);
+    driver.contract_reset_runtime_authority().unwrap();
     driver.contract_reset_cleanup()
 }
 
 fn destroy_runtime(driver: &mut EphemeralRuntimeDriver) -> usize {
     let abandoned = driver.contract_destroy_cleanup();
-    driver.contract_force_runtime_authority(RuntimeState::Destroyed, None, None);
+    driver.contract_destroy_runtime_authority().unwrap();
     abandoned
 }
 
 fn stop_runtime(driver: &mut EphemeralRuntimeDriver) {
-    driver.contract_force_runtime_authority(RuntimeState::Stopped, None, None);
+    driver.contract_stop_runtime_authority().unwrap();
     driver.contract_finalize_stop_runtime();
 }
 
@@ -377,7 +372,9 @@ async fn on_run_completed_consumes() {
         .run_completed(run_id.clone(), vec![input_id.clone()])
         .await
         .unwrap();
-    complete_run_projection(&mut driver, RuntimeState::Idle);
+    driver
+        .contract_commit_run_authority(&input_id, &run_id)
+        .unwrap();
 
     // Input should be consumed
     assert!(driver.input_state(&input_id).is_some());
@@ -403,7 +400,7 @@ async fn on_run_failed_rollbacks() {
     // Run failed
     driver
         .run_failed(
-            run_id,
+            run_id.clone(),
             vec![input_id.clone()],
             ReplayQueuedContributorsPlan {
                 queue_work_ids: vec![input_id.clone()],
@@ -416,7 +413,7 @@ async fn on_run_failed_rollbacks() {
         )
         .await
         .unwrap();
-    complete_run_projection(&mut driver, RuntimeState::Idle);
+    driver.contract_rollback_run_authority(&run_id).unwrap();
 
     // Input should be rolled back to Queued
     assert!(driver.input_state(&input_id).is_some());
@@ -708,8 +705,13 @@ async fn retired_can_drain_queue_via_run_cycle() {
         .unwrap();
 
     // Complete run → returns to Retired (not Idle)
-    driver.run_completed(run_id, vec![input_id]).await.unwrap();
-    complete_run_projection(&mut driver, RuntimeState::Retired);
+    driver
+        .run_completed(run_id.clone(), vec![input_id.clone()])
+        .await
+        .unwrap();
+    driver
+        .contract_commit_run_authority(&input_id, &run_id)
+        .unwrap();
 
     assert_eq!(driver.runtime_state(), RuntimeState::Retired);
     assert!(driver.queue().is_empty());

--- a/meerkat-runtime/tests/driver_persistent.rs
+++ b/meerkat-runtime/tests/driver_persistent.rs
@@ -15,7 +15,7 @@ use meerkat_runtime::store::RuntimeStoreError;
 use meerkat_runtime::{
     InMemoryRuntimeStore, Input, InputDurability, InputHeader, InputOrigin, InputState,
     InputVisibility, LogicalRuntimeId, PersistentRuntimeDriver, PromptInput, RuntimeDriver,
-    RuntimeState, RuntimeStore, SessionDelta,
+    RuntimeDriverError, RuntimeState, RuntimeStore, SessionDelta,
 };
 use meerkat_store::MemoryBlobStore;
 
@@ -357,24 +357,23 @@ fn make_multimodal_prompt(text: &str, label: &str) -> Input {
 }
 
 fn bind_running(driver: &mut PersistentRuntimeDriver, run_id: RunId, pre_run_phase: RuntimeState) {
-    driver.contract_force_runtime_authority(
-        RuntimeState::Running,
-        Some(run_id),
-        Some(pre_run_phase),
-    );
+    assert_eq!(driver.runtime_state(), pre_run_phase);
+    driver.contract_begin_run_authority(run_id).unwrap();
+    assert_eq!(driver.runtime_state(), RuntimeState::Running);
+    assert_eq!(driver.inner_ref().pre_run_phase(), Some(pre_run_phase));
 }
 
 async fn retire_runtime(
     driver: &mut PersistentRuntimeDriver,
 ) -> Result<meerkat_runtime::RetireReport, meerkat_runtime::RuntimeDriverError> {
-    driver.contract_force_runtime_authority(RuntimeState::Retired, None, None);
+    driver.contract_retire_runtime_authority()?;
     driver.contract_finalize_retire().await
 }
 
 async fn reset_runtime(
     driver: &mut PersistentRuntimeDriver,
 ) -> Result<meerkat_runtime::ResetReport, meerkat_runtime::RuntimeDriverError> {
-    driver.contract_force_runtime_authority(RuntimeState::Idle, None, None);
+    driver.contract_reset_runtime_authority()?;
     driver.contract_finalize_reset().await
 }
 
@@ -1004,7 +1003,7 @@ async fn direct_destroy_persists_destroyed_runtime_state() {
 }
 
 #[tokio::test]
-async fn direct_destroy_rejects_before_persisting_when_dsl_guard_rejects() {
+async fn direct_destroy_rejects_when_dsl_guard_rejects_destroyed_state() {
     let store = Arc::new(InMemoryRuntimeStore::new());
     let rid = LogicalRuntimeId::new("test");
     let mut driver = PersistentRuntimeDriver::new(
@@ -1012,25 +1011,29 @@ async fn direct_destroy_rejects_before_persisting_when_dsl_guard_rejects() {
         store.clone() as Arc<dyn RuntimeStore>,
         memory_blob_store(),
     );
-    driver.contract_force_runtime_authority(RuntimeState::Initializing, None, None);
+
+    driver
+        .destroy()
+        .await
+        .expect("first destroy should reach destroyed");
 
     let error = driver
         .destroy()
         .await
-        .expect_err("destroy without bound runtime identity must surface the DSL rejection");
+        .expect_err("destroy from destroyed must surface the DSL rejection");
     assert!(
         error.to_string().contains("DSL authority (Destroy)"),
         "unexpected error: {error}",
     );
     assert_eq!(
         driver.runtime_state(),
-        RuntimeState::Initializing,
-        "failed destroy must not override DSL lifecycle authority",
+        RuntimeState::Destroyed,
+        "failed destroy must preserve existing destroyed authority",
     );
-    assert_ne!(
+    assert_eq!(
         store.load_runtime_state(&rid).await.unwrap(),
         Some(RuntimeState::Destroyed),
-        "failed destroy must not persist shell-projected destroyed state",
+        "failed destroy must not rewrite durable state away from destroyed",
     );
 }
 
@@ -1672,5 +1675,47 @@ async fn recover_ignores_legacy_runtime_state_load_error_after_canonical_miss() 
         driver.runtime_state(),
         RuntimeState::Idle,
         "canonical runtime-state miss should retain the fresh idle runtime state"
+    );
+}
+
+#[tokio::test]
+async fn driver_persistent_recovery_without_session_authority_fails_closed_for_recovered_retire() {
+    let store = Arc::new(InMemoryRuntimeStore::new());
+    let rid = LogicalRuntimeId::new("test");
+    store
+        .atomic_lifecycle_commit(&rid, RuntimeState::Retired, &[])
+        .await
+        .unwrap();
+
+    let mut driver = PersistentRuntimeDriver::new(rid.clone(), store.clone(), memory_blob_store());
+    let error = driver
+        .recover()
+        .await
+        .expect_err("recovered Retired without DSL session authority must fail closed");
+
+    let RuntimeDriverError::RecoveryCorruption { reason } = error else {
+        panic!("expected recovery corruption error, got {error}");
+    };
+    assert!(
+        reason.contains("recovered 'retired' runtime state"),
+        "unexpected error: {reason}",
+    );
+    assert!(
+        reason.contains("missing DSL session authority"),
+        "unexpected error: {reason}",
+    );
+    assert_eq!(
+        driver.runtime_state(),
+        RuntimeState::Idle,
+        "failed recovery must roll back the live runtime projection",
+    );
+    assert!(
+        driver.active_input_ids().is_empty(),
+        "failed recovery must not leave recovered driver rows live",
+    );
+    assert_eq!(
+        store.load_runtime_state(&rid).await.unwrap(),
+        Some(RuntimeState::Retired),
+        "failed recovery must not repair or overwrite durable lifecycle truth from the shell",
     );
 }

--- a/meerkat-runtime/tests/peer_handling_mode_contract.rs
+++ b/meerkat-runtime/tests/peer_handling_mode_contract.rs
@@ -19,10 +19,11 @@ fn runtime_id() -> LogicalRuntimeId {
 }
 
 fn bind_running(driver: &mut EphemeralRuntimeDriver) {
-    driver.contract_force_runtime_authority(
-        meerkat_runtime::RuntimeState::Running,
-        Some(RunId::new()),
-        Some(meerkat_runtime::RuntimeState::Idle),
+    assert_eq!(driver.runtime_state(), meerkat_runtime::RuntimeState::Idle);
+    driver.contract_begin_run_authority(RunId::new()).unwrap();
+    assert_eq!(
+        driver.runtime_state(),
+        meerkat_runtime::RuntimeState::Running
     );
 }
 

--- a/meerkat-runtime/tests/recovery_contract.rs
+++ b/meerkat-runtime/tests/recovery_contract.rs
@@ -10,6 +10,8 @@ use chrono::Utc;
 use meerkat_core::BlobStore;
 use meerkat_core::lifecycle::run_primitive::RunApplyBoundary;
 use meerkat_core::lifecycle::{InputId, RunBoundaryReceipt, RunId};
+use meerkat_core::types::SessionId;
+use meerkat_runtime::SessionServiceRuntimeExt;
 use meerkat_runtime::identifiers::LogicalRuntimeId;
 use meerkat_runtime::input::{
     Input, InputDurability, InputHeader, InputOrigin, InputVisibility, PromptInput,
@@ -20,7 +22,7 @@ use meerkat_runtime::input_state::{
 use meerkat_runtime::runtime_state::RuntimeState;
 use meerkat_runtime::store::{InMemoryRuntimeStore, RuntimeStore, SessionDelta};
 use meerkat_runtime::traits::RuntimeDriver;
-use meerkat_runtime::{EphemeralRuntimeDriver, PersistentRuntimeDriver};
+use meerkat_runtime::{EphemeralRuntimeDriver, MeerkatMachine, PersistentRuntimeDriver};
 use meerkat_store::MemoryBlobStore;
 use tempfile::TempDir;
 use uuid::Uuid;
@@ -154,17 +156,16 @@ fn sorted_id_strings(ids: impl IntoIterator<Item = InputId>) -> Vec<String> {
 }
 
 fn bind_running(driver: &mut EphemeralRuntimeDriver, run_id: RunId, pre_run_phase: RuntimeState) {
-    driver.contract_force_runtime_authority(
-        RuntimeState::Running,
-        Some(run_id),
-        Some(pre_run_phase),
-    );
+    assert_eq!(driver.runtime_state(), pre_run_phase);
+    driver.contract_begin_run_authority(run_id).unwrap();
+    assert_eq!(driver.runtime_state(), RuntimeState::Running);
+    assert_eq!(driver.pre_run_phase(), Some(pre_run_phase));
 }
 
 async fn retire_runtime(
     driver: &mut PersistentRuntimeDriver,
 ) -> Result<meerkat_runtime::RetireReport, meerkat_runtime::RuntimeDriverError> {
-    driver.contract_force_runtime_authority(RuntimeState::Retired, None, None);
+    driver.contract_retire_runtime_authority()?;
     driver.contract_finalize_retire().await
 }
 
@@ -386,41 +387,35 @@ async fn recovery_persistent_driver_contract_replays_missing_receipts_and_persis
         );
 
         drop(driver);
+    }
+}
 
-        let mut retired_driver = PersistentRuntimeDriver::new(
-            runtime_id.clone(),
-            harness.store.clone(),
-            memory_blob_store(),
-        );
-        retired_driver.recover().await.unwrap();
-        assert_eq!(
-            retired_driver.runtime_state(),
+#[tokio::test]
+async fn recovery_contract_replays_recovered_runtime_lifecycle_facts_through_machine_dsl_authority()
+{
+    for harness in supported_store_harnesses() {
+        for recovered_state in [
             RuntimeState::Retired,
-            "{}: persisted retire state should round-trip through recovery",
-            harness.name
-        );
-        assert_eq!(
-            sorted_id_strings(retired_driver.active_input_ids()),
-            expected_ids,
-            "{}: retire recovery should keep the replayable contributors active",
-            harness.name
-        );
+            RuntimeState::Stopped,
+            RuntimeState::Destroyed,
+        ] {
+            let session_id = SessionId::new();
+            let runtime_id = LogicalRuntimeId::for_session(&session_id);
+            harness
+                .store
+                .atomic_lifecycle_commit(&runtime_id, recovered_state, &[])
+                .await
+                .unwrap();
 
-        let retired_replayed_ids = vec![
-            retired_driver.dequeue_next().unwrap().0,
-            retired_driver.dequeue_next().unwrap().0,
-        ];
-        assert!(
-            retired_driver.dequeue_next().is_none(),
-            "{}: retire recovery should requeue the preserved contributors exactly once",
-            harness.name
-        );
-        assert_eq!(
-            sorted_id_strings(retired_replayed_ids),
-            expected_ids,
-            "{}: retire recovery should surface the same replay contributors",
-            harness.name
-        );
+            let machine = MeerkatMachine::persistent(harness.store.clone(), memory_blob_store());
+            machine.register_session(session_id.clone()).await;
+            assert_eq!(
+                machine.runtime_state(&session_id).await.unwrap(),
+                recovered_state,
+                "{}: recovered {recovered_state} fact should replay through DSL authority",
+                harness.name
+            );
+        }
     }
 }
 

--- a/meerkat-runtime/tests/regression_comms_runtime.rs
+++ b/meerkat-runtime/tests/regression_comms_runtime.rs
@@ -16,6 +16,7 @@ use meerkat_core::interaction::{
     InboxInteraction, InteractionContent, InteractionId, PeerIngressConvention, PeerIngressFact,
     PeerIngressIdentity, PeerInputCandidate, PeerInputClass, ResponseStatus,
 };
+use meerkat_core::lifecycle::RunId;
 use meerkat_runtime::comms_bridge::peer_input_candidate_to_runtime_input;
 use meerkat_runtime::driver::ephemeral::{EphemeralRuntimeDriver, PostAdmissionSignal};
 use meerkat_runtime::identifiers::LogicalRuntimeId;
@@ -38,12 +39,12 @@ fn assert_machine_owned_admission_signal(
     );
 }
 
-fn bind_running(driver: &mut EphemeralRuntimeDriver) {
-    driver.contract_force_runtime_authority(
-        RuntimeState::Running,
-        Some(meerkat_core::lifecycle::RunId::new()),
-        Some(RuntimeState::Idle),
-    );
+fn bind_running(driver: &mut EphemeralRuntimeDriver) -> RunId {
+    let run_id = RunId::new();
+    assert_eq!(driver.runtime_state(), RuntimeState::Idle);
+    driver.contract_begin_run_authority(run_id.clone()).unwrap();
+    assert_eq!(driver.runtime_state(), RuntimeState::Running);
+    run_id
 }
 
 fn iid() -> InteractionId {
@@ -387,8 +388,8 @@ async fn response_after_completed_turn_wakes() {
     let mut driver = EphemeralRuntimeDriver::new(rid());
 
     // Simulate a completed run by starting and completing
-    bind_running(&mut driver);
-    driver.contract_force_runtime_authority(RuntimeState::Idle, None, None);
+    let run_id = bind_running(&mut driver);
+    driver.contract_rollback_run_authority(&run_id).unwrap();
 
     // Now idle — accept a terminal response
     let resp = make_response("peer-1", ResponseStatus::Completed);


### PR DESCRIPTION
## Summary
- Remove production recovery fallback that directly forced DSL lifecycle authority from recovered runtime state.
- Replay recovered Retired/Stopped/Destroyed lifecycle facts through DSL inputs and fail closed with `RuntimeDriverError::RecoveryCorruption` when replay is impossible.
- Keep direct authority writes only behind contract helpers, and add regression tests for legal replay plus the former missing-session fallback case.

## Validation
- `./scripts/repo-cargo test -p meerkat-runtime recovery_contract -- --nocapture`
- `./scripts/repo-cargo test -p meerkat-runtime driver_persistent -- --nocapture`
- `./scripts/repo-cargo test -p meerkat-runtime --test recovery_contract -- --nocapture`
- `./scripts/repo-cargo test -p meerkat-runtime --test driver_persistent -- --nocapture`
- `./scripts/repo-cargo test -p meerkat-runtime cold_reregister -- --nocapture`
- `./scripts/repo-cargo test -p meerkat-runtime destroy_from_bound_initializing_is_backed_by_dsl_guard -- --nocapture`
- `./scripts/repo-cargo test -p meerkat-runtime persistent_retire_keeps_committed_dsl_state_when_runtime_retired_signal_dispatch_fails -- --nocapture`
- `MEERKAT_BUILDBUDDY=1 make e2e-smoke` (passed after installing local `cargo-nextest v0.9.133`; first attempt built successfully in BuildBuddy but failed locally because nextest was missing)

Fixes LUC-385
