### PR TITLE
Update and validate examples

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,6 +26,7 @@
 # Temporary files
 nohup.out
 .release-hook-done
+examples/*/.work/
 .rct/*
 !.rct/round5/
 !.rct/round5/**
@@ -37,6 +38,7 @@ test-project/
 vendor
 
 # Python
+.venv/
 __pycache__/
 *.pyc
 *.pyo

--- a/examples/001-hello-meerkat-rs/README.md
+++ b/examples/001-hello-meerkat-rs/README.md
@@ -10,5 +10,7 @@ The simplest possible Meerkat Rust example. Create a `SessionService`, run one s
 
 ## Run
 ```bash
-# This is a reference implementation. For runnable examples, see meerkat/examples/.
+# From the repository root
+ANTHROPIC_API_KEY=sk-... ./scripts/repo-cargo run -p meerkat \
+  --example 001-hello-meerkat --features jsonl-store
 ```

--- a/examples/002-hello-meerkat-py/README.md
+++ b/examples/002-hello-meerkat-py/README.md
@@ -6,7 +6,10 @@ communicates via JSON-RPC — zero HTTP servers, zero configuration.
 ## Prerequisites
 ```bash
 # From the repository root when running from a checkout
-python3 -m pip install -e sdks/python
+python3 -m venv .venv
+. .venv/bin/activate
+python -m pip install --upgrade pip
+python -m pip install -e sdks/python
 ./scripts/repo-cargo build -p meerkat-rpc --bin rkat-rpc
 export MEERKAT_BIN_PATH="$(./scripts/repo-cargo --print-env | sed -n 's/^CARGO_TARGET_DIR=//p')/debug/rkat-rpc"
 ```

--- a/examples/002-hello-meerkat-py/README.md
+++ b/examples/002-hello-meerkat-py/README.md
@@ -5,7 +5,10 @@ communicates via JSON-RPC — zero HTTP servers, zero configuration.
 
 ## Prerequisites
 ```bash
-pip install meerkat-sdk   # or: pip install -e sdks/python
+# From the repository root when running from a checkout
+python3 -m pip install -e sdks/python
+./scripts/repo-cargo build -p meerkat-rpc --bin rkat-rpc
+export MEERKAT_BIN_PATH="$(./scripts/repo-cargo --print-env | sed -n 's/^CARGO_TARGET_DIR=//p')/debug/rkat-rpc"
 ```
 
 ## Concepts
@@ -16,5 +19,5 @@ pip install meerkat-sdk   # or: pip install -e sdks/python
 
 ## Run
 ```bash
-ANTHROPIC_API_KEY=sk-... python main.py
+ANTHROPIC_API_KEY=sk-... python3 main.py
 ```

--- a/examples/002-hello-meerkat-py/main.py
+++ b/examples/002-hello-meerkat-py/main.py
@@ -11,7 +11,7 @@ What you'll learn:
 - Reading the Session result
 
 Run:
-    ANTHROPIC_API_KEY=sk-... python main.py
+    ANTHROPIC_API_KEY=sk-... python3 main.py
 """
 
 import asyncio

--- a/examples/003-hello-meerkat-ts/README.md
+++ b/examples/003-hello-meerkat-ts/README.md
@@ -1,11 +1,17 @@
 # 003 — Hello Meerkat (TypeScript SDK)
 
-The simplest TypeScript agent. The SDK auto-downloads and spawns `rkat-rpc`
-as a child process — no manual binary management needed.
+The simplest TypeScript agent. The SDK spawns `rkat-rpc` as a child process
+and can use either an installed/downloaded runtime binary or the repo-local
+binary built from this checkout.
 
 ## Prerequisites
 ```bash
-npm install @rkat/sdk   # or: npm link from sdks/typescript
+# From the repository root when running from a checkout
+npm --prefix sdks/typescript install
+npm --prefix sdks/typescript run build
+(cd examples && npm install)
+./scripts/repo-cargo build -p meerkat-rpc --bin rkat-rpc
+export MEERKAT_BIN_PATH="$(./scripts/repo-cargo --print-env | sed -n 's/^CARGO_TARGET_DIR=//p')/debug/rkat-rpc"
 ```
 
 ## Concepts

--- a/examples/004-cli-one-liners-sh/README.md
+++ b/examples/004-cli-one-liners-sh/README.md
@@ -13,7 +13,7 @@ Everything you can do with `rkat` from the command line — no code required.
 ## Prerequisites
 ```bash
 export ANTHROPIC_API_KEY=sk-...
-cargo build -p meerkat-cli
+./scripts/repo-cargo build -p rkat --bin rkat
 ```
 
 ## Run

--- a/examples/004-cli-one-liners-sh/README.md
+++ b/examples/004-cli-one-liners-sh/README.md
@@ -4,8 +4,8 @@ Everything you can do with `rkat` from the command line — no code required.
 
 ## Concepts
 - `rkat run` — single-turn agent execution
-- `rkat resume` — multi-turn session resumption
-- `rkat sessions list/read/archive` — session management
+- `rkat run --resume last` — multi-turn session resumption
+- `rkat session list/show/delete` — session management
 - `--isolated` / `--realm` — workspace isolation
 - `--verbose` / `--stream` — output modes
 - `rkat config` — runtime configuration

--- a/examples/004-cli-one-liners-sh/examples.sh
+++ b/examples/004-cli-one-liners-sh/examples.sh
@@ -6,7 +6,7 @@
 #
 # What you'll learn:
 # - Running single-turn prompts
-# - Managing sessions (create, resume, list, read, archive)
+# - Managing sessions (create, resume, list, show, delete)
 # - Using realms for isolation
 # - Configuring the runtime from the command line
 #
@@ -57,24 +57,19 @@ $RKAT run "List three benefits of Rust. Be concise."
 
 echo ""
 echo "=== 2. Create a session and continue it ==="
-SESSION_OUTPUT=$($RKAT run "Remember: my favorite color is blue." 2>&1)
-echo "$SESSION_OUTPUT"
-# Extract session ID from output (rkat prints it to stderr)
-SESSION_ID=$(echo "$SESSION_OUTPUT" | sed -n 's/.*Session: \([a-f0-9-]*\).*/\1/p' | head -1)
+$RKAT run "Remember: my favorite color is blue."
 
-if [ -n "$SESSION_ID" ]; then
-    echo ""
-    echo "=== 3. Resume the session ==="
-    $RKAT resume "$SESSION_ID" "What is my favorite color?"
-fi
+echo ""
+echo "=== 3. Resume the latest session ==="
+$RKAT run --resume last "What is my favorite color?"
 
 echo ""
 echo "=== 4. List sessions ==="
-$RKAT sessions list
+$RKAT session list
 
 echo ""
 echo "=== 5. Isolated realm (ephemeral workspace) ==="
-$RKAT --isolated run "This session lives in its own isolated realm."
+$RKAT run --isolated "This session lives in its own isolated realm."
 
 echo ""
 echo "=== 6. Configuration from CLI ==="

--- a/examples/004-cli-one-liners-sh/examples.sh
+++ b/examples/004-cli-one-liners-sh/examples.sh
@@ -12,11 +12,45 @@
 #
 # Prerequisites:
 #   export ANTHROPIC_API_KEY=sk-...
-#   cargo build -p meerkat-cli  # produces ./target/debug/rkat
+#   ./scripts/repo-cargo build -p rkat --bin rkat
 
 set -euo pipefail
 
-RKAT="${RKAT:-rkat}"
+ROOT="$(cd "$(dirname "$0")" && pwd)"
+WORKSPACE_ROOT="$(cd "$ROOT/../.." && pwd)"
+
+resolve_rkat() {
+  if [[ -n "${RKAT:-}" ]]; then
+    printf '%s\n' "$RKAT"
+    return
+  fi
+
+  local candidate
+  for candidate in \
+    "$WORKSPACE_ROOT/target/debug/rkat" \
+    "$WORKSPACE_ROOT/target/release/rkat"
+  do
+    if [[ -x "$candidate" ]]; then
+      printf '%s\n' "$candidate"
+      return
+    fi
+  done
+
+  if [[ -x "$WORKSPACE_ROOT/scripts/repo-cargo" ]]; then
+    local target_dir
+    target_dir="$("$WORKSPACE_ROOT/scripts/repo-cargo" --print-env | sed -n 's/^CARGO_TARGET_DIR=//p')"
+    for candidate in "$target_dir/debug/rkat" "$target_dir/release/rkat"; do
+      if [[ -x "$candidate" ]]; then
+        printf '%s\n' "$candidate"
+        return
+      fi
+    done
+  fi
+
+  printf '%s\n' "rkat"
+}
+
+RKAT="$(resolve_rkat)"
 
 echo "=== 1. Single-turn prompt ==="
 $RKAT run "List three benefits of Rust. Be concise."

--- a/examples/005-streaming-events-rs/README.md
+++ b/examples/005-streaming-events-rs/README.md
@@ -20,5 +20,7 @@ and state transition is surfaced as a typed `AgentEvent`.
 
 ## Run
 ```bash
-# This is a reference implementation. For runnable examples, see meerkat/examples/.
+# From the repository root
+ANTHROPIC_API_KEY=sk-... ./scripts/repo-cargo run -p meerkat \
+  --example 005-streaming-events --features jsonl-store
 ```

--- a/examples/006-custom-tools-rs/README.md
+++ b/examples/006-custom-tools-rs/README.md
@@ -19,5 +19,7 @@ Your code runs → ToolResult returned → Agent loop feeds result back to LLM
 
 ## Run
 ```bash
-# This is a reference implementation. For runnable examples, see meerkat/examples/.
+# From the repository root
+ANTHROPIC_API_KEY=sk-... ./scripts/repo-cargo run -p meerkat \
+  --example 006-custom-tools --features jsonl-store
 ```

--- a/examples/007-multi-turn-sessions-py/README.md
+++ b/examples/007-multi-turn-sessions-py/README.md
@@ -24,7 +24,9 @@ session.archive()  → clean up
 ## Run
 ```bash
 # From the repository root, first build/install the local Python SDK runtime:
-# python3 -m pip install -e sdks/python
+# python3 -m venv .venv && . .venv/bin/activate
+# python -m pip install --upgrade pip
+# python -m pip install -e sdks/python
 # ./scripts/repo-cargo build -p meerkat-rpc --bin rkat-rpc
 # export MEERKAT_BIN_PATH="$(./scripts/repo-cargo --print-env | sed -n 's/^CARGO_TARGET_DIR=//p')/debug/rkat-rpc"
 ANTHROPIC_API_KEY=sk-... python3 main.py

--- a/examples/007-multi-turn-sessions-py/README.md
+++ b/examples/007-multi-turn-sessions-py/README.md
@@ -23,5 +23,9 @@ session.archive()  → clean up
 
 ## Run
 ```bash
-ANTHROPIC_API_KEY=sk-... python main.py
+# From the repository root, first build/install the local Python SDK runtime:
+# python3 -m pip install -e sdks/python
+# ./scripts/repo-cargo build -p meerkat-rpc --bin rkat-rpc
+# export MEERKAT_BIN_PATH="$(./scripts/repo-cargo --print-env | sed -n 's/^CARGO_TARGET_DIR=//p')/debug/rkat-rpc"
+ANTHROPIC_API_KEY=sk-... python3 main.py
 ```

--- a/examples/007-multi-turn-sessions-py/main.py
+++ b/examples/007-multi-turn-sessions-py/main.py
@@ -11,7 +11,7 @@ What you'll learn:
 - Streaming events in real-time
 
 Run:
-    ANTHROPIC_API_KEY=sk-... python main.py
+    ANTHROPIC_API_KEY=sk-... python3 main.py
 """
 
 import asyncio

--- a/examples/007-multi-turn-sessions-py/main.py
+++ b/examples/007-multi-turn-sessions-py/main.py
@@ -64,10 +64,11 @@ async def main():
         # ── Session management ──
         print("\n=== Session info ===")
         info = await client.read_session(session.id)
-        print(f"Messages: {info.get('message_count', 'N/A')}")
-        print(f"Tokens:   {info.get('total_tokens', 'N/A')}")
+        print(f"Messages: {info.message_count}")
 
         sessions = await client.list_sessions()
+        summary = next((item for item in sessions if item.session_id == session.id), None)
+        print(f"Tokens:   {summary.total_tokens if summary else 'N/A'}")
         print(f"Active sessions: {len(sessions)}")
 
         # Clean up

--- a/examples/008-structured-output-ts/README.md
+++ b/examples/008-structured-output-ts/README.md
@@ -25,5 +25,10 @@ Standard JSON Schema. Meerkat validates and auto-retries:
 
 ## Run
 ```bash
+# From the repository root, first build the local TypeScript SDK and RPC binary:
+# npm --prefix sdks/typescript install && npm --prefix sdks/typescript run build
+# (cd examples && npm install)
+# ./scripts/repo-cargo build -p meerkat-rpc --bin rkat-rpc
+# export MEERKAT_BIN_PATH="$(./scripts/repo-cargo --print-env | sed -n 's/^CARGO_TARGET_DIR=//p')/debug/rkat-rpc"
 ANTHROPIC_API_KEY=sk-... npx tsx main.ts
 ```

--- a/examples/009-budget-and-retry-rs/README.md
+++ b/examples/009-budget-and-retry-rs/README.md
@@ -26,5 +26,7 @@ Attempt 4 → give up
 
 ## Run
 ```bash
