### PR TITLE
Surface typed LLM turn failures

### DIFF
--- a/meerkat-cli/src/main.rs
+++ b/meerkat-cli/src/main.rs
@@ -319,6 +319,29 @@ fn completion_outcome_to_cli_runtime_turn_result(
         meerkat_runtime::completion::CompletionOutcome::Abandoned(reason) => {
             Err(anyhow::anyhow!("turn abandoned: {reason}"))
         }
+        meerkat_runtime::completion::CompletionOutcome::AbandonedWithError { reason, error } => {
+            Err(anyhow::anyhow!(
+                "turn abandoned: {reason}; error={}",
+                serde_json::to_string(&error).unwrap_or_else(|_| "<unserializable>".to_string())
+            ))
+        }
+        meerkat_runtime::completion::CompletionOutcome::CompletedWithFinalizationFailure {
+            result,
+            error,
+        } => {
+            let structured_output = result
+                .structured_output
+                .as_ref()
+                .map(serde_json::Value::to_string)
+                .unwrap_or_else(|| "null".to_string());
+            Err(anyhow::anyhow!(
+                "turn finalization failed after output: {}; structured_output={structured_output}",
+                error
+                    .detail
+                    .as_deref()
+                    .unwrap_or("turn finalization failed")
+            ))
+        }
         meerkat_runtime::completion::CompletionOutcome::RuntimeTerminated(reason) => {
             Err(anyhow::anyhow!("runtime terminated: {reason}"))
         }

--- a/meerkat-core/src/event.rs
+++ b/meerkat-core/src/event.rs
@@ -516,6 +516,136 @@ impl AgentErrorReport {
     }
 }
 
+/// Stable machine-readable metadata for a turn failure.
+///
+/// Human-readable diagnostics remain in `detail`; consumers should key
+/// behavior off `kind`/`terminal` instead of parsing display strings.
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct TurnErrorMetadata {
+    /// Closed failure classifier, serialized as `llm_failure`,
+    /// `runtime_apply_failure`, etc.
+    pub kind: TurnTerminalCauseKind,
+    /// Whether this error terminated the turn/runtime boundary.
+    #[serde(default)]
+    pub terminal: bool,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub outcome: Option<TurnTerminalOutcome>,
+    /// Original operator-facing diagnostic text.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub detail: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub provider: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub model: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub retryable: Option<bool>,
+}
+
+impl TurnErrorMetadata {
+    pub fn terminal(
+        kind: TurnTerminalCauseKind,
+        outcome: TurnTerminalOutcome,
+        detail: impl Into<String>,
+    ) -> Self {
+        Self {
+            kind,
+            terminal: true,
+            outcome: Some(outcome),
+            detail: Some(detail.into()),
+            provider: None,
+            model: None,
+            retryable: None,
+        }
+    }
+
+    pub fn runtime_apply_failure(detail: impl Into<String>) -> Self {
+        Self::terminal(
+            TurnTerminalCauseKind::RuntimeApplyFailure,
+            TurnTerminalOutcome::Failed,
+            detail,
+        )
+    }
+
+    pub fn from_agent_error(error: &AgentError) -> Option<Self> {
+        match error {
+            AgentError::Llm {
+                provider,
+                reason,
+                message,
+            } => {
+                let mut metadata = Self::terminal(
+                    TurnTerminalCauseKind::LlmFailure,
+                    TurnTerminalOutcome::Failed,
+                    message.clone(),
+                );
+                metadata.provider = Some((*provider).to_string());
+                metadata.retryable = Some(error.is_recoverable());
+                if let LlmFailureReason::InvalidModel(model) = reason {
+                    metadata.model = Some(model.clone());
+                }
+                Some(metadata)
+            }
+            AgentError::TerminalFailure {
+                outcome,
+                cause_kind,
+                message,
+            } if cause_kind.is_specific_failure_cause() => {
+                Some(Self::terminal(*cause_kind, *outcome, message.clone()))
+            }
+            _ => {
+                let kind = TurnTerminalCauseKind::from_agent_error(error);
+                kind.is_specific_failure_cause()
+                    .then(|| Self::terminal(kind, TurnTerminalOutcome::Failed, error.to_string()))
+            }
+        }
+    }
+
+    pub fn from_agent_error_report(
+        report: &AgentErrorReport,
+        detail: impl Into<String>,
+    ) -> Option<Self> {
+        let detail = detail.into();
+        match &report.reason {
+            Some(AgentErrorReason::TurnTerminalCause {
+                outcome,
+                cause_kind,
+            }) => Some(Self::terminal(*cause_kind, *outcome, detail)),
+            Some(reason) if report.class == AgentErrorClass::Llm => {
+                let mut metadata = Self::terminal(
+                    TurnTerminalCauseKind::LlmFailure,
+                    TurnTerminalOutcome::Failed,
+                    detail,
+                );
+                match reason {
+                    AgentErrorReason::LlmRateLimited { .. }
+                    | AgentErrorReason::LlmNetworkTimeout { .. }
+                    | AgentErrorReason::LlmCallTimeout { .. } => {
+                        metadata.retryable = Some(true);
+                    }
+                    AgentErrorReason::LlmProviderError {
+                        provider_error_retryability,
+                        ..
+                    } => {
+                        metadata.retryable = Some(provider_error_retryability.is_retryable());
+                    }
+                    AgentErrorReason::LlmContextExceeded { .. }
+                    | AgentErrorReason::LlmAuthError => {
+                        metadata.retryable = Some(false);
+                    }
+                    AgentErrorReason::LlmInvalidModel { model } => {
+                        metadata.retryable = Some(false);
+                        metadata.model = Some(model.clone());
+                    }
+                    _ => {}
+                }
+                Some(metadata)
+            }
+            _ => None,
+        }
+    }
+}
+
 #[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
 #[derive(Debug, Clone, PartialEq, Eq, Serialize)]
 #[serde(tag = "reason_type", rename_all = "snake_case")]

