### PR TITLE
Add blob file tools and OpenAI replay continuity

### DIFF
--- a/docs/concepts/tools.mdx
+++ b/docs/concepts/tools.mdx
@@ -75,7 +75,7 @@ Meerkat ships with tool categories you enable per-agent. Nothing is on by defaul
 
 | Category | Tools | Enable with |
 |----------|-------|-------------|
-| Builtins | `task_create`, `task_list`, `task_get`, `task_update`, `datetime`, `apply_patch`, `view_image`, `generate_image` | `enable_builtins` |
+| Builtins | `task_create`, `task_list`, `task_get`, `task_update`, `datetime`, `apply_patch`, `view_image`, `generate_image`, `blob_save_file`, `blob_load_file`, `blob_inspect` | `enable_builtins` |
 | Shell | `shell`, `shell_jobs`, `shell_job_status`, `shell_job_cancel` | `enable_shell` |
 | Memory | `memory_search` | `enable_memory` |
 | Scheduler | `meerkat_schedule_*` | `enable_schedule` |
@@ -143,7 +143,9 @@ Tools can return rich content beyond plain text. The injected runtime shape is `
 
 The built-in `view_image` tool reads an image file from disk and returns a result containing image content blocks. It supports PNG, JPEG, GIF, WebP, and SVG formats up to 5 MB. The tool is automatically hidden from models that lack vision support via capability-aware tool visibility.
 
-The built-in `generate_image` tool is session-owned runtime dispatch. It lets a model request generated or edited images through universal fields plus provider-owned `provider_params`. Generated image bytes are stored as blobs and committed as `AssistantBlock::Image` transcript blocks, so every surface reads the same `image_id`/`blob_ref` history and fetches bytes through `blob/get`.
+The built-in `generate_image` tool is session-owned runtime dispatch. It lets a model request generated or edited images through universal fields plus provider-owned `provider_params`. Generated image bytes are stored as blobs and committed as `AssistantBlock::Image` transcript blocks, so every surface reads the same `image_id`/`blob_ref` history and fetches bytes through `blob/get` or model-facing `blob_save_file`.
+
+The blob file bridge tools are registered only when the session has a blob store. `blob_save_file` writes decoded blob bytes to a file inside the project root, `blob_load_file` reads a project file into the blob store, and `blob_inspect` returns blob metadata without raw payload bytes. They do not expose blob listing or deletion.
 
 Custom tools can return multimodal content by returning `ToolResult::with_blocks(...)` with the appropriate content blocks.
 
@@ -151,7 +153,7 @@ Custom tools can return multimodal content by returning `ToolResult::with_blocks
 
 `generate_image` is a session-owned builtin for creating or editing assistant images. It is registered when builtins are enabled and the runtime-backed surface supplies the image-generation machine, provider executor, planner, and blob store. CLI sessions wire this automatically; the default `--tools safe` preset includes builtins.
 
-The tool accepts a typed request under `request`, routes it to OpenAI or Gemini image backends, stores generated image bytes in the realm blob store, and returns structured `ImageGenerationToolResult` JSON with durable `images[].blob_ref` values.
+The tool accepts a typed request under `request`, routes it to OpenAI or Gemini image backends, stores generated image bytes in the realm blob store, and returns structured `ImageGenerationToolResult` JSON with durable `images[].blob_ref` values. A model can then call `blob_save_file` to materialize that blob as a project file, for example `top-news-infographic.png`.
 
 For setup, provider parameters, result fields, and troubleshooting, see [Image generation](/guides/image-generation).
 

--- a/docs/guides/image-generation.mdx
+++ b/docs/guides/image-generation.mdx
@@ -16,7 +16,7 @@ This is not a standalone `image/generate` RPC. Use it by running a session with 
 - `count` must be `1`. Multiple image output is rejected today with `unsupported_count`; run multiple operations if you need several variants.
 
 <Note>
-`generate_image` is separate from `view_image`. `view_image` reads an existing file into the model as image input. `generate_image` creates a new assistant-owned image and stores it as a blob.
+`generate_image` is separate from `view_image`. `view_image` reads an existing file into the model as image input. `generate_image` creates a new assistant-owned image and stores it as a blob. When the model needs to save a generated blob to disk during the same run, it can call `blob_save_file`.
 </Note>
 
 ## CLI quickstart
@@ -34,6 +34,12 @@ When the tool succeeds, the tool result includes `images[].blob_ref.blob_id`. Sa
 
 ```bash
 rkat blob get <blob_id> --output cat.png
+```
+
+You can also ask the agent to save the image itself:
+
+```bash
+rkat run "Create a PNG infographic about today's top news and save it to top-news-infographic.png" --yolo -m gpt-5.5
 ```
 
 Inspect the stored payload instead of writing raw bytes:
@@ -225,7 +231,7 @@ Important fields:
 |-------|---------|
 | `operation_id` | Runtime identity for this image operation. |
 | `terminal` | Final state: `generated`, `empty_result`, `denied`, `refused_by_provider`, `safety_filtered`, `failed`, `cancelled`, `timeout`, or `scoped_restore_failed`. |
-| `images` | Durable assistant image references. Use `blob_ref.blob_id` with `rkat blob get`. |
+| `images` | Durable assistant image references. Use `blob_ref.blob_id` with `blob_save_file` inside a run or `rkat blob get` outside the run. |
 | `provider_text` | Captured provider-side text when the image backend emits text alongside images. |
 | `revised_prompt` | Provider-revised prompt when the backend returns one. |
 | `native_metadata` | Provider-specific metadata such as response ids and target model. |

--- a/docs/reference/builtin-tools.mdx
+++ b/docs/reference/builtin-tools.mdx
@@ -21,6 +21,9 @@ icon: "wrench"
 | `apply_patch` | Utility | Yes | -- | Apply structured file patches inside the project root |
 | `view_image` | Utility | Yes | `image_tool_results` | Read an image file and return base64 content |
 | `generate_image` | Image generation | Runtime-backed | image provider profile | Generate or edit assistant images and commit blob-backed image blocks |
+| `blob_save_file` | Blob files | Runtime-backed | blob store | Save decoded blob bytes to a project-root-contained file |
+| `blob_load_file` | Blob files | Runtime-backed | blob store | Load a project-root-contained file into the realm blob store |
+| `blob_inspect` | Blob files | Runtime-backed | blob store | Inspect blob media type and decoded byte size without returning bytes |
 | `send_message` | Comms | Yes | `comms` | Send a collaboration message to a peer |
 | `send_request` | Comms | Yes | `comms` | Send a structured request to a peer |
 | `send_response` | Comms | Yes | `comms` | Send a response to a peer request |
@@ -48,7 +51,7 @@ icon: "wrench"
 
 | Flag | Builder Method | Default | Controls |
 |------|---------------|---------|----------|
-| `enable_builtins` | `.builtins(bool)` | `false` | Task tools, utility tools (`datetime`, `apply_patch`, `view_image`), and runtime-backed `generate_image` when an image runtime is wired |
+| `enable_builtins` | `.builtins(bool)` | `false` | Task tools, utility tools (`datetime`, `apply_patch`, `view_image`), runtime-backed `generate_image`, and blob file tools when a blob store is wired |
 | `enable_shell` | `.shell(bool)` | `false` | All shell tools (`shell`, `shell_jobs`, `shell_job_status`, `shell_job_cancel`) |
 | `enable_memory` | `.memory(bool)` | `false` | `memory_search` (requires `memory-store-session` feature) |
 | `enable_schedule` | `.schedule(bool)` | `false` | Scheduler tools (`meerkat_schedule_*`) |
