### PR TITLE
Pin Rustup toolchain for CI cargo lanes

### DIFF
--- a/.github/actions/setup-buildbuddy-ci/action.yml
+++ b/.github/actions/setup-buildbuddy-ci/action.yml
@@ -14,10 +14,15 @@ runs:
       if: ${{ inputs.profile == 'submitter' || inputs.profile == 'doctor' || inputs.profile == 'lint' || inputs.profile == 'sdk' || inputs.profile == 'rust' || inputs.profile == 'wasm' || inputs.profile == 'audit' || inputs.profile == 'native' || inputs.profile == 'full' }}
       uses: dtolnay/rust-toolchain@1.94.0
 
+    - name: Export pinned Rustup toolchain
+      if: ${{ inputs.profile == 'submitter' || inputs.profile == 'doctor' || inputs.profile == 'lint' || inputs.profile == 'sdk' || inputs.profile == 'rust' || inputs.profile == 'wasm' || inputs.profile == 'audit' || inputs.profile == 'native' || inputs.profile == 'full' }}
+      shell: bash
+      run: echo "RUSTUP_TOOLCHAIN=1.94.0" >> "${GITHUB_ENV}"
+
     - name: Add wasm32 target
       if: ${{ inputs.profile == 'wasm' || inputs.profile == 'full' }}
       shell: bash
-      run: rustup target add wasm32-unknown-unknown
+      run: rustup target add --toolchain "${RUSTUP_TOOLCHAIN}" wasm32-unknown-unknown
 
     - name: Setup Python
       if: ${{ inputs.profile == 'sdk' || inputs.profile == 'full' }}

--- a/.github/actions/setup-buildbuddy-ci/action.yml
+++ b/.github/actions/setup-buildbuddy-ci/action.yml
@@ -14,10 +14,12 @@ runs:
       if: ${{ inputs.profile == 'submitter' || inputs.profile == 'doctor' || inputs.profile == 'lint' || inputs.profile == 'sdk' || inputs.profile == 'rust' || inputs.profile == 'wasm' || inputs.profile == 'audit' || inputs.profile == 'native' || inputs.profile == 'full' }}
       uses: dtolnay/rust-toolchain@1.94.0
 
-    - name: Export pinned Rustup toolchain
+    - name: Pin Rust toolchain binaries
       if: ${{ inputs.profile == 'submitter' || inputs.profile == 'doctor' || inputs.profile == 'lint' || inputs.profile == 'sdk' || inputs.profile == 'rust' || inputs.profile == 'wasm' || inputs.profile == 'audit' || inputs.profile == 'native' || inputs.profile == 'full' }}
       shell: bash
-      run: echo "RUSTUP_TOOLCHAIN=1.94.0" >> "${GITHUB_ENV}"
+      env:
+        RUSTUP_TOOLCHAIN: 1.94.0
+      run: scripts/ci-pin-rust-toolchain-env
 
     - name: Add wasm32 target
       if: ${{ inputs.profile == 'wasm' || inputs.profile == 'full' }}

--- a/.github/actions/setup-rust-ci/action.yml
+++ b/.github/actions/setup-rust-ci/action.yml
@@ -1,0 +1,12 @@
+name: Setup Rust CI
+description: Install Meerkat's pinned Rust toolchain and force its binaries ahead of runner defaults.
+
+runs:
+  using: composite
+  steps:
+    - name: Install Rust
+      uses: dtolnay/rust-toolchain@1.94.0
+
+    - name: Pin Rust toolchain binaries
+      shell: bash
+      run: scripts/ci-pin-rust-toolchain-env

--- a/.github/workflows/buildbuddy.yml
+++ b/.github/workflows/buildbuddy.yml
@@ -106,6 +106,7 @@ concurrency:
 
 env:
   CARGO_HOME: /tmp/meerkat-cargo-home
+  RUSTUP_TOOLCHAIN: 1.94.0
   MEERKAT_BUILDBUDDY: ${{ vars.MEERKAT_BUILDBUDDY || 'false' }}
   MEERKAT_BAZEL_BACKEND: ${{ inputs.backend || 'buildbuddy-hosted' }}
   BUILDBUDDY_BAZEL_CONFIG: ${{ (inputs.backend || '') == 'gcp-local' && 'gcp-linux' || (inputs.backend || '') == 'gcp-buildbuddy' && 'buildbuddy-linux-gcp-ci-rbe' || '' }}

--- a/.github/workflows/cargo.yml
+++ b/.github/workflows/cargo.yml
@@ -31,8 +31,8 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v6
 
-      - name: Install Rust
-        uses: dtolnay/rust-toolchain@1.94.0
+      - name: Setup Rust
+        uses: ./.github/actions/setup-rust-ci
 
       - name: Cache cargo registry
         uses: Swatinem/rust-cache@v2
@@ -76,8 +76,8 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v6
 
-      - name: Install Rust
-        uses: dtolnay/rust-toolchain@1.94.0
+      - name: Setup Rust
+        uses: ./.github/actions/setup-rust-ci
 
       - name: Cache cargo registry
         uses: Swatinem/rust-cache@v2
@@ -145,9 +145,9 @@ jobs:
         if: ${{ steps.machine-changes.outputs.changed != 'true' }}
         run: echo "No machine-authority inputs changed; skipping TLA+ machine checks."
 
-      - name: Install Rust
+      - name: Setup Rust
         if: ${{ steps.machine-changes.outputs.changed == 'true' }}
-        uses: dtolnay/rust-toolchain@1.94.0
+        uses: ./.github/actions/setup-rust-ci
 
       - name: Cache cargo registry
         if: ${{ steps.machine-changes.outputs.changed == 'true' }}
@@ -206,8 +206,8 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v6
 
-      - name: Install Rust
-        uses: dtolnay/rust-toolchain@1.94.0
+      - name: Setup Rust
+        uses: ./.github/actions/setup-rust-ci
 
       - name: Cache cargo registry
         uses: Swatinem/rust-cache@v2
@@ -230,8 +230,8 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v6
 
-      - name: Install Rust
-        uses: dtolnay/rust-toolchain@1.94.0
+      - name: Setup Rust
+        uses: ./.github/actions/setup-rust-ci
 
       - name: Cache cargo registry
         uses: Swatinem/rust-cache@v2
@@ -248,8 +248,8 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v6
 
