### PR TITLE
Canonicalize realtime transcript appends

### DIFF
--- a/meerkat-core/src/lib.rs
+++ b/meerkat-core/src/lib.rs
@@ -56,6 +56,7 @@ pub mod placement;
 pub mod prompt;
 pub mod provider;
 pub mod provider_matrix;
+pub mod realtime_transcript;
 pub mod retry;
 pub mod runtime_bootstrap;
 pub mod runtime_epoch;
@@ -223,6 +224,10 @@ pub use ops_lifecycle::{
 #[cfg(not(target_arch = "wasm32"))]
 pub use prompt::{AGENTS_MD_MAX_BYTES, DEFAULT_SYSTEM_PROMPT, SystemPromptConfig};
 pub use provider::Provider;
+pub use realtime_transcript::{
+    RealtimeTranscriptApplyOutcome, RealtimeTranscriptEvent, RealtimeTranscriptMaterializedMessage,
+    RealtimeTranscriptRole, SESSION_REALTIME_TRANSCRIPT_STATE_KEY,
+};
 pub use retry::{
     LlmRetryFailure, LlmRetryFailureKind, LlmRetryPlan, LlmRetrySchedule, RetryPolicy,
     select_retry_delay,

--- a/meerkat-core/src/realtime_transcript.rs
+++ b/meerkat-core/src/realtime_transcript.rs
@@ -31,6 +31,12 @@ pub enum RealtimeTranscriptEvent {
         role: RealtimeTranscriptRole,
         response_id: Option<String>,
     },
+    /// Observe a provider item that participates in provider causal ordering
+    /// but must not materialize transcript content.
+    ItemSkipped {
+        item_id: String,
+        previous_item_id: Option<String>,
+    },
     /// Provider finalized the transcript for a user input item.
     UserTranscriptFinal {
         item_id: String,

--- a/meerkat-core/src/realtime_transcript.rs
+++ b/meerkat-core/src/realtime_transcript.rs
@@ -29,6 +29,7 @@ pub enum RealtimeTranscriptEvent {
         item_id: String,
         previous_item_id: Option<String>,
         role: RealtimeTranscriptRole,
+        response_id: Option<String>,
     },
     /// Provider finalized the transcript for a user input item.
     UserTranscriptFinal {
@@ -39,6 +40,7 @@ pub enum RealtimeTranscriptEvent {
     },
     /// Provider emitted an assistant text delta for an output item.
     AssistantTextDelta {
+        response_id: String,
         delta_id: String,
         item_id: String,
         previous_item_id: Option<String>,
@@ -48,6 +50,7 @@ pub enum RealtimeTranscriptEvent {
     /// Provider reported the assistant output item was truncated to the heard
     /// transcript prefix.
     AssistantTranscriptTruncated {
+        response_id: String,
         item_id: String,
         content_index: u32,
         text: String,
@@ -55,11 +58,12 @@ pub enum RealtimeTranscriptEvent {
     /// Provider turn reached a terminal boundary. The session decides which
     /// staged assistant items, if any, are now canonical.
     AssistantTurnCompleted {
+        response_id: String,
         stop_reason: StopReason,
         usage: Usage,
     },
     /// Provider turn was interrupted before terminal materialization.
-    AssistantTurnInterrupted,
+    AssistantTurnInterrupted { response_id: String },
 }
 
 /// Canonical message materialized by applying a realtime transcript event.
@@ -71,6 +75,7 @@ pub enum RealtimeTranscriptMaterializedMessage {
     },
     Assistant {
         item_id: String,
+        response_id: String,
         text: String,
         stop_reason: StopReason,
         usage: Usage,

--- a/meerkat-core/src/realtime_transcript.rs
+++ b/meerkat-core/src/realtime_transcript.rs
@@ -1,0 +1,91 @@
+//! Typed realtime transcript append seam.
+//!
+//! Provider adapters translate provider-native realtime events into these
+//! identity-bearing events. The session layer owns idempotency, causal ordering,
+//! and the decision to materialize canonical transcript messages.
+
+use serde::{Deserialize, Serialize};
+
+use crate::types::{StopReason, Usage};
+
+/// Durable session metadata key for realtime transcript append state.
+pub const SESSION_REALTIME_TRANSCRIPT_STATE_KEY: &str = "realtime_transcript_state";
+
+/// Provider-neutral role for a realtime transcript item.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum RealtimeTranscriptRole {
+    User,
+    Assistant,
+}
+
+/// A typed, identity-bearing realtime transcript event consumed by the session.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(tag = "type", rename_all = "snake_case")]
+pub enum RealtimeTranscriptEvent {
+    /// Observe a provider item and its causal predecessor without committing
+    /// content yet.
+    ItemObserved {
+        item_id: String,
+        previous_item_id: Option<String>,
+        role: RealtimeTranscriptRole,
+    },
+    /// Provider finalized the transcript for a user input item.
+    UserTranscriptFinal {
+        item_id: String,
+        previous_item_id: Option<String>,
+        content_index: u32,
+        text: String,
+    },
+    /// Provider emitted an assistant text delta for an output item.
+    AssistantTextDelta {
+        delta_id: String,
+        item_id: String,
+        previous_item_id: Option<String>,
+        content_index: u32,
+        delta: String,
+    },
+    /// Provider reported the assistant output item was truncated to the heard
+    /// transcript prefix.
+    AssistantTranscriptTruncated {
+        item_id: String,
+        content_index: u32,
+        text: String,
+    },
+    /// Provider turn reached a terminal boundary. The session decides which
+    /// staged assistant items, if any, are now canonical.
+    AssistantTurnCompleted {
+        stop_reason: StopReason,
+        usage: Usage,
+    },
+    /// Provider turn was interrupted before terminal materialization.
+    AssistantTurnInterrupted,
+}
+
+/// Canonical message materialized by applying a realtime transcript event.
+#[derive(Debug, Clone, PartialEq)]
+pub enum RealtimeTranscriptMaterializedMessage {
+    User {
+        item_id: String,
+        text: String,
+    },
+    Assistant {
+        item_id: String,
+        text: String,
+        stop_reason: StopReason,
+        usage: Usage,
+    },
+}
+
+/// Result of applying a realtime transcript event.
+#[derive(Debug, Clone, Default, PartialEq)]
+pub struct RealtimeTranscriptApplyOutcome {
+    pub materialized_messages: Vec<RealtimeTranscriptMaterializedMessage>,
+}
+
+impl RealtimeTranscriptApplyOutcome {
+    #[must_use]
+    pub fn is_inert(&self) -> bool {
+        self.materialized_messages.is_empty()
+    }
+}

--- a/meerkat-core/src/session.rs
+++ b/meerkat-core/src/session.rs
@@ -11,6 +11,10 @@
 
 use crate::Provider;
 use crate::peer_meta::PeerMeta;
+use crate::realtime_transcript::{
+    RealtimeTranscriptApplyOutcome, RealtimeTranscriptEvent, RealtimeTranscriptMaterializedMessage,
+    RealtimeTranscriptRole, SESSION_REALTIME_TRANSCRIPT_STATE_KEY,
+};
 use crate::service::{AppendSystemContextRequest, MobToolAuthorityContext};
 use crate::time_compat::SystemTime;
 use crate::tool_scope::ToolFilter;
@@ -44,6 +48,57 @@ pub const SESSION_VERSION: u32 = 2;
 ///   `SessionMetadata`-local shape change bumps this without moving
 ///   `SESSION_VERSION`.
 pub const SESSION_METADATA_SCHEMA_VERSION: u32 = 2;
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+struct SessionRealtimeTranscriptState {
+    #[serde(default)]
+    items: BTreeMap<String, RealtimeTranscriptItemState>,
+    #[serde(default)]
+    first_seen_order: Vec<String>,
+    #[serde(default)]
+    seen_delta_ids: BTreeSet<String>,
+    #[serde(default)]
+    pending_assistant_completion: Option<RealtimeAssistantCompletion>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+struct RealtimeTranscriptItemState {
+    role: RealtimeTranscriptRole,
+    #[serde(default)]
+    previous_item_id: Option<String>,
+    #[serde(default)]
+    content_segments: BTreeMap<u32, String>,
+    #[serde(default)]
+    ready: bool,
+    #[serde(default)]
+    materialized: bool,
+}
+
+impl RealtimeTranscriptItemState {
+    fn new(role: RealtimeTranscriptRole, previous_item_id: Option<String>) -> Self {
+        Self {
+            role,
+            previous_item_id,
+            content_segments: BTreeMap::new(),
+            ready: false,
+            materialized: false,
+        }
+    }
+
+    fn text(&self) -> String {
+        self.content_segments.values().cloned().collect()
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+struct RealtimeAssistantCompletion {
+    stop_reason: StopReason,
+    usage: Usage,
+    usage_consumed: bool,
+}
 
 /// A conversation session with full history
 ///
@@ -731,6 +786,231 @@ impl Session {
         }
     }
 
+    /// Apply an identity-bearing provider realtime transcript event.
+    ///
+    /// This is the canonical append authority for provider-managed realtime
+    /// turns: provider item ids, predecessor links, and content segment ids are
+    /// persisted in session metadata so duplicate websocket delivery,
+    /// reconnect replay, and causally equivalent event ordering cannot create
+    /// duplicate or misordered canonical messages.
+    pub fn append_realtime_transcript_event(
+        &mut self,
+        event: RealtimeTranscriptEvent,
+    ) -> RealtimeTranscriptApplyOutcome {
+        let mut state = self.realtime_transcript_state();
+        match event {
+            RealtimeTranscriptEvent::ItemObserved {
+                item_id,
+                previous_item_id,
+                role,
+            } => {
+                observe_realtime_item(&mut state, item_id, previous_item_id, role);
+            }
+            RealtimeTranscriptEvent::UserTranscriptFinal {
+                item_id,
+                previous_item_id,
+                content_index,
+                text,
+            } => {
+                if let Some(item) = observe_realtime_item(
+                    &mut state,
+                    item_id,
+                    previous_item_id,
+                    RealtimeTranscriptRole::User,
+                ) {
+                    item.content_segments.insert(content_index, text);
+                    item.ready = true;
+                }
+            }
+            RealtimeTranscriptEvent::AssistantTextDelta {
+                delta_id,
+                item_id,
+                previous_item_id,
+                content_index,
+                delta,
+            } => {
+                if !delta_id.trim().is_empty() && !state.seen_delta_ids.insert(delta_id) {
+                    return RealtimeTranscriptApplyOutcome::default();
+                }
+                if let Some(item) = observe_realtime_item(
+                    &mut state,
+                    item_id,
+                    previous_item_id,
+                    RealtimeTranscriptRole::Assistant,
+                ) {
+                    item.content_segments
+                        .entry(content_index)
+                        .or_default()
+                        .push_str(&delta);
+                }
+            }
+            RealtimeTranscriptEvent::AssistantTranscriptTruncated {
+                item_id,
+                content_index,
+                text,
+            } => {
+                if let Some(item) = observe_realtime_item(
+                    &mut state,
+                    item_id,
+                    None,
+                    RealtimeTranscriptRole::Assistant,
+                ) {
+                    item.content_segments.insert(content_index, text);
+                }
+            }
+            RealtimeTranscriptEvent::AssistantTurnCompleted { stop_reason, usage } => {
+                match stop_reason {
+                    StopReason::Cancelled => {
+                        for item in state.items.values_mut() {
+                            if item.role == RealtimeTranscriptRole::Assistant && !item.materialized
+                            {
+                                item.content_segments.clear();
+                                item.ready = false;
+                            }
+                        }
+                        state.pending_assistant_completion = None;
+                    }
+                    StopReason::ToolUse => {
+                        state.pending_assistant_completion = None;
+                    }
+                    _ => {
+                        state.pending_assistant_completion = Some(RealtimeAssistantCompletion {
+                            stop_reason,
+                            usage,
+                            usage_consumed: false,
+                        });
+                        for item in state.items.values_mut() {
+                            if item.role == RealtimeTranscriptRole::Assistant
+                                && !item.materialized
+                                && !item.text().is_empty()
+                            {
+                                item.ready = true;
+                            }
+                        }
+                    }
+                }
+            }
+            RealtimeTranscriptEvent::AssistantTurnInterrupted => {
+                for item in state.items.values_mut() {
+                    if item.role == RealtimeTranscriptRole::Assistant && !item.materialized {
+                        item.content_segments.clear();
+                        item.ready = false;
+                    }
+                }
+                state.pending_assistant_completion = None;
+            }
+        }
+
+        let outcome = self.materialize_realtime_transcript_ready_items(&mut state);
+        self.store_realtime_transcript_state(&state);
+        outcome
+    }
+
+    fn realtime_transcript_state(&self) -> SessionRealtimeTranscriptState {
+        self.metadata
+            .get(SESSION_REALTIME_TRANSCRIPT_STATE_KEY)
+            .cloned()
+            .and_then(|value| serde_json::from_value(value).ok())
+            .unwrap_or_default()
+    }
+
+    fn store_realtime_transcript_state(&mut self, state: &SessionRealtimeTranscriptState) {
+        match serde_json::to_value(state) {
+            Ok(value) => self.set_metadata(SESSION_REALTIME_TRANSCRIPT_STATE_KEY, value),
+            Err(error) => {
+                tracing::warn!(error = %error, "failed to serialize realtime transcript state");
+            }
+        }
+    }
+
+    fn materialize_realtime_transcript_ready_items(
+        &mut self,
+        state: &mut SessionRealtimeTranscriptState,
+    ) -> RealtimeTranscriptApplyOutcome {
+        let mut materialized = Vec::new();
+        loop {
+            let order = realtime_transcript_order(state);
+            let mut batch = Vec::new();
+            for item_id in order {
+                let Some(item) = state.items.get(&item_id) else {
+                    continue;
+                };
+                if item.materialized || !item.ready {
+                    continue;
+                }
+                if !realtime_predecessor_materialized(state, item.previous_item_id.as_deref()) {
+                    continue;
+                }
+                let text = item.text();
+                if text.is_empty() {
+                    continue;
+                }
+                match item.role {
+                    RealtimeTranscriptRole::User => {
+                        batch.push(RealtimeTranscriptMaterializedMessage::User {
+                            item_id: item_id.clone(),
+                            text,
+                        });
+                    }
+                    RealtimeTranscriptRole::Assistant => {
+                        let Some(completion) = state.pending_assistant_completion.as_ref() else {
+                            continue;
+                        };
+                        let usage = if completion.usage_consumed {
+                            Usage::default()
+                        } else {
+                            completion.usage.clone()
+                        };
+                        batch.push(RealtimeTranscriptMaterializedMessage::Assistant {
+                            item_id: item_id.clone(),
+                            text,
+                            stop_reason: completion.stop_reason,
+                            usage,
+                        });
+                    }
+                }
+            }
+            if batch.is_empty() {
+                break;
+            }
+            for message in batch {
+                match &message {
+                    RealtimeTranscriptMaterializedMessage::User { item_id, text } => {
+                        if let Some(item) = state.items.get_mut(item_id) {
+                            item.materialized = true;
+                        }
+                        self.append_external_user_content(ContentInput::Text(text.clone()));
+                    }
+                    RealtimeTranscriptMaterializedMessage::Assistant {
+                        item_id,
+                        text,
+                        stop_reason,
+                        usage,
+                    } => {
+                        if let Some(item) = state.items.get_mut(item_id) {
+                            item.materialized = true;
+                        }
+                        if let Some(completion) = state.pending_assistant_completion.as_mut() {
+                            completion.usage_consumed = true;
+                        }
+                        self.append_external_assistant_blocks(
+                            vec![AssistantBlock::Text {
+                                text: text.clone(),
+                                meta: None,
+                            }],
+                            *stop_reason,
+                            usage.clone(),
+                        );
+                    }
+                }
+                materialized.push(message);
+            }
+        }
+        RealtimeTranscriptApplyOutcome {
+            materialized_messages: materialized,
+        }
+    }
+
     /// Set a system prompt (adds or replaces System message at start)
     pub fn set_system_prompt(&mut self, prompt: String) {
         use crate::types::SystemMessage;
@@ -1366,6 +1646,121 @@ where
     deserializer.deserialize_any(ToolCategoryVisitor)
 }
 
+fn normalize_realtime_item_id(item_id: String) -> Option<String> {
+    let trimmed = item_id.trim();
+    (!trimmed.is_empty()).then(|| trimmed.to_string())
+}
+
+fn normalize_realtime_previous_item_id(previous_item_id: Option<String>) -> Option<String> {
+    previous_item_id.and_then(normalize_realtime_item_id)
+}
+
+fn observe_realtime_item(
+    state: &mut SessionRealtimeTranscriptState,
+    item_id: String,
+    previous_item_id: Option<String>,
+    role: RealtimeTranscriptRole,
+) -> Option<&mut RealtimeTranscriptItemState> {
+    let item_id = normalize_realtime_item_id(item_id)?;
+    let previous_item_id = normalize_realtime_previous_item_id(previous_item_id);
+    if !state
+        .first_seen_order
+        .iter()
+        .any(|existing| existing == &item_id)
+    {
+        state.first_seen_order.push(item_id.clone());
+    }
+    let item = state
+        .items
+        .entry(item_id.clone())
+        .or_insert_with(|| RealtimeTranscriptItemState::new(role, previous_item_id.clone()));
+    if item.role != role {
+        tracing::warn!(
+            item_id = %item_id,
+            existing_role = ?item.role,
+            observed_role = ?role,
+            "ignoring realtime transcript item role conflict"
+        );
+        return None;
+    }
+    if item.previous_item_id.is_none() && previous_item_id.is_some() {
+        item.previous_item_id = previous_item_id;
+    }
+    Some(item)
+}
+
+fn realtime_transcript_order(state: &SessionRealtimeTranscriptState) -> Vec<String> {
+    let mut roots = Vec::new();
+    let mut children: BTreeMap<String, Vec<String>> = BTreeMap::new();
+    for item_id in &state.first_seen_order {
+        let Some(item) = state.items.get(item_id) else {
+            continue;
+        };
+        if let Some(previous) = item.previous_item_id.as_ref()
+            && state.items.contains_key(previous)
+        {
+            children
+                .entry(previous.clone())
+                .or_default()
+                .push(item_id.clone());
+        } else {
+            roots.push(item_id.clone());
+        }
+    }
+    roots.sort_by_key(|item_id| realtime_first_seen_index(state, item_id));
+    for child_ids in children.values_mut() {
+        child_ids.sort_by_key(|item_id| realtime_first_seen_index(state, item_id));
+    }
+
+    let mut ordered = Vec::new();
+    let mut visited = BTreeSet::new();
+    for root in roots {
+        visit_realtime_transcript_item(&root, &children, &mut visited, &mut ordered);
+    }
+    for item_id in &state.first_seen_order {
+        visit_realtime_transcript_item(item_id, &children, &mut visited, &mut ordered);
+    }
+    ordered
+}
+
+fn realtime_first_seen_index(state: &SessionRealtimeTranscriptState, item_id: &str) -> usize {
+    state
+        .first_seen_order
+        .iter()
+        .position(|existing| existing == item_id)
+        .unwrap_or(usize::MAX)
+}
+
+fn visit_realtime_transcript_item(
+    item_id: &str,
+    children: &BTreeMap<String, Vec<String>>,
+    visited: &mut BTreeSet<String>,
+    ordered: &mut Vec<String>,
+) {
+    if !visited.insert(item_id.to_string()) {
+        return;
+    }
+    ordered.push(item_id.to_string());
+    if let Some(child_ids) = children.get(item_id) {
+        for child_id in child_ids {
+            visit_realtime_transcript_item(child_id, children, visited, ordered);
+        }
+    }
+}
+
+fn realtime_predecessor_materialized(
+    state: &SessionRealtimeTranscriptState,
+    previous_item_id: Option<&str>,
+) -> bool {
+    match previous_item_id {
+        None => true,
+        Some(previous_item_id) => state
+            .items
+            .get(previous_item_id)
+            .is_some_and(|item| item.materialized),
+    }
+}
+
 /// Tooling intent captured at session creation time.
 ///
 /// Fields use [`ToolCategoryOverride`] to distinguish "no opinion" from
@@ -1414,12 +1809,163 @@ mod tests {
     };
     use std::sync::Arc;
 
+    fn block_assistant_text(message: &BlockAssistantMessage) -> String {
+        message
+            .blocks
+            .iter()
+            .filter_map(|block| match block {
+                AssistantBlock::Text { text, .. } => Some(text.as_str()),
+                _ => None,
+            })
+            .collect()
+    }
+
     #[test]
     fn test_session_new() {
         let session = Session::new();
         assert_eq!(session.version(), SESSION_VERSION);
         assert!(session.messages().is_empty());
         assert!(session.created_at() <= session.updated_at());
+    }
+
+    #[test]
+    fn realtime_transcript_append_is_idempotent_by_provider_item_and_delta_id() {
+        let mut session = Session::new();
+
+        let user = RealtimeTranscriptEvent::UserTranscriptFinal {
+            item_id: "item_user".to_string(),
+            previous_item_id: None,
+            content_index: 0,
+            text: "hello".to_string(),
+        };
+        assert!(
+            !session
+                .append_realtime_transcript_event(user.clone())
+                .is_inert()
+        );
+        assert!(session.append_realtime_transcript_event(user).is_inert());
+
+        let delta = RealtimeTranscriptEvent::AssistantTextDelta {
+            delta_id: "evt_delta_1".to_string(),
+            item_id: "item_assistant".to_string(),
+            previous_item_id: Some("item_user".to_string()),
+            content_index: 0,
+            delta: "hi".to_string(),
+        };
+        assert!(
+            session
+                .append_realtime_transcript_event(delta.clone())
+                .is_inert()
+        );
+        assert!(session.append_realtime_transcript_event(delta).is_inert());
+
+        let terminal = RealtimeTranscriptEvent::AssistantTurnCompleted {
+            stop_reason: StopReason::EndTurn,
+            usage: Usage::default(),
+        };
+        assert!(
+            !session
+                .append_realtime_transcript_event(terminal.clone())
+                .is_inert()
+        );
+        assert!(
+            session
+                .append_realtime_transcript_event(terminal)
+                .is_inert()
+        );
+
+        assert_eq!(session.messages().len(), 2);
+        assert!(matches!(
+            &session.messages()[0],
+            Message::User(user) if user.text_content() == "hello"
+        ));
+        assert!(matches!(
+            &session.messages()[1],
+            Message::BlockAssistant(assistant) if block_assistant_text(assistant) == "hi"
+        ));
+    }
+
+    #[test]
+    fn realtime_transcript_append_orders_causally_equivalent_out_of_order_items() {
+        let mut session = Session::new();
+
+        assert!(
+            session
+                .append_realtime_transcript_event(RealtimeTranscriptEvent::AssistantTextDelta {
+                    delta_id: "evt_delta_1".to_string(),
+                    item_id: "item_assistant".to_string(),
+                    previous_item_id: Some("item_user".to_string()),
+                    content_index: 0,
+                    delta: "answer".to_string(),
+                })
+                .is_inert()
+        );
+        assert!(
+            session
+                .append_realtime_transcript_event(RealtimeTranscriptEvent::AssistantTurnCompleted {
+                    stop_reason: StopReason::EndTurn,
+                    usage: Usage::default(),
+                })
+                .is_inert()
+        );
+
+        let outcome = session.append_realtime_transcript_event(
+            RealtimeTranscriptEvent::UserTranscriptFinal {
+                item_id: "item_user".to_string(),
+                previous_item_id: None,
+                content_index: 0,
+                text: "question".to_string(),
+            },
+        );
+
+        assert_eq!(outcome.materialized_messages.len(), 2);
+        assert_eq!(session.messages().len(), 2);
+        assert!(matches!(
+            &session.messages()[0],
+            Message::User(user) if user.text_content() == "question"
+        ));
+        assert!(matches!(
+            &session.messages()[1],
+            Message::BlockAssistant(assistant) if block_assistant_text(assistant) == "answer"
+        ));
+    }
+
+    #[test]
+    fn realtime_transcript_replay_of_seen_provider_items_is_inert() {
+        let mut session = Session::new();
+        let events = vec![
+            RealtimeTranscriptEvent::UserTranscriptFinal {
+                item_id: "item_user".to_string(),
+                previous_item_id: None,
+                content_index: 0,
+                text: "hello".to_string(),
+            },
+            RealtimeTranscriptEvent::AssistantTextDelta {
+                delta_id: "evt_delta_1".to_string(),
+                item_id: "item_assistant".to_string(),
+                previous_item_id: Some("item_user".to_string()),
+                content_index: 0,
+                delta: "world".to_string(),
+            },
+            RealtimeTranscriptEvent::AssistantTurnCompleted {
+                stop_reason: StopReason::EndTurn,
+                usage: Usage::default(),
+            },
+        ];
+
+        for event in events.iter().cloned() {
+            let _ = session.append_realtime_transcript_event(event);
+        }
+        let first_messages = serde_json::to_value(session.messages()).unwrap();
+
+        for event in events {
+            assert!(session.append_realtime_transcript_event(event).is_inert());
+        }
+
+        assert_eq!(
+            serde_json::to_value(session.messages()).unwrap(),
+            first_messages
+        );
     }
 
     // Performance tests for Arc-based CoW

--- a/meerkat-core/src/session.rs
+++ b/meerkat-core/src/session.rs
@@ -851,7 +851,7 @@ impl Session {
                     item_id,
                     previous_item_id,
                     RealtimeTranscriptRole::Assistant,
-                    Some(response_id.clone()),
+                    Some(response_id),
                 ) {
                     item.content_segments
                         .entry(content_index)
@@ -877,7 +877,7 @@ impl Session {
                     item_id,
                     None,
                     RealtimeTranscriptRole::Assistant,
-                    Some(response_id.clone()),
+                    Some(response_id),
                 ) {
                     item.content_segments.insert(content_index, text);
                     if response_completed && !item.text().is_empty() {

--- a/meerkat-core/src/session.rs
+++ b/meerkat-core/src/session.rs
@@ -73,6 +73,8 @@ struct RealtimeTranscriptItemState {
     #[serde(default)]
     content_segments: BTreeMap<u32, String>,
     #[serde(default)]
+    skipped: bool,
+    #[serde(default)]
     ready: bool,
     #[serde(default)]
     materialized: bool,
@@ -89,7 +91,20 @@ impl RealtimeTranscriptItemState {
             previous_item_id,
             response_id,
             content_segments: BTreeMap::new(),
+            skipped: false,
             ready: false,
+            materialized: false,
+        }
+    }
+
+    fn skipped(previous_item_id: Option<String>) -> Self {
+        Self {
+            role: RealtimeTranscriptRole::Assistant,
+            previous_item_id,
+            response_id: None,
+            content_segments: BTreeMap::new(),
+            skipped: true,
+            ready: true,
             materialized: false,
         }
     }
@@ -814,6 +829,12 @@ impl Session {
             } => {
                 observe_realtime_item(&mut state, item_id, previous_item_id, role, response_id);
             }
+            RealtimeTranscriptEvent::ItemSkipped {
+                item_id,
+                previous_item_id,
+            } => {
+                observe_realtime_skipped_item(&mut state, item_id, previous_item_id);
+            }
             RealtimeTranscriptEvent::UserTranscriptFinal {
                 item_id,
                 previous_item_id,
@@ -827,7 +848,15 @@ impl Session {
                     RealtimeTranscriptRole::User,
                     None,
                 ) {
-                    item.content_segments.insert(content_index, text);
+                    let segment = item.content_segments.entry(content_index).or_default();
+                    if segment.is_empty() && !text.is_empty() {
+                        *segment = text;
+                    } else if !text.is_empty() && segment.as_str() != text {
+                        tracing::warn!(
+                            content_index,
+                            "ignoring conflicting realtime user transcript segment replay"
+                        );
+                    }
                     item.ready = true;
                 }
             }
@@ -950,15 +979,23 @@ impl Session {
         let mut materialized = Vec::new();
         loop {
             let order = realtime_transcript_order(state);
+            let mut skipped_batch = Vec::new();
             let mut batch = Vec::new();
             for item_id in order {
                 let Some(item) = state.items.get(&item_id) else {
                     continue;
                 };
-                if item.materialized || !item.ready {
+                if item.materialized {
                     continue;
                 }
                 if !realtime_predecessor_materialized(state, item.previous_item_id.as_deref()) {
+                    continue;
+                }
+                if item.skipped {
+                    skipped_batch.push(item_id.clone());
+                    continue;
+                }
+                if !item.ready {
                     continue;
                 }
                 let text = item.text();
@@ -994,8 +1031,13 @@ impl Session {
                     }
                 }
             }
-            if batch.is_empty() {
+            if skipped_batch.is_empty() && batch.is_empty() {
                 break;
+            }
+            for item_id in skipped_batch {
+                if let Some(item) = state.items.get_mut(&item_id) {
+                    item.materialized = true;
+                }
             }
             for message in batch {
                 match &message {
@@ -1708,6 +1750,14 @@ fn observe_realtime_item(
     let item = state.items.entry(item_id.clone()).or_insert_with(|| {
         RealtimeTranscriptItemState::new(role, previous_item_id.clone(), response_id.clone())
     });
+    if item.skipped {
+        tracing::warn!(
+            item_id = %item_id,
+            observed_role = ?role,
+            "ignoring realtime transcript content for item previously observed as non-dialogue"
+        );
+        return None;
+    }
     if item.role != role {
         tracing::warn!(
             item_id = %item_id,
@@ -1736,6 +1786,34 @@ fn observe_realtime_item(
         }
     }
     Some(item)
+}
+
+fn observe_realtime_skipped_item(
+    state: &mut SessionRealtimeTranscriptState,
+    item_id: String,
+    previous_item_id: Option<String>,
+) {
+    let Some(item_id) = normalize_realtime_item_id(item_id) else {
+        return;
+    };
+    let previous_item_id = normalize_realtime_previous_item_id(previous_item_id);
+    if !state
+        .first_seen_order
+        .iter()
+        .any(|existing| existing == &item_id)
+    {
+        state.first_seen_order.push(item_id.clone());
+    }
+    let item = state
+        .items
+        .entry(item_id)
+        .or_insert_with(|| RealtimeTranscriptItemState::skipped(previous_item_id.clone()));
+    if !item.content_segments.is_empty() || !item.skipped {
+        return;
+    }
+    if item.previous_item_id.is_none() && previous_item_id.is_some() {
+        item.previous_item_id = previous_item_id;
+    }
 }
 
 fn mark_realtime_assistant_response_ready(
@@ -2048,6 +2126,149 @@ mod tests {
             assert!(session.append_realtime_transcript_event(event).is_inert());
         }
 
+        assert_eq!(
+            serde_json::to_value(session.messages()).unwrap(),
+            first_messages
+        );
+    }
+
+    #[test]
+    fn realtime_transcript_user_final_replay_cannot_erase_existing_segment() {
+        let mut session = Session::new();
+
+        let user = RealtimeTranscriptEvent::UserTranscriptFinal {
+            item_id: "item_user".to_string(),
+            previous_item_id: None,
+            content_index: 0,
+            text: "remember amber lantern".to_string(),
+        };
+        assert!(
+            !session
+                .append_realtime_transcript_event(user.clone())
+                .is_inert()
+        );
+        let first_messages = serde_json::to_value(session.messages()).unwrap();
+
+        assert!(
+            session
+                .append_realtime_transcript_event(RealtimeTranscriptEvent::UserTranscriptFinal {
+                    item_id: "item_user".to_string(),
+                    previous_item_id: None,
+                    content_index: 0,
+                    text: String::new(),
+                })
+                .is_inert()
+        );
+        assert!(session.append_realtime_transcript_event(user).is_inert());
+        assert_eq!(
+            serde_json::to_value(session.messages()).unwrap(),
+            first_messages
+        );
+    }
+
+    #[test]
+    fn realtime_transcript_empty_user_final_can_be_filled_by_later_nonempty_replay() {
+        let mut session = Session::new();
+
+        assert!(
+            session
+                .append_realtime_transcript_event(RealtimeTranscriptEvent::UserTranscriptFinal {
+                    item_id: "item_user".to_string(),
+                    previous_item_id: None,
+                    content_index: 0,
+                    text: String::new(),
+                })
+                .is_inert()
+        );
+        assert!(session.messages().is_empty());
+
+        let outcome = session.append_realtime_transcript_event(
+            RealtimeTranscriptEvent::UserTranscriptFinal {
+                item_id: "item_user".to_string(),
+                previous_item_id: None,
+                content_index: 0,
+                text: "remember amber lantern".to_string(),
+            },
+        );
+        assert_eq!(outcome.materialized_messages.len(), 1);
+        assert_eq!(session.messages().len(), 1);
+        assert!(matches!(
+            &session.messages()[0],
+            Message::User(user) if user.text_content() == "remember amber lantern"
+        ));
+    }
+
+    #[test]
+    fn realtime_transcript_skipped_provider_items_preserve_causal_order_without_content() {
+        let mut session = Session::new();
+
+        let assistant_delta = RealtimeTranscriptEvent::AssistantTextDelta {
+            response_id: "resp_assistant".to_string(),
+            delta_id: "evt_delta_1".to_string(),
+            item_id: "item_assistant".to_string(),
+            previous_item_id: Some("item_tool".to_string()),
+            content_index: 0,
+            delta: "done".to_string(),
+        };
+        assert!(
+            session
+                .append_realtime_transcript_event(assistant_delta.clone())
+                .is_inert()
+        );
+        let assistant_complete = RealtimeTranscriptEvent::AssistantTurnCompleted {
+            response_id: "resp_assistant".to_string(),
+            stop_reason: StopReason::EndTurn,
+            usage: Usage::default(),
+        };
+        assert!(
+            session
+                .append_realtime_transcript_event(assistant_complete.clone())
+                .is_inert()
+        );
+
+        let skipped = RealtimeTranscriptEvent::ItemSkipped {
+            item_id: "item_tool".to_string(),
+            previous_item_id: Some("item_user".to_string()),
+        };
+        assert!(
+            session
+                .append_realtime_transcript_event(skipped.clone())
+                .is_inert(),
+            "a skipped provider item must not append transcript content"
+        );
+        assert!(session.messages().is_empty());
+
+        let outcome = session.append_realtime_transcript_event(
+            RealtimeTranscriptEvent::UserTranscriptFinal {
+                item_id: "item_user".to_string(),
+                previous_item_id: None,
+                content_index: 0,
+                text: "please use the tool".to_string(),
+            },
+        );
+        assert_eq!(outcome.materialized_messages.len(), 2);
+        assert_eq!(session.messages().len(), 2);
+        assert!(matches!(
+            &session.messages()[0],
+            Message::User(user) if user.text_content() == "please use the tool"
+        ));
+        assert!(matches!(
+            &session.messages()[1],
+            Message::BlockAssistant(assistant) if block_assistant_text(assistant) == "done"
+        ));
+
+        let first_messages = serde_json::to_value(session.messages()).unwrap();
+        assert!(session.append_realtime_transcript_event(skipped).is_inert());
+        assert!(
+            session
+                .append_realtime_transcript_event(assistant_delta)
+                .is_inert()
+        );
+        assert!(
+            session
+                .append_realtime_transcript_event(assistant_complete)
+                .is_inert()
+        );
         assert_eq!(
             serde_json::to_value(session.messages()).unwrap(),
             first_messages

--- a/meerkat-core/src/session.rs
+++ b/meerkat-core/src/session.rs
@@ -1751,10 +1751,13 @@ fn observe_realtime_item(
         RealtimeTranscriptItemState::new(role, previous_item_id.clone(), response_id.clone())
     });
     if item.skipped {
+        if item.previous_item_id.is_none() && previous_item_id.is_some() {
+            item.previous_item_id = previous_item_id;
+        }
         tracing::warn!(
             item_id = %item_id,
             observed_role = ?role,
-            "ignoring realtime transcript content for item previously observed as non-dialogue"
+            "ignoring realtime transcript content for item already marked as a contentless causal anchor"
         );
         return None;
     }
@@ -1841,7 +1844,8 @@ fn discard_realtime_assistant_response(
             && !item.materialized
         {
             item.content_segments.clear();
-            item.ready = false;
+            item.skipped = true;
+            item.ready = true;
         }
     }
     state.assistant_completions.remove(response_id);
@@ -2272,6 +2276,71 @@ mod tests {
         assert_eq!(
             serde_json::to_value(session.messages()).unwrap(),
             first_messages
+        );
+    }
+
+    #[test]
+    fn realtime_transcript_interrupted_assistant_item_unblocks_later_provider_items() {
+        let mut session = Session::new();
+
+        let _ = session.append_realtime_transcript_event(
+            RealtimeTranscriptEvent::UserTranscriptFinal {
+                item_id: "item_repeat".to_string(),
+                previous_item_id: None,
+                content_index: 0,
+                text: "repeat until stop".to_string(),
+            },
+        );
+        assert!(
+            session
+                .append_realtime_transcript_event(RealtimeTranscriptEvent::AssistantTextDelta {
+                    response_id: "resp_loop".to_string(),
+                    delta_id: "evt_loop_1".to_string(),
+                    item_id: "item_loop".to_string(),
+                    previous_item_id: Some("item_repeat".to_string()),
+                    content_index: 0,
+                    delta: "Looping now".to_string(),
+                })
+                .is_inert()
+        );
+        assert!(
+            session
+                .append_realtime_transcript_event(RealtimeTranscriptEvent::UserTranscriptFinal {
+                    item_id: "item_stop".to_string(),
+                    previous_item_id: Some("item_loop".to_string()),
+                    content_index: 0,
+                    text: "Stop.".to_string(),
+                })
+                .is_inert(),
+            "the stop turn waits until the interrupted assistant provider item is resolved"
+        );
+
+        let outcome = session.append_realtime_transcript_event(
+            RealtimeTranscriptEvent::AssistantTurnInterrupted {
+                response_id: "resp_loop".to_string(),
+            },
+        );
+
+        assert_eq!(outcome.materialized_messages.len(), 1);
+        assert_eq!(session.messages().len(), 2);
+        assert!(matches!(
+            &session.messages()[0],
+            Message::User(user) if user.text_content() == "repeat until stop"
+        ));
+        assert!(matches!(
+            &session.messages()[1],
+            Message::User(user) if user.text_content() == "Stop."
+        ));
+        assert!(
+            session
+                .messages()
+                .iter()
+                .filter_map(|message| match message {
+                    Message::BlockAssistant(assistant) => Some(block_assistant_text(assistant)),
+                    _ => None,
+                })
+                .all(|text| !text.contains("Looping now")),
+            "interrupted assistant text must remain non-canonical"
         );
     }
 

--- a/meerkat-core/src/session.rs
+++ b/meerkat-core/src/session.rs
@@ -59,7 +59,7 @@ struct SessionRealtimeTranscriptState {
     #[serde(default)]
     seen_delta_ids: BTreeSet<String>,
     #[serde(default)]
-    pending_assistant_completion: Option<RealtimeAssistantCompletion>,
+    assistant_completions: BTreeMap<String, RealtimeAssistantCompletion>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -69,6 +69,8 @@ struct RealtimeTranscriptItemState {
     #[serde(default)]
     previous_item_id: Option<String>,
     #[serde(default)]
+    response_id: Option<String>,
+    #[serde(default)]
     content_segments: BTreeMap<u32, String>,
     #[serde(default)]
     ready: bool,
@@ -77,10 +79,15 @@ struct RealtimeTranscriptItemState {
 }
 
 impl RealtimeTranscriptItemState {
-    fn new(role: RealtimeTranscriptRole, previous_item_id: Option<String>) -> Self {
+    fn new(
+        role: RealtimeTranscriptRole,
+        previous_item_id: Option<String>,
+        response_id: Option<String>,
+    ) -> Self {
         Self {
             role,
             previous_item_id,
+            response_id,
             content_segments: BTreeMap::new(),
             ready: false,
             materialized: false,
@@ -803,8 +810,9 @@ impl Session {
                 item_id,
                 previous_item_id,
                 role,
+                response_id,
             } => {
-                observe_realtime_item(&mut state, item_id, previous_item_id, role);
+                observe_realtime_item(&mut state, item_id, previous_item_id, role, response_id);
             }
             RealtimeTranscriptEvent::UserTranscriptFinal {
                 item_id,
@@ -817,87 +825,99 @@ impl Session {
                     item_id,
                     previous_item_id,
                     RealtimeTranscriptRole::User,
+                    None,
                 ) {
                     item.content_segments.insert(content_index, text);
                     item.ready = true;
                 }
             }
             RealtimeTranscriptEvent::AssistantTextDelta {
+                response_id,
                 delta_id,
                 item_id,
                 previous_item_id,
                 content_index,
                 delta,
             } => {
+                let Some(response_id) = normalize_realtime_response_id(response_id) else {
+                    return RealtimeTranscriptApplyOutcome::default();
+                };
                 if !delta_id.trim().is_empty() && !state.seen_delta_ids.insert(delta_id) {
                     return RealtimeTranscriptApplyOutcome::default();
                 }
+                let response_completed = state.assistant_completions.contains_key(&response_id);
                 if let Some(item) = observe_realtime_item(
                     &mut state,
                     item_id,
                     previous_item_id,
                     RealtimeTranscriptRole::Assistant,
+                    Some(response_id.clone()),
                 ) {
                     item.content_segments
                         .entry(content_index)
                         .or_default()
                         .push_str(&delta);
+                    if response_completed && !item.text().is_empty() {
+                        item.ready = true;
+                    }
                 }
             }
             RealtimeTranscriptEvent::AssistantTranscriptTruncated {
+                response_id,
                 item_id,
                 content_index,
                 text,
             } => {
+                let Some(response_id) = normalize_realtime_response_id(response_id) else {
+                    return RealtimeTranscriptApplyOutcome::default();
+                };
+                let response_completed = state.assistant_completions.contains_key(&response_id);
                 if let Some(item) = observe_realtime_item(
                     &mut state,
                     item_id,
                     None,
                     RealtimeTranscriptRole::Assistant,
+                    Some(response_id.clone()),
                 ) {
                     item.content_segments.insert(content_index, text);
+                    if response_completed && !item.text().is_empty() {
+                        item.ready = true;
+                    }
                 }
             }
-            RealtimeTranscriptEvent::AssistantTurnCompleted { stop_reason, usage } => {
+            RealtimeTranscriptEvent::AssistantTurnCompleted {
+                response_id,
+                stop_reason,
+                usage,
+            } => {
+                let Some(response_id) = normalize_realtime_response_id(response_id) else {
+                    return RealtimeTranscriptApplyOutcome::default();
+                };
                 match stop_reason {
                     StopReason::Cancelled => {
-                        for item in state.items.values_mut() {
-                            if item.role == RealtimeTranscriptRole::Assistant && !item.materialized
-                            {
-                                item.content_segments.clear();
-                                item.ready = false;
-                            }
-                        }
-                        state.pending_assistant_completion = None;
+                        discard_realtime_assistant_response(&mut state, &response_id);
                     }
                     StopReason::ToolUse => {
-                        state.pending_assistant_completion = None;
+                        state.assistant_completions.remove(&response_id);
                     }
                     _ => {
-                        state.pending_assistant_completion = Some(RealtimeAssistantCompletion {
-                            stop_reason,
-                            usage,
-                            usage_consumed: false,
-                        });
-                        for item in state.items.values_mut() {
-                            if item.role == RealtimeTranscriptRole::Assistant
-                                && !item.materialized
-                                && !item.text().is_empty()
-                            {
-                                item.ready = true;
-                            }
-                        }
+                        state
+                            .assistant_completions
+                            .entry(response_id.clone())
+                            .or_insert(RealtimeAssistantCompletion {
+                                stop_reason,
+                                usage,
+                                usage_consumed: false,
+                            });
+                        mark_realtime_assistant_response_ready(&mut state, &response_id);
                     }
                 }
             }
-            RealtimeTranscriptEvent::AssistantTurnInterrupted => {
-                for item in state.items.values_mut() {
-                    if item.role == RealtimeTranscriptRole::Assistant && !item.materialized {
-                        item.content_segments.clear();
-                        item.ready = false;
-                    }
-                }
-                state.pending_assistant_completion = None;
+            RealtimeTranscriptEvent::AssistantTurnInterrupted { response_id } => {
+                let Some(response_id) = normalize_realtime_response_id(response_id) else {
+                    return RealtimeTranscriptApplyOutcome::default();
+                };
+                discard_realtime_assistant_response(&mut state, &response_id);
             }
         }
 
@@ -953,7 +973,10 @@ impl Session {
                         });
                     }
                     RealtimeTranscriptRole::Assistant => {
-                        let Some(completion) = state.pending_assistant_completion.as_ref() else {
+                        let Some(response_id) = item.response_id.as_ref() else {
+                            continue;
+                        };
+                        let Some(completion) = state.assistant_completions.get(response_id) else {
                             continue;
                         };
                         let usage = if completion.usage_consumed {
@@ -963,6 +986,7 @@ impl Session {
                         };
                         batch.push(RealtimeTranscriptMaterializedMessage::Assistant {
                             item_id: item_id.clone(),
+                            response_id: response_id.clone(),
                             text,
                             stop_reason: completion.stop_reason,
                             usage,
@@ -983,6 +1007,7 @@ impl Session {
                     }
                     RealtimeTranscriptMaterializedMessage::Assistant {
                         item_id,
+                        response_id,
                         text,
                         stop_reason,
                         usage,
@@ -990,7 +1015,7 @@ impl Session {
                         if let Some(item) = state.items.get_mut(item_id) {
                             item.materialized = true;
                         }
-                        if let Some(completion) = state.pending_assistant_completion.as_mut() {
+                        if let Some(completion) = state.assistant_completions.get_mut(response_id) {
                             completion.usage_consumed = true;
                         }
                         self.append_external_assistant_blocks(
@@ -1655,14 +1680,24 @@ fn normalize_realtime_previous_item_id(previous_item_id: Option<String>) -> Opti
     previous_item_id.and_then(normalize_realtime_item_id)
 }
 
+fn normalize_realtime_response_id(response_id: String) -> Option<String> {
+    normalize_realtime_item_id(response_id)
+}
+
+fn normalize_realtime_optional_response_id(response_id: Option<String>) -> Option<String> {
+    response_id.and_then(normalize_realtime_response_id)
+}
+
 fn observe_realtime_item(
     state: &mut SessionRealtimeTranscriptState,
     item_id: String,
     previous_item_id: Option<String>,
     role: RealtimeTranscriptRole,
+    response_id: Option<String>,
 ) -> Option<&mut RealtimeTranscriptItemState> {
     let item_id = normalize_realtime_item_id(item_id)?;
     let previous_item_id = normalize_realtime_previous_item_id(previous_item_id);
+    let response_id = normalize_realtime_optional_response_id(response_id);
     if !state
         .first_seen_order
         .iter()
@@ -1670,10 +1705,9 @@ fn observe_realtime_item(
     {
         state.first_seen_order.push(item_id.clone());
     }
-    let item = state
-        .items
-        .entry(item_id.clone())
-        .or_insert_with(|| RealtimeTranscriptItemState::new(role, previous_item_id.clone()));
+    let item = state.items.entry(item_id.clone()).or_insert_with(|| {
+        RealtimeTranscriptItemState::new(role, previous_item_id.clone(), response_id.clone())
+    });
     if item.role != role {
         tracing::warn!(
             item_id = %item_id,
@@ -1686,7 +1720,53 @@ fn observe_realtime_item(
     if item.previous_item_id.is_none() && previous_item_id.is_some() {
         item.previous_item_id = previous_item_id;
     }
+    if let Some(response_id) = response_id {
+        match item.response_id.as_ref() {
+            Some(existing) if existing != &response_id => {
+                tracing::warn!(
+                    item_id = %item_id,
+                    existing_response_id = %existing,
+                    observed_response_id = %response_id,
+                    "ignoring realtime transcript item response conflict"
+                );
+                return None;
+            }
+            Some(_) => {}
+            None => item.response_id = Some(response_id),
+        }
+    }
     Some(item)
+}
+
+fn mark_realtime_assistant_response_ready(
+    state: &mut SessionRealtimeTranscriptState,
+    response_id: &str,
+) {
+    for item in state.items.values_mut() {
+        if item.role == RealtimeTranscriptRole::Assistant
+            && item.response_id.as_deref() == Some(response_id)
+            && !item.materialized
+            && !item.text().is_empty()
+        {
+            item.ready = true;
+        }
+    }
+}
+
+fn discard_realtime_assistant_response(
+    state: &mut SessionRealtimeTranscriptState,
+    response_id: &str,
+) {
+    for item in state.items.values_mut() {
+        if item.role == RealtimeTranscriptRole::Assistant
+            && item.response_id.as_deref() == Some(response_id)
+            && !item.materialized
+        {
+            item.content_segments.clear();
+            item.ready = false;
+        }
+    }
+    state.assistant_completions.remove(response_id);
 }
 
 fn realtime_transcript_order(state: &SessionRealtimeTranscriptState) -> Vec<String> {
@@ -1846,6 +1926,7 @@ mod tests {
         assert!(session.append_realtime_transcript_event(user).is_inert());
 
         let delta = RealtimeTranscriptEvent::AssistantTextDelta {
+            response_id: "resp_assistant".to_string(),
             delta_id: "evt_delta_1".to_string(),
             item_id: "item_assistant".to_string(),
             previous_item_id: Some("item_user".to_string()),
@@ -1860,6 +1941,7 @@ mod tests {
         assert!(session.append_realtime_transcript_event(delta).is_inert());
 
         let terminal = RealtimeTranscriptEvent::AssistantTurnCompleted {
+            response_id: "resp_assistant".to_string(),
             stop_reason: StopReason::EndTurn,
             usage: Usage::default(),
         };
@@ -1892,6 +1974,7 @@ mod tests {
         assert!(
             session
                 .append_realtime_transcript_event(RealtimeTranscriptEvent::AssistantTextDelta {
+                    response_id: "resp_assistant".to_string(),
                     delta_id: "evt_delta_1".to_string(),
                     item_id: "item_assistant".to_string(),
                     previous_item_id: Some("item_user".to_string()),
@@ -1903,6 +1986,7 @@ mod tests {
         assert!(
             session
                 .append_realtime_transcript_event(RealtimeTranscriptEvent::AssistantTurnCompleted {
+                    response_id: "resp_assistant".to_string(),
                     stop_reason: StopReason::EndTurn,
                     usage: Usage::default(),
                 })
@@ -1941,6 +2025,7 @@ mod tests {
                 text: "hello".to_string(),
             },
             RealtimeTranscriptEvent::AssistantTextDelta {
+                response_id: "resp_assistant".to_string(),
                 delta_id: "evt_delta_1".to_string(),
                 item_id: "item_assistant".to_string(),
                 previous_item_id: Some("item_user".to_string()),
@@ -1948,6 +2033,7 @@ mod tests {
                 delta: "world".to_string(),
             },
             RealtimeTranscriptEvent::AssistantTurnCompleted {
+                response_id: "resp_assistant".to_string(),
                 stop_reason: StopReason::EndTurn,
                 usage: Usage::default(),
             },
@@ -1966,6 +2052,232 @@ mod tests {
             serde_json::to_value(session.messages()).unwrap(),
             first_messages
         );
+    }
+
+    #[test]
+    fn realtime_transcript_completion_only_finalizes_matching_response() {
+        let mut session = Session::new();
+
+        let _ = session.append_realtime_transcript_event(
+            RealtimeTranscriptEvent::UserTranscriptFinal {
+                item_id: "item_user".to_string(),
+                previous_item_id: None,
+                content_index: 0,
+                text: "question".to_string(),
+            },
+        );
+        assert!(
+            session
+                .append_realtime_transcript_event(RealtimeTranscriptEvent::AssistantTextDelta {
+                    response_id: "resp_a".to_string(),
+                    delta_id: "evt_a".to_string(),
+                    item_id: "item_a".to_string(),
+                    previous_item_id: Some("item_user".to_string()),
+                    content_index: 0,
+                    delta: "answer a".to_string(),
+                })
+                .is_inert()
+        );
+
+        assert!(
+            session
+                .append_realtime_transcript_event(RealtimeTranscriptEvent::AssistantTurnCompleted {
+                    response_id: "resp_b".to_string(),
+                    stop_reason: StopReason::EndTurn,
+                    usage: Usage::default(),
+                })
+                .is_inert(),
+            "a completion for another response must not finalize buffered assistant text"
+        );
+        assert_eq!(session.messages().len(), 1);
+
+        let outcome = session.append_realtime_transcript_event(
+            RealtimeTranscriptEvent::AssistantTurnCompleted {
+                response_id: "resp_a".to_string(),
+                stop_reason: StopReason::EndTurn,
+                usage: Usage::default(),
+            },
+        );
+        assert_eq!(outcome.materialized_messages.len(), 1);
+        assert_eq!(session.messages().len(), 2);
+        assert!(matches!(
+            &session.messages()[1],
+            Message::BlockAssistant(assistant) if block_assistant_text(assistant) == "answer a"
+        ));
+    }
+
+    #[test]
+    fn realtime_transcript_completion_before_later_delta_is_response_scoped() {
+        let mut session = Session::new();
+
+        let _ = session.append_realtime_transcript_event(
+            RealtimeTranscriptEvent::UserTranscriptFinal {
+                item_id: "item_user".to_string(),
+                previous_item_id: None,
+                content_index: 0,
+                text: "question".to_string(),
+            },
+        );
+        assert!(
+            session
+                .append_realtime_transcript_event(RealtimeTranscriptEvent::AssistantTurnCompleted {
+                    response_id: "resp_a".to_string(),
+                    stop_reason: StopReason::EndTurn,
+                    usage: Usage::default(),
+                })
+                .is_inert()
+        );
+        assert!(
+            session
+                .append_realtime_transcript_event(RealtimeTranscriptEvent::AssistantTextDelta {
+                    response_id: "resp_b".to_string(),
+                    delta_id: "evt_b".to_string(),
+                    item_id: "item_b".to_string(),
+                    previous_item_id: Some("item_user".to_string()),
+                    content_index: 0,
+                    delta: "wrong response".to_string(),
+                })
+                .is_inert(),
+            "a later delta for another response must not be finalized by resp_a's pending completion"
+        );
+
+        let outcome =
+            session.append_realtime_transcript_event(RealtimeTranscriptEvent::AssistantTextDelta {
+                response_id: "resp_a".to_string(),
+                delta_id: "evt_a".to_string(),
+                item_id: "item_a".to_string(),
+                previous_item_id: Some("item_user".to_string()),
+                content_index: 0,
+                delta: "right response".to_string(),
+            });
+
+        assert_eq!(outcome.materialized_messages.len(), 1);
+        assert_eq!(session.messages().len(), 2);
+        assert!(matches!(
+            &session.messages()[1],
+            Message::BlockAssistant(assistant) if block_assistant_text(assistant) == "right response"
+        ));
+    }
+
+    #[test]
+    fn realtime_transcript_late_duplicate_completion_cannot_finalize_unrelated_response() {
+        let mut session = Session::new();
+
+        let _ = session.append_realtime_transcript_event(
+            RealtimeTranscriptEvent::UserTranscriptFinal {
+                item_id: "item_user".to_string(),
+                previous_item_id: None,
+                content_index: 0,
+                text: "question".to_string(),
+            },
+        );
+        let _ =
+            session.append_realtime_transcript_event(RealtimeTranscriptEvent::AssistantTextDelta {
+                response_id: "resp_a".to_string(),
+                delta_id: "evt_a".to_string(),
+                item_id: "item_a".to_string(),
+                previous_item_id: Some("item_user".to_string()),
+                content_index: 0,
+                delta: "first".to_string(),
+            });
+        let _ = session.append_realtime_transcript_event(
+            RealtimeTranscriptEvent::AssistantTurnCompleted {
+                response_id: "resp_a".to_string(),
+                stop_reason: StopReason::EndTurn,
+                usage: Usage::default(),
+            },
+        );
+        assert_eq!(session.messages().len(), 2);
+
+        assert!(
+            session
+                .append_realtime_transcript_event(RealtimeTranscriptEvent::AssistantTextDelta {
+                    response_id: "resp_b".to_string(),
+                    delta_id: "evt_b".to_string(),
+                    item_id: "item_b".to_string(),
+                    previous_item_id: Some("item_a".to_string()),
+                    content_index: 0,
+                    delta: "second".to_string(),
+                })
+                .is_inert()
+        );
+        assert!(
+            session
+                .append_realtime_transcript_event(RealtimeTranscriptEvent::AssistantTurnCompleted {
+                    response_id: "resp_a".to_string(),
+                    stop_reason: StopReason::EndTurn,
+                    usage: Usage::default(),
+                })
+                .is_inert(),
+            "a duplicate late terminal for resp_a must not finalize resp_b"
+        );
+        assert_eq!(session.messages().len(), 2);
+
+        let outcome = session.append_realtime_transcript_event(
+            RealtimeTranscriptEvent::AssistantTurnCompleted {
+                response_id: "resp_b".to_string(),
+                stop_reason: StopReason::EndTurn,
+                usage: Usage::default(),
+            },
+        );
+        assert_eq!(outcome.materialized_messages.len(), 1);
+        assert_eq!(session.messages().len(), 3);
+    }
+
+    #[test]
+    fn realtime_transcript_interruption_discards_only_matching_response() {
+        let mut session = Session::new();
+
+        let _ = session.append_realtime_transcript_event(
+            RealtimeTranscriptEvent::UserTranscriptFinal {
+                item_id: "item_user".to_string(),
+                previous_item_id: None,
+                content_index: 0,
+                text: "question".to_string(),
+            },
+        );
+        let _ =
+            session.append_realtime_transcript_event(RealtimeTranscriptEvent::AssistantTextDelta {
+                response_id: "resp_a".to_string(),
+                delta_id: "evt_a".to_string(),
+                item_id: "item_a".to_string(),
+                previous_item_id: Some("item_user".to_string()),
+                content_index: 0,
+                delta: "discard me".to_string(),
+            });
+        let _ =
+            session.append_realtime_transcript_event(RealtimeTranscriptEvent::AssistantTextDelta {
+                response_id: "resp_b".to_string(),
+                delta_id: "evt_b".to_string(),
+                item_id: "item_b".to_string(),
+                previous_item_id: Some("item_user".to_string()),
+                content_index: 0,
+                delta: "keep me".to_string(),
+            });
+
+        assert!(
+            session
+                .append_realtime_transcript_event(
+                    RealtimeTranscriptEvent::AssistantTurnInterrupted {
+                        response_id: "resp_a".to_string(),
+                    }
+                )
+                .is_inert()
+        );
+        let outcome = session.append_realtime_transcript_event(
+            RealtimeTranscriptEvent::AssistantTurnCompleted {
+                response_id: "resp_b".to_string(),
+                stop_reason: StopReason::EndTurn,
+                usage: Usage::default(),
+            },
+        );
+
+        assert_eq!(outcome.materialized_messages.len(), 1);
+        assert_eq!(session.messages().len(), 2);
+        assert!(matches!(
+            &session.messages()[1],
+            Message::BlockAssistant(assistant) if block_assistant_text(assistant) == "keep me"
+        ));
     }
 
     // Performance tests for Arc-based CoW

--- a/meerkat-llm-core/src/realtime_session.rs
+++ b/meerkat-llm-core/src/realtime_session.rs
@@ -53,6 +53,7 @@ pub enum RealtimeSessionEvent {
     TurnStarted,
     TurnCommitted,
     TurnCompleted {
+        response_id: String,
         stop_reason: StopReason,
         usage: Usage,
     },
@@ -60,6 +61,7 @@ pub enum RealtimeSessionEvent {
         delta: String,
     },
     OutputTextDeltaForItem {
+        response_id: String,
         delta_id: String,
         item_id: String,
         previous_item_id: Option<String>,
@@ -72,7 +74,9 @@ pub enum RealtimeSessionEvent {
     OutputVideoChunk {
         chunk: RealtimeVideoChunk,
     },
-    Interrupted,
+    Interrupted {
+        response_id: Option<String>,
+    },
     ToolCallRequested {
         call_id: String,
         tool_name: String,
@@ -82,6 +86,7 @@ pub enum RealtimeSessionEvent {
     /// `audio_played_ms` because the user barged in. `truncated_text` is the
     /// heard prefix, or `None` if the provider has not yet re-projected it.
     AssistantTranscriptTruncated {
+        response_id: Option<String>,
         item_id: String,
         audio_played_ms: u64,
         truncated_text: Option<String>,
@@ -128,7 +133,7 @@ impl RealtimeSessionEvent {
             Self::OutputVideoChunk { chunk } => RealtimeEvent::OutputVideoChunk {
                 chunk: chunk.clone(),
             },
-            Self::Interrupted => RealtimeEvent::Interrupted,
+            Self::Interrupted { .. } => RealtimeEvent::Interrupted,
             Self::ToolCallRequested {
                 call_id, tool_name, ..
             } => RealtimeEvent::ToolCallRequested {
@@ -136,6 +141,7 @@ impl RealtimeSessionEvent {
                 tool_name: tool_name.clone(),
             },
             Self::AssistantTranscriptTruncated {
+                response_id: _,
                 item_id,
                 audio_played_ms,
                 truncated_text,

--- a/meerkat-llm-core/src/realtime_session.rs
+++ b/meerkat-llm-core/src/realtime_session.rs
@@ -8,7 +8,7 @@ use meerkat_contracts::{
     RealtimeAudioChunk, RealtimeCapabilities, RealtimeEvent, RealtimeInputChunk,
     RealtimeTurningMode, RealtimeVideoChunk,
 };
-use meerkat_core::{PendingSystemContextAppend, ToolResult};
+use meerkat_core::{PendingSystemContextAppend, RealtimeTranscriptEvent, ToolResult};
 use meerkat_core::{SessionLlmIdentity, StopReason, ToolDef, types::Message, types::Usage};
 use serde_json::Value;
 
@@ -44,6 +44,12 @@ pub enum RealtimeSessionEvent {
     InputTranscriptFinal {
         text: String,
     },
+    InputTranscriptFinalForItem {
+        item_id: String,
+        previous_item_id: Option<String>,
+        content_index: u32,
+        text: String,
+    },
     TurnStarted,
     TurnCommitted,
     TurnCompleted {
@@ -51,6 +57,13 @@ pub enum RealtimeSessionEvent {
         usage: Usage,
     },
     OutputTextDelta {
+        delta: String,
+    },
+    OutputTextDeltaForItem {
+        delta_id: String,
+        item_id: String,
+        previous_item_id: Option<String>,
+        content_index: u32,
         delta: String,
     },
     OutputAudioChunk {
@@ -73,13 +86,18 @@ pub enum RealtimeSessionEvent {
         audio_played_ms: u64,
         truncated_text: Option<String>,
     },
+    /// Identity-bearing transcript event for providers that need to expose an
+    /// ordering/append fact without an otherwise public channel event.
+    RealtimeTranscript {
+        event: RealtimeTranscriptEvent,
+    },
 }
 
 impl RealtimeSessionEvent {
     /// Project an internal provider event into the public channel event shape.
     #[must_use]
-    pub fn to_public_event(&self) -> RealtimeEvent {
-        match self {
+    pub fn to_public_event(&self) -> Option<RealtimeEvent> {
+        Some(match self {
             Self::InputTranscriptPartial { text } => {
                 RealtimeEvent::InputTranscriptPartial { text: text.clone() }
             }
@@ -91,10 +109,17 @@ impl RealtimeSessionEvent {
                 // this field before emitting the public event.
                 prosody_hint: None,
             },
+            Self::InputTranscriptFinalForItem { text, .. } => RealtimeEvent::InputTranscriptFinal {
+                text: text.clone(),
+                prosody_hint: None,
+            },
             Self::TurnStarted => RealtimeEvent::TurnStarted,
             Self::TurnCommitted => RealtimeEvent::TurnCommitted,
             Self::TurnCompleted { .. } => RealtimeEvent::TurnCompleted,
             Self::OutputTextDelta { delta } => RealtimeEvent::OutputTextDelta {
+                delta: delta.clone(),
+            },
+            Self::OutputTextDeltaForItem { delta, .. } => RealtimeEvent::OutputTextDelta {
                 delta: delta.clone(),
             },
             Self::OutputAudioChunk { chunk } => RealtimeEvent::OutputAudioChunk {
@@ -119,7 +144,8 @@ impl RealtimeSessionEvent {
                 audio_played_ms: *audio_played_ms,
                 truncated_text: truncated_text.clone(),
             },
-        }
+            Self::RealtimeTranscript { .. } => return None,
+        })
     }
 }
 
@@ -297,10 +323,10 @@ mod tests {
 
         assert_eq!(
             public,
-            RealtimeEvent::ToolCallRequested {
+            Some(RealtimeEvent::ToolCallRequested {
                 call_id: "call_1".to_string(),
                 tool_name: "lookup".to_string(),
-            }
+            })
         );
     }
 }

--- a/meerkat-openai/src/live.rs
+++ b/meerkat-openai/src/live.rs
@@ -25,7 +25,7 @@ use oai_rt_rs::protocol::models::{
     Role, SessionUpdate, SessionUpdateConfig, Tool, TurnDetection, Voice,
 };
 use oai_rt_rs::{ClientEvent, Error as OpenAiLiveError, RealtimeClient, ServerEvent};
-use std::collections::{BTreeMap, VecDeque};
+use std::collections::{BTreeMap, BTreeSet, VecDeque};
 use std::sync::Arc;
 use std::time::Duration;
 
@@ -762,7 +762,30 @@ fn openai_realtime_item_transcript_identity(
 
 fn openai_realtime_item_id(item: &Item) -> Option<&str> {
     match item {
-        Item::Message { id: Some(id), .. } | Item::McpCall { id: Some(id), .. } => Some(id),
+        Item::Message { id: Some(id), .. }
+        | Item::FunctionCall { id: Some(id), .. }
+        | Item::FunctionCallOutput { id: Some(id), .. }
+        | Item::McpCall { id: Some(id), .. }
+        | Item::McpListTools { id: Some(id), .. }
+        | Item::McpApprovalRequest { id: Some(id), .. }
+        | Item::McpApprovalResponse { id: Some(id), .. } => Some(id),
+        _ => None,
+    }
+}
+
+fn openai_realtime_skipped_item_id(item: &Item) -> Option<String> {
+    match item {
+        Item::Message {
+            id: Some(id),
+            role: Role::System,
+            ..
+        }
+        | Item::FunctionCall { id: Some(id), .. }
+        | Item::FunctionCallOutput { id: Some(id), .. }
+        | Item::McpCall { id: Some(id), .. }
+        | Item::McpListTools { id: Some(id), .. }
+        | Item::McpApprovalRequest { id: Some(id), .. }
+        | Item::McpApprovalResponse { id: Some(id), .. } => Some(id.clone()),
         _ => None,
     }
 }
@@ -853,6 +876,7 @@ pub struct OpenAiRealtimeSession {
     pending_mcp_calls: BTreeMap<String, PendingMcpCall>,
     item_previous: BTreeMap<String, Option<String>>,
     item_response: BTreeMap<String, String>,
+    projected_seed_item_ids: BTreeSet<String>,
     pending_output_audio_transcripts: BTreeMap<String, String>,
     pending_text_suppressions: VecDeque<String>,
     active_response_id: Option<String>,
@@ -896,6 +920,7 @@ impl OpenAiRealtimeSession {
             pending_mcp_calls: BTreeMap::new(),
             item_previous: BTreeMap::new(),
             item_response: BTreeMap::new(),
+            projected_seed_item_ids: BTreeSet::new(),
             pending_output_audio_transcripts: BTreeMap::new(),
             pending_text_suppressions: VecDeque::new(),
             active_response_id: None,
@@ -964,8 +989,11 @@ impl OpenAiRealtimeSession {
                     return Err(LlmError::ConnectionReset);
                 };
                 match event {
-                    ServerEvent::ConversationItemCreated { .. }
-                    | ServerEvent::ConversationItemAdded { .. } => {
+                    ServerEvent::ConversationItemCreated { item, .. }
+                    | ServerEvent::ConversationItemAdded { item, .. } => {
+                        if let Some(item_id) = openai_realtime_item_id(&item) {
+                            self.projected_seed_item_ids.insert(item_id.to_string());
+                        }
                         acknowledged += 1;
                     }
                     other => {
@@ -991,7 +1019,21 @@ impl OpenAiRealtimeSession {
     }
 
     fn previous_item_id_for(&self, item_id: &str) -> Option<String> {
-        self.item_previous.get(item_id).cloned().flatten()
+        self.canonical_previous_item_id(self.item_previous.get(item_id).cloned().flatten())
+    }
+
+    fn canonical_previous_item_id(&self, previous_item_id: Option<String>) -> Option<String> {
+        previous_item_id.filter(|item_id| !self.projected_seed_item_ids.contains(item_id))
+    }
+
+    fn note_previous_for_item(&mut self, item_id: &str, previous_item_id: Option<String>) {
+        let entry = self
+            .item_previous
+            .entry(item_id.to_string())
+            .or_insert(None);
+        if entry.is_none() && previous_item_id.is_some() {
+            *entry = previous_item_id;
+        }
     }
 
     fn note_response_for_item(&mut self, response_id: &str, item_id: &str) {
@@ -1012,9 +1054,8 @@ impl OpenAiRealtimeSession {
         role: RealtimeTranscriptRole,
         response_id: Option<String>,
     ) -> RealtimeSessionEvent {
-        self.item_previous
-            .entry(item_id.clone())
-            .or_insert_with(|| previous_item_id.clone());
+        self.note_previous_for_item(&item_id, previous_item_id.clone());
+        let previous_item_id = self.canonical_previous_item_id(previous_item_id);
         if let Some(response_id) = response_id.as_deref() {
             self.note_response_for_item(response_id, &item_id);
         }
@@ -1024,6 +1065,21 @@ impl OpenAiRealtimeSession {
                 previous_item_id,
                 role,
                 response_id,
+            },
+        }
+    }
+
+    fn observe_skipped_item(
+        &mut self,
+        item_id: String,
+        previous_item_id: Option<String>,
+    ) -> RealtimeSessionEvent {
+        self.note_previous_for_item(&item_id, previous_item_id.clone());
+        let previous_item_id = self.canonical_previous_item_id(previous_item_id);
+        RealtimeSessionEvent::RealtimeTranscript {
+            event: RealtimeTranscriptEvent::ItemSkipped {
+                item_id,
+                previous_item_id,
             },
         }
     }
@@ -1211,9 +1267,14 @@ impl OpenAiRealtimeSession {
                 previous_item_id,
                 item,
                 ..
-            } => openai_realtime_item_transcript_identity(&item).map(|(item_id, role)| {
-                self.observe_transcript_item(item_id, previous_item_id, role, None)
-            }),
+            } => {
+                if let Some((item_id, role)) = openai_realtime_item_transcript_identity(&item) {
+                    Some(self.observe_transcript_item(item_id, previous_item_id, role, None))
+                } else {
+                    openai_realtime_skipped_item_id(&item)
+                        .map(|item_id| self.observe_skipped_item(item_id, previous_item_id))
+                }
+            }
             ServerEvent::InputAudioTranscriptionDelta { delta, .. } => {
                 Some(RealtimeSessionEvent::InputTranscriptPartial { text: delta })
             }
@@ -1246,9 +1307,7 @@ impl OpenAiRealtimeSession {
                 item_id,
                 ..
             } => {
-                self.item_previous
-                    .entry(item_id)
-                    .or_insert(previous_item_id);
+                self.note_previous_for_item(&item_id, previous_item_id);
                 self.awaiting_provider_response_after_commit =
                     self.turning_mode == RealtimeTurningMode::ProviderManaged;
                 self.provider_response_acknowledged_without_progress = false;
@@ -3222,6 +3281,117 @@ mod tests {
                 stop_reason: StopReason::ToolUse,
                 ..
             })
+        ));
+        assert_eq!(session.next_event().await.expect("eof"), None);
+    }
+
+    #[tokio::test]
+    async fn provider_neutral_session_emits_non_dialogue_items_as_transcript_anchors() {
+        let mut session = OpenAiRealtimeSession::new(
+            Box::new(FakeOpenAiLiveSession {
+                seen: Arc::new(Mutex::new(Vec::new())),
+                next_events: Arc::new(Mutex::new(VecDeque::from(vec![
+                    Ok(Some(ServerEvent::ConversationItemAdded {
+                        event_id: "evt_tool_item".to_string(),
+                        previous_item_id: Some("item_user".to_string()),
+                        item: Item::FunctionCall {
+                            id: Some("item_tool".to_string()),
+                            status: None,
+                            name: "lookup".to_string(),
+                            call_id: "call_tool".to_string(),
+                            arguments: "{}".to_string(),
+                        },
+                    })),
+                    Ok(Some(ServerEvent::InputAudioBufferCommitted {
+                        event_id: "evt_commit".to_string(),
+                        previous_item_id: Some("item_tool".to_string()),
+                        item_id: "item_next_user".to_string(),
+                    })),
+                    Ok(None),
+                ]))),
+            }),
+            RealtimeTurningMode::ProviderManaged,
+        );
+
+        assert!(matches!(
+            session.next_event().await.expect("tool anchor"),
+            Some(RealtimeSessionEvent::RealtimeTranscript {
+                event: RealtimeTranscriptEvent::ItemSkipped {
+                    item_id,
+                    previous_item_id: Some(previous),
+                },
+            }) if item_id == "item_tool" && previous == "item_user"
+        ));
+        assert!(matches!(
+            session.next_event().await.expect("commit"),
+            Some(RealtimeSessionEvent::TurnCommitted)
+        ));
+        assert_eq!(
+            session.previous_item_id_for("item_next_user").as_deref(),
+            Some("item_tool")
+        );
+        assert_eq!(session.next_event().await.expect("eof"), None);
+    }
+
+    #[tokio::test]
+    async fn provider_neutral_session_treats_projected_seed_items_as_transcript_boundaries() {
+        let seen = Arc::new(Mutex::new(Vec::new()));
+        let mut session = OpenAiRealtimeSession::new(
+            Box::new(FakeOpenAiLiveSession {
+                seen: Arc::clone(&seen),
+                next_events: Arc::new(Mutex::new(VecDeque::from(vec![
+                    Ok(Some(ServerEvent::ConversationItemCreated {
+                        event_id: "evt_seed_user".to_string(),
+                        previous_item_id: None,
+                        item: Item::Message {
+                            id: Some("item_seed_user".to_string()),
+                            status: None,
+                            role: Role::User,
+                            content: vec![ContentPart::InputText {
+                                text: "remember amber lantern".to_string(),
+                            }],
+                        },
+                    })),
+                    Ok(Some(ServerEvent::InputAudioBufferCommitted {
+                        event_id: "evt_commit".to_string(),
+                        previous_item_id: Some("item_seed_user".to_string()),
+                        item_id: "item_live_user".to_string(),
+                    })),
+                    Ok(Some(ServerEvent::InputAudioTranscriptionCompleted {
+                        event_id: "evt_final".to_string(),
+                        item_id: "item_live_user".to_string(),
+                        content_index: 0,
+                        transcript: "Say only the codeword once.".to_string(),
+                        logprobs: None,
+                        usage: None,
+                    })),
+                    Ok(None),
+                ]))),
+            }),
+            RealtimeTurningMode::ProviderManaged,
+        );
+        let seed_messages = vec![Message::User(meerkat_core::UserMessage::text(
+            "remember amber lantern",
+        ))];
+
+        session
+            .seed_history_projection(&seed_messages, &[])
+            .await
+            .expect("seed history projection");
+        assert_eq!(seen.lock().await.len(), 1);
+
+        assert!(matches!(
+            session.next_event().await.expect("commit"),
+            Some(RealtimeSessionEvent::TurnCommitted)
+        ));
+        assert!(matches!(
+            session.next_event().await.expect("final"),
+            Some(RealtimeSessionEvent::InputTranscriptFinalForItem {
+                item_id,
+                previous_item_id: None,
+                text,
+                ..
+            }) if item_id == "item_live_user" && text == "Say only the codeword once."
         ));
         assert_eq!(session.next_event().await.expect("eof"), None);
     }

--- a/meerkat-openai/src/live.rs
+++ b/meerkat-openai/src/live.rs
@@ -760,6 +760,13 @@ fn openai_realtime_item_transcript_identity(
     }
 }
 
+fn openai_realtime_item_id(item: &Item) -> Option<&str> {
+    match item {
+        Item::Message { id: Some(id), .. } | Item::McpCall { id: Some(id), .. } => Some(id),
+        _ => None,
+    }
+}
+
 const OPENAI_REALTIME_AUDIO_MIME_TYPE: &str = "audio/pcm";
 /// Sample rate OpenAI Realtime negotiates for PCM audio on both input and output.
 pub(crate) const OPENAI_REALTIME_AUDIO_SAMPLE_RATE_HZ: u32 = 24_000;
@@ -845,8 +852,10 @@ pub struct OpenAiRealtimeSession {
     pending_events: VecDeque<RealtimeSessionEvent>,
     pending_mcp_calls: BTreeMap<String, PendingMcpCall>,
     item_previous: BTreeMap<String, Option<String>>,
+    item_response: BTreeMap<String, String>,
     pending_output_audio_transcripts: BTreeMap<String, String>,
     pending_text_suppressions: VecDeque<String>,
+    active_response_id: Option<String>,
     response_output_active: bool,
     response_interrupt_emitted: bool,
     response_tool_call_observed: bool,
@@ -886,8 +895,10 @@ impl OpenAiRealtimeSession {
             pending_events: VecDeque::new(),
             pending_mcp_calls: BTreeMap::new(),
             item_previous: BTreeMap::new(),
+            item_response: BTreeMap::new(),
             pending_output_audio_transcripts: BTreeMap::new(),
             pending_text_suppressions: VecDeque::new(),
+            active_response_id: None,
             response_output_active: false,
             response_interrupt_emitted: false,
             response_tool_call_observed: false,
@@ -983,20 +994,36 @@ impl OpenAiRealtimeSession {
         self.item_previous.get(item_id).cloned().flatten()
     }
 
+    fn note_response_for_item(&mut self, response_id: &str, item_id: &str) {
+        self.active_response_id = Some(response_id.to_string());
+        self.item_response
+            .entry(item_id.to_string())
+            .or_insert_with(|| response_id.to_string());
+    }
+
+    fn response_id_for_item(&self, item_id: &str) -> Option<String> {
+        self.item_response.get(item_id).cloned()
+    }
+
     fn observe_transcript_item(
         &mut self,
         item_id: String,
         previous_item_id: Option<String>,
         role: RealtimeTranscriptRole,
+        response_id: Option<String>,
     ) -> RealtimeSessionEvent {
         self.item_previous
             .entry(item_id.clone())
             .or_insert_with(|| previous_item_id.clone());
+        if let Some(response_id) = response_id.as_deref() {
+            self.note_response_for_item(response_id, &item_id);
+        }
         RealtimeSessionEvent::RealtimeTranscript {
             event: RealtimeTranscriptEvent::ItemObserved {
                 item_id,
                 previous_item_id,
                 role,
+                response_id,
             },
         }
     }
@@ -1084,18 +1111,21 @@ impl OpenAiRealtimeSession {
 
     fn note_output_audio_transcript_delta(
         &mut self,
+        response_id: String,
         event_id: String,
         item_id: &str,
         content_index: u32,
         delta: String,
     ) -> RealtimeSessionEvent {
         self.mark_response_output_active();
+        self.note_response_for_item(&response_id, item_id);
         let key = openai_output_audio_transcript_key(item_id, content_index);
         self.pending_output_audio_transcripts
             .entry(key)
             .or_default()
             .push_str(&delta);
         RealtimeSessionEvent::OutputTextDeltaForItem {
+            response_id,
             delta_id: event_id,
             item_id: item_id.to_string(),
             previous_item_id: self.previous_item_id_for(item_id),
@@ -1124,12 +1154,14 @@ impl OpenAiRealtimeSession {
 
     fn note_output_audio_transcript_done(
         &mut self,
+        response_id: String,
         event_id: String,
         item_id: &str,
         content_index: u32,
         transcript: String,
     ) -> Option<RealtimeSessionEvent> {
         self.mark_response_output_active();
+        self.note_response_for_item(&response_id, item_id);
         let key = openai_output_audio_transcript_key(item_id, content_index);
         let seen = self
             .pending_output_audio_transcripts
@@ -1140,6 +1172,7 @@ impl OpenAiRealtimeSession {
         }
         if seen.is_empty() {
             return Some(RealtimeSessionEvent::OutputTextDeltaForItem {
+                response_id,
                 delta_id: event_id,
                 item_id: item_id.to_string(),
                 previous_item_id: self.previous_item_id_for(item_id),
@@ -1149,6 +1182,7 @@ impl OpenAiRealtimeSession {
         }
         transcript.strip_prefix(&seen).and_then(|suffix| {
             (!suffix.is_empty()).then(|| RealtimeSessionEvent::OutputTextDeltaForItem {
+                response_id,
                 delta_id: event_id,
                 item_id: item_id.to_string(),
                 previous_item_id: self.previous_item_id_for(item_id),
@@ -1178,7 +1212,7 @@ impl OpenAiRealtimeSession {
                 item,
                 ..
             } => openai_realtime_item_transcript_identity(&item).map(|(item_id, role)| {
-                self.observe_transcript_item(item_id, previous_item_id, role)
+                self.observe_transcript_item(item_id, previous_item_id, role, None)
             }),
             ServerEvent::InputAudioTranscriptionDelta { delta, .. } => {
                 Some(RealtimeSessionEvent::InputTranscriptPartial { text: delta })
@@ -1200,7 +1234,9 @@ impl OpenAiRealtimeSession {
                     self.response_interrupt_emitted = true;
                     self.pending_events
                         .push_back(RealtimeSessionEvent::TurnStarted);
-                    Some(RealtimeSessionEvent::Interrupted)
+                    Some(RealtimeSessionEvent::Interrupted {
+                        response_id: self.active_response_id.clone(),
+                    })
                 } else {
                     Some(RealtimeSessionEvent::TurnStarted)
                 }
@@ -1237,16 +1273,19 @@ impl OpenAiRealtimeSession {
                         .push_back(RealtimeSessionEvent::TurnStarted);
                     self.pending_events
                         .push_back(RealtimeSessionEvent::TurnCommitted);
-                    Some(RealtimeSessionEvent::Interrupted)
+                    Some(RealtimeSessionEvent::Interrupted {
+                        response_id: self.active_response_id.clone(),
+                    })
                 } else {
                     Some(RealtimeSessionEvent::TurnCommitted)
                 }
             }
-            ServerEvent::ResponseCreated { .. } => {
+            ServerEvent::ResponseCreated { response, .. } => {
                 // `response.created` proves the provider accepted a response,
                 // but it does not yet prove turn progress. Keep the adapter in
                 // a bounded waiting state until we see output, tool activity,
                 // or a terminal response event for this turn.
+                self.active_response_id = Some(response.id);
                 self.note_provider_response_acknowledged();
                 trace_openai_realtime_lifecycle("response.created");
                 None
@@ -1280,7 +1319,9 @@ impl OpenAiRealtimeSession {
                     response.status
                 ));
                 let stop_reason = openai_response_stop_reason(&response, observed_tool_call);
+                let response_id = response.id.clone();
                 let turn_completed = RealtimeSessionEvent::TurnCompleted {
+                    response_id: response_id.clone(),
                     stop_reason,
                     usage: openai_response_usage(response.usage.as_ref()),
                 };
@@ -1300,12 +1341,14 @@ impl OpenAiRealtimeSession {
                 {
                     self.response_interrupt_emitted = true;
                     self.pending_events.push_back(turn_completed);
-                    Some(RealtimeSessionEvent::Interrupted)
+                    Some(RealtimeSessionEvent::Interrupted {
+                        response_id: Some(response_id),
+                    })
                 } else {
                     Some(turn_completed)
                 }
             }
-            ServerEvent::ResponseCancelled { .. } => {
+            ServerEvent::ResponseCancelled { response, .. } => {
                 if self.awaiting_provider_response_after_commit {
                     trace_openai_realtime_lifecycle("response.cancelled suppressed_while_awaiting");
                     self.response_output_active = false;
@@ -1320,27 +1363,57 @@ impl OpenAiRealtimeSession {
                     None
                 } else {
                     self.response_interrupt_emitted = true;
-                    Some(RealtimeSessionEvent::Interrupted)
+                    Some(RealtimeSessionEvent::Interrupted {
+                        response_id: Some(response.id),
+                    })
                 }
             }
-            ServerEvent::ResponseOutputItemAdded { item, .. }
-            | ServerEvent::ResponseOutputItemDone { item, .. } => {
+            ServerEvent::ResponseOutputItemAdded {
+                response_id, item, ..
+            }
+            | ServerEvent::ResponseOutputItemDone {
+                response_id, item, ..
+            } => {
                 self.note_provider_response_progressed();
+                if let Some(item_id) = openai_realtime_item_id(&item) {
+                    self.note_response_for_item(&response_id, item_id);
+                }
+                if let Some((item_id, role)) = openai_realtime_item_transcript_identity(&item)
+                    && role == RealtimeTranscriptRole::Assistant
+                {
+                    return Ok(Some(self.observe_transcript_item(
+                        item_id,
+                        None,
+                        role,
+                        Some(response_id),
+                    )));
+                }
                 self.capture_mcp_call_item(&item)
             }
-            ServerEvent::ResponseMcpCallArgumentsDelta { item_id, delta, .. } => {
+            ServerEvent::ResponseMcpCallArgumentsDelta {
+                response_id,
+                item_id,
+                delta,
+                ..
+            } => {
                 self.note_provider_response_progressed();
+                self.note_response_for_item(&response_id, &item_id);
                 self.note_mcp_argument_delta(&item_id, delta);
                 None
             }
             ServerEvent::ResponseMcpCallArgumentsDone {
-                item_id, arguments, ..
+                response_id,
+                item_id,
+                arguments,
+                ..
             } => {
                 self.note_provider_response_progressed();
+                self.note_response_for_item(&response_id, &item_id);
                 self.note_mcp_argument_done(&item_id, arguments)
             }
             ServerEvent::ResponseOutputTextDelta {
                 event_id,
+                response_id,
                 item_id,
                 content_index,
                 delta,
@@ -1351,7 +1424,9 @@ impl OpenAiRealtimeSession {
                     None
                 } else {
                     self.mark_response_output_active();
+                    self.note_response_for_item(&response_id, &item_id);
                     Some(RealtimeSessionEvent::OutputTextDeltaForItem {
+                        response_id,
                         delta_id: event_id,
                         previous_item_id: self.previous_item_id_for(&item_id),
                         item_id,
@@ -1362,6 +1437,7 @@ impl OpenAiRealtimeSession {
             }
             ServerEvent::ResponseOutputAudioTranscriptDelta {
                 event_id,
+                response_id,
                 item_id,
                 content_index,
                 delta,
@@ -1369,6 +1445,7 @@ impl OpenAiRealtimeSession {
             } => {
                 self.note_provider_response_progressed();
                 Some(self.note_output_audio_transcript_delta(
+                    response_id,
                     event_id,
                     &item_id,
                     content_index,
@@ -1377,6 +1454,7 @@ impl OpenAiRealtimeSession {
             }
             ServerEvent::ResponseOutputAudioTranscriptDone {
                 event_id,
+                response_id,
                 item_id,
                 content_index,
                 transcript,
@@ -1384,15 +1462,22 @@ impl OpenAiRealtimeSession {
             } => {
                 self.note_provider_response_progressed();
                 self.note_output_audio_transcript_done(
+                    response_id,
                     event_id,
                     &item_id,
                     content_index,
                     transcript,
                 )
             }
-            ServerEvent::ResponseOutputAudioDelta { delta, .. } => {
+            ServerEvent::ResponseOutputAudioDelta {
+                response_id,
+                item_id,
+                delta,
+                ..
+            } => {
                 self.note_provider_response_progressed();
                 self.mark_response_output_active();
+                self.note_response_for_item(&response_id, &item_id);
                 Some(RealtimeSessionEvent::OutputAudioChunk {
                     chunk: RealtimeAudioChunk {
                         mime_type: OPENAI_REALTIME_AUDIO_MIME_TYPE.to_string(),
@@ -1403,12 +1488,15 @@ impl OpenAiRealtimeSession {
                 })
             }
             ServerEvent::ResponseFunctionCallArgumentsDone {
+                response_id,
+                item_id,
                 call_id,
                 name,
                 arguments,
                 ..
             } => {
                 self.note_provider_response_progressed();
+                self.note_response_for_item(&response_id, &item_id);
                 self.response_tool_call_observed = true;
                 Some(RealtimeSessionEvent::ToolCallRequested {
                     call_id,
@@ -1438,8 +1526,12 @@ impl OpenAiRealtimeSession {
                 // the audio-end fraction of the original duration. Providers
                 // that cannot supply an exact projection leave `None` and
                 // downstream projectors leave the existing transcript intact.
-                let truncated_text = self.pending_output_audio_transcripts.get(&item_id).cloned();
+                let truncated_text = self
+                    .pending_output_audio_transcripts
+                    .get(&openai_output_audio_transcript_key(&item_id, 0))
+                    .cloned();
                 Some(RealtimeSessionEvent::AssistantTranscriptTruncated {
+                    response_id: self.response_id_for_item(&item_id),
                     item_id,
                     audio_played_ms,
                     truncated_text,
@@ -3081,7 +3173,7 @@ mod tests {
         ));
         assert!(matches!(
             session.next_event().await.expect("interrupted"),
-            Some(RealtimeSessionEvent::Interrupted)
+            Some(RealtimeSessionEvent::Interrupted { .. })
         ));
         assert!(matches!(
             session.next_event().await.expect("completed"),
@@ -3734,7 +3826,7 @@ mod tests {
         ));
         assert!(matches!(
             session.next_event().await.expect("interrupted"),
-            Some(RealtimeSessionEvent::Interrupted)
+            Some(RealtimeSessionEvent::Interrupted { .. })
         ));
         assert!(matches!(
             session.next_event().await.expect("turn started"),
@@ -3775,7 +3867,7 @@ mod tests {
         ));
         assert!(matches!(
             session.next_event().await.expect("interrupted"),
-            Some(RealtimeSessionEvent::Interrupted)
+            Some(RealtimeSessionEvent::Interrupted { .. })
         ));
         assert!(matches!(
             session.next_event().await.expect("turn started"),
@@ -3828,7 +3920,7 @@ mod tests {
         ));
         assert!(matches!(
             session.next_event().await.expect("interrupted"),
-            Some(RealtimeSessionEvent::Interrupted)
+            Some(RealtimeSessionEvent::Interrupted { .. })
         ));
         assert!(matches!(
             session
@@ -3882,7 +3974,7 @@ mod tests {
                 .next_event()
                 .await
                 .expect("interrupted from speech_started"),
-            Some(RealtimeSessionEvent::Interrupted)
+            Some(RealtimeSessionEvent::Interrupted { .. })
         ));
         assert!(matches!(
             session.next_event().await.expect("turn started queued"),
@@ -4258,6 +4350,7 @@ mod tests {
         assert_eq!(
             opened.next_event().await.expect("buffered event"),
             Some(RealtimeSessionEvent::OutputTextDeltaForItem {
+                response_id: "resp_seed".to_string(),
                 delta_id: "evt_seed_buffered_delta".to_string(),
                 item_id: "item_seed".to_string(),
                 previous_item_id: None,

--- a/meerkat-openai/src/live.rs
+++ b/meerkat-openai/src/live.rs
@@ -8,7 +8,10 @@ use meerkat_contracts::{
     RealtimeAudioChunk, RealtimeAudioFormat, RealtimeCapabilities, RealtimeInputChunk,
     RealtimeInputKind, RealtimeOutputKind, RealtimeTurningMode,
 };
-use meerkat_core::{Message, PendingSystemContextAppend, ToolDef, ToolResult};
+use meerkat_core::{
+    Message, PendingSystemContextAppend, RealtimeTranscriptEvent, RealtimeTranscriptRole, ToolDef,
+    ToolResult,
+};
 use meerkat_core::{StopReason, types::Usage};
 use meerkat_llm_core::LlmError;
 use meerkat_llm_core::realtime_session::{
@@ -742,6 +745,21 @@ fn openai_output_audio_transcript_key(item_id: &str, content_index: u32) -> Stri
     format!("{item_id}:{content_index}")
 }
 
+fn openai_realtime_item_transcript_identity(
+    item: &Item,
+) -> Option<(String, RealtimeTranscriptRole)> {
+    match item {
+        Item::Message {
+            id: Some(id), role, ..
+        } => match role {
+            Role::User => Some((id.clone(), RealtimeTranscriptRole::User)),
+            Role::Assistant => Some((id.clone(), RealtimeTranscriptRole::Assistant)),
+            Role::System => None,
+        },
+        _ => None,
+    }
+}
+
 const OPENAI_REALTIME_AUDIO_MIME_TYPE: &str = "audio/pcm";
 /// Sample rate OpenAI Realtime negotiates for PCM audio on both input and output.
 pub(crate) const OPENAI_REALTIME_AUDIO_SAMPLE_RATE_HZ: u32 = 24_000;
@@ -826,6 +844,7 @@ pub struct OpenAiRealtimeSession {
     has_staged_audio: bool,
     pending_events: VecDeque<RealtimeSessionEvent>,
     pending_mcp_calls: BTreeMap<String, PendingMcpCall>,
+    item_previous: BTreeMap<String, Option<String>>,
     pending_output_audio_transcripts: BTreeMap<String, String>,
     pending_text_suppressions: VecDeque<String>,
     response_output_active: bool,
@@ -866,6 +885,7 @@ impl OpenAiRealtimeSession {
             has_staged_audio: false,
             pending_events: VecDeque::new(),
             pending_mcp_calls: BTreeMap::new(),
+            item_previous: BTreeMap::new(),
             pending_output_audio_transcripts: BTreeMap::new(),
             pending_text_suppressions: VecDeque::new(),
             response_output_active: false,
@@ -959,6 +979,28 @@ impl OpenAiRealtimeSession {
         self.response_output_active = true;
     }
 
+    fn previous_item_id_for(&self, item_id: &str) -> Option<String> {
+        self.item_previous.get(item_id).cloned().flatten()
+    }
+
+    fn observe_transcript_item(
+        &mut self,
+        item_id: String,
+        previous_item_id: Option<String>,
+        role: RealtimeTranscriptRole,
+    ) -> RealtimeSessionEvent {
+        self.item_previous
+            .entry(item_id.clone())
+            .or_insert_with(|| previous_item_id.clone());
+        RealtimeSessionEvent::RealtimeTranscript {
+            event: RealtimeTranscriptEvent::ItemObserved {
+                item_id,
+                previous_item_id,
+                role,
+            },
+        }
+    }
+
     fn pending_mcp_call_mut(&mut self, item_id: &str) -> &mut PendingMcpCall {
         self.pending_mcp_calls
             .entry(item_id.to_string())
@@ -1042,6 +1084,7 @@ impl OpenAiRealtimeSession {
 
     fn note_output_audio_transcript_delta(
         &mut self,
+        event_id: String,
         item_id: &str,
         content_index: u32,
         delta: String,
@@ -1052,7 +1095,13 @@ impl OpenAiRealtimeSession {
             .entry(key)
             .or_default()
             .push_str(&delta);
-        RealtimeSessionEvent::OutputTextDelta { delta }
+        RealtimeSessionEvent::OutputTextDeltaForItem {
+            delta_id: event_id,
+            item_id: item_id.to_string(),
+            previous_item_id: self.previous_item_id_for(item_id),
+            content_index,
+            delta,
+        }
     }
 
     fn waiting_for_provider_progress(&self) -> bool {
@@ -1075,6 +1124,7 @@ impl OpenAiRealtimeSession {
 
     fn note_output_audio_transcript_done(
         &mut self,
+        event_id: String,
         item_id: &str,
         content_index: u32,
         transcript: String,
@@ -1089,10 +1139,20 @@ impl OpenAiRealtimeSession {
             return None;
         }
         if seen.is_empty() {
-            return Some(RealtimeSessionEvent::OutputTextDelta { delta: transcript });
+            return Some(RealtimeSessionEvent::OutputTextDeltaForItem {
+                delta_id: event_id,
+                item_id: item_id.to_string(),
+                previous_item_id: self.previous_item_id_for(item_id),
+                content_index,
+                delta: transcript,
+            });
         }
         transcript.strip_prefix(&seen).and_then(|suffix| {
-            (!suffix.is_empty()).then(|| RealtimeSessionEvent::OutputTextDelta {
+            (!suffix.is_empty()).then(|| RealtimeSessionEvent::OutputTextDeltaForItem {
+                delta_id: event_id,
+                item_id: item_id.to_string(),
+                previous_item_id: self.previous_item_id_for(item_id),
+                content_index,
                 delta: suffix.to_string(),
             })
         })
@@ -1103,12 +1163,37 @@ impl OpenAiRealtimeSession {
         event: ServerEvent,
     ) -> Result<Option<RealtimeSessionEvent>, LlmError> {
         let mapped = match event {
+            ServerEvent::ConversationItemCreated {
+                previous_item_id,
+                item,
+                ..
+            }
+            | ServerEvent::ConversationItemAdded {
+                previous_item_id,
+                item,
+                ..
+            }
+            | ServerEvent::ConversationItemDone {
+                previous_item_id,
+                item,
+                ..
+            } => openai_realtime_item_transcript_identity(&item).map(|(item_id, role)| {
+                self.observe_transcript_item(item_id, previous_item_id, role)
+            }),
             ServerEvent::InputAudioTranscriptionDelta { delta, .. } => {
                 Some(RealtimeSessionEvent::InputTranscriptPartial { text: delta })
             }
-            ServerEvent::InputAudioTranscriptionCompleted { transcript, .. } => {
-                Some(RealtimeSessionEvent::InputTranscriptFinal { text: transcript })
-            }
+            ServerEvent::InputAudioTranscriptionCompleted {
+                item_id,
+                content_index,
+                transcript,
+                ..
+            } => Some(RealtimeSessionEvent::InputTranscriptFinalForItem {
+                previous_item_id: self.previous_item_id_for(&item_id),
+                item_id,
+                content_index,
+                text: transcript,
+            }),
             ServerEvent::InputAudioBufferSpeechStarted { .. } => {
                 if self.response_output_active && !self.response_interrupt_emitted {
                     self.response_output_active = false;
@@ -1120,7 +1205,14 @@ impl OpenAiRealtimeSession {
                     Some(RealtimeSessionEvent::TurnStarted)
                 }
             }
-            ServerEvent::InputAudioBufferCommitted { .. } => {
+            ServerEvent::InputAudioBufferCommitted {
+                previous_item_id,
+                item_id,
+                ..
+            } => {
+                self.item_previous
+                    .entry(item_id)
+                    .or_insert(previous_item_id);
                 self.awaiting_provider_response_after_commit =
                     self.turning_mode == RealtimeTurningMode::ProviderManaged;
                 self.provider_response_acknowledged_without_progress = false;
@@ -1247,32 +1339,56 @@ impl OpenAiRealtimeSession {
                 self.note_provider_response_progressed();
                 self.note_mcp_argument_done(&item_id, arguments)
             }
-            ServerEvent::ResponseOutputTextDelta { delta, .. } => {
-                self.note_provider_response_progressed();
-                if self.should_suppress_mcp_echoed_text(&delta) {
-                    None
-                } else {
-                    self.mark_response_output_active();
-                    Some(RealtimeSessionEvent::OutputTextDelta { delta })
-                }
-            }
-            ServerEvent::ResponseOutputAudioTranscriptDelta {
+            ServerEvent::ResponseOutputTextDelta {
+                event_id,
                 item_id,
                 content_index,
                 delta,
                 ..
             } => {
                 self.note_provider_response_progressed();
-                Some(self.note_output_audio_transcript_delta(&item_id, content_index, delta))
+                if self.should_suppress_mcp_echoed_text(&delta) {
+                    None
+                } else {
+                    self.mark_response_output_active();
+                    Some(RealtimeSessionEvent::OutputTextDeltaForItem {
+                        delta_id: event_id,
+                        previous_item_id: self.previous_item_id_for(&item_id),
+                        item_id,
+                        content_index,
+                        delta,
+                    })
+                }
+            }
+            ServerEvent::ResponseOutputAudioTranscriptDelta {
+                event_id,
+                item_id,
+                content_index,
+                delta,
+                ..
+            } => {
+                self.note_provider_response_progressed();
+                Some(self.note_output_audio_transcript_delta(
+                    event_id,
+                    &item_id,
+                    content_index,
+                    delta,
+                ))
             }
             ServerEvent::ResponseOutputAudioTranscriptDone {
+                event_id,
                 item_id,
                 content_index,
                 transcript,
                 ..
             } => {
                 self.note_provider_response_progressed();
-                self.note_output_audio_transcript_done(&item_id, content_index, transcript)
+                self.note_output_audio_transcript_done(
+                    event_id,
+                    &item_id,
+                    content_index,
+                    transcript,
+                )
             }
             ServerEvent::ResponseOutputAudioDelta { delta, .. } => {
                 self.note_provider_response_progressed();
@@ -1435,12 +1551,14 @@ impl RealtimeSession for OpenAiRealtimeSession {
             }
             RealtimeInputChunk::TextChunk(chunk) => {
                 let text = chunk.text;
+                let synthetic_item_id =
+                    format!("meerkat_text_{}", meerkat_core::time_compat::new_uuid_v7());
                 self.raw_mut()?
                     .send_raw(ClientEvent::ConversationItemCreate {
                         event_id: None,
                         previous_item_id: None,
                         item: Box::new(Item::Message {
-                            id: None,
+                            id: Some(synthetic_item_id.clone()),
                             status: None,
                             role: Role::User,
                             content: vec![ContentPart::InputText { text: text.clone() }],
@@ -1455,10 +1573,9 @@ impl RealtimeSession for OpenAiRealtimeSession {
                 // stays consistent — callers waiting for the canonical
                 // TurnStarted / InputTranscriptPartial / InputTranscriptFinal /
                 // TurnCommitted sequence get the same events for text as for
-                // audio. InputTranscriptFinal is also the canonical-history
-                // append seam on the consumer side (handle_product_session_event
-                // in meerkat-rpc), so text chunks must emit it or the user's
-                // turn never lands in the session history.
+                // audio. The synthetic item id is sent to OpenAI as the item id
+                // and then reused on the typed transcript seam so canonical
+                // session append remains keyed and idempotent.
                 if matches!(self.turning_mode, RealtimeTurningMode::ProviderManaged) {
                     self.pending_events
                         .push_back(RealtimeSessionEvent::TurnStarted);
@@ -1466,8 +1583,14 @@ impl RealtimeSession for OpenAiRealtimeSession {
                         .push_back(RealtimeSessionEvent::InputTranscriptPartial {
                             text: text.clone(),
                         });
-                    self.pending_events
-                        .push_back(RealtimeSessionEvent::InputTranscriptFinal { text });
+                    self.pending_events.push_back(
+                        RealtimeSessionEvent::InputTranscriptFinalForItem {
+                            item_id: synthetic_item_id,
+                            previous_item_id: None,
+                            content_index: 0,
+                            text,
+                        },
+                    );
                     self.pending_events
                         .push_back(RealtimeSessionEvent::TurnCommitted);
                     self.raw_mut()?
@@ -2934,7 +3057,7 @@ mod tests {
         ));
         assert!(matches!(
             session.next_event().await.expect("final"),
-            Some(RealtimeSessionEvent::InputTranscriptFinal { text }) if text == "hello"
+            Some(RealtimeSessionEvent::InputTranscriptFinalForItem { text, .. }) if text == "hello"
         ));
         assert!(matches!(
             session.next_event().await.expect("turn started"),
@@ -2946,7 +3069,7 @@ mod tests {
         ));
         assert!(matches!(
             session.next_event().await.expect("text delta"),
-            Some(RealtimeSessionEvent::OutputTextDelta { delta }) if delta == "hi"
+            Some(RealtimeSessionEvent::OutputTextDeltaForItem { delta, .. }) if delta == "hi"
         ));
         assert!(matches!(
             session.next_event().await.expect("audio delta"),
@@ -3340,7 +3463,7 @@ mod tests {
         ));
         assert!(matches!(
             session.next_event().await.expect("new response delta"),
-            Some(RealtimeSessionEvent::OutputTextDelta { delta }) if delta == "birch seventeen"
+            Some(RealtimeSessionEvent::OutputTextDeltaForItem { delta, .. }) if delta == "birch seventeen"
         ));
         assert!(matches!(
             session.next_event().await.expect("new response completed"),
@@ -3387,7 +3510,7 @@ mod tests {
         ));
         assert!(matches!(
             session.next_event().await.expect("response output"),
-            Some(RealtimeSessionEvent::OutputTextDelta { delta }) if delta == "amber lantern"
+            Some(RealtimeSessionEvent::OutputTextDeltaForItem { delta, .. }) if delta == "amber lantern"
         ));
         assert!(matches!(
             session.next_event().await.expect("response completed"),
@@ -3442,11 +3565,11 @@ mod tests {
         ));
         assert!(matches!(
             session.next_event().await.expect("first delta"),
-            Some(RealtimeSessionEvent::OutputTextDelta { delta }) if delta == "Amber Lantern. "
+            Some(RealtimeSessionEvent::OutputTextDeltaForItem { delta, .. }) if delta == "Amber Lantern. "
         ));
         assert!(matches!(
             session.next_event().await.expect("second delta"),
-            Some(RealtimeSessionEvent::OutputTextDelta { delta }) if delta == "birch seventeen"
+            Some(RealtimeSessionEvent::OutputTextDeltaForItem { delta, .. }) if delta == "birch seventeen"
         ));
         assert!(matches!(
             session.next_event().await.expect("turn completed"),
@@ -3524,7 +3647,7 @@ mod tests {
 
         assert!(matches!(
             session.next_event().await.expect("queued event after refresh"),
-            Some(RealtimeSessionEvent::OutputTextDelta { delta }) if delta == "birch seventeen"
+            Some(RealtimeSessionEvent::OutputTextDeltaForItem { delta, .. }) if delta == "birch seventeen"
         ));
         assert_eq!(session.next_event().await.expect("eof"), None);
     }
@@ -3567,15 +3690,15 @@ mod tests {
 
         assert!(matches!(
             session.next_event().await.expect("first delta"),
-            Some(RealtimeSessionEvent::OutputTextDelta { delta }) if delta == "birch "
+            Some(RealtimeSessionEvent::OutputTextDeltaForItem { delta, .. }) if delta == "birch "
         ));
         assert!(matches!(
             session.next_event().await.expect("suffix delta"),
-            Some(RealtimeSessionEvent::OutputTextDelta { delta }) if delta == "seventeen"
+            Some(RealtimeSessionEvent::OutputTextDeltaForItem { delta, .. }) if delta == "seventeen"
         ));
         assert!(matches!(
             session.next_event().await.expect("done without delta still projects text"),
-            Some(RealtimeSessionEvent::OutputTextDelta { delta }) if delta == "silver harbor"
+            Some(RealtimeSessionEvent::OutputTextDeltaForItem { delta, .. }) if delta == "silver harbor"
         ));
         assert_eq!(session.next_event().await.expect("eof"), None);
     }
@@ -3701,7 +3824,7 @@ mod tests {
 
         assert!(matches!(
             session.next_event().await.expect("text delta"),
-            Some(RealtimeSessionEvent::OutputTextDelta { delta }) if delta == "Looping now"
+            Some(RealtimeSessionEvent::OutputTextDeltaForItem { delta, .. }) if delta == "Looping now"
         ));
         assert!(matches!(
             session.next_event().await.expect("interrupted"),
@@ -3752,7 +3875,7 @@ mod tests {
 
         assert!(matches!(
             session.next_event().await.expect("text delta"),
-            Some(RealtimeSessionEvent::OutputTextDelta { delta }) if delta == "Looping now"
+            Some(RealtimeSessionEvent::OutputTextDeltaForItem { delta, .. }) if delta == "Looping now"
         ));
         assert!(matches!(
             session
@@ -3885,7 +4008,7 @@ mod tests {
         ));
         assert!(matches!(
             session.next_event().await.expect("assistant text"),
-            Some(RealtimeSessionEvent::OutputTextDelta { delta }) if delta == "birch seventeen"
+            Some(RealtimeSessionEvent::OutputTextDeltaForItem { delta, .. }) if delta == "birch seventeen"
         ));
         assert_eq!(session.next_event().await.expect("eof"), None);
     }
@@ -4134,7 +4257,11 @@ mod tests {
 
         assert_eq!(
             opened.next_event().await.expect("buffered event"),
-            Some(RealtimeSessionEvent::OutputTextDelta {
+            Some(RealtimeSessionEvent::OutputTextDeltaForItem {
+                delta_id: "evt_seed_buffered_delta".to_string(),
+                item_id: "item_seed".to_string(),
+                previous_item_id: None,
+                content_index: 0,
                 delta: "projection buffered text".to_string(),
             })
         );

--- a/meerkat-openai/tests/mock_realtime_ws/server.rs
+++ b/meerkat-openai/tests/mock_realtime_ws/server.rs
@@ -70,11 +70,14 @@ impl ScriptedEvent {
             ScriptedEvent::TurnCommitted => Some(Ok(Some(RealtimeSessionEvent::TurnCommitted))),
             ScriptedEvent::TurnCompleted { stop_reason } => {
                 Some(Ok(Some(RealtimeSessionEvent::TurnCompleted {
+                    response_id: "mock_response".to_string(),
                     stop_reason,
                     usage: Default::default(),
                 })))
             }
-            ScriptedEvent::Interrupted => Some(Ok(Some(RealtimeSessionEvent::Interrupted))),
+            ScriptedEvent::Interrupted => Some(Ok(Some(RealtimeSessionEvent::Interrupted {
+                response_id: Some("mock_response".to_string()),
+            }))),
             ScriptedEvent::End => Some(Ok(None)),
         }
     }

--- a/meerkat-rpc/src/realtime_ws.rs
+++ b/meerkat-rpc/src/realtime_ws.rs
@@ -142,7 +142,6 @@ struct ActiveTargetEntry {
 #[derive(Debug, Default)]
 struct RealtimePendingTurn {
     staged_user_text: String,
-    staged_assistant_text: String,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -1754,7 +1753,8 @@ async fn handle_realtime_socket(mut socket: WebSocket, state: RealtimeWsState) {
                                                     );
                                                     None
                                                 }
-                                                RealtimeSessionEvent::InputTranscriptFinal { .. } => Some("input_transcript_final"),
+                                                RealtimeSessionEvent::InputTranscriptFinal { .. }
+                                                | RealtimeSessionEvent::InputTranscriptFinalForItem { .. } => Some("input_transcript_final"),
                                                 RealtimeSessionEvent::Interrupted => Some("interrupted"),
                                                 RealtimeSessionEvent::ToolCallRequested { .. } => Some("tool_call_requested"),
                                                 _ => None,
@@ -1785,7 +1785,6 @@ async fn handle_realtime_socket(mut socket: WebSocket, state: RealtimeWsState) {
                                                 handle_product_session_event(
                                                     &state.runtime,
                                                     binding.as_ref(),
-                                                    &mut pending_turn,
                                                     other,
                                                 )
                                                 .await
@@ -3216,13 +3215,15 @@ fn classify_product_session_event(event: &RealtimeSessionEvent) -> ProductSessio
             // async mutation signal would set `StaleDeferred` for an own-
             // turn mutation and cause a spurious provider-session reopen at
             // turn end.
-            | RealtimeSessionEvent::InputTranscriptFinal { .. }
+            | RealtimeSessionEvent::InputTranscriptFinalForItem { .. }
+            | RealtimeSessionEvent::RealtimeTranscript { .. }
     ) || logical_turn_completed;
     let tool_call_requested = matches!(event, RealtimeSessionEvent::ToolCallRequested { .. });
     let turn_committed = matches!(event, RealtimeSessionEvent::TurnCommitted);
     let output_started = matches!(
         event,
         RealtimeSessionEvent::OutputTextDelta { .. }
+            | RealtimeSessionEvent::OutputTextDeltaForItem { .. }
             | RealtimeSessionEvent::OutputAudioChunk { .. }
             | RealtimeSessionEvent::OutputVideoChunk { .. }
             | RealtimeSessionEvent::ToolCallRequested { .. }
@@ -3616,40 +3617,37 @@ async fn submit_product_session_tool_error(
 async fn handle_product_session_event(
     runtime: &SessionRuntime,
     binding: Option<&RealtimeSocketBinding>,
-    pending_turn: &mut RealtimePendingTurn,
     event: RealtimeSessionEvent,
 ) -> Result<Vec<RealtimeServerFrame>, RealtimeChannelErrorFrame> {
     match event {
         RealtimeSessionEvent::InputTranscriptPartial { text } => {
-            pending_turn.staged_user_text = text.clone();
             Ok(vec![channel_event(RealtimeEvent::InputTranscriptPartial {
                 text,
             })])
         }
         RealtimeSessionEvent::InputTranscriptFinal { text } => {
-            // Canonical-history append on transcript finalization, not on
-            // TurnCommitted. For OpenAI audio the provider emits
-            // `input_audio_buffer.committed` *before* transcription
-            // completes, so relying on TurnCommitted's staged text would
-            // either leak the prior turn's transcript or drop this turn's
-            // transcript entirely. The transcript-final event is the earliest
-            // point where the full user utterance is known; use it as the
-            // append trigger and clear the staging slot so the subsequent
-            // TurnCommitted handler does not re-append.
-            let session_id = resolve_primary_session_id(
+            Ok(vec![channel_event(RealtimeEvent::InputTranscriptFinal {
+                text,
+                prosody_hint: None,
+            })])
+        }
+        RealtimeSessionEvent::InputTranscriptFinalForItem {
+            item_id,
+            previous_item_id,
+            content_index,
+            text,
+        } => {
+            append_realtime_transcript_event(
                 runtime,
                 binding,
-                "realtime product session is not wired to a session target",
+                meerkat_core::RealtimeTranscriptEvent::UserTranscriptFinal {
+                    item_id,
+                    previous_item_id,
+                    content_index,
+                    text: text.clone(),
+                },
             )
             .await?;
-            runtime
-                .append_external_user_content(
-                    &session_id,
-                    meerkat_core::types::ContentInput::Text(text.clone()),
-                )
-                .await
-                .map_err(session_error_frame)?;
-            pending_turn.staged_user_text.clear();
             Ok(vec![channel_event(RealtimeEvent::InputTranscriptFinal {
                 text,
                 prosody_hint: None,
@@ -3657,52 +3655,72 @@ async fn handle_product_session_event(
         }
         RealtimeSessionEvent::TurnStarted => Ok(vec![channel_event(RealtimeEvent::TurnStarted)]),
         RealtimeSessionEvent::TurnCommitted => {
-            let session_id = resolve_primary_session_id(
-                runtime,
-                binding,
-                "realtime product session is not wired to a session target",
-            )
-            .await?;
-            if pending_turn.staged_user_text.is_empty() {
-                // Either the transcript-final handler already appended the
-                // canonical user turn and cleared staging, or the provider
-                // committed with no transcript at all.
-                return Ok(vec![channel_event(RealtimeEvent::TurnCommitted)]);
-            }
-            // Fallback: transcript partials accumulated but no final event
-            // arrived before the commit. Append the best-known staged text so
-            // the canonical history still records *something* for this turn.
-            let text = std::mem::take(&mut pending_turn.staged_user_text);
-            append_external_user_transcript(runtime, &session_id, text, false).await
+            Ok(vec![channel_event(RealtimeEvent::TurnCommitted)])
         }
         RealtimeSessionEvent::TurnCompleted { stop_reason, usage } => {
             match product_turn_completion_disposition(stop_reason) {
                 RealtimeTurnCompletionDisposition::Finalize => {
-                    let session_id = resolve_primary_session_id(
+                    append_realtime_transcript_event(
                         runtime,
                         binding,
-                        "realtime product session is not wired to a session target",
+                        meerkat_core::RealtimeTranscriptEvent::AssistantTurnCompleted {
+                            stop_reason,
+                            usage,
+                        },
                     )
                     .await?;
-                    let assistant_text = std::mem::take(&mut pending_turn.staged_assistant_text);
-                    append_external_assistant_output(
-                        runtime,
-                        &session_id,
-                        assistant_text,
-                        stop_reason,
-                        usage,
-                    )
-                    .await
+                    Ok(vec![channel_event(RealtimeEvent::TurnCompleted)])
                 }
-                RealtimeTurnCompletionDisposition::SuppressKeepStaged => Ok(Vec::new()),
+                RealtimeTurnCompletionDisposition::SuppressKeepStaged => {
+                    append_realtime_transcript_event(
+                        runtime,
+                        binding,
+                        meerkat_core::RealtimeTranscriptEvent::AssistantTurnCompleted {
+                            stop_reason,
+                            usage,
+                        },
+                    )
+                    .await?;
+                    Ok(Vec::new())
+                }
                 RealtimeTurnCompletionDisposition::SuppressDiscardStaged => {
-                    pending_turn.staged_assistant_text.clear();
+                    append_realtime_transcript_event(
+                        runtime,
+                        binding,
+                        meerkat_core::RealtimeTranscriptEvent::AssistantTurnCompleted {
+                            stop_reason,
+                            usage,
+                        },
+                    )
+                    .await?;
                     Ok(Vec::new())
                 }
             }
         }
         RealtimeSessionEvent::OutputTextDelta { delta } => {
-            pending_turn.staged_assistant_text.push_str(&delta);
+            Ok(vec![channel_event(RealtimeEvent::OutputTextDelta {
+                delta,
+            })])
+        }
+        RealtimeSessionEvent::OutputTextDeltaForItem {
+            delta_id,
+            item_id,
+            previous_item_id,
+            content_index,
+            delta,
+        } => {
+            append_realtime_transcript_event(
+                runtime,
+                binding,
+                meerkat_core::RealtimeTranscriptEvent::AssistantTextDelta {
+                    delta_id,
+                    item_id,
+                    previous_item_id,
+                    content_index,
+                    delta: delta.clone(),
+                },
+            )
+            .await?;
             Ok(vec![channel_event(RealtimeEvent::OutputTextDelta {
                 delta,
             })])
@@ -3718,7 +3736,12 @@ async fn handle_product_session_event(
             })])
         }
         RealtimeSessionEvent::Interrupted => {
-            pending_turn.staged_assistant_text.clear();
+            append_realtime_transcript_event(
+                runtime,
+                binding,
+                meerkat_core::RealtimeTranscriptEvent::AssistantTurnInterrupted,
+            )
+            .await?;
             Ok(vec![channel_event(RealtimeEvent::Interrupted)])
         }
         RealtimeSessionEvent::ToolCallRequested {
@@ -3732,14 +3755,17 @@ async fn handle_product_session_event(
             audio_played_ms,
             truncated_text,
         } => {
-            // Canonical-history projection: replace the staged assistant text
-            // with the heard prefix so the next turn's projection seeds from
-            // what the user actually heard. If the provider did not supply a
-            // re-projected text, leave existing staging and let the next
-            // TurnCompleted event finalize from whatever the provider
-            // eventually surfaces.
             if let Some(text) = truncated_text.clone() {
-                pending_turn.staged_assistant_text = text;
+                append_realtime_transcript_event(
+                    runtime,
+                    binding,
+                    meerkat_core::RealtimeTranscriptEvent::AssistantTranscriptTruncated {
+                        item_id: item_id.clone(),
+                        content_index: 0,
+                        text,
+                    },
+                )
+                .await?;
             }
             Ok(vec![channel_event(
                 RealtimeEvent::AssistantTranscriptTruncated {
@@ -3749,7 +3775,28 @@ async fn handle_product_session_event(
                 },
             )])
         }
+        RealtimeSessionEvent::RealtimeTranscript { event } => {
+            append_realtime_transcript_event(runtime, binding, event).await?;
+            Ok(Vec::new())
+        }
     }
+}
+
+async fn append_realtime_transcript_event(
+    runtime: &SessionRuntime,
+    binding: Option<&RealtimeSocketBinding>,
+    event: meerkat_core::RealtimeTranscriptEvent,
+) -> Result<meerkat_core::RealtimeTranscriptApplyOutcome, RealtimeChannelErrorFrame> {
+    let session_id = resolve_primary_session_id(
+        runtime,
+        binding,
+        "realtime product session is not wired to a session target",
+    )
+    .await?;
+    runtime
+        .append_realtime_transcript_event(&session_id, event)
+        .await
+        .map_err(session_error_frame)
 }
 
 async fn resolve_primary_session_id(
@@ -4144,51 +4191,6 @@ async fn commit_runtime_turn_text(
     }
 
     Ok(frames)
-}
-
-async fn append_external_user_transcript(
-    runtime: &SessionRuntime,
-    session_id: &SessionId,
-    text: String,
-    emit_transcript_final: bool,
-) -> Result<Vec<RealtimeServerFrame>, RealtimeChannelErrorFrame> {
-    runtime
-        .append_external_user_content(
-            session_id,
-            meerkat_core::types::ContentInput::Text(text.clone()),
-        )
-        .await
-        .map_err(session_error_frame)?;
-
-    let mut frames = Vec::new();
-    if emit_transcript_final {
-        frames.push(channel_event(RealtimeEvent::InputTranscriptFinal {
-            text,
-            prosody_hint: None,
-        }));
-    }
-    frames.push(channel_event(RealtimeEvent::TurnCommitted));
-    Ok(frames)
-}
-
-async fn append_external_assistant_output(
-    runtime: &SessionRuntime,
-    session_id: &SessionId,
-    text: String,
-    stop_reason: meerkat_core::types::StopReason,
-    usage: meerkat_core::types::Usage,
-) -> Result<Vec<RealtimeServerFrame>, RealtimeChannelErrorFrame> {
-    let blocks = if text.is_empty() {
-        Vec::new()
-    } else {
-        vec![meerkat_core::types::AssistantBlock::Text { text, meta: None }]
-    };
-    runtime
-        .append_external_assistant_output(session_id, blocks, stop_reason, usage)
-        .await
-        .map_err(session_error_frame)?;
-
-    Ok(vec![channel_event(RealtimeEvent::TurnCompleted)])
 }
 
 fn runtime_error_frame(err: RuntimeDriverError, action: &str) -> RealtimeChannelErrorFrame {

--- a/meerkat-rpc/src/realtime_ws.rs
+++ b/meerkat-rpc/src/realtime_ws.rs
@@ -1755,7 +1755,7 @@ async fn handle_realtime_socket(mut socket: WebSocket, state: RealtimeWsState) {
                                                 }
                                                 RealtimeSessionEvent::InputTranscriptFinal { .. }
                                                 | RealtimeSessionEvent::InputTranscriptFinalForItem { .. } => Some("input_transcript_final"),
-                                                RealtimeSessionEvent::Interrupted => Some("interrupted"),
+                                                RealtimeSessionEvent::Interrupted { .. } => Some("interrupted"),
                                                 RealtimeSessionEvent::ToolCallRequested { .. } => Some("tool_call_requested"),
                                                 _ => None,
                                             };
@@ -3228,7 +3228,7 @@ fn classify_product_session_event(event: &RealtimeSessionEvent) -> ProductSessio
             | RealtimeSessionEvent::OutputVideoChunk { .. }
             | RealtimeSessionEvent::ToolCallRequested { .. }
     );
-    let interrupted = matches!(event, RealtimeSessionEvent::Interrupted);
+    let interrupted = matches!(event, RealtimeSessionEvent::Interrupted { .. });
     ProductSessionEventLifecycle {
         advances_projection_known_state,
         logical_turn_completed,
@@ -3657,52 +3657,58 @@ async fn handle_product_session_event(
         RealtimeSessionEvent::TurnCommitted => {
             Ok(vec![channel_event(RealtimeEvent::TurnCommitted)])
         }
-        RealtimeSessionEvent::TurnCompleted { stop_reason, usage } => {
-            match product_turn_completion_disposition(stop_reason) {
-                RealtimeTurnCompletionDisposition::Finalize => {
-                    append_realtime_transcript_event(
-                        runtime,
-                        binding,
-                        meerkat_core::RealtimeTranscriptEvent::AssistantTurnCompleted {
-                            stop_reason,
-                            usage,
-                        },
-                    )
-                    .await?;
-                    Ok(vec![channel_event(RealtimeEvent::TurnCompleted)])
-                }
-                RealtimeTurnCompletionDisposition::SuppressKeepStaged => {
-                    append_realtime_transcript_event(
-                        runtime,
-                        binding,
-                        meerkat_core::RealtimeTranscriptEvent::AssistantTurnCompleted {
-                            stop_reason,
-                            usage,
-                        },
-                    )
-                    .await?;
-                    Ok(Vec::new())
-                }
-                RealtimeTurnCompletionDisposition::SuppressDiscardStaged => {
-                    append_realtime_transcript_event(
-                        runtime,
-                        binding,
-                        meerkat_core::RealtimeTranscriptEvent::AssistantTurnCompleted {
-                            stop_reason,
-                            usage,
-                        },
-                    )
-                    .await?;
-                    Ok(Vec::new())
-                }
+        RealtimeSessionEvent::TurnCompleted {
+            response_id,
+            stop_reason,
+            usage,
+        } => match product_turn_completion_disposition(stop_reason) {
+            RealtimeTurnCompletionDisposition::Finalize => {
+                append_realtime_transcript_event(
+                    runtime,
+                    binding,
+                    meerkat_core::RealtimeTranscriptEvent::AssistantTurnCompleted {
+                        response_id,
+                        stop_reason,
+                        usage,
+                    },
+                )
+                .await?;
+                Ok(vec![channel_event(RealtimeEvent::TurnCompleted)])
             }
-        }
+            RealtimeTurnCompletionDisposition::SuppressKeepStaged => {
+                append_realtime_transcript_event(
+                    runtime,
+                    binding,
+                    meerkat_core::RealtimeTranscriptEvent::AssistantTurnCompleted {
+                        response_id,
+                        stop_reason,
+                        usage,
+                    },
+                )
+                .await?;
+                Ok(Vec::new())
+            }
+            RealtimeTurnCompletionDisposition::SuppressDiscardStaged => {
+                append_realtime_transcript_event(
+                    runtime,
+                    binding,
+                    meerkat_core::RealtimeTranscriptEvent::AssistantTurnCompleted {
+                        response_id,
+                        stop_reason,
+                        usage,
+                    },
+                )
+                .await?;
+                Ok(Vec::new())
+            }
+        },
         RealtimeSessionEvent::OutputTextDelta { delta } => {
             Ok(vec![channel_event(RealtimeEvent::OutputTextDelta {
                 delta,
             })])
         }
         RealtimeSessionEvent::OutputTextDeltaForItem {
+            response_id,
             delta_id,
             item_id,
             previous_item_id,
@@ -3713,6 +3719,7 @@ async fn handle_product_session_event(
                 runtime,
                 binding,
                 meerkat_core::RealtimeTranscriptEvent::AssistantTextDelta {
+                    response_id,
                     delta_id,
                     item_id,
                     previous_item_id,
@@ -3735,13 +3742,15 @@ async fn handle_product_session_event(
                 chunk,
             })])
         }
-        RealtimeSessionEvent::Interrupted => {
-            append_realtime_transcript_event(
-                runtime,
-                binding,
-                meerkat_core::RealtimeTranscriptEvent::AssistantTurnInterrupted,
-            )
-            .await?;
+        RealtimeSessionEvent::Interrupted { response_id } => {
+            if let Some(response_id) = response_id {
+                append_realtime_transcript_event(
+                    runtime,
+                    binding,
+                    meerkat_core::RealtimeTranscriptEvent::AssistantTurnInterrupted { response_id },
+                )
+                .await?;
+            }
             Ok(vec![channel_event(RealtimeEvent::Interrupted)])
         }
         RealtimeSessionEvent::ToolCallRequested {
@@ -3751,15 +3760,17 @@ async fn handle_product_session_event(
             tool_name,
         })]),
         RealtimeSessionEvent::AssistantTranscriptTruncated {
+            response_id,
             item_id,
             audio_played_ms,
             truncated_text,
         } => {
-            if let Some(text) = truncated_text.clone() {
+            if let (Some(response_id), Some(text)) = (response_id, truncated_text.clone()) {
                 append_realtime_transcript_event(
                     runtime,
                     binding,
                     meerkat_core::RealtimeTranscriptEvent::AssistantTranscriptTruncated {
+                        response_id,
                         item_id: item_id.clone(),
                         content_index: 0,
                         text,

--- a/meerkat-rpc/src/session_runtime.rs
+++ b/meerkat-rpc/src/session_runtime.rs
@@ -4399,6 +4399,16 @@ impl SessionRuntime {
             .await
     }
 
+    pub async fn append_realtime_transcript_event(
+        &self,
+        session_id: &SessionId,
+        event: meerkat_core::RealtimeTranscriptEvent,
+    ) -> Result<meerkat_core::RealtimeTranscriptApplyOutcome, SessionError> {
+        self.service
+            .append_realtime_transcript_event(session_id, event)
+            .await
+    }
+
     #[cfg(feature = "mob")]
     pub fn session_service(&self) -> Arc<dyn meerkat_mob::MobSessionService> {
         Arc::new(RpcMobSessionService::new(

--- a/meerkat-rpc/tests/realtime_ws_protocol.rs
+++ b/meerkat-rpc/tests/realtime_ws_protocol.rs
@@ -1326,6 +1326,7 @@ async fn audio_input_uses_product_session_factory_and_streams_provider_events() 
                     })),
                     Ok(Some(RealtimeSessionEvent::TurnCommitted)),
                     Ok(Some(RealtimeSessionEvent::OutputTextDeltaForItem {
+                        response_id: "resp_assistant".to_string(),
                         delta_id: "evt_assistant_ready".to_string(),
                         item_id: "item_assistant".to_string(),
                         previous_item_id: Some("item_user".to_string()),
@@ -1333,6 +1334,7 @@ async fn audio_input_uses_product_session_factory_and_streams_provider_events() 
                         delta: "ready".to_string(),
                     })),
                     Ok(Some(RealtimeSessionEvent::OutputTextDeltaForItem {
+                        response_id: "resp_assistant".to_string(),
                         delta_id: "evt_assistant_ready".to_string(),
                         item_id: "item_assistant".to_string(),
                         previous_item_id: Some("item_user".to_string()),
@@ -1348,6 +1350,7 @@ async fn audio_input_uses_product_session_factory_and_streams_provider_events() 
                         },
                     })),
                     Ok(Some(RealtimeSessionEvent::TurnCompleted {
+                        response_id: "resp_assistant".to_string(),
                         stop_reason: StopReason::EndTurn,
                         usage: meerkat_core::types::Usage::default(),
                     })),
@@ -1527,6 +1530,7 @@ async fn unkeyed_provider_transcript_events_are_projection_only_for_websocket() 
                         delta: "unkeyed assistant".to_string(),
                     })),
                     Ok(Some(RealtimeSessionEvent::TurnCompleted {
+                        response_id: "resp_unkeyed".to_string(),
                         stop_reason: StopReason::EndTurn,
                         usage: meerkat_core::types::Usage::default(),
                     })),
@@ -1667,6 +1671,7 @@ async fn provider_tool_use_boundary_does_not_surface_public_turn_completed_or_fl
                     })),
                     Ok(Some(RealtimeSessionEvent::TurnCommitted)),
                     Ok(Some(RealtimeSessionEvent::OutputTextDeltaForItem {
+                        response_id: "resp_assistant".to_string(),
                         delta_id: "evt_assistant_asking".to_string(),
                         item_id: "item_assistant".to_string(),
                         previous_item_id: Some("item_user".to_string()),
@@ -1674,10 +1679,12 @@ async fn provider_tool_use_boundary_does_not_surface_public_turn_completed_or_fl
                         delta: "asking ".to_string(),
                     })),
                     Ok(Some(RealtimeSessionEvent::TurnCompleted {
+                        response_id: "resp_assistant".to_string(),
                         stop_reason: StopReason::ToolUse,
                         usage: meerkat_core::types::Usage::default(),
                     })),
                     Ok(Some(RealtimeSessionEvent::OutputTextDeltaForItem {
+                        response_id: "resp_assistant".to_string(),
                         delta_id: "evt_assistant_done".to_string(),
                         item_id: "item_assistant".to_string(),
                         previous_item_id: Some("item_user".to_string()),
@@ -1685,6 +1692,7 @@ async fn provider_tool_use_boundary_does_not_surface_public_turn_completed_or_fl
                         delta: "done".to_string(),
                     })),
                     Ok(Some(RealtimeSessionEvent::TurnCompleted {
+                        response_id: "resp_assistant".to_string(),
                         stop_reason: StopReason::EndTurn,
                         usage: meerkat_core::types::Usage::default(),
                     })),
@@ -1840,8 +1848,11 @@ async fn provider_interrupted_event_is_forwarded_as_public_channel_event() {
                             data: "AAEC".to_string(),
                         },
                     })),
-                    Ok(Some(RealtimeSessionEvent::Interrupted)),
+                    Ok(Some(RealtimeSessionEvent::Interrupted {
+                        response_id: Some("resp_audio".to_string()),
+                    })),
                     Ok(Some(RealtimeSessionEvent::TurnCompleted {
+                        response_id: "resp_audio".to_string(),
                         stop_reason: StopReason::Cancelled,
                         usage: meerkat_core::types::Usage::default(),
                     })),
@@ -1969,8 +1980,11 @@ async fn cancelled_provider_turn_does_not_surface_public_completion_or_commit_pa
                     Ok(Some(RealtimeSessionEvent::OutputTextDelta {
                         delta: "partial".to_string(),
                     })),
-                    Ok(Some(RealtimeSessionEvent::Interrupted)),
+                    Ok(Some(RealtimeSessionEvent::Interrupted {
+                        response_id: None,
+                    })),
                     Ok(Some(RealtimeSessionEvent::TurnCompleted {
+                        response_id: "resp_cancelled".to_string(),
                         stop_reason: StopReason::Cancelled,
                         usage: meerkat_core::types::Usage::default(),
                     })),
@@ -2134,13 +2148,16 @@ async fn interrupted_provider_turn_followed_by_new_commit_appends_new_user_turn_
                     })),
                     Ok(Some(RealtimeSessionEvent::TurnCommitted)),
                     Ok(Some(RealtimeSessionEvent::OutputTextDeltaForItem {
+                        response_id: "resp_interrupted".to_string(),
                         delta_id: "evt_assistant_interrupted".to_string(),
                         item_id: "item_assistant_1".to_string(),
                         previous_item_id: Some("item_user_1".to_string()),
                         content_index: 0,
                         delta: "the token is ".to_string(),
                     })),
-                    Ok(Some(RealtimeSessionEvent::Interrupted)),
+                    Ok(Some(RealtimeSessionEvent::Interrupted {
+                        response_id: Some("resp_interrupted".to_string()),
+                    })),
                     Ok(Some(RealtimeSessionEvent::TurnStarted)),
                     Ok(Some(RealtimeSessionEvent::InputTranscriptFinalForItem {
                         item_id: "item_user_2".to_string(),
@@ -2150,6 +2167,7 @@ async fn interrupted_provider_turn_followed_by_new_commit_appends_new_user_turn_
                     })),
                     Ok(Some(RealtimeSessionEvent::TurnCommitted)),
                     Ok(Some(RealtimeSessionEvent::OutputTextDeltaForItem {
+                        response_id: "resp_final".to_string(),
                         delta_id: "evt_assistant_final_1".to_string(),
                         item_id: "item_assistant_2".to_string(),
                         previous_item_id: Some("item_user_2".to_string()),
@@ -2157,6 +2175,7 @@ async fn interrupted_provider_turn_followed_by_new_commit_appends_new_user_turn_
                         delta: "amber lantern. ".to_string(),
                     })),
                     Ok(Some(RealtimeSessionEvent::OutputTextDeltaForItem {
+                        response_id: "resp_final".to_string(),
                         delta_id: "evt_assistant_final_2".to_string(),
                         item_id: "item_assistant_2".to_string(),
                         previous_item_id: Some("item_user_2".to_string()),
@@ -2164,6 +2183,7 @@ async fn interrupted_provider_turn_followed_by_new_commit_appends_new_user_turn_
                         delta: "birch seventeen.".to_string(),
                     })),
                     Ok(Some(RealtimeSessionEvent::TurnCompleted {
+                        response_id: "resp_final".to_string(),
                         stop_reason: StopReason::EndTurn,
                         usage: meerkat_core::types::Usage::default(),
                     })),

--- a/meerkat-rpc/tests/realtime_ws_protocol.rs
+++ b/meerkat-rpc/tests/realtime_ws_protocol.rs
@@ -1318,11 +1318,25 @@ async fn audio_input_uses_product_session_factory_and_streams_provider_events() 
                     Ok(Some(RealtimeSessionEvent::InputTranscriptPartial {
                         text: "cedar".to_string(),
                     })),
-                    Ok(Some(RealtimeSessionEvent::InputTranscriptFinal {
+                    Ok(Some(RealtimeSessionEvent::InputTranscriptFinalForItem {
+                        item_id: "item_user".to_string(),
+                        previous_item_id: None,
+                        content_index: 0,
                         text: "cedar seven".to_string(),
                     })),
                     Ok(Some(RealtimeSessionEvent::TurnCommitted)),
-                    Ok(Some(RealtimeSessionEvent::OutputTextDelta {
+                    Ok(Some(RealtimeSessionEvent::OutputTextDeltaForItem {
+                        delta_id: "evt_assistant_ready".to_string(),
+                        item_id: "item_assistant".to_string(),
+                        previous_item_id: Some("item_user".to_string()),
+                        content_index: 0,
+                        delta: "ready".to_string(),
+                    })),
+                    Ok(Some(RealtimeSessionEvent::OutputTextDeltaForItem {
+                        delta_id: "evt_assistant_ready".to_string(),
+                        item_id: "item_assistant".to_string(),
+                        previous_item_id: Some("item_user".to_string()),
+                        content_index: 0,
                         delta: "ready".to_string(),
                     })),
                     Ok(Some(RealtimeSessionEvent::OutputAudioChunk {
@@ -1433,6 +1447,12 @@ async fn audio_input_uses_product_session_factory_and_streams_provider_events() 
     );
     assert_channel_event(
         read_server_frame(&mut ws_stream).await,
+        RealtimeEvent::OutputTextDelta {
+            delta: "ready".to_string(),
+        },
+    );
+    assert_channel_event(
+        read_server_frame(&mut ws_stream).await,
         RealtimeEvent::OutputAudioChunk {
             chunk: RealtimeAudioChunk {
                 mime_type: "audio/pcm".to_string(),
@@ -1486,6 +1506,137 @@ async fn audio_input_uses_product_session_factory_and_streams_provider_events() 
 }
 
 #[tokio::test]
+async fn unkeyed_provider_transcript_events_are_projection_only_for_websocket() {
+    let (_temp, runtime, config_store) = build_test_runtime();
+    let session_id = create_materialized_session(&runtime).await;
+    let session_id_text = session_id.to_string();
+    let baseline_history = read_history(&runtime, &session_id_text).await;
+    let session_factory = Arc::new(FakeRealtimeSessionFactory {
+        capabilities: conservative_capabilities(vec![RealtimeTurningMode::ProviderManaged]),
+        opened_sessions: tokio::sync::Mutex::new(std::collections::VecDeque::from(vec![Ok(
+            Box::new(FakeRealtimeSession {
+                capabilities: conservative_capabilities(vec![RealtimeTurningMode::ProviderManaged]),
+                turning_mode: RealtimeTurningMode::ProviderManaged,
+                scripted_events: std::collections::VecDeque::from(vec![
+                    Ok(Some(RealtimeSessionEvent::TurnStarted)),
+                    Ok(Some(RealtimeSessionEvent::InputTranscriptFinal {
+                        text: "unkeyed user".to_string(),
+                    })),
+                    Ok(Some(RealtimeSessionEvent::TurnCommitted)),
+                    Ok(Some(RealtimeSessionEvent::OutputTextDelta {
+                        delta: "unkeyed assistant".to_string(),
+                    })),
+                    Ok(Some(RealtimeSessionEvent::TurnCompleted {
+                        stop_reason: StopReason::EndTurn,
+                        usage: meerkat_core::types::Usage::default(),
+                    })),
+                    Ok(None),
+                ]),
+                seen_inputs: Arc::new(tokio::sync::Mutex::new(Vec::new())),
+                seen_tool_results: Arc::new(tokio::sync::Mutex::new(Vec::new())),
+                seen_tool_errors: Arc::new(tokio::sync::Mutex::new(Vec::new())),
+                release_events_after_input: true,
+                release_events_after_tool_submission: false,
+                input_seen: Arc::new(AtomicBool::new(false)),
+                input_gate: Arc::new(Notify::new()),
+                tool_submission_seen: Arc::new(AtomicBool::new(false)),
+                tool_submission_gate: Arc::new(Notify::new()),
+            }) as Box<dyn RealtimeSession>,
+        )])),
+        open_calls: Arc::new(tokio::sync::Mutex::new(0usize)),
+        open_configs: Arc::new(tokio::sync::Mutex::new(Vec::new())),
+        attach_calls: Arc::new(tokio::sync::Mutex::new(0usize)),
+    });
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    let ws_url = format!("ws://{addr}{REALTIME_WS_PATH}");
+    let host = Arc::new(RealtimeWsHost::new(ws_url.clone()).with_session_factory(session_factory));
+    let open_info = issue_open_info(
+        host.as_ref(),
+        &runtime,
+        &session_id_text,
+        RealtimeChannelRole::Primary,
+        RealtimeTurningMode::ProviderManaged,
+    )
+    .await;
+    let server_host = Arc::clone(&host);
+    let server_runtime = Arc::clone(&runtime);
+    let server = tokio::spawn(async move {
+        serve_realtime_ws_listener(listener, server_host, server_runtime, config_store).await
+    });
+
+    let mut ws_stream = connect_and_open(
+        &ws_url,
+        &open_info,
+        RealtimeChannelRole::Primary,
+        RealtimeTurningMode::ProviderManaged,
+    )
+    .await;
+    match read_server_frame(&mut ws_stream).await {
+        RealtimeServerFrame::ChannelOpened(opened) => {
+            assert_eq!(opened.status.state, RealtimeChannelState::Ready);
+        }
+        other => panic!("expected channel.opened, got {other:?}"),
+    }
+    ws_stream
+        .send(WsMessage::Text(
+            serde_json::to_string(&RealtimeClientFrame::ChannelInput(
+                RealtimeChannelInputFrame {
+                    chunk: RealtimeInputChunk::AudioChunk(RealtimeAudioChunk {
+                        mime_type: "audio/pcm".to_string(),
+                        sample_rate_hz: 24_000,
+                        channels: 1,
+                        data: "AQID".to_string(),
+                    }),
+                },
+            ))
+            .expect("channel.input should serialize")
+            .into(),
+        ))
+        .await
+        .expect("channel.input should send");
+
+    let deadline = tokio::time::Instant::now() + Duration::from_secs(2);
+    let mut saw_completed = false;
+    while tokio::time::Instant::now() < deadline {
+        let remaining = deadline.saturating_duration_since(tokio::time::Instant::now());
+        let frame = tokio::time::timeout(remaining, read_server_frame(&mut ws_stream))
+            .await
+            .expect("expected provider frames before timeout");
+        match frame {
+            RealtimeServerFrame::ChannelEvent(event_frame) => {
+                if matches!(event_frame.event, RealtimeEvent::TurnCompleted) {
+                    saw_completed = true;
+                    break;
+                }
+            }
+            RealtimeServerFrame::ChannelStatus(_) | RealtimeServerFrame::ChannelOpened(_) => {}
+            RealtimeServerFrame::ChannelClosed(frame) => {
+                panic!("unexpected channel close {frame:?}")
+            }
+            RealtimeServerFrame::ChannelError(error) => {
+                panic!("unexpected channel error {error:?}")
+            }
+        }
+    }
+    assert!(
+        saw_completed,
+        "provider public turn completion should surface"
+    );
+
+    let history = read_history(&runtime, &session_id_text).await;
+    assert_eq!(history.message_count, baseline_history.message_count);
+    assert_eq!(
+        serde_json::to_value(&history.messages).unwrap(),
+        serde_json::to_value(&baseline_history.messages).unwrap(),
+        "unkeyed websocket translation must not append canonical transcript content"
+    );
+
+    let _ = ws_stream.close(None).await;
+    server.abort();
+}
+
+#[tokio::test]
 // Re-enabled 2026-04-19: the underlying race (tool-use subresponse
 // boundary sometimes reconstructs the provider session mid-turn under
 // CI load) is kept in check by `.config/nextest.toml`'s retries=2
@@ -1508,18 +1659,29 @@ async fn provider_tool_use_boundary_does_not_surface_public_turn_completed_or_fl
                 turning_mode: RealtimeTurningMode::ProviderManaged,
                 scripted_events: std::collections::VecDeque::from(vec![
                     Ok(Some(RealtimeSessionEvent::TurnStarted)),
-                    Ok(Some(RealtimeSessionEvent::InputTranscriptFinal {
+                    Ok(Some(RealtimeSessionEvent::InputTranscriptFinalForItem {
+                        item_id: "item_user".to_string(),
+                        previous_item_id: None,
+                        content_index: 0,
                         text: "cedar seven".to_string(),
                     })),
                     Ok(Some(RealtimeSessionEvent::TurnCommitted)),
-                    Ok(Some(RealtimeSessionEvent::OutputTextDelta {
+                    Ok(Some(RealtimeSessionEvent::OutputTextDeltaForItem {
+                        delta_id: "evt_assistant_asking".to_string(),
+                        item_id: "item_assistant".to_string(),
+                        previous_item_id: Some("item_user".to_string()),
+                        content_index: 0,
                         delta: "asking ".to_string(),
                     })),
                     Ok(Some(RealtimeSessionEvent::TurnCompleted {
                         stop_reason: StopReason::ToolUse,
                         usage: meerkat_core::types::Usage::default(),
                     })),
-                    Ok(Some(RealtimeSessionEvent::OutputTextDelta {
+                    Ok(Some(RealtimeSessionEvent::OutputTextDeltaForItem {
+                        delta_id: "evt_assistant_done".to_string(),
+                        item_id: "item_assistant".to_string(),
+                        previous_item_id: Some("item_user".to_string()),
+                        content_index: 0,
                         delta: "done".to_string(),
                     })),
                     Ok(Some(RealtimeSessionEvent::TurnCompleted {
@@ -1964,23 +2126,41 @@ async fn interrupted_provider_turn_followed_by_new_commit_appends_new_user_turn_
                 turning_mode: RealtimeTurningMode::ProviderManaged,
                 scripted_events: std::collections::VecDeque::from(vec![
                     Ok(Some(RealtimeSessionEvent::TurnStarted)),
-                    Ok(Some(RealtimeSessionEvent::InputTranscriptFinal {
+                    Ok(Some(RealtimeSessionEvent::InputTranscriptFinalForItem {
+                        item_id: "item_user_1".to_string(),
+                        previous_item_id: None,
+                        content_index: 0,
                         text: "ask analyst for the token".to_string(),
                     })),
                     Ok(Some(RealtimeSessionEvent::TurnCommitted)),
-                    Ok(Some(RealtimeSessionEvent::OutputTextDelta {
+                    Ok(Some(RealtimeSessionEvent::OutputTextDeltaForItem {
+                        delta_id: "evt_assistant_interrupted".to_string(),
+                        item_id: "item_assistant_1".to_string(),
+                        previous_item_id: Some("item_user_1".to_string()),
+                        content_index: 0,
                         delta: "the token is ".to_string(),
                     })),
                     Ok(Some(RealtimeSessionEvent::Interrupted)),
                     Ok(Some(RealtimeSessionEvent::TurnStarted)),
-                    Ok(Some(RealtimeSessionEvent::InputTranscriptFinal {
+                    Ok(Some(RealtimeSessionEvent::InputTranscriptFinalForItem {
+                        item_id: "item_user_2".to_string(),
+                        previous_item_id: Some("item_user_1".to_string()),
+                        content_index: 0,
                         text: "stop and tell me the codeword and the token".to_string(),
                     })),
                     Ok(Some(RealtimeSessionEvent::TurnCommitted)),
-                    Ok(Some(RealtimeSessionEvent::OutputTextDelta {
+                    Ok(Some(RealtimeSessionEvent::OutputTextDeltaForItem {
+                        delta_id: "evt_assistant_final_1".to_string(),
+                        item_id: "item_assistant_2".to_string(),
+                        previous_item_id: Some("item_user_2".to_string()),
+                        content_index: 0,
                         delta: "amber lantern. ".to_string(),
                     })),
-                    Ok(Some(RealtimeSessionEvent::OutputTextDelta {
+                    Ok(Some(RealtimeSessionEvent::OutputTextDeltaForItem {
+                        delta_id: "evt_assistant_final_2".to_string(),
+                        item_id: "item_assistant_2".to_string(),
+                        previous_item_id: Some("item_user_2".to_string()),
+                        content_index: 0,
                         delta: "birch seventeen.".to_string(),
                     })),
                     Ok(Some(RealtimeSessionEvent::TurnCompleted {

--- a/meerkat-session/src/ephemeral.rs
+++ b/meerkat-session/src/ephemeral.rs
@@ -24,7 +24,8 @@ use meerkat_core::time_compat::SystemTime;
 use meerkat_core::types::{ContentInput, RunResult, SessionId, ToolResult, Usage};
 use meerkat_core::{
     DeferredFirstTurnPhase, InputId, PendingDeferredPrompt, PendingSystemContextAppend,
-    PendingToolResultsMessage, RunId, SessionDeferredTurnState, SessionLlmIdentity,
+    PendingToolResultsMessage, RealtimeTranscriptApplyOutcome, RealtimeTranscriptEvent,
+    RealtimeTranscriptMaterializedMessage, RunId, SessionDeferredTurnState, SessionLlmIdentity,
     SessionSystemContextState,
 };
 use sha2::{Digest, Sha256};
@@ -147,6 +148,12 @@ enum SessionCommand {
         stop_reason: meerkat_core::types::StopReason,
         usage: Usage,
         reply_tx: oneshot::Sender<Result<(), meerkat_core::error::AgentError>>,
+    },
+    AppendRealtimeTranscriptEvent {
+        event: RealtimeTranscriptEvent,
+        reply_tx: oneshot::Sender<
+            Result<RealtimeTranscriptApplyOutcome, meerkat_core::error::AgentError>,
+        >,
     },
     DispatchExternalToolCall {
         call: meerkat_core::ToolCall,
@@ -628,6 +635,16 @@ pub trait SessionAgent: Send {
     ) -> Result<(), meerkat_core::error::AgentError> {
         Err(meerkat_core::error::AgentError::ConfigError(
             "external assistant output append is not supported by this session agent".to_string(),
+        ))
+    }
+
+    /// Apply an identity-bearing provider realtime transcript event.
+    fn append_realtime_transcript_event(
+        &mut self,
+        _event: RealtimeTranscriptEvent,
+    ) -> Result<RealtimeTranscriptApplyOutcome, meerkat_core::error::AgentError> {
+        Err(meerkat_core::error::AgentError::ConfigError(
+            "realtime transcript append is not supported by this session agent".to_string(),
         ))
     }
 
@@ -1384,6 +1401,36 @@ impl<B: SessionAgentBuilder + 'static> EphemeralSessionService<B> {
                 usage,
                 reply_tx,
             })
+            .await
+            .map_err(|_| {
+                SessionError::Agent(meerkat_core::error::AgentError::InternalError(
+                    "Session task has exited".to_string(),
+                ))
+            })?;
+        reply_rx
+            .await
+            .map_err(|_| {
+                SessionError::Agent(meerkat_core::error::AgentError::InternalError(
+                    "Session task dropped the reply channel".to_string(),
+                ))
+            })?
+            .map_err(SessionError::Agent)
+    }
+
+    /// Apply an identity-bearing provider realtime transcript event.
+    pub async fn append_realtime_transcript_event(
+        &self,
+        id: &SessionId,
+        event: RealtimeTranscriptEvent,
+    ) -> Result<RealtimeTranscriptApplyOutcome, SessionError> {
+        let sessions = self.sessions.read().await;
+        let handle = sessions
+            .get(id)
+            .ok_or_else(|| SessionError::NotFound { id: id.clone() })?;
+        let (reply_tx, reply_rx) = oneshot::channel();
+        handle
+            .command_tx
+            .send(SessionCommand::AppendRealtimeTranscriptEvent { event, reply_tx })
             .await
             .map_err(|_| {
                 SessionError::Agent(meerkat_core::error::AgentError::InternalError(
@@ -3590,6 +3637,49 @@ async fn session_task<A: SessionAgent>(
                         },
                     );
                     let _ = control.session_event_tx.send(envelope);
+                }
+                let _ = reply_tx.send(result);
+            }
+            SessionCommand::AppendRealtimeTranscriptEvent { event, reply_tx } => {
+                let result = agent.append_realtime_transcript_event(event);
+                if let Ok(outcome) = &result {
+                    let snap = agent.snapshot();
+                    control.publish_summary(SessionSummaryCache {
+                        updated_at: snap.updated_at,
+                        message_count: snap.message_count,
+                        total_tokens: snap.total_tokens,
+                        usage: snap.usage,
+                        last_assistant_text: snap.last_assistant_text,
+                    });
+                    for materialized in &outcome.materialized_messages {
+                        if let RealtimeTranscriptMaterializedMessage::Assistant {
+                            text,
+                            stop_reason,
+                            usage,
+                            ..
+                        } = materialized
+                        {
+                            if !text.is_empty() {
+                                let envelope = stamp_event_envelope(
+                                    &mut next_seq,
+                                    &source,
+                                    AgentEvent::TextComplete {
+                                        content: text.clone(),
+                                    },
+                                );
+                                let _ = control.session_event_tx.send(envelope);
+                            }
+                            let envelope = stamp_event_envelope(
+                                &mut next_seq,
+                                &source,
+                                AgentEvent::TurnCompleted {
+                                    stop_reason: *stop_reason,
+                                    usage: usage.clone(),
+                                },
+                            );
+                            let _ = control.session_event_tx.send(envelope);
+                        }
+                    }
                 }
                 let _ = reply_tx.send(result);
             }

--- a/meerkat-session/src/persistent.rs
+++ b/meerkat-session/src/persistent.rs
@@ -1051,6 +1051,23 @@ impl<B: SessionAgentBuilder + 'static> PersistentSessionService<B> {
         Ok(())
     }
 
+    pub async fn append_realtime_transcript_event(
+        &self,
+        id: &SessionId,
+        event: meerkat_core::RealtimeTranscriptEvent,
+    ) -> Result<meerkat_core::RealtimeTranscriptApplyOutcome, SessionError> {
+        let _mutation_guard = self.live_persist_mutation_guard(id).await?;
+        let outcome = self
+            .inner
+            .append_realtime_transcript_event(id, event)
+            .await?;
+        if let Err(error) = self.persist_full_session(id).await {
+            let _ = self.discard_live_session(id).await;
+            return Err(error);
+        }
+        Ok(outcome)
+    }
+
     /// Create a new persistent session service.
     pub fn new(
         builder: B,

--- a/meerkat/src/service_factory.rs
+++ b/meerkat/src/service_factory.rs
@@ -382,6 +382,25 @@ impl SessionAgent for FactoryAgent {
         Ok(())
     }
 
+    fn append_realtime_transcript_event(
+        &mut self,
+        event: meerkat_core::RealtimeTranscriptEvent,
+    ) -> Result<meerkat_core::RealtimeTranscriptApplyOutcome, meerkat_core::error::AgentError> {
+        let outcome = self
+            .agent
+            .session_mut()
+            .append_realtime_transcript_event(event);
+        for materialized in &outcome.materialized_messages {
+            if let meerkat_core::RealtimeTranscriptMaterializedMessage::Assistant {
+                usage, ..
+            } = materialized
+            {
+                self.agent.budget().record_usage(usage);
+            }
+        }
+        Ok(outcome)
+    }
+
     fn system_context_state(
         &self,
     ) -> Arc<std::sync::Mutex<meerkat_core::SessionSystemContextState>> {


### PR DESCRIPTION
## Summary
- add a typed session-owned realtime transcript append seam keyed by provider item/delta identity
- route keyed provider realtime transcript events through the session seam from the websocket
- leave unkeyed websocket transcript translation projection-only and delete the old private websocket append helpers
- update OpenAI realtime mapping to emit keyed transcript events and add regressions for duplicate, replay, ordering, and old-path uncallability

## Old Path Amputated
`meerkat-rpc/src/realtime_ws.rs::RealtimePendingTurn` no longer owns canonical assistant transcript text, and `handle_product_session_event` no longer calls websocket-local `append_external_user_content` / `append_external_assistant_output` helpers. Provider transcript content must pass through `Session::append_realtime_transcript_event` via the runtime/session service seam.

## Validation
- `./scripts/repo-cargo test -p meerkat-rpc --test realtime_ws_protocol explicit_commit_text_input_stays_local_until_commit_turn -- --nocapture`
- `./scripts/repo-cargo test -p meerkat-rpc --test realtime_ws_protocol interrupted_provider_turn_followed_by_new_commit_appends_new_user_turn_and_final_output -- --nocapture`
- `./scripts/repo-cargo test -p meerkat-core realtime_transcript -- --nocapture`
- `./scripts/repo-cargo test -p meerkat-openai --features realtime provider_neutral_session_maps_raw_events_to_generic_events -- --nocapture`
- `./scripts/repo-cargo check -p meerkat-session -p meerkat-openai -p meerkat-rpc --features meerkat-openai/realtime`
- `./scripts/repo-cargo test -p meerkat-rpc --test realtime_ws_protocol -- --nocapture`
- `MEERKAT_BUILDBUDDY=1 make e2e-smoke` (BuildBuddy invocation `770aa56a-8347-45aa-966e-5219329253fa`; 44 passed)

Linear: LUC-393