### PR TITLE
LUC-407: Refresh architecture and API references

### DIFF
--- a/artifacts/schemas/rest-openapi.json
+++ b/artifacts/schemas/rest-openapi.json
@@ -8337,6 +8337,44 @@
         "summary": "Get product-layer realtime channel status for a target"
       }
     },
+    "/requests/{request_id}/cancel": {
+      "post": {
+        "operationId": "post_requests_request_id_cancel",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "request_id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/JsonValue"
+                }
+              }
+            },
+            "description": "Successful response"
+          },
+          "default": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/WireError"
+                }
+              }
+            },
+            "description": "Error response"
+          }
+        },
+        "summary": "Cancel an uncommitted in-flight request"
+      }
+    },
     "/runtime/capabilities": {
       "get": {
         "operationId": "get_runtime_capabilities",

--- a/docs/api/mcp.mdx
+++ b/docs/api/mcp.mdx
@@ -60,7 +60,22 @@ second surface-local execution loop.
 | `meerkat_mob_status` | Get lifecycle status for one mob (mob feature) |
 | `meerkat_mob_lifecycle` | Apply a lifecycle action to a mob (mob feature) |
 | `meerkat_mob_spawn` | Spawn a member into a mob (mob feature) |
+| `meerkat_mob_spawn_many` | Spawn multiple members into a mob (mob feature) |
+| `meerkat_mob_retire` | Retire a mob member (mob feature) |
+| `meerkat_mob_respawn` | Respawn a mob member with topology restore (mob feature) |
+| `meerkat_mob_wire` | Wire two mob members or an external peer (mob feature) |
+| `meerkat_mob_unwire` | Remove mob comms wiring (mob feature) |
 | `meerkat_mob_member_send` | Deliver host-owned work to a specific mob member (mob feature) |
+| `meerkat_mob_append_system_context` | Stage system context for a member session (mob feature) |
+| `meerkat_mob_events` | Read mob event history (mob feature) |
+| `meerkat_mob_flows` | List flows defined for a mob (mob feature) |
+| `meerkat_mob_flow_run` | Start a mob flow run (mob feature) |
+| `meerkat_mob_flow_status` | Get flow run status (mob feature) |
+| `meerkat_mob_flow_cancel` | Cancel a flow run (mob feature) |
+| `meerkat_mob_force_cancel` | Force-cancel a member's active work (mob feature) |
+| `meerkat_mob_wait_kickoff` | Wait for autonomous kickoff completion (mob feature) |
+| `meerkat_mob_wait_ready` | Wait for mob startup readiness (mob feature) |
+| `meerkat_mob_profile_*` tools | Realm-scoped mob profile create/get/list/update/delete (mob feature) |
 | `meerkat_mob_event_stream_open` | Open a mob-level event stream (mob feature) |
 | `meerkat_mob_event_stream_read` | Read the next event from an open mob stream (mob feature) |
 | `meerkat_mob_event_stream_close` | Close a previously opened mob event stream (mob feature) |
@@ -68,10 +83,12 @@ second surface-local execution loop.
 | `meerkat_comms_peers` | List peers visible to a session (comms feature) |
 | `meerkat_realtime_open_info` | Issue a single-use bootstrap token for opening a realtime channel (realtime feature) |
 | `meerkat_realtime_status` | Read product-layer realtime channel status for a session or mob member (realtime feature) |
-| `meerkat_realtime_capabilities` | Read product-layer realtime capabilities for a target (realtime feature) |
 
 <Note>
-Default `rkat-mcp` builds are driven by the crate feature set. The base/default tool surface includes the core session/config/history/blob/skills surface plus schedule tools. Mob and realtime MCP tools are feature-gated and appear only when the `mob` feature is compiled in.
+Default `rkat-mcp` builds are driven by the crate feature set. The base/default
+tool surface includes core session/config/history/blob/skills tools, schedule
+tools, and `meerkat_realtime_open_info`. Mob tools and
+`meerkat_realtime_status` appear when the `mob` feature is compiled in.
 </Note>
 
 <Note>
@@ -87,9 +104,10 @@ model. Public host MCP surfaces should not re-export that raw dispatcher.
 `ModelCapabilities.realtime` on the session's model; it attaches
 automatically when the session runs a realtime-capable model (e.g.
 `gpt-realtime-1.5`). The public MCP tool set exposes only the product-layer
-bootstrap and status surfaces (`meerkat_realtime_open_info`,
-`meerkat_realtime_status`, `meerkat_realtime_capabilities`) — there is
-no MCP attach/detach tool. See the [Realtime
+bootstrap and status surfaces (`meerkat_realtime_open_info` and
+`meerkat_realtime_status`) — there is no MCP attach/detach tool and no
+MCP realtime capabilities tool. Use RPC `realtime/capabilities` when an app
+needs the detailed product-layer capability projection. See the [Realtime
 guide](/guides/realtime) for the capability-driven model and the full
 attachment state machine.
 </Note>

--- a/docs/api/rest.mdx
+++ b/docs/api/rest.mdx
@@ -9,15 +9,15 @@ Meerkat ships a REST server for running and managing agent sessions over HTTP. T
 ## Getting started
 
 <Steps>
-  <Step title="Build the server">
+  <Step title="Start the server">
     <CodeGroup>
-    ```bash Development
-    cargo run --package meerkat-rest -- --realm team-alpha
+    ```bash Installed binary
+    rkat-rest --realm team-alpha
     ```
 
-    ```bash Production
-    cargo build --release --package meerkat-rest
-    ./target/release/rkat-rest --realm team-alpha
+    ```bash Realtime bootstrap proxy
+    rkat-rpc --realm team-alpha --tcp 127.0.0.1:9001 --realtime-ws 127.0.0.1:9002
+    rkat-rest --realm team-alpha --realtime-rpc-tcp 127.0.0.1:9001
     ```
     </CodeGroup>
   </Step>
@@ -43,19 +43,32 @@ Meerkat ships a REST server for running and managing agent sessions over HTTP. T
 `rkat-rest` accepts:
 
 - `--realm <id>`
+- `--isolated`
 - `--instance <id>`
 - `--realm-backend <sqlite|jsonl>`
+- `--state-root <path>`
+- `--context-root <path>`
+- `--user-config-root <path>`
+- `--expose-paths`
+- `--realtime-rpc-tcp <addr>`
 
 If `--realm` is omitted, the server creates a new isolated opaque realm (`realm-...`).
+`--realm-backend` is a creation hint only; after first open, `realm_manifest.json`
+is authoritative.
 
 ## Endpoint overview
+
+This overview follows the generated OpenAPI artifact at
+`artifacts/schemas/rest-openapi.json`.
 
 | Method | Path | Description |
 |--------|------|-------------|
 | `POST` | `/sessions` | Create and run a new session |
 | `GET` | `/sessions` | List sessions |
 | `GET` | `/sessions/{id}` | Fetch session metadata and usage |
+| `GET` | `/sessions/{id}/status` | Fetch current runtime state for a session |
 | `GET` | `/sessions/{id}/history` | Fetch committed session transcript messages |
+| `GET` | `/sessions/{id}/realtime-attachment-status` | Fetch runtime-owned realtime attachment status |
 | `POST` | `/sessions/{id}/system_context` | Append staged runtime system context |
 | `POST` | `/sessions/{id}/messages` | Continue an existing session |
 | `POST` | `/sessions/{id}/external-events` | Queue a runtime-backed external event |
@@ -78,7 +91,9 @@ If `--realm` is omitted, the server creates a new isolated opaque realm (`realm-
 | `POST` | `/sessions/{id}/mcp/reload` | Reload MCP server(s) (mcp feature) |
 | `POST` | `/comms/send` | Push comms message into a session (comms feature) |
 | `GET` | `/comms/peers` | List discoverable peers (comms feature) |
+| `POST` | `/realtime/open_info` | Proxy realtime channel bootstrap to a configured `rkat-rpc` realtime host |
 | `POST` | `/realtime/status` | Read product-layer realtime status |
+| `POST` | `/realtime/capabilities` | Read product-layer realtime capabilities |
 | `GET` | `/auth/profiles` | List realm auth profiles, backend profiles, and bindings |
 | `POST` | `/auth/profiles` | Store binding-scoped credentials |
 | `GET` | `/auth/bindings/{binding_id}` | Read a binding-scoped auth profile |
@@ -101,6 +116,9 @@ If `--realm` is omitted, the server creates a new isolated opaque realm (`realm-
 | `POST` | `/mob/{id}/members/{agent_identity}/respawn` | Respawn a member (mob feature) |
 | `GET` | `/skills` | List skills with provenance |
 | `GET` | `/health` | Liveness check |
+| `GET` | `/runtime/host_info` | Read runtime host identity, endpoints, and realm projection |
+| `GET` | `/runtime/capabilities` | Read runtime host capability flags |
+| `GET` | `/runtime/health` | Read runtime host health |
 | `GET` | `/models/catalog` | Curated model catalog with provider profiles |
 | `GET` | `/capabilities` | Runtime capabilities |
 | `GET` | `/config` | Read config |
@@ -116,8 +134,9 @@ Generated images are not returned as inline bytes in history. `GET /sessions/{id
 REST keeps observation and helper endpoints for mobs, but typed lifecycle/control
 for app hosts lives on the canonical RPC/SDK `mob/*` surface. Inside running
 sessions, mob capability is still exposed by composing `meerkat-mob-mcp`
-(`MobMcpState` + `MobMcpDispatcher`) into `SessionBuildOptions.external_tools`
-in the host runtime.
+(`MobMcpState` + `AgentMobToolSurfaceFactory`) into
+`SessionBuildOptions.mob_tools` in the host runtime. `external_tools` remains
+reserved for callback and MCP-backed dispatchers.
 </Note>
 
 ## Request cancellation
@@ -535,7 +554,9 @@ Cancel an uncommitted in-flight request that previously supplied `X-Meerkat-Requ
 {"cancelled": true}
 ```
 
-Returns `404` if the session is not found, `409` if the session is not running.
+Returns `200` with `{"cancelled": false, "reason": "already_terminal"}` when
+the tracked request already published or completed. Returns `404` only when the
+request ID is unknown.
 
 ### DELETE /sessions/\{id\}
 
@@ -1180,12 +1201,42 @@ curl -X POST http://127.0.0.1:8080/sessions \
 ```
 
 The runtime attaches the OpenAI Realtime transport automatically and
-the status endpoint below reports `binding_ready` once the provider
+`GET /sessions/{id}/realtime-attachment-status` reports `binding_ready` once the provider
 confirms. There is no caller-initiated attach/detach endpoint — swap
 the session's model (or choose a realtime-capable default) to control
 whether the session runs in realtime mode. See the [Realtime
 guide](/guides/realtime) for the full capability-driven model, state
 machine, and reconfigure flow.
+
+### GET /sessions/{id}/realtime-attachment-status
+
+Read the runtime-owned attachment projection for a session.
+
+```json Response
+{
+  "status": "binding_ready"
+}
+```
+
+Status values: `unattached`, `intent_present_unbound`, `binding_not_ready`,
+`binding_ready`, `replacement_pending`, and `reattach_required`.
+
+### POST /realtime/open_info
+
+Proxy a product-layer `realtime/open_info` request to the configured
+`rkat-rpc --tcp ... --realtime-ws ...` host.
+
+```bash
+curl -X POST http://127.0.0.1:8080/realtime/open_info \
+  -H 'content-type: application/json' \
+  -d '{"target":{"type":"session_target","session_id":"01936f8a-7b2c-7000-8000-000000000001"},"role":"primary","turning_mode":"provider_managed"}'
+```
+
+`/realtime/status` and `/realtime/capabilities` use
+`{"target":{"type":"session_target","session_id":"..."}}`; mob-member targets
+use `{"target":{"type":"mob_member","mob_id":"...","agent_identity":"..."}}`.
+If `--realtime-rpc-tcp` is not configured on `rkat-rest`, these product-layer
+routes return an unavailable transport error.
 
 ## Error responses
 

--- a/docs/api/rpc.mdx
+++ b/docs/api/rpc.mdx
@@ -67,6 +67,11 @@ rkat-rpc [--realm <id>] [--isolated] [--instance <id>] [--realm-backend <sqlite|
 
 ## Method overview
 
+This table mirrors the generated catalog in `artifacts/schemas/rpc-methods.json`
+(`meerkat_contracts::rpc_method_catalog`). `initialize` returns the methods
+enabled in the running binary, so reduced or feature-limited builds expose a
+subset.
+
 | Method | Category | Description |
 |--------|----------|-------------|
 | `initialize` | Handshake | Returns server capabilities |
@@ -118,10 +123,6 @@ rkat-rpc [--realm <id>] [--isolated] [--instance <id>] [--realm-backend <sqlite|
 | `mob/member_send` | Mob | Deliver ordinary content to a specific mob member via the host control plane (mob feature) |
 | `mob/append_system_context` | Mob | Stage system context for a member session (mob feature) |
 | `mob/flows` | Mob | List mob flows (mob feature) |
-
-<Note>
-Generated assistant images use the same surface-neutral history and blob APIs as other blob-backed artifacts. Read `session/history`, find assistant blocks with `block_type: "image"`, then call `blob/get` with `data.blob_ref.blob_id` to retrieve the base64 payload.
-</Note>
 | `mob/flow_run` | Mob | Start a mob flow run (mob feature) |
 | `mob/flow_status` | Mob | Get flow run status (mob feature) |
 | `mob/flow_cancel` | Mob | Cancel a flow run (mob feature) |
@@ -182,6 +183,10 @@ Generated assistant images use the same surface-neutral history and blob APIs as
 | `realm/get` | Realm | Get full realm connection set |
 
 <Note>
+Generated assistant images use the same surface-neutral history and blob APIs as other blob-backed artifacts. Read `session/history`, find assistant blocks with `block_type: "image"`, then call `blob/get` with `data.blob_ref.blob_id` to retrieve the base64 payload.
+</Note>
+
+<Note>
 Realtime is a delivery mode of the session's LLM, driven by
 `ModelCapabilities.realtime`. To enable realtime audio on a session,
 create the session with a realtime-capable model (for example
@@ -191,7 +196,7 @@ There is no caller-initiated attach/detach RPC.
 </Note>
 
 <Note>
-RPC is the canonical typed substrate for the SDKs: use explicit `mob/*` lifecycle, host-ingress, and observation methods from apps. Inside running sessions, mob capability is still exposed by composing `meerkat-mob-mcp` (`MobMcpState` + `MobMcpDispatcher`) into `SessionBuildOptions.external_tools`, which provides `mob_*` tools to the agent.
+RPC is the canonical typed substrate for the SDKs: use explicit `mob/*` lifecycle, host-ingress, and observation methods from apps. Inside running sessions, mob capability is exposed by composing `meerkat-mob-mcp` (`MobMcpState` + `AgentMobToolSurfaceFactory`) into `SessionBuildOptions.mob_tools`, which provides authorized `mob_*` tools to the agent. `external_tools` remains for callback and MCP-backed tool dispatchers.
 </Note>
 
 ## Protocol
@@ -250,34 +255,19 @@ Handshake. Returns server capabilities.
     "contract_version": "0.6.0",
     "methods": [
       "initialize", "initialized",
-      "session/create", "session/list", "session/read", "session/history",
-      "session/archive", "session/external_event", "session/peer_response_terminal", "session/inject_context",
-      "blob/get",
+      "session/create", "session/list", "session/read",
       "turn/start", "turn/interrupt",
-      "config/get", "config/set", "config/patch",
-      "capabilities/get", "models/catalog",
-      "skills/list",
-      "realtime/open_info", "realtime/status", "realtime/capabilities",
-      "session/realtime_attachment_status",
-      "session/stream_open", "session/stream_close",
-      "mob/create", "mob/list", "mob/status",
-      "mob/members", "mob/spawn", "mob/spawn_many",
-      "mob/retire", "mob/respawn",
-      "mob/wire", "mob/unwire", "mob/lifecycle",
-      "mob/events", "mob/stream_open", "mob/stream_close",
-      "mob/member_send", "mob/append_system_context", "mob/flows", "mob/flow_run",
-      "mob/flow_status", "mob/flow_cancel",
-      "mob/spawn_helper", "mob/fork_helper", "mob/force_cancel", "mob/member_status",
-      "mob/wait_kickoff", "mob/wait_ready", "mob/turn_start",
-      "mob/profile/create", "mob/profile/get", "mob/profile/list",
-      "mob/profile/update", "mob/profile/delete",
-      "mcp/add", "mcp/remove", "mcp/reload",
-      "comms/send", "comms/peers",
+      "runtime/host_info", "config/get",
+      "realtime/open_info", "mob/create"
     ]
   }
 }
 ```
 </CodeGroup>
+
+The actual array contains every method compiled into the server. For the full
+documented list and parameter/result type names, use
+`artifacts/schemas/rpc-methods.json`.
 
 <ResponseField name="server_info.name" type="string">
   Server name.
@@ -897,7 +887,6 @@ Read the runtime-owned realtime attachment status projection for a session.
   "jsonrpc": "2.0",
   "id": 22,
   "result": {
-    "session_id": "01936f8a-7b2c-7000-8000-000000000001",
     "status": "binding_ready"
   }
 }

--- a/docs/concepts/tools.mdx
+++ b/docs/concepts/tools.mdx
@@ -161,12 +161,12 @@ Tools from different sources (custom, MCP, built-in) are composed into a single 
 ## Mob tools (`meerkat-mob-mcp`)
 
 Mob tools (`mob_*`) are provided by the `meerkat-mob-mcp` dispatcher and composed
-through `SessionBuildOptions.external_tools`.
+through the late-bound `SessionBuildOptions.mob_tools` factory slot.
 
 - CLI `run` composes this dispatcher when the `full` tool preset is selected (`--tools full` or `--yolo`).
 - `rkat mob ...` remains the explicit direct lifecycle surface.
 - Other session-driven surfaces can grant the same agent-side `mob_*` capability
-  by composing `MobMcpDispatcher` into their session build path.
+  by installing `AgentMobToolSurfaceFactory` into their session build path.
 - Public host APIs should not re-export that raw dispatcher. They use typed
   control planes instead: `mob/*` on RPC/SDK surfaces and `meerkat_mob_*` on
   public MCP surfaces.

--- a/docs/reference/api-reference.mdx
+++ b/docs/reference/api-reference.mdx
@@ -6,6 +6,37 @@ icon: "book"
 
 This page is a quick-lookup index. For current session/runtime semantics, see [Session contracts](/reference/session-contracts). For detailed usage with examples, see the [Rust SDK reference](/rust/overview).
 
+## Generated wire catalogs
+
+The public protocol catalogs are generated from `meerkat-contracts` and
+committed with the repository:
+
+| Artifact | Source | Purpose |
+|----------|--------|---------|
+| `artifacts/schemas/rpc-methods.json` | `meerkat_contracts::rpc_method_catalog` | Canonical JSON-RPC method names, descriptions, parameter types, result types, and request lifecycle rules |
+| `artifacts/schemas/rest-openapi.json` | REST router/OpenAPI emission | Canonical HTTP paths, methods, summaries, and schema references |
+| `artifacts/schemas/wire-types.json` | `meerkat-contracts` schemas | Wire request/result/event types shared by protocol and SDK layers |
+| `artifacts/schemas/errors.json` | `meerkat-contracts` error catalog | Stable wire error strings, JSON-RPC codes, HTTP statuses, and CLI exits |
+| `artifacts/schemas/runtime-host.json` | Runtime host schema emission | Runtime host info, capability, and health projections |
+
+`rkat-rpc initialize` returns the compiled feature subset at runtime. The
+catalog above is the full documented surface with blob, sessions, events,
+streams, schedule, skills, runtime, realtime, mob, MCP, comms, auth, realm, and
+approval methods enabled.
+
+## Surface entry points
+
+| Surface | API authority |
+|---------|---------------|
+| CLI | `rkat` commands in [CLI commands](/cli/commands); `rkat-mini` is the reduced CLI build |
+| REST | HTTP paths in [REST API](/api/rest) and `artifacts/schemas/rest-openapi.json` |
+| JSON-RPC | `rkat-rpc` methods in [JSON-RPC API](/api/rpc) and `artifacts/schemas/rpc-methods.json` |
+| MCP | `rkat-mcp` public `meerkat_*` tools in [MCP](/api/mcp) |
+| Rust SDK | `SessionService`, `AgentFactory`, and runtime build modes in [Rust SDK overview](/rust/overview) |
+| Python SDK | Async wrappers over `rkat-rpc`; see [Python SDK reference](/sdks/python/reference) |
+| TypeScript SDK | Node wrappers over `rkat-rpc`; see [TypeScript SDK reference](/sdks/typescript/reference) |
+| Web SDK | Browser/WASM runtime and mobpack deployment target; see [WASM example](/examples/wasm) |
+
 ## Core types
 
 | Type | Module | Purpose |
@@ -29,6 +60,10 @@ This page is a quick-lookup index. For current session/runtime semantics, see [S
 | `RetryPolicy` | `meerkat_core` | Exponential backoff configuration |
 | `RuntimeBuildMode` | `meerkat_core` | Explicit runtime ownership mode (`SessionOwned` vs `StandaloneEphemeral`) |
 | `SessionRuntimeBindings` | `meerkat_core` | Runtime-backed session bindings (`session_id`, `epoch_id`, ops lifecycle, cursor state) |
+| `SessionBuildOptions` | `meerkat_core::service` | Build-time surface options including provider params, structured output, hooks, skills, auth binding, external callback/MCP tools, mob tools, schedule tools, and runtime mode |
+| `AuthBindingRef` | `meerkat_core` | Realm-scoped provider credential binding reference carried by sessions and mob members |
+| `BlobPayload` | `meerkat_core` | Blob metadata and bytes returned by blob fetch APIs |
+| `ArtifactRecord` | `meerkat_core` | Stable artifact metadata for blob-backed generated content |
 | `MobRun` | `meerkat_mob` | Persisted flow run aggregate |
 | `MobRunStatus` | `meerkat_mob` | Flow run lifecycle (`pending`, `running`, `completed`, `failed`, `canceled`) |
 | `StepLedgerEntry` | `meerkat_mob` | Per-target step execution record |
@@ -188,7 +223,8 @@ fn with_mob_tools(session_service: Arc<dyn MobSessionService>) -> SessionBuildOp
 
 This is the in-session mechanism for granting `mob_*` tools to the agent.
 `external_tools` remains the surface for custom callback tools and MCP-backed
-dispatchers; mob orchestration now has its own late-bound factory slot.
+dispatchers. Mob orchestration has its own late-bound `mob_tools` factory slot,
+which receives session-scoped runtime authority before producing the dispatcher.
 
 Public host surfaces use typed control planes instead:
 
@@ -202,6 +238,17 @@ For mob-only MCP hosts, `meerkat-mob-mcp` also exposes:
 
 Those helpers are for public host control-plane tools. `MobMcpDispatcher`
 remains the agent-side `mob_*` tool surface.
+
+### Public mob host methods
+
+Public application hosts should use the typed control planes rather than the
+agent-internal `mob_*` tool dispatcher:
+
+| Surface | Contract |
+|---------|----------|
+| JSON-RPC / SDKs | `mob/create`, `mob/list`, `mob/status`, `mob/lifecycle`, `mob/spawn`, `mob/spawn_many`, `mob/ensure_member`, `mob/reconcile`, `mob/list_members_matching`, `mob/retire`, `mob/respawn`, `mob/wire`, `mob/unwire`, `mob/member_send`, `mob/turn_start`, `mob/ingress_interaction`, `mob/events`, `mob/stream_open`, `mob/stream_close`, flow, work-lane, wait, snapshot, destroy, supervisor, and profile methods |
+| MCP | `meerkat_mob_*` tools from `meerkat-mob-mcp::public_tools_list()` plus MCP event stream tools from `rkat-mcp` |
+| REST | Helper and observation endpoints (`/mob/{id}/events`, helper spawn/fork, member status/cancel/respawn, wait kickoff); full typed lifecycle remains RPC/SDK |
 
 For cross-surface behavior and examples (CLI/RPC/REST/MCP/Python/TypeScript), see [Mobs](/guides/mobs).
 

--- a/docs/reference/architecture.mdx
+++ b/docs/reference/architecture.mdx
@@ -4,7 +4,7 @@ description: "Current Meerkat architecture: execution path, canonical machines, 
 icon: "layer-group"
 ---
 
-Meerkat is a library-first agent runtime. The same execution substrate powers the CLI, REST, JSON-RPC, MCP, Rust embedding, and the SDKs layered on top of `rkat-rpc`.
+Meerkat is a library-first agent runtime. The same execution substrate powers the CLI, mini CLI, REST, JSON-RPC, mini RPC, MCP, Rust embedding, Python/TypeScript SDKs layered on top of `rkat-rpc`, and the browser/WASM runtime.
 
 <Note>
 The architecture working dump under `docs/architecture/two-kernel-research/` was retired during the April 2026 docs cleanup. The canonical sources of truth are the machine catalog, generated specs, and the doctrine/ADR documents linked from this page.
@@ -18,6 +18,8 @@ graph TD
     MACHINE --> BINDINGS["prepare_bindings(session_id)"]
     BINDINGS --> SERVICE["SessionService::create_session / start_turn"]
     SERVICE --> FACTORY["AgentFactory::build_agent()"]
+    WEB["Web SDK / WASM"] --> EPHEMERAL["EphemeralSessionService"]
+    EPHEMERAL --> FACTORY
     FACTORY --> AGENT["Agent loop"]
 
     AGENT --> PROVIDERS["LLM adapters"]
@@ -34,6 +36,53 @@ Runtime-backed surfaces prepare session-owned runtime bindings through
 session-scoped agent with the resolved provider, tool surface, memory/hooks/skills,
 and optional mob tooling.
 
+## Surface topology
+
+| Surface | Runtime mode | Primary contract |
+|---------|--------------|------------------|
+| `rkat` CLI | Runtime-backed | Developer and automation workflows over the shared session service |
+| `rkat-mini` | Runtime-backed reduced build | Smaller CLI command set for embeddable/product distributions |
+| `rkat-rpc` | Runtime-backed | JSON-RPC 2.0 over stdio/TCP, SDK backend, optional realtime WebSocket bootstrap |
+| `rkat-rpc-mini` | Runtime-backed reduced build | Core session/config/catalog/capability RPC subset |
+| `rkat-rest` | Runtime-backed | HTTP/SSE adapter over the same session, schedule, auth, config, comms, and limited mob helper surfaces |
+| `rkat-mcp` | Runtime-backed | Public `meerkat_*` MCP tools backed by `SessionService` plus typed public mob tools when compiled |
+| Rust SDK | Runtime-backed or standalone | Direct `SessionService` embedding; `StandaloneEphemeral` is explicit for tests and local-only embeddings |
+| Python / TypeScript SDKs | Runtime-backed | Process-manage or connect to `rkat-rpc`, then expose typed client wrappers |
+| Web SDK / WASM | Standalone/browser | In-browser sessions, mobs, subscriptions, JS tools, and mobpack deployment target without filesystem or TCP access |
+
+`initialize` and generated protocol artifacts expose the active surface subset.
+The full documented RPC catalog is committed at `artifacts/schemas/rpc-methods.json`,
+and REST paths are committed at `artifacts/schemas/rest-openapi.json`.
+
+## Realm, session, and storage model
+
+`realm_id` is the sharing key across surfaces. CLI `run`/`resume` and `session`
+commands use a workspace-derived realm by default; RPC, REST, MCP, and SDK
+hosts create a new opaque realm unless the caller passes an explicit realm.
+Within a realm, sessions, config, auth profiles/bindings, schedules, blobs, and
+mob state share the same persistent root.
+
+Persistent realms are pinned once in `realm_manifest.json` to `sqlite` or
+`jsonl`. When SQLite support is compiled, new persistent realms default to
+SQLite because it is the normal same-realm multi-process backend. JSONL remains
+an explicit inspectable backend. Standalone/test/WASM paths use local ephemeral
+state unless the embedding provides a store.
+
+## Runtime subsystems
+
+| Subsystem | Runtime boundary |
+|-----------|------------------|
+| Sessions | `SessionService` owns create/turn/read/list/archive/interrupt; runtime-backed surfaces enter through `MeerkatMachine` bindings |
+| Providers and auth | Provider selection resolves through model profiles and realm-scoped `auth_binding`/AuthMachine state; env keys remain a bootstrap path |
+| Tools | Builtins, shell, MCP-backed tools, callback tools, and provider-native tools compose through dispatchers and tool visibility policy |
+| Hooks | Hook entries run through the session build path with typed hook points, capability modes, and failure policy |
+| Skills | Skill sources are resolved from runtime/context roots and injected as structured skill references with provenance |
+| Memory | Semantic memory and compaction are optional build-time capabilities attached to the factory/session service |
+| Scheduling | `meerkat-schedule` materializes sessions or mobs from durable trigger/target/policy records |
+| Mobs | `meerkat-mob` owns roster, lifecycle, wiring, flows, task board, and member runtime bindings; public host surfaces use typed `mob/*` or `meerkat_mob_*` control planes |
+| Realtime | Model capability drives OpenAI Realtime attach/detach; RPC owns the audio WebSocket bootstrap and runtime status is observed through attachment projections |
+| Blobs/artifacts | Blob-backed content, including generated images, is stored in the realm blob store and exposed through history plus blob/artifact APIs |
+
 ## Architectural rules
 
 - `meerkat-core` owns the primary contracts and keeps zero network or filesystem dependencies.
@@ -41,6 +90,7 @@ and optional mob tooling.
 - Runtime-backed surfaces own runtime semantics; standalone Rust/WASM paths opt into explicit ephemeral mode instead of silently emulating the runtime.
 - Mob orchestration is the multi-agent runtime path; member identity is stable via `AgentIdentity`, while live runtime bindings rotate through `AgentRuntimeId` plus `FenceToken`.
 - Public realtime APIs are capability-driven: a session becomes realtime by selecting a model with `ModelCapabilities.realtime == true`.
+- Public app hosts should use typed control planes (`mob/*`, `schedule/*`, REST schedule endpoints, MCP `meerkat_*` tools). Agent-facing orchestration tools are injected separately into running sessions.
 
 ## Canonical machines
 

--- a/meerkat-contracts/src/rest_catalog.rs
+++ b/meerkat-contracts/src/rest_catalog.rs
@@ -105,6 +105,13 @@ pub fn rest_path_catalog() -> Vec<RestPathDescriptor> {
             vec![RestOperationDescriptor::new("get", "SSE event stream")],
         ),
         RestPathDescriptor::new(
+            "/requests/{request_id}/cancel",
+            vec![RestOperationDescriptor::new(
+                "post",
+                "Cancel an uncommitted in-flight request",
+            )],
+        ),
+        RestPathDescriptor::new(
             "/schedule/tools",
             vec![RestOperationDescriptor::new("get", "List schedule tools")],
         ),

--- a/meerkat-rest/tests/rest_catalog_regression.rs
+++ b/meerkat-rest/tests/rest_catalog_regression.rs
@@ -10,6 +10,7 @@ fn documented_rest_surface_keeps_live_config_and_member_routes() {
         "/runtime/host_info",
         "/runtime/capabilities",
         "/runtime/health",
+        "/requests/{request_id}/cancel",
         "/mob/{id}/members/{agent_identity}/status",
         "/mob/{id}/members/{agent_identity}/cancel",
         "/mob/{id}/members/{agent_identity}/respawn",


### PR DESCRIPTION
## Summary
- Refresh architecture and API reference docs around runtime-backed surfaces, Web/WASM boundaries, realm storage, subsystems, and generated wire catalogs.
- Bring REST/RPC/MCP docs back in line with current generated catalogs and realtime/mob tool contracts.
- Add the live REST request-cancel route to `rest_path_catalog`, regenerate `rest-openapi.json`, and pin it in the REST catalog regression.

## Validation
- `make check` (BuildBuddy invocation `d55f5fa6-9dc1-4e47-998e-9ae1c55f8c20`)
- `make regen-schemas`
- `make verify-schema-freshness`
- `make verify-rpc-surface-alignment`
- `./scripts/repo-cargo test -p meerkat-rest documented_rest_surface_keeps_live_config_and_member_routes`
- `git diff --check`
- REST docs endpoint overview compared against `artifacts/schemas/rest-openapi.json`

## Reviewer gate
- Architecture/API reviewer: approved after rework
- API surface reviewer: approved after rework
- Docs-quality reviewer: approved after rework

Linear: LUC-407