-# This is a reference implementation. For runnable examples, see meerkat/examples/.
+# From the repository root
+ANTHROPIC_API_KEY=sk-... ./scripts/repo-cargo run -p meerkat \
+  --example 009-budget-and-retry --features jsonl-store
 ```

--- a/examples/010-mcp-tool-server-sh/README.md
+++ b/examples/010-mcp-tool-server-sh/README.md
@@ -30,11 +30,11 @@ an on-call coordination prompt that must quote fields returned by those tools.
 
 ```bash
 export ANTHROPIC_API_KEY=sk-...
-cargo build -p meerkat-cli
+./scripts/repo-cargo build -p rkat --bin rkat
 ```
 
 If `rkat` is not on your `PATH`, the script automatically falls back to
-`../../target/debug/rkat` or `../../target/release/rkat`.
+repo-local binaries built by `./scripts/repo-cargo`.
 
 ## Run
 

--- a/examples/010-mcp-tool-server-sh/setup.sh
+++ b/examples/010-mcp-tool-server-sh/setup.sh
@@ -10,11 +10,12 @@
 #
 # Prerequisites:
 #   export ANTHROPIC_API_KEY=sk-...
-#   cargo build -p meerkat-cli   # or install rkat globally
+#   ./scripts/repo-cargo build -p rkat --bin rkat
 
 set -euo pipefail
 
 ROOT="$(cd "$(dirname "$0")" && pwd)"
+WORKSPACE_ROOT="$(cd "$ROOT/../.." && pwd)"
 WORK="$ROOT/.work"
 STATE_ROOT="$WORK/state"
 CONTEXT_ROOT="$WORK/project"
@@ -22,13 +23,38 @@ USER_CONFIG_ROOT="$WORK/user"
 SERVER_NAME="incident-kit"
 SERVER_SCRIPT="$ROOT/demo_mcp_server.py"
 
-if [[ -x "$ROOT/../../target/debug/rkat" ]]; then
-  RKAT="${RKAT:-$ROOT/../../target/debug/rkat}"
-elif [[ -x "$ROOT/../../target/release/rkat" ]]; then
-  RKAT="${RKAT:-$ROOT/../../target/release/rkat}"
-else
-  RKAT="${RKAT:-rkat}"
-fi
+resolve_rkat() {
+  if [[ -n "${RKAT:-}" ]]; then
+    printf '%s\n' "$RKAT"
+    return
+  fi
+
+  local candidate
+  for candidate in \
+    "$WORKSPACE_ROOT/target/debug/rkat" \
+    "$WORKSPACE_ROOT/target/release/rkat"
+  do
+    if [[ -x "$candidate" ]]; then
+      printf '%s\n' "$candidate"
+      return
+    fi
+  done
+
+  if [[ -x "$WORKSPACE_ROOT/scripts/repo-cargo" ]]; then
+    local target_dir
+    target_dir="$("$WORKSPACE_ROOT/scripts/repo-cargo" --print-env | sed -n 's/^CARGO_TARGET_DIR=//p')"
+    for candidate in "$target_dir/debug/rkat" "$target_dir/release/rkat"; do
+      if [[ -x "$candidate" ]]; then
+        printf '%s\n' "$candidate"
+        return
+      fi
+    done
+  fi
+
+  printf '%s\n' "rkat"
+}
+
+RKAT="$(resolve_rkat)"
 
 if [[ -z "${ANTHROPIC_API_KEY:-}" ]]; then
   echo "Set ANTHROPIC_API_KEY to run the live agent step."

--- a/examples/011-hooks-guardrails-rs/README.md
+++ b/examples/011-hooks-guardrails-rs/README.md
@@ -22,5 +22,7 @@ pre_llm_call → LLM → post_llm_response → pre_tool_dispatch → Tool
 
 ## Run
 ```bash
-# This is a reference implementation. For runnable examples, see meerkat/examples/.
+# From the repository root
+ANTHROPIC_API_KEY=sk-... ./scripts/repo-cargo run -p meerkat \
+  --example 011-hooks-guardrails --features jsonl-store
 ```

--- a/examples/011-hooks-guardrails-rs/main.rs
+++ b/examples/011-hooks-guardrails-rs/main.rs
@@ -12,7 +12,7 @@
 //!
 //! ## Run
 //! ```bash
-//! ANTHROPIC_API_KEY=... cargo run --example 011-hooks-guardrails --features jsonl-store
+//! ANTHROPIC_API_KEY=... ./scripts/repo-cargo run -p meerkat --example 011-hooks-guardrails --features jsonl-store
 //! ```
 
 use std::sync::Arc;

--- a/examples/012-skills-loading-rs/README.md
+++ b/examples/012-skills-loading-rs/README.md
@@ -26,5 +26,7 @@ guidance — all without changing agent code.
 
 ## Run
 ```bash
-# This is a reference implementation. For runnable examples, see meerkat/examples/.
+# From the repository root
+ANTHROPIC_API_KEY=sk-... ./scripts/repo-cargo run -p meerkat \
+  --example 012-skills-loading --features jsonl-store,skills
 ```

--- a/examples/012-skills-loading-rs/main.rs
+++ b/examples/012-skills-loading-rs/main.rs
@@ -23,7 +23,7 @@
 //!
 //! ## Run
 //! ```bash
-//! ANTHROPIC_API_KEY=... cargo run --example 012-skills-loading --features jsonl-store,skills
+//! ANTHROPIC_API_KEY=... ./scripts/repo-cargo run -p meerkat --example 012-skills-loading --features jsonl-store,skills
 //! ```
 
 use std::sync::Arc;

--- a/examples/013-context-compaction-rs/README.md
+++ b/examples/013-context-compaction-rs/README.md
@@ -24,5 +24,7 @@ Messages accumulate → token_threshold exceeded →
 
 ## Run
 ```bash
-# This is a reference implementation. For runnable examples, see meerkat/examples/.
+# From the repository root
+ANTHROPIC_API_KEY=sk-... ./scripts/repo-cargo run -p meerkat \
+  --example 013-context-compaction --features jsonl-store,session-compaction
 ```

--- a/examples/013-context-compaction-rs/main.rs
+++ b/examples/013-context-compaction-rs/main.rs
@@ -12,7 +12,7 @@
 //!
 //! ## Run
 //! ```bash
-//! ANTHROPIC_API_KEY=... cargo run --example 013-context-compaction --features jsonl-store,session-compaction
+//! ANTHROPIC_API_KEY=... ./scripts/repo-cargo run -p meerkat --example 013-context-compaction --features jsonl-store,session-compaction
 //! ```
 
 use std::sync::Arc;

--- a/examples/014-semantic-memory-rs/README.md
+++ b/examples/014-semantic-memory-rs/README.md
@@ -22,5 +22,7 @@ Later: Agent calls memory_search("what language for backend?")
 
 ## Run
 ```bash
-# This is a reference implementation. For runnable examples, see meerkat/examples/.
+# From the repository root
+ANTHROPIC_API_KEY=sk-... ./scripts/repo-cargo run -p meerkat \
+  --example 014-semantic-memory --features jsonl-store,memory-store-session
 ```

--- a/examples/014-semantic-memory-rs/main.rs
+++ b/examples/014-semantic-memory-rs/main.rs
@@ -19,7 +19,7 @@
 //!
 //! ## Run
 //! ```bash
-//! ANTHROPIC_API_KEY=... cargo run --example 014-semantic-memory --features jsonl-store,memory-store-session
+//! ANTHROPIC_API_KEY=... ./scripts/repo-cargo run -p meerkat --example 014-semantic-memory --features jsonl-store,memory-store-session
 //! ```
 
 use std::sync::Arc;

--- a/examples/015-session-persistence-rs/README.md
+++ b/examples/015-session-persistence-rs/README.md
@@ -22,5 +22,7 @@ Agent ←→ StoreAdapter ←→ SessionStore trait
 
 ## Run
 ```bash
-# This is a reference implementation. For runnable examples, see meerkat/examples/.
+# From the repository root
+ANTHROPIC_API_KEY=sk-... ./scripts/repo-cargo run -p meerkat \
+  --example 015-session-persistence --features jsonl-store
 ```

--- a/examples/017-mob-coding-swarm-rs/README.md
+++ b/examples/017-mob-coding-swarm-rs/README.md
@@ -32,5 +32,7 @@ for coding tasks. The mob runtime handles spawning, wiring, and lifecycle.
 
 ## Run
 ```bash
-# This is a reference implementation. For runnable examples, see meerkat/examples/.
+# From the repository root
+ANTHROPIC_API_KEY=sk-... ./scripts/repo-cargo run -p meerkat-mob \
+  --example 017-mob-coding-swarm
 ```

--- a/examples/017-mob-coding-swarm-rs/README.md
+++ b/examples/017-mob-coding-swarm-rs/README.md
@@ -14,7 +14,7 @@ for coding tasks. The mob runtime handles spawning, wiring, and lifecycle.
 ## Mob Architecture
 ```
                     ┌──────────────┐
-    User prompt ──→ │     Lead     │ (claude-opus-4-6)
+    User prompt ──→ │     Lead     │ (claude-opus-4-7)
                     │ Orchestrator │
                     │              │
                     │ mob.spawn()  │

--- a/examples/017-mob-coding-swarm-rs/main.rs
+++ b/examples/017-mob-coding-swarm-rs/main.rs
@@ -33,7 +33,7 @@ id = "coding_swarm"
 orchestrator = "lead"
 
 [profiles.lead]
-model = "claude-opus-4-6"
+model = "claude-opus-4-7"
 skills = ["orchestrator"]
 peer_description = "Orchestrator"
 external_addressable = true
@@ -129,7 +129,7 @@ id = "my-dev-team"
 orchestrator = "architect"
 
 [profiles.architect]
-model = "claude-opus-4-6"
+model = "claude-opus-4-7"
 skills = ["system-design"]
 peer_description = "System architect and task coordinator"
 external_addressable = true

--- a/examples/017-mob-coding-swarm-rs/main.rs
+++ b/examples/017-mob-coding-swarm-rs/main.rs
@@ -16,7 +16,7 @@
 //!
 //! ## Run
 //! ```bash
-//! ANTHROPIC_API_KEY=... cargo run --example 017-mob-coding-swarm --features comms
+//! ANTHROPIC_API_KEY=... ./scripts/repo-cargo run -p meerkat-mob --example 017-mob-coding-swarm
 //! ```
 
 use std::sync::Arc;

--- a/examples/017-mob-coding-swarm-rs/mob.toml
+++ b/examples/017-mob-coding-swarm-rs/mob.toml
@@ -9,7 +9,7 @@ id = "coding_swarm"
 orchestrator = "lead"
 
 [profiles.lead]
-model = "claude-opus-4-6"
+model = "claude-opus-4-7"
 skills = ["orchestrator"]
 peer_description = "Orchestrator — breaks down tasks, assigns work, reviews results"
 external_addressable = true

--- a/examples/018-mob-research-team-rs/README.md
+++ b/examples/018-mob-research-team-rs/README.md
@@ -20,5 +20,7 @@ and a lead analyst synthesizes findings into a cohesive report.
 
 ## Run
 ```bash
-# This is a reference implementation. For runnable examples, see meerkat/examples/.
+# From the repository root
+ANTHROPIC_API_KEY=sk-... ./scripts/repo-cargo run -p meerkat-mob \
+  --example 018-mob-research-team
 ```

--- a/examples/018-mob-research-team-rs/README.md
+++ b/examples/018-mob-research-team-rs/README.md
@@ -13,7 +13,7 @@ and a lead analyst synthesizes findings into a cohesive report.
 ## Profiles
 | Profile | Model | Role |
 |---------|-------|------|
-| lead-analyst | claude-opus-4-6 | Coordinates research, synthesizes findings |
+| lead-analyst | claude-opus-4-7 | Coordinates research, synthesizes findings |
 | market-researcher | claude-sonnet-4-6 | Competitive analysis, market sizing |
 | tech-researcher | claude-sonnet-4-6 | Technical feasibility |
 | user-researcher | claude-sonnet-4-6 | Personas, pain points |

--- a/examples/018-mob-research-team-rs/main.rs
+++ b/examples/018-mob-research-team-rs/main.rs
@@ -16,7 +16,7 @@
 //!
 //! ## Run
 //! ```bash
-//! ANTHROPIC_API_KEY=... cargo run --example 018-mob-research-team --features comms
+//! ANTHROPIC_API_KEY=... ./scripts/repo-cargo run -p meerkat-mob --example 018-mob-research-team
 //! ```
 
 use std::sync::Arc;

--- a/examples/018-mob-research-team-rs/main.rs
+++ b/examples/018-mob-research-team-rs/main.rs
@@ -33,7 +33,7 @@ id = "research_team"
 orchestrator = "lead"
 
 [profiles.lead]
