### PR TITLE
[codex] Fix provider web search tool plumbing

### DIFF
--- a/artifacts/schemas/events.json
+++ b/artifacts/schemas/events.json
@@ -1679,6 +1679,31 @@
         "type": "object"
       },
       {
+        "description": "Provider-executed tool content surfaced during a model turn.",
+        "properties": {
+          "content": true,
+          "id": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "name": {
+            "type": "string"
+          },
+          "type": {
+            "const": "server_tool_content",
+            "type": "string"
+          }
+        },
+        "required": [
+          "type",
+          "name",
+          "content"
+        ],
+        "type": "object"
+      },
+      {
         "description": "Model requested a tool call",
         "properties": {
           "args": {
@@ -2951,6 +2976,31 @@
             },
             "required": [
               "type",
+              "content"
+            ],
+            "type": "object"
+          },
+          {
+            "description": "Provider-executed tool content surfaced during a model turn.",
+            "properties": {
+              "content": true,
+              "id": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "name": {
+                "type": "string"
+              },
+              "type": {
+                "const": "server_tool_content",
+                "type": "string"
+              }
+            },
+            "required": [
+              "type",
+              "name",
               "content"
             ],
             "type": "object"

--- a/artifacts/schemas/rest-openapi.json
+++ b/artifacts/schemas/rest-openapi.json
@@ -5848,6 +5848,48 @@
           {
             "properties": {
               "block_type": {
+                "const": "server_tool_content",
+                "type": "string"
+              },
+              "data": {
+                "properties": {
+                  "content": true,
+                  "id": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "meta": {
+                    "anyOf": [
+                      {
+                        "$ref": "#/components/schemas/WireProviderMeta"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ]
+                  },
+                  "name": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "name",
+                  "content"
+                ],
+                "type": "object"
+              }
+            },
+            "required": [
+              "block_type",
+              "data"
+            ],
+            "type": "object"
+          },
+          {
+            "properties": {
+              "block_type": {
                 "const": "image",
                 "type": "string"
               },

--- a/artifacts/schemas/wire-types.json
+++ b/artifacts/schemas/wire-types.json
@@ -736,6 +736,31 @@
             "type": "object"
           },
           {
+            "description": "Provider-executed tool content surfaced during a model turn.",
+            "properties": {
+              "content": true,
+              "id": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "name": {
+                "type": "string"
+              },
+              "type": {
+                "const": "server_tool_content",
+                "type": "string"
+              }
+            },
+            "required": [
+              "type",
+              "name",
+              "content"
+            ],
+            "type": "object"
+          },
+          {
             "description": "Model requested a tool call",
             "properties": {
               "args": {
@@ -21015,6 +21040,48 @@
       {
         "properties": {
           "block_type": {
+            "const": "server_tool_content",
+            "type": "string"
+          },
+          "data": {
+            "properties": {
+              "content": true,
+              "id": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "meta": {
+                "anyOf": [
+                  {
+                    "$ref": "#/$defs/WireProviderMeta"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
+              },
+              "name": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "name",
+              "content"
+            ],
+            "type": "object"
+          }
+        },
+        "required": [
+          "block_type",
+          "data"
+        ],
+        "type": "object"
+      },
+      {
+        "properties": {
+          "block_type": {
             "const": "image",
             "type": "string"
           },
@@ -27190,6 +27257,48 @@
           {
             "properties": {
               "block_type": {
+                "const": "server_tool_content",
+                "type": "string"
+              },
+              "data": {
+                "properties": {
+                  "content": true,
+                  "id": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "meta": {
+                    "anyOf": [
+                      {
+                        "$ref": "#/$defs/WireProviderMeta"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ]
+                  },
+                  "name": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "name",
+                  "content"
+                ],
+                "type": "object"
+              }
+            },
+            "required": [
+              "block_type",
+              "data"
+            ],
+            "type": "object"
+          },
+          {
+            "properties": {
+              "block_type": {
                 "const": "image",
                 "type": "string"
               },
@@ -28132,6 +28241,48 @@
                   "id",
                   "name",
                   "args"
+                ],
+                "type": "object"
+              }
+            },
+            "required": [
+              "block_type",
+              "data"
+            ],
+            "type": "object"
+          },
+          {
+            "properties": {
+              "block_type": {
+                "const": "server_tool_content",
+                "type": "string"
+              },
+              "data": {
+                "properties": {
+                  "content": true,
+                  "id": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "meta": {
+                    "anyOf": [
+                      {
+                        "$ref": "#/$defs/WireProviderMeta"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ]
+                  },
+                  "name": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "name",
+                  "content"
                 ],
                 "type": "object"
               }

--- a/meerkat-anthropic/src/client.rs
+++ b/meerkat-anthropic/src/client.rs
@@ -342,6 +342,41 @@ impl AnthropicClient {
                                     "input": args_value
                                 }));
                             }
+                            meerkat_core::AssistantBlock::ServerToolContent {
+                                id,
+                                name,
+                                content: server_content,
+                                ..
+                            } => {
+                                if server_content.get("type").and_then(Value::as_str)
+                                    == Some("server_tool_use")
+                                {
+                                    content.push(serde_json::json!({
+                                        "type": "server_tool_use",
+                                        "id": id,
+                                        "name": name,
+                                        "input": server_content
+                                            .get("input")
+                                            .cloned()
+                                            .unwrap_or_else(|| serde_json::json!({}))
+                                    }));
+                                } else {
+                                    let mut block = server_content.clone();
+                                    if let Some(object) = block.as_object_mut() {
+                                        object.insert(
+                                            "type".to_string(),
+                                            Value::String("web_search_tool_result".to_string()),
+                                        );
+                                        if let Some(tool_use_id) = id {
+                                            object.insert(
+                                                "tool_use_id".to_string(),
+                                                Value::String(tool_use_id.clone()),
+                                            );
+                                        }
+                                    }
+                                    content.push(block);
+                                }
+                            }
                             // Handle future block types (non_exhaustive pattern)
                             _ => {}
                         }
@@ -727,6 +762,9 @@ impl LlmClient for AnthropicClient {
             let mut current_tool_id: Option<String> = None;
             let mut current_tool_name: Option<String> = None;
             let mut accumulated_tool_args = String::new();
+            let mut current_server_tool_id: Option<String> = None;
+            let mut current_server_tool_name: Option<String> = None;
+            let mut accumulated_server_tool_input = String::new();
             let mut current_block_type: Option<String> = None;
             let mut current_thinking_signature: Option<String> = None;
             let mut last_stop_reason: Option<StopReason> = None;
@@ -762,13 +800,17 @@ impl LlmClient for AnthropicClient {
                                     }
                                     "input_json_delta" => {
                                         if let Some(partial_json) = delta.partial_json {
-                                            accumulated_tool_args.push_str(&partial_json);
                                             saw_event = true;
-                                            yield LlmEvent::ToolCallDelta {
-                                                id: current_tool_id.clone().unwrap_or_default(),
-                                                name: None,
-                                                args_delta: partial_json,
-                                            };
+                                            if current_block_type.as_deref() == Some("server_tool_use") {
+                                                accumulated_server_tool_input.push_str(&partial_json);
+                                            } else {
+                                                accumulated_tool_args.push_str(&partial_json);
+                                                yield LlmEvent::ToolCallDelta {
+                                                    id: current_tool_id.clone().unwrap_or_default(),
+                                                    name: None,
+                                                    args_delta: partial_json,
+                                                };
+                                            }
                                         }
                                     }
                                     "compaction_delta" => {
@@ -789,6 +831,20 @@ impl LlmClient for AnthropicClient {
                             if let Some(content_block) = $event.content_block {
                                 current_block_type = Some(content_block.block_type.clone());
                                 match content_block.block_type.as_str() {
+                                    "text" => {
+                                        if let Some(citations) = content_block.extra.get("citations") {
+                                            saw_event = true;
+                                            yield LlmEvent::ServerToolContent {
+                                                id: None,
+                                                name: "web_search_citations".to_string(),
+                                                content: serde_json::json!({
+                                                    "type": "text_citations",
+                                                    "citations": citations
+                                                }),
+                                                meta: None,
+                                            };
+                                        }
+                                    }
                                     "thinking" => {
                                         // Start of thinking block
                                         // Signature may already be present or arrive via signature_delta
@@ -817,6 +873,20 @@ impl LlmClient for AnthropicClient {
                                             id,
                                             name: content_block.name,
                                             args_delta: String::new(),
+                                        };
+                                    }
+                                    "server_tool_use" => {
+                                        current_server_tool_id = content_block.id.clone();
+                                        current_server_tool_name = content_block.name.clone();
+                                        accumulated_server_tool_input.clear();
+                                    }
+                                    "web_search_tool_result" => {
+                                        saw_event = true;
+                                        yield LlmEvent::ServerToolContent {
+                                            id: content_block.tool_use_id.clone(),
+                                            name: "web_search".to_string(),
+                                            content: content_block.extra.clone(),
+                                            meta: None,
                                         };
                                     }
                                     _ => {}
@@ -873,6 +943,31 @@ impl LlmClient for AnthropicClient {
                                         accumulated_tool_args.clear();
                                     }
                                     current_tool_id = None;
+                                }
+                                Some("server_tool_use") => {
+                                    let input = if accumulated_server_tool_input.is_empty() {
+                                        serde_json::json!({})
+                                    } else {
+                                        serde_json::from_str(&accumulated_server_tool_input)
+                                            .unwrap_or_else(|_| serde_json::json!({
+                                                "partial_json": accumulated_server_tool_input
+                                            }))
+                                    };
+                                    let id = current_server_tool_id.take();
+                                    let name = current_server_tool_name
+                                        .take()
+                                        .unwrap_or_else(|| "server_tool".to_string());
+                                    accumulated_server_tool_input.clear();
+                                    saw_event = true;
+                                    yield LlmEvent::ServerToolContent {
+                                        id,
+                                        name,
+                                        content: serde_json::json!({
+                                            "type": "server_tool_use",
+                                            "input": input
+                                        }),
+                                        meta: None,
+                                    };
                                 }
                                 _ => {}
                             }
@@ -1074,10 +1169,13 @@ struct AnthropicContentBlock {
     block_type: String,
     id: Option<String>,
     name: Option<String>,
+    tool_use_id: Option<String>,
     /// Signature for thinking block continuity
     signature: Option<String>,
     /// Encrypted data for redacted_thinking blocks
     data: Option<String>,
+    #[serde(flatten)]
+    extra: Value,
 }
 
 fn parse_streamed_tool_args(args: &str, tool_id: &str) -> Result<Value, LlmError> {
@@ -2146,6 +2244,58 @@ mod tests {
             "Expected Done event from message_delta stop_reason"
         );
         assert!(done_is_success, "Expected successful Done outcome");
+    }
+
+    #[tokio::test]
+    async fn test_web_search_server_tool_blocks_are_emitted() {
+        let payload = [
+            r#"data: {"type":"message_start","message":{"usage":{"input_tokens":10,"output_tokens":0}}}"#,
+            r#"data: {"type":"content_block_start","content_block":{"type":"server_tool_use","id":"srvtoolu_1","name":"web_search"}}"#,
+            r#"data: {"type":"content_block_delta","delta":{"type":"input_json_delta","partial_json":"{\"query\":\"latest meerkat runtime\"}"}}"#,
+            r#"data: {"type":"content_block_stop"}"#,
+            r#"data: {"type":"content_block_start","content_block":{"type":"web_search_tool_result","tool_use_id":"srvtoolu_1","content":[{"type":"web_search_result","title":"Result","url":"https://example.com"}]}}"#,
+            r#"data: {"type":"content_block_stop"}"#,
+            r#"data: {"type":"message_delta","usage":{"output_tokens":5},"delta":{"stop_reason":"end_turn"}}"#,
+            "",
+        ]
+        .join("\n");
+        let (base_url, server) = spawn_anthropic_stub_server(payload).await;
+        let client = AnthropicClient::builder("test-key".to_string())
+            .base_url(base_url)
+            .build()
+            .unwrap();
+        let request = LlmRequest::new(
+            "claude-sonnet-4-5",
+            vec![Message::User(UserMessage::text("search".to_string()))],
+        );
+
+        let mut stream = client.stream(&request);
+        let mut server_blocks = Vec::new();
+        while let Some(event) = stream.next().await {
+            match event.expect("stream event") {
+                LlmEvent::ServerToolContent {
+                    id, name, content, ..
+                } => {
+                    server_blocks.push((id, name, content));
+                }
+                LlmEvent::Done { .. } => break,
+                _ => {}
+            }
+        }
+        server.abort();
+
+        assert_eq!(server_blocks.len(), 2);
+        assert_eq!(server_blocks[0].0.as_deref(), Some("srvtoolu_1"));
+        assert_eq!(server_blocks[0].1, "web_search");
+        assert_eq!(
+            server_blocks[0].2["input"]["query"],
+            "latest meerkat runtime"
+        );
+        assert_eq!(server_blocks[1].0.as_deref(), Some("srvtoolu_1"));
+        assert_eq!(
+            server_blocks[1].2["content"][0]["url"],
+            "https://example.com"
+        );
     }
 
     /// Regression: Anthropic streaming error event must yield Done with error.

--- a/meerkat-client/tests/live_client_provider_matrix.rs
+++ b/meerkat-client/tests/live_client_provider_matrix.rs
@@ -20,6 +20,9 @@ use meerkat_core::image_generation::{
     ToolCallId,
 };
 use meerkat_core::lifecycle::run_primitive::ModelId;
+use meerkat_core::lifecycle::run_primitive::{
+    AnthropicProviderTag, GeminiProviderTag, OpaqueProviderBody, OpenAiProviderTag, ProviderTag,
+};
 use meerkat_core::{Message, StopReason, UserMessage};
 use meerkat_gemini::{GeminiImageOutputOptions, GeminiImageTurnPlan};
 use meerkat_llm_core::{ImageGenerationExecutor, ProviderImageGenerationRequest};
@@ -135,6 +138,25 @@ fn gemini_api_key() -> Option<String> {
     first_env(&["RKAT_GEMINI_API_KEY", "GEMINI_API_KEY", "GOOGLE_API_KEY"])
 }
 
+async fn collect_stream_text_and_server_tool_count<C: LlmClient + ?Sized>(
+    client: &C,
+    request: &LlmRequest,
+) -> Result<(String, usize), Box<dyn std::error::Error>> {
+    let mut stream = client.stream(request);
+    let mut text = String::new();
+    let mut server_tool_count = 0;
+    while let Some(result) = stream.next().await {
+        match result {
+            Ok(LlmEvent::TextDelta { delta, .. }) => text.push_str(&delta),
+            Ok(LlmEvent::ServerToolContent { .. }) => server_tool_count += 1,
+            Ok(LlmEvent::Done { .. }) => break,
+            Ok(_) => {}
+            Err(e) => return Err(format!("Unexpected error: {e:?}").into()),
+        }
+    }
+    Ok((text, server_tool_count))
+}
+
 fn tiny_image_request(provider: &str, model: &str) -> GenerateImageRequest {
     GenerateImageRequest::new(
         ImageGenerationIntent::Generate {
@@ -199,6 +221,95 @@ async fn e2e_anthropic_stream() -> Result<(), Box<dyn std::error::Error>> {
     }
 
     assert!(got_text);
+    Ok(())
+}
+
+#[tokio::test]
+#[ignore = "lane:e2e-smoke"]
+async fn e2e_smoke_provider_web_search_all_three() -> Result<(), Box<dyn std::error::Error>> {
+    let mut ran = 0usize;
+    let prompt = "Use the web search tool for this answer. Search for the current title of https://example.com and answer in one short sentence with the source URL.";
+
+    if let Some(api_key) = openai_api_key() {
+        ran += 1;
+        let client = OpenAiClient::new(api_key);
+        let request = LlmRequest::new(
+            "gpt-5.4",
+            vec![Message::User(UserMessage::text(prompt.to_string()))],
+        )
+        .with_provider_params(ProviderTag::OpenAi(OpenAiProviderTag {
+            web_search: Some(OpaqueProviderBody::from_value(&serde_json::json!({
+                "type": "web_search"
+            }))),
+            ..Default::default()
+        }));
+        let (text, server_tools) =
+            collect_stream_text_and_server_tool_count(&client, &request).await?;
+        assert!(
+            server_tools > 0,
+            "OpenAI should emit web_search server tool content; text={text}"
+        );
+        assert!(!text.trim().is_empty(), "OpenAI should return text");
+    } else {
+        eprintln!(
+            "Skipping OpenAI web search smoke: missing OPENAI_API_KEY (or RKAT_OPENAI_API_KEY)"
+        );
+    }
+
+    if let Some(api_key) = anthropic_api_key() {
+        ran += 1;
+        let client = AnthropicClient::new(api_key)?;
+        let request = LlmRequest::new(
+            "claude-sonnet-4-6",
+            vec![Message::User(UserMessage::text(prompt.to_string()))],
+        )
+        .with_provider_params(ProviderTag::Anthropic(AnthropicProviderTag {
+            web_search: Some(OpaqueProviderBody::from_value(&serde_json::json!({
+                "type": "web_search_20250305",
+                "name": "web_search"
+            }))),
+            ..Default::default()
+        }));
+        let (text, server_tools) =
+            collect_stream_text_and_server_tool_count(&client, &request).await?;
+        assert!(
+            server_tools > 0,
+            "Anthropic should emit web_search server tool content; text={text}"
+        );
+        assert!(!text.trim().is_empty(), "Anthropic should return text");
+    } else {
+        eprintln!(
+            "Skipping Anthropic web search smoke: missing ANTHROPIC_API_KEY (or RKAT_ANTHROPIC_API_KEY)"
+        );
+    }
+
+    if let Some(api_key) = gemini_api_key() {
+        ran += 1;
+        let client = GeminiClient::new(api_key);
+        let request = LlmRequest::new(
+            "gemini-2.5-flash",
+            vec![Message::User(UserMessage::text(prompt.to_string()))],
+        )
+        .with_provider_params(ProviderTag::Gemini(GeminiProviderTag {
+            google_search: Some(OpaqueProviderBody::from_value(&serde_json::json!({}))),
+            ..Default::default()
+        }));
+        let (text, server_tools) =
+            collect_stream_text_and_server_tool_count(&client, &request).await?;
+        assert!(
+            server_tools > 0,
+            "Gemini should emit google_search grounding metadata; text={text}"
+        );
+        assert!(!text.trim().is_empty(), "Gemini should return text");
+    } else {
+        eprintln!(
+            "Skipping Gemini web search smoke: missing GOOGLE_API_KEY (or GEMINI_API_KEY/RKAT_GEMINI_API_KEY)"
+        );
+    }
+
+    if ran == 0 {
+        eprintln!("Skipping provider web search smoke: no provider API keys configured");
+    }
     Ok(())
 }
 

--- a/meerkat-client/tests/live_client_provider_matrix.rs
+++ b/meerkat-client/tests/live_client_provider_matrix.rs
@@ -287,7 +287,7 @@ async fn e2e_smoke_provider_web_search_all_three() -> Result<(), Box<dyn std::er
         ran += 1;
         let client = GeminiClient::new(api_key);
         let request = LlmRequest::new(
-            "gemini-2.5-flash",
+            "gemini-3.1-flash-lite-preview",
             vec![Message::User(UserMessage::text(prompt.to_string()))],
         )
         .with_provider_params(ProviderTag::Gemini(GeminiProviderTag {

--- a/meerkat-contracts/src/wire/session.rs
+++ b/meerkat-contracts/src/wire/session.rs
@@ -407,6 +407,14 @@ pub enum WireAssistantBlock {
         #[serde(skip_serializing_if = "Option::is_none")]
         meta: Option<WireProviderMeta>,
     },
+    ServerToolContent {
+        #[serde(skip_serializing_if = "Option::is_none")]
+        id: Option<String>,
+        name: String,
+        content: serde_json::Value,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        meta: Option<WireProviderMeta>,
+    },
     Image {
         image_id: meerkat_core::AssistantImageId,
         blob_ref: meerkat_core::BlobRef,
@@ -443,6 +451,17 @@ impl From<AssistantBlock> for WireAssistantBlock {
                 // args are opaque from provider to dispatcher and this
                 // wire type preserves that invariant.
                 args,
+                meta: meta.map(|m| (*m).into()),
+            },
+            AssistantBlock::ServerToolContent {
+                id,
+                name,
+                content,
+                meta,
+            } => Self::ServerToolContent {
+                id,
+                name,
+                content,
                 meta: meta.map(|m| (*m).into()),
             },
             AssistantBlock::Image {

--- a/meerkat-core/src/event.rs
+++ b/meerkat-core/src/event.rs
@@ -870,6 +870,7 @@ pub fn agent_event_type(event: &AgentEvent) -> &'static str {
         AgentEvent::ReasoningComplete { .. } => "reasoning_complete",
         AgentEvent::TextDelta { .. } => "text_delta",
         AgentEvent::TextComplete { .. } => "text_complete",
+        AgentEvent::ServerToolContent { .. } => "server_tool_content",
         AgentEvent::ToolCallRequested { .. } => "tool_call_requested",
         AgentEvent::ToolResultReceived { .. } => "tool_result_received",
         AgentEvent::TurnCompleted { .. } => "turn_completed",
@@ -1391,6 +1392,9 @@ pub enum AgentEvent {
 
     /// Text generation complete for this turn
     TextComplete { content: String },
+
+    /// Provider-executed tool content surfaced during a model turn.
+    ServerToolContent { name: String, content: Value },
 
     /// Model requested a tool call
     ToolCallRequested {

--- a/meerkat-core/src/event.rs
+++ b/meerkat-core/src/event.rs
@@ -1394,7 +1394,12 @@ pub enum AgentEvent {
     TextComplete { content: String },
 
     /// Provider-executed tool content surfaced during a model turn.
-    ServerToolContent { name: String, content: Value },
+    ServerToolContent {
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        id: Option<String>,
+        name: String,
+        content: Value,
+    },
 
     /// Model requested a tool call
     ToolCallRequested {

--- a/meerkat-core/src/types.rs
+++ b/meerkat-core/src/types.rs
@@ -499,6 +499,21 @@ pub enum AssistantBlock {
         meta: Option<Box<ProviderMeta>>,
     },
 
+    /// Provider-executed tool evidence, such as OpenAI web search calls,
+    /// Anthropic server-side web search blocks, or Gemini grounding metadata.
+    ServerToolContent {
+        /// Provider item or tool-use ID when one exists.
+        #[serde(skip_serializing_if = "Option::is_none")]
+        id: Option<String>,
+        /// Provider-native tool name, for example `web_search` or `google_search`.
+        name: String,
+        /// Provider-native JSON payload, preserved for citations and grounding evidence.
+        content: Value,
+        /// Provider continuity metadata, if any.
+        #[serde(skip_serializing_if = "Option::is_none")]
+        meta: Option<Box<ProviderMeta>>,
+    },
+
     /// Canonical generated image output.
     Image {
         image_id: AssistantImageId,
@@ -536,6 +551,20 @@ impl PartialEq for AssistantBlock {
                     meta: m2,
                 },
             ) => i1 == i2 && n1 == n2 && a1.get() == a2.get() && m1 == m2,
+            (
+                AssistantBlock::ServerToolContent {
+                    id: i1,
+                    name: n1,
+                    content: c1,
+                    meta: m1,
+                },
+                AssistantBlock::ServerToolContent {
+                    id: i2,
+                    name: n2,
+                    content: c2,
+                    meta: m2,
+                },
+            ) => i1 == i2 && n1 == n2 && c1 == c2 && m1 == m2,
             (
                 AssistantBlock::Image {
                     image_id: i1,

--- a/meerkat-gemini/src/client.rs
+++ b/meerkat-gemini/src/client.rs
@@ -1378,6 +1378,14 @@ impl LlmClient for GeminiClient {
                                     }
                                 }
 
+                                if let Some(grounding_metadata) = cand.grounding_metadata {
+                                    yield LlmEvent::ServerToolContent {
+                                        id: None,
+                                        name: "google_search".to_string(),
+                                        content: grounding_metadata,
+                                        meta: None,
+                                    };
+                                }
                                 if let Some(reason) = cand.finish_reason {
                                     let stop = match reason.as_str() {
                                         "MAX_TOKENS" => StopReason::MaxTokens,
@@ -1441,6 +1449,7 @@ struct PromptFeedback {
 struct Candidate {
     content: Option<CandidateContent>,
     finish_reason: Option<String>,
+    grounding_metadata: Option<Value>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -1568,6 +1577,25 @@ mod tests {
         (format!("http://{addr}"), handle)
     }
 
+    async fn spawn_gemini_stream_stub(
+        model: &'static str,
+        payload: String,
+        seen: Arc<Mutex<Vec<Value>>>,
+    ) -> (String, tokio::task::JoinHandle<()>) {
+        let route = format!("/v1beta/models/{model}:streamGenerateContent");
+        let app = Router::new()
+            .route(&route, post(gemini_stream_stub))
+            .with_state(GeminiStreamStubState { payload, seen });
+        let listener = TcpListener::bind("127.0.0.1:0")
+            .await
+            .expect("bind test server");
+        let addr = listener.local_addr().expect("local addr");
+        let handle = tokio::spawn(async move {
+            axum::serve(listener, app).await.expect("serve test server");
+        });
+        (format!("http://{addr}"), handle)
+    }
+
     fn gemini_image_executor_request_json() -> ProviderImageGenerationRequest {
         serde_json::from_value(serde_json::json!({
             "operation_id": "00000000-0000-0000-0000-000000000201",
@@ -1684,6 +1712,46 @@ mod tests {
         assert!(
             body.get("contents").is_none(),
             "Code Assist must not send public generateContent fields at top level",
+        );
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn stream_emits_grounding_metadata_as_server_tool_content()
+    -> Result<(), Box<dyn std::error::Error>> {
+        let seen = Arc::new(Mutex::new(Vec::new()));
+        let payload = [
+            r#"data: {"candidates":[{"content":{"parts":[{"text":"grounded"}]},"finishReason":"STOP","groundingMetadata":{"webSearchQueries":["meerkat runtime"],"groundingChunks":[{"web":{"uri":"https://example.com","title":"Example"}}],"groundingSupports":[{"segment":{"startIndex":0,"endIndex":8},"groundingChunkIndices":[0]}]}}],"usageMetadata":{"promptTokenCount":3,"candidatesTokenCount":4}}"#,
+            "",
+        ]
+        .join("\n");
+        let (base_url, handle) =
+            spawn_gemini_stream_stub("gemini-2.5-flash", payload, seen.clone()).await;
+        let client = GeminiClient::new_with_base_url("test-key".to_string(), base_url);
+        let request = LlmRequest::new(
+            "gemini-2.5-flash",
+            vec![Message::User(UserMessage::text("search".to_string()))],
+        );
+
+        let mut stream = client.stream(&request);
+        let mut grounding = None;
+        while let Some(event) = stream.next().await {
+            match event? {
+                LlmEvent::ServerToolContent { name, content, .. } => {
+                    assert_eq!(name, "google_search");
+                    grounding = Some(content);
+                }
+                LlmEvent::Done { .. } => break,
+                _ => {}
+            }
+        }
+        handle.abort();
+
+        let grounding = grounding.expect("grounding metadata");
+        assert_eq!(grounding["webSearchQueries"][0], "meerkat runtime");
+        assert_eq!(
+            grounding["groundingChunks"][0]["web"]["uri"],
+            "https://example.com"
         );
         Ok(())
     }

--- a/meerkat-llm-core/src/adapter.rs
+++ b/meerkat-llm-core/src/adapter.rs
@@ -301,6 +301,19 @@ impl AgentLlmClient for LlmClientAdapter {
                         };
                         let _ = assembler.on_tool_call_complete(id, name, args_raw, effective_meta);
                     }
+                    LlmEvent::ServerToolContent {
+                        id,
+                        name,
+                        content,
+                        meta,
+                    } => {
+                        assembler.on_server_tool_content(id, name.clone(), content.clone(), meta);
+                        if let Some(ref tx) = self.event_tx {
+                            let _ = tx
+                                .send(AgentEvent::ServerToolContent { name, content })
+                                .await;
+                        }
+                    }
                     LlmEvent::UsageUpdate { usage: u } => {
                         usage = u;
                     }

--- a/meerkat-llm-core/src/adapter.rs
+++ b/meerkat-llm-core/src/adapter.rs
@@ -307,10 +307,15 @@ impl AgentLlmClient for LlmClientAdapter {
                         content,
                         meta,
                     } => {
+                        let event_id = id.clone();
                         assembler.on_server_tool_content(id, name.clone(), content.clone(), meta);
                         if let Some(ref tx) = self.event_tx {
                             let _ = tx
-                                .send(AgentEvent::ServerToolContent { name, content })
+                                .send(AgentEvent::ServerToolContent {
+                                    id: event_id,
+                                    name,
+                                    content,
+                                })
                                 .await;
                         }
                     }

--- a/meerkat-llm-core/src/block_assembler.rs
+++ b/meerkat-llm-core/src/block_assembler.rs
@@ -254,6 +254,24 @@ impl BlockAssembler {
         }
     }
 
+    /// Add a provider-executed tool content block.
+    pub fn on_server_tool_content(
+        &mut self,
+        id: Option<String>,
+        name: String,
+        content: serde_json::Value,
+        meta: Option<Box<ProviderMeta>>,
+    ) {
+        self.slots.push(BlockSlot::Finalized(Box::new(
+            AssistantBlock::ServerToolContent {
+                id,
+                name,
+                content,
+                meta,
+            },
+        )));
+    }
+
     /// Finalize the assembler and return the ordered blocks.
     ///
     /// Slab iteration is in insertion order, so blocks are returned

--- a/meerkat-llm-core/src/types.rs
+++ b/meerkat-llm-core/src/types.rs
@@ -332,6 +332,16 @@ pub enum LlmEvent {
         meta: Option<Box<meerkat_core::ProviderMeta>>,
     },
 
+    /// Provider-executed tool content, including web-search citations and
+    /// grounding metadata that are not caller-dispatched tool calls.
+    ServerToolContent {
+        id: Option<String>,
+        name: String,
+        content: Value,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        meta: Option<Box<meerkat_core::ProviderMeta>>,
+    },
+
     /// Token usage update
     UsageUpdate { usage: Usage },
 

--- a/meerkat-openai/src/client.rs
+++ b/meerkat-openai/src/client.rs
@@ -423,6 +423,9 @@ impl OpenAiClient {
                                     "arguments": args.get()  // Already JSON string
                                 }));
                             }
+                            AssistantBlock::ServerToolContent { content, .. } => {
+                                items.push(content.clone());
+                            }
                             // Reasoning replay can violate Responses API adjacency
                             // constraints and hard-fail requests; skip it and any
                             // unknown future variants.
@@ -1006,6 +1009,19 @@ impl LlmClient for OpenAiClient {
                                                             if let Some(part_type) = part.get("type").and_then(|t| t.as_str()) {
                                                                 match part_type {
                                                                     "output_text" => {
+                                                                        if let Some(annotations) = part.get("annotations") {
+                                                                            yield LlmEvent::ServerToolContent {
+                                                                                id: item.get("id")
+                                                                                    .and_then(|v| v.as_str())
+                                                                                    .map(std::string::ToString::to_string),
+                                                                                name: "web_search_annotations".to_string(),
+                                                                                content: serde_json::json!({
+                                                                                    "type": "message_annotations",
+                                                                                    "annotations": annotations
+                                                                                }),
+                                                                                meta: None,
+                                                                            };
+                                                                        }
                                                                         if let Some(text) = part.get("text").and_then(|t| t.as_str())
                                                                             && !saw_stream_text_delta
                                                                         {
@@ -1111,6 +1127,18 @@ impl LlmClient for OpenAiClient {
                                                         id: call_id.to_string(),
                                                         name: name.into(),
                                                         args: args_value,
+                                                        meta: None,
+                                                    };
+                                                }
+                                                "web_search_call" | "web_search_result" => {
+                                                    let id = item.get("id")
+                                                        .or_else(|| item.get("call_id"))
+                                                        .and_then(|v| v.as_str())
+                                                        .map(std::string::ToString::to_string);
+                                                    yield LlmEvent::ServerToolContent {
+                                                        id,
+                                                        name: item_type.to_string(),
+                                                        content: item.clone(),
                                                         meta: None,
                                                     };
                                                 }
@@ -1250,6 +1278,25 @@ impl LlmClient for OpenAiClient {
                                 };
                             }
                         }
+                        else if event.event_type.starts_with("response.web_search_call.") {
+                            let mut content = serde_json::Map::new();
+                            content.insert("type".to_string(), Value::String(event.event_type.clone()));
+                            if let Some(item_id) = &event.item_id {
+                                content.insert("item_id".to_string(), Value::String(item_id.clone()));
+                            }
+                            if let Some(output_index) = event.output_index {
+                                content.insert("output_index".to_string(), Value::from(output_index));
+                            }
+                            if let Some(sequence_number) = event.sequence_number {
+                                content.insert("sequence_number".to_string(), Value::from(sequence_number));
+                            }
+                            yield LlmEvent::ServerToolContent {
+                                id: event.item_id.clone(),
+                                name: "web_search".to_string(),
+                                content: Value::Object(content),
+                                meta: None,
+                            };
+                        }
                         else if event.event_type == "response.done" {
                             // Final done event — always update usage
                             if let Some(response_obj) = &event.response {
@@ -1383,6 +1430,12 @@ struct ResponsesStreamEvent {
     response: Option<Value>,
     /// Error object for streaming error events
     error: Option<Value>,
+    /// Output item ID for built-in tool streaming events.
+    item_id: Option<String>,
+    /// Output index for built-in tool streaming events.
+    output_index: Option<u64>,
+    /// Sequence number for built-in tool streaming events.
+    sequence_number: Option<u64>,
 }
 
 #[allow(clippy::unwrap_used, clippy::expect_used)]
@@ -2842,6 +2895,57 @@ mod tests {
         server.abort();
 
         assert_eq!(deltas, vec!["Hello"]);
+    }
+
+    #[tokio::test]
+    async fn test_web_search_call_blocks_are_emitted() {
+        let payload = [
+            r#"data: {"type":"response.web_search_call.searching","output_index":0,"item_id":"ws_123","sequence_number":1}"#,
+            r#"data: {"type":"response.completed","response":{"status":"completed","output":[{"type":"web_search_call","id":"ws_123","status":"completed","action":{"type":"search","queries":["meerkat runtime"]}},{"type":"message","content":[{"type":"output_text","text":"done","annotations":[{"type":"url_citation","url":"https://example.com","title":"Example","start_index":0,"end_index":4}]}]}],"usage":{"input_tokens":10,"output_tokens":5}}}"#,
+            "data: [DONE]",
+            "",
+        ]
+        .join("\n");
+        let (base_url, server) = spawn_openai_stub_server(payload).await;
+        let client = OpenAiClient::new_with_base_url("test-key".to_string(), base_url);
+        let request = LlmRequest::new(
+            "gpt-5-mini",
+            vec![Message::User(UserMessage::text("search".to_string()))],
+        );
+
+        let mut stream = client.stream(&request);
+        let mut server_blocks = Vec::new();
+        while let Some(event) = stream.next().await {
+            match event.expect("stream event") {
+                LlmEvent::ServerToolContent {
+                    id, name, content, ..
+                } => {
+                    server_blocks.push((id, name, content));
+                }
+                LlmEvent::Done { .. } => break,
+                _ => {}
+            }
+        }
+        server.abort();
+
+        assert_eq!(server_blocks.len(), 3);
+        assert_eq!(server_blocks[0].0.as_deref(), Some("ws_123"));
+        assert_eq!(server_blocks[0].1, "web_search");
+        assert_eq!(
+            server_blocks[0].2["type"],
+            "response.web_search_call.searching"
+        );
+        assert_eq!(server_blocks[1].0.as_deref(), Some("ws_123"));
+        assert_eq!(server_blocks[1].1, "web_search_call");
+        assert_eq!(
+            server_blocks[1].2["action"]["queries"][0],
+            "meerkat runtime"
+        );
+        assert_eq!(server_blocks[2].1, "web_search_annotations");
+        assert_eq!(
+            server_blocks[2].2["annotations"][0]["url"],
+            "https://example.com"
+        );
     }
 
     // =========================================================================

--- a/meerkat-rpc/src/session_runtime.rs
+++ b/meerkat-rpc/src/session_runtime.rs
@@ -1814,42 +1814,17 @@ impl SessionRuntimeLlmReconfigureHost {
         }
     }
 
-    fn explicit_meerkat_tool_policy_for_session(session: &Session) -> bool {
-        let Some(metadata) = session.session_metadata() else {
-            return false;
-        };
-        !matches!(
-            metadata.tooling.builtins,
-            meerkat_core::ToolCategoryOverride::Inherit
-        ) || !matches!(
-            metadata.tooling.shell,
-            meerkat_core::ToolCategoryOverride::Inherit
-        ) || !matches!(
-            metadata.tooling.memory,
-            meerkat_core::ToolCategoryOverride::Inherit
-        ) || !matches!(
-            metadata.tooling.mob,
-            meerkat_core::ToolCategoryOverride::Inherit
-        )
-    }
-
     async fn build_request_policy_for_llm_identity(
         &self,
         session_id: &SessionId,
         identity: &SessionLlmIdentity,
     ) -> Result<meerkat_core::SessionLlmRequestPolicy, RuntimeDriverError> {
         let config = self.load_config_for_hot_swap().await?;
-        let session = self
-            .service
-            .export_live_session(session_id)
-            .await
-            .map_err(session_error_to_runtime_driver)?;
-        let explicit_meerkat_tool_policy = Self::explicit_meerkat_tool_policy_for_session(&session);
         self.factory
-            .request_policy_for_llm_identity(&config, identity, explicit_meerkat_tool_policy)
+            .request_policy_for_llm_identity(&config, identity)
             .map_err(|e| {
                 RuntimeDriverError::Internal(format!(
-                    "Failed to build LLM request policy for session identity hot-swap: {e}"
+                    "Failed to build LLM request policy for session {session_id} identity hot-swap: {e}"
                 ))
             })
     }

--- a/meerkat/BUILD.bazel
+++ b/meerkat/BUILD.bazel
@@ -1084,9 +1084,12 @@ rust_library(
     compile_data = [
         "Cargo.toml",
         "skills/mob-communication/SKILL.md",
+        "src/help_content/api_reference.md",
+        "src/help_content/cli_reference_skill.md",
+        "src/help_content/migration_0_5.md",
+        "src/help_content/mobs.md",
+        "src/help_content/platform_skill.md",
         "src/surface/request_execution.rs",
-    ] + [
-        "//:meerkat_platform_skill_files",
     ],
     srcs = glob(["src/**/*.rs"]),
     visibility = ["//visibility:public"],
@@ -1155,9 +1158,12 @@ rust_test(
     compile_data = [
         "Cargo.toml",
         "skills/mob-communication/SKILL.md",
+        "src/help_content/api_reference.md",
+        "src/help_content/cli_reference_skill.md",
+        "src/help_content/migration_0_5.md",
+        "src/help_content/mobs.md",
+        "src/help_content/platform_skill.md",
         "src/surface/request_execution.rs",
-    ] + [
-        "//:meerkat_platform_skill_files",
     ],
     srcs = glob(["src/**/*.rs"]),
     visibility = ["//visibility:public"],
@@ -1238,9 +1244,12 @@ rust_test(
     compile_data = [
         "Cargo.toml",
         "skills/mob-communication/SKILL.md",
+        "src/help_content/api_reference.md",
+        "src/help_content/cli_reference_skill.md",
+        "src/help_content/migration_0_5.md",
+        "src/help_content/mobs.md",
+        "src/help_content/platform_skill.md",
         "src/surface/request_execution.rs",
-    ] + [
-        "//:meerkat_platform_skill_files",
     ],
     srcs = [
         "tests/agent_builder_policy_canary.rs",
@@ -1355,9 +1364,12 @@ rust_test(
     compile_data = [
         "Cargo.toml",
         "skills/mob-communication/SKILL.md",
+        "src/help_content/api_reference.md",
+        "src/help_content/cli_reference_skill.md",
+        "src/help_content/migration_0_5.md",
+        "src/help_content/mobs.md",
+        "src/help_content/platform_skill.md",
         "src/surface/request_execution.rs",
-    ] + [
-        "//:meerkat_platform_skill_files",
     ],
     srcs = [
         "tests/agent_factory_auth_binding.rs",
@@ -1438,9 +1450,12 @@ rust_test(
     compile_data = [
         "Cargo.toml",
         "skills/mob-communication/SKILL.md",
+        "src/help_content/api_reference.md",
+        "src/help_content/cli_reference_skill.md",
+        "src/help_content/migration_0_5.md",
+        "src/help_content/mobs.md",
+        "src/help_content/platform_skill.md",
         "src/surface/request_execution.rs",
-    ] + [
-        "//:meerkat_platform_skill_files",
     ],
     srcs = [
         "tests/catalog_control_agent_boundary.rs",
@@ -1521,9 +1536,12 @@ rust_test(
     compile_data = [
         "Cargo.toml",
         "skills/mob-communication/SKILL.md",
+        "src/help_content/api_reference.md",
+        "src/help_content/cli_reference_skill.md",
+        "src/help_content/migration_0_5.md",
+        "src/help_content/mobs.md",
+        "src/help_content/platform_skill.md",
         "src/surface/request_execution.rs",
-    ] + [
-        "//:meerkat_platform_skill_files",
     ],
     srcs = [
         "tests/e2e_shell.rs",
@@ -1608,9 +1626,12 @@ rust_test(
     compile_data = [
         "Cargo.toml",
         "skills/mob-communication/SKILL.md",
+        "src/help_content/api_reference.md",
+        "src/help_content/cli_reference_skill.md",
+        "src/help_content/migration_0_5.md",
+        "src/help_content/mobs.md",
+        "src/help_content/platform_skill.md",
         "src/surface/request_execution.rs",
-    ] + [
-        "//:meerkat_platform_skill_files",
     ],
     srcs = [
         "tests/embedded_skill_registration.rs",
@@ -1691,9 +1712,12 @@ rust_test(
     compile_data = [
         "Cargo.toml",
         "skills/mob-communication/SKILL.md",
+        "src/help_content/api_reference.md",
+        "src/help_content/cli_reference_skill.md",
+        "src/help_content/migration_0_5.md",
+        "src/help_content/mobs.md",
+        "src/help_content/platform_skill.md",
         "src/surface/request_execution.rs",
-    ] + [
-        "//:meerkat_platform_skill_files",
     ],
     srcs = [
         "tests/factory_build_agent.rs",
@@ -1776,9 +1800,12 @@ rust_test(
     compile_data = [
         "Cargo.toml",
         "skills/mob-communication/SKILL.md",
+        "src/help_content/api_reference.md",
+        "src/help_content/cli_reference_skill.md",
+        "src/help_content/migration_0_5.md",
+        "src/help_content/mobs.md",
+        "src/help_content/platform_skill.md",
         "src/surface/request_execution.rs",
-    ] + [
-        "//:meerkat_platform_skill_files",
     ],
     srcs = [
         "tests/integration.rs",
@@ -1862,9 +1889,12 @@ rust_test(
     compile_data = [
         "Cargo.toml",
         "skills/mob-communication/SKILL.md",
+        "src/help_content/api_reference.md",
+        "src/help_content/cli_reference_skill.md",
+        "src/help_content/migration_0_5.md",
+        "src/help_content/mobs.md",
+        "src/help_content/platform_skill.md",
         "src/surface/request_execution.rs",
-    ] + [
-        "//:meerkat_platform_skill_files",
     ],
     srcs = [
         "tests/live_meerkat_comms.rs",
@@ -1946,9 +1976,12 @@ rust_test(
     compile_data = [
         "Cargo.toml",
         "skills/mob-communication/SKILL.md",
+        "src/help_content/api_reference.md",
+        "src/help_content/cli_reference_skill.md",
+        "src/help_content/migration_0_5.md",
+        "src/help_content/mobs.md",
+        "src/help_content/platform_skill.md",
         "src/surface/request_execution.rs",
-    ] + [
-        "//:meerkat_platform_skill_files",
     ],
     srcs = [
         "tests/live_meerkat_regression.rs",
@@ -2030,9 +2063,12 @@ rust_test(
     compile_data = [
         "Cargo.toml",
         "skills/mob-communication/SKILL.md",
+        "src/help_content/api_reference.md",
+        "src/help_content/cli_reference_skill.md",
+        "src/help_content/migration_0_5.md",
+        "src/help_content/mobs.md",
+        "src/help_content/platform_skill.md",
         "src/surface/request_execution.rs",
-    ] + [
-        "//:meerkat_platform_skill_files",
     ],
     srcs = [
         "tests/live_meerkat_user_flows.rs",
@@ -2118,9 +2154,12 @@ rust_test(
     compile_data = [
         "Cargo.toml",
         "skills/mob-communication/SKILL.md",
+        "src/help_content/api_reference.md",
+        "src/help_content/cli_reference_skill.md",
+        "src/help_content/migration_0_5.md",
+        "src/help_content/mobs.md",
+        "src/help_content/platform_skill.md",
         "src/surface/request_execution.rs",
-    ] + [
-        "//:meerkat_platform_skill_files",
     ],
     srcs = [
         "tests/persistence_contract.rs",
@@ -2201,9 +2240,12 @@ rust_test(
     compile_data = [
         "Cargo.toml",
         "skills/mob-communication/SKILL.md",
+        "src/help_content/api_reference.md",
+        "src/help_content/cli_reference_skill.md",
+        "src/help_content/migration_0_5.md",
+        "src/help_content/mobs.md",
+        "src/help_content/platform_skill.md",
         "src/surface/request_execution.rs",
-    ] + [
-        "//:meerkat_platform_skill_files",
     ],
     srcs = [
         "tests/realtime_channel_builder.rs",
@@ -2284,9 +2326,12 @@ rust_test(
     compile_data = [
         "Cargo.toml",
         "skills/mob-communication/SKILL.md",
+        "src/help_content/api_reference.md",
+        "src/help_content/cli_reference_skill.md",
+        "src/help_content/migration_0_5.md",
+        "src/help_content/mobs.md",
+        "src/help_content/platform_skill.md",
         "src/surface/request_execution.rs",
-    ] + [
-        "//:meerkat_platform_skill_files",
     ],
     srcs = [
         "tests/schedule_host_typed_mapping.rs",
@@ -2369,9 +2414,12 @@ rust_test(
     compile_data = [
         "Cargo.toml",
         "skills/mob-communication/SKILL.md",
+        "src/help_content/api_reference.md",
+        "src/help_content/cli_reference_skill.md",
+        "src/help_content/migration_0_5.md",
+        "src/help_content/mobs.md",
+        "src/help_content/platform_skill.md",
         "src/surface/request_execution.rs",
-    ] + [
-        "//:meerkat_platform_skill_files",
     ],
     srcs = [
         "tests/sdk_agentfactory.rs",
@@ -2456,9 +2504,12 @@ rust_test(
     compile_data = [
         "Cargo.toml",
         "skills/mob-communication/SKILL.md",
+        "src/help_content/api_reference.md",
+        "src/help_content/cli_reference_skill.md",
+        "src/help_content/migration_0_5.md",
+        "src/help_content/mobs.md",
+        "src/help_content/platform_skill.md",
         "src/surface/request_execution.rs",
-    ] + [
-        "//:meerkat_platform_skill_files",
     ],
     srcs = [
         "tests/sdk_config_ephemeral.rs",
@@ -2539,9 +2590,12 @@ rust_test(
     compile_data = [
         "Cargo.toml",
         "skills/mob-communication/SKILL.md",
+        "src/help_content/api_reference.md",
+        "src/help_content/cli_reference_skill.md",
+        "src/help_content/migration_0_5.md",
+        "src/help_content/mobs.md",
+        "src/help_content/platform_skill.md",
         "src/surface/request_execution.rs",
-    ] + [
-        "//:meerkat_platform_skill_files",
     ],
     srcs = [
         "tests/sdk_structured_output.rs",
@@ -2623,9 +2677,12 @@ rust_test(
     compile_data = [
         "Cargo.toml",
         "skills/mob-communication/SKILL.md",
+        "src/help_content/api_reference.md",
+        "src/help_content/cli_reference_skill.md",
+        "src/help_content/migration_0_5.md",
+        "src/help_content/mobs.md",
+        "src/help_content/platform_skill.md",
         "src/surface/request_execution.rs",
-    ] + [
-        "//:meerkat_platform_skill_files",
     ],
     srcs = [
         "tests/smoke_meerkat_sdk.rs",

--- a/meerkat/examples/comms_verbose.rs
+++ b/meerkat/examples/comms_verbose.rs
@@ -128,7 +128,9 @@ impl AgentLlmClient for LoggingLlmAdapter {
                         println!("└────────────────────────────────────────┘");
                         tool_calls.push(ToolCall::new(id, name, args));
                     }
-                    LlmEvent::ReasoningDelta { .. } | LlmEvent::ReasoningComplete { .. } => {}
+                    LlmEvent::ReasoningDelta { .. }
+                    | LlmEvent::ReasoningComplete { .. }
+                    | LlmEvent::ServerToolContent { .. } => {}
                     LlmEvent::UsageUpdate { usage: u } => {
                         usage = u;
                     }

--- a/meerkat/src/factory.rs
+++ b/meerkat/src/factory.rs
@@ -743,11 +743,9 @@ fn provider_tool_defaults_for(
     provider: Provider,
     config: &Config,
     model_profile: Option<&meerkat_core::model_profile::ModelProfile>,
-    explicit_meerkat_tool_policy: bool,
+    _explicit_meerkat_tool_policy: bool,
 ) -> Option<serde_json::Value> {
-    if explicit_meerkat_tool_policy
-        || !model_profile.is_some_and(|profile| profile.supports_web_search)
-    {
+    if !model_profile.is_some_and(|profile| profile.supports_web_search) {
         return None;
     }
 

--- a/meerkat/src/factory.rs
+++ b/meerkat/src/factory.rs
@@ -743,7 +743,6 @@ fn provider_tool_defaults_for(
     provider: Provider,
     config: &Config,
     model_profile: Option<&meerkat_core::model_profile::ModelProfile>,
-    _explicit_meerkat_tool_policy: bool,
 ) -> Option<serde_json::Value> {
     if !model_profile.is_some_and(|profile| profile.supports_web_search) {
         return None;
@@ -2049,7 +2048,6 @@ impl AgentFactory {
         &self,
         config: &Config,
         identity: &SessionLlmIdentity,
-        explicit_meerkat_tool_policy: bool,
     ) -> Result<meerkat_core::SessionLlmRequestPolicy, FactoryError> {
         let registry = config
             .model_registry()
@@ -2062,7 +2060,6 @@ impl AgentFactory {
                 identity.provider,
                 config,
                 model_profile.as_ref(),
-                explicit_meerkat_tool_policy,
             ),
         })
     }
@@ -2762,18 +2759,6 @@ impl AgentFactory {
                     as Arc<dyn meerkat_core::ImageGenerationPlanner>
             })
         };
-
-        let explicit_meerkat_tool_policy =
-            !matches!(
-                build_config.override_builtins,
-                ToolCategoryOverride::Inherit
-            ) || !matches!(build_config.override_shell, ToolCategoryOverride::Inherit)
-                || !matches!(build_config.override_memory, ToolCategoryOverride::Inherit)
-                || !matches!(
-                    build_config.override_schedule,
-                    ToolCategoryOverride::Inherit
-                )
-                || !matches!(build_config.override_mob, ToolCategoryOverride::Inherit);
 
         // 2. Resolve provider and any self-hosted server binding.
         let resumed_self_hosted_server_id = resumed_session_metadata
@@ -3967,12 +3952,8 @@ impl AgentFactory {
             }))
             .with_call_timeout_override(effective_call_timeout_override);
 
-        if let Some(defaults) = provider_tool_defaults_for(
-            provider,
-            config,
-            model_profile.as_ref(),
-            explicit_meerkat_tool_policy,
-        ) {
+        if let Some(defaults) = provider_tool_defaults_for(provider, config, model_profile.as_ref())
+        {
             builder = builder.provider_tool_defaults(defaults);
         }
         if let Some(params) = build_config.provider_params.clone() {
@@ -4379,7 +4360,7 @@ mod tests {
         };
 
         let openai_policy = factory
-            .request_policy_for_llm_identity(&config, &openai_identity, false)
+            .request_policy_for_llm_identity(&config, &openai_identity)
             .expect("OpenAI request policy");
         assert_eq!(
             openai_policy.provider_tool_defaults,
@@ -4388,7 +4369,7 @@ mod tests {
         );
 
         let mismatched_policy = factory
-            .request_policy_for_llm_identity(&config, &mismatched_identity, false)
+            .request_policy_for_llm_identity(&config, &mismatched_identity)
             .expect("mismatched request policy should fail closed, not error");
         assert!(
             mismatched_policy.provider_tool_defaults.is_none(),

--- a/meerkat/tests/factory_build_agent.rs
+++ b/meerkat/tests/factory_build_agent.rs
@@ -2156,7 +2156,7 @@ async fn web_search_explicit_params_merged_with_defaults() {
 }
 
 #[tokio::test]
-async fn explicit_meerkat_tool_policy_suppresses_ambient_provider_search_defaults() {
+async fn explicit_meerkat_tool_policy_preserves_provider_search_defaults() {
     let temp = tempfile::tempdir().unwrap();
     let factory = temp_factory(&temp);
     let config = Config::default();
@@ -2171,8 +2171,8 @@ async fn explicit_meerkat_tool_policy_suppresses_ambient_provider_search_default
     let params = client.captured_params();
     let has_web_search = params.as_ref().and_then(|p| p.get("web_search")).is_some();
     assert!(
-        !has_web_search,
-        "explicit Meerkat tool policy should suppress ambient provider web_search defaults: {params:?}"
+        has_web_search,
+        "explicit Meerkat tool policy should not suppress provider web_search defaults: {params:?}"
     );
 }
 

--- a/meerkat/tests/integration.rs
+++ b/meerkat/tests/integration.rs
@@ -81,6 +81,9 @@ mod llm_normalization {
                 Ok(LlmEvent::ReasoningDelta { .. } | LlmEvent::ReasoningComplete { .. }) => {
                     // Reasoning events are valid
                 }
+                Ok(LlmEvent::ServerToolContent { .. }) => {
+                    // Provider-executed tool evidence is a valid side-channel event.
+                }
                 Err(e) => panic!("Unexpected error: {e:?}"),
             }
         }

--- a/meerkat/tests/live_meerkat_comms.rs
+++ b/meerkat/tests/live_meerkat_comms.rs
@@ -109,7 +109,9 @@ impl<C: LlmClient + 'static> AgentLlmClient for LlmClientAdapter<C> {
                             ));
                         }
                     },
-                    LlmEvent::ReasoningDelta { .. } | LlmEvent::ReasoningComplete { .. } => {}
+                    LlmEvent::ReasoningDelta { .. }
+                    | LlmEvent::ReasoningComplete { .. }
+                    | LlmEvent::ServerToolContent { .. } => {}
                 },
                 Err(e) => {
                     return Err(AgentError::llm(

--- a/meerkat/tests/live_meerkat_user_flows.rs
+++ b/meerkat/tests/live_meerkat_user_flows.rs
@@ -107,7 +107,9 @@ impl<C: LlmClient + 'static> AgentLlmClient for LlmClientAdapter<C> {
                             ));
                         }
                     },
-                    LlmEvent::ReasoningDelta { .. } | LlmEvent::ReasoningComplete { .. } => {}
+                    LlmEvent::ReasoningDelta { .. }
+                    | LlmEvent::ReasoningComplete { .. }
+                    | LlmEvent::ServerToolContent { .. } => {}
                 },
                 Err(e) => {
                     return Err(AgentError::llm(

--- a/meerkat/tests/smoke_meerkat_sdk.rs
+++ b/meerkat/tests/smoke_meerkat_sdk.rs
@@ -115,7 +115,9 @@ impl<C: LlmClient + 'static> AgentLlmClient for LlmClientAdapter<C> {
                             ));
                         }
                     },
-                    LlmEvent::ReasoningDelta { .. } | LlmEvent::ReasoningComplete { .. } => {}
+                    LlmEvent::ReasoningDelta { .. }
+                    | LlmEvent::ReasoningComplete { .. }
+                    | LlmEvent::ServerToolContent { .. } => {}
                 },
                 Err(e) => {
                     return Err(AgentError::llm(

--- a/sdks/python/meerkat/generated/types.py
+++ b/sdks/python/meerkat/generated/types.py
@@ -2562,6 +2562,10 @@ class WireAssistantBlockToolUse(TypedDict, total=False):
     block_type: Required[Literal['tool_use']]
     data: Required[dict[str, Any]]
 
+class WireAssistantBlockServerToolContent(TypedDict, total=False):
+    block_type: Required[Literal['server_tool_content']]
+    data: Required[dict[str, Any]]
+
 class WireAssistantBlockImage(TypedDict, total=False):
     block_type: Required[Literal['image']]
     data: Required[dict[str, Any]]
@@ -2569,7 +2573,7 @@ class WireAssistantBlockImage(TypedDict, total=False):
 class WireAssistantBlockUnknown(TypedDict, total=False):
     block_type: Required[Literal['unknown']]
 
-WireAssistantBlock = WireAssistantBlockText | WireAssistantBlockReasoning | WireAssistantBlockToolUse | WireAssistantBlockImage | WireAssistantBlockUnknown
+WireAssistantBlock = WireAssistantBlockText | WireAssistantBlockReasoning | WireAssistantBlockToolUse | WireAssistantBlockServerToolContent | WireAssistantBlockImage | WireAssistantBlockUnknown
 
 # Machine-owned image operation phase.
 class WireImageOperationPhaseRequested(TypedDict, total=False):

--- a/sdks/typescript/src/generated/types.ts
+++ b/sdks/typescript/src/generated/types.ts
@@ -2369,6 +2369,11 @@ export interface WireAssistantBlockToolUse {
   data: Record<string, unknown>;
 }
 
+export interface WireAssistantBlockServerToolContent {
+  block_type: "server_tool_content";
+  data: Record<string, unknown>;
+}
+
 export interface WireAssistantBlockImage {
   block_type: "image";
   data: Record<string, unknown>;
@@ -2378,7 +2383,7 @@ export interface WireAssistantBlockUnknown {
   block_type: "unknown";
 }
 
-export type WireAssistantBlock = WireAssistantBlockText | WireAssistantBlockReasoning | WireAssistantBlockToolUse | WireAssistantBlockImage | WireAssistantBlockUnknown;
+export type WireAssistantBlock = WireAssistantBlockText | WireAssistantBlockReasoning | WireAssistantBlockToolUse | WireAssistantBlockServerToolContent | WireAssistantBlockImage | WireAssistantBlockUnknown;
 
 export interface WireImageOperationPhaseRequested {
   phase: "requested";

--- a/sdks/web/src/generated/events.ts
+++ b/sdks/web/src/generated/events.ts
@@ -348,6 +348,13 @@ export interface TextCompleteEvent {
   type: "text_complete";
 }
 
+export interface ServerToolContentEvent {
+  content: unknown;
+  id?: string | null;
+  name: string;
+  type: "server_tool_content";
+}
+
 export interface ToolCallRequestedEvent {
   args: ToolCallArguments;
   id: string;
@@ -534,6 +541,7 @@ export type AgentEvent =
   ReasoningCompleteEvent |
   TextDeltaEvent |
   TextCompleteEvent |
+  ServerToolContentEvent |
   ToolCallRequestedEvent |
   ToolResultReceivedEvent |
   TurnCompletedEvent |


### PR DESCRIPTION
## Summary

Fix provider-native web search plumbing across request injection and response capture.

## Root Cause

Provider tool defaults were incorrectly coupled to Meerkat tool category overrides. CLI and other surface-built sessions collapse tool presets into explicit enable/disable overrides, which caused provider web search defaults to be suppressed even when the selected model supports web search.

On the response side, provider-native search evidence was parsed as unknown content and dropped because the assistant block model had no place for server-executed tool output, citations, or grounding metadata.

## Changes

- Decouple provider-native web search defaults from Meerkat tool category policy.
- Add typed `ServerToolContent` plumbing through `LlmEvent`, `AssistantBlock`, block assembly, agent events, and wire projection.
- Capture provider search evidence:
  - Anthropic `server_tool_use`, `web_search_tool_result`, and text citation side-channel.
  - OpenAI `web_search_call`, streamed `response.web_search_call.*`, and message URL annotations.
  - Gemini `groundingMetadata`, emitted before terminal `Done`.
- Add parser/default regression tests and an ignored e2e smoke covering OpenAI, Anthropic, and Gemini web search.

## Validation

- `make lint`
- `./scripts/repo-cargo test -p meerkat explicit_meerkat_tool_policy_preserves_provider_search_defaults --test factory_build_agent`
- `./scripts/repo-cargo test -p meerkat-anthropic test_web_search_server_tool_blocks_are_emitted`
- `./scripts/repo-cargo test -p meerkat-openai test_web_search_call_blocks_are_emitted`
- `./scripts/repo-cargo test -p meerkat-gemini stream_emits_grounding_metadata_as_server_tool_content`
- Pre-push hooks, including changed-crates Clippy, codegen verify, generated-header audit, bridge invariant check, and workspace deterministic gate.
