### PR TITLE
LUC-386 make runtime terminalization boundary-atomic

### DIFF
--- a/meerkat-runtime/src/driver/persistent.rs
+++ b/meerkat-runtime/src/driver/persistent.rs
@@ -77,6 +77,14 @@ impl PersistentRuntimeDriver {
         &self.inner
     }
 
+    pub(crate) fn rollback_snapshot(&self) -> EphemeralDriverRollbackSnapshot {
+        self.inner.rollback_snapshot()
+    }
+
+    pub(crate) fn restore_rollback_snapshot(&mut self, snapshot: EphemeralDriverRollbackSnapshot) {
+        self.inner.restore_rollback_snapshot(snapshot);
+    }
+
     /// Get the logical runtime ID for this driver.
     pub fn runtime_id(&self) -> &LogicalRuntimeId {
         &self.runtime_id

--- a/meerkat-runtime/src/meerkat_machine/driver.rs
+++ b/meerkat-runtime/src/meerkat_machine/driver.rs
@@ -105,6 +105,11 @@ pub(crate) enum PreparedDestroyLifecycle {
     Persistent(EphemeralDriverRollbackSnapshot),
 }
 
+enum DriverRollbackSnapshot {
+    Ephemeral(EphemeralDriverRollbackSnapshot),
+    Persistent(EphemeralDriverRollbackSnapshot),
+}
+
 pub(crate) struct PreparedDestroy {
     pub(crate) report: DestroyReport,
     pub(crate) lifecycle: PreparedDestroyLifecycle,
@@ -344,6 +349,25 @@ impl DriverEntry {
         match self {
             DriverEntry::Ephemeral(d) => d.ledger(),
             DriverEntry::Persistent(d) => d.inner_ref().ledger(),
+        }
+    }
+
+    fn rollback_snapshot(&self) -> DriverRollbackSnapshot {
+        match self {
+            DriverEntry::Ephemeral(d) => DriverRollbackSnapshot::Ephemeral(d.rollback_snapshot()),
+            DriverEntry::Persistent(d) => DriverRollbackSnapshot::Persistent(d.rollback_snapshot()),
+        }
+    }
+
+    fn restore_rollback_snapshot(&mut self, checkpoint: DriverRollbackSnapshot) {
+        match (self, checkpoint) {
+            (DriverEntry::Ephemeral(d), DriverRollbackSnapshot::Ephemeral(checkpoint)) => {
+                d.restore_rollback_snapshot(checkpoint);
+            }
+            (DriverEntry::Persistent(d), DriverRollbackSnapshot::Persistent(checkpoint)) => {
+                d.restore_rollback_snapshot(checkpoint);
+            }
+            _ => {}
         }
     }
 
@@ -2455,42 +2479,60 @@ pub(crate) async fn commit_runtime_loop_run(
     let commit_input_id = consumed_input_ids.first().cloned();
     machine_validate_run_commit_receipt(&driver, &run_id, &consumed_input_ids, &receipt)
         .map_err(RuntimeLoopRunCommitError::Rejected)?;
+    machine_validate_active_run(&driver, &run_id, next_phase).map_err(|err| {
+        RuntimeLoopRunCommitError::Rejected(RuntimeDriverError::Internal(err.to_string()))
+    })?;
     let completed_run_id = run_id.clone();
-    machine_apply_turn_run_completed(&mut driver, &completed_run_id)
-        .map_err(RuntimeLoopRunCommitError::Rejected)?;
-    let disposition = match commit_input_id.as_ref() {
-        Some(input_id) => RunReturnDisposition::Commit { input_id },
-        None => RunReturnDisposition::Rollback,
-    };
-    machine_apply_run_return_projection(&mut driver, &completed_run_id, disposition, next_phase)
-        .map_err(|err| {
-            RuntimeLoopRunCommitError::Rejected(RuntimeDriverError::Internal(format!(
-                "failed to apply runtime return projection after completion: {err}"
-            )))
-        })?;
+
+    let boundary_checkpoint = driver.rollback_snapshot();
     if let Err(err) = driver
         .machine_realize_boundary_applied(run_id.clone(), receipt, session_snapshot)
         .await
     {
-        let _ = driver.rollback_staged(&consumed_input_ids);
+        driver.restore_rollback_snapshot(boundary_checkpoint);
         return Err(RuntimeLoopRunCommitError::BoundaryCommit(
             RuntimeDriverError::Internal(format!("runtime boundary commit failed: {err}")),
         ));
     }
 
-    machine_validate_run_completed(&driver, &consumed_input_ids).map_err(|err| {
-        RuntimeLoopRunCommitError::PostBoundaryValidation(RuntimeDriverError::Internal(format!(
-            "runtime completion validation failed after boundary commit: {err}"
-        )))
-    })?;
-    driver
+    let terminal_checkpoint = driver.rollback_snapshot();
+    if let Err(err) = machine_validate_run_completed(&driver, &consumed_input_ids) {
+        driver.restore_rollback_snapshot(terminal_checkpoint);
+        return Err(RuntimeLoopRunCommitError::PostBoundaryValidation(
+            RuntimeDriverError::Internal(format!(
+                "runtime completion validation failed after boundary commit: {err}"
+            )),
+        ));
+    }
+    if let Err(err) = machine_apply_turn_run_completed(&mut driver, &completed_run_id) {
+        driver.restore_rollback_snapshot(terminal_checkpoint);
+        return Err(RuntimeLoopRunCommitError::Rejected(err));
+    }
+    let disposition = match commit_input_id.as_ref() {
+        Some(input_id) => RunReturnDisposition::Commit { input_id },
+        None => RunReturnDisposition::Rollback,
+    };
+    if let Err(err) =
+        machine_apply_run_return_projection(&mut driver, &completed_run_id, disposition, next_phase)
+    {
+        driver.restore_rollback_snapshot(terminal_checkpoint);
+        return Err(RuntimeLoopRunCommitError::Rejected(
+            RuntimeDriverError::Internal(format!(
+                "failed to apply runtime return projection after completion: {err}"
+            )),
+        ));
+    }
+    if let Err(err) = driver
         .machine_realize_run_completed(completed_run_id.clone(), consumed_input_ids)
         .await
-        .map_err(|err| {
-            RuntimeLoopRunCommitError::TerminalSnapshot(RuntimeDriverError::Internal(format!(
+    {
+        driver.restore_rollback_snapshot(terminal_checkpoint);
+        return Err(RuntimeLoopRunCommitError::TerminalSnapshot(
+            RuntimeDriverError::Internal(format!(
                 "failed to persist runtime completion snapshot: {err}"
-            )))
-        })?;
+            )),
+        ));
+    }
 
     Ok(())
 }
@@ -2547,27 +2589,32 @@ async fn fail_runtime_loop_run_inner(
     let staged_input_ids = machine_staged_contributors(&driver);
     machine_validate_run_failed(&driver, &staged_input_ids)
         .map_err(RuntimeLoopRunFailError::Rejected)?;
-    machine_apply_turn_run_failed(
+    let terminal_checkpoint = driver.rollback_snapshot();
+    if let Err(err) = machine_apply_turn_run_failed(
         &mut driver,
         &failed_run_id,
         &terminal_error,
         terminal_cause_kind,
         runtime_apply_failure.as_ref(),
-    )
-    .map_err(RuntimeLoopRunFailError::Rejected)?;
+    ) {
+        driver.restore_rollback_snapshot(terminal_checkpoint);
+        return Err(RuntimeLoopRunFailError::Rejected(err));
+    }
     let replay_plan = machine_build_replay_plan(&driver, &staged_input_ids, "RunFailed");
-    machine_apply_run_return_projection(
+    if let Err(err) = machine_apply_run_return_projection(
         &mut driver,
         &failed_run_id,
         RunReturnDisposition::Failed,
         next_phase,
-    )
-    .map_err(|err| {
-        RuntimeLoopRunFailError::Rejected(RuntimeDriverError::Internal(format!(
-            "failed to apply runtime return projection after failure: {err}"
-        )))
-    })?;
-    driver
+    ) {
+        driver.restore_rollback_snapshot(terminal_checkpoint);
+        return Err(RuntimeLoopRunFailError::Rejected(
+            RuntimeDriverError::Internal(format!(
+                "failed to apply runtime return projection after failure: {err}"
+            )),
+        ));
+    }
+    if let Err(run_err) = driver
         .machine_realize_run_failed(
             failed_run_id.clone(),
             staged_input_ids,
@@ -2577,11 +2624,13 @@ async fn fail_runtime_loop_run_inner(
             true,
         )
         .await
-        .map_err(|run_err| {
-            RuntimeLoopRunFailError::TerminalSnapshot(RuntimeDriverError::Internal(format!(
-                "failed to record run-failed event: {run_err}"
-            )))
-        })
+    {
+        driver.restore_rollback_snapshot(terminal_checkpoint);
+        return Err(RuntimeLoopRunFailError::TerminalSnapshot(
+            RuntimeDriverError::Internal(format!("failed to record run-failed event: {run_err}")),
+        ));
+    }
+    Ok(())
 }
 
 #[cfg(test)]

--- a/meerkat-runtime/src/meerkat_machine_tests.rs
+++ b/meerkat-runtime/src/meerkat_machine_tests.rs
@@ -14,7 +14,7 @@ use meerkat_core::lifecycle::core_executor::{
 };
 use meerkat_core::lifecycle::run_primitive::{RunApplyBoundary, RunPrimitive};
 use meerkat_core::lifecycle::run_receipt::RunBoundaryReceipt;
-use meerkat_core::lifecycle::{InputId, RunId};
+use meerkat_core::lifecycle::{CoreApplyFailureCause, InputId, RunId};
 use meerkat_core::ops::{OperationId, OperationResult};
 use meerkat_core::ops_lifecycle::{
     OperationKind, OperationProgressUpdate, OperationSpec, OpsLifecycleRegistry,
@@ -13906,6 +13906,250 @@ fn batch_receipt(run_id: RunId, contributing_input_ids: Vec<InputId>) -> RunBoun
     }
 }
 
+struct RuntimeCommitAtomicityStore {
+    inner: Arc<crate::store::InMemoryRuntimeStore>,
+    fail_atomic_apply: AtomicBool,
+    fail_atomic_lifecycle_commit: AtomicBool,
+}
+
+impl RuntimeCommitAtomicityStore {
+    fn fail_atomic_apply_once(inner: Arc<crate::store::InMemoryRuntimeStore>) -> Self {
+        Self {
+            inner,
+            fail_atomic_apply: AtomicBool::new(true),
+            fail_atomic_lifecycle_commit: AtomicBool::new(false),
+        }
+    }
+
+    fn fail_atomic_lifecycle_commit_once(inner: Arc<crate::store::InMemoryRuntimeStore>) -> Self {
+        Self {
+            inner,
+            fail_atomic_apply: AtomicBool::new(false),
+            fail_atomic_lifecycle_commit: AtomicBool::new(true),
+        }
+    }
+}
+
+#[async_trait::async_trait]
+impl RuntimeStore for RuntimeCommitAtomicityStore {
+    async fn commit_session_boundary(
+        &self,
+        runtime_id: &LogicalRuntimeId,
+        session_delta: crate::store::SessionDelta,
+        run_id: RunId,
+        boundary: RunApplyBoundary,
+        contributing_input_ids: Vec<InputId>,
+        input_updates: Vec<crate::input_state::StoredInputState>,
+    ) -> Result<RunBoundaryReceipt, crate::store::RuntimeStoreError> {
+        self.inner
+            .commit_session_boundary(
+                runtime_id,
+                session_delta,
+                run_id,
+                boundary,
+                contributing_input_ids,
+                input_updates,
+            )
+            .await
+    }
+
+    async fn commit_session_snapshot(
+        &self,
+        runtime_id: &LogicalRuntimeId,
+        session_delta: crate::store::SessionDelta,
+    ) -> Result<(), crate::store::RuntimeStoreError> {
+        self.inner
+            .commit_session_snapshot(runtime_id, session_delta)
+            .await
+    }
+
+    async fn atomic_apply(
+        &self,
+        runtime_id: &LogicalRuntimeId,
+        session_delta: Option<crate::store::SessionDelta>,
+        receipt: RunBoundaryReceipt,
+        input_updates: Vec<crate::input_state::StoredInputState>,
+        session_store_key: Option<SessionId>,
+    ) -> Result<(), crate::store::RuntimeStoreError> {
+        if self.fail_atomic_apply.swap(false, Ordering::SeqCst) {
+            return Err(crate::store::RuntimeStoreError::WriteFailed(
+                "synthetic atomic_apply failure".into(),
+            ));
+        }
+        self.inner
+            .atomic_apply(
+                runtime_id,
+                session_delta,
+                receipt,
+                input_updates,
+                session_store_key,
+            )
+            .await
+    }
+
+    async fn load_input_states(
+        &self,
+        runtime_id: &LogicalRuntimeId,
+    ) -> Result<Vec<crate::input_state::StoredInputState>, crate::store::RuntimeStoreError> {
+        self.inner.load_input_states(runtime_id).await
+    }
+
+    async fn load_boundary_receipt(
+        &self,
+        runtime_id: &LogicalRuntimeId,
+        run_id: &RunId,
+        sequence: u64,
+    ) -> Result<Option<RunBoundaryReceipt>, crate::store::RuntimeStoreError> {
+        self.inner
+            .load_boundary_receipt(runtime_id, run_id, sequence)
+            .await
+    }
+
+    async fn load_session_snapshot(
+        &self,
+        runtime_id: &LogicalRuntimeId,
+    ) -> Result<Option<Vec<u8>>, crate::store::RuntimeStoreError> {
+        self.inner.load_session_snapshot(runtime_id).await
+    }
+
+    async fn persist_input_state(
+        &self,
+        runtime_id: &LogicalRuntimeId,
+        state: &crate::input_state::StoredInputState,
+    ) -> Result<(), crate::store::RuntimeStoreError> {
+        self.inner.persist_input_state(runtime_id, state).await
+    }
+
+    async fn load_input_state(
+        &self,
+        runtime_id: &LogicalRuntimeId,
+        input_id: &InputId,
+    ) -> Result<Option<crate::input_state::StoredInputState>, crate::store::RuntimeStoreError> {
+        self.inner.load_input_state(runtime_id, input_id).await
+    }
+
+    async fn persist_runtime_state(
+        &self,
+        runtime_id: &LogicalRuntimeId,
+        state: RuntimeState,
+    ) -> Result<(), crate::store::RuntimeStoreError> {
+        self.inner.persist_runtime_state(runtime_id, state).await
+    }
+
+    async fn load_runtime_state(
+        &self,
+        runtime_id: &LogicalRuntimeId,
+    ) -> Result<Option<RuntimeState>, crate::store::RuntimeStoreError> {
+        self.inner.load_runtime_state(runtime_id).await
+    }
+
+    async fn atomic_lifecycle_commit(
+        &self,
+        runtime_id: &LogicalRuntimeId,
+        runtime_state: RuntimeState,
+        input_states: &[crate::input_state::StoredInputState],
+    ) -> Result<(), crate::store::RuntimeStoreError> {
+        if self
+            .fail_atomic_lifecycle_commit
+            .swap(false, Ordering::SeqCst)
+        {
+            return Err(crate::store::RuntimeStoreError::WriteFailed(
+                "synthetic atomic_lifecycle_commit failure".into(),
+            ));
+        }
+        self.inner
+            .atomic_lifecycle_commit(runtime_id, runtime_state, input_states)
+            .await
+    }
+}
+
+async fn persistent_staged_run_driver(
+    store: Arc<dyn RuntimeStore>,
+) -> (SharedDriver, LogicalRuntimeId, RunId, InputId) {
+    let runtime_id = LogicalRuntimeId::new("persistent-commit-atomicity");
+    let mut driver = PersistentRuntimeDriver::new(runtime_id.clone(), store, memory_blob_store());
+    let input = make_prompt("persistent terminalization");
+    let input_id = input.id().clone();
+    driver
+        .accept_input(input)
+        .await
+        .expect("persistent input should be accepted");
+
+    let run_id = RunId::new();
+    driver.contract_force_runtime_authority(
+        RuntimeState::Running,
+        Some(run_id.clone()),
+        Some(RuntimeState::Idle),
+    );
+    driver
+        .stage_input(&input_id, &run_id)
+        .expect("input should stage for the run");
+
+    (
+        Arc::new(Mutex::new(DriverEntry::Persistent(driver))),
+        runtime_id,
+        run_id,
+        input_id,
+    )
+}
+
+fn assert_live_run_remains_staged(
+    entry: &DriverEntry,
+    run_id: &RunId,
+    input_id: &InputId,
+    context: &str,
+) {
+    assert_eq!(
+        entry.runtime_state(),
+        RuntimeState::Running,
+        "{context}: runtime must remain running"
+    );
+    assert_eq!(
+        entry.current_run_id(),
+        Some(run_id.clone()),
+        "{context}: active run id must remain bound"
+    );
+    assert_eq!(
+        entry.input_phase(input_id),
+        Some(crate::input_state::InputLifecycleState::Staged),
+        "{context}: contributor must remain staged"
+    );
+    assert_eq!(
+        entry.input_terminal_outcome(input_id),
+        None,
+        "{context}: contributor must not be consumed or otherwise terminal"
+    );
+
+    let authority = entry.shared_dsl_authority();
+    let auth = authority
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner);
+    assert_eq!(
+        auth.state.lifecycle_phase,
+        mm_dsl::MeerkatPhase::Running,
+        "{context}: DSL lifecycle must remain Running"
+    );
+    assert_eq!(
+        auth.state.current_run_id.as_ref().map(|id| id.0.as_str()),
+        Some(run_id.to_string().as_str()),
+        "{context}: DSL current_run_id must remain bound"
+    );
+    assert_eq!(
+        auth.state.turn_phase,
+        mm_dsl::TurnPhase::Ready,
+        "{context}: DSL turn_phase must not become terminal"
+    );
+    assert_eq!(
+        auth.state.terminal_outcome, None,
+        "{context}: DSL terminal_outcome must not be set"
+    );
+    assert_eq!(
+        auth.state.input_phases.get(&input_id.to_string()),
+        Some(&mm_dsl::InputPhase::Staged),
+        "{context}: DSL input phase must remain staged"
+    );
+}
+
 async fn assert_commit_rejection_preserved_staged_batch(
     driver: &SharedDriver,
     run_id: &RunId,
@@ -13973,6 +14217,152 @@ async fn legacy_run_commit_rejects_reordered_receipt_contributors_before_mutatio
         "receipt contributors must exactly match consumed input ids"
     );
     assert_commit_rejection_preserved_staged_batch(&driver, &run_id, &staged_ids).await;
+}
+
+#[tokio::test]
+async fn persistent_commit_atomic_apply_failure_preserves_pre_terminal_state() {
+    let inner = Arc::new(crate::store::InMemoryRuntimeStore::new());
+    let store: Arc<dyn RuntimeStore> = Arc::new(
+        RuntimeCommitAtomicityStore::fail_atomic_apply_once(Arc::clone(&inner)),
+    );
+    let (driver, runtime_id, run_id, input_id) = persistent_staged_run_driver(store).await;
+
+    let err = commit_runtime_loop_run(
+        &driver,
+        run_id.clone(),
+        vec![input_id.clone()],
+        batch_receipt(run_id.clone(), vec![input_id.clone()]),
+        Some(b"session-data".to_vec()),
+    )
+    .await
+    .expect_err("synthetic atomic_apply failure should reject the commit");
+    assert!(
+        err.to_string().contains("synthetic atomic_apply failure"),
+        "unexpected commit error: {err}"
+    );
+
+    let entry = driver.lock().await;
+    assert_live_run_remains_staged(&entry, &run_id, &input_id, "failed boundary commit");
+    drop(entry);
+
+    assert!(
+        inner
+            .load_boundary_receipt(&runtime_id, &run_id, 0)
+            .await
+            .unwrap()
+            .is_none(),
+        "failed boundary commit must not persist a receipt"
+    );
+    assert_eq!(
+        inner.load_session_snapshot(&runtime_id).await.unwrap(),
+        None,
+        "failed boundary commit must not persist a session snapshot"
+    );
+}
+
+#[tokio::test]
+async fn persistent_commit_success_persists_receipt_and_terminalizes_once() {
+    let inner = Arc::new(crate::store::InMemoryRuntimeStore::new());
+    let store: Arc<dyn RuntimeStore> = inner.clone();
+    let (driver, runtime_id, run_id, input_id) = persistent_staged_run_driver(store).await;
+    let session_snapshot = b"session-data".to_vec();
+
+    commit_runtime_loop_run(
+        &driver,
+        run_id.clone(),
+        vec![input_id.clone()],
+        batch_receipt(run_id.clone(), vec![input_id.clone()]),
+        Some(session_snapshot.clone()),
+    )
+    .await
+    .expect("persistent commit should succeed");
+
+    assert!(
+        inner
+            .load_boundary_receipt(&runtime_id, &run_id, 0)
+            .await
+            .unwrap()
+            .is_some(),
+        "successful commit must persist the boundary receipt"
+    );
+    assert_eq!(
+        inner.load_session_snapshot(&runtime_id).await.unwrap(),
+        Some(session_snapshot),
+        "successful commit must persist the session snapshot"
+    );
+
+    let entry = driver.lock().await;
+    assert_eq!(entry.runtime_state(), RuntimeState::Idle);
+    assert_eq!(entry.current_run_id(), None);
+    assert_eq!(
+        entry.input_phase(&input_id),
+        Some(crate::input_state::InputLifecycleState::Consumed)
+    );
+    assert_eq!(
+        entry.input_terminal_outcome(&input_id),
+        Some(crate::input_state::InputTerminalOutcome::Consumed)
+    );
+    let input_state = entry
+        .as_driver()
+        .input_state(&input_id)
+        .expect("committed input state should remain available");
+    assert_eq!(
+        input_state
+            .history
+            .iter()
+            .filter(|event| event.to == crate::input_state::InputLifecycleState::Consumed)
+            .count(),
+        1,
+        "successful commit must consume the contributor exactly once"
+    );
+
+    let authority = entry.shared_dsl_authority();
+    let auth = authority
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner);
+    assert_eq!(auth.state.lifecycle_phase, mm_dsl::MeerkatPhase::Idle);
+    assert_eq!(auth.state.current_run_id, None);
+    assert_eq!(auth.state.turn_phase, mm_dsl::TurnPhase::Completed);
+    assert_eq!(
+        auth.state.terminal_outcome,
+        Some(mm_dsl::TurnTerminalOutcome::Completed)
+    );
+    assert_eq!(
+        auth.state.input_phases.get(&input_id.to_string()),
+        Some(&mm_dsl::InputPhase::Consumed)
+    );
+}
+
+#[tokio::test]
+async fn persistent_failed_run_lifecycle_commit_failure_preserves_pre_terminal_state() {
+    let inner = Arc::new(crate::store::InMemoryRuntimeStore::new());
+    let store: Arc<dyn RuntimeStore> = Arc::new(
+        RuntimeCommitAtomicityStore::fail_atomic_lifecycle_commit_once(Arc::clone(&inner)),
+    );
+    let (driver, runtime_id, run_id, input_id) = persistent_staged_run_driver(store).await;
+
+    let err = fail_runtime_loop_run(
+        &driver,
+        run_id.clone(),
+        CoreApplyFailureCause::executor_internal("synthetic run failure"),
+    )
+    .await
+    .expect_err("synthetic lifecycle commit failure should reject the failed-run persist");
+    assert!(
+        err.to_string()
+            .contains("synthetic atomic_lifecycle_commit failure"),
+        "unexpected failed-run error: {err}"
+    );
+
+    let entry = driver.lock().await;
+    assert_live_run_remains_staged(&entry, &run_id, &input_id, "failed run persist");
+    drop(entry);
+
+    assert_ne!(
+        inner.load_runtime_state(&runtime_id).await.unwrap(),
+        Some(RuntimeState::Idle),
+        "failed run persist must not durably commit the returned runtime state"
+    );
 }
 
 // ---------------------------------------------------------------


### PR DESCRIPTION
## Summary
- persist/apply the runtime boundary receipt before applying RunCompleted/Commit terminal DSL projection
- restore full driver rollback checkpoints on boundary and failed-run terminal persistence failures
- add regression coverage for failed atomic_apply, successful commit, and failed-run lifecycle persist rollback

## Validation
- ./scripts/repo-cargo fmt --check
- ./scripts/repo-cargo test -p meerkat-runtime persistent_commit -- --nocapture
- ./scripts/repo-cargo test -p meerkat-runtime persistent_failed_run_lifecycle_commit_failure_preserves_pre_terminal_state -- --nocapture
- ./scripts/repo-cargo test -p meerkat-runtime --test driver_persistent -- --nocapture
- ./scripts/repo-cargo test -p meerkat-runtime meerkat_machine -- --nocapture
- MEERKAT_BUILDBUDDY=1 make e2e-smoke

Linear: LUC-386