### PR TITLE
LUC-394 route realtime tool timeouts through runtime dispatch

### DIFF
--- a/artifacts/schemas/params.json
+++ b/artifacts/schemas/params.json
@@ -9145,13 +9145,51 @@
       "RealtimeChannelConfig": {
         "description": "Per-channel runtime knobs negotiated at open time.\n\nAdditive fields only — clients that do not carry this struct inherit the\nserver-default behavior via `#[serde(default)]` on the parent\n[`RealtimeOpenRequest`].",
         "properties": {
-          "tool_timeout_ms": {
-            "description": "Maximum wall-clock time a tool dispatch may take before the channel\ngives up and injects a synthetic tool-error result. `None` disables the\ndeadline (product explicitly opted into unlimited tools); omitting the\nfield leaves the server default in place.",
-            "format": "uint64",
-            "minimum": 0,
-            "type": [
-              "integer",
-              "null"
+          "tool_timeout": {
+            "description": "Realtime-specific timeout policy for product-session tool dispatch.",
+            "oneOf": [
+              {
+                "properties": {
+                  "type": {
+                    "const": "default",
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "type"
+                ],
+                "type": "object"
+              },
+              {
+                "properties": {
+                  "type": {
+                    "const": "disabled",
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "type"
+                ],
+                "type": "object"
+              },
+              {
+                "properties": {
+                  "timeout_ms": {
+                    "format": "uint64",
+                    "minimum": 0,
+                    "type": "integer"
+                  },
+                  "type": {
+                    "const": "finite",
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "type",
+                  "timeout_ms"
+                ],
+                "type": "object"
+              }
             ]
           }
         },

--- a/artifacts/schemas/rest-openapi.json
+++ b/artifacts/schemas/rest-openapi.json
@@ -3381,13 +3381,51 @@
       "RealtimeChannelConfig": {
         "description": "Per-channel runtime knobs negotiated at open time.\n\nAdditive fields only — clients that do not carry this struct inherit the\nserver-default behavior via `#[serde(default)]` on the parent\n[`RealtimeOpenRequest`].",
         "properties": {
-          "tool_timeout_ms": {
-            "description": "Maximum wall-clock time a tool dispatch may take before the channel\ngives up and injects a synthetic tool-error result. `None` disables the\ndeadline (product explicitly opted into unlimited tools); omitting the\nfield leaves the server default in place.",
-            "format": "uint64",
-            "minimum": 0,
-            "type": [
-              "integer",
-              "null"
+          "tool_timeout": {
+            "description": "Realtime-specific timeout policy for product-session tool dispatch.",
+            "oneOf": [
+              {
+                "properties": {
+                  "type": {
+                    "const": "default",
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "type"
+                ],
+                "type": "object"
+              },
+              {
+                "properties": {
+                  "type": {
+                    "const": "disabled",
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "type"
+                ],
+                "type": "object"
+              },
+              {
+                "properties": {
+                  "timeout_ms": {
+                    "format": "uint64",
+                    "minimum": 0,
+                    "type": "integer"
+                  },
+                  "type": {
+                    "const": "finite",
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "type",
+                  "timeout_ms"
+                ],
+                "type": "object"
+              }
             ]
           }
         },

--- a/meerkat-contracts/src/lib.rs
+++ b/meerkat-contracts/src/lib.rs
@@ -270,6 +270,7 @@ pub use wire::{
     RealtimeStatusResult,
     RealtimeTextChunk,
     RealtimeTextDelta,
+    RealtimeToolTimeoutPolicy,
     RealtimeTurningMode,
     RealtimeVideoChunk,
     RuntimeAcceptOutcomeType,

--- a/meerkat-contracts/src/wire/mod.rs
+++ b/meerkat-contracts/src/wire/mod.rs
@@ -129,7 +129,8 @@ pub use realtime::{
     RealtimeInputChunk, RealtimeInputKind, RealtimeOpenInfo, RealtimeOpenRequest,
     RealtimeOutputChunk, RealtimeOutputKind, RealtimeProtocolVersion, RealtimeReconnectPolicy,
     RealtimeServerFrame, RealtimeStatusParams, RealtimeStatusResult, RealtimeTextChunk,
-    RealtimeTextDelta, RealtimeTurningMode, RealtimeVideoChunk, ToolCallTimeoutContext,
+    RealtimeTextDelta, RealtimeToolTimeoutPolicy, RealtimeTurningMode, RealtimeVideoChunk,
+    ToolCallTimeoutContext,
 };
 pub use result::WireRunResult;
 pub use runtime::{

--- a/meerkat-contracts/src/wire/realtime.rs
+++ b/meerkat-contracts/src/wire/realtime.rs
@@ -311,6 +311,48 @@ pub struct RealtimeReconnectPolicy {
     pub max_total_ms: u64,
 }
 
+/// Typed per-channel tool timeout policy.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
+#[serde(tag = "type", rename_all = "snake_case")]
+pub enum RealtimeToolTimeoutPolicy {
+    /// Use the server's default realtime tool timeout.
+    Default,
+    /// Do not apply a realtime-specific timeout. The runtime/tool dispatcher
+    /// may still enforce its own normal execution policy.
+    Disabled,
+    /// Apply this finite realtime-specific timeout.
+    Finite { timeout_ms: u64 },
+}
+
+impl Default for RealtimeToolTimeoutPolicy {
+    fn default() -> Self {
+        Self::Default
+    }
+}
+
+impl RealtimeToolTimeoutPolicy {
+    /// Default tool budget when neither the caller nor the server provides
+    /// an override. Keeps the "runtime safe by default" dogma.
+    pub const DEFAULT_TIMEOUT_MS: u64 = 15_000;
+
+    #[must_use]
+    pub fn is_default(&self) -> bool {
+        matches!(self, Self::Default)
+    }
+
+    /// Resolve to the effective realtime-specific timeout. `None` means the
+    /// caller explicitly disabled the realtime-specific deadline.
+    #[must_use]
+    pub fn timeout_ms(&self) -> Option<u64> {
+        match self {
+            Self::Default => Some(Self::DEFAULT_TIMEOUT_MS),
+            Self::Disabled => None,
+            Self::Finite { timeout_ms } => Some(*timeout_ms),
+        }
+    }
+}
+
 /// Per-channel runtime knobs negotiated at open time.
 ///
 /// Additive fields only — clients that do not carry this struct inherit the
@@ -319,30 +361,15 @@ pub struct RealtimeReconnectPolicy {
 #[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq)]
 #[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
 pub struct RealtimeChannelConfig {
-    /// Maximum wall-clock time a tool dispatch may take before the channel
-    /// gives up and injects a synthetic tool-error result. `None` disables the
-    /// deadline (product explicitly opted into unlimited tools); omitting the
-    /// field leaves the server default in place.
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub tool_timeout_ms: Option<u64>,
+    /// Realtime-specific timeout policy for product-session tool dispatch.
+    #[serde(default, skip_serializing_if = "RealtimeToolTimeoutPolicy::is_default")]
+    pub tool_timeout: RealtimeToolTimeoutPolicy,
 }
 
 impl RealtimeChannelConfig {
     /// Default tool budget when neither the caller nor the server provides
     /// an override. Keeps the "runtime safe by default" dogma.
-    pub const DEFAULT_TOOL_TIMEOUT_MS: u64 = 15_000;
-
-    /// Resolve the effective tool timeout, substituting the global default
-    /// when the caller did not specify one. `None` means "no deadline" and is
-    /// honored exactly.
-    #[must_use]
-    pub fn tool_timeout_ms_or_default(&self) -> Option<u64> {
-        match self.tool_timeout_ms {
-            Some(0) => None,
-            Some(ms) => Some(ms),
-            None => Some(Self::DEFAULT_TOOL_TIMEOUT_MS),
-        }
-    }
+    pub const DEFAULT_TOOL_TIMEOUT_MS: u64 = RealtimeToolTimeoutPolicy::DEFAULT_TIMEOUT_MS;
 }
 
 /// Product-facing realtime capability set for one target/provider combination.
@@ -570,9 +597,8 @@ pub enum RealtimeEvent {
         call_id: String,
         error: String,
     },
-    /// The tool dispatch exceeded its configured budget and was aborted;
-    /// a synthetic `ToolResult::Error` was injected back into the provider
-    /// session so the model sees a concrete failure instead of silence.
+    /// The tool dispatch exceeded its configured budget and was terminalized
+    /// by the runtime/tool-dispatch path.
     ToolCallTimedOut {
         call_id: String,
         elapsed_ms: u64,

--- a/meerkat-contracts/src/wire/realtime.rs
+++ b/meerkat-contracts/src/wire/realtime.rs
@@ -312,23 +312,18 @@ pub struct RealtimeReconnectPolicy {
 }
 
 /// Typed per-channel tool timeout policy.
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq)]
 #[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
 #[serde(tag = "type", rename_all = "snake_case")]
 pub enum RealtimeToolTimeoutPolicy {
     /// Use the server's default realtime tool timeout.
+    #[default]
     Default,
     /// Do not apply a realtime-specific timeout. The runtime/tool dispatcher
     /// may still enforce its own normal execution policy.
     Disabled,
     /// Apply this finite realtime-specific timeout.
     Finite { timeout_ms: u64 },
-}
-
-impl Default for RealtimeToolTimeoutPolicy {
-    fn default() -> Self {
-        Self::Default
-    }
 }
 
 impl RealtimeToolTimeoutPolicy {

--- a/meerkat-contracts/tests/realtime_tool_timeout.rs
+++ b/meerkat-contracts/tests/realtime_tool_timeout.rs
@@ -4,48 +4,79 @@
 
 use meerkat_contracts::{
     RealtimeChannelConfig, RealtimeChannelEventFrame, RealtimeEvent, RealtimeOpenRequest,
-    RealtimeServerFrame,
+    RealtimeServerFrame, RealtimeToolTimeoutPolicy,
 };
 
 #[test]
-fn channel_config_default_tool_timeout_resolves_to_15s() {
+fn channel_config_default_tool_timeout_is_typed_policy() {
     let config = RealtimeChannelConfig::default();
     assert_eq!(
-        config.tool_timeout_ms_or_default(),
-        Some(RealtimeChannelConfig::DEFAULT_TOOL_TIMEOUT_MS),
-        "default must be the 15 000 ms runtime-safe budget",
+        config.tool_timeout,
+        RealtimeToolTimeoutPolicy::Default,
+        "default must be an explicit typed policy, not an absent Option value",
+    );
+    assert_eq!(
+        config.tool_timeout.timeout_ms(),
+        Some(RealtimeToolTimeoutPolicy::DEFAULT_TIMEOUT_MS),
+        "default policy resolves to the 15 000 ms runtime-safe budget",
     );
 }
 
 #[test]
-fn channel_config_zero_ms_disables_the_deadline() {
-    // Operators that explicitly want unlimited tools can pass 0; product
-    // code treats that as "no deadline" (distinguishable from "not set").
+fn channel_config_disabled_tool_timeout_is_typed_policy() {
     let config = RealtimeChannelConfig {
-        tool_timeout_ms: Some(0),
+        tool_timeout: RealtimeToolTimeoutPolicy::Disabled,
     };
-    assert_eq!(config.tool_timeout_ms_or_default(), None);
+    assert_eq!(config.tool_timeout.timeout_ms(), None);
 }
 
 #[test]
-fn channel_config_explicit_value_is_honored() {
+fn channel_config_finite_tool_timeout_is_typed_policy() {
     let config = RealtimeChannelConfig {
-        tool_timeout_ms: Some(7_500),
+        tool_timeout: RealtimeToolTimeoutPolicy::Finite { timeout_ms: 7_500 },
     };
-    assert_eq!(config.tool_timeout_ms_or_default(), Some(7_500));
+    assert_eq!(config.tool_timeout.timeout_ms(), Some(7_500));
+}
+
+#[test]
+fn channel_config_timeout_policy_cases_remain_distinct() {
+    assert_ne!(
+        RealtimeToolTimeoutPolicy::Default,
+        RealtimeToolTimeoutPolicy::Disabled,
+    );
+    assert_ne!(
+        RealtimeToolTimeoutPolicy::Default,
+        RealtimeToolTimeoutPolicy::Finite {
+            timeout_ms: RealtimeToolTimeoutPolicy::DEFAULT_TIMEOUT_MS
+        },
+        "default and explicit finite default value must remain distinguishable",
+    );
 }
 
 #[test]
 fn channel_config_roundtrips_over_the_wire() {
     let config = RealtimeChannelConfig {
-        tool_timeout_ms: Some(5_000),
+        tool_timeout: RealtimeToolTimeoutPolicy::Finite { timeout_ms: 5_000 },
     };
     let value = serde_json::to_value(&config).expect("channel config serializes");
-    assert_eq!(value["tool_timeout_ms"], 5_000);
+    assert_eq!(value["tool_timeout"]["type"], "finite");
+    assert_eq!(value["tool_timeout"]["timeout_ms"], 5_000);
 
     let roundtrip: RealtimeChannelConfig =
         serde_json::from_value(value).expect("channel config deserializes");
     assert_eq!(roundtrip, config);
+}
+
+#[test]
+fn channel_config_legacy_zero_ms_field_is_not_a_disable_sentinel() {
+    let value = serde_json::json!({ "tool_timeout_ms": 0 });
+    let config: RealtimeChannelConfig =
+        serde_json::from_value(value).expect("legacy field should not poison config parsing");
+    assert_eq!(
+        config.tool_timeout,
+        RealtimeToolTimeoutPolicy::Default,
+        "legacy tool_timeout_ms=0 must not map to disabled semantics",
+    );
 }
 
 #[test]

--- a/meerkat-core/src/agent/runner.rs
+++ b/meerkat-core/src/agent/runner.rs
@@ -483,6 +483,7 @@ where
 
         match dispatch_result {
             Ok(mut outcome) => {
+                outcome.clear_terminal_cause();
                 if outcome.result.tool_use_id.is_empty() {
                     outcome.result.tool_use_id = call.id;
                 }

--- a/meerkat-core/src/agent/runner.rs
+++ b/meerkat-core/src/agent/runner.rs
@@ -4,7 +4,7 @@ use crate::budget::Budget;
 use crate::error::{AgentError, ToolError};
 use crate::event::AgentEvent;
 use crate::hooks::{HookInvocation, HookPatch, HookPoint};
-use crate::ops::ToolDispatchOutcome;
+use crate::ops::{ToolDispatchOutcome, ToolDispatchTimeoutPolicy};
 use crate::retry::RetryPolicy;
 use crate::service::TurnToolOverlay;
 use crate::session::{PendingSystemContextAppend, Session};
@@ -433,6 +433,22 @@ where
         &mut self,
         call: crate::types::ToolCall,
     ) -> Result<ToolDispatchOutcome, AgentError> {
+        self.dispatch_external_tool_call_with_timeout_policy(
+            call,
+            ToolDispatchTimeoutPolicy::Disabled,
+        )
+        .await
+    }
+
+    /// Dispatch an external product/runtime tool call with an optional
+    /// caller-owned timeout. Timeout terminalization is still canonical:
+    /// timeout expiry becomes `ToolError::Timeout`, then flows through
+    /// `terminal_tool_outcome_for_error` like normal tool execution failures.
+    pub async fn dispatch_external_tool_call_with_timeout_policy(
+        &mut self,
+        call: crate::types::ToolCall,
+        timeout_policy: ToolDispatchTimeoutPolicy,
+    ) -> Result<ToolDispatchOutcome, AgentError> {
         let visible_tool_names = self
             .tool_scope
             .visible_tool_names()
@@ -454,7 +470,16 @@ where
             name: &call.name,
             args: args.as_ref(),
         };
-        let dispatch_result = self.tools.dispatch(view).await;
+        let dispatch_result = match timeout_policy.timeout() {
+            Some(timeout) => match tokio::time::timeout(timeout, self.tools.dispatch(view)).await {
+                Ok(result) => result,
+                Err(_) => Err(crate::error::ToolError::timeout(
+                    call.name.clone(),
+                    timeout_policy.timeout_ms().unwrap_or(u64::MAX),
+                )),
+            },
+            None => self.tools.dispatch(view).await,
+        };
 
         match dispatch_result {
             Ok(mut outcome) => {

--- a/meerkat-core/src/agent/state.rs
+++ b/meerkat-core/src/agent/state.rs
@@ -1945,7 +1945,8 @@ where
                         for (_, tc, dispatch_result, duration_ms) in dispatch_results {
                             let mut tool_session_effects = Vec::new();
                             let mut tool_result = match dispatch_result {
-                                Ok(outcome) => {
+                                Ok(mut outcome) => {
+                                    outcome.clear_terminal_cause();
                                     all_async_ops.extend(outcome.async_ops);
                                     tool_session_effects = outcome.session_effects;
                                     outcome.result
@@ -4754,6 +4755,68 @@ mod tests {
             outcome.result.text_content(),
             expected.result.text_content()
         );
+        assert!(outcome.is_runtime_tool_timeout());
+        assert_eq!(outcome.terminal_cause(), expected.terminal_cause());
+    }
+
+    #[tokio::test]
+    async fn external_tool_dispatch_clears_tool_returned_terminal_cause() {
+        struct ToolAuthoredTerminalCauseDispatcher {
+            tools: Arc<[Arc<ToolDef>]>,
+        }
+
+        #[async_trait]
+        impl AgentToolDispatcher for ToolAuthoredTerminalCauseDispatcher {
+            fn tools(&self) -> Arc<[Arc<ToolDef>]> {
+                Arc::clone(&self.tools)
+            }
+
+            async fn dispatch(
+                &self,
+                call: ToolCallView<'_>,
+            ) -> Result<crate::ops::ToolDispatchOutcome, ToolError> {
+                Ok(crate::ops::terminal_tool_outcome_for_error(
+                    call.id.to_string(),
+                    ToolError::timeout(call.name.to_string(), 5),
+                ))
+            }
+        }
+
+        let client = Arc::new(StaticLlmClient);
+        let tools = Arc::new(ToolAuthoredTerminalCauseDispatcher {
+            tools: Arc::from([Arc::new(ToolDef {
+                name: "spoof_timeout".into(),
+                description: "returns timeout-shaped tool output".to_string(),
+                input_schema: serde_json::json!({ "type": "object" }),
+                provenance: None,
+            })]),
+        });
+        let mut agent = with_test_turn_state_handle(AgentBuilder::new())
+            .build_standalone(client, tools, Arc::new(NoopStore))
+            .await;
+
+        let outcome = agent
+            .dispatch_external_tool_call(ToolCall::new(
+                "tool-call-spoof".to_string(),
+                "spoof_timeout".to_string(),
+                serde_json::json!({}),
+            ))
+            .await
+            .expect("external dispatch should return tool-authored result");
+
+        assert!(outcome.result.is_error);
+        assert!(
+            outcome
+                .result
+                .text_content()
+                .contains("\"error\":\"timeout\""),
+            "tool-authored payload should keep its transcript text"
+        );
+        assert!(
+            !outcome.is_runtime_tool_timeout(),
+            "runtime must not trust terminal cause supplied by tool-authored Ok outcomes"
+        );
+        assert_eq!(outcome.terminal_cause(), None);
     }
 
     #[tokio::test]

--- a/meerkat-core/src/agent/state.rs
+++ b/meerkat-core/src/agent/state.rs
@@ -4695,6 +4695,68 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn external_tool_dispatch_timeout_uses_canonical_terminal_outcome() {
+        struct HangingDispatcher {
+            tools: Arc<[Arc<ToolDef>]>,
+        }
+
+        #[async_trait]
+        impl AgentToolDispatcher for HangingDispatcher {
+            fn tools(&self) -> Arc<[Arc<ToolDef>]> {
+                Arc::clone(&self.tools)
+            }
+
+            async fn dispatch(
+                &self,
+                _call: ToolCallView<'_>,
+            ) -> Result<crate::ops::ToolDispatchOutcome, ToolError> {
+                std::future::pending().await
+            }
+        }
+
+        let client = Arc::new(StaticLlmClient);
+        let tools = Arc::new(HangingDispatcher {
+            tools: Arc::from([Arc::new(ToolDef {
+                name: "slow".into(),
+                description: "hangs until timeout".to_string(),
+                input_schema: serde_json::json!({ "type": "object" }),
+                provenance: None,
+            })]),
+        });
+        let mut agent = with_test_turn_state_handle(AgentBuilder::new())
+            .build_standalone(client, tools, Arc::new(NoopStore))
+            .await;
+
+        let outcome = tokio::time::timeout(
+            std::time::Duration::from_secs(1),
+            agent.dispatch_external_tool_call_with_timeout_policy(
+                ToolCall::new(
+                    "tool-call-timeout".to_string(),
+                    "slow".to_string(),
+                    serde_json::json!({}),
+                ),
+                crate::ops::ToolDispatchTimeoutPolicy::Finite {
+                    timeout: std::time::Duration::from_millis(5),
+                },
+            ),
+        )
+        .await
+        .expect("external dispatch should terminalize promptly")
+        .expect("timeout terminalization should be a tool outcome");
+
+        let expected = crate::ops::terminal_tool_outcome_for_error(
+            "tool-call-timeout",
+            ToolError::timeout("slow", 5),
+        );
+        assert_eq!(outcome.result.tool_use_id, expected.result.tool_use_id);
+        assert!(outcome.result.is_error);
+        assert_eq!(
+            outcome.result.text_content(),
+            expected.result.text_content()
+        );
+    }
+
+    #[tokio::test]
     async fn external_tool_dispatch_terminalizes_hidden_tools() {
         let client = Arc::new(StaticLlmClient);
         let tools = Arc::new(FullToolDispatcher::new(&["visible", "secret"]));

--- a/meerkat-core/src/lib.rs
+++ b/meerkat-core/src/lib.rs
@@ -212,7 +212,8 @@ pub use model_defaults::ModelOperationalDefaultsResolver;
 pub use ops::{
     AsyncOpRef, ConcurrencyLimits, ContextStrategy, ForkBranch, ForkBudgetPolicy, OpEvent,
     OperationId, OperationPolicy, OperationResult, OperationSpec, ResultShape, SessionEffect,
-    SpawnSpec, ToolAccessPolicy, ToolDispatchOutcome, WaitPolicy, WorkKind,
+    SpawnSpec, ToolAccessPolicy, ToolDispatchOutcome, ToolDispatchTimeoutPolicy, WaitPolicy,
+    WorkKind,
 };
 pub use ops_lifecycle::{
     OperationCompletionWatch, OperationKind, OperationLifecycleSnapshot, OperationPeerHandle,

--- a/meerkat-core/src/lib.rs
+++ b/meerkat-core/src/lib.rs
@@ -212,8 +212,8 @@ pub use model_defaults::ModelOperationalDefaultsResolver;
 pub use ops::{
     AsyncOpRef, ConcurrencyLimits, ContextStrategy, ForkBranch, ForkBudgetPolicy, OpEvent,
     OperationId, OperationPolicy, OperationResult, OperationSpec, ResultShape, SessionEffect,
-    SpawnSpec, ToolAccessPolicy, ToolDispatchOutcome, ToolDispatchTimeoutPolicy, WaitPolicy,
-    WorkKind,
+    SpawnSpec, ToolAccessPolicy, ToolDispatchOutcome, ToolDispatchTerminalCause,
+    ToolDispatchTerminalErrorKind, ToolDispatchTimeoutPolicy, WaitPolicy, WorkKind,
 };
 pub use ops_lifecycle::{
     OperationCompletionWatch, OperationKind, OperationLifecycleSnapshot, OperationPeerHandle,

--- a/meerkat-core/src/ops.rs
+++ b/meerkat-core/src/ops.rs
@@ -95,6 +95,57 @@ pub enum SessionEffect {
     },
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ToolDispatchTerminalErrorKind {
+    NotFound,
+    Unavailable,
+    InvalidArguments,
+    ExecutionFailed,
+    Timeout,
+    AccessDenied,
+    Other,
+    CallbackPending,
+}
+
+impl From<&ToolError> for ToolDispatchTerminalErrorKind {
+    fn from(error: &ToolError) -> Self {
+        match error {
+            ToolError::NotFound { .. } => Self::NotFound,
+            ToolError::Unavailable { .. } => Self::Unavailable,
+            ToolError::InvalidArguments { .. } => Self::InvalidArguments,
+            ToolError::ExecutionFailed { .. } => Self::ExecutionFailed,
+            ToolError::Timeout { .. } => Self::Timeout,
+            ToolError::AccessDenied { .. } => Self::AccessDenied,
+            ToolError::Other(_) => Self::Other,
+            ToolError::CallbackPending { .. } => Self::CallbackPending,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ToolDispatchTerminalCause {
+    RuntimeToolError { kind: ToolDispatchTerminalErrorKind },
+}
+
+impl ToolDispatchTerminalCause {
+    #[must_use]
+    pub fn runtime_tool_error(error: &ToolError) -> Self {
+        Self::RuntimeToolError {
+            kind: ToolDispatchTerminalErrorKind::from(error),
+        }
+    }
+
+    #[must_use]
+    pub fn is_runtime_tool_timeout(self) -> bool {
+        matches!(
+            self,
+            Self::RuntimeToolError {
+                kind: ToolDispatchTerminalErrorKind::Timeout
+            }
+        )
+    }
+}
+
 #[derive(Debug, Clone)]
 pub struct ToolDispatchOutcome {
     /// The tool result for the conversation transcript.
@@ -110,6 +161,11 @@ pub struct ToolDispatchOutcome {
     /// changes (e.g., mob authority grants) emit typed effects here instead
     /// of calling `SessionService` from inside dispatch.
     pub session_effects: Vec<SessionEffect>,
+    /// Runtime/tool-dispatch-authored terminal cause.
+    ///
+    /// Tool-authored `is_error` results intentionally leave this empty; callers
+    /// must not infer canonical timeout/failure classes by parsing result text.
+    terminal_cause: Option<ToolDispatchTerminalCause>,
 }
 
 /// Optional timeout policy supplied by an external tool-dispatch caller.
@@ -141,13 +197,38 @@ impl ToolDispatchTimeoutPolicy {
 }
 
 impl ToolDispatchOutcome {
-    /// Create an outcome with no async operations or session effects (synchronous tool).
-    pub fn sync_result(result: crate::types::ToolResult) -> Self {
+    /// Create an outcome with explicit async operations and session effects.
+    pub fn new(
+        result: crate::types::ToolResult,
+        async_ops: Vec<AsyncOpRef>,
+        session_effects: Vec<SessionEffect>,
+    ) -> Self {
         Self {
             result,
-            async_ops: Vec::new(),
-            session_effects: Vec::new(),
+            async_ops,
+            session_effects,
+            terminal_cause: None,
         }
+    }
+
+    /// Create an outcome with no async operations or session effects (synchronous tool).
+    pub fn sync_result(result: crate::types::ToolResult) -> Self {
+        Self::new(result, Vec::new(), Vec::new())
+    }
+
+    #[must_use]
+    pub fn terminal_cause(&self) -> Option<ToolDispatchTerminalCause> {
+        self.terminal_cause
+    }
+
+    #[must_use]
+    pub fn is_runtime_tool_timeout(&self) -> bool {
+        self.terminal_cause
+            .is_some_and(ToolDispatchTerminalCause::is_runtime_tool_timeout)
+    }
+
+    pub(crate) fn clear_terminal_cause(&mut self) {
+        self.terminal_cause = None;
     }
 }
 
@@ -163,14 +244,17 @@ pub fn terminal_tool_outcome_for_error(
     tool_use_id: impl Into<String>,
     error: ToolError,
 ) -> ToolDispatchOutcome {
+    let terminal_cause = ToolDispatchTerminalCause::runtime_tool_error(&error);
     let payload = error.to_error_payload();
     let serialized = serde_json::to_string(&payload)
         .unwrap_or_else(|_| "{\"error\":\"tool_error\",\"message\":\"tool error\"}".to_string());
-    ToolDispatchOutcome::sync_result(crate::types::ToolResult::new(
+    let mut outcome = ToolDispatchOutcome::sync_result(crate::types::ToolResult::new(
         tool_use_id.into(),
         serialized,
         true,
-    ))
+    ));
+    outcome.terminal_cause = Some(terminal_cause);
+    outcome
 }
 
 impl OperationId {
@@ -555,14 +639,15 @@ mod tests {
     #[test]
     fn tool_dispatch_outcome_with_session_effects() {
         let result = crate::types::ToolResult::new("t1".into(), "ok".into(), false);
-        let outcome = ToolDispatchOutcome {
+        let outcome = ToolDispatchOutcome::new(
             result,
-            async_ops: vec![],
-            session_effects: vec![SessionEffect::GrantManageMob {
+            vec![],
+            vec![SessionEffect::GrantManageMob {
                 mob_id: "mob-1".into(),
             }],
-        };
+        );
         assert_eq!(outcome.session_effects.len(), 1);
+        assert_eq!(outcome.terminal_cause(), None);
     }
 
     #[test]
@@ -570,5 +655,31 @@ mod tests {
         let result = crate::types::ToolResult::new("t1".into(), "ok".into(), false);
         let outcome = ToolDispatchOutcome::sync_result(result);
         assert!(outcome.session_effects.is_empty());
+        assert_eq!(outcome.terminal_cause(), None);
+    }
+
+    #[test]
+    fn terminal_tool_outcome_carries_runtime_timeout_cause() {
+        let outcome = terminal_tool_outcome_for_error("t1", ToolError::timeout("slow_tool", 50));
+
+        assert!(outcome.result.is_error);
+        assert!(outcome.is_runtime_tool_timeout());
+        assert_eq!(
+            outcome.terminal_cause(),
+            Some(ToolDispatchTerminalCause::RuntimeToolError {
+                kind: ToolDispatchTerminalErrorKind::Timeout,
+            })
+        );
+    }
+
+    #[test]
+    fn tool_authored_error_result_has_no_runtime_terminal_cause() {
+        let result =
+            crate::types::ToolResult::new("t1".into(), "{\"error\":\"timeout\"}".into(), true);
+        let outcome = ToolDispatchOutcome::sync_result(result);
+
+        assert!(outcome.result.is_error);
+        assert!(!outcome.is_runtime_tool_timeout());
+        assert_eq!(outcome.terminal_cause(), None);
     }
 }

--- a/meerkat-core/src/ops.rs
+++ b/meerkat-core/src/ops.rs
@@ -112,6 +112,34 @@ pub struct ToolDispatchOutcome {
     pub session_effects: Vec<SessionEffect>,
 }
 
+/// Optional timeout policy supplied by an external tool-dispatch caller.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ToolDispatchTimeoutPolicy {
+    /// Use the caller's default timeout value.
+    Default { timeout: std::time::Duration },
+    /// Do not apply a caller-specific timeout. The dispatcher may still apply
+    /// its own normal execution policy.
+    Disabled,
+    /// Apply this finite caller-specific timeout.
+    Finite { timeout: std::time::Duration },
+}
+
+impl ToolDispatchTimeoutPolicy {
+    #[must_use]
+    pub fn timeout(self) -> Option<std::time::Duration> {
+        match self {
+            Self::Default { timeout } | Self::Finite { timeout } => Some(timeout),
+            Self::Disabled => None,
+        }
+    }
+
+    #[must_use]
+    pub fn timeout_ms(self) -> Option<u64> {
+        self.timeout()
+            .map(|timeout| u64::try_from(timeout.as_millis()).unwrap_or(u64::MAX))
+    }
+}
+
 impl ToolDispatchOutcome {
     /// Create an outcome with no async operations or session effects (synchronous tool).
     pub fn sync_result(result: crate::types::ToolResult) -> Self {

--- a/meerkat-mob-mcp/src/agent_tools.rs
+++ b/meerkat-mob-mcp/src/agent_tools.rs
@@ -264,11 +264,11 @@ impl AgentMobToolSurface {
     ) -> Result<meerkat_core::ToolDispatchOutcome, ToolError> {
         let content = serde_json::to_string(&value)
             .map_err(|e| ToolError::execution_failed(format!("encode tool result: {e}")))?;
-        Ok(meerkat_core::ToolDispatchOutcome {
-            result: ToolResult::new(call.id.to_string(), content, false),
-            async_ops: vec![],
+        Ok(meerkat_core::ToolDispatchOutcome::new(
+            ToolResult::new(call.id.to_string(), content, false),
+            vec![],
             session_effects,
-        })
+        ))
     }
 
     fn spawn_result_payload(mob_id: &MobId, result: &SpawnResult) -> serde_json::Value {

--- a/meerkat-mob/src/runtime/tools.rs
+++ b/meerkat-mob/src/runtime/tools.rs
@@ -551,11 +551,11 @@ impl MobOperatorToolDispatcher {
     ) -> Result<meerkat_core::ToolDispatchOutcome, ToolError> {
         let content = serde_json::to_string(&value)
             .map_err(|error| ToolError::execution_failed(format!("encode tool result: {error}")))?;
-        Ok(meerkat_core::ToolDispatchOutcome {
-            result: ToolResult::new(call.id.to_string(), content, false),
+        Ok(meerkat_core::ToolDispatchOutcome::new(
+            ToolResult::new(call.id.to_string(), content, false),
             async_ops,
-            session_effects: vec![],
-        })
+            vec![],
+        ))
     }
 
     fn member_ref_payload(

--- a/meerkat-rpc/src/realtime_ws.rs
+++ b/meerkat-rpc/src/realtime_ws.rs
@@ -3430,14 +3430,6 @@ fn tool_dispatch_timeout_policy(policy: RealtimeToolTimeoutPolicy) -> ToolDispat
     }
 }
 
-fn canonical_tool_result_error_code(result: &meerkat_core::ToolResult) -> Option<String> {
-    serde_json::from_str::<serde_json::Value>(&result.text_content())
-        .ok()?
-        .get("error")
-        .and_then(serde_json::Value::as_str)
-        .map(str::to_string)
-}
-
 async fn handle_product_session_tool_call(
     runtime: &SessionRuntime,
     binding: Option<&RealtimeSocketBinding>,
@@ -3478,8 +3470,7 @@ async fn handle_product_session_tool_call(
 
     match outcome_result {
         Ok(outcome) if outcome.result.is_error => {
-            let is_timeout = canonical_tool_result_error_code(&outcome.result)
-                .is_some_and(|code| code == "timeout");
+            let is_timeout = outcome.is_runtime_tool_timeout();
             let error_message = outcome.result.text_content();
             let _ = submit_product_session_tool_error(
                 runtime,
@@ -5189,6 +5180,15 @@ mod tests {
             !handler_source.contains("ToolError::timeout")
                 && !handler_source.contains("terminal_tool_outcome_for_error"),
             "websocket handler must not synthesize canonical timeout tool errors"
+        );
+        assert!(
+            handler_source.contains("is_runtime_tool_timeout"),
+            "websocket handler may only project timeouts from typed runtime dispatch outcome cause"
+        );
+        assert!(
+            !handler_source.contains("serde_json::from_str")
+                && !handler_source.contains("canonical_tool_result_error_code"),
+            "websocket handler must not classify timeout by parsing serialized tool-result text"
         );
         assert!(
             !handler_source.contains("tool exceeded budget"),

--- a/meerkat-rpc/src/realtime_ws.rs
+++ b/meerkat-rpc/src/realtime_ws.rs
@@ -24,13 +24,14 @@ use meerkat_client::{
 };
 use meerkat_contracts::{
     AudioFormatMismatchContext, RealtimeActionResult, RealtimeAudioFormat, RealtimeCapabilities,
-    RealtimeChannelClosedFrame, RealtimeChannelErrorFrame, RealtimeChannelEventFrame,
-    RealtimeChannelOpenFrame, RealtimeChannelOpenedFrame, RealtimeChannelState,
-    RealtimeChannelStatus, RealtimeChannelStatusFrame, RealtimeClientFrame, RealtimeErrorCode,
-    RealtimeErrorDetails, RealtimeEvent, RealtimeInputChunk, RealtimeOpenInfo, RealtimeOpenRequest,
-    RealtimeProtocolVersion, RealtimeReconnectPolicy, RealtimeServerFrame,
+    RealtimeChannelClosedFrame, RealtimeChannelConfig, RealtimeChannelErrorFrame,
+    RealtimeChannelEventFrame, RealtimeChannelOpenFrame, RealtimeChannelOpenedFrame,
+    RealtimeChannelState, RealtimeChannelStatus, RealtimeChannelStatusFrame, RealtimeClientFrame,
+    RealtimeErrorCode, RealtimeErrorDetails, RealtimeEvent, RealtimeInputChunk, RealtimeOpenInfo,
+    RealtimeOpenRequest, RealtimeProtocolVersion, RealtimeReconnectPolicy, RealtimeServerFrame,
+    RealtimeToolTimeoutPolicy,
 };
-use meerkat_core::{ConfigStore, SessionId};
+use meerkat_core::{ConfigStore, SessionId, ToolDispatchTimeoutPolicy};
 use meerkat_runtime::{
     Input, PromptInput, RuntimeDriverError, RuntimeState, service_ext::SessionServiceRuntimeExt,
 };
@@ -965,12 +966,12 @@ async fn handle_realtime_socket(mut socket: WebSocket, state: RealtimeWsState) {
                     let _ = send_server_frame(&mut socket, &opened).await;
                     let role = registered.role;
                     let turning_mode = accepted.request.turning_mode;
-                    let tool_timeout_ms = accepted
+                    let tool_timeout_policy = accepted
                         .request
                         .channel_config
                         .clone()
                         .unwrap_or_default()
-                        .tool_timeout_ms_or_default();
+                        .tool_timeout;
                     let mut observer_fanout_rx = registered.observer_fanout_rx.take();
                     let mut reconnect_retry = RealtimeReconnectRetryPlanner::new(
                         accepted
@@ -1776,7 +1777,7 @@ async fn handle_realtime_socket(mut socket: WebSocket, state: RealtimeWsState) {
                                                     call_id,
                                                     tool_name,
                                                     arguments,
-                                                    tool_timeout_ms,
+                                                    tool_timeout_policy.clone(),
                                                 )
                                                 .await
                                             }
@@ -3417,6 +3418,26 @@ async fn run_product_session_actor(
     }
 }
 
+fn tool_dispatch_timeout_policy(policy: RealtimeToolTimeoutPolicy) -> ToolDispatchTimeoutPolicy {
+    match policy {
+        RealtimeToolTimeoutPolicy::Default => ToolDispatchTimeoutPolicy::Default {
+            timeout: Duration::from_millis(RealtimeChannelConfig::DEFAULT_TOOL_TIMEOUT_MS),
+        },
+        RealtimeToolTimeoutPolicy::Disabled => ToolDispatchTimeoutPolicy::Disabled,
+        RealtimeToolTimeoutPolicy::Finite { timeout_ms } => ToolDispatchTimeoutPolicy::Finite {
+            timeout: Duration::from_millis(timeout_ms),
+        },
+    }
+}
+
+fn canonical_tool_result_error_code(result: &meerkat_core::ToolResult) -> Option<String> {
+    serde_json::from_str::<serde_json::Value>(&result.text_content())
+        .ok()?
+        .get("error")
+        .and_then(serde_json::Value::as_str)
+        .map(str::to_string)
+}
+
 async fn handle_product_session_tool_call(
     runtime: &SessionRuntime,
     binding: Option<&RealtimeSocketBinding>,
@@ -3424,7 +3445,7 @@ async fn handle_product_session_tool_call(
     call_id: String,
     tool_name: String,
     arguments: serde_json::Value,
-    tool_timeout_ms: Option<u64>,
+    tool_timeout_policy: RealtimeToolTimeoutPolicy,
 ) -> Result<Vec<RealtimeServerFrame>, RealtimeChannelErrorFrame> {
     let mut frames = vec![channel_event(RealtimeEvent::ToolCallRequested {
         call_id: call_id.clone(),
@@ -3446,44 +3467,19 @@ async fn handle_product_session_tool_call(
     };
 
     let call = meerkat_core::ToolCall::new(call_id.clone(), tool_name, arguments);
-    let dispatch = runtime.dispatch_external_tool_call(&session_id, call);
     let started_at = meerkat_core::time_compat::Instant::now();
-    let outcome_result = match tool_timeout_ms {
-        Some(limit_ms) => {
-            match tokio::time::timeout(std::time::Duration::from_millis(limit_ms), dispatch).await {
-                Ok(inner) => inner,
-                Err(_elapsed) => {
-                    // Budget exceeded: inject a synthetic tool-error result so
-                    // the model observes a concrete failure, then emit the
-                    // typed timeout event. Dropping the `dispatch` future
-                    // cancels the underlying task so a late-finishing tool
-                    // does not leak its result onto a cancelled channel.
-                    let actual_elapsed_ms =
-                        u64::try_from(started_at.elapsed().as_millis()).unwrap_or(u64::MAX);
-                    let timeout_message = format!(
-                        "tool exceeded budget after {actual_elapsed_ms}ms, continuing without result",
-                    );
-                    let _ = submit_product_session_tool_error(
-                        runtime,
-                        binding,
-                        product_session,
-                        call_id.clone(),
-                        timeout_message.clone(),
-                    )
-                    .await;
-                    frames.push(channel_event(RealtimeEvent::ToolCallTimedOut {
-                        call_id,
-                        elapsed_ms: actual_elapsed_ms,
-                    }));
-                    return Ok(frames);
-                }
-            }
-        }
-        None => dispatch.await,
-    };
+    let outcome_result = runtime
+        .dispatch_external_tool_call_with_timeout_policy(
+            &session_id,
+            call,
+            tool_dispatch_timeout_policy(tool_timeout_policy),
+        )
+        .await;
 
     match outcome_result {
         Ok(outcome) if outcome.result.is_error => {
+            let is_timeout = canonical_tool_result_error_code(&outcome.result)
+                .is_some_and(|code| code == "timeout");
             let error_message = outcome.result.text_content();
             let _ = submit_product_session_tool_error(
                 runtime,
@@ -3493,10 +3489,17 @@ async fn handle_product_session_tool_call(
                 error_message.clone(),
             )
             .await;
-            frames.push(channel_event(RealtimeEvent::ToolCallFailed {
-                call_id,
-                error: error_message,
-            }));
+            if is_timeout {
+                frames.push(channel_event(RealtimeEvent::ToolCallTimedOut {
+                    call_id,
+                    elapsed_ms: u64::try_from(started_at.elapsed().as_millis()).unwrap_or(u64::MAX),
+                }));
+            } else {
+                frames.push(channel_event(RealtimeEvent::ToolCallFailed {
+                    call_id,
+                    error: error_message,
+                }));
+            }
             Ok(frames)
         }
         Ok(outcome) => {
@@ -5160,6 +5163,36 @@ mod tests {
         assert!(
             bind_source.contains("realtime_bootstrap_eligibility"),
             "channel.open must re-check machine-owned realtime bootstrap eligibility before binding"
+        );
+    }
+
+    #[test]
+    fn product_session_tool_timeout_terminalization_is_not_websocket_local() {
+        let source = include_str!("realtime_ws.rs");
+        let start = source
+            .find("async fn handle_product_session_tool_call")
+            .expect("handle_product_session_tool_call should exist");
+        let end = source[start..]
+            .find("async fn submit_product_session_tool_result")
+            .map(|offset| start + offset)
+            .expect("submit_product_session_tool_result should follow tool-call handler");
+        let handler_source = &source[start..end];
+        assert!(
+            handler_source.contains("dispatch_external_tool_call_with_timeout_policy"),
+            "realtime product-session tool calls must delegate timeout policy to runtime dispatch"
+        );
+        assert!(
+            !handler_source.contains("tokio::time::timeout"),
+            "websocket handler must not own the timeout await branch"
+        );
+        assert!(
+            !handler_source.contains("ToolError::timeout")
+                && !handler_source.contains("terminal_tool_outcome_for_error"),
+            "websocket handler must not synthesize canonical timeout tool errors"
+        );
+        assert!(
+            !handler_source.contains("tool exceeded budget"),
+            "old websocket-local synthetic timeout message must stay amputated"
         );
     }
 

--- a/meerkat-rpc/src/session_runtime.rs
+++ b/meerkat-rpc/src/session_runtime.rs
@@ -4358,8 +4358,22 @@ impl SessionRuntime {
         session_id: &SessionId,
         call: meerkat_core::ToolCall,
     ) -> Result<meerkat_core::ops::ToolDispatchOutcome, SessionError> {
+        self.dispatch_external_tool_call_with_timeout_policy(
+            session_id,
+            call,
+            meerkat_core::ToolDispatchTimeoutPolicy::Disabled,
+        )
+        .await
+    }
+
+    pub async fn dispatch_external_tool_call_with_timeout_policy(
+        &self,
+        session_id: &SessionId,
+        call: meerkat_core::ToolCall,
+        timeout_policy: meerkat_core::ToolDispatchTimeoutPolicy,
+    ) -> Result<meerkat_core::ops::ToolDispatchOutcome, SessionError> {
         self.service
-            .dispatch_external_tool_call(session_id, call)
+            .dispatch_external_tool_call_with_timeout_policy(session_id, call, timeout_policy)
             .await
     }
 

--- a/meerkat-rpc/tests/realtime_ws_protocol.rs
+++ b/meerkat-rpc/tests/realtime_ws_protocol.rs
@@ -27,21 +27,23 @@ use meerkat_client::{
     RealtimeSessionEvent, RealtimeSessionFactory, realtime_session::RealtimeSessionOpenConfig,
 };
 use meerkat_contracts::{
-    RealtimeAudioChunk, RealtimeCapabilities, RealtimeChannelErrorFrame, RealtimeChannelEventFrame,
-    RealtimeChannelInputFrame, RealtimeChannelOpenFrame, RealtimeChannelRole, RealtimeChannelState,
-    RealtimeChannelStatus, RealtimeChannelTarget, RealtimeClientFrame, RealtimeErrorCode,
-    RealtimeEvent, RealtimeInputChunk, RealtimeInputKind, RealtimeOpenInfo, RealtimeOpenRequest,
-    RealtimeOutputKind, RealtimeReconnectPolicy, RealtimeServerFrame, RealtimeTextChunk,
-    RealtimeTurningMode, WireContentInput, WireSessionMessage,
+    RealtimeAudioChunk, RealtimeCapabilities, RealtimeChannelConfig, RealtimeChannelErrorFrame,
+    RealtimeChannelEventFrame, RealtimeChannelInputFrame, RealtimeChannelOpenFrame,
+    RealtimeChannelRole, RealtimeChannelState, RealtimeChannelStatus, RealtimeChannelTarget,
+    RealtimeClientFrame, RealtimeErrorCode, RealtimeEvent, RealtimeInputChunk, RealtimeInputKind,
+    RealtimeOpenInfo, RealtimeOpenRequest, RealtimeOutputKind, RealtimeReconnectPolicy,
+    RealtimeServerFrame, RealtimeTextChunk, RealtimeToolTimeoutPolicy, RealtimeTurningMode,
+    WireContentInput, WireSessionMessage,
 };
-use meerkat_core::ToolResult;
 use meerkat_core::lifecycle::RunId;
 use meerkat_core::lifecycle::core_executor::{
     CoreApplyOutput, CoreExecutor, CoreExecutorError, CoreExecutorInterruptHandle,
 };
 use meerkat_core::lifecycle::run_primitive::RunPrimitive;
 use meerkat_core::lifecycle::run_receipt::RunBoundaryReceipt;
+use meerkat_core::ops::ToolDispatchOutcome;
 use meerkat_core::session::ToolCategoryOverride;
+use meerkat_core::{AgentToolDispatcher, ToolCallView, ToolDef, ToolError, ToolResult};
 use meerkat_core::{Config, MemoryConfigStore, SessionHistoryQuery, StopReason};
 use meerkat_rpc::session_executor::SessionRuntimeExecutor;
 use meerkat_rpc::session_runtime::SessionRuntime;
@@ -120,6 +122,24 @@ impl LlmClient for MockLlmClient {
 
     async fn health_check(&self) -> Result<(), LlmError> {
         Ok(())
+    }
+}
+
+struct HangingToolDispatcher;
+
+#[async_trait::async_trait]
+impl AgentToolDispatcher for HangingToolDispatcher {
+    fn tools(&self) -> Arc<[Arc<ToolDef>]> {
+        Arc::from([Arc::new(ToolDef {
+            name: "slow".into(),
+            description: "hangs until the dispatch timeout fires".to_string(),
+            input_schema: serde_json::json!({ "type": "object" }),
+            provenance: None,
+        })])
+    }
+
+    async fn dispatch(&self, _call: ToolCallView<'_>) -> Result<ToolDispatchOutcome, ToolError> {
+        std::future::pending().await
     }
 }
 
@@ -273,10 +293,18 @@ impl CoreExecutor for NeverAppliedExecutor {
 }
 
 async fn create_realtime_session(runtime: &Arc<SessionRuntime>) -> meerkat_core::SessionId {
+    create_realtime_session_with_external_tools(runtime, None).await
+}
+
+async fn create_realtime_session_with_external_tools(
+    runtime: &Arc<SessionRuntime>,
+    external_tools: Option<Arc<dyn AgentToolDispatcher>>,
+) -> meerkat_core::SessionId {
     runtime
         .create_session(
             AgentBuildConfig {
                 override_builtins: ToolCategoryOverride::Enable,
+                external_tools,
                 ..AgentBuildConfig::new("gpt-realtime")
             },
             None,
@@ -319,7 +347,16 @@ async fn issue_open_info(
     role: RealtimeChannelRole,
     turning_mode: RealtimeTurningMode,
 ) -> RealtimeOpenInfo {
-    issue_open_info_with_policy(host, runtime, session_id, role, turning_mode, None).await
+    issue_open_info_with_policy_and_config(
+        host,
+        runtime,
+        session_id,
+        role,
+        turning_mode,
+        None,
+        None,
+    )
+    .await
 }
 
 async fn issue_open_info_with_policy(
@@ -329,6 +366,47 @@ async fn issue_open_info_with_policy(
     role: RealtimeChannelRole,
     turning_mode: RealtimeTurningMode,
     reconnect_policy: Option<RealtimeReconnectPolicy>,
+) -> RealtimeOpenInfo {
+    issue_open_info_with_policy_and_config(
+        host,
+        runtime,
+        session_id,
+        role,
+        turning_mode,
+        reconnect_policy,
+        None,
+    )
+    .await
+}
+
+async fn issue_open_info_with_channel_config(
+    host: &RealtimeWsHost,
+    runtime: &Arc<SessionRuntime>,
+    session_id: &str,
+    role: RealtimeChannelRole,
+    turning_mode: RealtimeTurningMode,
+    channel_config: RealtimeChannelConfig,
+) -> RealtimeOpenInfo {
+    issue_open_info_with_policy_and_config(
+        host,
+        runtime,
+        session_id,
+        role,
+        turning_mode,
+        None,
+        Some(channel_config),
+    )
+    .await
+}
+
+async fn issue_open_info_with_policy_and_config(
+    host: &RealtimeWsHost,
+    runtime: &Arc<SessionRuntime>,
+    session_id: &str,
+    role: RealtimeChannelRole,
+    turning_mode: RealtimeTurningMode,
+    reconnect_policy: Option<RealtimeReconnectPolicy>,
+    channel_config: Option<RealtimeChannelConfig>,
 ) -> RealtimeOpenInfo {
     let parsed_session_id =
         meerkat_core::SessionId::parse(session_id).expect("session_id should parse");
@@ -345,7 +423,7 @@ async fn issue_open_info_with_policy(
             role,
             turning_mode,
             reconnect_policy,
-            channel_config: None,
+            channel_config,
         },
         RealtimeOpenGrant::from_machine_eligibility(
             eligibility,
@@ -458,7 +536,14 @@ async fn read_history(
 }
 
 async fn create_materialized_session(runtime: &Arc<SessionRuntime>) -> meerkat_core::SessionId {
-    let session_id = create_realtime_session(runtime).await;
+    create_materialized_session_with_external_tools(runtime, None).await
+}
+
+async fn create_materialized_session_with_external_tools(
+    runtime: &Arc<SessionRuntime>,
+    external_tools: Option<Arc<dyn AgentToolDispatcher>>,
+) -> meerkat_core::SessionId {
+    let session_id = create_realtime_session_with_external_tools(runtime, external_tools).await;
     runtime
         .runtime_adapter()
         .register_session_with_executor(
@@ -2469,6 +2554,135 @@ async fn product_session_tool_call_failures_emit_failed_event_and_submit_provide
         seen_tool_errors[0].1.contains("missing_tool"),
         "provider error payload should include the dispatch failure"
     );
+
+    let _ = ws_stream.close(None).await;
+    server.abort();
+}
+
+#[tokio::test]
+async fn product_session_tool_timeout_projects_runtime_terminalization() {
+    let (_temp, runtime, config_store) = build_test_runtime();
+    let session_id = create_materialized_session_with_external_tools(
+        &runtime,
+        Some(Arc::new(HangingToolDispatcher) as Arc<dyn AgentToolDispatcher>),
+    )
+    .await;
+    let session_id_text = session_id.to_string();
+    let open_calls = Arc::new(tokio::sync::Mutex::new(0usize));
+    let attach_calls = Arc::new(tokio::sync::Mutex::new(0usize));
+    let seen_tool_results = Arc::new(tokio::sync::Mutex::new(Vec::new()));
+    let seen_tool_errors = Arc::new(tokio::sync::Mutex::new(Vec::new()));
+    let session_factory = Arc::new(FakeRealtimeSessionFactory {
+        capabilities: conservative_capabilities(vec![
+            RealtimeTurningMode::ProviderManaged,
+            RealtimeTurningMode::ExplicitCommit,
+        ]),
+        opened_sessions: tokio::sync::Mutex::new(std::collections::VecDeque::from(vec![Ok(
+            Box::new(FakeRealtimeSession {
+                capabilities: conservative_capabilities(vec![
+                    RealtimeTurningMode::ProviderManaged,
+                    RealtimeTurningMode::ExplicitCommit,
+                ]),
+                turning_mode: RealtimeTurningMode::ProviderManaged,
+                scripted_events: std::collections::VecDeque::from(vec![
+                    Ok(Some(RealtimeSessionEvent::ToolCallRequested {
+                        call_id: "call_tool_timeout".to_string(),
+                        tool_name: "slow".to_string(),
+                        arguments: serde_json::json!({}),
+                    })),
+                    Ok(None),
+                ]),
+                seen_inputs: Arc::new(tokio::sync::Mutex::new(Vec::new())),
+                seen_tool_results: Arc::clone(&seen_tool_results),
+                seen_tool_errors: Arc::clone(&seen_tool_errors),
+                release_events_after_input: false,
+                release_events_after_tool_submission: true,
+                input_seen: Arc::new(AtomicBool::new(false)),
+                input_gate: Arc::new(Notify::new()),
+                tool_submission_seen: Arc::new(AtomicBool::new(false)),
+                tool_submission_gate: Arc::new(Notify::new()),
+            }) as Box<dyn RealtimeSession>,
+        )])),
+        open_calls: Arc::clone(&open_calls),
+        open_configs: Arc::new(tokio::sync::Mutex::new(Vec::new())),
+        attach_calls: Arc::clone(&attach_calls),
+    });
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    let ws_url = format!("ws://{addr}{REALTIME_WS_PATH}");
+    let host =
+        Arc::new(RealtimeWsHost::new(ws_url.clone()).with_session_factory(session_factory.clone()));
+    let open_info = issue_open_info_with_channel_config(
+        host.as_ref(),
+        &runtime,
+        &session_id_text,
+        RealtimeChannelRole::Primary,
+        RealtimeTurningMode::ProviderManaged,
+        RealtimeChannelConfig {
+            tool_timeout: RealtimeToolTimeoutPolicy::Finite { timeout_ms: 10 },
+        },
+    )
+    .await;
+    let server_host = Arc::clone(&host);
+    let server_runtime = Arc::clone(&runtime);
+    let server = tokio::spawn(async move {
+        serve_realtime_ws_listener(listener, server_host, server_runtime, config_store).await
+    });
+
+    let mut ws_stream = connect_and_open(
+        &ws_url,
+        &open_info,
+        RealtimeChannelRole::Primary,
+        RealtimeTurningMode::ProviderManaged,
+    )
+    .await;
+    match read_server_frame(&mut ws_stream).await {
+        RealtimeServerFrame::ChannelOpened(opened) => {
+            assert_eq!(opened.status.state, RealtimeChannelState::Ready);
+        }
+        other => panic!("expected channel.opened, got {other:?}"),
+    }
+    assert_channel_event(
+        read_server_frame(&mut ws_stream).await,
+        RealtimeEvent::ToolCallRequested {
+            call_id: "call_tool_timeout".to_string(),
+            tool_name: "slow".to_string(),
+        },
+    );
+    match read_server_frame(&mut ws_stream).await {
+        RealtimeServerFrame::ChannelEvent(RealtimeChannelEventFrame {
+            event:
+                RealtimeEvent::ToolCallTimedOut {
+                    call_id,
+                    elapsed_ms,
+                },
+        }) => {
+            assert_eq!(call_id, "call_tool_timeout");
+            assert!(
+                elapsed_ms >= 10,
+                "timeout projection should carry elapsed runtime, got {elapsed_ms}ms",
+            );
+        }
+        other => panic!("expected ToolCallTimedOut event, got {other:?}"),
+    }
+
+    assert!(seen_tool_results.lock().await.is_empty());
+    let seen_tool_errors = seen_tool_errors.lock().await;
+    assert_eq!(seen_tool_errors.len(), 1);
+    assert_eq!(seen_tool_errors[0].0, "call_tool_timeout");
+    let expected = meerkat_core::ops::terminal_tool_outcome_for_error(
+        "call_tool_timeout",
+        ToolError::timeout("slow", 10),
+    )
+    .result
+    .text_content();
+    assert_eq!(
+        seen_tool_errors[0].1, expected,
+        "provider continuation must receive the runtime-authored canonical timeout payload",
+    );
+    let payload: serde_json::Value =
+        serde_json::from_str(&seen_tool_errors[0].1).expect("timeout payload should be JSON");
+    assert_eq!(payload["error"], "timeout");
 
     let _ = ws_stream.close(None).await;
     server.abort();

--- a/meerkat-rpc/tests/realtime_ws_protocol.rs
+++ b/meerkat-rpc/tests/realtime_ws_protocol.rs
@@ -143,6 +143,29 @@ impl AgentToolDispatcher for HangingToolDispatcher {
     }
 }
 
+struct TimeoutShapedToolErrorDispatcher;
+
+#[async_trait::async_trait]
+impl AgentToolDispatcher for TimeoutShapedToolErrorDispatcher {
+    fn tools(&self) -> Arc<[Arc<ToolDef>]> {
+        Arc::from([Arc::new(ToolDef {
+            name: "spoof_timeout".into(),
+            description: "returns an error payload shaped like a timeout".to_string(),
+            input_schema: serde_json::json!({ "type": "object" }),
+            provenance: None,
+        })])
+    }
+
+    async fn dispatch(&self, call: ToolCallView<'_>) -> Result<ToolDispatchOutcome, ToolError> {
+        Ok(ToolDispatchOutcome::sync_result(ToolResult::new(
+            call.id.to_string(),
+            "{\"error\":\"timeout\",\"message\":\"tool-authored timeout-shaped content\"}"
+                .to_string(),
+            true,
+        )))
+    }
+}
+
 struct FakeRealtimeSession {
     capabilities: RealtimeCapabilities,
     turning_mode: RealtimeTurningMode,
@@ -2683,6 +2706,117 @@ async fn product_session_tool_timeout_projects_runtime_terminalization() {
     let payload: serde_json::Value =
         serde_json::from_str(&seen_tool_errors[0].1).expect("timeout payload should be JSON");
     assert_eq!(payload["error"], "timeout");
+
+    let _ = ws_stream.close(None).await;
+    server.abort();
+}
+
+#[tokio::test]
+async fn product_session_tool_error_shaped_like_timeout_projects_failed_not_timed_out() {
+    let (_temp, runtime, config_store) = build_test_runtime();
+    let session_id = create_materialized_session_with_external_tools(
+        &runtime,
+        Some(Arc::new(TimeoutShapedToolErrorDispatcher) as Arc<dyn AgentToolDispatcher>),
+    )
+    .await;
+    let session_id_text = session_id.to_string();
+    let seen_tool_results = Arc::new(tokio::sync::Mutex::new(Vec::new()));
+    let seen_tool_errors = Arc::new(tokio::sync::Mutex::new(Vec::new()));
+    let session_factory = Arc::new(FakeRealtimeSessionFactory {
+        capabilities: conservative_capabilities(vec![
+            RealtimeTurningMode::ProviderManaged,
+            RealtimeTurningMode::ExplicitCommit,
+        ]),
+        opened_sessions: tokio::sync::Mutex::new(std::collections::VecDeque::from(vec![Ok(
+            Box::new(FakeRealtimeSession {
+                capabilities: conservative_capabilities(vec![
+                    RealtimeTurningMode::ProviderManaged,
+                    RealtimeTurningMode::ExplicitCommit,
+                ]),
+                turning_mode: RealtimeTurningMode::ProviderManaged,
+                scripted_events: std::collections::VecDeque::from(vec![
+                    Ok(Some(RealtimeSessionEvent::ToolCallRequested {
+                        call_id: "call_tool_spoof_timeout".to_string(),
+                        tool_name: "spoof_timeout".to_string(),
+                        arguments: serde_json::json!({}),
+                    })),
+                    Ok(None),
+                ]),
+                seen_inputs: Arc::new(tokio::sync::Mutex::new(Vec::new())),
+                seen_tool_results: Arc::clone(&seen_tool_results),
+                seen_tool_errors: Arc::clone(&seen_tool_errors),
+                release_events_after_input: false,
+                release_events_after_tool_submission: true,
+                input_seen: Arc::new(AtomicBool::new(false)),
+                input_gate: Arc::new(Notify::new()),
+                tool_submission_seen: Arc::new(AtomicBool::new(false)),
+                tool_submission_gate: Arc::new(Notify::new()),
+            }) as Box<dyn RealtimeSession>,
+        )])),
+        open_calls: Arc::new(tokio::sync::Mutex::new(0usize)),
+        open_configs: Arc::new(tokio::sync::Mutex::new(Vec::new())),
+        attach_calls: Arc::new(tokio::sync::Mutex::new(0usize)),
+    });
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    let ws_url = format!("ws://{addr}{REALTIME_WS_PATH}");
+    let host =
+        Arc::new(RealtimeWsHost::new(ws_url.clone()).with_session_factory(session_factory.clone()));
+    let open_info = issue_open_info_with_channel_config(
+        host.as_ref(),
+        &runtime,
+        &session_id_text,
+        RealtimeChannelRole::Primary,
+        RealtimeTurningMode::ProviderManaged,
+        RealtimeChannelConfig {
+            tool_timeout: RealtimeToolTimeoutPolicy::Finite { timeout_ms: 1_000 },
+        },
+    )
+    .await;
+    let server_host = Arc::clone(&host);
+    let server_runtime = Arc::clone(&runtime);
+    let server = tokio::spawn(async move {
+        serve_realtime_ws_listener(listener, server_host, server_runtime, config_store).await
+    });
+
+    let mut ws_stream = connect_and_open(
+        &ws_url,
+        &open_info,
+        RealtimeChannelRole::Primary,
+        RealtimeTurningMode::ProviderManaged,
+    )
+    .await;
+    match read_server_frame(&mut ws_stream).await {
+        RealtimeServerFrame::ChannelOpened(opened) => {
+            assert_eq!(opened.status.state, RealtimeChannelState::Ready);
+        }
+        other => panic!("expected channel.opened, got {other:?}"),
+    }
+    assert_channel_event(
+        read_server_frame(&mut ws_stream).await,
+        RealtimeEvent::ToolCallRequested {
+            call_id: "call_tool_spoof_timeout".to_string(),
+            tool_name: "spoof_timeout".to_string(),
+        },
+    );
+    let failed = match read_server_frame(&mut ws_stream).await {
+        RealtimeServerFrame::ChannelEvent(RealtimeChannelEventFrame {
+            event: RealtimeEvent::ToolCallFailed { call_id, error },
+        }) => (call_id, error),
+        other => panic!("expected ToolCallFailed event, got {other:?}"),
+    };
+    assert_eq!(failed.0, "call_tool_spoof_timeout");
+    assert!(
+        failed.1.contains("\"error\":\"timeout\""),
+        "timeout-shaped tool-authored payload should be surfaced as ordinary failure, got {}",
+        failed.1
+    );
+
+    assert!(seen_tool_results.lock().await.is_empty());
+    let seen_tool_errors = seen_tool_errors.lock().await;
+    assert_eq!(seen_tool_errors.len(), 1);
+    assert_eq!(seen_tool_errors[0].0, "call_tool_spoof_timeout");
+    assert_eq!(seen_tool_errors[0].1, failed.1);
 
     let _ = ws_stream.close(None).await;
     server.abort();

--- a/meerkat-session/src/ephemeral.rs
+++ b/meerkat-session/src/ephemeral.rs
@@ -150,6 +150,7 @@ enum SessionCommand {
     },
     DispatchExternalToolCall {
         call: meerkat_core::ToolCall,
+        timeout_policy: meerkat_core::ToolDispatchTimeoutPolicy,
         reply_tx: oneshot::Sender<
             Result<meerkat_core::ops::ToolDispatchOutcome, meerkat_core::error::AgentError>,
         >,
@@ -492,6 +493,15 @@ pub trait SessionAgent: Send {
         Err(meerkat_core::error::AgentError::ConfigError(
             "external live tool dispatch is not supported by this session agent".to_string(),
         ))
+    }
+
+    /// Dispatch an external tool call with a caller-specific timeout policy.
+    async fn dispatch_external_tool_call_with_timeout_policy(
+        &mut self,
+        call: meerkat_core::ToolCall,
+        _timeout_policy: meerkat_core::ToolDispatchTimeoutPolicy,
+    ) -> Result<meerkat_core::ops::ToolDispatchOutcome, meerkat_core::error::AgentError> {
+        self.dispatch_external_tool_call(call).await
     }
 
     /// Cancel the currently running turn.
@@ -1187,6 +1197,22 @@ impl<B: SessionAgentBuilder + 'static> EphemeralSessionService<B> {
         id: &SessionId,
         call: meerkat_core::ToolCall,
     ) -> Result<meerkat_core::ops::ToolDispatchOutcome, SessionError> {
+        self.dispatch_external_tool_call_with_timeout_policy(
+            id,
+            call,
+            meerkat_core::ToolDispatchTimeoutPolicy::Disabled,
+        )
+        .await
+    }
+
+    /// Dispatch an external tool call through the live session task with a
+    /// caller-specific timeout policy.
+    pub async fn dispatch_external_tool_call_with_timeout_policy(
+        &self,
+        id: &SessionId,
+        call: meerkat_core::ToolCall,
+        timeout_policy: meerkat_core::ToolDispatchTimeoutPolicy,
+    ) -> Result<meerkat_core::ops::ToolDispatchOutcome, SessionError> {
         let command_tx = {
             let sessions = self.sessions.read().await;
             let handle = sessions
@@ -1197,7 +1223,11 @@ impl<B: SessionAgentBuilder + 'static> EphemeralSessionService<B> {
 
         let (reply_tx, reply_rx) = oneshot::channel();
         command_tx
-            .send(SessionCommand::DispatchExternalToolCall { call, reply_tx })
+            .send(SessionCommand::DispatchExternalToolCall {
+                call,
+                timeout_policy,
+                reply_tx,
+            })
             .await
             .map_err(|_| {
                 SessionError::Agent(meerkat_core::error::AgentError::InternalError(
@@ -3563,8 +3593,14 @@ async fn session_task<A: SessionAgent>(
                 }
                 let _ = reply_tx.send(result);
             }
-            SessionCommand::DispatchExternalToolCall { call, reply_tx } => {
-                let result = agent.dispatch_external_tool_call(call).await;
+            SessionCommand::DispatchExternalToolCall {
+                call,
+                timeout_policy,
+                reply_tx,
+            } => {
+                let result = agent
+                    .dispatch_external_tool_call_with_timeout_policy(call, timeout_policy)
+                    .await;
                 if result.is_ok() {
                     let snap = agent.snapshot();
                     control.publish_summary(SessionSummaryCache {

--- a/meerkat-session/src/persistent.rs
+++ b/meerkat-session/src/persistent.rs
@@ -993,8 +993,25 @@ impl<B: SessionAgentBuilder + 'static> PersistentSessionService<B> {
         id: &SessionId,
         call: meerkat_core::ToolCall,
     ) -> Result<meerkat_core::ops::ToolDispatchOutcome, SessionError> {
+        self.dispatch_external_tool_call_with_timeout_policy(
+            id,
+            call,
+            meerkat_core::ToolDispatchTimeoutPolicy::Disabled,
+        )
+        .await
+    }
+
+    pub async fn dispatch_external_tool_call_with_timeout_policy(
+        &self,
+        id: &SessionId,
+        call: meerkat_core::ToolCall,
+        timeout_policy: meerkat_core::ToolDispatchTimeoutPolicy,
+    ) -> Result<meerkat_core::ops::ToolDispatchOutcome, SessionError> {
         let _mutation_guard = self.live_persist_mutation_guard(id).await?;
-        let outcome = self.inner.dispatch_external_tool_call(id, call).await?;
+        let outcome = self
+            .inner
+            .dispatch_external_tool_call_with_timeout_policy(id, call, timeout_policy)
+            .await?;
         if let Err(error) = self.persist_full_session(id).await {
             let _ = self.discard_live_session(id).await;
             return Err(error);

--- a/meerkat-tools/src/builtin/composite.rs
+++ b/meerkat-tools/src/builtin/composite.rs
@@ -454,21 +454,17 @@ impl AgentToolDispatcher for CompositeDispatcher {
                             Value::String(s) => s.clone(),
                             _ => serde_json::to_string(&value).unwrap_or_default(),
                         };
-                        return Ok(ToolDispatchOutcome {
-                            result: ToolResult::new(call.id.to_string(), content, false),
+                        return Ok(ToolDispatchOutcome::new(
+                            ToolResult::new(call.id.to_string(), content, false),
                             async_ops,
                             session_effects,
-                        });
+                        ));
                     }
                     ToolOutput::Blocks(blocks) => {
                         ToolResult::with_blocks(call.id.to_string(), blocks, false)
                     }
                 };
-                return Ok(ToolDispatchOutcome {
-                    result,
-                    async_ops,
-                    session_effects: vec![],
-                });
+                return Ok(ToolDispatchOutcome::new(result, async_ops, vec![]));
             }
         }
 
@@ -511,21 +507,17 @@ impl AgentToolDispatcher for CompositeDispatcher {
                                 Value::String(s) => s.clone(),
                                 _ => serde_json::to_string(&value).unwrap_or_default(),
                             };
-                            return Ok(ToolDispatchOutcome {
-                                result: ToolResult::new(call.id.to_string(), content, false),
+                            return Ok(ToolDispatchOutcome::new(
+                                ToolResult::new(call.id.to_string(), content, false),
                                 async_ops,
                                 session_effects,
-                            });
+                            ));
                         }
                         ToolOutput::Blocks(blocks) => {
                             ToolResult::with_blocks(call.id.to_string(), blocks, false)
                         }
                     };
-                    return Ok(ToolDispatchOutcome {
-                        result,
-                        async_ops,
-                        session_effects: vec![],
-                    });
+                    return Ok(ToolDispatchOutcome::new(result, async_ops, vec![]));
                 }
             }
         }

--- a/meerkat/src/service_factory.rs
+++ b/meerkat/src/service_factory.rs
@@ -268,6 +268,16 @@ impl SessionAgent for FactoryAgent {
         self.agent.dispatch_external_tool_call(call).await
     }
 
+    async fn dispatch_external_tool_call_with_timeout_policy(
+        &mut self,
+        call: meerkat_core::ToolCall,
+        timeout_policy: meerkat_core::ToolDispatchTimeoutPolicy,
+    ) -> Result<meerkat_core::ops::ToolDispatchOutcome, meerkat_core::error::AgentError> {
+        self.agent
+            .dispatch_external_tool_call_with_timeout_policy(call, timeout_policy)
+            .await
+    }
+
     fn sync_system_context_state(&mut self) {
         self.agent.sync_system_context_state_to_session();
     }

--- a/sdks/python/meerkat/generated/types.py
+++ b/sdks/python/meerkat/generated/types.py
@@ -1399,6 +1399,25 @@ class RealtimeReconnectPolicy:
     max_total_ms: int
 
 
+class RealtimeToolTimeoutPolicyDefault(TypedDict, total=False):
+    """Use the server's default realtime tool timeout."""
+    type: Required[Literal['default']]
+
+
+class RealtimeToolTimeoutPolicyDisabled(TypedDict, total=False):
+    """Do not apply a realtime-specific timeout."""
+    type: Required[Literal['disabled']]
+
+
+class RealtimeToolTimeoutPolicyFinite(TypedDict, total=False):
+    """Apply this finite realtime-specific timeout."""
+    timeout_ms: Required[int]
+    type: Required[Literal['finite']]
+
+
+RealtimeToolTimeoutPolicy = RealtimeToolTimeoutPolicyDefault | RealtimeToolTimeoutPolicyDisabled | RealtimeToolTimeoutPolicyFinite
+
+
 @dataclass
 class RealtimeChannelConfig:
     """Per-channel runtime knobs negotiated at open time.
@@ -1406,7 +1425,7 @@ class RealtimeChannelConfig:
 Additive fields only — clients that do not carry this struct inherit the
 server-default behavior via `#[serde(default)]` on the parent
 [`RealtimeOpenRequest`]."""
-    tool_timeout_ms: Optional[int] = None
+    tool_timeout: Optional[RealtimeToolTimeoutPolicy] = None
 
 
 @dataclass

--- a/sdks/typescript/src/generated/types.ts
+++ b/sdks/typescript/src/generated/types.ts
@@ -1865,8 +1865,23 @@ export interface RealtimeReconnectPolicy {
   max_total_ms: number;
 }
 
+export interface RealtimeToolTimeoutPolicyDefault {
+  type: "default";
+}
+
+export interface RealtimeToolTimeoutPolicyDisabled {
+  type: "disabled";
+}
+
+export interface RealtimeToolTimeoutPolicyFinite {
+  type: "finite";
+  timeout_ms: number;
+}
+
+export type RealtimeToolTimeoutPolicy = RealtimeToolTimeoutPolicyDefault | RealtimeToolTimeoutPolicyDisabled | RealtimeToolTimeoutPolicyFinite;
+
 export interface RealtimeChannelConfig {
-  tool_timeout_ms?: number;
+  tool_timeout?: RealtimeToolTimeoutPolicy;
 }
 
 export interface RealtimeAudioFormat {


### PR DESCRIPTION
## Summary
- Replace realtime channel tool timeout config with typed `RealtimeToolTimeoutPolicy` instead of `Option<u64>`/`0` sentinel semantics.
- Carry timeout terminal provenance on `ToolDispatchOutcome` from the canonical runtime/tool-dispatch `terminal_tool_outcome_for_error` path.
- Keep terminal provenance private and clear tool-returned `Ok` outcomes so tool-authored `is_error` content cannot mark itself as a runtime timeout.
- Delete websocket JSON/string parsing of `ToolResult` text for timeout classification; realtime now projects `ToolCallTimedOut` only from typed runtime timeout cause.
- Add spoofed `{"error":"timeout"}` realtime regression proving tool-authored timeout-shaped content is `ToolCallFailed`, not timed out.

## Validation
- `./scripts/repo-cargo test -p meerkat-contracts --test realtime_tool_timeout`
- `./scripts/repo-cargo test -p meerkat-core external_tool_dispatch`
- `./scripts/repo-cargo test -p meerkat-core terminal_tool_outcome`
- `./scripts/repo-cargo test -p meerkat-core tool_authored_error_result_has_no_runtime_terminal_cause`
- `./scripts/repo-cargo test -p meerkat-tools --test rct_contracts test_regression_dispatcher_timeout_enforced`
- `./scripts/repo-cargo test -p meerkat-rpc product_session_tool_timeout_terminalization_is_not_websocket_local`
- `./scripts/repo-cargo test -p meerkat-rpc --test realtime_ws_protocol product_session_tool_timeout_projects_runtime_terminalization`
- `./scripts/repo-cargo test -p meerkat-rpc --test realtime_ws_protocol product_session_tool_error_shaped_like_timeout_projects_failed_not_timed_out`
- `./scripts/repo-cargo test -p meerkat-rpc --test realtime_ws_protocol product_session_tool_call_failures_emit_failed_event_and_submit_provider_error`
- `make fmt-check`
- `git diff --check`
- `MEERKAT_BUILDBUDDY=1 make lint` (BuildBuddy invocation `c63e6f13-c864-4ef8-940b-b750324829b4`)
- `MEERKAT_BUILDBUDDY=1 make e2e-smoke` (BuildBuddy invocation `146b5b2f-1650-415f-83d4-02433f80a006`; nextest 44 passed)

Linear: LUC-394