### PR TITLE
Harden mobpack validation

### DIFF
--- a/meerkat-mob-pack/src/archive.rs
+++ b/meerkat-mob-pack/src/archive.rs
@@ -1,4 +1,5 @@
 use crate::manifest::MobpackManifest;
+use crate::pack::{ValidatedPackFiles, validate_extracted_pack_files};
 use crate::targz::extract_targz_safe;
 use crate::validate::PackValidationError;
 use meerkat_mob::MobDefinition;
@@ -42,18 +43,10 @@ impl MobpackArchive {
     pub fn from_extracted_files(
         files: &BTreeMap<String, Vec<u8>>,
     ) -> Result<Self, PackValidationError> {
-        let manifest_bytes = files
-            .get("manifest.toml")
-            .ok_or(PackValidationError::MissingManifest)?;
-        let definition_bytes = files
-            .get("definition.json")
-            .ok_or(PackValidationError::MissingDefinition)?;
-        let manifest_text = String::from_utf8(manifest_bytes.clone())
-            .map_err(|err| PackValidationError::InvalidManifest(err.to_string()))?;
-        let manifest: MobpackManifest = toml::from_str(&manifest_text)
-            .map_err(|err| PackValidationError::InvalidManifest(err.to_string()))?;
-        let definition: MobDefinition = serde_json::from_slice(definition_bytes)
-            .map_err(|err| PackValidationError::BadDefinition(err.to_string()))?;
+        let ValidatedPackFiles {
+            manifest,
+            definition,
+        } = validate_extracted_pack_files(files)?;
 
         let mut skills = BTreeMap::new();
         let mut hooks = BTreeMap::new();
@@ -153,5 +146,25 @@ mod tests {
             let err = MobpackArchive::from_archive_bytes(&bytes).unwrap_err();
             assert!(matches!(err, PackValidationError::UnsafeEntry { .. }));
         }
+    }
+
+    #[test]
+    fn test_archive_reader_rejects_semantic_pack_errors() {
+        let files = BTreeMap::from([
+            (
+                "manifest.toml".to_string(),
+                b"[mobpack]\nname = \"fixture\"\nversion = \"1.0.0\"\n".to_vec(),
+            ),
+            (
+                "definition.json".to_string(),
+                br#"{"id":"mob","profiles":{"worker":{"realm_profile":"prod-worker"}}}"#.to_vec(),
+            ),
+        ]);
+        let archive_bytes = create_targz(&files).unwrap();
+        let err = MobpackArchive::from_archive_bytes(&archive_bytes).unwrap_err();
+        assert!(matches!(
+            err,
+            PackValidationError::RealmRefForbidden { profile_name } if profile_name == "worker"
+        ));
     }
 }

--- a/meerkat-mob-pack/src/pack.rs
+++ b/meerkat-mob-pack/src/pack.rs
@@ -1,11 +1,11 @@
 use crate::digest::{MobpackDigest, canonical_digest_from_map};
 use crate::manifest::MobpackManifest;
 use crate::signing::{PackSignature, sign_digest};
-use crate::targz::{create_targz, extract_targz_safe};
+use crate::targz::{create_targz, extract_targz_safe, normalize_for_archive};
 use crate::validate::PackValidationError;
 use chrono::{SecondsFormat, Utc};
 use ed25519_dalek::SigningKey;
-use meerkat_mob::MobDefinition;
+use meerkat_mob::{MobDefinition, definition::SkillSource};
 use std::collections::BTreeMap;
 use std::path::Path;
 
@@ -36,6 +36,11 @@ pub struct SigningRequest<'a> {
     pub key_path: &'a Path,
 }
 