--- a/meerkat-core/src/lib.rs
+++ b/meerkat-core/src/lib.rs
@@ -158,9 +158,9 @@ pub use event::{
     AgentErrorClass, AgentErrorReport, AgentEvent, AssistantImageEvent, BudgetType, EventEnvelope,
     EventSourceIdentity, ExternalToolDelta, ExternalToolDeltaPhase, ScopedAgentEvent,
     SkillResolutionFailureReason, StreamScopeFrame, ToolCallArguments, ToolCallArgumentsError,
-    ToolConfigChangeOperation, ToolConfigChangeStatus, ToolConfigChangedPayload,
-    TurnErrorMetadata, VerboseEventConfig, agent_event_type, compare_event_envelopes,
-    format_verbose_event, format_verbose_event_with_config,
+    ToolConfigChangeOperation, ToolConfigChangeStatus, ToolConfigChangedPayload, TurnErrorMetadata,
+    VerboseEventConfig, agent_event_type, compare_event_envelopes, format_verbose_event,
+    format_verbose_event_with_config,
 };
 pub use event_injector::{EventInjector, EventInjectorError};
 pub use event_tap::{

--- a/meerkat-core/src/lib.rs
+++ b/meerkat-core/src/lib.rs
@@ -159,8 +159,8 @@ pub use event::{
     EventSourceIdentity, ExternalToolDelta, ExternalToolDeltaPhase, ScopedAgentEvent,
     SkillResolutionFailureReason, StreamScopeFrame, ToolCallArguments, ToolCallArgumentsError,
     ToolConfigChangeOperation, ToolConfigChangeStatus, ToolConfigChangedPayload,
-    VerboseEventConfig, agent_event_type, compare_event_envelopes, format_verbose_event,
-    format_verbose_event_with_config,
+    TurnErrorMetadata, VerboseEventConfig, agent_event_type, compare_event_envelopes,
+    format_verbose_event, format_verbose_event_with_config,
 };
 pub use event_injector::{EventInjector, EventInjectorError};
 pub use event_tap::{

--- a/meerkat-mcp-server/src/runtime_ingress.rs
+++ b/meerkat-mcp-server/src/runtime_ingress.rs
@@ -188,9 +188,17 @@ fn wrap_mcp_runtime_pre_admission_cleanup(
 
 fn completion_outcome_requires_mcp_runtime_cleanup(outcome: &CompletionOutcome) -> bool {
     match outcome {
-        CompletionOutcome::Abandoned(reason) | CompletionOutcome::RuntimeTerminated(reason) => {
+        CompletionOutcome::Abandoned(reason)
+        | CompletionOutcome::AbandonedWithError { reason, .. }
+        | CompletionOutcome::RuntimeTerminated(reason) => {
             reason.contains("runtime boundary commit failed")
                 || reason.contains("runtime loop commit failed")
+        }
+        CompletionOutcome::CompletedWithFinalizationFailure { error, .. } => {
+            error.detail.as_deref().is_some_and(|reason| {
+                reason.contains("runtime boundary commit failed")
+                    || reason.contains("runtime loop commit failed")
+            })
         }
         CompletionOutcome::Completed(_)
         | CompletionOutcome::CompletedWithoutResult
@@ -201,9 +209,10 @@ fn completion_outcome_requires_mcp_runtime_cleanup(outcome: &CompletionOutcome) 
 
 fn completion_outcome_is_mcp_apply_failure(outcome: &CompletionOutcome) -> bool {
     match outcome {
-        CompletionOutcome::Abandoned(reason) | CompletionOutcome::RuntimeTerminated(reason) => {
-            reason.starts_with("apply failed:")
-        }
+        CompletionOutcome::Abandoned(reason)
+        | CompletionOutcome::AbandonedWithError { reason, .. }
+        | CompletionOutcome::RuntimeTerminated(reason) => reason.starts_with("apply failed:"),
+        CompletionOutcome::CompletedWithFinalizationFailure { .. } => false,
         CompletionOutcome::Completed(_)
         | CompletionOutcome::CompletedWithoutResult
         | CompletionOutcome::Cancelled

--- a/meerkat-mob/src/event.rs
+++ b/meerkat-mob/src/event.rs
@@ -428,6 +428,10 @@ pub enum MobEventKind {
         step_id: StepId,
         target: AgentRuntimeId,
         reason: String,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        error_report: Option<meerkat_core::event::AgentErrorReport>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        error: Option<meerkat_core::event::TurnErrorMetadata>,
     },
     /// Aggregate step completion event.
     StepCompleted { run_id: RunId, step_id: StepId },
@@ -778,6 +782,8 @@ mod tests {
             step_id: step_id.clone(),
             target: runtime_id.clone(),
             reason: "fail".to_string(),
+            error_report: None,
+            error: None,
         });
         roundtrip(&MobEventKind::StepCompleted {
             run_id: run_id.clone(),

--- a/meerkat-mob/src/run.rs
+++ b/meerkat-mob/src/run.rs
@@ -4505,6 +4505,10 @@ impl StepRunStatus {
 pub struct FailureLedgerEntry {
     pub step_id: StepId,
     pub reason: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub error_report: Option<meerkat_core::event::AgentErrorReport>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub error: Option<meerkat_core::event::TurnErrorMetadata>,
     pub timestamp: DateTime<Utc>,
 }
 
@@ -5083,6 +5087,8 @@ mod tests {
             failure_ledger: vec![FailureLedgerEntry {
                 step_id: StepId::from("step-2"),
                 reason: "boom".to_string(),
+                error_report: None,
+                error: None,
                 timestamp: now,
             }],
             frames: BTreeMap::new(),

--- a/meerkat-mob/src/runtime/actor.rs
+++ b/meerkat-mob/src/runtime/actor.rs
@@ -2846,6 +2846,9 @@ impl MobActor {
                 agent_identity,
                 match outcome {
                     meerkat_runtime::completion::CompletionOutcome::Completed(_)
+                    | meerkat_runtime::completion::CompletionOutcome::CompletedWithFinalizationFailure {
+                        ..
+                    }
                     | meerkat_runtime::completion::CompletionOutcome::CompletedWithoutResult => {
                         mob_dsl::MobMachineInput::KickoffResolveStarted {
                             member_id: agent_identity.to_string(),
@@ -2863,6 +2866,10 @@ impl MobActor {
                         }
                     }
                     meerkat_runtime::completion::CompletionOutcome::Abandoned(error)
+                    | meerkat_runtime::completion::CompletionOutcome::AbandonedWithError {
+                        reason: error,
+                        ..
+                    }
                     | meerkat_runtime::completion::CompletionOutcome::RuntimeTerminated(error) => {
                         mob_dsl::MobMachineInput::KickoffResolveFailed {
                             member_id: agent_identity.to_string(),

--- a/meerkat-mob/src/runtime/actor_turn_executor.rs
+++ b/meerkat-mob/src/runtime/actor_turn_executor.rs
@@ -10,7 +10,7 @@ use crate::tokio;
 use async_trait::async_trait;
 use futures::FutureExt;
 use meerkat_core::EventEnvelope;
-use meerkat_core::event::{AgentEvent, ScopedAgentEvent, StreamScopeFrame};
+use meerkat_core::event::{AgentEvent, ScopedAgentEvent, StreamScopeFrame, TurnErrorMetadata};
 use meerkat_core::service::{StartTurnRequest, TurnToolOverlay};
 use meerkat_core::types::ContentInput;
 use std::collections::BTreeMap;
@@ -204,6 +204,14 @@ impl ActorFlowTurnExecutor {
                                 reason: format!(
                                     "structured output extraction failed after {attempts} attempt(s): {reason}; last_output={output:?}"
                                 ),
+                                error_report: None,
+                                error: Some(TurnErrorMetadata::terminal(
+                                    meerkat_core::TurnTerminalCauseKind::StructuredOutputValidationFailed,
+                                    meerkat_core::TurnTerminalOutcome::StructuredOutputValidationFailed,
+                                    format!(
+                                        "structured output extraction failed after {attempts} attempt(s): {reason}; last_output={output:?}"
+                                    ),
+                                )),
                             });
                         }
                         return;
@@ -227,14 +235,36 @@ impl ActorFlowTurnExecutor {
                         if let Some(tx) = completion_tx.take() {
                             let _ = tx.send(FlowTurnOutcome::Failed {
                                 reason: format!("callback pending for tool '{tool_name}': {args}"),
+                                error_report: None,
+                                error: None,
                             });
                         }
                         return;
                     }
-                    AgentEvent::RunFailed { error, .. }
-                    | AgentEvent::InteractionFailed { error, .. } => {
+                    AgentEvent::RunFailed {
+                        error,
+                        error_report,
+                        ..
+                    } => {
                         if let Some(tx) = completion_tx.take() {
-                            let _ = tx.send(FlowTurnOutcome::Failed { reason: error });
+                            let metadata = error_report.as_ref().and_then(|report| {
+                                TurnErrorMetadata::from_agent_error_report(report, error.clone())
+                            });
+                            let _ = tx.send(FlowTurnOutcome::Failed {
+                                reason: error,
+                                error_report,
+                                error: metadata,
+                            });
+                        }
+                        return;
+                    }
+                    AgentEvent::InteractionFailed { error, .. } => {
+                        if let Some(tx) = completion_tx.take() {
+                            let _ = tx.send(FlowTurnOutcome::Failed {
+                                reason: error,
+                                error_report: None,
+                                error: None,
+                            });
                         }
                         return;
                     }
@@ -245,6 +275,8 @@ impl ActorFlowTurnExecutor {
             if let Some(tx) = completion_tx {
                 let _ = tx.send(FlowTurnOutcome::Failed {
                     reason: "turn event stream closed before terminal outcome".to_string(),
+                    error_report: None,
+                    error: None,
                 });
             }
         })
@@ -469,6 +501,8 @@ impl FlowTurnExecutor for ActorFlowTurnExecutor {
                 }
                 Ok(FlowTurnOutcome::Failed {
                     reason: "turn completion channel closed".to_string(),
+                    error_report: None,
+                    error: None,
                 })
             }
             Err(_) => Err(MobError::FlowTurnTimedOut),
@@ -513,6 +547,7 @@ mod tests {
     use crate::ids::RunId;
     use crate::runtime::FlowTurnOutcome;
     use meerkat_core::AgentEvent;
+    use meerkat_core::event::{AgentErrorClass, AgentErrorReason, AgentErrorReport};
     use meerkat_core::interaction::InteractionId;
     use std::collections::BTreeMap;
     use std::sync::Arc;
@@ -632,6 +667,55 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn test_subscription_bridge_preserves_run_failed_typed_llm_error() {
+        let (events_tx, events_rx) = tokio::sync::mpsc::channel(1);
+        let (completion_tx, completion_rx) = oneshot::channel();
+        let bridge =
+            ActorFlowTurnExecutor::spawn_subscription_bridge(events_rx, completion_tx, None, None);
+
+        let report = AgentErrorReport {
+            class: AgentErrorClass::Terminal,
+            reason: Some(AgentErrorReason::TurnTerminalCause {
+                outcome: meerkat_core::TurnTerminalOutcome::Failed,
+                cause_kind: meerkat_core::TurnTerminalCauseKind::LlmFailure,
+            }),
+            message: "LLM failure terminal turn".to_string(),
+        };
+
+        events_tx
+            .send(AgentEvent::RunFailed {
+                session_id: meerkat_core::SessionId::new(),
+                error_class: AgentErrorClass::Terminal,
+                error: "LLM failure terminal turn".to_string(),
+                terminal_cause_kind: Some(meerkat_core::TurnTerminalCauseKind::LlmFailure),
+                error_report: Some(report.clone()),
+            })
+            .await
+            .expect("send event");
+
+        match completion_rx.await.expect("completion outcome") {
+            FlowTurnOutcome::Failed {
+                reason,
+                error_report,
+                error,
+            } => {
+                assert_eq!(reason, "LLM failure terminal turn");
+                assert_eq!(error_report, Some(report));
+                let error = error.expect("typed turn error metadata");
+                assert_eq!(error.kind, meerkat_core::TurnTerminalCauseKind::LlmFailure);
+                assert!(error.terminal);
+                assert_eq!(
+                    error.outcome,
+                    Some(meerkat_core::TurnTerminalOutcome::Failed)
+                );
+                assert_eq!(error.detail.as_deref(), Some("LLM failure terminal turn"));
+            }
+            other => panic!("expected failed outcome, got {other:?}"),
+        }
+        bridge.await.expect("bridge exits after terminal event");
+    }
+
+    #[tokio::test]
     async fn test_subscription_bridge_waits_for_required_extraction_success() {
         let (events_tx, events_rx) = tokio::sync::mpsc::channel(2);
         let (completion_tx, completion_rx) = oneshot::channel();
@@ -702,7 +786,7 @@ mod tests {
             .expect("send extraction failed event");
 
         match completion_rx.await.expect("completion outcome") {
-            FlowTurnOutcome::Failed { reason } => {
+            FlowTurnOutcome::Failed { reason, .. } => {
                 assert!(
                     reason.contains("structured output extraction failed after 2 attempt(s)"),
                     "reason should preserve extraction attempts: {reason}"

--- a/meerkat-mob/src/runtime/events.rs
+++ b/meerkat-mob/src/runtime/events.rs
@@ -4,6 +4,7 @@ use crate::ids::{
     AgentIdentity, AgentRuntimeId, FlowId, MeerkatId, MobId, ProfileName, RunId, StepId,
 };
 use crate::store::MobEventStore;
+use meerkat_core::event::{AgentErrorReport, TurnErrorMetadata};
 use std::sync::Arc;
 
 #[derive(Clone)]
@@ -79,12 +80,27 @@ impl MobEventEmitter {
         agent_identity: MeerkatId,
         reason: String,
     ) -> Result<MobEvent, MobError> {
+        self.step_target_failed_with_error(run_id, step_id, agent_identity, reason, None, None)
+            .await
+    }
+
+    pub async fn step_target_failed_with_error(
+        &self,
+        run_id: RunId,
+        step_id: StepId,
+        agent_identity: MeerkatId,
+        reason: String,
+        error_report: Option<AgentErrorReport>,
+        error: Option<TurnErrorMetadata>,
+    ) -> Result<MobEvent, MobError> {
         let target = AgentRuntimeId::initial(AgentIdentity::from(agent_identity.as_str()));
         self.append(MobEventKind::StepTargetFailed {
             run_id,
             step_id,
             target,
             reason,
+            error_report,
+            error,
         })
         .await
     }
@@ -147,5 +163,68 @@ impl MobEventEmitter {
             escalated_to: AgentIdentity::from(escalated_to.as_str()),
         })
         .await
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::MobEventEmitter;
+    use crate::event::MobEventKind;
+    use crate::ids::{MeerkatId, MobId, RunId, StepId};
+    use crate::store::{InMemoryMobEventStore, MobEventStore};
+    use meerkat_core::event::{AgentErrorClass, AgentErrorReason, AgentErrorReport};
+    use std::sync::Arc;
+
+    #[tokio::test]
+    async fn step_target_failed_persists_typed_error_metadata() {
+        let store: Arc<dyn MobEventStore> = Arc::new(InMemoryMobEventStore::new());
+        let emitter = MobEventEmitter::new(Arc::clone(&store), MobId::from("mob-typed-error"));
+        let report = AgentErrorReport {
+            class: AgentErrorClass::Terminal,
+            reason: Some(AgentErrorReason::TurnTerminalCause {
+                outcome: meerkat_core::TurnTerminalOutcome::Failed,
+                cause_kind: meerkat_core::TurnTerminalCauseKind::LlmFailure,
+            }),
+            message: "LLM failure terminal turn".to_string(),
+        };
+        let error = meerkat_core::TurnErrorMetadata::terminal(
+            meerkat_core::TurnTerminalCauseKind::LlmFailure,
+            meerkat_core::TurnTerminalOutcome::Failed,
+            "LLM failure terminal turn",
+        );
+
+        emitter
+            .step_target_failed_with_error(
+                RunId::new(),
+                StepId::from("review"),
+                MeerkatId::from("reviewer"),
+                "LLM failure terminal turn".to_string(),
+                Some(report.clone()),
+                Some(error.clone()),
+            )
+            .await
+            .expect("event append should succeed");
+
+        let events = store
+            .replay_all()
+            .await
+            .expect("event replay should succeed");
+        match &events
+            .first()
+            .expect("step target failed event should persist")
+            .kind
+        {
+            MobEventKind::StepTargetFailed {
+                reason,
+                error_report,
+                error: persisted_error,
+                ..
+            } => {
+                assert_eq!(reason, "LLM failure terminal turn");
+                assert_eq!(error_report.as_ref(), Some(&report));
+                assert_eq!(persisted_error.as_ref(), Some(&error));
+            }
+            other => panic!("expected StepTargetFailed, got {other:?}"),
+        }
     }
 }

--- a/meerkat-mob/src/runtime/flow.rs
+++ b/meerkat-mob/src/runtime/flow.rs
@@ -825,6 +825,8 @@ impl FlowEngine {
                                     FailureLedgerEntry {
                                         step_id: step_id.clone(),
                                         reason: reason.clone(),
+                                        error_report: None,
+                                        error: None,
                                         timestamp: Utc::now(),
                                     },
                                 )
@@ -833,15 +835,21 @@ impl FlowEngine {
                         }
                     }
                 }
-                Ok(FlowTurnOutcome::Failed { reason }) => {
+                Ok(FlowTurnOutcome::Failed {
+                    reason,
+                    error_report,
+                    error,
+                }) => {
                     if attempt < max_retries {
                         attempt += 1;
                         self.emitter
-                            .step_target_failed(
+                            .step_target_failed_with_error(
                                 run_id.clone(),
                                 step_id.clone(),
                                 target.clone(),
                                 reason.clone(),
+                                error_report.clone(),
+                                error.clone(),
                             )
                             .await?;
                         continue;
@@ -859,11 +867,13 @@ impl FlowEngine {
                         )
                         .await?;
                     self.emitter
-                        .step_target_failed(
+                        .step_target_failed_with_error(
                             run_id.clone(),
                             step_id.clone(),
                             target.clone(),
                             reason.clone(),
+                            error_report.clone(),
+                            error.clone(),
                         )
                         .await?;
                     self.run_store
@@ -872,6 +882,8 @@ impl FlowEngine {
                             FailureLedgerEntry {
                                 step_id: step_id.clone(),
                                 reason: reason.clone(),
+                                error_report,
+                                error,
                                 timestamp: Utc::now(),
                             },
                         )
@@ -909,6 +921,8 @@ impl FlowEngine {
                             FailureLedgerEntry {
                                 step_id: step_id.clone(),
                                 reason: cancel_reason.clone(),
+                                error_report: None,
+                                error: None,
                                 timestamp: Utc::now(),
                             },
                         )
@@ -974,6 +988,8 @@ impl FlowEngine {
                             FailureLedgerEntry {
                                 step_id: step_id.clone(),
                                 reason: timeout_reason.clone(),
+                                error_report: None,
+                                error: None,
                                 timestamp: Utc::now(),
                             },
                         )
@@ -1043,6 +1059,8 @@ impl FlowEngine {
                             FailureLedgerEntry {
                                 step_id: step_id.clone(),
                                 reason: reason.clone(),
+                                error_report: None,
+                                error: None,
                                 timestamp: Utc::now(),
                             },
                         )
@@ -1134,6 +1152,8 @@ impl FlowEngine {
                     FailureLedgerEntry {
                         step_id: step_id.clone(),
                         reason,
+                        error_report: None,
+                        error: None,
                         timestamp: Utc::now(),
                     },
                 )

--- a/meerkat-mob/src/runtime/provisioner.rs
+++ b/meerkat-mob/src/runtime/provisioner.rs
@@ -450,6 +450,27 @@ fn runtime_completion_to_mob_result(
         meerkat_runtime::completion::CompletionOutcome::Abandoned(reason) => {
             Err(MobError::Internal(format!("turn abandoned: {reason}")))
         }
+        meerkat_runtime::completion::CompletionOutcome::AbandonedWithError { reason, error } => {
+            Err(MobError::Internal(format!(
+                "turn abandoned: {reason}; error={}",
+                serde_json::to_string(&error).unwrap_or_else(|_| "<unserializable>".to_string())
+            )))
+        }
+        meerkat_runtime::completion::CompletionOutcome::CompletedWithFinalizationFailure {
+            result,
+            error,
+        } => Err(MobError::Internal(format!(
+            "turn finalization failed after output: {}; structured_output={}",
+            error
+                .detail
+                .as_deref()
+                .unwrap_or("turn finalization failed"),
+            result
+                .structured_output
+                .as_ref()
+                .map(serde_json::Value::to_string)
+                .unwrap_or_else(|| "null".to_string())
+        ))),
         meerkat_runtime::completion::CompletionOutcome::RuntimeTerminated(reason) => {
             Err(MobError::Internal(format!("runtime terminated: {reason}")))
         }

--- a/meerkat-mob/src/runtime/terminalization.rs
+++ b/meerkat-mob/src/runtime/terminalization.rs
@@ -212,6 +212,8 @@ impl FlowTerminalizationAuthority {
                 FailureLedgerEntry {
                     step_id: flow_system_step_id(),
                     reason: reason.clone(),
+                    error_report: None,
+                    error: None,
                     timestamp: Utc::now(),
                 },
             )

--- a/meerkat-mob/src/runtime/turn_executor.rs
+++ b/meerkat-mob/src/runtime/turn_executor.rs
@@ -3,6 +3,7 @@ use crate::ids::{MeerkatId, RunId, StepId};
 #[cfg(target_arch = "wasm32")]
 use crate::tokio;
 use async_trait::async_trait;
+use meerkat_core::event::{AgentErrorReport, TurnErrorMetadata};
 use meerkat_core::service::TurnToolOverlay;
 use meerkat_core::types::ContentInput;
 use serde_json::Value;
@@ -39,6 +40,8 @@ pub enum FlowTurnOutcome {
     },
     Failed {
         reason: String,
+        error_report: Option<AgentErrorReport>,
+        error: Option<TurnErrorMetadata>,
     },
     Canceled,
 }

--- a/meerkat-mob/src/store/in_memory.rs
+++ b/meerkat-mob/src/store/in_memory.rs
@@ -1470,6 +1470,8 @@ mod tests {
                 FailureLedgerEntry {
                     step_id: StepId::from("s1"),
                     reason: "failed".to_string(),
+                    error_report: None,
+                    error: None,
                     timestamp: Utc::now(),
                 },
             )

--- a/meerkat-rest/src/lib.rs
+++ b/meerkat-rest/src/lib.rs
@@ -812,10 +812,18 @@ fn completion_outcome_requires_rest_runtime_cleanup(
 ) -> bool {
     match outcome {
         meerkat_runtime::completion::CompletionOutcome::Abandoned(reason)
+        | meerkat_runtime::completion::CompletionOutcome::AbandonedWithError { reason, .. }
         | meerkat_runtime::completion::CompletionOutcome::RuntimeTerminated(reason) => {
             reason.contains("runtime boundary commit failed")
                 || reason.contains("runtime loop commit failed")
         }
+        meerkat_runtime::completion::CompletionOutcome::CompletedWithFinalizationFailure {
+            error,
+            ..
+        } => error.detail.as_deref().is_some_and(|reason| {
+            reason.contains("runtime boundary commit failed")
+                || reason.contains("runtime loop commit failed")
+        }),
         meerkat_runtime::completion::CompletionOutcome::Completed(_)
         | meerkat_runtime::completion::CompletionOutcome::CompletedWithoutResult
         | meerkat_runtime::completion::CompletionOutcome::Cancelled
@@ -828,9 +836,13 @@ fn completion_outcome_is_rest_apply_failure(
 ) -> bool {
     match outcome {
         meerkat_runtime::completion::CompletionOutcome::Abandoned(reason)
+        | meerkat_runtime::completion::CompletionOutcome::AbandonedWithError { reason, .. }
         | meerkat_runtime::completion::CompletionOutcome::RuntimeTerminated(reason) => {
             reason.starts_with("apply failed:")
         }
+        meerkat_runtime::completion::CompletionOutcome::CompletedWithFinalizationFailure {
+            ..
+        } => false,
         meerkat_runtime::completion::CompletionOutcome::Completed(_)
         | meerkat_runtime::completion::CompletionOutcome::CompletedWithoutResult
         | meerkat_runtime::completion::CompletionOutcome::Cancelled
@@ -3518,6 +3530,34 @@ fn completion_outcome_to_api_result(
         }
         meerkat_runtime::completion::CompletionOutcome::Abandoned(reason) => {
             Err(ApiError::Internal(format!("turn abandoned: {reason}")))
+        }
+        meerkat_runtime::completion::CompletionOutcome::AbandonedWithError { reason, error } => {
+            Err(ApiError::InternalWithData {
+                message: format!("turn abandoned: {reason}"),
+                code: "TURN_ABANDONED".to_string(),
+                details: json!({
+                    "error": error,
+                }),
+            })
+        }
+        meerkat_runtime::completion::CompletionOutcome::CompletedWithFinalizationFailure {
+            result,
+            error,
+        } => {
+            let response = run_result_to_response(*result, realm);
+            let structured_output = response.structured_output.clone();
+            Err(ApiError::InternalWithData {
+                message: error
+                    .detail
+                    .clone()
+                    .unwrap_or_else(|| "turn finalization failed".to_string()),
+                code: "TURN_FINALIZATION_FAILED".to_string(),
+                details: json!({
+                    "error": error,
+                    "run_result": response,
+                    "structured_output": structured_output,
+                }),
+            })
         }
         meerkat_runtime::completion::CompletionOutcome::RuntimeTerminated(reason) => {
             Err(ApiError::Internal(format!("runtime terminated: {reason}")))
@@ -11169,6 +11209,55 @@ mod tests {
         .expect_err("cancelled completion should map to API cancellation");
 
         assert!(matches!(err, ApiError::RequestCancelled { details: None }));
+    }
+
+    #[test]
+    fn completion_outcome_to_api_result_surfaces_output_and_finalization_error() {
+        let session_id = SessionId::new();
+        let realm = meerkat_core::RealmId::parse("test-realm").expect("valid test realm id");
+        let run_result = meerkat_core::RunResult {
+            text: "{\"gate\":\"green\"}".to_string(),
+            session_id: session_id.clone(),
+            usage: Default::default(),
+            turns: 1,
+            tool_calls: 0,
+            terminal_cause_kind: None,
+            structured_output: Some(json!({ "gate": "green" })),
+            extraction_error: None,
+            schema_warnings: None,
+            skill_diagnostics: None,
+        };
+        let err = completion_outcome_to_api_result(
+            meerkat_runtime::completion::CompletionOutcome::CompletedWithFinalizationFailure {
+                result: Box::new(run_result),
+                error: meerkat_core::TurnErrorMetadata::runtime_apply_failure(
+                    "runtime loop commit failed: synthetic finalization failure",
+                ),
+            },
+            &session_id,
+            &realm,
+            false,
+        )
+        .expect_err("finalization failure should map to an API error");
+
+        let ApiError::InternalWithData {
+            code,
+            details,
+            message,
+        } = err
+        else {
+            panic!("expected typed finalization API error");
+        };
+
+        assert_eq!(code, "TURN_FINALIZATION_FAILED");
+        assert!(message.contains("synthetic finalization failure"));
+        assert_eq!(details["error"]["kind"], "runtime_apply_failure");
+        assert_eq!(details["error"]["terminal"], true);
+        assert_eq!(
+            details["run_result"]["structured_output"],
+            json!({ "gate": "green" })
+        );
+        assert_eq!(details["structured_output"], json!({ "gate": "green" }));
     }
 
     #[test]

--- a/meerkat-rest/src/lib.rs
+++ b/meerkat-rest/src/lib.rs
@@ -3511,6 +3511,39 @@ fn callback_pending_api_error(
     }
 }
 
+fn session_created_with_turn_failure_api_error(
+    message: String,
+    session_id: &SessionId,
+    realm: &meerkat_core::RealmId,
+    turn_error_code: Option<String>,
+    turn_error_details: Option<Value>,
+) -> ApiError {
+    let mut details = serde_json::Map::new();
+    details.insert("session_id".to_string(), json!(session_id.to_string()));
+    details.insert(
+        "session_ref".to_string(),
+        json!(format_session_ref(realm, session_id)),
+    );
+    details.insert("session_created".to_string(), json!(true));
+    details.insert("resumable".to_string(), json!(true));
+
+    if let Some(turn_error_code) = turn_error_code {
+        details.insert("turn_error_code".to_string(), json!(turn_error_code));
+    }
+    if let Some(turn_error_details) = turn_error_details {
+        if let Some(error) = turn_error_details.get("error") {
+            details.insert("error".to_string(), error.clone());
+        }
+        details.insert("turn_error_details".to_string(), turn_error_details);
+    }
+
+    ApiError::InternalWithData {
+        message,
+        code: "SESSION_CREATED_WITH_TURN_FAILURE".to_string(),
+        details: Value::Object(details),
+    }
+}
+
 fn completion_outcome_to_api_result(
     outcome: meerkat_runtime::completion::CompletionOutcome,
     session_id: &SessionId,
@@ -3529,16 +3562,35 @@ fn completion_outcome_to_api_result(
             Err(ApiError::RequestCancelled { details: None })
         }
         meerkat_runtime::completion::CompletionOutcome::Abandoned(reason) => {
-            Err(ApiError::Internal(format!("turn abandoned: {reason}")))
+            let message = format!("turn abandoned: {reason}");
+            if session_created {
+                Err(session_created_with_turn_failure_api_error(
+                    message, session_id, realm, None, None,
+                ))
+            } else {
+                Err(ApiError::Internal(message))
+            }
         }
         meerkat_runtime::completion::CompletionOutcome::AbandonedWithError { reason, error } => {
-            Err(ApiError::InternalWithData {
-                message: format!("turn abandoned: {reason}"),
-                code: "TURN_ABANDONED".to_string(),
-                details: json!({
-                    "error": error,
-                }),
-            })
+            let message = format!("turn abandoned: {reason}");
+            let details = json!({
+                "error": error,
+            });
+            if session_created {
+                Err(session_created_with_turn_failure_api_error(
+                    message,
+                    session_id,
+                    realm,
+                    Some("TURN_ABANDONED".to_string()),
+                    Some(details),
+                ))
+            } else {
+                Err(ApiError::InternalWithData {
+                    message,
+                    code: "TURN_ABANDONED".to_string(),
+                    details,
+                })
+            }
         }
         meerkat_runtime::completion::CompletionOutcome::CompletedWithFinalizationFailure {
             result,
@@ -4299,16 +4351,13 @@ async fn create_session_inner(
                 ApiError::Internal(msg) => msg,
                 other => return RequestTerminal::Publish(Err(other)),
             };
-            RequestTerminal::Publish(Err(ApiError::InternalWithData {
+            RequestTerminal::Publish(Err(session_created_with_turn_failure_api_error(
                 message,
-                code: "SESSION_CREATED_WITH_TURN_FAILURE".to_string(),
-                details: json!({
-                    "session_id": session_id.to_string(),
-                    "session_ref": format_session_ref(&state.realm, &session_id),
-                    "session_created": true,
-                    "resumable": true,
-                }),
-            }))
+                &session_id,
+                &state.realm,
+                None,
+                None,
+            )))
         }
     }
 }
@@ -11031,6 +11080,9 @@ mod tests {
         assert_eq!(payload["details"]["resumable"], true);
         assert!(payload["details"]["session_id"].is_string());
         assert!(payload["details"]["session_ref"].is_string());
+        assert_eq!(payload["details"]["turn_error_code"], "TURN_ABANDONED");
+        assert_eq!(payload["details"]["error"]["kind"], "llm_failure");
+        assert_eq!(payload["details"]["error"]["terminal"], true);
     }
 
     #[test]
@@ -11209,6 +11261,47 @@ mod tests {
         .expect_err("cancelled completion should map to API cancellation");
 
         assert!(matches!(err, ApiError::RequestCancelled { details: None }));
+    }
+
+    #[test]
+    fn completion_outcome_to_api_result_preserves_created_session_abandoned_metadata() {
+        let session_id = SessionId::new();
+        let realm = meerkat_core::RealmId::parse("test-realm").expect("valid test realm id");
+        let err = completion_outcome_to_api_result(
+            meerkat_runtime::completion::CompletionOutcome::AbandonedWithError {
+                reason: "apply failed: Terminal failure: Failed (LlmFailure)".to_string(),
+                error: meerkat_core::TurnErrorMetadata::terminal(
+                    meerkat_core::TurnTerminalCauseKind::LlmFailure,
+                    meerkat_core::TurnTerminalOutcome::Failed,
+                    "LLM failure terminal turn",
+                ),
+            },
+            &session_id,
+            &realm,
+            true,
+        )
+        .expect_err("created-session abandoned turn should map to resumable session failure");
+
+        let ApiError::InternalWithData {
+            code,
+            details,
+            message,
+        } = err
+        else {
+            panic!("expected created-session turn failure");
+        };
+
+        assert_eq!(code, "SESSION_CREATED_WITH_TURN_FAILURE");
+        assert!(message.contains("turn abandoned: apply failed"));
+        assert_eq!(details["session_created"], true);
+        assert_eq!(details["resumable"], true);
+        assert_eq!(details["turn_error_code"], "TURN_ABANDONED");
+        assert_eq!(details["error"]["kind"], "llm_failure");
+        assert_eq!(details["error"]["terminal"], true);
+        assert_eq!(
+            details["turn_error_details"]["error"]["kind"],
+            "llm_failure"
+        );
     }
 
     #[test]

--- a/meerkat-rpc/src/realtime_ws.rs
+++ b/meerkat-rpc/src/realtime_ws.rs
@@ -4177,9 +4177,13 @@ async fn commit_runtime_turn_text(
         if let Some(completion_handle) = completion_handle {
             match completion_handle.wait().await {
                 meerkat_runtime::completion::CompletionOutcome::Completed(_)
+                | meerkat_runtime::completion::CompletionOutcome::CompletedWithFinalizationFailure {
+                    ..
+                }
                 | meerkat_runtime::completion::CompletionOutcome::CompletedWithoutResult
                 | meerkat_runtime::completion::CompletionOutcome::Cancelled
                 | meerkat_runtime::completion::CompletionOutcome::Abandoned(_)
+                | meerkat_runtime::completion::CompletionOutcome::AbandonedWithError { .. }
                 | meerkat_runtime::completion::CompletionOutcome::RuntimeTerminated(_) => {
                     frames.push(channel_event(RealtimeEvent::TurnCompleted));
                 }

--- a/meerkat-rpc/src/session_runtime.rs
+++ b/meerkat-rpc/src/session_runtime.rs
@@ -2984,10 +2984,17 @@ impl SessionRuntime {
     ) -> bool {
         match outcome {
             meerkat_runtime::CompletionOutcome::Abandoned(reason)
+            | meerkat_runtime::CompletionOutcome::AbandonedWithError { reason, .. }
             | meerkat_runtime::CompletionOutcome::RuntimeTerminated(reason) => {
                 reason.contains("runtime boundary commit failed")
                     || reason.contains("runtime loop commit failed")
             }
+            meerkat_runtime::CompletionOutcome::CompletedWithFinalizationFailure {
+                error, ..
+            } => error.detail.as_deref().is_some_and(|reason| {
+                reason.contains("runtime boundary commit failed")
+                    || reason.contains("runtime loop commit failed")
+            }),
             meerkat_runtime::CompletionOutcome::Completed(_)
             | meerkat_runtime::CompletionOutcome::CompletedWithoutResult
             | meerkat_runtime::CompletionOutcome::Cancelled
@@ -2998,9 +3005,11 @@ impl SessionRuntime {
     fn completion_outcome_is_apply_failure(outcome: &meerkat_runtime::CompletionOutcome) -> bool {
         match outcome {
             meerkat_runtime::CompletionOutcome::Abandoned(reason)
+            | meerkat_runtime::CompletionOutcome::AbandonedWithError { reason, .. }
             | meerkat_runtime::CompletionOutcome::RuntimeTerminated(reason) => {
                 reason.starts_with("apply failed:")
             }
+            meerkat_runtime::CompletionOutcome::CompletedWithFinalizationFailure { .. } => false,
             meerkat_runtime::CompletionOutcome::Completed(_)
             | meerkat_runtime::CompletionOutcome::CompletedWithoutResult
             | meerkat_runtime::CompletionOutcome::Cancelled
@@ -7984,6 +7993,35 @@ fn completion_outcome_to_rpc_result(
             message: format!("turn abandoned: {reason}"),
             data: None,
         }),
+        CompletionOutcome::AbandonedWithError {
+            reason,
+            error: turn_error,
+        } => Err(RpcError {
+            code: error::INTERNAL_ERROR,
+            message: format!("turn abandoned: {reason}"),
+            data: Some(serde_json::json!({
+                "error": turn_error,
+            })),
+        }),
+        CompletionOutcome::CompletedWithFinalizationFailure {
+            result,
+            error: turn_error,
+        } => {
+            let wire_result = meerkat_contracts::WireRunResult::from(*result);
+            let structured_output = wire_result.structured_output.clone();
+            Err(RpcError {
+                code: error::INTERNAL_ERROR,
+                message: turn_error
+                    .detail
+                    .clone()
+                    .unwrap_or_else(|| "turn finalization failed".to_string()),
+                data: Some(serde_json::json!({
+                    "error": turn_error,
+                    "run_result": wire_result,
+                    "structured_output": structured_output,
+                })),
+            })
+        }
         CompletionOutcome::RuntimeTerminated(reason) => Err(RpcError {
             code: error::INTERNAL_ERROR,
             message: format!("runtime terminated: {reason}"),
@@ -19093,6 +19131,47 @@ mod tests {
 
         assert_eq!(err.code, error::REQUEST_CANCELLED);
         assert_eq!(err.message, "request cancelled");
+    }
+
+    #[test]
+    fn completion_outcome_to_rpc_result_surfaces_output_and_finalization_error() {
+        let session_id = SessionId::new();
+        let run_result = meerkat_core::RunResult {
+            text: "{\"gate\":\"green\"}".to_string(),
+            session_id: session_id.clone(),
+            usage: Default::default(),
+            turns: 1,
+            tool_calls: 0,
+            terminal_cause_kind: None,
+            structured_output: Some(serde_json::json!({ "gate": "green" })),
+            extraction_error: None,
+            schema_warnings: None,
+            skill_diagnostics: None,
+        };
+        let err = completion_outcome_to_rpc_result(
+            meerkat_runtime::completion::CompletionOutcome::CompletedWithFinalizationFailure {
+                result: Box::new(run_result),
+                error: meerkat_core::TurnErrorMetadata::runtime_apply_failure(
+                    "runtime loop commit failed: synthetic finalization failure",
+                ),
+            },
+            &session_id,
+        )
+        .expect_err("finalization failure should map to an RPC error");
+
+        assert_eq!(err.code, error::INTERNAL_ERROR);
+        assert!(err.message.contains("synthetic finalization failure"));
+        let data = err.data.expect("finalization failure error data");
+        assert_eq!(data["error"]["kind"], "runtime_apply_failure");
+        assert_eq!(data["error"]["terminal"], true);
+        assert_eq!(
+            data["run_result"]["structured_output"],
+            serde_json::json!({ "gate": "green" })
+        );
+        assert_eq!(
+            data["structured_output"],
+            serde_json::json!({ "gate": "green" })
+        );
     }
 
     #[test]

--- a/meerkat-runtime/src/comms_drain.rs
+++ b/meerkat-runtime/src/comms_drain.rs
@@ -1832,10 +1832,18 @@ fn interaction_terminal_event(
             interaction_id,
             error: "cancelled".to_string(),
         },
-        CompletionOutcome::Abandoned(reason) | CompletionOutcome::RuntimeTerminated(reason) => {
+        CompletionOutcome::Abandoned(reason)
+        | CompletionOutcome::AbandonedWithError { reason, .. }
+        | CompletionOutcome::RuntimeTerminated(reason) => AgentEvent::InteractionFailed {
+            interaction_id,
+            error: reason,
+        },
+        CompletionOutcome::CompletedWithFinalizationFailure { error, .. } => {
             AgentEvent::InteractionFailed {
                 interaction_id,
-                error: reason,
+                error: error
+                    .detail
+                    .unwrap_or_else(|| "turn finalization failed".to_string()),
             }
         }
     }

--- a/meerkat-runtime/src/completion.rs
+++ b/meerkat-runtime/src/completion.rs
@@ -12,6 +12,7 @@
 use std::collections::HashMap;
 use std::future::Future;
 
+use meerkat_core::TurnErrorMetadata;
 use meerkat_core::lifecycle::InputId;
 use meerkat_core::types::RunResult;
 use serde_json::Value;
@@ -32,6 +33,17 @@ pub enum CompletionOutcome {
     Cancelled,
     /// The input was abandoned before completing.
     Abandoned(String),
+    /// The input was abandoned before completing, with typed failure metadata.
+    AbandonedWithError {
+        reason: String,
+        error: TurnErrorMetadata,
+    },
+    /// The turn produced a valid result, but a later runtime finalization step
+    /// failed. Consumers can use the result while handling the mechanics error.
+    CompletedWithFinalizationFailure {
+        result: Box<RunResult>,
+        error: TurnErrorMetadata,
+    },
     /// The runtime was stopped or destroyed while the input was pending.
     RuntimeTerminated(String),
 }
@@ -121,6 +133,23 @@ impl CompletionHandle {
     }
 }
 
+impl CompletionOutcome {
+    pub fn abandoned_reason(&self) -> Option<&str> {
+        match self {
+            Self::Abandoned(reason) | Self::AbandonedWithError { reason, .. } => Some(reason),
+            _ => None,
+        }
+    }
+
+    pub fn error_metadata(&self) -> Option<&TurnErrorMetadata> {
+        match self {
+            Self::AbandonedWithError { error, .. }
+            | Self::CompletedWithFinalizationFailure { error, .. } => Some(error),
+            _ => None,
+        }
+    }
+}
+
 /// Registry of pending completion waiters, keyed by InputId.
 ///
 /// Uses `Vec<Sender>` per InputId to support multiple waiters for the same input
@@ -201,6 +230,41 @@ impl CompletionRegistry {
         if let Some(senders) = self.take_waiters(input_id) {
             for tx in senders {
                 let _ = tx.send(CompletionOutcome::Abandoned(reason.clone()));
+            }
+        }
+    }
+
+    /// Resolve all waiters for an abandoned input with typed failure metadata.
+    pub(crate) fn resolve_abandoned_with_error(
+        &mut self,
+        input_id: &InputId,
+        reason: String,
+        error: TurnErrorMetadata,
+    ) {
+        if let Some(senders) = self.take_waiters(input_id) {
+            for tx in senders {
+                let _ = tx.send(CompletionOutcome::AbandonedWithError {
+                    reason: reason.clone(),
+                    error: error.clone(),
+                });
+            }
+        }
+    }
+
+    /// Resolve all waiters for a turn whose output exists but finalization
+    /// failed after output production.
+    pub(crate) fn resolve_completed_with_finalization_failure(
+        &mut self,
+        input_id: &InputId,
+        result: RunResult,
+        error: TurnErrorMetadata,
+    ) {
+        if let Some(senders) = self.take_waiters(input_id) {
+            for tx in senders {
+                let _ = tx.send(CompletionOutcome::CompletedWithFinalizationFailure {
+                    result: Box::new(result.clone()),
+                    error: error.clone(),
+                });
             }
         }
     }

--- a/meerkat-runtime/src/meerkat_machine_tests.rs
+++ b/meerkat-runtime/src/meerkat_machine_tests.rs
@@ -1420,10 +1420,42 @@ async fn machine_terminal_failure_preserves_typed_cause_through_runtime_loop() {
         .register_session_with_executor(session_id.clone(), Box::new(TypedMachineFailureExecutor))
         .await;
 
-    adapter
-        .accept_input(&session_id, make_prompt("typed machine failure"))
+    let (accept_outcome, completion_handle) = adapter
+        .accept_input_with_completion(&session_id, make_prompt("typed machine failure"))
         .await
         .expect("input should be accepted");
+    assert!(matches!(accept_outcome, AcceptOutcome::Accepted { .. }));
+
+    let completion = tokio::time::timeout(
+        Duration::from_secs(1),
+        completion_handle
+            .expect("accepted input should register a completion waiter")
+            .wait(),
+    )
+    .await
+    .expect("completion waiter should resolve");
+    match completion {
+        CompletionOutcome::AbandonedWithError { reason, error } => {
+            assert!(
+                reason.contains("apply failed: Terminal failure: Failed (LlmFailure)"),
+                "operator reason should remain available: {reason}"
+            );
+            assert_eq!(error.kind, meerkat_core::TurnTerminalCauseKind::LlmFailure);
+            assert!(error.terminal);
+            assert_eq!(
+                error.outcome,
+                Some(meerkat_core::TurnTerminalOutcome::Failed)
+            );
+            assert!(
+                error
+                    .detail
+                    .as_deref()
+                    .is_some_and(|detail| detail.contains("provider auth denied")),
+                "typed metadata should preserve original diagnostic detail: {error:?}"
+            );
+        }
+        other => panic!("expected typed abandoned completion, got {other:?}"),
+    }
 
     let (terminal_cause_kind, runtime_apply_failure_cause, runtime_apply_failure_message) =
         tokio::time::timeout(Duration::from_secs(1), async {
@@ -1456,6 +1488,121 @@ async fn machine_terminal_failure_preserves_typed_cause_through_runtime_loop() {
     );
     assert_eq!(runtime_apply_failure_cause, None);
     assert_eq!(runtime_apply_failure_message, None);
+}
+
+#[tokio::test]
+async fn completion_preserves_structured_output_when_runtime_finalization_fails() {
+    struct StructuredOutputExecutor {
+        session_id: SessionId,
+    }
+
+    #[async_trait::async_trait]
+    impl CoreExecutor for StructuredOutputExecutor {
+        async fn apply(
+            &mut self,
+            run_id: RunId,
+            primitive: RunPrimitive,
+        ) -> Result<CoreApplyOutput, CoreExecutorError> {
+            let receipt = RunBoundaryReceipt {
+                run_id,
+                boundary: RunApplyBoundary::RunStart,
+                contributing_input_ids: primitive.contributing_input_ids().to_vec(),
+                conversation_digest: None,
+                message_count: 0,
+                sequence: 0,
+            };
+            Ok(CoreApplyOutput::with_run_result(
+                receipt,
+                Some(b"session snapshot".to_vec()),
+                meerkat_core::RunResult {
+                    text: "{\"gate\":\"green\"}".to_string(),
+                    session_id: self.session_id.clone(),
+                    usage: Default::default(),
+                    turns: 1,
+                    tool_calls: 0,
+                    terminal_cause_kind: None,
+                    structured_output: Some(serde_json::json!({ "gate": "green" })),
+                    extraction_error: None,
+                    schema_warnings: None,
+                    skill_diagnostics: None,
+                },
+            ))
+        }
+
+        async fn cancel_after_boundary(
+            &mut self,
+            _reason: String,
+        ) -> Result<(), CoreExecutorError> {
+            Ok(())
+        }
+
+        async fn stop_runtime_executor(
+            &mut self,
+            _reason: String,
+        ) -> Result<(), CoreExecutorError> {
+            Ok(())
+        }
+    }
+
+    let inner = Arc::new(crate::store::InMemoryRuntimeStore::new());
+    let store: Arc<dyn RuntimeStore> = Arc::new(
+        RuntimeCommitAtomicityStore::fail_atomic_apply_once(Arc::clone(&inner)),
+    );
+    let adapter = Arc::new(MeerkatMachine::persistent(store, memory_blob_store()));
+    let session_id = SessionId::new();
+    adapter
+        .register_session_with_executor(
+            session_id.clone(),
+            Box::new(StructuredOutputExecutor {
+                session_id: session_id.clone(),
+            }),
+        )
+        .await;
+
+    let (accept_outcome, completion_handle) = adapter
+        .accept_input_with_completion(
+            &session_id,
+            make_prompt("structured gate before finalization failure"),
+        )
+        .await
+        .expect("input should be accepted");
+    assert!(matches!(accept_outcome, AcceptOutcome::Accepted { .. }));
+
+    let completion = tokio::time::timeout(
+        Duration::from_secs(1),
+        completion_handle
+            .expect("accepted input should register a completion waiter")
+            .wait(),
+    )
+    .await
+    .expect("completion waiter should resolve after finalization failure");
+
+    match completion {
+        CompletionOutcome::CompletedWithFinalizationFailure { result, error } => {
+            assert_eq!(result.text, "{\"gate\":\"green\"}");
+            assert_eq!(
+                result.structured_output,
+                Some(serde_json::json!({ "gate": "green" }))
+            );
+            assert_eq!(
+                error.kind,
+                meerkat_core::TurnTerminalCauseKind::RuntimeApplyFailure
+            );
+            assert!(error.terminal);
+            assert_eq!(
+                error.outcome,
+                Some(meerkat_core::TurnTerminalOutcome::Failed)
+            );
+            assert!(
+                error
+                    .detail
+                    .as_deref()
+                    .is_some_and(|detail| detail.contains("synthetic atomic_apply failure")),
+                "finalization failure detail should remain available: {error:?}"
+            );
+        }
+        other => panic!("expected completed output with finalization failure, got {other:?}"),
+    }
 }
 
 #[tokio::test]

--- a/meerkat-runtime/src/runtime_loop.rs
+++ b/meerkat-runtime/src/runtime_loop.rs
@@ -115,6 +115,32 @@ fn resolve_completion_waiters(
     }
 }
 
+fn resolve_completion_waiters_with_finalization_failure(
+    registry: &mut crate::completion::CompletionRegistry,
+    input_ids: &[InputId],
+    terminal: Option<CoreApplyTerminal>,
+    error: meerkat_core::TurnErrorMetadata,
+) {
+    match terminal {
+        Some(CoreApplyTerminal::RunResult(result)) => {
+            for input_id in input_ids {
+                registry.resolve_completed_with_finalization_failure(
+                    input_id,
+                    result.as_ref().clone(),
+                    error.clone(),
+                );
+            }
+        }
+        _ => {
+            let reason = error
+                .detail
+                .clone()
+                .unwrap_or_else(|| "runtime finalization failed".to_string());
+            abandon_completion_waiters_with_error(registry, input_ids, reason, error);
+        }
+    }
+}
+
 async fn stop_runtime_loop_executor_from_dsl_effect(
     driver: &crate::meerkat_machine::SharedDriver,
     completions: Option<&crate::meerkat_machine::SharedCompletionRegistry>,
@@ -186,6 +212,18 @@ fn abandon_completion_waiters(
     let reason = reason.into();
     for input_id in input_ids {
         registry.resolve_abandoned(input_id, reason.clone());
+    }
+}
+
+fn abandon_completion_waiters_with_error(
+    registry: &mut crate::completion::CompletionRegistry,
+    input_ids: &[InputId],
+    reason: impl Into<String>,
+    error: meerkat_core::TurnErrorMetadata,
+) {
+    let reason = reason.into();
+    for input_id in input_ids {
+        registry.resolve_abandoned_with_error(input_id, reason.clone(), error.clone());
     }
 }
 
@@ -845,6 +883,19 @@ async fn process_queue(
                         .await
                         {
                             tracing::error!(%run_id, error = %err, "failed to commit runtime loop run");
+                            let completion_error =
+                                meerkat_core::TurnErrorMetadata::runtime_apply_failure(format!(
+                                    "runtime loop commit failed: {err}"
+                                ));
+                            if let Some(completions) = completions.as_ref() {
+                                let mut completions = completions.lock().await;
+                                resolve_completion_waiters_with_finalization_failure(
+                                    &mut completions,
+                                    &input_ids,
+                                    terminal,
+                                    completion_error,
+                                );
+                            }
                             let should_stop = stop_runtime_loop_executor_from_dsl_effect(
                                 driver,
                                 completions,
@@ -852,14 +903,6 @@ async fn process_queue(
                                 format!("runtime loop commit failed for run {run_id}: {err}"),
                             )
                             .await;
-                            if let Some(completions) = completions.as_ref() {
-                                let mut completions = completions.lock().await;
-                                abandon_completion_waiters(
-                                    &mut completions,
-                                    &input_ids,
-                                    format!("runtime loop commit failed: {err}"),
-                                );
-                            }
                             return should_stop;
                         }
 
@@ -880,6 +923,18 @@ async fn process_queue(
                             } => Some(crate::meerkat_machine_types::MeerkatMachineRunFailure::new(
                                 *cause_kind,
                                 message.clone(),
+                            )),
+                            _ => None,
+                        };
+                        let completion_error = match &e {
+                            CoreExecutorError::TerminalFailure {
+                                outcome,
+                                cause_kind,
+                                ..
+                            } => Some(meerkat_core::TurnErrorMetadata::terminal(
+                                *cause_kind,
+                                *outcome,
+                                format!("apply failed: {error_msg}"),
                             )),
                             _ => None,
                         };
@@ -923,11 +978,21 @@ async fn process_queue(
                                     completions.resolve_cancelled(input_id);
                                 }
                             } else {
-                                abandon_completion_waiters(
-                                    &mut completions,
-                                    &input_ids,
-                                    format!("apply failed: {error_msg}"),
-                                );
+                                let reason = format!("apply failed: {error_msg}");
+                                if let Some(error) = completion_error {
+                                    abandon_completion_waiters_with_error(
+                                        &mut completions,
+                                        &input_ids,
+                                        reason,
+                                        error,
+                                    );
+                                } else {
+                                    abandon_completion_waiters(
+                                        &mut completions,
+                                        &input_ids,
+                                        reason,
+                                    );
+                                }
                             }
                         }
                         let mut d = driver.lock().await;


### PR DESCRIPTION
## Summary
- add typed turn error metadata for terminal LLM/runtime failures
- preserve structured output when runtime finalization fails after a valid run result
- pass typed failure metadata through REST/RPC error data and mob step failure history

## Validation
- ./scripts/repo-cargo test -p meerkat-runtime machine_terminal_failure_preserves_typed_cause_through_runtime_loop -- --nocapture
- ./scripts/repo-cargo test -p meerkat-runtime completion_preserves_structured_output_when_runtime_finalization_fails -- --nocapture
- ./scripts/repo-cargo test -p meerkat-mob test_subscription_bridge_preserves_run_failed_typed_llm_error -- --nocapture
- ./scripts/repo-cargo test -p meerkat-mob step_target_failed_persists_typed_error_metadata -- --nocapture
- ./scripts/repo-cargo test -p meerkat-mob test_subscription_bridge_preserves_run_structured_output -- --nocapture
- ./scripts/repo-cargo test -p meerkat-rest completion_outcome_to_api_result_surfaces_output_and_finalization_error -- --nocapture
- ./scripts/repo-cargo test -p meerkat-rpc completion_outcome_to_rpc_result_surfaces_output_and_finalization_error -- --nocapture
- make verify-schema-freshness
- ./scripts/repo-cargo check -p meerkat-mcp-server
- make check