### PR TITLE
LUC-497: Add provider replay projection contract

### DIFF
--- a/examples/035-mdm-tux-rs/src/bin/target.rs
+++ b/examples/035-mdm-tux-rs/src/bin/target.rs
@@ -2163,6 +2163,13 @@ mod tests {
 
     #[async_trait::async_trait]
     impl LlmClient for ScriptedClient {
+        fn project_replay_messages(
+            &self,
+            messages: &[meerkat_core::Message],
+        ) -> Result<Vec<meerkat_core::Message>, meerkat_client::LlmError> {
+            Ok(messages.to_vec())
+        }
+
         fn stream<'a>(&'a self, request: &'a LlmRequest) -> LlmStream<'a> {
             let _ = request;
             let events = self

--- a/examples/035-mdm-tux-rs/src/test_support.rs
+++ b/examples/035-mdm-tux-rs/src/test_support.rs
@@ -28,6 +28,13 @@ impl CaptureClient {
 #[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
 #[cfg_attr(not(target_arch = "wasm32"), async_trait)]
 impl LlmClient for CaptureClient {
+    fn project_replay_messages(
+        &self,
+        messages: &[meerkat_core::Message],
+    ) -> Result<Vec<meerkat_core::Message>, meerkat_client::LlmError> {
+        Ok(messages.to_vec())
+    }
+
     fn stream<'a>(&'a self, request: &'a LlmRequest) -> LlmStream<'a> {
         *self.seen_tools.lock().expect("capture lock") =
             request.tools.iter().map(|tool| tool.name.to_string()).collect();

--- a/meerkat-anthropic/src/client.rs
+++ b/meerkat-anthropic/src/client.rs
@@ -9,12 +9,16 @@ use meerkat_core::lifecycle::run_primitive::{
     AnthropicProviderTag, AnthropicThinkingConfig, ProviderTag,
 };
 use meerkat_core::schema::{CompiledSchema, SchemaError};
-use meerkat_core::{ContentBlock, ImageData, Message, OutputSchema, Provider, StopReason, Usage};
+use meerkat_core::{
+    AssistantBlock, BlockAssistantMessage, ContentBlock, ImageData, Message, OutputSchema,
+    Provider, StopReason, ToolResult, Usage,
+};
 use meerkat_llm_core::LlmError;
 use meerkat_llm_core::{LlmClient, LlmDoneOutcome, LlmEvent, LlmRequest, LlmStream};
 use meerkat_llm_core::{http, streaming};
 use serde::Deserialize;
 use serde_json::Value;
+use std::collections::HashSet;
 use std::time::Duration;
 
 /// Default connect timeout
@@ -157,6 +161,191 @@ fn catalog_context_beta_value(request: &LlmRequest) -> Option<&'static str> {
     .context_window_beta?
     .header;
     header.strip_prefix("anthropic-beta: ")
+}
+
+fn invalid_replay(message: impl Into<String>) -> LlmError {
+    LlmError::InvalidRequest {
+        message: message.into(),
+    }
+}
+
+fn project_anthropic_content_blocks(blocks: &[ContentBlock]) -> Vec<ContentBlock> {
+    blocks
+        .iter()
+        .map(|block| match block {
+            ContentBlock::Text { .. } => block.clone(),
+            ContentBlock::Image {
+                data: ImageData::Inline { .. },
+                ..
+            } => block.clone(),
+            ContentBlock::Image { .. } | ContentBlock::Video { .. } => ContentBlock::Text {
+                text: block.text_projection().into_owned(),
+            },
+            _ => ContentBlock::Text {
+                text: block.text_projection().into_owned(),
+            },
+        })
+        .collect()
+}
+
+fn project_anthropic_tool_result(result: &ToolResult) -> Result<ToolResult, LlmError> {
+    if result.has_video() {
+        return Err(invalid_replay(
+            "video blocks are not supported in Anthropic tool results",
+        ));
+    }
+    Ok(ToolResult::with_blocks(
+        result.tool_use_id.clone(),
+        project_anthropic_content_blocks(&result.content),
+        result.is_error,
+    ))
+}
+
+fn anthropic_server_tool_content_replayable(content: &Value) -> bool {
+    matches!(
+        content.get("type").and_then(Value::as_str),
+        Some("server_tool_use" | "web_search_tool_result")
+    )
+}
+
+fn project_anthropic_assistant_blocks(blocks: &[AssistantBlock]) -> Vec<AssistantBlock> {
+    blocks
+        .iter()
+        .filter_map(|block| match block {
+            AssistantBlock::Text { text, .. } if text.is_empty() => None,
+            AssistantBlock::Text { .. } | AssistantBlock::ToolUse { .. } => Some(block.clone()),
+            AssistantBlock::Reasoning { meta, .. } => match meta.as_deref() {
+                Some(meerkat_core::ProviderMeta::Anthropic { .. })
+                | Some(meerkat_core::ProviderMeta::AnthropicRedacted { .. })
+                | Some(meerkat_core::ProviderMeta::AnthropicCompaction { .. }) => {
+                    Some(block.clone())
+                }
+                _ => None,
+            },
+            AssistantBlock::ServerToolContent { content, .. }
+                if anthropic_server_tool_content_replayable(content) =>
+            {
+                Some(block.clone())
+            }
+            AssistantBlock::Image { .. } | AssistantBlock::ServerToolContent { .. } => None,
+            _ => None,
+        })
+        .collect()
+}
+
+fn tool_ids_from_assistant(message: &Message) -> HashSet<String> {
+    match message {
+        Message::Assistant(assistant) => assistant
+            .tool_calls
+            .iter()
+            .map(|tool_call| tool_call.id.clone())
+            .collect(),
+        Message::BlockAssistant(assistant) => assistant
+            .blocks
+            .iter()
+            .filter_map(|block| match block {
+                AssistantBlock::ToolUse { id, .. } => Some(id.clone()),
+                _ => None,
+            })
+            .collect(),
+        _ => HashSet::new(),
+    }
+}
+
+fn validate_tool_results(
+    provider: &str,
+    pending: HashSet<String>,
+    results: &[ToolResult],
+) -> Result<(), LlmError> {
+    let actual: HashSet<String> = results
+        .iter()
+        .map(|result| result.tool_use_id.clone())
+        .collect();
+    if actual == pending {
+        Ok(())
+    } else {
+        Err(invalid_replay(format!(
+            "{provider} replay projection found tool results that are not adjacent to matching tool uses"
+        )))
+    }
+}
+
+fn project_anthropic_replay_messages(messages: &[Message]) -> Result<Vec<Message>, LlmError> {
+    let mut projected = Vec::with_capacity(messages.len());
+    let mut pending_tool_ids: Option<HashSet<String>> = None;
+
+    for message in messages {
+        if let Message::ToolResults {
+            results,
+            created_at,
+        } = message
+        {
+            let Some(pending) = pending_tool_ids.take() else {
+                return Err(invalid_replay(
+                    "Anthropic replay projection found tool results without preceding tool use",
+                ));
+            };
+            validate_tool_results("Anthropic", pending, results)?;
+            let results = results
+                .iter()
+                .map(project_anthropic_tool_result)
+                .collect::<Result<Vec<_>, _>>()?;
+            projected.push(Message::ToolResults {
+                results,
+                created_at: *created_at,
+            });
+            continue;
+        }
+
+        if pending_tool_ids.is_some() {
+            return Err(invalid_replay(
+                "Anthropic replay projection found a tool use without adjacent tool results",
+            ));
+        }
+
+        let next_message = match message {
+            Message::System(_) | Message::SystemNotice(_) => Some(message.clone()),
+            Message::User(user) => Some(Message::User(meerkat_core::UserMessage {
+                content: project_anthropic_content_blocks(&user.content),
+                render_metadata: user.render_metadata.clone(),
+                created_at: user.created_at,
+            })),
+            Message::Assistant(assistant) => {
+                if assistant.content.is_empty() && assistant.tool_calls.is_empty() {
+                    None
+                } else {
+                    Some(Message::Assistant(assistant.clone()))
+                }
+            }
+            Message::BlockAssistant(assistant) => {
+                let blocks = project_anthropic_assistant_blocks(&assistant.blocks);
+                (!blocks.is_empty()).then(|| {
+                    Message::BlockAssistant(BlockAssistantMessage {
+                        blocks,
+                        stop_reason: assistant.stop_reason,
+                        created_at: assistant.created_at,
+                    })
+                })
+            }
+            Message::ToolResults { .. } => unreachable!("handled above"),
+        };
+
+        if let Some(message) = next_message {
+            let tool_ids = tool_ids_from_assistant(&message);
+            if !tool_ids.is_empty() {
+                pending_tool_ids = Some(tool_ids);
+            }
+            projected.push(message);
+        }
+    }
+
+    if pending_tool_ids.is_some() {
+        return Err(invalid_replay(
+            "Anthropic replay projection found a trailing tool use without tool results",
+        ));
+    }
+
+    Ok(projected)
 }
 
 impl AnthropicClient {
@@ -660,8 +849,15 @@ fn merge_usage(target: &mut Usage, update: &AnthropicUsage) {
 #[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
 #[cfg_attr(not(target_arch = "wasm32"), async_trait)]
 impl LlmClient for AnthropicClient {
+    fn project_replay_messages(&self, messages: &[Message]) -> Result<Vec<Message>, LlmError> {
+        project_anthropic_replay_messages(messages)
+    }
+
     fn stream<'a>(&'a self, request: &'a LlmRequest) -> LlmStream<'a> {
         let inner: LlmStream<'a> = Box::pin(async_stream::try_stream! {
+            let mut projected_request = request.clone();
+            projected_request.messages = self.project_replay_messages(&request.messages)?;
+            let request = &projected_request;
             let body = self.build_request_body(request)?;
 
             // Collect beta headers based on request features
@@ -1210,12 +1406,196 @@ struct AnthropicUsage {
 mod tests {
     use super::*;
     use meerkat_core::{
-        AssistantBlock, BlockAssistantMessage, ContentBlock, ProviderMeta, UserMessage,
+        AssistantBlock, AssistantImageId, BlobId, BlobRef, BlockAssistantMessage, ContentBlock,
+        ImageData, MediaType, ProviderImageMetadata, ProviderMeta, RevisedPromptDisposition,
+        ToolResult, UserMessage,
     };
+
+    fn assistant_image_block() -> AssistantBlock {
+        AssistantBlock::Image {
+            image_id: AssistantImageId::new(meerkat_core::time_compat::new_uuid_v7()),
+            blob_ref: BlobRef {
+                blob_id: BlobId::from("anthropic-image"),
+                media_type: "image/png".to_string(),
+            },
+            media_type: MediaType::new("image/png"),
+            width: 128,
+            height: 128,
+            revised_prompt: RevisedPromptDisposition::NotRequested,
+            meta: ProviderImageMetadata::NotEmitted,
+        }
+    }
 
     // =========================================================================
     // Thinking block SSE parsing tests (spec section 3.5)
     // =========================================================================
+
+    #[test]
+    fn replay_projection_policy_handles_anthropic_history_blocks()
+    -> Result<(), Box<dyn std::error::Error>> {
+        let client = AnthropicClient::new("test-key".to_string())?;
+        let tool_args = serde_json::value::RawValue::from_string(r#"{"query":"m"}"#.to_string())?;
+        let messages = vec![
+            Message::User(UserMessage::with_blocks(vec![
+                ContentBlock::Text {
+                    text: "look at this".to_string(),
+                },
+                ContentBlock::Image {
+                    media_type: "image/png".to_string(),
+                    data: ImageData::Inline {
+                        data: "AAAA".to_string(),
+                    },
+                },
+                ContentBlock::Video {
+                    media_type: "video/mp4".to_string(),
+                    duration_ms: 1_000,
+                    data: meerkat_core::VideoData::Inline {
+                        data: "BBBB".to_string(),
+                    },
+                },
+            ])),
+            Message::BlockAssistant(BlockAssistantMessage::new(
+                vec![
+                    AssistantBlock::Reasoning {
+                        text: "signed plan".to_string(),
+                        meta: Some(Box::new(ProviderMeta::Anthropic {
+                            signature: "sig_1".to_string(),
+                        })),
+                    },
+                    AssistantBlock::Reasoning {
+                        text: "unsigned plan".to_string(),
+                        meta: None,
+                    },
+                    AssistantBlock::ServerToolContent {
+                        id: Some("srv_1".to_string()),
+                        name: "web_search".to_string(),
+                        content: serde_json::json!({
+                            "type": "server_tool_use",
+                            "input": {"query": "m"}
+                        }),
+                        meta: None,
+                    },
+                    AssistantBlock::ServerToolContent {
+                        id: None,
+                        name: "web_search_citations".to_string(),
+                        content: serde_json::json!({
+                            "type": "text_citations",
+                            "citations": []
+                        }),
+                        meta: None,
+                    },
+                    assistant_image_block(),
+                    AssistantBlock::Text {
+                        text: "answer".to_string(),
+                        meta: None,
+                    },
+                    AssistantBlock::ToolUse {
+                        id: "tool_1".to_string(),
+                        name: "lookup".to_string(),
+                        args: tool_args,
+                        meta: None,
+                    },
+                ],
+                StopReason::ToolUse,
+            )),
+            Message::tool_results(vec![ToolResult::with_blocks(
+                "tool_1".to_string(),
+                vec![
+                    ContentBlock::Text {
+                        text: "tool text".to_string(),
+                    },
+                    ContentBlock::Image {
+                        media_type: "image/png".to_string(),
+                        data: ImageData::Inline {
+                            data: "CCCC".to_string(),
+                        },
+                    },
+                ],
+                false,
+            )]),
+        ];
+
+        let projected = client.project_replay_messages(&messages)?;
+
+        let Message::User(user) = &projected[0] else {
+            panic!("expected user message");
+        };
+        assert!(
+            user.content
+                .iter()
+                .any(|block| matches!(block, ContentBlock::Image { .. })),
+            "Anthropic should retain inline user images"
+        );
+        assert!(
+            user.content.iter().any(|block| matches!(
+                block,
+                ContentBlock::Text { text } if text == "[video: video/mp4]"
+            )),
+            "Anthropic should degrade user video to text"
+        );
+        assert!(
+            !user
+                .content
+                .iter()
+                .any(|block| matches!(block, ContentBlock::Video { .. })),
+            "Anthropic projection should not leave video blocks"
+        );
+
+        let Message::BlockAssistant(assistant) = &projected[1] else {
+            panic!("expected assistant message");
+        };
+        assert!(assistant.blocks.iter().any(|block| matches!(
+            block,
+            AssistantBlock::Reasoning {
+                text,
+                meta: Some(meta),
+            } if text == "signed plan"
+                && matches!(meta.as_ref(), ProviderMeta::Anthropic { .. })
+        )));
+        assert!(!assistant.blocks.iter().any(|block| matches!(
+            block,
+            AssistantBlock::Reasoning { text, .. } if text == "unsigned plan"
+        )));
+        assert!(assistant.blocks.iter().any(|block| matches!(
+            block,
+            AssistantBlock::ServerToolContent { content, .. }
+                if content.get("type").and_then(Value::as_str) == Some("server_tool_use")
+        )));
+        assert!(!assistant.blocks.iter().any(|block| matches!(
+            block,
+            AssistantBlock::ServerToolContent { content, .. }
+                if content.get("type").and_then(Value::as_str) == Some("text_citations")
+        )));
+        assert!(
+            !assistant
+                .blocks
+                .iter()
+                .any(|block| matches!(block, AssistantBlock::Image { .. })),
+            "assistant images must be removed from Anthropic replay"
+        );
+
+        let Message::ToolResults { results, .. } = &projected[2] else {
+            panic!("expected tool results");
+        };
+        assert!(
+            results[0].has_images(),
+            "Anthropic should retain inline image tool results"
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn replay_projection_rejects_anthropic_orphan_tool_results() {
+        let client = AnthropicClient::new("test-key".to_string()).expect("client");
+        let err = client
+            .project_replay_messages(&[Message::tool_results(vec![ToolResult::new(
+                "tool_1".to_string(),
+                "orphaned".to_string(),
+                false,
+            )])])
+            .expect_err("orphan tool results must be rejected");
+        assert!(matches!(err, LlmError::InvalidRequest { .. }));
+    }
 
     #[test]
     fn test_anthropic_content_block_parses_thinking_type() {

--- a/meerkat-anthropic/src/client.rs
+++ b/meerkat-anthropic/src/client.rs
@@ -319,13 +319,15 @@ fn project_anthropic_replay_messages(messages: &[Message]) -> Result<Vec<Message
             }
             Message::BlockAssistant(assistant) => {
                 let blocks = project_anthropic_assistant_blocks(&assistant.blocks);
-                (!blocks.is_empty()).then(|| {
-                    Message::BlockAssistant(BlockAssistantMessage {
+                if blocks.is_empty() {
+                    None
+                } else {
+                    Some(Message::BlockAssistant(BlockAssistantMessage {
                         blocks,
                         stop_reason: assistant.stop_reason,
                         created_at: assistant.created_at,
-                    })
-                })
+                    }))
+                }
             }
             Message::ToolResults { .. } => unreachable!("handled above"),
         };

--- a/meerkat-cli/src/main.rs
+++ b/meerkat-cli/src/main.rs
@@ -12256,6 +12256,13 @@ default_model = "gemma"
 
     #[async_trait]
     impl LlmClient for CapturingLlmClient {
+        fn project_replay_messages(
+            &self,
+            messages: &[meerkat_core::Message],
+        ) -> Result<Vec<meerkat_core::Message>, meerkat_client::LlmError> {
+            Ok(messages.to_vec())
+        }
+
         fn stream<'a>(
             &'a self,
             request: &'a LlmRequest,

--- a/meerkat-client/tests/rct_contracts.rs
+++ b/meerkat-client/tests/rct_contracts.rs
@@ -18,6 +18,13 @@ struct MockClient {
 
 #[async_trait]
 impl LlmClient for MockClient {
+    fn project_replay_messages(
+        &self,
+        messages: &[meerkat_core::Message],
+    ) -> Result<Vec<meerkat_core::Message>, meerkat_client::LlmError> {
+        Ok(messages.to_vec())
+    }
+
     fn stream<'a>(
         &'a self,
         _request: &'a LlmRequest,

--- a/meerkat-gemini/src/client.rs
+++ b/meerkat-gemini/src/client.rs
@@ -7,9 +7,9 @@ use futures::StreamExt;
 use meerkat_core::lifecycle::run_primitive::{GeminiProviderTag, ProviderTag};
 use meerkat_core::schema::{CompiledSchema, SchemaCompat, SchemaError, SchemaWarning};
 use meerkat_core::{
-    ContentBlock, GeminiImageMetadata, ImageData, ImageGenerationIntent,
-    ImageOperationTerminalClass, Message, OutputSchema, Provider, ProviderImageMetadata,
-    ProviderTextDisposition, StopReason, Usage,
+    AssistantBlock, BlockAssistantMessage, ContentBlock, GeminiImageMetadata, ImageData,
+    ImageGenerationIntent, ImageOperationTerminalClass, Message, OutputSchema, Provider,
+    ProviderImageMetadata, ProviderTextDisposition, StopReason, ToolResult, Usage, UserMessage,
 };
 use meerkat_llm_core::LlmError;
 use meerkat_llm_core::{
@@ -20,7 +20,7 @@ use meerkat_llm_core::{
 use meerkat_llm_core::{http, streaming};
 use serde::Deserialize;
 use serde_json::{Map, Value, json};
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 
 use crate::image_generation::{GeminiImageOutputOptions, GeminiImageTurnPlan};
 
@@ -57,6 +57,208 @@ fn code_assist_model(model: &str) -> &str {
         "gemini-3.1-flash-lite" | "gemini-3.1-flash-lite-preview" => "gemini-2.5-flash",
         other => other,
     }
+}
+
+fn invalid_replay(message: impl Into<String>) -> LlmError {
+    LlmError::InvalidRequest {
+        message: message.into(),
+    }
+}
+
+fn project_gemini_content_blocks(blocks: &[ContentBlock]) -> Vec<ContentBlock> {
+    blocks
+        .iter()
+        .map(|block| match block {
+            ContentBlock::Text { .. } => block.clone(),
+            ContentBlock::Image {
+                data: ImageData::Inline { .. },
+                ..
+            } => block.clone(),
+            ContentBlock::Video { .. } => block.clone(),
+            ContentBlock::Image { .. } => ContentBlock::Text {
+                text: block.text_projection().into_owned(),
+            },
+            _ => ContentBlock::Text {
+                text: block.text_projection().into_owned(),
+            },
+        })
+        .collect()
+}
+
+fn project_gemini_tool_result(result: &ToolResult) -> Result<ToolResult, LlmError> {
+    if result.has_video() {
+        return Err(invalid_replay(
+            "video blocks are not supported in Gemini tool results",
+        ));
+    }
+    Ok(ToolResult::with_blocks(
+        result.tool_use_id.clone(),
+        project_gemini_content_blocks(&result.content),
+        result.is_error,
+    ))
+}
+
+fn project_gemini_assistant_blocks(blocks: &[AssistantBlock]) -> Vec<AssistantBlock> {
+    blocks
+        .iter()
+        .filter_map(|block| match block {
+            AssistantBlock::Text { text, .. } if text.is_empty() => None,
+            AssistantBlock::Text { .. } | AssistantBlock::ToolUse { .. } => Some(block.clone()),
+            AssistantBlock::Reasoning { text, .. } if !text.is_empty() => {
+                Some(AssistantBlock::Text {
+                    text: format!("[Reasoning: {text}]"),
+                    meta: None,
+                })
+            }
+            AssistantBlock::Reasoning { .. }
+            | AssistantBlock::ServerToolContent { .. }
+            | AssistantBlock::Image { .. } => None,
+            _ => None,
+        })
+        .collect()
+}
+
+fn legacy_assistant_to_gemini_blocks(
+    assistant: &meerkat_core::AssistantMessage,
+) -> Result<Vec<AssistantBlock>, LlmError> {
+    let mut blocks = Vec::new();
+    if !assistant.content.is_empty() {
+        blocks.push(AssistantBlock::Text {
+            text: assistant.content.clone(),
+            meta: None,
+        });
+    }
+    for tool_call in &assistant.tool_calls {
+        let args = serde_json::to_string(&tool_call.args)
+            .map_err(|error| invalid_replay(format!("invalid legacy tool args: {error}")))?;
+        let args = serde_json::value::RawValue::from_string(args)
+            .map_err(|error| invalid_replay(format!("invalid legacy tool args: {error}")))?;
+        blocks.push(AssistantBlock::ToolUse {
+            id: tool_call.id.clone(),
+            name: tool_call.name.clone(),
+            args,
+            meta: None,
+        });
+    }
+    Ok(blocks)
+}
+
+fn tool_ids_from_assistant(message: &Message) -> HashSet<String> {
+    match message {
+        Message::Assistant(assistant) => assistant
+            .tool_calls
+            .iter()
+            .map(|tool_call| tool_call.id.clone())
+            .collect(),
+        Message::BlockAssistant(assistant) => assistant
+            .blocks
+            .iter()
+            .filter_map(|block| match block {
+                AssistantBlock::ToolUse { id, .. } => Some(id.clone()),
+                _ => None,
+            })
+            .collect(),
+        _ => HashSet::new(),
+    }
+}
+
+fn validate_tool_results(
+    provider: &str,
+    pending: HashSet<String>,
+    results: &[ToolResult],
+) -> Result<(), LlmError> {
+    let actual: HashSet<String> = results
+        .iter()
+        .map(|result| result.tool_use_id.clone())
+        .collect();
+    if actual == pending {
+        Ok(())
+    } else {
+        Err(invalid_replay(format!(
+            "{provider} replay projection found tool results that are not adjacent to matching tool uses"
+        )))
+    }
+}
+
+fn project_gemini_replay_messages(messages: &[Message]) -> Result<Vec<Message>, LlmError> {
+    let mut projected = Vec::with_capacity(messages.len());
+    let mut pending_tool_ids: Option<HashSet<String>> = None;
+
+    for message in messages {
+        if let Message::ToolResults {
+            results,
+            created_at,
+        } = message
+        {
+            let Some(pending) = pending_tool_ids.take() else {
+                return Err(invalid_replay(
+                    "Gemini replay projection found tool results without preceding tool use",
+                ));
+            };
+            validate_tool_results("Gemini", pending, results)?;
+            let results = results
+                .iter()
+                .map(project_gemini_tool_result)
+                .collect::<Result<Vec<_>, _>>()?;
+            projected.push(Message::ToolResults {
+                results,
+                created_at: *created_at,
+            });
+            continue;
+        }
+
+        if pending_tool_ids.is_some() {
+            return Err(invalid_replay(
+                "Gemini replay projection found a tool use without adjacent tool results",
+            ));
+        }
+
+        let next_message = match message {
+            Message::System(_) | Message::SystemNotice(_) => Some(message.clone()),
+            Message::User(user) => Some(Message::User(UserMessage {
+                content: project_gemini_content_blocks(&user.content),
+                render_metadata: user.render_metadata.clone(),
+                created_at: user.created_at,
+            })),
+            Message::Assistant(assistant) => {
+                let blocks = legacy_assistant_to_gemini_blocks(assistant)?;
+                (!blocks.is_empty()).then(|| {
+                    Message::BlockAssistant(BlockAssistantMessage {
+                        blocks,
+                        stop_reason: assistant.stop_reason,
+                        created_at: assistant.created_at,
+                    })
+                })
+            }
+            Message::BlockAssistant(assistant) => {
+                let blocks = project_gemini_assistant_blocks(&assistant.blocks);
+                (!blocks.is_empty()).then(|| {
+                    Message::BlockAssistant(BlockAssistantMessage {
+                        blocks,
+                        stop_reason: assistant.stop_reason,
+                        created_at: assistant.created_at,
+                    })
+                })
+            }
+            Message::ToolResults { .. } => unreachable!("handled above"),
+        };
+
+        if let Some(message) = next_message {
+            let tool_ids = tool_ids_from_assistant(&message);
+            if !tool_ids.is_empty() {
+                pending_tool_ids = Some(tool_ids);
+            }
+            projected.push(message);
+        }
+    }
+
+    if pending_tool_ids.is_some() {
+        return Err(invalid_replay(
+            "Gemini replay projection found a trailing tool use without tool results",
+        ));
+    }
+
+    Ok(projected)
 }
 
 impl GeminiClient {
@@ -1265,8 +1467,15 @@ fn join_index(prefix: &str, index: usize) -> String {
 #[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
 #[cfg_attr(not(target_arch = "wasm32"), async_trait)]
 impl LlmClient for GeminiClient {
+    fn project_replay_messages(&self, messages: &[Message]) -> Result<Vec<Message>, LlmError> {
+        project_gemini_replay_messages(messages)
+    }
+
     fn stream<'a>(&'a self, request: &'a LlmRequest) -> LlmStream<'a> {
         let inner: LlmStream<'a> = Box::pin(async_stream::try_stream! {
+            let mut projected_request = request.clone();
+            projected_request.messages = self.project_replay_messages(&request.messages)?;
+            let request = &projected_request;
             let body = self.build_stream_request_body(request)?;
             let url = self.stream_generate_content_url(&request.model);
 
@@ -1499,11 +1708,28 @@ mod tests {
     use axum::{Json, Router, extract::State, response::IntoResponse, routing::post};
     use meerkat_core::lifecycle::run_primitive::GeminiThinkingLevel;
     use meerkat_core::{
-        AssistantBlock, BlockAssistantMessage, ContentBlock, ProviderMeta, UserMessage,
+        AssistantBlock, AssistantImageId, BlobId, BlobRef, BlockAssistantMessage, ContentBlock,
+        ImageData, MediaType, ProviderImageMetadata, ProviderMeta, RevisedPromptDisposition,
+        ToolResult, UserMessage, VideoData,
     };
     use meerkat_llm_core::ImageGenerationExecutor;
     use std::sync::{Arc, Mutex};
     use tokio::net::TcpListener;
+
+    fn assistant_image_block() -> AssistantBlock {
+        AssistantBlock::Image {
+            image_id: AssistantImageId::new(meerkat_core::time_compat::new_uuid_v7()),
+            blob_ref: BlobRef {
+                blob_id: BlobId::from("gemini-image"),
+                media_type: "image/png".to_string(),
+            },
+            media_type: MediaType::new("image/png"),
+            width: 128,
+            height: 128,
+            revised_prompt: RevisedPromptDisposition::NotRequested,
+            meta: ProviderImageMetadata::NotEmitted,
+        }
+    }
 
     #[derive(Clone)]
     struct GeminiImageStubState {
@@ -1531,6 +1757,143 @@ mod tests {
     ) -> impl IntoResponse {
         state.seen.lock().expect("seen mutex").push(body);
         ([("content-type", "text/event-stream")], state.payload)
+    }
+
+    #[test]
+    fn replay_projection_policy_handles_gemini_history_blocks()
+    -> Result<(), Box<dyn std::error::Error>> {
+        let client = GeminiClient::new("test-key".to_string());
+        let tool_args = serde_json::value::RawValue::from_string(r#"{"query":"m"}"#.to_string())?;
+        let messages = vec![
+            Message::User(UserMessage::with_blocks(vec![
+                ContentBlock::Text {
+                    text: "look at this".to_string(),
+                },
+                ContentBlock::Image {
+                    media_type: "image/png".to_string(),
+                    data: ImageData::Inline {
+                        data: "AAAA".to_string(),
+                    },
+                },
+                ContentBlock::Video {
+                    media_type: "video/mp4".to_string(),
+                    duration_ms: 1_000,
+                    data: VideoData::Inline {
+                        data: "BBBB".to_string(),
+                    },
+                },
+            ])),
+            Message::BlockAssistant(BlockAssistantMessage::new(
+                vec![
+                    AssistantBlock::Reasoning {
+                        text: "model thought".to_string(),
+                        meta: None,
+                    },
+                    AssistantBlock::ServerToolContent {
+                        id: None,
+                        name: "google_search".to_string(),
+                        content: serde_json::json!({
+                            "groundingChunks": []
+                        }),
+                        meta: None,
+                    },
+                    assistant_image_block(),
+                    AssistantBlock::Text {
+                        text: "answer".to_string(),
+                        meta: None,
+                    },
+                    AssistantBlock::ToolUse {
+                        id: "tool_1".to_string(),
+                        name: "lookup".to_string(),
+                        args: tool_args,
+                        meta: Some(Box::new(ProviderMeta::Gemini {
+                            thought_signature: "sig_1".to_string(),
+                        })),
+                    },
+                ],
+                StopReason::ToolUse,
+            )),
+            Message::tool_results(vec![ToolResult::with_blocks(
+                "tool_1".to_string(),
+                vec![
+                    ContentBlock::Text {
+                        text: "tool text".to_string(),
+                    },
+                    ContentBlock::Image {
+                        media_type: "image/png".to_string(),
+                        data: ImageData::Inline {
+                            data: "CCCC".to_string(),
+                        },
+                    },
+                ],
+                false,
+            )]),
+        ];
+
+        let projected = client.project_replay_messages(&messages)?;
+
+        let Message::User(user) = &projected[0] else {
+            panic!("expected user message");
+        };
+        assert!(
+            user.content
+                .iter()
+                .any(|block| matches!(block, ContentBlock::Image { .. })),
+            "Gemini should retain inline user images"
+        );
+        assert!(
+            user.content
+                .iter()
+                .any(|block| matches!(block, ContentBlock::Video { .. })),
+            "Gemini should retain inline user video"
+        );
+
+        let Message::BlockAssistant(assistant) = &projected[1] else {
+            panic!("expected assistant message");
+        };
+        assert!(
+            assistant.blocks.iter().any(|block| matches!(
+                block,
+                AssistantBlock::Text { text, .. } if text == "[Reasoning: model thought]"
+            )),
+            "Gemini should project reasoning into text context"
+        );
+        assert!(
+            !assistant
+                .blocks
+                .iter()
+                .any(|block| matches!(block, AssistantBlock::ServerToolContent { .. })),
+            "Gemini should drop server grounding metadata from replay"
+        );
+        assert!(
+            !assistant
+                .blocks
+                .iter()
+                .any(|block| matches!(block, AssistantBlock::Image { .. })),
+            "assistant images must be removed from Gemini replay"
+        );
+
+        let Message::ToolResults { results, .. } = &projected[2] else {
+            panic!("expected tool results");
+        };
+        assert!(
+            results[0].has_images(),
+            "Gemini should retain inline image tool results"
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn replay_projection_rejects_gemini_orphan_tool_results() {
+        let client = GeminiClient::new("test-key".to_string());
+        let err = client
+            .project_replay_messages(&[Message::tool_results(vec![ToolResult::new(
+                "tool_1".to_string(),
+                "orphaned".to_string(),
+                false,
+            )])])
+            .expect_err("orphan tool results must be rejected");
+        assert!(matches!(err, LlmError::InvalidRequest { .. }));
     }
 
     async fn spawn_gemini_image_stub(

--- a/meerkat-gemini/src/client.rs
+++ b/meerkat-gemini/src/client.rs
@@ -222,23 +222,27 @@ fn project_gemini_replay_messages(messages: &[Message]) -> Result<Vec<Message>, 
             })),
             Message::Assistant(assistant) => {
                 let blocks = legacy_assistant_to_gemini_blocks(assistant)?;
-                (!blocks.is_empty()).then(|| {
-                    Message::BlockAssistant(BlockAssistantMessage {
+                if blocks.is_empty() {
+                    None
+                } else {
+                    Some(Message::BlockAssistant(BlockAssistantMessage {
                         blocks,
                         stop_reason: assistant.stop_reason,
                         created_at: assistant.created_at,
-                    })
-                })
+                    }))
+                }
             }
             Message::BlockAssistant(assistant) => {
                 let blocks = project_gemini_assistant_blocks(&assistant.blocks);
-                (!blocks.is_empty()).then(|| {
-                    Message::BlockAssistant(BlockAssistantMessage {
+                if blocks.is_empty() {
+                    None
+                } else {
+                    Some(Message::BlockAssistant(BlockAssistantMessage {
                         blocks,
                         stop_reason: assistant.stop_reason,
                         created_at: assistant.created_at,
-                    })
-                })
+                    }))
+                }
             }
             Message::ToolResults { .. } => unreachable!("handled above"),
         };

--- a/meerkat-llm-core/src/adapter.rs
+++ b/meerkat-llm-core/src/adapter.rs
@@ -187,9 +187,20 @@ impl AgentLlmClient for LlmClientAdapter {
             .and_then(|params| params.temperature)
             .or(temperature);
 
+        let projected_messages =
+            self.client
+                .project_replay_messages(messages)
+                .map_err(|error| {
+                    AgentError::llm(
+                        self.client.provider(),
+                        error.failure_reason(),
+                        error.to_string(),
+                    )
+                })?;
+
         let request = LlmRequest {
             model: self.model.clone(),
-            messages: messages.to_vec(),
+            messages: projected_messages,
             tools: tools.to_vec(),
             max_tokens: effective_max_tokens,
             temperature: effective_temperature,
@@ -361,5 +372,100 @@ impl AgentLlmClient for LlmClientAdapter {
 
     fn compile_schema(&self, output_schema: &OutputSchema) -> Result<CompiledSchema, SchemaError> {
         self.client.compile_schema(output_schema)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{LlmError, LlmStream};
+    use futures::stream;
+    use meerkat_core::{
+        AssistantBlock, AssistantImageId, BlobId, BlobRef, MediaType, ProviderImageMetadata,
+        RevisedPromptDisposition, UserMessage,
+    };
+    use std::sync::Mutex;
+
+    struct ProjectionClient {
+        seen: Arc<Mutex<Option<Vec<Message>>>>,
+    }
+
+    #[cfg_attr(target_arch = "wasm32", async_trait::async_trait(?Send))]
+    #[cfg_attr(not(target_arch = "wasm32"), async_trait::async_trait)]
+    impl LlmClient for ProjectionClient {
+        fn project_replay_messages(&self, messages: &[Message]) -> Result<Vec<Message>, LlmError> {
+            Ok(messages
+                .iter()
+                .filter(|message| {
+                    !matches!(
+                        message,
+                        Message::BlockAssistant(assistant)
+                            if assistant
+                                .blocks
+                                .iter()
+                                .any(|block| matches!(block, AssistantBlock::Image { .. }))
+                    )
+                })
+                .cloned()
+                .collect())
+        }
+
+        fn stream<'a>(&'a self, request: &'a LlmRequest) -> LlmStream<'a> {
+            *self.seen.lock().expect("seen lock") = Some(request.messages.clone());
+            Box::pin(stream::iter([Ok(LlmEvent::Done {
+                outcome: LlmDoneOutcome::Success {
+                    stop_reason: StopReason::EndTurn,
+                },
+            })]))
+        }
+
+        fn provider(&self) -> &'static str {
+            "projection-test"
+        }
+
+        async fn health_check(&self) -> Result<(), LlmError> {
+            Ok(())
+        }
+    }
+
+    fn assistant_image_block() -> AssistantBlock {
+        AssistantBlock::Image {
+            image_id: AssistantImageId::new(meerkat_core::time_compat::new_uuid_v7()),
+            blob_ref: BlobRef {
+                blob_id: BlobId::from("blob-1"),
+                media_type: "image/png".to_string(),
+            },
+            media_type: MediaType::new("image/png"),
+            width: 64,
+            height: 64,
+            revised_prompt: RevisedPromptDisposition::NotRequested,
+            meta: ProviderImageMetadata::NotEmitted,
+        }
+    }
+
+    #[tokio::test]
+    async fn adapter_invokes_provider_replay_projection_before_streaming() {
+        let seen = Arc::new(Mutex::new(None));
+        let client = ProjectionClient {
+            seen: Arc::clone(&seen),
+        };
+        let adapter = LlmClientAdapter::new(Arc::new(client), "test-model".to_string());
+
+        let raw_messages = vec![
+            Message::User(UserMessage::text("continue")),
+            Message::BlockAssistant(meerkat_core::BlockAssistantMessage::new(
+                vec![assistant_image_block()],
+                StopReason::EndTurn,
+            )),
+        ];
+
+        adapter
+            .stream_response(&raw_messages, &[], 1024, None, None)
+            .await
+            .expect("stream response");
+
+        let projected = seen.lock().expect("seen lock").clone().expect("request");
+        assert_eq!(projected.len(), 1);
+        assert!(matches!(projected[0], Message::User(_)));
     }
 }

--- a/meerkat-llm-core/src/test_client.rs
+++ b/meerkat-llm-core/src/test_client.rs
@@ -32,6 +32,13 @@ impl Default for TestClient {
 #[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
 #[cfg_attr(not(target_arch = "wasm32"), async_trait)]
 impl LlmClient for TestClient {
+    fn project_replay_messages(
+        &self,
+        messages: &[meerkat_core::Message],
+    ) -> Result<Vec<meerkat_core::Message>, LlmError> {
+        Ok(messages.to_vec())
+    }
+
     fn stream<'a>(&'a self, _request: &'a LlmRequest) -> LlmStream<'a> {
         let events = self.events.clone();
         crate::streaming::ensure_terminal_done(Box::pin(futures::stream::iter(

--- a/meerkat-llm-core/src/types.rs
+++ b/meerkat-llm-core/src/types.rs
@@ -33,6 +33,22 @@ pub type LlmStream<'a> = Pin<Box<dyn Stream<Item = Result<LlmEvent, LlmError>> +
 #[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
 #[cfg_attr(not(target_arch = "wasm32"), async_trait)]
 pub trait LlmClient: Send + Sync {
+    /// Project canonical Meerkat transcript history into the provider-safe
+    /// replay history for this client.
+    ///
+    /// Core owns canonical messages; provider clients own the policy for which
+    /// blocks can be replayed, transformed, or rejected for their wire API.
+    /// The default fails closed so raw canonical history is never implicitly
+    /// treated as provider-safe.
+    fn project_replay_messages(&self, _messages: &[Message]) -> Result<Vec<Message>, LlmError> {
+        Err(LlmError::InvalidRequest {
+            message: format!(
+                "{} client does not implement provider replay projection",
+                self.provider()
+            ),
+        })
+    }
+
     /// Stream a completion request
     ///
     /// Returns a stream of normalized events. The stream completes

--- a/meerkat-mcp-server/src/lib.rs
+++ b/meerkat-mcp-server/src/lib.rs
@@ -4000,6 +4000,13 @@ mod tests {
 
     #[async_trait]
     impl LlmClient for MockLlmClient {
+        fn project_replay_messages(
+            &self,
+            messages: &[meerkat_core::Message],
+        ) -> Result<Vec<meerkat_core::Message>, meerkat_client::LlmError> {
+            Ok(messages.to_vec())
+        }
+
         fn stream<'a>(
             &'a self,
             _request: &'a LlmRequest,

--- a/meerkat-openai/src/client.rs
+++ b/meerkat-openai/src/client.rs
@@ -10,9 +10,10 @@ use meerkat_core::lifecycle::run_primitive::{
 };
 use meerkat_core::schema::{CompiledSchema, SchemaError};
 use meerkat_core::{
-    AssistantBlock, ContentBlock, ImageData, ImageGenerationIntent, ImageGenerationWarning,
-    ImageOperationTerminalClass, Message, OpenAiImageMetadata, OutputSchema, ProviderImageMetadata,
-    ProviderMeta, RevisedPromptDisposition, RevisedPromptSource, StopReason, Usage,
+    AssistantBlock, BlockAssistantMessage, ContentBlock, ImageData, ImageGenerationIntent,
+    ImageGenerationWarning, ImageOperationTerminalClass, Message, OpenAiImageMetadata,
+    OutputSchema, ProviderImageMetadata, ProviderMeta, RevisedPromptDisposition,
+    RevisedPromptSource, StopReason, ToolResult, Usage, UserMessage,
 };
 use meerkat_llm_core::BlockAssembler;
 use meerkat_llm_core::LlmError;
@@ -64,6 +65,203 @@ pub struct OpenAiClient {
 enum SystemMessageMode {
     IncludeInInput,
     ExtractToInstructions,
+}
+
+#[derive(Clone, Copy)]
+pub(crate) enum OpenAiReplayProjectionMode {
+    Responses,
+    ChatCompletions,
+}
+
+fn invalid_replay(message: impl Into<String>) -> LlmError {
+    LlmError::InvalidRequest {
+        message: message.into(),
+    }
+}
+
+fn project_openai_content_blocks(blocks: &[ContentBlock]) -> Vec<ContentBlock> {
+    blocks
+        .iter()
+        .map(|block| match block {
+            ContentBlock::Text { .. } => block.clone(),
+            ContentBlock::Image {
+                data: ImageData::Inline { .. },
+                ..
+            } => block.clone(),
+            ContentBlock::Image { .. } | ContentBlock::Video { .. } => ContentBlock::Text {
+                text: block.text_projection().into_owned(),
+            },
+            _ => ContentBlock::Text {
+                text: block.text_projection().into_owned(),
+            },
+        })
+        .collect()
+}
+
+fn project_openai_tool_result(result: &ToolResult) -> Result<ToolResult, LlmError> {
+    if result.has_video() {
+        return Err(invalid_replay(
+            "video blocks are not supported in OpenAI tool results",
+        ));
+    }
+    Ok(ToolResult::new(
+        result.tool_use_id.clone(),
+        result.text_content(),
+        result.is_error,
+    ))
+}
+
+fn openai_server_tool_content_replayable(
+    mode: OpenAiReplayProjectionMode,
+    content: &Value,
+) -> bool {
+    match mode {
+        OpenAiReplayProjectionMode::Responses => matches!(
+            content.get("type").and_then(Value::as_str),
+            Some("web_search_call" | "web_search_result")
+        ),
+        OpenAiReplayProjectionMode::ChatCompletions => false,
+    }
+}
+
+fn project_openai_assistant_blocks(
+    mode: OpenAiReplayProjectionMode,
+    blocks: &[AssistantBlock],
+) -> Vec<AssistantBlock> {
+    blocks
+        .iter()
+        .filter_map(|block| match block {
+            AssistantBlock::Text { text, .. } if text.is_empty() => None,
+            AssistantBlock::Text { .. } | AssistantBlock::ToolUse { .. } => Some(block.clone()),
+            AssistantBlock::ServerToolContent { content, .. }
+                if openai_server_tool_content_replayable(mode, content) =>
+            {
+                Some(block.clone())
+            }
+            AssistantBlock::Reasoning { .. }
+            | AssistantBlock::ServerToolContent { .. }
+            | AssistantBlock::Image { .. } => None,
+            _ => None,
+        })
+        .collect()
+}
+
+fn tool_ids_from_assistant(message: &Message) -> HashSet<String> {
+    match message {
+        Message::Assistant(assistant) => assistant
+            .tool_calls
+            .iter()
+            .map(|tool_call| tool_call.id.clone())
+            .collect(),
+        Message::BlockAssistant(assistant) => assistant
+            .blocks
+            .iter()
+            .filter_map(|block| match block {
+                AssistantBlock::ToolUse { id, .. } => Some(id.clone()),
+                _ => None,
+            })
+            .collect(),
+        _ => HashSet::new(),
+    }
+}
+
+fn validate_tool_results(
+    provider: &str,
+    pending: HashSet<String>,
+    results: &[ToolResult],
+) -> Result<(), LlmError> {
+    let actual: HashSet<String> = results
+        .iter()
+        .map(|result| result.tool_use_id.clone())
+        .collect();
+    if actual == pending {
+        Ok(())
+    } else {
+        Err(invalid_replay(format!(
+            "{provider} replay projection found tool results that are not adjacent to matching tool uses"
+        )))
+    }
+}
+
+pub(crate) fn project_openai_replay_messages(
+    messages: &[Message],
+    mode: OpenAiReplayProjectionMode,
+) -> Result<Vec<Message>, LlmError> {
+    let mut projected = Vec::with_capacity(messages.len());
+    let mut pending_tool_ids: Option<HashSet<String>> = None;
+
+    for message in messages {
+        if let Message::ToolResults {
+            results,
+            created_at,
+        } = message
+        {
+            let Some(pending) = pending_tool_ids.take() else {
+                return Err(invalid_replay(
+                    "OpenAI replay projection found tool results without preceding tool use",
+                ));
+            };
+            validate_tool_results("OpenAI", pending, results)?;
+            let results = results
+                .iter()
+                .map(project_openai_tool_result)
+                .collect::<Result<Vec<_>, _>>()?;
+            projected.push(Message::ToolResults {
+                results,
+                created_at: *created_at,
+            });
+            continue;
+        }
+
+        if pending_tool_ids.is_some() {
+            return Err(invalid_replay(
+                "OpenAI replay projection found a tool use without adjacent tool results",
+            ));
+        }
+
+        let next_message = match message {
+            Message::System(_) | Message::SystemNotice(_) => Some(message.clone()),
+            Message::User(user) => Some(Message::User(UserMessage {
+                content: project_openai_content_blocks(&user.content),
+                render_metadata: user.render_metadata.clone(),
+                created_at: user.created_at,
+            })),
+            Message::Assistant(assistant) => {
+                if assistant.content.is_empty() && assistant.tool_calls.is_empty() {
+                    None
+                } else {
+                    Some(Message::Assistant(assistant.clone()))
+                }
+            }
+            Message::BlockAssistant(assistant) => {
+                let blocks = project_openai_assistant_blocks(mode, &assistant.blocks);
+                (!blocks.is_empty()).then(|| {
+                    Message::BlockAssistant(BlockAssistantMessage {
+                        blocks,
+                        stop_reason: assistant.stop_reason,
+                        created_at: assistant.created_at,
+                    })
+                })
+            }
+            Message::ToolResults { .. } => unreachable!("handled above"),
+        };
+
+        if let Some(message) = next_message {
+            let tool_ids = tool_ids_from_assistant(&message);
+            if !tool_ids.is_empty() {
+                pending_tool_ids = Some(tool_ids);
+            }
+            projected.push(message);
+        }
+    }
+
+    if pending_tool_ids.is_some() {
+        return Err(invalid_replay(
+            "OpenAI replay projection found a trailing tool use without tool results",
+        ));
+    }
+
+    Ok(projected)
 }
 
 impl OpenAiClient {
@@ -909,8 +1107,15 @@ fn ensure_additional_properties_false(value: &mut Value) {
 #[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
 #[cfg_attr(not(target_arch = "wasm32"), async_trait)]
 impl LlmClient for OpenAiClient {
+    fn project_replay_messages(&self, messages: &[Message]) -> Result<Vec<Message>, LlmError> {
+        project_openai_replay_messages(messages, OpenAiReplayProjectionMode::Responses)
+    }
+
     fn stream<'a>(&'a self, request: &'a LlmRequest) -> LlmStream<'a> {
         let inner: LlmStream<'a> = Box::pin(async_stream::try_stream! {
+            let mut projected_request = request.clone();
+            projected_request.messages = self.project_replay_messages(&request.messages)?;
+            let request = &projected_request;
             let body = self.build_request_body(request)?;
 
             let endpoint = self.responses_endpoint();
@@ -1470,13 +1675,200 @@ fn parse_tool_call_arguments(
 mod tests {
     use super::*;
     use axum::{Json, Router, extract::State, response::IntoResponse, routing::post};
-    use meerkat_core::UserMessage;
+    use meerkat_core::{
+        AssistantImageId, BlobId, BlobRef, BlockAssistantMessage, MediaType, ProviderImageMetadata,
+        RevisedPromptDisposition, ToolResult, UserMessage, VideoData,
+    };
     use meerkat_llm_core::ImageGenerationExecutor;
     use std::sync::{Arc, Mutex};
     use tokio::net::TcpListener;
 
+    fn assistant_image_block() -> AssistantBlock {
+        AssistantBlock::Image {
+            image_id: AssistantImageId::new(meerkat_core::time_compat::new_uuid_v7()),
+            blob_ref: BlobRef {
+                blob_id: BlobId::from("openai-image"),
+                media_type: "image/png".to_string(),
+            },
+            media_type: MediaType::new("image/png"),
+            width: 128,
+            height: 128,
+            revised_prompt: RevisedPromptDisposition::NotRequested,
+            meta: ProviderImageMetadata::NotEmitted,
+        }
+    }
+
     async fn responses_sse(State(payload): State<String>) -> impl IntoResponse {
         ([("content-type", "text/event-stream")], payload)
+    }
+
+    #[test]
+    fn replay_projection_policy_handles_openai_history_blocks()
+    -> Result<(), Box<dyn std::error::Error>> {
+        let client = OpenAiClient::new("test-key".to_string());
+        let tool_args = RawValue::from_string(r#"{"query":"m"}"#.to_string())?;
+        let messages = vec![
+            Message::User(UserMessage::with_blocks(vec![
+                ContentBlock::Text {
+                    text: "look at this".to_string(),
+                },
+                ContentBlock::Image {
+                    media_type: "image/png".to_string(),
+                    data: ImageData::Inline {
+                        data: "AAAA".to_string(),
+                    },
+                },
+                ContentBlock::Video {
+                    media_type: "video/mp4".to_string(),
+                    duration_ms: 1_000,
+                    data: VideoData::Inline {
+                        data: "BBBB".to_string(),
+                    },
+                },
+            ])),
+            Message::BlockAssistant(BlockAssistantMessage::new(
+                vec![
+                    AssistantBlock::Reasoning {
+                        text: "encrypted reasoning".to_string(),
+                        meta: Some(Box::new(ProviderMeta::OpenAi {
+                            id: "rs_1".to_string(),
+                            encrypted_content: Some("ciphertext".to_string()),
+                        })),
+                    },
+                    AssistantBlock::ServerToolContent {
+                        id: Some("ws_status".to_string()),
+                        name: "web_search".to_string(),
+                        content: serde_json::json!({
+                            "type": "response.web_search_call.searching",
+                            "item_id": "ws_status"
+                        }),
+                        meta: None,
+                    },
+                    AssistantBlock::ServerToolContent {
+                        id: Some("ws_1".to_string()),
+                        name: "web_search_call".to_string(),
+                        content: serde_json::json!({
+                            "type": "web_search_call",
+                            "id": "ws_1",
+                            "status": "completed"
+                        }),
+                        meta: None,
+                    },
+                    AssistantBlock::ServerToolContent {
+                        id: None,
+                        name: "web_search_annotations".to_string(),
+                        content: serde_json::json!({
+                            "type": "message_annotations",
+                            "annotations": []
+                        }),
+                        meta: None,
+                    },
+                    assistant_image_block(),
+                    AssistantBlock::Text {
+                        text: "answer".to_string(),
+                        meta: None,
+                    },
+                    AssistantBlock::ToolUse {
+                        id: "tool_1".to_string(),
+                        name: "lookup".to_string(),
+                        args: tool_args,
+                        meta: None,
+                    },
+                ],
+                StopReason::ToolUse,
+            )),
+            Message::tool_results(vec![ToolResult::with_blocks(
+                "tool_1".to_string(),
+                vec![
+                    ContentBlock::Text {
+                        text: "tool text".to_string(),
+                    },
+                    ContentBlock::Image {
+                        media_type: "image/png".to_string(),
+                        data: ImageData::Inline {
+                            data: "CCCC".to_string(),
+                        },
+                    },
+                ],
+                false,
+            )]),
+        ];
+
+        let projected = client.project_replay_messages(&messages)?;
+
+        let Message::User(user) = &projected[0] else {
+            panic!("expected user message");
+        };
+        assert!(
+            user.content
+                .iter()
+                .any(|block| matches!(block, ContentBlock::Image { .. })),
+            "OpenAI should retain inline user images"
+        );
+        assert!(
+            user.content.iter().any(|block| matches!(
+                block,
+                ContentBlock::Text { text } if text == "[video: video/mp4]"
+            )),
+            "OpenAI should degrade user video to text"
+        );
+
+        let Message::BlockAssistant(assistant) = &projected[1] else {
+            panic!("expected assistant message");
+        };
+        assert!(
+            !assistant
+                .blocks
+                .iter()
+                .any(|block| matches!(block, AssistantBlock::Reasoning { .. })),
+            "OpenAI replay projection should drop reasoning blocks"
+        );
+        assert!(assistant.blocks.iter().any(|block| matches!(
+            block,
+            AssistantBlock::ServerToolContent { content, .. }
+                if content.get("type").and_then(Value::as_str) == Some("web_search_call")
+        )));
+        assert!(!assistant.blocks.iter().any(|block| matches!(
+            block,
+            AssistantBlock::ServerToolContent { content, .. }
+                if content.get("type").and_then(Value::as_str)
+                    == Some("response.web_search_call.searching")
+        )));
+        assert!(!assistant.blocks.iter().any(|block| matches!(
+            block,
+            AssistantBlock::ServerToolContent { content, .. }
+                if content.get("type").and_then(Value::as_str) == Some("message_annotations")
+        )));
+        assert!(
+            !assistant
+                .blocks
+                .iter()
+                .any(|block| matches!(block, AssistantBlock::Image { .. })),
+            "assistant images must be removed from OpenAI replay"
+        );
+
+        let Message::ToolResults { results, .. } = &projected[2] else {
+            panic!("expected tool results");
+        };
+        assert!(
+            !results[0].has_images(),
+            "OpenAI tool results should be text-only replay"
+        );
+        assert!(results[0].text_content().contains("[image: image/png]"));
+        Ok(())
+    }
+
+    #[test]
+    fn replay_projection_rejects_openai_orphan_tool_results() {
+        let client = OpenAiClient::new("test-key".to_string());
+        let err = client
+            .project_replay_messages(&[Message::tool_results(vec![ToolResult::new(
+                "tool_1".to_string(),
+                "orphaned".to_string(),
+                false,
+            )])])
+            .expect_err("orphan tool results must be rejected");
+        assert!(matches!(err, LlmError::InvalidRequest { .. }));
     }
 
     #[derive(Clone)]

--- a/meerkat-openai/src/client.rs
+++ b/meerkat-openai/src/client.rs
@@ -235,13 +235,15 @@ pub(crate) fn project_openai_replay_messages(
             }
             Message::BlockAssistant(assistant) => {
                 let blocks = project_openai_assistant_blocks(mode, &assistant.blocks);
-                (!blocks.is_empty()).then(|| {
-                    Message::BlockAssistant(BlockAssistantMessage {
+                if blocks.is_empty() {
+                    None
+                } else {
+                    Some(Message::BlockAssistant(BlockAssistantMessage {
                         blocks,
                         stop_reason: assistant.stop_reason,
                         created_at: assistant.created_at,
-                    })
-                })
+                    }))
+                }
             }
             Message::ToolResults { .. } => unreachable!("handled above"),
         };

--- a/meerkat-openai/src/client_compatible.rs
+++ b/meerkat-openai/src/client_compatible.rs
@@ -15,6 +15,8 @@ use serde::Deserialize;
 use serde_json::Value;
 use std::collections::HashMap;
 
+use crate::client::{OpenAiReplayProjectionMode, project_openai_replay_messages};
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum OpenAiCompatibleMode {
     Responses,
@@ -382,6 +384,14 @@ fn ensure_additional_properties_false(value: &mut Value) {
 #[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
 #[cfg_attr(not(target_arch = "wasm32"), async_trait)]
 impl LlmClient for OpenAiCompatibleClient {
+    fn project_replay_messages(&self, messages: &[Message]) -> Result<Vec<Message>, LlmError> {
+        let mode = match self.mode {
+            OpenAiCompatibleMode::Responses => OpenAiReplayProjectionMode::Responses,
+            OpenAiCompatibleMode::ChatCompletions => OpenAiReplayProjectionMode::ChatCompletions,
+        };
+        project_openai_replay_messages(messages, mode)
+    }
+
     fn stream<'a>(&'a self, request: &'a LlmRequest) -> LlmStream<'a> {
         match self.mode {
             OpenAiCompatibleMode::Responses => {
@@ -395,7 +405,8 @@ impl LlmClient for OpenAiCompatibleClient {
                     return inner;
                 };
                 let inner: LlmStream<'a> = Box::pin(async_stream::try_stream! {
-                    let translated = self.request_with_remote_model(request);
+                    let mut translated = self.request_with_remote_model(request);
+                    translated.messages = self.project_replay_messages(&request.messages)?;
                     let mut stream = delegate.stream(&translated);
                     while let Some(event) = stream.next().await {
                         yield event?;
@@ -405,7 +416,9 @@ impl LlmClient for OpenAiCompatibleClient {
             }
             OpenAiCompatibleMode::ChatCompletions => {
                 let inner: LlmStream<'a> = Box::pin(async_stream::try_stream! {
-                    let body = self.build_chat_completions_body(request)?;
+                    let mut projected_request = request.clone();
+                    projected_request.messages = self.project_replay_messages(&request.messages)?;
+                    let body = self.build_chat_completions_body(&projected_request)?;
                     let response = self
                         .apply_auth(
                             self.http.post(format!("{}/chat/completions", self.base_url)),

--- a/meerkat-openai/src/text_adapter.rs
+++ b/meerkat-openai/src/text_adapter.rs
@@ -188,13 +188,15 @@ fn project_realtime_replay_messages(messages: &[Message]) -> Result<Vec<Message>
             }
             Message::BlockAssistant(assistant) => {
                 let blocks = project_realtime_assistant_blocks(&assistant.blocks);
-                (!blocks.is_empty()).then(|| {
-                    Message::BlockAssistant(BlockAssistantMessage {
+                if blocks.is_empty() {
+                    None
+                } else {
+                    Some(Message::BlockAssistant(BlockAssistantMessage {
                         blocks,
                         stop_reason: assistant.stop_reason,
                         created_at: assistant.created_at,
-                    })
-                })
+                    }))
+                }
             }
             Message::ToolResults { .. } => unreachable!("handled above"),
         };

--- a/meerkat-openai/src/text_adapter.rs
+++ b/meerkat-openai/src/text_adapter.rs
@@ -27,7 +27,8 @@ use async_stream::try_stream;
 use async_trait::async_trait;
 use meerkat_core::schema::{CompiledSchema, SchemaError};
 use meerkat_core::{
-    AssistantBlock, ContentBlock, ImageData, Message, OutputSchema, StopReason, Usage,
+    AssistantBlock, BlockAssistantMessage, ContentBlock, ImageData, Message, OutputSchema,
+    StopReason, ToolResult, Usage, UserMessage,
 };
 use meerkat_llm_core::{LlmClient, LlmDoneOutcome, LlmError, LlmEvent, LlmRequest, LlmStream};
 
@@ -36,6 +37,7 @@ use oai_rt_rs::protocol::models::{
     SessionUpdate, SessionUpdateConfig, Temperature, Tool, Usage as OaiUsage,
 };
 use oai_rt_rs::{ClientEvent, RealtimeClient, ServerEvent};
+use std::collections::HashSet;
 
 /// OpenAI's Realtime API caps `response.max_output_tokens` at 4096 for
 /// integer values; larger values fail with `integer above maximum value`.
@@ -59,6 +61,162 @@ pub struct OpenAiRealtimeTextAdapter {
     api_key: String,
 }
 
+fn invalid_replay(message: impl Into<String>) -> LlmError {
+    LlmError::InvalidRequest {
+        message: message.into(),
+    }
+}
+
+fn project_realtime_content_blocks(blocks: &[ContentBlock]) -> Vec<ContentBlock> {
+    blocks
+        .iter()
+        .map(|block| match block {
+            ContentBlock::Text { .. } => block.clone(),
+            _ => ContentBlock::Text {
+                text: block.text_projection().into_owned(),
+            },
+        })
+        .collect()
+}
+
+fn project_realtime_tool_result(result: &ToolResult) -> Result<ToolResult, LlmError> {
+    if result.has_video() {
+        return Err(invalid_replay(
+            "video blocks are not supported in OpenAI realtime tool results",
+        ));
+    }
+    Ok(ToolResult::new(
+        result.tool_use_id.clone(),
+        result.text_content(),
+        result.is_error,
+    ))
+}
+
+fn project_realtime_assistant_blocks(blocks: &[AssistantBlock]) -> Vec<AssistantBlock> {
+    blocks
+        .iter()
+        .filter_map(|block| match block {
+            AssistantBlock::Text { text, .. } if text.is_empty() => None,
+            AssistantBlock::Text { .. } | AssistantBlock::ToolUse { .. } => Some(block.clone()),
+            AssistantBlock::Reasoning { .. }
+            | AssistantBlock::ServerToolContent { .. }
+            | AssistantBlock::Image { .. } => None,
+            _ => None,
+        })
+        .collect()
+}
+
+fn tool_ids_from_assistant(message: &Message) -> HashSet<String> {
+    match message {
+        Message::Assistant(assistant) => assistant
+            .tool_calls
+            .iter()
+            .map(|tool_call| tool_call.id.clone())
+            .collect(),
+        Message::BlockAssistant(assistant) => assistant
+            .blocks
+            .iter()
+            .filter_map(|block| match block {
+                AssistantBlock::ToolUse { id, .. } => Some(id.clone()),
+                _ => None,
+            })
+            .collect(),
+        _ => HashSet::new(),
+    }
+}
+
+fn validate_tool_results(pending: HashSet<String>, results: &[ToolResult]) -> Result<(), LlmError> {
+    let actual: HashSet<String> = results
+        .iter()
+        .map(|result| result.tool_use_id.clone())
+        .collect();
+    if actual == pending {
+        Ok(())
+    } else {
+        Err(invalid_replay(
+            "OpenAI realtime replay projection found tool results that are not adjacent to matching tool uses",
+        ))
+    }
+}
+
+fn project_realtime_replay_messages(messages: &[Message]) -> Result<Vec<Message>, LlmError> {
+    let mut projected = Vec::with_capacity(messages.len());
+    let mut pending_tool_ids: Option<HashSet<String>> = None;
+
+    for message in messages {
+        if let Message::ToolResults {
+            results,
+            created_at,
+        } = message
+        {
+            let Some(pending) = pending_tool_ids.take() else {
+                return Err(invalid_replay(
+                    "OpenAI realtime replay projection found tool results without preceding tool use",
+                ));
+            };
+            validate_tool_results(pending, results)?;
+            let results = results
+                .iter()
+                .map(project_realtime_tool_result)
+                .collect::<Result<Vec<_>, _>>()?;
+            projected.push(Message::ToolResults {
+                results,
+                created_at: *created_at,
+            });
+            continue;
+        }
+
+        if pending_tool_ids.is_some() {
+            return Err(invalid_replay(
+                "OpenAI realtime replay projection found a tool use without adjacent tool results",
+            ));
+        }
+
+        let next_message = match message {
+            Message::System(_) | Message::SystemNotice(_) => Some(message.clone()),
+            Message::User(user) => Some(Message::User(UserMessage {
+                content: project_realtime_content_blocks(&user.content),
+                render_metadata: user.render_metadata.clone(),
+                created_at: user.created_at,
+            })),
+            Message::Assistant(assistant) => {
+                if assistant.content.is_empty() && assistant.tool_calls.is_empty() {
+                    None
+                } else {
+                    Some(Message::Assistant(assistant.clone()))
+                }
+            }
+            Message::BlockAssistant(assistant) => {
+                let blocks = project_realtime_assistant_blocks(&assistant.blocks);
+                (!blocks.is_empty()).then(|| {
+                    Message::BlockAssistant(BlockAssistantMessage {
+                        blocks,
+                        stop_reason: assistant.stop_reason,
+                        created_at: assistant.created_at,
+                    })
+                })
+            }
+            Message::ToolResults { .. } => unreachable!("handled above"),
+        };
+
+        if let Some(message) = next_message {
+            let tool_ids = tool_ids_from_assistant(&message);
+            if !tool_ids.is_empty() {
+                pending_tool_ids = Some(tool_ids);
+            }
+            projected.push(message);
+        }
+    }
+
+    if pending_tool_ids.is_some() {
+        return Err(invalid_replay(
+            "OpenAI realtime replay projection found a trailing tool use without tool results",
+        ));
+    }
+
+    Ok(projected)
+}
+
 impl OpenAiRealtimeTextAdapter {
     /// Create a new adapter bound to the given API key. Callers should
     /// acquire the key through
@@ -73,9 +231,16 @@ impl OpenAiRealtimeTextAdapter {
 
 #[async_trait]
 impl LlmClient for OpenAiRealtimeTextAdapter {
+    fn project_replay_messages(&self, messages: &[Message]) -> Result<Vec<Message>, LlmError> {
+        project_realtime_replay_messages(messages)
+    }
+
     fn stream<'a>(&'a self, request: &'a LlmRequest) -> LlmStream<'a> {
         let api_key = self.api_key.clone();
         Box::pin(try_stream! {
+            let mut projected_request = request.clone();
+            projected_request.messages = self.project_replay_messages(&request.messages)?;
+            let request = &projected_request;
             let (instructions, history_items) = convert_messages(&request.messages)?;
             let tools = build_tools(request);
 
@@ -508,7 +673,11 @@ fn map_server_error(err: oai_rt_rs::error::ServerError) -> LlmError {
 #[allow(clippy::unwrap_used, clippy::expect_used, clippy::panic)]
 mod tests {
     use super::*;
-    use meerkat_core::{AssistantMessage, SystemMessage, ToolCall, ToolResult, UserMessage};
+    use meerkat_core::{
+        AssistantImageId, AssistantMessage, BlobId, BlobRef, BlockAssistantMessage, ImageData,
+        MediaType, ProviderImageMetadata, RevisedPromptDisposition, SystemMessage, ToolCall,
+        ToolResult, UserMessage,
+    };
 
     fn sys(text: &str) -> Message {
         Message::System(SystemMessage::new(text.to_string()))
@@ -526,6 +695,117 @@ mod tests {
             usage: Usage::default(),
             created_at: meerkat_core::types::message_timestamp_now(),
         })
+    }
+
+    fn assistant_image_block() -> AssistantBlock {
+        AssistantBlock::Image {
+            image_id: AssistantImageId::new(meerkat_core::time_compat::new_uuid_v7()),
+            blob_ref: BlobRef {
+                blob_id: BlobId::from("realtime-image"),
+                media_type: "image/png".to_string(),
+            },
+            media_type: MediaType::new("image/png"),
+            width: 64,
+            height: 64,
+            revised_prompt: RevisedPromptDisposition::NotRequested,
+            meta: ProviderImageMetadata::NotEmitted,
+        }
+    }
+
+    #[test]
+    fn replay_projection_policy_handles_realtime_history_blocks()
+    -> Result<(), Box<dyn std::error::Error>> {
+        let tool_args = serde_json::value::RawValue::from_string(r#"{"query":"m"}"#.to_string())?;
+        let messages = vec![
+            Message::User(UserMessage::with_blocks(vec![
+                ContentBlock::Text {
+                    text: "look".to_string(),
+                },
+                ContentBlock::Image {
+                    media_type: "image/png".to_string(),
+                    data: ImageData::Inline {
+                        data: "AAAA".to_string(),
+                    },
+                },
+            ])),
+            Message::BlockAssistant(BlockAssistantMessage::new(
+                vec![
+                    AssistantBlock::Reasoning {
+                        text: "plan".to_string(),
+                        meta: None,
+                    },
+                    AssistantBlock::ServerToolContent {
+                        id: None,
+                        name: "web_search".to_string(),
+                        content: serde_json::json!({"type": "web_search_call"}),
+                        meta: None,
+                    },
+                    assistant_image_block(),
+                    AssistantBlock::Text {
+                        text: "answer".to_string(),
+                        meta: None,
+                    },
+                    AssistantBlock::ToolUse {
+                        id: "tool_1".to_string(),
+                        name: "lookup".to_string(),
+                        args: tool_args,
+                        meta: None,
+                    },
+                ],
+                StopReason::ToolUse,
+            )),
+            Message::tool_results(vec![ToolResult::with_blocks(
+                "tool_1".to_string(),
+                vec![ContentBlock::Image {
+                    media_type: "image/png".to_string(),
+                    data: ImageData::Inline {
+                        data: "BBBB".to_string(),
+                    },
+                }],
+                false,
+            )]),
+        ];
+
+        let projected = project_realtime_replay_messages(&messages)?;
+        let Message::User(user) = &projected[0] else {
+            panic!("expected user");
+        };
+        assert!(
+            user.content
+                .iter()
+                .all(|block| matches!(block, ContentBlock::Text { .. })),
+            "Realtime replay should text-project multimodal user content"
+        );
+
+        let Message::BlockAssistant(assistant) = &projected[1] else {
+            panic!("expected assistant");
+        };
+        assert!(
+            assistant.blocks.iter().all(|block| matches!(
+                block,
+                AssistantBlock::Text { .. } | AssistantBlock::ToolUse { .. }
+            )),
+            "Realtime replay should only keep assistant text and tool-use blocks"
+        );
+
+        let Message::ToolResults { results, .. } = &projected[2] else {
+            panic!("expected tool results");
+        };
+        assert!(!results[0].has_images());
+        assert!(results[0].text_content().contains("[image: image/png]"));
+        Ok(())
+    }
+
+    #[test]
+    fn replay_projection_rejects_realtime_orphan_tool_results() {
+        let err =
+            project_realtime_replay_messages(&[Message::tool_results(vec![ToolResult::new(
+                "tool_1".to_string(),
+                "orphaned".to_string(),
+                false,
+            )])])
+            .expect_err("orphan tool results must be rejected");
+        assert!(matches!(err, LlmError::InvalidRequest { .. }));
     }
 
     #[test]

--- a/meerkat-rest/src/lib.rs
+++ b/meerkat-rest/src/lib.rs
@@ -6447,6 +6447,13 @@ mod tests {
 
     #[async_trait]
     impl LlmClient for MockLlmClient {
+        fn project_replay_messages(
+            &self,
+            messages: &[meerkat_core::Message],
+        ) -> Result<Vec<meerkat_core::Message>, meerkat_client::LlmError> {
+            Ok(messages.to_vec())
+        }
+
         fn stream<'a>(
             &'a self,
             _request: &'a LlmRequest,
@@ -6475,6 +6482,13 @@ mod tests {
 
     #[async_trait]
     impl LlmClient for BlockingMockLlmClient {
+        fn project_replay_messages(
+            &self,
+            messages: &[meerkat_core::Message],
+        ) -> Result<Vec<meerkat_core::Message>, meerkat_client::LlmError> {
+            Ok(messages.to_vec())
+        }
+
         fn stream<'a>(
             &'a self,
             _request: &'a LlmRequest,
@@ -6511,6 +6525,13 @@ mod tests {
 
     #[async_trait]
     impl LlmClient for ErrorLlmClient {
+        fn project_replay_messages(
+            &self,
+            messages: &[meerkat_core::Message],
+        ) -> Result<Vec<meerkat_core::Message>, meerkat_client::LlmError> {
+            Ok(messages.to_vec())
+        }
+
         fn stream<'a>(
             &'a self,
             _request: &'a LlmRequest,

--- a/meerkat-rest/tests/runtime_backed_ingress.rs
+++ b/meerkat-rest/tests/runtime_backed_ingress.rs
@@ -41,6 +41,13 @@ impl FirstTurnOnlyClient {
 
 #[async_trait]
 impl LlmClient for FirstTurnOnlyClient {
+    fn project_replay_messages(
+        &self,
+        messages: &[meerkat_core::Message],
+    ) -> Result<Vec<meerkat_core::Message>, meerkat_client::LlmError> {
+        Ok(messages.to_vec())
+    }
+
     fn stream<'a>(&'a self, _request: &'a LlmRequest) -> LlmStream<'a> {
         let call = self.calls.fetch_add(1, Ordering::AcqRel);
         if call == 0 {

--- a/meerkat-rpc/src/router.rs
+++ b/meerkat-rpc/src/router.rs
@@ -3235,6 +3235,13 @@ args = [{}]
 
     #[async_trait]
     impl LlmClient for MockLlmClient {
+        fn project_replay_messages(
+            &self,
+            messages: &[meerkat_core::Message],
+        ) -> Result<Vec<meerkat_core::Message>, meerkat_client::LlmError> {
+            Ok(messages.to_vec())
+        }
+
         fn stream<'a>(
             &'a self,
             _request: &'a meerkat_client::LlmRequest,
@@ -3286,6 +3293,13 @@ args = [{}]
 
     #[async_trait]
     impl LlmClient for RecordingMockLlmClient {
+        fn project_replay_messages(
+            &self,
+            messages: &[meerkat_core::Message],
+        ) -> Result<Vec<meerkat_core::Message>, meerkat_client::LlmError> {
+            Ok(messages.to_vec())
+        }
+
         fn stream<'a>(
             &'a self,
             request: &'a meerkat_client::LlmRequest,

--- a/meerkat-rpc/src/server.rs
+++ b/meerkat-rpc/src/server.rs
@@ -769,6 +769,13 @@ mod tests {
 
     #[async_trait]
     impl LlmClient for MockLlmClient {
+        fn project_replay_messages(
+            &self,
+            messages: &[meerkat_core::Message],
+        ) -> Result<Vec<meerkat_core::Message>, meerkat_client::LlmError> {
+            Ok(messages.to_vec())
+        }
+
         fn stream<'a>(
             &'a self,
             _request: &'a meerkat_client::LlmRequest,

--- a/meerkat-rpc/src/session_runtime.rs
+++ b/meerkat-rpc/src/session_runtime.rs
@@ -8148,6 +8148,13 @@ mod tests {
 
     #[async_trait]
     impl LlmClient for MockLlmClient {
+        fn project_replay_messages(
+            &self,
+            messages: &[meerkat_core::Message],
+        ) -> Result<Vec<meerkat_core::Message>, meerkat_client::LlmError> {
+            Ok(messages.to_vec())
+        }
+
         fn stream<'a>(
             &'a self,
             _request: &'a meerkat_client::LlmRequest,
@@ -8190,6 +8197,13 @@ mod tests {
 
     #[async_trait]
     impl LlmClient for SlowMockLlmClient {
+        fn project_replay_messages(
+            &self,
+            messages: &[meerkat_core::Message],
+        ) -> Result<Vec<meerkat_core::Message>, meerkat_client::LlmError> {
+            Ok(messages.to_vec())
+        }
+
         fn stream<'a>(
             &'a self,
             _request: &'a meerkat_client::LlmRequest,
@@ -8227,6 +8241,13 @@ mod tests {
 
     #[async_trait]
     impl LlmClient for BlockingMockLlmClient {
+        fn project_replay_messages(
+            &self,
+            messages: &[meerkat_core::Message],
+        ) -> Result<Vec<meerkat_core::Message>, meerkat_client::LlmError> {
+            Ok(messages.to_vec())
+        }
+
         fn stream<'a>(
             &'a self,
             _request: &'a meerkat_client::LlmRequest,
@@ -8273,6 +8294,13 @@ mod tests {
 
     #[async_trait]
     impl LlmClient for FailAfterFirstMockLlmClient {
+        fn project_replay_messages(
+            &self,
+            messages: &[meerkat_core::Message],
+        ) -> Result<Vec<meerkat_core::Message>, meerkat_client::LlmError> {
+            Ok(messages.to_vec())
+        }
+
         fn stream<'a>(
             &'a self,
             _request: &'a meerkat_client::LlmRequest,

--- a/meerkat-rpc/tests/integration_server.rs
+++ b/meerkat-rpc/tests/integration_server.rs
@@ -31,6 +31,13 @@ struct MockLlmClient;
 
 #[async_trait]
 impl LlmClient for MockLlmClient {
+    fn project_replay_messages(
+        &self,
+        messages: &[meerkat_core::Message],
+    ) -> Result<Vec<meerkat_core::Message>, meerkat_client::LlmError> {
+        Ok(messages.to_vec())
+    }
+
     fn stream<'a>(
         &'a self,
         request: &'a meerkat_client::LlmRequest,
@@ -72,6 +79,13 @@ impl RecordingToolClient {
 
 #[async_trait]
 impl LlmClient for RecordingToolClient {
+    fn project_replay_messages(
+        &self,
+        messages: &[meerkat_core::Message],
+    ) -> Result<Vec<meerkat_core::Message>, meerkat_client::LlmError> {
+        Ok(messages.to_vec())
+    }
+
     fn stream<'a>(
         &'a self,
         request: &'a meerkat_client::LlmRequest,

--- a/meerkat-rpc/tests/realtime_ws_protocol.rs
+++ b/meerkat-rpc/tests/realtime_ws_protocol.rs
@@ -99,6 +99,13 @@ struct MockLlmClient;
 
 #[async_trait::async_trait]
 impl LlmClient for MockLlmClient {
+    fn project_replay_messages(
+        &self,
+        messages: &[meerkat_core::Message],
+    ) -> Result<Vec<meerkat_core::Message>, meerkat_client::LlmError> {
+        Ok(messages.to_vec())
+    }
+
     fn stream<'a>(
         &'a self,
         _request: &'a LlmRequest,

--- a/meerkat-rpc/tests/regression_rpc.rs
+++ b/meerkat-rpc/tests/regression_rpc.rs
@@ -30,6 +30,13 @@ struct MockLlmClient;
 
 #[async_trait]
 impl LlmClient for MockLlmClient {
+    fn project_replay_messages(
+        &self,
+        messages: &[meerkat_core::Message],
+    ) -> Result<Vec<meerkat_core::Message>, meerkat_client::LlmError> {
+        Ok(messages.to_vec())
+    }
+
     fn stream<'a>(
         &'a self,
         _request: &'a meerkat_client::LlmRequest,

--- a/meerkat-rpc/tests/runtime_backed_ingress.rs
+++ b/meerkat-rpc/tests/runtime_backed_ingress.rs
@@ -22,6 +22,13 @@ struct MockLlmClient;
 
 #[async_trait]
 impl LlmClient for MockLlmClient {
+    fn project_replay_messages(
+        &self,
+        messages: &[meerkat_core::Message],
+    ) -> Result<Vec<meerkat_core::Message>, meerkat_client::LlmError> {
+        Ok(messages.to_vec())
+    }
+
     fn stream<'a>(
         &'a self,
         request: &'a meerkat_client::LlmRequest,

--- a/meerkat/src/factory.rs
+++ b/meerkat/src/factory.rs
@@ -4185,6 +4185,13 @@ mod tests {
 
     #[async_trait]
     impl LlmClient for NeverLlmClient {
+        fn project_replay_messages(
+            &self,
+            messages: &[meerkat_core::Message],
+        ) -> Result<Vec<meerkat_core::Message>, meerkat_client::LlmError> {
+            Ok(messages.to_vec())
+        }
+
         fn stream<'a>(
             &'a self,
             _request: &'a meerkat_client::LlmRequest,
@@ -7449,6 +7456,13 @@ mod prompt_tests {
 
     #[async_trait]
     impl LlmClient for PromptTestClient {
+        fn project_replay_messages(
+            &self,
+            messages: &[meerkat_core::Message],
+        ) -> Result<Vec<meerkat_core::Message>, meerkat_client::LlmError> {
+            Ok(messages.to_vec())
+        }
+
         fn stream<'a>(
             &'a self,
             _request: &'a LlmRequest,

--- a/meerkat/src/service_factory.rs
+++ b/meerkat/src/service_factory.rs
@@ -722,6 +722,13 @@ mod tests {
     #[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
     #[cfg_attr(not(target_arch = "wasm32"), async_trait)]
     impl LlmClient for CaptureToolClient {
+        fn project_replay_messages(
+            &self,
+            messages: &[meerkat_core::Message],
+        ) -> Result<Vec<meerkat_core::Message>, meerkat_client::LlmError> {
+            Ok(messages.to_vec())
+        }
+
         fn stream<'a>(
             &'a self,
             request: &'a LlmRequest,
@@ -880,6 +887,13 @@ mod tests {
     #[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
     #[cfg_attr(not(target_arch = "wasm32"), async_trait)]
     impl LlmClient for MockLlmClient {
+        fn project_replay_messages(
+            &self,
+            messages: &[meerkat_core::Message],
+        ) -> Result<Vec<meerkat_core::Message>, meerkat_client::LlmError> {
+            Ok(messages.to_vec())
+        }
+
         fn stream<'a>(
             &'a self,
             _request: &'a LlmRequest,

--- a/meerkat/src/surface/embedded.rs
+++ b/meerkat/src/surface/embedded.rs
@@ -71,6 +71,13 @@ mod tests {
     #[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
     #[cfg_attr(not(target_arch = "wasm32"), async_trait)]
     impl LlmClient for CaptureToolClient {
+        fn project_replay_messages(
+            &self,
+            messages: &[meerkat_core::Message],
+        ) -> Result<Vec<meerkat_core::Message>, meerkat_client::LlmError> {
+            Ok(messages.to_vec())
+        }
+
         fn stream<'a>(
             &'a self,
             request: &'a LlmRequest,

--- a/meerkat/src/surface/runtime_backed.rs
+++ b/meerkat/src/surface/runtime_backed.rs
@@ -788,6 +788,13 @@ mod tests {
 
     #[async_trait::async_trait]
     impl LlmClient for BlockingClient {
+        fn project_replay_messages(
+            &self,
+            messages: &[meerkat_core::Message],
+        ) -> Result<Vec<meerkat_core::Message>, meerkat_client::LlmError> {
+            Ok(messages.to_vec())
+        }
+
         fn stream<'a>(&'a self, _request: &'a LlmRequest) -> LlmStream<'a> {
             let started = Arc::clone(&self.started);
             let release = Arc::clone(&self.release);
@@ -815,6 +822,13 @@ mod tests {
 
     #[async_trait::async_trait]
     impl LlmClient for TerminalLlmFailureClient {
+        fn project_replay_messages(
+            &self,
+            messages: &[meerkat_core::Message],
+        ) -> Result<Vec<meerkat_core::Message>, meerkat_client::LlmError> {
+            Ok(messages.to_vec())
+        }
+
         fn stream<'a>(&'a self, _request: &'a LlmRequest) -> LlmStream<'a> {
             Box::pin(futures::stream::once(async {
                 Err(LlmError::AuthenticationFailed {

--- a/meerkat/tests/agent_factory_auth_binding.rs
+++ b/meerkat/tests/agent_factory_auth_binding.rs
@@ -136,6 +136,13 @@ struct MockLlmClient;
 
 #[async_trait]
 impl LlmClient for MockLlmClient {
+    fn project_replay_messages(
+        &self,
+        messages: &[meerkat_core::Message],
+    ) -> Result<Vec<meerkat_core::Message>, meerkat_client::LlmError> {
+        Ok(messages.to_vec())
+    }
+
     fn stream<'a>(
         &'a self,
         _request: &'a LlmRequest,

--- a/meerkat/tests/factory_build_agent.rs
+++ b/meerkat/tests/factory_build_agent.rs
@@ -38,6 +38,13 @@ struct MockLlmClient;
 
 #[async_trait]
 impl LlmClient for MockLlmClient {
+    fn project_replay_messages(
+        &self,
+        messages: &[meerkat_core::Message],
+    ) -> Result<Vec<meerkat_core::Message>, meerkat_client::LlmError> {
+        Ok(messages.to_vec())
+    }
+
     fn stream<'a>(
         &'a self,
         _request: &'a LlmRequest,
@@ -79,6 +86,13 @@ impl CaptureClient {
 
 #[async_trait]
 impl LlmClient for CaptureClient {
+    fn project_replay_messages(
+        &self,
+        messages: &[meerkat_core::Message],
+    ) -> Result<Vec<meerkat_core::Message>, meerkat_client::LlmError> {
+        Ok(messages.to_vec())
+    }
+
     fn stream<'a>(
         &'a self,
         request: &'a LlmRequest,
@@ -2049,6 +2063,13 @@ impl ParamsCaptureClient {
 
 #[async_trait]
 impl LlmClient for ParamsCaptureClient {
+    fn project_replay_messages(
+        &self,
+        messages: &[meerkat_core::Message],
+    ) -> Result<Vec<meerkat_core::Message>, meerkat_client::LlmError> {
+        Ok(messages.to_vec())
+    }
+
     fn stream<'a>(
         &'a self,
         request: &'a LlmRequest,

--- a/meerkat/tests/live_meerkat_regression.rs
+++ b/meerkat/tests/live_meerkat_regression.rs
@@ -219,6 +219,13 @@ mod image_generation_substrate {
 
     #[async_trait]
     impl LlmClient for ScriptedImageToolCallClient {
+        fn project_replay_messages(
+            &self,
+            messages: &[meerkat_core::Message],
+        ) -> Result<Vec<meerkat_core::Message>, meerkat_client::LlmError> {
+            Ok(messages.to_vec())
+        }
+
         fn stream<'a>(
             &'a self,
             _request: &'a LlmRequest,

--- a/meerkat/tests/persistence_contract.rs
+++ b/meerkat/tests/persistence_contract.rs
@@ -62,6 +62,13 @@ mod tests {
 
     #[async_trait::async_trait]
     impl LlmClient for CatalogLoadClient {
+        fn project_replay_messages(
+            &self,
+            messages: &[meerkat_core::Message],
+        ) -> Result<Vec<meerkat_core::Message>, meerkat_client::LlmError> {
+            Ok(messages.to_vec())
+        }
+
         fn stream<'a>(
             &'a self,
             request: &'a LlmRequest,

--- a/meerkat/tests/sdk_agentfactory.rs
+++ b/meerkat/tests/sdk_agentfactory.rs
@@ -37,6 +37,13 @@ struct MockLlmClient {
 
 #[async_trait]
 impl LlmClient for MockLlmClient {
+    fn project_replay_messages(
+        &self,
+        messages: &[meerkat_core::Message],
+    ) -> Result<Vec<meerkat_core::Message>, meerkat_client::LlmError> {
+        Ok(messages.to_vec())
+    }
+
     fn stream<'a>(
         &'a self,
         _request: &'a LlmRequest,
@@ -254,6 +261,13 @@ impl ParamsCaptureClient {
 
 #[async_trait]
 impl LlmClient for ParamsCaptureClient {
+    fn project_replay_messages(
+        &self,
+        messages: &[meerkat_core::Message],
+    ) -> Result<Vec<meerkat_core::Message>, meerkat_client::LlmError> {
+        Ok(messages.to_vec())
+    }
+
     fn stream<'a>(
         &'a self,
         request: &'a LlmRequest,

--- a/meerkat/tests/sdk_structured_output.rs
+++ b/meerkat/tests/sdk_structured_output.rs
@@ -31,6 +31,13 @@ struct MockLlmClientWithStructuredOutput {
 
 #[async_trait]
 impl LlmClient for MockLlmClientWithStructuredOutput {
+    fn project_replay_messages(
+        &self,
+        messages: &[meerkat_core::Message],
+    ) -> Result<Vec<meerkat_core::Message>, meerkat_client::LlmError> {
+        Ok(messages.to_vec())
+    }
+
     fn stream<'a>(
         &'a self,
         _request: &'a LlmRequest,
@@ -88,6 +95,13 @@ struct MockLlmClientWithNamedWrapper {
 
 #[async_trait]
 impl LlmClient for MockLlmClientWithNamedWrapper {
+    fn project_replay_messages(
+        &self,
+        messages: &[meerkat_core::Message],
+    ) -> Result<Vec<meerkat_core::Message>, meerkat_client::LlmError> {
+        Ok(messages.to_vec())
+    }
+
     fn stream<'a>(
         &'a self,
         _request: &'a LlmRequest,
@@ -133,6 +147,13 @@ impl LlmClient for MockLlmClientWithNamedWrapper {
 
 #[async_trait]
 impl LlmClient for MockLlmClientWithRetry {
+    fn project_replay_messages(
+        &self,
+        messages: &[meerkat_core::Message],
+    ) -> Result<Vec<meerkat_core::Message>, meerkat_client::LlmError> {
+        Ok(messages.to_vec())
+    }
+
     fn stream<'a>(
         &'a self,
         _request: &'a LlmRequest,


### PR DESCRIPTION
## Summary
- add fail-closed LlmClient replay projection contract and invoke it before adapter/provider calls
- implement explicit replay policies for Anthropic, OpenAI/compatible/realtime text, and Gemini
- cover assistant images, server content, reasoning, tool adjacency, and multimodal replay behavior with focused tests

Linear: https://linear.app/lucrfr/issue/LUC-497/issue-1

## Validation
- ./scripts/repo-cargo test -p meerkat-llm-core adapter --lib
- ./scripts/repo-cargo test -p meerkat-openai test_build_request_body --lib
- ./scripts/repo-cargo test -p meerkat-anthropic test_build_request_body --lib
- ./scripts/repo-cargo test -p meerkat-gemini test_build_request_body --lib
- ./scripts/repo-cargo test -p meerkat-llm-core adapter_invokes_provider_replay_projection_before_streaming --lib
- ./scripts/repo-cargo test -p meerkat-anthropic replay_projection --lib
- ./scripts/repo-cargo test -p meerkat-gemini replay_projection --lib
- ./scripts/repo-cargo test -p meerkat-openai --features realtime replay_projection --lib
- make fmt
- make check
- make test
- git diff --check

## Note
- Local make e2e-smoke remote build completed, but the local smoke harness failed with environment-style failures: comms runtime readiness, Linux executing a macOS wasm-pack binary from cache, and later no-space errors. Recorded in Linear workpad pending PR CI/smoke signal.