-model = "claude-opus-4-6"
+model = "claude-opus-4-7"
 skills = ["orchestrator"]
 peer_description = "Orchestrator"
 external_addressable = true
@@ -124,7 +124,7 @@ id = "market-research"
 orchestrator = "lead-analyst"
 
 [profiles.lead-analyst]
-model = "claude-opus-4-6"
+model = "claude-opus-4-7"
 skills = ["research-lead"]
 peer_description = "Lead analyst -- defines research questions, synthesizes findings"
 external_addressable = true

--- a/examples/019-mob-pipeline-rs/README.md
+++ b/examples/019-mob-pipeline-rs/README.md
@@ -20,5 +20,7 @@ Lint → Test → Security → Deploy
 
 ## Run
 ```bash
-# This is a reference implementation. For runnable examples, see meerkat/examples/.
+# From the repository root
+ANTHROPIC_API_KEY=sk-... ./scripts/repo-cargo run -p meerkat-mob \
+  --example 019-mob-pipeline
 ```

--- a/examples/019-mob-pipeline-rs/main.rs
+++ b/examples/019-mob-pipeline-rs/main.rs
@@ -15,7 +15,7 @@
 //!
 //! ## Run
 //! ```bash
-//! ANTHROPIC_API_KEY=... cargo run --example 019-mob-pipeline --features comms
+//! ANTHROPIC_API_KEY=... ./scripts/repo-cargo run -p meerkat-mob --example 019-mob-pipeline
 //! ```
 
 use std::sync::Arc;

--- a/examples/019-mob-pipeline-rs/main.rs
+++ b/examples/019-mob-pipeline-rs/main.rs
@@ -32,7 +32,7 @@ id = "pipeline"
 orchestrator = "lead"
 
 [profiles.lead]
-model = "claude-opus-4-6"
+model = "claude-opus-4-7"
 skills = ["orchestrator"]
 peer_description = "Orchestrator"
 external_addressable = true
@@ -150,7 +150,7 @@ id = "cicd-pipeline"
 orchestrator = "coordinator"
 
 [profiles.coordinator]
-model = "claude-opus-4-6"
+model = "claude-opus-4-7"
 skills = ["pipeline-coordinator"]
 peer_description = "Pipeline coordinator -- drives sequential stage execution"
 external_addressable = true

--- a/examples/020-comms-peer-messaging-rs/README.md
+++ b/examples/020-comms-peer-messaging-rs/README.md
@@ -21,5 +21,7 @@ Agent A signs message with private key A
 
 ## Run
 ```bash
-# This is a reference implementation. For runnable examples, see meerkat/examples/.
+# From the repository root
+ANTHROPIC_API_KEY=sk-... ./scripts/repo-cargo run -p meerkat \
+  --example 020-comms-peer-messaging --features jsonl-store,comms
 ```

--- a/examples/020-comms-peer-messaging-rs/main.rs
+++ b/examples/020-comms-peer-messaging-rs/main.rs
@@ -13,7 +13,7 @@
 //!
 //! ## Run
 //! ```bash
-//! ANTHROPIC_API_KEY=... cargo run --example 020-comms-peer-messaging --features "jsonl-store,comms"
+//! ANTHROPIC_API_KEY=... ./scripts/repo-cargo run -p meerkat --example 020-comms-peer-messaging --features jsonl-store,comms
 //! ```
 
 use std::sync::Arc;

--- a/examples/021-multi-provider-routing-py/README.md
+++ b/examples/021-multi-provider-routing-py/README.md
@@ -12,14 +12,16 @@ and Gemini responses. Use provider-specific parameters.
 ## Supported Providers
 | Provider | Models | Env Var |
 |----------|--------|---------|
-| Anthropic | `claude-opus-4-6`, `claude-sonnet-4-6` | `ANTHROPIC_API_KEY` |
-| OpenAI | `gpt-5.2` | `OPENAI_API_KEY` |
-| Gemini | `gemini-3-flash-preview`, `gemini-3-pro-preview` | `GEMINI_API_KEY` |
+| Anthropic | `claude-opus-4-7`, `claude-sonnet-4-6` | `ANTHROPIC_API_KEY` |
+| OpenAI | `gpt-5.5` | `OPENAI_API_KEY` |
+| Gemini | `gemini-3-flash-preview`, `gemini-3.1-pro-preview` | `GEMINI_API_KEY` |
 
 ## Run
 ```bash
 # From the repository root, first build/install the local Python SDK runtime:
-# python3 -m pip install -e sdks/python
+# python3 -m venv .venv && . .venv/bin/activate
+# python -m pip install --upgrade pip
+# python -m pip install -e sdks/python
 # ./scripts/repo-cargo build -p meerkat-rpc --bin rkat-rpc
 # export MEERKAT_BIN_PATH="$(./scripts/repo-cargo --print-env | sed -n 's/^CARGO_TARGET_DIR=//p')/debug/rkat-rpc"
 ANTHROPIC_API_KEY=sk-... OPENAI_API_KEY=sk-... python3 main.py

--- a/examples/021-multi-provider-routing-py/README.md
+++ b/examples/021-multi-provider-routing-py/README.md
@@ -18,5 +18,9 @@ and Gemini responses. Use provider-specific parameters.
 
 ## Run
 ```bash
-ANTHROPIC_API_KEY=sk-... OPENAI_API_KEY=sk-... python main.py
+# From the repository root, first build/install the local Python SDK runtime:
+# python3 -m pip install -e sdks/python
+# ./scripts/repo-cargo build -p meerkat-rpc --bin rkat-rpc
+# export MEERKAT_BIN_PATH="$(./scripts/repo-cargo --print-env | sed -n 's/^CARGO_TARGET_DIR=//p')/debug/rkat-rpc"
+ANTHROPIC_API_KEY=sk-... OPENAI_API_KEY=sk-... python3 main.py
 ```

--- a/examples/021-multi-provider-routing-py/main.py
+++ b/examples/021-multi-provider-routing-py/main.py
@@ -54,7 +54,7 @@ async def main():
         if os.environ.get("ANTHROPIC_API_KEY"):
             models.append("claude-sonnet-4-6")
         if os.environ.get("OPENAI_API_KEY"):
-            models.append("gpt-5.2")
+            models.append("gpt-5.5")
         if os.environ.get("GEMINI_API_KEY"):
             models.append("gemini-3-flash-preview")
 
@@ -84,9 +84,7 @@ async def main():
                 prompt="What is the optimal data structure for a LRU cache? Think step by step.",
                 model="claude-sonnet-4-6",
                 provider_params={
-                    "anthropic": {
-                        "thinking": {"budget_tokens": 5000}
-                    }
+                    "thinking": {"budget_tokens": 5000}
                 },
             )
             print(f"  Response: {session.text[:200]}...")
@@ -97,11 +95,9 @@ async def main():
             print("--- OpenAI with reasoning effort ---")
             session = await client.create_session(
                 prompt="What is the optimal data structure for a LRU cache?",
-                model="gpt-5.2",
+                model="gpt-5.5",
                 provider_params={
-                    "openai": {
-                        "reasoning_effort": "high"
-                    }
+                    "reasoning_effort": "high"
                 },
             )
             print(f"  Response: {session.text[:200]}...")
@@ -115,11 +111,11 @@ Model selection strategies:
 
 1. COST OPTIMIZATION
    - Simple tasks → claude-sonnet-4-6 or gemini-3-flash-preview
-   - Complex tasks → claude-opus-4-6 or gpt-5.2
+   - Complex tasks → claude-opus-4-7 or gpt-5.5
 
 2. CAPABILITY-BASED
    - Code generation → claude-sonnet-4-6 (strong at code)
-   - Reasoning → claude-opus-4-6 with thinking, or gpt-5.2 high effort
+   - Reasoning → claude-opus-4-7 with thinking, or gpt-5.5 high effort
    - Speed → gemini-3-flash-preview
 
 3. FALLBACK CHAIN
@@ -128,7 +124,7 @@ Model selection strategies:
    - Meerkat's retry policy handles transient failures
 
 4. PER-AGENT ROUTING (in mobs)
-   - Orchestrator: claude-opus-4-6 (complex planning)
+   - Orchestrator: claude-opus-4-7 (complex planning)
    - Workers: claude-sonnet-4-6 (execution)
    - Validators: gemini-3-flash-preview (fast checks)
 """)

--- a/examples/021-multi-provider-routing-py/main.py
+++ b/examples/021-multi-provider-routing-py/main.py
@@ -11,7 +11,7 @@ What you'll learn:
 - Model selection strategies
 
 Run:
-    ANTHROPIC_API_KEY=sk-... OPENAI_API_KEY=sk-... python main.py
+    ANTHROPIC_API_KEY=sk-... OPENAI_API_KEY=sk-... python3 main.py
 """
 
 import asyncio

--- a/examples/022-rest-api-client-py/README.md
+++ b/examples/022-rest-api-client-py/README.md
@@ -23,9 +23,13 @@ language or tool that speaks HTTP can integrate.
 
 ## Setup
 ```bash
+# From the repository root, build the REST server first:
+./scripts/repo-cargo build -p meerkat-rest --bin rkat-rest
+export RKAT_REST="$(./scripts/repo-cargo --print-env | sed -n 's/^CARGO_TARGET_DIR=//p')/debug/rkat-rest"
+
 # Terminal 1: Start REST server (default port 8080, configured in [rest] section)
-ANTHROPIC_API_KEY=sk-... rkat-rest
+ANTHROPIC_API_KEY=sk-... "$RKAT_REST"
 
 # Terminal 2: Run the example
-python main.py
+python3 main.py
 ```

--- a/examples/022-rest-api-client-py/main.py
+++ b/examples/022-rest-api-client-py/main.py
@@ -16,7 +16,7 @@ Run:
     ANTHROPIC_API_KEY=sk-... rkat-rest
 
     # Terminal 2: Run this script
-    python main.py
+    python3 main.py
 """
 
 import json

--- a/examples/023-rpc-ide-integration-ts/README.md
+++ b/examples/023-rpc-ide-integration-ts/README.md
@@ -20,5 +20,10 @@ stay alive between turns for instant multi-turn conversations.
 
 ## Run
 ```bash
+# From the repository root, first build the local TypeScript SDK and RPC binary:
+# npm --prefix sdks/typescript install && npm --prefix sdks/typescript run build
+# (cd examples && npm install)
+# ./scripts/repo-cargo build -p meerkat-rpc --bin rkat-rpc
+# export MEERKAT_BIN_PATH="$(./scripts/repo-cargo --print-env | sed -n 's/^CARGO_TARGET_DIR=//p')/debug/rkat-rpc"
 ANTHROPIC_API_KEY=sk-... npx tsx main.ts
 ```

--- a/examples/024-host-mode-event-mesh-rs/README.md
+++ b/examples/024-host-mode-event-mesh-rs/README.md
@@ -36,5 +36,7 @@ that long-lived sessions enable.
 
 ## Run
 ```bash
-ANTHROPIC_API_KEY=... cargo run -p meerkat --example 024-host-mode-event-mesh
+# From the repository root
+ANTHROPIC_API_KEY=sk-... ./scripts/repo-cargo run -p meerkat \
+  --example 024-host-mode-event-mesh --features jsonl-store
 ```

--- a/examples/024-host-mode-event-mesh-rs/main.rs
+++ b/examples/024-host-mode-event-mesh-rs/main.rs
@@ -23,7 +23,7 @@
 //!
 //! ## Run
 //! ```bash
-//! ANTHROPIC_API_KEY=... cargo run --example 024-host-mode-event-mesh
+//! ANTHROPIC_API_KEY=... ./scripts/repo-cargo run -p meerkat --example 024-host-mode-event-mesh --features jsonl-store
 //! ```
 
 use std::sync::Arc;

--- a/examples/025-full-stack-agent-rs/README.md
+++ b/examples/025-full-stack-agent-rs/README.md
@@ -39,5 +39,7 @@ persistence, event streaming, and composable dispatchers.
 
 ## Run
 ```bash
-# This is a reference implementation. For runnable examples, see meerkat/examples/.
+# From the repository root
+ANTHROPIC_API_KEY=sk-... ./scripts/repo-cargo run -p meerkat \
+  --example 025-full-stack-agent --features jsonl-store
 ```

--- a/examples/026-skills-v21-invoke-py/README.md
+++ b/examples/026-skills-v21-invoke-py/README.md
@@ -8,18 +8,24 @@ Invoke a skill using canonical typed refs (`SkillKey`) with
 - Canonical `SkillKey` refs (recommended)
 - Runtime capability check via `client.require_capability("skills")`
 
-## Required Environment
+## Optional Environment
 ```bash
 export ANTHROPIC_API_KEY=sk-...
-export MEERKAT_SKILL_SOURCE_UUID=dc256086-0d2f-4f61-a307-320d4148107f
-export MEERKAT_SKILL_NAME=shell-patterns
+# Optional: override the default local example skill identity.
+# export MEERKAT_SKILL_SOURCE_UUID=dc256086-0d2f-4f61-a307-320d4148107f
+# export MEERKAT_SKILL_NAME=shell-patterns
 ```
 
 ## Run
 ```bash
 # From the repository root, first build/install the local Python SDK runtime:
-# python3 -m pip install -e sdks/python
+# python3 -m venv .venv && . .venv/bin/activate
+# python -m pip install --upgrade pip
+# python -m pip install -e sdks/python
 # ./scripts/repo-cargo build -p meerkat-rpc --bin rkat-rpc
 # export MEERKAT_BIN_PATH="$(./scripts/repo-cargo --print-env | sed -n 's/^CARGO_TARGET_DIR=//p')/debug/rkat-rpc"
 python3 main.py
 ```