-      - name: Install Rust
-        uses: dtolnay/rust-toolchain@1.94.0
+      - name: Setup Rust
+        uses: ./.github/actions/setup-rust-ci
 
       - name: Add wasm32 target
         run: rustup target add --toolchain "${RUSTUP_TOOLCHAIN}" wasm32-unknown-unknown
@@ -314,8 +314,8 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v6
 
-      - name: Install Rust
-        uses: dtolnay/rust-toolchain@1.94.0
+      - name: Setup Rust
+        uses: ./.github/actions/setup-rust-ci
 
       - name: Cache cargo registry
         uses: Swatinem/rust-cache@v2
@@ -335,8 +335,8 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v6
 
-      - name: Install Rust
-        uses: dtolnay/rust-toolchain@1.94.0
+      - name: Setup Rust
+        uses: ./.github/actions/setup-rust-ci
 
       - name: Add wasm32 target
         run: rustup target add --toolchain "${RUSTUP_TOOLCHAIN}" wasm32-unknown-unknown
@@ -369,8 +369,8 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v6
 
-      - name: Install Rust
-        uses: dtolnay/rust-toolchain@1.94.0
+      - name: Setup Rust
+        uses: ./.github/actions/setup-rust-ci
 
       - name: Cache cargo registry
         uses: Swatinem/rust-cache@v2
@@ -392,8 +392,8 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v6
 
-      - name: Install Rust
-        uses: dtolnay/rust-toolchain@1.94.0
+      - name: Setup Rust
+        uses: ./.github/actions/setup-rust-ci
 
       - name: Add wasm32 target
         run: rustup target add --toolchain "${RUSTUP_TOOLCHAIN}" wasm32-unknown-unknown
@@ -426,8 +426,8 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v6
 
-      - name: Install Rust
-        uses: dtolnay/rust-toolchain@1.94.0
+      - name: Setup Rust
+        uses: ./.github/actions/setup-rust-ci
 
       - name: Cache cargo registry
         uses: Swatinem/rust-cache@v2
@@ -455,8 +455,8 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v6
 
-      - name: Install Rust
-        uses: dtolnay/rust-toolchain@1.94.0
+      - name: Setup Rust
+        uses: ./.github/actions/setup-rust-ci
 
       - name: Cache cargo registry
         uses: Swatinem/rust-cache@v2
@@ -487,8 +487,8 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v6
 
-      - name: Install Rust
-        uses: dtolnay/rust-toolchain@1.94.0
+      - name: Setup Rust
+        uses: ./.github/actions/setup-rust-ci
 
       - name: Cache cargo registry
         uses: Swatinem/rust-cache@v2
@@ -508,8 +508,8 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v6
 
-      - name: Install Rust
-        uses: dtolnay/rust-toolchain@1.94.0
+      - name: Setup Rust
+        uses: ./.github/actions/setup-rust-ci
 
       - name: Add wasm32 target
         run: rustup target add --toolchain "${RUSTUP_TOOLCHAIN}" wasm32-unknown-unknown

--- a/.github/workflows/cargo.yml
+++ b/.github/workflows/cargo.yml
@@ -21,6 +21,7 @@ permissions:
 env:
   CARGO_TERM_COLOR: always
   CARGO_HOME: /tmp/meerkat-cargo-home
+  RUSTUP_TOOLCHAIN: 1.94.0
 
 jobs:
   fmt-lint:
@@ -251,7 +252,7 @@ jobs:
         uses: dtolnay/rust-toolchain@1.94.0
 
       - name: Add wasm32 target
-        run: rustup target add wasm32-unknown-unknown
+        run: rustup target add --toolchain "${RUSTUP_TOOLCHAIN}" wasm32-unknown-unknown
 
       - name: Cache cargo registry
         uses: Swatinem/rust-cache@v2
@@ -338,7 +339,7 @@ jobs:
         uses: dtolnay/rust-toolchain@1.94.0
 
       - name: Add wasm32 target
-        run: rustup target add wasm32-unknown-unknown
+        run: rustup target add --toolchain "${RUSTUP_TOOLCHAIN}" wasm32-unknown-unknown
 
       - name: Cache cargo registry
         uses: Swatinem/rust-cache@v2
@@ -395,7 +396,7 @@ jobs:
         uses: dtolnay/rust-toolchain@1.94.0
 
       - name: Add wasm32 target
-        run: rustup target add wasm32-unknown-unknown
+        run: rustup target add --toolchain "${RUSTUP_TOOLCHAIN}" wasm32-unknown-unknown
 
       - name: Cache cargo registry
         uses: Swatinem/rust-cache@v2
@@ -511,7 +512,7 @@ jobs:
         uses: dtolnay/rust-toolchain@1.94.0
 
       - name: Add wasm32 target
-        run: rustup target add wasm32-unknown-unknown
+        run: rustup target add --toolchain "${RUSTUP_TOOLCHAIN}" wasm32-unknown-unknown
 
       - name: Cache cargo registry
         uses: Swatinem/rust-cache@v2

--- a/.github/workflows/live-e2e.yml
+++ b/.github/workflows/live-e2e.yml
@@ -28,6 +28,7 @@ permissions:
 env:
   CARGO_TERM_COLOR: always
   CARGO_HOME: /tmp/meerkat-cargo-home
+  RUSTUP_TOOLCHAIN: 1.94.0
   BUILDBUDDY_API_KEY: ${{ secrets.BUILDBUDDY_API_KEY }}
   BUILDBUDDY_ENDPOINT: ${{ secrets.BUILDBUDDY_ENDPOINT }}
   ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
@@ -52,8 +53,8 @@ jobs:
     runs-on: ${{ fromJSON(vars.MEERKAT_CI_RUNNER || '"ubuntu-latest"') }}
     steps:
       - uses: actions/checkout@v6
-      - uses: dtolnay/rust-toolchain@stable
-      - run: rustup target add wasm32-unknown-unknown
+      - uses: dtolnay/rust-toolchain@1.94.0
+      - run: rustup target add --toolchain "${RUSTUP_TOOLCHAIN}" wasm32-unknown-unknown
       - uses: actions/setup-python@v5
         with:
           python-version: "3.14"
@@ -75,8 +76,8 @@ jobs:
     runs-on: ${{ fromJSON(vars.MEERKAT_CI_RUNNER || '"ubuntu-latest"') }}
     steps:
       - uses: actions/checkout@v6
-      - uses: dtolnay/rust-toolchain@stable
-      - run: rustup target add wasm32-unknown-unknown
+      - uses: dtolnay/rust-toolchain@1.94.0
+      - run: rustup target add --toolchain "${RUSTUP_TOOLCHAIN}" wasm32-unknown-unknown
       - uses: actions/setup-python@v5
         with:
           python-version: "3.14"