@@ -83,7 +86,7 @@ Individual tools can be enabled or disabled via `ToolPolicyLayer` in `BuiltinToo
 <Accordion title="Capability registrations">
 Capabilities are registered via the `inventory` crate in `meerkat-tools/src/lib.rs`:
 
-- **Builtins** (`CapabilityId::Builtins`): `task_list`, `task_create`, `task_get`, `task_update`, `datetime`, `apply_patch`, `view_image`, and runtime-backed `generate_image` when image generation wiring is available. Controlled by `config.tools.builtins_enabled`.
+- **Builtins** (`CapabilityId::Builtins`): `task_list`, `task_create`, `task_get`, `task_update`, `datetime`, `apply_patch`, `view_image`, runtime-backed `generate_image`, and runtime-backed `blob_save_file`/`blob_load_file`/`blob_inspect` when a blob store is available. Controlled by `config.tools.builtins_enabled`.
 - **Shell** (`CapabilityId::Shell`): `shell`, `shell_jobs`, `shell_job_status`, `shell_job_cancel`. Controlled by `config.tools.shell_enabled`.
 </Accordion>
 
@@ -566,6 +569,62 @@ Read an image file from the project directory and return its contents as a base6
 **Source:** `meerkat-tools/src/builtin/utility/view_image.rs`
 </Accordion>
 
+<Accordion title="blob_save_file">
+Save decoded bytes from the session blob store to a file inside the project root. This is the model-facing equivalent of materializing a blob with `rkat blob get`, but it remains sandboxed to the active project.
+
+**Default enabled:** Yes when builtins are on and the runtime-backed session has a blob store.
+
+<ParamField body="blob_id" type="String" required>
+  Blob ID to save.
+</ParamField>
+
+<ParamField body="path" type="String" required>
+  Destination path, relative to the project root or absolute within the project root.
+</ParamField>
+
+<ParamField body="overwrite" type="Boolean" default="false">
+  Whether to replace an existing file.
+</ParamField>
+
+**Returns:** JSON metadata: `blob_id`, `media_type`, `path`, and `bytes_written`. Raw bytes are never returned in the tool result.
+
+**Source:** `meerkat-tools/src/builtin/utility/blob_file.rs`
+</Accordion>
+
+<Accordion title="blob_load_file">
+Read a file inside the project root and store its bytes in the realm blob store.
+
+**Default enabled:** Yes when builtins are on and the runtime-backed session has a blob store.
+
+<ParamField body="path" type="String" required>
+  Source path, relative to the project root or absolute within the project root.
+</ParamField>
+
+<ParamField body="media_type" type="String" default="inferred from extension">
+  Optional media type. When omitted, Meerkat infers common image, text, JSON, CSV, SVG, and PDF media types from the file extension.
+</ParamField>
+
+**Size limit:** 25 MB.
+
+**Returns:** JSON metadata: `blob_id`, `media_type`, `path`, and `bytes_read`. Raw bytes are never returned in the tool result.
+
+**Source:** `meerkat-tools/src/builtin/utility/blob_file.rs`
+</Accordion>
+
+<Accordion title="blob_inspect">
+Inspect a blob without returning its raw payload.
+
+**Default enabled:** Yes when builtins are on and the runtime-backed session has a blob store.
+
+<ParamField body="blob_id" type="String" required>
+  Blob ID to inspect.
+</ParamField>
+
+**Returns:** JSON metadata: `blob_id`, `media_type`, and decoded `size_bytes`.
+
+**Source:** `meerkat-tools/src/builtin/utility/blob_file.rs`
+</Accordion>
+
 <Accordion title="generate_image">
 Generate or edit an assistant-owned image through the session image-generation substrate. Generated bytes are committed to the realm blob store and returned as durable `AssistantImageRef` values.
 
@@ -597,7 +656,7 @@ Generate or edit an assistant-owned image through the session image-generation s
 
 **Provider params:** OpenAI accepts `background`, `output_compression`, `moderation`, and hosted-tool-only `action`. Gemini accepts `aspect_ratio` and `image_size`.
 
-**Returns:** `ImageGenerationToolResult` JSON containing `operation_id`, `terminal`, `images`, `provider_text`, `revised_prompt`, `native_metadata`, and `warnings`. Each generated image includes `blob_ref.blob_id`, which can be fetched with `rkat blob get <blob_id> --output image.png`.
+**Returns:** `ImageGenerationToolResult` JSON containing `operation_id`, `terminal`, `images`, `provider_text`, `revised_prompt`, `native_metadata`, and `warnings`. Each generated image includes `blob_ref.blob_id`, which can be saved from inside the session with `blob_save_file` or fetched externally with `rkat blob get <blob_id> --output image.png`.
 
 **Source:** `meerkat-tools/src/builtin/image_generation.rs`
 

--- a/meerkat-cli/src/main.rs
+++ b/meerkat-cli/src/main.rs
@@ -13308,6 +13308,19 @@ default_model = "gemma"
     }
 
     #[test]
+    fn test_run_cli_surface_does_not_add_full_flag_alias() {
+        let err = match Cli::try_parse_from(["rkat", "run", "hello", "--full"]) {
+            Ok(_) => panic!("run should not accept a new --full alias"),
+            Err(err) => err,
+        };
+        assert!(
+            err.to_string().contains("unexpected argument '--full'")
+                || err.to_string().contains("Found argument '--full'"),
+            "unexpected parse error for --full: {err}"
+        );
+    }
+
+    #[test]
     fn test_auth_realm_option_does_not_select_runtime_realm() {
         let cli = Cli::try_parse_from(["rkat", "auth", "test", "--realm", "dev", "google_oauth"])
             .expect("auth test should parse");

--- a/meerkat-cli/tests/live_smoke_cli.rs
+++ b/meerkat-cli/tests/live_smoke_cli.rs
@@ -76,6 +76,35 @@ fn smoke_model() -> String {
     std::env::var("SMOKE_MODEL").unwrap_or_else(|_| "claude-sonnet-4-5".to_string())
 }
 
+async fn read_jsonl_files_under(
+    root: &std::path::Path,
+) -> Result<String, Box<dyn std::error::Error>> {
+    let mut stack = vec![root.to_path_buf()];
+    let mut combined = String::new();
+    while let Some(dir) = stack.pop() {
+        let mut entries = match tokio::fs::read_dir(&dir).await {
+            Ok(entries) => entries,
+            Err(err) if err.kind() == std::io::ErrorKind::NotFound => continue,
+            Err(err) => return Err(Box::new(err)),
+        };
+        while let Some(entry) = entries.next_entry().await? {
+            let path = entry.path();
+            let file_type = entry.file_type().await?;
+            if file_type.is_dir() {
+                stack.push(path);
+            } else if path
+                .extension()
+                .and_then(|ext| ext.to_str())
+                .is_some_and(|ext| ext == "jsonl")
+            {
+                combined.push_str(&tokio::fs::read_to_string(path).await?);
+                combined.push('\n');
+            }
+        }
+    }
+    Ok(combined)
+}
+
 /// Returns `true` if prerequisites are missing and the test should be skipped.
 fn skip_if_no_prereqs() -> bool {
     if rkat_binary_path().is_none() {
@@ -375,7 +404,7 @@ async fn inner_e2e_cli_shell_tool() -> Result<(), Box<dyn std::error::Error>> {
 }
 
 // ===========================================================================
-// Scenario 73: CLI generate_image with OpenAI image default
+// Scenario 73: CLI generate_image blob save smoke
 // ===========================================================================
 
 #[tokio::test]
@@ -422,13 +451,14 @@ async fn inner_e2e_cli_generate_image_openai_default() -> Result<(), Box<dyn std
 
     let rkat = rkat_binary_path().ok_or("rkat binary not found")?;
     let output = timeout(
-        Duration::from_secs(240),
+        Duration::from_secs(600),
         Command::new(&rkat)
             .current_dir(&project_dir)
             .args([
                 "run",
-                "Generate a picture of a cat using the generate_image tool.",
-                "--model",
+                "Check today's news and generate an infographic image with the top news. Save it to top-news-infographic.png",
+                "--yolo",
+                "-m",
                 "gpt-5.5",
             ])
             .output(),
@@ -462,14 +492,35 @@ async fn inner_e2e_cli_generate_image_openai_default() -> Result<(), Box<dyn std
             "CLI generate_image smoke hit failure marker {failure:?}: {combined}"
         );
     }
-    let lower = combined.to_ascii_lowercase();
-    let tool_was_called = lower.contains("generate_image");
-    let text_mentions_image =
-        (lower.contains("generated") || lower.contains("created") || lower.contains("here"))
-            && (lower.contains("cat") || lower.contains("image") || lower.contains("picture"));
+    let saved_path = project_dir.join("top-news-infographic.png");
+    let saved = tokio::fs::read(&saved_path)
+        .await
+        .map_err(|err| format!("expected saved PNG at '{}': {err}", saved_path.display()))?;
     assert!(
-        tool_was_called || text_mentions_image,
-        "CLI generate_image smoke should call the tool or report an image, got: {combined}"
+        !saved.is_empty(),
+        "saved infographic should be nonempty at '{}'",
+        saved_path.display()
+    );
+    assert!(
+        saved.len() >= 8,
+        "saved infographic should be long enough to include a PNG signature"
+    );
+    assert_eq!(
+        &saved[..8],
+        &[0x89, b'P', b'N', b'G', 0x0D, 0x0A, 0x1A, 0x0A],
+        "saved infographic should be a PNG file; output was: {combined}"
+    );
+    let temp_root = project_dir
+        .parent()
+        .ok_or("project dir should have a parent temp root")?;
+    let events = read_jsonl_files_under(temp_root).await?;
+    assert!(
+        events.contains(r#""name":"generate_image""#),
+        "smoke should exercise generate_image, not just create a PNG by other means; output was: {combined}"
+    );
+    assert!(
+        events.contains(r#""name":"blob_save_file""#),
+        "smoke should exercise blob_save_file to materialize the generated blob; output was: {combined}"
     );
 
     Ok(())

--- a/meerkat-contracts/src/wire/session.rs
+++ b/meerkat-contracts/src/wire/session.rs
@@ -198,8 +198,12 @@ pub enum WireProviderMeta {
     },
     OpenAi {
         id: String,
+        #[serde(default)]
         #[serde(skip_serializing_if = "Option::is_none")]
         encrypted_content: Option<String>,
+        #[serde(default)]
+        #[serde(skip_serializing_if = "Option::is_none")]
+        phase: Option<String>,
     },
     Unknown,
 }
@@ -214,9 +218,12 @@ impl From<ProviderMeta> for WireProviderMeta {
             ProviderMeta::OpenAi {
                 id,
                 encrypted_content,
+                phase,
+                ..
             } => Self::OpenAi {
                 id,
                 encrypted_content,
+                phase,
             },
             _ => Self::Unknown,
         }

--- a/meerkat-core/src/types.rs
+++ b/meerkat-core/src/types.rs
@@ -435,13 +435,19 @@ pub enum ProviderMeta {
         thought_signature: String,
     },
     /// OpenAI reasoning item metadata for stateless replay.
-    /// Both `id` and `encrypted_content` are required for faithful round-trip.
+    /// The `id`, `encrypted_content`, and `phase` fields must be preserved
+    /// verbatim when present so Responses API output items can be replayed.
     OpenAi {
         /// Reasoning item ID (required by OpenAI schema)
         id: String,
         /// Encrypted reasoning tokens for continuity
+        #[serde(default)]
         #[serde(skip_serializing_if = "Option::is_none")]
         encrypted_content: Option<String>,
+        /// Responses API phase marker for manual stateless replay.
+        #[serde(default)]
+        #[serde(skip_serializing_if = "Option::is_none")]
+        phase: Option<String>,
     },
 }
 

--- a/meerkat-core/src/types/tests.rs
+++ b/meerkat-core/src/types/tests.rs
@@ -700,6 +700,7 @@ mod ordered_transcript_types {
         let meta = ProviderMeta::OpenAi {
             id: "reasoning_item_123".to_string(),
             encrypted_content: Some("encrypted_tokens_abc".to_string()),
+            phase: Some("reasoning".to_string()),
         };
 
         let json = serde_json::to_string(&meta).unwrap();
@@ -711,6 +712,7 @@ mod ordered_transcript_types {
         assert_eq!(value["provider"], "open_ai");
         assert_eq!(value["id"], "reasoning_item_123");
         assert_eq!(value["encrypted_content"], "encrypted_tokens_abc");
+        assert_eq!(value["phase"], "reasoning");
     }
 
     #[test]
@@ -718,6 +720,7 @@ mod ordered_transcript_types {
         let meta = ProviderMeta::OpenAi {
             id: "reasoning_item_456".to_string(),
             encrypted_content: None,
+            phase: None,
         };
 
         let json = serde_json::to_string(&meta).unwrap();
@@ -798,6 +801,7 @@ mod ordered_transcript_types {
             meta: Some(Box::new(ProviderMeta::OpenAi {
                 id: "reasoning_123".to_string(),
                 encrypted_content: Some("encrypted".to_string()),
+                phase: None,
             })),
         };
 

--- a/meerkat-openai/src/client.rs
+++ b/meerkat-openai/src/client.rs
@@ -111,6 +111,14 @@ fn project_openai_tool_result(result: &ToolResult) -> Result<ToolResult, LlmErro
     ))
 }
 
+fn openai_reasoning_replayable(
+    mode: OpenAiReplayProjectionMode,
+    meta: &Option<Box<ProviderMeta>>,
+) -> bool {
+    matches!(mode, OpenAiReplayProjectionMode::Responses)
+        && matches!(meta.as_deref(), Some(ProviderMeta::OpenAi { .. }))
+}
+
 fn openai_server_tool_content_replayable(
     mode: OpenAiReplayProjectionMode,
     content: &Value,
@@ -118,7 +126,17 @@ fn openai_server_tool_content_replayable(
     match mode {
         OpenAiReplayProjectionMode::Responses => matches!(
             content.get("type").and_then(Value::as_str),
-            Some("web_search_call" | "web_search_result")
+            Some(
+                "web_search_call"
+                    | "web_search_result"
+                    | "file_search_call"
+                    | "computer_call"
+                    | "code_interpreter_call"
+                    | "image_generation_call"
+                    | "mcp_call"
+                    | "mcp_list_tools"
+                    | "mcp_approval_request"
+            )
         ),
         OpenAiReplayProjectionMode::ChatCompletions => false,
     }
@@ -128,22 +146,41 @@ fn project_openai_assistant_blocks(
     mode: OpenAiReplayProjectionMode,
     blocks: &[AssistantBlock],
 ) -> Vec<AssistantBlock> {
-    blocks
-        .iter()
-        .filter_map(|block| match block {
+    let mut projected = Vec::with_capacity(blocks.len());
+    let mut has_output_item = false;
+
+    for block in blocks {
+        let projected_block = match block {
             AssistantBlock::Text { text, .. } if text.is_empty() => None,
-            AssistantBlock::Text { .. } | AssistantBlock::ToolUse { .. } => Some(block.clone()),
+            AssistantBlock::Text { .. } | AssistantBlock::ToolUse { .. } => {
+                has_output_item = true;
+                Some(block.clone())
+            }
+            AssistantBlock::Reasoning { meta, .. } if openai_reasoning_replayable(mode, meta) => {
+                Some(block.clone())
+            }
             AssistantBlock::ServerToolContent { content, .. }
                 if openai_server_tool_content_replayable(mode, content) =>
             {
+                has_output_item = true;
                 Some(block.clone())
             }
             AssistantBlock::Reasoning { .. }
             | AssistantBlock::ServerToolContent { .. }
             | AssistantBlock::Image { .. } => None,
             _ => None,
-        })
-        .collect()
+        };
+
+        if let Some(block) = projected_block {
+            projected.push(block);
+        }
+    }
+
+    if has_output_item {
+        projected
+    } else {
+        Vec::new()
+    }
 }
 
 fn tool_ids_from_assistant(message: &Message) -> HashSet<String> {
@@ -213,12 +250,6 @@ pub(crate) fn project_openai_replay_messages(
             continue;
         }
 
-        if pending_tool_ids.is_some() {
-            return Err(invalid_replay(
-                "OpenAI replay projection found a tool use without adjacent tool results",
-            ));
-        }
-
         let next_message = match message {
             Message::System(_) | Message::SystemNotice(_) => Some(message.clone()),
             Message::User(user) => Some(Message::User(UserMessage {
@@ -248,13 +279,21 @@ pub(crate) fn project_openai_replay_messages(
             Message::ToolResults { .. } => unreachable!("handled above"),
         };
 
-        if let Some(message) = next_message {
-            let tool_ids = tool_ids_from_assistant(&message);
-            if !tool_ids.is_empty() {
-                pending_tool_ids = Some(tool_ids);
-            }
-            projected.push(message);
+        let Some(message) = next_message else {
+            continue;
+        };
+
+        if pending_tool_ids.is_some() {
+            return Err(invalid_replay(
+                "OpenAI replay projection found a tool use without adjacent tool results",
+            ));
         }
+
+        let tool_ids = tool_ids_from_assistant(&message);
+        if !tool_ids.is_empty() {
+            pending_tool_ids = Some(tool_ids);
+        }
+        projected.push(message);
     }
 
     if pending_tool_ids.is_some() {
@@ -503,16 +542,52 @@ impl OpenAiClient {
 
     /// Convert messages to Responses API input format.
     ///
-    /// Note: we intentionally do not replay prior `reasoning` items.
-    /// OpenAI enforces strict adjacency invariants for reasoning replay, and
-    /// violating them causes hard request failures. Replaying only user/assistant
-    /// messages and tool items is robust across retries and tool-call turns.
+    /// OpenAI-hosted tool output items can depend on paired reasoning output
+    /// items. `project_openai_replay_messages` filters provider-specific
+    /// history before this point so Responses replay keeps OpenAI reasoning and
+    /// final hosted-tool items together, while provider switches and Chat
+    /// Completions mode do not receive OpenAI-private transcript state.
     fn convert_to_responses_input(messages: &[Message]) -> Result<Vec<Value>, LlmError> {
         Self::convert_to_responses_input_with_system_mode(
             messages,
             SystemMessageMode::IncludeInInput,
         )
         .map(|(input, _)| input)
+    }
+
+    fn openai_reasoning_input_item(text: &str, meta: &ProviderMeta) -> Option<Value> {
+        let ProviderMeta::OpenAi {
+            id,
+            encrypted_content,
+            phase,
+            ..
+        } = meta
+        else {
+            return None;
+        };
+
+        let summary = if text.is_empty() {
+            Value::Array(Vec::new())
+        } else {
+            serde_json::json!([{
+                "type": "summary_text",
+                "text": text
+            }])
+        };
+        let mut item = serde_json::json!({
+            "type": "reasoning",
+            "id": id,
+            "summary": summary
+        });
+
+        if let Some(encrypted_content) = encrypted_content {
+            item["encrypted_content"] = Value::String(encrypted_content.clone());
+        }
+        if let Some(phase) = phase {
+            item["phase"] = Value::String(phase.clone());
+        }
+
+        Some(item)
     }
 
     fn convert_to_responses_input_with_system_mode(
@@ -623,12 +698,19 @@ impl OpenAiClient {
                                     "arguments": args.get()  // Already JSON string
                                 }));
                             }
+                            AssistantBlock::Reasoning { text, meta } => {
+                                if let Some(item) = meta
+                                    .as_deref()
+                                    .and_then(|meta| Self::openai_reasoning_input_item(text, meta))
+                                {
+                                    items.push(item);
+                                }
+                            }
                             AssistantBlock::ServerToolContent { content, .. } => {
                                 items.push(content.clone());
                             }
-                            // Reasoning replay can violate Responses API adjacency
-                            // constraints and hard-fail requests; skip it and any
-                            // unknown future variants.
+                            // Unknown future variants are omitted unless the
+                            // OpenAI projection explicitly admits them above.
                             _ => {}
                         }
                     }
@@ -1279,10 +1361,14 @@ impl LlmClient for OpenAiClient {
                                                     let encrypted = item.get("encrypted_content")
                                                         .and_then(|v| v.as_str())
                                                         .map(std::string::ToString::to_string);
+                                                    let phase = item.get("phase")
+                                                        .and_then(|v| v.as_str())
+                                                        .map(std::string::ToString::to_string);
 
                                                     let meta = Some(Box::new(ProviderMeta::OpenAi {
                                                         id: reasoning_id.to_string(),
                                                         encrypted_content: encrypted,
+                                                        phase,
                                                     }));
 
                                                     assembler.on_reasoning_start();
@@ -1466,10 +1552,14 @@ impl LlmClient for OpenAiClient {
                                 let encrypted = item.get("encrypted_content")
                                     .and_then(|v| v.as_str())
                                     .map(std::string::ToString::to_string);
+                                let phase = item.get("phase")
+                                    .and_then(|v| v.as_str())
+                                    .map(std::string::ToString::to_string);
 
                                 let meta = Some(Box::new(ProviderMeta::OpenAi {
                                     id: reasoning_id.to_string(),
                                     encrypted_content: encrypted,
+                                    phase,
                                 }));
 
                                 assembler.on_reasoning_start();
@@ -1700,6 +1790,16 @@ mod tests {
         }
     }
 
+    fn build_projected_request_body(client: &OpenAiClient, request: &LlmRequest) -> Value {
+        let mut projected = request.clone();
+        projected.messages = client
+            .project_replay_messages(&request.messages)
+            .expect("project replay messages");
+        client
+            .build_request_body(&projected)
+            .expect("build request")
+    }
+
     async fn responses_sse(State(payload): State<String>) -> impl IntoResponse {
         ([("content-type", "text/event-stream")], payload)
     }
@@ -1735,6 +1835,7 @@ mod tests {
                         meta: Some(Box::new(ProviderMeta::OpenAi {
                             id: "rs_1".to_string(),
                             encrypted_content: Some("ciphertext".to_string()),
+                            phase: Some("reasoning".to_string()),
                         })),
                     },
                     AssistantBlock::ServerToolContent {
@@ -1819,11 +1920,11 @@ mod tests {
             panic!("expected assistant message");
         };
         assert!(
-            !assistant
+            assistant
                 .blocks
                 .iter()
                 .any(|block| matches!(block, AssistantBlock::Reasoning { .. })),
-            "OpenAI replay projection should drop reasoning blocks"
+            "OpenAI Responses replay projection should keep OpenAI reasoning blocks"
         );
         assert!(assistant.blocks.iter().any(|block| matches!(
             block,
@@ -1848,6 +1949,30 @@ mod tests {
                 .any(|block| matches!(block, AssistantBlock::Image { .. })),
             "assistant images must be removed from OpenAI replay"
         );
+        let body = client.build_request_body(&LlmRequest::new("gpt-5.4", projected.clone()))?;
+        let input = body["input"].as_array().expect("input array");
+        assert!(input.iter().any(|item| {
+            item.get("type").and_then(Value::as_str) == Some("reasoning")
+                && item.get("id").and_then(Value::as_str) == Some("rs_1")
+                && item.get("encrypted_content").and_then(Value::as_str) == Some("ciphertext")
+                && item.get("phase").and_then(Value::as_str) == Some("reasoning")
+        }));
+        assert!(input.iter().any(|item| {
+            item.get("type").and_then(Value::as_str) == Some("web_search_call")
+                && item.get("id").and_then(Value::as_str) == Some("ws_1")
+        }));
+        let reasoning_pos = input
+            .iter()
+            .position(|item| item.get("type").and_then(Value::as_str) == Some("reasoning"))
+            .expect("reasoning item");
+        let web_search_pos = input
+            .iter()
+            .position(|item| item.get("type").and_then(Value::as_str) == Some("web_search_call"))
+            .expect("web search item");
+        assert!(
+            reasoning_pos < web_search_pos,
+            "reasoning must replay before dependent hosted-tool item"
+        );
 
         let Message::ToolResults { results, .. } = &projected[2] else {
             panic!("expected tool results");
@@ -1871,6 +1996,93 @@ mod tests {
             )])])
             .expect_err("orphan tool results must be rejected");
         assert!(matches!(err, LlmError::InvalidRequest { .. }));
+    }
+
+    #[test]
+    fn replay_projection_drops_openai_provider_items_for_chat_completions()
+    -> Result<(), Box<dyn std::error::Error>> {
+        let messages = vec![Message::BlockAssistant(BlockAssistantMessage::new(
+            vec![
+                AssistantBlock::Reasoning {
+                    text: "private".to_string(),
+                    meta: Some(Box::new(ProviderMeta::OpenAi {
+                        id: "rs_1".to_string(),
+                        encrypted_content: Some("enc".to_string()),
+                        phase: Some("reasoning".to_string()),
+                    })),
+                },
+                AssistantBlock::ServerToolContent {
+                    id: Some("ws_1".to_string()),
+                    name: "web_search_call".to_string(),
+                    content: serde_json::json!({
+                        "type": "web_search_call",
+                        "id": "ws_1",
+                        "status": "completed"
+                    }),
+                    meta: None,
+                },
+                AssistantBlock::Text {
+                    text: "visible".to_string(),
+                    meta: None,
+                },
+            ],
+            StopReason::EndTurn,
+        ))];
+
+        let projected =
+            project_openai_replay_messages(&messages, OpenAiReplayProjectionMode::ChatCompletions)?;
+
+        let Message::BlockAssistant(assistant) = &projected[0] else {
+            panic!("expected assistant");
+        };
+        assert_eq!(assistant.blocks.len(), 1);
+        assert!(matches!(
+            &assistant.blocks[0],
+            AssistantBlock::Text { text, .. } if text == "visible"
+        ));
+        Ok(())
+    }
+
+    #[test]
+    fn replay_projection_allows_dropped_image_between_tool_use_and_result()
+    -> Result<(), Box<dyn std::error::Error>> {
+        let client = OpenAiClient::new("test-key".to_string());
+        let tool_args = RawValue::from_string(r#"{"path":"out.png"}"#.to_string())?;
+        let messages = vec![
+            Message::BlockAssistant(BlockAssistantMessage::new(
+                vec![AssistantBlock::ToolUse {
+                    id: "tool_1".to_string(),
+                    name: "blob_save_file".to_string(),
+                    args: tool_args,
+                    meta: None,
+                }],
+                StopReason::ToolUse,
+            )),
+            Message::BlockAssistant(BlockAssistantMessage::new(
+                vec![assistant_image_block()],
+                StopReason::EndTurn,
+            )),
+            Message::tool_results(vec![ToolResult::new(
+                "tool_1".to_string(),
+                r#"{"path":"out.png"}"#.to_string(),
+                false,
+            )]),
+        ];
+
+        let projected = client.project_replay_messages(&messages)?;
+
+        assert_eq!(projected.len(), 2);
+        let Message::BlockAssistant(assistant) = &projected[0] else {
+            panic!("expected assistant tool use");
+        };
+        assert!(assistant.blocks.iter().any(|block| {
+            matches!(
+                block,
+                AssistantBlock::ToolUse { name, .. } if name == "blob_save_file"
+            )
+        }));
+        assert!(matches!(projected[1], Message::ToolResults { .. }));
+        Ok(())
     }
 
     #[derive(Clone)]
@@ -2624,7 +2836,7 @@ mod tests {
             ],
         );
 
-        let body = client.build_request_body(&request).expect("build request");
+        let body = build_projected_request_body(&client, &request);
         let input = body["input"].as_array().expect("input should be array");
 
         assert_eq!(input[1]["type"], "message");
@@ -2633,7 +2845,7 @@ mod tests {
     }
 
     #[test]
-    fn test_request_input_format_block_assistant_reasoning_with_output_skips_reasoning_replay() {
+    fn test_request_input_format_block_assistant_reasoning_with_output_replays_reasoning() {
         use meerkat_core::BlockAssistantMessage;
 
         let client = OpenAiClient::new("test-key".to_string());
@@ -2648,6 +2860,7 @@ mod tests {
                             meta: Some(Box::new(ProviderMeta::OpenAi {
                                 id: "rs_abc123".to_string(),
                                 encrypted_content: Some("encrypted_data".to_string()),
+                                phase: None,
                             })),
                         },
                         AssistantBlock::Text {
@@ -2661,13 +2874,15 @@ mod tests {
             ],
         );
 
-        let body = client.build_request_body(&request).expect("build request");
+        let body = build_projected_request_body(&client, &request);
         let input = body["input"].as_array().expect("input should be array");
 
-        // Reasoning is intentionally not replayed; assistant text remains.
-        assert_eq!(input.len(), 2);
-        assert_eq!(input[1]["type"], "message");
-        assert_eq!(input[1]["role"], "assistant");
+        assert_eq!(input.len(), 3);
+        assert_eq!(input[1]["type"], "reasoning");
+        assert_eq!(input[1]["id"], "rs_abc123");
+        assert_eq!(input[1]["encrypted_content"], "encrypted_data");
+        assert_eq!(input[2]["type"], "message");
+        assert_eq!(input[2]["role"], "assistant");
     }
 
     #[test]
@@ -3443,6 +3658,7 @@ mod tests {
                         meta: Some(Box::new(ProviderMeta::OpenAi {
                             id: "rs_orphan".to_string(),
                             encrypted_content: None,
+                            phase: None,
                         })),
                     }],
                     stop_reason: StopReason::EndTurn,
@@ -3451,7 +3667,7 @@ mod tests {
             ],
         );
 
-        let body = client.build_request_body(&request).expect("build request");
+        let body = build_projected_request_body(&client, &request);
         let input = body["input"].as_array().expect("input should be array");
 
         // Orphaned reasoning should be stripped, leaving only the user message
@@ -3476,6 +3692,7 @@ mod tests {
                         meta: Some(Box::new(ProviderMeta::OpenAi {
                             id: "rs_mid".to_string(),
                             encrypted_content: None,
+                            phase: None,
                         })),
                     }],
                     stop_reason: StopReason::EndTurn,
@@ -3485,7 +3702,7 @@ mod tests {
             ],
         );
 
-        let body = client.build_request_body(&request).expect("build request");
+        let body = build_projected_request_body(&client, &request);
         let input = body["input"].as_array().expect("input should be array");
 
         // Reasoning followed by user message (not assistant output) should be stripped
@@ -3501,10 +3718,21 @@ mod tests {
         use meerkat_core::BlockAssistantMessage;
 
         let client = OpenAiClient::new("test-key".to_string());
+        let args = RawValue::from_string(r"{}".to_string()).unwrap();
         let request = LlmRequest::new(
             "gpt-5.4",
             vec![
                 Message::User(UserMessage::text("Hello".to_string())),
+                Message::BlockAssistant(BlockAssistantMessage {
+                    blocks: vec![AssistantBlock::ToolUse {
+                        id: "call_123".to_string(),
+                        name: "lookup".to_string(),
+                        args,
+                        meta: None,
+                    }],
+                    stop_reason: StopReason::ToolUse,
+                    created_at: meerkat_core::types::message_timestamp_now(),
+                }),
                 // Reasoning-only at end of one assistant message
                 Message::BlockAssistant(BlockAssistantMessage {
                     blocks: vec![AssistantBlock::Reasoning {
@@ -3512,12 +3740,14 @@ mod tests {
                         meta: Some(Box::new(ProviderMeta::OpenAi {
                             id: "rs_before_tool".to_string(),
                             encrypted_content: None,
+                            phase: None,
                         })),
                     }],
                     stop_reason: StopReason::EndTurn,
                     created_at: meerkat_core::types::message_timestamp_now(),
                 }),
-                // Next message is tool results — not a valid follower for reasoning
+                // Next message is tool results; the reasoning-only message
+                // must be dropped without breaking tool-call adjacency.
                 Message::ToolResults {
                     results: vec![meerkat_core::ToolResult::new(
                         "call_123".to_string(),
@@ -3529,17 +3759,18 @@ mod tests {
             ],
         );
 
-        let body = client.build_request_body(&request).expect("build request");
+        let body = build_projected_request_body(&client, &request);
         let input = body["input"].as_array().expect("input should be array");
 
-        // Reasoning should be stripped; user message + tool result remain
-        assert_eq!(input.len(), 2);
+        // Reasoning should be stripped; tool call/result adjacency remains.
+        assert_eq!(input.len(), 3);
         assert_eq!(input[0]["type"], "message");
-        assert_eq!(input[1]["type"], "function_call_output");
+        assert_eq!(input[1]["type"], "function_call");
+        assert_eq!(input[2]["type"], "function_call_output");
     }
 
     #[test]
-    fn test_reasoning_followed_by_function_call_skips_reasoning_replay() {
+    fn test_reasoning_followed_by_function_call_replays_reasoning() {
         use meerkat_core::BlockAssistantMessage;
 
         let client = OpenAiClient::new("test-key".to_string());
@@ -3555,6 +3786,7 @@ mod tests {
                             meta: Some(Box::new(ProviderMeta::OpenAi {
                                 id: "rs_valid".to_string(),
                                 encrypted_content: Some("enc_valid".to_string()),
+                                phase: None,
                             })),
                         },
                         AssistantBlock::ToolUse {
@@ -3573,9 +3805,11 @@ mod tests {
         let body = client.build_request_body(&request).expect("build request");
         let input = body["input"].as_array().expect("input should be array");
 
-        // Reasoning is intentionally not replayed; function_call remains.
-        assert_eq!(input.len(), 2);
-        assert_eq!(input[1]["type"], "function_call");
+        assert_eq!(input.len(), 3);
+        assert_eq!(input[1]["type"], "reasoning");
+        assert_eq!(input[1]["id"], "rs_valid");
+        assert_eq!(input[1]["encrypted_content"], "enc_valid");
+        assert_eq!(input[2]["type"], "function_call");
     }
 
     #[test]
@@ -3606,7 +3840,7 @@ mod tests {
             ],
         );
 
-        let body = client.build_request_body(&request).expect("build request");
+        let body = build_projected_request_body(&client, &request);
         let input = body["input"].as_array().expect("input should be array");
 
         // Non-OpenAI reasoning is not serialized at all, only text remains
@@ -3633,6 +3867,7 @@ mod tests {
                         meta: Some(Box::new(ProviderMeta::OpenAi {
                             id: "rs_first".to_string(),
                             encrypted_content: Some("enc_1".to_string()),
+                            phase: None,
                         })),
                     }],
                     stop_reason: StopReason::EndTurn,
@@ -3644,6 +3879,7 @@ mod tests {
                         meta: Some(Box::new(ProviderMeta::OpenAi {
                             id: "rs_second".to_string(),
                             encrypted_content: None,
+                            phase: None,
                         })),
                     }],
                     stop_reason: StopReason::EndTurn,
@@ -3653,7 +3889,7 @@ mod tests {
             ],
         );
 
-        let body = client.build_request_body(&request).expect("build request");
+        let body = build_projected_request_body(&client, &request);
         let input = body["input"].as_array().expect("input should be array");
 
         // Both orphaned reasoning items stripped, only user messages remain
@@ -3692,11 +3928,11 @@ mod tests {
     }
 
     // =========================================================================
-    // Reasoning encrypted_content stripping tests
+    // Reasoning encrypted_content replay tests
     // =========================================================================
 
     #[test]
-    fn test_reasoning_without_encrypted_content_is_stripped() {
+    fn test_reasoning_without_encrypted_content_is_replayed_without_encrypted_content() {
         use meerkat_core::BlockAssistantMessage;
 
         let client = OpenAiClient::new("test-key".to_string());
@@ -3712,6 +3948,7 @@ mod tests {
                             meta: Some(Box::new(ProviderMeta::OpenAi {
                                 id: "rs_no_enc".to_string(),
                                 encrypted_content: None,
+                                phase: None,
                             })),
                         },
                         AssistantBlock::ToolUse {
@@ -3730,14 +3967,16 @@ mod tests {
         let body = client.build_request_body(&request).expect("build request");
         let input = body["input"].as_array().expect("input should be array");
 
-        // Reasoning without encrypted_content is stripped even with valid follower
-        assert_eq!(input.len(), 2);
+        assert_eq!(input.len(), 3);
         assert_eq!(input[0]["type"], "message");
-        assert_eq!(input[1]["type"], "function_call");
+        assert_eq!(input[1]["type"], "reasoning");
+        assert_eq!(input[1]["id"], "rs_no_enc");
+        assert!(input[1].get("encrypted_content").is_none());
+        assert_eq!(input[2]["type"], "function_call");
     }
 
     #[test]
-    fn test_reasoning_with_encrypted_content_is_not_replayed() {
+    fn test_reasoning_with_encrypted_content_is_replayed() {
         use meerkat_core::BlockAssistantMessage;
 
         let client = OpenAiClient::new("test-key".to_string());
@@ -3752,6 +3991,7 @@ mod tests {
                             meta: Some(Box::new(ProviderMeta::OpenAi {
                                 id: "rs_enc".to_string(),
                                 encrypted_content: Some("enc_data_here".to_string()),
+                                phase: None,
                             })),
                         },
                         AssistantBlock::Text {
@@ -3768,9 +4008,11 @@ mod tests {
         let body = client.build_request_body(&request).expect("build request");
         let input = body["input"].as_array().expect("input should be array");
 
-        // Reasoning is intentionally not replayed; assistant text remains.
-        assert_eq!(input.len(), 2);
-        assert_eq!(input[1]["type"], "message");
+        assert_eq!(input.len(), 3);
+        assert_eq!(input[1]["type"], "reasoning");
+        assert_eq!(input[1]["id"], "rs_enc");
+        assert_eq!(input[1]["encrypted_content"], "enc_data_here");
+        assert_eq!(input[2]["type"], "message");
     }
 
     // =========================================================================

--- a/meerkat-tools/src/builtin/composite.rs
+++ b/meerkat-tools/src/builtin/composite.rs
@@ -8,6 +8,8 @@ use crate::builtin::store::TaskStore;
 use crate::builtin::{BuiltinTool, BuiltinToolConfig, BuiltinToolError, ToolOutput};
 use async_trait::async_trait;
 use meerkat_core::AgentToolDispatcher;
+#[cfg(not(target_arch = "wasm32"))]
+use meerkat_core::BlobStore;
 use meerkat_core::ExternalToolUpdate;
 #[cfg(not(target_arch = "wasm32"))]
 use meerkat_core::ToolCategoryOverride;
@@ -43,6 +45,11 @@ struct ImageGenerationToolBinding {
     visibility: ToolCategoryOverride,
 }
 
+#[cfg(not(target_arch = "wasm32"))]
+struct BlobToolBinding {
+    blob_store: Arc<dyn BlobStore>,
+}
+
 /// A composite dispatcher that combines multiple sources of tools.
 pub struct CompositeDispatcher {
     builtin_tools: Vec<Arc<dyn BuiltinTool>>,
@@ -66,6 +73,8 @@ pub struct CompositeDispatcher {
     job_manager: Option<Arc<JobManager>>,
     #[cfg(not(target_arch = "wasm32"))]
     image_generation_runtime: Option<ImageGenerationToolBinding>,
+    #[cfg(not(target_arch = "wasm32"))]
+    blob_tools: Option<BlobToolBinding>,
     allowed_tools: HashSet<String>,
 }
 
@@ -200,6 +209,7 @@ impl CompositeDispatcher {
             image_tool_results: _image_tool_results,
             job_manager,
             image_generation_runtime: None,
+            blob_tools: None,
             allowed_tools,
         })
     }
@@ -282,6 +292,32 @@ impl CompositeDispatcher {
             runtime,
             visibility,
         });
+    }
+
+    /// Register blob file bridge builtins backed by the session blob store.
+    #[cfg(not(target_arch = "wasm32"))]
+    pub fn register_blob_file_tools(&mut self, blob_store: Arc<dyn BlobStore>) {
+        let Some(project_root) = self.project_root.clone() else {
+            return;
+        };
+        use crate::builtin::utility::{BlobInspectTool, BlobLoadFileTool, BlobSaveFileTool};
+        let tools: [Arc<dyn BuiltinTool>; 3] = [
+            Arc::new(BlobSaveFileTool::new(
+                project_root.clone(),
+                Arc::clone(&blob_store),
+            )),
+            Arc::new(BlobLoadFileTool::new(project_root, Arc::clone(&blob_store))),
+            Arc::new(BlobInspectTool::new(Arc::clone(&blob_store))),
+        ];
+        let resolved_policy = self.builtin_config.resolve();
+        for tool in tools {
+            let name = tool.name().to_string();
+            if resolved_policy.is_enabled(&name, tool.default_enabled()) {
+                self.allowed_tools.insert(name);
+            }
+            self.builtin_tools.push(tool);
+        }
+        self.blob_tools = Some(BlobToolBinding { blob_store });
     }
 
     /// Get usage instructions for all enabled tools.
@@ -637,7 +673,11 @@ impl AgentToolDispatcher for CompositeDispatcher {
 
         #[cfg(not(target_arch = "wasm32"))]
         {
-            if owned.job_manager.is_none() && rebound_external.is_none() {
+            if owned.job_manager.is_none()
+                && rebound_external.is_none()
+                && owned.image_generation_runtime.is_none()
+                && owned.blob_tools.is_none()
+            {
                 return Err(OpsLifecycleBindError::Unsupported);
             }
 
@@ -660,6 +700,9 @@ impl AgentToolDispatcher for CompositeDispatcher {
             }
             if let Some(binding) = owned.image_generation_runtime.take() {
                 rebound.register_image_generation_tool(binding.runtime, binding.visibility);
+            }
+            if let Some(binding) = owned.blob_tools.take() {
+                rebound.register_blob_file_tools(binding.blob_store);
             }
 
             Ok(BindOutcome::Bound(Arc::new(rebound)))
@@ -693,10 +736,56 @@ impl AgentToolDispatcher for CompositeDispatcher {
 mod tests {
     use super::*;
     use crate::builtin::MemoryTaskStore;
+    use crate::builtin::ToolPolicyLayer;
     use meerkat_core::ops_lifecycle::OpsLifecycleRegistry;
     use meerkat_core::types::SessionId;
+    use meerkat_core::{BlobId, BlobPayload, BlobRef, BlobStoreError};
     use serde_json::json;
+    use std::collections::HashMap;
     use tempfile::TempDir;
+    use tokio::sync::Mutex;
+
+    #[derive(Default)]
+    struct TestBlobStore {
+        blobs: Mutex<HashMap<BlobId, BlobPayload>>,
+    }
+
+    #[async_trait]
+    impl BlobStore for TestBlobStore {
+        async fn put_image(&self, media_type: &str, data: &str) -> Result<BlobRef, BlobStoreError> {
+            let blob_id = BlobId::new(format!("sha256:{media_type}:{data}"));
+            self.blobs.lock().await.insert(
+                blob_id.clone(),
+                BlobPayload {
+                    blob_id: blob_id.clone(),
+                    media_type: media_type.to_string(),
+                    data: data.to_string(),
+                },
+            );
+            Ok(BlobRef {
+                blob_id,
+                media_type: media_type.to_string(),
+            })
+        }
+
+        async fn get(&self, blob_id: &BlobId) -> Result<BlobPayload, BlobStoreError> {
+            self.blobs
+                .lock()
+                .await
+                .get(blob_id)
+                .cloned()
+                .ok_or_else(|| BlobStoreError::NotFound(blob_id.clone()))
+        }
+
+        async fn delete(&self, blob_id: &BlobId) -> Result<(), BlobStoreError> {
+            self.blobs.lock().await.remove(blob_id);
+            Ok(())
+        }
+
+        fn is_persistent(&self) -> bool {
+            false
+        }
+    }
 
     struct MockExternalDispatcher {
         tools: Arc<[Arc<ToolDef>]>,
@@ -1132,6 +1221,159 @@ mod tests {
             .await
             .expect("external tool dispatch should succeed even with a stale allow-set entry");
         assert_eq!(result.result.text_content(), "{}");
+    }
+
+    #[test]
+    fn blob_file_tools_register_when_blob_store_is_wired() {
+        let temp_dir = TempDir::new().unwrap();
+        let mut dispatcher = CompositeDispatcher::new(
+            Arc::new(MemoryTaskStore::new()),
+            &BuiltinToolConfig::default(),
+            Some(temp_dir.path().to_path_buf()),
+            None,
+            None,
+            None,
+            true,
+        )
+        .expect("composite dispatcher should build");
+
+        dispatcher.register_blob_file_tools(Arc::new(TestBlobStore::default()));
+
+        let names: Vec<_> = dispatcher
+            .tools()
+            .iter()
+            .map(|tool| tool.name.to_string())
+            .collect();
+        for expected in ["blob_save_file", "blob_load_file", "blob_inspect"] {
+            assert!(
+                names.contains(&expected.to_string()),
+                "{expected} should be exposed when a blob store is wired; tools={names:?}"
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn blob_file_tools_are_absent_without_blob_store() {
+        let temp_dir = TempDir::new().unwrap();
+        let dispatcher = CompositeDispatcher::new(
+            Arc::new(MemoryTaskStore::new()),
+            &BuiltinToolConfig::default(),
+            Some(temp_dir.path().to_path_buf()),
+            None,
+            None,
+            None,
+            true,
+        )
+        .expect("composite dispatcher should build");
+
+        assert!(
+            dispatcher
+                .tools()
+                .iter()
+                .all(|tool| !tool.name.starts_with("blob_")),
+            "blob tools should not be advertised without a session blob store"
+        );
+
+        let call_json =
+            serde_json::value::RawValue::from_string(r#"{"blob_id":"sha256:missing"}"#.into())
+                .unwrap();
+        let call = ToolCallView {
+            id: "blob-inspect",
+            name: "blob_inspect",
+            args: &call_json,
+        };
+        let err = dispatcher.dispatch(call).await.unwrap_err();
+        assert!(matches!(err, ToolError::NotFound { .. }));
+    }
+
+    #[tokio::test]
+    async fn blob_file_tools_respect_builtin_policy() {
+        let temp_dir = TempDir::new().unwrap();
+        let config = BuiltinToolConfig {
+            policy: ToolPolicyLayer::new().disable_tool("blob_save_file"),
+            ..Default::default()
+        };
+        let mut dispatcher = CompositeDispatcher::new(
+            Arc::new(MemoryTaskStore::new()),
+            &config,
+            Some(temp_dir.path().to_path_buf()),
+            None,
+            None,
+            None,
+            true,
+        )
+        .expect("composite dispatcher should build");
+
+        let store: Arc<dyn BlobStore> = Arc::new(TestBlobStore::default());
+        let blob_ref = store.put_image("image/png", "iVBORw0KGgo=").await.unwrap();
+        dispatcher.register_blob_file_tools(store);
+
+        assert!(
+            dispatcher
+                .tools()
+                .iter()
+                .all(|tool| tool.name != "blob_save_file"),
+            "disabled blob_save_file must not be advertised"
+        );
+        assert!(
+            dispatcher
+                .tools()
+                .iter()
+                .any(|tool| tool.name == "blob_inspect"),
+            "other blob tools should remain available"
+        );
+
+        let call_json = serde_json::value::RawValue::from_string(
+            serde_json::json!({
+                "blob_id": blob_ref.blob_id.as_str(),
+                "path": "out.png",
+            })
+            .to_string(),
+        )
+        .unwrap();
+        let call = ToolCallView {
+            id: "blob-save",
+            name: "blob_save_file",
+            args: &call_json,
+        };
+        let err = dispatcher.dispatch(call).await.unwrap_err();
+        assert!(matches!(err, ToolError::AccessDenied { .. }));
+    }
+
+    #[tokio::test]
+    async fn blob_file_tools_survive_ops_lifecycle_rebind() {
+        let temp_dir = TempDir::new().unwrap();
+        let store: Arc<dyn BlobStore> = Arc::new(TestBlobStore::default());
+        let mut dispatcher = CompositeDispatcher::new(
+            Arc::new(MemoryTaskStore::new()),
+            &BuiltinToolConfig::default(),
+            Some(temp_dir.path().to_path_buf()),
+            None,
+            None,
+            Some(SessionId::new().to_string()),
+            true,
+        )
+        .expect("composite dispatcher should build");
+        dispatcher.register_blob_file_tools(store);
+
+        let registry: Arc<dyn OpsLifecycleRegistry> =
+            Arc::new(meerkat_runtime::RuntimeOpsLifecycleRegistry::new());
+        let rebound = Arc::new(dispatcher)
+            .bind_ops_lifecycle(registry, SessionId::new())
+            .expect("ops lifecycle binding should preserve blob tools")
+            .into_dispatcher();
+
+        let names: Vec<_> = rebound
+            .tools()
+            .iter()
+            .map(|tool| tool.name.to_string())
+            .collect();
+        for expected in ["blob_save_file", "blob_load_file", "blob_inspect"] {
+            assert!(
+                names.contains(&expected.to_string()),
+                "{expected} should survive ops lifecycle rebinding; tools={names:?}"
+            );
+        }
     }
 
     #[test]

--- a/meerkat-tools/src/builtin/image_generation.rs
+++ b/meerkat-tools/src/builtin/image_generation.rs
@@ -131,6 +131,8 @@ pub struct GenerateImageTool {
 
 const GENERATE_IMAGE_TOOL_DOCUMENTATION: &str = r#"Generate or edit an assistant image through the session-owned image substrate.
 
+Use this tool whenever the user asks you to generate, create, draw, render, or edit an image. If the user asks to save the result to disk, generate the image here first, then save the returned blob with `blob_save_file`. Do not use shell scripts, drawing libraries, or placeholder files as a substitute for requested image generation when this tool is available.
+
 Use a simple request shape unless you explicitly need the canonical internal shape:
 {"request":{"intent":"generate","prompt":"a cozy tabby cat by a sunlit window","size":"1024x1024","quality":"auto","format":"png","count":1}}
 

--- a/meerkat-tools/src/builtin/shell/tool.rs
+++ b/meerkat-tools/src/builtin/shell/tool.rs
@@ -399,10 +399,13 @@ impl BuiltinTool for ShellTool {
         ToolDef {
             name: "shell".into(),
             description:
-                "Execute a shell command (POSIX-style parsing for policy checks; runs via Nushell or fallback shell)"
+                "Execute a shell command (POSIX-style parsing for policy checks; runs via Nushell or fallback shell). Do not use shell scripts or drawing libraries to satisfy image-generation requests when generate_image is available; use generate_image and blob_save_file instead."
                     .into(),
             input_schema: crate::schema::schema_for::<ShellInput>(),
-            provenance: Some(ToolProvenance { kind: ToolSourceKind::Shell, source_id: "shell".into() }),
+            provenance: Some(ToolProvenance {
+                kind: ToolSourceKind::Shell,
+                source_id: "shell".into(),
+            }),
         }
     }
 

--- a/meerkat-tools/src/builtin/utility/blob_file.rs
+++ b/meerkat-tools/src/builtin/utility/blob_file.rs
@@ -1,0 +1,769 @@
+//! Blob file bridge tools.
+
+use crate::builtin::{BuiltinTool, BuiltinToolError, ToolOutput};
+use async_trait::async_trait;
+use base64::Engine;
+use meerkat_core::types::{ToolDef, ToolProvenance, ToolSourceKind};
+use meerkat_core::{BlobId, BlobStore};
+use serde::Deserialize;
+use serde_json::{Value, json};
+use std::path::{Component, Path, PathBuf};
+use std::sync::Arc;
+use tokio::io::AsyncWriteExt;
+
+const MAX_LOAD_FILE_SIZE: u64 = 25 * 1024 * 1024;
+
+const MEDIA_TYPES_BY_EXTENSION: &[(&str, &str)] = &[
+    ("png", "image/png"),
+    ("jpg", "image/jpeg"),
+    ("jpeg", "image/jpeg"),
+    ("gif", "image/gif"),
+    ("webp", "image/webp"),
+    ("svg", "image/svg+xml"),
+    ("txt", "text/plain; charset=utf-8"),
+    ("md", "text/markdown; charset=utf-8"),
+    ("json", "application/json"),
+    ("csv", "text/csv; charset=utf-8"),
+    ("pdf", "application/pdf"),
+];
+
+#[derive(Debug, Deserialize, schemars::JsonSchema)]
+struct BlobSaveFileArgs {
+    /// Blob ID to save.
+    blob_id: String,
+    /// Destination path, relative to project root or absolute within the project.
+    path: String,
+    /// Allow replacing an existing file. Defaults to false.
+    #[serde(default)]
+    overwrite: bool,
+}
+
+#[derive(Debug, Deserialize, schemars::JsonSchema)]
+struct BlobLoadFileArgs {
+    /// Source file path, relative to project root or absolute within the project.
+    path: String,
+    /// Optional media type. Inferred from the file extension when omitted.
+    #[serde(default)]
+    media_type: Option<String>,
+}
+
+#[derive(Debug, Deserialize, schemars::JsonSchema)]
+struct BlobInspectArgs {
+    /// Blob ID to inspect.
+    blob_id: String,
+}
+
+#[derive(Clone)]
+pub struct BlobSaveFileTool {
+    project_root: PathBuf,
+    blob_store: Arc<dyn BlobStore>,
+}
+
+impl BlobSaveFileTool {
+    pub fn new(project_root: PathBuf, blob_store: Arc<dyn BlobStore>) -> Self {
+        Self {
+            project_root,
+            blob_store,
+        }
+    }
+}
+
+#[derive(Clone)]
+pub struct BlobLoadFileTool {
+    project_root: PathBuf,
+    blob_store: Arc<dyn BlobStore>,
+}
+
+impl BlobLoadFileTool {
+    pub fn new(project_root: PathBuf, blob_store: Arc<dyn BlobStore>) -> Self {
+        Self {
+            project_root,
+            blob_store,
+        }
+    }
+}
+
+#[derive(Clone)]
+pub struct BlobInspectTool {
+    blob_store: Arc<dyn BlobStore>,
+}
+
+impl BlobInspectTool {
+    pub fn new(blob_store: Arc<dyn BlobStore>) -> Self {
+        Self { blob_store }
+    }
+}
+
+fn resolve_project_path(
+    project_root: &Path,
+    user_path: &Path,
+) -> Result<PathBuf, BuiltinToolError> {
+    let mut resolved = if user_path.is_absolute() {
+        PathBuf::new()
+    } else {
+        project_root.to_path_buf()
+    };
+
+    for component in user_path.components() {
+        match component {
+            Component::Prefix(_) => {
+                return Err(BuiltinToolError::invalid_args(format!(
+                    "unsupported path prefix '{}'",
+                    user_path.display()
+                )));
+            }
+            Component::RootDir => resolved = PathBuf::from("/"),
+            Component::CurDir => {}
+            Component::ParentDir => {
+                resolved.pop();
+            }
+            Component::Normal(segment) => resolved.push(segment),
+        }
+    }
+
+    if !resolved.starts_with(project_root) {
+        return Err(BuiltinToolError::invalid_args(format!(
+            "path '{}' escapes the project root",
+            user_path.display()
+        )));
+    }
+
+    Ok(resolved)
+}
+
+async fn canonical_project_root(project_root: &Path) -> Result<PathBuf, BuiltinToolError> {
+    tokio::fs::canonicalize(project_root).await.map_err(|err| {
+        BuiltinToolError::execution_failed(format!(
+            "cannot resolve project root '{}': {err}",
+            project_root.display()
+        ))
+    })
+}
+
+fn ensure_under_root(
+    canonical_root: &Path,
+    canonical_path: &Path,
+    original: &Path,
+) -> Result<(), BuiltinToolError> {
+    if canonical_path.starts_with(canonical_root) {
+        Ok(())
+    } else {
+        Err(BuiltinToolError::invalid_args(format!(
+            "path '{}' escapes the project root (symlink detected)",
+            original.display()
+        )))
+    }
+}
+
+async fn ensure_existing_file_under_root(
+    project_root: &Path,
+    resolved: &Path,
+    original: &Path,
+) -> Result<std::fs::Metadata, BuiltinToolError> {
+    let metadata = tokio::fs::metadata(resolved).await.map_err(|err| {
+        BuiltinToolError::execution_failed(format!("cannot read '{}': {err}", resolved.display()))
+    })?;
+    if !metadata.is_file() {
+        return Err(BuiltinToolError::invalid_args(format!(
+            "'{}' is not a file",
+            original.display()
+        )));
+    }
+    let canonical_root = canonical_project_root(project_root).await?;
+    let canonical_path = tokio::fs::canonicalize(resolved).await.map_err(|err| {
+        BuiltinToolError::execution_failed(format!(
+            "cannot resolve '{}': {err}",
+            resolved.display()
+        ))
+    })?;
+    ensure_under_root(&canonical_root, &canonical_path, original)?;
+    Ok(metadata)
+}
+
+async fn ensure_writable_parent_under_root(
+    project_root: &Path,
+    resolved: &Path,
+    original: &Path,
+) -> Result<(), BuiltinToolError> {
+    let parent = resolved.parent().ok_or_else(|| {
+        BuiltinToolError::invalid_args(format!("path '{}' has no parent", original.display()))
+    })?;
+    let canonical_root = canonical_project_root(project_root).await?;
+    let relative_parent = parent.strip_prefix(project_root).map_err(|_| {
+        BuiltinToolError::invalid_args(format!(
+            "path '{}' escapes the project root",
+            original.display()
+        ))
+    })?;
+    let mut current = project_root.to_path_buf();
+    for component in relative_parent.components() {
+        match component {
+            Component::CurDir => continue,
+            Component::Normal(segment) => current.push(segment),
+            _ => {
+                return Err(BuiltinToolError::invalid_args(format!(
+                    "path '{}' escapes the project root",
+                    original.display()
+                )));
+            }
+        }
+
+        match tokio::fs::symlink_metadata(&current).await {
+            Ok(metadata) => {
+                let canonical_current = tokio::fs::canonicalize(&current).await.map_err(|err| {
+                    BuiltinToolError::execution_failed(format!(
+                        "cannot resolve '{}': {err}",
+                        current.display()
+                    ))
+                })?;
+                ensure_under_root(&canonical_root, &canonical_current, original)?;
+                let target_metadata = if metadata.file_type().is_symlink() {
+                    tokio::fs::metadata(&current).await.map_err(|err| {
+                        BuiltinToolError::execution_failed(format!(
+                            "cannot inspect parent directory '{}': {err}",
+                            current.display()
+                        ))
+                    })?
+                } else {
+                    metadata
+                };
+                if !target_metadata.is_dir() {
+                    return Err(BuiltinToolError::invalid_args(format!(
+                        "'{}' is not a directory",
+                        current.display()
+                    )));
+                }
+            }
+            Err(err) if err.kind() == std::io::ErrorKind::NotFound => {
+                tokio::fs::create_dir(&current).await.map_err(|err| {
+                    BuiltinToolError::execution_failed(format!(
+                        "failed to create parent directory '{}': {err}",
+                        current.display()
+                    ))
+                })?;
+                let canonical_current = tokio::fs::canonicalize(&current).await.map_err(|err| {
+                    BuiltinToolError::execution_failed(format!(
+                        "cannot resolve '{}': {err}",
+                        current.display()
+                    ))
+                })?;
+                ensure_under_root(&canonical_root, &canonical_current, original)?;
+            }
+            Err(err) => {
+                return Err(BuiltinToolError::execution_failed(format!(
+                    "cannot inspect parent directory '{}': {err}",
+                    current.display()
+                )));
+            }
+        }
+    }
+    Ok(())
+}
+
+fn infer_media_type(path: &Path) -> Result<String, BuiltinToolError> {
+    let extension = path
+        .extension()
+        .and_then(|ext| ext.to_str())
+        .ok_or_else(|| {
+            BuiltinToolError::invalid_args(format!(
+                "cannot infer media type for '{}'; provide media_type",
+                path.display()
+            ))
+        })?;
+    let extension = extension.to_ascii_lowercase();
+    MEDIA_TYPES_BY_EXTENSION
+        .iter()
+        .find(|(ext, _)| *ext == extension)
+        .map(|(_, media_type)| (*media_type).to_string())
+        .ok_or_else(|| {
+            BuiltinToolError::invalid_args(format!(
+                "cannot infer media type from extension '.{extension}'; provide media_type"
+            ))
+        })
+}
+
+fn relative_or_absolute_display(project_root: &Path, path: &Path) -> String {
+    path.strip_prefix(project_root)
+        .unwrap_or(path)
+        .display()
+        .to_string()
+}
+
+#[async_trait]
+impl BuiltinTool for BlobSaveFileTool {
+    fn name(&self) -> &'static str {
+        "blob_save_file"
+    }
+
+    fn def(&self) -> ToolDef {
+        ToolDef {
+            name: self.name().into(),
+            description: "Save blob bytes from the session blob store to a file inside the project root. For generated-image requests, first call generate_image, then call this tool with the returned blob id. Does not transcode formats and never returns raw bytes.".into(),
+            input_schema: crate::schema::schema_for::<BlobSaveFileArgs>(),
+            provenance: Some(ToolProvenance {
+                kind: ToolSourceKind::Builtin,
+                source_id: "builtin".into(),
+            }),
+        }
+    }
+
+    fn default_enabled(&self) -> bool {
+        true
+    }
+
+    async fn call(&self, args: Value) -> Result<ToolOutput, BuiltinToolError> {
+        let args: BlobSaveFileArgs = serde_json::from_value(args)
+            .map_err(|err| BuiltinToolError::invalid_args(err.to_string()))?;
+        let user_path = PathBuf::from(&args.path);
+        let resolved = resolve_project_path(&self.project_root, &user_path)?;
+        let payload = self
+            .blob_store
+            .get(&BlobId::new(args.blob_id.clone()))
+            .await
+            .map_err(|err| BuiltinToolError::execution_failed(err.to_string()))?;
+        let bytes = base64::engine::general_purpose::STANDARD
+            .decode(payload.data.as_bytes())
+            .map_err(|err| {
+                BuiltinToolError::execution_failed(format!(
+                    "blob '{}' payload is not valid base64: {err}",
+                    payload.blob_id
+                ))
+            })?;
+
+        ensure_writable_parent_under_root(&self.project_root, &resolved, &user_path).await?;
+        if tokio::fs::try_exists(&resolved).await.map_err(|err| {
+            BuiltinToolError::execution_failed(format!(
+                "failed to check destination '{}': {err}",
+                resolved.display()
+            ))
+        })? {
+            if !args.overwrite {
+                return Err(BuiltinToolError::invalid_args(format!(
+                    "destination '{}' already exists; set overwrite=true to replace it",
+                    user_path.display()
+                )));
+            }
+            ensure_existing_file_under_root(&self.project_root, &resolved, &user_path).await?;
+        }
+
+        let mut options = tokio::fs::OpenOptions::new();
+        options.write(true);
+        if args.overwrite {
+            options.create(true).truncate(true);
+        } else {
+            options.create_new(true);
+        }
+        let mut file = options.open(&resolved).await.map_err(|err| {
+            BuiltinToolError::execution_failed(format!(
+                "failed to open destination '{}': {err}",
+                resolved.display()
+            ))
+        })?;
+        file.write_all(&bytes).await.map_err(|err| {
+            BuiltinToolError::execution_failed(format!(
+                "failed to write destination '{}': {err}",
+                resolved.display()
+            ))
+        })?;
+        file.flush().await.map_err(|err| {
+            BuiltinToolError::execution_failed(format!(
+                "failed to flush destination '{}': {err}",
+                resolved.display()
+            ))
+        })?;
+
+        Ok(ToolOutput::Json(json!({
+            "blob_id": payload.blob_id,
+            "media_type": payload.media_type,
+            "path": relative_or_absolute_display(&self.project_root, &resolved),
+            "bytes_written": bytes.len(),
+        })))
+    }
+}
+
+#[async_trait]
+impl BuiltinTool for BlobLoadFileTool {
+    fn name(&self) -> &'static str {
+        "blob_load_file"
+    }
+
+    fn def(&self) -> ToolDef {
+        ToolDef {
+            name: self.name().into(),
+            description: "Read a file from inside the project root and store its bytes in the session blob store. Returns a blob id that other blob-aware tools can use.".into(),
+            input_schema: crate::schema::schema_for::<BlobLoadFileArgs>(),
+            provenance: Some(ToolProvenance {
+                kind: ToolSourceKind::Builtin,
+                source_id: "builtin".into(),
+            }),
+        }
+    }
+
+    fn default_enabled(&self) -> bool {
+        true
+    }
+
+    async fn call(&self, args: Value) -> Result<ToolOutput, BuiltinToolError> {
+        let args: BlobLoadFileArgs = serde_json::from_value(args)
+            .map_err(|err| BuiltinToolError::invalid_args(err.to_string()))?;
+        let user_path = PathBuf::from(&args.path);
+        let resolved = resolve_project_path(&self.project_root, &user_path)?;
+        let metadata =
+            ensure_existing_file_under_root(&self.project_root, &resolved, &user_path).await?;
+        if metadata.len() > MAX_LOAD_FILE_SIZE {
+            return Err(BuiltinToolError::invalid_args(format!(
+                "file size {} bytes exceeds maximum {} bytes",
+                metadata.len(),
+                MAX_LOAD_FILE_SIZE
+            )));
+        }
+        let media_type = match args.media_type {
+            Some(media_type) => media_type,
+            None => infer_media_type(&resolved)?,
+        };
+        let bytes = tokio::fs::read(&resolved).await.map_err(|err| {
+            BuiltinToolError::execution_failed(format!(
+                "failed to read '{}': {err}",
+                resolved.display()
+            ))
+        })?;
+        let data = base64::engine::general_purpose::STANDARD.encode(&bytes);
+        let blob_ref = self
+            .blob_store
+            .put_artifact(&media_type, &data)
+            .await
+            .map_err(|err| BuiltinToolError::execution_failed(err.to_string()))?;
+        Ok(ToolOutput::Json(json!({
+            "blob_id": blob_ref.blob_id,
+            "media_type": blob_ref.media_type,
+            "path": relative_or_absolute_display(&self.project_root, &resolved),
+            "bytes_read": bytes.len(),
+        })))
+    }
+}
+
+#[async_trait]
+impl BuiltinTool for BlobInspectTool {
+    fn name(&self) -> &'static str {
+        "blob_inspect"
+    }
+
+    fn def(&self) -> ToolDef {
+        ToolDef {
+            name: self.name().into(),
+            description: "Inspect a blob in the session blob store without returning raw bytes. Returns blob id, media type, and decoded byte size.".into(),
+            input_schema: crate::schema::schema_for::<BlobInspectArgs>(),
+            provenance: Some(ToolProvenance {
+                kind: ToolSourceKind::Builtin,
+                source_id: "builtin".into(),
+            }),
+        }
+    }
+
+    fn default_enabled(&self) -> bool {
+        true
+    }
+
+    async fn call(&self, args: Value) -> Result<ToolOutput, BuiltinToolError> {
+        let args: BlobInspectArgs = serde_json::from_value(args)
+            .map_err(|err| BuiltinToolError::invalid_args(err.to_string()))?;
+        let payload = self
+            .blob_store
+            .get(&BlobId::new(args.blob_id))
+            .await
+            .map_err(|err| BuiltinToolError::execution_failed(err.to_string()))?;
+        let size_bytes = base64::engine::general_purpose::STANDARD
+            .decode(payload.data.as_bytes())
+            .map_err(|err| {
+                BuiltinToolError::execution_failed(format!(
+                    "blob '{}' payload is not valid base64: {err}",
+                    payload.blob_id
+                ))
+            })?
+            .len();
+        Ok(ToolOutput::Json(json!({
+            "blob_id": payload.blob_id,
+            "media_type": payload.media_type,
+            "size_bytes": size_bytes,
+        })))
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used)]
+mod tests {
+    use super::*;
+    use meerkat_core::{BlobPayload, BlobRef, BlobStoreError};
+    use std::collections::HashMap;
+    use tokio::sync::Mutex;
+
+    #[derive(Default)]
+    struct TestBlobStore {
+        blobs: Mutex<HashMap<BlobId, BlobPayload>>,
+    }
+
+    #[async_trait]
+    impl BlobStore for TestBlobStore {
+        async fn put_image(&self, media_type: &str, data: &str) -> Result<BlobRef, BlobStoreError> {
+            let blob_id = BlobId::new(format!("sha256:test-{media_type}-{data}"));
+            let payload = BlobPayload {
+                blob_id: blob_id.clone(),
+                media_type: media_type.to_string(),
+                data: data.to_string(),
+            };
+            self.blobs.lock().await.insert(blob_id.clone(), payload);
+            Ok(BlobRef {
+                blob_id,
+                media_type: media_type.to_string(),
+            })
+        }
+
+        async fn get(&self, blob_id: &BlobId) -> Result<BlobPayload, BlobStoreError> {
+            self.blobs
+                .lock()
+                .await
+                .get(blob_id)
+                .cloned()
+                .ok_or_else(|| BlobStoreError::NotFound(blob_id.clone()))
+        }
+
+        async fn delete(&self, blob_id: &BlobId) -> Result<(), BlobStoreError> {
+            self.blobs.lock().await.remove(blob_id);
+            Ok(())
+        }
+
+        fn is_persistent(&self) -> bool {
+            false
+        }
+    }
+
+    fn png_bytes() -> Vec<u8> {
+        vec![0x89, b'P', b'N', b'G', 0x0D, 0x0A, 0x1A, 0x0A, 1, 2, 3]
+    }
+
+    async fn seeded_store() -> (Arc<dyn BlobStore>, BlobId) {
+        let store: Arc<dyn BlobStore> = Arc::new(TestBlobStore::default());
+        let data = base64::engine::general_purpose::STANDARD.encode(png_bytes());
+        let blob_ref = store.put_image("image/png", &data).await.unwrap();
+        (store, blob_ref.blob_id)
+    }
+
+    #[tokio::test]
+    async fn save_file_writes_blob_bytes() {
+        let temp = tempfile::tempdir().unwrap();
+        let (store, blob_id) = seeded_store().await;
+        let tool = BlobSaveFileTool::new(temp.path().to_path_buf(), store);
+        let output = tool
+            .call(json!({
+                "blob_id": blob_id.as_str(),
+                "path": "out/top-news-infographic.png"
+            }))
+            .await
+            .unwrap()
+            .into_json()
+            .unwrap();
+
+        let written = tokio::fs::read(temp.path().join("out/top-news-infographic.png"))
+            .await
+            .unwrap();
+        assert_eq!(
+            &written[..8],
+            &[0x89, b'P', b'N', b'G', 0x0D, 0x0A, 0x1A, 0x0A]
+        );
+        assert_eq!(output["media_type"], "image/png");
+        assert_eq!(output["bytes_written"], png_bytes().len());
+    }
+
+    #[tokio::test]
+    async fn save_file_rejects_overwrite_by_default() {
+        let temp = tempfile::tempdir().unwrap();
+        tokio::fs::write(temp.path().join("out.png"), b"old")
+            .await
+            .unwrap();
+        let (store, blob_id) = seeded_store().await;
+        let tool = BlobSaveFileTool::new(temp.path().to_path_buf(), store);
+        let err = tool
+            .call(json!({
+                "blob_id": blob_id.as_str(),
+                "path": "out.png"
+            }))
+            .await
+            .unwrap_err();
+        assert!(err.to_string().contains("already exists"));
+    }
+
+    #[tokio::test]
+    async fn save_file_allows_explicit_overwrite() {
+        let temp = tempfile::tempdir().unwrap();
+        tokio::fs::write(temp.path().join("out.png"), b"old")
+            .await
+            .unwrap();
+        let (store, blob_id) = seeded_store().await;
+        let tool = BlobSaveFileTool::new(temp.path().to_path_buf(), store);
+        tool.call(json!({
+            "blob_id": blob_id.as_str(),
+            "path": "out.png",
+            "overwrite": true
+        }))
+        .await
+        .unwrap();
+        let written = tokio::fs::read(temp.path().join("out.png")).await.unwrap();
+        assert_eq!(written, png_bytes());
+    }
+
+    #[tokio::test]
+    async fn save_file_rejects_missing_blob() {
+        let temp = tempfile::tempdir().unwrap();
+        let store: Arc<dyn BlobStore> = Arc::new(TestBlobStore::default());
+        let tool = BlobSaveFileTool::new(temp.path().to_path_buf(), store);
+        let err = tool
+            .call(json!({
+                "blob_id": "sha256:missing",
+                "path": "out.png"
+            }))
+            .await
+            .unwrap_err();
+        assert!(err.to_string().contains("blob not found"));
+    }
+
+    #[tokio::test]
+    async fn load_file_stores_blob_with_inferred_media_type() {
+        let temp = tempfile::tempdir().unwrap();
+        tokio::fs::write(temp.path().join("source.png"), png_bytes())
+            .await
+            .unwrap();
+        let store: Arc<dyn BlobStore> = Arc::new(TestBlobStore::default());
+        let tool = BlobLoadFileTool::new(temp.path().to_path_buf(), store.clone());
+        let output = tool
+            .call(json!({"path": "source.png"}))
+            .await
+            .unwrap()
+            .into_json()
+            .unwrap();
+        assert_eq!(output["media_type"], "image/png");
+        let blob_id = BlobId::new(output["blob_id"].as_str().unwrap());
+        let payload = store.get(&blob_id).await.unwrap();
+        assert_eq!(payload.media_type, "image/png");
+    }
+
+    #[tokio::test]
+    async fn load_file_accepts_explicit_media_type() {
+        let temp = tempfile::tempdir().unwrap();
+        tokio::fs::write(temp.path().join("source.bin"), b"abc")
+            .await
+            .unwrap();
+        let store: Arc<dyn BlobStore> = Arc::new(TestBlobStore::default());
+        let tool = BlobLoadFileTool::new(temp.path().to_path_buf(), store);
+        let output = tool
+            .call(json!({"path": "source.bin", "media_type": "application/custom"}))
+            .await
+            .unwrap()
+            .into_json()
+            .unwrap();
+        assert_eq!(output["media_type"], "application/custom");
+        assert_eq!(output["bytes_read"], 3);
+    }
+
+    #[tokio::test]
+    async fn load_file_requires_media_type_when_extension_is_unknown() {
+        let temp = tempfile::tempdir().unwrap();
+        tokio::fs::write(temp.path().join("source.unknown"), b"abc")
+            .await
+            .unwrap();
+        let store: Arc<dyn BlobStore> = Arc::new(TestBlobStore::default());
+        let tool = BlobLoadFileTool::new(temp.path().to_path_buf(), store);
+        let err = tool
+            .call(json!({"path": "source.unknown"}))
+            .await
+            .unwrap_err();
+        assert!(err.to_string().contains("cannot infer media type"));
+    }
+
+    #[tokio::test]
+    async fn inspect_returns_metadata_without_bytes() {
+        let (store, blob_id) = seeded_store().await;
+        let tool = BlobInspectTool::new(store);
+        let output = tool
+            .call(json!({"blob_id": blob_id.as_str()}))
+            .await
+            .unwrap()
+            .into_json()
+            .unwrap();
+        assert_eq!(output["blob_id"], blob_id.as_str());
+        assert_eq!(output["media_type"], "image/png");
+        assert_eq!(output["size_bytes"], png_bytes().len());
+        assert!(output.get("data").is_none());
+    }
+
+    #[tokio::test]
+    async fn tools_reject_path_traversal() {
+        let temp = tempfile::tempdir().unwrap();
+        let (store, blob_id) = seeded_store().await;
+        let save = BlobSaveFileTool::new(temp.path().to_path_buf(), store.clone());
+        let save_err = save
+            .call(json!({
+                "blob_id": blob_id.as_str(),
+                "path": "../escape.png"
+            }))
+            .await
+            .unwrap_err();
+        assert!(save_err.to_string().contains("escapes the project root"));
+
+        let load = BlobLoadFileTool::new(temp.path().to_path_buf(), store);
+        let load_err = load
+            .call(json!({"path": "../escape.png"}))
+            .await
+            .unwrap_err();
+        assert!(load_err.to_string().contains("escapes the project root"));
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn tools_reject_symlink_escape() {
+        use std::os::unix::fs::symlink;
+
+        let temp = tempfile::tempdir().unwrap();
+        let outside = tempfile::tempdir().unwrap();
+        symlink(outside.path(), temp.path().join("link")).unwrap();
+        tokio::fs::write(outside.path().join("source.png"), png_bytes())
+            .await
+            .unwrap();
+
+        let (store, blob_id) = seeded_store().await;
+        let save = BlobSaveFileTool::new(temp.path().to_path_buf(), store.clone());
+        let save_err = save
+            .call(json!({
+                "blob_id": blob_id.as_str(),
+                "path": "link/sub/out.png"
+            }))
+            .await
+            .unwrap_err();
+        assert!(save_err.to_string().contains("symlink detected"));
+        assert!(
+            !outside.path().join("sub").exists(),
+            "save must reject a symlink escape before creating deeper directories"
+        );
+
+        let load = BlobLoadFileTool::new(temp.path().to_path_buf(), store);
+        let load_err = load
+            .call(json!({"path": "link/source.png"}))
+            .await
+            .unwrap_err();
+        assert!(load_err.to_string().contains("symlink detected"));
+    }
+
+    #[tokio::test]
+    async fn load_file_rejects_oversized_file() {
+        let temp = tempfile::tempdir().unwrap();
+        let path = temp.path().join("large.bin");
+        let file = std::fs::File::create(&path).unwrap();
+        file.set_len(MAX_LOAD_FILE_SIZE + 1).unwrap();
+        let store: Arc<dyn BlobStore> = Arc::new(TestBlobStore::default());
+        let tool = BlobLoadFileTool::new(temp.path().to_path_buf(), store);
+        let err = tool
+            .call(json!({"path": "large.bin", "media_type": "application/octet-stream"}))
+            .await
+            .unwrap_err();
+        assert!(err.to_string().contains("exceeds maximum"));
+    }
+}

--- a/meerkat-tools/src/builtin/utility/mod.rs
+++ b/meerkat-tools/src/builtin/utility/mod.rs
@@ -3,11 +3,14 @@
 //! This module provides utility tools that are useful across many agent workflows:
 //! - [`DateTimeTool`] - Get the current date and time
 //! - [`ApplyPatchTool`] - Apply structured file edits inside the project root
+//! - Blob file tools - Move files to and from the session blob store
 //!
 //! These tools are enabled by default when built-in tools are enabled.
 
 #[cfg(not(target_arch = "wasm32"))]
 mod apply_patch;
+#[cfg(not(target_arch = "wasm32"))]
+mod blob_file;
 mod datetime;
 mod tool_set;
 #[cfg(not(target_arch = "wasm32"))]
@@ -15,6 +18,8 @@ mod view_image;
 
 #[cfg(not(target_arch = "wasm32"))]
 pub use apply_patch::ApplyPatchTool;
+#[cfg(not(target_arch = "wasm32"))]
+pub use blob_file::{BlobInspectTool, BlobLoadFileTool, BlobSaveFileTool};
 pub use datetime::DateTimeTool;
 pub use tool_set::UtilityToolSet;
 #[cfg(not(target_arch = "wasm32"))]

--- a/meerkat-tools/src/lib.rs
+++ b/meerkat-tools/src/lib.rs
@@ -68,7 +68,7 @@ pub use schema::{empty_object_schema, schema_for};
 inventory::submit! {
     meerkat_contracts::CapabilityRegistration {
         id: meerkat_contracts::CapabilityId::Builtins,
-        description: "Built-in tools: task_list, task_create, task_get, task_update, datetime, apply_patch",
+        description: "Built-in tools: task_list, task_create, task_get, task_update, datetime, apply_patch, view_image, generate_image, blob_save_file, blob_load_file, blob_inspect",
         scope: meerkat_contracts::CapabilityScope::Universal,
         requires_feature: None,
         prerequisites: &[],

--- a/meerkat/src/factory.rs
+++ b/meerkat/src/factory.rs
@@ -2706,6 +2706,10 @@ impl AgentFactory {
                 .register_skill_tools(meerkat_tools::builtin::skills::SkillToolSet::new(engine));
         }
 
+        if let Some(blob_store) = image_generation_blob_store.clone() {
+            composite.register_blob_file_tools(blob_store);
+        }
+
         if let (Some(session_id), Some(machine), Some(executor), Some(planner), Some(blob_store)) = (
             session_id
                 .as_deref()
@@ -4203,11 +4207,14 @@ mod tests {
         SourceIdentityLineageEvent, SourceIdentityRecord, SourceIdentityRegistry,
         SourceIdentityStatus, SourceTransportKind, SourceUuid,
     };
+    use meerkat_core::types::ToolCallView;
     use meerkat_core::{
-        BackendProfileConfig, BindingId, CredentialSourceSpec, ProviderBindingConfig,
-        RealmConfigSection, SelfHostedApiStyle, SelfHostedModelConfig, SelfHostedServerConfig,
-        SelfHostedTransport,
+        BackendProfileConfig, BindingId, BlobId, BlobPayload, BlobRef, BlobStoreError,
+        CredentialSourceSpec, ProviderBindingConfig, RealmConfigSection, SelfHostedApiStyle,
+        SelfHostedModelConfig, SelfHostedServerConfig, SelfHostedTransport,
     };
+    use std::collections::HashMap;
+    use tokio::sync::Mutex;
 
     struct NeverLlmClient;
 
@@ -4270,6 +4277,48 @@ mod tests {
             _id: &meerkat_core::SessionId,
         ) -> Result<(), meerkat_store::SessionStoreError> {
             Ok(())
+        }
+    }
+
+    #[derive(Default)]
+    struct TestBlobStore {
+        blobs: Mutex<HashMap<BlobId, BlobPayload>>,
+    }
+
+    #[async_trait]
+    impl BlobStore for TestBlobStore {
+        async fn put_image(&self, media_type: &str, data: &str) -> Result<BlobRef, BlobStoreError> {
+            let blob_id = BlobId::new(format!("sha256:{media_type}:{data}"));
+            self.blobs.lock().await.insert(
+                blob_id.clone(),
+                BlobPayload {
+                    blob_id: blob_id.clone(),
+                    media_type: media_type.to_string(),
+                    data: data.to_string(),
+                },
+            );
+            Ok(BlobRef {
+                blob_id,
+                media_type: media_type.to_string(),
+            })
+        }
+
+        async fn get(&self, blob_id: &BlobId) -> Result<BlobPayload, BlobStoreError> {
+            self.blobs
+                .lock()
+                .await
+                .get(blob_id)
+                .cloned()
+                .ok_or_else(|| BlobStoreError::NotFound(blob_id.clone()))
+        }
+
+        async fn delete(&self, blob_id: &BlobId) -> Result<(), BlobStoreError> {
+            self.blobs.lock().await.remove(blob_id);
+            Ok(())
+        }
+
+        fn is_persistent(&self) -> bool {
+            false
         }
     }
 
@@ -7313,6 +7362,118 @@ mod tests {
         let factory = AgentFactory::new(temp.path().join("sessions")).project_root(&explicit_root);
 
         assert_eq!(factory.shell_project_root(), explicit_root);
+    }
+
+    #[cfg(not(target_arch = "wasm32"))]
+    #[tokio::test]
+    async fn factory_exposes_blob_tools_when_blob_store_is_wired() {
+        let temp = tempfile::tempdir().unwrap();
+        let project_root = temp.path().join("workspace");
+        tokio::fs::create_dir_all(&project_root).await.unwrap();
+        tokio::fs::write(
+            project_root.join("source.png"),
+            [0x89, b'P', b'N', b'G', 0x0D, 0x0A, 0x1A, 0x0A],
+        )
+        .await
+        .unwrap();
+        let blob_store = Arc::new(TestBlobStore::default());
+        let factory = AgentFactory::new(temp.path().join("sessions")).project_root(&project_root);
+        let ops_lifecycle: Arc<dyn OpsLifecycleRegistry> =
+            Arc::new(RuntimeOpsLifecycleRegistry::new());
+
+        let (dispatcher, usage) = factory
+            .build_tool_dispatcher_for_agent_with_overrides(
+                &Config::default(),
+                None,
+                true,
+                false,
+                None,
+                None,
+                SessionId::new().to_string(),
+                ops_lifecycle,
+                true,
+                None,
+                None,
+                None,
+                Some(blob_store.clone()),
+                ToolCategoryOverride::Inherit,
+            )
+            .await
+            .expect("dispatcher should build with blob store");
+
+        for expected in ["blob_save_file", "blob_load_file", "blob_inspect"] {
+            assert!(
+                dispatcher.tools().iter().any(|tool| tool.name == expected),
+                "{expected} should be visible through factory-built builtins"
+            );
+            assert!(
+                usage.contains(expected),
+                "{expected} should appear in usage instructions"
+            );
+        }
+
+        let call_json =
+            serde_json::value::RawValue::from_string(r#"{"path":"source.png"}"#.to_string())
+                .unwrap();
+        let call = ToolCallView {
+            id: "blob-load",
+            name: "blob_load_file",
+            args: &call_json,
+        };
+        let outcome = dispatcher
+            .dispatch(call)
+            .await
+            .expect("blob_load_file dispatch should succeed");
+        let payload: serde_json::Value =
+            serde_json::from_str(&outcome.result.text_content()).unwrap();
+        let blob_id = BlobId::new(payload["blob_id"].as_str().unwrap());
+        assert_eq!(
+            blob_store.get(&blob_id).await.unwrap().media_type,
+            "image/png"
+        );
+    }
+
+    #[cfg(not(target_arch = "wasm32"))]
+    #[tokio::test]
+    async fn factory_does_not_expose_blob_tools_without_blob_store() {
+        let temp = tempfile::tempdir().unwrap();
+        let project_root = temp.path().join("workspace");
+        tokio::fs::create_dir_all(&project_root).await.unwrap();
+        let factory = AgentFactory::new(temp.path().join("sessions")).project_root(&project_root);
+        let ops_lifecycle: Arc<dyn OpsLifecycleRegistry> =
+            Arc::new(RuntimeOpsLifecycleRegistry::new());
+
+        let (dispatcher, usage) = factory
+            .build_tool_dispatcher_for_agent_with_overrides(
+                &Config::default(),
+                None,
+                true,
+                false,
+                None,
+                None,
+                SessionId::new().to_string(),
+                ops_lifecycle,
+                true,
+                None,
+                None,
+                None,
+                None,
+                ToolCategoryOverride::Inherit,
+            )
+            .await
+            .expect("dispatcher should build without blob store");
+
+        assert!(
+            dispatcher
+                .tools()
+                .iter()
+                .all(|tool| !tool.name.starts_with("blob_")),
+            "blob tools should be absent without a session blob store"
+        );
+        assert!(
+            !usage.contains("blob_save_file"),
+            "blob tool usage should be absent without a session blob store"
+        );
     }
 }
 

--- a/meerkat/src/help_content/api_reference.md
+++ b/meerkat/src/help_content/api_reference.md
@@ -246,6 +246,7 @@ CLI image generation is assistant-mediated; there is no direct `rkat image` comm
 ```bash
 rkat run --allow-tool generate_image "Use generate_image to create a 1024x1024 PNG of a meerkat on a laptop. Return the blob id."
 rkat blob get <BLOB-ID> --output meerkat.png