+
+The example writes a tiny local filesystem-backed skill source under `.work/`
+and starts the RPC runtime with isolated state rooted there.

--- a/examples/026-skills-v21-invoke-py/README.md
+++ b/examples/026-skills-v21-invoke-py/README.md
@@ -17,5 +17,9 @@ export MEERKAT_SKILL_NAME=shell-patterns
 
 ## Run
 ```bash
-python main.py
+# From the repository root, first build/install the local Python SDK runtime:
+# python3 -m pip install -e sdks/python
+# ./scripts/repo-cargo build -p meerkat-rpc --bin rkat-rpc
+# export MEERKAT_BIN_PATH="$(./scripts/repo-cargo --print-env | sed -n 's/^CARGO_TARGET_DIR=//p')/debug/rkat-rpc"
+python3 main.py
 ```

--- a/examples/026-skills-v21-invoke-py/main.py
+++ b/examples/026-skills-v21-invoke-py/main.py
@@ -5,29 +5,76 @@ Invoke a specific skill using canonical refs (`SkillKey`) from the rebuilt
 skill system.
 
 Run:
-    ANTHROPIC_API_KEY=sk-... \
-    MEERKAT_SKILL_SOURCE_UUID=dc256086-0d2f-4f61-a307-320d4148107f \
-    MEERKAT_SKILL_NAME=shell-patterns \
-    python3 main.py
+    ANTHROPIC_API_KEY=sk-... python3 main.py
 """
 
 import asyncio
 import os
+from pathlib import Path
 from meerkat import MeerkatClient, SkillKey
+
+DEFAULT_SOURCE_UUID = "dc256086-0d2f-4f61-a307-320d4148107f"
+DEFAULT_SKILL_NAME = "shell-patterns"
+
+SKILL_BODY = """---
+name: shell-patterns
+description: Review shell commands for safety and portability.
+---
+
+# Shell Patterns
+
+Review shell commands before execution. Flag destructive operations, missing
+quoting, non-portable flags, and places where a safer dry-run or explicit path
+would reduce risk.
+
+Respond with:
+- Risk level
+- Specific concern
+- Safer command or mitigation
+"""
+
+
+def prepare_local_skill_source(source_uuid: str, skill_name: str) -> tuple[Path, Path, Path]:
+    root = Path(__file__).resolve().parent
+    work = root / ".work"
+    context_root = work / "project"
+    state_root = work / "state"
+    user_config_root = work / "user"
+    skill_dir = context_root / ".rkat" / "skills" / skill_name
+    skill_dir.mkdir(parents=True, exist_ok=True)
+    state_root.mkdir(parents=True, exist_ok=True)
+    user_config_root.mkdir(parents=True, exist_ok=True)
+    (skill_dir / "SKILL.md").write_text(SKILL_BODY, encoding="utf-8")
+    (context_root / ".rkat" / "skills.toml").write_text(
+        "\n".join(
+            [
+                "enabled = true",
+                "",
+                "[[repositories]]",
+                'name = "example-local"',
+                f'source_uuid = "{source_uuid}"',
+                'type = "filesystem"',
+                'path = ".rkat/skills"',
+                "",
+            ]
+        ),
+        encoding="utf-8",
+    )
+    return context_root, state_root, user_config_root
 
 
 async def main() -> None:
-    source_uuid = os.environ.get("MEERKAT_SKILL_SOURCE_UUID")
-    skill_name = os.environ.get("MEERKAT_SKILL_NAME")
-
-    if not source_uuid or not skill_name:
-        print("Missing required env vars:")
-        print("  MEERKAT_SKILL_SOURCE_UUID=<source uuid>")
-        print("  MEERKAT_SKILL_NAME=<skill name>")
-        return
+    source_uuid = os.environ.get("MEERKAT_SKILL_SOURCE_UUID", DEFAULT_SOURCE_UUID)
+    skill_name = os.environ.get("MEERKAT_SKILL_NAME", DEFAULT_SKILL_NAME)
+    context_root, state_root, user_config_root = prepare_local_skill_source(source_uuid, skill_name)
 
     client = MeerkatClient()
-    await client.connect()
+    await client.connect(
+        isolated=True,
+        context_root=str(context_root),
+        state_root=str(state_root),
+        user_config_root=str(user_config_root),
+    )
 
     try:
         client.require_capability("skills")

--- a/examples/026-skills-v21-invoke-py/main.py
+++ b/examples/026-skills-v21-invoke-py/main.py
@@ -8,7 +8,7 @@ Run:
     ANTHROPIC_API_KEY=sk-... \
     MEERKAT_SKILL_SOURCE_UUID=dc256086-0d2f-4f61-a307-320d4148107f \
     MEERKAT_SKILL_NAME=shell-patterns \
-    python main.py
+    python3 main.py
 """
 
 import asyncio

--- a/examples/027-skills-v21-invoke-ts/README.md
+++ b/examples/027-skills-v21-invoke-ts/README.md
@@ -17,5 +17,10 @@ export MEERKAT_SKILL_NAME=shell-patterns
 
 ## Run
 ```bash
+# From the repository root, first build the local TypeScript SDK and RPC binary:
+# npm --prefix sdks/typescript install && npm --prefix sdks/typescript run build
+# (cd examples && npm install)
+# ./scripts/repo-cargo build -p meerkat-rpc --bin rkat-rpc
+# export MEERKAT_BIN_PATH="$(./scripts/repo-cargo --print-env | sed -n 's/^CARGO_TARGET_DIR=//p')/debug/rkat-rpc"
 npx tsx main.ts
 ```

--- a/examples/027-skills-v21-invoke-ts/README.md
+++ b/examples/027-skills-v21-invoke-ts/README.md
@@ -8,11 +8,12 @@ Invoke a skill using canonical refs with
 - Canonical `SkillKey` refs (recommended)
 - Capability gating via `client.requireCapability("skills")`
 
-## Required Environment
+## Optional Environment
 ```bash
 export ANTHROPIC_API_KEY=sk-...
-export MEERKAT_SKILL_SOURCE_UUID=dc256086-0d2f-4f61-a307-320d4148107f
-export MEERKAT_SKILL_NAME=shell-patterns
+# Optional: override the default local example skill identity.
+# export MEERKAT_SKILL_SOURCE_UUID=dc256086-0d2f-4f61-a307-320d4148107f
+# export MEERKAT_SKILL_NAME=shell-patterns
 ```
 
 ## Run
@@ -24,3 +25,6 @@ export MEERKAT_SKILL_NAME=shell-patterns
 # export MEERKAT_BIN_PATH="$(./scripts/repo-cargo --print-env | sed -n 's/^CARGO_TARGET_DIR=//p')/debug/rkat-rpc"
 npx tsx main.ts
 ```
+
+The example writes a tiny local filesystem-backed skill source under `.work/`
+and starts the RPC runtime with isolated state rooted there.

--- a/examples/027-skills-v21-invoke-ts/main.ts
+++ b/examples/027-skills-v21-invoke-ts/main.ts
@@ -5,28 +5,70 @@
  * skill system.
  *
  * Run:
- *   ANTHROPIC_API_KEY=sk-... \
- *   MEERKAT_SKILL_SOURCE_UUID=dc256086-0d2f-4f61-a307-320d4148107f \
- *   MEERKAT_SKILL_NAME=shell-patterns \
- *   npx tsx main.ts
+ *   ANTHROPIC_API_KEY=sk-... npx tsx main.ts
  */
 
 import { MeerkatClient } from "@rkat/sdk";
 import type { SkillKey } from "@rkat/sdk";
+import { mkdirSync, writeFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const DEFAULT_SOURCE_UUID = "dc256086-0d2f-4f61-a307-320d4148107f";
+const DEFAULT_SKILL_NAME = "shell-patterns";
+
+const SKILL_BODY = `---
+name: shell-patterns
+description: Review shell commands for safety and portability.
+---
+
+# Shell Patterns
+
+Review shell commands before execution. Flag destructive operations, missing
+quoting, non-portable flags, and places where a safer dry-run or explicit path
+would reduce risk.
+
+Respond with:
+- Risk level
+- Specific concern
+- Safer command or mitigation
+`;
+
+function prepareLocalSkillSource(sourceUuid: string, skillName: string) {
+  const root = dirname(fileURLToPath(import.meta.url));
+  const work = join(root, ".work");
+  const contextRoot = join(work, "project");
+  const stateRoot = join(work, "state");
+  const userConfigRoot = join(work, "user");
+  const skillDir = join(contextRoot, ".rkat", "skills", skillName);
+  mkdirSync(skillDir, { recursive: true });
+  mkdirSync(stateRoot, { recursive: true });
+  mkdirSync(userConfigRoot, { recursive: true });
+  writeFileSync(join(skillDir, "SKILL.md"), SKILL_BODY, "utf8");
+  writeFileSync(
+    join(contextRoot, ".rkat", "skills.toml"),
+    [
+      "enabled = true",
+      "",
+      "[[repositories]]",
+      'name = "example-local"',
+      `source_uuid = "${sourceUuid}"`,
+      'type = "filesystem"',
+      'path = ".rkat/skills"',
+      "",
+    ].join("\n"),
+    "utf8",
+  );
+  return { contextRoot, stateRoot, userConfigRoot };
+}
 
 async function main() {
-  const sourceUuid = process.env.MEERKAT_SKILL_SOURCE_UUID;
-  const skillName = process.env.MEERKAT_SKILL_NAME;
-
-  if (!sourceUuid || !skillName) {
-    console.error("Missing required env vars:");
-    console.error("  MEERKAT_SKILL_SOURCE_UUID=<source uuid>");
-    console.error("  MEERKAT_SKILL_NAME=<skill name>");
-    process.exit(1);
-  }
+  const sourceUuid = process.env.MEERKAT_SKILL_SOURCE_UUID ?? DEFAULT_SOURCE_UUID;
+  const skillName = process.env.MEERKAT_SKILL_NAME ?? DEFAULT_SKILL_NAME;
+  const roots = prepareLocalSkillSource(sourceUuid, skillName);
 
   const client = new MeerkatClient();
-  await client.connect();
+  await client.connect({ isolated: true, ...roots });
 
   try {
     client.requireCapability("skills");

--- a/examples/028-mobpack-release-triage-sh/README.md
+++ b/examples/028-mobpack-release-triage-sh/README.md
@@ -50,10 +50,10 @@ with:
 
 ```bash
 export ANTHROPIC_API_KEY=sk-...
-cargo install rkat
+./scripts/repo-cargo build -p rkat --bin rkat
 
