### PR TITLE
[codex] Keep image tool visible without image auth

### DIFF
--- a/meerkat-cli/src/main.rs
+++ b/meerkat-cli/src/main.rs
@@ -15909,6 +15909,77 @@ capabilities = ["definitely_missing_capability"]
         assert!(names.contains("generate_image"));
     }
 
+    #[tokio::test]
+    async fn test_run_session_build_keeps_generate_image_visible_without_executor() {
+        let temp = tempfile::tempdir().expect("tempdir must be created");
+        let runtime_adapter = Arc::new(meerkat_runtime::MeerkatMachine::ephemeral());
+        let factory = AgentFactory::new(temp.path().join("sessions")).builtins(true);
+        let service = Arc::new(build_cli_service_with_defaults(
+            factory,
+            Config::default(),
+            CliServiceBuildDefaults {
+                image_generation_machine: Some(runtime_adapter.clone()),
+                default_blob_store: Some(Arc::new(meerkat_store::MemoryBlobStore::default())),
+                ..Default::default()
+            },
+        ));
+
+        let captured_tool_names = Arc::new(Mutex::new(Vec::<String>::new()));
+        let captured_system_prompt = Arc::new(Mutex::new(None::<String>));
+        let llm_override: Arc<dyn LlmClient> = Arc::new(CapturingLlmClient::new(
+            captured_tool_names.clone(),
+            captured_system_prompt,
+        ));
+
+        let session = Session::new();
+        let session_id = session.id().clone();
+        let bindings = runtime_adapter
+            .prepare_bindings(session_id)
+            .await
+            .expect("runtime bindings should be prepared");
+
+        let req = CreateSessionRequest {
+            model: "gpt-5.4".to_string(),
+            prompt: "list tools".to_string().into(),
+            render_metadata: None,
+            system_prompt: None,
+            max_tokens: Some(32),
+            event_tx: None,
+            skill_references: None,
+            initial_turn: meerkat_core::service::InitialTurnPolicy::RunImmediately,
+            deferred_prompt_policy: DeferredPromptPolicy::Discard,
+            build: Some(SessionBuildOptions {
+                resume_session: Some(session),
+                runtime_build_mode: meerkat_core::RuntimeBuildMode::SessionOwned(bindings),
+                initial_turn_metadata: Some(meerkat_runtime::runtime_stamped_prompt_turn_metadata(
+                    None,
+                )),
+                llm_client_override: Some(meerkat::encode_llm_client_override_for_service(
+                    llm_override,
+                )),
+                ..SessionBuildOptions::default()
+            }),
+            labels: None,
+        };
+
+        service
+            .create_session(req)
+            .await
+            .expect("session should run with llm override");
+
+        let names: std::collections::BTreeSet<String> = captured_tool_names
+            .lock()
+            .expect("captured tool mutex should not be poisoned")
+            .iter()
+            .cloned()
+            .collect();
+
+        assert!(
+            names.contains("generate_image"),
+            "generate_image should remain visible even when image credentials are unavailable"
+        );
+    }
+
     #[cfg(feature = "mob")]
     async fn call_tool_json(
         dispatcher: &Arc<dyn AgentToolDispatcher>,

--- a/meerkat/src/factory.rs
+++ b/meerkat/src/factory.rs
@@ -794,6 +794,25 @@ pub fn provider_key(provider: Provider) -> &'static str {
     provider.as_str()
 }
 
+#[cfg(not(target_arch = "wasm32"))]
+struct UnavailableImageGenerationExecutor;
+
+#[cfg(not(target_arch = "wasm32"))]
+#[async_trait::async_trait]
+impl meerkat_llm_core::ImageGenerationExecutor for UnavailableImageGenerationExecutor {
+    async fn execute_image_generation(
+        &self,
+        _request: meerkat_llm_core::ProviderImageGenerationRequest,
+    ) -> Result<meerkat_llm_core::ProviderImageGenerationOutput, meerkat_llm_core::LlmError> {
+        Err(meerkat_llm_core::LlmError::InvalidRequest {
+            message: "image generation is available, but no image provider credential or executor \
+                      could be resolved for this session; configure an OpenAI or Gemini image \
+                      binding, or pass an image-generation executor override"
+                .to_string(),
+        })
+    }
+}
+
 #[cfg(feature = "openai")]
 const SELF_HOSTED_LEGACY_REALM_ID: &str = "self_hosted_legacy";
 
@@ -1342,6 +1361,14 @@ impl AgentFactory {
             return Self::resolve_realm_binding_for_provider(config, provider, None, None);
         }
         let selected_realm = RealmId::parse(selected_realm).map_err(|e| e.to_string())?;