+rkat run "Use generate_image to create a 1024x1024 PNG of a meerkat on a laptop. Save it to meerkat.png." --yolo -m gpt-5.5
 ```
 
 ### Realtime (capability-driven)

--- a/meerkat/src/help_content/cli_reference_skill.md
+++ b/meerkat/src/help_content/cli_reference_skill.md
@@ -130,11 +130,13 @@ global/realm options.
 ## Image Generation Via CLI
 
 Image generation is assistant-mediated. Ask through `rkat run`, allow the image
-tool, and fetch the returned blob id:
+tool, and fetch the returned blob id or ask the assistant to save the generated
+blob with `blob_save_file`:
 
 ```bash
 rkat run --allow-tool generate_image "Use generate_image to create a 1024x1024 PNG of a red fox in snow. Return the blob id."
 rkat blob get <BLOB-ID> --output fox.png
+rkat run "Use generate_image to create a 1024x1024 PNG of a red fox in snow. Save it to fox.png." --yolo -m gpt-5.5
 ```
 
 If the assistant did not print the blob id, resume the same session and ask for

--- a/meerkat/src/help_content/platform_skill.md
+++ b/meerkat/src/help_content/platform_skill.md
@@ -515,16 +515,19 @@ Prompts and tool results support multimodal content (text, images, and video). T
 
 **view_image builtin tool:** Reads images from disk (PNG/JPEG/GIF/WebP/SVG), returns base64 `ContentBlock::Image`. Path sandboxed to project root. 5 MB limit. Hidden on non-vision-capable models via `ToolScope` based on `ModelProfile.vision` and `ModelProfile.image_tool_results`.
 
-**generate_image builtin tool:** Session-owned assistant image generation. The model calls one stable tool with universal fields (`prompt`, `provider`, `model`, `size`, `quality`, `format`, `count`, reference/source images) plus provider-owned `provider_params`. Provider crates own image model profiles, supported parameters, and backend selection. Generated images are stored in the blob store; user-facing surfaces fetch blob payload/bytes by blob id via `rkat blob get <BLOB-ID>`, JSON-RPC `blob/get`, or SDK `get_blob` / `getBlob`.
+**generate_image builtin tool:** Session-owned assistant image generation. The model calls one stable tool with universal fields (`prompt`, `provider`, `model`, `size`, `quality`, `format`, `count`, reference/source images) plus provider-owned `provider_params`. Provider crates own image model profiles, supported parameters, and backend selection. Generated images are stored in the blob store; the model can save them to project files with `blob_save_file`, and user-facing surfaces can fetch blob payload/bytes by blob id via `rkat blob get <BLOB-ID>`, JSON-RPC `blob/get`, or SDK `get_blob` / `getBlob`.
+
+**Blob file builtin tools:** `blob_save_file` writes decoded blob bytes to a project-root-contained file, `blob_load_file` reads a project file into the blob store, and `blob_inspect` returns metadata (`blob_id`, `media_type`, decoded size) without raw base64. These are available only when builtins are enabled and the session has a blob store. No list/delete model tools are exposed.
 
 **Image generation via CLI:** There is no direct image-generation CLI command and no `rkat rpc` subcommand. Ask the assistant through a session, allow the image tool, and fetch the resulting blob:
 
 ```bash
 rkat run --allow-tool generate_image "Use generate_image to create a square PNG of a cozy tabby cat by a sunlit window. Return the blob id."
 rkat blob get <BLOB-ID> --output cat.png