-# Optional when working from this repo instead of a global install:
-export RKAT=../../target/debug/rkat
+# Optional override if you want to use a specific binary:
+export RKAT=/path/to/rkat
 ```
 
 ## Run

--- a/examples/028-mobpack-release-triage-sh/README.md
+++ b/examples/028-mobpack-release-triage-sh/README.md
@@ -40,7 +40,7 @@ with:
 ## Concepts
 
 - `rkat mob pack` for artifact creation from generated mob source
-- `--sign` to attach provenance to the packed artifact
+- `--sign` / `--signer-id` to attach provenance to the packed artifact
 - `rkat mob inspect` to see what was embedded
 - `rkat mob validate` to check the artifact contract before use
 - `rkat mob deploy` to run the same signed artifact with a real prompt

--- a/examples/028-mobpack-release-triage-sh/examples.sh
+++ b/examples/028-mobpack-release-triage-sh/examples.sh
@@ -6,6 +6,7 @@ WORK="$ROOT/.work"
 MOB_DIR="$WORK/release-triage"
 PACK="$WORK/release-triage.mobpack"
 KEY="$WORK/release.key"
+SIGNER_ID="release-triage-demo"
 WORKSPACE_ROOT="$(cd "$ROOT/../.." && pwd)"
 
 resolve_rkat() {
@@ -55,7 +56,7 @@ capabilities = ["comms"]
 
 [models]
 default = "claude-sonnet-4-6"
-lead = "claude-opus-4-6"
+lead = "claude-opus-4-7"
 TOML
 
 cat > "$MOB_DIR/config/defaults.toml" <<'TOML'
@@ -74,7 +75,7 @@ cat > "$MOB_DIR/definition.json" <<'JSON'
   "orchestrator": { "profile": "lead" },
   "profiles": {
     "lead": {
-      "model": "claude-opus-4-6",
+      "model": "claude-opus-4-7",
       "skills": ["lead-playbook"],
       "peer_description": "Release lead who owns severity, decisions, and executive updates",
       "external_addressable": true,
@@ -238,7 +239,7 @@ printf '0707070707070707070707070707070707070707070707070707070707070707' > "$KE
 
 echo ""
 echo "==> Packing and signing portable artifact"
-"$RKAT" mob pack "$MOB_DIR" -o "$PACK" --sign "$KEY"
+"$RKAT" mob pack "$MOB_DIR" -o "$PACK" --sign "$KEY" --signer-id "$SIGNER_ID"
 
 echo ""
 echo "==> Inspecting artifact contents"

--- a/examples/028-mobpack-release-triage-sh/examples.sh
+++ b/examples/028-mobpack-release-triage-sh/examples.sh
@@ -6,7 +6,40 @@ WORK="$ROOT/.work"
 MOB_DIR="$WORK/release-triage"
 PACK="$WORK/release-triage.mobpack"
 KEY="$WORK/release.key"
-RKAT="${RKAT:-rkat}"
+WORKSPACE_ROOT="$(cd "$ROOT/../.." && pwd)"
+
+resolve_rkat() {
+  if [[ -n "${RKAT:-}" ]]; then
+    printf '%s\n' "$RKAT"
+    return
+  fi
+
+  local candidate
+  for candidate in \
+    "$WORKSPACE_ROOT/target/debug/rkat" \
+    "$WORKSPACE_ROOT/target/release/rkat"
+  do
+    if [[ -x "$candidate" ]]; then
+      printf '%s\n' "$candidate"
+      return
+    fi
+  done
+
+  if [[ -x "$WORKSPACE_ROOT/scripts/repo-cargo" ]]; then
+    local target_dir
+    target_dir="$("$WORKSPACE_ROOT/scripts/repo-cargo" --print-env | sed -n 's/^CARGO_TARGET_DIR=//p')"
+    for candidate in "$target_dir/debug/rkat" "$target_dir/release/rkat"; do
+      if [[ -x "$candidate" ]]; then
+        printf '%s\n' "$candidate"
+        return
+      fi
+    done
+  fi
+
+  printf '%s\n' "rkat"
+}
+
+RKAT="$(resolve_rkat)"
 
 rm -rf "$MOB_DIR"
 mkdir -p "$MOB_DIR/skills" "$MOB_DIR/config" "$WORK"

--- a/examples/029-web-incident-war-room-sh/README.md
+++ b/examples/029-web-incident-war-room-sh/README.md
@@ -38,12 +38,13 @@ or a local SDK.
 ## Prerequisites
 ```bash
 export ANTHROPIC_API_KEY=sk-...
-cargo install rkat wasm-pack
+./scripts/repo-cargo build -p rkat --bin rkat
+wasm-pack --version
 ```
 
 If you are running from this repo checkout instead of a global install, the
-script will automatically prefer `../../target/debug/rkat` or
-`../../target/release/rkat` when present.
+script will automatically prefer repo-local binaries built by
+`./scripts/repo-cargo` when present.
 
 ## Run
 ```bash

--- a/examples/029-web-incident-war-room-sh/examples.sh
+++ b/examples/029-web-incident-war-room-sh/examples.sh
@@ -8,14 +8,40 @@ PROMPTS="$ROOT/prompts"
 MOB_DIR="$WORK/incident-war-room"
 PACK="$WORK/incident-war-room.mobpack"
 WEB_OUT="$WORK/incident-war-room-web"
+WORKSPACE_ROOT="$(cd "$ROOT/../.." && pwd)"
 
-if [[ -x "$ROOT/../../target/debug/rkat" ]]; then
-  RKAT="$ROOT/../../target/debug/rkat"
-elif [[ -x "$ROOT/../../target/release/rkat" ]]; then
-  RKAT="$ROOT/../../target/release/rkat"
-else
-  RKAT="${RKAT:-rkat}"
-fi
+resolve_rkat() {
+  if [[ -n "${RKAT:-}" ]]; then
+    printf '%s\n' "$RKAT"
+    return
+  fi
+
+  local candidate
+  for candidate in \
+    "$WORKSPACE_ROOT/target/debug/rkat" \
+    "$WORKSPACE_ROOT/target/release/rkat"
+  do
+    if [[ -x "$candidate" ]]; then
+      printf '%s\n' "$candidate"
+      return
+    fi
+  done
+
+  if [[ -x "$WORKSPACE_ROOT/scripts/repo-cargo" ]]; then
+    local target_dir
+    target_dir="$("$WORKSPACE_ROOT/scripts/repo-cargo" --print-env | sed -n 's/^CARGO_TARGET_DIR=//p')"
+    for candidate in "$target_dir/debug/rkat" "$target_dir/release/rkat"; do
+      if [[ -x "$candidate" ]]; then
+        printf '%s\n' "$candidate"
+        return
+      fi
+    done
+  fi
+
+  printf '%s\n' "rkat"
+}
+
+RKAT="$(resolve_rkat)"
 
 if [[ "${1:-}" == "--clean" ]]; then
   rm -rf "$WORK"

--- a/examples/030-web-dashboard-copilot-sh/README.md
+++ b/examples/030-web-dashboard-copilot-sh/README.md
@@ -38,11 +38,13 @@ clear operator recommendation.
 
 ```bash
 export ANTHROPIC_API_KEY=sk-...
-cargo install rkat wasm-pack
+./scripts/repo-cargo build -p rkat --bin rkat
+wasm-pack --version
 ```
 
 If you are working from this repo checkout instead of a global install, the
-script will prefer `../../target/debug/rkat` automatically when it exists.
+script will prefer repo-local binaries built by `./scripts/repo-cargo` when
+present.
 
 ## Run
 

--- a/examples/030-web-dashboard-copilot-sh/examples.sh
+++ b/examples/030-web-dashboard-copilot-sh/examples.sh
@@ -11,13 +11,42 @@ EMBED_SNIPPET="$WORK/embed-snippet.html"
 QUESTIONS="$WORK/example-questions.md"
 WORKSPACE_ROOT="$(cd "$ROOT/../.." && pwd)"
 
-if [[ -x "$WORKSPACE_ROOT/target/debug/rkat" ]]; then
-  RKAT_BIN="$WORKSPACE_ROOT/target/debug/rkat"
-elif [[ -x "$WORKSPACE_ROOT/target/release/rkat" ]]; then
-  RKAT_BIN="$WORKSPACE_ROOT/target/release/rkat"
-else
-  RKAT_BIN="${RKAT_BIN:-rkat}"
-fi
+resolve_rkat() {
+  if [[ -n "${RKAT_BIN:-}" ]]; then
+    printf '%s\n' "$RKAT_BIN"
+    return
+  fi
+  if [[ -n "${RKAT:-}" ]]; then
+    printf '%s\n' "$RKAT"
+    return
+  fi
+
+  local candidate
+  for candidate in \
+    "$WORKSPACE_ROOT/target/debug/rkat" \
+    "$WORKSPACE_ROOT/target/release/rkat"
+  do
+    if [[ -x "$candidate" ]]; then
+      printf '%s\n' "$candidate"
+      return
+    fi
+  done
+
+  if [[ -x "$WORKSPACE_ROOT/scripts/repo-cargo" ]]; then
+    local target_dir
+    target_dir="$("$WORKSPACE_ROOT/scripts/repo-cargo" --print-env | sed -n 's/^CARGO_TARGET_DIR=//p')"
+    for candidate in "$target_dir/debug/rkat" "$target_dir/release/rkat"; do
+      if [[ -x "$candidate" ]]; then
+        printf '%s\n' "$candidate"
+        return
+      fi
+    done
+  fi
+
+  printf '%s\n' "rkat"
+}
+
+RKAT_BIN="$(resolve_rkat)"
 
 mkdir -p "$MOB_DIR/skills" "$WORK"
 
@@ -29,7 +58,7 @@ description = "Embeddable release command center copilot for production dashboar
 authors = ["Meerkat examples"]
 
 [requires]
-meerkat = ">=0.4.13"
+meerkat = ">=0.6.0"
 credentials = ["anthropic_api_key"]
 capabilities = ["comms"]
 

--- a/examples/031-wasm-mini-diplomacy-sh/README.md
+++ b/examples/031-wasm-mini-diplomacy-sh/README.md
@@ -62,14 +62,14 @@ JS detects quiescence → extracts orders → resolves combat → narrator flow
 ## Prerequisites
 
 ```bash
-cargo build -p meerkat-cli       # builds rkat for repo-local runs
-cargo install wasm-pack          # if not already installed
-node --version                   # 20+
+./scripts/repo-cargo build -p rkat --bin rkat  # builds rkat for repo-local runs
+wasm-pack --version                            # install if not already available
+node --version                                 # 20+
 npm --version
 ```
 
-`./examples.sh` will automatically prefer the repo-local `../../target/debug/rkat`
-or `../../target/release/rkat` when present.
+`./examples.sh` will automatically prefer repo-local binaries built by
+`./scripts/repo-cargo` when present.
 
 ## Build & Run
 
@@ -93,12 +93,12 @@ open http://127.0.0.1:4173
 ### Rebuild after Rust changes
 
 ```bash
-cargo build -p meerkat-cli
+./scripts/repo-cargo build -p rkat --bin rkat
 cd examples/031-wasm-mini-diplomacy-sh
 ./examples.sh
 ```
 
-That path stays aligned with the current 0.5 browser packaging flow because it
+That path stays aligned with the current browser packaging flow because it
 rebuilds the runtime through `rkat mob web build` instead of teaching a separate
 direct `wasm-pack` recipe.
 

--- a/examples/031-wasm-mini-diplomacy-sh/examples.sh
+++ b/examples/031-wasm-mini-diplomacy-sh/examples.sh
@@ -10,13 +10,42 @@ WEB_DIR="$ROOT/web"
 WEB_DIST="$WEB_DIR/dist"
 WORKSPACE_ROOT="$(cd "$ROOT/../.." && pwd)"
 
-if [[ -x "$WORKSPACE_ROOT/target/debug/rkat" ]]; then
-  RKAT_BIN="$WORKSPACE_ROOT/target/debug/rkat"
-elif [[ -x "$WORKSPACE_ROOT/target/release/rkat" ]]; then
-  RKAT_BIN="$WORKSPACE_ROOT/target/release/rkat"
-else
-  RKAT_BIN="${RKAT_BIN:-rkat}"
-fi
+resolve_rkat() {
+  if [[ -n "${RKAT_BIN:-}" ]]; then
+    printf '%s\n' "$RKAT_BIN"
+    return
+  fi
+  if [[ -n "${RKAT:-}" ]]; then
+    printf '%s\n' "$RKAT"
+    return
+  fi
+
+  local candidate
+  for candidate in \
+    "$WORKSPACE_ROOT/target/debug/rkat" \
+    "$WORKSPACE_ROOT/target/release/rkat"
+  do
+    if [[ -x "$candidate" ]]; then
+      printf '%s\n' "$candidate"
+      return
+    fi
+  done
+
+  if [[ -x "$WORKSPACE_ROOT/scripts/repo-cargo" ]]; then
+    local target_dir
+    target_dir="$("$WORKSPACE_ROOT/scripts/repo-cargo" --print-env | sed -n 's/^CARGO_TARGET_DIR=//p')"
+    for candidate in "$target_dir/debug/rkat" "$target_dir/release/rkat"; do
+      if [[ -x "$candidate" ]]; then
+        printf '%s\n' "$candidate"
+        return
+      fi
+    done
+  fi
+
+  printf '%s\n' "rkat"
+}
+
+RKAT_BIN="$(resolve_rkat)"
 
 mkdir -p "$WORK" "$MOB_RUNTIME"
 

--- a/examples/031-wasm-mini-diplomacy-sh/web/src/config.ts
+++ b/examples/031-wasm-mini-diplomacy-sh/web/src/config.ts
@@ -6,10 +6,10 @@ export type Provider = "anthropic" | "openai" | "gemini";
 
 export const MODEL_PROVIDER: Record<string, Provider> = {
   "claude-sonnet-4-6": "anthropic",
-  "claude-opus-4-6": "anthropic",
-  "gpt-5.2": "openai",
+  "claude-opus-4-7": "anthropic",
+  "gpt-5.5": "openai",
   "gemini-3-flash-preview": "gemini",
-  "gemini-3-pro-preview": "gemini",
+  "gemini-3.1-pro-preview": "gemini",
 };
 
 export const ALL_MODELS = Object.keys(MODEL_PROVIDER);