--- a/.github/workflows/live-e2e.yml
+++ b/.github/workflows/live-e2e.yml
@@ -53,7 +53,7 @@ jobs:
     runs-on: ${{ fromJSON(vars.MEERKAT_CI_RUNNER || '"ubuntu-latest"') }}
     steps:
       - uses: actions/checkout@v6
-      - uses: dtolnay/rust-toolchain@1.94.0
+      - uses: ./.github/actions/setup-rust-ci
       - run: rustup target add --toolchain "${RUSTUP_TOOLCHAIN}" wasm32-unknown-unknown
       - uses: actions/setup-python@v5
         with:
@@ -76,7 +76,7 @@ jobs:
     runs-on: ${{ fromJSON(vars.MEERKAT_CI_RUNNER || '"ubuntu-latest"') }}
     steps:
       - uses: actions/checkout@v6
-      - uses: dtolnay/rust-toolchain@1.94.0
+      - uses: ./.github/actions/setup-rust-ci
       - run: rustup target add --toolchain "${RUSTUP_TOOLCHAIN}" wasm32-unknown-unknown
       - uses: actions/setup-python@v5
         with:

--- a/scripts/ci-pin-rust-toolchain-env
+++ b/scripts/ci-pin-rust-toolchain-env
@@ -19,27 +19,42 @@ if ! command -v rustup >/dev/null 2>&1; then
   exit 1
 fi
 
-rustup component add --toolchain "${toolchain}" rustfmt clippy >/dev/null
+wrapper_root="${RUNNER_TEMP:-${TMPDIR:-/tmp}}/meerkat-rust-toolchains"
+wrapper_bin="${wrapper_root}/${toolchain}/bin"
+mkdir -p "${wrapper_bin}"
 
-cargo_path="$(rustup which --toolchain "${toolchain}" cargo)"
-rustc_path="$(rustup which --toolchain "${toolchain}" rustc)"
-rustdoc_path="$(rustup which --toolchain "${toolchain}" rustdoc)"
-rustfmt_path="$(rustup which --toolchain "${toolchain}" rustfmt)"
-toolchain_bin="$(dirname "${cargo_path}")"
+write_wrapper() {
+  local tool="$1"
+  local path="${wrapper_bin}/${tool}"
+  {
+    printf '#!/usr/bin/env bash\n'
+    printf 'exec rustup run %q %q "$@"\n' "${toolchain}" "${tool}"
+  } >"${path}"
+  chmod +x "${path}"
+}
+
+write_wrapper cargo
+write_wrapper rustc
+write_wrapper rustdoc
+write_wrapper rustfmt
+
+resolved_cargo_path="$(rustup which --toolchain "${toolchain}" cargo)"
+resolved_toolchain_bin="$(dirname "${resolved_cargo_path}")"
 
 echo "Pinned Rust toolchain: ${toolchain}"
-"${rustc_path}" -Vv
+"${wrapper_bin}/rustc" -Vv
 
 if [[ -n "${GITHUB_PATH:-}" ]]; then
-  echo "${toolchain_bin}" >>"${GITHUB_PATH}"
+  echo "${wrapper_bin}" >>"${GITHUB_PATH}"
 fi
 
 if [[ -n "${GITHUB_ENV:-}" ]]; then
   {
     echo "RUSTUP_TOOLCHAIN=${toolchain}"
-    echo "RUSTC=${rustc_path}"
-    echo "RUSTDOC=${rustdoc_path}"
-    echo "RUSTFMT=${rustfmt_path}"
-    echo "MEERKAT_RUST_TOOLCHAIN_BIN=${toolchain_bin}"
+    echo "RUSTC=${wrapper_bin}/rustc"
+    echo "RUSTDOC=${wrapper_bin}/rustdoc"
+    echo "RUSTFMT=${wrapper_bin}/rustfmt"
+    echo "MEERKAT_RUST_TOOLCHAIN_BIN=${wrapper_bin}"
+    echo "MEERKAT_RUST_RESOLVED_TOOLCHAIN_BIN=${resolved_toolchain_bin}"
   } >>"${GITHUB_ENV}"
 fi

--- a/scripts/ci-pin-rust-toolchain-env
+++ b/scripts/ci-pin-rust-toolchain-env
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+root="$(git rev-parse --show-toplevel)"
+cd "${root}"
+
+toolchain="${RUSTUP_TOOLCHAIN:-}"
+if [[ -z "${toolchain}" && -f rust-toolchain.toml ]]; then
+  toolchain="$(awk -F '"' '/^[[:space:]]*channel[[:space:]]*=/ { print $2; exit }' rust-toolchain.toml)"
+fi
+
+if [[ -z "${toolchain}" ]]; then
+  echo "error: RUSTUP_TOOLCHAIN is unset and rust-toolchain.toml has no channel" >&2
+  exit 1
+fi
+
+if ! command -v rustup >/dev/null 2>&1; then
+  echo "error: rustup is required to pin CI toolchain binaries" >&2
+  exit 1
+fi
+
+rustup component add --toolchain "${toolchain}" rustfmt clippy >/dev/null
+
+cargo_path="$(rustup which --toolchain "${toolchain}" cargo)"
+rustc_path="$(rustup which --toolchain "${toolchain}" rustc)"
+rustdoc_path="$(rustup which --toolchain "${toolchain}" rustdoc)"
+rustfmt_path="$(rustup which --toolchain "${toolchain}" rustfmt)"
+toolchain_bin="$(dirname "${cargo_path}")"
+
+echo "Pinned Rust toolchain: ${toolchain}"
+"${rustc_path}" -Vv
+
+if [[ -n "${GITHUB_PATH:-}" ]]; then
+  echo "${toolchain_bin}" >>"${GITHUB_PATH}"
+fi
+
+if [[ -n "${GITHUB_ENV:-}" ]]; then
+  {
+    echo "RUSTUP_TOOLCHAIN=${toolchain}"
+    echo "RUSTC=${rustc_path}"
+    echo "RUSTDOC=${rustdoc_path}"
+    echo "RUSTFMT=${rustfmt_path}"
+    echo "MEERKAT_RUST_TOOLCHAIN_BIN=${toolchain_bin}"
+  } >>"${GITHUB_ENV}"
+fi

