### PR TITLE
[codex] Enable provider web search by default

### DIFF
--- a/.github/actions/setup-buildbuddy-ci/action.yml
+++ b/.github/actions/setup-buildbuddy-ci/action.yml
@@ -12,7 +12,7 @@ runs:
   steps:
     - name: Install Rust
       if: ${{ inputs.profile == 'doctor' || inputs.profile == 'lint' || inputs.profile == 'sdk' || inputs.profile == 'rust' || inputs.profile == 'wasm' || inputs.profile == 'audit' || inputs.profile == 'full' }}
-      uses: dtolnay/rust-toolchain@stable
+      uses: dtolnay/rust-toolchain@1.94.0
 
     - name: Add wasm32 target
       if: ${{ inputs.profile == 'wasm' || inputs.profile == 'full' }}

--- a/.github/workflows/cargo.yml
+++ b/.github/workflows/cargo.yml
@@ -31,7 +31,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Install Rust
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@1.94.0
 
       - name: Cache cargo registry
         uses: Swatinem/rust-cache@v2
@@ -62,6 +62,8 @@ jobs:
 
       - name: Install cargo-machete
         uses: taiki-e/install-action@cargo-machete
+        env:
+          HOME: ${{ runner.temp }}/install-action-home-${{ github.job }}
 
       - name: Check for unused dependencies
         run: ./scripts/repo-cargo machete --with-metadata
@@ -74,7 +76,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Install Rust
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@1.94.0
 
       - name: Cache cargo registry
         uses: Swatinem/rust-cache@v2
@@ -144,7 +146,7 @@ jobs:
 
       - name: Install Rust
         if: ${{ steps.machine-changes.outputs.changed == 'true' }}
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@1.94.0
 
       - name: Cache cargo registry
         if: ${{ steps.machine-changes.outputs.changed == 'true' }}
@@ -204,7 +206,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Install Rust
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@1.94.0
 
       - name: Cache cargo registry
         uses: Swatinem/rust-cache@v2
@@ -228,7 +230,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Install Rust
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@1.94.0
 
       - name: Cache cargo registry
         uses: Swatinem/rust-cache@v2
@@ -246,7 +248,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Install Rust
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@1.94.0
 
       - name: Add wasm32 target
         run: rustup target add wasm32-unknown-unknown
@@ -260,6 +262,9 @@ jobs:
         uses: taiki-e/install-action@v2
         with:
           tool: wasm-pack
+          checksum: false
+        env:
+          HOME: ${{ runner.temp }}/install-action-home-${{ github.job }}
 
       - name: Build browser-contract tests
         env:
@@ -309,13 +314,15 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Install Rust
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@1.94.0
 
       - name: Cache cargo registry
         uses: Swatinem/rust-cache@v2
 
       - name: Install nextest
         uses: taiki-e/install-action@nextest
+        env:
+          HOME: ${{ runner.temp }}/install-action-home-${{ github.job }}
 
       - name: Unit test lane
         run: ./scripts/repo-cargo unit
@@ -328,7 +335,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Install Rust
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@1.94.0
 
       - name: Add wasm32 target
         run: rustup target add wasm32-unknown-unknown
@@ -342,9 +349,14 @@ jobs:
         uses: taiki-e/install-action@v2
         with:
           tool: wasm-pack
+          checksum: false
+        env:
+          HOME: ${{ runner.temp }}/install-action-home-${{ github.job }}
 
       - name: Install nextest
         uses: taiki-e/install-action@nextest
+        env:
+          HOME: ${{ runner.temp }}/install-action-home-${{ github.job }}
 
       - name: Integration-fast lane
         run: ./scripts/repo-cargo int
@@ -357,7 +369,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Install Rust
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@1.94.0
 
       - name: Cache cargo registry
         uses: Swatinem/rust-cache@v2
@@ -366,6 +378,8 @@ jobs:
 
       - name: Install nextest
         uses: taiki-e/install-action@nextest
+        env:
+          HOME: ${{ runner.temp }}/install-action-home-${{ github.job }}
 
       - name: Run e2e-fast lane
         run: ./scripts/repo-cargo e2e-fast
@@ -378,7 +392,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Install Rust
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@1.94.0
 
       - name: Add wasm32 target
         run: rustup target add wasm32-unknown-unknown
@@ -392,9 +406,14 @@ jobs:
         uses: taiki-e/install-action@v2
         with:
           tool: wasm-pack
+          checksum: false
+        env:
+          HOME: ${{ runner.temp }}/install-action-home-${{ github.job }}
 
       - name: Install nextest
         uses: taiki-e/install-action@nextest
+        env:
+          HOME: ${{ runner.temp }}/install-action-home-${{ github.job }}
 
       - name: Run e2e-system lane
         run: ./scripts/repo-cargo e2e-system
@@ -407,7 +426,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Install Rust
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@1.94.0
 
       - name: Cache cargo registry
         uses: Swatinem/rust-cache@v2
@@ -416,6 +435,8 @@ jobs:
 
       - name: Install nextest
         uses: taiki-e/install-action@nextest