--- a/examples/032-wasm-webcm-agent/README.md
+++ b/examples/032-wasm-webcm-agent/README.md
@@ -39,8 +39,8 @@ Use `./examples.sh --clean` to force a fresh download/rebuild.
 ```
 Browser Tab
 ├── Meerkat Mob (4 agents, comms-wired)
-│   ├── Alpha Meerkat (orchestrator) → claude-opus-4-6
-│   ├── Planner → gpt-5.2
+│   ├── Alpha Meerkat (orchestrator) → claude-opus-4-7
+│   ├── Planner → gpt-5.5
 │   ├── Coder → gpt-5.3-codex
 │   └── Reviewer → gemini-3-flash-preview
 ├── meerkat-web-runtime (Rust WASM)

--- a/examples/032-wasm-webcm-agent/examples.sh
+++ b/examples/032-wasm-webcm-agent/examples.sh
@@ -46,6 +46,11 @@ echo "Building and syncing current meerkat-web-runtime for wasm32..."
 REPO_ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
 SDK_WASM_DIR="${REPO_ROOT}/sdks/web/wasm"
 
+if [[ -x "${REPO_ROOT}/scripts/repo-cargo" ]]; then
+  REPO_CARGO_HOME="$("${REPO_ROOT}/scripts/repo-cargo" --print-env | sed -n 's/^CARGO_HOME=//p')"
+  export PATH="${REPO_CARGO_HOME}/bin:${PATH}"
+fi
+
 # Build via sdks/web's build:wasm script (handles --out-dir and .gitignore cleanup)
 if [[ -f "${REPO_ROOT}/sdks/web/package.json" ]]; then
   (cd "${REPO_ROOT}/sdks/web" && npm run build:wasm)

--- a/examples/032-wasm-webcm-agent/web/src/mob.ts
+++ b/examples/032-wasm-webcm-agent/web/src/mob.ts
@@ -45,7 +45,7 @@ export interface MobRuntime {
 
 /**
  * Resolve model assignments based on available API keys.
- * Preferred: main=opus, planner=gpt-5.2, coder=gpt-5.3-codex, reviewer=gemini-3.1-pro-preview.
+ * Preferred: main=opus, planner=gpt-5.5, coder=gpt-5.3-codex, reviewer=gemini-3.1-pro-preview.
  * Falls back to available providers when keys are missing.
  */
 export function resolveModels(keys: ApiKeys): ModelAssignments {
@@ -56,12 +56,12 @@ export function resolveModels(keys: ApiKeys): ModelAssignments {
   // Main agent: prefer Anthropic Opus
   let main: string;
   let mainKey: string;
-  if (hasAnthropic) { main = "claude-opus-4-6"; mainKey = keys.anthropic!; }
-  else if (hasOpenAI) { main = "gpt-5.2"; mainKey = keys.openai!; }
+  if (hasAnthropic) { main = "claude-opus-4-7"; mainKey = keys.anthropic!; }
+  else if (hasOpenAI) { main = "gpt-5.5"; mainKey = keys.openai!; }
   else { main = "gemini-3.1-pro-preview"; mainKey = keys.gemini!; }
 
-  // Planner: prefer OpenAI gpt-5.2
-  const planner = hasOpenAI ? "gpt-5.2"
+  // Planner: prefer OpenAI GPT-5.5
+  const planner = hasOpenAI ? "gpt-5.5"
     : hasAnthropic ? "claude-sonnet-4-6"
     : "gemini-3.1-pro-preview";
 
@@ -73,7 +73,7 @@ export function resolveModels(keys: ApiKeys): ModelAssignments {
   // Reviewer: prefer Gemini (schema issues fixed in PR #93)
   const reviewer = hasGemini ? "gemini-3-flash-preview"
     : hasAnthropic ? "claude-sonnet-4-6"
-    : "gpt-5.2";
+    : "gpt-5.5";
 
   return { main, mainKey, planner, coder, reviewer };
 }

--- a/examples/033-the-office-demo-sh/README.md
+++ b/examples/033-the-office-demo-sh/README.md
@@ -53,12 +53,13 @@ open http://127.0.0.1:4174
 
 ### Dev mode (with WASM runtime):
 ```bash
+(cd ../../sdks/web && npm install && npm run build:wasm)
 cd web && npm install && npm run dev
 ```
 
-`npm run dev`/`npm run build` auto-sync the paired WASM runtime bundle from the
-repo-local `sdks/web` package (falling back to the installed `@rkat/web`
-package only if needed) into `web/public/meerkat-pkg`.
+`npm run dev`/`npm run build` sync an existing WASM runtime bundle from the
+repo-local `sdks/web` package, or from an installed `@rkat/web` package, into
+`web/public/meerkat-pkg`. Use `examples.sh` for the full rebuild path.
 
 ## Usage
 

--- a/examples/033-the-office-demo-sh/examples.sh
+++ b/examples/033-the-office-demo-sh/examples.sh
@@ -6,6 +6,11 @@ WEB_DIR="$ROOT/web"
 WEB_DIST="$WEB_DIR/dist"
 REPO_ROOT="$(cd "$ROOT/../.." && pwd)"
 
+if [[ -x "$REPO_ROOT/scripts/repo-cargo" ]]; then
+  REPO_CARGO_HOME="$("$REPO_ROOT/scripts/repo-cargo" --print-env | sed -n 's/^CARGO_HOME=//p')"
+  export PATH="$REPO_CARGO_HOME/bin:$PATH"
+fi
+
 if [[ "${1:-}" == "--clean" ]]; then
   echo "Cleaning generated web artifacts..."
   rm -rf "$WEB_DIR/public/meerkat-pkg" "$WEB_DIST"

--- a/examples/033-the-office-demo-sh/web/package-lock.json
+++ b/examples/033-the-office-demo-sh/web/package-lock.json
@@ -18,7 +18,7 @@
     },
     "../../../sdks/web": {
       "name": "@rkat/web",
-      "version": "0.4.13",
+      "version": "0.6.0",
       "dev": true,
       "license": "MIT OR Apache-2.0",
       "bin": {

--- a/examples/033-the-office-demo-sh/web/src/config.ts
+++ b/examples/033-the-office-demo-sh/web/src/config.ts
@@ -6,7 +6,6 @@ export type Provider = "anthropic" | "openai" | "gemini";
 
 export const MODEL_PROVIDER: Record<string, Provider> = {
   "claude-sonnet-4-6": "anthropic",
-  "claude-sonnet-4-6": "anthropic",
   "claude-opus-4-6": "anthropic",
   "gpt-5.2": "openai",
   "gemini-3-flash-preview": "gemini",

--- a/examples/033-the-office-demo-sh/web/src/config.ts
+++ b/examples/033-the-office-demo-sh/web/src/config.ts
@@ -6,8 +6,8 @@ export type Provider = "anthropic" | "openai" | "gemini";
 
 export const MODEL_PROVIDER: Record<string, Provider> = {
   "claude-sonnet-4-6": "anthropic",
-  "claude-opus-4-6": "anthropic",
-  "gpt-5.2": "openai",
+  "claude-opus-4-7": "anthropic",
+  "gpt-5.5": "openai",
   "gemini-3-flash-preview": "gemini",
   "gemini-3.1-pro-preview": "gemini",
 };

--- a/examples/034-codemob-mcp/README.md
+++ b/examples/034-codemob-mcp/README.md
@@ -108,13 +108,13 @@ CRUD for user-created mob definitions. Saved to `.codemob-mcp/mobs/` and immedia
 
 | Pack | Agents | Pattern | Default Models |
 |------|--------|---------|---------------|
-| **advisor** | 1 | Single opinion | GPT-5.4 |
-| **review** | 4 | 3 parallel reviewers → synthesis | Gemini 3.1 Pro, GPT-5.4, Gemini 3.1 Flash Lite, Opus |
-| **architect** | 3 | Plan → critique → revise → ADR | Opus, GPT-5.4, Gemini 3.1 Pro |
-| **brainstorm** | 4 | 3 diverse ideators → ranked synthesis | Gemini 3.1 Pro, GPT-5.4, Gemini 3.1 Flash Lite, Opus |
-| **red-team** | 3 | Advocate + adversary → judge | Gemini 3.1 Flash Lite, GPT-5.4, Opus |
-| **rct** | 6 | Plan → implement → 3 parallel gate reviews → aggregate | Opus, GPT-5.4, Gemini 3.1 Pro, GPT-5.2, Gemini 3.1 Flash Lite, Sonnet |
-| **implement** | 2 | Implementer ↔ reviewer loop (max 3 rounds) | Sonnet, GPT-5.4 |
+| **advisor** | 1 | Single opinion | GPT-5.5 |
+| **review** | 4 | 3 parallel reviewers → synthesis | Gemini 3.1 Pro, GPT-5.5, Gemini 3.1 Flash Lite, Opus |
+| **architect** | 3 | Plan → critique → revise → ADR | Opus, GPT-5.5, Gemini 3.1 Pro |
+| **brainstorm** | 4 | 3 diverse ideators → ranked synthesis | Gemini 3.1 Pro, GPT-5.5, Gemini 3.1 Flash Lite, Opus |
+| **red-team** | 3 | Advocate + adversary → judge | Gemini 3.1 Flash Lite, GPT-5.5, Opus |
+| **rct** | 6 | Plan → implement → 3 parallel gate reviews → aggregate | Opus, GPT-5.5, Gemini 3.1 Pro, GPT-5.5 Pro, Gemini 3.1 Flash Lite, Sonnet |
+| **implement** | 2 | Implementer ↔ reviewer loop (max 3 rounds) | Sonnet, GPT-5.5 |
 
 ### Comms-based (autonomous debate)
 
@@ -133,7 +133,7 @@ Every agent in every pack uses a distinct model by default — different trainin
 | `gemini-3.1-pro-preview` | Google | Strong general | General reviewer, purist, guardian |
 | `gemini-3.1-flash-lite-preview` | Google | Fastest | Advocate, skeptic, perf reviewer, contrarian |
 | `claude-sonnet-4-6` | Anthropic | Fast + capable | RCT aggregator, implementer |
-| `gpt-5.2-pro` | OpenAI | Deepest reasoning | Available for override (slow — use sparingly) |
+| `gpt-5.5-pro` | OpenAI | Deepest reasoning | Available for override (slow — use sparingly) |
 
 ## Skills
 
@@ -168,7 +168,7 @@ Override the default model for any role in a pack:
 deliberate(
   pack: "review",
   task: "...",
-  model_overrides: {"security": "claude-opus-4-7", "perf": "gpt-5.2-pro"}
+  model_overrides: {"security": "claude-opus-4-7", "perf": "gpt-5.5-pro"}
 )
 ```
 