--- a/scripts/ci-pin-rust-toolchain-env
+++ b/scripts/ci-pin-rust-toolchain-env
@@ -19,6 +19,16 @@ if ! command -v rustup >/dev/null 2>&1; then
   exit 1
 fi
 
+if [[ "${GITHUB_ACTIONS:-}" == "true" ]]; then
+  cargo_home="${CARGO_HOME:-/tmp/meerkat-cargo-home}"
+  if [[ "${cargo_home}" == "/tmp/meerkat-cargo-home" ]]; then
+    cargo_home="/tmp/meerkat-cargo-home/${GITHUB_RUN_ID:-run}-${GITHUB_RUN_ATTEMPT:-1}-${GITHUB_JOB:-job}"
+  fi
+  mkdir -p "${cargo_home}"
+else
+  cargo_home="${CARGO_HOME:-}"
+fi
+
 wrapper_root="${RUNNER_TEMP:-${TMPDIR:-/tmp}}/meerkat-rust-toolchains"
 wrapper_bin="${wrapper_root}/${toolchain}/bin"
 mkdir -p "${wrapper_bin}"
@@ -50,6 +60,9 @@ fi
 
 if [[ -n "${GITHUB_ENV:-}" ]]; then
   {
+    if [[ -n "${cargo_home}" ]]; then
+      echo "CARGO_HOME=${cargo_home}"
+    fi
     echo "RUSTUP_TOOLCHAIN=${toolchain}"
     echo "RUSTC=${wrapper_bin}/rustc"
     echo "RUSTDOC=${wrapper_bin}/rustdoc"

--- a/scripts/repo-cargo
+++ b/scripts/repo-cargo
@@ -34,6 +34,7 @@ toolchain_cargo=""
 toolchain_rustc=""
 toolchain_rustdoc=""
 toolchain_rustfmt=""
+resolved_toolchain_bin=""
 
 if [[ -n "${RUSTUP_TOOLCHAIN:-}" ]]; then
   toolchain_spec="${RUSTUP_TOOLCHAIN}"
@@ -59,7 +60,7 @@ if [[ -n "${toolchain_spec}" ]] && command -v rustup >/dev/null 2>&1; then
   toolchain_rustdoc="$(rustup which --toolchain "${toolchain_spec}" rustdoc 2>/dev/null || true)"
   toolchain_rustfmt="$(rustup which --toolchain "${toolchain_spec}" rustfmt 2>/dev/null || true)"
   if [[ -n "${toolchain_cargo}" ]]; then
-    toolchain_bin="$(dirname "${toolchain_cargo}")"
+    resolved_toolchain_bin="$(dirname "${toolchain_cargo}")"
   fi
 fi
 
@@ -112,6 +113,23 @@ if [[ "${GITHUB_ACTIONS:-}" == "true" && "${target_dir_was_set}" == "false" ]]; 
   fi
 fi
 
+if [[ -n "${toolchain_spec}" ]] && command -v rustup >/dev/null 2>&1; then
+  toolchain_bin="${CARGO_TARGET_DIR}/.repo-cargo-toolchain-bin"
+  mkdir -p "${toolchain_bin}"
+  for tool in cargo rustc rustdoc rustfmt; do
+    tool_path="${toolchain_bin}/${tool}"
+    {
+      printf '#!/usr/bin/env bash\n'
+      printf 'exec rustup run %q %q "$@"\n' "${toolchain_spec}" "${tool}"
+    } >"${tool_path}"
+    chmod +x "${tool_path}"
+  done
+  toolchain_cargo="${toolchain_bin}/cargo"
+  toolchain_rustc="${toolchain_bin}/rustc"
+  toolchain_rustdoc="${toolchain_bin}/rustdoc"
+  toolchain_rustfmt="${toolchain_bin}/rustfmt"
+fi
+
 if [[ "${1-}" == "--print-env" ]]; then
   printf '%s\n' \
     "repo_root=${repo_root}" \
@@ -125,6 +143,7 @@ if [[ "${1-}" == "--print-env" ]]; then
     "RUSTC=${toolchain_rustc}" \
     "RUSTDOC=${toolchain_rustdoc}" \
     "RUSTFMT=${toolchain_rustfmt}" \
+    "MEERKAT_RUST_RESOLVED_TOOLCHAIN_BIN=${resolved_toolchain_bin}" \
     "lane_key=${lane_key}" \
     "CARGO_HOME=${CARGO_HOME}" \
     "CARGO_TARGET_DIR=${CARGO_TARGET_DIR}"
@@ -151,6 +170,7 @@ if [[ "${1-}" == "--doctor" ]]; then
     "RUSTC=${toolchain_rustc}" \
     "RUSTDOC=${toolchain_rustdoc}" \
     "RUSTFMT=${toolchain_rustfmt}" \
+    "MEERKAT_RUST_RESOLVED_TOOLCHAIN_BIN=${resolved_toolchain_bin}" \
     "lane_key=${lane_key}" \
     "CARGO_HOME=${CARGO_HOME}" \
     "CARGO_TARGET_DIR=${CARGO_TARGET_DIR}"

--- a/scripts/repo-cargo
+++ b/scripts/repo-cargo
@@ -29,6 +29,11 @@ repo_key="${repo_slug}-$(hash_path "${git_common_dir}")"
 target_cache_schema="v4"
 toolchain_spec=""
 toolchain_key="${MEERKAT_RUST_TOOLCHAIN_ID:-}"
+toolchain_bin=""
+toolchain_cargo=""
+toolchain_rustc=""
+toolchain_rustdoc=""
+toolchain_rustfmt=""
 
 if [[ -n "${RUSTUP_TOOLCHAIN:-}" ]]; then
   toolchain_spec="${RUSTUP_TOOLCHAIN}"
@@ -48,6 +53,13 @@ if [[ -n "${toolchain_spec}" ]] && command -v rustup >/dev/null 2>&1; then
     rustc_host="$(awk -F ': ' '$1 == "host" { print $2; exit }' <<<"${rustc_verbose}")"
     rustc_commit="$(awk -F ': ' '$1 == "commit-hash" { print substr($2, 1, 10); exit }' <<<"${rustc_verbose}")"
     toolchain_key="${rustc_release:-${toolchain_key}}-${rustc_host:-unknown}-${rustc_commit:-unknown}"
+  fi
+  toolchain_cargo="$(rustup which --toolchain "${toolchain_spec}" cargo 2>/dev/null || true)"
+  toolchain_rustc="$(rustup which --toolchain "${toolchain_spec}" rustc 2>/dev/null || true)"
+  toolchain_rustdoc="$(rustup which --toolchain "${toolchain_spec}" rustdoc 2>/dev/null || true)"
+  toolchain_rustfmt="$(rustup which --toolchain "${toolchain_spec}" rustfmt 2>/dev/null || true)"
+  if [[ -n "${toolchain_cargo}" ]]; then
+    toolchain_bin="$(dirname "${toolchain_cargo}")"
   fi
 fi
 
@@ -109,6 +121,10 @@ if [[ "${1-}" == "--print-env" ]]; then
     "toolchain_spec=${toolchain_spec}" \
     "toolchain_key=${toolchain_key}" \
     "RUSTUP_TOOLCHAIN=${toolchain_spec}" \
+    "MEERKAT_RUST_TOOLCHAIN_BIN=${toolchain_bin}" \
+    "RUSTC=${toolchain_rustc}" \
+    "RUSTDOC=${toolchain_rustdoc}" \
+    "RUSTFMT=${toolchain_rustfmt}" \
     "lane_key=${lane_key}" \
     "CARGO_HOME=${CARGO_HOME}" \
     "CARGO_TARGET_DIR=${CARGO_TARGET_DIR}"
@@ -131,6 +147,10 @@ if [[ "${1-}" == "--doctor" ]]; then
     "toolchain_spec=${toolchain_spec}" \
     "toolchain_key=${toolchain_key}" \
     "RUSTUP_TOOLCHAIN=${toolchain_spec}" \
+    "MEERKAT_RUST_TOOLCHAIN_BIN=${toolchain_bin}" \
+    "RUSTC=${toolchain_rustc}" \
+    "RUSTDOC=${toolchain_rustdoc}" \
+    "RUSTFMT=${toolchain_rustfmt}" \
     "lane_key=${lane_key}" \
     "CARGO_HOME=${CARGO_HOME}" \
     "CARGO_TARGET_DIR=${CARGO_TARGET_DIR}"
@@ -141,10 +161,25 @@ cd "${workspace_root}"
 
 if [[ -n "${toolchain_spec}" ]]; then
   export RUSTUP_TOOLCHAIN="${toolchain_spec}"
+  if [[ -n "${toolchain_bin}" ]]; then
+    export PATH="${toolchain_bin}:${PATH}"
+    export MEERKAT_RUST_TOOLCHAIN_BIN="${toolchain_bin}"
+  fi
+  if [[ -n "${toolchain_rustc}" ]]; then
+    export RUSTC="${toolchain_rustc}"
+  fi
+  if [[ -n "${toolchain_rustdoc}" ]]; then
+    export RUSTDOC="${toolchain_rustdoc}"
+  fi
+  if [[ -n "${toolchain_rustfmt}" ]]; then
+    export RUSTFMT="${toolchain_rustfmt}"
+  fi
 fi
 
 if [[ -n "${CARGO_BIN:-}" ]]; then
   cargo_cmd=("${CARGO_BIN}")
+elif [[ -n "${toolchain_cargo}" ]]; then
+  cargo_cmd=("${toolchain_cargo}")
 elif [[ -n "${toolchain_spec}" ]] && command -v rustup >/dev/null 2>&1; then
   cargo_cmd=(rustup run "${toolchain_spec}" cargo)
 elif command -v cargo >/dev/null 2>&1; then

--- a/scripts/repo-cargo
+++ b/scripts/repo-cargo
@@ -101,17 +101,17 @@ if [[ "${GITHUB_ACTIONS:-}" == "true" && "${target_dir_was_set}" == "false" ]]; 
 fi
 
 if [[ "${1-}" == "--print-env" ]]; then
-  cat <<EOF
-repo_root=${repo_root}
-workspace_root=${workspace_root}
-repo_key=${repo_key}
-target_cache_schema=${target_cache_schema}
-toolchain_spec=${toolchain_spec}
-toolchain_key=${toolchain_key}
-lane_key=${lane_key}
-CARGO_HOME=${CARGO_HOME}
-CARGO_TARGET_DIR=${CARGO_TARGET_DIR}
-EOF
+  printf '%s\n' \
+    "repo_root=${repo_root}" \
+    "workspace_root=${workspace_root}" \
+    "repo_key=${repo_key}" \
+    "target_cache_schema=${target_cache_schema}" \
+    "toolchain_spec=${toolchain_spec}" \
+    "toolchain_key=${toolchain_key}" \
+    "RUSTUP_TOOLCHAIN=${toolchain_spec}" \
+    "lane_key=${lane_key}" \
+    "CARGO_HOME=${CARGO_HOME}" \
+    "CARGO_TARGET_DIR=${CARGO_TARGET_DIR}"
   exit 0
 fi
 
@@ -122,22 +122,26 @@ if [[ "${1-}" == "--doctor" ]]; then
   fi
   [[ -w "${CARGO_HOME}" ]] || { echo "error: CARGO_HOME not writable" >&2; exit 1; }
   [[ -w "${CARGO_TARGET_DIR}" ]] || { echo "error: CARGO_TARGET_DIR not writable" >&2; exit 1; }
-  cat <<EOF
-doctor=ok
-repo_root=${repo_root}
-workspace_root=${workspace_root}
-repo_key=${repo_key}
-target_cache_schema=${target_cache_schema}
-toolchain_spec=${toolchain_spec}
-toolchain_key=${toolchain_key}
-lane_key=${lane_key}
-CARGO_HOME=${CARGO_HOME}
-CARGO_TARGET_DIR=${CARGO_TARGET_DIR}
-EOF
+  printf '%s\n' \
+    "doctor=ok" \
+    "repo_root=${repo_root}" \
+    "workspace_root=${workspace_root}" \
+    "repo_key=${repo_key}" \
+    "target_cache_schema=${target_cache_schema}" \
+    "toolchain_spec=${toolchain_spec}" \
+    "toolchain_key=${toolchain_key}" \
+    "RUSTUP_TOOLCHAIN=${toolchain_spec}" \
+    "lane_key=${lane_key}" \
+    "CARGO_HOME=${CARGO_HOME}" \
+    "CARGO_TARGET_DIR=${CARGO_TARGET_DIR}"
   exit 0
 fi
 
 cd "${workspace_root}"
+
+if [[ -n "${toolchain_spec}" ]]; then
+  export RUSTUP_TOOLCHAIN="${toolchain_spec}"
+fi
 
 if [[ -n "${CARGO_BIN:-}" ]]; then
   cargo_cmd=("${CARGO_BIN}")

--- a/scripts/repo-cargo
+++ b/scripts/repo-cargo
@@ -94,7 +94,11 @@ target_dir_was_set=false
 if [[ -n "${CARGO_TARGET_DIR:-}" ]]; then
   target_dir_was_set=true
 fi
-export CARGO_HOME="${CARGO_HOME:-${cache_root}/${repo_key}/cargo-home}"
+cargo_home="${CARGO_HOME:-${cache_root}/${repo_key}/cargo-home}"
+if [[ "${GITHUB_ACTIONS:-}" == "true" && "${cargo_home}" == "/tmp/meerkat-cargo-home" ]]; then
+  cargo_home="${cargo_home}/${lane_key}"
+fi
+export CARGO_HOME="${cargo_home}"
 export CARGO_TARGET_DIR="${CARGO_TARGET_DIR:-${cache_root}/${repo_key}/targets/${target_cache_schema}/${toolchain_key}/${lane_key}}"
 
 mkdir -p "${CARGO_HOME}" "${CARGO_TARGET_DIR}"
@@ -114,7 +118,7 @@ if [[ "${GITHUB_ACTIONS:-}" == "true" && "${target_dir_was_set}" == "false" ]]; 
 fi
 
 if [[ -n "${toolchain_spec}" ]] && command -v rustup >/dev/null 2>&1; then
-  toolchain_bin="${CARGO_TARGET_DIR}/.repo-cargo-toolchain-bin"
+  toolchain_bin="${CARGO_HOME}/.repo-cargo-toolchain-bin/${toolchain_key}"
   mkdir -p "${toolchain_bin}"
   for tool in cargo rustc rustdoc rustfmt; do
     tool_path="${toolchain_bin}/${tool}"

--- a/scripts/rust-lane-doctor
+++ b/scripts/rust-lane-doctor
@@ -25,11 +25,18 @@ bad() {
 
 value_from_env() {
   local key="$1"
-  awk -F= -v key="${key}" '$1 == key { print substr($0, length(key) + 2) }'
+  local text="$2"
+  printf '%s\n' "${text}" | awk -F= -v key="${key}" '$1 == key { print substr($0, length(key) + 2) }'
+}
+
+contains_line() {
+  local needle="$1"
+  local text="$2"
+  [[ $'\n'"${text}"$'\n' == *$'\n'"${needle}"$'\n'* ]]
 }
 
 doctor_output="$(./scripts/repo-cargo --doctor 2>&1 || true)"
-if grep -q '^doctor=ok$' <<<"${doctor_output}"; then
+if contains_line "doctor=ok" "${doctor_output}"; then
   pass "repo-cargo doctor passes"
 else
   bad "repo-cargo doctor failed"
@@ -37,8 +44,9 @@ else
 fi
 
 default_env="$(./scripts/repo-cargo --print-env)"
-default_target="$(value_from_env CARGO_TARGET_DIR <<<"${default_env}")"
-default_home="$(value_from_env CARGO_HOME <<<"${default_env}")"
+default_target="$(value_from_env CARGO_TARGET_DIR "${default_env}")"
+default_home="$(value_from_env CARGO_HOME "${default_env}")"
+default_rustup_toolchain="$(value_from_env RUSTUP_TOOLCHAIN "${default_env}")"
 if [[ "${default_target}" == "${workspace_root}"* || "${default_home}" == "${workspace_root}"* ]]; then
   bad "Cargo cache paths resolve inside the repository"
 else
@@ -47,10 +55,10 @@ fi
 
 lane_a_env="$(RUST_LANE_ID=doctor-a ./scripts/repo-cargo --print-env)"
 lane_b_env="$(RUST_LANE_ID=doctor-b ./scripts/repo-cargo --print-env)"
-lane_a_target="$(value_from_env CARGO_TARGET_DIR <<<"${lane_a_env}")"
-lane_b_target="$(value_from_env CARGO_TARGET_DIR <<<"${lane_b_env}")"
-lane_a_home="$(value_from_env CARGO_HOME <<<"${lane_a_env}")"
-lane_b_home="$(value_from_env CARGO_HOME <<<"${lane_b_env}")"
+lane_a_target="$(value_from_env CARGO_TARGET_DIR "${lane_a_env}")"
+lane_b_target="$(value_from_env CARGO_TARGET_DIR "${lane_b_env}")"
+lane_a_home="$(value_from_env CARGO_HOME "${lane_a_env}")"
+lane_b_home="$(value_from_env CARGO_HOME "${lane_b_env}")"
 
 if [[ "${lane_a_target}" != "${lane_b_target}" ]]; then
   pass "RUST_LANE_ID creates distinct target directories"
@@ -59,7 +67,7 @@ else
 fi
 
 codex_agent_env="$(CODEX_AGENT_ID=doctor-codex-agent ./scripts/repo-cargo --print-env)"
-codex_agent_lane="$(value_from_env lane_key <<<"${codex_agent_env}")"
+codex_agent_lane="$(value_from_env lane_key "${codex_agent_env}")"
 if [[ "${codex_agent_lane}" == "doctor-codex-agent" ]]; then
   pass "CODEX_AGENT_ID creates a distinct same-worktree Cargo lane"
 else
@@ -67,7 +75,7 @@ else
 fi
 
 github_lane_env="$(GITHUB_JOB=fmt-lint GITHUB_RUN_ID=12345 GITHUB_RUN_ATTEMPT=2 ./scripts/repo-cargo --print-env)"
-github_lane="$(value_from_env lane_key <<<"${github_lane_env}")"
+github_lane="$(value_from_env lane_key "${github_lane_env}")"
 if [[ "${github_lane}" == "gha-12345-2-fmt-lint" ]]; then
   pass "GitHub Actions target lanes are isolated per run attempt"
 else
@@ -101,8 +109,8 @@ for (const pkg of metadata.packages.filter((p) => p.name === "rkat" || p.name ==
 }
 '
 )"
-if grep -q '^rkat-mini=false$' <<<"${mini_bin_test_flags}" &&
-  grep -q '^rkat-rpc-mini=false$' <<<"${mini_bin_test_flags}"; then
+if contains_line "rkat-mini=false" "${mini_bin_test_flags}" &&
+  contains_line "rkat-rpc-mini=false" "${mini_bin_test_flags}"; then
   pass "mini binary duplicate unit-test harnesses are disabled"
 else
   bad "mini binary duplicate unit-test harnesses are still enabled"
@@ -124,7 +132,7 @@ else
 fi
 
 raw_cargo_shell_hits="$(
-  rg -n '^\s*(cargo|exec cargo)\b|\bcargo run -p xtask\b' \
+  rg -n '^\s*(cargo|exec cargo)\s+(check|test|nextest|run|xtask|build|unit|int|e2e|clippy|fmt|machete)\b|\bcargo run -p xtask\b' \
     scripts specs \
     --glob '*.sh' \
     --glob '!scripts/repo-cargo' 2>/dev/null || true
@@ -158,6 +166,16 @@ else
   bad "Cargo or BuildBuddy CI Rust toolchain does not match rust-toolchain.toml"
 fi
 
+if [[ -n "${rust_channel}" ]] &&
+  [[ "${default_rustup_toolchain}" == "${rust_channel}" ]] &&
+  grep -Fq "RUSTUP_TOOLCHAIN: ${rust_channel}" .github/workflows/cargo.yml &&
+  grep -Fq "RUSTUP_TOOLCHAIN: ${rust_channel}" .github/workflows/buildbuddy.yml &&
+  grep -Fq "RUSTUP_TOOLCHAIN=${rust_channel}" .github/actions/setup-buildbuddy-ci/action.yml; then
+  pass "Cargo and BuildBuddy CI export the pinned Rustup toolchain"
+else
+  bad "Cargo or BuildBuddy CI can fall back to the runner Rustup default"
+fi
+
 if grep -q 'CARGO_HOME: /tmp/meerkat-cargo-home' .github/workflows/cargo.yml &&
   grep -q 'CARGO_HOME: /tmp/meerkat-cargo-home' .github/workflows/buildbuddy.yml; then
   pass "CI and BuildBuddy workflows keep repo-cargo Cargo home cacheable"
@@ -166,7 +184,7 @@ else
 fi
 
 selector_selftest_output="$(./scripts/rust-selector-selftest.mjs 2>&1 || true)"
-if grep -q '^rust selector selftest ok$' <<<"${selector_selftest_output}"; then
+if contains_line "rust selector selftest ok" "${selector_selftest_output}"; then
   pass "Rust selector module parser selftest passes"
 else
   bad "Rust selector module parser selftest failed"
@@ -175,9 +193,9 @@ fi
 
 agent_gate_probe="$(./scripts/agent-gate --dry-run --working-tree meerkat-runtime/src/input_ledger.rs 2>&1 || true)"
 if [[ -x scripts/agent-gate ]] &&
-  grep -q 'Cargo agent gate packages:' <<<"${agent_gate_probe}" &&
-  grep -q 'meerkat-runtime' <<<"${agent_gate_probe}" &&
-  ! grep -q 'BuildBuddy agent gate' <<<"${agent_gate_probe}"; then
+  [[ "${agent_gate_probe}" == *"Cargo agent gate packages:"* ]] &&
+  [[ "${agent_gate_probe}" == *"meerkat-runtime"* ]] &&
+  [[ "${agent_gate_probe}" != *"BuildBuddy agent gate"* ]]; then
   pass "agent-gate defaults to the Cargo changed-path gate"
 else
   bad "agent-gate default routing is not Cargo-first"

--- a/scripts/rust-lane-doctor
+++ b/scripts/rust-lane-doctor
@@ -158,12 +158,18 @@ else
 fi
 
 rust_channel="$(awk -F '"' '/^[[:space:]]*channel[[:space:]]*=/ { print $2; exit }' rust-toolchain.toml)"
+default_rustc_release=""
+if [[ -x "${default_rustc}" ]]; then
+  default_rustc_verbose="$("${default_rustc}" -Vv 2>/dev/null || true)"
+  default_rustc_release="$(printf '%s\n' "${default_rustc_verbose}" | awk -F ': ' '$1 == "release" { print $2; exit }')"
+fi
 if [[ -n "${rust_channel}" ]] &&
-  [[ "${default_rustc}" == *"/toolchains/${rust_channel}-"*"/bin/rustc" ]] &&
-  [[ "${default_toolchain_bin}" == *"/toolchains/${rust_channel}-"*"/bin" ]]; then
-  pass "repo-cargo resolves exact pinned Rust toolchain binaries"
+  [[ "${default_rustc_release}" == "${rust_channel}" ]] &&
+  [[ "${default_rustc}" == "${default_target}/.repo-cargo-toolchain-bin/rustc" ]] &&
+  [[ "${default_toolchain_bin}" == "${default_target}/.repo-cargo-toolchain-bin" ]]; then
+  pass "repo-cargo resolves stable pinned Rust toolchain wrappers"
 else
-  bad "repo-cargo does not resolve exact pinned Rust toolchain binaries"
+  bad "repo-cargo does not resolve stable pinned Rust toolchain wrappers"
 fi
 
 if [[ -n "${rust_channel}" ]] &&
@@ -189,7 +195,7 @@ if [[ -n "${rust_channel}" ]] &&
   grep -Fq "scripts/ci-pin-rust-toolchain-env" .github/actions/setup-buildbuddy-ci/action.yml &&
   grep -Fq "RUSTC=" scripts/ci-pin-rust-toolchain-env &&
   grep -Fq 'GITHUB_PATH' scripts/ci-pin-rust-toolchain-env; then
-  pass "Cargo and BuildBuddy CI export exact pinned Rust toolchain binaries"
+  pass "Cargo and BuildBuddy CI export stable pinned Rust toolchain wrappers"
 else
   bad "Cargo or BuildBuddy CI can fall back to runner Rust binaries"
 fi

--- a/scripts/rust-lane-doctor
+++ b/scripts/rust-lane-doctor
@@ -47,6 +47,8 @@ default_env="$(./scripts/repo-cargo --print-env)"
 default_target="$(value_from_env CARGO_TARGET_DIR "${default_env}")"
 default_home="$(value_from_env CARGO_HOME "${default_env}")"
 default_rustup_toolchain="$(value_from_env RUSTUP_TOOLCHAIN "${default_env}")"
+default_toolchain_bin="$(value_from_env MEERKAT_RUST_TOOLCHAIN_BIN "${default_env}")"
+default_rustc="$(value_from_env RUSTC "${default_env}")"
 if [[ "${default_target}" == "${workspace_root}"* || "${default_home}" == "${workspace_root}"* ]]; then
   bad "Cargo cache paths resolve inside the repository"
 else
@@ -157,9 +159,20 @@ fi
 
 rust_channel="$(awk -F '"' '/^[[:space:]]*channel[[:space:]]*=/ { print $2; exit }' rust-toolchain.toml)"
 if [[ -n "${rust_channel}" ]] &&
-  grep -Fq "dtolnay/rust-toolchain@${rust_channel}" .github/workflows/cargo.yml &&
+  [[ "${default_rustc}" == *"/toolchains/${rust_channel}-"*"/bin/rustc" ]] &&
+  [[ "${default_toolchain_bin}" == *"/toolchains/${rust_channel}-"*"/bin" ]]; then
+  pass "repo-cargo resolves exact pinned Rust toolchain binaries"
+else
+  bad "repo-cargo does not resolve exact pinned Rust toolchain binaries"
+fi
+
+if [[ -n "${rust_channel}" ]] &&
+  grep -Fq "dtolnay/rust-toolchain@${rust_channel}" .github/actions/setup-rust-ci/action.yml &&
   grep -Fq "dtolnay/rust-toolchain@${rust_channel}" .github/actions/setup-buildbuddy-ci/action.yml &&
+  grep -Fq "uses: ./.github/actions/setup-rust-ci" .github/workflows/cargo.yml &&
+  grep -Fq "uses: ./.github/actions/setup-rust-ci" .github/workflows/live-e2e.yml &&
   ! grep -Fq 'dtolnay/rust-toolchain@stable' .github/workflows/cargo.yml &&
+  ! grep -Fq 'dtolnay/rust-toolchain@stable' .github/workflows/live-e2e.yml &&
   ! grep -Fq 'dtolnay/rust-toolchain@stable' .github/actions/setup-buildbuddy-ci/action.yml; then
   pass "Cargo and BuildBuddy CI install the pinned Rust toolchain"
 else
@@ -170,10 +183,15 @@ if [[ -n "${rust_channel}" ]] &&
   [[ "${default_rustup_toolchain}" == "${rust_channel}" ]] &&
   grep -Fq "RUSTUP_TOOLCHAIN: ${rust_channel}" .github/workflows/cargo.yml &&
   grep -Fq "RUSTUP_TOOLCHAIN: ${rust_channel}" .github/workflows/buildbuddy.yml &&
-  grep -Fq "RUSTUP_TOOLCHAIN=${rust_channel}" .github/actions/setup-buildbuddy-ci/action.yml; then
-  pass "Cargo and BuildBuddy CI export the pinned Rustup toolchain"
+  grep -Fq "RUSTUP_TOOLCHAIN: ${rust_channel}" .github/workflows/live-e2e.yml &&
+  grep -Fq "RUSTUP_TOOLCHAIN: ${rust_channel}" .github/actions/setup-buildbuddy-ci/action.yml &&
+  grep -Fq "scripts/ci-pin-rust-toolchain-env" .github/actions/setup-rust-ci/action.yml &&
+  grep -Fq "scripts/ci-pin-rust-toolchain-env" .github/actions/setup-buildbuddy-ci/action.yml &&
+  grep -Fq "RUSTC=" scripts/ci-pin-rust-toolchain-env &&
+  grep -Fq 'GITHUB_PATH' scripts/ci-pin-rust-toolchain-env; then
+  pass "Cargo and BuildBuddy CI export exact pinned Rust toolchain binaries"
 else
-  bad "Cargo or BuildBuddy CI can fall back to the runner Rustup default"
+  bad "Cargo or BuildBuddy CI can fall back to runner Rust binaries"
 fi
 
 if grep -q 'CARGO_HOME: /tmp/meerkat-cargo-home' .github/workflows/cargo.yml &&

--- a/scripts/rust-lane-doctor
+++ b/scripts/rust-lane-doctor
@@ -165,8 +165,8 @@ if [[ -x "${default_rustc}" ]]; then
 fi
 if [[ -n "${rust_channel}" ]] &&
   [[ "${default_rustc_release}" == "${rust_channel}" ]] &&
-  [[ "${default_rustc}" == "${default_target}/.repo-cargo-toolchain-bin/rustc" ]] &&
-  [[ "${default_toolchain_bin}" == "${default_target}/.repo-cargo-toolchain-bin" ]]; then
+  [[ "${default_rustc}" == "${default_home}/.repo-cargo-toolchain-bin/${rust_channel}-"*"/rustc" ]] &&
+  [[ "${default_toolchain_bin}" == "${default_home}/.repo-cargo-toolchain-bin/${rust_channel}-"* ]]; then
   pass "repo-cargo resolves stable pinned Rust toolchain wrappers"
 else
   bad "repo-cargo does not resolve stable pinned Rust toolchain wrappers"
@@ -201,10 +201,12 @@ else
 fi
 
 if grep -q 'CARGO_HOME: /tmp/meerkat-cargo-home' .github/workflows/cargo.yml &&
-  grep -q 'CARGO_HOME: /tmp/meerkat-cargo-home' .github/workflows/buildbuddy.yml; then
-  pass "CI and BuildBuddy workflows keep repo-cargo Cargo home cacheable"
+  grep -q 'CARGO_HOME: /tmp/meerkat-cargo-home' .github/workflows/buildbuddy.yml &&
+  grep -q 'CARGO_HOME: /tmp/meerkat-cargo-home' .github/workflows/live-e2e.yml &&
+  grep -Fq '${GITHUB_JOB:-job}' scripts/ci-pin-rust-toolchain-env; then
+  pass "CI and BuildBuddy workflows isolate Cargo home per GitHub job before cache restore"
 else
-  bad "CI or BuildBuddy workflow is missing a stable repo-cargo CARGO_HOME"
+  bad "CI or BuildBuddy workflow can share mutable Cargo home across parallel jobs"
 fi
 
 selector_selftest_output="$(./scripts/rust-selector-selftest.mjs 2>&1 || true)"


### PR DESCRIPTION
## Summary
- export RUSTUP_TOOLCHAIN=1.94.0 in Cargo, BuildBuddy, and live E2E workflows
- make scripts/repo-cargo export/report the selected Rustup toolchain before running cargo
- harden rust-lane-doctor so it verifies the CI Rustup pin without hanging on Bash here-strings

## Verification
- ./scripts/repo-cargo --doctor
- ./scripts/repo-cargo --print-env
- ./scripts/rust-lane-doctor
- bash -n scripts/repo-cargo scripts/rust-lane-doctor
- git diff --check
- pre-push hooks