### PR TITLE
LUC-408 Dogma

### DIFF
--- a/meerkat-tools/src/builtin/skills/browse.rs
+++ b/meerkat-tools/src/builtin/skills/browse.rs
@@ -9,7 +9,7 @@ use std::sync::Arc;
 
 use async_trait::async_trait;
 use meerkat_core::ToolDef;
-use meerkat_core::skills::{SkillFilter, SkillRuntime};
+use meerkat_core::skills::{SkillFilter, SkillRuntime, SourceUuid};
 use meerkat_core::types::{ToolProvenance, ToolSourceKind};
 use serde::Deserialize;
 use serde_json::{Value, json};
@@ -17,7 +17,6 @@ use serde_json::{Value, json};
 use crate::builtin::{BuiltinTool, BuiltinToolError, ToolOutput};
 
 #[derive(Debug, Deserialize, schemars::JsonSchema)]
-#[allow(dead_code)]
 struct BrowseSkillsArgs {
     /// Free-text search across skill names and descriptions.
     #[serde(default)]
@@ -62,19 +61,20 @@ impl BuiltinTool for BrowseSkillsTool {
     }
 
     async fn call(&self, args: Value) -> Result<ToolOutput, BuiltinToolError> {
-        let query = args
-            .get("query")
-            .and_then(|v| v.as_str())
-            .map(ToString::to_string);
-        let source_uuid = match args.get("source_uuid").and_then(|v| v.as_str()) {
+        let args: BrowseSkillsArgs = serde_json::from_value(args)
+            .map_err(|err| BuiltinToolError::InvalidArgs(err.to_string()))?;
+        let source_uuid = match args.source_uuid.as_deref() {
             Some(raw) => Some(
-                meerkat_core::skills::SourceUuid::parse(raw)
+                SourceUuid::parse(raw)
                     .map_err(|e| BuiltinToolError::ExecutionFailed(e.to_string()))?,
             ),
             None => None,
         };
 
-        let filter = SkillFilter { query, source_uuid };
+        let filter = SkillFilter {
+            query: args.query,
+            source_uuid,
+        };
 
         let entries = self
             .engine

--- a/meerkat-tools/src/builtin/skills/functions.rs
+++ b/meerkat-tools/src/builtin/skills/functions.rs
@@ -15,7 +15,6 @@ use serde_json::{Value, json};
 use crate::builtin::{BuiltinTool, BuiltinToolError, ToolOutput};
 
 #[derive(Debug, Deserialize, schemars::JsonSchema)]
-#[allow(dead_code)]
 struct SkillInvokeFunctionArgs {
     source_uuid: String,
     skill_name: String,
@@ -34,15 +33,7 @@ impl SkillInvokeFunctionTool {
     }
 }
 
-fn parse_key(args: &Value) -> Result<SkillKey, BuiltinToolError> {
-    let source_raw = args
-        .get("source_uuid")
-        .and_then(|v| v.as_str())
-        .ok_or_else(|| BuiltinToolError::InvalidArgs("missing 'source_uuid'".into()))?;
-    let skill_raw = args
-        .get("skill_name")
-        .and_then(|v| v.as_str())
-        .ok_or_else(|| BuiltinToolError::InvalidArgs("missing 'skill_name'".into()))?;
+fn parse_key(source_raw: &str, skill_raw: &str) -> Result<SkillKey, BuiltinToolError> {
     let source_uuid =
         SourceUuid::parse(source_raw).map_err(|e| BuiltinToolError::InvalidArgs(e.to_string()))?;
     let skill_name =
@@ -79,13 +70,9 @@ impl BuiltinTool for SkillInvokeFunctionTool {
     }
 
     async fn call(&self, args: Value) -> Result<ToolOutput, BuiltinToolError> {
-        let raw_key = parse_key(&args)?;
-        let function_name = args
-            .get("function_name")
-            .and_then(|v| v.as_str())
-            .ok_or_else(|| {
-                BuiltinToolError::InvalidArgs("missing 'function_name' parameter".into())
-            })?;
+        let args: SkillInvokeFunctionArgs = serde_json::from_value(args)
+            .map_err(|err| BuiltinToolError::InvalidArgs(err.to_string()))?;
+        let raw_key = parse_key(&args.source_uuid, &args.skill_name)?;
         // Apply source-identity lineage remaps before dispatch.
         let key = self
             .engine
@@ -94,18 +81,14 @@ impl BuiltinTool for SkillInvokeFunctionTool {
             .map_err(|e| BuiltinToolError::ExecutionFailed(e.to_string()))?;
         let output = self
             .engine
-            .invoke_function(
-                &key,
-                function_name,
-                args.get("arguments").cloned().unwrap_or(Value::Null),
-            )
+            .invoke_function(&key, &args.function_name, args.arguments)
             .await
             .map_err(|e| BuiltinToolError::ExecutionFailed(e.to_string()))?;
 
         Ok(ToolOutput::Json(json!({
             "source_uuid": key.source_uuid.to_string(),
             "skill_name": key.skill_name.as_str(),
-            "function_name": function_name,
+            "function_name": args.function_name,
             "output": output,
         })))
     }

--- a/meerkat-tools/src/builtin/skills/load.rs
+++ b/meerkat-tools/src/builtin/skills/load.rs
@@ -16,7 +16,6 @@ use serde_json::{Value, json};
 use crate::builtin::{BuiltinTool, BuiltinToolError, ToolOutput};
 
 #[derive(Debug, Deserialize, schemars::JsonSchema)]
-#[allow(dead_code)]
 struct LoadSkillArgs {
     source_uuid: String,
     skill_name: String,
@@ -33,15 +32,7 @@ impl LoadSkillTool {
     }
 }
 
-fn parse_key(args: &Value) -> Result<SkillKey, BuiltinToolError> {
-    let source_raw = args
-        .get("source_uuid")
-        .and_then(|v| v.as_str())
-        .ok_or_else(|| BuiltinToolError::InvalidArgs("missing 'source_uuid'".into()))?;
-    let skill_raw = args
-        .get("skill_name")
-        .and_then(|v| v.as_str())
-        .ok_or_else(|| BuiltinToolError::InvalidArgs("missing 'skill_name'".into()))?;
+fn parse_key(source_raw: &str, skill_raw: &str) -> Result<SkillKey, BuiltinToolError> {
     let source_uuid =
         SourceUuid::parse(source_raw).map_err(|e| BuiltinToolError::InvalidArgs(e.to_string()))?;
     let skill_name =
@@ -78,7 +69,9 @@ impl BuiltinTool for LoadSkillTool {
     }
 
     async fn call(&self, args: Value) -> Result<ToolOutput, BuiltinToolError> {
-        let raw_key = parse_key(&args)?;
+        let args: LoadSkillArgs = serde_json::from_value(args)
+            .map_err(|err| BuiltinToolError::InvalidArgs(err.to_string()))?;
+        let raw_key = parse_key(&args.source_uuid, &args.skill_name)?;
         // Apply the source-identity lineage remap chain before dispatch
         // so legacy source_uuids that have since been rotated/merged
         // still resolve to the canonical backing skill.

--- a/meerkat-tools/src/builtin/skills/resources.rs
+++ b/meerkat-tools/src/builtin/skills/resources.rs
@@ -15,29 +15,19 @@ use serde_json::{Value, json};
 use crate::builtin::{BuiltinTool, BuiltinToolError, ToolOutput};
 
 #[derive(Debug, Deserialize, schemars::JsonSchema)]
-#[allow(dead_code)]
 struct SkillListResourcesArgs {
     source_uuid: String,
     skill_name: String,
 }
 
 #[derive(Debug, Deserialize, schemars::JsonSchema)]
-#[allow(dead_code)]
 struct SkillReadResourceArgs {
     source_uuid: String,
     skill_name: String,
     path: String,
 }
 
-fn parse_key(args: &Value) -> Result<SkillKey, BuiltinToolError> {
-    let source_raw = args
-        .get("source_uuid")
-        .and_then(|v| v.as_str())
-        .ok_or_else(|| BuiltinToolError::InvalidArgs("missing 'source_uuid'".into()))?;
-    let skill_raw = args
-        .get("skill_name")
-        .and_then(|v| v.as_str())
-        .ok_or_else(|| BuiltinToolError::InvalidArgs("missing 'skill_name'".into()))?;
+fn parse_key(source_raw: &str, skill_raw: &str) -> Result<SkillKey, BuiltinToolError> {
     let source_uuid =
         SourceUuid::parse(source_raw).map_err(|e| BuiltinToolError::InvalidArgs(e.to_string()))?;
     let skill_name =
@@ -93,7 +83,9 @@ impl BuiltinTool for SkillListResourcesTool {
     }
 
     async fn call(&self, args: Value) -> Result<ToolOutput, BuiltinToolError> {
-        let raw_key = parse_key(&args)?;
+        let args: SkillListResourcesArgs = serde_json::from_value(args)
+            .map_err(|err| BuiltinToolError::InvalidArgs(err.to_string()))?;
+        let raw_key = parse_key(&args.source_uuid, &args.skill_name)?;
         // Apply source-identity lineage remaps before dispatch.
         let key = self
             .engine
@@ -139,11 +131,9 @@ impl BuiltinTool for SkillReadResourceTool {
     }
 
     async fn call(&self, args: Value) -> Result<ToolOutput, BuiltinToolError> {
-        let raw_key = parse_key(&args)?;
-        let path = args
-            .get("path")
-            .and_then(|v| v.as_str())
-            .ok_or_else(|| BuiltinToolError::InvalidArgs("missing 'path' parameter".into()))?;
+        let args: SkillReadResourceArgs = serde_json::from_value(args)
+            .map_err(|err| BuiltinToolError::InvalidArgs(err.to_string()))?;
+        let raw_key = parse_key(&args.source_uuid, &args.skill_name)?;
         // Apply source-identity lineage remaps before dispatch.
         let key = self
             .engine
@@ -152,7 +142,7 @@ impl BuiltinTool for SkillReadResourceTool {
             .map_err(|e| BuiltinToolError::ExecutionFailed(e.to_string()))?;
         let artifact = self
             .engine
-            .read_artifact(&key, path)
+            .read_artifact(&key, &args.path)
             .await
             .map_err(|e| BuiltinToolError::ExecutionFailed(e.to_string()))?;
         Ok(ToolOutput::Json(json!({

--- a/meerkat-tools/tests/browse_load_surface.rs
+++ b/meerkat-tools/tests/browse_load_surface.rs
@@ -1,13 +1,11 @@
 #![allow(clippy::panic)]
 
-//! Browse / load skill tool surface tests (C-T §6 #15).
+//! Skill builtin tool surface tests (C-T §6 #15).
 //!
-//! Covers the agent-facing tools `browse_skills` + `load_skill` exposed
-//! by `meerkat-tools::builtin::skills`. Post-V4 the surface is strictly
-//! typed: every identifier on the wire is `SkillKey = (SourceUuid,
-//! SkillName)`, no slash-path parsing. These tests ride the real
-//! `SkillRuntime` over an `InMemorySkillSource` so the BuiltinTool
-//! contract (def / call / output shape) is exercised end-to-end.
+//! Covers the agent-facing tools exposed by
+//! `meerkat-tools::builtin::skills`. Post-V4 the surface is strictly typed:
+//! every identifier on the wire is `SkillKey = (SourceUuid, SkillName)`, no
+//! slash-path parsing.
 //!
 //! Cases:
 //! - browse with no filter returns every listed skill.
@@ -26,13 +24,16 @@ use std::sync::Arc;
 
 use indexmap::IndexMap;
 use meerkat_core::skills::{
-    SkillDescriptor, SkillDocument, SkillKey, SkillName, SkillRuntime, SkillScope,
-    SourceIdentityRecord, SourceIdentityRegistry, SourceIdentityStatus, SourceTransportKind,
-    SourceUuid,
+    SkillArtifact, SkillArtifactContent, SkillDescriptor, SkillDocument, SkillError, SkillFilter,
+    SkillKey, SkillName, SkillRuntime, SkillScope, SkillSource, SourceIdentityRecord,
+    SourceIdentityRegistry, SourceIdentityStatus, SourceTransportKind, SourceUuid, apply_filter,
 };
 use meerkat_skills::{DefaultSkillEngine, InMemorySkillSource};
 use meerkat_tools::BuiltinTool;
-use meerkat_tools::builtin::skills::{BrowseSkillsTool, LoadSkillTool};
+use meerkat_tools::builtin::skills::{
+    BrowseSkillsTool, LoadSkillTool, SkillInvokeFunctionTool, SkillListResourcesTool,
+    SkillReadResourceTool,
+};
 
 fn skill_doc(source: &SourceUuid, skill: &str, display: &str, body: &str) -> SkillDocument {
     SkillDocument {
@@ -108,6 +109,103 @@ fn runtime_with_unknown_source_identity() -> (Arc<SkillRuntime>, SourceUuid) {
     let engine = DefaultSkillEngine::new(source, Vec::new())
         .with_source_identity_registry(Arc::new(SourceIdentityRegistry::default()));
     (Arc::new(SkillRuntime::new(Arc::new(engine))), unknown)
+}
+
+struct HarnessSkillSource {
+    doc: SkillDocument,
+}
+
+impl HarnessSkillSource {
+    fn new(source: &SourceUuid) -> Self {
+        Self {
+            doc: skill_doc(source, "alpha", "Alpha", "# Alpha\n\nbody-alpha"),
+        }
+    }
+
+    fn artifact(&self) -> SkillArtifact {
+        SkillArtifact {
+            path: "README.md".to_string(),
+            mime_type: "text/markdown".to_string(),
+            byte_length: 12,
+        }
+    }
+
+    fn require_key(&self, key: &SkillKey) -> Result<(), SkillError> {
+        if key == &self.doc.descriptor.key {
+            Ok(())
+        } else {
+            Err(SkillError::NotFound { key: key.clone() })
+        }
+    }
+}
+
+impl SkillSource for HarnessSkillSource {
+    async fn list(&self, filter: &SkillFilter) -> Result<Vec<SkillDescriptor>, SkillError> {
+        Ok(apply_filter(&[self.doc.descriptor.clone()], filter))
+    }
+
+    async fn load(&self, key: &SkillKey) -> Result<SkillDocument, SkillError> {
+        self.require_key(key)?;
+        Ok(self.doc.clone())
+    }
+
+    async fn list_artifacts(&self, key: &SkillKey) -> Result<Vec<SkillArtifact>, SkillError> {
+        self.require_key(key)?;
+        Ok(vec![self.artifact()])
+    }
+
+    async fn read_artifact(
+        &self,
+        key: &SkillKey,
+        artifact_path: &str,
+    ) -> Result<SkillArtifactContent, SkillError> {
+        self.require_key(key)?;
+        if artifact_path != "README.md" {
+            return Err(SkillError::Load(
+                format!("missing artifact: {artifact_path}").into(),
+            ));
+        }
+        Ok(SkillArtifactContent {
+            path: artifact_path.to_string(),
+            mime_type: "text/markdown".to_string(),
+            content: "artifact body".to_string(),
+        })
+    }
+
+    async fn invoke_function(
+        &self,
+        key: &SkillKey,
+        function_name: &str,
+        arguments: serde_json::Value,
+    ) -> Result<serde_json::Value, SkillError> {
+        self.require_key(key)?;
+        if function_name != "echo" {
+            return Err(SkillError::Load(
+                format!("missing function: {function_name}").into(),
+            ));
+        }
+        Ok(serde_json::json!({ "received": arguments }))
+    }
+}
+
+fn harness_runtime() -> (Arc<SkillRuntime>, SourceUuid) {
+    let source = SourceUuid::parse("dc256086-0d2f-4f61-a307-320d4148107f").unwrap();
+    let registry = SourceIdentityRegistry::build(
+        vec![SourceIdentityRecord {
+            source_uuid: source.clone(),
+            display_name: "harness fixture".to_string(),
+            transport_kind: SourceTransportKind::Filesystem,
+            fingerprint: format!("fixture:{source}"),
+            status: SourceIdentityStatus::Active,
+        }],
+        Vec::new(),
+        Vec::new(),
+        Vec::new(),
+    )
+    .unwrap();
+    let engine = DefaultSkillEngine::new(HarnessSkillSource::new(&source), Vec::new())
+        .with_source_identity_registry(Arc::new(registry));
+    (Arc::new(SkillRuntime::new(Arc::new(engine))), source)
 }
 
 #[tokio::test]
@@ -322,4 +420,111 @@ async fn browse_output_always_carries_typed_key_fields() {
         SourceUuid::parse(obj["source_uuid"].as_str().unwrap()).unwrap();
         SkillName::parse(obj["skill_name"].as_str().unwrap()).unwrap();
     }
+}
+
+#[tokio::test]
+async fn list_resources_returns_artifact_metadata_for_known_skill() {
+    let (runtime, source) = harness_runtime();
+    let tool = SkillListResourcesTool::new(runtime);
+
+    let output = tool
+        .call(serde_json::json!({
+            "source_uuid": source.to_string(),
+            "skill_name": "alpha",
+        }))
+        .await
+        .unwrap();
+    let json = output.into_json().unwrap();
+    let artifacts = json["artifacts"].as_array().unwrap();
+
+    assert_eq!(artifacts.len(), 1);
+    assert_eq!(artifacts[0]["path"].as_str().unwrap(), "README.md");
+    assert_eq!(artifacts[0]["mime_type"].as_str().unwrap(), "text/markdown");
+}
+
+#[tokio::test]
+async fn read_resource_returns_artifact_content_for_known_path() {
+    let (runtime, source) = harness_runtime();
+    let tool = SkillReadResourceTool::new(runtime);
+
+    let output = tool
+        .call(serde_json::json!({
+            "source_uuid": source.to_string(),
+            "skill_name": "alpha",
+            "path": "README.md",
+        }))
+        .await
+        .unwrap();
+    let json = output.into_json().unwrap();
+
+    assert_eq!(json["artifact"]["path"].as_str().unwrap(), "README.md");
+    assert_eq!(
+        json["artifact"]["content"].as_str().unwrap(),
+        "artifact body"
+    );
+}
+
+#[tokio::test]
+async fn read_resource_missing_path_returns_invalid_args() {
+    let (runtime, source) = harness_runtime();
+    let tool = SkillReadResourceTool::new(runtime);
+
+    let err = tool
+        .call(serde_json::json!({
+            "source_uuid": source.to_string(),
+            "skill_name": "alpha",
+        }))
+        .await
+        .unwrap_err();
+
+    match &err {
+        meerkat_tools::BuiltinToolError::InvalidArgs(msg) => {
+            assert!(
+                msg.contains("path"),
+                "InvalidArgs must name the missing path; got {msg:?}"
+            );
+        }
+        other => panic!("expected InvalidArgs for missing path; got {other:?}"),
+    }
+}
+
+#[tokio::test]
+async fn invoke_function_passes_typed_key_and_default_arguments() {
+    let (runtime, source) = harness_runtime();
+    let tool = SkillInvokeFunctionTool::new(runtime);
+
+    let output = tool
+        .call(serde_json::json!({
+            "source_uuid": source.to_string(),
+            "skill_name": "alpha",
+            "function_name": "echo",
+        }))
+        .await
+        .unwrap();
+    let json = output.into_json().unwrap();
+
+    assert_eq!(json["function_name"].as_str().unwrap(), "echo");
+    assert!(json["output"]["received"].is_null());
+}
+
+#[tokio::test]
+async fn invoke_function_preserves_structured_arguments() {
+    let (runtime, source) = harness_runtime();
+    let tool = SkillInvokeFunctionTool::new(runtime);
+
+    let output = tool
+        .call(serde_json::json!({
+            "source_uuid": source.to_string(),
+            "skill_name": "alpha",
+            "function_name": "echo",
+            "arguments": { "subject": "typed" },
+        }))
+        .await
+        .unwrap();
+    let json = output.into_json().unwrap();
+
+    assert_eq!(
+        json["output"]["received"]["subject"].as_str().unwrap(),
+        "typed"
+    );
 }


### PR DESCRIPTION
# LUC-408 Review Readiness Packet

Dogma cleanup PR: yes.

## Review Readiness Packet

Current head SHA: `2cb2f5c3654dbd8232331475b0e377c2458320d4`

Command output:

```text
$ rg -n '#\[allow\(dead_code\)\]|\.get\("(query|source_uuid|skill_name|function_name|arguments|path)"\)|fn parse_key\(args: &Value\)' meerkat-tools/src/builtin/skills
<no output>

$ ./scripts/repo-cargo test -p meerkat-tools --test builtin_skill_canonical_key --test browse_load_surface
test result: ok. 14 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out
test result: ok. 2 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out

$ make dogma-cleanup-gate-fixtures
Ran 53 tests
OK

$ make check
Build completed successfully

$ make lint
Build completed successfully

$ make test
37 tests pass
13 tests pass

$ git diff --check
<no output>
```

## Complexity Delta

- Docs/scripts/tests: 1 focused Rust integration test file extends existing skill-tool surface coverage.
- Non-test implementation: 4 `meerkat-tools` skill builtin files delete raw semantic field reads and dead-code suppressions.
- Generated/schema churn: none.

## Old Path Amputation Proof

| Old path | Classification | Search literal | Mechanical proof | Follow-up |
| --- | --- | --- | --- | --- |
| `BrowseSkillsArgs` dead-code suppression | deleted | `BrowseSkillsArgs dead_code suppression` | `rg` over `meerkat-tools/src/builtin/skills` reports no dead-code suppressions. | none |
| `LoadSkillArgs` dead-code suppression | deleted | `LoadSkillArgs dead_code suppression` | `rg` over `meerkat-tools/src/builtin/skills` reports no dead-code suppressions. | none |
| `SkillInvokeFunctionArgs` dead-code suppression | deleted | `SkillInvokeFunctionArgs dead_code suppression` | `rg` over `meerkat-tools/src/builtin/skills` reports no dead-code suppressions. | none |
| `SkillListResourcesArgs` dead-code suppression | deleted | `SkillListResourcesArgs dead_code suppression` | `rg` over `meerkat-tools/src/builtin/skills` reports no dead-code suppressions. | none |
| `SkillReadResourceArgs` dead-code suppression | deleted | `SkillReadResourceArgs dead_code suppression` | `rg` over `meerkat-tools/src/builtin/skills` reports no dead-code suppressions. | none |
| `browse_skills` raw `query` / `source_uuid` field reads | deleted | `browse_skills raw query source_uuid field reads` | `BrowseSkillsTool::call` now deserializes `BrowseSkillsArgs`; the path-scoped `rg` proof reports no raw reads for those fields. | none |
| `load_skill` raw `SkillKey` object parser | deleted | `load_skill raw SkillKey object parser` | `LoadSkillTool::call` now deserializes `LoadSkillArgs`; the path-scoped `rg` proof reports no `parse_key(args: &Value)` path. | none |
| `skill_invoke_function` raw `SkillKey` and function argument reads | deleted | `skill_invoke_function raw SkillKey function argument reads` | `SkillInvokeFunctionTool::call` now deserializes `SkillInvokeFunctionArgs`; the path-scoped `rg` proof reports no raw reads for key, function name, or arguments. | none |
| `skill_list_resources` raw `SkillKey` object parser | deleted | `skill_list_resources raw SkillKey object parser` | `SkillListResourcesTool::call` now deserializes `SkillListResourcesArgs`; the path-scoped `rg` proof reports no `parse_key(args: &Value)` path. | none |
| `skill_read_resource` raw `SkillKey` / `path` field reads | deleted | `skill_read_resource raw SkillKey path field reads` | `SkillReadResourceTool::call` now deserializes `SkillReadResourceArgs`; the path-scoped `rg` proof reports no raw path read. | none |

## Validation

- Baseline before edits: `make dogma-cleanup-gate-fixtures` passed, 53 tests.
- Focused behavior: `./scripts/repo-cargo test -p meerkat-tools --test builtin_skill_canonical_key --test browse_load_surface` passed, 16 tests.
- Dogma proof: path-scoped `rg` reports no old raw-field/dead-code ingress paths in `meerkat-tools/src/builtin/skills`.
- Broad BuildBuddy check: `make check` passed, invocation `f5ddb4ab-fca8-499e-b0f1-192e0c96b405`.
- Broad BuildBuddy lint: `make lint` passed, invocation `3dece837-40c6-4908-a5db-a50de1e7fa91`.
- Broad BuildBuddy tests: `make test` passed, invocations `3e14f444-c436-4045-8ffe-9e9a55369dd7` and `7f126038-1747-4132-964c-3b31787f23df`.
- Diff hygiene: `git diff --check` passed.

## Sample Passing Old Path Amputation Proof

| Old path | Classification | Search literal | Mechanical proof | Follow-up |
| --- | --- | --- | --- | --- |
| `old/session-route` | deleted | `old/session-route` | No production references remain. | none |

## Sample Failing Old Path Amputation Proof

| Old path | Classification | Search literal | Mechanical proof | Follow-up |
| --- | --- | --- | --- | --- |
| `old/session-route` | wrapped | `old/session-route` | A preferred path exists beside the old route. | none |
