### PR TITLE
Add structured output to completion events

### DIFF
--- a/artifacts/schemas/events.json
+++ b/artifacts/schemas/events.json
@@ -1318,6 +1318,9 @@
           "session_id": {
             "$ref": "#/$defs/SessionId"
           },
+          "structured_output": {
+            "description": "Structured output from the completed run, when schema extraction\nproduced a typed value."
+          },
           "terminal_cause_kind": {
             "anyOf": [
               {
@@ -1989,6 +1992,9 @@
           "result": {
             "type": "string"
           },
+          "structured_output": {
+            "description": "Structured output from the completed interaction, when schema\nextraction produced a typed value."
+          },
           "type": {
             "const": "interaction_complete",
             "type": "string"
@@ -2524,6 +2530,9 @@
               },
               "session_id": {
                 "$ref": "#/$defs/SessionId"
+              },
+              "structured_output": {
+                "description": "Structured output from the completed run, when schema extraction\nproduced a typed value."
               },
               "terminal_cause_kind": {
                 "anyOf": [
@@ -3195,6 +3204,9 @@
               },
               "result": {
                 "type": "string"
+              },
+              "structured_output": {
+                "description": "Structured output from the completed interaction, when schema\nextraction produced a typed value."
               },
               "type": {
                 "const": "interaction_complete",

--- a/artifacts/schemas/wire-types.json
+++ b/artifacts/schemas/wire-types.json
@@ -406,6 +406,9 @@
               "session_id": {
                 "$ref": "#/$defs/SessionId"
               },
+              "structured_output": {
+                "description": "Structured output from the completed run, when schema extraction\nproduced a typed value."
+              },
               "terminal_cause_kind": {
                 "anyOf": [
                   {
@@ -1076,6 +1079,9 @@
               },
               "result": {
                 "type": "string"
+              },
+              "structured_output": {
+                "description": "Structured output from the completed interaction, when schema\nextraction produced a typed value."
               },
               "type": {
                 "const": "interaction_complete",

--- a/meerkat-contracts/tests/regression_wire_types.rs
+++ b/meerkat-contracts/tests/regression_wire_types.rs
@@ -362,6 +362,7 @@ fn agent_event_all_variants_roundtrip() {
         AgentEvent::RunCompleted {
             session_id: session_id.clone(),
             result: "done".to_string(),
+            structured_output: Some(serde_json::json!({"ok": true})),
             usage: Usage {
                 input_tokens: 10,
                 output_tokens: 5,
@@ -589,6 +590,7 @@ fn documented_event_catalog_covers_core_agent_event_discriminators() {
         AgentEvent::RunCompleted {
             session_id: SessionId::new(),
             result: "done".to_string(),
+            structured_output: None,
             usage: Usage::default(),
             terminal_cause_kind: None,
         },
@@ -709,6 +711,7 @@ fn documented_event_catalog_covers_core_agent_event_discriminators() {
             ))
             .unwrap(),
             result: "ok".to_string(),
+            structured_output: Some(serde_json::json!({"answer": 42})),
         },
         AgentEvent::InteractionFailed {
             interaction_id: serde_json::from_value(serde_json::json!(

--- a/meerkat-core/src/agent/runner.rs
+++ b/meerkat-core/src/agent/runner.rs
@@ -726,6 +726,7 @@ where
             AgentEvent::RunCompleted {
                 session_id: self.session.id().clone(),
                 result: result.text.clone(),
+                structured_output: result.structured_output.clone(),
                 usage: result.usage.clone(),
                 terminal_cause_kind: result.terminal_cause_kind,
             },

--- a/meerkat-core/src/event.rs
+++ b/meerkat-core/src/event.rs
@@ -1305,6 +1305,10 @@ pub enum AgentEvent {
     RunCompleted {
         session_id: SessionId,
         result: String,
+        /// Structured output from the completed run, when schema extraction
+        /// produced a typed value.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        structured_output: Option<Value>,
         usage: Usage,
         #[serde(default, skip_serializing_if = "Option::is_none")]
         terminal_cause_kind: Option<TurnTerminalCauseKind>,
@@ -1484,6 +1488,10 @@ pub enum AgentEvent {
     InteractionComplete {
         interaction_id: crate::interaction::InteractionId,
         result: String,
+        /// Structured output from the completed interaction, when schema
+        /// extraction produced a typed value.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        structured_output: Option<Value>,
     },
 
     /// An interaction reached an external callback boundary and is waiting for
@@ -2225,6 +2233,7 @@ mod tests {
             AgentEvent::RunCompleted {
                 session_id: SessionId::new(),
                 result: "Done".to_string(),
+                structured_output: None,
                 usage: Usage {
                     input_tokens: 100,
                     output_tokens: 50,
@@ -2260,6 +2269,7 @@ mod tests {
             AgentEvent::InteractionComplete {
                 interaction_id: crate::interaction::InteractionId(uuid::Uuid::new_v4()),
                 result: "agent response".to_string(),
+                structured_output: None,
             },
             AgentEvent::InteractionCallbackPending {
                 interaction_id: crate::interaction::InteractionId(uuid::Uuid::new_v4()),
@@ -2745,6 +2755,7 @@ mod tests {
             AgentEvent::RunCompleted {
                 session_id: SessionId::new(),
                 result: "Done".to_string(),
+                structured_output: None,
                 usage: Usage::default(),
                 terminal_cause_kind: None,
             },
@@ -2866,6 +2877,7 @@ mod tests {
             AgentEvent::InteractionComplete {
                 interaction_id: crate::interaction::InteractionId(uuid::Uuid::new_v4()),
                 result: "ok".to_string(),
+                structured_output: None,
             },
             AgentEvent::InteractionCallbackPending {
                 interaction_id: crate::interaction::InteractionId(uuid::Uuid::new_v4()),

--- a/meerkat-core/src/event_tap.rs
+++ b/meerkat-core/src/event_tap.rs
@@ -204,6 +204,7 @@ mod tests {
             AgentEvent::RunCompleted {
                 session_id: crate::types::SessionId::new(),
                 result: "done".to_string(),
+                structured_output: None,
                 usage: crate::types::Usage::default(),
                 terminal_cause_kind: None,
             },
@@ -223,6 +224,7 @@ mod tests {
             AgentEvent::RunCompleted {
                 session_id: crate::types::SessionId::new(),
                 result: "done".to_string(),
+                structured_output: None,
                 usage: crate::types::Usage::default(),
                 terminal_cause_kind: None,
             },

--- a/meerkat-mob-mcp/src/agent_tools.rs
+++ b/meerkat-mob-mcp/src/agent_tools.rs
@@ -2119,6 +2119,7 @@ mod tests {
                     .send(AgentEvent::InteractionComplete {
                         interaction_id: interaction_id_for_task,
                         result: "ok".to_string(),
+                        structured_output: None,
                     })
                     .await;
             });

--- a/meerkat-mob-mcp/src/lib.rs
+++ b/meerkat-mob-mcp/src/lib.rs
@@ -1824,6 +1824,7 @@ impl SessionService for LocalSessionService {
                 AgentEvent::RunCompleted {
                     session_id: id.clone(),
                     result: "ok".to_string(),
+                    structured_output: None,
                     usage,
                     terminal_cause_kind: None,
                 },
@@ -3310,6 +3311,7 @@ mod tests {
                     .send(AgentEvent::InteractionComplete {
                         interaction_id: interaction_id_for_task,
                         result: "ok".to_string(),
+                        structured_output: None,
                     })
                     .await;
             });

--- a/meerkat-mob/src/event.rs
+++ b/meerkat-mob/src/event.rs
@@ -387,7 +387,13 @@ pub enum MobEventKind {
         params: serde_json::Value,
     },
     /// Flow run completed.
-    FlowCompleted { run_id: RunId, flow_id: FlowId },
+    FlowCompleted {
+        run_id: RunId,
+        flow_id: FlowId,
+        /// Typed flow outputs captured at completion time.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        structured_output: Option<serde_json::Value>,
+    },
     /// Flow run failed.
     FlowFailed {
         run_id: RunId,
@@ -722,6 +728,13 @@ mod tests {
         roundtrip(&MobEventKind::FlowCompleted {
             run_id: run_id.clone(),
             flow_id: flow_id.clone(),
+            structured_output: Some(serde_json::json!({
+                "steps": {
+                    "step-a": {
+                        "ok": true
+                    }
+                }
+            })),
         });
         roundtrip(&MobEventKind::FlowFailed {
             run_id: run_id.clone(),

--- a/meerkat-mob/src/runtime/actor.rs
+++ b/meerkat-mob/src/runtime/actor.rs
@@ -9775,7 +9775,10 @@ impl MobActor {
                 (TerminalizationTarget::Canceled, MobRunStatus::Failed)
             )
         {
-            return Ok(TerminalizationOutcome::Noop);
+            return self
+                .flow_engine
+                .repair_persisted_terminalization(run_id, flow_id, target)
+                .await;
         }
 
         let authority_input = command.authority_input(&run_id);

--- a/meerkat-mob/src/runtime/actor_turn_executor.rs
+++ b/meerkat-mob/src/runtime/actor_turn_executor.rs
@@ -158,10 +158,29 @@ impl ActorFlowTurnExecutor {
                     let _ = tx.send(scoped).await;
                 }
                 match payload {
-                    AgentEvent::RunCompleted { result, .. }
-                    | AgentEvent::InteractionComplete { result, .. } => {
+                    AgentEvent::RunCompleted {
+                        result,
+                        structured_output,
+                        ..
+                    } => {
                         if let Some(tx) = completion_tx.take() {
-                            let _ = tx.send(FlowTurnOutcome::Completed { output: result });
+                            let _ = tx.send(FlowTurnOutcome::Completed {
+                                output: result,
+                                structured_output,
+                            });
+                        }
+                        return;
+                    }
+                    AgentEvent::InteractionComplete {
+                        result,
+                        structured_output,
+                        ..
+                    } => {
+                        if let Some(tx) = completion_tx.take() {
+                            let _ = tx.send(FlowTurnOutcome::Completed {
+                                output: result,
+                                structured_output,
+                            });
                         }
                         return;
                     }
@@ -455,10 +474,13 @@ impl FlowTurnExecutor for ActorFlowTurnExecutor {
 mod tests {
     use super::ActorFlowTurnExecutor;
     use crate::ids::RunId;
+    use crate::runtime::FlowTurnOutcome;
+    use meerkat_core::AgentEvent;
+    use meerkat_core::interaction::InteractionId;
     use std::collections::BTreeMap;
     use std::sync::Arc;
     use std::sync::atomic::{AtomicUsize, Ordering};
-    use tokio::sync::Mutex;
+    use tokio::sync::{Mutex, oneshot};
 
     #[test]
     fn test_release_orphan_slot_caps_at_max_budget() {
@@ -509,5 +531,65 @@ mod tests {
             !per_run_orphans.lock().await.contains_key(&run_id),
             "detached panic path should release per-run orphan accounting"
         );
+    }
+
+    #[tokio::test]
+    async fn test_subscription_bridge_preserves_interaction_structured_output() {
+        let (events_tx, events_rx) = tokio::sync::mpsc::channel(1);
+        let (completion_tx, completion_rx) = oneshot::channel();
+        let bridge =
+            ActorFlowTurnExecutor::spawn_subscription_bridge(events_rx, completion_tx, None, None);
+
+        events_tx
+            .send(AgentEvent::InteractionComplete {
+                interaction_id: InteractionId(uuid::Uuid::new_v4()),
+                result: "{\"answer\":42}".to_string(),
+                structured_output: Some(serde_json::json!({"answer": 42})),
+            })
+            .await
+            .expect("send event");
+
+        match completion_rx.await.expect("completion outcome") {
+            FlowTurnOutcome::Completed {
+                output,
+                structured_output,
+            } => {
+                assert_eq!(output, "{\"answer\":42}");
+                assert_eq!(structured_output, Some(serde_json::json!({"answer": 42})));
+            }
+            other => panic!("expected completed outcome, got {other:?}"),
+        }
+        bridge.await.expect("bridge exits after terminal event");
+    }
+
+    #[tokio::test]
+    async fn test_subscription_bridge_preserves_run_structured_output() {
+        let (events_tx, events_rx) = tokio::sync::mpsc::channel(1);
+        let (completion_tx, completion_rx) = oneshot::channel();
+        let bridge =
+            ActorFlowTurnExecutor::spawn_subscription_bridge(events_rx, completion_tx, None, None);
+
+        events_tx
+            .send(AgentEvent::RunCompleted {
+                session_id: meerkat_core::SessionId::new(),
+                result: "{\"answer\":42}".to_string(),
+                structured_output: Some(serde_json::json!({"answer": 42})),
+                usage: meerkat_core::Usage::default(),
+                terminal_cause_kind: None,
+            })
+            .await
+            .expect("send event");
+
+        match completion_rx.await.expect("completion outcome") {
+            FlowTurnOutcome::Completed {
+                output,
+                structured_output,
+            } => {
+                assert_eq!(output, "{\"answer\":42}");
+                assert_eq!(structured_output, Some(serde_json::json!({"answer": 42})));
+            }
+            other => panic!("expected completed outcome, got {other:?}"),
+        }
+        bridge.await.expect("bridge exits after terminal event");
     }
 }

--- a/meerkat-mob/src/runtime/flow.rs
+++ b/meerkat-mob/src/runtime/flow.rs
@@ -752,8 +752,18 @@ impl FlowEngine {
             };
 
             match terminal {
-                Ok(FlowTurnOutcome::Completed { output }) => {
-                    match parse_output_value(&output, step_id, target, &output_format) {
+                Ok(FlowTurnOutcome::Completed {
+                    output,
+                    structured_output,
+                }) => {
+                    let output_value = completed_output_value(
+                        &output,
+                        structured_output,
+                        step_id,
+                        target,
+                        &output_format,
+                    );
+                    match output_value {
                         Ok(value) => {
                             self.run_store
                                 .append_step_entry(
@@ -1554,16 +1564,26 @@ impl FlowEngine {
             }
         }
 
-        self.terminalize_completed(run_id.clone(), flow_id).await
+        self.terminalize_completed(
+            run_id.clone(),
+            flow_id,
+            flow_structured_output_from_outputs(outputs),
+        )
+        .await
     }
 
     pub(crate) async fn terminalize_completed(
         &self,
         run_id: RunId,
         flow_id: FlowId,
+        structured_output: Option<Value>,
     ) -> Result<TerminalizationOutcome, MobError> {
-        self.terminalize(run_id, flow_id, TerminalizationTarget::Completed)
-            .await
+        self.terminalize(
+            run_id,
+            flow_id,
+            TerminalizationTarget::Completed { structured_output },
+        )
+        .await
     }
 
     pub(crate) async fn terminalize_failed(
@@ -1614,9 +1634,11 @@ impl FlowEngine {
         target: TerminalizationTarget,
     ) -> Result<TerminalizationOutcome, MobError> {
         let input = match &target {
-            TerminalizationTarget::Completed => MobMachineFlowRunCommand::TerminalizeCompleted(
-                flow_run::inputs::TerminalizeCompleted {},
-            ),
+            TerminalizationTarget::Completed { .. } => {
+                MobMachineFlowRunCommand::TerminalizeCompleted(
+                    flow_run::inputs::TerminalizeCompleted {},
+                )
+            }
             TerminalizationTarget::Failed { .. } => {
                 MobMachineFlowRunCommand::TerminalizeFailed(flow_run::inputs::TerminalizeFailed {})
             }
@@ -1626,6 +1648,17 @@ impl FlowEngine {
         };
         self.handle
             .commit_flow_terminalization(run_id, flow_id, target, input, "flow_terminalize")
+            .await
+    }
+
+    pub(super) async fn repair_persisted_terminalization(
+        &self,
+        run_id: RunId,
+        flow_id: FlowId,
+        target: TerminalizationTarget,
+    ) -> Result<TerminalizationOutcome, MobError> {
+        self.terminalization
+            .repair_persisted_terminalization(run_id, flow_id, target)
             .await
     }
 
@@ -1649,7 +1682,9 @@ impl FlowEngine {
                     (TerminalizationTarget::Canceled, MobRunStatus::Failed)
                 )
             {
-                return Ok(TerminalizationOutcome::Noop);
+                return self
+                    .repair_persisted_terminalization(run_id, flow_id, target)
+                    .await;
             }
             let next_state = apply_mob_machine_flow_run_command(
                 &run.flow_state,
@@ -1933,6 +1968,34 @@ fn parse_output_value(
             "malformed JSON output for step '{step_id}' target '{target}': {error}; raw_output={excerpt:?}"
         )
     })
+}
+
+fn completed_output_value(
+    raw: &str,
+    structured_output: Option<Value>,
+    step_id: &StepId,
+    target: &MeerkatId,
+    format: &StepOutputFormat,
+) -> Result<Value, String> {
+    match (format, structured_output) {
+        (StepOutputFormat::Json, Some(value)) => Ok(value),
+        _ => parse_output_value(raw, step_id, target, format),
+    }
+}
+
+fn flow_structured_output_from_outputs(outputs: &IndexMap<StepId, Value>) -> Option<Value> {
+    if outputs.is_empty() {
+        return None;
+    }
+
+    let mut steps = Map::new();
+    for (step_id, output) in outputs {
+        steps.insert(step_id.as_str().to_string(), output.clone());
+    }
+
+    let mut structured_output = Map::new();
+    structured_output.insert("steps".to_string(), Value::Object(steps));
+    Some(Value::Object(structured_output))
 }
 
 /// Strip markdown code fences from LLM output.
@@ -2552,6 +2615,40 @@ mod template_tests {
             }
             other => panic!("expected rendered blocks, got {other:?}"),
         }
+    }
+}
+
+#[cfg(test)]
+mod completed_output_value_tests {
+    use super::{StepOutputFormat, completed_output_value};
+    use crate::ids::{AgentIdentity, StepId};
+
+    #[test]
+    fn json_format_preserves_typed_structured_output() {
+        let value = completed_output_value(
+            "not-json",
+            Some(serde_json::json!({"answer": 42})),
+            &StepId::from("step-1"),
+            &AgentIdentity::from("worker-1"),
+            &StepOutputFormat::Json,
+        )
+        .expect("structured output should be accepted directly");
+
+        assert_eq!(value, serde_json::json!({"answer": 42}));
+    }
+
+    #[test]
+    fn text_format_keeps_raw_text_output() {
+        let value = completed_output_value(
+            "plain text",
+            Some(serde_json::json!({"answer": 42})),
+            &StepId::from("step-1"),
+            &AgentIdentity::from("worker-1"),
+            &StepOutputFormat::Text,
+        )
+        .expect("text output should be accepted as raw text");
+
+        assert_eq!(value, serde_json::json!("plain text"));
     }
 }
 

--- a/meerkat-mob/src/runtime/terminalization.rs
+++ b/meerkat-mob/src/runtime/terminalization.rs
@@ -2,14 +2,15 @@ use super::flow_system_step_id;
 use crate::error::MobError;
 use crate::event::{MobEventKind, NewMobEvent};
 use crate::ids::{FlowId, MobId, RunId};
-use crate::run::{FailureLedgerEntry, MobRunStatus};
+use crate::run::{FailureLedgerEntry, MobRun, MobRunStatus};
 use crate::store::{MobEventStore, MobRunStore};
 use chrono::Utc;
+use serde_json::{Map, Value};
 use std::sync::Arc;
 
 #[derive(Debug, Clone)]
 pub(super) enum TerminalizationTarget {
-    Completed,
+    Completed { structured_output: Option<Value> },
     Failed { reason: String },
     Canceled,
 }
@@ -17,7 +18,7 @@ pub(super) enum TerminalizationTarget {
 impl TerminalizationTarget {
     pub(super) fn status(&self) -> MobRunStatus {
         match self {
-            Self::Completed => MobRunStatus::Completed,
+            Self::Completed { .. } => MobRunStatus::Completed,
             Self::Failed { .. } => MobRunStatus::Failed,
             Self::Canceled => MobRunStatus::Canceled,
         }
@@ -25,7 +26,7 @@ impl TerminalizationTarget {
 
     fn event_name(&self) -> &'static str {
         match self {
-            Self::Completed => "FlowCompleted",
+            Self::Completed { .. } => "FlowCompleted",
             Self::Failed { .. } => "FlowFailed",
             Self::Canceled => "FlowCanceled",
         }
@@ -33,7 +34,11 @@ impl TerminalizationTarget {
 
     fn into_event_kind(self, run_id: RunId, flow_id: FlowId) -> MobEventKind {
         match self {
-            Self::Completed => MobEventKind::FlowCompleted { run_id, flow_id },
+            Self::Completed { structured_output } => MobEventKind::FlowCompleted {
+                run_id,
+                flow_id,
+                structured_output,
+            },
             Self::Failed { reason } => MobEventKind::FlowFailed {
                 run_id,
                 flow_id,
@@ -99,6 +104,99 @@ impl FlowTerminalizationAuthority {
         Ok(TerminalizationOutcome::Transitioned)
     }
 
+    pub(super) async fn repair_persisted_terminalization(
+        &self,
+        run_id: RunId,
+        flow_id: FlowId,
+        target: TerminalizationTarget,
+    ) -> Result<TerminalizationOutcome, MobError> {
+        let run = self
+            .run_store
+            .get_run(&run_id)
+            .await?
+            .ok_or_else(|| MobError::RunNotFound(run_id.clone()))?;
+        if !run.status.is_terminal() {
+            return Ok(TerminalizationOutcome::Noop);
+        }
+        let target = Self::repair_target_for_run(&run, target);
+        let event_name = target.event_name();
+        let event_kind = target.into_event_kind(run_id.clone(), flow_id);
+        match self
+            .events
+            .append_terminal_event_if_absent(NewMobEvent {
+                mob_id: self.mob_id.clone(),
+                timestamp: None,
+                kind: event_kind,
+            })
+            .await
+        {
+            Ok(Some(_)) | Ok(None) => Ok(TerminalizationOutcome::Noop),
+            Err(append_error) => {
+                self.record_terminal_event_append_failure(
+                    &run_id,
+                    event_name,
+                    MobError::from(append_error),
+                )
+                .await
+            }
+        }
+    }
+
+    fn repair_target_for_run(
+        run: &MobRun,
+        requested: TerminalizationTarget,
+    ) -> TerminalizationTarget {
+        match run.status {
+            MobRunStatus::Completed => {
+                let requested_output = match requested {
+                    TerminalizationTarget::Completed { structured_output } => structured_output,
+                    _ => None,
+                };
+                TerminalizationTarget::Completed {
+                    structured_output: requested_output
+                        .or_else(|| structured_output_from_run_outputs(run)),
+                }
+            }
+            MobRunStatus::Failed => {
+                let reason = match requested {
+                    TerminalizationTarget::Failed { reason } => reason,
+                    _ => run
+                        .failure_ledger
+                        .last()
+                        .map(|entry| entry.reason.clone())
+                        .unwrap_or_else(|| "run already failed".to_string()),
+                };
+                TerminalizationTarget::Failed { reason }
+            }
+            MobRunStatus::Canceled => TerminalizationTarget::Canceled,
+            MobRunStatus::Pending | MobRunStatus::Running => requested,
+        }
+    }
+}
+
+fn structured_output_from_run_outputs(run: &MobRun) -> Option<Value> {
+    if run.root_step_outputs.is_empty() && run.loop_iteration_outputs.is_empty() {
+        return None;
+    }
+
+    let mut steps = Map::new();
+    for (step_id, output) in &run.root_step_outputs {
+        steps.insert(step_id.as_str().to_string(), output.clone());
+    }
+    for iterations in run.loop_iteration_outputs.values() {
+        for iteration in iterations {
+            for (step_id, output) in iteration {
+                steps.insert(step_id.as_str().to_string(), output.clone());
+            }
+        }
+    }
+
+    let mut structured_output = Map::new();
+    structured_output.insert("steps".to_string(), Value::Object(steps));
+    Some(Value::Object(structured_output))
+}
+
+impl FlowTerminalizationAuthority {
     async fn record_terminal_event_append_failure(
         &self,
         run_id: &RunId,
@@ -145,9 +243,11 @@ impl FlowTerminalizationAuthority {
 mod tests {
     use super::{FlowTerminalizationAuthority, TerminalizationOutcome, TerminalizationTarget};
     use crate::event::{MobEvent, MobEventKind, NewMobEvent};
-    use crate::ids::{FlowId, MobId, RunId, StepId};
+    use crate::ids::{FlowId, LoopId, MobId, RunId, StepId};
     use crate::run::{FailureLedgerEntry, MobRun, MobRunStatus, StepLedgerEntry};
-    use crate::store::{InMemoryMobRunStore, MobEventStore, MobRunStore, MobStoreError};
+    use crate::store::{
+        InMemoryMobRunStore, MobEventStore, MobRunStore, MobStoreError, terminal_event_identity,
+    };
     use async_trait::async_trait;
     use chrono::Utc;
     use std::collections::HashSet;
@@ -156,13 +256,19 @@ mod tests {
 
     struct RecordingRunStore {
         inner: InMemoryMobRunStore,
+        fail_get_run: RwLock<bool>,
     }
 
     impl RecordingRunStore {
         fn new() -> Self {
             Self {
                 inner: InMemoryMobRunStore::new(),
+                fail_get_run: RwLock::new(false),
             }
+        }
+
+        async fn fail_get_run(&self, fail: bool) {
+            *self.fail_get_run.write().await = fail;
         }
     }
 
@@ -173,6 +279,11 @@ mod tests {
         }
 
         async fn get_run(&self, run_id: &RunId) -> Result<Option<MobRun>, MobStoreError> {
+            if *self.fail_get_run.read().await {
+                return Err(MobStoreError::Internal(
+                    "fault-injected get_run failure".to_string(),
+                ));
+            }
             self.inner.get_run(run_id).await
         }
 
@@ -699,6 +810,10 @@ mod tests {
             self.fail_on_kind.write().await.insert(kind);
         }
 
+        async fn allow_appends_for(&self, kind: &'static str) {
+            self.fail_on_kind.write().await.remove(kind);
+        }
+
         fn kind_label(kind: &MobEventKind) -> &'static str {
             match kind {
                 MobEventKind::FlowCompleted { .. } => "FlowCompleted",
@@ -727,6 +842,47 @@ mod tests {
             };
             events.push(stored.clone());
             Ok(stored)
+        }
+
+        async fn append_terminal_event_if_absent(
+            &self,
+            event: NewMobEvent,
+        ) -> Result<Option<MobEvent>, MobStoreError> {
+            let Some((run_id, flow_id)) = terminal_event_identity(&event.kind) else {
+                return Err(MobStoreError::Internal(
+                    "append_terminal_event_if_absent requires a terminal flow event".to_string(),
+                ));
+            };
+            let run_id = run_id.clone();
+            let flow_id = flow_id.clone();
+            let mob_id = event.mob_id.clone();
+
+            let mut events = self.events.write().await;
+            if events.iter().any(|existing| {
+                existing.mob_id == mob_id
+                    && terminal_event_identity(&existing.kind).is_some_and(
+                        |(existing_run_id, existing_flow_id)| {
+                            existing_run_id == &run_id && existing_flow_id == &flow_id
+                        },
+                    )
+            }) {
+                return Ok(None);
+            }
+
+            let kind = Self::kind_label(&event.kind);
+            if self.fail_on_kind.read().await.contains(kind) {
+                return Err(MobStoreError::Internal(format!(
+                    "fault-injected append failure for {kind}"
+                )));
+            }
+            let stored = MobEvent {
+                cursor: events.len() as u64 + 1,
+                timestamp: Utc::now(),
+                mob_id: event.mob_id,
+                kind: event.kind,
+            };
+            events.push(stored.clone());
+            Ok(Some(stored))
         }
 
         async fn poll(
@@ -817,6 +973,308 @@ mod tests {
             .await
             .expect("terminalize");
         assert_eq!(outcome, TerminalizationOutcome::Transitioned);
+    }
+
+    #[tokio::test]
+    async fn test_completed_terminalization_carries_structured_output() {
+        let run_store = Arc::new(RecordingRunStore::new());
+        let events = Arc::new(FaultInjectedEventStore::default());
+        let authority = FlowTerminalizationAuthority::new(
+            run_store.clone(),
+            events.clone(),
+            MobId::from("mob"),
+        );
+
+        let run_id = RunId::new();
+        let mut run = sample_run(run_id.clone(), MobRunStatus::Completed);
+        run.root_step_outputs
+            .insert(StepId::from("step-1"), serde_json::json!({"answer": 42}));
+        run_store.create_run(run).await.expect("create run");
+
+        let outcome = authority
+            .record_persisted_terminalization(
+                run_id.clone(),
+                FlowId::from("flow"),
+                TerminalizationTarget::Completed {
+                    structured_output: Some(serde_json::json!({
+                        "steps": {
+                            "step-1": {
+                                "answer": 42
+                            }
+                        }
+                    })),
+                },
+            )
+            .await
+            .expect("terminalize");
+        assert_eq!(outcome, TerminalizationOutcome::Transitioned);
+
+        let emitted = events.replay_all().await.expect("replay events");
+        match &emitted[0].kind {
+            MobEventKind::FlowCompleted {
+                structured_output, ..
+            } => assert_eq!(
+                structured_output,
+                &Some(serde_json::json!({
+                    "steps": {
+                        "step-1": {
+                            "answer": 42
+                        }
+                    }
+                }))
+            ),
+            other => panic!("expected FlowCompleted, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn test_completed_terminalization_does_not_read_snapshot_for_structured_output() {
+        let run_store = Arc::new(RecordingRunStore::new());
+        let events = Arc::new(FaultInjectedEventStore::default());
+        let authority = FlowTerminalizationAuthority::new(
+            run_store.clone(),
+            events.clone(),
+            MobId::from("mob"),
+        );
+
+        let run_id = RunId::new();
+        let mut run = sample_run(run_id.clone(), MobRunStatus::Completed);
+        run.root_step_outputs
+            .insert(StepId::from("step-1"), serde_json::json!({"answer": 42}));
+        run_store.create_run(run).await.expect("create run");
+        run_store.fail_get_run(true).await;
+
+        let outcome = authority
+            .record_persisted_terminalization(
+                run_id.clone(),
+                FlowId::from("flow"),
+                TerminalizationTarget::Completed {
+                    structured_output: Some(serde_json::json!({
+                        "steps": {
+                            "step-1": {
+                                "answer": 42
+                            }
+                        }
+                    })),
+                },
+            )
+            .await
+            .expect("terminalize");
+
+        assert_eq!(outcome, TerminalizationOutcome::Transitioned);
+        assert_eq!(
+            events.replay_all().await.expect("replay events").len(),
+            1,
+            "FlowCompleted should use the target output and avoid an extra run read"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_completed_terminalization_repair_appends_missing_event() {
+        let run_store = Arc::new(RecordingRunStore::new());
+        let events = Arc::new(FaultInjectedEventStore::default());
+        let authority = FlowTerminalizationAuthority::new(
+            run_store.clone(),
+            events.clone(),
+            MobId::from("mob"),
+        );
+
+        let run_id = RunId::new();
+        run_store
+            .create_run(sample_run(run_id.clone(), MobRunStatus::Completed))
+            .await
+            .expect("create run");
+        events.fail_appends_for("FlowCompleted").await;
+        authority
+            .record_persisted_terminalization(
+                run_id.clone(),
+                FlowId::from("flow"),
+                TerminalizationTarget::Completed {
+                    structured_output: Some(serde_json::json!({
+                        "steps": {
+                            "step-1": {
+                                "answer": 42
+                            }
+                        }
+                    })),
+                },
+            )
+            .await
+            .expect_err("initial terminal event append should fail");
+        events.allow_appends_for("FlowCompleted").await;
+
+        let outcome = authority
+            .repair_persisted_terminalization(
+                run_id.clone(),
+                FlowId::from("flow"),
+                TerminalizationTarget::Completed {
+                    structured_output: Some(serde_json::json!({
+                        "steps": {
+                            "step-1": {
+                                "answer": 42
+                            }
+                        }
+                    })),
+                },
+            )
+            .await
+            .expect("repair terminal event");
+        assert_eq!(outcome, TerminalizationOutcome::Noop);
+
+        let emitted = events.replay_all().await.expect("replay events");
+        assert_eq!(emitted.len(), 1);
+        match &emitted[0].kind {
+            MobEventKind::FlowCompleted {
+                structured_output, ..
+            } => assert_eq!(
+                structured_output,
+                &Some(serde_json::json!({
+                    "steps": {
+                        "step-1": {
+                            "answer": 42
+                        }
+                    }
+                }))
+            ),
+            other => panic!("expected FlowCompleted, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn test_completed_terminalization_repair_is_idempotent() {
+        let run_store = Arc::new(RecordingRunStore::new());
+        let events = Arc::new(FaultInjectedEventStore::default());
+        let authority = FlowTerminalizationAuthority::new(
+            run_store.clone(),
+            events.clone(),
+            MobId::from("mob"),
+        );
+
+        let run_id = RunId::new();
+        run_store
+            .create_run(sample_run(run_id.clone(), MobRunStatus::Completed))
+            .await
+            .expect("create run");
+
+        authority
+            .record_persisted_terminalization(
+                run_id.clone(),
+                FlowId::from("flow"),
+                TerminalizationTarget::Completed {
+                    structured_output: Some(serde_json::json!({"steps": {"step-1": "ok"}})),
+                },
+            )
+            .await
+            .expect("record terminal event");
+        let outcome = authority
+            .repair_persisted_terminalization(
+                run_id.clone(),
+                FlowId::from("flow"),
+                TerminalizationTarget::Completed {
+                    structured_output: Some(serde_json::json!({"steps": {"step-1": "ok"}})),
+                },
+            )
+            .await
+            .expect("repair terminal event");
+
+        assert_eq!(outcome, TerminalizationOutcome::Noop);
+        assert_eq!(events.replay_all().await.expect("replay events").len(), 1);
+    }
+
+    #[tokio::test]
+    async fn test_completed_terminalization_repair_uses_persisted_status() {
+        let run_store = Arc::new(RecordingRunStore::new());
+        let events = Arc::new(FaultInjectedEventStore::default());
+        let authority = FlowTerminalizationAuthority::new(
+            run_store.clone(),
+            events.clone(),
+            MobId::from("mob"),
+        );
+
+        let run_id = RunId::new();
+        let mut run = sample_run(run_id.clone(), MobRunStatus::Completed);
+        run.root_step_outputs
+            .insert(StepId::from("step-1"), serde_json::json!({"answer": 42}));
+        run_store.create_run(run).await.expect("create run");
+
+        let outcome = authority
+            .repair_persisted_terminalization(
+                run_id.clone(),
+                FlowId::from("flow"),
+                TerminalizationTarget::Failed {
+                    reason: "fallback failure".to_string(),
+                },
+            )
+            .await
+            .expect("repair terminal event");
+        assert_eq!(outcome, TerminalizationOutcome::Noop);
+
+        let emitted = events.replay_all().await.expect("replay events");
+        assert_eq!(emitted.len(), 1);
+        match &emitted[0].kind {
+            MobEventKind::FlowCompleted {
+                structured_output, ..
+            } => assert_eq!(
+                structured_output,
+                &Some(serde_json::json!({
+                    "steps": {
+                        "step-1": {
+                            "answer": 42
+                        }
+                    }
+                }))
+            ),
+            other => panic!("expected FlowCompleted repair, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn test_completed_terminalization_repair_preserves_loop_outputs() {
+        let run_store = Arc::new(RecordingRunStore::new());
+        let events = Arc::new(FaultInjectedEventStore::default());
+        let authority = FlowTerminalizationAuthority::new(
+            run_store.clone(),
+            events.clone(),
+            MobId::from("mob"),
+        );
+
+        let run_id = RunId::new();
+        let mut run = sample_run(run_id.clone(), MobRunStatus::Completed);
+        let mut iteration = indexmap::IndexMap::new();
+        iteration.insert(StepId::from("body-step"), serde_json::json!({"loop": true}));
+        run.loop_iteration_outputs
+            .insert(LoopId::from("loop-1"), vec![iteration]);
+        run_store.create_run(run).await.expect("create run");
+
+        let outcome = authority
+            .repair_persisted_terminalization(
+                run_id.clone(),
+                FlowId::from("flow"),
+                TerminalizationTarget::Failed {
+                    reason: "fallback failure".to_string(),
+                },
+            )
+            .await
+            .expect("repair terminal event");
+        assert_eq!(outcome, TerminalizationOutcome::Noop);
+
+        let emitted = events.replay_all().await.expect("replay events");
+        assert_eq!(emitted.len(), 1);
+        match &emitted[0].kind {
+            MobEventKind::FlowCompleted {
+                structured_output, ..
+            } => assert_eq!(
+                structured_output,
+                &Some(serde_json::json!({
+                    "steps": {
+                        "body-step": {
+                            "loop": true
+                        }
+                    }
+                }))
+            ),
+            other => panic!("expected FlowCompleted repair, got {other:?}"),
+        }
     }
 
     #[tokio::test]

--- a/meerkat-mob/src/runtime/tests.rs
+++ b/meerkat-mob/src/runtime/tests.rs
@@ -13,7 +13,7 @@ use crate::store::{
     ExternalBindingOverlayRecord, ExternalBindingOverlayStatus, InMemoryMobEventStore,
     InMemoryMobRunStore, InMemoryMobRuntimeMetadataStore, InMemoryMobSpecStore, MobEventStore,
     MobRunStore, MobRuntimeMetadataStore, MobStoreError, RealmProfileStore,
-    SupervisorAuthorityRecord,
+    SupervisorAuthorityRecord, terminal_event_identity,
 };
 use async_trait::async_trait;
 use chrono::Utc;
@@ -1275,6 +1275,7 @@ impl SessionService for MockSessionService {
                             AgentEvent::RunCompleted {
                                 session_id,
                                 result: completed_result,
+                                structured_output: None,
                                 usage: Usage::default(),
                                 terminal_cause_kind: None,
                             },
@@ -1466,6 +1467,7 @@ impl SubscribableInjector for CountingInjector {
                 AgentEvent::InteractionComplete {
                     interaction_id: interaction_id_for_task,
                     result: completed_result,
+                    structured_output: None,
                 }
             };
             let _ = tx.send(event).await;
@@ -1700,6 +1702,10 @@ impl FaultInjectedMobEventStore {
         self.fail_on_kind.write().await.insert(kind);
     }
 
+    async fn allow_appends_for(&self, kind: &'static str) {
+        self.fail_on_kind.write().await.remove(kind);
+    }
+
     fn replay_calls(&self) -> u64 {
         self.replay_calls.load(Ordering::Relaxed)
     }
@@ -1762,6 +1768,50 @@ impl MobEventStore for FaultInjectedMobEventStore {
         drop(events);
         let _ = self.event_tx.send(stored.clone());
         Ok(stored)
+    }
+
+    async fn append_terminal_event_if_absent(
+        &self,
+        event: NewMobEvent,
+    ) -> Result<Option<MobEvent>, MobStoreError> {
+        let Some((run_id, flow_id)) = terminal_event_identity(&event.kind) else {
+            return Err(MobStoreError::Internal(
+                "append_terminal_event_if_absent requires a terminal flow event".to_string(),
+            ));
+        };
+        let run_id = run_id.clone();
+        let flow_id = flow_id.clone();
+        let mob_id = event.mob_id.clone();
+
+        let mut events = self.events.write().await;
+        if events.iter().any(|existing| {
+            existing.mob_id == mob_id
+                && terminal_event_identity(&existing.kind).is_some_and(
+                    |(existing_run_id, existing_flow_id)| {
+                        existing_run_id == &run_id && existing_flow_id == &flow_id
+                    },
+                )
+        }) {
+            return Ok(None);
+        }
+
+        let kind_label = Self::kind_label(&event.kind);
+        if self.fail_on_kind.read().await.contains(kind_label) {
+            return Err(MobStoreError::Internal(format!(
+                "fault-injected append failure for {kind_label}"
+            )));
+        }
+        let cursor = events.len() as u64 + 1;
+        let stored = MobEvent {
+            cursor,
+            timestamp: Utc::now(),
+            mob_id: event.mob_id,
+            kind: event.kind,
+        };
+        events.push(stored.clone());
+        drop(events);
+        let _ = self.event_tx.send(stored.clone());
+        Ok(Some(stored))
     }
 
     async fn poll(&self, after_cursor: u64, limit: usize) -> Result<Vec<MobEvent>, MobStoreError> {
@@ -4537,6 +4587,7 @@ impl SessionAgent for OverlayProbeSessionAgent {
             .send(AgentEvent::RunCompleted {
                 session_id,
                 result: result.text.clone(),
+                structured_output: result.structured_output.clone(),
                 usage: result.usage.clone(),
                 terminal_cause_kind: None,
             })
@@ -17440,7 +17491,9 @@ async fn test_flow_run_start_and_completion_persist_authority_inputs_with_projec
         .commit_flow_terminalization(
             run_id.clone(),
             FlowId::from("test-flow"),
-            super::terminalization::TerminalizationTarget::Completed,
+            super::terminalization::TerminalizationTarget::Completed {
+                structured_output: None,
+            },
             crate::run::MobMachineFlowRunCommand::TerminalizeCompleted(
                 crate::run::flow_run::inputs::TerminalizeCompleted {},
             ),
@@ -18268,8 +18321,11 @@ async fn test_flow_failed_append_failure_records_coherence_failure_ledger_entry(
 async fn test_flow_completed_append_failure_records_coherence_failure_ledger_entry() {
     let events = Arc::new(FaultInjectedMobEventStore::new());
     events.fail_appends_for("FlowCompleted").await;
-    let (handle, _service) =
-        create_test_mob_with_events(sample_definition_with_single_step_flow(500, 8), events).await;
+    let (handle, _service) = create_test_mob_with_events(
+        sample_definition_with_single_step_flow(500, 8),
+        events.clone(),
+    )
+    .await;
     handle
         .spawn(ProfileName::from("worker"), MeerkatId::from("w-1"), None)
         .await
@@ -18301,6 +18357,62 @@ async fn test_flow_completed_append_failure_records_coherence_failure_ledger_ent
     assert_eq!(
         machine_state.active_run_count, 0,
         "terminal append failure must not leave MobMachine active_run_count running"
+    );
+    let events_after_failed_append = handle.events().replay_all().await.expect("replay events");
+    assert!(
+        !events_after_failed_append
+            .iter()
+            .any(|event| matches!(&event.kind, MobEventKind::FlowFailed { run_id: id, .. } if id == &run_id)),
+        "fallback error handling must not append FlowFailed for a run persisted as Completed"
+    );
+
+    events.allow_appends_for("FlowCompleted").await;
+    let outcome = handle
+        .commit_flow_terminalization(
+            run_id.clone(),
+            FlowId::from("demo"),
+            super::terminalization::TerminalizationTarget::Completed {
+                structured_output: Some(serde_json::json!({
+                    "steps": {
+                        "start": "Turn completed"
+                    }
+                })),
+            },
+            crate::run::MobMachineFlowRunCommand::TerminalizeCompleted(
+                crate::run::flow_run::inputs::TerminalizeCompleted {},
+            ),
+            "test_repair_flow_completed_event",
+        )
+        .await
+        .expect("retry should repair missing FlowCompleted event");
+    assert_eq!(
+        outcome,
+        super::terminalization::TerminalizationOutcome::Noop
+    );
+
+    let events = handle.events().replay_all().await.expect("replay events");
+    assert!(
+        !events
+            .iter()
+            .any(|event| matches!(&event.kind, MobEventKind::FlowFailed { run_id: id, .. } if id == &run_id)),
+        "completed repair must not leave a duplicate wrong FlowFailed event"
+    );
+    let completed = events.iter().find_map(|event| match &event.kind {
+        MobEventKind::FlowCompleted {
+            run_id: event_run_id,
+            structured_output,
+            ..
+        } if event_run_id == &run_id => Some(structured_output),
+        _ => None,
+    });
+    assert_eq!(
+        completed,
+        Some(&Some(serde_json::json!({
+            "steps": {
+                "start": "Turn completed"
+            }
+        }))),
+        "retry should repair missing FlowCompleted event with structured output"
     );
 }
 

--- a/meerkat-mob/src/runtime/turn_executor.rs
+++ b/meerkat-mob/src/runtime/turn_executor.rs
@@ -5,6 +5,7 @@ use crate::tokio;
 use async_trait::async_trait;
 use meerkat_core::service::TurnToolOverlay;
 use meerkat_core::types::ContentInput;
+use serde_json::Value;
 use std::fmt;
 use std::sync::Arc;
 use std::time::Duration;
@@ -32,8 +33,13 @@ impl fmt::Debug for FlowTurnTicket {
 
 #[derive(Debug)]
 pub enum FlowTurnOutcome {
-    Completed { output: String },
-    Failed { reason: String },
+    Completed {
+        output: String,
+        structured_output: Option<Value>,
+    },
+    Failed {
+        reason: String,
+    },
     Canceled,
 }
 

--- a/meerkat-mob/src/store/in_memory.rs
+++ b/meerkat-mob/src/store/in_memory.rs
@@ -3,7 +3,7 @@
 use super::realm_profile::{RealmProfileStore, StoredRealmProfile};
 use super::{
     ExternalBindingOverlayRecord, MobEventStore, MobRunStore, MobRuntimeMetadataStore,
-    MobSpecStore, MobStoreError, SupervisorAuthorityRecord,
+    MobSpecStore, MobStoreError, SupervisorAuthorityRecord, terminal_event_identity,
 };
 use crate::definition::MobDefinition;
 use crate::event::{MobEvent, NewMobEvent};
@@ -205,6 +205,44 @@ impl MobEventStore for InMemoryMobEventStore {
         drop(events);
         let _ = self.event_tx.send(stored.clone());
         Ok(stored)
+    }
+
+    async fn append_terminal_event_if_absent(
+        &self,
+        event: NewMobEvent,
+    ) -> Result<Option<MobEvent>, MobStoreError> {
+        let Some((run_id, flow_id)) = terminal_event_identity(&event.kind) else {
+            return Err(MobStoreError::Internal(
+                "append_terminal_event_if_absent requires a terminal flow event".to_string(),
+            ));
+        };
+        let run_id = run_id.clone();
+        let flow_id = flow_id.clone();
+        let mob_id = event.mob_id.clone();
+
+        let mut events = self.events.write().await;
+        if events.iter().any(|existing| {
+            existing.mob_id == mob_id
+                && terminal_event_identity(&existing.kind).is_some_and(
+                    |(existing_run_id, existing_flow_id)| {
+                        existing_run_id == &run_id && existing_flow_id == &flow_id
+                    },
+                )
+        }) {
+            return Ok(None);
+        }
+
+        let cursor = events.last().map_or(1, |existing| existing.cursor + 1);
+        let stored = MobEvent {
+            cursor,
+            timestamp: event.timestamp.unwrap_or_else(Utc::now),
+            mob_id: event.mob_id,
+            kind: event.kind,
+        };
+        events.push(stored.clone());
+        drop(events);
+        let _ = self.event_tx.send(stored.clone());
+        Ok(Some(stored))
     }
 
     async fn append_batch(&self, batch: Vec<NewMobEvent>) -> Result<Vec<MobEvent>, MobStoreError> {

--- a/meerkat-mob/src/store/mod.rs
+++ b/meerkat-mob/src/store/mod.rs
@@ -17,7 +17,7 @@ pub use sqlite::{
 };
 
 use crate::definition::MobDefinition;
-use crate::event::{MemberRef, MobEvent, NewMobEvent};
+use crate::event::{MemberRef, MobEvent, MobEventKind, NewMobEvent};
 use crate::ids::{
     AgentIdentity, FlowId, FrameId, Generation, LoopId, LoopInstanceId, MobId, RunId, StepId,
 };
@@ -37,6 +37,19 @@ use tokio::sync::broadcast;
 
 /// Receiver for append-driven structural mob events.
 pub type MobEventReceiver = broadcast::Receiver<MobEvent>;
+
+pub(crate) fn terminal_event_identity(kind: &MobEventKind) -> Option<(&RunId, &FlowId)> {
+    match kind {
+        MobEventKind::FlowCompleted {
+            run_id, flow_id, ..
+        }
+        | MobEventKind::FlowFailed {
+            run_id, flow_id, ..
+        }
+        | MobEventKind::FlowCanceled { run_id, flow_id } => Some((run_id, flow_id)),
+        _ => None,
+    }
+}
 
 /// Frame-aware atomic persistence operation required by the flow/frame store contract.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
@@ -185,6 +198,13 @@ pub struct ExternalBindingOverlayRecord {
 pub trait MobEventStore: Send + Sync {
     /// Append a new event to the store.
     async fn append(&self, event: NewMobEvent) -> Result<MobEvent, MobStoreError>;
+
+    /// Append a terminal flow event only when no terminal event for the same
+    /// mob/run/flow has already been persisted.
+    async fn append_terminal_event_if_absent(
+        &self,
+        event: NewMobEvent,
+    ) -> Result<Option<MobEvent>, MobStoreError>;
 
     /// Append multiple events atomically.
     ///

--- a/meerkat-mob/src/store/sqlite.rs
+++ b/meerkat-mob/src/store/sqlite.rs
@@ -6,7 +6,7 @@
 use super::realm_profile::{RealmProfileStore, StoredRealmProfile};
 use super::{
     ExternalBindingOverlayRecord, MobEventStore, MobRunStore, MobRuntimeMetadataStore,
-    MobSpecStore, MobStoreError, SupervisorAuthorityRecord,
+    MobSpecStore, MobStoreError, SupervisorAuthorityRecord, terminal_event_identity,
 };
 use crate::definition::MobDefinition;
 use crate::error::MobError;
@@ -779,6 +779,70 @@ impl MobEventStore for SqliteMobEventStore {
         })
         .await?;
         self.event_bus.publish_committed(stored.clone());
+        Ok(stored)
+    }
+
+    async fn append_terminal_event_if_absent(
+        &self,
+        event: NewMobEvent,
+    ) -> Result<Option<MobEvent>, MobStoreError> {
+        let Some((run_id, flow_id)) = terminal_event_identity(&event.kind) else {
+            return Err(MobStoreError::Internal(
+                "append_terminal_event_if_absent requires a terminal flow event".to_string(),
+            ));
+        };
+        let run_id = run_id.clone();
+        let flow_id = flow_id.clone();
+        let mob_id = event.mob_id.clone();
+
+        let path = self.path.clone();
+        let stored = run_sqlite_task(move || {
+            let mut conn = open_connection(&path)?;
+            let tx = begin_immediate(&mut conn)?;
+            let mut stmt = tx
+                .prepare("SELECT event_json FROM mob_events ORDER BY cursor")
+                .map_err(se)?;
+            let rows = stmt
+                .query_map([], |row| row.get::<_, Vec<u8>>(0))
+                .map_err(se)?;
+            for row in rows {
+                let bytes = row.map_err(se)?;
+                let existing = decode_stored_mob_event(&bytes)
+                    .map_err(|e| MobStoreError::Serialization(e.to_string()))?;
+                if existing.mob_id == mob_id
+                    && terminal_event_identity(&existing.kind).is_some_and(
+                        |(existing_run_id, existing_flow_id)| {
+                            existing_run_id == &run_id && existing_flow_id == &flow_id
+                        },
+                    )
+                {
+                    return Ok(None);
+                }
+            }
+            drop(stmt);
+
+            let cursor = next_event_cursor(&tx)?;
+            let stored = MobEvent {
+                cursor,
+                timestamp: event.timestamp.unwrap_or_else(Utc::now),
+                mob_id: event.mob_id,
+                kind: event.kind,
+            };
+            let encoded = encode_stored_mob_event(&stored)
+                .map_err(|e| MobStoreError::Serialization(e.to_string()))?;
+            tx.execute(
+                "INSERT INTO mob_events (cursor, event_json) VALUES (?1, ?2)",
+                params![cursor_to_i64(cursor)?, encoded],
+            )
+            .map_err(se)?;
+            set_next_cursor(&tx, cursor.saturating_add(1))?;
+            tx.commit().map_err(se)?;
+            Ok(Some(stored))
+        })
+        .await?;
+        if let Some(stored) = stored.as_ref() {
+            self.event_bus.publish_committed(stored.clone());
+        }
         Ok(stored)
     }
 

--- a/meerkat-runtime/src/comms_drain.rs
+++ b/meerkat-runtime/src/comms_drain.rs
@@ -1814,10 +1814,12 @@ fn interaction_terminal_event(
         CompletionOutcome::Completed(result) => AgentEvent::InteractionComplete {
             interaction_id,
             result: result.text,
+            structured_output: result.structured_output,
         },
         CompletionOutcome::CompletedWithoutResult => AgentEvent::InteractionComplete {
             interaction_id,
             result: String::new(),
+            structured_output: None,
         },
         CompletionOutcome::CallbackPending { tool_name, args } => {
             AgentEvent::InteractionCallbackPending {
@@ -2929,6 +2931,38 @@ mod tests {
             ),
             lifecycle_peer: Some("peer-1".to_string()),
             response_terminality: None,
+        }
+    }
+
+    #[test]
+    fn completed_outcome_maps_structured_output_to_interaction_complete() {
+        let interaction_id = InteractionId(Uuid::new_v4());
+        let event = interaction_terminal_event(
+            interaction_id,
+            CompletionOutcome::Completed(meerkat_core::RunResult {
+                text: "{\"answer\":42}".to_string(),
+                session_id: meerkat_core::SessionId::new(),
+                usage: meerkat_core::Usage::default(),
+                turns: 1,
+                tool_calls: 0,
+                terminal_cause_kind: None,
+                structured_output: Some(json!({"answer": 42})),
+                schema_warnings: None,
+                skill_diagnostics: None,
+            }),
+        );
+
+        match event {
+            AgentEvent::InteractionComplete {
+                interaction_id: actual_id,
+                result,
+                structured_output,
+            } => {
+                assert_eq!(actual_id, interaction_id);
+                assert_eq!(result, "{\"answer\":42}");
+                assert_eq!(structured_output, Some(json!({"answer": 42})));
+            }
+            other => panic!("expected InteractionComplete, got {other:?}"),
         }
     }
 

--- a/meerkat-session/src/ephemeral.rs
+++ b/meerkat-session/src/ephemeral.rs
@@ -2878,6 +2878,7 @@ fn apply_runtime_system_context_and_publish<A: SessionAgent>(
             AgentEvent::RunCompleted {
                 session_id,
                 result: String::new(),
+                structured_output: None,
                 usage: Usage::default(),
                 terminal_cause_kind: None,
             },
@@ -2911,6 +2912,7 @@ fn publish_runtime_system_context_events<A: SessionAgent>(
             AgentEvent::RunCompleted {
                 session_id,
                 result: String::new(),
+                structured_output: None,
                 usage: Usage::default(),
                 terminal_cause_kind: None,
             },

--- a/meerkat-session/src/persistent.rs
+++ b/meerkat-session/src/persistent.rs
@@ -3824,6 +3824,7 @@ mod tests {
                 .send(AgentEvent::RunCompleted {
                     session_id,
                     result: result.text.clone(),
+                    structured_output: result.structured_output.clone(),
                     usage: result.usage.clone(),
                     terminal_cause_kind: result.terminal_cause_kind,
                 })

--- a/meerkat-session/src/projector.rs
+++ b/meerkat-session/src/projector.rs
@@ -375,6 +375,7 @@ mod tests {
                 AgentEvent::RunCompleted {
                     session_id: sid.clone(),
                     result: "Hi there!".to_string(),
+                    structured_output: None,
                     usage: Usage::default(),
                     terminal_cause_kind: None,
                 },

--- a/meerkat-session/tests/regression_lifecycle.rs
+++ b/meerkat-session/tests/regression_lifecycle.rs
@@ -112,6 +112,7 @@ impl SessionAgent for MockAgent {
             .send(AgentEvent::RunCompleted {
                 session_id: self.session_id.clone(),
                 result: "Hello from mock".to_string(),
+                structured_output: None,
                 usage: usage.clone(),
                 terminal_cause_kind: None,
             })

--- a/sdks/python/meerkat/events.py
+++ b/sdks/python/meerkat/events.py
@@ -93,6 +93,7 @@ class RunCompleted(Event):
     result: str = ""
     usage: Usage = field(default_factory=Usage)
     terminal_cause_kind: TurnTerminalCauseKind | None = None
+    structured_output: Any = None
 
 
 TurnTerminalOutcome = Literal[
@@ -426,6 +427,7 @@ class InteractionComplete(Event):
 
     interaction_id: str = ""
     result: str = ""
+    structured_output: Any = None
 
 
 @dataclass(frozen=True, slots=True)

--- a/sdks/python/tests/test_types.py
+++ b/sdks/python/tests/test_types.py
@@ -67,6 +67,7 @@ from meerkat.events import (
     CompactionStarted,
     Event,
     HookDenied,
+    InteractionComplete,
     Retrying,
     RunCompleted,
     RunFailed,
@@ -1063,6 +1064,19 @@ def test_parse_turn_started():
     assert event.turn_number == 3
 
 
+def test_parse_interaction_complete_structured_output():
+    raw = {
+        "type": "interaction_complete",
+        "interaction_id": "i1",
+        "result": "{\"answer\":42}",
+        "structured_output": {"answer": 42},
+    }
+    event = parse_event(raw)
+    assert isinstance(event, InteractionComplete)
+    assert event.interaction_id == "i1"
+    assert event.structured_output == {"answer": 42}
+
+
 def test_parse_scoped_mob_event_omits_runtime_binding_atoms():
     raw = {
         "scope_id": "mob:writer",
@@ -1415,12 +1429,14 @@ def test_parse_run_completed():
         "type": "run_completed",
         "session_id": "abc-123",
         "result": "Done!",
+        "structured_output": {"answer": 42},
         "usage": {"input_tokens": 100, "output_tokens": 50},
     }
     event = parse_event(raw)
     assert isinstance(event, RunCompleted)
     assert event.session_id == "abc-123"
     assert event.result == "Done!"
+    assert event.structured_output == {"answer": 42}
     assert event.usage.input_tokens == 100
 
 

--- a/sdks/typescript/src/events.ts
+++ b/sdks/typescript/src/events.ts
@@ -116,6 +116,7 @@ export interface RunCompletedEvent {
   readonly type: "run_completed";
   readonly sessionId: string;
   readonly result: string;
+  readonly structuredOutput?: unknown;
   readonly usage: Usage;
   readonly terminalCauseKind?: TurnTerminalCauseKind;
 }
@@ -384,6 +385,7 @@ export interface InteractionCompleteEvent {
   readonly type: "interaction_complete";
   readonly interactionId: string;
   readonly result: string;
+  readonly structuredOutput?: unknown;
 }
 
 export interface InteractionFailedEvent {
@@ -1018,6 +1020,7 @@ export function parseCoreEvent(raw: Record<string, unknown>): AgentEvent {
         type,
         sessionId: requireStringField(raw, "session_id"),
         result: requireStringField(raw, "result"),
+        ...(raw.structured_output !== undefined ? { structuredOutput: raw.structured_output } : {}),
         usage: parseUsage(raw.usage),
         ...terminalCauseKindField(raw),
       };
@@ -1131,7 +1134,12 @@ export function parseCoreEvent(raw: Record<string, unknown>): AgentEvent {
 
     // Interaction (comms)
     case "interaction_complete":
-      return { type, interactionId: requireStringField(raw, "interaction_id"), result: requireStringField(raw, "result") };
+      return {
+        type,
+        interactionId: requireStringField(raw, "interaction_id"),
+        result: requireStringField(raw, "result"),
+        ...(raw.structured_output !== undefined ? { structuredOutput: raw.structured_output } : {}),
+      };
     case "interaction_failed":
       return { type, interactionId: requireStringField(raw, "interaction_id"), error: requireStringField(raw, "error") };
 

--- a/sdks/typescript/tests/types.test.js
+++ b/sdks/typescript/tests/types.test.js
@@ -137,6 +137,20 @@ describe("Typed Events", () => {
     }
   });
 
+  it("should parse interaction_complete structured output", () => {
+    const event = parseEvent({
+      type: "interaction_complete",
+      interaction_id: "i1",
+      result: "{\"answer\":42}",
+      structured_output: { answer: 42 },
+    });
+    assert.equal(event.type, "interaction_complete");
+    if (event.type === "interaction_complete") {
+      assert.equal(event.interactionId, "i1");
+      assert.deepEqual(event.structuredOutput, { answer: 42 });
+    }
+  });
+
   it("should parse turn_completed with usage in camelCase", () => {
     const event = parseEvent({
       type: "turn_completed",
@@ -268,11 +282,13 @@ describe("Typed Events", () => {
       type: "run_completed",
       session_id: "abc-123",
       result: "Done!",
+      structured_output: { answer: 42 },
       usage: { input_tokens: 100, output_tokens: 50 },
     });
     if (isRunCompleted(event)) {
       assert.equal(event.sessionId, "abc-123");
       assert.equal(event.result, "Done!");
+      assert.deepEqual(event.structuredOutput, { answer: 42 });
       assert.equal(event.usage.inputTokens, 100);
     } else {
       assert.fail("Expected RunCompletedEvent");

--- a/sdks/web/src/generated/events.ts
+++ b/sdks/web/src/generated/events.ts
@@ -255,6 +255,7 @@ export interface RunStartedEvent {
 export interface RunCompletedEvent {
   result: string;
   session_id: SessionId;
+  structured_output?: unknown;
   terminal_cause_kind?: TurnTerminalCauseKind | null;
   type: "run_completed";
   usage: Usage;
@@ -420,6 +421,7 @@ export interface SkillResolutionFailedEvent {
 export interface InteractionCompleteEvent {
   interaction_id: InteractionId;
   result: string;
+  structured_output?: unknown;
   type: "interaction_complete";
 }
 

--- a/tests/integration/tests/phase2_mode_routing.rs
+++ b/tests/integration/tests/phase2_mode_routing.rs
@@ -78,6 +78,7 @@ impl SubscribableInjector for MockInjector {
                 .send(AgentEvent::InteractionComplete {
                     interaction_id: interaction_id_for_task,
                     result: "ok".to_string(),
+                    structured_output: None,
                 })
                 .await;
         });


### PR DESCRIPTION
## Summary
- Add structured_output to agent run/interaction completion events and propagate it from run results.
- Add structured_output to mob FlowCompleted events, preserving typed flow outputs through normal completion and repair paths.
- Regenerate event schemas and update Python/TypeScript SDK event parsing/tests.

## Validation
- MEERKAT_BUILDBUDDY=1 make check (BuildBuddy invocation 5fee5c25-dd8a-45c9-bf44-838c05e7de58)
- make fmt
- make verify-schema-freshness
- ./scripts/repo-cargo check -p meerkat-core -p meerkat-runtime -p meerkat-mob -p meerkat-mob-mcp -p meerkat-contracts -p meerkat-session --tests
- ./scripts/repo-cargo test -p meerkat-runtime completed_outcome_maps_structured_output_to_interaction_complete
- ./scripts/repo-cargo test -p meerkat-mob structured_output
- ./scripts/repo-cargo test -p meerkat-mob completed_output_value
- ./scripts/repo-cargo test -p meerkat-mob terminalization_repair
- ./scripts/repo-cargo test -p meerkat-mob test_flow_completed_append_failure_records_coherence_failure_ledger_entry
- make test-sdk-typescript
- Python SDK tests in isolated venv: 169 passed, 11 skipped (make test-sdk-python is blocked by host PEP 668 externally-managed Python)

Linear: LUC-439
