### PR TITLE
Refresh platform help skill CLI facts

### DIFF
--- a/.claude/skills/meerkat-platform/SKILL.md
+++ b/.claude/skills/meerkat-platform/SKILL.md
@@ -70,6 +70,46 @@ When a mob member runs in a different process or host, declare it with `MobBacke
 For full per-surface schemas and examples, load: `references/api_reference.md`.
 For detailed mob behavior across all surfaces, load: `references/mobs.md`.
 
+## MCP server config (CLI)
+
+Use `rkat mcp ...` to manage local MCP server configuration. This writes config; new `rkat run` and `rkat resume` sessions load configured MCP servers and expose their tools to the agent.
+
+Config locations:
+
+- Project scope (default): `.rkat/mcp.toml`
+- User scope: `~/.rkat/mcp.toml`
+
+Command forms:
+
+```bash
+rkat mcp add <NAME> [--transport stdio|http|sse] [--scope project|user|local] [-H KEY:VALUE...] [-e KEY=VALUE...] (--url <URL> | -- <CMD...>)
+rkat mcp remove <NAME> [--scope project|user|local]
+rkat mcp list [--scope project|user|local|all] [--json]
+rkat mcp get <NAME> [--scope project|user|local|all] [--json]
+```
+
+Examples:
+
+```bash
+# stdio server; command and args go after --
+rkat mcp add filesystem -- npx -y @modelcontextprotocol/server-filesystem .
+
+# HTTP server
+rkat mcp add linear --transport http --url https://mcp.example.com
+
+# User-wide server with environment passed to the stdio process
+rkat mcp add github --scope user -e GITHUB_TOKEN=ghp_... -- npx -y @modelcontextprotocol/server-github
+
+rkat mcp list --scope all
+rkat mcp get filesystem --scope project
+```
+
+Notes:
+
+- Use `--transport http` for streamable HTTP and `--transport sse` for legacy SSE.
+- `-H KEY:VALUE` is for HTTP/SSE headers; `-e KEY=VALUE` is for stdio process environment.
+- `rkat mcp` is a config surface. Live mutation of a running session uses JSON-RPC `mcp/add|remove|reload`, REST `POST /sessions/{id}/mcp/*`, MCP-server tools, or SDK helpers.
+
 ## Mob behavior (current contract)
 
 - CLI `run`/`resume` compose `mob_*` tools through `meerkat-mob-mcp` dispatcher integration.
@@ -273,6 +313,7 @@ rkat "What is Rust?"                     # "run" is the default subcommand
 rkat run "What is Rust?"                 # equivalent explicit form
 rkat --realm team-alpha run "Create a todo app" --tools workspace --stream -v
 # Global flags: --realm, --isolated, --instance, --realm-backend, --state-root, --context-root, --user-config-root
+rkat help "How do I add an MCP server?"
 rkat run --resume "keep going"           # resume most recent session
 rkat run --resume 019c8b99 "continue"    # resume by short prefix
 rkat --realm team-alpha run --resume sid_abc123 "Now add error handling"
@@ -375,7 +416,7 @@ Every session resolves credentials through realm-scoped bindings. Two onramps:
 
 ```bash
 rkat auth login anthropic                                            # OAuth (PKCE S256)
-rkat --auth-binding prod:claude run "ship the release notes"
+rkat run --auth-binding prod:claude "ship the release notes"
 ```
 
 Supported auth methods:
@@ -494,6 +535,7 @@ Canonical skill identity is `SkillKey { source_uuid, skill_name }`. `preload_ski
 **Skill introspection** surfaces:
 
 - CLI: `rkat skill list [--json]`, `rkat skill inspect <skill-name> --source-uuid <uuid> [--json]`
+- CLI config: `rkat skill add <PATH_OR_ID> [--name <NAME>]`, `rkat skill remove <NAME_OR_ID_OR_PATH>`, `rkat skill get <NAME_OR_ID_OR_PATH> [--json]`
 - RPC: `skills/list`
 - REST: `GET /skills`
 - MCP: `meerkat_skills` tool (`action: "list"` or `"inspect"` with typed `skill_key` and optional `source` UUID)
@@ -535,7 +577,8 @@ Tool visibility can change during a session without restarting the agent. All ch
 
 - **External filters** — allow-list or deny-list staged via `ToolScopeHandle`, applied at `CallingLlm` boundary. Persisted in session metadata (`tool_scope_external_filter`).
 - **Per-turn overlay** — `TurnToolOverlay` on `StartTurnRequest.flow_tool_overlay`. Ephemeral, used by mob flow steps to restrict tools per step.
-- **Live MCP mutation** — `mcp/add`, `mcp/remove`, `mcp/reload` stage server changes on the `McpRouter`. Applied at next turn boundary. Removals drain in-flight calls before finalizing.
+- **Configured MCP servers** — CLI `rkat mcp add/remove/list/get` edits `.rkat/mcp.toml` or `~/.rkat/mcp.toml`. New `rkat run` and `rkat resume` sessions load that config.
+- **Live MCP mutation** — JSON-RPC `mcp/add`, `mcp/remove`, `mcp/reload`, REST `POST /sessions/{id}/mcp/*`, MCP-server tools, and SDK helpers stage server changes on the `McpRouter`. Applied at next turn boundary. Removals drain in-flight calls before finalizing.
 - **Async MCP loading** — At startup, MCP servers connect in parallel in the background. The agent loop polls `poll_external_updates()` at each `CallingLlm` boundary. Tools appear as each server completes its handshake. A `[MCP_PENDING]` system notice is injected while servers are still connecting.
   - Per-server timeout: `connect_timeout_secs` in `.rkat/mcp.toml` (default: 10s)
   - CLI: `--wait-for-mcp` flag blocks before the first turn until all servers finish connecting
@@ -546,11 +589,12 @@ Tool visibility can change during a session without restarting the agent. All ch
 
 Surface availability:
 
-| Surface | Live MCP | Tool filter | Status |
-|---------|----------|-------------|--------|
-| JSON-RPC | `mcp/add`, `mcp/remove`, `mcp/reload` | Via session runtime | Fully wired |
-| REST | `POST /sessions/{id}/mcp/*` | — | Fully wired |
-| CLI | `rkat mcp reload --session --live-server-url` | — | Host-managed live reload flow |
+| Surface | MCP config / live mutation | Tool filter | Status |
+|---------|----------------------------|-------------|--------|
+| CLI | `rkat mcp add/remove/list/get` edits project/user config | — | Config surface |
+| JSON-RPC | `mcp/add`, `mcp/remove`, `mcp/reload` live session mutation | Via session runtime | Fully wired |
+| REST | `POST /sessions/{id}/mcp/add|remove|reload` live session mutation | — | Fully wired |
+| MCP server | `meerkat_mcp_add`, `meerkat_mcp_remove`, `meerkat_mcp_reload` live session mutation | — | Fully wired |
 
 ### Memory
 

--- a/.claude/skills/meerkat-platform/references/api_reference.md
+++ b/.claude/skills/meerkat-platform/references/api_reference.md
@@ -57,13 +57,15 @@ rkat session list [--limit N] [--offset N] [--label KEY=VALUE]
 rkat session show <ID>
 rkat session delete <ID>
 rkat session interrupt <ID>
-rkat comms send <SESSION-ID> --json <JSON>        # (comms feature)
-rkat comms peers <SESSION-ID>                     # (comms feature)
+rkat realtime open-info|status|capabilities|bridge session <SESSION-ID>
+rkat realtime open-info|status|capabilities|bridge member <MOB-ID> <AGENT-IDENTITY>
+rkat blob get <BLOB-ID> [--output <FILE>] [--json]
 rkat realm current|list|show
-rkat skill list [--json]
-rkat skill inspect <skill-name> --source-uuid <uuid> [--json]
-rkat models [--json]
-rkat auth login|logout|status|profile ...
+rkat mcp add|remove|list|get ...
+rkat skill add|remove|get|list|inspect ...
+rkat models
+rkat help <QUESTION> [--prompt <PROMPT>] [--plan-execution]
+rkat auth realms|profiles|profile|profile-delete|bindings|test|status|login|logout|refresh ...
 # (Scheduling has no top-level CLI subcommand. Schedules are managed
 # through the agent tools `meerkat_schedule_*` from `rkat run`,
 # the RPC `schedule/*` methods, REST schedule endpoints, or SDK helpers.)
@@ -80,6 +82,25 @@ CLI keep-alive terminology:
 
 - use `--keep-alive`
 - do not use `--host`
+
+### MCP CLI config surface
+
+`rkat mcp` edits project/user MCP server config; it is not the live mutation surface for an already-running session.
+
+```bash
+rkat mcp add <NAME> [--transport stdio|http|sse] [--scope project|user|local] [-H KEY:VALUE...] [-e KEY=VALUE...] (--url <URL> | -- <CMD...>)
+rkat mcp remove <NAME> [--scope project|user|local]
+rkat mcp list [--scope project|user|local|all] [--json]
+rkat mcp get <NAME> [--scope project|user|local|all] [--json]
+```
+
+Examples:
+
+```bash
+rkat mcp add filesystem -- npx -y @modelcontextprotocol/server-filesystem .
+rkat mcp add linear --transport http --url https://mcp.example.com
+rkat mcp list --scope all
+```
 
 ### Mob CLI surface
 
@@ -233,6 +254,7 @@ Set `model: "gpt-realtime-1.5"` on `session/create` to enable realtime; transpor
 ### MCP live mutation
 
 - `mcp/add`, `mcp/remove`, `mcp/reload`
+- These are JSON-RPC live session operations. CLI `rkat mcp add/remove/list/get` is the config surface.
 
 ### Mob (feature-gated)
 
@@ -275,7 +297,7 @@ Profiles (when a profile store is present):
 
 ```bash
 rkat config get --format json --with-generation
-rkat config set --file config.toml --expected-generation 4
+rkat config set config.toml --expected-generation 4
 rkat config patch --json '{"agent":{"model":"gpt-5.2"}}' --expected-generation 4
 ```
 
@@ -590,7 +612,7 @@ if let Some(runtime) = factory.build_skill_runtime(&config).await {
 
 - Inproc comms is namespace-scoped; realm namespace isolates peer discovery/sends.
 - **Peer lifecycle typing**: mob lifecycle routing is typed at ingress. `mob.peer_added`, `mob.peer_retired`, and `mob.peer_unwired` are silent lifecycle notices; `mob.kickoff_failed` and `mob.kickoff_cancelled` are visible lifecycle notices. Do not depend on mob defaults in `silent_comms_intents` for canonical behavior.
-- **Comms choice**: use `peer_message` for normal collaboration. `peer_request` is only structured correlated ask-reply. Public peer reservation streams were removed.
+- **Comms choice**: agents use `send_message` for ordinary collaboration, `send_request` for structured ask/reply, and `send_response` for replies. Public peer reservation streams were removed.
 - Hooks and skills resolve from runtime root. Workspace-default CLI realms preserve project ergonomics.
 - **Skill introspection**: `SkillRuntime::list_all_with_provenance()` returns active + shadowed skills; `load_from_source()` bypasses first-wins.
 - Multi-agent orchestration uses mobs exclusively. `MemberLaunchMode::Fork` provides history branching via `Session::fork()`. `spawn_helper()`/`fork_helper()` provide one-call convenience.

--- a/docs/api/mcp.mdx
+++ b/docs/api/mcp.mdx
@@ -11,7 +11,7 @@ Model Context Protocol (MCP) is the tool protocol Meerkat uses in two ways: as a
 <Steps>
   <Step title="Add an MCP server">
     ```bash
-    rkat mcp add filesystem -- npx -y @anthropic/mcp-server-filesystem /tmp
+    rkat mcp add filesystem -- npx -y @modelcontextprotocol/server-filesystem /tmp
     ```
   </Step>
   <Step title="Verify it's registered">
@@ -120,10 +120,10 @@ Use the `rkat mcp` commands to manage MCP servers:
 
 ```bash
 # Add a stdio server
-rkat mcp add filesystem -- npx -y @anthropic/mcp-server-filesystem /tmp
+rkat mcp add filesystem -- npx -y @modelcontextprotocol/server-filesystem /tmp
 
 # Add a streamable HTTP server
-rkat mcp add api --url https://mcp.example.com/api
+rkat mcp add api --transport http --url https://mcp.example.com/api
 
 # List servers
 rkat mcp list

--- a/docs/cli/commands.mdx
+++ b/docs/cli/commands.mdx
@@ -271,10 +271,10 @@ Follow [Self-hosted Gemma 4](/guides/self-hosted-gemma4) for complete examples.
 `rkat mcp` is for local and project configuration only.
 
 ```bash
-rkat mcp add <NAME> [--transport stdio|http|sse] [--scope project|user] [-H KEY:VALUE...] [-e KEY=VALUE...] (--url <URL> | -- <CMD...>)
-rkat mcp remove <NAME> [--scope project|user]
-rkat mcp list [--scope project|user|all] [--json]
-rkat mcp get <NAME> [--scope project|user|all] [--json]
+rkat mcp add <NAME> [--transport stdio|http|sse] [--scope project|user|local] [-H KEY:VALUE...] [-e KEY=VALUE...] (--url <URL> | -- <CMD...>)
+rkat mcp remove <NAME> [--scope project|user|local]
+rkat mcp list [--scope project|user|local|all] [--json]
+rkat mcp get <NAME> [--scope project|user|local|all] [--json]
 ```
 
 Examples:
@@ -296,13 +296,14 @@ rkat mob inspect <PACK.mobpack>
 rkat mob validate <PACK.mobpack>
 rkat mob deploy <PACK.mobpack> <PROMPT> [--trust-policy <permissive|strict>] [--surface <cli|rpc>]
 rkat mob web build <PACK.mobpack> -o <OUT_DIR>
-rkat mob run-flow <MOB_ID> --flow <FLOW_ID> [--params <JSON>] [--stream]
+rkat mob run-flow <MOB_ID> --flow <FLOW_ID> [--params <JSON>] [--stream|--no-stream]
 rkat mob flow-status <MOB_ID> <RUN_ID>
-rkat mob spawn-helper <MOB_ID> <PROFILE_ID> [--model <MODEL>]
-rkat mob fork-helper <MOB_ID> <SOURCE_MEMBER_ID> [--fork-context <full|last-n>]
-rkat mob member-status <MOB_ID> <AGENT_IDENTITY>
+rkat mob spawn-helper <MOB_ID> <PROMPT> [--profile <PROFILE>] [--agent-identity <ID>] [--json]
+rkat mob fork-helper <MOB_ID> <SOURCE_MEMBER_ID> <PROMPT> [--profile <PROFILE>] [--agent-identity <ID>] [--fork-context <full-history|last-messages>] [--last-messages <N>] [--json]
+rkat mob member-status <MOB_ID> <AGENT_IDENTITY> [--json]
 rkat mob force-cancel <MOB_ID> <AGENT_IDENTITY>
-rkat mob respawn <MOB_ID> <AGENT_IDENTITY>
+rkat mob respawn <MOB_ID> <AGENT_IDENTITY> [--initial-message <MESSAGE>]
+rkat mob wait-kickoff <MOB_ID> [--member <AGENT_IDENTITY>...] [--timeout-ms <MS>] [--json]
 ```
 
 Examples:
@@ -345,7 +346,7 @@ rkat skill inspect <skill-name> --source-uuid <uuid> [--json]
 ## models
 
 ```bash
-rkat models [--json]
+rkat models
 ```
 
 Lists all available models grouped by provider, including display name, tier, context window, max output tokens, and profile capabilities (temperature, thinking, reasoning support). Data is compiled from the `meerkat-models` catalog.

--- a/docs/concepts/tools.mdx
+++ b/docs/concepts/tools.mdx
@@ -63,8 +63,8 @@ impl AgentToolDispatcher for MathTools {
 Register any MCP server and its tools automatically appear in the agent's tool set:
 
 ```bash
-rkat mcp add filesystem -- npx -y @anthropic/mcp-server-filesystem /tmp
-rkat mcp add api --url https://mcp.example.com/api
+rkat mcp add filesystem -- npx -y @modelcontextprotocol/server-filesystem /tmp
+rkat mcp add api --transport http --url https://mcp.example.com/api
 ```
 
 Config is stored in `.rkat/mcp.toml` (project) or `~/.rkat/mcp.toml` (user). Supports stdio, streamable HTTP, and SSE transports. See the [MCP reference](/api/mcp) for full details.
@@ -98,7 +98,7 @@ Tool visibility can change during a session without restarting the agent. Change
 
 ### Live MCP controls
 
-MCP servers can be added, removed, or reloaded on a running session via the RPC surface:
+MCP servers can be added, removed, or reloaded on a running session via JSON-RPC, REST, MCP-server tools, or SDK helpers:
 
 ```json
 {"jsonrpc":"2.0","id":1,"method":"mcp/add","params":{
@@ -121,8 +121,9 @@ All mutations are staged and applied at the next turn boundary. Set `persisted: 
 | Surface | Live MCP | External tool filter |
 |---------|----------|---------------------|
 | JSON-RPC | `mcp/add`, `mcp/remove`, `mcp/reload` | Via in-process `ToolScopeHandle` on the session runtime |
-| CLI | `rkat mcp reload --session --live-server-url ...` and related host-managed flows | No standalone public CLI surface today |
+| CLI | `rkat mcp add/remove/list/get` edits project/user config; start or resume a session to load it | No standalone public CLI filter surface today |
 | REST | `POST /sessions/{id}/mcp/add`, `remove`, `reload` | No standalone public REST filter surface today |
+| MCP server | `meerkat_mcp_add`, `meerkat_mcp_remove`, `meerkat_mcp_reload` | No standalone public MCP filter surface today |
 
 See the [built-in tools reference](/reference/builtin-tools) for the mechanical details of factory flags and per-build overrides.
 

--- a/docs/examples/tools.mdx
+++ b/docs/examples/tools.mdx
@@ -132,10 +132,10 @@ Built-in tool categories: builtins, shell, semantic memory, and mob orchestratio
 
 ```bash
 # Add a stdio server
-rkat mcp add filesystem -- npx -y @anthropic/mcp-server-filesystem /tmp
+rkat mcp add filesystem -- npx -y @modelcontextprotocol/server-filesystem /tmp
 
 # Add a streamable HTTP server
-rkat mcp add remote-api --url https://mcp.example.com/api
+rkat mcp add remote-api --transport http --url https://mcp.example.com/api
 
 # List all registered servers
 rkat mcp list
@@ -147,9 +147,6 @@ rkat mcp get filesystem
 # Remove a server
 rkat mcp remove filesystem
 
-# Reload MCP servers on a live session
-rkat mcp reload --session <SESSION_ID> --live-server-url http://localhost:8080
-rkat mcp reload --session <SESSION_ID> --live-server-url http://localhost:8080 --name my-tools
 ```
 
 Config is stored in `.rkat/mcp.toml` (project) or `~/.rkat/mcp.toml` (user). Project scope wins on name collisions.
@@ -170,7 +167,7 @@ connect_timeout_secs = 30
 Add, remove, or reload MCP servers on a running session without restarting the agent. Changes are staged and applied at the next turn boundary.
 
 <Note>
-CLI `rkat mcp add/remove` manages static server config (persisted to `.rkat/mcp.toml`). The methods below manage servers on a **running session** — changes are staged and applied at the next turn boundary.
+CLI `rkat mcp add/remove/list/get` manages server config (persisted to `.rkat/mcp.toml` or `~/.rkat/mcp.toml`). The methods below manage servers on a **running session** — changes are staged and applied at the next turn boundary.
 </Note>
 
 <Tabs>

--- a/docs/reference/builtin-tools.mdx
+++ b/docs/reference/builtin-tools.mdx
@@ -117,7 +117,8 @@ MCP servers can be added or removed from a running session. Operations are stage
 |---------|--------|--------|
 | JSON-RPC | `mcp/add`, `mcp/remove`, `mcp/reload` | Fully wired (staged) |
 | REST | `POST /sessions/{id}/mcp/add\|remove\|reload` | Fully wired |
-| CLI | `rkat mcp reload --session <id> --live-server-url <url>` | Host-managed live reload flow |
+| CLI | `rkat mcp add/remove/list/get` | Config surface; start or resume a session to load config |
+| MCP server | `meerkat_mcp_add`, `meerkat_mcp_remove`, `meerkat_mcp_reload` | Fully wired |
 
 Servers being removed transition through `Active → Removing (draining) → Removed` to allow in-flight tool calls to complete before finalization.
 

--- a/meerkat/src/help.rs
+++ b/meerkat/src/help.rs
@@ -127,6 +127,34 @@ mod tests {
     }
 
     #[test]
+    fn platform_skill_pins_current_cli_help_facts() {
+        assert!(
+            MEERKAT_PLATFORM_SKILL_BODY.contains("rkat mcp add <NAME>"),
+            "help skill must teach the actual MCP CLI config surface"
+        );
+        assert!(
+            MEERKAT_PLATFORM_API_REFERENCE.contains("rkat help <QUESTION>"),
+            "API reference must include the dedicated help command"
+        );
+        assert!(
+            MEERKAT_PLATFORM_SKILL_BODY.contains("rkat run --auth-binding"),
+            "--auth-binding belongs to rkat run, not the global CLI"
+        );
+        assert!(
+            !MEERKAT_PLATFORM_SKILL_BODY.contains("rkat mcp reload --session"),
+            "rkat mcp reload is not a shipped CLI command"
+        );
+        assert!(
+            !MEERKAT_PLATFORM_API_REFERENCE.contains("rkat comms send"),
+            "there is no top-level rkat comms command"
+        );
+        assert!(
+            !MEERKAT_PLATFORM_API_REFERENCE.contains("rkat models [--json]"),
+            "rkat models has no --json flag"
+        );
+    }
+
+    #[test]
     fn platform_skill_key_uses_builtin_source() {
         let key = platform_skill_key();
         assert_eq!(key.source_uuid, meerkat_core::skills::SourceUuid::builtin());


### PR DESCRIPTION
## Summary
- update embedded meerkat-platform skill and API reference to match current CLI MCP/config/help/auth facts
- clean stale MCP examples in docs
- add regression coverage for embedded help facts

## Verification
- ./scripts/repo-cargo test -p meerkat help --lib
- ./scripts/repo-cargo fmt --check
- git diff --check
- ./scripts/repo-cargo run -p rkat --bin rkat -- mcp add --help