### PR TITLE
LUC-501: Add canonical assistant image event

### DIFF
--- a/meerkat-contracts/src/event_catalog.rs
+++ b/meerkat-contracts/src/event_catalog.rs
@@ -18,6 +18,7 @@ pub const KNOWN_AGENT_EVENT_TYPES: &[&str] = &[
     "reasoning_complete",
     "text_delta",
     "text_complete",
+    "assistant_image_appended",
     "tool_call_requested",
     "tool_result_received",
     "turn_completed",

--- a/meerkat-contracts/tests/image_generation_wire.rs
+++ b/meerkat-contracts/tests/image_generation_wire.rs
@@ -5,24 +5,26 @@ use std::num::NonZeroU32;
 use meerkat_contracts::wire::{
     WireAssistantBlock, WireGenerateImageExecutionPlan, WireGenerateImageRequest,
     WireImageGenerationToolResult, WireImageOperationPhase, WireModelRoutingApprovalPhase,
-    WireModelRoutingApprovalRequest, WireScopedModelOverride, WireSessionModelRoutingStatus,
-    WireSwitchTurnControlResult, WireSwitchTurnIntent, WireSwitchTurnPhase,
+    WireModelRoutingApprovalRequest, WireScopedModelOverride, WireSessionHistory,
+    WireSessionMessage, WireSessionModelRoutingStatus, WireSwitchTurnControlResult,
+    WireSwitchTurnIntent, WireSwitchTurnPhase,
 };
 use meerkat_core::lifecycle::run_primitive::ModelId;
 use meerkat_core::{
-    ApprovalId, AssistantImageId, AssistantImageRef, BlobId, BlobRef, GenerateImageExecutionPlan,
-    GenerateImageRequest, ImageContinuityTokenSupport, ImageFormatPreference,
-    ImageGenerationBackendKind, ImageGenerationIntent, ImageGenerationTargetCapabilities,
-    ImageGenerationTargetPreference, ImageGenerationToolResult, ImageOperationApprovalReason,
-    ImageOperationDenialReason, ImageOperationId, ImageOperationPhase, ImageOperationTerminalClass,
-    ImageQualityPreference, ImageSizePreference, MediaType, ModelRoutingApprovalPhase,
-    ModelRoutingApprovalRequest, ModelRoutingApprovalTerminalClass, PromptSource, PromptText,
-    ProviderId, ProviderImageMetadata, ProviderTextDisposition, RevisedPromptDisposition,
-    ScopedModelOverride, ScopedModelOverrideId, ScopedModelOverrideKind,
-    ScopedModelOverrideSummary, SwitchTurnApprovalReason, SwitchTurnControlResult,
-    SwitchTurnDenialReason, SwitchTurnDuration, SwitchTurnIntent, SwitchTurnOrigin,
-    SwitchTurnPhase, SwitchTurnPolicyReason, SwitchTurnReasonText, SwitchTurnReasonTextDisposition,
-    SwitchTurnRequestId, SwitchTurnTerminalClass, TextArtifactRef, ToolCallId, TopologyEpoch,
+    ApprovalId, AssistantImageId, AssistantImageRef, BlobId, BlobRef, BlockAssistantMessage,
+    GenerateImageExecutionPlan, GenerateImageRequest, ImageContinuityTokenSupport,
+    ImageFormatPreference, ImageGenerationBackendKind, ImageGenerationIntent,
+    ImageGenerationTargetCapabilities, ImageGenerationTargetPreference, ImageGenerationToolResult,
+    ImageOperationApprovalReason, ImageOperationDenialReason, ImageOperationId,
+    ImageOperationPhase, ImageOperationTerminalClass, ImageQualityPreference, ImageSizePreference,
+    MediaType, Message, ModelRoutingApprovalPhase, ModelRoutingApprovalRequest,
+    ModelRoutingApprovalTerminalClass, PromptSource, PromptText, ProviderId, ProviderImageMetadata,
+    ProviderTextDisposition, RevisedPromptDisposition, ScopedModelOverride, ScopedModelOverrideId,
+    ScopedModelOverrideKind, ScopedModelOverrideSummary, SessionHistoryPage, StopReason,
+    SwitchTurnApprovalReason, SwitchTurnControlResult, SwitchTurnDenialReason, SwitchTurnDuration,
+    SwitchTurnIntent, SwitchTurnOrigin, SwitchTurnPhase, SwitchTurnPolicyReason,
+    SwitchTurnReasonText, SwitchTurnReasonTextDisposition, SwitchTurnRequestId,
+    SwitchTurnTerminalClass, TextArtifactRef, ToolCallId, TopologyEpoch,
 };
 use serde::Serialize;
 use serde::de::DeserializeOwned;
@@ -63,6 +65,51 @@ fn assistant_image_block_projects_to_wire_image_not_unknown() {
     assert!(encoded.contains("\"block_type\":\"image\""));
     let decoded: WireAssistantBlock = serde_json::from_str(&encoded).unwrap();
     assert!(matches!(decoded, WireAssistantBlock::Image { .. }));
+}
+
+#[test]
+fn assistant_image_block_remains_typed_in_wire_history() {
+    let page = SessionHistoryPage {
+        session_id: meerkat_core::SessionId::new(),
+        offset: 0,
+        limit: Some(50),
+        message_count: 1,
+        has_more: false,
+        messages: vec![Message::BlockAssistant(BlockAssistantMessage::new(
+            vec![meerkat_core::AssistantBlock::Image {
+                image_id: AssistantImageId::new(uuid(2)),
+                blob_ref: BlobRef {
+                    blob_id: BlobId::new("generated-history-image"),
+                    media_type: "image/png".into(),
+                },
+                media_type: MediaType::new("image/png"),
+                width: 1024,
+                height: 1024,
+                revised_prompt: RevisedPromptDisposition::NotRequested,
+                meta: ProviderImageMetadata::NotEmitted,
+            }],
+            StopReason::EndTurn,
+        ))],
+    };
+
+    let wire = WireSessionHistory::from(page);
+    match &wire.messages[0] {
+        WireSessionMessage::BlockAssistant { blocks, .. } => match &blocks[0] {
+            WireAssistantBlock::Image {
+                blob_ref,
+                media_type,
+                width,
+                height,
+                ..
+            } => {
+                assert_eq!(blob_ref.blob_id.as_str(), "generated-history-image");
+                assert_eq!(media_type.as_str(), "image/png");
+                assert_eq!((*width, *height), (1024, 1024));
+            }
+            other => panic!("expected assistant image block, got {other:?}"),
+        },
+        other => panic!("expected block assistant history message, got {other:?}"),
+    }
 }
 
 #[test]

--- a/meerkat-contracts/tests/regression_wire_types.rs
+++ b/meerkat-contracts/tests/regression_wire_types.rs
@@ -18,10 +18,11 @@ use meerkat_contracts::{
 };
 use meerkat_core::event::BackgroundJobTerminalStatus;
 use meerkat_core::{
-    AgentErrorClass, AgentEvent, BudgetType, ContentBlock, ContentInput, HookId, HookPoint,
-    HookReasonCode, RunResult, SessionId, SkillResolutionFailureReason, StopReason,
-    ToolCallArguments, ToolConfigChangeOperation, ToolConfigChangeStatus, ToolConfigChangedPayload,
-    Usage,
+    AgentErrorClass, AgentEvent, AssistantImageEvent, AssistantImageId, BlobId, BlobRef,
+    BudgetType, ContentBlock, ContentInput, HookId, HookPoint, HookReasonCode, MediaType,
+    ProviderImageMetadata, RevisedPromptDisposition, RunResult, SessionId,
+    SkillResolutionFailureReason, StopReason, ToolCallArguments, ToolConfigChangeOperation,
+    ToolConfigChangeStatus, ToolConfigChangedPayload, Usage,
 };
 
 fn tool_args(value: serde_json::Value) -> ToolCallArguments {
@@ -739,6 +740,20 @@ fn documented_event_catalog_covers_core_agent_event_discriminators() {
                 true,
             )
             .with_applied_at_turn(Some(1)),
+        },
+        AgentEvent::AssistantImageAppended {
+            image: AssistantImageEvent {
+                image_id: AssistantImageId::new(uuid::Uuid::new_v4()),
+                blob_ref: BlobRef {
+                    blob_id: BlobId::new("image-1"),
+                    media_type: "image/png".to_string(),
+                },
+                media_type: MediaType::new("image/png"),
+                width: 1024,
+                height: 1024,
+                revised_prompt: RevisedPromptDisposition::NotRequested,
+                meta: ProviderImageMetadata::NotEmitted,
+            },
         },
         AgentEvent::background_job_completed(
             "j_123",

--- a/meerkat-core/src/agent/state.rs
+++ b/meerkat-core/src/agent/state.rs
@@ -128,6 +128,27 @@ fn public_terminal_cause_kind(
     cause_kind.filter(|cause_kind| cause_kind.is_specific_failure_cause())
 }
 
+fn assistant_image_events_from_blocks(
+    blocks: &[crate::types::AssistantBlock],
+) -> Vec<crate::event::AssistantImageEvent> {
+    blocks
+        .iter()
+        .filter_map(crate::event::AssistantImageEvent::from_assistant_block)
+        .collect()
+}
+
+fn assistant_image_events_from_effects(
+    effects: &[crate::ops::SessionEffect],
+) -> Vec<crate::event::AssistantImageEvent> {
+    let mut images = Vec::new();
+    for effect in effects {
+        if let crate::ops::SessionEffect::AppendAssistantBlocks { blocks } = effect {
+            images.extend(assistant_image_events_from_blocks(blocks));
+        }
+    }
+    images
+}
+
 fn validate_turn_input_failure_reason(input: &TurnExecutionInput) -> Result<(), AgentError> {
     if let Some(reason) = turn_input_failure_reason(input)
         && !reason.cause_kind.is_specific_failure_cause()
@@ -1921,6 +1942,9 @@ where
                         // Add assistant message with ordered blocks
                         self.session
                             .push(Message::BlockAssistant(assistant_msg.clone()));
+                        for image in assistant_image_events_from_blocks(&assistant_msg.blocks) {
+                            emit_event!(AgentEvent::AssistantImageAppended { image });
+                        }
 
                         // Emit tool call requests
                         for (tc, args) in &tool_calls {
@@ -2174,8 +2198,13 @@ where
                         // Add tool results to session
                         self.session.push(Message::tool_results(tool_results));
 
+                        let assistant_image_events =
+                            assistant_image_events_from_effects(&post_tool_effects);
                         if !post_tool_effects.is_empty() {
                             self.apply_session_effects(&post_tool_effects)?;
+                        }
+                        for image in assistant_image_events {
+                            emit_event!(AgentEvent::AssistantImageAppended { image });
                         }
 
                         self.observe_cancel_after_boundary_request(&run_id)?;
@@ -2212,7 +2241,12 @@ where
                         turn_count += 1;
                     } else if self.turn_in_extraction_flow()? {
                         // Extraction turn response — validate against schema
+                        let assistant_image_events =
+                            assistant_image_events_from_blocks(&assistant_msg.blocks);
                         self.session.push(Message::BlockAssistant(assistant_msg));
+                        for image in assistant_image_events {
+                            emit_event!(AgentEvent::AssistantImageAppended { image });
+                        }
 
                         // Drain turn boundary (fires TurnBoundary hooks, drains comms)
                         self.apply_turn_input(TurnExecutionInput::LlmReturnedTerminal {
@@ -2388,7 +2422,12 @@ where
                     } else {
                         // No tool calls - we're done with the agentic loop
                         let final_text = assistant_text.clone();
+                        let assistant_image_events =
+                            assistant_image_events_from_blocks(&assistant_msg.blocks);
                         self.session.push(Message::BlockAssistant(assistant_msg));
+                        for image in assistant_image_events {
+                            emit_event!(AgentEvent::AssistantImageAppended { image });
+                        }
 
                         self.apply_turn_input(TurnExecutionInput::LlmReturnedTerminal {
                             run_id: run_id.clone(),
@@ -5177,6 +5216,45 @@ mod tests {
         }
     }
 
+    struct DirectImageClient;
+
+    #[async_trait]
+    impl AgentLlmClient for DirectImageClient {
+        async fn stream_response(
+            &self,
+            _messages: &[Message],
+            _tools: &[Arc<ToolDef>],
+            _max_tokens: u32,
+            _temperature: Option<f32>,
+            _provider_params: Option<&crate::lifecycle::run_primitive::ProviderParamsOverride>,
+        ) -> Result<super::LlmStreamResult, AgentError> {
+            Ok(super::LlmStreamResult::new(
+                vec![AssistantBlock::Image {
+                    image_id: crate::AssistantImageId::new(uuid::Uuid::from_u128(501)),
+                    blob_ref: crate::BlobRef {
+                        blob_id: crate::BlobId::new("direct-image-blob"),
+                        media_type: "image/png".to_string(),
+                    },
+                    media_type: crate::MediaType::new("image/png"),
+                    width: 32,
+                    height: 24,
+                    revised_prompt: crate::RevisedPromptDisposition::NotRequested,
+                    meta: crate::ProviderImageMetadata::NotEmitted,
+                }],
+                StopReason::EndTurn,
+                Usage::default(),
+            ))
+        }
+
+        fn provider(&self) -> &'static str {
+            "mock"
+        }
+
+        fn model(&self) -> &'static str {
+            "mock-model"
+        }
+    }
+
     struct ImageEffectDispatcher {
         tools: Arc<[Arc<ToolDef>]>,
     }
@@ -5373,7 +5451,44 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn tool_image_session_effects_preserve_tool_result_adjacency() {
+    async fn direct_assistant_image_response_emits_typed_event() {
+        let client = Arc::new(DirectImageClient);
+        let tools = Arc::new(NoTools);
+        let mut agent = with_test_turn_state_handle(AgentBuilder::new())
+            .build_standalone(client, tools, Arc::new(NoopStore))
+            .await;
+        agent.config.max_turns = Some(1);
+
+        let (tx, mut rx) = mpsc::channel::<crate::event::AgentEvent>(32);
+        agent
+            .run_with_events("prompt".to_string().into(), tx)
+            .await
+            .unwrap();
+
+        assert!(agent.session().messages().iter().any(|message| matches!(
+            message,
+            Message::BlockAssistant(blocks)
+                if blocks
+                    .blocks
+                    .iter()
+                    .any(|block| matches!(block, AssistantBlock::Image { .. }))
+        )));
+
+        let mut image_events = Vec::new();
+        while let Ok(event) = rx.try_recv() {
+            if let crate::event::AgentEvent::AssistantImageAppended { image } = event {
+                image_events.push(image);
+            }
+        }
+        assert_eq!(image_events.len(), 1);
+        let image = &image_events[0];
+        assert_eq!(image.blob_ref.blob_id.as_str(), "direct-image-blob");
+        assert_eq!(image.media_type.as_str(), "image/png");
+        assert_eq!((image.width, image.height), (32, 24));
+    }
+
+    #[tokio::test]
+    async fn tool_image_session_effects_preserve_tool_result_adjacency_and_emit_typed_event() {
         let client = Arc::new(ImageEffectClient {
             call_count: Mutex::new(0),
         });
@@ -5383,7 +5498,11 @@ mod tests {
             .await;
         agent.config.max_turns = Some(2);
 
-        let result = agent.run("prompt".to_string().into()).await.unwrap();
+        let (tx, mut rx) = mpsc::channel::<crate::event::AgentEvent>(32);
+        let result = agent
+            .run_with_events("prompt".to_string().into(), tx)
+            .await
+            .unwrap();
         assert_eq!(result.text, "done");
 
         let messages = agent.session().messages();
@@ -5427,6 +5546,43 @@ mod tests {
             image_index > tool_results_index,
             "assistant image blocks should be appended after tool results"
         );
+
+        let image_event_index = {
+            let mut events = Vec::new();
+            while let Ok(event) = rx.try_recv() {
+                events.push(event);
+            }
+            let tool_result_event_index = events
+                .iter()
+                .position(|event| {
+                    matches!(event, crate::event::AgentEvent::ToolResultReceived { .. })
+                })
+                .expect("tool result event should be emitted");
+            let image_event_index = events
+                .iter()
+                .position(|event| {
+                    matches!(
+                        event,
+                        crate::event::AgentEvent::AssistantImageAppended { .. }
+                    )
+                })
+                .expect("assistant image append event should be emitted");
+            assert!(
+                image_event_index > tool_result_event_index,
+                "assistant image append event should follow tool-result events"
+            );
+            match &events[image_event_index] {
+                crate::event::AgentEvent::AssistantImageAppended { image } => {
+                    assert_eq!(image.blob_ref.blob_id.as_str(), "image-blob");
+                    assert_eq!(image.media_type.as_str(), "image/png");
+                    assert_eq!(image.width, 1);
+                    assert_eq!(image.height, 1);
+                }
+                other => panic!("expected assistant image event, got {other:?}"),
+            }
+            image_event_index
+        };
+        assert!(image_event_index > 0);
     }
 
     #[tokio::test]

--- a/meerkat-core/src/event.rs
+++ b/meerkat-core/src/event.rs
@@ -871,6 +871,7 @@ pub fn agent_event_type(event: &AgentEvent) -> &'static str {
         AgentEvent::TextDelta { .. } => "text_delta",
         AgentEvent::TextComplete { .. } => "text_complete",
         AgentEvent::ServerToolContent { .. } => "server_tool_content",
+        AgentEvent::AssistantImageAppended { .. } => "assistant_image_appended",
         AgentEvent::ToolCallRequested { .. } => "tool_call_requested",
         AgentEvent::ToolResultReceived { .. } => "tool_result_received",
         AgentEvent::TurnCompleted { .. } => "turn_completed",
@@ -890,6 +891,45 @@ pub fn agent_event_type(event: &AgentEvent) -> &'static str {
         AgentEvent::StreamTruncated { .. } => "stream_truncated",
         AgentEvent::ToolConfigChanged { .. } => "tool_config_changed",
         AgentEvent::BackgroundJobCompleted { .. } => "background_job_completed",
+    }
+}
+
+/// Typed public event payload for a canonical assistant image block appended to history.
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct AssistantImageEvent {
+    pub image_id: crate::AssistantImageId,
+    pub blob_ref: crate::BlobRef,
+    pub media_type: crate::MediaType,
+    pub width: u32,
+    pub height: u32,
+    pub revised_prompt: crate::RevisedPromptDisposition,
+    pub meta: crate::ProviderImageMetadata,
+}
+
+impl AssistantImageEvent {
+    #[must_use]
+    pub fn from_assistant_block(block: &crate::types::AssistantBlock) -> Option<Self> {
+        match block {
+            crate::types::AssistantBlock::Image {
+                image_id,
+                blob_ref,
+                media_type,
+                width,
+                height,
+                revised_prompt,
+                meta,
+            } => Some(Self {
+                image_id: *image_id,
+                blob_ref: blob_ref.clone(),
+                media_type: media_type.clone(),
+                width: *width,
+                height: *height,
+                revised_prompt: revised_prompt.clone(),
+                meta: meta.clone(),
+            }),
+            _ => None,
+        }
     }
 }
 
@@ -1400,6 +1440,9 @@ pub enum AgentEvent {
         name: String,
         content: Value,
     },
+
+    /// Canonical assistant image block appended to transcript history.
+    AssistantImageAppended { image: AssistantImageEvent },
 
     /// Model requested a tool call
     ToolCallRequested {
@@ -2837,6 +2880,20 @@ mod tests {
             AgentEvent::TextComplete {
                 content: "done".to_string(),
             },
+            AgentEvent::AssistantImageAppended {
+                image: AssistantImageEvent {
+                    image_id: crate::AssistantImageId::new(uuid::Uuid::new_v4()),
+                    blob_ref: crate::BlobRef {
+                        blob_id: crate::BlobId::new("image-1"),
+                        media_type: "image/png".to_string(),
+                    },
+                    media_type: crate::MediaType::new("image/png"),
+                    width: 1024,
+                    height: 1024,
+                    revised_prompt: crate::RevisedPromptDisposition::NotRequested,
+                    meta: crate::ProviderImageMetadata::NotEmitted,
+                },
+            },
             AgentEvent::ToolCallRequested {
                 id: "tool-1".to_string(),
                 name: "search".to_string(),
@@ -2959,6 +3016,39 @@ mod tests {
             expected_event_count,
             "expected one distinct discriminator per covered event variant"
         );
+    }
+
+    #[test]
+    fn assistant_image_appended_event_serializes_typed_image_fact() {
+        let event = AgentEvent::AssistantImageAppended {
+            image: AssistantImageEvent {
+                image_id: crate::AssistantImageId::new(uuid::Uuid::from_u128(42)),
+                blob_ref: crate::BlobRef {
+                    blob_id: crate::BlobId::new("generated-image"),
+                    media_type: "image/png".to_string(),
+                },
+                media_type: crate::MediaType::new("image/png"),
+                width: 1024,
+                height: 1024,
+                revised_prompt: crate::RevisedPromptDisposition::NotRequested,
+                meta: crate::ProviderImageMetadata::NotEmitted,
+            },
+        };
+
+        let json = serde_json::to_value(&event).unwrap();
+        assert_eq!(json["type"], "assistant_image_appended");
+        assert_eq!(json["image"]["blob_ref"]["blob_id"], "generated-image");
+        assert_eq!(json["image"]["media_type"], "image/png");
+
+        let roundtrip: AgentEvent = serde_json::from_value(json).unwrap();
+        match roundtrip {
+            AgentEvent::AssistantImageAppended { image } => {
+                assert_eq!(image.blob_ref.blob_id.as_str(), "generated-image");
+                assert_eq!(image.width, 1024);
+                assert_eq!(image.height, 1024);
+            }
+            other => panic!("expected assistant image event, got {other:?}"),
+        }
     }
 
     #[test]

--- a/meerkat-core/src/lib.rs
+++ b/meerkat-core/src/lib.rs
@@ -155,11 +155,12 @@ pub use config_store::{
 };
 pub use error::{AgentError, ToolError};
 pub use event::{
-    AgentErrorClass, AgentErrorReport, AgentEvent, BudgetType, EventEnvelope, EventSourceIdentity,
-    ExternalToolDelta, ExternalToolDeltaPhase, ScopedAgentEvent, SkillResolutionFailureReason,
-    StreamScopeFrame, ToolCallArguments, ToolCallArgumentsError, ToolConfigChangeOperation,
-    ToolConfigChangeStatus, ToolConfigChangedPayload, VerboseEventConfig, agent_event_type,
-    compare_event_envelopes, format_verbose_event, format_verbose_event_with_config,
+    AgentErrorClass, AgentErrorReport, AgentEvent, AssistantImageEvent, BudgetType, EventEnvelope,
+    EventSourceIdentity, ExternalToolDelta, ExternalToolDeltaPhase, ScopedAgentEvent,
+    SkillResolutionFailureReason, StreamScopeFrame, ToolCallArguments, ToolCallArgumentsError,
+    ToolConfigChangeOperation, ToolConfigChangeStatus, ToolConfigChangedPayload,
+    VerboseEventConfig, agent_event_type, compare_event_envelopes, format_verbose_event,
+    format_verbose_event_with_config,
 };
 pub use event_injector::{EventInjector, EventInjectorError};
 pub use event_tap::{


### PR DESCRIPTION
## Summary
- add typed `AssistantImageEvent` and `AgentEvent::AssistantImageAppended` for canonical assistant image blocks
- emit assistant image append events for direct assistant image messages and image-generation tool effects after tool results
- keep assistant image history typed in wire history and extend the documented event catalog

## Validation
- `./scripts/repo-cargo test -p meerkat-core image`
- `./scripts/repo-cargo test -p meerkat-contracts image_generation`
- `./scripts/repo-cargo test -p meerkat-contracts assistant_image_block_remains_typed_in_wire_history`
- `./scripts/repo-cargo test -p meerkat-contracts documented_event_catalog_covers_core_agent_event_discriminators`
- `./scripts/repo-cargo test -p meerkat-tools generate_image_dispatch_commits_blob_and_emits_assistant_image_effect`
- `./scripts/repo-cargo test -p meerkat-rpc blob_get_returns_payload`
- `./scripts/repo-cargo fmt --all`
- `git diff --check`
- `make check` (BuildBuddy `afcec088-ab4b-435f-8631-36733cb1fdc4`)
- `make lint` (BuildBuddy `7fdb1d69-b379-4fc3-a6bf-82514d60af68`)
- `make test` (BuildBuddy `678586a7-304d-4684-89de-dee89baf482f`, `4c3348a6-1e04-4183-876f-adb7fde2e8a5`)

## Smoke Gate
- First local `make e2e-smoke` attempt built the BuildBuddy foundation (`8384e5df-ac62-49bf-a28c-469716ad93e6`) but failed in the local smoke runner due unrelated live mob timeouts, Linux trying to execute the macOS BuildBuddy `wasm-pack`, and later `No space left on device` while multiple sibling smoke lanes were active.
- Retry is pending after concurrent smoke lanes drain, using `/home/luka_crnkovicfriis_king_com/.cache/meerkat/tools/wasm-pack-0.14.0-linux/wasm-pack`.

Linear: LUC-501