+        if !config.realm.contains_key(selected_realm.as_str()) {
+            return Self::resolve_realm_binding_for_provider(
+                config,
+                provider,
+                None,
+                Some(selected_realm.as_str()),
+            );
+        }
         Self::resolve_selected_image_binding_for_provider(config, provider, selected_realm)
     }
 
@@ -3377,7 +3404,13 @@ impl AgentFactory {
                         build_config
                             .image_generation_executor_override
                             .clone()
-                            .or_else(|| auto_image_generation_executor.clone()),
+                            .or_else(|| auto_image_generation_executor.clone())
+                            .or_else(|| {
+                                image_generation_planner.as_ref().map(|_| {
+                                    Arc::new(UnavailableImageGenerationExecutor)
+                                        as Arc<dyn meerkat_llm_core::ImageGenerationExecutor>
+                                })
+                            }),
                         image_generation_planner.clone(),
                         build_config.blob_store_override.clone(),
                     )
@@ -5073,26 +5106,24 @@ mod tests {
     }
 
     #[test]
-    fn missing_selected_realm_image_binding_rejects_configured_default_realm() {
+    fn unconfigured_storage_realm_can_still_use_configured_default_realm() {
         let mut config = Config::default();
         config.realm.insert(
             "default".to_string(),
             inline_realm_section(&[("openai", "default-openai-key")]),
         );
 
-        let err = AgentFactory::resolve_image_binding_for_provider(
+        let (realm, binding_id, auth_binding) = AgentFactory::resolve_image_binding_for_provider(
             &config,
             Provider::OpenAI,
             Some("session_missing"),
         )
-        .expect_err("missing selected image realm must not fall back to configured default");
+        .expect("unconfigured storage realm may use configured default credentials");
 
-        assert!(
-            err.contains("provider 'openai'")
-                && err.contains("selected realm 'session_missing'")
-                && err.contains("not found"),
-            "unexpected error: {err}"
-        );
+        assert_eq!(realm.realm_id, "default");
+        assert_eq!(binding_id, "default_openai");
+        assert_eq!(auth_binding.realm.as_str(), "default");
+        assert_eq!(auth_binding.binding.as_str(), "default_openai");
     }
 
     #[test]
@@ -5143,21 +5174,19 @@ mod tests {
     }
 
     #[test]
-    fn missing_selected_realm_image_binding_rejects_env_default_synthesis() {
+    fn unconfigured_storage_realm_can_still_synthesize_env_default_image_binding() {
         let config = Config::default();
-        let err = AgentFactory::resolve_image_binding_for_provider(
+        let (realm, binding_id, auth_binding) = AgentFactory::resolve_image_binding_for_provider(
             &config,
             Provider::OpenAI,
             Some("workspace_derived"),
         )
-        .expect_err("selected image realm without credential config must not use env_default");
+        .expect("workspace storage realm without credential config may use env_default");
 
-        assert!(
-            err.contains("provider 'openai'")
-                && err.contains("selected realm 'workspace_derived'")
-                && err.contains("not found"),
-            "unexpected error: {err}"
-        );
+        assert_eq!(realm.realm_id, "env_default");
+        assert_eq!(binding_id, "default");
+        assert_eq!(auth_binding.realm.as_str(), "env_default");
+        assert_eq!(auth_binding.binding.as_str(), "default");
     }
 
     #[cfg(all(feature = "openai", not(target_arch = "wasm32")))]


### PR DESCRIPTION
## Summary
- keep `generate_image` registered when image runtime support exists but no OpenAI/Gemini image executor resolves
- restore fallback from unconfigured workspace/storage realms to default or env image credentials
- add CLI coverage for `rkat run` preserving `generate_image` in the tool list without image auth

## Root Cause
`rkat run` passes a workspace-derived realm id through session build options. Image credential resolution treated any selected realm as strict, so an unconfigured storage realm prevented default/env image credentials from resolving. Because image tool registration was coupled to executor resolution, the tool disappeared instead of reporting that no supported image provider was configured.

## Validation
- `./scripts/repo-cargo test -p meerkat --lib unconfigured_storage_realm_can_still -- --nocapture`
- `./scripts/repo-cargo test -p rkat --bin rkat test_run_session_build_keeps_generate_image_visible_without_executor -- --nocapture`
- `./scripts/repo-cargo test -p meerkat --lib selected_realm_skips_env_default_same_provider_image_executor -- --nocapture`
- `make build`
- push hook: cargo fmt, changed-crate clippy, codegen/header/workspace gates