+        env:
+          HOME: ${{ runner.temp }}/install-action-home-${{ github.job }}
 
       - name: Minimal build checks
         run: |
@@ -434,7 +455,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Install Rust
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@1.94.0
 
       - name: Cache cargo registry
         uses: Swatinem/rust-cache@v2
@@ -443,6 +464,8 @@ jobs:
 
       - name: Install nextest
         uses: taiki-e/install-action@nextest
+        env:
+          HOME: ${{ runner.temp }}/install-action-home-${{ github.job }}
 
       - name: Library crate feature combinations
         run: |
@@ -464,7 +487,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Install Rust
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@1.94.0
 
       - name: Cache cargo registry
         uses: Swatinem/rust-cache@v2
@@ -485,7 +508,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Install Rust
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@1.94.0
 
       - name: Add wasm32 target
         run: rustup target add wasm32-unknown-unknown

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -248,7 +248,7 @@ This is a breaking release. Wire contracts that previously accepted free-form st
 - `SelfHostedModelConfig.supports_web_search` (default `false`) for self-hosted model opt-in.
 - Non-persisted `AgentConfig.provider_tool_defaults` re-derived on every build (including resume) from current config + profile.
 - Per-turn merge via RFC 7396 merge-patch in `state.rs`; extraction turns strip tool keys.
-- Opt-out: `provider_tools.*.web_search = false` in config, or `provider_params: {"web_search": null}` per-request.
+- Opt-out: `provider_tools.anthropic.web_search = false`, `provider_tools.openai.web_search = false`, or `provider_tools.gemini.google_search = false` in config; `rkat run --no-web-search`; or the provider-native null key in `provider_params` per request.
 
 #### Realm-scoped mob profiles
 - `RealmProfileStore` with `InMemoryRealmProfileStore` and `SqliteRealmProfileStore` for realm-local reusable profile definitions.

--- a/MODULE.bazel.lock
+++ b/MODULE.bazel.lock
@@ -544,7 +544,7 @@
           "FILE:@@//test-fixtures/surface-build-fixtures/Cargo.toml 593af70f4a0efde1688789cb5e7d486825efe4b03156e6b75656cf44ea944ba1",
           "FILE:@@//test-fixtures/machine-dsl-tests/Cargo.toml bc9c8bd79e3d4529e12b6495c1ddf79d02020782b06e265539f7dca351438ccd",
           "FILE:@@//xtask/Cargo.toml e3212c96185cd3e09f10115934760c0f29cfd6a1b61fa28ceb55c10092b2bc65",