+pub(crate) struct ValidatedPackFiles {
+    pub manifest: MobpackManifest,
+    pub definition: MobDefinition,
+}
+
 pub fn pack_directory(
     directory: &Path,
     signing: Option<SigningRequest<'_>>,
@@ -53,7 +58,7 @@ pub fn pack_directory_with_excludes(
     if let Some(request) = signing {
         exclude_paths_from_pack(directory, &[request.key_path], &mut files);
     }
-    validate_required_files(&files)?;
+    validate_extracted_pack_files(&files)?;
 
     if let Some(request) = signing {
         let unsigned_archive = create_targz(&files)?;
@@ -81,9 +86,7 @@ pub fn pack_directory_with_excludes(
 
 pub fn inspect_archive_bytes(bytes: &[u8]) -> Result<InspectResult, PackValidationError> {
     let files = extract_targz_safe(bytes)?;
-    validate_required_files(&files)?;
-    let manifest = parse_manifest(&files)?;
-    parse_definition(&files)?;
+    let ValidatedPackFiles { manifest, .. } = validate_extracted_pack_files(&files)?;
     let mut file_list: Vec<String> = files.keys().cloned().collect();
     file_list.sort();
     Ok(InspectResult {
@@ -98,6 +101,22 @@ pub fn inspect_archive_bytes(bytes: &[u8]) -> Result<InspectResult, PackValidati
 pub fn compute_archive_digest(bytes: &[u8]) -> Result<MobpackDigest, PackValidationError> {
     let files = extract_targz_safe(bytes)?;
     Ok(canonical_digest_from_map(&files))
+}
+
+pub(crate) fn validate_extracted_pack_files(
+    files: &BTreeMap<String, Vec<u8>>,
+) -> Result<ValidatedPackFiles, PackValidationError> {
+    validate_required_files(files)?;
+    ensure_no_trust_section(files)?;
+    let manifest = parse_manifest(files)?;
+    validate_manifest_identity(&manifest)?;
+    let definition = parse_definition(files)?;
+    reject_realm_refs(&definition)?;
+    validate_skill_paths(&definition, files)?;
+    Ok(ValidatedPackFiles {
+        manifest,
+        definition,
+    })
 }
 
 fn parse_manifest(
@@ -121,6 +140,22 @@ fn parse_definition(
     serde_json::from_slice(bytes).map_err(|err| PackValidationError::BadDefinition(err.to_string()))
 }
 
+fn validate_manifest_identity(manifest: &MobpackManifest) -> Result<(), PackValidationError> {
+    if manifest.mobpack.name.trim().is_empty() {
+        return Err(PackValidationError::InvalidManifestField {
+            field: "mobpack.name".to_string(),
+            reason: "must not be empty".to_string(),
+        });
+    }
+    if manifest.mobpack.version.trim().is_empty() {
+        return Err(PackValidationError::InvalidManifestField {
+            field: "mobpack.version".to_string(),
+            reason: "must not be empty".to_string(),
+        });
+    }
+    Ok(())
+}
+
 fn reject_realm_refs(definition: &MobDefinition) -> Result<(), PackValidationError> {
     for (name, binding) in &definition.profiles {
         if binding.realm_ref_name().is_some() {
@@ -128,6 +163,49 @@ fn reject_realm_refs(definition: &MobDefinition) -> Result<(), PackValidationErr
                 profile_name: name.to_string(),
             });
         }
+    }
+    Ok(())
+}
+
+fn validate_skill_paths(
+    definition: &MobDefinition,
+    files: &BTreeMap<String, Vec<u8>>,
+) -> Result<(), PackValidationError> {
+    for (skill_name, source) in &definition.skills {
+        let SkillSource::Path { path } = source else {
+            continue;
+        };
+        let normalized_path =
+            normalize_for_archive(path).map_err(|err| PackValidationError::InvalidSkillPath {
+                skill_name: skill_name.clone(),
+                path: path.clone(),
+                reason: err.to_string(),
+            })?;
+        if normalized_path != *path {
+            return Err(PackValidationError::InvalidSkillPath {
+                skill_name: skill_name.clone(),
+                path: path.clone(),
+                reason: format!("must use canonical archive path `{normalized_path}`"),
+            });
+        }
+        if !normalized_path.starts_with("skills/") {
+            return Err(PackValidationError::InvalidSkillPath {
+                skill_name: skill_name.clone(),
+                path: path.clone(),
+                reason: "must be under skills/".to_string(),
+            });
+        }
+        let Some(bytes) = files.get(&normalized_path) else {
+            return Err(PackValidationError::MissingSkillFile {
+                skill_name: skill_name.clone(),
+                path: normalized_path,
+            });
+        };
+        std::str::from_utf8(bytes).map_err(|err| PackValidationError::InvalidSkillUtf8 {
+            skill_name: skill_name.clone(),
+            path: normalized_path,
+            reason: err.to_string(),
+        })?;
     }
     Ok(())
 }
@@ -333,6 +411,127 @@ mod tests {
     }
 
     #[test]
+    fn test_pack_rejects_manifest_trust_section() {
+        let temp = fixture_mob_dir();
+        std::fs::write(
+            temp.path().join("manifest.toml"),
+            "[mobpack]\nname = \"fixture\"\nversion = \"1.0.0\"\n\n[trust]\npolicy = \"strict\"\n",
+        )
+        .unwrap();
+        let err = pack_directory(temp.path(), None).unwrap_err();
+        assert!(matches!(err, PackValidationError::TrustSectionForbidden));
+    }
+
+    #[test]
+    fn test_pack_rejects_blank_manifest_name() {
+        let temp = fixture_mob_dir();
+        std::fs::write(
+            temp.path().join("manifest.toml"),
+            "[mobpack]\nname = \"   \"\nversion = \"1.0.0\"\n",
+        )
+        .unwrap();
+        let err = pack_directory(temp.path(), None).unwrap_err();
+        assert!(matches!(
+            err,
+            PackValidationError::InvalidManifestField { field, .. } if field == "mobpack.name"
+        ));
+    }
+
+    #[test]
+    fn test_pack_rejects_blank_manifest_version() {
+        let temp = fixture_mob_dir();
+        std::fs::write(
+            temp.path().join("manifest.toml"),
+            "[mobpack]\nname = \"fixture\"\nversion = \"\"\n",
+        )
+        .unwrap();
+        let err = pack_directory(temp.path(), None).unwrap_err();
+        assert!(matches!(
+            err,
+            PackValidationError::InvalidManifestField { field, .. } if field == "mobpack.version"
+        ));
+    }
+
+    #[test]
+    fn test_pack_rejects_realm_profile_refs() {
+        let temp = fixture_mob_dir();
+        std::fs::write(
+            temp.path().join("definition.json"),
+            br#"{"id":"mob","profiles":{"worker":{"realm_profile":"prod-worker"}}}"#,
+        )
+        .unwrap();
+        let err = pack_directory(temp.path(), None).unwrap_err();
+        assert!(matches!(
+            err,
+            PackValidationError::RealmRefForbidden { profile_name } if profile_name == "worker"
+        ));
+    }
+
+    #[test]
+    fn test_pack_rejects_missing_packed_skill_path() {
+        let temp = fixture_mob_dir_with_skill_path("skills/missing.md");
+        let err = pack_directory(temp.path(), None).unwrap_err();
+        assert!(matches!(
+            err,
+            PackValidationError::MissingSkillFile { skill_name, path }
+                if skill_name == "review" && path == "skills/missing.md"
+        ));
+    }
+
+    #[test]
+    fn test_pack_rejects_non_skills_skill_path() {
+        let temp = fixture_mob_dir_with_skill_path("config/review.md");
+        std::fs::create_dir_all(temp.path().join("config")).unwrap();
+        std::fs::write(temp.path().join("config").join("review.md"), "# Review\n").unwrap();
+        let err = pack_directory(temp.path(), None).unwrap_err();
+        assert!(matches!(
+            err,
+            PackValidationError::InvalidSkillPath { skill_name, path, .. }
+                if skill_name == "review" && path == "config/review.md"
+        ));
+    }
+
+    #[test]
+    fn test_pack_rejects_noncanonical_skill_path() {
+        let temp = fixture_mob_dir_with_skill_path("./skills/review.md");
+        let err = pack_directory(temp.path(), None).unwrap_err();
+        assert!(matches!(
+            err,
+            PackValidationError::InvalidSkillPath { skill_name, path, reason }
+                if skill_name == "review"
+                    && path == "./skills/review.md"
+                    && reason.contains("canonical archive path")
+        ));
+    }
+
+    #[test]
+    fn test_pack_rejects_invalid_utf8_skill_path_content() {
+        let temp = fixture_mob_dir_with_skill_path("skills/review.md");
+        std::fs::write(temp.path().join("skills").join("review.md"), [0xff, 0xfe]).unwrap();
+        let err = pack_directory(temp.path(), None).unwrap_err();
+        assert!(matches!(
+            err,
+            PackValidationError::InvalidSkillUtf8 { skill_name, path, .. }
+                if skill_name == "review" && path == "skills/review.md"
+        ));
+    }
+
+    #[test]
+    fn test_inspect_rejects_semantically_invalid_archive() {
+        let files = BTreeMap::from([
+            (
+                "manifest.toml".to_string(),
+                b"[mobpack]\nname = \"fixture\"\nversion = \"1.0.0\"\n\n[trust]\npolicy = \"strict\"\n"
+                    .to_vec(),
+            ),
+            ("definition.json".to_string(), br#"{"id":"mob"}"#.to_vec()),
+        ]);
+        let archive = create_targz(&files).unwrap();
+        let err = inspect_archive_bytes(&archive).unwrap_err();
+        assert!(matches!(err, PackValidationError::TrustSectionForbidden));
+    }
+
+    #[test]
     fn test_inspect_shows_manifest_and_digest() {
         let temp = fixture_mob_dir();
         let packed = pack_directory(temp.path(), None).unwrap();
@@ -361,6 +560,21 @@ mod tests {
         std::fs::write(
             temp.path().join("hooks").join("run.sh"),
             "#!/bin/sh\necho run\n",
+        )
+        .unwrap();
+        temp
+    }
+
+    fn fixture_mob_dir_with_skill_path(path: &str) -> TempDir {
+        let temp = fixture_mob_dir();
+        std::fs::write(
+            temp.path().join("definition.json"),
+            format!(
+                r#"{{
+  "id":"mob",
+  "skills":{{"review":{{"source":"path","path":"{path}"}}}}
+}}"#
+            ),
         )
         .unwrap();
         temp

--- a/meerkat-mob-pack/src/targz.rs
+++ b/meerkat-mob-pack/src/targz.rs
@@ -3,7 +3,7 @@ use crate::validate::PackValidationError;
 use flate2::Compression;
 use flate2::read::GzDecoder;
 use flate2::write::GzEncoder;
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, BTreeSet};
 use std::io::{Cursor, Read};
 use tar::{Archive, Builder, EntryType, Header};
 
@@ -11,8 +11,14 @@ pub fn create_targz(files: &BTreeMap<String, Vec<u8>>) -> Result<Vec<u8>, PackVa
     let mut encoder = GzEncoder::new(Vec::new(), Compression::default());
     {
         let mut builder = Builder::new(&mut encoder);
+        let mut normalized_paths = BTreeSet::new();
         for (path, bytes) in files {
             let normalized_path = normalize_for_archive(path)?;
+            if !normalized_paths.insert(normalized_path.clone()) {
+                return Err(PackValidationError::DuplicateArchiveEntry {
+                    path: normalized_path,
+                });
+            }
             let exec = normalize_executable_bit(&normalized_path, bytes);
             let mut header = Header::new_gnu();
             header.set_size(bytes.len() as u64);
@@ -70,6 +76,11 @@ pub fn extract_targz_safe(input: &[u8]) -> Result<BTreeMap<String, Vec<u8>>, Pac
         }
 
         let normalized_path = normalize_for_archive(&raw_path_string)?;
+        if out.contains_key(&normalized_path) {
+            return Err(PackValidationError::DuplicateArchiveEntry {
+                path: normalized_path,
+            });
+        }
         let mut bytes = Vec::new();
         entry.read_to_end(&mut bytes)?;
         out.insert(normalized_path, bytes);
@@ -78,7 +89,7 @@ pub fn extract_targz_safe(input: &[u8]) -> Result<BTreeMap<String, Vec<u8>>, Pac
     Ok(out)
 }
 
-fn normalize_for_archive(path: &str) -> Result<String, PackValidationError> {
+pub(crate) fn normalize_for_archive(path: &str) -> Result<String, PackValidationError> {
     let replaced = path.replace('\\', "/");
     if replaced.starts_with('/') || looks_like_windows_absolute(&replaced) {
         return Err(PackValidationError::UnsafeEntry {
@@ -174,11 +185,56 @@ mod tests {
     }
 
     #[test]
+    fn test_targz_rejects_duplicate_normalized_entries_on_extract() {
+        let bytes = create_duplicate_archive("./skills/review.md", "skills/review.md");
+        let err = extract_targz_safe(&bytes).unwrap_err();
+        assert!(matches!(
+            err,
+            PackValidationError::DuplicateArchiveEntry { path } if path == "skills/review.md"
+        ));
+    }
+
+    #[test]
+    fn test_targz_rejects_duplicate_normalized_entries_on_create() {
+        let files = BTreeMap::from([
+            ("./skills/review.md".to_string(), b"one".to_vec()),
+            ("skills/review.md".to_string(), b"two".to_vec()),
+        ]);
+        let err = create_targz(&files).unwrap_err();
+        assert!(matches!(
+            err,
+            PackValidationError::DuplicateArchiveEntry { path } if path == "skills/review.md"
+        ));
+    }
+
+    #[test]
     fn test_mob_definition_json_roundtrip() {
         let definition: meerkat_mob::MobDefinition =
             serde_json::from_str(r#"{"id":"mobpack-test"}"#).unwrap();
         let encoded = serde_json::to_string(&definition).unwrap();
         let decoded: meerkat_mob::MobDefinition = serde_json::from_str(&encoded).unwrap();
         assert_eq!(decoded, definition);
+    }
+
+    fn create_duplicate_archive(first_path: &str, second_path: &str) -> Vec<u8> {
+        let mut encoder = GzEncoder::new(Vec::new(), Compression::default());
+        {
+            let mut builder = Builder::new(&mut encoder);
+            for (path, bytes) in [
+                (first_path, b"one".as_slice()),
+                (second_path, b"two".as_slice()),
+            ] {
+                let mut header = Header::new_gnu();
+                header.set_size(bytes.len() as u64);
+                header.set_entry_type(EntryType::Regular);
+                header.set_mode(0o644);
+                header.set_cksum();
+                builder
+                    .append_data(&mut header, path, Cursor::new(bytes))
+                    .expect("append duplicate entry");
+            }
+            builder.finish().expect("finish archive");
+        }
+        encoder.finish().expect("finish gzip")
     }
 }

--- a/meerkat-mob-pack/src/validate.rs
+++ b/meerkat-mob-pack/src/validate.rs
@@ -10,10 +10,14 @@ pub enum PackValidationError {
     BadDefinition(String),
     #[error("manifest.toml is invalid: {0}")]
     InvalidManifest(String),
+    #[error("manifest.toml field `{field}` is invalid: {reason}")]
+    InvalidManifestField { field: String, reason: String },
     #[error("manifest.toml may not contain [trust]")]
     TrustSectionForbidden,
     #[error("unsafe archive entry `{path}`: {reason}")]
     UnsafeEntry { path: String, reason: String },
+    #[error("duplicate archive entry after path normalization: `{path}`")]
+    DuplicateArchiveEntry { path: String },
     #[error("unsigned pack rejected in strict trust mode")]
     UnsignedStrict,
     #[error("signature is invalid: {0}")]
@@ -34,6 +38,20 @@ pub enum PackValidationError {
     InvalidSigningKey(String),
     #[error("profile `{profile_name}` uses a realm reference, which is forbidden in packs")]
     RealmRefForbidden { profile_name: String },
+    #[error("mobpack skill path '{path}' for '{skill_name}' is invalid: {reason}")]
+    InvalidSkillPath {
+        skill_name: String,
+        path: String,
+        reason: String,
+    },
+    #[error("mobpack skill path '{path}' for '{skill_name}' missing from archive")]
+    MissingSkillFile { skill_name: String, path: String },
+    #[error("mobpack skill path '{path}' for '{skill_name}' is not valid UTF-8: {reason}")]
+    InvalidSkillUtf8 {
+        skill_name: String,
+        path: String,
+        reason: String,
+    },
 }
 
 impl From<std::io::Error> for PackValidationError {
@@ -62,7 +80,14 @@ mod tests {
             PackValidationError::SignerKeyMismatch("ci".to_string()),
             PackValidationError::SignatureDigestMismatch,
             PackValidationError::InvalidManifest("bad toml".to_string()),
+            PackValidationError::InvalidManifestField {
+                field: "mobpack.name".to_string(),
+                reason: "must not be empty".to_string(),
+            },
             PackValidationError::TrustSectionForbidden,
+            PackValidationError::DuplicateArchiveEntry {
+                path: "skills/review.md".to_string(),
+            },
             PackValidationError::CapabilityMismatch("comms".to_string()),
             PackValidationError::Archive("bad tar".to_string()),
             PackValidationError::Io("disk full".to_string()),
@@ -70,8 +95,22 @@ mod tests {
             PackValidationError::RealmRefForbidden {
                 profile_name: "worker".to_string(),
             },
+            PackValidationError::InvalidSkillPath {
+                skill_name: "review".to_string(),
+                path: "../review.md".to_string(),
+                reason: "path traversal is not allowed".to_string(),
+            },
+            PackValidationError::MissingSkillFile {
+                skill_name: "review".to_string(),
+                path: "skills/review.md".to_string(),
+            },
+            PackValidationError::InvalidSkillUtf8 {
+                skill_name: "review".to_string(),
+                path: "skills/review.md".to_string(),
+                reason: "invalid utf-8 sequence".to_string(),
+            },
         ];
 
-        assert_eq!(errors.len(), 16);
+        assert_eq!(errors.len(), 21);
     }
 }


### PR DESCRIPTION
## Summary
- centralize mobpack semantic validation for pack, inspect, validate, and archive-load paths
- reject embedded trust sections, realm profile refs, blank manifest identity fields, duplicate normalized archive entries, and invalid skill path references earlier
- add regression coverage for the new mobpack and CLI validation behavior

## Validation
- `./scripts/repo-cargo test -p meerkat-mob-pack`
- `./scripts/repo-cargo clippy -p meerkat-mob-pack --all-targets -- -D warnings`
- `./scripts/repo-cargo test -p rkat test_mob_`
- `./scripts/repo-cargo test -p rkat deploy_surfaces`
- `./scripts/repo-cargo test -p rkat test_mob_validate_success_and_failure_behaviors`
- `MEERKAT_BUILDBUDDY=1 make check`
- `MEERKAT_BUILDBUDDY=1 make test`
- `MEERKAT_BUILDBUDDY=1 make lint`
- `MEERKAT_BUILDBUDDY=1 make SHELL=/bin/bash agent-gate`

Linear: LUC-406
