### PR TITLE
Harden help grounding against invented CLI surfaces

### DIFF
--- a/.claude/skills/meerkat-platform/SKILL.md
+++ b/.claude/skills/meerkat-platform/SKILL.md
@@ -501,7 +501,16 @@ Prompts and tool results support multimodal content (text, images, and video). T
 
 **view_image builtin tool:** Reads images from disk (PNG/JPEG/GIF/WebP/SVG), returns base64 `ContentBlock::Image`. Path sandboxed to project root. 5 MB limit. Hidden on non-vision-capable models via `ToolScope` based on `ModelProfile.vision` and `ModelProfile.image_tool_results`.
 
-**generate_image builtin tool:** Session-owned assistant image generation. The model calls one stable tool with universal fields (`prompt`, `provider`, `model`, `size`, `quality`, `format`, `count`, reference/source images) plus provider-owned `provider_params`. Provider crates own image model profiles, supported parameters, and backend selection. Generated images are stored in the blob store and committed as `AssistantBlock::Image`; surfaces read `image_id`/`blob_ref` from history and fetch bytes via `blob/get` or SDK `get_blob` / `getBlob`.
+**generate_image builtin tool:** Session-owned assistant image generation. The model calls one stable tool with universal fields (`prompt`, `provider`, `model`, `size`, `quality`, `format`, `count`, reference/source images) plus provider-owned `provider_params`. Provider crates own image model profiles, supported parameters, and backend selection. Generated images are stored in the blob store; user-facing surfaces fetch the resulting blob id via `rkat blob get`, JSON-RPC `blob/get`, or SDK `get_blob` / `getBlob`.
+
+**Image generation via CLI:** There is no direct image-generation CLI command and no `rkat rpc` subcommand. Ask the assistant through a session, allow the image tool, and fetch the resulting blob:
+
+```bash
+rkat run --allow-tool generate_image "Use generate_image to create a square PNG of a cozy tabby cat by a sunlit window. Return the blob id."
+rkat blob get <BLOB-ID> --output cat.png
+```
+
+Use `rkat blob get <BLOB-ID> --json` to inspect the blob payload. If the answer does not include a blob id, resume the session and ask for the blob id.
 
 **Provider capabilities:**
 | Provider | `vision` | `image_tool_results` | `inline_video` |

--- a/.claude/skills/meerkat-platform/references/api_reference.md
+++ b/.claude/skills/meerkat-platform/references/api_reference.md
@@ -213,6 +213,13 @@ rkat-rpc --realm team-alpha --tcp 127.0.0.1:9000
 
 Generated assistant images appear in `session/history` as assistant blocks with `block_type: "image"`; fetch bytes via `blob/get` using `data.blob_ref.blob_id`.
 
+CLI image generation is assistant-mediated; there is no direct `rkat image` command and no `rkat rpc` subcommand. Use:
+
+```bash
+rkat run --allow-tool generate_image "Use generate_image to create a 1024x1024 PNG of a meerkat on a laptop. Return the blob id."
+rkat blob get <BLOB-ID> --output meerkat.png
+```
+
 ### Realtime (capability-driven)
 
 - `realtime/open_info` — open audio channel info

--- a/meerkat/src/help.rs
+++ b/meerkat/src/help.rs
@@ -30,9 +30,18 @@ pub const MEERKAT_PLATFORM_SKILL_EXTENSIONS: &[(&str, &str)] = &[
 
 const HELP_SYSTEM_PROMPT: &str = r"You are Meerkat's dedicated help surface.
 
-Use the preloaded `meerkat-platform` skill as the canonical source for Meerkat CLI, REST, JSON-RPC, MCP, SDK, auth, skills, hooks, scheduling, realtime, and mob answers.
+Use the preloaded `meerkat-platform` skill and its loaded references as the only authority for Meerkat CLI, REST, JSON-RPC, MCP, SDK, auth, skills, hooks, scheduling, realtime, mob, tools, and image-generation answers.
 
-Answer with the exact command, request, or tool call first when one is appropriate. Keep explanations short and operational. If the request is ambiguous, state the missing choice and give the safest concrete next command or API shape.
+Grounding rules:
+- Do not invent commands, binaries, flags, endpoints, request fields, Rust types, or SDK methods.
+- Command spelling matters. Use only documented CLI commands from the embedded context, such as `rkat session`, `rkat blob`, `rkat mcp`, and binaries such as `rkat-rpc`. Never create plausible aliases such as `rkat sessions`, `rkat rpc`, or `rkat image` unless the embedded context documents them.
+- If the embedded context does not document an exact command or API shape, say that plainly and point to the nearest documented `rkat <command> --help`, binary, or API surface.
+- When the user asks for “via rkat”, “CLI”, or “short”, answer only with CLI commands and keep the reply minimal.
+- For workflows that are assistant-mediated, say that the user asks through `rkat run`; do not imply the user can invoke the internal tool directly.
+
+Answer with the exact documented command, request, or tool call first when one is appropriate. Keep explanations short and operational. If the request is ambiguous, state the missing choice and give only a documented next command or API shape.
+
+Avoid internal implementation details unless the user asks for internals. Do not mention Rust enum names, transcript internals, or provider-owned request fields in ordinary user help.
 
 When a request uses relative time, calculate from the current UTC timestamp in the prompt. Do not invent stale example dates.
 
@@ -152,6 +161,34 @@ mod tests {
             !MEERKAT_PLATFORM_API_REFERENCE.contains("rkat models [--json]"),
             "rkat models has no --json flag"
         );
+        assert!(
+            MEERKAT_PLATFORM_SKILL_BODY.contains("rkat run --allow-tool generate_image"),
+            "help skill must teach image generation as an assistant-mediated rkat run workflow"
+        );
+        assert!(
+            MEERKAT_PLATFORM_SKILL_BODY.contains("rkat blob get <BLOB-ID> --output"),
+            "help skill must teach the actual blob download CLI"
+        );
+        assert!(
+            !MEERKAT_PLATFORM_SKILL_BODY.contains("rkat rpc blob/get"),
+            "there is no top-level rkat rpc command"
+        );
+        assert!(
+            !MEERKAT_PLATFORM_SKILL_BODY.contains("rkat sessions show"),
+            "the CLI command is singular rkat session, not rkat sessions"
+        );
+    }
+
+    #[test]
+    fn help_system_prompt_requires_documented_surface_grounding() {
+        let prompt = help_system_prompt();
+        assert!(prompt.contains("Do not invent commands"));
+        assert!(prompt.contains("Use only documented CLI commands"));
+        assert!(prompt.contains("If the embedded context does not document an exact command"));
+        assert!(prompt.contains("rkat <command> --help"));
+        assert!(prompt.contains("rkat sessions"));
+        assert!(prompt.contains("rkat rpc"));
+        assert!(prompt.contains("Avoid internal implementation details"));
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- strengthen the help system prompt to require exact documented commands/API shapes
- document image generation as an assistant-mediated CLI workflow using `rkat run --allow-tool generate_image` plus `rkat blob get`
- add regressions for fake spellings like `rkat rpc blob/get` and `rkat sessions show`

## Verification
- `./scripts/repo-cargo test -p meerkat help --lib`
- `./scripts/repo-cargo fmt --check`
- `git diff --check`
- `make check`
- push hooks: fmt, clippy (changed crates), codegen verify, workspace deterministic gate