### PR TITLE
[codex] Fix Bazel module lock refresh for releases

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ YELLOW := \033[0;33m
 RED := \033[0;31m
 NC := \033[0m
 
-.PHONY: all install-build-deps build test test-unit test-int e2e-fast e2e-build e2e-system e2e-live e2e-smoke e2e-auth test-int-real test-e2e test-all test-minimal test-feature-matrix-lib test-feature-matrix-surface test-feature-matrix test-surface-modularity test-sdk-python test-sdk-typescript test-sdk-suites lint lint-feature-matrix fmt fmt-check audit rust-lane-doctor agent-gate cargo-agent-gate buildbuddy-install buildbuddy-generate buildbuddy-generate-check buildbuddy-doctor buildbuddy-build buildbuddy-check buildbuddy-clippy buildbuddy-lint buildbuddy-test buildbuddy-test-all buildbuddy-test-unit buildbuddy-test-int buildbuddy-e2e-fast buildbuddy-e2e-system buildbuddy-e2e-live buildbuddy-e2e-smoke buildbuddy-e2e-auth buildbuddy-agent-gate buildbuddy-ci-dispatch buildbuddy-fast buildbuddy-benchmark buildbuddy-ci buildbuddy-ci-warm buildbuddy-ci-full buildbuddy-ci-full-warm ci ci-smoke release-preflight release-preflight-smoke release-workflow release-assets release-packages release-web-sdk publish-dry-run publish-dry-run-python publish-dry-run-typescript release-dry-run release-dry-run-smoke clean doc release install-hooks coverage check help legacy-surface-gate legacy-surface-inventory session-control-gate deprecated-backend-gate deprecated-backend-inventory dogma-cleanup-gate dogma-cleanup-gate-fixtures dogma-cleanup-ci-gate verify-version-parity verify-schema-freshness verify-rpc-surface-alignment verify-sdk-wrapper-freshness check-rust-release-config check-rust-release-packaging check-published-facade-link check-mini-skill-size bump-sdk-versions smoke-sdk-python-artifact smoke-sdk-typescript-artifact xtask-build machine-codegen machine-verify machine-check-drift seam-inventory rmat-audit audit-generated-headers
+.PHONY: all install-build-deps build test test-unit test-int e2e-fast e2e-build e2e-system e2e-live e2e-smoke e2e-auth test-int-real test-e2e test-all test-minimal test-feature-matrix-lib test-feature-matrix-surface test-feature-matrix test-surface-modularity test-sdk-python test-sdk-typescript test-sdk-suites lint lint-feature-matrix fmt fmt-check audit rust-lane-doctor agent-gate cargo-agent-gate buildbuddy-install buildbuddy-generate buildbuddy-lock-update buildbuddy-generate-check buildbuddy-doctor buildbuddy-build buildbuddy-check buildbuddy-clippy buildbuddy-lint buildbuddy-test buildbuddy-test-all buildbuddy-test-unit buildbuddy-test-int buildbuddy-e2e-fast buildbuddy-e2e-system buildbuddy-e2e-live buildbuddy-e2e-smoke buildbuddy-e2e-auth buildbuddy-agent-gate buildbuddy-ci-dispatch buildbuddy-fast buildbuddy-benchmark buildbuddy-ci buildbuddy-ci-warm buildbuddy-ci-full buildbuddy-ci-full-warm ci ci-smoke release-preflight release-preflight-smoke release-workflow release-assets release-packages release-web-sdk publish-dry-run publish-dry-run-python publish-dry-run-typescript release-dry-run release-dry-run-smoke clean doc release install-hooks coverage check help legacy-surface-gate legacy-surface-inventory session-control-gate deprecated-backend-gate deprecated-backend-inventory dogma-cleanup-gate dogma-cleanup-gate-fixtures dogma-cleanup-ci-gate verify-version-parity verify-schema-freshness verify-rpc-surface-alignment verify-sdk-wrapper-freshness check-rust-release-config check-rust-release-packaging check-published-facade-link check-mini-skill-size bump-sdk-versions smoke-sdk-python-artifact smoke-sdk-typescript-artifact xtask-build machine-codegen machine-verify machine-check-drift seam-inventory rmat-audit audit-generated-headers
 
 # Default target
 all: ci
@@ -230,6 +230,10 @@ buildbuddy-install:
 buildbuddy-generate:
 	@echo "$(GREEN)Regenerating optional Bazel BUILD files...$(NC)"
 	@node scripts/generate-bazel-rust-builds.mjs
+
+buildbuddy-lock-update:
+	@echo "$(GREEN)Refreshing Bazel module lockfile...$(NC)"
+	@BB_BIN="$$(scripts/install-buildbuddy-cli)" && "$$BB_BIN" mod deps --lockfile_mode=update
 
 buildbuddy-generate-check:
 	@echo "$(GREEN)Checking generated optional Bazel BUILD files...$(NC)"
@@ -706,6 +710,7 @@ help:
 	@echo "  $(GREEN)dogma-cleanup-ci-gate$(NC)- Enforce dogma cleanup packet for signaled PRs"
 	@echo "  $(GREEN)buildbuddy-install$(NC)- Install pinned optional BuildBuddy CLI"
 	@echo "  $(GREEN)buildbuddy-generate$(NC)- Regenerate optional Bazel BUILD files"
+	@echo "  $(GREEN)buildbuddy-lock-update$(NC)- Refresh Bazel module lockfile"
 	@echo "  $(GREEN)buildbuddy-generate-check$(NC)- Check optional Bazel BUILD freshness"
 	@echo "  $(GREEN)buildbuddy-doctor$(NC)- Check optional BuildBuddy setup"
 	@echo "  $(GREEN)buildbuddy-build$(NC)- Build workspace with BuildBuddy"

--- a/scripts/buildbuddy-doctor
+++ b/scripts/buildbuddy-doctor
@@ -61,13 +61,18 @@ else
   bad "BuildBuddy API key is not configured; set BUILDBUDDY_API_KEY or add it to ~/.zshrc"
 fi
 
+bb_bin=""
 if [[ -n "${BUILDBUDDY_BB:-}" && -x "${BUILDBUDDY_BB}" ]]; then
+  bb_bin="${BUILDBUDDY_BB}"
   pass "BuildBuddy CLI found via BUILDBUDDY_BB"
 elif command -v bb >/dev/null 2>&1; then
+  bb_bin="$(command -v bb)"
   pass "BuildBuddy CLI found on PATH"
 elif [[ -x "${XDG_CACHE_HOME:-${HOME}/.cache}/meerkat/buildbuddy-cli/5.0.350/bin/bb" ]]; then
+  bb_bin="${XDG_CACHE_HOME:-${HOME}/.cache}/meerkat/buildbuddy-cli/5.0.350/bin/bb"
   pass "BuildBuddy CLI found in pinned repo cache"
 elif [[ -x /tmp/buildbuddy-poc/bin/bb ]]; then
+  bb_bin="/tmp/buildbuddy-poc/bin/bb"
   pass "BuildBuddy CLI found at /tmp/buildbuddy-poc/bin/bb"
 else
   bad "BuildBuddy CLI not found; run make buildbuddy-install or set BUILDBUDDY_BB"
@@ -103,6 +108,17 @@ else
   cat "${generate_check_log}" >&2
 fi
 rm -f "${generate_check_log}"
+
+module_lock_check_log="${TMPDIR:-/tmp}/meerkat-bazel-module-lock-check.$$"
+if [[ -n "${bb_bin}" ]]; then
+  if "${bb_bin}" mod deps --lockfile_mode=error >"${module_lock_check_log}" 2>&1; then
+    pass "Bazel module lockfile is up to date"
+  else
+    bad "Bazel module lockfile is stale; run make buildbuddy-lock-update"
+    cat "${module_lock_check_log}" >&2
+  fi
+fi
+rm -f "${module_lock_check_log}"
 
 fast_parity_output="$(node scripts/buildbuddy-fast-parity.mjs 2>&1 || true)"
 if [[ "${fast_parity_output}" == "BuildBuddy fast parity ok:"* ]]; then

--- a/scripts/release-hook.sh
+++ b/scripts/release-hook.sh
@@ -59,6 +59,9 @@ python3 "$ROOT/tools/sdk-codegen/generate.py"
 echo "==> Regenerating BuildBuddy BUILD files..."
 make buildbuddy-generate
 
+echo "==> Refreshing Bazel module lockfile..."
+make buildbuddy-lock-update
+
 # 3. Verify everything is in sync
 echo "==> Verifying version parity..."
 "$ROOT/scripts/verify-version-parity.sh"
@@ -71,6 +74,7 @@ echo "==> Verifying SDK wrapper freshness..."
 
 # 4. Stage SDK and artifact files for the release commit
 git add \
+    "$ROOT/MODULE.bazel.lock" \
     "$ROOT/meerkat-contracts/src/version.rs" \
     "$ROOT/sdks/python/pyproject.toml" \
     "$ROOT/sdks/typescript/package.json" \


### PR DESCRIPTION
## Summary
- refresh MODULE.bazel.lock for the v0.6.4 release bump so Bazel/Bzlmod stops failing before analysis
- add `make buildbuddy-lock-update` for explicit lock refreshes
- make the release hook refresh/stage the Bazel module lock and teach BuildBuddy doctor to catch stale locks

## Validation
- `make buildbuddy-generate-check`
- `make buildbuddy-lock-update`
- `bb mod deps --lockfile_mode=error`
- `make buildbuddy-doctor`
- `git diff --check`