-          "FILE:@@//vendor/oai-rt-rs/Cargo.toml 5325298146e1f43afb519170283663b96ddafe2b43c65d64be3ab6b92516bc42"
+          "FILE:@@//vendor/oai-rt-rs/Cargo.toml a20231e72abb794e301ab3488bc7c1aa1ab736fd17f4a438c79f7e99383c7d8e"
         ],
         "generatedRepoSpecs": {
           "crates": {

--- a/README.md
+++ b/README.md
@@ -441,6 +441,9 @@ web_search = true
 
 [provider_tools.openai]
 web_search = true
+
+[provider_tools.gemini]
+google_search = true
 ```
 
 See the [configuration guide](https://docs.rkat.ai/concepts/configuration), [realms](https://docs.rkat.ai/concepts/realms), [providers](https://docs.rkat.ai/concepts/providers), and [auth guide](https://docs.rkat.ai/guides/auth) for the full reference.

--- a/docs/cli/commands.mdx
+++ b/docs/cli/commands.mdx
@@ -111,6 +111,7 @@ rkat run --yolo --param temperature=0.2 "take the gloves off"
 - `--json`
 - `-s, --stream`
 - `--no-stream`
+- `--no-web-search`
 - `--resume[=<SESSION>]`
 - `--skill <PATH_OR_ID>` repeatable
 - `-d, --max-duration <DURATION>`

--- a/docs/concepts/providers.mdx
+++ b/docs/concepts/providers.mdx
@@ -144,6 +144,10 @@ meerkat = { version = "0.6.0", features = ["all-providers", "jsonl-store"] }
 
 Provider-specific options can be passed via the `--param` CLI flag or `provider_params` in the SDK:
 
+Provider-native web search is on by default for catalog models that support it.
+Disable it in config with the matching `provider_tools.<provider>` search toggle,
+or for a single CLI run with `rkat run --no-web-search "..."`.
+
 <Tabs>
   <Tab title="Anthropic">
     | Parameter | Description |

--- a/docs/reference/capability-matrix.mdx
+++ b/docs/reference/capability-matrix.mdx
@@ -106,9 +106,11 @@ Web search is enabled by default for all catalog models with `supports_web_searc
 | Self-hosted | Not wired (v1) | `SelfHostedModelConfig.supports_web_search` | `false` |
 
 **Opt-out:**
-- Config-level: `[provider_tools.anthropic] web_search = false`
-- Per-request: `provider_params: {"web_search": null}` (RFC 7396 null removal)
-- Per-request: `provider_params: {"web_search": false}` (treated as disable)
+- Config-level: set the matching config key from the table above to `false`
+- CLI: `rkat run --no-web-search "..."`.
+- Per-request Anthropic/OpenAI: `provider_params: {"web_search": null}` (RFC 7396 null removal)
+- Per-request Gemini: `provider_params: {"google_search": null}` (RFC 7396 null removal)
+- Per-request boolean: `false` for the provider-native search key is treated as disable
 
 **Resume behavior:** Tool defaults are re-derived on every build (including resume) from current config and model profile. Config changes take effect immediately on resumed sessions. Explicit `provider_params` overrides are persisted in `SessionMetadata`.
 

--- a/meerkat-cli/src/main.rs
+++ b/meerkat-cli/src/main.rs
@@ -92,7 +92,7 @@ const CLI_ABOUT: &str = "Run agent tasks and manage local Meerkat surfaces from 
 const ROOT_AFTER_HELP: &str = "Command groups:\n  Runtime:      run, help, realtime\n  Realm config: init, config, realm\n  Utility:      session, blob, models, capabilities, doctor\n\nAdditional commands appear when their supporting capabilities are compiled in.\n\nExamples:\n  rkat \"summarize this repository\"\n  rkat help \"How do I add an mcp server?\"\n  cat story.txt | rkat \"summarize the story\"\n  git diff | rkat run \"review these changes\"\n  tail -f app.log | rkat run --stdin lines \"watch for incidents\"\n  rkat run -t workspace \"fix the failing test\"\n\nUse `<binary> <command> -h` for the basic view and `<binary> <command> --help` for all options.";
 const HELP_AFTER_HELP: &str = "Examples:\n  rkat help \"How do I add an mcp server and schedule to remove it in 30 minutes\"\n  rkat help \"Use gemini with my vertex auth, load ~/codex/skills\" --prompt \"Write a match-3 game in Erlang\"";
 
-const RUN_AFTER_HELP: &str = "Examples:\n  rkat run \"summarize this repository\"\n  cat story.txt | rkat run \"summarize the story\"\n  git diff | rkat run --json \"review these changes\"\n  rkat run --resume \"keep going\"\n  rkat run --resume ~2 \"pick this thread back up\"\n  tail -f app.log | rkat run --stdin lines \"watch for incidents\"\n  rkat run -t workspace \"fix the failing test\"\n\nDefaults:\n  - `--tools safe`\n  - stream on in a TTY, off in pipes/scripts\n  - piped stdin is read as blob context unless `--stdin lines` is set";
+const RUN_AFTER_HELP: &str = "Examples:\n  rkat run \"summarize this repository\"\n  cat story.txt | rkat run \"summarize the story\"\n  git diff | rkat run --json \"review these changes\"\n  rkat run --resume \"keep going\"\n  rkat run --resume ~2 \"pick this thread back up\"\n  tail -f app.log | rkat run --stdin lines \"watch for incidents\"\n  rkat run -t workspace \"fix the failing test\"\n\nDefaults:\n  - `--tools safe`\n  - provider-native web search on for supporting models; use `--no-web-search` to disable\n  - stream on in a TTY, off in pipes/scripts\n  - piped stdin is read as blob context unless `--stdin lines` is set";
 
 const DEFAULT_TRACE_FILTER: &str = "off";
 const VERBOSE_TRACE_FILTER: &str = "info";
@@ -1141,6 +1141,10 @@ enum Commands {
         #[arg(long, help_heading = "Common options")]
         no_stream: bool,
 
+        /// Disable provider-native web search for this run.
+        #[arg(long, help_heading = "Common options")]
+        no_web_search: bool,
+
         /// Provider-specific parameter (KEY=VALUE). Can be repeated.
         #[arg(
             long = "param",
@@ -2116,6 +2120,7 @@ async fn main() -> anyhow::Result<ExitCode> {
             json,
             stream,
             no_stream,
+            no_web_search,
             params,
             provider_params_json,
             output_schema,
@@ -2168,6 +2173,7 @@ async fn main() -> anyhow::Result<ExitCode> {
                 json,
                 stream,
                 no_stream,
+                no_web_search,
                 params,
                 provider_params_json,
                 output_schema,
@@ -2321,6 +2327,7 @@ async fn handle_help_command(
         json,
         stream,
         no_stream,
+        false,
         Vec::new(),
         None,
         None,
@@ -2358,6 +2365,7 @@ async fn handle_run_command(
     json: bool,
     stream: bool,
     no_stream: bool,
+    no_web_search: bool,
     params: Vec<String>,
     provider_params_json: Option<String>,
     output_schema: Option<String>,
@@ -2400,6 +2408,7 @@ async fn handle_run_command(
             output,
             params,
             provider_params_json,
+            no_web_search,
             stream,
             no_stream,
             stdin,
@@ -2459,6 +2468,11 @@ async fn handle_run_command(
     match (duration, provider_params, provider_params_json) {
         (Ok(dur), Ok(parsed_params), Ok(parsed_params_json)) => {
             let merged_provider_params = merge_provider_params(parsed_params, parsed_params_json)?;
+            let merged_provider_params = apply_no_web_search_provider_param(
+                resolved_provider,
+                merged_provider_params,
+                no_web_search,
+            )?;
             let mut limits = config.budget_limits();
             if let Some(max_duration) = dur {
                 limits.max_duration = Some(max_duration);
@@ -2570,6 +2584,60 @@ fn merge_provider_params(
             "provider params must be JSON objects after parsing"
         )),
     }
+}
+
+fn provider_web_search_param_key(provider: Provider) -> Option<&'static str> {
+    match provider {
+        Provider::Anthropic | Provider::Openai => Some("web_search"),
+        Provider::Gemini => Some("google_search"),
+        Provider::SelfHosted => None,
+    }
+}
+
+fn apply_no_web_search_provider_param(
+    provider: Provider,
+    provider_params: Option<serde_json::Value>,
+    no_web_search: bool,
+) -> anyhow::Result<Option<serde_json::Value>> {
+    if !no_web_search {
+        return Ok(provider_params);
+    }
+
+    let Some(key) = provider_web_search_param_key(provider) else {
+        return Ok(provider_params);
+    };
+
+    let mut opt_out = serde_json::Map::new();
+    opt_out.insert(key.to_string(), serde_json::Value::Null);
+    let opt_out = Some(serde_json::Value::Object(opt_out));
+    merge_provider_params(opt_out, provider_params)
+}
+
+fn apply_no_web_search_resume_provider_params(
+    provider: Option<Provider>,
+    model_override_provider: Option<Provider>,
+    stored_provider: meerkat_core::Provider,
+    stored_provider_params: Option<&serde_json::Value>,
+    merged_provider_params: &mut Option<serde_json::Value>,
+    no_web_search: bool,
+) -> anyhow::Result<()> {
+    if !no_web_search {
+        return Ok(());
+    }
+
+    let Some(web_search_provider) = provider
+        .or(model_override_provider)
+        .or_else(|| Provider::from_core(stored_provider))
+    else {
+        return Ok(());
+    };
+
+    let base_params = merged_provider_params
+        .take()
+        .or_else(|| stored_provider_params.cloned());
+    *merged_provider_params =
+        apply_no_web_search_provider_param(web_search_provider, base_params, true)?;
+    Ok(())
 }
 
 fn looks_like_path(raw: &str) -> bool {
@@ -7110,6 +7178,7 @@ async fn resume_session(
     output: String,
     params: Vec<String>,
     provider_params_json: Option<String>,
+    no_web_search: bool,
     stream: bool,
     no_stream: bool,
     stdin: StdinMode,
@@ -7146,6 +7215,7 @@ async fn resume_session(
         output,
         params,
         provider_params_json,
+        no_web_search,
         stream,
         no_stream,
         stdin,
@@ -7183,6 +7253,7 @@ async fn resume_session_with_llm_override(
     output: String,
     params: Vec<String>,
     provider_params_json: Option<String>,
+    no_web_search: bool,
     stream: bool,
     no_stream: bool,
     stdin: StdinMode,
@@ -7218,6 +7289,7 @@ async fn resume_session_with_llm_override(
             output,
             params,
             provider_params_json,
+            no_web_search,
             stream,
             no_stream,
             stdin,
@@ -7256,7 +7328,7 @@ async fn resume_session_with_llm_override(
         let stream = resolve_stream_enabled(stream, no_stream, !json_output)?;
         let parsed_params = parse_provider_params(&params)?;
         let parsed_params_json = parse_provider_params_json(provider_params_json)?;
-        let merged_provider_params = merge_provider_params(parsed_params, parsed_params_json)?;
+        let mut merged_provider_params = merge_provider_params(parsed_params, parsed_params_json)?;
         let parsed_output_schema = output_schema
             .as_ref()
             .map(|s| parse_output_schema(s))
@@ -7305,11 +7377,23 @@ async fn resume_session_with_llm_override(
         } else {
             model
         };
-        if provider.is_none()
-            && let Some(model_override) = model_override.as_deref()
-        {
-            let _ = resolve_cli_provider(&config, model_override, None)?;
-        }
+        let model_override_provider = if provider.is_none() {
+            model_override
+                .as_deref()
+                .map(|model_override| resolve_cli_provider(&config, model_override, None))
+                .transpose()?
+        } else {
+            None
+        };
+
+        apply_no_web_search_resume_provider_params(
+            provider,
+            model_override_provider,
+            stored_metadata.provider,
+            stored_metadata.provider_params.as_ref(),
+            &mut merged_provider_params,
+            no_web_search,
+        )?;
 
         let mut limits = build_state
             .budget_limits
@@ -12808,6 +12892,7 @@ default_model = "gemma"
             false,
             false,
             true,
+            false,
             Vec::new(),
             None,
             None,
@@ -13048,6 +13133,7 @@ default_model = "gemma"
             "temperature=0.2",
             "--params-json",
             r#"{"reasoning":{"effort":"high"}}"#,
+            "--no-web-search",
             "--schema",
             "./schema.json",
             "--json",
@@ -13071,6 +13157,7 @@ default_model = "gemma"
                 skills,
                 params,
                 provider_params_json,
+                no_web_search,
                 output_schema,
                 json,
                 stdin,
@@ -13089,6 +13176,7 @@ default_model = "gemma"
                     provider_params_json.as_deref(),
                     Some(r#"{"reasoning":{"effort":"high"}}"#)
                 );
+                assert!(no_web_search);
                 assert_eq!(output_schema.as_deref(), Some("./schema.json"));
                 assert!(json);
                 assert!(matches!(stdin, StdinMode::Lines));
@@ -15347,6 +15435,102 @@ capabilities = ["definitely_missing_capability"]
         let result = parse_provider_params(&params)?;
         let json = result.ok_or("missing result")?;
         assert_eq!(json["reasoning_effort"], "high");
+        Ok(())
+    }
+
+    #[test]
+    fn test_no_web_search_provider_param_uses_provider_native_key()
+    -> Result<(), Box<dyn std::error::Error>> {
+        let openai = apply_no_web_search_provider_param(
+            Provider::Openai,
+            Some(serde_json::json!({
+                "reasoning_effort": "high",
+                "web_search": {"type": "web_search"}
+            })),
+            true,
+        )?
+        .expect("OpenAI opt-out params");
+        assert_eq!(openai["reasoning_effort"], "high");
+        assert!(
+            openai
+                .get("web_search")
+                .is_some_and(serde_json::Value::is_null)
+        );
+
+        let gemini = apply_no_web_search_provider_param(Provider::Gemini, None, true)?
+            .expect("Gemini opt-out params");
+        assert!(
+            gemini
+                .get("google_search")
+                .is_some_and(serde_json::Value::is_null)
+        );
+        assert!(gemini.get("web_search").is_none());
+
+        let self_hosted = apply_no_web_search_provider_param(Provider::SelfHosted, None, true)?;
+        assert!(self_hosted.is_none());
+        Ok(())
+    }
+
+    #[test]
+    fn test_no_web_search_resume_params_preserve_resume_precedence()
+    -> Result<(), Box<dyn std::error::Error>> {
+        let stored = serde_json::json!({
+            "temperature": 0.1,
+            "web_search": {"type": "web_search"}
+        });
+        let mut inherited = None;
+        apply_no_web_search_resume_provider_params(
+            None,
+            None,
+            meerkat_core::Provider::OpenAI,
+            Some(&stored),
+            &mut inherited,
+            true,
+        )?;
+        let inherited = inherited.expect("stored params plus opt-out");
+        assert_eq!(inherited["temperature"], 0.1);
+        assert!(
+            inherited
+                .get("web_search")
+                .is_some_and(serde_json::Value::is_null)
+        );
+
+        let mut explicit = Some(serde_json::json!({"reasoning_effort": "high"}));
+        apply_no_web_search_resume_provider_params(
+            None,
+            None,
+            meerkat_core::Provider::OpenAI,
+            Some(&stored),
+            &mut explicit,
+            true,
+        )?;
+        let explicit = explicit.expect("explicit params plus opt-out");
+        assert_eq!(explicit["reasoning_effort"], "high");
+        assert!(explicit.get("temperature").is_none());
+        assert!(
+            explicit
+                .get("web_search")
+                .is_some_and(serde_json::Value::is_null)
+        );
+
+        let mut model_override = Some(serde_json::json!({"top_p": 0.8}));
+        apply_no_web_search_resume_provider_params(
+            None,
+            Some(Provider::Gemini),
+            meerkat_core::Provider::OpenAI,
+            Some(&stored),
+            &mut model_override,
+            true,
+        )?;
+        let model_override = model_override.expect("model override params plus opt-out");
+        assert_eq!(model_override["top_p"], 0.8);
+        assert!(model_override.get("web_search").is_none());
+        assert!(
+            model_override
+                .get("google_search")
+                .is_some_and(serde_json::Value::is_null)
+        );
+
         Ok(())
     }
 

--- a/meerkat-core/src/config_template.toml
+++ b/meerkat-core/src/config_template.toml
@@ -40,7 +40,9 @@ background_max_concurrency = 32
 
 # Provider-native tool defaults. Controls whether provider web search tools
 # are injected by default for models that support them. Set to false to disable.
-# Per-request opt-out: send provider_params: {"web_search": null}.
+# CLI opt-out: rkat run --no-web-search ...
+# Per-request opt-out: send provider_params: {"web_search": null} for
+# Anthropic/OpenAI or {"google_search": null} for Gemini.
 [provider_tools.anthropic]
 web_search = true
 

--- a/meerkat-mob-mcp/src/lib.rs
+++ b/meerkat-mob-mcp/src/lib.rs
@@ -1020,6 +1020,11 @@ impl MobMcpState {
         handling_mode: HandlingMode,
         render_metadata: Option<RenderMetadata>,
     ) -> Result<meerkat_mob::MemberDeliveryReceipt, MobError> {
+        if matches!(handling_mode, HandlingMode::Steer) {
+            return Err(MobError::Internal(
+                "handling_mode Steer requires a runtime-backed surface".to_string(),
+            ));
+        }
         self.handle_for(mob_id)
             .await?
             .member(&identity)

--- a/meerkat-mob/src/runtime/provisioner.rs
+++ b/meerkat-mob/src/runtime/provisioner.rs
@@ -903,13 +903,15 @@ impl CoreExecutor for MobSessionRuntimeExecutor {
             .state
             .take_turn_context_for_inputs(&contributing_input_ids)
             .await;
+        let runtime_render_metadata = primitive
+            .turn_metadata()
+            .and_then(|meta| meta.render_metadata.clone());
         // The runtime has already resolved handling_mode routing (Queue vs
         // Steer) before the executor fires. The session-service start_turn
         // path only supports Queue — Steer semantics are realized by the
-        // runtime ingress, not by the executor. Similarly, render_metadata
-        // is runtime-owned and must not leak into the session-service path.
-        // Strip both from turn_metadata to prevent the session extracting
-        // them from metadata and overriding the flattened Queue value.
+        // runtime ingress, not by the executor. Render metadata is carried on
+        // the flattened request while stripped from turn_metadata so session
+        // implementations cannot re-extract metadata and override the request.
         let executor_turn_metadata = primitive.turn_metadata().map(|meta| {
             let mut m = meta.clone();
             m.handling_mode = Some(meerkat_core::types::HandlingMode::Queue);
@@ -919,7 +921,7 @@ impl CoreExecutor for MobSessionRuntimeExecutor {
         let req = StartTurnRequest {
             prompt: primitive.extract_content_input(),
             system_prompt: None,
-            render_metadata: None,
+            render_metadata: runtime_render_metadata,
             handling_mode: meerkat_core::types::HandlingMode::Queue,
             event_tx: queued_context.map(|context| context.event_tx),
             skill_references: primitive

--- a/meerkat/src/help_content/cli_reference_skill.md
+++ b/meerkat/src/help_content/cli_reference_skill.md
@@ -77,6 +77,7 @@ Common options:
 --json                          # alias for --output json
 -s, --stream
 --no-stream
+--no-web-search                 # disable provider-native web search for this run
 --skill <PATH_OR_ID>            # repeatable
 -t, --tools <safe|workspace|full|none>
 --yolo                          # alias for --tools full
@@ -111,6 +112,7 @@ Resume targets: full UUID, short UUID prefix, `realm:<uuid>`, `last`, `~`,
 Defaults:
 
 - `--tools safe`
+- provider-native web search on for supporting models; use `--no-web-search` to disable
 - stream on in a TTY, off in pipes/scripts
 - piped stdin is blob context unless `--stdin lines`
 

--- a/scripts/repo-cargo
+++ b/scripts/repo-cargo
@@ -17,8 +17,41 @@ hash_path() {
   fi
 }
 
+sanitize_cache_key() {
+  local raw="${1:-}"
+  local key
+  key="$(printf '%s' "${raw}" | LC_ALL=C tr -c 'A-Za-z0-9._@+-' '-')"
+  printf '%s' "${key:-default}"
+}
+
 repo_slug="$(basename "${repo_root}")"
 repo_key="${repo_slug}-$(hash_path "${git_common_dir}")"
+target_cache_schema="v4"
+toolchain_spec=""
+toolchain_key="${MEERKAT_RUST_TOOLCHAIN_ID:-}"
+
+if [[ -n "${RUSTUP_TOOLCHAIN:-}" ]]; then
+  toolchain_spec="${RUSTUP_TOOLCHAIN}"
+  toolchain_key="${toolchain_key:-${toolchain_spec}}"
+elif [[ -f "${repo_root}/rust-toolchain.toml" ]]; then
+  toolchain_spec="$(awk -F '"' '/^[[:space:]]*channel[[:space:]]*=/ { print $2; exit }' "${repo_root}/rust-toolchain.toml")"
+  toolchain_key="${toolchain_key:-${toolchain_spec}}"
+elif [[ -f "${repo_root}/rust-toolchain" ]]; then
+  toolchain_spec="$(sed -n 's/#.*//; /^[[:space:]]*$/d; s/^[[:space:]]*//; s/[[:space:]]*$//; p; q' "${repo_root}/rust-toolchain")"
+  toolchain_key="${toolchain_key:-${toolchain_spec}}"
+fi
+
+if [[ -n "${toolchain_spec}" ]] && command -v rustup >/dev/null 2>&1; then
+  rustc_verbose="$(rustup run "${toolchain_spec}" rustc -Vv 2>/dev/null || true)"
+  if [[ -n "${rustc_verbose}" ]]; then
+    rustc_release="$(awk -F ': ' '$1 == "release" { print $2; exit }' <<<"${rustc_verbose}")"
+    rustc_host="$(awk -F ': ' '$1 == "host" { print $2; exit }' <<<"${rustc_verbose}")"
+    rustc_commit="$(awk -F ': ' '$1 == "commit-hash" { print substr($2, 1, 10); exit }' <<<"${rustc_verbose}")"
+    toolchain_key="${rustc_release:-${toolchain_key}}-${rustc_host:-unknown}-${rustc_commit:-unknown}"
+  fi
+fi
+
+toolchain_key="$(sanitize_cache_key "${toolchain_key:-default}")"
 
 if [[ -n "${RUST_LANE_ID:-}" ]]; then
   lane_key="${RUST_LANE_ID}"
@@ -26,10 +59,17 @@ elif [[ -n "${MEERKAT_AGENT_LANE:-}" ]]; then
   lane_key="${MEERKAT_AGENT_LANE}"
 elif [[ -n "${CODEX_AGENT_ID:-}" ]]; then
   lane_key="${CODEX_AGENT_ID}"
+elif [[ -n "${GITHUB_JOB:-}" ]]; then
+  if [[ -n "${GITHUB_RUN_ID:-}" ]]; then
+    lane_key="gha-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT:-1}-${GITHUB_JOB}"
+  else
+    lane_key="gha-${GITHUB_JOB}"
+  fi
 else
   worktree_name="$(basename "${worktree_root}")"
   lane_key="${worktree_name}-$(hash_path "${worktree_root}")"
 fi
+lane_key="$(sanitize_cache_key "${lane_key}")"
 
 if [[ "$(uname -s)" == "Darwin" ]]; then
   cache_root="${HOME}/Library/Caches/rust-workspaces"
@@ -37,16 +77,37 @@ else
   cache_root="${XDG_CACHE_HOME:-${HOME}/.cache}/rust-workspaces"
 fi
 
+target_dir_was_set=false
+if [[ -n "${CARGO_TARGET_DIR:-}" ]]; then
+  target_dir_was_set=true
+fi
 export CARGO_HOME="${CARGO_HOME:-${cache_root}/${repo_key}/cargo-home}"
-export CARGO_TARGET_DIR="${CARGO_TARGET_DIR:-${cache_root}/${repo_key}/targets/${lane_key}}"
+export CARGO_TARGET_DIR="${CARGO_TARGET_DIR:-${cache_root}/${repo_key}/targets/${target_cache_schema}/${toolchain_key}/${lane_key}}"
 
 mkdir -p "${CARGO_HOME}" "${CARGO_TARGET_DIR}"
+
+if [[ "${GITHUB_ACTIONS:-}" == "true" && "${target_dir_was_set}" == "false" ]]; then
+  if [[ "${CARGO_TARGET_DIR}" == "${repo_root}"* ]]; then
+    echo "error: refusing to clean a Cargo target directory inside the repo tree" >&2
+    exit 1
+  fi
+  target_marker="${CARGO_TARGET_DIR}/.repo-cargo-toolchain"
+  target_marker_value="schema=${target_cache_schema}"$'\n'"toolchain=${toolchain_key}"$'\n'
+  if [[ ! -f "${target_marker}" ]] || [[ "$(cat "${target_marker}")"$'\n' != "${target_marker_value}" ]]; then
+    rm -rf "${CARGO_TARGET_DIR}"
+    mkdir -p "${CARGO_TARGET_DIR}"
+    printf '%s' "${target_marker_value}" >"${target_marker}"
+  fi
+fi
 
 if [[ "${1-}" == "--print-env" ]]; then
   cat <<EOF
 repo_root=${repo_root}
 workspace_root=${workspace_root}
 repo_key=${repo_key}
+target_cache_schema=${target_cache_schema}
+toolchain_spec=${toolchain_spec}
+toolchain_key=${toolchain_key}
 lane_key=${lane_key}
 CARGO_HOME=${CARGO_HOME}
 CARGO_TARGET_DIR=${CARGO_TARGET_DIR}
@@ -66,6 +127,9 @@ doctor=ok
 repo_root=${repo_root}
 workspace_root=${workspace_root}
 repo_key=${repo_key}
+target_cache_schema=${target_cache_schema}
+toolchain_spec=${toolchain_spec}
+toolchain_key=${toolchain_key}
 lane_key=${lane_key}
 CARGO_HOME=${CARGO_HOME}
 CARGO_TARGET_DIR=${CARGO_TARGET_DIR}
@@ -76,11 +140,13 @@ fi
 cd "${workspace_root}"
 
 if [[ -n "${CARGO_BIN:-}" ]]; then
-  cargo_cmd="${CARGO_BIN}"
+  cargo_cmd=("${CARGO_BIN}")
+elif [[ -n "${toolchain_spec}" ]] && command -v rustup >/dev/null 2>&1; then
+  cargo_cmd=(rustup run "${toolchain_spec}" cargo)
 elif command -v cargo >/dev/null 2>&1; then
-  cargo_cmd="$(command -v cargo)"
+  cargo_cmd=("$(command -v cargo)")
 elif [[ -x "${HOME}/.cargo/bin/cargo" ]]; then
-  cargo_cmd="${HOME}/.cargo/bin/cargo"
+  cargo_cmd=("${HOME}/.cargo/bin/cargo")
   export PATH="${HOME}/.cargo/bin:${PATH}"
 else
   cat >&2 <<'EOF'
@@ -92,4 +158,4 @@ EOF
   exit 127
 fi
 
-exec "${cargo_cmd}" "$@"
+exec "${cargo_cmd[@]}" "$@"

--- a/scripts/rust-lane-doctor
+++ b/scripts/rust-lane-doctor
@@ -66,6 +66,14 @@ else
   bad "CODEX_AGENT_ID was not used as the default Cargo lane"
 fi
 
+github_lane_env="$(GITHUB_JOB=fmt-lint GITHUB_RUN_ID=12345 GITHUB_RUN_ATTEMPT=2 ./scripts/repo-cargo --print-env)"
+github_lane="$(value_from_env lane_key <<<"${github_lane_env}")"
+if [[ "${github_lane}" == "gha-12345-2-fmt-lint" ]]; then
+  pass "GitHub Actions target lanes are isolated per run attempt"
+else
+  bad "GitHub Actions target lanes do not include the run attempt"
+fi
+
 if [[ "${lane_a_home}" == "${lane_b_home}" ]]; then
   pass "Cargo home stays shared per repository"
 else
@@ -137,6 +145,17 @@ if [[ -n "${raw_cargo_workflow_hits}" ]]; then
   printf '%s\n' "${raw_cargo_workflow_hits}" >&2
 else
   pass "GitHub workflow Rust entrypoints use the repo Cargo wrapper"
+fi
+
+rust_channel="$(awk -F '"' '/^[[:space:]]*channel[[:space:]]*=/ { print $2; exit }' rust-toolchain.toml)"
+if [[ -n "${rust_channel}" ]] &&
+  grep -Fq "dtolnay/rust-toolchain@${rust_channel}" .github/workflows/cargo.yml &&
+  grep -Fq "dtolnay/rust-toolchain@${rust_channel}" .github/actions/setup-buildbuddy-ci/action.yml &&
+  ! grep -Fq 'dtolnay/rust-toolchain@stable' .github/workflows/cargo.yml &&
+  ! grep -Fq 'dtolnay/rust-toolchain@stable' .github/actions/setup-buildbuddy-ci/action.yml; then
+  pass "Cargo and BuildBuddy CI install the pinned Rust toolchain"
+else
+  bad "Cargo or BuildBuddy CI Rust toolchain does not match rust-toolchain.toml"
 fi
 
 if grep -q 'CARGO_HOME: /tmp/meerkat-cargo-home' .github/workflows/cargo.yml &&

--- a/sdks/python/tests/test_types.py
+++ b/sdks/python/tests/test_types.py
@@ -2712,10 +2712,10 @@ async def test_realtime_wrappers_and_channel_scaffold() -> None:
     scoped_capabilities = await session_channel.capabilities()
 
     assert open_info.default_protocol_version == REALTIME_PROTOCOL_VERSION
-    assert status.status["state"] == "opening"
+    assert status.status.state == "opening"
     assert capabilities.capabilities["turning_modes"] == ["provider_managed"]
     assert scoped_open_info.open_token == "token-1"
-    assert scoped_status.status["state"] == "opening"
+    assert scoped_status.status.state == "opening"
     assert scoped_capabilities.capabilities["input_kinds"] == ["text", "audio"]
     assert [method for method, _ in calls] == [
         "realtime/open_info",
@@ -2805,7 +2805,7 @@ async def test_realtime_channel_mob_member_builds_mob_member_wire_target() -> No
     # status() and capabilities() also send the MobMember target with
     # no `mob/member_status` pre-resolve round-trip.
     status_result = await member_channel.status()
-    assert status_result.status["state"] == "opening"
+    assert status_result.status.state == "opening"
     await member_channel.capabilities()
 
     # Call order encodes the new contract: only `realtime/*` calls


### PR DESCRIPTION
## Summary

- Keep provider-native web search enabled by default for Anthropic, OpenAI, and Gemini models that support it.
- Add `rkat run --no-web-search` as a first-class CLI opt-out for new runs and resumed sessions.
- Translate the CLI opt-out to provider-native request keys: `web_search: null` for Anthropic/OpenAI and `google_search: null` for Gemini.
- Update the config template, CLI help, README, changelog, and provider/capability docs to describe default-on behavior and opt-out paths.

## Why

Config should be the first source of truth. When config does not disable provider-native search, supported models should get search by default, while users still have an explicit per-run escape hatch.

## Validation

- `./scripts/repo-cargo test -p rkat no_web_search -- --nocapture`
- `./scripts/repo-cargo test -p rkat test_run_cli_surface_parses_current_flags -- --nocapture`
- `make fmt-check`
- `./scripts/repo-cargo check -p rkat --bins`
- `git diff --check`
- Pre-push hooks: hardcoded secrets, trailing whitespace, EOF, TOML, merge conflicts, large files, cargo fmt, changed-crates clippy, machine codegen/verify, generated-header audit, bridge guard, workspace deterministic gate