@@ -187,7 +187,7 @@ deliberate(
 
 consult(
   question: "...",
-  model: "gpt-5.2-pro",
+  model: "gpt-5.5-pro",
   provider_params: {"reasoning_effort": "high"}
 )
 ```

--- a/examples/034-codemob-mcp/README.md
+++ b/examples/034-codemob-mcp/README.md
@@ -11,15 +11,14 @@ standalone runtime mode explicitly.
 ## Quick Start
 
 ```bash
-# Build
-cd examples/034-codemob-mcp
-cargo build --release
+# Build from the repository root
+./scripts/repo-cargo build --manifest-path examples/034-codemob-mcp/Cargo.toml --release
 
 # Register in Claude Code (.mcp.json in your project root)
 {
   "mcpServers": {
     "codemob": {
-      "command": "/path/to/target/release/codemob-mcp",
+      "command": "/path/to/codemob-mcp",
       "env": {
         "ANTHROPIC_API_KEY": "sk-ant-...",
         "OPENAI_API_KEY": "sk-...",

--- a/examples/034-codemob-mcp/src/packs/mod.rs
+++ b/examples/034-codemob-mcp/src/packs/mod.rs
@@ -224,6 +224,10 @@ mod tests {
             "Anthropic default should include claude-opus-4-7: {models:?}"
         );
         assert!(
+            !models.iter().any(|model| model == "gpt-5.2"),
+            "advanced packs should not regress to gpt-5.2: {models:?}"
+        );
+        assert!(
             !models.iter().any(|model| model == "gpt-5.4"),
             "advanced packs should not regress to gpt-5.4: {models:?}"
         );

--- a/examples/034-codemob-mcp/src/packs/rct.rs
+++ b/examples/034-codemob-mcp/src/packs/rct.rs
@@ -79,7 +79,7 @@ impl Pack for RctPack {
                 "integration_sheriff",
                 "rct-sheriff-skill",
                 "Integration Sheriff reviewer",
-                "gpt-5.2",
+                "gpt-5.5-pro",
                 tools_with_shell.clone(),
             ),
             (

--- a/examples/034-codemob-mcp/src/tools/mod.rs
+++ b/examples/034-codemob-mcp/src/tools/mod.rs
@@ -47,11 +47,11 @@ Available models: \
 claude-opus-4-7 (Anthropic, strongest reasoning), \
 claude-sonnet-4-6 (Anthropic, fast + capable), \
 gpt-5.5 (OpenAI, strongest general + code), \
-gpt-5.2-pro (OpenAI, deep reasoning — slow, use sparingly), \
+gpt-5.5-pro (OpenAI, deep reasoning — slow, use sparingly), \
 gemini-3.1-pro-preview (Google, strong general), \
 gemini-3.1-flash-lite-preview (Google, fastest). \
 Default: gpt-5.5. \
-Guidance: use opus/gpt-5.2-pro for complex reasoning (architecture, judging). \
+Guidance: use opus/gpt-5.5-pro for complex reasoning (architecture, judging). \
 Use sonnet/gpt-5.5 for code tasks. \
 Use gemini-3.1-flash-lite-preview for speed-sensitive roles. \
 Mix providers in multi-agent packs for perspective diversity";
@@ -404,6 +404,7 @@ mod tests {
 
         assert!(schema.contains("gpt-5.5"));
         assert!(schema.contains("claude-opus-4-7"));
+        assert!(!schema.contains("gpt-5.2"));
         assert!(!schema.contains("gpt-5.4"));
         assert!(!schema.contains("claude-opus-4-6"));
     }

--- a/examples/035-mdm-tux-rs/README.md
+++ b/examples/035-mdm-tux-rs/README.md
@@ -61,30 +61,33 @@ the fleet.
 ### Direct mode (no kennel)
 
 ```bash
-cd examples/035-mdm-tux-rs
-
 # Terminal 1 — target agent
-ANTHROPIC_API_KEY=sk-ant-... cargo run --bin mdm-target -- \
+ANTHROPIC_API_KEY=sk-ant-... ./scripts/repo-cargo run \
+    --manifest-path examples/035-mdm-tux-rs/Cargo.toml \
+    --bin mdm-target -- \
     --rpc-port 4800 --name my-mac
 
 # Terminal 2 — TUX controller (direct connection)
-cargo run --bin mdm-tux -- --target 127.0.0.1:4800
+./scripts/repo-cargo run --manifest-path examples/035-mdm-tux-rs/Cargo.toml \
+    --bin mdm-tux -- --target 127.0.0.1:4800
 ```
 
 ### Kennel mode (brokered discovery)
 
 ```bash
-cd examples/035-mdm-tux-rs
-
 # Terminal 1 — kennel broker
-cargo run --bin mdm-kennel -- --listen 127.0.0.1:5000
+./scripts/repo-cargo run --manifest-path examples/035-mdm-tux-rs/Cargo.toml \
+    --bin mdm-kennel -- --listen 127.0.0.1:5000
 
 # Terminal 2 — target agent (registers with kennel)
-ANTHROPIC_API_KEY=sk-ant-... cargo run --bin mdm-target -- \
+ANTHROPIC_API_KEY=sk-ant-... ./scripts/repo-cargo run \
+    --manifest-path examples/035-mdm-tux-rs/Cargo.toml \
+    --bin mdm-target -- \
     --kennel 127.0.0.1:5000 --rpc-port 4800 --name my-mac
 
 # Terminal 3 — TUX controller (discovers targets via kennel)
-cargo run --bin mdm-tux -- --kennel 127.0.0.1:5000
+./scripts/repo-cargo run --manifest-path examples/035-mdm-tux-rs/Cargo.toml \
+    --bin mdm-tux -- --kennel 127.0.0.1:5000
 ```
 
 In TUX, use `/claim` to claim a target, then type a command and press Enter.
@@ -313,14 +316,13 @@ schedule tools:
 ### Install the binaries
 
 ```bash
-cd examples/035-mdm-tux-rs
-cargo build --release
-# Produces: target/release/mdm-target, target/release/mdm-tux, target/release/mdm-kennel
+./scripts/repo-cargo build --manifest-path examples/035-mdm-tux-rs/Cargo.toml --release
+export MDM_TARGET_DIR="$(./scripts/repo-cargo --print-env | sed -n 's/^CARGO_TARGET_DIR=//p')/release"
 ```
 
-Copy `target/release/mdm-target` to each managed machine.
-Run `target/release/mdm-tux` on the controller.
-Run `target/release/mdm-kennel` on the rendezvous host.
+Copy `$MDM_TARGET_DIR/mdm-target` to each managed machine.
+Run `$MDM_TARGET_DIR/mdm-tux` on the controller.
+Run `$MDM_TARGET_DIR/mdm-kennel` on the rendezvous host.
 
 ### macOS launchd (target as a persistent service)
 
@@ -360,7 +362,7 @@ Run `target/release/mdm-kennel` on the rendezvous host.
 ```
 
 ```bash
-sudo cp target/release/mdm-target /usr/local/bin/mdm-target
+sudo cp "$MDM_TARGET_DIR/mdm-target" /usr/local/bin/mdm-target
 sudo launchctl load /Library/LaunchDaemons/com.example.mdm-target.plist
 ```
 
@@ -386,7 +388,7 @@ WantedBy=multi-user.target
 ```
 
 ```bash
-sudo cp target/release/mdm-target /usr/local/bin/mdm-target
+sudo cp "$MDM_TARGET_DIR/mdm-target" /usr/local/bin/mdm-target
 sudo systemctl daemon-reload
 sudo systemctl enable --now mdm-target
 ```

--- a/examples/035-mdm-tux-rs/src/bin/target.rs
+++ b/examples/035-mdm-tux-rs/src/bin/target.rs
@@ -2405,7 +2405,7 @@ mod tests {
         let capture: Arc<CaptureClient> = Arc::new(CaptureClient::default());
 
         let req = CreateSessionRequest {
-            model: "gpt-5.2".to_string(),
+            model: "gpt-5.5".to_string(),
             prompt: ContentInput::Text("inspect target tools".to_string()),
             render_metadata: None,
             system_prompt: Some("test target".to_string()),
@@ -2474,7 +2474,7 @@ mod tests {
             &surface.service,
             &surface.runtime_adapter,
             None,
-            "gpt-5.2",
+            "gpt-5.5",
             "test",
             &surface.mob_state,
             "openai",
@@ -2550,7 +2550,7 @@ mod tests {
             .await
             .unwrap();
         let req = CreateSessionRequest {
-            model: "gpt-5.2".to_string(),
+            model: "gpt-5.5".to_string(),
             prompt: ContentInput::Text(String::new()),
             render_metadata: None,
             system_prompt: Some("cleanup".to_string()),
@@ -2579,7 +2579,7 @@ mod tests {
 
         surface
             .mob_state
-            .get_or_create_implicit_mob_for_bridge_session(&session_id.to_string(), "gpt-5.2")
+            .get_or_create_implicit_mob_for_bridge_session(&session_id.to_string(), "gpt-5.5")
             .await
             .unwrap();
         assert!(
@@ -2666,7 +2666,7 @@ mod tests {
             &surface.service,
             &surface.runtime_adapter,
             None,
-            "gpt-5.2",
+            "gpt-5.5",
             "test background shell",
             &surface.mob_state,
             "openai",
@@ -2697,7 +2697,14 @@ mod tests {
                     skill_references: None,
                     flow_tool_overlay: None,
                     pre_turn_context_appends: Vec::new(),
-                    turn_metadata: None,
+                    turn_metadata: Some(
+                        meerkat_core::lifecycle::run_primitive::RuntimeTurnMetadata {
+                            execution_kind: Some(
+                                meerkat_core::lifecycle::RuntimeExecutionKind::ContentTurn,
+                            ),
+                            ..Default::default()
+                        },
+                    ),
                 },
             )
             .await
@@ -2774,7 +2781,7 @@ mod tests {
 
         let capture2: Arc<CaptureClient> = Arc::new(CaptureClient::default());
         let req2 = CreateSessionRequest {
-            model: "gpt-5.2".to_string(),
+            model: "gpt-5.5".to_string(),
             prompt: ContentInput::Text("list tools".into()),
             render_metadata: None,
             system_prompt: Some("test".into()),
@@ -2878,7 +2885,7 @@ mod tests {
             &surface.service,
             &surface.runtime_adapter,
             None,
-            "gpt-5.2",
+            "gpt-5.5",
             "test",
             &surface.mob_state,
             "openai",
@@ -2921,7 +2928,7 @@ mod tests {
         ));
 
         let req = CreateSessionRequest {
-            model: "gpt-5.2".to_string(),
+            model: "gpt-5.5".to_string(),
             prompt: ContentInput::Text("list tools".into()),
             render_metadata: None,
             system_prompt: Some("test".into()),

--- a/examples/036-realtime-audio-py/README.md
+++ b/examples/036-realtime-audio-py/README.md
@@ -64,7 +64,7 @@ same mob and prints the helper's final output when it is available.
 python3 main.py --help
 python3 main.py --text-probe
 python3 main.py --input-device 1 --output-device 2
-python3 main.py --helper-model gpt-5.2
+python3 main.py --helper-model gpt-5.5
 python3 main.py --realm realtime-demo
 ```
 

--- a/examples/036-realtime-audio-py/README.md
+++ b/examples/036-realtime-audio-py/README.md
@@ -22,6 +22,14 @@ python3 -m pip install -e ../../sdks/python
 python3 -m pip install -r requirements.txt
 ```
 
+When running from a source checkout, build the local RPC binary from the
+repository root and pass it with `--rkat-path` or `MEERKAT_BIN_PATH`:
+
+```bash
+./scripts/repo-cargo build -p meerkat-rpc --bin rkat-rpc
+export MEERKAT_BIN_PATH="$(./scripts/repo-cargo --print-env | sed -n 's/^CARGO_TARGET_DIR=//p')/debug/rkat-rpc"
+```
+
 Linux hosts may also need PortAudio:
 
 ```bash

--- a/examples/036-realtime-audio-py/main.py
+++ b/examples/036-realtime-audio-py/main.py
@@ -27,7 +27,7 @@ from meerkat import MeerkatClient, RealtimeChannel
 
 
 DEFAULT_REALTIME_MODEL = "gpt-realtime-1.5"
-DEFAULT_HELPER_MODEL = "gpt-5.2"
+DEFAULT_HELPER_MODEL = "gpt-5.5"
 HOST_IDENTITY = "voice-host"
 
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -9,11 +9,23 @@ from "Hello World" to production multi-agent systems.
 # Set your API key
 export ANTHROPIC_API_KEY=sk-...
 
+# Build the repo-local CLI/RPC binaries used by shell and SDK examples
+./scripts/repo-cargo build -p rkat --bin rkat
+./scripts/repo-cargo build -p meerkat-rpc --bin rkat-rpc
+
+# Point SDK examples at the repo-local RPC binary
+export MEERKAT_BIN_PATH="$(./scripts/repo-cargo --print-env | sed -n 's/^CARGO_TARGET_DIR=//p')/debug/rkat-rpc"
+
+# Install/build local SDK dependencies
+python3 -m pip install -e sdks/python
+npm --prefix sdks/typescript install
+npm --prefix sdks/typescript run build
+
 # Install shared TypeScript example dependencies once
 cd examples && npm install
 
 # Run a Python example
-(cd 002-hello-meerkat-py && python main.py)
+(cd 002-hello-meerkat-py && python3 main.py)
 
 # Run a TypeScript example
 (cd 003-hello-meerkat-ts && npx tsx main.ts)
@@ -23,8 +35,11 @@ cd examples && npm install
 ```
 
 Rust examples in this folder are wired into `meerkat/Cargo.toml` and can be run
-directly from the workspace root with `cargo run -p meerkat --example <name>`.
-For example: `cargo run -p meerkat --example 001-hello-meerkat --features jsonl-store`.
+directly from the workspace root. For example:
+
+```bash
+./scripts/repo-cargo run -p meerkat --example 001-hello-meerkat --features jsonl-store
+```
 
 ## Flagship Shell Examples
 
@@ -40,16 +55,15 @@ pedagogical workflows rather than lightweight command recipes:
 
 ## Verification Status
 
-This repo now mixes fully live-ran examples, build-verified examples, and
-recipe-style examples that are still useful but depend on heavier external
-toolchains. The table below reflects the current verification state for this
-branch.
+This repo mixes live examples, build-verified examples, and recipe-style
+examples that depend on external toolchains or provider credentials. The table
+below describes the expected local validation level.
 
 | Status | Examples |
 |--------|----------|
-| **Live-ran** | 001, 002, 003, 007, 008, 010, 021, 022, 023, 028, 029, 030, 034 via MCP stdio, 035 via Docker/TUX hive suite |
-| **Build-verified** | Registered Rust examples via `cargo check`; 031, 032, 033 via Vite builds |
-| **Syntax-checked / recipe-oriented** | 004, 036, and shell entrypoints that are safe but intentionally operational rather than fully automated |
+| **Live when provider keys/services are available** | 001-003, 005-015, 017-028, 034-036 |
+| **Build-verified locally** | Registered Rust examples via `./scripts/repo-cargo check`; 031 and 032 via Vite builds; 033 via `sdks/web` WASM artifacts plus Vite |
+| **Syntax-checked / recipe-oriented** | 004, 010, 028-030 shell entrypoints and 036 audio setup when live provider/audio devices are unavailable |
 
 ## Examples by Level
 
@@ -157,22 +171,27 @@ branch.
 ### Rust Examples
 ```bash
 # Build from source
-cargo build --workspace
+make build
 
-# Or install from crates.io
-cargo install meerkat
+# Run one registered Rust example from the workspace root
+ANTHROPIC_API_KEY=sk-... ./scripts/repo-cargo run -p meerkat \
+  --example 001-hello-meerkat --features jsonl-store
 ```
 
 ### Python Examples
 ```bash
-pip install meerkat-sdk
-# Or install from source:
-pip install -e sdks/python
+python3 -m pip install -e sdks/python
+./scripts/repo-cargo build -p meerkat-rpc --bin rkat-rpc
+export MEERKAT_BIN_PATH="$(./scripts/repo-cargo --print-env | sed -n 's/^CARGO_TARGET_DIR=//p')/debug/rkat-rpc"
 ```
 
 ### TypeScript Examples
 ```bash
-cd examples && npm install
+npm --prefix sdks/typescript install
+npm --prefix sdks/typescript run build
+(cd examples && npm install)
+./scripts/repo-cargo build -p meerkat-rpc --bin rkat-rpc
+export MEERKAT_BIN_PATH="$(./scripts/repo-cargo --print-env | sed -n 's/^CARGO_TARGET_DIR=//p')/debug/rkat-rpc"
 ```
 
 ### API Keys

--- a/examples/README.md
+++ b/examples/README.md
@@ -17,7 +17,10 @@ export ANTHROPIC_API_KEY=sk-...
 export MEERKAT_BIN_PATH="$(./scripts/repo-cargo --print-env | sed -n 's/^CARGO_TARGET_DIR=//p')/debug/rkat-rpc"
 
 # Install/build local SDK dependencies
-python3 -m pip install -e sdks/python
+python3 -m venv .venv
+. .venv/bin/activate
+python -m pip install --upgrade pip
+python -m pip install -e sdks/python
 npm --prefix sdks/typescript install
 npm --prefix sdks/typescript run build
 
@@ -180,7 +183,10 @@ ANTHROPIC_API_KEY=sk-... ./scripts/repo-cargo run -p meerkat \
 
 ### Python Examples
 ```bash
-python3 -m pip install -e sdks/python
+python3 -m venv .venv
+. .venv/bin/activate
+python -m pip install --upgrade pip
+python -m pip install -e sdks/python
 ./scripts/repo-cargo build -p meerkat-rpc --bin rkat-rpc
 export MEERKAT_BIN_PATH="$(./scripts/repo-cargo --print-env | sed -n 's/^CARGO_TARGET_DIR=//p')/debug/rkat-rpc"
 ```

--- a/examples/package-lock.json
+++ b/examples/package-lock.json
@@ -16,10 +16,15 @@
     },
     "../sdks/typescript": {
       "name": "@rkat/sdk",
-      "version": "0.4.13",
+      "version": "0.6.0",
       "license": "MIT OR Apache-2.0",
+      "dependencies": {
+        "ws": "^8.20.0"
+      },
       "devDependencies": {
-        "@types/node": "^22"
+        "@types/node": "^22",
+        "@types/ws": "^8.18.1",
+        "typescript": "^5.8.3"
       }
     },
     "node_modules/@esbuild/aix-ppc64": {

--- a/meerkat-core/build.rs
+++ b/meerkat-core/build.rs
@@ -11,6 +11,7 @@ fn agent_factory_policy_bridge_symbol_suffix() -> String {
     use std::hash::{Hash, Hasher};
 
     let mut hasher = std::collections::hash_map::DefaultHasher::new();
+    "meerkat-agent-factory-policy-bridge-v3".hash(&mut hasher);
     let manifest_dir = std::env::var("CARGO_MANIFEST_DIR")
         .map(std::path::PathBuf::from)
         .ok()
@@ -18,9 +19,6 @@ fn agent_factory_policy_bridge_symbol_suffix() -> String {
         .map(|path| path.to_string_lossy().into_owned())
         .unwrap_or_default();
     manifest_dir.hash(&mut hasher);
-    std::env::var("OUT_DIR")
-        .unwrap_or_default()
-        .hash(&mut hasher);
     std::env::var("TARGET")
         .unwrap_or_default()
         .hash(&mut hasher);

--- a/meerkat/build.rs
+++ b/meerkat/build.rs
@@ -16,55 +16,13 @@ fn agent_factory_policy_bridge_symbol_suffix() -> Option<String> {
     let manifest_dir = std::path::PathBuf::from(std::env::var_os("CARGO_MANIFEST_DIR")?);
     let core_manifest_dirs = core_manifest_dir_candidates(&manifest_dir, &build_dir);
 
-    let mut best: Option<(std::time::SystemTime, String)> = None;
-    for entry in std::fs::read_dir(build_dir).ok()? {
-        let Ok(entry) = entry else {
-            continue;
-        };
-        let package_dir = entry.path();
-        let package_name = package_dir.file_name()?.to_string_lossy();
-        if !package_name.starts_with("meerkat-core-") {
-            continue;
-        }
-        let core_out_dir = package_dir.join("out");
-        if !core_out_dir.is_dir() {
-            continue;
-        }
-        let emitted_suffix = std::fs::read_to_string(package_dir.join("output"))
-            .ok()
-            .and_then(|output| {
-                output.lines().find_map(|line| {
-                    line.strip_prefix(
-                        "cargo:rustc-env=MEERKAT_AGENT_FACTORY_POLICY_BRIDGE_SYMBOL_SUFFIX=",
-                    )
-                    .map(str::to_owned)
-                })
-            });
-        if emitted_suffix.is_none() {
-            continue;
-        }
-        let suffix = core_manifest_dirs.iter().find_map(|core_manifest_dir| {
-            let mut hasher = std::collections::hash_map::DefaultHasher::new();
-            core_manifest_dir.to_string_lossy().hash(&mut hasher);
-            core_out_dir.to_string_lossy().hash(&mut hasher);
-            target.hash(&mut hasher);
-            let suffix = format!("{:016x}", hasher.finish());
-            (emitted_suffix.as_deref() == Some(suffix.as_str())).then_some(suffix)
-        });
-        let Some(suffix) = suffix else {
-            continue;
-        };
-        let modified = std::fs::metadata(&core_out_dir)
-            .and_then(|metadata| metadata.modified())
-            .unwrap_or(std::time::SystemTime::UNIX_EPOCH);
-        if best
-            .as_ref()
-            .is_none_or(|(best_modified, _)| modified > *best_modified)
-        {
-            best = Some((modified, suffix));
-        }
-    }
-    best.map(|(_, suffix)| suffix)
+    core_manifest_dirs.first().map(|core_manifest_dir| {
+        let mut hasher = std::collections::hash_map::DefaultHasher::new();
+        "meerkat-agent-factory-policy-bridge-v3".hash(&mut hasher);
+        core_manifest_dir.to_string_lossy().hash(&mut hasher);
+        target.hash(&mut hasher);
+        format!("{:016x}", hasher.finish())
+    })
 }
 
 fn core_manifest_dir_candidates(

--- a/sdks/python/meerkat/client.py
+++ b/sdks/python/meerkat/client.py
@@ -202,8 +202,8 @@ def _wire_params(value: Any) -> dict[str, Any]:
     return converted if isinstance(converted, dict) else dict(converted)
 
 
-def _skill_refs_to_wire(refs: list[SkillRef] | None) -> list[dict[str, str]] | None:
-    """Convert a list of SkillRef to the wire format for JSON-RPC."""
+def _skill_keys_to_wire(refs: list[SkillRef] | None) -> list[dict[str, str]] | None:
+    """Convert SkillKey-like refs to the bare SkillKey wire format."""
     if refs is None:
         return None
     return [
@@ -212,6 +212,20 @@ def _skill_refs_to_wire(refs: list[SkillRef] | None) -> list[dict[str, str]] | N
             "skill_name": _normalize_skill_ref(r).skill_name,
         }
         for r in refs
+    ]
+
+
+def _skill_refs_to_wire(refs: list[SkillRef] | None) -> list[dict[str, str]] | None:
+    """Convert SkillRef values to the tagged wire format for skill_refs."""
+    keys = _skill_keys_to_wire(refs)
+    if keys is None:
+        return None
+    return [
+        {
+            "kind": "structured",
+            **key,
+        }
+        for key in keys
     ]
 
 
@@ -2646,7 +2660,7 @@ class MeerkatClient:
         if provider_params is not None:
             params["provider_params"] = provider_params
         if preload_skills is not None:
-            params["preload_skills"] = _skill_refs_to_wire(preload_skills)
+            params["preload_skills"] = _skill_keys_to_wire(preload_skills)
         wire_refs = _skill_refs_to_wire(skill_refs)
         if wire_refs is not None:
             params["skill_refs"] = wire_refs

--- a/sdks/python/tests/test_types.py
+++ b/sdks/python/tests/test_types.py
@@ -2093,6 +2093,7 @@ async def test_mob_turn_start_wrapper_uses_typed_prompt_and_overrides():
                 "prompt": [{"type": "text", "text": "continue"}],
                 "skill_refs": [
                     {
+                        "kind": "structured",
                         "source_uuid": "00000000-0000-4000-8000-000000000001",
                         "skill_name": "read",
                     }

--- a/sdks/typescript/src/client.ts
+++ b/sdks/typescript/src/client.ts
@@ -199,10 +199,20 @@ export interface ConnectOptions {
   userConfigRoot?: string;
 }
 
+interface WireSkillKey {
+  [key: string]: string;
+  source_uuid: string;
+  skill_name: string;
+}
+
+interface WireSkillRef extends WireSkillKey {
+  kind: "structured";
+}
+
 /**
- * Normalize a structured SkillRef to the wire format { source_uuid, skill_name }.
+ * Normalize a structured SkillRef to the bare SkillKey wire format.
  */
-function normalizeSkillRef(ref: SkillRef): { source_uuid: string; skill_name: string } {
+function normalizeSkillKey(ref: SkillRef): WireSkillKey {
   if (
     ref === null ||
     typeof ref !== "object" ||
@@ -214,9 +224,14 @@ function normalizeSkillRef(ref: SkillRef): { source_uuid: string; skill_name: st
   return { source_uuid: ref.sourceUuid, skill_name: ref.skillName };
 }
 
-function skillRefsToWire(refs: SkillRef[] | undefined): Array<{ source_uuid: string; skill_name: string }> | undefined {
+function skillKeysToWire(refs: SkillRef[] | undefined): WireSkillKey[] | undefined {
   if (!refs) return undefined;
-  return refs.map(normalizeSkillRef);
+  return refs.map(normalizeSkillKey);
+}
+
+function skillRefsToWire(refs: SkillRef[] | undefined): WireSkillRef[] | undefined {
+  const keys = skillKeysToWire(refs);
+  return keys?.map((key) => ({ kind: "structured", ...key }));
 }
 
 function setIfDefined<T extends object, K extends keyof T>(
@@ -3188,7 +3203,7 @@ export class MeerkatClient {
     if (options.budgetLimits != null) params.budget_limits = options.budgetLimits;
     if (options.providerParams != null) params.provider_params = options.providerParams;
     if (options.preloadSkills != null) {
-      params.preload_skills = skillRefsToWire(options.preloadSkills);
+      params.preload_skills = skillKeysToWire(options.preloadSkills);
     }
     const wireRefs = skillRefsToWire(options.skillRefs);
     if (wireRefs) params.skill_refs = wireRefs;

--- a/sdks/typescript/tests/types.test.js
+++ b/sdks/typescript/tests/types.test.js
@@ -1999,6 +1999,7 @@ describe("Parity wrappers", () => {
       prompt: [{ type: "text", text: "continue" }],
       skill_refs: [
         {
+          kind: "structured",
           source_uuid: "00000000-0000-4000-8000-000000000001",
           skill_name: "read",
         },


### PR DESCRIPTION
## Summary
- update example READMEs and doc comments to use the repo Make/repo-cargo command surface and current local SDK setup
- teach shell examples to resolve repo-local rkat binaries from repo-cargo target directories
- fix the Cargo factory bridge suffix mismatch that prevented rkat/rkat-rpc/rkat-rest builds when stale sibling build outputs existed
- refresh example npm lockfiles and remove the duplicate Office demo model provider key

Linear: https://linear.app/lucrfr/issue/LUC-398/get-examples-up-to-datebuildrun

## Validation
- find examples -name '*.sh' -print0 | xargs -0 bash -n
- find examples -name '*.py' -print0 | xargs -0 python3 -m py_compile
- npm exec -- tsc --noEmit --target ES2022 --module NodeNext --moduleResolution NodeNext --types node 003-hello-meerkat-ts/main.ts 008-structured-output-ts/main.ts 023-rpc-ide-integration-ts/main.ts 027-skills-v21-invoke-ts/main.ts
- npm run build (examples/031-wasm-mini-diplomacy-sh/web)
- npm run build (examples/032-wasm-webcm-agent/web)
- npm exec -- tsc --noEmit (examples/033-the-office-demo-sh/web)
- ./scripts/repo-cargo build -p rkat --bin rkat
- ./scripts/repo-cargo build -p meerkat-rpc --bin rkat-rpc
- ./scripts/repo-cargo build -p meerkat-rest --bin rkat-rest
- ./scripts/repo-cargo check -p meerkat --examples --features jsonl-store,skills,session-compaction,memory-store-session,comms
- ./scripts/repo-cargo check -p meerkat-mob --examples
- ./scripts/repo-cargo check --manifest-path examples/034-codemob-mcp/Cargo.toml
- ./scripts/repo-cargo check --manifest-path examples/035-mdm-tux-rs/Cargo.toml
- ./scripts/repo-cargo test -p meerkat --test agent_builder_policy_canary
- ./scripts/repo-cargo fmt --all -- --check
- git diff --check
- MEERKAT_BUILDBUDDY=1 make check

Notes: provider keys were not present, so live provider/audio examples were not executed. Full sdks/web release WASM build was attempted but stopped locally after becoming impractically long; 033 was typechecked and documents the required prebuilt WASM runtime artifacts.