+rkat run "Create a square PNG of a cozy tabby cat by a sunlit window and save it to cat.png." --yolo -m gpt-5.5
 ```
 
-Use `rkat blob get <BLOB-ID> --json` to inspect the blob payload. If the answer does not include a blob id, resume the session and ask for the blob id.
+Use `rkat blob get <BLOB-ID> --json` or the model-facing `blob_inspect` tool to inspect blob metadata. If the answer does not include a blob id or file path, resume the session and ask for it.
 
 **Provider capabilities:**
 | Provider | `vision` | `image_tool_results` | `inline_video` |

--- a/scripts/generate-bazel-rust-builds.mjs
+++ b/scripts/generate-bazel-rust-builds.mjs
@@ -1244,7 +1244,7 @@ for (const pkg of localPackages.values()) {
         ...workspaceDataLabels(target).filter((label) => label !== currentPackageRunfiles),
       ];
       const unitEnv = [`        "RUST_MIN_STACK": "16777216",`];
-      const unitSize = key === "meerkat-mob" ? "large" : "small";
+      const unitSize = key === "meerkat-mob" ? "large" : key === "xtask" ? "medium" : "small";
       if (key === "xtask") {
         const rustfmt = "@@rules_rust++rust+rustfmt_nightly-2026-04-16__aarch64-apple-darwin_tools//:rustfmt_bin";
         const rustfmtLib = "@@rules_rust++rust+rustfmt_nightly-2026-04-16__aarch64-apple-darwin_tools//:rustc_lib";

--- a/tests/integration/src/e2e_lanes.rs
+++ b/tests/integration/src/e2e_lanes.rs
@@ -4052,7 +4052,7 @@ fn scenario_spec(id: u16) -> Option<&'static Spec> {
         73 => Some(&Spec {
             id: Some(73),
             lane: Lane::Smoke,
-            title: "CLI generate_image OpenAI default",
+            title: "CLI generate_image blob save",
             timeout_secs: 900,
             required_env: &[&["RKAT_OPENAI_API_KEY", "OPENAI_API_KEY"]],
             required_bins: &["cargo"],

--- a/xtask/BUILD.bazel
+++ b/xtask/BUILD.bazel
@@ -85,7 +85,7 @@ rust_test(
         "fast",
         "unit",
     ],
-    size = "small",
+    size = "medium",
     data = [
         "//:workspace_runfiles",
         ":package_runfiles",


### PR DESCRIPTION
## Summary
- add built-in `blob_save_file`, `blob_load_file`, and `blob_inspect` tools wired to the session blob store
- wire blob file tools alongside `generate_image` and document the model-facing image-save flow
- preserve OpenAI Responses reasoning + final hosted-tool output items for same-provider replay, while still dropping progress deltas and provider-private items for Chat Completions/provider switches
- update scenario 73 e2e smoke to run the requested `--yolo -m gpt-5.5` top-news infographic save flow and assert the PNG plus tool calls

## Local validation
- `./scripts/repo-cargo fmt --all`
- `./scripts/repo-cargo test -p meerkat-openai --lib`
- `./scripts/repo-cargo test -p meerkat-tools blob_file --lib`
- `./scripts/repo-cargo test -p meerkat-tools blob_file_tools --lib`
- `./scripts/repo-cargo test -p meerkat blob_tools --lib`
- `./scripts/repo-cargo test -p rkat --bin rkat test_run_cli_surface_does_not_add_full_flag_alias`
- direct built-binary smoke saved a PNG: `/tmp/rkat-blob-live.NHya6c/top-news-infographic.png`, 1,888,318 bytes, PNG signature `89504e470d0a1a0a`
- `make e2e-smoke SCENARIO=73` passed in 471.555s
- pre-push hook passed: secrets, whitespace, fmt check, clippy changed crates, codegen verify, generated-header audit, response-status bridge guard, deterministic workspace gate
